### PR TITLE
feat(parity): closes #274 — wire net echo-server into parity runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4160,7 +4160,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "atty",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "log",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "base64",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "serde",
  "serde_json",
@@ -4274,11 +4274,11 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.374"
+version = "0.5.375"
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "clap",
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -4324,7 +4324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "base64",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4423,7 +4423,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -4441,11 +4441,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.374"
+version = "0.5.375"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "itoa",
  "jni",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "rand 0.8.5",
  "serde",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "cairo-rs",
  "gtk4",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4496,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4514,11 +4514,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.374"
+version = "0.5.375"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -4573,7 +4573,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.374"
+version = "0.5.375"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -4027,13 +4027,14 @@ const NATIVE_MODULE_TABLE: &[NativeModSig] = &[
         runtime: "js_ws_close_client", args: &[NA_F64], ret: NR_VOID },
 
     // ========== Raw TCP sockets (net) + TLS ==========
-    // Factory: `net.createConnection(host, port)` returns a Socket handle.
+    // Factory: `net.createConnection(port, host)` returns a Socket handle.
+    // Argument order matches Node.js: port (number) first, host (string) second.
     // HIR lowering at crates/perry-hir/src/lower.rs registers the return
     // value as class "Socket" so subsequent methods dispatch via the
     // class_filter entries below.
     NativeModSig { module: "net", has_receiver: false, method: "createConnection",
         class_filter: None,
-        runtime: "js_net_socket_connect", args: &[NA_STR, NA_F64], ret: NR_PTR },
+        runtime: "js_net_socket_connect", args: &[NA_F64, NA_STR], ret: NR_PTR },
     NativeModSig { module: "net", has_receiver: true, method: "write",
         class_filter: Some("Socket"),
         runtime: "js_net_socket_write", args: &[NA_PTR], ret: NR_VOID },

--- a/crates/perry-stdlib/src/net/mod.rs
+++ b/crates/perry-stdlib/src/net/mod.rs
@@ -284,15 +284,16 @@ fn build_tls_connector_insecure() -> Result<TlsConnector, String> {
     Ok(TlsConnector::from(Arc::new(config)))
 }
 
-// ─── FFI: net.createConnection(host, port) ───────────────────────────────────
+// ─── FFI: net.createConnection(port, host) ───────────────────────────────────
 
-/// `net.createConnection(host, port)` — returns a handle immediately;
+/// `net.createConnection(port, host)` — returns a handle immediately;
 /// connection happens in the background and emits `'connect'` or `'error'`.
 ///
+/// Argument order matches Node.js: port (number) first, host (string) second.
 /// Signature matches NATIVE_MODULE_TABLE entry
-/// `{ module: "net", method: "createConnection", args: &[NA_STR, NA_F64], ret: NR_PTR }`.
+/// `{ module: "net", method: "createConnection", args: &[NA_F64, NA_STR], ret: NR_PTR }`.
 #[no_mangle]
