### PR TITLE
feat(codegen): wire perry/plugin codegen dispatch (closes #189)

### DIFF
--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -2642,6 +2642,19 @@ pub(crate) fn lower_native_method_call(
         }
     }
 
+    // perry/plugin dispatch: loadPlugin, listPlugins, emitHook, etc.
+    if module == "perry/plugin" && object.is_none() {
+        if let Some(sig) = perry_plugin_table_lookup(method) {
+            return lower_perry_ui_table_call(ctx, sig, args);
+        }
+        bail!(
+            "perry/plugin: '{}' is not a known function (args: {}). \
+             Check types/perry/plugin/index.d.ts for the supported API surface.",
+            method,
+            args.len()
+        );
+    }
+
     if module == "perry/ui"
         && object.is_none()
         && method != "App"
@@ -2949,7 +2962,7 @@ pub(crate) fn lower_native_method_call(
                 }
             }
             let return_type = match sig.ret {
-                UiReturnKind::Widget => I64,
+                UiReturnKind::Widget | UiReturnKind::I64AsF64 => I64,
                 UiReturnKind::F64 => DOUBLE,
                 UiReturnKind::Void => crate::types::VOID,
                 UiReturnKind::Str => I64,
@@ -2974,6 +2987,10 @@ pub(crate) fn lower_native_method_call(
                     let raw = blk.call(I64, sig.runtime, &ref_args);
                     Ok(crate::expr::nanbox_string_inline(blk, &raw))
                 }
+                UiReturnKind::I64AsF64 => {
+                    let raw = blk.call(I64, sig.runtime, &ref_args);
+                    Ok(blk.sitofp(I64, &raw, DOUBLE))
+                }
             };
         }
         // Unknown instance method — fail the compile. Previously this
