### PR TITLE
fix(async): closes #264 — conditional await-return in if/else branches returns wrong value

### DIFF
--- a/crates/perry-transform/src/generator.rs
+++ b/crates/perry-transform/src/generator.rs
@@ -1205,6 +1205,35 @@ fn linearize_body(
                 });
             }
 
+            // return (yield expr)  — i.e. `return await x` after async→generator rewrite
+            // The yield must be emitted as a real yield state so the async-step driver can
+            // await the expression; the continuation state then returns {value: __sent, done: true}
+            // where __sent is the resolved value delivered back by the step driver.
+            Stmt::Return(Some(yield_expr @ Expr::Yield { .. })) => {
+                let yield_val = if let Expr::Yield { value, .. } = yield_expr {
+                    value.as_ref().map(|v| *v.clone()).unwrap_or(Expr::Undefined)
+                } else {
+                    unreachable!()
+                };
+                // Flush pre-return code as a yield state
+                let this_state = *state_num;
+                *state_num += 1;
+                states.push(State {
+                    num: this_state,
+                    body: std::mem::take(current),
+                    exit: StateExit::Yield { value: yield_val, next_state: *state_num },
+                });
+                // Continuation state: return { value: __sent, done: true }
+                current.push(Stmt::Return(Some(make_iter_result(Expr::LocalGet(sent_id), true))));
+                let cont_state = *state_num;
+                *state_num += 1;
+                states.push(State {
+                    num: cont_state,
+                    body: std::mem::take(current),
+                    exit: StateExit::Done,
+                });
+            }
+
             // return expr (terminal - ends the generator)
             Stmt::Return(val) => {
                 // Add the return with {value: expr, done: true} wrapping

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -7,10 +7,6 @@
     "status": "flake",
     "reason": "Same flake family as test_edge_control_flow: failed in parity run 2026-04-25 but passed on isolated re-run with the same binary. Pre-existing, appeared between 2026-04-24 and 2026-04-25 parity runs."
   },
-  "test_edge_promises": {
-    "status": "bug",
-    "reason": "Regression introduced by v0.5.371's async-to-generator transform (#256). Two distinct symptoms: (1) `if (cond) return await Promise.resolve('yes'); else return await Promise.resolve('no');` returns '0'/'0' instead of 'yes'/'no' — the conditional-await-return shape inside the state-machine transform produces wrong value propagation; (2) `await Promise.resolve(42)` deep in a chain returns 0 instead of 42. Same bug class as `test_stress_promises` Promise-constructor entry. Tracked as a v0.5.371 follow-up — the transform's conservative-scope guards (skip if classes have __perry_cap_* markers, skip if closures have non-empty captures) cover the most common patterns but miss this specific conditional-await-return shape."
-  },
   "test_gap_async_advanced": {
     "status": "known_limitation",
     "reason": "Async generators, for-await-of, Promise.allSettled not implemented (segfault)"


### PR DESCRIPTION
## Summary

- Fixes `return await x` inside if/else branches (and similar shapes) returning `0` instead of the awaited value — a regression from v0.5.371's async-to-generator transform.
- Removes `test_edge_promises` from `test-parity/known_failures.json` since the test now passes byte-for-byte against Node.

## Root Cause

The `linearize_body` function in `crates/perry-transform/src/generator.rs` (around line 1208) had a generic `Stmt::Return(val)` arm that handled all return statements by embedding the return value directly into `{value: <expr>, done: true}`. When `return await x` was rewritten by the async-to-generator pre-pass into `return yield x` (i.e. `Stmt::Return(Some(Expr::Yield { value: Some(x) }))`), this generic arm treated the `Expr::Yield` expression itself as the return value. But `Expr::Yield` compiles to `double_literal(0.0)` in codegen (it's only meaningful as a state-machine split point, not a value expression) — so the state machine never actually suspended on the awaited Promise and always returned `{value: 0, done: true}`.

## What Changed

**`crates/perry-transform/src/generator.rs`** — Added a new arm for `Stmt::Return(Some(Expr::Yield { .. }))` **before** the generic `Stmt::Return(val)` arm. The new arm handles `return await x` correctly by:
1. Emitting a real `StateExit::Yield { value: yield_val }` state so the async-step driver can chain `Promise.resolve(x).then(...)` and resume with the resolved value stored in `__sent`.
2. Emitting a continuation state that does `return {value: __sent, done: true}` — returning the awaited result as the function's final value.

**`test-parity/known_failures.json`** — Removed the `test_edge_promises` entry (it now passes).

## Verification

```
$ diff /tmp/node.out /tmp/perry.out
(empty — no diff)
```

All three previously-failing lines now match Node:
- `asyncConditional(true)` → `yes` ✓
- `asyncConditional(false)` → `no` ✓  
- `outerAsync()` → `value=42` ✓

Gap tests: 25/28 baseline preserved (same pre-existing failures: `console_methods` ci-env, `typed_arrays` categorical gap, `array_methods` known limitation).

Closes #264

https://claude.ai/code/session_0145fZh49mzBEQYVyxQMC3Ym

---
_Generated by [Claude Code](https://claude.ai/code/session_0145fZh49mzBEQYVyxQMC3Ym)_