### PR TITLE
fix(codegen): declare @llvm.assume intrinsic in IR module prelude

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -311,17 +311,21 @@ jobs:
           #   the platform widgets.
           # - test_timer: hangs on the runtime event loop under the
           #   no-arg compile path.
-          # - The macOS-14-only compile failures (test_gap_buffer_ops,
-          #   test_gap_node_crypto_buffer, test_gap_typed_arrays,
-          #   test_stress_buffer, test_stress_int_ops,
-          #   test_buffer_numeric_read_intrinsic, test_buffer_small_alloc)
-          #   compile cleanly on local macOS 15.x but fail on the GitHub
-          #   macOS-14 runner (SDK/linker version interaction). Tracked
-          #   as `ci-env` in `test-parity/known_failures.json`. Stderr
-          #   is now captured by the parity job into the
-          #   `parity-compile-errors-*` artifact (sibling to this skip
-          #   list); inspect that artifact to see the actual link error
-          #   for any of these tests.
+          #
+          # The 11-entry Buffer/typed-array `ci-env` skip family that
+          # previously lived here (test_gap_buffer_ops, test_buffer_*,
+          # test_inline_uint8array_param, test_issue_167_*,
+          # test_issue_227_*, test_gap_fetch_response,
+          # test_issue_234_blob_methods, etc.) has been removed as of
+          # this PR: the actual root cause was a missing
+          # `module.declare_function("llvm.assume", VOID, &[I1])` in
+          # `crates/perry-codegen/src/runtime_decls.rs`. Apple Clang
+          # ≥21 (Xcode 26 / local) auto-recognised the intrinsic;
+          # Apple Clang 15 (macos-14 runner / Xcode 15.x / LLVM 17)
+          # errored with `error: use of undefined value '@llvm.assume'`.
+          # Not an SDK gap — a long-standing latent codegen bug
+          # diagnosed via the compile-stderr capture artifact added in
+          # PR #239 (now part of main).
           # Space-separated skip list (associative arrays require bash
           # 4+; macOS-14 ships bash 3.2). Word-boundary match keeps
           # the substring lookup safe.
@@ -329,19 +333,7 @@ jobs:
             test_ui_comprehensive \
             test_ui_controls \
             test_ui_phase4 \
-            test_timer \
-            test_gap_buffer_ops \
-            test_gap_node_crypto_buffer \
-            test_gap_typed_arrays \
-            test_stress_buffer \
-            test_stress_int_ops \
-            test_buffer_numeric_read_intrinsic \
-            test_buffer_small_alloc \
-            test_inline_uint8array_param \
-            test_issue_167_loop_alloca_stack_eat \
-            test_issue_227_array_buffer_bytes \
-            test_issue_234_blob_methods \
-            test_gap_fetch_response "
+            test_timer "
 
           # Capture compile stderr per test so the artifact upload below
           # can preserve the actual error message — pre-fix the loop

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -11,7 +11,7 @@
 //! gets garbage back (see anvil README §48 bug hunt).
 
 use crate::module::LlModule;
-use crate::types::{DOUBLE, I32, I64, PTR, VOID};
+use crate::types::{DOUBLE, I1, I32, I64, PTR, VOID};
 
 /// Declare the minimum set of runtime functions needed by Phase 1
 /// (`console.log(42)`):
@@ -119,6 +119,18 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("llvm.ceil.f64", DOUBLE, &[DOUBLE]);
     module.declare_function("llvm.fabs.f64", DOUBLE, &[DOUBLE]);
     module.declare_function("llvm.copysign.f64", DOUBLE, &[DOUBLE, DOUBLE]);
+    // `llvm.assume` — used by Buffer index-set/get fast paths
+    // (`crates/perry-codegen/src/expr.rs::Expr::BufferIndexSet/Get` etc.)
+    // and the Buffer numeric-read intrinsics
+    // (`lower_call.rs::lower_buffer_numeric_read`) for branchless bounds
+    // checks. Apple Clang ≥21 (Xcode 26) auto-recognises the intrinsic
+    // even when undeclared in the IR, but Apple Clang 15 (LLVM 17 — what
+    // ships on the macOS-14 GitHub runner via Xcode 15.x) errors with
+    // `error: use of undefined value '@llvm.assume'`. This was the actual
+    // root cause of the long-tail of `ci-env` Buffer/typed-array test
+    // skips in `test-parity/known_failures.json` — diagnosed via the
+    // compile-stderr capture artifact added in the previous commit.
+    module.declare_function("llvm.assume", VOID, &[I1]);
     // Keep js_math_pow for now — Math.pow has overflow / NaN
     // semantics that the libm pow doesn't quite match.
 

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -27,33 +27,9 @@
     "status": "skip",
     "reason": "Compile failure — TLS connect not implemented"
   },
