### PR TITLE
fix(fs): wire fs.appendFileSync end-to-end (closes #226)

### DIFF
--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -7022,6 +7022,27 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(double_literal(0.0))
         }
 
+        Expr::FsAppendFileSync(path, content) => {
+            // Issue #226. JS and WASM backends already had arms for this
+            // HIR variant; the LLVM backend was missing the case here next
+            // to `FsWriteFileSync`. The runtime fn
+            // (`crates/perry-runtime/src/fs.rs::js_fs_append_file_sync`)
+            // is correct; the codegen + lowerer plumbing was the gap.
+            // The companion fix in `crates/perry-hir/src/lower/expr_call.rs`
+            // extends the namespace-import path (`fs.appendFileSync` via
+            // `import * as fs from "fs"`) — without that the variant
+            // never gets emitted for the common usage shape. Returns i32
+            // (1=success) which we discard; appendFileSync is void in JS.
+            let p = lower_expr(ctx, path)?;
+            let c = lower_expr(ctx, content)?;
+            let _ = ctx.block().call(
+                I32,
+                "js_fs_append_file_sync",
+                &[(DOUBLE, &p), (DOUBLE, &c)],
+            );
+            Ok(double_literal(0.0))
+        }
+
         // -------- NativeMethodCall (Phase H.1) --------
         // Perry's HIR uses NativeMethodCall { module, method, object, args }
         // for method calls on natively-typed receivers — specifically for

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -194,6 +194,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_map_from_array", I64, &[I64]);
     module.declare_function("js_object_has_property", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_fs_write_file_sync", I32, &[DOUBLE, DOUBLE]);
+    // fs.appendFileSync(path, content) — returns i32 status. Issue #226.
+    module.declare_function("js_fs_append_file_sync", I32, &[DOUBLE, DOUBLE]);
     module.declare_function("js_fs_exists_sync", I32, &[DOUBLE]);
     // fs.readFileSync(path, encoding) — returns a raw *mut StringHeader i64.
     module.declare_function("js_fs_read_file_sync", I64, &[DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_call.rs
+++ b/crates/perry-hir/src/lower/expr_call.rs
@@ -866,6 +866,14 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                                                 return Ok(Expr::FsWriteFileSync(Box::new(path), Box::new(content)));
                                             }
                                         }
+                                        "appendFileSync" => {
+                                            if args.len() >= 2 {
+                                                let mut iter = args.into_iter();
+                                                let path = iter.next().unwrap();
+                                                let content = iter.next().unwrap();
+                                                return Ok(Expr::FsAppendFileSync(Box::new(path), Box::new(content)));
+                                            }
+                                        }
                                         "existsSync" => {
                                             if args.len() >= 1 {
                                                 return Ok(Expr::FsExistsSync(Box::new(args.into_iter().next().unwrap())));

--- a/test-files/test_fs_appendfile.ts
+++ b/test-files/test_fs_appendfile.ts
@@ -1,0 +1,42 @@
+// Issue #226: regression for `fs.appendFileSync` codegen.
+//
+// Two paths needed wiring (only one was in the issue's diagnosis):
+//
+//   1. SWC→HIR lowerer in `crates/perry-hir/src/lower/expr_call.rs`. The
+//      named-import path (`import { appendFileSync } from "fs"`) already
+//      had an arm; the namespace-import + property-access path
+//      (`import * as fs from "fs"; fs.appendFileSync(...)`) did not, so
+//      the call slipped past as a generic `Call { callee: PropertyGet
+//      { object: NativeModuleRef("fs"), property: "appendFileSync" } }`
+//      and `Expr::FsAppendFileSync` never got emitted.
+//
+//   2. LLVM codegen in `crates/perry-codegen/src/expr.rs`. Even when
+//      the HIR variant was emitted, the backend lacked the arm next to
+//      `FsWriteFileSync`, so the call fell through and was silently
+//      dropped. JS and WASM backends had had the arm for a while.
+//
+// Net pre-fix behaviour: every `fs.appendFileSync` wrote 0 bytes, the
+// file wasn't even created on a fresh path. This test exercises the
+// common namespace-import shape and asserts the file accumulates.
+
+import * as fs from "fs";
+
+const path = "/tmp/perry_appendfile_test.txt";
+
+if (fs.existsSync(path)) {
+  fs.unlinkSync(path);
+}
+
+// First call — file doesn't exist yet, append-mode open creates it.
+fs.appendFileSync(path, "line one\n");
+console.log(fs.readFileSync(path, "utf-8"));
+
+// Second call — should grow the file rather than overwrite.
+fs.appendFileSync(path, "line two\n");
+console.log(fs.readFileSync(path, "utf-8"));
+
+// Third — accumulates.
+fs.appendFileSync(path, "line three\n");
+console.log(fs.readFileSync(path, "utf-8"));
+
+fs.unlinkSync(path);


### PR DESCRIPTION
Closes #226.

## What was broken

Pre-fix every `fs.appendFileSync(path, content)` wrote 0 bytes — the file wasn't even created on a fresh path. Confirmed against `node --experimental-strip-types` (Node correctly accumulates content, Perry produced an empty file).

## Why the issue's diagnosis was incomplete

The issue body pointed at `crates/perry-codegen/src/expr.rs` next to `FsWriteFileSync` — that arm was indeed missing. But adding it alone changes nothing for the common usage shape, because the **HIR `Expr::FsAppendFileSync` variant is never emitted** for namespace imports.

The SWC→HIR lowerer in `crates/perry-hir/src/lower/expr_call.rs` has two paths for `fs.X(...)` calls:

- A named-import path (line ~3884) for `import { appendFileSync } from "fs"` — already had the `appendFileSync` arm.
- A namespace-import path (line ~851) for `import * as fs from "fs"; fs.appendFileSync(...)` — had arms for `writeFileSync` / `existsSync` / `mkdirSync` / `unlinkSync` / `rmRecursive` / `readFileBuffer`, but not `appendFileSync`. Without this, `fs.appendFileSync(path, content)` slipped past as a generic `Call { callee: PropertyGet { object: NativeModuleRef("fs"), property: "appendFileSync" }, args: [...] }` and the typed variant never got emitted.

That namespace shape is what most user code actually writes (`import * as fs from "fs"`), so the bug surfaced as "every call writes 0 bytes" in practice. `writeFileSync` works because it's in both paths; `appendFileSync` was in only one.

The runtime function (`crates/perry-runtime/src/fs.rs::js_fs_append_file_sync`) was already correct — `OpenOptions::new().create(true).append(true).write_all(content)`.

## What changed

1. **HIR lowerer** — added `appendFileSync` arm to the namespace-import path next to `writeFileSync`.
2. **LLVM codegen** — added `Expr::FsAppendFileSync` arm next to `FsWriteFileSync`. Same shape: lower path + content, call `js_fs_append_file_sync`, discard the i32 status.
3. **runtime_decls** — declared `js_fs_append_file_sync` so the LLVM module can resolve the symbol at link.
4. **Regression test** at `test-files/test_fs_appendfile.ts` exercising the common `import * as fs from "fs"` shape with three sequential appends.

JS and WASM backends already had arms for the HIR variant since it was originally added, so they're unaffected.

## Verified

`cargo build --release -p perry` clean; `cargo test -p perry-hir -p perry-codegen --lib` green (20 tests, no regressions).

Byte-for-byte match against `node --experimental-strip-types` on the regression test:

```
perry:                  node:
line one                line one
                        <blank>
line one                line one
line two                line two
                        <blank>
line one                line one
line two                line two
line three              line three
```

## Test plan

- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows`
- [ ] Manual: compile `test-files/test_fs_appendfile.ts` with the maintainer's local `perry` and confirm output matches Node
- [ ] At merge: maintainer bumps version + adds CLAUDE.md entry per CONTRIBUTING.md