@@ -2988,6 +3005,82 @@ pub(crate) fn lower_native_method_call(
              See types/perry/ui/index.d.ts — widget styling uses free functions \
              like `textSetFontSize(label, 24)` and `widgetSetBackgroundColor(btn, r, g, b, a)`, \
              not instance-method setters.",
+            method,
+            args.len()
+        );
+    }
+
+    // perry/plugin PluginApi instance methods: `api.registerHook(...)`, `api.emit(...)`, etc.
+    // The HIR produces these with `object: Some(handle)` and `module: "perry/plugin"`.
+    if module == "perry/plugin" {
+        let recv_val = lower_expr(ctx, recv)?;
+        let blk = ctx.block();
+        let handle = unbox_to_i64(blk, &recv_val);
+        if let Some(sig) = perry_plugin_instance_method_lookup(method) {
+            let mut llvm_args: Vec<(crate::types::LlvmType, String)> = Vec::with_capacity(1 + args.len());
+            let mut runtime_param_types: Vec<crate::types::LlvmType> = Vec::with_capacity(1 + args.len());
+            llvm_args.push((I64, handle));
+            runtime_param_types.push(I64);
+            for (kind, arg) in sig.args.iter().zip(args.iter()) {
+                match kind {
+                    UiArgKind::Widget => {
+                        let v = lower_expr(ctx, arg)?;
+                        let blk = ctx.block();
+                        let h = unbox_to_i64(blk, &v);
+                        llvm_args.push((I64, h));
+                        runtime_param_types.push(I64);
+                    }
+                    UiArgKind::Str => {
+                        let h = get_raw_string_ptr(ctx, arg)?;
+                        llvm_args.push((I64, h));
+                        runtime_param_types.push(I64);
+                    }
+                    UiArgKind::F64 | UiArgKind::Closure => {
+                        let v = lower_expr(ctx, arg)?;
+                        llvm_args.push((DOUBLE, v));
+                        runtime_param_types.push(DOUBLE);
+                    }
+                    UiArgKind::I64Raw => {
+                        let v = lower_expr(ctx, arg)?;
+                        let blk = ctx.block();
+                        let i = blk.fptosi(DOUBLE, &v, I64);
+                        llvm_args.push((I64, i));
+                        runtime_param_types.push(I64);
+                    }
+                }
+            }
+            let return_type = match sig.ret {
+                UiReturnKind::Widget | UiReturnKind::I64AsF64 | UiReturnKind::Str => I64,
+                UiReturnKind::F64 => DOUBLE,
+                UiReturnKind::Void => crate::types::VOID,
+            };
+            ctx.pending_declares.push((sig.runtime.to_string(), return_type, runtime_param_types));
+            let ref_args: Vec<(crate::types::LlvmType, &str)> =
+                llvm_args.iter().map(|(t, s)| (*t, s.as_str())).collect();
+            let blk = ctx.block();
+            return match sig.ret {
+                UiReturnKind::Void => {
+                    blk.call_void(sig.runtime, &ref_args);
+                    Ok(double_literal(0.0))
+                }
+                UiReturnKind::Widget => {
+                    let raw = blk.call(I64, sig.runtime, &ref_args);
+                    Ok(crate::expr::nanbox_pointer_inline(blk, &raw))
+                }
+                UiReturnKind::F64 => Ok(blk.call(DOUBLE, sig.runtime, &ref_args)),
+                UiReturnKind::I64AsF64 => {
+                    let raw = blk.call(I64, sig.runtime, &ref_args);
+                    Ok(blk.sitofp(I64, &raw, DOUBLE))
+                }
+                UiReturnKind::Str => {
+                    let raw = blk.call(I64, sig.runtime, &ref_args);
+                    Ok(crate::expr::nanbox_string_inline(blk, &raw))
+                }
+            };
+        }
+        bail!(
+            "perry/plugin: '.{}(...)' is not a known PluginApi method (args: {}). \
+             See types/perry/plugin/index.d.ts for the supported API surface.",
             method,
             args.len()
         );
@@ -4710,6 +4803,9 @@ enum UiReturnKind {
     /// returned value reads back as a real string in `console.log`,
     /// template interpolation, and `typeof === "string"` checks.
     Str,
+    /// i64 result converted to plain JS number via `sitofp`. Used for integer
+    /// counts/IDs that the TS caller should see as a JS number (not a handle).
+    I64AsF64,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -5339,6 +5435,99 @@ fn perry_i18n_table_lookup(method: &str) -> Option<&'static UiSig> {
     PERRY_I18N_TABLE.iter().find(|s| s.method == method)
 }
 
+// =============================================================================
+// perry/plugin dispatch table
+// =============================================================================
+
+/// Receiver-less (host-side) functions exported from perry/plugin.
+/// These map `import { loadPlugin, listPlugins, … } from "perry/plugin"` to
+/// their `perry_plugin_*` runtime symbols. Arg shapes match plugin.rs exactly:
+/// strings are passed as NaN-boxed f64 (`UiArgKind::F64`) because the runtime
+/// calls `extract_string(nanboxed: f64)` internally — not raw pointer.
+static PERRY_PLUGIN_TABLE: &[UiSig] = &[
+    // loadPlugin(path) -> PluginId (NaN-boxed i64 handle, 0 on failure)
+    UiSig { method: "loadPlugin", runtime: "perry_plugin_load",
+            args: &[UiArgKind::F64], ret: UiReturnKind::Widget },
+    // unloadPlugin(id) -> void
+    UiSig { method: "unloadPlugin", runtime: "perry_plugin_unload",
+            args: &[UiArgKind::Widget], ret: UiReturnKind::Void },
+    // emitHook(hookName, context) -> context (possibly transformed by handlers)
+    UiSig { method: "emitHook", runtime: "perry_plugin_emit_hook",
+            args: &[UiArgKind::F64, UiArgKind::F64], ret: UiReturnKind::F64 },
+    // emitEvent(event, data) -> undefined
+    UiSig { method: "emitEvent", runtime: "perry_plugin_emit_event",
+            args: &[UiArgKind::F64, UiArgKind::F64], ret: UiReturnKind::F64 },
+    // invokeTool(name, args) -> handler return value
+    UiSig { method: "invokeTool", runtime: "perry_plugin_invoke_tool",
+            args: &[UiArgKind::F64, UiArgKind::F64], ret: UiReturnKind::F64 },
+    // setPluginConfig(key, value) -> undefined
+    UiSig { method: "setPluginConfig", runtime: "perry_plugin_set_config",
+            args: &[UiArgKind::F64, UiArgKind::F64], ret: UiReturnKind::F64 },
+    // discoverPlugins(dir) -> string[] of plugin paths
+    UiSig { method: "discoverPlugins", runtime: "perry_plugin_discover",
+            args: &[UiArgKind::F64], ret: UiReturnKind::F64 },
+    // listPlugins() -> { id, name, version, description }[]
+    UiSig { method: "listPlugins", runtime: "perry_plugin_list_plugins",
+            args: &[], ret: UiReturnKind::F64 },
+    // listHooks() -> string[]
+    UiSig { method: "listHooks", runtime: "perry_plugin_list_hooks",
+            args: &[], ret: UiReturnKind::F64 },
+    // listTools() -> { name, description, pluginId }[]
+    UiSig { method: "listTools", runtime: "perry_plugin_list_tools",
+            args: &[], ret: UiReturnKind::F64 },
+    // pluginCount() -> number
+    UiSig { method: "pluginCount", runtime: "perry_plugin_count",
+            args: &[], ret: UiReturnKind::I64AsF64 },
+    // initPlugins() -> void  (call once from main before loading plugins)
+    UiSig { method: "initPlugins", runtime: "perry_plugin_init",
+            args: &[], ret: UiReturnKind::Void },
+];
+
+/// Instance methods on a PluginApi handle returned by `loadPlugin`.
+/// The handle (NaN-boxed i64) is the receiver and is prepended as the
+/// first `i64` arg (`api_handle`) in every runtime call.
+static PERRY_PLUGIN_INSTANCE_TABLE: &[UiSig] = &[
+    // api.registerHook(hookName, handler) -> undefined
+    UiSig { method: "registerHook", runtime: "perry_plugin_register_hook",
+            args: &[UiArgKind::F64, UiArgKind::Closure], ret: UiReturnKind::F64 },
+    // api.registerHookEx(hookName, handler, priority, mode) -> undefined
+    UiSig { method: "registerHookEx", runtime: "perry_plugin_register_hook_ex",
+            args: &[UiArgKind::F64, UiArgKind::Closure, UiArgKind::I64Raw, UiArgKind::I64Raw],
+            ret: UiReturnKind::F64 },
+    // api.registerTool(name, description, handler) -> undefined
+    UiSig { method: "registerTool", runtime: "perry_plugin_register_tool",
+            args: &[UiArgKind::F64, UiArgKind::F64, UiArgKind::Closure], ret: UiReturnKind::F64 },
+    // api.registerService(name, startFn, stopFn) -> undefined
+    UiSig { method: "registerService", runtime: "perry_plugin_register_service",
+            args: &[UiArgKind::F64, UiArgKind::Closure, UiArgKind::Closure], ret: UiReturnKind::F64 },
+    // api.registerRoute(path, handler) -> undefined
+    UiSig { method: "registerRoute", runtime: "perry_plugin_register_route",
+            args: &[UiArgKind::F64, UiArgKind::Closure], ret: UiReturnKind::F64 },
+    // api.getConfig(key) -> any
+    UiSig { method: "getConfig", runtime: "perry_plugin_get_config",
+            args: &[UiArgKind::F64], ret: UiReturnKind::F64 },
+    // api.log(level, message) -> undefined   (level: 0=DEBUG,1=INFO,2=WARN,3=ERROR)
+    UiSig { method: "log", runtime: "perry_plugin_log",
+            args: &[UiArgKind::I64Raw, UiArgKind::F64], ret: UiReturnKind::F64 },
+    // api.setMetadata(name, version, description) -> undefined
+    UiSig { method: "setMetadata", runtime: "perry_plugin_set_metadata",
+            args: &[UiArgKind::F64, UiArgKind::F64, UiArgKind::F64], ret: UiReturnKind::F64 },
+    // api.on(event, handler) -> undefined
+    UiSig { method: "on", runtime: "perry_plugin_on",
+            args: &[UiArgKind::F64, UiArgKind::Closure], ret: UiReturnKind::F64 },
+    // api.emit(event, data) -> undefined
+    UiSig { method: "emit", runtime: "perry_plugin_emit",
+            args: &[UiArgKind::F64, UiArgKind::F64], ret: UiReturnKind::F64 },
+];
+
+fn perry_plugin_table_lookup(method: &str) -> Option<&'static UiSig> {
+    PERRY_PLUGIN_TABLE.iter().find(|s| s.method == method)
+}
+
+fn perry_plugin_instance_method_lookup(method: &str) -> Option<&'static UiSig> {
+    PERRY_PLUGIN_INSTANCE_TABLE.iter().find(|s| s.method == method)
+}
+
 /// Lower a perry/ui call described by `sig`. Walks each arg, applies
 /// the per-kind coercion to produce an LLVM SSA value of the right type,
 /// lazy-declares the runtime function, emits the call, and boxes the