-  "test_gap_buffer_ops": {
-    "status": "ci-env",
-    "reason": "Compile-fails on macOS-14 CI runner, passes locally on macOS 15.x. Likely SDK/linker version interaction; perry CLI itself is fine"
-  },
-  "test_gap_node_crypto_buffer": {
-    "status": "ci-env",
-    "reason": "Compile-fails on macOS-14 CI runner, passes locally on macOS 15.x. Same SDK gap as test_gap_buffer_ops"
-  },
-  "test_gap_typed_arrays": {
-    "status": "ci-env",
-    "reason": "Compile-fails on macOS-14 CI runner, passes locally on macOS 15.x. Same SDK gap as test_gap_buffer_ops"
-  },
-  "test_stress_buffer": {
-    "status": "ci-env",
-    "reason": "Compile-fails on macOS-14 CI runner, passes locally on macOS 15.x"
-  },
   "test_stress_int_ops": {
     "status": "bug",
     "reason": "Console.log array-of-numbers inspection format: Node right-aligns + computes per-line count via util.inspect (`[\n   0,  1,  4,  9, 16,\n  25, 36, 49, 64, 81\n]`); Perry packs without padding 4 per line. NaN/Infinity ToInt32 coercion (`(NaN) | 0`, etc.) was fixed at v0.5.279 — that bug had `is_known_finite` accepting any `Expr::Number(_)` regardless of finite-ness; now checks `n.is_finite()`."
-  },
-  "test_buffer_small_alloc": {
-    "status": "ci-env",
-    "reason": "Compile-fails on macOS-14 CI runner, passes locally on macOS 15.x. Same SDK gap as test_gap_buffer_ops; exercises the #92 Buffer.alloc small-buffer slab fast path."
-  },
-  "test_buffer_numeric_read_intrinsic": {
-    "status": "ci-env",
-    "reason": "Compile-fails on macOS-14 CI runner, passes locally on macOS 15.x. Same SDK gap as test_gap_buffer_ops; exercises the #92 Buffer numeric-read intrinsic."
   },
   "test_gap_console_methods": {
     "status": "ci-env",
@@ -63,14 +39,6 @@
     "status": "bug",
     "reason": "Multiple distinct Promise issues remaining after v0.5.283 fix (which addressed (a) microtask FIFO ordering — TASK_QUEUE was a Vec with .pop() → LIFO; switched to VecDeque + pop_front, and (b) `.then(h)` / `.catch(h)` not catching throws inside h — microtask runner now wraps closure call in setjmp): (1) `new Promise<T>((resolve, reject) => ...)` constructor body not running (lines `constructor resolve: 99` / `constructor reject: constructor-err` missing from output); (2) `Promise.any` produces no output (any/any-all-rejected/any-errors-length lines missing); (3) `.then(p => Promise.resolve(...))` doesn't unwrap inner Promise (logs `Promise { <pending> }` instead of resolved value); (4) `.finally(() => ...).then(v => ...)` value-passing wrong (Perry: `finally value: 0`, Node: `finally value: done`)."
   },
