### PR TITLE
fix(check): emit file:line:column for HIR lowering errors (#129)

### DIFF
--- a/crates/perry-hir/src/error.rs
+++ b/crates/perry-hir/src/error.rs
@@ -1,0 +1,52 @@
+//! Structured errors for HIR lowering.
+//!
+//! Lowering returns `anyhow::Result` throughout, but when the failure has a
+//! known source location we wrap it in a `LowerError` so downstream tooling
+//! (notably `perry check`) can downcast and produce a diagnostic with a
+//! proper span instead of a locationless message.
+
+use swc_common::Span;
+
+/// A lowering failure, optionally with a SWC span pointing at the offending
+/// AST node.
+#[derive(Debug, Clone)]
+pub struct LowerError {
+    pub message: String,
+    pub span: Option<Span>,
+}
+
+impl LowerError {
+    pub fn new(message: impl Into<String>, span: Span) -> Self {
+        Self {
+            message: message.into(),
+            span: Some(span),
+        }
+    }
+
+    pub fn without_span(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            span: None,
+        }
+    }
+}
+
+impl std::fmt::Display for LowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for LowerError {}
+
+/// Return early from a lowering function with a span-tagged error.
+///
+/// Usage: `lower_bail!(some_ast_node.span, "unsupported thing: {}", detail);`
+#[macro_export]
+macro_rules! lower_bail {
+    ($span:expr, $($arg:tt)*) => {
+        return ::std::result::Result::Err(::anyhow::Error::new(
+            $crate::error::LowerError::new(format!($($arg)*), $span),
+        ))
+    };
+}

--- a/crates/perry-hir/src/lib.rs
+++ b/crates/perry-hir/src/lib.rs
@@ -3,6 +3,7 @@
 //! The HIR is a typed, simplified representation of TypeScript code
 //! that is easier to analyze and transform than the raw AST.
 
+pub mod error;
 pub mod ir;
 pub mod js_transform;
 pub mod lower;

--- a/crates/perry-hir/src/lower.rs
+++ b/crates/perry-hir/src/lower.rs
@@ -10599,10 +10599,16 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                 ast::SuperProp::Ident(_ident) => {
                     // This is typically used in Call expressions like super.method()
                     // We return a placeholder that will be handled specially
-                    Err(anyhow!("Direct super property access not yet supported, use super.method()"))
+                    crate::lower_bail!(
+                        super_prop.span,
+                        "Direct super property access not yet supported, use super.method()"
+                    );
                 }
                 ast::SuperProp::Computed(_) => {
-                    Err(anyhow!("Computed super property access not supported"))
+                    crate::lower_bail!(
+                        super_prop.span,
+                        "Computed super property access not supported"
+                    );
                 }
             }
         }

--- a/crates/perry-hir/src/lower_patterns.rs
+++ b/crates/perry-hir/src/lower_patterns.rs
@@ -5,6 +5,7 @@
 
 use anyhow::{anyhow, Result};
 use perry_types::{LocalId, Type};
+use swc_common::Spanned;
 use swc_ecma_ast as ast;
 use crate::ir::*;
 use crate::lower::{LoweringContext, lower_expr};
@@ -131,7 +132,9 @@ pub(crate) fn lower_assign_target_to_expr(ctx: &mut LoweringContext, target: &as
 pub(crate) fn get_binding_name(pat: &ast::Pat) -> Result<String> {
     match pat {
         ast::Pat::Ident(ident) => Ok(ident.id.sym.to_string()),
-        _ => Err(anyhow!("Unsupported binding pattern")),
+        _ => {
+            crate::lower_bail!(pat.span(), "Unsupported binding pattern");
+        }
     }
 }
 

--- a/crates/perry/src/commands/check.rs
+++ b/crates/perry/src/commands/check.rs
@@ -3,7 +3,7 @@
 use anyhow::{anyhow, Result};
 use clap::Args;
 use perry_diagnostics::{
-    Diagnostic, DiagnosticCode, DiagnosticEmitter, Diagnostics, JsonEmitter, SourceCache,
+    Diagnostic, DiagnosticCode, DiagnosticEmitter, Diagnostics, JsonEmitter, SourceCache, Span,
     TerminalEmitter,
 };
 use std::collections::HashSet;
@@ -226,15 +226,39 @@ pub fn run(args: CheckArgs, format: OutputFormat, use_color: bool, verbose: u8) 
         }
 
         // Try to lower to HIR to catch more errors
+        let file_id = parse_result.file_id;
         match perry_hir::lower_module(&parse_result.module, &filename, &filename) {
             Ok(_hir_module) => {
                 // Successfully lowered
             }
             Err(e) => {
-                all_diagnostics.push(
-                    Diagnostic::error(DiagnosticCode::UnsupportedFeature, format!("{}", e))
-                        .build(),
-                );
+                // If the lowering error carried a span, attach it so the
+                // diagnostic emitter can print file:line:column and the
+                // offending source snippet. Otherwise fall back to a
+                // location-less message (but still tag it with the file_id
+                // so the emitter can at least show the filename).
+                let (message, span) = if let Some(lower_err) =
+                    e.downcast_ref::<perry_hir::error::LowerError>()
+                {
+                    let span = match lower_err.span {
+                        Some(swc_span) => {
+                            Span::new(file_id, swc_span.lo.0, swc_span.hi.0)
+                        }
+                        None => Span::DUMMY,
+                    };
+                    (lower_err.message.clone(), span)
+                } else {
+                    // No span info — prefix the filename so the user at
+                    // least knows which file produced the error.
+                    (format!("{}: {}", filename, e), Span::DUMMY)
+                };
+
+                let mut builder =
+                    Diagnostic::error(DiagnosticCode::UnsupportedFeature, message);
+                if !span.is_dummy() {
+                    builder = builder.with_span(span);
+                }
+                all_diagnostics.push(builder.build());
             }
         }
 


### PR DESCRIPTION
`perry check` was turning every HIR-lowering error into a
location-less diagnostic, so users saw messages like

    error[U006]: Direct super property access not yet supported
    error[U006]: Unsupported binding pattern

with no way to find the offending code. Root cause: lower_module
returns anyhow::Error values that carry just a string, and
check.rs had no way to recover the SWC span of the AST node
that tripped the error.

- Add perry_hir::error::LowerError, an error carrying an optional
  swc_common::Span, and a lower_bail! macro that bails with one.
- Migrate the two sites mentioned in the issue (direct/computed
  super-prop access in lower.rs, non-ident binding patterns in
  lower_patterns.rs) to use lower_bail! with the offending node's
  span.
- In check.rs, downcast the lowering error to LowerError and
  attach its span to the emitted Diagnostic so the existing
  TerminalEmitter/JsonEmitter paths print file:line:column and
  render the source snippet. Fall back to prefixing the filename
  onto the message when an older (non-span-carrying) anyhow error
  comes through, so the file is at least identifiable.

Verified end-to-end: `perry check` now prints

    error[U006]: Direct super property access not yet supported, use super.method()
      --> /tmp/test.ts:9:24
      |
    9 |         const value = super.x;
      |                        ^^^^^^^

and the JSON output includes a proper `location` object. Existing
perry-hir and perry tests pass.

Infrastructure is in place to migrate the remaining ~35
`Err(anyhow!(...))` sites in lower.rs incrementally — each one
only needs its surrounding AST node's span passed to lower_bail!.