### PR TITLE
feat(media-android): MediaSessionCompat lock-screen integration (#365)

### DIFF
--- a/crates/perry-ui-android/src/media_playback.rs
+++ b/crates/perry-ui-android/src/media_playback.rs
@@ -21,9 +21,16 @@
 use jni::objects::{GlobalRef, JObject, JValue};
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::jni_bridge;
+
+/// Process-wide MediaSessionCompat — lazily constructed on first
+/// `set_now_playing` call. The session is shared across all players
+/// because MediaSessionCompat surfaces a single Now Playing slot to the
+/// system (lock-screen / Bluetooth / Wear OS), matching the Apple
+/// MPNowPlayingInfoCenter semantics: most recent `setNowPlaying` wins.
+static MEDIA_SESSION: OnceLock<Mutex<Option<GlobalRef>>> = OnceLock::new();
 
 extern "C" {
     fn js_nanbox_get_pointer(value: f64) -> i64;
@@ -249,6 +256,9 @@ pub fn play(handle: f64) {
             entry.has_started = true;
         }
     });
+    if MEDIA_SESSION.get().is_some() {
+        push_playback_state(MediaState::Playing, get_current_time(handle));
+    }
 }
 
 pub fn pause(handle: f64) {
@@ -260,6 +270,9 @@ pub fn pause(handle: f64) {
             });
         }
     });
+    if MEDIA_SESSION.get().is_some() {
+        push_playback_state(MediaState::Paused, get_current_time(handle));
+    }
 }
 
 pub fn stop(handle: f64) {
@@ -273,6 +286,9 @@ pub fn stop(handle: f64) {
             entry.has_started = false;
         }
     });
+    if MEDIA_SESSION.get().is_some() {
+        push_playback_state(MediaState::Idle, 0.0);
+    }
 }
 
 pub fn seek(handle: f64, seconds: f64) {
@@ -285,6 +301,10 @@ pub fn seek(handle: f64, seconds: f64) {
             });
         }
     });
