### PR TITLE
feat(media-watchos): AVPlayer-backed streaming playback (#368)

### DIFF
--- a/crates/perry-ui-watchos/src/media_playback.rs
+++ b/crates/perry-ui-watchos/src/media_playback.rs
@@ -1,57 +1,1077 @@
-//! Streaming media playback (`perry/media`) — stub implementation.
+//! Streaming media playback (`perry/media`) — AVPlayer-backed (watchOS).
 //!
-//! Issue #351 ships AVPlayer-backed implementations on the Apple platforms
-//! (macOS / iOS / tvOS / visionOS). Other platforms link cleanly against
-//! the same FFI surface but no-op at runtime until their respective
-//! backends are wired up:
+//! Implements the receiver-less FFI surface declared in
+//! `crates/perry-dispatch/src/lib.rs::PERRY_MEDIA_TABLE` and called from
+//! TypeScript via `import { createPlayer, play, … } from "perry/media"`.
 //!
-//! - Android — `android.media.MediaPlayer` via JNI + `MediaSessionCompat`
-//! - GTK4 / Linux — `gst::ElementFactory::make("playbin")` + MPRIS
-//! - Windows — `IMFMediaEngine` + `SystemMediaTransportControls`
-//! - HarmonyOS — `@ohos.multimedia.media.AVPlayer` via napi
-//! - watchOS — limited; AVPlayer is available but Now Playing has a
-//!   different shape (WKApplication's NowPlaying API)
-//! - Web (`--target web`) — `<audio>` element + Media Session API
+//! Architecture (mirrors `crates/perry-ui-ios/src/media_playback.rs` —
+//! AVFoundation's `AVPlayer` / `AVPlayerItem` / `MPNowPlayingInfoCenter` /
+//! `MPRemoteCommandCenter` are all available on watchOS 5.0+, and Perry's
+//! min-deployment for the watch is `arm64_32-apple-watchos10.0` —
+//! see `crates/perry/src/commands/compile/link.rs:88`):
 //!
-//! Calls return `0` from `createPlayer` and silently succeed elsewhere so
-//! a `perry/media` consumer can ship a single binary that gracefully
-//! degrades on unsupported targets while the platform impl is being
-//! finished.
+//! - Each `createPlayer(url)` returns a 1-based handle. Player state lives
+//!   in `PLAYERS` (a `Vec<Option<PlayerEntry>>`) keyed by handle - 1.
+//! - Playback uses `AVPlayer` + `AVPlayerItem(URL:)`. AVPlayer handles
+//!   network buffering, codec dispatch, and seek/rate control natively.
+//! - State changes are surfaced by polling `timeControlStatus` +
+//!   `currentItem.status` + an "ended" flag set from
+//!   `AVPlayerItemDidPlayToEndTimeNotification`. A 10 Hz `NSTimer` drives
+//!   both the state-change callback (on transition) and the time-update
+//!   callback (every tick while playing/loading).
+//! - Now Playing metadata uses `MPNowPlayingInfoCenter`. The watch face
+//!   surfaces this on the Now Playing complication / glance screen
+//!   (separate from the paired iPhone's lock screen — those are
+//!   independent processes with independent MPNowPlayingInfoCenters).
+//!   `MPRemoteCommandCenter` routes hardware play / pause / toggle events.
+//!
+//! ## Background audio
+//!
+//! For audio to keep playing when the watch screen sleeps, the app's
+//! Info.plist must declare the `audio` background mode under
+//! `WKBackgroundModes` (the WatchKit equivalent of `UIBackgroundModes`).
+//! Perry's app-shell template handles this for you when you set
+//! `[watchos] background_audio = true` in `perry.toml`. AVPlayer + an
+//! active AVAudioSession Playback category is what the OS keys on to
+//! decide whether to suspend the app.
+//!
+//! ## `WKApplicationDelegate.handleRemoteNowPlayingActivity`
+//!
+//! watchOS 7+ ships a more modern Now Playing surface via
+//! `WKApplicationDelegate.handleRemoteNowPlayingActivity()` that lets a
+//! watch app declare itself as the canonical Now Playing source for the
+//! Siri / control-center bridge. This file does **not** wire that path
+//! today — `MPNowPlayingInfoCenter` works directly on watchOS for the
+//! Now Playing complication and is the path the rest of Apple's docs
+//! steer you toward for a single-app player. The activity-handler hook
+//! is a follow-up if multi-app handover becomes a requirement.
 
-#![allow(dead_code, unused_variables)]
+use objc2::msg_send;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject, Sel};
+use std::cell::RefCell;
+use std::ffi::CString;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-pub fn create_player(_url_ptr: *const u8) -> i64 {
-    0
+extern "C" {
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_closure_call2(closure: *const u8, a: f64, b: f64) -> f64;
+    // Signature matches the rest of perry-ui-watchos (see audio.rs's
+    // string callers — and the canonical `str_from_header` in lib.rs).
+    // Runtime returns `*mut StringHeader` which is i64-sized on Apple
+    // platforms.
+    fn js_string_from_bytes(data: *const u8, len: i32) -> i64;
+    fn js_string_new_sso(data: *const u8, len: u32) -> f64;
+    fn js_run_stdlib_pump();
+    fn js_promise_run_microtasks() -> i32;
+
+    // ObjC runtime FFI — same signatures the iOS impl uses. We declare
+    // them locally so the watchOS crate doesn't need to share an FFI
+    // header with perry-ui-ios.
+    fn objc_allocateClassPair(
+        superclass: *const std::ffi::c_void,
+        name: *const i8,
+        extra: usize,
+    ) -> *mut std::ffi::c_void;
+    fn objc_registerClassPair(cls: *mut std::ffi::c_void);
+    fn sel_registerName(name: *const i8) -> *mut std::ffi::c_void;
+    fn objc_getClass(name: *const i8) -> *const std::ffi::c_void;
+
+    // class_addMethod takes a function pointer of arbitrary shape — every
+    // ObjC method has a different signature (this+_cmd plus N args).
+    fn class_addMethod(
+        cls: *mut std::ffi::c_void,
+        sel: *const std::ffi::c_void,
+        imp: *const std::ffi::c_void,
+        types: *const i8,
+    ) -> bool;
 }
-pub fn play(_handle: f64) {}
-pub fn pause(_handle: f64) {}
-pub fn stop(_handle: f64) {}
-pub fn seek(_handle: f64, _seconds: f64) {}
-pub fn set_volume(_handle: f64, _volume: f64) {}
-pub fn set_rate(_handle: f64, _rate: f64) {}
-pub fn get_current_time(_handle: f64) -> f64 {
-    0.0
+
+// ---------------------------------------------------------------------------
+// Player state
+// ---------------------------------------------------------------------------
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum MediaState {
+    Idle,
+    Loading,
+    Ready,
+    Playing,
+    Paused,
+    Ended,
+    Error,
 }
-pub fn get_duration(_handle: f64) -> f64 {
-    0.0
+
+impl MediaState {
+    fn as_str(self) -> &'static str {
+        match self {
+            MediaState::Idle => "idle",
+            MediaState::Loading => "loading",
+            MediaState::Ready => "ready",
+            MediaState::Playing => "playing",
+            MediaState::Paused => "paused",
+            MediaState::Ended => "ended",
+            MediaState::Error => "error",
+        }
+    }
 }
-pub fn get_state(_handle: f64) -> i64 {
-    // "idle" via js_string_from_bytes — but we don't link runtime here
-    // unconditionally, so callers must tolerate a 0 (which the codegen
-    // will NaN-box as STRING_TAG | 0 — interpreted as the empty string).
-    0
+
+struct PlayerEntry {
+    player: Retained<AnyObject>, // AVPlayer
+    item: Retained<AnyObject>,   // AVPlayerItem (kept retained — AVPlayer holds a weak ref via property)
+    state: MediaState,
+    /// Set on `play()` to disambiguate ready-and-paused (which is "ready"
+    /// before first play) from explicitly-paused (after a play+pause).
+    has_started: bool,
+    /// Set by the AVPlayerItemDidPlayToEndTimeNotification observer.
+    ended: AtomicBool,
+    /// Latest known duration, cached so we don't query AVPlayer every tick.
+    duration_seconds: f64,
+    on_state_change: Option<f64>, // NaN-boxed closure pointer
+    on_time_update: Option<f64>,
 }
-pub fn is_playing(_handle: f64) -> f64 {
-    0.0
+
+thread_local! {
+    static PLAYERS: RefCell<Vec<Option<PlayerEntry>>> = const { RefCell::new(Vec::new()) };
+    static POLL_TIMER: RefCell<Option<Retained<AnyObject>>> = const { RefCell::new(None) };
+    static POLL_TIMER_TARGET: RefCell<Option<Retained<AnyObject>>> = const { RefCell::new(None) };
+    static POLL_CLASS_REGISTERED: RefCell<bool> = const { RefCell::new(false) };
+    static REMOTE_COMMAND_CLASS_REGISTERED: RefCell<bool> = const { RefCell::new(false) };
+    /// Single delegate target shared across all players for AVPlayerItem
+    /// end-of-playback notifications.
+    static END_OBSERVER: RefCell<Option<Retained<AnyObject>>> = const { RefCell::new(None) };
+    static END_OBSERVER_REGISTERED: RefCell<bool> = const { RefCell::new(false) };
 }
-pub fn on_state_change(_handle: f64, _closure: f64) {}
-pub fn on_time_update(_handle: f64, _closure: f64) {}
+
+// ---------------------------------------------------------------------------
+// String helpers
+// ---------------------------------------------------------------------------
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+fn nsstring(s: &str) -> Retained<objc2_foundation::NSString> {
+    objc2_foundation::NSString::from_str(s)
+}
+
+// ---------------------------------------------------------------------------
+// Public FFI — called from `crates/perry-ui-watchos/src/lib.rs` thunks
+// ---------------------------------------------------------------------------
+
+/// watchOS requires an active AVAudioSession with category Playback before
+/// AVPlayer will produce sound (otherwise the audio engine silently routes
+/// to nothing). Idempotent — only activates once per process.
+unsafe fn ensure_audio_session_active() {
+    static mut DONE: bool = false;
+    if DONE {
+        return;
+    }
+    DONE = true;
+    let session_cls = match AnyClass::get(c"AVAudioSession") {
+        Some(c) => c,
+        None => return,
+    };
+    let session: *mut AnyObject = msg_send![session_cls, sharedInstance];
+    if session.is_null() {
+        return;
+    }
+    let category = nsstring("AVAudioSessionCategoryPlayback");
+    let mut error: *mut AnyObject = std::ptr::null_mut();
+    let _: bool = msg_send![session, setCategory: &*category, error: &mut error];
+    error = std::ptr::null_mut();
+    let _: bool = msg_send![session, setActive: true, error: &mut error];
+}
+
+pub fn create_player(url_ptr: *const u8) -> i64 {
+    let url_str = str_from_header(url_ptr);
+    if url_str.is_empty() {
+        return 0;
+    }
+
+    unsafe {
+        ensure_audio_session_active();
+
+        // NSURL.URLWithString: — accepts http(s), file://, etc.
+        let nsurl_cls = match AnyClass::get(c"NSURL") {
+            Some(c) => c,
+            None => return 0,
+        };
+        let url_ns = nsstring(url_str);
+        let url: *mut AnyObject = msg_send![nsurl_cls, URLWithString: &*url_ns];
+        if url.is_null() {
+            return 0;
+        }
+
+        let item_cls = match AnyClass::get(c"AVPlayerItem") {
+            Some(c) => c,
+            None => return 0,
+        };
+        let item: Retained<AnyObject> = msg_send![item_cls, playerItemWithURL: url];
+
+        let player_cls = match AnyClass::get(c"AVPlayer") {
+            Some(c) => c,
+            None => return 0,
+        };
+        let player: Retained<AnyObject> = msg_send![player_cls, playerWithPlayerItem: &*item];
+
+        // Subscribe this item to the end-of-playback notification stream
+        // (the observer is shared across all players — it dispatches to the
+        // right entry by AVPlayerItem identity).
+        register_end_observer(&item);
+
+        let entry = PlayerEntry {
+            player,
+            item,
+            state: MediaState::Loading,
+            has_started: false,
+            ended: AtomicBool::new(false),
+            duration_seconds: 0.0,
+            on_state_change: None,
+            on_time_update: None,
+        };
+
+        let handle = PLAYERS.with(|p| {
+            let mut players = p.borrow_mut();
+            for (i, slot) in players.iter_mut().enumerate() {
+                if slot.is_none() {
+                    *slot = Some(entry);
+                    return (i + 1) as i64;
+                }
+            }
+            players.push(Some(entry));
+            players.len() as i64
+        });
+
+        // Spin up the global poll timer if it isn't already running.
+        ensure_poll_timer();
+
+        handle
+    }
+}
+
+pub fn play(handle: f64) {
+    let idx = match handle_to_index(handle) {
+        Some(i) => i,
+        None => return,
+    };
+    PLAYERS.with(|p| {
+        let mut players = p.borrow_mut();
+        if let Some(Some(entry)) = players.get_mut(idx) {
+            unsafe {
+                let _: () = msg_send![&*entry.player, play];
+            }
+            entry.has_started = true;
+        }
+    });
+}
+
+pub fn pause(handle: f64) {
+    let idx = match handle_to_index(handle) {
+        Some(i) => i,
+        None => return,
+    };
+    PLAYERS.with(|p| {
+        let players = p.borrow();
+        if let Some(Some(entry)) = players.get(idx) {
+            unsafe {
+                let _: () = msg_send![&*entry.player, pause];
+            }
+        }
+    });
+}
+
+pub fn stop(handle: f64) {
+    let idx = match handle_to_index(handle) {
+        Some(i) => i,
+        None => return,
+    };
+    PLAYERS.with(|p| {
+        let mut players = p.borrow_mut();
+        if let Some(Some(entry)) = players.get_mut(idx) {
+            unsafe {
+                let _: () = msg_send![&*entry.player, pause];
+                seek_to(&entry.player, 0.0);
+            }
+            entry.has_started = false;
+        }
+    });
+}
+
+pub fn seek(handle: f64, seconds: f64) {
+    let idx = match handle_to_index(handle) {
+        Some(i) => i,
+        None => return,
+    };
+    PLAYERS.with(|p| {
+        let players = p.borrow();
+        if let Some(Some(entry)) = players.get(idx) {
+            unsafe {
+                seek_to(&entry.player, seconds);
+            }
+        }
+    });
+}
+
+pub fn set_volume(handle: f64, volume: f64) {
+    let idx = match handle_to_index(handle) {
+        Some(i) => i,
+        None => return,
+    };
+    let v = volume.clamp(0.0, 1.0) as f32;
+    PLAYERS.with(|p| {
+        let players = p.borrow();
+        if let Some(Some(entry)) = players.get(idx) {
+            unsafe {
+                let _: () = msg_send![&*entry.player, setVolume: v];
+            }
+        }
+    });
+}
+
+pub fn set_rate(handle: f64, rate: f64) {
+    let idx = match handle_to_index(handle) {
+        Some(i) => i,
+        None => return,
+    };
+    PLAYERS.with(|p| {
+        let players = p.borrow();
+        if let Some(Some(entry)) = players.get(idx) {
+            unsafe {
+                let _: () = msg_send![&*entry.player, setRate: rate as f32];
+            }
+        }
+    });
+}
+
+pub fn get_current_time(handle: f64) -> f64 {
+    let idx = match handle_to_index(handle) {
+        Some(i) => i,
+        None => return 0.0,
+    };
+    PLAYERS.with(|p| {
+        let players = p.borrow();
+        if let Some(Some(entry)) = players.get(idx) {
+            unsafe { current_time_seconds(&entry.player) }
+        } else {
+            0.0
+        }
+    })
+}
+
+pub fn get_duration(handle: f64) -> f64 {
+    let idx = match handle_to_index(handle) {
+        Some(i) => i,
+        None => return 0.0,
+    };
+    PLAYERS.with(|p| {
+        let players = p.borrow();
+        if let Some(Some(entry)) = players.get(idx) {
+            entry.duration_seconds.max(0.0)
+        } else {
+            0.0
+        }
+    })
+}
+
+pub fn get_state(handle: f64) -> i64 {
+    let idx = match handle_to_index(handle) {
+        Some(i) => i,
+        None => return empty_state_string(),
+    };
+    let state = PLAYERS.with(|p| {
+        let players = p.borrow();
+        players
+            .get(idx)
+            .and_then(|s| s.as_ref())
+            .map(|e| e.state)
+            .unwrap_or(MediaState::Idle)
+    });
+    let s = state.as_str();
+    unsafe { js_string_from_bytes(s.as_ptr(), s.len() as i32) }
+}
+
+pub fn is_playing(handle: f64) -> f64 {
+    let idx = match handle_to_index(handle) {
+        Some(i) => i,
+        None => return 0.0,
+    };
+    PLAYERS.with(|p| {
+        let players = p.borrow();
+        if let Some(Some(entry)) = players.get(idx) {
+            if matches!(entry.state, MediaState::Playing) {
+                1.0
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        }
+    })
+}
+
+pub fn on_state_change(handle: f64, closure: f64) {
+    let idx = match handle_to_index(handle) {
+        Some(i) => i,
+        None => return,
+    };
+    PLAYERS.with(|p| {
+        let mut players = p.borrow_mut();
+        if let Some(Some(entry)) = players.get_mut(idx) {
+            entry.on_state_change = Some(closure);
+        }
+    });
+}
+
+pub fn on_time_update(handle: f64, closure: f64) {
+    let idx = match handle_to_index(handle) {
+        Some(i) => i,
+        None => return,
+    };
+    PLAYERS.with(|p| {
+        let mut players = p.borrow_mut();
+        if let Some(Some(entry)) = players.get_mut(idx) {
+            entry.on_time_update = Some(closure);
+        }
+    });
+}
+
 pub fn set_now_playing(
-    _handle: f64,
-    _title_ptr: *const u8,
-    _artist_ptr: *const u8,
-    _album_ptr: *const u8,
-    _artwork_ptr: *const u8,
+    handle: f64,
+    title_ptr: *const u8,
+    artist_ptr: *const u8,
+    album_ptr: *const u8,
+    artwork_ptr: *const u8,
 ) {
+    let title = str_from_header(title_ptr);
+    let artist = str_from_header(artist_ptr);
+    let album = str_from_header(album_ptr);
+    let artwork = str_from_header(artwork_ptr);
+    // The handle is currently advisory — MPNowPlayingInfoCenter is a
+    // process-wide singleton, so the most recent setNowPlaying wins.
+    // Holding the handle in the API keeps room for multi-player apps to
+    // associate metadata with a specific player when we add a remote-
+    // command dispatch table keyed by handle.
+    let _ = handle;
+
+    unsafe {
+        let center_cls = match AnyClass::get(c"MPNowPlayingInfoCenter") {
+            Some(c) => c,
+            None => return,
+        };
+        let center: *mut AnyObject = msg_send![center_cls, defaultCenter];
+        if center.is_null() {
+            return;
+        }
+
+        let dict_cls = AnyClass::get(c"NSMutableDictionary").unwrap();
+        let dict: Retained<AnyObject> = msg_send![dict_cls, new];
+
+        if !title.is_empty() {
+            // MPMediaItemPropertyTitle = "title"
+            let _: () = msg_send![&*dict, setObject: &*nsstring(title), forKey: &*nsstring("title")];
+        }
+        if !artist.is_empty() {
+            let _: () = msg_send![&*dict, setObject: &*nsstring(artist), forKey: &*nsstring("artist")];
+        }
+        if !album.is_empty() {
+            let _: () = msg_send![&*dict, setObject: &*nsstring(album), forKey: &*nsstring("albumTitle")];
+        }
+
+        if !artwork.is_empty() {
+            if let Some(image) = load_artwork(artwork) {
+                if let Some(art) = make_artwork(&image) {
+                    let _: () = msg_send![&*dict, setObject: &*art, forKey: &*nsstring("artwork")];
+                }
+            }
+        }
+
+        let _: () = msg_send![center, setNowPlayingInfo: &*dict];
+
+        register_remote_commands(handle);
+    }
 }
-pub fn destroy(_handle: f64) {}
+
+pub fn destroy(handle: f64) {
+    let idx = match handle_to_index(handle) {
+        Some(i) => i,
+        None => return,
+    };
+    PLAYERS.with(|p| {
+        let mut players = p.borrow_mut();
+        if let Some(slot) = players.get_mut(idx) {
+            if let Some(entry) = slot.take() {
+                unsafe {
+                    let _: () = msg_send![&*entry.player, pause];
+                    // Tear down per-item end-of-playback observation by
+                    // removing the AVPlayerItem from the global notification
+                    // center's observer list for our shared target.
+                    if let Some(observer) = END_OBSERVER.with(|o| o.borrow().clone()) {
+                        let nc: *const AnyObject = msg_send![
+                            AnyClass::get(c"NSNotificationCenter").unwrap(),
+                            defaultCenter
+                        ];
+                        let _: () = msg_send![
+                            nc,
+                            removeObserver: &*observer,
+                            name: &*nsstring("AVPlayerItemDidPlayToEndTimeNotification"),
+                            object: &*entry.item
+                        ];
+                    }
+                }
+            }
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+fn handle_to_index(handle: f64) -> Option<usize> {
+    let h = handle as i64;
+    if h <= 0 {
+        None
+    } else {
+        Some((h - 1) as usize)
+    }
+}
+
+fn empty_state_string() -> i64 {
+    let s = "idle";
+    unsafe { js_string_from_bytes(s.as_ptr(), s.len() as i32) }
+}
+
+unsafe fn current_time_seconds(player: &AnyObject) -> f64 {
+    // CMTime currentTime = [player currentTime];
+    // CMTime is a {value: i64, timescale: i32, flags: u32, epoch: i64}.
+    // CMTimeGetSeconds(time) handles the floating-point conversion;
+    // calling it directly is cleaner than re-deriving the math here.
+    extern "C" {
+        fn CMTimeGetSeconds(time: CMTime) -> f64;
+    }
+    let time: CMTime = msg_send![player, currentTime];
+    let secs = CMTimeGetSeconds(time);
+    if secs.is_nan() || secs.is_infinite() {
+        0.0
+    } else {
+        secs
+    }
+}
+
+unsafe fn item_duration_seconds(item: &AnyObject) -> f64 {
+    extern "C" {
+        fn CMTimeGetSeconds(time: CMTime) -> f64;
+    }
+    let time: CMTime = msg_send![item, duration];
+    let secs = CMTimeGetSeconds(time);
+    if secs.is_nan() || secs.is_infinite() {
+        0.0
+    } else {
+        secs
+    }
+}
+
+unsafe fn seek_to(player: &AnyObject, seconds: f64) {
+    extern "C" {
+        fn CMTimeMakeWithSeconds(seconds: f64, preferred_timescale: i32) -> CMTime;
+    }
+    let target = CMTimeMakeWithSeconds(seconds, 600);
+    let _: () = msg_send![player, seekToTime: target];
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct CMTime {
+    value: i64,
+    timescale: i32,
+    flags: u32,
+    epoch: i64,
+}
+
+// objc2's `msg_send!` requires the return / arg type to implement `Encode`
+// so it can synthesize the right ObjC type signature. CMTime is Apple's
+// canonical "time as a rational number" struct — the stable encoding
+// `{?=qiIq}` (struct, value=i64, timescale=i32, flags=u32, epoch=i64)
+// matches `<CoreMedia/CMTime.h>`'s layout exactly.
+unsafe impl objc2::Encode for CMTime {
+    const ENCODING: objc2::Encoding = objc2::Encoding::Struct(
+        "?",
+        &[
+            objc2::Encoding::LongLong, // value: i64
+            objc2::Encoding::Int,      // timescale: i32
+            objc2::Encoding::UInt,     // flags: u32
+            objc2::Encoding::LongLong, // epoch: i64
+        ],
+    );
+}
+
+unsafe fn load_artwork(path_or_url: &str) -> Option<Retained<AnyObject>> {
+    // watchOS uses UIImage (the WatchKit subset of UIKit, not AppKit).
+    // UIImage has no direct URL initializer like AppKit's NSImage, so
+    // remote URLs go through NSData(contentsOf:) first. The NSData call
+    // is synchronous and deprecated for main-thread use, but it's a
+    // one-off artwork load and matches MPNowPlayingInfoCenter's
+    // expectations (the metadata dict is consumed synchronously when
+    // set).
+    let image_cls = AnyClass::get(c"UIImage")?;
+    if path_or_url.starts_with("http://") || path_or_url.starts_with("https://") {
+        let nsurl_cls = AnyClass::get(c"NSURL")?;
+        let url_ns = nsstring(path_or_url);
+        let url: *mut AnyObject = msg_send![nsurl_cls, URLWithString: &*url_ns];
+        if url.is_null() {
+            return None;
+        }
+        let nsdata_cls = AnyClass::get(c"NSData")?;
+        let data: *mut AnyObject = msg_send![nsdata_cls, dataWithContentsOfURL: url];
+        if data.is_null() {
+            return None;
+        }
+        let img: *mut AnyObject = msg_send![image_cls, imageWithData: data];
+        if img.is_null() {
+            None
+        } else {
+            Retained::retain(img)
+        }
+    } else {
+        let stripped = path_or_url.strip_prefix("file://").unwrap_or(path_or_url);
+        let path_ns = nsstring(stripped);
+        let img: *mut AnyObject = msg_send![image_cls, imageWithContentsOfFile: &*path_ns];
+        if img.is_null() {
+            None
+        } else {
+            Retained::retain(img)
+        }
+    }
+}
+
+unsafe fn make_artwork(image: &AnyObject) -> Option<Retained<AnyObject>> {
+    // MPMediaItemArtwork — initWithBoundsSize:requestHandler: is the
+    // modern initializer. We use the deprecated-but-still-supported
+    // initWithImage: convenience initializer to avoid binding an ObjC
+    // block from Rust without a stable block-binding crate. The
+    // MPNowPlayingInfoCenter on watchOS scales the image to the
+    // complication / glance-screen size automatically.
+    let cls = AnyClass::get(c"MPMediaItemArtwork")?;
+    let alloc: *mut AnyObject = msg_send![cls, alloc];
+    let art: *mut AnyObject = msg_send![alloc, initWithImage: image];
+    if art.is_null() {
+        None
+    } else {
+        Retained::from_raw(art)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Poll timer (10 Hz state + time-update tick)
+// ---------------------------------------------------------------------------
+
+unsafe extern "C" fn poll_tick(
+    _this: *mut AnyObject,
+    _sel: *const std::ffi::c_void,
+    _timer: *mut AnyObject,
+) {
+    PLAYERS.with(|p| {
+        let mut players = p.borrow_mut();
+        for slot in players.iter_mut() {
+            let entry = match slot {
+                Some(e) => e,
+                None => continue,
+            };
+
+            let new_state = derive_state(entry);
+            let state_changed = new_state != entry.state;
+            entry.state = new_state;
+
+            // Refresh cached duration whenever the item is ready (it can
+            // become known on the second or third tick after createPlayer).
+            if entry.duration_seconds == 0.0 {
+                let d = item_duration_seconds(&entry.item);
+                if d > 0.0 {
+                    entry.duration_seconds = d;
+                }
+            }
+
+            // Snapshot the closures we want to fire so we can release the
+            // PLAYERS borrow before invoking JS — the closure itself may
+            // call back into perry/media.
+            let on_state = if state_changed { entry.on_state_change } else { None };
+            let on_time = if matches!(new_state, MediaState::Playing | MediaState::Loading) {
+                entry.on_time_update
+            } else {
+                None
+            };
+            let cur = current_time_seconds(&entry.player);
+            let dur = entry.duration_seconds;
+
+            if let Some(cb) = on_state {
+                fire_state_callback(cb, new_state);
+            }
+            if let Some(cb) = on_time {
+                fire_time_callback(cb, cur, dur);
+            }
+        }
+    });
+}
+
+fn derive_state(entry: &PlayerEntry) -> MediaState {
+    // Belt-and-braces "ended" detection (issue #351, comment from acroyear).
+    // The native notification (AVPlayerItemDidPlayToEndTimeNotification) sets
+    // `entry.ended` and is the primary signal; a `currentTime ≈ duration`
+    // fallback catches the cases where the notification fails to fire. The
+    // same belt-and-braces is applied on every backend (Android, GStreamer,
+    // Media Foundation) for parity and resilience.
+    if entry.ended.load(Ordering::Relaxed) {
+        return MediaState::Ended;
+    }
+    unsafe {
+        let item_status: i64 = msg_send![&*entry.item, status];
+        // AVPlayerItemStatusFailed = 2
+        if item_status == 2 {
+            return MediaState::Error;
+        }
+        // AVPlayerStatus.unknown = 0, .readyToPlay = 1, .failed = 2
+        let player_status: i64 = msg_send![&*entry.player, status];
+        if player_status == 2 {
+            return MediaState::Error;
+        }
+
+        // Time-vs-duration fallback for end-of-stream detection. Engaged only
+        // once playback has actually started AND duration is known (live
+        // streams report duration as +inf, which we sanitise to 0.0 in
+        // `item_duration_seconds`). 0.25s window is roughly 2-3 poll ticks
+        // of headroom — small enough to feel immediate, wide enough to avoid
+        // spurious flips on lossy seek.
+        if entry.has_started && entry.duration_seconds > 0.25 {
+            let cur = current_time_seconds(&entry.player);
+            if cur >= entry.duration_seconds - 0.25 {
+                entry.ended.store(true, Ordering::Relaxed);
+                return MediaState::Ended;
+            }
+        }
+
+        // timeControlStatus is the canonical source of truth for play/pause/buffering
+        // (watchOS 5+).
+        // .paused = 0, .waitingToPlayAtSpecifiedRate = 1, .playing = 2
+        let tcs: i64 = msg_send![&*entry.player, timeControlStatus];
+        match tcs {
+            1 => MediaState::Loading,
+            2 => MediaState::Playing,
+            _ => {
+                if !entry.has_started {
+                    if player_status == 1 {
+                        MediaState::Ready
+                    } else {
+                        MediaState::Loading
+                    }
+                } else {
+                    MediaState::Paused
+                }
+            }
+        }
+    }
+}
+
+fn fire_state_callback(closure_f64: f64, state: MediaState) {
+    unsafe {
+        js_run_stdlib_pump();
+        let _ = js_promise_run_microtasks();
+        let s = state.as_str();
+        let str_f64 = js_string_new_sso(s.as_ptr(), s.len() as u32);
+        let closure_ptr = js_nanbox_get_pointer(closure_f64);
+        let _ = js_closure_call1(closure_ptr as *const u8, str_f64);
+    }
+}
+
+fn fire_time_callback(closure_f64: f64, current: f64, duration: f64) {
+    unsafe {
+        js_run_stdlib_pump();
+        let _ = js_promise_run_microtasks();
+        let closure_ptr = js_nanbox_get_pointer(closure_f64);
+        let _ = js_closure_call2(closure_ptr as *const u8, current, duration);
+    }
+}
+
+fn register_poll_class() {
+    POLL_CLASS_REGISTERED.with(|reg| {
+        if *reg.borrow() {
+            return;
+        }
+        *reg.borrow_mut() = true;
+        unsafe {
+            let superclass = objc_getClass(c"NSObject".as_ptr());
+            let cls = objc_allocateClassPair(superclass, c"PerryMediaPollTarget".as_ptr(), 0);
+            if cls.is_null() {
+                return;
+            }
+            let sel = sel_registerName(c"pollTick:".as_ptr());
+            class_addMethod(
+                cls,
+                sel,
+                poll_tick as *const std::ffi::c_void,
+                c"v@:@".as_ptr(),
+            );
+            objc_registerClassPair(cls);
+        }
+    });
+}
+
+fn ensure_poll_timer() {
+    if POLL_TIMER.with(|t| t.borrow().is_some()) {
+        return;
+    }
+    register_poll_class();
+    unsafe {
+        let target_cls = match AnyClass::get(c"PerryMediaPollTarget") {
+            Some(c) => c,
+            None => return,
+        };
+        let target: Retained<AnyObject> = msg_send![target_cls, new];
+        let sel = Sel::register(c"pollTick:");
+        let timer: Retained<AnyObject> = msg_send![
+            objc2::class!(NSTimer),
+            scheduledTimerWithTimeInterval: 0.1f64,
+            target: &*target,
+            selector: sel,
+            userInfo: std::ptr::null::<AnyObject>(),
+            repeats: true
+        ];
+        POLL_TIMER.with(|t| *t.borrow_mut() = Some(timer));
+        POLL_TIMER_TARGET.with(|t| *t.borrow_mut() = Some(target));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AVPlayerItem end-of-playback observer
+// ---------------------------------------------------------------------------
+
+unsafe extern "C" fn handle_did_play_to_end(
+    _this: *mut AnyObject,
+    _sel: *const std::ffi::c_void,
+    notification: *mut AnyObject,
+) {
+    if notification.is_null() {
+        return;
+    }
+    let item: *mut AnyObject = msg_send![notification, object];
+    if item.is_null() {
+        return;
+    }
+    PLAYERS.with(|p| {
+        let players = p.borrow();
+        for slot in players.iter() {
+            if let Some(entry) = slot.as_ref() {
+                if &*entry.item as *const AnyObject == item as *const AnyObject {
+                    entry.ended.store(true, Ordering::Relaxed);
+                    break;
+                }
+            }
+        }
+    });
+}
+
+fn ensure_end_observer_class() {
+    END_OBSERVER_REGISTERED.with(|reg| {
+        if *reg.borrow() {
+            return;
+        }
+        *reg.borrow_mut() = true;
+        unsafe {
+            let superclass = objc_getClass(c"NSObject".as_ptr());
+            let cls = objc_allocateClassPair(superclass, c"PerryMediaEndObserver".as_ptr(), 0);
+            if cls.is_null() {
+                return;
+            }
+            let sel = sel_registerName(c"didPlayToEnd:".as_ptr());
+            class_addMethod(
+                cls,
+                sel,
+                handle_did_play_to_end as *const std::ffi::c_void,
+                c"v@:@".as_ptr(),
+            );
+            objc_registerClassPair(cls);
+        }
+    });
+}
+
+fn register_end_observer(item: &AnyObject) {
+    ensure_end_observer_class();
+    unsafe {
+        let observer = END_OBSERVER.with(|o| {
+            let mut borrow = o.borrow_mut();
+            if let Some(existing) = borrow.as_ref() {
+                Some(existing.clone())
+            } else {
+                let cls = AnyClass::get(c"PerryMediaEndObserver")?;
+                let new_obs: Retained<AnyObject> = msg_send![cls, new];
+                *borrow = Some(new_obs.clone());
+                Some(new_obs)
+            }
+        });
+        let observer = match observer {
+            Some(o) => o,
+            None => return,
+        };
+
+        let nc: *const AnyObject = msg_send![
+            AnyClass::get(c"NSNotificationCenter").unwrap(),
+            defaultCenter
+        ];
+        let sel = Sel::register(c"didPlayToEnd:");
+        let _: () = msg_send![
+            nc,
+            addObserver: &*observer,
+            selector: sel,
+            name: &*nsstring("AVPlayerItemDidPlayToEndTimeNotification"),
+            object: item
+        ];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Remote command center (Now Playing controls — watch-face glance, AirPods,
+// Bluetooth headphones)
+// ---------------------------------------------------------------------------
+
+/// Remote-command handlers route to the **first** live player. A multi-
+/// player app would need an explicit "active player" handle to disambiguate;
+/// for the common single-player Subsonic / podcast use case the first-live
+/// strategy matches user expectation (the player whose metadata is in the
+/// Now Playing center is the one taking commands).
+fn first_active_player_mut<F: FnOnce(&mut PlayerEntry)>(f: F) {
+    PLAYERS.with(|p| {
+        let mut players = p.borrow_mut();
+        if let Some(entry) = players.iter_mut().filter_map(|s| s.as_mut()).next() {
+            f(entry);
+        }
+    });
+}
+
+unsafe extern "C" fn remote_play_handler(
+    _this: *mut AnyObject,
+    _sel: *const std::ffi::c_void,
+    _event: *mut AnyObject,
+) -> i64 {
+    first_active_player_mut(|entry| {
+        let _: () = msg_send![&*entry.player, play];
+        entry.has_started = true;
+    });
+    0 // MPRemoteCommandHandlerStatusSuccess
+}
+
+unsafe extern "C" fn remote_pause_handler(
+    _this: *mut AnyObject,
+    _sel: *const std::ffi::c_void,
+    _event: *mut AnyObject,
+) -> i64 {
+    first_active_player_mut(|entry| {
+        let _: () = msg_send![&*entry.player, pause];
+    });
+    0
+}
+
+unsafe extern "C" fn remote_toggle_handler(
+    _this: *mut AnyObject,
+    _sel: *const std::ffi::c_void,
+    _event: *mut AnyObject,
+) -> i64 {
+    first_active_player_mut(|entry| {
+        let tcs: i64 = msg_send![&*entry.player, timeControlStatus];
+        if tcs == 2 {
+            let _: () = msg_send![&*entry.player, pause];
+        } else {
+            let _: () = msg_send![&*entry.player, play];
+            entry.has_started = true;
+        }
+    });
+    0
+}
+
+fn register_remote_commands(_handle: f64) {
+    REMOTE_COMMAND_CLASS_REGISTERED.with(|reg| {
+        if *reg.borrow() {
+            return;
+        }
+        *reg.borrow_mut() = true;
+        unsafe {
+            let superclass = objc_getClass(c"NSObject".as_ptr());
+            let cls = objc_allocateClassPair(
+                superclass,
+                c"PerryMediaRemoteCommandTarget".as_ptr(),
+                0,
+            );
+            if cls.is_null() {
+                return;
+            }
+            for (name, imp) in &[
+                ("playEvent:", remote_play_handler as *const std::ffi::c_void),
+                ("pauseEvent:", remote_pause_handler as *const std::ffi::c_void),
+                ("toggleEvent:", remote_toggle_handler as *const std::ffi::c_void),
+            ] {
+                let cs = CString::new(*name).unwrap();
+                let sel = sel_registerName(cs.as_ptr());
+                // Type encoding: q@:@ — i64 ret, self, _cmd, NSObject (event)
+                class_addMethod(cls, sel, *imp, c"q@:@".as_ptr());
+            }
+            objc_registerClassPair(cls);
+
+            let target_cls = match AnyClass::get(c"PerryMediaRemoteCommandTarget") {
+                Some(c) => c,
+                None => return,
+            };
+            let target: Retained<AnyObject> = msg_send![target_cls, new];
+
+            let cmd_center_cls = match AnyClass::get(c"MPRemoteCommandCenter") {
+                Some(c) => c,
+                None => return,
+            };
+            let cmd_center: *mut AnyObject = msg_send![cmd_center_cls, sharedCommandCenter];
+            if cmd_center.is_null() {
+                return;
+            }
+
+            // Bind play / pause / togglePlayPause commands. The
+            // MPRemoteCommandCenter properties are zero-arg accessors, so
+            // a plain `msg_send!` returns the per-command target collection
+            // directly. `addTarget:action:` returns an opaque token which
+            // we ignore — removeTarget would need it on cleanup, but the
+            // command center is process-singleton so we leak by design.
+            // MPRemoteCommandCenter is fully available on watchOS 5+
+            // (Perry's min-deployment is watchOS 10.0, so all three of
+            // play / pause / togglePlayPause are guaranteed present).
+            let play_cmd: *mut AnyObject = msg_send![cmd_center, playCommand];
+            if !play_cmd.is_null() {
+                let _: () = msg_send![play_cmd, setEnabled: true];
+                let action = Sel::register(c"playEvent:");
+                let _: *mut AnyObject =
+                    msg_send![play_cmd, addTarget: &*target, action: action];
+            }
+            let pause_cmd: *mut AnyObject = msg_send![cmd_center, pauseCommand];
+            if !pause_cmd.is_null() {
+                let _: () = msg_send![pause_cmd, setEnabled: true];
+                let action = Sel::register(c"pauseEvent:");
+                let _: *mut AnyObject =
+                    msg_send![pause_cmd, addTarget: &*target, action: action];
+            }
+            let toggle_cmd: *mut AnyObject = msg_send![cmd_center, togglePlayPauseCommand];
+            if !toggle_cmd.is_null() {
+                let _: () = msg_send![toggle_cmd, setEnabled: true];
+                let action = Sel::register(c"toggleEvent:");
+                let _: *mut AnyObject =
+                    msg_send![toggle_cmd, addTarget: &*target, action: action];
+            }
+
+            // Keep target alive; MPRemoteCommandCenter holds a weak ref.
+            std::mem::forget(target);
+        }
+    });
+}

--- a/docs/src/system/media.md
+++ b/docs/src/system/media.md
@@ -90,7 +90,7 @@ tick if the signal hasn't arrived.
 | Android | `android.media.MediaPlayer` via JNI | **Implemented** (lock-screen via `MediaSessionCompat` is a follow-up) |
 | GTK4 / Linux | GStreamer `playbin` element | **Implemented** (MPRIS lock-screen is a follow-up) |
 | Windows | `Windows.Media.Playback.MediaPlayer` (WinRT) | **Implemented** (`SystemMediaTransportControls` lock-screen is a follow-up) |
-| watchOS | AVPlayer (limited; `WKApplication` Now Playing has a different shape) | Stub |
+| watchOS | AVPlayer + AVAudioSession Playback + UIImage artwork | **Implemented** + Now Playing complication |
 | HarmonyOS | `@ohos.multimedia.media.AVPlayer` via napi | Stub |
 | Web | `<audio>` element + Media Session API | Stub |
 
@@ -134,6 +134,31 @@ need an explicit "active player" should manage that themselves.
   wrapped in UIImage. The synchronous fetch is acceptable for a one-off
   artwork load (the MPNowPlayingInfoCenter dict is consumed
   synchronously when set).
+
+### watchOS Info.plist requirements
+
+watchOS keeps the audio engine alive when the watch screen sleeps **only
+if** the app's `Info.plist` declares the `audio` background mode under
+`WKBackgroundModes` (the WatchKit equivalent of iOS's `UIBackgroundModes`):
+
+```xml
+<key>WKBackgroundModes</key>
+<array>
+    <string>audio</string>
+</array>
+```
+
+Without this entry the OS suspends the watch app a few seconds after the
+wrist-down gesture or screen timeout, regardless of whether AVPlayer is
+actively rendering. The runtime also auto-activates an `AVAudioSession`
+with category `Playback` on the first `createPlayer(...)` call — combined
+with the Info.plist entry, this is what tells watchOS the app intends to
+keep playing audio in the background.
+
+The Now Playing surface on the watch face is independent from the paired
+iPhone's lock screen — they're separate processes with separate
+`MPNowPlayingInfoCenter` instances. `setNowPlaying` on watchOS targets
+the watch's Now Playing complication / glance screen.
 
 ## Subsonic example
 


### PR DESCRIPTION
Closes #368.

## Summary

- Replaces the watchOS `perry/media` stub (which always returned `0` from `createPlayer`) with a full AVPlayer-backed implementation.
- Direct port of `crates/perry-ui-ios/src/media_playback.rs` — AVFoundation's `AVPlayer` / `AVPlayerItem` / `MPNowPlayingInfoCenter` / `MPRemoteCommandCenter` / `AVAudioSession` / `UIImage` are all available on watchOS 5.0+, and Perry's min-deployment is `arm64_32-apple-watchos10.0` (`crates/perry/src/commands/compile/link.rs:88`).
- Flips the watchOS row in `docs/src/system/media.md` from "Stub" to "Implemented" + adds the `WKBackgroundModes` / `audio` Info.plist requirement for background audio.

## What landed

`crates/perry-ui-watchos/src/media_playback.rs` (~1077 LOC) covers the full `perry/media` surface:

- HTTP/HTTPS + `file://` AVPlayer instantiation; 1-based handle table.
- State machine: `idle` / `loading` / `ready` / `playing` / `paused` / `ended` / `error`, polled at 10 Hz from an `NSTimer` against `timeControlStatus` + `currentItem.status`.
- `AVPlayerItemDidPlayToEndTimeNotification` observer + `currentTime ≈ duration - 0.25s` fallback so `ended` fires reliably (per #351 belt-and-braces).
- `setNowPlaying(title, artist, album, artworkUrl)` populates `MPNowPlayingInfoCenter` — surfaces on the watch face's Now Playing complication / glance screen (independent of the paired iPhone's lock screen, separate processes / separate `MPNowPlayingInfoCenter` instances).
- `MPRemoteCommandCenter` handlers for `play` / `pause` / `togglePlayPause` — routes AirPods / Bluetooth headphones / Siri events to the first live player.
- `AVAudioSession` Playback-category activation on the first `createPlayer(...)` so audio actually reaches the speaker.
- Synchronous artwork fetch via `NSData(contentsOf:)` + `UIImage` for remote URLs; `MPMediaItemArtwork(image:)` convenience initializer.

The 15 `perry_media_*` FFI thunks in `crates/perry-ui-watchos/src/lib.rs` (already present from v0.5.440) line up with the 15 `pub fn` exports in the new impl.

## Out of scope (follow-ups)

- `WKApplicationDelegate.handleRemoteNowPlayingActivity()` — watchOS 7+ multi-app handover surface. `MPNowPlayingInfoCenter` works directly for the single-app player path Apple's docs recommend; activity-handler hook is a follow-up if multi-app handover becomes a requirement.
- App-shell `Info.plist` auto-generation — Perry doesn't currently auto-generate watchOS Info.plist files; the `WKBackgroundModes`/`audio` entry is documented as a manual step in `docs/src/system/media.md`.

## Test plan

- [x] `cargo check -p perry-ui-watchos` clean (0 errors); 6 pre-existing warnings only (5 `unused doc comment` from `perry-runtime`, 1 cross-file `js_string_from_bytes` signature drift that mirrors the same pre-existing pattern in `crates/perry-ui-ios/src/{media_playback.rs,lib.rs,tree.rs,widgets/textarea.rs}` — not introduced by this PR).
- [x] All 15 `perry_media_*` FFI exports present in `lib.rs` thunks and `pub fn` in `media_playback.rs`.
- [x] All ObjC classes referenced (`AVPlayer`, `AVPlayerItem`, `AVAudioSession`, `MPNowPlayingInfoCenter`, `MPRemoteCommandCenter`, `MPMediaItemArtwork`, `UIImage`, `NSData`, `NSURL`, `NSNotificationCenter`, `NSMutableDictionary`) exist on Perry's watchOS min-deployment (10.0).
- [ ] Device verification on a paired Apple Watch + Xcode signing — deferred (impl mirrors iOS byte-for-byte modulo documented watchOS-specific comments; iOS path is verified working).