### PR TITLE
fix(runtime,codegen): closes #344, #345, #346 — stdio routing + process.argv prototype

### DIFF
--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -1868,15 +1868,22 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
                 }
                 return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
             }
-            // Single-arg fast path: just print directly.
+            // Single-arg fast path: just print directly. Pre-fix #345 this
+            // ignored the `property` and always called `js_console_log_*`,
+            // which collapsed `console.error("x")` and `console.warn("x")`
+            // onto stdout. Dispatch on property so each console method
+            // routes to its matching runtime fn (and stream).
             if args.len() == 1 {
                 let arg = &args[0];
                 let is_number_literal = matches!(arg, Expr::Integer(_) | Expr::Number(_));
                 let v = lower_expr(ctx, arg)?;
-                let runtime_fn = if is_number_literal {
-                    "js_console_log_number"
-                } else {
-                    "js_console_log_dynamic"
+                let runtime_fn = match (property.as_str(), is_number_literal) {
+                    ("error", true) => "js_console_error_number",
+                    ("error", false) => "js_console_error_dynamic",
+                    ("warn", true) => "js_console_warn_number",
+                    ("warn", false) => "js_console_warn_dynamic",
+                    (_, true) => "js_console_log_number",
+                    (_, false) => "js_console_log_dynamic",
                 };
                 ctx.block().call_void(runtime_fn, &[(DOUBLE, &v)]);
                 return Ok("0.0".to_string());

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -31,6 +31,14 @@ pub fn declare_phase1(module: &mut LlModule) {
     // Console.
     module.declare_function("js_console_log_dynamic", VOID, &[DOUBLE]);
     module.declare_function("js_console_log_number", VOID, &[DOUBLE]);
+    // console.error / console.warn single-arg fast paths (#345). These
+    // route the print to stderr / stdout-styled-as-warn respectively;
+    // pre-fix the single-arg path always called js_console_log_dynamic
+    // and silently lost the stream distinction.
+    module.declare_function("js_console_error_dynamic", VOID, &[DOUBLE]);
+    module.declare_function("js_console_error_number", VOID, &[DOUBLE]);
+    module.declare_function("js_console_warn_dynamic", VOID, &[DOUBLE]);
+    module.declare_function("js_console_warn_number", VOID, &[DOUBLE]);
 
     // NaN-boxing wrappers (bridge between raw handles and NaN-boxed doubles).
     module.declare_function("js_nanbox_string", DOUBLE, &[I64]);

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -1193,6 +1193,11 @@ pub(crate) fn static_type_of(ctx: &FnCtx<'_>, e: &Expr) -> Option<HirType> {
         | Expr::ObjectKeys(_)
         | Expr::ObjectValues(_)
         | Expr::ObjectEntries(_) => Some(HirType::Array(Box::new(HirType::Any))),
+        // `process.argv` is a real Array<string> at runtime (see
+        // `js_process_argv` in perry-runtime/os.rs). Without this entry
+        // `is_array_expr(Expr::ProcessArgv)` is false and `argv.includes(x)`
+        // takes the string-method dispatch path (issue #346) — closes #346.
+        Expr::ProcessArgv => Some(HirType::Array(Box::new(HirType::String))),
         // `str.split(delim)` returns Array<String>. Catches the generic
         // Call form that bypasses the `Expr::StringSplit` variant — e.g.
         // `"a,b,c".split(",")` in an expression position where we need

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -520,51 +520,107 @@ pub extern "C" fn js_process_kill(pid: f64, signal: f64) {
     }
 }
 
-/// Stub `write` function used by process.stdin/stdout/stderr objects.
-/// Receives a single value, writes it to stdout/stderr, returns true.
-extern "C" fn process_stream_write_stub(
+/// Coerce a NaN-boxed JSValue to its display bytes, suitable for raw
+/// stream writes. Used by `process.stdout.write` / `process.stderr.write`.
+/// Mirrors Node's behavior: numbers/booleans/null/undefined coerce to
+/// their string form; strings pass through verbatim.
+fn jsvalue_to_write_bytes(value: f64) -> Vec<u8> {
+    let s_ptr = crate::value::js_jsvalue_to_string(value);
+    if s_ptr.is_null() {
+        return Vec::new();
+    }
+    unsafe {
+        let header = &*s_ptr;
+        let len = header.byte_len as usize;
+        let data = (s_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        std::slice::from_raw_parts(data, len).to_vec()
+    }
+}
+
+/// `write` impl for process.stdout — writes the value's display bytes to
+/// fd 1 without appending a newline (matching Node.js semantics — the
+/// caller is responsible for `\n`).
+extern "C" fn process_stdout_write_stub(
     _closure: *const crate::closure::ClosureHeader,
-    _arg: f64,
+    arg: f64,
 ) -> f64 {
-    // Just return true
+    use std::io::Write;
+    let bytes = jsvalue_to_write_bytes(arg);
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    let _ = handle.write_all(&bytes);
+    let _ = handle.flush();
     f64::from_bits(0x7FFC_0000_0000_0004) // TAG_TRUE
 }
 
-/// Build a stub stream object with a `write` field set to a closure.
-fn build_stream_object() -> *mut crate::object::ObjectHeader {
+/// `write` impl for process.stderr — same as the stdout stub but
+/// targeting fd 2.
+extern "C" fn process_stderr_write_stub(
+    _closure: *const crate::closure::ClosureHeader,
+    arg: f64,
+) -> f64 {
+    use std::io::Write;
+    let bytes = jsvalue_to_write_bytes(arg);
+    let stderr = std::io::stderr();
+    let mut handle = stderr.lock();
+    let _ = handle.write_all(&bytes);
+    let _ = handle.flush();
+    f64::from_bits(0x7FFC_0000_0000_0004) // TAG_TRUE
+}
+
+/// `write` impl for process.stdin — reading from stdin via `.write` is
+/// nonsensical; keep it as a no-op that returns `true` so existing code
+/// that calls `process.stdin.write(...)` (rare) doesn't crash.
+extern "C" fn process_stdin_write_noop_stub(
+    _closure: *const crate::closure::ClosureHeader,
+    _arg: f64,
+) -> f64 {
+    f64::from_bits(0x7FFC_0000_0000_0004) // TAG_TRUE
+}
+
+/// Build a stream object with a `write` field bound to the given stub.
+/// Each invocation of `process.stdout` / `process.stderr` returns a fresh
+/// object whose `write` closure points at the matching fd.
+fn build_stream_object_with_write(
+    write_stub: extern "C" fn(*const crate::closure::ClosureHeader, f64) -> f64,
+) -> *mut crate::object::ObjectHeader {
     use crate::closure::js_closure_alloc;
     use crate::object::{js_object_alloc_with_shape, js_object_set_field};
     use crate::value::JSValue;
 
     let packed = b"write\0";
     let obj = js_object_alloc_with_shape(0x7FFF_FF22, 1, packed.as_ptr(), packed.len() as u32);
-    let closure = js_closure_alloc(process_stream_write_stub as *const u8, 0);
+    let closure = js_closure_alloc(write_stub as *const u8, 0);
     let cval = JSValue::pointer(closure as *const u8);
     js_object_set_field(obj, 0, cval);
     obj
 }
 
-/// process.stdin -> stub stream object
+/// process.stdin -> stream object whose `.write(...)` is a no-op (writing
+/// to stdin from the program side has no useful semantics — kept as a
+/// crash-free placeholder).
 #[no_mangle]
 pub extern "C" fn js_process_stdin() -> f64 {
     use crate::value::JSValue;
-    let obj = build_stream_object();
+    let obj = build_stream_object_with_write(process_stdin_write_noop_stub);
     f64::from_bits(JSValue::pointer(obj as *const u8).bits())
 }
 
-/// process.stdout -> stub stream object
+/// process.stdout -> stream object whose `.write(s)` writes `s` to fd 1
+/// without appending a newline, matching Node.js semantics.
 #[no_mangle]
 pub extern "C" fn js_process_stdout() -> f64 {
     use crate::value::JSValue;
-    let obj = build_stream_object();
+    let obj = build_stream_object_with_write(process_stdout_write_stub);
     f64::from_bits(JSValue::pointer(obj as *const u8).bits())
 }
 
-/// process.stderr -> stub stream object
+/// process.stderr -> stream object whose `.write(s)` writes `s` to fd 2
+/// without appending a newline, matching Node.js semantics.
 #[no_mangle]
 pub extern "C" fn js_process_stderr() -> f64 {
     use crate::value::JSValue;
-    let obj = build_stream_object();
+    let obj = build_stream_object_with_write(process_stderr_write_stub);
     f64::from_bits(JSValue::pointer(obj as *const u8).bits())
 }
 


### PR DESCRIPTION
Three small fixes for stdio/argv gaps surfaced while compiling [skelpo-listener](https://github.com/PerryTS/perry/issues/344#issuecomment-) (a TS social-listening CLI) with `perry compile`. Each is independently reproducible via a 4-line script and each preserves existing behavior outside the fix path.

## #344 — `process.{stdout,stderr}.write` are silent no-ops

`crates/perry-runtime/src/os.rs`: `process_stream_write_stub` literally dropped its argument and returned `true`, plus stdout/stderr shared the same stub so it couldn't have routed correctly even if it wrote.

Replace with two stubs bound to fd 1 / fd 2 via `std::io::stdout()`/`stderr().write_all`, matching Node's `process.std*.write(s)` semantics (no trailing newline added). `process.stdin` keeps a no-op write closure for crash-safety.

## #345 — `console.error` / `console.warn` (single-arg) collapse onto stdout

`crates/perry-codegen/src/lower_call.rs`: the multi-arg console path correctly dispatches on `property` to `js_console_{log,warn,error}_spread`, but the single-arg fast path always called `js_console_log_{number,dynamic}` regardless of whether the user wrote `.log` / `.warn` / `.error`.

Dispatch on `(property, is_number_literal)` so each method routes to its matching runtime fn — the `{warn,error}_{number,dynamic}` impls already existed in `perry-runtime/src/builtins.rs` and use `eprintln!` for the stderr-bound variants. Also declare those four runtime fns in `runtime_decls.rs` so the codegen-side calls resolve at link time.

## #346 — `process.argv.includes(x)` returns false

`crates/perry-codegen/src/type_analysis.rs`: `static_type_of` lists every array-producing expression (`Expr::Array`, `Expr::ArrayMap`, `Expr::ObjectKeys`, ...) but did not include `Expr::ProcessArgv`. With `ProcessArgv` missing, `is_array_expr(ctx, &Expr::ProcessArgv)` returns false, so `argv.includes(x)` (1-arg form) hits the string-method-only routing in `lower_call.rs` and falls through.

Add `ProcessArgv` as `Array<String>` — `js_process_argv()` already returns a real `ArrayHeader` at runtime, this just teaches the type analyzer to recognize it.

## Verification

Each issue's template repro now passes:

```bash
# #344 — was: only console.log surfaced; now all three reach the right fd.
perry compile s344.ts -o s344 && ./s344 1>/tmp/o 2>/tmp/e
# /tmp/o: "via stdout.write\nvia console.log"
# /tmp/e: "via stderr.write"

# #345 — was: both on stdout; now console.error on stderr.
perry compile s345.ts -o s345 && ./s345 1>/tmp/o 2>/tmp/e
# /tmp/o: "via console.log"
# /tmp/e: "via console.error"

# #346 — was: false; now: true.
perry compile s346.ts -o s346 && ./s346 --help
# argv.includes("--help")=true
# copy.includes("--help")=true
```

`cargo build --release -p perry` clean (warnings unchanged from baseline).

Closes #344
Closes #345
Closes #346