-pub unsafe extern "C" fn js_net_socket_connect(host_ptr: i64, port: f64) -> i64 {
+pub unsafe extern "C" fn js_net_socket_connect(port: f64, host_ptr: i64) -> i64 {
     let host = match string_from_header_i64(host_ptr) {
         Some(h) => h,
         None => return 0,

--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -77,13 +77,11 @@ SKIP_TESTS=(
     "test_fs"               # fs module needs import
     "test_path"             # path module needs import
     "test_integration_app"  # uses fs module
-    # Network tests — require a live TCP/TLS server on the host. CI runners
-    # don't host one, so these consistently fail with `Connection refused`
-    # against any hard-coded address. Skip in environments where the
-    # server isn't available; both Perry and Node hit the same error so
-    # the diff is just network-noise.
-    "test_net_min"
-    "test_net_socket"
+    # Network tests — test_net_upgrade_tls requires a TLS upgrade server
+    # (separate scope, tracked as #275).  test_tls_connect requires an
+    # outbound internet connection to example.com:443.  Both are skipped
+    # unconditionally.  test_net_min and test_net_socket are handled by
+    # the echo-server lifecycle below and are NOT listed here.
     "test_net_upgrade_tls"
     "test_tls_connect"
     # Timing benchmarks — print Date.now() deltas which differ
@@ -174,6 +172,55 @@ fi
 echo -e "${GREEN}Compiler and runtime built successfully${NC}"
 echo ""
 echo "Running parity tests (backend: $BACKEND_LABEL)..."
+echo ""
+
+# ---------------------------------------------------------------------------
+# Echo server lifecycle (port 17891) — required by test_net_min and
+# test_net_socket.  We spawn it in the background, wait up to 5 s for it to
+# accept connections, and register a cleanup trap so it always gets killed on
+# script exit regardless of how the script terminates.
+# ---------------------------------------------------------------------------
+ECHO_SERVER_PID=""
+ECHO_SERVER_SCRIPT="$SCRIPT_DIR/test-files/test_net_echo_server.py"
+
+start_echo_server() {
+    if ! command -v python3 &>/dev/null; then
+        echo "Warning: python3 not found — test_net_min / test_net_socket will fail parity"
+        return
+    fi
+    if [[ ! -f "$ECHO_SERVER_SCRIPT" ]]; then
+        echo "Warning: $ECHO_SERVER_SCRIPT not found — test_net_min / test_net_socket will fail parity"
+        return
+    fi
+    python3 "$ECHO_SERVER_SCRIPT" &
+    ECHO_SERVER_PID=$!
+    # Poll up to 5 s (50 × 100 ms) for the server to accept connections.
+    local ready=0
+    for _i in $(seq 1 50); do
+        if nc -z 127.0.0.1 17891 2>/dev/null; then
+            ready=1
+            break
+        fi
+        sleep 0.1
+    done
+    if [[ $ready -eq 1 ]]; then
+        echo "Echo server started on 127.0.0.1:17891 (PID $ECHO_SERVER_PID)"
+    else
+        echo "Warning: echo server did not become ready in 5 s — net tests may fail parity"
+    fi
+}
+
+stop_echo_server() {
+    if [[ -n "$ECHO_SERVER_PID" ]]; then
+        kill "$ECHO_SERVER_PID" 2>/dev/null
+        wait "$ECHO_SERVER_PID" 2>/dev/null
+        ECHO_SERVER_PID=""
+    fi
+}
+
+trap stop_echo_server EXIT
+
+start_echo_server
 echo ""
 
 # JSON report data

--- a/test-files/test_net_echo_server.py
+++ b/test-files/test_net_echo_server.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Plain-TCP echo server for Perry parity tests.
+
+Listens on 127.0.0.1:17891 and echoes every received byte back to
+the same client.  Used by test_net_min.ts and test_net_socket.ts.
+
+Usage (from repo root):
+    python3 test-files/test_net_echo_server.py &
+    # ... run net tests ...
+    kill %1
+"""
+import socketserver
+import sys
+
+PORT = 17891
+
+
+class EchoHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        try:
+            while True:
+                data = self.request.recv(4096)
+                if not data:
+                    break
+                self.request.sendall(data)
+        except (ConnectionResetError, BrokenPipeError):
+            pass
+
+
+class ReusableTCPServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+
+if __name__ == "__main__":
+    try:
+        with ReusableTCPServer(("127.0.0.1", PORT), EchoHandler) as server:
+            print(f"echo server listening on 127.0.0.1:{PORT}", flush=True)
+            server.serve_forever()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/test-files/test_net_min.ts
+++ b/test-files/test_net_min.ts
@@ -5,7 +5,7 @@ import * as net from 'net';
 
 console.log('importing net ok');
 
-const sock = net.createConnection('127.0.0.1', 17891);
+const sock = net.createConnection(17891, '127.0.0.1');
 
 console.log('createConnection returned');
 

--- a/test-files/test_net_socket.ts
+++ b/test-files/test_net_socket.ts
@@ -20,7 +20,7 @@ let received = '';
 let seen_connect = false;
 let seen_close = false;
 
-const sock = createConnection(ECHO_HOST, ECHO_PORT);
+const sock = createConnection(ECHO_PORT, ECHO_HOST);
 
 sock.on('connect', () => {
     seen_connect = true;

--- a/test-files/test_net_upgrade_tls.ts
+++ b/test-files/test_net_upgrade_tls.ts
@@ -15,7 +15,7 @@ let received = '';
 let done = false;
 let upgraded = false;
 
-const sock = net.createConnection(HOST, PORT);
+const sock = net.createConnection(PORT, HOST);
 
 sock.on('connect', () => {
     console.log('plain connect ok');

--- a/test-files/test_sock_write_map.ts
+++ b/test-files/test_sock_write_map.ts
@@ -31,7 +31,7 @@ const CONN_MAP = new Map<number, { sock: net.Socket }>();
 let phase = 0;
 let done = false;
 
-const sock = net.createConnection(ECHO_HOST, ECHO_PORT);
+const sock = net.createConnection(ECHO_PORT, ECHO_HOST);
 CONN_MAP.set(1, { sock });
 
 sock.on('connect', () => {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -15,14 +15,6 @@
     "status": "known_limitation",
     "reason": "Async generators, for-await-of, Promise.allSettled not implemented (segfault)"
   },
-  "test_net_min": {
-    "status": "skip",
-    "reason": "Requires live network socket"
-  },
-  "test_net_socket": {
-    "status": "skip",
-    "reason": "Requires live network socket"
-  },
   "test_net_upgrade_tls": {
     "status": "skip",
     "reason": "Requires TLS/network infrastructure"


### PR DESCRIPTION
## Summary

- Add `test-files/test_net_echo_server.py`: a self-contained Python 3 TCP echo server on `127.0.0.1:17891` that echoes every received byte and exits cleanly on SIGINT. Chosen over a Rust crate because Python is always available in CI workers and starts with no build step.
- `run_parity_tests.sh`: add `start_echo_server` / `stop_echo_server` helpers. The runner now spawns the server in the background before the test loop, polls with `nc -z` until the port is ready (up to 5 s), and registers an `EXIT` trap to kill it afterward. Remove `test_net_min` and `test_net_socket` from `SKIP_TESTS`.
- **Fix `net.createConnection` argument order to match Node.js** (`port, host` — not `host, port`). Node.js v22 applies an `isPipeName()` check: if the first arg is a string that isn't a pure decimal number, it's treated as a Unix-socket path. `createConnection('127.0.0.1', 17891)` therefore hits `ENOENT` in Node while Perry connected successfully, making parity impossible until the order is corrected.
  - `crates/perry-codegen/src/lower_call.rs`: dispatch args `[NA_STR, NA_F64]` → `[NA_F64, NA_STR]`
  - `crates/perry-stdlib/src/net/mod.rs`: `js_net_socket_connect(host_ptr, port)` → `js_net_socket_connect(port, host_ptr)` (ABI-safe: int and float occupy separate SysV / AAPCS64 register banks)
  - All four net test files updated: `test_net_min.ts`, `test_net_socket.ts`, `test_net_upgrade_tls.ts`, `test_sock_write_map.ts`
- Remove `test_net_min` and `test_net_socket` from `test-parity/known_failures.json`.

## Test plan

- [x] `test_net_min` — **PASS** in full parity sweep
- [x] `test_net_socket` — **PASS** in full parity sweep
- [x] `test_sock_write_map` — **PASS** (bonus; fixed by the same argument-order change)
- [x] `test_net_upgrade_tls` — still **SKIP** (separate scope, #275)
- [x] `test_tls_connect` — still **SKIP** (separate scope, #270)
- [x] Overall parity rate: **94.9%** (no regressions)

Node.js and Perry now produce identical output with the echo server running:
```
test_net_min:    start / importing net ok / createConnection returned /
                 listeners registered / connect fired / tick 1 / tick 2 / tick 3 / tick 4
test_net_socket: connected / got echo: hello-perry-net / closed / OK
```

Closes #274

https://claude.ai/code/session_01XaHtf4st1UfKgJdcBAhg8D

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaHtf4st1UfKgJdcBAhg8D)_