### PR TITLE
fix(npm): add libc:glibc to linux-x64 and linux-arm64 packages (closes #116)

### DIFF
--- a/npm/perry-linux-arm64/package.json.tmpl
+++ b/npm/perry-linux-arm64/package.json.tmpl
@@ -4,6 +4,7 @@
   "description": "Perry native TypeScript compiler — Linux arm64 (glibc) binary + static libraries.",
   "os": ["linux"],
   "cpu": ["arm64"],
+  "libc": ["glibc"],
   "files": [
     "bin/",
     "lib/",

--- a/npm/perry-linux-x64/package.json.tmpl
+++ b/npm/perry-linux-x64/package.json.tmpl
@@ -4,6 +4,7 @@
   "description": "Perry native TypeScript compiler — Linux x64 (glibc) binary + static libraries.",
   "os": ["linux"],
   "cpu": ["x64"],
+  "libc": ["glibc"],
   "files": [
     "bin/",
     "lib/",


### PR DESCRIPTION
## Summary

Fixes #116 — `@perryts/perry` on Linux x64 glibc fails with "The @perryts/perry-linux-x64 package is not installed".

### Root cause

npm 9.4+ introduced the [`libc` optional-dependency field](https://github.com/npm/rfcs/blob/main/accepted/0055-libc-field.md). When **any** package in a `cpu`+`os` group carries an explicit `libc` selector (here: `@perryts/perry-linux-x64-musl` declares `"libc": ["musl"]`), npm 9.4+ expects the companion glibc package to also carry `"libc": ["glibc"]`. Without it, npm skips the untagged package on glibc systems, leaving no binary installed, and the `perry.js` wrapper throws:

```
[perry] The @perryts/perry-linux-x64 package is not installed.
Cannot find module '@perryts/perry-linux-x64/bin/perry'
```

The user's npm 11.3.0 is a clean glibc install — the selector mismatch is entirely on the package side. This is the same problem esbuild and Bun ran into when they added musl variants: their fix was to add `"libc": ["glibc"]` to the glibc packages, making the matrix symmetric.

### Changes

- `npm/perry-linux-x64/package.json.tmpl`: add `"libc": ["glibc"]`
- `npm/perry-linux-arm64/package.json.tmpl`: add `"libc": ["glibc"]`

The musl templates already have `"libc": ["musl"]`. No other files changed.

**Backwards compatibility**: npm < 9.4 ignores the `libc` field entirely, so the change has no effect on older npm versions — both glibc and musl packages install on all Linux x64/arm64, and `perry.js`'s `isMusl()` runtime check picks the right binary.

### Action required after merge

A **republish** is needed. The currently-published `@perryts/perry-linux-x64` and `@perryts/perry-linux-arm64` on npmjs.com are missing the `libc` field. Triggering `release-packages.yml` (workflow_dispatch with `publish_npm: true`) against the current release tag will re-publish both packages with the corrected `package.json`.

## Test plan

- [ ] `npm install @perryts/perry` on glibc Linux x64 (Ubuntu/Debian) with npm ≥ 9.4 — `@perryts/perry-linux-x64` should be selected and installed
- [ ] `npm install @perryts/perry` on musl Linux x64 (Alpine) — `@perryts/perry-linux-x64-musl` should be selected; glibc package should be skipped
- [ ] `npm install @perryts/perry` on glibc Linux arm64 — `@perryts/perry-linux-arm64` should be selected
- [ ] `npm install @perryts/perry` on npm < 9 (e.g. npm 8) on Linux x64 glibc — both glibc + musl packages install; wrapper picks glibc via `isMusl()` returning false

https://claude.ai/code/session_01U8z7eJFTmCu1LBxwzPjuty

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8z7eJFTmCu1LBxwzPjuty)_