@@ -5435,7 +5624,7 @@ fn lower_perry_ui_table_call(
     // libperry_ui_*.a symbol. Same pending_declares mechanism the
     // cross-module call site uses for `perry_fn_*`.
     let return_type = match sig.ret {
-        UiReturnKind::Widget => I64,
+        UiReturnKind::Widget | UiReturnKind::I64AsF64 => I64,
         UiReturnKind::F64 => DOUBLE,
         UiReturnKind::Void => crate::types::VOID,
         UiReturnKind::Str => I64,
@@ -5477,6 +5666,11 @@ fn lower_perry_ui_table_call(
             let blk = ctx.block();
             let raw = blk.call(I64, sig.runtime, &arg_slices);
             Ok(crate::expr::nanbox_string_inline(blk, &raw))
+        }
+        UiReturnKind::I64AsF64 => {
+            let blk = ctx.block();
+            let raw = blk.call(I64, sig.runtime, &arg_slices);
+            Ok(blk.sitofp(I64, &raw, DOUBLE))
         }
     }
 }

--- a/types/perry/plugin/index.d.ts
+++ b/types/perry/plugin/index.d.ts
@@ -1,0 +1,181 @@
+// Type declarations for perry/plugin — Perry's native plugin system.
+// Plugins are compiled to shared libraries (.dylib / .so) loaded at runtime
+// via dlopen. One GC, one arena, one runtime — plugin symbols bind to the
+// host executable's copies at load time.
+
+// ---------------------------------------------------------------------------
+// PluginId — opaque handle returned by loadPlugin
+// ---------------------------------------------------------------------------
+
+/** Opaque handle to a loaded plugin. Pass to unloadPlugin or use as a PluginApi. */
+export type PluginId = number & { readonly __pluginId: unique symbol };
+
+// ---------------------------------------------------------------------------
+// PluginApi — instance methods available on a loaded plugin handle
+// ---------------------------------------------------------------------------
+
+/**
+ * API handle passed to a plugin's `plugin_activate` function and returned
+ * by `loadPlugin`. Call instance methods on this handle to register hooks,
+ * tools, services, and routes on behalf of the plugin.
+ */
+export interface PluginApi {
+    /**
+     * Register a hook handler (priority=10, mode=filter by default).
+     * @param hookName  Name of the hook to listen for.
+     * @param handler   Closure receiving the hook context; its return value
+     *                  becomes the new context (filter mode).
+     */
+    registerHook(hookName: string, handler: (ctx: unknown) => unknown): void;
+
+    /**
+     * Register a hook handler with explicit priority and execution mode.
+     * @param hookName  Name of the hook.
+     * @param handler   Hook handler closure.
+     * @param priority  Lower numbers run first (default 10).
+     * @param mode      0=filter (chain), 1=action (fire-and-forget), 2=waterfall (first result wins).
+     */
+    registerHookEx(hookName: string, handler: (ctx: unknown) => unknown, priority: number, mode: number): void;
+
+    /**
+     * Register a named tool with a description and handler.
+     * @param name        Tool name (must be unique across all plugins).
+     * @param description Human-readable description of the tool.
+     * @param handler     Closure called when the tool is invoked via `invokeTool`.
+     */
+    registerTool(name: string, description: string, handler: (args: unknown) => unknown): void;
+
+    /**
+     * Register a service with start and stop lifecycle functions.
+     * @param name     Service name.
+     * @param startFn  Called when the service is started.
+     * @param stopFn   Called when the service is stopped.
+     */
+    registerService(name: string, startFn: () => void, stopFn: () => void): void;
+
+    /**
+     * Register an HTTP route handler (requires an HTTP plugin integration).
+     * @param path     Route path (e.g. "/api/foo").
+     * @param handler  Request handler closure.
+     */
+    registerRoute(path: string, handler: (req: unknown) => unknown): void;
+
+    /**
+     * Get a host-provided config value by key.
+     * @param key  Config key set via `setPluginConfig`.
+     * @returns    The stored value, or `undefined` if not set.
+     */
+    getConfig(key: string): unknown;
+
+    /**
+     * Log a message at the given level.
+     * @param level    0=DEBUG, 1=INFO, 2=WARN, 3=ERROR.
+     * @param message  Message to log (written to stderr with plugin prefix).
+     */
+    log(level: number, message: string): void;
+
+    /**
+     * Set plugin metadata (name, version, description).
+     * Must be called during `plugin_activate`; has no effect after load.
+     */
+    setMetadata(name: string, version: string, description: string): void;
+
+    /**
+     * Subscribe to an event on the host event bus.
+     * @param event    Event name.
+     * @param handler  Closure called when the event is emitted.
+     */
+    on(event: string, handler: (data: unknown) => void): void;
+
+    /**
+     * Emit an event on the host event bus, dispatching to all subscribers.
+     * @param event  Event name.
+     * @param data   Payload forwarded to every subscriber.
+     */
+    emit(event: string, data: unknown): void;
+}
+
+// ---------------------------------------------------------------------------
+// Host-side API (static, receiver-less)
+// ---------------------------------------------------------------------------
+
+/**
+ * Load a plugin from a shared library path (.dylib / .so).
+ * Calls the plugin's `plugin_activate(api_handle)` entry point.
+ * @param path  Absolute or relative path to the shared library.
+ * @returns     A PluginId handle (> 0) on success, or 0 on failure.
+ */
+export function loadPlugin(path: string): PluginId;
+
+/**
+ * Unload a previously loaded plugin by its ID.
+ * Calls `plugin_deactivate()` if the symbol is present, then dlcloses the library.
+ * All hooks, tools, services, and routes registered by the plugin are removed.
+ */
+export function unloadPlugin(id: PluginId): void;
+
+/**
+ * Emit a hook, calling all registered handlers in priority order.
+ * The hook mode (filter/action/waterfall) is determined per handler at registration.
+ * @param hookName  Name of the hook.
+ * @param context   Initial context value threaded through handlers (filter mode).
+ * @returns         The final context value after all handlers have run.
+ */
+export function emitHook(hookName: string, context: unknown): unknown;
+
+/**
+ * Emit an event on the host event bus, dispatching to all subscribers.
+ * @param event  Event name.
+ * @param data   Payload forwarded to every subscriber.
+ */
+export function emitEvent(event: string, data: unknown): void;
+
+/**
+ * Invoke a registered tool by name.
+ * @param name  Tool name as registered via `registerTool`.
+ * @param args  Arguments forwarded to the tool handler.
+ * @returns     The tool handler's return value, or `undefined` if not found.
+ */
+export function invokeTool(name: string, args: unknown): unknown;
+
+/**
+ * Set a host-provided config value (readable by plugins via `api.getConfig`).
+ * Can be called before or after loading plugins.
+ */
+export function setPluginConfig(key: string, value: unknown): void;
+
+/**
+ * Scan a directory for plugin files (.dylib / .so / .dll).
+ * @param dir  Directory path to scan.
+ * @returns    Array of absolute file paths to discovered plugin libraries.
+ */
+export function discoverPlugins(dir: string): string[];
+
+/**
+ * List all currently loaded plugins.
+ * @returns Array of `{ id, name, version, description }` objects.
+ */
+export function listPlugins(): Array<{ id: number; name: string; version: string; description: string }>;
+
+/**
+ * List all registered hook names.
+ * @returns Array of hook name strings.
+ */
+export function listHooks(): string[];
+
+/**
+ * List all registered tools.
+ * @returns Array of `{ name, description, pluginId }` objects.
+ */
+export function listTools(): Array<{ name: string; description: string; pluginId: number }>;
+
+/**
+ * Returns the number of currently loaded plugins.
+ */
+export function pluginCount(): number;
+
+/**
+ * Initialize the plugin registry (call once before loading any plugins).
+ * Safe to call multiple times; subsequent calls are no-ops.
+ */
+export function initPlugins(): void;

