### PR TITLE
feat(codegen): wire perry/i18n format wrappers (closes #188)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ private-*
 
 # mdBook output
 docs/book/
+.cargo/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "atty",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "log",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "base64",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4238,7 +4238,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "serde",
  "serde_json",
@@ -4246,7 +4246,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.293"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "clap",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4304,7 +4304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "base64",
@@ -4325,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4399,7 +4399,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -4407,11 +4407,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.295"
+version = "0.5.296"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "itoa",
  "jni",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "rand 0.8.5",
  "serde",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "cairo-rs",
  "gtk4",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "block2",
  "libc",
@@ -4462,7 +4462,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "block2",
  "libc",
@@ -4480,11 +4480,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.293"
+version = "0.5.296"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "block2",
  "libc",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.293"
+version = "0.5.296"
 dependencies = [
  "block2",
  "libc",
@@ -4514,7 +4514,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "block2",
  "libc",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.295"
+version = "0.5.296"
 dependencies = [
  "libc",
  "perry-runtime",

--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -2407,6 +2407,12 @@ pub(crate) fn lower_native_method_call(
         }
     }
 
+    if module == "perry/i18n" && object.is_none() {
+        if let Some(sig) = perry_i18n_table_lookup(method) {
+            return lower_perry_ui_table_call(ctx, sig, args);
+        }
+    }
+
     // `perry/ui.App({ title, width, height, body, icon? })` — minimum-viable
     // dispatch so a perry/ui app actually launches an NSApplication and
     // shows a window. Pre-v0.5.10 this fell into the receiver-less early-
@@ -2904,6 +2910,7 @@ pub(crate) fn lower_native_method_call(
                 UiReturnKind::Widget => I64,
                 UiReturnKind::F64 => DOUBLE,
                 UiReturnKind::Void => crate::types::VOID,
+                UiReturnKind::Str => I64,
             };
             ctx.pending_declares.push((sig.runtime.to_string(), return_type, runtime_param_types));
             let ref_args: Vec<(crate::types::LlvmType, &str)> =
@@ -2920,6 +2927,10 @@ pub(crate) fn lower_native_method_call(
                 }
                 UiReturnKind::F64 => {
                     Ok(blk.call(DOUBLE, sig.runtime, &ref_args))
+                }
+                UiReturnKind::Str => {
+                    let raw = blk.call(I64, sig.runtime, &ref_args);
+                    Ok(nanbox_string_inline(blk, &raw))
                 }
             };
         }
@@ -4124,6 +4135,8 @@ enum UiReturnKind {
     F64,
     /// Void return: emit `call void` and return the `0.0` sentinel f64.
     Void,
+    /// String pointer (*mut StringHeader): NaN-box the i64 result with STRING_TAG.
+    Str,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -4651,6 +4664,27 @@ fn perry_system_table_lookup(method: &str) -> Option<&'static UiSig> {
     PERRY_SYSTEM_TABLE.iter().find(|s| s.method == method)
 }
 
+// =============================================================================
+// perry/i18n dispatch table
+// =============================================================================
+
+/// Maps the 7 perry/i18n format-wrapper names to their single-arg shim symbols
+/// in perry-runtime/src/i18n.rs. All take one F64 (NaN-boxed value) and
+/// return a *mut StringHeader (NaN-boxed as Str).
+static PERRY_I18N_TABLE: &[UiSig] = &[
+    UiSig { method: "Currency",     runtime: "perry_i18n_currency",          args: &[UiArgKind::F64], ret: UiReturnKind::Str },
+    UiSig { method: "Percent",      runtime: "perry_i18n_percent",           args: &[UiArgKind::F64], ret: UiReturnKind::Str },
+    UiSig { method: "FormatNumber", runtime: "perry_i18n_number",            args: &[UiArgKind::F64], ret: UiReturnKind::Str },
+    UiSig { method: "ShortDate",    runtime: "perry_i18n_format_date_short", args: &[UiArgKind::F64], ret: UiReturnKind::Str },
+    UiSig { method: "LongDate",     runtime: "perry_i18n_format_date_long",  args: &[UiArgKind::F64], ret: UiReturnKind::Str },
+    UiSig { method: "FormatTime",   runtime: "perry_i18n_time",              args: &[UiArgKind::F64], ret: UiReturnKind::Str },
+    UiSig { method: "Raw",          runtime: "perry_i18n_format_raw",        args: &[UiArgKind::F64], ret: UiReturnKind::Str },
+];
+
+fn perry_i18n_table_lookup(method: &str) -> Option<&'static UiSig> {
+    PERRY_I18N_TABLE.iter().find(|s| s.method == method)
+}
+
 /// Lower a perry/ui call described by `sig`. Walks each arg, applies
 /// the per-kind coercion to produce an LLVM SSA value of the right type,
 /// lazy-declares the runtime function, emits the call, and boxes the
