### PR TITLE
feat(ui-gtk4): wire 4 styling FFIs (closes #202)

### DIFF
--- a/crates/perry-ui-gtk4/src/lib.rs
+++ b/crates/perry-ui-gtk4/src/lib.rs
@@ -488,6 +488,18 @@ pub extern "C" fn perry_ui_button_set_text_color(handle: i64, r: f64, g: f64, b:
     widgets::button::set_text_color(handle, r, g, b, a);
 }
 
+/// Set the tint color of a button's image/icon.
+#[no_mangle]
+pub extern "C" fn perry_ui_button_set_content_tint_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    widgets::button::set_content_tint_color(handle, r, g, b, a);
+}
+
+/// Set the position of the image relative to the label on a button.
+#[no_mangle]
+pub extern "C" fn perry_ui_button_set_image_position(handle: i64, position: i64) {
+    widgets::button::set_image_position(handle, position);
+}
+
 // =============================================================================
 // TextField Ops
 // =============================================================================
@@ -768,6 +780,12 @@ pub extern "C" fn perry_ui_widget_set_on_hover(handle: i64, callback: f64) {
     widgets::set_on_hover(handle, callback);
 }
 
+/// Set a single-click callback.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_on_click(handle: i64, callback: f64) {
+    widgets::set_on_click(handle, callback);
+}
+
 /// Set a double-click callback.
 #[no_mangle]
 pub extern "C" fn perry_ui_widget_set_on_double_click(handle: i64, callback: f64) {
@@ -874,6 +892,12 @@ pub extern "C" fn perry_ui_stack_set_distribution(handle: i64, distribution: f64
 #[no_mangle]
 pub extern "C" fn perry_ui_stack_set_alignment(handle: i64, alignment: f64) {
     widgets::set_alignment(handle, alignment as i64);
+}
+
+/// GTK4 already excludes non-visible children from layout — this is a no-op stub.
+#[no_mangle]
+pub extern "C" fn perry_ui_stack_set_detaches_hidden(handle: i64, flag: i64) {
+    widgets::set_detaches_hidden(handle, flag != 0);
 }
 
 /// Set the application icon.

--- a/crates/perry-ui-gtk4/src/widgets/button.rs
+++ b/crates/perry-ui-gtk4/src/widgets/button.rs
@@ -88,6 +88,32 @@ pub fn set_title(handle: i64, title_ptr: *const u8) {
     }
 }
 
+/// Set the tint color of a button's image/icon via CSS (mirrors set_corner_radius pattern).
+pub fn set_content_tint_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    if let Some(widget) = super::get_widget(handle) {
+        let rgba = format!(
+            "rgba({},{},{},{})",
+            (r * 255.0) as u8,
+            (g * 255.0) as u8,
+            (b * 255.0) as u8,
+            a
+        );
+        let class_name = format!("perry-ctc-{}", handle);
+        widget.add_css_class(&class_name);
+        let css = format!("button.{} image {{ color: {}; }}", class_name, rgba);
+        let provider = gtk4::CssProvider::new();
+        provider.load_from_data(&css);
+        gtk4::style_context_add_provider_for_display(
+            &widget.display(),
+            &provider,
+            gtk4::STYLE_PROVIDER_PRIORITY_USER,
+        );
+    }
+}
+
+/// Reorder image relative to label. GTK4 no-op — button image not yet implemented on this backend.
+pub fn set_image_position(_handle: i64, _position: i64) {}
+
 /// Set the text color of a button's label via CSS.
 pub fn set_text_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
     if let Some(widget) = super::get_widget(handle) {

--- a/crates/perry-ui-gtk4/src/widgets/mod.rs
+++ b/crates/perry-ui-gtk4/src/widgets/mod.rs
@@ -320,6 +320,29 @@ pub fn set_on_double_click(handle: i64, callback: f64) {
     }
 }
 
