### PR TITLE
ci: capture compile stderr in parity + compile-smoke jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -237,6 +237,19 @@ jobs:
           name: parity-report
           path: test-parity/reports/latest.json
 
+      # Capture per-test compile stderr written by run_parity_tests.sh into
+      # `test-parity/output/*.compile_error.log` so the long-tail
+      # macOS-14-only compile failures (tracked as `ci-env` in
+      # known_failures.json) can finally be diagnosed by reading the actual
+      # error message rather than inferring from the test family.
+      - name: Upload compile-error logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: parity-compile-errors-${{ runner.os }}
+          path: test-parity/output/*.compile_error.log
+          if-no-files-found: ignore
+
   # ---------------------------------------------------------------------------
   # Compile smoke test (all 130+ test files must compile)
   # ---------------------------------------------------------------------------
@@ -304,7 +317,11 @@ jobs:
           #   test_buffer_numeric_read_intrinsic, test_buffer_small_alloc)
           #   compile cleanly on local macOS 15.x but fail on the GitHub
           #   macOS-14 runner (SDK/linker version interaction). Tracked
-          #   as `ci-env` in `test-parity/known_failures.json`.
+          #   as `ci-env` in `test-parity/known_failures.json`. Stderr
+          #   is now captured by the parity job into the
+          #   `parity-compile-errors-*` artifact (sibling to this skip
+          #   list); inspect that artifact to see the actual link error
+          #   for any of these tests.
           # Space-separated skip list (associative arrays require bash
           # 4+; macOS-14 ships bash 3.2). Word-boundary match keeps
           # the substring lookup safe.
@@ -325,6 +342,12 @@ jobs:
             test_issue_227_array_buffer_bytes \
             test_gap_fetch_response "
 
+          # Capture compile stderr per test so the artifact upload below
+          # can preserve the actual error message — pre-fix the loop
+          # discarded stderr (`2>/dev/null`) so the macOS-14-only failures
+          # (tracked as `ci-env` in test-parity/known_failures.json) had to
+          # be diagnosed by inference rather than data.
+          mkdir -p /tmp/perry_smoke_logs
           for f in test-files/*.ts; do
             [[ -d "$f" ]] && continue
             name=$(basename "$f" .ts)
@@ -332,9 +355,10 @@ jobs:
               ((SKIP++))
               continue
             fi
-            if $PERRY "$f" -o "/tmp/perry_smoke_${name}" 2>/dev/null; then
+            err_log="/tmp/perry_smoke_logs/${name}.compile_error.log"
+            if $PERRY "$f" -o "/tmp/perry_smoke_${name}" 2>"$err_log"; then
               ((PASS++))
-              rm -f "/tmp/perry_smoke_${name}"
+              rm -f "/tmp/perry_smoke_${name}" "$err_log"
             else
               ((FAIL++))
               FAILURES+=("$name")
@@ -347,9 +371,25 @@ jobs:
             echo "Compile failures:"
             for f in "${FAILURES[@]}"; do
               echo "  - $f"
+              # Surface the head of each failure log directly in the job
+              # output so a quick scan reveals the underlying error without
+              # downloading the artifact.
+              if [[ -s "/tmp/perry_smoke_logs/${f}.compile_error.log" ]]; then
+                echo "    --- compile stderr (first 30 lines) ---"
+                head -n 30 "/tmp/perry_smoke_logs/${f}.compile_error.log" | sed 's/^/    /'
+                echo "    --- end ---"
+              fi
             done
             exit 1
           fi
+
+      - name: Upload compile-smoke error logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compile-smoke-error-logs
+          path: /tmp/perry_smoke_logs/*.compile_error.log
+          if-no-files-found: ignore
 
       # Thread-primitive compile-error tests (#146): checks that closures
       # passed to perry/thread primitives with outer-variable writes are

--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -223,6 +223,13 @@ for test_file in "$TEST_DIR"/*.ts; do
         ((COMPILE_FAIL++))
         COMPILE_FAILURES+=("$test_name")
         echo "" > "$perry_output_file"
+        # Persist the actual compile stderr so CI artifacts can be inspected
+        # to diagnose long-tail compile failures (e.g. the macOS-14 SDK gap
+        # tracked as `ci-env` in test-parity/known_failures.json). Pre-fix
+        # the parity runner only logged "compile error" with no detail and
+        # the macOS-14 family was diagnosed by inference, not data.
+        compile_log="$OUTPUT_DIR/${test_name}.compile_error.log"
+        printf "%s\n" "$compile_output" > "$compile_log"
         continue
     fi
 


### PR DESCRIPTION
## Why

11 tests are tracked in `test-parity/known_failures.json` with `status: \"ci-env\"` and the same vague reason — \"macOS-14 CI runner SDK/linker version interaction\":

- `test_gap_buffer_ops`, `test_buffer_small_alloc`, `test_buffer_numeric_read_intrinsic`, `test_gap_node_crypto_buffer`, `test_gap_typed_arrays`, `test_stress_buffer`, `test_inline_uint8array_param`, `test_issue_167_loop_alloca_stack_eat`, `test_issue_227_array_buffer_bytes`, `test_gap_fetch_response`, plus the new `test_issue_234_blob_methods` from #238.

But the actual error message has never been pinned down, because both compile harnesses silently discard stderr:

- [`run_parity_tests.sh:218`](https://github.com/PerryTS/perry/blob/main/run_parity_tests.sh#L218) captures `compile_output` into a local var but only logs `\"compile error\"` with no detail.
- [`.github/workflows/test.yml::compile-smoke`](https://github.com/PerryTS/perry/blob/main/.github/workflows/test.yml#L335) compiles with `2>/dev/null`, so the job summary lists only the failing test names.

Net effect: every PR that adds a Buffer / Uint8Array regression test ends up in the same skip list (\"ci-env / passes-locally\") **on inference alone**, and the underlying root cause never gets fixed. The v0.5.354 changelog itself acknowledges:

> \"the underlying SDK/linker gap is the real long-tail problem and a CI runner image bump (macOS-15) would clear all 9+ ci-env Buffer skips at once.\"

…but that hypothesis has never been verified against an actual error message.

## What this PR does

Pure diagnostic plumbing — no source changes, no SKIP_TESTS edits, no runner bump, no version bump.

### 1. `run_parity_tests.sh`

On compile-fail, write the captured `compile_output` to `test-parity/output/<test_name>.compile_error.log`. The existing per-test loop is unchanged; this just persists the stderr the script was already capturing into a memory-only var.

### 2. `.github/workflows/test.yml`

Two new artifact upload steps (both `if: always()` + `if-no-files-found: ignore` so green CI runs produce no artifact noise):

- **`parity-compile-errors-${{ runner.os }}`** from the `parity` job — gathers the per-test logs the script now writes.
- **`compile-smoke-error-logs`** from `compile-smoke` — captures stderr per test to `/tmp/perry_smoke_logs/`, plus inlines `head -n 30` of each failure log into the job output (so a quick scan in the GitHub UI reveals the error without needing to download the artifact).

## What you'll see on the next CI run

The `parity` job naturally exercises every `ci-env` test (it doesn't have a SKIP_TESTS list — it tracks them via `known_failures.json` instead). With this PR, that job will produce ~11 `*.compile_error.log` files in the `parity-compile-errors-macOS` artifact, one per known failure. Reading any of them gives the actual link error.

## Decision tree once we have the data

- **If the error matches the maintainer's hypothesis** (link symbol mismatch / SDK ABI skew): file a follow-up PR bumping `runs-on: macos-14` → `macos-15` and removing the skips.
- **If the error is a real Perry bug** (e.g. a stdlib codegen path that emits something the macOS-14 SDK linker rejects but local does accept): fix it in Perry rather than skipping it.
- **Either way**: the diagnostic capture stays as defensive infra — future Buffer/typed-array regressions will surface the link error in the PR's CI run instead of getting silently added to the skip list.

## Refs

- v0.5.354 changelog (\"the underlying SDK/linker gap is the real long-tail problem\")
- v0.5.314 / #169 (`test_inline_uint8array_param` — original ci-env entry from this family)
- #232 / #227 (most recent additions to the skip list)
- #238 (PR for #234, latest addition to the same skip list)