-  "test_inline_uint8array_param": {
-    "status": "bug",
-    "reason": "Regression test added by v0.5.314 (#169 fix in perry-transform substitute_locals). The test compiles successfully locally but compile-fails on CI runners — likely an SDK/linker version interaction shared with the test_gap_buffer_ops family. The underlying Uint8Array param substitution fix landed in 976c3eb5; this test documents the case but the CI env exhibits a separate compile-fail mode. Pair-investigate with test_issue_167_loop_alloca_stack_eat."
-  },
-  "test_issue_167_loop_alloca_stack_eat": {
-    "status": "bug",
-    "reason": "Regression test added by v0.5.316 (#167 fix hoisting js_native_call_method args alloca to entry block). Same compile-fail-on-CI / passes-locally pattern as test_inline_uint8array_param — both tests are about Buffer/Uint8Array codepaths and likely share the macOS-14 SDK gap."
-  },
   "test_gap_array_methods": {
     "status": "known_limitation",
     "reason": "TypedArray.prototype.at() returns undefined instead of element values on Int32Array / Float64Array (e.g. `Int32Array.at(0)` → undefined where Node returns 1). Categorical typed-array gap, same family as test_gap_typed_arrays — Perry's .at() codegen fast path is wired for regular Array but not for the TypedArray instance shapes. Was passing 26/28 at v0.5.319 after the SSO-unboxing fix transitively flipped it; regressed somewhere in v0.5.319→v0.5.343 (likely an SSO/typed-array interaction in the bulk extraction series). Stale CLAUDE.md TypeScript-Parity-Status header still reads 26/28 — actual is 25/28 with array_methods/console_methods/typed_arrays failing."
@@ -78,17 +46,5 @@
   "test_json_lazy_predicates": {
     "status": "bug",
     "reason": "`Array.isArray()` returns false on the result of `[...].map(fn)` (Perry: `map-result-isArray:false`, Node: `map-result-isArray:true`). The map-returned shape isn't being recognized by the isArray predicate — likely a missing tag check or the map fast path returns a different runtime type than the isArray fast path expects. Distinct from the typed-array gap; affects the hot Array.prototype.map → Array.isArray idiom that lazy-iterator libraries (lodash etc.) lean on."
-  },
-  "test_issue_227_array_buffer_bytes": {
-    "status": "ci-env",
-    "reason": "Regression test added by #227 fix (response.arrayBuffer() body bytes — js_response_array_buffer copy-into-BufferHeader + js_uint8array_new buffer-source detection branch). Same compile-fail-on-CI / passes-locally pattern as the rest of the Buffer/Uint8Array family (test_gap_buffer_ops, test_buffer_small_alloc, test_inline_uint8array_param, etc.) — macOS-14 runner SDK/linker gap. The fix itself is verified locally byte-for-byte against `node --experimental-strip-types`; cargo test runtime+stdlib clean."
-  },
-  "test_gap_fetch_response": {
-    "status": "ci-env",
-    "reason": "PR #232 (issue #227 follow-up) added `Buffer.from(ab).toString(\"utf8\")` byte-level assertions to the previously-passing `arrayBuffer byteLength: 5` check. The Buffer pull-in trips the same macOS-14 SDK/linker gap as the rest of the Buffer family (test_gap_buffer_ops, test_buffer_small_alloc, test_issue_227_array_buffer_bytes, etc.). Compiles and runs byte-for-byte clean on local macOS 15.x+; only the macOS-14 GitHub runner is affected."
-  },
-  "test_issue_234_blob_methods": {
-    "status": "ci-env",
-    "reason": "Regression test added by issue #234 fix (real Blob with arrayBuffer/text/bytes/slice). Includes a `Buffer.from(blob.arrayBuffer())` round-trip (multi-byte UTF-8 case) which trips the same macOS-14 SDK/linker gap as the rest of the Buffer family (test_gap_buffer_ops, test_buffer_small_alloc, test_issue_227_array_buffer_bytes, test_gap_fetch_response). Compiles and runs byte-for-byte against `node --experimental-strip-types` on local macOS 15.x+; only the macOS-14 GitHub runner is affected."
   }
 }


### PR DESCRIPTION
## Summary

The diagnostic capture from PR #239 revealed that **all 11** `ci-env` Buffer/typed-array tests in `test-parity/known_failures.json` were failing with the same exact error:

```
/var/folders/.../perry_llvm.ll:1281:13: error: use of undefined value '@llvm.assume'
  call void @llvm.assume(i1 %r43)
```

