### PR TITLE
feat(jsx): closes #277 — link-clean _jsx/_jsxs runtime stubs

### DIFF
--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -405,6 +405,29 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
                 ctx.block().call_void("js_gc_collect", &[]);
                 return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
             }
+            // JSX runtime calls: `jsx(type, props)` and `jsxs(type, props)`.
+            // The HIR lowers <div>…</div> to ExternFuncRef { name: "jsx" } and
+            // <div><a/><b/></div> (multiple children) to "jsxs".  The first arg
+            // is the element type (a string literal for HTML tags, or a NaN-boxed
+            // function/class reference for components); the second arg is a
+            // NaN-boxed props object (or TAG_NULL).  Both are passed as DOUBLE so
+            // the ABI is uniform regardless of whether the type arg is a string or
+            // a component reference — avoiding the PTR vs DOUBLE divergence that
+            // the generic ExternFuncRef path would otherwise produce for string
+            // literals.  The runtime stubs `js_jsx`/`js_jsxs` are no-op link
+            // stubs that return TAG_UNDEFINED; real JSX rendering should be
+            // implemented by importing a JSX runtime package (e.g. react or
+            // preact) via the `perry.compilePackages` mechanism.
+            "jsx" | "jsxs" => {
+                let runtime_fn = if name == "jsx" { "js_jsx" } else { "js_jsxs" };
+                let mut lowered: Vec<String> = Vec::with_capacity(args.len());
+                for a in args {
+                    lowered.push(lower_expr(ctx, a)?);
+                }
+                let arg_slices: Vec<(crate::types::LlvmType, &str)> =
+                    lowered.iter().map(|s| (DOUBLE, s.as_str())).collect();
+                return Ok(ctx.block().call(DOUBLE, runtime_fn, &arg_slices));
+            }
             _ => {}
         }
         // perry/system dispatch: map JS names (isDarkMode, getDeviceIdiom,

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -1746,4 +1746,16 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // through `array_from_async_step`.
     module.declare_function("js_object_group_by", DOUBLE, &[DOUBLE, I64]);
     module.declare_function("js_array_from_async", DOUBLE, &[DOUBLE]);
+
+    // ========== JSX runtime stubs (issue #277) ==========
+    // `js_jsx(type, props)` and `js_jsxs(type, props)` are no-op stubs that
+    // let TSX/JSX files compile and link without a real JSX runtime package.
+    // The codegen intercepts ExternFuncRef { name: "jsx" } / "jsxs" in
+    // `lower_call.rs` and routes them here with both args as DOUBLE
+    // (NaN-boxed), bypassing the string→PTR conversion the generic path
+    // would apply to string literals.  When a real JSX runtime is imported
+    // via `perry.compilePackages` the imported symbol takes precedence and
+    // these stubs are never called.
+    module.declare_function("js_jsx", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_jsxs", DOUBLE, &[DOUBLE, DOUBLE]);
 }

