### PR TITLE
fix(console): closes #265 — right-align numeric arrays with Node's groupArrayElements column heuristic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4160,7 +4160,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "atty",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "log",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "base64",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "serde",
  "serde_json",
@@ -4274,11 +4274,11 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.377"
+version = "0.5.375"
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "clap",
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -4324,7 +4324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "base64",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4423,7 +4423,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -4441,11 +4441,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.377"
+version = "0.5.375"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "itoa",
  "jni",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "rand 0.8.5",
  "serde",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "cairo-rs",
  "gtk4",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4496,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4514,11 +4514,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.377"
+version = "0.5.375"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -4573,7 +4573,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.377"
+version = "0.5.375"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/crates/perry-runtime/src/builtins.rs
+++ b/crates/perry-runtime/src/builtins.rs
@@ -460,31 +460,80 @@ fn format_jsvalue(value: f64, depth: usize) -> String {
                     }
                     let maybe_arr = ptr;
                     let length = (*maybe_arr).length as usize;
+                    if length == 0 {
+                        return "[]".to_string();
+                    }
                     let data_ptr = (maybe_arr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const f64;
                     let mut parts: Vec<String> = Vec::with_capacity(length);
+                    let mut all_numeric = true;
                     for i in 0..length {
                         let elem_value = *data_ptr.add(i);
                         let elem_jsval = JSValue::from_bits(elem_value.to_bits());
                         // Quote string elements like Node's util.inspect: 'hello'
                         if elem_jsval.is_any_string() {
+                            all_numeric = false;
                             let s = format_jsvalue(elem_value, depth + 1);
                             parts.push(format!("'{}'", s));
                         } else {
+                            if !elem_jsval.is_number() && !elem_jsval.is_int32() {
+                                all_numeric = false;
+                            }
                             parts.push(format_jsvalue(elem_value, depth + 1));
                         }
                     }
                     let inner = parts.join(", ");
-                    // Node uses multi-line for arrays with >6 elements or >72 chars
-                    if length > 6 || inner.len() > 72 {
-                        let indent = "  ";
-                        let lines: Vec<String> = parts.chunks(4).map(|chunk| {
-                            format!("{}{}", indent, chunk.join(", "))
-                        }).collect();
-                        format!("[\n{}\n]", lines.join(",\n"))
-                    } else if length == 0 {
-                        "[]".to_string()
-                    } else {
+                    // Node uses multi-line when length > 6 or single-line exceeds breakLength (76)
+                    let use_multiline = length > 6 || inner.len() + 4 > 76;
+                    if !use_multiline {
                         format!("[ {} ]", inner)
+                    } else if all_numeric {
+                        // Node.js groupArrayElements for numeric arrays:
+                        // right-align each number to max width, compute per-line
+                        // column count via Node's sqrt heuristic.
+                        let max_len = parts.iter().map(|s| s.len()).max().unwrap_or(1);
+                        // biasedMax = max(maxLength - 2, 1)
+                        let biased_max = max_len.saturating_sub(2).max(1);
+                        // cols_by_sqrt = round(sqrt(2.5 * biasedMax * N) / biasedMax)
+                        let cols_by_sqrt = ((2.5_f64 * biased_max as f64 * length as f64).sqrt()
+                            / biased_max as f64)
+                            .round() as usize;
+                        // cols_by_width = ceil(breakLength / (maxLen + 2)); breakLength=76
+                        let actual_max = max_len + 2;
+                        let cols_by_width = (76 + actual_max - 1) / actual_max;
+                        let columns = cols_by_sqrt
+                            .min(cols_by_width.max(1))
+                            .min(12) // compact(3) * 4
+                            .min(15) // absolute max per Node
+                            .max(1);
+                        let indent = "  ";
+                        let mut lines: Vec<String> = parts
+                            .chunks(columns)
+                            .map(|chunk| {
+                                let elems: Vec<String> = chunk
+                                    .iter()
+                                    .map(|s| format!("{:>width$}", s, width = max_len))
+                                    .collect();
+                                format!("{}{}", indent, elems.join(", "))
+                            })
+                            .collect();
+                        // Trailing comma on every line but the last (Node format)
+                        let n_lines = lines.len();
+                        for line in lines.iter_mut().take(n_lines - 1) {
+                            line.push(',');
+                        }
+                        format!("[\n{}\n]", lines.join("\n"))
+                    } else {
+                        // Non-numeric multi-line: 4 per line, no padding
+                        let indent = "  ";
+                        let mut row_strs: Vec<String> = parts
+                            .chunks(4)
+                            .map(|chunk| format!("{}{}", indent, chunk.join(", ")))
+                            .collect();
+                        let n = row_strs.len();
+                        for line in row_strs.iter_mut().take(n - 1) {
+                            line.push(',');
+                        }
+                        format!("[\n{}\n]", row_strs.join("\n"))
                     }
                 } else if gc_type == crate::gc::GC_TYPE_OBJECT {
                     // Object — check for keys_array. Node's default depth

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -31,10 +31,6 @@
     "status": "skip",
     "reason": "Compile failure — TLS connect not implemented"
   },
-  "test_stress_int_ops": {
-    "status": "bug",
-    "reason": "Console.log array-of-numbers inspection format: Node right-aligns + computes per-line count via util.inspect (`[\n   0,  1,  4,  9, 16,\n  25, 36, 49, 64, 81\n]`); Perry packs without padding 4 per line. NaN/Infinity ToInt32 coercion (`(NaN) | 0`, etc.) was fixed at v0.5.279 — that bug had `is_known_finite` accepting any `Expr::Number(_)` regardless of finite-ness; now checks `n.is_finite()`."
-  },
   "test_gap_console_methods": {
     "status": "ci-env",
     "reason": "Re-added v0.5.294 after the v0.5.290 stub-audit drop turned out to be premature: passes locally through the parity-runner's normalize_output (timer-value variation gets normalized) but fails on macOS-14 CI runners where normalize_output doesn't catch the variant produced. Either the normalize_output rule needs broadening or the test needs more determinism — investigate separately."


### PR DESCRIPTION
## Summary

- Implements Node's `util.inspect` `groupArrayElements` algorithm for all-numeric arrays in `crates/perry-runtime/src/builtins.rs` (`format_jsvalue`, lines 454–520)
- Removes `test_stress_int_ops` from `test-parity/known_failures.json` — it now matches Node byte-for-byte

## Root cause

`format_jsvalue`'s array branch hardcoded `chunks(4)` with no padding:

```rust
// before (wrong)
let lines: Vec<String> = parts.chunks(4).map(|chunk| {
    format!("{}{}", indent, chunk.join(", "))
}).collect();
format!("[\n{}\n]", lines.join(",\n"))
```

Node's `util.inspect` does two things the old code did not:
1. **Right-aligns** each numeric element to `max(toString().length)` using `str.padStart(maxLen)`
2. **Computes per-line column count** via `round(sqrt(2.5 × biasedMax × N) / biasedMax)` capped by `ceil(76 / (maxLen+2))`, `compact×4 = 12`, and 15

For `[0, 1, 4, 9, 16, 25, 36, 49, 64, 81]` (maxLen=2, biasedMax=1, N=10):
- `cols_by_sqrt = round(sqrt(25) / 1) = 5`
- `cols_by_width = ceil(76/4) = 19`
- `columns = min(5, 19, 12, 15) = 5`

## What changed (`crates/perry-runtime/src/builtins.rs`)

- Added `all_numeric` tracking during the element loop (`is_number() || is_int32()` clears on string/pointer/bool/null/undefined/bigint elements).
- When `use_multiline && all_numeric`: apply Node's column formula, right-align via `format!("{:>width$}", s, width=max_len)`, split into rows of `columns`, join rows with `\n` — trailing comma on non-final rows only.
- Non-numeric multi-line path unchanged in behaviour (still 4-per-line), just got the same correct trailing-comma fix.
- Empty-array early return moved before the loop.

## Verification

```
$ diff /tmp/node.out /tmp/perry.out
(empty — byte-for-byte match)
```

Before:
```
squares: [
  0, 1, 4, 9,
  16, 25, 36, 49,
  64, 81
]
```

After (matches Node exactly):
```
squares: [
   0,  1,  4,  9, 16,
  25, 36, 49, 64, 81
]
```

Gap tests: 25 previously-passing tests still pass; the 4 pre-existing known failures (`array_methods`, `async_advanced`, `console_methods`, `typed_arrays`) are unchanged.

Closes #265


---
_Generated by [Claude Code](https://claude.ai/code/session_01KN7BsuyKHYx1haWpp73Rqe)_