### PR TITLE
feat(dev): in-memory AST cache for perry dev rebuilds (V2.1)

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -19,6 +19,82 @@ pub struct CompileResult {
     pub is_dylib: bool,
 }
 
+/// In-memory TypeScript AST cache used by `perry dev` to skip reparsing
+/// unchanged files across rebuilds in a single dev session.
+///
+/// Keyed by canonical path. Staleness check is a full source byte comparison
+/// — if the bytes match what we parsed last time, reuse the cached `Module`;
+/// otherwise reparse and replace the entry. Content-addressed invalidation
+/// means formatter-on-save that rewrites trivia invalidates us correctly,
+/// and we never get confused by mtime weirdness (git checkout, touch, etc.).
+///
+/// Scope is strictly per-process: this cache lives for the duration of one
+/// `perry dev` invocation. `perry compile` never sees it.
+#[derive(Default)]
+pub struct ParseCache {
+    entries: HashMap<PathBuf, ParseCacheEntry>,
+    hits: usize,
+    misses: usize,
+}
+
+struct ParseCacheEntry {
+    source: String,
+    module: swc_ecma_ast::Module,
+}
+
+impl ParseCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of cache hits since creation (or since `reset_counters`).
+    pub fn hits(&self) -> usize {
+        self.hits
+    }
+
+    /// Number of cache misses (fresh parses) since creation.
+    pub fn misses(&self) -> usize {
+        self.misses
+    }
+
+    /// Reset hit/miss counters. Intended to be called between dev rebuilds
+    /// so the counters reflect a single rebuild rather than cumulative.
+    pub fn reset_counters(&mut self) {
+        self.hits = 0;
+        self.misses = 0;
+    }
+}
+
+/// Parse `source` via the cache: return a borrowed `&Module` from the cache,
+/// reusing the last entry if its source bytes match, else reparsing.
+fn parse_cached<'a>(
+    cache: &'a mut ParseCache,
+    path: &Path,
+    source: &str,
+    filename: &str,
+) -> Result<&'a swc_ecma_ast::Module> {
+    let fresh = cache
+        .entries
+        .get(path)
+        .map_or(false, |e| e.source == source);
+    if fresh {
+        cache.hits += 1;
+    } else {
+        let parsed = perry_parser::parse_typescript(source, filename)
+            .map_err(|e| anyhow!("Failed to parse {}: {}", path.display(), e))?;
+        cache.entries.insert(
+            path.to_path_buf(),
+            ParseCacheEntry {
+                source: source.to_string(),
+                module: parsed,
+            },
+        );
+        cache.misses += 1;
+    }
+    // The entry is guaranteed to exist at this point (we just inserted on miss).
+    Ok(&cache.entries[path].module)
+}
+
 #[derive(Args, Debug)]
 pub struct CompileArgs {
     /// Input TypeScript file
@@ -2160,6 +2236,7 @@ fn collect_modules(
     target: Option<&str>,
     next_class_id: &mut perry_hir::ClassId,
     skip_transforms: bool,
+    mut parse_cache: Option<&mut ParseCache>,
 ) -> Result<()> {
     let canonical = entry_path
         .canonicalize()
@@ -2242,13 +2319,23 @@ fn collect_modules(
         .map(|s| s.to_string())
         .unwrap_or_else(|| filename.to_string());
 
-    let ast_module = perry_parser::parse_typescript(&source, filename)
-        .map_err(|e| anyhow!("Failed to parse {}: {}", canonical.display(), e))?;
+    // Parse via the optional in-memory cache (only populated by `perry dev`).
+    // On a cache hit, we reuse the AST from the previous rebuild — the single
+    // largest time sink in the hot rebuild path on unchanged files.
+    let ast_module_owned: swc_ecma_ast::Module;
+    let ast_module: &swc_ecma_ast::Module = match parse_cache.as_deref_mut() {
+        Some(cache) => parse_cached(cache, &canonical, &source, filename)?,
+        None => {
+            ast_module_owned = perry_parser::parse_typescript(&source, filename)
+                .map_err(|e| anyhow!("Failed to parse {}: {}", canonical.display(), e))?;
+            &ast_module_owned
+        }
+    };
     let source_file_path = canonical.to_string_lossy().to_string();
 
     // If type checking is enabled, resolve types from tsgo before lowering
     let resolved_types = if ctx.type_checker.is_some() {
-        let positions = super::typecheck::collect_untyped_positions(&ast_module);
+        let positions = super::typecheck::collect_untyped_positions(ast_module);
         if !positions.is_empty() {
             let client = ctx.type_checker.as_mut().unwrap();
             match super::typecheck::resolve_types_for_file(client, &source_file_path, &positions) {
@@ -2269,7 +2356,7 @@ fn collect_modules(
     };
 
     let (mut hir_module, new_next_class_id) = perry_hir::lower_module_with_class_id_and_types(
-        &ast_module, &module_name, &source_file_path, *next_class_id, resolved_types
+        ast_module, &module_name, &source_file_path, *next_class_id, resolved_types
     )?;
     *next_class_id = new_next_class_id; // Update the global class_id counter
 
@@ -2368,7 +2455,7 @@ fn collect_modules(
                         }
                     }
                     // Recursively collect TypeScript modules
-                    collect_modules(&resolved_path, ctx, visited, enable_js_runtime, format, target, next_class_id, skip_transforms)?;
+                    collect_modules(&resolved_path, ctx, visited, enable_js_runtime, format, target, next_class_id, skip_transforms, parse_cache.as_deref_mut())?;
                 }
                 ModuleKind::Interpreted => {
                     // Perry native extension packages (ioredis, ethers, ws, mysql2, dotenv)
@@ -2417,7 +2504,7 @@ fn collect_modules(
                     }
 
                     // Collect JS module
-                    collect_modules(&resolved_path, ctx, visited, enable_js_runtime, format, target, next_class_id, skip_transforms)?;
+                    collect_modules(&resolved_path, ctx, visited, enable_js_runtime, format, target, next_class_id, skip_transforms, parse_cache.as_deref_mut())?;
                 }
                 ModuleKind::NativeRust => {
                     // Native Rust modules are handled by stdlib
@@ -2448,11 +2535,11 @@ fn collect_modules(
             if let Some((resolved_path, kind)) = cached_resolve_import(src, &canonical, ctx) {
                 match kind {
                     ModuleKind::NativeCompiled => {
-                        collect_modules(&resolved_path, ctx, visited, enable_js_runtime, format, target, next_class_id, skip_transforms)?;
+                        collect_modules(&resolved_path, ctx, visited, enable_js_runtime, format, target, next_class_id, skip_transforms, parse_cache.as_deref_mut())?;
                     }
                     ModuleKind::Interpreted => {
                         if enable_js_runtime {
-                            collect_modules(&resolved_path, ctx, visited, enable_js_runtime, format, target, next_class_id, skip_transforms)?;
+                            collect_modules(&resolved_path, ctx, visited, enable_js_runtime, format, target, next_class_id, skip_transforms, parse_cache.as_deref_mut())?;
                         }
                     }
                     ModuleKind::NativeRust => {}
@@ -3264,6 +3351,19 @@ fn compile_for_wasm(ctx: &CompilationContext, args: &CompileArgs, format: Output
 }
 
 pub fn run(args: CompileArgs, format: OutputFormat, use_color: bool, verbose: u8) -> Result<CompileResult> {
+    run_with_parse_cache(args, None, format, use_color, verbose)
+}
+
+/// Same as [`run`] but accepts an optional in-memory [`ParseCache`] that
+/// `perry dev` uses to reuse parsed ASTs across rebuilds in a single session.
+/// Pass `None` for the batch-compile path.
+pub fn run_with_parse_cache(
+    args: CompileArgs,
+    mut parse_cache: Option<&mut ParseCache>,
+    format: OutputFormat,
+    use_color: bool,
+    verbose: u8,
+) -> Result<CompileResult> {
     match format {
         OutputFormat::Text => println!("Collecting modules..."),
         OutputFormat::Json => {}
@@ -3451,7 +3551,7 @@ pub fn run(args: CompileArgs, format: OutputFormat, use_color: bool, verbose: u8
     let mut next_class_id: perry_hir::ClassId = 1; // Start at 1, 0 is reserved for "no parent"
     let skip_transforms = matches!(args.target.as_deref(), Some("web") | Some("wasm"));
 
-    collect_modules(&args.input, &mut ctx, &mut visited, args.enable_js_runtime, format, args.target.as_deref(), &mut next_class_id, skip_transforms)?;
+    collect_modules(&args.input, &mut ctx, &mut visited, args.enable_js_runtime, format, args.target.as_deref(), &mut next_class_id, skip_transforms, parse_cache.as_deref_mut())?;
 
     // Bundle extensions if --bundle-extensions specified
     let mut bundled_extensions: Vec<(PathBuf, String)> = Vec::new();
@@ -3467,7 +3567,7 @@ pub fn run(args: CompileArgs, format: OutputFormat, use_color: bool, verbose: u8
                 OutputFormat::Json => {}
             }
             collect_modules(entry_path, &mut ctx, &mut visited,
-                           args.enable_js_runtime, format, args.target.as_deref(), &mut next_class_id, skip_transforms)?;
+                           args.enable_js_runtime, format, args.target.as_deref(), &mut next_class_id, skip_transforms, parse_cache.as_deref_mut())?;
             bundled_extensions.push((entry_path.canonicalize()?, plugin_id.clone()));
         }
     }
@@ -7323,4 +7423,119 @@ pub fn run(args: CompileArgs, format: OutputFormat, use_color: bool, verbose: u8
         bundle_id: result_bundle_id,
         is_dylib,
     })
+}
+
+#[cfg(test)]
+mod parse_cache_tests {
+    use super::*;
+
+    const SRC_V1: &str = "export function greet(name: string): string { return `hi ${name}`; }\n";
+    const SRC_V2: &str = "export function greet(name: string): string { return `hello ${name}`; }\n";
+
+    #[test]
+    fn first_call_is_a_miss() {
+        let mut cache = ParseCache::new();
+        let path = PathBuf::from("/virtual/greet.ts");
+        let _ = parse_cached(&mut cache, &path, SRC_V1, "greet.ts").unwrap();
+        assert_eq!(cache.hits(), 0);
+        assert_eq!(cache.misses(), 1);
+        assert_eq!(cache.entries.len(), 1);
+    }
+
+    #[test]
+    fn identical_source_is_a_hit() {
+        let mut cache = ParseCache::new();
+        let path = PathBuf::from("/virtual/greet.ts");
+        let _ = parse_cached(&mut cache, &path, SRC_V1, "greet.ts").unwrap();
+        let _ = parse_cached(&mut cache, &path, SRC_V1, "greet.ts").unwrap();
+        assert_eq!(cache.hits(), 1);
+        assert_eq!(cache.misses(), 1);
+    }
+
+    #[test]
+    fn changed_source_is_a_miss_and_replaces_entry() {
+        let mut cache = ParseCache::new();
+        let path = PathBuf::from("/virtual/greet.ts");
+        let _ = parse_cached(&mut cache, &path, SRC_V1, "greet.ts").unwrap();
+        let _ = parse_cached(&mut cache, &path, SRC_V2, "greet.ts").unwrap();
+        // Two misses, zero hits; cache still holds one entry (the new version).
+        assert_eq!(cache.hits(), 0);
+        assert_eq!(cache.misses(), 2);
+        assert_eq!(cache.entries.len(), 1);
+        assert_eq!(cache.entries[&path].source, SRC_V2);
+    }
+
+    #[test]
+    fn reverting_to_previous_source_is_still_a_miss() {
+        // The cache keeps only the last version, not history. Reverting to a
+        // prior source counts as a miss — documented behaviour.
+        let mut cache = ParseCache::new();
+        let path = PathBuf::from("/virtual/greet.ts");
+        let _ = parse_cached(&mut cache, &path, SRC_V1, "greet.ts").unwrap();
+        let _ = parse_cached(&mut cache, &path, SRC_V2, "greet.ts").unwrap();
+        let _ = parse_cached(&mut cache, &path, SRC_V1, "greet.ts").unwrap();
+        assert_eq!(cache.hits(), 0);
+        assert_eq!(cache.misses(), 3);
+    }
+
+    #[test]
+    fn distinct_paths_are_independent() {
+        let mut cache = ParseCache::new();
+        let p_a = PathBuf::from("/virtual/a.ts");
+        let p_b = PathBuf::from("/virtual/b.ts");
+        let _ = parse_cached(&mut cache, &p_a, SRC_V1, "a.ts").unwrap();
+        let _ = parse_cached(&mut cache, &p_b, SRC_V1, "b.ts").unwrap();
+        let _ = parse_cached(&mut cache, &p_a, SRC_V1, "a.ts").unwrap();
+        let _ = parse_cached(&mut cache, &p_b, SRC_V1, "b.ts").unwrap();
+        assert_eq!(cache.hits(), 2);
+        assert_eq!(cache.misses(), 2);
+    }
+
+    #[test]
+    fn reset_counters_clears_hit_miss_but_keeps_entries() {
+        let mut cache = ParseCache::new();
+        let path = PathBuf::from("/virtual/greet.ts");
+        let _ = parse_cached(&mut cache, &path, SRC_V1, "greet.ts").unwrap();
+        let _ = parse_cached(&mut cache, &path, SRC_V1, "greet.ts").unwrap();
+        assert_eq!(cache.hits(), 1);
+        assert_eq!(cache.misses(), 1);
+        cache.reset_counters();
+        assert_eq!(cache.hits(), 0);
+        assert_eq!(cache.misses(), 0);
+        // Next lookup for the same source should be a hit, not a miss —
+        // entries survive reset_counters.
+        let _ = parse_cached(&mut cache, &path, SRC_V1, "greet.ts").unwrap();
+        assert_eq!(cache.hits(), 1);
+        assert_eq!(cache.misses(), 0);
+    }
+
+    #[test]
+    fn hit_returns_equivalent_ast_to_fresh_parse() {
+        // A cache hit must give us the same AST shape as reparsing from
+        // scratch — this is the correctness invariant V2.1 relies on.
+        let mut cache = ParseCache::new();
+        let path = PathBuf::from("/virtual/greet.ts");
+        let first = parse_cached(&mut cache, &path, SRC_V1, "greet.ts")
+            .unwrap()
+            .clone();
+        let cached = parse_cached(&mut cache, &path, SRC_V1, "greet.ts")
+            .unwrap()
+            .clone();
+        let fresh = perry_parser::parse_typescript(SRC_V1, "greet.ts").unwrap();
+        assert_eq!(first.body.len(), fresh.body.len());
+        assert_eq!(cached.body.len(), fresh.body.len());
+    }
+
+    #[test]
+    fn parse_error_propagates_and_does_not_poison_cache() {
+        let mut cache = ParseCache::new();
+        let path = PathBuf::from("/virtual/bad.ts");
+        let err = parse_cached(&mut cache, &path, "let x: number = ;", "bad.ts");
+        assert!(err.is_err());
+        // A later good parse at the same path still works and is a miss.
+        let ok = parse_cached(&mut cache, &path, SRC_V1, "bad.ts");
+        assert!(ok.is_ok());
+        assert_eq!(cache.hits(), 0);
+        assert_eq!(cache.misses(), 1);
+    }
 }

--- a/crates/perry/src/commands/dev.rs
+++ b/crates/perry/src/commands/dev.rs
@@ -11,8 +11,17 @@
 //! trigger a single rebuild.
 //!
 //! This is the V1 watch mode: it shells out to the existing compile pipeline
-//! and relies on Perry's auto-optimize library cache for speed. A future V2
-//! may add in-memory AST caching and per-module `.o` reuse.
+//! and relies on Perry's auto-optimize library cache for speed.
+//!
+//! V2.1 (this file): an in-memory AST cache keyed by canonical path is held
+//! across rebuilds in a single `perry dev` session. On a rebuild, unchanged
+//! files reuse the previous parsed `swc_ecma_ast::Module` and skip the parse
+//! step entirely. Invalidation is content-addressed (full source byte
+//! comparison), so editor-format-on-save, timestamp-only touches, and git
+//! checkouts all behave correctly. Set `PERRY_DEV_VERBOSE=1` to print the
+//! hit/miss counts per rebuild.
+//!
+//! V2.2 (scoped in issue #131) will add per-module `.o` reuse on disk.
 
 use anyhow::{anyhow, Result};
 use clap::Args;
@@ -23,7 +32,7 @@ use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
-use super::compile::CompileArgs;
+use super::compile::{CompileArgs, ParseCache};
 use crate::OutputFormat;
 
 /// How long to wait after the first event before triggering a rebuild,
@@ -98,8 +107,13 @@ pub fn run(args: DevArgs, _format: OutputFormat, use_color: bool, verbose: u8) -
 
     print_banner(&project_root, &input, &output_path, &watch_roots, use_color);
 
+    // Per-session parse cache: kept alive across rebuilds so unchanged files
+    // skip parse+lower on the hot path. See module-level docs for details.
+    let mut parse_cache = ParseCache::new();
+    let verbose_cache = std::env::var("PERRY_DEV_VERBOSE").ok().as_deref() == Some("1");
+
     // Initial build + spawn.
-    let mut child: Option<Child> = match build_once(&input, &output_path, verbose) {
+    let mut child: Option<Child> = match build_once(&input, &output_path, verbose, &mut parse_cache, verbose_cache, use_color) {
         Ok(()) => spawn_child(&output_path, &args.child_args, use_color).ok(),
         Err(e) => {
             eprintln!(
@@ -164,7 +178,7 @@ pub fn run(args: DevArgs, _format: OutputFormat, use_color: bool, verbose: u8) -
         cleanup_child(&mut child);
 
         let started = Instant::now();
-        match build_once(&input, &output_path, verbose) {
+        match build_once(&input, &output_path, verbose, &mut parse_cache, verbose_cache, use_color) {
             Ok(()) => {
                 let ms = started.elapsed().as_millis();
                 eprintln!(
@@ -257,7 +271,14 @@ fn is_trigger_path(path: &Path) -> bool {
     }
 }
 
-fn build_once(input: &Path, output: &Path, verbose: u8) -> Result<()> {
+fn build_once(
+    input: &Path,
+    output: &Path,
+    verbose: u8,
+    parse_cache: &mut ParseCache,
+    verbose_cache: bool,
+    use_color: bool,
+) -> Result<()> {
     let args = CompileArgs {
         input: input.to_path_buf(),
         output: Some(output.to_path_buf()),
@@ -277,7 +298,28 @@ fn build_once(input: &Path, output: &Path, verbose: u8) -> Result<()> {
         minimal_stdlib: false,
         no_auto_optimize: false,
     };
-    super::compile::run(args, OutputFormat::Text, true, verbose)?;
+    parse_cache.reset_counters();
+    super::compile::run_with_parse_cache(
+        args,
+        Some(parse_cache),
+        OutputFormat::Text,
+        true,
+        verbose,
+    )?;
+    if verbose_cache {
+        let hits = parse_cache.hits();
+        let misses = parse_cache.misses();
+        let total = hits + misses;
+        if total > 0 {
+            eprintln!(
+                "  {} parse cache: {}/{} hit ({} miss)",
+                paint("•", "dim", use_color),
+                hits,
+                total,
+                misses
+            );
+        }
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

V2.1 of the `perry dev` watch mode: an in-memory AST cache held across rebuilds in a single dev session. On each rebuild, files whose source bytes match the cached version skip SWC parsing and reuse the previous `swc_ecma_ast::Module`. Scope is strictly `perry dev` — `perry compile` and every other entry point pass `None` and behave byte-identically to v0.5.155.

This is the first of the two deliverables scoped in #131. The V2.2 follow-up (per-module `.o` reuse on disk, with cache keying over class-IDs / import prefixes / imported-function signatures / perry version / target / opt flags) is a separate PR tracked in that issue.

Smoke-tested on a two-module project with `PERRY_DEV_VERBOSE=1`:
```
Initial build:    parse cache: 0/2 hit (2 miss)
After edit:       parse cache: 1/2 hit (1 miss)   rebuilt in 502ms
```

## What this changes

**`commands/compile.rs`**
- New `pub struct ParseCache` (path-keyed `HashMap<PathBuf, ParseCacheEntry>` storing `{ source: String, module: swc_ecma_ast::Module }` plus hit/miss counters).
- New `parse_cached(&mut ParseCache, &Path, &str, &str) -> Result<&Module>` helper that does the full-source-bytes comparison and reparse-on-miss.
- `collect_modules` gains a trailing `Option<&mut ParseCache>` parameter, re-borrowed at its four recursive call sites via `Option::as_deref_mut()`.
- New `pub fn run_with_parse_cache(args, Option<&mut ParseCache>, ...)`. The existing `pub fn run(...)` delegates to it with `None`, so every callsite outside this PR is unchanged.

**`commands/dev.rs`**
- Owns one `ParseCache::new()` across the watch loop; `reset_counters()` before each rebuild; prints the per-rebuild hit/miss ratio when `PERRY_DEV_VERBOSE=1`.
- `build_once` threads the cache into `run_with_parse_cache`.

## Design choices worth calling out

**Content-addressed invalidation, not mtime.** The cached entry stores the last seen source bytes and compares byte-for-byte on lookup. A formatter-on-save that changes trivia is a miss (correctly); a `touch` that only bumps mtime is a hit (correctly); git checkout to the same content is a hit. Byte comparison is O(n) but it beats parsing O(n) by a large factor, and we already have the bytes in hand from `fs::read_to_string` so there's no extra I/O.

**No metadata-based heuristics.** I considered mtime+size but that can get fooled by tools that rewrite files with the same mtime (rare but real), and metadata-only invalidation leaves the door open for subtle bugs. Full byte compare is simpler to reason about and costs microseconds.

**Scope is dev-only.** Every non-dev path still calls the unchanged `pub fn run(...)`. This keeps the correctness risk bounded to the watch loop — where the worst-case failure mode is a confusing rebuild the user resolves by restarting `perry dev`.

**No serialization, no disk.** The cache lives in the `perry dev` process and dies with it. The on-disk equivalent is V2.2 in #131, which has its own ABI and cache-key concerns (class-ID coupling, import-prefix mangling, perry version gate) that aren't relevant here.

## Test plan

- [x] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` — all green.
- [x] New unit tests in `commands::compile::parse_cache_tests` (8 tests, all pass):
  - cold lookup is a miss
  - identical source twice → hit
  - changed source → miss + entry replaced
  - revert to prior source is still a miss (documented behaviour — cache keeps only the latest version, not history)
  - distinct paths are independent
  - `reset_counters` clears counters but preserves entries
  - hit returns an equivalent AST to a fresh parse
  - parse errors propagate without poisoning subsequent lookups on the same path
- [x] Existing `commands::dev::tests` (8 tests) still pass — V1 helpers untouched.
- [x] End-to-end smoke test: two-module project, initial `0/2 hit`, post-edit `1/2 hit` with correct rebuilt output.

## What's NOT in this PR

- Per-module `.o` cache on disk (V2.2 — issue #131).
- Promotion to `perry compile` (explicitly out of scope for V2.1 per the issue's "Proposal" section).
- Per-session telemetry beyond the opt-in `PERRY_DEV_VERBOSE=1` line.

Refs #131.
