### PR TITLE
feat(doc-tests): surface --app-bundle-id for widget-target examples (closes #194 partially)

### DIFF
--- a/crates/perry-doc-tests/src/main.rs
+++ b/crates/perry-doc-tests/src/main.rs
@@ -232,12 +232,31 @@ fn run(cli: &Cli) -> Result<i32> {
                 });
                 continue;
             }
+            if is_widget_target(target) && ex.widget_bundle_id.is_none() {
+                results.push(ExampleReport {
+                    file: rel.clone(),
+                    kind: ex.kind,
+                    status: Status::CrossCompileSkip,
+                    detail: format!(
+                        "target=`{target}`: widget target requires \
+                         // widget-bundle-id: <com.example.id> banner directive"
+                    ),
+                    duration_ms: 0,
+                });
+                continue;
+            }
             let started = Instant::now();
             if cli.verbose {
                 eprintln!("[xcompile] {rel} --target {target}");
             }
-            let mut report =
-                cross_compile_one(&ex, &rel, &perry_bin, &out_dir, target);
+            let mut report = cross_compile_one(
+                &ex,
+                &rel,
+                &perry_bin,
+                &out_dir,
+                target,
+                ex.widget_bundle_id.as_deref(),
+            );
             report.duration_ms = started.elapsed().as_millis();
             if cli.verbose {
                 eprintln!("   -> {:?} ({} ms)", report.status, report.duration_ms);
@@ -336,6 +355,7 @@ struct Example {
     platforms: BTreeSet<String>,
     targets: BTreeSet<String>,
     compile_only: bool,
+    widget_bundle_id: Option<String>,
 }
 
 fn discover_examples(root: &Path) -> Result<Vec<Example>> {
@@ -369,6 +389,7 @@ fn discover_examples(root: &Path) -> Result<Vec<Example>> {
             platforms: banner.platforms,
             targets: banner.targets,
             compile_only: banner.compile_only,
+            widget_bundle_id: banner.widget_bundle_id,
         });
     }
     out.sort_by(|a, b| a.path.cmp(&b.path));
@@ -385,6 +406,9 @@ struct Banner {
     /// single-program timeout. Catches API/TS drift without the
     /// integration-test overhead.
     compile_only: bool,
+    /// Required for any `*-widget` / `wearos-tile` target — passed as
+    /// `--app-bundle-id` on the perry compile invocation.
+    widget_bundle_id: Option<String>,
 }
 
 fn read_banner(path: &Path) -> Result<Banner> {
@@ -415,6 +439,11 @@ fn read_banner(path: &Path) -> Result<Banner> {
             let v = rest.trim();
             if v.eq_ignore_ascii_case("false") || v == "0" || v.eq_ignore_ascii_case("no") {
                 b.compile_only = true;
+            }
+        } else if let Some(rest) = body.strip_prefix("widget-bundle-id:") {
+            let v = rest.trim();
+            if !v.is_empty() {
+                b.widget_bundle_id = Some(v.to_string());
             }
         }
     }
@@ -579,7 +608,8 @@ fn target_buildable_reason(target: &str, host: &str) -> Option<String> {
             Some(format!("target=`{target}` is Rust Tier-3 (nightly + -Zbuild-std); not yet wired"))
         }
         "ios" | "ios-simulator" | "tvos" | "tvos-simulator" | "macos"
