### PR TITLE
fix(parity): closes #271 — normalize_output covers macOS-14 variants

### DIFF
--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -146,9 +146,23 @@ normalize_output() {
         sed -E 's/([0-9]+\.[0-9]{10})[0-9]+/\1/g' | \
         # Normalize console.time/timeLog/timeEnd output: the elapsed value
         # will always differ between Node.js (JIT) and Perry (native LLVM).
-        # Strip the numeric portion, keeping only label and unit so both
-        # sides compare as "label: <timer>".
-        sed -E 's/^([^:]+): [0-9]+(\.[0-9]+)?(ms|s)$/\1: <timer>/g' | \
+        # Covers ms, s, and μs (microseconds — emitted on fast macOS-14 ARM
+        # runners when timer duration is < 1 ms, e.g. timerA/timerB in
+        # test_gap_console_methods which have no work between start and end).
+        # The optional [[:space:]]* handles Node.js v18's "N.NNN ms" format
+        # (space before unit); v22 produces "N.NNNms" without.
+        sed -E 's/^([^:]+): [0-9]+(\.[0-9]+)?[[:space:]]*(μs|ms|s)$/\1: <timer>/g' | \
+        # Normalize console.trace output: strip stack frame lines so only
+        # the "Trace: <message>" header survives for comparison.
+        # Node.js emits "    at <symbol> (<location>)" JS stack frames;
+        # Perry emits "    N: <symbol>" native frame headers, indented
+        # "             at <file:line>" continuation lines, and
+        # "        (… N more identical frames)" dedup-collapse lines.
+        # All three shapes have leading whitespace; the distinguishing
+        # suffixes are "at ", a digit+colon, or a literal "(…".
+        sed -E '/^[[:space:]]+at /d' | \
+        sed -E '/^[[:space:]]+[0-9]+: /d' | \
+        sed -E '/^[[:space:]]+[(].*more identical frames[)]/d' | \
         # Remove trailing empty lines
         sed -e :a -e '/^\n*$/{$d;N;ba' -e '}'
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -27,10 +27,6 @@
     "status": "skip",
     "reason": "Compile failure — TLS connect not implemented"
   },
-  "test_gap_console_methods": {
-    "status": "ci-env",
-    "reason": "Re-added v0.5.294 after the v0.5.290 stub-audit drop turned out to be premature: passes locally through the parity-runner's normalize_output (timer-value variation gets normalized) but fails on macOS-14 CI runners where normalize_output doesn't catch the variant produced. Either the normalize_output rule needs broadening or the test needs more determinism — investigate separately."
-  },
   "test_stress_promises": {
     "status": "bug",
     "reason": "Multiple distinct Promise issues remaining after v0.5.283 fix (which addressed (a) microtask FIFO ordering — TASK_QUEUE was a Vec with .pop() → LIFO; switched to VecDeque + pop_front, and (b) `.then(h)` / `.catch(h)` not catching throws inside h — microtask runner now wraps closure call in setjmp): (1) `new Promise<T>((resolve, reject) => ...)` constructor body not running (lines `constructor resolve: 99` / `constructor reject: constructor-err` missing from output); (2) `Promise.any` produces no output (any/any-all-rejected/any-errors-length lines missing); (3) `.then(p => Promise.resolve(...))` doesn't unwrap inner Promise (logs `Promise { <pending> }` instead of resolved value); (4) `.finally(() => ...).then(v => ...)` value-passing wrong (Perry: `finally value: 0`, Node: `finally value: done`)."


### PR DESCRIPTION
## Summary

Two gaps in `normalize_output` (`run_parity_tests.sh`) caused `test_gap_console_methods` to fail on macOS-14 CI runners while passing on local dev machines:

- **Timer unit `μs`**: Node.js emits `timerName: N.NNNμs` (microseconds) for sub-millisecond timers on fast ARM runners. `timerA` and `timerB` have no work between start and end, so on macOS-14 M1/M2 they easily fall below 1 ms. The old regex only matched `ms` and `s`. Extended to also accept `μs` and an optional space before the unit (Node.js v18 produces `N.NNN ms` with a space; v22 produces `N.NNNms` without).

- **`console.trace` stack frames**: Node.js emits JS `    at Object.<anonymous> (file.ts:103:9)` frames; Perry emits native C backtrace frames (`    0: <unknown>`, `    1: __libc_start_call_main`, `        (… N more identical frames)`). Both are runtime-environment noise — the test comment on line 122 explicitly calls this out as a varying format. Three targeted `sed` rules strip all three frame-line shapes, leaving only the `Trace: <message>` header for comparison:
  1. `/^[[:space:]]+at /d` — Node.js JS frames and Perry continuation `at file:line` lines
  2. `/^[[:space:]]+[0-9]+: /d` — Perry native frame headers (`N: <symbol>`)
  3. `/^[[:space:]]+[(].*more identical frames[)]/d` — Perry dedup-collapse lines

## Diff summary

`run_parity_tests.sh` — two additions inside `normalize_output`:
1. Timer `sed` — adds `μs` and `[[:space:]]*` (optional space before unit) to the existing timer regex
2. Three `sed -E` rules that strip trace-frame lines from both Node.js and Perry outputs

`test-parity/known_failures.json` — removes the `test_gap_console_methods` `ci-env` entry.

## Verification

- `test_gap_console_methods` PASS on Linux (Node 22.22.2 + Perry release build): `diff` after normalization is empty
- Simulated macOS-14 μs timer variant (`timerA: 26.000μs`, `timerB: 2.001μs`) normalizes to `<timer>` correctly
- Simulated Node v18 space-before-unit format (`timerA: 26.000 μs`) also normalizes correctly
- `console.group` indented lines (`  inside outer`, `    inside inner`) are NOT affected — none start with `at `, `[0-9]+: `, or `(…`

Closes #271