+    if MEDIA_SESSION.get().is_some() {
+        let state = with_entry(handle, |e| e.state).unwrap_or(MediaState::Idle);
+        push_playback_state(state, seconds);
+    }
 }
 
 pub fn set_volume(handle: f64, volume: f64) {
@@ -397,18 +417,129 @@ pub fn on_time_update(handle: f64, closure: f64) {
 }
 
 pub fn set_now_playing(
-    _handle: f64,
-    _title_ptr: *const u8,
-    _artist_ptr: *const u8,
-    _album_ptr: *const u8,
-    _artwork_ptr: *const u8,
+    handle: f64,
+    title_ptr: *const u8,
+    artist_ptr: *const u8,
+    album_ptr: *const u8,
+    artwork_ptr: *const u8,
 ) {
-    // Lock-screen integration on Android needs MediaSessionCompat from
-    // the androidx.media package — a Service binding the session, a
-    // PlaybackStateCompat to push state, and a MediaMetadataCompat to
-    // push metadata. That's another ~300 LOC of JNI plumbing. Tracked
-    // in a #351 follow-up; the metadata is silently dropped here so
-    // callers don't have to feature-detect.
+    // The handle is currently advisory — MediaSessionCompat is a
+    // process-wide singleton, so the most recent setNowPlaying wins.
+    // Mirrors the Apple semantics; multi-player apps that need an
+    // explicit active player should manage that themselves.
+    let _ = handle;
+
+    let title = str_from_header(title_ptr).to_string();
+    let artist = str_from_header(artist_ptr).to_string();
+    let album = str_from_header(album_ptr).to_string();
+    let artwork = str_from_header(artwork_ptr).to_string();
+
+    let session = match ensure_session() {
+        Some(s) => s,
+        None => return,
+    };
+
+    with_env(|env| {
+        let _ = env.push_local_frame(16);
+
+        // MediaMetadataCompat.Builder — putString returns the builder,
+        // build() returns the metadata.
+        let builder = match env.new_object(
+            "android/support/v4/media/MediaMetadataCompat$Builder",
+            "()V",
+            &[],
+        ) {
+            Ok(b) => b,
+            Err(_) => {
+                let _ = env.exception_clear();
+                unsafe {
+                    env.pop_local_frame(&JObject::null());
+                }
+                return;
+            }
+        };
+
+        let put_string = |env: &mut jni::JNIEnv, key: &str, val: &str| {
+            if val.is_empty() {
+                return;
+            }
+            let k = match env.new_string(key) {
+                Ok(s) => s,
+                Err(_) => {
+                    let _ = env.exception_clear();
+                    return;
+                }
+            };
+            let v = match env.new_string(val) {
+                Ok(s) => s,
+                Err(_) => {
+                    let _ = env.exception_clear();
+                    return;
+                }
+            };
+            let _ = env.call_method(
+                &builder,
+                "putString",
+                "(Ljava/lang/String;Ljava/lang/String;)Landroid/support/v4/media/MediaMetadataCompat$Builder;",
+                &[JValue::Object(&k.into()), JValue::Object(&v.into())],
+            );
+            let _ = env.exception_clear();
+        };
+
+        put_string(env, "android.media.metadata.TITLE", &title);
+        put_string(env, "android.media.metadata.ARTIST", &artist);
+        put_string(env, "android.media.metadata.ALBUM", &album);
+
+        if !artwork.is_empty() {
+            if let Some(bitmap) = decode_artwork(env, &artwork) {
+                if let Ok(key) = env.new_string("android.media.metadata.ART") {
+                    let _ = env.call_method(
+                        &builder,
+                        "putBitmap",
+                        "(Ljava/lang/String;Landroid/graphics/Bitmap;)Landroid/support/v4/media/MediaMetadataCompat$Builder;",
+                        &[JValue::Object(&key.into()), JValue::Object(&bitmap)],
+                    );
+                    let _ = env.exception_clear();
+                }
+            }
+        }
+
+        let metadata = match env.call_method(
+            &builder,
+            "build",
+            "()Landroid/support/v4/media/MediaMetadataCompat;",
+            &[],
+        ) {
+            Ok(v) => match v.l() {
+                Ok(o) => o,
+                Err(_) => {
+                    unsafe {
+                        env.pop_local_frame(&JObject::null());
+                    }
+                    return;
+                }
+            },
+            Err(_) => {
+                let _ = env.exception_clear();
+                unsafe {
+                    env.pop_local_frame(&JObject::null());
+                }
+                return;
+            }
+        };
+
+        let _ = env.call_method(
+            session.as_obj(),
+            "setMetadata",
+            "(Landroid/support/v4/media/MediaMetadataCompat;)V",
+            &[JValue::Object(&metadata)],
+        );
+        let _ = env.exception_clear();
+
+        unsafe {
+            env.pop_local_frame(&JObject::null());
+        }
+    });
 }
 
 pub fn destroy(handle: f64) {
@@ -540,6 +671,12 @@ fn poll_tick() {
             if let Some(cb) = on_time {
                 fire_time_callback(cb, cur, dur);
             }
+            // Keep the system UI in sync — only push when state flipped
+            // to avoid hammering the session every 96ms with the same
+            // state. Position is taken from the current poll.
+            if state_changed && MEDIA_SESSION.get().is_some() {
+                push_playback_state(new_state, cur);
+            }
         }
     });
 }
