### PR TITLE
fix(array): closes #267 — Array.isArray() returns true on .map()/.filter() result from any-typed receiver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4160,7 +4160,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "atty",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "log",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "base64",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "serde",
  "serde_json",
@@ -4274,11 +4274,11 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.374"
+version = "0.5.375"
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "clap",
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -4324,7 +4324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "base64",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4423,7 +4423,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -4441,11 +4441,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.374"
+version = "0.5.375"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "itoa",
  "jni",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "rand 0.8.5",
  "serde",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "cairo-rs",
  "gtk4",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4496,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4514,11 +4514,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.374"
+version = "0.5.375"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -4573,7 +4573,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -3191,6 +3191,42 @@ pub unsafe extern "C" fn js_native_call_method(
             return dispatch_buffer_method(raw_ptr, method_name, args_ptr, args_len);
         }
 
+        // Array method dispatch: when the object is a real or lazy array at runtime,
+        // dispatch callback-bearing array methods directly to the array runtime helpers.
+        // This covers the `anyTypedVar.map(fn)` / `anyTypedVar.filter(fn)` pattern where
+        // the HIR lowering conservatively skipped Expr::ArrayMap/Filter because the
+        // receiver's static type was `any` and the method name overlaps with user-class
+        // method names — see the `is_class_overlapping_method` guard in expr_call.rs
+        // (issue #267). The GC type check here ensures we only intercept when the
+        // value is actually an array; user-class instances with a `.map` closure field
+        // fall through to the object-field scan below unchanged.
+        if raw_ptr >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+            let arr_gc_hdr = (raw_ptr as *const u8)
+                .sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+            let arr_obj_type = (*arr_gc_hdr).obj_type;
+            if arr_obj_type == crate::gc::GC_TYPE_ARRAY
+                || arr_obj_type == crate::gc::GC_TYPE_LAZY_ARRAY
+            {
+                match method_name {
+                    "map" if args_len >= 1 && !args_ptr.is_null() => {
+                        let arr = raw_ptr as *const crate::array::ArrayHeader;
+                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
+                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        let result = crate::array::js_array_map(arr, cb_ptr);
+                        return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
+                    }
+                    "filter" if args_len >= 1 && !args_ptr.is_null() => {
+                        let arr = raw_ptr as *const crate::array::ArrayHeader;
+                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
+                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        let result = crate::array::js_array_filter(arr, cb_ptr);
+                        return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
+                    }
+                    _ => {} // not a handled array method — fall through to object dispatch
+                }
+            }
+        }
+
         // Check if this is a native module namespace object (e.g., fs, os, path)
         let obj = jsval.as_pointer::<ObjectHeader>();
         // Validate GcHeader to confirm this is actually an object before reading class_id

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -51,8 +51,4 @@
     "status": "known_limitation",
     "reason": "Categorical typed-array gap documented in CLAUDE.md TypeScript-Parity-Status header (`typed_arrays (categorical gap)`). Perry's TypedArray instance shapes (Int8Array / Uint8Array / Int16Array / Uint16Array / Int32Array / Uint32Array / Float32Array / Float64Array) don't fully cover the prototype surface that JS code expects. Same family as `test_gap_array_methods`'s `.at()` issue. Tracked separately as the broader TypedArray completeness work."
   },
-  "test_json_lazy_predicates": {
-    "status": "bug",
-    "reason": "`Array.isArray()` returns false on the result of `[...].map(fn)` (Perry: `map-result-isArray:false`, Node: `map-result-isArray:true`). The map-returned shape isn't being recognized by the isArray predicate — likely a missing tag check or the map fast path returns a different runtime type than the isArray fast path expects. Distinct from the typed-array gap; affects the hot Array.prototype.map → Array.isArray idiom that lazy-iterator libraries (lodash etc.) lean on."
-  }
 }


### PR DESCRIPTION
## Root cause

When `.map()` or `.filter()` is called on an `any`-typed variable that holds an array at runtime (e.g. the result of `JSON.parse(largeBlob)`), the HIR lowerer conservatively declines to emit `Expr::ArrayMap`/`Expr::ArrayFilter`. The `is_class_overlapping_method` guard in `crates/perry-hir/src/lower/expr_call.rs` (lines 2012–2054) treats `"map"` as a name that can belong to user-class instances, so when the receiver's static type is `any` it skips the array-specific lowering path and falls through to a generic `Expr::Call` → `js_native_call_method`.

`js_native_call_method` in `crates/perry-runtime/src/object.rs` had no handler for `"map"` or `"filter"` on `GC_TYPE_ARRAY` / `GC_TYPE_LAZY_ARRAY` objects. The call fell through the buffer check, then the object check (which requires `GC_TYPE_OBJECT`), and eventually returned `0.0` / null. `Array.isArray(0.0)` → `false`.

## Fix

**`crates/perry-runtime/src/object.rs`** — added an early array-method dispatch block immediately after the buffer-dispatch check in `js_native_call_method` (line ~3194). It reads the GC header `obj_type` of the runtime receiver: when `GC_TYPE_ARRAY` or `GC_TYPE_LAZY_ARRAY`, `"map"` and `"filter"` are routed directly to `js_array_map` / `js_array_filter`. Those helpers call `clean_arr_ptr()` internally, so lazy→real materialization is handled automatically. User-class instances (`GC_TYPE_OBJECT`) are not matched by the type check and fall through to the existing object-field scan unchanged.

**`test-parity/known_failures.json`** — removed the `test_json_lazy_predicates` entry (previously `status: "bug"`).

## Verification

```
# test_json_lazy_predicates.ts — canonical regression test
diff <(node --experimental-strip-types test-files/test_json_lazy_predicates.ts 2>/dev/null) \
     <(./target/release/perry test-files/test_json_lazy_predicates.ts -o /tmp/p && /tmp/p)
# → no diff (PASS)

# Reduced 1-line form
node -e "const r = [1,2,3].map(x=>x*2); console.log(Array.isArray(r));"
# → true
./target/release/perry -e "const r: any = [1,2,3].map((x:any)=>x*2); console.log(Array.isArray(r));"
# → true

# Gap test baseline: 24/24 non-known-failures pass (25/28 including documented known_limitations)
```

Closes #267

---
_Generated by [Claude Code](https://claude.ai/code/session_01FELRiPEsFyCQ4Mckv9UVzN)_