### PR TITLE
Fix #137: for-loop continue skips update on --target web

### DIFF
--- a/crates/perry-codegen-wasm/src/emit.rs
+++ b/crates/perry-codegen-wasm/src/emit.rs
@@ -3742,14 +3742,20 @@ impl<'a> FuncEmitCtx<'a> {
             Stmt::For { init, condition, update, body } => {
                 // <init>
                 // block $break
-                //   loop $continue
+                //   loop $loop_top
                 //     <condition>
-                //     is_truthy ; i32.eqz ; br_if $break
-                //     <body>
+                //     is_truthy ; i32.eqz ; br_if $break   (rel=1, loop is directly inside block)
+                //     block $body_end                       ← continue targets this block's exit
+                //       <body>                             ← continue: br(rel) exits $body_end
+                //     end                                  ← fall through to update
                 //     <update> ; drop
-                //     br $continue
+                //     br 0                                 ← restart $loop_top (rel=0)
                 //   end
                 // end
+                //
+                // Wrapping the body in $body_end ensures `continue` falls through to
+                // the update expression before restarting, fixing the iterator-stuck
+                // bug when `continue` fires inside an if/else chain (issue #137).
                 if let Some(init_stmt) = init {
                     self.emit_stmt(func, init_stmt, in_returning_func);
                 }
@@ -3761,6 +3767,20 @@ impl<'a> FuncEmitCtx<'a> {
 
                 func.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
                 self.block_depth += 1;
+                // block_depth is now the loop's depth; Br(0) here restarts the loop.
+
+                if let Some(cond) = condition {
+                    self.emit_frame_begin(func, 1);
+                    self.emit_store_arg(func, 0, cond);
+                    self.emit_memcall_i32(func, "is_truthy", 1);
+                    func.instruction(&Instruction::I32Eqz);
+                    // loop is directly inside block, so break is always 1 level up
+                    func.instruction(&Instruction::BrIf(1));
+                }
+
+                // Inner block: continue targets this block's exit, then update runs.
+                func.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+                self.block_depth += 1;
                 let continue_d = self.block_depth;
                 self.loop_depth.push(continue_d);
 
@@ -3769,17 +3789,15 @@ impl<'a> FuncEmitCtx<'a> {
                     true
                 } else { false };
 
-                if let Some(cond) = condition {
-                    self.emit_frame_begin(func, 1);
-                    self.emit_store_arg(func, 0, cond);
-                    self.emit_memcall_i32(func, "is_truthy", 1);
-                    func.instruction(&Instruction::I32Eqz);
-                    func.instruction(&Instruction::BrIf(1));
-                }
-
                 for s in body {
                     self.emit_stmt(func, s, in_returning_func);
                 }
+
+                // Close inner body block; continue lands here, then falls to update.
+                if label_pushed { self.label_stack.pop(); }
+                self.loop_depth.pop();
+                self.block_depth -= 1;
+                func.instruction(&Instruction::End);
 
                 if let Some(upd) = update {
                     self.emit_expr(func, upd);
@@ -3788,12 +3806,11 @@ impl<'a> FuncEmitCtx<'a> {
                     }
                 }
 
+                // Restart loop (block_depth == loop's depth, so rel=0).
                 func.instruction(&Instruction::Br(0));
                 self.block_depth -= 1;
                 func.instruction(&Instruction::End);
 
-                if label_pushed { self.label_stack.pop(); }
-                self.loop_depth.pop();
                 self.break_depth.pop();
                 self.block_depth -= 1;
                 func.instruction(&Instruction::End);


### PR DESCRIPTION
## Root cause

In `crates/perry-codegen-wasm/src/emit.rs`, `Stmt::For` lowered the update expression at the end of the loop body, just before the explicit `Br(0)` restart:

```wat
;; BEFORE (broken)
block $break
  loop $loop_top               ;; continue_d = this label
    <condition>; br_if 1 ($break)
    <body>                     ;; continue → Br(rel) targets $loop_top
    <update>                   ;; SKIPPED when continue fires
    br 0 ($loop_top)
  end
end
```

When `continue` fired (as `Br(rel)` targeting the loop label), it jumped back to the loop start and skipped the update — causing the iterator to pin forever on the last active index.

The bug was latent before v0.5.161 because `continue` was hardcoded to `Br(0)` (always targeting the innermost block, i.e. the loop). After #135's fix made `continue` use the formula `block_depth - loop_depth.last()`, continue correctly escaped nested `if` blocks — but now exposed that the `for` update was always in the wrong place relative to where `continue` landed.

## Fix

Wrap the loop body in an inner `block` so that `continue` exits that inner block and falls through to the update before the loop restarts:

```wat
;; AFTER (fixed)
block $break
  loop $loop_top
    <condition>; br_if 1 ($break)    ;; loop directly inside block, rel=1 unchanged
    block $body_end                  ;; continue_d = this label (pushed to loop_depth)
      <body>                         ;; continue → Br(rel) exits $body_end
    end                              ;; fall through here
    <update>                         ;; always runs before restart
    br 0 ($loop_top)
  end
end
```

`loop_depth` now tracks `$body_end` instead of `$loop_top`, so the existing `Stmt::Continue` formula (`block_depth - loop_depth.last()`) produces the correct relative branch without any changes to the `Stmt::Continue` handler. `break_depth` still tracks `$break`, so `Stmt::Break` is unaffected.

## Verification

WAT disassembly of the repro from #137 (via `wasm-tools print`) confirms:

```wat
block           ;; @1 ($break)
  loop          ;; @2 ($loop_top)
    ...
    br_if 1 (;@1;)      ;; condition exit — unchanged
    block       ;; @3 ($body_end) ← NEW
      ...
      if        ;; @4 (EA[i] < 0.5 check)
        br 1 (;@3;)     ;; continue A — exits $body_end ✓
      end
      ...if/else-if/else chain...
      if        ;; (type > 99.0 check)
        br 1 (;@3;)     ;; continue C — exits $body_end ✓
      end
    end                 ;; $body_end — falls through to update
    ...update (i = i + 1)...
    br 0 (;@2;)         ;; restart loop ✓
  end
end
```

Both `continue` statements emit `br 1 (;@3;)` targeting the inner body block, the update always runs before `br 0` restarts the loop. Native target output (`walker 2` / `done`) matches — no non-WASM code paths touched.

## Scope

Single-file change in `crates/perry-codegen-wasm/src/emit.rs`. No version bump, no CLAUDE.md changes (external contributor PR per project rules).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BBbsJYwY1ZWTjESXffRC6C)_