### PR TITLE
[codex] Add visionOS simulator support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
         run: |
           cargo test --workspace \
             --exclude perry-ui-ios \
+            --exclude perry-ui-visionos \
             --exclude perry-ui-tvos \
             --exclude perry-ui-watchos \
             --exclude perry-ui-gtk4 \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "atty",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "log",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "base64",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4238,7 +4238,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "serde",
  "serde_json",
@@ -4246,7 +4246,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "clap",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4304,7 +4304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "base64",
@@ -4325,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4399,7 +4399,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -4407,11 +4407,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.179"
+version = "0.5.185"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "itoa",
  "jni",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "rand 0.8.5",
  "serde",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "cairo-rs",
  "gtk4",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "block2",
  "libc",
@@ -4462,7 +4462,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "block2",
  "libc",
@@ -4480,11 +4480,26 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.179"
+version = "0.5.185"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.179"
+version = "0.5.185"
+dependencies = [
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "perry-runtime",
+ "perry-ui",
+ "perry-ui-testkit",
+]
+
+[[package]]
+name = "perry-ui-visionos"
+version = "0.5.185"
 dependencies = [
  "block2",
  "libc",
@@ -4499,7 +4514,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "block2",
  "libc",
@@ -4512,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.179"
+version = "0.5.185"
 dependencies = [
  "libc",
  "perry-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/perry-ui",
     "crates/perry-ui-macos",
     "crates/perry-ui-ios",
+    "crates/perry-ui-visionos",
     "crates/perry-ui-android",
     "crates/perry-ui-gtk4",
     "crates/perry-ui-windows",
@@ -85,6 +86,10 @@ codegen-units = 16
 strip = false
 codegen-units = 16
 
+[profile.release.package.perry-ui-visionos]
+strip = false
+codegen-units = 16
+
 [profile.release.package.perry-ui-tvos]
 strip = false
 codegen-units = 16
@@ -104,7 +109,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.184"
+version = "0.5.185"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/README.md
+++ b/README.md
@@ -351,12 +351,13 @@ splitViewAddChild(split, content);
 App({ title: 'My App', width: 800, height: 500, body: split });
 ```
 
-**9 platforms from one codebase:**
+**10 target outputs from one codebase:**
 
 | Platform | Backend | Target Flag |
 |----------|---------|-------------|
 | macOS | AppKit (NSView) | *(default on macOS)* |
 | iOS / iPadOS | UIKit | `--target ios` / `--target ios-simulator` |
+| visionOS | UIKit (2D windows) | `--target visionos` / `--target visionos-simulator` |
 | tvOS | UIKit | `--target tvos` / `--target tvos-simulator` |
 | watchOS | WatchKit | `--target watchos` / `--target watchos-simulator` |
 | Android | Android Views (JNI) | `--target android` |
@@ -437,6 +438,8 @@ perry compile src/main.ts -o myapp
 # Mobile
 perry compile src/main.ts --target ios -o MyApp
 perry compile src/main.ts --target ios-simulator -o MyApp
+perry compile src/main.ts --target visionos -o MyApp
+perry compile src/main.ts --target visionos-simulator -o MyApp
 perry compile src/main.ts --target android -o MyApp
 
 # TV / Watch
@@ -671,8 +674,8 @@ await prisma.$disconnect();
 
 ```
 -o, --output <name>      Output file name
---target <target>        ios | ios-simulator | tvos | tvos-simulator |
-                         watchos | watchos-simulator | android |
+--target <target>        ios | ios-simulator | visionos | visionos-simulator |
+                         tvos | tvos-simulator | watchos | watchos-simulator | android |
                          web | wasm | ios-widget | android-widget |
                          wearos-tile | watchos-widget
 --output-type <type>     executable | dylib
@@ -790,6 +793,7 @@ Before tagging a major/minor bump, these must all pass:
 | **Linux musl** (x86_64 + aarch64) | Release build via `release-packages.yml`; spot-check a compiled `hello.ts` runs on Alpine | Build only |
 | **Windows** (x86_64 MSVC) | `scripts/run_doc_tests.ps1`; smoke-test `perry compile hello.ts -o hello.exe && .\hello.exe` | Build only |
 | **iOS Simulator** | `perry compile --target ios-simulator examples/widget_demo.ts && xcrun simctl install booted out.app` | No (Xcode required) |
+| **visionOS Simulator** | `perry compile --target visionos-simulator ...`, launch in Apple Vision Pro Simulator | No (Xcode required) |
 | **tvOS Simulator** | `perry compile --target tvos-simulator ...`, launch in Simulator | No (Xcode required) |
 | **watchOS Simulator** | `perry compile --target watchos-simulator ...` — requires `rustup toolchain install nightly` + `cargo +nightly -Zbuild-std` | No (Xcode + nightly required) |
 | **Android** | `perry compile --target android examples/widget_demo.ts`; install APK on emulator | No (NDK required) |

--- a/crates/perry-codegen/src/codegen.rs
+++ b/crates/perry-codegen/src/codegen.rs
@@ -511,12 +511,14 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
     }
 
     // Derive __platform__ number from target triple:
-    //   0 = macOS, 1 = iOS, 2 = Android, 3 = Windows, 4 = Linux, 5 = watchOS, 6 = Web
+    //   0 = macOS, 1 = iOS, 2 = Android, 3 = Windows, 4 = Linux,
+    //   5 = Web, 6 = tvOS, 7 = watchOS, 8 = visionOS
     let platform_number: f64 = {
         let t = triple.to_lowercase();
-        if t.contains("watchos") { 5.0 }
+        if t.contains("visionos") || t.contains("xros") { 8.0 }
+        else if t.contains("watchos") { 7.0 }
         else if t.contains("ios") { 1.0 }
-        else if t.contains("tvos") { 1.0 }
+        else if t.contains("tvos") { 6.0 }
         else if t.contains("android") { 2.0 }
         else if t.contains("windows") || t.contains("mingw") || t.contains("msvc") { 3.0 }
         else if t.contains("linux") { 4.0 }
@@ -3116,8 +3118,9 @@ fn default_target_triple() -> String {
 ///
 /// Supported:
 ///  * `ios`, `ios-simulator`           → aarch64-apple-ios
-///  * `watchos`                         → arm64_32-apple-watchos (ILP32)
-///  * `watchos-simulator`               → arm64-apple-watchos10.0-simulator
+///  * `visionos`, `visionos-simulator` → arm64-apple-xros1.0{,-simulator}
+///  * `watchos`                        → arm64_32-apple-watchos (ILP32)
+///  * `watchos-simulator`              → arm64-apple-watchos10.0-simulator
 ///  * `tvos`, `tvos-simulator`         → aarch64-apple-tvos
 ///  * `android`                        → aarch64-unknown-linux-android
 ///  * `linux` (x86_64 alias)           → x86_64-unknown-linux-gnu
@@ -3130,6 +3133,8 @@ pub fn resolve_target_triple(name: &str) -> Option<String> {
     match name {
         "ios" => Some("aarch64-apple-ios".to_string()),
         "ios-simulator" => Some("arm64-apple-ios17.0-simulator".to_string()),
+        "visionos" => Some("arm64-apple-xros1.0".to_string()),
+        "visionos-simulator" => Some("arm64-apple-xros1.0-simulator".to_string()),
         "watchos" => Some("arm64_32-apple-watchos".to_string()),
         "watchos-simulator" => Some("arm64-apple-watchos10.0-simulator".to_string()),
         "tvos" => Some("aarch64-apple-tvos".to_string()),

--- a/crates/perry-doc-tests/src/main.rs
+++ b/crates/perry-doc-tests/src/main.rs
@@ -573,7 +573,7 @@ fn target_buildable_on_host(target: &str, host: &str) -> bool {
 /// Reason the target can't be built from this host, or None if it can.
 fn target_buildable_reason(target: &str, host: &str) -> Option<String> {
     match target {
-        "watchos" | "watchos-simulator" => {
+        "watchos" | "watchos-simulator" | "visionos" | "visionos-simulator" => {
             // Rust Tier-3 — requires nightly + `-Zbuild-std`. Skip in the
             // generic cross-compile until we wire up a dedicated job.
             Some(format!("target=`{target}` is Rust Tier-3 (nightly + -Zbuild-std); not yet wired"))
@@ -642,7 +642,7 @@ fn cross_compile_one(
     // For Apple bundle targets, perry produces `<out>.app/` alongside (or
     // replacing) the linked binary; check that directory for the artifact.
     let artifact_check = match target {
-        "ios" | "ios-simulator" | "tvos" | "tvos-simulator" | "watchos"
+        "ios" | "ios-simulator" | "visionos" | "visionos-simulator" | "tvos" | "tvos-simulator" | "watchos"
         | "watchos-simulator" | "ios-widget" | "ios-widget-simulator" => {
             out.with_extension("app")
         }

--- a/crates/perry-ui-visionos/Cargo.toml
+++ b/crates/perry-ui-visionos/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+name = "perry-ui-visionos"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+crate-type = ["rlib", "staticlib"]
+
+[features]
+default = []
+plugins = []
+geisterhand = []
+
+[dependencies]
+perry-ui = { path = "../perry-ui" }
+perry-ui-testkit = { workspace = true }
+perry-runtime = { path = "../perry-runtime", default-features = false }
+block2 = "0.6"
+libc = "0.2"
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = [
+    "NSString",
+    "NSThread",
+    "NSRunLoop",
+    "NSURL",
+    "NSArray",
+    "NSError",
+] }
+objc2-core-foundation = { version = "0.3", features = [
+    "CFCGTypes",
+] }
+objc2-ui-kit = { version = "0.3", features = [
+    "UIApplication",
+    "UIWindow",
+    "UIWindowScene",
+    "UIScene",
+    "UISceneSession",
+    "UISceneConfiguration",
+    "UIView",
+    "UIViewController",
+    "UILabel",
+    "UIButton",
+    "UIStackView",
+    "UISwitch",
+    "UISlider",
+    "UIScrollView",
+    "UITextField",
+    "UITextView",
+    "UIColor",
+    "UIFont",
+    "UIControl",
+    "UIPasteboard",
+    "UIResponder",
+    "UIScreen",
+] }

--- a/crates/perry-ui-visionos/src/app.rs
+++ b/crates/perry-ui-visionos/src/app.rs
@@ -1,0 +1,583 @@
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject, Sel};
+use objc2::{define_class, msg_send, AnyThread, DefinedClass};
+use objc2_foundation::{NSObject, NSString};
+use objc2_ui_kit::UIView;
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::widgets;
+use crate::menu;
+
+thread_local! {
+    static PENDING_CONFIG: RefCell<Option<AppConfig>> = RefCell::new(None);
+    static PENDING_BODY: RefCell<Option<i64>> = RefCell::new(None);
+    /// The bottom constraint of the root widget, adjusted when keyboard appears/disappears
+    static ROOT_BOTTOM_CONSTRAINT: RefCell<Option<Retained<AnyObject>>> = RefCell::new(None);
+    static RUNTIME_STARTED: RefCell<bool> = const { RefCell::new(false) };
+}
+
+struct AppConfig {
+    title: String,
+    _width: f64,
+    _height: f64,
+}
+
+/// Extract a &str from a *const StringHeader pointer.
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// Create an app. Stores config in thread-local for deferred creation.
+/// Returns app handle (i64).
+pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
+    let title = if title_ptr.is_null() {
+        "Perry App".to_string()
+    } else {
+        str_from_header(title_ptr).to_string()
+    };
+
+    let w = if width > 0.0 { width } else { 400.0 };
+    let h = if height > 0.0 { height } else { 300.0 };
+
+    PENDING_CONFIG.with(|c| {
+        *c.borrow_mut() = Some(AppConfig {
+            title,
+            _width: w,
+            _height: h,
+        });
+    });
+
+    1 // Single app handle
+}
+
+/// Set the root widget (body) of the app.
+pub fn app_set_body(_app_handle: i64, root_handle: i64) {
+    PENDING_BODY.with(|b| {
+        *b.borrow_mut() = Some(root_handle);
+    });
+}
+
+fn ensure_runtime_services_started() {
+    let already_started = RUNTIME_STARTED.with(|started| {
+        let mut started = started.borrow_mut();
+        if *started {
+            true
+        } else {
+            *started = true;
+            false
+        }
+    });
+    if already_started {
+        return;
+    }
+
+    register_keyboard_observers();
+
+    let pump_target = PerryPumpTarget::new();
+    let pump_sel = Sel::register(c"pump:");
+    let _: Retained<AnyObject> = unsafe {
+        msg_send![
+            objc2::class!(NSTimer),
+            scheduledTimerWithTimeInterval: 0.008f64,
+            target: &*pump_target,
+            selector: pump_sel,
+            userInfo: std::ptr::null::<AnyObject>(),
+            repeats: true
+        ]
+    };
+    std::mem::forget(pump_target);
+}
+
+fn make_fallback_root_view() -> Retained<UIView> {
+    unsafe {
+        let label_cls = AnyClass::get(c"UILabel").unwrap();
+        let label_obj: Retained<AnyObject> = msg_send![label_cls, new];
+        let label: Retained<UIView> = Retained::cast_unchecked(label_obj);
+        let title = PENDING_CONFIG.with(|c| {
+            c.borrow()
+                .as_ref()
+                .map(|cfg| cfg.title.clone())
+                .unwrap_or_else(|| "Perry visionOS App".to_string())
+        });
+        let ns_title = NSString::from_str(&title);
+        let _: () = msg_send![&*label, setText: &*ns_title];
+        label
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn perry_visionos_root_view() -> i64 {
+    ensure_runtime_services_started();
+
+    let view = PENDING_BODY.with(|b| {
+        b.borrow()
+            .as_ref()
+            .and_then(|root_handle| widgets::get_widget(*root_handle))
+    }).unwrap_or_else(make_fallback_root_view);
+
+    KEYBOARD_VIEW.with(|kv| {
+        *kv.borrow_mut() = Some(Retained::as_ptr(&view) as usize);
+    });
+
+    let ptr = Retained::as_ptr(&view) as i64;
+    std::mem::forget(view);
+    ptr
+}
+
+// Raw ObjC runtime FFI for dynamic class registration
+extern "C" {
+    fn objc_allocateClassPair(superclass: *const std::ffi::c_void, name: *const i8, extra_bytes: usize) -> *mut std::ffi::c_void;
+    fn objc_registerClassPair(cls: *mut std::ffi::c_void);
+    fn class_addMethod(cls: *mut std::ffi::c_void, sel: *const std::ffi::c_void, imp: *const std::ffi::c_void, types: *const i8) -> bool;
+    fn sel_registerName(name: *const i8) -> *const std::ffi::c_void;
+    fn objc_getClass(name: *const i8) -> *const std::ffi::c_void;
+}
+
+// ─── PerryViewController ─────────────────────────────────────────────────────
+// A custom UIViewController subclass that overrides:
+//   - buildMenuWithBuilder: — populates the iPadOS menu bar via UIMenuBuilder
+//   - perryMenuAction:      — dispatches UICommand/UIKeyCommand taps to JS callbacks
+
+/// buildMenuWithBuilder: callback — forwards to menu::build_menubar_for_builder.
+unsafe extern "C" fn vc_build_menu(
+    _this: *mut AnyObject,
+    _sel: *const std::ffi::c_void,
+    builder: *mut AnyObject,
+) {
+    // Call super first so UIKit fills in system menus
+    // (we can't easily call [super buildMenuWithBuilder:] from raw FFI,
+    //  but UIViewController's default impl is a no-op, so skipping is fine.)
+    menu::build_menubar_for_builder(builder);
+}
+
+/// perryMenuAction: callback — dispatches to menu::dispatch_menu_action.
+unsafe extern "C" fn vc_perry_menu_action(
+    _this: *mut AnyObject,
+    _sel: *const std::ffi::c_void,
+    sender: *mut AnyObject,
+) {
+    menu::dispatch_menu_action(sender);
+}
+
+/// canPerformAction:withSender: — return YES for perryMenuAction: so UIKit routes commands here.
+unsafe extern "C" fn vc_can_perform_action(
+    _this: *mut AnyObject,
+    _sel: *const std::ffi::c_void,
+    action: *const std::ffi::c_void,
+    _sender: *mut AnyObject,
+) -> bool {
+    let perry_sel = sel_registerName(c"perryMenuAction:".as_ptr());
+    action == perry_sel
+}
+
+/// Register the PerryViewController class dynamically at runtime.
+fn register_view_controller() {
+    unsafe {
+        let superclass = objc_getClass(c"UIViewController".as_ptr());
+        let cls = objc_allocateClassPair(superclass, c"PerryViewController".as_ptr(), 0);
+        if cls.is_null() {
+            // Already registered
+            return;
+        }
+
+        // buildMenuWithBuilder: — type encoding: v@:@ (void, self, _cmd, builder)
+        let sel_build = sel_registerName(c"buildMenuWithBuilder:".as_ptr());
+        class_addMethod(
+            cls,
+            sel_build,
+            vc_build_menu as *const std::ffi::c_void,
+            c"v@:@".as_ptr(),
+        );
+
+        // perryMenuAction: — type encoding: v@:@ (void, self, _cmd, sender)
+        let sel_action = sel_registerName(c"perryMenuAction:".as_ptr());
+        class_addMethod(
+            cls,
+            sel_action,
+            vc_perry_menu_action as *const std::ffi::c_void,
+            c"v@:@".as_ptr(),
+        );
+
+        // canPerformAction:withSender: — type encoding: B@::@ (BOOL, self, _cmd, action, sender)
+        let sel_can = sel_registerName(c"canPerformAction:withSender:".as_ptr());
+        class_addMethod(
+            cls,
+            sel_can,
+            vc_can_perform_action as *const std::ffi::c_void,
+            c"B@::@".as_ptr(),
+        );
+
+        objc_registerClassPair(cls);
+    }
+}
+
+/// visionOS uses a SwiftUI host app; `perry_main_init` should not enter
+/// UIApplicationMain itself. The Swift host calls back into
+/// `perry_visionos_root_view()` to embed the UIKit tree.
+pub fn app_run(_app_handle: i64) {
+    crate::crash_log::install_crash_hooks();
+    register_view_controller();
+}
+
+/// Set minimum window size (no-op on iOS — windows are always full-screen).
+pub fn set_min_size(_app_handle: i64, _w: f64, _h: f64) {
+    // No-op on iOS
+}
+
+/// Set maximum window size (no-op on iOS — windows are always full-screen).
+pub fn set_max_size(_app_handle: i64, _w: f64, _h: f64) {
+    // No-op on iOS
+}
+
+/// Add a keyboard shortcut (stub on iOS — UIKeyCommand not yet implemented).
+pub fn add_keyboard_shortcut(_key_ptr: *const u8, _modifiers: f64, _callback: f64) {
+    // No-op on iOS for now
+}
+
+// ============================================
+// Timer
+// ============================================
+
+thread_local! {
+    static TIMER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+
+extern "C" {
+    fn js_stdlib_process_pending();
+    fn js_promise_run_microtasks() -> i32;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_closure_call0(closure: *const u8) -> f64;
+    fn js_callback_timer_tick() -> i32;
+    fn js_interval_timer_tick() -> i32;
+}
+
+// ============================================
+// Timer Pump — drives setTimeout/setInterval callbacks
+// ============================================
+
+pub struct PerryPumpTargetIvars;
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryPumpTarget"]
+    #[ivars = PerryPumpTargetIvars]
+    pub struct PerryPumpTarget;
+
+    impl PerryPumpTarget {
+        #[unsafe(method(pump:))]
+        fn pump(&self, _sender: &AnyObject) {
+            crate::catch_callback_panic("pump", std::panic::AssertUnwindSafe(|| {
+                unsafe {
+                    js_callback_timer_tick();
+                    js_interval_timer_tick();
+                    js_promise_run_microtasks();
+                    #[cfg(feature = "geisterhand")]
+                    {
+                        extern "C" { fn perry_geisterhand_pump(); }
+                        perry_geisterhand_pump();
+                    }
+                }
+            }));
+        }
+    }
+);
+
+impl PerryPumpTarget {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryPumpTargetIvars);
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+pub struct PerryTimerTargetIvars {
+    callback_key: std::cell::Cell<usize>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryTimerTarget"]
+    #[ivars = PerryTimerTargetIvars]
+    pub struct PerryTimerTarget;
+
+    impl PerryTimerTarget {
+        #[unsafe(method(timerFired:))]
+        fn timer_fired(&self, _sender: &AnyObject) {
+            // Drain resolved promises, then run microtasks (.then callbacks)
+            unsafe {
+                js_stdlib_process_pending();
+                js_promise_run_microtasks();
+            }
+
+            let key = self.ivars().callback_key.get();
+            let closure_f64 = TIMER_CALLBACKS.with(|cbs| {
+                cbs.borrow().get(&key).copied()
+            });
+            if let Some(closure_f64) = closure_f64 {
+                let closure_ptr = unsafe { js_nanbox_get_pointer(closure_f64) };
+                unsafe {
+                    js_closure_call0(closure_ptr as *const u8);
+                }
+            }
+        }
+    }
+);
+
+impl PerryTimerTarget {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryTimerTargetIvars {
+            callback_key: std::cell::Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+// ============================================
+// Keyboard Avoidance
+// ============================================
+
+thread_local! {
+    static KEYBOARD_VIEW: RefCell<Option<usize>> = RefCell::new(None);
+}
+
+/// Register for UIKeyboard notifications to adjust the root view when the keyboard appears.
+fn register_keyboard_observers() {
+    unsafe {
+        let nc: *const AnyObject = msg_send![
+            AnyClass::get(c"NSNotificationCenter").unwrap(),
+            defaultCenter
+        ];
+
+        // Register the PerryKeyboardObserver class
+        let observer = PerryKeyboardObserver::new();
+
+        // UIKeyboardWillChangeFrameNotification
+        let notif_name = NSString::from_str("UIKeyboardWillChangeFrameNotification");
+        let sel = Sel::register(c"keyboardWillChangeFrame:");
+        let _: () = msg_send![
+            nc,
+            addObserver: &*observer,
+            selector: sel,
+            name: &*notif_name,
+            object: std::ptr::null::<AnyObject>()
+        ];
+
+        std::mem::forget(observer); // keep alive
+    }
+}
+
+pub struct PerryKeyboardObserverIvars;
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryKeyboardObserver"]
+    #[ivars = PerryKeyboardObserverIvars]
+    pub struct PerryKeyboardObserver;
+
+    impl PerryKeyboardObserver {
+        #[unsafe(method(keyboardWillChangeFrame:))]
+        fn keyboard_will_change_frame(&self, notification: &AnyObject) {
+            unsafe {
+                // Get keyboard frame from notification userInfo
+                let user_info: *const AnyObject = msg_send![notification, userInfo];
+                if user_info.is_null() { return; }
+
+                let frame_key = NSString::from_str("UIKeyboardFrameEndUserInfoKey");
+                let frame_value: *const AnyObject = msg_send![user_info, objectForKey: &*frame_key];
+                if frame_value.is_null() { return; }
+
+                let kbd_frame: objc2_core_foundation::CGRect = msg_send![frame_value, CGRectValue];
+
+                // Get animation duration
+                let duration_key = NSString::from_str("UIKeyboardAnimationDurationUserInfoKey");
+                let duration_value: *const AnyObject = msg_send![user_info, objectForKey: &*duration_key];
+                let duration: f64 = if !duration_value.is_null() {
+                    msg_send![duration_value, doubleValue]
+                } else {
+                    0.25
+                };
+
+                // Get the screen height to determine if keyboard is showing or hiding
+                let screen: *const AnyObject = msg_send![
+                    AnyClass::get(c"UIScreen").unwrap(),
+                    mainScreen
+                ];
+                let screen_bounds: objc2_core_foundation::CGRect = msg_send![screen, bounds];
+                let screen_height = screen_bounds.size.height;
+
+                // Keyboard height: if kbd_frame.origin.y >= screen_height, keyboard is hidden
+                let keyboard_height = if kbd_frame.origin.y >= screen_height {
+                    0.0
+                } else {
+                    screen_height - kbd_frame.origin.y
+                };
+
+                // Adjust the root bottom constraint
+                ROOT_BOTTOM_CONSTRAINT.with(|rc| {
+                    if let Some(ref constraint) = *rc.borrow() {
+                        // Negative constant because bottom constraint is root.bottom == view.bottom + constant
+                        let _: () = msg_send![&**constraint, setConstant: -keyboard_height];
+                    }
+                });
+
+                // Animate the layout change
+                KEYBOARD_VIEW.with(|kv| {
+                    if let Some(view_ptr) = *kv.borrow() {
+                        let view = view_ptr as *const AnyObject;
+
+                        // Get animation curve
+                        let curve_key = NSString::from_str("UIKeyboardAnimationCurveUserInfoKey");
+                        let curve_value: *const AnyObject = msg_send![user_info, objectForKey: &*curve_key];
+                        let curve: u64 = if !curve_value.is_null() {
+                            msg_send![curve_value, unsignedIntegerValue]
+                        } else {
+                            7 // UIViewAnimationCurveKeyboard (undocumented but standard)
+                        };
+
+                        // UIView.animateWithDuration:delay:options:animations:completion:
+                        // options: curve << 16 to convert UIViewAnimationCurve to UIViewAnimationOptions
+                        let options = curve << 16;
+                        let view_copy = view;
+
+                        // Use block-based animation
+                        let animation_block = block2::RcBlock::new(move || {
+                            let _: () = msg_send![view_copy, layoutIfNeeded];
+                        });
+
+                        let _: () = msg_send![
+                            AnyClass::get(c"UIView").unwrap(),
+                            animateWithDuration: duration,
+                            delay: 0.0f64,
+                            options: options,
+                            animations: &*animation_block,
+                            completion: std::ptr::null::<AnyObject>()
+                        ];
+
+                        // Also scroll the focused text field into view
+                        scroll_focused_field_into_view(keyboard_height);
+                    }
+                });
+            }
+        }
+    }
+);
+
+impl PerryKeyboardObserver {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryKeyboardObserverIvars);
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+/// Find the currently focused UITextField/UISecureTextField and scroll its
+/// parent UIScrollView so the field is visible above the keyboard.
+unsafe fn scroll_focused_field_into_view(keyboard_height: f64) {
+    if keyboard_height <= 0.0 { return; }
+
+    // Find the first responder
+    let app: *const AnyObject = msg_send![
+        AnyClass::get(c"UIApplication").unwrap(),
+        sharedApplication
+    ];
+    let key_window: *const AnyObject = msg_send![app, keyWindow];
+    if key_window.is_null() { return; }
+
+    // Use a private but widely-used method to find first responder
+    // Alternatively, walk the view hierarchy
+    let first_responder: *const AnyObject = find_first_responder(key_window as *const AnyObject);
+    if first_responder.is_null() { return; }
+
+    // Check if it's a text field
+    let tf_cls = AnyClass::get(c"UITextField").unwrap();
+    let is_tf: bool = msg_send![first_responder, isKindOfClass: tf_cls];
+    if !is_tf { return; }
+
+    // Find parent UIScrollView
+    let mut parent: *const AnyObject = msg_send![first_responder, superview];
+    let scroll_cls = AnyClass::get(c"UIScrollView").unwrap();
+    while !parent.is_null() {
+        let is_scroll: bool = msg_send![parent, isKindOfClass: scroll_cls];
+        if is_scroll {
+            // Convert the text field's frame to the scroll view's coordinate space
+            let tf_frame: objc2_core_foundation::CGRect = msg_send![first_responder, frame];
+            let tf_superview: *const AnyObject = msg_send![first_responder, superview];
+            let converted: objc2_core_foundation::CGRect = msg_send![
+                parent,
+                convertRect: tf_frame,
+                fromView: tf_superview
+            ];
+
+            // Calculate visible area (scroll view height minus keyboard)
+            let scroll_bounds: objc2_core_foundation::CGRect = msg_send![parent, bounds];
+            let visible_height = scroll_bounds.size.height - keyboard_height;
+
+            // If the text field is below the visible area, scroll to it
+            let tf_bottom = converted.origin.y + converted.size.height + 20.0; // 20px padding
+            let scroll_offset: objc2_core_foundation::CGPoint = msg_send![parent, contentOffset];
+
+            if tf_bottom > scroll_offset.y + visible_height {
+                let new_offset = tf_bottom - visible_height;
+                let point = objc2_core_foundation::CGPoint::new(0.0, new_offset);
+                let _: () = msg_send![parent, setContentOffset: point, animated: true];
+            }
+
+            break;
+        }
+        parent = msg_send![parent, superview];
+    }
+}
+
+/// Recursively find the first responder in the view hierarchy.
+unsafe fn find_first_responder(view: *const AnyObject) -> *const AnyObject {
+    let is_first: bool = msg_send![view, isFirstResponder];
+    if is_first { return view; }
+
+    let subviews: *const AnyObject = msg_send![view, subviews];
+    let count: usize = msg_send![subviews, count];
+    for i in 0..count {
+        let subview: *const AnyObject = msg_send![subviews, objectAtIndex: i];
+        let result = find_first_responder(subview);
+        if !result.is_null() { return result; }
+    }
+
+    std::ptr::null()
+}
+
+/// Set a recurring timer. interval_ms is in milliseconds.
+/// The timer calls js_stdlib_process_pending() then invokes the callback.
+pub fn set_timer(interval_ms: f64, callback: f64) {
+    let interval_secs = interval_ms / 1000.0;
+
+    unsafe {
+        let target = PerryTimerTarget::new();
+        let target_addr = Retained::as_ptr(&target) as usize;
+        target.ivars().callback_key.set(target_addr);
+
+        TIMER_CALLBACKS.with(|cbs| {
+            cbs.borrow_mut().insert(target_addr, callback);
+        });
+
+        // NSTimer.scheduledTimerWithTimeInterval:target:selector:userInfo:repeats:
+        let sel = Sel::register(c"timerFired:");
+        let _: Retained<AnyObject> = msg_send![
+            objc2::class!(NSTimer),
+            scheduledTimerWithTimeInterval: interval_secs,
+            target: &*target,
+            selector: sel,
+            userInfo: std::ptr::null::<AnyObject>(),
+            repeats: true
+        ];
+
+        // Keep the target alive
+        std::mem::forget(target);
+    }
+}

--- a/crates/perry-ui-visionos/src/audio.rs
+++ b/crates/perry-ui-visionos/src/audio.rs
@@ -1,0 +1,315 @@
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject};
+use objc2::msg_send;
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+// =============================================================================
+// Shared atomic state — written by audio thread, read by main thread
+// =============================================================================
+
+static CURRENT_DB: AtomicU64 = AtomicU64::new(0);
+static CURRENT_PEAK: AtomicU64 = AtomicU64::new(0);
+
+const WAVEFORM_SIZE: usize = 256;
+static WAVEFORM_WRITE_INDEX: AtomicU64 = AtomicU64::new(0);
+static mut WAVEFORM_BUFFER: [f64; WAVEFORM_SIZE] = [0.0; WAVEFORM_SIZE];
+
+// =============================================================================
+// A-weighting IIR filter
+// =============================================================================
+
+struct AWeightState {
+    sections: [[f64; 4]; 3],
+}
+
+impl AWeightState {
+    fn new() -> Self {
+        AWeightState {
+            sections: [[0.0; 4]; 3],
+        }
+    }
+}
+
+// A-weighting coefficients for 48kHz (default on modern Apple devices).
+const A_WEIGHT_SOS: [[f64; 6]; 3] = [
+    [1.0, -2.0, 1.0, 1.0, -1.9746716508129498, 0.97504628855498883],
+    [1.0, -2.0, 1.0, 1.0, -1.1440825051498020, 0.20482985688498268],
+    [0.24649652853975498, -0.49299305707950996, 0.24649652853975498, 1.0, -0.48689808685150487, 0.0],
+];
+
+const A_WEIGHT_GAIN: f64 = 0.11310782960598924;
+
+fn a_weight_filter(sample: f64, state: &mut AWeightState) -> f64 {
+    let mut x = sample * A_WEIGHT_GAIN;
+    for (i, sos) in A_WEIGHT_SOS.iter().enumerate() {
+        let b0 = sos[0]; let b1 = sos[1]; let b2 = sos[2];
+        let a1 = sos[4]; let a2 = sos[5];
+        let s = &mut state.sections[i];
+        let y = b0 * x + b1 * s[0] + b2 * s[1] - a1 * s[2] - a2 * s[3];
+        s[1] = s[0]; s[0] = x; s[3] = s[2]; s[2] = y;
+        x = y;
+    }
+    x
+}
+
+// =============================================================================
+// Thread-local state
+// =============================================================================
+
+thread_local! {
+    static ENGINE: RefCell<Option<Retained<AnyObject>>> = RefCell::new(None);
+    static FILTER_STATE: RefCell<AWeightState> = RefCell::new(AWeightState::new());
+    static EMA_DB: RefCell<f64> = RefCell::new(0.0);
+}
+
+extern "C" {
+    fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    fn js_array_create() -> i64;
+    fn js_array_push_f64(array_ptr: i64, value: f64);
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+pub fn start() -> i64 {
+    let already_running = ENGINE.with(|e| e.borrow().is_some());
+    if already_running {
+        return 1;
+    }
+
+    unsafe {
+        // Configure audio session for recording
+        let session_cls = match AnyClass::get(c"AVAudioSession") {
+            Some(cls) => cls,
+            None => {
+                crate::ws_log!("[audio] AVAudioSession not found");
+                return 0;
+            }
+        };
+        let session: *mut AnyObject = msg_send![session_cls, sharedInstance];
+        if session.is_null() {
+            crate::ws_log!("[audio] sharedInstance is null");
+            return 0;
+        }
+
+        // Set category to Record
+        let category = objc2_foundation::NSString::from_str("AVAudioSessionCategoryRecord");
+        let mut error: *mut AnyObject = std::ptr::null_mut();
+        let _: bool = msg_send![session, setCategory: &*category error: &mut error];
+        if !error.is_null() {
+            crate::ws_log!("[audio] failed to set audio session category");
+            return 0;
+        }
+
+        // Activate the session
+        let _: bool = msg_send![session, setActive: true error: &mut error];
+
+        // Request microphone permission
+        // On iOS, this shows the system permission dialog if not yet determined.
+        // The block is called asynchronously with the result.
+        // For simplicity, we proceed optimistically — if denied, the engine will fail to start.
+        let record_permission: i64 = msg_send![session, recordPermission];
+        // 0 = undetermined, 1 = denied, 2 = granted
+        if record_permission == 1 {
+            crate::ws_log!("[audio] microphone permission denied");
+            return 0;
+        }
+        if record_permission == 0 {
+            // Request permission - this will show the system dialog.
+            // Use a no-op block; the user calls audioStart() again after granting.
+            let permission_block = block2::RcBlock::new(|_granted: objc2::runtime::Bool| {
+                // Permission result handled on next audioStart() call
+            });
+            let _: () = msg_send![session, requestRecordPermission: &*permission_block];
+            crate::ws_log!("[audio] requesting microphone permission");
+            return 0; // Caller should retry after permission is granted
+        }
+
+        // Create AVAudioEngine
+        let engine_cls = match AnyClass::get(c"AVAudioEngine") {
+            Some(cls) => cls,
+            None => {
+                crate::ws_log!("[audio] AVAudioEngine not found");
+                return 0;
+            }
+        };
+        let engine: Retained<AnyObject> = msg_send![engine_cls, new];
+
+        // Get input node
+        let input_node: *mut AnyObject = msg_send![&*engine, inputNode];
+        if input_node.is_null() {
+            crate::ws_log!("[audio] inputNode is null");
+            return 0;
+        }
+
+        // Get format
+        let format: *mut AnyObject = msg_send![input_node, outputFormatForBus: 0u64];
+        if format.is_null() {
+            crate::ws_log!("[audio] could not get input format");
+            return 0;
+        }
+
+        let sample_rate: f64 = msg_send![format, sampleRate];
+        crate::ws_log!("[audio] input format: {}Hz", sample_rate);
+
+        // Create tap block
+        let tap_block = block2::RcBlock::new(move |buffer: *mut AnyObject, _when: *mut AnyObject| {
+            process_audio_buffer(buffer, sample_rate);
+        });
+
+        // Install tap
+        let buffer_size: u32 = 1024;
+        let _: () = msg_send![
+            input_node,
+            installTapOnBus: 0u32
+            bufferSize: buffer_size
+            format: format
+            block: &*tap_block
+        ];
+
+        // Start engine
+        let mut error: *mut AnyObject = std::ptr::null_mut();
+        let started: bool = msg_send![&*engine, startAndReturnError: &mut error];
+        if !started {
+            crate::ws_log!("[audio] failed to start engine");
+            let _: () = msg_send![input_node, removeTapOnBus: 0u32];
+            return 0;
+        }
+
+        crate::ws_log!("[audio] engine started successfully");
+        ENGINE.with(|e| { *e.borrow_mut() = Some(engine); });
+        1
+    }
+}
+
+pub fn stop() {
+    ENGINE.with(|e| {
+        if let Some(engine) = e.borrow_mut().take() {
+            unsafe {
+                let input_node: *mut AnyObject = msg_send![&*engine, inputNode];
+                if !input_node.is_null() {
+                    let _: () = msg_send![input_node, removeTapOnBus: 0u32];
+                }
+                let _: () = msg_send![&*engine, stop];
+            }
+            crate::ws_log!("[audio] engine stopped");
+        }
+    });
+}
+
+pub fn get_level() -> f64 {
+    f64::from_bits(CURRENT_DB.load(Ordering::Relaxed))
+}
+
+pub fn get_peak() -> f64 {
+    f64::from_bits(CURRENT_PEAK.load(Ordering::Relaxed))
+}
+
+pub fn get_waveform(count: f64) -> f64 {
+    let n = (count as usize).min(WAVEFORM_SIZE);
+    let write_idx = WAVEFORM_WRITE_INDEX.load(Ordering::Relaxed) as usize;
+    unsafe {
+        let array = js_array_create();
+        for i in 0..n {
+            let idx = (write_idx + WAVEFORM_SIZE - n + i) % WAVEFORM_SIZE;
+            js_array_push_f64(array, WAVEFORM_BUFFER[idx]);
+        }
+        f64::from_bits(array as u64)
+    }
+}
+
+pub fn get_device_model() -> i64 {
+    let model = get_sysctl_model();
+    unsafe {
+        js_string_from_bytes(model.as_ptr(), model.len() as i32)
+    }
+}
+
+// =============================================================================
+// Internal: Audio processing
+// =============================================================================
+
+unsafe fn process_audio_buffer(buffer: *mut AnyObject, sample_rate: f64) {
+    if buffer.is_null() { return; }
+
+    let float_channel_data: *const *const f32 = msg_send![buffer, floatChannelData];
+    if float_channel_data.is_null() { return; }
+
+    let frame_length: u32 = msg_send![buffer, frameLength];
+    if frame_length == 0 { return; }
+
+    let samples: *const f32 = *float_channel_data;
+    if samples.is_null() { return; }
+
+    let n = frame_length as usize;
+    let mut sum_sq = 0.0f64;
+    let mut peak = 0.0f32;
+
+    FILTER_STATE.with(|fs| {
+        let mut state = fs.borrow_mut();
+        for i in 0..n {
+            let sample = *samples.add(i);
+            let abs_sample = sample.abs();
+            if abs_sample > peak { peak = abs_sample; }
+            let weighted = a_weight_filter(sample as f64, &mut state);
+            sum_sq += weighted * weighted;
+        }
+    });
+
+    let rms = (sum_sq / n as f64).sqrt();
+    // Map digital RMS to dB SPL. 0 dBFS ≈ 110 dB SPL (conservative;
+    // per-device calibration in calibration.ts refines this).
+    let db_raw = if rms > 1.0e-10 {
+        20.0 * rms.log10() + 110.0
+    } else {
+        0.0
+    };
+    let db_clamped = db_raw.max(0.0).min(140.0);
+
+    let dt = n as f64 / sample_rate;
+    let tau = 0.125;
+    let alpha = 1.0 - (-dt / tau).exp();
+
+    let smoothed = EMA_DB.with(|ema| {
+        let mut current = ema.borrow_mut();
+        *current += alpha * (db_clamped - *current);
+        *current
+    });
+
+    CURRENT_DB.store(smoothed.to_bits(), Ordering::Relaxed);
+    CURRENT_PEAK.store((peak as f64).to_bits(), Ordering::Relaxed);
+
+    let idx = WAVEFORM_WRITE_INDEX.load(Ordering::Relaxed) as usize % WAVEFORM_SIZE;
+    WAVEFORM_BUFFER[idx] = smoothed;
+    WAVEFORM_WRITE_INDEX.store((idx + 1) as u64, Ordering::Relaxed);
+}
+
+// =============================================================================
+// Internal: Device model detection
+// =============================================================================
+
+fn get_sysctl_model() -> String {
+    use std::ffi::CStr;
+    let mut size: libc::size_t = 0;
+    // On iOS, hw.machine returns the device identifier (e.g., "iPhone15,2")
+    let name = c"hw.machine";
+    unsafe {
+        libc::sysctlbyname(name.as_ptr(), std::ptr::null_mut(), &mut size, std::ptr::null_mut(), 0);
+        if size == 0 {
+            return "Unknown".to_string();
+        }
+        let mut buf = vec![0u8; size];
+        libc::sysctlbyname(
+            name.as_ptr(),
+            buf.as_mut_ptr() as *mut _,
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        );
+        CStr::from_ptr(buf.as_ptr() as *const i8)
+            .to_string_lossy()
+            .into_owned()
+    }
+}

--- a/crates/perry-ui-visionos/src/audio_playback.rs
+++ b/crates/perry-ui-visionos/src/audio_playback.rs
@@ -1,0 +1,816 @@
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject, Sel};
+use objc2::msg_send;
+use std::cell::RefCell;
+
+extern "C" {
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_stdlib_process_pending();
+    fn js_promise_run_microtasks() -> i32;
+}
+
+// Raw ObjC runtime FFI for dynamic class registration
+extern "C" {
+    fn objc_allocateClassPair(
+        superclass: *const std::ffi::c_void,
+        name: *const i8,
+        extra_bytes: usize,
+    ) -> *mut std::ffi::c_void;
+    fn objc_registerClassPair(cls: *mut std::ffi::c_void);
+    fn class_addMethod(
+        cls: *mut std::ffi::c_void,
+        sel: *const std::ffi::c_void,
+        imp: *const std::ffi::c_void,
+        types: *const i8,
+    ) -> bool;
+    fn sel_registerName(name: *const i8) -> *const std::ffi::c_void;
+    fn objc_getClass(name: *const i8) -> *const std::ffi::c_void;
+}
+
+// =============================================================================
+// Data structures
+// =============================================================================
+
+struct PlayerEntry {
+    player_node: Retained<AnyObject>,  // AVAudioPlayerNode
+    buffer: Retained<AnyObject>,       // AVAudioPCMBuffer
+    _format: Retained<AnyObject>,      // AVAudioFormat
+    volume: f64,
+    is_playing: bool,
+    // Fade state
+    fade_target: f64,
+    fade_step: f64,
+    fade_ticks_remaining: u32,
+}
+
+// =============================================================================
+// Thread-local state
+// =============================================================================
+
+thread_local! {
+    static PLAYBACK_ENGINE: RefCell<Option<Retained<AnyObject>>> = RefCell::new(None);
+    static PLAYERS: RefCell<Vec<Option<PlayerEntry>>> = RefCell::new(Vec::new());
+    static INTERRUPTION_CALLBACK: RefCell<Option<f64>> = RefCell::new(None);
+    static FADE_TIMER: RefCell<Option<Retained<AnyObject>>> = RefCell::new(None);
+    static FADE_TIMER_TARGET: RefCell<Option<Retained<AnyObject>>> = RefCell::new(None);
+    static FADE_CLASS_REGISTERED: RefCell<bool> = RefCell::new(false);
+    static INTERRUPTION_CLASS_REGISTERED: RefCell<bool> = RefCell::new(false);
+}
+
+// =============================================================================
+// Helper: extract string from StringHeader pointer
+// =============================================================================
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+// =============================================================================
+// Engine initialisation (lazy, on first player_create)
+// =============================================================================
+
+fn ensure_engine() -> bool {
+    let already_running = PLAYBACK_ENGINE.with(|e| e.borrow().is_some());
+    if already_running {
+        return true;
+    }
+
+    unsafe {
+        // Configure audio session for playback
+        let session_cls = match AnyClass::get(c"AVAudioSession") {
+            Some(cls) => cls,
+            None => {
+                crate::ws_log!("[audio_playback] AVAudioSession not found");
+                return false;
+            }
+        };
+        let session: *mut AnyObject = msg_send![session_cls, sharedInstance];
+        if session.is_null() {
+            crate::ws_log!("[audio_playback] sharedInstance is null");
+            return false;
+        }
+
+        // Set category to Playback
+        let category = objc2_foundation::NSString::from_str("AVAudioSessionCategoryPlayback");
+        let mut error: *mut AnyObject = std::ptr::null_mut();
+        let _: bool = msg_send![session, setCategory: &*category error: &mut error];
+        if !error.is_null() {
+            crate::ws_log!("[audio_playback] failed to set audio session category");
+            return false;
+        }
+
+        // Activate the session
+        error = std::ptr::null_mut();
+        let _: bool = msg_send![session, setActive: true error: &mut error];
+        if !error.is_null() {
+            crate::ws_log!("[audio_playback] failed to activate audio session");
+            return false;
+        }
+
+        // Create AVAudioEngine
+        let engine_cls = match AnyClass::get(c"AVAudioEngine") {
+            Some(cls) => cls,
+            None => {
+                crate::ws_log!("[audio_playback] AVAudioEngine not found");
+                return false;
+            }
+        };
+        let engine: Retained<AnyObject> = msg_send![engine_cls, new];
+
+        // Start engine
+        error = std::ptr::null_mut();
+        let started: bool = msg_send![&*engine, startAndReturnError: &mut error];
+        if !started {
+            crate::ws_log!("[audio_playback] failed to start engine");
+            return false;
+        }
+
+        crate::ws_log!("[audio_playback] engine started successfully");
+        PLAYBACK_ENGINE.with(|e| {
+            *e.borrow_mut() = Some(engine);
+        });
+        true
+    }
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/// Create a player for the given audio file. Returns a 1-based handle as f64,
+/// or 0.0 on failure.
+pub fn player_create(filename_ptr: i64) -> f64 {
+    if !ensure_engine() {
+        return 0.0;
+    }
+
+    let filename = str_from_header(filename_ptr as *const u8);
+    if filename.is_empty() {
+        crate::ws_log!("[audio_playback] empty filename");
+        return 0.0;
+    }
+
+    // Split filename into name and extension if it contains a dot;
+    // otherwise treat as name with "m4a" extension.
+    let (name, ext) = if let Some(dot_pos) = filename.rfind('.') {
+        (&filename[..dot_pos], &filename[dot_pos + 1..])
+    } else {
+        (filename, "m4a")
+    };
+
+    unsafe {
+        let bundle_cls = AnyClass::get(c"NSBundle").unwrap();
+        let bundle: *mut AnyObject = msg_send![bundle_cls, mainBundle];
+        if bundle.is_null() {
+            crate::ws_log!("[audio_playback] mainBundle is null");
+            return 0.0;
+        }
+
+        let ns_name = objc2_foundation::NSString::from_str(name);
+        let ns_ext = objc2_foundation::NSString::from_str(ext);
+
+        // Try root of bundle first
+        let mut url: *mut AnyObject = msg_send![
+            bundle,
+            URLForResource: &*ns_name
+            withExtension: &*ns_ext
+        ];
+
+        // Try the sounds/ subdirectory
+        if url.is_null() {
+            let ns_subdir = objc2_foundation::NSString::from_str("sounds");
+            url = msg_send![
+                bundle,
+                URLForResource: &*ns_name
+                withExtension: &*ns_ext
+                subdirectory: &*ns_subdir
+            ];
+        }
+
+        if url.is_null() {
+            crate::ws_log!("[audio_playback] file not found: {}.{}", name, ext);
+            return 0.0;
+        }
+
+        // Create AVAudioFile(forReading: url)
+        let file_cls = match AnyClass::get(c"AVAudioFile") {
+            Some(cls) => cls,
+            None => {
+                crate::ws_log!("[audio_playback] AVAudioFile not found");
+                return 0.0;
+            }
+        };
+        let file_alloc: *mut AnyObject = msg_send![file_cls, alloc];
+        let mut error: *mut AnyObject = std::ptr::null_mut();
+        let file: *mut AnyObject = msg_send![file_alloc, initForReading: url error: &mut error];
+        if file.is_null() || !error.is_null() {
+            crate::ws_log!("[audio_playback] failed to open audio file: {}.{}", name, ext);
+            return 0.0;
+        }
+
+        // Get processing format and frame count
+        let format: *mut AnyObject = msg_send![file, processingFormat];
+        if format.is_null() {
+            crate::ws_log!("[audio_playback] processingFormat is null");
+            return 0.0;
+        }
+        let format: Retained<AnyObject> = Retained::retain(format).unwrap();
+        let frame_count: i64 = msg_send![file, length];
+        if frame_count <= 0 {
+            crate::ws_log!("[audio_playback] audio file has no frames");
+            return 0.0;
+        }
+
+        // Create AVAudioPCMBuffer
+        let buffer_cls = match AnyClass::get(c"AVAudioPCMBuffer") {
+            Some(cls) => cls,
+            None => {
+                crate::ws_log!("[audio_playback] AVAudioPCMBuffer not found");
+                return 0.0;
+            }
+        };
+        let buffer_alloc: *mut AnyObject = msg_send![buffer_cls, alloc];
+        let capacity = frame_count as u32;
+        let format_ptr: *mut AnyObject = &*format as *const AnyObject as *mut AnyObject;
+        let buffer: *mut AnyObject = msg_send![
+            buffer_alloc,
+            initWithPCMFormat: format_ptr
+            frameCapacity: capacity
+        ];
+        if buffer.is_null() {
+            crate::ws_log!("[audio_playback] failed to create AVAudioPCMBuffer");
+            return 0.0;
+        }
+        let buffer = Retained::retain(buffer).unwrap();
+
+        // Read file into buffer
+        error = std::ptr::null_mut();
+        let read_ok: bool = msg_send![file, readIntoBuffer: &*buffer error: &mut error];
+        if !read_ok || !error.is_null() {
+            crate::ws_log!("[audio_playback] failed to read audio file into buffer");
+            return 0.0;
+        }
+
+        // Create AVAudioPlayerNode
+        let player_cls = match AnyClass::get(c"AVAudioPlayerNode") {
+            Some(cls) => cls,
+            None => {
+                crate::ws_log!("[audio_playback] AVAudioPlayerNode not found");
+                return 0.0;
+            }
+        };
+        let player_node: Retained<AnyObject> = msg_send![player_cls, new];
+
+        // Attach player node to engine and connect
+        let handle = PLAYBACK_ENGINE.with(|e| {
+            let borrow = e.borrow();
+            let engine = borrow.as_ref().unwrap();
+
+            // engine.attachNode(playerNode)
+            let _: () = msg_send![&**engine, attachNode: &*player_node];
+
+            // engine.mainMixerNode
+            let mixer: *mut AnyObject = msg_send![&**engine, mainMixerNode];
+
+            // Get the buffer's format for the connection
+            let buf_format: *mut AnyObject = msg_send![&*buffer, format];
+
+            // engine.connect(playerNode, to: mixer, format: format)
+            let _: () = msg_send![
+                &**engine,
+                connect: &*player_node
+                to: mixer
+                format: buf_format
+            ];
+
+            // Store PlayerEntry
+            let entry = PlayerEntry {
+                player_node,
+                buffer,
+                _format: format,
+                volume: 1.0,
+                is_playing: false,
+                fade_target: 1.0,
+                fade_step: 0.0,
+                fade_ticks_remaining: 0,
+            };
+
+            PLAYERS.with(|p| {
+                let mut players = p.borrow_mut();
+                // Find an empty slot or push a new one
+                for (i, slot) in players.iter_mut().enumerate() {
+                    if slot.is_none() {
+                        *slot = Some(entry);
+                        return (i + 1) as f64;
+                    }
+                }
+                players.push(Some(entry));
+                players.len() as f64
+            })
+        });
+
+        crate::ws_log!("[audio_playback] player created, handle={}", handle);
+        handle
+    }
+}
+
+/// Play the audio in a loop.
+pub fn player_play(handle: f64) {
+    let idx = handle as usize;
+    if idx == 0 {
+        return;
+    }
+    let idx = idx - 1;
+
+    PLAYERS.with(|p| {
+        let mut players = p.borrow_mut();
+        if let Some(Some(entry)) = players.get_mut(idx) {
+            unsafe {
+                // Schedule buffer for looping:
+                // AVAudioPlayerNodeBufferLoops = 2
+                let _: () = msg_send![
+                    &*entry.player_node,
+                    scheduleBuffer: &*entry.buffer
+                    atTime: std::ptr::null::<AnyObject>()
+                    options: 2u64
+                    completionHandler: std::ptr::null::<AnyObject>()
+                ];
+
+                let _: () = msg_send![&*entry.player_node, play];
+            }
+            entry.is_playing = true;
+            crate::ws_log!("[audio_playback] player {} playing", handle);
+        }
+    });
+}
+
+/// Stop playback and cancel any active fade.
+pub fn player_stop(handle: f64) {
+    let idx = handle as usize;
+    if idx == 0 {
+        return;
+    }
+    let idx = idx - 1;
+
+    PLAYERS.with(|p| {
+        let mut players = p.borrow_mut();
+        if let Some(Some(entry)) = players.get_mut(idx) {
+            unsafe {
+                let _: () = msg_send![&*entry.player_node, stop];
+            }
+            entry.is_playing = false;
+            entry.fade_ticks_remaining = 0;
+            crate::ws_log!("[audio_playback] player {} stopped", handle);
+        }
+    });
+}
+
+/// Set volume immediately (0.0 to 1.0).
+pub fn player_set_volume(handle: f64, volume: f64) {
+    let idx = handle as usize;
+    if idx == 0 {
+        return;
+    }
+    let idx = idx - 1;
+
+    PLAYERS.with(|p| {
+        let mut players = p.borrow_mut();
+        if let Some(Some(entry)) = players.get_mut(idx) {
+            let vol = volume.max(0.0).min(1.0);
+            unsafe {
+                let _: () = msg_send![&*entry.player_node, setVolume: vol as f32];
+            }
+            entry.volume = vol;
+        }
+    });
+}
+
+/// Fade volume to target over duration seconds.
+pub fn player_fade_to(handle: f64, target: f64, duration: f64) {
+    let idx = handle as usize;
+    if idx == 0 {
+        return;
+    }
+    let idx = idx - 1;
+
+    let target = target.max(0.0).min(1.0);
+
+    PLAYERS.with(|p| {
+        let mut players = p.borrow_mut();
+        if let Some(Some(entry)) = players.get_mut(idx) {
+            if duration <= 0.0 {
+                // Instant change
+                entry.volume = target;
+                entry.fade_ticks_remaining = 0;
+                unsafe {
+                    let _: () = msg_send![&*entry.player_node, setVolume: target as f32];
+                }
+                if target == 0.0 {
+                    unsafe {
+                        let _: () = msg_send![&*entry.player_node, stop];
+                    }
+                    entry.is_playing = false;
+                }
+                return;
+            }
+
+            let ticks = (duration * 30.0).max(1.0) as u32;
+            entry.fade_target = target;
+            entry.fade_step = (target - entry.volume) / ticks as f64;
+            entry.fade_ticks_remaining = ticks;
+        }
+    });
+
+    // Ensure the global fade timer is running
+    ensure_fade_timer();
+}
+
+/// Returns 1.0 if playing, 0.0 otherwise. -1.0 for invalid handle.
+pub fn player_is_playing(handle: f64) -> f64 {
+    let idx = handle as usize;
+    if idx == 0 {
+        return -1.0;
+    }
+    let idx = idx - 1;
+
+    PLAYERS.with(|p| {
+        let players = p.borrow();
+        match players.get(idx) {
+            Some(Some(entry)) => {
+                if entry.is_playing { 1.0 } else { 0.0 }
+            }
+            _ => -1.0,
+        }
+    })
+}
+
+/// Destroy a player, detaching it from the engine and freeing resources.
+pub fn player_destroy(handle: f64) {
+    let idx = handle as usize;
+    if idx == 0 {
+        return;
+    }
+    let idx = idx - 1;
+
+    PLAYERS.with(|p| {
+        let mut players = p.borrow_mut();
+        if let Some(slot) = players.get_mut(idx) {
+            if let Some(entry) = slot.take() {
+                unsafe {
+                    if entry.is_playing {
+                        let _: () = msg_send![&*entry.player_node, stop];
+                    }
+                    // Detach from engine
+                    PLAYBACK_ENGINE.with(|e| {
+                        if let Some(engine) = e.borrow().as_ref() {
+                            let _: () = msg_send![&**engine, detachNode: &*entry.player_node];
+                        }
+                    });
+                }
+                crate::ws_log!("[audio_playback] player {} destroyed", handle);
+            }
+        }
+    });
+}
+
+/// Set Now Playing info (lock screen / Control Center metadata).
+pub fn player_set_now_playing(title_ptr: i64) {
+    let title = str_from_header(title_ptr as *const u8);
+
+    unsafe {
+        // MPNowPlayingInfoCenter.defaultCenter
+        let center_cls = match AnyClass::get(c"MPNowPlayingInfoCenter") {
+            Some(cls) => cls,
+            None => {
+                crate::ws_log!("[audio_playback] MPNowPlayingInfoCenter not found");
+                return;
+            }
+        };
+        let center: *mut AnyObject = msg_send![center_cls, defaultCenter];
+        if center.is_null() {
+            crate::ws_log!("[audio_playback] defaultCenter is null");
+            return;
+        }
+
+        // Create NSMutableDictionary
+        let dict_cls = AnyClass::get(c"NSMutableDictionary").unwrap();
+        let dict: Retained<AnyObject> = msg_send![dict_cls, new];
+
+        // Set title: MPMediaItemPropertyTitle = "title"
+        let key = objc2_foundation::NSString::from_str("title");
+        let value = objc2_foundation::NSString::from_str(title);
+        let _: () = msg_send![&*dict, setObject: &*value forKey: &*key];
+
+        // Set nowPlayingInfo
+        let _: () = msg_send![center, setNowPlayingInfo: &*dict];
+
+        // Set up MPRemoteCommandCenter play/pause commands
+        let cmd_center_cls = match AnyClass::get(c"MPRemoteCommandCenter") {
+            Some(cls) => cls,
+            None => {
+                crate::ws_log!("[audio_playback] MPRemoteCommandCenter not found");
+                return;
+            }
+        };
+        let cmd_center: *mut AnyObject = msg_send![cmd_center_cls, sharedCommandCenter];
+        if cmd_center.is_null() {
+            return;
+        }
+
+        // Enable play command
+        let play_cmd: *mut AnyObject = msg_send![cmd_center, playCommand];
+        if !play_cmd.is_null() {
+            let _: () = msg_send![play_cmd, setEnabled: true];
+        }
+
+        // Enable pause command
+        let pause_cmd: *mut AnyObject = msg_send![cmd_center, pauseCommand];
+        if !pause_cmd.is_null() {
+            let _: () = msg_send![pause_cmd, setEnabled: true];
+        }
+
+        crate::ws_log!("[audio_playback] now playing set: {}", title);
+    }
+}
+
+/// Register a JS callback to be invoked on audio session interruption.
+/// The callback receives 1.0 when interrupted (began) and 0.0 when resumed (ended).
+pub fn player_set_on_interruption(callback: f64) {
+    INTERRUPTION_CALLBACK.with(|c| {
+        *c.borrow_mut() = Some(callback);
+    });
+
+    register_interruption_observer();
+}
+
+// =============================================================================
+// Fade timer
+// =============================================================================
+
+/// The fadeTick: callback — iterates all players with active fades.
+unsafe extern "C" fn fade_tick(
+    _this: *mut AnyObject,
+    _sel: *const std::ffi::c_void,
+    _timer: *mut AnyObject,
+) {
+    let mut any_active = false;
+
+    PLAYERS.with(|p| {
+        let mut players = p.borrow_mut();
+        for slot in players.iter_mut() {
+            if let Some(entry) = slot.as_mut() {
+                if entry.fade_ticks_remaining == 0 {
+                    continue;
+                }
+
+                entry.fade_ticks_remaining -= 1;
+                if entry.fade_ticks_remaining == 0 {
+                    // Fade complete — snap to exact target
+                    entry.volume = entry.fade_target;
+                    let _: () = msg_send![&*entry.player_node, setVolume: entry.fade_target as f32];
+
+                    // If faded to silence, stop playback
+                    if entry.fade_target == 0.0 {
+                        let _: () = msg_send![&*entry.player_node, stop];
+                        entry.is_playing = false;
+                    }
+                } else {
+                    entry.volume += entry.fade_step;
+                    let vol = entry.volume.max(0.0).min(1.0);
+                    entry.volume = vol;
+                    let _: () = msg_send![&*entry.player_node, setVolume: vol as f32];
+                    any_active = true;
+                }
+            }
+        }
+    });
+
+    if !any_active {
+        // No fades active — invalidate the timer
+        FADE_TIMER.with(|ft| {
+            if let Some(timer) = ft.borrow_mut().take() {
+                let _: () = msg_send![&*timer, invalidate];
+            }
+        });
+        // Release the target
+        FADE_TIMER_TARGET.with(|t| {
+            t.borrow_mut().take();
+        });
+    }
+}
+
+/// Register the PerryFadeTimerTarget class dynamically.
+fn register_fade_timer_class() {
+    FADE_CLASS_REGISTERED.with(|reg| {
+        if *reg.borrow() {
+            return;
+        }
+        *reg.borrow_mut() = true;
+
+        unsafe {
+            let superclass = objc_getClass(c"NSObject".as_ptr());
+            let cls = objc_allocateClassPair(superclass, c"PerryFadeTimerTarget".as_ptr(), 0);
+            if cls.is_null() {
+                return; // Already registered
+            }
+
+            // fadeTick: — type encoding: v@:@ (void, self, _cmd, timer)
+            let sel = sel_registerName(c"fadeTick:".as_ptr());
+            class_addMethod(
+                cls,
+                sel,
+                fade_tick as *const std::ffi::c_void,
+                c"v@:@".as_ptr(),
+            );
+
+            objc_registerClassPair(cls);
+        }
+    });
+}
+
+/// Ensure the global 30Hz fade timer is running.
+fn ensure_fade_timer() {
+    let already_running = FADE_TIMER.with(|ft| ft.borrow().is_some());
+    if already_running {
+        return;
+    }
+
+    register_fade_timer_class();
+
+    unsafe {
+        let target_cls = match AnyClass::get(c"PerryFadeTimerTarget") {
+            Some(cls) => cls,
+            None => {
+                crate::ws_log!("[audio_playback] PerryFadeTimerTarget class not found");
+                return;
+            }
+        };
+        let target: Retained<AnyObject> = msg_send![target_cls, new];
+
+        let sel = Sel::register(c"fadeTick:");
+        let timer: Retained<AnyObject> = msg_send![
+            objc2::class!(NSTimer),
+            scheduledTimerWithTimeInterval: (1.0 / 30.0f64),
+            target: &*target,
+            selector: sel,
+            userInfo: std::ptr::null::<AnyObject>(),
+            repeats: true
+        ];
+
+        FADE_TIMER.with(|ft| {
+            *ft.borrow_mut() = Some(timer);
+        });
+        FADE_TIMER_TARGET.with(|t| {
+            *t.borrow_mut() = Some(target);
+        });
+    }
+}
+
+// =============================================================================
+// Audio session interruption observer
+// =============================================================================
+
+/// The handleInterruption: callback — invoked by NSNotificationCenter.
+unsafe extern "C" fn handle_interruption(
+    _this: *mut AnyObject,
+    _sel: *const std::ffi::c_void,
+    notification: *mut AnyObject,
+) {
+    if notification.is_null() {
+        return;
+    }
+
+    // Get userInfo dictionary
+    let user_info: *mut AnyObject = msg_send![notification, userInfo];
+    if user_info.is_null() {
+        return;
+    }
+
+    // Get the interruption type from the userInfo.
+    // Key: AVAudioSessionInterruptionTypeKey
+    let type_key = objc2_foundation::NSString::from_str("AVAudioSessionInterruptionType");
+    let type_val: *mut AnyObject = msg_send![user_info, objectForKey: &*type_key];
+    if type_val.is_null() {
+        return;
+    }
+
+    let interruption_type: u64 = msg_send![type_val, unsignedIntegerValue];
+    // 1 = began, 0 = ended
+    let callback_arg = if interruption_type == 1 { 1.0 } else { 0.0 };
+
+    crate::ws_log!("[audio_playback] interruption type={}", interruption_type);
+
+    // If interruption ended, reactivate the audio session and restart the engine
+    if interruption_type == 0 {
+        let session_cls = AnyClass::get(c"AVAudioSession").unwrap();
+        let session: *mut AnyObject = msg_send![session_cls, sharedInstance];
+        if !session.is_null() {
+            let mut error: *mut AnyObject = std::ptr::null_mut();
+            let _: bool = msg_send![session, setActive: true error: &mut error];
+        }
+
+        // Restart the engine if it was stopped
+        PLAYBACK_ENGINE.with(|e| {
+            if let Some(engine) = e.borrow().as_ref() {
+                let running: bool = msg_send![&**engine, isRunning];
+                if !running {
+                    let mut error: *mut AnyObject = std::ptr::null_mut();
+                    let _: bool = msg_send![&**engine, startAndReturnError: &mut error];
+                    crate::ws_log!("[audio_playback] engine restarted after interruption");
+                }
+            }
+        });
+    }
+
+    // Invoke JS callback
+    let cb = INTERRUPTION_CALLBACK.with(|c| *c.borrow());
+    if let Some(closure_f64) = cb {
+        js_stdlib_process_pending();
+        js_promise_run_microtasks();
+        let closure_ptr = js_nanbox_get_pointer(closure_f64);
+        js_closure_call1(closure_ptr as *const u8, callback_arg);
+    }
+}
+
+/// Register the PerryInterruptionObserver class dynamically.
+fn register_interruption_class() {
+    INTERRUPTION_CLASS_REGISTERED.with(|reg| {
+        if *reg.borrow() {
+            return;
+        }
+        *reg.borrow_mut() = true;
+
+        unsafe {
+            let superclass = objc_getClass(c"NSObject".as_ptr());
+            let cls = objc_allocateClassPair(
+                superclass,
+                c"PerryInterruptionObserver".as_ptr(),
+                0,
+            );
+            if cls.is_null() {
+                return; // Already registered
+            }
+
+            // handleInterruption: — type encoding: v@:@ (void, self, _cmd, notification)
+            let sel = sel_registerName(c"handleInterruption:".as_ptr());
+            class_addMethod(
+                cls,
+                sel,
+                handle_interruption as *const std::ffi::c_void,
+                c"v@:@".as_ptr(),
+            );
+
+            objc_registerClassPair(cls);
+        }
+    });
+}
+
+/// Register for AVAudioSessionInterruptionNotification.
+fn register_interruption_observer() {
+    register_interruption_class();
+
+    unsafe {
+        let observer_cls = match AnyClass::get(c"PerryInterruptionObserver") {
+            Some(cls) => cls,
+            None => {
+                crate::ws_log!("[audio_playback] PerryInterruptionObserver class not found");
+                return;
+            }
+        };
+        let observer: Retained<AnyObject> = msg_send![observer_cls, new];
+
+        let nc: *const AnyObject = msg_send![
+            AnyClass::get(c"NSNotificationCenter").unwrap(),
+            defaultCenter
+        ];
+
+        let notif_name = objc2_foundation::NSString::from_str("AVAudioSessionInterruptionNotification");
+        let sel = Sel::register(c"handleInterruption:");
+
+        // Get the shared audio session as the notification sender
+        let session_cls = AnyClass::get(c"AVAudioSession").unwrap();
+        let session: *mut AnyObject = msg_send![session_cls, sharedInstance];
+
+        let _: () = msg_send![
+            nc,
+            addObserver: &*observer,
+            selector: sel,
+            name: &*notif_name,
+            object: session
+        ];
+
+        // Keep the observer alive
+        std::mem::forget(observer);
+
+        crate::ws_log!("[audio_playback] interruption observer registered");
+    }
+}

--- a/crates/perry-ui-visionos/src/camera.rs
+++ b/crates/perry-ui-visionos/src/camera.rs
@@ -1,0 +1,616 @@
+// Camera widget — live camera preview with color sampling
+//
+// Uses AVCaptureSession + AVCaptureVideoPreviewLayer for live preview,
+// AVCaptureVideoDataOutput for frame capture, and CVPixelBuffer for color sampling.
+
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject, Sel};
+use objc2::{msg_send, Encode, Encoding, RefEncode};
+use objc2_ui_kit::UIView;
+use objc2_core_foundation::CGRect;
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicPtr, AtomicBool, Ordering};
+use std::ffi::c_void;
+
+use crate::widgets;
+
+extern "C" {
+    fn js_closure_call0(closure: *const u8) -> f64;
+    fn js_closure_call2(closure: *const u8, arg1: f64, arg2: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_stdlib_process_pending();
+    fn js_promise_run_microtasks() -> i32;
+    static _dispatch_main_q: c_void;
+    fn dispatch_async_f(
+        queue: *const c_void,
+        context: *mut c_void,
+        work: unsafe extern "C" fn(*mut c_void),
+    );
+}
+
+// Core Video / Core Media C API
+type CVPixelBufferRef = *mut c_void;
+type CVReturn = i32;
+
+extern "C" {
+    fn CVPixelBufferLockBaseAddress(pixelBuffer: CVPixelBufferRef, lockFlags: u64) -> CVReturn;
+    fn CVPixelBufferUnlockBaseAddress(pixelBuffer: CVPixelBufferRef, lockFlags: u64) -> CVReturn;
+    fn CVPixelBufferGetBaseAddress(pixelBuffer: CVPixelBufferRef) -> *mut u8;
+    fn CVPixelBufferGetWidth(pixelBuffer: CVPixelBufferRef) -> usize;
+    fn CVPixelBufferGetHeight(pixelBuffer: CVPixelBufferRef) -> usize;
+    fn CVPixelBufferGetBytesPerRow(pixelBuffer: CVPixelBufferRef) -> usize;
+    fn CMSampleBufferGetImageBuffer(sbuf: *mut c_void) -> CVPixelBufferRef;
+    fn CFRetain(cf: *mut c_void) -> *mut c_void;
+    fn CFRelease(cf: *mut c_void);
+}
+
+// ObjC runtime FFI for dynamic class registration
+extern "C" {
+    fn objc_allocateClassPair(
+        superclass: *const c_void,
+        name: *const i8,
+        extra_bytes: usize,
+    ) -> *mut c_void;
+    fn objc_registerClassPair(cls: *mut c_void);
+    fn class_addMethod(
+        cls: *mut c_void,
+        sel: *const c_void,
+        imp: *const c_void,
+        types: *const i8,
+    ) -> bool;
+    fn sel_registerName(name: *const i8) -> *const c_void;
+    fn objc_getClass(name: *const i8) -> *const c_void;
+}
+
+// =============================================================================
+// State
+// =============================================================================
+
+/// Latest CMSampleBuffer — written by capture delegate (background queue),
+/// read by sample_color (main thread). Uses AtomicPtr for thread safety.
+static LATEST_BUFFER: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
+static FROZEN: AtomicBool = AtomicBool::new(false);
+
+thread_local! {
+    static CAPTURE_SESSION: RefCell<Option<Retained<AnyObject>>> = RefCell::new(None);
+    static PREVIEW_LAYER: RefCell<Option<Retained<AnyObject>>> = RefCell::new(None);
+    static CAMERA_VIEW: RefCell<Option<Retained<UIView>>> = RefCell::new(None);
+    static DELEGATE_INSTANCE: RefCell<Option<Retained<AnyObject>>> = RefCell::new(None);
+    static DELEGATE_REGISTERED: RefCell<bool> = RefCell::new(false);
+    static TAP_CALLBACK: RefCell<Option<f64>> = RefCell::new(None);
+    static TAP_TARGET: RefCell<Option<Retained<AnyObject>>> = RefCell::new(None);
+}
+
+// =============================================================================
+// Camera delegate — receives frames from AVCaptureVideoDataOutput
+// =============================================================================
+
+/// captureOutput:didOutputSampleBuffer:fromConnection:
+unsafe extern "C" fn did_output_sample_buffer(
+    _this: *mut AnyObject,
+    _sel: *const c_void,
+    _output: *mut AnyObject,
+    sample_buffer: *mut c_void,
+    _connection: *mut AnyObject,
+) {
+    if FROZEN.load(Ordering::Relaxed) {
+        return;
+    }
+    if sample_buffer.is_null() {
+        return;
+    }
+    // Retain the new buffer and swap with the old one
+    let new_buf = CFRetain(sample_buffer);
+    let old_buf = LATEST_BUFFER.swap(new_buf, Ordering::Release);
+    if !old_buf.is_null() {
+        CFRelease(old_buf);
+    }
+}
+
+fn register_camera_delegate() {
+    DELEGATE_REGISTERED.with(|reg| {
+        if *reg.borrow() {
+            return;
+        }
+        *reg.borrow_mut() = true;
+
+        unsafe {
+            let superclass = objc_getClass(c"NSObject".as_ptr());
+            let cls = objc_allocateClassPair(superclass, c"PerryCameraDelegate".as_ptr(), 0);
+            if cls.is_null() {
+                return; // Already registered
+            }
+
+            // captureOutput:didOutputSampleBuffer:fromConnection: — type: v@:@@@
+            let sel = sel_registerName(c"captureOutput:didOutputSampleBuffer:fromConnection:".as_ptr());
+            class_addMethod(
+                cls, sel,
+                did_output_sample_buffer as *const c_void,
+                c"v@:@@@".as_ptr(),
+            );
+
+            objc_registerClassPair(cls);
+        }
+    });
+}
+
+// =============================================================================
+// Camera view — UIView subclass with layoutSubviews override
+// =============================================================================
+
+/// Register PerryCameraView class (UIView that resizes its preview sublayer)
+fn camera_view_class() -> *const c_void {
+    use std::sync::Once;
+    static REGISTER: Once = Once::new();
+    static mut CLS: *const c_void = std::ptr::null();
+    REGISTER.call_once(|| {
+        unsafe {
+            let superclass = objc_getClass(c"UIView".as_ptr());
+            let cls = objc_allocateClassPair(superclass, c"PerryCameraView".as_ptr(), 0);
+            assert!(!cls.is_null(), "Failed to allocate PerryCameraView class");
+
+            extern "C" fn layout_subviews(this: *mut AnyObject, _cmd: *const c_void) {
+                unsafe {
+                    // Call [super layoutSubviews]
+                    let sup = AnyClass::get(c"UIView").unwrap();
+                    let _: () = msg_send![super(this, sup), layoutSubviews];
+                    // Resize all sublayers to match layer bounds
+                    let layer: *mut AnyObject = msg_send![this, layer];
+                    if layer.is_null() { return; }
+                    let bounds: CGRect = msg_send![layer, bounds];
+                    let sublayers: *mut AnyObject = msg_send![layer, sublayers];
+                    if !sublayers.is_null() {
+                        let count: usize = msg_send![sublayers, count];
+                        for i in 0..count {
+                            let sub: *mut AnyObject = msg_send![sublayers, objectAtIndex: i];
+                            let _: () = msg_send![sub, setFrame: bounds];
+                        }
+                    }
+                }
+            }
+
+            let sel = sel_registerName(c"layoutSubviews".as_ptr());
+            class_addMethod(cls, sel, layout_subviews as *const c_void, c"v@:".as_ptr());
+
+            objc_registerClassPair(cls);
+            CLS = cls as *const c_void;
+        }
+    });
+    unsafe { CLS }
+}
+
+// =============================================================================
+// Tap handler — reports normalized (x, y) coordinates
+// =============================================================================
+
+fn register_tap_handler_class() -> *const c_void {
+    use std::sync::Once;
+    static REGISTER: Once = Once::new();
+    static mut CLS: *const c_void = std::ptr::null();
+    REGISTER.call_once(|| {
+        unsafe {
+            let superclass = objc_getClass(c"NSObject".as_ptr());
+            let cls = objc_allocateClassPair(superclass, c"PerryCameraTapHandler".as_ptr(), 0);
+            assert!(!cls.is_null());
+
+            extern "C" fn handle_tap(this: *mut AnyObject, _cmd: *const c_void, recognizer: *mut AnyObject) {
+                unsafe {
+                    // Get the view from the gesture recognizer
+                    let view: *mut AnyObject = msg_send![recognizer, view];
+                    if view.is_null() { return; }
+
+                    // Get location in view
+                    #[repr(C)]
+                    #[derive(Copy, Clone)]
+                    struct CGPoint { x: f64, y: f64 }
+                    unsafe impl Encode for CGPoint {
+                        const ENCODING: Encoding = Encoding::Struct("CGPoint", &[Encoding::Double, Encoding::Double]);
+                    }
+                    unsafe impl RefEncode for CGPoint {
+                        const ENCODING_REF: Encoding = Encoding::Pointer(&<Self as Encode>::ENCODING);
+                    }
+
+                    let point: CGPoint = msg_send![recognizer, locationInView: view];
+                    let bounds: CGRect = msg_send![view, bounds];
+
+                    // Normalize to 0-1
+                    let norm_x = if bounds.size.width > 0.0 { point.x / bounds.size.width } else { 0.5 };
+                    let norm_y = if bounds.size.height > 0.0 { point.y / bounds.size.height } else { 0.5 };
+
+                    // Dispatch callback on main queue
+                    TAP_CALLBACK.with(|cb| {
+                        if let Some(closure_f64) = *cb.borrow() {
+                            js_stdlib_process_pending();
+                            js_promise_run_microtasks();
+                            let closure_ptr = js_nanbox_get_pointer(closure_f64);
+                            js_closure_call2(closure_ptr as *const u8, norm_x, norm_y);
+                        }
+                    });
+                }
+            }
+
+            let sel = sel_registerName(c"handleTap:".as_ptr());
+            class_addMethod(cls, sel, handle_tap as *const c_void, c"v@:@".as_ptr());
+
+            objc_registerClassPair(cls);
+            CLS = cls as *const c_void;
+        }
+    });
+    unsafe { CLS }
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/// Create a CameraView widget. Returns widget handle.
+pub fn create() -> i64 {
+    let cls = camera_view_class();
+    unsafe {
+        let view: *mut AnyObject = msg_send![cls as *const AnyObject, new];
+        let _: () = msg_send![view, setTranslatesAutoresizingMaskIntoConstraints: false];
+        let _: () = msg_send![view, setClipsToBounds: true];
+
+        // Set black background
+        let black: Retained<AnyObject> = msg_send![AnyClass::get(c"UIColor").unwrap(), blackColor];
+        let _: () = msg_send![view, setBackgroundColor: &*black];
+
+        let retained: Retained<UIView> = Retained::retain(view as *mut UIView).unwrap();
+
+        // Store for later access
+        CAMERA_VIEW.with(|cv| {
+            *cv.borrow_mut() = Some(retained.clone());
+        });
+
+        widgets::register_widget(retained)
+    }
+}
+
+/// Start the camera capture session. Handles permissions internally.
+pub fn start(_handle: i64) {
+    register_camera_delegate();
+
+    let already_running = CAPTURE_SESSION.with(|s| s.borrow().is_some());
+    if already_running {
+        return;
+    }
+
+    unsafe {
+        // Check camera authorization
+        let device_cls = AnyClass::get(c"AVCaptureDevice")
+            .expect("AVCaptureDevice not found — link AVFoundation.framework");
+
+        // AVMediaTypeVideo
+        let media_type = objc2_foundation::NSString::from_str("vide");
+        let status: i64 = msg_send![device_cls, authorizationStatusForMediaType: &*media_type];
+        // 0 = notDetermined, 1 = restricted, 2 = denied, 3 = authorized
+        if status == 2 || status == 1 {
+            crate::ws_log!("[camera] permission denied/restricted");
+            return;
+        }
+        if status == 0 {
+            // Request permission — user calls start() again after granting
+            let permission_block = block2::RcBlock::new(|_granted: objc2::runtime::Bool| {
+                // Permission result handled on next start() call
+            });
+            let _: () = msg_send![device_cls, requestAccessForMediaType: &*media_type completionHandler: &*permission_block];
+            crate::ws_log!("[camera] requesting camera permission");
+            return;
+        }
+
+        // Create AVCaptureSession
+        let session_cls = AnyClass::get(c"AVCaptureSession").unwrap();
+        let session: Retained<AnyObject> = msg_send![session_cls, new];
+
+        // Set preset
+        let preset = objc2_foundation::NSString::from_str("AVCaptureSessionPresetHigh");
+        let _: () = msg_send![&*session, setSessionPreset: &*preset];
+
+        // Get default video device (back camera)
+        let media_type = objc2_foundation::NSString::from_str("vide");
+        let device: *mut AnyObject = msg_send![device_cls, defaultDeviceWithMediaType: &*media_type];
+        if device.is_null() {
+            crate::ws_log!("[camera] no video device found");
+            return;
+        }
+
+        // Create input
+        let input_cls = AnyClass::get(c"AVCaptureDeviceInput").unwrap();
+        let mut error: *mut AnyObject = std::ptr::null_mut();
+        let input: *mut AnyObject = msg_send![input_cls, deviceInputWithDevice: device error: &mut error];
+        if input.is_null() || !error.is_null() {
+            crate::ws_log!("[camera] failed to create device input");
+            return;
+        }
+
+        let can_add_input: bool = msg_send![&*session, canAddInput: input];
+        if !can_add_input {
+            crate::ws_log!("[camera] cannot add input to session");
+            return;
+        }
+        let _: () = msg_send![&*session, addInput: input];
+
+        // Create video data output
+        let output_cls = AnyClass::get(c"AVCaptureVideoDataOutput").unwrap();
+        let output: Retained<AnyObject> = msg_send![output_cls, new];
+
+        // Set pixel format to BGRA
+        let pixel_format_key = objc2_foundation::NSString::from_str("PixelFormatType");
+        let bgra_format: i64 = 0x42475241; // 'BGRA' = kCVPixelFormatType_32BGRA
+        let format_num: Retained<AnyObject> = msg_send![
+            AnyClass::get(c"NSNumber").unwrap(),
+            numberWithInteger: bgra_format
+        ];
+        let settings_cls = AnyClass::get(c"NSDictionary").unwrap();
+        let video_settings: Retained<AnyObject> = msg_send![
+            settings_cls,
+            dictionaryWithObject: &*format_num,
+            forKey: &*pixel_format_key
+        ];
+        let _: () = msg_send![&*output, setVideoSettings: &*video_settings];
+        let _: () = msg_send![&*output, setAlwaysDiscardsLateVideoFrames: true];
+
+        // Create delegate
+        let del_cls = AnyClass::get(c"PerryCameraDelegate").unwrap();
+        let delegate: Retained<AnyObject> = msg_send![del_cls, new];
+
+        // Create serial dispatch queue for delegate
+        let queue_label = c"com.perry.camera.queue";
+        extern "C" {
+            fn dispatch_queue_create(label: *const i8, attr: *const c_void) -> *mut c_void;
+        }
+        let queue = dispatch_queue_create(queue_label.as_ptr(), std::ptr::null());
+
+        let _: () = msg_send![&*output, setSampleBufferDelegate: &*delegate queue: queue];
+
+        let can_add_output: bool = msg_send![&*session, canAddOutput: &*output];
+        if !can_add_output {
+            crate::ws_log!("[camera] cannot add output to session");
+            return;
+        }
+        let _: () = msg_send![&*session, addOutput: &*output];
+
+        // Create preview layer
+        let preview_cls = AnyClass::get(c"AVCaptureVideoPreviewLayer").unwrap();
+        let preview: Retained<AnyObject> = msg_send![preview_cls, layerWithSession: &*session];
+
+        // Set video gravity to aspect fill
+        let gravity = objc2_foundation::NSString::from_str("AVLayerVideoGravityResizeAspectFill");
+        let _: () = msg_send![&*preview, setVideoGravity: &*gravity];
+
+        // Add preview layer to the camera view
+        CAMERA_VIEW.with(|cv| {
+            if let Some(view) = cv.borrow().as_ref() {
+                let layer: *mut AnyObject = msg_send![&**view, layer];
+                let _: () = msg_send![layer, addSublayer: &*preview];
+            }
+        });
+
+        // Start session on a background thread to avoid blocking UI
+        let session_ptr = Retained::as_ptr(&session) as usize;
+        let start_block = block2::RcBlock::new(move || {
+            let session = session_ptr as *mut AnyObject;
+            let _: () = msg_send![session, startRunning];
+        });
+
+        extern "C" {
+            fn dispatch_async(queue: *mut c_void, block: *const c_void);
+        }
+        extern "C" {
+            fn dispatch_get_global_queue(identifier: i64, flags: u64) -> *mut c_void;
+        }
+        let global_queue = dispatch_get_global_queue(0, 0); // QOS_CLASS_DEFAULT
+        dispatch_async(global_queue, &*start_block as *const _ as *const c_void);
+
+        // Store session, preview layer, and delegate
+        CAPTURE_SESSION.with(|s| { *s.borrow_mut() = Some(session); });
+        PREVIEW_LAYER.with(|p| { *p.borrow_mut() = Some(preview); });
+        DELEGATE_INSTANCE.with(|d| { *d.borrow_mut() = Some(delegate); });
+
+        // Update video orientation to match current device orientation
+        update_video_orientation();
+
+        // Register for orientation change notifications so preview stays correct on iPad rotation
+        let nc: *mut AnyObject = msg_send![AnyClass::get(c"NSNotificationCenter").unwrap(), defaultCenter];
+        let device_cls = AnyClass::get(c"UIDevice").unwrap();
+        let current_device: *mut AnyObject = msg_send![device_cls, currentDevice];
+        let _: () = msg_send![current_device, beginGeneratingDeviceOrientationNotifications];
+
+        // Use a block-based observer for orientation changes
+        let name = objc2_foundation::NSString::from_str("UIDeviceOrientationDidChangeNotification");
+        let observer_block = block2::RcBlock::new(move |_notif: *mut AnyObject| {
+            update_video_orientation();
+        });
+        let _: *mut AnyObject = msg_send![nc,
+            addObserverForName: &*name,
+            object: std::ptr::null::<AnyObject>(),
+            queue: std::ptr::null::<AnyObject>(),  // nil = deliver on posting queue
+            usingBlock: &*observer_block
+        ];
+
+        crate::ws_log!("[camera] session started");
+    }
+}
+
+/// Update the preview layer's connection videoOrientation to match current device orientation.
+fn update_video_orientation() {
+    unsafe {
+        PREVIEW_LAYER.with(|p| {
+            if let Some(preview) = p.borrow().as_ref() {
+                let connection: *mut AnyObject = msg_send![&**preview, connection];
+                if connection.is_null() { return; }
+
+                let device_cls = AnyClass::get(c"UIDevice").unwrap();
+                let current_device: *mut AnyObject = msg_send![device_cls, currentDevice];
+                let device_orientation: i64 = msg_send![current_device, orientation];
+
+                // Map UIDeviceOrientation to AVCaptureVideoOrientation
+                // UIDeviceOrientation: 1=portrait, 2=portraitUpsideDown, 3=landscapeLeft, 4=landscapeRight
+                // AVCaptureVideoOrientation: 1=portrait, 2=portraitUpsideDown, 3=landscapeRight, 4=landscapeLeft
+                let video_orientation: i64 = match device_orientation {
+                    1 => 1, // Portrait
+                    2 => 2, // PortraitUpsideDown
+                    3 => 4, // LandscapeLeft device → LandscapeLeft video (AVCapture swaps L/R)
+                    4 => 3, // LandscapeRight device → LandscapeRight video
+                    _ => return, // Unknown/faceUp/faceDown — keep current
+                };
+
+                let _: () = msg_send![connection, setVideoOrientation: video_orientation];
+            }
+        });
+    }
+}
+
+/// Stop the camera capture session.
+pub fn stop(_handle: i64) {
+    CAPTURE_SESSION.with(|s| {
+        if let Some(session) = s.borrow_mut().take() {
+            unsafe {
+                let _: () = msg_send![&*session, stopRunning];
+            }
+            crate::ws_log!("[camera] session stopped");
+        }
+    });
+    // Release the latest buffer
+    let old = LATEST_BUFFER.swap(std::ptr::null_mut(), Ordering::Release);
+    if !old.is_null() {
+        unsafe { CFRelease(old); }
+    }
+    FROZEN.store(false, Ordering::Relaxed);
+}
+
+/// Freeze the camera (stop updating the buffer, pause preview).
+pub fn freeze(_handle: i64) {
+    FROZEN.store(true, Ordering::Relaxed);
+    // Pause the preview layer connection
+    PREVIEW_LAYER.with(|p| {
+        if let Some(preview) = p.borrow().as_ref() {
+            unsafe {
+                let connection: *mut AnyObject = msg_send![&**preview, connection];
+                if !connection.is_null() {
+                    let _: () = msg_send![connection, setEnabled: false];
+                }
+            }
+        }
+    });
+    crate::ws_log!("[camera] frozen");
+}
+
+/// Unfreeze the camera (resume live capture).
+pub fn unfreeze(_handle: i64) {
+    FROZEN.store(false, Ordering::Relaxed);
+    // Resume the preview layer connection
+    PREVIEW_LAYER.with(|p| {
+        if let Some(preview) = p.borrow().as_ref() {
+            unsafe {
+                let connection: *mut AnyObject = msg_send![&**preview, connection];
+                if !connection.is_null() {
+                    let _: () = msg_send![connection, setEnabled: true];
+                }
+            }
+        }
+    });
+    crate::ws_log!("[camera] unfrozen");
+}
+
+/// Sample the color at normalized coordinates (0.0-1.0) from the latest frame.
+/// Returns packed RGB as f64: r * 65536 + g * 256 + b.
+/// Returns -1.0 if no frame is available.
+pub fn sample_color(x: f64, y: f64) -> f64 {
+    let buffer = LATEST_BUFFER.load(Ordering::Acquire);
+    if buffer.is_null() {
+        return -1.0;
+    }
+
+    unsafe {
+        let pixel_buffer = CMSampleBufferGetImageBuffer(buffer);
+        if pixel_buffer.is_null() {
+            return -1.0;
+        }
+
+        // Lock the pixel buffer for read-only access
+        let lock_result = CVPixelBufferLockBaseAddress(pixel_buffer, 1); // kCVPixelBufferLock_ReadOnly = 1
+        if lock_result != 0 {
+            return -1.0;
+        }
+
+        let base_address = CVPixelBufferGetBaseAddress(pixel_buffer);
+        let width = CVPixelBufferGetWidth(pixel_buffer);
+        let height = CVPixelBufferGetHeight(pixel_buffer);
+        let bytes_per_row = CVPixelBufferGetBytesPerRow(pixel_buffer);
+
+        if base_address.is_null() || width == 0 || height == 0 {
+            CVPixelBufferUnlockBaseAddress(pixel_buffer, 1);
+            return -1.0;
+        }
+
+        // Clamp coordinates
+        let px = ((x.clamp(0.0, 1.0) * (width as f64 - 1.0)) as usize).min(width - 1);
+        let py = ((y.clamp(0.0, 1.0) * (height as f64 - 1.0)) as usize).min(height - 1);
+
+        // Average a 5x5 region around the sample point for noise reduction
+        let half = 2usize;
+        let mut r_sum: u64 = 0;
+        let mut g_sum: u64 = 0;
+        let mut b_sum: u64 = 0;
+        let mut count: u64 = 0;
+
+        let y_start = py.saturating_sub(half);
+        let y_end = (py + half + 1).min(height);
+        let x_start = px.saturating_sub(half);
+        let x_end = (px + half + 1).min(width);
+
+        for sy in y_start..y_end {
+            for sx in x_start..x_end {
+                let offset = sy * bytes_per_row + sx * 4;
+                let ptr = base_address.add(offset);
+                // BGRA format
+                b_sum += *ptr as u64;
+                g_sum += *ptr.add(1) as u64;
+                r_sum += *ptr.add(2) as u64;
+                count += 1;
+            }
+        }
+
+        CVPixelBufferUnlockBaseAddress(pixel_buffer, 1);
+
+        if count == 0 {
+            return -1.0;
+        }
+
+        let r = (r_sum / count) as f64;
+        let g = (g_sum / count) as f64;
+        let b = (b_sum / count) as f64;
+
+        r * 65536.0 + g * 256.0 + b
+    }
+}
+
+/// Set a tap handler that receives normalized (x, y) coordinates.
+pub fn set_on_tap(handle: i64, callback: f64) {
+    TAP_CALLBACK.with(|cb| {
+        *cb.borrow_mut() = Some(callback);
+    });
+
+    if let Some(view) = widgets::get_widget(handle) {
+        unsafe {
+            let tap_cls = register_tap_handler_class();
+            let target: Retained<AnyObject> = msg_send![tap_cls as *const AnyObject, new];
+
+            let sel = sel_registerName(c"handleTap:".as_ptr());
+            let gr_cls = AnyClass::get(c"UITapGestureRecognizer").unwrap();
+            let recognizer: *mut AnyObject = msg_send![gr_cls, alloc];
+            let recognizer: *mut AnyObject = msg_send![
+                recognizer, initWithTarget: &*target, action: sel as *const c_void as *const AnyObject
+            ];
+            let _: () = msg_send![recognizer, setNumberOfTapsRequired: 1i64];
+            let _: () = msg_send![&*view, setUserInteractionEnabled: true];
+            let _: () = msg_send![&*view, addGestureRecognizer: recognizer];
+
+            // Keep target alive
+            TAP_TARGET.with(|t| {
+                *t.borrow_mut() = Some(target);
+            });
+        }
+    }
+}

--- a/crates/perry-ui-visionos/src/clipboard.rs
+++ b/crates/perry-ui-visionos/src/clipboard.rs
@@ -1,0 +1,54 @@
+use objc2::msg_send;
+use objc2::rc::Retained;
+use objc2_foundation::NSString;
+
+extern "C" {
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_nanbox_string(ptr: i64) -> f64;
+}
+
+/// Read the current text from the system clipboard (UIPasteboard).
+/// Returns a NaN-boxed string (f64) or TAG_UNDEFINED if empty.
+pub fn read() -> f64 {
+    unsafe {
+        let pasteboard: *const objc2::runtime::AnyObject = msg_send![
+            objc2::runtime::AnyClass::get(c"UIPasteboard").unwrap(),
+            generalPasteboard
+        ];
+        let text: *const NSString = msg_send![pasteboard, string];
+        if !text.is_null() {
+            let rust_str = (*text).to_string();
+            let bytes = rust_str.as_bytes();
+            let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+            js_nanbox_string(str_ptr as i64)
+        } else {
+            // Return TAG_UNDEFINED
+            f64::from_bits(0x7FFC_0000_0000_0001)
+        }
+    }
+}
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// Write text to the system clipboard (UIPasteboard).
+pub fn write(text_ptr: *const u8) {
+    let text = str_from_header(text_ptr);
+    unsafe {
+        let pasteboard: *const objc2::runtime::AnyObject = msg_send![
+            objc2::runtime::AnyClass::get(c"UIPasteboard").unwrap(),
+            generalPasteboard
+        ];
+        let ns_string = NSString::from_str(text);
+        let _: () = msg_send![pasteboard, setString: &*ns_string];
+    }
+}

--- a/crates/perry-ui-visionos/src/crash_log.rs
+++ b/crates/perry-ui-visionos/src/crash_log.rs
@@ -1,0 +1,115 @@
+//! Crash log persistence — writes panic/signal info to ~/.hone/crash.log
+//! so the TypeScript telemetry layer can report it via Chirp on next launch.
+//!
+//! iOS variant: $HOME points to the app sandbox container, so
+//! ~/.hone/crash.log lands inside the sandbox (no permissions issues).
+
+use std::io::Write;
+
+/// Pre-computed crash log path as a null-terminated C string for signal-handler safety.
+static mut CRASH_LOG_PATH_BUF: [u8; 512] = [0u8; 512];
+static mut CRASH_LOG_PATH_LEN: usize = 0;
+
+/// Get the crash log path (~/.hone/crash.log), ensuring the directory exists.
+fn crash_log_path() -> Option<String> {
+    if let Ok(home) = std::env::var("HOME") {
+        let dir = format!("{}/.hone", home);
+        let _ = std::fs::create_dir_all(&dir);
+        Some(format!("{}/crash.log", dir))
+    } else {
+        None
+    }
+}
+
+/// Write a crash entry to the crash log file (overwrites any previous entry).
+pub fn write_crash(crash_type: &str, message: &str) {
+    if let Some(path) = crash_log_path() {
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)
+        {
+            let _ = writeln!(f, "{}:{}", crash_type, message);
+        }
+    }
+}
+
+/// Clear the crash log (called after a panic is caught non-fatally).
+pub fn clear_crash_log() {
+    if let Some(path) = crash_log_path() {
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+/// Install global panic hook and signal handlers.
+pub fn install_crash_hooks() {
+    // Pre-compute the path as a C string for signal handler use
+    if let Some(path) = crash_log_path() {
+        let bytes = path.as_bytes();
+        let len = bytes.len().min(511);
+        unsafe {
+            CRASH_LOG_PATH_BUF[..len].copy_from_slice(&bytes[..len]);
+            CRASH_LOG_PATH_BUF[len] = 0;
+            CRASH_LOG_PATH_LEN = len;
+        }
+    }
+
+    std::panic::set_hook(Box::new(|info| {
+        let msg = if let Some(s) = info.payload().downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = info.payload().downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "unknown".to_string()
+        };
+
+        let location = if let Some(loc) = info.location() {
+            format!(" at {}:{}", loc.file(), loc.line())
+        } else {
+            String::new()
+        };
+
+        write_crash("panic", &format!("{}{}", msg, location));
+        // Also log to file since iOS eprintln is invisible
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open("/tmp/hone-crash.log")
+        {
+            let _ = writeln!(f, "[hone] FATAL: {}{}", msg, location);
+        }
+    }));
+
+    unsafe {
+        libc::signal(libc::SIGSEGV, signal_handler as libc::sighandler_t);
+        libc::signal(libc::SIGBUS, signal_handler as libc::sighandler_t);
+        libc::signal(libc::SIGABRT, signal_handler as libc::sighandler_t);
+    }
+}
+
+extern "C" fn signal_handler(sig: libc::c_int) {
+    let msg: &[u8] = match sig {
+        libc::SIGSEGV => b"signal:SIGSEGV\n",
+        libc::SIGBUS  => b"signal:SIGBUS\n",
+        libc::SIGABRT => b"signal:SIGABRT\n",
+        _             => b"signal:unknown\n",
+    };
+
+    unsafe {
+        if CRASH_LOG_PATH_LEN > 0 {
+            let fd = libc::open(
+                CRASH_LOG_PATH_BUF.as_ptr() as *const libc::c_char,
+                libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC,
+                0o644,
+            );
+            if fd >= 0 {
+                libc::write(fd, msg.as_ptr() as *const libc::c_void, msg.len());
+                libc::close(fd);
+            }
+        }
+
+        libc::signal(sig, libc::SIG_DFL);
+        libc::raise(sig);
+    }
+}

--- a/crates/perry-ui-visionos/src/file_dialog.rs
+++ b/crates/perry-ui-visionos/src/file_dialog.rs
@@ -1,0 +1,14 @@
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+}
+
+/// Open a file dialog (stub — UIDocumentPickerVC not yet implemented).
+/// Calls callback with TAG_UNDEFINED immediately.
+pub fn open_dialog(callback: f64) {
+    unsafe {
+        let closure_ptr = js_nanbox_get_pointer(callback) as *const u8;
+        // Call callback with TAG_UNDEFINED (user "cancelled")
+        js_closure_call1(closure_ptr, f64::from_bits(0x7FFC_0000_0000_0001));
+    }
+}

--- a/crates/perry-ui-visionos/src/lib.rs
+++ b/crates/perry-ui-visionos/src/lib.rs
@@ -1,0 +1,1762 @@
+pub mod app;
+pub mod audio;
+pub mod camera;
+pub mod clipboard;
+pub mod crash_log;
+pub mod file_dialog;
+pub mod location;
+pub mod menu;
+pub mod screenshot;
+pub mod state;
+pub mod websocket;
+pub mod widgets;
+
+/// Debug logging macro that writes to a file (NSLog/eprintln don't work reliably on iOS)
+#[macro_export]
+macro_rules! ws_log {
+    ($($arg:tt)*) => {{
+        use std::io::Write;
+        let msg = format!($($arg)*);
+        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open("/tmp/hone-ws-ios.log") {
+            let _ = writeln!(f, "{}", msg);
+        }
+    }};
+}
+
+/// Run a closure, catching any Rust panics so they don't abort across the FFI boundary.
+/// Clears the crash log since the panic was caught (non-fatal).
+pub fn catch_callback_panic<F: FnOnce() + std::panic::UnwindSafe>(label: &str, f: F) {
+    if let Err(e) = std::panic::catch_unwind(f) {
+        crash_log::clear_crash_log();
+
+        let msg = if let Some(s) = e.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = e.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            format!("{:?}", e)
+        };
+        // Log to file since iOS eprintln is invisible
+        ws_log!("[perry] panic in {} (caught): {}", label, msg);
+    }
+}
+
+// =============================================================================
+// FFI exports — identical signatures to perry-ui-macos
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_create(title_ptr: i64, width: f64, height: f64) -> i64 {
+    app::app_create(title_ptr as *const u8, width, height)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_set_body(app_handle: i64, root_handle: i64) {
+    app::app_set_body(app_handle, root_handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_run(app_handle: i64) {
+    app::app_run(app_handle);
+}
+
+/// Register an external UIView (from a native library) as a Perry widget.
+/// Alias of perry_ui_embed_nsview so cross-platform Perry code works unchanged on iOS.
+#[no_mangle]
+pub extern "C" fn perry_ui_embed_nsview(uiview_ptr: i64) -> i64 {
+    use objc2::rc::Retained;
+    use objc2_ui_kit::UIView;
+    if uiview_ptr == 0 {
+        return 0;
+    }
+    match unsafe { Retained::retain(uiview_ptr as *mut UIView) } {
+        Some(view) => {
+            // Disable autoresizing mask → Auto Layout constraint translation.
+            // Without this, the embedded view's autoresizing mask conflicts with
+            // UIStackView layout constraints, causing black screen in HStack.
+            let _: () = unsafe { objc2::msg_send![&*view, setTranslatesAutoresizingMaskIntoConstraints: false] };
+            widgets::register_widget(view)
+        },
+        None => 0,
+    }
+}
+
+/// Create a split view container (plain UIView with Auto Layout, not UIStackView).
+/// Left panel gets fixed width; right panel fills remaining space.
+#[no_mangle]
+pub extern "C" fn perry_ui_splitview_create(left_width: f64) -> i64 {
+    widgets::splitview::create(left_width)
+}
+
+/// Add a child to a split view. First call adds left panel, second adds right panel.
+#[no_mangle]
+pub extern "C" fn perry_ui_splitview_add_child(parent_handle: i64, child_handle: i64, child_index: f64) {
+    if let (Some(parent), Some(child)) = (widgets::get_widget(parent_handle), widgets::get_widget(child_handle)) {
+        widgets::splitview::add_child(&parent, &child, child_index as usize);
+    }
+}
+
+/// Create a vertical layout container (plain UIView, not UIStackView).
+#[no_mangle]
+pub extern "C" fn perry_ui_vbox_create() -> i64 {
+    widgets::splitview::create_vbox()
+}
+
+/// Add a child to a vbox at a slot: 0=top, 1=middle(fills), 2=bottom.
+#[no_mangle]
+pub extern "C" fn perry_ui_vbox_add_child(parent_handle: i64, child_handle: i64, slot: f64) {
+    if let (Some(parent), Some(child)) = (widgets::get_widget(parent_handle), widgets::get_widget(child_handle)) {
+        widgets::splitview::vbox_add_child(&parent, &child, slot as usize);
+    }
+}
+
+/// Finalize vbox layout by connecting middle.bottom to bottom.top.
+#[no_mangle]
+pub extern "C" fn perry_ui_vbox_finalize(parent_handle: i64) {
+    if let Some(parent) = widgets::get_widget(parent_handle) {
+        widgets::splitview::vbox_finalize(&parent);
+    }
+}
+
+/// Create a frame-based horizontal split container.
+/// Uses layoutSubviews for child positioning (no Auto Layout on children).
+/// This avoids constraint conflicts with embedded UIViews.
+#[no_mangle]
+pub extern "C" fn perry_ui_frame_split_create(left_width: f64) -> i64 {
+    widgets::splitview::create_frame_split(left_width)
+}
+
+/// Add a child to a frame-based split container.
+/// Children use frame-based layout (translatesAutoresizingMaskIntoConstraints = true).
+#[no_mangle]
+pub extern "C" fn perry_ui_frame_split_add_child(parent_handle: i64, child_handle: i64) {
+    if let (Some(parent), Some(child)) = (widgets::get_widget(parent_handle), widgets::get_widget(child_handle)) {
+        widgets::splitview::frame_split_add_child(&parent, &child);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_text_create(text_ptr: i64) -> i64 {
+    widgets::text::create(text_ptr as *const u8)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_button_create(label_ptr: i64, on_press: f64) -> i64 {
+    widgets::button::create(label_ptr as *const u8, on_press)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_vstack_create(spacing: f64) -> i64 {
+    widgets::vstack::create(spacing)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_hstack_create(spacing: f64) -> i64 {
+    widgets::hstack::create(spacing)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_add_child(parent_handle: i64, child_handle: i64) {
+    widgets::add_child(parent_handle, child_handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_state_create(initial: f64) -> i64 {
+    state::state_create(initial)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_state_get(state_handle: i64) -> f64 {
+    state::state_get(state_handle)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_state_set(state_handle: i64, value: f64) {
+    state::state_set(state_handle, value);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_state_bind_text_numeric(state_handle: i64, text_handle: i64, prefix_ptr: i64, suffix_ptr: i64) {
+    state::bind_text_numeric(state_handle, text_handle, prefix_ptr as *const u8, suffix_ptr as *const u8);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_spacer_create() -> i64 {
+    widgets::spacer::create()
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_divider_create() -> i64 {
+    widgets::divider::create()
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textfield_create(placeholder_ptr: i64, on_change: f64) -> i64 {
+    widgets::textfield::create(placeholder_ptr as *const u8, on_change)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textarea_create(placeholder_ptr: i64, on_change: f64) -> i64 {
+    widgets::textarea::create(placeholder_ptr as *const u8, on_change)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textarea_set_string(handle: i64, text_ptr: i64) {
+    widgets::textarea::set_string(handle, text_ptr as *const u8);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textarea_get_string(handle: i64) -> i64 {
+    widgets::textarea::get_string(handle) as i64
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_toggle_create(label_ptr: i64, on_change: f64) -> i64 {
+    match std::panic::catch_unwind(|| widgets::toggle::create(label_ptr as *const u8, on_change)) {
+        Ok(handle) => handle,
+        Err(e) => {
+            crash_log::clear_crash_log();
+            let msg = if let Some(s) = e.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = e.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                format!("{:?}", e)
+            };
+            ws_log!("[perry] panic in perry_ui_toggle_create (caught): {}", msg);
+            0
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_slider_create(min: f64, max: f64, initial: f64, on_change: f64) -> i64 {
+    widgets::slider::create(min, max, initial, on_change)
+}
+
+// =============================================================================
+// Phase 4: Advanced Reactive UI
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_state_bind_slider(state_handle: i64, slider_handle: i64) {
+    state::bind_slider(state_handle, slider_handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_state_bind_toggle(state_handle: i64, toggle_handle: i64) {
+    state::bind_toggle(state_handle, toggle_handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_state_bind_text_template(
+    text_handle: i64,
+    num_parts: i32,
+    types_ptr: i64,
+    values_ptr: i64,
+) {
+    state::bind_text_template(text_handle, num_parts, types_ptr as *const i32, values_ptr as *const i64);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_state_bind_visibility(state_handle: i64, show_handle: i64, hide_handle: i64) {
+    state::bind_visibility(state_handle, show_handle, hide_handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_set_widget_hidden(handle: i64, hidden: i64) {
+    widgets::set_hidden(handle, hidden != 0);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_for_each_init(container_handle: i64, state_handle: i64, render_closure: f64) {
+    state::for_each_init(container_handle, state_handle, render_closure);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_clear_children(handle: i64) {
+    widgets::clear_children(handle);
+}
+
+// =============================================================================
+// Phase A.1: Text Mutation & Layout Control
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_string(handle: i64, text_ptr: i64) {
+    widgets::text::set_string(handle, text_ptr as *const u8);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_vstack_create_with_insets(spacing: f64, top: f64, left: f64, bottom: f64, right: f64) -> i64 {
+    widgets::vstack::create_with_insets(spacing, top, left, bottom, right)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_hstack_create_with_insets(spacing: f64, top: f64, left: f64, bottom: f64, right: f64) -> i64 {
+    widgets::hstack::create_with_insets(spacing, top, left, bottom, right)
+}
+
+// =============================================================================
+// Phase A.2: ScrollView, Clipboard & Keyboard Shortcuts
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_scrollview_create() -> i64 {
+    widgets::scrollview::create()
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_scrollview_set_child(scroll_handle: i64, child_handle: i64) {
+    widgets::scrollview::set_child(scroll_handle, child_handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_clipboard_read() -> f64 {
+    clipboard::read()
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_clipboard_write(text_ptr: i64) {
+    clipboard::write(text_ptr as *const u8);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_add_keyboard_shortcut(key_ptr: i64, modifiers: f64, callback: f64) {
+    app::add_keyboard_shortcut(key_ptr as *const u8, modifiers, callback);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_register_global_hotkey(_key: i64, _mods: f64, _cb: f64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_system_get_app_icon(_path: i64) -> i64 { 0 }
+
+// =============================================================================
+// Phase A.3: Text Styling & Button Styling
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    widgets::text::set_color(handle, r, g, b, a);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_font_size(handle: i64, size: f64) {
+    widgets::text::set_font_size(handle, size);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_font_weight(handle: i64, size: f64, weight: f64) {
+    widgets::text::set_font_weight(handle, size, weight);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_wraps(handle: i64, max_width: f64) {
+    widgets::text::set_wraps(handle, max_width);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_selectable(handle: i64, selectable: f64) {
+    widgets::text::set_selectable(handle, selectable != 0.0);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_button_set_bordered(handle: i64, bordered: f64) {
+    widgets::button::set_bordered(handle, bordered != 0.0);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_button_set_title(handle: i64, title_ptr: i64) {
+    widgets::button::set_title(handle, title_ptr as *const u8);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_button_set_text_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    widgets::button::set_text_color(handle, r, g, b, a);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_button_set_image(handle: i64, name_ptr: i64) {
+    widgets::button::set_image(handle, name_ptr as *const u8);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_button_set_image_position(handle: i64, position: i64) {
+    widgets::button::set_image_position(handle, position);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_button_set_content_tint_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    widgets::button::set_content_tint_color(handle, r, g, b, a);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_width(handle: i64, width: f64) {
+    widgets::set_width(handle, width);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_height(handle: i64, height: f64) {
+    widgets::set_height(handle, height);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_hugging(handle: i64, priority: f64) {
+    widgets::set_hugging_priority(handle, priority);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_remove_child(parent_handle: i64, child_handle: i64) {
+    widgets::remove_child(parent_handle, child_handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_reorder_child(parent_handle: i64, from_index: f64, to_index: f64) {
+    widgets::reorder_child(parent_handle, from_index as i64, to_index as i64);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_match_parent_width(handle: i64) {
+    widgets::match_parent_width(handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_match_parent_height(handle: i64) {
+    widgets::match_parent_height(handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_stack_set_detaches_hidden(handle: i64, flag: i64) {
+    widgets::set_detaches_hidden_views(handle, flag != 0);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_stack_set_distribution(handle: i64, distribution: f64) {
+    // UIStackView distribution: 0=Fill, 1=FillEqually, 2=FillProportionally, 3=EqualSpacing, 4=EqualCentering
+    if let Some(view) = widgets::get_widget(handle) {
+        let is_stack = if let Some(cls) = objc2::runtime::AnyClass::get(c"UIStackView") {
+            use objc2_foundation::NSObjectProtocol;
+            view.isKindOfClass(cls)
+        } else {
+            false
+        };
+        if is_stack {
+            let dist = if distribution < 0.0 { 0_i64 } else { distribution as i64 };
+            unsafe {
+                let _: () = objc2::msg_send![&*view, setDistribution: dist];
+            }
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_stack_set_alignment(handle: i64, alignment: f64) {
+    // UIStackView alignment: 0=Fill, 1=Leading, 2=FirstBaseline, 3=Center, 4=Trailing, 5=LastBaseline
+    if let Some(view) = widgets::get_widget(handle) {
+        let is_stack = if let Some(cls) = objc2::runtime::AnyClass::get(c"UIStackView") {
+            use objc2_foundation::NSObjectProtocol;
+            view.isKindOfClass(cls)
+        } else {
+            false
+        };
+        if is_stack {
+            let align = alignment as i64;
+            unsafe {
+                let _: () = objc2::msg_send![&*view, setAlignment: align];
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Phase A.4: Focus & Scroll-To
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textfield_focus(handle: i64) {
+    widgets::textfield::focus(handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_scrollview_scroll_to(scroll_handle: i64, child_handle: i64) {
+    widgets::scrollview::scroll_to(scroll_handle, child_handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_scrollview_get_offset(scroll_handle: i64) -> f64 {
+    widgets::scrollview::get_offset(scroll_handle)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_scrollview_set_offset(scroll_handle: i64, offset: f64) {
+    widgets::scrollview::set_offset(scroll_handle, offset);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_scrollview_set_refresh_control(scroll_handle: i64, callback: f64) {
+    widgets::scrollview::set_refresh_control(scroll_handle, callback);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_scrollview_end_refreshing(scroll_handle: i64) {
+    widgets::scrollview::end_refreshing(scroll_handle);
+}
+
+// =============================================================================
+// Phase A.5: Context Menus, File Dialog & Window Sizing
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_menu_create() -> i64 {
+    menu::create()
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_menu_add_item(menu_handle: i64, title_ptr: i64, callback: f64) {
+    menu::add_item(menu_handle, title_ptr as *const u8, callback);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_context_menu(widget_handle: i64, menu_handle: i64) {
+    menu::set_context_menu(widget_handle, menu_handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_menu_add_item_with_shortcut(menu_handle: i64, title_ptr: i64, callback: f64, shortcut_ptr: i64) {
+    menu::add_item_with_shortcut(menu_handle, title_ptr as *const u8, callback, shortcut_ptr as *const u8);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_menu_add_separator(menu_handle: i64) {
+    menu::add_separator(menu_handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_menu_add_submenu(menu_handle: i64, title_ptr: i64, submenu_handle: i64) {
+    menu::add_submenu(menu_handle, title_ptr as *const u8, submenu_handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_menubar_create() -> i64 {
+    menu::menubar_create()
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_menubar_add_menu(bar_handle: i64, title_ptr: i64, menu_handle: i64) {
+    menu::menubar_add_menu(bar_handle, title_ptr as *const u8, menu_handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_menubar_attach(bar_handle: i64) {
+    menu::menubar_attach(bar_handle);
+}
+
+/// Remove all items from a menu.
+#[no_mangle]
+pub extern "C" fn perry_ui_menu_clear(menu_handle: i64) {
+    menu::clear(menu_handle);
+}
+
+/// Add a menu item with a standard action (no-op on iOS — macOS responder chain concept).
+#[no_mangle]
+pub extern "C" fn perry_ui_menu_add_standard_action(_menu_handle: i64, _title_ptr: i64, _selector_ptr: i64, _shortcut_ptr: i64) {
+    // No-op on iOS — standard Edit menu actions are handled by UIResponder chain natively
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_open_file_dialog(callback: f64) {
+    file_dialog::open_dialog(callback);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_set_min_size(app_handle: i64, w: f64, h: f64) {
+    app::set_min_size(app_handle, w, h);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_set_max_size(app_handle: i64, w: f64, h: f64) {
+    app::set_max_size(app_handle, w, h);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textfield_set_string(handle: i64, text_ptr: i64) {
+    widgets::textfield::set_string_value(handle, text_ptr as *const u8);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textfield_get_string(handle: i64) -> i64 {
+    widgets::textfield::get_string_value(handle) as i64
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textfield_set_on_submit(handle: i64, on_submit: f64) {
+    widgets::textfield::set_on_submit(handle, on_submit);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textfield_set_on_focus(handle: i64, on_focus: f64) {
+    // TODO: implement iOS textfield focus observer
+    let _ = (handle, on_focus);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textfield_blur_all() {
+    // TODO: implement iOS blur
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textfield_set_next_key_view(_handle: i64, _next_handle: i64) {
+    // iOS handles tab navigation automatically
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textfield_set_borderless(handle: i64, borderless: f64) {
+    widgets::textfield::set_borderless(handle, borderless);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textfield_set_background_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    widgets::textfield::set_background_color(handle, r, g, b, a);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textfield_set_font_size(handle: i64, size: f64) {
+    widgets::textfield::set_font_size(handle, size);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_textfield_set_text_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    widgets::textfield::set_text_color(handle, r, g, b, a);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_add_child_at(parent_handle: i64, child_handle: i64, index: f64) {
+    widgets::add_child_at(parent_handle, child_handle, index as i64);
+}
+
+// =============================================================================
+// Timer, Background Styling & Canvas
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_set_timer(interval_ms: f64, callback: f64) {
+    app::set_timer(interval_ms, callback);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_background_color(
+    handle: i64, r: f64, g: f64, b: f64, a: f64,
+) {
+    widgets::set_background_color(handle, r, g, b, a);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_background_gradient(
+    handle: i64, r1: f64, g1: f64, b1: f64, a1: f64,
+    r2: f64, g2: f64, b2: f64, a2: f64, direction: f64,
+) {
+    widgets::set_background_gradient(handle, r1, g1, b1, a1, r2, g2, b2, a2, direction);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_corner_radius(handle: i64, radius: f64) {
+    widgets::set_corner_radius(handle, radius);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_canvas_create(width: f64, height: f64) -> i64 {
+    widgets::canvas::create(width, height)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_canvas_clear(handle: i64) {
+    widgets::canvas::clear(handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_canvas_begin_path(handle: i64) {
+    widgets::canvas::begin_path(handle);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_canvas_move_to(handle: i64, x: f64, y: f64) {
+    widgets::canvas::move_to(handle, x, y);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_canvas_line_to(handle: i64, x: f64, y: f64) {
+    widgets::canvas::line_to(handle, x, y);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_canvas_stroke(
+    handle: i64, r: f64, g: f64, b: f64, a: f64, line_width: f64,
+) {
+    widgets::canvas::stroke(handle, r, g, b, a, line_width);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_canvas_fill_gradient(
+    handle: i64, r1: f64, g1: f64, b1: f64, a1: f64,
+    r2: f64, g2: f64, b2: f64, a2: f64, direction: f64,
+) {
+    widgets::canvas::fill_gradient(handle, r1, g1, b1, a1, r2, g2, b2, a2, direction);
+}
+
+// =============================================================================
+// New Widgets: SecureField, ProgressView, Image, Picker, Form, NavStack, ZStack
+// =============================================================================
+
+/// Create a SecureField (password input). Returns widget handle.
+#[no_mangle]
+pub extern "C" fn perry_ui_securefield_create(placeholder_ptr: i64, on_change: f64) -> i64 {
+    widgets::securefield::create(placeholder_ptr as *const u8, on_change)
+}
+
+/// Create an indeterminate ProgressView (spinner). Returns widget handle.
+#[no_mangle]
+pub extern "C" fn perry_ui_progressview_create() -> i64 {
+    widgets::progressview::create()
+}
+
+/// Set determinate progress value (0.0-1.0).
+#[no_mangle]
+pub extern "C" fn perry_ui_progressview_set_value(handle: i64, value: f64) {
+    widgets::progressview::set_value(handle, value);
+}
+
+/// Create an Image from an SF Symbol name. Returns widget handle.
+#[no_mangle]
+pub extern "C" fn perry_ui_image_create_symbol(name_ptr: i64) -> i64 {
+    widgets::image::create_symbol(name_ptr as *const u8)
+}
+
+/// Create an Image from a file path. Returns widget handle.
+#[no_mangle]
+pub extern "C" fn perry_ui_image_create_file(path_ptr: i64) -> i64 {
+    widgets::image::create_file(path_ptr as *const u8)
+}
+
+/// Set the size of an Image widget.
+#[no_mangle]
+pub extern "C" fn perry_ui_image_set_size(handle: i64, width: f64, height: f64) {
+    widgets::image::set_size(handle, width, height);
+}
+
+/// Set the tint color of an Image widget.
+#[no_mangle]
+pub extern "C" fn perry_ui_image_set_tint(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    widgets::image::set_tint(handle, r, g, b, a);
+}
+
+/// Create a Picker (dropdown). style: 0=dropdown, 1=segmented. Returns widget handle.
+#[no_mangle]
+pub extern "C" fn perry_ui_picker_create(label_ptr: i64, on_change: f64, style: i64) -> i64 {
+    widgets::picker::create(label_ptr as *const u8, on_change, style)
+}
+
+/// Add an item to a Picker.
+#[no_mangle]
+pub extern "C" fn perry_ui_picker_add_item(handle: i64, title_ptr: i64) {
+    widgets::picker::add_item(handle, title_ptr as *const u8);
+}
+
+/// Set the selected index of a Picker.
+#[no_mangle]
+pub extern "C" fn perry_ui_picker_set_selected(handle: i64, index: i64) {
+    widgets::picker::set_selected(handle, index);
+}
+
+/// Get the selected index of a Picker.
+#[no_mangle]
+pub extern "C" fn perry_ui_picker_get_selected(handle: i64) -> i64 {
+    widgets::picker::get_selected(handle)
+}
+
+/// Create a TabBar. Returns widget handle.
+#[no_mangle]
+pub extern "C" fn perry_ui_tabbar_create(on_change: f64) -> i64 {
+    widgets::tabbar::create(on_change)
+}
+
+/// Add a tab to a TabBar.
+#[no_mangle]
+pub extern "C" fn perry_ui_tabbar_add_tab(handle: i64, label_ptr: i64) {
+    widgets::tabbar::add_tab(handle, label_ptr as *const u8);
+}
+
+/// Set the selected tab index.
+#[no_mangle]
+pub extern "C" fn perry_ui_tabbar_set_selected(handle: i64, index: i64) {
+    widgets::tabbar::set_selected(handle, index);
+}
+
+/// Create a Form container. Returns widget handle.
+#[no_mangle]
+pub extern "C" fn perry_ui_form_create() -> i64 {
+    widgets::form::form_create()
+}
+
+/// Create a Section with title. Returns widget handle.
+#[no_mangle]
+pub extern "C" fn perry_ui_section_create(title_ptr: i64) -> i64 {
+    widgets::form::section_create(title_ptr as *const u8)
+}
+
+/// Create a NavigationStack. Returns widget handle.
+#[no_mangle]
+pub extern "C" fn perry_ui_navstack_create(title_ptr: i64, body_handle: i64) -> i64 {
+    widgets::navstack::create(title_ptr as *const u8, body_handle)
+}
+
+/// Push a view onto the NavigationStack.
+#[no_mangle]
+pub extern "C" fn perry_ui_navstack_push(handle: i64, title_ptr: i64, body_handle: i64) {
+    widgets::navstack::push(handle, title_ptr as *const u8, body_handle);
+}
+
+/// Pop the top view from the NavigationStack.
+#[no_mangle]
+pub extern "C" fn perry_ui_navstack_pop(handle: i64) {
+    widgets::navstack::pop(handle);
+}
+
+/// Create a ZStack (overlay layout). Returns widget handle.
+#[no_mangle]
+pub extern "C" fn perry_ui_zstack_create() -> i64 {
+    widgets::zstack::create()
+}
+
+// =============================================================================
+// Cross-cutting: Enabled, Hover, DoubleClick, Animations, Tooltip, ControlSize
+// =============================================================================
+
+/// Set the enabled state of a widget. enabled: 0=disabled, 1=enabled.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_enabled(handle: i64, enabled: i64) {
+    widgets::set_enabled(handle, enabled != 0);
+}
+
+/// Set a tooltip on a widget.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_tooltip(handle: i64, text_ptr: i64) {
+    fn str_from_header(ptr: *const u8) -> &'static str {
+        if ptr.is_null() { return ""; }
+        unsafe {
+            let header = ptr as *const perry_runtime::string::StringHeader;
+            let len = (*header).byte_len as usize;
+            let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+        }
+    }
+    widgets::set_tooltip(handle, str_from_header(text_ptr as *const u8));
+}
+
+/// Set the control size of a widget. 0=regular, 1=small, 2=mini, 3=large.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_control_size(handle: i64, size: i64) {
+    widgets::set_control_size(handle, size);
+}
+
+/// Set an on-hover callback for a widget.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_on_hover(handle: i64, callback: f64) {
+    widgets::set_on_hover(handle, callback);
+}
+
+/// Set a single-tap handler for any widget.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_on_click(handle: i64, callback: f64) {
+    widgets::set_on_click(handle, callback);
+}
+
+/// Set a double-click/tap handler for a widget.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_on_double_click(handle: i64, callback: f64) {
+    widgets::set_on_double_click(handle, callback);
+}
+
+/// Animate the opacity of a widget. `duration_secs` is in seconds.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_animate_opacity(handle: i64, target: f64, duration_secs: f64) {
+    widgets::animate_opacity(handle, target, duration_secs);
+}
+
+/// Animate the position of a widget by delta. `duration_secs` is in seconds.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_animate_position(handle: i64, dx: f64, dy: f64, duration_secs: f64) {
+    widgets::animate_position(handle, dx, dy, duration_secs);
+}
+
+/// Register an onChange callback for a state cell.
+#[no_mangle]
+pub extern "C" fn perry_ui_state_on_change(state_handle: i64, callback: f64) {
+    state::state_on_change(state_handle, callback);
+}
+
+// =============================================================================
+// System APIs (perry/system module)
+// =============================================================================
+
+/// Open a URL in the default browser/app.
+#[no_mangle]
+pub extern "C" fn perry_system_open_url(url_ptr: i64) {
+    fn str_from_header(ptr: *const u8) -> &'static str {
+        if ptr.is_null() { return ""; }
+        unsafe {
+            let header = ptr as *const perry_runtime::string::StringHeader;
+            let len = (*header).byte_len as usize;
+            let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+        }
+    }
+    let url_str = str_from_header(url_ptr as *const u8);
+    unsafe {
+        let ns_url_str = objc2_foundation::NSString::from_str(url_str);
+        let url_cls = objc2::runtime::AnyClass::get(c"NSURL").unwrap();
+        let url: *mut objc2::runtime::AnyObject = objc2::msg_send![url_cls, URLWithString: &*ns_url_str];
+        if !url.is_null() {
+            let app_cls = objc2::runtime::AnyClass::get(c"UIApplication").unwrap();
+            let app: *mut objc2::runtime::AnyObject = objc2::msg_send![app_cls, sharedApplication];
+            let _: () = objc2::msg_send![app, openURL: url];
+        }
+    }
+}
+
+/// Request one-shot location. Callback receives (lat, lon) or (NaN, NaN) on error.
+#[no_mangle]
+pub extern "C" fn perry_system_request_location(callback: f64) {
+    location::request_location(callback);
+}
+
+// =============================================================================
+// Audio (perry/system) — AVAudioEngine-based microphone capture
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_system_audio_start() -> i64 {
+    audio::start()
+}
+
+#[no_mangle]
+pub extern "C" fn perry_system_audio_stop() {
+    audio::stop()
+}
+
+#[no_mangle]
+pub extern "C" fn perry_system_audio_get_level() -> f64 {
+    audio::get_level()
+}
+
+#[no_mangle]
+pub extern "C" fn perry_system_audio_get_peak() -> f64 {
+    audio::get_peak()
+}
+
+#[no_mangle]
+pub extern "C" fn perry_system_audio_get_waveform(count: f64) -> f64 {
+    audio::get_waveform(count)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_system_get_device_model() -> i64 {
+    audio::get_device_model()
+}
+
+// =============================================================================
+// Camera (perry/ui) — AVCaptureSession-based camera capture
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_camera_create() -> i64 {
+    camera::create()
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_camera_start(handle: i64) {
+    camera::start(handle)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_camera_stop(handle: i64) {
+    camera::stop(handle)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_camera_freeze(handle: i64) {
+    camera::freeze(handle)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_camera_unfreeze(handle: i64) {
+    camera::unfreeze(handle)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_camera_sample_color(x: f64, y: f64) -> f64 {
+    camera::sample_color(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_camera_set_on_tap(handle: i64, callback: f64) {
+    camera::set_on_tap(handle, callback)
+}
+
+/// Check if dark mode is active. Returns 1 if dark, 0 if light.
+#[no_mangle]
+pub extern "C" fn perry_system_is_dark_mode() -> i64 {
+    unsafe {
+        let tc_cls = objc2::runtime::AnyClass::get(c"UITraitCollection").unwrap();
+        let tc: *mut objc2::runtime::AnyObject = objc2::msg_send![tc_cls, currentTraitCollection];
+        if tc.is_null() { return 0; }
+        let style: i64 = objc2::msg_send![tc, userInterfaceStyle];
+        if style == 2 { 1 } else { 0 } // 2 = UIUserInterfaceStyleDark
+    }
+}
+
+/// Set a preference value (UserDefaults).
+#[no_mangle]
+pub extern "C" fn perry_system_preferences_set(key_ptr: i64, value: f64) {
+    fn str_from_header(ptr: *const u8) -> &'static str {
+        if ptr.is_null() { return ""; }
+        unsafe {
+            let header = ptr as *const perry_runtime::string::StringHeader;
+            let len = (*header).byte_len as usize;
+            let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+        }
+    }
+    extern "C" {
+        fn js_nanbox_get_pointer(value: f64) -> i64;
+    }
+    let key = str_from_header(key_ptr as *const u8);
+    let bits = value.to_bits();
+    unsafe {
+        let defaults_cls = objc2::runtime::AnyClass::get(c"NSUserDefaults").unwrap();
+        let defaults: *mut objc2::runtime::AnyObject = objc2::msg_send![defaults_cls, standardUserDefaults];
+        let ns_key = objc2_foundation::NSString::from_str(key);
+        if (bits >> 48) == 0x7FFF {
+            let str_ptr = js_nanbox_get_pointer(value) as *const u8;
+            let s = str_from_header(str_ptr);
+            let ns_str = objc2_foundation::NSString::from_str(s);
+            let _: () = objc2::msg_send![defaults, setObject: &*ns_str, forKey: &*ns_key];
+        } else {
+            let ns_num: objc2::rc::Retained<objc2::runtime::AnyObject> = objc2::msg_send![
+                objc2::runtime::AnyClass::get(c"NSNumber").unwrap(), numberWithDouble: value
+            ];
+            let _: () = objc2::msg_send![defaults, setObject: &*ns_num, forKey: &*ns_key];
+        }
+    }
+}
+
+/// Get a preference value (UserDefaults). Returns NaN-boxed value or TAG_UNDEFINED.
+#[no_mangle]
+pub extern "C" fn perry_system_preferences_get(key_ptr: i64) -> f64 {
+    fn str_from_header(ptr: *const u8) -> &'static str {
+        if ptr.is_null() { return ""; }
+        unsafe {
+            let header = ptr as *const perry_runtime::string::StringHeader;
+            let len = (*header).byte_len as usize;
+            let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+        }
+    }
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+        fn js_nanbox_string(ptr: i64) -> f64;
+    }
+    let key = str_from_header(key_ptr as *const u8);
+    unsafe {
+        let defaults_cls = objc2::runtime::AnyClass::get(c"NSUserDefaults").unwrap();
+        let defaults: *mut objc2::runtime::AnyObject = objc2::msg_send![defaults_cls, standardUserDefaults];
+        let ns_key = objc2_foundation::NSString::from_str(key);
+        let obj: *mut objc2::runtime::AnyObject = objc2::msg_send![defaults, objectForKey: &*ns_key];
+        if obj.is_null() {
+            return f64::from_bits(0x7FFC_0000_0000_0001);
+        }
+        if let Some(str_cls) = objc2::runtime::AnyClass::get(c"NSString") {
+            let is_string: bool = objc2::msg_send![obj, isKindOfClass: str_cls];
+            if is_string {
+                let ns_str: &objc2_foundation::NSString = &*(obj as *const objc2_foundation::NSString);
+                let rust_str = ns_str.to_string();
+                let bytes = rust_str.as_bytes();
+                let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                return js_nanbox_string(str_ptr as i64);
+            }
+        }
+        if let Some(num_cls) = objc2::runtime::AnyClass::get(c"NSNumber") {
+            let is_number: bool = objc2::msg_send![obj, isKindOfClass: num_cls];
+            if is_number {
+                let val: f64 = objc2::msg_send![obj, doubleValue];
+                return val;
+            }
+        }
+        // NSArray: return first element as string (for AppleLanguages etc.)
+        if let Some(arr_cls) = objc2::runtime::AnyClass::get(c"NSArray") {
+            let is_array: bool = objc2::msg_send![obj, isKindOfClass: arr_cls];
+            if is_array {
+                let count: usize = objc2::msg_send![obj, count];
+                if count > 0 {
+                    let first: *mut objc2::runtime::AnyObject = objc2::msg_send![obj, objectAtIndex: 0usize];
+                    if !first.is_null() {
+                        if let Some(str_cls2) = objc2::runtime::AnyClass::get(c"NSString") {
+                            let is_str: bool = objc2::msg_send![first, isKindOfClass: str_cls2];
+                            if is_str {
+                                let ns_str: &objc2_foundation::NSString = &*(first as *const objc2_foundation::NSString);
+                                let rust_str = ns_str.to_string();
+                                let bytes = rust_str.as_bytes();
+                                let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                                return js_nanbox_string(str_ptr as i64);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        f64::from_bits(0x7FFC_0000_0000_0001)
+    }
+}
+
+/// Set border color on a widget via its CALayer.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_border_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    if let Some(view) = widgets::get_widget(handle) {
+        unsafe {
+            let layer: *mut objc2::runtime::AnyObject = objc2::msg_send![&*view, layer];
+            if !layer.is_null() {
+                let cg_color = widgets::create_cg_color(r, g, b, a);
+                let _: () = objc2::msg_send![layer, setBorderColor: cg_color];
+                extern "C" { fn CGColorRelease(color: *mut std::ffi::c_void); }
+                CGColorRelease(cg_color);
+            }
+        }
+    }
+}
+
+/// Set border width on a widget via its CALayer.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_border_width(handle: i64, width: f64) {
+    if let Some(view) = widgets::get_widget(handle) {
+        unsafe {
+            let layer: *mut objc2::runtime::AnyObject = objc2::msg_send![&*view, layer];
+            if !layer.is_null() {
+                let _: () = objc2::msg_send![layer, setBorderWidth: width];
+            }
+        }
+    }
+}
+
+/// Set edge insets (padding) on a UIStackView. No-op for other widget types.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_edge_insets(handle: i64, top: f64, left: f64, bottom: f64, right: f64) {
+    if let Some(view) = widgets::get_widget(handle) {
+        unsafe {
+            let is_stack = if let Some(cls) = objc2::runtime::AnyClass::get(c"UIStackView") {
+                use objc2_foundation::NSObjectProtocol;
+                view.isKindOfClass(cls)
+            } else {
+                false
+            };
+            if is_stack {
+                let _: () = objc2::msg_send![&*view, setLayoutMarginsRelativeArrangement: true];
+                let insets = objc2_ui_kit::UIEdgeInsets { top, left, bottom, right };
+                let _: () = objc2::msg_send![&*view, setDirectionalLayoutMargins: insets];
+            }
+        }
+    }
+}
+
+/// Set view opacity (alpha) in [0.0, 1.0].
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_opacity(handle: i64, alpha: f64) {
+    if let Some(view) = widgets::get_widget(handle) {
+        unsafe {
+            let _: () = objc2::msg_send![&*view, setAlpha: alpha];
+        }
+    }
+}
+
+/// Set the font family on a Text widget.
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_font_family(handle: i64, family_ptr: i64) {
+    fn str_from_header(ptr: *const u8) -> &'static str {
+        if ptr.is_null() { return ""; }
+        unsafe {
+            let header = ptr as *const perry_runtime::string::StringHeader;
+            let len = (*header).byte_len as usize;
+            let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+        }
+    }
+    let family = str_from_header(family_ptr as *const u8);
+    if let Some(view) = widgets::get_widget(handle) {
+        unsafe {
+            let size: f64 = objc2::msg_send![&*view, font];
+            let size = 13.0f64; // Default size for iOS
+            let font: objc2::rc::Retained<objc2::runtime::AnyObject> = if family == "monospaced" || family == "monospace" {
+                objc2::msg_send![
+                    objc2::runtime::AnyClass::get(c"UIFont").unwrap(),
+                    monospacedSystemFontOfSize: size,
+                    weight: 0.0f64
+                ]
+            } else {
+                let ns_name = objc2_foundation::NSString::from_str(family);
+                let raw_font: *mut objc2::runtime::AnyObject = objc2::msg_send![
+                    objc2::runtime::AnyClass::get(c"UIFont").unwrap(),
+                    fontWithName: &*ns_name,
+                    size: size
+                ];
+                if raw_font.is_null() {
+                    // Font not found — fall back to system font
+                    objc2::msg_send![
+                        objc2::runtime::AnyClass::get(c"UIFont").unwrap(),
+                        systemFontOfSize: size
+                    ]
+                } else {
+                    objc2::rc::Retained::retain(raw_font).unwrap()
+                }
+            };
+            let _: () = objc2::msg_send![&*view, setFont: &*font];
+        }
+    }
+}
+
+// =============================================================================
+// QR Code
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_qrcode_create(data_ptr: i64, size: f64) -> i64 {
+    widgets::qrcode::create(data_ptr as *const u8, size)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_qrcode_set_data(handle: i64, data_ptr: i64) {
+    widgets::qrcode::set_data(handle, data_ptr as *const u8);
+}
+
+// =============================================================================
+// Folder Dialog
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_open_folder_dialog(callback: f64) {
+    // iOS: UIDocumentPickerViewController for directories — stub for now
+    file_dialog::open_dialog(callback);
+}
+
+// =============================================================================
+// Save File Dialog
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_save_file_dialog(_callback: f64, _default_name: i64, _allowed_types: i64) {
+    // iOS: UIDocumentPickerViewController needed — stub for now
+}
+
+// =============================================================================
+// Poll Open File (stub — iOS uses URL schemes / UIDocumentBrowser instead)
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_poll_open_file() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+
+// =============================================================================
+// Overlay (stub — iOS uses different approach)
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_add_overlay(_parent_handle: i64, _child_handle: i64) {
+    // Stub — iOS would use addSubview directly
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_overlay_frame(_handle: i64, _x: f64, _y: f64, _w: f64, _h: f64) {
+    // Stub
+}
+
+// =============================================================================
+// State TextField Binding
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_state_bind_textfield(state_handle: i64, textfield_handle: i64) {
+    state::bind_textfield(state_handle, textfield_handle);
+}
+
+// =============================================================================
+// Alert Dialog
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_alert(_title: i64, _message: i64, _buttons: i64, _callback: f64) {
+    // iOS: UIAlertController — stub for now
+}
+
+// =============================================================================
+// Sheet
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_sheet_create(_width: f64, _height: f64, _title: i64) -> i64 {
+    0 // stub
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_sheet_present(_sheet: i64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_sheet_dismiss(_sheet: i64) {}
+
+// =============================================================================
+// Screen Detection (iPad vs iPhone, orientation)
+// =============================================================================
+
+extern "C" {
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_nanbox_string(ptr: i64) -> f64;
+}
+
+fn nanbox_static_str(s: &'static [u8]) -> f64 {
+    let ptr = unsafe { js_string_from_bytes(s.as_ptr(), s.len() as i64) };
+    unsafe { js_nanbox_string(ptr as i64) }
+}
+
+/// perry_get_screen_width() → logical width in points (e.g. 820 for iPad Air portrait)
+#[no_mangle]
+pub extern "C" fn perry_get_screen_width() -> f64 {
+    unsafe {
+        let screen_cls = objc2::runtime::AnyClass::get(c"UIScreen").unwrap();
+        let main_screen: *mut objc2::runtime::AnyObject = objc2::msg_send![screen_cls, mainScreen];
+        // UIScreen.bounds is orientation-aware since iOS 8
+        let bounds: objc2_core_foundation::CGRect = objc2::msg_send![main_screen, bounds];
+        bounds.size.width
+    }
+}
+
+/// perry_get_screen_height() → logical height in points
+#[no_mangle]
+pub extern "C" fn perry_get_screen_height() -> f64 {
+    unsafe {
+        let screen_cls = objc2::runtime::AnyClass::get(c"UIScreen").unwrap();
+        let main_screen: *mut objc2::runtime::AnyObject = objc2::msg_send![screen_cls, mainScreen];
+        let bounds: objc2_core_foundation::CGRect = objc2::msg_send![main_screen, bounds];
+        bounds.size.height
+    }
+}
+
+/// perry_get_scale_factor() → device pixel ratio (e.g. 2.0 for iPad, 3.0 for iPhone Pro)
+#[no_mangle]
+pub extern "C" fn perry_get_scale_factor() -> f64 {
+    unsafe {
+        let screen_cls = objc2::runtime::AnyClass::get(c"UIScreen").unwrap();
+        let main_screen: *mut objc2::runtime::AnyObject = objc2::msg_send![screen_cls, mainScreen];
+        let scale: f64 = objc2::msg_send![main_screen, scale];
+        scale
+    }
+}
+
+/// perry_get_orientation() → "landscape" or "portrait"
+#[no_mangle]
+pub extern "C" fn perry_get_orientation() -> f64 {
+    unsafe {
+        let screen_cls = objc2::runtime::AnyClass::get(c"UIScreen").unwrap();
+        let main_screen: *mut objc2::runtime::AnyObject = objc2::msg_send![screen_cls, mainScreen];
+        let bounds: objc2_core_foundation::CGRect = objc2::msg_send![main_screen, bounds];
+        if bounds.size.width > bounds.size.height {
+            nanbox_static_str(b"landscape")
+        } else {
+            nanbox_static_str(b"portrait")
+        }
+    }
+}
+
+/// perry_get_device_idiom() → 0 = phone, 1 = pad
+/// Uses UIDevice.model string comparison (more reliable than userInterfaceIdiom
+/// which can return 0 before full UIApplication init on iOS 26 simulator).
+#[no_mangle]
+pub extern "C" fn perry_get_device_idiom() -> f64 {
+    unsafe {
+        let device_cls = objc2::runtime::AnyClass::get(c"UIDevice").unwrap();
+        let current: *mut objc2::runtime::AnyObject = objc2::msg_send![device_cls, currentDevice];
+
+        // Check UIDevice.model — returns @"iPad" on iPad, @"iPhone" on iPhone
+        let model: *mut objc2::runtime::AnyObject = objc2::msg_send![current, model];
+        let utf8: *const u8 = objc2::msg_send![model, UTF8String];
+        if !utf8.is_null() {
+            // "iPad" starts with 'i' (0x69) then 'P' (0x50)
+            // "iPhone" starts with 'i' (0x69) then 'P' (0x50) too...
+            // Actually: "iPad" has 4 chars, "iPhone" has 6 chars
+            // Check 3rd char: 'a' (0x61) for iPad vs 'h' (0x68) for iPhone
+            let third = *utf8.add(2);
+            if third == b'a' {
+                // "iPad"
+                return 1.0;
+            }
+        }
+        0.0
+    }
+}
+
+// =============================================================================
+// App Lifecycle
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_on_terminate(_callback: f64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_on_activate(_callback: f64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_set_icon(_path_ptr: i64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_set_size(_app: i64, _w: f64, _h: f64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_set_frameless(_app_handle: i64, _value: f64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_set_level(_app_handle: i64, _value_ptr: i64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_set_transparent(_app_handle: i64, _value: f64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_set_vibrancy(_app_handle: i64, _value_ptr: i64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_app_set_activation_policy(_app_handle: i64, _value_ptr: i64) {}
+
+// =============================================================================
+// Toolbar
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_toolbar_create() -> i64 {
+    0 // stub
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_toolbar_add_item(_toolbar: i64, _label: i64, _icon: i64, _callback: f64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_toolbar_attach(_toolbar: i64) {}
+
+// =============================================================================
+// Keychain (iOS — uses SecItem API with data protection keychain)
+// =============================================================================
+
+fn keychain_str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() { return ""; }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+extern "C" {
+    fn SecItemAdd(attributes: *const std::ffi::c_void, result: *mut *const std::ffi::c_void) -> i32;
+    fn SecItemCopyMatching(query: *const std::ffi::c_void, result: *mut *const std::ffi::c_void) -> i32;
+    fn SecItemUpdate(query: *const std::ffi::c_void, attrs: *const std::ffi::c_void) -> i32;
+    fn SecItemDelete(query: *const std::ffi::c_void) -> i32;
+    static kSecClass: *const std::ffi::c_void;
+    static kSecClassGenericPassword: *const std::ffi::c_void;
+    static kSecAttrAccount: *const std::ffi::c_void;
+    static kSecAttrService: *const std::ffi::c_void;
+    static kSecValueData: *const std::ffi::c_void;
+    static kSecReturnData: *const std::ffi::c_void;
+    static kSecMatchLimit: *const std::ffi::c_void;
+    static kSecMatchLimitOne: *const std::ffi::c_void;
+}
+
+unsafe fn keychain_make_query(key: &str) -> objc2::rc::Retained<objc2::runtime::AnyObject> {
+    let dict_cls = objc2::runtime::AnyClass::get(c"NSMutableDictionary").unwrap();
+    let dict: objc2::rc::Retained<objc2::runtime::AnyObject> = objc2::msg_send![dict_cls, new];
+    let _: () = objc2::msg_send![&*dict, setObject: kSecClassGenericPassword as *const objc2::runtime::AnyObject, forKey: kSecClass as *const objc2::runtime::AnyObject];
+    let ns_key = objc2_foundation::NSString::from_str(key);
+    let _: () = objc2::msg_send![&*dict, setObject: &*ns_key, forKey: kSecAttrAccount as *const objc2::runtime::AnyObject];
+    let ns_service = objc2_foundation::NSString::from_str("perry");
+    let _: () = objc2::msg_send![&*dict, setObject: &*ns_service, forKey: kSecAttrService as *const objc2::runtime::AnyObject];
+    dict
+}
+
+#[no_mangle]
+pub extern "C" fn perry_system_keychain_save(key_ptr: i64, value_ptr: i64) {
+    let key = keychain_str_from_header(key_ptr as *const u8);
+    let value = keychain_str_from_header(value_ptr as *const u8);
+    unsafe {
+        let value_data: objc2::rc::Retained<objc2::runtime::AnyObject> = {
+            let ns_str = objc2_foundation::NSString::from_str(value);
+            objc2::msg_send![&*ns_str, dataUsingEncoding: 4u64]
+        };
+        // Try update first
+        let query = keychain_make_query(key);
+        let dict_cls = objc2::runtime::AnyClass::get(c"NSMutableDictionary").unwrap();
+        let update: objc2::rc::Retained<objc2::runtime::AnyObject> = objc2::msg_send![dict_cls, new];
+        let _: () = objc2::msg_send![&*update, setObject: &*value_data, forKey: kSecValueData as *const objc2::runtime::AnyObject];
+        let status = SecItemUpdate(&*query as *const _ as *const std::ffi::c_void, &*update as *const _ as *const std::ffi::c_void);
+        if status == -25300 { // errSecItemNotFound
+            let add = keychain_make_query(key);
+            let _: () = objc2::msg_send![&*add, setObject: &*value_data, forKey: kSecValueData as *const objc2::runtime::AnyObject];
+            SecItemAdd(&*add as *const _ as *const std::ffi::c_void, std::ptr::null_mut());
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn perry_system_keychain_get(key_ptr: i64) -> f64 {
+    let key = keychain_str_from_header(key_ptr as *const u8);
+    unsafe {
+        let dict = keychain_make_query(key);
+        let cf_true: *const objc2::runtime::AnyObject = objc2::msg_send![
+            objc2::runtime::AnyClass::get(c"NSNumber").unwrap(), numberWithBool: true
+        ];
+        let _: () = objc2::msg_send![&*dict, setObject: cf_true, forKey: kSecReturnData as *const objc2::runtime::AnyObject];
+        let _: () = objc2::msg_send![&*dict, setObject: kSecMatchLimitOne as *const objc2::runtime::AnyObject, forKey: kSecMatchLimit as *const objc2::runtime::AnyObject];
+        let mut result: *const std::ffi::c_void = std::ptr::null();
+        let status = SecItemCopyMatching(&*dict as *const _ as *const std::ffi::c_void, &mut result);
+        if status == 0 && !result.is_null() {
+            let data = result as *const objc2::runtime::AnyObject;
+            let bytes: *const u8 = objc2::msg_send![data, bytes];
+            let length: usize = objc2::msg_send![data, length];
+            extern "C" {
+                fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+                fn js_nanbox_string(ptr: i64) -> f64;
+            }
+            let str_ptr = js_string_from_bytes(bytes, length as i64);
+            js_nanbox_string(str_ptr as i64)
+        } else {
+            f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn perry_system_keychain_delete(key_ptr: i64) {
+    let key = keychain_str_from_header(key_ptr as *const u8);
+    unsafe {
+        let query = keychain_make_query(key);
+        SecItemDelete(&*query as *const _ as *const std::ffi::c_void);
+    }
+}
+
+// =============================================================================
+// Notifications
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_system_notification_send(_title: i64, _body: i64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_system_get_locale() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    }
+    unsafe {
+        // Use currentLocale.languageCode — reflects the actual device language setting
+        let ns_locale: *mut objc2::runtime::AnyObject = objc2::msg_send![
+            objc2::runtime::AnyClass::get(c"NSLocale").unwrap(),
+            currentLocale
+        ];
+        let lang_code: *mut objc2::runtime::AnyObject = objc2::msg_send![ns_locale, languageCode];
+        if lang_code.is_null() {
+            let fallback = b"en";
+            return js_string_from_bytes(fallback.as_ptr(), 2) as i64;
+        }
+        let utf8: *const u8 = objc2::msg_send![lang_code, UTF8String];
+        let len = libc::strlen(utf8 as *const i8);
+        let code_len = if len >= 2 { 2 } else { len };
+        js_string_from_bytes(utf8, code_len as i64) as i64
+    }
+}
+
+// =============================================================================
+// Multi-Window
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_window_create(_title: i64, _width: f64, _height: f64) -> i64 {
+    0 // stub — iOS uses UIScene for multi-window
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_window_set_body(_window: i64, _widget: i64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_window_show(_window: i64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_window_close(_window: i64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_window_hide(_window: i64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_window_set_size(_window: i64, _w: f64, _h: f64) {}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_window_on_focus_lost(_window: i64, _callback: f64) {}
+
+// =============================================================================
+// LazyVStack
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_lazyvstack_create(_count: i64, _render: f64) -> i64 {
+    0 // stub
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_lazyvstack_update(_handle: i64, _count: i64) {}
+
+// =============================================================================
+// Table (stub — not yet implemented on iOS)
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_ui_table_create(_row_count: f64, _col_count: f64, _render: f64) -> i64 {
+    0 // stub
+}
+#[no_mangle]
+pub extern "C" fn perry_ui_table_set_column_header(_handle: i64, _col: i64, _title_ptr: i64) {}
+#[no_mangle]
+pub extern "C" fn perry_ui_table_set_column_width(_handle: i64, _col: i64, _width: f64) {}
+#[no_mangle]
+pub extern "C" fn perry_ui_table_update_row_count(_handle: i64, _count: i64) {}
+#[no_mangle]
+pub extern "C" fn perry_ui_table_set_on_row_select(_handle: i64, _callback: f64) {}
+#[no_mangle]
+pub extern "C" fn perry_ui_table_get_selected_row(_handle: i64) -> i64 {
+    -1
+}
+
+// =============================================================================
+// iOS Documents directory (for persistent storage)
+// =============================================================================
+
+/// Returns the app's Documents directory path as a NaN-boxed string.
+/// Used by hone-ide's paths.ts for persistent storage on iOS.
+#[no_mangle]
+pub extern "C" fn hone_get_documents_dir() -> f64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+        fn js_nanbox_string(ptr: i64) -> f64;
+    }
+    unsafe {
+        let file_manager: *const objc2::runtime::AnyObject =
+            objc2::msg_send![objc2::runtime::AnyClass::get(c"NSFileManager").unwrap(), defaultManager];
+        // NSDocumentDirectory = 9, NSUserDomainMask = 1
+        let urls: objc2::rc::Retained<objc2_foundation::NSArray<objc2_foundation::NSURL>> =
+            objc2::msg_send![file_manager, URLsForDirectory: 9u64, inDomains: 1u64];
+        let count: usize = objc2::msg_send![&*urls, count];
+        if count > 0 {
+            let url: *const objc2::runtime::AnyObject = objc2::msg_send![&*urls, objectAtIndex: 0usize];
+            let path: objc2::rc::Retained<objc2_foundation::NSString> = objc2::msg_send![url, path];
+            let rust_str = path.to_string();
+            let bytes = rust_str.as_bytes();
+            let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+            js_nanbox_string(str_ptr as i64)
+        } else {
+            // Return empty string
+            let str_ptr = js_string_from_bytes(std::ptr::null(), 0);
+            js_nanbox_string(str_ptr as i64)
+        }
+    }
+}
+
+/// Wrapper for Perry codegen (some declare functions use __wrapper_ prefix).
+#[no_mangle]
+pub extern "C" fn __wrapper_hone_get_documents_dir() -> f64 {
+    hone_get_documents_dir()
+}
+
+// =============================================================================
+// Native iOS WebSocket (bypasses tokio which doesn't work on iOS)
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn hone_ws_connect(url_ptr: i64) -> f64 {
+    // Log to file for debugging (Perry GUI apps don't show stderr)
+    use std::io::Write;
+    if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open("/tmp/hone-ws-debug.log") {
+        let _ = writeln!(f, "hone_ws_connect called, url_ptr={}", url_ptr);
+        let ptr = url_ptr as *const u8;
+        if !ptr.is_null() && url_ptr > 0x1000 {
+            let header = ptr as *const perry_runtime::string::StringHeader;
+            unsafe {
+                let len = (*header).byte_len as usize;
+                let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+                if let Ok(s) = std::str::from_utf8(std::slice::from_raw_parts(data, len.min(200))) {
+                    let _ = writeln!(f, "  url_str={}", s);
+                }
+            }
+        }
+    }
+    websocket::connect(url_ptr as *const u8)
+}
+#[no_mangle]
+pub extern "C" fn __wrapper_hone_ws_connect(url_nanboxed: f64) -> f64 {
+    // Wrapper called with f64 NaN-boxed string — extract pointer
+    let ptr = perry_runtime::js_get_string_pointer_unified(url_nanboxed);
+    if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open("/tmp/hone-ws-debug.log") {
+        use std::io::Write;
+        let _ = writeln!(f, "__wrapper_hone_ws_connect called, nanboxed={}, extracted_ptr={}", url_nanboxed, ptr);
+    }
+    hone_ws_connect(ptr)
+}
+
+#[no_mangle]
+pub extern "C" fn hone_ws_is_open(handle: f64) -> f64 {
+    websocket::is_open(handle)
+}
+#[no_mangle]
+pub extern "C" fn __wrapper_hone_ws_is_open(handle: f64) -> f64 {
+    websocket::is_open(handle)
+}
+
+#[no_mangle]
+pub extern "C" fn hone_ws_send(handle: f64, msg_ptr: i64) {
+    websocket::send(handle, msg_ptr as *const u8)
+}
+#[no_mangle]
+pub extern "C" fn __wrapper_hone_ws_send(handle: f64, msg_nanboxed: f64) {
+    let ptr = perry_runtime::js_get_string_pointer_unified(msg_nanboxed);
+    hone_ws_send(handle, ptr)
+}
+
+#[no_mangle]
+pub extern "C" fn hone_ws_receive(handle: f64) -> f64 {
+    websocket::receive(handle)
+}
+#[no_mangle]
+pub extern "C" fn __wrapper_hone_ws_receive(handle: f64) -> f64 {
+    websocket::receive(handle)
+}
+
+#[no_mangle]
+pub extern "C" fn hone_ws_message_count(handle: f64) -> f64 {
+    websocket::message_count(handle)
+}
+#[no_mangle]
+pub extern "C" fn __wrapper_hone_ws_message_count(handle: f64) -> f64 {
+    websocket::message_count(handle)
+}
+
+#[no_mangle]
+pub extern "C" fn hone_ws_close(handle: f64) {
+    websocket::close(handle)
+}
+#[no_mangle]
+pub extern "C" fn __wrapper_hone_ws_close(handle: f64) {
+    websocket::close(handle)
+}

--- a/crates/perry-ui-visionos/src/location.rs
+++ b/crates/perry-ui-visionos/src/location.rs
@@ -1,0 +1,211 @@
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject};
+use objc2::{msg_send, Encode, Encoding, RefEncode};
+use std::cell::RefCell;
+
+extern "C" {
+    fn js_stdlib_process_pending();
+    fn js_promise_run_microtasks() -> i32;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_closure_call2(closure: *const u8, arg1: f64, arg2: f64) -> f64;
+}
+
+// Raw ObjC runtime FFI for dynamic class registration
+extern "C" {
+    fn objc_allocateClassPair(
+        superclass: *const std::ffi::c_void,
+        name: *const i8,
+        extra_bytes: usize,
+    ) -> *mut std::ffi::c_void;
+    fn objc_registerClassPair(cls: *mut std::ffi::c_void);
+    fn class_addMethod(
+        cls: *mut std::ffi::c_void,
+        sel: *const std::ffi::c_void,
+        imp: *const std::ffi::c_void,
+        types: *const i8,
+    ) -> bool;
+    fn sel_registerName(name: *const i8) -> *const std::ffi::c_void;
+    fn objc_getClass(name: *const i8) -> *const std::ffi::c_void;
+}
+
+thread_local! {
+    static LOCATION_CALLBACK: RefCell<Option<f64>> = RefCell::new(None);
+    /// Prevent the CLLocationManager and delegate from being deallocated.
+    static RETAINED_MANAGER: RefCell<Option<Retained<AnyObject>>> = RefCell::new(None);
+    static RETAINED_DELEGATE: RefCell<Option<Retained<AnyObject>>> = RefCell::new(None);
+    static DELEGATE_REGISTERED: RefCell<bool> = RefCell::new(false);
+}
+
+/// Invoke the stored JS callback with (lat, lon), draining promises first.
+unsafe fn invoke_callback(lat: f64, lon: f64) {
+    let cb = LOCATION_CALLBACK.with(|c| c.borrow_mut().take());
+    if let Some(closure_f64) = cb {
+        js_stdlib_process_pending();
+        js_promise_run_microtasks();
+        let closure_ptr = js_nanbox_get_pointer(closure_f64);
+        js_closure_call2(closure_ptr as *const u8, lat, lon);
+    }
+}
+
+// =============================================================================
+// CLLocationManagerDelegate methods (registered dynamically)
+// =============================================================================
+
+/// locationManager:didUpdateLocations:
+unsafe extern "C" fn did_update_locations(
+    _this: *mut AnyObject,
+    _sel: *const std::ffi::c_void,
+    _manager: *mut AnyObject,
+    locations: *mut AnyObject,
+) {
+    println!("[location] didUpdateLocations called");
+    // [locations lastObject]
+    let location: *mut AnyObject = msg_send![locations, lastObject];
+    if location.is_null() {
+        println!("[location] location is null");
+        invoke_callback(f64::NAN, f64::NAN);
+        return;
+    }
+    let coord: CLLocationCoordinate2D = get_coordinate(location);
+    println!("[location] got coordinates: {}, {}", coord.latitude, coord.longitude);
+    invoke_callback(coord.latitude, coord.longitude);
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct CLLocationCoordinate2D {
+    latitude: f64,
+    longitude: f64,
+}
+
+unsafe impl Encode for CLLocationCoordinate2D {
+    const ENCODING: Encoding = Encoding::Struct(
+        "CLLocationCoordinate2D",
+        &[Encoding::Double, Encoding::Double],
+    );
+}
+
+unsafe impl RefEncode for CLLocationCoordinate2D {
+    const ENCODING_REF: Encoding = Encoding::Pointer(&<Self as Encode>::ENCODING);
+}
+
+/// Extract coordinate from a CLLocation* via objc_msgSend_stret / direct.
+unsafe fn get_coordinate(location: *mut AnyObject) -> CLLocationCoordinate2D {
+    // On arm64, structs up to 4 registers (32 bytes) are returned in registers,
+    // not via stret. CLLocationCoordinate2D is 16 bytes, so direct msg_send works.
+    let coord: CLLocationCoordinate2D = msg_send![location, coordinate];
+    coord
+}
+
+/// locationManager:didFailWithError:
+unsafe extern "C" fn did_fail_with_error(
+    _this: *mut AnyObject,
+    _sel: *const std::ffi::c_void,
+    _manager: *mut AnyObject,
+    _error: *mut AnyObject,
+) {
+    println!("[location] didFailWithError called");
+    invoke_callback(f64::NAN, f64::NAN);
+}
+
+/// locationManagerDidChangeAuthorization:
+unsafe extern "C" fn did_change_authorization(
+    _this: *mut AnyObject,
+    _sel: *const std::ffi::c_void,
+    manager: *mut AnyObject,
+) {
+    // Check authorization status
+    let status: i32 = msg_send![manager, authorizationStatus];
+    println!("[location] didChangeAuthorization, status: {}", status);
+    // 3 = authorizedWhenInUse, 4 = authorizedAlways
+    if status == 3 || status == 4 {
+        // Only request if we have a pending callback
+        let has_callback = LOCATION_CALLBACK.with(|c| c.borrow().is_some());
+        if has_callback {
+            let _: () = msg_send![manager, requestLocation];
+        }
+    } else if status == 2 {
+        // 2 = denied
+        unsafe { invoke_callback(f64::NAN, f64::NAN); }
+    }
+    // status 0 = notDetermined — wait for user to respond
+    // status 1 = restricted — wait or fail
+}
+
+/// Register the PerryLocationDelegate class dynamically at runtime.
+fn register_location_delegate() {
+    DELEGATE_REGISTERED.with(|reg| {
+        if *reg.borrow() {
+            return;
+        }
+        *reg.borrow_mut() = true;
+
+        unsafe {
+            let superclass = objc_getClass(c"NSObject".as_ptr());
+            let cls = objc_allocateClassPair(superclass, c"PerryLocationDelegate".as_ptr(), 0);
+            if cls.is_null() {
+                return; // Already registered
+            }
+
+            // locationManager:didUpdateLocations: — type: v@:@@
+            let sel1 = sel_registerName(c"locationManager:didUpdateLocations:".as_ptr());
+            class_addMethod(cls, sel1, did_update_locations as *const std::ffi::c_void, c"v@:@@".as_ptr());
+
+            // locationManager:didFailWithError: — type: v@:@@
+            let sel2 = sel_registerName(c"locationManager:didFailWithError:".as_ptr());
+            class_addMethod(cls, sel2, did_fail_with_error as *const std::ffi::c_void, c"v@:@@".as_ptr());
+
+            // locationManagerDidChangeAuthorization: — type: v@:@
+            let sel3 = sel_registerName(c"locationManagerDidChangeAuthorization:".as_ptr());
+            class_addMethod(cls, sel3, did_change_authorization as *const std::ffi::c_void, c"v@:@".as_ptr());
+
+            objc_registerClassPair(cls);
+        }
+    });
+}
+
+/// Request a one-shot location. Callback receives (lat, lon) on success or (NaN, NaN) on error.
+/// Handles authorization automatically — if not determined, requests When In Use first.
+pub fn request_location(callback: f64) {
+    println!("[location] request_location called, callback bits: {:016x}", callback.to_bits());
+    register_location_delegate();
+
+    // Store the callback
+    LOCATION_CALLBACK.with(|c| {
+        *c.borrow_mut() = Some(callback);
+    });
+
+    unsafe {
+        // Create CLLocationManager
+        let mgr_cls = AnyClass::get(c"CLLocationManager").expect("CLLocationManager not found — link CoreLocation.framework");
+        let manager: Retained<AnyObject> = msg_send![mgr_cls, new];
+        println!("[location] CLLocationManager created");
+
+        // Create delegate
+        let del_cls = AnyClass::get(c"PerryLocationDelegate").unwrap();
+        let delegate: Retained<AnyObject> = msg_send![del_cls, new];
+        println!("[location] delegate created");
+
+        // Set delegate on manager
+        let _: () = msg_send![&*manager, setDelegate: &*delegate];
+
+        // Check current authorization status
+        let status: i32 = msg_send![&*manager, authorizationStatus];
+        println!("[location] authorization status: {}", status);
+
+        // Retain manager and delegate so they stay alive
+        RETAINED_MANAGER.with(|m| { *m.borrow_mut() = Some(manager.clone()); });
+        RETAINED_DELEGATE.with(|d| { *d.borrow_mut() = Some(delegate); });
+
+        if status == 3 || status == 4 {
+            println!("[location] already authorized, requesting location");
+            let _: () = msg_send![&*manager, requestLocation];
+        } else if status == 0 {
+            println!("[location] not determined, requesting authorization");
+            let _: () = msg_send![&*manager, requestWhenInUseAuthorization];
+        } else {
+            println!("[location] denied/restricted (status={}), sending NaN", status);
+            invoke_callback(f64::NAN, f64::NAN);
+        }
+    }
+}

--- a/crates/perry-ui-visionos/src/menu.rs
+++ b/crates/perry-ui-visionos/src/menu.rs
@@ -1,0 +1,482 @@
+//! iOS menu system — UIMenu / UIAction / UIKeyCommand for iPadOS menu bar and context menus.
+//!
+//! On iPadOS 26+, menus appear as a native menu bar. On iPhone / older iPad,
+//! keyboard shortcuts still work via UIKeyCommand discoverability.
+
+use objc2::msg_send;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject, Sel};
+use std::cell::RefCell;
+
+extern "C" {
+    fn js_closure_call0(closure: *const u8) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+}
+
+/// A stored menu item — either a regular item, separator, or submenu.
+#[derive(Clone)]
+enum MenuItemEntry {
+    Item {
+        title: String,
+        callback: f64,
+        shortcut: Option<String>,
+    },
+    Separator,
+    Submenu {
+        title: String,
+        submenu_handle: i64,
+    },
+}
+
+/// A menu bar: ordered list of (title, menu_handle).
+#[derive(Clone)]
+struct MenuBarEntry {
+    menus: Vec<(String, i64)>,
+}
+
+thread_local! {
+    static MENUS: RefCell<Vec<Vec<MenuItemEntry>>> = RefCell::new(Vec::new());
+    static MENUBARS: RefCell<Vec<MenuBarEntry>> = RefCell::new(Vec::new());
+    /// The attached menu bar handle (if any). Read by buildMenuWithBuilder:.
+    pub(crate) static ATTACHED_MENUBAR: RefCell<Option<i64>> = RefCell::new(None);
+    /// Global action counter for unique selector names.
+    static NEXT_ACTION_ID: RefCell<usize> = RefCell::new(1);
+    /// Map from action tag (usize) to callback f64.
+    static ACTION_CALLBACKS: RefCell<Vec<(usize, f64)>> = RefCell::new(Vec::new());
+}
+
+/// Extract a &str from a *const StringHeader pointer.
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/// Create a new menu. Returns menu handle (1-based).
+pub fn create() -> i64 {
+    MENUS.with(|m| {
+        let mut menus = m.borrow_mut();
+        menus.push(Vec::new());
+        menus.len() as i64
+    })
+}
+
+/// Add an item to a menu with a title and callback.
+pub fn add_item(menu_handle: i64, title_ptr: *const u8, callback: f64) {
+    let title = str_from_header(title_ptr).to_string();
+    MENUS.with(|m| {
+        let mut menus = m.borrow_mut();
+        let idx = (menu_handle - 1) as usize;
+        if idx < menus.len() {
+            menus[idx].push(MenuItemEntry::Item {
+                title,
+                callback,
+                shortcut: None,
+            });
+        }
+    });
+    #[cfg(feature = "geisterhand")]
+    {
+        extern "C" { fn perry_geisterhand_register(h: i64, wt: u8, ck: u8, cb: f64, lbl: *const u8); }
+        unsafe { perry_geisterhand_register(menu_handle, 5, 0, callback, title_ptr); }
+    }
+}
+
+/// Add an item with a keyboard shortcut (e.g. "Cmd+N").
+pub fn add_item_with_shortcut(
+    menu_handle: i64,
+    title_ptr: *const u8,
+    callback: f64,
+    shortcut_ptr: *const u8,
+) {
+    let title = str_from_header(title_ptr).to_string();
+    let shortcut = str_from_header(shortcut_ptr).to_string();
+    MENUS.with(|m| {
+        let mut menus = m.borrow_mut();
+        let idx = (menu_handle - 1) as usize;
+        if idx < menus.len() {
+            menus[idx].push(MenuItemEntry::Item {
+                title,
+                callback,
+                shortcut: Some(shortcut.clone()),
+            });
+        }
+    });
+    #[cfg(feature = "geisterhand")]
+    {
+        extern "C" {
+            fn perry_geisterhand_register_with_shortcut(
+                h: i64, wt: u8, ck: u8, cb: f64, lbl: *const u8,
+                shortcut_ptr: *const u8, shortcut_len: usize,
+            );
+        }
+        let shortcut_bytes = shortcut.as_bytes();
+        unsafe {
+            perry_geisterhand_register_with_shortcut(
+                menu_handle, 5, 0, callback, title_ptr,
+                shortcut_bytes.as_ptr(), shortcut_bytes.len(),
+            );
+        }
+    }
+}
+
+/// Remove all items from a menu.
+pub fn clear(menu_handle: i64) {
+    MENUS.with(|m| {
+        let mut menus = m.borrow_mut();
+        let idx = (menu_handle - 1) as usize;
+        if idx < menus.len() {
+            menus[idx].clear();
+        }
+    });
+}
+
+/// Add a separator to a menu.
+pub fn add_separator(menu_handle: i64) {
+    MENUS.with(|m| {
+        let mut menus = m.borrow_mut();
+        let idx = (menu_handle - 1) as usize;
+        if idx < menus.len() {
+            menus[idx].push(MenuItemEntry::Separator);
+        }
+    });
+}
+
+/// Add a submenu to a menu.
+pub fn add_submenu(menu_handle: i64, title_ptr: *const u8, submenu_handle: i64) {
+    let title = str_from_header(title_ptr).to_string();
+    MENUS.with(|m| {
+        let mut menus = m.borrow_mut();
+        let idx = (menu_handle - 1) as usize;
+        if idx < menus.len() {
+            menus[idx].push(MenuItemEntry::Submenu {
+                title,
+                submenu_handle,
+            });
+        }
+    });
+}
+
+/// Create a menu bar. Returns bar handle (1-based).
+pub fn menubar_create() -> i64 {
+    MENUBARS.with(|m| {
+        let mut bars = m.borrow_mut();
+        bars.push(MenuBarEntry { menus: Vec::new() });
+        bars.len() as i64
+    })
+}
+
+/// Add a menu to the menu bar with a title.
+pub fn menubar_add_menu(bar_handle: i64, title_ptr: *const u8, menu_handle: i64) {
+    let title = str_from_header(title_ptr).to_string();
+    MENUBARS.with(|m| {
+        let mut bars = m.borrow_mut();
+        let idx = (bar_handle - 1) as usize;
+        if idx < bars.len() {
+            bars[idx].menus.push((title, menu_handle));
+        }
+    });
+}
+
+/// Attach a menu bar. Stores handle and triggers UIMenuSystem rebuild.
+pub fn menubar_attach(bar_handle: i64) {
+    ATTACHED_MENUBAR.with(|a| {
+        *a.borrow_mut() = Some(bar_handle);
+    });
+
+    // Tell UIKit to rebuild the menu bar
+    unsafe {
+        let menu_system_cls = AnyClass::get(c"UIMenuSystem");
+        if let Some(cls) = menu_system_cls {
+            let main_system: *mut AnyObject = msg_send![cls, mainSystem];
+            if !main_system.is_null() {
+                let _: () = msg_send![main_system, setNeedsRebuild];
+            }
+        }
+    }
+}
+
+/// Set a context menu on a widget (stub — UIContextMenuInteraction not yet implemented).
+pub fn set_context_menu(_widget_handle: i64, _menu_handle: i64) {
+    // TODO: UIContextMenuInteraction
+}
+
+// ─── UIMenu Construction ─────────────────────────────────────────────────────
+
+/// Build the UIMenu hierarchy for a menu handle.
+/// Returns a Retained<AnyObject> pointing to a UIMenu, or None.
+pub(crate) unsafe fn build_uimenu(menu_handle: i64) -> Option<Retained<AnyObject>> {
+    let items: Vec<MenuItemEntry> = MENUS.with(|m| {
+        let menus = m.borrow();
+        let idx = (menu_handle - 1) as usize;
+        if idx < menus.len() {
+            menus[idx].clone()
+        } else {
+            Vec::new()
+        }
+    });
+
+    if items.is_empty() {
+        return None;
+    }
+
+    // Build an NSMutableArray of UIMenuElement objects
+    let arr_cls = AnyClass::get(c"NSMutableArray").unwrap();
+    let children: Retained<AnyObject> = msg_send![arr_cls, new];
+
+    // Group items by separator — each group becomes a section (UIMenu with .displayInline)
+    let mut current_group: Vec<Retained<AnyObject>> = Vec::new();
+    let mut groups: Vec<Vec<Retained<AnyObject>>> = Vec::new();
+
+    for item in &items {
+        match item {
+            MenuItemEntry::Item {
+                title,
+                callback,
+                shortcut,
+            } => {
+                let element = build_uiaction(title, *callback, shortcut.as_deref());
+                current_group.push(element);
+            }
+            MenuItemEntry::Separator => {
+                if !current_group.is_empty() {
+                    groups.push(std::mem::take(&mut current_group));
+                }
+            }
+            MenuItemEntry::Submenu {
+                title,
+                submenu_handle,
+            } => {
+                if let Some(sub) = build_uimenu(*submenu_handle) {
+                    // Set title on the submenu
+                    let ns_title = objc2_foundation::NSString::from_str(title);
+                    let sub_with_title: Retained<AnyObject> = build_uimenu_with_title(&ns_title, &sub);
+                    current_group.push(sub_with_title);
+                }
+            }
+        }
+    }
+    if !current_group.is_empty() {
+        groups.push(current_group);
+    }
+
+    // If there's only one group (no separators), put all items directly in children
+    if groups.len() <= 1 {
+        for group in &groups {
+            for element in group {
+                let _: () = msg_send![&*children, addObject: &**element];
+            }
+        }
+    } else {
+        // Multiple groups — wrap each in a displayInline UIMenu for separator rendering
+        for group in &groups {
+            let section_arr: Retained<AnyObject> = msg_send![arr_cls, new];
+            for element in group {
+                let _: () = msg_send![&*section_arr, addObject: &**element];
+            }
+            let empty_title = objc2_foundation::NSString::from_str("");
+            let menu_cls = AnyClass::get(c"UIMenu").unwrap();
+            // UIMenuOptions.displayInline = 1 << 0 = 1
+            let section: Retained<AnyObject> = msg_send![
+                menu_cls,
+                menuWithTitle: &*empty_title,
+                image: std::ptr::null::<AnyObject>(),
+                identifier: std::ptr::null::<AnyObject>(),
+                options: 1u64,
+                children: &*section_arr
+            ];
+            let _: () = msg_send![&*children, addObject: &*section];
+        }
+    }
+
+    // Create the top-level UIMenu (no title — the bar item title comes from menuBarAddMenu)
+    let empty_title = objc2_foundation::NSString::from_str("");
+    let menu_cls = AnyClass::get(c"UIMenu").unwrap();
+    let menu: Retained<AnyObject> = msg_send![
+        menu_cls,
+        menuWithTitle: &*empty_title,
+        children: &*children
+    ];
+    Some(menu)
+}
+
+/// Wrap a UIMenu with a new title (for submenus).
+unsafe fn build_uimenu_with_title(
+    title: &objc2_foundation::NSString,
+    source_menu: &AnyObject,
+) -> Retained<AnyObject> {
+    // Get the children array from source_menu
+    let source_children: Retained<AnyObject> = msg_send![source_menu, children];
+    let menu_cls = AnyClass::get(c"UIMenu").unwrap();
+    let menu: Retained<AnyObject> = msg_send![
+        menu_cls,
+        menuWithTitle: title,
+        children: &*source_children
+    ];
+    menu
+}
+
+/// Build a UIAction for a menu item.
+unsafe fn build_uiaction(
+    title: &str,
+    callback: f64,
+    shortcut: Option<&str>,
+) -> Retained<AnyObject> {
+    let ns_title = objc2_foundation::NSString::from_str(title);
+
+    // Allocate a unique tag for this action
+    let tag = NEXT_ACTION_ID.with(|id| {
+        let mut id = id.borrow_mut();
+        let current = *id;
+        *id += 1;
+        current
+    });
+
+    // Store callback
+    ACTION_CALLBACKS.with(|cbs| {
+        cbs.borrow_mut().push((tag, callback));
+    });
+
+    if let Some(shortcut_str) = shortcut {
+        // Create a UIKeyCommand with keyboard shortcut
+        let (key, mods) = parse_shortcut(shortcut_str);
+        let ns_key = objc2_foundation::NSString::from_str(&key);
+
+        let cmd_cls = AnyClass::get(c"UIKeyCommand").unwrap();
+        let sel = Sel::register(c"perryMenuAction:");
+        let cmd: Retained<AnyObject> = msg_send![
+            cmd_cls,
+            keyCommandWithInput: &*ns_key,
+            modifierFlags: mods,
+            action: sel
+        ];
+
+        // Set title for menu bar display
+        let _: () = msg_send![&*cmd, setTitle: &*ns_title];
+
+        // Store the tag in the property number so we can look up the callback
+        // Use the wantsPriorityOverSystemBehavior property tag approach —
+        // actually we'll use the command's hash as key, but simpler: use a
+        // global counter and store tag on the object via associated object or
+        // by encoding in the property text. Simplest: store in discoverabilityTitle.
+        let tag_str = format!("__perry_tag_{}", tag);
+        let ns_tag = objc2_foundation::NSString::from_str(&tag_str);
+        let _: () = msg_send![&*cmd, setDiscoverabilityTitle: &*ns_tag];
+
+        cmd
+    } else {
+        // Create a UIAction (closure-based, no shortcut)
+        // UIAction requires a block/closure — use UICommand with a selector instead
+        let cmd_cls = AnyClass::get(c"UICommand").unwrap();
+        let sel = Sel::register(c"perryMenuAction:");
+        let cmd: Retained<AnyObject> = msg_send![
+            cmd_cls,
+            commandWithTitle: &*ns_title,
+            image: std::ptr::null::<AnyObject>(),
+            action: sel,
+            propertyList: std::ptr::null::<AnyObject>()
+        ];
+
+        // Store tag in discoverabilityTitle for lookup
+        let tag_str = format!("__perry_tag_{}", tag);
+        let ns_tag = objc2_foundation::NSString::from_str(&tag_str);
+        let _: () = msg_send![&*cmd, setDiscoverabilityTitle: &*ns_tag];
+
+        cmd
+    }
+}
+
+/// Called from the perryMenuAction: selector on the responder.
+/// Extracts the tag from the sender's discoverabilityTitle and invokes the callback.
+pub(crate) unsafe fn dispatch_menu_action(sender: *mut AnyObject) {
+    if sender.is_null() {
+        return;
+    }
+    let disc_title: *mut AnyObject = msg_send![sender, discoverabilityTitle];
+    if disc_title.is_null() {
+        return;
+    }
+    let ns_str: &objc2_foundation::NSString =
+        &*(disc_title as *const objc2_foundation::NSString);
+    let rust_str = ns_str.to_string();
+
+    if let Some(tag_str) = rust_str.strip_prefix("__perry_tag_") {
+        if let Ok(tag) = tag_str.parse::<usize>() {
+            let callback = ACTION_CALLBACKS.with(|cbs| {
+                let cbs = cbs.borrow();
+                cbs.iter()
+                    .find(|&&(t, _)| t == tag)
+                    .map(|&(_, cb)| cb)
+            });
+            if let Some(cb) = callback {
+                let ptr = js_nanbox_get_pointer(cb) as *const u8;
+                js_closure_call0(ptr);
+            }
+        }
+    }
+}
+
+/// Parse a shortcut string like "Cmd+Shift+N" into (key, UIKeyModifierFlags bitmask).
+/// UIKeyModifierFlags: Command=1<<20, Shift=1<<17, Alternate(Option)=1<<19, Control=1<<18
+fn parse_shortcut(s: &str) -> (String, u64) {
+    let mut flags: u64 = 0;
+    let mut key = String::new();
+
+    for part in s.split('+') {
+        let trimmed = part.trim();
+        match trimmed.to_lowercase().as_str() {
+            "cmd" | "command" => flags |= 1 << 20, // UIKeyModifierCommand
+            "shift" => flags |= 1 << 17,           // UIKeyModifierShift
+            "option" | "alt" => flags |= 1 << 19,  // UIKeyModifierAlternate
+            "ctrl" | "control" => flags |= 1 << 18, // UIKeyModifierControl
+            _ => key = trimmed.to_lowercase(),
+        }
+    }
+
+    (key, flags)
+}
+
+/// Build the complete menu bar for the UIMenuBuilder.
+/// Called from the `buildMenuWithBuilder:` override on PerryViewController.
+pub(crate) unsafe fn build_menubar_for_builder(builder: *mut AnyObject) {
+    let bar_handle = ATTACHED_MENUBAR.with(|a| *a.borrow());
+    let bar_handle = match bar_handle {
+        Some(h) => h,
+        None => return,
+    };
+
+    let bar_menus: Vec<(String, i64)> = MENUBARS.with(|m| {
+        let bars = m.borrow();
+        let idx = (bar_handle - 1) as usize;
+        if idx < bars.len() {
+            bars[idx].menus.clone()
+        } else {
+            Vec::new()
+        }
+    });
+
+    for (title, menu_handle) in bar_menus {
+        if let Some(uimenu) = build_uimenu(menu_handle) {
+            // Re-wrap with the correct title
+            let ns_title = objc2_foundation::NSString::from_str(&title);
+            let titled_menu = build_uimenu_with_title(&ns_title, &uimenu);
+
+            // Insert at end of the main menu via UIMenuBuilder
+            // builder.insertChild(_:atEndOfMenu:) with identifier .root
+            let root_id = objc2_foundation::NSString::from_str("UIMenuRoot");
+            let _: () = msg_send![
+                builder,
+                insertSiblingMenu: &*titled_menu,
+                afterMenuForIdentifier: &*root_id
+            ];
+        }
+    }
+}

--- a/crates/perry-ui-visionos/src/screenshot.rs
+++ b/crates/perry-ui-visionos/src/screenshot.rs
@@ -1,0 +1,71 @@
+//! Screenshot capture for iOS (behind geisterhand feature).
+
+use objc2::runtime::{AnyClass, AnyObject};
+use objc2::msg_send;
+use objc2_core_foundation::{CGRect, CGSize};
+
+#[no_mangle]
+pub extern "C" fn perry_ui_screenshot_capture(out_len: *mut usize) -> *mut u8 {
+    unsafe {
+        *out_len = 0;
+    }
+
+    unsafe {
+        // Get the shared UIApplication and its key window
+        let app_cls = AnyClass::get(c"UIApplication").unwrap();
+        let app: *const AnyObject = msg_send![app_cls, sharedApplication];
+        if app.is_null() {
+            return std::ptr::null_mut();
+        }
+
+        let key_window: *const AnyObject = msg_send![app, keyWindow];
+        if key_window.is_null() {
+            return std::ptr::null_mut();
+        }
+
+        // Get window bounds
+        let bounds: CGRect = msg_send![key_window, bounds];
+        let size: CGSize = bounds.size;
+
+        // UIGraphicsBeginImageContextWithOptions(bounds.size, NO, 0.0)
+        extern "C" {
+            fn UIGraphicsBeginImageContextWithOptions(size: CGSize, opaque: bool, scale: f64);
+            fn UIGraphicsGetImageFromCurrentImageContext() -> *const AnyObject;
+            fn UIGraphicsEndImageContext();
+            fn UIImagePNGRepresentation(image: *const AnyObject) -> *const AnyObject;
+        }
+
+        UIGraphicsBeginImageContextWithOptions(size, false, 0.0);
+
+        // drawViewHierarchyInRect:afterScreenUpdates:
+        let _: bool = msg_send![key_window, drawViewHierarchyInRect: bounds afterScreenUpdates: true];
+
+        let image = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+
+        if image.is_null() {
+            return std::ptr::null_mut();
+        }
+
+        let png_data = UIImagePNGRepresentation(image);
+        if png_data.is_null() {
+            return std::ptr::null_mut();
+        }
+
+        // NSData bytes/length
+        let length: usize = msg_send![png_data, length];
+        let bytes: *const u8 = msg_send![png_data, bytes];
+
+        if length == 0 || bytes.is_null() {
+            return std::ptr::null_mut();
+        }
+
+        let buf = libc::malloc(length) as *mut u8;
+        if buf.is_null() {
+            return std::ptr::null_mut();
+        }
+        std::ptr::copy_nonoverlapping(bytes, buf, length);
+        *out_len = length;
+        buf
+    }
+}

--- a/crates/perry-ui-visionos/src/state.rs
+++ b/crates/perry-ui-visionos/src/state.rs
@@ -1,0 +1,369 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::widgets;
+
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+}
+
+struct StateEntry {
+    value: f64,
+}
+
+struct TextBinding {
+    text_handle: i64,
+    prefix: String,
+    suffix: String,
+}
+
+struct SliderBinding {
+    slider_handle: i64,
+}
+
+struct ToggleBinding {
+    toggle_handle: i64,
+}
+
+struct TextFieldBinding {
+    textfield_handle: i64,
+}
+
+enum TextPart {
+    Literal(String),
+    StateRef(i64),
+}
+
+struct MultiTextBinding {
+    text_handle: i64,
+    parts: Vec<TextPart>,
+}
+
+struct VisibilityBinding {
+    show_handle: i64,
+    hide_handle: i64,
+}
+
+struct ForEachBinding {
+    container_handle: i64,
+    render_closure: f64,
+}
+
+thread_local! {
+    static STATES: RefCell<Vec<StateEntry>> = RefCell::new(Vec::new());
+    static TEXT_BINDINGS: RefCell<HashMap<i64, Vec<TextBinding>>> = RefCell::new(HashMap::new());
+    static SLIDER_BINDINGS: RefCell<HashMap<i64, Vec<SliderBinding>>> = RefCell::new(HashMap::new());
+    static TOGGLE_BINDINGS: RefCell<HashMap<i64, Vec<ToggleBinding>>> = RefCell::new(HashMap::new());
+    static TEXTFIELD_BINDINGS: RefCell<HashMap<i64, Vec<TextFieldBinding>>> = RefCell::new(HashMap::new());
+    static MULTI_TEXT_BINDINGS: RefCell<Vec<MultiTextBinding>> = RefCell::new(Vec::new());
+    static MULTI_TEXT_INDEX: RefCell<HashMap<i64, Vec<usize>>> = RefCell::new(HashMap::new());
+    static VISIBILITY_BINDINGS: RefCell<HashMap<i64, Vec<VisibilityBinding>>> = RefCell::new(HashMap::new());
+    static FOR_EACH_BINDINGS: RefCell<HashMap<i64, Vec<ForEachBinding>>> = RefCell::new(HashMap::new());
+    static ON_CHANGE_CALLBACKS: RefCell<HashMap<i64, Vec<f64>>> = RefCell::new(HashMap::new());
+}
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// Check if a f64 value is a NaN-boxed string (STRING_TAG = 0x7FFF).
+fn is_nanboxed_string(value: f64) -> bool {
+    let bits = value.to_bits();
+    (bits >> 48) == 0x7FFF
+}
+
+/// Extract the string content from a NaN-boxed string value.
+fn extract_nanboxed_string(value: f64) -> String {
+    let ptr = unsafe { js_nanbox_get_pointer(value) } as *const u8;
+    str_from_header(ptr).to_string()
+}
+
+fn format_value(value: f64) -> String {
+    if is_nanboxed_string(value) {
+        extract_nanboxed_string(value)
+    } else if value.fract() == 0.0 && value.abs() < 1e15 {
+        format!("{}", value as i64)
+    } else {
+        format!("{}", value)
+    }
+}
+
+pub fn state_create(initial: f64) -> i64 {
+    STATES.with(|s| {
+        let mut states = s.borrow_mut();
+        states.push(StateEntry { value: initial });
+        states.len() as i64
+    })
+}
+
+pub fn state_get(handle: i64) -> f64 {
+    STATES.with(|s| {
+        let states = s.borrow();
+        let idx = (handle - 1) as usize;
+        if idx < states.len() {
+            states[idx].value
+        } else {
+            f64::from_bits(0x7FFC_0000_0000_0001)
+        }
+    })
+}
+
+pub fn state_set(handle: i64, value: f64) {
+    STATES.with(|s| {
+        let mut states = s.borrow_mut();
+        let idx = (handle - 1) as usize;
+        if idx < states.len() {
+            states[idx].value = value;
+        }
+    });
+
+    let formatted = format_value(value);
+
+    TEXT_BINDINGS.with(|b| {
+        if let Some(bindings) = b.borrow().get(&handle) {
+            for binding in bindings {
+                let text = format!("{}{}{}", binding.prefix, formatted, binding.suffix);
+                widgets::text::set_text_str(binding.text_handle, &text);
+            }
+        }
+    });
+
+    MULTI_TEXT_INDEX.with(|idx| {
+        if let Some(binding_indices) = idx.borrow().get(&handle) {
+            MULTI_TEXT_BINDINGS.with(|bindings| {
+                let bindings = bindings.borrow();
+                for &bi in binding_indices {
+                    if bi < bindings.len() {
+                        let binding = &bindings[bi];
+                        let text = rebuild_multi_text(&binding.parts);
+                        widgets::text::set_text_str(binding.text_handle, &text);
+                    }
+                }
+            });
+        }
+    });
+
+    SLIDER_BINDINGS.with(|b| {
+        if let Some(bindings) = b.borrow().get(&handle) {
+            for binding in bindings {
+                widgets::slider::set_value(binding.slider_handle, value);
+            }
+        }
+    });
+
+    TOGGLE_BINDINGS.with(|b| {
+        if let Some(bindings) = b.borrow().get(&handle) {
+            for binding in bindings {
+                let on = if value != 0.0 && !value.is_nan() { 1 } else { 0 };
+                widgets::toggle::set_state(binding.toggle_handle, on);
+            }
+        }
+    });
+
+    // Update textfield bindings (two-way)
+    TEXTFIELD_BINDINGS.with(|b| {
+        if let Some(bindings) = b.borrow().get(&handle) {
+            for binding in bindings {
+                widgets::textfield::set_text_str(binding.textfield_handle, &formatted);
+            }
+        }
+    });
+
+    VISIBILITY_BINDINGS.with(|b| {
+        if let Some(bindings) = b.borrow().get(&handle) {
+            let truthy = is_truthy_f64(value);
+            for binding in bindings {
+                widgets::set_hidden(binding.show_handle, !truthy);
+                if binding.hide_handle != 0 {
+                    widgets::set_hidden(binding.hide_handle, truthy);
+                }
+            }
+        }
+    });
+
+    // Update forEach bindings (dynamic lists).
+    // Clone into local Vec to release borrow before calling user closures
+    // (render_for_each invokes js_closure_call1 which could re-enter state code).
+    let foreach_snapshot: Vec<(i64, f64)> = FOR_EACH_BINDINGS.with(|b| {
+        b.borrow()
+            .get(&handle)
+            .map(|bindings| bindings.iter().map(|b| (b.container_handle, b.render_closure)).collect())
+            .unwrap_or_default()
+    });
+    for (container, closure) in foreach_snapshot {
+        widgets::clear_children(container);
+        render_for_each(container, closure, value);
+    }
+
+    // Invoke onChange callbacks.
+    // Clone callbacks into a local Vec before invoking, so the immutable borrow
+    // on ON_CHANGE_CALLBACKS is released before user code runs. Without this,
+    // a callback that registers new onChange handlers (e.g. perry-react's
+    // _scheduleRerender → re-render → new useState → sig.onChange) would try
+    // borrow_mut while the immutable borrow is still held → RefCell panic.
+    let callbacks_snapshot: Vec<f64> = ON_CHANGE_CALLBACKS.with(|cbs| {
+        cbs.borrow()
+            .get(&handle)
+            .map(|v| v.clone())
+            .unwrap_or_default()
+    });
+    for closure_f64 in callbacks_snapshot {
+        let closure_ptr = unsafe { js_nanbox_get_pointer(closure_f64) } as *const u8;
+        unsafe { js_closure_call1(closure_ptr, value); }
+    }
+}
+
+fn is_truthy_f64(value: f64) -> bool {
+    let bits = value.to_bits();
+    const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+    const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+    const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
+
+    if bits == TAG_FALSE || bits == TAG_UNDEFINED || bits == TAG_NULL {
+        return false;
+    }
+    if value == 0.0 || value.is_nan() {
+        return false;
+    }
+    true
+}
+
+fn rebuild_multi_text(parts: &[TextPart]) -> String {
+    let mut result = String::new();
+    for part in parts {
+        match part {
+            TextPart::Literal(s) => result.push_str(s),
+            TextPart::StateRef(state_handle) => {
+                let val = state_get(*state_handle);
+                result.push_str(&format_value(val));
+            }
+        }
+    }
+    result
+}
+
+fn render_for_each(container: i64, closure: f64, count: f64) {
+    let n = count as i64;
+    let closure_ptr = unsafe { js_nanbox_get_pointer(closure) } as *const u8;
+    for i in 0..n {
+        let child_f64 = unsafe { js_closure_call1(closure_ptr, i as f64) };
+        let child_handle = unsafe { js_nanbox_get_pointer(child_f64) };
+        widgets::add_child(container, child_handle);
+    }
+}
+
+pub fn bind_text_numeric(state_handle: i64, text_handle: i64, prefix_ptr: *const u8, suffix_ptr: *const u8) {
+    let prefix = str_from_header(prefix_ptr).to_string();
+    let suffix = str_from_header(suffix_ptr).to_string();
+    TEXT_BINDINGS.with(|b| {
+        b.borrow_mut()
+            .entry(state_handle)
+            .or_default()
+            .push(TextBinding { text_handle, prefix, suffix });
+    });
+}
+
+pub fn bind_slider(state_handle: i64, slider_handle: i64) {
+    SLIDER_BINDINGS.with(|b| {
+        b.borrow_mut()
+            .entry(state_handle)
+            .or_default()
+            .push(SliderBinding { slider_handle });
+    });
+}
+
+pub fn bind_toggle(state_handle: i64, toggle_handle: i64) {
+    TOGGLE_BINDINGS.with(|b| {
+        b.borrow_mut()
+            .entry(state_handle)
+            .or_default()
+            .push(ToggleBinding { toggle_handle });
+    });
+}
+
+pub fn bind_text_template(text_handle: i64, num_parts: i32, types_ptr: *const i32, values_ptr: *const i64) {
+    let mut parts = Vec::new();
+    let mut state_handles = Vec::new();
+
+    for i in 0..num_parts as usize {
+        let part_type = unsafe { *types_ptr.add(i) };
+        let part_value = unsafe { *values_ptr.add(i) };
+
+        if part_type == 0 {
+            let s = str_from_header(part_value as *const u8).to_string();
+            parts.push(TextPart::Literal(s));
+        } else {
+            state_handles.push(part_value);
+            parts.push(TextPart::StateRef(part_value));
+        }
+    }
+
+    MULTI_TEXT_BINDINGS.with(|bindings| {
+        let mut bindings = bindings.borrow_mut();
+        let idx = bindings.len();
+        bindings.push(MultiTextBinding { text_handle, parts });
+
+        MULTI_TEXT_INDEX.with(|index| {
+            let mut index = index.borrow_mut();
+            for &sh in &state_handles {
+                index.entry(sh).or_default().push(idx);
+            }
+        });
+    });
+}
+
+pub fn bind_visibility(state_handle: i64, show_handle: i64, hide_handle: i64) {
+    VISIBILITY_BINDINGS.with(|b| {
+        b.borrow_mut()
+            .entry(state_handle)
+            .or_default()
+            .push(VisibilityBinding { show_handle, hide_handle });
+    });
+    let value = state_get(state_handle);
+    let truthy = is_truthy_f64(value);
+    widgets::set_hidden(show_handle, !truthy);
+    if hide_handle != 0 {
+        widgets::set_hidden(hide_handle, truthy);
+    }
+}
+
+pub fn for_each_init(container_handle: i64, state_handle: i64, render_closure: f64) {
+    let count = state_get(state_handle);
+    render_for_each(container_handle, render_closure, count);
+
+    FOR_EACH_BINDINGS.with(|b| {
+        b.borrow_mut()
+            .entry(state_handle)
+            .or_default()
+            .push(ForEachBinding { container_handle, render_closure });
+    });
+}
+
+/// Bind a textfield to a state cell (two-way binding).
+pub fn bind_textfield(state_handle: i64, textfield_handle: i64) {
+    TEXTFIELD_BINDINGS.with(|b| {
+        b.borrow_mut()
+            .entry(state_handle)
+            .or_default()
+            .push(TextFieldBinding { textfield_handle });
+    });
+}
+
+/// Register a callback to be invoked whenever a state cell changes.
+pub fn state_on_change(state_handle: i64, callback: f64) {
+    ON_CHANGE_CALLBACKS.with(|cbs| {
+        cbs.borrow_mut()
+            .entry(state_handle)
+            .or_default()
+            .push(callback);
+    });
+}

--- a/crates/perry-ui-visionos/src/websocket.rs
+++ b/crates/perry-ui-visionos/src/websocket.rs
@@ -1,0 +1,370 @@
+//! Native iOS WebSocket using NSURLSessionWebSocketTask.
+//!
+//! Bypasses tokio (which doesn't work on iOS) and uses Apple's
+//! native networking stack instead.
+
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject, Sel};
+use objc2::{msg_send, define_class, DefinedClass, AnyThread};
+use objc2_foundation::{NSObject, NSString};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+extern "C" {
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_nanbox_string(ptr: i64) -> f64;
+}
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// Per-connection state — stores raw pointers to avoid objc2 Retained issues
+struct WsConn {
+    /// Raw pointer to NSURLSessionWebSocketTask (retained via CFRetain)
+    task: *const AnyObject,
+    /// Raw pointer to NSURLSession (retained via CFRetain)
+    session: *const AnyObject,
+    is_open: bool,
+    messages: Vec<String>,
+}
+
+// Safety: WsConn is only accessed from the main thread (thread_local)
+unsafe impl Send for WsConn {}
+
+thread_local! {
+    static CONNECTIONS: RefCell<HashMap<u32, WsConn>> = RefCell::new(HashMap::new());
+    static NEXT_ID: RefCell<u32> = RefCell::new(1);
+}
+
+extern "C" {
+    fn CFRetain(cf: *const std::ffi::c_void) -> *const std::ffi::c_void;
+    fn CFRelease(cf: *const std::ffi::c_void);
+}
+
+/// Delegate that receives open/close WebSocket events.
+pub struct WsDelegateIvars {
+    conn_id: std::cell::Cell<u32>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryWsDelegate"]
+    #[ivars = WsDelegateIvars]
+    pub struct PerryWsDelegate;
+
+    impl PerryWsDelegate {
+        #[unsafe(method(URLSession:webSocketTask:didOpenWithProtocol:))]
+        fn did_open(&self, _session: &AnyObject, _task: &AnyObject, _protocol: Option<&NSString>) {
+            let cid = self.ivars().conn_id.get();
+            crate::ws_log!("[WS-iOS] didOpen for conn_id={}", cid);
+            CONNECTIONS.with(|conns| {
+                if let Some(conn) = conns.borrow_mut().get_mut(&cid) {
+                    conn.is_open = true;
+                    // Start receiving messages now that we're connected
+                    schedule_receive_raw(cid, conn.task);
+                }
+            });
+        }
+
+        #[unsafe(method(URLSession:webSocketTask:didCloseWithCode:reason:))]
+        fn did_close(&self, _session: &AnyObject, _task: &AnyObject, _code: i64, _reason: Option<&AnyObject>) {
+            let cid = self.ivars().conn_id.get();
+            crate::ws_log!("[WS-iOS] didClose for conn_id={}, code={}", cid, _code);
+            CONNECTIONS.with(|conns| {
+                if let Some(conn) = conns.borrow_mut().get_mut(&cid) {
+                    conn.is_open = false;
+                }
+            });
+        }
+
+        #[unsafe(method(URLSession:task:didCompleteWithError:))]
+        fn did_complete(&self, _session: &AnyObject, _task: &AnyObject, error: Option<&AnyObject>) {
+            let cid = self.ivars().conn_id.get();
+            if let Some(err) = error {
+                let desc: *const NSString = unsafe { msg_send![err, localizedDescription] };
+                if !desc.is_null() {
+                    let msg = unsafe { (*desc).to_string() };
+                    crate::ws_log!("[WS-iOS] didCompleteWithError conn_id={}: {}", cid, msg);
+                } else {
+                    crate::ws_log!("[WS-iOS] didCompleteWithError conn_id={}: (no description)", cid);
+                }
+            } else {
+                crate::ws_log!("[WS-iOS] didComplete conn_id={} (no error)", cid);
+            }
+            CONNECTIONS.with(|conns| {
+                if let Some(conn) = conns.borrow_mut().get_mut(&cid) {
+                    conn.is_open = false;
+                }
+            });
+        }
+    }
+);
+
+impl PerryWsDelegate {
+    fn new(conn_id: u32) -> Retained<Self> {
+        let this = Self::alloc().set_ivars(WsDelegateIvars {
+            conn_id: std::cell::Cell::new(conn_id),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+/// Schedule receiving one message, then re-schedule on success.
+fn schedule_receive_raw(conn_id: u32, task_ptr: *const AnyObject) {
+    crate::ws_log!("[WS-iOS] schedule_receive_raw conn_id={} task_null={}", conn_id, task_ptr.is_null());
+    if task_ptr.is_null() {
+        return;
+    }
+    unsafe {
+        let block = block2::RcBlock::new(move |message: *const AnyObject, error: *const AnyObject| {
+            if !error.is_null() || message.is_null() {
+                // Error or nil message — connection likely closed
+                if !error.is_null() {
+                    let desc: *const NSString = msg_send![error, localizedDescription];
+                    if !desc.is_null() {
+                        crate::ws_log!("[WS-iOS] recv error conn_id={}: {}", conn_id, (*desc).to_string());
+                    }
+                } else {
+                    crate::ws_log!("[WS-iOS] recv nil message conn_id={}", conn_id);
+                }
+                CONNECTIONS.with(|conns| {
+                    if let Some(conn) = conns.borrow_mut().get_mut(&conn_id) {
+                        conn.is_open = false;
+                    }
+                });
+                return;
+            }
+            // NSURLSessionWebSocketMessage: type 0=data, 1=string
+            let msg_type: i64 = msg_send![message, type];
+            if msg_type == 1 {
+                let ns_string: *const NSString = msg_send![message, string];
+                if !ns_string.is_null() {
+                    let rust_string = (*ns_string).to_string();
+                    crate::ws_log!("[WS-iOS] recv conn_id={} len={} first80={}", conn_id, rust_string.len(), &rust_string[..rust_string.len().min(80)]);
+                    CONNECTIONS.with(|conns| {
+                        if let Some(conn) = conns.borrow_mut().get_mut(&conn_id) {
+                            conn.messages.push(rust_string);
+                        }
+                    });
+                }
+            }
+            // Re-schedule next receive
+            let still_open = CONNECTIONS.with(|conns| {
+                conns.borrow().get(&conn_id).map(|c| c.is_open).unwrap_or(false)
+            });
+            crate::ws_log!("[WS-iOS] re-schedule? still_open={}", still_open);
+            if still_open {
+                schedule_receive_raw(conn_id, task_ptr);
+            } else {
+                crate::ws_log!("[WS-iOS] NOT re-scheduling, conn closed");
+            }
+        });
+        let _: () = msg_send![task_ptr, receiveMessageWithCompletionHandler: &*block];
+    }
+}
+
+/// Connect to a WebSocket URL. Returns a connection handle (f64).
+pub fn connect(url_ptr: *const u8) -> f64 {
+    let url_str = str_from_header(url_ptr);
+    crate::ws_log!("[WS-iOS] connect called, url={}", url_str);
+    if url_str.is_empty() {
+        crate::ws_log!("[WS-iOS] empty URL, returning 0");
+        return 0.0;
+    }
+
+    let conn_id = NEXT_ID.with(|id| {
+        let current = *id.borrow();
+        *id.borrow_mut() = current + 1;
+        current
+    });
+    crate::ws_log!("[WS-iOS] conn_id={}", conn_id);
+
+    unsafe {
+        let ns_url_str = NSString::from_str(url_str);
+        let url_cls = AnyClass::get(c"NSURL").unwrap();
+        let url: *const AnyObject = msg_send![url_cls, URLWithString: &*ns_url_str];
+        if url.is_null() {
+            crate::ws_log!("[WS-iOS] NSURL is null!");
+            return 0.0;
+        }
+        CFRetain(url as *const _);
+
+        // Create delegate
+        let delegate = PerryWsDelegate::new(conn_id);
+
+        // Create NSURLSession with delegate
+        let config_cls = AnyClass::get(c"NSURLSessionConfiguration").unwrap();
+        let config: *const AnyObject = msg_send![config_cls, defaultSessionConfiguration];
+
+        let session_cls = AnyClass::get(c"NSURLSession").unwrap();
+        // MUST use mainQueue so delegate callbacks fire on the main thread,
+        // where thread_local CONNECTIONS is accessible.
+        let op_queue_cls = AnyClass::get(c"NSOperationQueue").unwrap();
+        let queue: *const AnyObject = msg_send![op_queue_cls, mainQueue];
+        let session: *const AnyObject = msg_send![
+            session_cls,
+            sessionWithConfiguration: config,
+            delegate: &*delegate,
+            delegateQueue: queue
+        ];
+        CFRetain(session as *const _);
+
+        // Create WebSocket task
+        let task: *const AnyObject = msg_send![session, webSocketTaskWithURL: url];
+        CFRetain(task as *const _);
+
+        // Resume (start connecting)
+        let _: () = msg_send![task, resume];
+
+        // Store connection
+        CONNECTIONS.with(|conns| {
+            conns.borrow_mut().insert(conn_id, WsConn {
+                task,
+                session,
+                is_open: false,
+                messages: Vec::new(),
+            });
+        });
+
+        // Keep delegate alive
+        std::mem::forget(delegate);
+
+        // Release our local NSURL ref
+        CFRelease(url as *const _);
+
+        conn_id as f64
+    }
+}
+
+/// Check if a WebSocket connection is open.
+pub fn is_open(handle: f64) -> f64 {
+    let conn_id = handle as u32;
+    CONNECTIONS.with(|conns| {
+        match conns.borrow().get(&conn_id) {
+            Some(conn) if conn.is_open => 1.0,
+            _ => 0.0,
+        }
+    })
+}
+
+/// Get pending message count.
+pub fn message_count(handle: f64) -> f64 {
+    let conn_id = handle as u32;
+    CONNECTIONS.with(|conns| {
+        match conns.borrow().get(&conn_id) {
+            Some(conn) => conn.messages.len() as f64,
+            None => 0.0,
+        }
+    })
+}
+
+/// Receive the next queued message. Returns a NaN-boxed string.
+pub fn receive(handle: f64) -> f64 {
+    let conn_id = handle as u32;
+    CONNECTIONS.with(|conns| {
+        if let Some(conn) = conns.borrow_mut().get_mut(&conn_id) {
+            if !conn.messages.is_empty() {
+                let msg = conn.messages.remove(0);
+                let bytes = msg.as_bytes();
+                unsafe {
+                    let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                    return js_nanbox_string(str_ptr as i64);
+                }
+            }
+        }
+        unsafe {
+            let str_ptr = js_string_from_bytes(std::ptr::null(), 0);
+            js_nanbox_string(str_ptr as i64)
+        }
+    })
+}
+
+/// Send a string message.
+pub fn send(handle: f64, msg_ptr: *const u8) {
+    let conn_id = handle as u32;
+    let msg_str = str_from_header(msg_ptr);
+    if msg_str.is_empty() {
+        return;
+    }
+    CONNECTIONS.with(|conns| {
+        if let Some(conn) = conns.borrow().get(&conn_id) {
+            if conn.is_open && !conn.task.is_null() {
+                unsafe {
+                    let ns_string = NSString::from_str(msg_str);
+                    let msg_cls = AnyClass::get(c"NSURLSessionWebSocketMessage").unwrap();
+                    let ws_msg: *const AnyObject = msg_send![msg_cls, alloc];
+                    let ws_msg: *const AnyObject = msg_send![ws_msg, initWithString: &*ns_string];
+
+                    let block = block2::RcBlock::new(|_error: *const AnyObject| {});
+                    let _: () = msg_send![
+                        conn.task,
+                        sendMessage: ws_msg,
+                        completionHandler: &*block
+                    ];
+                }
+            }
+        }
+    });
+}
+
+// =============================================================================
+// perry_native_ws_* exports — called by perry-stdlib/ws.rs on iOS via extern "C"
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn perry_native_ws_connect(url_ptr: *const u8) -> f64 {
+    connect(url_ptr)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_native_ws_is_open(handle: f64) -> f64 {
+    is_open(handle)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_native_ws_send(handle: f64, msg_ptr: *const u8) {
+    send(handle, msg_ptr)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_native_ws_receive(handle: f64) -> f64 {
+    receive(handle)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_native_ws_message_count(handle: f64) -> f64 {
+    message_count(handle)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_native_ws_close(handle: f64) {
+    close(handle)
+}
+
+/// Close the WebSocket connection.
+pub fn close(handle: f64) {
+    let conn_id = handle as u32;
+    CONNECTIONS.with(|conns| {
+        if let Some(conn) = conns.borrow_mut().get_mut(&conn_id) {
+            conn.is_open = false;
+            if !conn.task.is_null() {
+                unsafe {
+                    let _: () = msg_send![
+                        conn.task,
+                        cancelWithCloseCode: 1000i64,
+                        reason: std::ptr::null::<AnyObject>()
+                    ];
+                }
+            }
+        }
+    });
+}

--- a/crates/perry-ui-visionos/src/widgets/button.rs
+++ b/crates/perry-ui-visionos/src/widgets/button.rs
@@ -1,0 +1,303 @@
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, Sel};
+use objc2::{define_class, msg_send, AnyThread, DefinedClass};
+use objc2_ui_kit::{UIButton, UIView};
+use objc2_foundation::{NSObject, NSString};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+thread_local! {
+    static BUTTON_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+
+extern "C" {
+    fn js_closure_call0(closure: *const u8) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    // dispatch_get_main_queue() is a macro; the actual symbol is _dispatch_main_q
+    static _dispatch_main_q: std::ffi::c_void;
+    fn dispatch_async_f(
+        queue: *const std::ffi::c_void,
+        context: *mut std::ffi::c_void,
+        work: unsafe extern "C" fn(*mut std::ffi::c_void),
+    );
+}
+
+unsafe extern "C" fn button_callback_trampoline(context: *mut std::ffi::c_void) {
+    let _ = std::panic::catch_unwind(|| {
+        let closure_f64 = f64::from_bits(context as u64);
+        let closure_ptr = js_nanbox_get_pointer(closure_f64);
+        js_closure_call0(closure_ptr as *const u8);
+    });
+}
+
+pub struct PerryButtonTargetIvars {
+    callback_key: std::cell::Cell<usize>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryButtonTarget"]
+    #[ivars = PerryButtonTargetIvars]
+    pub struct PerryButtonTarget;
+
+    impl PerryButtonTarget {
+        #[unsafe(method(buttonPressed:))]
+        fn button_pressed(&self, _sender: &AnyObject) {
+            let key = self.ivars().callback_key.get();
+            BUTTON_CALLBACKS.with(|cbs| {
+                if let Some(&closure_f64) = cbs.borrow().get(&key) {
+                    // Dispatch async to avoid modifying the view hierarchy during
+                    // UIKit touch event processing (crashes on iOS 26+).
+                    unsafe {
+                        dispatch_async_f(
+                            &_dispatch_main_q as *const _ as *const std::ffi::c_void,
+                            closure_f64.to_bits() as *mut std::ffi::c_void,
+                            button_callback_trampoline,
+                        );
+                    }
+                }
+            });
+        }
+    }
+);
+
+impl PerryButtonTarget {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryButtonTargetIvars {
+            callback_key: std::cell::Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// Create a UIButton with a label and closure callback.
+pub fn create(label_ptr: *const u8, on_press: f64) -> i64 {
+    let label = str_from_header(label_ptr);
+
+    unsafe {
+        // UIButton.buttonWithType: 0 = UIButtonTypeCustom, 1 = UIButtonTypeSystem
+        let button: Retained<UIButton> = msg_send![
+            objc2::runtime::AnyClass::get(c"UIButton").unwrap(),
+            buttonWithType: 1i64  // UIButtonTypeSystem
+        ];
+
+        let ns_string = NSString::from_str(label);
+        let _: () = msg_send![&*button, setTitle: &*ns_string, forState: 0u64]; // UIControlStateNormal = 0
+        let _: () = msg_send![&*button, setAccessibilityLabel: &*ns_string];
+
+        let _: () = msg_send![&*button, setTranslatesAutoresizingMaskIntoConstraints: false];
+
+        let target = PerryButtonTarget::new();
+        let target_addr = Retained::as_ptr(&target) as usize;
+        target.ivars().callback_key.set(target_addr);
+
+        BUTTON_CALLBACKS.with(|cbs| {
+            cbs.borrow_mut().insert(target_addr, on_press);
+        });
+
+        let sel = Sel::register(c"buttonPressed:");
+        // addTarget:action:forControlEvents: UIControlEventTouchUpInside = 1 << 6 = 64
+        let _: () = msg_send![&*button, addTarget: &*target, action: sel, forControlEvents: 64u64];
+
+        std::mem::forget(target);
+
+        let view: Retained<UIView> = Retained::cast_unchecked(button);
+        let handle = super::register_widget(view);
+        #[cfg(feature = "geisterhand")]
+        {
+            extern "C" { fn perry_geisterhand_register(h: i64, wt: u8, ck: u8, cb: f64, lbl: *const u8); }
+            unsafe { perry_geisterhand_register(handle, 0, 0, on_press, label_ptr); }
+        }
+        handle
+    }
+}
+
+/// Set whether a button has a border (approximated via layer).
+pub fn set_bordered(handle: i64, bordered: bool) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let layer: *const AnyObject = msg_send![&*view, layer];
+            if !layer.is_null() {
+                if bordered {
+                    let _: () = msg_send![layer, setBorderWidth: 1.0f64];
+                    let color: *const AnyObject = msg_send![
+                        objc2::runtime::AnyClass::get(c"UIColor").unwrap(),
+                        systemBlueColor
+                    ];
+                    let cg_color: *const AnyObject = msg_send![color, CGColor];
+                    let _: () = msg_send![layer, setBorderColor: cg_color];
+                    let _: () = msg_send![layer, setCornerRadius: 5.0f64];
+                } else {
+                    let _: () = msg_send![layer, setBorderWidth: 0.0f64];
+                }
+            }
+        }
+    }
+}
+
+/// Set the text color of a button.
+pub fn set_text_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let color: Retained<AnyObject> = msg_send![
+                objc2::runtime::AnyClass::get(c"UIColor").unwrap(),
+                colorWithRed: r,
+                green: g,
+                blue: b,
+                alpha: a
+            ];
+            // setTitleColor:forState: UIControlStateNormal = 0
+            let _: () = msg_send![&*view, setTitleColor: &*color, forState: 0u64];
+        }
+    }
+}
+
+/// Set the title text of a button.
+pub fn set_title(handle: i64, title_ptr: *const u8) {
+    let title = str_from_header(title_ptr);
+    if let Some(view) = super::get_widget(handle) {
+        let ns_title = NSString::from_str(title);
+        unsafe {
+            let _: () = msg_send![&*view, setTitle: &*ns_title, forState: 0u64];
+        }
+    }
+}
+
+/// Set an SF Symbol image on a UIButton.
+pub fn set_image(handle: i64, name_ptr: *const u8) {
+    let name = str_from_header(name_ptr);
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let ns_name = NSString::from_str(name);
+            // UIImage.systemImageNamed:
+            let img_cls = objc2::runtime::AnyClass::get(c"UIImage").unwrap();
+            let img: *mut AnyObject = msg_send![img_cls, systemImageNamed: &*ns_name];
+            if !img.is_null() {
+                // Apply large symbol configuration
+                let config_cls = objc2::runtime::AnyClass::get(c"UIImageSymbolConfiguration");
+                if let Some(config_cls) = config_cls {
+                    // UIImageSymbolScale: 1=small, 2=medium, 3=large
+                    let config: *mut AnyObject = msg_send![
+                        config_cls, configurationWithScale: 3_i64
+                    ];
+                    if !config.is_null() {
+                        let scaled_img: *mut AnyObject = msg_send![img, imageWithConfiguration: config];
+                        if !scaled_img.is_null() {
+                            let _: () = msg_send![&*view, setImage: scaled_img, forState: 0_u64];
+                        } else {
+                            let _: () = msg_send![&*view, setImage: img, forState: 0_u64];
+                        }
+                    } else {
+                        let _: () = msg_send![&*view, setImage: img, forState: 0_u64];
+                    }
+                } else {
+                    let _: () = msg_send![&*view, setImage: img, forState: 0_u64];
+                }
+            }
+        }
+    }
+}
+
+/// Set the image position of a UIButton (no-op on iOS — UIButton handles layout differently).
+pub fn set_image_position(_handle: i64, _position: i64) {
+    // iOS UIButton doesn't have NSImagePosition.
+    // Image placement is controlled by configuration or content edge insets.
+    // No-op for compatibility.
+}
+
+/// Set the tint color of a UIButton (affects SF Symbol icon color).
+pub fn set_content_tint_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let color: objc2::rc::Retained<AnyObject> = msg_send![
+                objc2::runtime::AnyClass::get(c"UIColor").unwrap(),
+                colorWithRed: r,
+                green: g,
+                blue: b,
+                alpha: a
+            ];
+            let _: () = msg_send![&*view, setTintColor: &*color];
+        }
+    }
+}
+
+thread_local! {
+    static TAP_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+
+pub struct PerryTapTargetIvars {
+    callback_key: std::cell::Cell<usize>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryTapTarget"]
+    #[ivars = PerryTapTargetIvars]
+    pub struct PerryTapTarget;
+
+    impl PerryTapTarget {
+        #[unsafe(method(handleTap:))]
+        fn handle_tap(&self, _sender: &AnyObject) {
+            let key = self.ivars().callback_key.get();
+            TAP_CALLBACKS.with(|cbs| {
+                if let Some(&closure_f64) = cbs.borrow().get(&key) {
+                    unsafe {
+                        dispatch_async_f(
+                            &_dispatch_main_q as *const _ as *const std::ffi::c_void,
+                            closure_f64.to_bits() as *mut std::ffi::c_void,
+                            button_callback_trampoline,
+                        );
+                    }
+                }
+            });
+        }
+    }
+);
+
+impl PerryTapTarget {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryTapTargetIvars {
+            callback_key: std::cell::Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+/// Attach a single-tap gesture recognizer to any widget view.
+pub fn set_on_tap(handle: i64, callback: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let target = PerryTapTarget::new();
+            let target_addr = Retained::as_ptr(&target) as usize;
+            target.ivars().callback_key.set(target_addr);
+
+            TAP_CALLBACKS.with(|cbs| {
+                cbs.borrow_mut().insert(target_addr, callback);
+            });
+
+            let sel = Sel::register(c"handleTap:");
+            let gr_cls = objc2::runtime::AnyClass::get(c"UITapGestureRecognizer").unwrap();
+            let recognizer: *mut AnyObject = msg_send![gr_cls, alloc];
+            let recognizer: *mut AnyObject = msg_send![
+                recognizer, initWithTarget: &*target, action: sel
+            ];
+            let _: () = msg_send![recognizer, setNumberOfTapsRequired: 1i64];
+            let _: () = msg_send![&*view, setUserInteractionEnabled: true];
+            let _: () = msg_send![&*view, addGestureRecognizer: recognizer];
+
+            std::mem::forget(target);
+        }
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/canvas.rs
+++ b/crates/perry-ui-visionos/src/widgets/canvas.rs
@@ -1,0 +1,348 @@
+// Canvas widget — custom drawing via Core Graphics
+//
+// Stores a command buffer that replays on each drawRect: call.
+// Commands: MoveTo, LineTo, Stroke, FillGradient, BeginPath, Clear.
+
+use objc2::rc::Retained;
+use objc2::runtime::AnyObject;
+use objc2::{define_class, msg_send, DefinedClass, MainThreadOnly};
+use objc2_ui_kit::UIView;
+use objc2_core_foundation::{CGPoint, CGSize, CGRect};
+use objc2_foundation::{NSObject, MainThreadMarker};
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::c_void;
+
+use super::register_widget;
+
+// Core Graphics C API
+type CGContextRef = *mut c_void;
+type CGColorSpaceRef = *mut c_void;
+type CGGradientRef = *mut c_void;
+type CGFloat = f64;
+
+extern "C" {
+    fn UIGraphicsGetCurrentContext() -> CGContextRef;
+    fn CGContextSaveGState(c: CGContextRef);
+    fn CGContextRestoreGState(c: CGContextRef);
+    fn CGContextBeginPath(c: CGContextRef);
+    fn CGContextMoveToPoint(c: CGContextRef, x: CGFloat, y: CGFloat);
+    fn CGContextAddLineToPoint(c: CGContextRef, x: CGFloat, y: CGFloat);
+    fn CGContextStrokePath(c: CGContextRef);
+    fn CGContextClosePath(c: CGContextRef);
+    fn CGContextClip(c: CGContextRef);
+    fn CGContextSetLineWidth(c: CGContextRef, width: CGFloat);
+    fn CGContextSetLineCap(c: CGContextRef, cap: i32);
+    fn CGContextSetLineJoin(c: CGContextRef, join: i32);
+    fn CGContextSetRGBStrokeColor(c: CGContextRef, r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat);
+    fn CGContextDrawLinearGradient(
+        c: CGContextRef, gradient: CGGradientRef,
+        start_point: CGPoint, end_point: CGPoint, options: u32,
+    );
+    fn CGColorSpaceCreateDeviceRGB() -> CGColorSpaceRef;
+    fn CGColorSpaceRelease(space: CGColorSpaceRef);
+    fn CGGradientCreateWithColorComponents(
+        space: CGColorSpaceRef, components: *const CGFloat,
+        locations: *const CGFloat, count: usize,
+    ) -> CGGradientRef;
+    fn CGGradientRelease(gradient: CGGradientRef);
+}
+
+// Drawing commands stored in command buffer
+#[derive(Clone)]
+enum DrawCommand {
+    BeginPath,
+    MoveTo(f64, f64),
+    LineTo(f64, f64),
+    Stroke { r: f64, g: f64, b: f64, a: f64, line_width: f64 },
+    FillGradient {
+        r1: f64, g1: f64, b1: f64, a1: f64,
+        r2: f64, g2: f64, b2: f64, a2: f64,
+        direction: f64,
+    },
+}
+
+thread_local! {
+    /// Canvas command buffers, keyed by view address
+    static CANVAS_COMMANDS: RefCell<HashMap<usize, Vec<DrawCommand>>> = RefCell::new(HashMap::new());
+    /// Canvas sizes (width, height), keyed by view address
+    static CANVAS_SIZES: RefCell<HashMap<usize, (f64, f64)>> = RefCell::new(HashMap::new());
+}
+
+// Custom UIView subclass for canvas drawing
+pub struct PerryCanvasViewIvars {
+    view_key: std::cell::Cell<usize>,
+}
+
+define_class!(
+    #[unsafe(super(UIView))]
+    #[name = "PerryCanvasView"]
+    #[ivars = PerryCanvasViewIvars]
+    pub struct PerryCanvasView;
+
+    impl PerryCanvasView {
+        #[unsafe(method(drawRect:))]
+        fn draw_rect(&self, _dirty_rect: CGRect) {
+            let key = self.ivars().view_key.get();
+
+            // Get the current graphics context (iOS)
+            let ctx: CGContextRef = unsafe { UIGraphicsGetCurrentContext() };
+            if ctx.is_null() { return; }
+
+            // Get canvas size for gradient direction
+            let (canvas_w, canvas_h) = CANVAS_SIZES.with(|s| {
+                s.borrow().get(&key).copied().unwrap_or((0.0, 0.0))
+            });
+
+            // Replay command buffer
+            CANVAS_COMMANDS.with(|cmds| {
+                let cmds = cmds.borrow();
+                if let Some(commands) = cmds.get(&key) {
+                    // Track current path points for gradient fill
+                    let mut path_points: Vec<(f64, f64)> = Vec::new();
+                    let mut in_path = false;
+
+                    for cmd in commands.iter() {
+                        match cmd {
+                            DrawCommand::BeginPath => {
+                                path_points.clear();
+                                in_path = true;
+                            }
+                            DrawCommand::MoveTo(x, y) => {
+                                // No Y-flipping on iOS (origin is top-left)
+                                path_points.push((*x, *y));
+                            }
+                            DrawCommand::LineTo(x, y) => {
+                                path_points.push((*x, *y));
+                            }
+                            DrawCommand::Stroke { r, g, b, a, line_width } => {
+                                if path_points.len() >= 2 {
+                                    unsafe {
+                                        CGContextSaveGState(ctx);
+                                        CGContextSetRGBStrokeColor(ctx, *r, *g, *b, *a);
+                                        CGContextSetLineWidth(ctx, *line_width);
+                                        CGContextSetLineCap(ctx, 1); // kCGLineCapRound
+                                        CGContextSetLineJoin(ctx, 1); // kCGLineJoinRound
+                                        CGContextBeginPath(ctx);
+                                        CGContextMoveToPoint(ctx, path_points[0].0, path_points[0].1);
+                                        for pt in &path_points[1..] {
+                                            CGContextAddLineToPoint(ctx, pt.0, pt.1);
+                                        }
+                                        CGContextStrokePath(ctx);
+                                        CGContextRestoreGState(ctx);
+                                    }
+                                }
+                                in_path = false;
+                            }
+                            DrawCommand::FillGradient { r1, g1, b1, a1, r2, g2, b2, a2, direction } => {
+                                if path_points.len() >= 2 {
+                                    unsafe {
+                                        CGContextSaveGState(ctx);
+
+                                        // Build closed path for clipping
+                                        CGContextBeginPath(ctx);
+                                        CGContextMoveToPoint(ctx, path_points[0].0, path_points[0].1);
+                                        for pt in &path_points[1..] {
+                                            CGContextAddLineToPoint(ctx, pt.0, pt.1);
+                                        }
+                                        // Close to bottom (iOS: larger Y = lower on screen)
+                                        let last_x = path_points[path_points.len() - 1].0;
+                                        let first_x = path_points[0].0;
+                                        CGContextAddLineToPoint(ctx, last_x, canvas_h); // bottom-right
+                                        CGContextAddLineToPoint(ctx, first_x, canvas_h); // bottom-left
+                                        CGContextClosePath(ctx);
+                                        CGContextClip(ctx);
+
+                                        // Draw gradient
+                                        let color_space = CGColorSpaceCreateDeviceRGB();
+                                        let components: [CGFloat; 8] = [
+                                            *r1, *g1, *b1, *a1,
+                                            *r2, *g2, *b2, *a2,
+                                        ];
+                                        let locations: [CGFloat; 2] = [0.0, 1.0];
+                                        let gradient = CGGradientCreateWithColorComponents(
+                                            color_space,
+                                            components.as_ptr(),
+                                            locations.as_ptr(),
+                                            2,
+                                        );
+
+                                        let (start, end) = if *direction < 0.5 {
+                                            // Vertical: top to bottom (iOS: 0,0 is top-left)
+                                            (CGPoint::new(0.0, 0.0), CGPoint::new(0.0, canvas_h))
+                                        } else {
+                                            // Horizontal: left to right
+                                            (CGPoint::new(0.0, 0.0), CGPoint::new(canvas_w, 0.0))
+                                        };
+
+                                        CGContextDrawLinearGradient(ctx, gradient, start, end, 0);
+                                        CGGradientRelease(gradient);
+                                        CGColorSpaceRelease(color_space);
+                                        CGContextRestoreGState(ctx);
+                                    }
+                                }
+                                in_path = false;
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+);
+
+impl PerryCanvasView {
+    fn new(width: f64, height: f64, mtm: MainThreadMarker) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(PerryCanvasViewIvars {
+            view_key: std::cell::Cell::new(0),
+        });
+        let view: Retained<Self> = unsafe { msg_send![super(this), init] };
+
+        let frame = CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(width, height));
+        unsafe {
+            let _: () = msg_send![&*view, setFrame: frame];
+        }
+
+        // Set opaque=false so background is transparent
+        unsafe {
+            let _: () = msg_send![&*view, setOpaque: false];
+        }
+
+        // Set a fixed size via Auto Layout constraints
+        unsafe {
+            let _: () = msg_send![&*view, setTranslatesAutoresizingMaskIntoConstraints: false];
+            let width_anchor: Retained<AnyObject> = msg_send![
+                &*view, widthAnchor
+            ];
+            let constraint: Retained<AnyObject> = msg_send![
+                &*width_anchor, constraintEqualToConstant: width
+            ];
+            let _: () = msg_send![&*constraint, setActive: true];
+
+            let height_anchor: Retained<AnyObject> = msg_send![
+                &*view, heightAnchor
+            ];
+            let h_constraint: Retained<AnyObject> = msg_send![
+                &*height_anchor, constraintEqualToConstant: height
+            ];
+            let _: () = msg_send![&*h_constraint, setActive: true];
+        }
+
+        view
+    }
+}
+
+/// Create a Canvas widget with given dimensions.
+pub fn create(width: f64, height: f64) -> i64 {
+    let mtm = MainThreadMarker::new().expect("perry/ui must run on main thread");
+    let view = PerryCanvasView::new(width, height, mtm);
+    let key = Retained::as_ptr(&view) as usize;
+    view.ivars().view_key.set(key);
+
+    CANVAS_COMMANDS.with(|cmds| {
+        cmds.borrow_mut().insert(key, Vec::new());
+    });
+    CANVAS_SIZES.with(|s| {
+        s.borrow_mut().insert(key, (width, height));
+    });
+
+    // Cast to UIView for registration
+    let ui_view: Retained<UIView> = unsafe {
+        Retained::cast_unchecked(view)
+    };
+    register_widget(ui_view)
+}
+
+fn get_canvas_key(handle: i64) -> Option<usize> {
+    super::get_widget(handle).map(|view| Retained::as_ptr(&view) as usize)
+}
+
+/// Clear all drawing commands.
+pub fn clear(handle: i64) {
+    if let Some(key) = get_canvas_key(handle) {
+        CANVAS_COMMANDS.with(|cmds| {
+            if let Some(commands) = cmds.borrow_mut().get_mut(&key) {
+                commands.clear();
+            }
+        });
+        // Trigger redraw (UIView: setNeedsDisplay with no argument)
+        if let Some(view) = super::get_widget(handle) {
+            unsafe {
+                let _: () = msg_send![&*view, setNeedsDisplay];
+            }
+        }
+    }
+}
+
+/// Begin a new path.
+pub fn begin_path(handle: i64) {
+    if let Some(key) = get_canvas_key(handle) {
+        CANVAS_COMMANDS.with(|cmds| {
+            if let Some(commands) = cmds.borrow_mut().get_mut(&key) {
+                commands.push(DrawCommand::BeginPath);
+            }
+        });
+    }
+}
+
+/// Move pen to point.
+pub fn move_to(handle: i64, x: f64, y: f64) {
+    if let Some(key) = get_canvas_key(handle) {
+        CANVAS_COMMANDS.with(|cmds| {
+            if let Some(commands) = cmds.borrow_mut().get_mut(&key) {
+                commands.push(DrawCommand::MoveTo(x, y));
+            }
+        });
+    }
+}
+
+/// Line to point.
+pub fn line_to(handle: i64, x: f64, y: f64) {
+    if let Some(key) = get_canvas_key(handle) {
+        CANVAS_COMMANDS.with(|cmds| {
+            if let Some(commands) = cmds.borrow_mut().get_mut(&key) {
+                commands.push(DrawCommand::LineTo(x, y));
+            }
+        });
+    }
+}
+
+/// Stroke the current path.
+pub fn stroke(handle: i64, r: f64, g: f64, b: f64, a: f64, line_width: f64) {
+    if let Some(key) = get_canvas_key(handle) {
+        CANVAS_COMMANDS.with(|cmds| {
+            if let Some(commands) = cmds.borrow_mut().get_mut(&key) {
+                commands.push(DrawCommand::Stroke { r, g, b, a, line_width });
+            }
+        });
+        // Trigger redraw
+        if let Some(view) = super::get_widget(handle) {
+            unsafe {
+                let _: () = msg_send![&*view, setNeedsDisplay];
+            }
+        }
+    }
+}
+
+/// Fill the current path area with a gradient.
+pub fn fill_gradient(
+    handle: i64, r1: f64, g1: f64, b1: f64, a1: f64,
+    r2: f64, g2: f64, b2: f64, a2: f64, direction: f64,
+) {
+    if let Some(key) = get_canvas_key(handle) {
+        CANVAS_COMMANDS.with(|cmds| {
+            if let Some(commands) = cmds.borrow_mut().get_mut(&key) {
+                commands.push(DrawCommand::FillGradient {
+                    r1, g1, b1, a1, r2, g2, b2, a2, direction,
+                });
+            }
+        });
+        // Trigger redraw
+        if let Some(view) = super::get_widget(handle) {
+            unsafe {
+                let _: () = msg_send![&*view, setNeedsDisplay];
+            }
+        }
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/divider.rs
+++ b/crates/perry-ui-visionos/src/widgets/divider.rs
@@ -1,0 +1,31 @@
+use objc2::rc::Retained;
+use objc2::msg_send;
+use objc2_ui_kit::UIView;
+
+/// Create a horizontal separator (1px UIView with separator color).
+pub fn create() -> i64 {
+    unsafe {
+        let view: Retained<UIView> = msg_send![
+            objc2::runtime::AnyClass::get(c"UIView").unwrap(),
+            new
+        ];
+        let _: () = msg_send![&*view, setTranslatesAutoresizingMaskIntoConstraints: false];
+
+        // Set separator color
+        let color: Retained<objc2::runtime::AnyObject> = msg_send![
+            objc2::runtime::AnyClass::get(c"UIColor").unwrap(),
+            separatorColor
+        ];
+        let _: () = msg_send![&*view, setBackgroundColor: &*color];
+
+        // Height constraint = 1 pixel
+        let height_anchor: *const objc2::runtime::AnyObject = msg_send![&*view, heightAnchor];
+        let constraint: Retained<objc2::runtime::AnyObject> = msg_send![
+            height_anchor,
+            constraintEqualToConstant: 1.0f64
+        ];
+        let _: () = msg_send![&*constraint, setActive: true];
+
+        super::register_widget(view)
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/form.rs
+++ b/crates/perry-ui-visionos/src/widgets/form.rs
@@ -1,0 +1,55 @@
+use objc2::rc::Retained;
+use objc2::msg_send;
+use objc2::runtime::AnyObject;
+use objc2_ui_kit::UIView;
+use objc2_foundation::{NSString, MainThreadMarker};
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+pub fn form_create() -> i64 {
+    let _mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+    unsafe {
+        let stack_cls = objc2::runtime::AnyClass::get(c"UIStackView").unwrap();
+        let obj: *mut AnyObject = msg_send![stack_cls, alloc];
+        let obj: *mut AnyObject = msg_send![obj, init];
+        let stack: Retained<UIView> = Retained::retain(obj as *mut UIView).unwrap();
+        let _: () = msg_send![&*stack, setAxis: 1i64]; // vertical
+        let _: () = msg_send![&*stack, setSpacing: 16.0f64];
+        super::register_widget(stack)
+    }
+}
+
+pub fn section_create(title_ptr: *const u8) -> i64 {
+    let title = str_from_header(title_ptr);
+    let _mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+    unsafe {
+        let stack_cls = objc2::runtime::AnyClass::get(c"UIStackView").unwrap();
+        let obj: *mut AnyObject = msg_send![stack_cls, alloc];
+        let obj: *mut AnyObject = msg_send![obj, init];
+        let stack: Retained<UIView> = Retained::retain(obj as *mut UIView).unwrap();
+        let _: () = msg_send![&*stack, setAxis: 1i64]; // vertical
+        let _: () = msg_send![&*stack, setSpacing: 8.0f64];
+
+        // Add title label if non-empty
+        if !title.is_empty() {
+            let label_cls = objc2::runtime::AnyClass::get(c"UILabel").unwrap();
+            let lbl: *mut AnyObject = msg_send![label_cls, new];
+            let label: Retained<UIView> = Retained::retain(lbl as *mut UIView).unwrap();
+            let ns_title = NSString::from_str(title);
+            let _: () = msg_send![&*label, setText: &*ns_title];
+            let _: () = msg_send![&*stack, addArrangedSubview: &*label];
+        }
+
+        super::register_widget(stack)
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/hstack.rs
+++ b/crates/perry-ui-visionos/src/widgets/hstack.rs
@@ -1,0 +1,44 @@
+use objc2::rc::Retained;
+use objc2::msg_send;
+use objc2_ui_kit::{UIStackView, UIView};
+
+/// Create a UIStackView with horizontal axis.
+pub fn create(spacing: f64) -> i64 {
+    unsafe {
+        let stack: Retained<UIStackView> = msg_send![
+            objc2::runtime::AnyClass::get(c"UIStackView").unwrap(),
+            new
+        ];
+        let _: () = msg_send![&*stack, setAxis: 0i64]; // UILayoutConstraintAxisHorizontal = 0
+        let _: () = msg_send![&*stack, setSpacing: spacing as objc2_core_foundation::CGFloat];
+        let _: () = msg_send![&*stack, setAlignment: 3i64]; // UIStackViewAlignmentCenter = 3 (CenterY)
+        let _: () = msg_send![&*stack, setDistribution: 0i64]; // UIStackViewDistributionFill = 0
+        let _: () = msg_send![&*stack, setTranslatesAutoresizingMaskIntoConstraints: false];
+
+        let view: Retained<UIView> = Retained::cast_unchecked(stack);
+        super::register_widget(view)
+    }
+}
+
+/// Create a UIStackView with horizontal axis and custom edge insets.
+pub fn create_with_insets(spacing: f64, top: f64, left: f64, bottom: f64, right: f64) -> i64 {
+    unsafe {
+        let stack: Retained<UIStackView> = msg_send![
+            objc2::runtime::AnyClass::get(c"UIStackView").unwrap(),
+            new
+        ];
+        let _: () = msg_send![&*stack, setAxis: 0i64];
+        let _: () = msg_send![&*stack, setSpacing: spacing as objc2_core_foundation::CGFloat];
+        let _: () = msg_send![&*stack, setAlignment: 3i64];
+        let _: () = msg_send![&*stack, setDistribution: 0i64]; // UIStackViewDistributionFill = 0
+        let _: () = msg_send![&*stack, setTranslatesAutoresizingMaskIntoConstraints: false];
+
+        let insets = super::vstack::UIEdgeInsets { top, left, bottom, right };
+        let _: () = msg_send![&*stack, setLayoutMargins: insets];
+        let _: () = msg_send![&*stack, setLayoutMarginsRelativeArrangement: true];
+        let _: () = msg_send![&*stack, setInsetsLayoutMarginsFromSafeArea: false];
+
+        let view: Retained<UIView> = Retained::cast_unchecked(stack);
+        super::register_widget(view)
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/image.rs
+++ b/crates/perry-ui-visionos/src/widgets/image.rs
@@ -1,0 +1,98 @@
+use objc2::rc::Retained;
+use objc2::msg_send;
+use objc2::runtime::AnyObject;
+use objc2_ui_kit::UIView;
+use objc2_foundation::{NSString, MainThreadMarker};
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+pub fn create_symbol(name_ptr: *const u8) -> i64 {
+    let name = str_from_header(name_ptr);
+    let _mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+    unsafe {
+        let ns_name = NSString::from_str(name);
+        let image_cls = objc2::runtime::AnyClass::get(c"UIImage").unwrap();
+        let image: *mut objc2::runtime::AnyObject = msg_send![image_cls, systemImageNamed: &*ns_name];
+        let iv_cls = objc2::runtime::AnyClass::get(c"UIImageView").unwrap();
+        let obj: *mut AnyObject = msg_send![iv_cls, alloc];
+        let obj: *mut AnyObject = msg_send![obj, initWithImage: image];
+        let image_view: Retained<UIView> = Retained::retain(obj as *mut UIView).unwrap();
+        super::register_widget(image_view)
+    }
+}
+
+pub fn create_file(path_ptr: *const u8) -> i64 {
+    let path = str_from_header(path_ptr);
+    let _mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+    unsafe {
+        // Resolve relative paths against the app bundle's resource directory
+        let resolved = if !path.starts_with('/') {
+            let bundle_cls = objc2::runtime::AnyClass::get(c"NSBundle").unwrap();
+            let main_bundle: *mut AnyObject = msg_send![bundle_cls, mainBundle];
+            let res_path: *mut AnyObject = msg_send![main_bundle, resourcePath];
+            if !res_path.is_null() {
+                let res_str: *const AnyObject = msg_send![res_path, UTF8String];
+                let c_str = std::ffi::CStr::from_ptr(res_str as *const i8);
+                format!("{}/{}", c_str.to_str().unwrap_or(""), path)
+            } else {
+                path.to_string()
+            }
+        } else {
+            path.to_string()
+        };
+        let ns_path = NSString::from_str(&resolved);
+        let image_cls = objc2::runtime::AnyClass::get(c"UIImage").unwrap();
+        let image: *mut AnyObject = msg_send![image_cls, imageWithContentsOfFile: &*ns_path];
+        if image.is_null() {
+            eprintln!("[perry-ui-ios] ImageFile: failed to load image at path: {}", resolved);
+        }
+        let iv_cls = objc2::runtime::AnyClass::get(c"UIImageView").unwrap();
+        let obj: *mut AnyObject = msg_send![iv_cls, alloc];
+        let obj: *mut AnyObject = msg_send![obj, initWithImage: image];
+        if obj.is_null() {
+            // Image not found — create an empty UIImageView instead of crashing
+            eprintln!("[perry-ui-ios] ImageFile: initWithImage returned nil for path: {}", resolved);
+            let obj: *mut AnyObject = msg_send![iv_cls, new];
+            let image_view: Retained<UIView> = Retained::retain(obj as *mut UIView).unwrap();
+            return super::register_widget(image_view);
+        }
+        // Set content mode to ScaleAspectFit so the image scales properly with constraints
+        let _: () = msg_send![obj, setContentMode: 1i64]; // UIViewContentModeScaleAspectFit
+        let image_view: Retained<UIView> = Retained::retain(obj as *mut UIView).unwrap();
+        super::register_widget(image_view)
+    }
+}
+
+pub fn set_size(handle: i64, width: f64, height: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let frame = objc2_core_foundation::CGRect::new(
+                objc2_core_foundation::CGPoint::new(0.0, 0.0),
+                objc2_core_foundation::CGSize::new(width, height),
+            );
+            let _: () = msg_send![&*view, setFrame: frame];
+        }
+    }
+}
+
+pub fn set_tint(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let color_cls = objc2::runtime::AnyClass::get(c"UIColor").unwrap();
+            let color: *mut objc2::runtime::AnyObject = msg_send![
+                color_cls, colorWithRed: r as f64, green: g as f64, blue: b as f64, alpha: a as f64
+            ];
+            let _: () = msg_send![&*view, setTintColor: color];
+        }
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/mod.rs
+++ b/crates/perry-ui-visionos/src/widgets/mod.rs
@@ -1,0 +1,701 @@
+pub mod text;
+pub mod button;
+pub mod vstack;
+pub mod hstack;
+pub mod spacer;
+pub mod divider;
+pub mod textarea;
+pub mod textfield;
+pub mod securefield;
+pub mod toggle;
+pub mod slider;
+pub mod scrollview;
+pub mod canvas;
+pub mod progressview;
+pub mod image;
+pub mod picker;
+pub mod form;
+pub mod navstack;
+pub mod zstack;
+pub mod tabbar;
+pub mod qrcode;
+pub mod splitview;
+
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject};
+use objc2_foundation::NSObjectProtocol;
+use objc2_ui_kit::{UIView, UIStackView};
+use std::cell::RefCell;
+use std::ffi::c_void;
+
+thread_local! {
+    /// Map from widget handle (1-based) to UIView
+    static WIDGETS: RefCell<Vec<Retained<UIView>>> = RefCell::new(Vec::new());
+    /// Stored height constraints per widget handle, so set_height can update instead of duplicate.
+    static HEIGHT_CONSTRAINTS: RefCell<std::collections::HashMap<i64, Retained<AnyObject>>> = RefCell::new(std::collections::HashMap::new());
+}
+
+/// Store a UIView and return its handle (1-based i64).
+pub fn register_widget(view: Retained<UIView>) -> i64 {
+    let handle = WIDGETS.with(|w| {
+        let mut widgets = w.borrow_mut();
+        widgets.push(view.clone());
+        widgets.len() as i64
+    });
+    #[cfg(feature = "geisterhand")]
+    {
+        use objc2_foundation::NSString;
+        let id_str = format!("gh-{}", handle);
+        let ns_id = NSString::from_str(&id_str);
+        unsafe {
+            let _: () = objc2::msg_send![&*view, setAccessibilityIdentifier: &*ns_id];
+        }
+    }
+    handle
+}
+
+#[cfg(feature = "geisterhand")]
+fn alloc_string_result(s: &str, out_len: *mut usize) -> *mut u8 {
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let buf = unsafe { libc::malloc(len) as *mut u8 };
+    if buf.is_null() { return std::ptr::null_mut(); }
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, len);
+        *out_len = len;
+    }
+    buf
+}
+
+/// Read the current value of a widget by handle (UITextField → text, UISlider → value, UISwitch → isOn).
+#[cfg(feature = "geisterhand")]
+#[no_mangle]
+pub extern "C" fn perry_ui_read_widget_value(handle: i64, out_len: *mut usize) -> *mut u8 {
+    unsafe { *out_len = 0; }
+    if let Some(view) = get_widget(handle) {
+        unsafe {
+            if let Some(tf_cls) = objc2::runtime::AnyClass::get(c"UITextField") {
+                let is_tf: bool = objc2::msg_send![&*view, isKindOfClass: tf_cls];
+                if is_tf {
+                    let val: *const objc2::runtime::AnyObject = objc2::msg_send![&*view, text];
+                    if !val.is_null() {
+                        let ns: &objc2_foundation::NSString = &*(val as *const objc2_foundation::NSString);
+                        return alloc_string_result(&ns.to_string(), out_len);
+                    }
+                }
+            }
+            if let Some(slider_cls) = objc2::runtime::AnyClass::get(c"UISlider") {
+                let is_slider: bool = objc2::msg_send![&*view, isKindOfClass: slider_cls];
+                if is_slider {
+                    let val: f32 = objc2::msg_send![&*view, value];
+                    return alloc_string_result(&format!("{}", val), out_len);
+                }
+            }
+            if let Some(switch_cls) = objc2::runtime::AnyClass::get(c"UISwitch") {
+                let is_switch: bool = objc2::msg_send![&*view, isKindOfClass: switch_cls];
+                if is_switch {
+                    let on: bool = objc2::msg_send![&*view, isOn];
+                    return alloc_string_result(if on { "true" } else { "false" }, out_len);
+                }
+            }
+        }
+    }
+    std::ptr::null_mut()
+}
+
+/// Query all widgets and return JSON with handle, visible, and frame data.
+#[cfg(feature = "geisterhand")]
+#[no_mangle]
+pub extern "C" fn perry_ui_query_widget_tree(out_len: *mut usize) -> *mut u8 {
+    use objc2_core_foundation::CGRect;
+    let json = WIDGETS.with(|w| {
+        let widgets = w.borrow();
+        let mut s = String::from("[");
+        for (i, view) in widgets.iter().enumerate() {
+            let handle = (i + 1) as i64;
+            if i > 0 { s.push(','); }
+            unsafe {
+                let hidden: bool = objc2::msg_send![&**view, isHidden];
+                let visible = !hidden;
+                let frame: CGRect = objc2::msg_send![&**view, frame];
+                s.push_str(&format!(
+                    r#"{{"handle":{},"visible":{},"frame":{{"x":{:.0},"y":{:.0},"width":{:.0},"height":{:.0}}}}}"#,
+                    handle, visible, frame.origin.x, frame.origin.y, frame.size.width, frame.size.height
+                ));
+            }
+        }
+        s.push(']');
+        s
+    });
+    let bytes = json.into_bytes();
+    let len = bytes.len();
+    let buf = unsafe { libc::malloc(len) as *mut u8 };
+    if buf.is_null() {
+        unsafe { *out_len = 0; }
+        return std::ptr::null_mut();
+    }
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, len);
+        *out_len = len;
+    }
+    buf
+}
+
+/// Retrieve the UIView for a given handle.
+pub fn get_widget(handle: i64) -> Option<Retained<UIView>> {
+    WIDGETS.with(|w| {
+        let widgets = w.borrow();
+        let idx = (handle - 1) as usize;
+        widgets.get(idx).cloned()
+    })
+}
+
+/// Set the hidden state of a widget.
+pub fn set_hidden(handle: i64, hidden: bool) {
+    if let Some(view) = get_widget(handle) {
+        unsafe {
+            let _: () = objc2::msg_send![&*view, setHidden: hidden];
+        }
+    }
+}
+
+/// Remove all arranged subviews from a container (UIStackView).
+/// Safe implementation: snapshots subviews before mutation, removes in reverse
+/// order, and cleans up HEIGHT_CONSTRAINTS for removed widgets.
+pub fn clear_children(handle: i64) {
+    if let Some(parent) = get_widget(handle) {
+        let is_stack = if let Some(cls) = AnyClass::get(c"UIStackView") {
+            parent.isKindOfClass(cls)
+        } else {
+            false
+        };
+        if is_stack {
+            let stack: &UIStackView = unsafe { &*(Retained::as_ptr(&parent) as *const UIStackView) };
+
+            // Phase 1: Snapshot subviews into a Vec (avoid iterator invalidation)
+            let subviews = stack.arrangedSubviews();
+            let count = subviews.len();
+            let mut views: Vec<Retained<UIView>> = Vec::with_capacity(count);
+            for i in 0..count {
+                let sv: *const UIView = unsafe { objc2::msg_send![&subviews, objectAtIndex: i] };
+                if !sv.is_null() {
+                    if let Some(retained) = unsafe { Retained::retain(sv as *mut UIView) } {
+                        views.push(retained);
+                    }
+                }
+            }
+
+            // Phase 2: Collect handles for cleanup
+            let handles: Vec<i64> = views.iter().filter_map(|sv| {
+                WIDGETS.with(|w| {
+                    let widgets = w.borrow();
+                    for (idx, widget) in widgets.iter().enumerate() {
+                        if std::ptr::eq(Retained::as_ptr(widget), &**sv as *const UIView) {
+                            return Some((idx + 1) as i64);
+                        }
+                    }
+                    None
+                })
+            }).collect();
+
+            // Phase 3: Remove views in reverse order
+            for sv in views.iter().rev() {
+                unsafe {
+                    let _: () = objc2::msg_send![stack, removeArrangedSubview: &**sv];
+                    sv.removeFromSuperview();
+                }
+            }
+
+            // Phase 4: Clean up HEIGHT_CONSTRAINTS for removed widgets
+            for h in &handles {
+                HEIGHT_CONSTRAINTS.with(|hc| {
+                    if let Some(old) = hc.borrow_mut().remove(h) {
+                        unsafe { let _: () = objc2::msg_send![&*old, setActive: false]; }
+                    }
+                });
+            }
+        }
+    }
+}
+
+/// Add a child view to a parent view at a specific index.
+pub fn add_child_at(parent_handle: i64, child_handle: i64, index: i64) {
+    if let (Some(parent), Some(child)) = (get_widget(parent_handle), get_widget(child_handle)) {
+        let is_stack = if let Some(cls) = AnyClass::get(c"UIStackView") {
+            parent.isKindOfClass(cls)
+        } else {
+            false
+        };
+
+        if is_stack {
+            let stack: &UIStackView = unsafe { &*(Retained::as_ptr(&parent) as *const UIStackView) };
+            unsafe {
+                let _: () = objc2::msg_send![stack, insertArrangedSubview: &*child, atIndex: index as usize];
+            }
+        } else {
+            parent.addSubview(&child);
+        }
+    }
+}
+
+/// Add a child view to a parent view.
+/// If the parent is a UIStackView, uses addArrangedSubview for proper layout.
+pub fn add_child(parent_handle: i64, child_handle: i64) {
+    if let (Some(parent), Some(child)) = (get_widget(parent_handle), get_widget(child_handle)) {
+        let is_stack = if let Some(cls) = AnyClass::get(c"UIStackView") {
+            parent.isKindOfClass(cls)
+        } else {
+            false
+        };
+
+        if is_stack {
+            let stack: &UIStackView = unsafe { &*(Retained::as_ptr(&parent) as *const UIStackView) };
+            stack.addArrangedSubview(&child);
+        } else {
+            // Non-stack parent (e.g. ZStack/plain UIView): pin child to fill parent
+            zstack::add_child(parent_handle, child_handle);
+        }
+    }
+}
+
+// =============================================================================
+// Widget Styling (Background, Gradient, Corner Radius)
+// =============================================================================
+
+type CGFloat = f64;
+
+extern "C" {
+    fn CGColorRelease(color: *mut c_void);
+    fn CGColorCreateSRGB(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) -> *mut c_void;
+}
+
+/// Create a retained CGColor from RGBA using CGColorCreateSRGB (iOS 14+).
+/// Returns a +1 retained CGColorRef that must be released with CGColorRelease.
+pub unsafe fn create_cg_color(r: f64, g: f64, b: f64, a: f64) -> *mut c_void {
+    CGColorCreateSRGB(r, g, b, a)
+}
+
+/// Set a solid background color on any widget.
+pub fn set_background_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    if let Some(view) = get_widget(handle) {
+        unsafe {
+            let ui_color: Retained<AnyObject> = objc2::msg_send![
+                AnyClass::get(c"UIColor").unwrap(),
+                colorWithRed: r,
+                green: g,
+                blue: b,
+                alpha: a
+            ];
+            let _: () = objc2::msg_send![&*view, setBackgroundColor: &*ui_color];
+        }
+    }
+}
+
+/// Register a dynamic UIView subclass whose `layoutSubviews` keeps all sublayers
+/// sized to the view's layer bounds. Created once via ObjC runtime.
+fn gradient_bg_class() -> &'static AnyClass {
+    use std::sync::Once;
+    static REGISTER: Once = Once::new();
+    REGISTER.call_once(|| {
+        unsafe {
+            extern "C" {
+                fn objc_allocateClassPair(
+                    superclass: *const AnyClass, name: *const std::ffi::c_char, extra: usize
+                ) -> *mut AnyClass;
+                fn objc_registerClassPair(cls: *mut AnyClass);
+                fn class_addMethod(
+                    cls: *mut AnyClass, sel: objc2::runtime::Sel,
+                    imp: *const std::ffi::c_void, types: *const std::ffi::c_char,
+                ) -> bool;
+            }
+            let superclass = AnyClass::get(c"UIView").unwrap();
+            let cls = objc_allocateClassPair(superclass, c"PerryGradientBGView".as_ptr(), 0);
+            assert!(!cls.is_null(), "Failed to allocate PerryGradientBGView class");
+
+            // Override layoutSubviews to resize all sublayers to layer.bounds
+            extern "C" fn layout_subviews(this: &AnyObject, _cmd: objc2::runtime::Sel) {
+                unsafe {
+                    // Call [super layoutSubviews]
+                    let sup = AnyClass::get(c"UIView").unwrap();
+                    let _: () = objc2::msg_send![super(this, sup), layoutSubviews];
+                    // Resize all sublayers to match layer bounds
+                    let layer: *mut AnyObject = objc2::msg_send![this, layer];
+                    if layer.is_null() { return; }
+                    let bounds: objc2_core_foundation::CGRect = objc2::msg_send![layer, bounds];
+                    let sublayers: *mut AnyObject = objc2::msg_send![layer, sublayers];
+                    if !sublayers.is_null() {
+                        let count: usize = objc2::msg_send![sublayers, count];
+                        for i in 0..count {
+                            let sub: *mut AnyObject = objc2::msg_send![sublayers, objectAtIndex: i];
+                            let _: () = objc2::msg_send![sub, setFrame: bounds];
+                        }
+                    }
+                }
+            }
+            class_addMethod(
+                cls,
+                objc2::sel!(layoutSubviews),
+                layout_subviews as *const std::ffi::c_void,
+                c"v@:".as_ptr(),
+            );
+            objc_registerClassPair(cls);
+        }
+    });
+    AnyClass::get(c"PerryGradientBGView").unwrap()
+}
+
+/// Set a linear gradient background on any widget.
+/// Uses a background UIView subclass (with layoutSubviews override) pinned via Auto Layout.
+/// This ensures the CAGradientLayer always matches the view bounds, even when the
+/// parent starts at zero size (common during init before Auto Layout resolves).
+pub fn set_background_gradient(
+    handle: i64, r1: f64, g1: f64, b1: f64, a1: f64,
+    r2: f64, g2: f64, b2: f64, a2: f64, direction: f64,
+) {
+    if let Some(view) = get_widget(handle) {
+        unsafe {
+            // Remove any existing gradient background view (tagged 9999)
+            let subviews: Retained<AnyObject> = objc2::msg_send![&*view, subviews];
+            let count: usize = objc2::msg_send![&*subviews, count];
+            let mut i = count;
+            while i > 0 {
+                i -= 1;
+                let sub: *mut AnyObject = objc2::msg_send![&*subviews, objectAtIndex: i];
+                let tag: isize = objc2::msg_send![sub, tag];
+                if tag == 9999 {
+                    let _: () = objc2::msg_send![sub, removeFromSuperview];
+                }
+            }
+
+            // Create PerryGradientBGView (overrides layoutSubviews to resize sublayers)
+            let bg_cls = gradient_bg_class();
+            let bg_view: *mut AnyObject = objc2::msg_send![bg_cls, new];
+            let _: () = objc2::msg_send![bg_view, setTag: 9999isize];
+            let _: () = objc2::msg_send![bg_view, setTranslatesAutoresizingMaskIntoConstraints: false];
+            let _: () = objc2::msg_send![bg_view, setUserInteractionEnabled: false];
+
+            // Insert as subview at index 0 (behind arranged subviews / content)
+            let _: () = objc2::msg_send![&*view, insertSubview: bg_view, atIndex: 0isize];
+
+            // Pin bg_view to parent edges via Auto Layout
+            let bg_leading: *mut AnyObject = objc2::msg_send![bg_view, leadingAnchor];
+            let bg_trailing: *mut AnyObject = objc2::msg_send![bg_view, trailingAnchor];
+            let bg_top: *mut AnyObject = objc2::msg_send![bg_view, topAnchor];
+            let bg_bottom: *mut AnyObject = objc2::msg_send![bg_view, bottomAnchor];
+
+            let p_leading: *mut AnyObject = objc2::msg_send![&*view, leadingAnchor];
+            let p_trailing: *mut AnyObject = objc2::msg_send![&*view, trailingAnchor];
+            let p_top: *mut AnyObject = objc2::msg_send![&*view, topAnchor];
+            let p_bottom: *mut AnyObject = objc2::msg_send![&*view, bottomAnchor];
+
+            let c1: *mut AnyObject = objc2::msg_send![bg_leading, constraintEqualToAnchor: p_leading];
+            let c2: *mut AnyObject = objc2::msg_send![bg_trailing, constraintEqualToAnchor: p_trailing];
+            let c3: *mut AnyObject = objc2::msg_send![bg_top, constraintEqualToAnchor: p_top];
+            let c4: *mut AnyObject = objc2::msg_send![bg_bottom, constraintEqualToAnchor: p_bottom];
+
+            let _: () = objc2::msg_send![c1, setActive: true];
+            let _: () = objc2::msg_send![c2, setActive: true];
+            let _: () = objc2::msg_send![c3, setActive: true];
+            let _: () = objc2::msg_send![c4, setActive: true];
+
+            // Create CAGradientLayer on the background view
+            let bg_layer: *mut AnyObject = objc2::msg_send![bg_view, layer];
+            let gradient_cls = AnyClass::get(c"CAGradientLayer")
+                .expect("CAGradientLayer class not found");
+            let gradient: *mut AnyObject = objc2::msg_send![gradient_cls, layer];
+
+            // Create colors
+            let color1 = create_cg_color(r1, g1, b1, a1);
+            let color2 = create_cg_color(r2, g2, b2, a2);
+
+            let colors: Retained<AnyObject> = {
+                let arr_cls = AnyClass::get(c"NSMutableArray").unwrap();
+                let arr: *mut AnyObject = objc2::msg_send![arr_cls, arrayWithCapacity: 2usize];
+                let _: () = objc2::msg_send![arr, addObject: color1 as *mut AnyObject];
+                let _: () = objc2::msg_send![arr, addObject: color2 as *mut AnyObject];
+                Retained::retain(arr).unwrap()
+            };
+            let _: () = objc2::msg_send![gradient, setColors: &*colors];
+            CGColorRelease(color1);
+            CGColorRelease(color2);
+
+            // Set direction
+            if direction < 0.5 {
+                let start = objc2_core_foundation::CGPoint::new(0.5, 0.0);
+                let end = objc2_core_foundation::CGPoint::new(0.5, 1.0);
+                let _: () = objc2::msg_send![gradient, setStartPoint: start];
+                let _: () = objc2::msg_send![gradient, setEndPoint: end];
+            } else {
+                let start = objc2_core_foundation::CGPoint::new(0.0, 0.5);
+                let end = objc2_core_foundation::CGPoint::new(1.0, 0.5);
+                let _: () = objc2::msg_send![gradient, setStartPoint: start];
+                let _: () = objc2::msg_send![gradient, setEndPoint: end];
+            }
+
+            // Add gradient to the background view's layer
+            let _: () = objc2::msg_send![bg_layer, addSublayer: gradient];
+        }
+    }
+}
+
+/// Set corner radius on any widget via its layer.
+pub fn set_corner_radius(handle: i64, radius: f64) {
+    if let Some(view) = get_widget(handle) {
+        unsafe {
+            let layer: *mut AnyObject = objc2::msg_send![&*view, layer];
+            if !layer.is_null() {
+                let _: () = objc2::msg_send![layer, setCornerRadius: radius];
+            }
+            let _: () = objc2::msg_send![&*view, setClipsToBounds: true];
+        }
+    }
+}
+
+/// Set a fixed width constraint on a widget.
+pub fn set_width(handle: i64, width: f64) {
+    if let Some(view) = get_widget(handle) {
+        unsafe {
+            let width_anchor: Retained<AnyObject> = objc2::msg_send![&*view, widthAnchor];
+            let constraint: Retained<AnyObject> = objc2::msg_send![
+                &*width_anchor, constraintEqualToConstant: width
+            ];
+            let _: () = objc2::msg_send![&*constraint, setActive: true];
+        }
+    }
+}
+
+/// Set a fixed height constraint on a widget.
+/// Idempotent: deactivates any previous height constraint before creating a new one.
+pub fn set_height(handle: i64, height: f64) {
+    if let Some(view) = get_widget(handle) {
+        // Deactivate old height constraint if any
+        HEIGHT_CONSTRAINTS.with(|hc| {
+            let mut map = hc.borrow_mut();
+            if let Some(old) = map.remove(&handle) {
+                unsafe {
+                    let _: () = objc2::msg_send![&*old, setActive: false];
+                }
+            }
+        });
+        unsafe {
+            let height_anchor: Retained<AnyObject> = objc2::msg_send![&*view, heightAnchor];
+            let constraint: Retained<AnyObject> = objc2::msg_send![
+                &*height_anchor, constraintEqualToConstant: height
+            ];
+            let _: () = objc2::msg_send![&*constraint, setActive: true];
+            HEIGHT_CONSTRAINTS.with(|hc| {
+                hc.borrow_mut().insert(handle, constraint);
+            });
+        }
+    }
+}
+
+/// Remove a child view from a parent view.
+/// If the parent is a UIStackView, removes from arranged subviews first.
+pub fn remove_child(parent_handle: i64, child_handle: i64) {
+    if let (Some(parent), Some(child)) = (get_widget(parent_handle), get_widget(child_handle)) {
+        let is_stack = if let Some(cls) = AnyClass::get(c"UIStackView") {
+            parent.isKindOfClass(cls)
+        } else {
+            false
+        };
+
+        if is_stack {
+            let stack: &UIStackView = unsafe { &*(Retained::as_ptr(&parent) as *const UIStackView) };
+            unsafe {
+                let _: () = objc2::msg_send![stack, removeArrangedSubview: &*child];
+            }
+        }
+        child.removeFromSuperview();
+    }
+}
+
+/// Reorder a child widget within a parent (UIStackView) by index.
+pub fn reorder_child(parent_handle: i64, from_index: i64, to_index: i64) {
+    if let Some(parent) = get_widget(parent_handle) {
+        let is_stack = if let Some(cls) = AnyClass::get(c"UIStackView") {
+            parent.isKindOfClass(cls)
+        } else {
+            false
+        };
+        if is_stack {
+            let stack: &UIStackView = unsafe { &*(Retained::as_ptr(&parent) as *const UIStackView) };
+            let subviews = stack.arrangedSubviews();
+            let from = from_index as usize;
+            if from < subviews.len() {
+                // Get child at index via objectAtIndex:
+                unsafe {
+                    let child: *mut AnyObject = objc2::msg_send![&*subviews, objectAtIndex: from];
+                    if !child.is_null() {
+                        let _: () = objc2::msg_send![stack, removeArrangedSubview: child];
+                        let _: () = objc2::msg_send![stack, insertArrangedSubview: child, atIndex: to_index as usize];
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Pin a child view's width to match its containing UIStackView.
+pub fn match_parent_width(child_handle: i64) {
+    if let Some(child) = get_widget(child_handle) {
+        unsafe {
+            let stack_cls = AnyClass::get(c"UIStackView");
+            if stack_cls.is_none() { return; }
+            let stack_cls = stack_cls.unwrap();
+            let mut sv: *const UIView = objc2::msg_send![&*child, superview];
+            let mut found_stack: *const UIView = std::ptr::null();
+            let mut depth = 0;
+            while !sv.is_null() && depth < 10 {
+                let is_stack: bool = objc2::msg_send![sv, isKindOfClass: stack_cls];
+                if is_stack {
+                    found_stack = sv;
+                    break;
+                }
+                sv = objc2::msg_send![sv, superview];
+                depth += 1;
+            }
+            if found_stack.is_null() { return; }
+            let child_width: Retained<AnyObject> = objc2::msg_send![&*child, widthAnchor];
+            // Use layoutMarginsGuide so the constraint respects the parent's padding/edge insets
+            let margins_guide: Retained<AnyObject> = objc2::msg_send![found_stack, layoutMarginsGuide];
+            let stack_width: Retained<AnyObject> = objc2::msg_send![&*margins_guide, widthAnchor];
+            let c: Retained<AnyObject> = objc2::msg_send![&*child_width, constraintEqualToAnchor: &*stack_width];
+            let _: () = objc2::msg_send![&*c, setActive: true];
+        }
+    }
+}
+
+/// Pin a child view's top and bottom anchors to its superview, forcing it to
+/// fill the parent's height.
+pub fn match_parent_height(child_handle: i64) {
+    if let Some(child) = get_widget(child_handle) {
+        unsafe {
+            let superview_ptr: *const UIView = objc2::msg_send![&*child, superview];
+            if superview_ptr.is_null() { return; }
+            let child_top: Retained<AnyObject> = objc2::msg_send![&*child, topAnchor];
+            let child_bottom: Retained<AnyObject> = objc2::msg_send![&*child, bottomAnchor];
+            let parent_top: Retained<AnyObject> = objc2::msg_send![superview_ptr, topAnchor];
+            let parent_bottom: Retained<AnyObject> = objc2::msg_send![superview_ptr, bottomAnchor];
+            let top_c: Retained<AnyObject> = objc2::msg_send![&*child_top, constraintEqualToAnchor: &*parent_top];
+            let bot_c: Retained<AnyObject> = objc2::msg_send![&*child_bottom, constraintEqualToAnchor: &*parent_bottom];
+            let _: () = objc2::msg_send![&*top_c, setActive: true];
+            let _: () = objc2::msg_send![&*bot_c, setActive: true];
+        }
+    }
+}
+
+/// Set detachesHiddenViews equivalent — no-op on iOS.
+/// UIStackView on iOS automatically adjusts for hidden views.
+pub fn set_detaches_hidden_views(_handle: i64, _detaches: bool) {
+    // No-op: UIStackView on iOS doesn't have this property.
+    // Hidden arranged subviews are automatically excluded from layout.
+}
+
+/// Set the content hugging priority for both axes.
+pub fn set_hugging_priority(handle: i64, priority: f64) {
+    if let Some(view) = get_widget(handle) {
+        unsafe {
+            let p = priority as f32;
+            // UILayoutConstraintAxis: 0 = Horizontal, 1 = Vertical
+            let _: () = objc2::msg_send![&*view, setContentHuggingPriority: p, forAxis: 0isize];
+            let _: () = objc2::msg_send![&*view, setContentHuggingPriority: p, forAxis: 1isize];
+        }
+    }
+}
+
+// =============================================================================
+// Cross-cutting: Enabled, Hover, DoubleClick, Animations, Tooltip, ControlSize
+// =============================================================================
+
+use std::collections::HashMap;
+
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+}
+
+thread_local! {
+    static DOUBLE_CLICK_CALLBACKS: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
+}
+
+/// Set the enabled state of any UIControl-based widget.
+pub fn set_enabled(handle: i64, enabled: bool) {
+    if let Some(view) = get_widget(handle) {
+        unsafe {
+            let _: () = objc2::msg_send![&*view, setEnabled: enabled];
+        }
+    }
+}
+
+/// Set a tooltip (no-op on iOS).
+pub fn set_tooltip(_handle: i64, _text: &str) {}
+
+/// Set control size variant (no-op on iOS).
+pub fn set_control_size(_handle: i64, _size: i64) {}
+
+/// Animate the opacity of a widget. `duration_secs` is in seconds.
+pub fn animate_opacity(handle: i64, target: f64, duration_secs: f64) {
+    if let Some(view) = get_widget(handle) {
+        unsafe {
+            let layer: *mut AnyObject = objc2::msg_send![&*view, layer];
+            let anim_cls = AnyClass::get(c"CABasicAnimation").unwrap();
+            let key = objc2_foundation::NSString::from_str("opacity");
+            let anim: *mut AnyObject = objc2::msg_send![anim_cls, animationWithKeyPath: &*key];
+            let target_ns: Retained<AnyObject> = objc2::msg_send![
+                AnyClass::get(c"NSNumber").unwrap(), numberWithDouble: target
+            ];
+            let _: () = objc2::msg_send![anim, setToValue: &*target_ns];
+            let _: () = objc2::msg_send![anim, setDuration: duration_secs];
+            let _: () = objc2::msg_send![anim, setFillMode:
+                &*objc2_foundation::NSString::from_str("forwards")];
+            let _: () = objc2::msg_send![anim, setRemovedOnCompletion: false];
+            let _: () = objc2::msg_send![layer, addAnimation: anim, forKey: &*key];
+            let _: () = objc2::msg_send![&*view, setAlpha: target];
+        }
+    }
+}
+
+/// Animate the position of a widget by delta. `duration_secs` is in seconds.
+pub fn animate_position(handle: i64, dx: f64, dy: f64, duration_secs: f64) {
+    if let Some(view) = get_widget(handle) {
+        unsafe {
+            let frame: objc2_core_foundation::CGRect = objc2::msg_send![&*view, frame];
+            let new_frame = objc2_core_foundation::CGRect::new(
+                objc2_core_foundation::CGPoint::new(frame.origin.x + dx, frame.origin.y + dy),
+                frame.size,
+            );
+            let layer: *mut AnyObject = objc2::msg_send![&*view, layer];
+            let anim_cls = AnyClass::get(c"CABasicAnimation").unwrap();
+            let key = objc2_foundation::NSString::from_str("position");
+            let anim: *mut AnyObject = objc2::msg_send![anim_cls, animationWithKeyPath: &*key];
+            let _: () = objc2::msg_send![anim, setDuration: duration_secs];
+            let _: () = objc2::msg_send![layer, addAnimation: anim, forKey: &*key];
+            let _: () = objc2::msg_send![&*view, setFrame: new_frame];
+        }
+    }
+}
+
+/// Set on-hover (no-op on iOS).
+pub fn set_on_hover(_handle: i64, _callback: f64) {}
+
+/// Set a single-tap handler for any widget.
+pub fn set_on_click(handle: i64, callback: f64) {
+    button::set_on_tap(handle, callback);
+}
+
+/// Set a double-tap handler.
+pub fn set_on_double_click(handle: i64, callback: f64) {
+    DOUBLE_CLICK_CALLBACKS.with(|cbs| {
+        cbs.borrow_mut().insert(handle, callback);
+    });
+    if let Some(view) = get_widget(handle) {
+        unsafe {
+            let gr_cls = AnyClass::get(c"UITapGestureRecognizer").unwrap();
+            let recognizer: *mut AnyObject = objc2::msg_send![gr_cls, alloc];
+            let recognizer: *mut AnyObject = objc2::msg_send![recognizer, init];
+            let _: () = objc2::msg_send![recognizer, setNumberOfTapsRequired: 2i64];
+            let _: () = objc2::msg_send![&*view, addGestureRecognizer: recognizer];
+        }
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/navstack.rs
+++ b/crates/perry-ui-visionos/src/widgets/navstack.rs
@@ -1,0 +1,58 @@
+use objc2::rc::Retained;
+use objc2::msg_send;
+use objc2::runtime::AnyObject;
+use objc2_ui_kit::UIView;
+use objc2_foundation::MainThreadMarker;
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+thread_local! {
+    static NAV_STACKS: RefCell<HashMap<i64, Vec<i64>>> = RefCell::new(HashMap::new());
+}
+
+pub fn create(_title_ptr: *const u8, body_handle: i64) -> i64 {
+    let _mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+    unsafe {
+        let stack_cls = objc2::runtime::AnyClass::get(c"UIStackView").unwrap();
+        let obj: *mut AnyObject = msg_send![stack_cls, alloc];
+        let obj: *mut AnyObject = msg_send![obj, init];
+        let stack: Retained<UIView> = Retained::retain(obj as *mut UIView).unwrap();
+        let _: () = msg_send![&*stack, setAxis: 1i64]; // vertical
+        let handle = super::register_widget(stack);
+        if body_handle > 0 {
+            super::add_child(handle, body_handle);
+        }
+        NAV_STACKS.with(|ns| {
+            ns.borrow_mut().insert(handle, vec![body_handle]);
+        });
+        handle
+    }
+}
+
+pub fn push(handle: i64, _title_ptr: *const u8, body_handle: i64) {
+    NAV_STACKS.with(|ns| {
+        let mut stacks = ns.borrow_mut();
+        if let Some(stack) = stacks.get_mut(&handle) {
+            if let Some(&top) = stack.last() {
+                super::set_hidden(top, true);
+            }
+            stack.push(body_handle);
+            super::add_child(handle, body_handle);
+        }
+    });
+}
+
+pub fn pop(handle: i64) {
+    NAV_STACKS.with(|ns| {
+        let mut stacks = ns.borrow_mut();
+        if let Some(stack) = stacks.get_mut(&handle) {
+            if stack.len() > 1 {
+                let popped = stack.pop().unwrap();
+                super::set_hidden(popped, true);
+                if let Some(&top) = stack.last() {
+                    super::set_hidden(top, false);
+                }
+            }
+        }
+    });
+}

--- a/crates/perry-ui-visionos/src/widgets/picker.rs
+++ b/crates/perry-ui-visionos/src/widgets/picker.rs
@@ -1,0 +1,92 @@
+use objc2::rc::Retained;
+use objc2::msg_send;
+use objc2::runtime::AnyObject;
+use objc2_ui_kit::UIView;
+use objc2_foundation::{NSString, MainThreadMarker};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+thread_local! {
+    static PICKER_ITEMS: RefCell<HashMap<i64, Vec<String>>> = RefCell::new(HashMap::new());
+    static PICKER_SELECTED: RefCell<HashMap<i64, i64>> = RefCell::new(HashMap::new());
+}
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+pub fn create(_label_ptr: *const u8, _on_change: f64, _style: i64) -> i64 {
+    let _mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+    unsafe {
+        // TODO(visionos): replace UILabel stub with a real picker once the
+        // segmented-control-backed path is stable in the simulator. See PR #127.
+        // TODO(visionos): wire `style` through once this migrates off the
+        // UILabel fallback and back onto a native picker implementation.
+        let label = str_from_header(_label_ptr);
+        let label_cls = objc2::runtime::AnyClass::get(c"UILabel").unwrap();
+        let obj: *mut AnyObject = msg_send![label_cls, new];
+        let text = NSString::from_str(label);
+        let _: () = msg_send![obj, setText: &*text];
+        let view: Retained<UIView> = Retained::retain(obj as *mut UIView).unwrap();
+        let handle = super::register_widget(view);
+        PICKER_ITEMS.with(|pi| pi.borrow_mut().insert(handle, Vec::new()));
+        PICKER_SELECTED.with(|ps| ps.borrow_mut().insert(handle, 0));
+        #[cfg(feature = "geisterhand")]
+        {
+            extern "C" { fn perry_geisterhand_register(h: i64, wt: u8, ck: u8, cb: f64, lbl: *const u8); }
+            perry_geisterhand_register(handle, 4, 1, _on_change, _label_ptr);
+        }
+        handle
+    }
+}
+
+pub fn add_item(handle: i64, title_ptr: *const u8) {
+    let title = str_from_header(title_ptr);
+    if let Some(view) = super::get_widget(handle) {
+        PICKER_ITEMS.with(|pi| {
+            let mut items = pi.borrow_mut();
+            if let Some(list) = items.get_mut(&handle) {
+                let index = list.len();
+                list.push(title.to_string());
+                if index == 0 {
+                    let ns_title = NSString::from_str(title);
+                    unsafe {
+                        let _: () = msg_send![&*view, setText: &*ns_title];
+                    }
+                }
+            }
+        });
+    }
+}
+
+pub fn set_selected(handle: i64, index: i64) {
+    if let Some(view) = super::get_widget(handle) {
+        PICKER_SELECTED.with(|ps| {
+            ps.borrow_mut().insert(handle, index);
+        });
+        PICKER_ITEMS.with(|pi| {
+            if let Some(items) = pi.borrow().get(&handle) {
+                if let Some(item) = items.get(index.max(0) as usize) {
+                    let ns_title = NSString::from_str(item);
+                    unsafe {
+                        let _: () = msg_send![&*view, setText: &*ns_title];
+                    }
+                }
+            }
+        });
+    }
+}
+
+pub fn get_selected(handle: i64) -> i64 {
+    PICKER_SELECTED.with(|ps| {
+        ps.borrow().get(&handle).copied().unwrap_or(-1)
+    })
+}

--- a/crates/perry-ui-visionos/src/widgets/progressview.rs
+++ b/crates/perry-ui-visionos/src/widgets/progressview.rs
@@ -1,0 +1,30 @@
+use objc2::rc::Retained;
+use objc2::msg_send;
+use objc2::runtime::AnyObject;
+use objc2_ui_kit::UIView;
+use objc2_foundation::MainThreadMarker;
+
+pub fn create() -> i64 {
+    let _mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+    unsafe {
+        let cls = objc2::runtime::AnyClass::get(c"UIActivityIndicatorView").unwrap();
+        let obj: *mut AnyObject = msg_send![cls, alloc];
+        let obj: *mut AnyObject = msg_send![obj, initWithActivityIndicatorStyle: 100i64]; // UIActivityIndicatorViewStyleMedium
+        let indicator: Retained<UIView> = Retained::retain(obj as *mut UIView).unwrap();
+        let _: () = msg_send![&*indicator, startAnimating];
+        super::register_widget(indicator)
+    }
+}
+
+pub fn set_value(handle: i64, value: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            // Switch to UIProgressView for determinate mode
+            let _: () = msg_send![&*view, setProgress: value as f32, animated: true];
+        }
+    }
+}
+
+pub fn set_label(_handle: i64, _label_ptr: *const u8) {
+    // No-op on iOS
+}

--- a/crates/perry-ui-visionos/src/widgets/qrcode.rs
+++ b/crates/perry-ui-visionos/src/widgets/qrcode.rs
@@ -1,0 +1,156 @@
+use objc2::rc::Retained;
+use objc2::msg_send;
+use objc2::runtime::{AnyClass, AnyObject};
+use objc2_ui_kit::UIView;
+use objc2_foundation::NSString;
+
+/// Extract a &str from a *const StringHeader pointer.
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// Create a UIImageView displaying a QR code for the given data string.
+/// `size` is the display width/height in points (QR codes are square).
+/// Returns widget handle, or 0 on failure.
+pub fn create(data_ptr: *const u8, size: f64) -> i64 {
+    let data_str = str_from_header(data_ptr);
+    let display_size = if size > 0.0 { size } else { 200.0 };
+
+    unsafe {
+        let frame = objc2_core_foundation::CGRect::new(
+            objc2_core_foundation::CGPoint::new(0.0, 0.0),
+            objc2_core_foundation::CGSize::new(display_size, display_size),
+        );
+        let iv_cls = AnyClass::get(c"UIImageView").unwrap();
+        let iv_raw: *mut AnyObject = msg_send![iv_cls, alloc];
+        let iv_raw: *mut AnyObject = msg_send![iv_raw, initWithFrame: frame];
+        if iv_raw.is_null() { return 0; }
+        let image_view: Retained<UIView> = Retained::retain(iv_raw as *mut UIView).unwrap();
+
+        // UIViewContentModeScaleAspectFit = 1
+        let _: () = msg_send![&*image_view, setContentMode: 1_i64];
+        let _: () = msg_send![&*image_view, setTranslatesAutoresizingMaskIntoConstraints: false];
+
+        // Set width/height constraints
+        let width_anchor: Retained<AnyObject> = msg_send![&*image_view, widthAnchor];
+        let wc: Retained<AnyObject> = msg_send![&*width_anchor, constraintEqualToConstant: display_size];
+        let _: () = msg_send![&*wc, setActive: true];
+
+        let height_anchor: Retained<AnyObject> = msg_send![&*image_view, heightAnchor];
+        let hc: Retained<AnyObject> = msg_send![&*height_anchor, constraintEqualToConstant: display_size];
+        let _: () = msg_send![&*hc, setActive: true];
+
+        if !data_str.is_empty() {
+            if let Some(ui_image) = generate_qr_image(data_str, display_size) {
+                let _: () = msg_send![&*image_view, setImage: &*ui_image];
+            }
+        }
+
+        super::register_widget(image_view)
+    }
+}
+
+/// Update the QR code content of an existing widget.
+pub fn set_data(handle: i64, data_ptr: *const u8) {
+    let data_str = str_from_header(data_ptr);
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let frame: objc2_core_foundation::CGRect = msg_send![&*view, frame];
+            let size = if frame.size.width > 0.0 {
+                frame.size.width
+            } else {
+                200.0
+            };
+            if let Some(ui_image) = generate_qr_image(data_str, size) {
+                let _: () = msg_send![&*view, setImage: &*ui_image];
+            }
+        }
+    }
+}
+
+/// Generate a UIImage containing a QR code for the given text.
+///
+/// Uses CIFilter("CIQRCodeGenerator") → CIContext → CGImage → UIImage.
+/// CoreImage is shared between macOS and iOS.
+unsafe fn generate_qr_image(text: &str, display_size: f64) -> Option<Retained<AnyObject>> {
+    if text.is_empty() {
+        return None;
+    }
+
+    // 1. Text → NSData (UTF-8)
+    let ns_str = NSString::from_str(text);
+    let utf8_data: *mut AnyObject = msg_send![&*ns_str, dataUsingEncoding: 4_u64]; // NSUTF8StringEncoding
+    if utf8_data.is_null() {
+        return None;
+    }
+
+    // 2. CIFilter "CIQRCodeGenerator"
+    let ci_filter_cls = AnyClass::get(c"CIFilter")?;
+    let filter_name = NSString::from_str("CIQRCodeGenerator");
+    let filter: *mut AnyObject = msg_send![ci_filter_cls, filterWithName: &*filter_name];
+    if filter.is_null() {
+        return None;
+    }
+
+    // Set inputMessage
+    let key_msg = NSString::from_str("inputMessage");
+    let _: () = msg_send![filter, setValue: utf8_data, forKey: &*key_msg];
+
+    // Set correction level to M (15% recovery)
+    let key_corr = NSString::from_str("inputCorrectionLevel");
+    let val_corr = NSString::from_str("M");
+    let _: () = msg_send![filter, setValue: &*val_corr, forKey: &*key_corr];
+
+    // 3. Get output CIImage
+    let key_output = NSString::from_str("outputImage");
+    let ci_image: *mut AnyObject = msg_send![filter, valueForKey: &*key_output];
+    if ci_image.is_null() {
+        return None;
+    }
+
+    // 4. Get extent (raw QR pixel dimensions, e.g. 23x23)
+    let extent: objc2_core_foundation::CGRect = msg_send![ci_image, extent];
+    let qr_width = extent.size.width;
+    if qr_width <= 0.0 {
+        return None;
+    }
+
+    // 5. Create CIContext and render to CGImage
+    let ci_context_cls = AnyClass::get(c"CIContext")?;
+    let context: *mut AnyObject = msg_send![ci_context_cls, context];
+    if context.is_null() {
+        return None;
+    }
+
+    let cg_image: *mut AnyObject = msg_send![context, createCGImage: ci_image, fromRect: extent];
+    if cg_image.is_null() {
+        return None;
+    }
+
+    // 6. Integer scale factor for crisp pixels
+    let scale = ((display_size / qr_width).floor() as i64).max(1) as f64;
+
+    // 7. Create UIImage from CGImage
+    // UIImage initWithCGImage:scale:orientation:
+    // scale=1/scale_factor to render at the right size, orientation=0 (Up)
+    let ui_image_cls = AnyClass::get(c"UIImage")?;
+    let ui_image: Retained<AnyObject> = msg_send![
+        ui_image_cls, imageWithCGImage: cg_image, scale: (1.0 / scale), orientation: 0_i64
+    ];
+
+    // Release the CGImage (we own it from createCGImage:fromRect:)
+    extern "C" {
+        fn CGImageRelease(image: *mut AnyObject);
+    }
+    CGImageRelease(cg_image);
+
+    Some(ui_image)
+}

--- a/crates/perry-ui-visionos/src/widgets/scrollview.rs
+++ b/crates/perry-ui-visionos/src/widgets/scrollview.rs
@@ -1,0 +1,219 @@
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, Sel};
+use objc2::{define_class, msg_send, AnyThread, DefinedClass};
+use objc2_ui_kit::{UIScrollView, UIView};
+use objc2_foundation::NSObject;
+use objc2_core_foundation::CGPoint;
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+extern "C" {
+    fn js_closure_call0(closure: *const u8) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    static _dispatch_main_q: std::ffi::c_void;
+    fn dispatch_async_f(
+        queue: *const std::ffi::c_void,
+        context: *mut std::ffi::c_void,
+        work: unsafe extern "C" fn(*mut std::ffi::c_void),
+    );
+}
+
+unsafe extern "C" fn refresh_callback_trampoline(context: *mut std::ffi::c_void) {
+    let _ = std::panic::catch_unwind(|| {
+        let closure_f64 = f64::from_bits(context as u64);
+        let closure_ptr = js_nanbox_get_pointer(closure_f64);
+        js_closure_call0(closure_ptr as *const u8);
+    });
+}
+
+thread_local! {
+    static REFRESH_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+
+pub struct PerryRefreshTargetIvars {
+    callback_key: std::cell::Cell<usize>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryRefreshTarget"]
+    #[ivars = PerryRefreshTargetIvars]
+    pub struct PerryRefreshTarget;
+
+    impl PerryRefreshTarget {
+        #[unsafe(method(handleRefresh:))]
+        fn handle_refresh(&self, _sender: &AnyObject) {
+            let key = self.ivars().callback_key.get();
+            REFRESH_CALLBACKS.with(|cbs| {
+                if let Some(&closure_f64) = cbs.borrow().get(&key) {
+                    unsafe {
+                        dispatch_async_f(
+                            &_dispatch_main_q as *const _ as *const std::ffi::c_void,
+                            closure_f64.to_bits() as *mut std::ffi::c_void,
+                            refresh_callback_trampoline,
+                        );
+                    }
+                }
+            });
+        }
+    }
+);
+
+impl PerryRefreshTarget {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryRefreshTargetIvars {
+            callback_key: std::cell::Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+/// Create a UIScrollView. Returns widget handle.
+pub fn create() -> i64 {
+    unsafe {
+        let scroll: Retained<UIScrollView> = msg_send![
+            objc2::runtime::AnyClass::get(c"UIScrollView").unwrap(),
+            new
+        ];
+        let _: () = msg_send![&*scroll, setTranslatesAutoresizingMaskIntoConstraints: false];
+        // Disable touch delay to avoid iOS 26 crash in
+        // UIGestureRecognizer _delayTouchesForEvent:inPhase:
+        let _: () = msg_send![&*scroll, setDelaysContentTouches: false];
+        // Dismiss keyboard when user scrolls (UIScrollViewKeyboardDismissModeOnDrag = 1)
+        let _: () = msg_send![&*scroll, setKeyboardDismissMode: 1i64];
+        // Automatically adjust content inset for safe area (status bar, home indicator)
+        // UIScrollViewContentInsetAdjustmentAlways = 2
+        let _: () = msg_send![&*scroll, setContentInsetAdjustmentBehavior: 2i64];
+
+        let view: Retained<UIView> = Retained::cast_unchecked(scroll);
+        let handle = super::register_widget(view);
+        #[cfg(feature = "geisterhand")]
+        {
+            extern "C" { fn perry_geisterhand_register(h: i64, wt: u8, ck: u8, cb: f64, lbl: *const u8); }
+            unsafe { perry_geisterhand_register(handle, 8, 0, 0.0, std::ptr::null()); }
+        }
+        handle
+    }
+}
+
+/// Set both x and y scroll offsets. Used by geisterhand for programmatic scrolling.
+#[no_mangle]
+pub extern "C" fn perry_ui_scroll_set_offset(scroll_handle: i64, x: f64, y: f64) {
+    if let Some(scroll_view) = super::get_widget(scroll_handle) {
+        unsafe {
+            use objc2_core_foundation::CGPoint;
+            let point = CGPoint { x, y };
+            let _: () = objc2::msg_send![&*scroll_view, setContentOffset: point, animated: false];
+        }
+    }
+}
+
+/// Set the content child of a UIScrollView.
+pub fn set_child(scroll_handle: i64, child_handle: i64) {
+    if let (Some(scroll_view), Some(child)) = (super::get_widget(scroll_handle), super::get_widget(child_handle)) {
+        unsafe {
+            // Add child as subview of the scroll view
+            scroll_view.addSubview(&child);
+
+            // Pin child to scroll view's content layout guide
+            let content_guide: *const objc2::runtime::AnyObject = msg_send![&*scroll_view, contentLayoutGuide];
+
+            let child_leading: *const objc2::runtime::AnyObject = msg_send![&*child, leadingAnchor];
+            let child_trailing: *const objc2::runtime::AnyObject = msg_send![&*child, trailingAnchor];
+            let child_top: *const objc2::runtime::AnyObject = msg_send![&*child, topAnchor];
+            let child_bottom: *const objc2::runtime::AnyObject = msg_send![&*child, bottomAnchor];
+
+            let guide_leading: *const objc2::runtime::AnyObject = msg_send![content_guide, leadingAnchor];
+            let guide_trailing: *const objc2::runtime::AnyObject = msg_send![content_guide, trailingAnchor];
+            let guide_top: *const objc2::runtime::AnyObject = msg_send![content_guide, topAnchor];
+            let guide_bottom: *const objc2::runtime::AnyObject = msg_send![content_guide, bottomAnchor];
+
+            let c1: Retained<objc2::runtime::AnyObject> = msg_send![child_leading, constraintEqualToAnchor: guide_leading];
+            let c2: Retained<objc2::runtime::AnyObject> = msg_send![child_trailing, constraintEqualToAnchor: guide_trailing];
+            let c3: Retained<objc2::runtime::AnyObject> = msg_send![child_top, constraintEqualToAnchor: guide_top];
+            let c4: Retained<objc2::runtime::AnyObject> = msg_send![child_bottom, constraintEqualToAnchor: guide_bottom];
+
+            let _: () = msg_send![&*c1, setActive: true];
+            let _: () = msg_send![&*c2, setActive: true];
+            let _: () = msg_send![&*c3, setActive: true];
+            let _: () = msg_send![&*c4, setActive: true];
+
+            // Match width to scroll view's frame layout guide
+            let frame_guide: *const objc2::runtime::AnyObject = msg_send![&*scroll_view, frameLayoutGuide];
+            let child_width: *const objc2::runtime::AnyObject = msg_send![&*child, widthAnchor];
+            let frame_width: *const objc2::runtime::AnyObject = msg_send![frame_guide, widthAnchor];
+            let cw: Retained<objc2::runtime::AnyObject> = msg_send![child_width, constraintEqualToAnchor: frame_width];
+            let _: () = msg_send![&*cw, setActive: true];
+        }
+    }
+}
+
+/// Scroll so that the given child widget is visible.
+pub fn scroll_to(_scroll_handle: i64, child_handle: i64) {
+    if let Some(child) = super::get_widget(child_handle) {
+        unsafe {
+            let frame: objc2_core_foundation::CGRect = msg_send![&*child, frame];
+            // Find the scroll view parent
+            let superview: *const objc2::runtime::AnyObject = msg_send![&*child, superview];
+            if !superview.is_null() {
+                let _: () = msg_send![superview, scrollRectToVisible: frame, animated: true];
+            }
+        }
+    }
+}
+
+/// Get the vertical scroll offset (contentOffset.y).
+pub fn get_offset(scroll_handle: i64) -> f64 {
+    if let Some(scroll_view) = super::get_widget(scroll_handle) {
+        unsafe {
+            let offset: CGPoint = msg_send![&*scroll_view, contentOffset];
+            offset.y
+        }
+    } else {
+        0.0
+    }
+}
+
+/// Set the vertical scroll offset.
+pub fn set_offset(scroll_handle: i64, offset: f64) {
+    if let Some(scroll_view) = super::get_widget(scroll_handle) {
+        unsafe {
+            let point = CGPoint::new(0.0, offset);
+            let _: () = msg_send![&*scroll_view, setContentOffset: point, animated: true];
+        }
+    }
+}
+
+/// Attach a UIRefreshControl to a UIScrollView. The callback is invoked when the user pulls to refresh.
+pub fn set_refresh_control(scroll_handle: i64, callback: f64) {
+    if let Some(scroll_view) = super::get_widget(scroll_handle) {
+        unsafe {
+            let target = PerryRefreshTarget::new();
+            let target_addr = Retained::as_ptr(&target) as usize;
+            target.ivars().callback_key.set(target_addr);
+            REFRESH_CALLBACKS.with(|cbs| {
+                cbs.borrow_mut().insert(target_addr, callback);
+            });
+
+            let sel = Sel::register(c"handleRefresh:");
+            let rc_cls = objc2::runtime::AnyClass::get(c"UIRefreshControl").unwrap();
+            let rc: *mut AnyObject = msg_send![rc_cls, new];
+            let _: () = msg_send![rc, addTarget: &*target, action: sel, forControlEvents: 1u64 << 12]; // UIControlEventValueChanged
+            let _: () = msg_send![&*scroll_view, setRefreshControl: rc];
+
+            std::mem::forget(target); // keep alive
+        }
+    }
+}
+
+/// End the refresh animation on a UIScrollView's UIRefreshControl.
+pub fn end_refreshing(scroll_handle: i64) {
+    if let Some(scroll_view) = super::get_widget(scroll_handle) {
+        unsafe {
+            let rc: *const AnyObject = msg_send![&*scroll_view, refreshControl];
+            if !rc.is_null() {
+                let _: () = msg_send![rc, endRefreshing];
+            }
+        }
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/securefield.rs
+++ b/crates/perry-ui-visionos/src/widgets/securefield.rs
@@ -1,0 +1,126 @@
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, Sel};
+use objc2::{define_class, msg_send, AnyThread, DefinedClass};
+use objc2_ui_kit::{UITextField, UIView};
+use objc2_foundation::{NSObject, NSString};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+thread_local! {
+    static SECUREFIELD_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_nanbox_string(ptr: i64) -> f64;
+}
+
+pub struct PerrySecureFieldTargetIvars {
+    callback_key: std::cell::Cell<usize>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerrySecureFieldTarget"]
+    #[ivars = PerrySecureFieldTargetIvars]
+    pub struct PerrySecureFieldTarget;
+
+    impl PerrySecureFieldTarget {
+        #[unsafe(method(textFieldChanged:))]
+        fn text_field_changed(&self, sender: &AnyObject) {
+            let key = self.ivars().callback_key.get();
+            SECUREFIELD_CALLBACKS.with(|cbs| {
+                if let Some(&closure_f64) = cbs.borrow().get(&key) {
+                    let text: Retained<NSString> = unsafe { msg_send![sender, text] };
+                    let rust_str = text.to_string();
+                    let bytes = rust_str.as_bytes();
+
+                    let str_ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64) };
+                    let nanboxed = unsafe { js_nanbox_string(str_ptr as i64) };
+
+                    let closure_ptr = unsafe { js_nanbox_get_pointer(closure_f64) };
+                    unsafe {
+                        js_closure_call1(closure_ptr as *const u8, nanboxed);
+                    }
+                }
+            });
+        }
+    }
+);
+
+impl PerrySecureFieldTarget {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerrySecureFieldTargetIvars {
+            callback_key: std::cell::Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// Create a UITextField with secureTextEntry enabled (password field).
+pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
+    let placeholder = str_from_header(placeholder_ptr);
+
+    unsafe {
+        let text_field: Retained<UITextField> = msg_send![
+            objc2::runtime::AnyClass::get(c"UITextField").unwrap(),
+            new
+        ];
+        let ns_placeholder = NSString::from_str(placeholder);
+        let _: () = msg_send![&*text_field, setPlaceholder: &*ns_placeholder];
+        let _: () = msg_send![&*text_field, setBorderStyle: 3i64]; // UITextBorderStyleRoundedRect = 3
+        let _: () = msg_send![&*text_field, setSecureTextEntry: true];
+        let _: () = msg_send![&*text_field, setTranslatesAutoresizingMaskIntoConstraints: false];
+
+        let target = PerrySecureFieldTarget::new();
+        let target_addr = Retained::as_ptr(&target) as usize;
+        target.ivars().callback_key.set(target_addr);
+
+        SECUREFIELD_CALLBACKS.with(|cbs| {
+            cbs.borrow_mut().insert(target_addr, on_change);
+        });
+
+        let sel = Sel::register(c"textFieldChanged:");
+        // UIControlEventEditingChanged = 1 << 17 = 131072
+        let _: () = msg_send![&*text_field, addTarget: &*target, action: sel, forControlEvents: 131072u64];
+
+        std::mem::forget(target);
+
+        let view: Retained<UIView> = Retained::cast_unchecked(text_field);
+        super::register_widget(view)
+    }
+}
+
+/// Focus a secure text field (make it first responder).
+pub fn focus(handle: i64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let _: () = msg_send![&*view, becomeFirstResponder];
+        }
+    }
+}
+
+/// Set the text of a secure text field from a StringHeader pointer.
+pub fn set_string_value(handle: i64, text_ptr: *const u8) {
+    let text = str_from_header(text_ptr);
+    if let Some(view) = super::get_widget(handle) {
+        let ns_string = NSString::from_str(text);
+        unsafe {
+            let _: () = msg_send![&*view, setText: &*ns_string];
+        }
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/slider.rs
+++ b/crates/perry-ui-visionos/src/widgets/slider.rs
@@ -1,0 +1,100 @@
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, Sel};
+use objc2::{define_class, msg_send, AnyThread, DefinedClass};
+use objc2_ui_kit::{UISlider, UIView};
+use objc2_foundation::NSObject;
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+thread_local! {
+    static SLIDER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+}
+
+pub struct PerrySliderTargetIvars {
+    callback_key: std::cell::Cell<usize>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerrySliderTarget"]
+    #[ivars = PerrySliderTargetIvars]
+    pub struct PerrySliderTarget;
+
+    impl PerrySliderTarget {
+        #[unsafe(method(sliderChanged:))]
+        fn slider_changed(&self, sender: &AnyObject) {
+            let key = self.ivars().callback_key.get();
+            SLIDER_CALLBACKS.with(|cbs| {
+                if let Some(&closure_f64) = cbs.borrow().get(&key) {
+                    // UISlider uses Float (f32), cast to f64 at boundary
+                    let value: f32 = unsafe { msg_send![sender, value] };
+                    let closure_ptr = unsafe { js_nanbox_get_pointer(closure_f64) };
+                    unsafe {
+                        js_closure_call1(closure_ptr as *const u8, value as f64);
+                    }
+                }
+            });
+        }
+    }
+);
+
+impl PerrySliderTarget {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerrySliderTargetIvars {
+            callback_key: std::cell::Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+/// Set the value of an existing UISlider widget.
+pub fn set_value(handle: i64, value: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let _: () = msg_send![&*view, setValue: value as f32, animated: true];
+        }
+    }
+}
+
+/// Create a UISlider with min, max, initial values and onChange callback.
+pub fn create(min: f64, max: f64, initial: f64, on_change: f64) -> i64 {
+    unsafe {
+        let slider: Retained<UISlider> = msg_send![
+            objc2::runtime::AnyClass::get(c"UISlider").unwrap(),
+            new
+        ];
+        let _: () = msg_send![&*slider, setMinimumValue: min as f32];
+        let _: () = msg_send![&*slider, setMaximumValue: max as f32];
+        let _: () = msg_send![&*slider, setValue: initial as f32];
+        let _: () = msg_send![&*slider, setContinuous: true];
+        let _: () = msg_send![&*slider, setTranslatesAutoresizingMaskIntoConstraints: false];
+
+        let target = PerrySliderTarget::new();
+        let target_addr = Retained::as_ptr(&target) as usize;
+        target.ivars().callback_key.set(target_addr);
+
+        SLIDER_CALLBACKS.with(|cbs| {
+            cbs.borrow_mut().insert(target_addr, on_change);
+        });
+
+        let sel = Sel::register(c"sliderChanged:");
+        // UIControlEventValueChanged = 4096
+        let _: () = msg_send![&*slider, addTarget: &*target, action: sel, forControlEvents: 4096u64];
+
+        std::mem::forget(target);
+
+        let view: Retained<UIView> = Retained::cast_unchecked(slider);
+        let handle = super::register_widget(view);
+        #[cfg(feature = "geisterhand")]
+        {
+            extern "C" { fn perry_geisterhand_register(h: i64, wt: u8, ck: u8, cb: f64, lbl: *const u8); }
+            unsafe { perry_geisterhand_register(handle, 2, 1, on_change, std::ptr::null()); }
+        }
+        handle
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/spacer.rs
+++ b/crates/perry-ui-visionos/src/widgets/spacer.rs
@@ -1,0 +1,27 @@
+use objc2::rc::Retained;
+use objc2::msg_send;
+use objc2::runtime::AnyClass;
+use objc2_ui_kit::UIView;
+
+/// Create a flexible spacer UIView with low content-hugging priority.
+/// Works inside UIStackView with Fill distribution: the low hugging priority
+/// and explicit zero-height constraint (at low priority) let the stack view
+/// expand this view to fill remaining space.
+pub fn create() -> i64 {
+    unsafe {
+        let view: Retained<UIView> = msg_send![
+            AnyClass::get(c"UIView").unwrap(),
+            new
+        ];
+        let _: () = msg_send![&*view, setTranslatesAutoresizingMaskIntoConstraints: false];
+        // Set low content hugging priority so spacer stretches in both axes
+        // UILayoutPriority is Float (f32) on iOS
+        let _: () = msg_send![&*view, setContentHuggingPriority: 1.0f32, forAxis: 0i64]; // Horizontal
+        let _: () = msg_send![&*view, setContentHuggingPriority: 1.0f32, forAxis: 1i64]; // Vertical
+        // Set low compression resistance so spacer can be shrunk if needed
+        let _: () = msg_send![&*view, setContentCompressionResistancePriority: 1.0f32, forAxis: 0i64];
+        let _: () = msg_send![&*view, setContentCompressionResistancePriority: 1.0f32, forAxis: 1i64];
+
+        super::register_widget(view)
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/splitview.rs
+++ b/crates/perry-ui-visionos/src/widgets/splitview.rs
@@ -1,0 +1,298 @@
+use objc2::rc::Retained;
+use objc2::runtime::AnyObject;
+use objc2::{msg_send};
+use objc2_ui_kit::UIView;
+
+// Raw ObjC runtime FFI for dynamic class registration
+extern "C" {
+    fn objc_allocateClassPair(superclass: *const std::ffi::c_void, name: *const i8, extra_bytes: usize) -> *mut std::ffi::c_void;
+    fn objc_registerClassPair(cls: *mut std::ffi::c_void);
+    fn class_addMethod(cls: *mut std::ffi::c_void, sel: *const std::ffi::c_void, imp: *const std::ffi::c_void, types: *const i8) -> bool;
+    fn sel_registerName(name: *const i8) -> *const std::ffi::c_void;
+    fn objc_getClass(name: *const i8) -> *const std::ffi::c_void;
+}
+
+/// intrinsicContentSize override — returns {-1, 10} so UIStackView (VStack) can stretch this view.
+/// Without this, UIStackView gives the view zero height since UIView has no intrinsic size.
+unsafe extern "C" fn frame_split_intrinsic_content_size(_this: *mut AnyObject, _sel: *const std::ffi::c_void) -> objc2_core_foundation::CGSize {
+    // UIViewNoIntrinsicMetric = -1 for width (don't constrain), small height so VStack can stretch
+    objc2_core_foundation::CGSize::new(-1.0, 10.0)
+}
+
+/// layoutSubviews callback for PerryFrameSplit — positions children using frames, not Auto Layout.
+/// Each direct subview is a wrapper UIView. layoutSubviews sets each wrapper's frame,
+/// then also sets the wrapper's first child's frame to fill the wrapper (bounds).
+unsafe extern "C" fn frame_split_layout_subviews(this: *mut AnyObject, _sel: *const std::ffi::c_void) {
+    let bounds: objc2_core_foundation::CGRect = objc2::msg_send![this, bounds];
+    let tag: i64 = objc2::msg_send![this, tag];
+    let left_width = tag as f64 / 100.0;
+
+    let subviews: *mut AnyObject = objc2::msg_send![this, subviews];
+    let count: usize = objc2::msg_send![subviews, count];
+
+    if count >= 1 {
+        let wrapper: *mut AnyObject = objc2::msg_send![subviews, objectAtIndex: 0usize];
+        let wrapper_frame = objc2_core_foundation::CGRect::new(
+            objc2_core_foundation::CGPoint::new(0.0, 0.0),
+            objc2_core_foundation::CGSize::new(left_width, bounds.size.height),
+        );
+        let _: () = objc2::msg_send![wrapper, setFrame: wrapper_frame];
+        // Set wrapper's child to fill wrapper bounds
+        let wrapper_subs: *mut AnyObject = objc2::msg_send![wrapper, subviews];
+        let wrapper_count: usize = objc2::msg_send![wrapper_subs, count];
+        if wrapper_count >= 1 {
+            let child: *mut AnyObject = objc2::msg_send![wrapper_subs, objectAtIndex: 0usize];
+            let child_frame = objc2_core_foundation::CGRect::new(
+                objc2_core_foundation::CGPoint::new(0.0, 0.0),
+                objc2_core_foundation::CGSize::new(left_width, bounds.size.height),
+            );
+            let _: () = objc2::msg_send![child, setFrame: child_frame];
+        }
+    }
+    if count >= 2 {
+        let wrapper: *mut AnyObject = objc2::msg_send![subviews, objectAtIndex: 1usize];
+        let rw = bounds.size.width - left_width;
+        let wrapper_frame = objc2_core_foundation::CGRect::new(
+            objc2_core_foundation::CGPoint::new(left_width, 0.0),
+            objc2_core_foundation::CGSize::new(rw, bounds.size.height),
+        );
+        let _: () = objc2::msg_send![wrapper, setFrame: wrapper_frame];
+        // Set wrapper's child to fill wrapper bounds
+        let wrapper_subs: *mut AnyObject = objc2::msg_send![wrapper, subviews];
+        let wrapper_count: usize = objc2::msg_send![wrapper_subs, count];
+        if wrapper_count >= 1 {
+            let child: *mut AnyObject = objc2::msg_send![wrapper_subs, objectAtIndex: 0usize];
+            let child_frame = objc2_core_foundation::CGRect::new(
+                objc2_core_foundation::CGPoint::new(0.0, 0.0),
+                objc2_core_foundation::CGSize::new(rw, bounds.size.height),
+            );
+            let _: () = objc2::msg_send![child, setFrame: child_frame];
+        }
+    }
+}
+
+/// Register the PerryFrameSplit UIView subclass (once).
+fn register_frame_split_class() {
+    unsafe {
+        let superclass = objc_getClass(c"UIView".as_ptr());
+        let cls = objc_allocateClassPair(superclass, c"PerryFrameSplit".as_ptr(), 0);
+        if cls.is_null() {
+            return; // already registered
+        }
+        let sel = sel_registerName(c"layoutSubviews".as_ptr());
+        class_addMethod(
+            cls,
+            sel,
+            frame_split_layout_subviews as *const std::ffi::c_void,
+            c"v@:".as_ptr(),
+        );
+        // Override intrinsicContentSize to return {-1, 10} so UIStackView can stretch this view
+        let size_sel = sel_registerName(c"intrinsicContentSize".as_ptr());
+        class_addMethod(
+            cls,
+            size_sel,
+            frame_split_intrinsic_content_size as *const std::ffi::c_void,
+            c"{CGSize=dd}@:".as_ptr(),
+        );
+        objc_registerClassPair(cls);
+    }
+}
+
+/// Create a frame-based horizontal split container.
+/// Children are positioned by `layoutSubviews` using frames — NO Auto Layout on children.
+/// This avoids the constraint conflicts that cause black screen with embedded UIViews.
+pub fn create_frame_split(left_width: f64) -> i64 {
+    register_frame_split_class();
+    unsafe {
+        let cls = objc2::runtime::AnyClass::get(c"PerryFrameSplit").unwrap();
+        let view: Retained<UIView> = objc2::msg_send![cls, new];
+        // Container itself uses Auto Layout (so VStack can size it)
+        let _: () = objc2::msg_send![&*view, setTranslatesAutoresizingMaskIntoConstraints: false];
+        // Store left_width * 100 in tag
+        let tag = (left_width * 100.0) as i64;
+        let _: () = objc2::msg_send![&*view, setTag: tag];
+        super::register_widget(view)
+    }
+}
+
+/// Add a child to a frame-based split.
+/// Wraps the child in a plain UIView. Both wrapper and child use frame-based layout.
+/// The parent's layoutSubviews explicitly sets frames for wrappers AND their children.
+pub fn frame_split_add_child(parent: &UIView, child: &UIView) {
+    unsafe {
+        // Create a wrapper UIView — uses frame-based layout (the default: translatesAutoresizing=true)
+        let wrapper: Retained<UIView> = objc2::msg_send![
+            objc2::runtime::AnyClass::get(c"UIView").unwrap(),
+            new
+        ];
+        // Child must use frame-based layout too (layoutSubviews sets its frame explicitly)
+        let _: () = objc2::msg_send![child, setTranslatesAutoresizingMaskIntoConstraints: true];
+        // Clip to wrapper bounds so content doesn't overflow
+        let _: () = objc2::msg_send![&*wrapper, setClipsToBounds: true];
+
+        let _: () = objc2::msg_send![&*wrapper, addSubview: child];
+        parent.addSubview(&wrapper);
+    }
+}
+
+/// Create a plain UIView that lays out exactly two children side by side
+/// using Auto Layout constraints (not UIStackView).
+///
+/// The first child added gets a fixed width (left_width) pinned to the left.
+/// The second child fills the remaining space on the right.
+/// This avoids UIStackView layout conflicts with embedded native views.
+pub fn create(left_width: f64) -> i64 {
+    unsafe {
+        let view: Retained<UIView> = msg_send![
+            objc2::runtime::AnyClass::get(c"UIView").unwrap(),
+            new
+        ];
+        let _: () = msg_send![&*view, setTranslatesAutoresizingMaskIntoConstraints: false];
+
+        // Store left_width in the view's tag (multiplied by 100 to preserve one decimal)
+        let tag = (left_width * 100.0) as i64;
+        let _: () = msg_send![&*view, setTag: tag];
+
+        super::register_widget(view)
+    }
+}
+
+/// Add a child to a split view container. The first child becomes the left panel
+/// (fixed width from tag), the second becomes the right panel (fills remaining).
+pub fn add_child(parent: &UIView, child: &UIView, child_index: usize) {
+    unsafe {
+        let _: () = msg_send![child, setTranslatesAutoresizingMaskIntoConstraints: false];
+        parent.addSubview(child);
+
+        // Get stored left_width from tag
+        let tag: i64 = msg_send![parent, tag];
+        let left_width = tag as f64 / 100.0;
+
+        let child_top: Retained<AnyObject> = msg_send![child, topAnchor];
+        let child_bottom: Retained<AnyObject> = msg_send![child, bottomAnchor];
+        let parent_top: Retained<AnyObject> = msg_send![parent, topAnchor];
+        let parent_bottom: Retained<AnyObject> = msg_send![parent, bottomAnchor];
+
+        // Pin top and bottom to parent
+        let tc: Retained<AnyObject> = msg_send![&*child_top, constraintEqualToAnchor: &*parent_top];
+        let bc: Retained<AnyObject> = msg_send![&*child_bottom, constraintEqualToAnchor: &*parent_bottom];
+        let _: () = msg_send![&*tc, setActive: true];
+        let _: () = msg_send![&*bc, setActive: true];
+
+        if child_index == 0 {
+            // Left panel: pin leading to parent, fixed width
+            let child_leading: Retained<AnyObject> = msg_send![child, leadingAnchor];
+            let parent_leading: Retained<AnyObject> = msg_send![parent, leadingAnchor];
+            let lc: Retained<AnyObject> = msg_send![&*child_leading, constraintEqualToAnchor: &*parent_leading];
+            let _: () = msg_send![&*lc, setActive: true];
+
+            let child_width: Retained<AnyObject> = msg_send![child, widthAnchor];
+            let wc: Retained<AnyObject> = msg_send![&*child_width, constraintEqualToConstant: left_width];
+            let _: () = msg_send![&*wc, setActive: true];
+        } else {
+            // Right panel: pin trailing to parent, leading to previous sibling's trailing
+            let child_leading: Retained<AnyObject> = msg_send![child, leadingAnchor];
+            let child_trailing: Retained<AnyObject> = msg_send![child, trailingAnchor];
+            let parent_trailing: Retained<AnyObject> = msg_send![parent, trailingAnchor];
+
+            // Find the first subview (left panel) to pin against
+            let subviews: Retained<AnyObject> = msg_send![parent, subviews];
+            let first_child: *const AnyObject = msg_send![&*subviews, firstObject];
+            if !first_child.is_null() {
+                let left_trailing: Retained<AnyObject> = msg_send![first_child, trailingAnchor];
+                let lc: Retained<AnyObject> = msg_send![&*child_leading, constraintEqualToAnchor: &*left_trailing];
+                let _: () = msg_send![&*lc, setActive: true];
+            }
+
+            let rc: Retained<AnyObject> = msg_send![&*child_trailing, constraintEqualToAnchor: &*parent_trailing];
+            let _: () = msg_send![&*rc, setActive: true];
+        }
+    }
+}
+
+/// Create a vertical layout container (plain UIView, NOT UIStackView).
+/// Lays out 3 children: top (intrinsic height), middle (fills), bottom (intrinsic height).
+/// UIStackView distribution=Fill doesn't stretch nested UIStackViews on iOS,
+/// so this manual approach is needed for reliable fill behavior.
+pub fn create_vbox() -> i64 {
+    unsafe {
+        let view: Retained<UIView> = msg_send![
+            objc2::runtime::AnyClass::get(c"UIView").unwrap(),
+            new
+        ];
+        let _: () = msg_send![&*view, setTranslatesAutoresizingMaskIntoConstraints: false];
+        super::register_widget(view)
+    }
+}
+
+/// Add a child to a vbox at a specific slot: 0=top, 1=middle, 2=bottom.
+/// - top: pinned to parent top, leading, trailing; intrinsic height
+/// - middle: pinned between top.bottom and bottom.top, leading, trailing (fills)
+/// - bottom: pinned to parent bottom, leading, trailing; intrinsic height
+pub fn vbox_add_child(parent: &UIView, child: &UIView, slot: usize) {
+    unsafe {
+        let _: () = msg_send![child, setTranslatesAutoresizingMaskIntoConstraints: false];
+        parent.addSubview(child);
+
+        let child_leading: Retained<AnyObject> = msg_send![child, leadingAnchor];
+        let child_trailing: Retained<AnyObject> = msg_send![child, trailingAnchor];
+        let parent_leading: Retained<AnyObject> = msg_send![parent, leadingAnchor];
+        let parent_trailing: Retained<AnyObject> = msg_send![parent, trailingAnchor];
+
+        // Pin leading and trailing to parent (full width)
+        let lc: Retained<AnyObject> = msg_send![&*child_leading, constraintEqualToAnchor: &*parent_leading];
+        let rc: Retained<AnyObject> = msg_send![&*child_trailing, constraintEqualToAnchor: &*parent_trailing];
+        let _: () = msg_send![&*lc, setActive: true];
+        let _: () = msg_send![&*rc, setActive: true];
+
+        if slot == 0 {
+            // Top: pin top to parent top
+            let child_top: Retained<AnyObject> = msg_send![child, topAnchor];
+            let parent_top: Retained<AnyObject> = msg_send![parent, topAnchor];
+            let c: Retained<AnyObject> = msg_send![&*child_top, constraintEqualToAnchor: &*parent_top];
+            let _: () = msg_send![&*c, setActive: true];
+        } else if slot == 2 {
+            // Bottom: pin bottom to parent bottom
+            let child_bottom: Retained<AnyObject> = msg_send![child, bottomAnchor];
+            let parent_bottom: Retained<AnyObject> = msg_send![parent, bottomAnchor];
+            let c: Retained<AnyObject> = msg_send![&*child_bottom, constraintEqualToAnchor: &*parent_bottom];
+            let _: () = msg_send![&*c, setActive: true];
+        } else {
+            // Middle (slot 1): pin top to first subview's bottom, bottom to third subview's top
+            // At this point, subviews should be [top, middle]. Bottom will be added next.
+            // We'll pin the middle's top to the first subview's bottom here,
+            // and bottom to the third subview's top when slot=2 is added.
+            let subviews: Retained<AnyObject> = msg_send![parent, subviews];
+            let count: usize = msg_send![&*subviews, count];
+            if count >= 2 {
+                // First subview is the "top" slot
+                let top_view: *const AnyObject = msg_send![&*subviews, objectAtIndex: 0usize];
+                if !top_view.is_null() {
+                    let top_bottom: Retained<AnyObject> = msg_send![top_view, bottomAnchor];
+                    let child_top: Retained<AnyObject> = msg_send![child, topAnchor];
+                    let c: Retained<AnyObject> = msg_send![&*child_top, constraintEqualToAnchor: &*top_bottom];
+                    let _: () = msg_send![&*c, setActive: true];
+                }
+            }
+        }
+    }
+}
+
+/// Finalize the vbox by pinning middle.bottom to bottom.top.
+/// Must be called after all 3 children (top=0, middle=1, bottom=2) are added.
+pub fn vbox_finalize(parent: &UIView) {
+    unsafe {
+        let subviews: Retained<AnyObject> = msg_send![parent, subviews];
+        let count: usize = msg_send![&*subviews, count];
+        if count >= 3 {
+            let middle: *const AnyObject = msg_send![&*subviews, objectAtIndex: 1usize];
+            let bottom: *const AnyObject = msg_send![&*subviews, objectAtIndex: 2usize];
+            if !middle.is_null() && !bottom.is_null() {
+                let mid_bottom: Retained<AnyObject> = msg_send![middle, bottomAnchor];
+                let bot_top: Retained<AnyObject> = msg_send![bottom, topAnchor];
+                let c: Retained<AnyObject> = msg_send![&*mid_bottom, constraintEqualToAnchor: &*bot_top];
+                let _: () = msg_send![&*c, setActive: true];
+            }
+        }
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/tabbar.rs
+++ b/crates/perry-ui-visionos/src/widgets/tabbar.rs
@@ -1,0 +1,232 @@
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, Sel};
+use objc2::{define_class, msg_send, AnyThread, DefinedClass};
+use objc2_ui_kit::UIView;
+use objc2_foundation::{NSObject, NSString, MainThreadMarker};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    static _dispatch_main_q: std::ffi::c_void;
+    fn dispatch_async_f(
+        queue: *const std::ffi::c_void,
+        context: *mut std::ffi::c_void,
+        work: unsafe extern "C" fn(*mut std::ffi::c_void),
+    );
+}
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// Pick an SF Symbol name based on the tab label.
+fn icon_for_label(label: &str) -> &'static str {
+    let lower = label.to_ascii_lowercase();
+    if lower.contains("dashboard") || lower.contains("home") || lower.contains("performance") {
+        "chart.bar.fill"
+    } else if lower.contains("profile") || lower.contains("account") {
+        "person.fill"
+    } else if lower.contains("setting") {
+        "gearshape.fill"
+    } else if lower.contains("search") {
+        "magnifyingglass"
+    } else if lower.contains("site") {
+        "globe"
+    } else if lower.contains("chart") || lower.contains("stat") || lower.contains("analytic") {
+        "chart.bar.fill"
+    } else {
+        "circle.fill"
+    }
+}
+
+// ── State ─────────────────────────────────────────────────────
+
+struct TabBarState {
+    items: Vec<*mut AnyObject>,    // UITabBarItem raw pointers (kept alive by UITabBar)
+    on_change: f64,
+}
+
+thread_local! {
+    static TABBAR_STATE: RefCell<HashMap<i64, TabBarState>> = RefCell::new(HashMap::new());
+    /// Maps delegate address → tabbar handle
+    static DELEGATE_MAP: RefCell<HashMap<usize, i64>> = RefCell::new(HashMap::new());
+}
+
+// ── UITabBarDelegate ─────────────────────────────────────────
+
+pub struct PerryTabBarDelegateIvars {
+    key: std::cell::Cell<usize>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryTabBarDelegate"]
+    #[ivars = PerryTabBarDelegateIvars]
+    pub struct PerryTabBarDelegate;
+
+    impl PerryTabBarDelegate {
+        #[unsafe(method(tabBar:didSelectItem:))]
+        fn tab_bar_did_select_item(&self, _tab_bar: &AnyObject, item: &AnyObject) {
+            let tag: i64 = unsafe { msg_send![item, tag] };
+            let key = self.ivars().key.get();
+
+            let tabbar_handle = DELEGATE_MAP.with(|m| {
+                m.borrow().get(&key).copied().unwrap_or(0)
+            });
+
+            if tabbar_handle == 0 { return; }
+
+            let on_change = TABBAR_STATE.with(|s| {
+                s.borrow().get(&tabbar_handle).map(|st| st.on_change).unwrap_or(0.0)
+            });
+
+            if on_change != 0.0 {
+                let packed = Box::new((on_change, tag));
+                unsafe {
+                    dispatch_async_f(
+                        &_dispatch_main_q as *const _ as *const std::ffi::c_void,
+                        Box::into_raw(packed) as *mut std::ffi::c_void,
+                        tab_callback_trampoline,
+                    );
+                }
+            }
+        }
+    }
+);
+
+impl PerryTabBarDelegate {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryTabBarDelegateIvars {
+            key: std::cell::Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+unsafe extern "C" fn tab_callback_trampoline(context: *mut std::ffi::c_void) {
+    let _ = std::panic::catch_unwind(|| {
+        let packed = Box::from_raw(context as *mut (f64, i64));
+        let (closure_f64, tab_index) = *packed;
+        let closure_ptr = js_nanbox_get_pointer(closure_f64);
+        js_closure_call1(closure_ptr as *const u8, tab_index as f64);
+    });
+}
+
+// ── Public API ────────────────────────────────────────────────
+
+/// Create a native UITabBar.
+pub fn create(on_change: f64) -> i64 {
+    let _mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+    unsafe {
+        // Create UITabBar
+        let tabbar_cls = objc2::runtime::AnyClass::get(c"UITabBar").unwrap();
+        let tabbar: *mut AnyObject = msg_send![tabbar_cls, alloc];
+        let tabbar: *mut AnyObject = msg_send![tabbar, init];
+
+        // Google Blue (#4285f4) tint
+        let tint: Retained<AnyObject> = msg_send![
+            objc2::runtime::AnyClass::get(c"UIColor").unwrap(),
+            colorWithRed: 0.263f64,
+            green: 0.522f64,
+            blue: 0.957f64,
+            alpha: 1.0f64
+        ];
+        let _: () = msg_send![tabbar, setTintColor: &*tint];
+
+        // Create and set delegate
+        let delegate = PerryTabBarDelegate::new();
+        let delegate_addr = Retained::as_ptr(&delegate) as usize;
+        delegate.ivars().key.set(delegate_addr);
+        let _: () = msg_send![tabbar, setDelegate: &*delegate];
+        std::mem::forget(delegate); // keep alive
+
+        let view: Retained<UIView> = Retained::retain(tabbar as *mut UIView).unwrap();
+        let handle = super::register_widget(view);
+
+        DELEGATE_MAP.with(|m| {
+            m.borrow_mut().insert(delegate_addr, handle);
+        });
+
+        TABBAR_STATE.with(|s| {
+            s.borrow_mut().insert(handle, TabBarState {
+                items: Vec::new(),
+                on_change,
+            });
+        });
+
+        handle
+    }
+}
+
+/// Add a tab item with a title and auto-detected SF Symbol icon.
+pub fn add_tab(tabbar_handle: i64, label_ptr: *const u8) {
+    let label = str_from_header(label_ptr);
+    let _mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+
+    let tab_index = TABBAR_STATE.with(|s| {
+        s.borrow().get(&tabbar_handle).map(|st| st.items.len() as i64).unwrap_or(0)
+    });
+
+    unsafe {
+        // Create SF Symbol image
+        let icon_name = icon_for_label(label);
+        let ns_icon = NSString::from_str(icon_name);
+        let image: *mut AnyObject = msg_send![
+            objc2::runtime::AnyClass::get(c"UIImage").unwrap(),
+            systemImageNamed: &*ns_icon
+        ];
+
+        // Create UITabBarItem
+        let ns_title = NSString::from_str(label);
+        let item_cls = objc2::runtime::AnyClass::get(c"UITabBarItem").unwrap();
+        let item: *mut AnyObject = msg_send![item_cls, alloc];
+        let item: *mut AnyObject = msg_send![
+            item,
+            initWithTitle: &*ns_title,
+            image: image,
+            tag: tab_index
+        ];
+
+        // Store item and update UITabBar
+        TABBAR_STATE.with(|s| {
+            if let Some(state) = s.borrow_mut().get_mut(&tabbar_handle) {
+                state.items.push(item);
+
+                // Build NSArray of all items
+                if let Some(bar_view) = super::get_widget(tabbar_handle) {
+                    let arr_cls = objc2::runtime::AnyClass::get(c"NSMutableArray").unwrap();
+                    let arr: *mut AnyObject = msg_send![arr_cls, arrayWithCapacity: state.items.len()];
+                    for &itm in &state.items {
+                        let _: () = msg_send![arr, addObject: itm];
+                    }
+                    let _: () = msg_send![&*bar_view, setItems: arr, animated: false];
+                }
+            }
+        });
+    }
+}
+
+/// Set the selected tab by index.
+pub fn set_selected(tabbar_handle: i64, index: i64) {
+    TABBAR_STATE.with(|s| {
+        if let Some(state) = s.borrow().get(&tabbar_handle) {
+            if let Some(&item) = state.items.get(index as usize) {
+                if let Some(bar_view) = super::get_widget(tabbar_handle) {
+                    unsafe {
+                        let _: () = msg_send![&*bar_view, setSelectedItem: item];
+                    }
+                }
+            }
+        }
+    });
+}

--- a/crates/perry-ui-visionos/src/widgets/text.rs
+++ b/crates/perry-ui-visionos/src/widgets/text.rs
@@ -1,0 +1,142 @@
+use objc2::rc::Retained;
+use objc2::msg_send;
+use objc2::runtime::AnyClass;
+use objc2_ui_kit::{UILabel, UIView};
+use objc2_foundation::NSString;
+use perry_runtime::string::StringHeader;
+
+use super::register_widget;
+
+/// Extract a &str from a *const StringHeader pointer.
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// Create a UILabel.
+pub fn create(text_ptr: *const u8) -> i64 {
+    let text = str_from_header(text_ptr);
+
+    unsafe {
+        let label: Retained<UILabel> = msg_send![objc2::runtime::AnyClass::get(c"UILabel").unwrap(), new];
+        let ns_string = NSString::from_str(text);
+        let _: () = msg_send![&*label, setText: &*ns_string];
+        let _: () = msg_send![&*label, setAccessibilityLabel: &*ns_string];
+        // translatesAutoresizingMaskIntoConstraints = false for Auto Layout
+        let _: () = msg_send![&*label, setTranslatesAutoresizingMaskIntoConstraints: false];
+
+        let view: Retained<UIView> = Retained::cast_unchecked(label);
+        register_widget(view)
+    }
+}
+
+/// Update the text of an existing UILabel.
+pub fn set_text_str(handle: i64, text: &str) {
+    if let Some(view) = super::get_widget(handle) {
+        let ns_string = NSString::from_str(text);
+        unsafe {
+            let _: () = msg_send![&*view, setText: &*ns_string];
+        }
+    }
+}
+
+/// Update the text of an existing UILabel from a StringHeader pointer.
+pub fn set_string(handle: i64, text_ptr: *const u8) {
+    let text = str_from_header(text_ptr);
+    set_text_str(handle, text);
+}
+
+/// Set the text color of a UILabel (RGBA 0.0-1.0).
+pub fn set_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let color: Retained<objc2::runtime::AnyObject> = msg_send![
+                objc2::runtime::AnyClass::get(c"UIColor").unwrap(),
+                colorWithRed: r as objc2_core_foundation::CGFloat,
+                green: g as objc2_core_foundation::CGFloat,
+                blue: b as objc2_core_foundation::CGFloat,
+                alpha: a as objc2_core_foundation::CGFloat
+            ];
+            let _: () = msg_send![&*view, setTextColor: &*color];
+        }
+    }
+}
+
+/// Determine the correct target for font/text operations.
+/// For UIButton, returns its titleLabel; for other views, returns the view itself.
+fn font_target(view: &UIView) -> *const objc2::runtime::AnyObject {
+    if let Some(btn_cls) = AnyClass::get(c"UIButton") {
+        let is_button: bool = unsafe { msg_send![view, isKindOfClass: btn_cls] };
+        if is_button {
+            // UIButton: set font on titleLabel, not the button itself
+            unsafe {
+                let title_label: *const objc2::runtime::AnyObject = msg_send![view, titleLabel];
+                return title_label;
+            }
+        }
+    }
+    view as *const UIView as *const objc2::runtime::AnyObject
+}
+
+/// Set the font size of a UILabel (or UIButton's titleLabel).
+pub fn set_font_size(handle: i64, size: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let font: Retained<objc2::runtime::AnyObject> = msg_send![
+                AnyClass::get(c"UIFont").unwrap(),
+                systemFontOfSize: size as objc2_core_foundation::CGFloat
+            ];
+            let target = font_target(&view);
+            if !target.is_null() {
+                let _: () = msg_send![target, setFont: &*font];
+            }
+        }
+    }
+}
+
+/// Set the font weight of a UILabel (or UIButton's titleLabel).
+pub fn set_font_weight(handle: i64, size: f64, weight: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let font: Retained<objc2::runtime::AnyObject> = msg_send![
+                AnyClass::get(c"UIFont").unwrap(),
+                systemFontOfSize: size as objc2_core_foundation::CGFloat,
+                weight: weight as objc2_core_foundation::CGFloat
+            ];
+            let target = font_target(&view);
+            if !target.is_null() {
+                let _: () = msg_send![target, setFont: &*font];
+            }
+        }
+    }
+}
+
+/// Enable word wrapping on a UILabel.
+/// max_width sets the preferred wrapping width (0 = use intrinsic width).
+pub fn set_wraps(handle: i64, max_width: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            // Set numberOfLines = 0 for unlimited lines
+            let _: () = msg_send![&*view, setNumberOfLines: 0_i64];
+            // NSLineBreakByWordWrapping = 0
+            let _: () = msg_send![&*view, setLineBreakMode: 0_i64];
+            // Set preferred max layout width for Auto Layout wrapping
+            if max_width > 0.0 {
+                let _: () = msg_send![&*view, setPreferredMaxLayoutWidth: max_width];
+            }
+        }
+    }
+}
+
+/// Set whether a UILabel is selectable (UILabel doesn't support this, no-op).
+pub fn set_selectable(_handle: i64, _selectable: bool) {
+    // UILabel is not selectable by default and making it so requires
+    // UITextView instead. No-op for now.
+}

--- a/crates/perry-ui-visionos/src/widgets/textarea.rs
+++ b/crates/perry-ui-visionos/src/widgets/textarea.rs
@@ -1,0 +1,137 @@
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject};
+use objc2::{define_class, msg_send, AnyThread, DefinedClass};
+use objc2_ui_kit::UIView;
+use objc2_foundation::{NSObject, NSString};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+thread_local! {
+    static TEXTAREA_CALLBACKS: RefCell<HashMap<usize, (f64, *const AnyObject)>> = RefCell::new(HashMap::new());
+}
+
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_nanbox_string(ptr: i64) -> f64;
+}
+
+pub struct PerryTextAreaDelegateIvars {
+    callback_key: std::cell::Cell<usize>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryTextAreaDelegate"]
+    #[ivars = PerryTextAreaDelegateIvars]
+    pub struct PerryTextAreaDelegate;
+
+    impl PerryTextAreaDelegate {
+        /// UITextViewDelegate method — called when the text view's text changes.
+        #[unsafe(method(textViewDidChange:))]
+        fn text_view_did_change(&self, text_view: &AnyObject) {
+            let key = self.ivars().callback_key.get();
+            TEXTAREA_CALLBACKS.with(|cbs| {
+                if let Some(&(closure_f64, _tv_ptr)) = cbs.borrow().get(&key) {
+                    let text: Retained<NSString> = unsafe { msg_send![text_view, text] };
+                    let rust_str = text.to_string();
+                    let bytes = rust_str.as_bytes();
+
+                    let str_ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64) };
+                    let nanboxed = unsafe { js_nanbox_string(str_ptr as i64) };
+
+                    let closure_ptr = unsafe { js_nanbox_get_pointer(closure_f64) };
+                    unsafe {
+                        js_closure_call1(closure_ptr as *const u8, nanboxed);
+                    }
+                }
+            });
+        }
+    }
+);
+
+impl PerryTextAreaDelegate {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryTextAreaDelegateIvars {
+            callback_key: std::cell::Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// Create a UITextView with placeholder text and onChange callback.
+/// Returns a widget handle.
+pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
+    let _placeholder = str_from_header(placeholder_ptr);
+
+    unsafe {
+        let text_view: Retained<AnyObject> = msg_send![
+            AnyClass::get(c"UITextView").unwrap(),
+            new
+        ];
+        let _: () = msg_send![&*text_view, setEditable: true];
+        let _: () = msg_send![&*text_view, setSelectable: true];
+        let _: () = msg_send![&*text_view, setTranslatesAutoresizingMaskIntoConstraints: false];
+
+        // Set default font (system 14pt)
+        let font_cls = AnyClass::get(c"UIFont").unwrap();
+        let font: Retained<AnyObject> = msg_send![font_cls, systemFontOfSize: 14.0f64];
+        let _: () = msg_send![&*text_view, setFont: &*font];
+
+        // Create delegate for text change notifications
+        let delegate = PerryTextAreaDelegate::new();
+        let delegate_addr = Retained::as_ptr(&delegate) as usize;
+        delegate.ivars().callback_key.set(delegate_addr);
+
+        let tv_ptr = Retained::as_ptr(&text_view) as *const AnyObject;
+        TEXTAREA_CALLBACKS.with(|cbs| {
+            cbs.borrow_mut().insert(delegate_addr, (on_change, tv_ptr));
+        });
+
+        // Set the delegate on the UITextView
+        let _: () = msg_send![&*text_view, setDelegate: &*delegate];
+
+        std::mem::forget(delegate);
+
+        let view: Retained<UIView> = Retained::cast_unchecked(text_view);
+        let handle = super::register_widget(view);
+        handle
+    }
+}
+
+/// Set the text content of a UITextView from a StringHeader pointer.
+pub fn set_string(handle: i64, text_ptr: *const u8) {
+    let text = str_from_header(text_ptr);
+    if let Some(view) = super::get_widget(handle) {
+        let ns_string = NSString::from_str(text);
+        unsafe {
+            let _: () = msg_send![&*view, setText: &*ns_string];
+        }
+    }
+}
+
+/// Get the current text content of a UITextView, returns a StringHeader pointer.
+pub fn get_string(handle: i64) -> *const u8 {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let text: Retained<NSString> = msg_send![&*view, text];
+            let rust_str = text.to_string();
+            let bytes = rust_str.as_bytes();
+            return js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        }
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}

--- a/crates/perry-ui-visionos/src/widgets/textfield.rs
+++ b/crates/perry-ui-visionos/src/widgets/textfield.rs
@@ -1,0 +1,282 @@
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, Sel};
+use objc2::{define_class, msg_send, AnyThread, DefinedClass};
+use objc2_ui_kit::{UITextField, UIView};
+use objc2_foundation::{NSObject, NSString};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+thread_local! {
+    static TEXTFIELD_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_nanbox_string(ptr: i64) -> f64;
+}
+
+pub struct PerryTextFieldTargetIvars {
+    callback_key: std::cell::Cell<usize>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryTextFieldTarget"]
+    #[ivars = PerryTextFieldTargetIvars]
+    pub struct PerryTextFieldTarget;
+
+    impl PerryTextFieldTarget {
+        #[unsafe(method(textFieldChanged:))]
+        fn text_field_changed(&self, sender: &AnyObject) {
+            let key = self.ivars().callback_key.get();
+            TEXTFIELD_CALLBACKS.with(|cbs| {
+                if let Some(&closure_f64) = cbs.borrow().get(&key) {
+                    let text: Retained<NSString> = unsafe { msg_send![sender, text] };
+                    let rust_str = text.to_string();
+                    let bytes = rust_str.as_bytes();
+
+                    let str_ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64) };
+                    let nanboxed = unsafe { js_nanbox_string(str_ptr as i64) };
+
+                    let closure_ptr = unsafe { js_nanbox_get_pointer(closure_f64) };
+                    unsafe {
+                        js_closure_call1(closure_ptr as *const u8, nanboxed);
+                    }
+                }
+            });
+        }
+    }
+);
+
+impl PerryTextFieldTarget {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryTextFieldTargetIvars {
+            callback_key: std::cell::Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// Create a UITextField with placeholder and onChange callback.
+pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
+    let placeholder = str_from_header(placeholder_ptr);
+
+    unsafe {
+        let text_field: Retained<UITextField> = msg_send![
+            objc2::runtime::AnyClass::get(c"UITextField").unwrap(),
+            new
+        ];
+        let ns_placeholder = NSString::from_str(placeholder);
+        let _: () = msg_send![&*text_field, setPlaceholder: &*ns_placeholder];
+        let _: () = msg_send![&*text_field, setAccessibilityLabel: &*ns_placeholder];
+        let _: () = msg_send![&*text_field, setBorderStyle: 3i64]; // UITextBorderStyleRoundedRect = 3
+        let _: () = msg_send![&*text_field, setTranslatesAutoresizingMaskIntoConstraints: false];
+
+        let target = PerryTextFieldTarget::new();
+        let target_addr = Retained::as_ptr(&target) as usize;
+        target.ivars().callback_key.set(target_addr);
+
+        TEXTFIELD_CALLBACKS.with(|cbs| {
+            cbs.borrow_mut().insert(target_addr, on_change);
+        });
+
+        let sel = Sel::register(c"textFieldChanged:");
+        // UIControlEventEditingChanged = 1 << 17 = 131072
+        let _: () = msg_send![&*text_field, addTarget: &*target, action: sel, forControlEvents: 131072u64];
+
+        std::mem::forget(target);
+
+        let view: Retained<UIView> = Retained::cast_unchecked(text_field);
+        let handle = super::register_widget(view);
+        #[cfg(feature = "geisterhand")]
+        {
+            extern "C" { fn perry_geisterhand_register(h: i64, wt: u8, ck: u8, cb: f64, lbl: *const u8); }
+            unsafe { perry_geisterhand_register(handle, 1, 1, on_change, placeholder_ptr); }
+        }
+        handle
+    }
+}
+
+/// Focus a UITextField (make it first responder).
+pub fn focus(handle: i64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let _: () = msg_send![&*view, becomeFirstResponder];
+        }
+    }
+}
+
+/// Set the text of a UITextField from a StringHeader pointer.
+pub fn set_string_value(handle: i64, text_ptr: *const u8) {
+    let text = str_from_header(text_ptr);
+    if let Some(view) = super::get_widget(handle) {
+        let ns_string = NSString::from_str(text);
+        unsafe {
+            let _: () = msg_send![&*view, setText: &*ns_string];
+        }
+    }
+}
+
+/// Set the text of a UITextField from a Rust string slice.
+pub fn set_text_str(handle: i64, text: &str) {
+    if let Some(view) = super::get_widget(handle) {
+        let ns_string = NSString::from_str(text);
+        unsafe {
+            let _: () = msg_send![&*view, setText: &*ns_string];
+        }
+    }
+}
+
+/// Get the current string value from a UITextField, returns a StringHeader pointer.
+pub fn get_string_value(handle: i64) -> *const u8 {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let text: Retained<NSString> = msg_send![&*view, text];
+            let rust_str = text.to_string();
+            let bytes = rust_str.as_bytes();
+            return js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        }
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+
+/// Set whether the text field is borderless (0 = bordered, 1 = borderless).
+pub fn set_borderless(handle: i64, borderless: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            if borderless > 0.5 {
+                // UITextBorderStyleNone = 0
+                let _: () = msg_send![&*view, setBorderStyle: 0i64];
+            } else {
+                // UITextBorderStyleRoundedRect = 3
+                let _: () = msg_send![&*view, setBorderStyle: 3i64];
+            }
+        }
+    }
+}
+
+/// Set the background color of the text field.
+pub fn set_background_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let cls = objc2::runtime::AnyClass::get(c"UIColor").unwrap();
+            let color: Retained<AnyObject> = msg_send![
+                cls,
+                colorWithRed: r as f64,
+                green: g as f64,
+                blue: b as f64,
+                alpha: a as f64
+            ];
+            let _: () = msg_send![&*view, setBackgroundColor: &*color];
+        }
+    }
+}
+
+/// Set the font size of the text field.
+pub fn set_font_size(handle: i64, size: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let cls = objc2::runtime::AnyClass::get(c"UIFont").unwrap();
+            let font: Retained<AnyObject> = msg_send![cls, systemFontOfSize: size as f64];
+            let _: () = msg_send![&*view, setFont: &*font];
+        }
+    }
+}
+
+/// Set the text color of the text field.
+pub fn set_text_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let cls = objc2::runtime::AnyClass::get(c"UIColor").unwrap();
+            let color: Retained<AnyObject> = msg_send![
+                cls,
+                colorWithRed: r as f64,
+                green: g as f64,
+                blue: b as f64,
+                alpha: a as f64
+            ];
+            let _: () = msg_send![&*view, setTextColor: &*color];
+        }
+    }
+}
+
+thread_local! {
+    static SUBMIT_CALLBACKS: RefCell<HashMap<usize, (f64, *const objc2::runtime::AnyObject)>> = RefCell::new(HashMap::new());
+}
+
+pub struct PerryTextFieldSubmitTargetIvars {
+    callback_key: std::cell::Cell<usize>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryTextFieldSubmitTarget"]
+    #[ivars = PerryTextFieldSubmitTargetIvars]
+    pub struct PerryTextFieldSubmitTarget;
+
+    impl PerryTextFieldSubmitTarget {
+        #[unsafe(method(textFieldDidReturn:))]
+        fn text_field_did_return(&self, sender: &AnyObject) {
+            let key = self.ivars().callback_key.get();
+            SUBMIT_CALLBACKS.with(|cbs| {
+                if let Some(&(closure_f64, _tf_ptr)) = cbs.borrow().get(&key) {
+                    // Get the text
+                    let text: Retained<NSString> = unsafe { msg_send![sender, text] };
+                    let rust_str = text.to_string();
+                    let bytes = rust_str.as_bytes();
+                    let str_ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64) };
+                    let nanboxed = unsafe { js_nanbox_string(str_ptr as i64) };
+                    let closure_ptr = unsafe { js_nanbox_get_pointer(closure_f64) };
+                    unsafe {
+                        js_closure_call1(closure_ptr as *const u8, nanboxed);
+                    }
+                }
+            });
+        }
+    }
+);
+
+impl PerryTextFieldSubmitTarget {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryTextFieldSubmitTargetIvars {
+            callback_key: std::cell::Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+/// Set an onSubmit callback (fires when user presses Return).
+pub fn set_on_submit(handle: i64, on_submit: f64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let target = PerryTextFieldSubmitTarget::new();
+            let target_addr = Retained::as_ptr(&target) as usize;
+            target.ivars().callback_key.set(target_addr);
+
+            let tf_raw = Retained::as_ptr(&view) as *const objc2::runtime::AnyObject;
+            SUBMIT_CALLBACKS.with(|cbs| {
+                cbs.borrow_mut().insert(target_addr, (on_submit, tf_raw));
+            });
+
+            let sel = Sel::register(c"textFieldDidReturn:");
+            // UIControlEventEditingDidEndOnExit = 1 << 19 = 524288
+            let _: () = msg_send![&*view, addTarget: &*target, action: sel, forControlEvents: 524288_u64];
+
+            std::mem::forget(target);
+        }
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/toggle.rs
+++ b/crates/perry-ui-visionos/src/widgets/toggle.rs
@@ -1,0 +1,71 @@
+use objc2::rc::Retained;
+use objc2::msg_send;
+use objc2_ui_kit::{UILabel, UIView};
+use objc2_foundation::NSString;
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+thread_local! {
+    static TOGGLE_LABELS: RefCell<HashMap<i64, String>> = RefCell::new(HashMap::new());
+}
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// Set the on/off state of an existing toggle widget.
+pub fn set_state(handle: i64, on: i64) {
+    if let Some(view) = super::get_widget(handle) {
+        TOGGLE_LABELS.with(|labels| {
+            if let Some(label) = labels.borrow().get(&handle) {
+                let text = NSString::from_str(&format!("{}: {}", label, if on != 0 { "On" } else { "Off" }));
+                unsafe {
+                    let _: () = msg_send![&*view, setText: &*text];
+                }
+            }
+        });
+    }
+}
+
+/// Create a visionOS-safe toggle fallback.
+///
+/// visionOS is rejecting the UIKit toggle control path with an Objective-C
+/// exception during construction in the simulator. For now render a static
+/// label so apps stay alive while the rest of the UI backend is exercised.
+pub fn create(label_ptr: *const u8, on_change: f64) -> i64 {
+    // TODO(visionos): replace UILabel stub with UISwitch once sim-side
+    // construction stops throwing Objective-C exceptions. See PR #127.
+    let label = str_from_header(label_ptr);
+    let _ = on_change;
+
+    unsafe {
+        let label_cls = match objc2::runtime::AnyClass::get(c"UILabel") {
+            Some(cls) => cls,
+            None => return 0,
+        };
+        let ns_label = NSString::from_str(&format!("{}: Off", label));
+        let text_label: Retained<UILabel> = msg_send![label_cls, new];
+        let _: () = msg_send![&*text_label, setText: &*ns_label];
+        let view: Retained<UIView> = Retained::cast_unchecked(text_label);
+        let handle = super::register_widget(view);
+        TOGGLE_LABELS.with(|labels| {
+            labels.borrow_mut().insert(handle, label.to_string());
+        });
+
+        #[cfg(feature = "geisterhand")]
+        {
+            extern "C" { fn perry_geisterhand_register(h: i64, wt: u8, ck: u8, cb: f64, lbl: *const u8); }
+            unsafe { perry_geisterhand_register(handle, 3, 1, on_change, label_ptr); }
+        }
+
+        handle
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/vstack.rs
+++ b/crates/perry-ui-visionos/src/widgets/vstack.rs
@@ -1,0 +1,73 @@
+use objc2::encode::Encode;
+use objc2::rc::Retained;
+use objc2::msg_send;
+use objc2_ui_kit::{UIStackView, UIView};
+
+/// UIEdgeInsets struct matching UIKit layout.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub(crate) struct UIEdgeInsets {
+    pub top: objc2_core_foundation::CGFloat,
+    pub left: objc2_core_foundation::CGFloat,
+    pub bottom: objc2_core_foundation::CGFloat,
+    pub right: objc2_core_foundation::CGFloat,
+}
+
+// Safety: UIEdgeInsets is a simple C struct with 4 CGFloat fields
+unsafe impl objc2::encode::Encode for UIEdgeInsets {
+    const ENCODING: objc2::encode::Encoding = objc2::encode::Encoding::Struct(
+        "UIEdgeInsets",
+        &[
+            objc2_core_foundation::CGFloat::ENCODING,
+            objc2_core_foundation::CGFloat::ENCODING,
+            objc2_core_foundation::CGFloat::ENCODING,
+            objc2_core_foundation::CGFloat::ENCODING,
+        ],
+    );
+}
+
+unsafe impl objc2::encode::RefEncode for UIEdgeInsets {
+    const ENCODING_REF: objc2::encode::Encoding = objc2::encode::Encoding::Pointer(
+        &Self::ENCODING,
+    );
+}
+
+/// Create a UIStackView with vertical axis (no default edge insets — matches macOS).
+pub fn create(spacing: f64) -> i64 {
+    unsafe {
+        let stack: Retained<UIStackView> = msg_send![
+            objc2::runtime::AnyClass::get(c"UIStackView").unwrap(),
+            new
+        ];
+        let _: () = msg_send![&*stack, setAxis: 1i64]; // UILayoutConstraintAxisVertical = 1
+        let _: () = msg_send![&*stack, setSpacing: spacing as objc2_core_foundation::CGFloat];
+        let _: () = msg_send![&*stack, setAlignment: 0i64]; // UIStackViewAlignmentFill = 0
+        let _: () = msg_send![&*stack, setDistribution: 0i64]; // UIStackViewDistributionFill = 0
+        let _: () = msg_send![&*stack, setTranslatesAutoresizingMaskIntoConstraints: false];
+
+        let view: Retained<UIView> = Retained::cast_unchecked(stack);
+        super::register_widget(view)
+    }
+}
+
+/// Create a UIStackView with vertical axis and custom edge insets.
+pub fn create_with_insets(spacing: f64, top: f64, left: f64, bottom: f64, right: f64) -> i64 {
+    unsafe {
+        let stack: Retained<UIStackView> = msg_send![
+            objc2::runtime::AnyClass::get(c"UIStackView").unwrap(),
+            new
+        ];
+        let _: () = msg_send![&*stack, setAxis: 1i64];
+        let _: () = msg_send![&*stack, setSpacing: spacing as objc2_core_foundation::CGFloat];
+        let _: () = msg_send![&*stack, setAlignment: 0i64]; // UIStackViewAlignmentFill = 0
+        let _: () = msg_send![&*stack, setTranslatesAutoresizingMaskIntoConstraints: false];
+
+        let insets = UIEdgeInsets { top, left, bottom, right };
+        let _: () = msg_send![&*stack, setLayoutMargins: insets];
+        let _: () = msg_send![&*stack, setLayoutMarginsRelativeArrangement: true];
+        let _: () = msg_send![&*stack, setInsetsLayoutMarginsFromSafeArea: false];
+
+        let view: Retained<UIView> = Retained::cast_unchecked(stack);
+        super::register_widget(view)
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/zstack.rs
+++ b/crates/perry-ui-visionos/src/widgets/zstack.rs
@@ -1,0 +1,43 @@
+use objc2::rc::Retained;
+use objc2::msg_send;
+use objc2::runtime::{AnyClass, AnyObject};
+use objc2_ui_kit::UIView;
+use objc2_foundation::MainThreadMarker;
+
+pub fn create() -> i64 {
+    let _mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+    unsafe {
+        let obj: *mut AnyObject = msg_send![AnyClass::get(c"UIView").unwrap(), new];
+        let view: Retained<UIView> = Retained::retain(obj as *mut UIView).unwrap();
+        super::register_widget(view)
+    }
+}
+
+pub fn add_child(parent_handle: i64, child_handle: i64) {
+    if let (Some(parent), Some(child)) = (super::get_widget(parent_handle), super::get_widget(child_handle)) {
+        unsafe {
+            let _: () = msg_send![&*parent, addSubview: &*child];
+            let _: () = msg_send![&*child, setTranslatesAutoresizingMaskIntoConstraints: false];
+            // Pin to fill parent
+            let leading: *mut objc2::runtime::AnyObject = msg_send![&*child, leadingAnchor];
+            let p_leading: *mut objc2::runtime::AnyObject = msg_send![&*parent, leadingAnchor];
+            let c1: *mut objc2::runtime::AnyObject = msg_send![leading, constraintEqualToAnchor: p_leading];
+            let _: () = msg_send![c1, setActive: true];
+
+            let trailing: *mut objc2::runtime::AnyObject = msg_send![&*child, trailingAnchor];
+            let p_trailing: *mut objc2::runtime::AnyObject = msg_send![&*parent, trailingAnchor];
+            let c2: *mut objc2::runtime::AnyObject = msg_send![trailing, constraintEqualToAnchor: p_trailing];
+            let _: () = msg_send![c2, setActive: true];
+
+            let top: *mut objc2::runtime::AnyObject = msg_send![&*child, topAnchor];
+            let p_top: *mut objc2::runtime::AnyObject = msg_send![&*parent, topAnchor];
+            let c3: *mut objc2::runtime::AnyObject = msg_send![top, constraintEqualToAnchor: p_top];
+            let _: () = msg_send![c3, setActive: true];
+
+            let bottom: *mut objc2::runtime::AnyObject = msg_send![&*child, bottomAnchor];
+            let p_bottom: *mut objc2::runtime::AnyObject = msg_send![&*parent, bottomAnchor];
+            let c4: *mut objc2::runtime::AnyObject = msg_send![bottom, constraintEqualToAnchor: p_bottom];
+            let _: () = msg_send![c4, setActive: true];
+        }
+    }
+}

--- a/crates/perry-ui-visionos/swift/PerryVisionApp.swift
+++ b/crates/perry-ui-visionos/swift/PerryVisionApp.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+import UIKit
+
+@_silgen_name("perry_main_init") func perry_main_init()
+@_silgen_name("perry_visionos_root_view") func perry_visionos_root_view() -> Int64
+
+final class PerryVisionBootstrap {
+    static let shared = PerryVisionBootstrap()
+    let rootView: UIView
+
+    private init() {
+        perry_main_init()
+        let ptr = perry_visionos_root_view()
+        if ptr != 0 {
+            rootView = Unmanaged<UIView>.fromOpaque(UnsafeRawPointer(bitPattern: UInt(ptr))!).takeRetainedValue()
+        } else {
+            let label = UILabel()
+            label.text = "Perry visionOS root view missing"
+            rootView = label
+        }
+    }
+}
+
+struct PerryHostedView: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let container = UIView(frame: .zero)
+        let root = PerryVisionBootstrap.shared.rootView
+        root.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(root)
+        NSLayoutConstraint.activate([
+            root.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            root.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            root.topAnchor.constraint(equalTo: container.topAnchor),
+            root.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+
+        let env = ProcessInfo.processInfo.environment
+        if let screenshotPath = env["PERRY_UI_SCREENSHOT_PATH"],
+           let testMode = env["PERRY_UI_TEST_MODE"],
+           !testMode.isEmpty,
+           testMode != "0",
+           !testMode.lowercased().elementsEqual("false") {
+            let delayMs = Int(env["PERRY_UI_TEST_EXIT_AFTER_MS"] ?? "1000") ?? 1000
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(delayMs)) {
+                let resolvedPath: String
+                if screenshotPath.hasPrefix("/") {
+                    resolvedPath = screenshotPath
+                } else {
+                    resolvedPath = "\(NSHomeDirectory())/\(screenshotPath)"
+                }
+                let url = URL(fileURLWithPath: resolvedPath)
+                let dir = url.deletingLastPathComponent()
+                try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+                var bounds = container.bounds
+                if bounds.width < 2 || bounds.height < 2 {
+                    bounds = CGRect(x: 0, y: 0, width: 1280, height: 720)
+                    container.frame = bounds
+                    root.frame = container.bounds
+                    container.layoutIfNeeded()
+                }
+                let renderer = UIGraphicsImageRenderer(bounds: bounds)
+                let image = renderer.image { ctx in
+                    container.drawHierarchy(in: bounds, afterScreenUpdates: true)
+                }
+                if let data = image.pngData() {
+                    try? data.write(to: url)
+                }
+                exit(0)
+            }
+        }
+
+        return container
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}
+
+@main
+struct PerryVisionApp: App {
+    init() {
+        _ = PerryVisionBootstrap.shared
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            PerryHostedView()
+        }
+    }
+}

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -804,6 +804,8 @@ fn rust_target_triple(target: Option<&str>) -> Option<&'static str> {
     match target {
         Some("ios-simulator") | Some("ios-widget-simulator") => Some("aarch64-apple-ios-sim"),
         Some("ios") | Some("ios-widget") => Some("aarch64-apple-ios"),
+        Some("visionos-simulator") => Some("aarch64-apple-visionos-sim"),
+        Some("visionos") => Some("aarch64-apple-visionos"),
         Some("watchos-simulator") => Some("aarch64-apple-watchos-sim"),
         Some("watchos") => Some("arm64_32-apple-watchos"),
         Some("tvos-simulator") => Some("aarch64-apple-tvos-sim"),
@@ -864,6 +866,8 @@ fn strip_duplicate_objects_from_lib(lib_path: &PathBuf) -> Result<PathBuf> {
         Some("windows")
     } else if lib_name.contains("_ios") {
         Some("ios")
+    } else if lib_name.contains("_visionos") {
+        Some("visionos")
     } else if lib_name.contains("_tvos") {
         Some("tvos")
     } else if lib_name.contains("_watchos") {
@@ -1343,6 +1347,14 @@ fn collect_library_candidates(name: &str, target: Option<&str>) -> Vec<PathBuf> 
                         candidates.push(dir.join(&ios_name));
                     }
                 }
+                if matches!(target, Some("visionos") | Some("visionos-simulator")) {
+                    if name.contains("_visionos") {
+                        candidates.push(dir.join(name));
+                    } else {
+                        let visionos_name = name.replace(".a", "_visionos.a");
+                        candidates.push(dir.join(&visionos_name));
+                    }
+                }
                 if matches!(target, Some("watchos") | Some("watchos-simulator")) {
                     if name.contains("_watchos") {
                         candidates.push(dir.join(name));
@@ -1459,6 +1471,7 @@ fn find_jsruntime_library(target: Option<&str>) -> Option<PathBuf> {
 fn find_ui_library(target: Option<&str>) -> Option<PathBuf> {
     let lib_name = match target {
         Some("ios-simulator") | Some("ios") => "libperry_ui_ios.a",
+        Some("visionos-simulator") | Some("visionos") => "libperry_ui_visionos.a",
         Some("android") => "libperry_ui_android.a",
         Some("watchos-simulator") | Some("watchos") => "libperry_ui_watchos.a",
         Some("tvos-simulator") | Some("tvos") => "libperry_ui_tvos.a",
@@ -1532,6 +1545,8 @@ fn find_geisterhand_runtime(target: Option<&str>) -> Option<PathBuf> {
 fn find_geisterhand_ui(target: Option<&str>) -> Option<PathBuf> {
     let name = if matches!(target, Some("ios-simulator") | Some("ios")) {
         "libperry_ui_ios.a"
+    } else if matches!(target, Some("visionos-simulator") | Some("visionos")) {
+        return None;
     } else if matches!(target, Some("android")) {
         "libperry_ui_android.a"
     } else if matches!(target, Some("linux")) || cfg!(target_os = "linux") {
@@ -1547,6 +1562,11 @@ fn find_geisterhand_ui(target: Option<&str>) -> Option<PathBuf> {
 /// Auto-build geisterhand-enabled libraries when they're missing.
 /// Uses a separate target dir (target/geisterhand/) to avoid mixing with normal builds.
 fn build_geisterhand_libs(target: Option<&str>, format: OutputFormat) -> Result<()> {
+    if matches!(target, Some("visionos") | Some("visionos-simulator")) {
+        return Err(anyhow!(
+            "Geisterhand is not supported on visionOS yet."
+        ));
+    }
     // Determine which UI crate to build based on target platform
     let ui_crate = match target {
         Some("ios-simulator") | Some("ios") => "perry-ui-ios",
@@ -1959,6 +1979,7 @@ fn build_optimized_libs(
         if ctx.needs_ui {
             let ui_crate = match target {
                 Some("ios-simulator") | Some("ios") | Some("ios-widget") | Some("ios-widget-simulator") => "perry-ui-ios",
+                Some("visionos-simulator") | Some("visionos") => "perry-ui-visionos",
                 Some("android") => "perry-ui-android",
                 Some("watchos-simulator") | Some("watchos") => "perry-ui-watchos",
                 Some("tvos-simulator") | Some("tvos") => "perry-ui-tvos",
@@ -2094,6 +2115,7 @@ fn parse_native_library_manifest(
     // Parse target config
     let target_key = match target {
         Some("ios-simulator") | Some("ios") => "ios",
+        Some("visionos-simulator") | Some("visionos") => "visionos",
         Some("android") => "android",
         Some("tvos-simulator") | Some("tvos") => "tvos",
         Some("watchos-simulator") | Some("watchos") => "watchos",
@@ -3335,6 +3357,47 @@ fn find_watchos_swift_runtime() -> Option<PathBuf> {
     }
 
     None
+}
+
+fn find_visionos_swift_runtime() -> Option<PathBuf> {
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let candidate = dir.join("swift").join("PerryVisionApp.swift");
+            if candidate.exists() {
+                return Some(candidate);
+            }
+            if let Some(prefix) = dir.parent() {
+                let candidate = prefix.join("lib").join("perry").join("swift").join("PerryVisionApp.swift");
+                if candidate.exists() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+
+    let source_candidate = PathBuf::from("crates/perry-ui-visionos/swift/PerryVisionApp.swift");
+    if source_candidate.exists() {
+        return Some(source_candidate);
+    }
+
+    None
+}
+
+fn apple_sdk_version(sdk: &str) -> Option<String> {
+    let output = Command::new("xcrun")
+        .args(["--sdk", sdk, "--show-sdk-version"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let version = String::from_utf8(output.stdout).ok()?;
+    let version = version.trim();
+    if version.is_empty() {
+        None
+    } else {
+        Some(version.to_string())
+    }
 }
 
 /// Look up bundle_id from perry.toml for a specific section (e.g., "watchos", "ios", "app")
@@ -4980,7 +5043,13 @@ pub fn run_with_parse_cache(
             .map(|f| f.trim().to_string())
             .filter(|f| !f.is_empty())
             .collect();
-        let is_mobile = matches!(target.as_deref(), Some("ios") | Some("ios-simulator") | Some("android") | Some("watchos") | Some("watchos-simulator") | Some("tvos") | Some("tvos-simulator"));
+        let is_mobile = matches!(target.as_deref(),
+            Some("ios") | Some("ios-simulator") |
+            Some("visionos") | Some("visionos-simulator") |
+            Some("android") |
+            Some("watchos") | Some("watchos-simulator") |
+            Some("tvos") | Some("tvos-simulator")
+        );
         if is_mobile {
             features.retain(|f| f != "plugins");
         }
@@ -5616,6 +5685,7 @@ pub fn run_with_parse_cache(
         // Use TARGET (what we're compiling to), not HOST (what we're running on)
         let is_macho = matches!(target.as_deref(),
             Some("ios") | Some("ios-simulator") | Some("ios-widget") | Some("ios-widget-simulator") |
+            Some("visionos") | Some("visionos-simulator") |
             Some("macos") | Some("watchos") | Some("watchos-simulator") |
             Some("tvos") | Some("tvos-simulator")
         ) || (!is_windows && !is_linux && !is_android && cfg!(target_os = "macos"));
@@ -5865,6 +5935,7 @@ pub fn run_with_parse_cache(
     }
 
     let is_ios = matches!(target.as_deref(), Some("ios-simulator") | Some("ios"));
+    let is_visionos = matches!(target.as_deref(), Some("visionos-simulator") | Some("visionos"));
     let is_android = matches!(target.as_deref(), Some("android"));
     let is_linux = matches!(target.as_deref(), Some("linux"))
         || (target.is_none() && cfg!(target_os = "linux"));
@@ -5872,6 +5943,7 @@ pub fn run_with_parse_cache(
         || (target.is_none() && cfg!(target_os = "windows"));
     let is_cross_windows = is_windows && !cfg!(target_os = "windows");
     let is_cross_ios = is_ios && !cfg!(target_os = "macos");
+    let is_cross_visionos = is_visionos && !cfg!(target_os = "macos");
     let is_cross_macos = matches!(target.as_deref(), Some("macos")) && !cfg!(target_os = "macos");
     // Note: is_watchos and is_tvos are defined below (near jsruntime_lib); is_cross_tvos
     // is set after them so this block keeps all is_cross_* bindings together.
@@ -5951,7 +6023,7 @@ pub fn run_with_parse_cache(
     // Without this the is_tvos branch below would unconditionally call `xcrun`,
     // which only exists on macOS with Xcode.
     let is_cross_tvos = is_tvos && !cfg!(target_os = "macos");
-    let jsruntime_lib = if !is_ios && !is_android && !is_watchos && !is_tvos && (ctx.needs_js_runtime || args.enable_js_runtime) {
+    let jsruntime_lib = if !is_ios && !is_visionos && !is_android && !is_watchos && !is_tvos && (ctx.needs_js_runtime || args.enable_js_runtime) {
         match find_jsruntime_library(target.as_deref()) {
             Some(lib) => {
                 match format {
@@ -6069,6 +6141,57 @@ pub fn run_with_parse_cache(
              .arg(&swift_runtime);
             c
         }
+    } else if is_visionos && is_cross_visionos {
+        return Err(anyhow!(
+            "Local visionOS compilation requires Xcode on macOS. Use a macOS host or Perry Hub remote build."
+        ));
+    } else if is_visionos {
+        let sdk = if target.as_deref() == Some("visionos-simulator") { "xrsimulator" } else { "xros" };
+        let swiftc = String::from_utf8(
+            Command::new("xcrun").args(["--sdk", sdk, "--find", "swiftc"]).output()?.stdout
+        )?.trim().to_string();
+        let sysroot = String::from_utf8(
+            Command::new("xcrun").args(["--sdk", sdk, "--show-sdk-path"]).output()?.stdout
+        )?.trim().to_string();
+        let sdk_version = apple_sdk_version(sdk).unwrap_or_else(|| "1.0".to_string());
+        let triple = if target.as_deref() == Some("visionos-simulator") {
+            format!("arm64-apple-xros{}-simulator", sdk_version)
+        } else {
+            format!("arm64-apple-xros{}", sdk_version)
+        };
+        let swift_runtime = find_visionos_swift_runtime()
+            .ok_or_else(|| anyhow!(
+                "PerryVisionApp.swift not found. Expected next to perry binary or in source tree."
+            ))?;
+
+        let input_stem = args.input.file_stem()
+            .and_then(|s| s.to_str())
+            .map(|s| format!("{}_ts", s))
+            .unwrap_or_else(|| "main_ts".to_string());
+        if let Some(entry_obj) = obj_paths.iter().find(|f| {
+            f.file_stem().and_then(|s| s.to_str())
+                .map(|s| s == input_stem.as_str() || s.ends_with(&format!("_{}", input_stem)))
+                .unwrap_or(false)
+        }) {
+            let objcopy = std::env::var("HOME").ok()
+                .map(|h| PathBuf::from(h).join(".rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/rust-objcopy"))
+                .filter(|p| p.exists())
+                .or_else(|| std::env::var("HOME").ok()
+                    .map(|h| PathBuf::from(h).join(".rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-objcopy"))
+                    .filter(|p| p.exists()))
+                .unwrap_or_else(|| PathBuf::from("rust-objcopy"));
+            let _ = Command::new(&objcopy)
+                .args(["--redefine-sym", "_main=_perry_main_init"])
+                .arg(entry_obj)
+                .status();
+        }
+
+        let mut c = Command::new(swiftc);
+        c.arg("-target").arg(&triple)
+         .arg("-sdk").arg(&sysroot)
+         .arg("-parse-as-library")
+         .arg(&swift_runtime);
+        c
     } else if is_ios && is_cross_ios {
         // Cross-compile iOS from Linux using ld64.lld + Apple SDK sysroot
         let ld64 = find_llvm_tool("ld64.lld")
@@ -6332,10 +6455,10 @@ pub fn run_with_parse_cache(
     if !is_windows {
         if is_android || is_linux {
             cmd.arg("-Wl,--gc-sections");
-        } else if is_cross_ios || is_cross_macos || is_cross_tvos {
+        } else if is_cross_ios || is_cross_visionos || is_cross_macos || is_cross_tvos {
             // ld64.lld called directly — no -Wl, prefix needed
             cmd.arg("-dead_strip");
-        } else if is_watchos {
+        } else if is_watchos || is_visionos {
             cmd.arg("-Xlinker").arg("-dead_strip");
         } else {
             // Native macOS/iOS via clang driver
@@ -6367,7 +6490,9 @@ pub fn run_with_parse_cache(
     // symbols (alloc, std::thread_local, etc.). The .a archive provides those
     // as a fallback — the linker only pulls object files from the .a that
     // resolve still-undefined symbols (first-definition-wins on macOS).
-    let skip_runtime = (is_android || is_watchos) && ctx.needs_ui && find_ui_library(target.as_deref()).is_some();
+    let skip_runtime = (is_android || is_watchos || is_visionos)
+        && ctx.needs_ui
+        && find_ui_library(target.as_deref()).is_some();
     if !skip_runtime {
         if let Some(ref jsruntime) = jsruntime_lib {
             cmd.arg(jsruntime);
@@ -6510,6 +6635,23 @@ pub fn run_with_parse_cache(
            .arg("-framework").arg("AVFoundation") // Camera capture (AVCaptureSession)
            .arg("-framework").arg("CoreMedia") // CMSampleBuffer
            .arg("-framework").arg("CoreVideo") // CVPixelBuffer
+           .arg("-liconv")
+           .arg("-lresolv")
+           .arg("-lobjc")
+           .arg("-lSystem");
+    } else if is_visionos {
+        cmd.arg("-framework").arg("SwiftUI")
+           .arg("-framework").arg("UIKit")
+           .arg("-framework").arg("Foundation")
+           .arg("-framework").arg("CoreGraphics")
+           .arg("-framework").arg("Security")
+           .arg("-framework").arg("CoreFoundation")
+           .arg("-framework").arg("SystemConfiguration")
+           .arg("-framework").arg("QuartzCore")
+           .arg("-framework").arg("AVFAudio")
+           .arg("-framework").arg("AVFoundation")
+           .arg("-framework").arg("CoreMedia")
+           .arg("-framework").arg("CoreVideo")
            .arg("-liconv")
            .arg("-lresolv")
            .arg("-lobjc")
@@ -6662,7 +6804,7 @@ pub fn run_with_parse_cache(
             // and --allow-multiple-definition (ELF) / /FORCE:MULTIPLE (COFF)
             // handles duplicate symbols safely. On Android, skip_runtime=true
             // means the UI lib is the sole provider of perry-runtime symbols.
-            let ui_lib = if is_windows || is_android {
+            let ui_lib = if is_windows || is_android || is_visionos {
                 ui_lib
             } else {
                 match strip_duplicate_objects_from_lib(&ui_lib) {
@@ -6685,7 +6827,7 @@ pub fn run_with_parse_cache(
 
             if is_watchos {
                 // SwiftUI/WatchKit already linked above
-            } else if is_ios || is_tvos {
+            } else if is_ios || is_visionos || is_tvos {
                 // UIKit already linked above
             } else if is_android {
                 // Allow multiple definitions from perry-runtime in both UI lib and native libs
@@ -6752,6 +6894,8 @@ pub fn run_with_parse_cache(
                 ("libperry_ui_watchos.a", "cargo build --release -p perry-ui-watchos --target arm64_32-apple-watchos")
             } else if is_tvos {
                 ("libperry_ui_tvos.a", "cargo build --release -p perry-ui-tvos --target aarch64-apple-tvos")
+            } else if is_visionos {
+                ("libperry_ui_visionos.a", "cargo build --release -p perry-ui-visionos --target aarch64-apple-visionos-sim")
             } else if is_ios {
                 ("libperry_ui_ios.a", "cargo build --release -p perry-ui-ios --target aarch64-apple-ios-sim")
             } else if is_android {
@@ -7685,6 +7829,216 @@ pub fn run_with_parse_cache(
                 println!("{}", serde_json::to_string(&result)?);
             }
         }
+    } else if is_visionos {
+        let app_dir = exe_path.with_extension("app");
+        let _ = fs::create_dir_all(&app_dir);
+        let bundle_exe = app_dir.join(exe_path.file_name().unwrap_or_default());
+        fs::copy(&exe_path, &bundle_exe)?;
+        let _ = fs::remove_file(&exe_path);
+
+        let exe_stem = exe_path.file_stem().and_then(|s| s.to_str()).unwrap_or(stem);
+        let bundle_id = lookup_bundle_id_from_toml(&args.input, "visionos")
+            .or_else(|| lookup_bundle_id_from_toml(&args.input, "app"))
+            .or_else(|| lookup_bundle_id_from_toml(&args.input, "ios"))
+            .unwrap_or_else(|| format!("com.perry.{}", exe_stem));
+        result_bundle_id = Some(bundle_id.clone());
+        result_app_dir = Some(app_dir.clone());
+
+        let (app_version, app_build_number, deployment_target, encryption_exempt, custom_plist_entries) = (|| -> Option<(String, String, String, Option<bool>, String)> {
+            let mut dir = args.input.canonicalize().ok()?;
+            for _ in 0..5 {
+                dir = dir.parent()?.to_path_buf();
+                let toml_path = dir.join("perry.toml");
+                if !toml_path.exists() {
+                    continue;
+                }
+                let data = fs::read_to_string(&toml_path).ok()?;
+                let doc: toml::Table = data.parse().ok()?;
+                let project = doc.get("project").and_then(|v| v.as_table());
+                let visionos = doc.get("visionos").and_then(|v| v.as_table());
+                let version = project
+                    .and_then(|p| p.get("version"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("1.0.0")
+                    .to_string();
+                let build_number = project
+                    .and_then(|p| p.get("build_number"))
+                    .and_then(|v| v.as_integer().map(|n| n.to_string()).or_else(|| v.as_str().map(|s| s.to_string())))
+                    .unwrap_or_else(|| "1".to_string());
+                let deployment_target = visionos
+                    .and_then(|v| v.get("deployment_target").or_else(|| v.get("minimum_version")))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("1.0")
+                    .to_string();
+                let encryption_exempt = visionos
+                    .and_then(|v| v.get("encryption_exempt"))
+                    .and_then(|v| v.as_bool());
+                let mut entries = String::new();
+                if let Some(info_plist) = visionos
+                    .and_then(|v| v.get("info_plist"))
+                    .and_then(|v| v.as_table())
+                {
+                    for (key, value) in info_plist {
+                        if let Some(s) = value.as_str() {
+                            entries.push_str(&format!("    <key>{}</key>\n    <string>{}</string>\n", key, s));
+                        } else if let Some(b) = value.as_bool() {
+                            entries.push_str(&format!("    <key>{}</key>\n    <{}/>\n", key, if b { "true" } else { "false" }));
+                        } else if let Some(i) = value.as_integer() {
+                            entries.push_str(&format!("    <key>{}</key>\n    <integer>{}</integer>\n", key, i));
+                        }
+                    }
+                }
+                return Some((version, build_number, deployment_target, encryption_exempt, entries));
+            }
+            Some(("1.0.0".to_string(), "1".to_string(), "1.0".to_string(), None, String::new()))
+        })().unwrap();
+
+        let platform_name = if target.as_deref() == Some("visionos-simulator") {
+            "XRSimulator"
+        } else {
+            "XROS"
+        };
+
+        let mut info_plist = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>{exe_stem}</string>
+    <key>CFBundleIdentifier</key>
+    <string>{bundle_id}</string>
+    <key>CFBundleName</key>
+    <string>{exe_stem}</string>
+    <key>CFBundleVersion</key>
+    <string>{app_build_number}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>{app_version}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>MinimumOSVersion</key>
+    <string>{deployment_target}</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>{platform_name}</string>
+    </array>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>arm64</string>
+    </array>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>7</integer>
+    </array>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <true/>
+        <key>UIApplicationPreferredDefaultSceneSessionRole</key>
+        <string>UIWindowSceneSessionRoleApplication</string>
+        <key>UISceneConfigurations</key>
+        <dict/>
+    </dict>
+</dict>
+</plist>"#
+        );
+
+        let usage_descriptions = concat!(
+            "    <key>NSCameraUsageDescription</key>\n",
+            "    <string>This app uses the camera to identify colors.</string>\n",
+            "    <key>NSMicrophoneUsageDescription</key>\n",
+            "    <string>This app uses the microphone to measure sound levels.</string>\n",
+        );
+        info_plist = info_plist.replace("</dict>\n</plist>", &format!("{}</dict>\n</plist>", usage_descriptions));
+
+        if let Some(exempt) = encryption_exempt {
+            let encryption_entry = format!(
+                "    <key>ITSAppUsesNonExemptEncryption</key>\n    <{}/>\n",
+                if exempt { "false" } else { "true" }
+            );
+            info_plist = info_plist.replace("</dict>\n</plist>", &format!("{}</dict>\n</plist>", encryption_entry));
+        }
+
+        if !custom_plist_entries.is_empty() {
+            info_plist = info_plist.replace("</dict>\n</plist>", &format!("{}</dict>\n</plist>", custom_plist_entries));
+        }
+
+        fs::write(app_dir.join("Info.plist"), info_plist)?;
+
+        let source_dir = args.input.canonicalize().ok()
+            .and_then(|p| p.parent().map(|d| d.to_path_buf()));
+        if let Some(src_dir) = &source_dir {
+            let mut project_root = src_dir.clone();
+            for _ in 0..5 {
+                if project_root.join("package.json").exists() || project_root.join("perry.toml").exists() { break; }
+                if let Some(parent) = project_root.parent() {
+                    project_root = parent.to_path_buf();
+                } else { break; }
+            }
+            fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+                fs::create_dir_all(dst)?;
+                for entry in fs::read_dir(src)? {
+                    let entry = entry?;
+                    let ty = entry.file_type()?;
+                    let dest_path = dst.join(entry.file_name());
+                    if ty.is_dir() {
+                        copy_dir_recursive(&entry.path(), &dest_path)?;
+                    } else {
+                        fs::copy(entry.path(), &dest_path)?;
+                    }
+                }
+                Ok(())
+            }
+            for dir_name in &["logo", "assets", "resources", "images"] {
+                let resource_dir = project_root.join(dir_name);
+                if resource_dir.is_dir() {
+                    let dest = app_dir.join(dir_name);
+                    let _ = copy_dir_recursive(&resource_dir, &dest);
+                }
+            }
+        }
+
+        if let (Some(ref table), Some(ref config)) = (&i18n_table, &i18n_config) {
+            if !table.keys.is_empty() {
+                for (locale_idx, locale) in config.locales.iter().enumerate() {
+                    let lproj_dir = app_dir.join(format!("{}.lproj", locale));
+                    let _ = fs::create_dir_all(&lproj_dir);
+                    let mut strings_content = String::new();
+                    for (key_idx, key) in table.keys.iter().enumerate() {
+                        let flat_idx = locale_idx * table.keys.len() + key_idx;
+                        let value = table.translations.get(flat_idx).cloned().unwrap_or_else(|| key.clone());
+                        let escaped_key = key.replace('\\', "\\\\").replace('"', "\\\"");
+                        let escaped_val = value.replace('\\', "\\\\").replace('"', "\\\"");
+                        strings_content.push_str(&format!("\"{}\" = \"{}\";\n", escaped_key, escaped_val));
+                    }
+                    let _ = fs::write(lproj_dir.join("Localizable.strings"), &strings_content);
+                }
+            }
+        }
+
+        match format {
+            OutputFormat::Text => {
+                println!("Wrote visionOS app bundle: {}", app_dir.display());
+                println!();
+                println!("To run on Apple Vision Pro Simulator:");
+                println!("  xcrun simctl install booted {}", app_dir.display());
+                println!("  xcrun simctl launch booted {}", bundle_id);
+            }
+            OutputFormat::Json => {
+                let result = serde_json::json!({
+                    "success": true,
+                    "output": app_dir.to_string_lossy(),
+                    "bundle_id": bundle_id,
+                    "native_modules": ctx.native_modules.len(),
+                    "js_modules": ctx.js_modules.len(),
+                });
+                println!("{}", serde_json::to_string(&result)?);
+            }
+        }
     } else if is_watchos {
         // Create watchOS .app bundle
         let app_dir = exe_path.with_extension("app");
@@ -7959,7 +8313,7 @@ pub fn run_with_parse_cache(
     // Strip debug symbols from the final binary (reduces size significantly)
     // Skip for iOS/Android cross-compilation — host strip can't handle foreign architectures
     // Skip when PERRY_DEBUG_SYMBOLS=1 is set — keep symbols for crash debugging
-    if !is_dylib && !is_ios && !is_tvos && target.as_deref() != Some("android")
+    if !is_dylib && !is_ios && !is_visionos && !is_tvos && target.as_deref() != Some("android")
         && std::env::var("PERRY_DEBUG_SYMBOLS").is_err() {
         if ctx.needs_plugins {
             // When plugins are enabled, use strip -x to keep exported symbols

--- a/crates/perry/src/commands/publish.rs
+++ b/crates/perry/src/commands/publish.rs
@@ -124,6 +124,7 @@ struct PerryToml {
     app: Option<AppConfig>,
     macos: Option<MacosConfig>,
     ios: Option<IosConfig>,
+    visionos: Option<VisionosConfig>,
     watchos: Option<WatchosConfig>,
     tvos: Option<TvosConfig>,
     android: Option<AndroidConfig>,
@@ -215,6 +216,24 @@ struct IosConfig {
     /// Custom Info.plist entries (key-value pairs added to the generated plist).
     /// Use for privacy descriptions, custom URL schemes, etc.
     /// Example: { NSMicrophoneUsageDescription = "Measures ambient sound levels" }
+    info_plist: Option<std::collections::HashMap<String, String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VisionosConfig {
+    bundle_id: Option<String>,
+    deployment_target: Option<String>,
+    minimum_version: Option<String>,
+    distribute: Option<String>,
+    entry: Option<String>,
+    provisioning_profile: Option<String>,
+    certificate: Option<String>,
+    signing_identity: Option<String>,
+    team_id: Option<String>,
+    key_id: Option<String>,
+    issuer_id: Option<String>,
+    p8_key_path: Option<String>,
+    encryption_exempt: Option<bool>,
     info_plist: Option<std::collections::HashMap<String, String>>,
 }
 
@@ -393,6 +412,14 @@ struct BuildManifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     ios_info_plist: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    visionos_deployment_target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    visionos_distribute: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    visionos_encryption_exempt: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    visionos_info_plist: Option<std::collections::HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     macos_distribute: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     macos_encryption_exempt: Option<bool>,
@@ -475,6 +502,7 @@ pub fn run(args: PublishArgs, format: OutputFormat, use_color: bool, _verbose: u
 
     let target_hint = match args.platform {
         Some(Platform::Ios) => Some("ios"),
+        Some(Platform::Visionos) => Some("visionos"),
         Some(Platform::Android) => Some("android"),
         Some(Platform::Linux) => Some("linux"),
         Some(Platform::Windows) => Some("windows"),
@@ -559,7 +587,7 @@ async fn run_async(args: PublishArgs, format: OutputFormat, use_color: bool) -> 
 
         // Infer app_type from target
         let app_type = match args.platform {
-            Some(Platform::Ios) | Some(Platform::Android) | Some(Platform::Macos) | Some(Platform::Tvos) | Some(Platform::Web) | Some(Platform::Windows) => "gui",
+            Some(Platform::Ios) | Some(Platform::Visionos) | Some(Platform::Android) | Some(Platform::Macos) | Some(Platform::Tvos) | Some(Platform::Web) | Some(Platform::Windows) => "gui",
             _ => "server",
         };
 
@@ -626,6 +654,7 @@ async fn run_async(args: PublishArgs, format: OutputFormat, use_color: bool) -> 
         match p {
             Platform::Macos => "macos".to_string(),
             Platform::Ios => "ios".to_string(),
+            Platform::Visionos => "visionos".to_string(),
             Platform::Watchos => "watchos".to_string(),
             Platform::Tvos => "tvos".to_string(),
             Platform::Android => "android".to_string(),
@@ -639,11 +668,12 @@ async fn run_async(args: PublishArgs, format: OutputFormat, use_color: bool) -> 
     } else if interactive {
         prompt_target(saved.default_target.as_deref())
     } else {
-        bail!("No target specified. Use: perry publish <macos|ios|tvos|android|linux|windows|web>");
+        bail!("No target specified. Use: perry publish <macos|ios|visionos|tvos|android|linux|windows|web>");
     };
 
     let target_display = match target_name.as_str() {
         "ios" => "iOS",
+        "visionos" => "visionOS",
         "tvos" => "tvOS",
         "android" => "Android",
         "linux" => "Linux",
@@ -652,6 +682,7 @@ async fn run_async(args: PublishArgs, format: OutputFormat, use_color: bool) -> 
         _ => "macOS",
     };
     let is_ios = target_name == "ios";
+    let is_visionos = target_name == "visionos";
     let is_tvos = target_name == "tvos";
     let is_android = target_name == "android";
     let is_linux = target_name == "linux";
@@ -675,6 +706,11 @@ async fn run_async(args: PublishArgs, format: OutputFormat, use_color: bool) -> 
             .or_else(|| config.app.as_ref().and_then(|a| a.entry.clone()))
             .or_else(|| config.project.as_ref().and_then(|p| p.entry.clone()))
             .unwrap_or_else(|| "src/main_ios.ts".into())
+    } else if is_visionos {
+        config.visionos.as_ref().and_then(|i| i.entry.clone())
+            .or_else(|| config.app.as_ref().and_then(|a| a.entry.clone()))
+            .or_else(|| config.project.as_ref().and_then(|p| p.entry.clone()))
+            .unwrap_or_else(|| "src/main_visionos.ts".into())
     } else if is_tvos {
         config.tvos.as_ref().and_then(|t| t.entry.clone())
             .or_else(|| config.app.as_ref().and_then(|a| a.entry.clone()))
@@ -721,12 +757,12 @@ async fn run_async(args: PublishArgs, format: OutputFormat, use_color: bool) -> 
     // Auto-increment build_number for targets that need monotonic build numbers
     let is_windows = target_name == "windows";
     let is_web = target_name == "web";
-    let is_macos = !is_ios && !is_tvos && !is_android && !is_linux && !is_windows && !is_web;
+    let is_macos = !is_ios && !is_visionos && !is_tvos && !is_android && !is_linux && !is_windows && !is_web;
     let macos_needs_upload = is_macos && matches!(
         macos_distribute.as_deref(),
         Some("appstore") | Some("both")
     );
-    let build_number = if is_ios || is_tvos || is_android || macos_needs_upload {
+    let build_number = if is_ios || is_visionos || is_tvos || is_android || macos_needs_upload {
         let n = toml_build_number + 1;
         if let Ok(content) = fs::read_to_string(&perry_toml_path) {
             let updated = if content.contains("build_number =") {
@@ -763,6 +799,13 @@ async fn run_async(args: PublishArgs, format: OutputFormat, use_color: bool) -> 
             .or_else(|| project_bundle_id.clone())
             .or_else(|| config.macos.as_ref().and_then(|m| m.bundle_id.clone()))
             .unwrap_or_else(|| format!("com.perry.{}", app_name.to_lowercase().replace(' ', "-")))
+    } else if is_visionos {
+        config.visionos.as_ref().and_then(|i| i.bundle_id.clone())
+            .or_else(|| app_bundle_id.clone())
+            .or_else(|| project_bundle_id.clone())
+            .or_else(|| config.ios.as_ref().and_then(|i| i.bundle_id.clone()))
+            .or_else(|| config.macos.as_ref().and_then(|m| m.bundle_id.clone()))
+            .unwrap_or_else(|| format!("com.perry.{}", app_name.to_lowercase().replace(' ', "-")))
     } else if is_tvos {
         config.tvos.as_ref().and_then(|t| t.bundle_id.clone())
             .or_else(|| app_bundle_id.clone())
@@ -780,7 +823,7 @@ async fn run_async(args: PublishArgs, format: OutputFormat, use_color: bool) -> 
         .or_else(|| config.app.as_ref().and_then(|a| a.icons.as_ref()).and_then(|i| i.source.clone()));
 
     // Prompt for icon if missing and building for a platform that needs one
-    let needs_icon = is_ios || is_android
+    let needs_icon = is_ios || is_visionos || is_android
         || (is_macos && matches!(macos_distribute.as_deref(), Some("appstore") | Some("both")));
     if icon.is_none() && interactive && needs_icon {
         println!();
@@ -852,6 +895,12 @@ async fn run_async(args: PublishArgs, format: OutputFormat, use_color: bool) -> 
     let mut ios_distribute = config.ios.as_ref().and_then(|i| i.distribute.clone());
     let ios_encryption_exempt = config.ios.as_ref().and_then(|i| i.encryption_exempt);
     let ios_info_plist = config.ios.as_ref().and_then(|i| i.info_plist.clone());
+    let visionos_deployment_target = config.visionos.as_ref().and_then(|i| {
+        i.deployment_target.clone().or_else(|| i.minimum_version.clone())
+    });
+    let visionos_distribute = config.visionos.as_ref().and_then(|i| i.distribute.clone());
+    let visionos_encryption_exempt = config.visionos.as_ref().and_then(|i| i.encryption_exempt);
+    let visionos_info_plist = config.visionos.as_ref().and_then(|i| i.info_plist.clone());
     let macos_encryption_exempt = config.macos.as_ref().and_then(|m| m.encryption_exempt);
 
     // Android-specific config from perry.toml
@@ -1712,7 +1761,7 @@ async fn run_async(args: PublishArgs, format: OutputFormat, use_color: bool) -> 
     // Build manifest
     // For iOS/Android/macOS-appstore: version = build_number (CFBundleVersion), short_version = marketing version
     // For macOS-notarize/Linux: version = marketing version string, short_version = None
-    let (manifest_version, manifest_short_version) = if is_ios || is_android || macos_needs_upload {
+    let (manifest_version, manifest_short_version) = if is_ios || is_visionos || is_android || macos_needs_upload {
         (build_number.to_string(), Some(version.clone()))
     } else {
         (version.clone(), None)
@@ -1735,6 +1784,10 @@ async fn run_async(args: PublishArgs, format: OutputFormat, use_color: bool) -> 
         ios_distribute: if is_ios { ios_distribute } else { None },
         ios_encryption_exempt: if is_ios { ios_encryption_exempt } else { None },
         ios_info_plist: if is_ios { ios_info_plist } else { None },
+        visionos_deployment_target: if is_visionos { visionos_deployment_target } else { None },
+        visionos_distribute: if is_visionos { visionos_distribute } else { None },
+        visionos_encryption_exempt: if is_visionos { visionos_encryption_exempt } else { None },
+        visionos_info_plist: if is_visionos { visionos_info_plist } else { None },
         macos_distribute: if is_macos { macos_distribute } else { None },
         macos_encryption_exempt: if is_macos { macos_encryption_exempt } else { None },
         tvos_deployment_target: if is_tvos { config.tvos.as_ref().and_then(|t| t.deployment_target.clone()) } else { None },
@@ -2637,14 +2690,15 @@ pub(crate) fn prompt_input(prompt: &str, default: Option<&str>) -> Option<String
     }
 }
 
-/// Prompt for target platform selection. Returns "macos", "ios", "android", or "linux".
+/// Prompt for target platform selection.
 fn prompt_target(default: Option<&str>) -> String {
-    let options = &["macOS", "iOS", "tvOS", "Android", "Linux"];
+    let options = &["macOS", "iOS", "visionOS", "tvOS", "Android", "Linux"];
     let default_idx = match default {
         Some("ios") => 1,
-        Some("tvos") => 2,
-        Some("android") => 3,
-        Some("linux") => 4,
+        Some("visionos") => 2,
+        Some("tvos") => 3,
+        Some("android") => 4,
+        Some("linux") => 5,
         _ => 0,
     };
     let selection = Select::new()
@@ -2655,9 +2709,10 @@ fn prompt_target(default: Option<&str>) -> String {
         .unwrap_or(0);
     match selection {
         1 => "ios".into(),
-        2 => "tvos".into(),
-        3 => "android".into(),
-        4 => "linux".into(),
+        2 => "visionos".into(),
+        3 => "tvos".into(),
+        4 => "android".into(),
+        5 => "linux".into(),
         _ => "macos".into(),
     }
 }

--- a/crates/perry/src/commands/run.rs
+++ b/crates/perry/src/commands/run.rs
@@ -12,7 +12,7 @@ use crate::{OutputFormat, Platform};
 #[derive(Args, Debug)]
 pub struct RunArgs {
     /// Positional args: [platform] [input]. Platform is one of: macos, ios,
-    /// watchos, tvos, android, linux, windows, web. If the first arg is not a
+    /// visionos, watchos, tvos, android, linux, windows, web. If the first arg is not a
     /// known platform it is treated as the input file/directory.
     pub positional: Vec<String>,
 
@@ -80,6 +80,7 @@ fn parse_platform(s: &str) -> Option<Platform> {
     match s.to_lowercase().as_str() {
         "macos" => Some(Platform::Macos),
         "ios" => Some(Platform::Ios),
+        "visionos" => Some(Platform::Visionos),
         "watchos" => Some(Platform::Watchos),
         "tvos" => Some(Platform::Tvos),
         "android" => Some(Platform::Android),
@@ -107,7 +108,13 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
     let (target, device_udid) = resolve_target(platform, &args)?;
 
     // 3. Decide local vs remote compilation
-    let needs_cross = matches!(target.as_deref(), Some("ios-simulator") | Some("ios") | Some("android") | Some("watchos-simulator") | Some("watchos") | Some("tvos-simulator") | Some("tvos"));
+    let needs_cross = matches!(target.as_deref(),
+        Some("ios-simulator") | Some("ios") |
+        Some("visionos-simulator") | Some("visionos") |
+        Some("android") |
+        Some("watchos-simulator") | Some("watchos") |
+        Some("tvos-simulator") | Some("tvos")
+    );
     let can_local = !needs_cross || can_compile_locally(target.as_deref());
 
     let use_remote = if args.remote {
@@ -174,7 +181,7 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
     let result = super::compile::run(compile_args, format, use_color, verbose)?;
 
     // Local iOS device builds need code signing before install
-    if target.as_deref() == Some("ios") {
+    if matches!(target.as_deref(), Some("ios") | Some("visionos")) {
         if let Some(udid) = device_udid.as_deref() {
             let config = super::publish::load_config();
             let rt = tokio::runtime::Runtime::new()?;
@@ -208,6 +215,8 @@ fn rust_target_triple(target: Option<&str>) -> Option<&'static str> {
     match target {
         Some("ios-simulator") => Some("aarch64-apple-ios-sim"),
         Some("ios") => Some("aarch64-apple-ios"),
+        Some("visionos-simulator") => Some("aarch64-apple-visionos-sim"),
+        Some("visionos") => Some("aarch64-apple-visionos"),
         Some("tvos-simulator") => Some("aarch64-apple-tvos-sim"),
         Some("tvos") => Some("aarch64-apple-tvos"),
         Some("android") => Some("aarch64-linux-android"),
@@ -627,7 +636,7 @@ async fn remote_build_and_launch(
     }
 
     // For iOS: extract .app from .ipa and install
-    if target == "ios-simulator" || target == "ios" {
+    if target == "ios-simulator" || target == "ios" || target == "visionos-simulator" || target == "visionos" {
         let app_dir = extract_app_from_ipa(&dest, &dist_dir)?;
         let udid = device_udid.ok_or_else(|| anyhow!("No device UDID for iOS launch"))?;
 
@@ -640,11 +649,11 @@ async fn remote_build_and_launch(
 
         // For device builds, re-sign with a local development identity
         // (the hub may have signed with a distribution profile)
-        if target == "ios" {
+        if target == "ios" || target == "visionos" {
             resign_for_development(&app_dir, &config, udid, format).await?;
         }
 
-        if target == "ios-simulator" {
+        if target == "ios-simulator" || target == "visionos-simulator" {
             launch_ios_simulator(&app_dir, &bundle_id, udid, format)
         } else {
             launch_ios_device(&app_dir, &bundle_id, udid, format)
@@ -1334,9 +1343,12 @@ fn read_app_metadata(project_root: &Path, input: &Path) -> (String, String) {
     let toml_bundle_id = toml_config
         .as_ref()
         .and_then(|t| {
-            // Check [ios].bundle_id, [macos].bundle_id, [app].bundle_id, [project].bundle_id, then top-level
-            t.get("ios")
+            // Check [visionos].bundle_id, [ios].bundle_id, [macos].bundle_id, [app].bundle_id, [project].bundle_id, then top-level
+            t.get("visionos")
                 .and_then(|i| i.get("bundle_id"))
+                .or_else(|| t.get("ios")
+                .and_then(|i| i.get("bundle_id"))
+                )
                 .or_else(|| t.get("macos").and_then(|m| m.get("bundle_id")))
                 .or_else(|| t.get("app").and_then(|a| a.get("bundle_id")))
                 .or_else(|| t.get("project").and_then(|p| p.get("bundle_id")))
@@ -1741,6 +1753,34 @@ fn resolve_target(platform: Option<Platform>, args: &RunArgs) -> Result<(Option<
             let (dev, target) = all.remove(selection);
             Ok((Some(target.to_string()), Some(dev.udid)))
         }
+        Some(Platform::Visionos) => {
+            if let Some(ref udid) = args.simulator {
+                return Ok((Some("visionos-simulator".to_string()), Some(udid.clone())));
+            }
+            if let Some(ref udid) = args.device {
+                return Ok((Some("visionos".to_string()), Some(udid.clone())));
+            }
+
+            let simulators = detect_booted_visionos_simulators().unwrap_or_default();
+
+            if simulators.is_empty() {
+                return Err(anyhow!(
+                    "No Apple Vision Pro simulators found.\n\
+                     Boot a simulator:  xcrun simctl boot <UDID>\n\
+                     Or specify one:    perry run visionos --simulator <UDID>"
+                ));
+            }
+
+            if simulators.len() == 1 {
+                let dev = simulators.into_iter().next().unwrap();
+                return Ok((Some("visionos-simulator".to_string()), Some(dev.udid)));
+            }
+
+            let names: Vec<String> = simulators.iter().map(|d| d.name.clone()).collect();
+            let selection = pick_from_list(&names, "Select Apple Vision Pro simulator")?;
+            let dev = &simulators[selection];
+            Ok((Some("visionos-simulator".to_string()), Some(dev.udid.clone())))
+        }
         Some(Platform::Watchos) => {
             if let Some(ref udid) = args.simulator {
                 return Ok((Some("watchos-simulator".to_string()), Some(udid.clone())));
@@ -1829,6 +1869,24 @@ fn launch(
                 .bundle_id
                 .as_deref()
                 .ok_or_else(|| anyhow!("No bundle ID found for iOS app"))?;
+            launch_ios_device(&result.output_path, bundle_id, udid, format)
+        }
+        "visionos-simulator" => {
+            let udid =
+                device_udid.ok_or_else(|| anyhow!("No simulator UDID — use --simulator <UDID>"))?;
+            let bundle_id = result
+                .bundle_id
+                .as_deref()
+                .ok_or_else(|| anyhow!("No bundle ID found for visionOS app"))?;
+            launch_ios_simulator(&result.output_path, bundle_id, udid, format)
+        }
+        "visionos" => {
+            let udid =
+                device_udid.ok_or_else(|| anyhow!("No device UDID — use --device <UDID>"))?;
+            let bundle_id = result
+                .bundle_id
+                .as_deref()
+                .ok_or_else(|| anyhow!("No bundle ID found for visionOS app"))?;
             launch_ios_device(&result.output_path, bundle_id, udid, format)
         }
         "watchos-simulator" => {
@@ -2363,6 +2421,48 @@ fn detect_booted_simulators() -> Result<Vec<DeviceInfo>> {
     let mut devices = Vec::new();
     if let Some(device_map) = json.get("devices").and_then(|d| d.as_object()) {
         for (_runtime, device_list) in device_map {
+            if let Some(arr) = device_list.as_array() {
+                for dev in arr {
+                    let state = dev.get("state").and_then(|s| s.as_str()).unwrap_or("");
+                    if state == "Booted" {
+                        if let (Some(udid), Some(name)) = (
+                            dev.get("udid").and_then(|s| s.as_str()),
+                            dev.get("name").and_then(|s| s.as_str()),
+                        ) {
+                            devices.push(DeviceInfo {
+                                udid: udid.to_string(),
+                                name: name.to_string(),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(devices)
+}
+
+/// Detect booted Apple Watch simulators
+fn detect_booted_visionos_simulators() -> Result<Vec<DeviceInfo>> {
+    let output = Command::new("xcrun")
+        .args(["simctl", "list", "devices", "booted", "--json"])
+        .output()
+        .map_err(|e| anyhow!("Failed to run xcrun simctl: {}", e))?;
+
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).unwrap_or(serde_json::Value::Null);
+
+    let mut devices = Vec::new();
+    if let Some(device_map) = json.get("devices").and_then(|d| d.as_object()) {
+        for (runtime, device_list) in device_map {
+            if !runtime.contains("visionOS") && !runtime.contains("xrOS") {
+                continue;
+            }
             if let Some(arr) = device_list.as_array() {
                 for dev in arr {
                     let state = dev.get("state").and_then(|s| s.as_str()).unwrap_or("");

--- a/crates/perry/src/commands/setup.rs
+++ b/crates/perry/src/commands/setup.rs
@@ -13,7 +13,7 @@ use super::publish::{
 
 #[derive(Args, Debug)]
 pub struct SetupArgs {
-    /// Platform to configure: android, ios, macos, tvos, watchos
+    /// Platform to configure: android, ios, visionos, macos, tvos, watchos
     pub platform: Option<String>,
 }
 
@@ -29,7 +29,7 @@ pub fn run(args: SetupArgs) -> Result<()> {
     let platform = match args.platform.as_deref() {
         Some(p) => p.to_string(),
         None => {
-            let options = &["Android", "iOS", "macOS", "tvOS", "watchOS"];
+            let options = &["Android", "iOS", "visionOS", "macOS", "tvOS", "watchOS"];
             let selection = Select::new()
                 .with_prompt("  Which platform to configure?")
                 .items(options)
@@ -38,8 +38,9 @@ pub fn run(args: SetupArgs) -> Result<()> {
             match selection {
                 0 => "android".to_string(),
                 1 => "ios".to_string(),
-                2 => "macos".to_string(),
-                3 => "tvos".to_string(),
+                2 => "visionos".to_string(),
+                3 => "macos".to_string(),
+                4 => "tvos".to_string(),
                 _ => "watchos".to_string(),
             }
         }
@@ -50,10 +51,11 @@ pub fn run(args: SetupArgs) -> Result<()> {
     match platform.as_str() {
         "android" => android_wizard(&mut saved)?,
         "ios" => ios_wizard(&mut saved)?,
+        "visionos" => visionos_wizard(&mut saved)?,
         "macos" => macos_wizard(&mut saved)?,
         "tvos" => tvos_wizard(&mut saved)?,
         "watchos" => watchos_wizard(&mut saved)?,
-        other => bail!("Unknown platform '{other}'. Use: android, ios, macos, tvos, watchos"),
+        other => bail!("Unknown platform '{other}'. Use: android, ios, visionos, macos, tvos, watchos"),
     }
 
     save_config(&saved)?;
@@ -1860,6 +1862,140 @@ fn update_perry_toml_macos(
     if let Some(installer_cert) = installer_certificate {
         macos.insert("installer_certificate".into(), toml::Value::String(installer_cert.into()));
     }
+
+    let new_content = toml::to_string_pretty(&doc)
+        .context("Failed to serialize perry.toml")?;
+    std::fs::write(perry_toml_path, new_content)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// visionOS wizard
+// ---------------------------------------------------------------------------
+
+pub(crate) fn visionos_wizard(saved: &mut PerryConfig) -> Result<()> {
+    println!("  {}", style("visionOS Setup").bold());
+    println!();
+
+    let existing_apple = saved.apple.clone().unwrap_or_default();
+
+    println!("  {} App Store Connect API Key", style("Step 1/2 —").cyan().bold());
+    println!();
+
+    let has_existing = existing_apple.p8_key_path.is_some()
+        && existing_apple.key_id.is_some()
+        && existing_apple.issuer_id.is_some();
+
+    let (p8_path, key_id, issuer_id, team_id) = if has_existing {
+        let p8 = existing_apple.p8_key_path.clone().unwrap();
+        let kid = existing_apple.key_id.clone().unwrap();
+        let iss = existing_apple.issuer_id.clone().unwrap();
+        let tid = existing_apple.team_id.clone().unwrap_or_default();
+        println!("  Found existing credentials (shared with iOS/macOS):");
+        println!("    Key ID:    {}", style(&kid).bold());
+        println!("    Issuer ID: {}", style(&iss).dim());
+        println!("    .p8 key:   {}", style(&p8).dim());
+        if !tid.is_empty() {
+            println!("    Team ID:   {}", style(&tid).dim());
+        }
+        println!();
+        let reuse = Confirm::new()
+            .with_prompt("  Use these existing credentials?")
+            .default(true)
+            .interact()?;
+        if reuse {
+            (p8, kid, iss, tid)
+        } else {
+            prompt_api_credentials()?
+        }
+    } else {
+        println!("  You need an App Store Connect API key.");
+        println!("  1. Go to: {}", style("https://appstoreconnect.apple.com/access/integrations/api").underlined());
+        println!("  2. Create an API key with \"App Manager\" or \"Admin\" role.");
+        println!("  3. Download the .p8 file and note the Key ID and Issuer ID.");
+        println!();
+        prompt_api_credentials()?
+    };
+
+    saved.apple = Some(AppleSavedConfig {
+        p8_key_path: Some(p8_path),
+        key_id: Some(key_id),
+        issuer_id: Some(issuer_id),
+        team_id: if team_id.is_empty() { None } else { Some(team_id) },
+        ..existing_apple
+    });
+
+    println!();
+    println!("  {} Bundle ID", style("Step 2/2 —").cyan().bold());
+    println!();
+
+    let perry_toml_path = std::env::current_dir()?.join("perry.toml");
+    let existing_bid = if perry_toml_path.exists() {
+        let content = std::fs::read_to_string(&perry_toml_path)?;
+        let parsed: toml::Table = content.parse().unwrap_or_default();
+        parsed.get("visionos").and_then(|w| w.get("bundle_id")).and_then(|v| v.as_str())
+            .or_else(|| parsed.get("app").and_then(|a| a.get("bundle_id")).and_then(|v| v.as_str()))
+            .or_else(|| parsed.get("project").and_then(|p| p.get("bundle_id")).and_then(|v| v.as_str()))
+            .or_else(|| parsed.get("ios").and_then(|p| p.get("bundle_id")).and_then(|v| v.as_str()))
+            .map(|s| s.to_string())
+    } else {
+        None
+    };
+
+    let bundle_id: String = if let Some(ref bid) = existing_bid {
+        println!("  Found existing bundle ID: {}", style(bid).bold());
+        let reuse = Confirm::new()
+            .with_prompt("  Use this bundle ID?")
+            .default(true)
+            .interact()?;
+        if reuse {
+            bid.clone()
+        } else {
+            Input::new()
+                .with_prompt("  visionOS Bundle ID (e.g. com.example.myvision)")
+                .interact_text()?
+        }
+    } else {
+        Input::new()
+            .with_prompt("  visionOS Bundle ID (e.g. com.example.myvision)")
+            .interact_text()?
+    };
+
+    if !perry_toml_path.exists() {
+        std::fs::write(&perry_toml_path, "")?;
+    }
+    save_visionos_bundle_id(&perry_toml_path, &bundle_id)?;
+
+    println!();
+    println!("  {} visionOS setup complete!", style("✓").green().bold());
+    println!();
+    println!("  Saved to:");
+    println!("    Global: {}", style(config_path().display()).dim());
+    println!("    Project: {}", style(perry_toml_path.display()).dim());
+    println!();
+    println!("  Next steps:");
+    println!("    perry compile app.ts --target visionos-simulator");
+    println!("    perry run visionos");
+    println!();
+
+    Ok(())
+}
+
+fn save_visionos_bundle_id(perry_toml_path: &std::path::Path, bundle_id: &str) -> Result<()> {
+    let content = if perry_toml_path.exists() {
+        std::fs::read_to_string(perry_toml_path)?
+    } else {
+        String::new()
+    };
+    let mut doc = content.parse::<toml::Table>()
+        .unwrap_or_else(|_| toml::Table::new());
+
+    let visionos = doc.entry("visionos")
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!("[visionos] in perry.toml is not a table"))?;
+
+    visionos.insert("bundle_id".into(), toml::Value::String(bundle_id.into()));
 
     let new_content = toml::to_string_pretty(&doc)
         .context("Failed to serialize perry.toml")?;

--- a/crates/perry/src/main.rs
+++ b/crates/perry/src/main.rs
@@ -47,6 +47,7 @@ pub enum OutputFormat {
 pub enum Platform {
     Macos,
     Ios,
+    Visionos,
     Watchos,
     Tvos,
     Android,

--- a/docs/examples/ui/counter.ts
+++ b/docs/examples/ui/counter.ts
@@ -1,7 +1,7 @@
 // demonstrates: minimal stateful UI — label + increment button
 // docs: docs/src/ui/state.md
 // platforms: macos, linux, windows
-// targets: ios-simulator, tvos-simulator, watchos-simulator, android, web, wasm
+// targets: ios-simulator, visionos-simulator, tvos-simulator, watchos-simulator, android, web, wasm
 
 import { App, VStack, Text, Button, State } from "perry/ui"
 

--- a/docs/examples/ui/gallery.ts
+++ b/docs/examples/ui/gallery.ts
@@ -1,7 +1,7 @@
 // demonstrates: every cross-platform perry/ui widget in one window
 // docs: docs/src/ui/widgets.md
 // platforms: macos, linux, windows
-// targets: ios-simulator, tvos-simulator, web, wasm
+// targets: ios-simulator, visionos-simulator, tvos-simulator, web, wasm
 //
 // Rendered deterministically — no timers, no animations, no state changes.
 // Captured at fixed size (900x1400) so the screenshot diff is reproducible

--- a/docs/examples/ui/widgets/image_symbol.ts
+++ b/docs/examples/ui/widgets/image_symbol.ts
@@ -1,7 +1,7 @@
 // demonstrates: ImageSymbol for SF Symbol glyphs (macOS/iOS)
 // docs: docs/src/ui/widgets.md
 // platforms: macos
-// targets: ios-simulator, tvos-simulator
+// targets: ios-simulator, visionos-simulator, tvos-simulator
 
 import { App, HStack, ImageSymbol, widgetSetWidth, widgetSetHeight } from "perry/ui"
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -50,6 +50,7 @@
 - [Overview](platforms/overview.md)
 - [macOS](platforms/macos.md)
 - [iOS](platforms/ios.md)
+- [visionOS](platforms/visionos.md)
 - [tvOS](platforms/tvos.md)
 - [watchOS](platforms/watchos.md)
 - [Android](platforms/android.md)

--- a/docs/src/cli/commands.md
+++ b/docs/src/cli/commands.md
@@ -52,6 +52,7 @@ Compile and launch your app in one step.
 ```bash
 perry run                          # Auto-detect entry file
 perry run ios                      # Run on iOS device/simulator
+perry run visionos                 # Run on Apple Vision Pro simulator/device
 perry run android                  # Run on Android device
 perry run -- --port 3000           # Forward args to your program
 ```
@@ -59,6 +60,7 @@ perry run -- --port 3000           # Forward args to your program
 | Argument / Flag | Description |
 |------|-------------|
 | `ios` | Target iOS (device or simulator) |
+| `visionos` | Target visionOS (device or simulator) |
 | `macos` | Target macOS (default on macOS host) |
 | `web` | Target web (opens in browser) |
 | `android` | Target Android device |
@@ -77,7 +79,7 @@ perry run -- --port 3000           # Forward args to your program
 
 **Device detection**: When targeting iOS, Perry auto-discovers available simulators (via `simctl`) and physical devices (via `devicectl`). For Android, it uses `adb`. When multiple targets are found, an interactive prompt lets you choose.
 
-**Remote build fallback**: If cross-compilation toolchains aren't installed locally (e.g., iOS targets on a machine without Xcode), `perry run ios` automatically falls back to Perry Hub's build server — it packages your project, uploads it, streams build progress via WebSocket, downloads the `.ipa`, and installs it on your device. Use `--local` or `--remote` to force either path.
+**Remote build fallback**: If cross-compilation toolchains aren't installed locally (e.g., Apple mobile targets on a machine without Xcode), `perry run ios` and `perry run visionos` can fall back to Perry Hub's build server when the backend supports the target. Use `--local` or `--remote` to force either path.
 
 ```bash
 # Run a CLI program
@@ -224,6 +226,7 @@ Build, sign, and distribute your app.
 ```bash
 perry publish macos
 perry publish ios
+perry publish visionos
 perry publish android
 ```
 
@@ -231,6 +234,7 @@ perry publish android
 |------|-------------|
 | `macos` | Build for macOS (App Store/notarization) |
 | `ios` | Build for iOS (App Store/TestFlight) |
+| `visionos` | Build for visionOS |
 | `android` | Build for Android (Google Play) |
 | `linux` | Build for Linux (AppImage/deb/rpm) |
 | `--server <URL>` | Build server (default: `https://hub.perryts.com`) |
@@ -271,6 +275,7 @@ Interactive credential wizard for app distribution.
 perry setup          # Show platform menu
 perry setup macos    # macOS setup
 perry setup ios      # iOS setup
+perry setup visionos # visionOS setup
 perry setup android  # Android setup
 ```
 

--- a/docs/src/cli/flags.md
+++ b/docs/src/cli/flags.md
@@ -22,6 +22,8 @@ Use `--target` to cross-compile:
 | *(none)* | Current platform | Default behavior |
 | `ios-simulator` | iOS Simulator | ARM64 simulator binary |
 | `ios` | iOS Device | ARM64 device binary |
+| `visionos-simulator` | visionOS Simulator | Apple Vision Pro simulator build |
+| `visionos` | visionOS Device | Apple Vision Pro device build |
 | `android` | Android | ARM64/ARMv7 |
 | `ios-widget` | iOS Widget | WidgetKit extension (requires `--app-bundle-id`) |
 | `ios-widget-simulator` | iOS Widget (Sim) | Widget for simulator |
@@ -142,6 +144,9 @@ perry main.ts -o app
 
 # iOS app for simulator
 perry app.ts -o app --target ios-simulator
+
+# visionOS app for simulator
+perry app.ts -o app --target visionos-simulator
 
 # Web app (WASM with DOM bridge — alias: --target wasm)
 perry app.ts -o app --target web

--- a/docs/src/cli/perry-toml.md
+++ b/docs/src/cli/perry-toml.md
@@ -290,6 +290,36 @@ iOS-specific configuration for `perry publish ios`, `perry run ios`, and `perry 
 
 ---
 
+### `[visionos]`
+
+visionOS-specific configuration for `perry publish visionos`, `perry run visionos`, and `perry compile --target visionos`/`--target visionos-simulator`.
+
+#### App Metadata
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `bundle_id` | string | Falls back to `[app]`/`[project]`/`[ios]` | visionOS-specific bundle identifier |
+| `deployment_target` | string | `"1.0"` | Minimum visionOS version required |
+| `minimum_version` | string | — | Alias for `deployment_target` |
+| `entry` | string | Falls back to `[project]`/`[app]` | visionOS-specific entry file |
+| `encryption_exempt` | bool | `false` | If `true`, adds `ITSAppUsesNonExemptEncryption = false` to Info.plist |
+| `info_plist` | table | — | Custom key-value pairs merged into the generated Info.plist |
+
+#### Distribution / Signing
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `distribute` | string | — | Distribution method for visionOS builds |
+| `signing_identity` | string | Auto-detected from Keychain | Code signing identity |
+| `certificate` | string | Auto-exported from Keychain | Path to `.p12` distribution certificate |
+| `provisioning_profile` | string | — | Path to `.mobileprovision` file |
+| `team_id` | string | From `~/.perry/config.toml` | Apple Developer Team ID |
+| `key_id` | string | From `~/.perry/config.toml` | App Store Connect API key ID |
+| `issuer_id` | string | From `~/.perry/config.toml` | App Store Connect issuer ID |
+| `p8_key_path` | string | From `~/.perry/config.toml` | Path to `.p8` API key file |
+
+---
+
 ### `[android]`
 
 Android-specific configuration for `perry publish android`, `perry run android`, and `perry compile --target android`.

--- a/docs/src/platforms/overview.md
+++ b/docs/src/platforms/overview.md
@@ -1,6 +1,6 @@
 # Platform Overview
 
-Perry compiles TypeScript to native executables for 7 platforms from the same source code.
+Perry compiles TypeScript to native executables for 9 platform families from the same source code.
 
 ## Supported Platforms
 
@@ -8,6 +8,7 @@ Perry compiles TypeScript to native executables for 7 platforms from the same so
 |----------|-------------|------------|--------|
 | macOS | *(default)* | AppKit | Full support (127/127 FFI functions) |
 | iOS | `--target ios` / `--target ios-simulator` | UIKit | Full support (127/127) |
+| visionOS | `--target visionos` / `--target visionos-simulator` | UIKit (2D windows) | Core support (2D only) |
 | tvOS | `--target tvos` / `--target tvos-simulator` | UIKit | Full support (focus engine + game controllers) |
 | watchOS | `--target watchos` / `--target watchos-simulator` | SwiftUI (data-driven) | Core support (15 widgets) |
 | Android | `--target android` | JNI/Android SDK | Full support (112/112) |
@@ -23,6 +24,7 @@ perry app.ts -o app
 
 # Compile for a specific target
 perry app.ts -o app --target ios-simulator
+perry app.ts -o app --target visionos-simulator
 perry app.ts -o app --target tvos-simulator
 perry app.ts -o app --target watchos-simulator
 perry app.ts -o app --target web   # alias: --target wasm
@@ -47,6 +49,7 @@ declare const __platform__: number;
 // 5 = Web (browser, --target web / --target wasm)
 // 6 = tvOS
 // 7 = watchOS
+// 8 = visionOS
 
 if (__platform__ === 0) {
   console.log("Running on macOS");
@@ -61,21 +64,22 @@ if (__platform__ === 0) {
 
 ## Platform Feature Matrix
 
-| Feature | macOS | iOS | tvOS | watchOS | Android | Windows | Linux | Web (WASM) |
-|---------|-------|-----|------|---------|---------|---------|-------|------------|
-| CLI programs | Yes | — | — | — | — | Yes | Yes | — |
-| Native UI (DOM on web) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Game engines | Yes | Yes | Yes | — | Yes | Yes | Yes | Via FFI |
-| File system | Yes | Sandboxed | Sandboxed | — | Sandboxed | Yes | Yes | File System Access API |
-| Networking | Yes | Yes | Yes | Yes | Yes | Yes | Yes | `fetch` / `WebSocket` |
-| System APIs | Yes | Partial | Partial | Minimal | Partial | Yes | Yes | Partial |
-| Widgets (WidgetKit) | — | Yes | — | Yes | — | — | — | — |
-| Threading | Native | Native | Native | Native | Native | Native | Native | Web Workers |
+| Feature | macOS | iOS | visionOS | tvOS | watchOS | Android | Windows | Linux | Web (WASM) |
+|---------|-------|-----|----------|------|---------|---------|---------|-------|------------|
+| CLI programs | Yes | — | — | — | — | — | Yes | Yes | — |
+| Native UI (DOM on web) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Game engines | Yes | Yes | — | Yes | — | Yes | Yes | Yes | Via FFI |
+| File system | Yes | Sandboxed | Sandboxed | Sandboxed | — | Sandboxed | Yes | Yes | File System Access API |
+| Networking | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | `fetch` / `WebSocket` |
+| System APIs | Yes | Partial | Partial | Partial | Minimal | Partial | Yes | Yes | Partial |
+| Widgets (WidgetKit) | — | Yes | — | — | Yes | — | — | — | — |
+| Threading | Native | Native | Native | Native | Native | Native | Native | Native | Web Workers |
 
 ## Next Steps
 
 - [macOS](macos.md)
 - [iOS](ios.md)
+- [visionOS](visionos.md)
 - [tvOS](tvos.md)
 - [watchOS](watchos.md)
 - [Android](android.md)

--- a/docs/src/platforms/visionos.md
+++ b/docs/src/platforms/visionos.md
@@ -1,0 +1,69 @@
+# visionOS
+
+Perry can compile TypeScript apps for Apple Vision Pro devices and the visionOS Simulator.
+
+This first pass targets **2D windowed apps only**. Perry uses the same UIKit-style `perry/ui` model as iOS, packaged for visionOS app bundles and scene lifecycle.
+
+## Prerequisites
+
+- macOS with Xcode installed
+- Rust visionOS targets:
+
+```bash
+rustup target add aarch64-apple-visionos aarch64-apple-visionos-sim
+```
+
+## Compile
+
+```bash
+perry compile app.ts -o app --target visionos-simulator
+perry compile app.ts -o app --target visionos
+```
+
+This produces a `.app` bundle with visionOS-specific `Info.plist` metadata and a `UIWindowScene` configuration.
+
+## Run
+
+```bash
+perry run visionos
+perry run visionos --simulator <UDID>
+perry run visionos --device <UDID>
+```
+
+Perry auto-detects booted Apple Vision Pro simulators via `simctl`. Physical device installs use `devicectl`, like other modern Apple platforms.
+
+## Configuration
+
+Configure visionOS-specific settings in `perry.toml`:
+
+```toml
+[visionos]
+bundle_id = "com.example.myvisionapp"
+deployment_target = "1.0"
+entry = "src/main_visionos.ts"
+encryption_exempt = true
+```
+
+Custom `Info.plist` keys can be merged through `[visionos.info_plist]`.
+
+## Platform Detection
+
+Use `__platform__ === 8` to detect visionOS at compile time:
+
+```typescript,no-test
+declare const __platform__: number;
+
+if (__platform__ === 8) {
+  console.log("Running on visionOS");
+}
+```
+
+## Current Scope
+
+- Supported: 2D windowed apps, simulator/device app bundles, `perry run`, `perry setup`, `perry publish`
+- Not supported yet: immersive spaces, volumes, RealityKit scene generation, Geisterhand
+
+## Related
+
+- [iOS](ios.md) — shared UIKit foundation
+- [Platform Overview](overview.md)

--- a/docs/src/platforms/watchos.md
+++ b/docs/src/platforms/watchos.md
@@ -171,12 +171,12 @@ This shares App Store Connect credentials with iOS/macOS (same team, API key, is
 
 ## Platform Detection
 
-Use `__platform__ === 5` to detect watchOS at compile time:
+Use `__platform__ === 7` to detect watchOS at compile time:
 
 ```typescript,no-test
 declare const __platform__: number;
 
-if (__platform__ === 5) {
+if (__platform__ === 7) {
   console.log("Running on watchOS");
 }
 ```


### PR DESCRIPTION
## What changed

- add first-class `visionos` / `visionos-simulator` targets across Perry CLI flows: compile, run, publish, setup, docs, and doc-tests
- add a dedicated `perry-ui-visionos` backend crate as a sibling to `perry-ui-ios`
- host visionOS apps through a SwiftUI `WindowGroup` bridge that embeds Perry's UIKit view tree
- add safe visionOS fallbacks for currently unstable simulator controls, including toggle and picker paths
- document visionOS as a 2D windowed target and remove unused immersive-focused default link frameworks

## Follow-up polish

Addressed review feedback in `830711f`:

- removed bring-up debug artifacts from the SwiftUI host
- removed the dead UIKit scene/app-delegate bootstrap from the visionOS backend
- added explicit TODOs to the temporary `Toggle` and `Picker` fallbacks
- dropped `ARKit` and `CompositorServices` from the default visionOS link line to match the current 2D-only scope

## Why it changed

Perry had no repo-side visionOS support. Reusing the iOS-style `UIApplicationMain` lifecycle was enough to get partway through the port, but it did not produce a stable visionOS simulator path. visionOS expects a SwiftUI-hosted window scene, and some UIKit control paths were crashing under simulator focus/tint handling.

This PR brings the visionOS simulator path up to a working state while keeping unsupported widget behavior non-fatal.

## Impact

- Perry apps can now compile for the Apple Vision Pro simulator with `--target visionos-simulator`
- the `counter` example renders in the simulator
- the `gallery` example renders in the simulator with current safe fallbacks for unsupported native controls
- the visionOS target is wired through the same repo workflows as the other Apple targets

## Current caveats

- some visionOS controls are still intentional safe fallbacks rather than native equivalents
- there is still a linker warning about duplicate `-lSystem`
- this PR only covers repo-side support; any external Perry Hub/backend handling remains separate

## Validation

Repo checks:

- `cargo check -p perry`
- `cargo check -p perry-ui-visionos`

Simulator compile checks:

- `target/debug/perry compile docs/examples/ui/counter.ts --target visionos-simulator -o /tmp/perry_vision_counter --no-auto-optimize`
- `target/debug/perry compile docs/examples/ui/gallery.ts --target visionos-simulator -o /tmp/perry_vision_gallery --no-auto-optimize`

Fresh simulator proof rerun on commit `830711f`:

- cold-installed and launched both apps on a booted Apple Vision Pro simulator
- verified visible rendering for both `counter` and `gallery`
- generated fresh in-app screenshots for both apps during the proof run
- checked for new `perry_vision_counter` / `perry_vision_gallery` crash reports after the proof start time and found none