--- a/types/perry/plugin/package.json
+++ b/types/perry/plugin/package.json
@@ -1,0 +1,3 @@
+{
+  "types": "./index.d.ts"
+}


### PR DESCRIPTION
## Summary

- **12 static-function rows** added to `PERRY_PLUGIN_TABLE` (receiver-less host-side API: `loadPlugin`, `unloadPlugin`, `emitHook`, `emitEvent`, `invokeTool`, `setPluginConfig`, `discoverPlugins`, `listPlugins`, `listHooks`, `listTools`, `pluginCount`, `initPlugins`)
- **10 instance-method rows** added to `PERRY_PLUGIN_INSTANCE_TABLE` (`registerHook`, `registerHookEx`, `registerTool`, `registerService`, `registerRoute`, `getConfig`, `log`, `setMetadata`, `on`, `emit`)
- New `UiReturnKind::I64AsF64` variant added so `pluginCount() -> i64` is returned as a plain JS number (via `sitofp`) rather than a NaN-boxed pointer
- New `types/perry/plugin/index.d.ts` with full TS declarations: `PluginId` opaque type, `PluginApi` interface, all 12 module-level functions
- New `types/perry/plugin/package.json`

All 21 `perry_plugin_*` runtime symbols are now reachable from TypeScript. All three `return_type` match arms on `UiReturnKind` updated for exhaustiveness.

