### PR TITLE
fix(promise): fix 4 bugs from #266 — constructor, any, finally, race ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4160,7 +4160,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "atty",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "log",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "base64",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "serde",
  "serde_json",
@@ -4274,11 +4274,11 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.380"
+version = "0.5.375"
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "clap",
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -4324,7 +4324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "base64",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4423,7 +4423,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -4441,11 +4441,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.380"
+version = "0.5.375"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "itoa",
  "jni",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "rand 0.8.5",
  "serde",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "cairo-rs",
  "gtk4",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4496,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4514,11 +4514,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.380"
+version = "0.5.375"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "block2",
  "libc",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -4573,7 +4573,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.380"
+version = "0.5.375"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -875,10 +875,11 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
                     }
                 }
                 "finally" => {
-                    // .finally(cb) — the callback takes no args and its
-                    // return value is ignored. We pass it as on_fulfilled
-                    // and on_rejected both set to the same closure; the
-                    // runtime handles the "ignore return" semantics.
+                    // .finally(cb) — per spec: call cb() ignoring its return value,
+                    // then propagate the upstream value/reason unchanged.
+                    // Routes through js_promise_finally which wraps cb in
+                    // fulfill/reject proxy closures that call cb() and then
+                    // return the upstream value (or re-throw the upstream reason).
                     if !args.is_empty() {
                         let promise_box = lower_expr(ctx, object)?;
                         let on_finally_box = lower_expr(ctx, &args[0])?;
@@ -887,10 +888,9 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
                         let on_finally_handle = unbox_to_i64(blk, &on_finally_box);
                         let new_promise = blk.call(
                             I64,
-                            "js_promise_then",
+                            "js_promise_finally",
                             &[
                                 (I64, &promise_handle),
-                                (I64, &on_finally_handle),
                                 (I64, &on_finally_handle),
                             ],
                         );

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -791,6 +791,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_promise_resolved", I64, &[DOUBLE]);
     module.declare_function("js_promise_rejected", I64, &[DOUBLE]);
     module.declare_function("js_promise_then", I64, &[I64, I64, I64]);
+    module.declare_function("js_promise_finally", I64, &[I64, I64]);
     module.declare_function("js_promise_all", I64, &[I64]);
     module.declare_function("js_promise_race", I64, &[I64]);
     module.declare_function("js_promise_any", I64, &[I64]);

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -870,11 +870,15 @@ pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
 /// - Async function calls (return type is Promise)
 pub(crate) fn is_promise_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     match e {
-        Expr::LocalGet(id) => matches!(
-            ctx.local_types.get(id),
-            Some(HirType::Promise(_))
-        ),
-        // Promise.resolve / reject / all / race / allSettled
+        Expr::LocalGet(id) => match ctx.local_types.get(id) {
+            Some(HirType::Promise(_)) => true,
+            // `const p: Promise<T> = ...` is lowered as Generic { base: "Promise", ... }
+            // by the HIR when the source annotation is `Promise<T>` rather than the
+            // async-function return inference path (which produces HirType::Promise).
+            Some(HirType::Generic { base, .. }) if base == "Promise" => true,
+            _ => false,
+        },
+        // Promise.resolve / reject / all / race / allSettled / any
         Expr::Call { callee, .. } => match callee.as_ref() {
             Expr::PropertyGet { object, property } => {
                 // `Promise.resolve(...)` etc. — GlobalGet receiver with
@@ -882,7 +886,7 @@ pub(crate) fn is_promise_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
                 if matches!(object.as_ref(), Expr::GlobalGet(_))
                     && matches!(
                         property.as_str(),
-                        "resolve" | "reject" | "all" | "race" | "allSettled"
+                        "resolve" | "reject" | "all" | "race" | "allSettled" | "any"
                     )
                 {
                     return true;

--- a/crates/perry-runtime/src/promise.rs
+++ b/crates/perry-runtime/src/promise.rs
@@ -306,16 +306,178 @@ pub extern "C" fn js_promise_catch(
     js_promise_then(promise, ptr::null(), on_rejected)
 }
 
-/// Register finally callback, returns a new promise for chaining
-/// This is equivalent to .finally(onFinally) in JavaScript
+/// Register finally callback, returns a new promise for chaining.
+/// This is equivalent to .finally(onFinally) in JavaScript.
+///
+/// Per spec, `.finally(cb)` must:
+///   - Call `cb()` (ignoring its return value)
+///   - Propagate the upstream fulfilled VALUE (not cb's return) to `next`
+///   - Re-reject with the upstream rejection REASON if the upstream rejected
+///
+/// The spec (and Node.js) requires `.finally(cb)` to take ONE more microtask
+/// tick than a plain `.then(cb)`.  We achieve this by setting `promise.next =
+/// null` so the microtask runner does NOT resolve `next` after invoking the
+/// wrapper callback — the wrappers resolve `next` themselves, via an extra
+/// `js_promise_then(resolved_promise, passthrough)` hop that adds one queue
+/// entry before `next` settles.
+///
+/// Capture layout for each wrapper: [on_finally, next_promise_ptr]
+/// Capture layout for passthrough closures: [next_promise_ptr, value_or_reason]
 #[no_mangle]
 pub extern "C" fn js_promise_finally(
     promise: *mut Promise,
     on_finally: ClosurePtr,
 ) -> *mut Promise {
-    // For finally, we pass the same callback for both fulfilled and rejected
-    // The finally callback doesn't receive any arguments in JS
-    js_promise_then(promise, on_finally, on_finally)
+    use crate::closure::{js_closure_alloc, js_closure_set_capture_ptr};
+
+    // Create the `next` promise that callers chain off.
+    let next = js_promise_new();
+    let next_i64 = next as i64;
+
+    // Build the fulfilled wrapper: captures [on_finally, next].
+    let fulfill_wrap = js_closure_alloc(finally_fulfill_wrapper as *const u8, 2);
+    js_closure_set_capture_ptr(fulfill_wrap, 0, on_finally as i64);
+    js_closure_set_capture_ptr(fulfill_wrap, 1, next_i64);
+
+    // Build the rejected wrapper: captures [on_finally, next].
+    let reject_wrap = js_closure_alloc(finally_reject_wrapper as *const u8, 2);
+    js_closure_set_capture_ptr(reject_wrap, 0, on_finally as i64);
+    js_closure_set_capture_ptr(reject_wrap, 1, next_i64);
+
+    // Register wrappers on `promise`.  Crucially, set `promise.next = null`
+    // so the microtask runner does NOT attempt to resolve `next` after calling
+    // the wrapper — each wrapper handles `next` settlement itself via the
+    // extra-tick passthrough pattern.
+    unsafe {
+        (*promise).on_fulfilled = fulfill_wrap;
+        (*promise).on_rejected = reject_wrap;
+        (*promise).next = ptr::null_mut(); // wrappers own next; runner must not touch it
+
+        // If the promise is already settled, push its task now.
+        match (*promise).state {
+            PromiseState::Fulfilled => {
+                TASK_QUEUE.with(|q| {
+                    q.borrow_mut().push_back((promise, (*promise).value, true));
+                });
+            }
+            PromiseState::Rejected => {
+                TASK_QUEUE.with(|q| {
+                    q.borrow_mut().push_back((promise, (*promise).reason, false));
+                });
+            }
+            PromiseState::Pending => {}
+        }
+    }
+
+    next
+}
+
+/// Fulfilled-path wrapper for `.finally()`.
+/// Captures [on_finally, next_promise].
+/// Called with the upstream fulfilled `value`.
+/// Runs `on_finally()`, then resolves `next` with `value` via ONE extra
+/// microtask hop (matching Node.js `.finally()` microtask depth).
+extern "C" fn finally_fulfill_wrapper(
+    closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    use crate::closure::{js_closure_alloc, js_closure_get_capture_ptr,
+                         js_closure_set_capture_ptr};
+
+    let on_finally = js_closure_get_capture_ptr(closure, 0)
+        as *const crate::closure::ClosureHeader;
+    let next = js_closure_get_capture_ptr(closure, 1) as *mut Promise;
+
+    // Call the user's finally callback (ignoring its return value).
+    if !on_finally.is_null() {
+        let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+        unsafe { crate::closure::js_closure_call1(on_finally, undef); }
+    }
+
+    // Add one extra microtask tick before settling `next` by registering a
+    // passthrough closure on an already-resolved promise.  The runner will
+    // enqueue it, call it next iteration, and THEN `next` gets resolved.
+    if !next.is_null() {
+        let pass = js_closure_alloc(finally_passthrough_fulfill as *const u8, 2);
+        js_closure_set_capture_ptr(pass, 0, next as i64);
+        crate::closure::js_closure_set_capture_f64(pass, 1, value);
+
+        let undef_promise = js_promise_resolved(f64::from_bits(crate::value::TAG_UNDEFINED));
+        // js_promise_then returns a new (discarded) promise; the side-effect
+        // is enqueuing `pass` to run in the next microtask iteration.
+        js_promise_then(undef_promise, pass, ptr::null());
+    }
+
+    // Return undefined.  Since promise.next is null (set in js_promise_finally),
+    // the runner will not try to resolve anything with this return value.
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// Passthrough closure for the extra hop in finally_fulfill_wrapper.
+/// Captures [next_promise_ptr (i64), value (f64)].
+/// Resolves `next` with `value`.
+extern "C" fn finally_passthrough_fulfill(
+    closure: *const crate::closure::ClosureHeader,
+    _: f64,
+) -> f64 {
+    use crate::closure::{js_closure_get_capture_ptr, js_closure_get_capture_f64};
+    let next = js_closure_get_capture_ptr(closure, 0) as *mut Promise;
+    let value = js_closure_get_capture_f64(closure, 1);
+    if !next.is_null() {
+        js_promise_resolve(next, value);
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// Rejected-path wrapper for `.finally()`.
+/// Captures [on_finally, next_promise].
+/// Called with the upstream rejection `reason`.
+/// Runs `on_finally()`, then rejects `next` with `reason` via ONE extra
+/// microtask hop.
+extern "C" fn finally_reject_wrapper(
+    closure: *const crate::closure::ClosureHeader,
+    reason: f64,
+) -> f64 {
+    use crate::closure::{js_closure_alloc, js_closure_get_capture_ptr,
+                         js_closure_set_capture_ptr};
+
+    let on_finally = js_closure_get_capture_ptr(closure, 0)
+        as *const crate::closure::ClosureHeader;
+    let next = js_closure_get_capture_ptr(closure, 1) as *mut Promise;
+
+    // Call the user's finally callback (ignoring its return value).
+    if !on_finally.is_null() {
+        let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+        unsafe { crate::closure::js_closure_call1(on_finally, undef); }
+    }
+
+    // Add one extra microtask tick before rejecting `next`.
+    if !next.is_null() {
+        let pass = js_closure_alloc(finally_passthrough_reject as *const u8, 2);
+        js_closure_set_capture_ptr(pass, 0, next as i64);
+        crate::closure::js_closure_set_capture_f64(pass, 1, reason);
+
+        let undef_promise = js_promise_resolved(f64::from_bits(crate::value::TAG_UNDEFINED));
+        js_promise_then(undef_promise, pass, ptr::null());
+    }
+
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// Passthrough closure for the extra hop in finally_reject_wrapper.
+/// Captures [next_promise_ptr (i64), reason (f64)].
+/// Rejects `next` with `reason`.
+extern "C" fn finally_passthrough_reject(
+    closure: *const crate::closure::ClosureHeader,
+    _: f64,
+) -> f64 {
+    use crate::closure::{js_closure_get_capture_ptr, js_closure_get_capture_f64};
+    let next = js_closure_get_capture_ptr(closure, 0) as *mut Promise;
+    let reason = js_closure_get_capture_f64(closure, 1);
+    if !next.is_null() {
+        js_promise_reject(next, reason);
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
 }
 
 /// Process all pending promise callbacks (run microtasks)
@@ -951,30 +1113,39 @@ pub extern "C" fn js_promise_race(promises_arr: *const crate::array::ArrayHeader
         return result_promise;
     }
 
-    // For each promise, attach resolve/reject handlers that settle the result promise
+    // For each promise, attach resolve/reject handlers that settle the result promise.
+    // Per the spec, even when an input promise is already settled we MUST route the
+    // resolution through the microtask queue (by registering `.then` handlers) rather
+    // than calling js_promise_resolve synchronously.  The synchronous short-circuit was
+    // causing race / any results to appear too early in the output when compared against
+    // Node's microtask-ordered output.
     for i in 0..count {
         let promise_f64 = js_array_get_f64(promises_arr, i);
         // Discriminate via GC-header obj_type — string/bigint NaN-boxed
         // values would otherwise pass through pointer extraction and crash
         // js_promise_then.
         if js_value_is_promise(promise_f64) == 0 {
-            // Non-promise value — resolve immediately with the value
-            js_promise_resolve(result_promise, promise_f64);
-            return result_promise;
+            // Non-promise value — wrap as an already-resolved promise so the
+            // resolution goes through the normal microtask path.
+            let wrapped = js_promise_resolved(promise_f64);
+            let resolve_closure = js_closure_alloc(
+                promise_race_resolve_handler as *const u8,
+                1,
+            );
+            js_closure_set_capture_ptr(resolve_closure, 0, result_promise as i64);
+            let reject_closure = js_closure_alloc(
+                promise_race_reject_handler as *const u8,
+                1,
+            );
+            js_closure_set_capture_ptr(reject_closure, 0, result_promise as i64);
+            js_promise_then(wrapped, resolve_closure, reject_closure);
+            continue;
         }
         let promise_ptr = js_nanbox_get_pointer(promise_f64) as *mut Promise;
 
-        // Check if already settled — resolve/reject immediately
-        let state = unsafe { (*promise_ptr).state };
-        if matches!(state, PromiseState::Fulfilled) {
-            js_promise_resolve(result_promise, unsafe { (*promise_ptr).value });
-            return result_promise;
-        } else if matches!(state, PromiseState::Rejected) {
-            js_promise_reject(result_promise, unsafe { (*promise_ptr).reason });
-            return result_promise;
-        }
-
-        // Create resolve handler closure (captures result_promise)
+        // Always use js_promise_then even for already-settled promises.
+        // This ensures race resolution goes through the microtask queue,
+        // matching the spec-mandated ordering vs other pending callbacks.
         let resolve_closure = js_closure_alloc(
             promise_race_resolve_handler as *const u8,
             1, // 1 capture: result_promise
@@ -988,7 +1159,8 @@ pub extern "C" fn js_promise_race(promises_arr: *const crate::array::ArrayHeader
         );
         js_closure_set_capture_ptr(reject_closure, 0, result_promise as i64);
 
-        // Attach handlers via then
+        // Attach handlers via then — if the input is already settled this will
+        // push a microtask rather than resolving result_promise synchronously.
         js_promise_then(promise_ptr, resolve_closure, reject_closure);
     }
 


### PR DESCRIPTION
## Summary

Fixes all 4 Promise bugs described in issue #266. `test-files/test_stress_promises.ts` now matches `node --experimental-strip-types` output byte-for-byte (zero diff).

- **Bug 1 — `new Promise((resolve, reject) => ...)` constructor output missing**: `is_promise_expr()` in `type_analysis.rs` didn't recognise `HirType::Generic { base: "Promise", .. }` — the HIR type produced when source has an explicit `Promise<T>` annotation. `p.then(...)` on such variables routed through `js_native_call_method` instead of `js_promise_then`, so the continuation was never registered. Fixed by adding the `Generic { base: "Promise" }` arm.

- **Bug 2 — `Promise.any(...).then(...)` output missing**: `"any"` was absent from `is_promise_expr()`'s static-method list, so the result of `Promise.any(...)` wasn't recognised as a Promise and the chained `.then` was misrouted to `js_native_call_method`. Fixed by adding `"any"` to the list.

- **Bug 3 — `.finally(cb).then(v => ...)` propagates `undefined` instead of upstream value**: Old codegen called `js_promise_then(p, cb, cb)` — using the user callback as both fulfilled and rejected handler. When the microtask runner called `cb()` and it returned `undefined`, it resolved the chained promise with `undefined` rather than the original value. Fixed by introducing a new `js_promise_finally(promise, on_finally)` runtime function (declared in `runtime_decls.rs`) that wraps the user callback in dedicated `finally_fulfill_wrapper` / `finally_reject_wrapper` closures. Each wrapper calls `cb()` (ignoring its return), then schedules a `finally_passthrough_*` closure via `js_promise_then(resolved_undef, pass)` to propagate the upstream value. Setting `promise.next = null` prevents the microtask runner from independently resolving `next` with the wrapper's `undefined` return value. This adds exactly one extra microtask tick, matching Node.js's `.finally()` ordering.

- **Bug 4 — `race resolve` / `race reject` appear too early**: `js_promise_race` had a synchronous early-settle optimisation that called `js_promise_resolve` directly for already-Fulfilled/Rejected inputs, bypassing the microtask queue. This caused race results to appear before other promises registered earlier in the queue. Fixed by removing the synchronous shortcut — always attaches `then` handlers so resolution goes through the queue.

## Files changed

- `crates/perry-runtime/src/promise.rs` — new `js_promise_finally` + 4 helper closures (`finally_fulfill_wrapper`, `finally_passthrough_fulfill`, `finally_reject_wrapper`, `finally_passthrough_reject`); race synchronous shortcut removed
- `crates/perry-codegen/src/lower_call.rs` — `.finally` codegen routes to `js_promise_finally` with 2 args instead of calling `js_promise_then` with 3
- `crates/perry-codegen/src/runtime_decls.rs` — declares `js_promise_finally(I64, I64) -> I64`
- `crates/perry-codegen/src/type_analysis.rs` — `is_promise_expr` recognises `HirType::Generic { base: "Promise" }` and adds `"any"` to static-method list

## Test plan

- [x] `diff <(node --experimental-strip-types test-files/test_stress_promises.ts) <(perry compile + run)` → empty (zero diff)
- [x] Gap test baseline: 24/28 on this machine — same 4 pre-existing known-limitation/ci-env failures (`array_methods`, `async_advanced`, `console_methods`, `typed_arrays` — all in `known_failures.json`), no new regressions

https://claude.ai/code/session_01Mf5P96Ygbbb2XWLcRkJLRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf5P96Ygbbb2XWLcRkJLRn)_