### PR TITLE
fix(fetch): #234 real Blob with arrayBuffer/text/bytes/slice instance methods

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -323,6 +323,7 @@ jobs:
             test_inline_uint8array_param \
             test_issue_167_loop_alloca_stack_eat \
             test_issue_227_array_buffer_bytes \
+            test_issue_234_blob_methods \
             test_gap_fetch_response "
 
           for f in test-files/*.ts; do

--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -3057,6 +3057,80 @@ pub(super) fn lower_fetch_native_method(
         }
     }
 
+    // ── Blob instance methods + property getters (issue #234) ──
+    // The receiver is a numeric Blob handle (registry id) carried as f64,
+    // mirroring the Response handle ABI. Locals are tagged blob::Blob via
+    // `register_native_instance` in `destructuring.rs`.
+    if module == "blob" {
+        let recv_handle = lower_expr(ctx, recv)?;
+        match method {
+            "size" => {
+                let blk = ctx.block();
+                let n = blk.call(DOUBLE, "js_blob_size", &[(DOUBLE, &recv_handle)]);
+                return Ok(Some(n));
+            }
+            "type" => {
+                let str_ptr = ctx
+                    .block()
+                    .call(I64, "js_blob_type", &[(DOUBLE, &recv_handle)]);
+                let blk = ctx.block();
+                return Ok(Some(nanbox_string_inline(blk, &str_ptr)));
+            }
+            "arrayBuffer" => {
+                let blk = ctx.block();
+                let promise =
+                    blk.call(I64, "js_blob_array_buffer", &[(DOUBLE, &recv_handle)]);
+                return Ok(Some(nanbox_pointer_inline(blk, &promise)));
+            }
+            "bytes" => {
+                let blk = ctx.block();
+                let promise = blk.call(I64, "js_blob_bytes", &[(DOUBLE, &recv_handle)]);
+                return Ok(Some(nanbox_pointer_inline(blk, &promise)));
+            }
+            "text" => {
+                let blk = ctx.block();
+                let promise = blk.call(I64, "js_blob_text", &[(DOUBLE, &recv_handle)]);
+                return Ok(Some(nanbox_pointer_inline(blk, &promise)));
+            }
+            "slice" => {
+                // slice(start?, end?, type?) — missing numeric args use NaN
+                // as sentinel; missing type uses null pointer (0). Runtime
+                // `js_blob_slice` checks `is_nan()` / `type_ptr.is_null()`
+                // to apply WHATWG defaults.
+                // Missing numeric args use canonical f64::NAN as sentinel;
+                // runtime `js_blob_slice` checks `is_nan()` to apply WHATWG
+                // defaults (start=0, end=len).
+                let start = if !args.is_empty() {
+                    lower_expr(ctx, &args[0])?
+                } else {
+                    double_literal(f64::NAN)
+                };
+                let end = if args.len() >= 2 {
+                    lower_expr(ctx, &args[1])?
+                } else {
+                    double_literal(f64::NAN)
+                };
+                let type_ptr = if args.len() >= 3 {
+                    get_raw_string_ptr(ctx, &args[2])?
+                } else {
+                    "0".to_string()
+                };
+                let new_handle = ctx.block().call(
+                    DOUBLE,
+                    "js_blob_slice",
+                    &[
+                        (DOUBLE, &recv_handle),
+                        (DOUBLE, &start),
+                        (DOUBLE, &end),
+                        (I64, &type_ptr),
+                    ],
+                );
+                return Ok(Some(new_handle));
+            }
+            _ => return Ok(None),
+        }
+    }
+
     // ── axios: response property access (response.status, .data, .statusText, .headers) ──
     if module == "axios" {
         if let Some(recv) = object {

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -817,6 +817,15 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_response_clone", DOUBLE, &[DOUBLE]);
     module.declare_function("js_response_array_buffer", I64, &[DOUBLE]);
     module.declare_function("js_response_blob", I64, &[DOUBLE]);
+    // Blob instance methods (issue #234) — handle is f64 (registry id).
+    // arrayBuffer/bytes/text return a Promise pointer (i64); slice returns a
+    // new blob handle as f64.
+    module.declare_function("js_blob_size", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_blob_type", I64, &[DOUBLE]);
+    module.declare_function("js_blob_array_buffer", I64, &[DOUBLE]);
+    module.declare_function("js_blob_bytes", I64, &[DOUBLE]);
+    module.declare_function("js_blob_text", I64, &[DOUBLE]);
+    module.declare_function("js_blob_slice", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE, I64]);
     // Static factories.
     module.declare_function("js_response_static_json", DOUBLE, &[DOUBLE]);
     module.declare_function("js_response_static_redirect", DOUBLE, &[I64, DOUBLE]);

--- a/crates/perry-hir/src/destructuring.rs
+++ b/crates/perry-hir/src/destructuring.rs
@@ -1359,6 +1359,50 @@ pub(crate) fn lower_var_decl_with_destructuring(
                         }
                     }
                 }
+                // Issue #234: const blob = await <res>.blob() — register `blob`
+                // as a blob::Blob native instance so subsequent `blob.text()` /
+                // `.arrayBuffer()` / `.bytes()` / `.slice()` / `.size` /
+                // `.type` calls dispatch through the codegen `module=="blob"`
+                // arm in `lower_call.rs`.
+                if let ast::Expr::Await(await_expr) = init_expr.as_ref() {
+                    if let ast::Expr::Call(call_expr) = await_expr.arg.as_ref() {
+                        if let ast::Callee::Expr(callee) = &call_expr.callee {
+                            if let ast::Expr::Member(member) = callee.as_ref() {
+                                if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
+                                    if let ast::MemberProp::Ident(prop_ident) = &member.prop {
+                                        if prop_ident.sym.as_ref() == "blob" {
+                                            if let Some((_, c)) = ctx.lookup_native_instance(obj_ident.sym.as_ref()) {
+                                                if c == "Response" {
+                                                    ctx.register_native_instance(name.clone(), "blob".to_string(), "Blob".to_string());
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                // Issue #234: const b2 = blob.slice(...) — chained slicing
+                // returns a new Blob. Detect when the receiver is already a
+                // blob::Blob native instance.
+                if let ast::Expr::Call(call_expr) = init_expr.as_ref() {
+                    if let ast::Callee::Expr(callee) = &call_expr.callee {
+                        if let ast::Expr::Member(member) = callee.as_ref() {
+                            if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
+                                if let ast::MemberProp::Ident(prop_ident) = &member.prop {
+                                    if prop_ident.sym.as_ref() == "slice" {
+                                        if let Some((_, c)) = ctx.lookup_native_instance(obj_ident.sym.as_ref()) {
+                                            if c == "Blob" {
+                                                ctx.register_native_instance(name.clone(), "blob".to_string(), "Blob".to_string());
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             // Check if calling a function whose return type is a native module type

--- a/crates/perry-stdlib/src/fetch.rs
+++ b/crates/perry-stdlib/src/fetch.rs
@@ -4,7 +4,7 @@
 //! Provides fetch() function for making HTTP requests.
 
 use perry_runtime::{
-    js_array_alloc, js_array_push, js_object_alloc, js_object_alloc_with_shape,
+    js_array_alloc, js_array_push, js_object_alloc,
     js_object_set_field, js_object_set_keys,
     js_string_from_bytes, JSValue, StringHeader,
 };
@@ -824,6 +824,23 @@ lazy_static::lazy_static! {
     static ref NEXT_HEADERS_ID: Mutex<usize> = Mutex::new(1);
     static ref REQUEST_REGISTRY: Mutex<HashMap<usize, RequestRecord>> = Mutex::new(HashMap::new());
     static ref NEXT_REQUEST_ID: Mutex<usize> = Mutex::new(1);
+    static ref BLOB_REGISTRY: Mutex<HashMap<usize, BlobData>> = Mutex::new(HashMap::new());
+    static ref NEXT_BLOB_ID: Mutex<usize> = Mutex::new(1);
+}
+
+#[derive(Clone)]
+struct BlobData {
+    body: Vec<u8>,
+    content_type: String,
+}
+
+fn alloc_blob(data: BlobData) -> usize {
+    let mut id_guard = NEXT_BLOB_ID.lock().unwrap();
+    let id = *id_guard;
+    *id_guard += 1;
+    drop(id_guard);
+    BLOB_REGISTRY.lock().unwrap().insert(id, data);
+    id
 }
 
 fn alloc_headers(store: HeadersStore) -> usize {
@@ -1052,19 +1069,20 @@ pub unsafe extern "C" fn js_response_array_buffer(handle: f64) -> *mut perry_run
     promise
 }
 
-/// response.blob() — returns an object { size: N, type: "..." }
+/// response.blob() — registers a real Blob in BLOB_REGISTRY (cloning body
+/// bytes + content-type) and resolves with the numeric blob handle as f64.
 /// Resolved synchronously; see `js_fetch_response_text`.
 ///
-/// TODO(#234): body bytes are dropped here. A real Blob requires implementing
-/// `.arrayBuffer()` / `.text()` / `.bytes()` / `.slice()` instance methods plus
-/// codegen dispatch routing (`crates/perry-codegen/src/lower_call.rs`).
-/// Until that lands, users needing binary body bytes should call
-/// `response.arrayBuffer()` directly instead of `response.blob()`.
+/// Closes #234 (followup of #232 / #227): pre-fix this returned a
+/// metadata-only stub `{size, type}` and silently dropped `resp.body`. The
+/// codegen-side dispatch arm at `crates/perry-codegen/src/lower_call.rs`
+/// (module=="blob") routes `.arrayBuffer()` / `.text()` / `.bytes()` /
+/// `.slice()` / `.size` / `.type` to the FFIs below.
 #[no_mangle]
 pub unsafe extern "C" fn js_response_blob(handle: f64) -> *mut perry_runtime::Promise {
     let promise = perry_runtime::js_promise_new();
     let id = handle as usize;
-    let (body_len, content_type) = {
+    let data = {
         let guard = FETCH_RESPONSES.lock().unwrap();
         match guard.get(&id) {
             Some(resp) => {
@@ -1072,19 +1090,139 @@ pub unsafe extern "C" fn js_response_blob(handle: f64) -> *mut perry_runtime::Pr
                     .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
                     .map(|(_, v)| v.clone())
                     .unwrap_or_default();
-                (resp.body.len(), ct)
+                BlobData { body: resp.body.clone(), content_type: ct }
             }
-            None => (0, String::new()),
+            None => BlobData { body: Vec::new(), content_type: String::new() },
         }
     };
-    let packed = b"size\0type\0".as_ptr();
-    let obj = js_object_alloc_with_shape(0x7FFE_FE02, 2, packed, 10);
-    perry_runtime::js_object_set_field(obj, 0, JSValue::number(body_len as f64));
-    let type_str = js_string_from_bytes(content_type.as_ptr(), content_type.len() as u32);
-    perry_runtime::js_object_set_field(obj, 1, JSValue::string_ptr(type_str));
-    let val = JSValue::object_ptr(obj as *mut u8);
+    let blob_id = alloc_blob(data);
+    perry_runtime::js_promise_resolve(promise, blob_id as f64);
+    promise
+}
+
+// ----------------- Blob FFI -----------------
+//
+// Blob handles are plain numeric f64 values (registry IDs into BLOB_REGISTRY),
+// matching the Response handle ABI. They must NOT be NaN-boxed; codegen passes
+// them through as DOUBLE arg kinds. See `lower_call.rs::module=="blob"` arm.
+
+/// blob.size — body byte length as f64.
+#[no_mangle]
+pub extern "C" fn js_blob_size(handle: f64) -> f64 {
+    let id = handle as usize;
+    BLOB_REGISTRY.lock().unwrap()
+        .get(&id)
+        .map(|b| b.body.len() as f64)
+        .unwrap_or(0.0)
+}
+
+/// blob.type — content_type as `*mut StringHeader` (codegen NaN-boxes with STRING_TAG).
+#[no_mangle]
+pub unsafe extern "C" fn js_blob_type(handle: f64) -> *mut StringHeader {
+    let id = handle as usize;
+    let ct = BLOB_REGISTRY.lock().unwrap()
+        .get(&id)
+        .map(|b| b.content_type.clone())
+        .unwrap_or_default();
+    js_string_from_bytes(ct.as_ptr(), ct.len() as u32)
+}
+
+/// blob.arrayBuffer() — allocates a `BufferHeader` holding the body bytes,
+/// resolves the promise with it NaN-boxed as POINTER_TAG. Mirrors
+/// `js_response_array_buffer` (closes #227 path). `new Uint8Array(buf)` and
+/// `Buffer.from(buf)` see the actual byte contents via the BufferHeader
+/// property dispatch in `value.rs`. Resolved synchronously.
+#[no_mangle]
+pub unsafe extern "C" fn js_blob_array_buffer(handle: f64) -> *mut perry_runtime::Promise {
+    let promise = perry_runtime::js_promise_new();
+    let id = handle as usize;
+    let body: Vec<u8> = BLOB_REGISTRY.lock().unwrap()
+        .get(&id)
+        .map(|b| b.body.clone())
+        .unwrap_or_default();
+    let buf = perry_runtime::buffer::buffer_alloc(body.len() as u32);
+    (*buf).length = body.len() as u32;
+    if !body.is_empty() {
+        std::ptr::copy_nonoverlapping(
+            body.as_ptr(),
+            perry_runtime::buffer::buffer_data_mut(buf),
+            body.len(),
+        );
+    }
+    let val = JSValue::object_ptr(buf as *mut u8);
     perry_runtime::js_promise_resolve(promise, f64::from_bits(val.bits()));
     promise
+}
+
+/// blob.bytes() — alias for arrayBuffer() (the BufferHeader is already
+/// byte-array-shaped; users wrap in Uint8Array via `new Uint8Array(buf)` which
+/// hits the `is_registered_buffer` path from #227).
+#[no_mangle]
+pub unsafe extern "C" fn js_blob_bytes(handle: f64) -> *mut perry_runtime::Promise {
+    js_blob_array_buffer(handle)
+}
+
+/// blob.text() — UTF-8-decodes the body bytes into a `StringHeader` and
+/// resolves the promise with it NaN-boxed as STRING_TAG. Lossy decode for
+/// invalid sequences (matches WHATWG Blob.text() spec which uses replacement
+/// characters; lossy_utf8 produces U+FFFD identically).
+#[no_mangle]
+pub unsafe extern "C" fn js_blob_text(handle: f64) -> *mut perry_runtime::Promise {
+    let promise = perry_runtime::js_promise_new();
+    let id = handle as usize;
+    let body: Vec<u8> = BLOB_REGISTRY.lock().unwrap()
+        .get(&id)
+        .map(|b| b.body.clone())
+        .unwrap_or_default();
+    let s = String::from_utf8_lossy(&body).into_owned();
+    let str_ptr = js_string_from_bytes(s.as_ptr(), s.len() as u32);
+    let val = JSValue::string_ptr(str_ptr);
+    perry_runtime::js_promise_resolve(promise, f64::from_bits(val.bits()));
+    promise
+}
+
+/// blob.slice(start?, end?, type?) — returns a NEW blob handle covering
+/// [start, end) of the body. `f64::NAN` sentinel for missing numeric args.
+/// `type_ptr` may be null to inherit the original content-type. Negative
+/// indices count from the end; out-of-range values clamp to [0, len] per
+/// WHATWG Blob spec.
+#[no_mangle]
+pub unsafe extern "C" fn js_blob_slice(
+    handle: f64,
+    start: f64,
+    end: f64,
+    type_ptr: *const StringHeader,
+) -> f64 {
+    let id = handle as usize;
+    let (body, original_type) = {
+        let guard = BLOB_REGISTRY.lock().unwrap();
+        match guard.get(&id) {
+            Some(b) => (b.body.clone(), b.content_type.clone()),
+            None => (Vec::new(), String::new()),
+        }
+    };
+    let len = body.len() as i64;
+    let normalize = |v: f64, default: i64| -> i64 {
+        if v.is_nan() {
+            return default;
+        }
+        let n = v as i64;
+        if n < 0 {
+            (len + n).max(0)
+        } else {
+            n.min(len)
+        }
+    };
+    let s = normalize(start, 0);
+    let e = normalize(end, len);
+    let (lo, hi) = if e < s { (s, s) } else { (s, e) };
+    let slice = body[lo as usize..hi as usize].to_vec();
+    let new_type = if type_ptr.is_null() {
+        original_type
+    } else {
+        string_from_header(type_ptr).unwrap_or(original_type)
+    };
+    alloc_blob(BlobData { body: slice, content_type: new_type }) as f64
 }
 
 /// Response.json(value) — static method. Allocates a Response with JSON-stringified body

--- a/test-files/test_issue_234_blob_methods.ts
+++ b/test-files/test_issue_234_blob_methods.ts
@@ -1,0 +1,87 @@
+// Regression for issue #234 — `await response.blob()` was returning a
+// metadata-only `{ size, type }` stub and dropping body bytes. Verify the
+// real Blob surface: `.size`, `.type`, `.arrayBuffer()`, `.bytes()`,
+// `.text()`, `.slice()` round-trip against Node.
+
+async function main(): Promise<void> {
+  // ── 1. Basic blob from a Response, size ──
+  const r1 = new Response("hello world");
+  const b1 = await r1.blob();
+  console.log("size: " + b1.size);
+
+  // ── 2. blob.text() — UTF-8 decode ──
+  const r2 = new Response("hello world");
+  const b2 = await r2.blob();
+  const t2 = await b2.text();
+  console.log("text: " + t2);
+  console.log("text length: " + t2.length);
+
+  // ── 3. blob.arrayBuffer() — bytes survive ──
+  const r3 = new Response("hello");
+  const b3 = await r3.blob();
+  const ab3 = await b3.arrayBuffer();
+  console.log("ab byteLength: " + ab3.byteLength);
+  const u8 = new Uint8Array(ab3);
+  console.log("u8 length: " + u8.length);
+  console.log("u8 bytes: " + u8[0] + "," + u8[1] + "," + u8[2] + "," + u8[3] + "," + u8[4]);
+
+  // ── 4. blob.bytes() — alias ──
+  const r4 = new Response("abc");
+  const b4 = await r4.blob();
+  const ab4 = await b4.bytes();
+  const u4 = new Uint8Array(ab4);
+  console.log("bytes: " + u4[0] + "," + u4[1] + "," + u4[2]);
+
+  // ── 5. Buffer.from(blob.arrayBuffer()) round-trip ──
+  const r5 = new Response("café 🎉");
+  const b5 = await r5.blob();
+  console.log("multi-byte size: " + b5.size);
+  const ab5 = await b5.arrayBuffer();
+  const bf = Buffer.from(ab5);
+  console.log("multi-byte text: " + bf.toString("utf8"));
+
+  // ── 6. blob.slice(start, end) ──
+  const r6 = new Response("abcdefghij");
+  const b6 = await r6.blob();
+  const s1 = b6.slice(2, 5);
+  console.log("slice 2-5 size: " + s1.size);
+  const t1 = await s1.text();
+  console.log("slice 2-5 text: " + t1);
+
+  // ── 7. blob.slice() with no args (full clone) ──
+  const r7 = new Response("xyz");
+  const b7 = await r7.blob();
+  const s7 = b7.slice();
+  const t7 = await s7.text();
+  console.log("slice all: " + t7);
+
+  // ── 8. blob.slice(start) — defaults end to length ──
+  const r8 = new Response("abcdef");
+  const b8 = await r8.blob();
+  const s8 = b8.slice(3);
+  const t8 = await s8.text();
+  console.log("slice from 3: " + t8);
+
+  // ── 9. blob.slice(start, end, type) — with type override ──
+  const r9 = new Response("hello");
+  const b9 = await r9.blob();
+  const s9 = b9.slice(0, 3, "text/plain");
+  console.log("typed slice size: " + s9.size);
+  console.log("typed slice type: " + s9.type);
+
+  // ── 10. Empty body ──
+  const r10 = new Response("");
+  const b10 = await r10.blob();
+  console.log("empty size: " + b10.size);
+  const t10 = await b10.text();
+  console.log("empty text length: " + t10.length);
+
+  // ── 11. Negative slice indices count from end ──
+  const r11 = new Response("abcdef");
+  const b11 = await r11.blob();
+  const s11 = b11.slice(-3);
+  const t11 = await s11.text();
+  console.log("slice -3: " + t11);
+}
+
+main();

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -86,5 +86,9 @@
   "test_gap_fetch_response": {
     "status": "ci-env",
     "reason": "PR #232 (issue #227 follow-up) added `Buffer.from(ab).toString(\"utf8\")` byte-level assertions to the previously-passing `arrayBuffer byteLength: 5` check. The Buffer pull-in trips the same macOS-14 SDK/linker gap as the rest of the Buffer family (test_gap_buffer_ops, test_buffer_small_alloc, test_issue_227_array_buffer_bytes, etc.). Compiles and runs byte-for-byte clean on local macOS 15.x+; only the macOS-14 GitHub runner is affected."
+  },
+  "test_issue_234_blob_methods": {
+    "status": "ci-env",
+    "reason": "Regression test added by issue #234 fix (real Blob with arrayBuffer/text/bytes/slice). Includes a `Buffer.from(blob.arrayBuffer())` round-trip (multi-byte UTF-8 case) which trips the same macOS-14 SDK/linker gap as the rest of the Buffer family (test_gap_buffer_ops, test_buffer_small_alloc, test_issue_227_array_buffer_bytes, test_gap_fetch_response). Compiles and runs byte-for-byte against `node --experimental-strip-types` on local macOS 15.x+; only the macOS-14 GitHub runner is affected."
   }
 }


### PR DESCRIPTION
## Summary

Closes #234.

Pre-fix `await response.blob()` returned a metadata-only stub `{size, type}` and silently dropped `resp.body`. Calls to `blob.arrayBuffer()` / `.text()` / `.bytes()` / `.slice()` got nothing because no codegen dispatch arms existed.

## Approach

Three-part fix mirroring the precedent from #232 (real `BufferHeader` for `response.arrayBuffer`) and #227 (registered-buffer `is_registered_buffer` plumbing):

### 1. Runtime — `crates/perry-stdlib/src/fetch.rs`

- New `BlobData { body, content_type }` + `BLOB_REGISTRY: Mutex<HashMap<usize, BlobData>>` + `NEXT_BLOB_ID` + `alloc_blob` helper, mirroring the `HEADERS_REGISTRY` / `alloc_headers` pattern in the same file.
- `js_response_blob` rewritten: clones body bytes + content-type into a fresh `BlobData`, registers it, resolves the promise with the numeric handle as `f64`. Matches the Response-handle ABI documented at `lower_call.rs:2788`.
- 6 new FFIs:
  - `js_blob_size(handle) -> f64`
  - `js_blob_type(handle) -> *mut StringHeader` (codegen NaN-boxes with `STRING_TAG`)
  - `js_blob_array_buffer(handle) -> *mut Promise` — allocates a real `BufferHeader` via `perry_runtime::buffer::buffer_alloc(len)`, memcpys body, NaN-boxes as `POINTER_TAG`. Same shape as `js_response_array_buffer` from #232 so `new Uint8Array(buf)` and `Buffer.from(buf)` see real bytes via the `is_registered_buffer` path from #227.
  - `js_blob_bytes(handle) -> *mut Promise` — alias to `js_blob_array_buffer` (the `BufferHeader` is already byte-array-shaped).
  - `js_blob_text(handle) -> *mut Promise` — UTF-8 lossy decode to `StringHeader`, matches WHATWG Blob.text() replacement-character semantics.
  - `js_blob_slice(handle, start, end, type_ptr) -> f64` — canonical `f64::NAN` sentinel for missing numeric args, null `type_ptr` to inherit the original content-type. Negative indices count from the end and clamp to `[0, len]` per WHATWG Blob spec; allocates a fresh blob with sliced bytes.

### 2. HIR — `crates/perry-hir/src/destructuring.rs`

Two new arms in `lower_var_decl` next to the existing Response.clone() propagation:
- `const blob = await <recv>.blob()` where `<recv>` is `fetch::Response` → `register_native_instance(name, "blob", "Blob")`.
- `const b2 = <recv>.slice(...)` where `<recv>` is `blob::Blob` → propagate the type so chained slicing keeps Blob-ness.

The existing native-instance method-call lowering at `expr_call.rs:723-740` and property access at `expr_member.rs:312-326` then route subsequent `.text()` / `.size` / etc. to `Expr::NativeMethodCall { module: "blob", method: ..., args: [] }` automatically — no other HIR changes needed.

### 3. Codegen — `crates/perry-codegen/src/lower_call.rs` + `runtime_decls.rs`

New `if module == "blob"` arm right after the existing `if module == "fetch"` block:
- `size` → `js_blob_size` (DOUBLE return)
- `type` → `js_blob_type` + `nanbox_string_inline`
- `arrayBuffer` / `bytes` / `text` → respective Promise-returning FFIs + `nanbox_pointer_inline`
- `slice` → 0-3 args with `double_literal(f64::NAN)` sentinels for missing numeric args and `"0"` for missing type pointer; returns the new blob handle as `f64` directly.

6 new `module.declare_function(...)` rows in `runtime_decls.rs` with the matching ABIs.

## Out of scope

- `blob.stream()` — needs a full WHATWG Web Streams API implementation (`ReadableStream`, `ReadableStreamDefaultReader`, `Symbol.asyncIterator` protocol for streams, eventually `WritableStream` + `TransformStream` for `pipeTo` / `pipeThrough`). That affects `response.body` / `Request.body` / `new Response(stream)` too, so a Blob-only stub would create inconsistency. Tracked as #237.
- `response.formData()` — separate gap; not requested by #234.

## Test plan

- [x] New `test-files/test_issue_234_blob_methods.ts` covers 11 cases: size, text, arrayBuffer + Uint8Array roundtrip, bytes alias, multi-byte UTF-8 + `Buffer.from` roundtrip, `slice(start, end)`, `slice()` (no args, full clone), `slice(start)` (defaults end to length), `slice(0, 3, "text/plain")` (typed slice), empty body, negative slice indices. All match `node --experimental-strip-types` byte-for-byte.
- [x] `test-files/test_issue_227_array_buffer_bytes.ts` (the #227 regression) continues to match Node byte-for-byte.
- [x] `test-files/test_gap_fetch_response.ts` continues to match Node modulo the pre-existing experimental-strip-types preamble.
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` clean.

## Refs

- Closes #234
- Follow-up #237 (`blob.stream()` + Web Streams API)
- Same lineage as #227 (`response.arrayBuffer()` body bytes) and #232 (real `BufferHeader` for response.arrayBuffer)