## Smoke test output

```
pluginCount: 0
[plugin] dlopen failed for /nonexistent/plugin.so: cannot open shared object file: No such file or directory
loadPlugin result: null
listPlugins: 0 plugins
listHooks: 0 hooks
listTools: 0 tools
emitHook: hello
[plugin] Tool not found: nonexistent-tool
invokeTool: undefined
discoverPlugins: true
smoke test OK
```

The `[plugin] dlopen failed` and `[plugin] Tool not found` stderr lines confirm the runtime was actually called — calls are no longer silently elided by the receiver-less stub at `lower_call.rs:2849-2854`.

Instance-method variant from the issue also compiles and links cleanly:
```ts
const api = loadPlugin("my-plugin");
if (api) {
  api.registerHook("on-event", (data) => { console.log("hook", data); });
  api.emit("on-event", { x: 1 });
}
console.log(listPlugins());
```

## Test plan

- [x] `cargo check -p perry-codegen` — no errors
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` — clean build
- [x] Static smoke test (all 12 module-level functions) compiles + runs cleanly
- [x] Instance-method smoke test compiles + runs cleanly
- [x] `cargo test --workspace` (all compilable crates on Linux) — 390 passed, 0 failed

https://claude.ai/code/session_0155Y2UUFqcjA1hLvC4PbapH

---
_Generated by [Claude Code](https://claude.ai/code/session_0155Y2UUFqcjA1hLvC4PbapH)_