-        | "ios-widget" | "ios-widget-simulator" => {
+        | "ios-widget" | "ios-widget-simulator"
+        | "watchos-widget" | "watchos-widget-simulator" => {
             if host != "macos" {
                 Some(format!("needs Xcode — host `{host}` can't build `{target}`"))
             } else if !has_xcode() {
@@ -588,7 +618,7 @@ fn target_buildable_reason(target: &str, host: &str) -> Option<String> {
                 None
             }
         }
-        "android" => {
+        "android" | "android-widget" | "wearos-tile" => {
             if host != "linux" && host != "macos" {
                 Some(format!("android cross-compile unsupported on host `{host}`"))
             } else if std::env::var("ANDROID_NDK_HOME").is_err()
@@ -610,6 +640,18 @@ fn target_buildable_reason(target: &str, host: &str) -> Option<String> {
     }
 }
 
+fn is_widget_target(target: &str) -> bool {
+    matches!(
+        target,
+        "ios-widget"
+            | "ios-widget-simulator"
+            | "watchos-widget"
+            | "watchos-widget-simulator"
+            | "android-widget"
+            | "wearos-tile"
+    )
+}
+
 fn has_xcode() -> bool {
     Command::new("xcrun")
         .arg("--version")
@@ -624,6 +666,7 @@ fn cross_compile_one(
     perry_bin: &Path,
     out_dir: &Path,
     target: &str,
+    widget_bundle_id: Option<&str>,
 ) -> ExampleReport {
     let stem = safe_stem(rel);
     // Output-path extension: perry itself creates the .app bundle directory
@@ -639,25 +682,45 @@ fn cross_compile_one(
         _ => "",
     };
     let out = out_dir.join(format!("{stem}__{target}{ext}"));
-    // For Apple bundle targets, perry produces `<out>.app/` alongside (or
-    // replacing) the linked binary; check that directory for the artifact.
+
+    // Determine where to find the artifact after a successful compile.
+    //
+    // Apple app-bundle targets (ios, tvos, …) create `<out>.app/` alongside
+    // the linked binary. Widget targets (ios-widget, android-widget, …) write
+    // source bundles directly into the `-o` directory, so `out` IS the artifact
+    // directory — no `.app` suffix appended.
     let artifact_check = match target {
-        "ios" | "ios-simulator" | "visionos" | "visionos-simulator" | "tvos" | "tvos-simulator" | "watchos"
-        | "watchos-simulator" | "ios-widget" | "ios-widget-simulator" => {
+        "ios" | "ios-simulator" | "visionos" | "visionos-simulator"
+        | "tvos" | "tvos-simulator" | "watchos" | "watchos-simulator" => {
             out.with_extension("app")
         }
+        // Widget targets: perry writes the source bundle into `-o` itself.
         _ => out.clone(),
     };
 
-    let output = match Command::new(perry_bin)
-        .arg("compile")
+    // Sentinel file expected inside a widget bundle directory.
+    // Apple widget dirs contain Info.plist; Android widget dirs contain
+    // AndroidManifest_snippet.xml. If present, we check for the sentinel
+    // instead of a raw non-empty-dir test.
+    let sentinel: Option<&str> = match target {
+        "ios-widget" | "ios-widget-simulator"
+        | "watchos-widget" | "watchos-widget-simulator" => Some("Info.plist"),
+        "android-widget" | "wearos-tile" => Some("AndroidManifest_snippet.xml"),
+        _ => None,
+    };
+
+    let mut cmd = Command::new(perry_bin);
+    cmd.arg("compile")
         .arg(&ex.path)
         .arg("--target")
         .arg(target)
         .arg("-o")
-        .arg(&out)
-        .output()
-    {
+        .arg(&out);
+    if let Some(bid) = widget_bundle_id {
+        cmd.arg("--app-bundle-id").arg(bid);
+    }
+
+    let output = match cmd.output() {
         Ok(o) => o,
         Err(e) => {
             return ExampleReport {
@@ -684,9 +747,12 @@ fn cross_compile_one(
         };
     }
 
-    // Verify the artifact landed and has bytes. Apple .app targets produce
-    // a directory bundle rather than a single file.
-    let ok = if artifact_check.is_dir() {
+    // Verify the artifact landed. Widget targets produce source-bundle
+    // directories; check for the sentinel file inside rather than just
+    // directory non-emptiness, so a zero-widget compile doesn't pass.
+    let ok = if let Some(s) = sentinel {
+        artifact_check.is_dir() && artifact_check.join(s).is_file()
+    } else if artifact_check.is_dir() {
         std::fs::read_dir(&artifact_check).map(|it| it.count() > 0).unwrap_or(false)
     } else {
         artifact_check.metadata().map(|m| m.len() > 0).unwrap_or(false)

--- a/docs/examples/widgets/_smoketest_bundleid.ts
+++ b/docs/examples/widgets/_smoketest_bundleid.ts
@@ -1,0 +1,18 @@
+// platforms: macos, linux, windows
+// targets: ios-widget, android-widget
+// widget-bundle-id: com.example.perry-doctest-bundleid
+// run: false
+//
+// Smoke-test: verifies the doc-tests harness correctly plumbs --app-bundle-id
+// for widget cross-compile targets.  On a host without Xcode or Android NDK
+// the harness will report XCOMPILE_SKIP (missing toolchain), not a failure.
+// Without the `widget-bundle-id` directive above the harness reports
+// XCOMPILE_SKIP (missing directive) rather than crashing or building with a
+// wrong default bundle-id.
+
+import { Widget } from "perry/widget";
+
+Widget({
+  kind: "perry.smoketest",
+  body: "Hello from the bundle-id smoke test",
+});


### PR DESCRIPTION
## Summary

Harness-side changes to let `perry-doc-tests` drive widget cross-compile targets. Closes #194 on the harness side; the CI matrix job (macOS runner + Xcode + Android NDK) is deferred as noted below.

### Changes (`crates/perry-doc-tests/src/main.rs`, ~98 LOC diff)

- **New banner directive `// widget-bundle-id: <id>`** — parsed by `read_banner` into `Banner.widget_bundle_id` and propagated into `Example`. Passed as `--app-bundle-id` to perry on every widget cross-compile invocation.

- **`target_buildable_reason` expanded** — `watchos-widget` / `watchos-widget-simulator` were falling through to `"unknown target"`; they now route to the Xcode branch (same as `ios-widget`). `android-widget` / `wearos-tile` now route to the Android NDK branch (same as `android`).

- **Missing-directive skip** — after the toolchain check, widget targets whose example has no `widget-bundle-id` banner get `XCOMPILE_SKIP` with reason `"widget target requires // widget-bundle-id: <com.example.id> banner directive"`, not a failure.

- **`cross_compile_one` plumbing** — accepts `widget_bundle_id: Option<&str>`; appends `--app-bundle-id <id>` when present.

- **Artifact check fixed for widget targets** — widget targets (`ios-widget`, `watchos-widget`, `android-widget`, `wearos-tile`) write source bundles **directly into the `-o` path** (not `<path>.app`); the old `.app`-suffix logic for `ios-widget` / `ios-widget-simulator` was wrong. Now uses the raw `-o` path as `artifact_check`. Sentinel files verify the bundle is real: `Info.plist` for Apple widget dirs, `AndroidManifest_snippet.xml` for Android/Wear dirs.

- **`is_widget_target` helper** — single truth for what counts as a widget target (used in the skip check above).

### New example file

`docs/examples/widgets/_smoketest_bundleid.ts` — verifies both harness paths:
- **Without Xcode/NDK** (e.g. this Linux sandbox): reports `XCOMPILE_SKIP` with toolchain reason, not a failure.
- **Without `widget-bundle-id` line**: reports `XCOMPILE_SKIP` with the missing-directive reason, not a crash or wrong-default compile.

### Deferred

The CI matrix job (`.github/workflows/test.yml` widget-targets step on a macOS runner with Xcode + Android NDK installed) is out of scope for a Linux sandbox and requires additional secrets/runner configuration. Natural next step once this lands.

## Test plan

- [ ] `cargo build --release -p perry-doc-tests` compiles clean (network required for first build in a fresh env).
- [ ] `cargo test --workspace --exclude perry-ui-ios` passes.
- [ ] On Linux, running the harness filtered to the smoke-test example shows `XCOMPILE_SKIP` (toolchain) for `ios-widget`/`android-widget`, **not** `XCOMPILE_FAIL`.
- [ ] Temporarily remove the `widget-bundle-id` line from `_smoketest_bundleid.ts` and confirm the harness shows `XCOMPILE_SKIP` (missing directive) instead of crashing.
- [ ] Existing examples unchanged — no new `XCOMPILE_FAIL` regressions.

https://claude.ai/code/session_01UvzDE5x7jA64TDXRAs83y7

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvzDE5x7jA64TDXRAs83y7)_