### PR TITLE
fix(transform): closes #342 — cond ? await a() : b() evaluates BOTH branches

### DIFF
--- a/crates/perry-transform/src/async_to_generator.rs
+++ b/crates/perry-transform/src/async_to_generator.rs
@@ -524,6 +524,17 @@ fn hoist_awaits_in_expr_full(expr: &mut Expr, next_id: &mut LocalId, hoisted: &m
         // scope for the v1 plain-async pre-pass.
         return;
     }
+    // A `cond ? await a() : b()` would otherwise have BOTH branches'
+    // awaits hoisted unconditionally above the containing statement,
+    // executing both calls regardless of `cond` — breaks JS semantics
+    // (issue #342). Lift the conditional to a statement-level if/else
+    // with a temp before the general hoisting walks into it.
+    if matches!(expr, Expr::Conditional { .. })
+        && conditional_branches_contain_await(expr)
+    {
+        lift_conditional_with_await_branches(expr, next_id, hoisted);
+        return;
+    }
     // Recurse into children first (innermost-first hoisting).
     perry_hir::walker::walk_expr_children_mut(expr, &mut |child| {
         hoist_awaits_in_expr_full(child, next_id, hoisted);
@@ -558,11 +569,96 @@ fn hoist_awaits_avoiding_top_level(
     if matches!(expr, Expr::Closure { .. }) {
         return;
     }
+    // Top-level conditional like `let r = cond ? await a() : b();` — see
+    // the matching note in `hoist_awaits_in_expr_full`. Lift here too so
+    // the await ends up inside an if-branch instead of unconditionally
+    // above the let.
+    if matches!(expr, Expr::Conditional { .. })
+        && conditional_branches_contain_await(expr)
+    {
+        lift_conditional_with_await_branches(expr, next_id, hoisted);
+        return;
+    }
     // Outer is NOT an await. Children may contain awaits which ARE
     // nested — fully hoist them.
     perry_hir::walker::walk_expr_children_mut(expr, &mut |child| {
         hoist_awaits_in_expr_full(child, next_id, hoisted);
     });
+}
+
+/// Returns true if either branch of `expr` (assumed `Expr::Conditional`)
+/// contains an `Expr::Await`, anywhere except inside nested closures.
+fn conditional_branches_contain_await(expr: &Expr) -> bool {
+    if let Expr::Conditional {
+        then_expr,
+        else_expr,
+        ..
+    } = expr
+    {
+        return expr_contains_await(then_expr) || expr_contains_await(else_expr);
+    }
+    false
+}
+
+fn expr_contains_await(expr: &Expr) -> bool {
+    if matches!(expr, Expr::Await(_)) {
+        return true;
+    }
+    if matches!(expr, Expr::Closure { .. }) {
+        return false;
+    }
+    let mut found = false;
+    perry_hir::walker::walk_expr_children(expr, &mut |child| {
+        if !found && expr_contains_await(child) {
+            found = true;
+        }
+    });
+    found
+}
+
+/// Replace `cond ? then_e : else_e` (where then_e or else_e contains an
+/// await) with `LocalGet(__cond_await_N)`, and emit before the containing
+/// statement:
+///
+///   let __cond_await_N: any;
+///   if (cond) { __cond_await_N = then_e; } else { __cond_await_N = else_e; }
+///
+/// Awaits inside each branch's `LocalSet` are then hoisted by the recursive
+/// `hoist_awaits_in_stmts` call so they end up at the top of their own
+/// if-branch — the position the await→yield rewrite expects.
+fn lift_conditional_with_await_branches(
+    expr: &mut Expr,
+    next_id: &mut LocalId,
+    hoisted: &mut Vec<Stmt>,
+) {
+    let temp_id = alloc_local(next_id);
+    let owned = std::mem::replace(expr, Expr::LocalGet(temp_id));
+    if let Expr::Conditional {
+        condition,
+        then_expr,
+        else_expr,
+    } = owned
+    {
+        hoisted.push(Stmt::Let {
+            id: temp_id,
+            name: format!("__cond_await_{}", temp_id),
+            ty: Type::Any,
+            mutable: true,
+            init: None,
+        });
+
+        let mut then_branch = vec![Stmt::Expr(Expr::LocalSet(temp_id, then_expr))];
+        hoist_awaits_in_stmts(&mut then_branch, next_id);
+
+        let mut else_branch = vec![Stmt::Expr(Expr::LocalSet(temp_id, else_expr))];
+        hoist_awaits_in_stmts(&mut else_branch, next_id);
+
+        hoisted.push(Stmt::If {
+            condition: *condition,
+            then_branch,
+            else_branch: Some(else_branch),
+        });
+    }
 }
 
 // ─── Rewrite await → yield ───────────────────────────────────────────────

--- a/crates/perry-transform/src/async_to_generator.rs
+++ b/crates/perry-transform/src/async_to_generator.rs
@@ -529,9 +529,7 @@ fn hoist_awaits_in_expr_full(expr: &mut Expr, next_id: &mut LocalId, hoisted: &m
     // executing both calls regardless of `cond` — breaks JS semantics
     // (issue #342). Lift the conditional to a statement-level if/else
     // with a temp before the general hoisting walks into it.
-    if matches!(expr, Expr::Conditional { .. })
-        && conditional_branches_contain_await(expr)
-    {
+    if matches!(expr, Expr::Conditional { .. }) && conditional_branches_contain_await(expr) {
         lift_conditional_with_await_branches(expr, next_id, hoisted);
         return;
     }
@@ -573,9 +571,7 @@ fn hoist_awaits_avoiding_top_level(
     // the matching note in `hoist_awaits_in_expr_full`. Lift here too so
     // the await ends up inside an if-branch instead of unconditionally
     // above the let.
-    if matches!(expr, Expr::Conditional { .. })
-        && conditional_branches_contain_await(expr)
-    {
+    if matches!(expr, Expr::Conditional { .. }) && conditional_branches_contain_await(expr) {
         lift_conditional_with_await_branches(expr, next_id, hoisted);
         return;
     }


### PR DESCRIPTION
## What's broken

A conditional expression with `await` on one side ran the awaited call regardless of the condition. The original repro from #342:

```typescript
async function a(): Promise<number> { console.log('ran a'); return 1; }
function       b():        number    { console.log('ran b'); return 2; }
async function main(): Promise<void> {
  const cmd: string = 'digest';
  const r = cmd === 'fetch' ? await a() : b();
  console.log('r=' + r);
  process.exit(0);
}
main().catch((e) => { console.log(e); process.exit(1); });
```

Buggy output: `ran a` / `ran b` / `r=2` (a ran even though the digest branch was taken).

## Root cause

Not codegen — the **async→generator pre-pass**. The hoister blindly walks expression children looking for `Expr::Await` and lifts each into a `let __await_N = await X` placed BEFORE the containing statement. So

```
let r = cond ? await a() : b();
```

becomes

```
let __await_N = await a();
let r = cond ? __await_N : b();
```

— `a()` runs unconditionally. `--print-hir` confirms it: `then_expr: LocalGet(N)`, and the original `Call` got moved to state 0 of the generator state machine.

## Fix

Detect `Expr::Conditional` whose then- or else-branch contains an `await` and, before any general hoisting walks into it, lift the whole conditional to a statement-level if/else with a temp local:

```
let __cond_await_N: any;
if (cond) { __cond_await_N = await a(); }
else      { __cond_await_N = b(); }
let r = __cond_await_N;
```

The recursive `hoist_awaits_in_stmts` call inside each branch then hoists the await to the top of its own if-arm — the position the await→yield rewrite expects. Both `hoist_awaits_in_expr_full` and `hoist_awaits_avoiding_top_level` get the early dispatch, so the lift fires whether the conditional is at let-init or in a deeper position.

## Verification

All four await-shape combinations behave correctly:

| Shape | Before | After |
|---|---|---|
| `cond ? await a() : b()` | both branches | only matched |
| `cond ? a() : await b()` | both branches | only matched |
| `cond ? await a() : await b()` | both branches | only matched |
| `cond ? a() : b()` (sync only) | already correct | unchanged |

Plus the actual skelpo-listener pattern that surfaced the bug:

```typescript
const code = args.command === 'fetch' ? await runFetch(args) : runDigest(args);
```

now runs only `runDigest` on a `digest` invocation.

`cargo build --release -p perry` clean.

Closes #342