### PR TITLE
fix(runtime): #393 reject invalid box pointers in js_box_set/get

### DIFF
--- a/crates/perry-runtime/src/box.rs
+++ b/crates/perry-runtime/src/box.rs
@@ -32,13 +32,19 @@ pub extern "C" fn js_box_alloc(initial_value: f64) -> *mut Box {
 }
 
 /// Get the value from a box
+///
+/// Same robustness as `js_box_set`: invalid pointers return NaN
+/// rather than dereferencing. See perry#393 for the failure mode.
 #[no_mangle]
 pub extern "C" fn js_box_get(ptr: *mut Box) -> f64 {
     unsafe {
-        if ptr.is_null() {
+        if !is_plausible_box_ptr(ptr) {
             let count = BOX_GET_NULL_COUNT.fetch_add(1, Ordering::Relaxed);
             if count < 3 {
-                eprintln!("[PERRY WARN] js_box_get: null box pointer #{}", count);
+                eprintln!(
+                    "[PERRY WARN] js_box_get: invalid box pointer {:p} #{}",
+                    ptr, count
+                );
             }
             return f64::NAN;
         }
@@ -47,14 +53,25 @@ pub extern "C" fn js_box_get(ptr: *mut Box) -> f64 {
 }
 
 /// Set the value in a box
+///
+/// Robust against bogus pointers: in addition to the null check, we
+/// reject obviously-invalid pointers (below the first user page or
+/// above the 48-bit user-address ceiling) and pointers that aren't
+/// 8-byte aligned. This avoids SIGSEGV on `(*ptr).value = value` when
+/// upstream codegen hands us a stale/uninitialized slot — a known
+/// failure mode for closure prologues at hub-scale (perry#393).
+/// Boxes are heap-allocated 8-byte f64s; a non-aligned or low/high
+/// pointer is definitely wrong, so a silent skip + telemetry warning
+/// is strictly safer than dereferencing it.
 #[no_mangle]
 pub extern "C" fn js_box_set(ptr: *mut Box, value: f64) {
     unsafe {
-        if ptr.is_null() {
+        if !is_plausible_box_ptr(ptr) {
             let count = BOX_SET_NULL_COUNT.fetch_add(1, Ordering::Relaxed);
             if count < 3 {
                 eprintln!(
-                    "[PERRY WARN] js_box_set: null box pointer #{} (value bits: 0x{:016x})",
+                    "[PERRY WARN] js_box_set: invalid box pointer {:p} #{} (value bits: 0x{:016x})",
+                    ptr,
                     count,
                     value.to_bits()
                 );
@@ -63,4 +80,31 @@ pub extern "C" fn js_box_set(ptr: *mut Box, value: f64) {
         }
         (*ptr).value = value;
     }
+}
+
+/// Cheap pointer-sanity test — same threat model as `get_valid_func_ptr`
+/// in closure.rs, adapted for box-shaped allocations.
+///
+/// A `*mut Box` from `js_box_alloc` is a Rust-`alloc()` heap pointer,
+/// which on x86_64 Linux/macOS lives in the 47-bit user-address half
+/// of the address space and (because `Layout::new::<Box>()` yields
+/// `align = 8`) is 8-byte aligned. Pointers below the first user page
+/// or above the user-address ceiling, or unaligned ones, can only come
+/// from stale/uninitialized stack slots reinterpreted as box pointers.
+#[inline]
+fn is_plausible_box_ptr(ptr: *mut Box) -> bool {
+    let addr = ptr as usize;
+    if addr == 0 {
+        return false;
+    }
+    if addr < 0x1000 {
+        return false;
+    }
+    if addr >= 0x0001_0000_0000_0000 {
+        return false;
+    }
+    if addr % std::mem::align_of::<Box>() != 0 {
+        return false;
+    }
+    true
 }


### PR DESCRIPTION
## What

Reject obviously-invalid pointers in `js_box_set` and `js_box_get` instead of dereferencing them, mirroring the threat model `get_valid_func_ptr` already applies to closure pointers.

## Why

Tracking #393. perry-hub on perry HEAD (0.5.465 / 0.5.468) was SIGSEGVing at startup with no output. Bisected the fault down to:

```
test  %rdi, %rdi
je    <warning_branch>
=> movsd %xmm0, (%rdi)   ← SEGFAULT
```

inside `js_box_set` — the null check passes (rdi is non-zero), but `(*ptr).value = value` faults because `ptr` is non-null garbage. The bad pointers observed in production:

- `0x40ab000000000000` — looks like a NaN-boxed double's bit pattern misinterpreted as a pointer
- `0x434c4f5300000000` — that's `"CLOS\0\0\0\0"` packed; this is the `CLOSURE_MAGIC` constant. Codegen is handing us a closure header where it expects a `*mut Box`.
- `0x1f1f1f1f1f1f1f1f`, `0x1616161616161616` — uninitialized stack-slot patterns

The actual codegen bug that produces these calls is filed as #393 and is layout-sensitive — the offending TS construct flickers based on total binary size, so it's a register/slot allocation issue, not a localized pattern. **This PR doesn't fix the codegen bug.** It fixes the runtime so a misissued `js_box_set(garbage, value)` falls through the same warn-and-return path the existing null check uses, instead of dereferencing.

`js_box_alloc` returns a `Rust alloc()` heap pointer, which:
- is non-null on success,
- lives in the 47-bit user-address half of the address space on x86_64 Linux/macOS,
- is 8-byte aligned (`align_of::<Box>() == 8`).

So a value below the first user page, above `0x1000_0000_0000_0000`, or unaligned on 8 bytes can only come from a stale/uninitialized slot. Returning early in that case + emitting a single telemetry line is strictly safer than the current `(*ptr).value = value`.

## Tested

- Local `cargo build --release -p perry-runtime` clean.
- Built perry-hub against patched runtime on a Linux x86_64 hub server (perry 0.5.465).
- Hub now boots cleanly: HTTP 3456 + WS 3457 listening, workers reconnect, real multipart `POST /api/v1/build` requests get parsed past the multipart layer and into license check (the rest of the path was already verified working).
- Logged warnings during startup confirm we're catching the bad pointers without crashing:
  ```
  [PERRY WARN] js_box_set: invalid box pointer 0x40ab000000000000 #0 (value bits: 0x7ffc000000000002)
  [PERRY WARN] js_box_set: invalid box pointer 0x434c4f5300000000 #1 (value bits: 0x7ffc000000000004)
  ```

## Caveats

- Defense-in-depth, not a fix for the underlying codegen issue. The misissued `js_box_set` calls correspond to writes that the user's TS code didn't ask for (silent skip is no behavioral change for them) — but if a future codegen actually NEEDS to write through one of these pointers, the silent skip becomes a real bug. Should remove this guard once #393 lands a real fix and there's a regression test.
- The codegen bug looks like spurious parameter boxing for arrow-function closures (the user callback in question has an empty body and no captures, yet codegen emits `js_box_set` calls in its prologue). Worth a follow-up audit of the closure-prologue path in `crates/perry-codegen/src/codegen.rs::compile_closure`.

## Related

- Closes the immediate hub-deploy blocker tracked in #393.
- The `get_valid_func_ptr` precedent in `crates/perry-runtime/src/closure.rs:153` is the same pattern applied to closure pointers — this just brings boxes up to the same bar.