--- a/crates/perry-runtime/src/jsx.rs
+++ b/crates/perry-runtime/src/jsx.rs
@@ -1,0 +1,40 @@
+//! JSX runtime stubs (`js_jsx` / `js_jsxs`).
+//!
+//! These are link-clean no-op stubs that let Perry compile and link TSX/JSX
+//! files without a JSX runtime package.  They accept the standard JSX
+//! transform's `(type, props)` arguments (both NaN-boxed as `f64`) and return
+//! `TAG_UNDEFINED`.
+//!
+//! A real JSX implementation (e.g. React, Preact, Solid) should be loaded via
+//! `perry.compilePackages` / `perry/jsruntime`; when a real `jsx` function is
+//! imported and in scope the HIR lowering resolves it to the imported symbol
+//! instead of the bare ExternFuncRef.  These stubs only fire when no runtime
+//! is wired — they make the linker happy and give a defined (rather than
+//! crashing-on-null-dereference) result.
+//!
+//! # ABI note
+//! The codegen in `lower_call.rs` routes `ExternFuncRef { name: "jsx" }` and
+//! `"jsxs"` through a dedicated arm that passes ALL arguments as `double`
+//! (NaN-boxed), bypassing the string→PTR conversion that the generic
+//! ExternFuncRef path would apply to string literals.  Both stubs therefore
+//! take `(f64, f64) -> f64`.  When more args are added in future (e.g. the
+//! optional `key` parameter from the React 17+ transform) the arm and the
+//! stubs should be updated together.
+
+use crate::value::TAG_UNDEFINED;
+
+/// No-op stub for the single-child JSX transform call `jsx(type, props)`.
+///
+/// Returns `TAG_UNDEFINED` as a NaN-boxed `f64`.
+#[no_mangle]
+pub extern "C" fn js_jsx(_type_arg: f64, _props: f64) -> f64 {
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// No-op stub for the multi-child JSX transform call `jsxs(type, props)`.
+///
+/// Returns `TAG_UNDEFINED` as a NaN-boxed `f64`.
+#[no_mangle]
+pub extern "C" fn js_jsxs(_type_arg: f64, _props: f64) -> f64 {
+    f64::from_bits(TAG_UNDEFINED)
+}

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -61,6 +61,7 @@ pub mod child_process;
 pub mod json;
 pub mod json_tape;
 pub mod i18n;
+pub mod jsx;
 pub mod weakref;
 pub mod static_plugins;
 #[cfg(not(feature = "stdlib"))]


### PR DESCRIPTION
## Summary

- TSX/JSX files previously failed at link time with `undefined reference to 'jsx'` because the HIR lowers every JSX element to `ExternFuncRef { name: "jsx" }` / `"jsxs"` calls with no corresponding symbol in any linked library.
- Implements **Path B** (link-clean stubs): add `js_jsx`/`js_jsxs` no-op stubs to `perry-runtime` and intercept the `"jsx"`/`"jsxs"` ExternFuncRef names in codegen to route to them with a uniform `(double, double) -> double` ABI.
- Does **not** bump version in `Cargo.toml` or add a `Recent Changes` entry to `CLAUDE.md` — maintainer folds that in at merge time.

## Changes

| File | What changed |
|------|-------------|
| `crates/perry-runtime/src/jsx.rs` | New file: `js_jsx(f64, f64) -> f64` and `js_jsxs(f64, f64) -> f64` no-op stubs returning `TAG_UNDEFINED` |
| `crates/perry-runtime/src/lib.rs` | `pub mod jsx;` registration |
| `crates/perry-codegen/src/lower_call.rs` | `"jsx" \| "jsxs"` match arms in the ExternFuncRef handler (line ~404) — route to `js_jsx`/`js_jsxs` with all args as `DOUBLE`, bypassing the `is_string_expr → PTR` conversion that would otherwise make the ABI non-uniform between HTML-tag strings and component function references |
| `crates/perry-codegen/src/runtime_decls.rs` | `declare_function("js_jsx", DOUBLE, &[DOUBLE, DOUBLE])` + same for `js_jsxs` in `declare_phase_all` |

## ABI rationale

Without the codegen intercept, `<div>hello</div>` would emit `jsx(ptr, double)` (first arg promoted to `PTR` because `"div"` is a string literal), while `<MyComp />` would emit `jsx(double, double)` (first arg is a `FuncRef`, not a string). Two different IR declarations for the same symbol → LLVM error or silent ABI mismatch. The intercept forces `(double, double)` in both cases, matching the stub's signature exactly.

## Test plan

- [x] `printf 'const App = () => <div>hello</div>;\n' > /tmp/jsx_test.tsx && perry compile /tmp/jsx_test.tsx -o /tmp/out && /tmp/out` — exits 0 (was: `undefined reference to 'jsx'`)
- [x] JSX with component reference first arg (`<MyComp name="world" />`) — compiles and links
- [x] JSX fragment `<>…</>` (triggers `jsxs`) — compiles, links, runs, prints `JSX compiled OK`
- [x] `cargo test --workspace --exclude perry-jsruntime` — all 434 tests pass, 0 failures

## Follow-up note

The stubs return `TAG_UNDEFINED` — real JSX rendering requires wiring a JSX runtime (React, Preact, etc.) via `perry.compilePackages`. That is orthogonal to this fix; the stubs make the linker happy and give a defined result for unrouted JSX expressions.

https://claude.ai/code/session_01FetQUsDywFmjyt4GwzXzv1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FetQUsDywFmjyt4GwzXzv1)_