@@ -4731,6 +4765,7 @@ fn lower_perry_ui_table_call(
         UiReturnKind::Widget => I64,
         UiReturnKind::F64 => DOUBLE,
         UiReturnKind::Void => crate::types::VOID,
+        UiReturnKind::Str => I64,
     };
     ctx.pending_declares.push((
         sig.runtime.to_string(),
@@ -4754,6 +4789,11 @@ fn lower_perry_ui_table_call(
         UiReturnKind::Void => {
             ctx.block().call_void(sig.runtime, &arg_slices);
             Ok(double_literal(0.0))
+        }
+        UiReturnKind::Str => {
+            let blk = ctx.block();
+            let raw = blk.call(I64, sig.runtime, &arg_slices);
+            Ok(nanbox_string_inline(blk, &raw))
         }
     }
 }

--- a/crates/perry-runtime/src/i18n.rs
+++ b/crates/perry-runtime/src/i18n.rs
@@ -840,3 +840,42 @@ pub extern "C" fn perry_i18n_format_time(timestamp: f64, locale_idx: i32) -> *mu
     let bytes = result.as_bytes();
     crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
 }
+
+// Single-arg shims for the UiSig dispatch table in perry-codegen.
+// The table uses `args: &[UiArgKind::F64]` (one TS-side arg); locale comes
+// from the global LOCALE_INDEX set by perry_i18n_init().
+
+#[no_mangle]
+pub extern "C" fn perry_i18n_currency(value: f64) -> *mut crate::StringHeader {
+    perry_i18n_format_currency(value, LOCALE_INDEX.load(Ordering::Relaxed))
+}
+
+#[no_mangle]
+pub extern "C" fn perry_i18n_percent(value: f64) -> *mut crate::StringHeader {
+    perry_i18n_format_percent(value, LOCALE_INDEX.load(Ordering::Relaxed))
+}
+
+#[no_mangle]
+pub extern "C" fn perry_i18n_number(value: f64) -> *mut crate::StringHeader {
+    perry_i18n_format_number(value, LOCALE_INDEX.load(Ordering::Relaxed))
+}
+
+#[no_mangle]
+pub extern "C" fn perry_i18n_format_date_short(timestamp: f64) -> *mut crate::StringHeader {
+    perry_i18n_format_date(timestamp, 1, LOCALE_INDEX.load(Ordering::Relaxed))
+}
+
+#[no_mangle]
+pub extern "C" fn perry_i18n_format_date_long(timestamp: f64) -> *mut crate::StringHeader {
+    perry_i18n_format_date(timestamp, 2, LOCALE_INDEX.load(Ordering::Relaxed))
+}
+
+#[no_mangle]
+pub extern "C" fn perry_i18n_time(value: f64) -> *mut crate::StringHeader {
+    perry_i18n_format_time(value, LOCALE_INDEX.load(Ordering::Relaxed))
+}
+
+#[no_mangle]
+pub extern "C" fn perry_i18n_format_raw(value: f64) -> *mut crate::StringHeader {
+    crate::js_jsvalue_to_string(value)
+}


### PR DESCRIPTION
## Summary

- **7 new `UiSig` rows** in `crates/perry-codegen/src/lower_call.rs` (`PERRY_I18N_TABLE`) that dispatch `Currency`, `Percent`, `FormatNumber`, `ShortDate`, `LongDate`, `FormatTime`, and `Raw` to their runtime shims. Dispatch fires for `module == "perry/i18n" && object.is_none()`, inserted right after the existing `t()` special-case.
- **`UiReturnKind::Str` variant** added to the shared `UiSig` machinery so it emits `call i64` + `nanbox_string_inline` (STRING_TAG). Both the table-call path and the instance-method path handle it.
- **7 single-arg runtime shims** in `crates/perry-runtime/src/i18n.rs`. Each takes `value: f64` and reads `LOCALE_INDEX` (set at startup by `perry_i18n_init`) so callers don't have to pass a locale index:
  - `perry_i18n_currency` / `perry_i18n_percent` / `perry_i18n_number` / `perry_i18n_time` → call existing two-arg implementations with `LOCALE_INDEX`
  - `perry_i18n_format_date_short` / `perry_i18n_format_date_long` → call `perry_i18n_format_date` with `style=1`/`style=2` and `LOCALE_INDEX` (avoids a style-flag TS API; two thin shims is fewer LOC than wiring the flag through the UiSig arg list)
  - `perry_i18n_format_raw` → delegates to `crate::js_jsvalue_to_string` (handles any NaN-boxed JSValue)

## Smoke-test output (en locale, `Date.now()` ≈ 2026-04-26T07:31)

```
$99.99
50%
1,234,567.89
4/26/2026
April 26, 2026
7:31 AM
42.5
```

All 7 previously returned `undefined`; all 7 now return locale-formatted strings.

## Test plan

- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` — clean build
- [x] Smoke-test binary runs each wrapper, non-`undefined` output for all 7
- [x] `cargo test -p perry -p perry-runtime -p perry-stdlib -p perry-codegen -p perry-hir -p perry-transform -p perry-parser -p perry-types` — 355 tests, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjMwN55a9MhoDy9JFPov4q)_