### PR TITLE
feat(ui): wire registerGlobalHotkey codegen + TS surface

### DIFF
--- a/crates/perry-codegen-wasm/src/wasm_runtime.js
+++ b/crates/perry-codegen-wasm/src/wasm_runtime.js
@@ -3093,6 +3093,9 @@ function perry_ui_alert(title, message, buttons, callback) {
 }
 
 // ---------- Keyboard ----------
+function perry_ui_register_global_hotkey(_key, _modifiers, _callback) {
+  // Global hotkeys require OS-level hook APIs not available in a browser context.
+}
 function perry_ui_add_keyboard_shortcut(key, modifiers, callback) {
   document.addEventListener("keydown", (e) => {
     const mods = modifiers || 0;
@@ -3285,7 +3288,7 @@ const __perryUiDispatch = {
   // Dialog
   perry_ui_open_file_dialog, perry_ui_open_folder_dialog, perry_ui_save_file_dialog, perry_ui_alert,
   // Keyboard
-  perry_ui_add_keyboard_shortcut,
+  perry_ui_register_global_hotkey, perry_ui_add_keyboard_shortcut,
   // Sheet
   perry_ui_sheet_create, perry_ui_sheet_present, perry_ui_sheet_dismiss,
   // Toolbar

--- a/crates/perry-dispatch/src/lib.rs
+++ b/crates/perry-dispatch/src/lib.rs
@@ -504,6 +504,10 @@ pub const PERRY_UI_TABLE: &[MethodRow] = &[
     // `modifiers` is a bitfield: 1=Cmd, 2=Shift, 4=Option, 8=Control.
     MethodRow { method: "addKeyboardShortcut", runtime: "perry_ui_add_keyboard_shortcut",
             args: &[ArgKind::Str, ArgKind::F64, ArgKind::Closure], ret: ReturnKind::Void },
+    // System-wide hotkey — fires even when the app is backgrounded.
+    // Real Carbon `RegisterEventHotKey` impl on macOS; no-op stub on all other platforms.
+    MethodRow { method: "registerGlobalHotkey", runtime: "perry_ui_register_global_hotkey",
+            args: &[ArgKind::Str, ArgKind::F64, ArgKind::Closure], ret: ReturnKind::Void },
 
     // ---- App lifecycle hooks ----
     MethodRow { method: "onTerminate", runtime: "perry_ui_app_on_terminate",

--- a/docs/examples/ui/events/snippets.ts
+++ b/docs/examples/ui/events/snippets.ts
@@ -7,7 +7,7 @@ import {
     VStack, HStack, Spacer,
     Text, Button,
     State,
-    addKeyboardShortcut,
+    addKeyboardShortcut, registerGlobalHotkey,
     widgetSetOnClick, widgetSetOnHover, widgetSetOnDoubleClick,
     clipboardRead, clipboardWrite,
     menuCreate, menuAddItem,
@@ -52,6 +52,19 @@ addKeyboardShortcut("s", 3, () => {
     log.set("Save as...")
 })
 // ANCHOR_END: keyboard
+
+// ANCHOR: global-hotkey
+// System-wide: fires even when the app is in the background.
+// macOS: real Carbon RegisterEventHotKey. Other platforms: no-op.
+registerGlobalHotkey("F5", 0, () => {
+    log.set("Global F5 hotkey fired")
+})
+
+// Cmd+Shift+G (modifiers: 1=Cmd + 2=Shift = 3)
+registerGlobalHotkey("g", 3, () => {
+    log.set("Global Cmd+Shift+G fired")
+})
+// ANCHOR_END: global-hotkey
 
 // ANCHOR: menu-shortcut
 const fileMenu = menuCreate()

--- a/docs/src/ui/events.md
+++ b/docs/src/ui/events.md
@@ -52,9 +52,19 @@ Keyboard shortcuts are also available on [menu items](menus.md):
 {{#include ../../examples/ui/events/snippets.ts:menu-shortcut}}
 ```
 
-> **Global hotkeys** (system-wide, fire even when the app is in the background)
-> exist in the macOS runtime FFI but are not yet wired into the cross-platform
-> codegen, so there is no TS-callable surface for them yet.
+### Global Hotkeys
+
+Register a hotkey that fires system-wide, even when the app is in the
+background:
+
+```typescript
+{{#include ../../examples/ui/events/snippets.ts:global-hotkey}}
+```
+
+**Platform support:** macOS uses Carbon `RegisterEventHotKey` (real
+implementation). Linux, Windows, iOS, tvOS, visionOS, watchOS, and Android
+log the registration and no-op — global hotkeys on those platforms require
+OS-level portal / hook APIs that vary per OS.
 
 ## Clipboard
 

--- a/types/perry/ui/index.d.ts
+++ b/types/perry/ui/index.d.ts
@@ -662,6 +662,23 @@ export function addKeyboardShortcut(
     callback: () => void,
 ): void;
 
+/**
+ * Register a system-wide hotkey that fires even when the app is backgrounded.
+ *
+ * **Modifier bits:** `1` = Cmd/Ctrl, `2` = Shift, `4` = Option/Alt, `8` =
+ * Control (macOS only). Combine by adding — `3` = Cmd+Shift, etc.
+ *
+ * **Platform support:**
+ * - macOS — real Carbon `RegisterEventHotKey` implementation.
+ * - Linux / Windows / iOS / tvOS / visionOS / watchOS / Android — logs + no-op;
+ *   global hotkeys require OS-level portal/hook APIs that differ per platform.
+ */
+export function registerGlobalHotkey(
+    key: string,
+    modifiers: number,
+    callback: () => void,
+): void;
+
 // ---------------------------------------------------------------------------
 // App lifecycle hooks
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `crates/perry-dispatch/src/lib.rs:506` — adds `MethodRow { method: "registerGlobalHotkey", runtime: "perry_ui_register_global_hotkey", args: &[Str, F64, Closure], ret: Void }` in the Keyboard shortcuts section; LLVM, JS, and WASM backends pick it up automatically via the existing `ui_method_to_runtime` fallback path.
- `crates/perry-codegen-wasm/src/wasm_runtime.js:3099` — adds no-op browser stub `perry_ui_register_global_hotkey` (global hotkeys unavailable in a browser context) + entry in `__perryUiDispatch`.
- `types/perry/ui/index.d.ts:663` — `registerGlobalHotkey(key, modifiers, cb)` declaration with modifier-bit table and per-platform support note.
- `docs/examples/ui/events/snippets.ts` — adds `registerGlobalHotkey` import + `ANCHOR:global-hotkey` block with two call sites (bare key + modifier combo).
- `docs/src/ui/events.md:55` — replaces the "not yet wired" blockquote with a `### Global Hotkeys` subsection, `{{#include}}` extract, and platform-support matrix.

**Wired vs stubbed:**
| Platform | Status |
|---|---|
| macOS | ✅ Real — Carbon `RegisterEventHotKey` at `perry-ui-macos/src/app.rs:880` |
| GTK4 | ⚠️ Stub — logs "not yet supported (requires X11/Wayland portal)" |
| iOS / tvOS / visionOS / watchOS / Android | ⚠️ No-op stub |
| Windows | ⚠️ Stub — logs + no-op |
| Web / WASM | ⚠️ No-op (global hotkeys not available in browser context) |

No runtime changes needed — all platform stubs already export `perry_ui_register_global_hotkey`.

## Test plan

- [x] `cargo test -p perry-dispatch` — all 5 dispatch drift tests pass (no-duplicate, JS/WASM coverage, resolvability checks)
- [x] `nm snippets_ts.o | grep global_hotkey` → `U perry_ui_register_global_hotkey` — codegen emits the call correctly
- [x] `cargo build --release -p perry-dispatch -p perry` — clean

Closes #276

https://claude.ai/code/session_011fcSuANE7XwQeztLUmxMrC

---
_Generated by [Claude Code](https://claude.ai/code/session_011fcSuANE7XwQeztLUmxMrC)_