Not an SDK gap, not a linker version interaction — a long-standing **latent codegen bug**. `crates/perry-codegen/src/expr.rs` and `lower_call.rs` emit `call void @llvm.assume(i1 ...)` six times for branchless Buffer bounds checks (the v0.5.183 #92 numeric-read intrinsic + the v0.5.190 small-buffer slab fast path), but the intrinsic was never declared in the LLVM IR module's prelude. The math intrinsics (`llvm.sqrt.f64`, `llvm.floor.f64`, etc.) are declared at `runtime_decls.rs:117-121` — `assume` was simply missed.

## Why it never got caught

- **Apple Clang ≥21** (Xcode 26 — what local devs run today) auto-recognises the intrinsic even when undeclared in the IR.
- **Apple Clang 15** (LLVM 17 — Xcode 15.x bundled with the macos-14 GitHub runner) requires the explicit declaration and errors out.

So the maintainer's `\"passes locally on macOS 15.x / SDK gap on macos-14\"` framing in `known_failures.json` was a **misdiagnosis**: the actual differentiator was the host's Xcode/Clang version, not the macOS or SDK version. \"Bumping the runner to macos-15\" (proposed in v0.5.354 changelog) would likely **not** have fixed it cleanly either — macos-15's bundled Xcode 16 (Apple Clang 16, LLVM 18) is from the same strict-IR-validation generation as Apple Clang 15. Only declaring the intrinsic actually fixes the underlying portability bug.

## Fix

One-line addition in `crates/perry-codegen/src/runtime_decls.rs`:

```rust
module.declare_function(\"llvm.assume\", VOID, &[I1]);
```

…alongside the existing math-intrinsic declarations.

## Cleanup follow-on (now that the root cause is fixed)

- **`.github/workflows/test.yml::compile-smoke`** — remove the 11-entry Buffer-family `SKIP_TESTS` list. UI/timer skips stay (different reasons).
- **`test-parity/known_failures.json`** — remove 8 `ci-env` entries plus 2 `bug` entries that were misdiagnosed but actually shared the same llvm.assume cause:
  - `test_gap_buffer_ops`, `test_gap_node_crypto_buffer`, `test_gap_typed_arrays`, `test_stress_buffer`, `test_buffer_small_alloc`, `test_buffer_numeric_read_intrinsic`, `test_issue_227_array_buffer_bytes`, `test_gap_fetch_response` (ci-env → fixed)
  - `test_inline_uint8array_param`, `test_issue_167_loop_alloca_stack_eat` (`bug` with SDK-gap speculation in their reasons → fixed)

`test_stress_int_ops` keeps its `bug` entry (separate console.log array-of-numbers padding issue exists independently of llvm.assume).

## Verified locally

```bash
$ cargo build --release -p perry-codegen -p perry
$ for t in test_buffer_numeric_read_intrinsic test_buffer_small_alloc test_gap_buffer_ops \
           test_gap_node_crypto_buffer test_gap_typed_arrays test_inline_uint8array_param \
           test_issue_167_loop_alloca_stack_eat test_issue_227_array_buffer_bytes \
           test_stress_buffer test_stress_int_ops; do
    ./target/release/perry compile test-files/$t.ts -o /tmp/perry_$t
  done
# All 10 → \"Wrote executable\" with no errors.

$ PERRY_NO_CACHE=1 PERRY_SAVE_LL=/tmp ./target/release/perry compile test-files/test_buffer_small_alloc.ts -o /tmp/x
$ grep \"@llvm.assume\" /tmp/test_buffer_small_alloc_ts.ll | head -2
declare void @llvm.assume(i1)
  call void @llvm.assume(i1 %r43)
```

The `declare void @llvm.assume(i1)` now appears at the top of the emitted IR — pre-fix it was missing and Apple Clang 15 / 16 rejected the call sites that referenced it.

## CI on this PR

The next CI run will exercise the previously-skipped Buffer tests on macos-14 (no skip-list entries → they actually run). If they pass, the bug is confirmed fixed end-to-end. The diagnostic capture infra from PR #239 stays in place as defensive infra — if any of these tests still fail (e.g. for a different reason masked by the previous compile-fail), the artifact will surface the new error.

## Refs

- PR #239 — diagnostic capture infra (independent, low-risk; **revealed the root cause that this PR fixes**)
- v0.5.354 changelog (the misattribution to \"SDK gap\" / \"macOS-15 runner bump\")
- v0.5.183 (#92) — Buffer numeric-read intrinsic that introduced the first `@llvm.assume` call site
- v0.5.190 (#92) — small-buffer slab fast path that added more call sites