### PR TITLE
fix(publish): #416 walk root always kept regardless of publish.exclude

### DIFF
--- a/crates/perry/src/commands/publish.rs
+++ b/crates/perry/src/commands/publish.rs
@@ -2656,6 +2656,16 @@ pub(crate) fn create_project_tarball_with_excludes(
 
     // Walk the project directory
     for entry in WalkDir::new(project_dir).into_iter().filter_entry(|e| {
+        // The walk root is always kept — exclusion rules below apply to
+        // children only. Without this guard, a user whose project root
+        // basename happens to match a bare-name entry in
+        // `publish.exclude` (typical when excluding a built binary that
+        // shares a name with the project dir) would have the entire
+        // tree pruned at depth 0, producing an empty tarball with no
+        // CLI-side error. Tracked in #416.
+        if e.depth() == 0 {
+            return true;
+        }
         let name = e.file_name().to_string_lossy();
         if builtin_exclude_dirs.iter().any(|ex| name == *ex) {
             return false;


### PR DESCRIPTION
## What

`create_project_tarball_with_excludes` now keeps the walk root regardless of `publish.exclude` — only descendants are subject to exclusion rules.

## Why

`WalkDir::new(project_dir).into_iter().filter_entry(...)` runs the filter on every entry including the starting directory itself. The existing filter rejected any entry whose basename matched a bare-name entry in `publish.exclude`. When a user's project root basename happens to match one of those bare-name entries — a common case is when the project dir and a built artifact binary share a name — the filter rejects the root and WalkDir prunes the entire tree at depth 0, returning zero entries. `resolve_file_deps` then appends `file:` deps to the tarball through a separate `WalkDir`, so the resulting upload has non-zero bytes and the CLI reports `Packaging project... done (N MB)`. The build worker on the other side correctly reports `Entry file not found` because `src/main.ts` (and everything else) was never packaged.

This silently broke every CI release for `Bloom-Engine/jump` — repo lives at `github.com/Bloom-Engine/jump`, root dir is `jump`, perry.toml had `publish.exclude = [..., "jump", ...]` to exclude the compiled binary that shares a name with the project dir. Took an hour to track down because the CLI side looks normal end-to-end.

## Fix

Add an early `if e.depth() == 0 { return true; }` to the filter closure. The walk root structurally cannot be a meaningful exclusion target — if you don't want the project, you don't run `perry publish`. All existing exclusion behavior is preserved for descendants.

## Tested

- `cargo check -p perry` clean.
- Built locally and pointed at a project with `publish.exclude = ["mynameisjump"]` whose root dir is named `mynameisjump` — before: 0 project files in tarball; after: full project tree present.
- The Bloom-Engine/jump release path is now ready to retry from this fix.

## Caveats / followup

- Bare-name `publish.exclude` entries continue to match by basename anywhere. After this PR it's no longer a footgun for the project root, but a user could still inadvertently exclude an unrelated nested directory by giving it the same name as something they meant to exclude near the project root. Worth a docs note pointing users to path-anchored entries (`/jump`, `./jump`) for binaries that live near root and share a name with another file/dir somewhere. Not blocking this fix.

## Related

Closes #416.
