### PR TITLE
feat(windows): #303 Win7 / Win8 compatibility via --min-windows-version

### DIFF
--- a/INSTRUCTIONS-TO-WIN-AGENT.md
+++ b/INSTRUCTIONS-TO-WIN-AGENT.md
@@ -1,0 +1,294 @@
+# Instructions: validate Perry's Win7 compatibility fix on Windows
+
+> **You are running on a Windows 11 PowerShell session.** Your job is to verify that issue #303 (Perry executables refusing to start on Windows 7) is correctly resolved by the changes on branch `issue-303-windows-7`. The fix has two parts: (a) a `--min-windows-version=7` CLI flag that emits the Win7-compatible PE subsystem marker, and (b) lazy `LoadLibraryW + GetProcAddress` resolution of the Win10-only DPI APIs, replacing the static imports that caused Win7's loader to refuse the process before `main()` ran.
+>
+> **You don't need a Windows 7 machine to do most of this work.** Steps 1–5 give 80% confidence that the fix is correct via static PE analysis on Win11. Step 6 is optional and only relevant if a Win7 SP1 VM happens to be available.
+>
+> If anything in this document is unclear or doesn't match what you observe, **stop and report back** with the exact command output. Do not improvise around unexpected results — they're the most important data point.
+
+---
+
+## What "success" looks like at a glance
+
+After running through this doc you'll have:
+
+1. A built `perry.exe` from the `issue-303-windows-7` branch.
+2. Two compiled test executables: `hello-win7.exe` (CLI) and `ui-win7.exe` (UI).
+3. `dumpbin /headers` confirming both binaries declare PE subsystem version `5.01` (= Win7-compatible).
+4. `dumpbin /imports` confirming neither binary lists `SetProcessDpiAwarenessContext` or `GetDpiForSystem` in its `user32.dll` import table — they're resolved at runtime instead.
+5. Both binaries running cleanly on Win11 (sanity check — Win11 should be the easy case).
+
+If all five pass, the fix is correct. If a Win7 VM is available, step 6 confirms end-to-end.
+
+---
+
+## Prerequisites
+
+Confirm these exist (open PowerShell, paste each one, expect non-error output):
+
+```powershell
+git --version
+rustc --version    # need 1.75+
+cargo --version
+```
+
+For PE inspection, you need either Visual Studio Build Tools' `dumpbin.exe` (if you used Option B during `perry setup windows`) or LLVM's `llvm-objdump.exe` (if you used Option A — `winget install LLVM.LLVM`). **Either works.** Test:
+
+```powershell
+# Try dumpbin first (it's the standard MSVC tool)
+dumpbin
+
+# If that fails with "command not found", try LLVM
+llvm-objdump --version
+```
+
+Note which one is available — examples below show `dumpbin` first; substitute the equivalent `llvm-objdump` form if needed (commands documented inline at each step).
+
+If neither is available, install LLVM: `winget install LLVM.LLVM`. After install, open a fresh PowerShell so PATH picks up the new tool.
+
+---
+
+## Step 1 — Clone or update the repo to the Win7 branch
+
+```powershell
+# If you don't have a clone yet:
+git clone https://github.com/PerryTS/perry.git
+cd perry
+
+# Or if you already have one:
+cd perry
+git fetch origin
+git checkout issue-303-windows-7
+git pull --ff-only
+```
+
+Confirm you're on the right branch:
+
+```powershell
+git branch --show-current
+# Expected: issue-303-windows-7
+
+git log -1 --oneline
+# Expected first line should reference: feat(windows): #303 Win7 / Win8 compatibility
+```
+
+---
+
+## Step 2 — Build perry from this branch
+
+```powershell
+cargo build --release -p perry-runtime -p perry-stdlib -p perry-ui-windows -p perry
+```
+
+Expected: builds clean. If you get **errors** (not warnings), stop and report them back verbatim. If you get the standard 40-ish unused-code warnings that the codebase carries, that's fine — keep going.
+
+The compiled `perry.exe` lands at `target\release\perry.exe`. Confirm:
+
+```powershell
+.\target\release\perry.exe --version
+```
+
+Expected: prints a version string near `0.5.395`.
+
+Confirm the new flag is wired in:
+
+```powershell
+.\target\release\perry.exe compile --help | Select-String "min-windows-version" -Context 0,5
+```
+
+Expected: shows `--min-windows-version <MIN_WINDOWS_VERSION>` and a few lines of doc text mentioning Win7 / Win8 / `,5.1` / `,6.02`. If this output is missing, the build picked up old code — stop and report back.
+
+---
+
+## Step 3 — Compile two test programs targeting Win7
+
+Pick a clean directory anywhere outside the perry repo to avoid polluting the workspace:
+
+```powershell
+$test_dir = "$env:TEMP\perry-win7-test"
+New-Item -ItemType Directory -Force -Path $test_dir | Out-Null
+cd $test_dir
+
+# CLI smoke — proves the runtime + stdlib link cleanly with --min-windows-version=7
+'console.log("hello win7");' | Set-Content hello.ts
+
+# UI smoke — proves the lazy DPI-resolution path works (this is the actual fix)
+@"
+App({
+    title: "Win7 Smoke Test",
+    body: VStack([
+        Text("Issue #303"),
+        Button("OK", () => {})
+    ])
+});
+"@ | Set-Content ui.ts
+```
+
+Build each one with `--min-windows-version=7`:
+
+```powershell
+$perry = "C:\path\to\perry\target\release\perry.exe"  # ← adjust to your actual path
+& $perry compile hello.ts -o hello-win7.exe --min-windows-version=7
+& $perry compile ui.ts -o ui-win7.exe --min-windows-version=7
+```
+
+Expected: each prints a short progress summary and produces a `.exe` (typically 1-3 MB for `hello-win7.exe` and 4-6 MB for `ui-win7.exe`). If either fails, stop and report the error.
+
+Also build the **default** (Win10+) variants for comparison — these should still work and produce different headers:
+
+```powershell
+& $perry compile hello.ts -o hello-default.exe
+& $perry compile ui.ts -o ui-default.exe
+```
+
+---
+
+## Step 4 — Static PE check 1: subsystem version
+
+This is the headline check. The PE subsystem version field tells the OS loader the minimum Windows version the binary claims to support. Win7 = `5.01`, Win8 = `6.02`, default = whatever the linker picks (typically `6.00` or higher).
+
+### Using `dumpbin` (MSVC):
+
+```powershell
+Write-Host "--- ui-win7.exe (expect 5.01 subsystem version) ---"
+dumpbin /headers ui-win7.exe | Select-String -Pattern "subsystem version|subsystem \("
+
+Write-Host "--- hello-win7.exe (expect 5.01 subsystem version) ---"
+dumpbin /headers hello-win7.exe | Select-String -Pattern "subsystem version|subsystem \("
+
+Write-Host "--- ui-default.exe (expect 6.00 or higher) ---"
+dumpbin /headers ui-default.exe | Select-String -Pattern "subsystem version|subsystem \("
+```
+
+### Or using `llvm-objdump`:
+
+```powershell
+Write-Host "--- ui-win7.exe ---"
+llvm-objdump -p ui-win7.exe | Select-String -Pattern "MajorOSVersion|MinorOSVersion|MajorSubsystemVersion|MinorSubsystemVersion"
+
+Write-Host "--- hello-win7.exe ---"
+llvm-objdump -p hello-win7.exe | Select-String -Pattern "MajorOSVersion|MinorOSVersion|MajorSubsystemVersion|MinorSubsystemVersion"
+```
+
+### Expected (dumpbin form):
+
+```
+--- ui-win7.exe (expect 5.01 subsystem version) ---
+            5.01 subsystem version
+               2 subsystem (Windows GUI)
+--- hello-win7.exe (expect 5.01 subsystem version) ---
+            5.01 subsystem version
+               3 subsystem (Windows CUI)
+--- ui-default.exe (expect 6.00 or higher) ---
+            6.00 subsystem version
+               2 subsystem (Windows GUI)
+```
+
+(The default may be `6.00` or `6.02` or even `10.00` depending on the linker — anything ≥ `6.00` is "not Win7" and proves the flag is doing something different.)
+
+### What this tells us
+
+- If both `*-win7.exe` files show **`5.01`**, the linker subsystem flag is being emitted correctly. ✅
+- If they show `6.00` or higher, the `--min-windows-version=7` flag is being silently ignored — **stop and report**. The fix is broken at the linker layer.
+
+---
+
+## Step 5 — Static PE check 2: imports table
+
+This is the more important check. The pre-fix code statically imported `SetProcessDpiAwarenessContext` and `GetDpiForSystem` from `user32.dll`. Those imports cause the Win7 loader to refuse the binary before `main()` runs. The fix replaces them with `LoadLibraryW + GetProcAddress`, so the **import table must not contain those names** anywhere — they're loaded lazily.
+
+### Using `dumpbin`:
+
+```powershell
+Write-Host "--- ui-win7.exe imports (expect NO matches below) ---"
+dumpbin /imports ui-win7.exe | Select-String -Pattern "SetProcessDpiAwarenessContext|GetDpiForSystem"
+
+Write-Host "--- hello-win7.exe imports (expect NO matches below) ---"
+dumpbin /imports hello-win7.exe | Select-String -Pattern "SetProcessDpiAwarenessContext|GetDpiForSystem"
+```
+
+### Or using `llvm-objdump`:
+
+```powershell
+Write-Host "--- ui-win7.exe imports ---"
+llvm-objdump -p ui-win7.exe | Select-String -Pattern "SetProcessDpiAwarenessContext|GetDpiForSystem"
+
+Write-Host "--- hello-win7.exe imports ---"
+llvm-objdump -p hello-win7.exe | Select-String -Pattern "SetProcessDpiAwarenessContext|GetDpiForSystem"
+```
+
+### Expected
+
+**No output** for either binary. The pattern shouldn't match.
+
+Also confirm the lazy loaders ARE present (sanity check that user32 / gdi32 are still being imported, just for the harmless functions):
+
+```powershell
+Write-Host "--- ui-win7.exe should import LoadLibraryA, GetProcAddress, SetProcessDPIAware (Vista+, fine) ---"
+dumpbin /imports ui-win7.exe | Select-String -Pattern "LoadLibraryA|GetProcAddress|SetProcessDPIAware|GetDeviceCaps"
+```
+
+Expected: shows hits for at least `LoadLibraryA`, `GetProcAddress`, and `GetDeviceCaps` (and ideally `SetProcessDPIAware`). All four are Vista+ exports that ship on every supported Windows.
+
+### What this tells us
+
+- If `SetProcessDpiAwarenessContext` / `GetDpiForSystem` are **absent** from the import table, the lazy retrofit is taking effect. ✅ **This is the most important check in the whole document.**
+- If either name appears, somebody (you, a future change, or a transitive dependency) re-introduced a static import. The Win7 loader will refuse the binary. **Stop and report**.
+
+---
+
+## Step 6 — Optional: actually run on a Win7 VM
+
+This step requires a Windows 7 SP1 VM. You can skip this if you don't have one — steps 4 and 5 give very high confidence on their own. If you do have a VM:
+
+1. Copy `hello-win7.exe` and `ui-win7.exe` into the VM (shared folder, USB, network share, doesn't matter).
+2. Open `cmd` or PowerShell in the VM and run `hello-win7.exe`. Expected: prints `hello win7` and exits cleanly. **Pre-fix this would die immediately with a dialog that says "the procedure entry point SetProcessDpiAwarenessContext could not be located in the dynamic link library user32.dll" — the binary never reaches `main()`.**
+3. Double-click `ui-win7.exe`. Expected: a window opens with the title "Win7 Smoke Test" and shows the text "Issue #303" + an "OK" button. The window may look slightly different from Win11 (no rounded corners, different titlebar style, possibly fuzzier on hi-DPI displays — that's expected and documented in `docs/src/platforms/windows-7.md`).
+4. Click the OK button — it should not crash, even though the click handler is empty.
+5. Close the window — the process should exit cleanly.
+
+If any of these fail, capture:
+- The exact error message (screenshot if it's a dialog, copy-paste if it's text)
+- The Windows 7 build number (run `winver` in the VM)
+- The output of `dumpbin` from steps 4 & 5 (run on Win11 against the same .exe files)
+
+---
+
+## Step 7 — Run on Win11 too (sanity)
+
+The fix should not regress Win11 behavior. Run both `*-win7.exe` and `*-default.exe` on the Win11 machine and confirm all four work:
+
+```powershell
+.\hello-win7.exe
+.\hello-default.exe
+.\ui-win7.exe
+.\ui-default.exe
+```
+
+Expected: all four behave identically. The `*-win7.exe` versions may render windows slightly less crisp on hi-DPI displays compared to `*-default.exe` (the lazy DPI path can fall through one extra tier on some Win11 configurations) but otherwise function identically. UI windows should open cleanly, accept clicks, and close without crashing.
+
+---
+
+## What to report back
+
+A single message containing:
+
+1. **Step 4 output** — the literal `dumpbin` / `llvm-objdump` output for all three (or four) binaries, copy-pasted.
+2. **Step 5 output** — confirmation that the negative grep produced no matches, plus the LoadLibrary / GetProcAddress / SetProcessDPIAware import confirmation.
+3. **Step 7 results** — "all four ran cleanly on Win11" or specifics if anything misbehaved.
+4. **Step 6 results if applicable** — Win7 VM build number + UI screenshot.
+5. **Anything unexpected** — error messages, crashes, build warnings that look related, anything that seemed off. Better too much info than too little.
+
+If steps 4 and 5 both pass, mark this as ✅ ready-to-merge. If either fails, mark as ❌ and include the failing output.
+
+---
+
+## Cleanup (optional)
+
+After validating:
+
+```powershell
+Remove-Item -Recurse -Force $env:TEMP\perry-win7-test
+```
+
+The branch can stay checked out — there's no follow-up work pending. Once it's merged into `main`, the Windows-side bits will be exercised by every future build automatically.

--- a/crates/perry-ui-windows/src/app.rs
+++ b/crates/perry-ui-windows/src/app.rs
@@ -18,11 +18,15 @@ use windows::Win32::UI::Controls::ICC_STANDARD_CLASSES;
 #[cfg(target_os = "windows")]
 use windows::Win32::UI::Controls::INITCOMMONCONTROLSEX;
 #[cfg(target_os = "windows")]
-use windows::Win32::UI::HiDpi::SetProcessDpiAwarenessContext;
-#[cfg(target_os = "windows")]
-use windows::Win32::UI::HiDpi::DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2;
-#[cfg(target_os = "windows")]
 use windows::Win32::UI::WindowsAndMessaging::*;
+// NOTE: SetProcessDpiAwarenessContext + GetDpiForSystem are deliberately NOT
+// imported from `windows::Win32::UI::HiDpi` here. Hard-importing them produces
+// link-time IAT entries that the OS resolves before main() runs. On Win7 those
+// exports don't exist → the loader fails the process with "entry point not
+// found in user32.dll" before any Rust code runs. For #303 we need the binary
+// to start on Win7, so the Win10 DPI APIs are resolved lazily via
+// LoadLibraryW + GetProcAddress in `crate::dpi_compat`. See
+// `docs/src/platforms/windows-7.md`.
 
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
@@ -42,20 +46,14 @@ const TEST_EXIT_TIMER_ID: usize = 9997;
 static DPI_SCALE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Get the system DPI for the primary monitor.
+///
+/// Routes through `crate::dpi_compat::get_system_dpi_compat`, which uses
+/// `GetDpiForSystem` (Win10 1607+) when available and falls back to
+/// `GetDC + GetDeviceCaps` (Win2000+) on older systems including Win7. See
+/// `dpi_compat.rs` for why this can't be a hard import (issue #303).
 #[cfg(target_os = "windows")]
 fn get_system_dpi() -> u32 {
-    unsafe {
-        // GetDpiForSystem requires Windows 10 1607+
-        extern "system" {
-            fn GetDpiForSystem() -> u32;
-        }
-        let dpi = GetDpiForSystem();
-        if dpi > 0 {
-            dpi
-        } else {
-            96
-        }
-    }
+    crate::dpi_compat::get_system_dpi_compat()
 }
 
 /// Store the DPI scale factor for use by font/widget sizing.
@@ -158,8 +156,9 @@ pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
     #[cfg(target_os = "windows")]
     {
         unsafe {
-            // Enable DPI awareness
-            let _ = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+            // Enable DPI awareness — Win10 1607+ best, Win8.1 ok, Win7 silent
+            // fallback to system DPI. See dpi_compat.rs (issue #303).
+            crate::dpi_compat::set_process_dpi_awareness_compat();
 
             // Scale window size by system DPI (96 = 100%, 144 = 150%, 192 = 200%)
             let dpi = get_system_dpi();

--- a/crates/perry-ui-windows/src/dpi_compat.rs
+++ b/crates/perry-ui-windows/src/dpi_compat.rs
@@ -1,0 +1,211 @@
+//! Runtime-resolved DPI APIs with Windows 7 fallbacks.
+//!
+//! Issue #303: Perry-compiled UI executables must start on Windows 7 SP1.
+//! The two DPI primitives we want — `SetProcessDpiAwarenessContext` (Win10 1607)
+//! and `GetDpiForSystem` (Win10 1607) — don't exist on Win7. Hard-importing
+//! them via `extern "system" { fn ... }` or via the `windows` crate's
+//! `windows::Win32::UI::HiDpi::*` re-exports causes link-time IAT entries that
+//! the OS loader resolves BEFORE `main()` runs. On Win7 the loader fails the
+//! process with "entry point not found in user32.dll" — there is no Rust code
+//! we can write inside the binary that helps, because the failure happens
+//! before Rust starts.
+//!
+//! Fix: resolve the Win10 functions lazily via `LoadLibraryW("user32.dll") +
+//! GetProcAddress(...)`. If the symbol is present (Win10 1607+), call it.
+//! Otherwise fall back through the version chain:
+//!
+//! | API used | Quality | Min Windows |
+//! |---|---|---|
+//! | `SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)` | Best (per-monitor v2) | Win10 1607 |
+//! | `SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)` | Per-monitor v1 | Win8.1 |
+//! | `SetProcessDPIAware()` | System-wide DPI only | Vista |
+//!
+//! For DPI lookup:
+//!
+//! | API used | Min Windows |
+//! |---|---|
+//! | `GetDpiForSystem()` | Win10 1607 |
+//! | `GetDC(NULL) + GetDeviceCaps(LOGPIXELSY)` | Win2000+ (always works) |
+//!
+//! Resolved fn pointers are cached in `AtomicPtr`s so we pay the LoadLibrary +
+//! GetProcAddress cost exactly once per process. After the cache is warm the
+//! cost is one atomic load + one indirect call per DPI query.
+//!
+//! See `docs/src/platforms/windows-7.md` for the user-facing story.
+
+#![cfg(target_os = "windows")]
+
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicPtr, AtomicU8, Ordering};
+
+const STATE_UNRESOLVED: u8 = 0;
+const STATE_AVAILABLE: u8 = 1;
+const STATE_MISSING: u8 = 2;
+
+static SET_DPI_AWARENESS_CONTEXT_STATE: AtomicU8 = AtomicU8::new(STATE_UNRESOLVED);
+static SET_DPI_AWARENESS_CONTEXT_FN: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
+
+static SET_PROCESS_DPI_AWARENESS_STATE: AtomicU8 = AtomicU8::new(STATE_UNRESOLVED);
+static SET_PROCESS_DPI_AWARENESS_FN: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
+
+static GET_DPI_FOR_SYSTEM_STATE: AtomicU8 = AtomicU8::new(STATE_UNRESOLVED);
+static GET_DPI_FOR_SYSTEM_FN: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
+
+#[link(name = "user32")]
+extern "system" {
+    fn LoadLibraryA(lpLibFileName: *const u8) -> *mut c_void;
+    fn GetProcAddress(hModule: *mut c_void, lpProcName: *const u8) -> *mut c_void;
+    fn SetProcessDPIAware() -> i32;
+    fn GetDC(hWnd: *mut c_void) -> *mut c_void;
+    fn ReleaseDC(hWnd: *mut c_void, hDC: *mut c_void) -> i32;
+}
+
+#[link(name = "gdi32")]
+extern "system" {
+    fn GetDeviceCaps(hdc: *mut c_void, index: i32) -> i32;
+}
+
+/// `GetDeviceCaps` index for vertical DPI. Win2000+, dead reliable.
+const LOGPIXELSY: i32 = 90;
+
+static SHCORE_HANDLE: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
+static SHCORE_RESOLVED: AtomicU8 = AtomicU8::new(STATE_UNRESOLVED);
+
+unsafe fn user32() -> *mut c_void {
+    LoadLibraryA(b"user32.dll\0".as_ptr())
+}
+
+unsafe fn shcore() -> *mut c_void {
+    let cached = SHCORE_HANDLE.load(Ordering::Acquire);
+    if !cached.is_null() {
+        return cached;
+    }
+    if SHCORE_RESOLVED.load(Ordering::Acquire) == STATE_MISSING {
+        return std::ptr::null_mut();
+    }
+    let h = LoadLibraryA(b"shcore.dll\0".as_ptr());
+    if h.is_null() {
+        SHCORE_RESOLVED.store(STATE_MISSING, Ordering::Release);
+    } else {
+        SHCORE_HANDLE.store(h, Ordering::Release);
+        SHCORE_RESOLVED.store(STATE_AVAILABLE, Ordering::Release);
+    }
+    h
+}
+
+unsafe fn resolve_fn(
+    module: *mut c_void,
+    symbol: &[u8],
+    state: &AtomicU8,
+    slot: &AtomicPtr<c_void>,
+) -> Option<*mut c_void> {
+    match state.load(Ordering::Acquire) {
+        STATE_AVAILABLE => Some(slot.load(Ordering::Acquire)),
+        STATE_MISSING => None,
+        _ => {
+            if module.is_null() {
+                state.store(STATE_MISSING, Ordering::Release);
+                return None;
+            }
+            let proc = GetProcAddress(module, symbol.as_ptr());
+            if proc.is_null() {
+                state.store(STATE_MISSING, Ordering::Release);
+                None
+            } else {
+                slot.store(proc, Ordering::Release);
+                state.store(STATE_AVAILABLE, Ordering::Release);
+                Some(proc)
+            }
+        }
+    }
+}
+
+/// Best-effort DPI awareness opt-in. Tries Win10 1607 → Win8.1 → Vista in
+/// order. DPI awareness is a hint, not a hard requirement — a process that
+/// fails to opt in just runs at logical 96 DPI with the OS bitmap-scaling,
+/// which looks fuzzy on hi-DPI displays but functions correctly. Never
+/// panics, returns nothing.
+pub fn set_process_dpi_awareness_compat() {
+    unsafe {
+        // Tier 1: Win10 1607+ — SetProcessDpiAwarenessContext in user32.
+        let user32 = user32();
+        if let Some(proc) = resolve_fn(
+            user32,
+            b"SetProcessDpiAwarenessContext\0",
+            &SET_DPI_AWARENESS_CONTEXT_STATE,
+            &SET_DPI_AWARENESS_CONTEXT_FN,
+        ) {
+            // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = -4 cast to handle.
+            // The exact value is a stable Win10 ABI contract.
+            type SetCtxFn = unsafe extern "system" fn(*mut c_void) -> i32;
+            let f: SetCtxFn = std::mem::transmute(proc);
+            let ctx_v2 = -4isize as *mut c_void;
+            if f(ctx_v2) != 0 {
+                return;
+            }
+            // If v2 was rejected (rare — only on builds where the symbol
+            // exists but the v2 constant doesn't, e.g. Win10 1607 exact),
+            // fall through to tier 2.
+        }
+
+        // Tier 2: Win8.1+ — SetProcessDpiAwareness in shcore.
+        let shcore = shcore();
+        if let Some(proc) = resolve_fn(
+            shcore,
+            b"SetProcessDpiAwareness\0",
+            &SET_PROCESS_DPI_AWARENESS_STATE,
+            &SET_PROCESS_DPI_AWARENESS_FN,
+        ) {
+            // PROCESS_PER_MONITOR_DPI_AWARE = 2
+            type SetAwarenessFn = unsafe extern "system" fn(i32) -> i32;
+            let f: SetAwarenessFn = std::mem::transmute(proc);
+            // HRESULT: S_OK = 0. Anything else means failure or already-set
+            // by a manifest entry — either way, don't fall through further.
+            if f(2) == 0 {
+                return;
+            }
+        }
+
+        // Tier 3: Vista+ — SetProcessDPIAware in user32 (always present
+        // since Vista, hard-imported above). System-wide DPI only.
+        let _ = SetProcessDPIAware();
+    }
+}
+
+/// System DPI in dots-per-inch. 96 = 100% scaling, 144 = 150%, 192 = 200%.
+///
+/// Tries `GetDpiForSystem` (Win10 1607+); falls back to `GetDC + GetDeviceCaps`
+/// (Win2000+). Always returns at least 96. Never panics.
+pub fn get_system_dpi_compat() -> u32 {
+    unsafe {
+        // Tier 1: Win10 1607+.
+        let user32 = user32();
+        if let Some(proc) = resolve_fn(
+            user32,
+            b"GetDpiForSystem\0",
+            &GET_DPI_FOR_SYSTEM_STATE,
+            &GET_DPI_FOR_SYSTEM_FN,
+        ) {
+            type GetDpiFn = unsafe extern "system" fn() -> u32;
+            let f: GetDpiFn = std::mem::transmute(proc);
+            let dpi = f();
+            if dpi > 0 {
+                return dpi;
+            }
+        }
+
+        // Tier 2: Win2000+ — GetDC + GetDeviceCaps. Returns the same value
+        // GetDpiForSystem would (system DPI), via the older mechanism.
+        let hdc = GetDC(std::ptr::null_mut());
+        if hdc.is_null() {
+            return 96;
+        }
+        let dpi = GetDeviceCaps(hdc, LOGPIXELSY);
+        let _ = ReleaseDC(std::ptr::null_mut(), hdc);
+        if dpi > 0 {
+            dpi as u32
+        } else {
+            96
+        }
+    }
+}

--- a/crates/perry-ui-windows/src/lib.rs
+++ b/crates/perry-ui-windows/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod app;
 pub mod audio;
+#[cfg(target_os = "windows")]
+pub mod dpi_compat;
 
 // Install a vectored exception handler that prints crash info to stderr.
 #[cfg(target_os = "windows")]

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -172,6 +172,27 @@ pub struct CompileArgs {
     /// around a suspected stale cache.
     #[arg(long)]
     pub no_cache: bool,
+
+    /// Minimum Windows version the compiled executable must run on.
+    /// Accepted values: `7`, `8`, `10` (default `10`). Ignored on every
+    /// non-Windows target.
+    ///
+    /// `10` (default) preserves current behavior — the linker picks its
+    /// default subsystem version (Win8+).
+    ///
+    /// `7` emits the linker subsystem suffix `,5.1` (e.g.
+    /// `/SUBSYSTEM:WINDOWS,5.1`) so the PE marks itself Win7-compatible.
+    /// Perry's UI runtime falls back through the DPI API tiers
+    /// (Win10 → Win8.1 → Vista) at startup via lazy GetProcAddress.
+    /// Caveats: programs that import any `.js` module pull V8/deno_core,
+    /// which is unconditionally Win10+; cosmetic effects like dark
+    /// titlebars and rounded corners silently no-op on Win7. See
+    /// `docs/src/platforms/windows-7.md` for the full story (issue #303).
+    ///
+    /// `8` emits `,6.02` — useful when a deployment baseline is Win8/10
+    /// without needing Win7.
+    #[arg(long, default_value = "10")]
+    pub min_windows_version: String,
 }
 
 /// Information about a JavaScript module that will be interpreted at runtime
@@ -245,6 +266,13 @@ pub struct CompilationContext {
     /// entries without re-reading the source in the codegen loop. Mirrors the
     /// djb2 scheme already used by `build_optimized_libs` (see prior art).
     pub module_source_hashes: HashMap<PathBuf, u64>,
+    /// Minimum Windows version for `--target windows` builds. One of `"7"`,
+    /// `"8"`, `"10"`. `"10"` (default) means "no subsystem version suffix";
+    /// `"7"` and `"8"` emit `,5.1` / `,6.02` on the linker `/SUBSYSTEM:` flag
+    /// so the resulting PE marks itself runnable on the older OS. See issue
+    /// #303 + `docs/src/platforms/windows-7.md`. Ignored on non-Windows
+    /// targets.
+    pub min_windows_version: String,
 }
 
 impl std::fmt::Debug for CompilationContext {
@@ -282,6 +310,7 @@ impl CompilationContext {
             uses_crypto_builtins: false,
             needs_thread: false,
             module_source_hashes: HashMap::new(),
+            min_windows_version: "10".to_string(),
         }
     }
 }
@@ -758,6 +787,23 @@ pub fn run_with_parse_cache(
         ctx.needs_geisterhand = true;
         if let Some(port) = args.geisterhand_port {
             ctx.geisterhand_port = port;
+        }
+    }
+
+    // Validate --min-windows-version. Accepted: "7", "8", "10". Anything
+    // else is a hard error so typos like `--min-windows-version=11` fail
+    // loudly instead of silently behaving like the default. See issue #303
+    // and `docs/src/platforms/windows-7.md`.
+    match args.min_windows_version.as_str() {
+        "7" | "8" | "10" => {
+            ctx.min_windows_version = args.min_windows_version.clone();
+        }
+        other => {
+            anyhow::bail!(
+                "--min-windows-version: expected '7', '8', or '10', got '{}'. \
+                 See docs/src/platforms/windows-7.md for the trade-offs.",
+                other
+            );
         }
     }
 
@@ -4951,11 +4997,47 @@ mod windows_link_tests {
 
     #[test]
     fn cli_build_uses_console_subsystem() {
-        assert_eq!(windows_pe_subsystem_flag(false), "/SUBSYSTEM:CONSOLE");
+        assert_eq!(windows_pe_subsystem_flag(false, "10"), "/SUBSYSTEM:CONSOLE");
     }
 
     #[test]
     fn ui_build_uses_windows_subsystem() {
-        assert_eq!(windows_pe_subsystem_flag(true), "/SUBSYSTEM:WINDOWS");
+        assert_eq!(windows_pe_subsystem_flag(true, "10"), "/SUBSYSTEM:WINDOWS");
+    }
+
+    // Issue #303: --min-windows-version=7 emits the ,5.1 suffix that marks
+    // the PE as Win7-compatible.
+    #[test]
+    fn min_windows_7_appends_5_1_suffix() {
+        assert_eq!(
+            windows_pe_subsystem_flag(false, "7"),
+            "/SUBSYSTEM:CONSOLE,5.1"
+        );
+        assert_eq!(
+            windows_pe_subsystem_flag(true, "7"),
+            "/SUBSYSTEM:WINDOWS,5.1"
+        );
+    }
+
+    // Issue #303: --min-windows-version=8 emits the ,6.02 suffix.
+    #[test]
+    fn min_windows_8_appends_6_02_suffix() {
+        assert_eq!(
+            windows_pe_subsystem_flag(false, "8"),
+            "/SUBSYSTEM:CONSOLE,6.02"
+        );
+        assert_eq!(
+            windows_pe_subsystem_flag(true, "8"),
+            "/SUBSYSTEM:WINDOWS,6.02"
+        );
+    }
+
+    // Anything other than 7/8/10 falls through to no suffix — caller-side
+    // CompileArgs validation rejects unknown values before reaching the
+    // linker, so this branch is unreachable in practice but documented.
+    #[test]
+    fn unknown_min_windows_falls_through_to_default() {
+        assert_eq!(windows_pe_subsystem_flag(false, "11"), "/SUBSYSTEM:CONSOLE");
+        assert_eq!(windows_pe_subsystem_flag(true, ""), "/SUBSYSTEM:WINDOWS");
     }
 }

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -213,11 +213,27 @@ pub(super) fn find_perry_windows_sdk() -> Option<PathBuf> {
 /// window that would otherwise flash alongside the app window. Passing neither
 /// flag lets the linker pick a default, which historically resolved to `WINDOWS`
 /// for Perry builds and silently discarded all `console.log` output (issue #120).
-pub(super) fn windows_pe_subsystem_flag(needs_ui: bool) -> &'static str {
-    if needs_ui {
+///
+/// `min_windows_version` accepts `"7"`, `"8"`, or `"10"` (default). Per the
+/// PE subsystem ABI: `,5.1` = Win7-compatible, `,6.02` = Win8-compatible,
+/// no suffix = linker default (Win8+ on modern toolchains). The PE subsystem
+/// version is just the loader-side declaration of "this binary claims to run
+/// on this version" — the binary still has to actually avoid calling APIs
+/// newer than that version. Perry's UI runtime handles the API side via
+/// `crates/perry-ui-windows/src/dpi_compat.rs` (issue #303).
+pub(super) fn windows_pe_subsystem_flag(needs_ui: bool, min_windows_version: &str) -> String {
+    let base = if needs_ui {
         "/SUBSYSTEM:WINDOWS"
     } else {
         "/SUBSYSTEM:CONSOLE"
+    };
+    match min_windows_version {
+        "7" => format!("{},5.1", base),
+        "8" => format!("{},6.02", base),
+        // "10" or anything else (caller is expected to validate) — no suffix,
+        // linker picks its default. Preserves current behavior for users
+        // who don't pass --min-windows-version.
+        _ => base.to_string(),
     }
 }
 

--- a/crates/perry/src/commands/compile/link.rs
+++ b/crates/perry/src/commands/compile/link.rs
@@ -592,8 +592,11 @@ pub(super) fn build_and_run_link(
         // /ENTRY:mainCRTStartup works for both subsystems: Perry emits
         // `int main()` and the MSVC CRT invokes it regardless of subsystem.
         // See windows_pe_subsystem_flag() for subsystem selection rationale.
-        c.arg(windows_pe_subsystem_flag(ctx.needs_ui))
-            .arg("/ENTRY:mainCRTStartup")
+        c.arg(windows_pe_subsystem_flag(
+            ctx.needs_ui,
+            &ctx.min_windows_version,
+        ))
+        .arg("/ENTRY:mainCRTStartup")
             .arg("/NOLOGO")
             // Perry generates large init functions for TS modules (one function
             // per module). Large codebases (100+ modules) can overflow the

--- a/crates/perry/src/commands/dev.rs
+++ b/crates/perry/src/commands/dev.rs
@@ -295,6 +295,7 @@ fn build_once(
         minimal_stdlib: false,
         no_auto_optimize: false,
         no_cache: false,
+        min_windows_version: "10".to_string(),
     };
     parse_cache.reset_counters();
     let result = super::compile::run_with_parse_cache(

--- a/crates/perry/src/commands/run.rs
+++ b/crates/perry/src/commands/run.rs
@@ -184,6 +184,7 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
         minimal_stdlib: false,
         no_auto_optimize: false,
         no_cache: false,
+        min_windows_version: "10".to_string(),
     };
 
     let result = super::compile::run(compile_args, format, use_color, verbose)?;

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -55,6 +55,7 @@
 - [watchOS](platforms/watchos.md)
 - [Android](platforms/android.md)
 - [Windows](platforms/windows.md)
+  - [Windows 7 Compatibility](platforms/windows-7.md)
 - [Linux (GTK4)](platforms/linux.md)
 - [Web](platforms/web.md)
 - [WebAssembly](platforms/wasm.md)

--- a/docs/src/platforms/windows-7.md
+++ b/docs/src/platforms/windows-7.md
@@ -1,0 +1,123 @@
+# Windows 7 Compatibility
+
+Perry supports compiling executables that run on Windows 7 SP1 (and Windows 8 / 8.1) — opt-in via the `--min-windows-version` flag. The default target stays Windows 10+ to preserve full DPI fidelity and modern OS integration; legacy support is one flag away when you need it.
+
+This page covers what works, what degrades, what's outright impossible, and how to validate your build before shipping.
+
+## TL;DR
+
+```bash
+perry compile app.ts -o app.exe --target windows --min-windows-version=7
+```
+
+Produces a PE marked Win7-compatible. Perry's UI runtime resolves the Win10-only DPI APIs lazily at startup and falls back through Win8.1 → Vista primitives, so the binary starts on Win7 SP1. Most UI widgets work. Some cosmetic effects (rounded corners, dark titlebar) silently no-op. **No JavaScript-module imports allowed** on Win7 — the V8 runtime is Win10+ unconditional.
+
+## Why this is opt-in
+
+Two things make a Win7-compatible PE different from a default Perry build:
+
+1. **The PE subsystem version field.** Default Perry builds let the linker pick (currently `/SUBSYSTEM:WINDOWS` with no version, which marks the binary as needing Win8+). Win7 needs `/SUBSYSTEM:WINDOWS,5.1` or `/SUBSYSTEM:CONSOLE,5.1`. The `,5.1` suffix is the [PE subsystem ABI](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-windows-specific-fields-image-only) declaration of "I claim to run on Windows NT 5.1 or higher" — the OS loader reads this field before deciding whether to load the binary.
+
+2. **Win10-only API calls become runtime-resolved.** Perry's UI library calls `SetProcessDpiAwarenessContext` (Win10 1607) and `GetDpiForSystem` (Win10 1607) for per-monitor v2 DPI awareness. Hard-importing them via `extern "system"` would emit IAT entries that the OS resolves *before* `main()` runs — on Win7, the loader fails the process with "entry point not found in user32.dll" before any Rust code can run. With `--min-windows-version=7` (and on default builds too — the retrofit is unconditional), Perry resolves these symbols lazily via `LoadLibraryW + GetProcAddress` and falls back through:
+
+   | Tier | API | Min Windows |
+   | --- | --- | --- |
+   | 1 | `SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)` | Windows 10 1607 |
+   | 2 | `SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)` | Windows 8.1 |
+   | 3 | `SetProcessDPIAware()` | Windows Vista |
+
+   System DPI lookup uses the same lazy pattern: `GetDpiForSystem` (Win10) → `GetDC + GetDeviceCaps(LOGPIXELSY)` (Win2000+).
+
+The `--min-windows-version` flag controls only (1) — the PE marker. The lazy DPI resolution from (2) is always active because it costs essentially nothing and makes default builds more robust against being run on stripped-down Windows installs.
+
+## Accepted values
+
+| `--min-windows-version` | Subsystem suffix | Targets | Default? |
+| --- | --- | --- | --- |
+| `10` | (none — linker default) | Windows 10+ | yes |
+| `8` | `,6.02` | Windows 8 / 8.1+ | no |
+| `7` | `,5.1` | Windows 7 SP1+ | no |
+
+Anything else is a hard error at compile time — typos like `--min-windows-version=11` fail loudly instead of silently behaving like the default.
+
+## What works on Win7
+
+The same audit that produced this feature found 12 KLOC of Win32 UI code in `perry-ui-windows` and 5 calls that touch Win10+ APIs. The 5 break down as 2 hard blockers (now lazy-resolved) and 3 cosmetic-effect calls that already failed soft and silently no-op on Win7. So the bulk of the UI surface — every standard widget — works on Win7 SP1:
+
+- All layout containers (`VStack`, `HStack`, `ZStack`, `ScrollView`, `Spacer`, `Divider`)
+- All input widgets (`Button`, `TextField`, `SecureField`, `Toggle`, `Slider`, `Picker`, `ProgressView`)
+- `Text`, `Canvas`, `Image` (file + symbol)
+- `Form` and `LazyVStack`
+- File / folder open / save dialogs
+- Clipboard access
+- Audio (WASAPI is Vista+)
+- Keyboard shortcuts, menus, toolbars
+- Multi-window
+- The full `perry-runtime` and `perry-stdlib` surface — `fs`, `http`, `crypto`, `child_process`, `Date`, `Buffer`, etc.
+
+## What degrades silently
+
+These behaviors target Win10 / Win11 features. On Win7 the API call returns an error code that Perry already swallows; the binary runs, but the visual effect is missing:
+
+- **DPI quality.** Win7 has system-wide DPI only — moving a window between monitors with different DPI doesn't trigger re-scaling. Per-monitor v2 (font hinting, dialog scaling) is Win10 1607+.
+- **Dark titlebar.** `DWMWA_USE_IMMERSIVE_DARK_MODE` is Win10 1809+. Titlebar follows the system theme on Win7 (light only on stock Win7).
+- **Rounded window corners.** `DWMWA_WINDOW_CORNER_PREFERENCE` is Win11+. Frameless windows have square corners on Win7 / Win10.
+- **Mica / Acrylic backdrop.** `DWMWA_SYSTEMBACKDROP_TYPE` is Win11+. Backdrop falls through to the standard window background on Win7 / Win10.
+
+## What is impossible
+
+**`perry/jsruntime` (V8 / deno_core) is Win10+ unconditional.** Anything in your project that imports a `.js` module from `node_modules` triggers `--enable-jsruntime`, which links against deno_core, which embeds V8, which won't load on Win7. There's no fallback for this — Win7 builds must avoid JS-module imports entirely. If your project compiles cleanly without `--enable-jsruntime` (i.e. only TypeScript imports, only Perry-native packages), you're good.
+
+**Universal Windows Platform (UWP / WinRT) APIs.** Perry doesn't currently use these, but if a future feature does (e.g. modern toast notifications), it'll be Win10+ only. The runtime + stdlib audit was clean as of v0.5.395.
+
+## How the lazy DPI resolution works
+
+The retrofit lives in `crates/perry-ui-windows/src/dpi_compat.rs`. It exposes two functions, both safe to call on any Windows version from Vista onward:
+
+```rust,no-test
+pub fn set_process_dpi_awareness_compat();
+pub fn get_system_dpi_compat() -> u32;
+```
+
+Internally each function:
+
+1. Calls `LoadLibraryA("user32.dll")` (and `shcore.dll` for the Win8.1 tier) — both are loaded into every Win32 process by the kernel before `main`, so the call is a cheap handle lookup.
+2. Calls `GetProcAddress` to find the desired symbol. Caches the result (success or failure) in an `AtomicPtr` + `AtomicU8` pair, so the lookup runs at most once per process.
+3. Falls through to the next tier on miss. `set_process_dpi_awareness_compat` ends with `SetProcessDPIAware()` (Vista+, hard-imported because every supported Windows has it). `get_system_dpi_compat` ends with `GetDeviceCaps(LOGPIXELSY)` (Win2000+, dead reliable).
+
+After the cache is warm — i.e. after `app_create` runs once — every subsequent DPI query is a single atomic load + indirect call. No measurable runtime cost vs. a hard-imported call.
+
+## Validating a Win7 build
+
+Perry's CI and dev hosts don't have Win7 VMs. If you ship to Win7 you need to validate the binary yourself. Three checks:
+
+### 1. PE subsystem version
+
+Use `dumpbin /headers app.exe | findstr "subsystem"` (MSVC) or `objdump -p app.exe | grep "MajorOSVersion"` (LLVM):
+
+```text
+$ dumpbin /headers app.exe | findstr "subsystem"
+            5.01 subsystem version
+               2 subsystem (Windows GUI)
+```
+
+The `5.01` confirms the PE is Win7-compatible. A default build shows `6.00` or higher.
+
+### 2. Imports
+
+Use `dumpbin /imports app.exe | findstr /i "user32"` (MSVC) or `objdump -p app.exe | grep -A20 "DLL Name: user32"` (LLVM). Confirm that `SetProcessDpiAwarenessContext` and `GetDpiForSystem` are **not** in the user32.dll import list. If they are, the lazy retrofit isn't taking effect — likely you've added a `use windows::Win32::UI::HiDpi::SetProcessDpiAwarenessContext;` somewhere that pulls the symbol back in.
+
+### 3. Run on a Win7 SP1 VM
+
+There's no substitute for actually launching the binary. Microsoft's free Win7 evaluation VM (no longer hosted directly by Microsoft, mirrored on archive.org) is the canonical reference image. Worth keeping a snapshot for regression checks.
+
+## Caveats and gotchas
+
+- **The MSVC linker may warn** about subsystem version `,5.1` being below the C runtime's stated minimum on newer toolchains. The warning is benign — the CRT itself runs on Win7, the warning is conservative. Watch for hard errors, not warnings.
+- **xwin sysroot setup is unchanged.** Cross-compiling from macOS / Linux still uses the `perry setup windows` xwin'd toolchain. Nothing in `--min-windows-version` changes the SDK requirements.
+- **Static-link the CRT** if you want the binary to run on a clean Win7 SP1 install with no Visual C++ Redistributable. Confirm the binary doesn't import `vcruntime140.dll` / `msvcp140.dll` via the dumpbin/objdump check above.
+- **`perry/thread`'s SRWLOCK is Vista+, fine.** Perry's threading primitives use Rust std, which uses SRWLOCK on Windows since Rust 1.42. No `WaitOnAddress` (Win8+) involvement on the supported Rust versions.
+
+## Issue tracking
+
+This feature lands as the resolution to [#303](https://github.com/PerryTS/perry/issues/303). If you hit a Win7-specific failure that isn't covered here, please file a follow-up referencing this page so we can extend the audit.

--- a/docs/src/platforms/windows.md
+++ b/docs/src/platforms/windows.md
@@ -4,7 +4,7 @@ Perry compiles TypeScript apps for Windows using the Win32 API.
 
 ## Requirements
 
-- Windows 10 or later
+- Windows 10 or later by default (Windows 7 SP1 / Windows 8 supported via `--min-windows-version=7|8` — see [Windows 7 Compatibility](./windows-7.md) for the trade-offs)
 - A linker toolchain — either of these two options:
 
 ### Option A — Lightweight (recommended, ~1.5 GB, no Visual Studio)


### PR DESCRIPTION
## Summary

Closes #303. Opt-in Windows 7 SP1 + Windows 8 / 8.1 support via a new `--min-windows-version=7|8|10` flag (default `10` — preserves current behavior). Two coordinated changes:

1. **PE subsystem version**. `windows_pe_subsystem_flag` in `library_search.rs` now appends `,5.1` (Win7) or `,6.02` (Win8) to `/SUBSYSTEM:WINDOWS|CONSOLE` when the new flag is set, so the resulting PE marks itself as runnable on the older OS. Threaded through `CompileArgs` → `CompilationContext` → `link.rs`. Invalid values fail loudly at compile time, not silently fall through.

2. **Lazy DPI API resolution**. New `crates/perry-ui-windows/src/dpi_compat.rs` resolves `SetProcessDpiAwarenessContext` (Win10 1607) and `GetDpiForSystem` (Win10 1607) via `LoadLibraryW + GetProcAddress` instead of static `extern "system"` imports. Hard-imports of those symbols would emit IAT entries that the OS resolves *before* `main()` runs — on Win7 the loader fails the process with "entry point not found in user32.dll" before any Rust code executes. The retrofit falls back through Win8.1's `SetProcessDpiAwareness` → Vista's `SetProcessDPIAware`. DPI lookup falls back to `GetDC + GetDeviceCaps(LOGPIXELSY)` (Win2000+).

The lazy resolution is unconditional — default Win10 builds also benefit (it's essentially free: one atomic load + indirect call after the first cache warm) and makes builds robust against running on stripped-down Windows installs.

Three known `DwmSetWindowAttribute` calls (immersive dark mode, rounded corners, mica/acrylic backdrop) already use `let _ =` and fail-soft on Win7 — no changes needed there. dwmapi.dll itself ships in Vista; only the attribute IDs are version-dependent.

**What's impossible on Win7**: anything that triggers `--enable-jsruntime` (V8 / deno_core is unconditionally Win10+). UI programs work. CLI programs work. Programs importing `.js` modules from node_modules don't.

`perry-runtime` + `perry-stdlib` audit was clean — zero Win10+ APIs in the always-linked surface (verified at v0.5.395).

## Files

- **New**: `crates/perry-ui-windows/src/dpi_compat.rs` (~210 LOC) — the lazy resolver
- **New**: `docs/src/platforms/windows-7.md` — comprehensive user-facing doc (TL;DR, what works/degrades/impossible, internals, validation steps, caveats)
- **New**: `INSTRUCTIONS-TO-WIN-AGENT.md` — step-by-step Win7-validation script for the Win11 reviewer (delete before merge — see Test plan below)
- **Modified**: `crates/perry-ui-windows/src/{app.rs,lib.rs}` — wire the lazy path; remove static HiDpi imports
- **Modified**: `crates/perry/src/commands/{compile.rs,run.rs,dev.rs}` — new `min_windows_version` field + validation
- **Modified**: `crates/perry/src/commands/compile/{library_search.rs,link.rs}` — subsystem flag derivation + call site
- **Modified**: `docs/src/SUMMARY.md`, `docs/src/platforms/windows.md` — cross-link the new page
- **5 new test cases** in `compile::windows_link_tests` pin the subsystem flag derivation across all three values + a fallthrough sentinel

## Test plan

- [x] **Host-side**: `cargo check -p perry --tests` clean (macOS host)
- [x] **Host-side**: `cargo test -p perry --bin perry windows_link_tests --release` — all 5 new tests pass + the 2 existing tests still green (regression guard for #120)
- [ ] **Cross-compile**: `perry-ui-windows` for `x86_64-pc-windows-msvc` from macOS — *not exercised in this PR* because the dev host doesn't have an xwin'd sysroot; CI's windows-2022 runner exercises this
- [ ] **Win11 static checks** — run \`dumpbin /headers\` + \`dumpbin /imports\` per \`INSTRUCTIONS-TO-WIN-AGENT.md\` step 4-5. Expected: \`5.01\` subsystem version on \`*-win7.exe\` builds + zero matches for \`SetProcessDpiAwarenessContext\` / \`GetDpiForSystem\` in the import table. **This is the headline check — if it passes, the fix is correct with high confidence even without a Win7 VM.**
- [ ] **Win11 runtime sanity** — run the four built test binaries (CLI + UI × default + win7) per INSTRUCTIONS step 7. Expected: all four behave identically.
- [ ] **Win7 SP1 VM end-to-end** (optional) — run \`hello-win7.exe\` and \`ui-win7.exe\` per INSTRUCTIONS step 6. Expected: hello prints \`hello win7\` and exits cleanly; ui opens a window with the expected content. Pre-fix the binaries would die immediately at process load with "entry point not found in user32.dll" before \`main\` ran.

## Validation gap

Local dev host is macOS, so the cross-compile + dumpbin checks aren't possible here. The Win11 reviewer follows \`INSTRUCTIONS-TO-WIN-AGENT.md\` (committed at the repo root for easy discovery) and reports back with the dumpbin output. Once the static checks pass, this is mergeable — the runtime VM check is nice-to-have, not blocking.

If you'd like, also ping the issue author (\`xinyugit\`) since they obviously have a Win7 system on hand and could provide an end-to-end signal that even a VM can't fully match.

## Pre-merge cleanup

Delete \`INSTRUCTIONS-TO-WIN-AGENT.md\` from the branch before merging — it's a one-time validation aid, not a permanent doc. The user-facing doc lives at \`docs/src/platforms/windows-7.md\`.