### PR TITLE
feat(media-gtk4): MPRIS lock-screen integration (#366)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7057,6 +7057,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.6.3",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -8570,6 +8571,7 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +671,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -1616,12 +1749,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1695,6 +1855,16 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1955,6 +2125,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -3665,6 +3848,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpris-server"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70cf358e9a9516cc35ed40eebd56cbe80f5190a7a2b3cd0c2d358c86b879132b"
+dependencies = [
+ "async-channel",
+ "futures-channel",
+ "serde",
+ "trait-variant",
+ "zbus",
+]
+
+[[package]]
 name = "muldiv"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4090,6 +4286,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0"
 dependencies = [
  "paste",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -4545,9 +4751,11 @@ dependencies = [
  "gstreamer",
  "gtk4",
  "libc",
+ "mpris-server",
  "perry-runtime",
  "perry-ui",
  "perry-ui-testkit",
+ "tokio",
 ]
 
 [[package]]
@@ -4773,6 +4981,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4829,6 +5048,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide 0.8.9",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5840,6 +6073,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7090,6 +7334,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "triomphe"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7170,6 +7425,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicase"
@@ -8280,6 +8546,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.1",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.1",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8471,4 +8798,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db0ecb8987cf5e92653c57c098f7f0e39a03112edb796f4fe089fb7eaa14ff"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.1",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b949b639ab1b4bed763aa7481ba0e368af68d8b55532f8ed4bec86a59f2ca98"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.1",
 ]

--- a/crates/perry-ui-gtk4/Cargo.toml
+++ b/crates/perry-ui-gtk4/Cargo.toml
@@ -15,6 +15,13 @@ gtk4 = { version = "0.9", features = ["v4_6"] }
 cairo-rs = "0.20"
 # perry/media — GStreamer playbin for streaming audio playback (#351).
 gstreamer = "0.23"
+# perry/media — MPRIS D-Bus exposure for GNOME / KDE / playerctl /
+# Bluetooth headphones (#366). Linux-only; zbus has Linux-specific
+# system deps that don't build on macOS / Windows hosts, so the crate
+# stays gated behind cfg(target_os = "linux") in the source.
+[target.'cfg(target_os = "linux")'.dependencies]
+mpris-server = { version = "0.10", features = ["tokio"] }
+tokio = { version = "1", features = ["rt", "sync", "time", "net", "io-util"] }
 
 [features]
 geisterhand = []

--- a/crates/perry-ui-gtk4/src/media_playback.rs
+++ b/crates/perry-ui-gtk4/src/media_playback.rs
@@ -421,10 +421,13 @@ fn poll_tick() {
                 .unwrap_or(0.0);
             let dur = entry.duration_seconds;
 
-            if state_changed {
-                #[cfg(target_os = "linux")]
-                mpris::push_playback_status(new_state);
-            }
+            // Always offer the current state to MPRIS (the impl dedupes
+            // internally via LAST_STATUS). This makes sure the first
+            // `set_now_playing` call after `play()` boots the D-Bus
+            // server and immediately publishes the actual PlaybackStatus,
+            // not just an old transition that fired before MPRIS was up.
+            #[cfg(target_os = "linux")]
+            mpris::push_playback_status(new_state);
             if let Some(cb) = on_state {
                 fire_state_callback(cb, new_state);
             }

--- a/crates/perry-ui-gtk4/src/media_playback.rs
+++ b/crates/perry-ui-gtk4/src/media_playback.rs
@@ -11,6 +11,16 @@
 //! both the GStreamer EOS message AND a `position ≥ duration - 0.25s`
 //! fallback set the same `ended` flag, so the JS state-change callback
 //! fires once per track even if EOS is dropped (rare, but cheap insurance).
+//!
+//! Lock-screen / system media-key integration (#366) goes through MPRIS
+//! — the canonical Linux desktop spec exposed over D-Bus as
+//! `org.mpris.MediaPlayer2.Player`. The MPRIS server runs on a dedicated
+//! thread with a tokio current-thread runtime owning the zbus connection;
+//! D-Bus method calls (Play / Pause / Seek …) post commands into a
+//! channel that the GLib poll tick drains, so all GStreamer pipeline
+//! mutation stays on the main thread (pipelines are stored in a
+//! thread_local). `set_now_playing` and state changes push the other
+//! direction via a sync `properties_changed` call into the runtime.
 
 use gstreamer::prelude::*;
 use std::cell::RefCell;
@@ -257,17 +267,21 @@ pub fn on_time_update(handle: f64, closure: f64) {
 
 pub fn set_now_playing(
     _handle: f64,
-    _title_ptr: *const u8,
-    _artist_ptr: *const u8,
-    _album_ptr: *const u8,
-    _artwork_ptr: *const u8,
+    title_ptr: *const u8,
+    artist_ptr: *const u8,
+    album_ptr: *const u8,
+    artwork_ptr: *const u8,
 ) {
-    // MPRIS is the canonical Linux lock-screen / media-key protocol.
-    // It's a D-Bus interface (org.mpris.MediaPlayer2.Player) — we'd
-    // expose ourselves as an MPRIS service so GNOME / KDE / playerctl
-    // can issue play/pause/skip events. Tracked as a #351 follow-up;
-    // the metadata is silently dropped here so callers don't have to
-    // feature-detect.
+    let title = str_from_header(title_ptr).to_string();
+    let artist = str_from_header(artist_ptr).to_string();
+    let album = str_from_header(album_ptr).to_string();
+    let artwork = str_from_header(artwork_ptr).to_string();
+    #[cfg(target_os = "linux")]
+    mpris::push_now_playing(title, artist, album, artwork);
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (title, artist, album, artwork);
+    }
 }
 
 pub fn destroy(handle: f64) {
@@ -407,6 +421,10 @@ fn poll_tick() {
                 .unwrap_or(0.0);
             let dur = entry.duration_seconds;
 
+            if state_changed {
+                #[cfg(target_os = "linux")]
+                mpris::push_playback_status(new_state);
+            }
             if let Some(cb) = on_state {
                 fire_state_callback(cb, new_state);
             }
@@ -415,6 +433,8 @@ fn poll_tick() {
             }
         }
     });
+    #[cfg(target_os = "linux")]
+    mpris::drain_commands();
 }
 
 fn derive_state(entry: &PlayerEntry) -> MediaState {
@@ -469,5 +489,390 @@ fn fire_time_callback(closure_f64: f64, current: f64, duration: f64) {
         let _ = js_promise_run_microtasks();
         let closure_ptr = js_nanbox_get_pointer(closure_f64);
         let _ = js_closure_call2(closure_ptr as *const u8, current, duration);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn first_active_handle() -> Option<f64> {
+    PLAYERS.with(|p| {
+        let players = p.borrow();
+        players
+            .iter()
+            .enumerate()
+            .find(|(_, s)| s.is_some())
+            .map(|(i, _)| (i + 1) as f64)
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn current_position_seconds(handle: f64) -> f64 {
+    with_entry(handle, |entry| {
+        entry
+            .pipeline
+            .query_position::<gstreamer::ClockTime>()
+            .map(|t| t.nseconds() as f64 / 1_000_000_000.0)
+            .unwrap_or(0.0)
+    })
+    .unwrap_or(0.0)
+}
+
+#[cfg(target_os = "linux")]
+mod mpris {
+    //! D-Bus MPRIS server. Lazy-bootstrapped on the first
+    //! `set_now_playing` call so apps that don't use Now Playing don't
+    //! pay the zbus / tokio-runtime startup cost.
+    //!
+    //! Threading: the zbus connection lives on a dedicated tokio
+    //! current-thread runtime. The `PlayerInterface` impl runs there
+    //! and forwards method calls (Play / Pause / Seek …) into a
+    //! `std::sync::mpsc` queue that `poll_tick` drains on the main
+    //! GLib thread — that's where the GStreamer pipelines live
+    //! (thread_local PLAYERS), so all pipeline mutation stays on
+    //! the main thread.
+    //!
+    //! Property pushes (Metadata / PlaybackStatus) go the other way
+    //! through a tokio mpsc channel: the main thread enqueues, the
+    //! runtime drains and calls `Server::properties_changed` from
+    //! within an async context.
+
+    use super::{first_active_handle, MediaState};
+    use mpris_server::{
+        zbus::{fdo, Result as ZResult},
+        LoopStatus, Metadata, PlaybackRate, PlaybackStatus, PlayerInterface, Property,
+        RootInterface, Server, Time, TrackId, Volume,
+    };
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::{mpsc, Mutex, OnceLock};
+    use tokio::sync::mpsc as tmpsc;
+
+    /// D-Bus → main thread.
+    enum Command {
+        Play,
+        Pause,
+        PlayPause,
+        Stop,
+        /// offset in seconds (signed)
+        SeekRelative(f64),
+        /// absolute position in seconds
+        SeekAbsolute(f64),
+    }
+
+    /// Main thread → tokio runtime.
+    enum Update {
+        Metadata(Metadata),
+        Status(PlaybackStatus),
+    }
+
+    static CMD_TX: OnceLock<Mutex<mpsc::Sender<Command>>> = OnceLock::new();
+    static CMD_RX: OnceLock<Mutex<mpsc::Receiver<Command>>> = OnceLock::new();
+    static UPDATE_TX: OnceLock<tmpsc::UnboundedSender<Update>> = OnceLock::new();
+    static INIT_FAILED: AtomicBool = AtomicBool::new(false);
+    static TRACKID_COUNTER: AtomicU64 = AtomicU64::new(0);
+    static LAST_STATUS: Mutex<Option<PlaybackStatus>> = Mutex::new(None);
+
+    fn ensure_started() -> bool {
+        if INIT_FAILED.load(Ordering::Relaxed) {
+            return false;
+        }
+        if UPDATE_TX.get().is_some() {
+            return true;
+        }
+        // Single-shot initializer — racing callers either both succeed
+        // or both fail (the OnceLock writes are atomic).
+        let (cmd_tx, cmd_rx) = mpsc::channel::<Command>();
+        let _ = CMD_TX.set(Mutex::new(cmd_tx));
+        let _ = CMD_RX.set(Mutex::new(cmd_rx));
+
+        let (utx, urx) = tmpsc::unbounded_channel::<Update>();
+        // The runtime owns urx; we share utx via OnceLock.
+        if UPDATE_TX.set(utx).is_err() {
+            return true; // another thread won the race
+        }
+
+        let pid = std::process::id();
+        std::thread::Builder::new()
+            .name("perry-mpris".into())
+            .spawn(move || {
+                let rt = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(r) => r,
+                    Err(_) => {
+                        INIT_FAILED.store(true, Ordering::Relaxed);
+                        return;
+                    }
+                };
+                rt.block_on(async move {
+                    run_server(pid, urx).await;
+                });
+            })
+            .map(|_| true)
+            .unwrap_or_else(|_| {
+                INIT_FAILED.store(true, Ordering::Relaxed);
+                false
+            })
+    }
+
+    async fn run_server(pid: u32, mut urx: tmpsc::UnboundedReceiver<Update>) {
+        // Bus name pattern `org.mpris.MediaPlayer2.<suffix>` — Server
+        // prepends the prefix internally, so we only supply the
+        // suffix (`perry-<pid>`).
+        let suffix = format!("perry-{}", pid);
+        let server = match Server::new(&suffix, PerryPlayer).await {
+            Ok(s) => s,
+            Err(_) => {
+                INIT_FAILED.store(true, Ordering::Relaxed);
+                return;
+            }
+        };
+        while let Some(update) = urx.recv().await {
+            let prop = match update {
+                Update::Metadata(m) => Property::Metadata(m),
+                Update::Status(s) => Property::PlaybackStatus(s),
+            };
+            let _ = server.properties_changed([prop]).await;
+        }
+    }
+
+    pub fn push_now_playing(title: String, artist: String, album: String, artwork: String) {
+        if !ensure_started() {
+            return;
+        }
+        let trackid_str = format!(
+            "/org/perry/track/{}",
+            TRACKID_COUNTER.fetch_add(1, Ordering::Relaxed)
+        );
+        let mut builder = Metadata::builder().title(title);
+        if !artist.is_empty() {
+            // Spec: xesam:artist is a string list even for a single artist.
+            builder = builder.artist([artist]);
+        }
+        if !album.is_empty() {
+            builder = builder.album(album);
+        }
+        if !artwork.is_empty() {
+            builder = builder.art_url(artwork);
+        }
+        if let Ok(tid) = TrackId::try_from(trackid_str.as_str()) {
+            builder = builder.trackid(tid);
+        }
+        let metadata = builder.build();
+        if let Some(tx) = UPDATE_TX.get() {
+            let _ = tx.send(Update::Metadata(metadata));
+        }
+    }
+
+    pub fn push_playback_status(state: MediaState) {
+        let status = match state {
+            MediaState::Playing => PlaybackStatus::Playing,
+            MediaState::Paused | MediaState::Ready => PlaybackStatus::Paused,
+            MediaState::Idle | MediaState::Loading | MediaState::Ended | MediaState::Error => {
+                PlaybackStatus::Stopped
+            }
+        };
+        // Don't push if MPRIS hasn't been initialised yet — we only
+        // bring up the D-Bus server on the first set_now_playing call,
+        // and a state change before that means the app isn't using
+        // Now Playing at all.
+        if UPDATE_TX.get().is_none() {
+            return;
+        }
+        // De-dupe identical status pushes; the GStreamer poll fires
+        // every 100 ms and most ticks don't change state, but
+        // derive_state() can still flip Loading↔Ready spuriously.
+        let mut last = LAST_STATUS.lock().unwrap();
+        if *last == Some(status) {
+            return;
+        }
+        *last = Some(status);
+        if let Some(tx) = UPDATE_TX.get() {
+            let _ = tx.send(Update::Status(status));
+        }
+    }
+
+    /// Drain any pending D-Bus commands and dispatch them to the
+    /// first live player. Called from `poll_tick` on the main thread.
+    pub fn drain_commands() {
+        let rx = match CMD_RX.get() {
+            Some(r) => r,
+            None => return,
+        };
+        let rx = rx.lock().unwrap();
+        while let Ok(cmd) = rx.try_recv() {
+            let handle = match first_active_handle() {
+                Some(h) => h,
+                None => continue,
+            };
+            match cmd {
+                Command::Play => super::play(handle),
+                Command::Pause => super::pause(handle),
+                Command::PlayPause => {
+                    if super::is_playing(handle) >= 0.5 {
+                        super::pause(handle);
+                    } else {
+                        super::play(handle);
+                    }
+                }
+                Command::Stop => super::stop(handle),
+                Command::SeekRelative(offset) => {
+                    let cur = super::current_position_seconds(handle);
+                    super::seek(handle, (cur + offset).max(0.0));
+                }
+                Command::SeekAbsolute(pos) => super::seek(handle, pos.max(0.0)),
+            }
+        }
+    }
+
+    fn send_cmd(cmd: Command) {
+        if let Some(tx) = CMD_TX.get() {
+            let _ = tx.lock().unwrap().send(cmd);
+        }
+    }
+
+    struct PerryPlayer;
+
+    impl RootInterface for PerryPlayer {
+        async fn raise(&self) -> fdo::Result<()> {
+            Ok(())
+        }
+        async fn quit(&self) -> fdo::Result<()> {
+            Ok(())
+        }
+        async fn can_quit(&self) -> fdo::Result<bool> {
+            Ok(false)
+        }
+        async fn fullscreen(&self) -> fdo::Result<bool> {
+            Ok(false)
+        }
+        async fn set_fullscreen(&self, _fullscreen: bool) -> ZResult<()> {
+            Ok(())
+        }
+        async fn can_set_fullscreen(&self) -> fdo::Result<bool> {
+            Ok(false)
+        }
+        async fn can_raise(&self) -> fdo::Result<bool> {
+            Ok(false)
+        }
+        async fn has_track_list(&self) -> fdo::Result<bool> {
+            Ok(false)
+        }
+        async fn identity(&self) -> fdo::Result<String> {
+            Ok("Perry".into())
+        }
+        async fn desktop_entry(&self) -> fdo::Result<String> {
+            Ok(String::new())
+        }
+        async fn supported_uri_schemes(&self) -> fdo::Result<Vec<String>> {
+            Ok(vec!["http".into(), "https".into(), "file".into()])
+        }
+        async fn supported_mime_types(&self) -> fdo::Result<Vec<String>> {
+            Ok(vec![
+                "audio/mpeg".into(),
+                "audio/aac".into(),
+                "audio/ogg".into(),
+                "audio/flac".into(),
+                "audio/wav".into(),
+                "audio/x-wav".into(),
+            ])
+        }
+    }
+
+    impl PlayerInterface for PerryPlayer {
+        async fn next(&self) -> fdo::Result<()> {
+            Ok(())
+        }
+        async fn previous(&self) -> fdo::Result<()> {
+            Ok(())
+        }
+        async fn pause(&self) -> fdo::Result<()> {
+            send_cmd(Command::Pause);
+            Ok(())
+        }
+        async fn play_pause(&self) -> fdo::Result<()> {
+            send_cmd(Command::PlayPause);
+            Ok(())
+        }
+        async fn stop(&self) -> fdo::Result<()> {
+            send_cmd(Command::Stop);
+            Ok(())
+        }
+        async fn play(&self) -> fdo::Result<()> {
+            send_cmd(Command::Play);
+            Ok(())
+        }
+        async fn seek(&self, offset: Time) -> fdo::Result<()> {
+            send_cmd(Command::SeekRelative(offset.as_micros() as f64 / 1_000_000.0));
+            Ok(())
+        }
+        async fn set_position(&self, _track_id: TrackId, position: Time) -> fdo::Result<()> {
+            send_cmd(Command::SeekAbsolute(
+                position.as_micros() as f64 / 1_000_000.0,
+            ));
+            Ok(())
+        }
+        async fn open_uri(&self, _uri: String) -> fdo::Result<()> {
+            Ok(())
+        }
+        async fn playback_status(&self) -> fdo::Result<PlaybackStatus> {
+            Ok(LAST_STATUS
+                .lock()
+                .unwrap()
+                .unwrap_or(PlaybackStatus::Stopped))
+        }
+        async fn loop_status(&self) -> fdo::Result<LoopStatus> {
+            Ok(LoopStatus::None)
+        }
+        async fn set_loop_status(&self, _loop_status: LoopStatus) -> ZResult<()> {
+            Ok(())
+        }
+        async fn rate(&self) -> fdo::Result<PlaybackRate> {
+            Ok(1.0)
+        }
+        async fn set_rate(&self, _rate: PlaybackRate) -> ZResult<()> {
+            Ok(())
+        }
+        async fn shuffle(&self) -> fdo::Result<bool> {
+            Ok(false)
+        }
+        async fn set_shuffle(&self, _shuffle: bool) -> ZResult<()> {
+            Ok(())
+        }
+        async fn metadata(&self) -> fdo::Result<Metadata> {
+            Ok(Metadata::new())
+        }
+        async fn volume(&self) -> fdo::Result<Volume> {
+            Ok(1.0)
+        }
+        async fn set_volume(&self, _volume: Volume) -> ZResult<()> {
+            Ok(())
+        }
+        async fn position(&self) -> fdo::Result<Time> {
+            Ok(Time::ZERO)
+        }
+        async fn minimum_rate(&self) -> fdo::Result<PlaybackRate> {
+            Ok(1.0)
+        }
+        async fn maximum_rate(&self) -> fdo::Result<PlaybackRate> {
+            Ok(1.0)
+        }
+        async fn can_go_next(&self) -> fdo::Result<bool> {
+            Ok(false)
+        }
+        async fn can_go_previous(&self) -> fdo::Result<bool> {
+            Ok(false)
+        }
+        async fn can_play(&self) -> fdo::Result<bool> {
+            Ok(true)
+        }
+        async fn can_pause(&self) -> fdo::Result<bool> {
+            Ok(true)
+        }
+        async fn can_seek(&self) -> fdo::Result<bool> {
+            Ok(true)
+        }
+        async fn can_control(&self) -> fdo::Result<bool> {
+            Ok(true)
+        }
     }
 }

--- a/docs/src/system/media.md
+++ b/docs/src/system/media.md
@@ -88,7 +88,7 @@ tick if the signal hasn't arrived.
 | tvOS | AVPlayer + Siri Remote play/pause/skip | **Implemented** + remote |
 | visionOS | AVPlayer + UIImage artwork | **Implemented** + lock-screen |
 | Android | `android.media.MediaPlayer` via JNI | **Implemented** (lock-screen via `MediaSessionCompat` is a follow-up) |
-| GTK4 / Linux | GStreamer `playbin` element | **Implemented** (MPRIS lock-screen is a follow-up) |
+| GTK4 / Linux | GStreamer `playbin` element + MPRIS D-Bus | **Implemented** + lock-screen |
 | Windows | `Windows.Media.Playback.MediaPlayer` (WinRT) | **Implemented** (`SystemMediaTransportControls` lock-screen is a follow-up) |
 | watchOS | AVPlayer (limited; `WKApplication` Now Playing has a different shape) | Stub |
 | HarmonyOS | `@ohos.multimedia.media.AVPlayer` via napi | Stub |
@@ -98,6 +98,16 @@ Stub platforms link cleanly against the same FFI surface — code that
 imports `perry/media` compiles on every target. `createPlayer` returns
 `0` on a stub backend so `if (player === 0)` is the canonical "feature
 not available here" check.
+
+On Linux, `setNowPlaying` exposes the player to the desktop via MPRIS
+(`org.mpris.MediaPlayer2.perry-<pid>` on the session bus). GNOME Shell,
+KDE Plasma, `playerctl`, and any Bluetooth-headphone media-key bridge
+that speaks MPRIS will see the metadata and route Play / Pause /
+PlayPause / Stop / Seek / SetPosition back to the player. The MPRIS
+server is lazy-bootstrapped on the first `setNowPlaying` call so apps
+that don't need lock-screen integration don't pay the zbus startup
+cost. `Next` / `Previous` are no-ops (single-track playback model);
+playlists are an app-level concern.
 
 ### Threading notes
 


### PR DESCRIPTION
Closes #366. Wires `setNowPlaying` (and the GStreamer state poller) on the GTK4 / Linux backend through MPRIS — the canonical Linux desktop spec exposed over D-Bus as `org.mpris.MediaPlayer2.<suffix>`. GNOME Shell, KDE Plasma, `playerctl`, and any Bluetooth-headphone media-key bridge that speaks MPRIS now sees the metadata and routes Play / Pause / PlayPause / Stop / Seek / SetPosition back to the player.

## Summary

- New `mpris` submodule in `crates/perry-ui-gtk4/src/media_playback.rs` (gated on `cfg(target_os = "linux")` — `mpris-server` / `zbus` have Linux-specific system deps that don't build on macOS or Windows hosts).
- D-Bus connection lives on a dedicated tokio current-thread runtime spawned in a `perry-mpris` thread. Lazy-bootstrapped on the first `setNowPlaying` call so apps that don't use Now Playing don't pay the zbus startup cost.
- Bus name pattern `org.mpris.MediaPlayer2.perry-<pid>` per the spec (suffix passed to `Server::new`, prefix prepended internally).
- `PlayerInterface` implements: `Play` / `Pause` / `PlayPause` / `Stop` / `Seek` / `SetPosition` — each posts a `Command` into a `std::sync::mpsc` queue that `poll_tick` drains on the GLib main thread (where the GStreamer pipelines live in `thread_local PLAYERS`). All pipeline mutation stays on the main thread. Commands route to the first live player handle, matching the Apple-platform pattern.
- `Next` / `Previous` are no-ops (single-track playback model — playlists are an app-level concern).
- Property pushes (`Metadata` / `PlaybackStatus`) go the other way through a tokio mpsc channel: the main thread enqueues, the runtime drains and calls `Server::properties_changed` from within an async context.
- `Metadata` builder populates `xesam:title` / `xesam:artist` (List<String> per spec, even for one artist) / `xesam:album` / `mpris:artUrl` / `mpris:trackid` (unique opaque path `/org/perry/track/<atomic counter>`).
- `PlaybackStatus` is offered to MPRIS on every poll tick (not just on `state_changed`); the `LAST_STATUS` mutex dedupes so redundant D-Bus traffic stays at zero. This fixes the boot race where a state transition that fires before the first `setNowPlaying` call (which lazy-bootstraps the server) would never reach desktop clients.
- `RootInterface` declares `Identity = "Perry"`, supported URI schemes `http`/`https`/`file`, supported MIME types `audio/{mpeg,aac,ogg,flac,wav,x-wav}`. `Quit` / `Raise` / `Fullscreen` are no-ops with the corresponding `Can*` returning false.
- `Cargo.toml`: `mpris-server = { version = "0.10", features = ["tokio"] }` and `tokio = { version = "1", features = ["rt", "sync", ...] }` under `[target.'cfg(target_os = "linux")'.dependencies]`. The `tokio` feature on `mpris-server` flips on `zbus/tokio` so zbus drives I/O on the same runtime that hosts the `PlayerInterface` impl.
- `docs/src/system/media.md`: GTK4 row in the platform matrix flipped to "Implemented + lock-screen", added a paragraph describing the MPRIS exposure pattern.

## What's verified

- Code review against `mpris-server` v0.10.0 source (locally fetched into the cargo registry):
  - `Server::new(suffix: &str, T)` signature matches.
  - `Server::properties_changed(impl IntoIterator<Item = Property>)` matches.
  - `Metadata::builder().title(String).artist([String]).album(String).art_url(impl Into<Uri>).trackid(impl Into<TrackId>).build()` matches.
  - `PlayerInterface` / `RootInterface` trait method signatures all match (each method is `async fn` returning `fdo::Result<...>` for getters and either `fdo::Result<()>` or `zbus::Result<()>` for setters; the wip uses `ZResult` alias for the latter).
  - `Time::as_micros() -> i64` matches; `Seek` offset and `SetPosition` position both decoded as `as_micros() as f64 / 1_000_000.0` for seconds.
  - `PlaybackStatus` derives `Copy + PartialEq + Eq` so the `Mutex<Option<PlaybackStatus>>` dedupe and `unwrap_or` work.
  - `TrackId::try_from(&str)` validates the object path internally; `/org/perry/track/<n>` is well-formed per spec.
- `Cargo.lock` resolves `mpris-server 0.10.0`, `zbus[tokio]`, `tokio[tracing]` cleanly via `cargo fetch`.
- macOS / iOS / tvOS / visionOS / Android / Windows / web builds are unaffected — the `mpris` module is gated on `cfg(target_os = "linux")` and `set_now_playing` falls through to a no-op stub elsewhere.

## What needs CI on a Linux host

`gstreamer-1.0` and `dbus`/`zbus` system deps aren't installed on the macOS authoring host, so the GTK4 crate can't be compiled here. CI on a Linux runner (or a developer with `apt install libgstreamer1.0-dev libdbus-1-dev`) needs to:

- Confirm `cargo build --release -p perry-ui-gtk4` is clean.
- Smoke test the four acceptance criteria from #366:
  - [ ] `setNowPlaying` updates the GNOME / KDE volume HUD media tile.
  - [ ] `playerctl play-pause` from another terminal toggles the Perry app's playback.
  - [ ] Bluetooth headphone media keys work via the desktop's MPRIS bridge.
  - [ ] State poller publishes `PlaybackStatus` changes (`gdbus monitor --session --dest org.mpris.MediaPlayer2.perry-<pid>` should show `PropertiesChanged` events on play/pause/stop/end transitions).