+/// Set a single-click callback on a widget.
+pub fn set_on_click(handle: i64, callback: f64) {
+    extern "C" {
+        fn js_closure_call0(closure: *const u8) -> f64;
+        fn js_nanbox_get_pointer(value: f64) -> i64;
+    }
+    if let Some(widget) = get_widget(handle) {
+        let gesture = gtk4::GestureClick::new();
+        gesture.set_button(1);
+        let cb = callback;
+        gesture.connect_pressed(move |_gesture, n_press, _x, _y| {
+            if n_press == 1 {
+                let ptr = unsafe { js_nanbox_get_pointer(cb) } as *const u8;
+                unsafe { js_closure_call0(ptr); }
+            }
+        });
+        widget.add_controller(gesture);
+    }
+}
+
+/// GTK4 already excludes non-visible children from layout — this is a no-op stub.
+pub fn set_detaches_hidden(_handle: i64, _detaches: bool) {}
+
 /// Animate the opacity of a widget. `duration_secs` is in seconds.
 pub fn animate_opacity(handle: i64, target: f64, duration_secs: f64) {
     use gtk4::glib;

--- a/crates/perry-ui-test/src/lib.rs
+++ b/crates/perry-ui-test/src/lib.rs
@@ -142,8 +142,10 @@ pub const FEATURES: &[Feature] = &[
     Feature { name: "perry_ui_text_set_font_family", category: TextStyling, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: Some("perry_ui_set_font_family") },
 
     // ── Button Ops ───────────────────────────────────────────────────────
-    Feature { name: "perry_ui_button_set_bordered", category: ButtonOps, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: None },
-    Feature { name: "perry_ui_button_set_title",    category: ButtonOps, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: None },
+    Feature { name: "perry_ui_button_set_bordered",           category: ButtonOps, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: None },
+    Feature { name: "perry_ui_button_set_title",              category: ButtonOps, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: None },
+    Feature { name: "perry_ui_button_set_content_tint_color", category: ButtonOps, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: None },
+    Feature { name: "perry_ui_button_set_image_position",     category: ButtonOps, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: None },
 
     // ── TextField Ops ────────────────────────────────────────────────────
     Feature { name: "perry_ui_textfield_focus",      category: TextFieldOps, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: None },
@@ -200,14 +202,16 @@ pub const FEATURES: &[Feature] = &[
     // ── Events ───────────────────────────────────────────────────────────
     Feature { name: "perry_ui_widget_set_on_hover",        category: Events, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: Some("perry_ui_set_on_hover") },
     Feature { name: "perry_ui_widget_set_on_double_click", category: Events, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: Some("perry_ui_set_on_double_click") },
+    Feature { name: "perry_ui_widget_set_on_click",        category: Events, macos: S, ios: S, android: S, gtk4: S, windows: S, web: U, web_name: None },
 
     // ── Animation ────────────────────────────────────────────────────────
     Feature { name: "perry_ui_widget_animate_opacity",  category: Animation, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: Some("perry_ui_animate_opacity") },
     Feature { name: "perry_ui_widget_animate_position", category: Animation, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: Some("perry_ui_animate_position") },
 
     // ── Layout ───────────────────────────────────────────────────────────
-    Feature { name: "perry_ui_vstack_create_with_insets", category: Layout, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: None },
-    Feature { name: "perry_ui_hstack_create_with_insets", category: Layout, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: None },
+    Feature { name: "perry_ui_vstack_create_with_insets",   category: Layout, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: None },
+    Feature { name: "perry_ui_hstack_create_with_insets",   category: Layout, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: None },
+    Feature { name: "perry_ui_stack_set_detaches_hidden",   category: Layout, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: None },
 
     // ── ForEach ──────────────────────────────────────────────────────────
     Feature { name: "perry_ui_for_each_init", category: ForEach, macos: S, ios: S, android: S, gtk4: S, windows: S, web: S, web_name: Some("perry_ui_state_bind_foreach") },


### PR DESCRIPTION
## Summary

Wires the 4 GTK4 styling FFIs left open after #185 Phase B, bringing GTK4 to 43/43 tracked entries in the parity matrix (all Supported).

| FFI | GTK4 implementation |
|-----|---------------------|
| `perry_ui_widget_set_on_click` | `GestureClick::new()` + `connect_pressed(n_press == 1)` — mirrors the existing `set_on_double_click` pattern |
| `perry_ui_button_set_content_tint_color` | Per-handle `CssProvider` emitting `button.perry-ctc-N image { color: rgba(...); }` at `STYLE_PROVIDER_PRIORITY_USER` — mirrors `set_corner_radius` |
| `perry_ui_button_set_image_position` | No-op stub — `perry_ui_button_set_image` is not yet implemented on GTK4, so ordering is moot |
| `perry_ui_stack_set_detaches_hidden` | No-op stub — GTK4 already excludes non-visible children from layout automatically |

Also adds the 4 `Feature` entries to `perry-ui-test/src/lib.rs` (the cross-platform parity matrix) so the drift check tracks them going forward.

## Test plan

- [x] `cargo test -p perry-ui-test` — all 6 platform tests green (GTK4, macOS, iOS, Android, Windows, Web)
- [x] `cargo build --release -p perry-ui-gtk4` — compiles cleanly (pre-existing `js_string_from_bytes` signature warning unrelated to this PR)
- [x] 4 new `#[no_mangle] pub extern "C" fn` declarations present in `crates/perry-ui-gtk4/src/lib.rs`
- [x] Matrix drift check: `test_gtk4` scans `lib.rs` exports vs matrix and passes

https://claude.ai/code/session_01HQ6WC9qgjdPDrMoZ6mSREq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQ6WC9qgjdPDrMoZ6mSREq)_