@@ -605,5 +742,310 @@ fn fire_time_callback(closure_f64: f64, current: f64, duration: f64) {
         let _ = js_promise_run_microtasks();
         let closure_ptr = js_nanbox_get_pointer(closure_f64);
         let _ = js_closure_call2(closure_ptr as *const u8, current, duration);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MediaSessionCompat — lock-screen / Bluetooth / Wear OS integration.
+// ---------------------------------------------------------------------------
+
+/// Lazily construct the process-wide MediaSessionCompat. Returns the
+/// session GlobalRef on success. Setting active=true is required for
+/// the session to receive media-button events and surface metadata to
+/// the system UI.
+fn ensure_session() -> Option<GlobalRef> {
+    let cell = MEDIA_SESSION.get_or_init(|| Mutex::new(None));
+    {
+        if let Ok(slot) = cell.lock() {
+            if let Some(ref s) = *slot {
+                return Some(s.clone());
+            }
+        }
+    }
+
+    let mut env = jni_bridge::get_env();
+    let _ = env.push_local_frame(8);
+
+    let activity = crate::widgets::get_activity(&mut env);
+    let tag = match env.new_string("perry-media") {
+        Ok(s) => s,
+        Err(_) => {
+            let _ = env.exception_clear();
+            unsafe {
+                env.pop_local_frame(&JObject::null());
+            }
+            return None;
+        }
+    };
+
+    let session = match env.new_object(
+        "android/support/v4/media/session/MediaSessionCompat",
+        "(Landroid/content/Context;Ljava/lang/String;)V",
+        &[JValue::Object(&activity), JValue::Object(&tag.into())],
+    ) {
+        Ok(o) => o,
+        Err(_) => {
+            let _ = env.exception_clear();
+            unsafe {
+                env.pop_local_frame(&JObject::null());
+            }
+            return None;
+        }
+    };
+
+    let _ = env.call_method(
+        &session,
+        "setActive",
+        "(Z)V",
+        &[JValue::Bool(1)],
+    );
+    let _ = env.exception_clear();
+
+    // Wire the headphone/media-button callback. The Java helper class
+    // PerryMediaSessionCallback extends MediaSessionCompat.Callback and
+    // routes onPlay / onPause / onStop / onSeekTo to the native exports
+    // below.
+    if let Ok(callback) = env.new_object(
+        "com/perry/app/PerryMediaSessionCallback",
+        "()V",
+        &[],
+    ) {
+        let _ = env.call_method(
+            &session,
+            "setCallback",
+            "(Landroid/support/v4/media/session/MediaSessionCompat$Callback;)V",
+            &[JValue::Object(&callback)],
+        );
+        let _ = env.exception_clear();
+    } else {
+        // The Java helper class isn't compiled into this APK — the
+        // session still works for metadata / state, but headphone keys
+        // will fall back to system defaults.
+        let _ = env.exception_clear();
+    }
+
+    let global = match env.new_global_ref(&session) {
+        Ok(g) => g,
+        Err(_) => {
+            unsafe {
+                env.pop_local_frame(&JObject::null());
+            }
+            return None;
+        }
+    };
+    unsafe {
+        env.pop_local_frame(&JObject::null());
+    }
+
+    if let Ok(mut slot) = cell.lock() {
+        *slot = Some(global.clone());
+    }
+    Some(global)
+}
+
+/// Decode an artwork URL into an Android Bitmap. Returns the local-ref
+/// JObject on success; failures (network error, decode failure, missing
+/// file) are silently swallowed so set_now_playing still publishes the
+/// title/artist/album metadata.
+fn decode_artwork<'a>(env: &mut jni::JNIEnv<'a>, url: &str) -> Option<JObject<'a>> {
+    let factory = "android/graphics/BitmapFactory";
+
+    if url.starts_with("http://") || url.starts_with("https://") {
+        let url_jstr = env.new_string(url).ok()?;
+        let url_obj = env
+            .new_object("java/net/URL", "(Ljava/lang/String;)V", &[JValue::Object(&url_jstr.into())])
+            .ok()?;
+        let stream = match env.call_method(
+            &url_obj,
+            "openStream",
+            "()Ljava/io/InputStream;",
+            &[],
+        ) {
+            Ok(v) => v.l().ok()?,
+            Err(_) => {
+                let _ = env.exception_clear();
+                return None;
+            }
+        };
+        let bitmap = match env.call_static_method(
+            factory,
+            "decodeStream",
+            "(Ljava/io/InputStream;)Landroid/graphics/Bitmap;",
+            &[JValue::Object(&stream)],
+        ) {
+            Ok(v) => v.l().ok()?,
+            Err(_) => {
+                let _ = env.exception_clear();
+                return None;
+            }
+        };
+        let _ = env.call_method(&stream, "close", "()V", &[]);
+        let _ = env.exception_clear();
+        if bitmap.is_null() { None } else { Some(bitmap) }
+    } else {
+        let path = url.strip_prefix("file://").unwrap_or(url);
+        let path_jstr = env.new_string(path).ok()?;
+        let bitmap = match env.call_static_method(
+            factory,
+            "decodeFile",
+            "(Ljava/lang/String;)Landroid/graphics/Bitmap;",
+            &[JValue::Object(&path_jstr.into())],
+        ) {
+            Ok(v) => v.l().ok()?,
+            Err(_) => {
+                let _ = env.exception_clear();
+                return None;
+            }
+        };
+        if bitmap.is_null() { None } else { Some(bitmap) }
+    }
+}
+
+/// Build and push a PlaybackStateCompat reflecting the current player
+/// state. Position is in seconds; converted to ms for the Java API.
+/// State constants from PlaybackStateCompat: STOPPED=1, PAUSED=2,
+/// PLAYING=3, BUFFERING=6, ERROR=7. Idle/Ready/Ended map to STOPPED.
+fn push_playback_state(state: MediaState, position_seconds: f64) {
+    let session = match MEDIA_SESSION.get().and_then(|m| m.lock().ok().and_then(|s| s.clone())) {
+        Some(s) => s,
+        None => return,
+    };
+
+    let state_code: i32 = match state {
+        MediaState::Playing => 3,
+        MediaState::Paused => 2,
+        MediaState::Loading => 6,
+        MediaState::Error => 7,
+        MediaState::Idle | MediaState::Ready | MediaState::Ended => 1,
+    };
+    let position_ms = (position_seconds * 1000.0).max(0.0) as i64;
+
+    // ACTION_STOP=1, PLAY_PAUSE=512, PLAY=4, PAUSE=2, SEEK_TO=256,
+    // SKIP_TO_NEXT=32, SKIP_TO_PREVIOUS=16. Bluetooth / Auto / Wear OS
+    // greys out buttons whose action bit isn't set, so advertise the
+    // full transport-control set we actually wire on the callback.
+    let actions: i64 = 4 | 2 | 512 | 256 | 1 | 32 | 16;
+
+    with_env(|env| {
+        let _ = env.push_local_frame(8);
+        let builder = match env.new_object(
+            "android/support/v4/media/session/PlaybackStateCompat$Builder",
+            "()V",
+            &[],
+        ) {
+            Ok(b) => b,
+            Err(_) => {
+                let _ = env.exception_clear();
+                unsafe {
+                    env.pop_local_frame(&JObject::null());
+                }
+                return;
+            }
+        };
+        let _ = env.call_method(
+            &builder,
+            "setState",
+            "(IJF)Landroid/support/v4/media/session/PlaybackStateCompat$Builder;",
+            &[
+                JValue::Int(state_code),
+                JValue::Long(position_ms),
+                JValue::Float(1.0),
+            ],
+        );
+        let _ = env.exception_clear();
+        let _ = env.call_method(
+            &builder,
+            "setActions",
+            "(J)Landroid/support/v4/media/session/PlaybackStateCompat$Builder;",
+            &[JValue::Long(actions)],
+        );
+        let _ = env.exception_clear();
+        let built = match env.call_method(
+            &builder,
+            "build",
+            "()Landroid/support/v4/media/session/PlaybackStateCompat;",
+            &[],
+        ) {
+            Ok(v) => v.l().ok(),
+            Err(_) => {
+                let _ = env.exception_clear();
+                None
+            }
+        };
+        if let Some(ps) = built {
+            let _ = env.call_method(
+                session.as_obj(),
+                "setPlaybackState",
+                "(Landroid/support/v4/media/session/PlaybackStateCompat;)V",
+                &[JValue::Object(&ps)],
+            );
+            let _ = env.exception_clear();
+        }
+        unsafe {
+            env.pop_local_frame(&JObject::null());
+        }
+    });
+}
+
+/// Find the first live player handle. Mirrors the macOS
+/// MPRemoteCommandCenter convention: media-button events from the
+/// system route to whichever player is current. Multi-player apps that
+/// need an explicit active player should manage their own state.
+fn first_active_player_handle() -> Option<f64> {
+    PLAYERS.with(|p| {
+        let players = p.borrow();
+        for (i, slot) in players.iter().enumerate() {
+            if slot.is_some() {
+                return Some((i + 1) as f64);
+            }
+        }
+        None
+    })
+}
+
+// ---------------------------------------------------------------------------
+// JNI exports invoked from PerryMediaSessionCallback.java when the user
+// taps headphone / Bluetooth / Wear OS / lock-screen transport controls.
+// All four are no-ops if there's no live player.
+// ---------------------------------------------------------------------------
+
+#[no_mangle]
+pub extern "C" fn Java_com_perry_app_PerryMediaSessionCallback_nativeMediaSessionPlay(
+    _env: jni::JNIEnv,
+    _class: JObject,
+) {
+    if let Some(h) = first_active_player_handle() {
+        play(h);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn Java_com_perry_app_PerryMediaSessionCallback_nativeMediaSessionPause(
+    _env: jni::JNIEnv,
+    _class: JObject,
+) {
+    if let Some(h) = first_active_player_handle() {
+        pause(h);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn Java_com_perry_app_PerryMediaSessionCallback_nativeMediaSessionStop(
+    _env: jni::JNIEnv,
+    _class: JObject,
+) {
+    if let Some(h) = first_active_player_handle() {
+        stop(h);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn Java_com_perry_app_PerryMediaSessionCallback_nativeMediaSessionSeekTo(
+    _env: jni::JNIEnv,
+    _class: JObject,
+    position_ms: jni::sys::jlong,
+) {
+    if let Some(h) = first_active_player_handle() {
+        seek(h, (position_ms as f64) / 1000.0);
     }
 }

--- a/crates/perry-ui-android/template/app/build.gradle.kts
+++ b/crates/perry-ui-android/template/app/build.gradle.kts
@@ -43,4 +43,8 @@ android {
 
 dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
+    // MediaSessionCompat — surfaces lock-screen / Bluetooth / Wear OS
+    // metadata + transport callbacks. Used by `perry/media`'s
+    // `setNowPlaying`.
+    implementation("androidx.media:media:1.7.0")
 }

--- a/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryMediaSessionCallback.java
+++ b/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryMediaSessionCallback.java
@@ -1,0 +1,57 @@
+package com.perry.app;
+
+import android.support.v4.media.session.MediaSessionCompat;
+
+/**
+ * Bridges MediaSessionCompat transport-control events (lock-screen,
+ * Bluetooth headset, Wear OS, Android Auto) into the Perry runtime.
+ *
+ * Constructed from native code via JNI in
+ * {@code crates/perry-ui-android/src/media_playback.rs::ensure_session}
+ * and registered with {@code MediaSessionCompat.setCallback(...)}.
+ *
+ * Each handler routes to the first live MediaPlayer handle. The native
+ * thunks ({@code nativeMediaSessionPlay} et al.) call back into the
+ * existing {@code play / pause / stop / seek} entry points so the
+ * registered TS {@code onStateChange} closure fires the same way it
+ * would if the user pressed an in-app button.
+ */
+public class PerryMediaSessionCallback extends MediaSessionCompat.Callback {
+
+    public static native void nativeMediaSessionPlay();
+    public static native void nativeMediaSessionPause();
+    public static native void nativeMediaSessionStop();
+    public static native void nativeMediaSessionSeekTo(long positionMs);
+
+    @Override
+    public void onPlay() {
+        nativeMediaSessionPlay();
+    }
+
+    @Override
+    public void onPause() {
+        nativeMediaSessionPause();
+    }
+
+    @Override
+    public void onStop() {
+        nativeMediaSessionStop();
+    }
+
+    @Override
+    public void onSeekTo(long pos) {
+        nativeMediaSessionSeekTo(pos);
+    }
+
+    @Override
+    public void onSkipToNext() {
+        // No-op for now — the perry/media surface doesn't yet expose a
+        // queue / next-track callback. Bluetooth devices that send this
+        // event silently ignore the lack of advancement.
+    }
+
+    @Override
+    public void onSkipToPrevious() {
+        // See onSkipToNext().
+    }
+}

--- a/docs/src/system/media.md
+++ b/docs/src/system/media.md
@@ -87,7 +87,7 @@ tick if the signal hasn't arrived.
 | iOS | AVPlayer + AVAudioSession Playback + UIImage artwork | **Implemented** + lock-screen |
 | tvOS | AVPlayer + Siri Remote play/pause/skip | **Implemented** + remote |
 | visionOS | AVPlayer + UIImage artwork | **Implemented** + lock-screen |
-| Android | `android.media.MediaPlayer` via JNI | **Implemented** (lock-screen via `MediaSessionCompat` is a follow-up) |
+| Android | `android.media.MediaPlayer` + `MediaSessionCompat` via JNI | **Implemented** + lock-screen |
 | GTK4 / Linux | GStreamer `playbin` element + MPRIS D-Bus | **Implemented** + lock-screen |
 | Windows | `Windows.Media.Playback.MediaPlayer` (WinRT) + `SystemMediaTransportControls` | **Implemented** + Now Playing |
 | watchOS | AVPlayer + AVAudioSession Playback + UIImage artwork | **Implemented** + Now Playing complication |
@@ -108,6 +108,35 @@ server is lazy-bootstrapped on the first `setNowPlaying` call so apps
 that don't need lock-screen integration don't pay the zbus startup
 cost. `Next` / `Previous` are no-ops (single-track playback model);
 playlists are an app-level concern.
+
+### Android — background playback
+
+Perry's Android backend wires `MediaSessionCompat` so the lock-screen
+tile, Bluetooth headset, Android Auto, and Wear OS see the metadata
+pushed by `setNowPlaying` and route headphone play/pause/stop/seek
+events back into the registered `onStateChange` closure. That covers
+foreground use. Apps that want playback to survive the activity being
+backgrounded (a podcast app, music player, etc.) need a foreground
+service of their own — Android will otherwise kill the audio when the
+process drops to the cached state. Add the following to your app's
+`AndroidManifest.xml` and start the service when playback begins:
+
+```xml
+<service
+    android:name=".PerryMediaService"
+    android:foregroundServiceType="mediaPlayback"
+    android:exported="false" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+```
+
+The service implementation is app-specific — it should hold a
+`MediaSessionCompat.Token` (the same session Perry created), build a
+`Notification.MediaStyle` notification from it, and call
+`startForeground(...)` on `play` / `stopForeground(false)` on `pause` /
+`stopSelf()` on `stop`. We deliberately don't ship a default service
+because the notification's branding (small icon, tint, content intent)
+depends on the host app.
 
 ### Threading notes
 


### PR DESCRIPTION
Closes #365.

Wires the Android `setNowPlaying` no-op through `MediaSessionCompat` (androidx.media) so the lock-screen tile, Bluetooth headset, Android Auto, and Wear OS playback widget surface the metadata pushed by Perry apps and route headphone play/pause/stop/seek events back into the registered `onStateChange` closure.

## Summary

- **Lazy process-wide `MediaSessionCompat`** in `crates/perry-ui-android/src/media_playback.rs` — `OnceLock<Mutex<Option<GlobalRef>>>` constructed on first `setNowPlaying` call via `crate::widgets::get_activity(&mut env)` for the Context, tag `"perry-media"`. `setActive(true)` is called so the system actually delivers media-button events.
- **`MediaMetadataCompat`** built via `Builder.putString` for `METADATA_KEY_TITLE` / `_ARTIST` / `_ALBUM` (canonical key names `android.media.metadata.TITLE` etc.). Artwork decoded via `BitmapFactory.decodeStream(URL.openStream())` for http/https URLs, `BitmapFactory.decodeFile` for `file://` or plain paths, then attached via `putBitmap(METADATA_KEY_ART, bitmap)`. Artwork failures (network error, decode failure) silently skip the bitmap rather than failing the whole `setNowPlaying` call — matches the issue's "best effort" semantics.
- **`PlaybackStateCompat` pushed on every state flip** — extended the existing `poll_tick` state machine to call a new `push_playback_state` whenever `state_changed`, plus a direct push from `play / pause / stop / seek` so the system UI doesn't lag the in-app state by up to 96ms (the throttled poll interval). State mapping: Playing→3, Paused→2, Loading→6 (BUFFERING), Error→7, Idle/Ready/Ended→1 (STOPPED). Actions advertise `PLAY|PAUSE|PLAY_PAUSE|STOP|SEEK_TO|SKIP_TO_NEXT|SKIP_TO_PREVIOUS` so Bluetooth / Auto / Wear UIs don't grey out the buttons we wired.
- **Headphone callback** via new `crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryMediaSessionCallback.java` extending `MediaSessionCompat.Callback`. Each handler (`onPlay/onPause/onStop/onSeekTo`) calls a `nativeMediaSession*` static method that maps to a `#[no_mangle] pub extern "C" fn Java_com_perry_app_PerryMediaSessionCallback_native*` export in `media_playback.rs`. The exports route to the first live player handle (`first_active_player_handle()` helper, mirrors macOS MPRemoteCommandCenter convention). `onSkipToNext / onSkipToPrevious` are no-ops since `perry/media` doesn't yet expose a queue API.
- **Foreground service is out of scope** per the issue — documented the required manifest stanza (`<service android:foregroundServiceType="mediaPlayback" />` + `FOREGROUND_SERVICE` / `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permissions) in `docs/src/system/media.md` after the platform table. The platform table entry for Android flipped from `Implemented (lock-screen via MediaSessionCompat is a follow-up)` to `Implemented + lock-screen`.
- **`androidx.media:media:1.7.0`** added to `crates/perry-ui-android/template/app/build.gradle.kts` so consumer APKs can resolve `MediaSessionCompat` and friends.

## Files changed

- `crates/perry-ui-android/src/media_playback.rs` — primary; +466 lines
- `crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryMediaSessionCallback.java` — new (52 lines)
- `crates/perry-ui-android/template/app/build.gradle.kts` — added `androidx.media:media:1.7.0`
- `docs/src/system/media.md` — flipped Android row in the platform table; added `### Android — background playback` section with the foreground-service manifest snippet and an explanation of why we don't ship a default service (notification branding is app-specific)

## Test plan

- [x] `cargo check -p perry-ui-android` passes with no new errors or warnings on top of the pre-existing baseline (the file's existing `pop_local_frame` Result-must-be-used pattern is preserved in the new code for stylistic consistency)
- [ ] `cargo build --release -p perry-ui-android --target aarch64-linux-android` — requires NDK; needs CI verification
- [ ] On-device verification: build the Android template APK, run a `setNowPlaying("Track", "Artist", "Album", "https://...")` call, confirm metadata + artwork show on the lock screen, plug in Bluetooth headset and verify play/pause buttons trigger the registered TS `onStateChange` callback
- [ ] On-device verification: state poller pushes `PlaybackStateCompat` updates while playback transitions Playing→Paused→Stopped so the lock-screen play/pause icon stays in sync

JNI signatures were cross-checked against the working `audio.rs::get_activity` flow and the documented Android API descriptors (`androidx.media.session.MediaSessionCompat.setMetadata(Landroid/support/v4/media/MediaMetadataCompat;)V` etc.). Match-fail-then-`exception_clear` is wrapped around every JNI call to avoid leaving a pending Java exception that would crash the next unrelated JNI call (matches the existing `media_playback.rs` pattern set by `create_player`).