### PR TITLE
fix(codegen): closes #221 — module-level array IndexSet writes through extend path

### DIFF
--- a/test-files/test_issue_221_module_array_index_set.ts
+++ b/test-files/test_issue_221_module_array_index_set.ts
@@ -24,13 +24,21 @@
 // return `undefined` for the gap; that's a documented divergence in the
 // runtime helper, not something this fix should change).
 
+// Exact repro from issue body: fill() writes and reads, read() reads only.
 const A: string[] = [];
-function fillA(): void {
+function fill(): void {
   for (let i = 0; i < 5; i = i + 1) {
     A[i] = "v" + i.toString();
   }
+  console.log("[fill] A.length =", A.length, "A[0]=", A[0], "A[2]=", A[2]);
 }
+function read(): void {
+  console.log("[read] A.length =", A.length, "A[0]=", A[0], "A[2]=", A[2]);
+}
+fill();
+read();
 
+// Additional cases:
 const N: number[] = [];
 function fillN(): void {
   for (let i = 0; i < 4; i = i + 1) N[i] = i * 10;
@@ -44,12 +52,10 @@ function fillO(): void {
   for (let i = 0; i < 3; i = i + 1) O[i] = { id: i };
 }
 
-fillA();
 fillN();
 extendM();
 fillO();
 
-console.log("A:", A.length, A[0], A[2], A[4]);
 console.log("N:", N.length, N[0], N[3]);
 console.log("M:", M.length, M[0], M[1], M[5]);
 console.log("O[0].id:", (O[0] as { id: number }).id, "O[2].id:", (O[2] as { id: number }).id);


### PR DESCRIPTION
## Summary

- The codegen fix for `arr[i] = v` silently dropping writes on empty module-level arrays is already present in `crates/perry-codegen/src/expr.rs` (lines 2440–2455): `Expr::IndexSet` routes module-global receivers through `js_array_set_f64_extend` (the realloc-capable variant) and writes the new pointer back to the global slot.
- This PR adds the **exact repro** from the issue body (`fill()` writes + reads back, `read()` reads only after fill) to the existing regression test, making it self-documenting of the failure mode.

## Root cause (already fixed)

**File**: `crates/perry-codegen/src/expr.rs`, `Expr::IndexSet` arm  
**Problem**: module-level array receivers (resolved via `ctx.module_globals`) were routed to `js_array_set_f64` — the bounds-checked variant that returns silently when `index >= length`. For an empty array (length=0), every write at any index dropped silently.  
**Fix**: detect the `module_globals` branch, call `js_array_set_f64_extend` (realloc-capable), and store the returned new pointer back to the global LLVM global slot — symmetric with the stack-local `lower_index_set_fast` path.

## Verification

```
Perry output:
[fill] A.length = 5 A[0]= v0 A[2]= v2
[read] A.length = 5 A[0]= v0 A[2]= v2
N: 4 0 30
M: 6 100 200 999
O[0].id: 0 O[2].id: 2

Node output (byte-for-byte match):
[fill] A.length = 5 A[0]= v0 A[2]= v2
[read] A.length = 5 A[0]= v0 A[2]= v2
N: 4 0 30
M: 6 100 200 999
O[0].id: 0 O[2].id: 2
```

Gap tests: **26/28 passing** (baseline preserved — `console_methods` ci-env diff and `typed_arrays` categorical gap are the known two failures).

## Test plan

- [x] Issue's exact repro compiles and produces correct output
- [x] `arr.length` increments correctly after out-of-bounds writes
- [x] Reads from a separate `read()` function see the written values
- [x] Byte-for-byte match against `node --experimental-strip-types`
- [x] Gap test baseline preserved (26/28)

Closes #221

https://claude.ai/code/session_01Nt1tNC6BkhRcGqELehcMT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nt1tNC6BkhRcGqELehcMT8)_