### PR TITLE
fix(runtime): #29 isWellFormed/toWellFormed lone-surrogate detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "atty",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "log",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "base64",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4238,7 +4238,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "serde",
  "serde_json",
@@ -4246,7 +4246,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "clap",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4304,7 +4304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "base64",
@@ -4325,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4399,7 +4399,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -4407,11 +4407,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.185"
+version = "0.5.190"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "itoa",
  "jni",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "rand 0.8.5",
  "serde",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "cairo-rs",
  "gtk4",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "block2",
  "libc",
@@ -4462,7 +4462,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "block2",
  "libc",
@@ -4480,11 +4480,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.185"
+version = "0.5.190"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "block2",
  "libc",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "block2",
  "libc",
@@ -4514,7 +4514,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "block2",
  "libc",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.185"
+version = "0.5.190"
 dependencies = [
  "libc",
  "perry-runtime",

--- a/crates/perry-codegen/src/codegen.rs
+++ b/crates/perry-codegen/src/codegen.rs
@@ -2641,9 +2641,14 @@ fn emit_string_pool(
         let handle_ref = format!("@{}", entry.handle_global);
         let len_str = entry.byte_len.to_string();
 
+        let init_fn = if entry.is_wtf8 {
+            "js_string_from_wtf8_bytes"
+        } else {
+            "js_string_from_bytes"
+        };
         let handle = blk.call(
             I64,
-            "js_string_from_bytes",
+            init_fn,
             &[(PTR, &bytes_ref), (I32, &len_str)],
         );
         let nanboxed = blk.call(DOUBLE, "js_nanbox_string", &[(I64, &handle)]);

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -651,6 +651,16 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(ctx.block().load(DOUBLE, &handle_global))
         }
 
+        // WTF-8 string literals (contain lone surrogates U+D800..U+DFFF).
+        // Same hoisting strategy as Expr::String, but initialized via
+        // js_string_from_wtf8_bytes which sets STRING_FLAG_HAS_LONE_SURROGATES.
+        Expr::WtfString(bytes) => {
+            let idx = ctx.strings.intern_wtf8(bytes);
+            let entry = ctx.strings.entry(idx);
+            let handle_global = format!("@{}", entry.handle_global);
+            Ok(ctx.block().load(DOUBLE, &handle_global))
+        }
+
         // -------- Variables --------
         // LocalGet lookup order:
         //   1. Closure captures (when lowering inside a closure body) →

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -39,6 +39,7 @@ pub fn declare_phase1(module: &mut LlModule) {
 
     // Strings (enough to produce string literals for later phases).
     module.declare_function("js_string_from_bytes", I64, &[PTR, I32]);
+    module.declare_function("js_string_from_wtf8_bytes", I64, &[PTR, I32]);
 
     // Type checks.
     module.declare_function("js_is_truthy", I32, &[DOUBLE]);
@@ -648,6 +649,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // subsequent method dispatch flows through HANDLE_METHOD_DISPATCH.
     module.declare_function("js_crypto_create_hash", DOUBLE, &[I64]);
     module.declare_function("js_string_from_bytes", I64, &[I64, I32]);
+    module.declare_function("js_string_from_wtf8_bytes", I64, &[I64, I32]);
     // Buffer.alloc(size, fill) — returns raw *mut BufferHeader.
     module.declare_function("js_buffer_alloc", I64, &[I32, I32]);
     // JSON full-featured stringify/parse (replacer + indent + reviver).

--- a/crates/perry-codegen/src/stmt.rs
+++ b/crates/perry-codegen/src/stmt.rs
@@ -1386,7 +1386,8 @@ fn expr_preserves_array_length(
         | Expr::Bool(_)
         | Expr::Null
         | Expr::Undefined
-        | Expr::String(_) => true,
+        | Expr::String(_)
+        | Expr::WtfString(_) => true,
         // Default: conservative reject for HIR variants we haven't
         // analyzed. Better to lose the optimization than to silently
         // hoist past a body that mutates the array.

--- a/crates/perry-codegen/src/strings.rs
+++ b/crates/perry-codegen/src/strings.rs
@@ -89,6 +89,8 @@ pub struct StringEntry {
     pub bytes_global: String,
     /// Symbol name of the mutable handle global (`.str.N.handle`).
     pub handle_global: String,
+    /// true = bytes contain WTF-8 lone surrogates; use js_string_from_wtf8_bytes at init.
+    pub is_wtf8: bool,
 }
 
 impl StringPool {
@@ -138,9 +140,44 @@ impl StringPool {
             escaped_ir,
             bytes_global,
             handle_global,
+            is_wtf8: false,
         };
         self.entries.push(entry);
         self.interned.insert(value.to_string(), idx);
+        idx
+    }
+
+    /// Intern a WTF-8 byte sequence (may contain lone surrogates).
+    /// Uses a separate key-space from normal strings (prefixed "wtf8:").
+    pub fn intern_wtf8(&mut self, bytes: &[u8]) -> u32 {
+        let key = format!("wtf8:{}", bytes.escape_ascii());
+        if let Some(&idx) = self.interned.get(&key) {
+            return idx;
+        }
+        let idx = self.entries.len() as u32;
+        let byte_len = bytes.len();
+        let escaped_ir = escape_for_llvm_ir(bytes);
+        let bytes_global = if self.module_prefix.is_empty() {
+            format!(".str.{}.bytes", idx)
+        } else {
+            format!("{}_.str.{}.bytes", self.module_prefix, idx)
+        };
+        let handle_global = if self.module_prefix.is_empty() {
+            format!(".str.{}.handle", idx)
+        } else {
+            format!("{}_.str.{}.handle", self.module_prefix, idx)
+        };
+        let entry = StringEntry {
+            idx,
+            value: key.clone(),
+            byte_len,
+            escaped_ir,
+            bytes_global,
+            handle_global,
+            is_wtf8: true,
+        };
+        self.entries.push(entry);
+        self.interned.insert(key, idx);
         idx
     }
 

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -94,6 +94,7 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
         Expr::ObjectGetOwnPropertyNames(_) => Some(HirType::Array(Box::new(HirType::String))),
         Expr::ObjectGetOwnPropertySymbols(_) => Some(HirType::Array(Box::new(HirType::Any))),
         Expr::String(_)
+        | Expr::WtfString(_)
         | Expr::ArrayJoin { .. }
         | Expr::StringCoerce(_)
         | Expr::StringFromCodePoint(_)
@@ -638,7 +639,7 @@ pub(crate) fn is_map_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
 /// the string path when the value might actually be a number.
 pub(crate) fn is_definitely_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     match e {
-        Expr::String(_) => true,
+        Expr::String(_) | Expr::WtfString(_) => true,
         Expr::LocalGet(id) => {
             matches!(ctx.local_types.get(id), Some(HirType::String))
         }
@@ -706,7 +707,7 @@ pub(crate) fn is_definitely_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
 
 pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     match e {
-        Expr::String(_) => true,
+        Expr::String(_) | Expr::WtfString(_) => true,
         Expr::LocalGet(id) => {
             match ctx.local_types.get(id) {
                 Some(HirType::String) => true,
@@ -1100,7 +1101,7 @@ pub(crate) fn static_type_of(ctx: &FnCtx<'_>, e: &Expr) -> Option<HirType> {
         Expr::New { class_name, .. } if class_name == "Array" => {
             Some(HirType::Array(Box::new(HirType::Any)))
         }
-        Expr::String(_) => Some(HirType::String),
+        Expr::String(_) | Expr::WtfString(_) => Some(HirType::String),
         Expr::Number(_) | Expr::Integer(_) => Some(HirType::Number),
         Expr::Bool(_) => Some(HirType::Boolean),
         Expr::LocalGet(id) => ctx.local_types.get(id).cloned(),

--- a/crates/perry-hir/src/ir.rs
+++ b/crates/perry-hir/src/ir.rs
@@ -761,6 +761,10 @@ pub enum Expr {
     Integer(i64), // Integer literal that fits in i64 (for optimization)
     BigInt(String), // Store as string to preserve precision
     String(String),
+    /// String literal containing WTF-8 bytes (lone surrogates U+D800..U+DFFF).
+    /// Raw WTF-8 bytes — cannot be represented as a valid Rust String.
+    /// Lowers to js_string_from_wtf8_bytes at runtime.
+    WtfString(Vec<u8>),
     /// Localizable string — resolved at compile time from locale files.
     /// The string_idx indexes into the global i18n string table (2D: [locale][key]).
     /// For parameterized strings like "Hello, {name}!", params contains the values to interpolate.

--- a/crates/perry-hir/src/lower_patterns.rs
+++ b/crates/perry-hir/src/lower_patterns.rs
@@ -52,7 +52,15 @@ pub(crate) fn lower_lit(lit: &ast::Lit) -> Result<Expr> {
                 Ok(Expr::Number(value))
             }
         }
-        ast::Lit::Str(s) => Ok(Expr::String(s.value.as_str().unwrap_or("").to_string())),
+        ast::Lit::Str(s) => {
+            if let Some(valid_utf8) = s.value.as_str() {
+                Ok(Expr::String(valid_utf8.to_string()))
+            } else {
+                // Lone surrogates (U+D800..U+DFFF): SWC stores them as WTF-8 bytes.
+                // as_str() returns None because they can't be represented as valid UTF-8.
+                Ok(Expr::WtfString(s.value.as_bytes().to_vec()))
+            }
+        }
         ast::Lit::Bool(b) => Ok(Expr::Bool(b.value)),
         ast::Lit::Null(_) => Ok(Expr::Null),
         ast::Lit::BigInt(bi) => Ok(Expr::BigInt(bi.value.to_string())),

--- a/crates/perry-jsruntime/src/bridge.rs
+++ b/crates/perry-jsruntime/src/bridge.rs
@@ -272,13 +272,14 @@ unsafe fn native_string_to_rust(ptr: *const u8) -> String {
         return String::new();
     }
 
-    // StringHeader layout: { utf16_len: u32, byte_len: u32, capacity: u32, refcount: u32, data: [u8] }
+    // StringHeader layout: { utf16_len: u32, byte_len: u32, capacity: u32, refcount: u32, flags: u32, data: [u8] }
     #[repr(C)]
     struct StringHeader {
         _utf16_len: u32,
         byte_len: u32,
         _capacity: u32,
         _refcount: u32,
+        _flags: u32,
     }
 
     let header = ptr as *const StringHeader;

--- a/crates/perry-runtime/src/string.rs
+++ b/crates/perry-runtime/src/string.rs
@@ -1,18 +1,25 @@
 //! String runtime support for Perry
 //!
-//! Strings are heap-allocated UTF-8 sequences with capacity for efficient appending.
+//! Strings are heap-allocated UTF-8 (or WTF-8) sequences with capacity for efficient appending.
 //! Layout:
 //!   - StringHeader at the start (utf16_len at offset 0 for inline codegen access)
 //!   - Followed by `capacity` bytes of data (only `byte_len` bytes are valid)
+//!
+//! Strings containing lone surrogates (U+D800..U+DFFF) are stored as WTF-8 bytes and
+//! marked with STRING_FLAG_HAS_LONE_SURROGATES in the `flags` field.
 
 use std::ptr;
 use std::slice;
 use std::str;
 
+/// Flag: string bytes contain WTF-8 lone-surrogate sequences (U+D800..U+DFFF).
+/// Set by js_string_from_wtf8_bytes. Checked by isWellFormed/toWellFormed.
+pub const STRING_FLAG_HAS_LONE_SURROGATES: u32 = 1;
+
 /// A static empty string that can be used as a safe fallback for null pointers.
-/// Has utf16_len=0, byte_len=0, capacity=0, refcount=0 (shared).
+/// Has utf16_len=0, byte_len=0, capacity=0, refcount=0, flags=0 (shared).
 #[no_mangle]
-pub static PERRY_EMPTY_STRING: StringHeader = StringHeader { utf16_len: 0, byte_len: 0, capacity: 0, refcount: 0 };
+pub static PERRY_EMPTY_STRING: StringHeader = StringHeader { utf16_len: 0, byte_len: 0, capacity: 0, refcount: 0, flags: 0 };
 
 /// Get a pointer to the static empty string (for codegen null guards).
 #[no_mangle]
@@ -31,23 +38,27 @@ pub fn is_valid_string_ptr(p: *const StringHeader) -> bool {
 /// Header for heap-allocated strings
 ///
 /// `utf16_len` is at offset 0 so codegen can inline `.length` as a single i32 load.
-/// `byte_len` tracks the actual UTF-8 byte count for internal memcpy/slice operations.
+/// `byte_len` tracks the actual byte count for internal memcpy/slice operations.
 ///
 /// The `refcount` field enables in-place append optimization in `js_string_append`:
 /// - refcount=0: shared/unknown ownership — never mutated in-place (safe default)
 /// - refcount=1: unique owner — `js_string_append` can append in-place if capacity allows
 /// Only strings created by `js_string_append` get refcount=1. When a string pointer is
 /// copied to another variable, codegen calls `js_string_addref` to set refcount=0 (shared).
+///
+/// `flags`: STRING_FLAG_HAS_LONE_SURROGATES (=1) marks WTF-8 strings with lone surrogates.
 #[repr(C)]
 pub struct StringHeader {
     /// Length in UTF-16 code units (JS `.length` semantics). At offset 0 for inline codegen.
     pub utf16_len: u32,
-    /// Length in UTF-8 bytes (internal use for memcpy, capacity checks, etc.)
+    /// Length in bytes (internal use for memcpy, capacity checks, etc.)
     pub byte_len: u32,
     /// Capacity in bytes (allocated space for data)
     pub capacity: u32,
     /// Reference hint: 0=shared (never mutate in-place), 1=unique (in-place append OK)
     pub refcount: u32,
+    /// Bit flags: STRING_FLAG_HAS_LONE_SURROGATES = 1
+    pub flags: u32,
 }
 
 // ── UTF-8 ↔ UTF-16 conversion helpers ──────────────────────────────────
@@ -129,6 +140,7 @@ fn js_string_from_ascii_bytes(data: *const u8, len: u32) -> *mut StringHeader {
         (*ptr).byte_len = len;
         (*ptr).capacity = len;
         (*ptr).refcount = 0;
+        (*ptr).flags = 0;
         if len > 0 && !data.is_null() {
             let data_ptr = (ptr as *mut u8).add(std::mem::size_of::<StringHeader>());
             ptr::copy_nonoverlapping(data, data_ptr, len as usize);
@@ -152,6 +164,7 @@ pub extern "C" fn js_string_from_bytes_with_capacity(data: *const u8, len: u32, 
         (*ptr).byte_len = len;
         (*ptr).capacity = capacity;
         (*ptr).refcount = 0; // shared by default — caller can set to 1 if uniquely owned
+        (*ptr).flags = 0;
 
         // Copy string data after header
         if len > 0 && !data.is_null() {
@@ -160,6 +173,64 @@ pub extern "C" fn js_string_from_bytes_with_capacity(data: *const u8, len: u32, 
         }
     }
 
+    ptr
+}
+
+/// Count UTF-16 code units for a WTF-8 byte slice without using from_utf8.
+/// Lone surrogate sequences (0xED 0xA0..0xBF 0x80..0xBF) each count as 1 unit,
+/// same as any other BMP codepoint. Astral sequences (4-byte) count as 2.
+#[inline]
+fn compute_utf16_len_wtf8(bytes: &[u8]) -> u32 {
+    let mut count = 0u32;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b < 0x80 {
+            count += 1;
+            i += 1;
+        } else if b < 0xC0 {
+            // continuation byte in lead position — skip
+            i += 1;
+        } else if b < 0xE0 {
+            count += 1;
+            i += 2;
+        } else if b < 0xF0 {
+            // 3-byte sequence: BMP codepoint or WTF-8 lone surrogate → 1 unit
+            count += 1;
+            i += 3;
+        } else {
+            // 4-byte sequence: astral codepoint → 2 UTF-16 units
+            count += 2;
+            i += 4;
+        }
+    }
+    count
+}
+
+/// Create a StringHeader from WTF-8 bytes (may contain lone-surrogate sequences).
+/// Sets STRING_FLAG_HAS_LONE_SURROGATES so isWellFormed()/toWellFormed() work correctly.
+#[no_mangle]
+pub extern "C" fn js_string_from_wtf8_bytes(data: *const u8, len: u32) -> *mut StringHeader {
+    let total_size = std::mem::size_of::<StringHeader>() + len as usize;
+    let raw = string_arena_alloc(total_size);
+    let ptr = raw as *mut StringHeader;
+    unsafe {
+        let bytes = if len > 0 && !data.is_null() {
+            slice::from_raw_parts(data, len as usize)
+        } else {
+            &[]
+        };
+        let u16len = compute_utf16_len_wtf8(bytes);
+        (*ptr).utf16_len = u16len;
+        (*ptr).byte_len = len;
+        (*ptr).capacity = len;
+        (*ptr).refcount = 0;
+        (*ptr).flags = STRING_FLAG_HAS_LONE_SURROGATES;
+        if len > 0 && !data.is_null() {
+            let data_ptr = (ptr as *mut u8).add(std::mem::size_of::<StringHeader>());
+            ptr::copy_nonoverlapping(data, data_ptr, len as usize);
+        }
+    }
     ptr
 }
 
@@ -339,10 +410,13 @@ pub extern "C" fn js_string_concat(a: *const StringHeader, b: *const StringHeade
     let ptr = raw as *mut StringHeader;
 
     unsafe {
+        let flags_a = if is_valid_string_ptr(a) { (*a).flags } else { 0 };
+        let flags_b = if is_valid_string_ptr(b) { (*b).flags } else { 0 };
         (*ptr).utf16_len = u16len_a + u16len_b;
         (*ptr).byte_len = total_blen;
         (*ptr).capacity = total_blen;
         (*ptr).refcount = 0; // shared by default
+        (*ptr).flags = flags_a | flags_b;
 
         let data_ptr = (ptr as *mut u8).add(std::mem::size_of::<StringHeader>());
 
@@ -433,6 +507,7 @@ pub extern "C" fn js_string_concat_value(
             (*ptr).byte_len = total_blen as u32;
             (*ptr).capacity = total_blen as u32;
             (*ptr).refcount = 0;
+            (*ptr).flags = if is_valid_string_ptr(prefix) { (*prefix).flags } else { 0 };
 
             let data_ptr = (ptr as *mut u8).add(std::mem::size_of::<StringHeader>());
             if is_valid_string_ptr(prefix) && prefix_blen > 0 {
@@ -508,6 +583,7 @@ pub extern "C" fn js_value_concat_string(
             (*ptr).byte_len = total_blen as u32;
             (*ptr).capacity = total_blen as u32;
             (*ptr).refcount = 0;
+            (*ptr).flags = if is_valid_string_ptr(suffix) { (*suffix).flags } else { 0 };
 
             let data_ptr = (ptr as *mut u8).add(std::mem::size_of::<StringHeader>());
             ptr::copy_nonoverlapping(num_buf.as_ptr(), data_ptr, num_len);
@@ -1351,6 +1427,7 @@ pub extern "C" fn js_string_locale_compare(
 
 /// String.prototype.isWellFormed() — returns NaN-boxed boolean.
 /// A string is well-formed if it contains no lone surrogates.
+/// Lone-surrogate strings are marked with STRING_FLAG_HAS_LONE_SURROGATES at construction.
 #[no_mangle]
 pub extern "C" fn js_string_is_well_formed(s: *const StringHeader) -> f64 {
     const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
@@ -1358,70 +1435,67 @@ pub extern "C" fn js_string_is_well_formed(s: *const StringHeader) -> f64 {
     if !is_valid_string_ptr(s) {
         return f64::from_bits(TAG_TRUE);
     }
-    let str_data = string_as_str(s);
-    // Rust &str is always valid UTF-8, so it can never contain lone surrogates.
-    // The only way to construct an ill-formed string in Perry is via escape
-    // sequences like "\uD800" — those should be encoded as the WTF-8/CESU-8
-    // 3-byte sequence ED A0 80 (which is invalid UTF-8 and would have already
-    // been rejected by the parser). For safety we walk the UTF-16 view here.
-    let utf16: Vec<u16> = str_data.encode_utf16().collect();
-    let len = utf16.len();
-    let mut i = 0;
-    while i < len {
-        let unit = utf16[i];
-        if (0xD800..=0xDBFF).contains(&unit) {
-            // High surrogate — must be followed by a low surrogate
-            if i + 1 >= len {
-                return f64::from_bits(TAG_FALSE);
-            }
-            let next = utf16[i + 1];
-            if !(0xDC00..=0xDFFF).contains(&next) {
-                return f64::from_bits(TAG_FALSE);
-            }
-            i += 2;
-        } else if (0xDC00..=0xDFFF).contains(&unit) {
-            // Lone low surrogate
-            return f64::from_bits(TAG_FALSE);
-        } else {
-            i += 1;
-        }
+    let flags = unsafe { (*s).flags };
+    if flags & STRING_FLAG_HAS_LONE_SURROGATES != 0 {
+        return f64::from_bits(TAG_FALSE);
     }
     f64::from_bits(TAG_TRUE)
 }
 
-/// String.prototype.toWellFormed() — replaces lone surrogates with U+FFFD.
+/// String.prototype.toWellFormed() — replaces lone surrogates with U+FFFD (U+FFFD = EF BF BD).
+/// Works directly on WTF-8 bytes: replaces each 3-byte surrogate sequence
+/// (ED A0..BF 80..BF) with the 3-byte U+FFFD encoding.
 #[no_mangle]
 pub extern "C" fn js_string_to_well_formed(s: *const StringHeader) -> *mut StringHeader {
     if !is_valid_string_ptr(s) {
         return js_string_from_bytes(std::ptr::null(), 0);
     }
-    let str_data = string_as_str(s);
-    let utf16: Vec<u16> = str_data.encode_utf16().collect();
-    let len = utf16.len();
-    let mut fixed: Vec<u16> = Vec::with_capacity(len);
+    let flags = unsafe { (*s).flags };
+    let blen = unsafe { (*s).byte_len } as usize;
+    let data = string_data(s);
+    if flags & STRING_FLAG_HAS_LONE_SURROGATES == 0 {
+        // Well-formed UTF-8: return a copy without scanning
+        return js_string_from_bytes(data, blen as u32);
+    }
+    // Scan raw bytes and replace every WTF-8 lone-surrogate sequence with U+FFFD.
+    // WTF-8 surrogate: first byte = 0xED, second = 0xA0..=0xBF, third = 0x80..=0xBF.
+    let bytes = unsafe { slice::from_raw_parts(data, blen) };
+    let mut result: Vec<u8> = Vec::with_capacity(blen);
     let mut i = 0;
-    while i < len {
-        let unit = utf16[i];
-        if (0xD800..=0xDBFF).contains(&unit) {
-            if i + 1 < len && (0xDC00..=0xDFFF).contains(&utf16[i + 1]) {
-                fixed.push(unit);
-                fixed.push(utf16[i + 1]);
-                i += 2;
-                continue;
-            }
-            fixed.push(0xFFFD);
+    while i < blen {
+        let b = bytes[i];
+        if b == 0xED
+            && i + 2 < blen
+            && (0xA0..=0xBF).contains(&bytes[i + 1])
+            && (0x80..=0xBF).contains(&bytes[i + 2])
+        {
+            // Lone surrogate → U+FFFD (EF BF BD)
+            result.extend_from_slice(&[0xEF, 0xBF, 0xBD]);
+            i += 3;
+        } else if b < 0x80 {
+            result.push(b);
             i += 1;
-        } else if (0xDC00..=0xDFFF).contains(&unit) {
-            fixed.push(0xFFFD);
+        } else if b < 0xC0 {
+            result.push(b);
             i += 1;
+        } else if b < 0xE0 {
+            result.push(b);
+            if i + 1 < blen { result.push(bytes[i + 1]); }
+            i += 2;
+        } else if b < 0xF0 {
+            result.push(b);
+            if i + 1 < blen { result.push(bytes[i + 1]); }
+            if i + 2 < blen { result.push(bytes[i + 2]); }
+            i += 3;
         } else {
-            fixed.push(unit);
-            i += 1;
+            result.push(b);
+            if i + 1 < blen { result.push(bytes[i + 1]); }
+            if i + 2 < blen { result.push(bytes[i + 2]); }
+            if i + 3 < blen { result.push(bytes[i + 3]); }
+            i += 4;
         }
     }
-    let result = String::from_utf16(&fixed).unwrap_or_else(|_| str_data.to_string());
-    let bytes = result.as_bytes();
-    js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
+    js_string_from_bytes(result.as_ptr(), result.len() as u32)
 }
 
 /// Print a string to stdout

--- a/crates/perry-transform/src/inline.rs
+++ b/crates/perry-transform/src/inline.rs
@@ -1245,7 +1245,7 @@ fn try_inline_call(
 fn is_trivial_expr(expr: &Expr) -> bool {
     matches!(expr,
         Expr::Integer(_) | Expr::Number(_) | Expr::Bool(_) |
-        Expr::String(_) | Expr::Null | Expr::Undefined |
+        Expr::String(_) | Expr::WtfString(_) | Expr::Null | Expr::Undefined |
         Expr::LocalGet(_) | Expr::GlobalGet(_)
     )
 }

--- a/crates/perry-ui-macos/src/string_header.rs
+++ b/crates/perry-ui-macos/src/string_header.rs
@@ -5,10 +5,12 @@
 pub struct StringHeader {
     /// Length in UTF-16 code units (JS `.length` semantics)
     pub utf16_len: u32,
-    /// Length in UTF-8 bytes
+    /// Length in bytes
     pub byte_len: u32,
     /// Capacity (allocated space for data)
     pub capacity: u32,
     /// Reference hint for in-place append optimization (0=shared, 1=unique)
     pub refcount: u32,
+    /// Bit flags: STRING_FLAG_HAS_LONE_SURROGATES = 1
+    pub flags: u32,
 }

--- a/test-files/test_is_well_formed.ts
+++ b/test-files/test_is_well_formed.ts
@@ -1,0 +1,42 @@
+// Tests for String.prototype.isWellFormed() and toWellFormed() (ES2024)
+// Covers: lone high surrogate, lone low surrogate, paired surrogates,
+// ASCII+surrogate mix, well-formed strings.
+
+// Well-formed strings
+console.log("Hello World".isWellFormed());       // true
+console.log("".isWellFormed());                  // true
+console.log("𐀀".isWellFormed());                 // true (U+10000 paired surrogates)
+console.log("café".isWellFormed());              // true
+
+// Lone high surrogate
+console.log("\uD800".isWellFormed());            // false
+console.log("\uDBFF".isWellFormed());            // false
+
+// Lone low surrogate
+console.log("\uDC00".isWellFormed());            // false
+console.log("\uDFFF".isWellFormed());            // false
+
+// Mixed: ASCII + lone surrogate
+console.log("ab\uD800cd".isWellFormed());        // false
+console.log("ab\uD800cd".length);               // 5
+
+// toWellFormed replaces lone surrogates with U+FFFD
+const a = "\uD800".toWellFormed();
+console.log(a.isWellFormed());                   // true
+console.log(a === "�");                     // true
+console.log(a.length);                           // 1
+
+const b = "ab\uD800cd".toWellFormed();
+console.log(b.isWellFormed());                   // true
+console.log(b.includes("�"));              // true
+console.log(b.length);                           // 5
+
+// toWellFormed on well-formed string is identity
+const c = "Hello".toWellFormed();
+console.log(c === "Hello");                      // true
+console.log(c.isWellFormed());                   // true
+
+// Paired surrogate (𐀀 = U+10000) is well-formed — toWellFormed preserves it
+const d = "𐀀".toWellFormed();
+console.log(d === "𐀀");                          // true
+console.log(d.length);                           // 2


### PR DESCRIPTION
Closes #29.

## What was broken

`String.prototype.isWellFormed()` always returned `true`, and `toWellFormed()` was a no-op, because lone surrogates were silently discarded at parse time.

SWC stores string literals with lone surrogates as `Wtf8Atom`. Calling `as_str()` on a `Wtf8Atom` that contains lone surrogates returns `None` (they can't be represented as valid UTF-8). The old code at `lower_patterns.rs` did:

```rust
ast::Lit::Str(s) => Ok(Expr::String(s.value.as_str().unwrap_or("").to_string()))
```

So `"\uD800"` (lone high surrogate) became an empty string `""` in the HIR. `isWellFormed()` was then checking a perfectly-valid empty string and returning `true`.

## Approach (StringHeader flag, not full WTF-8)

A full WTF-8 migration would touch every string operation in the runtime. Instead, this PR uses a minimal flag-based approach:

1. **New HIR variant `Expr::WtfString(Vec<u8>)`** — carries raw WTF-8 bytes through the pipeline for string literals that contain lone surrogates. Regular `Expr::String(String)` is unchanged.

2. **New runtime function `js_string_from_wtf8_bytes`** — allocates and stores the raw WTF-8 bytes, sets `STRING_FLAG_HAS_LONE_SURROGATES` in the new `StringHeader.flags` field.

3. **`StringHeader` gains a `flags: u32` field** (offset 16, struct grows 16→20 bytes). Flag propagates through `js_string_concat` and fused concat variants so a concatenation of a tainted + clean string is tainted.

4. **`isWellFormed()`** — O(1) flag check. Returns `false` iff `STRING_FLAG_HAS_LONE_SURROGATES` is set.

5. **`toWellFormed()`** — scans raw WTF-8 bytes. Replaces the WTF-8 lone-surrogate pattern (`0xED 0xA0–0xBF 0x80–0xBF`) with U+FFFD (`0xEF 0xBF 0xBD`). Returns a clean string via `js_string_from_bytes`.

## Before / After

```
// Before (node --experimental-strip-types):
isWellFormed lone high surrogate: false
isWellFormed lone low surrogate: false
isWellFormed paired surrogates: true
toWellFormed result: [�]

// Before (Perry v0.5.190 — same file):
isWellFormed lone high surrogate: true   ← wrong
isWellFormed lone low surrogate: true    ← wrong
isWellFormed paired surrogates: true
toWellFormed result: []                  ← wrong (surrogate lost at parse time)

// After (Perry with this fix, --no-cache):
isWellFormed lone high surrogate: false  ✓
isWellFormed lone low surrogate: false   ✓
isWellFormed paired surrogates: true     ✓
toWellFormed result: [�]            ✓
```

## Gap test delta

`test_gap_string_methods`: **FAIL → PASS**

Gap suite total: 18/28 → 25/27 (several other tests in the suite had also improved between the last recorded sweep and now; this PR is responsible only for the `string_methods` flip).

## Test file

`test-files/test_is_well_formed.ts` — 20 cases covering:
- Lone high surrogate (`\uD800`)
- Lone low surrogate (`\uDFFF`)
- Properly paired surrogates (`𐀀` = U+10000)
- ASCII + lone surrogate mix
- `toWellFormed` replacement
- `isWellFormed` on normal ASCII / Unicode strings
- `.length` of a string containing a lone surrogate (should be 1, not 0)

All 20 cases match Node `--experimental-strip-types` byte-for-byte.

## What this does NOT fix

- Lone surrogates in identifiers, template literals, or regex character classes (separate parse paths in `lower.rs` / `lower_types.rs`)
- `String.prototype.normalize()` with lone surrogates
- Full WTF-8 round-trip through `JSON.stringify` / regex engines / `encodeURIComponent` (those would need a deeper WTF-8 migration)

These adjacent cases are noted in GAPS.md's "lone surrogate handling (WTF-8)" entry and are out of scope for this PR.

## Struct layout note

`StringHeader` grows from 16 to 20 bytes. All construction sites use `std::mem::size_of::<StringHeader>()` so they adjust automatically. The two out-of-crate copies (`perry-ui-macos/src/string_header.rs` and `perry-jsruntime/src/bridge.rs`) are updated in this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BoA5GtjsABeieJLRXNBLHE)_