### PR TITLE
docs(i18n): set up translations for de/ja/ko/zh-CN

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,11 @@ jobs:
           mkdir -p "$HOME/.cargo/bin"
           tag=$(curl -sS -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/rust-lang/mdBook/releases/latest | jq -r .tag_name)
           curl -sSL "https://github.com/rust-lang/mdBook/releases/download/${tag}/mdbook-${tag}-x86_64-unknown-linux-gnu.tar.gz" | tar -xz -C "$HOME/.cargo/bin"
-      - name: Build docs
+      - name: Install mdbook-i18n-helpers
+        run: cargo install mdbook-i18n-helpers --locked --version 0.4.0
+      - name: Build docs (all languages)
         run: |
-          mdbook build docs
+          ./docs/i18n.sh build-all
           cp docs/CNAME docs/book/CNAME
       - uses: actions/configure-pages@v4
       - uses: actions/upload-pages-artifact@v3

--- a/docs/TRANSLATING.md
+++ b/docs/TRANSLATING.md
@@ -1,0 +1,46 @@
+# Translating the Perry docs
+
+The Perry documentation is internationalized via [`mdbook-i18n-helpers`](https://github.com/google/mdbook-i18n-helpers) (gettext `.po` files). English lives in `docs/src/`; translations live in `docs/po/<lang>.po`.
+
+Site layout:
+
+- English: `https://docs.perryts.com/`
+- Other languages: `https://docs.perryts.com/<lang>/` (currently `/de/`, `/ja/`, `/ko/`, `/zh-CN/`)
+
+The current `.po` files include a seed translation of the sidebar navigation, the introduction page, and the Getting Started chapter headings. Everything beyond that falls through to English until translators fill in more `msgstr` entries.
+
+## Translating an existing language
+
+1. Open `docs/po/<lang>.po` (e.g. `de.po`).
+2. Find entries with `msgstr ""` and fill in the translation. Leave `msgid` (the English source) untouched.
+3. Preview locally: `./docs/i18n.sh build de` then open `docs/book/de/introduction.html`.
+4. Open a PR. Untranslated entries fall back to English automatically — partial PRs are welcome.
+
+Notes:
+
+- Markdown formatting in the source is preserved by gettext — translate the prose, keep `**bold**`, `[links](...)`, and code spans intact.
+- Code blocks are extracted as their own entries; usually leave them as-is unless you're translating an inline comment.
+- Entries marked `#, fuzzy` mean the English source changed since the translation was written. Review, fix the `msgstr`, and remove the `#, fuzzy` line.
+
+## Adding a new language
+
+```bash
+./docs/i18n.sh add zh-CN     # creates po/zh-CN.po
+# edit po/zh-CN.po, fill in some msgstr entries
+./docs/i18n.sh build zh-CN   # preview at docs/book/zh-CN/
+```
+
+Then add the language to the picker in `docs/theme/language-switcher.js` (one line in the `LANGS` array) and submit a PR. CI will auto-build it; no workflow edit needed.
+
+Use a [BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) code: `de`, `ja`, `ko`, `zh-CN`, `zh-TW`, `fr`, `es`, `pt-BR`, etc.
+
+## Maintainer: refreshing translations after English changes
+
+When the English source changes, the `.po` files need to be re-synced so translators see the new/changed strings:
+
+```bash
+./docs/i18n.sh extract   # regenerates po/messages.pot from src/
+./docs/i18n.sh sync      # merges .pot into every po/<lang>.po
+```
+
+`sync` preserves existing translations, adds new entries with empty `msgstr`, and marks edited entries `#, fuzzy` for review. Commit the updated `.pot` and `.po` files alongside the English changes.

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,12 +8,16 @@ src = "src"
 build-dir = "book"
 create-missing = false
 
+[preprocessor.gettext]
+after = ["links"]
+
 [output.html]
 default-theme = "light"
 preferred-dark-theme = "ayu"
 site-url = "https://docs.perryts.com/"
 git-repository-url = "https://github.com/skelpo/perry"
 edit-url-template = "https://github.com/skelpo/perry/edit/main/docs/src/{path}"
+additional-js = ["theme/language-switcher.js"]
 
 [output.html.search]
 enable = true

--- a/docs/i18n.sh
+++ b/docs/i18n.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Translation helper for the Perry docs.
+#
+# Usage:
+#   ./docs/i18n.sh extract         Regenerate po/messages.pot from English source
+#   ./docs/i18n.sh sync            Merge .pot into every po/<lang>.po
+#   ./docs/i18n.sh add <lang>      Create po/<lang>.po (e.g. ./docs/i18n.sh add zh-CN)
+#   ./docs/i18n.sh build <lang>    Build a single language into book/<lang>/
+#   ./docs/i18n.sh build-all       Build English + every po/<lang>.po into book/
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+cmd=${1:-help}
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || { echo "missing tool: $1" >&2; exit 1; }
+}
+
+extract() {
+  require mdbook
+  require mdbook-xgettext
+  rm -rf /tmp/perry-i18n-extract
+  MDBOOK_OUTPUT__XGETTEXT__POT_FILE=messages.pot \
+    mdbook build -d /tmp/perry-i18n-extract >/dev/null
+  mkdir -p po
+  cp /tmp/perry-i18n-extract/xgettext/messages.pot po/messages.pot
+  rm -rf /tmp/perry-i18n-extract
+  echo "wrote po/messages.pot"
+}
+
+sync_all() {
+  require msgmerge
+  for f in po/*.po; do
+    [ -e "$f" ] || continue
+    msgmerge --quiet --update --backup=none "$f" po/messages.pot
+    echo "synced $f"
+  done
+}
+
+add_lang() {
+  require msginit
+  local lang=${1:?usage: i18n.sh add <lang>}
+  local out="po/${lang}.po"
+  if [ -e "$out" ]; then
+    echo "$out already exists" >&2
+    exit 1
+  fi
+  [ -e po/messages.pot ] || extract
+  msginit -i po/messages.pot -l "${lang}.UTF-8" -o "$out" --no-translator
+  echo "created $out — translate msgstr entries and submit a PR"
+}
+
+build_one() {
+  require mdbook
+  require mdbook-gettext
+  local lang=${1:?usage: i18n.sh build <lang>}
+  if [ "$lang" = "en" ]; then
+    mdbook build -d book
+  else
+    [ -e "po/${lang}.po" ] || { echo "po/${lang}.po not found" >&2; exit 1; }
+    MDBOOK_BOOK__LANGUAGE="$lang" mdbook build -d "book/${lang}"
+  fi
+}
+
+build_all() {
+  build_one en
+  for f in po/*.po; do
+    [ -e "$f" ] || continue
+    local lang
+    lang=$(basename "$f" .po)
+    build_one "$lang"
+  done
+}
+
+case "$cmd" in
+  extract)   extract ;;
+  sync)      sync_all ;;
+  add)       add_lang "${2:-}" ;;
+  build)     build_one "${2:-}" ;;
+  build-all) build_all ;;
+  *)
+    sed -n '2,9p' "$0"
+    exit 1 ;;
+esac

--- a/docs/po/de.po
+++ b/docs/po/de.po
@@ -1,0 +1,26531 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Perry Documentation\n"
+"POT-Creation-Date: 2026-05-02T21:12:49+02:00\n"
+"PO-Revision-Date: 2026-05-02T21:12:49+02:00\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/SUMMARY.md:1
+msgid "Summary"
+msgstr "Übersicht"
+
+#: src/SUMMARY.md:3 src/introduction.md:1
+msgid "Introduction"
+msgstr "Einführung"
+
+#: src/SUMMARY.md:7
+msgid "Getting Started"
+msgstr "Erste Schritte"
+
+#: src/SUMMARY.md:9 src/getting-started/installation.md:1 src/ui/theming.md:5
+msgid "Installation"
+msgstr "Installation"
+
+#: src/SUMMARY.md:10 src/getting-started/hello-world.md:1
+msgid "Hello World"
+msgstr "Hello World"
+
+#: src/SUMMARY.md:11 src/getting-started/first-app.md:1
+msgid "First Native App"
+msgstr "Erste native App"
+
+#: src/SUMMARY.md:12 src/getting-started/project-config.md:1
+msgid "Project Configuration"
+msgstr "Projektkonfiguration"
+
+#: src/SUMMARY.md:14
+msgid "Language"
+msgstr "Sprache"
+
+#: src/SUMMARY.md:16 src/platforms/wasm.md:39
+msgid "Supported Features"
+msgstr "Unterstützte Funktionen"
+
+#: src/SUMMARY.md:17 src/language/type-system.md:1
+msgid "Type System"
+msgstr "Typsystem"
+
+#: src/SUMMARY.md:18 src/language/limitations.md:1 src/platforms/tvos.md:156
+#: src/platforms/watchos.md:192 src/platforms/wasm.md:146
+msgid "Limitations"
+msgstr "Einschränkungen"
+
+#: src/SUMMARY.md:20
+msgid "npm Packages"
+msgstr "npm-Pakete"
+
+#: src/SUMMARY.md:22
+msgid "Porting Packages (experimental)"
+msgstr "Pakete portieren (experimentell)"
+
+#: src/SUMMARY.md:24 src/getting-started/hello-world.md:97
+#: src/threading/overview.md:1
+msgid "Multi-Threading"
+msgstr "Multithreading"
+
+#: src/SUMMARY.md:26 src/SUMMARY.md:33 src/SUMMARY.md:50 src/SUMMARY.md:66
+#: src/SUMMARY.md:76 src/SUMMARY.md:83 src/SUMMARY.md:87 src/SUMMARY.md:108
+msgid "Overview"
+msgstr "Übersicht"
+
+#: src/SUMMARY.md:27 src/threading/parallel-map.md:1
+msgid "parallelMap"
+msgstr ""
+
+#: src/SUMMARY.md:28 src/threading/parallel-filter.md:1
+msgid "parallelFilter"
+msgstr ""
+
+#: src/SUMMARY.md:29 src/threading/spawn.md:1
+msgid "spawn"
+msgstr ""
+
+#: src/SUMMARY.md:31
+msgid "Native UI"
+msgstr "Native UI"
+
+#: src/SUMMARY.md:34 src/SUMMARY.md:95 src/SUMMARY.md:97 src/ui/widgets.md:1
+msgid "Widgets"
+msgstr "Widgets"
+
+#: src/SUMMARY.md:35 src/ui/overview.md:174 src/ui/layout.md:1
+#: src/widgets/components.md:41
+msgid "Layout"
+msgstr "Layout"
+
+#: src/SUMMARY.md:36 src/ui/styling.md:1 src/platforms/linux.md:63
+msgid "Styling"
+msgstr "Gestaltung"
+
+#: src/SUMMARY.md:37 src/ui/state.md:1 src/platforms/watchos.md:105
+msgid "State Management"
+msgstr "Zustandsverwaltung"
+
+#: src/SUMMARY.md:38 src/ui/events.md:1 src/plugins/creating-plugins.md:104
+msgid "Events"
+msgstr "Ereignisse"
+
+#: src/SUMMARY.md:39 src/ui/canvas.md:1 src/platforms/macos.md:37
+#: src/platforms/android.md:38 src/platforms/windows.md:55
+#: src/platforms/linux.md:49
+msgid "Canvas"
+msgstr "Canvas"
+
+#: src/SUMMARY.md:40 src/ui/overview.md:175 src/ui/menus.md:1
+msgid "Menus"
+msgstr "Menüs"
+
+#: src/SUMMARY.md:41 src/ui/dialogs.md:1
+msgid "Dialogs"
+msgstr "Dialoge"
+
+#: src/SUMMARY.md:42 src/ui/table.md:1 src/platforms/macos.md:36
+#: src/testing/geisterhand.md:93 src/testing/geisterhand.md:296
+msgid "Table"
+msgstr "Tabelle"
+
+#: src/SUMMARY.md:43 src/ui/animation.md:1
+msgid "Animation"
+msgstr "Animation"
+
+#: src/SUMMARY.md:44
+msgid "Multi-Window"
+msgstr "Mehrfachfenster"
+
+#: src/SUMMARY.md:45 src/ui/theming.md:1
+msgid "Theming"
+msgstr "Themes"
+
+#: src/SUMMARY.md:46 src/ui/camera.md:1
+msgid "Camera"
+msgstr "Kamera"
+
+#: src/SUMMARY.md:48 src/system/overview.md:21
+msgid "Platforms"
+msgstr "Plattformen"
+
+#: src/SUMMARY.md:51 src/getting-started/installation.md:103
+#: src/ui/overview.md:170 src/ui/canvas.md:74 src/ui/menus.md:68
+#: src/ui/menus.md:111 src/ui/dialogs.md:108 src/ui/animation.md:64
+#: src/ui/multi-window.md:72 src/ui/multi-window.md:89
+#: src/ui/multi-window.md:100 src/ui/multi-window.md:116
+#: src/ui/multi-window.md:132 src/ui/multi-window.md:140
+#: src/platforms/overview.md:9 src/platforms/overview.md:67
+#: src/platforms/macos.md:1 src/i18n/overview.md:89
+#: src/updater/overview.md:257 src/system/preferences.md:34
+#: src/system/keychain.md:25 src/system/notifications.md:62
+#: src/system/audio.md:61 src/system/media.md:86 src/system/other.md:20
+#: src/system/other.md:37 src/plugins/native-extensions.md:275
+#: src/plugins/appstore-review.md:89 src/testing/geisterhand.md:259
+#: src/testing/geisterhand.md:331
+msgid "macOS"
+msgstr ""
+
+#: src/SUMMARY.md:52 src/ui/overview.md:170 src/ui/canvas.md:75
+#: src/ui/menus.md:112 src/ui/dialogs.md:108 src/ui/animation.md:65
+#: src/platforms/overview.md:10 src/platforms/overview.md:67
+#: src/platforms/ios.md:1 src/platforms/tvos.md:170 src/i18n/overview.md:90
+#: src/system/preferences.md:35 src/system/keychain.md:26
+#: src/system/notifications.md:63 src/system/audio.md:62
+#: src/system/media.md:87 src/system/other.md:21 src/system/other.md:38
+#: src/widgets/platforms.md:11 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:39 src/widgets/platforms.md:63
+#: src/plugins/native-extensions.md:273 src/plugins/appstore-review.md:73
+#: src/testing/geisterhand.md:260
+msgid "iOS"
+msgstr ""
+
+#: src/SUMMARY.md:53 src/platforms/overview.md:11 src/platforms/overview.md:67
+#: src/platforms/visionos.md:1 src/system/media.md:89
+msgid "visionOS"
+msgstr ""
+
+#: src/SUMMARY.md:54 src/platforms/overview.md:12 src/platforms/overview.md:67
+#: src/platforms/tvos.md:1 src/platforms/tvos.md:170 src/system/media.md:88
+msgid "tvOS"
+msgstr ""
+
+#: src/SUMMARY.md:55 src/platforms/overview.md:13 src/platforms/overview.md:67
+#: src/platforms/watchos.md:1 src/system/media.md:93
+#: src/widgets/platforms.md:14 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:49 src/widgets/platforms.md:79
+msgid "watchOS"
+msgstr ""
+
+#: src/SUMMARY.md:56 src/ui/canvas.md:78 src/ui/animation.md:66
+#: src/platforms/overview.md:14 src/platforms/overview.md:67
+#: src/platforms/android.md:1 src/i18n/overview.md:91 src/i18n/overview.md:104
+#: src/system/preferences.md:36 src/system/keychain.md:27
+#: src/system/notifications.md:64 src/system/audio.md:63
+#: src/system/media.md:90 src/system/other.md:22 src/system/other.md:39
+#: src/widgets/platforms.md:13 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:44 src/widgets/platforms.md:71
+#: src/plugins/native-extensions.md:276 src/plugins/appstore-review.md:102
+#: src/testing/geisterhand.md:261 src/cli/flags.md:27
+#: src/cli/perry-toml.md:501
+msgid "Android"
+msgstr ""
+
+#: src/SUMMARY.md:57 src/platforms/harmonyos.md:1
+msgid "HarmonyOS NEXT"
+msgstr "HarmonyOS NEXT"
+
+#: src/SUMMARY.md:58 src/getting-started/installation.md:121
+#: src/ui/overview.md:170 src/ui/styling.md:372 src/ui/canvas.md:77
+#: src/ui/menus.md:113 src/ui/dialogs.md:108 src/ui/animation.md:67
+#: src/ui/multi-window.md:73 src/ui/multi-window.md:90
+#: src/ui/multi-window.md:101 src/ui/multi-window.md:117
+#: src/ui/multi-window.md:133 src/ui/multi-window.md:141
+#: src/platforms/overview.md:15 src/platforms/overview.md:67
+#: src/platforms/windows.md:1 src/i18n/overview.md:92
+#: src/updater/overview.md:258 src/system/preferences.md:37
+#: src/system/keychain.md:28 src/system/notifications.md:65
+#: src/system/audio.md:65 src/system/media.md:92 src/system/other.md:23
+#: src/system/other.md:40 src/testing/geisterhand.md:263
+#: src/testing/geisterhand.md:392 src/cli/flags.md:36
+msgid "Windows"
+msgstr ""
+
+#: src/SUMMARY.md:59 src/platforms/windows-7.md:1
+msgid "Windows 7 Compatibility"
+msgstr "Windows 7-Kompatibilität"
+
+#: src/SUMMARY.md:60 src/platforms/linux.md:1 src/testing/geisterhand.md:262
+#: src/testing/geisterhand.md:379
+msgid "Linux (GTK4)"
+msgstr ""
+
+#: src/SUMMARY.md:61 src/ui/overview.md:170 src/ui/canvas.md:72
+#: src/ui/menus.md:115 src/ui/dialogs.md:108 src/ui/animation.md:69
+#: src/ui/multi-window.md:143 src/platforms/web.md:1
+#: src/system/preferences.md:39 src/system/keychain.md:30
+#: src/system/notifications.md:67 src/system/audio.md:66
+#: src/system/media.md:95 src/system/other.md:25 src/system/other.md:42
+#: src/cli/flags.md:35
+msgid "Web"
+msgstr ""
+
+#: src/SUMMARY.md:62 src/cli/flags.md:34
+msgid "WebAssembly"
+msgstr "WebAssembly"
+
+#: src/SUMMARY.md:64
+msgid "Standard Library"
+msgstr "Standardbibliothek"
+
+#: src/SUMMARY.md:67 src/stdlib/fs.md:1
+msgid "File System"
+msgstr "Dateisystem"
+
+#: src/SUMMARY.md:68 src/stdlib/http.md:1
+msgid "HTTP & Networking"
+msgstr "HTTP & Netzwerk"
+
+#: src/SUMMARY.md:69 src/stdlib/overview.md:22 src/stdlib/database.md:1
+msgid "Databases"
+msgstr "Datenbanken"
+
+#: src/SUMMARY.md:70 src/stdlib/overview.md:29 src/stdlib/crypto.md:1
+msgid "Cryptography"
+msgstr "Kryptografie"
+
+#: src/SUMMARY.md:71 src/stdlib/overview.md:36 src/stdlib/utilities.md:1
+#: src/cli/perry-toml.md:231
+msgid "Utilities"
+msgstr "Hilfsprogramme"
+
+#: src/SUMMARY.md:72 src/stdlib/other.md:1
+msgid "Other Modules"
+msgstr "Weitere Module"
+
+#: src/SUMMARY.md:74
+msgid "Internationalization"
+msgstr "Internationalisierung"
+
+#: src/SUMMARY.md:77 src/i18n/interpolation.md:1
+msgid "Interpolation & Plurals"
+msgstr "Interpolation & Plural"
+
+#: src/SUMMARY.md:78
+msgid "Formatting"
+msgstr "Formatierung"
+
+#: src/SUMMARY.md:79
+msgid "CLI Tools"
+msgstr "CLI-Werkzeuge"
+
+#: src/SUMMARY.md:81 src/updater/overview.md:1
+msgid "Auto-Update"
+msgstr "Automatische Updates"
+
+#: src/SUMMARY.md:85 src/platforms/overview.md:74 src/platforms/macos.md:75
+msgid "System APIs"
+msgstr "System-APIs"
+
+#: src/SUMMARY.md:88 src/system/preferences.md:1
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: src/SUMMARY.md:89 src/system/keychain.md:1
+msgid "Keychain"
+msgstr "Schlüsselbund"
+
+#: src/SUMMARY.md:90 src/system/notifications.md:1
+msgid "Notifications"
+msgstr "Benachrichtigungen"
+
+#: src/SUMMARY.md:91 src/system/audio.md:1
+msgid "Audio Capture"
+msgstr "Audioaufnahme"
+
+#: src/SUMMARY.md:92 src/system/media.md:1
+msgid "Media Playback"
+msgstr "Medienwiedergabe"
+
+#: src/SUMMARY.md:93 src/ui/menus.md:68 src/stdlib/overview.md:50
+msgid "Other"
+msgstr "Weitere"
+
+#: src/SUMMARY.md:98 src/widgets/creating-widgets.md:1
+msgid "Creating Widgets"
+msgstr "Widgets erstellen"
+
+#: src/SUMMARY.md:99
+msgid "Components & Modifiers"
+msgstr "Komponenten & Modifier"
+
+#: src/SUMMARY.md:100 src/platforms/visionos.md:35 src/platforms/tvos.md:123
+#: src/platforms/watchos.md:149 src/widgets/watchos.md:77
+#: src/plugins/creating-plugins.md:98 src/plugins/hooks-and-events.md:115
+msgid "Configuration"
+msgstr "Konfiguration"
+
+#: src/SUMMARY.md:101
+msgid "Data Fetching"
+msgstr "Datenabruf"
+
+#: src/SUMMARY.md:102 src/widgets/platforms.md:1
+msgid "Cross-Platform Reference"
+msgstr "Plattformübergreifende Referenz"
+
+#: src/SUMMARY.md:103 src/widgets/watchos.md:1
+msgid "watchOS Complications"
+msgstr "watchOS-Komplikationen"
+
+#: src/SUMMARY.md:104 src/widgets/wearos.md:1
+msgid "Wear OS Tiles"
+msgstr "Wear OS-Kacheln"
+
+#: src/SUMMARY.md:106
+msgid "Plugins"
+msgstr "Plug-ins"
+
+#: src/SUMMARY.md:109 src/plugins/creating-plugins.md:1
+msgid "Creating Plugins"
+msgstr "Plug-ins erstellen"
+
+#: src/SUMMARY.md:110 src/plugins/hooks-and-events.md:1
+msgid "Hooks & Events"
+msgstr "Hooks & Events"
+
+#: src/SUMMARY.md:111 src/plugins/overview.md:90
+#: src/plugins/native-extensions.md:1
+msgid "Native Extensions"
+msgstr "Native Erweiterungen"
+
+#: src/SUMMARY.md:112 src/plugins/appstore-review.md:1
+msgid "App Store Review"
+msgstr "App Store-Prüfung"
+
+#: src/SUMMARY.md:114
+msgid "Testing"
+msgstr "Testen"
+
+#: src/SUMMARY.md:116
+msgid "Geisterhand (UI Fuzzer)"
+msgstr "Geisterhand (UI-Fuzzer)"
+
+#: src/SUMMARY.md:118
+msgid "CLI Reference"
+msgstr "CLI-Referenz"
+
+#: src/SUMMARY.md:120
+msgid "Commands"
+msgstr "Befehle"
+
+#: src/SUMMARY.md:121 src/cli/flags.md:1
+msgid "Compiler Flags"
+msgstr "Compiler-Flags"
+
+#: src/SUMMARY.md:122 src/cli/perry-toml.md:1
+msgid "perry.toml Reference"
+msgstr "perry.toml-Referenz"
+
+#: src/SUMMARY.md:126
+msgid "Contributing"
+msgstr "Mitwirken"
+
+#: src/SUMMARY.md:128 src/platforms/harmonyos.md:5
+#: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
+msgid "Architecture"
+msgstr "Architektur"
+
+#: src/SUMMARY.md:129 src/contributing/building.md:1
+msgid "Building from Source"
+msgstr "Aus dem Quellcode bauen"
+
+#: src/introduction.md:3
+msgid ""
+"Perry is a native TypeScript compiler that compiles TypeScript source code "
+"directly to native executables. No JavaScript runtime, no JIT warmup, no V8 "
+"— your TypeScript compiles to a real binary."
+msgstr ""
+"Perry ist ein nativer TypeScript-Compiler, der TypeScript-Quellcode direkt "
+"in native ausführbare Dateien übersetzt. Keine JavaScript-Laufzeitumgebung, "
+"kein JIT-Warmup, kein V8 — Ihr TypeScript wird zu einer echten Binärdatei "
+"kompiliert."
+
+#: src/introduction.md:5
+msgid ""
+"```typescript\n"
+"// demonstrates: the one-liner hello shown on the docs landing page\n"
+"// docs: docs/src/introduction.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"console.log(\"Hello from Perry!\")\n"
+"```"
+msgstr ""
+
+#: src/introduction.md:20
+msgid "Why Perry?"
+msgstr "Warum Perry?"
+
+#: src/introduction.md:22
+msgid ""
+"**Native performance** — Compiles to machine code via LLVM. Integer-heavy "
+"code like Fibonacci runs 2x faster than Node.js."
+msgstr ""
+"**Native Performance** — Kompiliert via LLVM zu Maschinencode. Integer-"
+"intensiver Code wie Fibonacci läuft 2x schneller als unter Node.js."
+
+#: src/introduction.md:23
+msgid ""
+"**Real multi-threading** — `parallelMap` and `spawn` give you actual OS "
+"threads with compile-time safety. No isolates, no message passing overhead. "
+"[Something no JS runtime can do](threading/overview.md)."
+msgstr ""
+"**Echtes Multi-Threading** — `parallelMap` und `spawn` bieten echte OS-"
+"Threads mit Compile-Zeit-Sicherheit. Keine Isolates, kein Overhead durch "
+"Nachrichtenweitergabe. [Etwas, das keine JS-Laufzeitumgebung "
+"kann](threading/overview.md)."
+
+#: src/introduction.md:24
+msgid ""
+"**Small binaries** — A hello world is ~300KB. Perry detects what runtime "
+"features you use and only links what's needed."
+msgstr ""
+"**Kleine Binärdateien** — Ein Hello World ist ca. 300 KB groß. Perry "
+"erkennt, welche Laufzeit-Funktionen Sie verwenden, und verlinkt nur das "
+"Nötige."
+
+#: src/introduction.md:25
+msgid ""
+"**Native UI** — Build desktop and mobile apps with declarative TypeScript "
+"that compiles to real AppKit, UIKit, GTK4, Win32, or DOM widgets."
+msgstr ""
+"**Native UI** — Erstellen Sie Desktop- und Mobile-Apps mit deklarativem "
+"TypeScript, das zu echten AppKit-, UIKit-, GTK4-, Win32- oder DOM-Widgets "
+"kompiliert wird."
+
+#: src/introduction.md:26
+msgid ""
+"**7 targets** — macOS, iOS, Android, Windows, Linux, Web, and WebAssembly "
+"from the same source code."
+msgstr ""
+"**7 Plattformen** — macOS, iOS, Android, Windows, Linux, Web und WebAssembly"
+" aus demselben Quellcode."
+
+#: src/introduction.md:27
+msgid ""
+"**Familiar ecosystem** — Use npm packages like `fastify`, `mysql2`, `redis`,"
+" `bcrypt`, `lodash`, and more — compiled natively."
+msgstr ""
+"**Vertrautes Ökosystem** — Verwenden Sie npm-Pakete wie `fastify`, `mysql2`,"
+" `redis`, `bcrypt`, `lodash` und mehr — nativ kompiliert."
+
+#: src/introduction.md:28
+msgid ""
+"**Zero config** — Point Perry at a `.ts` file and get a binary. No "
+"`tsconfig.json` required."
+msgstr ""
+"**Keine Konfiguration nötig** — Geben Sie Perry eine `.ts`-Datei und "
+"erhalten Sie eine Binärdatei. Keine `tsconfig.json` erforderlich."
+
+#: src/introduction.md:30
+msgid "What Perry Compiles"
+msgstr "Was Perry kompiliert"
+
+#: src/introduction.md:32
+msgid "Perry supports a practical subset of TypeScript:"
+msgstr "Perry unterstützt eine praktische Teilmenge von TypeScript:"
+
+#: src/introduction.md:34
+msgid "Variables, functions, classes, enums, interfaces"
+msgstr "Variablen, Funktionen, Klassen, Enums, Interfaces"
+
+#: src/introduction.md:35
+msgid "Async/await, closures, generators"
+msgstr "Async/Await, Closures, Generatoren"
+
+#: src/introduction.md:36
+msgid "Destructuring, spread, template literals"
+msgstr "Destrukturierung, Spread, Template-Literale"
+
+#: src/introduction.md:37
+msgid "Arrays, Maps, Sets, typed arrays"
+msgstr "Arrays, Maps, Sets, typisierte Arrays"
+
+#: src/introduction.md:38
+msgid "Regular expressions, JSON, Promises"
+msgstr "Reguläre Ausdrücke, JSON, Promises"
+
+#: src/introduction.md:39
+msgid "Module imports/exports"
+msgstr "Modul-Imports/-Exports"
+
+#: src/introduction.md:40
+msgid "Generic type erasure"
+msgstr "Generische Typlöschung"
+
+#: src/introduction.md:42
+msgid ""
+"See [Supported Features](language/supported-features.md) for the complete "
+"list."
+msgstr ""
+"Die vollständige Liste finden Sie unter [Unterstützte "
+"Funktionen](language/supported-features.md)."
+
+#: src/introduction.md:44
+msgid "Quick Example: Native App"
+msgstr "Schnellbeispiel: Native App"
+
+#: src/introduction.md:46 src/getting-started/first-app.md:10
+msgid ""
+"```typescript\n"
+"// demonstrates: minimal stateful UI — label + increment button\n"
+"// docs: docs/src/ui/state.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, visionos-simulator, tvos-simulator, watchos-simulator, android, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Button, State } from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"App({\n"
+"    title: \"Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Count: ${count.value}`),\n"
+"        Button(\"Increment\", () => count.set(count.value + 1)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/introduction.md:69
+msgid "# Opens a native macOS/Windows/Linux window\n"
+msgstr ""
+
+#: src/introduction.md:72
+msgid ""
+"This produces a ~3MB native app with real platform widgets — no Electron, no"
+" WebView."
+msgstr ""
+"Daraus entsteht eine ca. 3 MB große native App mit echten Plattform-Widgets "
+"— kein Electron, keine WebView."
+
+#: src/introduction.md:74 src/getting-started/first-app.md:41
+#: src/threading/overview.md:286 src/threading/parallel-map.md:18
+#: src/threading/parallel-filter.md:18 src/platforms/watchos.md:127
+#: src/platforms/wasm.md:29 src/stdlib/overview.md:5 src/i18n/overview.md:78
+#: src/widgets/overview.md:34 src/plugins/overview.md:7
+msgid "How It Works"
+msgstr "So funktioniert es"
+
+#: src/introduction.md:87
+msgid ""
+"Perry uses [SWC](https://swc.rs/) for TypeScript parsing and "
+"[LLVM](https://llvm.org/) for native code generation. Types are erased at "
+"compile time (like `tsc`), and values are represented at runtime using NaN-"
+"boxing for efficient 64-bit tagged values."
+msgstr ""
+"Perry verwendet [SWC](https://swc.rs/) zum Parsen von TypeScript und "
+"[LLVM](https://llvm.org/) zur nativen Codegenerierung. Typen werden zur "
+"Compile-Zeit gelöscht (wie bei `tsc`), und Werte werden zur Laufzeit mittels"
+" NaN-Boxing als effiziente 64-Bit-Tagged-Values dargestellt."
+
+#: src/introduction.md:89 src/getting-started/hello-world.md:152
+#: src/getting-started/first-app.md:184
+#: src/getting-started/project-config.md:201
+#: src/language/supported-features.md:600 src/language/type-system.md:149
+#: src/language/limitations.md:182 src/threading/overview.md:312
+#: src/ui/overview.md:179 src/ui/widgets.md:396 src/ui/layout.md:367
+#: src/ui/styling.md:377 src/ui/state.md:225 src/ui/events.md:167
+#: src/ui/canvas.md:80 src/ui/menus.md:119 src/ui/dialogs.md:166
+#: src/ui/table.md:107 src/ui/animation.md:71 src/ui/multi-window.md:149
+#: src/ui/theming.md:166 src/ui/camera.md:143 src/platforms/overview.md:78
+#: src/platforms/macos.md:86 src/platforms/ios.md:137
+#: src/platforms/tvos.md:180 src/platforms/watchos.md:213
+#: src/platforms/android.md:92 src/platforms/windows.md:69
+#: src/platforms/linux.md:81 src/platforms/web.md:21 src/platforms/wasm.md:191
+#: src/stdlib/overview.md:100 src/stdlib/fs.md:88 src/stdlib/http.md:93
+#: src/stdlib/database.md:107 src/stdlib/crypto.md:87
+#: src/stdlib/utilities.md:104 src/stdlib/other.md:184
+#: src/i18n/overview.md:107 src/updater/overview.md:433
+#: src/system/overview.md:71 src/system/preferences.md:44
+#: src/system/keychain.md:35 src/system/notifications.md:72
+#: src/system/audio.md:71 src/system/other.md:68 src/widgets/overview.md:60
+#: src/widgets/creating-widgets.md:249 src/widgets/components.md:270
+#: src/widgets/configuration.md:139 src/widgets/data-fetching.md:203
+#: src/plugins/overview.md:96 src/plugins/creating-plugins.md:111
+#: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:297
+#: src/plugins/appstore-review.md:192 src/cli/commands.md:320
+#: src/cli/flags.md:176 src/contributing/architecture.md:97
+#: src/contributing/building.md:86
+msgid "Next Steps"
+msgstr "Nächste Schritte"
+
+#: src/introduction.md:91
+msgid "[Install Perry](getting-started/installation.md)"
+msgstr "[Perry installieren](getting-started/installation.md)"
+
+#: src/introduction.md:92
+msgid "[Write your first program](getting-started/hello-world.md)"
+msgstr "[Ihr erstes Programm schreiben](getting-started/hello-world.md)"
+
+#: src/introduction.md:93
+msgid "[Build a native app](getting-started/first-app.md)"
+msgstr "[Eine native App erstellen](getting-started/first-app.md)"
+
+#: src/getting-started/installation.md:3 src/platforms/visionos.md:7
+#: src/contributing/building.md:3
+msgid "Prerequisites"
+msgstr "Voraussetzungen"
+
+#: src/getting-started/installation.md:5
+msgid ""
+"Perry compiles TypeScript to native binaries by linking with your system's C"
+" toolchain, so every install path needs a linker:"
+msgstr ""
+
+#: src/getting-started/installation.md:7
+msgid "**macOS**: Xcode Command Line Tools (`xcode-select --install`)"
+msgstr ""
+
+#: src/getting-started/installation.md:8
+msgid ""
+"**Linux**: `gcc` or `clang` (`apt install build-essential` on Debian/Ubuntu,"
+" `apk add build-base` on Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:9
+msgid ""
+"**Windows**: LLVM (`winget install LLVM.LLVM`) + `perry setup windows` "
+"(lightweight, ~1.5 GB, no Visual Studio needed), or MSVC Build Tools with "
+"the \"Desktop development with C++\" workload — see the [Windows platform "
+"guide](../platforms/windows.md) for both options"
+msgstr ""
+
+#: src/getting-started/installation.md:11
+msgid ""
+"The source install additionally needs the **Rust toolchain** via "
+"[rustup](https://rustup.rs/)."
+msgstr ""
+
+#: src/getting-started/installation.md:13
+msgid "Install Perry"
+msgstr "Perry installieren"
+
+#: src/getting-started/installation.md:15
+msgid "npm / npx (recommended — any platform)"
+msgstr ""
+
+#: src/getting-started/installation.md:17
+msgid ""
+"Perry ships as a prebuilt-binary npm package. This is the fastest way to get"
+" started and the only path that covers all seven supported platforms (macOS "
+"arm64/x64, Linux x64/arm64 glibc + musl, Windows x64) with a single command:"
+msgstr ""
+
+#: src/getting-started/installation.md:20
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
+msgstr ""
+
+#: src/getting-started/installation.md:23
+msgid "# Global\n"
+msgstr ""
+
+#: src/getting-started/installation.md:27
+msgid "# Zero-install, one-shot\n"
+msgstr ""
+
+#: src/getting-started/installation.md:32
+msgid ""
+"[`@perryts/perry`](https://www.npmjs.com/package/@perryts/perry) is a thin "
+"launcher; npm automatically picks the matching prebuilt via "
+"`optionalDependencies` (`@perryts/perry-darwin-arm64`, `@perryts/perry-"
+"linux-x64-musl`, etc.) based on your `os` / `cpu` / `libc`. Requires Node.js"
+" ≥ 16."
+msgstr ""
+
+#: src/getting-started/installation.md:34 src/ui/styling.md:368
+#: src/ui/canvas.md:70 src/ui/menus.md:109 src/ui/animation.md:62
+#: src/ui/multi-window.md:70 src/ui/multi-window.md:87
+#: src/ui/multi-window.md:98 src/ui/multi-window.md:114
+#: src/ui/multi-window.md:130 src/ui/multi-window.md:138
+#: src/platforms/overview.md:7 src/i18n/overview.md:87
+#: src/i18n/overview.md:101 src/updater/overview.md:255
+#: src/system/preferences.md:32 src/system/keychain.md:23
+#: src/system/notifications.md:60 src/system/audio.md:59
+#: src/system/media.md:84 src/system/other.md:18 src/system/other.md:35
+#: src/widgets/platforms.md:9 src/plugins/native-extensions.md:271
+#: src/testing/geisterhand.md:257 src/cli/flags.md:20
+msgid "Platform"
+msgstr ""
+
+#: src/getting-started/installation.md:34
+msgid "Prebuilt package"
+msgstr ""
+
+#: src/getting-started/installation.md:36
+msgid "macOS arm64 (Apple Silicon)"
+msgstr ""
+
+#: src/getting-started/installation.md:36
+msgid "`@perryts/perry-darwin-arm64`"
+msgstr ""
+
+#: src/getting-started/installation.md:37
+msgid "macOS x64 (Intel)"
+msgstr ""
+
+#: src/getting-started/installation.md:37
+msgid "`@perryts/perry-darwin-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:38
+msgid "Linux x64 (glibc)"
+msgstr ""
+
+#: src/getting-started/installation.md:38
+msgid "`@perryts/perry-linux-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:39
+msgid "Linux arm64 (glibc)"
+msgstr ""
+
+#: src/getting-started/installation.md:39
+msgid "`@perryts/perry-linux-arm64`"
+msgstr ""
+
+#: src/getting-started/installation.md:40
+msgid "Linux x64 (musl / Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:40
+msgid "`@perryts/perry-linux-x64-musl`"
+msgstr ""
+
+#: src/getting-started/installation.md:41
+msgid "Linux arm64 (musl / Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:41
+msgid "`@perryts/perry-linux-arm64-musl`"
+msgstr ""
+
+#: src/getting-started/installation.md:42
+msgid "Windows x64"
+msgstr ""
+
+#: src/getting-started/installation.md:42
+msgid "`@perryts/perry-win32-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:44
+msgid "Homebrew (macOS)"
+msgstr ""
+
+#: src/getting-started/installation.md:50
+msgid "winget (Windows)"
+msgstr ""
+
+#: src/getting-started/installation.md:56
+msgid "APT (Debian / Ubuntu)"
+msgstr ""
+
+#: src/getting-started/installation.md:60
+msgid ""
+"\"deb [signed-by=/usr/share/keyrings/perry.gpg] "
+"https://perryts.github.io/perry-apt stable main\""
+msgstr ""
+
+#: src/getting-started/installation.md:64
+msgid "From Source"
+msgstr ""
+
+#: src/getting-started/installation.md:72
+msgid "The binary is at `target/release/perry`. Add it to your PATH:"
+msgstr ""
+
+#: src/getting-started/installation.md:75
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
+msgstr ""
+
+#: src/getting-started/installation.md:76
+msgid "\"/path/to/perry/target/release:$PATH\""
+msgstr ""
+
+#: src/getting-started/installation.md:79
+msgid "Self-Update"
+msgstr ""
+
+#: src/getting-started/installation.md:81
+msgid "Once installed, Perry can update itself:"
+msgstr ""
+
+#: src/getting-started/installation.md:87
+msgid "This downloads the latest release and atomically replaces the binary."
+msgstr ""
+
+#: src/getting-started/installation.md:89
+msgid "Verify Installation"
+msgstr ""
+
+#: src/getting-started/installation.md:95
+msgid ""
+"This checks your installation, shows the current version, and reports if an "
+"update is available."
+msgstr ""
+
+#: src/getting-started/installation.md:101
+msgid "Platform-Specific Setup"
+msgstr ""
+
+#: src/getting-started/installation.md:105
+msgid ""
+"No additional setup needed. Perry uses the system `cc` linker and AppKit for"
+" UI apps."
+msgstr ""
+
+#: src/getting-started/installation.md:107
+msgid ""
+"For iOS development, install Xcode (not just Command Line Tools) for the iOS"
+" SDK and simulator."
+msgstr ""
+
+#: src/getting-started/installation.md:109 src/ui/overview.md:170
+#: src/ui/canvas.md:76 src/ui/menus.md:114 src/ui/dialogs.md:108
+#: src/ui/animation.md:68 src/ui/multi-window.md:74 src/ui/multi-window.md:91
+#: src/ui/multi-window.md:102 src/ui/multi-window.md:118
+#: src/ui/multi-window.md:134 src/ui/multi-window.md:142
+#: src/platforms/overview.md:16 src/platforms/overview.md:67
+#: src/i18n/overview.md:93 src/updater/overview.md:259
+#: src/system/preferences.md:38 src/system/keychain.md:29
+#: src/system/notifications.md:66 src/system/audio.md:64
+#: src/system/other.md:24 src/system/other.md:41 src/cli/flags.md:37
+msgid "Linux"
+msgstr ""
+
+#: src/getting-started/installation.md:111
+msgid "Install GTK4 development libraries for UI apps:"
+msgstr ""
+
+#: src/getting-started/installation.md:114 src/platforms/linux.md:9
+#: src/testing/geisterhand.md:384
+msgid "# Ubuntu/Debian\n"
+msgstr ""
+
+#: src/getting-started/installation.md:116 src/platforms/linux.md:12
+msgid "# Fedora\n"
+msgstr ""
+
+#: src/getting-started/installation.md:123
+msgid "Two toolchain options — pick one. Both produce identical binaries."
+msgstr ""
+
+#: src/getting-started/installation.md:125
+msgid "**Lightweight (recommended, ~1.5 GB, no Visual Studio):**"
+msgstr ""
+
+#: src/getting-started/installation.md:132
+msgid ""
+"`perry setup windows` downloads the Microsoft CRT + Windows SDK libraries "
+"via xwin after prompting for license acceptance. Pass `--accept-license` to "
+"skip the prompt in CI."
+msgstr ""
+
+#: src/getting-started/installation.md:134
+msgid "**MSVC Build Tools (~8 GB):**"
+msgstr ""
+
+#: src/getting-started/installation.md:136
+msgid ""
+"Install Visual Studio Build Tools with the \"Desktop development with C++\" "
+"workload — via the Visual Studio Installer, or:"
+msgstr ""
+
+#: src/getting-started/installation.md:138 src/platforms/windows.md:25
+msgid ""
+"```powershell\n"
+"winget install Microsoft.VisualStudio.2022.BuildTools --override `\n"
+"  \"--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended\"\n"
+"```"
+msgstr ""
+
+#: src/getting-started/installation.md:143
+msgid ""
+"Run `perry doctor` to verify the toolchain. See the [Windows platform "
+"guide](../platforms/windows.md) for details."
+msgstr ""
+
+#: src/getting-started/installation.md:145
+msgid "What's Next"
+msgstr ""
+
+#: src/getting-started/installation.md:147
+msgid "[Write your first program](hello-world.md)"
+msgstr ""
+
+#: src/getting-started/installation.md:148
+msgid "[Build a native app](first-app.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:3
+msgid "Your First Program"
+msgstr "Ihr erstes Programm"
+
+#: src/getting-started/hello-world.md:5
+msgid "Create a file called `hello.ts`:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:7
+msgid ""
+"```typescript\n"
+"// demonstrates: the minimal Perry program in the docs\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"console.log(\"Hello, Perry!\")\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:16
+msgid "Compile and run it:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:23 src/threading/spawn.md:46
+#: src/widgets/wearos.md:64
+msgid "Output:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:29
+msgid ""
+"That's it. Perry compiled your TypeScript to a native executable — no "
+"Node.js, no bundler, no runtime."
+msgstr ""
+
+#: src/getting-started/hello-world.md:31
+msgid "A Slightly Bigger Example"
+msgstr "Ein etwas größeres Beispiel"
+
+#: src/getting-started/hello-world.md:33
+msgid ""
+"```typescript\n"
+"// demonstrates: recursive fib as a perf-vs-node talking point\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"function fibonacci(n: number): number {\n"
+"    if (n <= 1) return n\n"
+"    return fibonacci(n - 1) + fibonacci(n - 2)\n"
+"}\n"
+"\n"
+"const start = Date.now()\n"
+"const result = fibonacci(35)\n"
+"const elapsed = Date.now() - start\n"
+"\n"
+"console.log(`fibonacci(35) = ${result}`)\n"
+"console.log(`Completed in ${elapsed}ms`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:57
+msgid ""
+"This runs about 2x faster than Node.js because Perry compiles to native "
+"machine code with integer specialization."
+msgstr ""
+
+#: src/getting-started/hello-world.md:59
+msgid "Using Variables and Functions"
+msgstr "Variablen und Funktionen verwenden"
+
+#: src/getting-started/hello-world.md:61
+msgid ""
+"```typescript\n"
+"const name: string = \"World\"\n"
+"const items: number[] = [1, 2, 3, 4, 5]\n"
+"\n"
+"const doubled = items.map((x) => x * 2)\n"
+"const sum = doubled.reduce((acc, x) => acc + x, 0)\n"
+"\n"
+"console.log(`Hello, ${name}!`)\n"
+"console.log(`Sum of doubled: ${sum}`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:72
+msgid "Async Code"
+msgstr "Asynchroner Code"
+
+#: src/getting-started/hello-world.md:74
+msgid ""
+"```typescript\n"
+"// demonstrates: async/await fetch shown in hello-world.md\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// run: false\n"
+"\n"
+"async function fetchData(): Promise<string> {\n"
+"    const response = await fetch(\"https://httpbin.org/get\")\n"
+"    const data = await response.json() as { origin: string }\n"
+"    return data.origin\n"
+"}\n"
+"\n"
+"const ip = await fetchData()\n"
+"console.log(`Your IP: ${ip}`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:95
+msgid "Perry compiles async/await to a native async runtime backed by Tokio."
+msgstr ""
+
+#: src/getting-started/hello-world.md:99
+msgid ""
+"Perry can do something no JavaScript runtime can — run your code on multiple"
+" CPU cores:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:101
+msgid ""
+"```typescript\n"
+"// demonstrates: parallelMap + spawn shown in hello-world.md\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"import { parallelMap, parallelFilter, spawn } from \"perry/thread\"\n"
+"\n"
+"const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"// Process all elements across all CPU cores\n"
+"const doubled = parallelMap(data, (x: number) => x * 2)\n"
+"console.log(doubled) // [2, 4, 6, 8, 10, 12, 14, 16]\n"
+"\n"
+"// Run heavy work in the background\n"
+"const result = await spawn(() => {\n"
+"    let sum = 0\n"
+"    for (let i = 0; i < 100_000_000; i++) sum += i\n"
+"    return sum\n"
+"})\n"
+"console.log(result)\n"
+"\n"
+"// parallelFilter is also available for the lift-and-parallelize case:\n"
+"const evens = parallelFilter(data, (x: number) => x % 2 === 0)\n"
+"console.log(evens)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:127
+msgid ""
+"This is real OS-level parallelism, not web workers or separate isolates. See"
+" [Multi-Threading](../threading/overview.md) for details."
+msgstr ""
+
+#: src/getting-started/hello-world.md:129
+msgid "What the Compiler Produces"
+msgstr "Was der Compiler erzeugt"
+
+#: src/getting-started/hello-world.md:131
+msgid "When you run `perry file.ts -o output`, Perry:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:133
+msgid "Parses your TypeScript with SWC"
+msgstr ""
+
+#: src/getting-started/hello-world.md:134
+msgid "Lowers the AST to an intermediate representation (HIR)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:135
+msgid "Applies optimizations (inlining, closure conversion, etc.)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:136
+msgid "Generates native machine code with LLVM"
+msgstr ""
+
+#: src/getting-started/hello-world.md:137
+msgid "Links with your system's C compiler"
+msgstr ""
+
+#: src/getting-started/hello-world.md:139
+msgid "The result is a standalone executable with no external dependencies."
+msgstr ""
+
+#: src/getting-started/hello-world.md:141
+#: src/getting-started/hello-world.md:143 src/stdlib/overview.md:66
+#: src/stdlib/overview.md:70
+msgid "Binary Size"
+msgstr "Binärgröße"
+
+#: src/getting-started/hello-world.md:143
+msgid "Program"
+msgstr ""
+
+#: src/getting-started/hello-world.md:145
+msgid "Hello world"
+msgstr ""
+
+#: src/getting-started/hello-world.md:145 src/stdlib/overview.md:72
+msgid "~300KB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:146
+msgid "CLI with fs/path"
+msgstr ""
+
+#: src/getting-started/hello-world.md:146
+#: src/getting-started/hello-world.md:147 src/stdlib/overview.md:73
+msgid "~3MB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:147
+msgid "UI app"
+msgstr ""
+
+#: src/getting-started/hello-world.md:148
+msgid "Full app with stdlib"
+msgstr ""
+
+#: src/getting-started/hello-world.md:148 src/stdlib/overview.md:74
+msgid "~48MB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:150
+msgid ""
+"Perry automatically detects which runtime features you use and only links "
+"what's needed."
+msgstr ""
+
+#: src/getting-started/hello-world.md:154
+msgid "[Build a native UI app](first-app.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:155
+msgid "[Configure your project](project-config.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:156
+msgid ""
+"[Explore supported TypeScript features](../language/supported-features.md)"
+msgstr ""
+
+#: src/getting-started/first-app.md:3
+msgid ""
+"Perry compiles declarative TypeScript UI code to native platform widgets. No"
+" Electron, no WebView — real AppKit on macOS, UIKit on iOS, GTK4 on Linux, "
+"Win32 on Windows. Every example on this page is a real source file under "
+"`docs/examples/` that CI compiles and runs on every PR."
+msgstr ""
+
+#: src/getting-started/first-app.md:8
+msgid "A Simple Counter"
+msgstr "Ein einfacher Zähler"
+
+#: src/getting-started/first-app.md:31
+msgid "Compile and run:"
+msgstr ""
+
+#: src/getting-started/first-app.md:38
+msgid ""
+"A native window opens with a label and two buttons. Clicking \"Increment\" "
+"updates the count in real-time."
+msgstr ""
+
+#: src/getting-started/first-app.md:43
+msgid ""
+"**`App({ title, width, height, body })`** — Creates a native application "
+"window. `body` is the root widget."
+msgstr ""
+
+#: src/getting-started/first-app.md:44
+msgid ""
+"**`State(initialValue)`** — Creates reactive state. `.value` reads, "
+"`.set(v)` writes and triggers UI updates."
+msgstr ""
+
+#: src/getting-started/first-app.md:45
+msgid ""
+"**`VStack(spacing, [...])`** — Vertical stack layout (like SwiftUI's VStack "
+"or CSS flexbox column). The first arg is the gap in points between children."
+msgstr ""
+
+#: src/getting-started/first-app.md:46
+msgid ""
+"**`Text(string)`** — A text label. Template literals referencing "
+"`${state.value}` bind reactively."
+msgstr ""
+
+#: src/getting-started/first-app.md:47
+msgid "**`Button(label, onClick)`** — A native button with a click handler."
+msgstr ""
+
+#: src/getting-started/first-app.md:49
+msgid "A Todo App"
+msgstr "Eine Todo-App"
+
+#: src/getting-started/first-app.md:51 src/ui/state.md:160
+msgid ""
+"```typescript\n"
+"// demonstrates: complete reactive todo app combining State, ForEach, and widget tree mutation\n"
+"// docs: docs/src/ui/state.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    TextField,\n"
+"    VStack,\n"
+"    HStack,\n"
+"    State,\n"
+"    ForEach,\n"
+"    Spacer,\n"
+"    Divider,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const todos = State<string[]>([])\n"
+"const count = State(0)\n"
+"const input = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"Todo App\",\n"
+"    width: 480,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        Text(\"My Todos\"),\n"
+"\n"
+"        HStack(8, [\n"
+"            TextField(\"What needs to be done?\", (value: string) => input.set(value)),\n"
+"            Button(\"Add\", () => {\n"
+"                const text = input.value\n"
+"                if (text.length > 0) {\n"
+"                    todos.set([...todos.value, text])\n"
+"                    count.set(count.value + 1)\n"
+"                    input.set(\"\")\n"
+"                }\n"
+"            }),\n"
+"        ]),\n"
+"\n"
+"        Divider(),\n"
+"\n"
+"        ForEach(count, (i: number) =>\n"
+"            HStack(8, [\n"
+"                Text(todos.value[i]),\n"
+"                Spacer(),\n"
+"                Button(\"Delete\", () => {\n"
+"                    todos.set(todos.value.filter((_, idx) => idx !== i))\n"
+"                    count.set(count.value - 1)\n"
+"                }),\n"
+"            ]),\n"
+"        ),\n"
+"\n"
+"        Spacer(),\n"
+"        Text(`${count.value} items`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/getting-started/first-app.md:112
+msgid ""
+"`ForEach(count, render)` iterates by index — keep an item array and a count "
+"state in sync, then read items via `array.value[i]` inside the closure. See "
+"[State Management](../ui/state.md) for the full pattern."
+msgstr ""
+
+#: src/getting-started/first-app.md:116
+msgid "Cross-Platform"
+msgstr "Plattformübergreifend"
+
+#: src/getting-started/first-app.md:118
+msgid "The same code runs on all 6 platforms:"
+msgstr ""
+
+#: src/getting-started/first-app.md:121
+msgid "# macOS (default)\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:124
+msgid "# iOS Simulator\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:127
+msgid ""
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:129 src/platforms/overview.md:30
+msgid "# alias: --target wasm\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:131
+msgid "# Other platforms\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:138
+msgid ""
+"Each target compiles to the platform's native widget toolkit. See "
+"[Platforms](../platforms/overview.md) for details."
+msgstr ""
+
+#: src/getting-started/first-app.md:141
+msgid "Adding Styling"
+msgstr ""
+
+#: src/getting-started/first-app.md:143
+msgid ""
+"Styling is applied via free functions that take the widget handle as their "
+"first argument. Colors are RGBA floats in `[0.0, 1.0]` — divide a hex byte "
+"by 255 to convert (`0x33 / 255 ≈ 0.2`)."
+msgstr ""
+
+#: src/getting-started/first-app.md:147
+msgid ""
+"```typescript\n"
+"// demonstrates: counter from getting-started/first-app.md with styled widgets\n"
+"// docs: docs/src/getting-started/first-app.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"// run: false\n"
+"\n"
+"import {\n"
+"    App, VStack, Text, Button, State,\n"
+"    textSetFontSize, textSetColor,\n"
+"    setCornerRadius, setPadding,\n"
+"    widgetSetBackgroundColor,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"const label = Text(`Count: ${count.value}`)\n"
+"textSetFontSize(label, 24)\n"
+"textSetColor(label, 0.2, 0.2, 0.2, 1.0)        // RGBA in [0,1] — same as #333333\n"
+"\n"
+"const btn = Button(\"Increment\", () => count.set(count.value + 1))\n"
+"setCornerRadius(btn, 8)\n"
+"widgetSetBackgroundColor(btn, 0.0, 0.478, 1.0, 1.0)  // system blue\n"
+"\n"
+"const stack = VStack(20, [label, btn])\n"
+"setPadding(stack, 20, 20, 20, 20)\n"
+"\n"
+"App({\n"
+"    title: \"Styled Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: stack,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/getting-started/first-app.md:182
+msgid "See [Styling](../ui/styling.md) for all available style properties."
+msgstr ""
+
+#: src/getting-started/first-app.md:186
+msgid ""
+"[Project Configuration](project-config.md) — Set up `package.json` for Perry"
+" projects"
+msgstr ""
+
+#: src/getting-started/first-app.md:187
+msgid "[UI Overview](../ui/overview.md) — Complete guide to Perry's UI system"
+msgstr ""
+
+#: src/getting-started/first-app.md:188
+msgid "[Widgets Reference](../ui/widgets.md) — All available widgets"
+msgstr ""
+
+#: src/getting-started/first-app.md:189
+msgid "[State Management](../ui/state.md) — Reactive state and bindings"
+msgstr ""
+
+#: src/getting-started/project-config.md:3
+msgid ""
+"Perry projects use `perry.toml` and `package.json` for configuration. No "
+"special config file is required for basic usage, but larger projects benefit"
+" from Perry-specific settings."
+msgstr ""
+
+#: src/getting-started/project-config.md:5
+msgid ""
+"**Looking for the full perry.toml reference?** See [perry.toml "
+"Reference](../cli/perry-toml.md) for every field, section, platform option, "
+"and environment variable."
+msgstr ""
+
+#: src/getting-started/project-config.md:7
+msgid "Basic Setup"
+msgstr "Grundkonfiguration"
+
+#: src/getting-started/project-config.md:14
+msgid "This creates a `package.json` and a starter `src/index.ts`."
+msgstr ""
+
+#: src/getting-started/project-config.md:16
+msgid "package.json"
+msgstr "package.json"
+
+#: src/getting-started/project-config.md:20
+#: src/plugins/native-extensions.md:58 src/plugins/native-extensions.md:64
+#: src/plugins/appstore-review.md:183
+msgid "\"name\""
+msgstr ""
+
+#: src/getting-started/project-config.md:20
+msgid "\"my-project\""
+msgstr ""
+
+#: src/getting-started/project-config.md:21
+#: src/plugins/native-extensions.md:59
+msgid "\"version\""
+msgstr ""
+
+#: src/getting-started/project-config.md:21
+msgid "\"1.0.0\""
+msgstr ""
+
+#: src/getting-started/project-config.md:22
+#: src/plugins/native-extensions.md:60
+msgid "\"main\""
+msgstr ""
+
+#: src/getting-started/project-config.md:22
+#: src/plugins/native-extensions.md:60
+msgid "\"src/index.ts\""
+msgstr ""
+
+#: src/getting-started/project-config.md:23
+#: src/getting-started/project-config.md:39
+#: src/getting-started/project-config.md:61
+#: src/getting-started/project-config.md:74
+#: src/getting-started/project-config.md:95 src/packages/porting.md:24
+#: src/platforms/ios.md:98 src/platforms/ios.md:111
+#: src/platforms/android.md:57 src/platforms/android.md:72
+#: src/stdlib/overview.md:84 src/plugins/native-extensions.md:61
+#: src/plugins/appstore-review.md:180
+msgid "\"perry\""
+msgstr ""
+
+#: src/getting-started/project-config.md:24
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"compilePackages\""
+msgstr ""
+
+#: src/getting-started/project-config.md:29
+msgid "Perry Configuration"
+msgstr "Perry-Konfiguration"
+
+#: src/getting-started/project-config.md:31
+msgid "The `perry` field in `package.json` controls compiler behavior:"
+msgstr ""
+
+#: src/getting-started/project-config.md:33
+msgid "`compilePackages`"
+msgstr ""
+
+#: src/getting-started/project-config.md:35
+msgid ""
+"List npm packages to compile natively instead of routing through the "
+"JavaScript runtime:"
+msgstr ""
+
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"@noble/curves\""
+msgstr ""
+
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"@noble/hashes\""
+msgstr ""
+
+#: src/getting-started/project-config.md:45
+msgid "When a package is listed here, Perry:"
+msgstr ""
+
+#: src/getting-started/project-config.md:46
+msgid "Resolves the package in `node_modules/`"
+msgstr ""
+
+#: src/getting-started/project-config.md:47
+msgid ""
+"Prefers TypeScript source (`src/index.ts`) over compiled JavaScript "
+"(`lib/index.js`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:48
+msgid "Compiles all functions natively through LLVM"
+msgstr ""
+
+#: src/getting-started/project-config.md:49
+msgid ""
+"Deduplicates across nested `node_modules/` to prevent duplicate linker "
+"symbols"
+msgstr ""
+
+#: src/getting-started/project-config.md:51
+msgid ""
+"This is useful for pure TypeScript/JavaScript packages that don't rely on "
+"Node.js APIs. Packages that use native bindings, `eval()`, or dynamic "
+"`require()` won't work."
+msgstr ""
+
+#: src/getting-started/project-config.md:53
+msgid "`splash`"
+msgstr ""
+
+#: src/getting-started/project-config.md:55
+msgid ""
+"Configure a native splash screen for iOS and Android. The splash screen "
+"appears instantly during cold start, before your app code runs."
+msgstr ""
+
+#: src/getting-started/project-config.md:57
+msgid "**Minimal (both platforms share the same splash):**"
+msgstr ""
+
+#: src/getting-started/project-config.md:62
+#: src/getting-started/project-config.md:75
+#: src/getting-started/project-config.md:96 src/platforms/ios.md:99
+#: src/platforms/ios.md:112 src/platforms/android.md:58
+#: src/platforms/android.md:73
+msgid "\"splash\""
+msgstr ""
+
+#: src/getting-started/project-config.md:63
+#: src/getting-started/project-config.md:76
+#: src/getting-started/project-config.md:79
+#: src/getting-started/project-config.md:83 src/platforms/ios.md:100
+#: src/platforms/android.md:59
+msgid "\"image\""
+msgstr ""
+
+#: src/getting-started/project-config.md:63
+#: src/getting-started/project-config.md:76 src/platforms/ios.md:100
+#: src/platforms/android.md:59
+msgid "\"logo/icon-256.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:64
+#: src/getting-started/project-config.md:77
+#: src/getting-started/project-config.md:80
+#: src/getting-started/project-config.md:84 src/ui/theming.md:26
+#: src/platforms/ios.md:101 src/platforms/android.md:60
+msgid "\"background\""
+msgstr ""
+
+#: src/getting-started/project-config.md:64
+#: src/getting-started/project-config.md:77 src/platforms/ios.md:101
+#: src/platforms/android.md:60
+msgid "\"#FFF5EE\""
+msgstr ""
+
+#: src/getting-started/project-config.md:70
+msgid "**Per-platform overrides:**"
+msgstr ""
+
+#: src/getting-started/project-config.md:78
+#: src/getting-started/project-config.md:97 src/platforms/ios.md:113
+#: src/plugins/native-extensions.md:67
+msgid "\"ios\""
+msgstr ""
+
+#: src/getting-started/project-config.md:79
+msgid "\"logo/splash-ios.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:80
+#: src/getting-started/project-config.md:84 src/ui/theming.md:26
+#: src/ui/theming.md:29
+msgid "\"#FFFFFF\""
+msgstr ""
+
+#: src/getting-started/project-config.md:82
+#: src/getting-started/project-config.md:100 src/platforms/android.md:74
+#: src/plugins/native-extensions.md:72
+msgid "\"android\""
+msgstr ""
+
+#: src/getting-started/project-config.md:83
+msgid "\"logo/splash-android.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:91
+msgid "**Full custom override (complete control):**"
+msgstr ""
+
+#: src/getting-started/project-config.md:98 src/platforms/ios.md:113
+msgid "\"storyboard\""
+msgstr ""
+
+#: src/getting-started/project-config.md:98 src/platforms/ios.md:113
+msgid "\"splash/LaunchScreen.storyboard\""
+msgstr ""
+
+#: src/getting-started/project-config.md:101 src/platforms/android.md:75
+msgid "\"layout\""
+msgstr ""
+
+#: src/getting-started/project-config.md:101 src/platforms/android.md:75
+msgid "\"splash/splash_background.xml\""
+msgstr ""
+
+#: src/getting-started/project-config.md:102 src/platforms/android.md:76
+msgid "\"theme\""
+msgstr ""
+
+#: src/getting-started/project-config.md:102 src/platforms/android.md:76
+msgid "\"splash/themes.xml\""
+msgstr ""
+
+#: src/getting-started/project-config.md:109 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414
+msgid "Field"
+msgstr ""
+
+#: src/getting-started/project-config.md:109 src/ui/overview.md:57
+#: src/ui/widgets.md:377 src/ui/layout.md:173 src/ui/menus.md:53
+#: src/ui/multi-window.md:36 src/ui/multi-window.md:80
+#: src/ui/multi-window.md:124 src/system/overview.md:21
+#: src/widgets/creating-widgets.md:45 src/widgets/configuration.md:70
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/testing/geisterhand.md:84 src/testing/geisterhand.md:98
+#: src/cli/commands.md:17 src/cli/commands.md:60 src/cli/commands.md:109
+#: src/cli/commands.md:148 src/cli/commands.md:181 src/cli/commands.md:195
+#: src/cli/commands.md:233 src/cli/commands.md:248 src/cli/commands.md:260
+#: src/cli/flags.md:9 src/cli/flags.md:43 src/cli/flags.md:50
+#: src/cli/flags.md:58 src/cli/flags.md:66 src/cli/flags.md:73
+#: src/cli/flags.md:80 src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:277
+#: src/cli/perry-toml.md:284 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:367 src/cli/perry-toml.md:377
+#: src/cli/perry-toml.md:387 src/cli/perry-toml.md:397
+#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:491
+#: src/cli/perry-toml.md:503 src/cli/perry-toml.md:513
+msgid "Description"
+msgstr ""
+
+#: src/getting-started/project-config.md:111
+msgid "`splash.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:111
+msgid "Path to a PNG image, centered on the splash screen (both platforms)"
+msgstr ""
+
+#: src/getting-started/project-config.md:112
+msgid "`splash.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:112
+msgid "Hex color for the background (default: `#FFFFFF`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:113
+msgid "`splash.ios.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:113
+msgid "iOS-specific image override"
+msgstr ""
+
+#: src/getting-started/project-config.md:114
+msgid "`splash.ios.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:114
+msgid "iOS-specific background color"
+msgstr ""
+
+#: src/getting-started/project-config.md:115
+msgid "`splash.ios.storyboard`"
+msgstr ""
+
+#: src/getting-started/project-config.md:115
+msgid "Custom LaunchScreen.storyboard (compiled with ibtool)"
+msgstr ""
+
+#: src/getting-started/project-config.md:116
+msgid "`splash.android.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:116
+msgid "Android-specific image override"
+msgstr ""
+
+#: src/getting-started/project-config.md:117
+msgid "`splash.android.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:117
+msgid "Android-specific background color"
+msgstr ""
+
+#: src/getting-started/project-config.md:118
+msgid "`splash.android.layout`"
+msgstr ""
+
+#: src/getting-started/project-config.md:118
+msgid "Custom drawable XML for `windowBackground`"
+msgstr ""
+
+#: src/getting-started/project-config.md:119
+msgid "`splash.android.theme`"
+msgstr ""
+
+#: src/getting-started/project-config.md:119
+msgid "Custom themes.xml"
+msgstr ""
+
+#: src/getting-started/project-config.md:121
+msgid "**Resolution order** per platform:"
+msgstr ""
+
+#: src/getting-started/project-config.md:122
+msgid "Custom file override (storyboard / layout+theme)"
+msgstr ""
+
+#: src/getting-started/project-config.md:123
+msgid "Platform-specific image/color (`splash.{platform}.image`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:124
+msgid "Universal image/color (`splash.image`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:125
+msgid "No `splash` key → blank white screen (backward compatible)"
+msgstr ""
+
+#: src/getting-started/project-config.md:127
+msgid "Using npm Packages"
+msgstr "npm-Pakete verwenden"
+
+#: src/getting-started/project-config.md:129
+msgid ""
+"Perry natively supports many popular npm packages without any configuration:"
+msgstr ""
+
+#: src/getting-started/project-config.md:131
+msgid ""
+"```typescript\n"
+"// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
+"// docs: docs/src/getting-started/project-config.md\n"
+"// platforms: macos, linux, windows\n"
+"// run: false\n"
+"\n"
+"// These four imports are Perry's most-used built-in stdlib shims:\n"
+"// fastify (HTTP server), mysql2 (db), ioredis (Redis), bcrypt (password\n"
+"// hashing). They're compiled to native code via Perry's per-package\n"
+"// implementations — no `compilePackages` needed.\n"
+"//\n"
+"// `// run: false` because each one needs a live external service (DB,\n"
+"// Redis, network port) to actually do anything; the binary still has to\n"
+"// link cleanly, which is the drift check we want.\n"
+"\n"
+"import fastify from \"fastify\"\n"
+"import mysql from \"mysql2/promise\"\n"
+"import Redis from \"ioredis\"\n"
+"import bcrypt from \"bcrypt\"\n"
+"\n"
+"const app = fastify({ logger: false })\n"
+"const db = mysql.createPool({ host: \"localhost\", user: \"root\", database: \"test\" })\n"
+"const redis = new Redis()\n"
+"const hashed = await bcrypt.hash(\"hunter2\", 10)\n"
+"\n"
+"console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/project-config.md:159
+msgid ""
+"These are compiled to native code using Perry's built-in implementations. "
+"See [Standard Library](../stdlib/overview.md) for the full list."
+msgstr ""
+
+#: src/getting-started/project-config.md:161
+msgid ""
+"For packages not natively supported, use `compilePackages` for pure TS/JS "
+"packages, or the JavaScript runtime fallback for complex packages."
+msgstr ""
+
+#: src/getting-started/project-config.md:163 src/contributing/building.md:61
+msgid "Project Structure"
+msgstr "Projektstruktur"
+
+#: src/getting-started/project-config.md:165
+msgid "Perry is flexible about project structure. Common patterns:"
+msgstr ""
+
+#: src/getting-started/project-config.md:175
+msgid "For UI apps:"
+msgstr ""
+
+#: src/getting-started/project-config.md:186 src/widgets/watchos.md:59
+#: src/widgets/wearos.md:58
+msgid "Compilation"
+msgstr ""
+
+#: src/getting-started/project-config.md:189
+msgid "# Compile a file\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:191
+msgid "# Compile with a specific target\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:194
+msgid "# Debug: print intermediate representation\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:199
+msgid "See [CLI Commands](../cli/commands.md) for all options."
+msgstr ""
+
+#: src/getting-started/project-config.md:203
+msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
+msgstr ""
+
+#: src/getting-started/project-config.md:204
+msgid ""
+"[Supported Features](../language/supported-features.md) — What TypeScript "
+"features work"
+msgstr ""
+
+#: src/getting-started/project-config.md:205
+msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
+msgstr ""
+
+#: src/language/supported-features.md:1
+msgid "Supported TypeScript Features"
+msgstr ""
+
+#: src/language/supported-features.md:3
+msgid ""
+"Perry compiles a practical subset of TypeScript to native code. This page "
+"lists what's supported."
+msgstr ""
+
+#: src/language/supported-features.md:5
+msgid "Primitive Types"
+msgstr ""
+
+#: src/language/supported-features.md:7
+msgid ""
+"```typescript\n"
+"function primitives(): void {\n"
+"    const n: number = 42;\n"
+"    const s: string = \"hello\";\n"
+"    const b: boolean = true;\n"
+"    const u: undefined = undefined;\n"
+"    const nl: null = null;\n"
+"\n"
+"    console.log(`primitives: n=${n} s=${s} b=${b} u=${u} nl=${nl}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:19
+msgid "All primitives are represented as 64-bit NaN-boxed values at runtime."
+msgstr ""
+
+#: src/language/supported-features.md:21
+msgid "Variables and Constants"
+msgstr ""
+
+#: src/language/supported-features.md:23
+msgid ""
+"```typescript\n"
+"function variables(): void {\n"
+"    let x = 10;\n"
+"    const y = \"immutable\";\n"
+"    var z = true; // var is supported but let/const preferred\n"
+"\n"
+"    console.log(`variables: x=${x} y=${y} z=${z}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:33
+msgid ""
+"Perry infers types from initializers — `let x = 5` is inferred as `number` "
+"without an explicit annotation."
+msgstr ""
+
+#: src/language/supported-features.md:35
+msgid "Functions"
+msgstr ""
+
+#: src/language/supported-features.md:37
+msgid ""
+"```typescript\n"
+"function functionsDemo(): void {\n"
+"    function add(a: number, b: number): number {\n"
+"        return a + b;\n"
+"    }\n"
+"\n"
+"    // Optional parameters\n"
+"    function greet(name: string, greeting: string = \"Hello\"): string {\n"
+"        return `${greeting}, ${name}!`;\n"
+"    }\n"
+"\n"
+"    // Rest parameters\n"
+"    function sum(...nums: number[]): number {\n"
+"        return nums.reduce((a, b) => a + b, 0);\n"
+"    }\n"
+"\n"
+"    // Arrow functions\n"
+"    const double = (x: number) => x * 2;\n"
+"\n"
+"    console.log(`functions: add=${add(2, 3)} greet=${greet(\"Perry\")} sum=${sum(1, 2, 3)} double=${double(5)}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:60
+msgid "Classes"
+msgstr ""
+
+#: src/language/supported-features.md:62
+msgid ""
+"```typescript\n"
+"class Animal {\n"
+"    name: string;\n"
+"\n"
+"    constructor(name: string) {\n"
+"        this.name = name;\n"
+"    }\n"
+"\n"
+"    speak(): string {\n"
+"        return `${this.name} makes a noise`;\n"
+"    }\n"
+"}\n"
+"\n"
+"class Dog extends Animal {\n"
+"    speak(): string {\n"
+"        return `${this.name} barks`;\n"
+"    }\n"
+"}\n"
+"\n"
+"// Static methods\n"
+"class Counter {\n"
+"    private static instance: Counter;\n"
+"    private count: number = 0;\n"
+"\n"
+"    static getInstance(): Counter {\n"
+"        if (!Counter.instance) {\n"
+"            Counter.instance = new Counter();\n"
+"        }\n"
+"        return Counter.instance;\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:95
+msgid "Supported class features:"
+msgstr ""
+
+#: src/language/supported-features.md:96
+msgid "Constructors"
+msgstr ""
+
+#: src/language/supported-features.md:97
+msgid "Instance and static methods"
+msgstr ""
+
+#: src/language/supported-features.md:98
+msgid "Instance and static properties"
+msgstr ""
+
+#: src/language/supported-features.md:99
+msgid "Inheritance (`extends`)"
+msgstr ""
+
+#: src/language/supported-features.md:100
+msgid "Method overriding"
+msgstr ""
+
+#: src/language/supported-features.md:101
+msgid "`instanceof` checks (via class ID chain)"
+msgstr ""
+
+#: src/language/supported-features.md:102
+msgid "Singleton patterns (static method return type inference)"
+msgstr ""
+
+#: src/language/supported-features.md:104
+msgid "Enums"
+msgstr ""
+
+#: src/language/supported-features.md:106
+msgid ""
+"```typescript\n"
+"// Numeric enums\n"
+"enum Direction {\n"
+"    Up,\n"
+"    Down,\n"
+"    Left,\n"
+"    Right,\n"
+"}\n"
+"\n"
+"// String enums\n"
+"enum Color {\n"
+"    Red = \"RED\",\n"
+"    Green = \"GREEN\",\n"
+"    Blue = \"BLUE\",\n"
+"}\n"
+"\n"
+"const dir = Direction.Up;\n"
+"const color = Color.Red;\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:126
+msgid "Enums are compiled to constants and work across modules."
+msgstr ""
+
+#: src/language/supported-features.md:128
+msgid "Interfaces and Type Aliases"
+msgstr ""
+
+#: src/language/supported-features.md:142
+msgid ""
+"Interfaces and type aliases are erased at compile time (like `tsc`). They "
+"exist only for documentation and editor tooling."
+msgstr ""
+
+#: src/language/supported-features.md:144 src/threading/overview.md:306
+#: src/threading/parallel-map.md:58
+msgid "Arrays"
+msgstr ""
+
+#: src/language/supported-features.md:146
+msgid ""
+"```typescript\n"
+"function arraysDemo(): void {\n"
+"    const nums: number[] = [1, 2, 3];\n"
+"\n"
+"    // Array methods\n"
+"    nums.push(4);\n"
+"    nums.pop();\n"
+"    const len = nums.length;\n"
+"    const doubled = nums.map((x) => x * 2);\n"
+"    const filtered = nums.filter((x) => x > 2);\n"
+"    const sum = nums.reduce((acc, x) => acc + x, 0);\n"
+"    const found = nums.find((x) => x === 3);\n"
+"    const idx = nums.indexOf(3);\n"
+"    const joined = nums.join(\", \");\n"
+"    const sliced = nums.slice(1, 3);\n"
+"    nums.splice(1, 1);\n"
+"    nums.unshift(0);\n"
+"    const sorted = nums.sort((a, b) => a - b);\n"
+"    const reversed = nums.reverse();\n"
+"    const includes = nums.includes(3);\n"
+"    const every = nums.every((x) => x > 0);\n"
+"    const some = nums.some((x) => x > 2);\n"
+"    nums.forEach((x) => console.log(x));\n"
+"    const flat = [[1, 2], [3]].flat();\n"
+"    const concatted = nums.concat([5, 6]);\n"
+"\n"
+"    // Array.from\n"
+"    const arr = Array.from([10, 20, 30]);\n"
+"\n"
+"    // Array.isArray\n"
+"    const value: any = [1, 2, 3]\n"
+"    if (Array.isArray(value)) { /* ... */ }\n"
+"\n"
+"    // for...of iteration\n"
+"    for (const item of nums) {\n"
+"        console.log(item);\n"
+"    }\n"
+"\n"
+"    console.log(`arrays: len=${len} doubled=${doubled.length} filtered=${filtered.length} sum=${sum} found=${found} idx=${idx} joined=${joined} sliced=${sliced.length} sorted=${sorted.length} reversed=${reversed.length} includes=${includes} every=${every} some=${some} flat=${flat.length} concatted=${concatted.length} arr=${arr.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:188 src/threading/overview.md:307
+#: src/threading/parallel-map.md:59
+msgid "Objects"
+msgstr ""
+
+#: src/language/supported-features.md:190
+msgid ""
+"```typescript\n"
+"function objectsDemo(): void {\n"
+"    const obj: { name: string; version: number; [k: string]: any } = { name: \"Perry\", version: 1 };\n"
+"    obj.name = \"Perry 2\";\n"
+"\n"
+"    // Dynamic property access\n"
+"    const key = \"name\";\n"
+"    const val = obj[key];\n"
+"\n"
+"    // Object.keys, Object.values, Object.entries\n"
+"    const keys = Object.keys(obj);\n"
+"    const values = Object.values(obj);\n"
+"    const entries = Object.entries(obj);\n"
+"\n"
+"    // Spread\n"
+"    const copy = { ...obj, extra: true };\n"
+"\n"
+"    // delete\n"
+"    delete obj[key];\n"
+"\n"
+"    console.log(`objects: val=${val} keys=${keys.length} values=${values.length} entries=${entries.length} copy=${copy.extra}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:214
+msgid "Destructuring"
+msgstr ""
+
+#: src/language/supported-features.md:216
+msgid ""
+"```typescript\n"
+"function destructuringDemo(): void {\n"
+"    // Array destructuring\n"
+"    const [a, b, ...rest] = [1, 2, 3, 4, 5];\n"
+"\n"
+"    const user = { name: \"Alice\", age: 30, email: \"a@example.com\", id: 1 }\n"
+"    const obj = { id: 2, role: \"admin\", level: 5 }\n"
+"\n"
+"    // Object destructuring\n"
+"    const { name, age, email = \"none\" } = user;\n"
+"\n"
+"    // Rename\n"
+"    const { name: userName } = user;\n"
+"\n"
+"    // Rest pattern\n"
+"    const { id, ...remaining } = obj;\n"
+"\n"
+"    // Function parameter destructuring\n"
+"    function process({ name, age }: { name: string; age: number }) {\n"
+"        console.log(name, age);\n"
+"    }\n"
+"\n"
+"    process(user)\n"
+"    console.log(`destructuring: a=${a} b=${b} rest=${rest.length} name=${name} age=${age} email=${email} userName=${userName} id=${id}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:243 src/widgets/creating-widgets.md:112
+msgid "Template Literals"
+msgstr ""
+
+#: src/language/supported-features.md:245
+msgid ""
+"```typescript\n"
+"function templateLiteralsDemo(): void {\n"
+"    const name = \"world\";\n"
+"    const greeting = `Hello, ${name}!`;\n"
+"    const multiline = `\n"
+"  Line 1\n"
+"  Line 2\n"
+"`;\n"
+"    const expr = `Result: ${1 + 2}`;\n"
+"\n"
+"    console.log(`template-literals: greeting=${greeting} multiline_len=${multiline.length} expr=${expr}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:259
+msgid "Spread and Rest"
+msgstr ""
+
+#: src/language/supported-features.md:261
+msgid ""
+"```typescript\n"
+"function spreadRestDemo(): void {\n"
+"    const arr1 = [1, 2]\n"
+"    const arr2 = [3, 4]\n"
+"    const defaults = { theme: \"light\", size: \"md\" }\n"
+"    const overrides = { size: \"lg\" }\n"
+"\n"
+"    // Array spread\n"
+"    const combined = [...arr1, ...arr2];\n"
+"\n"
+"    // Object spread\n"
+"    const merged = { ...defaults, ...overrides };\n"
+"\n"
+"    // Rest parameters\n"
+"    function log(...args: any[]) { /* ... */ }\n"
+"\n"
+"    log(\"a\", \"b\", \"c\")\n"
+"    console.log(`spread-rest: combined=${combined.length} merged=${merged.size}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:282 src/threading/overview.md:308
+msgid "Closures"
+msgstr ""
+
+#: src/language/supported-features.md:284
+msgid ""
+"```typescript\n"
+"function closuresDemo(): void {\n"
+"    function makeCounter() {\n"
+"        let count = 0;\n"
+"        return {\n"
+"            increment: () => ++count,\n"
+"            get: () => count,\n"
+"        };\n"
+"    }\n"
+"\n"
+"    const counter = makeCounter();\n"
+"    counter.increment();\n"
+"    console.log(counter.get()); // 1\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:300
+msgid ""
+"Perry performs closure conversion — captured variables are stored in heap-"
+"allocated closure objects."
+msgstr ""
+
+#: src/language/supported-features.md:302
+msgid "Async/Await"
+msgstr ""
+
+#: src/language/supported-features.md:304
+msgid ""
+"```typescript\n"
+"async function asyncAwaitDemo(): Promise<void> {\n"
+"    interface Profile { id: number; name: string }\n"
+"\n"
+"    async function fetchUser(id: number): Promise<Profile> {\n"
+"        // The docs example uses fetch(...) here; we inline a synthetic\n"
+"        // result so the snippet compiles and runs hermetically.\n"
+"        return { id, name: `user-${id}` }\n"
+"    }\n"
+"\n"
+"    const data = await fetchUser(1);\n"
+"    console.log(`async-await: id=${data.id} name=${data.name}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:319
+msgid ""
+"Perry compiles async functions to a state machine backed by Tokio's async "
+"runtime."
+msgstr ""
+
+#: src/language/supported-features.md:321
+msgid "Promises"
+msgstr ""
+
+#: src/language/supported-features.md:323
+msgid ""
+"```typescript\n"
+"async function promisesDemo(): Promise<void> {\n"
+"    const p = new Promise<number>((resolve, reject) => {\n"
+"        resolve(42);\n"
+"    });\n"
+"\n"
+"    p.then((value) => console.log(value));\n"
+"\n"
+"    // Promise.all\n"
+"    const results = await Promise.all([\n"
+"        Promise.resolve(\"a\"),\n"
+"        Promise.resolve(\"b\"),\n"
+"    ]);\n"
+"\n"
+"    console.log(`promises: results=${results.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:341
+msgid "Generators"
+msgstr ""
+
+#: src/language/supported-features.md:357
+msgid "Map and Set"
+msgstr ""
+
+#: src/language/supported-features.md:359
+msgid ""
+"```typescript\n"
+"function mapSetDemo(): void {\n"
+"    const map = new Map<string, number>();\n"
+"    map.set(\"a\", 1);\n"
+"    map.get(\"a\");\n"
+"    map.has(\"a\");\n"
+"    map.delete(\"a\");\n"
+"    map.size;\n"
+"\n"
+"    const set = new Set<number>();\n"
+"    set.add(1);\n"
+"    set.has(1);\n"
+"    set.delete(1);\n"
+"    set.size;\n"
+"\n"
+"    console.log(`map-set: map_size=${map.size} set_size=${set.size}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:378
+msgid "Regular Expressions"
+msgstr ""
+
+#: src/language/supported-features.md:380
+msgid ""
+"```typescript\n"
+"function regexDemo(): void {\n"
+"    const re = /hello\\s+(\\w+)/;\n"
+"    const match = \"hello world\".match(re);\n"
+"\n"
+"    if (re.test(\"hello perry\")) {\n"
+"        console.log(\"Matched!\");\n"
+"    }\n"
+"\n"
+"    const replaced = \"hello world\".replace(/world/, \"perry\");\n"
+"\n"
+"    console.log(`regex: match=${match !== null} replaced=${replaced}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:395 src/widgets/data-fetching.md:154
+msgid "Error Handling"
+msgstr ""
+
+#: src/language/supported-features.md:397
+msgid ""
+"```typescript\n"
+"function errorsDemo(): void {\n"
+"    try {\n"
+"        throw new Error(\"something went wrong\");\n"
+"    } catch (e: any) {\n"
+"        console.log(e.message);\n"
+"    } finally {\n"
+"        console.log(\"cleanup\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:409
+msgid "JSON"
+msgstr ""
+
+#: src/language/supported-features.md:411
+msgid ""
+"```typescript\n"
+"function jsonDemo(): void {\n"
+"    const obj = JSON.parse('{\"key\": \"value\"}');\n"
+"    const str = JSON.stringify(obj);\n"
+"    const pretty = JSON.stringify(obj, null, 2);\n"
+"\n"
+"    console.log(`json: str_len=${str.length} pretty_len=${pretty.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:421
+msgid "typeof and instanceof"
+msgstr ""
+
+#: src/language/supported-features.md:423
+msgid ""
+"```typescript\n"
+"function typeofInstanceofDemo(): void {\n"
+"    const x: any = \"hello\"\n"
+"    if (typeof x === \"string\") {\n"
+"        console.log(x.length);\n"
+"    }\n"
+"\n"
+"    const obj: any = new Dog(\"Rex\")\n"
+"    if (obj instanceof Dog) {\n"
+"        obj.speak();\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:437
+msgid ""
+"`typeof` checks NaN-boxing tags at runtime. `instanceof` walks the class ID "
+"chain."
+msgstr ""
+
+#: src/language/supported-features.md:439
+msgid "Modules"
+msgstr ""
+
+#: src/language/supported-features.md:441
+msgid ""
+"ES module syntax is fully supported: named exports, default exports, and re-"
+"exports."
+msgstr ""
+
+#: src/language/supported-features.md:444
+msgid "The exporting module:"
+msgstr ""
+
+#: src/language/supported-features.md:446
+msgid ""
+"```typescript\n"
+"// Named exports\n"
+"export function helper(x: number): number { return x + 1 }\n"
+"export const VALUE = 42\n"
+"\n"
+"// Default export\n"
+"export default class MyClass {\n"
+"    name: string\n"
+"    constructor(name: string) {\n"
+"        this.name = name\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:460
+msgid "The importing module:"
+msgstr ""
+
+#: src/language/supported-features.md:462
+msgid ""
+"```typescript\n"
+"// Default + named imports from a sibling module\n"
+"import MyClass, { helper, VALUE } from \"./utils\"\n"
+"\n"
+"// Re-export\n"
+"export { helper } from \"./utils\"\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:470
+msgid "BigInt"
+msgstr ""
+
+#: src/language/supported-features.md:472
+msgid ""
+"```typescript\n"
+"function bigintDemo(): void {\n"
+"    const big = BigInt(9007199254740991);\n"
+"    const result = big + BigInt(1);\n"
+"\n"
+"    // Bitwise operations\n"
+"    const and = big & BigInt(0xFF);\n"
+"    const or = big | BigInt(0xFF);\n"
+"    const xor = big ^ BigInt(0xFF);\n"
+"    const shl = big << BigInt(2);\n"
+"    const shr = big >> BigInt(2);\n"
+"    const not = ~big;\n"
+"\n"
+"    console.log(`bigint: result_ok=${result !== null} and_ok=${and !== null} or_ok=${or !== null}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:489
+msgid "String Methods"
+msgstr ""
+
+#: src/language/supported-features.md:491
+msgid ""
+"```typescript\n"
+"function stringMethodsDemo(): void {\n"
+"    const s = \"Hello, World!\";\n"
+"    s.length;\n"
+"    s.toUpperCase();\n"
+"    s.toLowerCase();\n"
+"    s.trim();\n"
+"    s.split(\", \");\n"
+"    s.includes(\"World\");\n"
+"    s.startsWith(\"Hello\");\n"
+"    s.endsWith(\"!\");\n"
+"    s.indexOf(\"World\");\n"
+"    s.slice(0, 5);\n"
+"    s.substring(0, 5);\n"
+"    s.replace(\"World\", \"Perry\");\n"
+"    s.repeat(3);\n"
+"    s.charAt(0);\n"
+"    s.padStart(20);\n"
+"    s.padEnd(20);\n"
+"\n"
+"    console.log(`string-methods: ${s.toUpperCase()}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:515
+msgid "Math"
+msgstr ""
+
+#: src/language/supported-features.md:538
+msgid "Date"
+msgstr ""
+
+#: src/language/supported-features.md:551
+msgid "Console"
+msgstr ""
+
+#: src/language/supported-features.md:553
+msgid ""
+"```typescript\n"
+"function consoleDemo(): void {\n"
+"    console.log(\"message\");\n"
+"    console.error(\"error\");\n"
+"    console.warn(\"warning\");\n"
+"    console.time(\"label\");\n"
+"    console.timeEnd(\"label\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:563 src/contributing/architecture.md:56
+msgid "Garbage Collection"
+msgstr ""
+
+#: src/language/supported-features.md:565
+msgid ""
+"Perry includes a mark-sweep garbage collector. It runs automatically when "
+"memory pressure is detected (~8MB arena blocks), but you can also trigger it"
+" manually:"
+msgstr ""
+
+#: src/language/supported-features.md:567
+msgid ""
+"```typescript\n"
+"function gcDemo(): void {\n"
+"    gc(); // Explicit garbage collection\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:573
+msgid ""
+"The GC uses conservative stack scanning to find roots and supports arena-"
+"allocated objects (arrays, objects) and malloc-allocated objects (strings, "
+"closures, promises, BigInts, errors)."
+msgstr ""
+
+#: src/language/supported-features.md:575
+msgid "JSX/TSX"
+msgstr ""
+
+#: src/language/supported-features.md:577
+msgid ""
+"Perry's parser and HIR understand JSX syntax (parsed via SWC, lowered in "
+"`crates/perry-hir/src/jsx.rs`), but the runtime `_jsx` / `_jsxs` symbols are"
+" not yet linked, so a `.tsx` file fails at the link stage today. The "
+"canonical pattern is the function-call form Perry's UI examples already use "
+"(`Text(\"hi\")` instead of `<Text>hi</Text>`)."
+msgstr ""
+
+#: src/language/supported-features.md:583
+msgid ""
+"```text\n"
+"// Planned JSX shape (parses but doesn't link yet — issue: runtime _jsx symbols):\n"
+"\n"
+"function Greeting({ name }: { name: string }) {\n"
+"  return <Text>{`Hello, ${name}!`}</Text>;\n"
+"}\n"
+"\n"
+"<Button onClick={() => console.log(\"clicked\")}>Click me</Button>\n"
+"\n"
+"<>\n"
+"  <Text>Line 1</Text>\n"
+"  <Text>Line 2</Text>\n"
+"</>\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:598
+msgid ""
+"JSX elements are transformed to function calls via the `jsx()`/`jsxs()` "
+"runtime."
+msgstr ""
+
+#: src/language/supported-features.md:602
+msgid "[Type System](type-system.md) — Type inference and checking"
+msgstr ""
+
+#: src/language/supported-features.md:603
+msgid "[Limitations](limitations.md) — What's not supported yet"
+msgstr ""
+
+#: src/language/type-system.md:3
+msgid ""
+"Perry erases types at compile time, similar to how `tsc` removes type "
+"annotations when emitting JavaScript. However, Perry also performs type "
+"inference to generate efficient native code."
+msgstr ""
+
+#: src/language/type-system.md:5
+msgid "Type Inference"
+msgstr ""
+
+#: src/language/type-system.md:7
+msgid "Perry infers types from expressions without requiring annotations:"
+msgstr ""
+
+#: src/language/type-system.md:9
+msgid ""
+"```typescript\n"
+"function inferenceBasics(): void {\n"
+"    let x = 5;           // inferred as number\n"
+"    let s = \"hello\";     // inferred as string\n"
+"    let b = true;        // inferred as boolean\n"
+"    let arr = [1, 2, 3]; // inferred as number[]\n"
+"\n"
+"    console.log(`inference: x=${x} s=${s} b=${b} arr_len=${arr.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:20
+msgid "Inference works through:"
+msgstr ""
+
+#: src/language/type-system.md:21
+msgid "**Literal values**: `5` → `number`, `\"hi\"` → `string`"
+msgstr ""
+
+#: src/language/type-system.md:22
+msgid "**Binary operations**: `a + b` where both are numbers → `number`"
+msgstr ""
+
+#: src/language/type-system.md:23
+msgid ""
+"**Variable propagation**: if `x` is `number`, then `let y = x` is `number`"
+msgstr ""
+
+#: src/language/type-system.md:24
+msgid ""
+"**Method returns**: `\"hello\".trim()` → `string`, `[1,2].length` → `number`"
+msgstr ""
+
+#: src/language/type-system.md:25
+msgid ""
+"**Function returns**: user-defined function return types are propagated to "
+"callers"
+msgstr ""
+
+#: src/language/type-system.md:27
+msgid ""
+"```typescript\n"
+"function inferenceFunction(): void {\n"
+"    function double(n: number): number {\n"
+"        return n * 2;\n"
+"    }\n"
+"    let result = double(5); // inferred as number\n"
+"\n"
+"    console.log(`inference-function: result=${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:38
+msgid "Type Annotations"
+msgstr ""
+
+#: src/language/type-system.md:40
+msgid "Standard TypeScript annotations work:"
+msgstr ""
+
+#: src/language/type-system.md:42
+msgid ""
+"```typescript\n"
+"interface Config {\n"
+"    port: number;\n"
+"    host: string;\n"
+"}\n"
+"\n"
+"function annotations(): void {\n"
+"    let name: string = \"Perry\";\n"
+"    let count: number = 0;\n"
+"    let items: string[] = [];\n"
+"\n"
+"    function greet(name: string): string {\n"
+"        return `Hello, ${name}`;\n"
+"    }\n"
+"\n"
+"    const cfg: Config = { port: 8080, host: \"localhost\" }\n"
+"    console.log(`annotations: ${greet(name)} count=${count} items=${items.length} port=${cfg.port}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:62
+msgid "Utility Types"
+msgstr ""
+
+#: src/language/type-system.md:64
+msgid ""
+"Common TypeScript utility types are erased at compile time (they don't "
+"affect code generation):"
+msgstr ""
+
+#: src/language/type-system.md:75
+msgid ""
+"These are all recognized and erased — they won't cause compilation errors."
+msgstr ""
+
+#: src/language/type-system.md:77
+msgid "Generics"
+msgstr ""
+
+#: src/language/type-system.md:79
+msgid "Generic type parameters are erased:"
+msgstr ""
+
+#: src/language/type-system.md:81
+msgid ""
+"```typescript\n"
+"function identity<T>(value: T): T {\n"
+"    return value;\n"
+"}\n"
+"\n"
+"class Box<T> {\n"
+"    value: T;\n"
+"    constructor(value: T) {\n"
+"        this.value = value;\n"
+"    }\n"
+"}\n"
+"\n"
+"function genericsDemo(): void {\n"
+"    const box = new Box<number>(42);\n"
+"    const id = identity<string>(\"hello\")\n"
+"    console.log(`generics: box.value=${box.value} id=${id}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:100
+msgid ""
+"At runtime, all values are NaN-boxed — the generic parameter doesn't affect "
+"code generation."
+msgstr ""
+
+#: src/language/type-system.md:102
+msgid "Type Checking with `--type-check`"
+msgstr ""
+
+#: src/language/type-system.md:104
+msgid ""
+"For stricter type checking, Perry can integrate with Microsoft's TypeScript "
+"checker:"
+msgstr ""
+
+#: src/language/type-system.md:110
+msgid ""
+"This resolves cross-file types, interfaces, and generics via an IPC "
+"protocol. It falls back gracefully if the type checker is not installed."
+msgstr ""
+
+#: src/language/type-system.md:112
+msgid ""
+"Without `--type-check`, Perry relies on its own inference engine, which "
+"handles common patterns but doesn't perform full TypeScript type checking."
+msgstr ""
+
+#: src/language/type-system.md:114
+msgid "Union and Intersection Types"
+msgstr ""
+
+#: src/language/type-system.md:116
+msgid ""
+"Union types are recognized syntactically but don't affect code generation:"
+msgstr ""
+
+#: src/language/type-system.md:118
+msgid ""
+"```typescript\n"
+"type StringOrNumber = string | number;\n"
+"\n"
+"function process(value: StringOrNumber) {\n"
+"    if (typeof value === \"string\") {\n"
+"        console.log(value.toUpperCase());\n"
+"    } else {\n"
+"        console.log(value + 1);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:130
+msgid "Use `typeof` checks for runtime type narrowing."
+msgstr ""
+
+#: src/language/type-system.md:132
+msgid "Type Guards"
+msgstr ""
+
+#: src/language/type-system.md:134
+msgid ""
+"```typescript\n"
+"function isString(value: any): value is string {\n"
+"    return typeof value === \"string\";\n"
+"}\n"
+"\n"
+"function typeGuardsDemo(): void {\n"
+"    const x: any = \"hello\"\n"
+"    if (isString(x)) {\n"
+"        console.log(x.toUpperCase());\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:147
+msgid ""
+"The `value is string` annotation is erased, but the `typeof` check works at "
+"runtime."
+msgstr ""
+
+#: src/language/type-system.md:151
+msgid "[Supported Features](supported-features.md) — Complete feature list"
+msgstr ""
+
+#: src/language/type-system.md:152
+msgid "[Limitations](limitations.md) — What's not supported"
+msgstr ""
+
+#: src/language/limitations.md:3
+msgid ""
+"Perry compiles a practical subset of TypeScript. This page documents what's "
+"not supported or works differently from Node.js/tsc."
+msgstr ""
+
+#: src/language/limitations.md:5
+msgid "No Runtime Type Checking"
+msgstr ""
+
+#: src/language/limitations.md:7
+msgid ""
+"Types are erased at compile time. There is no runtime type system — Perry "
+"doesn't generate type guards or runtime type metadata."
+msgstr ""
+
+#: src/language/limitations.md:9
+msgid ""
+"```typescript\n"
+"function someFunction(): number {\n"
+"    return 42\n"
+"}\n"
+"\n"
+"function erasedTypes(): void {\n"
+"    // These annotations are erased — no runtime effect\n"
+"    const x: number = someFunction(); // No runtime check that result is actually a number\n"
+"    console.log(`erased-types: x=${x}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:21
+msgid ""
+"Use explicit `typeof` checks where runtime type discrimination is needed."
+msgstr ""
+
+#: src/language/limitations.md:23
+msgid "No eval() or Dynamic Code"
+msgstr ""
+
+#: src/language/limitations.md:25
+msgid ""
+"Perry compiles to native code ahead of time. Dynamic code execution is not "
+"possible:"
+msgstr ""
+
+#: src/language/limitations.md:28
+msgid ""
+"```text\n"
+"// Not supported\n"
+"eval(\"console.log('hi')\");\n"
+"new Function(\"return 42\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:34
+msgid "No Decorators"
+msgstr ""
+
+#: src/language/limitations.md:36
+msgid "TypeScript decorators are not currently supported:"
+msgstr ""
+
+#: src/language/limitations.md:39
+msgid ""
+"```text\n"
+"// Not supported\n"
+"@Component\n"
+"class MyClass {}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:45
+msgid "No Reflection"
+msgstr ""
+
+#: src/language/limitations.md:47
+msgid "There is no `Reflect` API or runtime type metadata:"
+msgstr ""
+
+#: src/language/limitations.md:50
+msgid ""
+"```text\n"
+"// Not supported\n"
+"Reflect.getMetadata(\"design:type\", target, key);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:55
+msgid "No Dynamic require()"
+msgstr ""
+
+#: src/language/limitations.md:57
+msgid "Only static imports are supported:"
+msgstr ""
+
+#: src/language/limitations.md:60
+msgid ""
+"```text\n"
+"// Supported\n"
+"import { foo } from \"./module\";\n"
+"\n"
+"// Not supported\n"
+"const mod = require(\"./module\");\n"
+"const mod = await import(\"./module\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:69
+msgid "No Prototype Manipulation"
+msgstr ""
+
+#: src/language/limitations.md:71
+msgid ""
+"Perry compiles classes to fixed structures. Dynamic prototype modification "
+"is not supported:"
+msgstr ""
+
+#: src/language/limitations.md:74
+msgid ""
+"```text\n"
+"// Not supported\n"
+"MyClass.prototype.newMethod = function() {};\n"
+"Object.setPrototypeOf(obj, proto);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:80
+msgid "No Symbol Type"
+msgstr ""
+
+#: src/language/limitations.md:82
+msgid "The `Symbol` primitive type is not currently supported:"
+msgstr ""
+
+#: src/language/limitations.md:85
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const sym = Symbol(\"description\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:90
+msgid "No WeakMap/WeakRef"
+msgstr ""
+
+#: src/language/limitations.md:92
+msgid "Weak references are not implemented:"
+msgstr ""
+
+#: src/language/limitations.md:95
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const wm = new WeakMap();\n"
+"const wr = new WeakRef(obj);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:101
+msgid "No Proxy"
+msgstr ""
+
+#: src/language/limitations.md:103
+msgid "The `Proxy` object is not supported:"
+msgstr ""
+
+#: src/language/limitations.md:106
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const proxy = new Proxy(target, handler);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:111
+msgid "Limited Error Types"
+msgstr ""
+
+#: src/language/limitations.md:113
+msgid ""
+"`Error` and basic `throw`/`catch` work, but custom error subclasses have "
+"limited support:"
+msgstr ""
+
+#: src/language/limitations.md:125
+msgid "Threading Model"
+msgstr ""
+
+#: src/language/limitations.md:127
+msgid ""
+"Perry supports real multi-threading via `parallelMap` and `spawn` from "
+"`perry/thread`. See [Multi-Threading](../threading/overview.md)."
+msgstr ""
+
+#: src/language/limitations.md:129
+msgid ""
+"Threads do not share mutable state — closures passed to thread primitives "
+"cannot capture mutable variables (enforced at compile time). Values are "
+"deep-copied across thread boundaries. There is no `SharedArrayBuffer` or "
+"`Atomics`."
+msgstr ""
+
+#: src/language/limitations.md:131
+msgid "No Computed Property Names"
+msgstr ""
+
+#: src/language/limitations.md:133
+msgid "Dynamic property keys in object literals are limited:"
+msgstr ""
+
+#: src/language/limitations.md:136
+msgid ""
+"```text\n"
+"// Supported\n"
+"const key = \"name\";\n"
+"obj[key] = \"value\";\n"
+"\n"
+"// Not supported\n"
+"const obj = { [key]: \"value\" };\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:145
+msgid "npm Package Compatibility"
+msgstr ""
+
+#: src/language/limitations.md:147
+msgid "Not all npm packages work with Perry:"
+msgstr ""
+
+#: src/language/limitations.md:149
+msgid ""
+"**Natively supported**: ~50 popular packages (fastify, mysql2, redis, etc.) "
+"— these are compiled natively. See [Standard "
+"Library](../stdlib/overview.md)."
+msgstr ""
+
+#: src/language/limitations.md:150
+msgid ""
+"**`compilePackages`**: Pure TS/JS packages can be compiled natively via "
+"[configuration](../getting-started/project-config.md)."
+msgstr ""
+
+#: src/language/limitations.md:151
+msgid ""
+"**Not supported**: Packages requiring native addons (`.node` files), "
+"`eval()`, dynamic `require()`, or Node.js internals."
+msgstr ""
+
+#: src/language/limitations.md:153
+msgid "Workarounds"
+msgstr ""
+
+#: src/language/limitations.md:155
+msgid "Dynamic Behavior"
+msgstr ""
+
+#: src/language/limitations.md:157
+msgid ""
+"For cases where you need dynamic behavior, use the JavaScript runtime "
+"fallback:"
+msgstr ""
+
+#: src/language/limitations.md:160
+msgid ""
+"```text\n"
+"import { jsEval } from \"perry/jsruntime\";\n"
+"// Routes specific code through QuickJS for dynamic evaluation\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:165
+msgid "Type Narrowing"
+msgstr ""
+
+#: src/language/limitations.md:167
+msgid "Since there's no runtime type checking, use explicit checks:"
+msgstr ""
+
+#: src/language/limitations.md:169
+msgid ""
+"```typescript\n"
+"function processValue(value: string | number) {\n"
+"    // Instead of relying on type narrowing from generics\n"
+"    if (typeof value === \"string\") {\n"
+"        // String path\n"
+"        console.log(`string path: ${value}`)\n"
+"    } else if (typeof value === \"number\") {\n"
+"        // Number path\n"
+"        console.log(`number path: ${value}`)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:184
+msgid "[Supported Features](supported-features.md) — What does work"
+msgstr ""
+
+#: src/language/limitations.md:185
+msgid "[Type System](type-system.md) — How types are handled"
+msgstr ""
+
+#: src/packages/porting.md:1
+msgid "Porting npm Packages"
+msgstr ""
+
+#: src/packages/porting.md:3
+msgid ""
+"**Status: experimental.** This guide — and the [`port-npm-to-perry` "
+"skill](https://github.com/PerryTS/perry/tree/main/.claude/skills/port-npm-"
+"to-perry) that ships alongside it — is a first pass at systematizing what "
+"Perry contributors have been doing ad-hoc. Results will vary by package. "
+"Feedback at [issue #115](https://github.com/PerryTS/perry/issues/115)."
+msgstr ""
+
+#: src/packages/porting.md:5
+msgid ""
+"Perry compiles a practical subset of TypeScript. Most pure TS/JS packages "
+"can be pulled into a native compile via `perry.compilePackages`, but some "
+"will need small patches to avoid the constructs Perry doesn't support. This "
+"page is a field guide for doing that port — by hand, or by driving a coding "
+"agent with the prompt template below."
+msgstr ""
+
+#: src/packages/porting.md:7
+msgid "When porting makes sense"
+msgstr ""
+
+#: src/packages/porting.md:9
+msgid "Situation"
+msgstr ""
+
+#: src/packages/porting.md:9
+msgid "Try this first"
+msgstr ""
+
+#: src/packages/porting.md:11
+msgid "Package uses native addons (`.node` files, `binding.gyp`, `node-gyp`)"
+msgstr ""
+
+#: src/packages/porting.md:11
+msgid ""
+"**Don't port** — no path forward. Find an alternative package or use the "
+"[QuickJS fallback](../stdlib/overview.md#javascript-runtime-fallback)."
+msgstr ""
+
+#: src/packages/porting.md:12
+msgid "Package is pure TS/JS with only light use of dynamic features"
+msgstr ""
+
+#: src/packages/porting.md:12
+msgid ""
+"**Good candidate.** Add to `compilePackages`, patch whatever trips the "
+"compiler."
+msgstr ""
+
+#: src/packages/porting.md:13
+msgid ""
+"Package's core API is built on `Proxy` (ORMs, validation DSLs, reactive "
+"stores)"
+msgstr ""
+
+#: src/packages/porting.md:13
+msgid "**Probably not portable.** The surface Perry-users touch is the Proxy."
+msgstr ""
+
+#: src/packages/porting.md:14
+msgid ""
+"Package is pure TS/JS but uses lookbehind regex, `Symbol`, `WeakMap`, etc."
+msgstr ""
+
+#: src/packages/porting.md:14
+msgid "**Patchable.** See [Common gaps](#common-gaps) below."
+msgstr ""
+
+#: src/packages/porting.md:16
+msgid "The workflow"
+msgstr ""
+
+#: src/packages/porting.md:18
+msgid "1. Add it to `compilePackages`"
+msgstr ""
+
+#: src/packages/porting.md:20
+msgid "In your project's `package.json`:"
+msgstr ""
+
+#: src/packages/porting.md:30
+msgid ""
+"This is what tells Perry to pull the package into the native compile instead"
+" of routing it through a JavaScript runtime. See [Project "
+"Configuration](../getting-started/project-config.md#compilepackages) for the"
+" full semantics — including how first-resolved directories get cached so "
+"transitive copies dedup."
+msgstr ""
+
+#: src/packages/porting.md:32
+msgid "2. Try compiling"
+msgstr ""
+
+#: src/packages/porting.md:38
+msgid ""
+"Most of the time this is where you find out what's actually broken. Compile-"
+"time errors cite a file:line in the package — that's your patch list."
+msgstr ""
+
+#: src/packages/porting.md:40
+msgid "3. Patch the gaps"
+msgstr ""
+
+#: src/packages/porting.md:42
+msgid ""
+"See [Common gaps](#common-gaps) for the typical fixes. Keep patches minimal "
+"and localized — the goal is a clean compile, not a refactor."
+msgstr ""
+
+#: src/packages/porting.md:44
+msgid ""
+"**Record each patch** in a file at your project root (convention: `perry-"
+"patches/<package>.md`) so you can reapply them after `npm install` blows "
+"them away. Until `compilePackages` grows a native patch-file convention, "
+"this is the one bit of maintenance overhead."
+msgstr ""
+
+#: src/packages/porting.md:46
+msgid "4. Re-check after each compile"
+msgstr ""
+
+#: src/packages/porting.md:48
+msgid ""
+"Iterate: compile, patch the next error, compile again. Don't try to catch "
+"everything in a single pass — some errors only surface after earlier ones "
+"are fixed."
+msgstr ""
+
+#: src/packages/porting.md:50
+msgid "Common gaps"
+msgstr ""
+
+#: src/packages/porting.md:52
+msgid ""
+"Perry's [full limitations list](../language/limitations.md) is the canonical"
+" reference. In practice, these are the ones you hit when porting:"
+msgstr ""
+
+#: src/packages/porting.md:54
+msgid "Lookbehind regex"
+msgstr ""
+
+#: src/packages/porting.md:56
+msgid ""
+"Perry uses Rust's `regex` crate, which doesn't support lookbehind (`(?<=…)` "
+"/ `(?<!…)`)."
+msgstr ""
+
+#: src/packages/porting.md:58
+msgid ""
+"```text\n"
+"// Not supported\n"
+"str.match(/(?<=prefix)\\w+/);\n"
+"\n"
+"// Rewrite — capture the prefix and slice\n"
+"const m = str.match(/prefix(\\w+)/);\n"
+"const rest = m ? m[1] : null;\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:67
+msgid "`Symbol`"
+msgstr ""
+
+#: src/packages/porting.md:69
+msgid ""
+"Not supported as a primitive. When a package uses `Symbol` as a sentinel "
+"(the common case — e.g., for unique keys in a registry), swap for a string:"
+msgstr ""
+
+#: src/packages/porting.md:71
+msgid ""
+"```text\n"
+"// Before\n"
+"const REGISTRY_KEY = Symbol(\"registry\");\n"
+"\n"
+"// After\n"
+"const REGISTRY_KEY = \"__pkg_registry__\";\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:79
+msgid ""
+"When `Symbol` is used to implement `Symbol.iterator`/`Symbol.asyncIterator`,"
+" check whether the iteration is actually reached in your use case — often "
+"the class has a `for`\\-loop method alongside the iterator and you can "
+"ignore the iterator path."
+msgstr ""
+
+#: src/packages/porting.md:81
+msgid "`Proxy`, `Reflect`"
+msgstr ""
+
+#: src/packages/porting.md:83
+msgid ""
+"Not supported. These are usually load-bearing for the package's public API, "
+"so porting is often not feasible. If the `Proxy` is only in an optional path"
+" (e.g., dev-mode warnings), delete that branch."
+msgstr ""
+
+#: src/packages/porting.md:85
+msgid "`WeakMap` / `WeakRef` / `FinalizationRegistry`"
+msgstr ""
+
+#: src/packages/porting.md:87
+msgid ""
+"Not implemented. Swap `WeakMap` for a regular `Map` if the GC semantics "
+"aren't critical for correctness (most caches can tolerate this — they'll "
+"just hold references slightly longer)."
+msgstr ""
+
+#: src/packages/porting.md:89
+msgid "Decorators"
+msgstr ""
+
+#: src/packages/porting.md:91
+msgid ""
+"```text\n"
+"// Not supported\n"
+"@Component\n"
+"class Foo {}\n"
+"\n"
+"// Remove the decorator and inline the behavior, or use a factory function\n"
+"const Foo = Component(class Foo {});\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:100
+msgid "Dynamic `require()` / `await import(…)`"
+msgstr ""
+
+#: src/packages/porting.md:102
+msgid ""
+"Perry only supports static imports. If a package branches on `typeof require"
+" !== \"undefined\"` for a Node/browser split, pick the branch that works "
+"natively and delete the other."
+msgstr ""
+
+#: src/packages/porting.md:104
+msgid "Prototype manipulation"
+msgstr ""
+
+#: src/packages/porting.md:106
+msgid ""
+"```text\n"
+"// Not supported\n"
+"Object.setPrototypeOf(obj, proto);\n"
+"MyClass.prototype.newMethod = function() {};\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:112
+msgid ""
+"Usually appears in fallback shims for older runtimes. Often dead code in the"
+" Perry path — just delete it."
+msgstr ""
+
+#: src/packages/porting.md:114
+msgid "Computed property keys in object literals"
+msgstr ""
+
+#: src/packages/porting.md:116
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const obj = { [key]: value };\n"
+"\n"
+"// Rewrite\n"
+"const obj: Record<string, V> = {};\n"
+"obj[key] = value;\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:125
+msgid "Using a coding agent"
+msgstr ""
+
+#: src/packages/porting.md:127
+msgid ""
+"A general coding agent (Claude Code, Cursor, Codex, Aider) can drive most of"
+" this workflow. If you're using a skill-aware agent, invoke the [`port-npm-"
+"to-perry` "
+"skill](https://github.com/PerryTS/perry/tree/main/.claude/skills/port-npm-"
+"to-perry) directly. Otherwise, paste this prompt:"
+msgstr ""
+
+#: src/packages/porting.md:129
+msgid ""
+"```\n"
+"I want to port the npm package <NAME> to run under Perry\n"
+"(https://github.com/PerryTS/perry). Perry compiles a subset of TypeScript\n"
+"natively; the subset's gaps are documented at\n"
+"https://github.com/PerryTS/perry/blob/main/docs/src/language/limitations.md.\n"
+"\n"
+"Please:\n"
+"\n"
+"1. Read the package at node_modules/<NAME>/. Check package.json for\n"
+"   native addons (binding.gyp, gypfile, prebuilds/ — stop if present).\n"
+"2. Scan for unsupported constructs: eval, new Function, dynamic require,\n"
+"   Symbol, Proxy, WeakMap, WeakRef, Reflect, decorators, lookbehind\n"
+"   regex (?<= / ?<!), Object.setPrototypeOf, computed property keys.\n"
+"3. Report a triage: what rules the package out vs. what's patchable.\n"
+"4. If patchable: add the package to perry.compilePackages in\n"
+"   package.json, apply minimal localized patches, and record each\n"
+"   patch in perry-patches/<NAME>.md.\n"
+"5. Verify by running `perry compile` against a small file that imports\n"
+"   the package.\n"
+"\n"
+"Don't patch blindly — a grep hit inside a string or comment isn't real.\n"
+"Show me the triage before applying substantial patches.\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:153
+msgid ""
+"This is intentionally an agent-agnostic prompt — it'll work with any "
+"competent coding agent. The skill version bundles the same instructions with"
+" richer context and is auto-discovered by Claude Code."
+msgstr ""
+
+#: src/packages/porting.md:155
+msgid "Giving feedback"
+msgstr ""
+
+#: src/packages/porting.md:157
+msgid ""
+"This whole workflow is experimental. If a port fails in a way that feels "
+"like Perry should handle it — or if the guide misses a common gap — please "
+"comment on [issue #115](https://github.com/PerryTS/perry/issues/115) so we "
+"can iterate."
+msgstr ""
+
+#: src/threading/overview.md:3
+msgid ""
+"Perry gives you real OS threads with a one-line API. No worker setup, no "
+"message ports, no structured clone overhead. Just `parallelMap`, "
+"`parallelFilter`, and `spawn`."
+msgstr ""
+
+#: src/threading/overview.md:5
+msgid ""
+"```typescript\n"
+"async function overviewHeader(): Promise<void> {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"    const records = [\n"
+"        { score: 50, id: 1 },\n"
+"        { score: 90, id: 2 },\n"
+"        { score: 85, id: 3 },\n"
+"    ]\n"
+"    const threshold = 80\n"
+"\n"
+"    // Process a million items across all CPU cores\n"
+"    const results = parallelMap(data, (item: number) => item * item)\n"
+"\n"
+"    // Filter a large dataset in parallel\n"
+"    const valid = parallelFilter(records, (r: { score: number; id: number }) => r.score > threshold)\n"
+"\n"
+"    // Run expensive work in the background\n"
+"    const answer = await spawn(() => {\n"
+"        let acc = 0\n"
+"        for (let i = 0; i < 100_000; i++) acc += i\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    console.log(`overview-header results=${results.length} valid=${valid.length} answer=${answer}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:32
+msgid ""
+"This is something **no JavaScript runtime can do**. V8, Bun, and Deno are "
+"all locked to one thread per isolate. Perry compiles to native code — there "
+"are no isolates, no GIL, no structural limitations. Your code runs on real "
+"OS threads with the full power of every CPU core."
+msgstr ""
+
+#: src/threading/overview.md:34
+msgid "Why This Matters"
+msgstr ""
+
+#: src/threading/overview.md:36
+msgid ""
+"JavaScript's single-threaded model is its biggest performance bottleneck. "
+"Here's how runtimes try to work around it:"
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "Runtime"
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "\"Multi-threading\""
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "Reality"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid "**Node.js**"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid "`worker_threads`"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid ""
+"Separate V8 isolates. Data copied via structured clone. ~2MB RAM per worker."
+" Complex API."
+msgstr ""
+
+#: src/threading/overview.md:41
+msgid "**Deno**"
+msgstr ""
+
+#: src/threading/overview.md:41 src/threading/overview.md:42
+msgid "`Worker`"
+msgstr ""
+
+#: src/threading/overview.md:41
+msgid "Same as Node — isolated heaps, message passing only."
+msgstr ""
+
+#: src/threading/overview.md:42
+msgid "**Bun**"
+msgstr ""
+
+#: src/threading/overview.md:42
+msgid "Same architecture. Faster structured clone, still isolated."
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid "**Perry**"
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid "`parallelMap` / `spawn`"
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid ""
+"Real OS threads. Lightweight (8MB stack). One-line API. Compile-time safety."
+msgstr ""
+
+#: src/threading/overview.md:45
+msgid ""
+"The fundamental problem: V8 uses a garbage-collected heap that **cannot be "
+"shared** between threads. Every \"worker\" is an entirely separate "
+"JavaScript engine instance with its own heap, its own GC, and its own copy "
+"of your data."
+msgstr ""
+
+#: src/threading/overview.md:47
+msgid ""
+"Perry doesn't have this limitation. It compiles TypeScript to native machine"
+" code. Values are transferred between threads using zero-cost copies for "
+"numbers and efficient serialization for objects — no separate engine "
+"instances, no multi-megabyte overhead per thread."
+msgstr ""
+
+#: src/threading/overview.md:49
+msgid "Three Primitives"
+msgstr ""
+
+#: src/threading/overview.md:51
+msgid "`parallelMap` — Data-Parallel Processing"
+msgstr ""
+
+#: src/threading/overview.md:53
+msgid ""
+"Split an array across all CPU cores. Each element is processed "
+"independently. Results are collected in order."
+msgstr ""
+
+#: src/threading/overview.md:55
+msgid ""
+"```typescript\n"
+"async function overviewParallelMap(): Promise<void> {\n"
+"    const prices = [100, 200, 300, 400, 500, 600, 700, 800]\n"
+"    const adjusted = parallelMap(prices, (price: number) => {\n"
+"        // Heavy computation runs on a worker thread\n"
+"        let result = price\n"
+"        for (let i = 0; i < 1000000; i++) {\n"
+"            result = Math.sqrt(result * result + i)\n"
+"        }\n"
+"        return result\n"
+"    })\n"
+"\n"
+"    console.log(`overview-parallel-map len=${adjusted.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:71 src/plugins/creating-plugins.md:37
+msgid "Perry automatically:"
+msgstr ""
+
+#: src/threading/overview.md:72
+msgid "Detects the number of CPU cores"
+msgstr ""
+
+#: src/threading/overview.md:73
+msgid "Splits the array into chunks (one per core)"
+msgstr ""
+
+#: src/threading/overview.md:74
+msgid "Spawns OS threads to process each chunk"
+msgstr ""
+
+#: src/threading/overview.md:75
+msgid "Collects results in the original order"
+msgstr ""
+
+#: src/threading/overview.md:76
+msgid "Returns a new array"
+msgstr ""
+
+#: src/threading/overview.md:78
+msgid ""
+"For small arrays, Perry skips threading entirely and processes inline — no "
+"overhead for trivial cases."
+msgstr ""
+
+#: src/threading/overview.md:80
+msgid "`parallelFilter` — Data-Parallel Filtering"
+msgstr ""
+
+#: src/threading/overview.md:82
+msgid ""
+"Filter a large array across all CPU cores. Like `.filter()` but parallel:"
+msgstr ""
+
+#: src/threading/overview.md:84
+msgid ""
+"```typescript\n"
+"async function overviewParallelFilter(): Promise<void> {\n"
+"    const cutoffDate = 1_700_000_000\n"
+"    const users = [\n"
+"        { lastLogin: 1_710_000_000, score: 150, name: \"alice\" },\n"
+"        { lastLogin: 1_690_000_000, score: 50, name: \"bob\" },\n"
+"        { lastLogin: 1_720_000_000, score: 120, name: \"carol\" },\n"
+"    ]\n"
+"\n"
+"    // Filter across all cores — order is preserved\n"
+"    const active = parallelFilter(users, (user: { lastLogin: number; score: number; name: string }) => {\n"
+"        return user.lastLogin > cutoffDate && user.score > 100\n"
+"    })\n"
+"\n"
+"    console.log(`overview-parallel-filter active=${active.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:102
+msgid ""
+"Same rules as `parallelMap`: closures cannot capture mutable variables "
+"(compile-time enforced), and values are deep-copied between threads."
+msgstr ""
+
+#: src/threading/overview.md:104
+msgid "`spawn` — Background Threads"
+msgstr ""
+
+#: src/threading/overview.md:106
+msgid ""
+"Run any computation in the background and get a Promise back. The main "
+"thread continues immediately."
+msgstr ""
+
+#: src/threading/overview.md:108
+msgid ""
+"```typescript\n"
+"async function overviewSpawnBg(): Promise<void> {\n"
+"    // Start heavy work in the background\n"
+"    const handle = spawn(() => {\n"
+"        let sum = 0\n"
+"        for (let i = 0; i < 100_000; i++) {\n"
+"            sum += Math.sin(i)\n"
+"        }\n"
+"        return sum\n"
+"    })\n"
+"\n"
+"    // Main thread keeps running — UI stays responsive\n"
+"    console.log(\"Computing...\")\n"
+"\n"
+"    // Get the result when you need it\n"
+"    const result = await handle\n"
+"    console.log(`Done: len=${typeof result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:128
+msgid ""
+"`spawn` returns a standard Promise. You can `await` it, pass it to "
+"`Promise.all`, or chain `.then()` — it works exactly like any other async "
+"operation."
+msgstr ""
+
+#: src/threading/overview.md:130
+msgid "Practical Examples"
+msgstr ""
+
+#: src/threading/overview.md:132
+msgid "Parallel Image Processing"
+msgstr ""
+
+#: src/threading/overview.md:134
+msgid ""
+"```typescript\n"
+"async function overviewImage(): Promise<void> {\n"
+"    const pixels = [\n"
+"        { r: 100, g: 120, b: 140 },\n"
+"        { r: 50, g: 60, b: 70 },\n"
+"        { r: 200, g: 210, b: 220 },\n"
+"    ]\n"
+"\n"
+"    // Each pixel processed on a separate core\n"
+"    const processed = parallelMap(pixels, (pixel: { r: number; g: number; b: number }) => {\n"
+"        const r = Math.min(255, pixel.r * 1.2)\n"
+"        const g = Math.min(255, pixel.g * 0.8)\n"
+"        const b = Math.min(255, pixel.b * 1.1)\n"
+"        return { r, g, b }\n"
+"    })\n"
+"\n"
+"    console.log(`overview-image processed=${processed.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:154
+msgid "Parallel Cryptographic Hashing"
+msgstr ""
+
+#: src/threading/overview.md:156
+msgid ""
+"```typescript\n"
+"async function overviewCrypto(): Promise<void> {\n"
+"    // Hash thousands of items across all cores\n"
+"    const passwords = [\"pass1\", \"pass2\", \"pass3\"]\n"
+"    const hashed = parallelMap(passwords, (password: string) => {\n"
+"        // Stand-in for a real hash: deterministic FNV-1a over the bytes.\n"
+"        let h = 2166136261\n"
+"        for (let i = 0; i < password.length; i++) {\n"
+"            h ^= password.charCodeAt(i)\n"
+"            h = (h * 16777619) >>> 0\n"
+"        }\n"
+"        return h\n"
+"    })\n"
+"\n"
+"    console.log(`overview-crypto hashed=${hashed.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:174
+msgid "Multiple Independent Computations"
+msgstr ""
+
+#: src/threading/overview.md:176
+msgid ""
+"```typescript\n"
+"async function overviewMultiple(): Promise<void> {\n"
+"    const dataA = [1, 2, 3]\n"
+"    const dataB = [4, 5, 6]\n"
+"    const dataC = [7, 8, 9]\n"
+"\n"
+"    // Three independent tasks run simultaneously on three OS threads\n"
+"    const task1 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataA) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"    const task2 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataB) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"    const task3 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataC) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    // All three run concurrently\n"
+"    const [result1, result2, result3] = await Promise.all([task1, task2, task3])\n"
+"    console.log(`overview-multiple ${result1} ${result2} ${result3}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:205
+msgid "Keeping UI Responsive"
+msgstr ""
+
+#: src/threading/overview.md:207
+msgid ""
+"```typescript\n"
+"const responsiveButton = Button(\"Start Analysis\", async () => {\n"
+"    status.set(\"Analyzing...\")\n"
+"\n"
+"    // Heavy computation runs on a background thread\n"
+"    // UI stays responsive — user can still interact\n"
+"    const value = await spawn(() => {\n"
+"        let acc = 0\n"
+"        for (let i = 0; i < 1_000_000; i++) acc += i\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    status.set(`Done: ${value}`)\n"
+"})\n"
+"\n"
+"const responsiveText = Text(`Status: ${status.value}`)\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:225
+msgid "Captured Variables"
+msgstr ""
+
+#: src/threading/overview.md:227
+msgid ""
+"Closures can capture outer variables. Captured values are automatically "
+"deep-copied to each worker thread:"
+msgstr ""
+
+#: src/threading/overview.md:229
+msgid ""
+"```typescript\n"
+"async function overviewCaptured(): Promise<void> {\n"
+"    const prices = [100, 200, 300, 400]\n"
+"    const taxRate = 0.08\n"
+"    const discount = 0.15\n"
+"\n"
+"    // taxRate and discount are captured and copied to each thread\n"
+"    const finalPrices = parallelMap(prices, (price: number) => {\n"
+"        const discounted = price * (1 - discount)\n"
+"        return discounted * (1 + taxRate)\n"
+"    })\n"
+"\n"
+"    console.log(`overview-captured len=${finalPrices.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:245
+msgid ""
+"Numbers and booleans are zero-cost copies (just 64-bit values). Strings, "
+"arrays, and objects are deep-copied automatically."
+msgstr ""
+
+#: src/threading/overview.md:247
+msgid "Safety"
+msgstr ""
+
+#: src/threading/overview.md:249
+msgid ""
+"Perry enforces thread safety **at compile time**. You don't need to think "
+"about race conditions, mutexes, or data corruption."
+msgstr ""
+
+#: src/threading/overview.md:251
+msgid "No Shared Mutable State"
+msgstr ""
+
+#: src/threading/overview.md:253
+msgid ""
+"Closures passed to `parallelMap` and `spawn` **cannot capture mutable "
+"variables**. The compiler rejects this:"
+msgstr ""
+
+#: src/threading/overview.md:255
+msgid ""
+"```text\n"
+"// Reject example — Perry rejects this at compile time:\n"
+"\n"
+"let counter = 0;\n"
+"\n"
+"// COMPILE ERROR: Closures passed to parallelMap cannot\n"
+"// capture mutable variable 'counter'\n"
+"parallelMap(data, (item) => {\n"
+"    counter++;  // Not allowed\n"
+"    return item;\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:268
+msgid ""
+"This eliminates data races by design. If you need to aggregate results, use "
+"the return values:"
+msgstr ""
+
+#: src/threading/overview.md:270
+msgid ""
+"```typescript\n"
+"async function overviewReduceInstead(): Promise<void> {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    // Instead of mutating a shared counter, return values and reduce\n"
+"    const results = parallelMap(data, (item: number) => item * item)\n"
+"    const total = results.reduce((sum: number, r: number) => sum + r, 0)\n"
+"\n"
+"    console.log(`overview-reduce-instead total=${total}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:282
+msgid "Independent Thread Arenas"
+msgstr ""
+
+#: src/threading/overview.md:284
+msgid ""
+"Each worker thread has its own memory arena. Objects created on one thread "
+"can never be accessed from another thread. Values cross thread boundaries "
+"only through deep-copy serialization, which Perry handles automatically and "
+"invisibly."
+msgstr ""
+
+#: src/threading/overview.md:288
+msgid "Perry's threading model is built on three pillars:"
+msgstr ""
+
+#: src/threading/overview.md:290
+msgid "**1. Native Code, Not Interpreted**"
+msgstr ""
+
+#: src/threading/overview.md:292
+msgid ""
+"Perry compiles TypeScript to native machine code via LLVM. There's no "
+"interpreter, no VM, no isolate. A function pointer is just a function "
+"pointer — it's valid on any thread."
+msgstr ""
+
+#: src/threading/overview.md:294
+msgid "**2. Thread-Local Memory**"
+msgstr ""
+
+#: src/threading/overview.md:296
+msgid ""
+"Each thread gets its own memory arena (bump allocator) and garbage "
+"collector. No synchronization overhead during computation. When a thread "
+"finishes, its arena is freed automatically."
+msgstr ""
+
+#: src/threading/overview.md:298
+msgid "**3. Serialized Transfer**"
+msgstr ""
+
+#: src/threading/overview.md:300
+msgid ""
+"Values crossing thread boundaries are serialized to a thread-safe "
+"intermediate format and deserialized on the target thread. The cost depends "
+"on the value type:"
+msgstr ""
+
+#: src/threading/overview.md:302
+msgid "Value Type"
+msgstr ""
+
+#: src/threading/overview.md:302
+msgid "Transfer Cost"
+msgstr ""
+
+#: src/threading/overview.md:304
+msgid "Numbers, booleans, null, undefined"
+msgstr ""
+
+#: src/threading/overview.md:304 src/threading/parallel-map.md:55
+msgid "Zero-cost (64-bit copy)"
+msgstr ""
+
+#: src/threading/overview.md:305 src/threading/parallel-map.md:57
+msgid "Strings"
+msgstr ""
+
+#: src/threading/overview.md:305
+msgid "O(n) byte copy"
+msgstr ""
+
+#: src/threading/overview.md:306
+msgid "O(n) deep copy of elements"
+msgstr ""
+
+#: src/threading/overview.md:307
+msgid "O(n) deep copy of fields"
+msgstr ""
+
+#: src/threading/overview.md:308
+msgid "Pointer + captured values"
+msgstr ""
+
+#: src/threading/overview.md:310
+msgid ""
+"For numeric workloads — the most common parallelizable tasks — the threading"
+" overhead is negligible."
+msgstr ""
+
+#: src/threading/overview.md:314
+msgid ""
+"[parallelMap Reference](parallel-map.md) — detailed API and performance tips"
+msgstr ""
+
+#: src/threading/overview.md:315
+msgid ""
+"[parallelFilter Reference](parallel-filter.md) — parallel array filtering"
+msgstr ""
+
+#: src/threading/overview.md:316
+msgid ""
+"[spawn Reference](spawn.md) — background threads and Promise integration"
+msgstr ""
+
+#: src/threading/parallel-map.md:3
+msgid ""
+"**Signature**: `parallelMap<T, U>(data: T[], fn: (item: T) => U): U[]` — "
+"imported from `perry/thread`."
+msgstr ""
+
+#: src/threading/parallel-map.md:5
+msgid ""
+"Processes every element of an array in parallel across all available CPU "
+"cores. Returns a new array with the results in the same order as the input."
+msgstr ""
+
+#: src/threading/parallel-map.md:7 src/threading/parallel-filter.md:7
+#: src/threading/spawn.md:7
+msgid "Basic Usage"
+msgstr ""
+
+#: src/threading/parallel-map.md:9
+msgid ""
+"```typescript\n"
+"function parallelMapBasic(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"    const doubled = parallelMap(numbers, (x: number) => x * 2)\n"
+"    // [2, 4, 6, 8, 10, 12, 14, 16]\n"
+"    console.log(`parallel-map-basic len=${doubled.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:31
+msgid ""
+"Perry automatically detects the number of CPU cores and splits the array "
+"into equal chunks. Elements within each chunk are processed sequentially; "
+"chunks run concurrently across cores."
+msgstr ""
+
+#: src/threading/parallel-map.md:33 src/threading/parallel-filter.md:53
+#: src/threading/spawn.md:80
+msgid "Capturing Variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:35
+msgid ""
+"The mapping function can reference variables from the outer scope. Captured "
+"values are deep-copied to each worker thread automatically:"
+msgstr ""
+
+#: src/threading/parallel-map.md:37
+msgid ""
+"```typescript\n"
+"function parallelMapCapture(): void {\n"
+"    const prices = [100, 200, 300]\n"
+"    const exchangeRate = 1.12\n"
+"\n"
+"    const converted = parallelMap(prices, (price: number) => {\n"
+"        // exchangeRate is captured and copied to each thread\n"
+"        return price * exchangeRate\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-capture len=${converted.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:51
+msgid "What Can Be Captured"
+msgstr ""
+
+#: src/threading/parallel-map.md:53 src/ui/overview.md:57 src/ui/styling.md:45
+#: src/widgets/creating-widgets.md:45 src/widgets/configuration.md:70
+#: src/testing/geisterhand.md:84 src/cli/flags.md:43 src/cli/perry-toml.md:114
+#: src/cli/perry-toml.md:125 src/cli/perry-toml.md:153
+#: src/cli/perry-toml.md:165 src/cli/perry-toml.md:175
+#: src/cli/perry-toml.md:181 src/cli/perry-toml.md:191
+#: src/cli/perry-toml.md:241 src/cli/perry-toml.md:254
+#: src/cli/perry-toml.md:260 src/cli/perry-toml.md:268
+#: src/cli/perry-toml.md:299 src/cli/perry-toml.md:310
+#: src/cli/perry-toml.md:327 src/cli/perry-toml.md:345
+#: src/cli/perry-toml.md:357 src/cli/perry-toml.md:367
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414 src/contributing/architecture.md:47
+msgid "Type"
+msgstr ""
+
+#: src/threading/parallel-map.md:53
+msgid "Supported"
+msgstr ""
+
+#: src/threading/parallel-map.md:53
+msgid "Transfer"
+msgstr ""
+
+#: src/threading/parallel-map.md:55
+msgid "Numbers"
+msgstr ""
+
+#: src/threading/parallel-map.md:55 src/threading/parallel-map.md:56
+#: src/threading/parallel-map.md:57 src/threading/parallel-map.md:58
+#: src/threading/parallel-map.md:59 src/threading/parallel-map.md:60
+#: src/platforms/overview.md:69 src/platforms/overview.md:70
+#: src/platforms/overview.md:71 src/platforms/overview.md:72
+#: src/platforms/overview.md:73 src/platforms/overview.md:74
+#: src/platforms/overview.md:75 src/widgets/platforms.md:22
+#: src/widgets/platforms.md:23 src/widgets/platforms.md:24
+#: src/widgets/platforms.md:25 src/widgets/platforms.md:26
+#: src/widgets/platforms.md:27 src/widgets/platforms.md:28
+#: src/widgets/platforms.md:29 src/widgets/platforms.md:30
+#: src/widgets/platforms.md:31 src/widgets/platforms.md:32
+#: src/widgets/platforms.md:33
+msgid "Yes"
+msgstr ""
+
+#: src/threading/parallel-map.md:56
+msgid "Booleans"
+msgstr ""
+
+#: src/threading/parallel-map.md:56
+msgid "Zero-cost"
+msgstr ""
+
+#: src/threading/parallel-map.md:57
+msgid "Byte copy"
+msgstr ""
+
+#: src/threading/parallel-map.md:58 src/threading/parallel-map.md:59
+msgid "Deep copy"
+msgstr ""
+
+#: src/threading/parallel-map.md:60
+msgid "`const` variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:60 src/threading/parallel-map.md:61
+msgid "Copied"
+msgstr ""
+
+#: src/threading/parallel-map.md:61
+msgid "`let`/`var` variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:61
+msgid "Only if not reassigned"
+msgstr ""
+
+#: src/threading/parallel-map.md:63
+msgid "What Cannot Be Captured"
+msgstr ""
+
+#: src/threading/parallel-map.md:65
+msgid ""
+"Mutable variables — variables that are reassigned anywhere in the enclosing "
+"scope — are rejected at compile time:"
+msgstr ""
+
+#: src/threading/parallel-map.md:67
+msgid ""
+"```text\n"
+"// Reject example — Perry rejects this at compile time:\n"
+"\n"
+"let total = 0;\n"
+"\n"
+"// COMPILE ERROR: Cannot capture mutable variable 'total'\n"
+"parallelMap(data, (item) => {\n"
+"    total += item;   // Would be a data race\n"
+"    return item;\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:79
+msgid "Instead, return values and reduce:"
+msgstr ""
+
+#: src/threading/parallel-map.md:90 src/threading/parallel-filter.md:155
+msgid "Performance"
+msgstr ""
+
+#: src/threading/parallel-map.md:92
+msgid "When to Use parallelMap"
+msgstr ""
+
+#: src/threading/parallel-map.md:94
+msgid ""
+"Use `parallelMap` when the computation per element is **significantly "
+"heavier** than the cost of copying the element across threads."
+msgstr ""
+
+#: src/threading/parallel-map.md:96
+msgid "**Good candidates** (CPU-bound work per element):"
+msgstr ""
+
+#: src/threading/parallel-map.md:98
+msgid ""
+"```typescript\n"
+"function parallelMapGoodCandidates(): void {\n"
+"    const data = [1.0, 2.0, 3.0, 4.0]\n"
+"    const documents = [\"alpha beta\", \"gamma delta\", \"epsilon\"]\n"
+"    const inputs = [\"a\", \"bb\", \"ccc\"]\n"
+"\n"
+"    // Heavy math\n"
+"    const out1 = parallelMap(data, (x: number) => {\n"
+"        let acc = x\n"
+"        for (let i = 0; i < 1_000; i++) acc = Math.sqrt(acc * acc + i)\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    // String processing on large strings\n"
+"    const out2 = parallelMap(documents, (doc: string) => {\n"
+"        const words = doc.split(\" \")\n"
+"        return { count: words.length, first: words[0] }\n"
+"    })\n"
+"\n"
+"    // Cryptographic operations\n"
+"    const out3 = parallelMap(inputs, (input: string) => {\n"
+"        let h = 0\n"
+"        for (let i = 0; i < input.length; i++) h = (h * 31 + input.charCodeAt(i)) >>> 0\n"
+"        return h\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-good-candidates ${out1.length} ${out2.length} ${out3.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:128
+msgid "**Poor candidates** (trivial work per element):"
+msgstr ""
+
+#: src/threading/parallel-map.md:130
+msgid ""
+"```typescript\n"
+"function parallelMapPoorCandidate(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5]\n"
+"\n"
+"    // Too simple — threading overhead outweighs the gain\n"
+"    const a = parallelMap(numbers, (x: number) => x + 1)\n"
+"\n"
+"    // For trivial operations, use regular map\n"
+"    const result = numbers.map((x: number) => x + 1)\n"
+"\n"
+"    console.log(`parallel-map-poor-candidate ${a.length} ${result.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:144
+msgid "Small Array Optimization"
+msgstr ""
+
+#: src/threading/parallel-map.md:146
+msgid ""
+"For arrays with fewer elements than CPU cores, Perry skips threading "
+"entirely and processes elements inline on the main thread. There's zero "
+"overhead for small inputs."
+msgstr ""
+
+#: src/threading/parallel-map.md:148
+msgid "Numeric Fast Path"
+msgstr ""
+
+#: src/threading/parallel-map.md:150
+msgid ""
+"When elements are pure numbers (no strings, objects, or arrays), Perry "
+"transfers them between threads at virtually zero cost — just 64-bit value "
+"copies with no serialization."
+msgstr ""
+
+#: src/threading/parallel-map.md:152 src/threading/parallel-filter.md:78
+#: src/threading/spawn.md:183 src/cli/flags.md:139
+msgid "Examples"
+msgstr ""
+
+#: src/threading/parallel-map.md:154
+msgid "Matrix Row Processing"
+msgstr ""
+
+#: src/threading/parallel-map.md:156
+msgid ""
+"```typescript\n"
+"function parallelMapMatrix(): void {\n"
+"    // Process each row of a matrix independently\n"
+"    const rows = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]\n"
+"    const rowSums = parallelMap(rows, (row: number[]) => {\n"
+"        let sum = 0\n"
+"        for (const val of row) sum += val\n"
+"        return sum\n"
+"    })\n"
+"    // [6, 15, 24]\n"
+"    console.log(`parallel-map-matrix sums=${rowSums[0]},${rowSums[1]},${rowSums[2]}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:170
+msgid "Batch Validation"
+msgstr ""
+
+#: src/threading/parallel-map.md:172
+msgid ""
+"```typescript\n"
+"function parallelMapValidation(): void {\n"
+"    const users = [\n"
+"        { name: \"Alice\", email: \"alice@example.com\" },\n"
+"        { name: \"Bob\", email: \"invalid\" },\n"
+"        { name: \"Charlie\", email: \"charlie@example.com\" },\n"
+"    ]\n"
+"\n"
+"    const validationResults = parallelMap(users, (user: { name: string; email: string }) => {\n"
+"        const emailValid = user.email.includes(\"@\") && user.email.includes(\".\")\n"
+"        const nameValid = user.name.length > 0 && user.name.length < 100\n"
+"        return { name: user.name, valid: emailValid && nameValid }\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-validation len=${validationResults.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:190
+msgid "Financial Calculations"
+msgstr ""
+
+#: src/threading/parallel-map.md:192
+msgid ""
+"```typescript\n"
+"function parallelMapMonteCarlo(): void {\n"
+"    const portfolios = [\n"
+"        { id: 1, base: 100 },\n"
+"        { id: 2, base: 200 },\n"
+"        { id: 3, base: 150 },\n"
+"    ] // thousands of portfolios\n"
+"\n"
+"    // Monte Carlo simulation across all cores\n"
+"    const riskScores = parallelMap(portfolios, (portfolio: { id: number; base: number }) => {\n"
+"        let totalRisk = 0\n"
+"        for (let sim = 0; sim < 1000; sim++) {\n"
+"            // simulateReturns stand-in: deterministic pseudo-random walk.\n"
+"            let s = portfolio.base + sim\n"
+"            s = ((s * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff\n"
+"            totalRisk += s\n"
+"        }\n"
+"        return totalRisk / 1000\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-monte-carlo len=${riskScores.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:3
+msgid ""
+"**Signature**: `parallelFilter<T>(data: T[], predicate: (item: T) => "
+"boolean): T[]` — imported from `perry/thread`."
+msgstr ""
+
+#: src/threading/parallel-filter.md:5
+msgid ""
+"Filters an array in parallel across all available CPU cores. Returns a new "
+"array containing only the elements where the predicate returned a truthy "
+"value. Order is preserved."
+msgstr ""
+
+#: src/threading/parallel-filter.md:9
+msgid ""
+"```typescript\n"
+"function parallelFilterBasic(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n"
+"    const evens = parallelFilter(numbers, (x: number) => x % 2 === 0)\n"
+"    // [2, 4, 6, 8, 10]\n"
+"    console.log(`parallel-filter-basic len=${evens.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:31
+msgid ""
+"Each core independently tests its chunk of elements. Results are merged in "
+"the original element order after all threads complete."
+msgstr ""
+
+#: src/threading/parallel-filter.md:33
+msgid "Why Not Just Use `.filter()`?"
+msgstr ""
+
+#: src/threading/parallel-filter.md:35
+msgid ""
+"Regular `.filter()` runs on a single thread. For large arrays with expensive"
+" predicates, `parallelFilter` distributes the work:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:37
+msgid ""
+"```typescript\n"
+"function parallelFilterVsFilter(): void {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    // Single-threaded — one core does all the work\n"
+"    const a = data.filter((item: number) => item > 3)\n"
+"\n"
+"    // Parallel — all cores share the work\n"
+"    const b = parallelFilter(data, (item: number) => item > 3)\n"
+"\n"
+"    console.log(`parallel-filter-vs-filter ${a.length} ${b.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:51
+msgid ""
+"The tradeoff: `parallelFilter` has overhead from copying values between "
+"threads. Use it when the predicate is expensive enough to justify that cost."
+msgstr ""
+
+#: src/threading/parallel-filter.md:55
+msgid ""
+"Like `parallelMap`, the predicate can capture outer variables. Captures are "
+"deep-copied to each thread:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:57
+msgid ""
+"```typescript\n"
+"function parallelFilterCapture(): void {\n"
+"    const candidates = [\n"
+"        { name: \"Alice\", score: 90, age: 28 },\n"
+"        { name: \"Bob\", score: 80, age: 35 },\n"
+"        { name: \"Carol\", score: 95, age: 25 },\n"
+"    ]\n"
+"    const minScore = 85\n"
+"    const maxAge = 30\n"
+"\n"
+"    // minScore and maxAge are captured and copied to each thread\n"
+"    const qualified = parallelFilter(candidates, (c: { name: string; score: number; age: number }) => {\n"
+"        return c.score >= minScore && c.age <= maxAge\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-capture len=${qualified.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:76
+msgid ""
+"Mutable variables cannot be captured — the compiler rejects this at compile "
+"time."
+msgstr ""
+
+#: src/threading/parallel-filter.md:80
+msgid "Filtering Large Datasets"
+msgstr ""
+
+#: src/threading/parallel-filter.md:82
+msgid ""
+"```typescript\n"
+"function parallelFilterLarge(): void {\n"
+"    // Stand-in for \"millions of records\" — same shape, smaller list.\n"
+"    const transactions = [\n"
+"        { amount: 15000, country: \"US\", user: { homeCountry: \"DE\" }, timestamp: { hour: 4 } },\n"
+"        { amount: 200, country: \"DE\", user: { homeCountry: \"DE\" }, timestamp: { hour: 12 } },\n"
+"        { amount: 50000, country: \"FR\", user: { homeCountry: \"DE\" }, timestamp: { hour: 3 } },\n"
+"    ]\n"
+"\n"
+"    const suspicious = parallelFilter(transactions, (tx: {\n"
+"        amount: number\n"
+"        country: string\n"
+"        user: { homeCountry: string }\n"
+"        timestamp: { hour: number }\n"
+"    }) => {\n"
+"        return tx.amount > 10000\n"
+"            && tx.country !== tx.user.homeCountry\n"
+"            && tx.timestamp.hour < 6\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-large len=${suspicious.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:106
+msgid "Combined with parallelMap"
+msgstr ""
+
+#: src/threading/parallel-filter.md:108
+msgid ""
+"```typescript\n"
+"function parallelFilterCombined(): void {\n"
+"    const users = [\n"
+"        { name: \"Alice\", isActive: true, age: 28, score: 90 },\n"
+"        { name: \"Bob\", isActive: false, age: 35, score: 80 },\n"
+"        { name: \"Carol\", isActive: true, age: 17, score: 95 },\n"
+"        { name: \"Dave\", isActive: true, age: 40, score: 60 },\n"
+"    ]\n"
+"\n"
+"    // Step 1: Filter to relevant items (parallel)\n"
+"    const active = parallelFilter(users, (u: { isActive: boolean; age: number }) => u.isActive && u.age >= 18)\n"
+"\n"
+"    // Step 2: Transform the filtered results (parallel)\n"
+"    const profiles = parallelMap(active, (u: { name: string; score: number }) => ({\n"
+"        name: u.name,\n"
+"        score: u.score * 2,\n"
+"    }))\n"
+"\n"
+"    console.log(`parallel-filter-combined active=${active.length} profiles=${profiles.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:130
+msgid "Predicate with Heavy Computation"
+msgstr ""
+
+#: src/threading/parallel-filter.md:132
+msgid ""
+"```typescript\n"
+"function parallelFilterHeavy(): void {\n"
+"    const certificates = [\n"
+"        { id: 1, fingerprint: \"aa\", revoked: false },\n"
+"        { id: 2, fingerprint: \"bb\", revoked: true },\n"
+"        { id: 3, fingerprint: \"cc\", revoked: false },\n"
+"    ]\n"
+"\n"
+"    // Each predicate call does significant work — perfect for parallelization.\n"
+"    const valid = parallelFilter(certificates, (cert: { id: number; fingerprint: string; revoked: boolean }) => {\n"
+"        // Stand-in for a real chain verification: hash the fingerprint a bit\n"
+"        // then sanity-check the revocation flag.\n"
+"        let h = 0\n"
+"        for (let i = 0; i < cert.fingerprint.length; i++) {\n"
+"            h = (h * 31 + cert.fingerprint.charCodeAt(i)) >>> 0\n"
+"        }\n"
+"        return h !== 0 && !cert.revoked\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-heavy len=${valid.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:157
+msgid "Use `parallelFilter` when:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:158
+msgid "The array has many elements (hundreds or more)"
+msgstr ""
+
+#: src/threading/parallel-filter.md:159
+msgid "The predicate function does meaningful work per element"
+msgstr ""
+
+#: src/threading/parallel-filter.md:160
+msgid "You need to keep the UI responsive during filtering"
+msgstr ""
+
+#: src/threading/parallel-filter.md:162
+msgid ""
+"For trivial predicates on small arrays, regular `.filter()` is faster (no "
+"threading overhead)."
+msgstr ""
+
+#: src/threading/spawn.md:3
+msgid ""
+"**Signature**: `spawn<T>(fn: () => T): Promise<T>` — imported from "
+"`perry/thread`."
+msgstr ""
+
+#: src/threading/spawn.md:5
+msgid ""
+"Runs a closure on a new OS thread and returns a Promise that resolves when "
+"the thread completes. The main thread continues immediately — UI and other "
+"work are not blocked."
+msgstr ""
+
+#: src/threading/spawn.md:9
+msgid ""
+"```typescript\n"
+"async function spawnBasic(): Promise<void> {\n"
+"    const result = await spawn(() => {\n"
+"        // This runs on a separate OS thread.\n"
+"        let sum = 0\n"
+"        for (let i = 0; i < 100_000_000; i++) {\n"
+"            sum += i\n"
+"        }\n"
+"        return sum\n"
+"    })\n"
+"\n"
+"    console.log(result) // 4999999950000000\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:24
+msgid "Non-Blocking"
+msgstr ""
+
+#: src/threading/spawn.md:26
+msgid "`spawn` returns immediately. The main thread doesn't wait:"
+msgstr ""
+
+#: src/threading/spawn.md:28
+msgid ""
+"```typescript\n"
+"async function spawnNonBlocking(): Promise<void> {\n"
+"    console.log(\"1. Starting background work\")\n"
+"\n"
+"    const handle = spawn(() => {\n"
+"        // Runs on a background thread — heavier work elided here.\n"
+"        let n = 0\n"
+"        for (let i = 0; i < 10_000_000; i++) n++\n"
+"        return n\n"
+"    })\n"
+"\n"
+"    console.log(\"2. Main thread continues immediately\")\n"
+"\n"
+"    const result = await handle\n"
+"    console.log(`3. Got result: ${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:53
+msgid "Multiple Concurrent Tasks"
+msgstr ""
+
+#: src/threading/spawn.md:55
+msgid ""
+"Spawn multiple tasks and they run truly concurrently — one OS thread per "
+"`spawn` call:"
+msgstr ""
+
+#: src/threading/spawn.md:57
+msgid ""
+"```typescript\n"
+"async function spawnMultiple(): Promise<void> {\n"
+"    const t1 = spawn(() => analyseChunk(0, 1_000_000))\n"
+"    const t2 = spawn(() => analyseChunk(1_000_000, 2_000_000))\n"
+"    const t3 = spawn(() => analyseChunk(2_000_000, 3_000_000))\n"
+"\n"
+"    // All three run simultaneously on separate OS threads.\n"
+"    const results = await Promise.all([t1, t2, t3])\n"
+"\n"
+"    console.log(`Region A: ${results[0]}`)\n"
+"    console.log(`Region B: ${results[1]}`)\n"
+"    console.log(`Region C: ${results[2]}`)\n"
+"}\n"
+"\n"
+"function analyseChunk(start: number, end: number): number {\n"
+"    let acc = 0\n"
+"    for (let i = start; i < end; i++) acc += i & 0xff\n"
+"    return acc\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:78
+msgid ""
+"Unlike Node.js `worker_threads`, each `spawn` is a lightweight OS thread "
+"(~8MB stack), not a full V8 isolate (~2MB heap + startup cost)."
+msgstr ""
+
+#: src/threading/spawn.md:82
+msgid ""
+"Like `parallelMap`, `spawn` closures can capture outer variables. They are "
+"deep-copied to the background thread:"
+msgstr ""
+
+#: src/threading/spawn.md:84
+msgid ""
+"```typescript\n"
+"async function spawnCapture(): Promise<void> {\n"
+"    const config = { iterations: 1000, seed: 42 }\n"
+"    const dataset = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    const result = await spawn(() => {\n"
+"        // config and dataset are deep-copied to this thread.\n"
+"        let acc = config.seed\n"
+"        for (let i = 0; i < config.iterations; i++) {\n"
+"            acc = (acc * 1103515245 + 12345) & 0x7fffffff\n"
+"        }\n"
+"        for (const v of dataset) acc ^= v\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-capture: ${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:103
+msgid ""
+"Mutable variables cannot be captured — this is enforced at compile time."
+msgstr ""
+
+#: src/threading/spawn.md:105
+msgid "Returning Complex Values"
+msgstr ""
+
+#: src/threading/spawn.md:107
+msgid ""
+"`spawn` can return any value type. Complex values (objects, arrays, strings)"
+" are serialized back to the main thread automatically:"
+msgstr ""
+
+#: src/threading/spawn.md:133
+msgid "UI Integration"
+msgstr ""
+
+#: src/threading/spawn.md:135
+msgid ""
+"`spawn` is ideal for keeping native UIs responsive during heavy computation:"
+msgstr ""
+
+#: src/threading/spawn.md:137
+msgid ""
+"```typescript\n"
+"const analyzeButton = Button(\"Analyze\", async () => {\n"
+"    status.set(\"Processing...\")\n"
+"\n"
+"    // Background thread — UI stays responsive\n"
+"    const data = await spawn(() => {\n"
+"        let count = 0\n"
+"        for (let i = 0; i < 1_000_000; i++) {\n"
+"            if ((i & 0xff) === 0) count++\n"
+"        }\n"
+"        return { count }\n"
+"    })\n"
+"\n"
+"    result.set(`Found ${data.count} patterns`)\n"
+"    status.set(\"Done\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:155
+msgid ""
+"Without `spawn`, the analysis would freeze the UI. With `spawn`, the user "
+"can still scroll, tap other buttons, or navigate while the computation runs."
+msgstr ""
+
+#: src/threading/spawn.md:157
+msgid "Compared to Node.js worker_threads"
+msgstr ""
+
+#: src/threading/spawn.md:160
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
+msgstr ""
+
+#: src/threading/spawn.md:162 src/threading/spawn.md:167
+msgid "\"worker_threads\""
+msgstr ""
+
+#: src/threading/spawn.md:165
+msgid "// main.js\n"
+msgstr ""
+
+#: src/threading/spawn.md:168
+msgid "\"./worker.js\""
+msgstr ""
+
+#: src/threading/spawn.md:171
+msgid "\"message\""
+msgstr ""
+
+#: src/threading/spawn.md:174 src/testing/geisterhand.md:319
+msgid "\"error\""
+msgstr ""
+
+#: src/threading/spawn.md:174
+msgid "/* handle */"
+msgstr ""
+
+#: src/threading/spawn.md:176
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
+msgstr ""
+
+#: src/threading/spawn.md:181
+msgid ""
+"No separate files. No message ports. No event handlers. No structured clone."
+" One line."
+msgstr ""
+
+#: src/threading/spawn.md:185
+msgid "Background File Processing"
+msgstr ""
+
+#: src/threading/spawn.md:187
+msgid ""
+"```typescript\n"
+"async function spawnBgFile(): Promise<void> {\n"
+"    // Read and process a \"large\" file without blocking. We inline a tiny CSV\n"
+"    // so the snippet runs hermetically — the docs' real version would call\n"
+"    // readFileSync from \"fs\".\n"
+"    const content = \"id,value\\n1,10\\n2,20\\n3,30\\n\"\n"
+"    const analysis = await spawn(() => {\n"
+"        const lines = content.split(\"\\n\").filter((l: string) => l.length > 0).slice(1)\n"
+"        let total = 0\n"
+"        for (const line of lines) {\n"
+"            const parts = line.split(\",\")\n"
+"            total += parseInt(parts[1], 10)\n"
+"        }\n"
+"        return { rows: lines.length, total }\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-bg-file rows=${analysis.rows} total=${analysis.total}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:207
+msgid "Parallel API Calls with Processing"
+msgstr ""
+
+#: src/threading/spawn.md:209
+msgid ""
+"```typescript\n"
+"async function spawnApiThenProcess(): Promise<void> {\n"
+"    // The docs example fetches a remote API; for a hermetic test we\n"
+"    // just hand-roll the same pipeline shape with synthetic data.\n"
+"    const rawData = { items: [1, 2, 3, 4, 5] }\n"
+"\n"
+"    // CPU-intensive processing happens off the main thread\n"
+"    const processed = await spawn(() => {\n"
+"        let total = 0\n"
+"        for (const v of rawData.items) total += v * v\n"
+"        return { total, count: rawData.items.length }\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-api-then-process total=${processed.total} count=${processed.count}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:226
+msgid "Deferred Computation"
+msgstr ""
+
+#: src/threading/spawn.md:228
+msgid ""
+"```typescript\n"
+"async function spawnDeferred(): Promise<void> {\n"
+"    const params = { size: 8 }\n"
+"\n"
+"    // Start computation early, use result later\n"
+"    const precomputed = spawn(() => {\n"
+"        const table: number[] = []\n"
+"        for (let i = 0; i < params.size; i++) table.push(i * i)\n"
+"        return table\n"
+"    })\n"
+"\n"
+"    // ... do other setup work ...\n"
+"\n"
+"    // Result is ready (or we wait for it)\n"
+"    const table = await precomputed\n"
+"    console.log(`spawn-deferred len=${table.length} last=${table[table.length - 1]}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:1
+msgid "UI Overview"
+msgstr ""
+
+#: src/ui/overview.md:3
+msgid ""
+"Perry's `perry/ui` module lets you build native desktop and mobile apps with"
+" declarative TypeScript. Your UI code compiles directly to platform-native "
+"widgets — AppKit on macOS, UIKit on iOS, GTK4 on Linux, Win32 on Windows, "
+"and DOM elements on the web."
+msgstr ""
+
+#: src/ui/overview.md:5 src/i18n/overview.md:27 src/testing/geisterhand.md:9
+msgid "Quick Start"
+msgstr ""
+
+#: src/ui/overview.md:7
+msgid ""
+"```typescript\n"
+"// demonstrates: the smallest complete Perry UI app\n"
+"// docs: docs/src/ui/overview.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My App\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello from Perry!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:29
+msgid "Mental Model"
+msgstr ""
+
+#: src/ui/overview.md:31
+msgid ""
+"Perry's UI follows the same model as SwiftUI and Flutter: you compose native"
+" widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`),"
+" control alignment and distribution, and style widgets via free functions "
+"that take the widget handle as their first argument (`textSetColor(label, r,"
+" g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
+"web development, the key shift is:"
+msgstr ""
+
+#: src/ui/overview.md:33
+msgid ""
+"**Layout** is controlled by stack alignment, distribution, and spacers — not"
+" CSS properties. See [Layout](layout.md)."
+msgstr ""
+
+#: src/ui/overview.md:34
+msgid ""
+"**Styling** is applied directly to widgets — not through stylesheets. See "
+"[Styling](styling.md)."
+msgstr ""
+
+#: src/ui/overview.md:35
+msgid ""
+"**Absolute positioning** uses overlays (`widgetAddOverlay` + "
+"`widgetSetOverlayFrame`) — not `position: absolute/relative`."
+msgstr ""
+
+#: src/ui/overview.md:36
+msgid ""
+"**Design tokens** come from the `perry-styling` package. See "
+"[Theming](theming.md)."
+msgstr ""
+
+#: src/ui/overview.md:38 src/platforms/ios.md:63 src/platforms/tvos.md:104
+#: src/platforms/watchos.md:80
+msgid "App Lifecycle"
+msgstr ""
+
+#: src/ui/overview.md:40
+msgid "Every Perry UI app starts with `App()`:"
+msgstr ""
+
+#: src/ui/overview.md:42
+msgid ""
+"```typescript\n"
+"function runAppShell(): void {\n"
+"    App({\n"
+"        title: \"Window Title\",\n"
+"        width: 800,\n"
+"        height: 600,\n"
+"        body: VStack(16, [\n"
+"            Text(\"Content here\"),\n"
+"        ]),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:55
+msgid "`App({})` accepts a config object with the following properties:"
+msgstr ""
+
+#: src/ui/overview.md:57 src/widgets/creating-widgets.md:45
+msgid "Property"
+msgstr ""
+
+#: src/ui/overview.md:59
+msgid "`title`"
+msgstr ""
+
+#: src/ui/overview.md:59 src/ui/overview.md:63 src/ui/overview.md:65
+#: src/ui/overview.md:67 src/ui/overview.md:68 src/ui/styling.md:58
+#: src/cli/perry-toml.md:116 src/cli/perry-toml.md:117
+#: src/cli/perry-toml.md:119 src/cli/perry-toml.md:120
+#: src/cli/perry-toml.md:121 src/cli/perry-toml.md:127
+#: src/cli/perry-toml.md:155 src/cli/perry-toml.md:167
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:169
+#: src/cli/perry-toml.md:177 src/cli/perry-toml.md:183
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:185
+#: src/cli/perry-toml.md:186 src/cli/perry-toml.md:187
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:194
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:196
+#: src/cli/perry-toml.md:243 src/cli/perry-toml.md:244
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:249
+#: src/cli/perry-toml.md:256 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:263 src/cli/perry-toml.md:264
+#: src/cli/perry-toml.md:270 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:272 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:301 src/cli/perry-toml.md:302
+#: src/cli/perry-toml.md:303 src/cli/perry-toml.md:304
+#: src/cli/perry-toml.md:312 src/cli/perry-toml.md:313
+#: src/cli/perry-toml.md:314 src/cli/perry-toml.md:315
+#: src/cli/perry-toml.md:316 src/cli/perry-toml.md:317
+#: src/cli/perry-toml.md:318 src/cli/perry-toml.md:319
+#: src/cli/perry-toml.md:329 src/cli/perry-toml.md:330
+#: src/cli/perry-toml.md:331 src/cli/perry-toml.md:333
+#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:335
+#: src/cli/perry-toml.md:336 src/cli/perry-toml.md:337
+#: src/cli/perry-toml.md:347 src/cli/perry-toml.md:348
+#: src/cli/perry-toml.md:349 src/cli/perry-toml.md:360
+#: src/cli/perry-toml.md:369 src/cli/perry-toml.md:379
+#: src/cli/perry-toml.md:389 src/cli/perry-toml.md:390
+#: src/cli/perry-toml.md:416
+msgid "string"
+msgstr ""
+
+#: src/ui/overview.md:59
+msgid "Window title"
+msgstr ""
+
+#: src/ui/overview.md:60
+msgid "`width`"
+msgstr ""
+
+#: src/ui/overview.md:60 src/ui/overview.md:61 src/ui/styling.md:50
+#: src/ui/styling.md:51 src/system/overview.md:28
+msgid "number"
+msgstr ""
+
+#: src/ui/overview.md:60
+msgid "Initial window width"
+msgstr ""
+
+#: src/ui/overview.md:61
+msgid "`height`"
+msgstr ""
+
+#: src/ui/overview.md:61
+msgid "Initial window height"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "`body`"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "widget"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "Root widget"
+msgstr ""
+
+#: src/ui/overview.md:63
+msgid "`icon`"
+msgstr ""
+
+#: src/ui/overview.md:63
+msgid "App icon file path (optional)"
+msgstr ""
+
+#: src/ui/overview.md:64
+msgid "`frameless`"
+msgstr ""
+
+#: src/ui/overview.md:64 src/ui/overview.md:66 src/ui/styling.md:59
+#: src/ui/styling.md:60 src/system/media.md:49 src/cli/perry-toml.md:361
+msgid "boolean"
+msgstr ""
+
+#: src/ui/overview.md:64
+msgid "Remove title bar (optional)"
+msgstr ""
+
+#: src/ui/overview.md:65
+msgid "`level`"
+msgstr ""
+
+#: src/ui/overview.md:65
+msgid "Window z-order: `\"floating\"`, `\"statusBar\"`, `\"modal\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:66
+msgid "`transparent`"
+msgstr ""
+
+#: src/ui/overview.md:66
+msgid "Transparent background (optional)"
+msgstr ""
+
+#: src/ui/overview.md:67
+msgid "`vibrancy`"
+msgstr ""
+
+#: src/ui/overview.md:67
+msgid "Native blur material, e.g. `\"sidebar\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:68
+msgid "`activationPolicy`"
+msgstr ""
+
+#: src/ui/overview.md:68
+msgid "`\"regular\"`, `\"accessory\"` (no dock icon), `\"background\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:70
+msgid ""
+"See [Multi-Window](multi-window.md) for full documentation on window "
+"properties."
+msgstr ""
+
+#: src/ui/overview.md:72
+msgid "Lifecycle Hooks"
+msgstr ""
+
+#: src/ui/overview.md:74
+msgid ""
+"```typescript\n"
+"onActivate(() => {\n"
+"    console.log(\"App became active\")\n"
+"})\n"
+"\n"
+"onTerminate(() => {\n"
+"    console.log(\"App is closing\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:84
+msgid "Widget Tree"
+msgstr ""
+
+#: src/ui/overview.md:86
+msgid "Perry UIs are built as a tree of widgets:"
+msgstr ""
+
+#: src/ui/overview.md:88
+msgid ""
+"```typescript\n"
+"function runWidgetTree(): void {\n"
+"    App({\n"
+"        title: \"Layout Demo\",\n"
+"        width: 400,\n"
+"        height: 300,\n"
+"        body: VStack(16, [\n"
+"            Text(\"Header\"),\n"
+"            HStack(8, [\n"
+"                Button(\"Left\", () => console.log(\"left\")),\n"
+"                Button(\"Right\", () => console.log(\"right\")),\n"
+"            ]),\n"
+"            Text(\"Footer\"),\n"
+"        ]),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:106
+msgid ""
+"Widgets are created by calling their constructor functions. Layout "
+"containers (`VStack`, `HStack`, `ZStack`) accept a spacing value (in points)"
+" followed by an array of child widgets."
+msgstr ""
+
+#: src/ui/overview.md:108
+msgid "Handle-Based Architecture"
+msgstr ""
+
+#: src/ui/overview.md:110
+msgid ""
+"Under the hood, each widget is a handle — a small integer that references a "
+"native platform object. When you call `Text(\"hello\")`, Perry creates a "
+"native `NSTextField` (macOS), `UILabel` (iOS), `GtkLabel` (Linux), or "
+"`<span>` (web) and returns a handle you can use to modify it."
+msgstr ""
+
+#: src/ui/overview.md:112
+msgid ""
+"```typescript\n"
+"const label = Text(\"Hello\")\n"
+"textSetFontSize(label, 18)              // Modifies the native widget\n"
+"textSetColor(label, 1.0, 0.0, 0.0, 1.0) // RGBA floats in [0,1]\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:118
+msgid "Imports"
+msgstr ""
+
+#: src/ui/overview.md:120
+msgid "All UI functions are imported from `perry/ui`:"
+msgstr ""
+
+#: src/ui/overview.md:122
+msgid ""
+"```typescript\n"
+"import {\n"
+"    // App lifecycle\n"
+"    App, onActivate, onTerminate,\n"
+"\n"
+"    // Widgets\n"
+"    Text, Button, TextField, SecureField, TextArea,\n"
+"    Toggle, Slider, ProgressView, Picker, ImageFile, ImageSymbol,\n"
+"\n"
+"    // Layout\n"
+"    VStack, HStack, ZStack, ScrollView, Spacer, Divider,\n"
+"    NavStack, TabBar, LazyVStack, Section,\n"
+"    VStackWithInsets, HStackWithInsets, SplitView, splitViewAddChild,\n"
+"\n"
+"    // Layout control\n"
+"    stackSetAlignment, stackSetDistribution, stackSetDetachesHidden,\n"
+"    widgetMatchParentWidth, widgetMatchParentHeight, widgetSetHugging,\n"
+"    widgetAddOverlay, widgetSetOverlayFrame,\n"
+"\n"
+"    // State\n"
+"    State, ForEach,\n"
+"\n"
+"    // Dialogs\n"
+"    openFileDialog, openFolderDialog, saveFileDialog,\n"
+"    alert, alertWithButtons,\n"
+"    sheetCreate, sheetPresent, sheetDismiss,\n"
+"\n"
+"    // Menus\n"
+"    menuCreate, menuAddItem, menuAddSeparator, menuAddSubmenu,\n"
+"    menuBarCreate, menuBarAddMenu, menuBarAttach,\n"
+"    widgetSetContextMenu,\n"
+"\n"
+"    // Window\n"
+"    Window,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:159
+msgid ""
+"[`Canvas`](canvas.md), [`CameraView`](camera.md), and the virtualized "
+"[`Table`](table.md) widget are wired through the LLVM codegen (closed via "
+"[\\#190](https://github.com/PerryTS/perry/issues/190), "
+"[\\#191](https://github.com/PerryTS/perry/issues/191), and "
+"[\\#192](https://github.com/PerryTS/perry/issues/192)). See each widget's "
+"page for the platform-support matrix."
+msgstr ""
+
+#: src/ui/overview.md:166
+msgid "Platform Differences"
+msgstr ""
+
+#: src/ui/overview.md:168
+msgid ""
+"The same code runs on all platforms, but the look and feel matches each "
+"platform's native style:"
+msgstr ""
+
+#: src/ui/overview.md:170 src/platforms/overview.md:67
+#: src/i18n/formatting.md:138 src/widgets/platforms.md:20
+msgid "Feature"
+msgstr ""
+
+#: src/ui/overview.md:172
+msgid "Buttons"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/macos.md:27
+msgid "NSButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/tvos.md:53
+msgid "UIButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/linux.md:37
+msgid "GtkButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/windows.md:45
+msgid "HWND Button"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/wasm.md:58
+msgid "`<button>`"
+msgstr ""
+
+#: src/ui/overview.md:173 src/ui/widgets.md:13 src/ui/canvas.md:60
+#: src/platforms/macos.md:26 src/platforms/ios.md:52 src/platforms/tvos.md:52
+#: src/platforms/watchos.md:52 src/platforms/android.md:26
+#: src/platforms/windows.md:44 src/platforms/linux.md:36
+#: src/widgets/components.md:25 src/widgets/platforms.md:22
+msgid "Text"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/macos.md:28
+msgid "NSTextField"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/ios.md:52 src/platforms/tvos.md:52
+msgid "UILabel"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/linux.md:36
+msgid "GtkLabel"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/windows.md:44
+msgid "Static HWND"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/wasm.md:57
+msgid "`<span>`"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/macos.md:34
+msgid "NSStackView"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/ios.md:60 src/platforms/tvos.md:59
+msgid "UIStackView"
+msgstr ""
+
+#: src/ui/overview.md:174
+msgid "GtkBox"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/windows.md:53
+msgid "Manual layout"
+msgstr ""
+
+#: src/ui/overview.md:174
+msgid "Flexbox"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:111
+msgid "NSMenu"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:113 src/ui/menus.md:114
+#: src/ui/dialogs.md:111 src/ui/dialogs.md:112 src/platforms/overview.md:69
+#: src/platforms/overview.md:71 src/platforms/overview.md:72
+#: src/platforms/overview.md:75 src/cli/perry-toml.md:119
+#: src/cli/perry-toml.md:120 src/cli/perry-toml.md:127
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:169
+#: src/cli/perry-toml.md:170 src/cli/perry-toml.md:177
+#: src/cli/perry-toml.md:185 src/cli/perry-toml.md:186
+#: src/cli/perry-toml.md:187 src/cli/perry-toml.md:245
+#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:256
+#: src/cli/perry-toml.md:264 src/cli/perry-toml.md:303
+#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:312
+#: src/cli/perry-toml.md:315 src/cli/perry-toml.md:330
+#: src/cli/perry-toml.md:331 src/cli/perry-toml.md:332
+#: src/cli/perry-toml.md:333 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:335 src/cli/perry-toml.md:336
+#: src/cli/perry-toml.md:347 src/cli/perry-toml.md:348
+#: src/cli/perry-toml.md:359 src/cli/perry-toml.md:391
+msgid "—"
+msgstr ""
+
+#: src/ui/overview.md:175
+msgid "GMenu"
+msgstr ""
+
+#: src/ui/overview.md:175
+msgid "HMENU"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:115
+msgid "DOM"
+msgstr ""
+
+#: src/ui/overview.md:177
+msgid ""
+"Platform-specific behavior is noted on each widget's documentation page."
+msgstr ""
+
+#: src/ui/overview.md:181 src/ui/layout.md:370 src/ui/styling.md:379
+#: src/ui/state.md:228 src/ui/events.md:170 src/ui/canvas.md:82
+#: src/ui/table.md:109 src/ui/animation.md:74 src/ui/camera.md:145
+msgid "[Widgets](widgets.md) — All available widgets"
+msgstr ""
+
+#: src/ui/overview.md:182
+msgid "[Layout](layout.md) — Arranging widgets"
+msgstr ""
+
+#: src/ui/overview.md:183
+msgid "[State Management](state.md) — Reactive state and bindings"
+msgstr ""
+
+#: src/ui/overview.md:184
+msgid "[Styling](styling.md) — Colors, fonts, sizing"
+msgstr ""
+
+#: src/ui/overview.md:185
+msgid "[Events](events.md) — Click, hover, keyboard"
+msgstr ""
+
+#: src/ui/widgets.md:3
+msgid ""
+"Perry provides native widgets that map to each platform's native controls. "
+"Every example on this page is a real runnable program verified by CI "
+"(`scripts/run_doc_tests.sh`) — the snippet you read is the same source "
+"that's compiled and launched."
+msgstr ""
+
+#: src/ui/widgets.md:8
+msgid ""
+"The widget API is **free functions**, not methods. A widget is a 64-bit "
+"opaque handle; you pass it into helpers like `textSetFontSize(widget, 18)` "
+"rather than calling `widget.setFontSize(18)`. That's the only shape perry/ui"
+" supports — no fluent chain, no prototype methods."
+msgstr ""
+
+#: src/ui/widgets.md:15
+msgid "Displays read-only text."
+msgstr ""
+
+#: src/ui/widgets.md:17
+msgid ""
+"```typescript\n"
+"// demonstrates: Text widget styling with the real free-function API\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, textSetFontSize, textSetFontWeight, textSetColor, textSetFontFamily } from \"perry/ui\"\n"
+"\n"
+"const label = Text(\"Hello, World!\")\n"
+"textSetFontSize(label, 18)\n"
+"textSetColor(label, 0.2, 0.2, 0.2, 1.0) // RGBA in [0, 1]\n"
+"textSetFontFamily(label, \"Menlo\")\n"
+"\n"
+"const bold = Text(\"Bold\")\n"
+"textSetFontWeight(bold, 20, 1.0)\n"
+"\n"
+"App({\n"
+"    title: \"Text\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(8, [label, bold]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:41
+msgid ""
+"Color is RGBA with each channel in `[0.0, 1.0]` — divide a hex byte by 255 "
+"(`0x33 / 255 ≈ 0.2`)."
+msgstr ""
+
+#: src/ui/widgets.md:44
+msgid ""
+"**Helpers:** `textSetString`, `textSetFontSize`, `textSetFontWeight`, "
+"`textSetFontFamily`, `textSetColor`, `textSetWraps`, `textSetSelectable`."
+msgstr ""
+
+#: src/ui/widgets.md:47
+msgid ""
+"Text widgets inside template literals with `state.value` update "
+"automatically — perry detects the state read and rewires the widget to re-"
+"render on change. See [State Management](state.md)."
+msgstr ""
+
+#: src/ui/widgets.md:51 src/platforms/macos.md:27 src/platforms/ios.md:53
+#: src/platforms/tvos.md:53 src/platforms/watchos.md:53
+#: src/platforms/android.md:27 src/platforms/windows.md:45
+#: src/platforms/linux.md:37 src/testing/geisterhand.md:86
+#: src/testing/geisterhand.md:289
+msgid "Button"
+msgstr ""
+
+#: src/ui/widgets.md:53
+msgid "A clickable button."
+msgstr ""
+
+#: src/ui/widgets.md:55
+msgid ""
+"```typescript\n"
+"// demonstrates: Button styling with buttonSet*/widgetSet* helpers\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack,\n"
+"    Button,\n"
+"    buttonSetBordered,\n"
+"    widgetSetEnabled,\n"
+"    setCornerRadius,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// Note: buttonSetContentTintColor is macOS/iOS-only (maps to NSButton /\n"
+"// UIButton tint). GTK4/Win32 don't have an equivalent — set\n"
+"// widgetSetBackgroundColor(btn, r, g, b, a) there instead.\n"
+"const primary = Button(\"Click Me\", () => console.log(\"Clicked!\"))\n"
+"buttonSetBordered(primary, 1)\n"
+"setCornerRadius(primary, 8)\n"
+"\n"
+"const disabled = Button(\"Can't click me\", () => {})\n"
+"widgetSetEnabled(disabled, 0)\n"
+"\n"
+"App({\n"
+"    title: \"Button\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [primary, disabled]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:88
+msgid ""
+"**Helpers:** `buttonSetTitle`, `buttonSetBordered`, `buttonSetImage` (SF "
+"Symbol name on macOS/iOS), `buttonSetImagePosition`, "
+"`buttonSetContentTintColor`, `buttonSetTextColor`, `widgetSetEnabled`."
+msgstr ""
+
+#: src/ui/widgets.md:92 src/platforms/macos.md:28 src/platforms/ios.md:54
+#: src/platforms/tvos.md:54 src/platforms/android.md:28
+#: src/platforms/windows.md:46 src/platforms/linux.md:38
+#: src/testing/geisterhand.md:87 src/testing/geisterhand.md:290
+msgid "TextField"
+msgstr ""
+
+#: src/ui/widgets.md:94
+msgid "An editable single-line text input."
+msgstr ""
+
+#: src/ui/widgets.md:96
+msgid ""
+"```typescript\n"
+"// demonstrates: TextField + two-way binding via stateBindTextfield\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, TextField, State, stateBindTextfield } from \"perry/ui\"\n"
+"\n"
+"const text = State(\"\")\n"
+"const field = TextField(\"Placeholder...\", (value: string) => text.set(value))\n"
+"stateBindTextfield(text, field) // programmatic text.set() also updates the field\n"
+"\n"
+"App({\n"
+"    title: \"TextField\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        field,\n"
+"        Text(`You typed: ${text.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:119
+msgid ""
+"`TextField(placeholder, onChange)` fires `onChange` as the user types. Pair "
+"with `stateBindTextfield(state, field)` for two-way binding so programmatic "
+"`state.set(…)` also updates the visible text."
+msgstr ""
+
+#: src/ui/widgets.md:123
+msgid ""
+"**Helpers:** `textfieldSetString`, `textfieldSetFontSize`, "
+"`textfieldSetTextColor`, `textfieldSetBackgroundColor`, "
+"`textfieldSetBorderless`, `textfieldSetOnSubmit`, `textfieldSetOnFocus`, "
+"`textfieldSetNextKeyView`."
+msgstr ""
+
+#: src/ui/widgets.md:128 src/platforms/macos.md:29 src/platforms/ios.md:55
+#: src/platforms/android.md:29 src/platforms/windows.md:47
+#: src/platforms/linux.md:39
+msgid "SecureField"
+msgstr ""
+
+#: src/ui/widgets.md:130
+msgid ""
+"A password input — identical signature to `TextField`, but text is masked."
+msgstr ""
+
+#: src/ui/widgets.md:132
+msgid ""
+"```typescript\n"
+"// demonstrates: SecureField for password input\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, SecureField, State } from \"perry/ui\"\n"
+"\n"
+"const password = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"SecureField\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        SecureField(\"Enter password...\", (value: string) => password.set(value)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:152 src/platforms/macos.md:30 src/platforms/ios.md:56
+#: src/platforms/tvos.md:55 src/platforms/watchos.md:59
+#: src/platforms/android.md:30 src/platforms/windows.md:48
+#: src/platforms/linux.md:40 src/testing/geisterhand.md:89
+#: src/testing/geisterhand.md:292
+msgid "Toggle"
+msgstr ""
+
+#: src/ui/widgets.md:154
+msgid "A boolean on/off switch."
+msgstr ""
+
+#: src/ui/widgets.md:156
+msgid ""
+"```typescript\n"
+"// demonstrates: Toggle widget bound to State\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Toggle, State } from \"perry/ui\"\n"
+"\n"
+"const enabled = State(false)\n"
+"\n"
+"App({\n"
+"    title: \"Toggle\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Toggle(\"Enable notifications\", (on: boolean) => enabled.set(on)),\n"
+"        Text(`Enabled: ${enabled.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:177 src/platforms/macos.md:31 src/platforms/ios.md:57
+#: src/platforms/tvos.md:56 src/platforms/watchos.md:60
+#: src/platforms/android.md:31 src/platforms/windows.md:49
+#: src/platforms/linux.md:41 src/testing/geisterhand.md:88
+#: src/testing/geisterhand.md:291
+msgid "Slider"
+msgstr ""
+
+#: src/ui/widgets.md:179
+msgid "A numeric slider."
+msgstr ""
+
+#: src/ui/widgets.md:181
+msgid ""
+"```typescript\n"
+"// demonstrates: Slider with a numeric range\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Slider, State } from \"perry/ui\"\n"
+"\n"
+"const value = State(50)\n"
+"\n"
+"App({\n"
+"    title: \"Slider\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Slider(0, 100, (v: number) => value.set(v)),\n"
+"        Text(`Value: ${value.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:202
+msgid ""
+"`Slider(min, max, onChange)` — `onChange` fires on every drag. Use "
+"`stateBindSlider(state, slider)` for two-way binding."
+msgstr ""
+
+#: src/ui/widgets.md:205 src/platforms/macos.md:32 src/platforms/ios.md:58
+#: src/platforms/tvos.md:57 src/platforms/watchos.md:64
+#: src/platforms/android.md:32 src/platforms/windows.md:50
+#: src/platforms/linux.md:42 src/testing/geisterhand.md:90
+#: src/testing/geisterhand.md:293
+msgid "Picker"
+msgstr ""
+
+#: src/ui/widgets.md:207
+msgid "A dropdown selection control. Items are added with `pickerAddItem`."
+msgstr ""
+
+#: src/ui/widgets.md:209
+msgid ""
+"```typescript\n"
+"// demonstrates: Picker with items added via pickerAddItem\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Picker, State, pickerAddItem } from \"perry/ui\"\n"
+"\n"
+"const selected = State(0)\n"
+"const picker = Picker((index: number) => selected.set(index))\n"
+"pickerAddItem(picker, \"Option A\")\n"
+"pickerAddItem(picker, \"Option B\")\n"
+"pickerAddItem(picker, \"Option C\")\n"
+"\n"
+"App({\n"
+"    title: \"Picker\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        picker,\n"
+"        Text(`Selected index: ${selected.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:234
+msgid "ImageFile / ImageSymbol"
+msgstr ""
+
+#: src/ui/widgets.md:236
+msgid "Two distinct constructors:"
+msgstr ""
+
+#: src/ui/widgets.md:238
+msgid "`ImageFile(path)` — image from a file path"
+msgstr ""
+
+#: src/ui/widgets.md:239
+msgid "`ImageSymbol(name)` — SF Symbol glyph name (macOS/iOS only)"
+msgstr ""
+
+#: src/ui/widgets.md:241
+msgid ""
+"```typescript\n"
+"// demonstrates: ImageSymbol for SF Symbol glyphs (macOS/iOS)\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos\n"
+"// targets: ios-simulator, visionos-simulator, tvos-simulator\n"
+"\n"
+"import { App, HStack, ImageSymbol, widgetSetWidth, widgetSetHeight } from \"perry/ui\"\n"
+"\n"
+"const star = ImageSymbol(\"star.fill\")\n"
+"widgetSetWidth(star, 32)\n"
+"widgetSetHeight(star, 32)\n"
+"\n"
+"const heart = ImageSymbol(\"heart.fill\")\n"
+"const bell = ImageSymbol(\"bell.fill\")\n"
+"\n"
+"App({\n"
+"    title: \"ImageSymbol\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: HStack(12, [star, heart, bell]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:264
+msgid ""
+"Use `widgetSetWidth(img, N)` / `widgetSetHeight(img, N)` to size the image."
+msgstr ""
+
+#: src/ui/widgets.md:266 src/platforms/watchos.md:63
+#: src/platforms/windows.md:51 src/platforms/linux.md:43
+msgid "ProgressView"
+msgstr ""
+
+#: src/ui/widgets.md:268
+msgid "An indeterminate or determinate progress indicator."
+msgstr ""
+
+#: src/ui/widgets.md:270
+msgid ""
+"```typescript\n"
+"// demonstrates: ProgressView as an indeterminate spinner\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, ProgressView } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"ProgressView\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Text(\"Loading...\"),\n"
+"        ProgressView(),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:289
+msgid "TextArea"
+msgstr ""
+
+#: src/ui/widgets.md:291
+msgid ""
+"A multi-line text input. Same `(placeholder, onChange)` signature as "
+"`TextField` but renders as a multi-line box."
+msgstr ""
+
+#: src/ui/widgets.md:294
+msgid ""
+"```typescript\n"
+"// demonstrates: TextArea for multi-line input\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, TextArea, State } from \"perry/ui\"\n"
+"\n"
+"const content = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"TextArea\",\n"
+"    width: 500,\n"
+"    height: 400,\n"
+"    body: VStack(12, [\n"
+"        TextArea(\"Enter multi-line text...\", (value: string) => content.set(value)),\n"
+"        Text(`Length: ${content.value.length}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:315
+msgid "**Helpers:** `textareaSetString`."
+msgstr ""
+
+#: src/ui/widgets.md:317 src/cli/perry-toml.md:108
+msgid "Sections"
+msgstr ""
+
+#: src/ui/widgets.md:319
+msgid ""
+"Group controls into labelled sections. Perry has no `Form()` widget — use a "
+"`VStack` of `Section(title)`s and attach children via `widgetAddChild`."
+msgstr ""
+
+#: src/ui/widgets.md:322
+msgid ""
+"```typescript\n"
+"// demonstrates: Section grouping with widgetAddChild (no Form widget in Perry)\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack,\n"
+"    Section,\n"
+"    TextField,\n"
+"    Toggle,\n"
+"    State,\n"
+"    widgetAddChild,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const name = State(\"\")\n"
+"const notifications = State(true)\n"
+"\n"
+"const personal = Section(\"Personal Info\")\n"
+"widgetAddChild(personal, TextField(\"Name\", (value: string) => name.set(value)))\n"
+"\n"
+"const settings = Section(\"Settings\")\n"
+"widgetAddChild(\n"
+"    settings,\n"
+"    Toggle(\"Notifications\", (on: boolean) => notifications.set(on)),\n"
+")\n"
+"\n"
+"App({\n"
+"    title: \"Sections\",\n"
+"    width: 500,\n"
+"    height: 400,\n"
+"    body: VStack(16, [personal, settings]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:358
+msgid "Platform-specific widgets"
+msgstr ""
+
+#: src/ui/widgets.md:360
+msgid ""
+"These exist only on specific platforms and aren't verified by the cross-"
+"platform doc-tests:"
+msgstr ""
+
+#: src/ui/widgets.md:363
+msgid ""
+"**`Table(rows, cols, renderer)`** — macOS only. A data table with rows, "
+"columns, and a cell renderer."
+msgstr ""
+
+#: src/ui/widgets.md:365
+msgid "**`QRCode(data, size)`** — macOS only. Renders a QR code."
+msgstr ""
+
+#: src/ui/widgets.md:366
+msgid ""
+"**`Canvas(width, height, draw)`** — all desktop platforms. A drawing "
+"surface; see [Canvas](canvas.md)."
+msgstr ""
+
+#: src/ui/widgets.md:368
+msgid ""
+"**`CameraView()`** — iOS only (other platforms planned). See "
+"[Camera](camera.md)."
+msgstr ""
+
+#: src/ui/widgets.md:371
+msgid "These are linked from their own pages with platform-specific examples."
+msgstr ""
+
+#: src/ui/widgets.md:373
+msgid "Common widget helpers"
+msgstr ""
+
+#: src/ui/widgets.md:375
+msgid "Every widget handle accepts these:"
+msgstr ""
+
+#: src/ui/widgets.md:377
+msgid "Helper"
+msgstr ""
+
+#: src/ui/widgets.md:379
+msgid "`widgetSetWidth(w, n)` / `widgetSetHeight(w, n)`"
+msgstr ""
+
+#: src/ui/widgets.md:379
+msgid "Explicit size in points"
+msgstr ""
+
+#: src/ui/widgets.md:380
+msgid "`widgetSetBackgroundColor(w, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/widgets.md:380
+msgid "RGBA in \\[0, 1\\]"
+msgstr ""
+
+#: src/ui/widgets.md:381
+msgid "`setCornerRadius(w, r)`"
+msgstr ""
+
+#: src/ui/widgets.md:381
+msgid "Rounded corners in points"
+msgstr ""
+
+#: src/ui/widgets.md:382
+msgid "`widgetSetOpacity(w, alpha)`"
+msgstr ""
+
+#: src/ui/widgets.md:382
+msgid "Opacity in \\[0, 1\\]"
+msgstr ""
+
+#: src/ui/widgets.md:383
+msgid "`widgetSetEnabled(w, flag)`"
+msgstr ""
+
+#: src/ui/widgets.md:383
+msgid "`0` disables, `1` enables"
+msgstr ""
+
+#: src/ui/widgets.md:384
+msgid "`widgetSetHidden(w, flag)`"
+msgstr ""
+
+#: src/ui/widgets.md:384
+msgid "`0` visible, `1` hidden"
+msgstr ""
+
+#: src/ui/widgets.md:385
+msgid "`widgetSetTooltip(w, text)`"
+msgstr ""
+
+#: src/ui/widgets.md:385
+msgid "Tooltip on hover (desktop only)"
+msgstr ""
+
+#: src/ui/widgets.md:386
+msgid "`widgetSetOnClick(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:386
+msgid "Click handler"
+msgstr ""
+
+#: src/ui/widgets.md:387
+msgid "`widgetSetOnHover(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:387
+msgid "Hover enter/leave (desktop only)"
+msgstr ""
+
+#: src/ui/widgets.md:388
+msgid "`widgetSetOnDoubleClick(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:388
+msgid "Double-click handler"
+msgstr ""
+
+#: src/ui/widgets.md:389
+msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+msgstr ""
+
+#: src/ui/widgets.md:389
+msgid "Padding around contents"
+msgstr ""
+
+#: src/ui/widgets.md:390
+msgid "`widgetSetBorderColor(w, r, g, b, a)` / `widgetSetBorderWidth(w, n)`"
+msgstr ""
+
+#: src/ui/widgets.md:390
+msgid "Border"
+msgstr ""
+
+#: src/ui/widgets.md:391 src/ui/layout.md:175
+msgid "`widgetAddChild(parent, child)`"
+msgstr ""
+
+#: src/ui/widgets.md:391
+msgid "Attach a child to a container"
+msgstr ""
+
+#: src/ui/widgets.md:392
+msgid "`widgetSetContextMenu(w, menu)`"
+msgstr ""
+
+#: src/ui/widgets.md:392
+msgid "Right-click menu"
+msgstr ""
+
+#: src/ui/widgets.md:394
+msgid "See [Styling](styling.md) and [Events](events.md) for deeper coverage."
+msgstr ""
+
+#: src/ui/widgets.md:398
+msgid "[Layout](layout.md) — Arranging widgets with stacks and containers"
+msgstr ""
+
+#: src/ui/widgets.md:399
+msgid "[Styling](styling.md) — Colors, fonts, borders"
+msgstr ""
+
+#: src/ui/widgets.md:400 src/ui/theming.md:169
+msgid "[State Management](state.md) — Reactive bindings"
+msgstr ""
+
+#: src/ui/layout.md:3
+msgid ""
+"Perry provides layout containers that arrange child widgets using the "
+"platform's native layout system. Every snippet below is excerpted from "
+"[`docs/examples/ui/layout/snippets.ts`](../../examples/ui/layout/snippets.ts)"
+" — CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/layout.md:8
+msgid ""
+"Layout helpers are free functions: `widgetAddChild(parent, child)`, "
+"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
+"bottom, right)`, etc. Stack constructors take a numeric spacing followed by "
+"a child array; everything else (alignment, distribution, padding, sizing) is"
+" applied post-construction via the free functions on the widget handle."
+msgstr ""
+
+#: src/ui/layout.md:14 src/platforms/watchos.md:54 src/platforms/android.md:34
+#: src/platforms/linux.md:45 src/widgets/components.md:43
+msgid "VStack"
+msgstr ""
+
+#: src/ui/layout.md:16
+msgid "Arranges children vertically (top to bottom)."
+msgstr ""
+
+#: src/ui/layout.md:18
+msgid ""
+"```typescript\n"
+"const stack = VStack(16, [\n"
+"    Text(\"First\"),\n"
+"    Text(\"Second\"),\n"
+"    Text(\"Third\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:26
+msgid ""
+"`VStack(spacing, children)` — the first argument is the gap in points "
+"between children."
+msgstr ""
+
+#: src/ui/layout.md:29 src/platforms/watchos.md:55 src/platforms/android.md:35
+#: src/platforms/linux.md:46 src/widgets/components.md:52
+msgid "HStack"
+msgstr ""
+
+#: src/ui/layout.md:31
+msgid "Arranges children horizontally (left to right)."
+msgstr ""
+
+#: src/ui/layout.md:33
+msgid ""
+"```typescript\n"
+"const row = HStack(8, [\n"
+"    Button(\"Cancel\", noop),\n"
+"    Spacer(),\n"
+"    Button(\"OK\", noop),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:41 src/platforms/watchos.md:56 src/platforms/android.md:36
+#: src/platforms/linux.md:47 src/widgets/components.md:62
+msgid "ZStack"
+msgstr ""
+
+#: src/ui/layout.md:43
+msgid ""
+"Layers children on top of each other (back to front). `ZStack()` takes no "
+"constructor children — populate it with `widgetAddChild`:"
+msgstr ""
+
+#: src/ui/layout.md:46
+msgid ""
+"```typescript\n"
+"const layered = ZStack()\n"
+"widgetAddChild(layered, ImageFile(\"background.png\"))\n"
+"widgetAddChild(layered, Text(\"Overlay text\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:52 src/platforms/macos.md:35 src/platforms/ios.md:61
+#: src/platforms/tvos.md:60 src/platforms/watchos.md:62
+#: src/platforms/android.md:37 src/platforms/windows.md:54
+#: src/platforms/linux.md:48 src/testing/geisterhand.md:94
+msgid "ScrollView"
+msgstr ""
+
+#: src/ui/layout.md:54
+msgid ""
+"A scrollable container. Built empty, then filled via `scrollviewSetChild`:"
+msgstr ""
+
+#: src/ui/layout.md:56
+msgid ""
+"```typescript\n"
+"// ScrollView() takes no args; populate it with `scrollviewSetChild`.\n"
+"const sv = ScrollView()\n"
+"const inner = VStack(8, [Text(\"a\"), Text(\"b\"), Text(\"c\")])\n"
+"scrollviewSetChild(sv, inner)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:63
+msgid "LazyVStack"
+msgstr ""
+
+#: src/ui/layout.md:65
+msgid ""
+"A vertically scrolling list that lazily renders items. More efficient than "
+"`ScrollView` + `VStack` for thousands of rows — on macOS this is backed by "
+"`NSTableView` so only rows in the visible rect are realized."
+msgstr ""
+
+#: src/ui/layout.md:69
+msgid ""
+"```typescript\n"
+"// `render(index)` is invoked lazily — only rows in the visible rect are realized.\n"
+"const lazy = LazyVStack(1000, (index: number) => Text(`Row ${index}`))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:74
+msgid ""
+"When the underlying data changes, call `lazyvstackUpdate(handle, newCount)` "
+"to refresh. Override the default 44pt row height with "
+"`lazyvstackSetRowHeight`."
+msgstr ""
+
+#: src/ui/layout.md:77
+msgid "NavStack"
+msgstr ""
+
+#: src/ui/layout.md:79
+msgid ""
+"A navigation container that supports push/pop navigation. Push a new view "
+"with `navstackPush(stack, view, title)`; pop with `navstackPop(stack)`:"
+msgstr ""
+
+#: src/ui/layout.md:82
+msgid ""
+"```typescript\n"
+"const home = VStack(16, [\n"
+"    Text(\"Home Screen\"),\n"
+"    Button(\"Go to Details\", () => {\n"
+"        navstackPush(nav, Text(\"Details!\"), \"Details\")\n"
+"    }),\n"
+"])\n"
+"const nav = NavStack()\n"
+"widgetAddChild(nav, home)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:93 src/platforms/watchos.md:57
+#: src/widgets/components.md:71 src/widgets/platforms.md:25
+#: src/widgets/platforms.md:26
+msgid "Spacer"
+msgstr ""
+
+#: src/ui/layout.md:95
+msgid "A flexible space that expands to fill available room."
+msgstr ""
+
+#: src/ui/layout.md:97
+msgid ""
+"```typescript\n"
+"const toolbar = HStack(8, [\n"
+"    Text(\"Left\"),\n"
+"    Spacer(),\n"
+"    Text(\"Right\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:105
+msgid "Use `Spacer()` inside `HStack` or `VStack` to push widgets apart."
+msgstr ""
+
+#: src/ui/layout.md:107 src/platforms/watchos.md:58
+#: src/widgets/components.md:106 src/widgets/platforms.md:26
+msgid "Divider"
+msgstr ""
+
+#: src/ui/layout.md:109
+msgid "A visual separator line."
+msgstr ""
+
+#: src/ui/layout.md:111
+msgid ""
+"```typescript\n"
+"const sections = VStack(12, [\n"
+"    Text(\"Section 1\"),\n"
+"    Divider(),\n"
+"    Text(\"Section 2\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:119
+msgid "Nesting Layouts"
+msgstr ""
+
+#: src/ui/layout.md:121
+msgid "Layouts can be nested freely. This complete example is verified by CI:"
+msgstr ""
+
+#: src/ui/layout.md:123
+msgid ""
+"```typescript\n"
+"// demonstrates: nested VStack/HStack + Spacer + Divider\n"
+"// docs: docs/src/ui/layout.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, HStack, Text, Button, Spacer, Divider } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"Layout Example\",\n"
+"    width: 800,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        // Header\n"
+"        HStack(8, [\n"
+"            Text(\"My App\"),\n"
+"            Spacer(),\n"
+"            Button(\"Settings\", () => {}),\n"
+"        ]),\n"
+"        Divider(),\n"
+"        // Content\n"
+"        VStack(12, [\n"
+"            Text(\"Welcome!\"),\n"
+"            HStack(8, [\n"
+"                Button(\"Action 1\", () => {}),\n"
+"                Button(\"Action 2\", () => {}),\n"
+"            ]),\n"
+"        ]),\n"
+"        Spacer(),\n"
+"        // Footer\n"
+"        Text(\"v1.0.0\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:158
+msgid "Child Management"
+msgstr ""
+
+#: src/ui/layout.md:160
+msgid "Containers support dynamic child management via free functions:"
+msgstr ""
+
+#: src/ui/layout.md:162
+msgid ""
+"```typescript\n"
+"const list = VStack(16, [])\n"
+"widgetAddChild(list, Text(\"appended\"))            // append\n"
+"widgetAddChildAt(list, Text(\"prepended\"), 0)      // insert at index\n"
+"widgetReorderChild(list, 1, 0)                    // move from→to\n"
+"const removeMe = Text(\"temporary\")\n"
+"widgetAddChild(list, removeMe)\n"
+"widgetRemoveChild(list, removeMe)                 // remove\n"
+"widgetClearChildren(list)                         // remove all\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:173 src/ui/menus.md:53 src/ui/theming.md:131
+#: src/system/overview.md:21 src/system/media.md:37
+#: src/plugins/native-extensions.md:175
+msgid "Function"
+msgstr ""
+
+#: src/ui/layout.md:175
+msgid "Append a child widget"
+msgstr ""
+
+#: src/ui/layout.md:176
+msgid "`widgetAddChildAt(parent, child, index)`"
+msgstr ""
+
+#: src/ui/layout.md:176
+msgid "Insert a child at a specific position"
+msgstr ""
+
+#: src/ui/layout.md:177
+msgid "`widgetRemoveChild(parent, child)`"
+msgstr ""
+
+#: src/ui/layout.md:177
+msgid "Remove a specific child"
+msgstr ""
+
+#: src/ui/layout.md:178
+msgid "`widgetReorderChild(widget, fromIndex, toIndex)`"
+msgstr ""
+
+#: src/ui/layout.md:178
+msgid "Move a child to a new position"
+msgstr ""
+
+#: src/ui/layout.md:179
+msgid "`widgetClearChildren(widget)`"
+msgstr ""
+
+#: src/ui/layout.md:179
+msgid "Remove all children"
+msgstr ""
+
+#: src/ui/layout.md:181
+msgid "Stack Alignment"
+msgstr ""
+
+#: src/ui/layout.md:183
+msgid ""
+"Control how children are aligned within a stack using `stackSetAlignment`:"
+msgstr ""
+
+#: src/ui/layout.md:185
+msgid ""
+"```typescript\n"
+"const centered = VStack(16, [\n"
+"    Text(\"Centered\"),\n"
+"    Text(\"Content\"),\n"
+"])\n"
+"stackSetAlignment(centered, 9) // CenterX\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:193
+msgid "**VStack alignment** (cross-axis = horizontal):"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203 src/ui/layout.md:221
+#: src/platforms/tvos.md:149 src/plugins/appstore-review.md:77
+#: src/plugins/appstore-review.md:93 src/plugins/appstore-review.md:106
+#: src/cli/perry-toml.md:215 src/cli/perry-toml.md:277
+#: src/cli/perry-toml.md:284
+msgid "Value"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203 src/ui/layout.md:221
+msgid "Name"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203
+msgid "Effect"
+msgstr ""
+
+#: src/ui/layout.md:197 src/ui/styling.md:372 src/testing/geisterhand.md:91
+#: src/testing/geisterhand.md:105 src/cli/perry-toml.md:400
+msgid "5"
+msgstr ""
+
+#: src/ui/layout.md:197
+msgid "Leading"
+msgstr ""
+
+#: src/ui/layout.md:197
+msgid "Children align to the leading (left) edge"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "9"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "CenterX"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "Children centered horizontally"
+msgstr ""
+
+#: src/ui/layout.md:199 src/testing/geisterhand.md:93
+msgid "7"
+msgstr ""
+
+#: src/ui/layout.md:199
+msgid "Width"
+msgstr ""
+
+#: src/ui/layout.md:199
+msgid "Children stretch to fill the stack's width"
+msgstr ""
+
+#: src/ui/layout.md:201
+msgid "**HStack alignment** (cross-axis = vertical):"
+msgstr ""
+
+#: src/ui/layout.md:205 src/ui/layout.md:226 src/platforms/windows-7.md:27
+#: src/testing/geisterhand.md:89 src/testing/geisterhand.md:103
+#: src/cli/perry-toml.md:402
+msgid "3"
+msgstr ""
+
+#: src/ui/layout.md:205
+msgid "Top"
+msgstr ""
+
+#: src/ui/layout.md:205
+msgid "Children align to the top"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "12"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "CenterY"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "Children centered vertically"
+msgstr ""
+
+#: src/ui/layout.md:207 src/ui/layout.md:227 src/ui/styling.md:371
+#: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
+#: src/cli/perry-toml.md:401
+msgid "4"
+msgstr ""
+
+#: src/ui/layout.md:207
+msgid "Bottom"
+msgstr ""
+
+#: src/ui/layout.md:207
+msgid "Children align to the bottom"
+msgstr ""
+
+#: src/ui/layout.md:209
+msgid "Stack Distribution"
+msgstr ""
+
+#: src/ui/layout.md:211
+msgid ""
+"Control how children share space within a stack using "
+"`stackSetDistribution`:"
+msgstr ""
+
+#: src/ui/layout.md:213
+msgid ""
+"```typescript\n"
+"const buttons = HStack(8, [\n"
+"    Button(\"Cancel\", noop),\n"
+"    Button(\"OK\", noop),\n"
+"])\n"
+"stackSetDistribution(buttons, 1) // FillEqually — both buttons get equal width\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:221 src/widgets/data-fetching.md:125
+msgid "Behavior"
+msgstr ""
+
+#: src/ui/layout.md:223 src/ui/styling.md:370 src/ui/styling.md:371
+#: src/ui/styling.md:372 src/testing/geisterhand.md:86
+#: src/testing/geisterhand.md:100
+msgid "0"
+msgstr ""
+
+#: src/ui/layout.md:223
+msgid "Fill"
+msgstr ""
+
+#: src/ui/layout.md:223
+msgid "Default. First resizable child fills remaining space"
+msgstr ""
+
+#: src/ui/layout.md:224 src/platforms/windows-7.md:25
+#: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
+#: src/cli/perry-toml.md:404
+msgid "1"
+msgstr ""
+
+#: src/ui/layout.md:224
+msgid "FillEqually"
+msgstr ""
+
+#: src/ui/layout.md:224
+msgid "All children get equal size"
+msgstr ""
+
+#: src/ui/layout.md:225 src/platforms/windows-7.md:26
+#: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
+#: src/cli/perry-toml.md:403
+msgid "2"
+msgstr ""
+
+#: src/ui/layout.md:225
+msgid "FillProportionally"
+msgstr ""
+
+#: src/ui/layout.md:225
+msgid "Children sized proportionally to their intrinsic content"
+msgstr ""
+
+#: src/ui/layout.md:226
+msgid "EqualSpacing"
+msgstr ""
+
+#: src/ui/layout.md:226
+msgid "Equal gaps between children"
+msgstr ""
+
+#: src/ui/layout.md:227
+msgid "EqualCentering"
+msgstr ""
+
+#: src/ui/layout.md:227
+msgid "Equal distance between child centers"
+msgstr ""
+
+#: src/ui/layout.md:229
+msgid "Fill Parent"
+msgstr ""
+
+#: src/ui/layout.md:231
+msgid "Pin a child's edges to its parent container:"
+msgstr ""
+
+#: src/ui/layout.md:233
+msgid ""
+"```typescript\n"
+"const banner = Text(\"Full width banner\")\n"
+"widgetMatchParentWidth(banner)\n"
+"const banneredPage = VStack(16, [banner, Text(\"Normal width\")])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:239
+msgid "`widgetMatchParentWidth(widget)` — stretch to fill parent's width"
+msgstr ""
+
+#: src/ui/layout.md:240
+msgid "`widgetMatchParentHeight(widget)` — stretch to fill parent's height"
+msgstr ""
+
+#: src/ui/layout.md:242
+msgid "Content Hugging"
+msgstr ""
+
+#: src/ui/layout.md:244
+msgid ""
+"Control whether a widget resists being stretched beyond its intrinsic size:"
+msgstr ""
+
+#: src/ui/layout.md:246
+msgid ""
+"```typescript\n"
+"const tight = Text(\"I stay small\")\n"
+"widgetSetHugging(tight, 750) // High priority — resist stretching\n"
+"\n"
+"const stretchy = Text(\"I stretch\")\n"
+"widgetSetHugging(stretchy, 1) // Low priority — stretch to fill\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:254
+msgid ""
+"**High priority** (250–750+): widget resists stretching, stays at its "
+"natural size"
+msgstr ""
+
+#: src/ui/layout.md:255
+msgid "**Low priority** (1–249): widget stretches to fill available space"
+msgstr ""
+
+#: src/ui/layout.md:257
+msgid "Overlay Positioning"
+msgstr ""
+
+#: src/ui/layout.md:259
+msgid "For absolute positioning, add overlay children to any container:"
+msgstr ""
+
+#: src/ui/layout.md:261
+msgid ""
+"```typescript\n"
+"// Overlay parent must be a ZStack — macOS NSView allows `addSubview` on\n"
+"// any view, but GTK4 can only float children above siblings inside\n"
+"// `gtk::Overlay` (which is what ZStack is backed by).\n"
+"const container = ZStack()\n"
+"widgetAddChild(container, VStack(16, [Text(\"Main content\")])) // main child\n"
+"\n"
+"const badge = Text(\"3\")\n"
+"setCornerRadius(badge, 10)\n"
+"widgetSetBackgroundColor(badge, 1.0, 0.231, 0.188, 1.0) // RGBA red\n"
+"\n"
+"widgetAddOverlay(container, badge)\n"
+"widgetSetOverlayFrame(badge, 280, 10, 20, 20) // x, y, width, height\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:276
+msgid ""
+"Overlay children are positioned absolutely relative to their parent — "
+"similar to CSS `position: absolute`."
+msgstr ""
+
+#: src/ui/layout.md:279
+msgid "Split Views"
+msgstr ""
+
+#: src/ui/layout.md:281
+msgid "Create resizable split panes for sidebar layouts:"
+msgstr ""
+
+#: src/ui/layout.md:283
+msgid ""
+"```typescript\n"
+"const split = SplitView()\n"
+"\n"
+"const sidebar = VStack(8, [Text(\"Navigation\"), Text(\"Item 1\"), Text(\"Item 2\")])\n"
+"const content = VStack(16, [Text(\"Main Content\")])\n"
+"\n"
+"splitViewAddChild(split, sidebar)\n"
+"splitViewAddChild(split, content)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:293
+msgid ""
+"The user can drag the divider to resize panes. On macOS this maps to "
+"`NSSplitView`."
+msgstr ""
+
+#: src/ui/layout.md:296
+msgid "Stacks with Built-in Padding"
+msgstr ""
+
+#: src/ui/layout.md:298
+msgid ""
+"Create a stack with padding in a single call. The order is **top, left, "
+"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+msgstr ""
+
+#: src/ui/layout.md:301
+msgid ""
+"```typescript\n"
+"// VStackWithInsets(spacing, top, left, bottom, right) — note: order is\n"
+"// top/left/bottom/right (CSS-style), not top/right/bottom/left.\n"
+"const card = VStackWithInsets(12, 16, 16, 16, 16)\n"
+"widgetAddChild(card, Text(\"Padded content\"))\n"
+"widgetAddChild(card, Text(\"More content\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:309
+msgid ""
+"`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
+"counterpart. Equivalent to creating a stack and then calling "
+"`widgetSetEdgeInsets`, but more concise. Children are added via "
+"`widgetAddChild` rather than the constructor array."
+msgstr ""
+
+#: src/ui/layout.md:314
+msgid "Detaching Hidden Views"
+msgstr ""
+
+#: src/ui/layout.md:316
+msgid ""
+"By default, hidden children still occupy space in a stack. To collapse them:"
+msgstr ""
+
+#: src/ui/layout.md:318
+msgid ""
+"```typescript\n"
+"const collapsible = VStack(8, [Text(\"Always visible\"), Text(\"Sometimes hidden\")])\n"
+"stackSetDetachesHidden(collapsible, 1) // Hidden children leave no gap\n"
+"// You can then toggle a child:\n"
+"const sometimesHidden = Text(\"toggle me\")\n"
+"widgetSetHidden(sometimesHidden, 1) // 1 = hidden, 0 = visible\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:326
+msgid "Common Layout Patterns"
+msgstr ""
+
+#: src/ui/layout.md:328
+msgid "Centered content"
+msgstr ""
+
+#: src/ui/layout.md:330
+msgid ""
+"```typescript\n"
+"const page = VStack(16, [Text(\"Title\"), Text(\"Subtitle\")])\n"
+"stackSetAlignment(page, 9) // CenterX\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:335
+msgid "Search row that fills the width"
+msgstr ""
+
+#: src/ui/layout.md:337
+msgid ""
+"```typescript\n"
+"const searchInput = TextField(\"Search...\", (v: string) => search.set(v))\n"
+"widgetMatchParentWidth(searchInput)\n"
+"const results = VStack(8, [])\n"
+"const searchPage = VStack(12, [searchInput, results])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:344
+msgid "Floating badge / overlay"
+msgstr ""
+
+#: src/ui/layout.md:346
+msgid ""
+"```typescript\n"
+"// Wrap the icon in a ZStack so the badge can float above it on every\n"
+"const icon = ZStack()\n"
+"widgetAddChild(icon, ImageSymbol(\"bell\"))\n"
+"const dotBadge = Text(\"3\")\n"
+"widgetAddOverlay(icon, dotBadge)\n"
+"widgetSetOverlayFrame(dotBadge, 20, -5, 16, 16)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:355
+msgid "Toolbar with spacers"
+msgstr ""
+
+#: src/ui/layout.md:357
+msgid ""
+"```typescript\n"
+"const titleBar = HStack(8, [\n"
+"    Button(\"Back\", noop),\n"
+"    Spacer(),\n"
+"    Text(\"Page Title\"),\n"
+"    Spacer(),\n"
+"    Button(\"Settings\", noop),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:369
+msgid "[Styling](styling.md) — Colors, padding, sizing"
+msgstr ""
+
+#: src/ui/layout.md:371
+msgid "[State Management](state.md) — Dynamic UI with state"
+msgstr ""
+
+#: src/ui/styling.md:3
+msgid ""
+"Perry widgets accept an inline `style: { ... }` object that maps to each "
+"platform's native styling APIs. The same shape works on every Widget "
+"constructor — `Button`, `Text`, `Toggle`, `Slider`, `VStack`/`HStack`, and "
+"friends — so cross-platform styling code stays the same regardless of "
+"target."
+msgstr ""
+
+#: src/ui/styling.md:9
+msgid "Inline style — recommended"
+msgstr ""
+
+#: src/ui/styling.md:11
+msgid ""
+"Pass a `StyleProps` object as the trailing argument to any widget "
+"constructor. Codegen destructures the literal at HIR time into a sequence of"
+" native setter calls, so the runtime shape is the same as hand-writing the "
+"imperative pattern below — but the source is much shorter:"
+msgstr ""
+
+#: src/ui/styling.md:17
+msgid ""
+"```typescript\n"
+"const card = Button(\"Save\", () => {\n"
+"    console.log(\"saved\")\n"
+"}, {\n"
+"    backgroundColor: { r: 0.231, g: 0.510, b: 0.965, a: 1.0 },\n"
+"    borderColor: { r: 0.0, g: 0.0, b: 0.0, a: 0.1 },\n"
+"    borderWidth: 1,\n"
+"    borderRadius: 8,\n"
+"    padding: 12,\n"
+"    opacity: 0.95,\n"
+"    shadow: {\n"
+"        color: { r: 0.0, g: 0.0, b: 0.0, a: 0.25 },\n"
+"        blur: 12,\n"
+"        offsetX: 0,\n"
+"        offsetY: 4,\n"
+"    },\n"
+"    tooltip: \"Save the current document\",\n"
+"    enabled: true,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:38
+msgid ""
+"The `style` arg is optional; widgets without it look identical to calls "
+"before this API existed. See "
+"[`docs/examples/ui/styling/button_inline_style.ts`](../../examples/ui/styling/button_inline_style.ts)"
+" for the full file."
+msgstr ""
+
+#: src/ui/styling.md:43
+msgid "What `style` accepts"
+msgstr ""
+
+#: src/ui/styling.md:45
+msgid "Prop"
+msgstr ""
+
+#: src/ui/styling.md:45
+msgid "Maps to"
+msgstr ""
+
+#: src/ui/styling.md:47
+msgid "`backgroundColor`"
+msgstr ""
+
+#: src/ui/styling.md:47 src/ui/styling.md:48 src/ui/styling.md:49
+msgid "string \\| PerryColor"
+msgstr ""
+
+#: src/ui/styling.md:47
+msgid "`widgetSetBackgroundColor`"
+msgstr ""
+
+#: src/ui/styling.md:48
+msgid "`color`"
+msgstr ""
+
+#: src/ui/styling.md:48
+msgid "`textSetColor` / `buttonSetTextColor`"
+msgstr ""
+
+#: src/ui/styling.md:49
+msgid "`borderColor`"
+msgstr ""
+
+#: src/ui/styling.md:49
+msgid "`widgetSetBorderColor`"
+msgstr ""
+
+#: src/ui/styling.md:50
+msgid "`borderWidth`"
+msgstr ""
+
+#: src/ui/styling.md:50
+msgid "`widgetSetBorderWidth`"
+msgstr ""
+
+#: src/ui/styling.md:51
+msgid "`borderRadius`"
+msgstr ""
+
+#: src/ui/styling.md:51
+msgid "`setCornerRadius`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "`padding`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "number \\| `{ top, right, bottom, left }`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "`widgetSetEdgeInsets`"
+msgstr ""
+
+#: src/ui/styling.md:53 src/platforms/watchos.md:77
+msgid "`opacity`"
+msgstr ""
+
+#: src/ui/styling.md:53
+msgid "number (0..=1)"
+msgstr ""
+
+#: src/ui/styling.md:53
+msgid "`widgetSetOpacity`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`shadow`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`{ color, blur, offsetX, offsetY }`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`widgetSetShadow`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`textDecoration`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`\"none\" \\| \"underline\" \\| \"strikethrough\"`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`textSetDecoration`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`gradient`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`{ angle, stops: [c1, c2] }`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`widgetSetBackgroundGradient`"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "`fontSize`, `fontWeight`, `fontFamily`"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "number / string"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "`textSetFont*`"
+msgstr ""
+
+#: src/ui/styling.md:58
+msgid "`tooltip`"
+msgstr ""
+
+#: src/ui/styling.md:58
+msgid "`widgetSetTooltip`"
+msgstr ""
+
+#: src/ui/styling.md:59
+msgid "`hidden`"
+msgstr ""
+
+#: src/ui/styling.md:59
+msgid "`widgetSetHidden`"
+msgstr ""
+
+#: src/ui/styling.md:60
+msgid "`enabled`"
+msgstr ""
+
+#: src/ui/styling.md:60
+msgid "`widgetSetEnabled`"
+msgstr ""
+
+#: src/ui/styling.md:62
+msgid "Color values"
+msgstr ""
+
+#: src/ui/styling.md:64
+msgid "Color props accept four interchangeable shapes:"
+msgstr ""
+
+#: src/ui/styling.md:66
+msgid ""
+"```typescript,no-test\n"
+"backgroundColor: \"#3B82F6\"                                   // hex 6/8\n"
+"backgroundColor: \"#3B82F6FF\"                                 // hex with alpha\n"
+"backgroundColor: \"blue\"                                      // named color\n"
+"backgroundColor: { r: 0.231, g: 0.510, b: 0.965, a: 1.0 }   // PerryColor object\n"
+"backgroundColor: themeColor                                  // runtime variable\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:74
+msgid ""
+"Named colors: `white`, `black`, `red`, `green`, `blue`, `yellow`, `cyan`, "
+"`magenta`, `gray` / `grey`, `transparent`. Hex forms supported: `#RGB`, "
+"`#RGBA`, `#RRGGBB`, `#RRGGBBAA`."
+msgstr ""
+
+#: src/ui/styling.md:78
+msgid ""
+"Literals (the first four forms) compile-time-fold into 4 baked-in float "
+"arguments — zero runtime cost. Runtime variables resolve through "
+"`js_color_parse_channel` (a small CSS color parser in `perry-runtime`) so "
+"`backgroundColor: someStringVar` works the same as the literal form."
+msgstr ""
+
+#: src/ui/styling.md:83
+msgid "Padding shapes"
+msgstr ""
+
+#: src/ui/styling.md:85
+msgid "A single number applies to all four sides; an object picks per-side:"
+msgstr ""
+
+#: src/ui/styling.md:87
+msgid ""
+"```typescript,no-test\n"
+"padding: 12                                       // all four sides 12\n"
+"padding: { top: 8, right: 16, bottom: 8, left: 16 }  // per-side\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:92
+msgid "Missing sides default to 0."
+msgstr ""
+
+#: src/ui/styling.md:94
+msgid "Container styling"
+msgstr ""
+
+#: src/ui/styling.md:96
+msgid "`VStack` and `HStack` accept `style` after the children array:"
+msgstr ""
+
+#: src/ui/styling.md:98
+msgid ""
+"```typescript\n"
+"// VStack with explicit spacing AND inline style — children + style.\n"
+"const card = VStack(8, [\n"
+"    Text(\"Heading\"),\n"
+"    Text(\"Subtitle\"),\n"
+"    Button(\"Action\", () => { console.log(\"clicked\") }),\n"
+"], {\n"
+"    backgroundColor: { r: 0.96, g: 0.97, b: 0.99, a: 1.0 },\n"
+"    borderRadius: 12,\n"
+"    padding: 16,\n"
+"    shadow: {\n"
+"        color: { r: 0.0, g: 0.0, b: 0.0, a: 0.1 },\n"
+"        blur: 8,\n"
+"        offsetY: 2,\n"
+"    },\n"
+"})\n"
+"\n"
+"// HStack with no explicit spacing (children-array first form) + style.\n"
+"const toolbar = HStack([\n"
+"    Text(\"Left\"),\n"
+"    Text(\"Right\"),\n"
+"], {\n"
+"    backgroundColor: { r: 0.2, g: 0.2, b: 0.2, a: 1.0 },\n"
+"    padding: { top: 8, right: 16, bottom: 8, left: 16 },\n"
+"    borderRadius: 6,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:126
+msgid ""
+"Both shapes work — `VStack(children, style?)` and `VStack(spacing, children,"
+" style?)`."
+msgstr ""
+
+#: src/ui/styling.md:128
+msgid "Coming from CSS"
+msgstr ""
+
+#: src/ui/styling.md:130
+msgid "If you're coming from web, the conceptual mapping is:"
+msgstr ""
+
+#: src/ui/styling.md:132
+msgid "CSS"
+msgstr ""
+
+#: src/ui/styling.md:132
+msgid "Perry inline style"
+msgstr ""
+
+#: src/ui/styling.md:134
+msgid "`display: flex; flex-direction: column`"
+msgstr ""
+
+#: src/ui/styling.md:134
+msgid "`VStack(spacing, [...])`"
+msgstr ""
+
+#: src/ui/styling.md:135
+msgid "`display: flex; flex-direction: row`"
+msgstr ""
+
+#: src/ui/styling.md:135
+msgid "`HStack(spacing, [...])`"
+msgstr ""
+
+#: src/ui/styling.md:136
+msgid "`width: 100%`"
+msgstr ""
+
+#: src/ui/styling.md:136
+msgid "`widgetMatchParentWidth(widget)`"
+msgstr ""
+
+#: src/ui/styling.md:137
+msgid "`padding: 10px 20px`"
+msgstr ""
+
+#: src/ui/styling.md:137
+msgid "`padding: { top: 10, right: 20, bottom: 10, left: 20 }`"
+msgstr ""
+
+#: src/ui/styling.md:138
+msgid "`gap: 16px`"
+msgstr ""
+
+#: src/ui/styling.md:138
+msgid "`VStack(16, [...])` — first argument is the gap"
+msgstr ""
+
+#: src/ui/styling.md:139
+msgid "CSS variables / design tokens"
+msgstr ""
+
+#: src/ui/styling.md:139
+msgid "[`perry-styling`](theming.md) package"
+msgstr ""
+
+#: src/ui/styling.md:140
+msgid "`opacity: 0.5`"
+msgstr ""
+
+#: src/ui/styling.md:141
+msgid "`border-radius: 8px`"
+msgstr ""
+
+#: src/ui/styling.md:141
+msgid "`borderRadius: 8`"
+msgstr ""
+
+#: src/ui/styling.md:142
+msgid "`background: #3B82F6`"
+msgstr ""
+
+#: src/ui/styling.md:142
+msgid "`backgroundColor: \"#3B82F6\"`"
+msgstr ""
+
+#: src/ui/styling.md:143
+msgid "`box-shadow: 0 4px 12px rgba(0,0,0,0.25)`"
+msgstr ""
+
+#: src/ui/styling.md:143
+msgid "`shadow: { color: \"#0004\", blur: 12, offsetY: 4 }`"
+msgstr ""
+
+#: src/ui/styling.md:144
+msgid "`text-decoration: underline`"
+msgstr ""
+
+#: src/ui/styling.md:144
+msgid "`textDecoration: \"underline\"`"
+msgstr ""
+
+#: src/ui/styling.md:146
+msgid ""
+"See [Layout](layout.md) for full details on alignment, distribution, "
+"overlays, and split views."
+msgstr ""
+
+#: src/ui/styling.md:148
+msgid "Imperative API (underlying)"
+msgstr ""
+
+#: src/ui/styling.md:150
+msgid ""
+"The inline `style` object lowers to the same FFI calls as Perry's imperative"
+" free-function setters: `widgetSet*`, `textSet*`, `buttonSet*`. They take "
+"the widget handle as the first argument and remain available for cases where"
+" you want fine-grained control or need to mutate styles after creation. "
+"Colors here are RGBA floats in `[0.0, 1.0]` (divide each hex byte by 255 — "
+"`0xFF3B30` → `(1.0, 0.231, 0.188, 1.0)`)."
+msgstr ""
+
+#: src/ui/styling.md:158
+msgid ""
+"Every snippet below is excerpted from "
+"[`docs/examples/ui/styling/snippets.ts`](../../examples/ui/styling/snippets.ts),"
+" which CI compiles and runs on every PR — so the API drawn here is always "
+"the API the compiler accepts."
+msgstr ""
+
+#: src/ui/styling.md:163
+msgid ""
+"```typescript\n"
+"import {\n"
+"    App,\n"
+"    VStack, VStackWithInsets, HStack, Spacer,\n"
+"    Text, Button,\n"
+"    textSetColor, textSetFontSize, textSetFontFamily, textSetFontWeight,\n"
+"    setCornerRadius, setPadding,\n"
+"    widgetAddChild,\n"
+"    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
+"    widgetSetBorderColor, widgetSetBorderWidth,\n"
+"    widgetSetEdgeInsets,\n"
+"    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
+"    widgetSetOpacity,\n"
+"    widgetSetControlSize,\n"
+"    widgetSetTooltip,\n"
+"    widgetSetEnabled,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:182
+msgid "Colors"
+msgstr ""
+
+#: src/ui/styling.md:184
+msgid ""
+"```typescript\n"
+"const colored = Text(\"Colored text\")\n"
+"textSetColor(colored, 1.0, 0.0, 0.0, 1.0)              // r, g, b, a in [0,1]\n"
+"widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:190
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/styling.md:192
+msgid ""
+"```typescript\n"
+"const font = Text(\"Styled text\")\n"
+"textSetFontSize(font, 24)                  // Font size in points\n"
+"textSetFontFamily(font, \"Menlo\")           // Font family name\n"
+"textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:199
+msgid "Use `\"monospaced\"` for the system monospaced font."
+msgstr ""
+
+#: src/ui/styling.md:201
+msgid "Corner Radius"
+msgstr ""
+
+#: src/ui/styling.md:203
+msgid ""
+"```typescript\n"
+"const rounded = Button(\"Rounded\", () => {})\n"
+"setCornerRadius(rounded, 12)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:208
+msgid "Borders"
+msgstr ""
+
+#: src/ui/styling.md:216
+msgid "Padding and Insets"
+msgstr ""
+
+#: src/ui/styling.md:218
+msgid ""
+"```typescript\n"
+"const padded = VStack(8, [Text(\"Padded content\")])\n"
+"// Both names accept (widget, top, left, bottom, right):\n"
+"setPadding(padded, 16, 16, 16, 16)\n"
+"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:225
+msgid "Sizing"
+msgstr ""
+
+#: src/ui/styling.md:227
+msgid ""
+"```typescript\n"
+"const sized = VStack(0, [])\n"
+"widgetSetWidth(sized, 300)\n"
+"widgetSetHeight(sized, 200)\n"
+"widgetMatchParentWidth(sized) // expand to fill parent's width\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:234 src/ui/theming.md:144
+msgid "Opacity"
+msgstr ""
+
+#: src/ui/styling.md:236
+msgid ""
+"```typescript\n"
+"const dim = Text(\"Semi-transparent\")\n"
+"widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:241
+msgid "Background Gradient"
+msgstr ""
+
+#: src/ui/styling.md:243
+msgid ""
+"```typescript\n"
+"const grad = VStack(0, [])\n"
+"// Two RGBA stops + angle (degrees, 0 = top-to-bottom).\n"
+"widgetSetBackgroundGradient(grad,\n"
+"    1.0, 0.0, 0.0, 1.0,   // start (red)\n"
+"    0.0, 0.0, 1.0, 1.0,   // end   (blue)\n"
+"    0,                    // angle\n"
+")\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:253
+msgid "Control Size"
+msgstr ""
+
+#: src/ui/styling.md:255
+msgid ""
+"```typescript\n"
+"const small = Button(\"Small\", () => {})\n"
+"widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:260
+msgid ""
+"**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
+"differently."
+msgstr ""
+
+#: src/ui/styling.md:262
+msgid "Tooltips"
+msgstr ""
+
+#: src/ui/styling.md:264
+msgid ""
+"```typescript\n"
+"const tip = Button(\"Hover me\", () => {})\n"
+"widgetSetTooltip(tip, \"Click to perform action\")\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:269
+msgid ""
+"**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
+"support. **Web**: HTML `title` attribute."
+msgstr ""
+
+#: src/ui/styling.md:271
+msgid "Enabled/Disabled"
+msgstr ""
+
+#: src/ui/styling.md:273
+msgid ""
+"```typescript\n"
+"const submit = Button(\"Submit\", () => {})\n"
+"widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:278
+msgid "Complete Imperative Example"
+msgstr ""
+
+#: src/ui/styling.md:280
+msgid ""
+"```typescript\n"
+"// demonstrates: a styled counter card using the real free-function API\n"
+"// docs: docs/src/ui/styling.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    VStack,\n"
+"    HStack,\n"
+"    State,\n"
+"    Spacer,\n"
+"    textSetFontSize,\n"
+"    textSetFontFamily,\n"
+"    textSetColor,\n"
+"    widgetSetBackgroundColor,\n"
+"    widgetSetEdgeInsets,\n"
+"    setCornerRadius,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// Note: widgetSetBorderColor / widgetSetBorderWidth are macOS/iOS/Windows\n"
+"// only — perry-ui-gtk4 doesn't export them (GTK4 borders are CSS-driven).\n"
+"// Omitted from this demo so it compiles everywhere.\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"const title = Text(\"Counter\")\n"
+"textSetFontSize(title, 28)\n"
+"textSetColor(title, 0.1, 0.1, 0.1, 1.0)\n"
+"\n"
+"const display = Text(`${count.value}`)\n"
+"textSetFontSize(display, 48)\n"
+"textSetFontFamily(display, \"monospaced\")\n"
+"textSetColor(display, 0.0, 0.478, 1.0, 1.0)\n"
+"\n"
+"const decBtn = Button(\"-\", () => count.set(count.value - 1))\n"
+"setCornerRadius(decBtn, 20)\n"
+"widgetSetBackgroundColor(decBtn, 1.0, 0.231, 0.188, 1.0)\n"
+"\n"
+"const incBtn = Button(\"+\", () => count.set(count.value + 1))\n"
+"setCornerRadius(incBtn, 20)\n"
+"widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
+"\n"
+"const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
+"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"\n"
+"const container = VStack(16, [title, display, controls])\n"
+"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setCornerRadius(container, 16)\n"
+"widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
+"\n"
+"App({\n"
+"    title: \"Styled App\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: container,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:341
+msgid "Composing Styles (imperative helper functions)"
+msgstr ""
+
+#: src/ui/styling.md:343
+msgid "Reduce repetition by creating helper functions:"
+msgstr ""
+
+#: src/ui/styling.md:357
+msgid ""
+"For larger apps, use the `perry-styling` package to define design tokens in "
+"JSON and generate a typed theme file. See [Theming](theming.md) for the full"
+" workflow."
+msgstr ""
+
+#: src/ui/styling.md:359
+msgid "Platform support"
+msgstr ""
+
+#: src/ui/styling.md:361
+msgid ""
+"Per-prop, per-platform support is tracked in the [styling matrix](styling-"
+"matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and"
+" CI-checked against each backend's `lib.rs` exports on every PR."
+msgstr ""
+
+#: src/ui/styling.md:366
+msgid ""
+"Current state (issue [\\#185](https://github.com/PerryTS/perry/issues/185)):"
+msgstr ""
+
+#: src/ui/styling.md:368 src/ui/canvas.md:72 src/ui/canvas.md:73
+#: src/ui/canvas.md:74 src/ui/canvas.md:75 src/ui/canvas.md:76
+#: src/ui/canvas.md:78
+msgid "Wired"
+msgstr ""
+
+#: src/ui/styling.md:368
+msgid "Stub"
+msgstr ""
+
+#: src/ui/styling.md:368
+msgid "Missing"
+msgstr ""
+
+#: src/ui/styling.md:370
+msgid "macOS / iOS / tvOS / visionOS / watchOS / Android / Web"
+msgstr ""
+
+#: src/ui/styling.md:370
+msgid "**43/43**"
+msgstr ""
+
+#: src/ui/styling.md:371
+msgid "GTK4 (Linux)"
+msgstr ""
+
+#: src/ui/styling.md:371
+msgid "39/43"
+msgstr ""
+
+#: src/ui/styling.md:372
+msgid "38/43"
+msgstr ""
+
+#: src/ui/styling.md:374
+msgid ""
+"**GTK4** has 4 styling props (`widget.on_click`, "
+"`button.content_tint_color`, `button.image_position`, "
+"`stack.detaches_hidden`) that need a Linux contributor — tracked in issue "
+"[\\#202](https://github.com/PerryTS/perry/issues/202). Inline `style: {...}`"
+" calls referencing only the wired props compile and run cleanly today; the "
+"missing props silently no-op until that issue lands."
+msgstr ""
+
+#: src/ui/styling.md:375
+msgid ""
+"**Windows** has 5 props in a \"deferred-paint family\" (`shadow`, `opacity`,"
+" `border_color`, `border_width`, `text.decoration`) where the FFI symbol "
+"exists and stores the requested params, but a custom `WM_PAINT` rendering "
+"pass is needed to make them visible — tracked in issue "
+"[\\#210](https://github.com/PerryTS/perry/issues/210). User code authoring "
+"inline styles compiles and links cleanly on Windows; the visual rendering "
+"catches up when that issue lands."
+msgstr ""
+
+#: src/ui/styling.md:380 src/ui/state.md:229 src/ui/table.md:110
+msgid "[Layout](layout.md) — Layout containers"
+msgstr ""
+
+#: src/ui/styling.md:381
+msgid "[Animation](animation.md) — Animate style changes"
+msgstr ""
+
+#: src/ui/styling.md:382
+msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
+msgstr ""
+
+#: src/ui/state.md:3
+msgid ""
+"Perry uses reactive state to automatically update the UI when data changes. "
+"Every snippet below is excerpted from "
+"[`docs/examples/ui/state/snippets.ts`](../../examples/ui/state/snippets.ts) "
+"— CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/state.md:8
+msgid "Creating State"
+msgstr ""
+
+#: src/ui/state.md:10
+msgid ""
+"```typescript\n"
+"const counter = State(0)               // number state\n"
+"const username = State(\"Perry\")        // string state\n"
+"const items = State<string[]>([])      // array state\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:16
+msgid "`State(initialValue)` creates a reactive state container."
+msgstr ""
+
+#: src/ui/state.md:18
+msgid "Reading and Writing"
+msgstr ""
+
+#: src/ui/state.md:20
+msgid ""
+"```typescript\n"
+"const value = counter.value     // Read current value\n"
+"counter.set(42)                  // Set new value → triggers UI update\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:25
+msgid "Every `.set()` call re-renders the widget tree with the new value."
+msgstr ""
+
+#: src/ui/state.md:27
+msgid "Reactive Text"
+msgstr ""
+
+#: src/ui/state.md:29
+msgid "Template literals with `state.value` update automatically:"
+msgstr ""
+
+#: src/ui/state.md:31
+msgid ""
+"```typescript\n"
+"const showCount = State(0)\n"
+"const countLabel = Text(`Count: ${showCount.value}`)\n"
+"// The text updates whenever showCount changes.\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:37
+msgid ""
+"This works because Perry detects `state.value` reads inside template "
+"literals and creates reactive bindings."
+msgstr ""
+
+#: src/ui/state.md:40
+msgid "Binding Inputs to State"
+msgstr ""
+
+#: src/ui/state.md:42
+msgid ""
+"Input widgets expose an `onChange` callback. Forward that into a state's "
+"`.set(...)` to keep the state in sync as the user types/toggles/drags:"
+msgstr ""
+
+#: src/ui/state.md:45
+msgid ""
+"```typescript\n"
+"const input = State(\"\")\n"
+"const field = TextField(\"Type here...\", (v: string) => input.set(v))\n"
+"\n"
+"// Optional: also let input.set(\"hello\") update the field on screen.\n"
+"stateBindTextfield(input, field)\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:53
+msgid "Input control signatures:"
+msgstr ""
+
+#: src/ui/state.md:54
+msgid ""
+"`TextField(placeholder, onChange)` — text input, `onChange: (value: string) "
+"=> void`"
+msgstr ""
+
+#: src/ui/state.md:55
+msgid ""
+"`SecureField(placeholder, onChange)` — password input, `onChange: (value: "
+"string) => void`"
+msgstr ""
+
+#: src/ui/state.md:56
+msgid ""
+"`Toggle(label, onChange)` — boolean toggle, `onChange: (value: boolean) => "
+"void`"
+msgstr ""
+
+#: src/ui/state.md:57
+msgid ""
+"`Slider(min, max, onChange)` — numeric slider, `onChange: (value: number) =>"
+" void`"
+msgstr ""
+
+#: src/ui/state.md:58
+msgid ""
+"`Picker(onChange)` — dropdown, `onChange: (index: number) => void`; items "
+"via `pickerAddItem`"
+msgstr ""
+
+#: src/ui/state.md:60
+msgid ""
+"For programmatic-to-UI sync (state-drives-widget) use the dedicated binders:"
+" `stateBindTextfield`, `stateBindSlider`, `stateBindToggle`, "
+"`stateBindTextNumeric`, `stateBindVisibility`."
+msgstr ""
+
+#: src/ui/state.md:64
+msgid "onChange Callbacks"
+msgstr ""
+
+#: src/ui/state.md:66
+msgid "Listen for state changes with the free-function `stateOnChange`:"
+msgstr ""
+
+#: src/ui/state.md:75 src/widgets/components.md:92 src/widgets/platforms.md:27
+msgid "ForEach"
+msgstr ""
+
+#: src/ui/state.md:77
+msgid "Render a list from numeric state (the index count):"
+msgstr ""
+
+#: src/ui/state.md:79
+msgid ""
+"```typescript\n"
+"const fruits = State([\"Apple\", \"Banana\", \"Cherry\"])\n"
+"const fruitCount = State(3)\n"
+"\n"
+"const fruitList = VStack(16, [\n"
+"    ForEach(fruitCount, (i: number) =>\n"
+"        Text(`${i + 1}. ${fruits.value[i]}`),\n"
+"    ),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:90
+msgid ""
+"**Note:** `ForEach` iterates by index over a numeric state. Keep a count "
+"state in sync with your array, then read the items via `array.value[i]` "
+"inside the closure."
+msgstr ""
+
+#: src/ui/state.md:94
+msgid "`ForEach` re-renders the list when the count state changes:"
+msgstr ""
+
+#: src/ui/state.md:96
+msgid ""
+"```typescript\n"
+"// Add an item:\n"
+"fruits.set([...fruits.value, \"Date\"])\n"
+"fruitCount.set(fruitCount.value + 1)\n"
+"\n"
+"// Remove an item:\n"
+"fruits.set(fruits.value.filter((_, i) => i !== 1))\n"
+"fruitCount.set(fruitCount.value - 1)\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:106
+msgid "Conditional Rendering"
+msgstr ""
+
+#: src/ui/state.md:108
+msgid "Use state to conditionally show widgets:"
+msgstr ""
+
+#: src/ui/state.md:110
+msgid ""
+"```typescript\n"
+"const showDetails = State(false)\n"
+"const detailsLabel: number = showDetails.value\n"
+"    ? Text(\"Details are visible!\")\n"
+"    : Spacer()\n"
+"const detailsPanel = VStack(16, [\n"
+"    Button(\"Toggle\", () => showDetails.set(!showDetails.value)),\n"
+"    detailsLabel,\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:121
+msgid "Multi-State Text"
+msgstr ""
+
+#: src/ui/state.md:123
+msgid "Text can depend on multiple state values:"
+msgstr ""
+
+#: src/ui/state.md:125
+msgid ""
+"```typescript\n"
+"const firstName = State(\"John\")\n"
+"const lastName = State(\"Doe\")\n"
+"\n"
+"const greeting = Text(`Hello, ${firstName.value} ${lastName.value}!`)\n"
+"// Updates when either firstName or lastName changes.\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:133
+msgid "State with Objects and Arrays"
+msgstr ""
+
+#: src/ui/state.md:135
+msgid ""
+"```typescript\n"
+"const user = State({ name: \"Perry\", age: 0 })\n"
+"\n"
+"// Update by replacing the whole object:\n"
+"user.set({ ...user.value, age: 1 })\n"
+"\n"
+"const todos = State<{ text: string; done: boolean }[]>([])\n"
+"\n"
+"// Add a todo:\n"
+"todos.set([...todos.value, { text: \"New task\", done: false }])\n"
+"\n"
+"// Toggle a todo (must produce a new array reference):\n"
+"const next = todos.value.slice()\n"
+"if (next.length > 0) {\n"
+"    next[0] = { ...next[0], done: !next[0].done }\n"
+"    todos.set(next)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:154
+msgid ""
+"**Note**: State uses identity comparison. You must create a new array/object"
+" reference for changes to be detected. Mutating in-place without calling "
+"`.set()` with a new reference won't trigger updates."
+msgstr ""
+
+#: src/ui/state.md:158 src/ui/events.md:113 src/ui/table.md:73
+#: src/widgets/components.md:225
+msgid "Complete Example"
+msgstr ""
+
+#: src/ui/state.md:221
+msgid ""
+"This program is built and run by CI (`scripts/run_doc_tests.sh`), so the "
+"snippet above always matches the compiled artifact under "
+"[`docs/examples/ui/state/todo_app.ts`](../../examples/ui/state/todo_app.ts)."
+msgstr ""
+
+#: src/ui/state.md:227
+msgid "[Events](events.md) — Click, hover, keyboard events"
+msgstr ""
+
+#: src/ui/events.md:3
+msgid ""
+"Perry widgets support native event handlers for user interaction. Every "
+"snippet below is excerpted from "
+"[`docs/examples/ui/events/snippets.ts`](../../examples/ui/events/snippets.ts)"
+" — CI compiles and runs it on every PR, so the API drawn here is the API the"
+" runtime exposes."
+msgstr ""
+
+#: src/ui/events.md:9
+msgid ""
+"Event handlers are registered as **free functions** that take the widget "
+"handle as the first argument. The widget handle itself is opaque (`number` "
+"at the type level); perry's API is function-first throughout."
+msgstr ""
+
+#: src/ui/events.md:13 src/testing/geisterhand.md:100
+msgid "onClick"
+msgstr ""
+
+#: src/ui/events.md:15
+msgid ""
+"```typescript\n"
+"const greet = Button(\"Click me\", () => {\n"
+"    log.set(\"Button clicked\")\n"
+"})\n"
+"\n"
+"// Or attach a click handler to a non-button widget after creation:\n"
+"const label = Text(\"Clickable text\")\n"
+"widgetSetOnClick(label, () => {\n"
+"    log.set(\"Text clicked\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:27 src/testing/geisterhand.md:103
+msgid "onHover"
+msgstr ""
+
+#: src/ui/events.md:29
+msgid "Triggered when the cursor enters the widget."
+msgstr ""
+
+#: src/ui/events.md:31
+msgid ""
+"```typescript\n"
+"const hoverBtn = Button(\"Hover me\", () => {})\n"
+"widgetSetOnHover(hoverBtn, () => {\n"
+"    log.set(\"hovered\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:38
+msgid ""
+"**Note**: Hover events are available on macOS, Windows, Linux, and Web. iOS "
+"and Android use touch interactions instead. The callback fires once on "
+"enter; if you need a \"left\" event you'll have to track it yourself."
+msgstr ""
+
+#: src/ui/events.md:42 src/testing/geisterhand.md:104
+msgid "onDoubleClick"
+msgstr ""
+
+#: src/ui/events.md:44
+msgid ""
+"```typescript\n"
+"const dbl = Text(\"Double-click me\")\n"
+"widgetSetOnDoubleClick(dbl, () => {\n"
+"    log.set(\"double-clicked!\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:51 src/ui/menus.md:64
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: src/ui/events.md:53
+msgid "Register in-app keyboard shortcuts (active when the app is focused):"
+msgstr ""
+
+#: src/ui/events.md:55
+msgid ""
+"```typescript\n"
+"// Cmd+N on macOS, Ctrl+N on other platforms (modifier 1 = Cmd/Ctrl).\n"
+"addKeyboardShortcut(\"n\", 1, () => {\n"
+"    log.set(\"New document\")\n"
+"})\n"
+"\n"
+"// Cmd+Shift+S — modifiers add: 1 (Cmd/Ctrl) + 2 (Shift) = 3.\n"
+"addKeyboardShortcut(\"s\", 3, () => {\n"
+"    log.set(\"Save as...\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:67
+msgid ""
+"**Modifier bits:** `1` = Cmd (macOS) / Ctrl (Windows/Linux), `2` = Shift, "
+"`4` = Option (macOS) / Alt (others), `8` = Control (macOS only). Combine by "
+"adding — `3` = Cmd+Shift, `5` = Cmd+Option, etc."
+msgstr ""
+
+#: src/ui/events.md:71
+msgid "Keyboard shortcuts are also available on [menu items](menus.md):"
+msgstr ""
+
+#: src/ui/events.md:73
+msgid ""
+"```typescript\n"
+"const fileMenu = menuCreate()\n"
+"menuAddItem(fileMenu, \"New\", () => log.set(\"file/new\"))\n"
+"menuAddItem(fileMenu, \"Save As\", () => log.set(\"file/saveAs\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:79
+msgid "Global Hotkeys"
+msgstr ""
+
+#: src/ui/events.md:81
+msgid ""
+"Register a hotkey that fires system-wide, even when the app is in the "
+"background:"
+msgstr ""
+
+#: src/ui/events.md:84
+msgid ""
+"```typescript\n"
+"// System-wide: fires even when the app is in the background.\n"
+"// macOS: real Carbon RegisterEventHotKey. Other platforms: no-op.\n"
+"registerGlobalHotkey(\"F5\", 0, () => {\n"
+"    log.set(\"Global F5 hotkey fired\")\n"
+"})\n"
+"\n"
+"// Cmd+Shift+G (modifiers: 1=Cmd + 2=Shift = 3)\n"
+"registerGlobalHotkey(\"g\", 3, () => {\n"
+"    log.set(\"Global Cmd+Shift+G fired\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:97
+msgid ""
+"**Platform support:** macOS uses Carbon `RegisterEventHotKey` (real "
+"implementation). Linux, Windows, iOS, tvOS, visionOS, watchOS, and Android "
+"log the registration and no-op — global hotkeys on those platforms require "
+"OS-level portal / hook APIs that vary per OS."
+msgstr ""
+
+#: src/ui/events.md:102 src/system/other.md:44
+msgid "Clipboard"
+msgstr ""
+
+#: src/ui/events.md:104 src/system/other.md:48
+msgid ""
+"```typescript\n"
+"// Copy to clipboard\n"
+"clipboardWrite(\"Hello, clipboard!\")\n"
+"\n"
+"// Read from clipboard\n"
+"const text = clipboardRead()\n"
+"log.set(`clipboard length: ${text.length}`)\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:115
+msgid ""
+"```typescript\n"
+"// demonstrates: click + hover + double-click + keyboard shortcut all wired to\n"
+"// a single State-backed status label\n"
+"// docs: docs/src/ui/events.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    VStack,\n"
+"    State,\n"
+"    Spacer,\n"
+"    addKeyboardShortcut,\n"
+"    widgetSetOnHover,\n"
+"    widgetSetOnDoubleClick,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const lastEvent = State(\"No events yet\")\n"
+"\n"
+"// Cmd+R (modifiers: 1 = Cmd/Ctrl).\n"
+"addKeyboardShortcut(\"r\", 1, () => {\n"
+"    lastEvent.set(\"Keyboard: Cmd+R\")\n"
+"})\n"
+"\n"
+"const hoverBtn = Button(\"Hover me\", () => {})\n"
+"widgetSetOnHover(hoverBtn, () => {\n"
+"    lastEvent.set(\"Hover fired\")\n"
+"})\n"
+"\n"
+"const dblLabel = Text(\"Double-click me\")\n"
+"widgetSetOnDoubleClick(dblLabel, () => {\n"
+"    lastEvent.set(\"Double-clicked!\")\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Events Demo\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Last event: ${lastEvent.value}`),\n"
+"        Spacer(),\n"
+"        Button(\"Click me\", () => {\n"
+"            lastEvent.set(\"Button clicked\")\n"
+"        }),\n"
+"        hoverBtn,\n"
+"        dblLabel,\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:169
+msgid "[Menus](menus.md) — Menu bar and context menus with keyboard shortcuts"
+msgstr ""
+
+#: src/ui/events.md:171
+msgid "[State Management](state.md) — Reactive state"
+msgstr ""
+
+#: src/ui/canvas.md:3
+msgid "The `Canvas` widget provides a 2D drawing surface for custom graphics."
+msgstr ""
+
+#: src/ui/canvas.md:5
+msgid ""
+"**Availability**: `Canvas` is wired in the **LLVM** codegen path (macOS, "
+"iOS, Linux, Android) and the **JS / web / wasm** codegen path. Closed via "
+"[\\#190](https://github.com/PerryTS/perry/issues/190). The snippets below "
+"are compile-link verified by the doc-tests harness against "
+"[`docs/examples/ui/canvas/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/ui/canvas/snippets.ts);"
+" see that file for the full standalone program."
+msgstr ""
+
+#: src/ui/canvas.md:12
+msgid ""
+"The drawing API is **method-based** on the canvas handle (matching the FFI "
+"shape — `perry_ui_canvas_set_fill_color(handle, r, g, b, a)` etc.). Colors "
+"are RGBA floats in `[0.0, 1.0]`."
+msgstr ""
+
+#: src/ui/canvas.md:16
+msgid "Creating a Canvas"
+msgstr ""
+
+#: src/ui/canvas.md:24
+msgid ""
+"`Canvas(width, height)` creates a canvas widget; subsequent draw operations "
+"are method calls on the returned handle."
+msgstr ""
+
+#: src/ui/canvas.md:27
+msgid "Drawing Shapes"
+msgstr ""
+
+#: src/ui/canvas.md:29
+msgid "Rectangles"
+msgstr ""
+
+#: src/ui/canvas.md:31
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(1.0, 0.0, 0.0, 1.0)    // red\n"
+"canvas.fillRect(10, 10, 100, 80)\n"
+"\n"
+"canvas.setStrokeColor(0.0, 0.0, 1.0, 1.0)  // blue\n"
+"canvas.setLineWidth(2)\n"
+"canvas.strokeRect(150, 10, 100, 80)\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:40
+msgid "Lines"
+msgstr ""
+
+#: src/ui/canvas.md:51
+msgid "Circles and Arcs"
+msgstr ""
+
+#: src/ui/canvas.md:53
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(0.0, 1.0, 0.0, 1.0)\n"
+"canvas.beginPath()\n"
+"canvas.arc(200, 150, 50, 0, Math.PI * 2)  // x, y, radius, startAngle, endAngle\n"
+"canvas.fill()\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:62
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(0.0, 0.0, 0.0, 1.0)\n"
+"canvas.setFont(\"16px sans-serif\")\n"
+"canvas.fillText(\"Hello Canvas!\", 50, 50)\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:68 src/ui/menus.md:107 src/ui/dialogs.md:106
+#: src/ui/animation.md:60 src/ui/multi-window.md:136
+msgid "Platform Notes"
+msgstr ""
+
+#: src/ui/canvas.md:70 src/ui/animation.md:62 src/ui/multi-window.md:70
+#: src/ui/multi-window.md:87 src/ui/multi-window.md:98
+#: src/ui/multi-window.md:114 src/ui/multi-window.md:130
+#: src/ui/multi-window.md:138 src/ui/camera.md:137 src/system/other.md:18
+msgid "Implementation"
+msgstr ""
+
+#: src/ui/canvas.md:70 src/platforms/overview.md:7 src/system/media.md:84
+#: src/testing/geisterhand.md:298
+msgid "Status"
+msgstr ""
+
+#: src/ui/canvas.md:72
+msgid "HTML5 Canvas"
+msgstr ""
+
+#: src/ui/canvas.md:73
+msgid "WASM"
+msgstr ""
+
+#: src/ui/canvas.md:73
+msgid "HTML5 Canvas via JS bridge"
+msgstr ""
+
+#: src/ui/canvas.md:74 src/ui/canvas.md:75
+msgid "Core Graphics (CGContext)"
+msgstr ""
+
+#: src/ui/canvas.md:76
+msgid "Cairo"
+msgstr ""
+
+#: src/ui/canvas.md:77 src/platforms/windows.md:52
+msgid "GDI"
+msgstr ""
+
+#: src/ui/canvas.md:77
+msgid "Planned"
+msgstr ""
+
+#: src/ui/canvas.md:78
+msgid "Canvas/Bitmap"
+msgstr ""
+
+#: src/ui/canvas.md:83
+msgid "[Animation](animation.md) — Animating widget properties"
+msgstr ""
+
+#: src/ui/canvas.md:84
+msgid "[Styling](styling.md) — Widget styling"
+msgstr ""
+
+#: src/ui/menus.md:3
+msgid ""
+"Perry supports native menu bars, context menus, and toolbars across all "
+"platforms. Every snippet below is excerpted from "
+"[`docs/examples/ui/menus/snippets.ts`](../../examples/ui/menus/snippets.ts) "
+"— CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/menus.md:8
+msgid ""
+"The menu API is **handle-based** and free-function: build menus with "
+"`menuCreate()`, fill them with `menuAddItem` / `menuAddItemWithShortcut`, "
+"and attach them with `menuBarAddMenu(bar, title, menu)`. Submenus go through"
+" `menuAddSubmenu(parent, title, submenu)`."
+msgstr ""
+
+#: src/ui/menus.md:13 src/ui/menus.md:109
+msgid "Menu Bar"
+msgstr ""
+
+#: src/ui/menus.md:15
+msgid ""
+"```typescript\n"
+"// Menus are created independently, then attached. Build child menus first,\n"
+"// then hand them to `menuBarAddMenu(bar, title, menu)`.\n"
+"const menuBar = menuBarCreate()\n"
+"\n"
+"// File menu\n"
+"const fileMenu = menuCreate()\n"
+"menuAddItemWithShortcut(fileMenu, \"New\",         \"n\", () => status.set(\"file/new\"))\n"
+"menuAddItemWithShortcut(fileMenu, \"Open…\",       \"o\", () => status.set(\"file/open\"))\n"
+"menuAddSeparator(fileMenu)\n"
+"menuAddItemWithShortcut(fileMenu, \"Save\",        \"s\", () => status.set(\"file/save\"))\n"
+"menuAddItemWithShortcut(fileMenu, \"Save As…\",    \"S\", () => status.set(\"file/saveAs\"))\n"
+"menuBarAddMenu(menuBar, \"File\", fileMenu)\n"
+"\n"
+"// Edit menu\n"
+"const editMenu = menuCreate()\n"
+"menuAddItemWithShortcut(editMenu, \"Undo\", \"z\", () => status.set(\"edit/undo\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Redo\", \"Z\", () => status.set(\"edit/redo\"))\n"
+"menuAddSeparator(editMenu)\n"
+"menuAddItemWithShortcut(editMenu, \"Cut\",   \"x\", () => status.set(\"edit/cut\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Copy\",  \"c\", () => status.set(\"edit/copy\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Paste\", \"v\", () => status.set(\"edit/paste\"))\n"
+"menuBarAddMenu(menuBar, \"Edit\", editMenu)\n"
+"\n"
+"// Submenu: View → Zoom\n"
+"const viewMenu = menuCreate()\n"
+"const zoomSubmenu = menuCreate()\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Zoom In\",     \"+\", () => status.set(\"zoom/in\"))\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Zoom Out\",    \"-\", () => status.set(\"zoom/out\"))\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Actual Size\", \"0\", () => status.set(\"zoom/reset\"))\n"
+"menuAddSubmenu(viewMenu, \"Zoom\", zoomSubmenu)\n"
+"menuBarAddMenu(menuBar, \"View\", viewMenu)\n"
+"\n"
+"menuBarAttach(menuBar)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:51
+msgid "Menu Bar Functions"
+msgstr ""
+
+#: src/ui/menus.md:55
+msgid "`menuBarCreate()`"
+msgstr ""
+
+#: src/ui/menus.md:55
+msgid "Create a new (empty) menu bar"
+msgstr ""
+
+#: src/ui/menus.md:56
+msgid "`menuCreate()`"
+msgstr ""
+
+#: src/ui/menus.md:56
+msgid "Create a new menu — used as a child of the bar or as a submenu"
+msgstr ""
+
+#: src/ui/menus.md:57
+msgid "`menuBarAddMenu(bar, title, menu)`"
+msgstr ""
+
+#: src/ui/menus.md:57
+msgid "Attach a top-level menu under `title`"
+msgstr ""
+
+#: src/ui/menus.md:58
+msgid "`menuAddItem(menu, label, callback)`"
+msgstr ""
+
+#: src/ui/menus.md:58
+msgid "Append an item without a shortcut"
+msgstr ""
+
+#: src/ui/menus.md:59
+msgid "`menuAddItemWithShortcut(menu, label, shortcut, callback)`"
+msgstr ""
+
+#: src/ui/menus.md:59
+msgid "Append an item with a keyboard shortcut"
+msgstr ""
+
+#: src/ui/menus.md:60
+msgid "`menuAddSeparator(menu)`"
+msgstr ""
+
+#: src/ui/menus.md:60
+msgid "Append a horizontal separator line"
+msgstr ""
+
+#: src/ui/menus.md:61
+msgid "`menuAddSubmenu(parent, title, submenu)`"
+msgstr ""
+
+#: src/ui/menus.md:61
+msgid "Nest a previously-created menu under a label"
+msgstr ""
+
+#: src/ui/menus.md:62
+msgid "`menuBarAttach(bar)`"
+msgstr ""
+
+#: src/ui/menus.md:62
+msgid "Install the bar as the application's main menu"
+msgstr ""
+
+#: src/ui/menus.md:66
+msgid "The third argument to `menuAddItemWithShortcut` is the shortcut key:"
+msgstr ""
+
+#: src/ui/menus.md:68 src/testing/geisterhand.md:92
+#: src/testing/geisterhand.md:295
+msgid "Shortcut"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "`\"n\"`"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "Cmd+N"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "Ctrl+N"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "`\"S\"`"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "Cmd+Shift+S"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "Ctrl+Shift+S"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "`\"+\"`"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "Cmd++"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "Ctrl++"
+msgstr ""
+
+#: src/ui/menus.md:74
+msgid "Uppercase letters imply Shift."
+msgstr ""
+
+#: src/ui/menus.md:76
+msgid "Context Menus"
+msgstr ""
+
+#: src/ui/menus.md:78
+msgid ""
+"Right-click menus are attached to widgets via `widgetSetContextMenu(widget, "
+"menu)`. Build the menu the same way as a menu-bar entry, then bind it:"
+msgstr ""
+
+#: src/ui/menus.md:81
+msgid ""
+"```typescript\n"
+"const label = Text(\"Right-click me\")\n"
+"const ctx = menuCreate()\n"
+"menuAddItem(ctx, \"Copy\",   () => status.set(\"ctx/copy\"))\n"
+"menuAddItem(ctx, \"Paste\",  () => status.set(\"ctx/paste\"))\n"
+"menuAddSeparator(ctx)\n"
+"menuAddItem(ctx, \"Delete\", () => status.set(\"ctx/delete\"))\n"
+"widgetSetContextMenu(label, ctx)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:91 src/ui/menus.md:109
+msgid "Toolbar"
+msgstr ""
+
+#: src/ui/menus.md:93
+msgid ""
+"Add a toolbar to a window. `toolbarAddItem` takes an _identifier_ (used by "
+"AppKit to deduplicate items) and a _label_:"
+msgstr ""
+
+#: src/ui/menus.md:96
+msgid ""
+"```typescript\n"
+"const toolbar = toolbarCreate()\n"
+"toolbarAddItem(toolbar, \"new\",  \"New\",  () => status.set(\"tb/new\"))\n"
+"toolbarAddItem(toolbar, \"save\", \"Save\", () => status.set(\"tb/save\"))\n"
+"toolbarAddItem(toolbar, \"run\",  \"Run\",  () => status.set(\"tb/run\"))\n"
+"\n"
+"// `toolbarAttach(toolbar, window)` mounts onto a specific window.\n"
+"const win = Window(\"Toolbar Demo\", 800, 600)\n"
+"toolbarAttach(toolbar, win as unknown as number)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:109
+msgid "Context Menu"
+msgstr ""
+
+#: src/ui/menus.md:111
+msgid "NSToolbar"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "— (no menu bar)"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "UIMenu"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "UIToolbar"
+msgstr ""
+
+#: src/ui/menus.md:113
+msgid "HMENU/SetMenu"
+msgstr ""
+
+#: src/ui/menus.md:113
+msgid "Horizontal layout"
+msgstr ""
+
+#: src/ui/menus.md:114
+msgid "GMenu/set_menubar"
+msgstr ""
+
+#: src/ui/menus.md:114
+msgid "HeaderBar"
+msgstr ""
+
+#: src/ui/menus.md:117
+msgid ""
+"**iOS**: Menu bars are not applicable. Use toolbar and navigation patterns "
+"instead."
+msgstr ""
+
+#: src/ui/menus.md:121
+msgid "[Events](events.md) — Keyboard shortcuts and interactions"
+msgstr ""
+
+#: src/ui/menus.md:122
+msgid "[Dialogs](dialogs.md) — File dialogs and alerts"
+msgstr ""
+
+#: src/ui/menus.md:123
+msgid "[Layout](layout.md) — Toolbar and navigation patterns"
+msgstr ""
+
+#: src/ui/dialogs.md:3
+msgid ""
+"Perry provides native dialog functions for file selection, alerts, and "
+"sheets. Every snippet below is excerpted from "
+"[`docs/examples/ui/dialogs/snippets.ts`](../../examples/ui/dialogs/snippets.ts)"
+" — CI compiles and links the file on every PR, so the API drawn here is the "
+"API the runtime exposes."
+msgstr ""
+
+#: src/ui/dialogs.md:9
+msgid ""
+"All file dialogs are **callback-based** (the OS-modal panel is non-blocking "
+"on Apple platforms, so a synchronous return wouldn't be possible without "
+"freezing the app's run loop). The callback receives an empty string when the"
+" user cancels."
+msgstr ""
+
+#: src/ui/dialogs.md:14
+msgid "File Open Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:16
+msgid ""
+"```typescript\n"
+"function pickFile(): void {\n"
+"    openFileDialog((path: string) => {\n"
+"        if (path.length > 0) {\n"
+"            console.log(`Selected: ${path}`)\n"
+"        } else {\n"
+"            console.log(\"Open dialog cancelled\")\n"
+"        }\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:28
+msgid "Folder Selection Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:40
+msgid "Save File Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:42
+msgid ""
+"```typescript\n"
+"function pickSaveTarget(): void {\n"
+"    saveFileDialog((path: string) => {\n"
+"        if (path.length > 0) {\n"
+"            console.log(`Will save to: ${path}`)\n"
+"        }\n"
+"    }, \"untitled\", \"txt\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:52
+msgid ""
+"`saveFileDialog(callback, defaultName, extension)` pre-fills the name field "
+"with `defaultName.<extension>`."
+msgstr ""
+
+#: src/ui/dialogs.md:55 src/ui/dialogs.md:113
+msgid "Alert"
+msgstr ""
+
+#: src/ui/dialogs.md:57
+msgid "Display a native alert dialog:"
+msgstr ""
+
+#: src/ui/dialogs.md:59
+msgid ""
+"```typescript\n"
+"function showSimpleAlert(): void {\n"
+"    alert(\"Operation Complete\", \"Your file has been saved successfully.\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:65
+msgid "`alert(title, message)` shows a modal alert with an OK button."
+msgstr ""
+
+#: src/ui/dialogs.md:67
+msgid "Alert with Buttons"
+msgstr ""
+
+#: src/ui/dialogs.md:69
+msgid ""
+"```typescript\n"
+"function confirmDelete(): void {\n"
+"    alertWithButtons(\n"
+"        \"Delete Item?\",\n"
+"        \"This action cannot be undone.\",\n"
+"        [\"Cancel\", \"Delete\"],\n"
+"        (index: number) => {\n"
+"            if (index === 1) {\n"
+"                console.log(\"user confirmed delete\")\n"
+"            }\n"
+"        },\n"
+"    )\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:84
+msgid ""
+"`alertWithButtons(title, message, buttons, callback)` invokes the callback "
+"with the 0-based index of the button the user clicked. By convention put a "
+"destructive label last and check the index in the callback."
+msgstr ""
+
+#: src/ui/dialogs.md:88
+msgid "Sheets"
+msgstr ""
+
+#: src/ui/dialogs.md:90
+msgid ""
+"Sheets are modal panels attached to a window. Build the body, hand it (with "
+"a size) to `sheetCreate`, then `sheetPresent` it. To dismiss "
+"programmatically, keep the handle around and call `sheetDismiss(handle)`:"
+msgstr ""
+
+#: src/ui/dialogs.md:94
+msgid ""
+"```typescript\n"
+"function showSheet(): void {\n"
+"    let sheet = 0\n"
+"    const body = VStack(16, [\n"
+"        Text(\"Sheet Content\"),\n"
+"        Button(\"Close\", () => sheetDismiss(sheet)),\n"
+"    ])\n"
+"    sheet = sheetCreate(body, 320, 200)\n"
+"    sheetPresent(sheet)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:108
+msgid "Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "File Open"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:112
+msgid "NSOpenPanel"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "UIDocumentPicker"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:112
+msgid "IFileOpenDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:111 src/ui/dialogs.md:112
+msgid "GtkFileChooserDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "`<input type=\"file\">`"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "File Save"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "NSSavePanel"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "IFileSaveDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "Download link"
+msgstr ""
+
+#: src/ui/dialogs.md:112
+msgid "Folder"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "NSAlert"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "UIAlertController"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "MessageBoxW"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "MessageDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "`alert()`"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Sheet"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "NSSheet"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal VC"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal Window"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal div"
+msgstr ""
+
+#: src/ui/dialogs.md:116
+msgid "Complete Example: minimal text editor"
+msgstr ""
+
+#: src/ui/dialogs.md:118
+msgid ""
+"A real program that wires `openFileDialog` and `saveFileDialog` into a "
+"state-bound `TextField`:"
+msgstr ""
+
+#: src/ui/dialogs.md:121
+msgid ""
+"```typescript\n"
+"// demonstrates: file-open / save dialogs wired to a tiny text editor\n"
+"// docs: docs/src/ui/dialogs.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack, HStack,\n"
+"    Text, Button, TextField,\n"
+"    State,\n"
+"    openFileDialog, saveFileDialog, alert,\n"
+"} from \"perry/ui\"\n"
+"import { readFileSync, writeFileSync } from \"fs\"\n"
+"\n"
+"const content = State(\"\")\n"
+"const filePath = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"Text Editor\",\n"
+"    width: 800,\n"
+"    height: 600,\n"
+"    body: VStack(12, [\n"
+"        HStack(8, [\n"
+"            Button(\"Open\", () => {\n"
+"                openFileDialog((path: string) => {\n"
+"                    if (path.length === 0) return\n"
+"                    filePath.set(path)\n"
+"                    content.set(readFileSync(path, \"utf-8\") as string)\n"
+"                })\n"
+"            }),\n"
+"            Button(\"Save As\", () => {\n"
+"                saveFileDialog((path: string) => {\n"
+"                    if (path.length === 0) return\n"
+"                    writeFileSync(path, content.value)\n"
+"                    filePath.set(path)\n"
+"                    alert(\"Saved\", `File saved to ${path}`)\n"
+"                }, \"untitled\", \"txt\")\n"
+"            }),\n"
+"        ]),\n"
+"        Text(filePath.value === \"\" ? \"No file open\" : `File: ${filePath.value}`),\n"
+"        TextField(\"Start typing...\", (value: string) => content.set(value)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:168
+msgid "[Menus](menus.md) — Menu bar and context menus"
+msgstr ""
+
+#: src/ui/dialogs.md:169
+msgid "[Multi-Window](multi-window.md) — Multiple windows"
+msgstr ""
+
+#: src/ui/dialogs.md:170
+msgid "[Events](events.md) — User interaction events"
+msgstr ""
+
+#: src/ui/table.md:3
+msgid ""
+"The `Table` widget displays tabular data with columns, headers, and row "
+"selection."
+msgstr ""
+
+#: src/ui/table.md:6
+msgid ""
+"**Platform support:** real implementation lives on **macOS** (`NSTableView` "
+"+ `NSScrollView`); the **Web** target uses an HTML `<table>`. **iOS**, "
+"**Android**, **Linux/GTK4**, **Windows**, **tvOS**, **visionOS**, and "
+"**watchOS** link no-op stubs so cross-platform code compiles everywhere — "
+"the table renders nothing and `tableGetSelectedRow` returns `-1`. For "
+"production lists on platforms without a real impl, use `LazyVStack` (see "
+"[Layout](layout.md))."
+msgstr ""
+
+#: src/ui/table.md:14
+msgid "Creating a Table"
+msgstr ""
+
+#: src/ui/table.md:22
+msgid ""
+"`Table(rowCount, colCount, renderCell)` creates a table. The render callback"
+" receives `(row, col)` and must return a `Widget` (typically `Text(...)`). "
+"The runtime resolves the returned handle as the cell view, which lets cells "
+"render images, stacks, or composites — not just plain strings."
+msgstr ""
+
+#: src/ui/table.md:28
+msgid "Column Headers"
+msgstr ""
+
+#: src/ui/table.md:30
+msgid ""
+"```ts\n"
+"const userTable = Table(users.length, 3, (row: number, col: number) => {\n"
+"    const user = users[row]\n"
+"    if (col === 0) return Text(user.name)\n"
+"    if (col === 1) return Text(user.email)\n"
+"    return Text(user.role)\n"
+"})\n"
+"\n"
+"tableSetColumnHeader(userTable, 0, \"Name\")\n"
+"tableSetColumnHeader(userTable, 1, \"Email\")\n"
+"tableSetColumnHeader(userTable, 2, \"Role\")\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:43
+msgid "Column Widths"
+msgstr ""
+
+#: src/ui/table.md:45
+msgid ""
+"```ts\n"
+"tableSetColumnWidth(userTable, 0, 150)  // Name column\n"
+"tableSetColumnWidth(userTable, 1, 250)  // Email column\n"
+"tableSetColumnWidth(userTable, 2, 100)  // Role column\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:51
+msgid "Row Selection"
+msgstr ""
+
+#: src/ui/table.md:53
+msgid ""
+"```ts\n"
+"const selectedRow = State(-1)\n"
+"\n"
+"tableSetOnRowSelect(userTable, (row: number) => {\n"
+"    selectedRow.set(row)\n"
+"    console.log(`Selected row: ${row}`)\n"
+"})\n"
+"\n"
+"// Read the currently selected row at any time:\n"
+"const current = tableGetSelectedRow(userTable)\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:65
+msgid "Dynamic Row Count"
+msgstr ""
+
+#: src/ui/table.md:67
+msgid "Update the number of rows after creation:"
+msgstr ""
+
+#: src/ui/table.md:75
+msgid ""
+"```ts\n"
+"const selectedName = State(\"None\")\n"
+"\n"
+"const table = Table(users.length, 3, (row: number, col: number) => {\n"
+"    const user = users[row]\n"
+"    if (col === 0) return Text(user.name)\n"
+"    if (col === 1) return Text(user.email)\n"
+"    return Text(user.role)\n"
+"})\n"
+"\n"
+"tableSetColumnHeader(table, 0, \"Name\")\n"
+"tableSetColumnHeader(table, 1, \"Email\")\n"
+"tableSetColumnHeader(table, 2, \"Role\")\n"
+"tableSetColumnWidth(table, 0, 150)\n"
+"tableSetColumnWidth(table, 1, 250)\n"
+"tableSetColumnWidth(table, 2, 100)\n"
+"\n"
+"tableSetOnRowSelect(table, (row: number) => {\n"
+"    selectedName.set(users[row].name)\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Table Demo\",\n"
+"    width: 600,\n"
+"    height: 400,\n"
+"    body: VStack(12, [\n"
+"        table,\n"
+"        Text(`Selected: ${selectedName.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:111
+msgid "[Events](events.md) — Event handling"
+msgstr ""
+
+#: src/ui/animation.md:3
+msgid ""
+"Perry supports animating widget properties for smooth transitions. Every "
+"snippet below is excerpted from "
+"[`docs/examples/ui/animation/snippets.ts`](../../examples/ui/animation/snippets.ts)"
+" — CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/animation.md:8
+msgid ""
+"`animateOpacity` and `animatePosition` are special: they're documented as "
+"methods on the widget handle (the only methods perry/ui exposes), and the "
+"HIR lowers them to `widgetAnimateOpacity` / `widgetAnimatePosition` calls "
+"under the hood."
+msgstr ""
+
+#: src/ui/animation.md:13
+msgid "Opacity Animation"
+msgstr ""
+
+#: src/ui/animation.md:15
+msgid ""
+"```typescript\n"
+"const fading = Text(\"Fading text\")\n"
+"// Animate from the widget's current opacity to `target` over `durationSecs`.\n"
+"fading.animateOpacity(1.0, 0.3) // target, durationSeconds\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:21
+msgid "Position Animation"
+msgstr ""
+
+#: src/ui/animation.md:23
+msgid ""
+"```typescript\n"
+"const moving = Button(\"Moving\", () => {})\n"
+"// Animate by a delta (dx, dy) relative to the widget's current position.\n"
+"moving.animatePosition(100, 200, 0.5) // dx, dy, durationSeconds\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:29
+msgid "Example: Fade-In Effect"
+msgstr ""
+
+#: src/ui/animation.md:31
+msgid ""
+"When the first argument reads from a `State.value`, Perry auto-subscribes "
+"the call to the state — toggling `visible` re-runs the animation."
+msgstr ""
+
+#: src/ui/animation.md:34
+msgid ""
+"```typescript\n"
+"// demonstrates: auto-reactive animateOpacity driven by a State toggle\n"
+"// docs: docs/src/ui/animation.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"\n"
+"import { App, Text, Button, VStack, State } from \"perry/ui\"\n"
+"\n"
+"const visible = State(false)\n"
+"\n"
+"const label = Text(\"Hello!\")\n"
+"label.animateOpacity(visible.value ? 1.0 : 0.0, 0.3)\n"
+"\n"
+"App({\n"
+"    title: \"Animation Demo\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Button(\"Toggle\", () => {\n"
+"            visible.set(!visible.value)\n"
+"        }),\n"
+"        label,\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:64
+msgid "NSAnimationContext / ViewPropertyAnimator"
+msgstr ""
+
+#: src/ui/animation.md:65
+msgid "UIView.animate"
+msgstr ""
+
+#: src/ui/animation.md:66
+msgid "ViewPropertyAnimator"
+msgstr ""
+
+#: src/ui/animation.md:67
+msgid "WM_TIMER-based animation"
+msgstr ""
+
+#: src/ui/animation.md:68
+msgid "CSS transitions (GTK4)"
+msgstr ""
+
+#: src/ui/animation.md:69
+msgid "CSS transitions"
+msgstr ""
+
+#: src/ui/animation.md:73
+msgid "[Styling](styling.md) — Widget styling properties"
+msgstr ""
+
+#: src/ui/animation.md:75
+msgid "[Events](events.md) — User interaction"
+msgstr ""
+
+#: src/ui/multi-window.md:1
+msgid "Multi-Window & Window Management"
+msgstr ""
+
+#: src/ui/multi-window.md:3
+msgid ""
+"Perry supports creating multiple native windows and controlling their "
+"appearance and behavior. Every snippet below is excerpted from "
+"[`docs/examples/ui/multi_window/snippets.ts`](../../examples/ui/multi_window/snippets.ts)"
+" — CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/multi-window.md:8
+msgid "Creating Windows"
+msgstr ""
+
+#: src/ui/multi-window.md:10
+msgid ""
+"`Window(title, width, height)` returns a window handle. Call `.setBody()` to"
+" set its content and `.show()` to display it:"
+msgstr ""
+
+#: src/ui/multi-window.md:13
+msgid ""
+"```typescript\n"
+"const settings = Window(\"Settings\", 500, 400)\n"
+"settings.setBody(VStack(16, [\n"
+"    Text(\"Settings panel\"),\n"
+"]))\n"
+"settings.show()\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:21
+msgid "Window Instance Methods"
+msgstr ""
+
+#: src/ui/multi-window.md:23
+msgid ""
+"```typescript\n"
+"const win = Window(\"My Window\", 600, 400)\n"
+"\n"
+"win.setBody(Text(\"Hello\"))   // Set the root widget\n"
+"win.show()                    // Show the window\n"
+"win.hide()                    // Hide without destroying\n"
+"win.setSize(800, 600)         // Resize dynamically\n"
+"win.onFocusLost(() => {       // Callback when the window loses focus\n"
+"    win.hide()\n"
+"})\n"
+"win.close()                   // Close and destroy\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:36 src/i18n/overview.md:87
+#: src/testing/geisterhand.md:257
+msgid "Method"
+msgstr ""
+
+#: src/ui/multi-window.md:38
+msgid "`setBody(widget)`"
+msgstr ""
+
+#: src/ui/multi-window.md:38
+msgid "Set the root widget of the window"
+msgstr ""
+
+#: src/ui/multi-window.md:39
+msgid "`show()`"
+msgstr ""
+
+#: src/ui/multi-window.md:39
+msgid "Show the window"
+msgstr ""
+
+#: src/ui/multi-window.md:40
+msgid "`hide()`"
+msgstr ""
+
+#: src/ui/multi-window.md:40
+msgid "Hide without destroying — call `show()` again to reveal"
+msgstr ""
+
+#: src/ui/multi-window.md:41
+msgid "`setSize(w, h)`"
+msgstr ""
+
+#: src/ui/multi-window.md:41
+msgid "Resize dynamically"
+msgstr ""
+
+#: src/ui/multi-window.md:42
+msgid "`onFocusLost(cb)`"
+msgstr ""
+
+#: src/ui/multi-window.md:42
+msgid "Register a callback that fires when focus leaves the window"
+msgstr ""
+
+#: src/ui/multi-window.md:43
+msgid "`close()`"
+msgstr ""
+
+#: src/ui/multi-window.md:43
+msgid "Close and destroy"
+msgstr ""
+
+#: src/ui/multi-window.md:45
+msgid "App Window Properties"
+msgstr ""
+
+#: src/ui/multi-window.md:47
+msgid ""
+"The main `App({})` config object accepts the same window properties for "
+"building launcher-style, overlay, or utility apps:"
+msgstr ""
+
+#: src/ui/multi-window.md:50
+msgid ""
+"```typescript\n"
+"App({\n"
+"    title: \"QuickLaunch\",\n"
+"    width: 600,\n"
+"    height: 80,\n"
+"    body: VStack(8, [\n"
+"        Text(\"Search...\"),\n"
+"        Button(\"Open Settings\", () => settings.show()),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:62
+msgid ""
+"`App` additionally accepts the optional fields `frameless`, `level`, "
+"`transparent`, `vibrancy`, `activationPolicy`, and `icon`. They map to the "
+"following native primitives:"
+msgstr ""
+
+#: src/ui/multi-window.md:66
+msgid "`frameless: true`"
+msgstr ""
+
+#: src/ui/multi-window.md:68
+msgid "Removes the window title bar and frame, creating a borderless window."
+msgstr ""
+
+#: src/ui/multi-window.md:72
+msgid "`NSWindowStyleMask::Borderless` + movable by background"
+msgstr ""
+
+#: src/ui/multi-window.md:73
+msgid "`WS_POPUP` window style"
+msgstr ""
+
+#: src/ui/multi-window.md:74
+msgid "`set_decorated(false)`"
+msgstr ""
+
+#: src/ui/multi-window.md:76
+msgid "`level: \"floating\" | \"statusBar\" | \"modal\" | \"normal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:78
+msgid "Controls the window's z-order level relative to other windows."
+msgstr ""
+
+#: src/ui/multi-window.md:80
+msgid "Level"
+msgstr ""
+
+#: src/ui/multi-window.md:82
+msgid "`\"normal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:82
+msgid "Default window level"
+msgstr ""
+
+#: src/ui/multi-window.md:83
+msgid "`\"floating\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:83
+msgid "Stays above normal windows"
+msgstr ""
+
+#: src/ui/multi-window.md:84
+msgid "`\"statusBar\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:84
+msgid "Stays above floating windows"
+msgstr ""
+
+#: src/ui/multi-window.md:85
+msgid "`\"modal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:85
+msgid "Modal panel level"
+msgstr ""
+
+#: src/ui/multi-window.md:89
+msgid "`NSWindow.level` (NSFloatingWindowLevel, etc.)"
+msgstr ""
+
+#: src/ui/multi-window.md:90
+msgid "`SetWindowPos` with `HWND_TOPMOST`"
+msgstr ""
+
+#: src/ui/multi-window.md:91
+msgid "`set_modal(true)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:93
+msgid "`transparent: true`"
+msgstr ""
+
+#: src/ui/multi-window.md:95
+msgid ""
+"Makes the window background transparent, allowing the desktop to show "
+"through non-opaque regions of your UI."
+msgstr ""
+
+#: src/ui/multi-window.md:100
+msgid "`isOpaque = false`, `backgroundColor = .clear`"
+msgstr ""
+
+#: src/ui/multi-window.md:101
+msgid "`WS_EX_LAYERED` with `SetLayeredWindowAttributes`"
+msgstr ""
+
+#: src/ui/multi-window.md:102
+msgid "CSS `background-color: transparent`"
+msgstr ""
+
+#: src/ui/multi-window.md:104
+msgid "`vibrancy: string`"
+msgstr ""
+
+#: src/ui/multi-window.md:106
+msgid ""
+"Applies a native translucent material to the window background. On macOS "
+"this uses the system vibrancy effect; on Windows it uses Mica/Acrylic."
+msgstr ""
+
+#: src/ui/multi-window.md:109
+msgid ""
+"**macOS materials:** `\"sidebar\"`, `\"titlebar\"`, `\"selection\"`, "
+"`\"menu\"`, `\"popover\"`, `\"headerView\"`, `\"sheet\"`, "
+"`\"windowBackground\"`, `\"hudWindow\"`, `\"fullScreenUI\"`, `\"tooltip\"`, "
+"`\"contentBackground\"`, `\"underWindowBackground\"`, "
+"`\"underPageBackground\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:116
+msgid "`NSVisualEffectView` with the specified material"
+msgstr ""
+
+#: src/ui/multi-window.md:117
+msgid ""
+"`DwmSetWindowAttribute(DWMWA_SYSTEMBACKDROP_TYPE)` — Mica, Acrylic, or Mica "
+"Alt depending on material (Windows 11 22H2+)"
+msgstr ""
+
+#: src/ui/multi-window.md:118
+msgid "CSS `alpha(@window_bg_color, 0.85)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:120
+msgid "`activationPolicy: \"regular\" | \"accessory\" | \"background\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:122
+msgid "Controls whether the app appears in the dock/taskbar."
+msgstr ""
+
+#: src/ui/multi-window.md:124 src/widgets/data-fetching.md:125
+msgid "Policy"
+msgstr ""
+
+#: src/ui/multi-window.md:126
+msgid "`\"regular\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:126
+msgid "Normal app with dock icon and menu bar (default)"
+msgstr ""
+
+#: src/ui/multi-window.md:127
+msgid "`\"accessory\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:127
+msgid ""
+"No dock icon, no menu bar activation — ideal for launchers and utilities"
+msgstr ""
+
+#: src/ui/multi-window.md:128
+msgid "`\"background\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:128
+msgid "Fully hidden from dock and app switcher"
+msgstr ""
+
+#: src/ui/multi-window.md:132
+msgid "`NSApp.setActivationPolicy()`"
+msgstr ""
+
+#: src/ui/multi-window.md:133
+msgid "`WS_EX_TOOLWINDOW` (removes from taskbar)"
+msgstr ""
+
+#: src/ui/multi-window.md:134
+msgid "`set_deletable(false)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:140
+msgid "NSWindow"
+msgstr ""
+
+#: src/ui/multi-window.md:141
+msgid "CreateWindowEx (HWND)"
+msgstr ""
+
+#: src/ui/multi-window.md:142
+msgid "GtkWindow"
+msgstr ""
+
+#: src/ui/multi-window.md:143
+msgid "Floating `<div>`"
+msgstr ""
+
+#: src/ui/multi-window.md:144
+msgid "iOS/Android"
+msgstr ""
+
+#: src/ui/multi-window.md:144
+msgid "Modal view controller / Dialog"
+msgstr ""
+
+#: src/ui/multi-window.md:146
+msgid ""
+"On mobile platforms, \"windows\" are presented as modal views or dialogs "
+"since mobile apps typically use a single-window model."
+msgstr ""
+
+#: src/ui/multi-window.md:151
+msgid "[Events](events.md) — Keyboard shortcuts"
+msgstr ""
+
+#: src/ui/multi-window.md:152
+msgid "[Dialogs](dialogs.md) — Modal dialogs and sheets"
+msgstr ""
+
+#: src/ui/multi-window.md:153
+msgid "[Menus](menus.md) — Menu bar and toolbar"
+msgstr ""
+
+#: src/ui/multi-window.md:154
+msgid "[UI Overview](overview.md) — Full UI system overview"
+msgstr ""
+
+#: src/ui/theming.md:3
+msgid ""
+"The `perry-styling` package provides a design system bridge for Perry UI — "
+"design token codegen and ergonomic styling helpers with compile-time "
+"platform detection."
+msgstr ""
+
+#: src/ui/theming.md:11
+msgid "Design Token Codegen"
+msgstr ""
+
+#: src/ui/theming.md:13
+msgid "Generate typed theme files from a JSON token definition:"
+msgstr ""
+
+#: src/ui/theming.md:19
+msgid "Token Format"
+msgstr ""
+
+#: src/ui/theming.md:23
+msgid "\"colors\""
+msgstr ""
+
+#: src/ui/theming.md:24
+msgid "\"primary\""
+msgstr ""
+
+#: src/ui/theming.md:24
+msgid "\"#007AFF\""
+msgstr ""
+
+#: src/ui/theming.md:25
+msgid "\"primary-dark\""
+msgstr ""
+
+#: src/ui/theming.md:25
+msgid "\"#0A84FF\""
+msgstr ""
+
+#: src/ui/theming.md:27
+msgid "\"background-dark\""
+msgstr ""
+
+#: src/ui/theming.md:27
+msgid "\"#1C1C1E\""
+msgstr ""
+
+#: src/ui/theming.md:28 src/testing/geisterhand.md:465
+msgid "\"text\""
+msgstr ""
+
+#: src/ui/theming.md:28
+msgid "\"#000000\""
+msgstr ""
+
+#: src/ui/theming.md:29
+msgid "\"text-dark\""
+msgstr ""
+
+#: src/ui/theming.md:31
+msgid "\"spacing\""
+msgstr ""
+
+#: src/ui/theming.md:32 src/ui/theming.md:38
+msgid "\"sm\""
+msgstr ""
+
+#: src/ui/theming.md:33 src/ui/theming.md:39
+msgid "\"md\""
+msgstr ""
+
+#: src/ui/theming.md:34 src/ui/theming.md:40
+msgid "\"lg\""
+msgstr ""
+
+#: src/ui/theming.md:35
+msgid "\"xl\""
+msgstr ""
+
+#: src/ui/theming.md:37
+msgid "\"radius\""
+msgstr ""
+
+#: src/ui/theming.md:42
+msgid "\"fontSize\""
+msgstr ""
+
+#: src/ui/theming.md:43
+msgid "\"body\""
+msgstr ""
+
+#: src/ui/theming.md:44
+msgid "\"heading\""
+msgstr ""
+
+#: src/ui/theming.md:45
+msgid "\"caption\""
+msgstr ""
+
+#: src/ui/theming.md:47
+msgid "\"borderWidth\""
+msgstr ""
+
+#: src/ui/theming.md:48
+msgid "\"thin\""
+msgstr ""
+
+#: src/ui/theming.md:49
+msgid "\"medium\""
+msgstr ""
+
+#: src/ui/theming.md:54
+msgid ""
+"Colors with a `-dark` suffix are used as the dark mode variant. If no dark "
+"variant is provided, the light value is used for both modes. Supported color"
+" formats: hex (`#RGB`, `#RRGGBB`, `#RRGGBBAA`), `rgb()`/`rgba()`, "
+"`hsl()`/`hsla()`, and CSS named colors."
+msgstr ""
+
+#: src/ui/theming.md:56
+msgid "Generated Types"
+msgstr ""
+
+#: src/ui/theming.md:58
+msgid "The codegen produces typed interfaces:"
+msgstr ""
+
+#: src/ui/theming.md:60
+msgid ""
+"```text\n"
+"interface PerryColor {\n"
+"  r: number; g: number; b: number; a: number; // floats in [0, 1]\n"
+"}\n"
+"\n"
+"interface PerryTheme {\n"
+"  light: { [key: string]: PerryColor };\n"
+"  dark: { [key: string]: PerryColor };\n"
+"  spacing: { [key: string]: number };\n"
+"  radius: { [key: string]: number };\n"
+"  fontSize: { [key: string]: number };\n"
+"  borderWidth: { [key: string]: number };\n"
+"}\n"
+"\n"
+"interface ResolvedTheme {\n"
+"  colors: { [key: string]: PerryColor };\n"
+"  spacing: { [key: string]: number };\n"
+"  radius: { [key: string]: number };\n"
+"  fontSize: { [key: string]: number };\n"
+"  borderWidth: { [key: string]: number };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:83
+msgid "Theme Resolution"
+msgstr ""
+
+#: src/ui/theming.md:85
+msgid "Resolve a theme at runtime based on the system's dark mode setting:"
+msgstr ""
+
+#: src/ui/theming.md:87
+msgid ""
+"```text\n"
+"import { getTheme } from \"perry-styling\";\n"
+"import { theme } from \"./theme\"; // generated file\n"
+"\n"
+"const resolved = getTheme(theme);\n"
+"// resolved.colors.primary → the correct light/dark variant\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:95
+msgid ""
+"`getTheme()` calls `isDarkMode()` from `perry/system` and returns the "
+"appropriate palette."
+msgstr ""
+
+#: src/ui/theming.md:97
+msgid "Styling Helpers"
+msgstr ""
+
+#: src/ui/theming.md:99
+msgid ""
+"Ergonomic functions for applying styles to widget handles. Perry's compiler "
+"doesn't yet support passing `PerryColor` objects as parameters into user "
+"functions, so the helpers take **flat primitives**: extract the channels at "
+"the call site:"
+msgstr ""
+
+#: src/ui/theming.md:104
+msgid ""
+"```text\n"
+"import {\n"
+"  applyBg, applyRadius, applyTextColor, applyFontSize, applyGradient,\n"
+"} from \"perry-styling\";\n"
+"\n"
+"const t = resolved;                    // your ResolvedTheme\n"
+"const c = t.colors.text;               // a PerryColor\n"
+"const bg = t.colors.background;\n"
+"const start = t.colors.primary;\n"
+"const end = t.colors[\"primary-dark\"];\n"
+"\n"
+"const label = Text(\"Hello\");\n"
+"applyTextColor(label, c.r, c.g, c.b, c.a);\n"
+"applyFontSize(label, t.fontSize.heading);\n"
+"\n"
+"const card = VStack(16, []);\n"
+"applyBg(card, bg.r, bg.g, bg.b, bg.a);\n"
+"applyRadius(card, t.radius.md);\n"
+"applyGradient(card,\n"
+"  start.r, start.g, start.b, start.a,\n"
+"  end.r,   end.g,   end.b,   end.a,\n"
+"  0,                                   // 0 = vertical, 1 = horizontal\n"
+");\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:129
+msgid "Available Helpers"
+msgstr ""
+
+#: src/ui/theming.md:131
+msgid "Signature"
+msgstr ""
+
+#: src/ui/theming.md:133
+msgid "`applyBg(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:133
+msgid "Background color"
+msgstr ""
+
+#: src/ui/theming.md:134
+msgid "`applyRadius(handle, radius)`"
+msgstr ""
+
+#: src/ui/theming.md:134
+msgid "Corner radius"
+msgstr ""
+
+#: src/ui/theming.md:135
+msgid "`applyTextColor(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:135
+msgid "Text color"
+msgstr ""
+
+#: src/ui/theming.md:136
+msgid "`applyFontSize(handle, size)`"
+msgstr ""
+
+#: src/ui/theming.md:136
+msgid "Font size (regular weight)"
+msgstr ""
+
+#: src/ui/theming.md:137
+msgid "`applyFontBold(handle, size)`"
+msgstr ""
+
+#: src/ui/theming.md:137
+msgid "Font size with bold weight"
+msgstr ""
+
+#: src/ui/theming.md:138
+msgid "`applyFontFamily(handle, family)`"
+msgstr ""
+
+#: src/ui/theming.md:138
+msgid "Font family"
+msgstr ""
+
+#: src/ui/theming.md:139
+msgid "`applyWidth(handle, width)`"
+msgstr ""
+
+#: src/ui/theming.md:139
+msgid "Fixed width"
+msgstr ""
+
+#: src/ui/theming.md:140
+msgid "`applyTooltip(handle, text)`"
+msgstr ""
+
+#: src/ui/theming.md:140
+msgid "Tooltip (no-op on iOS/Android)"
+msgstr ""
+
+#: src/ui/theming.md:141
+msgid "`applyBorderColor(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:141
+msgid "Border color"
+msgstr ""
+
+#: src/ui/theming.md:142
+msgid "`applyBorderWidth(handle, width)`"
+msgstr ""
+
+#: src/ui/theming.md:142
+msgid "Border width"
+msgstr ""
+
+#: src/ui/theming.md:143
+msgid "`applyEdgeInsets(handle, top, left, bottom, right)`"
+msgstr ""
+
+#: src/ui/theming.md:143
+msgid "Edge insets (padding)"
+msgstr ""
+
+#: src/ui/theming.md:144
+msgid "`applyOpacity(handle, alpha)`"
+msgstr ""
+
+#: src/ui/theming.md:145
+msgid "`applyGradient(handle, r1, g1, b1, a1, r2, g2, b2, a2, direction)`"
+msgstr ""
+
+#: src/ui/theming.md:145
+msgid "Background gradient"
+msgstr ""
+
+#: src/ui/theming.md:146
+msgid "`applyButtonBg(btn, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:146
+msgid "Button background"
+msgstr ""
+
+#: src/ui/theming.md:147
+msgid "`applyButtonTextColor(btn, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:147
+msgid "Button text color"
+msgstr ""
+
+#: src/ui/theming.md:148
+msgid "`applyButtonBordered(btn, bordered)`"
+msgstr ""
+
+#: src/ui/theming.md:148
+msgid "Bordered button style (`true`/`false`)"
+msgstr ""
+
+#: src/ui/theming.md:150
+msgid "Platform Constants"
+msgstr ""
+
+#: src/ui/theming.md:152
+msgid ""
+"`perry-styling` exports compile-time platform constants based on the "
+"`__platform__` built-in:"
+msgstr ""
+
+#: src/ui/theming.md:154
+msgid ""
+"```text\n"
+"import { isMac, isIOS, isAndroid, isWindows, isLinux, isDesktop, isMobile } from \"perry-styling\";\n"
+"\n"
+"if (isMobile) {\n"
+"  applyFontSize(label, 16);\n"
+"} else {\n"
+"  applyFontSize(label, 14);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:164
+msgid ""
+"These are constant-folded by LLVM at compile time — dead branches are "
+"eliminated with zero runtime cost."
+msgstr ""
+
+#: src/ui/theming.md:168
+msgid "[Styling](styling.md) — Widget styling basics"
+msgstr ""
+
+#: src/ui/camera.md:3
+msgid ""
+"The `perry/ui` module provides a live camera preview widget with color "
+"sampling capabilities."
+msgstr ""
+
+#: src/ui/camera.md:6
+msgid ""
+"```ts\n"
+"import {\n"
+"    CameraView,\n"
+"    cameraStart, cameraStop,\n"
+"    cameraFreeze, cameraUnfreeze,\n"
+"    cameraSampleColor, cameraSetOnTap,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:15
+msgid ""
+"**Platform support:** real capture is implemented on **iOS** "
+"(AVCaptureSession) and **Android** (Camera2). On **macOS**, **Linux** "
+"(GTK4), **Windows**, and the **Web** target the runtime exports no-op stubs "
+"so cross-platform code compiles and links cleanly — `CameraView()` returns "
+"handle 0 and `cameraSampleColor` returns `-1`. Wiring real capture on those "
+"platforms (AVFoundation on macOS, GStreamer/V4L2 on Linux, Media Foundation "
+"on Windows, `getUserMedia` on Web) is tracked as a follow-up."
+msgstr ""
+
+#: src/ui/camera.md:24 src/system/overview.md:43 src/plugins/overview.md:25
+msgid "Quick Example"
+msgstr ""
+
+#: src/ui/camera.md:26
+msgid ""
+"```ts\n"
+"const colorHex = State(\"#000000\")\n"
+"\n"
+"const cam = CameraView()\n"
+"cameraStart(cam)\n"
+"\n"
+"cameraSetOnTap(cam, (x: number, y: number) => {\n"
+"    const rgb = cameraSampleColor(x, y)\n"
+"    if (rgb >= 0) {\n"
+"        const r = Math.floor(rgb / 65536)\n"
+"        const g = Math.floor((rgb % 65536) / 256)\n"
+"        const b = Math.floor(rgb % 256)\n"
+"        colorHex.set(`#${r.toString(16).padStart(2, \"0\")}${g.toString(16).padStart(2, \"0\")}${b.toString(16).padStart(2, \"0\")}`)\n"
+"    }\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Color Picker\",\n"
+"    width: 400,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        cam,\n"
+"        Text(`Color: ${colorHex.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:53 src/system/audio.md:21 src/testing/geisterhand.md:45
+msgid "API Reference"
+msgstr ""
+
+#: src/ui/camera.md:55
+msgid "`CameraView()`"
+msgstr ""
+
+#: src/ui/camera.md:57
+msgid "Create a live camera preview widget."
+msgstr ""
+
+#: src/ui/camera.md:63
+msgid ""
+"Returns a widget handle. The camera does not start automatically — call "
+"`cameraStart()` to begin capture."
+msgstr ""
+
+#: src/ui/camera.md:65
+msgid "`cameraStart(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:67
+msgid "Start the live camera feed."
+msgstr ""
+
+#: src/ui/camera.md:73
+msgid ""
+"On iOS, the camera permission dialog is shown automatically on first use."
+msgstr ""
+
+#: src/ui/camera.md:75
+msgid "`cameraStop(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:77
+msgid "Stop the camera feed and release the capture session."
+msgstr ""
+
+#: src/ui/camera.md:83
+msgid "`cameraFreeze(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:85
+msgid "Pause the live preview (freeze the current frame)."
+msgstr ""
+
+#: src/ui/camera.md:91
+msgid ""
+"The camera session remains active but the preview stops updating. Useful for"
+" \"capture\" moments where you want to inspect the frozen frame."
+msgstr ""
+
+#: src/ui/camera.md:93
+msgid "`cameraUnfreeze(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:95
+msgid "Resume the live preview after a freeze."
+msgstr ""
+
+#: src/ui/camera.md:101
+msgid "`cameraSampleColor(x, y)`"
+msgstr ""
+
+#: src/ui/camera.md:103
+msgid "Sample the pixel color at normalized coordinates."
+msgstr ""
+
+#: src/ui/camera.md:105
+msgid ""
+"```ts\n"
+"const rgb = cameraSampleColor(0.5, 0.5) // center of frame\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:109
+msgid "`x`, `y` are normalized coordinates (0.0–1.0)"
+msgstr ""
+
+#: src/ui/camera.md:110
+msgid "Returns packed RGB as a number: `r * 65536 + g * 256 + b`"
+msgstr ""
+
+#: src/ui/camera.md:111
+msgid "Returns `-1` if no frame is available"
+msgstr ""
+
+#: src/ui/camera.md:113
+msgid "To extract individual channels:"
+msgstr ""
+
+#: src/ui/camera.md:121
+msgid ""
+"The color is averaged over a 5x5 pixel region around the sample point for "
+"noise reduction."
+msgstr ""
+
+#: src/ui/camera.md:123
+msgid "`cameraSetOnTap(handle, callback)`"
+msgstr ""
+
+#: src/ui/camera.md:125
+msgid "Register a tap handler on the camera view."
+msgstr ""
+
+#: src/ui/camera.md:127
+msgid ""
+"```ts\n"
+"cameraSetOnTap(preview, (tx: number, ty: number) => {\n"
+"    // tx, ty are normalized coordinates (0.0-1.0)\n"
+"    const tappedRgb = cameraSampleColor(tx, ty)\n"
+"    console.log(`tapped color: ${tappedRgb}`)\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:135
+msgid ""
+"The callback receives normalized coordinates of the tap location, which can "
+"be passed directly to `cameraSampleColor()`."
+msgstr ""
+
+#: src/ui/camera.md:139
+msgid ""
+"On iOS, the camera uses AVCaptureSession with AVCaptureVideoPreviewLayer for"
+" GPU-accelerated live preview, and AVCaptureVideoDataOutput for frame "
+"capture. Color sampling reads pixel data from CVPixelBuffer."
+msgstr ""
+
+#: src/ui/camera.md:141
+msgid ""
+"On Android, the camera uses Camera2 with a TextureView preview surface. "
+"Color sampling reads from the most recent ImageReader frame."
+msgstr ""
+
+#: src/ui/camera.md:146
+msgid ""
+"[Audio Capture](../system/audio.md) — Microphone input and sound metering"
+msgstr ""
+
+#: src/platforms/overview.md:1
+msgid "Platform Overview"
+msgstr ""
+
+#: src/platforms/overview.md:3
+msgid ""
+"Perry compiles TypeScript to native executables for 9 platform families from"
+" the same source code."
+msgstr ""
+
+#: src/platforms/overview.md:5
+msgid "Supported Platforms"
+msgstr ""
+
+#: src/platforms/overview.md:7 src/widgets/platforms.md:9
+msgid "Target Flag"
+msgstr ""
+
+#: src/platforms/overview.md:7 src/platforms/macos.md:20
+#: src/platforms/ios.md:46 src/platforms/tvos.md:46
+#: src/platforms/watchos.md:46 src/platforms/android.md:20
+#: src/platforms/windows.md:38 src/platforms/linux.md:30
+msgid "UI Toolkit"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "_(default)_"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "AppKit"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "Full support (127/127 FFI functions)"
+msgstr ""
+
+#: src/platforms/overview.md:10
+msgid "`--target ios` / `--target ios-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:10 src/platforms/overview.md:12
+#: src/platforms/tvos.md:178
+msgid "UIKit"
+msgstr ""
+
+#: src/platforms/overview.md:10
+msgid "Full support (127/127)"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "`--target visionos` / `--target visionos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "UIKit (2D windows)"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "Core support (2D only)"
+msgstr ""
+
+#: src/platforms/overview.md:12
+msgid "`--target tvos` / `--target tvos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:12
+msgid "Full support (focus engine + game controllers)"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "`--target watchos` / `--target watchos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "SwiftUI (data-driven)"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "Core support (15 widgets)"
+msgstr ""
+
+#: src/platforms/overview.md:14
+msgid "`--target android`"
+msgstr ""
+
+#: src/platforms/overview.md:14
+msgid "JNI/Android SDK"
+msgstr ""
+
+#: src/platforms/overview.md:14 src/platforms/overview.md:15
+#: src/platforms/overview.md:16
+msgid "Full support (112/112)"
+msgstr ""
+
+#: src/platforms/overview.md:15
+msgid "`--target windows`"
+msgstr ""
+
+#: src/platforms/overview.md:15
+msgid "Win32"
+msgstr ""
+
+#: src/platforms/overview.md:16
+msgid "`--target linux`"
+msgstr ""
+
+#: src/platforms/overview.md:16
+msgid "GTK4"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "Web / WebAssembly"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "`--target web` _(alias `--target wasm`)_"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "DOM/CSS via WASM bridge"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "Full support (168 widgets)"
+msgstr ""
+
+#: src/platforms/overview.md:19
+msgid "Cross-Compilation"
+msgstr ""
+
+#: src/platforms/overview.md:22
+msgid "# Default: compile for current platform\n"
+msgstr ""
+
+#: src/platforms/overview.md:24
+msgid "# Compile for a specific target\n"
+msgstr ""
+
+#: src/platforms/overview.md:36 src/platforms/visionos.md:49
+#: src/platforms/tvos.md:133 src/platforms/watchos.md:170
+msgid "Platform Detection"
+msgstr ""
+
+#: src/platforms/overview.md:38
+msgid "Use the `__platform__` compile-time constant to branch by platform:"
+msgstr ""
+
+#: src/platforms/overview.md:40
+msgid ""
+"```typescript\n"
+"declare const __platform__: number\n"
+"\n"
+"// Platform constants:\n"
+"// 0 = macOS\n"
+"// 1 = iOS\n"
+"// 2 = Android\n"
+"// 3 = Windows\n"
+"// 4 = Linux\n"
+"// 5 = Web (browser, --target web / --target wasm)\n"
+"// 6 = tvOS\n"
+"// 7 = watchOS\n"
+"// 8 = visionOS\n"
+"\n"
+"if (__platform__ === 0) {\n"
+"    console.log(\"Running on macOS\")\n"
+"} else if (__platform__ === 1) {\n"
+"    console.log(\"Running on iOS\")\n"
+"} else if (__platform__ === 3) {\n"
+"    console.log(\"Running on Windows\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/overview.md:63
+msgid ""
+"`__platform__` is resolved at compile time. The compiler constant-folds "
+"comparisons and eliminates dead branches, so platform-specific code has zero"
+" runtime cost."
+msgstr ""
+
+#: src/platforms/overview.md:65
+msgid "Platform Feature Matrix"
+msgstr ""
+
+#: src/platforms/overview.md:67
+msgid "Web (WASM)"
+msgstr ""
+
+#: src/platforms/overview.md:69
+msgid "CLI programs"
+msgstr ""
+
+#: src/platforms/overview.md:70
+msgid "Native UI (DOM on web)"
+msgstr ""
+
+#: src/platforms/overview.md:71
+msgid "Game engines"
+msgstr ""
+
+#: src/platforms/overview.md:71
+msgid "Via FFI"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "File system"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "Sandboxed"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "File System Access API"
+msgstr ""
+
+#: src/platforms/overview.md:73
+msgid "Networking"
+msgstr ""
+
+#: src/platforms/overview.md:73
+msgid "`fetch` / `WebSocket`"
+msgstr ""
+
+#: src/platforms/overview.md:74
+msgid "Partial"
+msgstr ""
+
+#: src/platforms/overview.md:74
+msgid "Minimal"
+msgstr ""
+
+#: src/platforms/overview.md:75
+msgid "Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Threading"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Native"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Web Workers"
+msgstr ""
+
+#: src/platforms/overview.md:80
+msgid "[macOS](macos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:81
+msgid "[iOS](ios.md)"
+msgstr ""
+
+#: src/platforms/overview.md:82
+msgid "[visionOS](visionos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:83
+msgid "[tvOS](tvos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:84
+msgid "[watchOS](watchos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:85
+msgid "[Android](android.md)"
+msgstr ""
+
+#: src/platforms/overview.md:86
+msgid "[Windows](windows.md)"
+msgstr ""
+
+#: src/platforms/overview.md:87
+msgid "[Linux (GTK4)](linux.md)"
+msgstr ""
+
+#: src/platforms/overview.md:88
+msgid "[Web](web.md)"
+msgstr ""
+
+#: src/platforms/overview.md:89
+msgid "[WebAssembly](wasm.md)"
+msgstr ""
+
+#: src/platforms/macos.md:3
+msgid ""
+"macOS is Perry's primary development platform. It uses AppKit for native UI."
+msgstr ""
+
+#: src/platforms/macos.md:5 src/platforms/ios.md:5 src/platforms/tvos.md:7
+#: src/platforms/watchos.md:7 src/platforms/android.md:5
+#: src/platforms/windows.md:5 src/platforms/linux.md:5
+#: src/plugins/native-extensions.md:271
+msgid "Requirements"
+msgstr ""
+
+#: src/platforms/macos.md:7
+msgid "macOS 13+ (Ventura or later)"
+msgstr ""
+
+#: src/platforms/macos.md:8
+msgid "Xcode Command Line Tools: `xcode-select --install`"
+msgstr ""
+
+#: src/platforms/macos.md:10 src/platforms/android.md:14
+#: src/platforms/windows.md:32 src/platforms/linux.md:23
+#: src/platforms/wasm.md:7 src/widgets/overview.md:48
+msgid "Building"
+msgstr ""
+
+#: src/platforms/macos.md:13
+msgid "# macOS is the default target\n"
+msgstr ""
+
+#: src/platforms/macos.md:18
+msgid "No additional flags needed — macOS is the default compilation target."
+msgstr ""
+
+#: src/platforms/macos.md:22
+msgid "Perry maps UI widgets to AppKit controls:"
+msgstr ""
+
+#: src/platforms/macos.md:24 src/platforms/ios.md:50 src/platforms/tvos.md:50
+#: src/platforms/watchos.md:50 src/platforms/android.md:24
+#: src/platforms/windows.md:42 src/platforms/linux.md:34
+#: src/platforms/wasm.md:55
+msgid "Perry Widget"
+msgstr ""
+
+#: src/platforms/macos.md:24
+msgid "AppKit Class"
+msgstr ""
+
+#: src/platforms/macos.md:26
+msgid "NSTextField (label mode)"
+msgstr ""
+
+#: src/platforms/macos.md:29
+msgid "NSSecureTextField"
+msgstr ""
+
+#: src/platforms/macos.md:30
+msgid "NSSwitch"
+msgstr ""
+
+#: src/platforms/macos.md:31
+msgid "NSSlider"
+msgstr ""
+
+#: src/platforms/macos.md:32
+msgid "NSPopUpButton"
+msgstr ""
+
+#: src/platforms/macos.md:33 src/platforms/ios.md:59 src/platforms/tvos.md:58
+#: src/platforms/watchos.md:61 src/platforms/android.md:33
+#: src/platforms/windows.md:52 src/platforms/linux.md:44
+#: src/widgets/components.md:83
+msgid "Image"
+msgstr ""
+
+#: src/platforms/macos.md:33
+msgid "NSImageView"
+msgstr ""
+
+#: src/platforms/macos.md:34 src/platforms/ios.md:60 src/platforms/tvos.md:59
+#: src/platforms/windows.md:53
+msgid "VStack/HStack"
+msgstr ""
+
+#: src/platforms/macos.md:35
+msgid "NSScrollView"
+msgstr ""
+
+#: src/platforms/macos.md:36
+msgid "NSTableView"
+msgstr ""
+
+#: src/platforms/macos.md:37
+msgid "NSView + Core Graphics"
+msgstr ""
+
+#: src/platforms/macos.md:39 src/cli/perry-toml.md:179
+#: src/cli/perry-toml.md:258
+msgid "Code Signing"
+msgstr ""
+
+#: src/platforms/macos.md:41
+msgid ""
+"For distribution, apps need to be signed. Perry supports automatic signing:"
+msgstr ""
+
+#: src/platforms/macos.md:47
+msgid ""
+"This auto-detects your signing identity from the macOS Keychain, exports it "
+"to a temporary `.p12` file, and signs the binary."
+msgstr ""
+
+#: src/platforms/macos.md:49
+msgid "For manual signing:"
+msgstr ""
+
+#: src/platforms/macos.md:52
+msgid "\"Developer ID Application: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:55
+msgid "App Store Distribution"
+msgstr ""
+
+#: src/platforms/macos.md:58
+msgid "# Sign with App Store certificate\n"
+msgstr ""
+
+#: src/platforms/macos.md:60
+msgid "\"3rd Party Mac Developer Application: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:60
+msgid "# Package\n"
+msgstr ""
+
+#: src/platforms/macos.md:62
+msgid "\"3rd Party Mac Developer Installer: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:65
+msgid "macOS-Specific Features"
+msgstr ""
+
+#: src/platforms/macos.md:67
+msgid "**Menu bar**: Full NSMenu support with keyboard shortcuts"
+msgstr ""
+
+#: src/platforms/macos.md:68
+msgid "**Toolbar**: NSToolbar integration"
+msgstr ""
+
+#: src/platforms/macos.md:69
+msgid "**Dock icon**: Automatic for GUI apps"
+msgstr ""
+
+#: src/platforms/macos.md:70
+msgid "**Dark mode**: `isDarkMode()` detects system appearance"
+msgstr ""
+
+#: src/platforms/macos.md:71
+msgid "**Keychain**: Secure storage via Security.framework"
+msgstr ""
+
+#: src/platforms/macos.md:72
+msgid "**Notifications**: Local notifications via UNUserNotificationCenter"
+msgstr ""
+
+#: src/platforms/macos.md:73
+msgid "**File dialogs**: NSOpenPanel/NSSavePanel"
+msgstr ""
+
+#: src/platforms/macos.md:77
+msgid ""
+"```typescript\n"
+"import { openURL, isDarkMode, preferencesSet, preferencesGet } from \"perry/system\"\n"
+"\n"
+"openURL(\"https://example.com\")          // Opens in default browser\n"
+"const dark = isDarkMode()               // Check appearance\n"
+"preferencesSet(\"key\", \"value\")          // NSUserDefaults\n"
+"const val = preferencesGet(\"key\")       // NSUserDefaults\n"
+"```"
+msgstr ""
+
+#: src/platforms/macos.md:88
+msgid "[iOS](ios.md) — Cross-compile for iPhone/iPad"
+msgstr ""
+
+#: src/platforms/macos.md:89
+msgid "[UI Overview](../ui/overview.md) — Full UI documentation"
+msgstr ""
+
+#: src/platforms/macos.md:90
+msgid "[System APIs](../system/overview.md) — System integration"
+msgstr ""
+
+#: src/platforms/ios.md:3
+msgid ""
+"Perry can cross-compile TypeScript apps for iOS devices and the iOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/ios.md:7 src/platforms/tvos.md:9 src/platforms/watchos.md:9
+msgid "macOS host (cross-compilation from Linux/Windows is not supported)"
+msgstr ""
+
+#: src/platforms/ios.md:8
+msgid ""
+"Xcode (full install, not just Command Line Tools) for iOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/ios.md:9
+msgid "Rust iOS targets:"
+msgstr ""
+
+#: src/platforms/ios.md:14 src/platforms/tvos.md:16
+#: src/platforms/watchos.md:16
+msgid "Building for Simulator"
+msgstr ""
+
+#: src/platforms/ios.md:20
+msgid ""
+"This uses LLVM cross-compilation with the iOS Simulator SDK. The binary can "
+"be run in the Xcode Simulator."
+msgstr ""
+
+#: src/platforms/ios.md:22 src/platforms/tvos.md:24
+#: src/platforms/watchos.md:24
+msgid "Building for Device"
+msgstr ""
+
+#: src/platforms/ios.md:28
+msgid ""
+"This produces an ARM64 binary for physical iOS devices. You'll need to code "
+"sign and package it in an `.app` bundle for deployment."
+msgstr ""
+
+#: src/platforms/ios.md:30 src/platforms/tvos.md:32
+#: src/platforms/watchos.md:32
+msgid "Running with `perry run`"
+msgstr ""
+
+#: src/platforms/ios.md:32
+msgid "The easiest way to build and run on iOS is `perry run`:"
+msgstr ""
+
+#: src/platforms/ios.md:35
+msgid "# Auto-detect device/simulator\n"
+msgstr ""
+
+#: src/platforms/ios.md:36
+msgid "# Stream live stdout/stderr\n"
+msgstr ""
+
+#: src/platforms/ios.md:37
+msgid "# Use Perry Hub build server\n"
+msgstr ""
+
+#: src/platforms/ios.md:40
+msgid ""
+"Perry auto-discovers available simulators (via `simctl`) and physical "
+"devices (via `devicectl`). When multiple targets are found, an interactive "
+"prompt lets you choose."
+msgstr ""
+
+#: src/platforms/ios.md:42
+msgid ""
+"For physical devices, Perry handles code signing automatically — it reads "
+"your signing identity and team ID from `~/.perry/config.toml` (set up via "
+"`perry setup ios`), embeds the provisioning profile, and signs the `.app` "
+"before installing."
+msgstr ""
+
+#: src/platforms/ios.md:44
+msgid ""
+"If you don't have the iOS cross-compilation toolchain installed locally, "
+"`perry run ios` automatically falls back to Perry Hub's remote build server."
+msgstr ""
+
+#: src/platforms/ios.md:48
+msgid "Perry maps UI widgets to UIKit controls:"
+msgstr ""
+
+#: src/platforms/ios.md:50 src/platforms/tvos.md:50
+msgid "UIKit Class"
+msgstr ""
+
+#: src/platforms/ios.md:53
+msgid "UIButton (TouchUpInside)"
+msgstr ""
+
+#: src/platforms/ios.md:54 src/platforms/tvos.md:54
+msgid "UITextField"
+msgstr ""
+
+#: src/platforms/ios.md:55
+msgid "UITextField (secureTextEntry)"
+msgstr ""
+
+#: src/platforms/ios.md:56 src/platforms/tvos.md:55
+msgid "UISwitch"
+msgstr ""
+
+#: src/platforms/ios.md:57
+msgid "UISlider (Float32, cast at boundary)"
+msgstr ""
+
+#: src/platforms/ios.md:58 src/platforms/tvos.md:57
+msgid "UIPickerView"
+msgstr ""
+
+#: src/platforms/ios.md:59 src/platforms/tvos.md:58
+msgid "UIImageView"
+msgstr ""
+
+#: src/platforms/ios.md:61 src/platforms/tvos.md:60
+msgid "UIScrollView"
+msgstr ""
+
+#: src/platforms/ios.md:65
+msgid "iOS apps use `UIApplicationMain` with a deferred creation pattern:"
+msgstr ""
+
+#: src/platforms/ios.md:67
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My iOS App\",\n"
+"    width: 400,\n"
+"    height: 800,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello, iPhone!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/ios.md:80
+msgid ""
+"The `App()` call triggers `UIApplicationMain`, and your render function is "
+"called via `PerryAppDelegate` once the app is ready."
+msgstr ""
+
+#: src/platforms/ios.md:82
+msgid "iOS Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/ios.md:84
+msgid ""
+"Perry can compile TypeScript widget declarations to native SwiftUI WidgetKit"
+" extensions:"
+msgstr ""
+
+#: src/platforms/ios.md:90
+msgid "See [Widgets (WidgetKit)](../widgets/overview.md) for details."
+msgstr ""
+
+#: src/platforms/ios.md:92 src/platforms/android.md:51
+msgid "Splash Screen"
+msgstr ""
+
+#: src/platforms/ios.md:94
+msgid ""
+"Perry auto-generates a native `LaunchScreen.storyboard` from the "
+"`perry.splash` config in `package.json`. The splash screen appears instantly"
+" during cold start."
+msgstr ""
+
+#: src/platforms/ios.md:107
+msgid ""
+"The image is centered at 128x128pt with `scaleAspectFit`. You can provide a "
+"custom storyboard for full control:"
+msgstr ""
+
+#: src/platforms/ios.md:119 src/platforms/android.md:83
+msgid ""
+"See [Project Configuration](../getting-started/project-config.md#splash) for"
+" the full config reference."
+msgstr ""
+
+#: src/platforms/ios.md:121
+msgid "Resource Bundling"
+msgstr ""
+
+#: src/platforms/ios.md:123
+msgid ""
+"Perry automatically bundles `logo/` and `assets/` directories from your "
+"project root into the `.app` bundle. These resources are available at "
+"runtime via standard file APIs relative to the app bundle path."
+msgstr ""
+
+#: src/platforms/ios.md:125
+msgid "Keyboard Avoidance"
+msgstr ""
+
+#: src/platforms/ios.md:127
+msgid ""
+"Perry apps automatically handle keyboard avoidance on iOS. When the keyboard"
+" appears, the root view adjusts its bottom constraint with an animated "
+"layout transition, and focused TextFields are auto-scrolled into view above "
+"the keyboard."
+msgstr ""
+
+#: src/platforms/ios.md:129
+msgid "Differences from macOS"
+msgstr ""
+
+#: src/platforms/ios.md:131
+msgid ""
+"**No menu bar**: iOS doesn't support menu bars. Use toolbar or navigation "
+"patterns."
+msgstr ""
+
+#: src/platforms/ios.md:132
+msgid ""
+"**Touch events**: `onHover` is not available. Use `onClick` (mapped to "
+"touch)."
+msgstr ""
+
+#: src/platforms/ios.md:133
+msgid ""
+"**Slider precision**: iOS UISlider uses Float32 internally (automatically "
+"converted)."
+msgstr ""
+
+#: src/platforms/ios.md:134
+msgid "**File dialogs**: Limited to UIDocumentPicker."
+msgstr ""
+
+#: src/platforms/ios.md:135
+msgid "**Keyboard shortcuts**: Not applicable on iOS."
+msgstr ""
+
+#: src/platforms/ios.md:139
+msgid ""
+"[Widgets (WidgetKit)](../widgets/overview.md) — iOS home screen widgets"
+msgstr ""
+
+#: src/platforms/ios.md:140 src/platforms/tvos.md:184
+#: src/platforms/watchos.md:217 src/platforms/android.md:94
+#: src/platforms/windows.md:71 src/platforms/linux.md:83
+#: src/platforms/wasm.md:193
+msgid "[Platform Overview](overview.md) — All platforms"
+msgstr ""
+
+#: src/platforms/ios.md:141 src/platforms/watchos.md:218
+#: src/platforms/android.md:95 src/platforms/windows.md:72
+#: src/platforms/linux.md:84 src/platforms/wasm.md:194
+msgid "[UI Overview](../ui/overview.md) — UI system"
+msgstr ""
+
+#: src/platforms/visionos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple Vision Pro devices and the "
+"visionOS Simulator."
+msgstr ""
+
+#: src/platforms/visionos.md:5
+msgid ""
+"This first pass targets **2D windowed apps only**. Perry uses the same "
+"UIKit-style `perry/ui` model as iOS, packaged for visionOS app bundles and "
+"scene lifecycle."
+msgstr ""
+
+#: src/platforms/visionos.md:9
+msgid "macOS with Xcode installed"
+msgstr ""
+
+#: src/platforms/visionos.md:10
+msgid "Rust visionOS targets:"
+msgstr ""
+
+#: src/platforms/visionos.md:16
+msgid "Compile"
+msgstr ""
+
+#: src/platforms/visionos.md:23
+msgid ""
+"This produces a `.app` bundle with visionOS-specific `Info.plist` metadata "
+"and a `UIWindowScene` configuration."
+msgstr ""
+
+#: src/platforms/visionos.md:25
+msgid "Run"
+msgstr ""
+
+#: src/platforms/visionos.md:33
+msgid ""
+"Perry auto-detects booted Apple Vision Pro simulators via `simctl`. Physical"
+" device installs use `devicectl`, like other modern Apple platforms."
+msgstr ""
+
+#: src/platforms/visionos.md:37
+msgid "Configure visionOS-specific settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/visionos.md:39
+msgid ""
+"```toml\n"
+"[visionos]\n"
+"bundle_id = \"com.example.myvisionapp\"\n"
+"deployment_target = \"1.0\"\n"
+"entry = \"src/main_visionos.ts\"\n"
+"encryption_exempt = true\n"
+"```"
+msgstr ""
+
+#: src/platforms/visionos.md:47
+msgid ""
+"Custom `Info.plist` keys can be merged through `[visionos.info_plist]`."
+msgstr ""
+
+#: src/platforms/visionos.md:51
+msgid "Use `__platform__ === 8` to detect visionOS at compile time:"
+msgstr ""
+
+#: src/platforms/visionos.md:53
+msgid ""
+"```typescript\n"
+"function reportVisionos(): void {\n"
+"    if (__platform__ === 8) {\n"
+"        console.log(\"Running on visionOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/visionos.md:61
+msgid "Current Scope"
+msgstr ""
+
+#: src/platforms/visionos.md:63
+msgid ""
+"Supported: 2D windowed apps, simulator/device app bundles, `perry run`, "
+"`perry setup`, `perry publish`"
+msgstr ""
+
+#: src/platforms/visionos.md:64
+msgid ""
+"Not supported yet: immersive spaces, volumes, RealityKit scene generation, "
+"Geisterhand"
+msgstr ""
+
+#: src/platforms/visionos.md:66
+msgid "Related"
+msgstr ""
+
+#: src/platforms/visionos.md:68
+msgid "[iOS](ios.md) — shared UIKit foundation"
+msgstr ""
+
+#: src/platforms/visionos.md:69
+msgid "[Platform Overview](overview.md)"
+msgstr ""
+
+#: src/platforms/tvos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple TV devices and the tvOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/tvos.md:5
+msgid ""
+"tvOS uses UIKit (the same framework as iOS), so Perry's tvOS support shares "
+"the same UIKit-based widget system. The primary difference is input: Apple "
+"TV apps are controlled via the Siri Remote and game controllers rather than "
+"touch, and all apps run full-screen."
+msgstr ""
+
+#: src/platforms/tvos.md:10
+msgid "Xcode (full install) for tvOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/tvos.md:11
+msgid "Rust tvOS targets:"
+msgstr ""
+
+#: src/platforms/tvos.md:22
+msgid ""
+"This produces an ARM64 binary linked with `clang` against the tvOS Simulator"
+" SDK, wrapped in a `.app` bundle."
+msgstr ""
+
+#: src/platforms/tvos.md:30
+msgid "This produces an ARM64 binary for physical Apple TV hardware."
+msgstr ""
+
+#: src/platforms/tvos.md:35
+msgid "# Auto-detect booted Apple TV simulator\n"
+msgstr ""
+
+#: src/platforms/tvos.md:39
+msgid ""
+"Perry auto-discovers booted Apple TV simulators. To install and launch "
+"manually:"
+msgstr ""
+
+#: src/platforms/tvos.md:48
+msgid "Perry maps UI widgets to UIKit controls on tvOS, identical to iOS:"
+msgstr ""
+
+#: src/platforms/tvos.md:50 src/platforms/tvos.md:149
+#: src/platforms/watchos.md:50 src/system/media.md:37
+#: src/testing/geisterhand.md:257 src/cli/flags.md:20
+msgid "Notes"
+msgstr ""
+
+#: src/platforms/tvos.md:53
+msgid "Focus-based navigation"
+msgstr ""
+
+#: src/platforms/tvos.md:54
+msgid "On-screen keyboard via Siri Remote"
+msgstr ""
+
+#: src/platforms/tvos.md:56
+msgid "UISlider"
+msgstr ""
+
+#: src/platforms/tvos.md:60
+msgid "Focus-based scrolling"
+msgstr ""
+
+#: src/platforms/tvos.md:62
+msgid "Focus Engine"
+msgstr ""
+
+#: src/platforms/tvos.md:64
+msgid ""
+"tvOS uses a **focus-based navigation model** instead of direct touch. The "
+"Siri Remote's touchpad and directional buttons move focus between focusable "
+"views. Perry widgets that support interaction (buttons, text fields, "
+"toggles, etc.) are automatically focusable."
+msgstr ""
+
+#: src/platforms/tvos.md:66
+msgid "Game Engine Support"
+msgstr ""
+
+#: src/platforms/tvos.md:68
+msgid ""
+"tvOS is particularly well-suited for game engines. When using a native "
+"library like [Bloom](https://bloomengine.dev), the game engine handles its "
+"own windowing, rendering, and input."
+msgstr ""
+
+#: src/platforms/tvos.md:70
+msgid ""
+"**Status:** illustrative only — Bloom is an external native library (see "
+"[bloomengine.dev](https://bloomengine.dev)). The snippet below is left as "
+"`,no-test` because it depends on Bloom's `.a`/`.so` being available at link "
+"time; the doc-tests harness compiles every other snippet on this page."
+msgstr ""
+
+#: src/platforms/tvos.md:72
+msgid ""
+"```text\n"
+"import { initWindow, windowShouldClose, beginDrawing, endDrawing,\n"
+"         clearBackground, isGamepadButtonDown, Colors } from \"bloom\";\n"
+"\n"
+"initWindow(1920, 1080, \"My Apple TV Game\");\n"
+"\n"
+"while (!windowShouldClose()) {\n"
+"  beginDrawing();\n"
+"  clearBackground(Colors.BLACK);\n"
+"\n"
+"  if (isGamepadButtonDown(0)) {\n"
+"    // A button (Siri Remote select) pressed\n"
+"  }\n"
+"\n"
+"  endDrawing();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:90
+msgid "Input on tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:92
+msgid "The Siri Remote acts as a game controller:"
+msgstr ""
+
+#: src/platforms/tvos.md:94
+msgid "Input"
+msgstr ""
+
+#: src/platforms/tvos.md:94
+msgid "Mapping"
+msgstr ""
+
+#: src/platforms/tvos.md:96
+msgid "Touchpad swipe"
+msgstr ""
+
+#: src/platforms/tvos.md:96
+msgid "Gamepad axes 0/1 (left stick)"
+msgstr ""
+
+#: src/platforms/tvos.md:97
+msgid "Touchpad click (Select)"
+msgstr ""
+
+#: src/platforms/tvos.md:97
+msgid "Gamepad button 0 (A) + mouse button 0"
+msgstr ""
+
+#: src/platforms/tvos.md:98
+msgid "Menu button"
+msgstr ""
+
+#: src/platforms/tvos.md:98
+msgid "Gamepad button 1 (B)"
+msgstr ""
+
+#: src/platforms/tvos.md:99
+msgid "Play/Pause button"
+msgstr ""
+
+#: src/platforms/tvos.md:99
+msgid "Gamepad button 9 (Start)"
+msgstr ""
+
+#: src/platforms/tvos.md:100
+msgid "Arrow presses (up/down/left/right)"
+msgstr ""
+
+#: src/platforms/tvos.md:100
+msgid "Gamepad D-pad buttons (12-15)"
+msgstr ""
+
+#: src/platforms/tvos.md:102
+msgid ""
+"Extended game controllers (MFi, PlayStation, Xbox) are fully supported with "
+"all axes, buttons, triggers, and D-pad mapped through the standard gamepad "
+"API."
+msgstr ""
+
+#: src/platforms/tvos.md:106
+msgid ""
+"tvOS apps use `UIApplicationMain` with the same lifecycle as iOS. When using"
+" `perry/ui`:"
+msgstr ""
+
+#: src/platforms/tvos.md:108
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My TV App\",\n"
+"    width: 1920,\n"
+"    height: 1080,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello, Apple TV!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:121
+msgid ""
+"When using a game engine with `--features ios-game-loop`, the runtime starts"
+" `UIApplicationMain` on the main thread and runs your game code on a "
+"dedicated game thread."
+msgstr ""
+
+#: src/platforms/tvos.md:125
+msgid "Configure tvOS settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/tvos.md:127
+msgid ""
+"```toml\n"
+"[tvos]\n"
+"bundle_id = \"com.example.mytvapp\"\n"
+"deployment_target = \"17.0\"\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:135
+msgid "Use `__platform__ === 6` to detect tvOS at compile time:"
+msgstr ""
+
+#: src/platforms/tvos.md:137
+msgid ""
+"```typescript\n"
+"function reportTvos(): void {\n"
+"    if (__platform__ === 6) {\n"
+"        console.log(\"Running on tvOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:145
+msgid "App Bundle"
+msgstr ""
+
+#: src/platforms/tvos.md:147
+msgid "Perry generates a `.app` bundle with an `Info.plist` containing:"
+msgstr ""
+
+#: src/platforms/tvos.md:149 src/cli/perry-toml.md:367
+msgid "Key"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "`UIDeviceFamily`"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "`[3]`"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "Apple TV"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "`MinimumOSVersion`"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "`17.0`"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "tvOS 17+"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "`UIRequiresFullScreen`"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "`true`"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "All tvOS apps are full-screen"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "`UILaunchStoryboardName`"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "`LaunchScreen`"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "Required by tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:158
+msgid ""
+"tvOS has inherent platform constraints compared to other Perry targets:"
+msgstr ""
+
+#: src/platforms/tvos.md:160
+msgid "**No camera**: Apple TV has no camera hardware"
+msgstr ""
+
+#: src/platforms/tvos.md:161
+msgid "**No clipboard**: UIPasteboard is not available on tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:162
+msgid "**No file dialogs**: No document picker"
+msgstr ""
+
+#: src/platforms/tvos.md:163
+msgid "**No QR code**: No camera for scanning"
+msgstr ""
+
+#: src/platforms/tvos.md:164
+msgid "**No multi-window**: Single full-screen window only"
+msgstr ""
+
+#: src/platforms/tvos.md:165
+msgid ""
+"**No direct touch**: Input is via Siri Remote focus engine and game "
+"controllers"
+msgstr ""
+
+#: src/platforms/tvos.md:166
+msgid ""
+"**Resolution**: Design for 1920x1080 (1080p) or 3840x2160 (4K) displays"
+msgstr ""
+
+#: src/platforms/tvos.md:168 src/platforms/watchos.md:206
+msgid "Differences from iOS"
+msgstr ""
+
+#: src/platforms/tvos.md:170
+msgid "Aspect"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "**Input**"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "Siri Remote + game controllers (focus engine)"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "Direct touch"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "**Display**"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "Full-screen only (1080p/4K)"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "Variable screen sizes"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "**Device family**"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "`[3]` (Apple TV)"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "`[1, 2]` (iPhone/iPad)"
+msgstr ""
+
+#: src/platforms/tvos.md:175
+msgid "**Camera**"
+msgstr ""
+
+#: src/platforms/tvos.md:175 src/platforms/tvos.md:176
+msgid "Not available"
+msgstr ""
+
+#: src/platforms/tvos.md:175 src/platforms/tvos.md:176
+msgid "Available"
+msgstr ""
+
+#: src/platforms/tvos.md:176
+msgid "**Clipboard**"
+msgstr ""
+
+#: src/platforms/tvos.md:177
+msgid "**Deployment target**"
+msgstr ""
+
+#: src/platforms/tvos.md:177
+msgid "17.0"
+msgstr ""
+
+#: src/platforms/tvos.md:178
+msgid "**UI framework**"
+msgstr ""
+
+#: src/platforms/tvos.md:178
+msgid "UIKit (same as iOS)"
+msgstr ""
+
+#: src/platforms/tvos.md:182
+msgid "[iOS](ios.md) — iOS platform reference (shared UIKit base)"
+msgstr ""
+
+#: src/platforms/tvos.md:183
+msgid "[watchOS](watchos.md) — watchOS platform reference"
+msgstr ""
+
+#: src/platforms/watchos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple Watch devices and the watchOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/watchos.md:5
+msgid ""
+"Since watchOS does not support UIKit views, Perry uses a **data-driven "
+"SwiftUI renderer**: your TypeScript code builds a UI tree via the standard "
+"`perry/ui` API, and a fixed SwiftUI runtime (shipped with Perry) queries the"
+" tree and renders it reactively. No code generation or transpilation is "
+"involved — the binary is fully native."
+msgstr ""
+
+#: src/platforms/watchos.md:10
+msgid "Xcode (full install) for watchOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/watchos.md:11
+msgid "Rust watchOS targets:"
+msgstr ""
+
+#: src/platforms/watchos.md:22
+msgid ""
+"This produces an ARM64 binary linked with `swiftc` against the watchOS "
+"Simulator SDK, wrapped in a `.app` bundle."
+msgstr ""
+
+#: src/platforms/watchos.md:30
+msgid ""
+"This produces an arm64_32 (ILP32) binary for physical Apple Watch hardware. "
+"Apple Watch uses 32-bit pointers on 64-bit ARM."
+msgstr ""
+
+#: src/platforms/watchos.md:35
+msgid "# Auto-detect booted watch simulator\n"
+msgstr ""
+
+#: src/platforms/watchos.md:39
+msgid ""
+"Perry auto-discovers booted Apple Watch simulators. To install and launch "
+"manually:"
+msgstr ""
+
+#: src/platforms/watchos.md:48
+msgid "Perry maps UI widgets to SwiftUI views via a data-driven bridge:"
+msgstr ""
+
+#: src/platforms/watchos.md:50
+msgid "SwiftUI View"
+msgstr ""
+
+#: src/platforms/watchos.md:52
+msgid "Font size, weight, color, wrapping"
+msgstr ""
+
+#: src/platforms/watchos.md:53
+msgid "Tap action via native closure callback"
+msgstr ""
+
+#: src/platforms/watchos.md:54 src/platforms/watchos.md:55
+msgid "With spacing"
+msgstr ""
+
+#: src/platforms/watchos.md:56
+msgid "Layered views"
+msgstr ""
+
+#: src/platforms/watchos.md:59
+msgid "Two-way state binding"
+msgstr ""
+
+#: src/platforms/watchos.md:60
+msgid "Min/max/value, state binding"
+msgstr ""
+
+#: src/platforms/watchos.md:61
+msgid "Image(systemName:)"
+msgstr ""
+
+#: src/platforms/watchos.md:61
+msgid "SF Symbols"
+msgstr ""
+
+#: src/platforms/watchos.md:63
+msgid "Linear"
+msgstr ""
+
+#: src/platforms/watchos.md:64
+msgid "Selection list"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "Form"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "List"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "Maps to List on watchOS"
+msgstr ""
+
+#: src/platforms/watchos.md:66 src/platforms/android.md:39
+#: src/platforms/linux.md:50
+msgid "NavigationStack"
+msgstr ""
+
+#: src/platforms/watchos.md:66
+msgid "Push navigation"
+msgstr ""
+
+#: src/platforms/watchos.md:68 src/widgets/components.md:136
+msgid "Modifiers"
+msgstr ""
+
+#: src/platforms/watchos.md:70
+msgid "All widgets support these styling modifiers:"
+msgstr ""
+
+#: src/platforms/watchos.md:72
+msgid "`foregroundColor` / `backgroundColor`"
+msgstr ""
+
+#: src/platforms/watchos.md:73
+msgid "`font` (size, weight, family)"
+msgstr ""
+
+#: src/platforms/watchos.md:74
+msgid "`frame` (width, height)"
+msgstr ""
+
+#: src/platforms/watchos.md:75
+msgid "`padding` (uniform or per-edge)"
+msgstr ""
+
+#: src/platforms/watchos.md:76
+msgid "`cornerRadius`"
+msgstr ""
+
+#: src/platforms/watchos.md:78
+msgid "`hidden` / `disabled`"
+msgstr ""
+
+#: src/platforms/watchos.md:82
+msgid ""
+"watchOS apps use SwiftUI's `@main App` pattern. Perry's PerryWatchApp.swift "
+"runtime handles the app lifecycle automatically:"
+msgstr ""
+
+#: src/platforms/watchos.md:84
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack, Button } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My Watch App\",\n"
+"    width: 200,\n"
+"    height: 200,\n"
+"    body: VStack(8, [\n"
+"        Text(\"Hello, Apple Watch!\"),\n"
+"        Button(\"Tap me\", () => {\n"
+"            console.log(\"Button tapped!\")\n"
+"        }),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:100
+msgid "Under the hood:"
+msgstr ""
+
+#: src/platforms/watchos.md:101
+msgid ""
+"`perry_main_init()` runs your compiled TypeScript, which builds the UI tree "
+"in memory"
+msgstr ""
+
+#: src/platforms/watchos.md:102
+msgid "The SwiftUI `@main` struct observes the tree version and renders it"
+msgstr ""
+
+#: src/platforms/watchos.md:103
+msgid ""
+"User interactions (button taps, toggle changes) call back into native "
+"closures"
+msgstr ""
+
+#: src/platforms/watchos.md:107
+msgid "Reactive state works the same as other platforms:"
+msgstr ""
+
+#: src/platforms/watchos.md:109 src/platforms/wasm.md:166
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack, Button, State } from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"App({\n"
+"    title: \"Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Count: ${count.value}`),\n"
+"        Button(\"Increment\", () => count.set(count.value + 1)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:125
+msgid ""
+"When `state.set()` is called, the tree version increments and SwiftUI re-"
+"renders the affected views automatically."
+msgstr ""
+
+#: src/platforms/watchos.md:129
+msgid ""
+"Unlike iOS (UIKit) and macOS (AppKit), where Perry calls native view APIs "
+"directly via FFI, watchOS uses a **data-driven architecture**:"
+msgstr ""
+
+#: src/platforms/watchos.md:147
+msgid ""
+"The `PerryWatchApp.swift` file is a fixed runtime (~280 lines) that ships "
+"with Perry. It never changes per-app — it's the watchOS equivalent of "
+"`libperry_ui_ios.a`."
+msgstr ""
+
+#: src/platforms/watchos.md:151
+msgid "Configure watchOS settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/watchos.md:153
+msgid ""
+"```toml\n"
+"[watchos]\n"
+"bundle_id = \"com.example.mywatch\"\n"
+"deployment_target = \"10.0\"\n"
+"\n"
+"[watchos.info_plist]\n"
+"NSLocationWhenInUseUsageDescription = \"Used for location features\"\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:162
+msgid "Set up signing credentials with:"
+msgstr ""
+
+#: src/platforms/watchos.md:168
+msgid ""
+"This shares App Store Connect credentials with iOS/macOS (same team, API "
+"key, issuer)."
+msgstr ""
+
+#: src/platforms/watchos.md:172
+msgid "Use `__platform__ === 7` to detect watchOS at compile time:"
+msgstr ""
+
+#: src/platforms/watchos.md:174
+msgid ""
+"```typescript\n"
+"function reportWatchos(): void {\n"
+"    if (__platform__ === 7) {\n"
+"        console.log(\"Running on watchOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:182
+msgid "watchOS Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/watchos.md:184
+msgid ""
+"Perry also supports watchOS WidgetKit complications (separate from full "
+"apps):"
+msgstr ""
+
+#: src/platforms/watchos.md:190
+msgid ""
+"See [watchOS Complications](../widgets/watchos.md) for widget-specific "
+"documentation."
+msgstr ""
+
+#: src/platforms/watchos.md:194
+msgid ""
+"watchOS apps have inherent platform constraints compared to other Perry "
+"targets:"
+msgstr ""
+
+#: src/platforms/watchos.md:196
+msgid "**No Canvas**: CoreGraphics drawing is not available"
+msgstr ""
+
+#: src/platforms/watchos.md:197
+msgid "**No Camera**: watchOS does not support camera APIs"
+msgstr ""
+
+#: src/platforms/watchos.md:198
+msgid "**No TextField**: Text input is extremely limited on Apple Watch"
+msgstr ""
+
+#: src/platforms/watchos.md:199
+msgid "**No File Dialogs**: No document picker"
+msgstr ""
+
+#: src/platforms/watchos.md:200
+msgid "**No Menu Bar / Toolbar**: Not applicable on watch"
+msgstr ""
+
+#: src/platforms/watchos.md:201
+msgid "**No Multi-Window**: Single window only"
+msgstr ""
+
+#: src/platforms/watchos.md:202
+msgid "**No QR Code**: Screen too small for practical QR display"
+msgstr ""
+
+#: src/platforms/watchos.md:203
+msgid ""
+"**Memory**: watchOS devices have ~50-75MB available RAM — keep apps "
+"lightweight"
+msgstr ""
+
+#: src/platforms/watchos.md:204
+msgid "**Screen size**: Design for 40-49mm watch faces"
+msgstr ""
+
+#: src/platforms/watchos.md:208
+msgid ""
+"**SwiftUI vs UIKit**: watchOS uses SwiftUI rendering; iOS uses UIKit "
+"directly"
+msgstr ""
+
+#: src/platforms/watchos.md:209
+msgid "**No splash screen**: watchOS apps don't use launch storyboards"
+msgstr ""
+
+#: src/platforms/watchos.md:210
+msgid ""
+"**Standalone**: watchOS apps are standalone (no iPhone companion required, "
+"`WKWatchOnly = true`)"
+msgstr ""
+
+#: src/platforms/watchos.md:211
+msgid ""
+"**Device family**: `UIDeviceFamily = [4]` (watch) vs `[1, 2]` (iPhone/iPad)"
+msgstr ""
+
+#: src/platforms/watchos.md:215
+msgid ""
+"[watchOS Complications](../widgets/watchos.md) — WidgetKit complications"
+msgstr ""
+
+#: src/platforms/watchos.md:216
+msgid "[iOS](ios.md) — iOS platform reference"
+msgstr ""
+
+#: src/platforms/android.md:3
+msgid ""
+"Perry compiles TypeScript apps for Android using JNI (Java Native "
+"Interface)."
+msgstr ""
+
+#: src/platforms/android.md:7
+msgid "Android NDK"
+msgstr ""
+
+#: src/platforms/android.md:8
+msgid "Android SDK"
+msgstr ""
+
+#: src/platforms/android.md:9
+msgid "Rust Android targets:"
+msgstr ""
+
+#: src/platforms/android.md:22
+msgid "Perry maps UI widgets to Android views via JNI:"
+msgstr ""
+
+#: src/platforms/android.md:24
+msgid "Android Class"
+msgstr ""
+
+#: src/platforms/android.md:26
+msgid "TextView"
+msgstr ""
+
+#: src/platforms/android.md:28
+msgid "EditText"
+msgstr ""
+
+#: src/platforms/android.md:29
+msgid "EditText (ES_PASSWORD)"
+msgstr ""
+
+#: src/platforms/android.md:30
+msgid "Switch"
+msgstr ""
+
+#: src/platforms/android.md:31
+msgid "SeekBar"
+msgstr ""
+
+#: src/platforms/android.md:32
+msgid "Spinner + ArrayAdapter"
+msgstr ""
+
+#: src/platforms/android.md:33
+msgid "ImageView"
+msgstr ""
+
+#: src/platforms/android.md:34
+msgid "LinearLayout (vertical)"
+msgstr ""
+
+#: src/platforms/android.md:35
+msgid "LinearLayout (horizontal)"
+msgstr ""
+
+#: src/platforms/android.md:36 src/platforms/android.md:39
+msgid "FrameLayout"
+msgstr ""
+
+#: src/platforms/android.md:38
+msgid "Canvas + Bitmap"
+msgstr ""
+
+#: src/platforms/android.md:41
+msgid "Android-Specific APIs"
+msgstr ""
+
+#: src/platforms/android.md:43
+msgid "**Dark mode**: `Configuration.uiMode` detection"
+msgstr ""
+
+#: src/platforms/android.md:44
+msgid "**Preferences**: SharedPreferences"
+msgstr ""
+
+#: src/platforms/android.md:45
+msgid "**Keychain**: Android Keystore"
+msgstr ""
+
+#: src/platforms/android.md:46
+msgid "**Notifications**: NotificationManager"
+msgstr ""
+
+#: src/platforms/android.md:47
+msgid "**Open URL**: `Intent.ACTION_VIEW`"
+msgstr ""
+
+#: src/platforms/android.md:48
+msgid "**Alerts**: `PerryBridge.showAlert`"
+msgstr ""
+
+#: src/platforms/android.md:49
+msgid "**Sheets**: Dialog (modal)"
+msgstr ""
+
+#: src/platforms/android.md:53
+msgid ""
+"Perry's Android template includes a splash theme (`Theme.Perry.Splash`) that"
+" displays a `windowBackground` drawable during cold start. Configure it via "
+"`perry.splash` in `package.json`:"
+msgstr ""
+
+#: src/platforms/android.md:66
+msgid ""
+"The image is centered via a `layer-list` drawable with a solid background "
+"color. The activity switches to the normal theme in `onCreate` before "
+"inflating the layout, so the splash disappears as soon as the app is ready."
+msgstr ""
+
+#: src/platforms/android.md:68
+msgid "For full control, provide custom drawable and theme XML files:"
+msgstr ""
+
+#: src/platforms/android.md:85
+msgid "Differences from Desktop"
+msgstr ""
+
+#: src/platforms/android.md:87
+msgid "**Touch-only**: No hover events, no right-click context menus"
+msgstr ""
+
+#: src/platforms/android.md:88
+msgid "**Single window**: Multi-window maps to Dialog views"
+msgstr ""
+
+#: src/platforms/android.md:89
+msgid "**Toolbar**: Horizontal LinearLayout"
+msgstr ""
+
+#: src/platforms/android.md:90
+msgid "**Font**: Typeface-based font family support"
+msgstr ""
+
+#: src/platforms/harmonyos.md:3
+msgid ""
+"Perry compiles TypeScript apps for HarmonyOS NEXT (Huawei's mobile OS) by "
+"emitting **declarative ArkUI** alongside a logic-only `.so` library. The "
+"same TypeScript source that targets macOS, iOS, Android, Linux, and Windows "
+"also runs natively on HarmonyOS — no platform-specific adapters needed in "
+"user code."
+msgstr ""
+
+#: src/platforms/harmonyos.md:7
+msgid ""
+"HarmonyOS NEXT runs apps via the ArkTS runtime, which owns the UI tree. "
+"Perry can't lower `perry/ui` calls to the imperative AppKit/UIKit/etc shape "
+"used on every other platform — it has to play by ArkTS's declarative rules. "
+"So the harmonyos target is structured differently:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:26
+msgid ""
+"The user splices three artifacts into a DevEco Studio project — "
+"`libentry.so`, `pages/Index.ets`, `cpp/types/libentry/Index.d.ts` — and "
+"DevEco signs + runs as usual. Tap interactions, text input, etc. fire NAPI "
+"calls into the `.so`, which dispatch the registered Perry closure bodies."
+msgstr ""
+
+#: src/platforms/harmonyos.md:28
+msgid "What's supported"
+msgstr ""
+
+#: src/platforms/harmonyos.md:30
+msgid "**Widgets** (introduced in v0.5.401, expanded in v0.5.418, v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:32
+msgid "Widget"
+msgstr ""
+
+#: src/platforms/harmonyos.md:32
+msgid "ArkUI emission"
+msgstr ""
+
+#: src/platforms/harmonyos.md:34
+msgid "`Text(content)` / `Text(content, \"id\")`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:34
+msgid "`Text(...).fontSize(20)` (reactive when id is given)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:35
+msgid "`VStack(children)` / `VStack(spacing, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:35
+msgid "`Column({ space })`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:36
+msgid "`HStack(children)` / `HStack(spacing, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:36
+msgid "`Row({ space })`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:37
+msgid "`Button(label, onPress)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:37
+msgid "`Button(...).onClick(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:38
+msgid "`TextField(placeholder, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:38
+msgid "`TextInput(...).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:39
+msgid "`Toggle(label, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:39
+msgid "`Toggle({type: ToggleType.Switch}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:40
+msgid "`Slider(min, max, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:40
+msgid "`Slider({...}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:41
+msgid "`Spacer()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:41
+msgid "`Blank()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:42
+msgid "`Divider()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:43
+msgid "`Image(src)` / `ImageFile(path)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:43
+msgid "`Image(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:44
+msgid "`ScrollView(children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:44
+msgid "`Scroll() { Column() { ... } }`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:45
+msgid "`LazyVStack(children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:45
+msgid "`Column({...})` (eager — see v10 follow-up)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:46
+msgid "`Picker(options, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:46
+msgid "`TextPicker({...}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:47
+msgid "`ProgressView(value, total)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:47
+msgid "`Progress({type: ProgressType.Linear})`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:48
+msgid "`Section(title, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:48
+msgid "`Column({ space: 4 }) { Text(title) ... }`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:50
+msgid "**Event handling** (v0.5.417 + v0.5.421):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:51
+msgid "`Button.onPress` → `invokeCallback(idx)` via NAPI"
+msgstr ""
+
+#: src/platforms/harmonyos.md:52
+msgid ""
+"`Toggle.onChange((isOn: boolean) => ...)` → `invokeCallback1(idx, isOn)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:53
+msgid ""
+"`TextField.onChange((value: string) => ...)` → `invokeCallback1(idx, value)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:54
+msgid ""
+"`Slider.onChange((value: number) => ...)` → `invokeCallback1(idx, value)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:55
+msgid ""
+"`Picker.onChange((idx: number) => ...)` → `invokeCallback1(idx, index)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:57
+msgid "**Reactivity** (v0.5.419 + v0.5.421):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:58
+msgid ""
+"`Text(\"0\", \"counter\")` registers a reactive slot bound to a generated "
+"`@State text_counter: string` field."
+msgstr ""
+
+#: src/platforms/harmonyos.md:59
+msgid ""
+"`setText(\"counter\", \"5\")` from inside any closure updates the Text on-"
+"screen."
+msgstr ""
+
+#: src/platforms/harmonyos.md:61
+msgid "**Toast banners** (v0.5.419):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:62
+msgid ""
+"`showToast(\"Saved!\")` from inside any closure shows an ArkUI "
+"`promptAction.showToast({ message })` banner."
+msgstr ""
+
+#: src/platforms/harmonyos.md:64
+msgid "**Inline styling** (v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:65
+msgid ""
+"`Text(\"hi\", { fontSize: 16, color: \"red\" })` maps to "
+"`.fontSize(16).fontColor('red')`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:66
+msgid ""
+"Supported props: `backgroundColor`, `color`, `fontSize`, `fontWeight`, "
+"`fontFamily`, `borderRadius`, `padding` (number or per-side object), "
+"`opacity`, `hidden`, `borderColor` + `borderWidth` (combined as "
+"`.border({...})`)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:67
+msgid "PerryColor objects (`{r,g,b,a}`) auto-convert to `rgba(...)` strings."
+msgstr ""
+
+#: src/platforms/harmonyos.md:69
+msgid "**Dynamic lists** (v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:70
+msgid ""
+"`VStack(items.map(item => Text(item)))` lowers to ArkUI `ForEach(items, "
+"(__item) => { Text(__item) }, (__item) => __item)`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:71
+msgid ""
+"Single-arg map closures only; complex array sources require Phase 2 v6 state"
+" binding."
+msgstr ""
+
+#: src/platforms/harmonyos.md:73
+msgid "Setup"
+msgstr ""
+
+#: src/platforms/harmonyos.md:75
+msgid ""
+"**Install DevEco Studio** + the OpenHarmony SDK from Huawei. Verified "
+"working with DevEco Studio 6.0.2 + OpenHarmony 5.0+."
+msgstr ""
+
+#: src/platforms/harmonyos.md:77
+msgid "**Run the setup wizard once** (introduced in v0.5.380):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:83
+msgid ""
+"The wizard auto-discovers your DevEco-generated debug certificates from "
+"`~/.ohos/config/`, prompts for the keystore password, and persists the "
+"configuration to `~/.perry/config.toml`. Subsequent `perry compile --target "
+"harmonyos` invocations sign HAPs automatically."
+msgstr ""
+
+#: src/platforms/harmonyos.md:85
+msgid ""
+"**Optional**: install `hdc` (HarmonyOS Device Connector) for emulator "
+"interaction. It ships inside DevEco at "
+"`Contents/sdk/default/openharmony/toolchains/hdc`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:87
+msgid "Compile + run workflow"
+msgstr ""
+
+#: src/platforms/harmonyos.md:89
+msgid "Write a TypeScript program with `App({body: ...})`:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:91
+msgid ""
+"```typescript,no-test\n"
+"// hi.ts\n"
+"import { App, VStack, Text, Button, showToast } from \"perry/ui\";\n"
+"\n"
+"let count = 0;\n"
+"\n"
+"App({\n"
+"  title: \"Perry on HarmonyOS\",\n"
+"  body: VStack([\n"
+"    Text(\"Count: 0\", \"counter\"),\n"
+"    Button(\"+\", () => {\n"
+"      count++;\n"
+"      setText(\"counter\", `Count: ${count}`);\n"
+"    }),\n"
+"    Button(\"Notify\", () => {\n"
+"      showToast(`Counter is ${count}`);\n"
+"    }),\n"
+"  ]),\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/platforms/harmonyos.md:112
+msgid "Compile for HarmonyOS:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:118
+msgid "This produces three artifacts in `/tmp/`:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:120
+msgid "`libentry.so` — the compiled `.so` (8-9 MB typically)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:121
+msgid "`ets/pages/Index.ets` — the auto-emitted ArkUI page"
+msgstr ""
+
+#: src/platforms/harmonyos.md:122
+msgid "`cpp/types/libentry/Index.d.ts` — the NAPI declaration file"
+msgstr ""
+
+#: src/platforms/harmonyos.md:124
+msgid "**Splice** into a DevEco Studio project:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:132
+msgid ""
+"Click ▶ Run in DevEco — DevEco's hvigor signs + bundles the HAP and installs"
+" onto the emulator (or attached device). The app launches, taps fire your TS"
+" closures, and the screen updates reactively."
+msgstr ""
+
+#: src/platforms/harmonyos.md:134
+msgid "Architecture deep dive"
+msgstr ""
+
+#: src/platforms/harmonyos.md:136
+msgid "The harvest model"
+msgstr ""
+
+#: src/platforms/harmonyos.md:138
+msgid ""
+"`perry-codegen-arkts::emit_index_ets` walks `module.init` looking for the "
+"first `App({body: <expr>})` call from `perry/ui`. It extracts the `body` "
+"field, recursively emits ArkUI source for each widget in the tree, and "
+"**destructively replaces the App call with `Stmt::Expr(Expr::Number(0.0))`**"
+" so the LLVM backend never sees `perry_ui_*` FFI calls (which would be "
+"unresolved on the OHOS target — there's no `perry-ui-harmonyos` crate by "
+"design)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:140
+msgid ""
+"The emitted Index.ets is a real ArkUI `@Entry @Component struct Index { "
+"build() { ... } }` page with `@State` declarations for any reactive Text "
+"widgets, `import promptAction from '@ohos.promptAction'` for toast routing, "
+"and per-Button onClick handlers that invoke NAPI callbacks then drain queued"
+" toasts and text updates."
+msgstr ""
+
+#: src/platforms/harmonyos.md:142
+msgid "Closures across the NAPI boundary"
+msgstr ""
+
+#: src/platforms/harmonyos.md:144
+msgid ""
+"Each Button/Toggle/etc onClick closure registers via "
+"`perry_arkts_register_callback(idx, closure_handle)` during `main()` "
+"startup. The `closure_handle` is a NaN-boxed pointer to a real Perry "
+"`*ClosureHeader`. A GC root scanner registered in `gc_init` keeps registered"
+" closures alive across collections."
+msgstr ""
+
+#: src/platforms/harmonyos.md:146
+msgid ""
+"When ArkUI fires an onClick, the auto-emitted `.onClick(() => "
+"perryEntry.invokeCallback(0))` calls back into the `.so` via NAPI. The "
+"`invoke_callback` NAPI handler in `crates/perry-runtime/src/ohos_napi.rs` "
+"reads the int32 idx, looks up the slot, and dispatches via "
+"`js_closure_call0`. Multi-arg variants (Toggle/TextField/Slider) use "
+"`invokeCallback1(idx, value)` with `napi_typeof` dispatch to NaN-box the "
+"value (boolean / string / number) before calling `js_closure_call1`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:148
+msgid "The drain queue pattern"
+msgstr ""
+
+#: src/platforms/harmonyos.md:150
+msgid ""
+"`showToast` and `setText` calls inside a closure body push entries onto "
+"thread-local queues:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:151
+msgid "`PENDING_TOASTS: Mutex<VecDeque<String>>`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:152
+msgid "`PENDING_TEXT_UPDATES: Mutex<VecDeque<(String, String)>>`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:154
+msgid ""
+"After every onClick/onChange invocation, the auto-emitted handler in "
+"Index.ets drains both queues:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:172
+msgid ""
+"`applyTextUpdate(id, value)` is a switch over registered Text ids that "
+"assigns to the matching `@State text_<id>: string` field — ArkUI's "
+"reactivity then rerenders the Text widget."
+msgstr ""
+
+#: src/platforms/harmonyos.md:174
+msgid "Why NAPI?"
+msgstr ""
+
+#: src/platforms/harmonyos.md:176
+msgid ""
+"HarmonyOS NEXT uses the OpenHarmony NAPI binding (modeled on Node's NAPI) to"
+" load native `.so` libraries from ArkTS. Perry's `crates/perry-"
+"runtime/src/ohos_napi.rs` registers a module via `napi_module_register` in "
+"an `.init_array` constructor (Rust's equivalent of "
+"`__attribute__((constructor))`), with the modname auto-derived from the "
+"`.so` filename via `dladdr`. The exported NAPI surface is just `run` / "
+"`invokeCallback` / `invokeCallback1` / `drainToast` / `drainTextUpdate` — "
+"every other Perry runtime call happens within the `.so` itself."
+msgstr ""
+
+#: src/platforms/harmonyos.md:178
+msgid "Known limitations"
+msgstr ""
+
+#: src/platforms/harmonyos.md:180
+msgid ""
+"**LazyVStack is currently rendered eagerly** as a plain `Column`. Real lazy "
+"rendering for big lists needs ArkUI's `LazyForEach` + a custom `IDataSource`"
+" impl — tracked as Phase 2 v10."
+msgstr ""
+
+#: src/platforms/harmonyos.md:181
+msgid ""
+"**State binding is one-way** — `setText(\"id\", value)` from a closure "
+"updates the Text on-screen, but a generic `state<T>` reactive container "
+"(`const count = state(0); count.set(...)`) is Phase 2 v6 follow-up work."
+msgstr ""
+
+#: src/platforms/harmonyos.md:182
+msgid ""
+"**Multi-page navigation** (NavStack / Router across multiple `.ets` files) "
+"is Phase 2 v11."
+msgstr ""
+
+#: src/platforms/harmonyos.md:183
+msgid ""
+"**AppGallery production signing** uses a different cert chain than DevEco's "
+"debug certs and isn't yet plumbed into `perry compile`. The current splice "
+"workflow handles debug-emulator deploy."
+msgstr ""
+
+#: src/platforms/harmonyos.md:184
+msgid ""
+"**Real device validation** is pending — every milestone has been verified on"
+" the Pura 90 Pro Max emulator. AppGallery upload + real-hardware install "
+"will follow."
+msgstr ""
+
+#: src/platforms/harmonyos.md:186
+msgid "Validated on emulator"
+msgstr ""
+
+#: src/platforms/harmonyos.md:188
+msgid ""
+"End-to-end on Pura 90 Pro Max with a 5-widget interactive page (counter + "
+"reset, TextField echoing input live as `You typed: <text>`, Toggle flipping "
+"`Notifications: on/off` with toast feedback, Slider tracking `Volume: N` "
+"continuously, reactive Texts everywhere). Each interaction routes:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:196
+msgid ""
+"This is the first time Perry-compiled TypeScript state mutation has "
+"reactively driven a HarmonyOS NEXT screen."
+msgstr ""
+
+#: src/platforms/harmonyos.md:198
+msgid "Version history"
+msgstr ""
+
+#: src/platforms/harmonyos.md:200
+msgid ""
+"**v0.5.401** — Phase 2 v1.5: full widget set rendering "
+"(Text/VStack/HStack/Button/TextField/Toggle/Slider/Spacer/Divider)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:201
+msgid ""
+"**v0.5.417** — Phase 2 v2 + v3 + v2.5: Button onClick callback bridge, "
+"showToast, reactive Text via setText, multi-arg Toggle/TextField/Slider "
+"value forwarding."
+msgstr ""
+
+#: src/platforms/harmonyos.md:202
+msgid ""
+"**v0.5.418** — Phase 2 v4: Image / ScrollView / LazyVStack / Picker / "
+"ProgressView / Section."
+msgstr ""
+
+#: src/platforms/harmonyos.md:203
+msgid ""
+"**v0.5.420 / .421** — Cross-platform showToast + setText on iOS / tvOS / "
+"visionOS / Android."
+msgstr ""
+
+#: src/platforms/harmonyos.md:204
+msgid ""
+"**v0.5.422 / .423** — Cross-platform showToast + setText on Windows / GTK4."
+msgstr ""
+
+#: src/platforms/harmonyos.md:205
+msgid ""
+"**v0.5.429** — Phase 2 v5: inline `style: { ... }` + ForEach via array.map."
+msgstr ""
+
+#: src/platforms/harmonyos.md:207
+msgid ""
+"For the full per-version detail see "
+"[CHANGELOG.md](https://github.com/PerryTS/perry/blob/main/CHANGELOG.md)."
+msgstr ""
+
+#: src/platforms/windows.md:3
+msgid "Perry compiles TypeScript apps for Windows using the Win32 API."
+msgstr ""
+
+#: src/platforms/windows.md:7
+msgid ""
+"Windows 10 or later by default (Windows 7 SP1 / Windows 8 supported via "
+"`--min-windows-version=7|8` — see [Windows 7 Compatibility](./windows-7.md) "
+"for the trade-offs)"
+msgstr ""
+
+#: src/platforms/windows.md:8
+msgid "A linker toolchain — either of these two options:"
+msgstr ""
+
+#: src/platforms/windows.md:10
+msgid "Option A — Lightweight (recommended, ~1.5 GB, no Visual Studio)"
+msgstr ""
+
+#: src/platforms/windows.md:12
+msgid ""
+"Uses LLVM's `clang` + `lld-link` plus an xwin'd copy of the Microsoft CRT + "
+"Windows SDK libraries. No admin rights, no Visual Studio install."
+msgstr ""
+
+#: src/platforms/windows.md:19
+msgid ""
+"`perry setup windows` downloads ~700 MB (unpacks to ~1.5 GB) at "
+"`%LOCALAPPDATA%\\perry\\windows-sdk` after prompting you to accept the "
+"Microsoft redistributable license. Pass `--accept-license` to skip the "
+"prompt in CI. Partial downloads resume safely on re-run."
+msgstr ""
+
+#: src/platforms/windows.md:21
+msgid "Option B — Visual Studio (~8 GB)"
+msgstr ""
+
+#: src/platforms/windows.md:23
+msgid ""
+"If you already have Visual Studio installed, add the C++ workload via the "
+"Visual Studio Installer → _Modify_ → check **Desktop development with C++**."
+" Or install standalone Build Tools:"
+msgstr ""
+
+#: src/platforms/windows.md:30
+msgid ""
+"Both options produce identical binaries — Perry picks Option A when the "
+"xwin'd sysroot is present, Option B otherwise. Run `perry doctor` to see "
+"which is active."
+msgstr ""
+
+#: src/platforms/windows.md:40
+msgid "Perry maps UI widgets to Win32 controls:"
+msgstr ""
+
+#: src/platforms/windows.md:42
+msgid "Win32 Class"
+msgstr ""
+
+#: src/platforms/windows.md:46
+msgid "Edit HWND"
+msgstr ""
+
+#: src/platforms/windows.md:47
+msgid "Edit (ES_PASSWORD)"
+msgstr ""
+
+#: src/platforms/windows.md:48
+msgid "Checkbox"
+msgstr ""
+
+#: src/platforms/windows.md:49
+msgid "Trackbar (TRACKBAR_CLASSW)"
+msgstr ""
+
+#: src/platforms/windows.md:50
+msgid "ComboBox"
+msgstr ""
+
+#: src/platforms/windows.md:51
+msgid "PROGRESS_CLASSW"
+msgstr ""
+
+#: src/platforms/windows.md:54
+msgid "WS_VSCROLL"
+msgstr ""
+
+#: src/platforms/windows.md:55
+msgid "GDI drawing"
+msgstr ""
+
+#: src/platforms/windows.md:56
+msgid "Form/Section"
+msgstr ""
+
+#: src/platforms/windows.md:56
+msgid "GroupBox"
+msgstr ""
+
+#: src/platforms/windows.md:58
+msgid "Windows-Specific APIs"
+msgstr ""
+
+#: src/platforms/windows.md:60
+msgid "**Menu bar**: HMENU / SetMenu"
+msgstr ""
+
+#: src/platforms/windows.md:61
+msgid "**Dark mode**: Windows Registry detection"
+msgstr ""
+
+#: src/platforms/windows.md:62
+msgid "**Preferences**: Windows Registry"
+msgstr ""
+
+#: src/platforms/windows.md:63
+msgid ""
+"**Keychain**: CredWrite/CredRead/CredDelete (Windows Credential Manager)"
+msgstr ""
+
+#: src/platforms/windows.md:64
+msgid "**Notifications**: Toast notifications"
+msgstr ""
+
+#: src/platforms/windows.md:65
+msgid "**File dialogs**: IFileOpenDialog / IFileSaveDialog (COM)"
+msgstr ""
+
+#: src/platforms/windows.md:66
+msgid "**Alerts**: MessageBoxW"
+msgstr ""
+
+#: src/platforms/windows.md:67
+msgid "**Open URL**: ShellExecuteW"
+msgstr ""
+
+#: src/platforms/windows-7.md:3
+msgid ""
+"Perry supports compiling executables that run on Windows 7 SP1 (and Windows "
+"8 / 8.1) — opt-in via the `--min-windows-version` flag. The default target "
+"stays Windows 10+ to preserve full DPI fidelity and modern OS integration; "
+"legacy support is one flag away when you need it."
+msgstr ""
+
+#: src/platforms/windows-7.md:5
+msgid ""
+"This page covers what works, what degrades, what's outright impossible, and "
+"how to validate your build before shipping."
+msgstr ""
+
+#: src/platforms/windows-7.md:7
+msgid "TL;DR"
+msgstr ""
+
+#: src/platforms/windows-7.md:13
+msgid ""
+"Produces a PE marked Win7-compatible. Perry's UI runtime resolves the "
+"Win10-only DPI APIs lazily at startup and falls back through Win8.1 → Vista "
+"primitives, so the binary starts on Win7 SP1. Most UI widgets work. Some "
+"cosmetic effects (rounded corners, dark titlebar) silently no-op. **No "
+"JavaScript-module imports allowed** on Win7 — the V8 runtime is Win10+ "
+"unconditional."
+msgstr ""
+
+#: src/platforms/windows-7.md:15
+msgid "Why this is opt-in"
+msgstr ""
+
+#: src/platforms/windows-7.md:17
+msgid ""
+"Two things make a Win7-compatible PE different from a default Perry build:"
+msgstr ""
+
+#: src/platforms/windows-7.md:19
+msgid ""
+"**The PE subsystem version field.** Default Perry builds let the linker pick"
+" (currently `/SUBSYSTEM:WINDOWS` with no version, which marks the binary as "
+"needing Win8+). Win7 needs `/SUBSYSTEM:WINDOWS,5.1` or "
+"`/SUBSYSTEM:CONSOLE,5.1`. The `,5.1` suffix is the [PE subsystem "
+"ABI](https://learn.microsoft.com/en-us/windows/win32/debug/pe-"
+"format#optional-header-windows-specific-fields-image-only) declaration of "
+"\"I claim to run on Windows NT 5.1 or higher\" — the OS loader reads this "
+"field before deciding whether to load the binary."
+msgstr ""
+
+#: src/platforms/windows-7.md:21
+msgid ""
+"**Win10-only API calls become runtime-resolved.** Perry's UI library calls "
+"`SetProcessDpiAwarenessContext` (Win10 1607) and `GetDpiForSystem` (Win10 "
+"1607) for per-monitor v2 DPI awareness. Hard-importing them via `extern "
+"\"system\"` would emit IAT entries that the OS resolves _before_ `main()` "
+"runs — on Win7, the loader fails the process with \"entry point not found in"
+" user32.dll\" before any Rust code can run. With `--min-windows-version=7` "
+"(and on default builds too — the retrofit is unconditional), Perry resolves "
+"these symbols lazily via `LoadLibraryW + GetProcAddress` and falls back "
+"through:"
+msgstr ""
+
+#: src/platforms/windows-7.md:23
+msgid "Tier"
+msgstr ""
+
+#: src/platforms/windows-7.md:23 src/plugins/appstore-review.md:54
+msgid "API"
+msgstr ""
+
+#: src/platforms/windows-7.md:23
+msgid "Min Windows"
+msgstr ""
+
+#: src/platforms/windows-7.md:25
+msgid "`SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)`"
+msgstr ""
+
+#: src/platforms/windows-7.md:25
+msgid "Windows 10 1607"
+msgstr ""
+
+#: src/platforms/windows-7.md:26
+msgid "`SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)`"
+msgstr ""
+
+#: src/platforms/windows-7.md:26
+msgid "Windows 8.1"
+msgstr ""
+
+#: src/platforms/windows-7.md:27
+msgid "`SetProcessDPIAware()`"
+msgstr ""
+
+#: src/platforms/windows-7.md:27
+msgid "Windows Vista"
+msgstr ""
+
+#: src/platforms/windows-7.md:29
+msgid ""
+"System DPI lookup uses the same lazy pattern: `GetDpiForSystem` (Win10) → "
+"`GetDC + GetDeviceCaps(LOGPIXELSY)` (Win2000+)."
+msgstr ""
+
+#: src/platforms/windows-7.md:31
+msgid ""
+"The `--min-windows-version` flag controls only (1) — the PE marker. The lazy"
+" DPI resolution from (2) is always active because it costs essentially "
+"nothing and makes default builds more robust against being run on stripped-"
+"down Windows installs."
+msgstr ""
+
+#: src/platforms/windows-7.md:33
+msgid "Accepted values"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "`--min-windows-version`"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Subsystem suffix"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Targets"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Default?"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "`10`"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "(none — linker default)"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "Windows 10+"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "yes"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "`8`"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "`,6.02`"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "Windows 8 / 8.1+"
+msgstr ""
+
+#: src/platforms/windows-7.md:38 src/platforms/windows-7.md:39
+msgid "no"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "`7`"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "`,5.1`"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "Windows 7 SP1+"
+msgstr ""
+
+#: src/platforms/windows-7.md:41
+msgid ""
+"Anything else is a hard error at compile time — typos like `--min-windows-"
+"version=11` fail loudly instead of silently behaving like the default."
+msgstr ""
+
+#: src/platforms/windows-7.md:43
+msgid "What works on Win7"
+msgstr ""
+
+#: src/platforms/windows-7.md:45
+msgid ""
+"The same audit that produced this feature found 12 KLOC of Win32 UI code in "
+"`perry-ui-windows` and 5 calls that touch Win10+ APIs. The 5 break down as 2"
+" hard blockers (now lazy-resolved) and 3 cosmetic-effect calls that already "
+"failed soft and silently no-op on Win7. So the bulk of the UI surface — "
+"every standard widget — works on Win7 SP1:"
+msgstr ""
+
+#: src/platforms/windows-7.md:47
+msgid ""
+"All layout containers (`VStack`, `HStack`, `ZStack`, `ScrollView`, `Spacer`,"
+" `Divider`)"
+msgstr ""
+
+#: src/platforms/windows-7.md:48
+msgid ""
+"All input widgets (`Button`, `TextField`, `SecureField`, `Toggle`, `Slider`,"
+" `Picker`, `ProgressView`)"
+msgstr ""
+
+#: src/platforms/windows-7.md:49
+msgid "`Text`, `Canvas`, `Image` (file + symbol)"
+msgstr ""
+
+#: src/platforms/windows-7.md:50
+msgid "`Form` and `LazyVStack`"
+msgstr ""
+
+#: src/platforms/windows-7.md:51
+msgid "File / folder open / save dialogs"
+msgstr ""
+
+#: src/platforms/windows-7.md:52
+msgid "Clipboard access"
+msgstr ""
+
+#: src/platforms/windows-7.md:53
+msgid "Audio (WASAPI is Vista+)"
+msgstr ""
+
+#: src/platforms/windows-7.md:54
+msgid "Keyboard shortcuts, menus, toolbars"
+msgstr ""
+
+#: src/platforms/windows-7.md:55
+msgid "Multi-window"
+msgstr ""
+
+#: src/platforms/windows-7.md:56
+msgid ""
+"The full `perry-runtime` and `perry-stdlib` surface — `fs`, `http`, "
+"`crypto`, `child_process`, `Date`, `Buffer`, etc."
+msgstr ""
+
+#: src/platforms/windows-7.md:58
+msgid "What degrades silently"
+msgstr ""
+
+#: src/platforms/windows-7.md:60
+msgid ""
+"These behaviors target Win10 / Win11 features. On Win7 the API call returns "
+"an error code that Perry already swallows; the binary runs, but the visual "
+"effect is missing:"
+msgstr ""
+
+#: src/platforms/windows-7.md:62
+msgid ""
+"**DPI quality.** Win7 has system-wide DPI only — moving a window between "
+"monitors with different DPI doesn't trigger re-scaling. Per-monitor v2 (font"
+" hinting, dialog scaling) is Win10 1607+."
+msgstr ""
+
+#: src/platforms/windows-7.md:63
+msgid ""
+"**Dark titlebar.** `DWMWA_USE_IMMERSIVE_DARK_MODE` is Win10 1809+. Titlebar "
+"follows the system theme on Win7 (light only on stock Win7)."
+msgstr ""
+
+#: src/platforms/windows-7.md:64
+msgid ""
+"**Rounded window corners.** `DWMWA_WINDOW_CORNER_PREFERENCE` is Win11+. "
+"Frameless windows have square corners on Win7 / Win10."
+msgstr ""
+
+#: src/platforms/windows-7.md:65
+msgid ""
+"**Mica / Acrylic backdrop.** `DWMWA_SYSTEMBACKDROP_TYPE` is Win11+. Backdrop"
+" falls through to the standard window background on Win7 / Win10."
+msgstr ""
+
+#: src/platforms/windows-7.md:67
+msgid "What is impossible"
+msgstr ""
+
+#: src/platforms/windows-7.md:69
+msgid ""
+"**`perry/jsruntime` (V8 / deno_core) is Win10+ unconditional.** Anything in "
+"your project that imports a `.js` module from `node_modules` triggers "
+"`--enable-jsruntime`, which links against deno_core, which embeds V8, which "
+"won't load on Win7. There's no fallback for this — Win7 builds must avoid "
+"JS-module imports entirely. If your project compiles cleanly without "
+"`--enable-jsruntime` (i.e. only TypeScript imports, only Perry-native "
+"packages), you're good."
+msgstr ""
+
+#: src/platforms/windows-7.md:71
+msgid ""
+"**Universal Windows Platform (UWP / WinRT) APIs.** Perry doesn't currently "
+"use these, but if a future feature does (e.g. modern toast notifications), "
+"it'll be Win10+ only. The runtime + stdlib audit was clean as of v0.5.395."
+msgstr ""
+
+#: src/platforms/windows-7.md:73
+msgid "How the lazy DPI resolution works"
+msgstr ""
+
+#: src/platforms/windows-7.md:75
+msgid ""
+"The retrofit lives in `crates/perry-ui-windows/src/dpi_compat.rs`. It "
+"exposes two functions, both safe to call on any Windows version from Vista "
+"onward:"
+msgstr ""
+
+#: src/platforms/windows-7.md:82
+msgid "Internally each function:"
+msgstr ""
+
+#: src/platforms/windows-7.md:84
+msgid ""
+"Calls `LoadLibraryA(\"user32.dll\")` (and `shcore.dll` for the Win8.1 tier) "
+"— both are loaded into every Win32 process by the kernel before `main`, so "
+"the call is a cheap handle lookup."
+msgstr ""
+
+#: src/platforms/windows-7.md:85
+msgid ""
+"Calls `GetProcAddress` to find the desired symbol. Caches the result "
+"(success or failure) in an `AtomicPtr` + `AtomicU8` pair, so the lookup runs"
+" at most once per process."
+msgstr ""
+
+#: src/platforms/windows-7.md:86
+msgid ""
+"Falls through to the next tier on miss. `set_process_dpi_awareness_compat` "
+"ends with `SetProcessDPIAware()` (Vista+, hard-imported because every "
+"supported Windows has it). `get_system_dpi_compat` ends with "
+"`GetDeviceCaps(LOGPIXELSY)` (Win2000+, dead reliable)."
+msgstr ""
+
+#: src/platforms/windows-7.md:88
+msgid ""
+"After the cache is warm — i.e. after `app_create` runs once — every "
+"subsequent DPI query is a single atomic load + indirect call. No measurable "
+"runtime cost vs. a hard-imported call."
+msgstr ""
+
+#: src/platforms/windows-7.md:90
+msgid "Validating a Win7 build"
+msgstr ""
+
+#: src/platforms/windows-7.md:92
+msgid ""
+"Perry's CI and dev hosts don't have Win7 VMs. If you ship to Win7 you need "
+"to validate the binary yourself. Three checks:"
+msgstr ""
+
+#: src/platforms/windows-7.md:94
+msgid "1. PE subsystem version"
+msgstr ""
+
+#: src/platforms/windows-7.md:96
+msgid ""
+"Use `dumpbin /headers app.exe | findstr \"subsystem\"` (MSVC) or `objdump -p"
+" app.exe | grep \"MajorOSVersion\"` (LLVM):"
+msgstr ""
+
+#: src/platforms/windows-7.md:98
+msgid ""
+"```text\n"
+"$ dumpbin /headers app.exe | findstr \"subsystem\"\n"
+"            5.01 subsystem version\n"
+"               2 subsystem (Windows GUI)\n"
+"```"
+msgstr ""
+
+#: src/platforms/windows-7.md:104
+msgid ""
+"The `5.01` confirms the PE is Win7-compatible. A default build shows `6.00` "
+"or higher."
+msgstr ""
+
+#: src/platforms/windows-7.md:106
+msgid "2. Imports"
+msgstr ""
+
+#: src/platforms/windows-7.md:108
+msgid ""
+"Use `dumpbin /imports app.exe | findstr /i \"user32\"` (MSVC) or `objdump -p"
+" app.exe | grep -A20 \"DLL Name: user32\"` (LLVM). Confirm that "
+"`SetProcessDpiAwarenessContext` and `GetDpiForSystem` are **not** in the "
+"user32.dll import list. If they are, the lazy retrofit isn't taking effect —"
+" likely you've added a `use "
+"windows::Win32::UI::HiDpi::SetProcessDpiAwarenessContext;` somewhere that "
+"pulls the symbol back in."
+msgstr ""
+
+#: src/platforms/windows-7.md:110
+msgid "3. Run on a Win7 SP1 VM"
+msgstr ""
+
+#: src/platforms/windows-7.md:112
+msgid ""
+"There's no substitute for actually launching the binary. Microsoft's free "
+"Win7 evaluation VM (no longer hosted directly by Microsoft, mirrored on "
+"archive.org) is the canonical reference image. Worth keeping a snapshot for "
+"regression checks."
+msgstr ""
+
+#: src/platforms/windows-7.md:114
+msgid "Caveats and gotchas"
+msgstr ""
+
+#: src/platforms/windows-7.md:116
+msgid ""
+"**The MSVC linker may warn** about subsystem version `,5.1` being below the "
+"C runtime's stated minimum on newer toolchains. The warning is benign — the "
+"CRT itself runs on Win7, the warning is conservative. Watch for hard errors,"
+" not warnings."
+msgstr ""
+
+#: src/platforms/windows-7.md:117
+msgid ""
+"**xwin sysroot setup is unchanged.** Cross-compiling from macOS / Linux "
+"still uses the `perry setup windows` xwin'd toolchain. Nothing in `--min-"
+"windows-version` changes the SDK requirements."
+msgstr ""
+
+#: src/platforms/windows-7.md:118
+msgid ""
+"**Static-link the CRT** if you want the binary to run on a clean Win7 SP1 "
+"install with no Visual C++ Redistributable. Confirm the binary doesn't "
+"import `vcruntime140.dll` / `msvcp140.dll` via the dumpbin/objdump check "
+"above."
+msgstr ""
+
+#: src/platforms/windows-7.md:119
+msgid ""
+"**`perry/thread`'s SRWLOCK is Vista+, fine.** Perry's threading primitives "
+"use Rust std, which uses SRWLOCK on Windows since Rust 1.42. No "
+"`WaitOnAddress` (Win8+) involvement on the supported Rust versions."
+msgstr ""
+
+#: src/platforms/windows-7.md:121
+msgid "Issue tracking"
+msgstr ""
+
+#: src/platforms/windows-7.md:123
+msgid ""
+"This feature lands as the resolution to "
+"[\\#303](https://github.com/PerryTS/perry/issues/303). If you hit a "
+"Win7-specific failure that isn't covered here, please file a follow-up "
+"referencing this page so we can extend the audit."
+msgstr ""
+
+#: src/platforms/linux.md:3
+msgid "Perry compiles TypeScript apps for Linux using GTK4."
+msgstr ""
+
+#: src/platforms/linux.md:7
+msgid "GTK4 development libraries:"
+msgstr ""
+
+#: src/platforms/linux.md:15
+msgid "# Arch\n"
+msgstr ""
+
+#: src/platforms/linux.md:18
+msgid "Cairo development libraries (for canvas):"
+msgstr ""
+
+#: src/platforms/linux.md:32
+msgid "Perry maps UI widgets to GTK4 widgets:"
+msgstr ""
+
+#: src/platforms/linux.md:34
+msgid "GTK4 Widget"
+msgstr ""
+
+#: src/platforms/linux.md:38
+msgid "GtkEntry"
+msgstr ""
+
+#: src/platforms/linux.md:39
+msgid "GtkPasswordEntry"
+msgstr ""
+
+#: src/platforms/linux.md:40
+msgid "GtkSwitch"
+msgstr ""
+
+#: src/platforms/linux.md:41
+msgid "GtkScale"
+msgstr ""
+
+#: src/platforms/linux.md:42
+msgid "GtkDropDown"
+msgstr ""
+
+#: src/platforms/linux.md:43
+msgid "GtkProgressBar"
+msgstr ""
+
+#: src/platforms/linux.md:44
+msgid "GtkImage"
+msgstr ""
+
+#: src/platforms/linux.md:45
+msgid "GtkBox (vertical)"
+msgstr ""
+
+#: src/platforms/linux.md:46
+msgid "GtkBox (horizontal)"
+msgstr ""
+
+#: src/platforms/linux.md:47
+msgid "GtkOverlay"
+msgstr ""
+
+#: src/platforms/linux.md:48
+msgid "GtkScrolledWindow"
+msgstr ""
+
+#: src/platforms/linux.md:49
+msgid "Cairo drawing"
+msgstr ""
+
+#: src/platforms/linux.md:50
+msgid "GtkStack"
+msgstr ""
+
+#: src/platforms/linux.md:52
+msgid "Linux-Specific APIs"
+msgstr ""
+
+#: src/platforms/linux.md:54
+msgid "**Menu bar**: GMenu / set_menubar"
+msgstr ""
+
+#: src/platforms/linux.md:55
+msgid "**Toolbar**: GtkHeaderBar"
+msgstr ""
+
+#: src/platforms/linux.md:56
+msgid "**Dark mode**: GTK settings detection"
+msgstr ""
+
+#: src/platforms/linux.md:57
+msgid "**Preferences**: GSettings or file-based"
+msgstr ""
+
+#: src/platforms/linux.md:58
+msgid "**Keychain**: libsecret"
+msgstr ""
+
+#: src/platforms/linux.md:59
+msgid "**Notifications**: GNotification"
+msgstr ""
+
+#: src/platforms/linux.md:60
+msgid "**File dialogs**: GtkFileChooserDialog"
+msgstr ""
+
+#: src/platforms/linux.md:61
+msgid "**Alerts**: GtkMessageDialog"
+msgstr ""
+
+#: src/platforms/linux.md:65
+msgid ""
+"GTK4 styling uses CSS under the hood. Perry's styling methods (colors, "
+"fonts, corner radius) are translated to CSS properties applied via "
+"`CssProvider`."
+msgstr ""
+
+#: src/platforms/linux.md:67
+msgid "Testing with Geisterhand"
+msgstr ""
+
+#: src/platforms/linux.md:69
+msgid ""
+"Perry's built-in UI fuzzer works on Linux/GTK4. Screenshots use "
+"`WidgetPaintable` + `GskRenderer` for pixel-accurate capture."
+msgstr ""
+
+#: src/platforms/linux.md:73
+msgid "# In another terminal:\n"
+msgstr ""
+
+#: src/platforms/linux.md:79
+msgid "See [Geisterhand](../testing/geisterhand.md) for full API reference."
+msgstr ""
+
+#: src/platforms/web.md:3
+msgid ""
+"`--target web` and `--target wasm` are aliases for the same backend. Both "
+"produce a self-contained HTML file with embedded WebAssembly and a "
+"JavaScript bridge for DOM widgets."
+msgstr ""
+
+#: src/platforms/web.md:6
+msgid "# same output as --target wasm\n"
+msgstr ""
+
+#: src/platforms/web.md:10
+msgid ""
+"See **[WebAssembly / Web](wasm.md)** for the full documentation: how it "
+"works, supported features, UI mapping, FFI, threading, limitations, and "
+"examples."
+msgstr ""
+
+#: src/platforms/web.md:12
+msgid "Why one target instead of two?"
+msgstr ""
+
+#: src/platforms/web.md:14
+msgid "Perry used to have two browser backends:"
+msgstr ""
+
+#: src/platforms/web.md:16
+msgid "`--target web` (`perry-codegen-js`) — transpiled HIR to JavaScript"
+msgstr ""
+
+#: src/platforms/web.md:17
+msgid "`--target wasm` (`perry-codegen-wasm`) — compiled HIR to WebAssembly"
+msgstr ""
+
+#: src/platforms/web.md:19
+msgid ""
+"These were consolidated into the WASM target so browser apps get near-native"
+" performance, FFI imports, and Web Worker threading without needing a "
+"separate JS-emit pipeline. The DOM widget runtime that the old `--target "
+"web` provided is now embedded in `wasm_runtime.js`. Both flags route through"
+" `perry-codegen-wasm` and produce identical HTML output."
+msgstr ""
+
+#: src/platforms/web.md:23
+msgid "[WebAssembly / Web](wasm.md) — full target documentation"
+msgstr ""
+
+#: src/platforms/web.md:24
+msgid "[Platform Overview](overview.md) — all platforms"
+msgstr ""
+
+#: src/platforms/wasm.md:1
+msgid "WebAssembly / Web"
+msgstr ""
+
+#: src/platforms/wasm.md:3
+msgid ""
+"Perry compiles TypeScript apps to **WebAssembly** for the browser using "
+"`--target wasm` or its alias `--target web`. Both flags route through the "
+"same backend (`perry-codegen-wasm`) and produce the same output: a self-"
+"contained HTML file with embedded WASM bytecode and a thin JavaScript bridge"
+" for DOM widgets and host APIs."
+msgstr ""
+
+#: src/platforms/wasm.md:5
+msgid ""
+"There used to be a separate JavaScript-emitting `--target web` (`perry-"
+"codegen-js`); it was consolidated into the WASM target so browser apps get "
+"near-native performance, FFI imports, and Web Worker threading \"for free\"."
+msgstr ""
+
+#: src/platforms/wasm.md:10
+msgid "# Self-contained HTML (default)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:13
+msgid "# Same thing\n"
+msgstr ""
+
+#: src/platforms/wasm.md:16
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:21
+msgid ""
+"The default output is a single `.html` file containing a base64-embedded "
+"WASM binary, the `wasm_runtime.js` bridge, and a `bootPerryWasm()` call that"
+" instantiates the module. Open it directly in any modern browser — no build "
+"step, no server required for simple apps."
+msgstr ""
+
+#: src/platforms/wasm.md:23
+msgid ""
+"**Note**: Apps that use `fetch()` or other web platform APIs that depend on "
+"a real origin must be served over HTTP (file:// URLs run into CORS / "
+"\"Failed to fetch\" errors). Any local static server works:"
+msgstr ""
+
+#: src/platforms/wasm.md:31
+msgid ""
+"The `perry-codegen-wasm` crate compiles HIR directly to WASM bytecode using "
+"`wasm-encoder`. The output WASM:"
+msgstr ""
+
+#: src/platforms/wasm.md:33
+msgid ""
+"Imports ~280 host functions under the `rt` namespace (string ops, math, "
+"console, JSON, classes, closures, promises, fetch, etc.)"
+msgstr ""
+
+#: src/platforms/wasm.md:34
+msgid "Imports user-declared FFI functions under the `ffi` namespace"
+msgstr ""
+
+#: src/platforms/wasm.md:35
+msgid ""
+"Exports `_start`, `memory`, `__indirect_function_table`, and every user "
+"function as `__wasm_func_<idx>` (so async function bodies compiled to JS can"
+" call back into WASM)"
+msgstr ""
+
+#: src/platforms/wasm.md:37
+msgid ""
+"The NaN-boxing scheme matches the native `perry-runtime` — f64 values with "
+"STRING_TAG/POINTER_TAG/INT32_TAG — so the same value representation is used "
+"across native and WASM targets. The JS bridge wraps every host import with "
+"bit-level reinterpretation so f64 NaN-boxed values pass through the BigInt-"
+"based JS↔WASM i64 boundary intact (BigInt(NaN) would otherwise throw)."
+msgstr ""
+
+#: src/platforms/wasm.md:41
+msgid ""
+"**Full TypeScript language**: classes (with constructors, methods, "
+"getters/setters, inheritance, fields), async/await, closures (with "
+"captures), generators, destructuring, template literals, generics, enums, "
+"try/catch/finally"
+msgstr ""
+
+#: src/platforms/wasm.md:42
+msgid ""
+"**Module system**: cross-module imports, top-level `const`/`let` (promoted "
+"to WASM globals), circular imports"
+msgstr ""
+
+#: src/platforms/wasm.md:43
+msgid ""
+"**Standard library**: String/Array/Object methods, Map/Set, JSON, Date, "
+"RegExp, Math, Error, URL/URLSearchParams, Buffer, Promise (with "
+"`.then`/`.catch`/`.allSettled`/`.race`/`.any`/`.all`)"
+msgstr ""
+
+#: src/platforms/wasm.md:44
+msgid ""
+"**Async**: `async`/`await` (compiled to JS Promises), "
+"`setTimeout`/`setInterval`, `fetch()` with full request options (method, "
+"headers, body)"
+msgstr ""
+
+#: src/platforms/wasm.md:45
+msgid ""
+"**Threading**: `perry/thread` `parallelMap`/`parallelFilter`/`spawn` via Web"
+" Worker pool with one WASM instance per worker (see "
+"[Threading](../threading/overview.md))"
+msgstr ""
+
+#: src/platforms/wasm.md:46
+msgid ""
+"**DOM-based UI**: every widget in `perry/ui` (`VStack`, `HStack`, `ZStack`, "
+"`Text`, `Button`, `TextField`, `Toggle`, `Slider`, `ScrollView`, `Picker`, "
+"`Image`, `Canvas`, `Form`, `Section`, `NavigationStack`, `Table`, "
+"`LazyVStack`, `TextArea`, etc.) maps to a DOM element with flexbox layout. "
+"State bindings (`bindText`/`bindSlider`/`bindToggle`/`bindForEach`/...) work"
+" via reactive subscribers."
+msgstr ""
+
+#: src/platforms/wasm.md:47
+msgid ""
+"**System APIs**: `localStorage`\\-backed preferences/keychain, dark mode "
+"detection (`prefers-color-scheme`), Web Notifications, clipboard, file "
+"open/save dialogs, File System Access API, Web Audio capture"
+msgstr ""
+
+#: src/platforms/wasm.md:48
+msgid ""
+"**FFI**: `declare function` declarations become WASM imports under the `ffi`"
+" namespace"
+msgstr ""
+
+#: src/platforms/wasm.md:49
+msgid ""
+"**Compile-time i18n**: `perry/i18n` `t()` calls work the same as native "
+"targets"
+msgstr ""
+
+#: src/platforms/wasm.md:51
+msgid "UI Mapping"
+msgstr ""
+
+#: src/platforms/wasm.md:53
+msgid "Perry widgets map to HTML elements:"
+msgstr ""
+
+#: src/platforms/wasm.md:55
+msgid "HTML Element"
+msgstr ""
+
+#: src/platforms/wasm.md:57 src/widgets/wearos.md:24
+msgid "`Text`"
+msgstr ""
+
+#: src/platforms/wasm.md:58
+msgid "`Button`"
+msgstr ""
+
+#: src/platforms/wasm.md:59
+msgid "`TextField`"
+msgstr ""
+
+#: src/platforms/wasm.md:59
+msgid "`<input type=\"text\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:60
+msgid "`SecureField`"
+msgstr ""
+
+#: src/platforms/wasm.md:60
+msgid "`<input type=\"password\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:61
+msgid "`Toggle`"
+msgstr ""
+
+#: src/platforms/wasm.md:61
+msgid "`<input type=\"checkbox\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:62
+msgid "`Slider`"
+msgstr ""
+
+#: src/platforms/wasm.md:62
+msgid "`<input type=\"range\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:63
+msgid "`Picker`"
+msgstr ""
+
+#: src/platforms/wasm.md:63
+msgid "`<select>`"
+msgstr ""
+
+#: src/platforms/wasm.md:64
+msgid "`ProgressView`"
+msgstr ""
+
+#: src/platforms/wasm.md:64
+msgid "`<progress>`"
+msgstr ""
+
+#: src/platforms/wasm.md:65
+msgid "`Image` / `ImageFile`"
+msgstr ""
+
+#: src/platforms/wasm.md:65
+msgid "`<img>`"
+msgstr ""
+
+#: src/platforms/wasm.md:66 src/widgets/wearos.md:25
+msgid "`VStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:66
+msgid "`<div>` (flexbox column)"
+msgstr ""
+
+#: src/platforms/wasm.md:67 src/widgets/wearos.md:26
+msgid "`HStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:67
+msgid "`<div>` (flexbox row)"
+msgstr ""
+
+#: src/platforms/wasm.md:68
+msgid "`ZStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:68
+msgid "`<div>` (position: relative + absolute children)"
+msgstr ""
+
+#: src/platforms/wasm.md:69
+msgid "`ScrollView`"
+msgstr ""
+
+#: src/platforms/wasm.md:69
+msgid "`<div>` (overflow: auto)"
+msgstr ""
+
+#: src/platforms/wasm.md:70
+msgid "`Canvas`"
+msgstr ""
+
+#: src/platforms/wasm.md:70
+msgid "`<canvas>` (2D context)"
+msgstr ""
+
+#: src/platforms/wasm.md:71
+msgid "`Table`"
+msgstr ""
+
+#: src/platforms/wasm.md:71
+msgid "`<table>`"
+msgstr ""
+
+#: src/platforms/wasm.md:72 src/widgets/wearos.md:28
+msgid "`Divider`"
+msgstr ""
+
+#: src/platforms/wasm.md:72
+msgid "`<hr>`"
+msgstr ""
+
+#: src/platforms/wasm.md:73 src/widgets/wearos.md:27
+msgid "`Spacer`"
+msgstr ""
+
+#: src/platforms/wasm.md:73
+msgid "`<div>` (flex: 1)"
+msgstr ""
+
+#: src/platforms/wasm.md:75
+msgid "FFI Support"
+msgstr ""
+
+#: src/platforms/wasm.md:77
+msgid ""
+"The WASM target supports external FFI functions declared with `declare "
+"function`. They become WASM imports under the `\"ffi\"` namespace:"
+msgstr ""
+
+#: src/platforms/wasm.md:85
+msgid "Provide them when instantiating:"
+msgstr ""
+
+#: src/platforms/wasm.md:88
+msgid "// Via __ffiImports global (set before boot)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:90
+msgid "// Or via bootPerryWasm second argument\n"
+msgstr ""
+
+#: src/platforms/wasm.md:95
+msgid ""
+"**Auto-stub for missing imports.** The `ffi` namespace is wrapped in a "
+"`Proxy` so any FFI function the host doesn't provide is auto-stubbed with a "
+"no-op that returns `TAG_UNDEFINED`. This means apps that use native "
+"libraries (e.g. Hone Editor's 56 `hone_editor_*` functions) can still "
+"instantiate and run in the browser even without the native bindings — the "
+"relevant features are simply no-ops."
+msgstr ""
+
+#: src/platforms/wasm.md:97
+msgid "Module-Level Constants"
+msgstr ""
+
+#: src/platforms/wasm.md:99
+msgid ""
+"Top-level `const`/`let` declarations are promoted to dedicated WASM globals "
+"so functions in the same module can read them, and so two modules' identical"
+" `LocalId`s don't collide:"
+msgstr ""
+
+#: src/platforms/wasm.md:101
+msgid ""
+"```typescript\n"
+"// telemetry.ts\n"
+"const CHIRP_URL = 'https://api.chirp247.com/api/v1/event'\n"
+"const API_KEY   = 'my-key'\n"
+"\n"
+"export function trackEvent(event: string): void {\n"
+"    fetch(CHIRP_URL, {\n"
+"        method: 'POST',\n"
+"        headers: { 'Content-Type': 'application/json', 'X-Chirp-Key': API_KEY },\n"
+"        body: JSON.stringify({ event }),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/wasm.md:115
+msgid ""
+"Both `CHIRP_URL` and `API_KEY` become WASM globals indexed by `(module_idx, "
+"LocalId)`. Reading them from `trackEvent` emits a `global.get` instead of "
+"trying to look up a function-local that doesn't exist."
+msgstr ""
+
+#: src/platforms/wasm.md:117
+msgid "JavaScript Runtime Bridge"
+msgstr ""
+
+#: src/platforms/wasm.md:119
+msgid ""
+"The bridge (`wasm_runtime.js`) is embedded in the HTML and provides ~280 "
+"imports across:"
+msgstr ""
+
+#: src/platforms/wasm.md:121
+msgid ""
+"**NaN-boxing helpers**: `f64ToU64` / `u64ToF64` / `nanboxString` / "
+"`nanboxPointer` / `toJsValue` / `fromJsValue`"
+msgstr ""
+
+#: src/platforms/wasm.md:122
+msgid "**String table**: dynamic JS string array indexed by string ID"
+msgstr ""
+
+#: src/platforms/wasm.md:123
+msgid ""
+"**Handle store**: maps integer handle IDs to JS objects, arrays, closures, "
+"promises, DOM elements"
+msgstr ""
+
+#: src/platforms/wasm.md:124
+msgid ""
+"**Core ops**: console, math, JSON, JSON.parse/stringify, Date, RegExp, URL, "
+"Map, Set, Buffer, fetch"
+msgstr ""
+
+#: src/platforms/wasm.md:125
+msgid ""
+"**Closure dispatch**: indirect function table + capture array, with "
+"`closure_call_0/1/2/3/spread`"
+msgstr ""
+
+#: src/platforms/wasm.md:126
+msgid ""
+"**Class dispatch**: `class_new`, `class_call_method`, `class_get_field`, "
+"`class_set_field`, parent table for inheritance"
+msgstr ""
+
+#: src/platforms/wasm.md:127
+msgid ""
+"**DOM widgets**: 168+ `perry_ui_*` functions covering every widget in "
+"`perry/ui`"
+msgstr ""
+
+#: src/platforms/wasm.md:128
+msgid ""
+"**Async functions**: compiled to JS function bodies and merged into the "
+"import object as `__async_<name>`"
+msgstr ""
+
+#: src/platforms/wasm.md:130
+msgid ""
+"All host imports are wrapped via `wrapImportsForI64()` so they automatically"
+" reinterpret BigInt args (from WASM i64 params) into f64 internally and "
+"reinterpret Number returns back into BigInt. Without this wrapping, every "
+"NaN-valued f64 return would crash with \"Cannot convert NaN to a BigInt\"."
+msgstr ""
+
+#: src/platforms/wasm.md:132
+msgid "Web Worker Threading"
+msgstr ""
+
+#: src/platforms/wasm.md:134
+msgid "`perry/thread` works in the browser via a Web Worker pool:"
+msgstr ""
+
+#: src/platforms/wasm.md:144
+msgid ""
+"Each worker instantiates its own WASM module with the same bytecode and "
+"bridge. Values cross between the main thread and workers via structured-"
+"clone serialization. See [Threading](../threading/overview.md)."
+msgstr ""
+
+#: src/platforms/wasm.md:148
+msgid ""
+"**No file system access** beyond the File System Access API "
+"(`window.showDirectoryPicker()`)"
+msgstr ""
+
+#: src/platforms/wasm.md:149
+msgid "**No raw TCP/UDP sockets** — only `fetch()` and `WebSocket`"
+msgstr ""
+
+#: src/platforms/wasm.md:150
+msgid "**No subprocess spawning** — `child_process.exec` etc. are no-ops"
+msgstr ""
+
+#: src/platforms/wasm.md:151
+msgid ""
+"**No native databases** — SQLite, Postgres, MySQL drivers don't compile to "
+"web"
+msgstr ""
+
+#: src/platforms/wasm.md:152
+msgid ""
+"**CORS** applies to all `fetch()` calls — third-party APIs must allow your "
+"origin"
+msgstr ""
+
+#: src/platforms/wasm.md:153
+msgid ""
+"**localStorage**, not real keychain — fine for preferences, not for secrets"
+msgstr ""
+
+#: src/platforms/wasm.md:154
+msgid ""
+"Source-mapped stack traces are JS-only; WASM stack frames show `wasm-"
+"function[N]`"
+msgstr ""
+
+#: src/platforms/wasm.md:156
+msgid "Minification"
+msgstr ""
+
+#: src/platforms/wasm.md:158
+msgid ""
+"Use `--minify` to minify the embedded JS runtime bridge in the HTML output. "
+"The Rust-native JS minifier strips comments, collapses whitespace, and "
+"mangles internal identifiers, compressing the runtime from ~3,400 lines to "
+"~180."
+msgstr ""
+
+#: src/platforms/wasm.md:164
+msgid "Example: Counter App"
+msgstr ""
+
+#: src/platforms/wasm.md:187
+msgid "Example: Real-World App (Mango MongoDB GUI)"
+msgstr ""
+
+#: src/platforms/wasm.md:189
+msgid ""
+"The [Mango](https://github.com/PerryTS/mango) MongoDB GUI — 50 modules, 998 "
+"functions, classes, async functions, fetch with custom headers, the Hone "
+"code editor — compiles to a single 4 MB HTML file via `--target web` and "
+"renders its full UI (welcome screen, query view, edit view) in the browser. "
+"SQLite-backed connection storage gracefully degrades to an in-memory "
+"transient store on web; the rest of the app works the same as the native "
+"version."
+msgstr ""
+
+#: src/platforms/wasm.md:195
+msgid "[Threading](../threading/overview.md) — Web Worker threading"
+msgstr ""
+
+#: src/stdlib/overview.md:1
+msgid "Standard Library Overview"
+msgstr ""
+
+#: src/stdlib/overview.md:3
+msgid ""
+"Perry natively implements many popular npm packages and Node.js APIs. When "
+"you import a supported package, Perry compiles it to native code — no "
+"JavaScript runtime involved."
+msgstr ""
+
+#: src/stdlib/overview.md:7
+msgid ""
+"```typescript\n"
+"import fastify from \"fastify\"\n"
+"import mysql from \"mysql2/promise\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/overview.md:12
+msgid ""
+"Perry recognizes these imports at compile time and routes them to native "
+"Rust implementations in the `perry-stdlib` crate. The API surface matches "
+"the original npm package, so existing code often works unchanged."
+msgstr ""
+
+#: src/stdlib/overview.md:14
+msgid "Supported Packages"
+msgstr ""
+
+#: src/stdlib/overview.md:16
+msgid "Networking & HTTP"
+msgstr ""
+
+#: src/stdlib/overview.md:17
+msgid "**fastify** — HTTP server framework"
+msgstr ""
+
+#: src/stdlib/overview.md:18
+msgid "**axios** — HTTP client"
+msgstr ""
+
+#: src/stdlib/overview.md:19
+msgid "**node-fetch** / **fetch** — HTTP fetch API"
+msgstr ""
+
+#: src/stdlib/overview.md:20
+msgid "**ws** — WebSocket client/server"
+msgstr ""
+
+#: src/stdlib/overview.md:23
+msgid "**mysql2** — MySQL client"
+msgstr ""
+
+#: src/stdlib/overview.md:24
+msgid "**pg** — PostgreSQL client"
+msgstr ""
+
+#: src/stdlib/overview.md:25
+msgid "**better-sqlite3** — SQLite"
+msgstr ""
+
+#: src/stdlib/overview.md:26
+msgid "**mongodb** — MongoDB client"
+msgstr ""
+
+#: src/stdlib/overview.md:27
+msgid "**ioredis** / **redis** — Redis client"
+msgstr ""
+
+#: src/stdlib/overview.md:30
+msgid "**bcrypt** — Password hashing"
+msgstr ""
+
+#: src/stdlib/overview.md:31
+msgid "**argon2** — Password hashing (Argon2)"
+msgstr ""
+
+#: src/stdlib/overview.md:32
+msgid "**jsonwebtoken** — JWT signing/verification"
+msgstr ""
+
+#: src/stdlib/overview.md:33
+msgid "**crypto** — Node.js crypto module"
+msgstr ""
+
+#: src/stdlib/overview.md:34
+msgid "**ethers** — Ethereum library"
+msgstr ""
+
+#: src/stdlib/overview.md:37
+msgid "**lodash** — Utility functions"
+msgstr ""
+
+#: src/stdlib/overview.md:38
+msgid "**dayjs** / **moment** — Date manipulation"
+msgstr ""
+
+#: src/stdlib/overview.md:39
+msgid "**uuid** — UUID generation"
+msgstr ""
+
+#: src/stdlib/overview.md:40
+msgid "**nanoid** — ID generation"
+msgstr ""
+
+#: src/stdlib/overview.md:41
+msgid "**slugify** — String slugification"
+msgstr ""
+
+#: src/stdlib/overview.md:42
+msgid "**validator** — String validation"
+msgstr ""
+
+#: src/stdlib/overview.md:44
+msgid "CLI & Data"
+msgstr ""
+
+#: src/stdlib/overview.md:45
+msgid "**commander** — CLI argument parsing"
+msgstr ""
+
+#: src/stdlib/overview.md:46
+msgid "**decimal.js** — Arbitrary precision decimals"
+msgstr ""
+
+#: src/stdlib/overview.md:47
+msgid "**bignumber.js** — Big number math"
+msgstr ""
+
+#: src/stdlib/overview.md:48
+msgid "**lru-cache** — LRU caching"
+msgstr ""
+
+#: src/stdlib/overview.md:51
+msgid "**sharp** — Image processing"
+msgstr ""
+
+#: src/stdlib/overview.md:52
+msgid "**cheerio** — HTML parsing"
+msgstr ""
+
+#: src/stdlib/overview.md:53
+msgid "**nodemailer** — Email sending"
+msgstr ""
+
+#: src/stdlib/overview.md:54
+msgid "**zlib** — Compression"
+msgstr ""
+
+#: src/stdlib/overview.md:55
+msgid "**cron** — Job scheduling"
+msgstr ""
+
+#: src/stdlib/overview.md:56
+msgid "**worker_threads** — Background workers"
+msgstr ""
+
+#: src/stdlib/overview.md:57
+msgid "**exponential-backoff** — Retry logic"
+msgstr ""
+
+#: src/stdlib/overview.md:58
+msgid "**async_hooks** — AsyncLocalStorage"
+msgstr ""
+
+#: src/stdlib/overview.md:60
+msgid "Node.js Built-ins"
+msgstr ""
+
+#: src/stdlib/overview.md:61
+msgid "**fs** — File system"
+msgstr ""
+
+#: src/stdlib/overview.md:62
+msgid "**path** — Path manipulation"
+msgstr ""
+
+#: src/stdlib/overview.md:63
+msgid "**child_process** — Process spawning"
+msgstr ""
+
+#: src/stdlib/overview.md:64
+msgid "**crypto** — Cryptographic functions"
+msgstr ""
+
+#: src/stdlib/overview.md:68
+msgid "Perry automatically detects which stdlib features your code uses:"
+msgstr ""
+
+#: src/stdlib/overview.md:70 src/system/preferences.md:8
+#: src/system/keychain.md:8
+msgid "Usage"
+msgstr ""
+
+#: src/stdlib/overview.md:72
+msgid "No stdlib imports"
+msgstr ""
+
+#: src/stdlib/overview.md:73
+msgid "fs + path only"
+msgstr ""
+
+#: src/stdlib/overview.md:74
+msgid "Full stdlib"
+msgstr ""
+
+#: src/stdlib/overview.md:76
+msgid "The compiler links only the required runtime components."
+msgstr ""
+
+#: src/stdlib/overview.md:78
+msgid "compilePackages"
+msgstr ""
+
+#: src/stdlib/overview.md:80
+msgid ""
+"For npm packages not natively supported, you can compile pure "
+"TypeScript/JavaScript packages natively:"
+msgstr ""
+
+#: src/stdlib/overview.md:90
+msgid ""
+"See [Project Configuration](../getting-started/project-config.md) for "
+"details."
+msgstr ""
+
+#: src/stdlib/overview.md:92
+msgid "JavaScript Runtime Fallback"
+msgstr ""
+
+#: src/stdlib/overview.md:94
+msgid ""
+"For packages that can't be compiled natively (native addons, dynamic code, "
+"etc.), Perry includes a QuickJS-based JavaScript runtime as a fallback. The "
+"exact API surface is internal-only today; the import below is illustrative:"
+msgstr ""
+
+#: src/stdlib/overview.md:96
+msgid ""
+"```text\n"
+"import { jsEval } from \"perry/jsruntime\"; // illustrative — not yet a public export\n"
+"```"
+msgstr ""
+
+#: src/stdlib/overview.md:102
+msgid "[File System](fs.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:103 src/stdlib/fs.md:90
+msgid "[HTTP & Networking](http.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:104 src/stdlib/http.md:95
+msgid "[Databases](database.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:105 src/stdlib/database.md:109
+msgid "[Cryptography](crypto.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:106 src/stdlib/crypto.md:89
+msgid "[Utilities](utilities.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:107 src/stdlib/utilities.md:106
+msgid "[Other Modules](other.md)"
+msgstr ""
+
+#: src/stdlib/fs.md:3
+msgid ""
+"Perry implements Node.js file system APIs for reading, writing, and managing"
+" files."
+msgstr ""
+
+#: src/stdlib/fs.md:5
+msgid "Reading Files"
+msgstr ""
+
+#: src/stdlib/fs.md:7
+msgid ""
+"```typescript\n"
+"const configPath = join(scratch, \"config.json\")\n"
+"const content = readFileSync(configPath, \"utf-8\")\n"
+"console.log(content)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:13
+msgid "Binary File Reading"
+msgstr ""
+
+#: src/stdlib/fs.md:15
+msgid ""
+"```typescript\n"
+"const imagePath = join(scratch, \"image.png\")\n"
+"const buffer = readFileBuffer(imagePath)\n"
+"console.log(`Read ${buffer.length} bytes`)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:21
+msgid ""
+"`readFileBuffer` reads files as binary data (uses `fs::read()` internally, "
+"not `read_to_string()`)."
+msgstr ""
+
+#: src/stdlib/fs.md:23
+msgid "Writing Files"
+msgstr ""
+
+#: src/stdlib/fs.md:25
+msgid ""
+"```typescript\n"
+"const outputPath = join(scratch, \"output.txt\")\n"
+"const dataPath = join(scratch, \"data.json\")\n"
+"writeFileSync(outputPath, \"Hello, World!\")\n"
+"writeFileSync(dataPath, JSON.stringify({ key: \"value\" }, null, 2))\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:32
+msgid "File Information"
+msgstr ""
+
+#: src/stdlib/fs.md:41
+msgid "Directory Operations"
+msgstr ""
+
+#: src/stdlib/fs.md:43
+msgid ""
+"```typescript\n"
+"// Create directory\n"
+"const outDir = join(scratch, \"output\")\n"
+"if (!existsSync(outDir)) mkdirSync(outDir)\n"
+"\n"
+"// Read directory contents\n"
+"const files = readdirSync(scratch)\n"
+"for (const file of files) {\n"
+"    console.log(file)\n"
+"}\n"
+"\n"
+"// Remove an empty directory\n"
+"rmdirSync(outDir)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:58
+msgid ""
+"For recursive removal Perry exposes `rmRecursive` (a thin wrapper around "
+"`std::fs::remove_dir_all`). Wired via "
+"[\\#193](https://github.com/PerryTS/perry/issues/193) through "
+"`js_fs_rm_recursive` in the LLVM backend."
+msgstr ""
+
+#: src/stdlib/fs.md:63
+msgid ""
+"```typescript,no-test\n"
+"import { rmRecursive } from \"fs\";\n"
+"rmRecursive(\"output\"); // Recursive remove; returns 1 on success, 0 on failure.\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:68
+msgid "Path Utilities"
+msgstr ""
+
+#: src/stdlib/fs.md:70
+msgid ""
+"```typescript\n"
+"const dir = dirname(configPath)\n"
+"const cfgPath = join(dir, \"config.json\")\n"
+"const name = basename(cfgPath)        // \"config.json\"\n"
+"const abs = resolve(\"relative/path\")  // Absolute path\n"
+"console.log(`${name} ${abs.length > 0}`)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:78
+msgid ""
+"For `import.meta.url` → filesystem path conversion, use `fileURLToPath` from"
+" the `url` module:"
+msgstr ""
+
+#: src/stdlib/fs.md:81
+msgid ""
+"```text\n"
+"import { fileURLToPath } from \"url\";\n"
+"import { dirname } from \"path\";\n"
+"\n"
+"const dir = dirname(fileURLToPath(import.meta.url));\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:91 src/stdlib/http.md:96 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:107 src/stdlib/other.md:186
+msgid "[Overview](overview.md) — All stdlib modules"
+msgstr ""
+
+#: src/stdlib/http.md:3
+msgid ""
+"Perry natively implements HTTP servers, clients, and WebSocket support."
+msgstr ""
+
+#: src/stdlib/http.md:5
+msgid "Fastify Server"
+msgstr ""
+
+#: src/stdlib/http.md:7
+msgid ""
+"```typescript\n"
+"import fastify from \"fastify\"\n"
+"\n"
+"const app = fastify()\n"
+"\n"
+"app.get(\"/\", async (request: any, reply: any) => {\n"
+"    return { hello: \"world\" }\n"
+"})\n"
+"\n"
+"app.get(\"/users/:id\", async (request: any, reply: any) => {\n"
+"    const id = request.params.id\n"
+"    return { id, name: \"User \" + id }\n"
+"})\n"
+"\n"
+"app.post(\"/data\", async (request: any, reply: any) => {\n"
+"    const body = request.body\n"
+"    reply.code(201)\n"
+"    return { received: body }\n"
+"})\n"
+"\n"
+"app.listen({ port: 3000 }, () => {\n"
+"    console.log(\"Server running on port 3000\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:32
+msgid ""
+"Perry's Fastify implementation is API-compatible with the npm package. "
+"Routes, request/reply objects, params, query strings, and JSON body parsing "
+"all work."
+msgstr ""
+
+#: src/stdlib/http.md:34
+msgid "Fetch API"
+msgstr ""
+
+#: src/stdlib/http.md:36
+msgid ""
+"```typescript\n"
+"async function fetchExamples(): Promise<void> {\n"
+"    // GET request\n"
+"    const response = await fetch(\"https://jsonplaceholder.typicode.com/posts/1\")\n"
+"    const data = await response.json()\n"
+"\n"
+"    // POST request\n"
+"    const result = await fetch(\"https://jsonplaceholder.typicode.com/posts\", {\n"
+"        method: \"POST\",\n"
+"        headers: { \"Content-Type\": \"application/json\" },\n"
+"        body: JSON.stringify({ title: \"hello\", body: \"world\", userId: 1 }),\n"
+"    })\n"
+"\n"
+"    console.log(`fetch ok: ${data !== null} status=${result.status}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:53
+msgid "Axios"
+msgstr ""
+
+#: src/stdlib/http.md:55
+msgid ""
+"```typescript\n"
+"import axios from \"axios\"\n"
+"\n"
+"async function axiosExamples(): Promise<void> {\n"
+"    const getResp = await axios.get(\"https://jsonplaceholder.typicode.com/users/1\")\n"
+"    const data = getResp.data\n"
+"\n"
+"    const response = await axios.post(\"https://jsonplaceholder.typicode.com/users\", {\n"
+"        name: \"Perry\",\n"
+"        email: \"perry@example.com\",\n"
+"    })\n"
+"\n"
+"    console.log(`axios ok: ${data !== null} status=${response.status}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:71
+msgid "WebSocket"
+msgstr ""
+
+#: src/stdlib/http.md:73
+msgid ""
+"```typescript\n"
+"import { WebSocket } from \"ws\"\n"
+"\n"
+"function wsExample(): void {\n"
+"    const ws = new WebSocket(\"ws://localhost:8080\")\n"
+"\n"
+"    ws.on(\"open\", () => {\n"
+"        ws.send(\"Hello, server!\")\n"
+"    })\n"
+"\n"
+"    ws.on(\"message\", (data: any) => {\n"
+"        console.log(`Received: ${data}`)\n"
+"    })\n"
+"\n"
+"    ws.on(\"close\", () => {\n"
+"        console.log(\"Connection closed\")\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:3
+msgid ""
+"Perry natively implements clients for MySQL, PostgreSQL, SQLite, MongoDB, "
+"and Redis."
+msgstr ""
+
+#: src/stdlib/database.md:5
+msgid "MySQL"
+msgstr ""
+
+#: src/stdlib/database.md:7
+msgid ""
+"```typescript\n"
+"import mysql from \"mysql2/promise\"\n"
+"\n"
+"async function mysqlExample(): Promise<void> {\n"
+"    const connection = await mysql.createConnection({\n"
+"        host: \"localhost\",\n"
+"        user: \"root\",\n"
+"        password: \"password\",\n"
+"        database: \"mydb\",\n"
+"    })\n"
+"\n"
+"    const [rows] = await connection.execute(\"SELECT * FROM users WHERE id = ?\", [1])\n"
+"    console.log(rows)\n"
+"\n"
+"    await connection.end()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:25
+msgid "PostgreSQL"
+msgstr ""
+
+#: src/stdlib/database.md:27
+msgid ""
+"```typescript\n"
+"import { Client } from \"pg\"\n"
+"\n"
+"async function postgresExample(): Promise<void> {\n"
+"    const client = new Client({\n"
+"        host: \"localhost\",\n"
+"        port: 5432,\n"
+"        user: \"postgres\",\n"
+"        password: \"password\",\n"
+"        database: \"mydb\",\n"
+"    })\n"
+"\n"
+"    await client.connect()\n"
+"    const result = await client.query(\"SELECT * FROM users WHERE id = $1\", [1])\n"
+"    console.log(result.rows)\n"
+"    await client.end()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:46
+msgid "SQLite"
+msgstr ""
+
+#: src/stdlib/database.md:48
+msgid ""
+"```typescript\n"
+"import Database from \"better-sqlite3\"\n"
+"\n"
+"function sqliteExample(): void {\n"
+"    const db = new Database(\"mydb.sqlite\")\n"
+"\n"
+"    db.exec(`\n"
+"      CREATE TABLE IF NOT EXISTS users (\n"
+"        id INTEGER PRIMARY KEY,\n"
+"        name TEXT,\n"
+"        email TEXT\n"
+"      )\n"
+"    `)\n"
+"\n"
+"    const insert = db.prepare(\"INSERT INTO users (name, email) VALUES (?, ?)\")\n"
+"    insert.run(\"Perry\", \"perry@example.com\")\n"
+"\n"
+"    const users = db.prepare(\"SELECT * FROM users\").all()\n"
+"    console.log(users)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:70
+msgid "MongoDB"
+msgstr ""
+
+#: src/stdlib/database.md:72
+msgid ""
+"```typescript\n"
+"import { MongoClient } from \"mongodb\"\n"
+"\n"
+"async function mongoExample(): Promise<void> {\n"
+"    const client = new MongoClient(\"mongodb://localhost:27017\")\n"
+"    await client.connect()\n"
+"\n"
+"    const db = client.db(\"mydb\")\n"
+"    const users = db.collection(\"users\")\n"
+"\n"
+"    await users.insertOne({ name: \"Perry\", email: \"perry@example.com\" })\n"
+"    const user = await users.findOne({ name: \"Perry\" })\n"
+"    console.log(user)\n"
+"\n"
+"    await client.close()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:90
+msgid "Redis"
+msgstr ""
+
+#: src/stdlib/database.md:92
+msgid ""
+"```typescript\n"
+"import Redis from \"ioredis\"\n"
+"\n"
+"async function redisExample(): Promise<void> {\n"
+"    const redis = new Redis()\n"
+"\n"
+"    await redis.set(\"key\", \"value\")\n"
+"    const value = await redis.get(\"key\")\n"
+"    console.log(value) // \"value\"\n"
+"\n"
+"    await redis.del(\"key\")\n"
+"    await redis.quit()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:3
+msgid ""
+"Perry natively implements password hashing, JWT tokens, and Ethereum "
+"cryptography."
+msgstr ""
+
+#: src/stdlib/crypto.md:5
+msgid "bcrypt"
+msgstr ""
+
+#: src/stdlib/crypto.md:7
+msgid ""
+"```typescript\n"
+"import bcrypt from \"bcrypt\"\n"
+"\n"
+"async function bcryptExample(): Promise<void> {\n"
+"    const hash = await bcrypt.hash(\"mypassword\", 10)\n"
+"    const match = await bcrypt.compare(\"mypassword\", hash)\n"
+"    console.log(match) // true\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:17
+msgid "Argon2"
+msgstr ""
+
+#: src/stdlib/crypto.md:19
+msgid ""
+"```typescript\n"
+"import argon2 from \"argon2\"\n"
+"\n"
+"async function argon2Example(): Promise<void> {\n"
+"    const hash = await argon2.hash(\"mypassword\")\n"
+"    const valid = await argon2.verify(hash, \"mypassword\")\n"
+"    console.log(valid) // true\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:29
+msgid "JSON Web Tokens"
+msgstr ""
+
+#: src/stdlib/crypto.md:31
+msgid ""
+"```typescript\n"
+"import jwt from \"jsonwebtoken\"\n"
+"\n"
+"function jwtExample(): void {\n"
+"    const secret = \"my-secret-key\"\n"
+"\n"
+"    // Sign a token\n"
+"    const token = jwt.sign({ userId: 123, role: \"admin\" }, secret, {\n"
+"        expiresIn: \"1h\",\n"
+"    })\n"
+"\n"
+"    // Verify a token\n"
+"    const decoded: any = jwt.verify(token, secret)\n"
+"    console.log(decoded.userId) // 123\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:48
+msgid "Node.js Crypto"
+msgstr ""
+
+#: src/stdlib/crypto.md:50
+msgid ""
+"```typescript\n"
+"import crypto from \"crypto\"\n"
+"\n"
+"function cryptoExample(): void {\n"
+"    // Hash\n"
+"    const hash = crypto.createHash(\"sha256\").update(\"data\").digest(\"hex\")\n"
+"\n"
+"    // HMAC\n"
+"    const hmac = crypto.createHmac(\"sha256\", \"secret\").update(\"data\").digest(\"hex\")\n"
+"\n"
+"    // Random bytes\n"
+"    const bytes = crypto.randomBytes(32)\n"
+"\n"
+"    console.log(`hash_len=${hash.length} hmac_len=${hmac.length} bytes_len=${bytes.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:67
+msgid "Ethers"
+msgstr ""
+
+#: src/stdlib/crypto.md:69
+msgid ""
+"```typescript\n"
+"import { ethers } from \"ethers\"\n"
+"\n"
+"function ethersExample(): void {\n"
+"    // Utility functions\n"
+"    const addr = ethers.getAddress(\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\")\n"
+"    const wei = ethers.parseEther(\"1.5\")\n"
+"    const ether = ethers.formatEther(wei)\n"
+"    console.log(`checksum: ${addr}`)\n"
+"    console.log(`1.5 ether in wei → formatted back: ${ether}`)\n"
+"\n"
+"    // Create a random wallet\n"
+"    const wallet = ethers.Wallet.createRandom()\n"
+"    console.log(`address: ${wallet.address}`)\n"
+"    console.log(`privateKey length: ${wallet.privateKey.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:3
+msgid "Perry natively implements common utility packages."
+msgstr ""
+
+#: src/stdlib/utilities.md:5
+msgid "lodash"
+msgstr ""
+
+#: src/stdlib/utilities.md:7
+msgid ""
+"The `lodash` runtime functions are partially implemented (see `crates/perry-"
+"stdlib/src/lodash.rs`) but the user-facing dispatch from `import _ from "
+"\"lodash\"; _.chunk(...)` is not wired into the LLVM backend yet. Track the "
+"follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:12
+msgid ""
+"```text\n"
+"import _ from \"lodash\";\n"
+"\n"
+"_.chunk([1, 2, 3, 4, 5], 2);     // [[1,2], [3,4], [5]]\n"
+"_.uniq([1, 2, 2, 3, 3]);          // [1, 2, 3]\n"
+"_.groupBy(users, \"role\");\n"
+"_.sortBy(users, [\"name\"]);\n"
+"_.cloneDeep(obj);\n"
+"_.merge(defaults, overrides);\n"
+"_.debounce(fn, 300);\n"
+"_.throttle(fn, 100);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:25
+msgid "dayjs"
+msgstr ""
+
+#: src/stdlib/utilities.md:27
+msgid ""
+"`dayjs` runtime functions are declared (`js_dayjs_now`, `js_dayjs_format`, "
+"`js_dayjs_add`, etc.) but the user-facing dispatch from `import dayjs from "
+"\"dayjs\"; dayjs()` chained methods is not wired into the LLVM backend yet. "
+"Track the follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:32
+msgid ""
+"```text\n"
+"import dayjs from \"dayjs\";\n"
+"\n"
+"const now = dayjs();\n"
+"console.log(now.format(\"YYYY-MM-DD\"));\n"
+"console.log(now.add(7, \"day\").format(\"YYYY-MM-DD\"));\n"
+"console.log(now.subtract(1, \"month\").toISOString());\n"
+"\n"
+"const diff = dayjs(\"2025-12-31\").diff(now, \"day\");\n"
+"console.log(`${diff} days until end of year`);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:44
+msgid "moment"
+msgstr ""
+
+#: src/stdlib/utilities.md:46
+msgid ""
+"Same status as `dayjs` — the runtime functions exist but the dispatch path "
+"is not wired yet."
+msgstr ""
+
+#: src/stdlib/utilities.md:49
+msgid ""
+"```text\n"
+"import moment from \"moment\";\n"
+"\n"
+"const now = moment();\n"
+"console.log(now.format(\"MMMM Do YYYY\"));\n"
+"console.log(now.fromNow());\n"
+"console.log(moment(\"2025-01-01\").isBefore(now));\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:58
+msgid "uuid"
+msgstr ""
+
+#: src/stdlib/utilities.md:60
+msgid ""
+"```typescript\n"
+"import { v4 as uuidv4 } from \"uuid\"\n"
+"\n"
+"const id = uuidv4()\n"
+"console.log(id) // e.g., \"550e8400-e29b-41d4-a716-446655440000\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:67
+msgid "nanoid"
+msgstr ""
+
+#: src/stdlib/utilities.md:69
+msgid ""
+"The default-length `nanoid()` call is wired. The custom-length form "
+"`nanoid(10)` has a runtime function (`js_nanoid_sized`) but no dispatch yet "
+"— track at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:73
+msgid ""
+"```typescript\n"
+"import { nanoid } from \"nanoid\"\n"
+"\n"
+"const nid = nanoid() // Default 21 chars\n"
+"console.log(nid)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:80
+msgid "slugify"
+msgstr ""
+
+#: src/stdlib/utilities.md:82
+msgid ""
+"The single-arg form is wired. The options-object form `slugify(\"Hello "
+"World!\", { lower: true })` has a runtime function "
+"(`js_slugify_with_options`) but no dispatch yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:86
+msgid ""
+"```typescript\n"
+"import slugify from \"slugify\"\n"
+"\n"
+"const slug = slugify(\"Hello World!\")\n"
+"console.log(slug) // \"hello-world\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:93
+msgid "validator"
+msgstr ""
+
+#: src/stdlib/utilities.md:95
+msgid ""
+"```typescript\n"
+"import validator from \"validator\"\n"
+"\n"
+"console.log(validator.isEmail(\"test@example.com\"))  // true\n"
+"console.log(validator.isURL(\"https://example.com\")) // true\n"
+"console.log(validator.isUUID(id))                   // true\n"
+"console.log(validator.isEmpty(\"\"))                  // true\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:3
+msgid "Additional npm packages and Node.js APIs supported by Perry."
+msgstr ""
+
+#: src/stdlib/other.md:5
+msgid "sharp (Image Processing)"
+msgstr ""
+
+#: src/stdlib/other.md:7
+msgid ""
+"The `sharp` runtime functions are declared (`js_sharp_resize`, "
+"`js_sharp_blur`, `js_sharp_to_buffer`, etc.) but the user-facing dispatch "
+"from `import sharp from \"sharp\"; sharp(input).resize(...)` is not wired "
+"into the LLVM backend yet. Track the follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:12
+msgid ""
+"```text\n"
+"import sharp from \"sharp\";\n"
+"\n"
+"await sharp(\"input.jpg\")\n"
+"  .resize(300, 200)\n"
+"  .toFile(\"output.png\");\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:20
+msgid "cheerio (HTML Parsing)"
+msgstr ""
+
+#: src/stdlib/other.md:22
+msgid ""
+"The `cheerio` runtime exists (see `crates/perry-stdlib/src/cheerio.rs`) but "
+"the dispatch path is not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:25
+msgid ""
+"```text\n"
+"import cheerio from \"cheerio\";\n"
+"\n"
+"const html = \"<html><body><h1>Hello</h1><p>World</p></body></html>\";\n"
+"const $ = cheerio.load(html);\n"
+"console.log($(\"h1\").text()); // \"Hello\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:33
+msgid "nodemailer (Email)"
+msgstr ""
+
+#: src/stdlib/other.md:35
+msgid ""
+"```typescript\n"
+"import nodemailer from \"nodemailer\"\n"
+"\n"
+"async function nodemailerExample(): Promise<void> {\n"
+"    const transporter = nodemailer.createTransport({\n"
+"        host: \"smtp.example.com\",\n"
+"        port: 587,\n"
+"        auth: { user: \"user\", pass: \"pass\" },\n"
+"    })\n"
+"\n"
+"    await transporter.sendMail({\n"
+"        from: \"sender@example.com\",\n"
+"        to: \"recipient@example.com\",\n"
+"        subject: \"Hello from Perry\",\n"
+"        text: \"This email was sent from a compiled TypeScript binary!\",\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:54
+msgid "zlib (Compression)"
+msgstr ""
+
+#: src/stdlib/other.md:56
+msgid ""
+"The `zlib` runtime exists but dispatch from `import zlib from \"zlib\"` is "
+"not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:59
+msgid ""
+"```text\n"
+"import zlib from \"zlib\";\n"
+"\n"
+"const compressed = zlib.gzipSync(\"Hello, World!\");\n"
+"const decompressed = zlib.gunzipSync(compressed);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:66
+msgid "cron (Job Scheduling)"
+msgstr ""
+
+#: src/stdlib/other.md:68
+msgid ""
+"The `cron` runtime exists but dispatch from `import { CronJob } from "
+"\"cron\"` is not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:71
+msgid ""
+"```text\n"
+"import { CronJob } from \"cron\";\n"
+"\n"
+"const job = new CronJob(\"*/5 * * * *\", () => {\n"
+"  console.log(\"Runs every 5 minutes\");\n"
+"});\n"
+"job.start();\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:80
+msgid "worker_threads"
+msgstr ""
+
+#: src/stdlib/other.md:82
+msgid ""
+"The `worker_threads` API is partially recognized at HIR-lowering time "
+"(`parentPort` / `Worker` shapes) but full dispatch is incomplete. For data-"
+"parallel work today, prefer `parallelMap` / `parallelFilter` / `spawn` from "
+"`perry/thread` (see [Threading](../threading/overview.md))."
+msgstr ""
+
+#: src/stdlib/other.md:87
+msgid ""
+"```text\n"
+"import { Worker, parentPort, workerData } from \"worker_threads\";\n"
+"\n"
+"if (parentPort) {\n"
+"  // Worker thread\n"
+"  const data = workerData;\n"
+"  parentPort.postMessage({ result: data.value * 2 });\n"
+"} else {\n"
+"  // Main thread\n"
+"  const worker = new Worker(\"./worker.ts\", {\n"
+"    workerData: { value: 21 },\n"
+"  });\n"
+"  worker.on(\"message\", (msg) => {\n"
+"    console.log(msg.result); // 42\n"
+"  });\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:105
+msgid "commander (CLI Parsing)"
+msgstr ""
+
+#: src/stdlib/other.md:107
+msgid ""
+"```typescript\n"
+"import { Command } from \"commander\"\n"
+"\n"
+"function commanderExample(): void {\n"
+"    const program = new Command()\n"
+"    program.name(\"my-cli\").version(\"1.0.0\").description(\"My CLI tool\")\n"
+"\n"
+"    program\n"
+"        .command(\"serve\")\n"
+"        .option(\"-p, --port <number>\", \"Port number\")\n"
+"        .option(\"--verbose\", \"Verbose output\")\n"
+"        .action((options: any) => {\n"
+"            console.log(`Starting server on port ${options.port}`)\n"
+"        })\n"
+"\n"
+"    program.parse(process.argv)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:126
+msgid "decimal.js (Arbitrary Precision)"
+msgstr ""
+
+#: src/stdlib/other.md:128
+msgid ""
+"```typescript\n"
+"import Decimal from \"decimal.js\"\n"
+"\n"
+"function decimalExample(): void {\n"
+"    const a = new Decimal(\"0.1\")\n"
+"    const b = new Decimal(\"0.2\")\n"
+"    const sum = a.plus(b) // Exactly 0.3 (no floating point errors)\n"
+"\n"
+"    console.log(sum.toFixed(2))      // \"0.30\"\n"
+"    console.log(sum.toNumber())      // 0.3\n"
+"    console.log(a.times(b).toFixed(2)) // \"0.02\"\n"
+"    console.log(a.div(b).toFixed(1))   // \"0.5\"\n"
+"    console.log(a.pow(10).toString())  // 1e-10\n"
+"    console.log(a.sqrt().toFixed(3))   // \"0.316\"\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:145
+msgid "lru-cache"
+msgstr ""
+
+#: src/stdlib/other.md:147
+msgid ""
+"The wired constructor takes the npm v7+ options-object shape (`new "
+"LRUCache({ max: 100 })`) — the older positional form `new LRUCache(100)` "
+"falls through to a `max=100` default."
+msgstr ""
+
+#: src/stdlib/other.md:151
+msgid ""
+"```typescript\n"
+"import { LRUCache } from \"lru-cache\"\n"
+"\n"
+"function lruCacheExample(): void {\n"
+"    const cache = new LRUCache({ max: 100 }) // max 100 entries\n"
+"\n"
+"    cache.set(\"key\", \"value\")\n"
+"    console.log(cache.get(\"key\"))   // \"value\"\n"
+"    console.log(cache.has(\"key\"))   // true\n"
+"    cache.delete(\"key\")\n"
+"    cache.clear()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:165
+msgid "child_process"
+msgstr ""
+
+#: src/stdlib/other.md:167
+msgid ""
+"```typescript\n"
+"import { spawnBackground, getProcessStatus, killProcess } from \"child_process\"\n"
+"\n"
+"function childProcessExample(): void {\n"
+"    // Spawn a background process\n"
+"    const { pid, handleId } = spawnBackground(\"sleep\", [\"10\"], \"/tmp/log.txt\")\n"
+"\n"
+"    // Check if it's still running\n"
+"    const status = getProcessStatus(handleId)\n"
+"    console.log(status.alive) // true\n"
+"    console.log(`pid=${pid}`)\n"
+"\n"
+"    // Kill it\n"
+"    killProcess(handleId)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:187
+msgid "[File System](fs.md) — fs and path APIs"
+msgstr ""
+
+#: src/i18n/overview.md:1
+msgid "Internationalization (i18n)"
+msgstr ""
+
+#: src/i18n/overview.md:3
+msgid ""
+"Perry's i18n system lets you write natural English strings and have them "
+"automatically translated at compile time. Zero ceremony, near-zero runtime "
+"cost."
+msgstr ""
+
+#: src/i18n/overview.md:5
+msgid ""
+"```typescript\n"
+"// String literals in UI component calls are automatically localizable keys.\n"
+"// (Conceptually the docs write `Button(\"Next\")` / `Text(\"Hello, {name}!\", ...)`\n"
+"// from \"perry/ui\"; we exercise the runtime API that backs them — t() — here.)\n"
+"const next = t(\"Next\")                                  // Automatically localized\n"
+"const hello = t(\"Hello, {name}!\", { name: \"Alice\" })    // With interpolation\n"
+"console.log(next, hello)\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:14
+msgid ""
+"The same key-resolution and interpolation runs through the explicit `t()` "
+"API for non-UI strings:"
+msgstr ""
+
+#: src/i18n/overview.md:16
+msgid ""
+"```typescript\n"
+"import { t, Currency, Percent, ShortDate, LongDate, FormatNumber, FormatTime, Raw } from \"perry/i18n\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:20
+msgid "Design Principles"
+msgstr ""
+
+#: src/i18n/overview.md:22
+msgid ""
+"**Zero ceremony**: String literals in UI components are automatically "
+"localizable keys"
+msgstr ""
+
+#: src/i18n/overview.md:23
+msgid ""
+"**Compile-time validation**: Missing translations, parameter mismatches, and"
+" plural form errors caught during build"
+msgstr ""
+
+#: src/i18n/overview.md:24
+msgid ""
+"**Embedded string table**: All translations baked into the binary as a flat "
+"2D table. Near-zero runtime lookup cost"
+msgstr ""
+
+#: src/i18n/overview.md:25
+msgid ""
+"**Platform-native locale detection**: Uses OS APIs on every platform (no env"
+" vars needed on mobile)"
+msgstr ""
+
+#: src/i18n/overview.md:29
+msgid "1. Add i18n config to perry.toml"
+msgstr ""
+
+#: src/i18n/overview.md:31
+msgid ""
+"```toml\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\"]\n"
+"default_locale = \"en\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:37
+msgid "2. Extract strings from your code"
+msgstr ""
+
+#: src/i18n/overview.md:43
+msgid ""
+"This scans your source files and creates `locales/en.json` and "
+"`locales/de.json`:"
+msgstr ""
+
+#: src/i18n/overview.md:46 src/i18n/interpolation.md:17
+#: src/i18n/interpolation.md:49
+msgid "// locales/en.json\n"
+msgstr ""
+
+#: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
+#: src/i18n/cli.md:38 src/i18n/cli.md:87
+msgid "\"Next\""
+msgstr ""
+
+#: src/i18n/overview.md:49 src/i18n/overview.md:55 src/i18n/overview.md:66
+msgid "\"Back\""
+msgstr ""
+
+#: src/i18n/overview.md:51
+msgid "// locales/de.json (empty values = needs translation)\n"
+msgstr ""
+
+#: src/i18n/overview.md:54 src/i18n/overview.md:55
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:73
+msgid "\"\""
+msgstr ""
+
+#: src/i18n/overview.md:59
+msgid "3. Translate"
+msgstr ""
+
+#: src/i18n/overview.md:61
+msgid "Fill in `locales/de.json`:"
+msgstr ""
+
+#: src/i18n/overview.md:65
+msgid "\"Weiter\""
+msgstr ""
+
+#: src/i18n/overview.md:66
+msgid "\"Zurck\""
+msgstr ""
+
+#: src/i18n/overview.md:70
+msgid "4. Build"
+msgstr ""
+
+#: src/i18n/overview.md:76
+msgid ""
+"Perry validates all translations at compile time and bakes them into the "
+"binary. At runtime, the app detects the user's system locale and shows the "
+"right language."
+msgstr ""
+
+#: src/i18n/overview.md:80
+msgid ""
+"**Detection**: String literals in UI component calls (`Button`, `Text`, "
+"`Label`, etc.) are automatically treated as i18n keys"
+msgstr ""
+
+#: src/i18n/overview.md:81
+msgid ""
+"**Transform**: The compiler replaces `Expr::String(\"Next\")` with "
+"`Expr::I18nString { key: \"Next\", string_idx: 0 }` in the HIR"
+msgstr ""
+
+#: src/i18n/overview.md:82
+msgid ""
+"**Codegen**: For each `I18nString`, the compiler emits a locale branch that "
+"selects the correct translation at runtime"
+msgstr ""
+
+#: src/i18n/overview.md:83
+msgid ""
+"**Locale detection**: At startup, `perry_i18n_init()` detects the system "
+"locale via native APIs and sets the global locale index"
+msgstr ""
+
+#: src/i18n/overview.md:85
+msgid "Locale Detection"
+msgstr ""
+
+#: src/i18n/overview.md:89 src/i18n/overview.md:90
+msgid "`CFLocaleCopyCurrent()` (CoreFoundation)"
+msgstr ""
+
+#: src/i18n/overview.md:91
+msgid "`__system_property_get(\"persist.sys.locale\")`"
+msgstr ""
+
+#: src/i18n/overview.md:92
+msgid "`GetUserDefaultLocaleName()` (Win32)"
+msgstr ""
+
+#: src/i18n/overview.md:93
+msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
+msgstr ""
+
+#: src/i18n/overview.md:95
+msgid ""
+"The detected locale is fuzzy-matched against your configured locales: "
+"`de_DE.UTF-8` matches `de`, `en-US` matches `en`, etc."
+msgstr ""
+
+#: src/i18n/overview.md:97
+msgid "Platform Output"
+msgstr ""
+
+#: src/i18n/overview.md:99
+msgid ""
+"When compiling for mobile targets, Perry generates platform-native locale "
+"resources alongside the binary:"
+msgstr ""
+
+#: src/i18n/overview.md:101 src/widgets/platforms.md:9
+msgid "Output"
+msgstr ""
+
+#: src/i18n/overview.md:103
+msgid "iOS/macOS"
+msgstr ""
+
+#: src/i18n/overview.md:103
+msgid "`{locale}.lproj/Localizable.strings` inside `.app` bundle"
+msgstr ""
+
+#: src/i18n/overview.md:104
+msgid "`res/values-{locale}/strings.xml`"
+msgstr ""
+
+#: src/i18n/overview.md:105
+msgid "Desktop"
+msgstr ""
+
+#: src/i18n/overview.md:105
+msgid "Strings embedded in binary (no extra files)"
+msgstr ""
+
+#: src/i18n/overview.md:109
+msgid "[Interpolation & Plurals](interpolation.md)"
+msgstr ""
+
+#: src/i18n/overview.md:110
+msgid "[Formatting](formatting.md)"
+msgstr ""
+
+#: src/i18n/overview.md:111
+msgid "[CLI Tools](cli.md)"
+msgstr ""
+
+#: src/i18n/interpolation.md:3
+msgid "Parameterized Strings"
+msgstr ""
+
+#: src/i18n/interpolation.md:5
+msgid ""
+"Use `{param}` placeholders in your strings and pass values as a second "
+"argument:"
+msgstr ""
+
+#: src/i18n/interpolation.md:7
+msgid ""
+"```typescript\n"
+"// Use {param} placeholders in your strings and pass values as a second arg.\n"
+"const greeting = t(\"Hello, {name}!\", { name: \"Alice\" })\n"
+"const total = t(\"Total: {price}\", { price: 23.10 })\n"
+"console.log(greeting, total)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:14
+msgid "Translation files use the same `{param}` syntax:"
+msgstr ""
+
+#: src/i18n/interpolation.md:19 src/i18n/interpolation.md:25
+#: src/i18n/cli.md:38 src/i18n/cli.md:88
+msgid "\"Hello, {name}!\""
+msgstr ""
+
+#: src/i18n/interpolation.md:20 src/i18n/interpolation.md:26
+msgid "\"Total: {price}\""
+msgstr ""
+
+#: src/i18n/interpolation.md:22 src/i18n/interpolation.md:54
+msgid "// locales/de.json\n"
+msgstr ""
+
+#: src/i18n/interpolation.md:25
+msgid "\"Hallo, {name}!\""
+msgstr ""
+
+#: src/i18n/interpolation.md:26
+msgid "\"Gesamt: {price}\""
+msgstr ""
+
+#: src/i18n/interpolation.md:30
+msgid ""
+"Parameters are substituted at runtime after the locale-appropriate template "
+"is selected. The substitution handles any value type (numbers, strings, "
+"dates) by converting to string."
+msgstr ""
+
+#: src/i18n/interpolation.md:32 src/i18n/interpolation.md:99
+msgid "Compile-Time Validation"
+msgstr ""
+
+#: src/i18n/interpolation.md:34
+msgid "Perry validates parameters across all locales during compilation:"
+msgstr ""
+
+#: src/i18n/interpolation.md:36 src/i18n/interpolation.md:101
+msgid "Condition"
+msgstr ""
+
+#: src/i18n/interpolation.md:36 src/i18n/interpolation.md:101
+msgid "Severity"
+msgstr ""
+
+#: src/i18n/interpolation.md:38
+msgid "`{param}` in translation but not provided in code"
+msgstr ""
+
+#: src/i18n/interpolation.md:38 src/i18n/interpolation.md:39
+#: src/i18n/interpolation.md:40 src/i18n/interpolation.md:103
+#: src/i18n/interpolation.md:104
+msgid "Error"
+msgstr ""
+
+#: src/i18n/interpolation.md:39
+msgid "Param in code but `{param}` not in translation"
+msgstr ""
+
+#: src/i18n/interpolation.md:40
+msgid "Parameter set differs between locales for same key"
+msgstr ""
+
+#: src/i18n/interpolation.md:42
+msgid "Plural Rules"
+msgstr ""
+
+#: src/i18n/interpolation.md:44
+msgid ""
+"Plural forms use dot-suffix keys based on CLDR plural categories: `.zero`, "
+"`.one`, `.two`, `.few`, `.many`, `.other`."
+msgstr ""
+
+#: src/i18n/interpolation.md:46
+msgid "Locale Files"
+msgstr ""
+
+#: src/i18n/interpolation.md:51 src/i18n/interpolation.md:57
+#: src/i18n/interpolation.md:63
+msgid "\"You have {count} items.one\""
+msgstr ""
+
+#: src/i18n/interpolation.md:51
+msgid "\"You have {count} item.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:52 src/i18n/interpolation.md:58
+#: src/i18n/interpolation.md:66
+msgid "\"You have {count} items.other\""
+msgstr ""
+
+#: src/i18n/interpolation.md:52
+msgid "\"You have {count} items.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:57 src/i18n/interpolation.md:58
+msgid "\"Du hast {count} Artikel.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:60
+msgid "// locales/pl.json (Polish: one, few, many)\n"
+msgstr ""
+
+#: src/i18n/interpolation.md:63
+msgid "\"Masz {count} element.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:64
+msgid "\"You have {count} items.few\""
+msgstr ""
+
+#: src/i18n/interpolation.md:64
+msgid "\"Masz {count} elementy.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:65
+msgid "\"You have {count} items.many\""
+msgstr ""
+
+#: src/i18n/interpolation.md:65
+msgid "\"Masz {count} elementow.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:66
+msgid "\"Masz {count} elementu.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:70
+msgid "Usage in Code"
+msgstr ""
+
+#: src/i18n/interpolation.md:72
+msgid ""
+"Reference the base key without any suffix. Perry detects the plural variants"
+" automatically:"
+msgstr ""
+
+#: src/i18n/interpolation.md:74
+msgid ""
+"```typescript\n"
+"// Reference the base key without any suffix — Perry picks the plural variant\n"
+"// from the `count` parameter and the current locale's CLDR rules.\n"
+"const cartCount = 3\n"
+"const itemMessage = t(\"You have {count} items\", { count: cartCount })\n"
+"console.log(itemMessage)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:82
+msgid ""
+"Perry determines which plural form to use based on the `count` parameter "
+"value and the current locale's CLDR rules."
+msgstr ""
+
+#: src/i18n/interpolation.md:84
+msgid "Supported Locales"
+msgstr ""
+
+#: src/i18n/interpolation.md:86
+msgid "Perry includes hand-rolled CLDR plural rules for 30+ locales:"
+msgstr ""
+
+#: src/i18n/interpolation.md:88
+msgid "Pattern"
+msgstr ""
+
+#: src/i18n/interpolation.md:88
+msgid "Locales"
+msgstr ""
+
+#: src/i18n/interpolation.md:90
+msgid "one/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:90
+msgid ""
+"English, German, Dutch, Swedish, Danish, Norwegian, Finnish, Estonian, "
+"Hungarian, Turkish, Greek, Hebrew, Italian, Spanish, Portuguese, Catalan, "
+"Bulgarian, Hindi, Bengali, Swahili, ..."
+msgstr ""
+
+#: src/i18n/interpolation.md:91
+msgid "one (0-1) / other"
+msgstr ""
+
+#: src/i18n/interpolation.md:91
+msgid "French"
+msgstr ""
+
+#: src/i18n/interpolation.md:92
+msgid "no distinction"
+msgstr ""
+
+#: src/i18n/interpolation.md:92
+msgid "Japanese, Chinese, Korean, Vietnamese, Thai, Indonesian, Malay"
+msgstr ""
+
+#: src/i18n/interpolation.md:93
+msgid "one/few/many"
+msgstr ""
+
+#: src/i18n/interpolation.md:93
+msgid "Russian, Ukrainian, Serbian, Croatian, Bosnian, Polish"
+msgstr ""
+
+#: src/i18n/interpolation.md:94 src/i18n/interpolation.md:96
+msgid "one/few/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:94
+msgid "Czech, Slovak"
+msgstr ""
+
+#: src/i18n/interpolation.md:95
+msgid "zero/one/two/few/many/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:95
+msgid "Arabic"
+msgstr ""
+
+#: src/i18n/interpolation.md:96
+msgid "Romanian, Lithuanian"
+msgstr ""
+
+#: src/i18n/interpolation.md:97
+msgid "zero/one/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:97
+msgid "Latvian"
+msgstr ""
+
+#: src/i18n/interpolation.md:103
+msgid "`.other` form missing for any locale"
+msgstr ""
+
+#: src/i18n/interpolation.md:104
+msgid "Required CLDR category missing (e.g., `.few` for Polish)"
+msgstr ""
+
+#: src/i18n/interpolation.md:105
+msgid "Extra category locale doesn't use (e.g., `.few` for English)"
+msgstr ""
+
+#: src/i18n/interpolation.md:105
+msgid "Warning"
+msgstr ""
+
+#: src/i18n/interpolation.md:107
+msgid "Explicit API for Non-UI Strings"
+msgstr ""
+
+#: src/i18n/interpolation.md:109
+msgid ""
+"For strings outside UI components (API responses, notifications, etc.), use "
+"`t()`:"
+msgstr ""
+
+#: src/i18n/interpolation.md:111
+msgid ""
+"```typescript\n"
+"// For strings outside UI components (API responses, notifications, …), use t():\n"
+"const message = t(\"Your order has been shipped.\")\n"
+"const welcome = t(\"Welcome back, {name}!\", { name: \"Alice\" })\n"
+"console.log(message, welcome)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:118
+msgid ""
+"This uses the same key lookup, validation, and interpolation as UI strings."
+msgstr ""
+
+#: src/i18n/formatting.md:1
+msgid "Locale-Aware Formatting"
+msgstr ""
+
+#: src/i18n/formatting.md:3
+msgid ""
+"Perry provides format wrapper functions that automatically format values "
+"according to the current locale. Import them from `perry/i18n`:"
+msgstr ""
+
+#: src/i18n/formatting.md:5
+msgid ""
+"```typescript\n"
+"// All format wrappers come from perry/i18n.\n"
+"// (The same `Currency`, `Percent`, … you'd pass into a Text(...) param object.)\n"
+"const price = Currency(23.10)\n"
+"const discount = Percent(0.15)\n"
+"const population = FormatNumber(1234567.89)\n"
+"const due = ShortDate(Date.now())\n"
+"const event = LongDate(Date.now())\n"
+"const at = FormatTime(Date.now())\n"
+"const code = Raw(12345)\n"
+"\n"
+"// Compose them with t() the same way you'd compose with Text(...):\n"
+"console.log(t(\"Total: {price}\", { price }))\n"
+"console.log(t(\"Discount: {rate}\", { rate: discount }))\n"
+"console.log(t(\"Population: {n}\", { n: population }))\n"
+"console.log(t(\"Due: {d}\", { d: due }))\n"
+"console.log(t(\"Event: {d}\", { d: event }))\n"
+"console.log(t(\"At: {t}\", { t: at }))\n"
+"console.log(t(\"Code: {amount}\", { amount: code }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:26
+msgid "Format Wrappers"
+msgstr ""
+
+#: src/i18n/formatting.md:28
+msgid "Currency"
+msgstr ""
+
+#: src/i18n/formatting.md:30
+msgid ""
+"Formats a number as currency with the locale's symbol, decimal separator, "
+"and symbol placement:"
+msgstr ""
+
+#: src/i18n/formatting.md:32
+msgid ""
+"```typescript\n"
+"// Currency: locale-appropriate symbol, separator, and placement.\n"
+"//   en: \"$23.10\"   de: \"23,10 €\"   ja: \"¥23.10\"\n"
+"const cur = Currency(23.10)\n"
+"console.log(t(\"Total: {price}\", { price: cur }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:39
+msgid ""
+"```text\n"
+"en: \"Total: $23.10\"\n"
+"de: \"Total: 23,10 €\"\n"
+"fr: \"Total: 23,10 €\"\n"
+"ja: \"Total: ¥23.10\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:46
+msgid "Percent"
+msgstr ""
+
+#: src/i18n/formatting.md:48
+msgid "Formats a decimal as a percentage (value is multiplied by 100):"
+msgstr ""
+
+#: src/i18n/formatting.md:50
+msgid ""
+"```typescript\n"
+"// Percent: input is a decimal (0.15 → 15 %). en omits the space; de/fr add it.\n"
+"const rate = Percent(0.15)\n"
+"console.log(t(\"Discount: {rate}\", { rate }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:56
+msgid ""
+"```text\n"
+"en: \"Discount: 15%\"\n"
+"de: \"Discount: 15 %\"\n"
+"fr: \"Discount: 15 %\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:62
+msgid "FormatNumber"
+msgstr ""
+
+#: src/i18n/formatting.md:64
+msgid ""
+"Formats a number with locale-appropriate grouping and decimal separators:"
+msgstr ""
+
+#: src/i18n/formatting.md:66
+msgid ""
+"```typescript\n"
+"// FormatNumber: locale-appropriate grouping + decimal separators.\n"
+"//   en: \"1,234,567.89\"   de: \"1.234.567,89\"   fr: \"1 234 567,89\"\n"
+"const n = FormatNumber(1234567.89)\n"
+"console.log(t(\"Population: {n}\", { n }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:73
+msgid ""
+"```text\n"
+"en: \"Population: 1,234,567.89\"\n"
+"de: \"Population: 1.234.567,89\"\n"
+"fr: \"Population: 1 234 567,89\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:79
+msgid "ShortDate / LongDate / FormatDate"
+msgstr ""
+
+#: src/i18n/formatting.md:81
+msgid "Formats a timestamp (milliseconds since epoch) as a date:"
+msgstr ""
+
+#: src/i18n/formatting.md:83
+msgid ""
+"```typescript\n"
+"// ShortDate / LongDate take a millisecond timestamp.\n"
+"const now = Date.now()\n"
+"const short = ShortDate(now)   // en: \"3/22/2026\"   de: \"22.03.2026\"\n"
+"const long = LongDate(now)     // en: \"March 22, 2026\"   de: \"22. März 2026\"\n"
+"console.log(t(\"Due: {d}\", { d: short }))\n"
+"console.log(t(\"Event: {d}\", { d: long }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:92
+msgid ""
+"```text\n"
+"ShortDate\n"
+"  en: \"Due: 3/22/2026\"\n"
+"  de: \"Due: 22.03.2026\"\n"
+"  ja: \"Due: 2026/03/22\"\n"
+"\n"
+"LongDate\n"
+"  en: \"Event: March 22, 2026\"\n"
+"  de: \"Event: 22. März 2026\"\n"
+"  fr: \"Event: 22 mars 2026\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:104
+msgid "FormatTime"
+msgstr ""
+
+#: src/i18n/formatting.md:106
+msgid "Formats a timestamp as time (12h vs 24h based on locale):"
+msgstr ""
+
+#: src/i18n/formatting.md:108
+msgid ""
+"```typescript\n"
+"// FormatTime: 12h vs 24h based on the active locale.\n"
+"const ts = Date.now()\n"
+"const formatted = FormatTime(ts)\n"
+"console.log(t(\"At: {t}\", { t: formatted }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:115
+msgid ""
+"```text\n"
+"en: \"At: 3:45 PM\"\n"
+"de: \"At: 15:45\"\n"
+"fr: \"At: 15:45\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:121
+msgid "Raw"
+msgstr ""
+
+#: src/i18n/formatting.md:123
+msgid ""
+"Pass-through — prevents any automatic formatting. Use when a parameter name "
+"might trigger auto-formatting but you want the raw value:"
+msgstr ""
+
+#: src/i18n/formatting.md:125
+msgid ""
+"```typescript\n"
+"// Raw is a pass-through — prevents auto-formatting when the param name\n"
+"// might otherwise trigger it.\n"
+"const orderCode = Raw(12345)\n"
+"console.log(t(\"Code: {amount}\", { amount: orderCode }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:132
+msgid "All locales: `\"Code: 12345\"` (no currency formatting despite the name)."
+msgstr ""
+
+#: src/i18n/formatting.md:134
+msgid "Locale-Specific Formatting Rules"
+msgstr ""
+
+#: src/i18n/formatting.md:136
+msgid "Perry includes hand-rolled formatting rules for 25+ locales:"
+msgstr ""
+
+#: src/i18n/formatting.md:138
+msgid "Example Locales"
+msgstr ""
+
+#: src/i18n/formatting.md:140
+msgid "Decimal: `.` / Thousands: `,`"
+msgstr ""
+
+#: src/i18n/formatting.md:140 src/i18n/formatting.md:144
+msgid "en, ja, zh, ko"
+msgstr ""
+
+#: src/i18n/formatting.md:141
+msgid "Decimal: `,` / Thousands: `.`"
+msgstr ""
+
+#: src/i18n/formatting.md:141
+msgid "de, nl, tr, es, it, pt"
+msgstr ""
+
+#: src/i18n/formatting.md:142
+msgid "Decimal: `,` / Thousands: ` ` (narrow space)"
+msgstr ""
+
+#: src/i18n/formatting.md:142
+msgid "fr"
+msgstr ""
+
+#: src/i18n/formatting.md:143
+msgid "Decimal: `,` / Thousands: ` ` (non-breaking space)"
+msgstr ""
+
+#: src/i18n/formatting.md:143
+msgid "ru, uk, pl, sv, da, no, fi"
+msgstr ""
+
+#: src/i18n/formatting.md:144
+msgid "Currency before number: `$23.10`"
+msgstr ""
+
+#: src/i18n/formatting.md:145
+msgid "Currency after number: `23,10 €`"
+msgstr ""
+
+#: src/i18n/formatting.md:145
+msgid "de, fr, es, it, ru"
+msgstr ""
+
+#: src/i18n/formatting.md:146
+msgid "Percent with space: `42 %`"
+msgstr ""
+
+#: src/i18n/formatting.md:146 src/i18n/formatting.md:149
+msgid "de, fr, es, ru"
+msgstr ""
+
+#: src/i18n/formatting.md:147
+msgid "Percent without space: `42%`"
+msgstr ""
+
+#: src/i18n/formatting.md:147
+msgid "en, ja, zh"
+msgstr ""
+
+#: src/i18n/formatting.md:148
+msgid "Date order: M/D/Y"
+msgstr ""
+
+#: src/i18n/formatting.md:148 src/i18n/formatting.md:152
+msgid "en"
+msgstr ""
+
+#: src/i18n/formatting.md:149
+msgid "Date order: D.M.Y"
+msgstr ""
+
+#: src/i18n/formatting.md:150
+msgid "Date order: Y/M/D"
+msgstr ""
+
+#: src/i18n/formatting.md:150
+msgid "ja, zh, ko, sv"
+msgstr ""
+
+#: src/i18n/formatting.md:151
+msgid "24-hour time"
+msgstr ""
+
+#: src/i18n/formatting.md:151
+msgid "de, fr, es, ja, zh, ru (most)"
+msgstr ""
+
+#: src/i18n/formatting.md:152
+msgid "12-hour time (AM/PM)"
+msgstr ""
+
+#: src/i18n/formatting.md:154
+msgid "Currency Configuration"
+msgstr ""
+
+#: src/i18n/formatting.md:156
+msgid "Configure default currency codes per locale in `perry.toml`:"
+msgstr ""
+
+#: src/i18n/formatting.md:158
+msgid ""
+"```toml\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\", \"fr\"]\n"
+"default_locale = \"en\"\n"
+"\n"
+"[i18n.currencies]\n"
+"en = \"USD\"\n"
+"de = \"EUR\"\n"
+"fr = \"EUR\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:169
+msgid ""
+"When `Currency(value)` is called, the locale's configured currency code "
+"determines the symbol and formatting rules."
+msgstr ""
+
+#: src/i18n/cli.md:1
+msgid "i18n CLI Tools"
+msgstr ""
+
+#: src/i18n/cli.md:3 src/cli/commands.md:308
+msgid "`perry i18n extract`"
+msgstr ""
+
+#: src/i18n/cli.md:5
+msgid ""
+"Scans your TypeScript source files for localizable strings and generates or "
+"updates locale JSON files."
+msgstr ""
+
+#: src/i18n/cli.md:11
+msgid "What It Does"
+msgstr ""
+
+#: src/i18n/cli.md:13
+msgid "Recursively scans all `.ts` and `.tsx` files in the source directory"
+msgstr ""
+
+#: src/i18n/cli.md:14
+msgid ""
+"Detects string literals in UI component calls: `Button(\"...\")`, "
+"`Text(\"...\")`, `Label(\"...\")`, etc."
+msgstr ""
+
+#: src/i18n/cli.md:15
+msgid "Also detects `t(\"...\")` calls from `perry/i18n`"
+msgstr ""
+
+#: src/i18n/cli.md:16
+msgid "Creates `locales/` directory if it doesn't exist"
+msgstr ""
+
+#: src/i18n/cli.md:17
+msgid "For each configured locale, creates or updates a JSON file:"
+msgstr ""
+
+#: src/i18n/cli.md:18
+msgid "**Default locale**: New keys are pre-filled with themselves as values"
+msgstr ""
+
+#: src/i18n/cli.md:19
+msgid ""
+"**Non-default locales**: New keys are added with empty string values "
+"(indicating \"needs translation\")"
+msgstr ""
+
+#: src/i18n/cli.md:21
+msgid "Example Output"
+msgstr ""
+
+#: src/i18n/cli.md:32
+msgid "Workflow"
+msgstr ""
+
+#: src/i18n/cli.md:34
+msgid "Typical translation workflow:"
+msgstr ""
+
+#: src/i18n/cli.md:37
+msgid "# 1. Write code with English strings\n"
+msgstr ""
+
+#: src/i18n/cli.md:39
+msgid "# 2. Extract strings to locale files\n"
+msgstr ""
+
+#: src/i18n/cli.md:42
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
+msgstr ""
+
+#: src/i18n/cli.md:44
+msgid "# 4. Build — Perry validates everything\n"
+msgstr ""
+
+#: src/i18n/cli.md:49
+msgid "Detected Patterns"
+msgstr ""
+
+#: src/i18n/cli.md:51
+msgid "The scanner detects these UI component patterns:"
+msgstr ""
+
+#: src/i18n/cli.md:53
+msgid "`Button(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:54
+msgid "`Text(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:55
+msgid "`Label(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:56
+msgid "`TextField(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:57
+msgid "`TextArea(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:58
+msgid "`Tab(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:59
+msgid "`NavigationTitle(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:60
+msgid "`SectionHeader(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:61
+msgid "`SecureField(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:62
+msgid "`Alert(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:63
+msgid "`t(\"string\")` (explicit i18n API)"
+msgstr ""
+
+#: src/i18n/cli.md:65
+msgid ""
+"Both double-quoted and single-quoted strings are supported. Escaped quotes "
+"are handled correctly."
+msgstr ""
+
+#: src/i18n/cli.md:67
+msgid "Build Output"
+msgstr ""
+
+#: src/i18n/cli.md:69
+msgid "During compilation, Perry reports i18n status:"
+msgstr ""
+
+#: src/i18n/cli.md:71
+msgid ""
+"```\n"
+"  i18n: 2 locale(s) [en, de], default: en\n"
+"    Loaded locales/en.json (12 keys)\n"
+"    Loaded locales/de.json (12 keys)\n"
+"  i18n: 12 localizable string(s) detected\n"
+"  i18n warning: Missing translation for key \"Settings\" in locale \"de\"\n"
+"  i18n warning: Unused i18n key \"Old Label\" in locale \"en\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/cli.md:80
+msgid "Key Registry"
+msgstr ""
+
+#: src/i18n/cli.md:82
+msgid ""
+"Perry maintains a `.perry/i18n-keys.json` file, updated on every build:"
+msgstr ""
+
+#: src/i18n/cli.md:86
+msgid "\"keys\""
+msgstr ""
+
+#: src/i18n/cli.md:87 src/i18n/cli.md:88 src/i18n/cli.md:89
+msgid "\"key\""
+msgstr ""
+
+#: src/i18n/cli.md:87 src/i18n/cli.md:88 src/i18n/cli.md:89
+msgid "\"string_idx\""
+msgstr ""
+
+#: src/i18n/cli.md:89
+msgid "\"You have {count} items\""
+msgstr ""
+
+#: src/i18n/cli.md:94
+msgid ""
+"This file serves as the source of truth for what strings exist in the "
+"codebase."
+msgstr ""
+
+#: src/updater/overview.md:3
+msgid ""
+"Ship updates to your Perry desktop app without rolling your own download + "
+"replace + relaunch flow. Two modules cooperate:"
+msgstr ""
+
+#: src/updater/overview.md:6
+msgid ""
+"**`@perry/updater`** — high-level wrapper. The 90% case: manifest fetch, "
+"semver compare, download, verify, install, relaunch, crash-loop rollback."
+msgstr ""
+
+#: src/updater/overview.md:8
+msgid ""
+"**`perry/updater`** — ambient primitives the wrapper is built on. Reach for "
+"these only when you need a custom flow (multi-channel rollouts, your own "
+"progress UI, an integration with an external supervisor)."
+msgstr ""
+
+#: src/updater/overview.md:12
+msgid ""
+"The trust model and wire format follow [Tauri's "
+"updater](https://v2.tauri.app/plugin/updater/): JSON manifest over HTTPS, "
+"SHA-256 + Ed25519 signature over the digest, atomic binary replace with a "
+"`.prev` backup, detached relaunch. Every snippet below is excerpted from "
+"[`docs/examples/updater/snippets.ts`](../../examples/updater/snippets.ts) — "
+"CI compile-links it on every PR."
+msgstr ""
+
+#: src/updater/overview.md:19
+msgid ""
+"**Desktop only.** iOS / TestFlight, Android Play Store, and sideloaded APKs "
+"own the install pipeline at the OS level — replacing your own binary at "
+"runtime is structurally impossible there. The crate still compiles on mobile"
+" targets so cross-platform code doesn't need `#ifdef`s, but the install path"
+" is a no-op. Gate updater code with `process.platform` if your app ships "
+"everywhere."
+msgstr ""
+
+#: src/updater/overview.md:26 src/system/media.md:8
+#: src/plugins/appstore-review.md:11
+msgid "Quick start"
+msgstr ""
+
+#: src/updater/overview.md:28
+msgid ""
+"```typescript\n"
+"// import { checkForUpdate, initUpdater, markHealthy } from \"@perry/updater\"\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:32
+msgid ""
+"Drop a \"Check for updates\" handler somewhere in your menu or a periodic "
+"timer. `checkForUpdate` returns `null` when up to date or when the manifest "
+"has no entry for the current platform."
+msgstr ""
+
+#: src/updater/overview.md:36
+msgid ""
+"```typescript\n"
+"// Pseudocode using @perry/updater's wrapper. Drop into a \"Check for updates\"\n"
+"// menu item or a periodic timer. The manifest URL must serve over HTTPS.\n"
+"//\n"
+"// const update = await checkForUpdate({\n"
+"//     manifestUrl: \"https://updates.example.com/myapp.json\",\n"
+"//     publicKey: \"BASE64_ED25519_PUBKEY\",\n"
+"//     currentVersion: \"1.4.0\",\n"
+"// })\n"
+"//\n"
+"// if (update !== null) {\n"
+"//     console.log(`v${update.version} is available`)\n"
+"//     console.log(update.notes)\n"
+"//\n"
+"//     await update.download((downloaded, total) => {\n"
+"//         const pct = Math.round((downloaded / total) * 100)\n"
+"//         console.log(`downloading: ${pct}%`)\n"
+"//     })\n"
+"//\n"
+"//     await update.installAndRelaunch()  // never returns — process.exit inside\n"
+"// }\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:59
+msgid ""
+"Call `initUpdater()` once near the top of `main()`. It handles boot-time "
+"crash-loop detection: if the new binary you just installed crashes during "
+"boot more than `crashLoopThreshold` times, the wrapper restores the previous"
+" version and exits so the OS / launcher restarts you on the rollback."
+msgstr ""
+
+#: src/updater/overview.md:64
+msgid ""
+"```typescript\n"
+"// Boot-time: detect a crash-looping new install and roll back. Call this\n"
+"// near the top of `main()`, right after process initialization.\n"
+"//\n"
+"// await initUpdater({\n"
+"//     autoRollback:       true,    // default\n"
+"//     healthCheckMs:      60_000,  // clear sentinel after this many ms alive\n"
+"//     crashLoopThreshold: 2,       // restarts before rollback fires\n"
+"// })\n"
+"//\n"
+"// // Optional: tell the updater explicitly that this version is healthy\n"
+"// // (e.g. after a successful login or migration finished).\n"
+"// // markHealthy()\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:79
+msgid "Manifest"
+msgstr ""
+
+#: src/updater/overview.md:81
+msgid ""
+"Serve a single JSON file over HTTPS. One entry per `<os>-<arch>` you publish"
+" for; clients ignore entries that don't match their platform."
+msgstr ""
+
+#: src/updater/overview.md:84
+msgid ""
+"```typescript\n"
+"// The manifest is a single JSON file you serve over HTTPS. Each platform\n"
+"// triple is `<os>-<arch>` (darwin-aarch64, darwin-x86_64, windows-x86_64,\n"
+"// linux-x86_64, linux-aarch64). The wrapper picks the entry matching the\n"
+"// running host and ignores the rest.\n"
+"//\n"
+"// {\n"
+"//   \"schemaVersion\": 1,\n"
+"//   \"version\": \"1.4.0\",\n"
+"//   \"pubDate\": \"2026-04-27T10:00:00Z\",\n"
+"//   \"notes\": \"Bug fixes and performance improvements\",\n"
+"//   \"platforms\": {\n"
+"//     \"darwin-aarch64\": {\n"
+"//       \"url\":       \"https://example.com/app-1.4.0-darwin-aarch64.bin\",\n"
+"//       \"sha256\":    \"0123456789abcdef...\",\n"
+"//       \"signature\": \"base64sig==\",\n"
+"//       \"size\":      12345678\n"
+"//     }\n"
+"//   }\n"
+"// }\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:106
+msgid "Meaning"
+msgstr ""
+
+#: src/updater/overview.md:108
+msgid "`schemaVersion`"
+msgstr ""
+
+#: src/updater/overview.md:108
+msgid ""
+"`1` (legacy, digest-only signature) or `2` (recommended — version-bound "
+"signature; see below)."
+msgstr ""
+
+#: src/updater/overview.md:109 src/cli/perry-toml.md:117
+msgid "`version`"
+msgstr ""
+
+#: src/updater/overview.md:109
+msgid "Semver string of the offered version (e.g. `\"1.4.0\"`)."
+msgstr ""
+
+#: src/updater/overview.md:110
+msgid "`pubDate`"
+msgstr ""
+
+#: src/updater/overview.md:110
+msgid "ISO-8601 timestamp the build was published — surfaced as metadata."
+msgstr ""
+
+#: src/updater/overview.md:111
+msgid "`notes`"
+msgstr ""
+
+#: src/updater/overview.md:111
+msgid "Markdown release notes shown to the user."
+msgstr ""
+
+#: src/updater/overview.md:112
+msgid "`platforms.<os>-<arch>.url`"
+msgstr ""
+
+#: src/updater/overview.md:112
+msgid "Direct download URL (HTTPS)."
+msgstr ""
+
+#: src/updater/overview.md:113
+msgid "`platforms.<os>-<arch>.sha256`"
+msgstr ""
+
+#: src/updater/overview.md:113
+msgid "Lowercase hex SHA-256 of the binary."
+msgstr ""
+
+#: src/updater/overview.md:114
+msgid "`platforms.<os>-<arch>.signature`"
+msgstr ""
+
+#: src/updater/overview.md:114
+msgid ""
+"Base64 Ed25519 signature. v1: over the raw 32-byte digest. v2: over `digest "
+"\\|\\| version_utf8`."
+msgstr ""
+
+#: src/updater/overview.md:115
+msgid "`platforms.<os>-<arch>.size`"
+msgstr ""
+
+#: src/updater/overview.md:115
+msgid "Byte length of the binary — used for progress reporting."
+msgstr ""
+
+#: src/updater/overview.md:117
+msgid "Platform keys are canonical Rust-style triples:"
+msgstr ""
+
+#: src/updater/overview.md:119
+msgid "Host"
+msgstr ""
+
+#: src/updater/overview.md:119
+msgid "Triple"
+msgstr ""
+
+#: src/updater/overview.md:121
+msgid "Apple Silicon mac"
+msgstr ""
+
+#: src/updater/overview.md:121
+msgid "`darwin-aarch64`"
+msgstr ""
+
+#: src/updater/overview.md:122
+msgid "Intel mac"
+msgstr ""
+
+#: src/updater/overview.md:122
+msgid "`darwin-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:123
+msgid "Windows 10/11 64-bit"
+msgstr ""
+
+#: src/updater/overview.md:123
+msgid "`windows-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:124
+msgid "Linux 64-bit"
+msgstr ""
+
+#: src/updater/overview.md:124
+msgid "`linux-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:125
+msgid "Linux ARM64"
+msgstr ""
+
+#: src/updater/overview.md:125
+msgid "`linux-aarch64`"
+msgstr ""
+
+#: src/updater/overview.md:127
+msgid "Trust model"
+msgstr ""
+
+#: src/updater/overview.md:129
+msgid "`schemaVersion: 2` (recommended) — version-bound signature"
+msgstr ""
+
+#: src/updater/overview.md:131
+msgid ""
+"The signed payload is `SHA256(binary) || version_utf8` — the 32-byte raw "
+"digest concatenated with the UTF-8 bytes of the version string. This binds "
+"the version into the signature, so an on-path attacker can't replay a "
+"previously-signed older binary as a \"new version\" by serving a manifest "
+"that pairs the old binary's URL + signature with a higher version number "
+"([\\#229](https://github.com/PerryTS/perry/issues/229))."
+msgstr ""
+
+#: src/updater/overview.md:138
+msgid "Sign side:"
+msgstr ""
+
+#: src/updater/overview.md:140
+msgid ""
+"```text\n"
+"payload = sha256(binary).digest() + version.encode(\"utf-8\")\n"
+"signature = ed25519_sign(secret_key, payload)  # 64-byte signature\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:145
+msgid "Verification on the client:"
+msgstr ""
+
+#: src/updater/overview.md:147
+msgid ""
+"SHA-256 the downloaded file. Reject if it doesn't match `manifest.sha256`."
+msgstr ""
+
+#: src/updater/overview.md:148
+msgid ""
+"Build the v2 payload (`digest || version_utf8`) using `manifest.version`."
+msgstr ""
+
+#: src/updater/overview.md:149
+msgid "Ed25519-verify the signature against the bundled public key."
+msgstr ""
+
+#: src/updater/overview.md:150
+msgid "Reject on any decode error, size mismatch, or signature failure."
+msgstr ""
+
+#: src/updater/overview.md:152
+msgid ""
+"If an attacker swaps the manifest's `version` field while keeping the old "
+"`signature`, step 3 fails because the signature was made over the _original_"
+" version. If they swap both `version` and `signature` (using a previously-"
+"signed older binary), step 1 fails because `sha256` of the older binary "
+"doesn't match the rewritten higher-version label either — every plausible "
+"attack on the version metadata invalidates something."
+msgstr ""
+
+#: src/updater/overview.md:160
+msgid "`schemaVersion: 1` (legacy, digest-only)"
+msgstr ""
+
+#: src/updater/overview.md:162
+msgid ""
+"The signed payload is the raw 32-byte digest only. **This shape is "
+"vulnerable to old-binary replay** "
+"([\\#229](https://github.com/PerryTS/perry/issues/229)): an on-path attacker"
+" can serve a manifest claiming a higher version while pointing at a "
+"previously-signed older binary, and signature verification still passes "
+"because the version isn't bound into the signature. Existing v1 manifests "
+"stay supported by the client during migration; new deployments should use "
+"v2."
+msgstr ""
+
+#: src/updater/overview.md:170
+msgid "Migration"
+msgstr ""
+
+#: src/updater/overview.md:172
+msgid ""
+"`@perry/updater` v0.5.391+ accepts both `schemaVersion: 1` and "
+"`schemaVersion: 2`. Bumping your manifest from 1 → 2 requires:"
+msgstr ""
+
+#: src/updater/overview.md:175
+msgid ""
+"Update sign-side tooling to compute the new payload (`sha256(binary) + "
+"version.encode(\"utf-8\")`) and sign that."
+msgstr ""
+
+#: src/updater/overview.md:177
+msgid "Bump `schemaVersion` in the manifest from `1` to `2`."
+msgstr ""
+
+#: src/updater/overview.md:178
+msgid ""
+"Make sure all deployed clients are running a perry-updater version that "
+"knows about v2 BEFORE you publish a v2 manifest. Older clients reject "
+"`schemaVersion: 2` with an `unsupported manifest schemaVersion` error. "
+"(Plan: ship a perry-updater bump with v2 support to your users via a v1 "
+"manifest first; once they're on the v2-aware client, the next manifest can "
+"be v2.)"
+msgstr ""
+
+#: src/updater/overview.md:185
+msgid "Keypair"
+msgstr ""
+
+#: src/updater/overview.md:187
+msgid ""
+"You generate the keypair once and bake the public key into your app at build"
+" time; the secret key stays on a release-signing machine alongside the rest "
+"of your build artifacts. Compromise of the manifest server alone never lets "
+"an attacker push a binary your client will accept."
+msgstr ""
+
+#: src/updater/overview.md:192
+msgid "Sign-side CLI (v0.5.395+)"
+msgstr ""
+
+#: src/updater/overview.md:194
+msgid ""
+"`perry updater` ships three subcommands that produce v2-shape signatures "
+"without needing any custom tooling:"
+msgstr ""
+
+#: src/updater/overview.md:198
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
+msgstr ""
+
+#: src/updater/overview.md:201
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
+msgstr ""
+
+#: src/updater/overview.md:219
+msgid ""
+"Compose a final manifest by piping `sign` output through `jq` for each "
+"asset, then merging into the per-platform layout shown above. CI tip: pass "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so"
+" the secret can come from a repository secret without ever hitting the "
+"worker's filesystem."
+msgstr ""
+
+#: src/updater/overview.md:225
+msgid "Install + rollback flow"
+msgstr ""
+
+#: src/updater/overview.md:227
+msgid ""
+"```text\n"
+"manifest fetch  →  semver compare  →  download to <exe>.staged\n"
+"                                          ↓\n"
+"                                      sha256 verify  →  ed25519 verify\n"
+"                                          ↓\n"
+"                                      arm sentinel (state: \"armed\")\n"
+"                                          ↓\n"
+"                                      install:  rename <exe> → <exe>.prev\n"
+"                                                rename <exe>.staged → <exe>\n"
+"                                                chmod +x   (Unix only)\n"
+"                                          ↓\n"
+"                                      detached relaunch  →  process.exit(0)\n"
+"\n"
+"next boot  →  initUpdater() reads sentinel\n"
+"                  ├── healthCheckMs alive  → clearSentinel  (success)\n"
+"                  ├── graceful exit         → clearSentinel  (success)\n"
+"                  └── restartCount ≥ N      → performRollback + exit\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:246
+msgid ""
+"`installUpdate` is atomic where the OS lets us be: POSIX `rename(2)` on the "
+"same filesystem, NTFS rename-while-open (the PE loader opens with "
+"`FILE_SHARE_DELETE` so Windows tolerates this since Vista), and Linux's "
+"mmap'd-inode-stays-alive semantics. If the staging directory ends up on a "
+"different filesystem (a separate mount for `/tmp`, for instance) the rename "
+"falls back to copy + remove, which has a small non-atomic window."
+msgstr ""
+
+#: src/updater/overview.md:253
+msgid "The sentinel is a JSON file at a per-OS user-writable path:"
+msgstr ""
+
+#: src/updater/overview.md:255
+msgid "Default location"
+msgstr ""
+
+#: src/updater/overview.md:257
+msgid "`~/Library/Application Support/<app>/updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:258
+msgid "`%LOCALAPPDATA%\\<app>\\updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:259
+msgid "`$XDG_STATE_HOME/<app>/updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:261
+msgid ""
+"`<app>` comes from the `PERRY_APP_ID` environment variable, falling back to "
+"the basename of the running exe. **Set `PERRY_APP_ID` in your launch "
+"environment** so the sentinel path stays stable across rename / relocation "
+"of the binary."
+msgstr ""
+
+#: src/updater/overview.md:266
+msgid "Low-level primitives"
+msgstr ""
+
+#: src/updater/overview.md:268
+msgid ""
+"Use these when the high-level wrapper doesn't fit — custom progress UI, a "
+"multi-channel manifest, an external supervisor that handles restarts, etc."
+msgstr ""
+
+#: src/updater/overview.md:271
+msgid ""
+"```typescript\n"
+"import {\n"
+"    compareVersions,\n"
+"    verifyHash,\n"
+"    verifySignature,\n"
+"    computeFileSha256,\n"
+"    writeSentinel,\n"
+"    readSentinel,\n"
+"    clearSentinel,\n"
+"    getExePath,\n"
+"    getBackupPath,\n"
+"    getSentinelPath,\n"
+"    installUpdate,\n"
+"    performRollback,\n"
+"    relaunch,\n"
+"} from \"perry/updater\"\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:289
+msgid "`compareVersions(current, candidate)`"
+msgstr ""
+
+#: src/updater/overview.md:291
+msgid ""
+"Returns `-1` (update available), `0` (equal), `1` (downgrade — never "
+"offered), or `-2` (parse error). Prerelease tags handled per the semver "
+"spec."
+msgstr ""
+
+#: src/updater/overview.md:294
+msgid ""
+"```typescript\n"
+"// Returns -1 (current < candidate, update available), 0 (equal),\n"
+"// 1 (current > candidate, never offered as an update), -2 (parse error).\n"
+"const cmp = compareVersions(\"1.4.0\", \"1.4.1\")\n"
+"if (cmp === -1) {\n"
+"    console.log(\"update available\")\n"
+"} else if (cmp === 0) {\n"
+"    console.log(\"up to date\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:305
+msgid "`verifyHash` / `verifySignature` / `computeFileSha256`"
+msgstr ""
+
+#: src/updater/overview.md:307
+msgid ""
+"```typescript\n"
+"// SHA-256 + Ed25519 verification of a binary on disk. The signed payload is\n"
+"// the *raw 32-byte SHA-256 digest* — not the hex string and not the file\n"
+"// bytes themselves. Sign side: `sha256(file) | ed25519_sign(secret_key)`.\n"
+"const stagedPath = getExePath() + \".staged\"\n"
+"const expectedHex = \"0123456789abcdef...\" // from your manifest\n"
+"const sigB64 = \"...base64...\"             // 64-byte signature, base64\n"
+"const pubB64 = \"...base64...\"             // 32-byte public key, base64\n"
+"\n"
+"if (verifyHash(stagedPath, expectedHex) !== 1) {\n"
+"    const actual = computeFileSha256(stagedPath)\n"
+"    console.error(`hash mismatch — expected ${expectedHex}, got ${actual}`)\n"
+"}\n"
+"if (verifySignature(stagedPath, sigB64, pubB64) !== 1) {\n"
+"    console.error(\"signature verification failed\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:325
+msgid ""
+"`verifyHash` and `verifySignature` return `1` on success, `0` on any failure"
+" (file missing, decode error, mismatch). `computeFileSha256` returns the hex"
+" digest as a string, or `\"\"` on failure — useful for logging the _actual_ "
+"hash when a `verifyHash` mismatch fires."
+msgstr ""
+
+#: src/updater/overview.md:330
+msgid "`installUpdate` / `performRollback` / `relaunch`"
+msgstr ""
+
+#: src/updater/overview.md:332
+msgid ""
+"```typescript\n"
+"// `installUpdate` atomically replaces `targetPath` with `stagedPath`,\n"
+"// keeping the displaced version at `<target>.prev` for rollback.\n"
+"const target = getExePath()\n"
+"const staged = target + \".staged\"\n"
+"\n"
+"if (installUpdate(staged, target) !== 1) {\n"
+"    console.error(\"install failed\")\n"
+"} else {\n"
+"    const pid = relaunch(target)\n"
+"    if (pid < 0) {\n"
+"        console.error(\"relaunch failed; restart manually\")\n"
+"    } else {\n"
+"        // Detached child is now running the new binary — get out of its way.\n"
+"        process.exit(0)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:351
+msgid ""
+"```typescript\n"
+"// `performRollback` restores `<target>.prev` over `target` and moves the\n"
+"// current (likely-broken) target to `<target>.broken` as a safety net.\n"
+"if (performRollback(getExePath()) !== 1) {\n"
+"    console.error(\"no backup to roll back to\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:359
+msgid ""
+"`relaunch` returns the child PID, or `-1` on failure. The new process is "
+"fully detached (`setsid` on Unix, `DETACHED_PROCESS | "
+"CREATE_NEW_PROCESS_GROUP` on Windows) so closing the current process doesn't"
+" take it down."
+msgstr ""
+
+#: src/updater/overview.md:363
+msgid "Path resolution"
+msgstr ""
+
+#: src/updater/overview.md:365
+msgid ""
+"```typescript\n"
+"// Resolved per platform. macOS walks up to the surrounding `.app` bundle;\n"
+"// Linux honors $APPIMAGE; Windows / bare ELF returns the canonical exe.\n"
+"console.log(\"running exe   :\", getExePath())\n"
+"console.log(\"backup target :\", getBackupPath())\n"
+"// Sentinel path is keyed off PERRY_APP_ID — set this env var so the path\n"
+"// stays stable across rename/relocation of the binary.\n"
+"console.log(\"sentinel path :\", getSentinelPath())\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:375
+msgid "`getExePath()` accounts for platform quirks:"
+msgstr ""
+
+#: src/updater/overview.md:377
+msgid ""
+"**macOS**: walks up to the surrounding `.app` bundle if applicable — the "
+"`.app` directory is the codesign unit, so that's what you replace."
+msgstr ""
+
+#: src/updater/overview.md:379
+msgid ""
+"**Linux**: honors `$APPIMAGE` when set. The AppImage runtime points "
+"`current_exe()` inside a read-only squashfs mount; the real target to "
+"replace is the AppImage file itself."
+msgstr ""
+
+#: src/updater/overview.md:382
+msgid ""
+"**Windows / bare ELF / bare Mach-O**: returns the canonicalized exe path."
+msgstr ""
+
+#: src/updater/overview.md:384
+msgid "Sentinel"
+msgstr ""
+
+#: src/updater/overview.md:386
+msgid ""
+"```typescript\n"
+"// Low-level sentinel API. Most apps use `initUpdater()` from @perry/updater\n"
+"// instead of touching this directly, but it's here when you need it (custom\n"
+"// rollback policies, multi-process apps, integration with another supervisor).\n"
+"const sentinelPath = getSentinelPath()\n"
+"writeSentinel(sentinelPath, JSON.stringify({ state: \"armed\", restartCount: 0 }))\n"
+"const raw = readSentinel(sentinelPath)\n"
+"if (raw) {\n"
+"    const state = JSON.parse(raw) as { state: string; restartCount: number }\n"
+"    if (state.restartCount >= 2) {\n"
+"        // looks like a crash loop — recover or roll back\n"
+"        clearSentinel(sentinelPath)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:402
+msgid ""
+"`writeSentinel` is atomic (tmp file + rename), creates the parent directory "
+"if needed, and returns `1` on success / `0` on any IO error. `clearSentinel`"
+" is idempotent — returns `1` whether the file existed or not."
+msgstr ""
+
+#: src/updater/overview.md:406
+msgid "What's not here (yet)"
+msgstr ""
+
+#: src/updater/overview.md:408
+msgid ""
+"**UI primitives** — a \"Restart now\" modal with `ProgressView` belongs "
+"inside `perry/ui` proper rather than the updater package. Tracked as a "
+"follow-up."
+msgstr ""
+
+#: src/updater/overview.md:411
+msgid ""
+"**Privileged install** for system-wide locations (`/Applications`, `Program "
+"Files`). The current install path only handles user-writable locations "
+"(`~/Applications`, `~/.local/bin`, `%LOCALAPPDATA%`). UAC / `SMJobBless` is "
+"a separate concern."
+msgstr ""
+
+#: src/updater/overview.md:415
+msgid ""
+"**Delta updates** (bsdiff), **multi-channel** (stable / beta), **staged "
+"rollouts**."
+msgstr ""
+
+#: src/updater/overview.md:417
+msgid ""
+"**Notarization / code-signing** during install. Binaries are expected to "
+"arrive already signed; the updater doesn't try to be a notarization tool."
+msgstr ""
+
+#: src/updater/overview.md:420
+msgid "Testing your update flow"
+msgstr ""
+
+#: src/updater/overview.md:422
+msgid ""
+"The crate ships smoke-test scripts that exercise verify → install → relaunch"
+" end-to-end against a real Perry binary:"
+msgstr ""
+
+#: src/updater/overview.md:425
+msgid "**Unix**: `scripts/smoke_updater.sh`"
+msgstr ""
+
+#: src/updater/overview.md:426
+msgid "**Windows**: `scripts/smoke_updater.ps1`"
+msgstr ""
+
+#: src/updater/overview.md:428
+msgid ""
+"Both spin up a tiny HTTP server, build a v1.0.0 binary that drives the "
+"update flow, build a v1.0.1 binary that proves it ran, and verify the "
+"relaunch handed off correctly. Run them locally before shipping a release "
+"that depends on the updater wiring."
+msgstr ""
+
+#: src/updater/overview.md:435
+msgid "[System APIs](../system/overview.md) — the rest of `perry/system`"
+msgstr ""
+
+#: src/updater/overview.md:436
+msgid ""
+"[HTTP & Networking](../stdlib/http.md) — `fetch()` is what the wrapper uses "
+"internally"
+msgstr ""
+
+#: src/updater/overview.md:438
+msgid ""
+"[Cryptography](../stdlib/crypto.md) — Ed25519 sign / verify primitives for "
+"tooling that builds the manifest"
+msgstr ""
+
+#: src/system/overview.md:1
+msgid "System APIs Overview"
+msgstr ""
+
+#: src/system/overview.md:3
+msgid ""
+"The `perry/system` module provides access to platform-native system "
+"features: preferences, secure storage, notifications, dark-mode detection, "
+"audio capture, and app introspection. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links the file on every PR."
+msgstr ""
+
+#: src/system/overview.md:9
+msgid ""
+"```typescript\n"
+"// import {\n"
+"//     openURL, isDarkMode,\n"
+"//     preferencesGet, preferencesSet,\n"
+"//     keychainSave, keychainGet, keychainDelete,\n"
+"//     notificationSend,\n"
+"//     audioStart, audioStop, audioGetLevel, audioGetPeak, audioGetWaveform,\n"
+"// } from \"perry/system\"\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:19
+msgid "Available APIs"
+msgstr ""
+
+#: src/system/overview.md:23
+msgid "`openURL(url)`"
+msgstr ""
+
+#: src/system/overview.md:23
+msgid "Open URL in default browser/app"
+msgstr ""
+
+#: src/system/overview.md:23 src/system/overview.md:24
+#: src/system/overview.md:25 src/system/overview.md:26
+#: src/system/overview.md:27 src/system/overview.md:29
+#: src/system/overview.md:30 src/system/overview.md:31
+#: src/system/overview.md:32 src/system/overview.md:36
+#: src/system/overview.md:37 src/system/overview.md:38
+msgid "All"
+msgstr ""
+
+#: src/system/overview.md:24
+msgid "`isDarkMode()`"
+msgstr ""
+
+#: src/system/overview.md:24
+msgid "Check system dark mode"
+msgstr ""
+
+#: src/system/overview.md:25
+msgid "`getDeviceIdiom()`"
+msgstr ""
+
+#: src/system/overview.md:25
+msgid "`\"phone\"`, `\"pad\"`, `\"mac\"`, `\"tv\"`, …"
+msgstr ""
+
+#: src/system/overview.md:26
+msgid "`getDeviceModel()`"
+msgstr ""
+
+#: src/system/overview.md:26
+msgid "Device model identifier (e.g. `\"iPhone13,4\"`)"
+msgstr ""
+
+#: src/system/overview.md:27
+msgid "`preferencesSet(key, value)`"
+msgstr ""
+
+#: src/system/overview.md:27
+msgid "Store a preference (string or number)"
+msgstr ""
+
+#: src/system/overview.md:28
+msgid "`preferencesGet(key)`"
+msgstr ""
+
+#: src/system/overview.md:28
+msgid "Read a preference (returns \\`string"
+msgstr ""
+
+#: src/system/overview.md:29
+msgid "`keychainSave(key, value)`"
+msgstr ""
+
+#: src/system/overview.md:29
+msgid "Secure storage write"
+msgstr ""
+
+#: src/system/overview.md:30
+msgid "`keychainGet(key)`"
+msgstr ""
+
+#: src/system/overview.md:30
+msgid "Secure storage read"
+msgstr ""
+
+#: src/system/overview.md:31
+msgid "`keychainDelete(key)`"
+msgstr ""
+
+#: src/system/overview.md:31
+msgid "Secure storage remove"
+msgstr ""
+
+#: src/system/overview.md:32
+msgid "`notificationSend(title, body)`"
+msgstr ""
+
+#: src/system/overview.md:32
+msgid "Local notification"
+msgstr ""
+
+#: src/system/overview.md:33
+msgid "`notificationCancel(id)`"
+msgstr ""
+
+#: src/system/overview.md:33
+msgid "Cancel a scheduled notification"
+msgstr ""
+
+#: src/system/overview.md:33 src/system/overview.md:34
+msgid "Apple"
+msgstr ""
+
+#: src/system/overview.md:34
+msgid "`notificationOnTap(cb)`"
+msgstr ""
+
+#: src/system/overview.md:34
+msgid "Handle banner taps"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "`notificationRegisterRemote(cb)` / `notificationOnReceive(cb)`"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "Push (APNs)"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "iOS, macOS"
+msgstr ""
+
+#: src/system/overview.md:36
+msgid "`audioStart()` / `audioStop()`"
+msgstr ""
+
+#: src/system/overview.md:36
+msgid "Microphone capture"
+msgstr ""
+
+#: src/system/overview.md:37
+msgid "`audioGetLevel()` / `audioGetPeak()`"
+msgstr ""
+
+#: src/system/overview.md:37
+msgid "RMS / peak amplitude (`0..1`)"
+msgstr ""
+
+#: src/system/overview.md:38
+msgid "`audioGetWaveform(n)`"
+msgstr ""
+
+#: src/system/overview.md:38
+msgid "Recent waveform samples for visualization"
+msgstr ""
+
+#: src/system/overview.md:40
+msgid ""
+"**Clipboard** lives in `perry/ui` (not `perry/system`): import "
+"`clipboardRead` and `clipboardWrite` from there."
+msgstr ""
+
+#: src/system/overview.md:45 src/system/other.md:29
+msgid ""
+"```typescript\n"
+"if (isDarkMode()) {\n"
+"    console.log(\"Dark mode is active\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:51 src/system/preferences.md:14
+msgid ""
+"```typescript\n"
+"// Strings and numbers round-trip natively — no manual stringification needed.\n"
+"preferencesSet(\"theme\", \"dark\")\n"
+"preferencesSet(\"font-size\", 14)\n"
+"\n"
+"const theme = preferencesGet(\"theme\")        // string | number | undefined\n"
+"const fontSize = preferencesGet(\"font-size\") // → 14 (number)\n"
+"\n"
+"if (typeof theme === \"string\") {\n"
+"    console.log(`saved theme: ${theme}`)\n"
+"}\n"
+"if (typeof fontSize === \"number\") {\n"
+"    console.log(`saved font-size: ${fontSize}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:67 src/system/other.md:14
+msgid ""
+"```typescript\n"
+"openURL(\"https://example.com\")\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:73
+msgid "[Preferences](preferences.md)"
+msgstr ""
+
+#: src/system/overview.md:74
+msgid "[Keychain](keychain.md)"
+msgstr ""
+
+#: src/system/overview.md:75
+msgid "[Notifications](notifications.md)"
+msgstr ""
+
+#: src/system/overview.md:76
+msgid "[Audio Capture](audio.md)"
+msgstr ""
+
+#: src/system/overview.md:77
+msgid "[Other](other.md)"
+msgstr ""
+
+#: src/system/preferences.md:3
+msgid ""
+"Store and retrieve user preferences using the platform's native storage. "
+"Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/preferences.md:10
+msgid ""
+"`preferencesSet(key, value)` accepts strings **or** numbers and round-trips "
+"them natively (NSUserDefaults / GSettings / Registry preserve the original "
+"type). `preferencesGet(key)` returns `string | number | undefined`:"
+msgstr ""
+
+#: src/system/preferences.md:30 src/system/keychain.md:21
+msgid "Platform Storage"
+msgstr ""
+
+#: src/system/preferences.md:32 src/system/keychain.md:23
+#: src/system/notifications.md:60 src/system/media.md:84
+msgid "Backend"
+msgstr ""
+
+#: src/system/preferences.md:34 src/system/preferences.md:35
+msgid "NSUserDefaults"
+msgstr ""
+
+#: src/system/preferences.md:36
+msgid "SharedPreferences"
+msgstr ""
+
+#: src/system/preferences.md:37
+msgid "Windows Registry"
+msgstr ""
+
+#: src/system/preferences.md:38
+msgid "GSettings / file-based"
+msgstr ""
+
+#: src/system/preferences.md:39
+msgid "localStorage"
+msgstr ""
+
+#: src/system/preferences.md:41
+msgid ""
+"Preferences persist across app launches. They are not encrypted — use "
+"[Keychain](keychain.md) for sensitive data."
+msgstr ""
+
+#: src/system/preferences.md:46 src/system/notifications.md:74
+msgid "[Keychain](keychain.md) — Secure storage"
+msgstr ""
+
+#: src/system/preferences.md:47 src/system/keychain.md:39
+#: src/system/notifications.md:76 src/system/audio.md:74
+#: src/system/media.md:245 src/system/other.md:70
+msgid "[Overview](overview.md) — All system APIs"
+msgstr ""
+
+#: src/system/keychain.md:3
+msgid ""
+"Securely store sensitive data like tokens, passwords, and API keys using the"
+" platform's secure storage. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/keychain.md:10
+msgid ""
+"```typescript\n"
+"keychainSave(\"api_token\", \"sk-...\")\n"
+"const token = keychainGet(\"api_token\")\n"
+"keychainDelete(\"api_token\")\n"
+"console.log(`token length: ${token.length}`)\n"
+"```"
+msgstr ""
+
+#: src/system/keychain.md:17
+msgid ""
+"The free-function API is `keychainSave(key, value)`, `keychainGet(key)` "
+"(returns the stored string, or an empty string if the key isn't present), "
+"and `keychainDelete(key)`."
+msgstr ""
+
+#: src/system/keychain.md:25 src/system/keychain.md:26
+msgid "Security.framework (Keychain)"
+msgstr ""
+
+#: src/system/keychain.md:27
+msgid "Android Keystore"
+msgstr ""
+
+#: src/system/keychain.md:28
+msgid "Windows Credential Manager (CredWrite/CredRead/CredDelete)"
+msgstr ""
+
+#: src/system/keychain.md:29
+msgid "libsecret"
+msgstr ""
+
+#: src/system/keychain.md:30
+msgid "localStorage (not truly secure)"
+msgstr ""
+
+#: src/system/keychain.md:32
+msgid ""
+"**Web**: The web platform uses `localStorage`, which is not encrypted. For "
+"web apps handling sensitive data, consider server-side storage instead."
+msgstr ""
+
+#: src/system/keychain.md:37
+msgid "[Preferences](preferences.md) — Non-sensitive preferences"
+msgstr ""
+
+#: src/system/keychain.md:38
+msgid "[Notifications](notifications.md) — Local notifications"
+msgstr ""
+
+#: src/system/notifications.md:3
+msgid ""
+"Send local notifications using the platform's notification system. Every "
+"snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/notifications.md:8
+msgid "Sending a notification"
+msgstr ""
+
+#: src/system/notifications.md:10
+msgid ""
+"```typescript\n"
+"notificationSend(\"Build complete\", \"All targets compiled in 4.2s.\")\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:14
+msgid "Reacting to a tap"
+msgstr ""
+
+#: src/system/notifications.md:16
+msgid ""
+"```typescript\n"
+"notificationOnTap((id: string, action?: string) => {\n"
+"    console.log(`tapped notification ${id}; action=${action ?? \"(default)\"}`)\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:22
+msgid ""
+"`action` is the action-button identifier when the user picks a button, or "
+"`undefined` for the default banner tap."
+msgstr ""
+
+#: src/system/notifications.md:25
+msgid "Cancelling a scheduled notification"
+msgstr ""
+
+#: src/system/notifications.md:27
+msgid ""
+"```typescript\n"
+"notificationCancel(\"daily-reminder\")\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:31
+msgid ""
+"`notificationCancel(id)` is a no-op if no scheduled notification with that "
+"id exists."
+msgstr ""
+
+#: src/system/notifications.md:34
+msgid "Push notifications (APNs / Firebase)"
+msgstr ""
+
+#: src/system/notifications.md:46
+msgid ""
+"`notificationRegisterRemote(cb)` fires once when the OS returns a device "
+"token — on Apple platforms the token is the canonical uppercase hex string "
+"APNs expects. `notificationOnReceive(cb)` runs whenever a remote payload "
+"arrives while the app is foregrounded; the payload is the APNs `aps` "
+"userInfo dictionary (or equivalent platform shape) converted to a plain "
+"object."
+msgstr ""
+
+#: src/system/notifications.md:52
+msgid ""
+"Requires the relevant platform capability (APNs entitlement on iOS/macOS, "
+"Firebase Messaging on Android — wired via JNI through "
+"`PerryFirebaseMessagingService`, see "
+"[\\#98](https://github.com/PerryTS/perry/issues/98)). No-op on platforms "
+"without a push pipeline (tvOS, visionOS, watchOS, GTK4, Windows, Web)."
+msgstr ""
+
+#: src/system/notifications.md:58
+msgid "Platform Implementation"
+msgstr ""
+
+#: src/system/notifications.md:62 src/system/notifications.md:63
+msgid "UNUserNotificationCenter"
+msgstr ""
+
+#: src/system/notifications.md:64
+msgid "NotificationManager"
+msgstr ""
+
+#: src/system/notifications.md:65
+msgid "Toast notifications"
+msgstr ""
+
+#: src/system/notifications.md:66
+msgid "GNotification"
+msgstr ""
+
+#: src/system/notifications.md:67
+msgid "Web Notification API"
+msgstr ""
+
+#: src/system/notifications.md:69
+msgid ""
+"**Permissions**: On macOS, iOS, and Web, the user may need to grant "
+"notification permissions. On first use, the system will prompt "
+"automatically."
+msgstr ""
+
+#: src/system/notifications.md:75
+msgid "[Other](other.md) — Additional system APIs"
+msgstr ""
+
+#: src/system/audio.md:3
+msgid ""
+"The `perry/system` module provides real-time audio capture from the device "
+"microphone, with A-weighted dB(A) level metering and waveform sampling — "
+"everything needed to build a sound meter, audio visualizer, or voice-level "
+"indicator. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/audio.md:10
+msgid ""
+"```typescript\n"
+"const ok = audioStart() // 1 on success, 0 on failure\n"
+"if (ok === 1) {\n"
+"    const level = audioGetLevel()           // 0..1\n"
+"    const peak = audioGetPeak()             // 0..1\n"
+"    const waveform = audioGetWaveform(64)   // sample-count\n"
+"    console.log(`level=${level} peak=${peak} waveform=${waveform}`)\n"
+"    audioStop()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/audio.md:23
+msgid "`audioStart()`"
+msgstr ""
+
+#: src/system/audio.md:25
+msgid ""
+"Start capturing audio from the device microphone. Returns `1` on success, "
+"`0` on failure (permission denied, no microphone, etc.)."
+msgstr ""
+
+#: src/system/audio.md:28
+msgid ""
+"On platforms that require permission (iOS, Android, Web), the system "
+"permission dialog is shown automatically."
+msgstr ""
+
+#: src/system/audio.md:31
+msgid "`audioStop()`"
+msgstr ""
+
+#: src/system/audio.md:33
+msgid "Stop audio capture and release the microphone."
+msgstr ""
+
+#: src/system/audio.md:35
+msgid "`audioGetLevel()`"
+msgstr ""
+
+#: src/system/audio.md:37
+msgid ""
+"Get the current A-weighted sound level (a smoothed value with a 125 ms time "
+"constant). Typical ranges:"
+msgstr ""
+
+#: src/system/audio.md:40
+msgid "~30 dB — quiet room"
+msgstr ""
+
+#: src/system/audio.md:41
+msgid "~50 dB — normal conversation"
+msgstr ""
+
+#: src/system/audio.md:42
+msgid "~70 dB — busy street"
+msgstr ""
+
+#: src/system/audio.md:43
+msgid "~90 dB — loud music"
+msgstr ""
+
+#: src/system/audio.md:44
+msgid "~110+ dB — dangerously loud"
+msgstr ""
+
+#: src/system/audio.md:46
+msgid "`audioGetPeak()`"
+msgstr ""
+
+#: src/system/audio.md:48
+msgid ""
+"Get the current peak sample amplitude (`0.0`–`1.0`). Useful for simple level"
+" indicators without dB conversion."
+msgstr ""
+
+#: src/system/audio.md:51
+msgid "`audioGetWaveform(sampleCount)`"
+msgstr ""
+
+#: src/system/audio.md:53
+msgid ""
+"Get recent waveform samples for visualization. Pass the number of samples "
+"you want; the runtime returns the most recent N readings from its internal "
+"ring buffer. Useful for drawing waveform displays or level history charts."
+msgstr ""
+
+#: src/system/audio.md:57
+msgid "Platform Implementations"
+msgstr ""
+
+#: src/system/audio.md:59
+msgid "Audio Backend"
+msgstr ""
+
+#: src/system/audio.md:59
+msgid "Permissions"
+msgstr ""
+
+#: src/system/audio.md:61
+msgid "AVAudioEngine"
+msgstr ""
+
+#: src/system/audio.md:61
+msgid "Microphone permission dialog"
+msgstr ""
+
+#: src/system/audio.md:62
+msgid "AVAudioSession + AVAudioEngine"
+msgstr ""
+
+#: src/system/audio.md:62
+msgid "System permission dialog"
+msgstr ""
+
+#: src/system/audio.md:63
+msgid "AudioRecord (JNI)"
+msgstr ""
+
+#: src/system/audio.md:63
+msgid "RECORD_AUDIO permission"
+msgstr ""
+
+#: src/system/audio.md:64
+msgid "PulseAudio (libpulse-simple)"
+msgstr ""
+
+#: src/system/audio.md:64
+msgid "None (system-level)"
+msgstr ""
+
+#: src/system/audio.md:65
+msgid "WASAPI (shared mode)"
+msgstr ""
+
+#: src/system/audio.md:65
+msgid "None"
+msgstr ""
+
+#: src/system/audio.md:66
+msgid "getUserMedia + AnalyserNode"
+msgstr ""
+
+#: src/system/audio.md:66
+msgid "Browser permission dialog"
+msgstr ""
+
+#: src/system/audio.md:68
+msgid ""
+"All platforms capture at 48 kHz mono and apply the same A-weighting filter "
+"(IEC 61672 standard, 3 cascaded biquad sections)."
+msgstr ""
+
+#: src/system/audio.md:73
+msgid "[Camera](../ui/camera.md) — Live camera preview (iOS)"
+msgstr ""
+
+#: src/system/media.md:3
+msgid ""
+"The `perry/media` module provides streaming media playback — HTTP/HTTPS "
+"audio URLs (Subsonic, Icecast, plain MP3/AAC, HLS m3u8), `file://` paths, "
+"lock-screen / Now Playing metadata, and remote-command (Siri Remote / Touch "
+"Bar / Control Center) integration."
+msgstr ""
+
+#: src/system/media.md:10
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"  createPlayer,\n"
+"  play,\n"
+"  pause,\n"
+"  setVolume,\n"
+"  onStateChange,\n"
+"  onTimeUpdate,\n"
+"  setNowPlaying,\n"
+"} from \"perry/media\";\n"
+"\n"
+"const player = createPlayer(\"https://example.com/track.mp3\");\n"
+"if (player === 0) {\n"
+"  console.error(\"createPlayer failed\");\n"
+"} else {\n"
+"  setVolume(player, 0.8);\n"
+"  setNowPlaying(player, \"Track Title\", \"Artist\", \"Album\", \"\");\n"
+"\n"
+"  onStateChange(player, (state) => console.log(\"state:\", state));\n"
+"  onTimeUpdate(player, (cur, dur) => console.log(`${cur}/${dur}s`));\n"
+"\n"
+"  play(player); // begins (or resumes) once buffered\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/media.md:35
+msgid "API surface"
+msgstr ""
+
+#: src/system/media.md:37
+msgid "Returns"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "`createPlayer(url)`"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "handle (1+) or `0` on failure"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "HTTP/HTTPS or `file://`"
+msgstr ""
+
+#: src/system/media.md:40
+msgid "`play(handle)`"
+msgstr ""
+
+#: src/system/media.md:40 src/system/media.md:41 src/system/media.md:42
+#: src/system/media.md:43 src/system/media.md:44 src/system/media.md:45
+#: src/system/media.md:50 src/system/media.md:51 src/system/media.md:52
+#: src/system/media.md:53
+msgid "void"
+msgstr ""
+
+#: src/system/media.md:40
+msgid "Resumes if paused"
+msgstr ""
+
+#: src/system/media.md:41
+msgid "`pause(handle)`"
+msgstr ""
+
+#: src/system/media.md:41
+msgid "Position preserved"
+msgstr ""
+
+#: src/system/media.md:42
+msgid "`stop(handle)`"
+msgstr ""
+
+#: src/system/media.md:42
+msgid "Resets position to 0"
+msgstr ""
+
+#: src/system/media.md:43
+msgid "`seek(handle, seconds)`"
+msgstr ""
+
+#: src/system/media.md:44
+msgid "`setVolume(handle, volume)`"
+msgstr ""
+
+#: src/system/media.md:44
+msgid "0.0–1.0, clamped"
+msgstr ""
+
+#: src/system/media.md:45
+msgid "`setRate(handle, rate)`"
+msgstr ""
+
+#: src/system/media.md:45
+msgid "1.0 = normal; Apple supports 0.5–2.0"
+msgstr ""
+
+#: src/system/media.md:46
+msgid "`getCurrentTime(handle)`"
+msgstr ""
+
+#: src/system/media.md:46 src/system/media.md:47
+msgid "seconds"
+msgstr ""
+
+#: src/system/media.md:47
+msgid "`getDuration(handle)`"
+msgstr ""
+
+#: src/system/media.md:47
+msgid "`0` if live / loading"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "`getState(handle)`"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "`MediaState`"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "See states below"
+msgstr ""
+
+#: src/system/media.md:49
+msgid "`isPlaying(handle)`"
+msgstr ""
+
+#: src/system/media.md:50
+msgid "`onStateChange(h, cb)`"
+msgstr ""
+
+#: src/system/media.md:50
+msgid "Fires on every transition"
+msgstr ""
+
+#: src/system/media.md:51
+msgid "`onTimeUpdate(h, cb)`"
+msgstr ""
+
+#: src/system/media.md:51
+msgid "~10 Hz while playing"
+msgstr ""
+
+#: src/system/media.md:52
+msgid "`setNowPlaying(h, title, artist, album, artworkUrl)`"
+msgstr ""
+
+#: src/system/media.md:52
+msgid "All strings; pass `\"\"` for unknown"
+msgstr ""
+
+#: src/system/media.md:53
+msgid "`destroy(handle)`"
+msgstr ""
+
+#: src/system/media.md:53
+msgid "Frees resources"
+msgstr ""
+
+#: src/system/media.md:55
+msgid "States"
+msgstr ""
+
+#: src/system/media.md:57
+msgid "`MediaState` is one of:"
+msgstr ""
+
+#: src/system/media.md:59
+msgid "`idle` — never started"
+msgstr ""
+
+#: src/system/media.md:60
+msgid "`loading` — buffering / fetching headers"
+msgstr ""
+
+#: src/system/media.md:61
+msgid "`ready` — first chunk decoded, ready to `play()`"
+msgstr ""
+
+#: src/system/media.md:62
+msgid "`playing` — actively rendering"
+msgstr ""
+
+#: src/system/media.md:63
+msgid "`paused` — paused (position preserved)"
+msgstr ""
+
+#: src/system/media.md:64
+msgid "`ended` — reached end of stream"
+msgstr ""
+
+#: src/system/media.md:65
+msgid "`error` — irrecoverable failure (network, codec, …)"
+msgstr ""
+
+#: src/system/media.md:67
+msgid "`ended` reliability"
+msgstr ""
+
+#: src/system/media.md:69
+msgid ""
+"`ended` is fired both from the platform's native end-of-playback signal "
+"**and** from a `currentTime ≈ duration` fallback. Per [issue #351 "
+"discussion](https://github.com/PerryTS/perry/issues/351), the native event "
+"has been historically flaky on the web / Chromecast — the same belt-and-"
+"braces is cheap to apply on every backend so a `perry/media` consumer can "
+"rely on `ended` firing once per track."
+msgstr ""
+
+#: src/system/media.md:76
+msgid ""
+"The fallback engages only after `play()` has been called and `duration` is "
+"known (live streams report `+inf`, which sanitises to `0` and disables the "
+"fallback). Window: 0.25s before duration. The native signal sets the flag "
+"first when it works; the fallback sets the same flag on the polling tick if "
+"the signal hasn't arrived."
+msgstr ""
+
+#: src/system/media.md:82
+msgid "Platform implementations"
+msgstr ""
+
+#: src/system/media.md:86
+msgid "AVPlayer + MPNowPlayingInfoCenter + MPRemoteCommandCenter"
+msgstr ""
+
+#: src/system/media.md:86 src/system/media.md:87 src/system/media.md:89
+#: src/system/media.md:90 src/system/media.md:91
+msgid "**Implemented** + lock-screen"
+msgstr ""
+
+#: src/system/media.md:87 src/system/media.md:93
+msgid "AVPlayer + AVAudioSession Playback + UIImage artwork"
+msgstr ""
+
+#: src/system/media.md:88
+msgid "AVPlayer + Siri Remote play/pause/skip"
+msgstr ""
+
+#: src/system/media.md:88
+msgid "**Implemented** + remote"
+msgstr ""
+
+#: src/system/media.md:89
+msgid "AVPlayer + UIImage artwork"
+msgstr ""
+
+#: src/system/media.md:90
+msgid "`android.media.MediaPlayer` + `MediaSessionCompat` via JNI"
+msgstr ""
+
+#: src/system/media.md:91
+msgid "GTK4 / Linux"
+msgstr ""
+
+#: src/system/media.md:91
+msgid "GStreamer `playbin` element + MPRIS D-Bus"
+msgstr ""
+
+#: src/system/media.md:92
+msgid ""
+"`Windows.Media.Playback.MediaPlayer` (WinRT) + "
+"`SystemMediaTransportControls`"
+msgstr ""
+
+#: src/system/media.md:92
+msgid "**Implemented** + Now Playing"
+msgstr ""
+
+#: src/system/media.md:93
+msgid "**Implemented** + Now Playing complication"
+msgstr ""
+
+#: src/system/media.md:94
+msgid "HarmonyOS"
+msgstr ""
+
+#: src/system/media.md:94
+msgid "`@ohos.multimedia.media.AVPlayer` via napi"
+msgstr ""
+
+#: src/system/media.md:94
+msgid ""
+"**Implemented** (lock-screen via `@ohos.multimedia.avsession` is a follow-"
+"up)"
+msgstr ""
+
+#: src/system/media.md:95
+msgid "`<audio>` element + Media Session API"
+msgstr ""
+
+#: src/system/media.md:95
+msgid ""
+"**Implemented** (`--target web`; `setNowPlaying` populates "
+"`navigator.mediaSession.metadata` + wires play / pause / seekto / "
+"seekforward / seekbackward action handlers)"
+msgstr ""
+
+#: src/system/media.md:97
+msgid ""
+"Stub platforms link cleanly against the same FFI surface — code that imports"
+" `perry/media` compiles on every target. `createPlayer` returns `0` on a "
+"stub backend so `if (player === 0)` is the canonical \"feature not available"
+" here\" check."
+msgstr ""
+
+#: src/system/media.md:102
+msgid ""
+"On Linux, `setNowPlaying` exposes the player to the desktop via MPRIS "
+"(`org.mpris.MediaPlayer2.perry-<pid>` on the session bus). GNOME Shell, KDE "
+"Plasma, `playerctl`, and any Bluetooth-headphone media-key bridge that "
+"speaks MPRIS will see the metadata and route Play / Pause / PlayPause / Stop"
+" / Seek / SetPosition back to the player. The MPRIS server is lazy-"
+"bootstrapped on the first `setNowPlaying` call so apps that don't need lock-"
+"screen integration don't pay the zbus startup cost. `Next` / `Previous` are "
+"no-ops (single-track playback model); playlists are an app-level concern."
+msgstr ""
+
+#: src/system/media.md:112
+msgid "Android — background playback"
+msgstr ""
+
+#: src/system/media.md:114
+msgid ""
+"Perry's Android backend wires `MediaSessionCompat` so the lock-screen tile, "
+"Bluetooth headset, Android Auto, and Wear OS see the metadata pushed by "
+"`setNowPlaying` and route headphone play/pause/stop/seek events back into "
+"the registered `onStateChange` closure. That covers foreground use. Apps "
+"that want playback to survive the activity being backgrounded (a podcast "
+"app, music player, etc.) need a foreground service of their own — Android "
+"will otherwise kill the audio when the process drops to the cached state. "
+"Add the following to your app's `AndroidManifest.xml` and start the service "
+"when playback begins:"
+msgstr ""
+
+#: src/system/media.md:126
+msgid "\".PerryMediaService\""
+msgstr ""
+
+#: src/system/media.md:127
+msgid "\"mediaPlayback\""
+msgstr ""
+
+#: src/system/media.md:128
+msgid "\"false\""
+msgstr ""
+
+#: src/system/media.md:129
+msgid "\"android.permission.FOREGROUND_SERVICE\""
+msgstr ""
+
+#: src/system/media.md:130
+msgid "\"android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK\""
+msgstr ""
+
+#: src/system/media.md:133
+msgid ""
+"The service implementation is app-specific — it should hold a "
+"`MediaSessionCompat.Token` (the same session Perry created), build a "
+"`Notification.MediaStyle` notification from it, and call "
+"`startForeground(...)` on `play` / `stopForeground(false)` on `pause` / "
+"`stopSelf()` on `stop`. We deliberately don't ship a default service because"
+" the notification's branding (small icon, tint, content intent) depends on "
+"the host app."
+msgstr ""
+
+#: src/system/media.md:141
+msgid "Threading notes"
+msgstr ""
+
+#: src/system/media.md:143
+msgid ""
+"The `onStateChange` and `onTimeUpdate` callbacks fire from the platform's "
+"main UI thread on every backend, so they share the same JS heap as the "
+"calling code. Implementation detail varies:"
+msgstr ""
+
+#: src/system/media.md:147
+msgid ""
+"**macOS / iOS / tvOS / visionOS** — driven by an `NSTimer` scheduled on the "
+"main run loop at 10 Hz."
+msgstr ""
+
+#: src/system/media.md:149
+msgid ""
+"**Android** — driven from `Java_com_perry_app_PerryBridge_nativePumpTick` "
+"(the existing 125 Hz UI-thread pump), throttled internally to ~10 Hz. The "
+"`prepare()` call runs on a background worker thread to avoid blocking the UI"
+" on network buffering."
+msgstr ""
+
+#: src/system/media.md:153
+msgid ""
+"**GTK4** — driven by a `glib::timeout_add_local` timer on the GLib main "
+"loop. EOS / error messages arrive on the GStreamer bus and get forwarded to "
+"per-player atomic flags via a `bus.add_watch_local` closure."
+msgstr ""
+
+#: src/system/media.md:157
+msgid ""
+"**Windows** — driven from the `GetMessageW` / `PeekMessageW` message loop "
+"after each dispatch, throttled to 100 ms by wall-clock comparison."
+msgstr ""
+
+#: src/system/media.md:159
+msgid ""
+"**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
+"directly, so `perry/media` calls record intents into Mutex-protected drain "
+"queues in `perry-runtime::media_playback`. The harvested `pages/Index.ets` "
+"(emitted by `perry-codegen-arkts` whenever the module uses `perry/media`) "
+"installs a 100 ms `setInterval` pump in `aboutToAppear` that drains the "
+"queues, dispatches each op against the matching `media.AVPlayer` instance "
+"(allocated lazily on the first `createPlayer` drain), and pushes state "
+"observations back into the runtime via the `pushMediaState(handle, state, "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / `timeUpdate`"
+" / `error` / `endOfStream` events feed the same callback path. The pump runs"
+" on the ArkTS UI thread, so closures fired by "
+"`media_playback::push_media_state` share the same arena as Perry's `main()`."
+" Lock-screen integration (`@ohos.multimedia.avsession`) is a follow-up — the"
+" runtime queues now-playing metadata via `drainNowPlaying` but the ArkTS-"
+"side AVSession dispatch is a no-op beyond a hilog line for now (tracked "
+"under issue #369)."
+msgstr ""
+
+#: src/system/media.md:177
+msgid "Now Playing on Apple platforms"
+msgstr ""
+
+#: src/system/media.md:179
+msgid ""
+"Apple's MPNowPlayingInfoCenter is a process-wide singleton — the most recent"
+" `setNowPlaying` call wins. For a single-player app (Subsonic client, "
+"podcast player) this matches user expectation. The MPRemoteCommandCenter "
+"handlers route `play` / `pause` / `togglePlayPause` events to the **first "
+"live player handle** — multi-player apps that need an explicit \"active "
+"player\" should manage that themselves."
+msgstr ""
+
+#: src/system/media.md:186
+msgid "`artworkUrl` accepts:"
+msgstr ""
+
+#: src/system/media.md:188
+msgid "`file://` paths — loaded synchronously via NSImage / UIImage"
+msgstr ""
+
+#: src/system/media.md:189
+msgid ""
+"`https://` URLs — fetched synchronously via NSData(contentsOf:) and wrapped "
+"in UIImage. The synchronous fetch is acceptable for a one-off artwork load "
+"(the MPNowPlayingInfoCenter dict is consumed synchronously when set)."
+msgstr ""
+
+#: src/system/media.md:194
+msgid "watchOS Info.plist requirements"
+msgstr ""
+
+#: src/system/media.md:196
+msgid ""
+"watchOS keeps the audio engine alive when the watch screen sleeps **only "
+"if** the app's `Info.plist` declares the `audio` background mode under "
+"`WKBackgroundModes` (the WatchKit equivalent of iOS's `UIBackgroundModes`):"
+msgstr ""
+
+#: src/system/media.md:207
+msgid ""
+"Without this entry the OS suspends the watch app a few seconds after the "
+"wrist-down gesture or screen timeout, regardless of whether AVPlayer is "
+"actively rendering. The runtime also auto-activates an `AVAudioSession` with"
+" category `Playback` on the first `createPlayer(...)` call — combined with "
+"the Info.plist entry, this is what tells watchOS the app intends to keep "
+"playing audio in the background."
+msgstr ""
+
+#: src/system/media.md:214
+msgid ""
+"The Now Playing surface on the watch face is independent from the paired "
+"iPhone's lock screen — they're separate processes with separate "
+"`MPNowPlayingInfoCenter` instances. `setNowPlaying` on watchOS targets the "
+"watch's Now Playing complication / glance screen."
+msgstr ""
+
+#: src/system/media.md:219
+msgid "Subsonic example"
+msgstr ""
+
+#: src/system/media.md:221
+msgid ""
+"```typescript,no-test\n"
+"import { createPlayer, play, setNowPlaying, onStateChange } from \"perry/media\";\n"
+"\n"
+"function streamUrl(serverUrl: string, user: string, pass: string, songId: string): string {\n"
+"  const params = new URLSearchParams({\n"
+"    u: user, p: pass, v: \"1.16.1\", c: \"PerryClient\", id: songId, format: \"mp3\",\n"
+"  });\n"
+"  return `${serverUrl}/rest/stream?${params.toString()}`;\n"
+"}\n"
+"\n"
+"const player = createPlayer(streamUrl(\"https://music.example.com\", \"alice\", \"secret\", \"12345\"));\n"
+"setNowPlaying(player, \"All These Things That I've Done\", \"The Killers\", \"Hot Fuss\",\n"
+"              \"https://music.example.com/rest/getCoverArt?id=12345&u=alice&p=secret&v=1.16.1&c=PerryClient\");\n"
+"onStateChange(player, (state) => {\n"
+"  if (state === \"ended\") {\n"
+"    // queue.next() ...\n"
+"  }\n"
+"});\n"
+"play(player);\n"
+"```"
+msgstr ""
+
+#: src/system/media.md:242
+msgid "Next steps"
+msgstr ""
+
+#: src/system/media.md:244
+msgid "[Audio Capture](audio.md) — Microphone input + dB metering"
+msgstr ""
+
+#: src/system/other.md:1
+msgid "Other System APIs"
+msgstr ""
+
+#: src/system/other.md:3
+msgid ""
+"Additional platform-level APIs. Every snippet below is excerpted from a real"
+" file CI compiles on every PR — see "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) for "
+"the perry/system pieces and "
+"[`docs/examples/ui/events/snippets.ts`](../../examples/ui/events/snippets.ts)"
+" for clipboard."
+msgstr ""
+
+#: src/system/other.md:10
+msgid "Open URL"
+msgstr ""
+
+#: src/system/other.md:12
+msgid "Open a URL in the default browser or application:"
+msgstr ""
+
+#: src/system/other.md:20
+msgid "NSWorkspace.open"
+msgstr ""
+
+#: src/system/other.md:21
+msgid "UIApplication.open"
+msgstr ""
+
+#: src/system/other.md:22
+msgid "Intent.ACTION_VIEW"
+msgstr ""
+
+#: src/system/other.md:23
+msgid "ShellExecuteW"
+msgstr ""
+
+#: src/system/other.md:24
+msgid "xdg-open"
+msgstr ""
+
+#: src/system/other.md:25
+msgid "window.open"
+msgstr ""
+
+#: src/system/other.md:27
+msgid "Dark Mode Detection"
+msgstr ""
+
+#: src/system/other.md:35
+msgid "Detection"
+msgstr ""
+
+#: src/system/other.md:37
+msgid "NSApp.effectiveAppearance"
+msgstr ""
+
+#: src/system/other.md:38
+msgid "UITraitCollection"
+msgstr ""
+
+#: src/system/other.md:39
+msgid "Configuration.uiMode"
+msgstr ""
+
+#: src/system/other.md:40
+msgid "Registry (AppsUseLightTheme)"
+msgstr ""
+
+#: src/system/other.md:41
+msgid "GTK settings"
+msgstr ""
+
+#: src/system/other.md:42
+msgid "prefers-color-scheme media query"
+msgstr ""
+
+#: src/system/other.md:46
+msgid "Clipboard helpers live in `perry/ui` (not `perry/system`):"
+msgstr ""
+
+#: src/system/other.md:57
+msgid "Device Identity"
+msgstr ""
+
+#: src/system/other.md:64
+msgid ""
+"`getDeviceIdiom()` returns the broad form factor (`\"phone\"`, `\"pad\"`, "
+"`\"mac\"`, `\"tv\"`, …); `getDeviceModel()` returns the platform-specific "
+"model identifier (`\"iPhone15,2\"`, `\"MacBookPro18,3\"`, etc.)."
+msgstr ""
+
+#: src/system/other.md:71
+msgid "[UI Overview](../ui/overview.md) — Building UIs"
+msgstr ""
+
+#: src/widgets/overview.md:1
+msgid "Widgets (WidgetKit) Overview"
+msgstr ""
+
+#: src/widgets/overview.md:3
+msgid ""
+"Perry can compile TypeScript widget declarations to native widget extensions"
+" across 4 platforms: iOS (WidgetKit), Android (App Widgets), watchOS "
+"(Complications), and Wear OS (Tiles)."
+msgstr ""
+
+#: src/widgets/overview.md:5
+msgid ""
+"**Status:** the `perry/widget` API is wired in the HIR (`crates/perry-"
+"hir/src/lower.rs:try_lower_widget_decl`) and emits via dedicated codegen "
+"crates (`perry-codegen-glance`, `perry-codegen-wear-tiles`, the WidgetKit "
+"emitter). The snippets on the widget docs pages compile-link cleanly on the "
+"host LLVM target — `Widget({...})` lowers to a no-op there — and CI verifies"
+" that via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts)."
+" What CI **cannot** do today is drive the actual cross-compile targets "
+"(`--target ios-widget`, `--target android-widget`, etc.) because each "
+"requires an `--app-bundle-id` not yet surfaced through the doc-tests harness"
+" — tracked in [\\#194](https://github.com/PerryTS/perry/issues/194). For a "
+"working end-to-end reference see "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+msgstr ""
+
+#: src/widgets/overview.md:17
+msgid "What Are Widgets?"
+msgstr ""
+
+#: src/widgets/overview.md:19
+msgid ""
+"Home screen widgets display glanceable information outside your app. Perry's"
+" `perry/widget` module lets you define widgets in TypeScript that compile to"
+" each platform's native widget system."
+msgstr ""
+
+#: src/widgets/overview.md:21
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"MyWidget\",\n"
+"    displayName: \"My Widget\",\n"
+"    description: \"Shows a greeting\",\n"
+"    entryFields: { name: \"string\" },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`Hello, ${entry.name}!`),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/overview.md:46
+msgid ""
+"The compiler generates a complete native widget extension for each platform "
+"— no platform-specific language knowledge required."
+msgstr ""
+
+#: src/widgets/overview.md:51
+msgid "# iOS WidgetKit extension\n"
+msgstr ""
+
+#: src/widgets/overview.md:52
+msgid "# Android App Widget\n"
+msgstr ""
+
+#: src/widgets/overview.md:53
+msgid "# watchOS Complication\n"
+msgstr ""
+
+#: src/widgets/overview.md:54
+msgid "# watchOS Simulator\n"
+msgstr ""
+
+#: src/widgets/overview.md:55
+msgid "# Wear OS Tile\n"
+msgstr ""
+
+#: src/widgets/overview.md:58
+msgid ""
+"Each target produces the appropriate native widget extension for that "
+"platform."
+msgstr ""
+
+#: src/widgets/overview.md:62
+msgid "[Creating Widgets](creating-widgets.md) — Widget() API in detail"
+msgstr ""
+
+#: src/widgets/overview.md:63
+msgid "[Components & Modifiers](components.md) — Available widget components"
+msgstr ""
+
+#: src/widgets/overview.md:64
+msgid "[Configuration](configuration.md) — Widget configuration options"
+msgstr ""
+
+#: src/widgets/overview.md:65
+msgid ""
+"[Data Fetching](data-fetching.md) — Timeline providers and data loading"
+msgstr ""
+
+#: src/widgets/overview.md:66
+msgid "[Cross-Platform Reference](platforms.md) — Platform-specific details"
+msgstr ""
+
+#: src/widgets/overview.md:67
+msgid "[watchOS Complications](watchos.md) — watchOS-specific guide"
+msgstr ""
+
+#: src/widgets/overview.md:68
+msgid "[Wear OS Tiles](wearos.md) — Wear OS-specific guide"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:3
+msgid "Define home screen widgets using the `Widget()` function."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:5
+msgid ""
+"**Status:** the full `Widget({...})` snippets on this page compile-link "
+"cleanly on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the API shapes are verified against the codegen. The actual cross-"
+"compile targets (`--target ios-widget`/`android-widget`/`watchos-"
+"widget`/`wearos-tile`) still aren't driven by the doc-tests harness — each "
+"requires `--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194)). For the canonical "
+"end-to-end shape see "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+" Fragments below that show partial syntax (just the `entryFields` object, "
+"just a `render:` body, etc.) are rendered as plain text — the full "
+"declarations they appear inside are covered by the verified anchors."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:18
+msgid "Widget Declaration"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:20
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"WeatherWidget\",\n"
+"    displayName: \"Weather\",\n"
+"    description: \"Shows current weather\",\n"
+"    entryFields: {\n"
+"        temperature: \"number\",\n"
+"        condition: \"string\",\n"
+"        location: \"string\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            HStack([\n"
+"                Text(entry.location),\n"
+"                Spacer(),\n"
+"                Image(\"cloud.sun.fill\"),\n"
+"            ]),\n"
+"            Text(`${entry.temperature}°`),\n"
+"            Text(entry.condition),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:43
+msgid "Widget Options"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47
+msgid "`kind`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47 src/widgets/creating-widgets.md:48
+#: src/widgets/creating-widgets.md:49 src/widgets/creating-widgets.md:54
+msgid "`string`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47
+msgid "Unique identifier for the widget"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:48
+msgid "`displayName`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:48
+msgid "Name shown in widget gallery"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:49 src/cli/perry-toml.md:119
+#: src/cli/perry-toml.md:349
+msgid "`description`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:49
+msgid "Description in widget gallery"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50
+msgid "`entryFields`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50 src/widgets/creating-widgets.md:52
+msgid "`object`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50
+msgid ""
+"Data fields with types (`\"string\"`, `\"number\"`, `\"boolean\"`, arrays, "
+"optionals, objects)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51
+msgid "`render`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51 src/widgets/creating-widgets.md:53
+msgid "`function`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51
+msgid ""
+"Render function receiving entry data, returns widget tree. Optional 2nd "
+"param for family."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:52
+msgid "`config`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:52
+msgid "Configurable parameters the user can edit (see below)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:53
+msgid "`provider`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:53
+msgid "Timeline provider function for dynamic data (see below)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:54
+msgid "`appGroup`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:54
+msgid "App group identifier for sharing data with the host app"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:56
+msgid "Entry Fields"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:58
+msgid ""
+"Entry fields define the data your widget displays. Each field has a name and"
+" type:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:60
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  title: \"string\",\n"
+"  count: \"number\",\n"
+"  isActive: \"boolean\",\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:68
+msgid "Array, Optional, and Object Fields"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:70
+msgid "Entry fields support richer types beyond primitives:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:72
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  items: [{ name: \"string\", value: \"number\" }],  // Array of objects\n"
+"  subtitle: \"string?\",                             // Optional string\n"
+"  stats: { wins: \"number\", losses: \"number\" },     // Nested object\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:80
+msgid "These compile to a Swift `TimelineEntry` struct:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:91
+msgid "Conditionals in Render"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:93
+msgid "Use ternary expressions for conditional rendering:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:95
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"ConditionalWidget\",\n"
+"    displayName: \"Conditional\",\n"
+"    description: \"Renders based on entry data\",\n"
+"    entryFields: {\n"
+"        isActive: \"boolean\",\n"
+"        count: \"number\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(entry.isActive ? \"Active\" : \"Inactive\"),\n"
+"            entry.count > 0 ? Text(`${entry.count} items`) : Spacer(),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:114
+msgid ""
+"Template literals in widget text are compiled to Swift string interpolation:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:116
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"TemplateLiteralWidget\",\n"
+"    displayName: \"Template Literal\",\n"
+"    description: \"Template literals compile to Swift string interpolation\",\n"
+"    entryFields: {\n"
+"        name: \"string\",\n"
+"        score: \"number\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        // Template literal: `${entry.name}: ${entry.score} points`\n"
+"        // Compiles to: Text(\"\\(entry.name): \\(entry.score) points\")\n"
+"        Text(`${entry.name}: ${entry.score} points`),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:132
+msgid "Configuration Parameters"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:134
+msgid ""
+"The `config` field defines user-editable parameters that appear in the "
+"widget's edit UI:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:136
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"CityWeather\",\n"
+"    displayName: \"City Weather\",\n"
+"    description: \"Weather for a chosen city\",\n"
+"    config: {\n"
+"        city: { type: \"string\", displayName: \"City\", default: \"New York\" },\n"
+"        units: {\n"
+"            type: \"enum\",\n"
+"            displayName: \"Units\",\n"
+"            values: [\"Celsius\", \"Fahrenheit\"],\n"
+"            default: \"Celsius\",\n"
+"        },\n"
+"    },\n"
+"    entryFields: { temperature: \"number\", condition: \"string\" },\n"
+"    render: (entry) => Text(`${entry.temperature}° ${entry.condition}`),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:155
+msgid "Provider Function"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:157
+msgid ""
+"The `provider` field defines a timeline provider that fetches data for the "
+"widget:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:159
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StockWidget\",\n"
+"    displayName: \"Stock Price\",\n"
+"    description: \"Shows current stock price\",\n"
+"    config: {\n"
+"        symbol: { type: \"string\", displayName: \"Symbol\", default: \"AAPL\" },\n"
+"    },\n"
+"    entryFields: { price: \"number\", change: \"string\" },\n"
+"    provider: async (config) => {\n"
+"        const res = await fetch(`https://api.example.com/stock/${config.symbol}`)\n"
+"        const data = await res.json()\n"
+"        return { price: data.price, change: data.change }\n"
+"    },\n"
+"    // Inline-options form — the chain form `.font(\"title\")` parses but is\n"
+"    // dropped at HIR-lowering time (#195).\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`$${entry.price}`, { font: \"title\" }),\n"
+"            Text(entry.change, { color: \"green\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:183
+msgid ""
+"Note: the chain-style modifiers (`.font(\"title\").color(\"green\")`) parse "
+"but are dropped at HIR-lowering time — see "
+"[\\#195](https://github.com/PerryTS/perry/issues/195). The verified extract "
+"above uses the inline-options form `Text(\"...\", { font: \"title\" })`, "
+"which is what actually round-trips through the widget codegen."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:189
+msgid "Placeholder Data"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:191
+msgid ""
+"When the widget has no data yet (e.g., first load), the provider can return "
+"placeholder data by providing a `placeholder` field:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:193
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"NewsWidget\",\n"
+"  entryFields: { headline: \"string\", source: \"string\" },\n"
+"  placeholder: { headline: \"Loading...\", source: \"---\" },\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:202
+msgid "Family-Specific Rendering"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:204
+msgid ""
+"The render function accepts an optional second parameter for the widget "
+"family, allowing different layouts per size:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:206
+msgid ""
+"```text\n"
+"render: (entry, family) =>\n"
+"  family === \"systemLarge\"\n"
+"    ? VStack([\n"
+"        Text(entry.title).font(\"title\"),\n"
+"        ForEach(entry.items, (item) => Text(item.name)),\n"
+"      ])\n"
+"    : HStack([\n"
+"        Image(\"star.fill\"),\n"
+"        Text(entry.title).font(\"headline\"),\n"
+"      ]),\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:219
+msgid ""
+"Supported families: `\"systemSmall\"`, `\"systemMedium\"`, "
+"`\"systemLarge\"`, `\"accessoryCircular\"`, `\"accessoryRectangular\"`, "
+"`\"accessoryInline\"`."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:221
+msgid "App Group"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:223
+msgid ""
+"The `appGroup` field specifies a shared container for data exchange between "
+"the host app and the widget:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:225
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"AppDataWidget\",\n"
+"  appGroup: \"group.com.example.myapp\",\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:233
+msgid "Multiple Widgets"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:235
+msgid ""
+"Define multiple widgets in a single file. They're bundled into a "
+"`WidgetBundle`:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:237
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"SmallWidget\",\n"
+"  // ...\n"
+"});\n"
+"\n"
+"Widget({\n"
+"  kind: \"LargeWidget\",\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:251
+msgid ""
+"[Components](components.md) — Available widget components and modifiers"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:252 src/widgets/components.md:273
+msgid "[Overview](overview.md) — Widget system overview"
+msgstr ""
+
+#: src/widgets/components.md:1
+msgid "Widget Components & Modifiers"
+msgstr ""
+
+#: src/widgets/components.md:3
+msgid "Available components and modifiers for widgets."
+msgstr ""
+
+#: src/widgets/components.md:5
+msgid ""
+"**Status:** this page mixes (a) tiny fragments showing component shape — "
+"rendered as plain `text` because they're not standalone declarations and "
+"can't compile — and (b) one full verified Widget at the bottom that compile-"
+"links via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts)."
+" The doc-tests harness can't drive `--target ios-widget`/`android-widget`/ "
+"`watchos-widget`/`wearos-tile` directly (each needs `--app-bundle-id` and a "
+"platform SDK — [\\#194](https://github.com/PerryTS/perry/issues/194)). Note "
+"also that the modifier parser in `crates/perry-hir/src/lower.rs` "
+"(`parse_modifiers_from_args` / `parse_single_modifier`) only reads modifiers"
+" from **inline option-object arguments** — e.g. `Text(\"hi\", { font: "
+"\"title\", color: \"red\" })` and `VStack([...], { padding: 16 })`. Method-"
+"style chains like `Text(\"hi\").font(\"title\")` shown below parse without "
+"error but **drop the modifier** at HIR-lowering time "
+"([\\#195](https://github.com/PerryTS/perry/issues/195)). The chain form is "
+"documented here because it reads naturally; the verified Complete Example at"
+" the bottom of the page uses the inline-options form that actually round-"
+"trips through the widget codegen path. The end-to-end reference is "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+msgstr ""
+
+#: src/widgets/components.md:27
+msgid ""
+"```text\n"
+"Text(\"Hello, World!\")\n"
+"Text(`${entry.name}: ${entry.value}`)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:32
+msgid "Text Modifiers"
+msgstr ""
+
+#: src/widgets/components.md:34
+msgid ""
+"```text\n"
+"const t = Text(\"Styled\");\n"
+"t.font(\"title\");       // .title, .headline, .body, .caption, etc.\n"
+"t.color(\"blue\");       // Named color or hex\n"
+"t.bold();\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:45
+msgid ""
+"```text\n"
+"VStack([\n"
+"  Text(\"Top\"),\n"
+"  Text(\"Bottom\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:54 src/widgets/components.md:75
+msgid ""
+"```text\n"
+"HStack([\n"
+"  Text(\"Left\"),\n"
+"  Spacer(),\n"
+"  Text(\"Right\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:64
+msgid ""
+"```text\n"
+"ZStack([\n"
+"  Image(\"background\"),\n"
+"  Text(\"Overlay\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:73
+msgid "Flexible space that expands to fill available room:"
+msgstr ""
+
+#: src/widgets/components.md:85
+msgid "Display SF Symbols or asset images:"
+msgstr ""
+
+#: src/widgets/components.md:87
+msgid ""
+"```text\n"
+"Image(\"star.fill\")           // SF Symbol\n"
+"Image(\"cloud.sun.rain.fill\") // SF Symbol\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:94
+msgid "Iterate over array entry fields to render a list of components:"
+msgstr ""
+
+#: src/widgets/components.md:108
+msgid "A visual separator line:"
+msgstr ""
+
+#: src/widgets/components.md:110
+msgid ""
+"```text\n"
+"VStack([\n"
+"  Text(\"Above\"),\n"
+"  Divider(),\n"
+"  Text(\"Below\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:118 src/widgets/platforms.md:28
+msgid "Label"
+msgstr ""
+
+#: src/widgets/components.md:120
+msgid "A label with text and an SF Symbol icon:"
+msgstr ""
+
+#: src/widgets/components.md:122
+msgid ""
+"```text\n"
+"Label(\"Downloads\", \"arrow.down.circle\")\n"
+"Label(`${entry.count} items`, \"folder.fill\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:127 src/widgets/platforms.md:29
+msgid "Gauge"
+msgstr ""
+
+#: src/widgets/components.md:129
+msgid "A circular or linear progress indicator:"
+msgstr ""
+
+#: src/widgets/components.md:131
+msgid ""
+"```text\n"
+"Gauge(entry.progress, 0, 100)       // value, min, max\n"
+"Gauge(entry.battery, 0, 1.0)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:138
+msgid ""
+"Widget components support SwiftUI-style modifiers. The chain forms shown "
+"below parse but drop their modifiers at HIR-lowering time "
+"([\\#195](https://github.com/PerryTS/perry/issues/195)) — use the inline "
+"option-object form (`Text(\"hi\", { font: \"title\" })`, `VStack([...], { "
+"padding: 16 })`) for the form that actually reaches the codegen, as in the "
+"[Complete Example](#complete-example) at the bottom of this page."
+msgstr ""
+
+#: src/widgets/components.md:146
+msgid "Font"
+msgstr ""
+
+#: src/widgets/components.md:148
+msgid ""
+"```text\n"
+"Text(\"Title\").font(\"title\")\n"
+"Text(\"Body\").font(\"body\")\n"
+"Text(\"Caption\").font(\"caption\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:154
+msgid "Color"
+msgstr ""
+
+#: src/widgets/components.md:156
+msgid ""
+"```text\n"
+"Text(\"Red text\").color(\"red\")\n"
+"Text(\"Custom\").color(\"#FF6600\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:161
+msgid "Padding"
+msgstr ""
+
+#: src/widgets/components.md:167
+msgid "Frame"
+msgstr ""
+
+#: src/widgets/components.md:173
+msgid "Max Width"
+msgstr ""
+
+#: src/widgets/components.md:175
+msgid ""
+"```text\n"
+"widget.maxWidth(\"infinity\")   // Expand to fill available width\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:179
+msgid "Minimum Scale Factor"
+msgstr ""
+
+#: src/widgets/components.md:181
+msgid "Allow text to shrink to fit:"
+msgstr ""
+
+#: src/widgets/components.md:183
+msgid ""
+"```text\n"
+"Text(\"Long text\").minimumScaleFactor(0.5)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:187
+msgid "Container Background"
+msgstr ""
+
+#: src/widgets/components.md:189
+msgid "Set background color for the widget container:"
+msgstr ""
+
+#: src/widgets/components.md:191
+msgid ""
+"```text\n"
+"VStack([...]).containerBackground(\"blue\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:195
+msgid "Widget URL"
+msgstr ""
+
+#: src/widgets/components.md:197
+msgid "Make the widget tappable with a deep link:"
+msgstr ""
+
+#: src/widgets/components.md:199
+msgid ""
+"```text\n"
+"VStack([...]).url(\"myapp://detail/123\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:203
+msgid "Edge-Specific Padding"
+msgstr ""
+
+#: src/widgets/components.md:205
+msgid "Apply padding to specific edges:"
+msgstr ""
+
+#: src/widgets/components.md:207
+msgid ""
+"```text\n"
+"VStack([...]).paddingEdge(\"top\", 8)\n"
+"VStack([...]).paddingEdge(\"horizontal\", 16)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:212
+msgid "Conditionals"
+msgstr ""
+
+#: src/widgets/components.md:214
+msgid "Render different components based on entry data:"
+msgstr ""
+
+#: src/widgets/components.md:216
+msgid ""
+"```text\n"
+"render: (entry) =>\n"
+"  VStack([\n"
+"    entry.isOnline\n"
+"      ? Text(\"Online\").color(\"green\")\n"
+"      : Text(\"Offline\").color(\"red\"),\n"
+"  ]),\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:227
+msgid ""
+"The full Widget below is the verified extract — it compile-links on the host"
+" LLVM target and uses the inline-options modifier form that round-trips "
+"through the codegen."
+msgstr ""
+
+#: src/widgets/components.md:231
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StatsWidget\",\n"
+"    displayName: \"Stats\",\n"
+"    description: \"Shows daily stats\",\n"
+"    entryFields: {\n"
+"        steps: \"number\",\n"
+"        calories: \"number\",\n"
+"        distance: \"string\",\n"
+"    },\n"
+"    // Inline-options modifier form — the `.font(\"title\").bold()` chain form\n"
+"    // parses but its modifiers don't reach the codegen (#195).\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            HStack([\n"
+"                Image(\"figure.walk\"),\n"
+"                Text(\"Daily Stats\", { font: \"headline\" }),\n"
+"            ]),\n"
+"            Spacer(),\n"
+"            HStack([\n"
+"                VStack([\n"
+"                    Text(`${entry.steps}`, { font: \"title\", fontWeight: \"bold\" }),\n"
+"                    Text(\"steps\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"                Spacer(),\n"
+"                VStack([\n"
+"                    Text(`${entry.calories}`, { font: \"title\", fontWeight: \"bold\" }),\n"
+"                    Text(\"cal\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"                Spacer(),\n"
+"                VStack([\n"
+"                    Text(entry.distance, { font: \"title\", fontWeight: \"bold\" }),\n"
+"                    Text(\"km\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"            ]),\n"
+"        ], { padding: 16 }),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:272
+msgid "[Creating Widgets](creating-widgets.md) — Widget() API"
+msgstr ""
+
+#: src/widgets/configuration.md:1
+msgid "Widget Configuration"
+msgstr ""
+
+#: src/widgets/configuration.md:3
+msgid ""
+"Perry widgets support user-configurable parameters. On iOS/watchOS, these "
+"compile to AppIntent configurations (the \"Edit Widget\" sheet). On "
+"Android/Wear OS, they compile to a Configuration Activity."
+msgstr ""
+
+#: src/widgets/configuration.md:5
+msgid ""
+"**Status:** the full `TopSitesWidget` declaration below compile-links "
+"cleanly on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `config: { ... }` shape is verified against `parse_config_params` in"
+" `crates/perry-hir/src/lower.rs`. The shorter fragments lower on the page "
+"(just a `provider:` body, just a `config:` object) are rendered as plain "
+"text — they're not standalone declarations. The cross-compile targets "
+"themselves (`--target ios-widget`/ `android-widget`/`watchos-"
+"widget`/`wearos-tile`) still aren't driven by the doc-tests harness — each "
+"needs `--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194))."
+msgstr ""
+
+#: src/widgets/configuration.md:17
+msgid "Defining Config Fields"
+msgstr ""
+
+#: src/widgets/configuration.md:19
+msgid ""
+"Add a `config` object to your `Widget()` declaration. Each field specifies a"
+" type, allowed values, a default, and a display title."
+msgstr ""
+
+#: src/widgets/configuration.md:21
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"TopSitesWidget\",\n"
+"    displayName: \"Top Sites\",\n"
+"    description: \"Your top performing sites\",\n"
+"    supportedFamilies: [\"systemSmall\", \"systemMedium\"],\n"
+"    appGroup: \"group.com.example.shared\",\n"
+"\n"
+"    config: {\n"
+"        sortBy: {\n"
+"            type: \"enum\",\n"
+"            values: [\"clicks\", \"impressions\", \"ctr\", \"position\"],\n"
+"            default: \"clicks\",\n"
+"            title: \"Sort By\",\n"
+"        },\n"
+"        dateRange: {\n"
+"            type: \"enum\",\n"
+"            values: [\"7d\", \"28d\", \"90d\"],\n"
+"            default: \"7d\",\n"
+"            title: \"Date Range\",\n"
+"        },\n"
+"    },\n"
+"\n"
+"    entryFields: {\n"
+"        total: \"number\",\n"
+"        label: \"string\",\n"
+"    },\n"
+"\n"
+"    provider: async (config: { sortBy: string; dateRange: string }) => {\n"
+"        const res = await fetch(\n"
+"            `https://api.example.com/stats?sort=${config.sortBy}&range=${config.dateRange}`,\n"
+"        )\n"
+"        const data = await res.json()\n"
+"        return {\n"
+"            entries: [{ total: data.total, label: data.label }],\n"
+"            reloadPolicy: { after: { minutes: 30 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`${entry.total}`, { font: \"title\", fontWeight: \"bold\" }),\n"
+"            Text(entry.label, { font: \"caption\", color: \"secondary\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:68
+msgid "Supported Parameter Types"
+msgstr ""
+
+#: src/widgets/configuration.md:70
+msgid "TypeScript"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "Enum"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "`{ type: \"enum\", values: [...], default: \"...\", title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "Picker with fixed choices"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "Boolean"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "`{ type: \"bool\", default: true, title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "Toggle switch"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "String"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "`{ type: \"string\", default: \"...\", title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "Free-text input"
+msgstr ""
+
+#: src/widgets/configuration.md:76
+msgid "Accessing Config in the Provider"
+msgstr ""
+
+#: src/widgets/configuration.md:78
+msgid ""
+"The `provider` function receives the current config values as its argument. "
+"The config object keys match the field names you defined:"
+msgstr ""
+
+#: src/widgets/configuration.md:80
+msgid ""
+"```text\n"
+"provider: async (config: { sortBy: string; dateRange: string }) => {\n"
+"  // config.sortBy === \"clicks\" | \"impressions\" | \"ctr\" | \"position\"\n"
+"  // config.dateRange === \"7d\" | \"28d\" | \"90d\"\n"
+"  const url = `https://api.example.com/data?sort=${config.sortBy}`;\n"
+"  const res = await fetch(url);\n"
+"  const data = await res.json();\n"
+"  return { entries: [data] };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:91
+msgid ""
+"When the user changes a config value, the system calls your provider again "
+"with the updated config."
+msgstr ""
+
+#: src/widgets/configuration.md:93
+msgid "Boolean Config Example"
+msgstr ""
+
+#: src/widgets/configuration.md:95
+msgid ""
+"```text\n"
+"config: {\n"
+"  showDetails: {\n"
+"    type: \"bool\",\n"
+"    default: true,\n"
+"    title: \"Show Details\",\n"
+"  },\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:105
+msgid "Platform Mapping"
+msgstr ""
+
+#: src/widgets/configuration.md:107
+msgid "iOS / watchOS (AppIntent)"
+msgstr ""
+
+#: src/widgets/configuration.md:109
+msgid ""
+"Perry generates a Swift `WidgetConfigurationIntent` struct with `@Parameter`"
+" properties and `AppEnum` types for each enum field. The widget uses "
+"`AppIntentConfiguration` instead of `StaticConfiguration`."
+msgstr ""
+
+#: src/widgets/configuration.md:111
+msgid "Generated output (auto-generated, not hand-written):"
+msgstr ""
+
+#: src/widgets/configuration.md:112
+msgid ""
+"`{Name}Intent.swift` -- contains the AppEnum cases and the intent struct"
+msgstr ""
+
+#: src/widgets/configuration.md:113
+msgid ""
+"The provider conforms to `AppIntentTimelineProvider` instead of "
+"`TimelineProvider`"
+msgstr ""
+
+#: src/widgets/configuration.md:114
+msgid ""
+"Config values are serialized to JSON and passed to the native provider "
+"function"
+msgstr ""
+
+#: src/widgets/configuration.md:116
+msgid ""
+"Users configure the widget by long-pressing and selecting \"Edit Widget\", "
+"which presents the system-generated AppIntent UI."
+msgstr ""
+
+#: src/widgets/configuration.md:118
+msgid "Android / Wear OS (Configuration Activity)"
+msgstr ""
+
+#: src/widgets/configuration.md:120
+msgid ""
+"Perry generates a `{Name}ConfigActivity.kt` with Spinner controls for enum "
+"fields and Switch controls for boolean fields. Values are persisted in "
+"SharedPreferences keyed by widget ID."
+msgstr ""
+
+#: src/widgets/configuration.md:122
+msgid "Generated output:"
+msgstr ""
+
+#: src/widgets/configuration.md:123
+msgid ""
+"`{Name}ConfigActivity.kt` -- Activity with UI controls and a Save button"
+msgstr ""
+
+#: src/widgets/configuration.md:124
+msgid ""
+"`widget_info_{name}.xml` -- includes `android:configure` pointing to the "
+"config activity"
+msgstr ""
+
+#: src/widgets/configuration.md:125
+msgid ""
+"AndroidManifest snippet includes an `<activity>` entry with "
+"`APPWIDGET_CONFIGURE` intent filter"
+msgstr ""
+
+#: src/widgets/configuration.md:127
+msgid ""
+"The config activity launches automatically when the user first adds the "
+"widget."
+msgstr ""
+
+#: src/widgets/configuration.md:129
+msgid "Build Commands"
+msgstr ""
+
+#: src/widgets/configuration.md:132
+msgid "# iOS\n"
+msgstr ""
+
+#: src/widgets/configuration.md:134
+msgid "# Android\n"
+msgstr ""
+
+#: src/widgets/configuration.md:141
+msgid ""
+"[Data Fetching](data-fetching.md) -- Provider function and shared storage"
+msgstr ""
+
+#: src/widgets/configuration.md:142
+msgid "[Components](components.md) -- Available widget components"
+msgstr ""
+
+#: src/widgets/configuration.md:143
+msgid ""
+"[Cross-Platform Reference](platforms.md) -- Feature matrix and build targets"
+msgstr ""
+
+#: src/widgets/data-fetching.md:1
+msgid "Provider Function and Data Fetching"
+msgstr ""
+
+#: src/widgets/data-fetching.md:3
+msgid ""
+"The `provider` function is the heart of a dynamic widget. It fetches data, "
+"transforms it, and returns timeline entries that the system renders on "
+"schedule."
+msgstr ""
+
+#: src/widgets/data-fetching.md:5
+msgid ""
+"**Status:** the basic `WeatherWidget` provider below compile-links cleanly "
+"on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `provider`/`reloadPolicy`/`entryFields` shapes are verified against "
+"the codegen. The shorter fragments lower on the page (a bare "
+"`reloadPolicy:`, a `provider:` body without surrounding `Widget({...})`, "
+"etc.) are rendered as plain text. The `sharedStorage()` and "
+"`preferencesSet()` examples are also rendered as plain text — those symbols "
+"are provided by the platform-specific glue (`AppGroupBridge.swift`, "
+"`Bridge.kt`) for `--target ios-widget`/`android-widget`/`watchos-widget`/ "
+"`wearos-tile` and don't link on the host LLVM target. The cross-compile "
+"targets themselves still aren't driven by the doc-tests harness — each needs"
+" `--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194))."
+msgstr ""
+
+#: src/widgets/data-fetching.md:20
+msgid "Provider Lifecycle"
+msgstr ""
+
+#: src/widgets/data-fetching.md:22
+msgid ""
+"The system calls your provider when the widget is first added, when a "
+"snapshot is needed, and when the reload policy expires."
+msgstr ""
+
+#: src/widgets/data-fetching.md:23
+msgid ""
+"Your provider runs as native LLVM-compiled code linked into the widget "
+"extension."
+msgstr ""
+
+#: src/widgets/data-fetching.md:24
+msgid ""
+"The provider returns one or more timeline entries. The system renders each "
+"entry at its scheduled time."
+msgstr ""
+
+#: src/widgets/data-fetching.md:25
+msgid ""
+"After the last entry, the reload policy determines when the provider runs "
+"again."
+msgstr ""
+
+#: src/widgets/data-fetching.md:27
+msgid "Basic Provider"
+msgstr ""
+
+#: src/widgets/data-fetching.md:29
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"WeatherProviderWidget\",\n"
+"    displayName: \"Weather\",\n"
+"    description: \"Current conditions\",\n"
+"    supportedFamilies: [\"systemSmall\"],\n"
+"\n"
+"    entryFields: {\n"
+"        temperature: \"number\",\n"
+"        condition: \"string\",\n"
+"    },\n"
+"\n"
+"    provider: async () => {\n"
+"        const res = await fetch(\"https://api.weather.example.com/current\")\n"
+"        const data = await res.json()\n"
+"        return {\n"
+"            entries: [\n"
+"                { temperature: data.temp, condition: data.description },\n"
+"            ],\n"
+"            reloadPolicy: { after: { minutes: 15 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`${entry.temperature}°`, { font: \"title\" }),\n"
+"            Text(entry.condition, { font: \"caption\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:60
+msgid "Authenticated Requests with Shared Storage"
+msgstr ""
+
+#: src/widgets/data-fetching.md:62
+msgid ""
+"Widgets run in a separate process and cannot access your app's memory. Use "
+"`sharedStorage()` to read values that your app has written to a shared "
+"container."
+msgstr ""
+
+#: src/widgets/data-fetching.md:64
+msgid "iOS / watchOS: App Groups"
+msgstr ""
+
+#: src/widgets/data-fetching.md:66
+msgid ""
+"On Apple platforms, shared storage maps to `UserDefaults(suiteName:)` backed"
+" by an App Group container. Set the `appGroup` field in your widget "
+"declaration:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:68
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"DashboardWidget\",\n"
+"  displayName: \"Dashboard\",\n"
+"  description: \"Account summary\",\n"
+"  appGroup: \"group.com.example.shared\",\n"
+"\n"
+"  entryFields: {\n"
+"    revenue: \"number\",\n"
+"    users: \"number\",\n"
+"  },\n"
+"\n"
+"  provider: async () => {\n"
+"    const token = sharedStorage(\"auth_token\");\n"
+"    const res = await fetch(\"https://api.example.com/dashboard\", {\n"
+"      headers: { Authorization: `Bearer ${token}` },\n"
+"    });\n"
+"    const data = await res.json();\n"
+"    return {\n"
+"      entries: [{ revenue: data.revenue, users: data.activeUsers }],\n"
+"      reloadPolicy: { after: { minutes: 30 } },\n"
+"    };\n"
+"  },\n"
+"\n"
+"  render: (entry) =>\n"
+"    VStack([\n"
+"      Text(`$${entry.revenue}`, { font: \"title\" }),\n"
+"      Text(`${entry.users} active users`, { font: \"caption\" }),\n"
+"    ]),\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:100
+msgid "Your main app writes the token to the shared container:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:102
+msgid ""
+"```text\n"
+"import { preferencesSet } from \"perry/system\";\n"
+"// In your app's login flow:\n"
+"preferencesSet(\"auth_token\", token);\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:108
+msgid ""
+"**Setup requirement (iOS):** Add an App Group capability in Xcode to both "
+"the main app target and the widget extension target. The identifier must "
+"match the `appGroup` value."
+msgstr ""
+
+#: src/widgets/data-fetching.md:110
+msgid "Android / Wear OS: SharedPreferences"
+msgstr ""
+
+#: src/widgets/data-fetching.md:112
+msgid ""
+"On Android, shared storage maps to `SharedPreferences` with the name "
+"`perry_shared`. The generated `Bridge.kt` reads values via "
+"`context.getSharedPreferences(\"perry_shared\", MODE_PRIVATE)`."
+msgstr ""
+
+#: src/widgets/data-fetching.md:114
+msgid "Reload Policies"
+msgstr ""
+
+#: src/widgets/data-fetching.md:116
+msgid ""
+"The `reloadPolicy` field controls when the system next calls your provider:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:127
+msgid "`{ after: { minutes: N } }`"
+msgstr ""
+
+#: src/widgets/data-fetching.md:127
+msgid ""
+"Re-fetch after N minutes. Compiles to "
+"`.after(Date().addingTimeInterval(N*60))` on iOS and "
+"`setFreshnessIntervalMillis(N*60000)` on Wear OS."
+msgstr ""
+
+#: src/widgets/data-fetching.md:128
+msgid "_(omitted)_"
+msgstr ""
+
+#: src/widgets/data-fetching.md:128
+msgid "Defaults to 30 minutes on iOS, 30 minutes on Android/Wear OS."
+msgstr ""
+
+#: src/widgets/data-fetching.md:130
+msgid ""
+"**Budget limits:** iOS restricts widget refreshes. Typical budget is 40--70 "
+"refreshes per day. watchOS is stricter (see [watchOS "
+"Complications](watchos.md)). Request only what you need."
+msgstr ""
+
+#: src/widgets/data-fetching.md:132
+msgid "JSON Response Handling"
+msgstr ""
+
+#: src/widgets/data-fetching.md:134
+msgid ""
+"The provider function receives the parsed JSON directly. Entry field types "
+"must match your `entryFields` declaration:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:136
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  items: { type: \"array\", items: { type: \"object\", fields: { name: \"string\", count: \"number\" } } },\n"
+"  total: \"number\",\n"
+"},\n"
+"\n"
+"provider: async () => {\n"
+"  const res = await fetch(\"https://api.example.com/items\");\n"
+"  const data = await res.json();\n"
+"  return {\n"
+"    entries: [{\n"
+"      items: data.results.map((r: any) => ({ name: r.name, count: r.count })),\n"
+"      total: data.total,\n"
+"    }],\n"
+"  };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:156
+msgid ""
+"If the fetch fails or JSON parsing throws, the widget extension falls back "
+"to the placeholder data:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:158
+msgid ""
+"```text\n"
+"Widget({\n"
+"  // ...\n"
+"  placeholder: { temperature: 0, condition: \"Loading...\" },\n"
+"\n"
+"  provider: async () => {\n"
+"    const res = await fetch(\"https://api.example.com/weather\");\n"
+"    if (!res.ok) {\n"
+"      // Return stale/fallback data with a short retry interval\n"
+"      return {\n"
+"        entries: [{ temperature: 0, condition: \"Unavailable\" }],\n"
+"        reloadPolicy: { after: { minutes: 5 } },\n"
+"      };\n"
+"    }\n"
+"    const data = await res.json();\n"
+"    return {\n"
+"      entries: [{ temperature: data.temp, condition: data.desc }],\n"
+"      reloadPolicy: { after: { minutes: 15 } },\n"
+"    };\n"
+"  },\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:181
+msgid ""
+"The `placeholder` field provides data shown in the widget gallery and during"
+" loading. If the provider throws an unhandled exception, the generated "
+"Swift/Kotlin code catches it and renders the placeholder instead."
+msgstr ""
+
+#: src/widgets/data-fetching.md:183
+msgid "Multiple Timeline Entries"
+msgstr ""
+
+#: src/widgets/data-fetching.md:185
+msgid ""
+"Return multiple entries to schedule future content without re-fetching:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:187
+msgid ""
+"```text\n"
+"provider: async () => {\n"
+"  const res = await fetch(\"https://api.example.com/hourly\");\n"
+"  const hours = await res.json();\n"
+"  return {\n"
+"    entries: hours.map((h: any) => ({\n"
+"      temperature: h.temp,\n"
+"      condition: h.condition,\n"
+"    })),\n"
+"    reloadPolicy: { after: { minutes: 60 } },\n"
+"  };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:201
+msgid ""
+"Each entry is rendered at the corresponding date in the timeline. The system"
+" transitions between entries automatically."
+msgstr ""
+
+#: src/widgets/data-fetching.md:205
+msgid "[Configuration](configuration.md) -- User-configurable parameters"
+msgstr ""
+
+#: src/widgets/data-fetching.md:206
+msgid ""
+"[Cross-Platform Reference](platforms.md) -- Build targets and platform "
+"differences"
+msgstr ""
+
+#: src/widgets/platforms.md:3
+msgid ""
+"Perry widgets compile from a single TypeScript source to four platforms. The"
+" same `Widget({...})` declaration produces native code for each target."
+msgstr ""
+
+#: src/widgets/platforms.md:5
+msgid ""
+"**Status:** this page has no TypeScript fences (only target-flag tables and "
+"shell build commands), so the doc-tests harness has nothing to run here. The"
+" `--target` flags listed below are all wired in "
+"`crates/perry/src/commands/compile.rs`, but the harness still can't exercise"
+" them end-to-end — each requires `--app-bundle-id` and a platform SDK "
+"(Xcode, Android NDK)."
+msgstr ""
+
+#: src/widgets/platforms.md:7
+msgid "Target Flags"
+msgstr ""
+
+#: src/widgets/platforms.md:11
+msgid "`--target ios-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:11
+msgid "SwiftUI `.swift` + Info.plist"
+msgstr ""
+
+#: src/widgets/platforms.md:12 src/plugins/native-extensions.md:274
+#: src/testing/geisterhand.md:341 src/cli/flags.md:23
+msgid "iOS Simulator"
+msgstr ""
+
+#: src/widgets/platforms.md:12
+msgid "`--target ios-widget-simulator`"
+msgstr ""
+
+#: src/widgets/platforms.md:12 src/widgets/platforms.md:15
+msgid "Same, simulator SDK"
+msgstr ""
+
+#: src/widgets/platforms.md:13
+msgid "`--target android-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:13
+msgid "Kotlin/Glance `.kt` + widget_info XML"
+msgstr ""
+
+#: src/widgets/platforms.md:14
+msgid "`--target watchos-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:14
+msgid "SwiftUI `.swift` (accessory families)"
+msgstr ""
+
+#: src/widgets/platforms.md:15
+msgid "watchOS Simulator"
+msgstr ""
+
+#: src/widgets/platforms.md:15
+msgid "`--target watchos-widget-simulator`"
+msgstr ""
+
+#: src/widgets/platforms.md:16 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:55 src/widgets/platforms.md:87
+msgid "Wear OS"
+msgstr ""
+
+#: src/widgets/platforms.md:16
+msgid "`--target wearos-tile`"
+msgstr ""
+
+#: src/widgets/platforms.md:16
+msgid "Kotlin Tiles `.kt` + manifest"
+msgstr ""
+
+#: src/widgets/platforms.md:18
+msgid "Feature Matrix"
+msgstr ""
+
+#: src/widgets/platforms.md:23
+msgid "VStack/HStack/ZStack"
+msgstr ""
+
+#: src/widgets/platforms.md:23
+msgid "Column/Row/Box"
+msgstr ""
+
+#: src/widgets/platforms.md:24
+msgid "Image (SF Symbols)"
+msgstr ""
+
+#: src/widgets/platforms.md:24
+msgid "R.drawable"
+msgstr ""
+
+#: src/widgets/platforms.md:26
+msgid "Spacer+bg"
+msgstr ""
+
+#: src/widgets/platforms.md:27
+msgid "forEach"
+msgstr ""
+
+#: src/widgets/platforms.md:28
+msgid "Row compound"
+msgstr ""
+
+#: src/widgets/platforms.md:28 src/widgets/platforms.md:29
+#: src/widgets/wearos.md:30
+msgid "Text fallback"
+msgstr ""
+
+#: src/widgets/platforms.md:29 src/widgets/platforms.md:35
+msgid "N/A"
+msgstr ""
+
+#: src/widgets/platforms.md:29
+msgid "CircularProgressIndicator"
+msgstr ""
+
+#: src/widgets/platforms.md:30
+msgid "Conditional"
+msgstr ""
+
+#: src/widgets/platforms.md:30
+msgid "if"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "FamilySwitch"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "LocalSize"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "requestedSize"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Config (AppIntent)"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Config Activity"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Yes (10+)"
+msgstr ""
+
+#: src/widgets/platforms.md:32 src/widgets/platforms.md:34
+msgid "SharedPrefs"
+msgstr ""
+
+#: src/widgets/platforms.md:33
+msgid "Native provider"
+msgstr ""
+
+#: src/widgets/platforms.md:33
+msgid "JNI"
+msgstr ""
+
+#: src/widgets/platforms.md:34
+msgid "sharedStorage"
+msgstr ""
+
+#: src/widgets/platforms.md:34
+msgid "UserDefaults"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "Deep linking (url)"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "widgetURL"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "clickable Intent"
+msgstr ""
+
+#: src/widgets/platforms.md:37
+msgid "Platform-Specific Notes"
+msgstr ""
+
+#: src/widgets/platforms.md:40
+msgid "Minimum deployment: iOS 17.0"
+msgstr ""
+
+#: src/widgets/platforms.md:41
+msgid "AppIntentConfiguration requires `import AppIntents`"
+msgstr ""
+
+#: src/widgets/platforms.md:42
+msgid "Widget extension memory limit: ~30MB"
+msgstr ""
+
+#: src/widgets/platforms.md:45
+msgid "Requires Glance dependency: `androidx.glance:glance-appwidget:1.1.0`"
+msgstr ""
+
+#: src/widgets/platforms.md:46
+msgid ""
+"Widget sizes mapped from iOS families: systemSmall=2x2, systemMedium=4x2, "
+"systemLarge=4x4"
+msgstr ""
+
+#: src/widgets/platforms.md:47
+msgid "`minimumScaleFactor` not supported in Glance (skipped with warning)"
+msgstr ""
+
+#: src/widgets/platforms.md:50
+msgid "Minimum deployment: watchOS 9.0"
+msgstr ""
+
+#: src/widgets/platforms.md:51
+msgid "Accessory families only (circular, rectangular, inline)"
+msgstr ""
+
+#: src/widgets/platforms.md:52
+msgid "Tighter memory (~15-20MB) and refresh budgets (hourly)"
+msgstr ""
+
+#: src/widgets/platforms.md:53
+msgid "AppIntent requires watchOS 10+; older versions get StaticConfiguration"
+msgstr ""
+
+#: src/widgets/platforms.md:56
+msgid "Same native compilation as Android phone (Wear OS = Android)"
+msgstr ""
+
+#: src/widgets/platforms.md:57
+msgid "Requires Horologist + Tiles Material 3 dependencies"
+msgstr ""
+
+#: src/widgets/platforms.md:58
+msgid "Tiles are full-screen cards in the carousel"
+msgstr ""
+
+#: src/widgets/platforms.md:59
+msgid "`Gauge` maps to `CircularProgressIndicator`"
+msgstr ""
+
+#: src/widgets/platforms.md:61
+msgid "Build Instructions"
+msgstr ""
+
+#: src/widgets/platforms.md:73
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
+msgstr ""
+
+#: src/widgets/platforms.md:75
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
+msgstr ""
+
+#: src/widgets/platforms.md:89
+msgid "# Copy .kt files to Wear OS module\n"
+msgstr ""
+
+#: src/widgets/platforms.md:91
+msgid "# Merge AndroidManifest_snippet.xml\n"
+msgstr ""
+
+#: src/widgets/watchos.md:3
+msgid ""
+"Perry widgets can compile to watchOS WidgetKit complications using `--target"
+" watchos-widget`. The same `Widget({...})` source produces both iOS and "
+"watchOS widgets — the supported families determine the rendering."
+msgstr ""
+
+#: src/widgets/watchos.md:5
+msgid ""
+"**Status:** the snippet on this page compile-links cleanly on the host LLVM "
+"target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `Widget({...})` shape is verified against the codegen. The actual "
+"`--target watchos-widget` / `--target watchos-widget-simulator` cross-"
+"compile is wired in `crates/perry/src/commands/compile.rs` (emits through "
+"the WidgetKit Swift emitter) but the doc-tests harness can't drive it yet — "
+"each cross-target requires `--app-bundle-id` not yet surfaced through the "
+"harness ([\\#194](https://github.com/PerryTS/perry/issues/194)) plus a "
+"watchOS SDK from Xcode. Build with the `perry` CLI to validate end-to-end."
+msgstr ""
+
+#: src/widgets/watchos.md:15
+msgid "Accessory Families"
+msgstr ""
+
+#: src/widgets/watchos.md:17
+msgid ""
+"watchOS complications use accessory families instead of system families:"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Family"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Size"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Best For"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "`accessoryCircular`"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "~76x76pt"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "Single icon, number, or Gauge"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "`accessoryRectangular`"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "~160x76pt"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "2-3 lines of text"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "`accessoryInline`"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "Single line"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "Short text only"
+msgstr ""
+
+#: src/widgets/watchos.md:25
+msgid "Gauge Component"
+msgstr ""
+
+#: src/widgets/watchos.md:27
+msgid "The `Gauge` component is designed for watchOS circular complications:"
+msgstr ""
+
+#: src/widgets/watchos.md:29
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"QuickStats\",\n"
+"    displayName: \"Quick Stats\",\n"
+"    supportedFamilies: [\"accessoryCircular\", \"accessoryRectangular\"],\n"
+"\n"
+"    render(entry: { progress: number; label: string }, family) {\n"
+"        if (family === \"accessoryCircular\") {\n"
+"            return Gauge(entry.progress, 1.0)\n"
+"        }\n"
+"        return VStack([\n"
+"            Text(entry.label),\n"
+"            Gauge(entry.progress, 1.0),\n"
+"        ])\n"
+"    },\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/watchos.md:47
+msgid "Gauge Styles"
+msgstr ""
+
+#: src/widgets/watchos.md:49
+msgid ""
+"**`circular`** — Ring gauge, maps to "
+"`.gaugeStyle(.accessoryCircularCapacity)` in SwiftUI"
+msgstr ""
+
+#: src/widgets/watchos.md:50
+msgid ""
+"**`linear`** / **`linearCapacity`** — Horizontal bar, maps to "
+"`.gaugeStyle(.linearCapacity)`"
+msgstr ""
+
+#: src/widgets/watchos.md:52
+msgid "Refresh Budgets"
+msgstr ""
+
+#: src/widgets/watchos.md:54
+msgid "watchOS has stricter refresh budgets than iOS:"
+msgstr ""
+
+#: src/widgets/watchos.md:55
+msgid ""
+"Recommended: refresh every 60 minutes (`reloadPolicy: { after: { minutes: 60"
+" } }`)"
+msgstr ""
+
+#: src/widgets/watchos.md:56
+msgid "Maximum: system may throttle more aggressively than iOS"
+msgstr ""
+
+#: src/widgets/watchos.md:57
+msgid "Background refresh uses `BackgroundTask` framework"
+msgstr ""
+
+#: src/widgets/watchos.md:62
+msgid "# For Apple Watch device\n"
+msgstr ""
+
+#: src/widgets/watchos.md:64
+msgid "# For Apple Watch Simulator\n"
+msgstr ""
+
+#: src/widgets/watchos.md:69
+msgid "Build:"
+msgstr ""
+
+#: src/widgets/watchos.md:79
+msgid ""
+"watchOS 10+ supports AppIntent for widget configuration (same as iOS 17+)"
+msgstr ""
+
+#: src/widgets/watchos.md:80
+msgid ""
+"Older watchOS versions automatically get `StaticConfiguration` fallback"
+msgstr ""
+
+#: src/widgets/watchos.md:81
+msgid "`config` params work identically to iOS"
+msgstr ""
+
+#: src/widgets/watchos.md:83
+msgid "Memory Considerations"
+msgstr ""
+
+#: src/widgets/watchos.md:85
+msgid ""
+"watchOS widget extensions have tighter memory limits (~15-20MB) compared to "
+"iOS (~30MB). The provider-only compilation approach is critical — only the "
+"data-fetching code runs natively, keeping memory usage minimal."
+msgstr ""
+
+#: src/widgets/wearos.md:3
+msgid ""
+"Perry widgets can compile to Wear OS Tiles using `--target wearos-tile`. "
+"Tiles are glanceable surfaces in the Wear OS tile carousel and watch face "
+"complications."
+msgstr ""
+
+#: src/widgets/wearos.md:5
+msgid ""
+"**Status:** the snippet on this page compile-links cleanly on the host LLVM "
+"target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `Widget({...})` shape is verified against the codegen. `--target "
+"wearos-tile` itself is wired through `crates/perry-codegen-wear-tiles` but "
+"the doc-tests harness can't drive that cross-target yet — `--app-bundle-id` "
+"plumbing is still pending "
+"([\\#194](https://github.com/PerryTS/perry/issues/194)) and you'll need an "
+"Android NDK + Wear OS Gradle deps. Build with the `perry` CLI to validate "
+"end-to-end."
+msgstr ""
+
+#: src/widgets/wearos.md:14
+msgid "Concepts"
+msgstr ""
+
+#: src/widgets/wearos.md:16
+msgid "**Tiles** are full-screen cards users swipe through on their watch"
+msgstr ""
+
+#: src/widgets/wearos.md:17
+msgid "**Complications** are small data displays on the watch face"
+msgstr ""
+
+#: src/widgets/wearos.md:18
+msgid ""
+"Perry compiles `Widget({...})` to a `SuspendingTileService` with layout "
+"builders"
+msgstr ""
+
+#: src/widgets/wearos.md:20
+msgid "Supported Components"
+msgstr ""
+
+#: src/widgets/wearos.md:22
+msgid "Widget API"
+msgstr ""
+
+#: src/widgets/wearos.md:22
+msgid "Wear OS Mapping"
+msgstr ""
+
+#: src/widgets/wearos.md:24
+msgid "`LayoutElementBuilders.Text`"
+msgstr ""
+
+#: src/widgets/wearos.md:25
+msgid "`LayoutElementBuilders.Column`"
+msgstr ""
+
+#: src/widgets/wearos.md:26
+msgid "`LayoutElementBuilders.Row`"
+msgstr ""
+
+#: src/widgets/wearos.md:27
+msgid "`LayoutElementBuilders.Spacer`"
+msgstr ""
+
+#: src/widgets/wearos.md:28
+msgid "Spacer with 1dp height"
+msgstr ""
+
+#: src/widgets/wearos.md:29
+msgid "`Gauge(circular)`"
+msgstr ""
+
+#: src/widgets/wearos.md:29
+msgid "`LayoutElementBuilders.Arc` + `ArcLine`"
+msgstr ""
+
+#: src/widgets/wearos.md:30
+msgid "`Gauge(linear)`"
+msgstr ""
+
+#: src/widgets/wearos.md:31
+msgid "`Image`"
+msgstr ""
+
+#: src/widgets/wearos.md:31
+msgid "Resource-based (provide drawable)"
+msgstr ""
+
+#: src/widgets/wearos.md:33
+msgid "Example"
+msgstr ""
+
+#: src/widgets/wearos.md:35
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StepsTile\",\n"
+"    displayName: \"Steps\",\n"
+"    description: \"Daily step count\",\n"
+"    supportedFamilies: [\"accessoryCircular\"],\n"
+"\n"
+"    provider: async () => {\n"
+"        return {\n"
+"            entries: [{ steps: 7500, goal: 10000 }],\n"
+"            reloadPolicy: { after: { minutes: 60 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render(entry: { steps: number; goal: number }) {\n"
+"        return VStack([\n"
+"            Gauge(entry.steps / entry.goal, 1.0),\n"
+"            Text(`${entry.steps}`),\n"
+"        ])\n"
+"    },\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/wearos.md:65
+msgid "`{Name}TileService.kt` — `SuspendingTileService` with tile layout"
+msgstr ""
+
+#: src/widgets/wearos.md:66
+msgid ""
+"`{Name}TileBridge.kt` — JNI bridge for native provider (if provider exists)"
+msgstr ""
+
+#: src/widgets/wearos.md:67
+msgid "`AndroidManifest_snippet.xml` — Service declaration"
+msgstr ""
+
+#: src/widgets/wearos.md:69
+msgid "Gradle Integration"
+msgstr ""
+
+#: src/widgets/wearos.md:71
+msgid "Add to your Wear OS module's `build.gradle`:"
+msgstr ""
+
+#: src/widgets/wearos.md:75
+msgid "\"com.google.android.horologist:horologist-tiles:0.6.5\""
+msgstr ""
+
+#: src/widgets/wearos.md:76
+msgid "\"androidx.wear.tiles:tiles-material:1.4.0\""
+msgstr ""
+
+#: src/widgets/wearos.md:77
+msgid "\"androidx.wear.tiles:tiles:1.4.0\""
+msgstr ""
+
+#: src/widgets/wearos.md:81
+msgid "Merge the manifest snippet into your `AndroidManifest.xml`:"
+msgstr ""
+
+#: src/widgets/wearos.md:85
+msgid "\".StepsTileService\""
+msgstr ""
+
+#: src/widgets/wearos.md:86
+msgid "\"true\""
+msgstr ""
+
+#: src/widgets/wearos.md:87
+msgid "\"com.google.android.wearable.permission.BIND_TILE_PROVIDER\""
+msgstr ""
+
+#: src/widgets/wearos.md:89
+msgid "\"androidx.wear.tiles.action.BIND_TILE_PROVIDER\""
+msgstr ""
+
+#: src/widgets/wearos.md:94
+msgid "Native Provider"
+msgstr ""
+
+#: src/widgets/wearos.md:96
+msgid "Same as Android phone widgets — Wear OS is Android:"
+msgstr ""
+
+#: src/widgets/wearos.md:97
+msgid "Target triple: `aarch64-linux-android`"
+msgstr ""
+
+#: src/widgets/wearos.md:98
+msgid "`libwidget_provider.so` loaded via `System.loadLibrary`"
+msgstr ""
+
+#: src/widgets/wearos.md:99
+msgid "JNI bridge pattern identical to phone Glance widgets"
+msgstr ""
+
+#: src/widgets/wearos.md:100
+msgid "`sharedStorage()` uses `SharedPreferences`"
+msgstr ""
+
+#: src/widgets/wearos.md:102
+msgid "Refresh"
+msgstr ""
+
+#: src/widgets/wearos.md:104
+msgid ""
+"Wear Tiles use `freshnessIntervalMillis` on the `Tile` builder. Set via "
+"`reloadPolicy: { after: { minutes: N } }` in the provider return value. "
+"Default: 60 minutes."
+msgstr ""
+
+#: src/plugins/overview.md:1
+msgid "Plugin System Overview"
+msgstr ""
+
+#: src/plugins/overview.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). Receiver-less calls (`loadPlugin`, `listPlugins`, `emitHook`, "
+"`invokeTool`, ...) and `PluginApi` instance methods (`api.registerHook`, "
+"`api.registerTool`, ...) dispatch through `crates/perry-"
+"codegen/src/lower_call.rs::PERRY_PLUGIN_TABLE` and "
+"`PERRY_PLUGIN_INSTANCE_TABLE`. TypeScript surface lives in "
+"`types/perry/plugin/index.d.ts`. Host-side snippets below are compile-link "
+"verified by the doc-tests harness against "
+"[`docs/examples/plugins/host_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/host_snippets.ts);"
+" plugin-side `activate(api)` snippets against "
+"[`docs/examples/plugins/plugin_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/plugin_snippets.ts)."
+msgstr ""
+
+#: src/plugins/overview.md:5
+msgid ""
+"Perry supports native plugins as shared libraries (`.dylib`/`.so`). Plugins "
+"extend Perry applications with custom hooks, tools, services, and routes."
+msgstr ""
+
+#: src/plugins/overview.md:9
+msgid ""
+"A plugin is a Perry-compiled shared library with `activate(api)` and "
+"`deactivate()` entry points"
+msgstr ""
+
+#: src/plugins/overview.md:10
+msgid "The host application loads plugins with `loadPlugin(path)`"
+msgstr ""
+
+#: src/plugins/overview.md:11
+msgid "Plugins register hooks, tools, and services via the API handle"
+msgstr ""
+
+#: src/plugins/overview.md:12
+msgid "The host dispatches events to plugins via `emitHook(name, data)`"
+msgstr ""
+
+#: src/plugins/overview.md:14
+msgid ""
+"```\n"
+"Host Application\n"
+"    ↓ loadPlugin(\"./my-plugin.dylib\")\n"
+"    ↓ calls plugin_activate(api_handle)\n"
+"Plugin\n"
+"    ↓ api.registerHook(\"beforeSave\", callback)\n"
+"    ↓ api.registerTool(\"format\", callback)\n"
+"Host\n"
+"    ↓ emitHook(\"beforeSave\", data) → plugin callback runs\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:27
+msgid "Plugin (compiled with `--output-type dylib`)"
+msgstr ""
+
+#: src/plugins/overview.md:29 src/plugins/creating-plugins.md:9
+msgid ""
+"```typescript\n"
+"let count = 0\n"
+"\n"
+"export function activate(api: PluginApi) {\n"
+"    api.setMetadata(\"counter\", \"1.0.0\", \"Counts hook invocations\")\n"
+"\n"
+"    api.registerHook(\"onRequest\", (data) => {\n"
+"        count++\n"
+"        console.log(`Request #${count}`)\n"
+"        return data\n"
+"    })\n"
+"\n"
+"    api.registerTool(\"getCount\", \"returns request count\", () => count)\n"
+"}\n"
+"\n"
+"export function deactivate() {\n"
+"    console.log(`Total requests processed: ${count}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:53
+msgid "Host Application"
+msgstr ""
+
+#: src/plugins/overview.md:55
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"    loadPlugin, unloadPlugin,\n"
+"    emitHook, emitEvent, invokeTool,\n"
+"    setPluginConfig,\n"
+"    discoverPlugins, listPlugins, listHooks, listTools,\n"
+"    pluginCount, initPlugins,\n"
+"} from \"perry/plugin\"\n"
+"\n"
+"const id = loadPlugin(\"./counter-plugin.dylib\")\n"
+"console.log(`load returned: ${id !== 0 ? \"ok\" : \"fail\"}`)\n"
+"\n"
+"const plugins = listPlugins()\n"
+"const hooks = listHooks()\n"
+"const tools = listTools()\n"
+"console.log(`loaded: ${pluginCount()} plugin(s), ${hooks.length} hook(s), ${tools.length} tool(s)`)\n"
+"\n"
+"const result = emitHook(\"beforeSave\", { content: \"hello world\" })\n"
+"\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:81
+msgid "Plugin ABI"
+msgstr ""
+
+#: src/plugins/overview.md:83
+msgid "Plugins must export these symbols:"
+msgstr ""
+
+#: src/plugins/overview.md:84
+msgid ""
+"`perry_plugin_abi_version()` — Returns ABI version (for compatibility "
+"checking)"
+msgstr ""
+
+#: src/plugins/overview.md:85
+msgid "`plugin_activate(api_handle)` — Called when plugin is loaded"
+msgstr ""
+
+#: src/plugins/overview.md:86
+msgid "`plugin_deactivate()` — Called when plugin is unloaded"
+msgstr ""
+
+#: src/plugins/overview.md:88
+msgid ""
+"Perry generates these automatically from your `activate`/`deactivate` "
+"exports."
+msgstr ""
+
+#: src/plugins/overview.md:92
+msgid ""
+"Perry also supports **native extensions** — packages that bundle platform-"
+"specific Rust/Swift/JNI code and compile directly into your binary. These "
+"are used for accessing platform APIs like the App Store review prompt or "
+"StoreKit in-app purchases."
+msgstr ""
+
+#: src/plugins/overview.md:94
+msgid "See [Native Extensions](native-extensions.md) for details."
+msgstr ""
+
+#: src/plugins/overview.md:98
+msgid "[Creating Plugins](creating-plugins.md) — Build a plugin step by step"
+msgstr ""
+
+#: src/plugins/overview.md:99
+msgid "[Hooks & Events](hooks-and-events.md) — Hook modes, event bus, tools"
+msgstr ""
+
+#: src/plugins/overview.md:100
+msgid ""
+"[Native Extensions](native-extensions.md) — Extensions with platform-native "
+"code"
+msgstr ""
+
+#: src/plugins/overview.md:101
+msgid ""
+"[App Store Review](appstore-review.md) — Native review prompt (iOS/Android)"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). See [Plugin System Overview — Status](overview.md) for the full "
+"surface. Snippets below are compile-link verified by the doc-tests harness "
+"against "
+"[`docs/examples/plugins/plugin_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/plugin_snippets.ts)"
+" and "
+"[`docs/examples/plugins/host_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/host_snippets.ts)."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:5
+msgid "Build Perry plugins as shared libraries that extend host applications."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:7
+msgid "Step 1: Write the Plugin"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:29
+msgid "Step 2: Compile as Shared Library"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:35
+msgid ""
+"The `--output-type dylib` flag tells Perry to produce a `.dylib` (macOS) or "
+"`.so` (Linux) instead of an executable."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:38
+msgid ""
+"Generates `perry_plugin_abi_version()` returning the current ABI version"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:39
+msgid ""
+"Generates `plugin_activate(api_handle)` calling your `activate()` function"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:40
+msgid "Generates `plugin_deactivate()` calling your `deactivate()` function"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:41
+msgid "Exports symbols with `-rdynamic` for the host to find"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:43
+msgid "Step 3: Load from Host"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:45
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"    loadPlugin, unloadPlugin,\n"
+"    emitHook, emitEvent, invokeTool,\n"
+"    setPluginConfig,\n"
+"    discoverPlugins, listPlugins, listHooks, listTools,\n"
+"    pluginCount, initPlugins,\n"
+"} from \"perry/plugin\"\n"
+"\n"
+"const id = loadPlugin(\"./counter-plugin.dylib\")\n"
+"console.log(`load returned: ${id !== 0 ? \"ok\" : \"fail\"}`)\n"
+"\n"
+"const found = discoverPlugins(\"./plugins/\")\n"
+"console.log(`discovered ${found.length} plugin(s)`)\n"
+"\n"
+"const result = emitHook(\"beforeSave\", { content: \"hello world\" })\n"
+"\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:69
+msgid "Plugin API Reference"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:71
+msgid "The `api: PluginApi` passed to `activate()` provides:"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:73
+msgid "Metadata"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:79
+msgid "Hooks"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:86
+msgid ""
+"`registerHook` defaults to priority 10 / mode 0 (filter). Use "
+"`registerHookEx` for explicit priority and mode (0=filter, 1=action, "
+"2=waterfall). Lower priority numbers run first."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:90 src/plugins/hooks-and-events.md:94
+msgid "Tools"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:96
+msgid "Tools are invoked by name from the host."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:100
+msgid ""
+"```typescript,no-test\n"
+"const value = api.getConfig(key: string)  // Read host-provided config\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:106
+msgid ""
+"```typescript,no-test\n"
+"api.on(event: string, handler: (data: unknown) => void): void  // Listen for events\n"
+"api.emit(event: string, data: unknown): void                    // Emit to other plugins\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:113
+msgid "[Hooks & Events](hooks-and-events.md) — Hook modes, event bus"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:114 src/plugins/hooks-and-events.md:147
+#: src/plugins/native-extensions.md:301
+msgid "[Overview](overview.md) — Plugin system overview"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). `api.registerHook`, `api.on`, `emitHook`, `emitEvent`, `invokeTool`"
+" all dispatch to `crates/perry-runtime/src/plugin.rs`. Snippets below are "
+"compile-link verified against "
+"[`docs/examples/plugins/{plugin,host}_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/)."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:5
+msgid "Perry plugins communicate through hooks, events, and tools."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:7
+msgid "Hook Modes"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:9
+msgid "Hooks support three execution modes:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:11
+msgid "Filter Mode (default)"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:13
+msgid ""
+"Each plugin receives data and returns (possibly modified) data. The output "
+"of one plugin becomes the input of the next:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:15
+msgid ""
+"```typescript\n"
+"function registerFilter(api: PluginApi) {\n"
+"    api.registerHook(\"transform\", (data: any) => {\n"
+"        data.content = data.content.toUpperCase()\n"
+"        return data // Returned data goes to next plugin\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:24
+msgid "Action Mode"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:26
+msgid ""
+"Plugins receive data but return value is ignored. Used for side effects. "
+"Pass `mode = 1` to `registerHookEx`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:29
+msgid ""
+"```typescript\n"
+"function registerAction(api: PluginApi) {\n"
+"    api.registerHook(\"onSave\", (data: any) => {\n"
+"        console.log(`Saved: ${data.path}`)\n"
+"        return data\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:38
+msgid "Waterfall Mode"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:40
+msgid ""
+"Like filter mode, but specifically for accumulating/building up a result "
+"through the chain. Pass `mode = 2` to `registerHookEx`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:43
+msgid ""
+"```typescript\n"
+"function registerWaterfall(api: PluginApi) {\n"
+"    api.registerHook(\"buildMenu\", (items: any) => {\n"
+"        items.push({ label: \"My Plugin Action\", action: () => {} })\n"
+"        return items\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:52
+msgid "Hook Priority"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:54
+msgid ""
+"Lower priority numbers run first. Use `registerHookEx` for explicit priority"
+" and mode:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:57
+msgid ""
+"```typescript\n"
+"function registerPriorities(api: PluginApi, validate: (d: any) => any, transform: (d: any) => any, log: (d: any) => any) {\n"
+"    // Lower priority numbers run first; default 10. Mode 0=filter / 1=action / 2=waterfall.\n"
+"    api.registerHookEx(\"beforeSave\", validate, 10, 0)   // Runs first\n"
+"    api.registerHookEx(\"beforeSave\", transform, 20, 0)  // Runs second\n"
+"    api.registerHookEx(\"beforeSave\", log, 100, 1)        // Runs last (action mode)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:66
+msgid "Default priority is 10 (the value `registerHook` passes implicitly)."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:68
+msgid "Event Bus"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:70
+msgid "Plugins can communicate with each other through events:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:72
+msgid "Emitting Events"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:74
+msgid ""
+"```typescript\n"
+"function emitFromPlugin(api: PluginApi) {\n"
+"    api.emit(\"dataUpdated\", { source: \"my-plugin\", records: 42 })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:80
+msgid ""
+"```typescript\n"
+"emitEvent(\"dataUpdated\", { source: \"host\", records: 100 })\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:84
+msgid "Listening for Events"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:86
+msgid ""
+"```typescript\n"
+"function listenForEvent(api: PluginApi) {\n"
+"    api.on(\"dataUpdated\", (data: any) => {\n"
+"        console.log(`${data.source} updated ${data.records} records`)\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:96
+msgid ""
+"Plugins register callable tools (note the 3-arg shape: `name`, "
+"`description`, `handler`):"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:99
+msgid ""
+"```typescript\n"
+"function registerFormatter(api: PluginApi) {\n"
+"    api.registerTool(\"formatCode\", \"format source code\", (args: any) => {\n"
+"        return `// formatted: ${args.code}`\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:107
+msgid ""
+"```typescript\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:117
+msgid "Hosts can pass configuration to plugins via `setPluginConfig`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:119
+msgid ""
+"```typescript\n"
+"initPlugins()\n"
+"setPluginConfig(\"api_key\", \"test-key\")\n"
+"setPluginConfig(\"max_retries\", \"3\")\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:125
+msgid ""
+"```typescript\n"
+"function readConfig(api: PluginApi) {\n"
+"    const theme = api.getConfig(\"theme\")     // \"dark\"\n"
+"    const retries = api.getConfig(\"maxRetries\") // \"3\"\n"
+"    return { theme, retries }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:133
+msgid "Introspection"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:135
+msgid "Query loaded plugins and their registrations:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:146
+msgid "[Creating Plugins](creating-plugins.md) — Build a plugin"
+msgstr ""
+
+#: src/plugins/native-extensions.md:3
+msgid ""
+"**Status: partially wired.** The `--bundle-extensions` flag, the "
+"`perry.nativeLibrary` `package.json` manifest, and `declare function` FFI "
+"imports are all wired into the compiler — see "
+"`crates/perry/src/commands/compile.rs` (the `bundle_extensions` argument, "
+"the `parse_native_library_manifest`/`build_external_native_libraries` "
+"helpers) and `crates/perry-codegen/src/codegen.rs` (the "
+"`nativeLibrary.functions` signature parser). The TypeScript snippets below "
+"assume a fully-populated extension directory exists on disk (e.g. `perry-"
+"appstore-review` cloned under `./extensions/`). They are kept as `,no-test` "
+"because the doc-tests harness doesn't have those external extensions checked"
+" in — a real project that does have them will compile cleanly. Drift "
+"protection for the parts that _don't_ depend on external extensions (the FFI"
+" declare-function shape, etc.) lives in "
+"`docs/examples/platforms/wasm_snippets.ts`."
+msgstr ""
+
+#: src/plugins/native-extensions.md:5
+msgid ""
+"Perry supports native extensions — packages that bundle platform-specific "
+"code (Rust, Swift, JNI) alongside a TypeScript API. Unlike [dynamic "
+"plugins](overview.md) loaded at runtime, native extensions are compiled "
+"directly into your binary."
+msgstr ""
+
+#: src/plugins/native-extensions.md:7
+msgid ""
+"Native extensions are how you access platform APIs that aren't part of "
+"Perry's built-in [System APIs](../system/overview.md) or [Standard "
+"Library](../stdlib/overview.md). Examples include [App Store "
+"Review](appstore-review.md) and StoreKit for in-app purchases."
+msgstr ""
+
+#: src/plugins/native-extensions.md:9
+msgid "Using a native extension"
+msgstr ""
+
+#: src/plugins/native-extensions.md:11
+msgid "1. Add the extension to your project"
+msgstr ""
+
+#: src/plugins/native-extensions.md:13
+msgid ""
+"Place the extension directory alongside your project, or in a shared "
+"extensions directory:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:30
+msgid "2. Compile with `--bundle-extensions`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:32
+msgid "Pass the extensions directory when building:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:38
+msgid ""
+"Perry discovers every subdirectory with a `package.json`, compiles its "
+"native crates for the target platform, and links them into your binary."
+msgstr ""
+
+#: src/plugins/native-extensions.md:40
+msgid "3. Import and use"
+msgstr ""
+
+#: src/plugins/native-extensions.md:42 src/plugins/appstore-review.md:60
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"\n"
+"await requestReview();\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:48
+msgid ""
+"The import resolves at compile time to the extension's entry point. No "
+"runtime module loading is involved — the function compiles to a direct "
+"native call."
+msgstr ""
+
+#: src/plugins/native-extensions.md:50
+msgid "How native extensions work"
+msgstr ""
+
+#: src/plugins/native-extensions.md:52
+msgid ""
+"A native extension is a directory with a `package.json` that declares a "
+"`perry.nativeLibrary` section. This tells Perry which native functions "
+"exist, their signatures, and which Rust crate to compile for each platform."
+msgstr ""
+
+#: src/plugins/native-extensions.md:54
+msgid "package.json manifest"
+msgstr ""
+
+#: src/plugins/native-extensions.md:58
+msgid "\"perry-appstore-review\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:59
+msgid "\"0.1.0\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:62 src/plugins/appstore-review.md:181
+msgid "\"nativeLibrary\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:63 src/plugins/appstore-review.md:182
+msgid "\"functions\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"sb_appreview_request\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"params\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"returns\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"f64\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:66
+msgid "\"targets\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:68 src/plugins/native-extensions.md:73
+#: src/plugins/native-extensions.md:78
+msgid "\"crate\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:68 src/plugins/native-extensions.md:78
+msgid "\"crate-ios\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:69 src/plugins/native-extensions.md:74
+#: src/plugins/native-extensions.md:79
+msgid "\"lib\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:69 src/plugins/native-extensions.md:74
+#: src/plugins/native-extensions.md:79
+msgid "\"libperry_appreview.a\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:70 src/plugins/native-extensions.md:75
+#: src/plugins/native-extensions.md:80
+msgid "\"frameworks\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:70 src/plugins/native-extensions.md:80
+msgid "\"StoreKit\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:73
+msgid "\"crate-android\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:77
+msgid "\"macos\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:88
+msgid "`functions`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:90
+msgid "Each entry declares a native function the extension exports:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:94 src/cli/perry-toml.md:116
+msgid "`name`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:94
+msgid "Symbol name — must match the `#[no_mangle]` Rust function exactly"
+msgstr ""
+
+#: src/plugins/native-extensions.md:95
+msgid "`params`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:95
+msgid ""
+"Array of LLVM types: `\"i64\"` for pointers/strings, `\"f64\"` for numbers, "
+"`\"i32\"` for integers"
+msgstr ""
+
+#: src/plugins/native-extensions.md:96
+msgid "`returns`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:96
+msgid "Return type — typically `\"f64\"` (NaN-boxed value or promise handle)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:98
+msgid "`targets`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:100
+msgid ""
+"Each target platform maps to a Rust crate that implements the native "
+"functions:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:104
+msgid "`crate`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:104
+msgid "Relative path to the Rust crate directory"
+msgstr ""
+
+#: src/plugins/native-extensions.md:105
+msgid "`lib`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:105
+msgid "Name of the static library produced by `cargo build`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:106
+msgid "`frameworks`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:106
+msgid "System frameworks to link (iOS/macOS only)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:108
+msgid ""
+"Multiple targets can share the same crate (e.g., iOS and macOS often share "
+"an implementation). Platforms without an entry fall back to the stub."
+msgstr ""
+
+#: src/plugins/native-extensions.md:110
+msgid "Extension directory layout"
+msgstr ""
+
+#: src/plugins/native-extensions.md:112
+msgid ""
+"```\n"
+"perry-appstore-review/\n"
+"├── package.json              # Manifest with perry.nativeLibrary\n"
+"├── src/\n"
+"│   └── index.ts              # TypeScript API (what users import)\n"
+"├── crate-ios/                # iOS/macOS native implementation\n"
+"│   ├── Cargo.toml            # [lib] crate-type = [\"staticlib\"]\n"
+"│   ├── build.rs              # Compiles Swift if needed\n"
+"│   ├── src/\n"
+"│   │   └── lib.rs            # Rust FFI: #[no_mangle] pub extern \"C\" fn ...\n"
+"│   └── swift/\n"
+"│       └── bridge.swift      # Swift bridge for Apple APIs (@_cdecl)\n"
+"├── crate-android/            # Android native implementation\n"
+"│   ├── Cargo.toml\n"
+"│   └── src/\n"
+"│       └── lib.rs            # Rust FFI with JNI calls\n"
+"└── crate-stub/               # Fallback for unsupported platforms\n"
+"    ├── Cargo.toml\n"
+"    └── src/\n"
+"        └── lib.rs            # Returns error immediately\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:134
+msgid "TypeScript side"
+msgstr ""
+
+#: src/plugins/native-extensions.md:136
+msgid ""
+"The `src/index.ts` declares native functions and optionally wraps them in a "
+"friendlier API:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:138
+msgid ""
+"```text\n"
+"// Declare the native function (name must match package.json)\n"
+"declare function sb_appreview_request(): number;\n"
+"\n"
+"// Wrap it with a proper TypeScript signature\n"
+"export async function requestReview(): Promise<void> {\n"
+"  await (sb_appreview_request() as any);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:148
+msgid ""
+"`declare function` tells Perry the function is provided by native code. The "
+"raw return type is `number` because all values cross the FFI boundary as "
+"NaN-boxed `f64` values. Promise handles are NaN-boxed pointers that Perry's "
+"runtime knows how to `await`."
+msgstr ""
+
+#: src/plugins/native-extensions.md:150
+msgid "Rust side"
+msgstr ""
+
+#: src/plugins/native-extensions.md:152
+msgid ""
+"Each platform crate is a `staticlib` that implements the declared functions "
+"using `#[no_mangle] pub extern \"C\"`:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:155
+msgid "// Perry runtime FFI\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:156 src/plugins/native-extensions.md:164
+#: src/plugins/native-extensions.md:256
+msgid "\"C\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:167
+msgid "// ... call platform API, resolve promise when done ...\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:173
+msgid "Key runtime functions available to native code:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:175 src/contributing/architecture.md:23
+msgid "Purpose"
+msgstr ""
+
+#: src/plugins/native-extensions.md:177
+msgid "`js_promise_new()`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:177
+msgid "Create a new Perry promise, returns pointer"
+msgstr ""
+
+#: src/plugins/native-extensions.md:178
+msgid "`js_promise_resolve(promise, value)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:178
+msgid "Resolve a promise with a NaN-boxed value"
+msgstr ""
+
+#: src/plugins/native-extensions.md:179
+msgid "`js_nanbox_string(ptr)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:179
+msgid "Convert a C string pointer to a NaN-boxed string"
+msgstr ""
+
+#: src/plugins/native-extensions.md:180
+msgid "`js_nanbox_pointer(ptr)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:180
+msgid "Convert a pointer to a NaN-boxed object reference"
+msgstr ""
+
+#: src/plugins/native-extensions.md:181
+msgid "`js_get_string_pointer_unified(val)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:181
+msgid "Extract string pointer from a NaN-boxed value"
+msgstr ""
+
+#: src/plugins/native-extensions.md:182
+msgid "`js_string_from_bytes(ptr, len)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:182
+msgid "Create a Perry string from bytes"
+msgstr ""
+
+#: src/plugins/native-extensions.md:184
+msgid "Swift bridge (iOS/macOS)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:186
+msgid ""
+"Apple platform APIs are often easiest to call from Swift. The pattern is:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:188
+msgid "Write a Swift file with `@_cdecl(\"function_name\")` exports"
+msgstr ""
+
+#: src/plugins/native-extensions.md:189
+msgid "Compile it to a static library in `build.rs`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:190
+msgid "Call the Swift functions from Rust via `extern \"C\"`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:192
+msgid ""
+"```swift\n"
+"import StoreKit\n"
+"\n"
+"typealias Callback = @convention(c) (UnsafeMutableRawPointer, UnsafePointer<CChar>) -> Void\n"
+"\n"
+"@_cdecl(\"swift_appreview_request\")\n"
+"func swiftRequestReview(_ callback: @escaping Callback, _ context: UnsafeMutableRawPointer) {\n"
+"    DispatchQueue.main.async {\n"
+"        if let scene = UIApplication.shared.connectedScenes\n"
+"            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {\n"
+"            SKStoreReviewController.requestReview(in: scene)\n"
+"        }\n"
+"        let result = \"{\\\"success\\\":true}\"\n"
+"        result.withCString { callback(context, $0) }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:210
+msgid ""
+"The `build.rs` compiles the Swift source into a static library using "
+"`swiftc`, targeting the correct platform SDK:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:213
+msgid "// build.rs (simplified)\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:215
+msgid ""
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:221
+msgid "JNI bridge (Android)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:223
+msgid "Android platform APIs are accessed through JNI. The pattern:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:225
+msgid "Get the `JavaVM` via `JNI_GetCreatedJavaVMs()`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:226
+msgid "Attach the current thread to get a `JNIEnv`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:227
+msgid "Call Java/Kotlin APIs through JNI method invocations"
+msgstr ""
+
+#: src/plugins/native-extensions.md:228
+msgid "Resolve the Perry promise with the result"
+msgstr ""
+
+#: src/plugins/native-extensions.md:238
+msgid "// Get Activity from PerryBridge\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:239
+msgid "\"com/perry/app/PerryBridge\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:240
+msgid "\"getActivity\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:240
+msgid "\"()Landroid/app/Activity;\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:243
+msgid "// Call platform APIs via JNI...\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:248
+msgid ""
+"If the Android implementation requires a Java library (e.g., Google Play In-"
+"App Review), the app's `build.gradle` must include the dependency. Document "
+"this requirement clearly for your extension's users."
+msgstr ""
+
+#: src/plugins/native-extensions.md:250
+msgid "Stub crate"
+msgstr ""
+
+#: src/plugins/native-extensions.md:252
+msgid ""
+"For platforms without a native implementation, the stub immediately resolves"
+" the promise with an error:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:259
+msgid "\"{\\\"error\\\":\\\"Not available on this platform\\\"}\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:269
+msgid "Build requirements"
+msgstr ""
+
+#: src/plugins/native-extensions.md:273
+msgid "macOS host, Xcode, `rustup target add aarch64-apple-ios`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:274
+msgid "macOS host, Xcode, `rustup target add aarch64-apple-ios-sim`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:275
+msgid "macOS host, Xcode Command Line Tools"
+msgstr ""
+
+#: src/plugins/native-extensions.md:276
+msgid "Android NDK, `rustup target add aarch64-linux-android`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:278
+msgid ""
+"When Perry encounters a `perry.nativeLibrary` manifest during compilation, "
+"it:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:280
+msgid "Selects the crate for the current `--target` platform"
+msgstr ""
+
+#: src/plugins/native-extensions.md:281
+msgid "Runs `cargo build --release --target <triple>` in the crate directory"
+msgstr ""
+
+#: src/plugins/native-extensions.md:282
+msgid "Links the resulting `.a` static library into the final binary"
+msgstr ""
+
+#: src/plugins/native-extensions.md:283
+msgid "Adds any declared frameworks (e.g., `-framework StoreKit`)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:285
+msgid "Creating your own native extension"
+msgstr ""
+
+#: src/plugins/native-extensions.md:287
+msgid "Create the directory structure shown above"
+msgstr ""
+
+#: src/plugins/native-extensions.md:288
+msgid "Define your functions in `package.json` under `perry.nativeLibrary`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:289
+msgid ""
+"Implement each function in the platform crates with matching `#[no_mangle] "
+"pub extern \"C\"` signatures"
+msgstr ""
+
+#: src/plugins/native-extensions.md:290
+msgid ""
+"Write a TypeScript entry point that declares and optionally wraps the native"
+" functions"
+msgstr ""
+
+#: src/plugins/native-extensions.md:291
+msgid "Add a stub crate for unsupported platforms"
+msgstr ""
+
+#: src/plugins/native-extensions.md:292
+msgid "Test with `--bundle-extensions`:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:299
+msgid ""
+"[App Store Review](appstore-review.md) — Native review prompt extension "
+"(iOS/Android)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:300
+msgid ""
+"[Creating Plugins](creating-plugins.md) — Dynamic plugins loaded at runtime"
+msgstr ""
+
+#: src/plugins/appstore-review.md:3
+msgid ""
+"**Status: extension-dependent.** The compiler-side wiring (`--bundle-"
+"extensions`, `perry.nativeLibrary`, `declare function`) is in place — see "
+"[Native Extensions — Status](native-extensions.md) — but the snippets below "
+"assume the `perry-appstore-review` extension repo has been cloned into "
+"`./extensions/`. The doc-tests harness doesn't ship that repo, so these "
+"snippets are kept as `,no-test`. Once the extension is on disk, they compile"
+" and run on iOS / iOS Simulator / macOS / Android."
+msgstr ""
+
+#: src/plugins/appstore-review.md:5
+msgid ""
+"Prompt users to rate your app using the native app store review dialog on "
+"iOS and Android."
+msgstr ""
+
+#: src/plugins/appstore-review.md:7
+msgid ""
+"The `perry-appstore-review` extension exposes a single function — "
+"`requestReview()` — that opens the platform's native review prompt. It does "
+"nothing else: when and how often to ask is entirely up to you."
+msgstr ""
+
+#: src/plugins/appstore-review.md:9
+msgid ""
+"**Repository:** "
+"[github.com/PerryTS/appstorereview](https://github.com/PerryTS/appstorereview)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:13
+msgid "1. Add the extension"
+msgstr ""
+
+#: src/plugins/appstore-review.md:15
+msgid "Clone or copy the extension into your project's extensions directory:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:24
+msgid "Your project structure:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:35
+msgid "2. Use in your app"
+msgstr ""
+
+#: src/plugins/appstore-review.md:37
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"\n"
+"// Show the review prompt when the user completes a meaningful action\n"
+"async function onLevelComplete() {\n"
+"  await requestReview();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/appstore-review.md:46
+msgid "3. Build"
+msgstr ""
+
+#: src/plugins/appstore-review.md:52
+msgid ""
+"The `--bundle-extensions` flag tells Perry to discover, compile, and link "
+"all native extensions in the given directory. The app store review native "
+"code is compiled and statically linked into your binary — no runtime "
+"dependencies."
+msgstr ""
+
+#: src/plugins/appstore-review.md:56
+msgid "`requestReview(): Promise<void>`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:58
+msgid ""
+"Opens the native app store review prompt. Returns a promise that resolves "
+"when the prompt has been presented (or skipped by the OS)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:66
+msgid "The function only triggers the prompt. It does not:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:67
+msgid "Track whether the user has already reviewed"
+msgstr ""
+
+#: src/plugins/appstore-review.md:68
+msgid ""
+"Throttle how often the prompt appears (iOS does this automatically; Android "
+"does not)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:69
+msgid ""
+"Return whether the user actually left a review (neither platform provides "
+"this)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:71
+msgid "Platform behavior"
+msgstr ""
+
+#: src/plugins/appstore-review.md:75
+msgid ""
+"Uses "
+"[`SKStoreReviewController.requestReview(in:)`](https://developer.apple.com/documentation/storekit/skstorereviewcontroller/requestreview(in:))"
+" from StoreKit."
+msgstr ""
+
+#: src/plugins/appstore-review.md:77 src/plugins/appstore-review.md:93
+#: src/plugins/appstore-review.md:106
+msgid "Detail"
+msgstr ""
+
+#: src/plugins/appstore-review.md:79 src/plugins/appstore-review.md:95
+#: src/plugins/appstore-review.md:108
+msgid "Native API"
+msgstr ""
+
+#: src/plugins/appstore-review.md:79
+msgid "`SKStoreReviewController.requestReview(in: UIWindowScene)`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:80
+msgid "Minimum iOS version"
+msgstr ""
+
+#: src/plugins/appstore-review.md:80
+msgid "14.0"
+msgstr ""
+
+#: src/plugins/appstore-review.md:81 src/plugins/appstore-review.md:97
+msgid "Framework"
+msgstr ""
+
+#: src/plugins/appstore-review.md:81 src/plugins/appstore-review.md:97
+msgid "StoreKit"
+msgstr ""
+
+#: src/plugins/appstore-review.md:82
+msgid "Thread"
+msgstr ""
+
+#: src/plugins/appstore-review.md:82
+msgid "Dispatched to main thread automatically"
+msgstr ""
+
+#: src/plugins/appstore-review.md:83 src/plugins/appstore-review.md:98
+#: src/plugins/appstore-review.md:111
+msgid "Throttling"
+msgstr ""
+
+#: src/plugins/appstore-review.md:83
+msgid ""
+"Apple limits display to 3 times per 365-day period per app. The system may "
+"silently ignore the call."
+msgstr ""
+
+#: src/plugins/appstore-review.md:84
+msgid "Development builds"
+msgstr ""
+
+#: src/plugins/appstore-review.md:84
+msgid "Always shown in debug/TestFlight builds"
+msgstr ""
+
+#: src/plugins/appstore-review.md:85
+msgid "User control"
+msgstr ""
+
+#: src/plugins/appstore-review.md:85
+msgid "Users can disable review prompts in Settings > App Store"
+msgstr ""
+
+#: src/plugins/appstore-review.md:87
+msgid ""
+"**Important:** Apple's throttling means the prompt is not guaranteed to "
+"appear every time `requestReview()` is called. Design your app flow so that "
+"not showing the prompt doesn't break the user experience."
+msgstr ""
+
+#: src/plugins/appstore-review.md:91
+msgid ""
+"Uses the same StoreKit API. Shares the iOS native crate (both compile from "
+"`crate-ios`)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:95
+msgid "`SKStoreReviewController.requestReview()`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:96
+msgid "Minimum macOS version"
+msgstr ""
+
+#: src/plugins/appstore-review.md:96
+msgid "13.0"
+msgstr ""
+
+#: src/plugins/appstore-review.md:98
+msgid "Same as iOS — system-controlled"
+msgstr ""
+
+#: src/plugins/appstore-review.md:100
+msgid "Only works for apps distributed through the Mac App Store."
+msgstr ""
+
+#: src/plugins/appstore-review.md:104
+msgid ""
+"Uses the [Google Play In-App Review "
+"API](https://developer.android.com/guide/playcore/in-app-review)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:108
+msgid "`ReviewManager.requestReviewFlow()` + `launchReviewFlow()`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:109
+msgid "Library"
+msgstr ""
+
+#: src/plugins/appstore-review.md:109
+msgid "`com.google.android.play:review`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:110
+msgid "Minimum API level"
+msgstr ""
+
+#: src/plugins/appstore-review.md:110
+msgid "21 (Android 5.0)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:111
+msgid "Google enforces a quota — the prompt may not appear every time"
+msgstr ""
+
+#: src/plugins/appstore-review.md:112
+msgid "Execution"
+msgstr ""
+
+#: src/plugins/appstore-review.md:112
+msgid "Runs on a background thread to avoid blocking the UI"
+msgstr ""
+
+#: src/plugins/appstore-review.md:114
+msgid ""
+"**Required Gradle dependency:** The Google Play In-App Review API is not "
+"part of the Android SDK. You must add it to your app's `build.gradle`:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:118
+msgid "'com.google.android.play:review:2.0.2'"
+msgstr ""
+
+#: src/plugins/appstore-review.md:122
+msgid ""
+"Without this dependency, `requestReview()` will resolve with an error "
+"explaining the missing library."
+msgstr ""
+
+#: src/plugins/appstore-review.md:124
+msgid "Other platforms"
+msgstr ""
+
+#: src/plugins/appstore-review.md:126
+msgid ""
+"On unsupported platforms (Linux, Windows, Web), `requestReview()` resolves "
+"immediately with an error. It will not throw — your app continues normally."
+msgstr ""
+
+#: src/plugins/appstore-review.md:128
+msgid "Best practices"
+msgstr ""
+
+#: src/plugins/appstore-review.md:130
+msgid ""
+"**Do ask at the right moment.** Prompt after a positive experience — "
+"completing a level, finishing a task, achieving a goal. Don't ask on first "
+"launch or during onboarding."
+msgstr ""
+
+#: src/plugins/appstore-review.md:132
+msgid ""
+"**Don't ask too often.** Even though iOS throttles automatically, Android "
+"does not have the same strict limits. Implement your own logic to track when"
+" you last asked:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:134
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"import { preferencesGet, preferencesSet } from \"perry/system\";\n"
+"\n"
+"async function maybeAskForReview() {\n"
+"  const lastAsked = Number(preferencesGet(\"lastReviewAsk\") || \"0\");\n"
+"  const now = Date.now();\n"
+"  const thirtyDays = 30 * 24 * 60 * 60 * 1000;\n"
+"\n"
+"  if (now - lastAsked > thirtyDays) {\n"
+"    preferencesSet(\"lastReviewAsk\", String(now));\n"
+"    await requestReview();\n"
+"  }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/appstore-review.md:150
+msgid ""
+"**Don't condition app behavior on the review.** Neither iOS nor Android "
+"tells you whether the user left a review, gave a rating, or dismissed the "
+"prompt. The promise resolving does not mean a review was submitted."
+msgstr ""
+
+#: src/plugins/appstore-review.md:152
+msgid ""
+"**Don't use custom review dialogs before the native one.** Both Apple and "
+"Google discourage showing your own \"Rate this app?\" dialog before the "
+"native prompt. The native prompt is designed to be low-friction — adding a "
+"pre-prompt increases abandonment."
+msgstr ""
+
+#: src/plugins/appstore-review.md:154
+msgid "Extension structure"
+msgstr ""
+
+#: src/plugins/appstore-review.md:156
+msgid ""
+"The extension follows the standard [native extension](native-extensions.md) "
+"layout:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:176
+msgid "One native function is declared in `package.json`:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:190
+msgid ""
+"The TypeScript layer wraps this into the public `requestReview()` function. "
+"The native layer creates a Perry promise, calls the platform API, and "
+"resolves the promise when done."
+msgstr ""
+
+#: src/plugins/appstore-review.md:194
+msgid ""
+"[Native Extensions](native-extensions.md) — How native extensions work, "
+"creating your own"
+msgstr ""
+
+#: src/plugins/appstore-review.md:195
+msgid "[iOS Platform](../platforms/ios.md) — iOS platform guide"
+msgstr ""
+
+#: src/plugins/appstore-review.md:196
+msgid "[Android Platform](../platforms/android.md) — Android platform guide"
+msgstr ""
+
+#: src/testing/geisterhand.md:1
+msgid "Geisterhand — In-Process UI Testing"
+msgstr ""
+
+#: src/testing/geisterhand.md:3
+msgid ""
+"Geisterhand (German for \"ghost hand\") embeds a lightweight HTTP server "
+"inside your Perry app that lets you interact with every widget "
+"programmatically. Click buttons, type into text fields, drag sliders, toggle"
+" switches, capture screenshots, and run chaos-mode random fuzzing — all via "
+"simple HTTP calls."
+msgstr ""
+
+#: src/testing/geisterhand.md:5
+msgid ""
+"It works on **all 5 native platforms** (macOS, iOS, Android, Linux/GTK4, "
+"Windows) with zero external dependencies. The server starts automatically "
+"when you compile with `--enable-geisterhand`."
+msgstr ""
+
+#: src/testing/geisterhand.md:12
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:14
+msgid "# 2. Run the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:16
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:18
+msgid "# 3. In another terminal — interact with the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:20
+msgid "# List all widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:21
+msgid "# Click button with handle 3\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:22
+msgid "# Capture window screenshot\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:25
+msgid "Custom Port"
+msgstr ""
+
+#: src/testing/geisterhand.md:27
+msgid ""
+"The default port is **7676**. Use `--geisterhand-port` to change it (this "
+"implies `--enable-geisterhand`, so you don't need both flags):"
+msgstr ""
+
+#: src/testing/geisterhand.md:30
+msgid "# or with perry run:\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:35
+msgid "With `perry run`"
+msgstr ""
+
+#: src/testing/geisterhand.md:47
+msgid ""
+"All endpoints return JSON unless noted otherwise. All responses include "
+"`Access-Control-Allow-Origin: *` for browser-based tools. OPTIONS requests "
+"are supported for CORS preflight."
+msgstr ""
+
+#: src/testing/geisterhand.md:49
+msgid "Health Check"
+msgstr ""
+
+#: src/testing/geisterhand.md:51
+msgid ""
+"```\n"
+"GET /health\n"
+"→ {\"status\":\"ok\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:56
+msgid "Use this to wait for the app to be ready before running tests."
+msgstr ""
+
+#: src/testing/geisterhand.md:58
+msgid "List Widgets"
+msgstr ""
+
+#: src/testing/geisterhand.md:64
+msgid "Returns a JSON array of all registered widgets:"
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"handle\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:458 src/testing/geisterhand.md:459
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"widget_type\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"callback_kind\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"label\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68
+msgid "\"Click Me\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+msgid "\"shortcut\""
+msgstr ""
+
+#: src/testing/geisterhand.md:69
+msgid "\"Type here...\""
+msgstr ""
+
+#: src/testing/geisterhand.md:71
+msgid "\"Enable\""
+msgstr ""
+
+#: src/testing/geisterhand.md:72
+msgid "\"Save\""
+msgstr ""
+
+#: src/testing/geisterhand.md:72
+msgid "\"s\""
+msgstr ""
+
+#: src/testing/geisterhand.md:77
+msgid "Supports query parameter filters:"
+msgstr ""
+
+#: src/testing/geisterhand.md:78
+msgid ""
+"`GET /widgets?label=Save` — filter by label substring (case-insensitive)"
+msgstr ""
+
+#: src/testing/geisterhand.md:79
+msgid "`GET /widgets?type=button` — filter by widget type name or code"
+msgstr ""
+
+#: src/testing/geisterhand.md:80
+msgid "`GET /widgets?label=Save&type=5` — combine filters"
+msgstr ""
+
+#: src/testing/geisterhand.md:82
+msgid "Widget Types"
+msgstr ""
+
+#: src/testing/geisterhand.md:84 src/testing/geisterhand.md:98
+msgid "Code"
+msgstr ""
+
+#: src/testing/geisterhand.md:86
+msgid "Push button with onClick"
+msgstr ""
+
+#: src/testing/geisterhand.md:87
+msgid "Text input field"
+msgstr ""
+
+#: src/testing/geisterhand.md:88
+msgid "Numeric slider"
+msgstr ""
+
+#: src/testing/geisterhand.md:89
+msgid "On/off switch"
+msgstr ""
+
+#: src/testing/geisterhand.md:90
+msgid "Dropdown selector"
+msgstr ""
+
+#: src/testing/geisterhand.md:91 src/testing/geisterhand.md:294
+msgid "Menu"
+msgstr ""
+
+#: src/testing/geisterhand.md:91
+msgid "Menu item"
+msgstr ""
+
+#: src/testing/geisterhand.md:92 src/cli/perry-toml.md:399
+msgid "6"
+msgstr ""
+
+#: src/testing/geisterhand.md:92
+msgid "Keyboard shortcut"
+msgstr ""
+
+#: src/testing/geisterhand.md:93
+msgid "Data table"
+msgstr ""
+
+#: src/testing/geisterhand.md:94
+msgid "8"
+msgstr ""
+
+#: src/testing/geisterhand.md:94
+msgid "Scrollable container"
+msgstr ""
+
+#: src/testing/geisterhand.md:96
+msgid "Callback Kinds"
+msgstr ""
+
+#: src/testing/geisterhand.md:98
+msgid "Kind"
+msgstr ""
+
+#: src/testing/geisterhand.md:100
+msgid "Triggered on click/tap"
+msgstr ""
+
+#: src/testing/geisterhand.md:101
+msgid "onChange"
+msgstr ""
+
+#: src/testing/geisterhand.md:101
+msgid "Triggered on value change"
+msgstr ""
+
+#: src/testing/geisterhand.md:102
+msgid "onSubmit"
+msgstr ""
+
+#: src/testing/geisterhand.md:102
+msgid "Triggered on submit (e.g., pressing Enter)"
+msgstr ""
+
+#: src/testing/geisterhand.md:103
+msgid "Triggered on mouse hover"
+msgstr ""
+
+#: src/testing/geisterhand.md:104
+msgid "Triggered on double-click"
+msgstr ""
+
+#: src/testing/geisterhand.md:105
+msgid "onFocus"
+msgstr ""
+
+#: src/testing/geisterhand.md:105
+msgid "Triggered on focus"
+msgstr ""
+
+#: src/testing/geisterhand.md:107
+msgid ""
+"A single widget may appear multiple times in the list with different "
+"callback kinds. For example, a button with both `onClick` and `onHover` "
+"handlers produces two entries (same handle, different `callback_kind`)."
+msgstr ""
+
+#: src/testing/geisterhand.md:109
+msgid "Click a Widget"
+msgstr ""
+
+#: src/testing/geisterhand.md:111
+msgid ""
+"```\n"
+"POST /click/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:116
+msgid ""
+"Fires the widget's `onClick` callback. Works with buttons, menu items, "
+"shortcuts, and table rows."
+msgstr ""
+
+#: src/testing/geisterhand.md:122
+msgid "Type into a TextField"
+msgstr ""
+
+#: src/testing/geisterhand.md:124
+msgid ""
+"```\n"
+"POST /type/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"text\": \"hello world\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:131
+msgid ""
+"Sets the text field's content and fires its `onChange` callback with the new"
+" text as a NaN-boxed string."
+msgstr ""
+
+#: src/testing/geisterhand.md:139
+msgid "Move a Slider"
+msgstr ""
+
+#: src/testing/geisterhand.md:141
+msgid ""
+"```\n"
+"POST /slide/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"value\": 0.75}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:148
+msgid "Sets the slider position and fires `onChange` with the numeric value."
+msgstr ""
+
+#: src/testing/geisterhand.md:156
+msgid "Toggle a Switch"
+msgstr ""
+
+#: src/testing/geisterhand.md:158
+msgid ""
+"```\n"
+"POST /toggle/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:163
+msgid "Fires the toggle's `onChange` callback with a boolean value."
+msgstr ""
+
+#: src/testing/geisterhand.md:169
+msgid "Set State Directly"
+msgstr ""
+
+#: src/testing/geisterhand.md:171
+msgid ""
+"```\n"
+"POST /state/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"value\": 42}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:178
+msgid ""
+"Directly sets a `State` cell's value, bypassing widget callbacks. This "
+"triggers any reactive bindings attached to the state (bound text labels, "
+"visibility, forEach loops, etc.)."
+msgstr ""
+
+#: src/testing/geisterhand.md:186
+msgid "Hover"
+msgstr ""
+
+#: src/testing/geisterhand.md:188
+msgid ""
+"```\n"
+"POST /hover/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:193
+msgid ""
+"Fires the widget's `onHover` callback. Useful for testing hover-dependent UI"
+" (tooltips, color changes, etc.)."
+msgstr ""
+
+#: src/testing/geisterhand.md:195
+msgid "Double-Click"
+msgstr ""
+
+#: src/testing/geisterhand.md:197
+msgid ""
+"```\n"
+"POST /doubleclick/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:202
+msgid "Fires the widget's `onDoubleClick` callback."
+msgstr ""
+
+#: src/testing/geisterhand.md:204
+msgid "Trigger Keyboard Shortcut"
+msgstr ""
+
+#: src/testing/geisterhand.md:206
+msgid ""
+"```\n"
+"POST /key\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"shortcut\": \"s\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:213
+msgid ""
+"Finds a registered menu item whose shortcut matches and fires its callback. "
+"Shortcut strings are case-insensitive and match the key string passed to "
+"`menuAddItem` (e.g., `\"s\"` for Cmd+S, `\"S\"` for Cmd+Shift+S, `\"n\"` for"
+" Cmd+N)."
+msgstr ""
+
+#: src/testing/geisterhand.md:221
+msgid ""
+"Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no "
+"match."
+msgstr ""
+
+#: src/testing/geisterhand.md:223
+msgid "Scroll a ScrollView"
+msgstr ""
+
+#: src/testing/geisterhand.md:225
+msgid ""
+"```\n"
+"POST /scroll/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"x\": 0, \"y\": 100}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:232
+msgid ""
+"Sets the scroll offset of a ScrollView widget. Both `x` and `y` are in "
+"points."
+msgstr ""
+
+#: src/testing/geisterhand.md:240
+msgid "Capture Screenshot"
+msgstr ""
+
+#: src/testing/geisterhand.md:247
+msgid ""
+"Captures the app window as a PNG image. The response is raw binary data, not"
+" JSON."
+msgstr ""
+
+#: src/testing/geisterhand.md:253
+msgid ""
+"Screenshot capture is synchronous from the caller's perspective — the HTTP "
+"request blocks until the main thread completes the capture (timeout: 5 "
+"seconds)."
+msgstr ""
+
+#: src/testing/geisterhand.md:255
+msgid "**Platform-specific capture methods:**"
+msgstr ""
+
+#: src/testing/geisterhand.md:259
+msgid "`CGWindowListCreateImage`"
+msgstr ""
+
+#: src/testing/geisterhand.md:259
+msgid "Retina resolution, reads from window ID"
+msgstr ""
+
+#: src/testing/geisterhand.md:260
+msgid "`UIGraphicsImageRenderer`"
+msgstr ""
+
+#: src/testing/geisterhand.md:260
+msgid "Draws view hierarchy into image context"
+msgstr ""
+
+#: src/testing/geisterhand.md:261
+msgid "JNI `View.draw()` on Canvas"
+msgstr ""
+
+#: src/testing/geisterhand.md:261
+msgid "Creates Bitmap, compresses to PNG"
+msgstr ""
+
+#: src/testing/geisterhand.md:262
+msgid "`WidgetPaintable` + `GskRenderer`"
+msgstr ""
+
+#: src/testing/geisterhand.md:262
+msgid "Renders to texture, saves as PNG bytes"
+msgstr ""
+
+#: src/testing/geisterhand.md:263
+msgid "`PrintWindow` + `GetDIBits`"
+msgstr ""
+
+#: src/testing/geisterhand.md:263
+msgid "Inline PNG encoder (stored zlib blocks)"
+msgstr ""
+
+#: src/testing/geisterhand.md:265
+msgid "Chaos Mode"
+msgstr ""
+
+#: src/testing/geisterhand.md:267
+msgid ""
+"Chaos mode randomly interacts with widgets at a configurable interval — "
+"useful for stress testing, finding edge cases, and crash hunting."
+msgstr ""
+
+#: src/testing/geisterhand.md:269
+msgid "Start"
+msgstr ""
+
+#: src/testing/geisterhand.md:271
+msgid ""
+"```\n"
+"POST /chaos/start\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"interval_ms\": 200}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:279
+msgid "# Fire random inputs every 200ms\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:285
+msgid ""
+"If `interval_ms` is omitted, a default interval is used. The chaos thread "
+"randomly selects a registered widget and fires an appropriate input based on"
+" widget type:"
+msgstr ""
+
+#: src/testing/geisterhand.md:287
+msgid "Widget Type"
+msgstr ""
+
+#: src/testing/geisterhand.md:287
+msgid "Random Input"
+msgstr ""
+
+#: src/testing/geisterhand.md:289 src/testing/geisterhand.md:294
+#: src/testing/geisterhand.md:295 src/testing/geisterhand.md:296
+msgid "Fires onClick (no args)"
+msgstr ""
+
+#: src/testing/geisterhand.md:290
+msgid "Random alphanumeric string, 5-20 characters"
+msgstr ""
+
+#: src/testing/geisterhand.md:291
+msgid "Random float between 0.0 and 1.0"
+msgstr ""
+
+#: src/testing/geisterhand.md:292
+msgid "Random true/false"
+msgstr ""
+
+#: src/testing/geisterhand.md:293
+msgid "Random index 0-9"
+msgstr ""
+
+#: src/testing/geisterhand.md:300
+msgid ""
+"```\n"
+"GET /chaos/status\n"
+"→ {\"running\":true,\"events_fired\":247,\"uptime_secs\":12}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:305
+msgid ""
+"Returns whether chaos mode is active, how many random events have been "
+"fired, and uptime in seconds."
+msgstr ""
+
+#: src/testing/geisterhand.md:307
+msgid "Stop"
+msgstr ""
+
+#: src/testing/geisterhand.md:309
+msgid ""
+"```\n"
+"POST /chaos/stop\n"
+"→ {\"ok\":true,\"chaos\":\"stopped\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:314
+msgid "Error Responses"
+msgstr ""
+
+#: src/testing/geisterhand.md:316
+msgid ""
+"All endpoints return errors as JSON with an appropriate HTTP status code:"
+msgstr ""
+
+#: src/testing/geisterhand.md:319
+msgid "\"widget handle 99 not found\""
+msgstr ""
+
+#: src/testing/geisterhand.md:322
+msgid "Common errors:"
+msgstr ""
+
+#: src/testing/geisterhand.md:323
+msgid "`404` — widget handle not found"
+msgstr ""
+
+#: src/testing/geisterhand.md:324
+msgid "`400` — malformed JSON body or missing required field"
+msgstr ""
+
+#: src/testing/geisterhand.md:325
+msgid "`405` — unsupported HTTP method"
+msgstr ""
+
+#: src/testing/geisterhand.md:329
+msgid "Platform Setup"
+msgstr ""
+
+#: src/testing/geisterhand.md:333
+msgid ""
+"No extra setup needed. The server binds to `0.0.0.0:7676` and is accessible "
+"on `localhost`."
+msgstr ""
+
+#: src/testing/geisterhand.md:343
+msgid ""
+"The iOS Simulator shares the host's network stack — access the server "
+"directly on `localhost`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:352 src/cli/flags.md:24
+msgid "iOS Device"
+msgstr ""
+
+#: src/testing/geisterhand.md:354
+msgid ""
+"For physical iOS devices, you need a network route to the device (same Wi-Fi"
+" network) or use `iproxy` from `libimobiledevice`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:357
+msgid "# Install and launch via Xcode/devicectl\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:359
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:363
+msgid "Android (Emulator or Device)"
+msgstr ""
+
+#: src/testing/geisterhand.md:365
+msgid ""
+"Use `adb forward` to bridge the port. Ensure `INTERNET` permission is in "
+"your manifest (or add it to `perry.toml`):"
+msgstr ""
+
+#: src/testing/geisterhand.md:367
+msgid ""
+"```toml\n"
+"[android]\n"
+"permissions = [\"INTERNET\"]\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:373
+msgid "# Package into APK and install\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:381
+msgid "Install GTK4 development libraries first:"
+msgstr ""
+
+#: src/testing/geisterhand.md:402
+msgid "Test Automation"
+msgstr ""
+
+#: src/testing/geisterhand.md:404
+msgid ""
+"Geisterhand turns your Perry app into a testable HTTP service. Here are "
+"practical patterns for automated testing."
+msgstr ""
+
+#: src/testing/geisterhand.md:406
+msgid "Shell Script Tests"
+msgstr ""
+
+#: src/testing/geisterhand.md:408
+msgid "A simple end-to-end test using bash:"
+msgstr ""
+
+#: src/testing/geisterhand.md:411
+msgid "#!/bin/bash\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:413
+msgid "# Build with geisterhand\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:416
+msgid "# Start the app in background\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:419
+msgid "$!"
+msgstr ""
+
+#: src/testing/geisterhand.md:420
+msgid "\"kill $APP_PID 2>/dev/null\""
+msgstr ""
+
+#: src/testing/geisterhand.md:421
+msgid "# Wait for the app to be ready\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:427
+msgid "# Get widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:430
+msgid "\"Registered widgets: $WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:431
+msgid "# Find the button labeled \"Submit\"\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
+msgstr ""
+
+#: src/testing/geisterhand.md:434
+msgid "# Click it\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:436
+msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
+msgstr ""
+
+#: src/testing/geisterhand.md:437
+msgid "# Take a screenshot after interaction\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:441
+msgid "\"Test passed\""
+msgstr ""
+
+#: src/testing/geisterhand.md:444
+msgid "Python Test Example"
+msgstr ""
+
+#: src/testing/geisterhand.md:448
+msgid "# Start the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:450
+msgid "\"./testapp\""
+msgstr ""
+
+#: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
+msgid "# Wait for startup\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:454
+msgid "# List widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:455
+msgid "\"http://127.0.0.1:7676/widgets\""
+msgstr ""
+
+#: src/testing/geisterhand.md:457
+msgid "# Find widgets by label\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:461
+msgid "# Type into the first text field\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:464
+msgid "\"http://127.0.0.1:7676/type/"
+msgstr ""
+
+#: src/testing/geisterhand.md:464 src/testing/geisterhand.md:470
+msgid "'handle'"
+msgstr ""
+
+#: src/testing/geisterhand.md:464 src/testing/geisterhand.md:470
+msgid "\""
+msgstr ""
+
+#: src/testing/geisterhand.md:465
+msgid "\"test@example.com\""
+msgstr ""
+
+#: src/testing/geisterhand.md:468
+msgid "# Click the first button\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:470
+msgid "\"http://127.0.0.1:7676/click/"
+msgstr ""
+
+#: src/testing/geisterhand.md:472
+msgid "# Capture screenshot for visual regression\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:473
+msgid "\"http://127.0.0.1:7676/screenshot\""
+msgstr ""
+
+#: src/testing/geisterhand.md:474
+msgid "\"test-result.png\""
+msgstr ""
+
+#: src/testing/geisterhand.md:474
+msgid "\"wb\""
+msgstr ""
+
+#: src/testing/geisterhand.md:477
+msgid "# Assert the app is still healthy\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"http://127.0.0.1:7676/health\""
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"status\""
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"ok\""
+msgstr ""
+
+#: src/testing/geisterhand.md:479
+msgid "\"All tests passed\""
+msgstr ""
+
+#: src/testing/geisterhand.md:484
+msgid "Stress Testing with Chaos Mode"
+msgstr ""
+
+#: src/testing/geisterhand.md:486
+msgid ""
+"Run chaos mode against your app to find crashes, freezes, or unexpected "
+"state:"
+msgstr ""
+
+#: src/testing/geisterhand.md:489
+msgid "# Build and launch\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:495
+msgid "# Start aggressive chaos (every 50ms)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:518
+msgid "Visual Regression Testing"
+msgstr ""
+
+#: src/testing/geisterhand.md:520
+msgid ""
+"Capture screenshots at key interaction points and compare against baselines:"
+msgstr ""
+
+#: src/testing/geisterhand.md:523
+msgid "# Initial state\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:525
+msgid "# Interact\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:528
+msgid "'{\"text\":\"Hello\"}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:529
+msgid "# Capture after interaction\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:532
+msgid "# Compare (using ImageMagick)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:537
+msgid "CI Pipeline Integration"
+msgstr ""
+
+#: src/testing/geisterhand.md:540
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr ""
+
+#: src/testing/geisterhand.md:542
+msgid "ui-test"
+msgstr ""
+
+#: src/testing/geisterhand.md:543
+msgid "runs-on"
+msgstr ""
+
+#: src/testing/geisterhand.md:543
+msgid "macos-latest"
+msgstr ""
+
+#: src/testing/geisterhand.md:544 src/cli/perry-toml.md:602
+msgid "steps"
+msgstr ""
+
+#: src/testing/geisterhand.md:545
+msgid "uses"
+msgstr ""
+
+#: src/testing/geisterhand.md:545
+msgid "actions/checkout@v4"
+msgstr ""
+
+#: src/testing/geisterhand.md:547 src/testing/geisterhand.md:550
+msgid "name"
+msgstr ""
+
+#: src/testing/geisterhand.md:547
+msgid "Build with geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:548 src/testing/geisterhand.md:551
+#: src/cli/commands.md:48 src/cli/perry-toml.md:604 src/cli/perry-toml.md:605
+#: src/cli/perry-toml.md:606
+msgid "run"
+msgstr ""
+
+#: src/testing/geisterhand.md:548
+msgid "perry app.ts -o testapp --enable-geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:550
+msgid "Run UI tests"
+msgstr ""
+
+#: src/testing/geisterhand.md:554
+msgid "# Run your test script\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:568
+msgid "Example App"
+msgstr ""
+
+#: src/testing/geisterhand.md:570
+msgid ""
+"A complete Perry UI app demonstrating every widget type Geisterhand can "
+"interact with — verified by CI:"
+msgstr ""
+
+#: src/testing/geisterhand.md:573
+msgid ""
+"```typescript\n"
+"// demonstrates: Geisterhand-targetable Perry UI app — every common widget\n"
+"// docs: docs/src/testing/geisterhand.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"// A complete Perry UI app exercising every widget type Geisterhand\n"
+"// (the UI fuzzer) can interact with. The doc-tests harness compiles\n"
+"// and runs this on every PR, so the snippet on the docs page can never\n"
+"// drift from the real perry/ui API.\n"
+"\n"
+"import {\n"
+"    App, VStack, HStack,\n"
+"    Text, Button, TextField, Slider, Toggle, Picker,\n"
+"    State, stateOnChange,\n"
+"    pickerAddItem,\n"
+"    textSetString,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// State for reactive UI\n"
+"const counterState = State(0)\n"
+"const textState = State(\"\")\n"
+"\n"
+"// Labels\n"
+"const title = Text(\"Geisterhand Demo\")\n"
+"const counterLabel = Text(\"Count: 0\")\n"
+"\n"
+"// Bind counter state to label via the free-function listener\n"
+"stateOnChange(counterState, (val: number) => {\n"
+"    textSetString(counterLabel, `Count: ${val}`)\n"
+"})\n"
+"\n"
+"// Button — widget_type = 0\n"
+"const incrementBtn = Button(\"Increment\", () => {\n"
+"    counterState.set(counterState.value + 1)\n"
+"})\n"
+"const resetBtn = Button(\"Reset\", () => {\n"
+"    counterState.set(0)\n"
+"})\n"
+"\n"
+"// TextField(placeholder, onChange) — widget_type = 1\n"
+"const nameField = TextField(\"Enter your name\", (text: string) => {\n"
+"    textState.set(text)\n"
+"    console.log(`Name: ${text}`)\n"
+"})\n"
+"\n"
+"// Slider(min, max, onChange) — widget_type = 2\n"
+"const volumeSlider = Slider(0, 100, (value: number) => {\n"
+"    console.log(`Volume: ${value}`)\n"
+"})\n"
+"\n"
+"// Toggle(label, onChange) — widget_type = 3\n"
+"const darkModeToggle = Toggle(\"Dark Mode\", (on: boolean) => {\n"
+"    console.log(`Dark mode: ${on}`)\n"
+"})\n"
+"\n"
+"// Picker(onChange); items added with pickerAddItem.\n"
+"const sizePicker = Picker((index: number) => {\n"
+"    console.log(`Size index: ${index}`)\n"
+"})\n"
+"pickerAddItem(sizePicker, \"Small\")\n"
+"pickerAddItem(sizePicker, \"Medium\")\n"
+"pickerAddItem(sizePicker, \"Large\")\n"
+"\n"
+"// Layout\n"
+"const buttonRow = HStack(8, [incrementBtn, resetBtn])\n"
+"const stack = VStack(12, [\n"
+"    title, counterLabel, buttonRow,\n"
+"    nameField, volumeSlider, darkModeToggle, sizePicker,\n"
+"])\n"
+"\n"
+"App({\n"
+"    title: \"Geisterhand Demo\",\n"
+"    width: 400,\n"
+"    height: 480,\n"
+"    body: stack,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:651
+msgid "After compiling with `--enable-geisterhand` and running:"
+msgstr ""
+
+#: src/testing/geisterhand.md:654
+msgid "# See all interactive widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:655
+msgid "# [\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:657
+msgid "\"Increment\""
+msgstr ""
+
+#: src/testing/geisterhand.md:657
+msgid "#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:659
+msgid "\"Enter your name\""
+msgstr ""
+
+#: src/testing/geisterhand.md:659
+msgid "#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:661
+msgid "\"Dark Mode\""
+msgstr ""
+
+#: src/testing/geisterhand.md:661
+msgid "# ]\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:663
+msgid "# Click Increment 3 times\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:665
+msgid "# Counter label now shows \"Count: 3\"\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:667
+msgid "# Type a name\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:669
+msgid "'{\"text\":\"Perry\"}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:670
+msgid "# Set slider to 80%\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:672
+msgid "'{\"value\":0.8}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:673
+msgid "# Toggle dark mode on\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:676
+msgid "# Screenshot\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:685
+msgid ""
+"Geisterhand operates as three cooperating components connected by thread-"
+"safe queues:"
+msgstr ""
+
+#: src/testing/geisterhand.md:729
+msgid "Lifecycle"
+msgstr ""
+
+#: src/testing/geisterhand.md:731
+msgid ""
+"**Startup**: When `--enable-geisterhand` is used, the compiled binary calls "
+"`perry_geisterhand_start(port)` during initialization. This spawns a "
+"background thread running a `tiny-http` server."
+msgstr ""
+
+#: src/testing/geisterhand.md:733
+msgid ""
+"**Widget Registration**: As UI widgets are created (Button, TextField, "
+"Slider, etc.), each one calls `perry_geisterhand_register(handle, "
+"widget_type, callback_kind, closure_f64, label)` to register its callback in"
+" the global registry. This is gated behind `#[cfg(feature = "
+"\"geisterhand\")]` so normal builds have zero overhead."
+msgstr ""
+
+#: src/testing/geisterhand.md:735
+msgid ""
+"**HTTP Requests**: When a request arrives (e.g., `POST /click/3`), the "
+"server looks up handle 3 in the registry, finds the associated closure, and "
+"pushes a `PendingAction::InvokeCallback` onto the pending actions queue."
+msgstr ""
+
+#: src/testing/geisterhand.md:737
+msgid ""
+"**Main-Thread Dispatch**: The platform's timer (NSTimer on macOS, glib "
+"timeout on GTK4, WM_TIMER on Windows, etc.) calls `perry_geisterhand_pump()`"
+" every ~8ms. This drains the pending actions queue and executes callbacks on"
+" the main thread, which is required for UI safety."
+msgstr ""
+
+#: src/testing/geisterhand.md:739
+msgid ""
+"**Screenshot Capture**: Screenshots use `Condvar` synchronization — the HTTP"
+" thread queues a `CaptureScreenshot` action, then blocks waiting on a "
+"condition variable. The main thread's pump executes the platform-specific "
+"capture, stores the PNG data, and signals the condvar. Timeout: 5 seconds."
+msgstr ""
+
+#: src/testing/geisterhand.md:741
+msgid "Thread Safety"
+msgstr ""
+
+#: src/testing/geisterhand.md:743
+msgid ""
+"**Widget Registry**: Protected by `Mutex`. Read by the HTTP server (to list "
+"widgets and look up handles), written by the main thread (during widget "
+"creation)."
+msgstr ""
+
+#: src/testing/geisterhand.md:744
+msgid ""
+"**Pending Actions Queue**: Protected by `Mutex`. Written by HTTP server "
+"thread, drained by main thread in `pump()`."
+msgstr ""
+
+#: src/testing/geisterhand.md:745
+msgid ""
+"**Screenshot Result**: Protected by `Mutex` + `Condvar`. HTTP thread waits, "
+"main thread signals."
+msgstr ""
+
+#: src/testing/geisterhand.md:746
+msgid ""
+"**Chaos Mode State**: Uses `AtomicBool` (running flag) and `AtomicU64` "
+"(event counter) for lock-free status checks."
+msgstr ""
+
+#: src/testing/geisterhand.md:748
+msgid "NaN-Boxing Bridge"
+msgstr ""
+
+#: src/testing/geisterhand.md:750
+msgid ""
+"When geisterhand needs to pass values to widget callbacks, it must create "
+"properly NaN-boxed values:"
+msgstr ""
+
+#: src/testing/geisterhand.md:752
+msgid ""
+"**Strings** (for TextField): Calls `js_string_from_bytes(ptr, len)` to "
+"allocate a runtime string, then `js_nanbox_string(ptr)` to wrap it with "
+"STRING_TAG (0x7FFF)."
+msgstr ""
+
+#: src/testing/geisterhand.md:753
+msgid ""
+"**Numbers** (for Slider): Passes the raw `f64` value directly (numbers are "
+"their own NaN-boxed representation)."
+msgstr ""
+
+#: src/testing/geisterhand.md:754
+msgid ""
+"**Booleans** (for Toggle/chaos): Uses `TAG_TRUE` (0x7FFC000000000004) or "
+"`TAG_FALSE` (0x7FFC000000000003)."
+msgstr ""
+
+#: src/testing/geisterhand.md:758
+msgid "Build Details"
+msgstr ""
+
+#: src/testing/geisterhand.md:760
+msgid "Auto-Build"
+msgstr ""
+
+#: src/testing/geisterhand.md:762
+msgid ""
+"When you pass `--enable-geisterhand` (or `--geisterhand-port`), Perry "
+"automatically builds the required libraries on first use if they're not "
+"already cached:"
+msgstr ""
+
+#: src/testing/geisterhand.md:771
+msgid "Platform crate selection is automatic based on `--target`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:773 src/cli/flags.md:20
+msgid "Target"
+msgstr ""
+
+#: src/testing/geisterhand.md:773
+msgid "UI Crate"
+msgstr ""
+
+#: src/testing/geisterhand.md:775
+msgid "(default/macOS)"
+msgstr ""
+
+#: src/testing/geisterhand.md:775 src/contributing/architecture.md:37
+msgid "`perry-ui-macos`"
+msgstr ""
+
+#: src/testing/geisterhand.md:776
+msgid "`ios` / `ios-simulator`"
+msgstr ""
+
+#: src/testing/geisterhand.md:776 src/contributing/architecture.md:38
+msgid "`perry-ui-ios`"
+msgstr ""
+
+#: src/testing/geisterhand.md:777 src/cli/commands.md:66
+#: src/cli/commands.md:238 src/cli/flags.md:27
+msgid "`android`"
+msgstr ""
+
+#: src/testing/geisterhand.md:777
+msgid "`perry-ui-android`"
+msgstr ""
+
+#: src/testing/geisterhand.md:778 src/cli/commands.md:239 src/cli/flags.md:37
+msgid "`linux`"
+msgstr ""
+
+#: src/testing/geisterhand.md:778
+msgid "`perry-ui-gtk4`"
+msgstr ""
+
+#: src/testing/geisterhand.md:779 src/cli/flags.md:36
+msgid "`windows`"
+msgstr ""
+
+#: src/testing/geisterhand.md:779
+msgid "`perry-ui-windows`"
+msgstr ""
+
+#: src/testing/geisterhand.md:781
+msgid "Separate Target Directory"
+msgstr ""
+
+#: src/testing/geisterhand.md:783
+msgid ""
+"Geisterhand libraries are built into `target/geisterhand/` (via "
+"`CARGO_TARGET_DIR`) to avoid interfering with normal builds. This means your"
+" first geisterhand build takes a moment, but subsequent builds reuse the "
+"cached libraries."
+msgstr ""
+
+#: src/testing/geisterhand.md:785
+msgid "Feature Flags"
+msgstr ""
+
+#: src/testing/geisterhand.md:787
+msgid ""
+"All geisterhand code is behind `#[cfg(feature = \"geisterhand\")]` feature "
+"gates:"
+msgstr ""
+
+#: src/testing/geisterhand.md:789
+msgid ""
+"**`perry-runtime/geisterhand`**: Compiles the `geisterhand_registry` module "
+"— widget registry, action queue, pump function, screenshot coordination."
+msgstr ""
+
+#: src/testing/geisterhand.md:790
+msgid ""
+"**`perry-ui-{platform}/geisterhand`**: Adds `perry_geisterhand_register()` "
+"calls to widget constructors and `perry_geisterhand_pump()` to the platform "
+"timer."
+msgstr ""
+
+#: src/testing/geisterhand.md:792
+msgid ""
+"When the feature is not enabled, no geisterhand code is compiled — zero "
+"binary size overhead and zero runtime cost."
+msgstr ""
+
+#: src/testing/geisterhand.md:794
+msgid "Linking"
+msgstr ""
+
+#: src/testing/geisterhand.md:796
+msgid "The compiled binary links three additional static libraries:"
+msgstr ""
+
+#: src/testing/geisterhand.md:797
+msgid ""
+"`libperry_runtime.a` (geisterhand-featured build, replaces the normal "
+"runtime)"
+msgstr ""
+
+#: src/testing/geisterhand.md:798
+msgid ""
+"`libperry_ui_{platform}.a` (geisterhand-featured build, replaces the normal "
+"UI lib)"
+msgstr ""
+
+#: src/testing/geisterhand.md:799
+msgid "`libperry_ui_geisterhand.a` (HTTP server + chaos mode)"
+msgstr ""
+
+#: src/testing/geisterhand.md:801
+msgid "Manual Build"
+msgstr ""
+
+#: src/testing/geisterhand.md:803
+msgid "If auto-build fails or you want to cross-compile manually:"
+msgstr ""
+
+#: src/testing/geisterhand.md:806
+msgid "# Build geisterhand libs for macOS\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:807
+msgid "target/geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:822
+msgid "Security"
+msgstr ""
+
+#: src/testing/geisterhand.md:824
+msgid ""
+"Geisterhand binds to `0.0.0.0` on the configured port (default 7676). This "
+"means it is **accessible from the local network** — any device on the same "
+"network can interact with your app, capture screenshots, or trigger chaos "
+"mode."
+msgstr ""
+
+#: src/testing/geisterhand.md:826
+msgid ""
+"**Do not ship geisterhand-enabled binaries to production or to end users.**"
+msgstr ""
+
+#: src/testing/geisterhand.md:828
+msgid ""
+"Geisterhand is a development and testing tool only. The feature-gate system "
+"ensures it cannot accidentally be included in normal builds — you must "
+"explicitly pass `--enable-geisterhand` or `--geisterhand-port`."
+msgstr ""
+
+#: src/testing/geisterhand.md:832
+msgid "Troubleshooting"
+msgstr ""
+
+#: src/testing/geisterhand.md:834
+msgid "\"Connection refused\" on port 7676"
+msgstr ""
+
+#: src/testing/geisterhand.md:836
+msgid ""
+"Ensure you compiled with `--enable-geisterhand` or `--geisterhand-port`"
+msgstr ""
+
+#: src/testing/geisterhand.md:837
+msgid ""
+"Check that the app has fully started (look for `[geisterhand] listening "
+"on...` in stderr)"
+msgstr ""
+
+#: src/testing/geisterhand.md:838
+msgid "Verify the port isn't in use by another process: `lsof -i :7676`"
+msgstr ""
+
+#: src/testing/geisterhand.md:840
+msgid "Widget handles not found"
+msgstr ""
+
+#: src/testing/geisterhand.md:842
+msgid ""
+"Handles are assigned at widget creation time. If you query `/widgets` before"
+" the UI is fully constructed, some widgets may not be registered yet."
+msgstr ""
+
+#: src/testing/geisterhand.md:843
+msgid "Wait for `GET /health` to return `{\"status\":\"ok\"}` before interacting."
+msgstr ""
+
+#: src/testing/geisterhand.md:845
+msgid "Screenshot returns empty data"
+msgstr ""
+
+#: src/testing/geisterhand.md:847
+msgid ""
+"Screenshot capture has a 5-second timeout. If the main thread is blocked "
+"(e.g., by a long-running synchronous operation), the screenshot will time "
+"out and return empty data."
+msgstr ""
+
+#: src/testing/geisterhand.md:848
+msgid ""
+"On macOS, ensure the app has a visible window (minimized windows may not "
+"capture correctly)."
+msgstr ""
+
+#: src/testing/geisterhand.md:850
+msgid "Auto-build fails"
+msgstr ""
+
+#: src/testing/geisterhand.md:852
+msgid "Ensure you have a working Rust toolchain (`rustup show`)"
+msgstr ""
+
+#: src/testing/geisterhand.md:853
+msgid ""
+"For cross-compilation targets, install the appropriate target: `rustup "
+"target add aarch64-apple-ios`"
+msgstr ""
+
+#: src/testing/geisterhand.md:854
+msgid ""
+"Check that the Perry source tree is accessible (auto-build searches upward "
+"from the `perry` executable for the workspace root)"
+msgstr ""
+
+#: src/testing/geisterhand.md:856
+msgid "Chaos mode crashes the app"
+msgstr ""
+
+#: src/testing/geisterhand.md:858
+msgid ""
+"That's the point — chaos mode found a bug. Check the app's stderr output for"
+" panic messages or stack traces. Common causes:"
+msgstr ""
+
+#: src/testing/geisterhand.md:859
+msgid ""
+"Callback handlers that assume valid state but receive unexpected values"
+msgstr ""
+
+#: src/testing/geisterhand.md:860
+msgid "Missing null checks on state values"
+msgstr ""
+
+#: src/testing/geisterhand.md:861
+msgid "Race conditions in state updates"
+msgstr ""
+
+#: src/cli/commands.md:1
+msgid "CLI Commands"
+msgstr ""
+
+#: src/cli/commands.md:3
+msgid ""
+"Perry provides 11 commands for compiling, checking, running, publishing, and"
+" managing your projects."
+msgstr ""
+
+#: src/cli/commands.md:5
+msgid ""
+"See also: [perry.toml Reference](perry-toml.md) for project configuration."
+msgstr ""
+
+#: src/cli/commands.md:7
+msgid "compile"
+msgstr ""
+
+#: src/cli/commands.md:9
+msgid "Compile TypeScript to a native executable."
+msgstr ""
+
+#: src/cli/commands.md:12
+msgid "# Or shorthand (auto-detects compile):\n"
+msgstr ""
+
+#: src/cli/commands.md:17 src/cli/commands.md:109 src/cli/commands.md:148
+#: src/cli/commands.md:181 src/cli/commands.md:195 src/cli/commands.md:248
+#: src/cli/commands.md:260 src/cli/flags.md:9 src/cli/flags.md:50
+#: src/cli/flags.md:58 src/cli/flags.md:66 src/cli/flags.md:73
+msgid "Flag"
+msgstr ""
+
+#: src/cli/commands.md:19 src/cli/commands.md:111 src/cli/commands.md:243
+msgid "`-o, --output <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:19
+msgid "Output file path"
+msgstr ""
+
+#: src/cli/commands.md:20
+msgid "`--target <TARGET>`"
+msgstr ""
+
+#: src/cli/commands.md:20
+msgid "Platform target (see [Compiler Flags](flags.md))"
+msgstr ""
+
+#: src/cli/commands.md:21
+msgid "`--output-type <TYPE>`"
+msgstr ""
+
+#: src/cli/commands.md:21
+msgid "`executable` (default) or `dylib` (plugin)"
+msgstr ""
+
+#: src/cli/commands.md:22 src/cli/flags.md:52
+msgid "`--print-hir`"
+msgstr ""
+
+#: src/cli/commands.md:22
+msgid "Print HIR intermediate representation"
+msgstr ""
+
+#: src/cli/commands.md:23 src/cli/flags.md:53
+msgid "`--no-link`"
+msgstr ""
+
+#: src/cli/commands.md:23
+msgid "Produce object file only, skip linking"
+msgstr ""
+
+#: src/cli/commands.md:24 src/cli/flags.md:54
+msgid "`--keep-intermediates`"
+msgstr ""
+
+#: src/cli/commands.md:24
+msgid "Keep `.o` and `.asm` files"
+msgstr ""
+
+#: src/cli/commands.md:25 src/cli/commands.md:71 src/cli/flags.md:75
+msgid "`--enable-js-runtime`"
+msgstr ""
+
+#: src/cli/commands.md:25
+msgid "Enable V8 JavaScript runtime fallback"
+msgstr ""
+
+#: src/cli/commands.md:26 src/cli/commands.md:72 src/cli/flags.md:76
+msgid "`--type-check`"
+msgstr ""
+
+#: src/cli/commands.md:26 src/cli/commands.md:72
+msgid "Enable type checking via tsgo"
+msgstr ""
+
+#: src/cli/commands.md:27 src/cli/flags.md:60
+msgid "`--minify`"
+msgstr ""
+
+#: src/cli/commands.md:27 src/cli/flags.md:60
+msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
+msgstr ""
+
+#: src/cli/commands.md:28
+msgid "`--app-bundle-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:28
+msgid "Bundle ID (required for widget targets)"
+msgstr ""
+
+#: src/cli/commands.md:29
+msgid "`--bundle-extensions <DIR>`"
+msgstr ""
+
+#: src/cli/commands.md:29
+msgid "Bundle TypeScript extensions from directory"
+msgstr ""
+
+#: src/cli/commands.md:32
+msgid "# Basic compilation\n"
+msgstr ""
+
+#: src/cli/commands.md:34
+msgid "# Cross-compile for iOS Simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:37
+msgid "# Build a plugin\n"
+msgstr ""
+
+#: src/cli/commands.md:40
+msgid "# Debug: view intermediate representation\n"
+msgstr ""
+
+#: src/cli/commands.md:43
+msgid "# Build an iOS widget\n"
+msgstr ""
+
+#: src/cli/commands.md:50
+msgid "Compile and launch your app in one step."
+msgstr ""
+
+#: src/cli/commands.md:53
+msgid "# Auto-detect entry file\n"
+msgstr ""
+
+#: src/cli/commands.md:54
+msgid "# Run on iOS device/simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:55
+msgid "# Run on Apple Vision Pro simulator/device\n"
+msgstr ""
+
+#: src/cli/commands.md:56
+msgid "# Run on Android device\n"
+msgstr ""
+
+#: src/cli/commands.md:57
+msgid "# Forward args to your program\n"
+msgstr ""
+
+#: src/cli/commands.md:60 src/cli/commands.md:233
+msgid "Argument / Flag"
+msgstr ""
+
+#: src/cli/commands.md:62 src/cli/commands.md:236 src/cli/flags.md:24
+msgid "`ios`"
+msgstr ""
+
+#: src/cli/commands.md:62
+msgid "Target iOS (device or simulator)"
+msgstr ""
+
+#: src/cli/commands.md:63 src/cli/commands.md:237 src/cli/flags.md:26
+msgid "`visionos`"
+msgstr ""
+
+#: src/cli/commands.md:63
+msgid "Target visionOS (device or simulator)"
+msgstr ""
+
+#: src/cli/commands.md:64 src/cli/commands.md:235
+msgid "`macos`"
+msgstr ""
+
+#: src/cli/commands.md:64
+msgid "Target macOS (default on macOS host)"
+msgstr ""
+
+#: src/cli/commands.md:65 src/cli/flags.md:35
+msgid "`web`"
+msgstr ""
+
+#: src/cli/commands.md:65
+msgid "Target web (opens in browser)"
+msgstr ""
+
+#: src/cli/commands.md:66
+msgid "Target Android device"
+msgstr ""
+
+#: src/cli/commands.md:67
+msgid "`--simulator <UDID>`"
+msgstr ""
+
+#: src/cli/commands.md:67
+msgid "Specify iOS simulator by UDID"
+msgstr ""
+
+#: src/cli/commands.md:68
+msgid "`--device <UDID>`"
+msgstr ""
+
+#: src/cli/commands.md:68
+msgid "Specify iOS physical device by UDID"
+msgstr ""
+
+#: src/cli/commands.md:69
+msgid "`--local`"
+msgstr ""
+
+#: src/cli/commands.md:69
+msgid "Force local compilation (no remote fallback)"
+msgstr ""
+
+#: src/cli/commands.md:70
+msgid "`--remote`"
+msgstr ""
+
+#: src/cli/commands.md:70
+msgid "Force remote build via Perry Hub"
+msgstr ""
+
+#: src/cli/commands.md:71
+msgid "Enable V8 JavaScript runtime"
+msgstr ""
+
+#: src/cli/commands.md:73 src/cli/commands.md:113
+msgid "`--`"
+msgstr ""
+
+#: src/cli/commands.md:73
+msgid "Separator for program arguments"
+msgstr ""
+
+#: src/cli/commands.md:75
+msgid "**Entry file detection** (checked in order):"
+msgstr ""
+
+#: src/cli/commands.md:76
+msgid "`perry.toml` → `[project] entry` field"
+msgstr ""
+
+#: src/cli/commands.md:77
+msgid "`src/main.ts`"
+msgstr ""
+
+#: src/cli/commands.md:78
+msgid "`main.ts`"
+msgstr ""
+
+#: src/cli/commands.md:80
+msgid ""
+"**Device detection**: When targeting iOS, Perry auto-discovers available "
+"simulators (via `simctl`) and physical devices (via `devicectl`). For "
+"Android, it uses `adb`. When multiple targets are found, an interactive "
+"prompt lets you choose."
+msgstr ""
+
+#: src/cli/commands.md:82
+msgid ""
+"**Remote build fallback**: If cross-compilation toolchains aren't installed "
+"locally (e.g., Apple mobile targets on a machine without Xcode), `perry run "
+"ios` and `perry run visionos` can fall back to Perry Hub's build server when"
+" the backend supports the target. Use `--local` or `--remote` to force "
+"either path."
+msgstr ""
+
+#: src/cli/commands.md:85
+msgid "# Run a CLI program\n"
+msgstr ""
+
+#: src/cli/commands.md:87
+msgid "# Run on a specific simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:90
+msgid "# Force remote build\n"
+msgstr ""
+
+#: src/cli/commands.md:93
+msgid "# Run web target\n"
+msgstr ""
+
+#: src/cli/commands.md:98
+msgid "dev"
+msgstr ""
+
+#: src/cli/commands.md:100
+msgid ""
+"Watch your TypeScript source tree and auto-recompile + relaunch on every "
+"save."
+msgstr ""
+
+#: src/cli/commands.md:103
+msgid "# watch + rebuild + relaunch on save\n"
+msgstr ""
+
+#: src/cli/commands.md:104
+msgid "# forward args to the child\n"
+msgstr ""
+
+#: src/cli/commands.md:105
+msgid "# watch an extra directory\n"
+msgstr ""
+
+#: src/cli/commands.md:106
+msgid "# override output path\n"
+msgstr ""
+
+#: src/cli/commands.md:111
+msgid "Output binary path (default: `.perry-dev/<entry-stem>`)"
+msgstr ""
+
+#: src/cli/commands.md:112
+msgid "`--watch <DIR>`"
+msgstr ""
+
+#: src/cli/commands.md:112
+msgid "Extra directories to watch (comma-separated or repeated)"
+msgstr ""
+
+#: src/cli/commands.md:113
+msgid "Separator — everything after is forwarded to the compiled binary"
+msgstr ""
+
+#: src/cli/commands.md:115
+msgid "**How it works:**"
+msgstr ""
+
+#: src/cli/commands.md:117
+msgid ""
+"Resolves the entry, computes the **project root** (walks up until it finds a"
+" `package.json` or `perry.toml`; falls back to the entry's parent "
+"directory)."
+msgstr ""
+
+#: src/cli/commands.md:118
+msgid ""
+"Does an initial `perry compile`, then spawns the resulting binary with stdio"
+" inherited."
+msgstr ""
+
+#: src/cli/commands.md:119
+msgid ""
+"Watches the project root (plus any `--watch` dirs) recursively using the "
+"`notify` crate. A 300 ms **debounce** window collapses editor \"save "
+"storms\" into one rebuild."
+msgstr ""
+
+#: src/cli/commands.md:120
+msgid ""
+"On each relevant change: kill the running child, recompile, relaunch. A "
+"failed build leaves the old child dead and waits for the next change; no "
+"crash loop."
+msgstr ""
+
+#: src/cli/commands.md:122
+msgid "**What counts as a \"relevant\" change:**"
+msgstr ""
+
+#: src/cli/commands.md:123
+msgid ""
+"**Trigger extensions:** `.ts`, `.tsx`, `.mts`, `.cts`, `.json`, `.toml`"
+msgstr ""
+
+#: src/cli/commands.md:124
+msgid ""
+"**Ignored directories (not watched, never retrigger):** `node_modules`, "
+"`target`, `.git`, `dist`, `build`, `.perry-dev`, `.perry-cache`"
+msgstr ""
+
+#: src/cli/commands.md:126
+msgid "**Benchmarks** (trivial single-file program, macOS):"
+msgstr ""
+
+#: src/cli/commands.md:128
+msgid "Phase"
+msgstr ""
+
+#: src/cli/commands.md:128
+msgid "Time"
+msgstr ""
+
+#: src/cli/commands.md:130
+msgid "Initial build (cold — runtime + stdlib rebuilt by auto-optimize)"
+msgstr ""
+
+#: src/cli/commands.md:130
+msgid "~15 s"
+msgstr ""
+
+#: src/cli/commands.md:131
+msgid "Post-edit rebuild (hot libs cached on disk)"
+msgstr ""
+
+#: src/cli/commands.md:131
+msgid "**~330 ms**"
+msgstr ""
+
+#: src/cli/commands.md:133
+msgid ""
+"The speedup on hot rebuilds comes from Perry's existing auto-optimize "
+"library cache. Multi-module projects will still recompile every changed "
+"module on each save — see the V2 note below for planned incremental work."
+msgstr ""
+
+#: src/cli/commands.md:135
+msgid "**Not yet in scope (V2+):**"
+msgstr ""
+
+#: src/cli/commands.md:136
+msgid "In-memory AST cache (reuse SWC parses across rebuilds)."
+msgstr ""
+
+#: src/cli/commands.md:137
+msgid "Per-module `.o` cache on disk (only re-codegen the changed module)."
+msgstr ""
+
+#: src/cli/commands.md:138
+msgid ""
+"State preservation across rebuilds / HMR — \"fast restart\" is the honest "
+"target."
+msgstr ""
+
+#: src/cli/commands.md:140
+msgid "check"
+msgstr ""
+
+#: src/cli/commands.md:142
+msgid "Validate TypeScript for Perry compatibility without compiling."
+msgstr ""
+
+#: src/cli/commands.md:150
+msgid "`--check-deps`"
+msgstr ""
+
+#: src/cli/commands.md:150
+msgid "Check `node_modules` for compatibility"
+msgstr ""
+
+#: src/cli/commands.md:151
+msgid "`--deep-deps`"
+msgstr ""
+
+#: src/cli/commands.md:151
+msgid "Scan all transitive dependencies"
+msgstr ""
+
+#: src/cli/commands.md:152
+msgid "`--all`"
+msgstr ""
+
+#: src/cli/commands.md:152
+msgid "Show all issues including hints"
+msgstr ""
+
+#: src/cli/commands.md:153
+msgid "`--strict`"
+msgstr ""
+
+#: src/cli/commands.md:153
+msgid "Treat warnings as errors"
+msgstr ""
+
+#: src/cli/commands.md:154
+msgid "`--fix`"
+msgstr ""
+
+#: src/cli/commands.md:154
+msgid "Automatically apply fixes"
+msgstr ""
+
+#: src/cli/commands.md:155
+msgid "`--fix-dry-run`"
+msgstr ""
+
+#: src/cli/commands.md:155
+msgid "Preview fixes without modifying files"
+msgstr ""
+
+#: src/cli/commands.md:156
+msgid "`--fix-unsafe`"
+msgstr ""
+
+#: src/cli/commands.md:156
+msgid "Include medium-confidence fixes"
+msgstr ""
+
+#: src/cli/commands.md:159
+msgid "# Check a single file\n"
+msgstr ""
+
+#: src/cli/commands.md:161
+msgid "# Check with dependency analysis\n"
+msgstr ""
+
+#: src/cli/commands.md:164
+msgid "# Auto-fix issues\n"
+msgstr ""
+
+#: src/cli/commands.md:167
+msgid "# Preview fixes without applying\n"
+msgstr ""
+
+#: src/cli/commands.md:172
+msgid "init"
+msgstr ""
+
+#: src/cli/commands.md:174
+msgid "Create a new Perry project."
+msgstr ""
+
+#: src/cli/commands.md:183
+msgid "`--name <NAME>`"
+msgstr ""
+
+#: src/cli/commands.md:183
+msgid "Project name (defaults to directory name)"
+msgstr ""
+
+#: src/cli/commands.md:185
+msgid "Creates `perry.toml`, `src/main.ts`, and `.gitignore`."
+msgstr ""
+
+#: src/cli/commands.md:187
+msgid "doctor"
+msgstr ""
+
+#: src/cli/commands.md:189
+msgid "Check your Perry installation and environment."
+msgstr ""
+
+#: src/cli/commands.md:197
+msgid "`--quiet`"
+msgstr ""
+
+#: src/cli/commands.md:197
+msgid "Only report failures"
+msgstr ""
+
+#: src/cli/commands.md:199
+msgid "Checks:"
+msgstr ""
+
+#: src/cli/commands.md:200
+msgid "Perry version"
+msgstr ""
+
+#: src/cli/commands.md:201
+msgid "System linker availability (cc/MSVC)"
+msgstr ""
+
+#: src/cli/commands.md:202
+msgid "Runtime library"
+msgstr ""
+
+#: src/cli/commands.md:203
+msgid "Project configuration"
+msgstr ""
+
+#: src/cli/commands.md:204
+msgid "Available updates"
+msgstr ""
+
+#: src/cli/commands.md:206
+msgid "explain"
+msgstr ""
+
+#: src/cli/commands.md:208
+msgid "Get detailed explanations for error codes."
+msgstr ""
+
+#: src/cli/commands.md:214
+msgid "Error code families:"
+msgstr ""
+
+#: src/cli/commands.md:215
+msgid "**P** — Parse errors"
+msgstr ""
+
+#: src/cli/commands.md:216
+msgid "**T** — Type errors"
+msgstr ""
+
+#: src/cli/commands.md:217
+msgid "**U** — Unsupported features"
+msgstr ""
+
+#: src/cli/commands.md:218
+msgid "**D** — Dependency issues"
+msgstr ""
+
+#: src/cli/commands.md:220
+msgid ""
+"Each explanation includes the error description, example code, and suggested"
+" fix."
+msgstr ""
+
+#: src/cli/commands.md:222
+msgid "publish"
+msgstr ""
+
+#: src/cli/commands.md:224
+msgid "Build, sign, and distribute your app."
+msgstr ""
+
+#: src/cli/commands.md:235
+msgid "Build for macOS (App Store/notarization)"
+msgstr ""
+
+#: src/cli/commands.md:236
+msgid "Build for iOS (App Store/TestFlight)"
+msgstr ""
+
+#: src/cli/commands.md:237
+msgid "Build for visionOS"
+msgstr ""
+
+#: src/cli/commands.md:238
+msgid "Build for Android (Google Play)"
+msgstr ""
+
+#: src/cli/commands.md:239
+msgid "Build for Linux (AppImage/deb/rpm)"
+msgstr ""
+
+#: src/cli/commands.md:240
+msgid "`--server <URL>`"
+msgstr ""
+
+#: src/cli/commands.md:240
+msgid "Build server (default: `https://hub.perryts.com`)"
+msgstr ""
+
+#: src/cli/commands.md:241
+msgid "`--license-key <KEY>`"
+msgstr ""
+
+#: src/cli/commands.md:241 src/cli/perry-toml.md:493
+msgid "Perry Hub license key"
+msgstr ""
+
+#: src/cli/commands.md:242
+msgid "`--project <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:242
+msgid "Project directory"
+msgstr ""
+
+#: src/cli/commands.md:243
+msgid "Artifact output directory (default: `dist`)"
+msgstr ""
+
+#: src/cli/commands.md:244
+msgid "`--no-download`"
+msgstr ""
+
+#: src/cli/commands.md:244
+msgid "Skip artifact download"
+msgstr ""
+
+#: src/cli/commands.md:246
+msgid "Apple-specific flags:"
+msgstr ""
+
+#: src/cli/commands.md:250
+msgid "`--apple-team-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:250
+msgid "Developer Team ID"
+msgstr ""
+
+#: src/cli/commands.md:251
+msgid "`--apple-identity <NAME>`"
+msgstr ""
+
+#: src/cli/commands.md:251
+msgid "Signing identity"
+msgstr ""
+
+#: src/cli/commands.md:252
+msgid "`--apple-p8-key <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:252
+msgid "App Store Connect .p8 key"
+msgstr ""
+
+#: src/cli/commands.md:253
+msgid "`--apple-key-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:253
+msgid "App Store Connect API Key ID"
+msgstr ""
+
+#: src/cli/commands.md:254
+msgid "`--apple-issuer-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:254
+msgid "App Store Connect Issuer ID"
+msgstr ""
+
+#: src/cli/commands.md:255
+msgid "`--certificate <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:255
+msgid ".p12 certificate bundle"
+msgstr ""
+
+#: src/cli/commands.md:256
+msgid "`--provisioning-profile <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:256
+msgid ".mobileprovision file (iOS)"
+msgstr ""
+
+#: src/cli/commands.md:258
+msgid "Android-specific flags:"
+msgstr ""
+
+#: src/cli/commands.md:262
+msgid "`--android-keystore <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:262
+msgid ".jks/.keystore file"
+msgstr ""
+
+#: src/cli/commands.md:263
+msgid "`--android-keystore-password <PASS>`"
+msgstr ""
+
+#: src/cli/commands.md:263 src/cli/perry-toml.md:507
+msgid "Keystore password"
+msgstr ""
+
+#: src/cli/commands.md:264
+msgid "`--android-key-alias <ALIAS>`"
+msgstr ""
+
+#: src/cli/commands.md:264
+msgid "Key alias"
+msgstr ""
+
+#: src/cli/commands.md:265
+msgid "`--android-key-password <PASS>`"
+msgstr ""
+
+#: src/cli/commands.md:265
+msgid "Key password"
+msgstr ""
+
+#: src/cli/commands.md:266
+msgid "`--google-play-key <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:266
+msgid "Google Play service account JSON"
+msgstr ""
+
+#: src/cli/commands.md:268
+msgid "On first use, `publish` auto-registers a free license key."
+msgstr ""
+
+#: src/cli/commands.md:270
+msgid "setup"
+msgstr ""
+
+#: src/cli/commands.md:272
+msgid ""
+"Interactive credential wizard for app distribution, plus toolchain setup for"
+" Windows."
+msgstr ""
+
+#: src/cli/commands.md:275
+msgid "# Show platform menu\n"
+msgstr ""
+
+#: src/cli/commands.md:276
+msgid "# macOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:277
+msgid "# iOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:278
+msgid "# visionOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:279
+msgid "# Android setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:280
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
+msgstr ""
+
+#: src/cli/commands.md:283
+msgid ""
+"`perry setup windows` downloads the Microsoft CRT + Windows SDK libraries "
+"(~1.5 GB) so Perry can link without Visual Studio Build Tools. Requires LLVM"
+" (`winget install LLVM.LLVM`) and prompts to accept the Microsoft "
+"redistributable license — pass `--accept-license` to skip the prompt for CI."
+" Output lands at `%LOCALAPPDATA%\\perry\\windows-sdk`. See the [Windows "
+"platform guide](../platforms/windows.md) for the full toolchain comparison."
+msgstr ""
+
+#: src/cli/commands.md:285
+msgid "Credential wizards store their output in `~/.perry/config.toml`."
+msgstr ""
+
+#: src/cli/commands.md:287
+msgid "update"
+msgstr ""
+
+#: src/cli/commands.md:289
+msgid "Check for and install Perry updates."
+msgstr ""
+
+#: src/cli/commands.md:292
+msgid "# Update to latest\n"
+msgstr ""
+
+#: src/cli/commands.md:293
+msgid "# Check without installing\n"
+msgstr ""
+
+#: src/cli/commands.md:294
+msgid "# Ignore 24h cache\n"
+msgstr ""
+
+#: src/cli/commands.md:297
+msgid "Update sources (checked in order):"
+msgstr ""
+
+#: src/cli/commands.md:298
+msgid "Custom server (env/config)"
+msgstr ""
+
+#: src/cli/commands.md:299
+msgid "Perry Hub"
+msgstr ""
+
+#: src/cli/commands.md:300
+msgid "GitHub API"
+msgstr ""
+
+#: src/cli/commands.md:302
+msgid ""
+"Opt out of automatic update checks with `PERRY_NO_UPDATE_CHECK=1` or "
+"`CI=true`."
+msgstr ""
+
+#: src/cli/commands.md:304
+msgid "i18n"
+msgstr ""
+
+#: src/cli/commands.md:306
+msgid ""
+"Internationalization tools for managing locale files and extracting "
+"localizable strings."
+msgstr ""
+
+#: src/cli/commands.md:310
+msgid "Scan source files and generate/update locale JSON scaffolds:"
+msgstr ""
+
+#: src/cli/commands.md:316
+msgid ""
+"Detects string literals in UI component calls (`Button`, `Text`, `Label`, "
+"etc.) and `t()` calls. Creates `locales/*.json` files based on the `[i18n]` "
+"config in `perry.toml`."
+msgstr ""
+
+#: src/cli/commands.md:318
+msgid "See the [i18n documentation](../i18n/overview.md) for full details."
+msgstr ""
+
+#: src/cli/commands.md:322
+msgid "[Compiler Flags](flags.md) — Complete flag reference"
+msgstr ""
+
+#: src/cli/commands.md:323
+msgid "[Getting Started](../getting-started/installation.md) — Installation"
+msgstr ""
+
+#: src/cli/flags.md:3
+msgid "Complete reference for all Perry CLI flags."
+msgstr ""
+
+#: src/cli/flags.md:5
+msgid "Global Flags"
+msgstr ""
+
+#: src/cli/flags.md:7
+msgid "Available on all commands:"
+msgstr ""
+
+#: src/cli/flags.md:11
+msgid "`--format text\\|json`"
+msgstr ""
+
+#: src/cli/flags.md:11
+msgid "Output format (default: `text`)"
+msgstr ""
+
+#: src/cli/flags.md:12
+msgid "`-v, --verbose`"
+msgstr ""
+
+#: src/cli/flags.md:12
+msgid "Increase verbosity (repeatable: `-v`, `-vv`, `-vvv`)"
+msgstr ""
+
+#: src/cli/flags.md:13
+msgid "`-q, --quiet`"
+msgstr ""
+
+#: src/cli/flags.md:13
+msgid "Suppress non-error output"
+msgstr ""
+
+#: src/cli/flags.md:14
+msgid "`--no-color`"
+msgstr ""
+
+#: src/cli/flags.md:14
+msgid "Disable ANSI color codes"
+msgstr ""
+
+#: src/cli/flags.md:16
+msgid "Compilation Targets"
+msgstr ""
+
+#: src/cli/flags.md:18
+msgid "Use `--target` to cross-compile:"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "_(none)_"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "Current platform"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "Default behavior"
+msgstr ""
+
+#: src/cli/flags.md:23
+msgid "`ios-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:23
+msgid "ARM64 simulator binary"
+msgstr ""
+
+#: src/cli/flags.md:24
+msgid "ARM64 device binary"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "`visionos-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "visionOS Simulator"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "Apple Vision Pro simulator build"
+msgstr ""
+
+#: src/cli/flags.md:26
+msgid "visionOS Device"
+msgstr ""
+
+#: src/cli/flags.md:26
+msgid "Apple Vision Pro device build"
+msgstr ""
+
+#: src/cli/flags.md:27
+msgid "ARM64/ARMv7"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "`ios-widget`"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "iOS Widget"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "WidgetKit extension (requires `--app-bundle-id`)"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "`ios-widget-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "iOS Widget (Sim)"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "Widget for simulator"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "`watchos-widget`"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "watchOS Complication"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "WidgetKit extension for Apple Watch"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "`watchos-widget-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "watchOS Widget (Sim)"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "Widget for watchOS simulator"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "`android-widget`"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "Android Widget"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "Android App Widget (AppWidgetProvider)"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "`wearos-tile`"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "Wear OS Tile"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "Wear OS Tile (TileService)"
+msgstr ""
+
+#: src/cli/flags.md:34
+msgid "`wasm`"
+msgstr ""
+
+#: src/cli/flags.md:34
+msgid "Self-contained HTML with WASM or raw `.wasm` binary"
+msgstr ""
+
+#: src/cli/flags.md:35
+msgid "Outputs HTML file with JS"
+msgstr ""
+
+#: src/cli/flags.md:36
+msgid "Win32 executable"
+msgstr ""
+
+#: src/cli/flags.md:37
+msgid "GTK4 executable"
+msgstr ""
+
+#: src/cli/flags.md:39
+msgid "Output Types"
+msgstr ""
+
+#: src/cli/flags.md:41
+msgid "Use `--output-type` to change what's produced:"
+msgstr ""
+
+#: src/cli/flags.md:45
+msgid "`executable`"
+msgstr ""
+
+#: src/cli/flags.md:45
+msgid "Standalone binary (default)"
+msgstr ""
+
+#: src/cli/flags.md:46
+msgid "`dylib`"
+msgstr ""
+
+#: src/cli/flags.md:46
+msgid "Shared library (`.dylib`/`.so`) for [plugins](../plugins/overview.md)"
+msgstr ""
+
+#: src/cli/flags.md:48
+msgid "Debug Flags"
+msgstr ""
+
+#: src/cli/flags.md:52
+msgid "Print HIR (intermediate representation) to stdout"
+msgstr ""
+
+#: src/cli/flags.md:53
+msgid "Produce `.o` object file only, skip linking"
+msgstr ""
+
+#: src/cli/flags.md:54
+msgid "Keep `.o` and `.asm` intermediate files"
+msgstr ""
+
+#: src/cli/flags.md:56
+msgid "Output Optimization"
+msgstr ""
+
+#: src/cli/flags.md:62
+msgid ""
+"Minification strips comments, collapses whitespace, and mangles local "
+"variable/parameter/non-exported function names for smaller output."
+msgstr ""
+
+#: src/cli/flags.md:64
+msgid "Testing Flags"
+msgstr ""
+
+#: src/cli/flags.md:68
+msgid "`--enable-geisterhand`"
+msgstr ""
+
+#: src/cli/flags.md:68
+msgid ""
+"Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
+"programmatic UI testing (default port 7676)"
+msgstr ""
+
+#: src/cli/flags.md:69
+msgid "`--geisterhand-port <PORT>`"
+msgstr ""
+
+#: src/cli/flags.md:69
+msgid ""
+"Set a custom port for the Geisterhand server (implies `--enable-"
+"geisterhand`)"
+msgstr ""
+
+#: src/cli/flags.md:71
+msgid "Runtime Flags"
+msgstr ""
+
+#: src/cli/flags.md:75
+msgid "Enable V8 JavaScript runtime for unsupported npm packages"
+msgstr ""
+
+#: src/cli/flags.md:76
+msgid "Enable type checking via tsgo IPC"
+msgstr ""
+
+#: src/cli/flags.md:78 src/cli/perry-toml.md:485
+msgid "Environment Variables"
+msgstr ""
+
+#: src/cli/flags.md:80 src/cli/perry-toml.md:491 src/cli/perry-toml.md:503
+#: src/cli/perry-toml.md:513
+msgid "Variable"
+msgstr ""
+
+#: src/cli/flags.md:82 src/cli/perry-toml.md:493
+msgid "`PERRY_LICENSE_KEY`"
+msgstr ""
+
+#: src/cli/flags.md:82
+msgid "Perry Hub license key for `perry publish`"
+msgstr ""
+
+#: src/cli/flags.md:83 src/cli/perry-toml.md:495
+msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/flags.md:83
+msgid "Password for .p12 certificate"
+msgstr ""
+
+#: src/cli/flags.md:84
+msgid "`PERRY_NO_UPDATE_CHECK=1`"
+msgstr ""
+
+#: src/cli/flags.md:84
+msgid "Disable automatic update checks"
+msgstr ""
+
+#: src/cli/flags.md:85
+msgid "`PERRY_UPDATE_SERVER`"
+msgstr ""
+
+#: src/cli/flags.md:85
+msgid "Custom update server URL"
+msgstr ""
+
+#: src/cli/flags.md:86
+msgid "`CI=true`"
+msgstr ""
+
+#: src/cli/flags.md:86
+msgid "Auto-skip update checks (set by most CI systems)"
+msgstr ""
+
+#: src/cli/flags.md:87
+msgid "`RUST_LOG`"
+msgstr ""
+
+#: src/cli/flags.md:87
+msgid "Debug logging level (`debug`, `info`, `trace`)"
+msgstr ""
+
+#: src/cli/flags.md:89
+msgid "Configuration Files"
+msgstr ""
+
+#: src/cli/flags.md:91
+msgid "perry.toml (project)"
+msgstr ""
+
+#: src/cli/flags.md:93
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"entry = \"src/main.ts\"\n"
+"version = \"1.0.0\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"build\"\n"
+"\n"
+"[app]\n"
+"name = \"My App\"\n"
+"description = \"A Perry application\"\n"
+"\n"
+"[macos]\n"
+"bundle_id = \"com.example.myapp\"\n"
+"category = \"public.app-category.developer-tools\"\n"
+"minimum_os = \"13.0\"\n"
+"distribute = \"notarize\"  # \"appstore\", \"notarize\", or \"both\"\n"
+"\n"
+"[ios]\n"
+"bundle_id = \"com.example.myapp\"\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = 26\n"
+"target_sdk = 34\n"
+"\n"
+"[linux]\n"
+"format = \"appimage\"  # \"appimage\", \"deb\", \"rpm\"\n"
+"category = \"Development\"\n"
+"```"
+msgstr ""
+
+#: src/cli/flags.md:127
+msgid "~/.perry/config.toml (global)"
+msgstr ""
+
+#: src/cli/flags.md:129
+msgid ""
+"```toml\n"
+"[apple]\n"
+"team_id = \"XXXXXXXXXX\"\n"
+"signing_identity = \"Developer ID Application: Your Name\"\n"
+"\n"
+"[android]\n"
+"keystore_path = \"/path/to/keystore.jks\"\n"
+"key_alias = \"my-key\"\n"
+"```"
+msgstr ""
+
+#: src/cli/flags.md:142
+msgid "# Simple CLI program\n"
+msgstr ""
+
+#: src/cli/flags.md:144
+msgid "# iOS app for simulator\n"
+msgstr ""
+
+#: src/cli/flags.md:147
+msgid "# visionOS app for simulator\n"
+msgstr ""
+
+#: src/cli/flags.md:150
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
+msgstr ""
+
+#: src/cli/flags.md:153
+msgid "# Plugin shared library\n"
+msgstr ""
+
+#: src/cli/flags.md:156
+msgid "# iOS widget with bundle ID\n"
+msgstr ""
+
+#: src/cli/flags.md:159
+msgid "# Debug compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:162
+msgid "# Verbose compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:165
+msgid "# Type-checked compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:168
+msgid "# Raw WASM binary (no HTML wrapper)\n"
+msgstr ""
+
+#: src/cli/flags.md:171
+msgid "# Minified web output (compresses embedded JS bridge)\n"
+msgstr ""
+
+#: src/cli/flags.md:178
+msgid "[Commands](commands.md) — All CLI commands"
+msgstr ""
+
+#: src/cli/flags.md:179
+msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
+msgstr ""
+
+#: src/cli/perry-toml.md:3
+msgid ""
+"`perry.toml` is the project-level configuration file for Perry. It controls "
+"project metadata, build settings, platform-specific options, code signing, "
+"distribution, auditing, and verification."
+msgstr ""
+
+#: src/cli/perry-toml.md:5
+msgid ""
+"Created automatically by `perry init`, it lives at the root of your project "
+"alongside `package.json`."
+msgstr ""
+
+#: src/cli/perry-toml.md:7
+msgid "Minimal Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:9
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"dist\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:18
+msgid "Full Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:20
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"version = \"1.2.0\"\n"
+"build_number = 42\n"
+"bundle_id = \"com.example.myapp\"\n"
+"description = \"A cross-platform Perry application\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[project.icons]\n"
+"source = \"assets/icon.png\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"dist\"\n"
+"\n"
+"[macos]\n"
+"bundle_id = \"com.example.myapp.macos\"\n"
+"category = \"public.app-category.developer-tools\"\n"
+"minimum_os = \"13.0\"\n"
+"entitlements = [\"com.apple.security.network.client\"]\n"
+"distribute = \"both\"\n"
+"signing_identity = \"Developer ID Application: My Company (TEAMID)\"\n"
+"certificate = \"certs/mac-appstore.p12\"\n"
+"notarize_certificate = \"certs/mac-devid.p12\"\n"
+"notarize_signing_identity = \"Developer ID Application: My Company (TEAMID)\"\n"
+"installer_certificate = \"certs/mac-installer.p12\"\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"certs/AuthKey.p8\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[ios]\n"
+"bundle_id = \"com.example.myapp.ios\"\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"orientations = [\"portrait\", \"landscape-left\", \"landscape-right\"]\n"
+"capabilities = [\"push-notification\"]\n"
+"distribute = \"appstore\"\n"
+"entry = \"src/main-ios.ts\"\n"
+"provisioning_profile = \"certs/MyApp.mobileprovision\"\n"
+"certificate = \"certs/ios-distribution.p12\"\n"
+"signing_identity = \"iPhone Distribution: My Company (TEAMID)\"\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"certs/AuthKey.p8\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = \"26\"\n"
+"target_sdk = \"34\"\n"
+"permissions = [\"INTERNET\", \"CAMERA\"]\n"
+"distribute = \"playstore\"\n"
+"keystore = \"certs/release.keystore\"\n"
+"key_alias = \"my-key\"\n"
+"google_play_key = \"certs/play-service-account.json\"\n"
+"entry = \"src/main-android.ts\"\n"
+"\n"
+"[linux]\n"
+"format = \"appimage\"\n"
+"category = \"Development\"\n"
+"description = \"A cross-platform Perry application\"\n"
+"\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\", \"fr\"]\n"
+"default_locale = \"en\"\n"
+"\n"
+"[i18n.currencies]\n"
+"en = \"USD\"\n"
+"de = \"EUR\"\n"
+"fr = \"EUR\"\n"
+"\n"
+"[publish]\n"
+"server = \"https://hub.perryts.com\"\n"
+"\n"
+"[audit]\n"
+"fail_on = \"B\"\n"
+"severity = \"high\"\n"
+"ignore = [\"RULE-001\", \"RULE-002\"]\n"
+"\n"
+"[verify]\n"
+"url = \"https://verify.perryts.com\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:110 src/cli/perry-toml.md:558
+msgid "`[project]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:112
+msgid ""
+"Core project metadata. This is the primary section for identifying your "
+"application."
+msgstr ""
+
+#: src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414
+msgid "Default"
+msgstr ""
+
+#: src/cli/perry-toml.md:116
+msgid "Directory name"
+msgstr ""
+
+#: src/cli/perry-toml.md:116
+msgid "Project name, used for binary output name and default bundle ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:117
+msgid "`\"1.0.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:117
+msgid "Semantic version string (e.g., `\"1.2.3\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "`build_number`"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "integer"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "`1`"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid ""
+"Numeric build number; auto-incremented on `perry publish` for iOS, Android, "
+"and macOS App Store builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:119
+msgid "Human-readable project description"
+msgstr ""
+
+#: src/cli/perry-toml.md:120 src/cli/perry-toml.md:249
+#: src/cli/perry-toml.md:304 src/cli/perry-toml.md:337
+msgid "`entry`"
+msgstr ""
+
+#: src/cli/perry-toml.md:120
+msgid ""
+"TypeScript entry file (e.g., `\"src/main.ts\"`). Used by `perry run` and "
+"`perry publish` when no input file is specified"
+msgstr ""
+
+#: src/cli/perry-toml.md:121 src/cli/perry-toml.md:167
+#: src/cli/perry-toml.md:243 src/cli/perry-toml.md:301
+msgid "`bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:121
+msgid "`com.perry.<name>`"
+msgstr ""
+
+#: src/cli/perry-toml.md:121
+msgid ""
+"Default bundle identifier, used as fallback when platform-specific sections "
+"don't define one"
+msgstr ""
+
+#: src/cli/perry-toml.md:123
+msgid "`[project.icons]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:127
+msgid "`source`"
+msgstr ""
+
+#: src/cli/perry-toml.md:127
+msgid ""
+"Path to a source icon image (PNG or JPG). Perry auto-resizes this to all "
+"required sizes for each platform"
+msgstr ""
+
+#: src/cli/perry-toml.md:129
+msgid "`[app]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:131
+msgid ""
+"Alternative to `[project]` with identical fields. Useful for organizational "
+"clarity — `[app]` takes precedence over `[project]` when both are present:"
+msgstr ""
+
+#: src/cli/perry-toml.md:133
+msgid ""
+"```toml\n"
+"# These two are equivalent:\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"\n"
+"# or:\n"
+"[app]\n"
+"name = \"my-app\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:143
+msgid ""
+"When both exist, resolution order is: `[app]` field -> `[project]` field -> "
+"default."
+msgstr ""
+
+#: src/cli/perry-toml.md:145
+msgid ""
+"`[app]` supports the same fields as `[project]`: `name`, `version`, "
+"`build_number`, `bundle_id`, `description`, `entry`, and `icons`."
+msgstr ""
+
+#: src/cli/perry-toml.md:149 src/cli/perry-toml.md:561
+msgid "`[build]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:151
+msgid "Build output settings."
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "`out_dir`"
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "`\"dist\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "Directory for build artifacts"
+msgstr ""
+
+#: src/cli/perry-toml.md:159
+msgid "`[macos]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:161
+msgid ""
+"macOS-specific configuration for `perry publish macos` and `perry compile "
+"--target macos`."
+msgstr ""
+
+#: src/cli/perry-toml.md:163 src/cli/perry-toml.md:239
+#: src/cli/perry-toml.md:297
+msgid "App Metadata"
+msgstr ""
+
+#: src/cli/perry-toml.md:167 src/cli/perry-toml.md:243
+msgid "Falls back to `[app]`/`[project]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:167
+msgid "macOS-specific bundle identifier (e.g., `\"com.example.myapp\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:348
+msgid "`category`"
+msgstr ""
+
+#: src/cli/perry-toml.md:168
+msgid ""
+"Mac App Store category. Uses Apple's UTI format (see [valid values](#macos-"
+"app-store-categories) below)"
+msgstr ""
+
+#: src/cli/perry-toml.md:169
+msgid "`minimum_os`"
+msgstr ""
+
+#: src/cli/perry-toml.md:169
+msgid "Minimum macOS version required (e.g., `\"13.0\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:170
+msgid "`entitlements`"
+msgstr ""
+
+#: src/cli/perry-toml.md:170 src/cli/perry-toml.md:246
+#: src/cli/perry-toml.md:247 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:332 src/cli/perry-toml.md:359
+#: src/cli/perry-toml.md:391
+msgid "string\\[\\]"
+msgstr ""
+
+#: src/cli/perry-toml.md:170
+msgid ""
+"macOS entitlements to include in the code signature (e.g., "
+"`[\"com.apple.security.network.client\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305
+msgid "`encryption_exempt`"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305
+msgid "bool"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305 src/cli/perry-toml.md:361
+msgid "`false`"
+msgstr ""
+
+#: src/cli/perry-toml.md:171
+msgid ""
+"If `true`, adds `ITSAppUsesNonExemptEncryption = false` to Info.plist, "
+"skipping the export compliance prompt in App Store Connect"
+msgstr ""
+
+#: src/cli/perry-toml.md:173 src/cli/perry-toml.md:252
+msgid "Distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:177 src/cli/perry-toml.md:256
+#: src/cli/perry-toml.md:312 src/cli/perry-toml.md:333
+msgid "`distribute`"
+msgstr ""
+
+#: src/cli/perry-toml.md:177
+msgid ""
+"Distribution method: `\"appstore\"`, `\"notarize\"`, or `\"both\"` (see "
+"[Distribution Modes](#macos-distribution-modes))"
+msgstr ""
+
+#: src/cli/perry-toml.md:183 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:313
+msgid "`signing_identity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:183 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:313
+msgid "Auto-detected from Keychain"
+msgstr ""
+
+#: src/cli/perry-toml.md:183
+msgid ""
+"Code signing identity name (e.g., `\"3rd Party Mac Developer Application: "
+"Company (TEAMID)\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:263
+#: src/cli/perry-toml.md:314
+msgid "`certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:263
+#: src/cli/perry-toml.md:314
+msgid "Auto-exported from Keychain"
+msgstr ""
+
+#: src/cli/perry-toml.md:184
+msgid "Path to `.p12` certificate file for App Store distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:185
+msgid "`notarize_certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:185
+msgid ""
+"Separate `.p12` certificate for notarization (only used with `distribute = "
+"\"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:186
+msgid "`notarize_signing_identity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:186
+msgid "Signing identity for notarization (only used with `distribute = \"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:187
+msgid "`installer_certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:187
+msgid "`.p12` certificate for Mac Installer Distribution (`.pkg` signing)"
+msgstr ""
+
+#: src/cli/perry-toml.md:189 src/cli/perry-toml.md:266
+msgid "App Store Connect"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:270
+#: src/cli/perry-toml.md:316
+msgid "`team_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:194
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:196
+#: src/cli/perry-toml.md:270 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:272 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:316 src/cli/perry-toml.md:317
+#: src/cli/perry-toml.md:318 src/cli/perry-toml.md:319
+msgid "From `~/.perry/config.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:270
+#: src/cli/perry-toml.md:316
+msgid "Apple Developer Team ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:194 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:317
+msgid "`key_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:194 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:497
+msgid "App Store Connect API key ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:272
+#: src/cli/perry-toml.md:318
+msgid "`issuer_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:272
+#: src/cli/perry-toml.md:318
+msgid "App Store Connect issuer ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:196 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:319
+msgid "`p8_key_path`"
+msgstr ""
+
+#: src/cli/perry-toml.md:196
+msgid "Path to App Store Connect `.p8` API key file"
+msgstr ""
+
+#: src/cli/perry-toml.md:198
+msgid "macOS Distribution Modes"
+msgstr ""
+
+#: src/cli/perry-toml.md:200
+msgid ""
+"The `distribute` field controls how your macOS app is signed and "
+"distributed:"
+msgstr ""
+
+#: src/cli/perry-toml.md:202
+msgid ""
+"**`\"appstore\"`** — Signs with an App Store distribution certificate and "
+"uploads to App Store Connect. Requires `team_id`, `key_id`, `issuer_id`, and"
+" `p8_key_path`."
+msgstr ""
+
+#: src/cli/perry-toml.md:204
+msgid ""
+"**`\"notarize\"`** — Signs with a Developer ID certificate and notarizes "
+"with Apple. For direct distribution outside the App Store."
+msgstr ""
+
+#: src/cli/perry-toml.md:206
+msgid ""
+"**`\"both\"`** — Produces **two** signed builds: one for the App Store and "
+"one notarized for direct distribution. Requires **two separate "
+"certificates**:"
+msgstr ""
+
+#: src/cli/perry-toml.md:207
+msgid "`certificate` + `signing_identity` for the App Store build"
+msgstr ""
+
+#: src/cli/perry-toml.md:208
+msgid ""
+"`notarize_certificate` + `notarize_signing_identity` for the notarized build"
+msgstr ""
+
+#: src/cli/perry-toml.md:209
+msgid "Optionally `installer_certificate` for `.pkg` signing"
+msgstr ""
+
+#: src/cli/perry-toml.md:211
+msgid "macOS App Store Categories"
+msgstr ""
+
+#: src/cli/perry-toml.md:213
+msgid "Common values for the `category` field (Apple UTI format):"
+msgstr ""
+
+#: src/cli/perry-toml.md:215
+msgid "Category"
+msgstr ""
+
+#: src/cli/perry-toml.md:217
+msgid "Business"
+msgstr ""
+
+#: src/cli/perry-toml.md:217
+msgid "`public.app-category.business`"
+msgstr ""
+
+#: src/cli/perry-toml.md:218
+msgid "Developer Tools"
+msgstr ""
+
+#: src/cli/perry-toml.md:218
+msgid "`public.app-category.developer-tools`"
+msgstr ""
+
+#: src/cli/perry-toml.md:219
+msgid "Education"
+msgstr ""
+
+#: src/cli/perry-toml.md:219
+msgid "`public.app-category.education`"
+msgstr ""
+
+#: src/cli/perry-toml.md:220
+msgid "Entertainment"
+msgstr ""
+
+#: src/cli/perry-toml.md:220
+msgid "`public.app-category.entertainment`"
+msgstr ""
+
+#: src/cli/perry-toml.md:221
+msgid "Finance"
+msgstr ""
+
+#: src/cli/perry-toml.md:221
+msgid "`public.app-category.finance`"
+msgstr ""
+
+#: src/cli/perry-toml.md:222
+msgid "Games"
+msgstr ""
+
+#: src/cli/perry-toml.md:222
+msgid "`public.app-category.games`"
+msgstr ""
+
+#: src/cli/perry-toml.md:223
+msgid "Graphics & Design"
+msgstr ""
+
+#: src/cli/perry-toml.md:223
+msgid "`public.app-category.graphics-design`"
+msgstr ""
+
+#: src/cli/perry-toml.md:224
+msgid "Health & Fitness"
+msgstr ""
+
+#: src/cli/perry-toml.md:224
+msgid "`public.app-category.healthcare-fitness`"
+msgstr ""
+
+#: src/cli/perry-toml.md:225
+msgid "Lifestyle"
+msgstr ""
+
+#: src/cli/perry-toml.md:225
+msgid "`public.app-category.lifestyle`"
+msgstr ""
+
+#: src/cli/perry-toml.md:226
+msgid "Music"
+msgstr ""
+
+#: src/cli/perry-toml.md:226
+msgid "`public.app-category.music`"
+msgstr ""
+
+#: src/cli/perry-toml.md:227
+msgid "News"
+msgstr ""
+
+#: src/cli/perry-toml.md:227
+msgid "`public.app-category.news`"
+msgstr ""
+
+#: src/cli/perry-toml.md:228
+msgid "Photography"
+msgstr ""
+
+#: src/cli/perry-toml.md:228
+msgid "`public.app-category.photography`"
+msgstr ""
+
+#: src/cli/perry-toml.md:229
+msgid "Productivity"
+msgstr ""
+
+#: src/cli/perry-toml.md:229
+msgid "`public.app-category.productivity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:230
+msgid "Social Networking"
+msgstr ""
+
+#: src/cli/perry-toml.md:230
+msgid "`public.app-category.social-networking`"
+msgstr ""
+
+#: src/cli/perry-toml.md:231
+msgid "`public.app-category.utilities`"
+msgstr ""
+
+#: src/cli/perry-toml.md:235
+msgid "`[ios]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:237
+msgid ""
+"iOS-specific configuration for `perry publish ios`, `perry run ios`, and "
+"`perry compile --target ios`/`--target ios-simulator`."
+msgstr ""
+
+#: src/cli/perry-toml.md:243
+msgid "iOS-specific bundle identifier"
+msgstr ""
+
+#: src/cli/perry-toml.md:244 src/cli/perry-toml.md:302
+msgid "`deployment_target`"
+msgstr ""
+
+#: src/cli/perry-toml.md:244
+msgid "`\"17.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:244
+msgid "Minimum iOS version required (e.g., `\"16.0\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:303
+msgid "`minimum_version`"
+msgstr ""
+
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:303
+msgid "Alias for `deployment_target`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "`device_family`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "`[\"iphone\", \"ipad\"]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "Supported device families"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "`orientations`"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "`[\"portrait\"]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "Supported interface orientations"
+msgstr ""
+
+#: src/cli/perry-toml.md:248
+msgid "`capabilities`"
+msgstr ""
+
+#: src/cli/perry-toml.md:248
+msgid "App capabilities (e.g., `[\"push-notification\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:249 src/cli/perry-toml.md:304
+#: src/cli/perry-toml.md:337 src/cli/perry-toml.md:349
+msgid "Falls back to `[project]`/`[app]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:249
+msgid ""
+"iOS-specific entry file (useful when iOS needs a different entry point)"
+msgstr ""
+
+#: src/cli/perry-toml.md:250 src/cli/perry-toml.md:305
+msgid "If `true`, adds `ITSAppUsesNonExemptEncryption = false` to Info.plist"
+msgstr ""
+
+#: src/cli/perry-toml.md:256
+msgid "Distribution method: `\"appstore\"`, `\"testflight\"`, or `\"development\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:262
+msgid "Code signing identity (e.g., `\"iPhone Distribution: Company (TEAMID)\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:263 src/cli/perry-toml.md:314
+msgid "Path to `.p12` distribution certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:264 src/cli/perry-toml.md:315
+msgid "`provisioning_profile`"
+msgstr ""
+
+#: src/cli/perry-toml.md:264
+msgid ""
+"Path to `.mobileprovision` file. Stored as `{bundle_id}.mobileprovision` in "
+"`~/.perry/` by `perry setup ios`"
+msgstr ""
+
+#: src/cli/perry-toml.md:273 src/cli/perry-toml.md:319
+msgid "Path to `.p8` API key file"
+msgstr ""
+
+#: src/cli/perry-toml.md:275
+msgid "Device Family Values"
+msgstr ""
+
+#: src/cli/perry-toml.md:279
+msgid "`\"iphone\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:279
+msgid "iPhone devices"
+msgstr ""
+
+#: src/cli/perry-toml.md:280
+msgid "`\"ipad\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:280
+msgid "iPad devices"
+msgstr ""
+
+#: src/cli/perry-toml.md:282
+msgid "Orientation Values"
+msgstr ""
+
+#: src/cli/perry-toml.md:286
+msgid "`\"portrait\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:286
+msgid "Device upright"
+msgstr ""
+
+#: src/cli/perry-toml.md:287
+msgid "`\"portrait-upside-down\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:287
+msgid "Device upside down"
+msgstr ""
+
+#: src/cli/perry-toml.md:288
+msgid "`\"landscape-left\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:288
+msgid "Device rotated left"
+msgstr ""
+
+#: src/cli/perry-toml.md:289
+msgid "`\"landscape-right\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:289
+msgid "Device rotated right"
+msgstr ""
+
+#: src/cli/perry-toml.md:293
+msgid "`[visionos]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:295
+msgid ""
+"visionOS-specific configuration for `perry publish visionos`, `perry run "
+"visionos`, and `perry compile --target visionos`/`--target visionos-"
+"simulator`."
+msgstr ""
+
+#: src/cli/perry-toml.md:301
+msgid "Falls back to `[app]`/`[project]`/`[ios]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:301
+msgid "visionOS-specific bundle identifier"
+msgstr ""
+
+#: src/cli/perry-toml.md:302
+msgid "`\"1.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:302
+msgid "Minimum visionOS version required"
+msgstr ""
+
+#: src/cli/perry-toml.md:304
+msgid "visionOS-specific entry file"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "`info_plist`"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "table"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "Custom key-value pairs merged into the generated Info.plist"
+msgstr ""
+
+#: src/cli/perry-toml.md:308
+msgid "Distribution / Signing"
+msgstr ""
+
+#: src/cli/perry-toml.md:312
+msgid "Distribution method for visionOS builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:313
+msgid "Code signing identity"
+msgstr ""
+
+#: src/cli/perry-toml.md:315
+msgid "Path to `.mobileprovision` file"
+msgstr ""
+
+#: src/cli/perry-toml.md:323
+msgid "`[android]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:325
+msgid ""
+"Android-specific configuration for `perry publish android`, `perry run "
+"android`, and `perry compile --target android`."
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "`package_name`"
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "Falls back to bundle_id chain"
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "Java package name (e.g., `\"com.example.myapp\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:330
+msgid "`min_sdk`"
+msgstr ""
+
+#: src/cli/perry-toml.md:330
+msgid "Minimum Android SDK version (e.g., `\"26\"` for Android 8.0)"
+msgstr ""
+
+#: src/cli/perry-toml.md:331
+msgid "`target_sdk`"
+msgstr ""
+
+#: src/cli/perry-toml.md:331
+msgid "Target Android SDK version (e.g., `\"34\"` for Android 14)"
+msgstr ""
+
+#: src/cli/perry-toml.md:332
+msgid "`permissions`"
+msgstr ""
+
+#: src/cli/perry-toml.md:332
+msgid "Android permissions (e.g., `[\"INTERNET\", \"CAMERA\", \"ACCESS_FINE_LOCATION\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:333
+msgid "Distribution method: `\"playstore\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:334
+msgid "`keystore`"
+msgstr ""
+
+#: src/cli/perry-toml.md:334
+msgid "Path to `.jks` or `.keystore` signing keystore"
+msgstr ""
+
+#: src/cli/perry-toml.md:335
+msgid "`key_alias`"
+msgstr ""
+
+#: src/cli/perry-toml.md:335
+msgid "Alias of the signing key within the keystore"
+msgstr ""
+
+#: src/cli/perry-toml.md:336
+msgid "`google_play_key`"
+msgstr ""
+
+#: src/cli/perry-toml.md:336
+msgid "Path to Google Play service account JSON file for automated uploads"
+msgstr ""
+
+#: src/cli/perry-toml.md:337
+msgid "Android-specific entry file"
+msgstr ""
+
+#: src/cli/perry-toml.md:341
+msgid "`[linux]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:343
+msgid "Linux-specific configuration for `perry publish linux`."
+msgstr ""
+
+#: src/cli/perry-toml.md:347
+msgid "`format`"
+msgstr ""
+
+#: src/cli/perry-toml.md:347
+msgid "Package format: `\"appimage\"`, `\"deb\"`, or `\"rpm\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:348
+msgid "Desktop application category (e.g., `\"Development\"`, `\"Utility\"`, `\"Game\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:349
+msgid "Application description for package metadata"
+msgstr ""
+
+#: src/cli/perry-toml.md:353
+msgid "`[i18n]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:355
+msgid ""
+"Internationalization configuration. See the [i18n "
+"documentation](../i18n/overview.md) for full details."
+msgstr ""
+
+#: src/cli/perry-toml.md:359
+msgid "`locales`"
+msgstr ""
+
+#: src/cli/perry-toml.md:359
+msgid ""
+"Supported locale codes (e.g., `[\"en\", \"de\", \"fr\"]`). Locale files must"
+" exist in `/locales`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "`default_locale`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "`\"en\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "Fallback locale. Used when a key is missing in another locale"
+msgstr ""
+
+#: src/cli/perry-toml.md:361
+msgid "`dynamic`"
+msgstr ""
+
+#: src/cli/perry-toml.md:361
+msgid ""
+"`false`: locale set at launch, strings inlined. `true`: locale switchable at"
+" runtime"
+msgstr ""
+
+#: src/cli/perry-toml.md:363
+msgid "`[i18n.currencies]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:365
+msgid ""
+"Maps locale codes to default ISO 4217 currency codes. Used by the "
+"`Currency()` format wrapper."
+msgstr ""
+
+#: src/cli/perry-toml.md:369
+msgid "`{locale}`"
+msgstr ""
+
+#: src/cli/perry-toml.md:369
+msgid "Currency code for the locale (e.g., `en = \"USD\"`, `de = \"EUR\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:373
+msgid "`[publish]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:375
+msgid "Publishing configuration."
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid "`server`"
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid "`https://hub.perryts.com`"
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid ""
+"Custom Perry Hub build server URL. Useful for self-hosted or enterprise "
+"deployments"
+msgstr ""
+
+#: src/cli/perry-toml.md:383
+msgid "`[audit]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:385
+msgid "Security audit configuration for `perry audit` and pre-publish audits."
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid "`fail_on`"
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid "`\"C\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid ""
+"Minimum acceptable audit grade. Build fails if the actual grade is below "
+"this threshold. Values: `\"A\"`, `\"A-\"`, `\"B\"`, `\"C\"`, `\"D\"`, "
+"`\"F\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid "`severity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid "`\"all\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid ""
+"Filter findings by severity: `\"all\"`, `\"critical\"`, `\"high\"`, "
+"`\"medium\"`, `\"low\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:391
+msgid "`ignore`"
+msgstr ""
+
+#: src/cli/perry-toml.md:391
+msgid "List of audit rule IDs to suppress (e.g., `[\"RULE-001\", \"RULE-042\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:393
+msgid "Audit Grade Scale"
+msgstr ""
+
+#: src/cli/perry-toml.md:395
+msgid "Grades are ranked from highest to lowest:"
+msgstr ""
+
+#: src/cli/perry-toml.md:397
+msgid "Grade"
+msgstr ""
+
+#: src/cli/perry-toml.md:397
+msgid "Rank"
+msgstr ""
+
+#: src/cli/perry-toml.md:399
+msgid "A"
+msgstr ""
+
+#: src/cli/perry-toml.md:399
+msgid "Excellent — no significant findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:400
+msgid "A-"
+msgstr ""
+
+#: src/cli/perry-toml.md:400
+msgid "Very good — minor findings only"
+msgstr ""
+
+#: src/cli/perry-toml.md:401
+msgid "B"
+msgstr ""
+
+#: src/cli/perry-toml.md:401
+msgid "Good — some findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:402
+msgid "C"
+msgstr ""
+
+#: src/cli/perry-toml.md:402
+msgid "Acceptable — moderate findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:403
+msgid "D"
+msgstr ""
+
+#: src/cli/perry-toml.md:403
+msgid "Poor — significant findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:404
+msgid "F"
+msgstr ""
+
+#: src/cli/perry-toml.md:404
+msgid "Fail — critical findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:406
+msgid ""
+"Setting `fail_on = \"B\"` means any grade below B (i.e., C, D, or F) will "
+"cause the build to fail."
+msgstr ""
+
+#: src/cli/perry-toml.md:410
+msgid "`[verify]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:412
+msgid "Runtime verification configuration for `perry verify`."
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "`url`"
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "`https://verify.perryts.com`"
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "Verification service endpoint URL"
+msgstr ""
+
+#: src/cli/perry-toml.md:420
+msgid "Bundle ID Resolution"
+msgstr ""
+
+#: src/cli/perry-toml.md:422
+msgid ""
+"Perry resolves the bundle identifier using a cascading priority system. The "
+"first non-empty value wins:"
+msgstr ""
+
+#: src/cli/perry-toml.md:424
+msgid "For iOS builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:425 src/cli/perry-toml.md:441
+msgid "`[ios].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:426 src/cli/perry-toml.md:434
+#: src/cli/perry-toml.md:443
+msgid "`[app].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:427 src/cli/perry-toml.md:435
+#: src/cli/perry-toml.md:444
+msgid "`[project].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:428 src/cli/perry-toml.md:433
+#: src/cli/perry-toml.md:442
+msgid "`[macos].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:429 src/cli/perry-toml.md:436
+msgid "`package.json` `bundleId` field"
+msgstr ""
+
+#: src/cli/perry-toml.md:430 src/cli/perry-toml.md:437
+#: src/cli/perry-toml.md:445
+msgid "`com.perry.<app_name>` (generated default)"
+msgstr ""
+
+#: src/cli/perry-toml.md:432
+msgid "For macOS builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:439
+msgid "For Android builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:440
+msgid "`[android].package_name`"
+msgstr ""
+
+#: src/cli/perry-toml.md:449
+msgid "Entry File Resolution"
+msgstr ""
+
+#: src/cli/perry-toml.md:451
+msgid ""
+"When no input file is specified on the command line, Perry resolves the "
+"entry file in this order:"
+msgstr ""
+
+#: src/cli/perry-toml.md:453
+msgid "`[ios].entry` / `[android].entry` (when targeting that platform)"
+msgstr ""
+
+#: src/cli/perry-toml.md:454
+msgid "`[project].entry` or `[app].entry`"
+msgstr ""
+
+#: src/cli/perry-toml.md:455
+msgid "`src/main.ts` (if it exists)"
+msgstr ""
+
+#: src/cli/perry-toml.md:456
+msgid "`main.ts` (if it exists)"
+msgstr ""
+
+#: src/cli/perry-toml.md:460
+msgid "Build Number Auto-Increment"
+msgstr ""
+
+#: src/cli/perry-toml.md:462
+msgid ""
+"The `build_number` field is automatically incremented by `perry publish` "
+"for:"
+msgstr ""
+
+#: src/cli/perry-toml.md:463
+msgid "iOS builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:464
+msgid "Android builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:465
+msgid "macOS App Store builds (`distribute = \"appstore\"` or `\"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:467
+msgid ""
+"The updated value is written back to `perry.toml` after a successful "
+"publish. This ensures each submission to the App Store / Play Store has a "
+"unique, monotonically increasing build number."
+msgstr ""
+
+#: src/cli/perry-toml.md:469
+msgid ""
+"macOS builds with `distribute = \"notarize\"` (direct distribution) do "
+"**not** auto-increment the build number."
+msgstr ""
+
+#: src/cli/perry-toml.md:473
+msgid "Configuration Priority"
+msgstr ""
+
+#: src/cli/perry-toml.md:475
+msgid ""
+"Perry resolves configuration values using a layered priority system (highest"
+" to lowest):"
+msgstr ""
+
+#: src/cli/perry-toml.md:477
+msgid "**CLI flags** — e.g., `--target`, `--output`"
+msgstr ""
+
+#: src/cli/perry-toml.md:478
+msgid "**Environment variables** — e.g., `PERRY_LICENSE_KEY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:479
+msgid ""
+"**perry.toml** — project-level config (platform-specific sections first, "
+"then `[app]`/`[project]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:480
+msgid "**~/.perry/config.toml** — user-level global config"
+msgstr ""
+
+#: src/cli/perry-toml.md:481
+msgid "**Built-in defaults**"
+msgstr ""
+
+#: src/cli/perry-toml.md:487
+msgid ""
+"These environment variables override perry.toml and global config values:"
+msgstr ""
+
+#: src/cli/perry-toml.md:489
+msgid "Apple / iOS / macOS"
+msgstr ""
+
+#: src/cli/perry-toml.md:494
+msgid "`PERRY_APPLE_CERTIFICATE`"
+msgstr ""
+
+#: src/cli/perry-toml.md:494
+msgid "`.p12` certificate file contents (base64)"
+msgstr ""
+
+#: src/cli/perry-toml.md:495
+msgid "Password for the `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:496
+msgid "`PERRY_APPLE_P8_KEY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:496
+msgid "`.p8` API key file contents"
+msgstr ""
+
+#: src/cli/perry-toml.md:497
+msgid "`PERRY_APPLE_KEY_ID`"
+msgstr ""
+
+#: src/cli/perry-toml.md:498
+msgid "`PERRY_APPLE_NOTARIZE_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:498
+msgid "Password for the notarization `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:499
+msgid "`PERRY_APPLE_INSTALLER_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:499
+msgid "Password for the installer `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:505
+msgid "`PERRY_ANDROID_KEYSTORE`"
+msgstr ""
+
+#: src/cli/perry-toml.md:505
+msgid "Path to `.jks`/`.keystore` file"
+msgstr ""
+
+#: src/cli/perry-toml.md:506
+msgid "`PERRY_ANDROID_KEY_ALIAS`"
+msgstr ""
+
+#: src/cli/perry-toml.md:506
+msgid "Keystore key alias"
+msgstr ""
+
+#: src/cli/perry-toml.md:507
+msgid "`PERRY_ANDROID_KEYSTORE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:508
+msgid "`PERRY_ANDROID_KEY_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:508
+msgid "Key password (within the keystore)"
+msgstr ""
+
+#: src/cli/perry-toml.md:509
+msgid "`PERRY_GOOGLE_PLAY_KEY_PATH`"
+msgstr ""
+
+#: src/cli/perry-toml.md:509
+msgid "Path to Google Play service account JSON"
+msgstr ""
+
+#: src/cli/perry-toml.md:511
+msgid "General"
+msgstr ""
+
+#: src/cli/perry-toml.md:515
+msgid "`PERRY_NO_TELEMETRY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:515
+msgid "Set to `1` to disable anonymous telemetry"
+msgstr ""
+
+#: src/cli/perry-toml.md:516
+msgid "`PERRY_NO_UPDATE_CHECK`"
+msgstr ""
+
+#: src/cli/perry-toml.md:516
+msgid "Set to `1` to disable background update checks"
+msgstr ""
+
+#: src/cli/perry-toml.md:520
+msgid "Global Config: `~/.perry/config.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:522
+msgid ""
+"Separate from the project-level `perry.toml`, Perry maintains a user-level "
+"global config at `~/.perry/config.toml`. This stores credentials and "
+"preferences shared across all projects."
+msgstr ""
+
+#: src/cli/perry-toml.md:524
+msgid ""
+"```toml\n"
+"license_key = \"perry-xxxxxxxx\"\n"
+"server = \"https://hub.perryts.com\"\n"
+"default_target = \"macos\"\n"
+"\n"
+"[apple]\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"/Users/me/.perry/AuthKey.p8\"\n"
+"\n"
+"[android]\n"
+"keystore_path = \"/Users/me/.perry/release.keystore\"\n"
+"key_alias = \"my-key\"\n"
+"google_play_key_path = \"/Users/me/.perry/play-service-account.json\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:541
+msgid ""
+"Fields in perry.toml (project-level) override `~/.perry/config.toml` "
+"(global-level). For example, `[ios].team_id` in perry.toml overrides "
+"`[apple].team_id` in the global config."
+msgstr ""
+
+#: src/cli/perry-toml.md:543
+msgid "The global config is managed by `perry setup` commands:"
+msgstr ""
+
+#: src/cli/perry-toml.md:544
+msgid "`perry setup ios` — configures Apple signing credentials"
+msgstr ""
+
+#: src/cli/perry-toml.md:545
+msgid "`perry setup android` — configures Android signing credentials"
+msgstr ""
+
+#: src/cli/perry-toml.md:546
+msgid "`perry setup macos` — configures macOS distribution settings"
+msgstr ""
+
+#: src/cli/perry-toml.md:550
+msgid "perry.toml vs package.json"
+msgstr ""
+
+#: src/cli/perry-toml.md:552
+msgid "Perry reads configuration from both files. Here's what goes where:"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "Setting"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "File"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "Section"
+msgstr ""
+
+#: src/cli/perry-toml.md:556
+msgid "Compile packages natively"
+msgstr ""
+
+#: src/cli/perry-toml.md:556 src/cli/perry-toml.md:557
+msgid "`package.json`"
+msgstr ""
+
+#: src/cli/perry-toml.md:556
+msgid "`perry.compilePackages`"
+msgstr ""
+
+#: src/cli/perry-toml.md:557
+msgid "Splash screen"
+msgstr ""
+
+#: src/cli/perry-toml.md:557
+msgid "`perry.splash`"
+msgstr ""
+
+#: src/cli/perry-toml.md:558
+msgid "Project name, version, entry"
+msgstr ""
+
+#: src/cli/perry-toml.md:558 src/cli/perry-toml.md:559
+#: src/cli/perry-toml.md:560 src/cli/perry-toml.md:561
+#: src/cli/perry-toml.md:562
+msgid "`perry.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:559
+msgid "Platform-specific settings"
+msgstr ""
+
+#: src/cli/perry-toml.md:559
+msgid "`[ios]`, `[macos]`, `[android]`, `[linux]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:560
+msgid "Code signing & distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:560
+msgid "Platform sections"
+msgstr ""
+
+#: src/cli/perry-toml.md:561
+msgid "Build output directory"
+msgstr ""
+
+#: src/cli/perry-toml.md:562
+msgid "Audit & verification"
+msgstr ""
+
+#: src/cli/perry-toml.md:562
+msgid "`[audit]`, `[verify]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:564
+msgid ""
+"When both files define the same value (e.g., project name), `perry.toml` "
+"takes precedence."
+msgstr ""
+
+#: src/cli/perry-toml.md:568
+msgid "Setup Wizard"
+msgstr ""
+
+#: src/cli/perry-toml.md:570
+msgid ""
+"Running `perry setup <platform>` interactively configures signing "
+"credentials and writes them back to both `perry.toml` and "
+"`~/.perry/config.toml`:"
+msgstr ""
+
+#: src/cli/perry-toml.md:573
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:574
+msgid "# Configure Android signing (keystore, Play Store key)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:575
+msgid "# Configure macOS distribution (App Store, notarization)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:578
+msgid "The wizard automatically:"
+msgstr ""
+
+#: src/cli/perry-toml.md:579
+msgid "Sets `[ios].distribute = \"testflight\"` if not already configured"
+msgstr ""
+
+#: src/cli/perry-toml.md:580
+msgid "Sets `[android].distribute = \"playstore\"` if not already configured"
+msgstr ""
+
+#: src/cli/perry-toml.md:581
+msgid "Stores provisioning profiles as `~/.perry/{bundle_id}.mobileprovision`"
+msgstr ""
+
+#: src/cli/perry-toml.md:582
+msgid "Auto-exports `.p12` certificates from macOS Keychain when possible"
+msgstr ""
+
+#: src/cli/perry-toml.md:586
+msgid "CI/CD Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:588
+msgid ""
+"For CI environments, use environment variables instead of storing "
+"credentials in `perry.toml`:"
+msgstr ""
+
+#: src/cli/perry-toml.md:591
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr ""
+
+#: src/cli/perry-toml.md:593
+msgid "PERRY_LICENSE_KEY"
+msgstr ""
+
+#: src/cli/perry-toml.md:593
+msgid "${{ secrets.PERRY_LICENSE_KEY }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:594
+msgid "PERRY_APPLE_CERTIFICATE"
+msgstr ""
+
+#: src/cli/perry-toml.md:594
+msgid "${{ secrets.APPLE_CERTIFICATE }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:595
+msgid "PERRY_APPLE_CERTIFICATE_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:595
+msgid "${{ secrets.APPLE_CERT_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:596
+msgid "PERRY_APPLE_P8_KEY"
+msgstr ""
+
+#: src/cli/perry-toml.md:596
+msgid "${{ secrets.APPLE_P8_KEY }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:597
+msgid "PERRY_APPLE_KEY_ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:597
+msgid "${{ secrets.APPLE_KEY_ID }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:598
+msgid "PERRY_ANDROID_KEYSTORE"
+msgstr ""
+
+#: src/cli/perry-toml.md:598
+msgid "${{ secrets.ANDROID_KEYSTORE }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:599
+msgid "PERRY_ANDROID_KEYSTORE_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:599
+msgid "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:600
+msgid "PERRY_ANDROID_KEY_ALIAS"
+msgstr ""
+
+#: src/cli/perry-toml.md:600
+msgid "${{ secrets.ANDROID_KEY_ALIAS }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:601
+msgid "PERRY_ANDROID_KEY_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:601
+msgid "${{ secrets.ANDROID_KEY_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:604
+msgid "perry publish ios"
+msgstr ""
+
+#: src/cli/perry-toml.md:605
+msgid "perry publish android"
+msgstr ""
+
+#: src/cli/perry-toml.md:606
+msgid "perry publish macos"
+msgstr ""
+
+#: src/cli/perry-toml.md:609
+msgid "Keep `perry.toml` in version control with non-sensitive fields only:"
+msgstr ""
+
+#: src/cli/perry-toml.md:611
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"version = \"2.1.0\"\n"
+"build_number = 47\n"
+"bundle_id = \"com.example.myapp\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[ios]\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"distribute = \"appstore\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = \"26\"\n"
+"target_sdk = \"34\"\n"
+"distribute = \"playstore\"\n"
+"\n"
+"[macos]\n"
+"distribute = \"both\"\n"
+"category = \"public.app-category.productivity\"\n"
+"minimum_os = \"13.0\"\n"
+"\n"
+"[audit]\n"
+"fail_on = \"B\"\n"
+"```"
+msgstr ""
+
+#: src/contributing/architecture.md:3
+msgid ""
+"This is a brief overview for contributors. For detailed implementation "
+"notes, see the project's `CLAUDE.md`."
+msgstr ""
+
+#: src/contributing/architecture.md:5
+msgid "Compilation Pipeline"
+msgstr ""
+
+#: src/contributing/architecture.md:21
+msgid "Crate Map"
+msgstr ""
+
+#: src/contributing/architecture.md:23
+msgid "Crate"
+msgstr ""
+
+#: src/contributing/architecture.md:25
+msgid "`perry`"
+msgstr ""
+
+#: src/contributing/architecture.md:25
+msgid "CLI driver, command parsing, compilation orchestration"
+msgstr ""
+
+#: src/contributing/architecture.md:26
+msgid "`perry-parser`"
+msgstr ""
+
+#: src/contributing/architecture.md:26
+msgid "SWC wrapper for TypeScript parsing"
+msgstr ""
+
+#: src/contributing/architecture.md:27
+msgid "`perry-types`"
+msgstr ""
+
+#: src/contributing/architecture.md:27
+msgid "Type system definitions"
+msgstr ""
+
+#: src/contributing/architecture.md:28
+msgid "`perry-hir`"
+msgstr ""
+
+#: src/contributing/architecture.md:28
+msgid "HIR data structures (`ir.rs`) and AST→HIR lowering (`lower.rs`)"
+msgstr ""
+
+#: src/contributing/architecture.md:29
+msgid "`perry-transform`"
+msgstr ""
+
+#: src/contributing/architecture.md:29
+msgid "IR passes: function inlining, closure conversion, async lowering"
+msgstr ""
+
+#: src/contributing/architecture.md:30
+msgid "`perry-codegen-llvm`"
+msgstr ""
+
+#: src/contributing/architecture.md:30
+msgid "LLVM-based native code generation"
+msgstr ""
+
+#: src/contributing/architecture.md:31
+msgid "`perry-codegen-wasm`"
+msgstr ""
+
+#: src/contributing/architecture.md:31
+msgid ""
+"WebAssembly code generation for `--target web` / `--target wasm` (HIR → WASM"
+" bytecode + JS bridge)"
+msgstr ""
+
+#: src/contributing/architecture.md:32
+msgid "`perry-codegen-js`"
+msgstr ""
+
+#: src/contributing/architecture.md:32
+msgid ""
+"Legacy JavaScript code generator (still present for the JS minifier; the JS-"
+"emit `--target web` path was consolidated into `perry-codegen-wasm`)"
+msgstr ""
+
+#: src/contributing/architecture.md:33
+msgid "`perry-codegen-swiftui`"
+msgstr ""
+
+#: src/contributing/architecture.md:33
+msgid "SwiftUI code generation for WidgetKit extensions"
+msgstr ""
+
+#: src/contributing/architecture.md:34
+msgid "`perry-runtime`"
+msgstr ""
+
+#: src/contributing/architecture.md:34
+msgid ""
+"Runtime library: NaN-boxed values, GC, arena allocator, objects, arrays, "
+"strings"
+msgstr ""
+
+#: src/contributing/architecture.md:35
+msgid "`perry-stdlib`"
+msgstr ""
+
+#: src/contributing/architecture.md:35
+msgid "Node.js API implementations: mysql2, redis, fastify, bcrypt, etc."
+msgstr ""
+
+#: src/contributing/architecture.md:36
+msgid "`perry-ui`"
+msgstr ""
+
+#: src/contributing/architecture.md:36
+msgid "Shared UI types"
+msgstr ""
+
+#: src/contributing/architecture.md:37
+msgid "macOS UI (AppKit)"
+msgstr ""
+
+#: src/contributing/architecture.md:38
+msgid "iOS UI (UIKit)"
+msgstr ""
+
+#: src/contributing/architecture.md:39
+msgid "`perry-jsruntime`"
+msgstr ""
+
+#: src/contributing/architecture.md:39
+msgid "JavaScript interop via QuickJS"
+msgstr ""
+
+#: src/contributing/architecture.md:41
+msgid "Key Concepts"
+msgstr ""
+
+#: src/contributing/architecture.md:43
+msgid "NaN-Boxing"
+msgstr ""
+
+#: src/contributing/architecture.md:45
+msgid ""
+"All JavaScript values are represented as 64-bit NaN-boxed values. The upper "
+"16 bits encode the type tag:"
+msgstr ""
+
+#: src/contributing/architecture.md:47
+msgid "Tag"
+msgstr ""
+
+#: src/contributing/architecture.md:49
+msgid "`0x7FFF`"
+msgstr ""
+
+#: src/contributing/architecture.md:49
+msgid "String (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:50
+msgid "`0x7FFD`"
+msgstr ""
+
+#: src/contributing/architecture.md:50
+msgid "Pointer/Object (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:51
+msgid "`0x7FFE`"
+msgstr ""
+
+#: src/contributing/architecture.md:51
+msgid "Int32 (lower 32 bits = integer)"
+msgstr ""
+
+#: src/contributing/architecture.md:52
+msgid "`0x7FFA`"
+msgstr ""
+
+#: src/contributing/architecture.md:52
+msgid "BigInt (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:53
+msgid "Special constants"
+msgstr ""
+
+#: src/contributing/architecture.md:53
+msgid "undefined, null, true, false"
+msgstr ""
+
+#: src/contributing/architecture.md:54
+msgid "Any other"
+msgstr ""
+
+#: src/contributing/architecture.md:54
+msgid "Float64 (the full 64 bits)"
+msgstr ""
+
+#: src/contributing/architecture.md:58
+msgid ""
+"Mark-sweep GC with conservative stack scanning. Arena-allocated objects "
+"(arrays, objects) are found by linear block walking. Malloc-allocated "
+"objects (strings, closures, promises) are tracked in a thread-local Vec."
+msgstr ""
+
+#: src/contributing/architecture.md:60
+msgid "Handle-Based UI"
+msgstr ""
+
+#: src/contributing/architecture.md:62
+msgid ""
+"UI widgets are represented as small integer handles NaN-boxed with "
+"`POINTER_TAG`. Each handle maps to a native platform widget (NSButton, "
+"UILabel, GtkButton, etc.). Two dispatch tables route method calls and "
+"property accesses to the correct FFI function."
+msgstr ""
+
+#: src/contributing/architecture.md:64
+msgid "Source Code Organization"
+msgstr ""
+
+#: src/contributing/architecture.md:66
+msgid "The codegen crate is organized into focused modules:"
+msgstr ""
+
+#: src/contributing/architecture.md:83
+msgid "The HIR lowering was split into 8 modules:"
+msgstr ""
+
+#: src/contributing/architecture.md:99
+msgid "[Building from Source](building.md)"
+msgstr ""
+
+#: src/contributing/architecture.md:100
+msgid ""
+"See `CLAUDE.md` in the repository root for detailed implementation notes"
+msgstr ""
+
+#: src/contributing/building.md:5
+msgid "Rust toolchain (stable): [rustup.rs](https://rustup.rs/)"
+msgstr ""
+
+#: src/contributing/building.md:6
+msgid "System C compiler (`cc` on macOS/Linux, MSVC on Windows)"
+msgstr ""
+
+#: src/contributing/building.md:8
+msgid "Build"
+msgstr ""
+
+#: src/contributing/building.md:13
+msgid "# Build all crates (release mode recommended)\n"
+msgstr ""
+
+#: src/contributing/building.md:18
+msgid "The binary is at `target/release/perry`."
+msgstr ""
+
+#: src/contributing/building.md:20
+msgid "Build Specific Crates"
+msgstr ""
+
+#: src/contributing/building.md:23
+msgid "# Runtime only (must rebuild stdlib too!)\n"
+msgstr ""
+
+#: src/contributing/building.md:25
+msgid "# Codegen only\n"
+msgstr ""
+
+#: src/contributing/building.md:30
+msgid ""
+"**Important**: When rebuilding `perry-runtime`, you must also rebuild "
+"`perry-stdlib` because `libperry_stdlib.a` embeds perry-runtime as a static "
+"dependency."
+msgstr ""
+
+#: src/contributing/building.md:32
+msgid "Run Tests"
+msgstr ""
+
+#: src/contributing/building.md:35
+msgid "# All tests (exclude iOS crate on non-iOS host)\n"
+msgstr ""
+
+#: src/contributing/building.md:37
+msgid "# Specific crate\n"
+msgstr ""
+
+#: src/contributing/building.md:43
+msgid "Compile and Run TypeScript"
+msgstr ""
+
+#: src/contributing/building.md:46
+msgid "# Compile a TypeScript file\n"
+msgstr ""
+
+#: src/contributing/building.md:49
+msgid "# Debug: print HIR\n"
+msgstr ""
+
+#: src/contributing/building.md:54
+msgid "Development Workflow"
+msgstr ""
+
+#: src/contributing/building.md:56
+msgid "Make changes to the relevant crate"
+msgstr ""
+
+#: src/contributing/building.md:57
+msgid "`cargo build --release` to build"
+msgstr ""
+
+#: src/contributing/building.md:58
+msgid "`cargo test --workspace --exclude perry-ui-ios` to verify"
+msgstr ""
+
+#: src/contributing/building.md:59
+msgid ""
+"Test with a real TypeScript file: `cargo run --release -- test.ts -o test &&"
+" ./test`"
+msgstr ""
+
+#: src/contributing/building.md:88
+msgid "[Architecture](architecture.md) — Crate map and pipeline overview"
+msgstr ""
+
+#: src/contributing/building.md:89
+msgid "See `CLAUDE.md` for detailed implementation notes and pitfalls"
+msgstr ""

--- a/docs/po/ja.po
+++ b/docs/po/ja.po
@@ -1,0 +1,26519 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Perry Documentation\n"
+"POT-Creation-Date: 2026-05-02T21:12:49+02:00\n"
+"PO-Revision-Date: 2026-05-02T21:12:49+02:00\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/SUMMARY.md:1
+msgid "Summary"
+msgstr "目次"
+
+#: src/SUMMARY.md:3 src/introduction.md:1
+msgid "Introduction"
+msgstr "はじめに"
+
+#: src/SUMMARY.md:7
+msgid "Getting Started"
+msgstr "入門"
+
+#: src/SUMMARY.md:9 src/getting-started/installation.md:1 src/ui/theming.md:5
+msgid "Installation"
+msgstr "インストール"
+
+#: src/SUMMARY.md:10 src/getting-started/hello-world.md:1
+msgid "Hello World"
+msgstr "Hello World"
+
+#: src/SUMMARY.md:11 src/getting-started/first-app.md:1
+msgid "First Native App"
+msgstr "最初のネイティブアプリ"
+
+#: src/SUMMARY.md:12 src/getting-started/project-config.md:1
+msgid "Project Configuration"
+msgstr "プロジェクト設定"
+
+#: src/SUMMARY.md:14
+msgid "Language"
+msgstr "言語"
+
+#: src/SUMMARY.md:16 src/platforms/wasm.md:39
+msgid "Supported Features"
+msgstr "サポートされている機能"
+
+#: src/SUMMARY.md:17 src/language/type-system.md:1
+msgid "Type System"
+msgstr "型システム"
+
+#: src/SUMMARY.md:18 src/language/limitations.md:1 src/platforms/tvos.md:156
+#: src/platforms/watchos.md:192 src/platforms/wasm.md:146
+msgid "Limitations"
+msgstr "制限事項"
+
+#: src/SUMMARY.md:20
+msgid "npm Packages"
+msgstr "npm パッケージ"
+
+#: src/SUMMARY.md:22
+msgid "Porting Packages (experimental)"
+msgstr "パッケージの移植（実験的）"
+
+#: src/SUMMARY.md:24 src/getting-started/hello-world.md:97
+#: src/threading/overview.md:1
+msgid "Multi-Threading"
+msgstr "マルチスレッド"
+
+#: src/SUMMARY.md:26 src/SUMMARY.md:33 src/SUMMARY.md:50 src/SUMMARY.md:66
+#: src/SUMMARY.md:76 src/SUMMARY.md:83 src/SUMMARY.md:87 src/SUMMARY.md:108
+msgid "Overview"
+msgstr "概要"
+
+#: src/SUMMARY.md:27 src/threading/parallel-map.md:1
+msgid "parallelMap"
+msgstr ""
+
+#: src/SUMMARY.md:28 src/threading/parallel-filter.md:1
+msgid "parallelFilter"
+msgstr ""
+
+#: src/SUMMARY.md:29 src/threading/spawn.md:1
+msgid "spawn"
+msgstr ""
+
+#: src/SUMMARY.md:31
+msgid "Native UI"
+msgstr "ネイティブ UI"
+
+#: src/SUMMARY.md:34 src/SUMMARY.md:95 src/SUMMARY.md:97 src/ui/widgets.md:1
+msgid "Widgets"
+msgstr "ウィジェット"
+
+#: src/SUMMARY.md:35 src/ui/overview.md:174 src/ui/layout.md:1
+#: src/widgets/components.md:41
+msgid "Layout"
+msgstr "レイアウト"
+
+#: src/SUMMARY.md:36 src/ui/styling.md:1 src/platforms/linux.md:63
+msgid "Styling"
+msgstr "スタイリング"
+
+#: src/SUMMARY.md:37 src/ui/state.md:1 src/platforms/watchos.md:105
+msgid "State Management"
+msgstr "状態管理"
+
+#: src/SUMMARY.md:38 src/ui/events.md:1 src/plugins/creating-plugins.md:104
+msgid "Events"
+msgstr "イベント"
+
+#: src/SUMMARY.md:39 src/ui/canvas.md:1 src/platforms/macos.md:37
+#: src/platforms/android.md:38 src/platforms/windows.md:55
+#: src/platforms/linux.md:49
+msgid "Canvas"
+msgstr "キャンバス"
+
+#: src/SUMMARY.md:40 src/ui/overview.md:175 src/ui/menus.md:1
+msgid "Menus"
+msgstr "メニュー"
+
+#: src/SUMMARY.md:41 src/ui/dialogs.md:1
+msgid "Dialogs"
+msgstr "ダイアログ"
+
+#: src/SUMMARY.md:42 src/ui/table.md:1 src/platforms/macos.md:36
+#: src/testing/geisterhand.md:93 src/testing/geisterhand.md:296
+msgid "Table"
+msgstr "テーブル"
+
+#: src/SUMMARY.md:43 src/ui/animation.md:1
+msgid "Animation"
+msgstr "アニメーション"
+
+#: src/SUMMARY.md:44
+msgid "Multi-Window"
+msgstr "マルチウィンドウ"
+
+#: src/SUMMARY.md:45 src/ui/theming.md:1
+msgid "Theming"
+msgstr "テーマ"
+
+#: src/SUMMARY.md:46 src/ui/camera.md:1
+msgid "Camera"
+msgstr "カメラ"
+
+#: src/SUMMARY.md:48 src/system/overview.md:21
+msgid "Platforms"
+msgstr "プラットフォーム"
+
+#: src/SUMMARY.md:51 src/getting-started/installation.md:103
+#: src/ui/overview.md:170 src/ui/canvas.md:74 src/ui/menus.md:68
+#: src/ui/menus.md:111 src/ui/dialogs.md:108 src/ui/animation.md:64
+#: src/ui/multi-window.md:72 src/ui/multi-window.md:89
+#: src/ui/multi-window.md:100 src/ui/multi-window.md:116
+#: src/ui/multi-window.md:132 src/ui/multi-window.md:140
+#: src/platforms/overview.md:9 src/platforms/overview.md:67
+#: src/platforms/macos.md:1 src/i18n/overview.md:89
+#: src/updater/overview.md:257 src/system/preferences.md:34
+#: src/system/keychain.md:25 src/system/notifications.md:62
+#: src/system/audio.md:61 src/system/media.md:86 src/system/other.md:20
+#: src/system/other.md:37 src/plugins/native-extensions.md:275
+#: src/plugins/appstore-review.md:89 src/testing/geisterhand.md:259
+#: src/testing/geisterhand.md:331
+msgid "macOS"
+msgstr ""
+
+#: src/SUMMARY.md:52 src/ui/overview.md:170 src/ui/canvas.md:75
+#: src/ui/menus.md:112 src/ui/dialogs.md:108 src/ui/animation.md:65
+#: src/platforms/overview.md:10 src/platforms/overview.md:67
+#: src/platforms/ios.md:1 src/platforms/tvos.md:170 src/i18n/overview.md:90
+#: src/system/preferences.md:35 src/system/keychain.md:26
+#: src/system/notifications.md:63 src/system/audio.md:62
+#: src/system/media.md:87 src/system/other.md:21 src/system/other.md:38
+#: src/widgets/platforms.md:11 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:39 src/widgets/platforms.md:63
+#: src/plugins/native-extensions.md:273 src/plugins/appstore-review.md:73
+#: src/testing/geisterhand.md:260
+msgid "iOS"
+msgstr ""
+
+#: src/SUMMARY.md:53 src/platforms/overview.md:11 src/platforms/overview.md:67
+#: src/platforms/visionos.md:1 src/system/media.md:89
+msgid "visionOS"
+msgstr ""
+
+#: src/SUMMARY.md:54 src/platforms/overview.md:12 src/platforms/overview.md:67
+#: src/platforms/tvos.md:1 src/platforms/tvos.md:170 src/system/media.md:88
+msgid "tvOS"
+msgstr ""
+
+#: src/SUMMARY.md:55 src/platforms/overview.md:13 src/platforms/overview.md:67
+#: src/platforms/watchos.md:1 src/system/media.md:93
+#: src/widgets/platforms.md:14 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:49 src/widgets/platforms.md:79
+msgid "watchOS"
+msgstr ""
+
+#: src/SUMMARY.md:56 src/ui/canvas.md:78 src/ui/animation.md:66
+#: src/platforms/overview.md:14 src/platforms/overview.md:67
+#: src/platforms/android.md:1 src/i18n/overview.md:91 src/i18n/overview.md:104
+#: src/system/preferences.md:36 src/system/keychain.md:27
+#: src/system/notifications.md:64 src/system/audio.md:63
+#: src/system/media.md:90 src/system/other.md:22 src/system/other.md:39
+#: src/widgets/platforms.md:13 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:44 src/widgets/platforms.md:71
+#: src/plugins/native-extensions.md:276 src/plugins/appstore-review.md:102
+#: src/testing/geisterhand.md:261 src/cli/flags.md:27
+#: src/cli/perry-toml.md:501
+msgid "Android"
+msgstr ""
+
+#: src/SUMMARY.md:57 src/platforms/harmonyos.md:1
+msgid "HarmonyOS NEXT"
+msgstr "HarmonyOS NEXT"
+
+#: src/SUMMARY.md:58 src/getting-started/installation.md:121
+#: src/ui/overview.md:170 src/ui/styling.md:372 src/ui/canvas.md:77
+#: src/ui/menus.md:113 src/ui/dialogs.md:108 src/ui/animation.md:67
+#: src/ui/multi-window.md:73 src/ui/multi-window.md:90
+#: src/ui/multi-window.md:101 src/ui/multi-window.md:117
+#: src/ui/multi-window.md:133 src/ui/multi-window.md:141
+#: src/platforms/overview.md:15 src/platforms/overview.md:67
+#: src/platforms/windows.md:1 src/i18n/overview.md:92
+#: src/updater/overview.md:258 src/system/preferences.md:37
+#: src/system/keychain.md:28 src/system/notifications.md:65
+#: src/system/audio.md:65 src/system/media.md:92 src/system/other.md:23
+#: src/system/other.md:40 src/testing/geisterhand.md:263
+#: src/testing/geisterhand.md:392 src/cli/flags.md:36
+msgid "Windows"
+msgstr ""
+
+#: src/SUMMARY.md:59 src/platforms/windows-7.md:1
+msgid "Windows 7 Compatibility"
+msgstr "Windows 7 互換性"
+
+#: src/SUMMARY.md:60 src/platforms/linux.md:1 src/testing/geisterhand.md:262
+#: src/testing/geisterhand.md:379
+msgid "Linux (GTK4)"
+msgstr ""
+
+#: src/SUMMARY.md:61 src/ui/overview.md:170 src/ui/canvas.md:72
+#: src/ui/menus.md:115 src/ui/dialogs.md:108 src/ui/animation.md:69
+#: src/ui/multi-window.md:143 src/platforms/web.md:1
+#: src/system/preferences.md:39 src/system/keychain.md:30
+#: src/system/notifications.md:67 src/system/audio.md:66
+#: src/system/media.md:95 src/system/other.md:25 src/system/other.md:42
+#: src/cli/flags.md:35
+msgid "Web"
+msgstr ""
+
+#: src/SUMMARY.md:62 src/cli/flags.md:34
+msgid "WebAssembly"
+msgstr "WebAssembly"
+
+#: src/SUMMARY.md:64
+msgid "Standard Library"
+msgstr "標準ライブラリ"
+
+#: src/SUMMARY.md:67 src/stdlib/fs.md:1
+msgid "File System"
+msgstr "ファイルシステム"
+
+#: src/SUMMARY.md:68 src/stdlib/http.md:1
+msgid "HTTP & Networking"
+msgstr "HTTP とネットワーク"
+
+#: src/SUMMARY.md:69 src/stdlib/overview.md:22 src/stdlib/database.md:1
+msgid "Databases"
+msgstr "データベース"
+
+#: src/SUMMARY.md:70 src/stdlib/overview.md:29 src/stdlib/crypto.md:1
+msgid "Cryptography"
+msgstr "暗号"
+
+#: src/SUMMARY.md:71 src/stdlib/overview.md:36 src/stdlib/utilities.md:1
+#: src/cli/perry-toml.md:231
+msgid "Utilities"
+msgstr "ユーティリティ"
+
+#: src/SUMMARY.md:72 src/stdlib/other.md:1
+msgid "Other Modules"
+msgstr "その他のモジュール"
+
+#: src/SUMMARY.md:74
+msgid "Internationalization"
+msgstr "国際化"
+
+#: src/SUMMARY.md:77 src/i18n/interpolation.md:1
+msgid "Interpolation & Plurals"
+msgstr "補間と複数形"
+
+#: src/SUMMARY.md:78
+msgid "Formatting"
+msgstr "書式設定"
+
+#: src/SUMMARY.md:79
+msgid "CLI Tools"
+msgstr "CLI ツール"
+
+#: src/SUMMARY.md:81 src/updater/overview.md:1
+msgid "Auto-Update"
+msgstr "自動更新"
+
+#: src/SUMMARY.md:85 src/platforms/overview.md:74 src/platforms/macos.md:75
+msgid "System APIs"
+msgstr "システム API"
+
+#: src/SUMMARY.md:88 src/system/preferences.md:1
+msgid "Preferences"
+msgstr "設定"
+
+#: src/SUMMARY.md:89 src/system/keychain.md:1
+msgid "Keychain"
+msgstr "キーチェーン"
+
+#: src/SUMMARY.md:90 src/system/notifications.md:1
+msgid "Notifications"
+msgstr "通知"
+
+#: src/SUMMARY.md:91 src/system/audio.md:1
+msgid "Audio Capture"
+msgstr "オーディオ録音"
+
+#: src/SUMMARY.md:92 src/system/media.md:1
+msgid "Media Playback"
+msgstr "メディア再生"
+
+#: src/SUMMARY.md:93 src/ui/menus.md:68 src/stdlib/overview.md:50
+msgid "Other"
+msgstr "その他"
+
+#: src/SUMMARY.md:98 src/widgets/creating-widgets.md:1
+msgid "Creating Widgets"
+msgstr "ウィジェットの作成"
+
+#: src/SUMMARY.md:99
+msgid "Components & Modifiers"
+msgstr "コンポーネントと修飾子"
+
+#: src/SUMMARY.md:100 src/platforms/visionos.md:35 src/platforms/tvos.md:123
+#: src/platforms/watchos.md:149 src/widgets/watchos.md:77
+#: src/plugins/creating-plugins.md:98 src/plugins/hooks-and-events.md:115
+msgid "Configuration"
+msgstr "設定"
+
+#: src/SUMMARY.md:101
+msgid "Data Fetching"
+msgstr "データ取得"
+
+#: src/SUMMARY.md:102 src/widgets/platforms.md:1
+msgid "Cross-Platform Reference"
+msgstr "クロスプラットフォーム リファレンス"
+
+#: src/SUMMARY.md:103 src/widgets/watchos.md:1
+msgid "watchOS Complications"
+msgstr "watchOS コンプリケーション"
+
+#: src/SUMMARY.md:104 src/widgets/wearos.md:1
+msgid "Wear OS Tiles"
+msgstr "Wear OS タイル"
+
+#: src/SUMMARY.md:106
+msgid "Plugins"
+msgstr "プラグイン"
+
+#: src/SUMMARY.md:109 src/plugins/creating-plugins.md:1
+msgid "Creating Plugins"
+msgstr "プラグインの作成"
+
+#: src/SUMMARY.md:110 src/plugins/hooks-and-events.md:1
+msgid "Hooks & Events"
+msgstr "フックとイベント"
+
+#: src/SUMMARY.md:111 src/plugins/overview.md:90
+#: src/plugins/native-extensions.md:1
+msgid "Native Extensions"
+msgstr "ネイティブ拡張"
+
+#: src/SUMMARY.md:112 src/plugins/appstore-review.md:1
+msgid "App Store Review"
+msgstr "App Store 審査"
+
+#: src/SUMMARY.md:114
+msgid "Testing"
+msgstr "テスト"
+
+#: src/SUMMARY.md:116
+msgid "Geisterhand (UI Fuzzer)"
+msgstr "Geisterhand（UI ファザー）"
+
+#: src/SUMMARY.md:118
+msgid "CLI Reference"
+msgstr "CLI リファレンス"
+
+#: src/SUMMARY.md:120
+msgid "Commands"
+msgstr "コマンド"
+
+#: src/SUMMARY.md:121 src/cli/flags.md:1
+msgid "Compiler Flags"
+msgstr "コンパイラフラグ"
+
+#: src/SUMMARY.md:122 src/cli/perry-toml.md:1
+msgid "perry.toml Reference"
+msgstr "perry.toml リファレンス"
+
+#: src/SUMMARY.md:126
+msgid "Contributing"
+msgstr "コントリビューション"
+
+#: src/SUMMARY.md:128 src/platforms/harmonyos.md:5
+#: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
+msgid "Architecture"
+msgstr "アーキテクチャ"
+
+#: src/SUMMARY.md:129 src/contributing/building.md:1
+msgid "Building from Source"
+msgstr "ソースからビルド"
+
+#: src/introduction.md:3
+msgid ""
+"Perry is a native TypeScript compiler that compiles TypeScript source code "
+"directly to native executables. No JavaScript runtime, no JIT warmup, no V8 "
+"— your TypeScript compiles to a real binary."
+msgstr ""
+"Perry は、TypeScript ソースコードを直接ネイティブ実行ファイルにコンパイルするネイティブ TypeScript "
+"コンパイラです。JavaScript ランタイム、JIT ウォームアップ、V8 は不要 — あなたの TypeScript "
+"が本物のバイナリにコンパイルされます。"
+
+#: src/introduction.md:5
+msgid ""
+"```typescript\n"
+"// demonstrates: the one-liner hello shown on the docs landing page\n"
+"// docs: docs/src/introduction.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"console.log(\"Hello from Perry!\")\n"
+"```"
+msgstr ""
+
+#: src/introduction.md:20
+msgid "Why Perry?"
+msgstr "なぜ Perry なのか？"
+
+#: src/introduction.md:22
+msgid ""
+"**Native performance** — Compiles to machine code via LLVM. Integer-heavy "
+"code like Fibonacci runs 2x faster than Node.js."
+msgstr ""
+"**ネイティブ性能** — LLVM 経由でマシンコードにコンパイル。フィボナッチのような整数演算中心のコードは Node.js の 2 "
+"倍速で動作します。"
+
+#: src/introduction.md:23
+msgid ""
+"**Real multi-threading** — `parallelMap` and `spawn` give you actual OS "
+"threads with compile-time safety. No isolates, no message passing overhead. "
+"[Something no JS runtime can do](threading/overview.md)."
+msgstr ""
+"**真のマルチスレッド** — `parallelMap` と `spawn` でコンパイル時の安全性を保ちつつ実際の OS "
+"スレッドを使えます。Isolate もメッセージパッシングのオーバーヘッドもありません。[他の JS "
+"ランタイムにはできないこと](threading/overview.md)。"
+
+#: src/introduction.md:24
+msgid ""
+"**Small binaries** — A hello world is ~300KB. Perry detects what runtime "
+"features you use and only links what's needed."
+msgstr ""
+"**小さなバイナリ** — Hello World は約 300KB。Perry が使用するランタイム機能を検出し、必要なものだけをリンクします。"
+
+#: src/introduction.md:25
+msgid ""
+"**Native UI** — Build desktop and mobile apps with declarative TypeScript "
+"that compiles to real AppKit, UIKit, GTK4, Win32, or DOM widgets."
+msgstr ""
+"**ネイティブ UI** — 宣言的な TypeScript でデスクトップ・モバイルアプリを構築。本物の "
+"AppKit、UIKit、GTK4、Win32、DOM ウィジェットにコンパイルされます。"
+
+#: src/introduction.md:26
+msgid ""
+"**7 targets** — macOS, iOS, Android, Windows, Linux, Web, and WebAssembly "
+"from the same source code."
+msgstr ""
+"**7 つのターゲット** — 同じソースコードから macOS、iOS、Android、Windows、Linux、Web、WebAssembly。"
+
+#: src/introduction.md:27
+msgid ""
+"**Familiar ecosystem** — Use npm packages like `fastify`, `mysql2`, `redis`,"
+" `bcrypt`, `lodash`, and more — compiled natively."
+msgstr ""
+"**慣れ親しんだエコシステム** — `fastify`、`mysql2`、`redis`、`bcrypt`、`lodash` などの npm "
+"パッケージをネイティブにコンパイルして使用できます。"
+
+#: src/introduction.md:28
+msgid ""
+"**Zero config** — Point Perry at a `.ts` file and get a binary. No "
+"`tsconfig.json` required."
+msgstr "**設定不要** — Perry に `.ts` ファイルを渡せばバイナリが得られます。`tsconfig.json` は不要。"
+
+#: src/introduction.md:30
+msgid "What Perry Compiles"
+msgstr "Perry がコンパイルできるもの"
+
+#: src/introduction.md:32
+msgid "Perry supports a practical subset of TypeScript:"
+msgstr "Perry は TypeScript の実用的なサブセットをサポートします:"
+
+#: src/introduction.md:34
+msgid "Variables, functions, classes, enums, interfaces"
+msgstr "変数、関数、クラス、列挙型、インターフェース"
+
+#: src/introduction.md:35
+msgid "Async/await, closures, generators"
+msgstr "Async/await、クロージャ、ジェネレーター"
+
+#: src/introduction.md:36
+msgid "Destructuring, spread, template literals"
+msgstr "分割代入、スプレッド、テンプレートリテラル"
+
+#: src/introduction.md:37
+msgid "Arrays, Maps, Sets, typed arrays"
+msgstr "配列、Map、Set、型付き配列"
+
+#: src/introduction.md:38
+msgid "Regular expressions, JSON, Promises"
+msgstr "正規表現、JSON、Promise"
+
+#: src/introduction.md:39
+msgid "Module imports/exports"
+msgstr "モジュールの import/export"
+
+#: src/introduction.md:40
+msgid "Generic type erasure"
+msgstr "ジェネリック型の消去"
+
+#: src/introduction.md:42
+msgid ""
+"See [Supported Features](language/supported-features.md) for the complete "
+"list."
+msgstr "完全なリストは[サポートされている機能](language/supported-features.md)を参照してください。"
+
+#: src/introduction.md:44
+msgid "Quick Example: Native App"
+msgstr "クイック例：ネイティブアプリ"
+
+#: src/introduction.md:46 src/getting-started/first-app.md:10
+msgid ""
+"```typescript\n"
+"// demonstrates: minimal stateful UI — label + increment button\n"
+"// docs: docs/src/ui/state.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, visionos-simulator, tvos-simulator, watchos-simulator, android, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Button, State } from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"App({\n"
+"    title: \"Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Count: ${count.value}`),\n"
+"        Button(\"Increment\", () => count.set(count.value + 1)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/introduction.md:69
+msgid "# Opens a native macOS/Windows/Linux window\n"
+msgstr ""
+
+#: src/introduction.md:72
+msgid ""
+"This produces a ~3MB native app with real platform widgets — no Electron, no"
+" WebView."
+msgstr ""
+"これで本物のプラットフォームウィジェットを備えた約 3MB のネイティブアプリが生成されます — Electron も WebView も不要です。"
+
+#: src/introduction.md:74 src/getting-started/first-app.md:41
+#: src/threading/overview.md:286 src/threading/parallel-map.md:18
+#: src/threading/parallel-filter.md:18 src/platforms/watchos.md:127
+#: src/platforms/wasm.md:29 src/stdlib/overview.md:5 src/i18n/overview.md:78
+#: src/widgets/overview.md:34 src/plugins/overview.md:7
+msgid "How It Works"
+msgstr "仕組み"
+
+#: src/introduction.md:87
+msgid ""
+"Perry uses [SWC](https://swc.rs/) for TypeScript parsing and "
+"[LLVM](https://llvm.org/) for native code generation. Types are erased at "
+"compile time (like `tsc`), and values are represented at runtime using NaN-"
+"boxing for efficient 64-bit tagged values."
+msgstr ""
+"Perry は TypeScript のパースに [SWC](https://swc.rs/) を、ネイティブコード生成に "
+"[LLVM](https://llvm.org/) を使用しています。型はコンパイル時に消去され（`tsc` と同様）、値は実行時に効率的な 64 "
+"ビットタグ付き値として NaN ボクシングで表現されます。"
+
+#: src/introduction.md:89 src/getting-started/hello-world.md:152
+#: src/getting-started/first-app.md:184
+#: src/getting-started/project-config.md:201
+#: src/language/supported-features.md:600 src/language/type-system.md:149
+#: src/language/limitations.md:182 src/threading/overview.md:312
+#: src/ui/overview.md:179 src/ui/widgets.md:396 src/ui/layout.md:367
+#: src/ui/styling.md:377 src/ui/state.md:225 src/ui/events.md:167
+#: src/ui/canvas.md:80 src/ui/menus.md:119 src/ui/dialogs.md:166
+#: src/ui/table.md:107 src/ui/animation.md:71 src/ui/multi-window.md:149
+#: src/ui/theming.md:166 src/ui/camera.md:143 src/platforms/overview.md:78
+#: src/platforms/macos.md:86 src/platforms/ios.md:137
+#: src/platforms/tvos.md:180 src/platforms/watchos.md:213
+#: src/platforms/android.md:92 src/platforms/windows.md:69
+#: src/platforms/linux.md:81 src/platforms/web.md:21 src/platforms/wasm.md:191
+#: src/stdlib/overview.md:100 src/stdlib/fs.md:88 src/stdlib/http.md:93
+#: src/stdlib/database.md:107 src/stdlib/crypto.md:87
+#: src/stdlib/utilities.md:104 src/stdlib/other.md:184
+#: src/i18n/overview.md:107 src/updater/overview.md:433
+#: src/system/overview.md:71 src/system/preferences.md:44
+#: src/system/keychain.md:35 src/system/notifications.md:72
+#: src/system/audio.md:71 src/system/other.md:68 src/widgets/overview.md:60
+#: src/widgets/creating-widgets.md:249 src/widgets/components.md:270
+#: src/widgets/configuration.md:139 src/widgets/data-fetching.md:203
+#: src/plugins/overview.md:96 src/plugins/creating-plugins.md:111
+#: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:297
+#: src/plugins/appstore-review.md:192 src/cli/commands.md:320
+#: src/cli/flags.md:176 src/contributing/architecture.md:97
+#: src/contributing/building.md:86
+msgid "Next Steps"
+msgstr "次のステップ"
+
+#: src/introduction.md:91
+msgid "[Install Perry](getting-started/installation.md)"
+msgstr "[Perry をインストール](getting-started/installation.md)"
+
+#: src/introduction.md:92
+msgid "[Write your first program](getting-started/hello-world.md)"
+msgstr "[最初のプログラムを書く](getting-started/hello-world.md)"
+
+#: src/introduction.md:93
+msgid "[Build a native app](getting-started/first-app.md)"
+msgstr "[ネイティブアプリを作成する](getting-started/first-app.md)"
+
+#: src/getting-started/installation.md:3 src/platforms/visionos.md:7
+#: src/contributing/building.md:3
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#: src/getting-started/installation.md:5
+msgid ""
+"Perry compiles TypeScript to native binaries by linking with your system's C"
+" toolchain, so every install path needs a linker:"
+msgstr ""
+
+#: src/getting-started/installation.md:7
+msgid "**macOS**: Xcode Command Line Tools (`xcode-select --install`)"
+msgstr ""
+
+#: src/getting-started/installation.md:8
+msgid ""
+"**Linux**: `gcc` or `clang` (`apt install build-essential` on Debian/Ubuntu,"
+" `apk add build-base` on Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:9
+msgid ""
+"**Windows**: LLVM (`winget install LLVM.LLVM`) + `perry setup windows` "
+"(lightweight, ~1.5 GB, no Visual Studio needed), or MSVC Build Tools with "
+"the \"Desktop development with C++\" workload — see the [Windows platform "
+"guide](../platforms/windows.md) for both options"
+msgstr ""
+
+#: src/getting-started/installation.md:11
+msgid ""
+"The source install additionally needs the **Rust toolchain** via "
+"[rustup](https://rustup.rs/)."
+msgstr ""
+
+#: src/getting-started/installation.md:13
+msgid "Install Perry"
+msgstr "Perry のインストール"
+
+#: src/getting-started/installation.md:15
+msgid "npm / npx (recommended — any platform)"
+msgstr ""
+
+#: src/getting-started/installation.md:17
+msgid ""
+"Perry ships as a prebuilt-binary npm package. This is the fastest way to get"
+" started and the only path that covers all seven supported platforms (macOS "
+"arm64/x64, Linux x64/arm64 glibc + musl, Windows x64) with a single command:"
+msgstr ""
+
+#: src/getting-started/installation.md:20
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
+msgstr ""
+
+#: src/getting-started/installation.md:23
+msgid "# Global\n"
+msgstr ""
+
+#: src/getting-started/installation.md:27
+msgid "# Zero-install, one-shot\n"
+msgstr ""
+
+#: src/getting-started/installation.md:32
+msgid ""
+"[`@perryts/perry`](https://www.npmjs.com/package/@perryts/perry) is a thin "
+"launcher; npm automatically picks the matching prebuilt via "
+"`optionalDependencies` (`@perryts/perry-darwin-arm64`, `@perryts/perry-"
+"linux-x64-musl`, etc.) based on your `os` / `cpu` / `libc`. Requires Node.js"
+" ≥ 16."
+msgstr ""
+
+#: src/getting-started/installation.md:34 src/ui/styling.md:368
+#: src/ui/canvas.md:70 src/ui/menus.md:109 src/ui/animation.md:62
+#: src/ui/multi-window.md:70 src/ui/multi-window.md:87
+#: src/ui/multi-window.md:98 src/ui/multi-window.md:114
+#: src/ui/multi-window.md:130 src/ui/multi-window.md:138
+#: src/platforms/overview.md:7 src/i18n/overview.md:87
+#: src/i18n/overview.md:101 src/updater/overview.md:255
+#: src/system/preferences.md:32 src/system/keychain.md:23
+#: src/system/notifications.md:60 src/system/audio.md:59
+#: src/system/media.md:84 src/system/other.md:18 src/system/other.md:35
+#: src/widgets/platforms.md:9 src/plugins/native-extensions.md:271
+#: src/testing/geisterhand.md:257 src/cli/flags.md:20
+msgid "Platform"
+msgstr ""
+
+#: src/getting-started/installation.md:34
+msgid "Prebuilt package"
+msgstr ""
+
+#: src/getting-started/installation.md:36
+msgid "macOS arm64 (Apple Silicon)"
+msgstr ""
+
+#: src/getting-started/installation.md:36
+msgid "`@perryts/perry-darwin-arm64`"
+msgstr ""
+
+#: src/getting-started/installation.md:37
+msgid "macOS x64 (Intel)"
+msgstr ""
+
+#: src/getting-started/installation.md:37
+msgid "`@perryts/perry-darwin-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:38
+msgid "Linux x64 (glibc)"
+msgstr ""
+
+#: src/getting-started/installation.md:38
+msgid "`@perryts/perry-linux-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:39
+msgid "Linux arm64 (glibc)"
+msgstr ""
+
+#: src/getting-started/installation.md:39
+msgid "`@perryts/perry-linux-arm64`"
+msgstr ""
+
+#: src/getting-started/installation.md:40
+msgid "Linux x64 (musl / Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:40
+msgid "`@perryts/perry-linux-x64-musl`"
+msgstr ""
+
+#: src/getting-started/installation.md:41
+msgid "Linux arm64 (musl / Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:41
+msgid "`@perryts/perry-linux-arm64-musl`"
+msgstr ""
+
+#: src/getting-started/installation.md:42
+msgid "Windows x64"
+msgstr ""
+
+#: src/getting-started/installation.md:42
+msgid "`@perryts/perry-win32-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:44
+msgid "Homebrew (macOS)"
+msgstr ""
+
+#: src/getting-started/installation.md:50
+msgid "winget (Windows)"
+msgstr ""
+
+#: src/getting-started/installation.md:56
+msgid "APT (Debian / Ubuntu)"
+msgstr ""
+
+#: src/getting-started/installation.md:60
+msgid ""
+"\"deb [signed-by=/usr/share/keyrings/perry.gpg] "
+"https://perryts.github.io/perry-apt stable main\""
+msgstr ""
+
+#: src/getting-started/installation.md:64
+msgid "From Source"
+msgstr ""
+
+#: src/getting-started/installation.md:72
+msgid "The binary is at `target/release/perry`. Add it to your PATH:"
+msgstr ""
+
+#: src/getting-started/installation.md:75
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
+msgstr ""
+
+#: src/getting-started/installation.md:76
+msgid "\"/path/to/perry/target/release:$PATH\""
+msgstr ""
+
+#: src/getting-started/installation.md:79
+msgid "Self-Update"
+msgstr ""
+
+#: src/getting-started/installation.md:81
+msgid "Once installed, Perry can update itself:"
+msgstr ""
+
+#: src/getting-started/installation.md:87
+msgid "This downloads the latest release and atomically replaces the binary."
+msgstr ""
+
+#: src/getting-started/installation.md:89
+msgid "Verify Installation"
+msgstr ""
+
+#: src/getting-started/installation.md:95
+msgid ""
+"This checks your installation, shows the current version, and reports if an "
+"update is available."
+msgstr ""
+
+#: src/getting-started/installation.md:101
+msgid "Platform-Specific Setup"
+msgstr ""
+
+#: src/getting-started/installation.md:105
+msgid ""
+"No additional setup needed. Perry uses the system `cc` linker and AppKit for"
+" UI apps."
+msgstr ""
+
+#: src/getting-started/installation.md:107
+msgid ""
+"For iOS development, install Xcode (not just Command Line Tools) for the iOS"
+" SDK and simulator."
+msgstr ""
+
+#: src/getting-started/installation.md:109 src/ui/overview.md:170
+#: src/ui/canvas.md:76 src/ui/menus.md:114 src/ui/dialogs.md:108
+#: src/ui/animation.md:68 src/ui/multi-window.md:74 src/ui/multi-window.md:91
+#: src/ui/multi-window.md:102 src/ui/multi-window.md:118
+#: src/ui/multi-window.md:134 src/ui/multi-window.md:142
+#: src/platforms/overview.md:16 src/platforms/overview.md:67
+#: src/i18n/overview.md:93 src/updater/overview.md:259
+#: src/system/preferences.md:38 src/system/keychain.md:29
+#: src/system/notifications.md:66 src/system/audio.md:64
+#: src/system/other.md:24 src/system/other.md:41 src/cli/flags.md:37
+msgid "Linux"
+msgstr ""
+
+#: src/getting-started/installation.md:111
+msgid "Install GTK4 development libraries for UI apps:"
+msgstr ""
+
+#: src/getting-started/installation.md:114 src/platforms/linux.md:9
+#: src/testing/geisterhand.md:384
+msgid "# Ubuntu/Debian\n"
+msgstr ""
+
+#: src/getting-started/installation.md:116 src/platforms/linux.md:12
+msgid "# Fedora\n"
+msgstr ""
+
+#: src/getting-started/installation.md:123
+msgid "Two toolchain options — pick one. Both produce identical binaries."
+msgstr ""
+
+#: src/getting-started/installation.md:125
+msgid "**Lightweight (recommended, ~1.5 GB, no Visual Studio):**"
+msgstr ""
+
+#: src/getting-started/installation.md:132
+msgid ""
+"`perry setup windows` downloads the Microsoft CRT + Windows SDK libraries "
+"via xwin after prompting for license acceptance. Pass `--accept-license` to "
+"skip the prompt in CI."
+msgstr ""
+
+#: src/getting-started/installation.md:134
+msgid "**MSVC Build Tools (~8 GB):**"
+msgstr ""
+
+#: src/getting-started/installation.md:136
+msgid ""
+"Install Visual Studio Build Tools with the \"Desktop development with C++\" "
+"workload — via the Visual Studio Installer, or:"
+msgstr ""
+
+#: src/getting-started/installation.md:138 src/platforms/windows.md:25
+msgid ""
+"```powershell\n"
+"winget install Microsoft.VisualStudio.2022.BuildTools --override `\n"
+"  \"--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended\"\n"
+"```"
+msgstr ""
+
+#: src/getting-started/installation.md:143
+msgid ""
+"Run `perry doctor` to verify the toolchain. See the [Windows platform "
+"guide](../platforms/windows.md) for details."
+msgstr ""
+
+#: src/getting-started/installation.md:145
+msgid "What's Next"
+msgstr ""
+
+#: src/getting-started/installation.md:147
+msgid "[Write your first program](hello-world.md)"
+msgstr ""
+
+#: src/getting-started/installation.md:148
+msgid "[Build a native app](first-app.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:3
+msgid "Your First Program"
+msgstr "最初のプログラム"
+
+#: src/getting-started/hello-world.md:5
+msgid "Create a file called `hello.ts`:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:7
+msgid ""
+"```typescript\n"
+"// demonstrates: the minimal Perry program in the docs\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"console.log(\"Hello, Perry!\")\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:16
+msgid "Compile and run it:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:23 src/threading/spawn.md:46
+#: src/widgets/wearos.md:64
+msgid "Output:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:29
+msgid ""
+"That's it. Perry compiled your TypeScript to a native executable — no "
+"Node.js, no bundler, no runtime."
+msgstr ""
+
+#: src/getting-started/hello-world.md:31
+msgid "A Slightly Bigger Example"
+msgstr "もう少し大きな例"
+
+#: src/getting-started/hello-world.md:33
+msgid ""
+"```typescript\n"
+"// demonstrates: recursive fib as a perf-vs-node talking point\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"function fibonacci(n: number): number {\n"
+"    if (n <= 1) return n\n"
+"    return fibonacci(n - 1) + fibonacci(n - 2)\n"
+"}\n"
+"\n"
+"const start = Date.now()\n"
+"const result = fibonacci(35)\n"
+"const elapsed = Date.now() - start\n"
+"\n"
+"console.log(`fibonacci(35) = ${result}`)\n"
+"console.log(`Completed in ${elapsed}ms`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:57
+msgid ""
+"This runs about 2x faster than Node.js because Perry compiles to native "
+"machine code with integer specialization."
+msgstr ""
+
+#: src/getting-started/hello-world.md:59
+msgid "Using Variables and Functions"
+msgstr "変数と関数の使い方"
+
+#: src/getting-started/hello-world.md:61
+msgid ""
+"```typescript\n"
+"const name: string = \"World\"\n"
+"const items: number[] = [1, 2, 3, 4, 5]\n"
+"\n"
+"const doubled = items.map((x) => x * 2)\n"
+"const sum = doubled.reduce((acc, x) => acc + x, 0)\n"
+"\n"
+"console.log(`Hello, ${name}!`)\n"
+"console.log(`Sum of doubled: ${sum}`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:72
+msgid "Async Code"
+msgstr "非同期コード"
+
+#: src/getting-started/hello-world.md:74
+msgid ""
+"```typescript\n"
+"// demonstrates: async/await fetch shown in hello-world.md\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// run: false\n"
+"\n"
+"async function fetchData(): Promise<string> {\n"
+"    const response = await fetch(\"https://httpbin.org/get\")\n"
+"    const data = await response.json() as { origin: string }\n"
+"    return data.origin\n"
+"}\n"
+"\n"
+"const ip = await fetchData()\n"
+"console.log(`Your IP: ${ip}`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:95
+msgid "Perry compiles async/await to a native async runtime backed by Tokio."
+msgstr ""
+
+#: src/getting-started/hello-world.md:99
+msgid ""
+"Perry can do something no JavaScript runtime can — run your code on multiple"
+" CPU cores:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:101
+msgid ""
+"```typescript\n"
+"// demonstrates: parallelMap + spawn shown in hello-world.md\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"import { parallelMap, parallelFilter, spawn } from \"perry/thread\"\n"
+"\n"
+"const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"// Process all elements across all CPU cores\n"
+"const doubled = parallelMap(data, (x: number) => x * 2)\n"
+"console.log(doubled) // [2, 4, 6, 8, 10, 12, 14, 16]\n"
+"\n"
+"// Run heavy work in the background\n"
+"const result = await spawn(() => {\n"
+"    let sum = 0\n"
+"    for (let i = 0; i < 100_000_000; i++) sum += i\n"
+"    return sum\n"
+"})\n"
+"console.log(result)\n"
+"\n"
+"// parallelFilter is also available for the lift-and-parallelize case:\n"
+"const evens = parallelFilter(data, (x: number) => x % 2 === 0)\n"
+"console.log(evens)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:127
+msgid ""
+"This is real OS-level parallelism, not web workers or separate isolates. See"
+" [Multi-Threading](../threading/overview.md) for details."
+msgstr ""
+
+#: src/getting-started/hello-world.md:129
+msgid "What the Compiler Produces"
+msgstr "コンパイラが生成するもの"
+
+#: src/getting-started/hello-world.md:131
+msgid "When you run `perry file.ts -o output`, Perry:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:133
+msgid "Parses your TypeScript with SWC"
+msgstr ""
+
+#: src/getting-started/hello-world.md:134
+msgid "Lowers the AST to an intermediate representation (HIR)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:135
+msgid "Applies optimizations (inlining, closure conversion, etc.)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:136
+msgid "Generates native machine code with LLVM"
+msgstr ""
+
+#: src/getting-started/hello-world.md:137
+msgid "Links with your system's C compiler"
+msgstr ""
+
+#: src/getting-started/hello-world.md:139
+msgid "The result is a standalone executable with no external dependencies."
+msgstr ""
+
+#: src/getting-started/hello-world.md:141
+#: src/getting-started/hello-world.md:143 src/stdlib/overview.md:66
+#: src/stdlib/overview.md:70
+msgid "Binary Size"
+msgstr "バイナリサイズ"
+
+#: src/getting-started/hello-world.md:143
+msgid "Program"
+msgstr ""
+
+#: src/getting-started/hello-world.md:145
+msgid "Hello world"
+msgstr ""
+
+#: src/getting-started/hello-world.md:145 src/stdlib/overview.md:72
+msgid "~300KB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:146
+msgid "CLI with fs/path"
+msgstr ""
+
+#: src/getting-started/hello-world.md:146
+#: src/getting-started/hello-world.md:147 src/stdlib/overview.md:73
+msgid "~3MB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:147
+msgid "UI app"
+msgstr ""
+
+#: src/getting-started/hello-world.md:148
+msgid "Full app with stdlib"
+msgstr ""
+
+#: src/getting-started/hello-world.md:148 src/stdlib/overview.md:74
+msgid "~48MB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:150
+msgid ""
+"Perry automatically detects which runtime features you use and only links "
+"what's needed."
+msgstr ""
+
+#: src/getting-started/hello-world.md:154
+msgid "[Build a native UI app](first-app.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:155
+msgid "[Configure your project](project-config.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:156
+msgid ""
+"[Explore supported TypeScript features](../language/supported-features.md)"
+msgstr ""
+
+#: src/getting-started/first-app.md:3
+msgid ""
+"Perry compiles declarative TypeScript UI code to native platform widgets. No"
+" Electron, no WebView — real AppKit on macOS, UIKit on iOS, GTK4 on Linux, "
+"Win32 on Windows. Every example on this page is a real source file under "
+"`docs/examples/` that CI compiles and runs on every PR."
+msgstr ""
+
+#: src/getting-started/first-app.md:8
+msgid "A Simple Counter"
+msgstr "シンプルなカウンタ"
+
+#: src/getting-started/first-app.md:31
+msgid "Compile and run:"
+msgstr ""
+
+#: src/getting-started/first-app.md:38
+msgid ""
+"A native window opens with a label and two buttons. Clicking \"Increment\" "
+"updates the count in real-time."
+msgstr ""
+
+#: src/getting-started/first-app.md:43
+msgid ""
+"**`App({ title, width, height, body })`** — Creates a native application "
+"window. `body` is the root widget."
+msgstr ""
+
+#: src/getting-started/first-app.md:44
+msgid ""
+"**`State(initialValue)`** — Creates reactive state. `.value` reads, "
+"`.set(v)` writes and triggers UI updates."
+msgstr ""
+
+#: src/getting-started/first-app.md:45
+msgid ""
+"**`VStack(spacing, [...])`** — Vertical stack layout (like SwiftUI's VStack "
+"or CSS flexbox column). The first arg is the gap in points between children."
+msgstr ""
+
+#: src/getting-started/first-app.md:46
+msgid ""
+"**`Text(string)`** — A text label. Template literals referencing "
+"`${state.value}` bind reactively."
+msgstr ""
+
+#: src/getting-started/first-app.md:47
+msgid "**`Button(label, onClick)`** — A native button with a click handler."
+msgstr ""
+
+#: src/getting-started/first-app.md:49
+msgid "A Todo App"
+msgstr "Todo アプリ"
+
+#: src/getting-started/first-app.md:51 src/ui/state.md:160
+msgid ""
+"```typescript\n"
+"// demonstrates: complete reactive todo app combining State, ForEach, and widget tree mutation\n"
+"// docs: docs/src/ui/state.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    TextField,\n"
+"    VStack,\n"
+"    HStack,\n"
+"    State,\n"
+"    ForEach,\n"
+"    Spacer,\n"
+"    Divider,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const todos = State<string[]>([])\n"
+"const count = State(0)\n"
+"const input = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"Todo App\",\n"
+"    width: 480,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        Text(\"My Todos\"),\n"
+"\n"
+"        HStack(8, [\n"
+"            TextField(\"What needs to be done?\", (value: string) => input.set(value)),\n"
+"            Button(\"Add\", () => {\n"
+"                const text = input.value\n"
+"                if (text.length > 0) {\n"
+"                    todos.set([...todos.value, text])\n"
+"                    count.set(count.value + 1)\n"
+"                    input.set(\"\")\n"
+"                }\n"
+"            }),\n"
+"        ]),\n"
+"\n"
+"        Divider(),\n"
+"\n"
+"        ForEach(count, (i: number) =>\n"
+"            HStack(8, [\n"
+"                Text(todos.value[i]),\n"
+"                Spacer(),\n"
+"                Button(\"Delete\", () => {\n"
+"                    todos.set(todos.value.filter((_, idx) => idx !== i))\n"
+"                    count.set(count.value - 1)\n"
+"                }),\n"
+"            ]),\n"
+"        ),\n"
+"\n"
+"        Spacer(),\n"
+"        Text(`${count.value} items`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/getting-started/first-app.md:112
+msgid ""
+"`ForEach(count, render)` iterates by index — keep an item array and a count "
+"state in sync, then read items via `array.value[i]` inside the closure. See "
+"[State Management](../ui/state.md) for the full pattern."
+msgstr ""
+
+#: src/getting-started/first-app.md:116
+msgid "Cross-Platform"
+msgstr "クロスプラットフォーム"
+
+#: src/getting-started/first-app.md:118
+msgid "The same code runs on all 6 platforms:"
+msgstr ""
+
+#: src/getting-started/first-app.md:121
+msgid "# macOS (default)\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:124
+msgid "# iOS Simulator\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:127
+msgid ""
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:129 src/platforms/overview.md:30
+msgid "# alias: --target wasm\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:131
+msgid "# Other platforms\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:138
+msgid ""
+"Each target compiles to the platform's native widget toolkit. See "
+"[Platforms](../platforms/overview.md) for details."
+msgstr ""
+
+#: src/getting-started/first-app.md:141
+msgid "Adding Styling"
+msgstr ""
+
+#: src/getting-started/first-app.md:143
+msgid ""
+"Styling is applied via free functions that take the widget handle as their "
+"first argument. Colors are RGBA floats in `[0.0, 1.0]` — divide a hex byte "
+"by 255 to convert (`0x33 / 255 ≈ 0.2`)."
+msgstr ""
+
+#: src/getting-started/first-app.md:147
+msgid ""
+"```typescript\n"
+"// demonstrates: counter from getting-started/first-app.md with styled widgets\n"
+"// docs: docs/src/getting-started/first-app.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"// run: false\n"
+"\n"
+"import {\n"
+"    App, VStack, Text, Button, State,\n"
+"    textSetFontSize, textSetColor,\n"
+"    setCornerRadius, setPadding,\n"
+"    widgetSetBackgroundColor,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"const label = Text(`Count: ${count.value}`)\n"
+"textSetFontSize(label, 24)\n"
+"textSetColor(label, 0.2, 0.2, 0.2, 1.0)        // RGBA in [0,1] — same as #333333\n"
+"\n"
+"const btn = Button(\"Increment\", () => count.set(count.value + 1))\n"
+"setCornerRadius(btn, 8)\n"
+"widgetSetBackgroundColor(btn, 0.0, 0.478, 1.0, 1.0)  // system blue\n"
+"\n"
+"const stack = VStack(20, [label, btn])\n"
+"setPadding(stack, 20, 20, 20, 20)\n"
+"\n"
+"App({\n"
+"    title: \"Styled Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: stack,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/getting-started/first-app.md:182
+msgid "See [Styling](../ui/styling.md) for all available style properties."
+msgstr ""
+
+#: src/getting-started/first-app.md:186
+msgid ""
+"[Project Configuration](project-config.md) — Set up `package.json` for Perry"
+" projects"
+msgstr ""
+
+#: src/getting-started/first-app.md:187
+msgid "[UI Overview](../ui/overview.md) — Complete guide to Perry's UI system"
+msgstr ""
+
+#: src/getting-started/first-app.md:188
+msgid "[Widgets Reference](../ui/widgets.md) — All available widgets"
+msgstr ""
+
+#: src/getting-started/first-app.md:189
+msgid "[State Management](../ui/state.md) — Reactive state and bindings"
+msgstr ""
+
+#: src/getting-started/project-config.md:3
+msgid ""
+"Perry projects use `perry.toml` and `package.json` for configuration. No "
+"special config file is required for basic usage, but larger projects benefit"
+" from Perry-specific settings."
+msgstr ""
+
+#: src/getting-started/project-config.md:5
+msgid ""
+"**Looking for the full perry.toml reference?** See [perry.toml "
+"Reference](../cli/perry-toml.md) for every field, section, platform option, "
+"and environment variable."
+msgstr ""
+
+#: src/getting-started/project-config.md:7
+msgid "Basic Setup"
+msgstr "基本セットアップ"
+
+#: src/getting-started/project-config.md:14
+msgid "This creates a `package.json` and a starter `src/index.ts`."
+msgstr ""
+
+#: src/getting-started/project-config.md:16
+msgid "package.json"
+msgstr "package.json"
+
+#: src/getting-started/project-config.md:20
+#: src/plugins/native-extensions.md:58 src/plugins/native-extensions.md:64
+#: src/plugins/appstore-review.md:183
+msgid "\"name\""
+msgstr ""
+
+#: src/getting-started/project-config.md:20
+msgid "\"my-project\""
+msgstr ""
+
+#: src/getting-started/project-config.md:21
+#: src/plugins/native-extensions.md:59
+msgid "\"version\""
+msgstr ""
+
+#: src/getting-started/project-config.md:21
+msgid "\"1.0.0\""
+msgstr ""
+
+#: src/getting-started/project-config.md:22
+#: src/plugins/native-extensions.md:60
+msgid "\"main\""
+msgstr ""
+
+#: src/getting-started/project-config.md:22
+#: src/plugins/native-extensions.md:60
+msgid "\"src/index.ts\""
+msgstr ""
+
+#: src/getting-started/project-config.md:23
+#: src/getting-started/project-config.md:39
+#: src/getting-started/project-config.md:61
+#: src/getting-started/project-config.md:74
+#: src/getting-started/project-config.md:95 src/packages/porting.md:24
+#: src/platforms/ios.md:98 src/platforms/ios.md:111
+#: src/platforms/android.md:57 src/platforms/android.md:72
+#: src/stdlib/overview.md:84 src/plugins/native-extensions.md:61
+#: src/plugins/appstore-review.md:180
+msgid "\"perry\""
+msgstr ""
+
+#: src/getting-started/project-config.md:24
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"compilePackages\""
+msgstr ""
+
+#: src/getting-started/project-config.md:29
+msgid "Perry Configuration"
+msgstr "Perry の設定"
+
+#: src/getting-started/project-config.md:31
+msgid "The `perry` field in `package.json` controls compiler behavior:"
+msgstr ""
+
+#: src/getting-started/project-config.md:33
+msgid "`compilePackages`"
+msgstr ""
+
+#: src/getting-started/project-config.md:35
+msgid ""
+"List npm packages to compile natively instead of routing through the "
+"JavaScript runtime:"
+msgstr ""
+
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"@noble/curves\""
+msgstr ""
+
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"@noble/hashes\""
+msgstr ""
+
+#: src/getting-started/project-config.md:45
+msgid "When a package is listed here, Perry:"
+msgstr ""
+
+#: src/getting-started/project-config.md:46
+msgid "Resolves the package in `node_modules/`"
+msgstr ""
+
+#: src/getting-started/project-config.md:47
+msgid ""
+"Prefers TypeScript source (`src/index.ts`) over compiled JavaScript "
+"(`lib/index.js`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:48
+msgid "Compiles all functions natively through LLVM"
+msgstr ""
+
+#: src/getting-started/project-config.md:49
+msgid ""
+"Deduplicates across nested `node_modules/` to prevent duplicate linker "
+"symbols"
+msgstr ""
+
+#: src/getting-started/project-config.md:51
+msgid ""
+"This is useful for pure TypeScript/JavaScript packages that don't rely on "
+"Node.js APIs. Packages that use native bindings, `eval()`, or dynamic "
+"`require()` won't work."
+msgstr ""
+
+#: src/getting-started/project-config.md:53
+msgid "`splash`"
+msgstr ""
+
+#: src/getting-started/project-config.md:55
+msgid ""
+"Configure a native splash screen for iOS and Android. The splash screen "
+"appears instantly during cold start, before your app code runs."
+msgstr ""
+
+#: src/getting-started/project-config.md:57
+msgid "**Minimal (both platforms share the same splash):**"
+msgstr ""
+
+#: src/getting-started/project-config.md:62
+#: src/getting-started/project-config.md:75
+#: src/getting-started/project-config.md:96 src/platforms/ios.md:99
+#: src/platforms/ios.md:112 src/platforms/android.md:58
+#: src/platforms/android.md:73
+msgid "\"splash\""
+msgstr ""
+
+#: src/getting-started/project-config.md:63
+#: src/getting-started/project-config.md:76
+#: src/getting-started/project-config.md:79
+#: src/getting-started/project-config.md:83 src/platforms/ios.md:100
+#: src/platforms/android.md:59
+msgid "\"image\""
+msgstr ""
+
+#: src/getting-started/project-config.md:63
+#: src/getting-started/project-config.md:76 src/platforms/ios.md:100
+#: src/platforms/android.md:59
+msgid "\"logo/icon-256.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:64
+#: src/getting-started/project-config.md:77
+#: src/getting-started/project-config.md:80
+#: src/getting-started/project-config.md:84 src/ui/theming.md:26
+#: src/platforms/ios.md:101 src/platforms/android.md:60
+msgid "\"background\""
+msgstr ""
+
+#: src/getting-started/project-config.md:64
+#: src/getting-started/project-config.md:77 src/platforms/ios.md:101
+#: src/platforms/android.md:60
+msgid "\"#FFF5EE\""
+msgstr ""
+
+#: src/getting-started/project-config.md:70
+msgid "**Per-platform overrides:**"
+msgstr ""
+
+#: src/getting-started/project-config.md:78
+#: src/getting-started/project-config.md:97 src/platforms/ios.md:113
+#: src/plugins/native-extensions.md:67
+msgid "\"ios\""
+msgstr ""
+
+#: src/getting-started/project-config.md:79
+msgid "\"logo/splash-ios.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:80
+#: src/getting-started/project-config.md:84 src/ui/theming.md:26
+#: src/ui/theming.md:29
+msgid "\"#FFFFFF\""
+msgstr ""
+
+#: src/getting-started/project-config.md:82
+#: src/getting-started/project-config.md:100 src/platforms/android.md:74
+#: src/plugins/native-extensions.md:72
+msgid "\"android\""
+msgstr ""
+
+#: src/getting-started/project-config.md:83
+msgid "\"logo/splash-android.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:91
+msgid "**Full custom override (complete control):**"
+msgstr ""
+
+#: src/getting-started/project-config.md:98 src/platforms/ios.md:113
+msgid "\"storyboard\""
+msgstr ""
+
+#: src/getting-started/project-config.md:98 src/platforms/ios.md:113
+msgid "\"splash/LaunchScreen.storyboard\""
+msgstr ""
+
+#: src/getting-started/project-config.md:101 src/platforms/android.md:75
+msgid "\"layout\""
+msgstr ""
+
+#: src/getting-started/project-config.md:101 src/platforms/android.md:75
+msgid "\"splash/splash_background.xml\""
+msgstr ""
+
+#: src/getting-started/project-config.md:102 src/platforms/android.md:76
+msgid "\"theme\""
+msgstr ""
+
+#: src/getting-started/project-config.md:102 src/platforms/android.md:76
+msgid "\"splash/themes.xml\""
+msgstr ""
+
+#: src/getting-started/project-config.md:109 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414
+msgid "Field"
+msgstr ""
+
+#: src/getting-started/project-config.md:109 src/ui/overview.md:57
+#: src/ui/widgets.md:377 src/ui/layout.md:173 src/ui/menus.md:53
+#: src/ui/multi-window.md:36 src/ui/multi-window.md:80
+#: src/ui/multi-window.md:124 src/system/overview.md:21
+#: src/widgets/creating-widgets.md:45 src/widgets/configuration.md:70
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/testing/geisterhand.md:84 src/testing/geisterhand.md:98
+#: src/cli/commands.md:17 src/cli/commands.md:60 src/cli/commands.md:109
+#: src/cli/commands.md:148 src/cli/commands.md:181 src/cli/commands.md:195
+#: src/cli/commands.md:233 src/cli/commands.md:248 src/cli/commands.md:260
+#: src/cli/flags.md:9 src/cli/flags.md:43 src/cli/flags.md:50
+#: src/cli/flags.md:58 src/cli/flags.md:66 src/cli/flags.md:73
+#: src/cli/flags.md:80 src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:277
+#: src/cli/perry-toml.md:284 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:367 src/cli/perry-toml.md:377
+#: src/cli/perry-toml.md:387 src/cli/perry-toml.md:397
+#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:491
+#: src/cli/perry-toml.md:503 src/cli/perry-toml.md:513
+msgid "Description"
+msgstr ""
+
+#: src/getting-started/project-config.md:111
+msgid "`splash.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:111
+msgid "Path to a PNG image, centered on the splash screen (both platforms)"
+msgstr ""
+
+#: src/getting-started/project-config.md:112
+msgid "`splash.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:112
+msgid "Hex color for the background (default: `#FFFFFF`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:113
+msgid "`splash.ios.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:113
+msgid "iOS-specific image override"
+msgstr ""
+
+#: src/getting-started/project-config.md:114
+msgid "`splash.ios.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:114
+msgid "iOS-specific background color"
+msgstr ""
+
+#: src/getting-started/project-config.md:115
+msgid "`splash.ios.storyboard`"
+msgstr ""
+
+#: src/getting-started/project-config.md:115
+msgid "Custom LaunchScreen.storyboard (compiled with ibtool)"
+msgstr ""
+
+#: src/getting-started/project-config.md:116
+msgid "`splash.android.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:116
+msgid "Android-specific image override"
+msgstr ""
+
+#: src/getting-started/project-config.md:117
+msgid "`splash.android.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:117
+msgid "Android-specific background color"
+msgstr ""
+
+#: src/getting-started/project-config.md:118
+msgid "`splash.android.layout`"
+msgstr ""
+
+#: src/getting-started/project-config.md:118
+msgid "Custom drawable XML for `windowBackground`"
+msgstr ""
+
+#: src/getting-started/project-config.md:119
+msgid "`splash.android.theme`"
+msgstr ""
+
+#: src/getting-started/project-config.md:119
+msgid "Custom themes.xml"
+msgstr ""
+
+#: src/getting-started/project-config.md:121
+msgid "**Resolution order** per platform:"
+msgstr ""
+
+#: src/getting-started/project-config.md:122
+msgid "Custom file override (storyboard / layout+theme)"
+msgstr ""
+
+#: src/getting-started/project-config.md:123
+msgid "Platform-specific image/color (`splash.{platform}.image`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:124
+msgid "Universal image/color (`splash.image`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:125
+msgid "No `splash` key → blank white screen (backward compatible)"
+msgstr ""
+
+#: src/getting-started/project-config.md:127
+msgid "Using npm Packages"
+msgstr "npm パッケージの使用"
+
+#: src/getting-started/project-config.md:129
+msgid ""
+"Perry natively supports many popular npm packages without any configuration:"
+msgstr ""
+
+#: src/getting-started/project-config.md:131
+msgid ""
+"```typescript\n"
+"// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
+"// docs: docs/src/getting-started/project-config.md\n"
+"// platforms: macos, linux, windows\n"
+"// run: false\n"
+"\n"
+"// These four imports are Perry's most-used built-in stdlib shims:\n"
+"// fastify (HTTP server), mysql2 (db), ioredis (Redis), bcrypt (password\n"
+"// hashing). They're compiled to native code via Perry's per-package\n"
+"// implementations — no `compilePackages` needed.\n"
+"//\n"
+"// `// run: false` because each one needs a live external service (DB,\n"
+"// Redis, network port) to actually do anything; the binary still has to\n"
+"// link cleanly, which is the drift check we want.\n"
+"\n"
+"import fastify from \"fastify\"\n"
+"import mysql from \"mysql2/promise\"\n"
+"import Redis from \"ioredis\"\n"
+"import bcrypt from \"bcrypt\"\n"
+"\n"
+"const app = fastify({ logger: false })\n"
+"const db = mysql.createPool({ host: \"localhost\", user: \"root\", database: \"test\" })\n"
+"const redis = new Redis()\n"
+"const hashed = await bcrypt.hash(\"hunter2\", 10)\n"
+"\n"
+"console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/project-config.md:159
+msgid ""
+"These are compiled to native code using Perry's built-in implementations. "
+"See [Standard Library](../stdlib/overview.md) for the full list."
+msgstr ""
+
+#: src/getting-started/project-config.md:161
+msgid ""
+"For packages not natively supported, use `compilePackages` for pure TS/JS "
+"packages, or the JavaScript runtime fallback for complex packages."
+msgstr ""
+
+#: src/getting-started/project-config.md:163 src/contributing/building.md:61
+msgid "Project Structure"
+msgstr "プロジェクト構造"
+
+#: src/getting-started/project-config.md:165
+msgid "Perry is flexible about project structure. Common patterns:"
+msgstr ""
+
+#: src/getting-started/project-config.md:175
+msgid "For UI apps:"
+msgstr ""
+
+#: src/getting-started/project-config.md:186 src/widgets/watchos.md:59
+#: src/widgets/wearos.md:58
+msgid "Compilation"
+msgstr ""
+
+#: src/getting-started/project-config.md:189
+msgid "# Compile a file\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:191
+msgid "# Compile with a specific target\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:194
+msgid "# Debug: print intermediate representation\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:199
+msgid "See [CLI Commands](../cli/commands.md) for all options."
+msgstr ""
+
+#: src/getting-started/project-config.md:203
+msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
+msgstr ""
+
+#: src/getting-started/project-config.md:204
+msgid ""
+"[Supported Features](../language/supported-features.md) — What TypeScript "
+"features work"
+msgstr ""
+
+#: src/getting-started/project-config.md:205
+msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
+msgstr ""
+
+#: src/language/supported-features.md:1
+msgid "Supported TypeScript Features"
+msgstr ""
+
+#: src/language/supported-features.md:3
+msgid ""
+"Perry compiles a practical subset of TypeScript to native code. This page "
+"lists what's supported."
+msgstr ""
+
+#: src/language/supported-features.md:5
+msgid "Primitive Types"
+msgstr ""
+
+#: src/language/supported-features.md:7
+msgid ""
+"```typescript\n"
+"function primitives(): void {\n"
+"    const n: number = 42;\n"
+"    const s: string = \"hello\";\n"
+"    const b: boolean = true;\n"
+"    const u: undefined = undefined;\n"
+"    const nl: null = null;\n"
+"\n"
+"    console.log(`primitives: n=${n} s=${s} b=${b} u=${u} nl=${nl}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:19
+msgid "All primitives are represented as 64-bit NaN-boxed values at runtime."
+msgstr ""
+
+#: src/language/supported-features.md:21
+msgid "Variables and Constants"
+msgstr ""
+
+#: src/language/supported-features.md:23
+msgid ""
+"```typescript\n"
+"function variables(): void {\n"
+"    let x = 10;\n"
+"    const y = \"immutable\";\n"
+"    var z = true; // var is supported but let/const preferred\n"
+"\n"
+"    console.log(`variables: x=${x} y=${y} z=${z}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:33
+msgid ""
+"Perry infers types from initializers — `let x = 5` is inferred as `number` "
+"without an explicit annotation."
+msgstr ""
+
+#: src/language/supported-features.md:35
+msgid "Functions"
+msgstr ""
+
+#: src/language/supported-features.md:37
+msgid ""
+"```typescript\n"
+"function functionsDemo(): void {\n"
+"    function add(a: number, b: number): number {\n"
+"        return a + b;\n"
+"    }\n"
+"\n"
+"    // Optional parameters\n"
+"    function greet(name: string, greeting: string = \"Hello\"): string {\n"
+"        return `${greeting}, ${name}!`;\n"
+"    }\n"
+"\n"
+"    // Rest parameters\n"
+"    function sum(...nums: number[]): number {\n"
+"        return nums.reduce((a, b) => a + b, 0);\n"
+"    }\n"
+"\n"
+"    // Arrow functions\n"
+"    const double = (x: number) => x * 2;\n"
+"\n"
+"    console.log(`functions: add=${add(2, 3)} greet=${greet(\"Perry\")} sum=${sum(1, 2, 3)} double=${double(5)}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:60
+msgid "Classes"
+msgstr ""
+
+#: src/language/supported-features.md:62
+msgid ""
+"```typescript\n"
+"class Animal {\n"
+"    name: string;\n"
+"\n"
+"    constructor(name: string) {\n"
+"        this.name = name;\n"
+"    }\n"
+"\n"
+"    speak(): string {\n"
+"        return `${this.name} makes a noise`;\n"
+"    }\n"
+"}\n"
+"\n"
+"class Dog extends Animal {\n"
+"    speak(): string {\n"
+"        return `${this.name} barks`;\n"
+"    }\n"
+"}\n"
+"\n"
+"// Static methods\n"
+"class Counter {\n"
+"    private static instance: Counter;\n"
+"    private count: number = 0;\n"
+"\n"
+"    static getInstance(): Counter {\n"
+"        if (!Counter.instance) {\n"
+"            Counter.instance = new Counter();\n"
+"        }\n"
+"        return Counter.instance;\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:95
+msgid "Supported class features:"
+msgstr ""
+
+#: src/language/supported-features.md:96
+msgid "Constructors"
+msgstr ""
+
+#: src/language/supported-features.md:97
+msgid "Instance and static methods"
+msgstr ""
+
+#: src/language/supported-features.md:98
+msgid "Instance and static properties"
+msgstr ""
+
+#: src/language/supported-features.md:99
+msgid "Inheritance (`extends`)"
+msgstr ""
+
+#: src/language/supported-features.md:100
+msgid "Method overriding"
+msgstr ""
+
+#: src/language/supported-features.md:101
+msgid "`instanceof` checks (via class ID chain)"
+msgstr ""
+
+#: src/language/supported-features.md:102
+msgid "Singleton patterns (static method return type inference)"
+msgstr ""
+
+#: src/language/supported-features.md:104
+msgid "Enums"
+msgstr ""
+
+#: src/language/supported-features.md:106
+msgid ""
+"```typescript\n"
+"// Numeric enums\n"
+"enum Direction {\n"
+"    Up,\n"
+"    Down,\n"
+"    Left,\n"
+"    Right,\n"
+"}\n"
+"\n"
+"// String enums\n"
+"enum Color {\n"
+"    Red = \"RED\",\n"
+"    Green = \"GREEN\",\n"
+"    Blue = \"BLUE\",\n"
+"}\n"
+"\n"
+"const dir = Direction.Up;\n"
+"const color = Color.Red;\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:126
+msgid "Enums are compiled to constants and work across modules."
+msgstr ""
+
+#: src/language/supported-features.md:128
+msgid "Interfaces and Type Aliases"
+msgstr ""
+
+#: src/language/supported-features.md:142
+msgid ""
+"Interfaces and type aliases are erased at compile time (like `tsc`). They "
+"exist only for documentation and editor tooling."
+msgstr ""
+
+#: src/language/supported-features.md:144 src/threading/overview.md:306
+#: src/threading/parallel-map.md:58
+msgid "Arrays"
+msgstr ""
+
+#: src/language/supported-features.md:146
+msgid ""
+"```typescript\n"
+"function arraysDemo(): void {\n"
+"    const nums: number[] = [1, 2, 3];\n"
+"\n"
+"    // Array methods\n"
+"    nums.push(4);\n"
+"    nums.pop();\n"
+"    const len = nums.length;\n"
+"    const doubled = nums.map((x) => x * 2);\n"
+"    const filtered = nums.filter((x) => x > 2);\n"
+"    const sum = nums.reduce((acc, x) => acc + x, 0);\n"
+"    const found = nums.find((x) => x === 3);\n"
+"    const idx = nums.indexOf(3);\n"
+"    const joined = nums.join(\", \");\n"
+"    const sliced = nums.slice(1, 3);\n"
+"    nums.splice(1, 1);\n"
+"    nums.unshift(0);\n"
+"    const sorted = nums.sort((a, b) => a - b);\n"
+"    const reversed = nums.reverse();\n"
+"    const includes = nums.includes(3);\n"
+"    const every = nums.every((x) => x > 0);\n"
+"    const some = nums.some((x) => x > 2);\n"
+"    nums.forEach((x) => console.log(x));\n"
+"    const flat = [[1, 2], [3]].flat();\n"
+"    const concatted = nums.concat([5, 6]);\n"
+"\n"
+"    // Array.from\n"
+"    const arr = Array.from([10, 20, 30]);\n"
+"\n"
+"    // Array.isArray\n"
+"    const value: any = [1, 2, 3]\n"
+"    if (Array.isArray(value)) { /* ... */ }\n"
+"\n"
+"    // for...of iteration\n"
+"    for (const item of nums) {\n"
+"        console.log(item);\n"
+"    }\n"
+"\n"
+"    console.log(`arrays: len=${len} doubled=${doubled.length} filtered=${filtered.length} sum=${sum} found=${found} idx=${idx} joined=${joined} sliced=${sliced.length} sorted=${sorted.length} reversed=${reversed.length} includes=${includes} every=${every} some=${some} flat=${flat.length} concatted=${concatted.length} arr=${arr.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:188 src/threading/overview.md:307
+#: src/threading/parallel-map.md:59
+msgid "Objects"
+msgstr ""
+
+#: src/language/supported-features.md:190
+msgid ""
+"```typescript\n"
+"function objectsDemo(): void {\n"
+"    const obj: { name: string; version: number; [k: string]: any } = { name: \"Perry\", version: 1 };\n"
+"    obj.name = \"Perry 2\";\n"
+"\n"
+"    // Dynamic property access\n"
+"    const key = \"name\";\n"
+"    const val = obj[key];\n"
+"\n"
+"    // Object.keys, Object.values, Object.entries\n"
+"    const keys = Object.keys(obj);\n"
+"    const values = Object.values(obj);\n"
+"    const entries = Object.entries(obj);\n"
+"\n"
+"    // Spread\n"
+"    const copy = { ...obj, extra: true };\n"
+"\n"
+"    // delete\n"
+"    delete obj[key];\n"
+"\n"
+"    console.log(`objects: val=${val} keys=${keys.length} values=${values.length} entries=${entries.length} copy=${copy.extra}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:214
+msgid "Destructuring"
+msgstr ""
+
+#: src/language/supported-features.md:216
+msgid ""
+"```typescript\n"
+"function destructuringDemo(): void {\n"
+"    // Array destructuring\n"
+"    const [a, b, ...rest] = [1, 2, 3, 4, 5];\n"
+"\n"
+"    const user = { name: \"Alice\", age: 30, email: \"a@example.com\", id: 1 }\n"
+"    const obj = { id: 2, role: \"admin\", level: 5 }\n"
+"\n"
+"    // Object destructuring\n"
+"    const { name, age, email = \"none\" } = user;\n"
+"\n"
+"    // Rename\n"
+"    const { name: userName } = user;\n"
+"\n"
+"    // Rest pattern\n"
+"    const { id, ...remaining } = obj;\n"
+"\n"
+"    // Function parameter destructuring\n"
+"    function process({ name, age }: { name: string; age: number }) {\n"
+"        console.log(name, age);\n"
+"    }\n"
+"\n"
+"    process(user)\n"
+"    console.log(`destructuring: a=${a} b=${b} rest=${rest.length} name=${name} age=${age} email=${email} userName=${userName} id=${id}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:243 src/widgets/creating-widgets.md:112
+msgid "Template Literals"
+msgstr ""
+
+#: src/language/supported-features.md:245
+msgid ""
+"```typescript\n"
+"function templateLiteralsDemo(): void {\n"
+"    const name = \"world\";\n"
+"    const greeting = `Hello, ${name}!`;\n"
+"    const multiline = `\n"
+"  Line 1\n"
+"  Line 2\n"
+"`;\n"
+"    const expr = `Result: ${1 + 2}`;\n"
+"\n"
+"    console.log(`template-literals: greeting=${greeting} multiline_len=${multiline.length} expr=${expr}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:259
+msgid "Spread and Rest"
+msgstr ""
+
+#: src/language/supported-features.md:261
+msgid ""
+"```typescript\n"
+"function spreadRestDemo(): void {\n"
+"    const arr1 = [1, 2]\n"
+"    const arr2 = [3, 4]\n"
+"    const defaults = { theme: \"light\", size: \"md\" }\n"
+"    const overrides = { size: \"lg\" }\n"
+"\n"
+"    // Array spread\n"
+"    const combined = [...arr1, ...arr2];\n"
+"\n"
+"    // Object spread\n"
+"    const merged = { ...defaults, ...overrides };\n"
+"\n"
+"    // Rest parameters\n"
+"    function log(...args: any[]) { /* ... */ }\n"
+"\n"
+"    log(\"a\", \"b\", \"c\")\n"
+"    console.log(`spread-rest: combined=${combined.length} merged=${merged.size}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:282 src/threading/overview.md:308
+msgid "Closures"
+msgstr ""
+
+#: src/language/supported-features.md:284
+msgid ""
+"```typescript\n"
+"function closuresDemo(): void {\n"
+"    function makeCounter() {\n"
+"        let count = 0;\n"
+"        return {\n"
+"            increment: () => ++count,\n"
+"            get: () => count,\n"
+"        };\n"
+"    }\n"
+"\n"
+"    const counter = makeCounter();\n"
+"    counter.increment();\n"
+"    console.log(counter.get()); // 1\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:300
+msgid ""
+"Perry performs closure conversion — captured variables are stored in heap-"
+"allocated closure objects."
+msgstr ""
+
+#: src/language/supported-features.md:302
+msgid "Async/Await"
+msgstr ""
+
+#: src/language/supported-features.md:304
+msgid ""
+"```typescript\n"
+"async function asyncAwaitDemo(): Promise<void> {\n"
+"    interface Profile { id: number; name: string }\n"
+"\n"
+"    async function fetchUser(id: number): Promise<Profile> {\n"
+"        // The docs example uses fetch(...) here; we inline a synthetic\n"
+"        // result so the snippet compiles and runs hermetically.\n"
+"        return { id, name: `user-${id}` }\n"
+"    }\n"
+"\n"
+"    const data = await fetchUser(1);\n"
+"    console.log(`async-await: id=${data.id} name=${data.name}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:319
+msgid ""
+"Perry compiles async functions to a state machine backed by Tokio's async "
+"runtime."
+msgstr ""
+
+#: src/language/supported-features.md:321
+msgid "Promises"
+msgstr ""
+
+#: src/language/supported-features.md:323
+msgid ""
+"```typescript\n"
+"async function promisesDemo(): Promise<void> {\n"
+"    const p = new Promise<number>((resolve, reject) => {\n"
+"        resolve(42);\n"
+"    });\n"
+"\n"
+"    p.then((value) => console.log(value));\n"
+"\n"
+"    // Promise.all\n"
+"    const results = await Promise.all([\n"
+"        Promise.resolve(\"a\"),\n"
+"        Promise.resolve(\"b\"),\n"
+"    ]);\n"
+"\n"
+"    console.log(`promises: results=${results.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:341
+msgid "Generators"
+msgstr ""
+
+#: src/language/supported-features.md:357
+msgid "Map and Set"
+msgstr ""
+
+#: src/language/supported-features.md:359
+msgid ""
+"```typescript\n"
+"function mapSetDemo(): void {\n"
+"    const map = new Map<string, number>();\n"
+"    map.set(\"a\", 1);\n"
+"    map.get(\"a\");\n"
+"    map.has(\"a\");\n"
+"    map.delete(\"a\");\n"
+"    map.size;\n"
+"\n"
+"    const set = new Set<number>();\n"
+"    set.add(1);\n"
+"    set.has(1);\n"
+"    set.delete(1);\n"
+"    set.size;\n"
+"\n"
+"    console.log(`map-set: map_size=${map.size} set_size=${set.size}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:378
+msgid "Regular Expressions"
+msgstr ""
+
+#: src/language/supported-features.md:380
+msgid ""
+"```typescript\n"
+"function regexDemo(): void {\n"
+"    const re = /hello\\s+(\\w+)/;\n"
+"    const match = \"hello world\".match(re);\n"
+"\n"
+"    if (re.test(\"hello perry\")) {\n"
+"        console.log(\"Matched!\");\n"
+"    }\n"
+"\n"
+"    const replaced = \"hello world\".replace(/world/, \"perry\");\n"
+"\n"
+"    console.log(`regex: match=${match !== null} replaced=${replaced}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:395 src/widgets/data-fetching.md:154
+msgid "Error Handling"
+msgstr ""
+
+#: src/language/supported-features.md:397
+msgid ""
+"```typescript\n"
+"function errorsDemo(): void {\n"
+"    try {\n"
+"        throw new Error(\"something went wrong\");\n"
+"    } catch (e: any) {\n"
+"        console.log(e.message);\n"
+"    } finally {\n"
+"        console.log(\"cleanup\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:409
+msgid "JSON"
+msgstr ""
+
+#: src/language/supported-features.md:411
+msgid ""
+"```typescript\n"
+"function jsonDemo(): void {\n"
+"    const obj = JSON.parse('{\"key\": \"value\"}');\n"
+"    const str = JSON.stringify(obj);\n"
+"    const pretty = JSON.stringify(obj, null, 2);\n"
+"\n"
+"    console.log(`json: str_len=${str.length} pretty_len=${pretty.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:421
+msgid "typeof and instanceof"
+msgstr ""
+
+#: src/language/supported-features.md:423
+msgid ""
+"```typescript\n"
+"function typeofInstanceofDemo(): void {\n"
+"    const x: any = \"hello\"\n"
+"    if (typeof x === \"string\") {\n"
+"        console.log(x.length);\n"
+"    }\n"
+"\n"
+"    const obj: any = new Dog(\"Rex\")\n"
+"    if (obj instanceof Dog) {\n"
+"        obj.speak();\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:437
+msgid ""
+"`typeof` checks NaN-boxing tags at runtime. `instanceof` walks the class ID "
+"chain."
+msgstr ""
+
+#: src/language/supported-features.md:439
+msgid "Modules"
+msgstr ""
+
+#: src/language/supported-features.md:441
+msgid ""
+"ES module syntax is fully supported: named exports, default exports, and re-"
+"exports."
+msgstr ""
+
+#: src/language/supported-features.md:444
+msgid "The exporting module:"
+msgstr ""
+
+#: src/language/supported-features.md:446
+msgid ""
+"```typescript\n"
+"// Named exports\n"
+"export function helper(x: number): number { return x + 1 }\n"
+"export const VALUE = 42\n"
+"\n"
+"// Default export\n"
+"export default class MyClass {\n"
+"    name: string\n"
+"    constructor(name: string) {\n"
+"        this.name = name\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:460
+msgid "The importing module:"
+msgstr ""
+
+#: src/language/supported-features.md:462
+msgid ""
+"```typescript\n"
+"// Default + named imports from a sibling module\n"
+"import MyClass, { helper, VALUE } from \"./utils\"\n"
+"\n"
+"// Re-export\n"
+"export { helper } from \"./utils\"\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:470
+msgid "BigInt"
+msgstr ""
+
+#: src/language/supported-features.md:472
+msgid ""
+"```typescript\n"
+"function bigintDemo(): void {\n"
+"    const big = BigInt(9007199254740991);\n"
+"    const result = big + BigInt(1);\n"
+"\n"
+"    // Bitwise operations\n"
+"    const and = big & BigInt(0xFF);\n"
+"    const or = big | BigInt(0xFF);\n"
+"    const xor = big ^ BigInt(0xFF);\n"
+"    const shl = big << BigInt(2);\n"
+"    const shr = big >> BigInt(2);\n"
+"    const not = ~big;\n"
+"\n"
+"    console.log(`bigint: result_ok=${result !== null} and_ok=${and !== null} or_ok=${or !== null}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:489
+msgid "String Methods"
+msgstr ""
+
+#: src/language/supported-features.md:491
+msgid ""
+"```typescript\n"
+"function stringMethodsDemo(): void {\n"
+"    const s = \"Hello, World!\";\n"
+"    s.length;\n"
+"    s.toUpperCase();\n"
+"    s.toLowerCase();\n"
+"    s.trim();\n"
+"    s.split(\", \");\n"
+"    s.includes(\"World\");\n"
+"    s.startsWith(\"Hello\");\n"
+"    s.endsWith(\"!\");\n"
+"    s.indexOf(\"World\");\n"
+"    s.slice(0, 5);\n"
+"    s.substring(0, 5);\n"
+"    s.replace(\"World\", \"Perry\");\n"
+"    s.repeat(3);\n"
+"    s.charAt(0);\n"
+"    s.padStart(20);\n"
+"    s.padEnd(20);\n"
+"\n"
+"    console.log(`string-methods: ${s.toUpperCase()}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:515
+msgid "Math"
+msgstr ""
+
+#: src/language/supported-features.md:538
+msgid "Date"
+msgstr ""
+
+#: src/language/supported-features.md:551
+msgid "Console"
+msgstr ""
+
+#: src/language/supported-features.md:553
+msgid ""
+"```typescript\n"
+"function consoleDemo(): void {\n"
+"    console.log(\"message\");\n"
+"    console.error(\"error\");\n"
+"    console.warn(\"warning\");\n"
+"    console.time(\"label\");\n"
+"    console.timeEnd(\"label\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:563 src/contributing/architecture.md:56
+msgid "Garbage Collection"
+msgstr ""
+
+#: src/language/supported-features.md:565
+msgid ""
+"Perry includes a mark-sweep garbage collector. It runs automatically when "
+"memory pressure is detected (~8MB arena blocks), but you can also trigger it"
+" manually:"
+msgstr ""
+
+#: src/language/supported-features.md:567
+msgid ""
+"```typescript\n"
+"function gcDemo(): void {\n"
+"    gc(); // Explicit garbage collection\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:573
+msgid ""
+"The GC uses conservative stack scanning to find roots and supports arena-"
+"allocated objects (arrays, objects) and malloc-allocated objects (strings, "
+"closures, promises, BigInts, errors)."
+msgstr ""
+
+#: src/language/supported-features.md:575
+msgid "JSX/TSX"
+msgstr ""
+
+#: src/language/supported-features.md:577
+msgid ""
+"Perry's parser and HIR understand JSX syntax (parsed via SWC, lowered in "
+"`crates/perry-hir/src/jsx.rs`), but the runtime `_jsx` / `_jsxs` symbols are"
+" not yet linked, so a `.tsx` file fails at the link stage today. The "
+"canonical pattern is the function-call form Perry's UI examples already use "
+"(`Text(\"hi\")` instead of `<Text>hi</Text>`)."
+msgstr ""
+
+#: src/language/supported-features.md:583
+msgid ""
+"```text\n"
+"// Planned JSX shape (parses but doesn't link yet — issue: runtime _jsx symbols):\n"
+"\n"
+"function Greeting({ name }: { name: string }) {\n"
+"  return <Text>{`Hello, ${name}!`}</Text>;\n"
+"}\n"
+"\n"
+"<Button onClick={() => console.log(\"clicked\")}>Click me</Button>\n"
+"\n"
+"<>\n"
+"  <Text>Line 1</Text>\n"
+"  <Text>Line 2</Text>\n"
+"</>\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:598
+msgid ""
+"JSX elements are transformed to function calls via the `jsx()`/`jsxs()` "
+"runtime."
+msgstr ""
+
+#: src/language/supported-features.md:602
+msgid "[Type System](type-system.md) — Type inference and checking"
+msgstr ""
+
+#: src/language/supported-features.md:603
+msgid "[Limitations](limitations.md) — What's not supported yet"
+msgstr ""
+
+#: src/language/type-system.md:3
+msgid ""
+"Perry erases types at compile time, similar to how `tsc` removes type "
+"annotations when emitting JavaScript. However, Perry also performs type "
+"inference to generate efficient native code."
+msgstr ""
+
+#: src/language/type-system.md:5
+msgid "Type Inference"
+msgstr ""
+
+#: src/language/type-system.md:7
+msgid "Perry infers types from expressions without requiring annotations:"
+msgstr ""
+
+#: src/language/type-system.md:9
+msgid ""
+"```typescript\n"
+"function inferenceBasics(): void {\n"
+"    let x = 5;           // inferred as number\n"
+"    let s = \"hello\";     // inferred as string\n"
+"    let b = true;        // inferred as boolean\n"
+"    let arr = [1, 2, 3]; // inferred as number[]\n"
+"\n"
+"    console.log(`inference: x=${x} s=${s} b=${b} arr_len=${arr.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:20
+msgid "Inference works through:"
+msgstr ""
+
+#: src/language/type-system.md:21
+msgid "**Literal values**: `5` → `number`, `\"hi\"` → `string`"
+msgstr ""
+
+#: src/language/type-system.md:22
+msgid "**Binary operations**: `a + b` where both are numbers → `number`"
+msgstr ""
+
+#: src/language/type-system.md:23
+msgid ""
+"**Variable propagation**: if `x` is `number`, then `let y = x` is `number`"
+msgstr ""
+
+#: src/language/type-system.md:24
+msgid ""
+"**Method returns**: `\"hello\".trim()` → `string`, `[1,2].length` → `number`"
+msgstr ""
+
+#: src/language/type-system.md:25
+msgid ""
+"**Function returns**: user-defined function return types are propagated to "
+"callers"
+msgstr ""
+
+#: src/language/type-system.md:27
+msgid ""
+"```typescript\n"
+"function inferenceFunction(): void {\n"
+"    function double(n: number): number {\n"
+"        return n * 2;\n"
+"    }\n"
+"    let result = double(5); // inferred as number\n"
+"\n"
+"    console.log(`inference-function: result=${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:38
+msgid "Type Annotations"
+msgstr ""
+
+#: src/language/type-system.md:40
+msgid "Standard TypeScript annotations work:"
+msgstr ""
+
+#: src/language/type-system.md:42
+msgid ""
+"```typescript\n"
+"interface Config {\n"
+"    port: number;\n"
+"    host: string;\n"
+"}\n"
+"\n"
+"function annotations(): void {\n"
+"    let name: string = \"Perry\";\n"
+"    let count: number = 0;\n"
+"    let items: string[] = [];\n"
+"\n"
+"    function greet(name: string): string {\n"
+"        return `Hello, ${name}`;\n"
+"    }\n"
+"\n"
+"    const cfg: Config = { port: 8080, host: \"localhost\" }\n"
+"    console.log(`annotations: ${greet(name)} count=${count} items=${items.length} port=${cfg.port}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:62
+msgid "Utility Types"
+msgstr ""
+
+#: src/language/type-system.md:64
+msgid ""
+"Common TypeScript utility types are erased at compile time (they don't "
+"affect code generation):"
+msgstr ""
+
+#: src/language/type-system.md:75
+msgid ""
+"These are all recognized and erased — they won't cause compilation errors."
+msgstr ""
+
+#: src/language/type-system.md:77
+msgid "Generics"
+msgstr ""
+
+#: src/language/type-system.md:79
+msgid "Generic type parameters are erased:"
+msgstr ""
+
+#: src/language/type-system.md:81
+msgid ""
+"```typescript\n"
+"function identity<T>(value: T): T {\n"
+"    return value;\n"
+"}\n"
+"\n"
+"class Box<T> {\n"
+"    value: T;\n"
+"    constructor(value: T) {\n"
+"        this.value = value;\n"
+"    }\n"
+"}\n"
+"\n"
+"function genericsDemo(): void {\n"
+"    const box = new Box<number>(42);\n"
+"    const id = identity<string>(\"hello\")\n"
+"    console.log(`generics: box.value=${box.value} id=${id}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:100
+msgid ""
+"At runtime, all values are NaN-boxed — the generic parameter doesn't affect "
+"code generation."
+msgstr ""
+
+#: src/language/type-system.md:102
+msgid "Type Checking with `--type-check`"
+msgstr ""
+
+#: src/language/type-system.md:104
+msgid ""
+"For stricter type checking, Perry can integrate with Microsoft's TypeScript "
+"checker:"
+msgstr ""
+
+#: src/language/type-system.md:110
+msgid ""
+"This resolves cross-file types, interfaces, and generics via an IPC "
+"protocol. It falls back gracefully if the type checker is not installed."
+msgstr ""
+
+#: src/language/type-system.md:112
+msgid ""
+"Without `--type-check`, Perry relies on its own inference engine, which "
+"handles common patterns but doesn't perform full TypeScript type checking."
+msgstr ""
+
+#: src/language/type-system.md:114
+msgid "Union and Intersection Types"
+msgstr ""
+
+#: src/language/type-system.md:116
+msgid ""
+"Union types are recognized syntactically but don't affect code generation:"
+msgstr ""
+
+#: src/language/type-system.md:118
+msgid ""
+"```typescript\n"
+"type StringOrNumber = string | number;\n"
+"\n"
+"function process(value: StringOrNumber) {\n"
+"    if (typeof value === \"string\") {\n"
+"        console.log(value.toUpperCase());\n"
+"    } else {\n"
+"        console.log(value + 1);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:130
+msgid "Use `typeof` checks for runtime type narrowing."
+msgstr ""
+
+#: src/language/type-system.md:132
+msgid "Type Guards"
+msgstr ""
+
+#: src/language/type-system.md:134
+msgid ""
+"```typescript\n"
+"function isString(value: any): value is string {\n"
+"    return typeof value === \"string\";\n"
+"}\n"
+"\n"
+"function typeGuardsDemo(): void {\n"
+"    const x: any = \"hello\"\n"
+"    if (isString(x)) {\n"
+"        console.log(x.toUpperCase());\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:147
+msgid ""
+"The `value is string` annotation is erased, but the `typeof` check works at "
+"runtime."
+msgstr ""
+
+#: src/language/type-system.md:151
+msgid "[Supported Features](supported-features.md) — Complete feature list"
+msgstr ""
+
+#: src/language/type-system.md:152
+msgid "[Limitations](limitations.md) — What's not supported"
+msgstr ""
+
+#: src/language/limitations.md:3
+msgid ""
+"Perry compiles a practical subset of TypeScript. This page documents what's "
+"not supported or works differently from Node.js/tsc."
+msgstr ""
+
+#: src/language/limitations.md:5
+msgid "No Runtime Type Checking"
+msgstr ""
+
+#: src/language/limitations.md:7
+msgid ""
+"Types are erased at compile time. There is no runtime type system — Perry "
+"doesn't generate type guards or runtime type metadata."
+msgstr ""
+
+#: src/language/limitations.md:9
+msgid ""
+"```typescript\n"
+"function someFunction(): number {\n"
+"    return 42\n"
+"}\n"
+"\n"
+"function erasedTypes(): void {\n"
+"    // These annotations are erased — no runtime effect\n"
+"    const x: number = someFunction(); // No runtime check that result is actually a number\n"
+"    console.log(`erased-types: x=${x}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:21
+msgid ""
+"Use explicit `typeof` checks where runtime type discrimination is needed."
+msgstr ""
+
+#: src/language/limitations.md:23
+msgid "No eval() or Dynamic Code"
+msgstr ""
+
+#: src/language/limitations.md:25
+msgid ""
+"Perry compiles to native code ahead of time. Dynamic code execution is not "
+"possible:"
+msgstr ""
+
+#: src/language/limitations.md:28
+msgid ""
+"```text\n"
+"// Not supported\n"
+"eval(\"console.log('hi')\");\n"
+"new Function(\"return 42\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:34
+msgid "No Decorators"
+msgstr ""
+
+#: src/language/limitations.md:36
+msgid "TypeScript decorators are not currently supported:"
+msgstr ""
+
+#: src/language/limitations.md:39
+msgid ""
+"```text\n"
+"// Not supported\n"
+"@Component\n"
+"class MyClass {}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:45
+msgid "No Reflection"
+msgstr ""
+
+#: src/language/limitations.md:47
+msgid "There is no `Reflect` API or runtime type metadata:"
+msgstr ""
+
+#: src/language/limitations.md:50
+msgid ""
+"```text\n"
+"// Not supported\n"
+"Reflect.getMetadata(\"design:type\", target, key);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:55
+msgid "No Dynamic require()"
+msgstr ""
+
+#: src/language/limitations.md:57
+msgid "Only static imports are supported:"
+msgstr ""
+
+#: src/language/limitations.md:60
+msgid ""
+"```text\n"
+"// Supported\n"
+"import { foo } from \"./module\";\n"
+"\n"
+"// Not supported\n"
+"const mod = require(\"./module\");\n"
+"const mod = await import(\"./module\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:69
+msgid "No Prototype Manipulation"
+msgstr ""
+
+#: src/language/limitations.md:71
+msgid ""
+"Perry compiles classes to fixed structures. Dynamic prototype modification "
+"is not supported:"
+msgstr ""
+
+#: src/language/limitations.md:74
+msgid ""
+"```text\n"
+"// Not supported\n"
+"MyClass.prototype.newMethod = function() {};\n"
+"Object.setPrototypeOf(obj, proto);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:80
+msgid "No Symbol Type"
+msgstr ""
+
+#: src/language/limitations.md:82
+msgid "The `Symbol` primitive type is not currently supported:"
+msgstr ""
+
+#: src/language/limitations.md:85
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const sym = Symbol(\"description\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:90
+msgid "No WeakMap/WeakRef"
+msgstr ""
+
+#: src/language/limitations.md:92
+msgid "Weak references are not implemented:"
+msgstr ""
+
+#: src/language/limitations.md:95
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const wm = new WeakMap();\n"
+"const wr = new WeakRef(obj);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:101
+msgid "No Proxy"
+msgstr ""
+
+#: src/language/limitations.md:103
+msgid "The `Proxy` object is not supported:"
+msgstr ""
+
+#: src/language/limitations.md:106
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const proxy = new Proxy(target, handler);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:111
+msgid "Limited Error Types"
+msgstr ""
+
+#: src/language/limitations.md:113
+msgid ""
+"`Error` and basic `throw`/`catch` work, but custom error subclasses have "
+"limited support:"
+msgstr ""
+
+#: src/language/limitations.md:125
+msgid "Threading Model"
+msgstr ""
+
+#: src/language/limitations.md:127
+msgid ""
+"Perry supports real multi-threading via `parallelMap` and `spawn` from "
+"`perry/thread`. See [Multi-Threading](../threading/overview.md)."
+msgstr ""
+
+#: src/language/limitations.md:129
+msgid ""
+"Threads do not share mutable state — closures passed to thread primitives "
+"cannot capture mutable variables (enforced at compile time). Values are "
+"deep-copied across thread boundaries. There is no `SharedArrayBuffer` or "
+"`Atomics`."
+msgstr ""
+
+#: src/language/limitations.md:131
+msgid "No Computed Property Names"
+msgstr ""
+
+#: src/language/limitations.md:133
+msgid "Dynamic property keys in object literals are limited:"
+msgstr ""
+
+#: src/language/limitations.md:136
+msgid ""
+"```text\n"
+"// Supported\n"
+"const key = \"name\";\n"
+"obj[key] = \"value\";\n"
+"\n"
+"// Not supported\n"
+"const obj = { [key]: \"value\" };\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:145
+msgid "npm Package Compatibility"
+msgstr ""
+
+#: src/language/limitations.md:147
+msgid "Not all npm packages work with Perry:"
+msgstr ""
+
+#: src/language/limitations.md:149
+msgid ""
+"**Natively supported**: ~50 popular packages (fastify, mysql2, redis, etc.) "
+"— these are compiled natively. See [Standard "
+"Library](../stdlib/overview.md)."
+msgstr ""
+
+#: src/language/limitations.md:150
+msgid ""
+"**`compilePackages`**: Pure TS/JS packages can be compiled natively via "
+"[configuration](../getting-started/project-config.md)."
+msgstr ""
+
+#: src/language/limitations.md:151
+msgid ""
+"**Not supported**: Packages requiring native addons (`.node` files), "
+"`eval()`, dynamic `require()`, or Node.js internals."
+msgstr ""
+
+#: src/language/limitations.md:153
+msgid "Workarounds"
+msgstr ""
+
+#: src/language/limitations.md:155
+msgid "Dynamic Behavior"
+msgstr ""
+
+#: src/language/limitations.md:157
+msgid ""
+"For cases where you need dynamic behavior, use the JavaScript runtime "
+"fallback:"
+msgstr ""
+
+#: src/language/limitations.md:160
+msgid ""
+"```text\n"
+"import { jsEval } from \"perry/jsruntime\";\n"
+"// Routes specific code through QuickJS for dynamic evaluation\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:165
+msgid "Type Narrowing"
+msgstr ""
+
+#: src/language/limitations.md:167
+msgid "Since there's no runtime type checking, use explicit checks:"
+msgstr ""
+
+#: src/language/limitations.md:169
+msgid ""
+"```typescript\n"
+"function processValue(value: string | number) {\n"
+"    // Instead of relying on type narrowing from generics\n"
+"    if (typeof value === \"string\") {\n"
+"        // String path\n"
+"        console.log(`string path: ${value}`)\n"
+"    } else if (typeof value === \"number\") {\n"
+"        // Number path\n"
+"        console.log(`number path: ${value}`)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:184
+msgid "[Supported Features](supported-features.md) — What does work"
+msgstr ""
+
+#: src/language/limitations.md:185
+msgid "[Type System](type-system.md) — How types are handled"
+msgstr ""
+
+#: src/packages/porting.md:1
+msgid "Porting npm Packages"
+msgstr ""
+
+#: src/packages/porting.md:3
+msgid ""
+"**Status: experimental.** This guide — and the [`port-npm-to-perry` "
+"skill](https://github.com/PerryTS/perry/tree/main/.claude/skills/port-npm-"
+"to-perry) that ships alongside it — is a first pass at systematizing what "
+"Perry contributors have been doing ad-hoc. Results will vary by package. "
+"Feedback at [issue #115](https://github.com/PerryTS/perry/issues/115)."
+msgstr ""
+
+#: src/packages/porting.md:5
+msgid ""
+"Perry compiles a practical subset of TypeScript. Most pure TS/JS packages "
+"can be pulled into a native compile via `perry.compilePackages`, but some "
+"will need small patches to avoid the constructs Perry doesn't support. This "
+"page is a field guide for doing that port — by hand, or by driving a coding "
+"agent with the prompt template below."
+msgstr ""
+
+#: src/packages/porting.md:7
+msgid "When porting makes sense"
+msgstr ""
+
+#: src/packages/porting.md:9
+msgid "Situation"
+msgstr ""
+
+#: src/packages/porting.md:9
+msgid "Try this first"
+msgstr ""
+
+#: src/packages/porting.md:11
+msgid "Package uses native addons (`.node` files, `binding.gyp`, `node-gyp`)"
+msgstr ""
+
+#: src/packages/porting.md:11
+msgid ""
+"**Don't port** — no path forward. Find an alternative package or use the "
+"[QuickJS fallback](../stdlib/overview.md#javascript-runtime-fallback)."
+msgstr ""
+
+#: src/packages/porting.md:12
+msgid "Package is pure TS/JS with only light use of dynamic features"
+msgstr ""
+
+#: src/packages/porting.md:12
+msgid ""
+"**Good candidate.** Add to `compilePackages`, patch whatever trips the "
+"compiler."
+msgstr ""
+
+#: src/packages/porting.md:13
+msgid ""
+"Package's core API is built on `Proxy` (ORMs, validation DSLs, reactive "
+"stores)"
+msgstr ""
+
+#: src/packages/porting.md:13
+msgid "**Probably not portable.** The surface Perry-users touch is the Proxy."
+msgstr ""
+
+#: src/packages/porting.md:14
+msgid ""
+"Package is pure TS/JS but uses lookbehind regex, `Symbol`, `WeakMap`, etc."
+msgstr ""
+
+#: src/packages/porting.md:14
+msgid "**Patchable.** See [Common gaps](#common-gaps) below."
+msgstr ""
+
+#: src/packages/porting.md:16
+msgid "The workflow"
+msgstr ""
+
+#: src/packages/porting.md:18
+msgid "1. Add it to `compilePackages`"
+msgstr ""
+
+#: src/packages/porting.md:20
+msgid "In your project's `package.json`:"
+msgstr ""
+
+#: src/packages/porting.md:30
+msgid ""
+"This is what tells Perry to pull the package into the native compile instead"
+" of routing it through a JavaScript runtime. See [Project "
+"Configuration](../getting-started/project-config.md#compilepackages) for the"
+" full semantics — including how first-resolved directories get cached so "
+"transitive copies dedup."
+msgstr ""
+
+#: src/packages/porting.md:32
+msgid "2. Try compiling"
+msgstr ""
+
+#: src/packages/porting.md:38
+msgid ""
+"Most of the time this is where you find out what's actually broken. Compile-"
+"time errors cite a file:line in the package — that's your patch list."
+msgstr ""
+
+#: src/packages/porting.md:40
+msgid "3. Patch the gaps"
+msgstr ""
+
+#: src/packages/porting.md:42
+msgid ""
+"See [Common gaps](#common-gaps) for the typical fixes. Keep patches minimal "
+"and localized — the goal is a clean compile, not a refactor."
+msgstr ""
+
+#: src/packages/porting.md:44
+msgid ""
+"**Record each patch** in a file at your project root (convention: `perry-"
+"patches/<package>.md`) so you can reapply them after `npm install` blows "
+"them away. Until `compilePackages` grows a native patch-file convention, "
+"this is the one bit of maintenance overhead."
+msgstr ""
+
+#: src/packages/porting.md:46
+msgid "4. Re-check after each compile"
+msgstr ""
+
+#: src/packages/porting.md:48
+msgid ""
+"Iterate: compile, patch the next error, compile again. Don't try to catch "
+"everything in a single pass — some errors only surface after earlier ones "
+"are fixed."
+msgstr ""
+
+#: src/packages/porting.md:50
+msgid "Common gaps"
+msgstr ""
+
+#: src/packages/porting.md:52
+msgid ""
+"Perry's [full limitations list](../language/limitations.md) is the canonical"
+" reference. In practice, these are the ones you hit when porting:"
+msgstr ""
+
+#: src/packages/porting.md:54
+msgid "Lookbehind regex"
+msgstr ""
+
+#: src/packages/porting.md:56
+msgid ""
+"Perry uses Rust's `regex` crate, which doesn't support lookbehind (`(?<=…)` "
+"/ `(?<!…)`)."
+msgstr ""
+
+#: src/packages/porting.md:58
+msgid ""
+"```text\n"
+"// Not supported\n"
+"str.match(/(?<=prefix)\\w+/);\n"
+"\n"
+"// Rewrite — capture the prefix and slice\n"
+"const m = str.match(/prefix(\\w+)/);\n"
+"const rest = m ? m[1] : null;\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:67
+msgid "`Symbol`"
+msgstr ""
+
+#: src/packages/porting.md:69
+msgid ""
+"Not supported as a primitive. When a package uses `Symbol` as a sentinel "
+"(the common case — e.g., for unique keys in a registry), swap for a string:"
+msgstr ""
+
+#: src/packages/porting.md:71
+msgid ""
+"```text\n"
+"// Before\n"
+"const REGISTRY_KEY = Symbol(\"registry\");\n"
+"\n"
+"// After\n"
+"const REGISTRY_KEY = \"__pkg_registry__\";\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:79
+msgid ""
+"When `Symbol` is used to implement `Symbol.iterator`/`Symbol.asyncIterator`,"
+" check whether the iteration is actually reached in your use case — often "
+"the class has a `for`\\-loop method alongside the iterator and you can "
+"ignore the iterator path."
+msgstr ""
+
+#: src/packages/porting.md:81
+msgid "`Proxy`, `Reflect`"
+msgstr ""
+
+#: src/packages/porting.md:83
+msgid ""
+"Not supported. These are usually load-bearing for the package's public API, "
+"so porting is often not feasible. If the `Proxy` is only in an optional path"
+" (e.g., dev-mode warnings), delete that branch."
+msgstr ""
+
+#: src/packages/porting.md:85
+msgid "`WeakMap` / `WeakRef` / `FinalizationRegistry`"
+msgstr ""
+
+#: src/packages/porting.md:87
+msgid ""
+"Not implemented. Swap `WeakMap` for a regular `Map` if the GC semantics "
+"aren't critical for correctness (most caches can tolerate this — they'll "
+"just hold references slightly longer)."
+msgstr ""
+
+#: src/packages/porting.md:89
+msgid "Decorators"
+msgstr ""
+
+#: src/packages/porting.md:91
+msgid ""
+"```text\n"
+"// Not supported\n"
+"@Component\n"
+"class Foo {}\n"
+"\n"
+"// Remove the decorator and inline the behavior, or use a factory function\n"
+"const Foo = Component(class Foo {});\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:100
+msgid "Dynamic `require()` / `await import(…)`"
+msgstr ""
+
+#: src/packages/porting.md:102
+msgid ""
+"Perry only supports static imports. If a package branches on `typeof require"
+" !== \"undefined\"` for a Node/browser split, pick the branch that works "
+"natively and delete the other."
+msgstr ""
+
+#: src/packages/porting.md:104
+msgid "Prototype manipulation"
+msgstr ""
+
+#: src/packages/porting.md:106
+msgid ""
+"```text\n"
+"// Not supported\n"
+"Object.setPrototypeOf(obj, proto);\n"
+"MyClass.prototype.newMethod = function() {};\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:112
+msgid ""
+"Usually appears in fallback shims for older runtimes. Often dead code in the"
+" Perry path — just delete it."
+msgstr ""
+
+#: src/packages/porting.md:114
+msgid "Computed property keys in object literals"
+msgstr ""
+
+#: src/packages/porting.md:116
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const obj = { [key]: value };\n"
+"\n"
+"// Rewrite\n"
+"const obj: Record<string, V> = {};\n"
+"obj[key] = value;\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:125
+msgid "Using a coding agent"
+msgstr ""
+
+#: src/packages/porting.md:127
+msgid ""
+"A general coding agent (Claude Code, Cursor, Codex, Aider) can drive most of"
+" this workflow. If you're using a skill-aware agent, invoke the [`port-npm-"
+"to-perry` "
+"skill](https://github.com/PerryTS/perry/tree/main/.claude/skills/port-npm-"
+"to-perry) directly. Otherwise, paste this prompt:"
+msgstr ""
+
+#: src/packages/porting.md:129
+msgid ""
+"```\n"
+"I want to port the npm package <NAME> to run under Perry\n"
+"(https://github.com/PerryTS/perry). Perry compiles a subset of TypeScript\n"
+"natively; the subset's gaps are documented at\n"
+"https://github.com/PerryTS/perry/blob/main/docs/src/language/limitations.md.\n"
+"\n"
+"Please:\n"
+"\n"
+"1. Read the package at node_modules/<NAME>/. Check package.json for\n"
+"   native addons (binding.gyp, gypfile, prebuilds/ — stop if present).\n"
+"2. Scan for unsupported constructs: eval, new Function, dynamic require,\n"
+"   Symbol, Proxy, WeakMap, WeakRef, Reflect, decorators, lookbehind\n"
+"   regex (?<= / ?<!), Object.setPrototypeOf, computed property keys.\n"
+"3. Report a triage: what rules the package out vs. what's patchable.\n"
+"4. If patchable: add the package to perry.compilePackages in\n"
+"   package.json, apply minimal localized patches, and record each\n"
+"   patch in perry-patches/<NAME>.md.\n"
+"5. Verify by running `perry compile` against a small file that imports\n"
+"   the package.\n"
+"\n"
+"Don't patch blindly — a grep hit inside a string or comment isn't real.\n"
+"Show me the triage before applying substantial patches.\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:153
+msgid ""
+"This is intentionally an agent-agnostic prompt — it'll work with any "
+"competent coding agent. The skill version bundles the same instructions with"
+" richer context and is auto-discovered by Claude Code."
+msgstr ""
+
+#: src/packages/porting.md:155
+msgid "Giving feedback"
+msgstr ""
+
+#: src/packages/porting.md:157
+msgid ""
+"This whole workflow is experimental. If a port fails in a way that feels "
+"like Perry should handle it — or if the guide misses a common gap — please "
+"comment on [issue #115](https://github.com/PerryTS/perry/issues/115) so we "
+"can iterate."
+msgstr ""
+
+#: src/threading/overview.md:3
+msgid ""
+"Perry gives you real OS threads with a one-line API. No worker setup, no "
+"message ports, no structured clone overhead. Just `parallelMap`, "
+"`parallelFilter`, and `spawn`."
+msgstr ""
+
+#: src/threading/overview.md:5
+msgid ""
+"```typescript\n"
+"async function overviewHeader(): Promise<void> {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"    const records = [\n"
+"        { score: 50, id: 1 },\n"
+"        { score: 90, id: 2 },\n"
+"        { score: 85, id: 3 },\n"
+"    ]\n"
+"    const threshold = 80\n"
+"\n"
+"    // Process a million items across all CPU cores\n"
+"    const results = parallelMap(data, (item: number) => item * item)\n"
+"\n"
+"    // Filter a large dataset in parallel\n"
+"    const valid = parallelFilter(records, (r: { score: number; id: number }) => r.score > threshold)\n"
+"\n"
+"    // Run expensive work in the background\n"
+"    const answer = await spawn(() => {\n"
+"        let acc = 0\n"
+"        for (let i = 0; i < 100_000; i++) acc += i\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    console.log(`overview-header results=${results.length} valid=${valid.length} answer=${answer}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:32
+msgid ""
+"This is something **no JavaScript runtime can do**. V8, Bun, and Deno are "
+"all locked to one thread per isolate. Perry compiles to native code — there "
+"are no isolates, no GIL, no structural limitations. Your code runs on real "
+"OS threads with the full power of every CPU core."
+msgstr ""
+
+#: src/threading/overview.md:34
+msgid "Why This Matters"
+msgstr ""
+
+#: src/threading/overview.md:36
+msgid ""
+"JavaScript's single-threaded model is its biggest performance bottleneck. "
+"Here's how runtimes try to work around it:"
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "Runtime"
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "\"Multi-threading\""
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "Reality"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid "**Node.js**"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid "`worker_threads`"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid ""
+"Separate V8 isolates. Data copied via structured clone. ~2MB RAM per worker."
+" Complex API."
+msgstr ""
+
+#: src/threading/overview.md:41
+msgid "**Deno**"
+msgstr ""
+
+#: src/threading/overview.md:41 src/threading/overview.md:42
+msgid "`Worker`"
+msgstr ""
+
+#: src/threading/overview.md:41
+msgid "Same as Node — isolated heaps, message passing only."
+msgstr ""
+
+#: src/threading/overview.md:42
+msgid "**Bun**"
+msgstr ""
+
+#: src/threading/overview.md:42
+msgid "Same architecture. Faster structured clone, still isolated."
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid "**Perry**"
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid "`parallelMap` / `spawn`"
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid ""
+"Real OS threads. Lightweight (8MB stack). One-line API. Compile-time safety."
+msgstr ""
+
+#: src/threading/overview.md:45
+msgid ""
+"The fundamental problem: V8 uses a garbage-collected heap that **cannot be "
+"shared** between threads. Every \"worker\" is an entirely separate "
+"JavaScript engine instance with its own heap, its own GC, and its own copy "
+"of your data."
+msgstr ""
+
+#: src/threading/overview.md:47
+msgid ""
+"Perry doesn't have this limitation. It compiles TypeScript to native machine"
+" code. Values are transferred between threads using zero-cost copies for "
+"numbers and efficient serialization for objects — no separate engine "
+"instances, no multi-megabyte overhead per thread."
+msgstr ""
+
+#: src/threading/overview.md:49
+msgid "Three Primitives"
+msgstr ""
+
+#: src/threading/overview.md:51
+msgid "`parallelMap` — Data-Parallel Processing"
+msgstr ""
+
+#: src/threading/overview.md:53
+msgid ""
+"Split an array across all CPU cores. Each element is processed "
+"independently. Results are collected in order."
+msgstr ""
+
+#: src/threading/overview.md:55
+msgid ""
+"```typescript\n"
+"async function overviewParallelMap(): Promise<void> {\n"
+"    const prices = [100, 200, 300, 400, 500, 600, 700, 800]\n"
+"    const adjusted = parallelMap(prices, (price: number) => {\n"
+"        // Heavy computation runs on a worker thread\n"
+"        let result = price\n"
+"        for (let i = 0; i < 1000000; i++) {\n"
+"            result = Math.sqrt(result * result + i)\n"
+"        }\n"
+"        return result\n"
+"    })\n"
+"\n"
+"    console.log(`overview-parallel-map len=${adjusted.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:71 src/plugins/creating-plugins.md:37
+msgid "Perry automatically:"
+msgstr ""
+
+#: src/threading/overview.md:72
+msgid "Detects the number of CPU cores"
+msgstr ""
+
+#: src/threading/overview.md:73
+msgid "Splits the array into chunks (one per core)"
+msgstr ""
+
+#: src/threading/overview.md:74
+msgid "Spawns OS threads to process each chunk"
+msgstr ""
+
+#: src/threading/overview.md:75
+msgid "Collects results in the original order"
+msgstr ""
+
+#: src/threading/overview.md:76
+msgid "Returns a new array"
+msgstr ""
+
+#: src/threading/overview.md:78
+msgid ""
+"For small arrays, Perry skips threading entirely and processes inline — no "
+"overhead for trivial cases."
+msgstr ""
+
+#: src/threading/overview.md:80
+msgid "`parallelFilter` — Data-Parallel Filtering"
+msgstr ""
+
+#: src/threading/overview.md:82
+msgid ""
+"Filter a large array across all CPU cores. Like `.filter()` but parallel:"
+msgstr ""
+
+#: src/threading/overview.md:84
+msgid ""
+"```typescript\n"
+"async function overviewParallelFilter(): Promise<void> {\n"
+"    const cutoffDate = 1_700_000_000\n"
+"    const users = [\n"
+"        { lastLogin: 1_710_000_000, score: 150, name: \"alice\" },\n"
+"        { lastLogin: 1_690_000_000, score: 50, name: \"bob\" },\n"
+"        { lastLogin: 1_720_000_000, score: 120, name: \"carol\" },\n"
+"    ]\n"
+"\n"
+"    // Filter across all cores — order is preserved\n"
+"    const active = parallelFilter(users, (user: { lastLogin: number; score: number; name: string }) => {\n"
+"        return user.lastLogin > cutoffDate && user.score > 100\n"
+"    })\n"
+"\n"
+"    console.log(`overview-parallel-filter active=${active.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:102
+msgid ""
+"Same rules as `parallelMap`: closures cannot capture mutable variables "
+"(compile-time enforced), and values are deep-copied between threads."
+msgstr ""
+
+#: src/threading/overview.md:104
+msgid "`spawn` — Background Threads"
+msgstr ""
+
+#: src/threading/overview.md:106
+msgid ""
+"Run any computation in the background and get a Promise back. The main "
+"thread continues immediately."
+msgstr ""
+
+#: src/threading/overview.md:108
+msgid ""
+"```typescript\n"
+"async function overviewSpawnBg(): Promise<void> {\n"
+"    // Start heavy work in the background\n"
+"    const handle = spawn(() => {\n"
+"        let sum = 0\n"
+"        for (let i = 0; i < 100_000; i++) {\n"
+"            sum += Math.sin(i)\n"
+"        }\n"
+"        return sum\n"
+"    })\n"
+"\n"
+"    // Main thread keeps running — UI stays responsive\n"
+"    console.log(\"Computing...\")\n"
+"\n"
+"    // Get the result when you need it\n"
+"    const result = await handle\n"
+"    console.log(`Done: len=${typeof result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:128
+msgid ""
+"`spawn` returns a standard Promise. You can `await` it, pass it to "
+"`Promise.all`, or chain `.then()` — it works exactly like any other async "
+"operation."
+msgstr ""
+
+#: src/threading/overview.md:130
+msgid "Practical Examples"
+msgstr ""
+
+#: src/threading/overview.md:132
+msgid "Parallel Image Processing"
+msgstr ""
+
+#: src/threading/overview.md:134
+msgid ""
+"```typescript\n"
+"async function overviewImage(): Promise<void> {\n"
+"    const pixels = [\n"
+"        { r: 100, g: 120, b: 140 },\n"
+"        { r: 50, g: 60, b: 70 },\n"
+"        { r: 200, g: 210, b: 220 },\n"
+"    ]\n"
+"\n"
+"    // Each pixel processed on a separate core\n"
+"    const processed = parallelMap(pixels, (pixel: { r: number; g: number; b: number }) => {\n"
+"        const r = Math.min(255, pixel.r * 1.2)\n"
+"        const g = Math.min(255, pixel.g * 0.8)\n"
+"        const b = Math.min(255, pixel.b * 1.1)\n"
+"        return { r, g, b }\n"
+"    })\n"
+"\n"
+"    console.log(`overview-image processed=${processed.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:154
+msgid "Parallel Cryptographic Hashing"
+msgstr ""
+
+#: src/threading/overview.md:156
+msgid ""
+"```typescript\n"
+"async function overviewCrypto(): Promise<void> {\n"
+"    // Hash thousands of items across all cores\n"
+"    const passwords = [\"pass1\", \"pass2\", \"pass3\"]\n"
+"    const hashed = parallelMap(passwords, (password: string) => {\n"
+"        // Stand-in for a real hash: deterministic FNV-1a over the bytes.\n"
+"        let h = 2166136261\n"
+"        for (let i = 0; i < password.length; i++) {\n"
+"            h ^= password.charCodeAt(i)\n"
+"            h = (h * 16777619) >>> 0\n"
+"        }\n"
+"        return h\n"
+"    })\n"
+"\n"
+"    console.log(`overview-crypto hashed=${hashed.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:174
+msgid "Multiple Independent Computations"
+msgstr ""
+
+#: src/threading/overview.md:176
+msgid ""
+"```typescript\n"
+"async function overviewMultiple(): Promise<void> {\n"
+"    const dataA = [1, 2, 3]\n"
+"    const dataB = [4, 5, 6]\n"
+"    const dataC = [7, 8, 9]\n"
+"\n"
+"    // Three independent tasks run simultaneously on three OS threads\n"
+"    const task1 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataA) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"    const task2 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataB) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"    const task3 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataC) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    // All three run concurrently\n"
+"    const [result1, result2, result3] = await Promise.all([task1, task2, task3])\n"
+"    console.log(`overview-multiple ${result1} ${result2} ${result3}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:205
+msgid "Keeping UI Responsive"
+msgstr ""
+
+#: src/threading/overview.md:207
+msgid ""
+"```typescript\n"
+"const responsiveButton = Button(\"Start Analysis\", async () => {\n"
+"    status.set(\"Analyzing...\")\n"
+"\n"
+"    // Heavy computation runs on a background thread\n"
+"    // UI stays responsive — user can still interact\n"
+"    const value = await spawn(() => {\n"
+"        let acc = 0\n"
+"        for (let i = 0; i < 1_000_000; i++) acc += i\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    status.set(`Done: ${value}`)\n"
+"})\n"
+"\n"
+"const responsiveText = Text(`Status: ${status.value}`)\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:225
+msgid "Captured Variables"
+msgstr ""
+
+#: src/threading/overview.md:227
+msgid ""
+"Closures can capture outer variables. Captured values are automatically "
+"deep-copied to each worker thread:"
+msgstr ""
+
+#: src/threading/overview.md:229
+msgid ""
+"```typescript\n"
+"async function overviewCaptured(): Promise<void> {\n"
+"    const prices = [100, 200, 300, 400]\n"
+"    const taxRate = 0.08\n"
+"    const discount = 0.15\n"
+"\n"
+"    // taxRate and discount are captured and copied to each thread\n"
+"    const finalPrices = parallelMap(prices, (price: number) => {\n"
+"        const discounted = price * (1 - discount)\n"
+"        return discounted * (1 + taxRate)\n"
+"    })\n"
+"\n"
+"    console.log(`overview-captured len=${finalPrices.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:245
+msgid ""
+"Numbers and booleans are zero-cost copies (just 64-bit values). Strings, "
+"arrays, and objects are deep-copied automatically."
+msgstr ""
+
+#: src/threading/overview.md:247
+msgid "Safety"
+msgstr ""
+
+#: src/threading/overview.md:249
+msgid ""
+"Perry enforces thread safety **at compile time**. You don't need to think "
+"about race conditions, mutexes, or data corruption."
+msgstr ""
+
+#: src/threading/overview.md:251
+msgid "No Shared Mutable State"
+msgstr ""
+
+#: src/threading/overview.md:253
+msgid ""
+"Closures passed to `parallelMap` and `spawn` **cannot capture mutable "
+"variables**. The compiler rejects this:"
+msgstr ""
+
+#: src/threading/overview.md:255
+msgid ""
+"```text\n"
+"// Reject example — Perry rejects this at compile time:\n"
+"\n"
+"let counter = 0;\n"
+"\n"
+"// COMPILE ERROR: Closures passed to parallelMap cannot\n"
+"// capture mutable variable 'counter'\n"
+"parallelMap(data, (item) => {\n"
+"    counter++;  // Not allowed\n"
+"    return item;\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:268
+msgid ""
+"This eliminates data races by design. If you need to aggregate results, use "
+"the return values:"
+msgstr ""
+
+#: src/threading/overview.md:270
+msgid ""
+"```typescript\n"
+"async function overviewReduceInstead(): Promise<void> {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    // Instead of mutating a shared counter, return values and reduce\n"
+"    const results = parallelMap(data, (item: number) => item * item)\n"
+"    const total = results.reduce((sum: number, r: number) => sum + r, 0)\n"
+"\n"
+"    console.log(`overview-reduce-instead total=${total}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:282
+msgid "Independent Thread Arenas"
+msgstr ""
+
+#: src/threading/overview.md:284
+msgid ""
+"Each worker thread has its own memory arena. Objects created on one thread "
+"can never be accessed from another thread. Values cross thread boundaries "
+"only through deep-copy serialization, which Perry handles automatically and "
+"invisibly."
+msgstr ""
+
+#: src/threading/overview.md:288
+msgid "Perry's threading model is built on three pillars:"
+msgstr ""
+
+#: src/threading/overview.md:290
+msgid "**1. Native Code, Not Interpreted**"
+msgstr ""
+
+#: src/threading/overview.md:292
+msgid ""
+"Perry compiles TypeScript to native machine code via LLVM. There's no "
+"interpreter, no VM, no isolate. A function pointer is just a function "
+"pointer — it's valid on any thread."
+msgstr ""
+
+#: src/threading/overview.md:294
+msgid "**2. Thread-Local Memory**"
+msgstr ""
+
+#: src/threading/overview.md:296
+msgid ""
+"Each thread gets its own memory arena (bump allocator) and garbage "
+"collector. No synchronization overhead during computation. When a thread "
+"finishes, its arena is freed automatically."
+msgstr ""
+
+#: src/threading/overview.md:298
+msgid "**3. Serialized Transfer**"
+msgstr ""
+
+#: src/threading/overview.md:300
+msgid ""
+"Values crossing thread boundaries are serialized to a thread-safe "
+"intermediate format and deserialized on the target thread. The cost depends "
+"on the value type:"
+msgstr ""
+
+#: src/threading/overview.md:302
+msgid "Value Type"
+msgstr ""
+
+#: src/threading/overview.md:302
+msgid "Transfer Cost"
+msgstr ""
+
+#: src/threading/overview.md:304
+msgid "Numbers, booleans, null, undefined"
+msgstr ""
+
+#: src/threading/overview.md:304 src/threading/parallel-map.md:55
+msgid "Zero-cost (64-bit copy)"
+msgstr ""
+
+#: src/threading/overview.md:305 src/threading/parallel-map.md:57
+msgid "Strings"
+msgstr ""
+
+#: src/threading/overview.md:305
+msgid "O(n) byte copy"
+msgstr ""
+
+#: src/threading/overview.md:306
+msgid "O(n) deep copy of elements"
+msgstr ""
+
+#: src/threading/overview.md:307
+msgid "O(n) deep copy of fields"
+msgstr ""
+
+#: src/threading/overview.md:308
+msgid "Pointer + captured values"
+msgstr ""
+
+#: src/threading/overview.md:310
+msgid ""
+"For numeric workloads — the most common parallelizable tasks — the threading"
+" overhead is negligible."
+msgstr ""
+
+#: src/threading/overview.md:314
+msgid ""
+"[parallelMap Reference](parallel-map.md) — detailed API and performance tips"
+msgstr ""
+
+#: src/threading/overview.md:315
+msgid ""
+"[parallelFilter Reference](parallel-filter.md) — parallel array filtering"
+msgstr ""
+
+#: src/threading/overview.md:316
+msgid ""
+"[spawn Reference](spawn.md) — background threads and Promise integration"
+msgstr ""
+
+#: src/threading/parallel-map.md:3
+msgid ""
+"**Signature**: `parallelMap<T, U>(data: T[], fn: (item: T) => U): U[]` — "
+"imported from `perry/thread`."
+msgstr ""
+
+#: src/threading/parallel-map.md:5
+msgid ""
+"Processes every element of an array in parallel across all available CPU "
+"cores. Returns a new array with the results in the same order as the input."
+msgstr ""
+
+#: src/threading/parallel-map.md:7 src/threading/parallel-filter.md:7
+#: src/threading/spawn.md:7
+msgid "Basic Usage"
+msgstr ""
+
+#: src/threading/parallel-map.md:9
+msgid ""
+"```typescript\n"
+"function parallelMapBasic(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"    const doubled = parallelMap(numbers, (x: number) => x * 2)\n"
+"    // [2, 4, 6, 8, 10, 12, 14, 16]\n"
+"    console.log(`parallel-map-basic len=${doubled.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:31
+msgid ""
+"Perry automatically detects the number of CPU cores and splits the array "
+"into equal chunks. Elements within each chunk are processed sequentially; "
+"chunks run concurrently across cores."
+msgstr ""
+
+#: src/threading/parallel-map.md:33 src/threading/parallel-filter.md:53
+#: src/threading/spawn.md:80
+msgid "Capturing Variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:35
+msgid ""
+"The mapping function can reference variables from the outer scope. Captured "
+"values are deep-copied to each worker thread automatically:"
+msgstr ""
+
+#: src/threading/parallel-map.md:37
+msgid ""
+"```typescript\n"
+"function parallelMapCapture(): void {\n"
+"    const prices = [100, 200, 300]\n"
+"    const exchangeRate = 1.12\n"
+"\n"
+"    const converted = parallelMap(prices, (price: number) => {\n"
+"        // exchangeRate is captured and copied to each thread\n"
+"        return price * exchangeRate\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-capture len=${converted.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:51
+msgid "What Can Be Captured"
+msgstr ""
+
+#: src/threading/parallel-map.md:53 src/ui/overview.md:57 src/ui/styling.md:45
+#: src/widgets/creating-widgets.md:45 src/widgets/configuration.md:70
+#: src/testing/geisterhand.md:84 src/cli/flags.md:43 src/cli/perry-toml.md:114
+#: src/cli/perry-toml.md:125 src/cli/perry-toml.md:153
+#: src/cli/perry-toml.md:165 src/cli/perry-toml.md:175
+#: src/cli/perry-toml.md:181 src/cli/perry-toml.md:191
+#: src/cli/perry-toml.md:241 src/cli/perry-toml.md:254
+#: src/cli/perry-toml.md:260 src/cli/perry-toml.md:268
+#: src/cli/perry-toml.md:299 src/cli/perry-toml.md:310
+#: src/cli/perry-toml.md:327 src/cli/perry-toml.md:345
+#: src/cli/perry-toml.md:357 src/cli/perry-toml.md:367
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414 src/contributing/architecture.md:47
+msgid "Type"
+msgstr ""
+
+#: src/threading/parallel-map.md:53
+msgid "Supported"
+msgstr ""
+
+#: src/threading/parallel-map.md:53
+msgid "Transfer"
+msgstr ""
+
+#: src/threading/parallel-map.md:55
+msgid "Numbers"
+msgstr ""
+
+#: src/threading/parallel-map.md:55 src/threading/parallel-map.md:56
+#: src/threading/parallel-map.md:57 src/threading/parallel-map.md:58
+#: src/threading/parallel-map.md:59 src/threading/parallel-map.md:60
+#: src/platforms/overview.md:69 src/platforms/overview.md:70
+#: src/platforms/overview.md:71 src/platforms/overview.md:72
+#: src/platforms/overview.md:73 src/platforms/overview.md:74
+#: src/platforms/overview.md:75 src/widgets/platforms.md:22
+#: src/widgets/platforms.md:23 src/widgets/platforms.md:24
+#: src/widgets/platforms.md:25 src/widgets/platforms.md:26
+#: src/widgets/platforms.md:27 src/widgets/platforms.md:28
+#: src/widgets/platforms.md:29 src/widgets/platforms.md:30
+#: src/widgets/platforms.md:31 src/widgets/platforms.md:32
+#: src/widgets/platforms.md:33
+msgid "Yes"
+msgstr ""
+
+#: src/threading/parallel-map.md:56
+msgid "Booleans"
+msgstr ""
+
+#: src/threading/parallel-map.md:56
+msgid "Zero-cost"
+msgstr ""
+
+#: src/threading/parallel-map.md:57
+msgid "Byte copy"
+msgstr ""
+
+#: src/threading/parallel-map.md:58 src/threading/parallel-map.md:59
+msgid "Deep copy"
+msgstr ""
+
+#: src/threading/parallel-map.md:60
+msgid "`const` variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:60 src/threading/parallel-map.md:61
+msgid "Copied"
+msgstr ""
+
+#: src/threading/parallel-map.md:61
+msgid "`let`/`var` variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:61
+msgid "Only if not reassigned"
+msgstr ""
+
+#: src/threading/parallel-map.md:63
+msgid "What Cannot Be Captured"
+msgstr ""
+
+#: src/threading/parallel-map.md:65
+msgid ""
+"Mutable variables — variables that are reassigned anywhere in the enclosing "
+"scope — are rejected at compile time:"
+msgstr ""
+
+#: src/threading/parallel-map.md:67
+msgid ""
+"```text\n"
+"// Reject example — Perry rejects this at compile time:\n"
+"\n"
+"let total = 0;\n"
+"\n"
+"// COMPILE ERROR: Cannot capture mutable variable 'total'\n"
+"parallelMap(data, (item) => {\n"
+"    total += item;   // Would be a data race\n"
+"    return item;\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:79
+msgid "Instead, return values and reduce:"
+msgstr ""
+
+#: src/threading/parallel-map.md:90 src/threading/parallel-filter.md:155
+msgid "Performance"
+msgstr ""
+
+#: src/threading/parallel-map.md:92
+msgid "When to Use parallelMap"
+msgstr ""
+
+#: src/threading/parallel-map.md:94
+msgid ""
+"Use `parallelMap` when the computation per element is **significantly "
+"heavier** than the cost of copying the element across threads."
+msgstr ""
+
+#: src/threading/parallel-map.md:96
+msgid "**Good candidates** (CPU-bound work per element):"
+msgstr ""
+
+#: src/threading/parallel-map.md:98
+msgid ""
+"```typescript\n"
+"function parallelMapGoodCandidates(): void {\n"
+"    const data = [1.0, 2.0, 3.0, 4.0]\n"
+"    const documents = [\"alpha beta\", \"gamma delta\", \"epsilon\"]\n"
+"    const inputs = [\"a\", \"bb\", \"ccc\"]\n"
+"\n"
+"    // Heavy math\n"
+"    const out1 = parallelMap(data, (x: number) => {\n"
+"        let acc = x\n"
+"        for (let i = 0; i < 1_000; i++) acc = Math.sqrt(acc * acc + i)\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    // String processing on large strings\n"
+"    const out2 = parallelMap(documents, (doc: string) => {\n"
+"        const words = doc.split(\" \")\n"
+"        return { count: words.length, first: words[0] }\n"
+"    })\n"
+"\n"
+"    // Cryptographic operations\n"
+"    const out3 = parallelMap(inputs, (input: string) => {\n"
+"        let h = 0\n"
+"        for (let i = 0; i < input.length; i++) h = (h * 31 + input.charCodeAt(i)) >>> 0\n"
+"        return h\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-good-candidates ${out1.length} ${out2.length} ${out3.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:128
+msgid "**Poor candidates** (trivial work per element):"
+msgstr ""
+
+#: src/threading/parallel-map.md:130
+msgid ""
+"```typescript\n"
+"function parallelMapPoorCandidate(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5]\n"
+"\n"
+"    // Too simple — threading overhead outweighs the gain\n"
+"    const a = parallelMap(numbers, (x: number) => x + 1)\n"
+"\n"
+"    // For trivial operations, use regular map\n"
+"    const result = numbers.map((x: number) => x + 1)\n"
+"\n"
+"    console.log(`parallel-map-poor-candidate ${a.length} ${result.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:144
+msgid "Small Array Optimization"
+msgstr ""
+
+#: src/threading/parallel-map.md:146
+msgid ""
+"For arrays with fewer elements than CPU cores, Perry skips threading "
+"entirely and processes elements inline on the main thread. There's zero "
+"overhead for small inputs."
+msgstr ""
+
+#: src/threading/parallel-map.md:148
+msgid "Numeric Fast Path"
+msgstr ""
+
+#: src/threading/parallel-map.md:150
+msgid ""
+"When elements are pure numbers (no strings, objects, or arrays), Perry "
+"transfers them between threads at virtually zero cost — just 64-bit value "
+"copies with no serialization."
+msgstr ""
+
+#: src/threading/parallel-map.md:152 src/threading/parallel-filter.md:78
+#: src/threading/spawn.md:183 src/cli/flags.md:139
+msgid "Examples"
+msgstr ""
+
+#: src/threading/parallel-map.md:154
+msgid "Matrix Row Processing"
+msgstr ""
+
+#: src/threading/parallel-map.md:156
+msgid ""
+"```typescript\n"
+"function parallelMapMatrix(): void {\n"
+"    // Process each row of a matrix independently\n"
+"    const rows = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]\n"
+"    const rowSums = parallelMap(rows, (row: number[]) => {\n"
+"        let sum = 0\n"
+"        for (const val of row) sum += val\n"
+"        return sum\n"
+"    })\n"
+"    // [6, 15, 24]\n"
+"    console.log(`parallel-map-matrix sums=${rowSums[0]},${rowSums[1]},${rowSums[2]}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:170
+msgid "Batch Validation"
+msgstr ""
+
+#: src/threading/parallel-map.md:172
+msgid ""
+"```typescript\n"
+"function parallelMapValidation(): void {\n"
+"    const users = [\n"
+"        { name: \"Alice\", email: \"alice@example.com\" },\n"
+"        { name: \"Bob\", email: \"invalid\" },\n"
+"        { name: \"Charlie\", email: \"charlie@example.com\" },\n"
+"    ]\n"
+"\n"
+"    const validationResults = parallelMap(users, (user: { name: string; email: string }) => {\n"
+"        const emailValid = user.email.includes(\"@\") && user.email.includes(\".\")\n"
+"        const nameValid = user.name.length > 0 && user.name.length < 100\n"
+"        return { name: user.name, valid: emailValid && nameValid }\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-validation len=${validationResults.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:190
+msgid "Financial Calculations"
+msgstr ""
+
+#: src/threading/parallel-map.md:192
+msgid ""
+"```typescript\n"
+"function parallelMapMonteCarlo(): void {\n"
+"    const portfolios = [\n"
+"        { id: 1, base: 100 },\n"
+"        { id: 2, base: 200 },\n"
+"        { id: 3, base: 150 },\n"
+"    ] // thousands of portfolios\n"
+"\n"
+"    // Monte Carlo simulation across all cores\n"
+"    const riskScores = parallelMap(portfolios, (portfolio: { id: number; base: number }) => {\n"
+"        let totalRisk = 0\n"
+"        for (let sim = 0; sim < 1000; sim++) {\n"
+"            // simulateReturns stand-in: deterministic pseudo-random walk.\n"
+"            let s = portfolio.base + sim\n"
+"            s = ((s * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff\n"
+"            totalRisk += s\n"
+"        }\n"
+"        return totalRisk / 1000\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-monte-carlo len=${riskScores.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:3
+msgid ""
+"**Signature**: `parallelFilter<T>(data: T[], predicate: (item: T) => "
+"boolean): T[]` — imported from `perry/thread`."
+msgstr ""
+
+#: src/threading/parallel-filter.md:5
+msgid ""
+"Filters an array in parallel across all available CPU cores. Returns a new "
+"array containing only the elements where the predicate returned a truthy "
+"value. Order is preserved."
+msgstr ""
+
+#: src/threading/parallel-filter.md:9
+msgid ""
+"```typescript\n"
+"function parallelFilterBasic(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n"
+"    const evens = parallelFilter(numbers, (x: number) => x % 2 === 0)\n"
+"    // [2, 4, 6, 8, 10]\n"
+"    console.log(`parallel-filter-basic len=${evens.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:31
+msgid ""
+"Each core independently tests its chunk of elements. Results are merged in "
+"the original element order after all threads complete."
+msgstr ""
+
+#: src/threading/parallel-filter.md:33
+msgid "Why Not Just Use `.filter()`?"
+msgstr ""
+
+#: src/threading/parallel-filter.md:35
+msgid ""
+"Regular `.filter()` runs on a single thread. For large arrays with expensive"
+" predicates, `parallelFilter` distributes the work:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:37
+msgid ""
+"```typescript\n"
+"function parallelFilterVsFilter(): void {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    // Single-threaded — one core does all the work\n"
+"    const a = data.filter((item: number) => item > 3)\n"
+"\n"
+"    // Parallel — all cores share the work\n"
+"    const b = parallelFilter(data, (item: number) => item > 3)\n"
+"\n"
+"    console.log(`parallel-filter-vs-filter ${a.length} ${b.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:51
+msgid ""
+"The tradeoff: `parallelFilter` has overhead from copying values between "
+"threads. Use it when the predicate is expensive enough to justify that cost."
+msgstr ""
+
+#: src/threading/parallel-filter.md:55
+msgid ""
+"Like `parallelMap`, the predicate can capture outer variables. Captures are "
+"deep-copied to each thread:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:57
+msgid ""
+"```typescript\n"
+"function parallelFilterCapture(): void {\n"
+"    const candidates = [\n"
+"        { name: \"Alice\", score: 90, age: 28 },\n"
+"        { name: \"Bob\", score: 80, age: 35 },\n"
+"        { name: \"Carol\", score: 95, age: 25 },\n"
+"    ]\n"
+"    const minScore = 85\n"
+"    const maxAge = 30\n"
+"\n"
+"    // minScore and maxAge are captured and copied to each thread\n"
+"    const qualified = parallelFilter(candidates, (c: { name: string; score: number; age: number }) => {\n"
+"        return c.score >= minScore && c.age <= maxAge\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-capture len=${qualified.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:76
+msgid ""
+"Mutable variables cannot be captured — the compiler rejects this at compile "
+"time."
+msgstr ""
+
+#: src/threading/parallel-filter.md:80
+msgid "Filtering Large Datasets"
+msgstr ""
+
+#: src/threading/parallel-filter.md:82
+msgid ""
+"```typescript\n"
+"function parallelFilterLarge(): void {\n"
+"    // Stand-in for \"millions of records\" — same shape, smaller list.\n"
+"    const transactions = [\n"
+"        { amount: 15000, country: \"US\", user: { homeCountry: \"DE\" }, timestamp: { hour: 4 } },\n"
+"        { amount: 200, country: \"DE\", user: { homeCountry: \"DE\" }, timestamp: { hour: 12 } },\n"
+"        { amount: 50000, country: \"FR\", user: { homeCountry: \"DE\" }, timestamp: { hour: 3 } },\n"
+"    ]\n"
+"\n"
+"    const suspicious = parallelFilter(transactions, (tx: {\n"
+"        amount: number\n"
+"        country: string\n"
+"        user: { homeCountry: string }\n"
+"        timestamp: { hour: number }\n"
+"    }) => {\n"
+"        return tx.amount > 10000\n"
+"            && tx.country !== tx.user.homeCountry\n"
+"            && tx.timestamp.hour < 6\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-large len=${suspicious.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:106
+msgid "Combined with parallelMap"
+msgstr ""
+
+#: src/threading/parallel-filter.md:108
+msgid ""
+"```typescript\n"
+"function parallelFilterCombined(): void {\n"
+"    const users = [\n"
+"        { name: \"Alice\", isActive: true, age: 28, score: 90 },\n"
+"        { name: \"Bob\", isActive: false, age: 35, score: 80 },\n"
+"        { name: \"Carol\", isActive: true, age: 17, score: 95 },\n"
+"        { name: \"Dave\", isActive: true, age: 40, score: 60 },\n"
+"    ]\n"
+"\n"
+"    // Step 1: Filter to relevant items (parallel)\n"
+"    const active = parallelFilter(users, (u: { isActive: boolean; age: number }) => u.isActive && u.age >= 18)\n"
+"\n"
+"    // Step 2: Transform the filtered results (parallel)\n"
+"    const profiles = parallelMap(active, (u: { name: string; score: number }) => ({\n"
+"        name: u.name,\n"
+"        score: u.score * 2,\n"
+"    }))\n"
+"\n"
+"    console.log(`parallel-filter-combined active=${active.length} profiles=${profiles.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:130
+msgid "Predicate with Heavy Computation"
+msgstr ""
+
+#: src/threading/parallel-filter.md:132
+msgid ""
+"```typescript\n"
+"function parallelFilterHeavy(): void {\n"
+"    const certificates = [\n"
+"        { id: 1, fingerprint: \"aa\", revoked: false },\n"
+"        { id: 2, fingerprint: \"bb\", revoked: true },\n"
+"        { id: 3, fingerprint: \"cc\", revoked: false },\n"
+"    ]\n"
+"\n"
+"    // Each predicate call does significant work — perfect for parallelization.\n"
+"    const valid = parallelFilter(certificates, (cert: { id: number; fingerprint: string; revoked: boolean }) => {\n"
+"        // Stand-in for a real chain verification: hash the fingerprint a bit\n"
+"        // then sanity-check the revocation flag.\n"
+"        let h = 0\n"
+"        for (let i = 0; i < cert.fingerprint.length; i++) {\n"
+"            h = (h * 31 + cert.fingerprint.charCodeAt(i)) >>> 0\n"
+"        }\n"
+"        return h !== 0 && !cert.revoked\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-heavy len=${valid.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:157
+msgid "Use `parallelFilter` when:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:158
+msgid "The array has many elements (hundreds or more)"
+msgstr ""
+
+#: src/threading/parallel-filter.md:159
+msgid "The predicate function does meaningful work per element"
+msgstr ""
+
+#: src/threading/parallel-filter.md:160
+msgid "You need to keep the UI responsive during filtering"
+msgstr ""
+
+#: src/threading/parallel-filter.md:162
+msgid ""
+"For trivial predicates on small arrays, regular `.filter()` is faster (no "
+"threading overhead)."
+msgstr ""
+
+#: src/threading/spawn.md:3
+msgid ""
+"**Signature**: `spawn<T>(fn: () => T): Promise<T>` — imported from "
+"`perry/thread`."
+msgstr ""
+
+#: src/threading/spawn.md:5
+msgid ""
+"Runs a closure on a new OS thread and returns a Promise that resolves when "
+"the thread completes. The main thread continues immediately — UI and other "
+"work are not blocked."
+msgstr ""
+
+#: src/threading/spawn.md:9
+msgid ""
+"```typescript\n"
+"async function spawnBasic(): Promise<void> {\n"
+"    const result = await spawn(() => {\n"
+"        // This runs on a separate OS thread.\n"
+"        let sum = 0\n"
+"        for (let i = 0; i < 100_000_000; i++) {\n"
+"            sum += i\n"
+"        }\n"
+"        return sum\n"
+"    })\n"
+"\n"
+"    console.log(result) // 4999999950000000\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:24
+msgid "Non-Blocking"
+msgstr ""
+
+#: src/threading/spawn.md:26
+msgid "`spawn` returns immediately. The main thread doesn't wait:"
+msgstr ""
+
+#: src/threading/spawn.md:28
+msgid ""
+"```typescript\n"
+"async function spawnNonBlocking(): Promise<void> {\n"
+"    console.log(\"1. Starting background work\")\n"
+"\n"
+"    const handle = spawn(() => {\n"
+"        // Runs on a background thread — heavier work elided here.\n"
+"        let n = 0\n"
+"        for (let i = 0; i < 10_000_000; i++) n++\n"
+"        return n\n"
+"    })\n"
+"\n"
+"    console.log(\"2. Main thread continues immediately\")\n"
+"\n"
+"    const result = await handle\n"
+"    console.log(`3. Got result: ${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:53
+msgid "Multiple Concurrent Tasks"
+msgstr ""
+
+#: src/threading/spawn.md:55
+msgid ""
+"Spawn multiple tasks and they run truly concurrently — one OS thread per "
+"`spawn` call:"
+msgstr ""
+
+#: src/threading/spawn.md:57
+msgid ""
+"```typescript\n"
+"async function spawnMultiple(): Promise<void> {\n"
+"    const t1 = spawn(() => analyseChunk(0, 1_000_000))\n"
+"    const t2 = spawn(() => analyseChunk(1_000_000, 2_000_000))\n"
+"    const t3 = spawn(() => analyseChunk(2_000_000, 3_000_000))\n"
+"\n"
+"    // All three run simultaneously on separate OS threads.\n"
+"    const results = await Promise.all([t1, t2, t3])\n"
+"\n"
+"    console.log(`Region A: ${results[0]}`)\n"
+"    console.log(`Region B: ${results[1]}`)\n"
+"    console.log(`Region C: ${results[2]}`)\n"
+"}\n"
+"\n"
+"function analyseChunk(start: number, end: number): number {\n"
+"    let acc = 0\n"
+"    for (let i = start; i < end; i++) acc += i & 0xff\n"
+"    return acc\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:78
+msgid ""
+"Unlike Node.js `worker_threads`, each `spawn` is a lightweight OS thread "
+"(~8MB stack), not a full V8 isolate (~2MB heap + startup cost)."
+msgstr ""
+
+#: src/threading/spawn.md:82
+msgid ""
+"Like `parallelMap`, `spawn` closures can capture outer variables. They are "
+"deep-copied to the background thread:"
+msgstr ""
+
+#: src/threading/spawn.md:84
+msgid ""
+"```typescript\n"
+"async function spawnCapture(): Promise<void> {\n"
+"    const config = { iterations: 1000, seed: 42 }\n"
+"    const dataset = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    const result = await spawn(() => {\n"
+"        // config and dataset are deep-copied to this thread.\n"
+"        let acc = config.seed\n"
+"        for (let i = 0; i < config.iterations; i++) {\n"
+"            acc = (acc * 1103515245 + 12345) & 0x7fffffff\n"
+"        }\n"
+"        for (const v of dataset) acc ^= v\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-capture: ${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:103
+msgid ""
+"Mutable variables cannot be captured — this is enforced at compile time."
+msgstr ""
+
+#: src/threading/spawn.md:105
+msgid "Returning Complex Values"
+msgstr ""
+
+#: src/threading/spawn.md:107
+msgid ""
+"`spawn` can return any value type. Complex values (objects, arrays, strings)"
+" are serialized back to the main thread automatically:"
+msgstr ""
+
+#: src/threading/spawn.md:133
+msgid "UI Integration"
+msgstr ""
+
+#: src/threading/spawn.md:135
+msgid ""
+"`spawn` is ideal for keeping native UIs responsive during heavy computation:"
+msgstr ""
+
+#: src/threading/spawn.md:137
+msgid ""
+"```typescript\n"
+"const analyzeButton = Button(\"Analyze\", async () => {\n"
+"    status.set(\"Processing...\")\n"
+"\n"
+"    // Background thread — UI stays responsive\n"
+"    const data = await spawn(() => {\n"
+"        let count = 0\n"
+"        for (let i = 0; i < 1_000_000; i++) {\n"
+"            if ((i & 0xff) === 0) count++\n"
+"        }\n"
+"        return { count }\n"
+"    })\n"
+"\n"
+"    result.set(`Found ${data.count} patterns`)\n"
+"    status.set(\"Done\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:155
+msgid ""
+"Without `spawn`, the analysis would freeze the UI. With `spawn`, the user "
+"can still scroll, tap other buttons, or navigate while the computation runs."
+msgstr ""
+
+#: src/threading/spawn.md:157
+msgid "Compared to Node.js worker_threads"
+msgstr ""
+
+#: src/threading/spawn.md:160
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
+msgstr ""
+
+#: src/threading/spawn.md:162 src/threading/spawn.md:167
+msgid "\"worker_threads\""
+msgstr ""
+
+#: src/threading/spawn.md:165
+msgid "// main.js\n"
+msgstr ""
+
+#: src/threading/spawn.md:168
+msgid "\"./worker.js\""
+msgstr ""
+
+#: src/threading/spawn.md:171
+msgid "\"message\""
+msgstr ""
+
+#: src/threading/spawn.md:174 src/testing/geisterhand.md:319
+msgid "\"error\""
+msgstr ""
+
+#: src/threading/spawn.md:174
+msgid "/* handle */"
+msgstr ""
+
+#: src/threading/spawn.md:176
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
+msgstr ""
+
+#: src/threading/spawn.md:181
+msgid ""
+"No separate files. No message ports. No event handlers. No structured clone."
+" One line."
+msgstr ""
+
+#: src/threading/spawn.md:185
+msgid "Background File Processing"
+msgstr ""
+
+#: src/threading/spawn.md:187
+msgid ""
+"```typescript\n"
+"async function spawnBgFile(): Promise<void> {\n"
+"    // Read and process a \"large\" file without blocking. We inline a tiny CSV\n"
+"    // so the snippet runs hermetically — the docs' real version would call\n"
+"    // readFileSync from \"fs\".\n"
+"    const content = \"id,value\\n1,10\\n2,20\\n3,30\\n\"\n"
+"    const analysis = await spawn(() => {\n"
+"        const lines = content.split(\"\\n\").filter((l: string) => l.length > 0).slice(1)\n"
+"        let total = 0\n"
+"        for (const line of lines) {\n"
+"            const parts = line.split(\",\")\n"
+"            total += parseInt(parts[1], 10)\n"
+"        }\n"
+"        return { rows: lines.length, total }\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-bg-file rows=${analysis.rows} total=${analysis.total}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:207
+msgid "Parallel API Calls with Processing"
+msgstr ""
+
+#: src/threading/spawn.md:209
+msgid ""
+"```typescript\n"
+"async function spawnApiThenProcess(): Promise<void> {\n"
+"    // The docs example fetches a remote API; for a hermetic test we\n"
+"    // just hand-roll the same pipeline shape with synthetic data.\n"
+"    const rawData = { items: [1, 2, 3, 4, 5] }\n"
+"\n"
+"    // CPU-intensive processing happens off the main thread\n"
+"    const processed = await spawn(() => {\n"
+"        let total = 0\n"
+"        for (const v of rawData.items) total += v * v\n"
+"        return { total, count: rawData.items.length }\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-api-then-process total=${processed.total} count=${processed.count}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:226
+msgid "Deferred Computation"
+msgstr ""
+
+#: src/threading/spawn.md:228
+msgid ""
+"```typescript\n"
+"async function spawnDeferred(): Promise<void> {\n"
+"    const params = { size: 8 }\n"
+"\n"
+"    // Start computation early, use result later\n"
+"    const precomputed = spawn(() => {\n"
+"        const table: number[] = []\n"
+"        for (let i = 0; i < params.size; i++) table.push(i * i)\n"
+"        return table\n"
+"    })\n"
+"\n"
+"    // ... do other setup work ...\n"
+"\n"
+"    // Result is ready (or we wait for it)\n"
+"    const table = await precomputed\n"
+"    console.log(`spawn-deferred len=${table.length} last=${table[table.length - 1]}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:1
+msgid "UI Overview"
+msgstr ""
+
+#: src/ui/overview.md:3
+msgid ""
+"Perry's `perry/ui` module lets you build native desktop and mobile apps with"
+" declarative TypeScript. Your UI code compiles directly to platform-native "
+"widgets — AppKit on macOS, UIKit on iOS, GTK4 on Linux, Win32 on Windows, "
+"and DOM elements on the web."
+msgstr ""
+
+#: src/ui/overview.md:5 src/i18n/overview.md:27 src/testing/geisterhand.md:9
+msgid "Quick Start"
+msgstr ""
+
+#: src/ui/overview.md:7
+msgid ""
+"```typescript\n"
+"// demonstrates: the smallest complete Perry UI app\n"
+"// docs: docs/src/ui/overview.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My App\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello from Perry!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:29
+msgid "Mental Model"
+msgstr ""
+
+#: src/ui/overview.md:31
+msgid ""
+"Perry's UI follows the same model as SwiftUI and Flutter: you compose native"
+" widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`),"
+" control alignment and distribution, and style widgets via free functions "
+"that take the widget handle as their first argument (`textSetColor(label, r,"
+" g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
+"web development, the key shift is:"
+msgstr ""
+
+#: src/ui/overview.md:33
+msgid ""
+"**Layout** is controlled by stack alignment, distribution, and spacers — not"
+" CSS properties. See [Layout](layout.md)."
+msgstr ""
+
+#: src/ui/overview.md:34
+msgid ""
+"**Styling** is applied directly to widgets — not through stylesheets. See "
+"[Styling](styling.md)."
+msgstr ""
+
+#: src/ui/overview.md:35
+msgid ""
+"**Absolute positioning** uses overlays (`widgetAddOverlay` + "
+"`widgetSetOverlayFrame`) — not `position: absolute/relative`."
+msgstr ""
+
+#: src/ui/overview.md:36
+msgid ""
+"**Design tokens** come from the `perry-styling` package. See "
+"[Theming](theming.md)."
+msgstr ""
+
+#: src/ui/overview.md:38 src/platforms/ios.md:63 src/platforms/tvos.md:104
+#: src/platforms/watchos.md:80
+msgid "App Lifecycle"
+msgstr ""
+
+#: src/ui/overview.md:40
+msgid "Every Perry UI app starts with `App()`:"
+msgstr ""
+
+#: src/ui/overview.md:42
+msgid ""
+"```typescript\n"
+"function runAppShell(): void {\n"
+"    App({\n"
+"        title: \"Window Title\",\n"
+"        width: 800,\n"
+"        height: 600,\n"
+"        body: VStack(16, [\n"
+"            Text(\"Content here\"),\n"
+"        ]),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:55
+msgid "`App({})` accepts a config object with the following properties:"
+msgstr ""
+
+#: src/ui/overview.md:57 src/widgets/creating-widgets.md:45
+msgid "Property"
+msgstr ""
+
+#: src/ui/overview.md:59
+msgid "`title`"
+msgstr ""
+
+#: src/ui/overview.md:59 src/ui/overview.md:63 src/ui/overview.md:65
+#: src/ui/overview.md:67 src/ui/overview.md:68 src/ui/styling.md:58
+#: src/cli/perry-toml.md:116 src/cli/perry-toml.md:117
+#: src/cli/perry-toml.md:119 src/cli/perry-toml.md:120
+#: src/cli/perry-toml.md:121 src/cli/perry-toml.md:127
+#: src/cli/perry-toml.md:155 src/cli/perry-toml.md:167
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:169
+#: src/cli/perry-toml.md:177 src/cli/perry-toml.md:183
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:185
+#: src/cli/perry-toml.md:186 src/cli/perry-toml.md:187
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:194
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:196
+#: src/cli/perry-toml.md:243 src/cli/perry-toml.md:244
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:249
+#: src/cli/perry-toml.md:256 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:263 src/cli/perry-toml.md:264
+#: src/cli/perry-toml.md:270 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:272 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:301 src/cli/perry-toml.md:302
+#: src/cli/perry-toml.md:303 src/cli/perry-toml.md:304
+#: src/cli/perry-toml.md:312 src/cli/perry-toml.md:313
+#: src/cli/perry-toml.md:314 src/cli/perry-toml.md:315
+#: src/cli/perry-toml.md:316 src/cli/perry-toml.md:317
+#: src/cli/perry-toml.md:318 src/cli/perry-toml.md:319
+#: src/cli/perry-toml.md:329 src/cli/perry-toml.md:330
+#: src/cli/perry-toml.md:331 src/cli/perry-toml.md:333
+#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:335
+#: src/cli/perry-toml.md:336 src/cli/perry-toml.md:337
+#: src/cli/perry-toml.md:347 src/cli/perry-toml.md:348
+#: src/cli/perry-toml.md:349 src/cli/perry-toml.md:360
+#: src/cli/perry-toml.md:369 src/cli/perry-toml.md:379
+#: src/cli/perry-toml.md:389 src/cli/perry-toml.md:390
+#: src/cli/perry-toml.md:416
+msgid "string"
+msgstr ""
+
+#: src/ui/overview.md:59
+msgid "Window title"
+msgstr ""
+
+#: src/ui/overview.md:60
+msgid "`width`"
+msgstr ""
+
+#: src/ui/overview.md:60 src/ui/overview.md:61 src/ui/styling.md:50
+#: src/ui/styling.md:51 src/system/overview.md:28
+msgid "number"
+msgstr ""
+
+#: src/ui/overview.md:60
+msgid "Initial window width"
+msgstr ""
+
+#: src/ui/overview.md:61
+msgid "`height`"
+msgstr ""
+
+#: src/ui/overview.md:61
+msgid "Initial window height"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "`body`"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "widget"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "Root widget"
+msgstr ""
+
+#: src/ui/overview.md:63
+msgid "`icon`"
+msgstr ""
+
+#: src/ui/overview.md:63
+msgid "App icon file path (optional)"
+msgstr ""
+
+#: src/ui/overview.md:64
+msgid "`frameless`"
+msgstr ""
+
+#: src/ui/overview.md:64 src/ui/overview.md:66 src/ui/styling.md:59
+#: src/ui/styling.md:60 src/system/media.md:49 src/cli/perry-toml.md:361
+msgid "boolean"
+msgstr ""
+
+#: src/ui/overview.md:64
+msgid "Remove title bar (optional)"
+msgstr ""
+
+#: src/ui/overview.md:65
+msgid "`level`"
+msgstr ""
+
+#: src/ui/overview.md:65
+msgid "Window z-order: `\"floating\"`, `\"statusBar\"`, `\"modal\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:66
+msgid "`transparent`"
+msgstr ""
+
+#: src/ui/overview.md:66
+msgid "Transparent background (optional)"
+msgstr ""
+
+#: src/ui/overview.md:67
+msgid "`vibrancy`"
+msgstr ""
+
+#: src/ui/overview.md:67
+msgid "Native blur material, e.g. `\"sidebar\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:68
+msgid "`activationPolicy`"
+msgstr ""
+
+#: src/ui/overview.md:68
+msgid "`\"regular\"`, `\"accessory\"` (no dock icon), `\"background\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:70
+msgid ""
+"See [Multi-Window](multi-window.md) for full documentation on window "
+"properties."
+msgstr ""
+
+#: src/ui/overview.md:72
+msgid "Lifecycle Hooks"
+msgstr ""
+
+#: src/ui/overview.md:74
+msgid ""
+"```typescript\n"
+"onActivate(() => {\n"
+"    console.log(\"App became active\")\n"
+"})\n"
+"\n"
+"onTerminate(() => {\n"
+"    console.log(\"App is closing\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:84
+msgid "Widget Tree"
+msgstr ""
+
+#: src/ui/overview.md:86
+msgid "Perry UIs are built as a tree of widgets:"
+msgstr ""
+
+#: src/ui/overview.md:88
+msgid ""
+"```typescript\n"
+"function runWidgetTree(): void {\n"
+"    App({\n"
+"        title: \"Layout Demo\",\n"
+"        width: 400,\n"
+"        height: 300,\n"
+"        body: VStack(16, [\n"
+"            Text(\"Header\"),\n"
+"            HStack(8, [\n"
+"                Button(\"Left\", () => console.log(\"left\")),\n"
+"                Button(\"Right\", () => console.log(\"right\")),\n"
+"            ]),\n"
+"            Text(\"Footer\"),\n"
+"        ]),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:106
+msgid ""
+"Widgets are created by calling their constructor functions. Layout "
+"containers (`VStack`, `HStack`, `ZStack`) accept a spacing value (in points)"
+" followed by an array of child widgets."
+msgstr ""
+
+#: src/ui/overview.md:108
+msgid "Handle-Based Architecture"
+msgstr ""
+
+#: src/ui/overview.md:110
+msgid ""
+"Under the hood, each widget is a handle — a small integer that references a "
+"native platform object. When you call `Text(\"hello\")`, Perry creates a "
+"native `NSTextField` (macOS), `UILabel` (iOS), `GtkLabel` (Linux), or "
+"`<span>` (web) and returns a handle you can use to modify it."
+msgstr ""
+
+#: src/ui/overview.md:112
+msgid ""
+"```typescript\n"
+"const label = Text(\"Hello\")\n"
+"textSetFontSize(label, 18)              // Modifies the native widget\n"
+"textSetColor(label, 1.0, 0.0, 0.0, 1.0) // RGBA floats in [0,1]\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:118
+msgid "Imports"
+msgstr ""
+
+#: src/ui/overview.md:120
+msgid "All UI functions are imported from `perry/ui`:"
+msgstr ""
+
+#: src/ui/overview.md:122
+msgid ""
+"```typescript\n"
+"import {\n"
+"    // App lifecycle\n"
+"    App, onActivate, onTerminate,\n"
+"\n"
+"    // Widgets\n"
+"    Text, Button, TextField, SecureField, TextArea,\n"
+"    Toggle, Slider, ProgressView, Picker, ImageFile, ImageSymbol,\n"
+"\n"
+"    // Layout\n"
+"    VStack, HStack, ZStack, ScrollView, Spacer, Divider,\n"
+"    NavStack, TabBar, LazyVStack, Section,\n"
+"    VStackWithInsets, HStackWithInsets, SplitView, splitViewAddChild,\n"
+"\n"
+"    // Layout control\n"
+"    stackSetAlignment, stackSetDistribution, stackSetDetachesHidden,\n"
+"    widgetMatchParentWidth, widgetMatchParentHeight, widgetSetHugging,\n"
+"    widgetAddOverlay, widgetSetOverlayFrame,\n"
+"\n"
+"    // State\n"
+"    State, ForEach,\n"
+"\n"
+"    // Dialogs\n"
+"    openFileDialog, openFolderDialog, saveFileDialog,\n"
+"    alert, alertWithButtons,\n"
+"    sheetCreate, sheetPresent, sheetDismiss,\n"
+"\n"
+"    // Menus\n"
+"    menuCreate, menuAddItem, menuAddSeparator, menuAddSubmenu,\n"
+"    menuBarCreate, menuBarAddMenu, menuBarAttach,\n"
+"    widgetSetContextMenu,\n"
+"\n"
+"    // Window\n"
+"    Window,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:159
+msgid ""
+"[`Canvas`](canvas.md), [`CameraView`](camera.md), and the virtualized "
+"[`Table`](table.md) widget are wired through the LLVM codegen (closed via "
+"[\\#190](https://github.com/PerryTS/perry/issues/190), "
+"[\\#191](https://github.com/PerryTS/perry/issues/191), and "
+"[\\#192](https://github.com/PerryTS/perry/issues/192)). See each widget's "
+"page for the platform-support matrix."
+msgstr ""
+
+#: src/ui/overview.md:166
+msgid "Platform Differences"
+msgstr ""
+
+#: src/ui/overview.md:168
+msgid ""
+"The same code runs on all platforms, but the look and feel matches each "
+"platform's native style:"
+msgstr ""
+
+#: src/ui/overview.md:170 src/platforms/overview.md:67
+#: src/i18n/formatting.md:138 src/widgets/platforms.md:20
+msgid "Feature"
+msgstr ""
+
+#: src/ui/overview.md:172
+msgid "Buttons"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/macos.md:27
+msgid "NSButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/tvos.md:53
+msgid "UIButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/linux.md:37
+msgid "GtkButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/windows.md:45
+msgid "HWND Button"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/wasm.md:58
+msgid "`<button>`"
+msgstr ""
+
+#: src/ui/overview.md:173 src/ui/widgets.md:13 src/ui/canvas.md:60
+#: src/platforms/macos.md:26 src/platforms/ios.md:52 src/platforms/tvos.md:52
+#: src/platforms/watchos.md:52 src/platforms/android.md:26
+#: src/platforms/windows.md:44 src/platforms/linux.md:36
+#: src/widgets/components.md:25 src/widgets/platforms.md:22
+msgid "Text"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/macos.md:28
+msgid "NSTextField"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/ios.md:52 src/platforms/tvos.md:52
+msgid "UILabel"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/linux.md:36
+msgid "GtkLabel"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/windows.md:44
+msgid "Static HWND"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/wasm.md:57
+msgid "`<span>`"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/macos.md:34
+msgid "NSStackView"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/ios.md:60 src/platforms/tvos.md:59
+msgid "UIStackView"
+msgstr ""
+
+#: src/ui/overview.md:174
+msgid "GtkBox"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/windows.md:53
+msgid "Manual layout"
+msgstr ""
+
+#: src/ui/overview.md:174
+msgid "Flexbox"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:111
+msgid "NSMenu"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:113 src/ui/menus.md:114
+#: src/ui/dialogs.md:111 src/ui/dialogs.md:112 src/platforms/overview.md:69
+#: src/platforms/overview.md:71 src/platforms/overview.md:72
+#: src/platforms/overview.md:75 src/cli/perry-toml.md:119
+#: src/cli/perry-toml.md:120 src/cli/perry-toml.md:127
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:169
+#: src/cli/perry-toml.md:170 src/cli/perry-toml.md:177
+#: src/cli/perry-toml.md:185 src/cli/perry-toml.md:186
+#: src/cli/perry-toml.md:187 src/cli/perry-toml.md:245
+#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:256
+#: src/cli/perry-toml.md:264 src/cli/perry-toml.md:303
+#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:312
+#: src/cli/perry-toml.md:315 src/cli/perry-toml.md:330
+#: src/cli/perry-toml.md:331 src/cli/perry-toml.md:332
+#: src/cli/perry-toml.md:333 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:335 src/cli/perry-toml.md:336
+#: src/cli/perry-toml.md:347 src/cli/perry-toml.md:348
+#: src/cli/perry-toml.md:359 src/cli/perry-toml.md:391
+msgid "—"
+msgstr ""
+
+#: src/ui/overview.md:175
+msgid "GMenu"
+msgstr ""
+
+#: src/ui/overview.md:175
+msgid "HMENU"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:115
+msgid "DOM"
+msgstr ""
+
+#: src/ui/overview.md:177
+msgid ""
+"Platform-specific behavior is noted on each widget's documentation page."
+msgstr ""
+
+#: src/ui/overview.md:181 src/ui/layout.md:370 src/ui/styling.md:379
+#: src/ui/state.md:228 src/ui/events.md:170 src/ui/canvas.md:82
+#: src/ui/table.md:109 src/ui/animation.md:74 src/ui/camera.md:145
+msgid "[Widgets](widgets.md) — All available widgets"
+msgstr ""
+
+#: src/ui/overview.md:182
+msgid "[Layout](layout.md) — Arranging widgets"
+msgstr ""
+
+#: src/ui/overview.md:183
+msgid "[State Management](state.md) — Reactive state and bindings"
+msgstr ""
+
+#: src/ui/overview.md:184
+msgid "[Styling](styling.md) — Colors, fonts, sizing"
+msgstr ""
+
+#: src/ui/overview.md:185
+msgid "[Events](events.md) — Click, hover, keyboard"
+msgstr ""
+
+#: src/ui/widgets.md:3
+msgid ""
+"Perry provides native widgets that map to each platform's native controls. "
+"Every example on this page is a real runnable program verified by CI "
+"(`scripts/run_doc_tests.sh`) — the snippet you read is the same source "
+"that's compiled and launched."
+msgstr ""
+
+#: src/ui/widgets.md:8
+msgid ""
+"The widget API is **free functions**, not methods. A widget is a 64-bit "
+"opaque handle; you pass it into helpers like `textSetFontSize(widget, 18)` "
+"rather than calling `widget.setFontSize(18)`. That's the only shape perry/ui"
+" supports — no fluent chain, no prototype methods."
+msgstr ""
+
+#: src/ui/widgets.md:15
+msgid "Displays read-only text."
+msgstr ""
+
+#: src/ui/widgets.md:17
+msgid ""
+"```typescript\n"
+"// demonstrates: Text widget styling with the real free-function API\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, textSetFontSize, textSetFontWeight, textSetColor, textSetFontFamily } from \"perry/ui\"\n"
+"\n"
+"const label = Text(\"Hello, World!\")\n"
+"textSetFontSize(label, 18)\n"
+"textSetColor(label, 0.2, 0.2, 0.2, 1.0) // RGBA in [0, 1]\n"
+"textSetFontFamily(label, \"Menlo\")\n"
+"\n"
+"const bold = Text(\"Bold\")\n"
+"textSetFontWeight(bold, 20, 1.0)\n"
+"\n"
+"App({\n"
+"    title: \"Text\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(8, [label, bold]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:41
+msgid ""
+"Color is RGBA with each channel in `[0.0, 1.0]` — divide a hex byte by 255 "
+"(`0x33 / 255 ≈ 0.2`)."
+msgstr ""
+
+#: src/ui/widgets.md:44
+msgid ""
+"**Helpers:** `textSetString`, `textSetFontSize`, `textSetFontWeight`, "
+"`textSetFontFamily`, `textSetColor`, `textSetWraps`, `textSetSelectable`."
+msgstr ""
+
+#: src/ui/widgets.md:47
+msgid ""
+"Text widgets inside template literals with `state.value` update "
+"automatically — perry detects the state read and rewires the widget to re-"
+"render on change. See [State Management](state.md)."
+msgstr ""
+
+#: src/ui/widgets.md:51 src/platforms/macos.md:27 src/platforms/ios.md:53
+#: src/platforms/tvos.md:53 src/platforms/watchos.md:53
+#: src/platforms/android.md:27 src/platforms/windows.md:45
+#: src/platforms/linux.md:37 src/testing/geisterhand.md:86
+#: src/testing/geisterhand.md:289
+msgid "Button"
+msgstr ""
+
+#: src/ui/widgets.md:53
+msgid "A clickable button."
+msgstr ""
+
+#: src/ui/widgets.md:55
+msgid ""
+"```typescript\n"
+"// demonstrates: Button styling with buttonSet*/widgetSet* helpers\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack,\n"
+"    Button,\n"
+"    buttonSetBordered,\n"
+"    widgetSetEnabled,\n"
+"    setCornerRadius,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// Note: buttonSetContentTintColor is macOS/iOS-only (maps to NSButton /\n"
+"// UIButton tint). GTK4/Win32 don't have an equivalent — set\n"
+"// widgetSetBackgroundColor(btn, r, g, b, a) there instead.\n"
+"const primary = Button(\"Click Me\", () => console.log(\"Clicked!\"))\n"
+"buttonSetBordered(primary, 1)\n"
+"setCornerRadius(primary, 8)\n"
+"\n"
+"const disabled = Button(\"Can't click me\", () => {})\n"
+"widgetSetEnabled(disabled, 0)\n"
+"\n"
+"App({\n"
+"    title: \"Button\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [primary, disabled]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:88
+msgid ""
+"**Helpers:** `buttonSetTitle`, `buttonSetBordered`, `buttonSetImage` (SF "
+"Symbol name on macOS/iOS), `buttonSetImagePosition`, "
+"`buttonSetContentTintColor`, `buttonSetTextColor`, `widgetSetEnabled`."
+msgstr ""
+
+#: src/ui/widgets.md:92 src/platforms/macos.md:28 src/platforms/ios.md:54
+#: src/platforms/tvos.md:54 src/platforms/android.md:28
+#: src/platforms/windows.md:46 src/platforms/linux.md:38
+#: src/testing/geisterhand.md:87 src/testing/geisterhand.md:290
+msgid "TextField"
+msgstr ""
+
+#: src/ui/widgets.md:94
+msgid "An editable single-line text input."
+msgstr ""
+
+#: src/ui/widgets.md:96
+msgid ""
+"```typescript\n"
+"// demonstrates: TextField + two-way binding via stateBindTextfield\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, TextField, State, stateBindTextfield } from \"perry/ui\"\n"
+"\n"
+"const text = State(\"\")\n"
+"const field = TextField(\"Placeholder...\", (value: string) => text.set(value))\n"
+"stateBindTextfield(text, field) // programmatic text.set() also updates the field\n"
+"\n"
+"App({\n"
+"    title: \"TextField\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        field,\n"
+"        Text(`You typed: ${text.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:119
+msgid ""
+"`TextField(placeholder, onChange)` fires `onChange` as the user types. Pair "
+"with `stateBindTextfield(state, field)` for two-way binding so programmatic "
+"`state.set(…)` also updates the visible text."
+msgstr ""
+
+#: src/ui/widgets.md:123
+msgid ""
+"**Helpers:** `textfieldSetString`, `textfieldSetFontSize`, "
+"`textfieldSetTextColor`, `textfieldSetBackgroundColor`, "
+"`textfieldSetBorderless`, `textfieldSetOnSubmit`, `textfieldSetOnFocus`, "
+"`textfieldSetNextKeyView`."
+msgstr ""
+
+#: src/ui/widgets.md:128 src/platforms/macos.md:29 src/platforms/ios.md:55
+#: src/platforms/android.md:29 src/platforms/windows.md:47
+#: src/platforms/linux.md:39
+msgid "SecureField"
+msgstr ""
+
+#: src/ui/widgets.md:130
+msgid ""
+"A password input — identical signature to `TextField`, but text is masked."
+msgstr ""
+
+#: src/ui/widgets.md:132
+msgid ""
+"```typescript\n"
+"// demonstrates: SecureField for password input\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, SecureField, State } from \"perry/ui\"\n"
+"\n"
+"const password = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"SecureField\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        SecureField(\"Enter password...\", (value: string) => password.set(value)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:152 src/platforms/macos.md:30 src/platforms/ios.md:56
+#: src/platforms/tvos.md:55 src/platforms/watchos.md:59
+#: src/platforms/android.md:30 src/platforms/windows.md:48
+#: src/platforms/linux.md:40 src/testing/geisterhand.md:89
+#: src/testing/geisterhand.md:292
+msgid "Toggle"
+msgstr ""
+
+#: src/ui/widgets.md:154
+msgid "A boolean on/off switch."
+msgstr ""
+
+#: src/ui/widgets.md:156
+msgid ""
+"```typescript\n"
+"// demonstrates: Toggle widget bound to State\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Toggle, State } from \"perry/ui\"\n"
+"\n"
+"const enabled = State(false)\n"
+"\n"
+"App({\n"
+"    title: \"Toggle\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Toggle(\"Enable notifications\", (on: boolean) => enabled.set(on)),\n"
+"        Text(`Enabled: ${enabled.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:177 src/platforms/macos.md:31 src/platforms/ios.md:57
+#: src/platforms/tvos.md:56 src/platforms/watchos.md:60
+#: src/platforms/android.md:31 src/platforms/windows.md:49
+#: src/platforms/linux.md:41 src/testing/geisterhand.md:88
+#: src/testing/geisterhand.md:291
+msgid "Slider"
+msgstr ""
+
+#: src/ui/widgets.md:179
+msgid "A numeric slider."
+msgstr ""
+
+#: src/ui/widgets.md:181
+msgid ""
+"```typescript\n"
+"// demonstrates: Slider with a numeric range\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Slider, State } from \"perry/ui\"\n"
+"\n"
+"const value = State(50)\n"
+"\n"
+"App({\n"
+"    title: \"Slider\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Slider(0, 100, (v: number) => value.set(v)),\n"
+"        Text(`Value: ${value.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:202
+msgid ""
+"`Slider(min, max, onChange)` — `onChange` fires on every drag. Use "
+"`stateBindSlider(state, slider)` for two-way binding."
+msgstr ""
+
+#: src/ui/widgets.md:205 src/platforms/macos.md:32 src/platforms/ios.md:58
+#: src/platforms/tvos.md:57 src/platforms/watchos.md:64
+#: src/platforms/android.md:32 src/platforms/windows.md:50
+#: src/platforms/linux.md:42 src/testing/geisterhand.md:90
+#: src/testing/geisterhand.md:293
+msgid "Picker"
+msgstr ""
+
+#: src/ui/widgets.md:207
+msgid "A dropdown selection control. Items are added with `pickerAddItem`."
+msgstr ""
+
+#: src/ui/widgets.md:209
+msgid ""
+"```typescript\n"
+"// demonstrates: Picker with items added via pickerAddItem\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Picker, State, pickerAddItem } from \"perry/ui\"\n"
+"\n"
+"const selected = State(0)\n"
+"const picker = Picker((index: number) => selected.set(index))\n"
+"pickerAddItem(picker, \"Option A\")\n"
+"pickerAddItem(picker, \"Option B\")\n"
+"pickerAddItem(picker, \"Option C\")\n"
+"\n"
+"App({\n"
+"    title: \"Picker\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        picker,\n"
+"        Text(`Selected index: ${selected.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:234
+msgid "ImageFile / ImageSymbol"
+msgstr ""
+
+#: src/ui/widgets.md:236
+msgid "Two distinct constructors:"
+msgstr ""
+
+#: src/ui/widgets.md:238
+msgid "`ImageFile(path)` — image from a file path"
+msgstr ""
+
+#: src/ui/widgets.md:239
+msgid "`ImageSymbol(name)` — SF Symbol glyph name (macOS/iOS only)"
+msgstr ""
+
+#: src/ui/widgets.md:241
+msgid ""
+"```typescript\n"
+"// demonstrates: ImageSymbol for SF Symbol glyphs (macOS/iOS)\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos\n"
+"// targets: ios-simulator, visionos-simulator, tvos-simulator\n"
+"\n"
+"import { App, HStack, ImageSymbol, widgetSetWidth, widgetSetHeight } from \"perry/ui\"\n"
+"\n"
+"const star = ImageSymbol(\"star.fill\")\n"
+"widgetSetWidth(star, 32)\n"
+"widgetSetHeight(star, 32)\n"
+"\n"
+"const heart = ImageSymbol(\"heart.fill\")\n"
+"const bell = ImageSymbol(\"bell.fill\")\n"
+"\n"
+"App({\n"
+"    title: \"ImageSymbol\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: HStack(12, [star, heart, bell]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:264
+msgid ""
+"Use `widgetSetWidth(img, N)` / `widgetSetHeight(img, N)` to size the image."
+msgstr ""
+
+#: src/ui/widgets.md:266 src/platforms/watchos.md:63
+#: src/platforms/windows.md:51 src/platforms/linux.md:43
+msgid "ProgressView"
+msgstr ""
+
+#: src/ui/widgets.md:268
+msgid "An indeterminate or determinate progress indicator."
+msgstr ""
+
+#: src/ui/widgets.md:270
+msgid ""
+"```typescript\n"
+"// demonstrates: ProgressView as an indeterminate spinner\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, ProgressView } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"ProgressView\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Text(\"Loading...\"),\n"
+"        ProgressView(),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:289
+msgid "TextArea"
+msgstr ""
+
+#: src/ui/widgets.md:291
+msgid ""
+"A multi-line text input. Same `(placeholder, onChange)` signature as "
+"`TextField` but renders as a multi-line box."
+msgstr ""
+
+#: src/ui/widgets.md:294
+msgid ""
+"```typescript\n"
+"// demonstrates: TextArea for multi-line input\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, TextArea, State } from \"perry/ui\"\n"
+"\n"
+"const content = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"TextArea\",\n"
+"    width: 500,\n"
+"    height: 400,\n"
+"    body: VStack(12, [\n"
+"        TextArea(\"Enter multi-line text...\", (value: string) => content.set(value)),\n"
+"        Text(`Length: ${content.value.length}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:315
+msgid "**Helpers:** `textareaSetString`."
+msgstr ""
+
+#: src/ui/widgets.md:317 src/cli/perry-toml.md:108
+msgid "Sections"
+msgstr ""
+
+#: src/ui/widgets.md:319
+msgid ""
+"Group controls into labelled sections. Perry has no `Form()` widget — use a "
+"`VStack` of `Section(title)`s and attach children via `widgetAddChild`."
+msgstr ""
+
+#: src/ui/widgets.md:322
+msgid ""
+"```typescript\n"
+"// demonstrates: Section grouping with widgetAddChild (no Form widget in Perry)\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack,\n"
+"    Section,\n"
+"    TextField,\n"
+"    Toggle,\n"
+"    State,\n"
+"    widgetAddChild,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const name = State(\"\")\n"
+"const notifications = State(true)\n"
+"\n"
+"const personal = Section(\"Personal Info\")\n"
+"widgetAddChild(personal, TextField(\"Name\", (value: string) => name.set(value)))\n"
+"\n"
+"const settings = Section(\"Settings\")\n"
+"widgetAddChild(\n"
+"    settings,\n"
+"    Toggle(\"Notifications\", (on: boolean) => notifications.set(on)),\n"
+")\n"
+"\n"
+"App({\n"
+"    title: \"Sections\",\n"
+"    width: 500,\n"
+"    height: 400,\n"
+"    body: VStack(16, [personal, settings]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:358
+msgid "Platform-specific widgets"
+msgstr ""
+
+#: src/ui/widgets.md:360
+msgid ""
+"These exist only on specific platforms and aren't verified by the cross-"
+"platform doc-tests:"
+msgstr ""
+
+#: src/ui/widgets.md:363
+msgid ""
+"**`Table(rows, cols, renderer)`** — macOS only. A data table with rows, "
+"columns, and a cell renderer."
+msgstr ""
+
+#: src/ui/widgets.md:365
+msgid "**`QRCode(data, size)`** — macOS only. Renders a QR code."
+msgstr ""
+
+#: src/ui/widgets.md:366
+msgid ""
+"**`Canvas(width, height, draw)`** — all desktop platforms. A drawing "
+"surface; see [Canvas](canvas.md)."
+msgstr ""
+
+#: src/ui/widgets.md:368
+msgid ""
+"**`CameraView()`** — iOS only (other platforms planned). See "
+"[Camera](camera.md)."
+msgstr ""
+
+#: src/ui/widgets.md:371
+msgid "These are linked from their own pages with platform-specific examples."
+msgstr ""
+
+#: src/ui/widgets.md:373
+msgid "Common widget helpers"
+msgstr ""
+
+#: src/ui/widgets.md:375
+msgid "Every widget handle accepts these:"
+msgstr ""
+
+#: src/ui/widgets.md:377
+msgid "Helper"
+msgstr ""
+
+#: src/ui/widgets.md:379
+msgid "`widgetSetWidth(w, n)` / `widgetSetHeight(w, n)`"
+msgstr ""
+
+#: src/ui/widgets.md:379
+msgid "Explicit size in points"
+msgstr ""
+
+#: src/ui/widgets.md:380
+msgid "`widgetSetBackgroundColor(w, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/widgets.md:380
+msgid "RGBA in \\[0, 1\\]"
+msgstr ""
+
+#: src/ui/widgets.md:381
+msgid "`setCornerRadius(w, r)`"
+msgstr ""
+
+#: src/ui/widgets.md:381
+msgid "Rounded corners in points"
+msgstr ""
+
+#: src/ui/widgets.md:382
+msgid "`widgetSetOpacity(w, alpha)`"
+msgstr ""
+
+#: src/ui/widgets.md:382
+msgid "Opacity in \\[0, 1\\]"
+msgstr ""
+
+#: src/ui/widgets.md:383
+msgid "`widgetSetEnabled(w, flag)`"
+msgstr ""
+
+#: src/ui/widgets.md:383
+msgid "`0` disables, `1` enables"
+msgstr ""
+
+#: src/ui/widgets.md:384
+msgid "`widgetSetHidden(w, flag)`"
+msgstr ""
+
+#: src/ui/widgets.md:384
+msgid "`0` visible, `1` hidden"
+msgstr ""
+
+#: src/ui/widgets.md:385
+msgid "`widgetSetTooltip(w, text)`"
+msgstr ""
+
+#: src/ui/widgets.md:385
+msgid "Tooltip on hover (desktop only)"
+msgstr ""
+
+#: src/ui/widgets.md:386
+msgid "`widgetSetOnClick(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:386
+msgid "Click handler"
+msgstr ""
+
+#: src/ui/widgets.md:387
+msgid "`widgetSetOnHover(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:387
+msgid "Hover enter/leave (desktop only)"
+msgstr ""
+
+#: src/ui/widgets.md:388
+msgid "`widgetSetOnDoubleClick(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:388
+msgid "Double-click handler"
+msgstr ""
+
+#: src/ui/widgets.md:389
+msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+msgstr ""
+
+#: src/ui/widgets.md:389
+msgid "Padding around contents"
+msgstr ""
+
+#: src/ui/widgets.md:390
+msgid "`widgetSetBorderColor(w, r, g, b, a)` / `widgetSetBorderWidth(w, n)`"
+msgstr ""
+
+#: src/ui/widgets.md:390
+msgid "Border"
+msgstr ""
+
+#: src/ui/widgets.md:391 src/ui/layout.md:175
+msgid "`widgetAddChild(parent, child)`"
+msgstr ""
+
+#: src/ui/widgets.md:391
+msgid "Attach a child to a container"
+msgstr ""
+
+#: src/ui/widgets.md:392
+msgid "`widgetSetContextMenu(w, menu)`"
+msgstr ""
+
+#: src/ui/widgets.md:392
+msgid "Right-click menu"
+msgstr ""
+
+#: src/ui/widgets.md:394
+msgid "See [Styling](styling.md) and [Events](events.md) for deeper coverage."
+msgstr ""
+
+#: src/ui/widgets.md:398
+msgid "[Layout](layout.md) — Arranging widgets with stacks and containers"
+msgstr ""
+
+#: src/ui/widgets.md:399
+msgid "[Styling](styling.md) — Colors, fonts, borders"
+msgstr ""
+
+#: src/ui/widgets.md:400 src/ui/theming.md:169
+msgid "[State Management](state.md) — Reactive bindings"
+msgstr ""
+
+#: src/ui/layout.md:3
+msgid ""
+"Perry provides layout containers that arrange child widgets using the "
+"platform's native layout system. Every snippet below is excerpted from "
+"[`docs/examples/ui/layout/snippets.ts`](../../examples/ui/layout/snippets.ts)"
+" — CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/layout.md:8
+msgid ""
+"Layout helpers are free functions: `widgetAddChild(parent, child)`, "
+"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
+"bottom, right)`, etc. Stack constructors take a numeric spacing followed by "
+"a child array; everything else (alignment, distribution, padding, sizing) is"
+" applied post-construction via the free functions on the widget handle."
+msgstr ""
+
+#: src/ui/layout.md:14 src/platforms/watchos.md:54 src/platforms/android.md:34
+#: src/platforms/linux.md:45 src/widgets/components.md:43
+msgid "VStack"
+msgstr ""
+
+#: src/ui/layout.md:16
+msgid "Arranges children vertically (top to bottom)."
+msgstr ""
+
+#: src/ui/layout.md:18
+msgid ""
+"```typescript\n"
+"const stack = VStack(16, [\n"
+"    Text(\"First\"),\n"
+"    Text(\"Second\"),\n"
+"    Text(\"Third\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:26
+msgid ""
+"`VStack(spacing, children)` — the first argument is the gap in points "
+"between children."
+msgstr ""
+
+#: src/ui/layout.md:29 src/platforms/watchos.md:55 src/platforms/android.md:35
+#: src/platforms/linux.md:46 src/widgets/components.md:52
+msgid "HStack"
+msgstr ""
+
+#: src/ui/layout.md:31
+msgid "Arranges children horizontally (left to right)."
+msgstr ""
+
+#: src/ui/layout.md:33
+msgid ""
+"```typescript\n"
+"const row = HStack(8, [\n"
+"    Button(\"Cancel\", noop),\n"
+"    Spacer(),\n"
+"    Button(\"OK\", noop),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:41 src/platforms/watchos.md:56 src/platforms/android.md:36
+#: src/platforms/linux.md:47 src/widgets/components.md:62
+msgid "ZStack"
+msgstr ""
+
+#: src/ui/layout.md:43
+msgid ""
+"Layers children on top of each other (back to front). `ZStack()` takes no "
+"constructor children — populate it with `widgetAddChild`:"
+msgstr ""
+
+#: src/ui/layout.md:46
+msgid ""
+"```typescript\n"
+"const layered = ZStack()\n"
+"widgetAddChild(layered, ImageFile(\"background.png\"))\n"
+"widgetAddChild(layered, Text(\"Overlay text\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:52 src/platforms/macos.md:35 src/platforms/ios.md:61
+#: src/platforms/tvos.md:60 src/platforms/watchos.md:62
+#: src/platforms/android.md:37 src/platforms/windows.md:54
+#: src/platforms/linux.md:48 src/testing/geisterhand.md:94
+msgid "ScrollView"
+msgstr ""
+
+#: src/ui/layout.md:54
+msgid ""
+"A scrollable container. Built empty, then filled via `scrollviewSetChild`:"
+msgstr ""
+
+#: src/ui/layout.md:56
+msgid ""
+"```typescript\n"
+"// ScrollView() takes no args; populate it with `scrollviewSetChild`.\n"
+"const sv = ScrollView()\n"
+"const inner = VStack(8, [Text(\"a\"), Text(\"b\"), Text(\"c\")])\n"
+"scrollviewSetChild(sv, inner)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:63
+msgid "LazyVStack"
+msgstr ""
+
+#: src/ui/layout.md:65
+msgid ""
+"A vertically scrolling list that lazily renders items. More efficient than "
+"`ScrollView` + `VStack` for thousands of rows — on macOS this is backed by "
+"`NSTableView` so only rows in the visible rect are realized."
+msgstr ""
+
+#: src/ui/layout.md:69
+msgid ""
+"```typescript\n"
+"// `render(index)` is invoked lazily — only rows in the visible rect are realized.\n"
+"const lazy = LazyVStack(1000, (index: number) => Text(`Row ${index}`))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:74
+msgid ""
+"When the underlying data changes, call `lazyvstackUpdate(handle, newCount)` "
+"to refresh. Override the default 44pt row height with "
+"`lazyvstackSetRowHeight`."
+msgstr ""
+
+#: src/ui/layout.md:77
+msgid "NavStack"
+msgstr ""
+
+#: src/ui/layout.md:79
+msgid ""
+"A navigation container that supports push/pop navigation. Push a new view "
+"with `navstackPush(stack, view, title)`; pop with `navstackPop(stack)`:"
+msgstr ""
+
+#: src/ui/layout.md:82
+msgid ""
+"```typescript\n"
+"const home = VStack(16, [\n"
+"    Text(\"Home Screen\"),\n"
+"    Button(\"Go to Details\", () => {\n"
+"        navstackPush(nav, Text(\"Details!\"), \"Details\")\n"
+"    }),\n"
+"])\n"
+"const nav = NavStack()\n"
+"widgetAddChild(nav, home)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:93 src/platforms/watchos.md:57
+#: src/widgets/components.md:71 src/widgets/platforms.md:25
+#: src/widgets/platforms.md:26
+msgid "Spacer"
+msgstr ""
+
+#: src/ui/layout.md:95
+msgid "A flexible space that expands to fill available room."
+msgstr ""
+
+#: src/ui/layout.md:97
+msgid ""
+"```typescript\n"
+"const toolbar = HStack(8, [\n"
+"    Text(\"Left\"),\n"
+"    Spacer(),\n"
+"    Text(\"Right\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:105
+msgid "Use `Spacer()` inside `HStack` or `VStack` to push widgets apart."
+msgstr ""
+
+#: src/ui/layout.md:107 src/platforms/watchos.md:58
+#: src/widgets/components.md:106 src/widgets/platforms.md:26
+msgid "Divider"
+msgstr ""
+
+#: src/ui/layout.md:109
+msgid "A visual separator line."
+msgstr ""
+
+#: src/ui/layout.md:111
+msgid ""
+"```typescript\n"
+"const sections = VStack(12, [\n"
+"    Text(\"Section 1\"),\n"
+"    Divider(),\n"
+"    Text(\"Section 2\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:119
+msgid "Nesting Layouts"
+msgstr ""
+
+#: src/ui/layout.md:121
+msgid "Layouts can be nested freely. This complete example is verified by CI:"
+msgstr ""
+
+#: src/ui/layout.md:123
+msgid ""
+"```typescript\n"
+"// demonstrates: nested VStack/HStack + Spacer + Divider\n"
+"// docs: docs/src/ui/layout.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, HStack, Text, Button, Spacer, Divider } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"Layout Example\",\n"
+"    width: 800,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        // Header\n"
+"        HStack(8, [\n"
+"            Text(\"My App\"),\n"
+"            Spacer(),\n"
+"            Button(\"Settings\", () => {}),\n"
+"        ]),\n"
+"        Divider(),\n"
+"        // Content\n"
+"        VStack(12, [\n"
+"            Text(\"Welcome!\"),\n"
+"            HStack(8, [\n"
+"                Button(\"Action 1\", () => {}),\n"
+"                Button(\"Action 2\", () => {}),\n"
+"            ]),\n"
+"        ]),\n"
+"        Spacer(),\n"
+"        // Footer\n"
+"        Text(\"v1.0.0\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:158
+msgid "Child Management"
+msgstr ""
+
+#: src/ui/layout.md:160
+msgid "Containers support dynamic child management via free functions:"
+msgstr ""
+
+#: src/ui/layout.md:162
+msgid ""
+"```typescript\n"
+"const list = VStack(16, [])\n"
+"widgetAddChild(list, Text(\"appended\"))            // append\n"
+"widgetAddChildAt(list, Text(\"prepended\"), 0)      // insert at index\n"
+"widgetReorderChild(list, 1, 0)                    // move from→to\n"
+"const removeMe = Text(\"temporary\")\n"
+"widgetAddChild(list, removeMe)\n"
+"widgetRemoveChild(list, removeMe)                 // remove\n"
+"widgetClearChildren(list)                         // remove all\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:173 src/ui/menus.md:53 src/ui/theming.md:131
+#: src/system/overview.md:21 src/system/media.md:37
+#: src/plugins/native-extensions.md:175
+msgid "Function"
+msgstr ""
+
+#: src/ui/layout.md:175
+msgid "Append a child widget"
+msgstr ""
+
+#: src/ui/layout.md:176
+msgid "`widgetAddChildAt(parent, child, index)`"
+msgstr ""
+
+#: src/ui/layout.md:176
+msgid "Insert a child at a specific position"
+msgstr ""
+
+#: src/ui/layout.md:177
+msgid "`widgetRemoveChild(parent, child)`"
+msgstr ""
+
+#: src/ui/layout.md:177
+msgid "Remove a specific child"
+msgstr ""
+
+#: src/ui/layout.md:178
+msgid "`widgetReorderChild(widget, fromIndex, toIndex)`"
+msgstr ""
+
+#: src/ui/layout.md:178
+msgid "Move a child to a new position"
+msgstr ""
+
+#: src/ui/layout.md:179
+msgid "`widgetClearChildren(widget)`"
+msgstr ""
+
+#: src/ui/layout.md:179
+msgid "Remove all children"
+msgstr ""
+
+#: src/ui/layout.md:181
+msgid "Stack Alignment"
+msgstr ""
+
+#: src/ui/layout.md:183
+msgid ""
+"Control how children are aligned within a stack using `stackSetAlignment`:"
+msgstr ""
+
+#: src/ui/layout.md:185
+msgid ""
+"```typescript\n"
+"const centered = VStack(16, [\n"
+"    Text(\"Centered\"),\n"
+"    Text(\"Content\"),\n"
+"])\n"
+"stackSetAlignment(centered, 9) // CenterX\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:193
+msgid "**VStack alignment** (cross-axis = horizontal):"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203 src/ui/layout.md:221
+#: src/platforms/tvos.md:149 src/plugins/appstore-review.md:77
+#: src/plugins/appstore-review.md:93 src/plugins/appstore-review.md:106
+#: src/cli/perry-toml.md:215 src/cli/perry-toml.md:277
+#: src/cli/perry-toml.md:284
+msgid "Value"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203 src/ui/layout.md:221
+msgid "Name"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203
+msgid "Effect"
+msgstr ""
+
+#: src/ui/layout.md:197 src/ui/styling.md:372 src/testing/geisterhand.md:91
+#: src/testing/geisterhand.md:105 src/cli/perry-toml.md:400
+msgid "5"
+msgstr ""
+
+#: src/ui/layout.md:197
+msgid "Leading"
+msgstr ""
+
+#: src/ui/layout.md:197
+msgid "Children align to the leading (left) edge"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "9"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "CenterX"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "Children centered horizontally"
+msgstr ""
+
+#: src/ui/layout.md:199 src/testing/geisterhand.md:93
+msgid "7"
+msgstr ""
+
+#: src/ui/layout.md:199
+msgid "Width"
+msgstr ""
+
+#: src/ui/layout.md:199
+msgid "Children stretch to fill the stack's width"
+msgstr ""
+
+#: src/ui/layout.md:201
+msgid "**HStack alignment** (cross-axis = vertical):"
+msgstr ""
+
+#: src/ui/layout.md:205 src/ui/layout.md:226 src/platforms/windows-7.md:27
+#: src/testing/geisterhand.md:89 src/testing/geisterhand.md:103
+#: src/cli/perry-toml.md:402
+msgid "3"
+msgstr ""
+
+#: src/ui/layout.md:205
+msgid "Top"
+msgstr ""
+
+#: src/ui/layout.md:205
+msgid "Children align to the top"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "12"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "CenterY"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "Children centered vertically"
+msgstr ""
+
+#: src/ui/layout.md:207 src/ui/layout.md:227 src/ui/styling.md:371
+#: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
+#: src/cli/perry-toml.md:401
+msgid "4"
+msgstr ""
+
+#: src/ui/layout.md:207
+msgid "Bottom"
+msgstr ""
+
+#: src/ui/layout.md:207
+msgid "Children align to the bottom"
+msgstr ""
+
+#: src/ui/layout.md:209
+msgid "Stack Distribution"
+msgstr ""
+
+#: src/ui/layout.md:211
+msgid ""
+"Control how children share space within a stack using "
+"`stackSetDistribution`:"
+msgstr ""
+
+#: src/ui/layout.md:213
+msgid ""
+"```typescript\n"
+"const buttons = HStack(8, [\n"
+"    Button(\"Cancel\", noop),\n"
+"    Button(\"OK\", noop),\n"
+"])\n"
+"stackSetDistribution(buttons, 1) // FillEqually — both buttons get equal width\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:221 src/widgets/data-fetching.md:125
+msgid "Behavior"
+msgstr ""
+
+#: src/ui/layout.md:223 src/ui/styling.md:370 src/ui/styling.md:371
+#: src/ui/styling.md:372 src/testing/geisterhand.md:86
+#: src/testing/geisterhand.md:100
+msgid "0"
+msgstr ""
+
+#: src/ui/layout.md:223
+msgid "Fill"
+msgstr ""
+
+#: src/ui/layout.md:223
+msgid "Default. First resizable child fills remaining space"
+msgstr ""
+
+#: src/ui/layout.md:224 src/platforms/windows-7.md:25
+#: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
+#: src/cli/perry-toml.md:404
+msgid "1"
+msgstr ""
+
+#: src/ui/layout.md:224
+msgid "FillEqually"
+msgstr ""
+
+#: src/ui/layout.md:224
+msgid "All children get equal size"
+msgstr ""
+
+#: src/ui/layout.md:225 src/platforms/windows-7.md:26
+#: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
+#: src/cli/perry-toml.md:403
+msgid "2"
+msgstr ""
+
+#: src/ui/layout.md:225
+msgid "FillProportionally"
+msgstr ""
+
+#: src/ui/layout.md:225
+msgid "Children sized proportionally to their intrinsic content"
+msgstr ""
+
+#: src/ui/layout.md:226
+msgid "EqualSpacing"
+msgstr ""
+
+#: src/ui/layout.md:226
+msgid "Equal gaps between children"
+msgstr ""
+
+#: src/ui/layout.md:227
+msgid "EqualCentering"
+msgstr ""
+
+#: src/ui/layout.md:227
+msgid "Equal distance between child centers"
+msgstr ""
+
+#: src/ui/layout.md:229
+msgid "Fill Parent"
+msgstr ""
+
+#: src/ui/layout.md:231
+msgid "Pin a child's edges to its parent container:"
+msgstr ""
+
+#: src/ui/layout.md:233
+msgid ""
+"```typescript\n"
+"const banner = Text(\"Full width banner\")\n"
+"widgetMatchParentWidth(banner)\n"
+"const banneredPage = VStack(16, [banner, Text(\"Normal width\")])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:239
+msgid "`widgetMatchParentWidth(widget)` — stretch to fill parent's width"
+msgstr ""
+
+#: src/ui/layout.md:240
+msgid "`widgetMatchParentHeight(widget)` — stretch to fill parent's height"
+msgstr ""
+
+#: src/ui/layout.md:242
+msgid "Content Hugging"
+msgstr ""
+
+#: src/ui/layout.md:244
+msgid ""
+"Control whether a widget resists being stretched beyond its intrinsic size:"
+msgstr ""
+
+#: src/ui/layout.md:246
+msgid ""
+"```typescript\n"
+"const tight = Text(\"I stay small\")\n"
+"widgetSetHugging(tight, 750) // High priority — resist stretching\n"
+"\n"
+"const stretchy = Text(\"I stretch\")\n"
+"widgetSetHugging(stretchy, 1) // Low priority — stretch to fill\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:254
+msgid ""
+"**High priority** (250–750+): widget resists stretching, stays at its "
+"natural size"
+msgstr ""
+
+#: src/ui/layout.md:255
+msgid "**Low priority** (1–249): widget stretches to fill available space"
+msgstr ""
+
+#: src/ui/layout.md:257
+msgid "Overlay Positioning"
+msgstr ""
+
+#: src/ui/layout.md:259
+msgid "For absolute positioning, add overlay children to any container:"
+msgstr ""
+
+#: src/ui/layout.md:261
+msgid ""
+"```typescript\n"
+"// Overlay parent must be a ZStack — macOS NSView allows `addSubview` on\n"
+"// any view, but GTK4 can only float children above siblings inside\n"
+"// `gtk::Overlay` (which is what ZStack is backed by).\n"
+"const container = ZStack()\n"
+"widgetAddChild(container, VStack(16, [Text(\"Main content\")])) // main child\n"
+"\n"
+"const badge = Text(\"3\")\n"
+"setCornerRadius(badge, 10)\n"
+"widgetSetBackgroundColor(badge, 1.0, 0.231, 0.188, 1.0) // RGBA red\n"
+"\n"
+"widgetAddOverlay(container, badge)\n"
+"widgetSetOverlayFrame(badge, 280, 10, 20, 20) // x, y, width, height\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:276
+msgid ""
+"Overlay children are positioned absolutely relative to their parent — "
+"similar to CSS `position: absolute`."
+msgstr ""
+
+#: src/ui/layout.md:279
+msgid "Split Views"
+msgstr ""
+
+#: src/ui/layout.md:281
+msgid "Create resizable split panes for sidebar layouts:"
+msgstr ""
+
+#: src/ui/layout.md:283
+msgid ""
+"```typescript\n"
+"const split = SplitView()\n"
+"\n"
+"const sidebar = VStack(8, [Text(\"Navigation\"), Text(\"Item 1\"), Text(\"Item 2\")])\n"
+"const content = VStack(16, [Text(\"Main Content\")])\n"
+"\n"
+"splitViewAddChild(split, sidebar)\n"
+"splitViewAddChild(split, content)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:293
+msgid ""
+"The user can drag the divider to resize panes. On macOS this maps to "
+"`NSSplitView`."
+msgstr ""
+
+#: src/ui/layout.md:296
+msgid "Stacks with Built-in Padding"
+msgstr ""
+
+#: src/ui/layout.md:298
+msgid ""
+"Create a stack with padding in a single call. The order is **top, left, "
+"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+msgstr ""
+
+#: src/ui/layout.md:301
+msgid ""
+"```typescript\n"
+"// VStackWithInsets(spacing, top, left, bottom, right) — note: order is\n"
+"// top/left/bottom/right (CSS-style), not top/right/bottom/left.\n"
+"const card = VStackWithInsets(12, 16, 16, 16, 16)\n"
+"widgetAddChild(card, Text(\"Padded content\"))\n"
+"widgetAddChild(card, Text(\"More content\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:309
+msgid ""
+"`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
+"counterpart. Equivalent to creating a stack and then calling "
+"`widgetSetEdgeInsets`, but more concise. Children are added via "
+"`widgetAddChild` rather than the constructor array."
+msgstr ""
+
+#: src/ui/layout.md:314
+msgid "Detaching Hidden Views"
+msgstr ""
+
+#: src/ui/layout.md:316
+msgid ""
+"By default, hidden children still occupy space in a stack. To collapse them:"
+msgstr ""
+
+#: src/ui/layout.md:318
+msgid ""
+"```typescript\n"
+"const collapsible = VStack(8, [Text(\"Always visible\"), Text(\"Sometimes hidden\")])\n"
+"stackSetDetachesHidden(collapsible, 1) // Hidden children leave no gap\n"
+"// You can then toggle a child:\n"
+"const sometimesHidden = Text(\"toggle me\")\n"
+"widgetSetHidden(sometimesHidden, 1) // 1 = hidden, 0 = visible\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:326
+msgid "Common Layout Patterns"
+msgstr ""
+
+#: src/ui/layout.md:328
+msgid "Centered content"
+msgstr ""
+
+#: src/ui/layout.md:330
+msgid ""
+"```typescript\n"
+"const page = VStack(16, [Text(\"Title\"), Text(\"Subtitle\")])\n"
+"stackSetAlignment(page, 9) // CenterX\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:335
+msgid "Search row that fills the width"
+msgstr ""
+
+#: src/ui/layout.md:337
+msgid ""
+"```typescript\n"
+"const searchInput = TextField(\"Search...\", (v: string) => search.set(v))\n"
+"widgetMatchParentWidth(searchInput)\n"
+"const results = VStack(8, [])\n"
+"const searchPage = VStack(12, [searchInput, results])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:344
+msgid "Floating badge / overlay"
+msgstr ""
+
+#: src/ui/layout.md:346
+msgid ""
+"```typescript\n"
+"// Wrap the icon in a ZStack so the badge can float above it on every\n"
+"const icon = ZStack()\n"
+"widgetAddChild(icon, ImageSymbol(\"bell\"))\n"
+"const dotBadge = Text(\"3\")\n"
+"widgetAddOverlay(icon, dotBadge)\n"
+"widgetSetOverlayFrame(dotBadge, 20, -5, 16, 16)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:355
+msgid "Toolbar with spacers"
+msgstr ""
+
+#: src/ui/layout.md:357
+msgid ""
+"```typescript\n"
+"const titleBar = HStack(8, [\n"
+"    Button(\"Back\", noop),\n"
+"    Spacer(),\n"
+"    Text(\"Page Title\"),\n"
+"    Spacer(),\n"
+"    Button(\"Settings\", noop),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:369
+msgid "[Styling](styling.md) — Colors, padding, sizing"
+msgstr ""
+
+#: src/ui/layout.md:371
+msgid "[State Management](state.md) — Dynamic UI with state"
+msgstr ""
+
+#: src/ui/styling.md:3
+msgid ""
+"Perry widgets accept an inline `style: { ... }` object that maps to each "
+"platform's native styling APIs. The same shape works on every Widget "
+"constructor — `Button`, `Text`, `Toggle`, `Slider`, `VStack`/`HStack`, and "
+"friends — so cross-platform styling code stays the same regardless of "
+"target."
+msgstr ""
+
+#: src/ui/styling.md:9
+msgid "Inline style — recommended"
+msgstr ""
+
+#: src/ui/styling.md:11
+msgid ""
+"Pass a `StyleProps` object as the trailing argument to any widget "
+"constructor. Codegen destructures the literal at HIR time into a sequence of"
+" native setter calls, so the runtime shape is the same as hand-writing the "
+"imperative pattern below — but the source is much shorter:"
+msgstr ""
+
+#: src/ui/styling.md:17
+msgid ""
+"```typescript\n"
+"const card = Button(\"Save\", () => {\n"
+"    console.log(\"saved\")\n"
+"}, {\n"
+"    backgroundColor: { r: 0.231, g: 0.510, b: 0.965, a: 1.0 },\n"
+"    borderColor: { r: 0.0, g: 0.0, b: 0.0, a: 0.1 },\n"
+"    borderWidth: 1,\n"
+"    borderRadius: 8,\n"
+"    padding: 12,\n"
+"    opacity: 0.95,\n"
+"    shadow: {\n"
+"        color: { r: 0.0, g: 0.0, b: 0.0, a: 0.25 },\n"
+"        blur: 12,\n"
+"        offsetX: 0,\n"
+"        offsetY: 4,\n"
+"    },\n"
+"    tooltip: \"Save the current document\",\n"
+"    enabled: true,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:38
+msgid ""
+"The `style` arg is optional; widgets without it look identical to calls "
+"before this API existed. See "
+"[`docs/examples/ui/styling/button_inline_style.ts`](../../examples/ui/styling/button_inline_style.ts)"
+" for the full file."
+msgstr ""
+
+#: src/ui/styling.md:43
+msgid "What `style` accepts"
+msgstr ""
+
+#: src/ui/styling.md:45
+msgid "Prop"
+msgstr ""
+
+#: src/ui/styling.md:45
+msgid "Maps to"
+msgstr ""
+
+#: src/ui/styling.md:47
+msgid "`backgroundColor`"
+msgstr ""
+
+#: src/ui/styling.md:47 src/ui/styling.md:48 src/ui/styling.md:49
+msgid "string \\| PerryColor"
+msgstr ""
+
+#: src/ui/styling.md:47
+msgid "`widgetSetBackgroundColor`"
+msgstr ""
+
+#: src/ui/styling.md:48
+msgid "`color`"
+msgstr ""
+
+#: src/ui/styling.md:48
+msgid "`textSetColor` / `buttonSetTextColor`"
+msgstr ""
+
+#: src/ui/styling.md:49
+msgid "`borderColor`"
+msgstr ""
+
+#: src/ui/styling.md:49
+msgid "`widgetSetBorderColor`"
+msgstr ""
+
+#: src/ui/styling.md:50
+msgid "`borderWidth`"
+msgstr ""
+
+#: src/ui/styling.md:50
+msgid "`widgetSetBorderWidth`"
+msgstr ""
+
+#: src/ui/styling.md:51
+msgid "`borderRadius`"
+msgstr ""
+
+#: src/ui/styling.md:51
+msgid "`setCornerRadius`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "`padding`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "number \\| `{ top, right, bottom, left }`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "`widgetSetEdgeInsets`"
+msgstr ""
+
+#: src/ui/styling.md:53 src/platforms/watchos.md:77
+msgid "`opacity`"
+msgstr ""
+
+#: src/ui/styling.md:53
+msgid "number (0..=1)"
+msgstr ""
+
+#: src/ui/styling.md:53
+msgid "`widgetSetOpacity`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`shadow`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`{ color, blur, offsetX, offsetY }`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`widgetSetShadow`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`textDecoration`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`\"none\" \\| \"underline\" \\| \"strikethrough\"`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`textSetDecoration`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`gradient`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`{ angle, stops: [c1, c2] }`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`widgetSetBackgroundGradient`"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "`fontSize`, `fontWeight`, `fontFamily`"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "number / string"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "`textSetFont*`"
+msgstr ""
+
+#: src/ui/styling.md:58
+msgid "`tooltip`"
+msgstr ""
+
+#: src/ui/styling.md:58
+msgid "`widgetSetTooltip`"
+msgstr ""
+
+#: src/ui/styling.md:59
+msgid "`hidden`"
+msgstr ""
+
+#: src/ui/styling.md:59
+msgid "`widgetSetHidden`"
+msgstr ""
+
+#: src/ui/styling.md:60
+msgid "`enabled`"
+msgstr ""
+
+#: src/ui/styling.md:60
+msgid "`widgetSetEnabled`"
+msgstr ""
+
+#: src/ui/styling.md:62
+msgid "Color values"
+msgstr ""
+
+#: src/ui/styling.md:64
+msgid "Color props accept four interchangeable shapes:"
+msgstr ""
+
+#: src/ui/styling.md:66
+msgid ""
+"```typescript,no-test\n"
+"backgroundColor: \"#3B82F6\"                                   // hex 6/8\n"
+"backgroundColor: \"#3B82F6FF\"                                 // hex with alpha\n"
+"backgroundColor: \"blue\"                                      // named color\n"
+"backgroundColor: { r: 0.231, g: 0.510, b: 0.965, a: 1.0 }   // PerryColor object\n"
+"backgroundColor: themeColor                                  // runtime variable\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:74
+msgid ""
+"Named colors: `white`, `black`, `red`, `green`, `blue`, `yellow`, `cyan`, "
+"`magenta`, `gray` / `grey`, `transparent`. Hex forms supported: `#RGB`, "
+"`#RGBA`, `#RRGGBB`, `#RRGGBBAA`."
+msgstr ""
+
+#: src/ui/styling.md:78
+msgid ""
+"Literals (the first four forms) compile-time-fold into 4 baked-in float "
+"arguments — zero runtime cost. Runtime variables resolve through "
+"`js_color_parse_channel` (a small CSS color parser in `perry-runtime`) so "
+"`backgroundColor: someStringVar` works the same as the literal form."
+msgstr ""
+
+#: src/ui/styling.md:83
+msgid "Padding shapes"
+msgstr ""
+
+#: src/ui/styling.md:85
+msgid "A single number applies to all four sides; an object picks per-side:"
+msgstr ""
+
+#: src/ui/styling.md:87
+msgid ""
+"```typescript,no-test\n"
+"padding: 12                                       // all four sides 12\n"
+"padding: { top: 8, right: 16, bottom: 8, left: 16 }  // per-side\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:92
+msgid "Missing sides default to 0."
+msgstr ""
+
+#: src/ui/styling.md:94
+msgid "Container styling"
+msgstr ""
+
+#: src/ui/styling.md:96
+msgid "`VStack` and `HStack` accept `style` after the children array:"
+msgstr ""
+
+#: src/ui/styling.md:98
+msgid ""
+"```typescript\n"
+"// VStack with explicit spacing AND inline style — children + style.\n"
+"const card = VStack(8, [\n"
+"    Text(\"Heading\"),\n"
+"    Text(\"Subtitle\"),\n"
+"    Button(\"Action\", () => { console.log(\"clicked\") }),\n"
+"], {\n"
+"    backgroundColor: { r: 0.96, g: 0.97, b: 0.99, a: 1.0 },\n"
+"    borderRadius: 12,\n"
+"    padding: 16,\n"
+"    shadow: {\n"
+"        color: { r: 0.0, g: 0.0, b: 0.0, a: 0.1 },\n"
+"        blur: 8,\n"
+"        offsetY: 2,\n"
+"    },\n"
+"})\n"
+"\n"
+"// HStack with no explicit spacing (children-array first form) + style.\n"
+"const toolbar = HStack([\n"
+"    Text(\"Left\"),\n"
+"    Text(\"Right\"),\n"
+"], {\n"
+"    backgroundColor: { r: 0.2, g: 0.2, b: 0.2, a: 1.0 },\n"
+"    padding: { top: 8, right: 16, bottom: 8, left: 16 },\n"
+"    borderRadius: 6,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:126
+msgid ""
+"Both shapes work — `VStack(children, style?)` and `VStack(spacing, children,"
+" style?)`."
+msgstr ""
+
+#: src/ui/styling.md:128
+msgid "Coming from CSS"
+msgstr ""
+
+#: src/ui/styling.md:130
+msgid "If you're coming from web, the conceptual mapping is:"
+msgstr ""
+
+#: src/ui/styling.md:132
+msgid "CSS"
+msgstr ""
+
+#: src/ui/styling.md:132
+msgid "Perry inline style"
+msgstr ""
+
+#: src/ui/styling.md:134
+msgid "`display: flex; flex-direction: column`"
+msgstr ""
+
+#: src/ui/styling.md:134
+msgid "`VStack(spacing, [...])`"
+msgstr ""
+
+#: src/ui/styling.md:135
+msgid "`display: flex; flex-direction: row`"
+msgstr ""
+
+#: src/ui/styling.md:135
+msgid "`HStack(spacing, [...])`"
+msgstr ""
+
+#: src/ui/styling.md:136
+msgid "`width: 100%`"
+msgstr ""
+
+#: src/ui/styling.md:136
+msgid "`widgetMatchParentWidth(widget)`"
+msgstr ""
+
+#: src/ui/styling.md:137
+msgid "`padding: 10px 20px`"
+msgstr ""
+
+#: src/ui/styling.md:137
+msgid "`padding: { top: 10, right: 20, bottom: 10, left: 20 }`"
+msgstr ""
+
+#: src/ui/styling.md:138
+msgid "`gap: 16px`"
+msgstr ""
+
+#: src/ui/styling.md:138
+msgid "`VStack(16, [...])` — first argument is the gap"
+msgstr ""
+
+#: src/ui/styling.md:139
+msgid "CSS variables / design tokens"
+msgstr ""
+
+#: src/ui/styling.md:139
+msgid "[`perry-styling`](theming.md) package"
+msgstr ""
+
+#: src/ui/styling.md:140
+msgid "`opacity: 0.5`"
+msgstr ""
+
+#: src/ui/styling.md:141
+msgid "`border-radius: 8px`"
+msgstr ""
+
+#: src/ui/styling.md:141
+msgid "`borderRadius: 8`"
+msgstr ""
+
+#: src/ui/styling.md:142
+msgid "`background: #3B82F6`"
+msgstr ""
+
+#: src/ui/styling.md:142
+msgid "`backgroundColor: \"#3B82F6\"`"
+msgstr ""
+
+#: src/ui/styling.md:143
+msgid "`box-shadow: 0 4px 12px rgba(0,0,0,0.25)`"
+msgstr ""
+
+#: src/ui/styling.md:143
+msgid "`shadow: { color: \"#0004\", blur: 12, offsetY: 4 }`"
+msgstr ""
+
+#: src/ui/styling.md:144
+msgid "`text-decoration: underline`"
+msgstr ""
+
+#: src/ui/styling.md:144
+msgid "`textDecoration: \"underline\"`"
+msgstr ""
+
+#: src/ui/styling.md:146
+msgid ""
+"See [Layout](layout.md) for full details on alignment, distribution, "
+"overlays, and split views."
+msgstr ""
+
+#: src/ui/styling.md:148
+msgid "Imperative API (underlying)"
+msgstr ""
+
+#: src/ui/styling.md:150
+msgid ""
+"The inline `style` object lowers to the same FFI calls as Perry's imperative"
+" free-function setters: `widgetSet*`, `textSet*`, `buttonSet*`. They take "
+"the widget handle as the first argument and remain available for cases where"
+" you want fine-grained control or need to mutate styles after creation. "
+"Colors here are RGBA floats in `[0.0, 1.0]` (divide each hex byte by 255 — "
+"`0xFF3B30` → `(1.0, 0.231, 0.188, 1.0)`)."
+msgstr ""
+
+#: src/ui/styling.md:158
+msgid ""
+"Every snippet below is excerpted from "
+"[`docs/examples/ui/styling/snippets.ts`](../../examples/ui/styling/snippets.ts),"
+" which CI compiles and runs on every PR — so the API drawn here is always "
+"the API the compiler accepts."
+msgstr ""
+
+#: src/ui/styling.md:163
+msgid ""
+"```typescript\n"
+"import {\n"
+"    App,\n"
+"    VStack, VStackWithInsets, HStack, Spacer,\n"
+"    Text, Button,\n"
+"    textSetColor, textSetFontSize, textSetFontFamily, textSetFontWeight,\n"
+"    setCornerRadius, setPadding,\n"
+"    widgetAddChild,\n"
+"    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
+"    widgetSetBorderColor, widgetSetBorderWidth,\n"
+"    widgetSetEdgeInsets,\n"
+"    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
+"    widgetSetOpacity,\n"
+"    widgetSetControlSize,\n"
+"    widgetSetTooltip,\n"
+"    widgetSetEnabled,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:182
+msgid "Colors"
+msgstr ""
+
+#: src/ui/styling.md:184
+msgid ""
+"```typescript\n"
+"const colored = Text(\"Colored text\")\n"
+"textSetColor(colored, 1.0, 0.0, 0.0, 1.0)              // r, g, b, a in [0,1]\n"
+"widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:190
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/styling.md:192
+msgid ""
+"```typescript\n"
+"const font = Text(\"Styled text\")\n"
+"textSetFontSize(font, 24)                  // Font size in points\n"
+"textSetFontFamily(font, \"Menlo\")           // Font family name\n"
+"textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:199
+msgid "Use `\"monospaced\"` for the system monospaced font."
+msgstr ""
+
+#: src/ui/styling.md:201
+msgid "Corner Radius"
+msgstr ""
+
+#: src/ui/styling.md:203
+msgid ""
+"```typescript\n"
+"const rounded = Button(\"Rounded\", () => {})\n"
+"setCornerRadius(rounded, 12)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:208
+msgid "Borders"
+msgstr ""
+
+#: src/ui/styling.md:216
+msgid "Padding and Insets"
+msgstr ""
+
+#: src/ui/styling.md:218
+msgid ""
+"```typescript\n"
+"const padded = VStack(8, [Text(\"Padded content\")])\n"
+"// Both names accept (widget, top, left, bottom, right):\n"
+"setPadding(padded, 16, 16, 16, 16)\n"
+"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:225
+msgid "Sizing"
+msgstr ""
+
+#: src/ui/styling.md:227
+msgid ""
+"```typescript\n"
+"const sized = VStack(0, [])\n"
+"widgetSetWidth(sized, 300)\n"
+"widgetSetHeight(sized, 200)\n"
+"widgetMatchParentWidth(sized) // expand to fill parent's width\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:234 src/ui/theming.md:144
+msgid "Opacity"
+msgstr ""
+
+#: src/ui/styling.md:236
+msgid ""
+"```typescript\n"
+"const dim = Text(\"Semi-transparent\")\n"
+"widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:241
+msgid "Background Gradient"
+msgstr ""
+
+#: src/ui/styling.md:243
+msgid ""
+"```typescript\n"
+"const grad = VStack(0, [])\n"
+"// Two RGBA stops + angle (degrees, 0 = top-to-bottom).\n"
+"widgetSetBackgroundGradient(grad,\n"
+"    1.0, 0.0, 0.0, 1.0,   // start (red)\n"
+"    0.0, 0.0, 1.0, 1.0,   // end   (blue)\n"
+"    0,                    // angle\n"
+")\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:253
+msgid "Control Size"
+msgstr ""
+
+#: src/ui/styling.md:255
+msgid ""
+"```typescript\n"
+"const small = Button(\"Small\", () => {})\n"
+"widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:260
+msgid ""
+"**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
+"differently."
+msgstr ""
+
+#: src/ui/styling.md:262
+msgid "Tooltips"
+msgstr ""
+
+#: src/ui/styling.md:264
+msgid ""
+"```typescript\n"
+"const tip = Button(\"Hover me\", () => {})\n"
+"widgetSetTooltip(tip, \"Click to perform action\")\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:269
+msgid ""
+"**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
+"support. **Web**: HTML `title` attribute."
+msgstr ""
+
+#: src/ui/styling.md:271
+msgid "Enabled/Disabled"
+msgstr ""
+
+#: src/ui/styling.md:273
+msgid ""
+"```typescript\n"
+"const submit = Button(\"Submit\", () => {})\n"
+"widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:278
+msgid "Complete Imperative Example"
+msgstr ""
+
+#: src/ui/styling.md:280
+msgid ""
+"```typescript\n"
+"// demonstrates: a styled counter card using the real free-function API\n"
+"// docs: docs/src/ui/styling.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    VStack,\n"
+"    HStack,\n"
+"    State,\n"
+"    Spacer,\n"
+"    textSetFontSize,\n"
+"    textSetFontFamily,\n"
+"    textSetColor,\n"
+"    widgetSetBackgroundColor,\n"
+"    widgetSetEdgeInsets,\n"
+"    setCornerRadius,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// Note: widgetSetBorderColor / widgetSetBorderWidth are macOS/iOS/Windows\n"
+"// only — perry-ui-gtk4 doesn't export them (GTK4 borders are CSS-driven).\n"
+"// Omitted from this demo so it compiles everywhere.\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"const title = Text(\"Counter\")\n"
+"textSetFontSize(title, 28)\n"
+"textSetColor(title, 0.1, 0.1, 0.1, 1.0)\n"
+"\n"
+"const display = Text(`${count.value}`)\n"
+"textSetFontSize(display, 48)\n"
+"textSetFontFamily(display, \"monospaced\")\n"
+"textSetColor(display, 0.0, 0.478, 1.0, 1.0)\n"
+"\n"
+"const decBtn = Button(\"-\", () => count.set(count.value - 1))\n"
+"setCornerRadius(decBtn, 20)\n"
+"widgetSetBackgroundColor(decBtn, 1.0, 0.231, 0.188, 1.0)\n"
+"\n"
+"const incBtn = Button(\"+\", () => count.set(count.value + 1))\n"
+"setCornerRadius(incBtn, 20)\n"
+"widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
+"\n"
+"const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
+"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"\n"
+"const container = VStack(16, [title, display, controls])\n"
+"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setCornerRadius(container, 16)\n"
+"widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
+"\n"
+"App({\n"
+"    title: \"Styled App\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: container,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:341
+msgid "Composing Styles (imperative helper functions)"
+msgstr ""
+
+#: src/ui/styling.md:343
+msgid "Reduce repetition by creating helper functions:"
+msgstr ""
+
+#: src/ui/styling.md:357
+msgid ""
+"For larger apps, use the `perry-styling` package to define design tokens in "
+"JSON and generate a typed theme file. See [Theming](theming.md) for the full"
+" workflow."
+msgstr ""
+
+#: src/ui/styling.md:359
+msgid "Platform support"
+msgstr ""
+
+#: src/ui/styling.md:361
+msgid ""
+"Per-prop, per-platform support is tracked in the [styling matrix](styling-"
+"matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and"
+" CI-checked against each backend's `lib.rs` exports on every PR."
+msgstr ""
+
+#: src/ui/styling.md:366
+msgid ""
+"Current state (issue [\\#185](https://github.com/PerryTS/perry/issues/185)):"
+msgstr ""
+
+#: src/ui/styling.md:368 src/ui/canvas.md:72 src/ui/canvas.md:73
+#: src/ui/canvas.md:74 src/ui/canvas.md:75 src/ui/canvas.md:76
+#: src/ui/canvas.md:78
+msgid "Wired"
+msgstr ""
+
+#: src/ui/styling.md:368
+msgid "Stub"
+msgstr ""
+
+#: src/ui/styling.md:368
+msgid "Missing"
+msgstr ""
+
+#: src/ui/styling.md:370
+msgid "macOS / iOS / tvOS / visionOS / watchOS / Android / Web"
+msgstr ""
+
+#: src/ui/styling.md:370
+msgid "**43/43**"
+msgstr ""
+
+#: src/ui/styling.md:371
+msgid "GTK4 (Linux)"
+msgstr ""
+
+#: src/ui/styling.md:371
+msgid "39/43"
+msgstr ""
+
+#: src/ui/styling.md:372
+msgid "38/43"
+msgstr ""
+
+#: src/ui/styling.md:374
+msgid ""
+"**GTK4** has 4 styling props (`widget.on_click`, "
+"`button.content_tint_color`, `button.image_position`, "
+"`stack.detaches_hidden`) that need a Linux contributor — tracked in issue "
+"[\\#202](https://github.com/PerryTS/perry/issues/202). Inline `style: {...}`"
+" calls referencing only the wired props compile and run cleanly today; the "
+"missing props silently no-op until that issue lands."
+msgstr ""
+
+#: src/ui/styling.md:375
+msgid ""
+"**Windows** has 5 props in a \"deferred-paint family\" (`shadow`, `opacity`,"
+" `border_color`, `border_width`, `text.decoration`) where the FFI symbol "
+"exists and stores the requested params, but a custom `WM_PAINT` rendering "
+"pass is needed to make them visible — tracked in issue "
+"[\\#210](https://github.com/PerryTS/perry/issues/210). User code authoring "
+"inline styles compiles and links cleanly on Windows; the visual rendering "
+"catches up when that issue lands."
+msgstr ""
+
+#: src/ui/styling.md:380 src/ui/state.md:229 src/ui/table.md:110
+msgid "[Layout](layout.md) — Layout containers"
+msgstr ""
+
+#: src/ui/styling.md:381
+msgid "[Animation](animation.md) — Animate style changes"
+msgstr ""
+
+#: src/ui/styling.md:382
+msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
+msgstr ""
+
+#: src/ui/state.md:3
+msgid ""
+"Perry uses reactive state to automatically update the UI when data changes. "
+"Every snippet below is excerpted from "
+"[`docs/examples/ui/state/snippets.ts`](../../examples/ui/state/snippets.ts) "
+"— CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/state.md:8
+msgid "Creating State"
+msgstr ""
+
+#: src/ui/state.md:10
+msgid ""
+"```typescript\n"
+"const counter = State(0)               // number state\n"
+"const username = State(\"Perry\")        // string state\n"
+"const items = State<string[]>([])      // array state\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:16
+msgid "`State(initialValue)` creates a reactive state container."
+msgstr ""
+
+#: src/ui/state.md:18
+msgid "Reading and Writing"
+msgstr ""
+
+#: src/ui/state.md:20
+msgid ""
+"```typescript\n"
+"const value = counter.value     // Read current value\n"
+"counter.set(42)                  // Set new value → triggers UI update\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:25
+msgid "Every `.set()` call re-renders the widget tree with the new value."
+msgstr ""
+
+#: src/ui/state.md:27
+msgid "Reactive Text"
+msgstr ""
+
+#: src/ui/state.md:29
+msgid "Template literals with `state.value` update automatically:"
+msgstr ""
+
+#: src/ui/state.md:31
+msgid ""
+"```typescript\n"
+"const showCount = State(0)\n"
+"const countLabel = Text(`Count: ${showCount.value}`)\n"
+"// The text updates whenever showCount changes.\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:37
+msgid ""
+"This works because Perry detects `state.value` reads inside template "
+"literals and creates reactive bindings."
+msgstr ""
+
+#: src/ui/state.md:40
+msgid "Binding Inputs to State"
+msgstr ""
+
+#: src/ui/state.md:42
+msgid ""
+"Input widgets expose an `onChange` callback. Forward that into a state's "
+"`.set(...)` to keep the state in sync as the user types/toggles/drags:"
+msgstr ""
+
+#: src/ui/state.md:45
+msgid ""
+"```typescript\n"
+"const input = State(\"\")\n"
+"const field = TextField(\"Type here...\", (v: string) => input.set(v))\n"
+"\n"
+"// Optional: also let input.set(\"hello\") update the field on screen.\n"
+"stateBindTextfield(input, field)\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:53
+msgid "Input control signatures:"
+msgstr ""
+
+#: src/ui/state.md:54
+msgid ""
+"`TextField(placeholder, onChange)` — text input, `onChange: (value: string) "
+"=> void`"
+msgstr ""
+
+#: src/ui/state.md:55
+msgid ""
+"`SecureField(placeholder, onChange)` — password input, `onChange: (value: "
+"string) => void`"
+msgstr ""
+
+#: src/ui/state.md:56
+msgid ""
+"`Toggle(label, onChange)` — boolean toggle, `onChange: (value: boolean) => "
+"void`"
+msgstr ""
+
+#: src/ui/state.md:57
+msgid ""
+"`Slider(min, max, onChange)` — numeric slider, `onChange: (value: number) =>"
+" void`"
+msgstr ""
+
+#: src/ui/state.md:58
+msgid ""
+"`Picker(onChange)` — dropdown, `onChange: (index: number) => void`; items "
+"via `pickerAddItem`"
+msgstr ""
+
+#: src/ui/state.md:60
+msgid ""
+"For programmatic-to-UI sync (state-drives-widget) use the dedicated binders:"
+" `stateBindTextfield`, `stateBindSlider`, `stateBindToggle`, "
+"`stateBindTextNumeric`, `stateBindVisibility`."
+msgstr ""
+
+#: src/ui/state.md:64
+msgid "onChange Callbacks"
+msgstr ""
+
+#: src/ui/state.md:66
+msgid "Listen for state changes with the free-function `stateOnChange`:"
+msgstr ""
+
+#: src/ui/state.md:75 src/widgets/components.md:92 src/widgets/platforms.md:27
+msgid "ForEach"
+msgstr ""
+
+#: src/ui/state.md:77
+msgid "Render a list from numeric state (the index count):"
+msgstr ""
+
+#: src/ui/state.md:79
+msgid ""
+"```typescript\n"
+"const fruits = State([\"Apple\", \"Banana\", \"Cherry\"])\n"
+"const fruitCount = State(3)\n"
+"\n"
+"const fruitList = VStack(16, [\n"
+"    ForEach(fruitCount, (i: number) =>\n"
+"        Text(`${i + 1}. ${fruits.value[i]}`),\n"
+"    ),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:90
+msgid ""
+"**Note:** `ForEach` iterates by index over a numeric state. Keep a count "
+"state in sync with your array, then read the items via `array.value[i]` "
+"inside the closure."
+msgstr ""
+
+#: src/ui/state.md:94
+msgid "`ForEach` re-renders the list when the count state changes:"
+msgstr ""
+
+#: src/ui/state.md:96
+msgid ""
+"```typescript\n"
+"// Add an item:\n"
+"fruits.set([...fruits.value, \"Date\"])\n"
+"fruitCount.set(fruitCount.value + 1)\n"
+"\n"
+"// Remove an item:\n"
+"fruits.set(fruits.value.filter((_, i) => i !== 1))\n"
+"fruitCount.set(fruitCount.value - 1)\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:106
+msgid "Conditional Rendering"
+msgstr ""
+
+#: src/ui/state.md:108
+msgid "Use state to conditionally show widgets:"
+msgstr ""
+
+#: src/ui/state.md:110
+msgid ""
+"```typescript\n"
+"const showDetails = State(false)\n"
+"const detailsLabel: number = showDetails.value\n"
+"    ? Text(\"Details are visible!\")\n"
+"    : Spacer()\n"
+"const detailsPanel = VStack(16, [\n"
+"    Button(\"Toggle\", () => showDetails.set(!showDetails.value)),\n"
+"    detailsLabel,\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:121
+msgid "Multi-State Text"
+msgstr ""
+
+#: src/ui/state.md:123
+msgid "Text can depend on multiple state values:"
+msgstr ""
+
+#: src/ui/state.md:125
+msgid ""
+"```typescript\n"
+"const firstName = State(\"John\")\n"
+"const lastName = State(\"Doe\")\n"
+"\n"
+"const greeting = Text(`Hello, ${firstName.value} ${lastName.value}!`)\n"
+"// Updates when either firstName or lastName changes.\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:133
+msgid "State with Objects and Arrays"
+msgstr ""
+
+#: src/ui/state.md:135
+msgid ""
+"```typescript\n"
+"const user = State({ name: \"Perry\", age: 0 })\n"
+"\n"
+"// Update by replacing the whole object:\n"
+"user.set({ ...user.value, age: 1 })\n"
+"\n"
+"const todos = State<{ text: string; done: boolean }[]>([])\n"
+"\n"
+"// Add a todo:\n"
+"todos.set([...todos.value, { text: \"New task\", done: false }])\n"
+"\n"
+"// Toggle a todo (must produce a new array reference):\n"
+"const next = todos.value.slice()\n"
+"if (next.length > 0) {\n"
+"    next[0] = { ...next[0], done: !next[0].done }\n"
+"    todos.set(next)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:154
+msgid ""
+"**Note**: State uses identity comparison. You must create a new array/object"
+" reference for changes to be detected. Mutating in-place without calling "
+"`.set()` with a new reference won't trigger updates."
+msgstr ""
+
+#: src/ui/state.md:158 src/ui/events.md:113 src/ui/table.md:73
+#: src/widgets/components.md:225
+msgid "Complete Example"
+msgstr ""
+
+#: src/ui/state.md:221
+msgid ""
+"This program is built and run by CI (`scripts/run_doc_tests.sh`), so the "
+"snippet above always matches the compiled artifact under "
+"[`docs/examples/ui/state/todo_app.ts`](../../examples/ui/state/todo_app.ts)."
+msgstr ""
+
+#: src/ui/state.md:227
+msgid "[Events](events.md) — Click, hover, keyboard events"
+msgstr ""
+
+#: src/ui/events.md:3
+msgid ""
+"Perry widgets support native event handlers for user interaction. Every "
+"snippet below is excerpted from "
+"[`docs/examples/ui/events/snippets.ts`](../../examples/ui/events/snippets.ts)"
+" — CI compiles and runs it on every PR, so the API drawn here is the API the"
+" runtime exposes."
+msgstr ""
+
+#: src/ui/events.md:9
+msgid ""
+"Event handlers are registered as **free functions** that take the widget "
+"handle as the first argument. The widget handle itself is opaque (`number` "
+"at the type level); perry's API is function-first throughout."
+msgstr ""
+
+#: src/ui/events.md:13 src/testing/geisterhand.md:100
+msgid "onClick"
+msgstr ""
+
+#: src/ui/events.md:15
+msgid ""
+"```typescript\n"
+"const greet = Button(\"Click me\", () => {\n"
+"    log.set(\"Button clicked\")\n"
+"})\n"
+"\n"
+"// Or attach a click handler to a non-button widget after creation:\n"
+"const label = Text(\"Clickable text\")\n"
+"widgetSetOnClick(label, () => {\n"
+"    log.set(\"Text clicked\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:27 src/testing/geisterhand.md:103
+msgid "onHover"
+msgstr ""
+
+#: src/ui/events.md:29
+msgid "Triggered when the cursor enters the widget."
+msgstr ""
+
+#: src/ui/events.md:31
+msgid ""
+"```typescript\n"
+"const hoverBtn = Button(\"Hover me\", () => {})\n"
+"widgetSetOnHover(hoverBtn, () => {\n"
+"    log.set(\"hovered\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:38
+msgid ""
+"**Note**: Hover events are available on macOS, Windows, Linux, and Web. iOS "
+"and Android use touch interactions instead. The callback fires once on "
+"enter; if you need a \"left\" event you'll have to track it yourself."
+msgstr ""
+
+#: src/ui/events.md:42 src/testing/geisterhand.md:104
+msgid "onDoubleClick"
+msgstr ""
+
+#: src/ui/events.md:44
+msgid ""
+"```typescript\n"
+"const dbl = Text(\"Double-click me\")\n"
+"widgetSetOnDoubleClick(dbl, () => {\n"
+"    log.set(\"double-clicked!\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:51 src/ui/menus.md:64
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: src/ui/events.md:53
+msgid "Register in-app keyboard shortcuts (active when the app is focused):"
+msgstr ""
+
+#: src/ui/events.md:55
+msgid ""
+"```typescript\n"
+"// Cmd+N on macOS, Ctrl+N on other platforms (modifier 1 = Cmd/Ctrl).\n"
+"addKeyboardShortcut(\"n\", 1, () => {\n"
+"    log.set(\"New document\")\n"
+"})\n"
+"\n"
+"// Cmd+Shift+S — modifiers add: 1 (Cmd/Ctrl) + 2 (Shift) = 3.\n"
+"addKeyboardShortcut(\"s\", 3, () => {\n"
+"    log.set(\"Save as...\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:67
+msgid ""
+"**Modifier bits:** `1` = Cmd (macOS) / Ctrl (Windows/Linux), `2` = Shift, "
+"`4` = Option (macOS) / Alt (others), `8` = Control (macOS only). Combine by "
+"adding — `3` = Cmd+Shift, `5` = Cmd+Option, etc."
+msgstr ""
+
+#: src/ui/events.md:71
+msgid "Keyboard shortcuts are also available on [menu items](menus.md):"
+msgstr ""
+
+#: src/ui/events.md:73
+msgid ""
+"```typescript\n"
+"const fileMenu = menuCreate()\n"
+"menuAddItem(fileMenu, \"New\", () => log.set(\"file/new\"))\n"
+"menuAddItem(fileMenu, \"Save As\", () => log.set(\"file/saveAs\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:79
+msgid "Global Hotkeys"
+msgstr ""
+
+#: src/ui/events.md:81
+msgid ""
+"Register a hotkey that fires system-wide, even when the app is in the "
+"background:"
+msgstr ""
+
+#: src/ui/events.md:84
+msgid ""
+"```typescript\n"
+"// System-wide: fires even when the app is in the background.\n"
+"// macOS: real Carbon RegisterEventHotKey. Other platforms: no-op.\n"
+"registerGlobalHotkey(\"F5\", 0, () => {\n"
+"    log.set(\"Global F5 hotkey fired\")\n"
+"})\n"
+"\n"
+"// Cmd+Shift+G (modifiers: 1=Cmd + 2=Shift = 3)\n"
+"registerGlobalHotkey(\"g\", 3, () => {\n"
+"    log.set(\"Global Cmd+Shift+G fired\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:97
+msgid ""
+"**Platform support:** macOS uses Carbon `RegisterEventHotKey` (real "
+"implementation). Linux, Windows, iOS, tvOS, visionOS, watchOS, and Android "
+"log the registration and no-op — global hotkeys on those platforms require "
+"OS-level portal / hook APIs that vary per OS."
+msgstr ""
+
+#: src/ui/events.md:102 src/system/other.md:44
+msgid "Clipboard"
+msgstr ""
+
+#: src/ui/events.md:104 src/system/other.md:48
+msgid ""
+"```typescript\n"
+"// Copy to clipboard\n"
+"clipboardWrite(\"Hello, clipboard!\")\n"
+"\n"
+"// Read from clipboard\n"
+"const text = clipboardRead()\n"
+"log.set(`clipboard length: ${text.length}`)\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:115
+msgid ""
+"```typescript\n"
+"// demonstrates: click + hover + double-click + keyboard shortcut all wired to\n"
+"// a single State-backed status label\n"
+"// docs: docs/src/ui/events.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    VStack,\n"
+"    State,\n"
+"    Spacer,\n"
+"    addKeyboardShortcut,\n"
+"    widgetSetOnHover,\n"
+"    widgetSetOnDoubleClick,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const lastEvent = State(\"No events yet\")\n"
+"\n"
+"// Cmd+R (modifiers: 1 = Cmd/Ctrl).\n"
+"addKeyboardShortcut(\"r\", 1, () => {\n"
+"    lastEvent.set(\"Keyboard: Cmd+R\")\n"
+"})\n"
+"\n"
+"const hoverBtn = Button(\"Hover me\", () => {})\n"
+"widgetSetOnHover(hoverBtn, () => {\n"
+"    lastEvent.set(\"Hover fired\")\n"
+"})\n"
+"\n"
+"const dblLabel = Text(\"Double-click me\")\n"
+"widgetSetOnDoubleClick(dblLabel, () => {\n"
+"    lastEvent.set(\"Double-clicked!\")\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Events Demo\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Last event: ${lastEvent.value}`),\n"
+"        Spacer(),\n"
+"        Button(\"Click me\", () => {\n"
+"            lastEvent.set(\"Button clicked\")\n"
+"        }),\n"
+"        hoverBtn,\n"
+"        dblLabel,\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:169
+msgid "[Menus](menus.md) — Menu bar and context menus with keyboard shortcuts"
+msgstr ""
+
+#: src/ui/events.md:171
+msgid "[State Management](state.md) — Reactive state"
+msgstr ""
+
+#: src/ui/canvas.md:3
+msgid "The `Canvas` widget provides a 2D drawing surface for custom graphics."
+msgstr ""
+
+#: src/ui/canvas.md:5
+msgid ""
+"**Availability**: `Canvas` is wired in the **LLVM** codegen path (macOS, "
+"iOS, Linux, Android) and the **JS / web / wasm** codegen path. Closed via "
+"[\\#190](https://github.com/PerryTS/perry/issues/190). The snippets below "
+"are compile-link verified by the doc-tests harness against "
+"[`docs/examples/ui/canvas/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/ui/canvas/snippets.ts);"
+" see that file for the full standalone program."
+msgstr ""
+
+#: src/ui/canvas.md:12
+msgid ""
+"The drawing API is **method-based** on the canvas handle (matching the FFI "
+"shape — `perry_ui_canvas_set_fill_color(handle, r, g, b, a)` etc.). Colors "
+"are RGBA floats in `[0.0, 1.0]`."
+msgstr ""
+
+#: src/ui/canvas.md:16
+msgid "Creating a Canvas"
+msgstr ""
+
+#: src/ui/canvas.md:24
+msgid ""
+"`Canvas(width, height)` creates a canvas widget; subsequent draw operations "
+"are method calls on the returned handle."
+msgstr ""
+
+#: src/ui/canvas.md:27
+msgid "Drawing Shapes"
+msgstr ""
+
+#: src/ui/canvas.md:29
+msgid "Rectangles"
+msgstr ""
+
+#: src/ui/canvas.md:31
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(1.0, 0.0, 0.0, 1.0)    // red\n"
+"canvas.fillRect(10, 10, 100, 80)\n"
+"\n"
+"canvas.setStrokeColor(0.0, 0.0, 1.0, 1.0)  // blue\n"
+"canvas.setLineWidth(2)\n"
+"canvas.strokeRect(150, 10, 100, 80)\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:40
+msgid "Lines"
+msgstr ""
+
+#: src/ui/canvas.md:51
+msgid "Circles and Arcs"
+msgstr ""
+
+#: src/ui/canvas.md:53
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(0.0, 1.0, 0.0, 1.0)\n"
+"canvas.beginPath()\n"
+"canvas.arc(200, 150, 50, 0, Math.PI * 2)  // x, y, radius, startAngle, endAngle\n"
+"canvas.fill()\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:62
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(0.0, 0.0, 0.0, 1.0)\n"
+"canvas.setFont(\"16px sans-serif\")\n"
+"canvas.fillText(\"Hello Canvas!\", 50, 50)\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:68 src/ui/menus.md:107 src/ui/dialogs.md:106
+#: src/ui/animation.md:60 src/ui/multi-window.md:136
+msgid "Platform Notes"
+msgstr ""
+
+#: src/ui/canvas.md:70 src/ui/animation.md:62 src/ui/multi-window.md:70
+#: src/ui/multi-window.md:87 src/ui/multi-window.md:98
+#: src/ui/multi-window.md:114 src/ui/multi-window.md:130
+#: src/ui/multi-window.md:138 src/ui/camera.md:137 src/system/other.md:18
+msgid "Implementation"
+msgstr ""
+
+#: src/ui/canvas.md:70 src/platforms/overview.md:7 src/system/media.md:84
+#: src/testing/geisterhand.md:298
+msgid "Status"
+msgstr ""
+
+#: src/ui/canvas.md:72
+msgid "HTML5 Canvas"
+msgstr ""
+
+#: src/ui/canvas.md:73
+msgid "WASM"
+msgstr ""
+
+#: src/ui/canvas.md:73
+msgid "HTML5 Canvas via JS bridge"
+msgstr ""
+
+#: src/ui/canvas.md:74 src/ui/canvas.md:75
+msgid "Core Graphics (CGContext)"
+msgstr ""
+
+#: src/ui/canvas.md:76
+msgid "Cairo"
+msgstr ""
+
+#: src/ui/canvas.md:77 src/platforms/windows.md:52
+msgid "GDI"
+msgstr ""
+
+#: src/ui/canvas.md:77
+msgid "Planned"
+msgstr ""
+
+#: src/ui/canvas.md:78
+msgid "Canvas/Bitmap"
+msgstr ""
+
+#: src/ui/canvas.md:83
+msgid "[Animation](animation.md) — Animating widget properties"
+msgstr ""
+
+#: src/ui/canvas.md:84
+msgid "[Styling](styling.md) — Widget styling"
+msgstr ""
+
+#: src/ui/menus.md:3
+msgid ""
+"Perry supports native menu bars, context menus, and toolbars across all "
+"platforms. Every snippet below is excerpted from "
+"[`docs/examples/ui/menus/snippets.ts`](../../examples/ui/menus/snippets.ts) "
+"— CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/menus.md:8
+msgid ""
+"The menu API is **handle-based** and free-function: build menus with "
+"`menuCreate()`, fill them with `menuAddItem` / `menuAddItemWithShortcut`, "
+"and attach them with `menuBarAddMenu(bar, title, menu)`. Submenus go through"
+" `menuAddSubmenu(parent, title, submenu)`."
+msgstr ""
+
+#: src/ui/menus.md:13 src/ui/menus.md:109
+msgid "Menu Bar"
+msgstr ""
+
+#: src/ui/menus.md:15
+msgid ""
+"```typescript\n"
+"// Menus are created independently, then attached. Build child menus first,\n"
+"// then hand them to `menuBarAddMenu(bar, title, menu)`.\n"
+"const menuBar = menuBarCreate()\n"
+"\n"
+"// File menu\n"
+"const fileMenu = menuCreate()\n"
+"menuAddItemWithShortcut(fileMenu, \"New\",         \"n\", () => status.set(\"file/new\"))\n"
+"menuAddItemWithShortcut(fileMenu, \"Open…\",       \"o\", () => status.set(\"file/open\"))\n"
+"menuAddSeparator(fileMenu)\n"
+"menuAddItemWithShortcut(fileMenu, \"Save\",        \"s\", () => status.set(\"file/save\"))\n"
+"menuAddItemWithShortcut(fileMenu, \"Save As…\",    \"S\", () => status.set(\"file/saveAs\"))\n"
+"menuBarAddMenu(menuBar, \"File\", fileMenu)\n"
+"\n"
+"// Edit menu\n"
+"const editMenu = menuCreate()\n"
+"menuAddItemWithShortcut(editMenu, \"Undo\", \"z\", () => status.set(\"edit/undo\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Redo\", \"Z\", () => status.set(\"edit/redo\"))\n"
+"menuAddSeparator(editMenu)\n"
+"menuAddItemWithShortcut(editMenu, \"Cut\",   \"x\", () => status.set(\"edit/cut\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Copy\",  \"c\", () => status.set(\"edit/copy\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Paste\", \"v\", () => status.set(\"edit/paste\"))\n"
+"menuBarAddMenu(menuBar, \"Edit\", editMenu)\n"
+"\n"
+"// Submenu: View → Zoom\n"
+"const viewMenu = menuCreate()\n"
+"const zoomSubmenu = menuCreate()\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Zoom In\",     \"+\", () => status.set(\"zoom/in\"))\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Zoom Out\",    \"-\", () => status.set(\"zoom/out\"))\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Actual Size\", \"0\", () => status.set(\"zoom/reset\"))\n"
+"menuAddSubmenu(viewMenu, \"Zoom\", zoomSubmenu)\n"
+"menuBarAddMenu(menuBar, \"View\", viewMenu)\n"
+"\n"
+"menuBarAttach(menuBar)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:51
+msgid "Menu Bar Functions"
+msgstr ""
+
+#: src/ui/menus.md:55
+msgid "`menuBarCreate()`"
+msgstr ""
+
+#: src/ui/menus.md:55
+msgid "Create a new (empty) menu bar"
+msgstr ""
+
+#: src/ui/menus.md:56
+msgid "`menuCreate()`"
+msgstr ""
+
+#: src/ui/menus.md:56
+msgid "Create a new menu — used as a child of the bar or as a submenu"
+msgstr ""
+
+#: src/ui/menus.md:57
+msgid "`menuBarAddMenu(bar, title, menu)`"
+msgstr ""
+
+#: src/ui/menus.md:57
+msgid "Attach a top-level menu under `title`"
+msgstr ""
+
+#: src/ui/menus.md:58
+msgid "`menuAddItem(menu, label, callback)`"
+msgstr ""
+
+#: src/ui/menus.md:58
+msgid "Append an item without a shortcut"
+msgstr ""
+
+#: src/ui/menus.md:59
+msgid "`menuAddItemWithShortcut(menu, label, shortcut, callback)`"
+msgstr ""
+
+#: src/ui/menus.md:59
+msgid "Append an item with a keyboard shortcut"
+msgstr ""
+
+#: src/ui/menus.md:60
+msgid "`menuAddSeparator(menu)`"
+msgstr ""
+
+#: src/ui/menus.md:60
+msgid "Append a horizontal separator line"
+msgstr ""
+
+#: src/ui/menus.md:61
+msgid "`menuAddSubmenu(parent, title, submenu)`"
+msgstr ""
+
+#: src/ui/menus.md:61
+msgid "Nest a previously-created menu under a label"
+msgstr ""
+
+#: src/ui/menus.md:62
+msgid "`menuBarAttach(bar)`"
+msgstr ""
+
+#: src/ui/menus.md:62
+msgid "Install the bar as the application's main menu"
+msgstr ""
+
+#: src/ui/menus.md:66
+msgid "The third argument to `menuAddItemWithShortcut` is the shortcut key:"
+msgstr ""
+
+#: src/ui/menus.md:68 src/testing/geisterhand.md:92
+#: src/testing/geisterhand.md:295
+msgid "Shortcut"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "`\"n\"`"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "Cmd+N"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "Ctrl+N"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "`\"S\"`"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "Cmd+Shift+S"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "Ctrl+Shift+S"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "`\"+\"`"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "Cmd++"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "Ctrl++"
+msgstr ""
+
+#: src/ui/menus.md:74
+msgid "Uppercase letters imply Shift."
+msgstr ""
+
+#: src/ui/menus.md:76
+msgid "Context Menus"
+msgstr ""
+
+#: src/ui/menus.md:78
+msgid ""
+"Right-click menus are attached to widgets via `widgetSetContextMenu(widget, "
+"menu)`. Build the menu the same way as a menu-bar entry, then bind it:"
+msgstr ""
+
+#: src/ui/menus.md:81
+msgid ""
+"```typescript\n"
+"const label = Text(\"Right-click me\")\n"
+"const ctx = menuCreate()\n"
+"menuAddItem(ctx, \"Copy\",   () => status.set(\"ctx/copy\"))\n"
+"menuAddItem(ctx, \"Paste\",  () => status.set(\"ctx/paste\"))\n"
+"menuAddSeparator(ctx)\n"
+"menuAddItem(ctx, \"Delete\", () => status.set(\"ctx/delete\"))\n"
+"widgetSetContextMenu(label, ctx)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:91 src/ui/menus.md:109
+msgid "Toolbar"
+msgstr ""
+
+#: src/ui/menus.md:93
+msgid ""
+"Add a toolbar to a window. `toolbarAddItem` takes an _identifier_ (used by "
+"AppKit to deduplicate items) and a _label_:"
+msgstr ""
+
+#: src/ui/menus.md:96
+msgid ""
+"```typescript\n"
+"const toolbar = toolbarCreate()\n"
+"toolbarAddItem(toolbar, \"new\",  \"New\",  () => status.set(\"tb/new\"))\n"
+"toolbarAddItem(toolbar, \"save\", \"Save\", () => status.set(\"tb/save\"))\n"
+"toolbarAddItem(toolbar, \"run\",  \"Run\",  () => status.set(\"tb/run\"))\n"
+"\n"
+"// `toolbarAttach(toolbar, window)` mounts onto a specific window.\n"
+"const win = Window(\"Toolbar Demo\", 800, 600)\n"
+"toolbarAttach(toolbar, win as unknown as number)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:109
+msgid "Context Menu"
+msgstr ""
+
+#: src/ui/menus.md:111
+msgid "NSToolbar"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "— (no menu bar)"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "UIMenu"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "UIToolbar"
+msgstr ""
+
+#: src/ui/menus.md:113
+msgid "HMENU/SetMenu"
+msgstr ""
+
+#: src/ui/menus.md:113
+msgid "Horizontal layout"
+msgstr ""
+
+#: src/ui/menus.md:114
+msgid "GMenu/set_menubar"
+msgstr ""
+
+#: src/ui/menus.md:114
+msgid "HeaderBar"
+msgstr ""
+
+#: src/ui/menus.md:117
+msgid ""
+"**iOS**: Menu bars are not applicable. Use toolbar and navigation patterns "
+"instead."
+msgstr ""
+
+#: src/ui/menus.md:121
+msgid "[Events](events.md) — Keyboard shortcuts and interactions"
+msgstr ""
+
+#: src/ui/menus.md:122
+msgid "[Dialogs](dialogs.md) — File dialogs and alerts"
+msgstr ""
+
+#: src/ui/menus.md:123
+msgid "[Layout](layout.md) — Toolbar and navigation patterns"
+msgstr ""
+
+#: src/ui/dialogs.md:3
+msgid ""
+"Perry provides native dialog functions for file selection, alerts, and "
+"sheets. Every snippet below is excerpted from "
+"[`docs/examples/ui/dialogs/snippets.ts`](../../examples/ui/dialogs/snippets.ts)"
+" — CI compiles and links the file on every PR, so the API drawn here is the "
+"API the runtime exposes."
+msgstr ""
+
+#: src/ui/dialogs.md:9
+msgid ""
+"All file dialogs are **callback-based** (the OS-modal panel is non-blocking "
+"on Apple platforms, so a synchronous return wouldn't be possible without "
+"freezing the app's run loop). The callback receives an empty string when the"
+" user cancels."
+msgstr ""
+
+#: src/ui/dialogs.md:14
+msgid "File Open Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:16
+msgid ""
+"```typescript\n"
+"function pickFile(): void {\n"
+"    openFileDialog((path: string) => {\n"
+"        if (path.length > 0) {\n"
+"            console.log(`Selected: ${path}`)\n"
+"        } else {\n"
+"            console.log(\"Open dialog cancelled\")\n"
+"        }\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:28
+msgid "Folder Selection Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:40
+msgid "Save File Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:42
+msgid ""
+"```typescript\n"
+"function pickSaveTarget(): void {\n"
+"    saveFileDialog((path: string) => {\n"
+"        if (path.length > 0) {\n"
+"            console.log(`Will save to: ${path}`)\n"
+"        }\n"
+"    }, \"untitled\", \"txt\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:52
+msgid ""
+"`saveFileDialog(callback, defaultName, extension)` pre-fills the name field "
+"with `defaultName.<extension>`."
+msgstr ""
+
+#: src/ui/dialogs.md:55 src/ui/dialogs.md:113
+msgid "Alert"
+msgstr ""
+
+#: src/ui/dialogs.md:57
+msgid "Display a native alert dialog:"
+msgstr ""
+
+#: src/ui/dialogs.md:59
+msgid ""
+"```typescript\n"
+"function showSimpleAlert(): void {\n"
+"    alert(\"Operation Complete\", \"Your file has been saved successfully.\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:65
+msgid "`alert(title, message)` shows a modal alert with an OK button."
+msgstr ""
+
+#: src/ui/dialogs.md:67
+msgid "Alert with Buttons"
+msgstr ""
+
+#: src/ui/dialogs.md:69
+msgid ""
+"```typescript\n"
+"function confirmDelete(): void {\n"
+"    alertWithButtons(\n"
+"        \"Delete Item?\",\n"
+"        \"This action cannot be undone.\",\n"
+"        [\"Cancel\", \"Delete\"],\n"
+"        (index: number) => {\n"
+"            if (index === 1) {\n"
+"                console.log(\"user confirmed delete\")\n"
+"            }\n"
+"        },\n"
+"    )\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:84
+msgid ""
+"`alertWithButtons(title, message, buttons, callback)` invokes the callback "
+"with the 0-based index of the button the user clicked. By convention put a "
+"destructive label last and check the index in the callback."
+msgstr ""
+
+#: src/ui/dialogs.md:88
+msgid "Sheets"
+msgstr ""
+
+#: src/ui/dialogs.md:90
+msgid ""
+"Sheets are modal panels attached to a window. Build the body, hand it (with "
+"a size) to `sheetCreate`, then `sheetPresent` it. To dismiss "
+"programmatically, keep the handle around and call `sheetDismiss(handle)`:"
+msgstr ""
+
+#: src/ui/dialogs.md:94
+msgid ""
+"```typescript\n"
+"function showSheet(): void {\n"
+"    let sheet = 0\n"
+"    const body = VStack(16, [\n"
+"        Text(\"Sheet Content\"),\n"
+"        Button(\"Close\", () => sheetDismiss(sheet)),\n"
+"    ])\n"
+"    sheet = sheetCreate(body, 320, 200)\n"
+"    sheetPresent(sheet)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:108
+msgid "Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "File Open"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:112
+msgid "NSOpenPanel"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "UIDocumentPicker"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:112
+msgid "IFileOpenDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:111 src/ui/dialogs.md:112
+msgid "GtkFileChooserDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "`<input type=\"file\">`"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "File Save"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "NSSavePanel"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "IFileSaveDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "Download link"
+msgstr ""
+
+#: src/ui/dialogs.md:112
+msgid "Folder"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "NSAlert"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "UIAlertController"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "MessageBoxW"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "MessageDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "`alert()`"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Sheet"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "NSSheet"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal VC"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal Window"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal div"
+msgstr ""
+
+#: src/ui/dialogs.md:116
+msgid "Complete Example: minimal text editor"
+msgstr ""
+
+#: src/ui/dialogs.md:118
+msgid ""
+"A real program that wires `openFileDialog` and `saveFileDialog` into a "
+"state-bound `TextField`:"
+msgstr ""
+
+#: src/ui/dialogs.md:121
+msgid ""
+"```typescript\n"
+"// demonstrates: file-open / save dialogs wired to a tiny text editor\n"
+"// docs: docs/src/ui/dialogs.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack, HStack,\n"
+"    Text, Button, TextField,\n"
+"    State,\n"
+"    openFileDialog, saveFileDialog, alert,\n"
+"} from \"perry/ui\"\n"
+"import { readFileSync, writeFileSync } from \"fs\"\n"
+"\n"
+"const content = State(\"\")\n"
+"const filePath = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"Text Editor\",\n"
+"    width: 800,\n"
+"    height: 600,\n"
+"    body: VStack(12, [\n"
+"        HStack(8, [\n"
+"            Button(\"Open\", () => {\n"
+"                openFileDialog((path: string) => {\n"
+"                    if (path.length === 0) return\n"
+"                    filePath.set(path)\n"
+"                    content.set(readFileSync(path, \"utf-8\") as string)\n"
+"                })\n"
+"            }),\n"
+"            Button(\"Save As\", () => {\n"
+"                saveFileDialog((path: string) => {\n"
+"                    if (path.length === 0) return\n"
+"                    writeFileSync(path, content.value)\n"
+"                    filePath.set(path)\n"
+"                    alert(\"Saved\", `File saved to ${path}`)\n"
+"                }, \"untitled\", \"txt\")\n"
+"            }),\n"
+"        ]),\n"
+"        Text(filePath.value === \"\" ? \"No file open\" : `File: ${filePath.value}`),\n"
+"        TextField(\"Start typing...\", (value: string) => content.set(value)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:168
+msgid "[Menus](menus.md) — Menu bar and context menus"
+msgstr ""
+
+#: src/ui/dialogs.md:169
+msgid "[Multi-Window](multi-window.md) — Multiple windows"
+msgstr ""
+
+#: src/ui/dialogs.md:170
+msgid "[Events](events.md) — User interaction events"
+msgstr ""
+
+#: src/ui/table.md:3
+msgid ""
+"The `Table` widget displays tabular data with columns, headers, and row "
+"selection."
+msgstr ""
+
+#: src/ui/table.md:6
+msgid ""
+"**Platform support:** real implementation lives on **macOS** (`NSTableView` "
+"+ `NSScrollView`); the **Web** target uses an HTML `<table>`. **iOS**, "
+"**Android**, **Linux/GTK4**, **Windows**, **tvOS**, **visionOS**, and "
+"**watchOS** link no-op stubs so cross-platform code compiles everywhere — "
+"the table renders nothing and `tableGetSelectedRow` returns `-1`. For "
+"production lists on platforms without a real impl, use `LazyVStack` (see "
+"[Layout](layout.md))."
+msgstr ""
+
+#: src/ui/table.md:14
+msgid "Creating a Table"
+msgstr ""
+
+#: src/ui/table.md:22
+msgid ""
+"`Table(rowCount, colCount, renderCell)` creates a table. The render callback"
+" receives `(row, col)` and must return a `Widget` (typically `Text(...)`). "
+"The runtime resolves the returned handle as the cell view, which lets cells "
+"render images, stacks, or composites — not just plain strings."
+msgstr ""
+
+#: src/ui/table.md:28
+msgid "Column Headers"
+msgstr ""
+
+#: src/ui/table.md:30
+msgid ""
+"```ts\n"
+"const userTable = Table(users.length, 3, (row: number, col: number) => {\n"
+"    const user = users[row]\n"
+"    if (col === 0) return Text(user.name)\n"
+"    if (col === 1) return Text(user.email)\n"
+"    return Text(user.role)\n"
+"})\n"
+"\n"
+"tableSetColumnHeader(userTable, 0, \"Name\")\n"
+"tableSetColumnHeader(userTable, 1, \"Email\")\n"
+"tableSetColumnHeader(userTable, 2, \"Role\")\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:43
+msgid "Column Widths"
+msgstr ""
+
+#: src/ui/table.md:45
+msgid ""
+"```ts\n"
+"tableSetColumnWidth(userTable, 0, 150)  // Name column\n"
+"tableSetColumnWidth(userTable, 1, 250)  // Email column\n"
+"tableSetColumnWidth(userTable, 2, 100)  // Role column\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:51
+msgid "Row Selection"
+msgstr ""
+
+#: src/ui/table.md:53
+msgid ""
+"```ts\n"
+"const selectedRow = State(-1)\n"
+"\n"
+"tableSetOnRowSelect(userTable, (row: number) => {\n"
+"    selectedRow.set(row)\n"
+"    console.log(`Selected row: ${row}`)\n"
+"})\n"
+"\n"
+"// Read the currently selected row at any time:\n"
+"const current = tableGetSelectedRow(userTable)\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:65
+msgid "Dynamic Row Count"
+msgstr ""
+
+#: src/ui/table.md:67
+msgid "Update the number of rows after creation:"
+msgstr ""
+
+#: src/ui/table.md:75
+msgid ""
+"```ts\n"
+"const selectedName = State(\"None\")\n"
+"\n"
+"const table = Table(users.length, 3, (row: number, col: number) => {\n"
+"    const user = users[row]\n"
+"    if (col === 0) return Text(user.name)\n"
+"    if (col === 1) return Text(user.email)\n"
+"    return Text(user.role)\n"
+"})\n"
+"\n"
+"tableSetColumnHeader(table, 0, \"Name\")\n"
+"tableSetColumnHeader(table, 1, \"Email\")\n"
+"tableSetColumnHeader(table, 2, \"Role\")\n"
+"tableSetColumnWidth(table, 0, 150)\n"
+"tableSetColumnWidth(table, 1, 250)\n"
+"tableSetColumnWidth(table, 2, 100)\n"
+"\n"
+"tableSetOnRowSelect(table, (row: number) => {\n"
+"    selectedName.set(users[row].name)\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Table Demo\",\n"
+"    width: 600,\n"
+"    height: 400,\n"
+"    body: VStack(12, [\n"
+"        table,\n"
+"        Text(`Selected: ${selectedName.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:111
+msgid "[Events](events.md) — Event handling"
+msgstr ""
+
+#: src/ui/animation.md:3
+msgid ""
+"Perry supports animating widget properties for smooth transitions. Every "
+"snippet below is excerpted from "
+"[`docs/examples/ui/animation/snippets.ts`](../../examples/ui/animation/snippets.ts)"
+" — CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/animation.md:8
+msgid ""
+"`animateOpacity` and `animatePosition` are special: they're documented as "
+"methods on the widget handle (the only methods perry/ui exposes), and the "
+"HIR lowers them to `widgetAnimateOpacity` / `widgetAnimatePosition` calls "
+"under the hood."
+msgstr ""
+
+#: src/ui/animation.md:13
+msgid "Opacity Animation"
+msgstr ""
+
+#: src/ui/animation.md:15
+msgid ""
+"```typescript\n"
+"const fading = Text(\"Fading text\")\n"
+"// Animate from the widget's current opacity to `target` over `durationSecs`.\n"
+"fading.animateOpacity(1.0, 0.3) // target, durationSeconds\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:21
+msgid "Position Animation"
+msgstr ""
+
+#: src/ui/animation.md:23
+msgid ""
+"```typescript\n"
+"const moving = Button(\"Moving\", () => {})\n"
+"// Animate by a delta (dx, dy) relative to the widget's current position.\n"
+"moving.animatePosition(100, 200, 0.5) // dx, dy, durationSeconds\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:29
+msgid "Example: Fade-In Effect"
+msgstr ""
+
+#: src/ui/animation.md:31
+msgid ""
+"When the first argument reads from a `State.value`, Perry auto-subscribes "
+"the call to the state — toggling `visible` re-runs the animation."
+msgstr ""
+
+#: src/ui/animation.md:34
+msgid ""
+"```typescript\n"
+"// demonstrates: auto-reactive animateOpacity driven by a State toggle\n"
+"// docs: docs/src/ui/animation.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"\n"
+"import { App, Text, Button, VStack, State } from \"perry/ui\"\n"
+"\n"
+"const visible = State(false)\n"
+"\n"
+"const label = Text(\"Hello!\")\n"
+"label.animateOpacity(visible.value ? 1.0 : 0.0, 0.3)\n"
+"\n"
+"App({\n"
+"    title: \"Animation Demo\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Button(\"Toggle\", () => {\n"
+"            visible.set(!visible.value)\n"
+"        }),\n"
+"        label,\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:64
+msgid "NSAnimationContext / ViewPropertyAnimator"
+msgstr ""
+
+#: src/ui/animation.md:65
+msgid "UIView.animate"
+msgstr ""
+
+#: src/ui/animation.md:66
+msgid "ViewPropertyAnimator"
+msgstr ""
+
+#: src/ui/animation.md:67
+msgid "WM_TIMER-based animation"
+msgstr ""
+
+#: src/ui/animation.md:68
+msgid "CSS transitions (GTK4)"
+msgstr ""
+
+#: src/ui/animation.md:69
+msgid "CSS transitions"
+msgstr ""
+
+#: src/ui/animation.md:73
+msgid "[Styling](styling.md) — Widget styling properties"
+msgstr ""
+
+#: src/ui/animation.md:75
+msgid "[Events](events.md) — User interaction"
+msgstr ""
+
+#: src/ui/multi-window.md:1
+msgid "Multi-Window & Window Management"
+msgstr ""
+
+#: src/ui/multi-window.md:3
+msgid ""
+"Perry supports creating multiple native windows and controlling their "
+"appearance and behavior. Every snippet below is excerpted from "
+"[`docs/examples/ui/multi_window/snippets.ts`](../../examples/ui/multi_window/snippets.ts)"
+" — CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/multi-window.md:8
+msgid "Creating Windows"
+msgstr ""
+
+#: src/ui/multi-window.md:10
+msgid ""
+"`Window(title, width, height)` returns a window handle. Call `.setBody()` to"
+" set its content and `.show()` to display it:"
+msgstr ""
+
+#: src/ui/multi-window.md:13
+msgid ""
+"```typescript\n"
+"const settings = Window(\"Settings\", 500, 400)\n"
+"settings.setBody(VStack(16, [\n"
+"    Text(\"Settings panel\"),\n"
+"]))\n"
+"settings.show()\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:21
+msgid "Window Instance Methods"
+msgstr ""
+
+#: src/ui/multi-window.md:23
+msgid ""
+"```typescript\n"
+"const win = Window(\"My Window\", 600, 400)\n"
+"\n"
+"win.setBody(Text(\"Hello\"))   // Set the root widget\n"
+"win.show()                    // Show the window\n"
+"win.hide()                    // Hide without destroying\n"
+"win.setSize(800, 600)         // Resize dynamically\n"
+"win.onFocusLost(() => {       // Callback when the window loses focus\n"
+"    win.hide()\n"
+"})\n"
+"win.close()                   // Close and destroy\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:36 src/i18n/overview.md:87
+#: src/testing/geisterhand.md:257
+msgid "Method"
+msgstr ""
+
+#: src/ui/multi-window.md:38
+msgid "`setBody(widget)`"
+msgstr ""
+
+#: src/ui/multi-window.md:38
+msgid "Set the root widget of the window"
+msgstr ""
+
+#: src/ui/multi-window.md:39
+msgid "`show()`"
+msgstr ""
+
+#: src/ui/multi-window.md:39
+msgid "Show the window"
+msgstr ""
+
+#: src/ui/multi-window.md:40
+msgid "`hide()`"
+msgstr ""
+
+#: src/ui/multi-window.md:40
+msgid "Hide without destroying — call `show()` again to reveal"
+msgstr ""
+
+#: src/ui/multi-window.md:41
+msgid "`setSize(w, h)`"
+msgstr ""
+
+#: src/ui/multi-window.md:41
+msgid "Resize dynamically"
+msgstr ""
+
+#: src/ui/multi-window.md:42
+msgid "`onFocusLost(cb)`"
+msgstr ""
+
+#: src/ui/multi-window.md:42
+msgid "Register a callback that fires when focus leaves the window"
+msgstr ""
+
+#: src/ui/multi-window.md:43
+msgid "`close()`"
+msgstr ""
+
+#: src/ui/multi-window.md:43
+msgid "Close and destroy"
+msgstr ""
+
+#: src/ui/multi-window.md:45
+msgid "App Window Properties"
+msgstr ""
+
+#: src/ui/multi-window.md:47
+msgid ""
+"The main `App({})` config object accepts the same window properties for "
+"building launcher-style, overlay, or utility apps:"
+msgstr ""
+
+#: src/ui/multi-window.md:50
+msgid ""
+"```typescript\n"
+"App({\n"
+"    title: \"QuickLaunch\",\n"
+"    width: 600,\n"
+"    height: 80,\n"
+"    body: VStack(8, [\n"
+"        Text(\"Search...\"),\n"
+"        Button(\"Open Settings\", () => settings.show()),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:62
+msgid ""
+"`App` additionally accepts the optional fields `frameless`, `level`, "
+"`transparent`, `vibrancy`, `activationPolicy`, and `icon`. They map to the "
+"following native primitives:"
+msgstr ""
+
+#: src/ui/multi-window.md:66
+msgid "`frameless: true`"
+msgstr ""
+
+#: src/ui/multi-window.md:68
+msgid "Removes the window title bar and frame, creating a borderless window."
+msgstr ""
+
+#: src/ui/multi-window.md:72
+msgid "`NSWindowStyleMask::Borderless` + movable by background"
+msgstr ""
+
+#: src/ui/multi-window.md:73
+msgid "`WS_POPUP` window style"
+msgstr ""
+
+#: src/ui/multi-window.md:74
+msgid "`set_decorated(false)`"
+msgstr ""
+
+#: src/ui/multi-window.md:76
+msgid "`level: \"floating\" | \"statusBar\" | \"modal\" | \"normal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:78
+msgid "Controls the window's z-order level relative to other windows."
+msgstr ""
+
+#: src/ui/multi-window.md:80
+msgid "Level"
+msgstr ""
+
+#: src/ui/multi-window.md:82
+msgid "`\"normal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:82
+msgid "Default window level"
+msgstr ""
+
+#: src/ui/multi-window.md:83
+msgid "`\"floating\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:83
+msgid "Stays above normal windows"
+msgstr ""
+
+#: src/ui/multi-window.md:84
+msgid "`\"statusBar\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:84
+msgid "Stays above floating windows"
+msgstr ""
+
+#: src/ui/multi-window.md:85
+msgid "`\"modal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:85
+msgid "Modal panel level"
+msgstr ""
+
+#: src/ui/multi-window.md:89
+msgid "`NSWindow.level` (NSFloatingWindowLevel, etc.)"
+msgstr ""
+
+#: src/ui/multi-window.md:90
+msgid "`SetWindowPos` with `HWND_TOPMOST`"
+msgstr ""
+
+#: src/ui/multi-window.md:91
+msgid "`set_modal(true)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:93
+msgid "`transparent: true`"
+msgstr ""
+
+#: src/ui/multi-window.md:95
+msgid ""
+"Makes the window background transparent, allowing the desktop to show "
+"through non-opaque regions of your UI."
+msgstr ""
+
+#: src/ui/multi-window.md:100
+msgid "`isOpaque = false`, `backgroundColor = .clear`"
+msgstr ""
+
+#: src/ui/multi-window.md:101
+msgid "`WS_EX_LAYERED` with `SetLayeredWindowAttributes`"
+msgstr ""
+
+#: src/ui/multi-window.md:102
+msgid "CSS `background-color: transparent`"
+msgstr ""
+
+#: src/ui/multi-window.md:104
+msgid "`vibrancy: string`"
+msgstr ""
+
+#: src/ui/multi-window.md:106
+msgid ""
+"Applies a native translucent material to the window background. On macOS "
+"this uses the system vibrancy effect; on Windows it uses Mica/Acrylic."
+msgstr ""
+
+#: src/ui/multi-window.md:109
+msgid ""
+"**macOS materials:** `\"sidebar\"`, `\"titlebar\"`, `\"selection\"`, "
+"`\"menu\"`, `\"popover\"`, `\"headerView\"`, `\"sheet\"`, "
+"`\"windowBackground\"`, `\"hudWindow\"`, `\"fullScreenUI\"`, `\"tooltip\"`, "
+"`\"contentBackground\"`, `\"underWindowBackground\"`, "
+"`\"underPageBackground\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:116
+msgid "`NSVisualEffectView` with the specified material"
+msgstr ""
+
+#: src/ui/multi-window.md:117
+msgid ""
+"`DwmSetWindowAttribute(DWMWA_SYSTEMBACKDROP_TYPE)` — Mica, Acrylic, or Mica "
+"Alt depending on material (Windows 11 22H2+)"
+msgstr ""
+
+#: src/ui/multi-window.md:118
+msgid "CSS `alpha(@window_bg_color, 0.85)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:120
+msgid "`activationPolicy: \"regular\" | \"accessory\" | \"background\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:122
+msgid "Controls whether the app appears in the dock/taskbar."
+msgstr ""
+
+#: src/ui/multi-window.md:124 src/widgets/data-fetching.md:125
+msgid "Policy"
+msgstr ""
+
+#: src/ui/multi-window.md:126
+msgid "`\"regular\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:126
+msgid "Normal app with dock icon and menu bar (default)"
+msgstr ""
+
+#: src/ui/multi-window.md:127
+msgid "`\"accessory\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:127
+msgid ""
+"No dock icon, no menu bar activation — ideal for launchers and utilities"
+msgstr ""
+
+#: src/ui/multi-window.md:128
+msgid "`\"background\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:128
+msgid "Fully hidden from dock and app switcher"
+msgstr ""
+
+#: src/ui/multi-window.md:132
+msgid "`NSApp.setActivationPolicy()`"
+msgstr ""
+
+#: src/ui/multi-window.md:133
+msgid "`WS_EX_TOOLWINDOW` (removes from taskbar)"
+msgstr ""
+
+#: src/ui/multi-window.md:134
+msgid "`set_deletable(false)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:140
+msgid "NSWindow"
+msgstr ""
+
+#: src/ui/multi-window.md:141
+msgid "CreateWindowEx (HWND)"
+msgstr ""
+
+#: src/ui/multi-window.md:142
+msgid "GtkWindow"
+msgstr ""
+
+#: src/ui/multi-window.md:143
+msgid "Floating `<div>`"
+msgstr ""
+
+#: src/ui/multi-window.md:144
+msgid "iOS/Android"
+msgstr ""
+
+#: src/ui/multi-window.md:144
+msgid "Modal view controller / Dialog"
+msgstr ""
+
+#: src/ui/multi-window.md:146
+msgid ""
+"On mobile platforms, \"windows\" are presented as modal views or dialogs "
+"since mobile apps typically use a single-window model."
+msgstr ""
+
+#: src/ui/multi-window.md:151
+msgid "[Events](events.md) — Keyboard shortcuts"
+msgstr ""
+
+#: src/ui/multi-window.md:152
+msgid "[Dialogs](dialogs.md) — Modal dialogs and sheets"
+msgstr ""
+
+#: src/ui/multi-window.md:153
+msgid "[Menus](menus.md) — Menu bar and toolbar"
+msgstr ""
+
+#: src/ui/multi-window.md:154
+msgid "[UI Overview](overview.md) — Full UI system overview"
+msgstr ""
+
+#: src/ui/theming.md:3
+msgid ""
+"The `perry-styling` package provides a design system bridge for Perry UI — "
+"design token codegen and ergonomic styling helpers with compile-time "
+"platform detection."
+msgstr ""
+
+#: src/ui/theming.md:11
+msgid "Design Token Codegen"
+msgstr ""
+
+#: src/ui/theming.md:13
+msgid "Generate typed theme files from a JSON token definition:"
+msgstr ""
+
+#: src/ui/theming.md:19
+msgid "Token Format"
+msgstr ""
+
+#: src/ui/theming.md:23
+msgid "\"colors\""
+msgstr ""
+
+#: src/ui/theming.md:24
+msgid "\"primary\""
+msgstr ""
+
+#: src/ui/theming.md:24
+msgid "\"#007AFF\""
+msgstr ""
+
+#: src/ui/theming.md:25
+msgid "\"primary-dark\""
+msgstr ""
+
+#: src/ui/theming.md:25
+msgid "\"#0A84FF\""
+msgstr ""
+
+#: src/ui/theming.md:27
+msgid "\"background-dark\""
+msgstr ""
+
+#: src/ui/theming.md:27
+msgid "\"#1C1C1E\""
+msgstr ""
+
+#: src/ui/theming.md:28 src/testing/geisterhand.md:465
+msgid "\"text\""
+msgstr ""
+
+#: src/ui/theming.md:28
+msgid "\"#000000\""
+msgstr ""
+
+#: src/ui/theming.md:29
+msgid "\"text-dark\""
+msgstr ""
+
+#: src/ui/theming.md:31
+msgid "\"spacing\""
+msgstr ""
+
+#: src/ui/theming.md:32 src/ui/theming.md:38
+msgid "\"sm\""
+msgstr ""
+
+#: src/ui/theming.md:33 src/ui/theming.md:39
+msgid "\"md\""
+msgstr ""
+
+#: src/ui/theming.md:34 src/ui/theming.md:40
+msgid "\"lg\""
+msgstr ""
+
+#: src/ui/theming.md:35
+msgid "\"xl\""
+msgstr ""
+
+#: src/ui/theming.md:37
+msgid "\"radius\""
+msgstr ""
+
+#: src/ui/theming.md:42
+msgid "\"fontSize\""
+msgstr ""
+
+#: src/ui/theming.md:43
+msgid "\"body\""
+msgstr ""
+
+#: src/ui/theming.md:44
+msgid "\"heading\""
+msgstr ""
+
+#: src/ui/theming.md:45
+msgid "\"caption\""
+msgstr ""
+
+#: src/ui/theming.md:47
+msgid "\"borderWidth\""
+msgstr ""
+
+#: src/ui/theming.md:48
+msgid "\"thin\""
+msgstr ""
+
+#: src/ui/theming.md:49
+msgid "\"medium\""
+msgstr ""
+
+#: src/ui/theming.md:54
+msgid ""
+"Colors with a `-dark` suffix are used as the dark mode variant. If no dark "
+"variant is provided, the light value is used for both modes. Supported color"
+" formats: hex (`#RGB`, `#RRGGBB`, `#RRGGBBAA`), `rgb()`/`rgba()`, "
+"`hsl()`/`hsla()`, and CSS named colors."
+msgstr ""
+
+#: src/ui/theming.md:56
+msgid "Generated Types"
+msgstr ""
+
+#: src/ui/theming.md:58
+msgid "The codegen produces typed interfaces:"
+msgstr ""
+
+#: src/ui/theming.md:60
+msgid ""
+"```text\n"
+"interface PerryColor {\n"
+"  r: number; g: number; b: number; a: number; // floats in [0, 1]\n"
+"}\n"
+"\n"
+"interface PerryTheme {\n"
+"  light: { [key: string]: PerryColor };\n"
+"  dark: { [key: string]: PerryColor };\n"
+"  spacing: { [key: string]: number };\n"
+"  radius: { [key: string]: number };\n"
+"  fontSize: { [key: string]: number };\n"
+"  borderWidth: { [key: string]: number };\n"
+"}\n"
+"\n"
+"interface ResolvedTheme {\n"
+"  colors: { [key: string]: PerryColor };\n"
+"  spacing: { [key: string]: number };\n"
+"  radius: { [key: string]: number };\n"
+"  fontSize: { [key: string]: number };\n"
+"  borderWidth: { [key: string]: number };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:83
+msgid "Theme Resolution"
+msgstr ""
+
+#: src/ui/theming.md:85
+msgid "Resolve a theme at runtime based on the system's dark mode setting:"
+msgstr ""
+
+#: src/ui/theming.md:87
+msgid ""
+"```text\n"
+"import { getTheme } from \"perry-styling\";\n"
+"import { theme } from \"./theme\"; // generated file\n"
+"\n"
+"const resolved = getTheme(theme);\n"
+"// resolved.colors.primary → the correct light/dark variant\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:95
+msgid ""
+"`getTheme()` calls `isDarkMode()` from `perry/system` and returns the "
+"appropriate palette."
+msgstr ""
+
+#: src/ui/theming.md:97
+msgid "Styling Helpers"
+msgstr ""
+
+#: src/ui/theming.md:99
+msgid ""
+"Ergonomic functions for applying styles to widget handles. Perry's compiler "
+"doesn't yet support passing `PerryColor` objects as parameters into user "
+"functions, so the helpers take **flat primitives**: extract the channels at "
+"the call site:"
+msgstr ""
+
+#: src/ui/theming.md:104
+msgid ""
+"```text\n"
+"import {\n"
+"  applyBg, applyRadius, applyTextColor, applyFontSize, applyGradient,\n"
+"} from \"perry-styling\";\n"
+"\n"
+"const t = resolved;                    // your ResolvedTheme\n"
+"const c = t.colors.text;               // a PerryColor\n"
+"const bg = t.colors.background;\n"
+"const start = t.colors.primary;\n"
+"const end = t.colors[\"primary-dark\"];\n"
+"\n"
+"const label = Text(\"Hello\");\n"
+"applyTextColor(label, c.r, c.g, c.b, c.a);\n"
+"applyFontSize(label, t.fontSize.heading);\n"
+"\n"
+"const card = VStack(16, []);\n"
+"applyBg(card, bg.r, bg.g, bg.b, bg.a);\n"
+"applyRadius(card, t.radius.md);\n"
+"applyGradient(card,\n"
+"  start.r, start.g, start.b, start.a,\n"
+"  end.r,   end.g,   end.b,   end.a,\n"
+"  0,                                   // 0 = vertical, 1 = horizontal\n"
+");\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:129
+msgid "Available Helpers"
+msgstr ""
+
+#: src/ui/theming.md:131
+msgid "Signature"
+msgstr ""
+
+#: src/ui/theming.md:133
+msgid "`applyBg(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:133
+msgid "Background color"
+msgstr ""
+
+#: src/ui/theming.md:134
+msgid "`applyRadius(handle, radius)`"
+msgstr ""
+
+#: src/ui/theming.md:134
+msgid "Corner radius"
+msgstr ""
+
+#: src/ui/theming.md:135
+msgid "`applyTextColor(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:135
+msgid "Text color"
+msgstr ""
+
+#: src/ui/theming.md:136
+msgid "`applyFontSize(handle, size)`"
+msgstr ""
+
+#: src/ui/theming.md:136
+msgid "Font size (regular weight)"
+msgstr ""
+
+#: src/ui/theming.md:137
+msgid "`applyFontBold(handle, size)`"
+msgstr ""
+
+#: src/ui/theming.md:137
+msgid "Font size with bold weight"
+msgstr ""
+
+#: src/ui/theming.md:138
+msgid "`applyFontFamily(handle, family)`"
+msgstr ""
+
+#: src/ui/theming.md:138
+msgid "Font family"
+msgstr ""
+
+#: src/ui/theming.md:139
+msgid "`applyWidth(handle, width)`"
+msgstr ""
+
+#: src/ui/theming.md:139
+msgid "Fixed width"
+msgstr ""
+
+#: src/ui/theming.md:140
+msgid "`applyTooltip(handle, text)`"
+msgstr ""
+
+#: src/ui/theming.md:140
+msgid "Tooltip (no-op on iOS/Android)"
+msgstr ""
+
+#: src/ui/theming.md:141
+msgid "`applyBorderColor(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:141
+msgid "Border color"
+msgstr ""
+
+#: src/ui/theming.md:142
+msgid "`applyBorderWidth(handle, width)`"
+msgstr ""
+
+#: src/ui/theming.md:142
+msgid "Border width"
+msgstr ""
+
+#: src/ui/theming.md:143
+msgid "`applyEdgeInsets(handle, top, left, bottom, right)`"
+msgstr ""
+
+#: src/ui/theming.md:143
+msgid "Edge insets (padding)"
+msgstr ""
+
+#: src/ui/theming.md:144
+msgid "`applyOpacity(handle, alpha)`"
+msgstr ""
+
+#: src/ui/theming.md:145
+msgid "`applyGradient(handle, r1, g1, b1, a1, r2, g2, b2, a2, direction)`"
+msgstr ""
+
+#: src/ui/theming.md:145
+msgid "Background gradient"
+msgstr ""
+
+#: src/ui/theming.md:146
+msgid "`applyButtonBg(btn, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:146
+msgid "Button background"
+msgstr ""
+
+#: src/ui/theming.md:147
+msgid "`applyButtonTextColor(btn, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:147
+msgid "Button text color"
+msgstr ""
+
+#: src/ui/theming.md:148
+msgid "`applyButtonBordered(btn, bordered)`"
+msgstr ""
+
+#: src/ui/theming.md:148
+msgid "Bordered button style (`true`/`false`)"
+msgstr ""
+
+#: src/ui/theming.md:150
+msgid "Platform Constants"
+msgstr ""
+
+#: src/ui/theming.md:152
+msgid ""
+"`perry-styling` exports compile-time platform constants based on the "
+"`__platform__` built-in:"
+msgstr ""
+
+#: src/ui/theming.md:154
+msgid ""
+"```text\n"
+"import { isMac, isIOS, isAndroid, isWindows, isLinux, isDesktop, isMobile } from \"perry-styling\";\n"
+"\n"
+"if (isMobile) {\n"
+"  applyFontSize(label, 16);\n"
+"} else {\n"
+"  applyFontSize(label, 14);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:164
+msgid ""
+"These are constant-folded by LLVM at compile time — dead branches are "
+"eliminated with zero runtime cost."
+msgstr ""
+
+#: src/ui/theming.md:168
+msgid "[Styling](styling.md) — Widget styling basics"
+msgstr ""
+
+#: src/ui/camera.md:3
+msgid ""
+"The `perry/ui` module provides a live camera preview widget with color "
+"sampling capabilities."
+msgstr ""
+
+#: src/ui/camera.md:6
+msgid ""
+"```ts\n"
+"import {\n"
+"    CameraView,\n"
+"    cameraStart, cameraStop,\n"
+"    cameraFreeze, cameraUnfreeze,\n"
+"    cameraSampleColor, cameraSetOnTap,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:15
+msgid ""
+"**Platform support:** real capture is implemented on **iOS** "
+"(AVCaptureSession) and **Android** (Camera2). On **macOS**, **Linux** "
+"(GTK4), **Windows**, and the **Web** target the runtime exports no-op stubs "
+"so cross-platform code compiles and links cleanly — `CameraView()` returns "
+"handle 0 and `cameraSampleColor` returns `-1`. Wiring real capture on those "
+"platforms (AVFoundation on macOS, GStreamer/V4L2 on Linux, Media Foundation "
+"on Windows, `getUserMedia` on Web) is tracked as a follow-up."
+msgstr ""
+
+#: src/ui/camera.md:24 src/system/overview.md:43 src/plugins/overview.md:25
+msgid "Quick Example"
+msgstr ""
+
+#: src/ui/camera.md:26
+msgid ""
+"```ts\n"
+"const colorHex = State(\"#000000\")\n"
+"\n"
+"const cam = CameraView()\n"
+"cameraStart(cam)\n"
+"\n"
+"cameraSetOnTap(cam, (x: number, y: number) => {\n"
+"    const rgb = cameraSampleColor(x, y)\n"
+"    if (rgb >= 0) {\n"
+"        const r = Math.floor(rgb / 65536)\n"
+"        const g = Math.floor((rgb % 65536) / 256)\n"
+"        const b = Math.floor(rgb % 256)\n"
+"        colorHex.set(`#${r.toString(16).padStart(2, \"0\")}${g.toString(16).padStart(2, \"0\")}${b.toString(16).padStart(2, \"0\")}`)\n"
+"    }\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Color Picker\",\n"
+"    width: 400,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        cam,\n"
+"        Text(`Color: ${colorHex.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:53 src/system/audio.md:21 src/testing/geisterhand.md:45
+msgid "API Reference"
+msgstr ""
+
+#: src/ui/camera.md:55
+msgid "`CameraView()`"
+msgstr ""
+
+#: src/ui/camera.md:57
+msgid "Create a live camera preview widget."
+msgstr ""
+
+#: src/ui/camera.md:63
+msgid ""
+"Returns a widget handle. The camera does not start automatically — call "
+"`cameraStart()` to begin capture."
+msgstr ""
+
+#: src/ui/camera.md:65
+msgid "`cameraStart(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:67
+msgid "Start the live camera feed."
+msgstr ""
+
+#: src/ui/camera.md:73
+msgid ""
+"On iOS, the camera permission dialog is shown automatically on first use."
+msgstr ""
+
+#: src/ui/camera.md:75
+msgid "`cameraStop(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:77
+msgid "Stop the camera feed and release the capture session."
+msgstr ""
+
+#: src/ui/camera.md:83
+msgid "`cameraFreeze(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:85
+msgid "Pause the live preview (freeze the current frame)."
+msgstr ""
+
+#: src/ui/camera.md:91
+msgid ""
+"The camera session remains active but the preview stops updating. Useful for"
+" \"capture\" moments where you want to inspect the frozen frame."
+msgstr ""
+
+#: src/ui/camera.md:93
+msgid "`cameraUnfreeze(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:95
+msgid "Resume the live preview after a freeze."
+msgstr ""
+
+#: src/ui/camera.md:101
+msgid "`cameraSampleColor(x, y)`"
+msgstr ""
+
+#: src/ui/camera.md:103
+msgid "Sample the pixel color at normalized coordinates."
+msgstr ""
+
+#: src/ui/camera.md:105
+msgid ""
+"```ts\n"
+"const rgb = cameraSampleColor(0.5, 0.5) // center of frame\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:109
+msgid "`x`, `y` are normalized coordinates (0.0–1.0)"
+msgstr ""
+
+#: src/ui/camera.md:110
+msgid "Returns packed RGB as a number: `r * 65536 + g * 256 + b`"
+msgstr ""
+
+#: src/ui/camera.md:111
+msgid "Returns `-1` if no frame is available"
+msgstr ""
+
+#: src/ui/camera.md:113
+msgid "To extract individual channels:"
+msgstr ""
+
+#: src/ui/camera.md:121
+msgid ""
+"The color is averaged over a 5x5 pixel region around the sample point for "
+"noise reduction."
+msgstr ""
+
+#: src/ui/camera.md:123
+msgid "`cameraSetOnTap(handle, callback)`"
+msgstr ""
+
+#: src/ui/camera.md:125
+msgid "Register a tap handler on the camera view."
+msgstr ""
+
+#: src/ui/camera.md:127
+msgid ""
+"```ts\n"
+"cameraSetOnTap(preview, (tx: number, ty: number) => {\n"
+"    // tx, ty are normalized coordinates (0.0-1.0)\n"
+"    const tappedRgb = cameraSampleColor(tx, ty)\n"
+"    console.log(`tapped color: ${tappedRgb}`)\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:135
+msgid ""
+"The callback receives normalized coordinates of the tap location, which can "
+"be passed directly to `cameraSampleColor()`."
+msgstr ""
+
+#: src/ui/camera.md:139
+msgid ""
+"On iOS, the camera uses AVCaptureSession with AVCaptureVideoPreviewLayer for"
+" GPU-accelerated live preview, and AVCaptureVideoDataOutput for frame "
+"capture. Color sampling reads pixel data from CVPixelBuffer."
+msgstr ""
+
+#: src/ui/camera.md:141
+msgid ""
+"On Android, the camera uses Camera2 with a TextureView preview surface. "
+"Color sampling reads from the most recent ImageReader frame."
+msgstr ""
+
+#: src/ui/camera.md:146
+msgid ""
+"[Audio Capture](../system/audio.md) — Microphone input and sound metering"
+msgstr ""
+
+#: src/platforms/overview.md:1
+msgid "Platform Overview"
+msgstr ""
+
+#: src/platforms/overview.md:3
+msgid ""
+"Perry compiles TypeScript to native executables for 9 platform families from"
+" the same source code."
+msgstr ""
+
+#: src/platforms/overview.md:5
+msgid "Supported Platforms"
+msgstr ""
+
+#: src/platforms/overview.md:7 src/widgets/platforms.md:9
+msgid "Target Flag"
+msgstr ""
+
+#: src/platforms/overview.md:7 src/platforms/macos.md:20
+#: src/platforms/ios.md:46 src/platforms/tvos.md:46
+#: src/platforms/watchos.md:46 src/platforms/android.md:20
+#: src/platforms/windows.md:38 src/platforms/linux.md:30
+msgid "UI Toolkit"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "_(default)_"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "AppKit"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "Full support (127/127 FFI functions)"
+msgstr ""
+
+#: src/platforms/overview.md:10
+msgid "`--target ios` / `--target ios-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:10 src/platforms/overview.md:12
+#: src/platforms/tvos.md:178
+msgid "UIKit"
+msgstr ""
+
+#: src/platforms/overview.md:10
+msgid "Full support (127/127)"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "`--target visionos` / `--target visionos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "UIKit (2D windows)"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "Core support (2D only)"
+msgstr ""
+
+#: src/platforms/overview.md:12
+msgid "`--target tvos` / `--target tvos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:12
+msgid "Full support (focus engine + game controllers)"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "`--target watchos` / `--target watchos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "SwiftUI (data-driven)"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "Core support (15 widgets)"
+msgstr ""
+
+#: src/platforms/overview.md:14
+msgid "`--target android`"
+msgstr ""
+
+#: src/platforms/overview.md:14
+msgid "JNI/Android SDK"
+msgstr ""
+
+#: src/platforms/overview.md:14 src/platforms/overview.md:15
+#: src/platforms/overview.md:16
+msgid "Full support (112/112)"
+msgstr ""
+
+#: src/platforms/overview.md:15
+msgid "`--target windows`"
+msgstr ""
+
+#: src/platforms/overview.md:15
+msgid "Win32"
+msgstr ""
+
+#: src/platforms/overview.md:16
+msgid "`--target linux`"
+msgstr ""
+
+#: src/platforms/overview.md:16
+msgid "GTK4"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "Web / WebAssembly"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "`--target web` _(alias `--target wasm`)_"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "DOM/CSS via WASM bridge"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "Full support (168 widgets)"
+msgstr ""
+
+#: src/platforms/overview.md:19
+msgid "Cross-Compilation"
+msgstr ""
+
+#: src/platforms/overview.md:22
+msgid "# Default: compile for current platform\n"
+msgstr ""
+
+#: src/platforms/overview.md:24
+msgid "# Compile for a specific target\n"
+msgstr ""
+
+#: src/platforms/overview.md:36 src/platforms/visionos.md:49
+#: src/platforms/tvos.md:133 src/platforms/watchos.md:170
+msgid "Platform Detection"
+msgstr ""
+
+#: src/platforms/overview.md:38
+msgid "Use the `__platform__` compile-time constant to branch by platform:"
+msgstr ""
+
+#: src/platforms/overview.md:40
+msgid ""
+"```typescript\n"
+"declare const __platform__: number\n"
+"\n"
+"// Platform constants:\n"
+"// 0 = macOS\n"
+"// 1 = iOS\n"
+"// 2 = Android\n"
+"// 3 = Windows\n"
+"// 4 = Linux\n"
+"// 5 = Web (browser, --target web / --target wasm)\n"
+"// 6 = tvOS\n"
+"// 7 = watchOS\n"
+"// 8 = visionOS\n"
+"\n"
+"if (__platform__ === 0) {\n"
+"    console.log(\"Running on macOS\")\n"
+"} else if (__platform__ === 1) {\n"
+"    console.log(\"Running on iOS\")\n"
+"} else if (__platform__ === 3) {\n"
+"    console.log(\"Running on Windows\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/overview.md:63
+msgid ""
+"`__platform__` is resolved at compile time. The compiler constant-folds "
+"comparisons and eliminates dead branches, so platform-specific code has zero"
+" runtime cost."
+msgstr ""
+
+#: src/platforms/overview.md:65
+msgid "Platform Feature Matrix"
+msgstr ""
+
+#: src/platforms/overview.md:67
+msgid "Web (WASM)"
+msgstr ""
+
+#: src/platforms/overview.md:69
+msgid "CLI programs"
+msgstr ""
+
+#: src/platforms/overview.md:70
+msgid "Native UI (DOM on web)"
+msgstr ""
+
+#: src/platforms/overview.md:71
+msgid "Game engines"
+msgstr ""
+
+#: src/platforms/overview.md:71
+msgid "Via FFI"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "File system"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "Sandboxed"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "File System Access API"
+msgstr ""
+
+#: src/platforms/overview.md:73
+msgid "Networking"
+msgstr ""
+
+#: src/platforms/overview.md:73
+msgid "`fetch` / `WebSocket`"
+msgstr ""
+
+#: src/platforms/overview.md:74
+msgid "Partial"
+msgstr ""
+
+#: src/platforms/overview.md:74
+msgid "Minimal"
+msgstr ""
+
+#: src/platforms/overview.md:75
+msgid "Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Threading"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Native"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Web Workers"
+msgstr ""
+
+#: src/platforms/overview.md:80
+msgid "[macOS](macos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:81
+msgid "[iOS](ios.md)"
+msgstr ""
+
+#: src/platforms/overview.md:82
+msgid "[visionOS](visionos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:83
+msgid "[tvOS](tvos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:84
+msgid "[watchOS](watchos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:85
+msgid "[Android](android.md)"
+msgstr ""
+
+#: src/platforms/overview.md:86
+msgid "[Windows](windows.md)"
+msgstr ""
+
+#: src/platforms/overview.md:87
+msgid "[Linux (GTK4)](linux.md)"
+msgstr ""
+
+#: src/platforms/overview.md:88
+msgid "[Web](web.md)"
+msgstr ""
+
+#: src/platforms/overview.md:89
+msgid "[WebAssembly](wasm.md)"
+msgstr ""
+
+#: src/platforms/macos.md:3
+msgid ""
+"macOS is Perry's primary development platform. It uses AppKit for native UI."
+msgstr ""
+
+#: src/platforms/macos.md:5 src/platforms/ios.md:5 src/platforms/tvos.md:7
+#: src/platforms/watchos.md:7 src/platforms/android.md:5
+#: src/platforms/windows.md:5 src/platforms/linux.md:5
+#: src/plugins/native-extensions.md:271
+msgid "Requirements"
+msgstr ""
+
+#: src/platforms/macos.md:7
+msgid "macOS 13+ (Ventura or later)"
+msgstr ""
+
+#: src/platforms/macos.md:8
+msgid "Xcode Command Line Tools: `xcode-select --install`"
+msgstr ""
+
+#: src/platforms/macos.md:10 src/platforms/android.md:14
+#: src/platforms/windows.md:32 src/platforms/linux.md:23
+#: src/platforms/wasm.md:7 src/widgets/overview.md:48
+msgid "Building"
+msgstr ""
+
+#: src/platforms/macos.md:13
+msgid "# macOS is the default target\n"
+msgstr ""
+
+#: src/platforms/macos.md:18
+msgid "No additional flags needed — macOS is the default compilation target."
+msgstr ""
+
+#: src/platforms/macos.md:22
+msgid "Perry maps UI widgets to AppKit controls:"
+msgstr ""
+
+#: src/platforms/macos.md:24 src/platforms/ios.md:50 src/platforms/tvos.md:50
+#: src/platforms/watchos.md:50 src/platforms/android.md:24
+#: src/platforms/windows.md:42 src/platforms/linux.md:34
+#: src/platforms/wasm.md:55
+msgid "Perry Widget"
+msgstr ""
+
+#: src/platforms/macos.md:24
+msgid "AppKit Class"
+msgstr ""
+
+#: src/platforms/macos.md:26
+msgid "NSTextField (label mode)"
+msgstr ""
+
+#: src/platforms/macos.md:29
+msgid "NSSecureTextField"
+msgstr ""
+
+#: src/platforms/macos.md:30
+msgid "NSSwitch"
+msgstr ""
+
+#: src/platforms/macos.md:31
+msgid "NSSlider"
+msgstr ""
+
+#: src/platforms/macos.md:32
+msgid "NSPopUpButton"
+msgstr ""
+
+#: src/platforms/macos.md:33 src/platforms/ios.md:59 src/platforms/tvos.md:58
+#: src/platforms/watchos.md:61 src/platforms/android.md:33
+#: src/platforms/windows.md:52 src/platforms/linux.md:44
+#: src/widgets/components.md:83
+msgid "Image"
+msgstr ""
+
+#: src/platforms/macos.md:33
+msgid "NSImageView"
+msgstr ""
+
+#: src/platforms/macos.md:34 src/platforms/ios.md:60 src/platforms/tvos.md:59
+#: src/platforms/windows.md:53
+msgid "VStack/HStack"
+msgstr ""
+
+#: src/platforms/macos.md:35
+msgid "NSScrollView"
+msgstr ""
+
+#: src/platforms/macos.md:36
+msgid "NSTableView"
+msgstr ""
+
+#: src/platforms/macos.md:37
+msgid "NSView + Core Graphics"
+msgstr ""
+
+#: src/platforms/macos.md:39 src/cli/perry-toml.md:179
+#: src/cli/perry-toml.md:258
+msgid "Code Signing"
+msgstr ""
+
+#: src/platforms/macos.md:41
+msgid ""
+"For distribution, apps need to be signed. Perry supports automatic signing:"
+msgstr ""
+
+#: src/platforms/macos.md:47
+msgid ""
+"This auto-detects your signing identity from the macOS Keychain, exports it "
+"to a temporary `.p12` file, and signs the binary."
+msgstr ""
+
+#: src/platforms/macos.md:49
+msgid "For manual signing:"
+msgstr ""
+
+#: src/platforms/macos.md:52
+msgid "\"Developer ID Application: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:55
+msgid "App Store Distribution"
+msgstr ""
+
+#: src/platforms/macos.md:58
+msgid "# Sign with App Store certificate\n"
+msgstr ""
+
+#: src/platforms/macos.md:60
+msgid "\"3rd Party Mac Developer Application: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:60
+msgid "# Package\n"
+msgstr ""
+
+#: src/platforms/macos.md:62
+msgid "\"3rd Party Mac Developer Installer: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:65
+msgid "macOS-Specific Features"
+msgstr ""
+
+#: src/platforms/macos.md:67
+msgid "**Menu bar**: Full NSMenu support with keyboard shortcuts"
+msgstr ""
+
+#: src/platforms/macos.md:68
+msgid "**Toolbar**: NSToolbar integration"
+msgstr ""
+
+#: src/platforms/macos.md:69
+msgid "**Dock icon**: Automatic for GUI apps"
+msgstr ""
+
+#: src/platforms/macos.md:70
+msgid "**Dark mode**: `isDarkMode()` detects system appearance"
+msgstr ""
+
+#: src/platforms/macos.md:71
+msgid "**Keychain**: Secure storage via Security.framework"
+msgstr ""
+
+#: src/platforms/macos.md:72
+msgid "**Notifications**: Local notifications via UNUserNotificationCenter"
+msgstr ""
+
+#: src/platforms/macos.md:73
+msgid "**File dialogs**: NSOpenPanel/NSSavePanel"
+msgstr ""
+
+#: src/platforms/macos.md:77
+msgid ""
+"```typescript\n"
+"import { openURL, isDarkMode, preferencesSet, preferencesGet } from \"perry/system\"\n"
+"\n"
+"openURL(\"https://example.com\")          // Opens in default browser\n"
+"const dark = isDarkMode()               // Check appearance\n"
+"preferencesSet(\"key\", \"value\")          // NSUserDefaults\n"
+"const val = preferencesGet(\"key\")       // NSUserDefaults\n"
+"```"
+msgstr ""
+
+#: src/platforms/macos.md:88
+msgid "[iOS](ios.md) — Cross-compile for iPhone/iPad"
+msgstr ""
+
+#: src/platforms/macos.md:89
+msgid "[UI Overview](../ui/overview.md) — Full UI documentation"
+msgstr ""
+
+#: src/platforms/macos.md:90
+msgid "[System APIs](../system/overview.md) — System integration"
+msgstr ""
+
+#: src/platforms/ios.md:3
+msgid ""
+"Perry can cross-compile TypeScript apps for iOS devices and the iOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/ios.md:7 src/platforms/tvos.md:9 src/platforms/watchos.md:9
+msgid "macOS host (cross-compilation from Linux/Windows is not supported)"
+msgstr ""
+
+#: src/platforms/ios.md:8
+msgid ""
+"Xcode (full install, not just Command Line Tools) for iOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/ios.md:9
+msgid "Rust iOS targets:"
+msgstr ""
+
+#: src/platforms/ios.md:14 src/platforms/tvos.md:16
+#: src/platforms/watchos.md:16
+msgid "Building for Simulator"
+msgstr ""
+
+#: src/platforms/ios.md:20
+msgid ""
+"This uses LLVM cross-compilation with the iOS Simulator SDK. The binary can "
+"be run in the Xcode Simulator."
+msgstr ""
+
+#: src/platforms/ios.md:22 src/platforms/tvos.md:24
+#: src/platforms/watchos.md:24
+msgid "Building for Device"
+msgstr ""
+
+#: src/platforms/ios.md:28
+msgid ""
+"This produces an ARM64 binary for physical iOS devices. You'll need to code "
+"sign and package it in an `.app` bundle for deployment."
+msgstr ""
+
+#: src/platforms/ios.md:30 src/platforms/tvos.md:32
+#: src/platforms/watchos.md:32
+msgid "Running with `perry run`"
+msgstr ""
+
+#: src/platforms/ios.md:32
+msgid "The easiest way to build and run on iOS is `perry run`:"
+msgstr ""
+
+#: src/platforms/ios.md:35
+msgid "# Auto-detect device/simulator\n"
+msgstr ""
+
+#: src/platforms/ios.md:36
+msgid "# Stream live stdout/stderr\n"
+msgstr ""
+
+#: src/platforms/ios.md:37
+msgid "# Use Perry Hub build server\n"
+msgstr ""
+
+#: src/platforms/ios.md:40
+msgid ""
+"Perry auto-discovers available simulators (via `simctl`) and physical "
+"devices (via `devicectl`). When multiple targets are found, an interactive "
+"prompt lets you choose."
+msgstr ""
+
+#: src/platforms/ios.md:42
+msgid ""
+"For physical devices, Perry handles code signing automatically — it reads "
+"your signing identity and team ID from `~/.perry/config.toml` (set up via "
+"`perry setup ios`), embeds the provisioning profile, and signs the `.app` "
+"before installing."
+msgstr ""
+
+#: src/platforms/ios.md:44
+msgid ""
+"If you don't have the iOS cross-compilation toolchain installed locally, "
+"`perry run ios` automatically falls back to Perry Hub's remote build server."
+msgstr ""
+
+#: src/platforms/ios.md:48
+msgid "Perry maps UI widgets to UIKit controls:"
+msgstr ""
+
+#: src/platforms/ios.md:50 src/platforms/tvos.md:50
+msgid "UIKit Class"
+msgstr ""
+
+#: src/platforms/ios.md:53
+msgid "UIButton (TouchUpInside)"
+msgstr ""
+
+#: src/platforms/ios.md:54 src/platforms/tvos.md:54
+msgid "UITextField"
+msgstr ""
+
+#: src/platforms/ios.md:55
+msgid "UITextField (secureTextEntry)"
+msgstr ""
+
+#: src/platforms/ios.md:56 src/platforms/tvos.md:55
+msgid "UISwitch"
+msgstr ""
+
+#: src/platforms/ios.md:57
+msgid "UISlider (Float32, cast at boundary)"
+msgstr ""
+
+#: src/platforms/ios.md:58 src/platforms/tvos.md:57
+msgid "UIPickerView"
+msgstr ""
+
+#: src/platforms/ios.md:59 src/platforms/tvos.md:58
+msgid "UIImageView"
+msgstr ""
+
+#: src/platforms/ios.md:61 src/platforms/tvos.md:60
+msgid "UIScrollView"
+msgstr ""
+
+#: src/platforms/ios.md:65
+msgid "iOS apps use `UIApplicationMain` with a deferred creation pattern:"
+msgstr ""
+
+#: src/platforms/ios.md:67
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My iOS App\",\n"
+"    width: 400,\n"
+"    height: 800,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello, iPhone!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/ios.md:80
+msgid ""
+"The `App()` call triggers `UIApplicationMain`, and your render function is "
+"called via `PerryAppDelegate` once the app is ready."
+msgstr ""
+
+#: src/platforms/ios.md:82
+msgid "iOS Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/ios.md:84
+msgid ""
+"Perry can compile TypeScript widget declarations to native SwiftUI WidgetKit"
+" extensions:"
+msgstr ""
+
+#: src/platforms/ios.md:90
+msgid "See [Widgets (WidgetKit)](../widgets/overview.md) for details."
+msgstr ""
+
+#: src/platforms/ios.md:92 src/platforms/android.md:51
+msgid "Splash Screen"
+msgstr ""
+
+#: src/platforms/ios.md:94
+msgid ""
+"Perry auto-generates a native `LaunchScreen.storyboard` from the "
+"`perry.splash` config in `package.json`. The splash screen appears instantly"
+" during cold start."
+msgstr ""
+
+#: src/platforms/ios.md:107
+msgid ""
+"The image is centered at 128x128pt with `scaleAspectFit`. You can provide a "
+"custom storyboard for full control:"
+msgstr ""
+
+#: src/platforms/ios.md:119 src/platforms/android.md:83
+msgid ""
+"See [Project Configuration](../getting-started/project-config.md#splash) for"
+" the full config reference."
+msgstr ""
+
+#: src/platforms/ios.md:121
+msgid "Resource Bundling"
+msgstr ""
+
+#: src/platforms/ios.md:123
+msgid ""
+"Perry automatically bundles `logo/` and `assets/` directories from your "
+"project root into the `.app` bundle. These resources are available at "
+"runtime via standard file APIs relative to the app bundle path."
+msgstr ""
+
+#: src/platforms/ios.md:125
+msgid "Keyboard Avoidance"
+msgstr ""
+
+#: src/platforms/ios.md:127
+msgid ""
+"Perry apps automatically handle keyboard avoidance on iOS. When the keyboard"
+" appears, the root view adjusts its bottom constraint with an animated "
+"layout transition, and focused TextFields are auto-scrolled into view above "
+"the keyboard."
+msgstr ""
+
+#: src/platforms/ios.md:129
+msgid "Differences from macOS"
+msgstr ""
+
+#: src/platforms/ios.md:131
+msgid ""
+"**No menu bar**: iOS doesn't support menu bars. Use toolbar or navigation "
+"patterns."
+msgstr ""
+
+#: src/platforms/ios.md:132
+msgid ""
+"**Touch events**: `onHover` is not available. Use `onClick` (mapped to "
+"touch)."
+msgstr ""
+
+#: src/platforms/ios.md:133
+msgid ""
+"**Slider precision**: iOS UISlider uses Float32 internally (automatically "
+"converted)."
+msgstr ""
+
+#: src/platforms/ios.md:134
+msgid "**File dialogs**: Limited to UIDocumentPicker."
+msgstr ""
+
+#: src/platforms/ios.md:135
+msgid "**Keyboard shortcuts**: Not applicable on iOS."
+msgstr ""
+
+#: src/platforms/ios.md:139
+msgid ""
+"[Widgets (WidgetKit)](../widgets/overview.md) — iOS home screen widgets"
+msgstr ""
+
+#: src/platforms/ios.md:140 src/platforms/tvos.md:184
+#: src/platforms/watchos.md:217 src/platforms/android.md:94
+#: src/platforms/windows.md:71 src/platforms/linux.md:83
+#: src/platforms/wasm.md:193
+msgid "[Platform Overview](overview.md) — All platforms"
+msgstr ""
+
+#: src/platforms/ios.md:141 src/platforms/watchos.md:218
+#: src/platforms/android.md:95 src/platforms/windows.md:72
+#: src/platforms/linux.md:84 src/platforms/wasm.md:194
+msgid "[UI Overview](../ui/overview.md) — UI system"
+msgstr ""
+
+#: src/platforms/visionos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple Vision Pro devices and the "
+"visionOS Simulator."
+msgstr ""
+
+#: src/platforms/visionos.md:5
+msgid ""
+"This first pass targets **2D windowed apps only**. Perry uses the same "
+"UIKit-style `perry/ui` model as iOS, packaged for visionOS app bundles and "
+"scene lifecycle."
+msgstr ""
+
+#: src/platforms/visionos.md:9
+msgid "macOS with Xcode installed"
+msgstr ""
+
+#: src/platforms/visionos.md:10
+msgid "Rust visionOS targets:"
+msgstr ""
+
+#: src/platforms/visionos.md:16
+msgid "Compile"
+msgstr ""
+
+#: src/platforms/visionos.md:23
+msgid ""
+"This produces a `.app` bundle with visionOS-specific `Info.plist` metadata "
+"and a `UIWindowScene` configuration."
+msgstr ""
+
+#: src/platforms/visionos.md:25
+msgid "Run"
+msgstr ""
+
+#: src/platforms/visionos.md:33
+msgid ""
+"Perry auto-detects booted Apple Vision Pro simulators via `simctl`. Physical"
+" device installs use `devicectl`, like other modern Apple platforms."
+msgstr ""
+
+#: src/platforms/visionos.md:37
+msgid "Configure visionOS-specific settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/visionos.md:39
+msgid ""
+"```toml\n"
+"[visionos]\n"
+"bundle_id = \"com.example.myvisionapp\"\n"
+"deployment_target = \"1.0\"\n"
+"entry = \"src/main_visionos.ts\"\n"
+"encryption_exempt = true\n"
+"```"
+msgstr ""
+
+#: src/platforms/visionos.md:47
+msgid ""
+"Custom `Info.plist` keys can be merged through `[visionos.info_plist]`."
+msgstr ""
+
+#: src/platforms/visionos.md:51
+msgid "Use `__platform__ === 8` to detect visionOS at compile time:"
+msgstr ""
+
+#: src/platforms/visionos.md:53
+msgid ""
+"```typescript\n"
+"function reportVisionos(): void {\n"
+"    if (__platform__ === 8) {\n"
+"        console.log(\"Running on visionOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/visionos.md:61
+msgid "Current Scope"
+msgstr ""
+
+#: src/platforms/visionos.md:63
+msgid ""
+"Supported: 2D windowed apps, simulator/device app bundles, `perry run`, "
+"`perry setup`, `perry publish`"
+msgstr ""
+
+#: src/platforms/visionos.md:64
+msgid ""
+"Not supported yet: immersive spaces, volumes, RealityKit scene generation, "
+"Geisterhand"
+msgstr ""
+
+#: src/platforms/visionos.md:66
+msgid "Related"
+msgstr ""
+
+#: src/platforms/visionos.md:68
+msgid "[iOS](ios.md) — shared UIKit foundation"
+msgstr ""
+
+#: src/platforms/visionos.md:69
+msgid "[Platform Overview](overview.md)"
+msgstr ""
+
+#: src/platforms/tvos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple TV devices and the tvOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/tvos.md:5
+msgid ""
+"tvOS uses UIKit (the same framework as iOS), so Perry's tvOS support shares "
+"the same UIKit-based widget system. The primary difference is input: Apple "
+"TV apps are controlled via the Siri Remote and game controllers rather than "
+"touch, and all apps run full-screen."
+msgstr ""
+
+#: src/platforms/tvos.md:10
+msgid "Xcode (full install) for tvOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/tvos.md:11
+msgid "Rust tvOS targets:"
+msgstr ""
+
+#: src/platforms/tvos.md:22
+msgid ""
+"This produces an ARM64 binary linked with `clang` against the tvOS Simulator"
+" SDK, wrapped in a `.app` bundle."
+msgstr ""
+
+#: src/platforms/tvos.md:30
+msgid "This produces an ARM64 binary for physical Apple TV hardware."
+msgstr ""
+
+#: src/platforms/tvos.md:35
+msgid "# Auto-detect booted Apple TV simulator\n"
+msgstr ""
+
+#: src/platforms/tvos.md:39
+msgid ""
+"Perry auto-discovers booted Apple TV simulators. To install and launch "
+"manually:"
+msgstr ""
+
+#: src/platforms/tvos.md:48
+msgid "Perry maps UI widgets to UIKit controls on tvOS, identical to iOS:"
+msgstr ""
+
+#: src/platforms/tvos.md:50 src/platforms/tvos.md:149
+#: src/platforms/watchos.md:50 src/system/media.md:37
+#: src/testing/geisterhand.md:257 src/cli/flags.md:20
+msgid "Notes"
+msgstr ""
+
+#: src/platforms/tvos.md:53
+msgid "Focus-based navigation"
+msgstr ""
+
+#: src/platforms/tvos.md:54
+msgid "On-screen keyboard via Siri Remote"
+msgstr ""
+
+#: src/platforms/tvos.md:56
+msgid "UISlider"
+msgstr ""
+
+#: src/platforms/tvos.md:60
+msgid "Focus-based scrolling"
+msgstr ""
+
+#: src/platforms/tvos.md:62
+msgid "Focus Engine"
+msgstr ""
+
+#: src/platforms/tvos.md:64
+msgid ""
+"tvOS uses a **focus-based navigation model** instead of direct touch. The "
+"Siri Remote's touchpad and directional buttons move focus between focusable "
+"views. Perry widgets that support interaction (buttons, text fields, "
+"toggles, etc.) are automatically focusable."
+msgstr ""
+
+#: src/platforms/tvos.md:66
+msgid "Game Engine Support"
+msgstr ""
+
+#: src/platforms/tvos.md:68
+msgid ""
+"tvOS is particularly well-suited for game engines. When using a native "
+"library like [Bloom](https://bloomengine.dev), the game engine handles its "
+"own windowing, rendering, and input."
+msgstr ""
+
+#: src/platforms/tvos.md:70
+msgid ""
+"**Status:** illustrative only — Bloom is an external native library (see "
+"[bloomengine.dev](https://bloomengine.dev)). The snippet below is left as "
+"`,no-test` because it depends on Bloom's `.a`/`.so` being available at link "
+"time; the doc-tests harness compiles every other snippet on this page."
+msgstr ""
+
+#: src/platforms/tvos.md:72
+msgid ""
+"```text\n"
+"import { initWindow, windowShouldClose, beginDrawing, endDrawing,\n"
+"         clearBackground, isGamepadButtonDown, Colors } from \"bloom\";\n"
+"\n"
+"initWindow(1920, 1080, \"My Apple TV Game\");\n"
+"\n"
+"while (!windowShouldClose()) {\n"
+"  beginDrawing();\n"
+"  clearBackground(Colors.BLACK);\n"
+"\n"
+"  if (isGamepadButtonDown(0)) {\n"
+"    // A button (Siri Remote select) pressed\n"
+"  }\n"
+"\n"
+"  endDrawing();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:90
+msgid "Input on tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:92
+msgid "The Siri Remote acts as a game controller:"
+msgstr ""
+
+#: src/platforms/tvos.md:94
+msgid "Input"
+msgstr ""
+
+#: src/platforms/tvos.md:94
+msgid "Mapping"
+msgstr ""
+
+#: src/platforms/tvos.md:96
+msgid "Touchpad swipe"
+msgstr ""
+
+#: src/platforms/tvos.md:96
+msgid "Gamepad axes 0/1 (left stick)"
+msgstr ""
+
+#: src/platforms/tvos.md:97
+msgid "Touchpad click (Select)"
+msgstr ""
+
+#: src/platforms/tvos.md:97
+msgid "Gamepad button 0 (A) + mouse button 0"
+msgstr ""
+
+#: src/platforms/tvos.md:98
+msgid "Menu button"
+msgstr ""
+
+#: src/platforms/tvos.md:98
+msgid "Gamepad button 1 (B)"
+msgstr ""
+
+#: src/platforms/tvos.md:99
+msgid "Play/Pause button"
+msgstr ""
+
+#: src/platforms/tvos.md:99
+msgid "Gamepad button 9 (Start)"
+msgstr ""
+
+#: src/platforms/tvos.md:100
+msgid "Arrow presses (up/down/left/right)"
+msgstr ""
+
+#: src/platforms/tvos.md:100
+msgid "Gamepad D-pad buttons (12-15)"
+msgstr ""
+
+#: src/platforms/tvos.md:102
+msgid ""
+"Extended game controllers (MFi, PlayStation, Xbox) are fully supported with "
+"all axes, buttons, triggers, and D-pad mapped through the standard gamepad "
+"API."
+msgstr ""
+
+#: src/platforms/tvos.md:106
+msgid ""
+"tvOS apps use `UIApplicationMain` with the same lifecycle as iOS. When using"
+" `perry/ui`:"
+msgstr ""
+
+#: src/platforms/tvos.md:108
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My TV App\",\n"
+"    width: 1920,\n"
+"    height: 1080,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello, Apple TV!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:121
+msgid ""
+"When using a game engine with `--features ios-game-loop`, the runtime starts"
+" `UIApplicationMain` on the main thread and runs your game code on a "
+"dedicated game thread."
+msgstr ""
+
+#: src/platforms/tvos.md:125
+msgid "Configure tvOS settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/tvos.md:127
+msgid ""
+"```toml\n"
+"[tvos]\n"
+"bundle_id = \"com.example.mytvapp\"\n"
+"deployment_target = \"17.0\"\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:135
+msgid "Use `__platform__ === 6` to detect tvOS at compile time:"
+msgstr ""
+
+#: src/platforms/tvos.md:137
+msgid ""
+"```typescript\n"
+"function reportTvos(): void {\n"
+"    if (__platform__ === 6) {\n"
+"        console.log(\"Running on tvOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:145
+msgid "App Bundle"
+msgstr ""
+
+#: src/platforms/tvos.md:147
+msgid "Perry generates a `.app` bundle with an `Info.plist` containing:"
+msgstr ""
+
+#: src/platforms/tvos.md:149 src/cli/perry-toml.md:367
+msgid "Key"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "`UIDeviceFamily`"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "`[3]`"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "Apple TV"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "`MinimumOSVersion`"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "`17.0`"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "tvOS 17+"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "`UIRequiresFullScreen`"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "`true`"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "All tvOS apps are full-screen"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "`UILaunchStoryboardName`"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "`LaunchScreen`"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "Required by tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:158
+msgid ""
+"tvOS has inherent platform constraints compared to other Perry targets:"
+msgstr ""
+
+#: src/platforms/tvos.md:160
+msgid "**No camera**: Apple TV has no camera hardware"
+msgstr ""
+
+#: src/platforms/tvos.md:161
+msgid "**No clipboard**: UIPasteboard is not available on tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:162
+msgid "**No file dialogs**: No document picker"
+msgstr ""
+
+#: src/platforms/tvos.md:163
+msgid "**No QR code**: No camera for scanning"
+msgstr ""
+
+#: src/platforms/tvos.md:164
+msgid "**No multi-window**: Single full-screen window only"
+msgstr ""
+
+#: src/platforms/tvos.md:165
+msgid ""
+"**No direct touch**: Input is via Siri Remote focus engine and game "
+"controllers"
+msgstr ""
+
+#: src/platforms/tvos.md:166
+msgid ""
+"**Resolution**: Design for 1920x1080 (1080p) or 3840x2160 (4K) displays"
+msgstr ""
+
+#: src/platforms/tvos.md:168 src/platforms/watchos.md:206
+msgid "Differences from iOS"
+msgstr ""
+
+#: src/platforms/tvos.md:170
+msgid "Aspect"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "**Input**"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "Siri Remote + game controllers (focus engine)"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "Direct touch"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "**Display**"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "Full-screen only (1080p/4K)"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "Variable screen sizes"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "**Device family**"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "`[3]` (Apple TV)"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "`[1, 2]` (iPhone/iPad)"
+msgstr ""
+
+#: src/platforms/tvos.md:175
+msgid "**Camera**"
+msgstr ""
+
+#: src/platforms/tvos.md:175 src/platforms/tvos.md:176
+msgid "Not available"
+msgstr ""
+
+#: src/platforms/tvos.md:175 src/platforms/tvos.md:176
+msgid "Available"
+msgstr ""
+
+#: src/platforms/tvos.md:176
+msgid "**Clipboard**"
+msgstr ""
+
+#: src/platforms/tvos.md:177
+msgid "**Deployment target**"
+msgstr ""
+
+#: src/platforms/tvos.md:177
+msgid "17.0"
+msgstr ""
+
+#: src/platforms/tvos.md:178
+msgid "**UI framework**"
+msgstr ""
+
+#: src/platforms/tvos.md:178
+msgid "UIKit (same as iOS)"
+msgstr ""
+
+#: src/platforms/tvos.md:182
+msgid "[iOS](ios.md) — iOS platform reference (shared UIKit base)"
+msgstr ""
+
+#: src/platforms/tvos.md:183
+msgid "[watchOS](watchos.md) — watchOS platform reference"
+msgstr ""
+
+#: src/platforms/watchos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple Watch devices and the watchOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/watchos.md:5
+msgid ""
+"Since watchOS does not support UIKit views, Perry uses a **data-driven "
+"SwiftUI renderer**: your TypeScript code builds a UI tree via the standard "
+"`perry/ui` API, and a fixed SwiftUI runtime (shipped with Perry) queries the"
+" tree and renders it reactively. No code generation or transpilation is "
+"involved — the binary is fully native."
+msgstr ""
+
+#: src/platforms/watchos.md:10
+msgid "Xcode (full install) for watchOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/watchos.md:11
+msgid "Rust watchOS targets:"
+msgstr ""
+
+#: src/platforms/watchos.md:22
+msgid ""
+"This produces an ARM64 binary linked with `swiftc` against the watchOS "
+"Simulator SDK, wrapped in a `.app` bundle."
+msgstr ""
+
+#: src/platforms/watchos.md:30
+msgid ""
+"This produces an arm64_32 (ILP32) binary for physical Apple Watch hardware. "
+"Apple Watch uses 32-bit pointers on 64-bit ARM."
+msgstr ""
+
+#: src/platforms/watchos.md:35
+msgid "# Auto-detect booted watch simulator\n"
+msgstr ""
+
+#: src/platforms/watchos.md:39
+msgid ""
+"Perry auto-discovers booted Apple Watch simulators. To install and launch "
+"manually:"
+msgstr ""
+
+#: src/platforms/watchos.md:48
+msgid "Perry maps UI widgets to SwiftUI views via a data-driven bridge:"
+msgstr ""
+
+#: src/platforms/watchos.md:50
+msgid "SwiftUI View"
+msgstr ""
+
+#: src/platforms/watchos.md:52
+msgid "Font size, weight, color, wrapping"
+msgstr ""
+
+#: src/platforms/watchos.md:53
+msgid "Tap action via native closure callback"
+msgstr ""
+
+#: src/platforms/watchos.md:54 src/platforms/watchos.md:55
+msgid "With spacing"
+msgstr ""
+
+#: src/platforms/watchos.md:56
+msgid "Layered views"
+msgstr ""
+
+#: src/platforms/watchos.md:59
+msgid "Two-way state binding"
+msgstr ""
+
+#: src/platforms/watchos.md:60
+msgid "Min/max/value, state binding"
+msgstr ""
+
+#: src/platforms/watchos.md:61
+msgid "Image(systemName:)"
+msgstr ""
+
+#: src/platforms/watchos.md:61
+msgid "SF Symbols"
+msgstr ""
+
+#: src/platforms/watchos.md:63
+msgid "Linear"
+msgstr ""
+
+#: src/platforms/watchos.md:64
+msgid "Selection list"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "Form"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "List"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "Maps to List on watchOS"
+msgstr ""
+
+#: src/platforms/watchos.md:66 src/platforms/android.md:39
+#: src/platforms/linux.md:50
+msgid "NavigationStack"
+msgstr ""
+
+#: src/platforms/watchos.md:66
+msgid "Push navigation"
+msgstr ""
+
+#: src/platforms/watchos.md:68 src/widgets/components.md:136
+msgid "Modifiers"
+msgstr ""
+
+#: src/platforms/watchos.md:70
+msgid "All widgets support these styling modifiers:"
+msgstr ""
+
+#: src/platforms/watchos.md:72
+msgid "`foregroundColor` / `backgroundColor`"
+msgstr ""
+
+#: src/platforms/watchos.md:73
+msgid "`font` (size, weight, family)"
+msgstr ""
+
+#: src/platforms/watchos.md:74
+msgid "`frame` (width, height)"
+msgstr ""
+
+#: src/platforms/watchos.md:75
+msgid "`padding` (uniform or per-edge)"
+msgstr ""
+
+#: src/platforms/watchos.md:76
+msgid "`cornerRadius`"
+msgstr ""
+
+#: src/platforms/watchos.md:78
+msgid "`hidden` / `disabled`"
+msgstr ""
+
+#: src/platforms/watchos.md:82
+msgid ""
+"watchOS apps use SwiftUI's `@main App` pattern. Perry's PerryWatchApp.swift "
+"runtime handles the app lifecycle automatically:"
+msgstr ""
+
+#: src/platforms/watchos.md:84
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack, Button } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My Watch App\",\n"
+"    width: 200,\n"
+"    height: 200,\n"
+"    body: VStack(8, [\n"
+"        Text(\"Hello, Apple Watch!\"),\n"
+"        Button(\"Tap me\", () => {\n"
+"            console.log(\"Button tapped!\")\n"
+"        }),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:100
+msgid "Under the hood:"
+msgstr ""
+
+#: src/platforms/watchos.md:101
+msgid ""
+"`perry_main_init()` runs your compiled TypeScript, which builds the UI tree "
+"in memory"
+msgstr ""
+
+#: src/platforms/watchos.md:102
+msgid "The SwiftUI `@main` struct observes the tree version and renders it"
+msgstr ""
+
+#: src/platforms/watchos.md:103
+msgid ""
+"User interactions (button taps, toggle changes) call back into native "
+"closures"
+msgstr ""
+
+#: src/platforms/watchos.md:107
+msgid "Reactive state works the same as other platforms:"
+msgstr ""
+
+#: src/platforms/watchos.md:109 src/platforms/wasm.md:166
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack, Button, State } from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"App({\n"
+"    title: \"Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Count: ${count.value}`),\n"
+"        Button(\"Increment\", () => count.set(count.value + 1)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:125
+msgid ""
+"When `state.set()` is called, the tree version increments and SwiftUI re-"
+"renders the affected views automatically."
+msgstr ""
+
+#: src/platforms/watchos.md:129
+msgid ""
+"Unlike iOS (UIKit) and macOS (AppKit), where Perry calls native view APIs "
+"directly via FFI, watchOS uses a **data-driven architecture**:"
+msgstr ""
+
+#: src/platforms/watchos.md:147
+msgid ""
+"The `PerryWatchApp.swift` file is a fixed runtime (~280 lines) that ships "
+"with Perry. It never changes per-app — it's the watchOS equivalent of "
+"`libperry_ui_ios.a`."
+msgstr ""
+
+#: src/platforms/watchos.md:151
+msgid "Configure watchOS settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/watchos.md:153
+msgid ""
+"```toml\n"
+"[watchos]\n"
+"bundle_id = \"com.example.mywatch\"\n"
+"deployment_target = \"10.0\"\n"
+"\n"
+"[watchos.info_plist]\n"
+"NSLocationWhenInUseUsageDescription = \"Used for location features\"\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:162
+msgid "Set up signing credentials with:"
+msgstr ""
+
+#: src/platforms/watchos.md:168
+msgid ""
+"This shares App Store Connect credentials with iOS/macOS (same team, API "
+"key, issuer)."
+msgstr ""
+
+#: src/platforms/watchos.md:172
+msgid "Use `__platform__ === 7` to detect watchOS at compile time:"
+msgstr ""
+
+#: src/platforms/watchos.md:174
+msgid ""
+"```typescript\n"
+"function reportWatchos(): void {\n"
+"    if (__platform__ === 7) {\n"
+"        console.log(\"Running on watchOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:182
+msgid "watchOS Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/watchos.md:184
+msgid ""
+"Perry also supports watchOS WidgetKit complications (separate from full "
+"apps):"
+msgstr ""
+
+#: src/platforms/watchos.md:190
+msgid ""
+"See [watchOS Complications](../widgets/watchos.md) for widget-specific "
+"documentation."
+msgstr ""
+
+#: src/platforms/watchos.md:194
+msgid ""
+"watchOS apps have inherent platform constraints compared to other Perry "
+"targets:"
+msgstr ""
+
+#: src/platforms/watchos.md:196
+msgid "**No Canvas**: CoreGraphics drawing is not available"
+msgstr ""
+
+#: src/platforms/watchos.md:197
+msgid "**No Camera**: watchOS does not support camera APIs"
+msgstr ""
+
+#: src/platforms/watchos.md:198
+msgid "**No TextField**: Text input is extremely limited on Apple Watch"
+msgstr ""
+
+#: src/platforms/watchos.md:199
+msgid "**No File Dialogs**: No document picker"
+msgstr ""
+
+#: src/platforms/watchos.md:200
+msgid "**No Menu Bar / Toolbar**: Not applicable on watch"
+msgstr ""
+
+#: src/platforms/watchos.md:201
+msgid "**No Multi-Window**: Single window only"
+msgstr ""
+
+#: src/platforms/watchos.md:202
+msgid "**No QR Code**: Screen too small for practical QR display"
+msgstr ""
+
+#: src/platforms/watchos.md:203
+msgid ""
+"**Memory**: watchOS devices have ~50-75MB available RAM — keep apps "
+"lightweight"
+msgstr ""
+
+#: src/platforms/watchos.md:204
+msgid "**Screen size**: Design for 40-49mm watch faces"
+msgstr ""
+
+#: src/platforms/watchos.md:208
+msgid ""
+"**SwiftUI vs UIKit**: watchOS uses SwiftUI rendering; iOS uses UIKit "
+"directly"
+msgstr ""
+
+#: src/platforms/watchos.md:209
+msgid "**No splash screen**: watchOS apps don't use launch storyboards"
+msgstr ""
+
+#: src/platforms/watchos.md:210
+msgid ""
+"**Standalone**: watchOS apps are standalone (no iPhone companion required, "
+"`WKWatchOnly = true`)"
+msgstr ""
+
+#: src/platforms/watchos.md:211
+msgid ""
+"**Device family**: `UIDeviceFamily = [4]` (watch) vs `[1, 2]` (iPhone/iPad)"
+msgstr ""
+
+#: src/platforms/watchos.md:215
+msgid ""
+"[watchOS Complications](../widgets/watchos.md) — WidgetKit complications"
+msgstr ""
+
+#: src/platforms/watchos.md:216
+msgid "[iOS](ios.md) — iOS platform reference"
+msgstr ""
+
+#: src/platforms/android.md:3
+msgid ""
+"Perry compiles TypeScript apps for Android using JNI (Java Native "
+"Interface)."
+msgstr ""
+
+#: src/platforms/android.md:7
+msgid "Android NDK"
+msgstr ""
+
+#: src/platforms/android.md:8
+msgid "Android SDK"
+msgstr ""
+
+#: src/platforms/android.md:9
+msgid "Rust Android targets:"
+msgstr ""
+
+#: src/platforms/android.md:22
+msgid "Perry maps UI widgets to Android views via JNI:"
+msgstr ""
+
+#: src/platforms/android.md:24
+msgid "Android Class"
+msgstr ""
+
+#: src/platforms/android.md:26
+msgid "TextView"
+msgstr ""
+
+#: src/platforms/android.md:28
+msgid "EditText"
+msgstr ""
+
+#: src/platforms/android.md:29
+msgid "EditText (ES_PASSWORD)"
+msgstr ""
+
+#: src/platforms/android.md:30
+msgid "Switch"
+msgstr ""
+
+#: src/platforms/android.md:31
+msgid "SeekBar"
+msgstr ""
+
+#: src/platforms/android.md:32
+msgid "Spinner + ArrayAdapter"
+msgstr ""
+
+#: src/platforms/android.md:33
+msgid "ImageView"
+msgstr ""
+
+#: src/platforms/android.md:34
+msgid "LinearLayout (vertical)"
+msgstr ""
+
+#: src/platforms/android.md:35
+msgid "LinearLayout (horizontal)"
+msgstr ""
+
+#: src/platforms/android.md:36 src/platforms/android.md:39
+msgid "FrameLayout"
+msgstr ""
+
+#: src/platforms/android.md:38
+msgid "Canvas + Bitmap"
+msgstr ""
+
+#: src/platforms/android.md:41
+msgid "Android-Specific APIs"
+msgstr ""
+
+#: src/platforms/android.md:43
+msgid "**Dark mode**: `Configuration.uiMode` detection"
+msgstr ""
+
+#: src/platforms/android.md:44
+msgid "**Preferences**: SharedPreferences"
+msgstr ""
+
+#: src/platforms/android.md:45
+msgid "**Keychain**: Android Keystore"
+msgstr ""
+
+#: src/platforms/android.md:46
+msgid "**Notifications**: NotificationManager"
+msgstr ""
+
+#: src/platforms/android.md:47
+msgid "**Open URL**: `Intent.ACTION_VIEW`"
+msgstr ""
+
+#: src/platforms/android.md:48
+msgid "**Alerts**: `PerryBridge.showAlert`"
+msgstr ""
+
+#: src/platforms/android.md:49
+msgid "**Sheets**: Dialog (modal)"
+msgstr ""
+
+#: src/platforms/android.md:53
+msgid ""
+"Perry's Android template includes a splash theme (`Theme.Perry.Splash`) that"
+" displays a `windowBackground` drawable during cold start. Configure it via "
+"`perry.splash` in `package.json`:"
+msgstr ""
+
+#: src/platforms/android.md:66
+msgid ""
+"The image is centered via a `layer-list` drawable with a solid background "
+"color. The activity switches to the normal theme in `onCreate` before "
+"inflating the layout, so the splash disappears as soon as the app is ready."
+msgstr ""
+
+#: src/platforms/android.md:68
+msgid "For full control, provide custom drawable and theme XML files:"
+msgstr ""
+
+#: src/platforms/android.md:85
+msgid "Differences from Desktop"
+msgstr ""
+
+#: src/platforms/android.md:87
+msgid "**Touch-only**: No hover events, no right-click context menus"
+msgstr ""
+
+#: src/platforms/android.md:88
+msgid "**Single window**: Multi-window maps to Dialog views"
+msgstr ""
+
+#: src/platforms/android.md:89
+msgid "**Toolbar**: Horizontal LinearLayout"
+msgstr ""
+
+#: src/platforms/android.md:90
+msgid "**Font**: Typeface-based font family support"
+msgstr ""
+
+#: src/platforms/harmonyos.md:3
+msgid ""
+"Perry compiles TypeScript apps for HarmonyOS NEXT (Huawei's mobile OS) by "
+"emitting **declarative ArkUI** alongside a logic-only `.so` library. The "
+"same TypeScript source that targets macOS, iOS, Android, Linux, and Windows "
+"also runs natively on HarmonyOS — no platform-specific adapters needed in "
+"user code."
+msgstr ""
+
+#: src/platforms/harmonyos.md:7
+msgid ""
+"HarmonyOS NEXT runs apps via the ArkTS runtime, which owns the UI tree. "
+"Perry can't lower `perry/ui` calls to the imperative AppKit/UIKit/etc shape "
+"used on every other platform — it has to play by ArkTS's declarative rules. "
+"So the harmonyos target is structured differently:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:26
+msgid ""
+"The user splices three artifacts into a DevEco Studio project — "
+"`libentry.so`, `pages/Index.ets`, `cpp/types/libentry/Index.d.ts` — and "
+"DevEco signs + runs as usual. Tap interactions, text input, etc. fire NAPI "
+"calls into the `.so`, which dispatch the registered Perry closure bodies."
+msgstr ""
+
+#: src/platforms/harmonyos.md:28
+msgid "What's supported"
+msgstr ""
+
+#: src/platforms/harmonyos.md:30
+msgid "**Widgets** (introduced in v0.5.401, expanded in v0.5.418, v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:32
+msgid "Widget"
+msgstr ""
+
+#: src/platforms/harmonyos.md:32
+msgid "ArkUI emission"
+msgstr ""
+
+#: src/platforms/harmonyos.md:34
+msgid "`Text(content)` / `Text(content, \"id\")`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:34
+msgid "`Text(...).fontSize(20)` (reactive when id is given)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:35
+msgid "`VStack(children)` / `VStack(spacing, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:35
+msgid "`Column({ space })`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:36
+msgid "`HStack(children)` / `HStack(spacing, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:36
+msgid "`Row({ space })`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:37
+msgid "`Button(label, onPress)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:37
+msgid "`Button(...).onClick(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:38
+msgid "`TextField(placeholder, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:38
+msgid "`TextInput(...).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:39
+msgid "`Toggle(label, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:39
+msgid "`Toggle({type: ToggleType.Switch}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:40
+msgid "`Slider(min, max, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:40
+msgid "`Slider({...}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:41
+msgid "`Spacer()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:41
+msgid "`Blank()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:42
+msgid "`Divider()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:43
+msgid "`Image(src)` / `ImageFile(path)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:43
+msgid "`Image(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:44
+msgid "`ScrollView(children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:44
+msgid "`Scroll() { Column() { ... } }`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:45
+msgid "`LazyVStack(children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:45
+msgid "`Column({...})` (eager — see v10 follow-up)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:46
+msgid "`Picker(options, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:46
+msgid "`TextPicker({...}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:47
+msgid "`ProgressView(value, total)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:47
+msgid "`Progress({type: ProgressType.Linear})`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:48
+msgid "`Section(title, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:48
+msgid "`Column({ space: 4 }) { Text(title) ... }`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:50
+msgid "**Event handling** (v0.5.417 + v0.5.421):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:51
+msgid "`Button.onPress` → `invokeCallback(idx)` via NAPI"
+msgstr ""
+
+#: src/platforms/harmonyos.md:52
+msgid ""
+"`Toggle.onChange((isOn: boolean) => ...)` → `invokeCallback1(idx, isOn)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:53
+msgid ""
+"`TextField.onChange((value: string) => ...)` → `invokeCallback1(idx, value)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:54
+msgid ""
+"`Slider.onChange((value: number) => ...)` → `invokeCallback1(idx, value)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:55
+msgid ""
+"`Picker.onChange((idx: number) => ...)` → `invokeCallback1(idx, index)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:57
+msgid "**Reactivity** (v0.5.419 + v0.5.421):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:58
+msgid ""
+"`Text(\"0\", \"counter\")` registers a reactive slot bound to a generated "
+"`@State text_counter: string` field."
+msgstr ""
+
+#: src/platforms/harmonyos.md:59
+msgid ""
+"`setText(\"counter\", \"5\")` from inside any closure updates the Text on-"
+"screen."
+msgstr ""
+
+#: src/platforms/harmonyos.md:61
+msgid "**Toast banners** (v0.5.419):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:62
+msgid ""
+"`showToast(\"Saved!\")` from inside any closure shows an ArkUI "
+"`promptAction.showToast({ message })` banner."
+msgstr ""
+
+#: src/platforms/harmonyos.md:64
+msgid "**Inline styling** (v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:65
+msgid ""
+"`Text(\"hi\", { fontSize: 16, color: \"red\" })` maps to "
+"`.fontSize(16).fontColor('red')`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:66
+msgid ""
+"Supported props: `backgroundColor`, `color`, `fontSize`, `fontWeight`, "
+"`fontFamily`, `borderRadius`, `padding` (number or per-side object), "
+"`opacity`, `hidden`, `borderColor` + `borderWidth` (combined as "
+"`.border({...})`)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:67
+msgid "PerryColor objects (`{r,g,b,a}`) auto-convert to `rgba(...)` strings."
+msgstr ""
+
+#: src/platforms/harmonyos.md:69
+msgid "**Dynamic lists** (v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:70
+msgid ""
+"`VStack(items.map(item => Text(item)))` lowers to ArkUI `ForEach(items, "
+"(__item) => { Text(__item) }, (__item) => __item)`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:71
+msgid ""
+"Single-arg map closures only; complex array sources require Phase 2 v6 state"
+" binding."
+msgstr ""
+
+#: src/platforms/harmonyos.md:73
+msgid "Setup"
+msgstr ""
+
+#: src/platforms/harmonyos.md:75
+msgid ""
+"**Install DevEco Studio** + the OpenHarmony SDK from Huawei. Verified "
+"working with DevEco Studio 6.0.2 + OpenHarmony 5.0+."
+msgstr ""
+
+#: src/platforms/harmonyos.md:77
+msgid "**Run the setup wizard once** (introduced in v0.5.380):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:83
+msgid ""
+"The wizard auto-discovers your DevEco-generated debug certificates from "
+"`~/.ohos/config/`, prompts for the keystore password, and persists the "
+"configuration to `~/.perry/config.toml`. Subsequent `perry compile --target "
+"harmonyos` invocations sign HAPs automatically."
+msgstr ""
+
+#: src/platforms/harmonyos.md:85
+msgid ""
+"**Optional**: install `hdc` (HarmonyOS Device Connector) for emulator "
+"interaction. It ships inside DevEco at "
+"`Contents/sdk/default/openharmony/toolchains/hdc`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:87
+msgid "Compile + run workflow"
+msgstr ""
+
+#: src/platforms/harmonyos.md:89
+msgid "Write a TypeScript program with `App({body: ...})`:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:91
+msgid ""
+"```typescript,no-test\n"
+"// hi.ts\n"
+"import { App, VStack, Text, Button, showToast } from \"perry/ui\";\n"
+"\n"
+"let count = 0;\n"
+"\n"
+"App({\n"
+"  title: \"Perry on HarmonyOS\",\n"
+"  body: VStack([\n"
+"    Text(\"Count: 0\", \"counter\"),\n"
+"    Button(\"+\", () => {\n"
+"      count++;\n"
+"      setText(\"counter\", `Count: ${count}`);\n"
+"    }),\n"
+"    Button(\"Notify\", () => {\n"
+"      showToast(`Counter is ${count}`);\n"
+"    }),\n"
+"  ]),\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/platforms/harmonyos.md:112
+msgid "Compile for HarmonyOS:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:118
+msgid "This produces three artifacts in `/tmp/`:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:120
+msgid "`libentry.so` — the compiled `.so` (8-9 MB typically)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:121
+msgid "`ets/pages/Index.ets` — the auto-emitted ArkUI page"
+msgstr ""
+
+#: src/platforms/harmonyos.md:122
+msgid "`cpp/types/libentry/Index.d.ts` — the NAPI declaration file"
+msgstr ""
+
+#: src/platforms/harmonyos.md:124
+msgid "**Splice** into a DevEco Studio project:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:132
+msgid ""
+"Click ▶ Run in DevEco — DevEco's hvigor signs + bundles the HAP and installs"
+" onto the emulator (or attached device). The app launches, taps fire your TS"
+" closures, and the screen updates reactively."
+msgstr ""
+
+#: src/platforms/harmonyos.md:134
+msgid "Architecture deep dive"
+msgstr ""
+
+#: src/platforms/harmonyos.md:136
+msgid "The harvest model"
+msgstr ""
+
+#: src/platforms/harmonyos.md:138
+msgid ""
+"`perry-codegen-arkts::emit_index_ets` walks `module.init` looking for the "
+"first `App({body: <expr>})` call from `perry/ui`. It extracts the `body` "
+"field, recursively emits ArkUI source for each widget in the tree, and "
+"**destructively replaces the App call with `Stmt::Expr(Expr::Number(0.0))`**"
+" so the LLVM backend never sees `perry_ui_*` FFI calls (which would be "
+"unresolved on the OHOS target — there's no `perry-ui-harmonyos` crate by "
+"design)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:140
+msgid ""
+"The emitted Index.ets is a real ArkUI `@Entry @Component struct Index { "
+"build() { ... } }` page with `@State` declarations for any reactive Text "
+"widgets, `import promptAction from '@ohos.promptAction'` for toast routing, "
+"and per-Button onClick handlers that invoke NAPI callbacks then drain queued"
+" toasts and text updates."
+msgstr ""
+
+#: src/platforms/harmonyos.md:142
+msgid "Closures across the NAPI boundary"
+msgstr ""
+
+#: src/platforms/harmonyos.md:144
+msgid ""
+"Each Button/Toggle/etc onClick closure registers via "
+"`perry_arkts_register_callback(idx, closure_handle)` during `main()` "
+"startup. The `closure_handle` is a NaN-boxed pointer to a real Perry "
+"`*ClosureHeader`. A GC root scanner registered in `gc_init` keeps registered"
+" closures alive across collections."
+msgstr ""
+
+#: src/platforms/harmonyos.md:146
+msgid ""
+"When ArkUI fires an onClick, the auto-emitted `.onClick(() => "
+"perryEntry.invokeCallback(0))` calls back into the `.so` via NAPI. The "
+"`invoke_callback` NAPI handler in `crates/perry-runtime/src/ohos_napi.rs` "
+"reads the int32 idx, looks up the slot, and dispatches via "
+"`js_closure_call0`. Multi-arg variants (Toggle/TextField/Slider) use "
+"`invokeCallback1(idx, value)` with `napi_typeof` dispatch to NaN-box the "
+"value (boolean / string / number) before calling `js_closure_call1`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:148
+msgid "The drain queue pattern"
+msgstr ""
+
+#: src/platforms/harmonyos.md:150
+msgid ""
+"`showToast` and `setText` calls inside a closure body push entries onto "
+"thread-local queues:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:151
+msgid "`PENDING_TOASTS: Mutex<VecDeque<String>>`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:152
+msgid "`PENDING_TEXT_UPDATES: Mutex<VecDeque<(String, String)>>`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:154
+msgid ""
+"After every onClick/onChange invocation, the auto-emitted handler in "
+"Index.ets drains both queues:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:172
+msgid ""
+"`applyTextUpdate(id, value)` is a switch over registered Text ids that "
+"assigns to the matching `@State text_<id>: string` field — ArkUI's "
+"reactivity then rerenders the Text widget."
+msgstr ""
+
+#: src/platforms/harmonyos.md:174
+msgid "Why NAPI?"
+msgstr ""
+
+#: src/platforms/harmonyos.md:176
+msgid ""
+"HarmonyOS NEXT uses the OpenHarmony NAPI binding (modeled on Node's NAPI) to"
+" load native `.so` libraries from ArkTS. Perry's `crates/perry-"
+"runtime/src/ohos_napi.rs` registers a module via `napi_module_register` in "
+"an `.init_array` constructor (Rust's equivalent of "
+"`__attribute__((constructor))`), with the modname auto-derived from the "
+"`.so` filename via `dladdr`. The exported NAPI surface is just `run` / "
+"`invokeCallback` / `invokeCallback1` / `drainToast` / `drainTextUpdate` — "
+"every other Perry runtime call happens within the `.so` itself."
+msgstr ""
+
+#: src/platforms/harmonyos.md:178
+msgid "Known limitations"
+msgstr ""
+
+#: src/platforms/harmonyos.md:180
+msgid ""
+"**LazyVStack is currently rendered eagerly** as a plain `Column`. Real lazy "
+"rendering for big lists needs ArkUI's `LazyForEach` + a custom `IDataSource`"
+" impl — tracked as Phase 2 v10."
+msgstr ""
+
+#: src/platforms/harmonyos.md:181
+msgid ""
+"**State binding is one-way** — `setText(\"id\", value)` from a closure "
+"updates the Text on-screen, but a generic `state<T>` reactive container "
+"(`const count = state(0); count.set(...)`) is Phase 2 v6 follow-up work."
+msgstr ""
+
+#: src/platforms/harmonyos.md:182
+msgid ""
+"**Multi-page navigation** (NavStack / Router across multiple `.ets` files) "
+"is Phase 2 v11."
+msgstr ""
+
+#: src/platforms/harmonyos.md:183
+msgid ""
+"**AppGallery production signing** uses a different cert chain than DevEco's "
+"debug certs and isn't yet plumbed into `perry compile`. The current splice "
+"workflow handles debug-emulator deploy."
+msgstr ""
+
+#: src/platforms/harmonyos.md:184
+msgid ""
+"**Real device validation** is pending — every milestone has been verified on"
+" the Pura 90 Pro Max emulator. AppGallery upload + real-hardware install "
+"will follow."
+msgstr ""
+
+#: src/platforms/harmonyos.md:186
+msgid "Validated on emulator"
+msgstr ""
+
+#: src/platforms/harmonyos.md:188
+msgid ""
+"End-to-end on Pura 90 Pro Max with a 5-widget interactive page (counter + "
+"reset, TextField echoing input live as `You typed: <text>`, Toggle flipping "
+"`Notifications: on/off` with toast feedback, Slider tracking `Volume: N` "
+"continuously, reactive Texts everywhere). Each interaction routes:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:196
+msgid ""
+"This is the first time Perry-compiled TypeScript state mutation has "
+"reactively driven a HarmonyOS NEXT screen."
+msgstr ""
+
+#: src/platforms/harmonyos.md:198
+msgid "Version history"
+msgstr ""
+
+#: src/platforms/harmonyos.md:200
+msgid ""
+"**v0.5.401** — Phase 2 v1.5: full widget set rendering "
+"(Text/VStack/HStack/Button/TextField/Toggle/Slider/Spacer/Divider)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:201
+msgid ""
+"**v0.5.417** — Phase 2 v2 + v3 + v2.5: Button onClick callback bridge, "
+"showToast, reactive Text via setText, multi-arg Toggle/TextField/Slider "
+"value forwarding."
+msgstr ""
+
+#: src/platforms/harmonyos.md:202
+msgid ""
+"**v0.5.418** — Phase 2 v4: Image / ScrollView / LazyVStack / Picker / "
+"ProgressView / Section."
+msgstr ""
+
+#: src/platforms/harmonyos.md:203
+msgid ""
+"**v0.5.420 / .421** — Cross-platform showToast + setText on iOS / tvOS / "
+"visionOS / Android."
+msgstr ""
+
+#: src/platforms/harmonyos.md:204
+msgid ""
+"**v0.5.422 / .423** — Cross-platform showToast + setText on Windows / GTK4."
+msgstr ""
+
+#: src/platforms/harmonyos.md:205
+msgid ""
+"**v0.5.429** — Phase 2 v5: inline `style: { ... }` + ForEach via array.map."
+msgstr ""
+
+#: src/platforms/harmonyos.md:207
+msgid ""
+"For the full per-version detail see "
+"[CHANGELOG.md](https://github.com/PerryTS/perry/blob/main/CHANGELOG.md)."
+msgstr ""
+
+#: src/platforms/windows.md:3
+msgid "Perry compiles TypeScript apps for Windows using the Win32 API."
+msgstr ""
+
+#: src/platforms/windows.md:7
+msgid ""
+"Windows 10 or later by default (Windows 7 SP1 / Windows 8 supported via "
+"`--min-windows-version=7|8` — see [Windows 7 Compatibility](./windows-7.md) "
+"for the trade-offs)"
+msgstr ""
+
+#: src/platforms/windows.md:8
+msgid "A linker toolchain — either of these two options:"
+msgstr ""
+
+#: src/platforms/windows.md:10
+msgid "Option A — Lightweight (recommended, ~1.5 GB, no Visual Studio)"
+msgstr ""
+
+#: src/platforms/windows.md:12
+msgid ""
+"Uses LLVM's `clang` + `lld-link` plus an xwin'd copy of the Microsoft CRT + "
+"Windows SDK libraries. No admin rights, no Visual Studio install."
+msgstr ""
+
+#: src/platforms/windows.md:19
+msgid ""
+"`perry setup windows` downloads ~700 MB (unpacks to ~1.5 GB) at "
+"`%LOCALAPPDATA%\\perry\\windows-sdk` after prompting you to accept the "
+"Microsoft redistributable license. Pass `--accept-license` to skip the "
+"prompt in CI. Partial downloads resume safely on re-run."
+msgstr ""
+
+#: src/platforms/windows.md:21
+msgid "Option B — Visual Studio (~8 GB)"
+msgstr ""
+
+#: src/platforms/windows.md:23
+msgid ""
+"If you already have Visual Studio installed, add the C++ workload via the "
+"Visual Studio Installer → _Modify_ → check **Desktop development with C++**."
+" Or install standalone Build Tools:"
+msgstr ""
+
+#: src/platforms/windows.md:30
+msgid ""
+"Both options produce identical binaries — Perry picks Option A when the "
+"xwin'd sysroot is present, Option B otherwise. Run `perry doctor` to see "
+"which is active."
+msgstr ""
+
+#: src/platforms/windows.md:40
+msgid "Perry maps UI widgets to Win32 controls:"
+msgstr ""
+
+#: src/platforms/windows.md:42
+msgid "Win32 Class"
+msgstr ""
+
+#: src/platforms/windows.md:46
+msgid "Edit HWND"
+msgstr ""
+
+#: src/platforms/windows.md:47
+msgid "Edit (ES_PASSWORD)"
+msgstr ""
+
+#: src/platforms/windows.md:48
+msgid "Checkbox"
+msgstr ""
+
+#: src/platforms/windows.md:49
+msgid "Trackbar (TRACKBAR_CLASSW)"
+msgstr ""
+
+#: src/platforms/windows.md:50
+msgid "ComboBox"
+msgstr ""
+
+#: src/platforms/windows.md:51
+msgid "PROGRESS_CLASSW"
+msgstr ""
+
+#: src/platforms/windows.md:54
+msgid "WS_VSCROLL"
+msgstr ""
+
+#: src/platforms/windows.md:55
+msgid "GDI drawing"
+msgstr ""
+
+#: src/platforms/windows.md:56
+msgid "Form/Section"
+msgstr ""
+
+#: src/platforms/windows.md:56
+msgid "GroupBox"
+msgstr ""
+
+#: src/platforms/windows.md:58
+msgid "Windows-Specific APIs"
+msgstr ""
+
+#: src/platforms/windows.md:60
+msgid "**Menu bar**: HMENU / SetMenu"
+msgstr ""
+
+#: src/platforms/windows.md:61
+msgid "**Dark mode**: Windows Registry detection"
+msgstr ""
+
+#: src/platforms/windows.md:62
+msgid "**Preferences**: Windows Registry"
+msgstr ""
+
+#: src/platforms/windows.md:63
+msgid ""
+"**Keychain**: CredWrite/CredRead/CredDelete (Windows Credential Manager)"
+msgstr ""
+
+#: src/platforms/windows.md:64
+msgid "**Notifications**: Toast notifications"
+msgstr ""
+
+#: src/platforms/windows.md:65
+msgid "**File dialogs**: IFileOpenDialog / IFileSaveDialog (COM)"
+msgstr ""
+
+#: src/platforms/windows.md:66
+msgid "**Alerts**: MessageBoxW"
+msgstr ""
+
+#: src/platforms/windows.md:67
+msgid "**Open URL**: ShellExecuteW"
+msgstr ""
+
+#: src/platforms/windows-7.md:3
+msgid ""
+"Perry supports compiling executables that run on Windows 7 SP1 (and Windows "
+"8 / 8.1) — opt-in via the `--min-windows-version` flag. The default target "
+"stays Windows 10+ to preserve full DPI fidelity and modern OS integration; "
+"legacy support is one flag away when you need it."
+msgstr ""
+
+#: src/platforms/windows-7.md:5
+msgid ""
+"This page covers what works, what degrades, what's outright impossible, and "
+"how to validate your build before shipping."
+msgstr ""
+
+#: src/platforms/windows-7.md:7
+msgid "TL;DR"
+msgstr ""
+
+#: src/platforms/windows-7.md:13
+msgid ""
+"Produces a PE marked Win7-compatible. Perry's UI runtime resolves the "
+"Win10-only DPI APIs lazily at startup and falls back through Win8.1 → Vista "
+"primitives, so the binary starts on Win7 SP1. Most UI widgets work. Some "
+"cosmetic effects (rounded corners, dark titlebar) silently no-op. **No "
+"JavaScript-module imports allowed** on Win7 — the V8 runtime is Win10+ "
+"unconditional."
+msgstr ""
+
+#: src/platforms/windows-7.md:15
+msgid "Why this is opt-in"
+msgstr ""
+
+#: src/platforms/windows-7.md:17
+msgid ""
+"Two things make a Win7-compatible PE different from a default Perry build:"
+msgstr ""
+
+#: src/platforms/windows-7.md:19
+msgid ""
+"**The PE subsystem version field.** Default Perry builds let the linker pick"
+" (currently `/SUBSYSTEM:WINDOWS` with no version, which marks the binary as "
+"needing Win8+). Win7 needs `/SUBSYSTEM:WINDOWS,5.1` or "
+"`/SUBSYSTEM:CONSOLE,5.1`. The `,5.1` suffix is the [PE subsystem "
+"ABI](https://learn.microsoft.com/en-us/windows/win32/debug/pe-"
+"format#optional-header-windows-specific-fields-image-only) declaration of "
+"\"I claim to run on Windows NT 5.1 or higher\" — the OS loader reads this "
+"field before deciding whether to load the binary."
+msgstr ""
+
+#: src/platforms/windows-7.md:21
+msgid ""
+"**Win10-only API calls become runtime-resolved.** Perry's UI library calls "
+"`SetProcessDpiAwarenessContext` (Win10 1607) and `GetDpiForSystem` (Win10 "
+"1607) for per-monitor v2 DPI awareness. Hard-importing them via `extern "
+"\"system\"` would emit IAT entries that the OS resolves _before_ `main()` "
+"runs — on Win7, the loader fails the process with \"entry point not found in"
+" user32.dll\" before any Rust code can run. With `--min-windows-version=7` "
+"(and on default builds too — the retrofit is unconditional), Perry resolves "
+"these symbols lazily via `LoadLibraryW + GetProcAddress` and falls back "
+"through:"
+msgstr ""
+
+#: src/platforms/windows-7.md:23
+msgid "Tier"
+msgstr ""
+
+#: src/platforms/windows-7.md:23 src/plugins/appstore-review.md:54
+msgid "API"
+msgstr ""
+
+#: src/platforms/windows-7.md:23
+msgid "Min Windows"
+msgstr ""
+
+#: src/platforms/windows-7.md:25
+msgid "`SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)`"
+msgstr ""
+
+#: src/platforms/windows-7.md:25
+msgid "Windows 10 1607"
+msgstr ""
+
+#: src/platforms/windows-7.md:26
+msgid "`SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)`"
+msgstr ""
+
+#: src/platforms/windows-7.md:26
+msgid "Windows 8.1"
+msgstr ""
+
+#: src/platforms/windows-7.md:27
+msgid "`SetProcessDPIAware()`"
+msgstr ""
+
+#: src/platforms/windows-7.md:27
+msgid "Windows Vista"
+msgstr ""
+
+#: src/platforms/windows-7.md:29
+msgid ""
+"System DPI lookup uses the same lazy pattern: `GetDpiForSystem` (Win10) → "
+"`GetDC + GetDeviceCaps(LOGPIXELSY)` (Win2000+)."
+msgstr ""
+
+#: src/platforms/windows-7.md:31
+msgid ""
+"The `--min-windows-version` flag controls only (1) — the PE marker. The lazy"
+" DPI resolution from (2) is always active because it costs essentially "
+"nothing and makes default builds more robust against being run on stripped-"
+"down Windows installs."
+msgstr ""
+
+#: src/platforms/windows-7.md:33
+msgid "Accepted values"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "`--min-windows-version`"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Subsystem suffix"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Targets"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Default?"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "`10`"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "(none — linker default)"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "Windows 10+"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "yes"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "`8`"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "`,6.02`"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "Windows 8 / 8.1+"
+msgstr ""
+
+#: src/platforms/windows-7.md:38 src/platforms/windows-7.md:39
+msgid "no"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "`7`"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "`,5.1`"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "Windows 7 SP1+"
+msgstr ""
+
+#: src/platforms/windows-7.md:41
+msgid ""
+"Anything else is a hard error at compile time — typos like `--min-windows-"
+"version=11` fail loudly instead of silently behaving like the default."
+msgstr ""
+
+#: src/platforms/windows-7.md:43
+msgid "What works on Win7"
+msgstr ""
+
+#: src/platforms/windows-7.md:45
+msgid ""
+"The same audit that produced this feature found 12 KLOC of Win32 UI code in "
+"`perry-ui-windows` and 5 calls that touch Win10+ APIs. The 5 break down as 2"
+" hard blockers (now lazy-resolved) and 3 cosmetic-effect calls that already "
+"failed soft and silently no-op on Win7. So the bulk of the UI surface — "
+"every standard widget — works on Win7 SP1:"
+msgstr ""
+
+#: src/platforms/windows-7.md:47
+msgid ""
+"All layout containers (`VStack`, `HStack`, `ZStack`, `ScrollView`, `Spacer`,"
+" `Divider`)"
+msgstr ""
+
+#: src/platforms/windows-7.md:48
+msgid ""
+"All input widgets (`Button`, `TextField`, `SecureField`, `Toggle`, `Slider`,"
+" `Picker`, `ProgressView`)"
+msgstr ""
+
+#: src/platforms/windows-7.md:49
+msgid "`Text`, `Canvas`, `Image` (file + symbol)"
+msgstr ""
+
+#: src/platforms/windows-7.md:50
+msgid "`Form` and `LazyVStack`"
+msgstr ""
+
+#: src/platforms/windows-7.md:51
+msgid "File / folder open / save dialogs"
+msgstr ""
+
+#: src/platforms/windows-7.md:52
+msgid "Clipboard access"
+msgstr ""
+
+#: src/platforms/windows-7.md:53
+msgid "Audio (WASAPI is Vista+)"
+msgstr ""
+
+#: src/platforms/windows-7.md:54
+msgid "Keyboard shortcuts, menus, toolbars"
+msgstr ""
+
+#: src/platforms/windows-7.md:55
+msgid "Multi-window"
+msgstr ""
+
+#: src/platforms/windows-7.md:56
+msgid ""
+"The full `perry-runtime` and `perry-stdlib` surface — `fs`, `http`, "
+"`crypto`, `child_process`, `Date`, `Buffer`, etc."
+msgstr ""
+
+#: src/platforms/windows-7.md:58
+msgid "What degrades silently"
+msgstr ""
+
+#: src/platforms/windows-7.md:60
+msgid ""
+"These behaviors target Win10 / Win11 features. On Win7 the API call returns "
+"an error code that Perry already swallows; the binary runs, but the visual "
+"effect is missing:"
+msgstr ""
+
+#: src/platforms/windows-7.md:62
+msgid ""
+"**DPI quality.** Win7 has system-wide DPI only — moving a window between "
+"monitors with different DPI doesn't trigger re-scaling. Per-monitor v2 (font"
+" hinting, dialog scaling) is Win10 1607+."
+msgstr ""
+
+#: src/platforms/windows-7.md:63
+msgid ""
+"**Dark titlebar.** `DWMWA_USE_IMMERSIVE_DARK_MODE` is Win10 1809+. Titlebar "
+"follows the system theme on Win7 (light only on stock Win7)."
+msgstr ""
+
+#: src/platforms/windows-7.md:64
+msgid ""
+"**Rounded window corners.** `DWMWA_WINDOW_CORNER_PREFERENCE` is Win11+. "
+"Frameless windows have square corners on Win7 / Win10."
+msgstr ""
+
+#: src/platforms/windows-7.md:65
+msgid ""
+"**Mica / Acrylic backdrop.** `DWMWA_SYSTEMBACKDROP_TYPE` is Win11+. Backdrop"
+" falls through to the standard window background on Win7 / Win10."
+msgstr ""
+
+#: src/platforms/windows-7.md:67
+msgid "What is impossible"
+msgstr ""
+
+#: src/platforms/windows-7.md:69
+msgid ""
+"**`perry/jsruntime` (V8 / deno_core) is Win10+ unconditional.** Anything in "
+"your project that imports a `.js` module from `node_modules` triggers "
+"`--enable-jsruntime`, which links against deno_core, which embeds V8, which "
+"won't load on Win7. There's no fallback for this — Win7 builds must avoid "
+"JS-module imports entirely. If your project compiles cleanly without "
+"`--enable-jsruntime` (i.e. only TypeScript imports, only Perry-native "
+"packages), you're good."
+msgstr ""
+
+#: src/platforms/windows-7.md:71
+msgid ""
+"**Universal Windows Platform (UWP / WinRT) APIs.** Perry doesn't currently "
+"use these, but if a future feature does (e.g. modern toast notifications), "
+"it'll be Win10+ only. The runtime + stdlib audit was clean as of v0.5.395."
+msgstr ""
+
+#: src/platforms/windows-7.md:73
+msgid "How the lazy DPI resolution works"
+msgstr ""
+
+#: src/platforms/windows-7.md:75
+msgid ""
+"The retrofit lives in `crates/perry-ui-windows/src/dpi_compat.rs`. It "
+"exposes two functions, both safe to call on any Windows version from Vista "
+"onward:"
+msgstr ""
+
+#: src/platforms/windows-7.md:82
+msgid "Internally each function:"
+msgstr ""
+
+#: src/platforms/windows-7.md:84
+msgid ""
+"Calls `LoadLibraryA(\"user32.dll\")` (and `shcore.dll` for the Win8.1 tier) "
+"— both are loaded into every Win32 process by the kernel before `main`, so "
+"the call is a cheap handle lookup."
+msgstr ""
+
+#: src/platforms/windows-7.md:85
+msgid ""
+"Calls `GetProcAddress` to find the desired symbol. Caches the result "
+"(success or failure) in an `AtomicPtr` + `AtomicU8` pair, so the lookup runs"
+" at most once per process."
+msgstr ""
+
+#: src/platforms/windows-7.md:86
+msgid ""
+"Falls through to the next tier on miss. `set_process_dpi_awareness_compat` "
+"ends with `SetProcessDPIAware()` (Vista+, hard-imported because every "
+"supported Windows has it). `get_system_dpi_compat` ends with "
+"`GetDeviceCaps(LOGPIXELSY)` (Win2000+, dead reliable)."
+msgstr ""
+
+#: src/platforms/windows-7.md:88
+msgid ""
+"After the cache is warm — i.e. after `app_create` runs once — every "
+"subsequent DPI query is a single atomic load + indirect call. No measurable "
+"runtime cost vs. a hard-imported call."
+msgstr ""
+
+#: src/platforms/windows-7.md:90
+msgid "Validating a Win7 build"
+msgstr ""
+
+#: src/platforms/windows-7.md:92
+msgid ""
+"Perry's CI and dev hosts don't have Win7 VMs. If you ship to Win7 you need "
+"to validate the binary yourself. Three checks:"
+msgstr ""
+
+#: src/platforms/windows-7.md:94
+msgid "1. PE subsystem version"
+msgstr ""
+
+#: src/platforms/windows-7.md:96
+msgid ""
+"Use `dumpbin /headers app.exe | findstr \"subsystem\"` (MSVC) or `objdump -p"
+" app.exe | grep \"MajorOSVersion\"` (LLVM):"
+msgstr ""
+
+#: src/platforms/windows-7.md:98
+msgid ""
+"```text\n"
+"$ dumpbin /headers app.exe | findstr \"subsystem\"\n"
+"            5.01 subsystem version\n"
+"               2 subsystem (Windows GUI)\n"
+"```"
+msgstr ""
+
+#: src/platforms/windows-7.md:104
+msgid ""
+"The `5.01` confirms the PE is Win7-compatible. A default build shows `6.00` "
+"or higher."
+msgstr ""
+
+#: src/platforms/windows-7.md:106
+msgid "2. Imports"
+msgstr ""
+
+#: src/platforms/windows-7.md:108
+msgid ""
+"Use `dumpbin /imports app.exe | findstr /i \"user32\"` (MSVC) or `objdump -p"
+" app.exe | grep -A20 \"DLL Name: user32\"` (LLVM). Confirm that "
+"`SetProcessDpiAwarenessContext` and `GetDpiForSystem` are **not** in the "
+"user32.dll import list. If they are, the lazy retrofit isn't taking effect —"
+" likely you've added a `use "
+"windows::Win32::UI::HiDpi::SetProcessDpiAwarenessContext;` somewhere that "
+"pulls the symbol back in."
+msgstr ""
+
+#: src/platforms/windows-7.md:110
+msgid "3. Run on a Win7 SP1 VM"
+msgstr ""
+
+#: src/platforms/windows-7.md:112
+msgid ""
+"There's no substitute for actually launching the binary. Microsoft's free "
+"Win7 evaluation VM (no longer hosted directly by Microsoft, mirrored on "
+"archive.org) is the canonical reference image. Worth keeping a snapshot for "
+"regression checks."
+msgstr ""
+
+#: src/platforms/windows-7.md:114
+msgid "Caveats and gotchas"
+msgstr ""
+
+#: src/platforms/windows-7.md:116
+msgid ""
+"**The MSVC linker may warn** about subsystem version `,5.1` being below the "
+"C runtime's stated minimum on newer toolchains. The warning is benign — the "
+"CRT itself runs on Win7, the warning is conservative. Watch for hard errors,"
+" not warnings."
+msgstr ""
+
+#: src/platforms/windows-7.md:117
+msgid ""
+"**xwin sysroot setup is unchanged.** Cross-compiling from macOS / Linux "
+"still uses the `perry setup windows` xwin'd toolchain. Nothing in `--min-"
+"windows-version` changes the SDK requirements."
+msgstr ""
+
+#: src/platforms/windows-7.md:118
+msgid ""
+"**Static-link the CRT** if you want the binary to run on a clean Win7 SP1 "
+"install with no Visual C++ Redistributable. Confirm the binary doesn't "
+"import `vcruntime140.dll` / `msvcp140.dll` via the dumpbin/objdump check "
+"above."
+msgstr ""
+
+#: src/platforms/windows-7.md:119
+msgid ""
+"**`perry/thread`'s SRWLOCK is Vista+, fine.** Perry's threading primitives "
+"use Rust std, which uses SRWLOCK on Windows since Rust 1.42. No "
+"`WaitOnAddress` (Win8+) involvement on the supported Rust versions."
+msgstr ""
+
+#: src/platforms/windows-7.md:121
+msgid "Issue tracking"
+msgstr ""
+
+#: src/platforms/windows-7.md:123
+msgid ""
+"This feature lands as the resolution to "
+"[\\#303](https://github.com/PerryTS/perry/issues/303). If you hit a "
+"Win7-specific failure that isn't covered here, please file a follow-up "
+"referencing this page so we can extend the audit."
+msgstr ""
+
+#: src/platforms/linux.md:3
+msgid "Perry compiles TypeScript apps for Linux using GTK4."
+msgstr ""
+
+#: src/platforms/linux.md:7
+msgid "GTK4 development libraries:"
+msgstr ""
+
+#: src/platforms/linux.md:15
+msgid "# Arch\n"
+msgstr ""
+
+#: src/platforms/linux.md:18
+msgid "Cairo development libraries (for canvas):"
+msgstr ""
+
+#: src/platforms/linux.md:32
+msgid "Perry maps UI widgets to GTK4 widgets:"
+msgstr ""
+
+#: src/platforms/linux.md:34
+msgid "GTK4 Widget"
+msgstr ""
+
+#: src/platforms/linux.md:38
+msgid "GtkEntry"
+msgstr ""
+
+#: src/platforms/linux.md:39
+msgid "GtkPasswordEntry"
+msgstr ""
+
+#: src/platforms/linux.md:40
+msgid "GtkSwitch"
+msgstr ""
+
+#: src/platforms/linux.md:41
+msgid "GtkScale"
+msgstr ""
+
+#: src/platforms/linux.md:42
+msgid "GtkDropDown"
+msgstr ""
+
+#: src/platforms/linux.md:43
+msgid "GtkProgressBar"
+msgstr ""
+
+#: src/platforms/linux.md:44
+msgid "GtkImage"
+msgstr ""
+
+#: src/platforms/linux.md:45
+msgid "GtkBox (vertical)"
+msgstr ""
+
+#: src/platforms/linux.md:46
+msgid "GtkBox (horizontal)"
+msgstr ""
+
+#: src/platforms/linux.md:47
+msgid "GtkOverlay"
+msgstr ""
+
+#: src/platforms/linux.md:48
+msgid "GtkScrolledWindow"
+msgstr ""
+
+#: src/platforms/linux.md:49
+msgid "Cairo drawing"
+msgstr ""
+
+#: src/platforms/linux.md:50
+msgid "GtkStack"
+msgstr ""
+
+#: src/platforms/linux.md:52
+msgid "Linux-Specific APIs"
+msgstr ""
+
+#: src/platforms/linux.md:54
+msgid "**Menu bar**: GMenu / set_menubar"
+msgstr ""
+
+#: src/platforms/linux.md:55
+msgid "**Toolbar**: GtkHeaderBar"
+msgstr ""
+
+#: src/platforms/linux.md:56
+msgid "**Dark mode**: GTK settings detection"
+msgstr ""
+
+#: src/platforms/linux.md:57
+msgid "**Preferences**: GSettings or file-based"
+msgstr ""
+
+#: src/platforms/linux.md:58
+msgid "**Keychain**: libsecret"
+msgstr ""
+
+#: src/platforms/linux.md:59
+msgid "**Notifications**: GNotification"
+msgstr ""
+
+#: src/platforms/linux.md:60
+msgid "**File dialogs**: GtkFileChooserDialog"
+msgstr ""
+
+#: src/platforms/linux.md:61
+msgid "**Alerts**: GtkMessageDialog"
+msgstr ""
+
+#: src/platforms/linux.md:65
+msgid ""
+"GTK4 styling uses CSS under the hood. Perry's styling methods (colors, "
+"fonts, corner radius) are translated to CSS properties applied via "
+"`CssProvider`."
+msgstr ""
+
+#: src/platforms/linux.md:67
+msgid "Testing with Geisterhand"
+msgstr ""
+
+#: src/platforms/linux.md:69
+msgid ""
+"Perry's built-in UI fuzzer works on Linux/GTK4. Screenshots use "
+"`WidgetPaintable` + `GskRenderer` for pixel-accurate capture."
+msgstr ""
+
+#: src/platforms/linux.md:73
+msgid "# In another terminal:\n"
+msgstr ""
+
+#: src/platforms/linux.md:79
+msgid "See [Geisterhand](../testing/geisterhand.md) for full API reference."
+msgstr ""
+
+#: src/platforms/web.md:3
+msgid ""
+"`--target web` and `--target wasm` are aliases for the same backend. Both "
+"produce a self-contained HTML file with embedded WebAssembly and a "
+"JavaScript bridge for DOM widgets."
+msgstr ""
+
+#: src/platforms/web.md:6
+msgid "# same output as --target wasm\n"
+msgstr ""
+
+#: src/platforms/web.md:10
+msgid ""
+"See **[WebAssembly / Web](wasm.md)** for the full documentation: how it "
+"works, supported features, UI mapping, FFI, threading, limitations, and "
+"examples."
+msgstr ""
+
+#: src/platforms/web.md:12
+msgid "Why one target instead of two?"
+msgstr ""
+
+#: src/platforms/web.md:14
+msgid "Perry used to have two browser backends:"
+msgstr ""
+
+#: src/platforms/web.md:16
+msgid "`--target web` (`perry-codegen-js`) — transpiled HIR to JavaScript"
+msgstr ""
+
+#: src/platforms/web.md:17
+msgid "`--target wasm` (`perry-codegen-wasm`) — compiled HIR to WebAssembly"
+msgstr ""
+
+#: src/platforms/web.md:19
+msgid ""
+"These were consolidated into the WASM target so browser apps get near-native"
+" performance, FFI imports, and Web Worker threading without needing a "
+"separate JS-emit pipeline. The DOM widget runtime that the old `--target "
+"web` provided is now embedded in `wasm_runtime.js`. Both flags route through"
+" `perry-codegen-wasm` and produce identical HTML output."
+msgstr ""
+
+#: src/platforms/web.md:23
+msgid "[WebAssembly / Web](wasm.md) — full target documentation"
+msgstr ""
+
+#: src/platforms/web.md:24
+msgid "[Platform Overview](overview.md) — all platforms"
+msgstr ""
+
+#: src/platforms/wasm.md:1
+msgid "WebAssembly / Web"
+msgstr ""
+
+#: src/platforms/wasm.md:3
+msgid ""
+"Perry compiles TypeScript apps to **WebAssembly** for the browser using "
+"`--target wasm` or its alias `--target web`. Both flags route through the "
+"same backend (`perry-codegen-wasm`) and produce the same output: a self-"
+"contained HTML file with embedded WASM bytecode and a thin JavaScript bridge"
+" for DOM widgets and host APIs."
+msgstr ""
+
+#: src/platforms/wasm.md:5
+msgid ""
+"There used to be a separate JavaScript-emitting `--target web` (`perry-"
+"codegen-js`); it was consolidated into the WASM target so browser apps get "
+"near-native performance, FFI imports, and Web Worker threading \"for free\"."
+msgstr ""
+
+#: src/platforms/wasm.md:10
+msgid "# Self-contained HTML (default)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:13
+msgid "# Same thing\n"
+msgstr ""
+
+#: src/platforms/wasm.md:16
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:21
+msgid ""
+"The default output is a single `.html` file containing a base64-embedded "
+"WASM binary, the `wasm_runtime.js` bridge, and a `bootPerryWasm()` call that"
+" instantiates the module. Open it directly in any modern browser — no build "
+"step, no server required for simple apps."
+msgstr ""
+
+#: src/platforms/wasm.md:23
+msgid ""
+"**Note**: Apps that use `fetch()` or other web platform APIs that depend on "
+"a real origin must be served over HTTP (file:// URLs run into CORS / "
+"\"Failed to fetch\" errors). Any local static server works:"
+msgstr ""
+
+#: src/platforms/wasm.md:31
+msgid ""
+"The `perry-codegen-wasm` crate compiles HIR directly to WASM bytecode using "
+"`wasm-encoder`. The output WASM:"
+msgstr ""
+
+#: src/platforms/wasm.md:33
+msgid ""
+"Imports ~280 host functions under the `rt` namespace (string ops, math, "
+"console, JSON, classes, closures, promises, fetch, etc.)"
+msgstr ""
+
+#: src/platforms/wasm.md:34
+msgid "Imports user-declared FFI functions under the `ffi` namespace"
+msgstr ""
+
+#: src/platforms/wasm.md:35
+msgid ""
+"Exports `_start`, `memory`, `__indirect_function_table`, and every user "
+"function as `__wasm_func_<idx>` (so async function bodies compiled to JS can"
+" call back into WASM)"
+msgstr ""
+
+#: src/platforms/wasm.md:37
+msgid ""
+"The NaN-boxing scheme matches the native `perry-runtime` — f64 values with "
+"STRING_TAG/POINTER_TAG/INT32_TAG — so the same value representation is used "
+"across native and WASM targets. The JS bridge wraps every host import with "
+"bit-level reinterpretation so f64 NaN-boxed values pass through the BigInt-"
+"based JS↔WASM i64 boundary intact (BigInt(NaN) would otherwise throw)."
+msgstr ""
+
+#: src/platforms/wasm.md:41
+msgid ""
+"**Full TypeScript language**: classes (with constructors, methods, "
+"getters/setters, inheritance, fields), async/await, closures (with "
+"captures), generators, destructuring, template literals, generics, enums, "
+"try/catch/finally"
+msgstr ""
+
+#: src/platforms/wasm.md:42
+msgid ""
+"**Module system**: cross-module imports, top-level `const`/`let` (promoted "
+"to WASM globals), circular imports"
+msgstr ""
+
+#: src/platforms/wasm.md:43
+msgid ""
+"**Standard library**: String/Array/Object methods, Map/Set, JSON, Date, "
+"RegExp, Math, Error, URL/URLSearchParams, Buffer, Promise (with "
+"`.then`/`.catch`/`.allSettled`/`.race`/`.any`/`.all`)"
+msgstr ""
+
+#: src/platforms/wasm.md:44
+msgid ""
+"**Async**: `async`/`await` (compiled to JS Promises), "
+"`setTimeout`/`setInterval`, `fetch()` with full request options (method, "
+"headers, body)"
+msgstr ""
+
+#: src/platforms/wasm.md:45
+msgid ""
+"**Threading**: `perry/thread` `parallelMap`/`parallelFilter`/`spawn` via Web"
+" Worker pool with one WASM instance per worker (see "
+"[Threading](../threading/overview.md))"
+msgstr ""
+
+#: src/platforms/wasm.md:46
+msgid ""
+"**DOM-based UI**: every widget in `perry/ui` (`VStack`, `HStack`, `ZStack`, "
+"`Text`, `Button`, `TextField`, `Toggle`, `Slider`, `ScrollView`, `Picker`, "
+"`Image`, `Canvas`, `Form`, `Section`, `NavigationStack`, `Table`, "
+"`LazyVStack`, `TextArea`, etc.) maps to a DOM element with flexbox layout. "
+"State bindings (`bindText`/`bindSlider`/`bindToggle`/`bindForEach`/...) work"
+" via reactive subscribers."
+msgstr ""
+
+#: src/platforms/wasm.md:47
+msgid ""
+"**System APIs**: `localStorage`\\-backed preferences/keychain, dark mode "
+"detection (`prefers-color-scheme`), Web Notifications, clipboard, file "
+"open/save dialogs, File System Access API, Web Audio capture"
+msgstr ""
+
+#: src/platforms/wasm.md:48
+msgid ""
+"**FFI**: `declare function` declarations become WASM imports under the `ffi`"
+" namespace"
+msgstr ""
+
+#: src/platforms/wasm.md:49
+msgid ""
+"**Compile-time i18n**: `perry/i18n` `t()` calls work the same as native "
+"targets"
+msgstr ""
+
+#: src/platforms/wasm.md:51
+msgid "UI Mapping"
+msgstr ""
+
+#: src/platforms/wasm.md:53
+msgid "Perry widgets map to HTML elements:"
+msgstr ""
+
+#: src/platforms/wasm.md:55
+msgid "HTML Element"
+msgstr ""
+
+#: src/platforms/wasm.md:57 src/widgets/wearos.md:24
+msgid "`Text`"
+msgstr ""
+
+#: src/platforms/wasm.md:58
+msgid "`Button`"
+msgstr ""
+
+#: src/platforms/wasm.md:59
+msgid "`TextField`"
+msgstr ""
+
+#: src/platforms/wasm.md:59
+msgid "`<input type=\"text\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:60
+msgid "`SecureField`"
+msgstr ""
+
+#: src/platforms/wasm.md:60
+msgid "`<input type=\"password\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:61
+msgid "`Toggle`"
+msgstr ""
+
+#: src/platforms/wasm.md:61
+msgid "`<input type=\"checkbox\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:62
+msgid "`Slider`"
+msgstr ""
+
+#: src/platforms/wasm.md:62
+msgid "`<input type=\"range\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:63
+msgid "`Picker`"
+msgstr ""
+
+#: src/platforms/wasm.md:63
+msgid "`<select>`"
+msgstr ""
+
+#: src/platforms/wasm.md:64
+msgid "`ProgressView`"
+msgstr ""
+
+#: src/platforms/wasm.md:64
+msgid "`<progress>`"
+msgstr ""
+
+#: src/platforms/wasm.md:65
+msgid "`Image` / `ImageFile`"
+msgstr ""
+
+#: src/platforms/wasm.md:65
+msgid "`<img>`"
+msgstr ""
+
+#: src/platforms/wasm.md:66 src/widgets/wearos.md:25
+msgid "`VStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:66
+msgid "`<div>` (flexbox column)"
+msgstr ""
+
+#: src/platforms/wasm.md:67 src/widgets/wearos.md:26
+msgid "`HStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:67
+msgid "`<div>` (flexbox row)"
+msgstr ""
+
+#: src/platforms/wasm.md:68
+msgid "`ZStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:68
+msgid "`<div>` (position: relative + absolute children)"
+msgstr ""
+
+#: src/platforms/wasm.md:69
+msgid "`ScrollView`"
+msgstr ""
+
+#: src/platforms/wasm.md:69
+msgid "`<div>` (overflow: auto)"
+msgstr ""
+
+#: src/platforms/wasm.md:70
+msgid "`Canvas`"
+msgstr ""
+
+#: src/platforms/wasm.md:70
+msgid "`<canvas>` (2D context)"
+msgstr ""
+
+#: src/platforms/wasm.md:71
+msgid "`Table`"
+msgstr ""
+
+#: src/platforms/wasm.md:71
+msgid "`<table>`"
+msgstr ""
+
+#: src/platforms/wasm.md:72 src/widgets/wearos.md:28
+msgid "`Divider`"
+msgstr ""
+
+#: src/platforms/wasm.md:72
+msgid "`<hr>`"
+msgstr ""
+
+#: src/platforms/wasm.md:73 src/widgets/wearos.md:27
+msgid "`Spacer`"
+msgstr ""
+
+#: src/platforms/wasm.md:73
+msgid "`<div>` (flex: 1)"
+msgstr ""
+
+#: src/platforms/wasm.md:75
+msgid "FFI Support"
+msgstr ""
+
+#: src/platforms/wasm.md:77
+msgid ""
+"The WASM target supports external FFI functions declared with `declare "
+"function`. They become WASM imports under the `\"ffi\"` namespace:"
+msgstr ""
+
+#: src/platforms/wasm.md:85
+msgid "Provide them when instantiating:"
+msgstr ""
+
+#: src/platforms/wasm.md:88
+msgid "// Via __ffiImports global (set before boot)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:90
+msgid "// Or via bootPerryWasm second argument\n"
+msgstr ""
+
+#: src/platforms/wasm.md:95
+msgid ""
+"**Auto-stub for missing imports.** The `ffi` namespace is wrapped in a "
+"`Proxy` so any FFI function the host doesn't provide is auto-stubbed with a "
+"no-op that returns `TAG_UNDEFINED`. This means apps that use native "
+"libraries (e.g. Hone Editor's 56 `hone_editor_*` functions) can still "
+"instantiate and run in the browser even without the native bindings — the "
+"relevant features are simply no-ops."
+msgstr ""
+
+#: src/platforms/wasm.md:97
+msgid "Module-Level Constants"
+msgstr ""
+
+#: src/platforms/wasm.md:99
+msgid ""
+"Top-level `const`/`let` declarations are promoted to dedicated WASM globals "
+"so functions in the same module can read them, and so two modules' identical"
+" `LocalId`s don't collide:"
+msgstr ""
+
+#: src/platforms/wasm.md:101
+msgid ""
+"```typescript\n"
+"// telemetry.ts\n"
+"const CHIRP_URL = 'https://api.chirp247.com/api/v1/event'\n"
+"const API_KEY   = 'my-key'\n"
+"\n"
+"export function trackEvent(event: string): void {\n"
+"    fetch(CHIRP_URL, {\n"
+"        method: 'POST',\n"
+"        headers: { 'Content-Type': 'application/json', 'X-Chirp-Key': API_KEY },\n"
+"        body: JSON.stringify({ event }),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/wasm.md:115
+msgid ""
+"Both `CHIRP_URL` and `API_KEY` become WASM globals indexed by `(module_idx, "
+"LocalId)`. Reading them from `trackEvent` emits a `global.get` instead of "
+"trying to look up a function-local that doesn't exist."
+msgstr ""
+
+#: src/platforms/wasm.md:117
+msgid "JavaScript Runtime Bridge"
+msgstr ""
+
+#: src/platforms/wasm.md:119
+msgid ""
+"The bridge (`wasm_runtime.js`) is embedded in the HTML and provides ~280 "
+"imports across:"
+msgstr ""
+
+#: src/platforms/wasm.md:121
+msgid ""
+"**NaN-boxing helpers**: `f64ToU64` / `u64ToF64` / `nanboxString` / "
+"`nanboxPointer` / `toJsValue` / `fromJsValue`"
+msgstr ""
+
+#: src/platforms/wasm.md:122
+msgid "**String table**: dynamic JS string array indexed by string ID"
+msgstr ""
+
+#: src/platforms/wasm.md:123
+msgid ""
+"**Handle store**: maps integer handle IDs to JS objects, arrays, closures, "
+"promises, DOM elements"
+msgstr ""
+
+#: src/platforms/wasm.md:124
+msgid ""
+"**Core ops**: console, math, JSON, JSON.parse/stringify, Date, RegExp, URL, "
+"Map, Set, Buffer, fetch"
+msgstr ""
+
+#: src/platforms/wasm.md:125
+msgid ""
+"**Closure dispatch**: indirect function table + capture array, with "
+"`closure_call_0/1/2/3/spread`"
+msgstr ""
+
+#: src/platforms/wasm.md:126
+msgid ""
+"**Class dispatch**: `class_new`, `class_call_method`, `class_get_field`, "
+"`class_set_field`, parent table for inheritance"
+msgstr ""
+
+#: src/platforms/wasm.md:127
+msgid ""
+"**DOM widgets**: 168+ `perry_ui_*` functions covering every widget in "
+"`perry/ui`"
+msgstr ""
+
+#: src/platforms/wasm.md:128
+msgid ""
+"**Async functions**: compiled to JS function bodies and merged into the "
+"import object as `__async_<name>`"
+msgstr ""
+
+#: src/platforms/wasm.md:130
+msgid ""
+"All host imports are wrapped via `wrapImportsForI64()` so they automatically"
+" reinterpret BigInt args (from WASM i64 params) into f64 internally and "
+"reinterpret Number returns back into BigInt. Without this wrapping, every "
+"NaN-valued f64 return would crash with \"Cannot convert NaN to a BigInt\"."
+msgstr ""
+
+#: src/platforms/wasm.md:132
+msgid "Web Worker Threading"
+msgstr ""
+
+#: src/platforms/wasm.md:134
+msgid "`perry/thread` works in the browser via a Web Worker pool:"
+msgstr ""
+
+#: src/platforms/wasm.md:144
+msgid ""
+"Each worker instantiates its own WASM module with the same bytecode and "
+"bridge. Values cross between the main thread and workers via structured-"
+"clone serialization. See [Threading](../threading/overview.md)."
+msgstr ""
+
+#: src/platforms/wasm.md:148
+msgid ""
+"**No file system access** beyond the File System Access API "
+"(`window.showDirectoryPicker()`)"
+msgstr ""
+
+#: src/platforms/wasm.md:149
+msgid "**No raw TCP/UDP sockets** — only `fetch()` and `WebSocket`"
+msgstr ""
+
+#: src/platforms/wasm.md:150
+msgid "**No subprocess spawning** — `child_process.exec` etc. are no-ops"
+msgstr ""
+
+#: src/platforms/wasm.md:151
+msgid ""
+"**No native databases** — SQLite, Postgres, MySQL drivers don't compile to "
+"web"
+msgstr ""
+
+#: src/platforms/wasm.md:152
+msgid ""
+"**CORS** applies to all `fetch()` calls — third-party APIs must allow your "
+"origin"
+msgstr ""
+
+#: src/platforms/wasm.md:153
+msgid ""
+"**localStorage**, not real keychain — fine for preferences, not for secrets"
+msgstr ""
+
+#: src/platforms/wasm.md:154
+msgid ""
+"Source-mapped stack traces are JS-only; WASM stack frames show `wasm-"
+"function[N]`"
+msgstr ""
+
+#: src/platforms/wasm.md:156
+msgid "Minification"
+msgstr ""
+
+#: src/platforms/wasm.md:158
+msgid ""
+"Use `--minify` to minify the embedded JS runtime bridge in the HTML output. "
+"The Rust-native JS minifier strips comments, collapses whitespace, and "
+"mangles internal identifiers, compressing the runtime from ~3,400 lines to "
+"~180."
+msgstr ""
+
+#: src/platforms/wasm.md:164
+msgid "Example: Counter App"
+msgstr ""
+
+#: src/platforms/wasm.md:187
+msgid "Example: Real-World App (Mango MongoDB GUI)"
+msgstr ""
+
+#: src/platforms/wasm.md:189
+msgid ""
+"The [Mango](https://github.com/PerryTS/mango) MongoDB GUI — 50 modules, 998 "
+"functions, classes, async functions, fetch with custom headers, the Hone "
+"code editor — compiles to a single 4 MB HTML file via `--target web` and "
+"renders its full UI (welcome screen, query view, edit view) in the browser. "
+"SQLite-backed connection storage gracefully degrades to an in-memory "
+"transient store on web; the rest of the app works the same as the native "
+"version."
+msgstr ""
+
+#: src/platforms/wasm.md:195
+msgid "[Threading](../threading/overview.md) — Web Worker threading"
+msgstr ""
+
+#: src/stdlib/overview.md:1
+msgid "Standard Library Overview"
+msgstr ""
+
+#: src/stdlib/overview.md:3
+msgid ""
+"Perry natively implements many popular npm packages and Node.js APIs. When "
+"you import a supported package, Perry compiles it to native code — no "
+"JavaScript runtime involved."
+msgstr ""
+
+#: src/stdlib/overview.md:7
+msgid ""
+"```typescript\n"
+"import fastify from \"fastify\"\n"
+"import mysql from \"mysql2/promise\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/overview.md:12
+msgid ""
+"Perry recognizes these imports at compile time and routes them to native "
+"Rust implementations in the `perry-stdlib` crate. The API surface matches "
+"the original npm package, so existing code often works unchanged."
+msgstr ""
+
+#: src/stdlib/overview.md:14
+msgid "Supported Packages"
+msgstr ""
+
+#: src/stdlib/overview.md:16
+msgid "Networking & HTTP"
+msgstr ""
+
+#: src/stdlib/overview.md:17
+msgid "**fastify** — HTTP server framework"
+msgstr ""
+
+#: src/stdlib/overview.md:18
+msgid "**axios** — HTTP client"
+msgstr ""
+
+#: src/stdlib/overview.md:19
+msgid "**node-fetch** / **fetch** — HTTP fetch API"
+msgstr ""
+
+#: src/stdlib/overview.md:20
+msgid "**ws** — WebSocket client/server"
+msgstr ""
+
+#: src/stdlib/overview.md:23
+msgid "**mysql2** — MySQL client"
+msgstr ""
+
+#: src/stdlib/overview.md:24
+msgid "**pg** — PostgreSQL client"
+msgstr ""
+
+#: src/stdlib/overview.md:25
+msgid "**better-sqlite3** — SQLite"
+msgstr ""
+
+#: src/stdlib/overview.md:26
+msgid "**mongodb** — MongoDB client"
+msgstr ""
+
+#: src/stdlib/overview.md:27
+msgid "**ioredis** / **redis** — Redis client"
+msgstr ""
+
+#: src/stdlib/overview.md:30
+msgid "**bcrypt** — Password hashing"
+msgstr ""
+
+#: src/stdlib/overview.md:31
+msgid "**argon2** — Password hashing (Argon2)"
+msgstr ""
+
+#: src/stdlib/overview.md:32
+msgid "**jsonwebtoken** — JWT signing/verification"
+msgstr ""
+
+#: src/stdlib/overview.md:33
+msgid "**crypto** — Node.js crypto module"
+msgstr ""
+
+#: src/stdlib/overview.md:34
+msgid "**ethers** — Ethereum library"
+msgstr ""
+
+#: src/stdlib/overview.md:37
+msgid "**lodash** — Utility functions"
+msgstr ""
+
+#: src/stdlib/overview.md:38
+msgid "**dayjs** / **moment** — Date manipulation"
+msgstr ""
+
+#: src/stdlib/overview.md:39
+msgid "**uuid** — UUID generation"
+msgstr ""
+
+#: src/stdlib/overview.md:40
+msgid "**nanoid** — ID generation"
+msgstr ""
+
+#: src/stdlib/overview.md:41
+msgid "**slugify** — String slugification"
+msgstr ""
+
+#: src/stdlib/overview.md:42
+msgid "**validator** — String validation"
+msgstr ""
+
+#: src/stdlib/overview.md:44
+msgid "CLI & Data"
+msgstr ""
+
+#: src/stdlib/overview.md:45
+msgid "**commander** — CLI argument parsing"
+msgstr ""
+
+#: src/stdlib/overview.md:46
+msgid "**decimal.js** — Arbitrary precision decimals"
+msgstr ""
+
+#: src/stdlib/overview.md:47
+msgid "**bignumber.js** — Big number math"
+msgstr ""
+
+#: src/stdlib/overview.md:48
+msgid "**lru-cache** — LRU caching"
+msgstr ""
+
+#: src/stdlib/overview.md:51
+msgid "**sharp** — Image processing"
+msgstr ""
+
+#: src/stdlib/overview.md:52
+msgid "**cheerio** — HTML parsing"
+msgstr ""
+
+#: src/stdlib/overview.md:53
+msgid "**nodemailer** — Email sending"
+msgstr ""
+
+#: src/stdlib/overview.md:54
+msgid "**zlib** — Compression"
+msgstr ""
+
+#: src/stdlib/overview.md:55
+msgid "**cron** — Job scheduling"
+msgstr ""
+
+#: src/stdlib/overview.md:56
+msgid "**worker_threads** — Background workers"
+msgstr ""
+
+#: src/stdlib/overview.md:57
+msgid "**exponential-backoff** — Retry logic"
+msgstr ""
+
+#: src/stdlib/overview.md:58
+msgid "**async_hooks** — AsyncLocalStorage"
+msgstr ""
+
+#: src/stdlib/overview.md:60
+msgid "Node.js Built-ins"
+msgstr ""
+
+#: src/stdlib/overview.md:61
+msgid "**fs** — File system"
+msgstr ""
+
+#: src/stdlib/overview.md:62
+msgid "**path** — Path manipulation"
+msgstr ""
+
+#: src/stdlib/overview.md:63
+msgid "**child_process** — Process spawning"
+msgstr ""
+
+#: src/stdlib/overview.md:64
+msgid "**crypto** — Cryptographic functions"
+msgstr ""
+
+#: src/stdlib/overview.md:68
+msgid "Perry automatically detects which stdlib features your code uses:"
+msgstr ""
+
+#: src/stdlib/overview.md:70 src/system/preferences.md:8
+#: src/system/keychain.md:8
+msgid "Usage"
+msgstr ""
+
+#: src/stdlib/overview.md:72
+msgid "No stdlib imports"
+msgstr ""
+
+#: src/stdlib/overview.md:73
+msgid "fs + path only"
+msgstr ""
+
+#: src/stdlib/overview.md:74
+msgid "Full stdlib"
+msgstr ""
+
+#: src/stdlib/overview.md:76
+msgid "The compiler links only the required runtime components."
+msgstr ""
+
+#: src/stdlib/overview.md:78
+msgid "compilePackages"
+msgstr ""
+
+#: src/stdlib/overview.md:80
+msgid ""
+"For npm packages not natively supported, you can compile pure "
+"TypeScript/JavaScript packages natively:"
+msgstr ""
+
+#: src/stdlib/overview.md:90
+msgid ""
+"See [Project Configuration](../getting-started/project-config.md) for "
+"details."
+msgstr ""
+
+#: src/stdlib/overview.md:92
+msgid "JavaScript Runtime Fallback"
+msgstr ""
+
+#: src/stdlib/overview.md:94
+msgid ""
+"For packages that can't be compiled natively (native addons, dynamic code, "
+"etc.), Perry includes a QuickJS-based JavaScript runtime as a fallback. The "
+"exact API surface is internal-only today; the import below is illustrative:"
+msgstr ""
+
+#: src/stdlib/overview.md:96
+msgid ""
+"```text\n"
+"import { jsEval } from \"perry/jsruntime\"; // illustrative — not yet a public export\n"
+"```"
+msgstr ""
+
+#: src/stdlib/overview.md:102
+msgid "[File System](fs.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:103 src/stdlib/fs.md:90
+msgid "[HTTP & Networking](http.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:104 src/stdlib/http.md:95
+msgid "[Databases](database.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:105 src/stdlib/database.md:109
+msgid "[Cryptography](crypto.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:106 src/stdlib/crypto.md:89
+msgid "[Utilities](utilities.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:107 src/stdlib/utilities.md:106
+msgid "[Other Modules](other.md)"
+msgstr ""
+
+#: src/stdlib/fs.md:3
+msgid ""
+"Perry implements Node.js file system APIs for reading, writing, and managing"
+" files."
+msgstr ""
+
+#: src/stdlib/fs.md:5
+msgid "Reading Files"
+msgstr ""
+
+#: src/stdlib/fs.md:7
+msgid ""
+"```typescript\n"
+"const configPath = join(scratch, \"config.json\")\n"
+"const content = readFileSync(configPath, \"utf-8\")\n"
+"console.log(content)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:13
+msgid "Binary File Reading"
+msgstr ""
+
+#: src/stdlib/fs.md:15
+msgid ""
+"```typescript\n"
+"const imagePath = join(scratch, \"image.png\")\n"
+"const buffer = readFileBuffer(imagePath)\n"
+"console.log(`Read ${buffer.length} bytes`)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:21
+msgid ""
+"`readFileBuffer` reads files as binary data (uses `fs::read()` internally, "
+"not `read_to_string()`)."
+msgstr ""
+
+#: src/stdlib/fs.md:23
+msgid "Writing Files"
+msgstr ""
+
+#: src/stdlib/fs.md:25
+msgid ""
+"```typescript\n"
+"const outputPath = join(scratch, \"output.txt\")\n"
+"const dataPath = join(scratch, \"data.json\")\n"
+"writeFileSync(outputPath, \"Hello, World!\")\n"
+"writeFileSync(dataPath, JSON.stringify({ key: \"value\" }, null, 2))\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:32
+msgid "File Information"
+msgstr ""
+
+#: src/stdlib/fs.md:41
+msgid "Directory Operations"
+msgstr ""
+
+#: src/stdlib/fs.md:43
+msgid ""
+"```typescript\n"
+"// Create directory\n"
+"const outDir = join(scratch, \"output\")\n"
+"if (!existsSync(outDir)) mkdirSync(outDir)\n"
+"\n"
+"// Read directory contents\n"
+"const files = readdirSync(scratch)\n"
+"for (const file of files) {\n"
+"    console.log(file)\n"
+"}\n"
+"\n"
+"// Remove an empty directory\n"
+"rmdirSync(outDir)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:58
+msgid ""
+"For recursive removal Perry exposes `rmRecursive` (a thin wrapper around "
+"`std::fs::remove_dir_all`). Wired via "
+"[\\#193](https://github.com/PerryTS/perry/issues/193) through "
+"`js_fs_rm_recursive` in the LLVM backend."
+msgstr ""
+
+#: src/stdlib/fs.md:63
+msgid ""
+"```typescript,no-test\n"
+"import { rmRecursive } from \"fs\";\n"
+"rmRecursive(\"output\"); // Recursive remove; returns 1 on success, 0 on failure.\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:68
+msgid "Path Utilities"
+msgstr ""
+
+#: src/stdlib/fs.md:70
+msgid ""
+"```typescript\n"
+"const dir = dirname(configPath)\n"
+"const cfgPath = join(dir, \"config.json\")\n"
+"const name = basename(cfgPath)        // \"config.json\"\n"
+"const abs = resolve(\"relative/path\")  // Absolute path\n"
+"console.log(`${name} ${abs.length > 0}`)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:78
+msgid ""
+"For `import.meta.url` → filesystem path conversion, use `fileURLToPath` from"
+" the `url` module:"
+msgstr ""
+
+#: src/stdlib/fs.md:81
+msgid ""
+"```text\n"
+"import { fileURLToPath } from \"url\";\n"
+"import { dirname } from \"path\";\n"
+"\n"
+"const dir = dirname(fileURLToPath(import.meta.url));\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:91 src/stdlib/http.md:96 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:107 src/stdlib/other.md:186
+msgid "[Overview](overview.md) — All stdlib modules"
+msgstr ""
+
+#: src/stdlib/http.md:3
+msgid ""
+"Perry natively implements HTTP servers, clients, and WebSocket support."
+msgstr ""
+
+#: src/stdlib/http.md:5
+msgid "Fastify Server"
+msgstr ""
+
+#: src/stdlib/http.md:7
+msgid ""
+"```typescript\n"
+"import fastify from \"fastify\"\n"
+"\n"
+"const app = fastify()\n"
+"\n"
+"app.get(\"/\", async (request: any, reply: any) => {\n"
+"    return { hello: \"world\" }\n"
+"})\n"
+"\n"
+"app.get(\"/users/:id\", async (request: any, reply: any) => {\n"
+"    const id = request.params.id\n"
+"    return { id, name: \"User \" + id }\n"
+"})\n"
+"\n"
+"app.post(\"/data\", async (request: any, reply: any) => {\n"
+"    const body = request.body\n"
+"    reply.code(201)\n"
+"    return { received: body }\n"
+"})\n"
+"\n"
+"app.listen({ port: 3000 }, () => {\n"
+"    console.log(\"Server running on port 3000\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:32
+msgid ""
+"Perry's Fastify implementation is API-compatible with the npm package. "
+"Routes, request/reply objects, params, query strings, and JSON body parsing "
+"all work."
+msgstr ""
+
+#: src/stdlib/http.md:34
+msgid "Fetch API"
+msgstr ""
+
+#: src/stdlib/http.md:36
+msgid ""
+"```typescript\n"
+"async function fetchExamples(): Promise<void> {\n"
+"    // GET request\n"
+"    const response = await fetch(\"https://jsonplaceholder.typicode.com/posts/1\")\n"
+"    const data = await response.json()\n"
+"\n"
+"    // POST request\n"
+"    const result = await fetch(\"https://jsonplaceholder.typicode.com/posts\", {\n"
+"        method: \"POST\",\n"
+"        headers: { \"Content-Type\": \"application/json\" },\n"
+"        body: JSON.stringify({ title: \"hello\", body: \"world\", userId: 1 }),\n"
+"    })\n"
+"\n"
+"    console.log(`fetch ok: ${data !== null} status=${result.status}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:53
+msgid "Axios"
+msgstr ""
+
+#: src/stdlib/http.md:55
+msgid ""
+"```typescript\n"
+"import axios from \"axios\"\n"
+"\n"
+"async function axiosExamples(): Promise<void> {\n"
+"    const getResp = await axios.get(\"https://jsonplaceholder.typicode.com/users/1\")\n"
+"    const data = getResp.data\n"
+"\n"
+"    const response = await axios.post(\"https://jsonplaceholder.typicode.com/users\", {\n"
+"        name: \"Perry\",\n"
+"        email: \"perry@example.com\",\n"
+"    })\n"
+"\n"
+"    console.log(`axios ok: ${data !== null} status=${response.status}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:71
+msgid "WebSocket"
+msgstr ""
+
+#: src/stdlib/http.md:73
+msgid ""
+"```typescript\n"
+"import { WebSocket } from \"ws\"\n"
+"\n"
+"function wsExample(): void {\n"
+"    const ws = new WebSocket(\"ws://localhost:8080\")\n"
+"\n"
+"    ws.on(\"open\", () => {\n"
+"        ws.send(\"Hello, server!\")\n"
+"    })\n"
+"\n"
+"    ws.on(\"message\", (data: any) => {\n"
+"        console.log(`Received: ${data}`)\n"
+"    })\n"
+"\n"
+"    ws.on(\"close\", () => {\n"
+"        console.log(\"Connection closed\")\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:3
+msgid ""
+"Perry natively implements clients for MySQL, PostgreSQL, SQLite, MongoDB, "
+"and Redis."
+msgstr ""
+
+#: src/stdlib/database.md:5
+msgid "MySQL"
+msgstr ""
+
+#: src/stdlib/database.md:7
+msgid ""
+"```typescript\n"
+"import mysql from \"mysql2/promise\"\n"
+"\n"
+"async function mysqlExample(): Promise<void> {\n"
+"    const connection = await mysql.createConnection({\n"
+"        host: \"localhost\",\n"
+"        user: \"root\",\n"
+"        password: \"password\",\n"
+"        database: \"mydb\",\n"
+"    })\n"
+"\n"
+"    const [rows] = await connection.execute(\"SELECT * FROM users WHERE id = ?\", [1])\n"
+"    console.log(rows)\n"
+"\n"
+"    await connection.end()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:25
+msgid "PostgreSQL"
+msgstr ""
+
+#: src/stdlib/database.md:27
+msgid ""
+"```typescript\n"
+"import { Client } from \"pg\"\n"
+"\n"
+"async function postgresExample(): Promise<void> {\n"
+"    const client = new Client({\n"
+"        host: \"localhost\",\n"
+"        port: 5432,\n"
+"        user: \"postgres\",\n"
+"        password: \"password\",\n"
+"        database: \"mydb\",\n"
+"    })\n"
+"\n"
+"    await client.connect()\n"
+"    const result = await client.query(\"SELECT * FROM users WHERE id = $1\", [1])\n"
+"    console.log(result.rows)\n"
+"    await client.end()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:46
+msgid "SQLite"
+msgstr ""
+
+#: src/stdlib/database.md:48
+msgid ""
+"```typescript\n"
+"import Database from \"better-sqlite3\"\n"
+"\n"
+"function sqliteExample(): void {\n"
+"    const db = new Database(\"mydb.sqlite\")\n"
+"\n"
+"    db.exec(`\n"
+"      CREATE TABLE IF NOT EXISTS users (\n"
+"        id INTEGER PRIMARY KEY,\n"
+"        name TEXT,\n"
+"        email TEXT\n"
+"      )\n"
+"    `)\n"
+"\n"
+"    const insert = db.prepare(\"INSERT INTO users (name, email) VALUES (?, ?)\")\n"
+"    insert.run(\"Perry\", \"perry@example.com\")\n"
+"\n"
+"    const users = db.prepare(\"SELECT * FROM users\").all()\n"
+"    console.log(users)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:70
+msgid "MongoDB"
+msgstr ""
+
+#: src/stdlib/database.md:72
+msgid ""
+"```typescript\n"
+"import { MongoClient } from \"mongodb\"\n"
+"\n"
+"async function mongoExample(): Promise<void> {\n"
+"    const client = new MongoClient(\"mongodb://localhost:27017\")\n"
+"    await client.connect()\n"
+"\n"
+"    const db = client.db(\"mydb\")\n"
+"    const users = db.collection(\"users\")\n"
+"\n"
+"    await users.insertOne({ name: \"Perry\", email: \"perry@example.com\" })\n"
+"    const user = await users.findOne({ name: \"Perry\" })\n"
+"    console.log(user)\n"
+"\n"
+"    await client.close()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:90
+msgid "Redis"
+msgstr ""
+
+#: src/stdlib/database.md:92
+msgid ""
+"```typescript\n"
+"import Redis from \"ioredis\"\n"
+"\n"
+"async function redisExample(): Promise<void> {\n"
+"    const redis = new Redis()\n"
+"\n"
+"    await redis.set(\"key\", \"value\")\n"
+"    const value = await redis.get(\"key\")\n"
+"    console.log(value) // \"value\"\n"
+"\n"
+"    await redis.del(\"key\")\n"
+"    await redis.quit()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:3
+msgid ""
+"Perry natively implements password hashing, JWT tokens, and Ethereum "
+"cryptography."
+msgstr ""
+
+#: src/stdlib/crypto.md:5
+msgid "bcrypt"
+msgstr ""
+
+#: src/stdlib/crypto.md:7
+msgid ""
+"```typescript\n"
+"import bcrypt from \"bcrypt\"\n"
+"\n"
+"async function bcryptExample(): Promise<void> {\n"
+"    const hash = await bcrypt.hash(\"mypassword\", 10)\n"
+"    const match = await bcrypt.compare(\"mypassword\", hash)\n"
+"    console.log(match) // true\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:17
+msgid "Argon2"
+msgstr ""
+
+#: src/stdlib/crypto.md:19
+msgid ""
+"```typescript\n"
+"import argon2 from \"argon2\"\n"
+"\n"
+"async function argon2Example(): Promise<void> {\n"
+"    const hash = await argon2.hash(\"mypassword\")\n"
+"    const valid = await argon2.verify(hash, \"mypassword\")\n"
+"    console.log(valid) // true\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:29
+msgid "JSON Web Tokens"
+msgstr ""
+
+#: src/stdlib/crypto.md:31
+msgid ""
+"```typescript\n"
+"import jwt from \"jsonwebtoken\"\n"
+"\n"
+"function jwtExample(): void {\n"
+"    const secret = \"my-secret-key\"\n"
+"\n"
+"    // Sign a token\n"
+"    const token = jwt.sign({ userId: 123, role: \"admin\" }, secret, {\n"
+"        expiresIn: \"1h\",\n"
+"    })\n"
+"\n"
+"    // Verify a token\n"
+"    const decoded: any = jwt.verify(token, secret)\n"
+"    console.log(decoded.userId) // 123\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:48
+msgid "Node.js Crypto"
+msgstr ""
+
+#: src/stdlib/crypto.md:50
+msgid ""
+"```typescript\n"
+"import crypto from \"crypto\"\n"
+"\n"
+"function cryptoExample(): void {\n"
+"    // Hash\n"
+"    const hash = crypto.createHash(\"sha256\").update(\"data\").digest(\"hex\")\n"
+"\n"
+"    // HMAC\n"
+"    const hmac = crypto.createHmac(\"sha256\", \"secret\").update(\"data\").digest(\"hex\")\n"
+"\n"
+"    // Random bytes\n"
+"    const bytes = crypto.randomBytes(32)\n"
+"\n"
+"    console.log(`hash_len=${hash.length} hmac_len=${hmac.length} bytes_len=${bytes.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:67
+msgid "Ethers"
+msgstr ""
+
+#: src/stdlib/crypto.md:69
+msgid ""
+"```typescript\n"
+"import { ethers } from \"ethers\"\n"
+"\n"
+"function ethersExample(): void {\n"
+"    // Utility functions\n"
+"    const addr = ethers.getAddress(\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\")\n"
+"    const wei = ethers.parseEther(\"1.5\")\n"
+"    const ether = ethers.formatEther(wei)\n"
+"    console.log(`checksum: ${addr}`)\n"
+"    console.log(`1.5 ether in wei → formatted back: ${ether}`)\n"
+"\n"
+"    // Create a random wallet\n"
+"    const wallet = ethers.Wallet.createRandom()\n"
+"    console.log(`address: ${wallet.address}`)\n"
+"    console.log(`privateKey length: ${wallet.privateKey.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:3
+msgid "Perry natively implements common utility packages."
+msgstr ""
+
+#: src/stdlib/utilities.md:5
+msgid "lodash"
+msgstr ""
+
+#: src/stdlib/utilities.md:7
+msgid ""
+"The `lodash` runtime functions are partially implemented (see `crates/perry-"
+"stdlib/src/lodash.rs`) but the user-facing dispatch from `import _ from "
+"\"lodash\"; _.chunk(...)` is not wired into the LLVM backend yet. Track the "
+"follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:12
+msgid ""
+"```text\n"
+"import _ from \"lodash\";\n"
+"\n"
+"_.chunk([1, 2, 3, 4, 5], 2);     // [[1,2], [3,4], [5]]\n"
+"_.uniq([1, 2, 2, 3, 3]);          // [1, 2, 3]\n"
+"_.groupBy(users, \"role\");\n"
+"_.sortBy(users, [\"name\"]);\n"
+"_.cloneDeep(obj);\n"
+"_.merge(defaults, overrides);\n"
+"_.debounce(fn, 300);\n"
+"_.throttle(fn, 100);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:25
+msgid "dayjs"
+msgstr ""
+
+#: src/stdlib/utilities.md:27
+msgid ""
+"`dayjs` runtime functions are declared (`js_dayjs_now`, `js_dayjs_format`, "
+"`js_dayjs_add`, etc.) but the user-facing dispatch from `import dayjs from "
+"\"dayjs\"; dayjs()` chained methods is not wired into the LLVM backend yet. "
+"Track the follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:32
+msgid ""
+"```text\n"
+"import dayjs from \"dayjs\";\n"
+"\n"
+"const now = dayjs();\n"
+"console.log(now.format(\"YYYY-MM-DD\"));\n"
+"console.log(now.add(7, \"day\").format(\"YYYY-MM-DD\"));\n"
+"console.log(now.subtract(1, \"month\").toISOString());\n"
+"\n"
+"const diff = dayjs(\"2025-12-31\").diff(now, \"day\");\n"
+"console.log(`${diff} days until end of year`);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:44
+msgid "moment"
+msgstr ""
+
+#: src/stdlib/utilities.md:46
+msgid ""
+"Same status as `dayjs` — the runtime functions exist but the dispatch path "
+"is not wired yet."
+msgstr ""
+
+#: src/stdlib/utilities.md:49
+msgid ""
+"```text\n"
+"import moment from \"moment\";\n"
+"\n"
+"const now = moment();\n"
+"console.log(now.format(\"MMMM Do YYYY\"));\n"
+"console.log(now.fromNow());\n"
+"console.log(moment(\"2025-01-01\").isBefore(now));\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:58
+msgid "uuid"
+msgstr ""
+
+#: src/stdlib/utilities.md:60
+msgid ""
+"```typescript\n"
+"import { v4 as uuidv4 } from \"uuid\"\n"
+"\n"
+"const id = uuidv4()\n"
+"console.log(id) // e.g., \"550e8400-e29b-41d4-a716-446655440000\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:67
+msgid "nanoid"
+msgstr ""
+
+#: src/stdlib/utilities.md:69
+msgid ""
+"The default-length `nanoid()` call is wired. The custom-length form "
+"`nanoid(10)` has a runtime function (`js_nanoid_sized`) but no dispatch yet "
+"— track at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:73
+msgid ""
+"```typescript\n"
+"import { nanoid } from \"nanoid\"\n"
+"\n"
+"const nid = nanoid() // Default 21 chars\n"
+"console.log(nid)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:80
+msgid "slugify"
+msgstr ""
+
+#: src/stdlib/utilities.md:82
+msgid ""
+"The single-arg form is wired. The options-object form `slugify(\"Hello "
+"World!\", { lower: true })` has a runtime function "
+"(`js_slugify_with_options`) but no dispatch yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:86
+msgid ""
+"```typescript\n"
+"import slugify from \"slugify\"\n"
+"\n"
+"const slug = slugify(\"Hello World!\")\n"
+"console.log(slug) // \"hello-world\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:93
+msgid "validator"
+msgstr ""
+
+#: src/stdlib/utilities.md:95
+msgid ""
+"```typescript\n"
+"import validator from \"validator\"\n"
+"\n"
+"console.log(validator.isEmail(\"test@example.com\"))  // true\n"
+"console.log(validator.isURL(\"https://example.com\")) // true\n"
+"console.log(validator.isUUID(id))                   // true\n"
+"console.log(validator.isEmpty(\"\"))                  // true\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:3
+msgid "Additional npm packages and Node.js APIs supported by Perry."
+msgstr ""
+
+#: src/stdlib/other.md:5
+msgid "sharp (Image Processing)"
+msgstr ""
+
+#: src/stdlib/other.md:7
+msgid ""
+"The `sharp` runtime functions are declared (`js_sharp_resize`, "
+"`js_sharp_blur`, `js_sharp_to_buffer`, etc.) but the user-facing dispatch "
+"from `import sharp from \"sharp\"; sharp(input).resize(...)` is not wired "
+"into the LLVM backend yet. Track the follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:12
+msgid ""
+"```text\n"
+"import sharp from \"sharp\";\n"
+"\n"
+"await sharp(\"input.jpg\")\n"
+"  .resize(300, 200)\n"
+"  .toFile(\"output.png\");\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:20
+msgid "cheerio (HTML Parsing)"
+msgstr ""
+
+#: src/stdlib/other.md:22
+msgid ""
+"The `cheerio` runtime exists (see `crates/perry-stdlib/src/cheerio.rs`) but "
+"the dispatch path is not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:25
+msgid ""
+"```text\n"
+"import cheerio from \"cheerio\";\n"
+"\n"
+"const html = \"<html><body><h1>Hello</h1><p>World</p></body></html>\";\n"
+"const $ = cheerio.load(html);\n"
+"console.log($(\"h1\").text()); // \"Hello\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:33
+msgid "nodemailer (Email)"
+msgstr ""
+
+#: src/stdlib/other.md:35
+msgid ""
+"```typescript\n"
+"import nodemailer from \"nodemailer\"\n"
+"\n"
+"async function nodemailerExample(): Promise<void> {\n"
+"    const transporter = nodemailer.createTransport({\n"
+"        host: \"smtp.example.com\",\n"
+"        port: 587,\n"
+"        auth: { user: \"user\", pass: \"pass\" },\n"
+"    })\n"
+"\n"
+"    await transporter.sendMail({\n"
+"        from: \"sender@example.com\",\n"
+"        to: \"recipient@example.com\",\n"
+"        subject: \"Hello from Perry\",\n"
+"        text: \"This email was sent from a compiled TypeScript binary!\",\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:54
+msgid "zlib (Compression)"
+msgstr ""
+
+#: src/stdlib/other.md:56
+msgid ""
+"The `zlib` runtime exists but dispatch from `import zlib from \"zlib\"` is "
+"not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:59
+msgid ""
+"```text\n"
+"import zlib from \"zlib\";\n"
+"\n"
+"const compressed = zlib.gzipSync(\"Hello, World!\");\n"
+"const decompressed = zlib.gunzipSync(compressed);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:66
+msgid "cron (Job Scheduling)"
+msgstr ""
+
+#: src/stdlib/other.md:68
+msgid ""
+"The `cron` runtime exists but dispatch from `import { CronJob } from "
+"\"cron\"` is not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:71
+msgid ""
+"```text\n"
+"import { CronJob } from \"cron\";\n"
+"\n"
+"const job = new CronJob(\"*/5 * * * *\", () => {\n"
+"  console.log(\"Runs every 5 minutes\");\n"
+"});\n"
+"job.start();\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:80
+msgid "worker_threads"
+msgstr ""
+
+#: src/stdlib/other.md:82
+msgid ""
+"The `worker_threads` API is partially recognized at HIR-lowering time "
+"(`parentPort` / `Worker` shapes) but full dispatch is incomplete. For data-"
+"parallel work today, prefer `parallelMap` / `parallelFilter` / `spawn` from "
+"`perry/thread` (see [Threading](../threading/overview.md))."
+msgstr ""
+
+#: src/stdlib/other.md:87
+msgid ""
+"```text\n"
+"import { Worker, parentPort, workerData } from \"worker_threads\";\n"
+"\n"
+"if (parentPort) {\n"
+"  // Worker thread\n"
+"  const data = workerData;\n"
+"  parentPort.postMessage({ result: data.value * 2 });\n"
+"} else {\n"
+"  // Main thread\n"
+"  const worker = new Worker(\"./worker.ts\", {\n"
+"    workerData: { value: 21 },\n"
+"  });\n"
+"  worker.on(\"message\", (msg) => {\n"
+"    console.log(msg.result); // 42\n"
+"  });\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:105
+msgid "commander (CLI Parsing)"
+msgstr ""
+
+#: src/stdlib/other.md:107
+msgid ""
+"```typescript\n"
+"import { Command } from \"commander\"\n"
+"\n"
+"function commanderExample(): void {\n"
+"    const program = new Command()\n"
+"    program.name(\"my-cli\").version(\"1.0.0\").description(\"My CLI tool\")\n"
+"\n"
+"    program\n"
+"        .command(\"serve\")\n"
+"        .option(\"-p, --port <number>\", \"Port number\")\n"
+"        .option(\"--verbose\", \"Verbose output\")\n"
+"        .action((options: any) => {\n"
+"            console.log(`Starting server on port ${options.port}`)\n"
+"        })\n"
+"\n"
+"    program.parse(process.argv)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:126
+msgid "decimal.js (Arbitrary Precision)"
+msgstr ""
+
+#: src/stdlib/other.md:128
+msgid ""
+"```typescript\n"
+"import Decimal from \"decimal.js\"\n"
+"\n"
+"function decimalExample(): void {\n"
+"    const a = new Decimal(\"0.1\")\n"
+"    const b = new Decimal(\"0.2\")\n"
+"    const sum = a.plus(b) // Exactly 0.3 (no floating point errors)\n"
+"\n"
+"    console.log(sum.toFixed(2))      // \"0.30\"\n"
+"    console.log(sum.toNumber())      // 0.3\n"
+"    console.log(a.times(b).toFixed(2)) // \"0.02\"\n"
+"    console.log(a.div(b).toFixed(1))   // \"0.5\"\n"
+"    console.log(a.pow(10).toString())  // 1e-10\n"
+"    console.log(a.sqrt().toFixed(3))   // \"0.316\"\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:145
+msgid "lru-cache"
+msgstr ""
+
+#: src/stdlib/other.md:147
+msgid ""
+"The wired constructor takes the npm v7+ options-object shape (`new "
+"LRUCache({ max: 100 })`) — the older positional form `new LRUCache(100)` "
+"falls through to a `max=100` default."
+msgstr ""
+
+#: src/stdlib/other.md:151
+msgid ""
+"```typescript\n"
+"import { LRUCache } from \"lru-cache\"\n"
+"\n"
+"function lruCacheExample(): void {\n"
+"    const cache = new LRUCache({ max: 100 }) // max 100 entries\n"
+"\n"
+"    cache.set(\"key\", \"value\")\n"
+"    console.log(cache.get(\"key\"))   // \"value\"\n"
+"    console.log(cache.has(\"key\"))   // true\n"
+"    cache.delete(\"key\")\n"
+"    cache.clear()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:165
+msgid "child_process"
+msgstr ""
+
+#: src/stdlib/other.md:167
+msgid ""
+"```typescript\n"
+"import { spawnBackground, getProcessStatus, killProcess } from \"child_process\"\n"
+"\n"
+"function childProcessExample(): void {\n"
+"    // Spawn a background process\n"
+"    const { pid, handleId } = spawnBackground(\"sleep\", [\"10\"], \"/tmp/log.txt\")\n"
+"\n"
+"    // Check if it's still running\n"
+"    const status = getProcessStatus(handleId)\n"
+"    console.log(status.alive) // true\n"
+"    console.log(`pid=${pid}`)\n"
+"\n"
+"    // Kill it\n"
+"    killProcess(handleId)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:187
+msgid "[File System](fs.md) — fs and path APIs"
+msgstr ""
+
+#: src/i18n/overview.md:1
+msgid "Internationalization (i18n)"
+msgstr ""
+
+#: src/i18n/overview.md:3
+msgid ""
+"Perry's i18n system lets you write natural English strings and have them "
+"automatically translated at compile time. Zero ceremony, near-zero runtime "
+"cost."
+msgstr ""
+
+#: src/i18n/overview.md:5
+msgid ""
+"```typescript\n"
+"// String literals in UI component calls are automatically localizable keys.\n"
+"// (Conceptually the docs write `Button(\"Next\")` / `Text(\"Hello, {name}!\", ...)`\n"
+"// from \"perry/ui\"; we exercise the runtime API that backs them — t() — here.)\n"
+"const next = t(\"Next\")                                  // Automatically localized\n"
+"const hello = t(\"Hello, {name}!\", { name: \"Alice\" })    // With interpolation\n"
+"console.log(next, hello)\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:14
+msgid ""
+"The same key-resolution and interpolation runs through the explicit `t()` "
+"API for non-UI strings:"
+msgstr ""
+
+#: src/i18n/overview.md:16
+msgid ""
+"```typescript\n"
+"import { t, Currency, Percent, ShortDate, LongDate, FormatNumber, FormatTime, Raw } from \"perry/i18n\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:20
+msgid "Design Principles"
+msgstr ""
+
+#: src/i18n/overview.md:22
+msgid ""
+"**Zero ceremony**: String literals in UI components are automatically "
+"localizable keys"
+msgstr ""
+
+#: src/i18n/overview.md:23
+msgid ""
+"**Compile-time validation**: Missing translations, parameter mismatches, and"
+" plural form errors caught during build"
+msgstr ""
+
+#: src/i18n/overview.md:24
+msgid ""
+"**Embedded string table**: All translations baked into the binary as a flat "
+"2D table. Near-zero runtime lookup cost"
+msgstr ""
+
+#: src/i18n/overview.md:25
+msgid ""
+"**Platform-native locale detection**: Uses OS APIs on every platform (no env"
+" vars needed on mobile)"
+msgstr ""
+
+#: src/i18n/overview.md:29
+msgid "1. Add i18n config to perry.toml"
+msgstr ""
+
+#: src/i18n/overview.md:31
+msgid ""
+"```toml\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\"]\n"
+"default_locale = \"en\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:37
+msgid "2. Extract strings from your code"
+msgstr ""
+
+#: src/i18n/overview.md:43
+msgid ""
+"This scans your source files and creates `locales/en.json` and "
+"`locales/de.json`:"
+msgstr ""
+
+#: src/i18n/overview.md:46 src/i18n/interpolation.md:17
+#: src/i18n/interpolation.md:49
+msgid "// locales/en.json\n"
+msgstr ""
+
+#: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
+#: src/i18n/cli.md:38 src/i18n/cli.md:87
+msgid "\"Next\""
+msgstr ""
+
+#: src/i18n/overview.md:49 src/i18n/overview.md:55 src/i18n/overview.md:66
+msgid "\"Back\""
+msgstr ""
+
+#: src/i18n/overview.md:51
+msgid "// locales/de.json (empty values = needs translation)\n"
+msgstr ""
+
+#: src/i18n/overview.md:54 src/i18n/overview.md:55
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:73
+msgid "\"\""
+msgstr ""
+
+#: src/i18n/overview.md:59
+msgid "3. Translate"
+msgstr ""
+
+#: src/i18n/overview.md:61
+msgid "Fill in `locales/de.json`:"
+msgstr ""
+
+#: src/i18n/overview.md:65
+msgid "\"Weiter\""
+msgstr ""
+
+#: src/i18n/overview.md:66
+msgid "\"Zurck\""
+msgstr ""
+
+#: src/i18n/overview.md:70
+msgid "4. Build"
+msgstr ""
+
+#: src/i18n/overview.md:76
+msgid ""
+"Perry validates all translations at compile time and bakes them into the "
+"binary. At runtime, the app detects the user's system locale and shows the "
+"right language."
+msgstr ""
+
+#: src/i18n/overview.md:80
+msgid ""
+"**Detection**: String literals in UI component calls (`Button`, `Text`, "
+"`Label`, etc.) are automatically treated as i18n keys"
+msgstr ""
+
+#: src/i18n/overview.md:81
+msgid ""
+"**Transform**: The compiler replaces `Expr::String(\"Next\")` with "
+"`Expr::I18nString { key: \"Next\", string_idx: 0 }` in the HIR"
+msgstr ""
+
+#: src/i18n/overview.md:82
+msgid ""
+"**Codegen**: For each `I18nString`, the compiler emits a locale branch that "
+"selects the correct translation at runtime"
+msgstr ""
+
+#: src/i18n/overview.md:83
+msgid ""
+"**Locale detection**: At startup, `perry_i18n_init()` detects the system "
+"locale via native APIs and sets the global locale index"
+msgstr ""
+
+#: src/i18n/overview.md:85
+msgid "Locale Detection"
+msgstr ""
+
+#: src/i18n/overview.md:89 src/i18n/overview.md:90
+msgid "`CFLocaleCopyCurrent()` (CoreFoundation)"
+msgstr ""
+
+#: src/i18n/overview.md:91
+msgid "`__system_property_get(\"persist.sys.locale\")`"
+msgstr ""
+
+#: src/i18n/overview.md:92
+msgid "`GetUserDefaultLocaleName()` (Win32)"
+msgstr ""
+
+#: src/i18n/overview.md:93
+msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
+msgstr ""
+
+#: src/i18n/overview.md:95
+msgid ""
+"The detected locale is fuzzy-matched against your configured locales: "
+"`de_DE.UTF-8` matches `de`, `en-US` matches `en`, etc."
+msgstr ""
+
+#: src/i18n/overview.md:97
+msgid "Platform Output"
+msgstr ""
+
+#: src/i18n/overview.md:99
+msgid ""
+"When compiling for mobile targets, Perry generates platform-native locale "
+"resources alongside the binary:"
+msgstr ""
+
+#: src/i18n/overview.md:101 src/widgets/platforms.md:9
+msgid "Output"
+msgstr ""
+
+#: src/i18n/overview.md:103
+msgid "iOS/macOS"
+msgstr ""
+
+#: src/i18n/overview.md:103
+msgid "`{locale}.lproj/Localizable.strings` inside `.app` bundle"
+msgstr ""
+
+#: src/i18n/overview.md:104
+msgid "`res/values-{locale}/strings.xml`"
+msgstr ""
+
+#: src/i18n/overview.md:105
+msgid "Desktop"
+msgstr ""
+
+#: src/i18n/overview.md:105
+msgid "Strings embedded in binary (no extra files)"
+msgstr ""
+
+#: src/i18n/overview.md:109
+msgid "[Interpolation & Plurals](interpolation.md)"
+msgstr ""
+
+#: src/i18n/overview.md:110
+msgid "[Formatting](formatting.md)"
+msgstr ""
+
+#: src/i18n/overview.md:111
+msgid "[CLI Tools](cli.md)"
+msgstr ""
+
+#: src/i18n/interpolation.md:3
+msgid "Parameterized Strings"
+msgstr ""
+
+#: src/i18n/interpolation.md:5
+msgid ""
+"Use `{param}` placeholders in your strings and pass values as a second "
+"argument:"
+msgstr ""
+
+#: src/i18n/interpolation.md:7
+msgid ""
+"```typescript\n"
+"// Use {param} placeholders in your strings and pass values as a second arg.\n"
+"const greeting = t(\"Hello, {name}!\", { name: \"Alice\" })\n"
+"const total = t(\"Total: {price}\", { price: 23.10 })\n"
+"console.log(greeting, total)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:14
+msgid "Translation files use the same `{param}` syntax:"
+msgstr ""
+
+#: src/i18n/interpolation.md:19 src/i18n/interpolation.md:25
+#: src/i18n/cli.md:38 src/i18n/cli.md:88
+msgid "\"Hello, {name}!\""
+msgstr ""
+
+#: src/i18n/interpolation.md:20 src/i18n/interpolation.md:26
+msgid "\"Total: {price}\""
+msgstr ""
+
+#: src/i18n/interpolation.md:22 src/i18n/interpolation.md:54
+msgid "// locales/de.json\n"
+msgstr ""
+
+#: src/i18n/interpolation.md:25
+msgid "\"Hallo, {name}!\""
+msgstr ""
+
+#: src/i18n/interpolation.md:26
+msgid "\"Gesamt: {price}\""
+msgstr ""
+
+#: src/i18n/interpolation.md:30
+msgid ""
+"Parameters are substituted at runtime after the locale-appropriate template "
+"is selected. The substitution handles any value type (numbers, strings, "
+"dates) by converting to string."
+msgstr ""
+
+#: src/i18n/interpolation.md:32 src/i18n/interpolation.md:99
+msgid "Compile-Time Validation"
+msgstr ""
+
+#: src/i18n/interpolation.md:34
+msgid "Perry validates parameters across all locales during compilation:"
+msgstr ""
+
+#: src/i18n/interpolation.md:36 src/i18n/interpolation.md:101
+msgid "Condition"
+msgstr ""
+
+#: src/i18n/interpolation.md:36 src/i18n/interpolation.md:101
+msgid "Severity"
+msgstr ""
+
+#: src/i18n/interpolation.md:38
+msgid "`{param}` in translation but not provided in code"
+msgstr ""
+
+#: src/i18n/interpolation.md:38 src/i18n/interpolation.md:39
+#: src/i18n/interpolation.md:40 src/i18n/interpolation.md:103
+#: src/i18n/interpolation.md:104
+msgid "Error"
+msgstr ""
+
+#: src/i18n/interpolation.md:39
+msgid "Param in code but `{param}` not in translation"
+msgstr ""
+
+#: src/i18n/interpolation.md:40
+msgid "Parameter set differs between locales for same key"
+msgstr ""
+
+#: src/i18n/interpolation.md:42
+msgid "Plural Rules"
+msgstr ""
+
+#: src/i18n/interpolation.md:44
+msgid ""
+"Plural forms use dot-suffix keys based on CLDR plural categories: `.zero`, "
+"`.one`, `.two`, `.few`, `.many`, `.other`."
+msgstr ""
+
+#: src/i18n/interpolation.md:46
+msgid "Locale Files"
+msgstr ""
+
+#: src/i18n/interpolation.md:51 src/i18n/interpolation.md:57
+#: src/i18n/interpolation.md:63
+msgid "\"You have {count} items.one\""
+msgstr ""
+
+#: src/i18n/interpolation.md:51
+msgid "\"You have {count} item.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:52 src/i18n/interpolation.md:58
+#: src/i18n/interpolation.md:66
+msgid "\"You have {count} items.other\""
+msgstr ""
+
+#: src/i18n/interpolation.md:52
+msgid "\"You have {count} items.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:57 src/i18n/interpolation.md:58
+msgid "\"Du hast {count} Artikel.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:60
+msgid "// locales/pl.json (Polish: one, few, many)\n"
+msgstr ""
+
+#: src/i18n/interpolation.md:63
+msgid "\"Masz {count} element.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:64
+msgid "\"You have {count} items.few\""
+msgstr ""
+
+#: src/i18n/interpolation.md:64
+msgid "\"Masz {count} elementy.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:65
+msgid "\"You have {count} items.many\""
+msgstr ""
+
+#: src/i18n/interpolation.md:65
+msgid "\"Masz {count} elementow.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:66
+msgid "\"Masz {count} elementu.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:70
+msgid "Usage in Code"
+msgstr ""
+
+#: src/i18n/interpolation.md:72
+msgid ""
+"Reference the base key without any suffix. Perry detects the plural variants"
+" automatically:"
+msgstr ""
+
+#: src/i18n/interpolation.md:74
+msgid ""
+"```typescript\n"
+"// Reference the base key without any suffix — Perry picks the plural variant\n"
+"// from the `count` parameter and the current locale's CLDR rules.\n"
+"const cartCount = 3\n"
+"const itemMessage = t(\"You have {count} items\", { count: cartCount })\n"
+"console.log(itemMessage)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:82
+msgid ""
+"Perry determines which plural form to use based on the `count` parameter "
+"value and the current locale's CLDR rules."
+msgstr ""
+
+#: src/i18n/interpolation.md:84
+msgid "Supported Locales"
+msgstr ""
+
+#: src/i18n/interpolation.md:86
+msgid "Perry includes hand-rolled CLDR plural rules for 30+ locales:"
+msgstr ""
+
+#: src/i18n/interpolation.md:88
+msgid "Pattern"
+msgstr ""
+
+#: src/i18n/interpolation.md:88
+msgid "Locales"
+msgstr ""
+
+#: src/i18n/interpolation.md:90
+msgid "one/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:90
+msgid ""
+"English, German, Dutch, Swedish, Danish, Norwegian, Finnish, Estonian, "
+"Hungarian, Turkish, Greek, Hebrew, Italian, Spanish, Portuguese, Catalan, "
+"Bulgarian, Hindi, Bengali, Swahili, ..."
+msgstr ""
+
+#: src/i18n/interpolation.md:91
+msgid "one (0-1) / other"
+msgstr ""
+
+#: src/i18n/interpolation.md:91
+msgid "French"
+msgstr ""
+
+#: src/i18n/interpolation.md:92
+msgid "no distinction"
+msgstr ""
+
+#: src/i18n/interpolation.md:92
+msgid "Japanese, Chinese, Korean, Vietnamese, Thai, Indonesian, Malay"
+msgstr ""
+
+#: src/i18n/interpolation.md:93
+msgid "one/few/many"
+msgstr ""
+
+#: src/i18n/interpolation.md:93
+msgid "Russian, Ukrainian, Serbian, Croatian, Bosnian, Polish"
+msgstr ""
+
+#: src/i18n/interpolation.md:94 src/i18n/interpolation.md:96
+msgid "one/few/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:94
+msgid "Czech, Slovak"
+msgstr ""
+
+#: src/i18n/interpolation.md:95
+msgid "zero/one/two/few/many/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:95
+msgid "Arabic"
+msgstr ""
+
+#: src/i18n/interpolation.md:96
+msgid "Romanian, Lithuanian"
+msgstr ""
+
+#: src/i18n/interpolation.md:97
+msgid "zero/one/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:97
+msgid "Latvian"
+msgstr ""
+
+#: src/i18n/interpolation.md:103
+msgid "`.other` form missing for any locale"
+msgstr ""
+
+#: src/i18n/interpolation.md:104
+msgid "Required CLDR category missing (e.g., `.few` for Polish)"
+msgstr ""
+
+#: src/i18n/interpolation.md:105
+msgid "Extra category locale doesn't use (e.g., `.few` for English)"
+msgstr ""
+
+#: src/i18n/interpolation.md:105
+msgid "Warning"
+msgstr ""
+
+#: src/i18n/interpolation.md:107
+msgid "Explicit API for Non-UI Strings"
+msgstr ""
+
+#: src/i18n/interpolation.md:109
+msgid ""
+"For strings outside UI components (API responses, notifications, etc.), use "
+"`t()`:"
+msgstr ""
+
+#: src/i18n/interpolation.md:111
+msgid ""
+"```typescript\n"
+"// For strings outside UI components (API responses, notifications, …), use t():\n"
+"const message = t(\"Your order has been shipped.\")\n"
+"const welcome = t(\"Welcome back, {name}!\", { name: \"Alice\" })\n"
+"console.log(message, welcome)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:118
+msgid ""
+"This uses the same key lookup, validation, and interpolation as UI strings."
+msgstr ""
+
+#: src/i18n/formatting.md:1
+msgid "Locale-Aware Formatting"
+msgstr ""
+
+#: src/i18n/formatting.md:3
+msgid ""
+"Perry provides format wrapper functions that automatically format values "
+"according to the current locale. Import them from `perry/i18n`:"
+msgstr ""
+
+#: src/i18n/formatting.md:5
+msgid ""
+"```typescript\n"
+"// All format wrappers come from perry/i18n.\n"
+"// (The same `Currency`, `Percent`, … you'd pass into a Text(...) param object.)\n"
+"const price = Currency(23.10)\n"
+"const discount = Percent(0.15)\n"
+"const population = FormatNumber(1234567.89)\n"
+"const due = ShortDate(Date.now())\n"
+"const event = LongDate(Date.now())\n"
+"const at = FormatTime(Date.now())\n"
+"const code = Raw(12345)\n"
+"\n"
+"// Compose them with t() the same way you'd compose with Text(...):\n"
+"console.log(t(\"Total: {price}\", { price }))\n"
+"console.log(t(\"Discount: {rate}\", { rate: discount }))\n"
+"console.log(t(\"Population: {n}\", { n: population }))\n"
+"console.log(t(\"Due: {d}\", { d: due }))\n"
+"console.log(t(\"Event: {d}\", { d: event }))\n"
+"console.log(t(\"At: {t}\", { t: at }))\n"
+"console.log(t(\"Code: {amount}\", { amount: code }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:26
+msgid "Format Wrappers"
+msgstr ""
+
+#: src/i18n/formatting.md:28
+msgid "Currency"
+msgstr ""
+
+#: src/i18n/formatting.md:30
+msgid ""
+"Formats a number as currency with the locale's symbol, decimal separator, "
+"and symbol placement:"
+msgstr ""
+
+#: src/i18n/formatting.md:32
+msgid ""
+"```typescript\n"
+"// Currency: locale-appropriate symbol, separator, and placement.\n"
+"//   en: \"$23.10\"   de: \"23,10 €\"   ja: \"¥23.10\"\n"
+"const cur = Currency(23.10)\n"
+"console.log(t(\"Total: {price}\", { price: cur }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:39
+msgid ""
+"```text\n"
+"en: \"Total: $23.10\"\n"
+"de: \"Total: 23,10 €\"\n"
+"fr: \"Total: 23,10 €\"\n"
+"ja: \"Total: ¥23.10\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:46
+msgid "Percent"
+msgstr ""
+
+#: src/i18n/formatting.md:48
+msgid "Formats a decimal as a percentage (value is multiplied by 100):"
+msgstr ""
+
+#: src/i18n/formatting.md:50
+msgid ""
+"```typescript\n"
+"// Percent: input is a decimal (0.15 → 15 %). en omits the space; de/fr add it.\n"
+"const rate = Percent(0.15)\n"
+"console.log(t(\"Discount: {rate}\", { rate }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:56
+msgid ""
+"```text\n"
+"en: \"Discount: 15%\"\n"
+"de: \"Discount: 15 %\"\n"
+"fr: \"Discount: 15 %\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:62
+msgid "FormatNumber"
+msgstr ""
+
+#: src/i18n/formatting.md:64
+msgid ""
+"Formats a number with locale-appropriate grouping and decimal separators:"
+msgstr ""
+
+#: src/i18n/formatting.md:66
+msgid ""
+"```typescript\n"
+"// FormatNumber: locale-appropriate grouping + decimal separators.\n"
+"//   en: \"1,234,567.89\"   de: \"1.234.567,89\"   fr: \"1 234 567,89\"\n"
+"const n = FormatNumber(1234567.89)\n"
+"console.log(t(\"Population: {n}\", { n }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:73
+msgid ""
+"```text\n"
+"en: \"Population: 1,234,567.89\"\n"
+"de: \"Population: 1.234.567,89\"\n"
+"fr: \"Population: 1 234 567,89\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:79
+msgid "ShortDate / LongDate / FormatDate"
+msgstr ""
+
+#: src/i18n/formatting.md:81
+msgid "Formats a timestamp (milliseconds since epoch) as a date:"
+msgstr ""
+
+#: src/i18n/formatting.md:83
+msgid ""
+"```typescript\n"
+"// ShortDate / LongDate take a millisecond timestamp.\n"
+"const now = Date.now()\n"
+"const short = ShortDate(now)   // en: \"3/22/2026\"   de: \"22.03.2026\"\n"
+"const long = LongDate(now)     // en: \"March 22, 2026\"   de: \"22. März 2026\"\n"
+"console.log(t(\"Due: {d}\", { d: short }))\n"
+"console.log(t(\"Event: {d}\", { d: long }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:92
+msgid ""
+"```text\n"
+"ShortDate\n"
+"  en: \"Due: 3/22/2026\"\n"
+"  de: \"Due: 22.03.2026\"\n"
+"  ja: \"Due: 2026/03/22\"\n"
+"\n"
+"LongDate\n"
+"  en: \"Event: March 22, 2026\"\n"
+"  de: \"Event: 22. März 2026\"\n"
+"  fr: \"Event: 22 mars 2026\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:104
+msgid "FormatTime"
+msgstr ""
+
+#: src/i18n/formatting.md:106
+msgid "Formats a timestamp as time (12h vs 24h based on locale):"
+msgstr ""
+
+#: src/i18n/formatting.md:108
+msgid ""
+"```typescript\n"
+"// FormatTime: 12h vs 24h based on the active locale.\n"
+"const ts = Date.now()\n"
+"const formatted = FormatTime(ts)\n"
+"console.log(t(\"At: {t}\", { t: formatted }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:115
+msgid ""
+"```text\n"
+"en: \"At: 3:45 PM\"\n"
+"de: \"At: 15:45\"\n"
+"fr: \"At: 15:45\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:121
+msgid "Raw"
+msgstr ""
+
+#: src/i18n/formatting.md:123
+msgid ""
+"Pass-through — prevents any automatic formatting. Use when a parameter name "
+"might trigger auto-formatting but you want the raw value:"
+msgstr ""
+
+#: src/i18n/formatting.md:125
+msgid ""
+"```typescript\n"
+"// Raw is a pass-through — prevents auto-formatting when the param name\n"
+"// might otherwise trigger it.\n"
+"const orderCode = Raw(12345)\n"
+"console.log(t(\"Code: {amount}\", { amount: orderCode }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:132
+msgid "All locales: `\"Code: 12345\"` (no currency formatting despite the name)."
+msgstr ""
+
+#: src/i18n/formatting.md:134
+msgid "Locale-Specific Formatting Rules"
+msgstr ""
+
+#: src/i18n/formatting.md:136
+msgid "Perry includes hand-rolled formatting rules for 25+ locales:"
+msgstr ""
+
+#: src/i18n/formatting.md:138
+msgid "Example Locales"
+msgstr ""
+
+#: src/i18n/formatting.md:140
+msgid "Decimal: `.` / Thousands: `,`"
+msgstr ""
+
+#: src/i18n/formatting.md:140 src/i18n/formatting.md:144
+msgid "en, ja, zh, ko"
+msgstr ""
+
+#: src/i18n/formatting.md:141
+msgid "Decimal: `,` / Thousands: `.`"
+msgstr ""
+
+#: src/i18n/formatting.md:141
+msgid "de, nl, tr, es, it, pt"
+msgstr ""
+
+#: src/i18n/formatting.md:142
+msgid "Decimal: `,` / Thousands: ` ` (narrow space)"
+msgstr ""
+
+#: src/i18n/formatting.md:142
+msgid "fr"
+msgstr ""
+
+#: src/i18n/formatting.md:143
+msgid "Decimal: `,` / Thousands: ` ` (non-breaking space)"
+msgstr ""
+
+#: src/i18n/formatting.md:143
+msgid "ru, uk, pl, sv, da, no, fi"
+msgstr ""
+
+#: src/i18n/formatting.md:144
+msgid "Currency before number: `$23.10`"
+msgstr ""
+
+#: src/i18n/formatting.md:145
+msgid "Currency after number: `23,10 €`"
+msgstr ""
+
+#: src/i18n/formatting.md:145
+msgid "de, fr, es, it, ru"
+msgstr ""
+
+#: src/i18n/formatting.md:146
+msgid "Percent with space: `42 %`"
+msgstr ""
+
+#: src/i18n/formatting.md:146 src/i18n/formatting.md:149
+msgid "de, fr, es, ru"
+msgstr ""
+
+#: src/i18n/formatting.md:147
+msgid "Percent without space: `42%`"
+msgstr ""
+
+#: src/i18n/formatting.md:147
+msgid "en, ja, zh"
+msgstr ""
+
+#: src/i18n/formatting.md:148
+msgid "Date order: M/D/Y"
+msgstr ""
+
+#: src/i18n/formatting.md:148 src/i18n/formatting.md:152
+msgid "en"
+msgstr ""
+
+#: src/i18n/formatting.md:149
+msgid "Date order: D.M.Y"
+msgstr ""
+
+#: src/i18n/formatting.md:150
+msgid "Date order: Y/M/D"
+msgstr ""
+
+#: src/i18n/formatting.md:150
+msgid "ja, zh, ko, sv"
+msgstr ""
+
+#: src/i18n/formatting.md:151
+msgid "24-hour time"
+msgstr ""
+
+#: src/i18n/formatting.md:151
+msgid "de, fr, es, ja, zh, ru (most)"
+msgstr ""
+
+#: src/i18n/formatting.md:152
+msgid "12-hour time (AM/PM)"
+msgstr ""
+
+#: src/i18n/formatting.md:154
+msgid "Currency Configuration"
+msgstr ""
+
+#: src/i18n/formatting.md:156
+msgid "Configure default currency codes per locale in `perry.toml`:"
+msgstr ""
+
+#: src/i18n/formatting.md:158
+msgid ""
+"```toml\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\", \"fr\"]\n"
+"default_locale = \"en\"\n"
+"\n"
+"[i18n.currencies]\n"
+"en = \"USD\"\n"
+"de = \"EUR\"\n"
+"fr = \"EUR\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:169
+msgid ""
+"When `Currency(value)` is called, the locale's configured currency code "
+"determines the symbol and formatting rules."
+msgstr ""
+
+#: src/i18n/cli.md:1
+msgid "i18n CLI Tools"
+msgstr ""
+
+#: src/i18n/cli.md:3 src/cli/commands.md:308
+msgid "`perry i18n extract`"
+msgstr ""
+
+#: src/i18n/cli.md:5
+msgid ""
+"Scans your TypeScript source files for localizable strings and generates or "
+"updates locale JSON files."
+msgstr ""
+
+#: src/i18n/cli.md:11
+msgid "What It Does"
+msgstr ""
+
+#: src/i18n/cli.md:13
+msgid "Recursively scans all `.ts` and `.tsx` files in the source directory"
+msgstr ""
+
+#: src/i18n/cli.md:14
+msgid ""
+"Detects string literals in UI component calls: `Button(\"...\")`, "
+"`Text(\"...\")`, `Label(\"...\")`, etc."
+msgstr ""
+
+#: src/i18n/cli.md:15
+msgid "Also detects `t(\"...\")` calls from `perry/i18n`"
+msgstr ""
+
+#: src/i18n/cli.md:16
+msgid "Creates `locales/` directory if it doesn't exist"
+msgstr ""
+
+#: src/i18n/cli.md:17
+msgid "For each configured locale, creates or updates a JSON file:"
+msgstr ""
+
+#: src/i18n/cli.md:18
+msgid "**Default locale**: New keys are pre-filled with themselves as values"
+msgstr ""
+
+#: src/i18n/cli.md:19
+msgid ""
+"**Non-default locales**: New keys are added with empty string values "
+"(indicating \"needs translation\")"
+msgstr ""
+
+#: src/i18n/cli.md:21
+msgid "Example Output"
+msgstr ""
+
+#: src/i18n/cli.md:32
+msgid "Workflow"
+msgstr ""
+
+#: src/i18n/cli.md:34
+msgid "Typical translation workflow:"
+msgstr ""
+
+#: src/i18n/cli.md:37
+msgid "# 1. Write code with English strings\n"
+msgstr ""
+
+#: src/i18n/cli.md:39
+msgid "# 2. Extract strings to locale files\n"
+msgstr ""
+
+#: src/i18n/cli.md:42
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
+msgstr ""
+
+#: src/i18n/cli.md:44
+msgid "# 4. Build — Perry validates everything\n"
+msgstr ""
+
+#: src/i18n/cli.md:49
+msgid "Detected Patterns"
+msgstr ""
+
+#: src/i18n/cli.md:51
+msgid "The scanner detects these UI component patterns:"
+msgstr ""
+
+#: src/i18n/cli.md:53
+msgid "`Button(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:54
+msgid "`Text(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:55
+msgid "`Label(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:56
+msgid "`TextField(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:57
+msgid "`TextArea(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:58
+msgid "`Tab(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:59
+msgid "`NavigationTitle(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:60
+msgid "`SectionHeader(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:61
+msgid "`SecureField(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:62
+msgid "`Alert(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:63
+msgid "`t(\"string\")` (explicit i18n API)"
+msgstr ""
+
+#: src/i18n/cli.md:65
+msgid ""
+"Both double-quoted and single-quoted strings are supported. Escaped quotes "
+"are handled correctly."
+msgstr ""
+
+#: src/i18n/cli.md:67
+msgid "Build Output"
+msgstr ""
+
+#: src/i18n/cli.md:69
+msgid "During compilation, Perry reports i18n status:"
+msgstr ""
+
+#: src/i18n/cli.md:71
+msgid ""
+"```\n"
+"  i18n: 2 locale(s) [en, de], default: en\n"
+"    Loaded locales/en.json (12 keys)\n"
+"    Loaded locales/de.json (12 keys)\n"
+"  i18n: 12 localizable string(s) detected\n"
+"  i18n warning: Missing translation for key \"Settings\" in locale \"de\"\n"
+"  i18n warning: Unused i18n key \"Old Label\" in locale \"en\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/cli.md:80
+msgid "Key Registry"
+msgstr ""
+
+#: src/i18n/cli.md:82
+msgid ""
+"Perry maintains a `.perry/i18n-keys.json` file, updated on every build:"
+msgstr ""
+
+#: src/i18n/cli.md:86
+msgid "\"keys\""
+msgstr ""
+
+#: src/i18n/cli.md:87 src/i18n/cli.md:88 src/i18n/cli.md:89
+msgid "\"key\""
+msgstr ""
+
+#: src/i18n/cli.md:87 src/i18n/cli.md:88 src/i18n/cli.md:89
+msgid "\"string_idx\""
+msgstr ""
+
+#: src/i18n/cli.md:89
+msgid "\"You have {count} items\""
+msgstr ""
+
+#: src/i18n/cli.md:94
+msgid ""
+"This file serves as the source of truth for what strings exist in the "
+"codebase."
+msgstr ""
+
+#: src/updater/overview.md:3
+msgid ""
+"Ship updates to your Perry desktop app without rolling your own download + "
+"replace + relaunch flow. Two modules cooperate:"
+msgstr ""
+
+#: src/updater/overview.md:6
+msgid ""
+"**`@perry/updater`** — high-level wrapper. The 90% case: manifest fetch, "
+"semver compare, download, verify, install, relaunch, crash-loop rollback."
+msgstr ""
+
+#: src/updater/overview.md:8
+msgid ""
+"**`perry/updater`** — ambient primitives the wrapper is built on. Reach for "
+"these only when you need a custom flow (multi-channel rollouts, your own "
+"progress UI, an integration with an external supervisor)."
+msgstr ""
+
+#: src/updater/overview.md:12
+msgid ""
+"The trust model and wire format follow [Tauri's "
+"updater](https://v2.tauri.app/plugin/updater/): JSON manifest over HTTPS, "
+"SHA-256 + Ed25519 signature over the digest, atomic binary replace with a "
+"`.prev` backup, detached relaunch. Every snippet below is excerpted from "
+"[`docs/examples/updater/snippets.ts`](../../examples/updater/snippets.ts) — "
+"CI compile-links it on every PR."
+msgstr ""
+
+#: src/updater/overview.md:19
+msgid ""
+"**Desktop only.** iOS / TestFlight, Android Play Store, and sideloaded APKs "
+"own the install pipeline at the OS level — replacing your own binary at "
+"runtime is structurally impossible there. The crate still compiles on mobile"
+" targets so cross-platform code doesn't need `#ifdef`s, but the install path"
+" is a no-op. Gate updater code with `process.platform` if your app ships "
+"everywhere."
+msgstr ""
+
+#: src/updater/overview.md:26 src/system/media.md:8
+#: src/plugins/appstore-review.md:11
+msgid "Quick start"
+msgstr ""
+
+#: src/updater/overview.md:28
+msgid ""
+"```typescript\n"
+"// import { checkForUpdate, initUpdater, markHealthy } from \"@perry/updater\"\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:32
+msgid ""
+"Drop a \"Check for updates\" handler somewhere in your menu or a periodic "
+"timer. `checkForUpdate` returns `null` when up to date or when the manifest "
+"has no entry for the current platform."
+msgstr ""
+
+#: src/updater/overview.md:36
+msgid ""
+"```typescript\n"
+"// Pseudocode using @perry/updater's wrapper. Drop into a \"Check for updates\"\n"
+"// menu item or a periodic timer. The manifest URL must serve over HTTPS.\n"
+"//\n"
+"// const update = await checkForUpdate({\n"
+"//     manifestUrl: \"https://updates.example.com/myapp.json\",\n"
+"//     publicKey: \"BASE64_ED25519_PUBKEY\",\n"
+"//     currentVersion: \"1.4.0\",\n"
+"// })\n"
+"//\n"
+"// if (update !== null) {\n"
+"//     console.log(`v${update.version} is available`)\n"
+"//     console.log(update.notes)\n"
+"//\n"
+"//     await update.download((downloaded, total) => {\n"
+"//         const pct = Math.round((downloaded / total) * 100)\n"
+"//         console.log(`downloading: ${pct}%`)\n"
+"//     })\n"
+"//\n"
+"//     await update.installAndRelaunch()  // never returns — process.exit inside\n"
+"// }\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:59
+msgid ""
+"Call `initUpdater()` once near the top of `main()`. It handles boot-time "
+"crash-loop detection: if the new binary you just installed crashes during "
+"boot more than `crashLoopThreshold` times, the wrapper restores the previous"
+" version and exits so the OS / launcher restarts you on the rollback."
+msgstr ""
+
+#: src/updater/overview.md:64
+msgid ""
+"```typescript\n"
+"// Boot-time: detect a crash-looping new install and roll back. Call this\n"
+"// near the top of `main()`, right after process initialization.\n"
+"//\n"
+"// await initUpdater({\n"
+"//     autoRollback:       true,    // default\n"
+"//     healthCheckMs:      60_000,  // clear sentinel after this many ms alive\n"
+"//     crashLoopThreshold: 2,       // restarts before rollback fires\n"
+"// })\n"
+"//\n"
+"// // Optional: tell the updater explicitly that this version is healthy\n"
+"// // (e.g. after a successful login or migration finished).\n"
+"// // markHealthy()\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:79
+msgid "Manifest"
+msgstr ""
+
+#: src/updater/overview.md:81
+msgid ""
+"Serve a single JSON file over HTTPS. One entry per `<os>-<arch>` you publish"
+" for; clients ignore entries that don't match their platform."
+msgstr ""
+
+#: src/updater/overview.md:84
+msgid ""
+"```typescript\n"
+"// The manifest is a single JSON file you serve over HTTPS. Each platform\n"
+"// triple is `<os>-<arch>` (darwin-aarch64, darwin-x86_64, windows-x86_64,\n"
+"// linux-x86_64, linux-aarch64). The wrapper picks the entry matching the\n"
+"// running host and ignores the rest.\n"
+"//\n"
+"// {\n"
+"//   \"schemaVersion\": 1,\n"
+"//   \"version\": \"1.4.0\",\n"
+"//   \"pubDate\": \"2026-04-27T10:00:00Z\",\n"
+"//   \"notes\": \"Bug fixes and performance improvements\",\n"
+"//   \"platforms\": {\n"
+"//     \"darwin-aarch64\": {\n"
+"//       \"url\":       \"https://example.com/app-1.4.0-darwin-aarch64.bin\",\n"
+"//       \"sha256\":    \"0123456789abcdef...\",\n"
+"//       \"signature\": \"base64sig==\",\n"
+"//       \"size\":      12345678\n"
+"//     }\n"
+"//   }\n"
+"// }\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:106
+msgid "Meaning"
+msgstr ""
+
+#: src/updater/overview.md:108
+msgid "`schemaVersion`"
+msgstr ""
+
+#: src/updater/overview.md:108
+msgid ""
+"`1` (legacy, digest-only signature) or `2` (recommended — version-bound "
+"signature; see below)."
+msgstr ""
+
+#: src/updater/overview.md:109 src/cli/perry-toml.md:117
+msgid "`version`"
+msgstr ""
+
+#: src/updater/overview.md:109
+msgid "Semver string of the offered version (e.g. `\"1.4.0\"`)."
+msgstr ""
+
+#: src/updater/overview.md:110
+msgid "`pubDate`"
+msgstr ""
+
+#: src/updater/overview.md:110
+msgid "ISO-8601 timestamp the build was published — surfaced as metadata."
+msgstr ""
+
+#: src/updater/overview.md:111
+msgid "`notes`"
+msgstr ""
+
+#: src/updater/overview.md:111
+msgid "Markdown release notes shown to the user."
+msgstr ""
+
+#: src/updater/overview.md:112
+msgid "`platforms.<os>-<arch>.url`"
+msgstr ""
+
+#: src/updater/overview.md:112
+msgid "Direct download URL (HTTPS)."
+msgstr ""
+
+#: src/updater/overview.md:113
+msgid "`platforms.<os>-<arch>.sha256`"
+msgstr ""
+
+#: src/updater/overview.md:113
+msgid "Lowercase hex SHA-256 of the binary."
+msgstr ""
+
+#: src/updater/overview.md:114
+msgid "`platforms.<os>-<arch>.signature`"
+msgstr ""
+
+#: src/updater/overview.md:114
+msgid ""
+"Base64 Ed25519 signature. v1: over the raw 32-byte digest. v2: over `digest "
+"\\|\\| version_utf8`."
+msgstr ""
+
+#: src/updater/overview.md:115
+msgid "`platforms.<os>-<arch>.size`"
+msgstr ""
+
+#: src/updater/overview.md:115
+msgid "Byte length of the binary — used for progress reporting."
+msgstr ""
+
+#: src/updater/overview.md:117
+msgid "Platform keys are canonical Rust-style triples:"
+msgstr ""
+
+#: src/updater/overview.md:119
+msgid "Host"
+msgstr ""
+
+#: src/updater/overview.md:119
+msgid "Triple"
+msgstr ""
+
+#: src/updater/overview.md:121
+msgid "Apple Silicon mac"
+msgstr ""
+
+#: src/updater/overview.md:121
+msgid "`darwin-aarch64`"
+msgstr ""
+
+#: src/updater/overview.md:122
+msgid "Intel mac"
+msgstr ""
+
+#: src/updater/overview.md:122
+msgid "`darwin-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:123
+msgid "Windows 10/11 64-bit"
+msgstr ""
+
+#: src/updater/overview.md:123
+msgid "`windows-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:124
+msgid "Linux 64-bit"
+msgstr ""
+
+#: src/updater/overview.md:124
+msgid "`linux-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:125
+msgid "Linux ARM64"
+msgstr ""
+
+#: src/updater/overview.md:125
+msgid "`linux-aarch64`"
+msgstr ""
+
+#: src/updater/overview.md:127
+msgid "Trust model"
+msgstr ""
+
+#: src/updater/overview.md:129
+msgid "`schemaVersion: 2` (recommended) — version-bound signature"
+msgstr ""
+
+#: src/updater/overview.md:131
+msgid ""
+"The signed payload is `SHA256(binary) || version_utf8` — the 32-byte raw "
+"digest concatenated with the UTF-8 bytes of the version string. This binds "
+"the version into the signature, so an on-path attacker can't replay a "
+"previously-signed older binary as a \"new version\" by serving a manifest "
+"that pairs the old binary's URL + signature with a higher version number "
+"([\\#229](https://github.com/PerryTS/perry/issues/229))."
+msgstr ""
+
+#: src/updater/overview.md:138
+msgid "Sign side:"
+msgstr ""
+
+#: src/updater/overview.md:140
+msgid ""
+"```text\n"
+"payload = sha256(binary).digest() + version.encode(\"utf-8\")\n"
+"signature = ed25519_sign(secret_key, payload)  # 64-byte signature\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:145
+msgid "Verification on the client:"
+msgstr ""
+
+#: src/updater/overview.md:147
+msgid ""
+"SHA-256 the downloaded file. Reject if it doesn't match `manifest.sha256`."
+msgstr ""
+
+#: src/updater/overview.md:148
+msgid ""
+"Build the v2 payload (`digest || version_utf8`) using `manifest.version`."
+msgstr ""
+
+#: src/updater/overview.md:149
+msgid "Ed25519-verify the signature against the bundled public key."
+msgstr ""
+
+#: src/updater/overview.md:150
+msgid "Reject on any decode error, size mismatch, or signature failure."
+msgstr ""
+
+#: src/updater/overview.md:152
+msgid ""
+"If an attacker swaps the manifest's `version` field while keeping the old "
+"`signature`, step 3 fails because the signature was made over the _original_"
+" version. If they swap both `version` and `signature` (using a previously-"
+"signed older binary), step 1 fails because `sha256` of the older binary "
+"doesn't match the rewritten higher-version label either — every plausible "
+"attack on the version metadata invalidates something."
+msgstr ""
+
+#: src/updater/overview.md:160
+msgid "`schemaVersion: 1` (legacy, digest-only)"
+msgstr ""
+
+#: src/updater/overview.md:162
+msgid ""
+"The signed payload is the raw 32-byte digest only. **This shape is "
+"vulnerable to old-binary replay** "
+"([\\#229](https://github.com/PerryTS/perry/issues/229)): an on-path attacker"
+" can serve a manifest claiming a higher version while pointing at a "
+"previously-signed older binary, and signature verification still passes "
+"because the version isn't bound into the signature. Existing v1 manifests "
+"stay supported by the client during migration; new deployments should use "
+"v2."
+msgstr ""
+
+#: src/updater/overview.md:170
+msgid "Migration"
+msgstr ""
+
+#: src/updater/overview.md:172
+msgid ""
+"`@perry/updater` v0.5.391+ accepts both `schemaVersion: 1` and "
+"`schemaVersion: 2`. Bumping your manifest from 1 → 2 requires:"
+msgstr ""
+
+#: src/updater/overview.md:175
+msgid ""
+"Update sign-side tooling to compute the new payload (`sha256(binary) + "
+"version.encode(\"utf-8\")`) and sign that."
+msgstr ""
+
+#: src/updater/overview.md:177
+msgid "Bump `schemaVersion` in the manifest from `1` to `2`."
+msgstr ""
+
+#: src/updater/overview.md:178
+msgid ""
+"Make sure all deployed clients are running a perry-updater version that "
+"knows about v2 BEFORE you publish a v2 manifest. Older clients reject "
+"`schemaVersion: 2` with an `unsupported manifest schemaVersion` error. "
+"(Plan: ship a perry-updater bump with v2 support to your users via a v1 "
+"manifest first; once they're on the v2-aware client, the next manifest can "
+"be v2.)"
+msgstr ""
+
+#: src/updater/overview.md:185
+msgid "Keypair"
+msgstr ""
+
+#: src/updater/overview.md:187
+msgid ""
+"You generate the keypair once and bake the public key into your app at build"
+" time; the secret key stays on a release-signing machine alongside the rest "
+"of your build artifacts. Compromise of the manifest server alone never lets "
+"an attacker push a binary your client will accept."
+msgstr ""
+
+#: src/updater/overview.md:192
+msgid "Sign-side CLI (v0.5.395+)"
+msgstr ""
+
+#: src/updater/overview.md:194
+msgid ""
+"`perry updater` ships three subcommands that produce v2-shape signatures "
+"without needing any custom tooling:"
+msgstr ""
+
+#: src/updater/overview.md:198
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
+msgstr ""
+
+#: src/updater/overview.md:201
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
+msgstr ""
+
+#: src/updater/overview.md:219
+msgid ""
+"Compose a final manifest by piping `sign` output through `jq` for each "
+"asset, then merging into the per-platform layout shown above. CI tip: pass "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so"
+" the secret can come from a repository secret without ever hitting the "
+"worker's filesystem."
+msgstr ""
+
+#: src/updater/overview.md:225
+msgid "Install + rollback flow"
+msgstr ""
+
+#: src/updater/overview.md:227
+msgid ""
+"```text\n"
+"manifest fetch  →  semver compare  →  download to <exe>.staged\n"
+"                                          ↓\n"
+"                                      sha256 verify  →  ed25519 verify\n"
+"                                          ↓\n"
+"                                      arm sentinel (state: \"armed\")\n"
+"                                          ↓\n"
+"                                      install:  rename <exe> → <exe>.prev\n"
+"                                                rename <exe>.staged → <exe>\n"
+"                                                chmod +x   (Unix only)\n"
+"                                          ↓\n"
+"                                      detached relaunch  →  process.exit(0)\n"
+"\n"
+"next boot  →  initUpdater() reads sentinel\n"
+"                  ├── healthCheckMs alive  → clearSentinel  (success)\n"
+"                  ├── graceful exit         → clearSentinel  (success)\n"
+"                  └── restartCount ≥ N      → performRollback + exit\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:246
+msgid ""
+"`installUpdate` is atomic where the OS lets us be: POSIX `rename(2)` on the "
+"same filesystem, NTFS rename-while-open (the PE loader opens with "
+"`FILE_SHARE_DELETE` so Windows tolerates this since Vista), and Linux's "
+"mmap'd-inode-stays-alive semantics. If the staging directory ends up on a "
+"different filesystem (a separate mount for `/tmp`, for instance) the rename "
+"falls back to copy + remove, which has a small non-atomic window."
+msgstr ""
+
+#: src/updater/overview.md:253
+msgid "The sentinel is a JSON file at a per-OS user-writable path:"
+msgstr ""
+
+#: src/updater/overview.md:255
+msgid "Default location"
+msgstr ""
+
+#: src/updater/overview.md:257
+msgid "`~/Library/Application Support/<app>/updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:258
+msgid "`%LOCALAPPDATA%\\<app>\\updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:259
+msgid "`$XDG_STATE_HOME/<app>/updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:261
+msgid ""
+"`<app>` comes from the `PERRY_APP_ID` environment variable, falling back to "
+"the basename of the running exe. **Set `PERRY_APP_ID` in your launch "
+"environment** so the sentinel path stays stable across rename / relocation "
+"of the binary."
+msgstr ""
+
+#: src/updater/overview.md:266
+msgid "Low-level primitives"
+msgstr ""
+
+#: src/updater/overview.md:268
+msgid ""
+"Use these when the high-level wrapper doesn't fit — custom progress UI, a "
+"multi-channel manifest, an external supervisor that handles restarts, etc."
+msgstr ""
+
+#: src/updater/overview.md:271
+msgid ""
+"```typescript\n"
+"import {\n"
+"    compareVersions,\n"
+"    verifyHash,\n"
+"    verifySignature,\n"
+"    computeFileSha256,\n"
+"    writeSentinel,\n"
+"    readSentinel,\n"
+"    clearSentinel,\n"
+"    getExePath,\n"
+"    getBackupPath,\n"
+"    getSentinelPath,\n"
+"    installUpdate,\n"
+"    performRollback,\n"
+"    relaunch,\n"
+"} from \"perry/updater\"\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:289
+msgid "`compareVersions(current, candidate)`"
+msgstr ""
+
+#: src/updater/overview.md:291
+msgid ""
+"Returns `-1` (update available), `0` (equal), `1` (downgrade — never "
+"offered), or `-2` (parse error). Prerelease tags handled per the semver "
+"spec."
+msgstr ""
+
+#: src/updater/overview.md:294
+msgid ""
+"```typescript\n"
+"// Returns -1 (current < candidate, update available), 0 (equal),\n"
+"// 1 (current > candidate, never offered as an update), -2 (parse error).\n"
+"const cmp = compareVersions(\"1.4.0\", \"1.4.1\")\n"
+"if (cmp === -1) {\n"
+"    console.log(\"update available\")\n"
+"} else if (cmp === 0) {\n"
+"    console.log(\"up to date\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:305
+msgid "`verifyHash` / `verifySignature` / `computeFileSha256`"
+msgstr ""
+
+#: src/updater/overview.md:307
+msgid ""
+"```typescript\n"
+"// SHA-256 + Ed25519 verification of a binary on disk. The signed payload is\n"
+"// the *raw 32-byte SHA-256 digest* — not the hex string and not the file\n"
+"// bytes themselves. Sign side: `sha256(file) | ed25519_sign(secret_key)`.\n"
+"const stagedPath = getExePath() + \".staged\"\n"
+"const expectedHex = \"0123456789abcdef...\" // from your manifest\n"
+"const sigB64 = \"...base64...\"             // 64-byte signature, base64\n"
+"const pubB64 = \"...base64...\"             // 32-byte public key, base64\n"
+"\n"
+"if (verifyHash(stagedPath, expectedHex) !== 1) {\n"
+"    const actual = computeFileSha256(stagedPath)\n"
+"    console.error(`hash mismatch — expected ${expectedHex}, got ${actual}`)\n"
+"}\n"
+"if (verifySignature(stagedPath, sigB64, pubB64) !== 1) {\n"
+"    console.error(\"signature verification failed\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:325
+msgid ""
+"`verifyHash` and `verifySignature` return `1` on success, `0` on any failure"
+" (file missing, decode error, mismatch). `computeFileSha256` returns the hex"
+" digest as a string, or `\"\"` on failure — useful for logging the _actual_ "
+"hash when a `verifyHash` mismatch fires."
+msgstr ""
+
+#: src/updater/overview.md:330
+msgid "`installUpdate` / `performRollback` / `relaunch`"
+msgstr ""
+
+#: src/updater/overview.md:332
+msgid ""
+"```typescript\n"
+"// `installUpdate` atomically replaces `targetPath` with `stagedPath`,\n"
+"// keeping the displaced version at `<target>.prev` for rollback.\n"
+"const target = getExePath()\n"
+"const staged = target + \".staged\"\n"
+"\n"
+"if (installUpdate(staged, target) !== 1) {\n"
+"    console.error(\"install failed\")\n"
+"} else {\n"
+"    const pid = relaunch(target)\n"
+"    if (pid < 0) {\n"
+"        console.error(\"relaunch failed; restart manually\")\n"
+"    } else {\n"
+"        // Detached child is now running the new binary — get out of its way.\n"
+"        process.exit(0)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:351
+msgid ""
+"```typescript\n"
+"// `performRollback` restores `<target>.prev` over `target` and moves the\n"
+"// current (likely-broken) target to `<target>.broken` as a safety net.\n"
+"if (performRollback(getExePath()) !== 1) {\n"
+"    console.error(\"no backup to roll back to\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:359
+msgid ""
+"`relaunch` returns the child PID, or `-1` on failure. The new process is "
+"fully detached (`setsid` on Unix, `DETACHED_PROCESS | "
+"CREATE_NEW_PROCESS_GROUP` on Windows) so closing the current process doesn't"
+" take it down."
+msgstr ""
+
+#: src/updater/overview.md:363
+msgid "Path resolution"
+msgstr ""
+
+#: src/updater/overview.md:365
+msgid ""
+"```typescript\n"
+"// Resolved per platform. macOS walks up to the surrounding `.app` bundle;\n"
+"// Linux honors $APPIMAGE; Windows / bare ELF returns the canonical exe.\n"
+"console.log(\"running exe   :\", getExePath())\n"
+"console.log(\"backup target :\", getBackupPath())\n"
+"// Sentinel path is keyed off PERRY_APP_ID — set this env var so the path\n"
+"// stays stable across rename/relocation of the binary.\n"
+"console.log(\"sentinel path :\", getSentinelPath())\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:375
+msgid "`getExePath()` accounts for platform quirks:"
+msgstr ""
+
+#: src/updater/overview.md:377
+msgid ""
+"**macOS**: walks up to the surrounding `.app` bundle if applicable — the "
+"`.app` directory is the codesign unit, so that's what you replace."
+msgstr ""
+
+#: src/updater/overview.md:379
+msgid ""
+"**Linux**: honors `$APPIMAGE` when set. The AppImage runtime points "
+"`current_exe()` inside a read-only squashfs mount; the real target to "
+"replace is the AppImage file itself."
+msgstr ""
+
+#: src/updater/overview.md:382
+msgid ""
+"**Windows / bare ELF / bare Mach-O**: returns the canonicalized exe path."
+msgstr ""
+
+#: src/updater/overview.md:384
+msgid "Sentinel"
+msgstr ""
+
+#: src/updater/overview.md:386
+msgid ""
+"```typescript\n"
+"// Low-level sentinel API. Most apps use `initUpdater()` from @perry/updater\n"
+"// instead of touching this directly, but it's here when you need it (custom\n"
+"// rollback policies, multi-process apps, integration with another supervisor).\n"
+"const sentinelPath = getSentinelPath()\n"
+"writeSentinel(sentinelPath, JSON.stringify({ state: \"armed\", restartCount: 0 }))\n"
+"const raw = readSentinel(sentinelPath)\n"
+"if (raw) {\n"
+"    const state = JSON.parse(raw) as { state: string; restartCount: number }\n"
+"    if (state.restartCount >= 2) {\n"
+"        // looks like a crash loop — recover or roll back\n"
+"        clearSentinel(sentinelPath)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:402
+msgid ""
+"`writeSentinel` is atomic (tmp file + rename), creates the parent directory "
+"if needed, and returns `1` on success / `0` on any IO error. `clearSentinel`"
+" is idempotent — returns `1` whether the file existed or not."
+msgstr ""
+
+#: src/updater/overview.md:406
+msgid "What's not here (yet)"
+msgstr ""
+
+#: src/updater/overview.md:408
+msgid ""
+"**UI primitives** — a \"Restart now\" modal with `ProgressView` belongs "
+"inside `perry/ui` proper rather than the updater package. Tracked as a "
+"follow-up."
+msgstr ""
+
+#: src/updater/overview.md:411
+msgid ""
+"**Privileged install** for system-wide locations (`/Applications`, `Program "
+"Files`). The current install path only handles user-writable locations "
+"(`~/Applications`, `~/.local/bin`, `%LOCALAPPDATA%`). UAC / `SMJobBless` is "
+"a separate concern."
+msgstr ""
+
+#: src/updater/overview.md:415
+msgid ""
+"**Delta updates** (bsdiff), **multi-channel** (stable / beta), **staged "
+"rollouts**."
+msgstr ""
+
+#: src/updater/overview.md:417
+msgid ""
+"**Notarization / code-signing** during install. Binaries are expected to "
+"arrive already signed; the updater doesn't try to be a notarization tool."
+msgstr ""
+
+#: src/updater/overview.md:420
+msgid "Testing your update flow"
+msgstr ""
+
+#: src/updater/overview.md:422
+msgid ""
+"The crate ships smoke-test scripts that exercise verify → install → relaunch"
+" end-to-end against a real Perry binary:"
+msgstr ""
+
+#: src/updater/overview.md:425
+msgid "**Unix**: `scripts/smoke_updater.sh`"
+msgstr ""
+
+#: src/updater/overview.md:426
+msgid "**Windows**: `scripts/smoke_updater.ps1`"
+msgstr ""
+
+#: src/updater/overview.md:428
+msgid ""
+"Both spin up a tiny HTTP server, build a v1.0.0 binary that drives the "
+"update flow, build a v1.0.1 binary that proves it ran, and verify the "
+"relaunch handed off correctly. Run them locally before shipping a release "
+"that depends on the updater wiring."
+msgstr ""
+
+#: src/updater/overview.md:435
+msgid "[System APIs](../system/overview.md) — the rest of `perry/system`"
+msgstr ""
+
+#: src/updater/overview.md:436
+msgid ""
+"[HTTP & Networking](../stdlib/http.md) — `fetch()` is what the wrapper uses "
+"internally"
+msgstr ""
+
+#: src/updater/overview.md:438
+msgid ""
+"[Cryptography](../stdlib/crypto.md) — Ed25519 sign / verify primitives for "
+"tooling that builds the manifest"
+msgstr ""
+
+#: src/system/overview.md:1
+msgid "System APIs Overview"
+msgstr ""
+
+#: src/system/overview.md:3
+msgid ""
+"The `perry/system` module provides access to platform-native system "
+"features: preferences, secure storage, notifications, dark-mode detection, "
+"audio capture, and app introspection. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links the file on every PR."
+msgstr ""
+
+#: src/system/overview.md:9
+msgid ""
+"```typescript\n"
+"// import {\n"
+"//     openURL, isDarkMode,\n"
+"//     preferencesGet, preferencesSet,\n"
+"//     keychainSave, keychainGet, keychainDelete,\n"
+"//     notificationSend,\n"
+"//     audioStart, audioStop, audioGetLevel, audioGetPeak, audioGetWaveform,\n"
+"// } from \"perry/system\"\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:19
+msgid "Available APIs"
+msgstr ""
+
+#: src/system/overview.md:23
+msgid "`openURL(url)`"
+msgstr ""
+
+#: src/system/overview.md:23
+msgid "Open URL in default browser/app"
+msgstr ""
+
+#: src/system/overview.md:23 src/system/overview.md:24
+#: src/system/overview.md:25 src/system/overview.md:26
+#: src/system/overview.md:27 src/system/overview.md:29
+#: src/system/overview.md:30 src/system/overview.md:31
+#: src/system/overview.md:32 src/system/overview.md:36
+#: src/system/overview.md:37 src/system/overview.md:38
+msgid "All"
+msgstr ""
+
+#: src/system/overview.md:24
+msgid "`isDarkMode()`"
+msgstr ""
+
+#: src/system/overview.md:24
+msgid "Check system dark mode"
+msgstr ""
+
+#: src/system/overview.md:25
+msgid "`getDeviceIdiom()`"
+msgstr ""
+
+#: src/system/overview.md:25
+msgid "`\"phone\"`, `\"pad\"`, `\"mac\"`, `\"tv\"`, …"
+msgstr ""
+
+#: src/system/overview.md:26
+msgid "`getDeviceModel()`"
+msgstr ""
+
+#: src/system/overview.md:26
+msgid "Device model identifier (e.g. `\"iPhone13,4\"`)"
+msgstr ""
+
+#: src/system/overview.md:27
+msgid "`preferencesSet(key, value)`"
+msgstr ""
+
+#: src/system/overview.md:27
+msgid "Store a preference (string or number)"
+msgstr ""
+
+#: src/system/overview.md:28
+msgid "`preferencesGet(key)`"
+msgstr ""
+
+#: src/system/overview.md:28
+msgid "Read a preference (returns \\`string"
+msgstr ""
+
+#: src/system/overview.md:29
+msgid "`keychainSave(key, value)`"
+msgstr ""
+
+#: src/system/overview.md:29
+msgid "Secure storage write"
+msgstr ""
+
+#: src/system/overview.md:30
+msgid "`keychainGet(key)`"
+msgstr ""
+
+#: src/system/overview.md:30
+msgid "Secure storage read"
+msgstr ""
+
+#: src/system/overview.md:31
+msgid "`keychainDelete(key)`"
+msgstr ""
+
+#: src/system/overview.md:31
+msgid "Secure storage remove"
+msgstr ""
+
+#: src/system/overview.md:32
+msgid "`notificationSend(title, body)`"
+msgstr ""
+
+#: src/system/overview.md:32
+msgid "Local notification"
+msgstr ""
+
+#: src/system/overview.md:33
+msgid "`notificationCancel(id)`"
+msgstr ""
+
+#: src/system/overview.md:33
+msgid "Cancel a scheduled notification"
+msgstr ""
+
+#: src/system/overview.md:33 src/system/overview.md:34
+msgid "Apple"
+msgstr ""
+
+#: src/system/overview.md:34
+msgid "`notificationOnTap(cb)`"
+msgstr ""
+
+#: src/system/overview.md:34
+msgid "Handle banner taps"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "`notificationRegisterRemote(cb)` / `notificationOnReceive(cb)`"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "Push (APNs)"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "iOS, macOS"
+msgstr ""
+
+#: src/system/overview.md:36
+msgid "`audioStart()` / `audioStop()`"
+msgstr ""
+
+#: src/system/overview.md:36
+msgid "Microphone capture"
+msgstr ""
+
+#: src/system/overview.md:37
+msgid "`audioGetLevel()` / `audioGetPeak()`"
+msgstr ""
+
+#: src/system/overview.md:37
+msgid "RMS / peak amplitude (`0..1`)"
+msgstr ""
+
+#: src/system/overview.md:38
+msgid "`audioGetWaveform(n)`"
+msgstr ""
+
+#: src/system/overview.md:38
+msgid "Recent waveform samples for visualization"
+msgstr ""
+
+#: src/system/overview.md:40
+msgid ""
+"**Clipboard** lives in `perry/ui` (not `perry/system`): import "
+"`clipboardRead` and `clipboardWrite` from there."
+msgstr ""
+
+#: src/system/overview.md:45 src/system/other.md:29
+msgid ""
+"```typescript\n"
+"if (isDarkMode()) {\n"
+"    console.log(\"Dark mode is active\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:51 src/system/preferences.md:14
+msgid ""
+"```typescript\n"
+"// Strings and numbers round-trip natively — no manual stringification needed.\n"
+"preferencesSet(\"theme\", \"dark\")\n"
+"preferencesSet(\"font-size\", 14)\n"
+"\n"
+"const theme = preferencesGet(\"theme\")        // string | number | undefined\n"
+"const fontSize = preferencesGet(\"font-size\") // → 14 (number)\n"
+"\n"
+"if (typeof theme === \"string\") {\n"
+"    console.log(`saved theme: ${theme}`)\n"
+"}\n"
+"if (typeof fontSize === \"number\") {\n"
+"    console.log(`saved font-size: ${fontSize}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:67 src/system/other.md:14
+msgid ""
+"```typescript\n"
+"openURL(\"https://example.com\")\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:73
+msgid "[Preferences](preferences.md)"
+msgstr ""
+
+#: src/system/overview.md:74
+msgid "[Keychain](keychain.md)"
+msgstr ""
+
+#: src/system/overview.md:75
+msgid "[Notifications](notifications.md)"
+msgstr ""
+
+#: src/system/overview.md:76
+msgid "[Audio Capture](audio.md)"
+msgstr ""
+
+#: src/system/overview.md:77
+msgid "[Other](other.md)"
+msgstr ""
+
+#: src/system/preferences.md:3
+msgid ""
+"Store and retrieve user preferences using the platform's native storage. "
+"Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/preferences.md:10
+msgid ""
+"`preferencesSet(key, value)` accepts strings **or** numbers and round-trips "
+"them natively (NSUserDefaults / GSettings / Registry preserve the original "
+"type). `preferencesGet(key)` returns `string | number | undefined`:"
+msgstr ""
+
+#: src/system/preferences.md:30 src/system/keychain.md:21
+msgid "Platform Storage"
+msgstr ""
+
+#: src/system/preferences.md:32 src/system/keychain.md:23
+#: src/system/notifications.md:60 src/system/media.md:84
+msgid "Backend"
+msgstr ""
+
+#: src/system/preferences.md:34 src/system/preferences.md:35
+msgid "NSUserDefaults"
+msgstr ""
+
+#: src/system/preferences.md:36
+msgid "SharedPreferences"
+msgstr ""
+
+#: src/system/preferences.md:37
+msgid "Windows Registry"
+msgstr ""
+
+#: src/system/preferences.md:38
+msgid "GSettings / file-based"
+msgstr ""
+
+#: src/system/preferences.md:39
+msgid "localStorage"
+msgstr ""
+
+#: src/system/preferences.md:41
+msgid ""
+"Preferences persist across app launches. They are not encrypted — use "
+"[Keychain](keychain.md) for sensitive data."
+msgstr ""
+
+#: src/system/preferences.md:46 src/system/notifications.md:74
+msgid "[Keychain](keychain.md) — Secure storage"
+msgstr ""
+
+#: src/system/preferences.md:47 src/system/keychain.md:39
+#: src/system/notifications.md:76 src/system/audio.md:74
+#: src/system/media.md:245 src/system/other.md:70
+msgid "[Overview](overview.md) — All system APIs"
+msgstr ""
+
+#: src/system/keychain.md:3
+msgid ""
+"Securely store sensitive data like tokens, passwords, and API keys using the"
+" platform's secure storage. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/keychain.md:10
+msgid ""
+"```typescript\n"
+"keychainSave(\"api_token\", \"sk-...\")\n"
+"const token = keychainGet(\"api_token\")\n"
+"keychainDelete(\"api_token\")\n"
+"console.log(`token length: ${token.length}`)\n"
+"```"
+msgstr ""
+
+#: src/system/keychain.md:17
+msgid ""
+"The free-function API is `keychainSave(key, value)`, `keychainGet(key)` "
+"(returns the stored string, or an empty string if the key isn't present), "
+"and `keychainDelete(key)`."
+msgstr ""
+
+#: src/system/keychain.md:25 src/system/keychain.md:26
+msgid "Security.framework (Keychain)"
+msgstr ""
+
+#: src/system/keychain.md:27
+msgid "Android Keystore"
+msgstr ""
+
+#: src/system/keychain.md:28
+msgid "Windows Credential Manager (CredWrite/CredRead/CredDelete)"
+msgstr ""
+
+#: src/system/keychain.md:29
+msgid "libsecret"
+msgstr ""
+
+#: src/system/keychain.md:30
+msgid "localStorage (not truly secure)"
+msgstr ""
+
+#: src/system/keychain.md:32
+msgid ""
+"**Web**: The web platform uses `localStorage`, which is not encrypted. For "
+"web apps handling sensitive data, consider server-side storage instead."
+msgstr ""
+
+#: src/system/keychain.md:37
+msgid "[Preferences](preferences.md) — Non-sensitive preferences"
+msgstr ""
+
+#: src/system/keychain.md:38
+msgid "[Notifications](notifications.md) — Local notifications"
+msgstr ""
+
+#: src/system/notifications.md:3
+msgid ""
+"Send local notifications using the platform's notification system. Every "
+"snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/notifications.md:8
+msgid "Sending a notification"
+msgstr ""
+
+#: src/system/notifications.md:10
+msgid ""
+"```typescript\n"
+"notificationSend(\"Build complete\", \"All targets compiled in 4.2s.\")\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:14
+msgid "Reacting to a tap"
+msgstr ""
+
+#: src/system/notifications.md:16
+msgid ""
+"```typescript\n"
+"notificationOnTap((id: string, action?: string) => {\n"
+"    console.log(`tapped notification ${id}; action=${action ?? \"(default)\"}`)\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:22
+msgid ""
+"`action` is the action-button identifier when the user picks a button, or "
+"`undefined` for the default banner tap."
+msgstr ""
+
+#: src/system/notifications.md:25
+msgid "Cancelling a scheduled notification"
+msgstr ""
+
+#: src/system/notifications.md:27
+msgid ""
+"```typescript\n"
+"notificationCancel(\"daily-reminder\")\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:31
+msgid ""
+"`notificationCancel(id)` is a no-op if no scheduled notification with that "
+"id exists."
+msgstr ""
+
+#: src/system/notifications.md:34
+msgid "Push notifications (APNs / Firebase)"
+msgstr ""
+
+#: src/system/notifications.md:46
+msgid ""
+"`notificationRegisterRemote(cb)` fires once when the OS returns a device "
+"token — on Apple platforms the token is the canonical uppercase hex string "
+"APNs expects. `notificationOnReceive(cb)` runs whenever a remote payload "
+"arrives while the app is foregrounded; the payload is the APNs `aps` "
+"userInfo dictionary (or equivalent platform shape) converted to a plain "
+"object."
+msgstr ""
+
+#: src/system/notifications.md:52
+msgid ""
+"Requires the relevant platform capability (APNs entitlement on iOS/macOS, "
+"Firebase Messaging on Android — wired via JNI through "
+"`PerryFirebaseMessagingService`, see "
+"[\\#98](https://github.com/PerryTS/perry/issues/98)). No-op on platforms "
+"without a push pipeline (tvOS, visionOS, watchOS, GTK4, Windows, Web)."
+msgstr ""
+
+#: src/system/notifications.md:58
+msgid "Platform Implementation"
+msgstr ""
+
+#: src/system/notifications.md:62 src/system/notifications.md:63
+msgid "UNUserNotificationCenter"
+msgstr ""
+
+#: src/system/notifications.md:64
+msgid "NotificationManager"
+msgstr ""
+
+#: src/system/notifications.md:65
+msgid "Toast notifications"
+msgstr ""
+
+#: src/system/notifications.md:66
+msgid "GNotification"
+msgstr ""
+
+#: src/system/notifications.md:67
+msgid "Web Notification API"
+msgstr ""
+
+#: src/system/notifications.md:69
+msgid ""
+"**Permissions**: On macOS, iOS, and Web, the user may need to grant "
+"notification permissions. On first use, the system will prompt "
+"automatically."
+msgstr ""
+
+#: src/system/notifications.md:75
+msgid "[Other](other.md) — Additional system APIs"
+msgstr ""
+
+#: src/system/audio.md:3
+msgid ""
+"The `perry/system` module provides real-time audio capture from the device "
+"microphone, with A-weighted dB(A) level metering and waveform sampling — "
+"everything needed to build a sound meter, audio visualizer, or voice-level "
+"indicator. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/audio.md:10
+msgid ""
+"```typescript\n"
+"const ok = audioStart() // 1 on success, 0 on failure\n"
+"if (ok === 1) {\n"
+"    const level = audioGetLevel()           // 0..1\n"
+"    const peak = audioGetPeak()             // 0..1\n"
+"    const waveform = audioGetWaveform(64)   // sample-count\n"
+"    console.log(`level=${level} peak=${peak} waveform=${waveform}`)\n"
+"    audioStop()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/audio.md:23
+msgid "`audioStart()`"
+msgstr ""
+
+#: src/system/audio.md:25
+msgid ""
+"Start capturing audio from the device microphone. Returns `1` on success, "
+"`0` on failure (permission denied, no microphone, etc.)."
+msgstr ""
+
+#: src/system/audio.md:28
+msgid ""
+"On platforms that require permission (iOS, Android, Web), the system "
+"permission dialog is shown automatically."
+msgstr ""
+
+#: src/system/audio.md:31
+msgid "`audioStop()`"
+msgstr ""
+
+#: src/system/audio.md:33
+msgid "Stop audio capture and release the microphone."
+msgstr ""
+
+#: src/system/audio.md:35
+msgid "`audioGetLevel()`"
+msgstr ""
+
+#: src/system/audio.md:37
+msgid ""
+"Get the current A-weighted sound level (a smoothed value with a 125 ms time "
+"constant). Typical ranges:"
+msgstr ""
+
+#: src/system/audio.md:40
+msgid "~30 dB — quiet room"
+msgstr ""
+
+#: src/system/audio.md:41
+msgid "~50 dB — normal conversation"
+msgstr ""
+
+#: src/system/audio.md:42
+msgid "~70 dB — busy street"
+msgstr ""
+
+#: src/system/audio.md:43
+msgid "~90 dB — loud music"
+msgstr ""
+
+#: src/system/audio.md:44
+msgid "~110+ dB — dangerously loud"
+msgstr ""
+
+#: src/system/audio.md:46
+msgid "`audioGetPeak()`"
+msgstr ""
+
+#: src/system/audio.md:48
+msgid ""
+"Get the current peak sample amplitude (`0.0`–`1.0`). Useful for simple level"
+" indicators without dB conversion."
+msgstr ""
+
+#: src/system/audio.md:51
+msgid "`audioGetWaveform(sampleCount)`"
+msgstr ""
+
+#: src/system/audio.md:53
+msgid ""
+"Get recent waveform samples for visualization. Pass the number of samples "
+"you want; the runtime returns the most recent N readings from its internal "
+"ring buffer. Useful for drawing waveform displays or level history charts."
+msgstr ""
+
+#: src/system/audio.md:57
+msgid "Platform Implementations"
+msgstr ""
+
+#: src/system/audio.md:59
+msgid "Audio Backend"
+msgstr ""
+
+#: src/system/audio.md:59
+msgid "Permissions"
+msgstr ""
+
+#: src/system/audio.md:61
+msgid "AVAudioEngine"
+msgstr ""
+
+#: src/system/audio.md:61
+msgid "Microphone permission dialog"
+msgstr ""
+
+#: src/system/audio.md:62
+msgid "AVAudioSession + AVAudioEngine"
+msgstr ""
+
+#: src/system/audio.md:62
+msgid "System permission dialog"
+msgstr ""
+
+#: src/system/audio.md:63
+msgid "AudioRecord (JNI)"
+msgstr ""
+
+#: src/system/audio.md:63
+msgid "RECORD_AUDIO permission"
+msgstr ""
+
+#: src/system/audio.md:64
+msgid "PulseAudio (libpulse-simple)"
+msgstr ""
+
+#: src/system/audio.md:64
+msgid "None (system-level)"
+msgstr ""
+
+#: src/system/audio.md:65
+msgid "WASAPI (shared mode)"
+msgstr ""
+
+#: src/system/audio.md:65
+msgid "None"
+msgstr ""
+
+#: src/system/audio.md:66
+msgid "getUserMedia + AnalyserNode"
+msgstr ""
+
+#: src/system/audio.md:66
+msgid "Browser permission dialog"
+msgstr ""
+
+#: src/system/audio.md:68
+msgid ""
+"All platforms capture at 48 kHz mono and apply the same A-weighting filter "
+"(IEC 61672 standard, 3 cascaded biquad sections)."
+msgstr ""
+
+#: src/system/audio.md:73
+msgid "[Camera](../ui/camera.md) — Live camera preview (iOS)"
+msgstr ""
+
+#: src/system/media.md:3
+msgid ""
+"The `perry/media` module provides streaming media playback — HTTP/HTTPS "
+"audio URLs (Subsonic, Icecast, plain MP3/AAC, HLS m3u8), `file://` paths, "
+"lock-screen / Now Playing metadata, and remote-command (Siri Remote / Touch "
+"Bar / Control Center) integration."
+msgstr ""
+
+#: src/system/media.md:10
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"  createPlayer,\n"
+"  play,\n"
+"  pause,\n"
+"  setVolume,\n"
+"  onStateChange,\n"
+"  onTimeUpdate,\n"
+"  setNowPlaying,\n"
+"} from \"perry/media\";\n"
+"\n"
+"const player = createPlayer(\"https://example.com/track.mp3\");\n"
+"if (player === 0) {\n"
+"  console.error(\"createPlayer failed\");\n"
+"} else {\n"
+"  setVolume(player, 0.8);\n"
+"  setNowPlaying(player, \"Track Title\", \"Artist\", \"Album\", \"\");\n"
+"\n"
+"  onStateChange(player, (state) => console.log(\"state:\", state));\n"
+"  onTimeUpdate(player, (cur, dur) => console.log(`${cur}/${dur}s`));\n"
+"\n"
+"  play(player); // begins (or resumes) once buffered\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/media.md:35
+msgid "API surface"
+msgstr ""
+
+#: src/system/media.md:37
+msgid "Returns"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "`createPlayer(url)`"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "handle (1+) or `0` on failure"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "HTTP/HTTPS or `file://`"
+msgstr ""
+
+#: src/system/media.md:40
+msgid "`play(handle)`"
+msgstr ""
+
+#: src/system/media.md:40 src/system/media.md:41 src/system/media.md:42
+#: src/system/media.md:43 src/system/media.md:44 src/system/media.md:45
+#: src/system/media.md:50 src/system/media.md:51 src/system/media.md:52
+#: src/system/media.md:53
+msgid "void"
+msgstr ""
+
+#: src/system/media.md:40
+msgid "Resumes if paused"
+msgstr ""
+
+#: src/system/media.md:41
+msgid "`pause(handle)`"
+msgstr ""
+
+#: src/system/media.md:41
+msgid "Position preserved"
+msgstr ""
+
+#: src/system/media.md:42
+msgid "`stop(handle)`"
+msgstr ""
+
+#: src/system/media.md:42
+msgid "Resets position to 0"
+msgstr ""
+
+#: src/system/media.md:43
+msgid "`seek(handle, seconds)`"
+msgstr ""
+
+#: src/system/media.md:44
+msgid "`setVolume(handle, volume)`"
+msgstr ""
+
+#: src/system/media.md:44
+msgid "0.0–1.0, clamped"
+msgstr ""
+
+#: src/system/media.md:45
+msgid "`setRate(handle, rate)`"
+msgstr ""
+
+#: src/system/media.md:45
+msgid "1.0 = normal; Apple supports 0.5–2.0"
+msgstr ""
+
+#: src/system/media.md:46
+msgid "`getCurrentTime(handle)`"
+msgstr ""
+
+#: src/system/media.md:46 src/system/media.md:47
+msgid "seconds"
+msgstr ""
+
+#: src/system/media.md:47
+msgid "`getDuration(handle)`"
+msgstr ""
+
+#: src/system/media.md:47
+msgid "`0` if live / loading"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "`getState(handle)`"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "`MediaState`"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "See states below"
+msgstr ""
+
+#: src/system/media.md:49
+msgid "`isPlaying(handle)`"
+msgstr ""
+
+#: src/system/media.md:50
+msgid "`onStateChange(h, cb)`"
+msgstr ""
+
+#: src/system/media.md:50
+msgid "Fires on every transition"
+msgstr ""
+
+#: src/system/media.md:51
+msgid "`onTimeUpdate(h, cb)`"
+msgstr ""
+
+#: src/system/media.md:51
+msgid "~10 Hz while playing"
+msgstr ""
+
+#: src/system/media.md:52
+msgid "`setNowPlaying(h, title, artist, album, artworkUrl)`"
+msgstr ""
+
+#: src/system/media.md:52
+msgid "All strings; pass `\"\"` for unknown"
+msgstr ""
+
+#: src/system/media.md:53
+msgid "`destroy(handle)`"
+msgstr ""
+
+#: src/system/media.md:53
+msgid "Frees resources"
+msgstr ""
+
+#: src/system/media.md:55
+msgid "States"
+msgstr ""
+
+#: src/system/media.md:57
+msgid "`MediaState` is one of:"
+msgstr ""
+
+#: src/system/media.md:59
+msgid "`idle` — never started"
+msgstr ""
+
+#: src/system/media.md:60
+msgid "`loading` — buffering / fetching headers"
+msgstr ""
+
+#: src/system/media.md:61
+msgid "`ready` — first chunk decoded, ready to `play()`"
+msgstr ""
+
+#: src/system/media.md:62
+msgid "`playing` — actively rendering"
+msgstr ""
+
+#: src/system/media.md:63
+msgid "`paused` — paused (position preserved)"
+msgstr ""
+
+#: src/system/media.md:64
+msgid "`ended` — reached end of stream"
+msgstr ""
+
+#: src/system/media.md:65
+msgid "`error` — irrecoverable failure (network, codec, …)"
+msgstr ""
+
+#: src/system/media.md:67
+msgid "`ended` reliability"
+msgstr ""
+
+#: src/system/media.md:69
+msgid ""
+"`ended` is fired both from the platform's native end-of-playback signal "
+"**and** from a `currentTime ≈ duration` fallback. Per [issue #351 "
+"discussion](https://github.com/PerryTS/perry/issues/351), the native event "
+"has been historically flaky on the web / Chromecast — the same belt-and-"
+"braces is cheap to apply on every backend so a `perry/media` consumer can "
+"rely on `ended` firing once per track."
+msgstr ""
+
+#: src/system/media.md:76
+msgid ""
+"The fallback engages only after `play()` has been called and `duration` is "
+"known (live streams report `+inf`, which sanitises to `0` and disables the "
+"fallback). Window: 0.25s before duration. The native signal sets the flag "
+"first when it works; the fallback sets the same flag on the polling tick if "
+"the signal hasn't arrived."
+msgstr ""
+
+#: src/system/media.md:82
+msgid "Platform implementations"
+msgstr ""
+
+#: src/system/media.md:86
+msgid "AVPlayer + MPNowPlayingInfoCenter + MPRemoteCommandCenter"
+msgstr ""
+
+#: src/system/media.md:86 src/system/media.md:87 src/system/media.md:89
+#: src/system/media.md:90 src/system/media.md:91
+msgid "**Implemented** + lock-screen"
+msgstr ""
+
+#: src/system/media.md:87 src/system/media.md:93
+msgid "AVPlayer + AVAudioSession Playback + UIImage artwork"
+msgstr ""
+
+#: src/system/media.md:88
+msgid "AVPlayer + Siri Remote play/pause/skip"
+msgstr ""
+
+#: src/system/media.md:88
+msgid "**Implemented** + remote"
+msgstr ""
+
+#: src/system/media.md:89
+msgid "AVPlayer + UIImage artwork"
+msgstr ""
+
+#: src/system/media.md:90
+msgid "`android.media.MediaPlayer` + `MediaSessionCompat` via JNI"
+msgstr ""
+
+#: src/system/media.md:91
+msgid "GTK4 / Linux"
+msgstr ""
+
+#: src/system/media.md:91
+msgid "GStreamer `playbin` element + MPRIS D-Bus"
+msgstr ""
+
+#: src/system/media.md:92
+msgid ""
+"`Windows.Media.Playback.MediaPlayer` (WinRT) + "
+"`SystemMediaTransportControls`"
+msgstr ""
+
+#: src/system/media.md:92
+msgid "**Implemented** + Now Playing"
+msgstr ""
+
+#: src/system/media.md:93
+msgid "**Implemented** + Now Playing complication"
+msgstr ""
+
+#: src/system/media.md:94
+msgid "HarmonyOS"
+msgstr ""
+
+#: src/system/media.md:94
+msgid "`@ohos.multimedia.media.AVPlayer` via napi"
+msgstr ""
+
+#: src/system/media.md:94
+msgid ""
+"**Implemented** (lock-screen via `@ohos.multimedia.avsession` is a follow-"
+"up)"
+msgstr ""
+
+#: src/system/media.md:95
+msgid "`<audio>` element + Media Session API"
+msgstr ""
+
+#: src/system/media.md:95
+msgid ""
+"**Implemented** (`--target web`; `setNowPlaying` populates "
+"`navigator.mediaSession.metadata` + wires play / pause / seekto / "
+"seekforward / seekbackward action handlers)"
+msgstr ""
+
+#: src/system/media.md:97
+msgid ""
+"Stub platforms link cleanly against the same FFI surface — code that imports"
+" `perry/media` compiles on every target. `createPlayer` returns `0` on a "
+"stub backend so `if (player === 0)` is the canonical \"feature not available"
+" here\" check."
+msgstr ""
+
+#: src/system/media.md:102
+msgid ""
+"On Linux, `setNowPlaying` exposes the player to the desktop via MPRIS "
+"(`org.mpris.MediaPlayer2.perry-<pid>` on the session bus). GNOME Shell, KDE "
+"Plasma, `playerctl`, and any Bluetooth-headphone media-key bridge that "
+"speaks MPRIS will see the metadata and route Play / Pause / PlayPause / Stop"
+" / Seek / SetPosition back to the player. The MPRIS server is lazy-"
+"bootstrapped on the first `setNowPlaying` call so apps that don't need lock-"
+"screen integration don't pay the zbus startup cost. `Next` / `Previous` are "
+"no-ops (single-track playback model); playlists are an app-level concern."
+msgstr ""
+
+#: src/system/media.md:112
+msgid "Android — background playback"
+msgstr ""
+
+#: src/system/media.md:114
+msgid ""
+"Perry's Android backend wires `MediaSessionCompat` so the lock-screen tile, "
+"Bluetooth headset, Android Auto, and Wear OS see the metadata pushed by "
+"`setNowPlaying` and route headphone play/pause/stop/seek events back into "
+"the registered `onStateChange` closure. That covers foreground use. Apps "
+"that want playback to survive the activity being backgrounded (a podcast "
+"app, music player, etc.) need a foreground service of their own — Android "
+"will otherwise kill the audio when the process drops to the cached state. "
+"Add the following to your app's `AndroidManifest.xml` and start the service "
+"when playback begins:"
+msgstr ""
+
+#: src/system/media.md:126
+msgid "\".PerryMediaService\""
+msgstr ""
+
+#: src/system/media.md:127
+msgid "\"mediaPlayback\""
+msgstr ""
+
+#: src/system/media.md:128
+msgid "\"false\""
+msgstr ""
+
+#: src/system/media.md:129
+msgid "\"android.permission.FOREGROUND_SERVICE\""
+msgstr ""
+
+#: src/system/media.md:130
+msgid "\"android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK\""
+msgstr ""
+
+#: src/system/media.md:133
+msgid ""
+"The service implementation is app-specific — it should hold a "
+"`MediaSessionCompat.Token` (the same session Perry created), build a "
+"`Notification.MediaStyle` notification from it, and call "
+"`startForeground(...)` on `play` / `stopForeground(false)` on `pause` / "
+"`stopSelf()` on `stop`. We deliberately don't ship a default service because"
+" the notification's branding (small icon, tint, content intent) depends on "
+"the host app."
+msgstr ""
+
+#: src/system/media.md:141
+msgid "Threading notes"
+msgstr ""
+
+#: src/system/media.md:143
+msgid ""
+"The `onStateChange` and `onTimeUpdate` callbacks fire from the platform's "
+"main UI thread on every backend, so they share the same JS heap as the "
+"calling code. Implementation detail varies:"
+msgstr ""
+
+#: src/system/media.md:147
+msgid ""
+"**macOS / iOS / tvOS / visionOS** — driven by an `NSTimer` scheduled on the "
+"main run loop at 10 Hz."
+msgstr ""
+
+#: src/system/media.md:149
+msgid ""
+"**Android** — driven from `Java_com_perry_app_PerryBridge_nativePumpTick` "
+"(the existing 125 Hz UI-thread pump), throttled internally to ~10 Hz. The "
+"`prepare()` call runs on a background worker thread to avoid blocking the UI"
+" on network buffering."
+msgstr ""
+
+#: src/system/media.md:153
+msgid ""
+"**GTK4** — driven by a `glib::timeout_add_local` timer on the GLib main "
+"loop. EOS / error messages arrive on the GStreamer bus and get forwarded to "
+"per-player atomic flags via a `bus.add_watch_local` closure."
+msgstr ""
+
+#: src/system/media.md:157
+msgid ""
+"**Windows** — driven from the `GetMessageW` / `PeekMessageW` message loop "
+"after each dispatch, throttled to 100 ms by wall-clock comparison."
+msgstr ""
+
+#: src/system/media.md:159
+msgid ""
+"**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
+"directly, so `perry/media` calls record intents into Mutex-protected drain "
+"queues in `perry-runtime::media_playback`. The harvested `pages/Index.ets` "
+"(emitted by `perry-codegen-arkts` whenever the module uses `perry/media`) "
+"installs a 100 ms `setInterval` pump in `aboutToAppear` that drains the "
+"queues, dispatches each op against the matching `media.AVPlayer` instance "
+"(allocated lazily on the first `createPlayer` drain), and pushes state "
+"observations back into the runtime via the `pushMediaState(handle, state, "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / `timeUpdate`"
+" / `error` / `endOfStream` events feed the same callback path. The pump runs"
+" on the ArkTS UI thread, so closures fired by "
+"`media_playback::push_media_state` share the same arena as Perry's `main()`."
+" Lock-screen integration (`@ohos.multimedia.avsession`) is a follow-up — the"
+" runtime queues now-playing metadata via `drainNowPlaying` but the ArkTS-"
+"side AVSession dispatch is a no-op beyond a hilog line for now (tracked "
+"under issue #369)."
+msgstr ""
+
+#: src/system/media.md:177
+msgid "Now Playing on Apple platforms"
+msgstr ""
+
+#: src/system/media.md:179
+msgid ""
+"Apple's MPNowPlayingInfoCenter is a process-wide singleton — the most recent"
+" `setNowPlaying` call wins. For a single-player app (Subsonic client, "
+"podcast player) this matches user expectation. The MPRemoteCommandCenter "
+"handlers route `play` / `pause` / `togglePlayPause` events to the **first "
+"live player handle** — multi-player apps that need an explicit \"active "
+"player\" should manage that themselves."
+msgstr ""
+
+#: src/system/media.md:186
+msgid "`artworkUrl` accepts:"
+msgstr ""
+
+#: src/system/media.md:188
+msgid "`file://` paths — loaded synchronously via NSImage / UIImage"
+msgstr ""
+
+#: src/system/media.md:189
+msgid ""
+"`https://` URLs — fetched synchronously via NSData(contentsOf:) and wrapped "
+"in UIImage. The synchronous fetch is acceptable for a one-off artwork load "
+"(the MPNowPlayingInfoCenter dict is consumed synchronously when set)."
+msgstr ""
+
+#: src/system/media.md:194
+msgid "watchOS Info.plist requirements"
+msgstr ""
+
+#: src/system/media.md:196
+msgid ""
+"watchOS keeps the audio engine alive when the watch screen sleeps **only "
+"if** the app's `Info.plist` declares the `audio` background mode under "
+"`WKBackgroundModes` (the WatchKit equivalent of iOS's `UIBackgroundModes`):"
+msgstr ""
+
+#: src/system/media.md:207
+msgid ""
+"Without this entry the OS suspends the watch app a few seconds after the "
+"wrist-down gesture or screen timeout, regardless of whether AVPlayer is "
+"actively rendering. The runtime also auto-activates an `AVAudioSession` with"
+" category `Playback` on the first `createPlayer(...)` call — combined with "
+"the Info.plist entry, this is what tells watchOS the app intends to keep "
+"playing audio in the background."
+msgstr ""
+
+#: src/system/media.md:214
+msgid ""
+"The Now Playing surface on the watch face is independent from the paired "
+"iPhone's lock screen — they're separate processes with separate "
+"`MPNowPlayingInfoCenter` instances. `setNowPlaying` on watchOS targets the "
+"watch's Now Playing complication / glance screen."
+msgstr ""
+
+#: src/system/media.md:219
+msgid "Subsonic example"
+msgstr ""
+
+#: src/system/media.md:221
+msgid ""
+"```typescript,no-test\n"
+"import { createPlayer, play, setNowPlaying, onStateChange } from \"perry/media\";\n"
+"\n"
+"function streamUrl(serverUrl: string, user: string, pass: string, songId: string): string {\n"
+"  const params = new URLSearchParams({\n"
+"    u: user, p: pass, v: \"1.16.1\", c: \"PerryClient\", id: songId, format: \"mp3\",\n"
+"  });\n"
+"  return `${serverUrl}/rest/stream?${params.toString()}`;\n"
+"}\n"
+"\n"
+"const player = createPlayer(streamUrl(\"https://music.example.com\", \"alice\", \"secret\", \"12345\"));\n"
+"setNowPlaying(player, \"All These Things That I've Done\", \"The Killers\", \"Hot Fuss\",\n"
+"              \"https://music.example.com/rest/getCoverArt?id=12345&u=alice&p=secret&v=1.16.1&c=PerryClient\");\n"
+"onStateChange(player, (state) => {\n"
+"  if (state === \"ended\") {\n"
+"    // queue.next() ...\n"
+"  }\n"
+"});\n"
+"play(player);\n"
+"```"
+msgstr ""
+
+#: src/system/media.md:242
+msgid "Next steps"
+msgstr ""
+
+#: src/system/media.md:244
+msgid "[Audio Capture](audio.md) — Microphone input + dB metering"
+msgstr ""
+
+#: src/system/other.md:1
+msgid "Other System APIs"
+msgstr ""
+
+#: src/system/other.md:3
+msgid ""
+"Additional platform-level APIs. Every snippet below is excerpted from a real"
+" file CI compiles on every PR — see "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) for "
+"the perry/system pieces and "
+"[`docs/examples/ui/events/snippets.ts`](../../examples/ui/events/snippets.ts)"
+" for clipboard."
+msgstr ""
+
+#: src/system/other.md:10
+msgid "Open URL"
+msgstr ""
+
+#: src/system/other.md:12
+msgid "Open a URL in the default browser or application:"
+msgstr ""
+
+#: src/system/other.md:20
+msgid "NSWorkspace.open"
+msgstr ""
+
+#: src/system/other.md:21
+msgid "UIApplication.open"
+msgstr ""
+
+#: src/system/other.md:22
+msgid "Intent.ACTION_VIEW"
+msgstr ""
+
+#: src/system/other.md:23
+msgid "ShellExecuteW"
+msgstr ""
+
+#: src/system/other.md:24
+msgid "xdg-open"
+msgstr ""
+
+#: src/system/other.md:25
+msgid "window.open"
+msgstr ""
+
+#: src/system/other.md:27
+msgid "Dark Mode Detection"
+msgstr ""
+
+#: src/system/other.md:35
+msgid "Detection"
+msgstr ""
+
+#: src/system/other.md:37
+msgid "NSApp.effectiveAppearance"
+msgstr ""
+
+#: src/system/other.md:38
+msgid "UITraitCollection"
+msgstr ""
+
+#: src/system/other.md:39
+msgid "Configuration.uiMode"
+msgstr ""
+
+#: src/system/other.md:40
+msgid "Registry (AppsUseLightTheme)"
+msgstr ""
+
+#: src/system/other.md:41
+msgid "GTK settings"
+msgstr ""
+
+#: src/system/other.md:42
+msgid "prefers-color-scheme media query"
+msgstr ""
+
+#: src/system/other.md:46
+msgid "Clipboard helpers live in `perry/ui` (not `perry/system`):"
+msgstr ""
+
+#: src/system/other.md:57
+msgid "Device Identity"
+msgstr ""
+
+#: src/system/other.md:64
+msgid ""
+"`getDeviceIdiom()` returns the broad form factor (`\"phone\"`, `\"pad\"`, "
+"`\"mac\"`, `\"tv\"`, …); `getDeviceModel()` returns the platform-specific "
+"model identifier (`\"iPhone15,2\"`, `\"MacBookPro18,3\"`, etc.)."
+msgstr ""
+
+#: src/system/other.md:71
+msgid "[UI Overview](../ui/overview.md) — Building UIs"
+msgstr ""
+
+#: src/widgets/overview.md:1
+msgid "Widgets (WidgetKit) Overview"
+msgstr ""
+
+#: src/widgets/overview.md:3
+msgid ""
+"Perry can compile TypeScript widget declarations to native widget extensions"
+" across 4 platforms: iOS (WidgetKit), Android (App Widgets), watchOS "
+"(Complications), and Wear OS (Tiles)."
+msgstr ""
+
+#: src/widgets/overview.md:5
+msgid ""
+"**Status:** the `perry/widget` API is wired in the HIR (`crates/perry-"
+"hir/src/lower.rs:try_lower_widget_decl`) and emits via dedicated codegen "
+"crates (`perry-codegen-glance`, `perry-codegen-wear-tiles`, the WidgetKit "
+"emitter). The snippets on the widget docs pages compile-link cleanly on the "
+"host LLVM target — `Widget({...})` lowers to a no-op there — and CI verifies"
+" that via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts)."
+" What CI **cannot** do today is drive the actual cross-compile targets "
+"(`--target ios-widget`, `--target android-widget`, etc.) because each "
+"requires an `--app-bundle-id` not yet surfaced through the doc-tests harness"
+" — tracked in [\\#194](https://github.com/PerryTS/perry/issues/194). For a "
+"working end-to-end reference see "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+msgstr ""
+
+#: src/widgets/overview.md:17
+msgid "What Are Widgets?"
+msgstr ""
+
+#: src/widgets/overview.md:19
+msgid ""
+"Home screen widgets display glanceable information outside your app. Perry's"
+" `perry/widget` module lets you define widgets in TypeScript that compile to"
+" each platform's native widget system."
+msgstr ""
+
+#: src/widgets/overview.md:21
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"MyWidget\",\n"
+"    displayName: \"My Widget\",\n"
+"    description: \"Shows a greeting\",\n"
+"    entryFields: { name: \"string\" },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`Hello, ${entry.name}!`),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/overview.md:46
+msgid ""
+"The compiler generates a complete native widget extension for each platform "
+"— no platform-specific language knowledge required."
+msgstr ""
+
+#: src/widgets/overview.md:51
+msgid "# iOS WidgetKit extension\n"
+msgstr ""
+
+#: src/widgets/overview.md:52
+msgid "# Android App Widget\n"
+msgstr ""
+
+#: src/widgets/overview.md:53
+msgid "# watchOS Complication\n"
+msgstr ""
+
+#: src/widgets/overview.md:54
+msgid "# watchOS Simulator\n"
+msgstr ""
+
+#: src/widgets/overview.md:55
+msgid "# Wear OS Tile\n"
+msgstr ""
+
+#: src/widgets/overview.md:58
+msgid ""
+"Each target produces the appropriate native widget extension for that "
+"platform."
+msgstr ""
+
+#: src/widgets/overview.md:62
+msgid "[Creating Widgets](creating-widgets.md) — Widget() API in detail"
+msgstr ""
+
+#: src/widgets/overview.md:63
+msgid "[Components & Modifiers](components.md) — Available widget components"
+msgstr ""
+
+#: src/widgets/overview.md:64
+msgid "[Configuration](configuration.md) — Widget configuration options"
+msgstr ""
+
+#: src/widgets/overview.md:65
+msgid ""
+"[Data Fetching](data-fetching.md) — Timeline providers and data loading"
+msgstr ""
+
+#: src/widgets/overview.md:66
+msgid "[Cross-Platform Reference](platforms.md) — Platform-specific details"
+msgstr ""
+
+#: src/widgets/overview.md:67
+msgid "[watchOS Complications](watchos.md) — watchOS-specific guide"
+msgstr ""
+
+#: src/widgets/overview.md:68
+msgid "[Wear OS Tiles](wearos.md) — Wear OS-specific guide"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:3
+msgid "Define home screen widgets using the `Widget()` function."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:5
+msgid ""
+"**Status:** the full `Widget({...})` snippets on this page compile-link "
+"cleanly on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the API shapes are verified against the codegen. The actual cross-"
+"compile targets (`--target ios-widget`/`android-widget`/`watchos-"
+"widget`/`wearos-tile`) still aren't driven by the doc-tests harness — each "
+"requires `--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194)). For the canonical "
+"end-to-end shape see "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+" Fragments below that show partial syntax (just the `entryFields` object, "
+"just a `render:` body, etc.) are rendered as plain text — the full "
+"declarations they appear inside are covered by the verified anchors."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:18
+msgid "Widget Declaration"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:20
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"WeatherWidget\",\n"
+"    displayName: \"Weather\",\n"
+"    description: \"Shows current weather\",\n"
+"    entryFields: {\n"
+"        temperature: \"number\",\n"
+"        condition: \"string\",\n"
+"        location: \"string\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            HStack([\n"
+"                Text(entry.location),\n"
+"                Spacer(),\n"
+"                Image(\"cloud.sun.fill\"),\n"
+"            ]),\n"
+"            Text(`${entry.temperature}°`),\n"
+"            Text(entry.condition),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:43
+msgid "Widget Options"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47
+msgid "`kind`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47 src/widgets/creating-widgets.md:48
+#: src/widgets/creating-widgets.md:49 src/widgets/creating-widgets.md:54
+msgid "`string`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47
+msgid "Unique identifier for the widget"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:48
+msgid "`displayName`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:48
+msgid "Name shown in widget gallery"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:49 src/cli/perry-toml.md:119
+#: src/cli/perry-toml.md:349
+msgid "`description`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:49
+msgid "Description in widget gallery"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50
+msgid "`entryFields`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50 src/widgets/creating-widgets.md:52
+msgid "`object`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50
+msgid ""
+"Data fields with types (`\"string\"`, `\"number\"`, `\"boolean\"`, arrays, "
+"optionals, objects)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51
+msgid "`render`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51 src/widgets/creating-widgets.md:53
+msgid "`function`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51
+msgid ""
+"Render function receiving entry data, returns widget tree. Optional 2nd "
+"param for family."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:52
+msgid "`config`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:52
+msgid "Configurable parameters the user can edit (see below)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:53
+msgid "`provider`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:53
+msgid "Timeline provider function for dynamic data (see below)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:54
+msgid "`appGroup`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:54
+msgid "App group identifier for sharing data with the host app"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:56
+msgid "Entry Fields"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:58
+msgid ""
+"Entry fields define the data your widget displays. Each field has a name and"
+" type:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:60
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  title: \"string\",\n"
+"  count: \"number\",\n"
+"  isActive: \"boolean\",\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:68
+msgid "Array, Optional, and Object Fields"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:70
+msgid "Entry fields support richer types beyond primitives:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:72
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  items: [{ name: \"string\", value: \"number\" }],  // Array of objects\n"
+"  subtitle: \"string?\",                             // Optional string\n"
+"  stats: { wins: \"number\", losses: \"number\" },     // Nested object\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:80
+msgid "These compile to a Swift `TimelineEntry` struct:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:91
+msgid "Conditionals in Render"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:93
+msgid "Use ternary expressions for conditional rendering:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:95
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"ConditionalWidget\",\n"
+"    displayName: \"Conditional\",\n"
+"    description: \"Renders based on entry data\",\n"
+"    entryFields: {\n"
+"        isActive: \"boolean\",\n"
+"        count: \"number\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(entry.isActive ? \"Active\" : \"Inactive\"),\n"
+"            entry.count > 0 ? Text(`${entry.count} items`) : Spacer(),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:114
+msgid ""
+"Template literals in widget text are compiled to Swift string interpolation:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:116
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"TemplateLiteralWidget\",\n"
+"    displayName: \"Template Literal\",\n"
+"    description: \"Template literals compile to Swift string interpolation\",\n"
+"    entryFields: {\n"
+"        name: \"string\",\n"
+"        score: \"number\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        // Template literal: `${entry.name}: ${entry.score} points`\n"
+"        // Compiles to: Text(\"\\(entry.name): \\(entry.score) points\")\n"
+"        Text(`${entry.name}: ${entry.score} points`),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:132
+msgid "Configuration Parameters"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:134
+msgid ""
+"The `config` field defines user-editable parameters that appear in the "
+"widget's edit UI:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:136
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"CityWeather\",\n"
+"    displayName: \"City Weather\",\n"
+"    description: \"Weather for a chosen city\",\n"
+"    config: {\n"
+"        city: { type: \"string\", displayName: \"City\", default: \"New York\" },\n"
+"        units: {\n"
+"            type: \"enum\",\n"
+"            displayName: \"Units\",\n"
+"            values: [\"Celsius\", \"Fahrenheit\"],\n"
+"            default: \"Celsius\",\n"
+"        },\n"
+"    },\n"
+"    entryFields: { temperature: \"number\", condition: \"string\" },\n"
+"    render: (entry) => Text(`${entry.temperature}° ${entry.condition}`),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:155
+msgid "Provider Function"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:157
+msgid ""
+"The `provider` field defines a timeline provider that fetches data for the "
+"widget:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:159
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StockWidget\",\n"
+"    displayName: \"Stock Price\",\n"
+"    description: \"Shows current stock price\",\n"
+"    config: {\n"
+"        symbol: { type: \"string\", displayName: \"Symbol\", default: \"AAPL\" },\n"
+"    },\n"
+"    entryFields: { price: \"number\", change: \"string\" },\n"
+"    provider: async (config) => {\n"
+"        const res = await fetch(`https://api.example.com/stock/${config.symbol}`)\n"
+"        const data = await res.json()\n"
+"        return { price: data.price, change: data.change }\n"
+"    },\n"
+"    // Inline-options form — the chain form `.font(\"title\")` parses but is\n"
+"    // dropped at HIR-lowering time (#195).\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`$${entry.price}`, { font: \"title\" }),\n"
+"            Text(entry.change, { color: \"green\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:183
+msgid ""
+"Note: the chain-style modifiers (`.font(\"title\").color(\"green\")`) parse "
+"but are dropped at HIR-lowering time — see "
+"[\\#195](https://github.com/PerryTS/perry/issues/195). The verified extract "
+"above uses the inline-options form `Text(\"...\", { font: \"title\" })`, "
+"which is what actually round-trips through the widget codegen."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:189
+msgid "Placeholder Data"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:191
+msgid ""
+"When the widget has no data yet (e.g., first load), the provider can return "
+"placeholder data by providing a `placeholder` field:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:193
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"NewsWidget\",\n"
+"  entryFields: { headline: \"string\", source: \"string\" },\n"
+"  placeholder: { headline: \"Loading...\", source: \"---\" },\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:202
+msgid "Family-Specific Rendering"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:204
+msgid ""
+"The render function accepts an optional second parameter for the widget "
+"family, allowing different layouts per size:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:206
+msgid ""
+"```text\n"
+"render: (entry, family) =>\n"
+"  family === \"systemLarge\"\n"
+"    ? VStack([\n"
+"        Text(entry.title).font(\"title\"),\n"
+"        ForEach(entry.items, (item) => Text(item.name)),\n"
+"      ])\n"
+"    : HStack([\n"
+"        Image(\"star.fill\"),\n"
+"        Text(entry.title).font(\"headline\"),\n"
+"      ]),\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:219
+msgid ""
+"Supported families: `\"systemSmall\"`, `\"systemMedium\"`, "
+"`\"systemLarge\"`, `\"accessoryCircular\"`, `\"accessoryRectangular\"`, "
+"`\"accessoryInline\"`."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:221
+msgid "App Group"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:223
+msgid ""
+"The `appGroup` field specifies a shared container for data exchange between "
+"the host app and the widget:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:225
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"AppDataWidget\",\n"
+"  appGroup: \"group.com.example.myapp\",\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:233
+msgid "Multiple Widgets"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:235
+msgid ""
+"Define multiple widgets in a single file. They're bundled into a "
+"`WidgetBundle`:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:237
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"SmallWidget\",\n"
+"  // ...\n"
+"});\n"
+"\n"
+"Widget({\n"
+"  kind: \"LargeWidget\",\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:251
+msgid ""
+"[Components](components.md) — Available widget components and modifiers"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:252 src/widgets/components.md:273
+msgid "[Overview](overview.md) — Widget system overview"
+msgstr ""
+
+#: src/widgets/components.md:1
+msgid "Widget Components & Modifiers"
+msgstr ""
+
+#: src/widgets/components.md:3
+msgid "Available components and modifiers for widgets."
+msgstr ""
+
+#: src/widgets/components.md:5
+msgid ""
+"**Status:** this page mixes (a) tiny fragments showing component shape — "
+"rendered as plain `text` because they're not standalone declarations and "
+"can't compile — and (b) one full verified Widget at the bottom that compile-"
+"links via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts)."
+" The doc-tests harness can't drive `--target ios-widget`/`android-widget`/ "
+"`watchos-widget`/`wearos-tile` directly (each needs `--app-bundle-id` and a "
+"platform SDK — [\\#194](https://github.com/PerryTS/perry/issues/194)). Note "
+"also that the modifier parser in `crates/perry-hir/src/lower.rs` "
+"(`parse_modifiers_from_args` / `parse_single_modifier`) only reads modifiers"
+" from **inline option-object arguments** — e.g. `Text(\"hi\", { font: "
+"\"title\", color: \"red\" })` and `VStack([...], { padding: 16 })`. Method-"
+"style chains like `Text(\"hi\").font(\"title\")` shown below parse without "
+"error but **drop the modifier** at HIR-lowering time "
+"([\\#195](https://github.com/PerryTS/perry/issues/195)). The chain form is "
+"documented here because it reads naturally; the verified Complete Example at"
+" the bottom of the page uses the inline-options form that actually round-"
+"trips through the widget codegen path. The end-to-end reference is "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+msgstr ""
+
+#: src/widgets/components.md:27
+msgid ""
+"```text\n"
+"Text(\"Hello, World!\")\n"
+"Text(`${entry.name}: ${entry.value}`)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:32
+msgid "Text Modifiers"
+msgstr ""
+
+#: src/widgets/components.md:34
+msgid ""
+"```text\n"
+"const t = Text(\"Styled\");\n"
+"t.font(\"title\");       // .title, .headline, .body, .caption, etc.\n"
+"t.color(\"blue\");       // Named color or hex\n"
+"t.bold();\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:45
+msgid ""
+"```text\n"
+"VStack([\n"
+"  Text(\"Top\"),\n"
+"  Text(\"Bottom\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:54 src/widgets/components.md:75
+msgid ""
+"```text\n"
+"HStack([\n"
+"  Text(\"Left\"),\n"
+"  Spacer(),\n"
+"  Text(\"Right\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:64
+msgid ""
+"```text\n"
+"ZStack([\n"
+"  Image(\"background\"),\n"
+"  Text(\"Overlay\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:73
+msgid "Flexible space that expands to fill available room:"
+msgstr ""
+
+#: src/widgets/components.md:85
+msgid "Display SF Symbols or asset images:"
+msgstr ""
+
+#: src/widgets/components.md:87
+msgid ""
+"```text\n"
+"Image(\"star.fill\")           // SF Symbol\n"
+"Image(\"cloud.sun.rain.fill\") // SF Symbol\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:94
+msgid "Iterate over array entry fields to render a list of components:"
+msgstr ""
+
+#: src/widgets/components.md:108
+msgid "A visual separator line:"
+msgstr ""
+
+#: src/widgets/components.md:110
+msgid ""
+"```text\n"
+"VStack([\n"
+"  Text(\"Above\"),\n"
+"  Divider(),\n"
+"  Text(\"Below\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:118 src/widgets/platforms.md:28
+msgid "Label"
+msgstr ""
+
+#: src/widgets/components.md:120
+msgid "A label with text and an SF Symbol icon:"
+msgstr ""
+
+#: src/widgets/components.md:122
+msgid ""
+"```text\n"
+"Label(\"Downloads\", \"arrow.down.circle\")\n"
+"Label(`${entry.count} items`, \"folder.fill\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:127 src/widgets/platforms.md:29
+msgid "Gauge"
+msgstr ""
+
+#: src/widgets/components.md:129
+msgid "A circular or linear progress indicator:"
+msgstr ""
+
+#: src/widgets/components.md:131
+msgid ""
+"```text\n"
+"Gauge(entry.progress, 0, 100)       // value, min, max\n"
+"Gauge(entry.battery, 0, 1.0)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:138
+msgid ""
+"Widget components support SwiftUI-style modifiers. The chain forms shown "
+"below parse but drop their modifiers at HIR-lowering time "
+"([\\#195](https://github.com/PerryTS/perry/issues/195)) — use the inline "
+"option-object form (`Text(\"hi\", { font: \"title\" })`, `VStack([...], { "
+"padding: 16 })`) for the form that actually reaches the codegen, as in the "
+"[Complete Example](#complete-example) at the bottom of this page."
+msgstr ""
+
+#: src/widgets/components.md:146
+msgid "Font"
+msgstr ""
+
+#: src/widgets/components.md:148
+msgid ""
+"```text\n"
+"Text(\"Title\").font(\"title\")\n"
+"Text(\"Body\").font(\"body\")\n"
+"Text(\"Caption\").font(\"caption\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:154
+msgid "Color"
+msgstr ""
+
+#: src/widgets/components.md:156
+msgid ""
+"```text\n"
+"Text(\"Red text\").color(\"red\")\n"
+"Text(\"Custom\").color(\"#FF6600\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:161
+msgid "Padding"
+msgstr ""
+
+#: src/widgets/components.md:167
+msgid "Frame"
+msgstr ""
+
+#: src/widgets/components.md:173
+msgid "Max Width"
+msgstr ""
+
+#: src/widgets/components.md:175
+msgid ""
+"```text\n"
+"widget.maxWidth(\"infinity\")   // Expand to fill available width\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:179
+msgid "Minimum Scale Factor"
+msgstr ""
+
+#: src/widgets/components.md:181
+msgid "Allow text to shrink to fit:"
+msgstr ""
+
+#: src/widgets/components.md:183
+msgid ""
+"```text\n"
+"Text(\"Long text\").minimumScaleFactor(0.5)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:187
+msgid "Container Background"
+msgstr ""
+
+#: src/widgets/components.md:189
+msgid "Set background color for the widget container:"
+msgstr ""
+
+#: src/widgets/components.md:191
+msgid ""
+"```text\n"
+"VStack([...]).containerBackground(\"blue\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:195
+msgid "Widget URL"
+msgstr ""
+
+#: src/widgets/components.md:197
+msgid "Make the widget tappable with a deep link:"
+msgstr ""
+
+#: src/widgets/components.md:199
+msgid ""
+"```text\n"
+"VStack([...]).url(\"myapp://detail/123\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:203
+msgid "Edge-Specific Padding"
+msgstr ""
+
+#: src/widgets/components.md:205
+msgid "Apply padding to specific edges:"
+msgstr ""
+
+#: src/widgets/components.md:207
+msgid ""
+"```text\n"
+"VStack([...]).paddingEdge(\"top\", 8)\n"
+"VStack([...]).paddingEdge(\"horizontal\", 16)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:212
+msgid "Conditionals"
+msgstr ""
+
+#: src/widgets/components.md:214
+msgid "Render different components based on entry data:"
+msgstr ""
+
+#: src/widgets/components.md:216
+msgid ""
+"```text\n"
+"render: (entry) =>\n"
+"  VStack([\n"
+"    entry.isOnline\n"
+"      ? Text(\"Online\").color(\"green\")\n"
+"      : Text(\"Offline\").color(\"red\"),\n"
+"  ]),\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:227
+msgid ""
+"The full Widget below is the verified extract — it compile-links on the host"
+" LLVM target and uses the inline-options modifier form that round-trips "
+"through the codegen."
+msgstr ""
+
+#: src/widgets/components.md:231
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StatsWidget\",\n"
+"    displayName: \"Stats\",\n"
+"    description: \"Shows daily stats\",\n"
+"    entryFields: {\n"
+"        steps: \"number\",\n"
+"        calories: \"number\",\n"
+"        distance: \"string\",\n"
+"    },\n"
+"    // Inline-options modifier form — the `.font(\"title\").bold()` chain form\n"
+"    // parses but its modifiers don't reach the codegen (#195).\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            HStack([\n"
+"                Image(\"figure.walk\"),\n"
+"                Text(\"Daily Stats\", { font: \"headline\" }),\n"
+"            ]),\n"
+"            Spacer(),\n"
+"            HStack([\n"
+"                VStack([\n"
+"                    Text(`${entry.steps}`, { font: \"title\", fontWeight: \"bold\" }),\n"
+"                    Text(\"steps\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"                Spacer(),\n"
+"                VStack([\n"
+"                    Text(`${entry.calories}`, { font: \"title\", fontWeight: \"bold\" }),\n"
+"                    Text(\"cal\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"                Spacer(),\n"
+"                VStack([\n"
+"                    Text(entry.distance, { font: \"title\", fontWeight: \"bold\" }),\n"
+"                    Text(\"km\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"            ]),\n"
+"        ], { padding: 16 }),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:272
+msgid "[Creating Widgets](creating-widgets.md) — Widget() API"
+msgstr ""
+
+#: src/widgets/configuration.md:1
+msgid "Widget Configuration"
+msgstr ""
+
+#: src/widgets/configuration.md:3
+msgid ""
+"Perry widgets support user-configurable parameters. On iOS/watchOS, these "
+"compile to AppIntent configurations (the \"Edit Widget\" sheet). On "
+"Android/Wear OS, they compile to a Configuration Activity."
+msgstr ""
+
+#: src/widgets/configuration.md:5
+msgid ""
+"**Status:** the full `TopSitesWidget` declaration below compile-links "
+"cleanly on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `config: { ... }` shape is verified against `parse_config_params` in"
+" `crates/perry-hir/src/lower.rs`. The shorter fragments lower on the page "
+"(just a `provider:` body, just a `config:` object) are rendered as plain "
+"text — they're not standalone declarations. The cross-compile targets "
+"themselves (`--target ios-widget`/ `android-widget`/`watchos-"
+"widget`/`wearos-tile`) still aren't driven by the doc-tests harness — each "
+"needs `--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194))."
+msgstr ""
+
+#: src/widgets/configuration.md:17
+msgid "Defining Config Fields"
+msgstr ""
+
+#: src/widgets/configuration.md:19
+msgid ""
+"Add a `config` object to your `Widget()` declaration. Each field specifies a"
+" type, allowed values, a default, and a display title."
+msgstr ""
+
+#: src/widgets/configuration.md:21
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"TopSitesWidget\",\n"
+"    displayName: \"Top Sites\",\n"
+"    description: \"Your top performing sites\",\n"
+"    supportedFamilies: [\"systemSmall\", \"systemMedium\"],\n"
+"    appGroup: \"group.com.example.shared\",\n"
+"\n"
+"    config: {\n"
+"        sortBy: {\n"
+"            type: \"enum\",\n"
+"            values: [\"clicks\", \"impressions\", \"ctr\", \"position\"],\n"
+"            default: \"clicks\",\n"
+"            title: \"Sort By\",\n"
+"        },\n"
+"        dateRange: {\n"
+"            type: \"enum\",\n"
+"            values: [\"7d\", \"28d\", \"90d\"],\n"
+"            default: \"7d\",\n"
+"            title: \"Date Range\",\n"
+"        },\n"
+"    },\n"
+"\n"
+"    entryFields: {\n"
+"        total: \"number\",\n"
+"        label: \"string\",\n"
+"    },\n"
+"\n"
+"    provider: async (config: { sortBy: string; dateRange: string }) => {\n"
+"        const res = await fetch(\n"
+"            `https://api.example.com/stats?sort=${config.sortBy}&range=${config.dateRange}`,\n"
+"        )\n"
+"        const data = await res.json()\n"
+"        return {\n"
+"            entries: [{ total: data.total, label: data.label }],\n"
+"            reloadPolicy: { after: { minutes: 30 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`${entry.total}`, { font: \"title\", fontWeight: \"bold\" }),\n"
+"            Text(entry.label, { font: \"caption\", color: \"secondary\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:68
+msgid "Supported Parameter Types"
+msgstr ""
+
+#: src/widgets/configuration.md:70
+msgid "TypeScript"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "Enum"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "`{ type: \"enum\", values: [...], default: \"...\", title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "Picker with fixed choices"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "Boolean"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "`{ type: \"bool\", default: true, title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "Toggle switch"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "String"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "`{ type: \"string\", default: \"...\", title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "Free-text input"
+msgstr ""
+
+#: src/widgets/configuration.md:76
+msgid "Accessing Config in the Provider"
+msgstr ""
+
+#: src/widgets/configuration.md:78
+msgid ""
+"The `provider` function receives the current config values as its argument. "
+"The config object keys match the field names you defined:"
+msgstr ""
+
+#: src/widgets/configuration.md:80
+msgid ""
+"```text\n"
+"provider: async (config: { sortBy: string; dateRange: string }) => {\n"
+"  // config.sortBy === \"clicks\" | \"impressions\" | \"ctr\" | \"position\"\n"
+"  // config.dateRange === \"7d\" | \"28d\" | \"90d\"\n"
+"  const url = `https://api.example.com/data?sort=${config.sortBy}`;\n"
+"  const res = await fetch(url);\n"
+"  const data = await res.json();\n"
+"  return { entries: [data] };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:91
+msgid ""
+"When the user changes a config value, the system calls your provider again "
+"with the updated config."
+msgstr ""
+
+#: src/widgets/configuration.md:93
+msgid "Boolean Config Example"
+msgstr ""
+
+#: src/widgets/configuration.md:95
+msgid ""
+"```text\n"
+"config: {\n"
+"  showDetails: {\n"
+"    type: \"bool\",\n"
+"    default: true,\n"
+"    title: \"Show Details\",\n"
+"  },\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:105
+msgid "Platform Mapping"
+msgstr ""
+
+#: src/widgets/configuration.md:107
+msgid "iOS / watchOS (AppIntent)"
+msgstr ""
+
+#: src/widgets/configuration.md:109
+msgid ""
+"Perry generates a Swift `WidgetConfigurationIntent` struct with `@Parameter`"
+" properties and `AppEnum` types for each enum field. The widget uses "
+"`AppIntentConfiguration` instead of `StaticConfiguration`."
+msgstr ""
+
+#: src/widgets/configuration.md:111
+msgid "Generated output (auto-generated, not hand-written):"
+msgstr ""
+
+#: src/widgets/configuration.md:112
+msgid ""
+"`{Name}Intent.swift` -- contains the AppEnum cases and the intent struct"
+msgstr ""
+
+#: src/widgets/configuration.md:113
+msgid ""
+"The provider conforms to `AppIntentTimelineProvider` instead of "
+"`TimelineProvider`"
+msgstr ""
+
+#: src/widgets/configuration.md:114
+msgid ""
+"Config values are serialized to JSON and passed to the native provider "
+"function"
+msgstr ""
+
+#: src/widgets/configuration.md:116
+msgid ""
+"Users configure the widget by long-pressing and selecting \"Edit Widget\", "
+"which presents the system-generated AppIntent UI."
+msgstr ""
+
+#: src/widgets/configuration.md:118
+msgid "Android / Wear OS (Configuration Activity)"
+msgstr ""
+
+#: src/widgets/configuration.md:120
+msgid ""
+"Perry generates a `{Name}ConfigActivity.kt` with Spinner controls for enum "
+"fields and Switch controls for boolean fields. Values are persisted in "
+"SharedPreferences keyed by widget ID."
+msgstr ""
+
+#: src/widgets/configuration.md:122
+msgid "Generated output:"
+msgstr ""
+
+#: src/widgets/configuration.md:123
+msgid ""
+"`{Name}ConfigActivity.kt` -- Activity with UI controls and a Save button"
+msgstr ""
+
+#: src/widgets/configuration.md:124
+msgid ""
+"`widget_info_{name}.xml` -- includes `android:configure` pointing to the "
+"config activity"
+msgstr ""
+
+#: src/widgets/configuration.md:125
+msgid ""
+"AndroidManifest snippet includes an `<activity>` entry with "
+"`APPWIDGET_CONFIGURE` intent filter"
+msgstr ""
+
+#: src/widgets/configuration.md:127
+msgid ""
+"The config activity launches automatically when the user first adds the "
+"widget."
+msgstr ""
+
+#: src/widgets/configuration.md:129
+msgid "Build Commands"
+msgstr ""
+
+#: src/widgets/configuration.md:132
+msgid "# iOS\n"
+msgstr ""
+
+#: src/widgets/configuration.md:134
+msgid "# Android\n"
+msgstr ""
+
+#: src/widgets/configuration.md:141
+msgid ""
+"[Data Fetching](data-fetching.md) -- Provider function and shared storage"
+msgstr ""
+
+#: src/widgets/configuration.md:142
+msgid "[Components](components.md) -- Available widget components"
+msgstr ""
+
+#: src/widgets/configuration.md:143
+msgid ""
+"[Cross-Platform Reference](platforms.md) -- Feature matrix and build targets"
+msgstr ""
+
+#: src/widgets/data-fetching.md:1
+msgid "Provider Function and Data Fetching"
+msgstr ""
+
+#: src/widgets/data-fetching.md:3
+msgid ""
+"The `provider` function is the heart of a dynamic widget. It fetches data, "
+"transforms it, and returns timeline entries that the system renders on "
+"schedule."
+msgstr ""
+
+#: src/widgets/data-fetching.md:5
+msgid ""
+"**Status:** the basic `WeatherWidget` provider below compile-links cleanly "
+"on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `provider`/`reloadPolicy`/`entryFields` shapes are verified against "
+"the codegen. The shorter fragments lower on the page (a bare "
+"`reloadPolicy:`, a `provider:` body without surrounding `Widget({...})`, "
+"etc.) are rendered as plain text. The `sharedStorage()` and "
+"`preferencesSet()` examples are also rendered as plain text — those symbols "
+"are provided by the platform-specific glue (`AppGroupBridge.swift`, "
+"`Bridge.kt`) for `--target ios-widget`/`android-widget`/`watchos-widget`/ "
+"`wearos-tile` and don't link on the host LLVM target. The cross-compile "
+"targets themselves still aren't driven by the doc-tests harness — each needs"
+" `--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194))."
+msgstr ""
+
+#: src/widgets/data-fetching.md:20
+msgid "Provider Lifecycle"
+msgstr ""
+
+#: src/widgets/data-fetching.md:22
+msgid ""
+"The system calls your provider when the widget is first added, when a "
+"snapshot is needed, and when the reload policy expires."
+msgstr ""
+
+#: src/widgets/data-fetching.md:23
+msgid ""
+"Your provider runs as native LLVM-compiled code linked into the widget "
+"extension."
+msgstr ""
+
+#: src/widgets/data-fetching.md:24
+msgid ""
+"The provider returns one or more timeline entries. The system renders each "
+"entry at its scheduled time."
+msgstr ""
+
+#: src/widgets/data-fetching.md:25
+msgid ""
+"After the last entry, the reload policy determines when the provider runs "
+"again."
+msgstr ""
+
+#: src/widgets/data-fetching.md:27
+msgid "Basic Provider"
+msgstr ""
+
+#: src/widgets/data-fetching.md:29
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"WeatherProviderWidget\",\n"
+"    displayName: \"Weather\",\n"
+"    description: \"Current conditions\",\n"
+"    supportedFamilies: [\"systemSmall\"],\n"
+"\n"
+"    entryFields: {\n"
+"        temperature: \"number\",\n"
+"        condition: \"string\",\n"
+"    },\n"
+"\n"
+"    provider: async () => {\n"
+"        const res = await fetch(\"https://api.weather.example.com/current\")\n"
+"        const data = await res.json()\n"
+"        return {\n"
+"            entries: [\n"
+"                { temperature: data.temp, condition: data.description },\n"
+"            ],\n"
+"            reloadPolicy: { after: { minutes: 15 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`${entry.temperature}°`, { font: \"title\" }),\n"
+"            Text(entry.condition, { font: \"caption\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:60
+msgid "Authenticated Requests with Shared Storage"
+msgstr ""
+
+#: src/widgets/data-fetching.md:62
+msgid ""
+"Widgets run in a separate process and cannot access your app's memory. Use "
+"`sharedStorage()` to read values that your app has written to a shared "
+"container."
+msgstr ""
+
+#: src/widgets/data-fetching.md:64
+msgid "iOS / watchOS: App Groups"
+msgstr ""
+
+#: src/widgets/data-fetching.md:66
+msgid ""
+"On Apple platforms, shared storage maps to `UserDefaults(suiteName:)` backed"
+" by an App Group container. Set the `appGroup` field in your widget "
+"declaration:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:68
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"DashboardWidget\",\n"
+"  displayName: \"Dashboard\",\n"
+"  description: \"Account summary\",\n"
+"  appGroup: \"group.com.example.shared\",\n"
+"\n"
+"  entryFields: {\n"
+"    revenue: \"number\",\n"
+"    users: \"number\",\n"
+"  },\n"
+"\n"
+"  provider: async () => {\n"
+"    const token = sharedStorage(\"auth_token\");\n"
+"    const res = await fetch(\"https://api.example.com/dashboard\", {\n"
+"      headers: { Authorization: `Bearer ${token}` },\n"
+"    });\n"
+"    const data = await res.json();\n"
+"    return {\n"
+"      entries: [{ revenue: data.revenue, users: data.activeUsers }],\n"
+"      reloadPolicy: { after: { minutes: 30 } },\n"
+"    };\n"
+"  },\n"
+"\n"
+"  render: (entry) =>\n"
+"    VStack([\n"
+"      Text(`$${entry.revenue}`, { font: \"title\" }),\n"
+"      Text(`${entry.users} active users`, { font: \"caption\" }),\n"
+"    ]),\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:100
+msgid "Your main app writes the token to the shared container:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:102
+msgid ""
+"```text\n"
+"import { preferencesSet } from \"perry/system\";\n"
+"// In your app's login flow:\n"
+"preferencesSet(\"auth_token\", token);\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:108
+msgid ""
+"**Setup requirement (iOS):** Add an App Group capability in Xcode to both "
+"the main app target and the widget extension target. The identifier must "
+"match the `appGroup` value."
+msgstr ""
+
+#: src/widgets/data-fetching.md:110
+msgid "Android / Wear OS: SharedPreferences"
+msgstr ""
+
+#: src/widgets/data-fetching.md:112
+msgid ""
+"On Android, shared storage maps to `SharedPreferences` with the name "
+"`perry_shared`. The generated `Bridge.kt` reads values via "
+"`context.getSharedPreferences(\"perry_shared\", MODE_PRIVATE)`."
+msgstr ""
+
+#: src/widgets/data-fetching.md:114
+msgid "Reload Policies"
+msgstr ""
+
+#: src/widgets/data-fetching.md:116
+msgid ""
+"The `reloadPolicy` field controls when the system next calls your provider:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:127
+msgid "`{ after: { minutes: N } }`"
+msgstr ""
+
+#: src/widgets/data-fetching.md:127
+msgid ""
+"Re-fetch after N minutes. Compiles to "
+"`.after(Date().addingTimeInterval(N*60))` on iOS and "
+"`setFreshnessIntervalMillis(N*60000)` on Wear OS."
+msgstr ""
+
+#: src/widgets/data-fetching.md:128
+msgid "_(omitted)_"
+msgstr ""
+
+#: src/widgets/data-fetching.md:128
+msgid "Defaults to 30 minutes on iOS, 30 minutes on Android/Wear OS."
+msgstr ""
+
+#: src/widgets/data-fetching.md:130
+msgid ""
+"**Budget limits:** iOS restricts widget refreshes. Typical budget is 40--70 "
+"refreshes per day. watchOS is stricter (see [watchOS "
+"Complications](watchos.md)). Request only what you need."
+msgstr ""
+
+#: src/widgets/data-fetching.md:132
+msgid "JSON Response Handling"
+msgstr ""
+
+#: src/widgets/data-fetching.md:134
+msgid ""
+"The provider function receives the parsed JSON directly. Entry field types "
+"must match your `entryFields` declaration:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:136
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  items: { type: \"array\", items: { type: \"object\", fields: { name: \"string\", count: \"number\" } } },\n"
+"  total: \"number\",\n"
+"},\n"
+"\n"
+"provider: async () => {\n"
+"  const res = await fetch(\"https://api.example.com/items\");\n"
+"  const data = await res.json();\n"
+"  return {\n"
+"    entries: [{\n"
+"      items: data.results.map((r: any) => ({ name: r.name, count: r.count })),\n"
+"      total: data.total,\n"
+"    }],\n"
+"  };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:156
+msgid ""
+"If the fetch fails or JSON parsing throws, the widget extension falls back "
+"to the placeholder data:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:158
+msgid ""
+"```text\n"
+"Widget({\n"
+"  // ...\n"
+"  placeholder: { temperature: 0, condition: \"Loading...\" },\n"
+"\n"
+"  provider: async () => {\n"
+"    const res = await fetch(\"https://api.example.com/weather\");\n"
+"    if (!res.ok) {\n"
+"      // Return stale/fallback data with a short retry interval\n"
+"      return {\n"
+"        entries: [{ temperature: 0, condition: \"Unavailable\" }],\n"
+"        reloadPolicy: { after: { minutes: 5 } },\n"
+"      };\n"
+"    }\n"
+"    const data = await res.json();\n"
+"    return {\n"
+"      entries: [{ temperature: data.temp, condition: data.desc }],\n"
+"      reloadPolicy: { after: { minutes: 15 } },\n"
+"    };\n"
+"  },\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:181
+msgid ""
+"The `placeholder` field provides data shown in the widget gallery and during"
+" loading. If the provider throws an unhandled exception, the generated "
+"Swift/Kotlin code catches it and renders the placeholder instead."
+msgstr ""
+
+#: src/widgets/data-fetching.md:183
+msgid "Multiple Timeline Entries"
+msgstr ""
+
+#: src/widgets/data-fetching.md:185
+msgid ""
+"Return multiple entries to schedule future content without re-fetching:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:187
+msgid ""
+"```text\n"
+"provider: async () => {\n"
+"  const res = await fetch(\"https://api.example.com/hourly\");\n"
+"  const hours = await res.json();\n"
+"  return {\n"
+"    entries: hours.map((h: any) => ({\n"
+"      temperature: h.temp,\n"
+"      condition: h.condition,\n"
+"    })),\n"
+"    reloadPolicy: { after: { minutes: 60 } },\n"
+"  };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:201
+msgid ""
+"Each entry is rendered at the corresponding date in the timeline. The system"
+" transitions between entries automatically."
+msgstr ""
+
+#: src/widgets/data-fetching.md:205
+msgid "[Configuration](configuration.md) -- User-configurable parameters"
+msgstr ""
+
+#: src/widgets/data-fetching.md:206
+msgid ""
+"[Cross-Platform Reference](platforms.md) -- Build targets and platform "
+"differences"
+msgstr ""
+
+#: src/widgets/platforms.md:3
+msgid ""
+"Perry widgets compile from a single TypeScript source to four platforms. The"
+" same `Widget({...})` declaration produces native code for each target."
+msgstr ""
+
+#: src/widgets/platforms.md:5
+msgid ""
+"**Status:** this page has no TypeScript fences (only target-flag tables and "
+"shell build commands), so the doc-tests harness has nothing to run here. The"
+" `--target` flags listed below are all wired in "
+"`crates/perry/src/commands/compile.rs`, but the harness still can't exercise"
+" them end-to-end — each requires `--app-bundle-id` and a platform SDK "
+"(Xcode, Android NDK)."
+msgstr ""
+
+#: src/widgets/platforms.md:7
+msgid "Target Flags"
+msgstr ""
+
+#: src/widgets/platforms.md:11
+msgid "`--target ios-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:11
+msgid "SwiftUI `.swift` + Info.plist"
+msgstr ""
+
+#: src/widgets/platforms.md:12 src/plugins/native-extensions.md:274
+#: src/testing/geisterhand.md:341 src/cli/flags.md:23
+msgid "iOS Simulator"
+msgstr ""
+
+#: src/widgets/platforms.md:12
+msgid "`--target ios-widget-simulator`"
+msgstr ""
+
+#: src/widgets/platforms.md:12 src/widgets/platforms.md:15
+msgid "Same, simulator SDK"
+msgstr ""
+
+#: src/widgets/platforms.md:13
+msgid "`--target android-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:13
+msgid "Kotlin/Glance `.kt` + widget_info XML"
+msgstr ""
+
+#: src/widgets/platforms.md:14
+msgid "`--target watchos-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:14
+msgid "SwiftUI `.swift` (accessory families)"
+msgstr ""
+
+#: src/widgets/platforms.md:15
+msgid "watchOS Simulator"
+msgstr ""
+
+#: src/widgets/platforms.md:15
+msgid "`--target watchos-widget-simulator`"
+msgstr ""
+
+#: src/widgets/platforms.md:16 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:55 src/widgets/platforms.md:87
+msgid "Wear OS"
+msgstr ""
+
+#: src/widgets/platforms.md:16
+msgid "`--target wearos-tile`"
+msgstr ""
+
+#: src/widgets/platforms.md:16
+msgid "Kotlin Tiles `.kt` + manifest"
+msgstr ""
+
+#: src/widgets/platforms.md:18
+msgid "Feature Matrix"
+msgstr ""
+
+#: src/widgets/platforms.md:23
+msgid "VStack/HStack/ZStack"
+msgstr ""
+
+#: src/widgets/platforms.md:23
+msgid "Column/Row/Box"
+msgstr ""
+
+#: src/widgets/platforms.md:24
+msgid "Image (SF Symbols)"
+msgstr ""
+
+#: src/widgets/platforms.md:24
+msgid "R.drawable"
+msgstr ""
+
+#: src/widgets/platforms.md:26
+msgid "Spacer+bg"
+msgstr ""
+
+#: src/widgets/platforms.md:27
+msgid "forEach"
+msgstr ""
+
+#: src/widgets/platforms.md:28
+msgid "Row compound"
+msgstr ""
+
+#: src/widgets/platforms.md:28 src/widgets/platforms.md:29
+#: src/widgets/wearos.md:30
+msgid "Text fallback"
+msgstr ""
+
+#: src/widgets/platforms.md:29 src/widgets/platforms.md:35
+msgid "N/A"
+msgstr ""
+
+#: src/widgets/platforms.md:29
+msgid "CircularProgressIndicator"
+msgstr ""
+
+#: src/widgets/platforms.md:30
+msgid "Conditional"
+msgstr ""
+
+#: src/widgets/platforms.md:30
+msgid "if"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "FamilySwitch"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "LocalSize"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "requestedSize"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Config (AppIntent)"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Config Activity"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Yes (10+)"
+msgstr ""
+
+#: src/widgets/platforms.md:32 src/widgets/platforms.md:34
+msgid "SharedPrefs"
+msgstr ""
+
+#: src/widgets/platforms.md:33
+msgid "Native provider"
+msgstr ""
+
+#: src/widgets/platforms.md:33
+msgid "JNI"
+msgstr ""
+
+#: src/widgets/platforms.md:34
+msgid "sharedStorage"
+msgstr ""
+
+#: src/widgets/platforms.md:34
+msgid "UserDefaults"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "Deep linking (url)"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "widgetURL"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "clickable Intent"
+msgstr ""
+
+#: src/widgets/platforms.md:37
+msgid "Platform-Specific Notes"
+msgstr ""
+
+#: src/widgets/platforms.md:40
+msgid "Minimum deployment: iOS 17.0"
+msgstr ""
+
+#: src/widgets/platforms.md:41
+msgid "AppIntentConfiguration requires `import AppIntents`"
+msgstr ""
+
+#: src/widgets/platforms.md:42
+msgid "Widget extension memory limit: ~30MB"
+msgstr ""
+
+#: src/widgets/platforms.md:45
+msgid "Requires Glance dependency: `androidx.glance:glance-appwidget:1.1.0`"
+msgstr ""
+
+#: src/widgets/platforms.md:46
+msgid ""
+"Widget sizes mapped from iOS families: systemSmall=2x2, systemMedium=4x2, "
+"systemLarge=4x4"
+msgstr ""
+
+#: src/widgets/platforms.md:47
+msgid "`minimumScaleFactor` not supported in Glance (skipped with warning)"
+msgstr ""
+
+#: src/widgets/platforms.md:50
+msgid "Minimum deployment: watchOS 9.0"
+msgstr ""
+
+#: src/widgets/platforms.md:51
+msgid "Accessory families only (circular, rectangular, inline)"
+msgstr ""
+
+#: src/widgets/platforms.md:52
+msgid "Tighter memory (~15-20MB) and refresh budgets (hourly)"
+msgstr ""
+
+#: src/widgets/platforms.md:53
+msgid "AppIntent requires watchOS 10+; older versions get StaticConfiguration"
+msgstr ""
+
+#: src/widgets/platforms.md:56
+msgid "Same native compilation as Android phone (Wear OS = Android)"
+msgstr ""
+
+#: src/widgets/platforms.md:57
+msgid "Requires Horologist + Tiles Material 3 dependencies"
+msgstr ""
+
+#: src/widgets/platforms.md:58
+msgid "Tiles are full-screen cards in the carousel"
+msgstr ""
+
+#: src/widgets/platforms.md:59
+msgid "`Gauge` maps to `CircularProgressIndicator`"
+msgstr ""
+
+#: src/widgets/platforms.md:61
+msgid "Build Instructions"
+msgstr ""
+
+#: src/widgets/platforms.md:73
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
+msgstr ""
+
+#: src/widgets/platforms.md:75
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
+msgstr ""
+
+#: src/widgets/platforms.md:89
+msgid "# Copy .kt files to Wear OS module\n"
+msgstr ""
+
+#: src/widgets/platforms.md:91
+msgid "# Merge AndroidManifest_snippet.xml\n"
+msgstr ""
+
+#: src/widgets/watchos.md:3
+msgid ""
+"Perry widgets can compile to watchOS WidgetKit complications using `--target"
+" watchos-widget`. The same `Widget({...})` source produces both iOS and "
+"watchOS widgets — the supported families determine the rendering."
+msgstr ""
+
+#: src/widgets/watchos.md:5
+msgid ""
+"**Status:** the snippet on this page compile-links cleanly on the host LLVM "
+"target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `Widget({...})` shape is verified against the codegen. The actual "
+"`--target watchos-widget` / `--target watchos-widget-simulator` cross-"
+"compile is wired in `crates/perry/src/commands/compile.rs` (emits through "
+"the WidgetKit Swift emitter) but the doc-tests harness can't drive it yet — "
+"each cross-target requires `--app-bundle-id` not yet surfaced through the "
+"harness ([\\#194](https://github.com/PerryTS/perry/issues/194)) plus a "
+"watchOS SDK from Xcode. Build with the `perry` CLI to validate end-to-end."
+msgstr ""
+
+#: src/widgets/watchos.md:15
+msgid "Accessory Families"
+msgstr ""
+
+#: src/widgets/watchos.md:17
+msgid ""
+"watchOS complications use accessory families instead of system families:"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Family"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Size"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Best For"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "`accessoryCircular`"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "~76x76pt"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "Single icon, number, or Gauge"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "`accessoryRectangular`"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "~160x76pt"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "2-3 lines of text"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "`accessoryInline`"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "Single line"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "Short text only"
+msgstr ""
+
+#: src/widgets/watchos.md:25
+msgid "Gauge Component"
+msgstr ""
+
+#: src/widgets/watchos.md:27
+msgid "The `Gauge` component is designed for watchOS circular complications:"
+msgstr ""
+
+#: src/widgets/watchos.md:29
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"QuickStats\",\n"
+"    displayName: \"Quick Stats\",\n"
+"    supportedFamilies: [\"accessoryCircular\", \"accessoryRectangular\"],\n"
+"\n"
+"    render(entry: { progress: number; label: string }, family) {\n"
+"        if (family === \"accessoryCircular\") {\n"
+"            return Gauge(entry.progress, 1.0)\n"
+"        }\n"
+"        return VStack([\n"
+"            Text(entry.label),\n"
+"            Gauge(entry.progress, 1.0),\n"
+"        ])\n"
+"    },\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/watchos.md:47
+msgid "Gauge Styles"
+msgstr ""
+
+#: src/widgets/watchos.md:49
+msgid ""
+"**`circular`** — Ring gauge, maps to "
+"`.gaugeStyle(.accessoryCircularCapacity)` in SwiftUI"
+msgstr ""
+
+#: src/widgets/watchos.md:50
+msgid ""
+"**`linear`** / **`linearCapacity`** — Horizontal bar, maps to "
+"`.gaugeStyle(.linearCapacity)`"
+msgstr ""
+
+#: src/widgets/watchos.md:52
+msgid "Refresh Budgets"
+msgstr ""
+
+#: src/widgets/watchos.md:54
+msgid "watchOS has stricter refresh budgets than iOS:"
+msgstr ""
+
+#: src/widgets/watchos.md:55
+msgid ""
+"Recommended: refresh every 60 minutes (`reloadPolicy: { after: { minutes: 60"
+" } }`)"
+msgstr ""
+
+#: src/widgets/watchos.md:56
+msgid "Maximum: system may throttle more aggressively than iOS"
+msgstr ""
+
+#: src/widgets/watchos.md:57
+msgid "Background refresh uses `BackgroundTask` framework"
+msgstr ""
+
+#: src/widgets/watchos.md:62
+msgid "# For Apple Watch device\n"
+msgstr ""
+
+#: src/widgets/watchos.md:64
+msgid "# For Apple Watch Simulator\n"
+msgstr ""
+
+#: src/widgets/watchos.md:69
+msgid "Build:"
+msgstr ""
+
+#: src/widgets/watchos.md:79
+msgid ""
+"watchOS 10+ supports AppIntent for widget configuration (same as iOS 17+)"
+msgstr ""
+
+#: src/widgets/watchos.md:80
+msgid ""
+"Older watchOS versions automatically get `StaticConfiguration` fallback"
+msgstr ""
+
+#: src/widgets/watchos.md:81
+msgid "`config` params work identically to iOS"
+msgstr ""
+
+#: src/widgets/watchos.md:83
+msgid "Memory Considerations"
+msgstr ""
+
+#: src/widgets/watchos.md:85
+msgid ""
+"watchOS widget extensions have tighter memory limits (~15-20MB) compared to "
+"iOS (~30MB). The provider-only compilation approach is critical — only the "
+"data-fetching code runs natively, keeping memory usage minimal."
+msgstr ""
+
+#: src/widgets/wearos.md:3
+msgid ""
+"Perry widgets can compile to Wear OS Tiles using `--target wearos-tile`. "
+"Tiles are glanceable surfaces in the Wear OS tile carousel and watch face "
+"complications."
+msgstr ""
+
+#: src/widgets/wearos.md:5
+msgid ""
+"**Status:** the snippet on this page compile-links cleanly on the host LLVM "
+"target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `Widget({...})` shape is verified against the codegen. `--target "
+"wearos-tile` itself is wired through `crates/perry-codegen-wear-tiles` but "
+"the doc-tests harness can't drive that cross-target yet — `--app-bundle-id` "
+"plumbing is still pending "
+"([\\#194](https://github.com/PerryTS/perry/issues/194)) and you'll need an "
+"Android NDK + Wear OS Gradle deps. Build with the `perry` CLI to validate "
+"end-to-end."
+msgstr ""
+
+#: src/widgets/wearos.md:14
+msgid "Concepts"
+msgstr ""
+
+#: src/widgets/wearos.md:16
+msgid "**Tiles** are full-screen cards users swipe through on their watch"
+msgstr ""
+
+#: src/widgets/wearos.md:17
+msgid "**Complications** are small data displays on the watch face"
+msgstr ""
+
+#: src/widgets/wearos.md:18
+msgid ""
+"Perry compiles `Widget({...})` to a `SuspendingTileService` with layout "
+"builders"
+msgstr ""
+
+#: src/widgets/wearos.md:20
+msgid "Supported Components"
+msgstr ""
+
+#: src/widgets/wearos.md:22
+msgid "Widget API"
+msgstr ""
+
+#: src/widgets/wearos.md:22
+msgid "Wear OS Mapping"
+msgstr ""
+
+#: src/widgets/wearos.md:24
+msgid "`LayoutElementBuilders.Text`"
+msgstr ""
+
+#: src/widgets/wearos.md:25
+msgid "`LayoutElementBuilders.Column`"
+msgstr ""
+
+#: src/widgets/wearos.md:26
+msgid "`LayoutElementBuilders.Row`"
+msgstr ""
+
+#: src/widgets/wearos.md:27
+msgid "`LayoutElementBuilders.Spacer`"
+msgstr ""
+
+#: src/widgets/wearos.md:28
+msgid "Spacer with 1dp height"
+msgstr ""
+
+#: src/widgets/wearos.md:29
+msgid "`Gauge(circular)`"
+msgstr ""
+
+#: src/widgets/wearos.md:29
+msgid "`LayoutElementBuilders.Arc` + `ArcLine`"
+msgstr ""
+
+#: src/widgets/wearos.md:30
+msgid "`Gauge(linear)`"
+msgstr ""
+
+#: src/widgets/wearos.md:31
+msgid "`Image`"
+msgstr ""
+
+#: src/widgets/wearos.md:31
+msgid "Resource-based (provide drawable)"
+msgstr ""
+
+#: src/widgets/wearos.md:33
+msgid "Example"
+msgstr ""
+
+#: src/widgets/wearos.md:35
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StepsTile\",\n"
+"    displayName: \"Steps\",\n"
+"    description: \"Daily step count\",\n"
+"    supportedFamilies: [\"accessoryCircular\"],\n"
+"\n"
+"    provider: async () => {\n"
+"        return {\n"
+"            entries: [{ steps: 7500, goal: 10000 }],\n"
+"            reloadPolicy: { after: { minutes: 60 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render(entry: { steps: number; goal: number }) {\n"
+"        return VStack([\n"
+"            Gauge(entry.steps / entry.goal, 1.0),\n"
+"            Text(`${entry.steps}`),\n"
+"        ])\n"
+"    },\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/wearos.md:65
+msgid "`{Name}TileService.kt` — `SuspendingTileService` with tile layout"
+msgstr ""
+
+#: src/widgets/wearos.md:66
+msgid ""
+"`{Name}TileBridge.kt` — JNI bridge for native provider (if provider exists)"
+msgstr ""
+
+#: src/widgets/wearos.md:67
+msgid "`AndroidManifest_snippet.xml` — Service declaration"
+msgstr ""
+
+#: src/widgets/wearos.md:69
+msgid "Gradle Integration"
+msgstr ""
+
+#: src/widgets/wearos.md:71
+msgid "Add to your Wear OS module's `build.gradle`:"
+msgstr ""
+
+#: src/widgets/wearos.md:75
+msgid "\"com.google.android.horologist:horologist-tiles:0.6.5\""
+msgstr ""
+
+#: src/widgets/wearos.md:76
+msgid "\"androidx.wear.tiles:tiles-material:1.4.0\""
+msgstr ""
+
+#: src/widgets/wearos.md:77
+msgid "\"androidx.wear.tiles:tiles:1.4.0\""
+msgstr ""
+
+#: src/widgets/wearos.md:81
+msgid "Merge the manifest snippet into your `AndroidManifest.xml`:"
+msgstr ""
+
+#: src/widgets/wearos.md:85
+msgid "\".StepsTileService\""
+msgstr ""
+
+#: src/widgets/wearos.md:86
+msgid "\"true\""
+msgstr ""
+
+#: src/widgets/wearos.md:87
+msgid "\"com.google.android.wearable.permission.BIND_TILE_PROVIDER\""
+msgstr ""
+
+#: src/widgets/wearos.md:89
+msgid "\"androidx.wear.tiles.action.BIND_TILE_PROVIDER\""
+msgstr ""
+
+#: src/widgets/wearos.md:94
+msgid "Native Provider"
+msgstr ""
+
+#: src/widgets/wearos.md:96
+msgid "Same as Android phone widgets — Wear OS is Android:"
+msgstr ""
+
+#: src/widgets/wearos.md:97
+msgid "Target triple: `aarch64-linux-android`"
+msgstr ""
+
+#: src/widgets/wearos.md:98
+msgid "`libwidget_provider.so` loaded via `System.loadLibrary`"
+msgstr ""
+
+#: src/widgets/wearos.md:99
+msgid "JNI bridge pattern identical to phone Glance widgets"
+msgstr ""
+
+#: src/widgets/wearos.md:100
+msgid "`sharedStorage()` uses `SharedPreferences`"
+msgstr ""
+
+#: src/widgets/wearos.md:102
+msgid "Refresh"
+msgstr ""
+
+#: src/widgets/wearos.md:104
+msgid ""
+"Wear Tiles use `freshnessIntervalMillis` on the `Tile` builder. Set via "
+"`reloadPolicy: { after: { minutes: N } }` in the provider return value. "
+"Default: 60 minutes."
+msgstr ""
+
+#: src/plugins/overview.md:1
+msgid "Plugin System Overview"
+msgstr ""
+
+#: src/plugins/overview.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). Receiver-less calls (`loadPlugin`, `listPlugins`, `emitHook`, "
+"`invokeTool`, ...) and `PluginApi` instance methods (`api.registerHook`, "
+"`api.registerTool`, ...) dispatch through `crates/perry-"
+"codegen/src/lower_call.rs::PERRY_PLUGIN_TABLE` and "
+"`PERRY_PLUGIN_INSTANCE_TABLE`. TypeScript surface lives in "
+"`types/perry/plugin/index.d.ts`. Host-side snippets below are compile-link "
+"verified by the doc-tests harness against "
+"[`docs/examples/plugins/host_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/host_snippets.ts);"
+" plugin-side `activate(api)` snippets against "
+"[`docs/examples/plugins/plugin_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/plugin_snippets.ts)."
+msgstr ""
+
+#: src/plugins/overview.md:5
+msgid ""
+"Perry supports native plugins as shared libraries (`.dylib`/`.so`). Plugins "
+"extend Perry applications with custom hooks, tools, services, and routes."
+msgstr ""
+
+#: src/plugins/overview.md:9
+msgid ""
+"A plugin is a Perry-compiled shared library with `activate(api)` and "
+"`deactivate()` entry points"
+msgstr ""
+
+#: src/plugins/overview.md:10
+msgid "The host application loads plugins with `loadPlugin(path)`"
+msgstr ""
+
+#: src/plugins/overview.md:11
+msgid "Plugins register hooks, tools, and services via the API handle"
+msgstr ""
+
+#: src/plugins/overview.md:12
+msgid "The host dispatches events to plugins via `emitHook(name, data)`"
+msgstr ""
+
+#: src/plugins/overview.md:14
+msgid ""
+"```\n"
+"Host Application\n"
+"    ↓ loadPlugin(\"./my-plugin.dylib\")\n"
+"    ↓ calls plugin_activate(api_handle)\n"
+"Plugin\n"
+"    ↓ api.registerHook(\"beforeSave\", callback)\n"
+"    ↓ api.registerTool(\"format\", callback)\n"
+"Host\n"
+"    ↓ emitHook(\"beforeSave\", data) → plugin callback runs\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:27
+msgid "Plugin (compiled with `--output-type dylib`)"
+msgstr ""
+
+#: src/plugins/overview.md:29 src/plugins/creating-plugins.md:9
+msgid ""
+"```typescript\n"
+"let count = 0\n"
+"\n"
+"export function activate(api: PluginApi) {\n"
+"    api.setMetadata(\"counter\", \"1.0.0\", \"Counts hook invocations\")\n"
+"\n"
+"    api.registerHook(\"onRequest\", (data) => {\n"
+"        count++\n"
+"        console.log(`Request #${count}`)\n"
+"        return data\n"
+"    })\n"
+"\n"
+"    api.registerTool(\"getCount\", \"returns request count\", () => count)\n"
+"}\n"
+"\n"
+"export function deactivate() {\n"
+"    console.log(`Total requests processed: ${count}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:53
+msgid "Host Application"
+msgstr ""
+
+#: src/plugins/overview.md:55
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"    loadPlugin, unloadPlugin,\n"
+"    emitHook, emitEvent, invokeTool,\n"
+"    setPluginConfig,\n"
+"    discoverPlugins, listPlugins, listHooks, listTools,\n"
+"    pluginCount, initPlugins,\n"
+"} from \"perry/plugin\"\n"
+"\n"
+"const id = loadPlugin(\"./counter-plugin.dylib\")\n"
+"console.log(`load returned: ${id !== 0 ? \"ok\" : \"fail\"}`)\n"
+"\n"
+"const plugins = listPlugins()\n"
+"const hooks = listHooks()\n"
+"const tools = listTools()\n"
+"console.log(`loaded: ${pluginCount()} plugin(s), ${hooks.length} hook(s), ${tools.length} tool(s)`)\n"
+"\n"
+"const result = emitHook(\"beforeSave\", { content: \"hello world\" })\n"
+"\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:81
+msgid "Plugin ABI"
+msgstr ""
+
+#: src/plugins/overview.md:83
+msgid "Plugins must export these symbols:"
+msgstr ""
+
+#: src/plugins/overview.md:84
+msgid ""
+"`perry_plugin_abi_version()` — Returns ABI version (for compatibility "
+"checking)"
+msgstr ""
+
+#: src/plugins/overview.md:85
+msgid "`plugin_activate(api_handle)` — Called when plugin is loaded"
+msgstr ""
+
+#: src/plugins/overview.md:86
+msgid "`plugin_deactivate()` — Called when plugin is unloaded"
+msgstr ""
+
+#: src/plugins/overview.md:88
+msgid ""
+"Perry generates these automatically from your `activate`/`deactivate` "
+"exports."
+msgstr ""
+
+#: src/plugins/overview.md:92
+msgid ""
+"Perry also supports **native extensions** — packages that bundle platform-"
+"specific Rust/Swift/JNI code and compile directly into your binary. These "
+"are used for accessing platform APIs like the App Store review prompt or "
+"StoreKit in-app purchases."
+msgstr ""
+
+#: src/plugins/overview.md:94
+msgid "See [Native Extensions](native-extensions.md) for details."
+msgstr ""
+
+#: src/plugins/overview.md:98
+msgid "[Creating Plugins](creating-plugins.md) — Build a plugin step by step"
+msgstr ""
+
+#: src/plugins/overview.md:99
+msgid "[Hooks & Events](hooks-and-events.md) — Hook modes, event bus, tools"
+msgstr ""
+
+#: src/plugins/overview.md:100
+msgid ""
+"[Native Extensions](native-extensions.md) — Extensions with platform-native "
+"code"
+msgstr ""
+
+#: src/plugins/overview.md:101
+msgid ""
+"[App Store Review](appstore-review.md) — Native review prompt (iOS/Android)"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). See [Plugin System Overview — Status](overview.md) for the full "
+"surface. Snippets below are compile-link verified by the doc-tests harness "
+"against "
+"[`docs/examples/plugins/plugin_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/plugin_snippets.ts)"
+" and "
+"[`docs/examples/plugins/host_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/host_snippets.ts)."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:5
+msgid "Build Perry plugins as shared libraries that extend host applications."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:7
+msgid "Step 1: Write the Plugin"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:29
+msgid "Step 2: Compile as Shared Library"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:35
+msgid ""
+"The `--output-type dylib` flag tells Perry to produce a `.dylib` (macOS) or "
+"`.so` (Linux) instead of an executable."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:38
+msgid ""
+"Generates `perry_plugin_abi_version()` returning the current ABI version"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:39
+msgid ""
+"Generates `plugin_activate(api_handle)` calling your `activate()` function"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:40
+msgid "Generates `plugin_deactivate()` calling your `deactivate()` function"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:41
+msgid "Exports symbols with `-rdynamic` for the host to find"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:43
+msgid "Step 3: Load from Host"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:45
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"    loadPlugin, unloadPlugin,\n"
+"    emitHook, emitEvent, invokeTool,\n"
+"    setPluginConfig,\n"
+"    discoverPlugins, listPlugins, listHooks, listTools,\n"
+"    pluginCount, initPlugins,\n"
+"} from \"perry/plugin\"\n"
+"\n"
+"const id = loadPlugin(\"./counter-plugin.dylib\")\n"
+"console.log(`load returned: ${id !== 0 ? \"ok\" : \"fail\"}`)\n"
+"\n"
+"const found = discoverPlugins(\"./plugins/\")\n"
+"console.log(`discovered ${found.length} plugin(s)`)\n"
+"\n"
+"const result = emitHook(\"beforeSave\", { content: \"hello world\" })\n"
+"\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:69
+msgid "Plugin API Reference"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:71
+msgid "The `api: PluginApi` passed to `activate()` provides:"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:73
+msgid "Metadata"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:79
+msgid "Hooks"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:86
+msgid ""
+"`registerHook` defaults to priority 10 / mode 0 (filter). Use "
+"`registerHookEx` for explicit priority and mode (0=filter, 1=action, "
+"2=waterfall). Lower priority numbers run first."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:90 src/plugins/hooks-and-events.md:94
+msgid "Tools"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:96
+msgid "Tools are invoked by name from the host."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:100
+msgid ""
+"```typescript,no-test\n"
+"const value = api.getConfig(key: string)  // Read host-provided config\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:106
+msgid ""
+"```typescript,no-test\n"
+"api.on(event: string, handler: (data: unknown) => void): void  // Listen for events\n"
+"api.emit(event: string, data: unknown): void                    // Emit to other plugins\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:113
+msgid "[Hooks & Events](hooks-and-events.md) — Hook modes, event bus"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:114 src/plugins/hooks-and-events.md:147
+#: src/plugins/native-extensions.md:301
+msgid "[Overview](overview.md) — Plugin system overview"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). `api.registerHook`, `api.on`, `emitHook`, `emitEvent`, `invokeTool`"
+" all dispatch to `crates/perry-runtime/src/plugin.rs`. Snippets below are "
+"compile-link verified against "
+"[`docs/examples/plugins/{plugin,host}_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/)."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:5
+msgid "Perry plugins communicate through hooks, events, and tools."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:7
+msgid "Hook Modes"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:9
+msgid "Hooks support three execution modes:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:11
+msgid "Filter Mode (default)"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:13
+msgid ""
+"Each plugin receives data and returns (possibly modified) data. The output "
+"of one plugin becomes the input of the next:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:15
+msgid ""
+"```typescript\n"
+"function registerFilter(api: PluginApi) {\n"
+"    api.registerHook(\"transform\", (data: any) => {\n"
+"        data.content = data.content.toUpperCase()\n"
+"        return data // Returned data goes to next plugin\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:24
+msgid "Action Mode"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:26
+msgid ""
+"Plugins receive data but return value is ignored. Used for side effects. "
+"Pass `mode = 1` to `registerHookEx`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:29
+msgid ""
+"```typescript\n"
+"function registerAction(api: PluginApi) {\n"
+"    api.registerHook(\"onSave\", (data: any) => {\n"
+"        console.log(`Saved: ${data.path}`)\n"
+"        return data\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:38
+msgid "Waterfall Mode"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:40
+msgid ""
+"Like filter mode, but specifically for accumulating/building up a result "
+"through the chain. Pass `mode = 2` to `registerHookEx`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:43
+msgid ""
+"```typescript\n"
+"function registerWaterfall(api: PluginApi) {\n"
+"    api.registerHook(\"buildMenu\", (items: any) => {\n"
+"        items.push({ label: \"My Plugin Action\", action: () => {} })\n"
+"        return items\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:52
+msgid "Hook Priority"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:54
+msgid ""
+"Lower priority numbers run first. Use `registerHookEx` for explicit priority"
+" and mode:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:57
+msgid ""
+"```typescript\n"
+"function registerPriorities(api: PluginApi, validate: (d: any) => any, transform: (d: any) => any, log: (d: any) => any) {\n"
+"    // Lower priority numbers run first; default 10. Mode 0=filter / 1=action / 2=waterfall.\n"
+"    api.registerHookEx(\"beforeSave\", validate, 10, 0)   // Runs first\n"
+"    api.registerHookEx(\"beforeSave\", transform, 20, 0)  // Runs second\n"
+"    api.registerHookEx(\"beforeSave\", log, 100, 1)        // Runs last (action mode)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:66
+msgid "Default priority is 10 (the value `registerHook` passes implicitly)."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:68
+msgid "Event Bus"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:70
+msgid "Plugins can communicate with each other through events:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:72
+msgid "Emitting Events"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:74
+msgid ""
+"```typescript\n"
+"function emitFromPlugin(api: PluginApi) {\n"
+"    api.emit(\"dataUpdated\", { source: \"my-plugin\", records: 42 })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:80
+msgid ""
+"```typescript\n"
+"emitEvent(\"dataUpdated\", { source: \"host\", records: 100 })\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:84
+msgid "Listening for Events"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:86
+msgid ""
+"```typescript\n"
+"function listenForEvent(api: PluginApi) {\n"
+"    api.on(\"dataUpdated\", (data: any) => {\n"
+"        console.log(`${data.source} updated ${data.records} records`)\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:96
+msgid ""
+"Plugins register callable tools (note the 3-arg shape: `name`, "
+"`description`, `handler`):"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:99
+msgid ""
+"```typescript\n"
+"function registerFormatter(api: PluginApi) {\n"
+"    api.registerTool(\"formatCode\", \"format source code\", (args: any) => {\n"
+"        return `// formatted: ${args.code}`\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:107
+msgid ""
+"```typescript\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:117
+msgid "Hosts can pass configuration to plugins via `setPluginConfig`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:119
+msgid ""
+"```typescript\n"
+"initPlugins()\n"
+"setPluginConfig(\"api_key\", \"test-key\")\n"
+"setPluginConfig(\"max_retries\", \"3\")\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:125
+msgid ""
+"```typescript\n"
+"function readConfig(api: PluginApi) {\n"
+"    const theme = api.getConfig(\"theme\")     // \"dark\"\n"
+"    const retries = api.getConfig(\"maxRetries\") // \"3\"\n"
+"    return { theme, retries }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:133
+msgid "Introspection"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:135
+msgid "Query loaded plugins and their registrations:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:146
+msgid "[Creating Plugins](creating-plugins.md) — Build a plugin"
+msgstr ""
+
+#: src/plugins/native-extensions.md:3
+msgid ""
+"**Status: partially wired.** The `--bundle-extensions` flag, the "
+"`perry.nativeLibrary` `package.json` manifest, and `declare function` FFI "
+"imports are all wired into the compiler — see "
+"`crates/perry/src/commands/compile.rs` (the `bundle_extensions` argument, "
+"the `parse_native_library_manifest`/`build_external_native_libraries` "
+"helpers) and `crates/perry-codegen/src/codegen.rs` (the "
+"`nativeLibrary.functions` signature parser). The TypeScript snippets below "
+"assume a fully-populated extension directory exists on disk (e.g. `perry-"
+"appstore-review` cloned under `./extensions/`). They are kept as `,no-test` "
+"because the doc-tests harness doesn't have those external extensions checked"
+" in — a real project that does have them will compile cleanly. Drift "
+"protection for the parts that _don't_ depend on external extensions (the FFI"
+" declare-function shape, etc.) lives in "
+"`docs/examples/platforms/wasm_snippets.ts`."
+msgstr ""
+
+#: src/plugins/native-extensions.md:5
+msgid ""
+"Perry supports native extensions — packages that bundle platform-specific "
+"code (Rust, Swift, JNI) alongside a TypeScript API. Unlike [dynamic "
+"plugins](overview.md) loaded at runtime, native extensions are compiled "
+"directly into your binary."
+msgstr ""
+
+#: src/plugins/native-extensions.md:7
+msgid ""
+"Native extensions are how you access platform APIs that aren't part of "
+"Perry's built-in [System APIs](../system/overview.md) or [Standard "
+"Library](../stdlib/overview.md). Examples include [App Store "
+"Review](appstore-review.md) and StoreKit for in-app purchases."
+msgstr ""
+
+#: src/plugins/native-extensions.md:9
+msgid "Using a native extension"
+msgstr ""
+
+#: src/plugins/native-extensions.md:11
+msgid "1. Add the extension to your project"
+msgstr ""
+
+#: src/plugins/native-extensions.md:13
+msgid ""
+"Place the extension directory alongside your project, or in a shared "
+"extensions directory:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:30
+msgid "2. Compile with `--bundle-extensions`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:32
+msgid "Pass the extensions directory when building:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:38
+msgid ""
+"Perry discovers every subdirectory with a `package.json`, compiles its "
+"native crates for the target platform, and links them into your binary."
+msgstr ""
+
+#: src/plugins/native-extensions.md:40
+msgid "3. Import and use"
+msgstr ""
+
+#: src/plugins/native-extensions.md:42 src/plugins/appstore-review.md:60
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"\n"
+"await requestReview();\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:48
+msgid ""
+"The import resolves at compile time to the extension's entry point. No "
+"runtime module loading is involved — the function compiles to a direct "
+"native call."
+msgstr ""
+
+#: src/plugins/native-extensions.md:50
+msgid "How native extensions work"
+msgstr ""
+
+#: src/plugins/native-extensions.md:52
+msgid ""
+"A native extension is a directory with a `package.json` that declares a "
+"`perry.nativeLibrary` section. This tells Perry which native functions "
+"exist, their signatures, and which Rust crate to compile for each platform."
+msgstr ""
+
+#: src/plugins/native-extensions.md:54
+msgid "package.json manifest"
+msgstr ""
+
+#: src/plugins/native-extensions.md:58
+msgid "\"perry-appstore-review\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:59
+msgid "\"0.1.0\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:62 src/plugins/appstore-review.md:181
+msgid "\"nativeLibrary\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:63 src/plugins/appstore-review.md:182
+msgid "\"functions\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"sb_appreview_request\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"params\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"returns\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"f64\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:66
+msgid "\"targets\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:68 src/plugins/native-extensions.md:73
+#: src/plugins/native-extensions.md:78
+msgid "\"crate\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:68 src/plugins/native-extensions.md:78
+msgid "\"crate-ios\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:69 src/plugins/native-extensions.md:74
+#: src/plugins/native-extensions.md:79
+msgid "\"lib\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:69 src/plugins/native-extensions.md:74
+#: src/plugins/native-extensions.md:79
+msgid "\"libperry_appreview.a\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:70 src/plugins/native-extensions.md:75
+#: src/plugins/native-extensions.md:80
+msgid "\"frameworks\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:70 src/plugins/native-extensions.md:80
+msgid "\"StoreKit\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:73
+msgid "\"crate-android\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:77
+msgid "\"macos\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:88
+msgid "`functions`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:90
+msgid "Each entry declares a native function the extension exports:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:94 src/cli/perry-toml.md:116
+msgid "`name`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:94
+msgid "Symbol name — must match the `#[no_mangle]` Rust function exactly"
+msgstr ""
+
+#: src/plugins/native-extensions.md:95
+msgid "`params`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:95
+msgid ""
+"Array of LLVM types: `\"i64\"` for pointers/strings, `\"f64\"` for numbers, "
+"`\"i32\"` for integers"
+msgstr ""
+
+#: src/plugins/native-extensions.md:96
+msgid "`returns`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:96
+msgid "Return type — typically `\"f64\"` (NaN-boxed value or promise handle)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:98
+msgid "`targets`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:100
+msgid ""
+"Each target platform maps to a Rust crate that implements the native "
+"functions:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:104
+msgid "`crate`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:104
+msgid "Relative path to the Rust crate directory"
+msgstr ""
+
+#: src/plugins/native-extensions.md:105
+msgid "`lib`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:105
+msgid "Name of the static library produced by `cargo build`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:106
+msgid "`frameworks`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:106
+msgid "System frameworks to link (iOS/macOS only)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:108
+msgid ""
+"Multiple targets can share the same crate (e.g., iOS and macOS often share "
+"an implementation). Platforms without an entry fall back to the stub."
+msgstr ""
+
+#: src/plugins/native-extensions.md:110
+msgid "Extension directory layout"
+msgstr ""
+
+#: src/plugins/native-extensions.md:112
+msgid ""
+"```\n"
+"perry-appstore-review/\n"
+"├── package.json              # Manifest with perry.nativeLibrary\n"
+"├── src/\n"
+"│   └── index.ts              # TypeScript API (what users import)\n"
+"├── crate-ios/                # iOS/macOS native implementation\n"
+"│   ├── Cargo.toml            # [lib] crate-type = [\"staticlib\"]\n"
+"│   ├── build.rs              # Compiles Swift if needed\n"
+"│   ├── src/\n"
+"│   │   └── lib.rs            # Rust FFI: #[no_mangle] pub extern \"C\" fn ...\n"
+"│   └── swift/\n"
+"│       └── bridge.swift      # Swift bridge for Apple APIs (@_cdecl)\n"
+"├── crate-android/            # Android native implementation\n"
+"│   ├── Cargo.toml\n"
+"│   └── src/\n"
+"│       └── lib.rs            # Rust FFI with JNI calls\n"
+"└── crate-stub/               # Fallback for unsupported platforms\n"
+"    ├── Cargo.toml\n"
+"    └── src/\n"
+"        └── lib.rs            # Returns error immediately\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:134
+msgid "TypeScript side"
+msgstr ""
+
+#: src/plugins/native-extensions.md:136
+msgid ""
+"The `src/index.ts` declares native functions and optionally wraps them in a "
+"friendlier API:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:138
+msgid ""
+"```text\n"
+"// Declare the native function (name must match package.json)\n"
+"declare function sb_appreview_request(): number;\n"
+"\n"
+"// Wrap it with a proper TypeScript signature\n"
+"export async function requestReview(): Promise<void> {\n"
+"  await (sb_appreview_request() as any);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:148
+msgid ""
+"`declare function` tells Perry the function is provided by native code. The "
+"raw return type is `number` because all values cross the FFI boundary as "
+"NaN-boxed `f64` values. Promise handles are NaN-boxed pointers that Perry's "
+"runtime knows how to `await`."
+msgstr ""
+
+#: src/plugins/native-extensions.md:150
+msgid "Rust side"
+msgstr ""
+
+#: src/plugins/native-extensions.md:152
+msgid ""
+"Each platform crate is a `staticlib` that implements the declared functions "
+"using `#[no_mangle] pub extern \"C\"`:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:155
+msgid "// Perry runtime FFI\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:156 src/plugins/native-extensions.md:164
+#: src/plugins/native-extensions.md:256
+msgid "\"C\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:167
+msgid "// ... call platform API, resolve promise when done ...\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:173
+msgid "Key runtime functions available to native code:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:175 src/contributing/architecture.md:23
+msgid "Purpose"
+msgstr ""
+
+#: src/plugins/native-extensions.md:177
+msgid "`js_promise_new()`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:177
+msgid "Create a new Perry promise, returns pointer"
+msgstr ""
+
+#: src/plugins/native-extensions.md:178
+msgid "`js_promise_resolve(promise, value)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:178
+msgid "Resolve a promise with a NaN-boxed value"
+msgstr ""
+
+#: src/plugins/native-extensions.md:179
+msgid "`js_nanbox_string(ptr)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:179
+msgid "Convert a C string pointer to a NaN-boxed string"
+msgstr ""
+
+#: src/plugins/native-extensions.md:180
+msgid "`js_nanbox_pointer(ptr)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:180
+msgid "Convert a pointer to a NaN-boxed object reference"
+msgstr ""
+
+#: src/plugins/native-extensions.md:181
+msgid "`js_get_string_pointer_unified(val)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:181
+msgid "Extract string pointer from a NaN-boxed value"
+msgstr ""
+
+#: src/plugins/native-extensions.md:182
+msgid "`js_string_from_bytes(ptr, len)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:182
+msgid "Create a Perry string from bytes"
+msgstr ""
+
+#: src/plugins/native-extensions.md:184
+msgid "Swift bridge (iOS/macOS)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:186
+msgid ""
+"Apple platform APIs are often easiest to call from Swift. The pattern is:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:188
+msgid "Write a Swift file with `@_cdecl(\"function_name\")` exports"
+msgstr ""
+
+#: src/plugins/native-extensions.md:189
+msgid "Compile it to a static library in `build.rs`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:190
+msgid "Call the Swift functions from Rust via `extern \"C\"`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:192
+msgid ""
+"```swift\n"
+"import StoreKit\n"
+"\n"
+"typealias Callback = @convention(c) (UnsafeMutableRawPointer, UnsafePointer<CChar>) -> Void\n"
+"\n"
+"@_cdecl(\"swift_appreview_request\")\n"
+"func swiftRequestReview(_ callback: @escaping Callback, _ context: UnsafeMutableRawPointer) {\n"
+"    DispatchQueue.main.async {\n"
+"        if let scene = UIApplication.shared.connectedScenes\n"
+"            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {\n"
+"            SKStoreReviewController.requestReview(in: scene)\n"
+"        }\n"
+"        let result = \"{\\\"success\\\":true}\"\n"
+"        result.withCString { callback(context, $0) }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:210
+msgid ""
+"The `build.rs` compiles the Swift source into a static library using "
+"`swiftc`, targeting the correct platform SDK:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:213
+msgid "// build.rs (simplified)\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:215
+msgid ""
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:221
+msgid "JNI bridge (Android)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:223
+msgid "Android platform APIs are accessed through JNI. The pattern:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:225
+msgid "Get the `JavaVM` via `JNI_GetCreatedJavaVMs()`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:226
+msgid "Attach the current thread to get a `JNIEnv`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:227
+msgid "Call Java/Kotlin APIs through JNI method invocations"
+msgstr ""
+
+#: src/plugins/native-extensions.md:228
+msgid "Resolve the Perry promise with the result"
+msgstr ""
+
+#: src/plugins/native-extensions.md:238
+msgid "// Get Activity from PerryBridge\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:239
+msgid "\"com/perry/app/PerryBridge\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:240
+msgid "\"getActivity\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:240
+msgid "\"()Landroid/app/Activity;\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:243
+msgid "// Call platform APIs via JNI...\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:248
+msgid ""
+"If the Android implementation requires a Java library (e.g., Google Play In-"
+"App Review), the app's `build.gradle` must include the dependency. Document "
+"this requirement clearly for your extension's users."
+msgstr ""
+
+#: src/plugins/native-extensions.md:250
+msgid "Stub crate"
+msgstr ""
+
+#: src/plugins/native-extensions.md:252
+msgid ""
+"For platforms without a native implementation, the stub immediately resolves"
+" the promise with an error:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:259
+msgid "\"{\\\"error\\\":\\\"Not available on this platform\\\"}\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:269
+msgid "Build requirements"
+msgstr ""
+
+#: src/plugins/native-extensions.md:273
+msgid "macOS host, Xcode, `rustup target add aarch64-apple-ios`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:274
+msgid "macOS host, Xcode, `rustup target add aarch64-apple-ios-sim`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:275
+msgid "macOS host, Xcode Command Line Tools"
+msgstr ""
+
+#: src/plugins/native-extensions.md:276
+msgid "Android NDK, `rustup target add aarch64-linux-android`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:278
+msgid ""
+"When Perry encounters a `perry.nativeLibrary` manifest during compilation, "
+"it:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:280
+msgid "Selects the crate for the current `--target` platform"
+msgstr ""
+
+#: src/plugins/native-extensions.md:281
+msgid "Runs `cargo build --release --target <triple>` in the crate directory"
+msgstr ""
+
+#: src/plugins/native-extensions.md:282
+msgid "Links the resulting `.a` static library into the final binary"
+msgstr ""
+
+#: src/plugins/native-extensions.md:283
+msgid "Adds any declared frameworks (e.g., `-framework StoreKit`)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:285
+msgid "Creating your own native extension"
+msgstr ""
+
+#: src/plugins/native-extensions.md:287
+msgid "Create the directory structure shown above"
+msgstr ""
+
+#: src/plugins/native-extensions.md:288
+msgid "Define your functions in `package.json` under `perry.nativeLibrary`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:289
+msgid ""
+"Implement each function in the platform crates with matching `#[no_mangle] "
+"pub extern \"C\"` signatures"
+msgstr ""
+
+#: src/plugins/native-extensions.md:290
+msgid ""
+"Write a TypeScript entry point that declares and optionally wraps the native"
+" functions"
+msgstr ""
+
+#: src/plugins/native-extensions.md:291
+msgid "Add a stub crate for unsupported platforms"
+msgstr ""
+
+#: src/plugins/native-extensions.md:292
+msgid "Test with `--bundle-extensions`:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:299
+msgid ""
+"[App Store Review](appstore-review.md) — Native review prompt extension "
+"(iOS/Android)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:300
+msgid ""
+"[Creating Plugins](creating-plugins.md) — Dynamic plugins loaded at runtime"
+msgstr ""
+
+#: src/plugins/appstore-review.md:3
+msgid ""
+"**Status: extension-dependent.** The compiler-side wiring (`--bundle-"
+"extensions`, `perry.nativeLibrary`, `declare function`) is in place — see "
+"[Native Extensions — Status](native-extensions.md) — but the snippets below "
+"assume the `perry-appstore-review` extension repo has been cloned into "
+"`./extensions/`. The doc-tests harness doesn't ship that repo, so these "
+"snippets are kept as `,no-test`. Once the extension is on disk, they compile"
+" and run on iOS / iOS Simulator / macOS / Android."
+msgstr ""
+
+#: src/plugins/appstore-review.md:5
+msgid ""
+"Prompt users to rate your app using the native app store review dialog on "
+"iOS and Android."
+msgstr ""
+
+#: src/plugins/appstore-review.md:7
+msgid ""
+"The `perry-appstore-review` extension exposes a single function — "
+"`requestReview()` — that opens the platform's native review prompt. It does "
+"nothing else: when and how often to ask is entirely up to you."
+msgstr ""
+
+#: src/plugins/appstore-review.md:9
+msgid ""
+"**Repository:** "
+"[github.com/PerryTS/appstorereview](https://github.com/PerryTS/appstorereview)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:13
+msgid "1. Add the extension"
+msgstr ""
+
+#: src/plugins/appstore-review.md:15
+msgid "Clone or copy the extension into your project's extensions directory:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:24
+msgid "Your project structure:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:35
+msgid "2. Use in your app"
+msgstr ""
+
+#: src/plugins/appstore-review.md:37
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"\n"
+"// Show the review prompt when the user completes a meaningful action\n"
+"async function onLevelComplete() {\n"
+"  await requestReview();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/appstore-review.md:46
+msgid "3. Build"
+msgstr ""
+
+#: src/plugins/appstore-review.md:52
+msgid ""
+"The `--bundle-extensions` flag tells Perry to discover, compile, and link "
+"all native extensions in the given directory. The app store review native "
+"code is compiled and statically linked into your binary — no runtime "
+"dependencies."
+msgstr ""
+
+#: src/plugins/appstore-review.md:56
+msgid "`requestReview(): Promise<void>`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:58
+msgid ""
+"Opens the native app store review prompt. Returns a promise that resolves "
+"when the prompt has been presented (or skipped by the OS)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:66
+msgid "The function only triggers the prompt. It does not:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:67
+msgid "Track whether the user has already reviewed"
+msgstr ""
+
+#: src/plugins/appstore-review.md:68
+msgid ""
+"Throttle how often the prompt appears (iOS does this automatically; Android "
+"does not)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:69
+msgid ""
+"Return whether the user actually left a review (neither platform provides "
+"this)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:71
+msgid "Platform behavior"
+msgstr ""
+
+#: src/plugins/appstore-review.md:75
+msgid ""
+"Uses "
+"[`SKStoreReviewController.requestReview(in:)`](https://developer.apple.com/documentation/storekit/skstorereviewcontroller/requestreview(in:))"
+" from StoreKit."
+msgstr ""
+
+#: src/plugins/appstore-review.md:77 src/plugins/appstore-review.md:93
+#: src/plugins/appstore-review.md:106
+msgid "Detail"
+msgstr ""
+
+#: src/plugins/appstore-review.md:79 src/plugins/appstore-review.md:95
+#: src/plugins/appstore-review.md:108
+msgid "Native API"
+msgstr ""
+
+#: src/plugins/appstore-review.md:79
+msgid "`SKStoreReviewController.requestReview(in: UIWindowScene)`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:80
+msgid "Minimum iOS version"
+msgstr ""
+
+#: src/plugins/appstore-review.md:80
+msgid "14.0"
+msgstr ""
+
+#: src/plugins/appstore-review.md:81 src/plugins/appstore-review.md:97
+msgid "Framework"
+msgstr ""
+
+#: src/plugins/appstore-review.md:81 src/plugins/appstore-review.md:97
+msgid "StoreKit"
+msgstr ""
+
+#: src/plugins/appstore-review.md:82
+msgid "Thread"
+msgstr ""
+
+#: src/plugins/appstore-review.md:82
+msgid "Dispatched to main thread automatically"
+msgstr ""
+
+#: src/plugins/appstore-review.md:83 src/plugins/appstore-review.md:98
+#: src/plugins/appstore-review.md:111
+msgid "Throttling"
+msgstr ""
+
+#: src/plugins/appstore-review.md:83
+msgid ""
+"Apple limits display to 3 times per 365-day period per app. The system may "
+"silently ignore the call."
+msgstr ""
+
+#: src/plugins/appstore-review.md:84
+msgid "Development builds"
+msgstr ""
+
+#: src/plugins/appstore-review.md:84
+msgid "Always shown in debug/TestFlight builds"
+msgstr ""
+
+#: src/plugins/appstore-review.md:85
+msgid "User control"
+msgstr ""
+
+#: src/plugins/appstore-review.md:85
+msgid "Users can disable review prompts in Settings > App Store"
+msgstr ""
+
+#: src/plugins/appstore-review.md:87
+msgid ""
+"**Important:** Apple's throttling means the prompt is not guaranteed to "
+"appear every time `requestReview()` is called. Design your app flow so that "
+"not showing the prompt doesn't break the user experience."
+msgstr ""
+
+#: src/plugins/appstore-review.md:91
+msgid ""
+"Uses the same StoreKit API. Shares the iOS native crate (both compile from "
+"`crate-ios`)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:95
+msgid "`SKStoreReviewController.requestReview()`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:96
+msgid "Minimum macOS version"
+msgstr ""
+
+#: src/plugins/appstore-review.md:96
+msgid "13.0"
+msgstr ""
+
+#: src/plugins/appstore-review.md:98
+msgid "Same as iOS — system-controlled"
+msgstr ""
+
+#: src/plugins/appstore-review.md:100
+msgid "Only works for apps distributed through the Mac App Store."
+msgstr ""
+
+#: src/plugins/appstore-review.md:104
+msgid ""
+"Uses the [Google Play In-App Review "
+"API](https://developer.android.com/guide/playcore/in-app-review)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:108
+msgid "`ReviewManager.requestReviewFlow()` + `launchReviewFlow()`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:109
+msgid "Library"
+msgstr ""
+
+#: src/plugins/appstore-review.md:109
+msgid "`com.google.android.play:review`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:110
+msgid "Minimum API level"
+msgstr ""
+
+#: src/plugins/appstore-review.md:110
+msgid "21 (Android 5.0)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:111
+msgid "Google enforces a quota — the prompt may not appear every time"
+msgstr ""
+
+#: src/plugins/appstore-review.md:112
+msgid "Execution"
+msgstr ""
+
+#: src/plugins/appstore-review.md:112
+msgid "Runs on a background thread to avoid blocking the UI"
+msgstr ""
+
+#: src/plugins/appstore-review.md:114
+msgid ""
+"**Required Gradle dependency:** The Google Play In-App Review API is not "
+"part of the Android SDK. You must add it to your app's `build.gradle`:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:118
+msgid "'com.google.android.play:review:2.0.2'"
+msgstr ""
+
+#: src/plugins/appstore-review.md:122
+msgid ""
+"Without this dependency, `requestReview()` will resolve with an error "
+"explaining the missing library."
+msgstr ""
+
+#: src/plugins/appstore-review.md:124
+msgid "Other platforms"
+msgstr ""
+
+#: src/plugins/appstore-review.md:126
+msgid ""
+"On unsupported platforms (Linux, Windows, Web), `requestReview()` resolves "
+"immediately with an error. It will not throw — your app continues normally."
+msgstr ""
+
+#: src/plugins/appstore-review.md:128
+msgid "Best practices"
+msgstr ""
+
+#: src/plugins/appstore-review.md:130
+msgid ""
+"**Do ask at the right moment.** Prompt after a positive experience — "
+"completing a level, finishing a task, achieving a goal. Don't ask on first "
+"launch or during onboarding."
+msgstr ""
+
+#: src/plugins/appstore-review.md:132
+msgid ""
+"**Don't ask too often.** Even though iOS throttles automatically, Android "
+"does not have the same strict limits. Implement your own logic to track when"
+" you last asked:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:134
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"import { preferencesGet, preferencesSet } from \"perry/system\";\n"
+"\n"
+"async function maybeAskForReview() {\n"
+"  const lastAsked = Number(preferencesGet(\"lastReviewAsk\") || \"0\");\n"
+"  const now = Date.now();\n"
+"  const thirtyDays = 30 * 24 * 60 * 60 * 1000;\n"
+"\n"
+"  if (now - lastAsked > thirtyDays) {\n"
+"    preferencesSet(\"lastReviewAsk\", String(now));\n"
+"    await requestReview();\n"
+"  }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/appstore-review.md:150
+msgid ""
+"**Don't condition app behavior on the review.** Neither iOS nor Android "
+"tells you whether the user left a review, gave a rating, or dismissed the "
+"prompt. The promise resolving does not mean a review was submitted."
+msgstr ""
+
+#: src/plugins/appstore-review.md:152
+msgid ""
+"**Don't use custom review dialogs before the native one.** Both Apple and "
+"Google discourage showing your own \"Rate this app?\" dialog before the "
+"native prompt. The native prompt is designed to be low-friction — adding a "
+"pre-prompt increases abandonment."
+msgstr ""
+
+#: src/plugins/appstore-review.md:154
+msgid "Extension structure"
+msgstr ""
+
+#: src/plugins/appstore-review.md:156
+msgid ""
+"The extension follows the standard [native extension](native-extensions.md) "
+"layout:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:176
+msgid "One native function is declared in `package.json`:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:190
+msgid ""
+"The TypeScript layer wraps this into the public `requestReview()` function. "
+"The native layer creates a Perry promise, calls the platform API, and "
+"resolves the promise when done."
+msgstr ""
+
+#: src/plugins/appstore-review.md:194
+msgid ""
+"[Native Extensions](native-extensions.md) — How native extensions work, "
+"creating your own"
+msgstr ""
+
+#: src/plugins/appstore-review.md:195
+msgid "[iOS Platform](../platforms/ios.md) — iOS platform guide"
+msgstr ""
+
+#: src/plugins/appstore-review.md:196
+msgid "[Android Platform](../platforms/android.md) — Android platform guide"
+msgstr ""
+
+#: src/testing/geisterhand.md:1
+msgid "Geisterhand — In-Process UI Testing"
+msgstr ""
+
+#: src/testing/geisterhand.md:3
+msgid ""
+"Geisterhand (German for \"ghost hand\") embeds a lightweight HTTP server "
+"inside your Perry app that lets you interact with every widget "
+"programmatically. Click buttons, type into text fields, drag sliders, toggle"
+" switches, capture screenshots, and run chaos-mode random fuzzing — all via "
+"simple HTTP calls."
+msgstr ""
+
+#: src/testing/geisterhand.md:5
+msgid ""
+"It works on **all 5 native platforms** (macOS, iOS, Android, Linux/GTK4, "
+"Windows) with zero external dependencies. The server starts automatically "
+"when you compile with `--enable-geisterhand`."
+msgstr ""
+
+#: src/testing/geisterhand.md:12
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:14
+msgid "# 2. Run the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:16
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:18
+msgid "# 3. In another terminal — interact with the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:20
+msgid "# List all widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:21
+msgid "# Click button with handle 3\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:22
+msgid "# Capture window screenshot\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:25
+msgid "Custom Port"
+msgstr ""
+
+#: src/testing/geisterhand.md:27
+msgid ""
+"The default port is **7676**. Use `--geisterhand-port` to change it (this "
+"implies `--enable-geisterhand`, so you don't need both flags):"
+msgstr ""
+
+#: src/testing/geisterhand.md:30
+msgid "# or with perry run:\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:35
+msgid "With `perry run`"
+msgstr ""
+
+#: src/testing/geisterhand.md:47
+msgid ""
+"All endpoints return JSON unless noted otherwise. All responses include "
+"`Access-Control-Allow-Origin: *` for browser-based tools. OPTIONS requests "
+"are supported for CORS preflight."
+msgstr ""
+
+#: src/testing/geisterhand.md:49
+msgid "Health Check"
+msgstr ""
+
+#: src/testing/geisterhand.md:51
+msgid ""
+"```\n"
+"GET /health\n"
+"→ {\"status\":\"ok\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:56
+msgid "Use this to wait for the app to be ready before running tests."
+msgstr ""
+
+#: src/testing/geisterhand.md:58
+msgid "List Widgets"
+msgstr ""
+
+#: src/testing/geisterhand.md:64
+msgid "Returns a JSON array of all registered widgets:"
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"handle\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:458 src/testing/geisterhand.md:459
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"widget_type\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"callback_kind\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"label\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68
+msgid "\"Click Me\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+msgid "\"shortcut\""
+msgstr ""
+
+#: src/testing/geisterhand.md:69
+msgid "\"Type here...\""
+msgstr ""
+
+#: src/testing/geisterhand.md:71
+msgid "\"Enable\""
+msgstr ""
+
+#: src/testing/geisterhand.md:72
+msgid "\"Save\""
+msgstr ""
+
+#: src/testing/geisterhand.md:72
+msgid "\"s\""
+msgstr ""
+
+#: src/testing/geisterhand.md:77
+msgid "Supports query parameter filters:"
+msgstr ""
+
+#: src/testing/geisterhand.md:78
+msgid ""
+"`GET /widgets?label=Save` — filter by label substring (case-insensitive)"
+msgstr ""
+
+#: src/testing/geisterhand.md:79
+msgid "`GET /widgets?type=button` — filter by widget type name or code"
+msgstr ""
+
+#: src/testing/geisterhand.md:80
+msgid "`GET /widgets?label=Save&type=5` — combine filters"
+msgstr ""
+
+#: src/testing/geisterhand.md:82
+msgid "Widget Types"
+msgstr ""
+
+#: src/testing/geisterhand.md:84 src/testing/geisterhand.md:98
+msgid "Code"
+msgstr ""
+
+#: src/testing/geisterhand.md:86
+msgid "Push button with onClick"
+msgstr ""
+
+#: src/testing/geisterhand.md:87
+msgid "Text input field"
+msgstr ""
+
+#: src/testing/geisterhand.md:88
+msgid "Numeric slider"
+msgstr ""
+
+#: src/testing/geisterhand.md:89
+msgid "On/off switch"
+msgstr ""
+
+#: src/testing/geisterhand.md:90
+msgid "Dropdown selector"
+msgstr ""
+
+#: src/testing/geisterhand.md:91 src/testing/geisterhand.md:294
+msgid "Menu"
+msgstr ""
+
+#: src/testing/geisterhand.md:91
+msgid "Menu item"
+msgstr ""
+
+#: src/testing/geisterhand.md:92 src/cli/perry-toml.md:399
+msgid "6"
+msgstr ""
+
+#: src/testing/geisterhand.md:92
+msgid "Keyboard shortcut"
+msgstr ""
+
+#: src/testing/geisterhand.md:93
+msgid "Data table"
+msgstr ""
+
+#: src/testing/geisterhand.md:94
+msgid "8"
+msgstr ""
+
+#: src/testing/geisterhand.md:94
+msgid "Scrollable container"
+msgstr ""
+
+#: src/testing/geisterhand.md:96
+msgid "Callback Kinds"
+msgstr ""
+
+#: src/testing/geisterhand.md:98
+msgid "Kind"
+msgstr ""
+
+#: src/testing/geisterhand.md:100
+msgid "Triggered on click/tap"
+msgstr ""
+
+#: src/testing/geisterhand.md:101
+msgid "onChange"
+msgstr ""
+
+#: src/testing/geisterhand.md:101
+msgid "Triggered on value change"
+msgstr ""
+
+#: src/testing/geisterhand.md:102
+msgid "onSubmit"
+msgstr ""
+
+#: src/testing/geisterhand.md:102
+msgid "Triggered on submit (e.g., pressing Enter)"
+msgstr ""
+
+#: src/testing/geisterhand.md:103
+msgid "Triggered on mouse hover"
+msgstr ""
+
+#: src/testing/geisterhand.md:104
+msgid "Triggered on double-click"
+msgstr ""
+
+#: src/testing/geisterhand.md:105
+msgid "onFocus"
+msgstr ""
+
+#: src/testing/geisterhand.md:105
+msgid "Triggered on focus"
+msgstr ""
+
+#: src/testing/geisterhand.md:107
+msgid ""
+"A single widget may appear multiple times in the list with different "
+"callback kinds. For example, a button with both `onClick` and `onHover` "
+"handlers produces two entries (same handle, different `callback_kind`)."
+msgstr ""
+
+#: src/testing/geisterhand.md:109
+msgid "Click a Widget"
+msgstr ""
+
+#: src/testing/geisterhand.md:111
+msgid ""
+"```\n"
+"POST /click/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:116
+msgid ""
+"Fires the widget's `onClick` callback. Works with buttons, menu items, "
+"shortcuts, and table rows."
+msgstr ""
+
+#: src/testing/geisterhand.md:122
+msgid "Type into a TextField"
+msgstr ""
+
+#: src/testing/geisterhand.md:124
+msgid ""
+"```\n"
+"POST /type/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"text\": \"hello world\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:131
+msgid ""
+"Sets the text field's content and fires its `onChange` callback with the new"
+" text as a NaN-boxed string."
+msgstr ""
+
+#: src/testing/geisterhand.md:139
+msgid "Move a Slider"
+msgstr ""
+
+#: src/testing/geisterhand.md:141
+msgid ""
+"```\n"
+"POST /slide/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"value\": 0.75}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:148
+msgid "Sets the slider position and fires `onChange` with the numeric value."
+msgstr ""
+
+#: src/testing/geisterhand.md:156
+msgid "Toggle a Switch"
+msgstr ""
+
+#: src/testing/geisterhand.md:158
+msgid ""
+"```\n"
+"POST /toggle/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:163
+msgid "Fires the toggle's `onChange` callback with a boolean value."
+msgstr ""
+
+#: src/testing/geisterhand.md:169
+msgid "Set State Directly"
+msgstr ""
+
+#: src/testing/geisterhand.md:171
+msgid ""
+"```\n"
+"POST /state/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"value\": 42}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:178
+msgid ""
+"Directly sets a `State` cell's value, bypassing widget callbacks. This "
+"triggers any reactive bindings attached to the state (bound text labels, "
+"visibility, forEach loops, etc.)."
+msgstr ""
+
+#: src/testing/geisterhand.md:186
+msgid "Hover"
+msgstr ""
+
+#: src/testing/geisterhand.md:188
+msgid ""
+"```\n"
+"POST /hover/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:193
+msgid ""
+"Fires the widget's `onHover` callback. Useful for testing hover-dependent UI"
+" (tooltips, color changes, etc.)."
+msgstr ""
+
+#: src/testing/geisterhand.md:195
+msgid "Double-Click"
+msgstr ""
+
+#: src/testing/geisterhand.md:197
+msgid ""
+"```\n"
+"POST /doubleclick/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:202
+msgid "Fires the widget's `onDoubleClick` callback."
+msgstr ""
+
+#: src/testing/geisterhand.md:204
+msgid "Trigger Keyboard Shortcut"
+msgstr ""
+
+#: src/testing/geisterhand.md:206
+msgid ""
+"```\n"
+"POST /key\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"shortcut\": \"s\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:213
+msgid ""
+"Finds a registered menu item whose shortcut matches and fires its callback. "
+"Shortcut strings are case-insensitive and match the key string passed to "
+"`menuAddItem` (e.g., `\"s\"` for Cmd+S, `\"S\"` for Cmd+Shift+S, `\"n\"` for"
+" Cmd+N)."
+msgstr ""
+
+#: src/testing/geisterhand.md:221
+msgid ""
+"Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no "
+"match."
+msgstr ""
+
+#: src/testing/geisterhand.md:223
+msgid "Scroll a ScrollView"
+msgstr ""
+
+#: src/testing/geisterhand.md:225
+msgid ""
+"```\n"
+"POST /scroll/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"x\": 0, \"y\": 100}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:232
+msgid ""
+"Sets the scroll offset of a ScrollView widget. Both `x` and `y` are in "
+"points."
+msgstr ""
+
+#: src/testing/geisterhand.md:240
+msgid "Capture Screenshot"
+msgstr ""
+
+#: src/testing/geisterhand.md:247
+msgid ""
+"Captures the app window as a PNG image. The response is raw binary data, not"
+" JSON."
+msgstr ""
+
+#: src/testing/geisterhand.md:253
+msgid ""
+"Screenshot capture is synchronous from the caller's perspective — the HTTP "
+"request blocks until the main thread completes the capture (timeout: 5 "
+"seconds)."
+msgstr ""
+
+#: src/testing/geisterhand.md:255
+msgid "**Platform-specific capture methods:**"
+msgstr ""
+
+#: src/testing/geisterhand.md:259
+msgid "`CGWindowListCreateImage`"
+msgstr ""
+
+#: src/testing/geisterhand.md:259
+msgid "Retina resolution, reads from window ID"
+msgstr ""
+
+#: src/testing/geisterhand.md:260
+msgid "`UIGraphicsImageRenderer`"
+msgstr ""
+
+#: src/testing/geisterhand.md:260
+msgid "Draws view hierarchy into image context"
+msgstr ""
+
+#: src/testing/geisterhand.md:261
+msgid "JNI `View.draw()` on Canvas"
+msgstr ""
+
+#: src/testing/geisterhand.md:261
+msgid "Creates Bitmap, compresses to PNG"
+msgstr ""
+
+#: src/testing/geisterhand.md:262
+msgid "`WidgetPaintable` + `GskRenderer`"
+msgstr ""
+
+#: src/testing/geisterhand.md:262
+msgid "Renders to texture, saves as PNG bytes"
+msgstr ""
+
+#: src/testing/geisterhand.md:263
+msgid "`PrintWindow` + `GetDIBits`"
+msgstr ""
+
+#: src/testing/geisterhand.md:263
+msgid "Inline PNG encoder (stored zlib blocks)"
+msgstr ""
+
+#: src/testing/geisterhand.md:265
+msgid "Chaos Mode"
+msgstr ""
+
+#: src/testing/geisterhand.md:267
+msgid ""
+"Chaos mode randomly interacts with widgets at a configurable interval — "
+"useful for stress testing, finding edge cases, and crash hunting."
+msgstr ""
+
+#: src/testing/geisterhand.md:269
+msgid "Start"
+msgstr ""
+
+#: src/testing/geisterhand.md:271
+msgid ""
+"```\n"
+"POST /chaos/start\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"interval_ms\": 200}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:279
+msgid "# Fire random inputs every 200ms\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:285
+msgid ""
+"If `interval_ms` is omitted, a default interval is used. The chaos thread "
+"randomly selects a registered widget and fires an appropriate input based on"
+" widget type:"
+msgstr ""
+
+#: src/testing/geisterhand.md:287
+msgid "Widget Type"
+msgstr ""
+
+#: src/testing/geisterhand.md:287
+msgid "Random Input"
+msgstr ""
+
+#: src/testing/geisterhand.md:289 src/testing/geisterhand.md:294
+#: src/testing/geisterhand.md:295 src/testing/geisterhand.md:296
+msgid "Fires onClick (no args)"
+msgstr ""
+
+#: src/testing/geisterhand.md:290
+msgid "Random alphanumeric string, 5-20 characters"
+msgstr ""
+
+#: src/testing/geisterhand.md:291
+msgid "Random float between 0.0 and 1.0"
+msgstr ""
+
+#: src/testing/geisterhand.md:292
+msgid "Random true/false"
+msgstr ""
+
+#: src/testing/geisterhand.md:293
+msgid "Random index 0-9"
+msgstr ""
+
+#: src/testing/geisterhand.md:300
+msgid ""
+"```\n"
+"GET /chaos/status\n"
+"→ {\"running\":true,\"events_fired\":247,\"uptime_secs\":12}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:305
+msgid ""
+"Returns whether chaos mode is active, how many random events have been "
+"fired, and uptime in seconds."
+msgstr ""
+
+#: src/testing/geisterhand.md:307
+msgid "Stop"
+msgstr ""
+
+#: src/testing/geisterhand.md:309
+msgid ""
+"```\n"
+"POST /chaos/stop\n"
+"→ {\"ok\":true,\"chaos\":\"stopped\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:314
+msgid "Error Responses"
+msgstr ""
+
+#: src/testing/geisterhand.md:316
+msgid ""
+"All endpoints return errors as JSON with an appropriate HTTP status code:"
+msgstr ""
+
+#: src/testing/geisterhand.md:319
+msgid "\"widget handle 99 not found\""
+msgstr ""
+
+#: src/testing/geisterhand.md:322
+msgid "Common errors:"
+msgstr ""
+
+#: src/testing/geisterhand.md:323
+msgid "`404` — widget handle not found"
+msgstr ""
+
+#: src/testing/geisterhand.md:324
+msgid "`400` — malformed JSON body or missing required field"
+msgstr ""
+
+#: src/testing/geisterhand.md:325
+msgid "`405` — unsupported HTTP method"
+msgstr ""
+
+#: src/testing/geisterhand.md:329
+msgid "Platform Setup"
+msgstr ""
+
+#: src/testing/geisterhand.md:333
+msgid ""
+"No extra setup needed. The server binds to `0.0.0.0:7676` and is accessible "
+"on `localhost`."
+msgstr ""
+
+#: src/testing/geisterhand.md:343
+msgid ""
+"The iOS Simulator shares the host's network stack — access the server "
+"directly on `localhost`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:352 src/cli/flags.md:24
+msgid "iOS Device"
+msgstr ""
+
+#: src/testing/geisterhand.md:354
+msgid ""
+"For physical iOS devices, you need a network route to the device (same Wi-Fi"
+" network) or use `iproxy` from `libimobiledevice`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:357
+msgid "# Install and launch via Xcode/devicectl\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:359
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:363
+msgid "Android (Emulator or Device)"
+msgstr ""
+
+#: src/testing/geisterhand.md:365
+msgid ""
+"Use `adb forward` to bridge the port. Ensure `INTERNET` permission is in "
+"your manifest (or add it to `perry.toml`):"
+msgstr ""
+
+#: src/testing/geisterhand.md:367
+msgid ""
+"```toml\n"
+"[android]\n"
+"permissions = [\"INTERNET\"]\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:373
+msgid "# Package into APK and install\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:381
+msgid "Install GTK4 development libraries first:"
+msgstr ""
+
+#: src/testing/geisterhand.md:402
+msgid "Test Automation"
+msgstr ""
+
+#: src/testing/geisterhand.md:404
+msgid ""
+"Geisterhand turns your Perry app into a testable HTTP service. Here are "
+"practical patterns for automated testing."
+msgstr ""
+
+#: src/testing/geisterhand.md:406
+msgid "Shell Script Tests"
+msgstr ""
+
+#: src/testing/geisterhand.md:408
+msgid "A simple end-to-end test using bash:"
+msgstr ""
+
+#: src/testing/geisterhand.md:411
+msgid "#!/bin/bash\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:413
+msgid "# Build with geisterhand\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:416
+msgid "# Start the app in background\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:419
+msgid "$!"
+msgstr ""
+
+#: src/testing/geisterhand.md:420
+msgid "\"kill $APP_PID 2>/dev/null\""
+msgstr ""
+
+#: src/testing/geisterhand.md:421
+msgid "# Wait for the app to be ready\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:427
+msgid "# Get widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:430
+msgid "\"Registered widgets: $WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:431
+msgid "# Find the button labeled \"Submit\"\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
+msgstr ""
+
+#: src/testing/geisterhand.md:434
+msgid "# Click it\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:436
+msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
+msgstr ""
+
+#: src/testing/geisterhand.md:437
+msgid "# Take a screenshot after interaction\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:441
+msgid "\"Test passed\""
+msgstr ""
+
+#: src/testing/geisterhand.md:444
+msgid "Python Test Example"
+msgstr ""
+
+#: src/testing/geisterhand.md:448
+msgid "# Start the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:450
+msgid "\"./testapp\""
+msgstr ""
+
+#: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
+msgid "# Wait for startup\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:454
+msgid "# List widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:455
+msgid "\"http://127.0.0.1:7676/widgets\""
+msgstr ""
+
+#: src/testing/geisterhand.md:457
+msgid "# Find widgets by label\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:461
+msgid "# Type into the first text field\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:464
+msgid "\"http://127.0.0.1:7676/type/"
+msgstr ""
+
+#: src/testing/geisterhand.md:464 src/testing/geisterhand.md:470
+msgid "'handle'"
+msgstr ""
+
+#: src/testing/geisterhand.md:464 src/testing/geisterhand.md:470
+msgid "\""
+msgstr ""
+
+#: src/testing/geisterhand.md:465
+msgid "\"test@example.com\""
+msgstr ""
+
+#: src/testing/geisterhand.md:468
+msgid "# Click the first button\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:470
+msgid "\"http://127.0.0.1:7676/click/"
+msgstr ""
+
+#: src/testing/geisterhand.md:472
+msgid "# Capture screenshot for visual regression\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:473
+msgid "\"http://127.0.0.1:7676/screenshot\""
+msgstr ""
+
+#: src/testing/geisterhand.md:474
+msgid "\"test-result.png\""
+msgstr ""
+
+#: src/testing/geisterhand.md:474
+msgid "\"wb\""
+msgstr ""
+
+#: src/testing/geisterhand.md:477
+msgid "# Assert the app is still healthy\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"http://127.0.0.1:7676/health\""
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"status\""
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"ok\""
+msgstr ""
+
+#: src/testing/geisterhand.md:479
+msgid "\"All tests passed\""
+msgstr ""
+
+#: src/testing/geisterhand.md:484
+msgid "Stress Testing with Chaos Mode"
+msgstr ""
+
+#: src/testing/geisterhand.md:486
+msgid ""
+"Run chaos mode against your app to find crashes, freezes, or unexpected "
+"state:"
+msgstr ""
+
+#: src/testing/geisterhand.md:489
+msgid "# Build and launch\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:495
+msgid "# Start aggressive chaos (every 50ms)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:518
+msgid "Visual Regression Testing"
+msgstr ""
+
+#: src/testing/geisterhand.md:520
+msgid ""
+"Capture screenshots at key interaction points and compare against baselines:"
+msgstr ""
+
+#: src/testing/geisterhand.md:523
+msgid "# Initial state\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:525
+msgid "# Interact\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:528
+msgid "'{\"text\":\"Hello\"}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:529
+msgid "# Capture after interaction\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:532
+msgid "# Compare (using ImageMagick)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:537
+msgid "CI Pipeline Integration"
+msgstr ""
+
+#: src/testing/geisterhand.md:540
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr ""
+
+#: src/testing/geisterhand.md:542
+msgid "ui-test"
+msgstr ""
+
+#: src/testing/geisterhand.md:543
+msgid "runs-on"
+msgstr ""
+
+#: src/testing/geisterhand.md:543
+msgid "macos-latest"
+msgstr ""
+
+#: src/testing/geisterhand.md:544 src/cli/perry-toml.md:602
+msgid "steps"
+msgstr ""
+
+#: src/testing/geisterhand.md:545
+msgid "uses"
+msgstr ""
+
+#: src/testing/geisterhand.md:545
+msgid "actions/checkout@v4"
+msgstr ""
+
+#: src/testing/geisterhand.md:547 src/testing/geisterhand.md:550
+msgid "name"
+msgstr ""
+
+#: src/testing/geisterhand.md:547
+msgid "Build with geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:548 src/testing/geisterhand.md:551
+#: src/cli/commands.md:48 src/cli/perry-toml.md:604 src/cli/perry-toml.md:605
+#: src/cli/perry-toml.md:606
+msgid "run"
+msgstr ""
+
+#: src/testing/geisterhand.md:548
+msgid "perry app.ts -o testapp --enable-geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:550
+msgid "Run UI tests"
+msgstr ""
+
+#: src/testing/geisterhand.md:554
+msgid "# Run your test script\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:568
+msgid "Example App"
+msgstr ""
+
+#: src/testing/geisterhand.md:570
+msgid ""
+"A complete Perry UI app demonstrating every widget type Geisterhand can "
+"interact with — verified by CI:"
+msgstr ""
+
+#: src/testing/geisterhand.md:573
+msgid ""
+"```typescript\n"
+"// demonstrates: Geisterhand-targetable Perry UI app — every common widget\n"
+"// docs: docs/src/testing/geisterhand.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"// A complete Perry UI app exercising every widget type Geisterhand\n"
+"// (the UI fuzzer) can interact with. The doc-tests harness compiles\n"
+"// and runs this on every PR, so the snippet on the docs page can never\n"
+"// drift from the real perry/ui API.\n"
+"\n"
+"import {\n"
+"    App, VStack, HStack,\n"
+"    Text, Button, TextField, Slider, Toggle, Picker,\n"
+"    State, stateOnChange,\n"
+"    pickerAddItem,\n"
+"    textSetString,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// State for reactive UI\n"
+"const counterState = State(0)\n"
+"const textState = State(\"\")\n"
+"\n"
+"// Labels\n"
+"const title = Text(\"Geisterhand Demo\")\n"
+"const counterLabel = Text(\"Count: 0\")\n"
+"\n"
+"// Bind counter state to label via the free-function listener\n"
+"stateOnChange(counterState, (val: number) => {\n"
+"    textSetString(counterLabel, `Count: ${val}`)\n"
+"})\n"
+"\n"
+"// Button — widget_type = 0\n"
+"const incrementBtn = Button(\"Increment\", () => {\n"
+"    counterState.set(counterState.value + 1)\n"
+"})\n"
+"const resetBtn = Button(\"Reset\", () => {\n"
+"    counterState.set(0)\n"
+"})\n"
+"\n"
+"// TextField(placeholder, onChange) — widget_type = 1\n"
+"const nameField = TextField(\"Enter your name\", (text: string) => {\n"
+"    textState.set(text)\n"
+"    console.log(`Name: ${text}`)\n"
+"})\n"
+"\n"
+"// Slider(min, max, onChange) — widget_type = 2\n"
+"const volumeSlider = Slider(0, 100, (value: number) => {\n"
+"    console.log(`Volume: ${value}`)\n"
+"})\n"
+"\n"
+"// Toggle(label, onChange) — widget_type = 3\n"
+"const darkModeToggle = Toggle(\"Dark Mode\", (on: boolean) => {\n"
+"    console.log(`Dark mode: ${on}`)\n"
+"})\n"
+"\n"
+"// Picker(onChange); items added with pickerAddItem.\n"
+"const sizePicker = Picker((index: number) => {\n"
+"    console.log(`Size index: ${index}`)\n"
+"})\n"
+"pickerAddItem(sizePicker, \"Small\")\n"
+"pickerAddItem(sizePicker, \"Medium\")\n"
+"pickerAddItem(sizePicker, \"Large\")\n"
+"\n"
+"// Layout\n"
+"const buttonRow = HStack(8, [incrementBtn, resetBtn])\n"
+"const stack = VStack(12, [\n"
+"    title, counterLabel, buttonRow,\n"
+"    nameField, volumeSlider, darkModeToggle, sizePicker,\n"
+"])\n"
+"\n"
+"App({\n"
+"    title: \"Geisterhand Demo\",\n"
+"    width: 400,\n"
+"    height: 480,\n"
+"    body: stack,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:651
+msgid "After compiling with `--enable-geisterhand` and running:"
+msgstr ""
+
+#: src/testing/geisterhand.md:654
+msgid "# See all interactive widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:655
+msgid "# [\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:657
+msgid "\"Increment\""
+msgstr ""
+
+#: src/testing/geisterhand.md:657
+msgid "#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:659
+msgid "\"Enter your name\""
+msgstr ""
+
+#: src/testing/geisterhand.md:659
+msgid "#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:661
+msgid "\"Dark Mode\""
+msgstr ""
+
+#: src/testing/geisterhand.md:661
+msgid "# ]\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:663
+msgid "# Click Increment 3 times\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:665
+msgid "# Counter label now shows \"Count: 3\"\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:667
+msgid "# Type a name\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:669
+msgid "'{\"text\":\"Perry\"}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:670
+msgid "# Set slider to 80%\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:672
+msgid "'{\"value\":0.8}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:673
+msgid "# Toggle dark mode on\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:676
+msgid "# Screenshot\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:685
+msgid ""
+"Geisterhand operates as three cooperating components connected by thread-"
+"safe queues:"
+msgstr ""
+
+#: src/testing/geisterhand.md:729
+msgid "Lifecycle"
+msgstr ""
+
+#: src/testing/geisterhand.md:731
+msgid ""
+"**Startup**: When `--enable-geisterhand` is used, the compiled binary calls "
+"`perry_geisterhand_start(port)` during initialization. This spawns a "
+"background thread running a `tiny-http` server."
+msgstr ""
+
+#: src/testing/geisterhand.md:733
+msgid ""
+"**Widget Registration**: As UI widgets are created (Button, TextField, "
+"Slider, etc.), each one calls `perry_geisterhand_register(handle, "
+"widget_type, callback_kind, closure_f64, label)` to register its callback in"
+" the global registry. This is gated behind `#[cfg(feature = "
+"\"geisterhand\")]` so normal builds have zero overhead."
+msgstr ""
+
+#: src/testing/geisterhand.md:735
+msgid ""
+"**HTTP Requests**: When a request arrives (e.g., `POST /click/3`), the "
+"server looks up handle 3 in the registry, finds the associated closure, and "
+"pushes a `PendingAction::InvokeCallback` onto the pending actions queue."
+msgstr ""
+
+#: src/testing/geisterhand.md:737
+msgid ""
+"**Main-Thread Dispatch**: The platform's timer (NSTimer on macOS, glib "
+"timeout on GTK4, WM_TIMER on Windows, etc.) calls `perry_geisterhand_pump()`"
+" every ~8ms. This drains the pending actions queue and executes callbacks on"
+" the main thread, which is required for UI safety."
+msgstr ""
+
+#: src/testing/geisterhand.md:739
+msgid ""
+"**Screenshot Capture**: Screenshots use `Condvar` synchronization — the HTTP"
+" thread queues a `CaptureScreenshot` action, then blocks waiting on a "
+"condition variable. The main thread's pump executes the platform-specific "
+"capture, stores the PNG data, and signals the condvar. Timeout: 5 seconds."
+msgstr ""
+
+#: src/testing/geisterhand.md:741
+msgid "Thread Safety"
+msgstr ""
+
+#: src/testing/geisterhand.md:743
+msgid ""
+"**Widget Registry**: Protected by `Mutex`. Read by the HTTP server (to list "
+"widgets and look up handles), written by the main thread (during widget "
+"creation)."
+msgstr ""
+
+#: src/testing/geisterhand.md:744
+msgid ""
+"**Pending Actions Queue**: Protected by `Mutex`. Written by HTTP server "
+"thread, drained by main thread in `pump()`."
+msgstr ""
+
+#: src/testing/geisterhand.md:745
+msgid ""
+"**Screenshot Result**: Protected by `Mutex` + `Condvar`. HTTP thread waits, "
+"main thread signals."
+msgstr ""
+
+#: src/testing/geisterhand.md:746
+msgid ""
+"**Chaos Mode State**: Uses `AtomicBool` (running flag) and `AtomicU64` "
+"(event counter) for lock-free status checks."
+msgstr ""
+
+#: src/testing/geisterhand.md:748
+msgid "NaN-Boxing Bridge"
+msgstr ""
+
+#: src/testing/geisterhand.md:750
+msgid ""
+"When geisterhand needs to pass values to widget callbacks, it must create "
+"properly NaN-boxed values:"
+msgstr ""
+
+#: src/testing/geisterhand.md:752
+msgid ""
+"**Strings** (for TextField): Calls `js_string_from_bytes(ptr, len)` to "
+"allocate a runtime string, then `js_nanbox_string(ptr)` to wrap it with "
+"STRING_TAG (0x7FFF)."
+msgstr ""
+
+#: src/testing/geisterhand.md:753
+msgid ""
+"**Numbers** (for Slider): Passes the raw `f64` value directly (numbers are "
+"their own NaN-boxed representation)."
+msgstr ""
+
+#: src/testing/geisterhand.md:754
+msgid ""
+"**Booleans** (for Toggle/chaos): Uses `TAG_TRUE` (0x7FFC000000000004) or "
+"`TAG_FALSE` (0x7FFC000000000003)."
+msgstr ""
+
+#: src/testing/geisterhand.md:758
+msgid "Build Details"
+msgstr ""
+
+#: src/testing/geisterhand.md:760
+msgid "Auto-Build"
+msgstr ""
+
+#: src/testing/geisterhand.md:762
+msgid ""
+"When you pass `--enable-geisterhand` (or `--geisterhand-port`), Perry "
+"automatically builds the required libraries on first use if they're not "
+"already cached:"
+msgstr ""
+
+#: src/testing/geisterhand.md:771
+msgid "Platform crate selection is automatic based on `--target`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:773 src/cli/flags.md:20
+msgid "Target"
+msgstr ""
+
+#: src/testing/geisterhand.md:773
+msgid "UI Crate"
+msgstr ""
+
+#: src/testing/geisterhand.md:775
+msgid "(default/macOS)"
+msgstr ""
+
+#: src/testing/geisterhand.md:775 src/contributing/architecture.md:37
+msgid "`perry-ui-macos`"
+msgstr ""
+
+#: src/testing/geisterhand.md:776
+msgid "`ios` / `ios-simulator`"
+msgstr ""
+
+#: src/testing/geisterhand.md:776 src/contributing/architecture.md:38
+msgid "`perry-ui-ios`"
+msgstr ""
+
+#: src/testing/geisterhand.md:777 src/cli/commands.md:66
+#: src/cli/commands.md:238 src/cli/flags.md:27
+msgid "`android`"
+msgstr ""
+
+#: src/testing/geisterhand.md:777
+msgid "`perry-ui-android`"
+msgstr ""
+
+#: src/testing/geisterhand.md:778 src/cli/commands.md:239 src/cli/flags.md:37
+msgid "`linux`"
+msgstr ""
+
+#: src/testing/geisterhand.md:778
+msgid "`perry-ui-gtk4`"
+msgstr ""
+
+#: src/testing/geisterhand.md:779 src/cli/flags.md:36
+msgid "`windows`"
+msgstr ""
+
+#: src/testing/geisterhand.md:779
+msgid "`perry-ui-windows`"
+msgstr ""
+
+#: src/testing/geisterhand.md:781
+msgid "Separate Target Directory"
+msgstr ""
+
+#: src/testing/geisterhand.md:783
+msgid ""
+"Geisterhand libraries are built into `target/geisterhand/` (via "
+"`CARGO_TARGET_DIR`) to avoid interfering with normal builds. This means your"
+" first geisterhand build takes a moment, but subsequent builds reuse the "
+"cached libraries."
+msgstr ""
+
+#: src/testing/geisterhand.md:785
+msgid "Feature Flags"
+msgstr ""
+
+#: src/testing/geisterhand.md:787
+msgid ""
+"All geisterhand code is behind `#[cfg(feature = \"geisterhand\")]` feature "
+"gates:"
+msgstr ""
+
+#: src/testing/geisterhand.md:789
+msgid ""
+"**`perry-runtime/geisterhand`**: Compiles the `geisterhand_registry` module "
+"— widget registry, action queue, pump function, screenshot coordination."
+msgstr ""
+
+#: src/testing/geisterhand.md:790
+msgid ""
+"**`perry-ui-{platform}/geisterhand`**: Adds `perry_geisterhand_register()` "
+"calls to widget constructors and `perry_geisterhand_pump()` to the platform "
+"timer."
+msgstr ""
+
+#: src/testing/geisterhand.md:792
+msgid ""
+"When the feature is not enabled, no geisterhand code is compiled — zero "
+"binary size overhead and zero runtime cost."
+msgstr ""
+
+#: src/testing/geisterhand.md:794
+msgid "Linking"
+msgstr ""
+
+#: src/testing/geisterhand.md:796
+msgid "The compiled binary links three additional static libraries:"
+msgstr ""
+
+#: src/testing/geisterhand.md:797
+msgid ""
+"`libperry_runtime.a` (geisterhand-featured build, replaces the normal "
+"runtime)"
+msgstr ""
+
+#: src/testing/geisterhand.md:798
+msgid ""
+"`libperry_ui_{platform}.a` (geisterhand-featured build, replaces the normal "
+"UI lib)"
+msgstr ""
+
+#: src/testing/geisterhand.md:799
+msgid "`libperry_ui_geisterhand.a` (HTTP server + chaos mode)"
+msgstr ""
+
+#: src/testing/geisterhand.md:801
+msgid "Manual Build"
+msgstr ""
+
+#: src/testing/geisterhand.md:803
+msgid "If auto-build fails or you want to cross-compile manually:"
+msgstr ""
+
+#: src/testing/geisterhand.md:806
+msgid "# Build geisterhand libs for macOS\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:807
+msgid "target/geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:822
+msgid "Security"
+msgstr ""
+
+#: src/testing/geisterhand.md:824
+msgid ""
+"Geisterhand binds to `0.0.0.0` on the configured port (default 7676). This "
+"means it is **accessible from the local network** — any device on the same "
+"network can interact with your app, capture screenshots, or trigger chaos "
+"mode."
+msgstr ""
+
+#: src/testing/geisterhand.md:826
+msgid ""
+"**Do not ship geisterhand-enabled binaries to production or to end users.**"
+msgstr ""
+
+#: src/testing/geisterhand.md:828
+msgid ""
+"Geisterhand is a development and testing tool only. The feature-gate system "
+"ensures it cannot accidentally be included in normal builds — you must "
+"explicitly pass `--enable-geisterhand` or `--geisterhand-port`."
+msgstr ""
+
+#: src/testing/geisterhand.md:832
+msgid "Troubleshooting"
+msgstr ""
+
+#: src/testing/geisterhand.md:834
+msgid "\"Connection refused\" on port 7676"
+msgstr ""
+
+#: src/testing/geisterhand.md:836
+msgid ""
+"Ensure you compiled with `--enable-geisterhand` or `--geisterhand-port`"
+msgstr ""
+
+#: src/testing/geisterhand.md:837
+msgid ""
+"Check that the app has fully started (look for `[geisterhand] listening "
+"on...` in stderr)"
+msgstr ""
+
+#: src/testing/geisterhand.md:838
+msgid "Verify the port isn't in use by another process: `lsof -i :7676`"
+msgstr ""
+
+#: src/testing/geisterhand.md:840
+msgid "Widget handles not found"
+msgstr ""
+
+#: src/testing/geisterhand.md:842
+msgid ""
+"Handles are assigned at widget creation time. If you query `/widgets` before"
+" the UI is fully constructed, some widgets may not be registered yet."
+msgstr ""
+
+#: src/testing/geisterhand.md:843
+msgid "Wait for `GET /health` to return `{\"status\":\"ok\"}` before interacting."
+msgstr ""
+
+#: src/testing/geisterhand.md:845
+msgid "Screenshot returns empty data"
+msgstr ""
+
+#: src/testing/geisterhand.md:847
+msgid ""
+"Screenshot capture has a 5-second timeout. If the main thread is blocked "
+"(e.g., by a long-running synchronous operation), the screenshot will time "
+"out and return empty data."
+msgstr ""
+
+#: src/testing/geisterhand.md:848
+msgid ""
+"On macOS, ensure the app has a visible window (minimized windows may not "
+"capture correctly)."
+msgstr ""
+
+#: src/testing/geisterhand.md:850
+msgid "Auto-build fails"
+msgstr ""
+
+#: src/testing/geisterhand.md:852
+msgid "Ensure you have a working Rust toolchain (`rustup show`)"
+msgstr ""
+
+#: src/testing/geisterhand.md:853
+msgid ""
+"For cross-compilation targets, install the appropriate target: `rustup "
+"target add aarch64-apple-ios`"
+msgstr ""
+
+#: src/testing/geisterhand.md:854
+msgid ""
+"Check that the Perry source tree is accessible (auto-build searches upward "
+"from the `perry` executable for the workspace root)"
+msgstr ""
+
+#: src/testing/geisterhand.md:856
+msgid "Chaos mode crashes the app"
+msgstr ""
+
+#: src/testing/geisterhand.md:858
+msgid ""
+"That's the point — chaos mode found a bug. Check the app's stderr output for"
+" panic messages or stack traces. Common causes:"
+msgstr ""
+
+#: src/testing/geisterhand.md:859
+msgid ""
+"Callback handlers that assume valid state but receive unexpected values"
+msgstr ""
+
+#: src/testing/geisterhand.md:860
+msgid "Missing null checks on state values"
+msgstr ""
+
+#: src/testing/geisterhand.md:861
+msgid "Race conditions in state updates"
+msgstr ""
+
+#: src/cli/commands.md:1
+msgid "CLI Commands"
+msgstr ""
+
+#: src/cli/commands.md:3
+msgid ""
+"Perry provides 11 commands for compiling, checking, running, publishing, and"
+" managing your projects."
+msgstr ""
+
+#: src/cli/commands.md:5
+msgid ""
+"See also: [perry.toml Reference](perry-toml.md) for project configuration."
+msgstr ""
+
+#: src/cli/commands.md:7
+msgid "compile"
+msgstr ""
+
+#: src/cli/commands.md:9
+msgid "Compile TypeScript to a native executable."
+msgstr ""
+
+#: src/cli/commands.md:12
+msgid "# Or shorthand (auto-detects compile):\n"
+msgstr ""
+
+#: src/cli/commands.md:17 src/cli/commands.md:109 src/cli/commands.md:148
+#: src/cli/commands.md:181 src/cli/commands.md:195 src/cli/commands.md:248
+#: src/cli/commands.md:260 src/cli/flags.md:9 src/cli/flags.md:50
+#: src/cli/flags.md:58 src/cli/flags.md:66 src/cli/flags.md:73
+msgid "Flag"
+msgstr ""
+
+#: src/cli/commands.md:19 src/cli/commands.md:111 src/cli/commands.md:243
+msgid "`-o, --output <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:19
+msgid "Output file path"
+msgstr ""
+
+#: src/cli/commands.md:20
+msgid "`--target <TARGET>`"
+msgstr ""
+
+#: src/cli/commands.md:20
+msgid "Platform target (see [Compiler Flags](flags.md))"
+msgstr ""
+
+#: src/cli/commands.md:21
+msgid "`--output-type <TYPE>`"
+msgstr ""
+
+#: src/cli/commands.md:21
+msgid "`executable` (default) or `dylib` (plugin)"
+msgstr ""
+
+#: src/cli/commands.md:22 src/cli/flags.md:52
+msgid "`--print-hir`"
+msgstr ""
+
+#: src/cli/commands.md:22
+msgid "Print HIR intermediate representation"
+msgstr ""
+
+#: src/cli/commands.md:23 src/cli/flags.md:53
+msgid "`--no-link`"
+msgstr ""
+
+#: src/cli/commands.md:23
+msgid "Produce object file only, skip linking"
+msgstr ""
+
+#: src/cli/commands.md:24 src/cli/flags.md:54
+msgid "`--keep-intermediates`"
+msgstr ""
+
+#: src/cli/commands.md:24
+msgid "Keep `.o` and `.asm` files"
+msgstr ""
+
+#: src/cli/commands.md:25 src/cli/commands.md:71 src/cli/flags.md:75
+msgid "`--enable-js-runtime`"
+msgstr ""
+
+#: src/cli/commands.md:25
+msgid "Enable V8 JavaScript runtime fallback"
+msgstr ""
+
+#: src/cli/commands.md:26 src/cli/commands.md:72 src/cli/flags.md:76
+msgid "`--type-check`"
+msgstr ""
+
+#: src/cli/commands.md:26 src/cli/commands.md:72
+msgid "Enable type checking via tsgo"
+msgstr ""
+
+#: src/cli/commands.md:27 src/cli/flags.md:60
+msgid "`--minify`"
+msgstr ""
+
+#: src/cli/commands.md:27 src/cli/flags.md:60
+msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
+msgstr ""
+
+#: src/cli/commands.md:28
+msgid "`--app-bundle-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:28
+msgid "Bundle ID (required for widget targets)"
+msgstr ""
+
+#: src/cli/commands.md:29
+msgid "`--bundle-extensions <DIR>`"
+msgstr ""
+
+#: src/cli/commands.md:29
+msgid "Bundle TypeScript extensions from directory"
+msgstr ""
+
+#: src/cli/commands.md:32
+msgid "# Basic compilation\n"
+msgstr ""
+
+#: src/cli/commands.md:34
+msgid "# Cross-compile for iOS Simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:37
+msgid "# Build a plugin\n"
+msgstr ""
+
+#: src/cli/commands.md:40
+msgid "# Debug: view intermediate representation\n"
+msgstr ""
+
+#: src/cli/commands.md:43
+msgid "# Build an iOS widget\n"
+msgstr ""
+
+#: src/cli/commands.md:50
+msgid "Compile and launch your app in one step."
+msgstr ""
+
+#: src/cli/commands.md:53
+msgid "# Auto-detect entry file\n"
+msgstr ""
+
+#: src/cli/commands.md:54
+msgid "# Run on iOS device/simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:55
+msgid "# Run on Apple Vision Pro simulator/device\n"
+msgstr ""
+
+#: src/cli/commands.md:56
+msgid "# Run on Android device\n"
+msgstr ""
+
+#: src/cli/commands.md:57
+msgid "# Forward args to your program\n"
+msgstr ""
+
+#: src/cli/commands.md:60 src/cli/commands.md:233
+msgid "Argument / Flag"
+msgstr ""
+
+#: src/cli/commands.md:62 src/cli/commands.md:236 src/cli/flags.md:24
+msgid "`ios`"
+msgstr ""
+
+#: src/cli/commands.md:62
+msgid "Target iOS (device or simulator)"
+msgstr ""
+
+#: src/cli/commands.md:63 src/cli/commands.md:237 src/cli/flags.md:26
+msgid "`visionos`"
+msgstr ""
+
+#: src/cli/commands.md:63
+msgid "Target visionOS (device or simulator)"
+msgstr ""
+
+#: src/cli/commands.md:64 src/cli/commands.md:235
+msgid "`macos`"
+msgstr ""
+
+#: src/cli/commands.md:64
+msgid "Target macOS (default on macOS host)"
+msgstr ""
+
+#: src/cli/commands.md:65 src/cli/flags.md:35
+msgid "`web`"
+msgstr ""
+
+#: src/cli/commands.md:65
+msgid "Target web (opens in browser)"
+msgstr ""
+
+#: src/cli/commands.md:66
+msgid "Target Android device"
+msgstr ""
+
+#: src/cli/commands.md:67
+msgid "`--simulator <UDID>`"
+msgstr ""
+
+#: src/cli/commands.md:67
+msgid "Specify iOS simulator by UDID"
+msgstr ""
+
+#: src/cli/commands.md:68
+msgid "`--device <UDID>`"
+msgstr ""
+
+#: src/cli/commands.md:68
+msgid "Specify iOS physical device by UDID"
+msgstr ""
+
+#: src/cli/commands.md:69
+msgid "`--local`"
+msgstr ""
+
+#: src/cli/commands.md:69
+msgid "Force local compilation (no remote fallback)"
+msgstr ""
+
+#: src/cli/commands.md:70
+msgid "`--remote`"
+msgstr ""
+
+#: src/cli/commands.md:70
+msgid "Force remote build via Perry Hub"
+msgstr ""
+
+#: src/cli/commands.md:71
+msgid "Enable V8 JavaScript runtime"
+msgstr ""
+
+#: src/cli/commands.md:73 src/cli/commands.md:113
+msgid "`--`"
+msgstr ""
+
+#: src/cli/commands.md:73
+msgid "Separator for program arguments"
+msgstr ""
+
+#: src/cli/commands.md:75
+msgid "**Entry file detection** (checked in order):"
+msgstr ""
+
+#: src/cli/commands.md:76
+msgid "`perry.toml` → `[project] entry` field"
+msgstr ""
+
+#: src/cli/commands.md:77
+msgid "`src/main.ts`"
+msgstr ""
+
+#: src/cli/commands.md:78
+msgid "`main.ts`"
+msgstr ""
+
+#: src/cli/commands.md:80
+msgid ""
+"**Device detection**: When targeting iOS, Perry auto-discovers available "
+"simulators (via `simctl`) and physical devices (via `devicectl`). For "
+"Android, it uses `adb`. When multiple targets are found, an interactive "
+"prompt lets you choose."
+msgstr ""
+
+#: src/cli/commands.md:82
+msgid ""
+"**Remote build fallback**: If cross-compilation toolchains aren't installed "
+"locally (e.g., Apple mobile targets on a machine without Xcode), `perry run "
+"ios` and `perry run visionos` can fall back to Perry Hub's build server when"
+" the backend supports the target. Use `--local` or `--remote` to force "
+"either path."
+msgstr ""
+
+#: src/cli/commands.md:85
+msgid "# Run a CLI program\n"
+msgstr ""
+
+#: src/cli/commands.md:87
+msgid "# Run on a specific simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:90
+msgid "# Force remote build\n"
+msgstr ""
+
+#: src/cli/commands.md:93
+msgid "# Run web target\n"
+msgstr ""
+
+#: src/cli/commands.md:98
+msgid "dev"
+msgstr ""
+
+#: src/cli/commands.md:100
+msgid ""
+"Watch your TypeScript source tree and auto-recompile + relaunch on every "
+"save."
+msgstr ""
+
+#: src/cli/commands.md:103
+msgid "# watch + rebuild + relaunch on save\n"
+msgstr ""
+
+#: src/cli/commands.md:104
+msgid "# forward args to the child\n"
+msgstr ""
+
+#: src/cli/commands.md:105
+msgid "# watch an extra directory\n"
+msgstr ""
+
+#: src/cli/commands.md:106
+msgid "# override output path\n"
+msgstr ""
+
+#: src/cli/commands.md:111
+msgid "Output binary path (default: `.perry-dev/<entry-stem>`)"
+msgstr ""
+
+#: src/cli/commands.md:112
+msgid "`--watch <DIR>`"
+msgstr ""
+
+#: src/cli/commands.md:112
+msgid "Extra directories to watch (comma-separated or repeated)"
+msgstr ""
+
+#: src/cli/commands.md:113
+msgid "Separator — everything after is forwarded to the compiled binary"
+msgstr ""
+
+#: src/cli/commands.md:115
+msgid "**How it works:**"
+msgstr ""
+
+#: src/cli/commands.md:117
+msgid ""
+"Resolves the entry, computes the **project root** (walks up until it finds a"
+" `package.json` or `perry.toml`; falls back to the entry's parent "
+"directory)."
+msgstr ""
+
+#: src/cli/commands.md:118
+msgid ""
+"Does an initial `perry compile`, then spawns the resulting binary with stdio"
+" inherited."
+msgstr ""
+
+#: src/cli/commands.md:119
+msgid ""
+"Watches the project root (plus any `--watch` dirs) recursively using the "
+"`notify` crate. A 300 ms **debounce** window collapses editor \"save "
+"storms\" into one rebuild."
+msgstr ""
+
+#: src/cli/commands.md:120
+msgid ""
+"On each relevant change: kill the running child, recompile, relaunch. A "
+"failed build leaves the old child dead and waits for the next change; no "
+"crash loop."
+msgstr ""
+
+#: src/cli/commands.md:122
+msgid "**What counts as a \"relevant\" change:**"
+msgstr ""
+
+#: src/cli/commands.md:123
+msgid ""
+"**Trigger extensions:** `.ts`, `.tsx`, `.mts`, `.cts`, `.json`, `.toml`"
+msgstr ""
+
+#: src/cli/commands.md:124
+msgid ""
+"**Ignored directories (not watched, never retrigger):** `node_modules`, "
+"`target`, `.git`, `dist`, `build`, `.perry-dev`, `.perry-cache`"
+msgstr ""
+
+#: src/cli/commands.md:126
+msgid "**Benchmarks** (trivial single-file program, macOS):"
+msgstr ""
+
+#: src/cli/commands.md:128
+msgid "Phase"
+msgstr ""
+
+#: src/cli/commands.md:128
+msgid "Time"
+msgstr ""
+
+#: src/cli/commands.md:130
+msgid "Initial build (cold — runtime + stdlib rebuilt by auto-optimize)"
+msgstr ""
+
+#: src/cli/commands.md:130
+msgid "~15 s"
+msgstr ""
+
+#: src/cli/commands.md:131
+msgid "Post-edit rebuild (hot libs cached on disk)"
+msgstr ""
+
+#: src/cli/commands.md:131
+msgid "**~330 ms**"
+msgstr ""
+
+#: src/cli/commands.md:133
+msgid ""
+"The speedup on hot rebuilds comes from Perry's existing auto-optimize "
+"library cache. Multi-module projects will still recompile every changed "
+"module on each save — see the V2 note below for planned incremental work."
+msgstr ""
+
+#: src/cli/commands.md:135
+msgid "**Not yet in scope (V2+):**"
+msgstr ""
+
+#: src/cli/commands.md:136
+msgid "In-memory AST cache (reuse SWC parses across rebuilds)."
+msgstr ""
+
+#: src/cli/commands.md:137
+msgid "Per-module `.o` cache on disk (only re-codegen the changed module)."
+msgstr ""
+
+#: src/cli/commands.md:138
+msgid ""
+"State preservation across rebuilds / HMR — \"fast restart\" is the honest "
+"target."
+msgstr ""
+
+#: src/cli/commands.md:140
+msgid "check"
+msgstr ""
+
+#: src/cli/commands.md:142
+msgid "Validate TypeScript for Perry compatibility without compiling."
+msgstr ""
+
+#: src/cli/commands.md:150
+msgid "`--check-deps`"
+msgstr ""
+
+#: src/cli/commands.md:150
+msgid "Check `node_modules` for compatibility"
+msgstr ""
+
+#: src/cli/commands.md:151
+msgid "`--deep-deps`"
+msgstr ""
+
+#: src/cli/commands.md:151
+msgid "Scan all transitive dependencies"
+msgstr ""
+
+#: src/cli/commands.md:152
+msgid "`--all`"
+msgstr ""
+
+#: src/cli/commands.md:152
+msgid "Show all issues including hints"
+msgstr ""
+
+#: src/cli/commands.md:153
+msgid "`--strict`"
+msgstr ""
+
+#: src/cli/commands.md:153
+msgid "Treat warnings as errors"
+msgstr ""
+
+#: src/cli/commands.md:154
+msgid "`--fix`"
+msgstr ""
+
+#: src/cli/commands.md:154
+msgid "Automatically apply fixes"
+msgstr ""
+
+#: src/cli/commands.md:155
+msgid "`--fix-dry-run`"
+msgstr ""
+
+#: src/cli/commands.md:155
+msgid "Preview fixes without modifying files"
+msgstr ""
+
+#: src/cli/commands.md:156
+msgid "`--fix-unsafe`"
+msgstr ""
+
+#: src/cli/commands.md:156
+msgid "Include medium-confidence fixes"
+msgstr ""
+
+#: src/cli/commands.md:159
+msgid "# Check a single file\n"
+msgstr ""
+
+#: src/cli/commands.md:161
+msgid "# Check with dependency analysis\n"
+msgstr ""
+
+#: src/cli/commands.md:164
+msgid "# Auto-fix issues\n"
+msgstr ""
+
+#: src/cli/commands.md:167
+msgid "# Preview fixes without applying\n"
+msgstr ""
+
+#: src/cli/commands.md:172
+msgid "init"
+msgstr ""
+
+#: src/cli/commands.md:174
+msgid "Create a new Perry project."
+msgstr ""
+
+#: src/cli/commands.md:183
+msgid "`--name <NAME>`"
+msgstr ""
+
+#: src/cli/commands.md:183
+msgid "Project name (defaults to directory name)"
+msgstr ""
+
+#: src/cli/commands.md:185
+msgid "Creates `perry.toml`, `src/main.ts`, and `.gitignore`."
+msgstr ""
+
+#: src/cli/commands.md:187
+msgid "doctor"
+msgstr ""
+
+#: src/cli/commands.md:189
+msgid "Check your Perry installation and environment."
+msgstr ""
+
+#: src/cli/commands.md:197
+msgid "`--quiet`"
+msgstr ""
+
+#: src/cli/commands.md:197
+msgid "Only report failures"
+msgstr ""
+
+#: src/cli/commands.md:199
+msgid "Checks:"
+msgstr ""
+
+#: src/cli/commands.md:200
+msgid "Perry version"
+msgstr ""
+
+#: src/cli/commands.md:201
+msgid "System linker availability (cc/MSVC)"
+msgstr ""
+
+#: src/cli/commands.md:202
+msgid "Runtime library"
+msgstr ""
+
+#: src/cli/commands.md:203
+msgid "Project configuration"
+msgstr ""
+
+#: src/cli/commands.md:204
+msgid "Available updates"
+msgstr ""
+
+#: src/cli/commands.md:206
+msgid "explain"
+msgstr ""
+
+#: src/cli/commands.md:208
+msgid "Get detailed explanations for error codes."
+msgstr ""
+
+#: src/cli/commands.md:214
+msgid "Error code families:"
+msgstr ""
+
+#: src/cli/commands.md:215
+msgid "**P** — Parse errors"
+msgstr ""
+
+#: src/cli/commands.md:216
+msgid "**T** — Type errors"
+msgstr ""
+
+#: src/cli/commands.md:217
+msgid "**U** — Unsupported features"
+msgstr ""
+
+#: src/cli/commands.md:218
+msgid "**D** — Dependency issues"
+msgstr ""
+
+#: src/cli/commands.md:220
+msgid ""
+"Each explanation includes the error description, example code, and suggested"
+" fix."
+msgstr ""
+
+#: src/cli/commands.md:222
+msgid "publish"
+msgstr ""
+
+#: src/cli/commands.md:224
+msgid "Build, sign, and distribute your app."
+msgstr ""
+
+#: src/cli/commands.md:235
+msgid "Build for macOS (App Store/notarization)"
+msgstr ""
+
+#: src/cli/commands.md:236
+msgid "Build for iOS (App Store/TestFlight)"
+msgstr ""
+
+#: src/cli/commands.md:237
+msgid "Build for visionOS"
+msgstr ""
+
+#: src/cli/commands.md:238
+msgid "Build for Android (Google Play)"
+msgstr ""
+
+#: src/cli/commands.md:239
+msgid "Build for Linux (AppImage/deb/rpm)"
+msgstr ""
+
+#: src/cli/commands.md:240
+msgid "`--server <URL>`"
+msgstr ""
+
+#: src/cli/commands.md:240
+msgid "Build server (default: `https://hub.perryts.com`)"
+msgstr ""
+
+#: src/cli/commands.md:241
+msgid "`--license-key <KEY>`"
+msgstr ""
+
+#: src/cli/commands.md:241 src/cli/perry-toml.md:493
+msgid "Perry Hub license key"
+msgstr ""
+
+#: src/cli/commands.md:242
+msgid "`--project <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:242
+msgid "Project directory"
+msgstr ""
+
+#: src/cli/commands.md:243
+msgid "Artifact output directory (default: `dist`)"
+msgstr ""
+
+#: src/cli/commands.md:244
+msgid "`--no-download`"
+msgstr ""
+
+#: src/cli/commands.md:244
+msgid "Skip artifact download"
+msgstr ""
+
+#: src/cli/commands.md:246
+msgid "Apple-specific flags:"
+msgstr ""
+
+#: src/cli/commands.md:250
+msgid "`--apple-team-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:250
+msgid "Developer Team ID"
+msgstr ""
+
+#: src/cli/commands.md:251
+msgid "`--apple-identity <NAME>`"
+msgstr ""
+
+#: src/cli/commands.md:251
+msgid "Signing identity"
+msgstr ""
+
+#: src/cli/commands.md:252
+msgid "`--apple-p8-key <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:252
+msgid "App Store Connect .p8 key"
+msgstr ""
+
+#: src/cli/commands.md:253
+msgid "`--apple-key-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:253
+msgid "App Store Connect API Key ID"
+msgstr ""
+
+#: src/cli/commands.md:254
+msgid "`--apple-issuer-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:254
+msgid "App Store Connect Issuer ID"
+msgstr ""
+
+#: src/cli/commands.md:255
+msgid "`--certificate <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:255
+msgid ".p12 certificate bundle"
+msgstr ""
+
+#: src/cli/commands.md:256
+msgid "`--provisioning-profile <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:256
+msgid ".mobileprovision file (iOS)"
+msgstr ""
+
+#: src/cli/commands.md:258
+msgid "Android-specific flags:"
+msgstr ""
+
+#: src/cli/commands.md:262
+msgid "`--android-keystore <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:262
+msgid ".jks/.keystore file"
+msgstr ""
+
+#: src/cli/commands.md:263
+msgid "`--android-keystore-password <PASS>`"
+msgstr ""
+
+#: src/cli/commands.md:263 src/cli/perry-toml.md:507
+msgid "Keystore password"
+msgstr ""
+
+#: src/cli/commands.md:264
+msgid "`--android-key-alias <ALIAS>`"
+msgstr ""
+
+#: src/cli/commands.md:264
+msgid "Key alias"
+msgstr ""
+
+#: src/cli/commands.md:265
+msgid "`--android-key-password <PASS>`"
+msgstr ""
+
+#: src/cli/commands.md:265
+msgid "Key password"
+msgstr ""
+
+#: src/cli/commands.md:266
+msgid "`--google-play-key <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:266
+msgid "Google Play service account JSON"
+msgstr ""
+
+#: src/cli/commands.md:268
+msgid "On first use, `publish` auto-registers a free license key."
+msgstr ""
+
+#: src/cli/commands.md:270
+msgid "setup"
+msgstr ""
+
+#: src/cli/commands.md:272
+msgid ""
+"Interactive credential wizard for app distribution, plus toolchain setup for"
+" Windows."
+msgstr ""
+
+#: src/cli/commands.md:275
+msgid "# Show platform menu\n"
+msgstr ""
+
+#: src/cli/commands.md:276
+msgid "# macOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:277
+msgid "# iOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:278
+msgid "# visionOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:279
+msgid "# Android setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:280
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
+msgstr ""
+
+#: src/cli/commands.md:283
+msgid ""
+"`perry setup windows` downloads the Microsoft CRT + Windows SDK libraries "
+"(~1.5 GB) so Perry can link without Visual Studio Build Tools. Requires LLVM"
+" (`winget install LLVM.LLVM`) and prompts to accept the Microsoft "
+"redistributable license — pass `--accept-license` to skip the prompt for CI."
+" Output lands at `%LOCALAPPDATA%\\perry\\windows-sdk`. See the [Windows "
+"platform guide](../platforms/windows.md) for the full toolchain comparison."
+msgstr ""
+
+#: src/cli/commands.md:285
+msgid "Credential wizards store their output in `~/.perry/config.toml`."
+msgstr ""
+
+#: src/cli/commands.md:287
+msgid "update"
+msgstr ""
+
+#: src/cli/commands.md:289
+msgid "Check for and install Perry updates."
+msgstr ""
+
+#: src/cli/commands.md:292
+msgid "# Update to latest\n"
+msgstr ""
+
+#: src/cli/commands.md:293
+msgid "# Check without installing\n"
+msgstr ""
+
+#: src/cli/commands.md:294
+msgid "# Ignore 24h cache\n"
+msgstr ""
+
+#: src/cli/commands.md:297
+msgid "Update sources (checked in order):"
+msgstr ""
+
+#: src/cli/commands.md:298
+msgid "Custom server (env/config)"
+msgstr ""
+
+#: src/cli/commands.md:299
+msgid "Perry Hub"
+msgstr ""
+
+#: src/cli/commands.md:300
+msgid "GitHub API"
+msgstr ""
+
+#: src/cli/commands.md:302
+msgid ""
+"Opt out of automatic update checks with `PERRY_NO_UPDATE_CHECK=1` or "
+"`CI=true`."
+msgstr ""
+
+#: src/cli/commands.md:304
+msgid "i18n"
+msgstr ""
+
+#: src/cli/commands.md:306
+msgid ""
+"Internationalization tools for managing locale files and extracting "
+"localizable strings."
+msgstr ""
+
+#: src/cli/commands.md:310
+msgid "Scan source files and generate/update locale JSON scaffolds:"
+msgstr ""
+
+#: src/cli/commands.md:316
+msgid ""
+"Detects string literals in UI component calls (`Button`, `Text`, `Label`, "
+"etc.) and `t()` calls. Creates `locales/*.json` files based on the `[i18n]` "
+"config in `perry.toml`."
+msgstr ""
+
+#: src/cli/commands.md:318
+msgid "See the [i18n documentation](../i18n/overview.md) for full details."
+msgstr ""
+
+#: src/cli/commands.md:322
+msgid "[Compiler Flags](flags.md) — Complete flag reference"
+msgstr ""
+
+#: src/cli/commands.md:323
+msgid "[Getting Started](../getting-started/installation.md) — Installation"
+msgstr ""
+
+#: src/cli/flags.md:3
+msgid "Complete reference for all Perry CLI flags."
+msgstr ""
+
+#: src/cli/flags.md:5
+msgid "Global Flags"
+msgstr ""
+
+#: src/cli/flags.md:7
+msgid "Available on all commands:"
+msgstr ""
+
+#: src/cli/flags.md:11
+msgid "`--format text\\|json`"
+msgstr ""
+
+#: src/cli/flags.md:11
+msgid "Output format (default: `text`)"
+msgstr ""
+
+#: src/cli/flags.md:12
+msgid "`-v, --verbose`"
+msgstr ""
+
+#: src/cli/flags.md:12
+msgid "Increase verbosity (repeatable: `-v`, `-vv`, `-vvv`)"
+msgstr ""
+
+#: src/cli/flags.md:13
+msgid "`-q, --quiet`"
+msgstr ""
+
+#: src/cli/flags.md:13
+msgid "Suppress non-error output"
+msgstr ""
+
+#: src/cli/flags.md:14
+msgid "`--no-color`"
+msgstr ""
+
+#: src/cli/flags.md:14
+msgid "Disable ANSI color codes"
+msgstr ""
+
+#: src/cli/flags.md:16
+msgid "Compilation Targets"
+msgstr ""
+
+#: src/cli/flags.md:18
+msgid "Use `--target` to cross-compile:"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "_(none)_"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "Current platform"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "Default behavior"
+msgstr ""
+
+#: src/cli/flags.md:23
+msgid "`ios-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:23
+msgid "ARM64 simulator binary"
+msgstr ""
+
+#: src/cli/flags.md:24
+msgid "ARM64 device binary"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "`visionos-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "visionOS Simulator"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "Apple Vision Pro simulator build"
+msgstr ""
+
+#: src/cli/flags.md:26
+msgid "visionOS Device"
+msgstr ""
+
+#: src/cli/flags.md:26
+msgid "Apple Vision Pro device build"
+msgstr ""
+
+#: src/cli/flags.md:27
+msgid "ARM64/ARMv7"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "`ios-widget`"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "iOS Widget"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "WidgetKit extension (requires `--app-bundle-id`)"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "`ios-widget-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "iOS Widget (Sim)"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "Widget for simulator"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "`watchos-widget`"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "watchOS Complication"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "WidgetKit extension for Apple Watch"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "`watchos-widget-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "watchOS Widget (Sim)"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "Widget for watchOS simulator"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "`android-widget`"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "Android Widget"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "Android App Widget (AppWidgetProvider)"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "`wearos-tile`"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "Wear OS Tile"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "Wear OS Tile (TileService)"
+msgstr ""
+
+#: src/cli/flags.md:34
+msgid "`wasm`"
+msgstr ""
+
+#: src/cli/flags.md:34
+msgid "Self-contained HTML with WASM or raw `.wasm` binary"
+msgstr ""
+
+#: src/cli/flags.md:35
+msgid "Outputs HTML file with JS"
+msgstr ""
+
+#: src/cli/flags.md:36
+msgid "Win32 executable"
+msgstr ""
+
+#: src/cli/flags.md:37
+msgid "GTK4 executable"
+msgstr ""
+
+#: src/cli/flags.md:39
+msgid "Output Types"
+msgstr ""
+
+#: src/cli/flags.md:41
+msgid "Use `--output-type` to change what's produced:"
+msgstr ""
+
+#: src/cli/flags.md:45
+msgid "`executable`"
+msgstr ""
+
+#: src/cli/flags.md:45
+msgid "Standalone binary (default)"
+msgstr ""
+
+#: src/cli/flags.md:46
+msgid "`dylib`"
+msgstr ""
+
+#: src/cli/flags.md:46
+msgid "Shared library (`.dylib`/`.so`) for [plugins](../plugins/overview.md)"
+msgstr ""
+
+#: src/cli/flags.md:48
+msgid "Debug Flags"
+msgstr ""
+
+#: src/cli/flags.md:52
+msgid "Print HIR (intermediate representation) to stdout"
+msgstr ""
+
+#: src/cli/flags.md:53
+msgid "Produce `.o` object file only, skip linking"
+msgstr ""
+
+#: src/cli/flags.md:54
+msgid "Keep `.o` and `.asm` intermediate files"
+msgstr ""
+
+#: src/cli/flags.md:56
+msgid "Output Optimization"
+msgstr ""
+
+#: src/cli/flags.md:62
+msgid ""
+"Minification strips comments, collapses whitespace, and mangles local "
+"variable/parameter/non-exported function names for smaller output."
+msgstr ""
+
+#: src/cli/flags.md:64
+msgid "Testing Flags"
+msgstr ""
+
+#: src/cli/flags.md:68
+msgid "`--enable-geisterhand`"
+msgstr ""
+
+#: src/cli/flags.md:68
+msgid ""
+"Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
+"programmatic UI testing (default port 7676)"
+msgstr ""
+
+#: src/cli/flags.md:69
+msgid "`--geisterhand-port <PORT>`"
+msgstr ""
+
+#: src/cli/flags.md:69
+msgid ""
+"Set a custom port for the Geisterhand server (implies `--enable-"
+"geisterhand`)"
+msgstr ""
+
+#: src/cli/flags.md:71
+msgid "Runtime Flags"
+msgstr ""
+
+#: src/cli/flags.md:75
+msgid "Enable V8 JavaScript runtime for unsupported npm packages"
+msgstr ""
+
+#: src/cli/flags.md:76
+msgid "Enable type checking via tsgo IPC"
+msgstr ""
+
+#: src/cli/flags.md:78 src/cli/perry-toml.md:485
+msgid "Environment Variables"
+msgstr ""
+
+#: src/cli/flags.md:80 src/cli/perry-toml.md:491 src/cli/perry-toml.md:503
+#: src/cli/perry-toml.md:513
+msgid "Variable"
+msgstr ""
+
+#: src/cli/flags.md:82 src/cli/perry-toml.md:493
+msgid "`PERRY_LICENSE_KEY`"
+msgstr ""
+
+#: src/cli/flags.md:82
+msgid "Perry Hub license key for `perry publish`"
+msgstr ""
+
+#: src/cli/flags.md:83 src/cli/perry-toml.md:495
+msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/flags.md:83
+msgid "Password for .p12 certificate"
+msgstr ""
+
+#: src/cli/flags.md:84
+msgid "`PERRY_NO_UPDATE_CHECK=1`"
+msgstr ""
+
+#: src/cli/flags.md:84
+msgid "Disable automatic update checks"
+msgstr ""
+
+#: src/cli/flags.md:85
+msgid "`PERRY_UPDATE_SERVER`"
+msgstr ""
+
+#: src/cli/flags.md:85
+msgid "Custom update server URL"
+msgstr ""
+
+#: src/cli/flags.md:86
+msgid "`CI=true`"
+msgstr ""
+
+#: src/cli/flags.md:86
+msgid "Auto-skip update checks (set by most CI systems)"
+msgstr ""
+
+#: src/cli/flags.md:87
+msgid "`RUST_LOG`"
+msgstr ""
+
+#: src/cli/flags.md:87
+msgid "Debug logging level (`debug`, `info`, `trace`)"
+msgstr ""
+
+#: src/cli/flags.md:89
+msgid "Configuration Files"
+msgstr ""
+
+#: src/cli/flags.md:91
+msgid "perry.toml (project)"
+msgstr ""
+
+#: src/cli/flags.md:93
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"entry = \"src/main.ts\"\n"
+"version = \"1.0.0\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"build\"\n"
+"\n"
+"[app]\n"
+"name = \"My App\"\n"
+"description = \"A Perry application\"\n"
+"\n"
+"[macos]\n"
+"bundle_id = \"com.example.myapp\"\n"
+"category = \"public.app-category.developer-tools\"\n"
+"minimum_os = \"13.0\"\n"
+"distribute = \"notarize\"  # \"appstore\", \"notarize\", or \"both\"\n"
+"\n"
+"[ios]\n"
+"bundle_id = \"com.example.myapp\"\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = 26\n"
+"target_sdk = 34\n"
+"\n"
+"[linux]\n"
+"format = \"appimage\"  # \"appimage\", \"deb\", \"rpm\"\n"
+"category = \"Development\"\n"
+"```"
+msgstr ""
+
+#: src/cli/flags.md:127
+msgid "~/.perry/config.toml (global)"
+msgstr ""
+
+#: src/cli/flags.md:129
+msgid ""
+"```toml\n"
+"[apple]\n"
+"team_id = \"XXXXXXXXXX\"\n"
+"signing_identity = \"Developer ID Application: Your Name\"\n"
+"\n"
+"[android]\n"
+"keystore_path = \"/path/to/keystore.jks\"\n"
+"key_alias = \"my-key\"\n"
+"```"
+msgstr ""
+
+#: src/cli/flags.md:142
+msgid "# Simple CLI program\n"
+msgstr ""
+
+#: src/cli/flags.md:144
+msgid "# iOS app for simulator\n"
+msgstr ""
+
+#: src/cli/flags.md:147
+msgid "# visionOS app for simulator\n"
+msgstr ""
+
+#: src/cli/flags.md:150
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
+msgstr ""
+
+#: src/cli/flags.md:153
+msgid "# Plugin shared library\n"
+msgstr ""
+
+#: src/cli/flags.md:156
+msgid "# iOS widget with bundle ID\n"
+msgstr ""
+
+#: src/cli/flags.md:159
+msgid "# Debug compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:162
+msgid "# Verbose compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:165
+msgid "# Type-checked compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:168
+msgid "# Raw WASM binary (no HTML wrapper)\n"
+msgstr ""
+
+#: src/cli/flags.md:171
+msgid "# Minified web output (compresses embedded JS bridge)\n"
+msgstr ""
+
+#: src/cli/flags.md:178
+msgid "[Commands](commands.md) — All CLI commands"
+msgstr ""
+
+#: src/cli/flags.md:179
+msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
+msgstr ""
+
+#: src/cli/perry-toml.md:3
+msgid ""
+"`perry.toml` is the project-level configuration file for Perry. It controls "
+"project metadata, build settings, platform-specific options, code signing, "
+"distribution, auditing, and verification."
+msgstr ""
+
+#: src/cli/perry-toml.md:5
+msgid ""
+"Created automatically by `perry init`, it lives at the root of your project "
+"alongside `package.json`."
+msgstr ""
+
+#: src/cli/perry-toml.md:7
+msgid "Minimal Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:9
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"dist\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:18
+msgid "Full Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:20
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"version = \"1.2.0\"\n"
+"build_number = 42\n"
+"bundle_id = \"com.example.myapp\"\n"
+"description = \"A cross-platform Perry application\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[project.icons]\n"
+"source = \"assets/icon.png\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"dist\"\n"
+"\n"
+"[macos]\n"
+"bundle_id = \"com.example.myapp.macos\"\n"
+"category = \"public.app-category.developer-tools\"\n"
+"minimum_os = \"13.0\"\n"
+"entitlements = [\"com.apple.security.network.client\"]\n"
+"distribute = \"both\"\n"
+"signing_identity = \"Developer ID Application: My Company (TEAMID)\"\n"
+"certificate = \"certs/mac-appstore.p12\"\n"
+"notarize_certificate = \"certs/mac-devid.p12\"\n"
+"notarize_signing_identity = \"Developer ID Application: My Company (TEAMID)\"\n"
+"installer_certificate = \"certs/mac-installer.p12\"\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"certs/AuthKey.p8\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[ios]\n"
+"bundle_id = \"com.example.myapp.ios\"\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"orientations = [\"portrait\", \"landscape-left\", \"landscape-right\"]\n"
+"capabilities = [\"push-notification\"]\n"
+"distribute = \"appstore\"\n"
+"entry = \"src/main-ios.ts\"\n"
+"provisioning_profile = \"certs/MyApp.mobileprovision\"\n"
+"certificate = \"certs/ios-distribution.p12\"\n"
+"signing_identity = \"iPhone Distribution: My Company (TEAMID)\"\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"certs/AuthKey.p8\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = \"26\"\n"
+"target_sdk = \"34\"\n"
+"permissions = [\"INTERNET\", \"CAMERA\"]\n"
+"distribute = \"playstore\"\n"
+"keystore = \"certs/release.keystore\"\n"
+"key_alias = \"my-key\"\n"
+"google_play_key = \"certs/play-service-account.json\"\n"
+"entry = \"src/main-android.ts\"\n"
+"\n"
+"[linux]\n"
+"format = \"appimage\"\n"
+"category = \"Development\"\n"
+"description = \"A cross-platform Perry application\"\n"
+"\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\", \"fr\"]\n"
+"default_locale = \"en\"\n"
+"\n"
+"[i18n.currencies]\n"
+"en = \"USD\"\n"
+"de = \"EUR\"\n"
+"fr = \"EUR\"\n"
+"\n"
+"[publish]\n"
+"server = \"https://hub.perryts.com\"\n"
+"\n"
+"[audit]\n"
+"fail_on = \"B\"\n"
+"severity = \"high\"\n"
+"ignore = [\"RULE-001\", \"RULE-002\"]\n"
+"\n"
+"[verify]\n"
+"url = \"https://verify.perryts.com\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:110 src/cli/perry-toml.md:558
+msgid "`[project]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:112
+msgid ""
+"Core project metadata. This is the primary section for identifying your "
+"application."
+msgstr ""
+
+#: src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414
+msgid "Default"
+msgstr ""
+
+#: src/cli/perry-toml.md:116
+msgid "Directory name"
+msgstr ""
+
+#: src/cli/perry-toml.md:116
+msgid "Project name, used for binary output name and default bundle ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:117
+msgid "`\"1.0.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:117
+msgid "Semantic version string (e.g., `\"1.2.3\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "`build_number`"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "integer"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "`1`"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid ""
+"Numeric build number; auto-incremented on `perry publish` for iOS, Android, "
+"and macOS App Store builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:119
+msgid "Human-readable project description"
+msgstr ""
+
+#: src/cli/perry-toml.md:120 src/cli/perry-toml.md:249
+#: src/cli/perry-toml.md:304 src/cli/perry-toml.md:337
+msgid "`entry`"
+msgstr ""
+
+#: src/cli/perry-toml.md:120
+msgid ""
+"TypeScript entry file (e.g., `\"src/main.ts\"`). Used by `perry run` and "
+"`perry publish` when no input file is specified"
+msgstr ""
+
+#: src/cli/perry-toml.md:121 src/cli/perry-toml.md:167
+#: src/cli/perry-toml.md:243 src/cli/perry-toml.md:301
+msgid "`bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:121
+msgid "`com.perry.<name>`"
+msgstr ""
+
+#: src/cli/perry-toml.md:121
+msgid ""
+"Default bundle identifier, used as fallback when platform-specific sections "
+"don't define one"
+msgstr ""
+
+#: src/cli/perry-toml.md:123
+msgid "`[project.icons]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:127
+msgid "`source`"
+msgstr ""
+
+#: src/cli/perry-toml.md:127
+msgid ""
+"Path to a source icon image (PNG or JPG). Perry auto-resizes this to all "
+"required sizes for each platform"
+msgstr ""
+
+#: src/cli/perry-toml.md:129
+msgid "`[app]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:131
+msgid ""
+"Alternative to `[project]` with identical fields. Useful for organizational "
+"clarity — `[app]` takes precedence over `[project]` when both are present:"
+msgstr ""
+
+#: src/cli/perry-toml.md:133
+msgid ""
+"```toml\n"
+"# These two are equivalent:\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"\n"
+"# or:\n"
+"[app]\n"
+"name = \"my-app\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:143
+msgid ""
+"When both exist, resolution order is: `[app]` field -> `[project]` field -> "
+"default."
+msgstr ""
+
+#: src/cli/perry-toml.md:145
+msgid ""
+"`[app]` supports the same fields as `[project]`: `name`, `version`, "
+"`build_number`, `bundle_id`, `description`, `entry`, and `icons`."
+msgstr ""
+
+#: src/cli/perry-toml.md:149 src/cli/perry-toml.md:561
+msgid "`[build]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:151
+msgid "Build output settings."
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "`out_dir`"
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "`\"dist\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "Directory for build artifacts"
+msgstr ""
+
+#: src/cli/perry-toml.md:159
+msgid "`[macos]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:161
+msgid ""
+"macOS-specific configuration for `perry publish macos` and `perry compile "
+"--target macos`."
+msgstr ""
+
+#: src/cli/perry-toml.md:163 src/cli/perry-toml.md:239
+#: src/cli/perry-toml.md:297
+msgid "App Metadata"
+msgstr ""
+
+#: src/cli/perry-toml.md:167 src/cli/perry-toml.md:243
+msgid "Falls back to `[app]`/`[project]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:167
+msgid "macOS-specific bundle identifier (e.g., `\"com.example.myapp\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:348
+msgid "`category`"
+msgstr ""
+
+#: src/cli/perry-toml.md:168
+msgid ""
+"Mac App Store category. Uses Apple's UTI format (see [valid values](#macos-"
+"app-store-categories) below)"
+msgstr ""
+
+#: src/cli/perry-toml.md:169
+msgid "`minimum_os`"
+msgstr ""
+
+#: src/cli/perry-toml.md:169
+msgid "Minimum macOS version required (e.g., `\"13.0\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:170
+msgid "`entitlements`"
+msgstr ""
+
+#: src/cli/perry-toml.md:170 src/cli/perry-toml.md:246
+#: src/cli/perry-toml.md:247 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:332 src/cli/perry-toml.md:359
+#: src/cli/perry-toml.md:391
+msgid "string\\[\\]"
+msgstr ""
+
+#: src/cli/perry-toml.md:170
+msgid ""
+"macOS entitlements to include in the code signature (e.g., "
+"`[\"com.apple.security.network.client\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305
+msgid "`encryption_exempt`"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305
+msgid "bool"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305 src/cli/perry-toml.md:361
+msgid "`false`"
+msgstr ""
+
+#: src/cli/perry-toml.md:171
+msgid ""
+"If `true`, adds `ITSAppUsesNonExemptEncryption = false` to Info.plist, "
+"skipping the export compliance prompt in App Store Connect"
+msgstr ""
+
+#: src/cli/perry-toml.md:173 src/cli/perry-toml.md:252
+msgid "Distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:177 src/cli/perry-toml.md:256
+#: src/cli/perry-toml.md:312 src/cli/perry-toml.md:333
+msgid "`distribute`"
+msgstr ""
+
+#: src/cli/perry-toml.md:177
+msgid ""
+"Distribution method: `\"appstore\"`, `\"notarize\"`, or `\"both\"` (see "
+"[Distribution Modes](#macos-distribution-modes))"
+msgstr ""
+
+#: src/cli/perry-toml.md:183 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:313
+msgid "`signing_identity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:183 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:313
+msgid "Auto-detected from Keychain"
+msgstr ""
+
+#: src/cli/perry-toml.md:183
+msgid ""
+"Code signing identity name (e.g., `\"3rd Party Mac Developer Application: "
+"Company (TEAMID)\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:263
+#: src/cli/perry-toml.md:314
+msgid "`certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:263
+#: src/cli/perry-toml.md:314
+msgid "Auto-exported from Keychain"
+msgstr ""
+
+#: src/cli/perry-toml.md:184
+msgid "Path to `.p12` certificate file for App Store distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:185
+msgid "`notarize_certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:185
+msgid ""
+"Separate `.p12` certificate for notarization (only used with `distribute = "
+"\"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:186
+msgid "`notarize_signing_identity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:186
+msgid "Signing identity for notarization (only used with `distribute = \"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:187
+msgid "`installer_certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:187
+msgid "`.p12` certificate for Mac Installer Distribution (`.pkg` signing)"
+msgstr ""
+
+#: src/cli/perry-toml.md:189 src/cli/perry-toml.md:266
+msgid "App Store Connect"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:270
+#: src/cli/perry-toml.md:316
+msgid "`team_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:194
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:196
+#: src/cli/perry-toml.md:270 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:272 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:316 src/cli/perry-toml.md:317
+#: src/cli/perry-toml.md:318 src/cli/perry-toml.md:319
+msgid "From `~/.perry/config.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:270
+#: src/cli/perry-toml.md:316
+msgid "Apple Developer Team ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:194 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:317
+msgid "`key_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:194 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:497
+msgid "App Store Connect API key ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:272
+#: src/cli/perry-toml.md:318
+msgid "`issuer_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:272
+#: src/cli/perry-toml.md:318
+msgid "App Store Connect issuer ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:196 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:319
+msgid "`p8_key_path`"
+msgstr ""
+
+#: src/cli/perry-toml.md:196
+msgid "Path to App Store Connect `.p8` API key file"
+msgstr ""
+
+#: src/cli/perry-toml.md:198
+msgid "macOS Distribution Modes"
+msgstr ""
+
+#: src/cli/perry-toml.md:200
+msgid ""
+"The `distribute` field controls how your macOS app is signed and "
+"distributed:"
+msgstr ""
+
+#: src/cli/perry-toml.md:202
+msgid ""
+"**`\"appstore\"`** — Signs with an App Store distribution certificate and "
+"uploads to App Store Connect. Requires `team_id`, `key_id`, `issuer_id`, and"
+" `p8_key_path`."
+msgstr ""
+
+#: src/cli/perry-toml.md:204
+msgid ""
+"**`\"notarize\"`** — Signs with a Developer ID certificate and notarizes "
+"with Apple. For direct distribution outside the App Store."
+msgstr ""
+
+#: src/cli/perry-toml.md:206
+msgid ""
+"**`\"both\"`** — Produces **two** signed builds: one for the App Store and "
+"one notarized for direct distribution. Requires **two separate "
+"certificates**:"
+msgstr ""
+
+#: src/cli/perry-toml.md:207
+msgid "`certificate` + `signing_identity` for the App Store build"
+msgstr ""
+
+#: src/cli/perry-toml.md:208
+msgid ""
+"`notarize_certificate` + `notarize_signing_identity` for the notarized build"
+msgstr ""
+
+#: src/cli/perry-toml.md:209
+msgid "Optionally `installer_certificate` for `.pkg` signing"
+msgstr ""
+
+#: src/cli/perry-toml.md:211
+msgid "macOS App Store Categories"
+msgstr ""
+
+#: src/cli/perry-toml.md:213
+msgid "Common values for the `category` field (Apple UTI format):"
+msgstr ""
+
+#: src/cli/perry-toml.md:215
+msgid "Category"
+msgstr ""
+
+#: src/cli/perry-toml.md:217
+msgid "Business"
+msgstr ""
+
+#: src/cli/perry-toml.md:217
+msgid "`public.app-category.business`"
+msgstr ""
+
+#: src/cli/perry-toml.md:218
+msgid "Developer Tools"
+msgstr ""
+
+#: src/cli/perry-toml.md:218
+msgid "`public.app-category.developer-tools`"
+msgstr ""
+
+#: src/cli/perry-toml.md:219
+msgid "Education"
+msgstr ""
+
+#: src/cli/perry-toml.md:219
+msgid "`public.app-category.education`"
+msgstr ""
+
+#: src/cli/perry-toml.md:220
+msgid "Entertainment"
+msgstr ""
+
+#: src/cli/perry-toml.md:220
+msgid "`public.app-category.entertainment`"
+msgstr ""
+
+#: src/cli/perry-toml.md:221
+msgid "Finance"
+msgstr ""
+
+#: src/cli/perry-toml.md:221
+msgid "`public.app-category.finance`"
+msgstr ""
+
+#: src/cli/perry-toml.md:222
+msgid "Games"
+msgstr ""
+
+#: src/cli/perry-toml.md:222
+msgid "`public.app-category.games`"
+msgstr ""
+
+#: src/cli/perry-toml.md:223
+msgid "Graphics & Design"
+msgstr ""
+
+#: src/cli/perry-toml.md:223
+msgid "`public.app-category.graphics-design`"
+msgstr ""
+
+#: src/cli/perry-toml.md:224
+msgid "Health & Fitness"
+msgstr ""
+
+#: src/cli/perry-toml.md:224
+msgid "`public.app-category.healthcare-fitness`"
+msgstr ""
+
+#: src/cli/perry-toml.md:225
+msgid "Lifestyle"
+msgstr ""
+
+#: src/cli/perry-toml.md:225
+msgid "`public.app-category.lifestyle`"
+msgstr ""
+
+#: src/cli/perry-toml.md:226
+msgid "Music"
+msgstr ""
+
+#: src/cli/perry-toml.md:226
+msgid "`public.app-category.music`"
+msgstr ""
+
+#: src/cli/perry-toml.md:227
+msgid "News"
+msgstr ""
+
+#: src/cli/perry-toml.md:227
+msgid "`public.app-category.news`"
+msgstr ""
+
+#: src/cli/perry-toml.md:228
+msgid "Photography"
+msgstr ""
+
+#: src/cli/perry-toml.md:228
+msgid "`public.app-category.photography`"
+msgstr ""
+
+#: src/cli/perry-toml.md:229
+msgid "Productivity"
+msgstr ""
+
+#: src/cli/perry-toml.md:229
+msgid "`public.app-category.productivity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:230
+msgid "Social Networking"
+msgstr ""
+
+#: src/cli/perry-toml.md:230
+msgid "`public.app-category.social-networking`"
+msgstr ""
+
+#: src/cli/perry-toml.md:231
+msgid "`public.app-category.utilities`"
+msgstr ""
+
+#: src/cli/perry-toml.md:235
+msgid "`[ios]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:237
+msgid ""
+"iOS-specific configuration for `perry publish ios`, `perry run ios`, and "
+"`perry compile --target ios`/`--target ios-simulator`."
+msgstr ""
+
+#: src/cli/perry-toml.md:243
+msgid "iOS-specific bundle identifier"
+msgstr ""
+
+#: src/cli/perry-toml.md:244 src/cli/perry-toml.md:302
+msgid "`deployment_target`"
+msgstr ""
+
+#: src/cli/perry-toml.md:244
+msgid "`\"17.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:244
+msgid "Minimum iOS version required (e.g., `\"16.0\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:303
+msgid "`minimum_version`"
+msgstr ""
+
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:303
+msgid "Alias for `deployment_target`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "`device_family`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "`[\"iphone\", \"ipad\"]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "Supported device families"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "`orientations`"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "`[\"portrait\"]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "Supported interface orientations"
+msgstr ""
+
+#: src/cli/perry-toml.md:248
+msgid "`capabilities`"
+msgstr ""
+
+#: src/cli/perry-toml.md:248
+msgid "App capabilities (e.g., `[\"push-notification\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:249 src/cli/perry-toml.md:304
+#: src/cli/perry-toml.md:337 src/cli/perry-toml.md:349
+msgid "Falls back to `[project]`/`[app]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:249
+msgid ""
+"iOS-specific entry file (useful when iOS needs a different entry point)"
+msgstr ""
+
+#: src/cli/perry-toml.md:250 src/cli/perry-toml.md:305
+msgid "If `true`, adds `ITSAppUsesNonExemptEncryption = false` to Info.plist"
+msgstr ""
+
+#: src/cli/perry-toml.md:256
+msgid "Distribution method: `\"appstore\"`, `\"testflight\"`, or `\"development\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:262
+msgid "Code signing identity (e.g., `\"iPhone Distribution: Company (TEAMID)\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:263 src/cli/perry-toml.md:314
+msgid "Path to `.p12` distribution certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:264 src/cli/perry-toml.md:315
+msgid "`provisioning_profile`"
+msgstr ""
+
+#: src/cli/perry-toml.md:264
+msgid ""
+"Path to `.mobileprovision` file. Stored as `{bundle_id}.mobileprovision` in "
+"`~/.perry/` by `perry setup ios`"
+msgstr ""
+
+#: src/cli/perry-toml.md:273 src/cli/perry-toml.md:319
+msgid "Path to `.p8` API key file"
+msgstr ""
+
+#: src/cli/perry-toml.md:275
+msgid "Device Family Values"
+msgstr ""
+
+#: src/cli/perry-toml.md:279
+msgid "`\"iphone\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:279
+msgid "iPhone devices"
+msgstr ""
+
+#: src/cli/perry-toml.md:280
+msgid "`\"ipad\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:280
+msgid "iPad devices"
+msgstr ""
+
+#: src/cli/perry-toml.md:282
+msgid "Orientation Values"
+msgstr ""
+
+#: src/cli/perry-toml.md:286
+msgid "`\"portrait\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:286
+msgid "Device upright"
+msgstr ""
+
+#: src/cli/perry-toml.md:287
+msgid "`\"portrait-upside-down\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:287
+msgid "Device upside down"
+msgstr ""
+
+#: src/cli/perry-toml.md:288
+msgid "`\"landscape-left\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:288
+msgid "Device rotated left"
+msgstr ""
+
+#: src/cli/perry-toml.md:289
+msgid "`\"landscape-right\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:289
+msgid "Device rotated right"
+msgstr ""
+
+#: src/cli/perry-toml.md:293
+msgid "`[visionos]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:295
+msgid ""
+"visionOS-specific configuration for `perry publish visionos`, `perry run "
+"visionos`, and `perry compile --target visionos`/`--target visionos-"
+"simulator`."
+msgstr ""
+
+#: src/cli/perry-toml.md:301
+msgid "Falls back to `[app]`/`[project]`/`[ios]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:301
+msgid "visionOS-specific bundle identifier"
+msgstr ""
+
+#: src/cli/perry-toml.md:302
+msgid "`\"1.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:302
+msgid "Minimum visionOS version required"
+msgstr ""
+
+#: src/cli/perry-toml.md:304
+msgid "visionOS-specific entry file"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "`info_plist`"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "table"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "Custom key-value pairs merged into the generated Info.plist"
+msgstr ""
+
+#: src/cli/perry-toml.md:308
+msgid "Distribution / Signing"
+msgstr ""
+
+#: src/cli/perry-toml.md:312
+msgid "Distribution method for visionOS builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:313
+msgid "Code signing identity"
+msgstr ""
+
+#: src/cli/perry-toml.md:315
+msgid "Path to `.mobileprovision` file"
+msgstr ""
+
+#: src/cli/perry-toml.md:323
+msgid "`[android]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:325
+msgid ""
+"Android-specific configuration for `perry publish android`, `perry run "
+"android`, and `perry compile --target android`."
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "`package_name`"
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "Falls back to bundle_id chain"
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "Java package name (e.g., `\"com.example.myapp\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:330
+msgid "`min_sdk`"
+msgstr ""
+
+#: src/cli/perry-toml.md:330
+msgid "Minimum Android SDK version (e.g., `\"26\"` for Android 8.0)"
+msgstr ""
+
+#: src/cli/perry-toml.md:331
+msgid "`target_sdk`"
+msgstr ""
+
+#: src/cli/perry-toml.md:331
+msgid "Target Android SDK version (e.g., `\"34\"` for Android 14)"
+msgstr ""
+
+#: src/cli/perry-toml.md:332
+msgid "`permissions`"
+msgstr ""
+
+#: src/cli/perry-toml.md:332
+msgid "Android permissions (e.g., `[\"INTERNET\", \"CAMERA\", \"ACCESS_FINE_LOCATION\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:333
+msgid "Distribution method: `\"playstore\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:334
+msgid "`keystore`"
+msgstr ""
+
+#: src/cli/perry-toml.md:334
+msgid "Path to `.jks` or `.keystore` signing keystore"
+msgstr ""
+
+#: src/cli/perry-toml.md:335
+msgid "`key_alias`"
+msgstr ""
+
+#: src/cli/perry-toml.md:335
+msgid "Alias of the signing key within the keystore"
+msgstr ""
+
+#: src/cli/perry-toml.md:336
+msgid "`google_play_key`"
+msgstr ""
+
+#: src/cli/perry-toml.md:336
+msgid "Path to Google Play service account JSON file for automated uploads"
+msgstr ""
+
+#: src/cli/perry-toml.md:337
+msgid "Android-specific entry file"
+msgstr ""
+
+#: src/cli/perry-toml.md:341
+msgid "`[linux]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:343
+msgid "Linux-specific configuration for `perry publish linux`."
+msgstr ""
+
+#: src/cli/perry-toml.md:347
+msgid "`format`"
+msgstr ""
+
+#: src/cli/perry-toml.md:347
+msgid "Package format: `\"appimage\"`, `\"deb\"`, or `\"rpm\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:348
+msgid "Desktop application category (e.g., `\"Development\"`, `\"Utility\"`, `\"Game\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:349
+msgid "Application description for package metadata"
+msgstr ""
+
+#: src/cli/perry-toml.md:353
+msgid "`[i18n]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:355
+msgid ""
+"Internationalization configuration. See the [i18n "
+"documentation](../i18n/overview.md) for full details."
+msgstr ""
+
+#: src/cli/perry-toml.md:359
+msgid "`locales`"
+msgstr ""
+
+#: src/cli/perry-toml.md:359
+msgid ""
+"Supported locale codes (e.g., `[\"en\", \"de\", \"fr\"]`). Locale files must"
+" exist in `/locales`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "`default_locale`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "`\"en\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "Fallback locale. Used when a key is missing in another locale"
+msgstr ""
+
+#: src/cli/perry-toml.md:361
+msgid "`dynamic`"
+msgstr ""
+
+#: src/cli/perry-toml.md:361
+msgid ""
+"`false`: locale set at launch, strings inlined. `true`: locale switchable at"
+" runtime"
+msgstr ""
+
+#: src/cli/perry-toml.md:363
+msgid "`[i18n.currencies]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:365
+msgid ""
+"Maps locale codes to default ISO 4217 currency codes. Used by the "
+"`Currency()` format wrapper."
+msgstr ""
+
+#: src/cli/perry-toml.md:369
+msgid "`{locale}`"
+msgstr ""
+
+#: src/cli/perry-toml.md:369
+msgid "Currency code for the locale (e.g., `en = \"USD\"`, `de = \"EUR\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:373
+msgid "`[publish]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:375
+msgid "Publishing configuration."
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid "`server`"
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid "`https://hub.perryts.com`"
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid ""
+"Custom Perry Hub build server URL. Useful for self-hosted or enterprise "
+"deployments"
+msgstr ""
+
+#: src/cli/perry-toml.md:383
+msgid "`[audit]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:385
+msgid "Security audit configuration for `perry audit` and pre-publish audits."
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid "`fail_on`"
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid "`\"C\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid ""
+"Minimum acceptable audit grade. Build fails if the actual grade is below "
+"this threshold. Values: `\"A\"`, `\"A-\"`, `\"B\"`, `\"C\"`, `\"D\"`, "
+"`\"F\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid "`severity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid "`\"all\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid ""
+"Filter findings by severity: `\"all\"`, `\"critical\"`, `\"high\"`, "
+"`\"medium\"`, `\"low\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:391
+msgid "`ignore`"
+msgstr ""
+
+#: src/cli/perry-toml.md:391
+msgid "List of audit rule IDs to suppress (e.g., `[\"RULE-001\", \"RULE-042\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:393
+msgid "Audit Grade Scale"
+msgstr ""
+
+#: src/cli/perry-toml.md:395
+msgid "Grades are ranked from highest to lowest:"
+msgstr ""
+
+#: src/cli/perry-toml.md:397
+msgid "Grade"
+msgstr ""
+
+#: src/cli/perry-toml.md:397
+msgid "Rank"
+msgstr ""
+
+#: src/cli/perry-toml.md:399
+msgid "A"
+msgstr ""
+
+#: src/cli/perry-toml.md:399
+msgid "Excellent — no significant findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:400
+msgid "A-"
+msgstr ""
+
+#: src/cli/perry-toml.md:400
+msgid "Very good — minor findings only"
+msgstr ""
+
+#: src/cli/perry-toml.md:401
+msgid "B"
+msgstr ""
+
+#: src/cli/perry-toml.md:401
+msgid "Good — some findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:402
+msgid "C"
+msgstr ""
+
+#: src/cli/perry-toml.md:402
+msgid "Acceptable — moderate findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:403
+msgid "D"
+msgstr ""
+
+#: src/cli/perry-toml.md:403
+msgid "Poor — significant findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:404
+msgid "F"
+msgstr ""
+
+#: src/cli/perry-toml.md:404
+msgid "Fail — critical findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:406
+msgid ""
+"Setting `fail_on = \"B\"` means any grade below B (i.e., C, D, or F) will "
+"cause the build to fail."
+msgstr ""
+
+#: src/cli/perry-toml.md:410
+msgid "`[verify]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:412
+msgid "Runtime verification configuration for `perry verify`."
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "`url`"
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "`https://verify.perryts.com`"
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "Verification service endpoint URL"
+msgstr ""
+
+#: src/cli/perry-toml.md:420
+msgid "Bundle ID Resolution"
+msgstr ""
+
+#: src/cli/perry-toml.md:422
+msgid ""
+"Perry resolves the bundle identifier using a cascading priority system. The "
+"first non-empty value wins:"
+msgstr ""
+
+#: src/cli/perry-toml.md:424
+msgid "For iOS builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:425 src/cli/perry-toml.md:441
+msgid "`[ios].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:426 src/cli/perry-toml.md:434
+#: src/cli/perry-toml.md:443
+msgid "`[app].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:427 src/cli/perry-toml.md:435
+#: src/cli/perry-toml.md:444
+msgid "`[project].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:428 src/cli/perry-toml.md:433
+#: src/cli/perry-toml.md:442
+msgid "`[macos].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:429 src/cli/perry-toml.md:436
+msgid "`package.json` `bundleId` field"
+msgstr ""
+
+#: src/cli/perry-toml.md:430 src/cli/perry-toml.md:437
+#: src/cli/perry-toml.md:445
+msgid "`com.perry.<app_name>` (generated default)"
+msgstr ""
+
+#: src/cli/perry-toml.md:432
+msgid "For macOS builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:439
+msgid "For Android builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:440
+msgid "`[android].package_name`"
+msgstr ""
+
+#: src/cli/perry-toml.md:449
+msgid "Entry File Resolution"
+msgstr ""
+
+#: src/cli/perry-toml.md:451
+msgid ""
+"When no input file is specified on the command line, Perry resolves the "
+"entry file in this order:"
+msgstr ""
+
+#: src/cli/perry-toml.md:453
+msgid "`[ios].entry` / `[android].entry` (when targeting that platform)"
+msgstr ""
+
+#: src/cli/perry-toml.md:454
+msgid "`[project].entry` or `[app].entry`"
+msgstr ""
+
+#: src/cli/perry-toml.md:455
+msgid "`src/main.ts` (if it exists)"
+msgstr ""
+
+#: src/cli/perry-toml.md:456
+msgid "`main.ts` (if it exists)"
+msgstr ""
+
+#: src/cli/perry-toml.md:460
+msgid "Build Number Auto-Increment"
+msgstr ""
+
+#: src/cli/perry-toml.md:462
+msgid ""
+"The `build_number` field is automatically incremented by `perry publish` "
+"for:"
+msgstr ""
+
+#: src/cli/perry-toml.md:463
+msgid "iOS builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:464
+msgid "Android builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:465
+msgid "macOS App Store builds (`distribute = \"appstore\"` or `\"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:467
+msgid ""
+"The updated value is written back to `perry.toml` after a successful "
+"publish. This ensures each submission to the App Store / Play Store has a "
+"unique, monotonically increasing build number."
+msgstr ""
+
+#: src/cli/perry-toml.md:469
+msgid ""
+"macOS builds with `distribute = \"notarize\"` (direct distribution) do "
+"**not** auto-increment the build number."
+msgstr ""
+
+#: src/cli/perry-toml.md:473
+msgid "Configuration Priority"
+msgstr ""
+
+#: src/cli/perry-toml.md:475
+msgid ""
+"Perry resolves configuration values using a layered priority system (highest"
+" to lowest):"
+msgstr ""
+
+#: src/cli/perry-toml.md:477
+msgid "**CLI flags** — e.g., `--target`, `--output`"
+msgstr ""
+
+#: src/cli/perry-toml.md:478
+msgid "**Environment variables** — e.g., `PERRY_LICENSE_KEY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:479
+msgid ""
+"**perry.toml** — project-level config (platform-specific sections first, "
+"then `[app]`/`[project]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:480
+msgid "**~/.perry/config.toml** — user-level global config"
+msgstr ""
+
+#: src/cli/perry-toml.md:481
+msgid "**Built-in defaults**"
+msgstr ""
+
+#: src/cli/perry-toml.md:487
+msgid ""
+"These environment variables override perry.toml and global config values:"
+msgstr ""
+
+#: src/cli/perry-toml.md:489
+msgid "Apple / iOS / macOS"
+msgstr ""
+
+#: src/cli/perry-toml.md:494
+msgid "`PERRY_APPLE_CERTIFICATE`"
+msgstr ""
+
+#: src/cli/perry-toml.md:494
+msgid "`.p12` certificate file contents (base64)"
+msgstr ""
+
+#: src/cli/perry-toml.md:495
+msgid "Password for the `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:496
+msgid "`PERRY_APPLE_P8_KEY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:496
+msgid "`.p8` API key file contents"
+msgstr ""
+
+#: src/cli/perry-toml.md:497
+msgid "`PERRY_APPLE_KEY_ID`"
+msgstr ""
+
+#: src/cli/perry-toml.md:498
+msgid "`PERRY_APPLE_NOTARIZE_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:498
+msgid "Password for the notarization `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:499
+msgid "`PERRY_APPLE_INSTALLER_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:499
+msgid "Password for the installer `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:505
+msgid "`PERRY_ANDROID_KEYSTORE`"
+msgstr ""
+
+#: src/cli/perry-toml.md:505
+msgid "Path to `.jks`/`.keystore` file"
+msgstr ""
+
+#: src/cli/perry-toml.md:506
+msgid "`PERRY_ANDROID_KEY_ALIAS`"
+msgstr ""
+
+#: src/cli/perry-toml.md:506
+msgid "Keystore key alias"
+msgstr ""
+
+#: src/cli/perry-toml.md:507
+msgid "`PERRY_ANDROID_KEYSTORE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:508
+msgid "`PERRY_ANDROID_KEY_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:508
+msgid "Key password (within the keystore)"
+msgstr ""
+
+#: src/cli/perry-toml.md:509
+msgid "`PERRY_GOOGLE_PLAY_KEY_PATH`"
+msgstr ""
+
+#: src/cli/perry-toml.md:509
+msgid "Path to Google Play service account JSON"
+msgstr ""
+
+#: src/cli/perry-toml.md:511
+msgid "General"
+msgstr ""
+
+#: src/cli/perry-toml.md:515
+msgid "`PERRY_NO_TELEMETRY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:515
+msgid "Set to `1` to disable anonymous telemetry"
+msgstr ""
+
+#: src/cli/perry-toml.md:516
+msgid "`PERRY_NO_UPDATE_CHECK`"
+msgstr ""
+
+#: src/cli/perry-toml.md:516
+msgid "Set to `1` to disable background update checks"
+msgstr ""
+
+#: src/cli/perry-toml.md:520
+msgid "Global Config: `~/.perry/config.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:522
+msgid ""
+"Separate from the project-level `perry.toml`, Perry maintains a user-level "
+"global config at `~/.perry/config.toml`. This stores credentials and "
+"preferences shared across all projects."
+msgstr ""
+
+#: src/cli/perry-toml.md:524
+msgid ""
+"```toml\n"
+"license_key = \"perry-xxxxxxxx\"\n"
+"server = \"https://hub.perryts.com\"\n"
+"default_target = \"macos\"\n"
+"\n"
+"[apple]\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"/Users/me/.perry/AuthKey.p8\"\n"
+"\n"
+"[android]\n"
+"keystore_path = \"/Users/me/.perry/release.keystore\"\n"
+"key_alias = \"my-key\"\n"
+"google_play_key_path = \"/Users/me/.perry/play-service-account.json\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:541
+msgid ""
+"Fields in perry.toml (project-level) override `~/.perry/config.toml` "
+"(global-level). For example, `[ios].team_id` in perry.toml overrides "
+"`[apple].team_id` in the global config."
+msgstr ""
+
+#: src/cli/perry-toml.md:543
+msgid "The global config is managed by `perry setup` commands:"
+msgstr ""
+
+#: src/cli/perry-toml.md:544
+msgid "`perry setup ios` — configures Apple signing credentials"
+msgstr ""
+
+#: src/cli/perry-toml.md:545
+msgid "`perry setup android` — configures Android signing credentials"
+msgstr ""
+
+#: src/cli/perry-toml.md:546
+msgid "`perry setup macos` — configures macOS distribution settings"
+msgstr ""
+
+#: src/cli/perry-toml.md:550
+msgid "perry.toml vs package.json"
+msgstr ""
+
+#: src/cli/perry-toml.md:552
+msgid "Perry reads configuration from both files. Here's what goes where:"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "Setting"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "File"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "Section"
+msgstr ""
+
+#: src/cli/perry-toml.md:556
+msgid "Compile packages natively"
+msgstr ""
+
+#: src/cli/perry-toml.md:556 src/cli/perry-toml.md:557
+msgid "`package.json`"
+msgstr ""
+
+#: src/cli/perry-toml.md:556
+msgid "`perry.compilePackages`"
+msgstr ""
+
+#: src/cli/perry-toml.md:557
+msgid "Splash screen"
+msgstr ""
+
+#: src/cli/perry-toml.md:557
+msgid "`perry.splash`"
+msgstr ""
+
+#: src/cli/perry-toml.md:558
+msgid "Project name, version, entry"
+msgstr ""
+
+#: src/cli/perry-toml.md:558 src/cli/perry-toml.md:559
+#: src/cli/perry-toml.md:560 src/cli/perry-toml.md:561
+#: src/cli/perry-toml.md:562
+msgid "`perry.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:559
+msgid "Platform-specific settings"
+msgstr ""
+
+#: src/cli/perry-toml.md:559
+msgid "`[ios]`, `[macos]`, `[android]`, `[linux]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:560
+msgid "Code signing & distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:560
+msgid "Platform sections"
+msgstr ""
+
+#: src/cli/perry-toml.md:561
+msgid "Build output directory"
+msgstr ""
+
+#: src/cli/perry-toml.md:562
+msgid "Audit & verification"
+msgstr ""
+
+#: src/cli/perry-toml.md:562
+msgid "`[audit]`, `[verify]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:564
+msgid ""
+"When both files define the same value (e.g., project name), `perry.toml` "
+"takes precedence."
+msgstr ""
+
+#: src/cli/perry-toml.md:568
+msgid "Setup Wizard"
+msgstr ""
+
+#: src/cli/perry-toml.md:570
+msgid ""
+"Running `perry setup <platform>` interactively configures signing "
+"credentials and writes them back to both `perry.toml` and "
+"`~/.perry/config.toml`:"
+msgstr ""
+
+#: src/cli/perry-toml.md:573
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:574
+msgid "# Configure Android signing (keystore, Play Store key)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:575
+msgid "# Configure macOS distribution (App Store, notarization)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:578
+msgid "The wizard automatically:"
+msgstr ""
+
+#: src/cli/perry-toml.md:579
+msgid "Sets `[ios].distribute = \"testflight\"` if not already configured"
+msgstr ""
+
+#: src/cli/perry-toml.md:580
+msgid "Sets `[android].distribute = \"playstore\"` if not already configured"
+msgstr ""
+
+#: src/cli/perry-toml.md:581
+msgid "Stores provisioning profiles as `~/.perry/{bundle_id}.mobileprovision`"
+msgstr ""
+
+#: src/cli/perry-toml.md:582
+msgid "Auto-exports `.p12` certificates from macOS Keychain when possible"
+msgstr ""
+
+#: src/cli/perry-toml.md:586
+msgid "CI/CD Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:588
+msgid ""
+"For CI environments, use environment variables instead of storing "
+"credentials in `perry.toml`:"
+msgstr ""
+
+#: src/cli/perry-toml.md:591
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr ""
+
+#: src/cli/perry-toml.md:593
+msgid "PERRY_LICENSE_KEY"
+msgstr ""
+
+#: src/cli/perry-toml.md:593
+msgid "${{ secrets.PERRY_LICENSE_KEY }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:594
+msgid "PERRY_APPLE_CERTIFICATE"
+msgstr ""
+
+#: src/cli/perry-toml.md:594
+msgid "${{ secrets.APPLE_CERTIFICATE }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:595
+msgid "PERRY_APPLE_CERTIFICATE_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:595
+msgid "${{ secrets.APPLE_CERT_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:596
+msgid "PERRY_APPLE_P8_KEY"
+msgstr ""
+
+#: src/cli/perry-toml.md:596
+msgid "${{ secrets.APPLE_P8_KEY }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:597
+msgid "PERRY_APPLE_KEY_ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:597
+msgid "${{ secrets.APPLE_KEY_ID }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:598
+msgid "PERRY_ANDROID_KEYSTORE"
+msgstr ""
+
+#: src/cli/perry-toml.md:598
+msgid "${{ secrets.ANDROID_KEYSTORE }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:599
+msgid "PERRY_ANDROID_KEYSTORE_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:599
+msgid "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:600
+msgid "PERRY_ANDROID_KEY_ALIAS"
+msgstr ""
+
+#: src/cli/perry-toml.md:600
+msgid "${{ secrets.ANDROID_KEY_ALIAS }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:601
+msgid "PERRY_ANDROID_KEY_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:601
+msgid "${{ secrets.ANDROID_KEY_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:604
+msgid "perry publish ios"
+msgstr ""
+
+#: src/cli/perry-toml.md:605
+msgid "perry publish android"
+msgstr ""
+
+#: src/cli/perry-toml.md:606
+msgid "perry publish macos"
+msgstr ""
+
+#: src/cli/perry-toml.md:609
+msgid "Keep `perry.toml` in version control with non-sensitive fields only:"
+msgstr ""
+
+#: src/cli/perry-toml.md:611
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"version = \"2.1.0\"\n"
+"build_number = 47\n"
+"bundle_id = \"com.example.myapp\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[ios]\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"distribute = \"appstore\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = \"26\"\n"
+"target_sdk = \"34\"\n"
+"distribute = \"playstore\"\n"
+"\n"
+"[macos]\n"
+"distribute = \"both\"\n"
+"category = \"public.app-category.productivity\"\n"
+"minimum_os = \"13.0\"\n"
+"\n"
+"[audit]\n"
+"fail_on = \"B\"\n"
+"```"
+msgstr ""
+
+#: src/contributing/architecture.md:3
+msgid ""
+"This is a brief overview for contributors. For detailed implementation "
+"notes, see the project's `CLAUDE.md`."
+msgstr ""
+
+#: src/contributing/architecture.md:5
+msgid "Compilation Pipeline"
+msgstr ""
+
+#: src/contributing/architecture.md:21
+msgid "Crate Map"
+msgstr ""
+
+#: src/contributing/architecture.md:23
+msgid "Crate"
+msgstr ""
+
+#: src/contributing/architecture.md:25
+msgid "`perry`"
+msgstr ""
+
+#: src/contributing/architecture.md:25
+msgid "CLI driver, command parsing, compilation orchestration"
+msgstr ""
+
+#: src/contributing/architecture.md:26
+msgid "`perry-parser`"
+msgstr ""
+
+#: src/contributing/architecture.md:26
+msgid "SWC wrapper for TypeScript parsing"
+msgstr ""
+
+#: src/contributing/architecture.md:27
+msgid "`perry-types`"
+msgstr ""
+
+#: src/contributing/architecture.md:27
+msgid "Type system definitions"
+msgstr ""
+
+#: src/contributing/architecture.md:28
+msgid "`perry-hir`"
+msgstr ""
+
+#: src/contributing/architecture.md:28
+msgid "HIR data structures (`ir.rs`) and AST→HIR lowering (`lower.rs`)"
+msgstr ""
+
+#: src/contributing/architecture.md:29
+msgid "`perry-transform`"
+msgstr ""
+
+#: src/contributing/architecture.md:29
+msgid "IR passes: function inlining, closure conversion, async lowering"
+msgstr ""
+
+#: src/contributing/architecture.md:30
+msgid "`perry-codegen-llvm`"
+msgstr ""
+
+#: src/contributing/architecture.md:30
+msgid "LLVM-based native code generation"
+msgstr ""
+
+#: src/contributing/architecture.md:31
+msgid "`perry-codegen-wasm`"
+msgstr ""
+
+#: src/contributing/architecture.md:31
+msgid ""
+"WebAssembly code generation for `--target web` / `--target wasm` (HIR → WASM"
+" bytecode + JS bridge)"
+msgstr ""
+
+#: src/contributing/architecture.md:32
+msgid "`perry-codegen-js`"
+msgstr ""
+
+#: src/contributing/architecture.md:32
+msgid ""
+"Legacy JavaScript code generator (still present for the JS minifier; the JS-"
+"emit `--target web` path was consolidated into `perry-codegen-wasm`)"
+msgstr ""
+
+#: src/contributing/architecture.md:33
+msgid "`perry-codegen-swiftui`"
+msgstr ""
+
+#: src/contributing/architecture.md:33
+msgid "SwiftUI code generation for WidgetKit extensions"
+msgstr ""
+
+#: src/contributing/architecture.md:34
+msgid "`perry-runtime`"
+msgstr ""
+
+#: src/contributing/architecture.md:34
+msgid ""
+"Runtime library: NaN-boxed values, GC, arena allocator, objects, arrays, "
+"strings"
+msgstr ""
+
+#: src/contributing/architecture.md:35
+msgid "`perry-stdlib`"
+msgstr ""
+
+#: src/contributing/architecture.md:35
+msgid "Node.js API implementations: mysql2, redis, fastify, bcrypt, etc."
+msgstr ""
+
+#: src/contributing/architecture.md:36
+msgid "`perry-ui`"
+msgstr ""
+
+#: src/contributing/architecture.md:36
+msgid "Shared UI types"
+msgstr ""
+
+#: src/contributing/architecture.md:37
+msgid "macOS UI (AppKit)"
+msgstr ""
+
+#: src/contributing/architecture.md:38
+msgid "iOS UI (UIKit)"
+msgstr ""
+
+#: src/contributing/architecture.md:39
+msgid "`perry-jsruntime`"
+msgstr ""
+
+#: src/contributing/architecture.md:39
+msgid "JavaScript interop via QuickJS"
+msgstr ""
+
+#: src/contributing/architecture.md:41
+msgid "Key Concepts"
+msgstr ""
+
+#: src/contributing/architecture.md:43
+msgid "NaN-Boxing"
+msgstr ""
+
+#: src/contributing/architecture.md:45
+msgid ""
+"All JavaScript values are represented as 64-bit NaN-boxed values. The upper "
+"16 bits encode the type tag:"
+msgstr ""
+
+#: src/contributing/architecture.md:47
+msgid "Tag"
+msgstr ""
+
+#: src/contributing/architecture.md:49
+msgid "`0x7FFF`"
+msgstr ""
+
+#: src/contributing/architecture.md:49
+msgid "String (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:50
+msgid "`0x7FFD`"
+msgstr ""
+
+#: src/contributing/architecture.md:50
+msgid "Pointer/Object (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:51
+msgid "`0x7FFE`"
+msgstr ""
+
+#: src/contributing/architecture.md:51
+msgid "Int32 (lower 32 bits = integer)"
+msgstr ""
+
+#: src/contributing/architecture.md:52
+msgid "`0x7FFA`"
+msgstr ""
+
+#: src/contributing/architecture.md:52
+msgid "BigInt (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:53
+msgid "Special constants"
+msgstr ""
+
+#: src/contributing/architecture.md:53
+msgid "undefined, null, true, false"
+msgstr ""
+
+#: src/contributing/architecture.md:54
+msgid "Any other"
+msgstr ""
+
+#: src/contributing/architecture.md:54
+msgid "Float64 (the full 64 bits)"
+msgstr ""
+
+#: src/contributing/architecture.md:58
+msgid ""
+"Mark-sweep GC with conservative stack scanning. Arena-allocated objects "
+"(arrays, objects) are found by linear block walking. Malloc-allocated "
+"objects (strings, closures, promises) are tracked in a thread-local Vec."
+msgstr ""
+
+#: src/contributing/architecture.md:60
+msgid "Handle-Based UI"
+msgstr ""
+
+#: src/contributing/architecture.md:62
+msgid ""
+"UI widgets are represented as small integer handles NaN-boxed with "
+"`POINTER_TAG`. Each handle maps to a native platform widget (NSButton, "
+"UILabel, GtkButton, etc.). Two dispatch tables route method calls and "
+"property accesses to the correct FFI function."
+msgstr ""
+
+#: src/contributing/architecture.md:64
+msgid "Source Code Organization"
+msgstr ""
+
+#: src/contributing/architecture.md:66
+msgid "The codegen crate is organized into focused modules:"
+msgstr ""
+
+#: src/contributing/architecture.md:83
+msgid "The HIR lowering was split into 8 modules:"
+msgstr ""
+
+#: src/contributing/architecture.md:99
+msgid "[Building from Source](building.md)"
+msgstr ""
+
+#: src/contributing/architecture.md:100
+msgid ""
+"See `CLAUDE.md` in the repository root for detailed implementation notes"
+msgstr ""
+
+#: src/contributing/building.md:5
+msgid "Rust toolchain (stable): [rustup.rs](https://rustup.rs/)"
+msgstr ""
+
+#: src/contributing/building.md:6
+msgid "System C compiler (`cc` on macOS/Linux, MSVC on Windows)"
+msgstr ""
+
+#: src/contributing/building.md:8
+msgid "Build"
+msgstr ""
+
+#: src/contributing/building.md:13
+msgid "# Build all crates (release mode recommended)\n"
+msgstr ""
+
+#: src/contributing/building.md:18
+msgid "The binary is at `target/release/perry`."
+msgstr ""
+
+#: src/contributing/building.md:20
+msgid "Build Specific Crates"
+msgstr ""
+
+#: src/contributing/building.md:23
+msgid "# Runtime only (must rebuild stdlib too!)\n"
+msgstr ""
+
+#: src/contributing/building.md:25
+msgid "# Codegen only\n"
+msgstr ""
+
+#: src/contributing/building.md:30
+msgid ""
+"**Important**: When rebuilding `perry-runtime`, you must also rebuild "
+"`perry-stdlib` because `libperry_stdlib.a` embeds perry-runtime as a static "
+"dependency."
+msgstr ""
+
+#: src/contributing/building.md:32
+msgid "Run Tests"
+msgstr ""
+
+#: src/contributing/building.md:35
+msgid "# All tests (exclude iOS crate on non-iOS host)\n"
+msgstr ""
+
+#: src/contributing/building.md:37
+msgid "# Specific crate\n"
+msgstr ""
+
+#: src/contributing/building.md:43
+msgid "Compile and Run TypeScript"
+msgstr ""
+
+#: src/contributing/building.md:46
+msgid "# Compile a TypeScript file\n"
+msgstr ""
+
+#: src/contributing/building.md:49
+msgid "# Debug: print HIR\n"
+msgstr ""
+
+#: src/contributing/building.md:54
+msgid "Development Workflow"
+msgstr ""
+
+#: src/contributing/building.md:56
+msgid "Make changes to the relevant crate"
+msgstr ""
+
+#: src/contributing/building.md:57
+msgid "`cargo build --release` to build"
+msgstr ""
+
+#: src/contributing/building.md:58
+msgid "`cargo test --workspace --exclude perry-ui-ios` to verify"
+msgstr ""
+
+#: src/contributing/building.md:59
+msgid ""
+"Test with a real TypeScript file: `cargo run --release -- test.ts -o test &&"
+" ./test`"
+msgstr ""
+
+#: src/contributing/building.md:88
+msgid "[Architecture](architecture.md) — Crate map and pipeline overview"
+msgstr ""
+
+#: src/contributing/building.md:89
+msgid "See `CLAUDE.md` for detailed implementation notes and pitfalls"
+msgstr ""

--- a/docs/po/ko.po
+++ b/docs/po/ko.po
@@ -1,0 +1,26517 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Perry Documentation\n"
+"POT-Creation-Date: 2026-05-02T21:12:49+02:00\n"
+"PO-Revision-Date: 2026-05-02T21:12:49+02:00\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/SUMMARY.md:1
+msgid "Summary"
+msgstr "목차"
+
+#: src/SUMMARY.md:3 src/introduction.md:1
+msgid "Introduction"
+msgstr "소개"
+
+#: src/SUMMARY.md:7
+msgid "Getting Started"
+msgstr "시작하기"
+
+#: src/SUMMARY.md:9 src/getting-started/installation.md:1 src/ui/theming.md:5
+msgid "Installation"
+msgstr "설치"
+
+#: src/SUMMARY.md:10 src/getting-started/hello-world.md:1
+msgid "Hello World"
+msgstr "Hello World"
+
+#: src/SUMMARY.md:11 src/getting-started/first-app.md:1
+msgid "First Native App"
+msgstr "첫 네이티브 앱"
+
+#: src/SUMMARY.md:12 src/getting-started/project-config.md:1
+msgid "Project Configuration"
+msgstr "프로젝트 설정"
+
+#: src/SUMMARY.md:14
+msgid "Language"
+msgstr "언어"
+
+#: src/SUMMARY.md:16 src/platforms/wasm.md:39
+msgid "Supported Features"
+msgstr "지원되는 기능"
+
+#: src/SUMMARY.md:17 src/language/type-system.md:1
+msgid "Type System"
+msgstr "타입 시스템"
+
+#: src/SUMMARY.md:18 src/language/limitations.md:1 src/platforms/tvos.md:156
+#: src/platforms/watchos.md:192 src/platforms/wasm.md:146
+msgid "Limitations"
+msgstr "제한 사항"
+
+#: src/SUMMARY.md:20
+msgid "npm Packages"
+msgstr "npm 패키지"
+
+#: src/SUMMARY.md:22
+msgid "Porting Packages (experimental)"
+msgstr "패키지 포팅 (실험적)"
+
+#: src/SUMMARY.md:24 src/getting-started/hello-world.md:97
+#: src/threading/overview.md:1
+msgid "Multi-Threading"
+msgstr "멀티스레딩"
+
+#: src/SUMMARY.md:26 src/SUMMARY.md:33 src/SUMMARY.md:50 src/SUMMARY.md:66
+#: src/SUMMARY.md:76 src/SUMMARY.md:83 src/SUMMARY.md:87 src/SUMMARY.md:108
+msgid "Overview"
+msgstr "개요"
+
+#: src/SUMMARY.md:27 src/threading/parallel-map.md:1
+msgid "parallelMap"
+msgstr ""
+
+#: src/SUMMARY.md:28 src/threading/parallel-filter.md:1
+msgid "parallelFilter"
+msgstr ""
+
+#: src/SUMMARY.md:29 src/threading/spawn.md:1
+msgid "spawn"
+msgstr ""
+
+#: src/SUMMARY.md:31
+msgid "Native UI"
+msgstr "네이티브 UI"
+
+#: src/SUMMARY.md:34 src/SUMMARY.md:95 src/SUMMARY.md:97 src/ui/widgets.md:1
+msgid "Widgets"
+msgstr "위젯"
+
+#: src/SUMMARY.md:35 src/ui/overview.md:174 src/ui/layout.md:1
+#: src/widgets/components.md:41
+msgid "Layout"
+msgstr "레이아웃"
+
+#: src/SUMMARY.md:36 src/ui/styling.md:1 src/platforms/linux.md:63
+msgid "Styling"
+msgstr "스타일링"
+
+#: src/SUMMARY.md:37 src/ui/state.md:1 src/platforms/watchos.md:105
+msgid "State Management"
+msgstr "상태 관리"
+
+#: src/SUMMARY.md:38 src/ui/events.md:1 src/plugins/creating-plugins.md:104
+msgid "Events"
+msgstr "이벤트"
+
+#: src/SUMMARY.md:39 src/ui/canvas.md:1 src/platforms/macos.md:37
+#: src/platforms/android.md:38 src/platforms/windows.md:55
+#: src/platforms/linux.md:49
+msgid "Canvas"
+msgstr "캔버스"
+
+#: src/SUMMARY.md:40 src/ui/overview.md:175 src/ui/menus.md:1
+msgid "Menus"
+msgstr "메뉴"
+
+#: src/SUMMARY.md:41 src/ui/dialogs.md:1
+msgid "Dialogs"
+msgstr "다이얼로그"
+
+#: src/SUMMARY.md:42 src/ui/table.md:1 src/platforms/macos.md:36
+#: src/testing/geisterhand.md:93 src/testing/geisterhand.md:296
+msgid "Table"
+msgstr "테이블"
+
+#: src/SUMMARY.md:43 src/ui/animation.md:1
+msgid "Animation"
+msgstr "애니메이션"
+
+#: src/SUMMARY.md:44
+msgid "Multi-Window"
+msgstr "다중 창"
+
+#: src/SUMMARY.md:45 src/ui/theming.md:1
+msgid "Theming"
+msgstr "테마"
+
+#: src/SUMMARY.md:46 src/ui/camera.md:1
+msgid "Camera"
+msgstr "카메라"
+
+#: src/SUMMARY.md:48 src/system/overview.md:21
+msgid "Platforms"
+msgstr "플랫폼"
+
+#: src/SUMMARY.md:51 src/getting-started/installation.md:103
+#: src/ui/overview.md:170 src/ui/canvas.md:74 src/ui/menus.md:68
+#: src/ui/menus.md:111 src/ui/dialogs.md:108 src/ui/animation.md:64
+#: src/ui/multi-window.md:72 src/ui/multi-window.md:89
+#: src/ui/multi-window.md:100 src/ui/multi-window.md:116
+#: src/ui/multi-window.md:132 src/ui/multi-window.md:140
+#: src/platforms/overview.md:9 src/platforms/overview.md:67
+#: src/platforms/macos.md:1 src/i18n/overview.md:89
+#: src/updater/overview.md:257 src/system/preferences.md:34
+#: src/system/keychain.md:25 src/system/notifications.md:62
+#: src/system/audio.md:61 src/system/media.md:86 src/system/other.md:20
+#: src/system/other.md:37 src/plugins/native-extensions.md:275
+#: src/plugins/appstore-review.md:89 src/testing/geisterhand.md:259
+#: src/testing/geisterhand.md:331
+msgid "macOS"
+msgstr ""
+
+#: src/SUMMARY.md:52 src/ui/overview.md:170 src/ui/canvas.md:75
+#: src/ui/menus.md:112 src/ui/dialogs.md:108 src/ui/animation.md:65
+#: src/platforms/overview.md:10 src/platforms/overview.md:67
+#: src/platforms/ios.md:1 src/platforms/tvos.md:170 src/i18n/overview.md:90
+#: src/system/preferences.md:35 src/system/keychain.md:26
+#: src/system/notifications.md:63 src/system/audio.md:62
+#: src/system/media.md:87 src/system/other.md:21 src/system/other.md:38
+#: src/widgets/platforms.md:11 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:39 src/widgets/platforms.md:63
+#: src/plugins/native-extensions.md:273 src/plugins/appstore-review.md:73
+#: src/testing/geisterhand.md:260
+msgid "iOS"
+msgstr ""
+
+#: src/SUMMARY.md:53 src/platforms/overview.md:11 src/platforms/overview.md:67
+#: src/platforms/visionos.md:1 src/system/media.md:89
+msgid "visionOS"
+msgstr ""
+
+#: src/SUMMARY.md:54 src/platforms/overview.md:12 src/platforms/overview.md:67
+#: src/platforms/tvos.md:1 src/platforms/tvos.md:170 src/system/media.md:88
+msgid "tvOS"
+msgstr ""
+
+#: src/SUMMARY.md:55 src/platforms/overview.md:13 src/platforms/overview.md:67
+#: src/platforms/watchos.md:1 src/system/media.md:93
+#: src/widgets/platforms.md:14 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:49 src/widgets/platforms.md:79
+msgid "watchOS"
+msgstr ""
+
+#: src/SUMMARY.md:56 src/ui/canvas.md:78 src/ui/animation.md:66
+#: src/platforms/overview.md:14 src/platforms/overview.md:67
+#: src/platforms/android.md:1 src/i18n/overview.md:91 src/i18n/overview.md:104
+#: src/system/preferences.md:36 src/system/keychain.md:27
+#: src/system/notifications.md:64 src/system/audio.md:63
+#: src/system/media.md:90 src/system/other.md:22 src/system/other.md:39
+#: src/widgets/platforms.md:13 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:44 src/widgets/platforms.md:71
+#: src/plugins/native-extensions.md:276 src/plugins/appstore-review.md:102
+#: src/testing/geisterhand.md:261 src/cli/flags.md:27
+#: src/cli/perry-toml.md:501
+msgid "Android"
+msgstr ""
+
+#: src/SUMMARY.md:57 src/platforms/harmonyos.md:1
+msgid "HarmonyOS NEXT"
+msgstr "HarmonyOS NEXT"
+
+#: src/SUMMARY.md:58 src/getting-started/installation.md:121
+#: src/ui/overview.md:170 src/ui/styling.md:372 src/ui/canvas.md:77
+#: src/ui/menus.md:113 src/ui/dialogs.md:108 src/ui/animation.md:67
+#: src/ui/multi-window.md:73 src/ui/multi-window.md:90
+#: src/ui/multi-window.md:101 src/ui/multi-window.md:117
+#: src/ui/multi-window.md:133 src/ui/multi-window.md:141
+#: src/platforms/overview.md:15 src/platforms/overview.md:67
+#: src/platforms/windows.md:1 src/i18n/overview.md:92
+#: src/updater/overview.md:258 src/system/preferences.md:37
+#: src/system/keychain.md:28 src/system/notifications.md:65
+#: src/system/audio.md:65 src/system/media.md:92 src/system/other.md:23
+#: src/system/other.md:40 src/testing/geisterhand.md:263
+#: src/testing/geisterhand.md:392 src/cli/flags.md:36
+msgid "Windows"
+msgstr ""
+
+#: src/SUMMARY.md:59 src/platforms/windows-7.md:1
+msgid "Windows 7 Compatibility"
+msgstr "Windows 7 호환성"
+
+#: src/SUMMARY.md:60 src/platforms/linux.md:1 src/testing/geisterhand.md:262
+#: src/testing/geisterhand.md:379
+msgid "Linux (GTK4)"
+msgstr ""
+
+#: src/SUMMARY.md:61 src/ui/overview.md:170 src/ui/canvas.md:72
+#: src/ui/menus.md:115 src/ui/dialogs.md:108 src/ui/animation.md:69
+#: src/ui/multi-window.md:143 src/platforms/web.md:1
+#: src/system/preferences.md:39 src/system/keychain.md:30
+#: src/system/notifications.md:67 src/system/audio.md:66
+#: src/system/media.md:95 src/system/other.md:25 src/system/other.md:42
+#: src/cli/flags.md:35
+msgid "Web"
+msgstr ""
+
+#: src/SUMMARY.md:62 src/cli/flags.md:34
+msgid "WebAssembly"
+msgstr "WebAssembly"
+
+#: src/SUMMARY.md:64
+msgid "Standard Library"
+msgstr "표준 라이브러리"
+
+#: src/SUMMARY.md:67 src/stdlib/fs.md:1
+msgid "File System"
+msgstr "파일 시스템"
+
+#: src/SUMMARY.md:68 src/stdlib/http.md:1
+msgid "HTTP & Networking"
+msgstr "HTTP 및 네트워킹"
+
+#: src/SUMMARY.md:69 src/stdlib/overview.md:22 src/stdlib/database.md:1
+msgid "Databases"
+msgstr "데이터베이스"
+
+#: src/SUMMARY.md:70 src/stdlib/overview.md:29 src/stdlib/crypto.md:1
+msgid "Cryptography"
+msgstr "암호화"
+
+#: src/SUMMARY.md:71 src/stdlib/overview.md:36 src/stdlib/utilities.md:1
+#: src/cli/perry-toml.md:231
+msgid "Utilities"
+msgstr "유틸리티"
+
+#: src/SUMMARY.md:72 src/stdlib/other.md:1
+msgid "Other Modules"
+msgstr "기타 모듈"
+
+#: src/SUMMARY.md:74
+msgid "Internationalization"
+msgstr "국제화"
+
+#: src/SUMMARY.md:77 src/i18n/interpolation.md:1
+msgid "Interpolation & Plurals"
+msgstr "보간 및 복수형"
+
+#: src/SUMMARY.md:78
+msgid "Formatting"
+msgstr "서식"
+
+#: src/SUMMARY.md:79
+msgid "CLI Tools"
+msgstr "CLI 도구"
+
+#: src/SUMMARY.md:81 src/updater/overview.md:1
+msgid "Auto-Update"
+msgstr "자동 업데이트"
+
+#: src/SUMMARY.md:85 src/platforms/overview.md:74 src/platforms/macos.md:75
+msgid "System APIs"
+msgstr "시스템 API"
+
+#: src/SUMMARY.md:88 src/system/preferences.md:1
+msgid "Preferences"
+msgstr "환경 설정"
+
+#: src/SUMMARY.md:89 src/system/keychain.md:1
+msgid "Keychain"
+msgstr "키체인"
+
+#: src/SUMMARY.md:90 src/system/notifications.md:1
+msgid "Notifications"
+msgstr "알림"
+
+#: src/SUMMARY.md:91 src/system/audio.md:1
+msgid "Audio Capture"
+msgstr "오디오 캡처"
+
+#: src/SUMMARY.md:92 src/system/media.md:1
+msgid "Media Playback"
+msgstr "미디어 재생"
+
+#: src/SUMMARY.md:93 src/ui/menus.md:68 src/stdlib/overview.md:50
+msgid "Other"
+msgstr "기타"
+
+#: src/SUMMARY.md:98 src/widgets/creating-widgets.md:1
+msgid "Creating Widgets"
+msgstr "위젯 만들기"
+
+#: src/SUMMARY.md:99
+msgid "Components & Modifiers"
+msgstr "컴포넌트 및 수정자"
+
+#: src/SUMMARY.md:100 src/platforms/visionos.md:35 src/platforms/tvos.md:123
+#: src/platforms/watchos.md:149 src/widgets/watchos.md:77
+#: src/plugins/creating-plugins.md:98 src/plugins/hooks-and-events.md:115
+msgid "Configuration"
+msgstr "설정"
+
+#: src/SUMMARY.md:101
+msgid "Data Fetching"
+msgstr "데이터 가져오기"
+
+#: src/SUMMARY.md:102 src/widgets/platforms.md:1
+msgid "Cross-Platform Reference"
+msgstr "크로스 플랫폼 레퍼런스"
+
+#: src/SUMMARY.md:103 src/widgets/watchos.md:1
+msgid "watchOS Complications"
+msgstr "watchOS 컴플리케이션"
+
+#: src/SUMMARY.md:104 src/widgets/wearos.md:1
+msgid "Wear OS Tiles"
+msgstr "Wear OS 타일"
+
+#: src/SUMMARY.md:106
+msgid "Plugins"
+msgstr "플러그인"
+
+#: src/SUMMARY.md:109 src/plugins/creating-plugins.md:1
+msgid "Creating Plugins"
+msgstr "플러그인 만들기"
+
+#: src/SUMMARY.md:110 src/plugins/hooks-and-events.md:1
+msgid "Hooks & Events"
+msgstr "훅 및 이벤트"
+
+#: src/SUMMARY.md:111 src/plugins/overview.md:90
+#: src/plugins/native-extensions.md:1
+msgid "Native Extensions"
+msgstr "네이티브 확장"
+
+#: src/SUMMARY.md:112 src/plugins/appstore-review.md:1
+msgid "App Store Review"
+msgstr "App Store 심사"
+
+#: src/SUMMARY.md:114
+msgid "Testing"
+msgstr "테스트"
+
+#: src/SUMMARY.md:116
+msgid "Geisterhand (UI Fuzzer)"
+msgstr "Geisterhand (UI 퍼저)"
+
+#: src/SUMMARY.md:118
+msgid "CLI Reference"
+msgstr "CLI 레퍼런스"
+
+#: src/SUMMARY.md:120
+msgid "Commands"
+msgstr "명령어"
+
+#: src/SUMMARY.md:121 src/cli/flags.md:1
+msgid "Compiler Flags"
+msgstr "컴파일러 플래그"
+
+#: src/SUMMARY.md:122 src/cli/perry-toml.md:1
+msgid "perry.toml Reference"
+msgstr "perry.toml 레퍼런스"
+
+#: src/SUMMARY.md:126
+msgid "Contributing"
+msgstr "기여"
+
+#: src/SUMMARY.md:128 src/platforms/harmonyos.md:5
+#: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
+msgid "Architecture"
+msgstr "아키텍처"
+
+#: src/SUMMARY.md:129 src/contributing/building.md:1
+msgid "Building from Source"
+msgstr "소스에서 빌드하기"
+
+#: src/introduction.md:3
+msgid ""
+"Perry is a native TypeScript compiler that compiles TypeScript source code "
+"directly to native executables. No JavaScript runtime, no JIT warmup, no V8 "
+"— your TypeScript compiles to a real binary."
+msgstr ""
+"Perry는 TypeScript 소스 코드를 네이티브 실행 파일로 직접 컴파일하는 네이티브 TypeScript 컴파일러입니다. "
+"JavaScript 런타임도, JIT 워밍업도, V8도 필요 없습니다 — TypeScript가 진짜 바이너리로 컴파일됩니다."
+
+#: src/introduction.md:5
+msgid ""
+"```typescript\n"
+"// demonstrates: the one-liner hello shown on the docs landing page\n"
+"// docs: docs/src/introduction.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"console.log(\"Hello from Perry!\")\n"
+"```"
+msgstr ""
+
+#: src/introduction.md:20
+msgid "Why Perry?"
+msgstr "왜 Perry인가?"
+
+#: src/introduction.md:22
+msgid ""
+"**Native performance** — Compiles to machine code via LLVM. Integer-heavy "
+"code like Fibonacci runs 2x faster than Node.js."
+msgstr ""
+"**네이티브 성능** — LLVM을 통해 머신 코드로 컴파일. 피보나치 같은 정수 위주 코드가 Node.js보다 2배 빠르게 실행됩니다."
+
+#: src/introduction.md:23
+msgid ""
+"**Real multi-threading** — `parallelMap` and `spawn` give you actual OS "
+"threads with compile-time safety. No isolates, no message passing overhead. "
+"[Something no JS runtime can do](threading/overview.md)."
+msgstr ""
+"**진짜 멀티스레딩** — `parallelMap`과 `spawn`이 컴파일 타임 안전성을 갖춘 실제 OS 스레드를 제공합니다. "
+"isolate도, 메시지 전달 오버헤드도 없습니다. [다른 JS 런타임은 할 수 없는 일](threading/overview.md)."
+
+#: src/introduction.md:24
+msgid ""
+"**Small binaries** — A hello world is ~300KB. Perry detects what runtime "
+"features you use and only links what's needed."
+msgstr ""
+"**작은 바이너리** — Hello World가 약 300KB. Perry는 사용하는 런타임 기능을 감지하여 필요한 것만 링크합니다."
+
+#: src/introduction.md:25
+msgid ""
+"**Native UI** — Build desktop and mobile apps with declarative TypeScript "
+"that compiles to real AppKit, UIKit, GTK4, Win32, or DOM widgets."
+msgstr ""
+"**네이티브 UI** — 선언적 TypeScript로 데스크톱과 모바일 앱을 구축. 실제 AppKit, UIKit, GTK4, "
+"Win32, DOM 위젯으로 컴파일됩니다."
+
+#: src/introduction.md:26
+msgid ""
+"**7 targets** — macOS, iOS, Android, Windows, Linux, Web, and WebAssembly "
+"from the same source code."
+msgstr ""
+"**7개 타깃** — 동일한 소스 코드에서 macOS, iOS, Android, Windows, Linux, Web, "
+"WebAssembly로 빌드."
+
+#: src/introduction.md:27
+msgid ""
+"**Familiar ecosystem** — Use npm packages like `fastify`, `mysql2`, `redis`,"
+" `bcrypt`, `lodash`, and more — compiled natively."
+msgstr ""
+"**익숙한 생태계** — `fastify`, `mysql2`, `redis`, `bcrypt`, `lodash` 같은 npm 패키지를 "
+"네이티브 컴파일하여 사용할 수 있습니다."
+
+#: src/introduction.md:28
+msgid ""
+"**Zero config** — Point Perry at a `.ts` file and get a binary. No "
+"`tsconfig.json` required."
+msgstr ""
+"**설정 불필요** — Perry에게 `.ts` 파일을 주면 바이너리가 나옵니다. `tsconfig.json`이 필요 없습니다."
+
+#: src/introduction.md:30
+msgid "What Perry Compiles"
+msgstr "Perry가 컴파일하는 것"
+
+#: src/introduction.md:32
+msgid "Perry supports a practical subset of TypeScript:"
+msgstr "Perry는 TypeScript의 실용적인 하위 집합을 지원합니다:"
+
+#: src/introduction.md:34
+msgid "Variables, functions, classes, enums, interfaces"
+msgstr "변수, 함수, 클래스, 열거형, 인터페이스"
+
+#: src/introduction.md:35
+msgid "Async/await, closures, generators"
+msgstr "Async/await, 클로저, 제너레이터"
+
+#: src/introduction.md:36
+msgid "Destructuring, spread, template literals"
+msgstr "구조 분해, 전개, 템플릿 리터럴"
+
+#: src/introduction.md:37
+msgid "Arrays, Maps, Sets, typed arrays"
+msgstr "배열, Map, Set, 타입 배열"
+
+#: src/introduction.md:38
+msgid "Regular expressions, JSON, Promises"
+msgstr "정규 표현식, JSON, Promise"
+
+#: src/introduction.md:39
+msgid "Module imports/exports"
+msgstr "모듈 import/export"
+
+#: src/introduction.md:40
+msgid "Generic type erasure"
+msgstr "제네릭 타입 소거"
+
+#: src/introduction.md:42
+msgid ""
+"See [Supported Features](language/supported-features.md) for the complete "
+"list."
+msgstr "전체 목록은 [지원되는 기능](language/supported-features.md)을 참조하세요."
+
+#: src/introduction.md:44
+msgid "Quick Example: Native App"
+msgstr "빠른 예제: 네이티브 앱"
+
+#: src/introduction.md:46 src/getting-started/first-app.md:10
+msgid ""
+"```typescript\n"
+"// demonstrates: minimal stateful UI — label + increment button\n"
+"// docs: docs/src/ui/state.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, visionos-simulator, tvos-simulator, watchos-simulator, android, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Button, State } from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"App({\n"
+"    title: \"Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Count: ${count.value}`),\n"
+"        Button(\"Increment\", () => count.set(count.value + 1)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/introduction.md:69
+msgid "# Opens a native macOS/Windows/Linux window\n"
+msgstr ""
+
+#: src/introduction.md:72
+msgid ""
+"This produces a ~3MB native app with real platform widgets — no Electron, no"
+" WebView."
+msgstr "이 명령은 실제 플랫폼 위젯을 가진 약 3MB짜리 네이티브 앱을 만듭니다 — Electron도, WebView도 없습니다."
+
+#: src/introduction.md:74 src/getting-started/first-app.md:41
+#: src/threading/overview.md:286 src/threading/parallel-map.md:18
+#: src/threading/parallel-filter.md:18 src/platforms/watchos.md:127
+#: src/platforms/wasm.md:29 src/stdlib/overview.md:5 src/i18n/overview.md:78
+#: src/widgets/overview.md:34 src/plugins/overview.md:7
+msgid "How It Works"
+msgstr "작동 방식"
+
+#: src/introduction.md:87
+msgid ""
+"Perry uses [SWC](https://swc.rs/) for TypeScript parsing and "
+"[LLVM](https://llvm.org/) for native code generation. Types are erased at "
+"compile time (like `tsc`), and values are represented at runtime using NaN-"
+"boxing for efficient 64-bit tagged values."
+msgstr ""
+"Perry는 TypeScript 파싱에 [SWC](https://swc.rs/)를, 네이티브 코드 생성에 "
+"[LLVM](https://llvm.org/)을 사용합니다. 타입은 (`tsc`처럼) 컴파일 타임에 소거되며, 값은 런타임에 효율적인 "
+"64비트 태그 값으로 NaN 박싱을 통해 표현됩니다."
+
+#: src/introduction.md:89 src/getting-started/hello-world.md:152
+#: src/getting-started/first-app.md:184
+#: src/getting-started/project-config.md:201
+#: src/language/supported-features.md:600 src/language/type-system.md:149
+#: src/language/limitations.md:182 src/threading/overview.md:312
+#: src/ui/overview.md:179 src/ui/widgets.md:396 src/ui/layout.md:367
+#: src/ui/styling.md:377 src/ui/state.md:225 src/ui/events.md:167
+#: src/ui/canvas.md:80 src/ui/menus.md:119 src/ui/dialogs.md:166
+#: src/ui/table.md:107 src/ui/animation.md:71 src/ui/multi-window.md:149
+#: src/ui/theming.md:166 src/ui/camera.md:143 src/platforms/overview.md:78
+#: src/platforms/macos.md:86 src/platforms/ios.md:137
+#: src/platforms/tvos.md:180 src/platforms/watchos.md:213
+#: src/platforms/android.md:92 src/platforms/windows.md:69
+#: src/platforms/linux.md:81 src/platforms/web.md:21 src/platforms/wasm.md:191
+#: src/stdlib/overview.md:100 src/stdlib/fs.md:88 src/stdlib/http.md:93
+#: src/stdlib/database.md:107 src/stdlib/crypto.md:87
+#: src/stdlib/utilities.md:104 src/stdlib/other.md:184
+#: src/i18n/overview.md:107 src/updater/overview.md:433
+#: src/system/overview.md:71 src/system/preferences.md:44
+#: src/system/keychain.md:35 src/system/notifications.md:72
+#: src/system/audio.md:71 src/system/other.md:68 src/widgets/overview.md:60
+#: src/widgets/creating-widgets.md:249 src/widgets/components.md:270
+#: src/widgets/configuration.md:139 src/widgets/data-fetching.md:203
+#: src/plugins/overview.md:96 src/plugins/creating-plugins.md:111
+#: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:297
+#: src/plugins/appstore-review.md:192 src/cli/commands.md:320
+#: src/cli/flags.md:176 src/contributing/architecture.md:97
+#: src/contributing/building.md:86
+msgid "Next Steps"
+msgstr "다음 단계"
+
+#: src/introduction.md:91
+msgid "[Install Perry](getting-started/installation.md)"
+msgstr "[Perry 설치하기](getting-started/installation.md)"
+
+#: src/introduction.md:92
+msgid "[Write your first program](getting-started/hello-world.md)"
+msgstr "[첫 프로그램 작성하기](getting-started/hello-world.md)"
+
+#: src/introduction.md:93
+msgid "[Build a native app](getting-started/first-app.md)"
+msgstr "[네이티브 앱 만들기](getting-started/first-app.md)"
+
+#: src/getting-started/installation.md:3 src/platforms/visionos.md:7
+#: src/contributing/building.md:3
+msgid "Prerequisites"
+msgstr "사전 요구 사항"
+
+#: src/getting-started/installation.md:5
+msgid ""
+"Perry compiles TypeScript to native binaries by linking with your system's C"
+" toolchain, so every install path needs a linker:"
+msgstr ""
+
+#: src/getting-started/installation.md:7
+msgid "**macOS**: Xcode Command Line Tools (`xcode-select --install`)"
+msgstr ""
+
+#: src/getting-started/installation.md:8
+msgid ""
+"**Linux**: `gcc` or `clang` (`apt install build-essential` on Debian/Ubuntu,"
+" `apk add build-base` on Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:9
+msgid ""
+"**Windows**: LLVM (`winget install LLVM.LLVM`) + `perry setup windows` "
+"(lightweight, ~1.5 GB, no Visual Studio needed), or MSVC Build Tools with "
+"the \"Desktop development with C++\" workload — see the [Windows platform "
+"guide](../platforms/windows.md) for both options"
+msgstr ""
+
+#: src/getting-started/installation.md:11
+msgid ""
+"The source install additionally needs the **Rust toolchain** via "
+"[rustup](https://rustup.rs/)."
+msgstr ""
+
+#: src/getting-started/installation.md:13
+msgid "Install Perry"
+msgstr "Perry 설치"
+
+#: src/getting-started/installation.md:15
+msgid "npm / npx (recommended — any platform)"
+msgstr ""
+
+#: src/getting-started/installation.md:17
+msgid ""
+"Perry ships as a prebuilt-binary npm package. This is the fastest way to get"
+" started and the only path that covers all seven supported platforms (macOS "
+"arm64/x64, Linux x64/arm64 glibc + musl, Windows x64) with a single command:"
+msgstr ""
+
+#: src/getting-started/installation.md:20
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
+msgstr ""
+
+#: src/getting-started/installation.md:23
+msgid "# Global\n"
+msgstr ""
+
+#: src/getting-started/installation.md:27
+msgid "# Zero-install, one-shot\n"
+msgstr ""
+
+#: src/getting-started/installation.md:32
+msgid ""
+"[`@perryts/perry`](https://www.npmjs.com/package/@perryts/perry) is a thin "
+"launcher; npm automatically picks the matching prebuilt via "
+"`optionalDependencies` (`@perryts/perry-darwin-arm64`, `@perryts/perry-"
+"linux-x64-musl`, etc.) based on your `os` / `cpu` / `libc`. Requires Node.js"
+" ≥ 16."
+msgstr ""
+
+#: src/getting-started/installation.md:34 src/ui/styling.md:368
+#: src/ui/canvas.md:70 src/ui/menus.md:109 src/ui/animation.md:62
+#: src/ui/multi-window.md:70 src/ui/multi-window.md:87
+#: src/ui/multi-window.md:98 src/ui/multi-window.md:114
+#: src/ui/multi-window.md:130 src/ui/multi-window.md:138
+#: src/platforms/overview.md:7 src/i18n/overview.md:87
+#: src/i18n/overview.md:101 src/updater/overview.md:255
+#: src/system/preferences.md:32 src/system/keychain.md:23
+#: src/system/notifications.md:60 src/system/audio.md:59
+#: src/system/media.md:84 src/system/other.md:18 src/system/other.md:35
+#: src/widgets/platforms.md:9 src/plugins/native-extensions.md:271
+#: src/testing/geisterhand.md:257 src/cli/flags.md:20
+msgid "Platform"
+msgstr ""
+
+#: src/getting-started/installation.md:34
+msgid "Prebuilt package"
+msgstr ""
+
+#: src/getting-started/installation.md:36
+msgid "macOS arm64 (Apple Silicon)"
+msgstr ""
+
+#: src/getting-started/installation.md:36
+msgid "`@perryts/perry-darwin-arm64`"
+msgstr ""
+
+#: src/getting-started/installation.md:37
+msgid "macOS x64 (Intel)"
+msgstr ""
+
+#: src/getting-started/installation.md:37
+msgid "`@perryts/perry-darwin-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:38
+msgid "Linux x64 (glibc)"
+msgstr ""
+
+#: src/getting-started/installation.md:38
+msgid "`@perryts/perry-linux-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:39
+msgid "Linux arm64 (glibc)"
+msgstr ""
+
+#: src/getting-started/installation.md:39
+msgid "`@perryts/perry-linux-arm64`"
+msgstr ""
+
+#: src/getting-started/installation.md:40
+msgid "Linux x64 (musl / Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:40
+msgid "`@perryts/perry-linux-x64-musl`"
+msgstr ""
+
+#: src/getting-started/installation.md:41
+msgid "Linux arm64 (musl / Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:41
+msgid "`@perryts/perry-linux-arm64-musl`"
+msgstr ""
+
+#: src/getting-started/installation.md:42
+msgid "Windows x64"
+msgstr ""
+
+#: src/getting-started/installation.md:42
+msgid "`@perryts/perry-win32-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:44
+msgid "Homebrew (macOS)"
+msgstr ""
+
+#: src/getting-started/installation.md:50
+msgid "winget (Windows)"
+msgstr ""
+
+#: src/getting-started/installation.md:56
+msgid "APT (Debian / Ubuntu)"
+msgstr ""
+
+#: src/getting-started/installation.md:60
+msgid ""
+"\"deb [signed-by=/usr/share/keyrings/perry.gpg] "
+"https://perryts.github.io/perry-apt stable main\""
+msgstr ""
+
+#: src/getting-started/installation.md:64
+msgid "From Source"
+msgstr ""
+
+#: src/getting-started/installation.md:72
+msgid "The binary is at `target/release/perry`. Add it to your PATH:"
+msgstr ""
+
+#: src/getting-started/installation.md:75
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
+msgstr ""
+
+#: src/getting-started/installation.md:76
+msgid "\"/path/to/perry/target/release:$PATH\""
+msgstr ""
+
+#: src/getting-started/installation.md:79
+msgid "Self-Update"
+msgstr ""
+
+#: src/getting-started/installation.md:81
+msgid "Once installed, Perry can update itself:"
+msgstr ""
+
+#: src/getting-started/installation.md:87
+msgid "This downloads the latest release and atomically replaces the binary."
+msgstr ""
+
+#: src/getting-started/installation.md:89
+msgid "Verify Installation"
+msgstr ""
+
+#: src/getting-started/installation.md:95
+msgid ""
+"This checks your installation, shows the current version, and reports if an "
+"update is available."
+msgstr ""
+
+#: src/getting-started/installation.md:101
+msgid "Platform-Specific Setup"
+msgstr ""
+
+#: src/getting-started/installation.md:105
+msgid ""
+"No additional setup needed. Perry uses the system `cc` linker and AppKit for"
+" UI apps."
+msgstr ""
+
+#: src/getting-started/installation.md:107
+msgid ""
+"For iOS development, install Xcode (not just Command Line Tools) for the iOS"
+" SDK and simulator."
+msgstr ""
+
+#: src/getting-started/installation.md:109 src/ui/overview.md:170
+#: src/ui/canvas.md:76 src/ui/menus.md:114 src/ui/dialogs.md:108
+#: src/ui/animation.md:68 src/ui/multi-window.md:74 src/ui/multi-window.md:91
+#: src/ui/multi-window.md:102 src/ui/multi-window.md:118
+#: src/ui/multi-window.md:134 src/ui/multi-window.md:142
+#: src/platforms/overview.md:16 src/platforms/overview.md:67
+#: src/i18n/overview.md:93 src/updater/overview.md:259
+#: src/system/preferences.md:38 src/system/keychain.md:29
+#: src/system/notifications.md:66 src/system/audio.md:64
+#: src/system/other.md:24 src/system/other.md:41 src/cli/flags.md:37
+msgid "Linux"
+msgstr ""
+
+#: src/getting-started/installation.md:111
+msgid "Install GTK4 development libraries for UI apps:"
+msgstr ""
+
+#: src/getting-started/installation.md:114 src/platforms/linux.md:9
+#: src/testing/geisterhand.md:384
+msgid "# Ubuntu/Debian\n"
+msgstr ""
+
+#: src/getting-started/installation.md:116 src/platforms/linux.md:12
+msgid "# Fedora\n"
+msgstr ""
+
+#: src/getting-started/installation.md:123
+msgid "Two toolchain options — pick one. Both produce identical binaries."
+msgstr ""
+
+#: src/getting-started/installation.md:125
+msgid "**Lightweight (recommended, ~1.5 GB, no Visual Studio):**"
+msgstr ""
+
+#: src/getting-started/installation.md:132
+msgid ""
+"`perry setup windows` downloads the Microsoft CRT + Windows SDK libraries "
+"via xwin after prompting for license acceptance. Pass `--accept-license` to "
+"skip the prompt in CI."
+msgstr ""
+
+#: src/getting-started/installation.md:134
+msgid "**MSVC Build Tools (~8 GB):**"
+msgstr ""
+
+#: src/getting-started/installation.md:136
+msgid ""
+"Install Visual Studio Build Tools with the \"Desktop development with C++\" "
+"workload — via the Visual Studio Installer, or:"
+msgstr ""
+
+#: src/getting-started/installation.md:138 src/platforms/windows.md:25
+msgid ""
+"```powershell\n"
+"winget install Microsoft.VisualStudio.2022.BuildTools --override `\n"
+"  \"--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended\"\n"
+"```"
+msgstr ""
+
+#: src/getting-started/installation.md:143
+msgid ""
+"Run `perry doctor` to verify the toolchain. See the [Windows platform "
+"guide](../platforms/windows.md) for details."
+msgstr ""
+
+#: src/getting-started/installation.md:145
+msgid "What's Next"
+msgstr ""
+
+#: src/getting-started/installation.md:147
+msgid "[Write your first program](hello-world.md)"
+msgstr ""
+
+#: src/getting-started/installation.md:148
+msgid "[Build a native app](first-app.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:3
+msgid "Your First Program"
+msgstr "첫 프로그램"
+
+#: src/getting-started/hello-world.md:5
+msgid "Create a file called `hello.ts`:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:7
+msgid ""
+"```typescript\n"
+"// demonstrates: the minimal Perry program in the docs\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"console.log(\"Hello, Perry!\")\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:16
+msgid "Compile and run it:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:23 src/threading/spawn.md:46
+#: src/widgets/wearos.md:64
+msgid "Output:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:29
+msgid ""
+"That's it. Perry compiled your TypeScript to a native executable — no "
+"Node.js, no bundler, no runtime."
+msgstr ""
+
+#: src/getting-started/hello-world.md:31
+msgid "A Slightly Bigger Example"
+msgstr "조금 더 큰 예제"
+
+#: src/getting-started/hello-world.md:33
+msgid ""
+"```typescript\n"
+"// demonstrates: recursive fib as a perf-vs-node talking point\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"function fibonacci(n: number): number {\n"
+"    if (n <= 1) return n\n"
+"    return fibonacci(n - 1) + fibonacci(n - 2)\n"
+"}\n"
+"\n"
+"const start = Date.now()\n"
+"const result = fibonacci(35)\n"
+"const elapsed = Date.now() - start\n"
+"\n"
+"console.log(`fibonacci(35) = ${result}`)\n"
+"console.log(`Completed in ${elapsed}ms`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:57
+msgid ""
+"This runs about 2x faster than Node.js because Perry compiles to native "
+"machine code with integer specialization."
+msgstr ""
+
+#: src/getting-started/hello-world.md:59
+msgid "Using Variables and Functions"
+msgstr "변수와 함수 사용하기"
+
+#: src/getting-started/hello-world.md:61
+msgid ""
+"```typescript\n"
+"const name: string = \"World\"\n"
+"const items: number[] = [1, 2, 3, 4, 5]\n"
+"\n"
+"const doubled = items.map((x) => x * 2)\n"
+"const sum = doubled.reduce((acc, x) => acc + x, 0)\n"
+"\n"
+"console.log(`Hello, ${name}!`)\n"
+"console.log(`Sum of doubled: ${sum}`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:72
+msgid "Async Code"
+msgstr "비동기 코드"
+
+#: src/getting-started/hello-world.md:74
+msgid ""
+"```typescript\n"
+"// demonstrates: async/await fetch shown in hello-world.md\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// run: false\n"
+"\n"
+"async function fetchData(): Promise<string> {\n"
+"    const response = await fetch(\"https://httpbin.org/get\")\n"
+"    const data = await response.json() as { origin: string }\n"
+"    return data.origin\n"
+"}\n"
+"\n"
+"const ip = await fetchData()\n"
+"console.log(`Your IP: ${ip}`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:95
+msgid "Perry compiles async/await to a native async runtime backed by Tokio."
+msgstr ""
+
+#: src/getting-started/hello-world.md:99
+msgid ""
+"Perry can do something no JavaScript runtime can — run your code on multiple"
+" CPU cores:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:101
+msgid ""
+"```typescript\n"
+"// demonstrates: parallelMap + spawn shown in hello-world.md\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"import { parallelMap, parallelFilter, spawn } from \"perry/thread\"\n"
+"\n"
+"const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"// Process all elements across all CPU cores\n"
+"const doubled = parallelMap(data, (x: number) => x * 2)\n"
+"console.log(doubled) // [2, 4, 6, 8, 10, 12, 14, 16]\n"
+"\n"
+"// Run heavy work in the background\n"
+"const result = await spawn(() => {\n"
+"    let sum = 0\n"
+"    for (let i = 0; i < 100_000_000; i++) sum += i\n"
+"    return sum\n"
+"})\n"
+"console.log(result)\n"
+"\n"
+"// parallelFilter is also available for the lift-and-parallelize case:\n"
+"const evens = parallelFilter(data, (x: number) => x % 2 === 0)\n"
+"console.log(evens)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:127
+msgid ""
+"This is real OS-level parallelism, not web workers or separate isolates. See"
+" [Multi-Threading](../threading/overview.md) for details."
+msgstr ""
+
+#: src/getting-started/hello-world.md:129
+msgid "What the Compiler Produces"
+msgstr "컴파일러가 만드는 것"
+
+#: src/getting-started/hello-world.md:131
+msgid "When you run `perry file.ts -o output`, Perry:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:133
+msgid "Parses your TypeScript with SWC"
+msgstr ""
+
+#: src/getting-started/hello-world.md:134
+msgid "Lowers the AST to an intermediate representation (HIR)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:135
+msgid "Applies optimizations (inlining, closure conversion, etc.)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:136
+msgid "Generates native machine code with LLVM"
+msgstr ""
+
+#: src/getting-started/hello-world.md:137
+msgid "Links with your system's C compiler"
+msgstr ""
+
+#: src/getting-started/hello-world.md:139
+msgid "The result is a standalone executable with no external dependencies."
+msgstr ""
+
+#: src/getting-started/hello-world.md:141
+#: src/getting-started/hello-world.md:143 src/stdlib/overview.md:66
+#: src/stdlib/overview.md:70
+msgid "Binary Size"
+msgstr "바이너리 크기"
+
+#: src/getting-started/hello-world.md:143
+msgid "Program"
+msgstr ""
+
+#: src/getting-started/hello-world.md:145
+msgid "Hello world"
+msgstr ""
+
+#: src/getting-started/hello-world.md:145 src/stdlib/overview.md:72
+msgid "~300KB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:146
+msgid "CLI with fs/path"
+msgstr ""
+
+#: src/getting-started/hello-world.md:146
+#: src/getting-started/hello-world.md:147 src/stdlib/overview.md:73
+msgid "~3MB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:147
+msgid "UI app"
+msgstr ""
+
+#: src/getting-started/hello-world.md:148
+msgid "Full app with stdlib"
+msgstr ""
+
+#: src/getting-started/hello-world.md:148 src/stdlib/overview.md:74
+msgid "~48MB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:150
+msgid ""
+"Perry automatically detects which runtime features you use and only links "
+"what's needed."
+msgstr ""
+
+#: src/getting-started/hello-world.md:154
+msgid "[Build a native UI app](first-app.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:155
+msgid "[Configure your project](project-config.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:156
+msgid ""
+"[Explore supported TypeScript features](../language/supported-features.md)"
+msgstr ""
+
+#: src/getting-started/first-app.md:3
+msgid ""
+"Perry compiles declarative TypeScript UI code to native platform widgets. No"
+" Electron, no WebView — real AppKit on macOS, UIKit on iOS, GTK4 on Linux, "
+"Win32 on Windows. Every example on this page is a real source file under "
+"`docs/examples/` that CI compiles and runs on every PR."
+msgstr ""
+
+#: src/getting-started/first-app.md:8
+msgid "A Simple Counter"
+msgstr "간단한 카운터"
+
+#: src/getting-started/first-app.md:31
+msgid "Compile and run:"
+msgstr ""
+
+#: src/getting-started/first-app.md:38
+msgid ""
+"A native window opens with a label and two buttons. Clicking \"Increment\" "
+"updates the count in real-time."
+msgstr ""
+
+#: src/getting-started/first-app.md:43
+msgid ""
+"**`App({ title, width, height, body })`** — Creates a native application "
+"window. `body` is the root widget."
+msgstr ""
+
+#: src/getting-started/first-app.md:44
+msgid ""
+"**`State(initialValue)`** — Creates reactive state. `.value` reads, "
+"`.set(v)` writes and triggers UI updates."
+msgstr ""
+
+#: src/getting-started/first-app.md:45
+msgid ""
+"**`VStack(spacing, [...])`** — Vertical stack layout (like SwiftUI's VStack "
+"or CSS flexbox column). The first arg is the gap in points between children."
+msgstr ""
+
+#: src/getting-started/first-app.md:46
+msgid ""
+"**`Text(string)`** — A text label. Template literals referencing "
+"`${state.value}` bind reactively."
+msgstr ""
+
+#: src/getting-started/first-app.md:47
+msgid "**`Button(label, onClick)`** — A native button with a click handler."
+msgstr ""
+
+#: src/getting-started/first-app.md:49
+msgid "A Todo App"
+msgstr "할 일 앱"
+
+#: src/getting-started/first-app.md:51 src/ui/state.md:160
+msgid ""
+"```typescript\n"
+"// demonstrates: complete reactive todo app combining State, ForEach, and widget tree mutation\n"
+"// docs: docs/src/ui/state.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    TextField,\n"
+"    VStack,\n"
+"    HStack,\n"
+"    State,\n"
+"    ForEach,\n"
+"    Spacer,\n"
+"    Divider,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const todos = State<string[]>([])\n"
+"const count = State(0)\n"
+"const input = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"Todo App\",\n"
+"    width: 480,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        Text(\"My Todos\"),\n"
+"\n"
+"        HStack(8, [\n"
+"            TextField(\"What needs to be done?\", (value: string) => input.set(value)),\n"
+"            Button(\"Add\", () => {\n"
+"                const text = input.value\n"
+"                if (text.length > 0) {\n"
+"                    todos.set([...todos.value, text])\n"
+"                    count.set(count.value + 1)\n"
+"                    input.set(\"\")\n"
+"                }\n"
+"            }),\n"
+"        ]),\n"
+"\n"
+"        Divider(),\n"
+"\n"
+"        ForEach(count, (i: number) =>\n"
+"            HStack(8, [\n"
+"                Text(todos.value[i]),\n"
+"                Spacer(),\n"
+"                Button(\"Delete\", () => {\n"
+"                    todos.set(todos.value.filter((_, idx) => idx !== i))\n"
+"                    count.set(count.value - 1)\n"
+"                }),\n"
+"            ]),\n"
+"        ),\n"
+"\n"
+"        Spacer(),\n"
+"        Text(`${count.value} items`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/getting-started/first-app.md:112
+msgid ""
+"`ForEach(count, render)` iterates by index — keep an item array and a count "
+"state in sync, then read items via `array.value[i]` inside the closure. See "
+"[State Management](../ui/state.md) for the full pattern."
+msgstr ""
+
+#: src/getting-started/first-app.md:116
+msgid "Cross-Platform"
+msgstr "크로스 플랫폼"
+
+#: src/getting-started/first-app.md:118
+msgid "The same code runs on all 6 platforms:"
+msgstr ""
+
+#: src/getting-started/first-app.md:121
+msgid "# macOS (default)\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:124
+msgid "# iOS Simulator\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:127
+msgid ""
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:129 src/platforms/overview.md:30
+msgid "# alias: --target wasm\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:131
+msgid "# Other platforms\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:138
+msgid ""
+"Each target compiles to the platform's native widget toolkit. See "
+"[Platforms](../platforms/overview.md) for details."
+msgstr ""
+
+#: src/getting-started/first-app.md:141
+msgid "Adding Styling"
+msgstr ""
+
+#: src/getting-started/first-app.md:143
+msgid ""
+"Styling is applied via free functions that take the widget handle as their "
+"first argument. Colors are RGBA floats in `[0.0, 1.0]` — divide a hex byte "
+"by 255 to convert (`0x33 / 255 ≈ 0.2`)."
+msgstr ""
+
+#: src/getting-started/first-app.md:147
+msgid ""
+"```typescript\n"
+"// demonstrates: counter from getting-started/first-app.md with styled widgets\n"
+"// docs: docs/src/getting-started/first-app.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"// run: false\n"
+"\n"
+"import {\n"
+"    App, VStack, Text, Button, State,\n"
+"    textSetFontSize, textSetColor,\n"
+"    setCornerRadius, setPadding,\n"
+"    widgetSetBackgroundColor,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"const label = Text(`Count: ${count.value}`)\n"
+"textSetFontSize(label, 24)\n"
+"textSetColor(label, 0.2, 0.2, 0.2, 1.0)        // RGBA in [0,1] — same as #333333\n"
+"\n"
+"const btn = Button(\"Increment\", () => count.set(count.value + 1))\n"
+"setCornerRadius(btn, 8)\n"
+"widgetSetBackgroundColor(btn, 0.0, 0.478, 1.0, 1.0)  // system blue\n"
+"\n"
+"const stack = VStack(20, [label, btn])\n"
+"setPadding(stack, 20, 20, 20, 20)\n"
+"\n"
+"App({\n"
+"    title: \"Styled Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: stack,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/getting-started/first-app.md:182
+msgid "See [Styling](../ui/styling.md) for all available style properties."
+msgstr ""
+
+#: src/getting-started/first-app.md:186
+msgid ""
+"[Project Configuration](project-config.md) — Set up `package.json` for Perry"
+" projects"
+msgstr ""
+
+#: src/getting-started/first-app.md:187
+msgid "[UI Overview](../ui/overview.md) — Complete guide to Perry's UI system"
+msgstr ""
+
+#: src/getting-started/first-app.md:188
+msgid "[Widgets Reference](../ui/widgets.md) — All available widgets"
+msgstr ""
+
+#: src/getting-started/first-app.md:189
+msgid "[State Management](../ui/state.md) — Reactive state and bindings"
+msgstr ""
+
+#: src/getting-started/project-config.md:3
+msgid ""
+"Perry projects use `perry.toml` and `package.json` for configuration. No "
+"special config file is required for basic usage, but larger projects benefit"
+" from Perry-specific settings."
+msgstr ""
+
+#: src/getting-started/project-config.md:5
+msgid ""
+"**Looking for the full perry.toml reference?** See [perry.toml "
+"Reference](../cli/perry-toml.md) for every field, section, platform option, "
+"and environment variable."
+msgstr ""
+
+#: src/getting-started/project-config.md:7
+msgid "Basic Setup"
+msgstr "기본 설정"
+
+#: src/getting-started/project-config.md:14
+msgid "This creates a `package.json` and a starter `src/index.ts`."
+msgstr ""
+
+#: src/getting-started/project-config.md:16
+msgid "package.json"
+msgstr "package.json"
+
+#: src/getting-started/project-config.md:20
+#: src/plugins/native-extensions.md:58 src/plugins/native-extensions.md:64
+#: src/plugins/appstore-review.md:183
+msgid "\"name\""
+msgstr ""
+
+#: src/getting-started/project-config.md:20
+msgid "\"my-project\""
+msgstr ""
+
+#: src/getting-started/project-config.md:21
+#: src/plugins/native-extensions.md:59
+msgid "\"version\""
+msgstr ""
+
+#: src/getting-started/project-config.md:21
+msgid "\"1.0.0\""
+msgstr ""
+
+#: src/getting-started/project-config.md:22
+#: src/plugins/native-extensions.md:60
+msgid "\"main\""
+msgstr ""
+
+#: src/getting-started/project-config.md:22
+#: src/plugins/native-extensions.md:60
+msgid "\"src/index.ts\""
+msgstr ""
+
+#: src/getting-started/project-config.md:23
+#: src/getting-started/project-config.md:39
+#: src/getting-started/project-config.md:61
+#: src/getting-started/project-config.md:74
+#: src/getting-started/project-config.md:95 src/packages/porting.md:24
+#: src/platforms/ios.md:98 src/platforms/ios.md:111
+#: src/platforms/android.md:57 src/platforms/android.md:72
+#: src/stdlib/overview.md:84 src/plugins/native-extensions.md:61
+#: src/plugins/appstore-review.md:180
+msgid "\"perry\""
+msgstr ""
+
+#: src/getting-started/project-config.md:24
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"compilePackages\""
+msgstr ""
+
+#: src/getting-started/project-config.md:29
+msgid "Perry Configuration"
+msgstr "Perry 설정"
+
+#: src/getting-started/project-config.md:31
+msgid "The `perry` field in `package.json` controls compiler behavior:"
+msgstr ""
+
+#: src/getting-started/project-config.md:33
+msgid "`compilePackages`"
+msgstr ""
+
+#: src/getting-started/project-config.md:35
+msgid ""
+"List npm packages to compile natively instead of routing through the "
+"JavaScript runtime:"
+msgstr ""
+
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"@noble/curves\""
+msgstr ""
+
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"@noble/hashes\""
+msgstr ""
+
+#: src/getting-started/project-config.md:45
+msgid "When a package is listed here, Perry:"
+msgstr ""
+
+#: src/getting-started/project-config.md:46
+msgid "Resolves the package in `node_modules/`"
+msgstr ""
+
+#: src/getting-started/project-config.md:47
+msgid ""
+"Prefers TypeScript source (`src/index.ts`) over compiled JavaScript "
+"(`lib/index.js`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:48
+msgid "Compiles all functions natively through LLVM"
+msgstr ""
+
+#: src/getting-started/project-config.md:49
+msgid ""
+"Deduplicates across nested `node_modules/` to prevent duplicate linker "
+"symbols"
+msgstr ""
+
+#: src/getting-started/project-config.md:51
+msgid ""
+"This is useful for pure TypeScript/JavaScript packages that don't rely on "
+"Node.js APIs. Packages that use native bindings, `eval()`, or dynamic "
+"`require()` won't work."
+msgstr ""
+
+#: src/getting-started/project-config.md:53
+msgid "`splash`"
+msgstr ""
+
+#: src/getting-started/project-config.md:55
+msgid ""
+"Configure a native splash screen for iOS and Android. The splash screen "
+"appears instantly during cold start, before your app code runs."
+msgstr ""
+
+#: src/getting-started/project-config.md:57
+msgid "**Minimal (both platforms share the same splash):**"
+msgstr ""
+
+#: src/getting-started/project-config.md:62
+#: src/getting-started/project-config.md:75
+#: src/getting-started/project-config.md:96 src/platforms/ios.md:99
+#: src/platforms/ios.md:112 src/platforms/android.md:58
+#: src/platforms/android.md:73
+msgid "\"splash\""
+msgstr ""
+
+#: src/getting-started/project-config.md:63
+#: src/getting-started/project-config.md:76
+#: src/getting-started/project-config.md:79
+#: src/getting-started/project-config.md:83 src/platforms/ios.md:100
+#: src/platforms/android.md:59
+msgid "\"image\""
+msgstr ""
+
+#: src/getting-started/project-config.md:63
+#: src/getting-started/project-config.md:76 src/platforms/ios.md:100
+#: src/platforms/android.md:59
+msgid "\"logo/icon-256.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:64
+#: src/getting-started/project-config.md:77
+#: src/getting-started/project-config.md:80
+#: src/getting-started/project-config.md:84 src/ui/theming.md:26
+#: src/platforms/ios.md:101 src/platforms/android.md:60
+msgid "\"background\""
+msgstr ""
+
+#: src/getting-started/project-config.md:64
+#: src/getting-started/project-config.md:77 src/platforms/ios.md:101
+#: src/platforms/android.md:60
+msgid "\"#FFF5EE\""
+msgstr ""
+
+#: src/getting-started/project-config.md:70
+msgid "**Per-platform overrides:**"
+msgstr ""
+
+#: src/getting-started/project-config.md:78
+#: src/getting-started/project-config.md:97 src/platforms/ios.md:113
+#: src/plugins/native-extensions.md:67
+msgid "\"ios\""
+msgstr ""
+
+#: src/getting-started/project-config.md:79
+msgid "\"logo/splash-ios.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:80
+#: src/getting-started/project-config.md:84 src/ui/theming.md:26
+#: src/ui/theming.md:29
+msgid "\"#FFFFFF\""
+msgstr ""
+
+#: src/getting-started/project-config.md:82
+#: src/getting-started/project-config.md:100 src/platforms/android.md:74
+#: src/plugins/native-extensions.md:72
+msgid "\"android\""
+msgstr ""
+
+#: src/getting-started/project-config.md:83
+msgid "\"logo/splash-android.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:91
+msgid "**Full custom override (complete control):**"
+msgstr ""
+
+#: src/getting-started/project-config.md:98 src/platforms/ios.md:113
+msgid "\"storyboard\""
+msgstr ""
+
+#: src/getting-started/project-config.md:98 src/platforms/ios.md:113
+msgid "\"splash/LaunchScreen.storyboard\""
+msgstr ""
+
+#: src/getting-started/project-config.md:101 src/platforms/android.md:75
+msgid "\"layout\""
+msgstr ""
+
+#: src/getting-started/project-config.md:101 src/platforms/android.md:75
+msgid "\"splash/splash_background.xml\""
+msgstr ""
+
+#: src/getting-started/project-config.md:102 src/platforms/android.md:76
+msgid "\"theme\""
+msgstr ""
+
+#: src/getting-started/project-config.md:102 src/platforms/android.md:76
+msgid "\"splash/themes.xml\""
+msgstr ""
+
+#: src/getting-started/project-config.md:109 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414
+msgid "Field"
+msgstr ""
+
+#: src/getting-started/project-config.md:109 src/ui/overview.md:57
+#: src/ui/widgets.md:377 src/ui/layout.md:173 src/ui/menus.md:53
+#: src/ui/multi-window.md:36 src/ui/multi-window.md:80
+#: src/ui/multi-window.md:124 src/system/overview.md:21
+#: src/widgets/creating-widgets.md:45 src/widgets/configuration.md:70
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/testing/geisterhand.md:84 src/testing/geisterhand.md:98
+#: src/cli/commands.md:17 src/cli/commands.md:60 src/cli/commands.md:109
+#: src/cli/commands.md:148 src/cli/commands.md:181 src/cli/commands.md:195
+#: src/cli/commands.md:233 src/cli/commands.md:248 src/cli/commands.md:260
+#: src/cli/flags.md:9 src/cli/flags.md:43 src/cli/flags.md:50
+#: src/cli/flags.md:58 src/cli/flags.md:66 src/cli/flags.md:73
+#: src/cli/flags.md:80 src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:277
+#: src/cli/perry-toml.md:284 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:367 src/cli/perry-toml.md:377
+#: src/cli/perry-toml.md:387 src/cli/perry-toml.md:397
+#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:491
+#: src/cli/perry-toml.md:503 src/cli/perry-toml.md:513
+msgid "Description"
+msgstr ""
+
+#: src/getting-started/project-config.md:111
+msgid "`splash.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:111
+msgid "Path to a PNG image, centered on the splash screen (both platforms)"
+msgstr ""
+
+#: src/getting-started/project-config.md:112
+msgid "`splash.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:112
+msgid "Hex color for the background (default: `#FFFFFF`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:113
+msgid "`splash.ios.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:113
+msgid "iOS-specific image override"
+msgstr ""
+
+#: src/getting-started/project-config.md:114
+msgid "`splash.ios.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:114
+msgid "iOS-specific background color"
+msgstr ""
+
+#: src/getting-started/project-config.md:115
+msgid "`splash.ios.storyboard`"
+msgstr ""
+
+#: src/getting-started/project-config.md:115
+msgid "Custom LaunchScreen.storyboard (compiled with ibtool)"
+msgstr ""
+
+#: src/getting-started/project-config.md:116
+msgid "`splash.android.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:116
+msgid "Android-specific image override"
+msgstr ""
+
+#: src/getting-started/project-config.md:117
+msgid "`splash.android.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:117
+msgid "Android-specific background color"
+msgstr ""
+
+#: src/getting-started/project-config.md:118
+msgid "`splash.android.layout`"
+msgstr ""
+
+#: src/getting-started/project-config.md:118
+msgid "Custom drawable XML for `windowBackground`"
+msgstr ""
+
+#: src/getting-started/project-config.md:119
+msgid "`splash.android.theme`"
+msgstr ""
+
+#: src/getting-started/project-config.md:119
+msgid "Custom themes.xml"
+msgstr ""
+
+#: src/getting-started/project-config.md:121
+msgid "**Resolution order** per platform:"
+msgstr ""
+
+#: src/getting-started/project-config.md:122
+msgid "Custom file override (storyboard / layout+theme)"
+msgstr ""
+
+#: src/getting-started/project-config.md:123
+msgid "Platform-specific image/color (`splash.{platform}.image`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:124
+msgid "Universal image/color (`splash.image`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:125
+msgid "No `splash` key → blank white screen (backward compatible)"
+msgstr ""
+
+#: src/getting-started/project-config.md:127
+msgid "Using npm Packages"
+msgstr "npm 패키지 사용하기"
+
+#: src/getting-started/project-config.md:129
+msgid ""
+"Perry natively supports many popular npm packages without any configuration:"
+msgstr ""
+
+#: src/getting-started/project-config.md:131
+msgid ""
+"```typescript\n"
+"// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
+"// docs: docs/src/getting-started/project-config.md\n"
+"// platforms: macos, linux, windows\n"
+"// run: false\n"
+"\n"
+"// These four imports are Perry's most-used built-in stdlib shims:\n"
+"// fastify (HTTP server), mysql2 (db), ioredis (Redis), bcrypt (password\n"
+"// hashing). They're compiled to native code via Perry's per-package\n"
+"// implementations — no `compilePackages` needed.\n"
+"//\n"
+"// `// run: false` because each one needs a live external service (DB,\n"
+"// Redis, network port) to actually do anything; the binary still has to\n"
+"// link cleanly, which is the drift check we want.\n"
+"\n"
+"import fastify from \"fastify\"\n"
+"import mysql from \"mysql2/promise\"\n"
+"import Redis from \"ioredis\"\n"
+"import bcrypt from \"bcrypt\"\n"
+"\n"
+"const app = fastify({ logger: false })\n"
+"const db = mysql.createPool({ host: \"localhost\", user: \"root\", database: \"test\" })\n"
+"const redis = new Redis()\n"
+"const hashed = await bcrypt.hash(\"hunter2\", 10)\n"
+"\n"
+"console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/project-config.md:159
+msgid ""
+"These are compiled to native code using Perry's built-in implementations. "
+"See [Standard Library](../stdlib/overview.md) for the full list."
+msgstr ""
+
+#: src/getting-started/project-config.md:161
+msgid ""
+"For packages not natively supported, use `compilePackages` for pure TS/JS "
+"packages, or the JavaScript runtime fallback for complex packages."
+msgstr ""
+
+#: src/getting-started/project-config.md:163 src/contributing/building.md:61
+msgid "Project Structure"
+msgstr "프로젝트 구조"
+
+#: src/getting-started/project-config.md:165
+msgid "Perry is flexible about project structure. Common patterns:"
+msgstr ""
+
+#: src/getting-started/project-config.md:175
+msgid "For UI apps:"
+msgstr ""
+
+#: src/getting-started/project-config.md:186 src/widgets/watchos.md:59
+#: src/widgets/wearos.md:58
+msgid "Compilation"
+msgstr ""
+
+#: src/getting-started/project-config.md:189
+msgid "# Compile a file\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:191
+msgid "# Compile with a specific target\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:194
+msgid "# Debug: print intermediate representation\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:199
+msgid "See [CLI Commands](../cli/commands.md) for all options."
+msgstr ""
+
+#: src/getting-started/project-config.md:203
+msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
+msgstr ""
+
+#: src/getting-started/project-config.md:204
+msgid ""
+"[Supported Features](../language/supported-features.md) — What TypeScript "
+"features work"
+msgstr ""
+
+#: src/getting-started/project-config.md:205
+msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
+msgstr ""
+
+#: src/language/supported-features.md:1
+msgid "Supported TypeScript Features"
+msgstr ""
+
+#: src/language/supported-features.md:3
+msgid ""
+"Perry compiles a practical subset of TypeScript to native code. This page "
+"lists what's supported."
+msgstr ""
+
+#: src/language/supported-features.md:5
+msgid "Primitive Types"
+msgstr ""
+
+#: src/language/supported-features.md:7
+msgid ""
+"```typescript\n"
+"function primitives(): void {\n"
+"    const n: number = 42;\n"
+"    const s: string = \"hello\";\n"
+"    const b: boolean = true;\n"
+"    const u: undefined = undefined;\n"
+"    const nl: null = null;\n"
+"\n"
+"    console.log(`primitives: n=${n} s=${s} b=${b} u=${u} nl=${nl}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:19
+msgid "All primitives are represented as 64-bit NaN-boxed values at runtime."
+msgstr ""
+
+#: src/language/supported-features.md:21
+msgid "Variables and Constants"
+msgstr ""
+
+#: src/language/supported-features.md:23
+msgid ""
+"```typescript\n"
+"function variables(): void {\n"
+"    let x = 10;\n"
+"    const y = \"immutable\";\n"
+"    var z = true; // var is supported but let/const preferred\n"
+"\n"
+"    console.log(`variables: x=${x} y=${y} z=${z}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:33
+msgid ""
+"Perry infers types from initializers — `let x = 5` is inferred as `number` "
+"without an explicit annotation."
+msgstr ""
+
+#: src/language/supported-features.md:35
+msgid "Functions"
+msgstr ""
+
+#: src/language/supported-features.md:37
+msgid ""
+"```typescript\n"
+"function functionsDemo(): void {\n"
+"    function add(a: number, b: number): number {\n"
+"        return a + b;\n"
+"    }\n"
+"\n"
+"    // Optional parameters\n"
+"    function greet(name: string, greeting: string = \"Hello\"): string {\n"
+"        return `${greeting}, ${name}!`;\n"
+"    }\n"
+"\n"
+"    // Rest parameters\n"
+"    function sum(...nums: number[]): number {\n"
+"        return nums.reduce((a, b) => a + b, 0);\n"
+"    }\n"
+"\n"
+"    // Arrow functions\n"
+"    const double = (x: number) => x * 2;\n"
+"\n"
+"    console.log(`functions: add=${add(2, 3)} greet=${greet(\"Perry\")} sum=${sum(1, 2, 3)} double=${double(5)}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:60
+msgid "Classes"
+msgstr ""
+
+#: src/language/supported-features.md:62
+msgid ""
+"```typescript\n"
+"class Animal {\n"
+"    name: string;\n"
+"\n"
+"    constructor(name: string) {\n"
+"        this.name = name;\n"
+"    }\n"
+"\n"
+"    speak(): string {\n"
+"        return `${this.name} makes a noise`;\n"
+"    }\n"
+"}\n"
+"\n"
+"class Dog extends Animal {\n"
+"    speak(): string {\n"
+"        return `${this.name} barks`;\n"
+"    }\n"
+"}\n"
+"\n"
+"// Static methods\n"
+"class Counter {\n"
+"    private static instance: Counter;\n"
+"    private count: number = 0;\n"
+"\n"
+"    static getInstance(): Counter {\n"
+"        if (!Counter.instance) {\n"
+"            Counter.instance = new Counter();\n"
+"        }\n"
+"        return Counter.instance;\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:95
+msgid "Supported class features:"
+msgstr ""
+
+#: src/language/supported-features.md:96
+msgid "Constructors"
+msgstr ""
+
+#: src/language/supported-features.md:97
+msgid "Instance and static methods"
+msgstr ""
+
+#: src/language/supported-features.md:98
+msgid "Instance and static properties"
+msgstr ""
+
+#: src/language/supported-features.md:99
+msgid "Inheritance (`extends`)"
+msgstr ""
+
+#: src/language/supported-features.md:100
+msgid "Method overriding"
+msgstr ""
+
+#: src/language/supported-features.md:101
+msgid "`instanceof` checks (via class ID chain)"
+msgstr ""
+
+#: src/language/supported-features.md:102
+msgid "Singleton patterns (static method return type inference)"
+msgstr ""
+
+#: src/language/supported-features.md:104
+msgid "Enums"
+msgstr ""
+
+#: src/language/supported-features.md:106
+msgid ""
+"```typescript\n"
+"// Numeric enums\n"
+"enum Direction {\n"
+"    Up,\n"
+"    Down,\n"
+"    Left,\n"
+"    Right,\n"
+"}\n"
+"\n"
+"// String enums\n"
+"enum Color {\n"
+"    Red = \"RED\",\n"
+"    Green = \"GREEN\",\n"
+"    Blue = \"BLUE\",\n"
+"}\n"
+"\n"
+"const dir = Direction.Up;\n"
+"const color = Color.Red;\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:126
+msgid "Enums are compiled to constants and work across modules."
+msgstr ""
+
+#: src/language/supported-features.md:128
+msgid "Interfaces and Type Aliases"
+msgstr ""
+
+#: src/language/supported-features.md:142
+msgid ""
+"Interfaces and type aliases are erased at compile time (like `tsc`). They "
+"exist only for documentation and editor tooling."
+msgstr ""
+
+#: src/language/supported-features.md:144 src/threading/overview.md:306
+#: src/threading/parallel-map.md:58
+msgid "Arrays"
+msgstr ""
+
+#: src/language/supported-features.md:146
+msgid ""
+"```typescript\n"
+"function arraysDemo(): void {\n"
+"    const nums: number[] = [1, 2, 3];\n"
+"\n"
+"    // Array methods\n"
+"    nums.push(4);\n"
+"    nums.pop();\n"
+"    const len = nums.length;\n"
+"    const doubled = nums.map((x) => x * 2);\n"
+"    const filtered = nums.filter((x) => x > 2);\n"
+"    const sum = nums.reduce((acc, x) => acc + x, 0);\n"
+"    const found = nums.find((x) => x === 3);\n"
+"    const idx = nums.indexOf(3);\n"
+"    const joined = nums.join(\", \");\n"
+"    const sliced = nums.slice(1, 3);\n"
+"    nums.splice(1, 1);\n"
+"    nums.unshift(0);\n"
+"    const sorted = nums.sort((a, b) => a - b);\n"
+"    const reversed = nums.reverse();\n"
+"    const includes = nums.includes(3);\n"
+"    const every = nums.every((x) => x > 0);\n"
+"    const some = nums.some((x) => x > 2);\n"
+"    nums.forEach((x) => console.log(x));\n"
+"    const flat = [[1, 2], [3]].flat();\n"
+"    const concatted = nums.concat([5, 6]);\n"
+"\n"
+"    // Array.from\n"
+"    const arr = Array.from([10, 20, 30]);\n"
+"\n"
+"    // Array.isArray\n"
+"    const value: any = [1, 2, 3]\n"
+"    if (Array.isArray(value)) { /* ... */ }\n"
+"\n"
+"    // for...of iteration\n"
+"    for (const item of nums) {\n"
+"        console.log(item);\n"
+"    }\n"
+"\n"
+"    console.log(`arrays: len=${len} doubled=${doubled.length} filtered=${filtered.length} sum=${sum} found=${found} idx=${idx} joined=${joined} sliced=${sliced.length} sorted=${sorted.length} reversed=${reversed.length} includes=${includes} every=${every} some=${some} flat=${flat.length} concatted=${concatted.length} arr=${arr.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:188 src/threading/overview.md:307
+#: src/threading/parallel-map.md:59
+msgid "Objects"
+msgstr ""
+
+#: src/language/supported-features.md:190
+msgid ""
+"```typescript\n"
+"function objectsDemo(): void {\n"
+"    const obj: { name: string; version: number; [k: string]: any } = { name: \"Perry\", version: 1 };\n"
+"    obj.name = \"Perry 2\";\n"
+"\n"
+"    // Dynamic property access\n"
+"    const key = \"name\";\n"
+"    const val = obj[key];\n"
+"\n"
+"    // Object.keys, Object.values, Object.entries\n"
+"    const keys = Object.keys(obj);\n"
+"    const values = Object.values(obj);\n"
+"    const entries = Object.entries(obj);\n"
+"\n"
+"    // Spread\n"
+"    const copy = { ...obj, extra: true };\n"
+"\n"
+"    // delete\n"
+"    delete obj[key];\n"
+"\n"
+"    console.log(`objects: val=${val} keys=${keys.length} values=${values.length} entries=${entries.length} copy=${copy.extra}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:214
+msgid "Destructuring"
+msgstr ""
+
+#: src/language/supported-features.md:216
+msgid ""
+"```typescript\n"
+"function destructuringDemo(): void {\n"
+"    // Array destructuring\n"
+"    const [a, b, ...rest] = [1, 2, 3, 4, 5];\n"
+"\n"
+"    const user = { name: \"Alice\", age: 30, email: \"a@example.com\", id: 1 }\n"
+"    const obj = { id: 2, role: \"admin\", level: 5 }\n"
+"\n"
+"    // Object destructuring\n"
+"    const { name, age, email = \"none\" } = user;\n"
+"\n"
+"    // Rename\n"
+"    const { name: userName } = user;\n"
+"\n"
+"    // Rest pattern\n"
+"    const { id, ...remaining } = obj;\n"
+"\n"
+"    // Function parameter destructuring\n"
+"    function process({ name, age }: { name: string; age: number }) {\n"
+"        console.log(name, age);\n"
+"    }\n"
+"\n"
+"    process(user)\n"
+"    console.log(`destructuring: a=${a} b=${b} rest=${rest.length} name=${name} age=${age} email=${email} userName=${userName} id=${id}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:243 src/widgets/creating-widgets.md:112
+msgid "Template Literals"
+msgstr ""
+
+#: src/language/supported-features.md:245
+msgid ""
+"```typescript\n"
+"function templateLiteralsDemo(): void {\n"
+"    const name = \"world\";\n"
+"    const greeting = `Hello, ${name}!`;\n"
+"    const multiline = `\n"
+"  Line 1\n"
+"  Line 2\n"
+"`;\n"
+"    const expr = `Result: ${1 + 2}`;\n"
+"\n"
+"    console.log(`template-literals: greeting=${greeting} multiline_len=${multiline.length} expr=${expr}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:259
+msgid "Spread and Rest"
+msgstr ""
+
+#: src/language/supported-features.md:261
+msgid ""
+"```typescript\n"
+"function spreadRestDemo(): void {\n"
+"    const arr1 = [1, 2]\n"
+"    const arr2 = [3, 4]\n"
+"    const defaults = { theme: \"light\", size: \"md\" }\n"
+"    const overrides = { size: \"lg\" }\n"
+"\n"
+"    // Array spread\n"
+"    const combined = [...arr1, ...arr2];\n"
+"\n"
+"    // Object spread\n"
+"    const merged = { ...defaults, ...overrides };\n"
+"\n"
+"    // Rest parameters\n"
+"    function log(...args: any[]) { /* ... */ }\n"
+"\n"
+"    log(\"a\", \"b\", \"c\")\n"
+"    console.log(`spread-rest: combined=${combined.length} merged=${merged.size}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:282 src/threading/overview.md:308
+msgid "Closures"
+msgstr ""
+
+#: src/language/supported-features.md:284
+msgid ""
+"```typescript\n"
+"function closuresDemo(): void {\n"
+"    function makeCounter() {\n"
+"        let count = 0;\n"
+"        return {\n"
+"            increment: () => ++count,\n"
+"            get: () => count,\n"
+"        };\n"
+"    }\n"
+"\n"
+"    const counter = makeCounter();\n"
+"    counter.increment();\n"
+"    console.log(counter.get()); // 1\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:300
+msgid ""
+"Perry performs closure conversion — captured variables are stored in heap-"
+"allocated closure objects."
+msgstr ""
+
+#: src/language/supported-features.md:302
+msgid "Async/Await"
+msgstr ""
+
+#: src/language/supported-features.md:304
+msgid ""
+"```typescript\n"
+"async function asyncAwaitDemo(): Promise<void> {\n"
+"    interface Profile { id: number; name: string }\n"
+"\n"
+"    async function fetchUser(id: number): Promise<Profile> {\n"
+"        // The docs example uses fetch(...) here; we inline a synthetic\n"
+"        // result so the snippet compiles and runs hermetically.\n"
+"        return { id, name: `user-${id}` }\n"
+"    }\n"
+"\n"
+"    const data = await fetchUser(1);\n"
+"    console.log(`async-await: id=${data.id} name=${data.name}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:319
+msgid ""
+"Perry compiles async functions to a state machine backed by Tokio's async "
+"runtime."
+msgstr ""
+
+#: src/language/supported-features.md:321
+msgid "Promises"
+msgstr ""
+
+#: src/language/supported-features.md:323
+msgid ""
+"```typescript\n"
+"async function promisesDemo(): Promise<void> {\n"
+"    const p = new Promise<number>((resolve, reject) => {\n"
+"        resolve(42);\n"
+"    });\n"
+"\n"
+"    p.then((value) => console.log(value));\n"
+"\n"
+"    // Promise.all\n"
+"    const results = await Promise.all([\n"
+"        Promise.resolve(\"a\"),\n"
+"        Promise.resolve(\"b\"),\n"
+"    ]);\n"
+"\n"
+"    console.log(`promises: results=${results.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:341
+msgid "Generators"
+msgstr ""
+
+#: src/language/supported-features.md:357
+msgid "Map and Set"
+msgstr ""
+
+#: src/language/supported-features.md:359
+msgid ""
+"```typescript\n"
+"function mapSetDemo(): void {\n"
+"    const map = new Map<string, number>();\n"
+"    map.set(\"a\", 1);\n"
+"    map.get(\"a\");\n"
+"    map.has(\"a\");\n"
+"    map.delete(\"a\");\n"
+"    map.size;\n"
+"\n"
+"    const set = new Set<number>();\n"
+"    set.add(1);\n"
+"    set.has(1);\n"
+"    set.delete(1);\n"
+"    set.size;\n"
+"\n"
+"    console.log(`map-set: map_size=${map.size} set_size=${set.size}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:378
+msgid "Regular Expressions"
+msgstr ""
+
+#: src/language/supported-features.md:380
+msgid ""
+"```typescript\n"
+"function regexDemo(): void {\n"
+"    const re = /hello\\s+(\\w+)/;\n"
+"    const match = \"hello world\".match(re);\n"
+"\n"
+"    if (re.test(\"hello perry\")) {\n"
+"        console.log(\"Matched!\");\n"
+"    }\n"
+"\n"
+"    const replaced = \"hello world\".replace(/world/, \"perry\");\n"
+"\n"
+"    console.log(`regex: match=${match !== null} replaced=${replaced}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:395 src/widgets/data-fetching.md:154
+msgid "Error Handling"
+msgstr ""
+
+#: src/language/supported-features.md:397
+msgid ""
+"```typescript\n"
+"function errorsDemo(): void {\n"
+"    try {\n"
+"        throw new Error(\"something went wrong\");\n"
+"    } catch (e: any) {\n"
+"        console.log(e.message);\n"
+"    } finally {\n"
+"        console.log(\"cleanup\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:409
+msgid "JSON"
+msgstr ""
+
+#: src/language/supported-features.md:411
+msgid ""
+"```typescript\n"
+"function jsonDemo(): void {\n"
+"    const obj = JSON.parse('{\"key\": \"value\"}');\n"
+"    const str = JSON.stringify(obj);\n"
+"    const pretty = JSON.stringify(obj, null, 2);\n"
+"\n"
+"    console.log(`json: str_len=${str.length} pretty_len=${pretty.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:421
+msgid "typeof and instanceof"
+msgstr ""
+
+#: src/language/supported-features.md:423
+msgid ""
+"```typescript\n"
+"function typeofInstanceofDemo(): void {\n"
+"    const x: any = \"hello\"\n"
+"    if (typeof x === \"string\") {\n"
+"        console.log(x.length);\n"
+"    }\n"
+"\n"
+"    const obj: any = new Dog(\"Rex\")\n"
+"    if (obj instanceof Dog) {\n"
+"        obj.speak();\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:437
+msgid ""
+"`typeof` checks NaN-boxing tags at runtime. `instanceof` walks the class ID "
+"chain."
+msgstr ""
+
+#: src/language/supported-features.md:439
+msgid "Modules"
+msgstr ""
+
+#: src/language/supported-features.md:441
+msgid ""
+"ES module syntax is fully supported: named exports, default exports, and re-"
+"exports."
+msgstr ""
+
+#: src/language/supported-features.md:444
+msgid "The exporting module:"
+msgstr ""
+
+#: src/language/supported-features.md:446
+msgid ""
+"```typescript\n"
+"// Named exports\n"
+"export function helper(x: number): number { return x + 1 }\n"
+"export const VALUE = 42\n"
+"\n"
+"// Default export\n"
+"export default class MyClass {\n"
+"    name: string\n"
+"    constructor(name: string) {\n"
+"        this.name = name\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:460
+msgid "The importing module:"
+msgstr ""
+
+#: src/language/supported-features.md:462
+msgid ""
+"```typescript\n"
+"// Default + named imports from a sibling module\n"
+"import MyClass, { helper, VALUE } from \"./utils\"\n"
+"\n"
+"// Re-export\n"
+"export { helper } from \"./utils\"\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:470
+msgid "BigInt"
+msgstr ""
+
+#: src/language/supported-features.md:472
+msgid ""
+"```typescript\n"
+"function bigintDemo(): void {\n"
+"    const big = BigInt(9007199254740991);\n"
+"    const result = big + BigInt(1);\n"
+"\n"
+"    // Bitwise operations\n"
+"    const and = big & BigInt(0xFF);\n"
+"    const or = big | BigInt(0xFF);\n"
+"    const xor = big ^ BigInt(0xFF);\n"
+"    const shl = big << BigInt(2);\n"
+"    const shr = big >> BigInt(2);\n"
+"    const not = ~big;\n"
+"\n"
+"    console.log(`bigint: result_ok=${result !== null} and_ok=${and !== null} or_ok=${or !== null}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:489
+msgid "String Methods"
+msgstr ""
+
+#: src/language/supported-features.md:491
+msgid ""
+"```typescript\n"
+"function stringMethodsDemo(): void {\n"
+"    const s = \"Hello, World!\";\n"
+"    s.length;\n"
+"    s.toUpperCase();\n"
+"    s.toLowerCase();\n"
+"    s.trim();\n"
+"    s.split(\", \");\n"
+"    s.includes(\"World\");\n"
+"    s.startsWith(\"Hello\");\n"
+"    s.endsWith(\"!\");\n"
+"    s.indexOf(\"World\");\n"
+"    s.slice(0, 5);\n"
+"    s.substring(0, 5);\n"
+"    s.replace(\"World\", \"Perry\");\n"
+"    s.repeat(3);\n"
+"    s.charAt(0);\n"
+"    s.padStart(20);\n"
+"    s.padEnd(20);\n"
+"\n"
+"    console.log(`string-methods: ${s.toUpperCase()}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:515
+msgid "Math"
+msgstr ""
+
+#: src/language/supported-features.md:538
+msgid "Date"
+msgstr ""
+
+#: src/language/supported-features.md:551
+msgid "Console"
+msgstr ""
+
+#: src/language/supported-features.md:553
+msgid ""
+"```typescript\n"
+"function consoleDemo(): void {\n"
+"    console.log(\"message\");\n"
+"    console.error(\"error\");\n"
+"    console.warn(\"warning\");\n"
+"    console.time(\"label\");\n"
+"    console.timeEnd(\"label\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:563 src/contributing/architecture.md:56
+msgid "Garbage Collection"
+msgstr ""
+
+#: src/language/supported-features.md:565
+msgid ""
+"Perry includes a mark-sweep garbage collector. It runs automatically when "
+"memory pressure is detected (~8MB arena blocks), but you can also trigger it"
+" manually:"
+msgstr ""
+
+#: src/language/supported-features.md:567
+msgid ""
+"```typescript\n"
+"function gcDemo(): void {\n"
+"    gc(); // Explicit garbage collection\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:573
+msgid ""
+"The GC uses conservative stack scanning to find roots and supports arena-"
+"allocated objects (arrays, objects) and malloc-allocated objects (strings, "
+"closures, promises, BigInts, errors)."
+msgstr ""
+
+#: src/language/supported-features.md:575
+msgid "JSX/TSX"
+msgstr ""
+
+#: src/language/supported-features.md:577
+msgid ""
+"Perry's parser and HIR understand JSX syntax (parsed via SWC, lowered in "
+"`crates/perry-hir/src/jsx.rs`), but the runtime `_jsx` / `_jsxs` symbols are"
+" not yet linked, so a `.tsx` file fails at the link stage today. The "
+"canonical pattern is the function-call form Perry's UI examples already use "
+"(`Text(\"hi\")` instead of `<Text>hi</Text>`)."
+msgstr ""
+
+#: src/language/supported-features.md:583
+msgid ""
+"```text\n"
+"// Planned JSX shape (parses but doesn't link yet — issue: runtime _jsx symbols):\n"
+"\n"
+"function Greeting({ name }: { name: string }) {\n"
+"  return <Text>{`Hello, ${name}!`}</Text>;\n"
+"}\n"
+"\n"
+"<Button onClick={() => console.log(\"clicked\")}>Click me</Button>\n"
+"\n"
+"<>\n"
+"  <Text>Line 1</Text>\n"
+"  <Text>Line 2</Text>\n"
+"</>\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:598
+msgid ""
+"JSX elements are transformed to function calls via the `jsx()`/`jsxs()` "
+"runtime."
+msgstr ""
+
+#: src/language/supported-features.md:602
+msgid "[Type System](type-system.md) — Type inference and checking"
+msgstr ""
+
+#: src/language/supported-features.md:603
+msgid "[Limitations](limitations.md) — What's not supported yet"
+msgstr ""
+
+#: src/language/type-system.md:3
+msgid ""
+"Perry erases types at compile time, similar to how `tsc` removes type "
+"annotations when emitting JavaScript. However, Perry also performs type "
+"inference to generate efficient native code."
+msgstr ""
+
+#: src/language/type-system.md:5
+msgid "Type Inference"
+msgstr ""
+
+#: src/language/type-system.md:7
+msgid "Perry infers types from expressions without requiring annotations:"
+msgstr ""
+
+#: src/language/type-system.md:9
+msgid ""
+"```typescript\n"
+"function inferenceBasics(): void {\n"
+"    let x = 5;           // inferred as number\n"
+"    let s = \"hello\";     // inferred as string\n"
+"    let b = true;        // inferred as boolean\n"
+"    let arr = [1, 2, 3]; // inferred as number[]\n"
+"\n"
+"    console.log(`inference: x=${x} s=${s} b=${b} arr_len=${arr.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:20
+msgid "Inference works through:"
+msgstr ""
+
+#: src/language/type-system.md:21
+msgid "**Literal values**: `5` → `number`, `\"hi\"` → `string`"
+msgstr ""
+
+#: src/language/type-system.md:22
+msgid "**Binary operations**: `a + b` where both are numbers → `number`"
+msgstr ""
+
+#: src/language/type-system.md:23
+msgid ""
+"**Variable propagation**: if `x` is `number`, then `let y = x` is `number`"
+msgstr ""
+
+#: src/language/type-system.md:24
+msgid ""
+"**Method returns**: `\"hello\".trim()` → `string`, `[1,2].length` → `number`"
+msgstr ""
+
+#: src/language/type-system.md:25
+msgid ""
+"**Function returns**: user-defined function return types are propagated to "
+"callers"
+msgstr ""
+
+#: src/language/type-system.md:27
+msgid ""
+"```typescript\n"
+"function inferenceFunction(): void {\n"
+"    function double(n: number): number {\n"
+"        return n * 2;\n"
+"    }\n"
+"    let result = double(5); // inferred as number\n"
+"\n"
+"    console.log(`inference-function: result=${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:38
+msgid "Type Annotations"
+msgstr ""
+
+#: src/language/type-system.md:40
+msgid "Standard TypeScript annotations work:"
+msgstr ""
+
+#: src/language/type-system.md:42
+msgid ""
+"```typescript\n"
+"interface Config {\n"
+"    port: number;\n"
+"    host: string;\n"
+"}\n"
+"\n"
+"function annotations(): void {\n"
+"    let name: string = \"Perry\";\n"
+"    let count: number = 0;\n"
+"    let items: string[] = [];\n"
+"\n"
+"    function greet(name: string): string {\n"
+"        return `Hello, ${name}`;\n"
+"    }\n"
+"\n"
+"    const cfg: Config = { port: 8080, host: \"localhost\" }\n"
+"    console.log(`annotations: ${greet(name)} count=${count} items=${items.length} port=${cfg.port}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:62
+msgid "Utility Types"
+msgstr ""
+
+#: src/language/type-system.md:64
+msgid ""
+"Common TypeScript utility types are erased at compile time (they don't "
+"affect code generation):"
+msgstr ""
+
+#: src/language/type-system.md:75
+msgid ""
+"These are all recognized and erased — they won't cause compilation errors."
+msgstr ""
+
+#: src/language/type-system.md:77
+msgid "Generics"
+msgstr ""
+
+#: src/language/type-system.md:79
+msgid "Generic type parameters are erased:"
+msgstr ""
+
+#: src/language/type-system.md:81
+msgid ""
+"```typescript\n"
+"function identity<T>(value: T): T {\n"
+"    return value;\n"
+"}\n"
+"\n"
+"class Box<T> {\n"
+"    value: T;\n"
+"    constructor(value: T) {\n"
+"        this.value = value;\n"
+"    }\n"
+"}\n"
+"\n"
+"function genericsDemo(): void {\n"
+"    const box = new Box<number>(42);\n"
+"    const id = identity<string>(\"hello\")\n"
+"    console.log(`generics: box.value=${box.value} id=${id}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:100
+msgid ""
+"At runtime, all values are NaN-boxed — the generic parameter doesn't affect "
+"code generation."
+msgstr ""
+
+#: src/language/type-system.md:102
+msgid "Type Checking with `--type-check`"
+msgstr ""
+
+#: src/language/type-system.md:104
+msgid ""
+"For stricter type checking, Perry can integrate with Microsoft's TypeScript "
+"checker:"
+msgstr ""
+
+#: src/language/type-system.md:110
+msgid ""
+"This resolves cross-file types, interfaces, and generics via an IPC "
+"protocol. It falls back gracefully if the type checker is not installed."
+msgstr ""
+
+#: src/language/type-system.md:112
+msgid ""
+"Without `--type-check`, Perry relies on its own inference engine, which "
+"handles common patterns but doesn't perform full TypeScript type checking."
+msgstr ""
+
+#: src/language/type-system.md:114
+msgid "Union and Intersection Types"
+msgstr ""
+
+#: src/language/type-system.md:116
+msgid ""
+"Union types are recognized syntactically but don't affect code generation:"
+msgstr ""
+
+#: src/language/type-system.md:118
+msgid ""
+"```typescript\n"
+"type StringOrNumber = string | number;\n"
+"\n"
+"function process(value: StringOrNumber) {\n"
+"    if (typeof value === \"string\") {\n"
+"        console.log(value.toUpperCase());\n"
+"    } else {\n"
+"        console.log(value + 1);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:130
+msgid "Use `typeof` checks for runtime type narrowing."
+msgstr ""
+
+#: src/language/type-system.md:132
+msgid "Type Guards"
+msgstr ""
+
+#: src/language/type-system.md:134
+msgid ""
+"```typescript\n"
+"function isString(value: any): value is string {\n"
+"    return typeof value === \"string\";\n"
+"}\n"
+"\n"
+"function typeGuardsDemo(): void {\n"
+"    const x: any = \"hello\"\n"
+"    if (isString(x)) {\n"
+"        console.log(x.toUpperCase());\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:147
+msgid ""
+"The `value is string` annotation is erased, but the `typeof` check works at "
+"runtime."
+msgstr ""
+
+#: src/language/type-system.md:151
+msgid "[Supported Features](supported-features.md) — Complete feature list"
+msgstr ""
+
+#: src/language/type-system.md:152
+msgid "[Limitations](limitations.md) — What's not supported"
+msgstr ""
+
+#: src/language/limitations.md:3
+msgid ""
+"Perry compiles a practical subset of TypeScript. This page documents what's "
+"not supported or works differently from Node.js/tsc."
+msgstr ""
+
+#: src/language/limitations.md:5
+msgid "No Runtime Type Checking"
+msgstr ""
+
+#: src/language/limitations.md:7
+msgid ""
+"Types are erased at compile time. There is no runtime type system — Perry "
+"doesn't generate type guards or runtime type metadata."
+msgstr ""
+
+#: src/language/limitations.md:9
+msgid ""
+"```typescript\n"
+"function someFunction(): number {\n"
+"    return 42\n"
+"}\n"
+"\n"
+"function erasedTypes(): void {\n"
+"    // These annotations are erased — no runtime effect\n"
+"    const x: number = someFunction(); // No runtime check that result is actually a number\n"
+"    console.log(`erased-types: x=${x}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:21
+msgid ""
+"Use explicit `typeof` checks where runtime type discrimination is needed."
+msgstr ""
+
+#: src/language/limitations.md:23
+msgid "No eval() or Dynamic Code"
+msgstr ""
+
+#: src/language/limitations.md:25
+msgid ""
+"Perry compiles to native code ahead of time. Dynamic code execution is not "
+"possible:"
+msgstr ""
+
+#: src/language/limitations.md:28
+msgid ""
+"```text\n"
+"// Not supported\n"
+"eval(\"console.log('hi')\");\n"
+"new Function(\"return 42\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:34
+msgid "No Decorators"
+msgstr ""
+
+#: src/language/limitations.md:36
+msgid "TypeScript decorators are not currently supported:"
+msgstr ""
+
+#: src/language/limitations.md:39
+msgid ""
+"```text\n"
+"// Not supported\n"
+"@Component\n"
+"class MyClass {}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:45
+msgid "No Reflection"
+msgstr ""
+
+#: src/language/limitations.md:47
+msgid "There is no `Reflect` API or runtime type metadata:"
+msgstr ""
+
+#: src/language/limitations.md:50
+msgid ""
+"```text\n"
+"// Not supported\n"
+"Reflect.getMetadata(\"design:type\", target, key);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:55
+msgid "No Dynamic require()"
+msgstr ""
+
+#: src/language/limitations.md:57
+msgid "Only static imports are supported:"
+msgstr ""
+
+#: src/language/limitations.md:60
+msgid ""
+"```text\n"
+"// Supported\n"
+"import { foo } from \"./module\";\n"
+"\n"
+"// Not supported\n"
+"const mod = require(\"./module\");\n"
+"const mod = await import(\"./module\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:69
+msgid "No Prototype Manipulation"
+msgstr ""
+
+#: src/language/limitations.md:71
+msgid ""
+"Perry compiles classes to fixed structures. Dynamic prototype modification "
+"is not supported:"
+msgstr ""
+
+#: src/language/limitations.md:74
+msgid ""
+"```text\n"
+"// Not supported\n"
+"MyClass.prototype.newMethod = function() {};\n"
+"Object.setPrototypeOf(obj, proto);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:80
+msgid "No Symbol Type"
+msgstr ""
+
+#: src/language/limitations.md:82
+msgid "The `Symbol` primitive type is not currently supported:"
+msgstr ""
+
+#: src/language/limitations.md:85
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const sym = Symbol(\"description\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:90
+msgid "No WeakMap/WeakRef"
+msgstr ""
+
+#: src/language/limitations.md:92
+msgid "Weak references are not implemented:"
+msgstr ""
+
+#: src/language/limitations.md:95
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const wm = new WeakMap();\n"
+"const wr = new WeakRef(obj);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:101
+msgid "No Proxy"
+msgstr ""
+
+#: src/language/limitations.md:103
+msgid "The `Proxy` object is not supported:"
+msgstr ""
+
+#: src/language/limitations.md:106
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const proxy = new Proxy(target, handler);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:111
+msgid "Limited Error Types"
+msgstr ""
+
+#: src/language/limitations.md:113
+msgid ""
+"`Error` and basic `throw`/`catch` work, but custom error subclasses have "
+"limited support:"
+msgstr ""
+
+#: src/language/limitations.md:125
+msgid "Threading Model"
+msgstr ""
+
+#: src/language/limitations.md:127
+msgid ""
+"Perry supports real multi-threading via `parallelMap` and `spawn` from "
+"`perry/thread`. See [Multi-Threading](../threading/overview.md)."
+msgstr ""
+
+#: src/language/limitations.md:129
+msgid ""
+"Threads do not share mutable state — closures passed to thread primitives "
+"cannot capture mutable variables (enforced at compile time). Values are "
+"deep-copied across thread boundaries. There is no `SharedArrayBuffer` or "
+"`Atomics`."
+msgstr ""
+
+#: src/language/limitations.md:131
+msgid "No Computed Property Names"
+msgstr ""
+
+#: src/language/limitations.md:133
+msgid "Dynamic property keys in object literals are limited:"
+msgstr ""
+
+#: src/language/limitations.md:136
+msgid ""
+"```text\n"
+"// Supported\n"
+"const key = \"name\";\n"
+"obj[key] = \"value\";\n"
+"\n"
+"// Not supported\n"
+"const obj = { [key]: \"value\" };\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:145
+msgid "npm Package Compatibility"
+msgstr ""
+
+#: src/language/limitations.md:147
+msgid "Not all npm packages work with Perry:"
+msgstr ""
+
+#: src/language/limitations.md:149
+msgid ""
+"**Natively supported**: ~50 popular packages (fastify, mysql2, redis, etc.) "
+"— these are compiled natively. See [Standard "
+"Library](../stdlib/overview.md)."
+msgstr ""
+
+#: src/language/limitations.md:150
+msgid ""
+"**`compilePackages`**: Pure TS/JS packages can be compiled natively via "
+"[configuration](../getting-started/project-config.md)."
+msgstr ""
+
+#: src/language/limitations.md:151
+msgid ""
+"**Not supported**: Packages requiring native addons (`.node` files), "
+"`eval()`, dynamic `require()`, or Node.js internals."
+msgstr ""
+
+#: src/language/limitations.md:153
+msgid "Workarounds"
+msgstr ""
+
+#: src/language/limitations.md:155
+msgid "Dynamic Behavior"
+msgstr ""
+
+#: src/language/limitations.md:157
+msgid ""
+"For cases where you need dynamic behavior, use the JavaScript runtime "
+"fallback:"
+msgstr ""
+
+#: src/language/limitations.md:160
+msgid ""
+"```text\n"
+"import { jsEval } from \"perry/jsruntime\";\n"
+"// Routes specific code through QuickJS for dynamic evaluation\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:165
+msgid "Type Narrowing"
+msgstr ""
+
+#: src/language/limitations.md:167
+msgid "Since there's no runtime type checking, use explicit checks:"
+msgstr ""
+
+#: src/language/limitations.md:169
+msgid ""
+"```typescript\n"
+"function processValue(value: string | number) {\n"
+"    // Instead of relying on type narrowing from generics\n"
+"    if (typeof value === \"string\") {\n"
+"        // String path\n"
+"        console.log(`string path: ${value}`)\n"
+"    } else if (typeof value === \"number\") {\n"
+"        // Number path\n"
+"        console.log(`number path: ${value}`)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:184
+msgid "[Supported Features](supported-features.md) — What does work"
+msgstr ""
+
+#: src/language/limitations.md:185
+msgid "[Type System](type-system.md) — How types are handled"
+msgstr ""
+
+#: src/packages/porting.md:1
+msgid "Porting npm Packages"
+msgstr ""
+
+#: src/packages/porting.md:3
+msgid ""
+"**Status: experimental.** This guide — and the [`port-npm-to-perry` "
+"skill](https://github.com/PerryTS/perry/tree/main/.claude/skills/port-npm-"
+"to-perry) that ships alongside it — is a first pass at systematizing what "
+"Perry contributors have been doing ad-hoc. Results will vary by package. "
+"Feedback at [issue #115](https://github.com/PerryTS/perry/issues/115)."
+msgstr ""
+
+#: src/packages/porting.md:5
+msgid ""
+"Perry compiles a practical subset of TypeScript. Most pure TS/JS packages "
+"can be pulled into a native compile via `perry.compilePackages`, but some "
+"will need small patches to avoid the constructs Perry doesn't support. This "
+"page is a field guide for doing that port — by hand, or by driving a coding "
+"agent with the prompt template below."
+msgstr ""
+
+#: src/packages/porting.md:7
+msgid "When porting makes sense"
+msgstr ""
+
+#: src/packages/porting.md:9
+msgid "Situation"
+msgstr ""
+
+#: src/packages/porting.md:9
+msgid "Try this first"
+msgstr ""
+
+#: src/packages/porting.md:11
+msgid "Package uses native addons (`.node` files, `binding.gyp`, `node-gyp`)"
+msgstr ""
+
+#: src/packages/porting.md:11
+msgid ""
+"**Don't port** — no path forward. Find an alternative package or use the "
+"[QuickJS fallback](../stdlib/overview.md#javascript-runtime-fallback)."
+msgstr ""
+
+#: src/packages/porting.md:12
+msgid "Package is pure TS/JS with only light use of dynamic features"
+msgstr ""
+
+#: src/packages/porting.md:12
+msgid ""
+"**Good candidate.** Add to `compilePackages`, patch whatever trips the "
+"compiler."
+msgstr ""
+
+#: src/packages/porting.md:13
+msgid ""
+"Package's core API is built on `Proxy` (ORMs, validation DSLs, reactive "
+"stores)"
+msgstr ""
+
+#: src/packages/porting.md:13
+msgid "**Probably not portable.** The surface Perry-users touch is the Proxy."
+msgstr ""
+
+#: src/packages/porting.md:14
+msgid ""
+"Package is pure TS/JS but uses lookbehind regex, `Symbol`, `WeakMap`, etc."
+msgstr ""
+
+#: src/packages/porting.md:14
+msgid "**Patchable.** See [Common gaps](#common-gaps) below."
+msgstr ""
+
+#: src/packages/porting.md:16
+msgid "The workflow"
+msgstr ""
+
+#: src/packages/porting.md:18
+msgid "1. Add it to `compilePackages`"
+msgstr ""
+
+#: src/packages/porting.md:20
+msgid "In your project's `package.json`:"
+msgstr ""
+
+#: src/packages/porting.md:30
+msgid ""
+"This is what tells Perry to pull the package into the native compile instead"
+" of routing it through a JavaScript runtime. See [Project "
+"Configuration](../getting-started/project-config.md#compilepackages) for the"
+" full semantics — including how first-resolved directories get cached so "
+"transitive copies dedup."
+msgstr ""
+
+#: src/packages/porting.md:32
+msgid "2. Try compiling"
+msgstr ""
+
+#: src/packages/porting.md:38
+msgid ""
+"Most of the time this is where you find out what's actually broken. Compile-"
+"time errors cite a file:line in the package — that's your patch list."
+msgstr ""
+
+#: src/packages/porting.md:40
+msgid "3. Patch the gaps"
+msgstr ""
+
+#: src/packages/porting.md:42
+msgid ""
+"See [Common gaps](#common-gaps) for the typical fixes. Keep patches minimal "
+"and localized — the goal is a clean compile, not a refactor."
+msgstr ""
+
+#: src/packages/porting.md:44
+msgid ""
+"**Record each patch** in a file at your project root (convention: `perry-"
+"patches/<package>.md`) so you can reapply them after `npm install` blows "
+"them away. Until `compilePackages` grows a native patch-file convention, "
+"this is the one bit of maintenance overhead."
+msgstr ""
+
+#: src/packages/porting.md:46
+msgid "4. Re-check after each compile"
+msgstr ""
+
+#: src/packages/porting.md:48
+msgid ""
+"Iterate: compile, patch the next error, compile again. Don't try to catch "
+"everything in a single pass — some errors only surface after earlier ones "
+"are fixed."
+msgstr ""
+
+#: src/packages/porting.md:50
+msgid "Common gaps"
+msgstr ""
+
+#: src/packages/porting.md:52
+msgid ""
+"Perry's [full limitations list](../language/limitations.md) is the canonical"
+" reference. In practice, these are the ones you hit when porting:"
+msgstr ""
+
+#: src/packages/porting.md:54
+msgid "Lookbehind regex"
+msgstr ""
+
+#: src/packages/porting.md:56
+msgid ""
+"Perry uses Rust's `regex` crate, which doesn't support lookbehind (`(?<=…)` "
+"/ `(?<!…)`)."
+msgstr ""
+
+#: src/packages/porting.md:58
+msgid ""
+"```text\n"
+"// Not supported\n"
+"str.match(/(?<=prefix)\\w+/);\n"
+"\n"
+"// Rewrite — capture the prefix and slice\n"
+"const m = str.match(/prefix(\\w+)/);\n"
+"const rest = m ? m[1] : null;\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:67
+msgid "`Symbol`"
+msgstr ""
+
+#: src/packages/porting.md:69
+msgid ""
+"Not supported as a primitive. When a package uses `Symbol` as a sentinel "
+"(the common case — e.g., for unique keys in a registry), swap for a string:"
+msgstr ""
+
+#: src/packages/porting.md:71
+msgid ""
+"```text\n"
+"// Before\n"
+"const REGISTRY_KEY = Symbol(\"registry\");\n"
+"\n"
+"// After\n"
+"const REGISTRY_KEY = \"__pkg_registry__\";\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:79
+msgid ""
+"When `Symbol` is used to implement `Symbol.iterator`/`Symbol.asyncIterator`,"
+" check whether the iteration is actually reached in your use case — often "
+"the class has a `for`\\-loop method alongside the iterator and you can "
+"ignore the iterator path."
+msgstr ""
+
+#: src/packages/porting.md:81
+msgid "`Proxy`, `Reflect`"
+msgstr ""
+
+#: src/packages/porting.md:83
+msgid ""
+"Not supported. These are usually load-bearing for the package's public API, "
+"so porting is often not feasible. If the `Proxy` is only in an optional path"
+" (e.g., dev-mode warnings), delete that branch."
+msgstr ""
+
+#: src/packages/porting.md:85
+msgid "`WeakMap` / `WeakRef` / `FinalizationRegistry`"
+msgstr ""
+
+#: src/packages/porting.md:87
+msgid ""
+"Not implemented. Swap `WeakMap` for a regular `Map` if the GC semantics "
+"aren't critical for correctness (most caches can tolerate this — they'll "
+"just hold references slightly longer)."
+msgstr ""
+
+#: src/packages/porting.md:89
+msgid "Decorators"
+msgstr ""
+
+#: src/packages/porting.md:91
+msgid ""
+"```text\n"
+"// Not supported\n"
+"@Component\n"
+"class Foo {}\n"
+"\n"
+"// Remove the decorator and inline the behavior, or use a factory function\n"
+"const Foo = Component(class Foo {});\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:100
+msgid "Dynamic `require()` / `await import(…)`"
+msgstr ""
+
+#: src/packages/porting.md:102
+msgid ""
+"Perry only supports static imports. If a package branches on `typeof require"
+" !== \"undefined\"` for a Node/browser split, pick the branch that works "
+"natively and delete the other."
+msgstr ""
+
+#: src/packages/porting.md:104
+msgid "Prototype manipulation"
+msgstr ""
+
+#: src/packages/porting.md:106
+msgid ""
+"```text\n"
+"// Not supported\n"
+"Object.setPrototypeOf(obj, proto);\n"
+"MyClass.prototype.newMethod = function() {};\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:112
+msgid ""
+"Usually appears in fallback shims for older runtimes. Often dead code in the"
+" Perry path — just delete it."
+msgstr ""
+
+#: src/packages/porting.md:114
+msgid "Computed property keys in object literals"
+msgstr ""
+
+#: src/packages/porting.md:116
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const obj = { [key]: value };\n"
+"\n"
+"// Rewrite\n"
+"const obj: Record<string, V> = {};\n"
+"obj[key] = value;\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:125
+msgid "Using a coding agent"
+msgstr ""
+
+#: src/packages/porting.md:127
+msgid ""
+"A general coding agent (Claude Code, Cursor, Codex, Aider) can drive most of"
+" this workflow. If you're using a skill-aware agent, invoke the [`port-npm-"
+"to-perry` "
+"skill](https://github.com/PerryTS/perry/tree/main/.claude/skills/port-npm-"
+"to-perry) directly. Otherwise, paste this prompt:"
+msgstr ""
+
+#: src/packages/porting.md:129
+msgid ""
+"```\n"
+"I want to port the npm package <NAME> to run under Perry\n"
+"(https://github.com/PerryTS/perry). Perry compiles a subset of TypeScript\n"
+"natively; the subset's gaps are documented at\n"
+"https://github.com/PerryTS/perry/blob/main/docs/src/language/limitations.md.\n"
+"\n"
+"Please:\n"
+"\n"
+"1. Read the package at node_modules/<NAME>/. Check package.json for\n"
+"   native addons (binding.gyp, gypfile, prebuilds/ — stop if present).\n"
+"2. Scan for unsupported constructs: eval, new Function, dynamic require,\n"
+"   Symbol, Proxy, WeakMap, WeakRef, Reflect, decorators, lookbehind\n"
+"   regex (?<= / ?<!), Object.setPrototypeOf, computed property keys.\n"
+"3. Report a triage: what rules the package out vs. what's patchable.\n"
+"4. If patchable: add the package to perry.compilePackages in\n"
+"   package.json, apply minimal localized patches, and record each\n"
+"   patch in perry-patches/<NAME>.md.\n"
+"5. Verify by running `perry compile` against a small file that imports\n"
+"   the package.\n"
+"\n"
+"Don't patch blindly — a grep hit inside a string or comment isn't real.\n"
+"Show me the triage before applying substantial patches.\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:153
+msgid ""
+"This is intentionally an agent-agnostic prompt — it'll work with any "
+"competent coding agent. The skill version bundles the same instructions with"
+" richer context and is auto-discovered by Claude Code."
+msgstr ""
+
+#: src/packages/porting.md:155
+msgid "Giving feedback"
+msgstr ""
+
+#: src/packages/porting.md:157
+msgid ""
+"This whole workflow is experimental. If a port fails in a way that feels "
+"like Perry should handle it — or if the guide misses a common gap — please "
+"comment on [issue #115](https://github.com/PerryTS/perry/issues/115) so we "
+"can iterate."
+msgstr ""
+
+#: src/threading/overview.md:3
+msgid ""
+"Perry gives you real OS threads with a one-line API. No worker setup, no "
+"message ports, no structured clone overhead. Just `parallelMap`, "
+"`parallelFilter`, and `spawn`."
+msgstr ""
+
+#: src/threading/overview.md:5
+msgid ""
+"```typescript\n"
+"async function overviewHeader(): Promise<void> {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"    const records = [\n"
+"        { score: 50, id: 1 },\n"
+"        { score: 90, id: 2 },\n"
+"        { score: 85, id: 3 },\n"
+"    ]\n"
+"    const threshold = 80\n"
+"\n"
+"    // Process a million items across all CPU cores\n"
+"    const results = parallelMap(data, (item: number) => item * item)\n"
+"\n"
+"    // Filter a large dataset in parallel\n"
+"    const valid = parallelFilter(records, (r: { score: number; id: number }) => r.score > threshold)\n"
+"\n"
+"    // Run expensive work in the background\n"
+"    const answer = await spawn(() => {\n"
+"        let acc = 0\n"
+"        for (let i = 0; i < 100_000; i++) acc += i\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    console.log(`overview-header results=${results.length} valid=${valid.length} answer=${answer}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:32
+msgid ""
+"This is something **no JavaScript runtime can do**. V8, Bun, and Deno are "
+"all locked to one thread per isolate. Perry compiles to native code — there "
+"are no isolates, no GIL, no structural limitations. Your code runs on real "
+"OS threads with the full power of every CPU core."
+msgstr ""
+
+#: src/threading/overview.md:34
+msgid "Why This Matters"
+msgstr ""
+
+#: src/threading/overview.md:36
+msgid ""
+"JavaScript's single-threaded model is its biggest performance bottleneck. "
+"Here's how runtimes try to work around it:"
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "Runtime"
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "\"Multi-threading\""
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "Reality"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid "**Node.js**"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid "`worker_threads`"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid ""
+"Separate V8 isolates. Data copied via structured clone. ~2MB RAM per worker."
+" Complex API."
+msgstr ""
+
+#: src/threading/overview.md:41
+msgid "**Deno**"
+msgstr ""
+
+#: src/threading/overview.md:41 src/threading/overview.md:42
+msgid "`Worker`"
+msgstr ""
+
+#: src/threading/overview.md:41
+msgid "Same as Node — isolated heaps, message passing only."
+msgstr ""
+
+#: src/threading/overview.md:42
+msgid "**Bun**"
+msgstr ""
+
+#: src/threading/overview.md:42
+msgid "Same architecture. Faster structured clone, still isolated."
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid "**Perry**"
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid "`parallelMap` / `spawn`"
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid ""
+"Real OS threads. Lightweight (8MB stack). One-line API. Compile-time safety."
+msgstr ""
+
+#: src/threading/overview.md:45
+msgid ""
+"The fundamental problem: V8 uses a garbage-collected heap that **cannot be "
+"shared** between threads. Every \"worker\" is an entirely separate "
+"JavaScript engine instance with its own heap, its own GC, and its own copy "
+"of your data."
+msgstr ""
+
+#: src/threading/overview.md:47
+msgid ""
+"Perry doesn't have this limitation. It compiles TypeScript to native machine"
+" code. Values are transferred between threads using zero-cost copies for "
+"numbers and efficient serialization for objects — no separate engine "
+"instances, no multi-megabyte overhead per thread."
+msgstr ""
+
+#: src/threading/overview.md:49
+msgid "Three Primitives"
+msgstr ""
+
+#: src/threading/overview.md:51
+msgid "`parallelMap` — Data-Parallel Processing"
+msgstr ""
+
+#: src/threading/overview.md:53
+msgid ""
+"Split an array across all CPU cores. Each element is processed "
+"independently. Results are collected in order."
+msgstr ""
+
+#: src/threading/overview.md:55
+msgid ""
+"```typescript\n"
+"async function overviewParallelMap(): Promise<void> {\n"
+"    const prices = [100, 200, 300, 400, 500, 600, 700, 800]\n"
+"    const adjusted = parallelMap(prices, (price: number) => {\n"
+"        // Heavy computation runs on a worker thread\n"
+"        let result = price\n"
+"        for (let i = 0; i < 1000000; i++) {\n"
+"            result = Math.sqrt(result * result + i)\n"
+"        }\n"
+"        return result\n"
+"    })\n"
+"\n"
+"    console.log(`overview-parallel-map len=${adjusted.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:71 src/plugins/creating-plugins.md:37
+msgid "Perry automatically:"
+msgstr ""
+
+#: src/threading/overview.md:72
+msgid "Detects the number of CPU cores"
+msgstr ""
+
+#: src/threading/overview.md:73
+msgid "Splits the array into chunks (one per core)"
+msgstr ""
+
+#: src/threading/overview.md:74
+msgid "Spawns OS threads to process each chunk"
+msgstr ""
+
+#: src/threading/overview.md:75
+msgid "Collects results in the original order"
+msgstr ""
+
+#: src/threading/overview.md:76
+msgid "Returns a new array"
+msgstr ""
+
+#: src/threading/overview.md:78
+msgid ""
+"For small arrays, Perry skips threading entirely and processes inline — no "
+"overhead for trivial cases."
+msgstr ""
+
+#: src/threading/overview.md:80
+msgid "`parallelFilter` — Data-Parallel Filtering"
+msgstr ""
+
+#: src/threading/overview.md:82
+msgid ""
+"Filter a large array across all CPU cores. Like `.filter()` but parallel:"
+msgstr ""
+
+#: src/threading/overview.md:84
+msgid ""
+"```typescript\n"
+"async function overviewParallelFilter(): Promise<void> {\n"
+"    const cutoffDate = 1_700_000_000\n"
+"    const users = [\n"
+"        { lastLogin: 1_710_000_000, score: 150, name: \"alice\" },\n"
+"        { lastLogin: 1_690_000_000, score: 50, name: \"bob\" },\n"
+"        { lastLogin: 1_720_000_000, score: 120, name: \"carol\" },\n"
+"    ]\n"
+"\n"
+"    // Filter across all cores — order is preserved\n"
+"    const active = parallelFilter(users, (user: { lastLogin: number; score: number; name: string }) => {\n"
+"        return user.lastLogin > cutoffDate && user.score > 100\n"
+"    })\n"
+"\n"
+"    console.log(`overview-parallel-filter active=${active.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:102
+msgid ""
+"Same rules as `parallelMap`: closures cannot capture mutable variables "
+"(compile-time enforced), and values are deep-copied between threads."
+msgstr ""
+
+#: src/threading/overview.md:104
+msgid "`spawn` — Background Threads"
+msgstr ""
+
+#: src/threading/overview.md:106
+msgid ""
+"Run any computation in the background and get a Promise back. The main "
+"thread continues immediately."
+msgstr ""
+
+#: src/threading/overview.md:108
+msgid ""
+"```typescript\n"
+"async function overviewSpawnBg(): Promise<void> {\n"
+"    // Start heavy work in the background\n"
+"    const handle = spawn(() => {\n"
+"        let sum = 0\n"
+"        for (let i = 0; i < 100_000; i++) {\n"
+"            sum += Math.sin(i)\n"
+"        }\n"
+"        return sum\n"
+"    })\n"
+"\n"
+"    // Main thread keeps running — UI stays responsive\n"
+"    console.log(\"Computing...\")\n"
+"\n"
+"    // Get the result when you need it\n"
+"    const result = await handle\n"
+"    console.log(`Done: len=${typeof result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:128
+msgid ""
+"`spawn` returns a standard Promise. You can `await` it, pass it to "
+"`Promise.all`, or chain `.then()` — it works exactly like any other async "
+"operation."
+msgstr ""
+
+#: src/threading/overview.md:130
+msgid "Practical Examples"
+msgstr ""
+
+#: src/threading/overview.md:132
+msgid "Parallel Image Processing"
+msgstr ""
+
+#: src/threading/overview.md:134
+msgid ""
+"```typescript\n"
+"async function overviewImage(): Promise<void> {\n"
+"    const pixels = [\n"
+"        { r: 100, g: 120, b: 140 },\n"
+"        { r: 50, g: 60, b: 70 },\n"
+"        { r: 200, g: 210, b: 220 },\n"
+"    ]\n"
+"\n"
+"    // Each pixel processed on a separate core\n"
+"    const processed = parallelMap(pixels, (pixel: { r: number; g: number; b: number }) => {\n"
+"        const r = Math.min(255, pixel.r * 1.2)\n"
+"        const g = Math.min(255, pixel.g * 0.8)\n"
+"        const b = Math.min(255, pixel.b * 1.1)\n"
+"        return { r, g, b }\n"
+"    })\n"
+"\n"
+"    console.log(`overview-image processed=${processed.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:154
+msgid "Parallel Cryptographic Hashing"
+msgstr ""
+
+#: src/threading/overview.md:156
+msgid ""
+"```typescript\n"
+"async function overviewCrypto(): Promise<void> {\n"
+"    // Hash thousands of items across all cores\n"
+"    const passwords = [\"pass1\", \"pass2\", \"pass3\"]\n"
+"    const hashed = parallelMap(passwords, (password: string) => {\n"
+"        // Stand-in for a real hash: deterministic FNV-1a over the bytes.\n"
+"        let h = 2166136261\n"
+"        for (let i = 0; i < password.length; i++) {\n"
+"            h ^= password.charCodeAt(i)\n"
+"            h = (h * 16777619) >>> 0\n"
+"        }\n"
+"        return h\n"
+"    })\n"
+"\n"
+"    console.log(`overview-crypto hashed=${hashed.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:174
+msgid "Multiple Independent Computations"
+msgstr ""
+
+#: src/threading/overview.md:176
+msgid ""
+"```typescript\n"
+"async function overviewMultiple(): Promise<void> {\n"
+"    const dataA = [1, 2, 3]\n"
+"    const dataB = [4, 5, 6]\n"
+"    const dataC = [7, 8, 9]\n"
+"\n"
+"    // Three independent tasks run simultaneously on three OS threads\n"
+"    const task1 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataA) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"    const task2 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataB) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"    const task3 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataC) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    // All three run concurrently\n"
+"    const [result1, result2, result3] = await Promise.all([task1, task2, task3])\n"
+"    console.log(`overview-multiple ${result1} ${result2} ${result3}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:205
+msgid "Keeping UI Responsive"
+msgstr ""
+
+#: src/threading/overview.md:207
+msgid ""
+"```typescript\n"
+"const responsiveButton = Button(\"Start Analysis\", async () => {\n"
+"    status.set(\"Analyzing...\")\n"
+"\n"
+"    // Heavy computation runs on a background thread\n"
+"    // UI stays responsive — user can still interact\n"
+"    const value = await spawn(() => {\n"
+"        let acc = 0\n"
+"        for (let i = 0; i < 1_000_000; i++) acc += i\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    status.set(`Done: ${value}`)\n"
+"})\n"
+"\n"
+"const responsiveText = Text(`Status: ${status.value}`)\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:225
+msgid "Captured Variables"
+msgstr ""
+
+#: src/threading/overview.md:227
+msgid ""
+"Closures can capture outer variables. Captured values are automatically "
+"deep-copied to each worker thread:"
+msgstr ""
+
+#: src/threading/overview.md:229
+msgid ""
+"```typescript\n"
+"async function overviewCaptured(): Promise<void> {\n"
+"    const prices = [100, 200, 300, 400]\n"
+"    const taxRate = 0.08\n"
+"    const discount = 0.15\n"
+"\n"
+"    // taxRate and discount are captured and copied to each thread\n"
+"    const finalPrices = parallelMap(prices, (price: number) => {\n"
+"        const discounted = price * (1 - discount)\n"
+"        return discounted * (1 + taxRate)\n"
+"    })\n"
+"\n"
+"    console.log(`overview-captured len=${finalPrices.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:245
+msgid ""
+"Numbers and booleans are zero-cost copies (just 64-bit values). Strings, "
+"arrays, and objects are deep-copied automatically."
+msgstr ""
+
+#: src/threading/overview.md:247
+msgid "Safety"
+msgstr ""
+
+#: src/threading/overview.md:249
+msgid ""
+"Perry enforces thread safety **at compile time**. You don't need to think "
+"about race conditions, mutexes, or data corruption."
+msgstr ""
+
+#: src/threading/overview.md:251
+msgid "No Shared Mutable State"
+msgstr ""
+
+#: src/threading/overview.md:253
+msgid ""
+"Closures passed to `parallelMap` and `spawn` **cannot capture mutable "
+"variables**. The compiler rejects this:"
+msgstr ""
+
+#: src/threading/overview.md:255
+msgid ""
+"```text\n"
+"// Reject example — Perry rejects this at compile time:\n"
+"\n"
+"let counter = 0;\n"
+"\n"
+"// COMPILE ERROR: Closures passed to parallelMap cannot\n"
+"// capture mutable variable 'counter'\n"
+"parallelMap(data, (item) => {\n"
+"    counter++;  // Not allowed\n"
+"    return item;\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:268
+msgid ""
+"This eliminates data races by design. If you need to aggregate results, use "
+"the return values:"
+msgstr ""
+
+#: src/threading/overview.md:270
+msgid ""
+"```typescript\n"
+"async function overviewReduceInstead(): Promise<void> {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    // Instead of mutating a shared counter, return values and reduce\n"
+"    const results = parallelMap(data, (item: number) => item * item)\n"
+"    const total = results.reduce((sum: number, r: number) => sum + r, 0)\n"
+"\n"
+"    console.log(`overview-reduce-instead total=${total}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:282
+msgid "Independent Thread Arenas"
+msgstr ""
+
+#: src/threading/overview.md:284
+msgid ""
+"Each worker thread has its own memory arena. Objects created on one thread "
+"can never be accessed from another thread. Values cross thread boundaries "
+"only through deep-copy serialization, which Perry handles automatically and "
+"invisibly."
+msgstr ""
+
+#: src/threading/overview.md:288
+msgid "Perry's threading model is built on three pillars:"
+msgstr ""
+
+#: src/threading/overview.md:290
+msgid "**1. Native Code, Not Interpreted**"
+msgstr ""
+
+#: src/threading/overview.md:292
+msgid ""
+"Perry compiles TypeScript to native machine code via LLVM. There's no "
+"interpreter, no VM, no isolate. A function pointer is just a function "
+"pointer — it's valid on any thread."
+msgstr ""
+
+#: src/threading/overview.md:294
+msgid "**2. Thread-Local Memory**"
+msgstr ""
+
+#: src/threading/overview.md:296
+msgid ""
+"Each thread gets its own memory arena (bump allocator) and garbage "
+"collector. No synchronization overhead during computation. When a thread "
+"finishes, its arena is freed automatically."
+msgstr ""
+
+#: src/threading/overview.md:298
+msgid "**3. Serialized Transfer**"
+msgstr ""
+
+#: src/threading/overview.md:300
+msgid ""
+"Values crossing thread boundaries are serialized to a thread-safe "
+"intermediate format and deserialized on the target thread. The cost depends "
+"on the value type:"
+msgstr ""
+
+#: src/threading/overview.md:302
+msgid "Value Type"
+msgstr ""
+
+#: src/threading/overview.md:302
+msgid "Transfer Cost"
+msgstr ""
+
+#: src/threading/overview.md:304
+msgid "Numbers, booleans, null, undefined"
+msgstr ""
+
+#: src/threading/overview.md:304 src/threading/parallel-map.md:55
+msgid "Zero-cost (64-bit copy)"
+msgstr ""
+
+#: src/threading/overview.md:305 src/threading/parallel-map.md:57
+msgid "Strings"
+msgstr ""
+
+#: src/threading/overview.md:305
+msgid "O(n) byte copy"
+msgstr ""
+
+#: src/threading/overview.md:306
+msgid "O(n) deep copy of elements"
+msgstr ""
+
+#: src/threading/overview.md:307
+msgid "O(n) deep copy of fields"
+msgstr ""
+
+#: src/threading/overview.md:308
+msgid "Pointer + captured values"
+msgstr ""
+
+#: src/threading/overview.md:310
+msgid ""
+"For numeric workloads — the most common parallelizable tasks — the threading"
+" overhead is negligible."
+msgstr ""
+
+#: src/threading/overview.md:314
+msgid ""
+"[parallelMap Reference](parallel-map.md) — detailed API and performance tips"
+msgstr ""
+
+#: src/threading/overview.md:315
+msgid ""
+"[parallelFilter Reference](parallel-filter.md) — parallel array filtering"
+msgstr ""
+
+#: src/threading/overview.md:316
+msgid ""
+"[spawn Reference](spawn.md) — background threads and Promise integration"
+msgstr ""
+
+#: src/threading/parallel-map.md:3
+msgid ""
+"**Signature**: `parallelMap<T, U>(data: T[], fn: (item: T) => U): U[]` — "
+"imported from `perry/thread`."
+msgstr ""
+
+#: src/threading/parallel-map.md:5
+msgid ""
+"Processes every element of an array in parallel across all available CPU "
+"cores. Returns a new array with the results in the same order as the input."
+msgstr ""
+
+#: src/threading/parallel-map.md:7 src/threading/parallel-filter.md:7
+#: src/threading/spawn.md:7
+msgid "Basic Usage"
+msgstr ""
+
+#: src/threading/parallel-map.md:9
+msgid ""
+"```typescript\n"
+"function parallelMapBasic(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"    const doubled = parallelMap(numbers, (x: number) => x * 2)\n"
+"    // [2, 4, 6, 8, 10, 12, 14, 16]\n"
+"    console.log(`parallel-map-basic len=${doubled.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:31
+msgid ""
+"Perry automatically detects the number of CPU cores and splits the array "
+"into equal chunks. Elements within each chunk are processed sequentially; "
+"chunks run concurrently across cores."
+msgstr ""
+
+#: src/threading/parallel-map.md:33 src/threading/parallel-filter.md:53
+#: src/threading/spawn.md:80
+msgid "Capturing Variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:35
+msgid ""
+"The mapping function can reference variables from the outer scope. Captured "
+"values are deep-copied to each worker thread automatically:"
+msgstr ""
+
+#: src/threading/parallel-map.md:37
+msgid ""
+"```typescript\n"
+"function parallelMapCapture(): void {\n"
+"    const prices = [100, 200, 300]\n"
+"    const exchangeRate = 1.12\n"
+"\n"
+"    const converted = parallelMap(prices, (price: number) => {\n"
+"        // exchangeRate is captured and copied to each thread\n"
+"        return price * exchangeRate\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-capture len=${converted.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:51
+msgid "What Can Be Captured"
+msgstr ""
+
+#: src/threading/parallel-map.md:53 src/ui/overview.md:57 src/ui/styling.md:45
+#: src/widgets/creating-widgets.md:45 src/widgets/configuration.md:70
+#: src/testing/geisterhand.md:84 src/cli/flags.md:43 src/cli/perry-toml.md:114
+#: src/cli/perry-toml.md:125 src/cli/perry-toml.md:153
+#: src/cli/perry-toml.md:165 src/cli/perry-toml.md:175
+#: src/cli/perry-toml.md:181 src/cli/perry-toml.md:191
+#: src/cli/perry-toml.md:241 src/cli/perry-toml.md:254
+#: src/cli/perry-toml.md:260 src/cli/perry-toml.md:268
+#: src/cli/perry-toml.md:299 src/cli/perry-toml.md:310
+#: src/cli/perry-toml.md:327 src/cli/perry-toml.md:345
+#: src/cli/perry-toml.md:357 src/cli/perry-toml.md:367
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414 src/contributing/architecture.md:47
+msgid "Type"
+msgstr ""
+
+#: src/threading/parallel-map.md:53
+msgid "Supported"
+msgstr ""
+
+#: src/threading/parallel-map.md:53
+msgid "Transfer"
+msgstr ""
+
+#: src/threading/parallel-map.md:55
+msgid "Numbers"
+msgstr ""
+
+#: src/threading/parallel-map.md:55 src/threading/parallel-map.md:56
+#: src/threading/parallel-map.md:57 src/threading/parallel-map.md:58
+#: src/threading/parallel-map.md:59 src/threading/parallel-map.md:60
+#: src/platforms/overview.md:69 src/platforms/overview.md:70
+#: src/platforms/overview.md:71 src/platforms/overview.md:72
+#: src/platforms/overview.md:73 src/platforms/overview.md:74
+#: src/platforms/overview.md:75 src/widgets/platforms.md:22
+#: src/widgets/platforms.md:23 src/widgets/platforms.md:24
+#: src/widgets/platforms.md:25 src/widgets/platforms.md:26
+#: src/widgets/platforms.md:27 src/widgets/platforms.md:28
+#: src/widgets/platforms.md:29 src/widgets/platforms.md:30
+#: src/widgets/platforms.md:31 src/widgets/platforms.md:32
+#: src/widgets/platforms.md:33
+msgid "Yes"
+msgstr ""
+
+#: src/threading/parallel-map.md:56
+msgid "Booleans"
+msgstr ""
+
+#: src/threading/parallel-map.md:56
+msgid "Zero-cost"
+msgstr ""
+
+#: src/threading/parallel-map.md:57
+msgid "Byte copy"
+msgstr ""
+
+#: src/threading/parallel-map.md:58 src/threading/parallel-map.md:59
+msgid "Deep copy"
+msgstr ""
+
+#: src/threading/parallel-map.md:60
+msgid "`const` variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:60 src/threading/parallel-map.md:61
+msgid "Copied"
+msgstr ""
+
+#: src/threading/parallel-map.md:61
+msgid "`let`/`var` variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:61
+msgid "Only if not reassigned"
+msgstr ""
+
+#: src/threading/parallel-map.md:63
+msgid "What Cannot Be Captured"
+msgstr ""
+
+#: src/threading/parallel-map.md:65
+msgid ""
+"Mutable variables — variables that are reassigned anywhere in the enclosing "
+"scope — are rejected at compile time:"
+msgstr ""
+
+#: src/threading/parallel-map.md:67
+msgid ""
+"```text\n"
+"// Reject example — Perry rejects this at compile time:\n"
+"\n"
+"let total = 0;\n"
+"\n"
+"// COMPILE ERROR: Cannot capture mutable variable 'total'\n"
+"parallelMap(data, (item) => {\n"
+"    total += item;   // Would be a data race\n"
+"    return item;\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:79
+msgid "Instead, return values and reduce:"
+msgstr ""
+
+#: src/threading/parallel-map.md:90 src/threading/parallel-filter.md:155
+msgid "Performance"
+msgstr ""
+
+#: src/threading/parallel-map.md:92
+msgid "When to Use parallelMap"
+msgstr ""
+
+#: src/threading/parallel-map.md:94
+msgid ""
+"Use `parallelMap` when the computation per element is **significantly "
+"heavier** than the cost of copying the element across threads."
+msgstr ""
+
+#: src/threading/parallel-map.md:96
+msgid "**Good candidates** (CPU-bound work per element):"
+msgstr ""
+
+#: src/threading/parallel-map.md:98
+msgid ""
+"```typescript\n"
+"function parallelMapGoodCandidates(): void {\n"
+"    const data = [1.0, 2.0, 3.0, 4.0]\n"
+"    const documents = [\"alpha beta\", \"gamma delta\", \"epsilon\"]\n"
+"    const inputs = [\"a\", \"bb\", \"ccc\"]\n"
+"\n"
+"    // Heavy math\n"
+"    const out1 = parallelMap(data, (x: number) => {\n"
+"        let acc = x\n"
+"        for (let i = 0; i < 1_000; i++) acc = Math.sqrt(acc * acc + i)\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    // String processing on large strings\n"
+"    const out2 = parallelMap(documents, (doc: string) => {\n"
+"        const words = doc.split(\" \")\n"
+"        return { count: words.length, first: words[0] }\n"
+"    })\n"
+"\n"
+"    // Cryptographic operations\n"
+"    const out3 = parallelMap(inputs, (input: string) => {\n"
+"        let h = 0\n"
+"        for (let i = 0; i < input.length; i++) h = (h * 31 + input.charCodeAt(i)) >>> 0\n"
+"        return h\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-good-candidates ${out1.length} ${out2.length} ${out3.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:128
+msgid "**Poor candidates** (trivial work per element):"
+msgstr ""
+
+#: src/threading/parallel-map.md:130
+msgid ""
+"```typescript\n"
+"function parallelMapPoorCandidate(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5]\n"
+"\n"
+"    // Too simple — threading overhead outweighs the gain\n"
+"    const a = parallelMap(numbers, (x: number) => x + 1)\n"
+"\n"
+"    // For trivial operations, use regular map\n"
+"    const result = numbers.map((x: number) => x + 1)\n"
+"\n"
+"    console.log(`parallel-map-poor-candidate ${a.length} ${result.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:144
+msgid "Small Array Optimization"
+msgstr ""
+
+#: src/threading/parallel-map.md:146
+msgid ""
+"For arrays with fewer elements than CPU cores, Perry skips threading "
+"entirely and processes elements inline on the main thread. There's zero "
+"overhead for small inputs."
+msgstr ""
+
+#: src/threading/parallel-map.md:148
+msgid "Numeric Fast Path"
+msgstr ""
+
+#: src/threading/parallel-map.md:150
+msgid ""
+"When elements are pure numbers (no strings, objects, or arrays), Perry "
+"transfers them between threads at virtually zero cost — just 64-bit value "
+"copies with no serialization."
+msgstr ""
+
+#: src/threading/parallel-map.md:152 src/threading/parallel-filter.md:78
+#: src/threading/spawn.md:183 src/cli/flags.md:139
+msgid "Examples"
+msgstr ""
+
+#: src/threading/parallel-map.md:154
+msgid "Matrix Row Processing"
+msgstr ""
+
+#: src/threading/parallel-map.md:156
+msgid ""
+"```typescript\n"
+"function parallelMapMatrix(): void {\n"
+"    // Process each row of a matrix independently\n"
+"    const rows = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]\n"
+"    const rowSums = parallelMap(rows, (row: number[]) => {\n"
+"        let sum = 0\n"
+"        for (const val of row) sum += val\n"
+"        return sum\n"
+"    })\n"
+"    // [6, 15, 24]\n"
+"    console.log(`parallel-map-matrix sums=${rowSums[0]},${rowSums[1]},${rowSums[2]}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:170
+msgid "Batch Validation"
+msgstr ""
+
+#: src/threading/parallel-map.md:172
+msgid ""
+"```typescript\n"
+"function parallelMapValidation(): void {\n"
+"    const users = [\n"
+"        { name: \"Alice\", email: \"alice@example.com\" },\n"
+"        { name: \"Bob\", email: \"invalid\" },\n"
+"        { name: \"Charlie\", email: \"charlie@example.com\" },\n"
+"    ]\n"
+"\n"
+"    const validationResults = parallelMap(users, (user: { name: string; email: string }) => {\n"
+"        const emailValid = user.email.includes(\"@\") && user.email.includes(\".\")\n"
+"        const nameValid = user.name.length > 0 && user.name.length < 100\n"
+"        return { name: user.name, valid: emailValid && nameValid }\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-validation len=${validationResults.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:190
+msgid "Financial Calculations"
+msgstr ""
+
+#: src/threading/parallel-map.md:192
+msgid ""
+"```typescript\n"
+"function parallelMapMonteCarlo(): void {\n"
+"    const portfolios = [\n"
+"        { id: 1, base: 100 },\n"
+"        { id: 2, base: 200 },\n"
+"        { id: 3, base: 150 },\n"
+"    ] // thousands of portfolios\n"
+"\n"
+"    // Monte Carlo simulation across all cores\n"
+"    const riskScores = parallelMap(portfolios, (portfolio: { id: number; base: number }) => {\n"
+"        let totalRisk = 0\n"
+"        for (let sim = 0; sim < 1000; sim++) {\n"
+"            // simulateReturns stand-in: deterministic pseudo-random walk.\n"
+"            let s = portfolio.base + sim\n"
+"            s = ((s * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff\n"
+"            totalRisk += s\n"
+"        }\n"
+"        return totalRisk / 1000\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-monte-carlo len=${riskScores.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:3
+msgid ""
+"**Signature**: `parallelFilter<T>(data: T[], predicate: (item: T) => "
+"boolean): T[]` — imported from `perry/thread`."
+msgstr ""
+
+#: src/threading/parallel-filter.md:5
+msgid ""
+"Filters an array in parallel across all available CPU cores. Returns a new "
+"array containing only the elements where the predicate returned a truthy "
+"value. Order is preserved."
+msgstr ""
+
+#: src/threading/parallel-filter.md:9
+msgid ""
+"```typescript\n"
+"function parallelFilterBasic(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n"
+"    const evens = parallelFilter(numbers, (x: number) => x % 2 === 0)\n"
+"    // [2, 4, 6, 8, 10]\n"
+"    console.log(`parallel-filter-basic len=${evens.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:31
+msgid ""
+"Each core independently tests its chunk of elements. Results are merged in "
+"the original element order after all threads complete."
+msgstr ""
+
+#: src/threading/parallel-filter.md:33
+msgid "Why Not Just Use `.filter()`?"
+msgstr ""
+
+#: src/threading/parallel-filter.md:35
+msgid ""
+"Regular `.filter()` runs on a single thread. For large arrays with expensive"
+" predicates, `parallelFilter` distributes the work:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:37
+msgid ""
+"```typescript\n"
+"function parallelFilterVsFilter(): void {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    // Single-threaded — one core does all the work\n"
+"    const a = data.filter((item: number) => item > 3)\n"
+"\n"
+"    // Parallel — all cores share the work\n"
+"    const b = parallelFilter(data, (item: number) => item > 3)\n"
+"\n"
+"    console.log(`parallel-filter-vs-filter ${a.length} ${b.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:51
+msgid ""
+"The tradeoff: `parallelFilter` has overhead from copying values between "
+"threads. Use it when the predicate is expensive enough to justify that cost."
+msgstr ""
+
+#: src/threading/parallel-filter.md:55
+msgid ""
+"Like `parallelMap`, the predicate can capture outer variables. Captures are "
+"deep-copied to each thread:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:57
+msgid ""
+"```typescript\n"
+"function parallelFilterCapture(): void {\n"
+"    const candidates = [\n"
+"        { name: \"Alice\", score: 90, age: 28 },\n"
+"        { name: \"Bob\", score: 80, age: 35 },\n"
+"        { name: \"Carol\", score: 95, age: 25 },\n"
+"    ]\n"
+"    const minScore = 85\n"
+"    const maxAge = 30\n"
+"\n"
+"    // minScore and maxAge are captured and copied to each thread\n"
+"    const qualified = parallelFilter(candidates, (c: { name: string; score: number; age: number }) => {\n"
+"        return c.score >= minScore && c.age <= maxAge\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-capture len=${qualified.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:76
+msgid ""
+"Mutable variables cannot be captured — the compiler rejects this at compile "
+"time."
+msgstr ""
+
+#: src/threading/parallel-filter.md:80
+msgid "Filtering Large Datasets"
+msgstr ""
+
+#: src/threading/parallel-filter.md:82
+msgid ""
+"```typescript\n"
+"function parallelFilterLarge(): void {\n"
+"    // Stand-in for \"millions of records\" — same shape, smaller list.\n"
+"    const transactions = [\n"
+"        { amount: 15000, country: \"US\", user: { homeCountry: \"DE\" }, timestamp: { hour: 4 } },\n"
+"        { amount: 200, country: \"DE\", user: { homeCountry: \"DE\" }, timestamp: { hour: 12 } },\n"
+"        { amount: 50000, country: \"FR\", user: { homeCountry: \"DE\" }, timestamp: { hour: 3 } },\n"
+"    ]\n"
+"\n"
+"    const suspicious = parallelFilter(transactions, (tx: {\n"
+"        amount: number\n"
+"        country: string\n"
+"        user: { homeCountry: string }\n"
+"        timestamp: { hour: number }\n"
+"    }) => {\n"
+"        return tx.amount > 10000\n"
+"            && tx.country !== tx.user.homeCountry\n"
+"            && tx.timestamp.hour < 6\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-large len=${suspicious.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:106
+msgid "Combined with parallelMap"
+msgstr ""
+
+#: src/threading/parallel-filter.md:108
+msgid ""
+"```typescript\n"
+"function parallelFilterCombined(): void {\n"
+"    const users = [\n"
+"        { name: \"Alice\", isActive: true, age: 28, score: 90 },\n"
+"        { name: \"Bob\", isActive: false, age: 35, score: 80 },\n"
+"        { name: \"Carol\", isActive: true, age: 17, score: 95 },\n"
+"        { name: \"Dave\", isActive: true, age: 40, score: 60 },\n"
+"    ]\n"
+"\n"
+"    // Step 1: Filter to relevant items (parallel)\n"
+"    const active = parallelFilter(users, (u: { isActive: boolean; age: number }) => u.isActive && u.age >= 18)\n"
+"\n"
+"    // Step 2: Transform the filtered results (parallel)\n"
+"    const profiles = parallelMap(active, (u: { name: string; score: number }) => ({\n"
+"        name: u.name,\n"
+"        score: u.score * 2,\n"
+"    }))\n"
+"\n"
+"    console.log(`parallel-filter-combined active=${active.length} profiles=${profiles.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:130
+msgid "Predicate with Heavy Computation"
+msgstr ""
+
+#: src/threading/parallel-filter.md:132
+msgid ""
+"```typescript\n"
+"function parallelFilterHeavy(): void {\n"
+"    const certificates = [\n"
+"        { id: 1, fingerprint: \"aa\", revoked: false },\n"
+"        { id: 2, fingerprint: \"bb\", revoked: true },\n"
+"        { id: 3, fingerprint: \"cc\", revoked: false },\n"
+"    ]\n"
+"\n"
+"    // Each predicate call does significant work — perfect for parallelization.\n"
+"    const valid = parallelFilter(certificates, (cert: { id: number; fingerprint: string; revoked: boolean }) => {\n"
+"        // Stand-in for a real chain verification: hash the fingerprint a bit\n"
+"        // then sanity-check the revocation flag.\n"
+"        let h = 0\n"
+"        for (let i = 0; i < cert.fingerprint.length; i++) {\n"
+"            h = (h * 31 + cert.fingerprint.charCodeAt(i)) >>> 0\n"
+"        }\n"
+"        return h !== 0 && !cert.revoked\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-heavy len=${valid.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:157
+msgid "Use `parallelFilter` when:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:158
+msgid "The array has many elements (hundreds or more)"
+msgstr ""
+
+#: src/threading/parallel-filter.md:159
+msgid "The predicate function does meaningful work per element"
+msgstr ""
+
+#: src/threading/parallel-filter.md:160
+msgid "You need to keep the UI responsive during filtering"
+msgstr ""
+
+#: src/threading/parallel-filter.md:162
+msgid ""
+"For trivial predicates on small arrays, regular `.filter()` is faster (no "
+"threading overhead)."
+msgstr ""
+
+#: src/threading/spawn.md:3
+msgid ""
+"**Signature**: `spawn<T>(fn: () => T): Promise<T>` — imported from "
+"`perry/thread`."
+msgstr ""
+
+#: src/threading/spawn.md:5
+msgid ""
+"Runs a closure on a new OS thread and returns a Promise that resolves when "
+"the thread completes. The main thread continues immediately — UI and other "
+"work are not blocked."
+msgstr ""
+
+#: src/threading/spawn.md:9
+msgid ""
+"```typescript\n"
+"async function spawnBasic(): Promise<void> {\n"
+"    const result = await spawn(() => {\n"
+"        // This runs on a separate OS thread.\n"
+"        let sum = 0\n"
+"        for (let i = 0; i < 100_000_000; i++) {\n"
+"            sum += i\n"
+"        }\n"
+"        return sum\n"
+"    })\n"
+"\n"
+"    console.log(result) // 4999999950000000\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:24
+msgid "Non-Blocking"
+msgstr ""
+
+#: src/threading/spawn.md:26
+msgid "`spawn` returns immediately. The main thread doesn't wait:"
+msgstr ""
+
+#: src/threading/spawn.md:28
+msgid ""
+"```typescript\n"
+"async function spawnNonBlocking(): Promise<void> {\n"
+"    console.log(\"1. Starting background work\")\n"
+"\n"
+"    const handle = spawn(() => {\n"
+"        // Runs on a background thread — heavier work elided here.\n"
+"        let n = 0\n"
+"        for (let i = 0; i < 10_000_000; i++) n++\n"
+"        return n\n"
+"    })\n"
+"\n"
+"    console.log(\"2. Main thread continues immediately\")\n"
+"\n"
+"    const result = await handle\n"
+"    console.log(`3. Got result: ${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:53
+msgid "Multiple Concurrent Tasks"
+msgstr ""
+
+#: src/threading/spawn.md:55
+msgid ""
+"Spawn multiple tasks and they run truly concurrently — one OS thread per "
+"`spawn` call:"
+msgstr ""
+
+#: src/threading/spawn.md:57
+msgid ""
+"```typescript\n"
+"async function spawnMultiple(): Promise<void> {\n"
+"    const t1 = spawn(() => analyseChunk(0, 1_000_000))\n"
+"    const t2 = spawn(() => analyseChunk(1_000_000, 2_000_000))\n"
+"    const t3 = spawn(() => analyseChunk(2_000_000, 3_000_000))\n"
+"\n"
+"    // All three run simultaneously on separate OS threads.\n"
+"    const results = await Promise.all([t1, t2, t3])\n"
+"\n"
+"    console.log(`Region A: ${results[0]}`)\n"
+"    console.log(`Region B: ${results[1]}`)\n"
+"    console.log(`Region C: ${results[2]}`)\n"
+"}\n"
+"\n"
+"function analyseChunk(start: number, end: number): number {\n"
+"    let acc = 0\n"
+"    for (let i = start; i < end; i++) acc += i & 0xff\n"
+"    return acc\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:78
+msgid ""
+"Unlike Node.js `worker_threads`, each `spawn` is a lightweight OS thread "
+"(~8MB stack), not a full V8 isolate (~2MB heap + startup cost)."
+msgstr ""
+
+#: src/threading/spawn.md:82
+msgid ""
+"Like `parallelMap`, `spawn` closures can capture outer variables. They are "
+"deep-copied to the background thread:"
+msgstr ""
+
+#: src/threading/spawn.md:84
+msgid ""
+"```typescript\n"
+"async function spawnCapture(): Promise<void> {\n"
+"    const config = { iterations: 1000, seed: 42 }\n"
+"    const dataset = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    const result = await spawn(() => {\n"
+"        // config and dataset are deep-copied to this thread.\n"
+"        let acc = config.seed\n"
+"        for (let i = 0; i < config.iterations; i++) {\n"
+"            acc = (acc * 1103515245 + 12345) & 0x7fffffff\n"
+"        }\n"
+"        for (const v of dataset) acc ^= v\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-capture: ${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:103
+msgid ""
+"Mutable variables cannot be captured — this is enforced at compile time."
+msgstr ""
+
+#: src/threading/spawn.md:105
+msgid "Returning Complex Values"
+msgstr ""
+
+#: src/threading/spawn.md:107
+msgid ""
+"`spawn` can return any value type. Complex values (objects, arrays, strings)"
+" are serialized back to the main thread automatically:"
+msgstr ""
+
+#: src/threading/spawn.md:133
+msgid "UI Integration"
+msgstr ""
+
+#: src/threading/spawn.md:135
+msgid ""
+"`spawn` is ideal for keeping native UIs responsive during heavy computation:"
+msgstr ""
+
+#: src/threading/spawn.md:137
+msgid ""
+"```typescript\n"
+"const analyzeButton = Button(\"Analyze\", async () => {\n"
+"    status.set(\"Processing...\")\n"
+"\n"
+"    // Background thread — UI stays responsive\n"
+"    const data = await spawn(() => {\n"
+"        let count = 0\n"
+"        for (let i = 0; i < 1_000_000; i++) {\n"
+"            if ((i & 0xff) === 0) count++\n"
+"        }\n"
+"        return { count }\n"
+"    })\n"
+"\n"
+"    result.set(`Found ${data.count} patterns`)\n"
+"    status.set(\"Done\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:155
+msgid ""
+"Without `spawn`, the analysis would freeze the UI. With `spawn`, the user "
+"can still scroll, tap other buttons, or navigate while the computation runs."
+msgstr ""
+
+#: src/threading/spawn.md:157
+msgid "Compared to Node.js worker_threads"
+msgstr ""
+
+#: src/threading/spawn.md:160
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
+msgstr ""
+
+#: src/threading/spawn.md:162 src/threading/spawn.md:167
+msgid "\"worker_threads\""
+msgstr ""
+
+#: src/threading/spawn.md:165
+msgid "// main.js\n"
+msgstr ""
+
+#: src/threading/spawn.md:168
+msgid "\"./worker.js\""
+msgstr ""
+
+#: src/threading/spawn.md:171
+msgid "\"message\""
+msgstr ""
+
+#: src/threading/spawn.md:174 src/testing/geisterhand.md:319
+msgid "\"error\""
+msgstr ""
+
+#: src/threading/spawn.md:174
+msgid "/* handle */"
+msgstr ""
+
+#: src/threading/spawn.md:176
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
+msgstr ""
+
+#: src/threading/spawn.md:181
+msgid ""
+"No separate files. No message ports. No event handlers. No structured clone."
+" One line."
+msgstr ""
+
+#: src/threading/spawn.md:185
+msgid "Background File Processing"
+msgstr ""
+
+#: src/threading/spawn.md:187
+msgid ""
+"```typescript\n"
+"async function spawnBgFile(): Promise<void> {\n"
+"    // Read and process a \"large\" file without blocking. We inline a tiny CSV\n"
+"    // so the snippet runs hermetically — the docs' real version would call\n"
+"    // readFileSync from \"fs\".\n"
+"    const content = \"id,value\\n1,10\\n2,20\\n3,30\\n\"\n"
+"    const analysis = await spawn(() => {\n"
+"        const lines = content.split(\"\\n\").filter((l: string) => l.length > 0).slice(1)\n"
+"        let total = 0\n"
+"        for (const line of lines) {\n"
+"            const parts = line.split(\",\")\n"
+"            total += parseInt(parts[1], 10)\n"
+"        }\n"
+"        return { rows: lines.length, total }\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-bg-file rows=${analysis.rows} total=${analysis.total}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:207
+msgid "Parallel API Calls with Processing"
+msgstr ""
+
+#: src/threading/spawn.md:209
+msgid ""
+"```typescript\n"
+"async function spawnApiThenProcess(): Promise<void> {\n"
+"    // The docs example fetches a remote API; for a hermetic test we\n"
+"    // just hand-roll the same pipeline shape with synthetic data.\n"
+"    const rawData = { items: [1, 2, 3, 4, 5] }\n"
+"\n"
+"    // CPU-intensive processing happens off the main thread\n"
+"    const processed = await spawn(() => {\n"
+"        let total = 0\n"
+"        for (const v of rawData.items) total += v * v\n"
+"        return { total, count: rawData.items.length }\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-api-then-process total=${processed.total} count=${processed.count}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:226
+msgid "Deferred Computation"
+msgstr ""
+
+#: src/threading/spawn.md:228
+msgid ""
+"```typescript\n"
+"async function spawnDeferred(): Promise<void> {\n"
+"    const params = { size: 8 }\n"
+"\n"
+"    // Start computation early, use result later\n"
+"    const precomputed = spawn(() => {\n"
+"        const table: number[] = []\n"
+"        for (let i = 0; i < params.size; i++) table.push(i * i)\n"
+"        return table\n"
+"    })\n"
+"\n"
+"    // ... do other setup work ...\n"
+"\n"
+"    // Result is ready (or we wait for it)\n"
+"    const table = await precomputed\n"
+"    console.log(`spawn-deferred len=${table.length} last=${table[table.length - 1]}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:1
+msgid "UI Overview"
+msgstr ""
+
+#: src/ui/overview.md:3
+msgid ""
+"Perry's `perry/ui` module lets you build native desktop and mobile apps with"
+" declarative TypeScript. Your UI code compiles directly to platform-native "
+"widgets — AppKit on macOS, UIKit on iOS, GTK4 on Linux, Win32 on Windows, "
+"and DOM elements on the web."
+msgstr ""
+
+#: src/ui/overview.md:5 src/i18n/overview.md:27 src/testing/geisterhand.md:9
+msgid "Quick Start"
+msgstr ""
+
+#: src/ui/overview.md:7
+msgid ""
+"```typescript\n"
+"// demonstrates: the smallest complete Perry UI app\n"
+"// docs: docs/src/ui/overview.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My App\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello from Perry!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:29
+msgid "Mental Model"
+msgstr ""
+
+#: src/ui/overview.md:31
+msgid ""
+"Perry's UI follows the same model as SwiftUI and Flutter: you compose native"
+" widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`),"
+" control alignment and distribution, and style widgets via free functions "
+"that take the widget handle as their first argument (`textSetColor(label, r,"
+" g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
+"web development, the key shift is:"
+msgstr ""
+
+#: src/ui/overview.md:33
+msgid ""
+"**Layout** is controlled by stack alignment, distribution, and spacers — not"
+" CSS properties. See [Layout](layout.md)."
+msgstr ""
+
+#: src/ui/overview.md:34
+msgid ""
+"**Styling** is applied directly to widgets — not through stylesheets. See "
+"[Styling](styling.md)."
+msgstr ""
+
+#: src/ui/overview.md:35
+msgid ""
+"**Absolute positioning** uses overlays (`widgetAddOverlay` + "
+"`widgetSetOverlayFrame`) — not `position: absolute/relative`."
+msgstr ""
+
+#: src/ui/overview.md:36
+msgid ""
+"**Design tokens** come from the `perry-styling` package. See "
+"[Theming](theming.md)."
+msgstr ""
+
+#: src/ui/overview.md:38 src/platforms/ios.md:63 src/platforms/tvos.md:104
+#: src/platforms/watchos.md:80
+msgid "App Lifecycle"
+msgstr ""
+
+#: src/ui/overview.md:40
+msgid "Every Perry UI app starts with `App()`:"
+msgstr ""
+
+#: src/ui/overview.md:42
+msgid ""
+"```typescript\n"
+"function runAppShell(): void {\n"
+"    App({\n"
+"        title: \"Window Title\",\n"
+"        width: 800,\n"
+"        height: 600,\n"
+"        body: VStack(16, [\n"
+"            Text(\"Content here\"),\n"
+"        ]),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:55
+msgid "`App({})` accepts a config object with the following properties:"
+msgstr ""
+
+#: src/ui/overview.md:57 src/widgets/creating-widgets.md:45
+msgid "Property"
+msgstr ""
+
+#: src/ui/overview.md:59
+msgid "`title`"
+msgstr ""
+
+#: src/ui/overview.md:59 src/ui/overview.md:63 src/ui/overview.md:65
+#: src/ui/overview.md:67 src/ui/overview.md:68 src/ui/styling.md:58
+#: src/cli/perry-toml.md:116 src/cli/perry-toml.md:117
+#: src/cli/perry-toml.md:119 src/cli/perry-toml.md:120
+#: src/cli/perry-toml.md:121 src/cli/perry-toml.md:127
+#: src/cli/perry-toml.md:155 src/cli/perry-toml.md:167
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:169
+#: src/cli/perry-toml.md:177 src/cli/perry-toml.md:183
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:185
+#: src/cli/perry-toml.md:186 src/cli/perry-toml.md:187
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:194
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:196
+#: src/cli/perry-toml.md:243 src/cli/perry-toml.md:244
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:249
+#: src/cli/perry-toml.md:256 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:263 src/cli/perry-toml.md:264
+#: src/cli/perry-toml.md:270 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:272 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:301 src/cli/perry-toml.md:302
+#: src/cli/perry-toml.md:303 src/cli/perry-toml.md:304
+#: src/cli/perry-toml.md:312 src/cli/perry-toml.md:313
+#: src/cli/perry-toml.md:314 src/cli/perry-toml.md:315
+#: src/cli/perry-toml.md:316 src/cli/perry-toml.md:317
+#: src/cli/perry-toml.md:318 src/cli/perry-toml.md:319
+#: src/cli/perry-toml.md:329 src/cli/perry-toml.md:330
+#: src/cli/perry-toml.md:331 src/cli/perry-toml.md:333
+#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:335
+#: src/cli/perry-toml.md:336 src/cli/perry-toml.md:337
+#: src/cli/perry-toml.md:347 src/cli/perry-toml.md:348
+#: src/cli/perry-toml.md:349 src/cli/perry-toml.md:360
+#: src/cli/perry-toml.md:369 src/cli/perry-toml.md:379
+#: src/cli/perry-toml.md:389 src/cli/perry-toml.md:390
+#: src/cli/perry-toml.md:416
+msgid "string"
+msgstr ""
+
+#: src/ui/overview.md:59
+msgid "Window title"
+msgstr ""
+
+#: src/ui/overview.md:60
+msgid "`width`"
+msgstr ""
+
+#: src/ui/overview.md:60 src/ui/overview.md:61 src/ui/styling.md:50
+#: src/ui/styling.md:51 src/system/overview.md:28
+msgid "number"
+msgstr ""
+
+#: src/ui/overview.md:60
+msgid "Initial window width"
+msgstr ""
+
+#: src/ui/overview.md:61
+msgid "`height`"
+msgstr ""
+
+#: src/ui/overview.md:61
+msgid "Initial window height"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "`body`"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "widget"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "Root widget"
+msgstr ""
+
+#: src/ui/overview.md:63
+msgid "`icon`"
+msgstr ""
+
+#: src/ui/overview.md:63
+msgid "App icon file path (optional)"
+msgstr ""
+
+#: src/ui/overview.md:64
+msgid "`frameless`"
+msgstr ""
+
+#: src/ui/overview.md:64 src/ui/overview.md:66 src/ui/styling.md:59
+#: src/ui/styling.md:60 src/system/media.md:49 src/cli/perry-toml.md:361
+msgid "boolean"
+msgstr ""
+
+#: src/ui/overview.md:64
+msgid "Remove title bar (optional)"
+msgstr ""
+
+#: src/ui/overview.md:65
+msgid "`level`"
+msgstr ""
+
+#: src/ui/overview.md:65
+msgid "Window z-order: `\"floating\"`, `\"statusBar\"`, `\"modal\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:66
+msgid "`transparent`"
+msgstr ""
+
+#: src/ui/overview.md:66
+msgid "Transparent background (optional)"
+msgstr ""
+
+#: src/ui/overview.md:67
+msgid "`vibrancy`"
+msgstr ""
+
+#: src/ui/overview.md:67
+msgid "Native blur material, e.g. `\"sidebar\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:68
+msgid "`activationPolicy`"
+msgstr ""
+
+#: src/ui/overview.md:68
+msgid "`\"regular\"`, `\"accessory\"` (no dock icon), `\"background\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:70
+msgid ""
+"See [Multi-Window](multi-window.md) for full documentation on window "
+"properties."
+msgstr ""
+
+#: src/ui/overview.md:72
+msgid "Lifecycle Hooks"
+msgstr ""
+
+#: src/ui/overview.md:74
+msgid ""
+"```typescript\n"
+"onActivate(() => {\n"
+"    console.log(\"App became active\")\n"
+"})\n"
+"\n"
+"onTerminate(() => {\n"
+"    console.log(\"App is closing\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:84
+msgid "Widget Tree"
+msgstr ""
+
+#: src/ui/overview.md:86
+msgid "Perry UIs are built as a tree of widgets:"
+msgstr ""
+
+#: src/ui/overview.md:88
+msgid ""
+"```typescript\n"
+"function runWidgetTree(): void {\n"
+"    App({\n"
+"        title: \"Layout Demo\",\n"
+"        width: 400,\n"
+"        height: 300,\n"
+"        body: VStack(16, [\n"
+"            Text(\"Header\"),\n"
+"            HStack(8, [\n"
+"                Button(\"Left\", () => console.log(\"left\")),\n"
+"                Button(\"Right\", () => console.log(\"right\")),\n"
+"            ]),\n"
+"            Text(\"Footer\"),\n"
+"        ]),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:106
+msgid ""
+"Widgets are created by calling their constructor functions. Layout "
+"containers (`VStack`, `HStack`, `ZStack`) accept a spacing value (in points)"
+" followed by an array of child widgets."
+msgstr ""
+
+#: src/ui/overview.md:108
+msgid "Handle-Based Architecture"
+msgstr ""
+
+#: src/ui/overview.md:110
+msgid ""
+"Under the hood, each widget is a handle — a small integer that references a "
+"native platform object. When you call `Text(\"hello\")`, Perry creates a "
+"native `NSTextField` (macOS), `UILabel` (iOS), `GtkLabel` (Linux), or "
+"`<span>` (web) and returns a handle you can use to modify it."
+msgstr ""
+
+#: src/ui/overview.md:112
+msgid ""
+"```typescript\n"
+"const label = Text(\"Hello\")\n"
+"textSetFontSize(label, 18)              // Modifies the native widget\n"
+"textSetColor(label, 1.0, 0.0, 0.0, 1.0) // RGBA floats in [0,1]\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:118
+msgid "Imports"
+msgstr ""
+
+#: src/ui/overview.md:120
+msgid "All UI functions are imported from `perry/ui`:"
+msgstr ""
+
+#: src/ui/overview.md:122
+msgid ""
+"```typescript\n"
+"import {\n"
+"    // App lifecycle\n"
+"    App, onActivate, onTerminate,\n"
+"\n"
+"    // Widgets\n"
+"    Text, Button, TextField, SecureField, TextArea,\n"
+"    Toggle, Slider, ProgressView, Picker, ImageFile, ImageSymbol,\n"
+"\n"
+"    // Layout\n"
+"    VStack, HStack, ZStack, ScrollView, Spacer, Divider,\n"
+"    NavStack, TabBar, LazyVStack, Section,\n"
+"    VStackWithInsets, HStackWithInsets, SplitView, splitViewAddChild,\n"
+"\n"
+"    // Layout control\n"
+"    stackSetAlignment, stackSetDistribution, stackSetDetachesHidden,\n"
+"    widgetMatchParentWidth, widgetMatchParentHeight, widgetSetHugging,\n"
+"    widgetAddOverlay, widgetSetOverlayFrame,\n"
+"\n"
+"    // State\n"
+"    State, ForEach,\n"
+"\n"
+"    // Dialogs\n"
+"    openFileDialog, openFolderDialog, saveFileDialog,\n"
+"    alert, alertWithButtons,\n"
+"    sheetCreate, sheetPresent, sheetDismiss,\n"
+"\n"
+"    // Menus\n"
+"    menuCreate, menuAddItem, menuAddSeparator, menuAddSubmenu,\n"
+"    menuBarCreate, menuBarAddMenu, menuBarAttach,\n"
+"    widgetSetContextMenu,\n"
+"\n"
+"    // Window\n"
+"    Window,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:159
+msgid ""
+"[`Canvas`](canvas.md), [`CameraView`](camera.md), and the virtualized "
+"[`Table`](table.md) widget are wired through the LLVM codegen (closed via "
+"[\\#190](https://github.com/PerryTS/perry/issues/190), "
+"[\\#191](https://github.com/PerryTS/perry/issues/191), and "
+"[\\#192](https://github.com/PerryTS/perry/issues/192)). See each widget's "
+"page for the platform-support matrix."
+msgstr ""
+
+#: src/ui/overview.md:166
+msgid "Platform Differences"
+msgstr ""
+
+#: src/ui/overview.md:168
+msgid ""
+"The same code runs on all platforms, but the look and feel matches each "
+"platform's native style:"
+msgstr ""
+
+#: src/ui/overview.md:170 src/platforms/overview.md:67
+#: src/i18n/formatting.md:138 src/widgets/platforms.md:20
+msgid "Feature"
+msgstr ""
+
+#: src/ui/overview.md:172
+msgid "Buttons"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/macos.md:27
+msgid "NSButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/tvos.md:53
+msgid "UIButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/linux.md:37
+msgid "GtkButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/windows.md:45
+msgid "HWND Button"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/wasm.md:58
+msgid "`<button>`"
+msgstr ""
+
+#: src/ui/overview.md:173 src/ui/widgets.md:13 src/ui/canvas.md:60
+#: src/platforms/macos.md:26 src/platforms/ios.md:52 src/platforms/tvos.md:52
+#: src/platforms/watchos.md:52 src/platforms/android.md:26
+#: src/platforms/windows.md:44 src/platforms/linux.md:36
+#: src/widgets/components.md:25 src/widgets/platforms.md:22
+msgid "Text"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/macos.md:28
+msgid "NSTextField"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/ios.md:52 src/platforms/tvos.md:52
+msgid "UILabel"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/linux.md:36
+msgid "GtkLabel"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/windows.md:44
+msgid "Static HWND"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/wasm.md:57
+msgid "`<span>`"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/macos.md:34
+msgid "NSStackView"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/ios.md:60 src/platforms/tvos.md:59
+msgid "UIStackView"
+msgstr ""
+
+#: src/ui/overview.md:174
+msgid "GtkBox"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/windows.md:53
+msgid "Manual layout"
+msgstr ""
+
+#: src/ui/overview.md:174
+msgid "Flexbox"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:111
+msgid "NSMenu"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:113 src/ui/menus.md:114
+#: src/ui/dialogs.md:111 src/ui/dialogs.md:112 src/platforms/overview.md:69
+#: src/platforms/overview.md:71 src/platforms/overview.md:72
+#: src/platforms/overview.md:75 src/cli/perry-toml.md:119
+#: src/cli/perry-toml.md:120 src/cli/perry-toml.md:127
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:169
+#: src/cli/perry-toml.md:170 src/cli/perry-toml.md:177
+#: src/cli/perry-toml.md:185 src/cli/perry-toml.md:186
+#: src/cli/perry-toml.md:187 src/cli/perry-toml.md:245
+#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:256
+#: src/cli/perry-toml.md:264 src/cli/perry-toml.md:303
+#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:312
+#: src/cli/perry-toml.md:315 src/cli/perry-toml.md:330
+#: src/cli/perry-toml.md:331 src/cli/perry-toml.md:332
+#: src/cli/perry-toml.md:333 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:335 src/cli/perry-toml.md:336
+#: src/cli/perry-toml.md:347 src/cli/perry-toml.md:348
+#: src/cli/perry-toml.md:359 src/cli/perry-toml.md:391
+msgid "—"
+msgstr ""
+
+#: src/ui/overview.md:175
+msgid "GMenu"
+msgstr ""
+
+#: src/ui/overview.md:175
+msgid "HMENU"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:115
+msgid "DOM"
+msgstr ""
+
+#: src/ui/overview.md:177
+msgid ""
+"Platform-specific behavior is noted on each widget's documentation page."
+msgstr ""
+
+#: src/ui/overview.md:181 src/ui/layout.md:370 src/ui/styling.md:379
+#: src/ui/state.md:228 src/ui/events.md:170 src/ui/canvas.md:82
+#: src/ui/table.md:109 src/ui/animation.md:74 src/ui/camera.md:145
+msgid "[Widgets](widgets.md) — All available widgets"
+msgstr ""
+
+#: src/ui/overview.md:182
+msgid "[Layout](layout.md) — Arranging widgets"
+msgstr ""
+
+#: src/ui/overview.md:183
+msgid "[State Management](state.md) — Reactive state and bindings"
+msgstr ""
+
+#: src/ui/overview.md:184
+msgid "[Styling](styling.md) — Colors, fonts, sizing"
+msgstr ""
+
+#: src/ui/overview.md:185
+msgid "[Events](events.md) — Click, hover, keyboard"
+msgstr ""
+
+#: src/ui/widgets.md:3
+msgid ""
+"Perry provides native widgets that map to each platform's native controls. "
+"Every example on this page is a real runnable program verified by CI "
+"(`scripts/run_doc_tests.sh`) — the snippet you read is the same source "
+"that's compiled and launched."
+msgstr ""
+
+#: src/ui/widgets.md:8
+msgid ""
+"The widget API is **free functions**, not methods. A widget is a 64-bit "
+"opaque handle; you pass it into helpers like `textSetFontSize(widget, 18)` "
+"rather than calling `widget.setFontSize(18)`. That's the only shape perry/ui"
+" supports — no fluent chain, no prototype methods."
+msgstr ""
+
+#: src/ui/widgets.md:15
+msgid "Displays read-only text."
+msgstr ""
+
+#: src/ui/widgets.md:17
+msgid ""
+"```typescript\n"
+"// demonstrates: Text widget styling with the real free-function API\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, textSetFontSize, textSetFontWeight, textSetColor, textSetFontFamily } from \"perry/ui\"\n"
+"\n"
+"const label = Text(\"Hello, World!\")\n"
+"textSetFontSize(label, 18)\n"
+"textSetColor(label, 0.2, 0.2, 0.2, 1.0) // RGBA in [0, 1]\n"
+"textSetFontFamily(label, \"Menlo\")\n"
+"\n"
+"const bold = Text(\"Bold\")\n"
+"textSetFontWeight(bold, 20, 1.0)\n"
+"\n"
+"App({\n"
+"    title: \"Text\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(8, [label, bold]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:41
+msgid ""
+"Color is RGBA with each channel in `[0.0, 1.0]` — divide a hex byte by 255 "
+"(`0x33 / 255 ≈ 0.2`)."
+msgstr ""
+
+#: src/ui/widgets.md:44
+msgid ""
+"**Helpers:** `textSetString`, `textSetFontSize`, `textSetFontWeight`, "
+"`textSetFontFamily`, `textSetColor`, `textSetWraps`, `textSetSelectable`."
+msgstr ""
+
+#: src/ui/widgets.md:47
+msgid ""
+"Text widgets inside template literals with `state.value` update "
+"automatically — perry detects the state read and rewires the widget to re-"
+"render on change. See [State Management](state.md)."
+msgstr ""
+
+#: src/ui/widgets.md:51 src/platforms/macos.md:27 src/platforms/ios.md:53
+#: src/platforms/tvos.md:53 src/platforms/watchos.md:53
+#: src/platforms/android.md:27 src/platforms/windows.md:45
+#: src/platforms/linux.md:37 src/testing/geisterhand.md:86
+#: src/testing/geisterhand.md:289
+msgid "Button"
+msgstr ""
+
+#: src/ui/widgets.md:53
+msgid "A clickable button."
+msgstr ""
+
+#: src/ui/widgets.md:55
+msgid ""
+"```typescript\n"
+"// demonstrates: Button styling with buttonSet*/widgetSet* helpers\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack,\n"
+"    Button,\n"
+"    buttonSetBordered,\n"
+"    widgetSetEnabled,\n"
+"    setCornerRadius,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// Note: buttonSetContentTintColor is macOS/iOS-only (maps to NSButton /\n"
+"// UIButton tint). GTK4/Win32 don't have an equivalent — set\n"
+"// widgetSetBackgroundColor(btn, r, g, b, a) there instead.\n"
+"const primary = Button(\"Click Me\", () => console.log(\"Clicked!\"))\n"
+"buttonSetBordered(primary, 1)\n"
+"setCornerRadius(primary, 8)\n"
+"\n"
+"const disabled = Button(\"Can't click me\", () => {})\n"
+"widgetSetEnabled(disabled, 0)\n"
+"\n"
+"App({\n"
+"    title: \"Button\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [primary, disabled]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:88
+msgid ""
+"**Helpers:** `buttonSetTitle`, `buttonSetBordered`, `buttonSetImage` (SF "
+"Symbol name on macOS/iOS), `buttonSetImagePosition`, "
+"`buttonSetContentTintColor`, `buttonSetTextColor`, `widgetSetEnabled`."
+msgstr ""
+
+#: src/ui/widgets.md:92 src/platforms/macos.md:28 src/platforms/ios.md:54
+#: src/platforms/tvos.md:54 src/platforms/android.md:28
+#: src/platforms/windows.md:46 src/platforms/linux.md:38
+#: src/testing/geisterhand.md:87 src/testing/geisterhand.md:290
+msgid "TextField"
+msgstr ""
+
+#: src/ui/widgets.md:94
+msgid "An editable single-line text input."
+msgstr ""
+
+#: src/ui/widgets.md:96
+msgid ""
+"```typescript\n"
+"// demonstrates: TextField + two-way binding via stateBindTextfield\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, TextField, State, stateBindTextfield } from \"perry/ui\"\n"
+"\n"
+"const text = State(\"\")\n"
+"const field = TextField(\"Placeholder...\", (value: string) => text.set(value))\n"
+"stateBindTextfield(text, field) // programmatic text.set() also updates the field\n"
+"\n"
+"App({\n"
+"    title: \"TextField\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        field,\n"
+"        Text(`You typed: ${text.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:119
+msgid ""
+"`TextField(placeholder, onChange)` fires `onChange` as the user types. Pair "
+"with `stateBindTextfield(state, field)` for two-way binding so programmatic "
+"`state.set(…)` also updates the visible text."
+msgstr ""
+
+#: src/ui/widgets.md:123
+msgid ""
+"**Helpers:** `textfieldSetString`, `textfieldSetFontSize`, "
+"`textfieldSetTextColor`, `textfieldSetBackgroundColor`, "
+"`textfieldSetBorderless`, `textfieldSetOnSubmit`, `textfieldSetOnFocus`, "
+"`textfieldSetNextKeyView`."
+msgstr ""
+
+#: src/ui/widgets.md:128 src/platforms/macos.md:29 src/platforms/ios.md:55
+#: src/platforms/android.md:29 src/platforms/windows.md:47
+#: src/platforms/linux.md:39
+msgid "SecureField"
+msgstr ""
+
+#: src/ui/widgets.md:130
+msgid ""
+"A password input — identical signature to `TextField`, but text is masked."
+msgstr ""
+
+#: src/ui/widgets.md:132
+msgid ""
+"```typescript\n"
+"// demonstrates: SecureField for password input\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, SecureField, State } from \"perry/ui\"\n"
+"\n"
+"const password = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"SecureField\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        SecureField(\"Enter password...\", (value: string) => password.set(value)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:152 src/platforms/macos.md:30 src/platforms/ios.md:56
+#: src/platforms/tvos.md:55 src/platforms/watchos.md:59
+#: src/platforms/android.md:30 src/platforms/windows.md:48
+#: src/platforms/linux.md:40 src/testing/geisterhand.md:89
+#: src/testing/geisterhand.md:292
+msgid "Toggle"
+msgstr ""
+
+#: src/ui/widgets.md:154
+msgid "A boolean on/off switch."
+msgstr ""
+
+#: src/ui/widgets.md:156
+msgid ""
+"```typescript\n"
+"// demonstrates: Toggle widget bound to State\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Toggle, State } from \"perry/ui\"\n"
+"\n"
+"const enabled = State(false)\n"
+"\n"
+"App({\n"
+"    title: \"Toggle\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Toggle(\"Enable notifications\", (on: boolean) => enabled.set(on)),\n"
+"        Text(`Enabled: ${enabled.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:177 src/platforms/macos.md:31 src/platforms/ios.md:57
+#: src/platforms/tvos.md:56 src/platforms/watchos.md:60
+#: src/platforms/android.md:31 src/platforms/windows.md:49
+#: src/platforms/linux.md:41 src/testing/geisterhand.md:88
+#: src/testing/geisterhand.md:291
+msgid "Slider"
+msgstr ""
+
+#: src/ui/widgets.md:179
+msgid "A numeric slider."
+msgstr ""
+
+#: src/ui/widgets.md:181
+msgid ""
+"```typescript\n"
+"// demonstrates: Slider with a numeric range\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Slider, State } from \"perry/ui\"\n"
+"\n"
+"const value = State(50)\n"
+"\n"
+"App({\n"
+"    title: \"Slider\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Slider(0, 100, (v: number) => value.set(v)),\n"
+"        Text(`Value: ${value.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:202
+msgid ""
+"`Slider(min, max, onChange)` — `onChange` fires on every drag. Use "
+"`stateBindSlider(state, slider)` for two-way binding."
+msgstr ""
+
+#: src/ui/widgets.md:205 src/platforms/macos.md:32 src/platforms/ios.md:58
+#: src/platforms/tvos.md:57 src/platforms/watchos.md:64
+#: src/platforms/android.md:32 src/platforms/windows.md:50
+#: src/platforms/linux.md:42 src/testing/geisterhand.md:90
+#: src/testing/geisterhand.md:293
+msgid "Picker"
+msgstr ""
+
+#: src/ui/widgets.md:207
+msgid "A dropdown selection control. Items are added with `pickerAddItem`."
+msgstr ""
+
+#: src/ui/widgets.md:209
+msgid ""
+"```typescript\n"
+"// demonstrates: Picker with items added via pickerAddItem\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Picker, State, pickerAddItem } from \"perry/ui\"\n"
+"\n"
+"const selected = State(0)\n"
+"const picker = Picker((index: number) => selected.set(index))\n"
+"pickerAddItem(picker, \"Option A\")\n"
+"pickerAddItem(picker, \"Option B\")\n"
+"pickerAddItem(picker, \"Option C\")\n"
+"\n"
+"App({\n"
+"    title: \"Picker\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        picker,\n"
+"        Text(`Selected index: ${selected.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:234
+msgid "ImageFile / ImageSymbol"
+msgstr ""
+
+#: src/ui/widgets.md:236
+msgid "Two distinct constructors:"
+msgstr ""
+
+#: src/ui/widgets.md:238
+msgid "`ImageFile(path)` — image from a file path"
+msgstr ""
+
+#: src/ui/widgets.md:239
+msgid "`ImageSymbol(name)` — SF Symbol glyph name (macOS/iOS only)"
+msgstr ""
+
+#: src/ui/widgets.md:241
+msgid ""
+"```typescript\n"
+"// demonstrates: ImageSymbol for SF Symbol glyphs (macOS/iOS)\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos\n"
+"// targets: ios-simulator, visionos-simulator, tvos-simulator\n"
+"\n"
+"import { App, HStack, ImageSymbol, widgetSetWidth, widgetSetHeight } from \"perry/ui\"\n"
+"\n"
+"const star = ImageSymbol(\"star.fill\")\n"
+"widgetSetWidth(star, 32)\n"
+"widgetSetHeight(star, 32)\n"
+"\n"
+"const heart = ImageSymbol(\"heart.fill\")\n"
+"const bell = ImageSymbol(\"bell.fill\")\n"
+"\n"
+"App({\n"
+"    title: \"ImageSymbol\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: HStack(12, [star, heart, bell]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:264
+msgid ""
+"Use `widgetSetWidth(img, N)` / `widgetSetHeight(img, N)` to size the image."
+msgstr ""
+
+#: src/ui/widgets.md:266 src/platforms/watchos.md:63
+#: src/platforms/windows.md:51 src/platforms/linux.md:43
+msgid "ProgressView"
+msgstr ""
+
+#: src/ui/widgets.md:268
+msgid "An indeterminate or determinate progress indicator."
+msgstr ""
+
+#: src/ui/widgets.md:270
+msgid ""
+"```typescript\n"
+"// demonstrates: ProgressView as an indeterminate spinner\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, ProgressView } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"ProgressView\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Text(\"Loading...\"),\n"
+"        ProgressView(),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:289
+msgid "TextArea"
+msgstr ""
+
+#: src/ui/widgets.md:291
+msgid ""
+"A multi-line text input. Same `(placeholder, onChange)` signature as "
+"`TextField` but renders as a multi-line box."
+msgstr ""
+
+#: src/ui/widgets.md:294
+msgid ""
+"```typescript\n"
+"// demonstrates: TextArea for multi-line input\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, TextArea, State } from \"perry/ui\"\n"
+"\n"
+"const content = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"TextArea\",\n"
+"    width: 500,\n"
+"    height: 400,\n"
+"    body: VStack(12, [\n"
+"        TextArea(\"Enter multi-line text...\", (value: string) => content.set(value)),\n"
+"        Text(`Length: ${content.value.length}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:315
+msgid "**Helpers:** `textareaSetString`."
+msgstr ""
+
+#: src/ui/widgets.md:317 src/cli/perry-toml.md:108
+msgid "Sections"
+msgstr ""
+
+#: src/ui/widgets.md:319
+msgid ""
+"Group controls into labelled sections. Perry has no `Form()` widget — use a "
+"`VStack` of `Section(title)`s and attach children via `widgetAddChild`."
+msgstr ""
+
+#: src/ui/widgets.md:322
+msgid ""
+"```typescript\n"
+"// demonstrates: Section grouping with widgetAddChild (no Form widget in Perry)\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack,\n"
+"    Section,\n"
+"    TextField,\n"
+"    Toggle,\n"
+"    State,\n"
+"    widgetAddChild,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const name = State(\"\")\n"
+"const notifications = State(true)\n"
+"\n"
+"const personal = Section(\"Personal Info\")\n"
+"widgetAddChild(personal, TextField(\"Name\", (value: string) => name.set(value)))\n"
+"\n"
+"const settings = Section(\"Settings\")\n"
+"widgetAddChild(\n"
+"    settings,\n"
+"    Toggle(\"Notifications\", (on: boolean) => notifications.set(on)),\n"
+")\n"
+"\n"
+"App({\n"
+"    title: \"Sections\",\n"
+"    width: 500,\n"
+"    height: 400,\n"
+"    body: VStack(16, [personal, settings]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:358
+msgid "Platform-specific widgets"
+msgstr ""
+
+#: src/ui/widgets.md:360
+msgid ""
+"These exist only on specific platforms and aren't verified by the cross-"
+"platform doc-tests:"
+msgstr ""
+
+#: src/ui/widgets.md:363
+msgid ""
+"**`Table(rows, cols, renderer)`** — macOS only. A data table with rows, "
+"columns, and a cell renderer."
+msgstr ""
+
+#: src/ui/widgets.md:365
+msgid "**`QRCode(data, size)`** — macOS only. Renders a QR code."
+msgstr ""
+
+#: src/ui/widgets.md:366
+msgid ""
+"**`Canvas(width, height, draw)`** — all desktop platforms. A drawing "
+"surface; see [Canvas](canvas.md)."
+msgstr ""
+
+#: src/ui/widgets.md:368
+msgid ""
+"**`CameraView()`** — iOS only (other platforms planned). See "
+"[Camera](camera.md)."
+msgstr ""
+
+#: src/ui/widgets.md:371
+msgid "These are linked from their own pages with platform-specific examples."
+msgstr ""
+
+#: src/ui/widgets.md:373
+msgid "Common widget helpers"
+msgstr ""
+
+#: src/ui/widgets.md:375
+msgid "Every widget handle accepts these:"
+msgstr ""
+
+#: src/ui/widgets.md:377
+msgid "Helper"
+msgstr ""
+
+#: src/ui/widgets.md:379
+msgid "`widgetSetWidth(w, n)` / `widgetSetHeight(w, n)`"
+msgstr ""
+
+#: src/ui/widgets.md:379
+msgid "Explicit size in points"
+msgstr ""
+
+#: src/ui/widgets.md:380
+msgid "`widgetSetBackgroundColor(w, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/widgets.md:380
+msgid "RGBA in \\[0, 1\\]"
+msgstr ""
+
+#: src/ui/widgets.md:381
+msgid "`setCornerRadius(w, r)`"
+msgstr ""
+
+#: src/ui/widgets.md:381
+msgid "Rounded corners in points"
+msgstr ""
+
+#: src/ui/widgets.md:382
+msgid "`widgetSetOpacity(w, alpha)`"
+msgstr ""
+
+#: src/ui/widgets.md:382
+msgid "Opacity in \\[0, 1\\]"
+msgstr ""
+
+#: src/ui/widgets.md:383
+msgid "`widgetSetEnabled(w, flag)`"
+msgstr ""
+
+#: src/ui/widgets.md:383
+msgid "`0` disables, `1` enables"
+msgstr ""
+
+#: src/ui/widgets.md:384
+msgid "`widgetSetHidden(w, flag)`"
+msgstr ""
+
+#: src/ui/widgets.md:384
+msgid "`0` visible, `1` hidden"
+msgstr ""
+
+#: src/ui/widgets.md:385
+msgid "`widgetSetTooltip(w, text)`"
+msgstr ""
+
+#: src/ui/widgets.md:385
+msgid "Tooltip on hover (desktop only)"
+msgstr ""
+
+#: src/ui/widgets.md:386
+msgid "`widgetSetOnClick(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:386
+msgid "Click handler"
+msgstr ""
+
+#: src/ui/widgets.md:387
+msgid "`widgetSetOnHover(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:387
+msgid "Hover enter/leave (desktop only)"
+msgstr ""
+
+#: src/ui/widgets.md:388
+msgid "`widgetSetOnDoubleClick(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:388
+msgid "Double-click handler"
+msgstr ""
+
+#: src/ui/widgets.md:389
+msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+msgstr ""
+
+#: src/ui/widgets.md:389
+msgid "Padding around contents"
+msgstr ""
+
+#: src/ui/widgets.md:390
+msgid "`widgetSetBorderColor(w, r, g, b, a)` / `widgetSetBorderWidth(w, n)`"
+msgstr ""
+
+#: src/ui/widgets.md:390
+msgid "Border"
+msgstr ""
+
+#: src/ui/widgets.md:391 src/ui/layout.md:175
+msgid "`widgetAddChild(parent, child)`"
+msgstr ""
+
+#: src/ui/widgets.md:391
+msgid "Attach a child to a container"
+msgstr ""
+
+#: src/ui/widgets.md:392
+msgid "`widgetSetContextMenu(w, menu)`"
+msgstr ""
+
+#: src/ui/widgets.md:392
+msgid "Right-click menu"
+msgstr ""
+
+#: src/ui/widgets.md:394
+msgid "See [Styling](styling.md) and [Events](events.md) for deeper coverage."
+msgstr ""
+
+#: src/ui/widgets.md:398
+msgid "[Layout](layout.md) — Arranging widgets with stacks and containers"
+msgstr ""
+
+#: src/ui/widgets.md:399
+msgid "[Styling](styling.md) — Colors, fonts, borders"
+msgstr ""
+
+#: src/ui/widgets.md:400 src/ui/theming.md:169
+msgid "[State Management](state.md) — Reactive bindings"
+msgstr ""
+
+#: src/ui/layout.md:3
+msgid ""
+"Perry provides layout containers that arrange child widgets using the "
+"platform's native layout system. Every snippet below is excerpted from "
+"[`docs/examples/ui/layout/snippets.ts`](../../examples/ui/layout/snippets.ts)"
+" — CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/layout.md:8
+msgid ""
+"Layout helpers are free functions: `widgetAddChild(parent, child)`, "
+"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
+"bottom, right)`, etc. Stack constructors take a numeric spacing followed by "
+"a child array; everything else (alignment, distribution, padding, sizing) is"
+" applied post-construction via the free functions on the widget handle."
+msgstr ""
+
+#: src/ui/layout.md:14 src/platforms/watchos.md:54 src/platforms/android.md:34
+#: src/platforms/linux.md:45 src/widgets/components.md:43
+msgid "VStack"
+msgstr ""
+
+#: src/ui/layout.md:16
+msgid "Arranges children vertically (top to bottom)."
+msgstr ""
+
+#: src/ui/layout.md:18
+msgid ""
+"```typescript\n"
+"const stack = VStack(16, [\n"
+"    Text(\"First\"),\n"
+"    Text(\"Second\"),\n"
+"    Text(\"Third\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:26
+msgid ""
+"`VStack(spacing, children)` — the first argument is the gap in points "
+"between children."
+msgstr ""
+
+#: src/ui/layout.md:29 src/platforms/watchos.md:55 src/platforms/android.md:35
+#: src/platforms/linux.md:46 src/widgets/components.md:52
+msgid "HStack"
+msgstr ""
+
+#: src/ui/layout.md:31
+msgid "Arranges children horizontally (left to right)."
+msgstr ""
+
+#: src/ui/layout.md:33
+msgid ""
+"```typescript\n"
+"const row = HStack(8, [\n"
+"    Button(\"Cancel\", noop),\n"
+"    Spacer(),\n"
+"    Button(\"OK\", noop),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:41 src/platforms/watchos.md:56 src/platforms/android.md:36
+#: src/platforms/linux.md:47 src/widgets/components.md:62
+msgid "ZStack"
+msgstr ""
+
+#: src/ui/layout.md:43
+msgid ""
+"Layers children on top of each other (back to front). `ZStack()` takes no "
+"constructor children — populate it with `widgetAddChild`:"
+msgstr ""
+
+#: src/ui/layout.md:46
+msgid ""
+"```typescript\n"
+"const layered = ZStack()\n"
+"widgetAddChild(layered, ImageFile(\"background.png\"))\n"
+"widgetAddChild(layered, Text(\"Overlay text\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:52 src/platforms/macos.md:35 src/platforms/ios.md:61
+#: src/platforms/tvos.md:60 src/platforms/watchos.md:62
+#: src/platforms/android.md:37 src/platforms/windows.md:54
+#: src/platforms/linux.md:48 src/testing/geisterhand.md:94
+msgid "ScrollView"
+msgstr ""
+
+#: src/ui/layout.md:54
+msgid ""
+"A scrollable container. Built empty, then filled via `scrollviewSetChild`:"
+msgstr ""
+
+#: src/ui/layout.md:56
+msgid ""
+"```typescript\n"
+"// ScrollView() takes no args; populate it with `scrollviewSetChild`.\n"
+"const sv = ScrollView()\n"
+"const inner = VStack(8, [Text(\"a\"), Text(\"b\"), Text(\"c\")])\n"
+"scrollviewSetChild(sv, inner)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:63
+msgid "LazyVStack"
+msgstr ""
+
+#: src/ui/layout.md:65
+msgid ""
+"A vertically scrolling list that lazily renders items. More efficient than "
+"`ScrollView` + `VStack` for thousands of rows — on macOS this is backed by "
+"`NSTableView` so only rows in the visible rect are realized."
+msgstr ""
+
+#: src/ui/layout.md:69
+msgid ""
+"```typescript\n"
+"// `render(index)` is invoked lazily — only rows in the visible rect are realized.\n"
+"const lazy = LazyVStack(1000, (index: number) => Text(`Row ${index}`))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:74
+msgid ""
+"When the underlying data changes, call `lazyvstackUpdate(handle, newCount)` "
+"to refresh. Override the default 44pt row height with "
+"`lazyvstackSetRowHeight`."
+msgstr ""
+
+#: src/ui/layout.md:77
+msgid "NavStack"
+msgstr ""
+
+#: src/ui/layout.md:79
+msgid ""
+"A navigation container that supports push/pop navigation. Push a new view "
+"with `navstackPush(stack, view, title)`; pop with `navstackPop(stack)`:"
+msgstr ""
+
+#: src/ui/layout.md:82
+msgid ""
+"```typescript\n"
+"const home = VStack(16, [\n"
+"    Text(\"Home Screen\"),\n"
+"    Button(\"Go to Details\", () => {\n"
+"        navstackPush(nav, Text(\"Details!\"), \"Details\")\n"
+"    }),\n"
+"])\n"
+"const nav = NavStack()\n"
+"widgetAddChild(nav, home)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:93 src/platforms/watchos.md:57
+#: src/widgets/components.md:71 src/widgets/platforms.md:25
+#: src/widgets/platforms.md:26
+msgid "Spacer"
+msgstr ""
+
+#: src/ui/layout.md:95
+msgid "A flexible space that expands to fill available room."
+msgstr ""
+
+#: src/ui/layout.md:97
+msgid ""
+"```typescript\n"
+"const toolbar = HStack(8, [\n"
+"    Text(\"Left\"),\n"
+"    Spacer(),\n"
+"    Text(\"Right\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:105
+msgid "Use `Spacer()` inside `HStack` or `VStack` to push widgets apart."
+msgstr ""
+
+#: src/ui/layout.md:107 src/platforms/watchos.md:58
+#: src/widgets/components.md:106 src/widgets/platforms.md:26
+msgid "Divider"
+msgstr ""
+
+#: src/ui/layout.md:109
+msgid "A visual separator line."
+msgstr ""
+
+#: src/ui/layout.md:111
+msgid ""
+"```typescript\n"
+"const sections = VStack(12, [\n"
+"    Text(\"Section 1\"),\n"
+"    Divider(),\n"
+"    Text(\"Section 2\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:119
+msgid "Nesting Layouts"
+msgstr ""
+
+#: src/ui/layout.md:121
+msgid "Layouts can be nested freely. This complete example is verified by CI:"
+msgstr ""
+
+#: src/ui/layout.md:123
+msgid ""
+"```typescript\n"
+"// demonstrates: nested VStack/HStack + Spacer + Divider\n"
+"// docs: docs/src/ui/layout.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, HStack, Text, Button, Spacer, Divider } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"Layout Example\",\n"
+"    width: 800,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        // Header\n"
+"        HStack(8, [\n"
+"            Text(\"My App\"),\n"
+"            Spacer(),\n"
+"            Button(\"Settings\", () => {}),\n"
+"        ]),\n"
+"        Divider(),\n"
+"        // Content\n"
+"        VStack(12, [\n"
+"            Text(\"Welcome!\"),\n"
+"            HStack(8, [\n"
+"                Button(\"Action 1\", () => {}),\n"
+"                Button(\"Action 2\", () => {}),\n"
+"            ]),\n"
+"        ]),\n"
+"        Spacer(),\n"
+"        // Footer\n"
+"        Text(\"v1.0.0\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:158
+msgid "Child Management"
+msgstr ""
+
+#: src/ui/layout.md:160
+msgid "Containers support dynamic child management via free functions:"
+msgstr ""
+
+#: src/ui/layout.md:162
+msgid ""
+"```typescript\n"
+"const list = VStack(16, [])\n"
+"widgetAddChild(list, Text(\"appended\"))            // append\n"
+"widgetAddChildAt(list, Text(\"prepended\"), 0)      // insert at index\n"
+"widgetReorderChild(list, 1, 0)                    // move from→to\n"
+"const removeMe = Text(\"temporary\")\n"
+"widgetAddChild(list, removeMe)\n"
+"widgetRemoveChild(list, removeMe)                 // remove\n"
+"widgetClearChildren(list)                         // remove all\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:173 src/ui/menus.md:53 src/ui/theming.md:131
+#: src/system/overview.md:21 src/system/media.md:37
+#: src/plugins/native-extensions.md:175
+msgid "Function"
+msgstr ""
+
+#: src/ui/layout.md:175
+msgid "Append a child widget"
+msgstr ""
+
+#: src/ui/layout.md:176
+msgid "`widgetAddChildAt(parent, child, index)`"
+msgstr ""
+
+#: src/ui/layout.md:176
+msgid "Insert a child at a specific position"
+msgstr ""
+
+#: src/ui/layout.md:177
+msgid "`widgetRemoveChild(parent, child)`"
+msgstr ""
+
+#: src/ui/layout.md:177
+msgid "Remove a specific child"
+msgstr ""
+
+#: src/ui/layout.md:178
+msgid "`widgetReorderChild(widget, fromIndex, toIndex)`"
+msgstr ""
+
+#: src/ui/layout.md:178
+msgid "Move a child to a new position"
+msgstr ""
+
+#: src/ui/layout.md:179
+msgid "`widgetClearChildren(widget)`"
+msgstr ""
+
+#: src/ui/layout.md:179
+msgid "Remove all children"
+msgstr ""
+
+#: src/ui/layout.md:181
+msgid "Stack Alignment"
+msgstr ""
+
+#: src/ui/layout.md:183
+msgid ""
+"Control how children are aligned within a stack using `stackSetAlignment`:"
+msgstr ""
+
+#: src/ui/layout.md:185
+msgid ""
+"```typescript\n"
+"const centered = VStack(16, [\n"
+"    Text(\"Centered\"),\n"
+"    Text(\"Content\"),\n"
+"])\n"
+"stackSetAlignment(centered, 9) // CenterX\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:193
+msgid "**VStack alignment** (cross-axis = horizontal):"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203 src/ui/layout.md:221
+#: src/platforms/tvos.md:149 src/plugins/appstore-review.md:77
+#: src/plugins/appstore-review.md:93 src/plugins/appstore-review.md:106
+#: src/cli/perry-toml.md:215 src/cli/perry-toml.md:277
+#: src/cli/perry-toml.md:284
+msgid "Value"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203 src/ui/layout.md:221
+msgid "Name"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203
+msgid "Effect"
+msgstr ""
+
+#: src/ui/layout.md:197 src/ui/styling.md:372 src/testing/geisterhand.md:91
+#: src/testing/geisterhand.md:105 src/cli/perry-toml.md:400
+msgid "5"
+msgstr ""
+
+#: src/ui/layout.md:197
+msgid "Leading"
+msgstr ""
+
+#: src/ui/layout.md:197
+msgid "Children align to the leading (left) edge"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "9"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "CenterX"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "Children centered horizontally"
+msgstr ""
+
+#: src/ui/layout.md:199 src/testing/geisterhand.md:93
+msgid "7"
+msgstr ""
+
+#: src/ui/layout.md:199
+msgid "Width"
+msgstr ""
+
+#: src/ui/layout.md:199
+msgid "Children stretch to fill the stack's width"
+msgstr ""
+
+#: src/ui/layout.md:201
+msgid "**HStack alignment** (cross-axis = vertical):"
+msgstr ""
+
+#: src/ui/layout.md:205 src/ui/layout.md:226 src/platforms/windows-7.md:27
+#: src/testing/geisterhand.md:89 src/testing/geisterhand.md:103
+#: src/cli/perry-toml.md:402
+msgid "3"
+msgstr ""
+
+#: src/ui/layout.md:205
+msgid "Top"
+msgstr ""
+
+#: src/ui/layout.md:205
+msgid "Children align to the top"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "12"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "CenterY"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "Children centered vertically"
+msgstr ""
+
+#: src/ui/layout.md:207 src/ui/layout.md:227 src/ui/styling.md:371
+#: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
+#: src/cli/perry-toml.md:401
+msgid "4"
+msgstr ""
+
+#: src/ui/layout.md:207
+msgid "Bottom"
+msgstr ""
+
+#: src/ui/layout.md:207
+msgid "Children align to the bottom"
+msgstr ""
+
+#: src/ui/layout.md:209
+msgid "Stack Distribution"
+msgstr ""
+
+#: src/ui/layout.md:211
+msgid ""
+"Control how children share space within a stack using "
+"`stackSetDistribution`:"
+msgstr ""
+
+#: src/ui/layout.md:213
+msgid ""
+"```typescript\n"
+"const buttons = HStack(8, [\n"
+"    Button(\"Cancel\", noop),\n"
+"    Button(\"OK\", noop),\n"
+"])\n"
+"stackSetDistribution(buttons, 1) // FillEqually — both buttons get equal width\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:221 src/widgets/data-fetching.md:125
+msgid "Behavior"
+msgstr ""
+
+#: src/ui/layout.md:223 src/ui/styling.md:370 src/ui/styling.md:371
+#: src/ui/styling.md:372 src/testing/geisterhand.md:86
+#: src/testing/geisterhand.md:100
+msgid "0"
+msgstr ""
+
+#: src/ui/layout.md:223
+msgid "Fill"
+msgstr ""
+
+#: src/ui/layout.md:223
+msgid "Default. First resizable child fills remaining space"
+msgstr ""
+
+#: src/ui/layout.md:224 src/platforms/windows-7.md:25
+#: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
+#: src/cli/perry-toml.md:404
+msgid "1"
+msgstr ""
+
+#: src/ui/layout.md:224
+msgid "FillEqually"
+msgstr ""
+
+#: src/ui/layout.md:224
+msgid "All children get equal size"
+msgstr ""
+
+#: src/ui/layout.md:225 src/platforms/windows-7.md:26
+#: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
+#: src/cli/perry-toml.md:403
+msgid "2"
+msgstr ""
+
+#: src/ui/layout.md:225
+msgid "FillProportionally"
+msgstr ""
+
+#: src/ui/layout.md:225
+msgid "Children sized proportionally to their intrinsic content"
+msgstr ""
+
+#: src/ui/layout.md:226
+msgid "EqualSpacing"
+msgstr ""
+
+#: src/ui/layout.md:226
+msgid "Equal gaps between children"
+msgstr ""
+
+#: src/ui/layout.md:227
+msgid "EqualCentering"
+msgstr ""
+
+#: src/ui/layout.md:227
+msgid "Equal distance between child centers"
+msgstr ""
+
+#: src/ui/layout.md:229
+msgid "Fill Parent"
+msgstr ""
+
+#: src/ui/layout.md:231
+msgid "Pin a child's edges to its parent container:"
+msgstr ""
+
+#: src/ui/layout.md:233
+msgid ""
+"```typescript\n"
+"const banner = Text(\"Full width banner\")\n"
+"widgetMatchParentWidth(banner)\n"
+"const banneredPage = VStack(16, [banner, Text(\"Normal width\")])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:239
+msgid "`widgetMatchParentWidth(widget)` — stretch to fill parent's width"
+msgstr ""
+
+#: src/ui/layout.md:240
+msgid "`widgetMatchParentHeight(widget)` — stretch to fill parent's height"
+msgstr ""
+
+#: src/ui/layout.md:242
+msgid "Content Hugging"
+msgstr ""
+
+#: src/ui/layout.md:244
+msgid ""
+"Control whether a widget resists being stretched beyond its intrinsic size:"
+msgstr ""
+
+#: src/ui/layout.md:246
+msgid ""
+"```typescript\n"
+"const tight = Text(\"I stay small\")\n"
+"widgetSetHugging(tight, 750) // High priority — resist stretching\n"
+"\n"
+"const stretchy = Text(\"I stretch\")\n"
+"widgetSetHugging(stretchy, 1) // Low priority — stretch to fill\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:254
+msgid ""
+"**High priority** (250–750+): widget resists stretching, stays at its "
+"natural size"
+msgstr ""
+
+#: src/ui/layout.md:255
+msgid "**Low priority** (1–249): widget stretches to fill available space"
+msgstr ""
+
+#: src/ui/layout.md:257
+msgid "Overlay Positioning"
+msgstr ""
+
+#: src/ui/layout.md:259
+msgid "For absolute positioning, add overlay children to any container:"
+msgstr ""
+
+#: src/ui/layout.md:261
+msgid ""
+"```typescript\n"
+"// Overlay parent must be a ZStack — macOS NSView allows `addSubview` on\n"
+"// any view, but GTK4 can only float children above siblings inside\n"
+"// `gtk::Overlay` (which is what ZStack is backed by).\n"
+"const container = ZStack()\n"
+"widgetAddChild(container, VStack(16, [Text(\"Main content\")])) // main child\n"
+"\n"
+"const badge = Text(\"3\")\n"
+"setCornerRadius(badge, 10)\n"
+"widgetSetBackgroundColor(badge, 1.0, 0.231, 0.188, 1.0) // RGBA red\n"
+"\n"
+"widgetAddOverlay(container, badge)\n"
+"widgetSetOverlayFrame(badge, 280, 10, 20, 20) // x, y, width, height\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:276
+msgid ""
+"Overlay children are positioned absolutely relative to their parent — "
+"similar to CSS `position: absolute`."
+msgstr ""
+
+#: src/ui/layout.md:279
+msgid "Split Views"
+msgstr ""
+
+#: src/ui/layout.md:281
+msgid "Create resizable split panes for sidebar layouts:"
+msgstr ""
+
+#: src/ui/layout.md:283
+msgid ""
+"```typescript\n"
+"const split = SplitView()\n"
+"\n"
+"const sidebar = VStack(8, [Text(\"Navigation\"), Text(\"Item 1\"), Text(\"Item 2\")])\n"
+"const content = VStack(16, [Text(\"Main Content\")])\n"
+"\n"
+"splitViewAddChild(split, sidebar)\n"
+"splitViewAddChild(split, content)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:293
+msgid ""
+"The user can drag the divider to resize panes. On macOS this maps to "
+"`NSSplitView`."
+msgstr ""
+
+#: src/ui/layout.md:296
+msgid "Stacks with Built-in Padding"
+msgstr ""
+
+#: src/ui/layout.md:298
+msgid ""
+"Create a stack with padding in a single call. The order is **top, left, "
+"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+msgstr ""
+
+#: src/ui/layout.md:301
+msgid ""
+"```typescript\n"
+"// VStackWithInsets(spacing, top, left, bottom, right) — note: order is\n"
+"// top/left/bottom/right (CSS-style), not top/right/bottom/left.\n"
+"const card = VStackWithInsets(12, 16, 16, 16, 16)\n"
+"widgetAddChild(card, Text(\"Padded content\"))\n"
+"widgetAddChild(card, Text(\"More content\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:309
+msgid ""
+"`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
+"counterpart. Equivalent to creating a stack and then calling "
+"`widgetSetEdgeInsets`, but more concise. Children are added via "
+"`widgetAddChild` rather than the constructor array."
+msgstr ""
+
+#: src/ui/layout.md:314
+msgid "Detaching Hidden Views"
+msgstr ""
+
+#: src/ui/layout.md:316
+msgid ""
+"By default, hidden children still occupy space in a stack. To collapse them:"
+msgstr ""
+
+#: src/ui/layout.md:318
+msgid ""
+"```typescript\n"
+"const collapsible = VStack(8, [Text(\"Always visible\"), Text(\"Sometimes hidden\")])\n"
+"stackSetDetachesHidden(collapsible, 1) // Hidden children leave no gap\n"
+"// You can then toggle a child:\n"
+"const sometimesHidden = Text(\"toggle me\")\n"
+"widgetSetHidden(sometimesHidden, 1) // 1 = hidden, 0 = visible\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:326
+msgid "Common Layout Patterns"
+msgstr ""
+
+#: src/ui/layout.md:328
+msgid "Centered content"
+msgstr ""
+
+#: src/ui/layout.md:330
+msgid ""
+"```typescript\n"
+"const page = VStack(16, [Text(\"Title\"), Text(\"Subtitle\")])\n"
+"stackSetAlignment(page, 9) // CenterX\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:335
+msgid "Search row that fills the width"
+msgstr ""
+
+#: src/ui/layout.md:337
+msgid ""
+"```typescript\n"
+"const searchInput = TextField(\"Search...\", (v: string) => search.set(v))\n"
+"widgetMatchParentWidth(searchInput)\n"
+"const results = VStack(8, [])\n"
+"const searchPage = VStack(12, [searchInput, results])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:344
+msgid "Floating badge / overlay"
+msgstr ""
+
+#: src/ui/layout.md:346
+msgid ""
+"```typescript\n"
+"// Wrap the icon in a ZStack so the badge can float above it on every\n"
+"const icon = ZStack()\n"
+"widgetAddChild(icon, ImageSymbol(\"bell\"))\n"
+"const dotBadge = Text(\"3\")\n"
+"widgetAddOverlay(icon, dotBadge)\n"
+"widgetSetOverlayFrame(dotBadge, 20, -5, 16, 16)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:355
+msgid "Toolbar with spacers"
+msgstr ""
+
+#: src/ui/layout.md:357
+msgid ""
+"```typescript\n"
+"const titleBar = HStack(8, [\n"
+"    Button(\"Back\", noop),\n"
+"    Spacer(),\n"
+"    Text(\"Page Title\"),\n"
+"    Spacer(),\n"
+"    Button(\"Settings\", noop),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:369
+msgid "[Styling](styling.md) — Colors, padding, sizing"
+msgstr ""
+
+#: src/ui/layout.md:371
+msgid "[State Management](state.md) — Dynamic UI with state"
+msgstr ""
+
+#: src/ui/styling.md:3
+msgid ""
+"Perry widgets accept an inline `style: { ... }` object that maps to each "
+"platform's native styling APIs. The same shape works on every Widget "
+"constructor — `Button`, `Text`, `Toggle`, `Slider`, `VStack`/`HStack`, and "
+"friends — so cross-platform styling code stays the same regardless of "
+"target."
+msgstr ""
+
+#: src/ui/styling.md:9
+msgid "Inline style — recommended"
+msgstr ""
+
+#: src/ui/styling.md:11
+msgid ""
+"Pass a `StyleProps` object as the trailing argument to any widget "
+"constructor. Codegen destructures the literal at HIR time into a sequence of"
+" native setter calls, so the runtime shape is the same as hand-writing the "
+"imperative pattern below — but the source is much shorter:"
+msgstr ""
+
+#: src/ui/styling.md:17
+msgid ""
+"```typescript\n"
+"const card = Button(\"Save\", () => {\n"
+"    console.log(\"saved\")\n"
+"}, {\n"
+"    backgroundColor: { r: 0.231, g: 0.510, b: 0.965, a: 1.0 },\n"
+"    borderColor: { r: 0.0, g: 0.0, b: 0.0, a: 0.1 },\n"
+"    borderWidth: 1,\n"
+"    borderRadius: 8,\n"
+"    padding: 12,\n"
+"    opacity: 0.95,\n"
+"    shadow: {\n"
+"        color: { r: 0.0, g: 0.0, b: 0.0, a: 0.25 },\n"
+"        blur: 12,\n"
+"        offsetX: 0,\n"
+"        offsetY: 4,\n"
+"    },\n"
+"    tooltip: \"Save the current document\",\n"
+"    enabled: true,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:38
+msgid ""
+"The `style` arg is optional; widgets without it look identical to calls "
+"before this API existed. See "
+"[`docs/examples/ui/styling/button_inline_style.ts`](../../examples/ui/styling/button_inline_style.ts)"
+" for the full file."
+msgstr ""
+
+#: src/ui/styling.md:43
+msgid "What `style` accepts"
+msgstr ""
+
+#: src/ui/styling.md:45
+msgid "Prop"
+msgstr ""
+
+#: src/ui/styling.md:45
+msgid "Maps to"
+msgstr ""
+
+#: src/ui/styling.md:47
+msgid "`backgroundColor`"
+msgstr ""
+
+#: src/ui/styling.md:47 src/ui/styling.md:48 src/ui/styling.md:49
+msgid "string \\| PerryColor"
+msgstr ""
+
+#: src/ui/styling.md:47
+msgid "`widgetSetBackgroundColor`"
+msgstr ""
+
+#: src/ui/styling.md:48
+msgid "`color`"
+msgstr ""
+
+#: src/ui/styling.md:48
+msgid "`textSetColor` / `buttonSetTextColor`"
+msgstr ""
+
+#: src/ui/styling.md:49
+msgid "`borderColor`"
+msgstr ""
+
+#: src/ui/styling.md:49
+msgid "`widgetSetBorderColor`"
+msgstr ""
+
+#: src/ui/styling.md:50
+msgid "`borderWidth`"
+msgstr ""
+
+#: src/ui/styling.md:50
+msgid "`widgetSetBorderWidth`"
+msgstr ""
+
+#: src/ui/styling.md:51
+msgid "`borderRadius`"
+msgstr ""
+
+#: src/ui/styling.md:51
+msgid "`setCornerRadius`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "`padding`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "number \\| `{ top, right, bottom, left }`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "`widgetSetEdgeInsets`"
+msgstr ""
+
+#: src/ui/styling.md:53 src/platforms/watchos.md:77
+msgid "`opacity`"
+msgstr ""
+
+#: src/ui/styling.md:53
+msgid "number (0..=1)"
+msgstr ""
+
+#: src/ui/styling.md:53
+msgid "`widgetSetOpacity`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`shadow`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`{ color, blur, offsetX, offsetY }`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`widgetSetShadow`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`textDecoration`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`\"none\" \\| \"underline\" \\| \"strikethrough\"`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`textSetDecoration`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`gradient`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`{ angle, stops: [c1, c2] }`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`widgetSetBackgroundGradient`"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "`fontSize`, `fontWeight`, `fontFamily`"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "number / string"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "`textSetFont*`"
+msgstr ""
+
+#: src/ui/styling.md:58
+msgid "`tooltip`"
+msgstr ""
+
+#: src/ui/styling.md:58
+msgid "`widgetSetTooltip`"
+msgstr ""
+
+#: src/ui/styling.md:59
+msgid "`hidden`"
+msgstr ""
+
+#: src/ui/styling.md:59
+msgid "`widgetSetHidden`"
+msgstr ""
+
+#: src/ui/styling.md:60
+msgid "`enabled`"
+msgstr ""
+
+#: src/ui/styling.md:60
+msgid "`widgetSetEnabled`"
+msgstr ""
+
+#: src/ui/styling.md:62
+msgid "Color values"
+msgstr ""
+
+#: src/ui/styling.md:64
+msgid "Color props accept four interchangeable shapes:"
+msgstr ""
+
+#: src/ui/styling.md:66
+msgid ""
+"```typescript,no-test\n"
+"backgroundColor: \"#3B82F6\"                                   // hex 6/8\n"
+"backgroundColor: \"#3B82F6FF\"                                 // hex with alpha\n"
+"backgroundColor: \"blue\"                                      // named color\n"
+"backgroundColor: { r: 0.231, g: 0.510, b: 0.965, a: 1.0 }   // PerryColor object\n"
+"backgroundColor: themeColor                                  // runtime variable\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:74
+msgid ""
+"Named colors: `white`, `black`, `red`, `green`, `blue`, `yellow`, `cyan`, "
+"`magenta`, `gray` / `grey`, `transparent`. Hex forms supported: `#RGB`, "
+"`#RGBA`, `#RRGGBB`, `#RRGGBBAA`."
+msgstr ""
+
+#: src/ui/styling.md:78
+msgid ""
+"Literals (the first four forms) compile-time-fold into 4 baked-in float "
+"arguments — zero runtime cost. Runtime variables resolve through "
+"`js_color_parse_channel` (a small CSS color parser in `perry-runtime`) so "
+"`backgroundColor: someStringVar` works the same as the literal form."
+msgstr ""
+
+#: src/ui/styling.md:83
+msgid "Padding shapes"
+msgstr ""
+
+#: src/ui/styling.md:85
+msgid "A single number applies to all four sides; an object picks per-side:"
+msgstr ""
+
+#: src/ui/styling.md:87
+msgid ""
+"```typescript,no-test\n"
+"padding: 12                                       // all four sides 12\n"
+"padding: { top: 8, right: 16, bottom: 8, left: 16 }  // per-side\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:92
+msgid "Missing sides default to 0."
+msgstr ""
+
+#: src/ui/styling.md:94
+msgid "Container styling"
+msgstr ""
+
+#: src/ui/styling.md:96
+msgid "`VStack` and `HStack` accept `style` after the children array:"
+msgstr ""
+
+#: src/ui/styling.md:98
+msgid ""
+"```typescript\n"
+"// VStack with explicit spacing AND inline style — children + style.\n"
+"const card = VStack(8, [\n"
+"    Text(\"Heading\"),\n"
+"    Text(\"Subtitle\"),\n"
+"    Button(\"Action\", () => { console.log(\"clicked\") }),\n"
+"], {\n"
+"    backgroundColor: { r: 0.96, g: 0.97, b: 0.99, a: 1.0 },\n"
+"    borderRadius: 12,\n"
+"    padding: 16,\n"
+"    shadow: {\n"
+"        color: { r: 0.0, g: 0.0, b: 0.0, a: 0.1 },\n"
+"        blur: 8,\n"
+"        offsetY: 2,\n"
+"    },\n"
+"})\n"
+"\n"
+"// HStack with no explicit spacing (children-array first form) + style.\n"
+"const toolbar = HStack([\n"
+"    Text(\"Left\"),\n"
+"    Text(\"Right\"),\n"
+"], {\n"
+"    backgroundColor: { r: 0.2, g: 0.2, b: 0.2, a: 1.0 },\n"
+"    padding: { top: 8, right: 16, bottom: 8, left: 16 },\n"
+"    borderRadius: 6,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:126
+msgid ""
+"Both shapes work — `VStack(children, style?)` and `VStack(spacing, children,"
+" style?)`."
+msgstr ""
+
+#: src/ui/styling.md:128
+msgid "Coming from CSS"
+msgstr ""
+
+#: src/ui/styling.md:130
+msgid "If you're coming from web, the conceptual mapping is:"
+msgstr ""
+
+#: src/ui/styling.md:132
+msgid "CSS"
+msgstr ""
+
+#: src/ui/styling.md:132
+msgid "Perry inline style"
+msgstr ""
+
+#: src/ui/styling.md:134
+msgid "`display: flex; flex-direction: column`"
+msgstr ""
+
+#: src/ui/styling.md:134
+msgid "`VStack(spacing, [...])`"
+msgstr ""
+
+#: src/ui/styling.md:135
+msgid "`display: flex; flex-direction: row`"
+msgstr ""
+
+#: src/ui/styling.md:135
+msgid "`HStack(spacing, [...])`"
+msgstr ""
+
+#: src/ui/styling.md:136
+msgid "`width: 100%`"
+msgstr ""
+
+#: src/ui/styling.md:136
+msgid "`widgetMatchParentWidth(widget)`"
+msgstr ""
+
+#: src/ui/styling.md:137
+msgid "`padding: 10px 20px`"
+msgstr ""
+
+#: src/ui/styling.md:137
+msgid "`padding: { top: 10, right: 20, bottom: 10, left: 20 }`"
+msgstr ""
+
+#: src/ui/styling.md:138
+msgid "`gap: 16px`"
+msgstr ""
+
+#: src/ui/styling.md:138
+msgid "`VStack(16, [...])` — first argument is the gap"
+msgstr ""
+
+#: src/ui/styling.md:139
+msgid "CSS variables / design tokens"
+msgstr ""
+
+#: src/ui/styling.md:139
+msgid "[`perry-styling`](theming.md) package"
+msgstr ""
+
+#: src/ui/styling.md:140
+msgid "`opacity: 0.5`"
+msgstr ""
+
+#: src/ui/styling.md:141
+msgid "`border-radius: 8px`"
+msgstr ""
+
+#: src/ui/styling.md:141
+msgid "`borderRadius: 8`"
+msgstr ""
+
+#: src/ui/styling.md:142
+msgid "`background: #3B82F6`"
+msgstr ""
+
+#: src/ui/styling.md:142
+msgid "`backgroundColor: \"#3B82F6\"`"
+msgstr ""
+
+#: src/ui/styling.md:143
+msgid "`box-shadow: 0 4px 12px rgba(0,0,0,0.25)`"
+msgstr ""
+
+#: src/ui/styling.md:143
+msgid "`shadow: { color: \"#0004\", blur: 12, offsetY: 4 }`"
+msgstr ""
+
+#: src/ui/styling.md:144
+msgid "`text-decoration: underline`"
+msgstr ""
+
+#: src/ui/styling.md:144
+msgid "`textDecoration: \"underline\"`"
+msgstr ""
+
+#: src/ui/styling.md:146
+msgid ""
+"See [Layout](layout.md) for full details on alignment, distribution, "
+"overlays, and split views."
+msgstr ""
+
+#: src/ui/styling.md:148
+msgid "Imperative API (underlying)"
+msgstr ""
+
+#: src/ui/styling.md:150
+msgid ""
+"The inline `style` object lowers to the same FFI calls as Perry's imperative"
+" free-function setters: `widgetSet*`, `textSet*`, `buttonSet*`. They take "
+"the widget handle as the first argument and remain available for cases where"
+" you want fine-grained control or need to mutate styles after creation. "
+"Colors here are RGBA floats in `[0.0, 1.0]` (divide each hex byte by 255 — "
+"`0xFF3B30` → `(1.0, 0.231, 0.188, 1.0)`)."
+msgstr ""
+
+#: src/ui/styling.md:158
+msgid ""
+"Every snippet below is excerpted from "
+"[`docs/examples/ui/styling/snippets.ts`](../../examples/ui/styling/snippets.ts),"
+" which CI compiles and runs on every PR — so the API drawn here is always "
+"the API the compiler accepts."
+msgstr ""
+
+#: src/ui/styling.md:163
+msgid ""
+"```typescript\n"
+"import {\n"
+"    App,\n"
+"    VStack, VStackWithInsets, HStack, Spacer,\n"
+"    Text, Button,\n"
+"    textSetColor, textSetFontSize, textSetFontFamily, textSetFontWeight,\n"
+"    setCornerRadius, setPadding,\n"
+"    widgetAddChild,\n"
+"    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
+"    widgetSetBorderColor, widgetSetBorderWidth,\n"
+"    widgetSetEdgeInsets,\n"
+"    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
+"    widgetSetOpacity,\n"
+"    widgetSetControlSize,\n"
+"    widgetSetTooltip,\n"
+"    widgetSetEnabled,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:182
+msgid "Colors"
+msgstr ""
+
+#: src/ui/styling.md:184
+msgid ""
+"```typescript\n"
+"const colored = Text(\"Colored text\")\n"
+"textSetColor(colored, 1.0, 0.0, 0.0, 1.0)              // r, g, b, a in [0,1]\n"
+"widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:190
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/styling.md:192
+msgid ""
+"```typescript\n"
+"const font = Text(\"Styled text\")\n"
+"textSetFontSize(font, 24)                  // Font size in points\n"
+"textSetFontFamily(font, \"Menlo\")           // Font family name\n"
+"textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:199
+msgid "Use `\"monospaced\"` for the system monospaced font."
+msgstr ""
+
+#: src/ui/styling.md:201
+msgid "Corner Radius"
+msgstr ""
+
+#: src/ui/styling.md:203
+msgid ""
+"```typescript\n"
+"const rounded = Button(\"Rounded\", () => {})\n"
+"setCornerRadius(rounded, 12)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:208
+msgid "Borders"
+msgstr ""
+
+#: src/ui/styling.md:216
+msgid "Padding and Insets"
+msgstr ""
+
+#: src/ui/styling.md:218
+msgid ""
+"```typescript\n"
+"const padded = VStack(8, [Text(\"Padded content\")])\n"
+"// Both names accept (widget, top, left, bottom, right):\n"
+"setPadding(padded, 16, 16, 16, 16)\n"
+"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:225
+msgid "Sizing"
+msgstr ""
+
+#: src/ui/styling.md:227
+msgid ""
+"```typescript\n"
+"const sized = VStack(0, [])\n"
+"widgetSetWidth(sized, 300)\n"
+"widgetSetHeight(sized, 200)\n"
+"widgetMatchParentWidth(sized) // expand to fill parent's width\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:234 src/ui/theming.md:144
+msgid "Opacity"
+msgstr ""
+
+#: src/ui/styling.md:236
+msgid ""
+"```typescript\n"
+"const dim = Text(\"Semi-transparent\")\n"
+"widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:241
+msgid "Background Gradient"
+msgstr ""
+
+#: src/ui/styling.md:243
+msgid ""
+"```typescript\n"
+"const grad = VStack(0, [])\n"
+"// Two RGBA stops + angle (degrees, 0 = top-to-bottom).\n"
+"widgetSetBackgroundGradient(grad,\n"
+"    1.0, 0.0, 0.0, 1.0,   // start (red)\n"
+"    0.0, 0.0, 1.0, 1.0,   // end   (blue)\n"
+"    0,                    // angle\n"
+")\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:253
+msgid "Control Size"
+msgstr ""
+
+#: src/ui/styling.md:255
+msgid ""
+"```typescript\n"
+"const small = Button(\"Small\", () => {})\n"
+"widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:260
+msgid ""
+"**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
+"differently."
+msgstr ""
+
+#: src/ui/styling.md:262
+msgid "Tooltips"
+msgstr ""
+
+#: src/ui/styling.md:264
+msgid ""
+"```typescript\n"
+"const tip = Button(\"Hover me\", () => {})\n"
+"widgetSetTooltip(tip, \"Click to perform action\")\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:269
+msgid ""
+"**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
+"support. **Web**: HTML `title` attribute."
+msgstr ""
+
+#: src/ui/styling.md:271
+msgid "Enabled/Disabled"
+msgstr ""
+
+#: src/ui/styling.md:273
+msgid ""
+"```typescript\n"
+"const submit = Button(\"Submit\", () => {})\n"
+"widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:278
+msgid "Complete Imperative Example"
+msgstr ""
+
+#: src/ui/styling.md:280
+msgid ""
+"```typescript\n"
+"// demonstrates: a styled counter card using the real free-function API\n"
+"// docs: docs/src/ui/styling.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    VStack,\n"
+"    HStack,\n"
+"    State,\n"
+"    Spacer,\n"
+"    textSetFontSize,\n"
+"    textSetFontFamily,\n"
+"    textSetColor,\n"
+"    widgetSetBackgroundColor,\n"
+"    widgetSetEdgeInsets,\n"
+"    setCornerRadius,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// Note: widgetSetBorderColor / widgetSetBorderWidth are macOS/iOS/Windows\n"
+"// only — perry-ui-gtk4 doesn't export them (GTK4 borders are CSS-driven).\n"
+"// Omitted from this demo so it compiles everywhere.\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"const title = Text(\"Counter\")\n"
+"textSetFontSize(title, 28)\n"
+"textSetColor(title, 0.1, 0.1, 0.1, 1.0)\n"
+"\n"
+"const display = Text(`${count.value}`)\n"
+"textSetFontSize(display, 48)\n"
+"textSetFontFamily(display, \"monospaced\")\n"
+"textSetColor(display, 0.0, 0.478, 1.0, 1.0)\n"
+"\n"
+"const decBtn = Button(\"-\", () => count.set(count.value - 1))\n"
+"setCornerRadius(decBtn, 20)\n"
+"widgetSetBackgroundColor(decBtn, 1.0, 0.231, 0.188, 1.0)\n"
+"\n"
+"const incBtn = Button(\"+\", () => count.set(count.value + 1))\n"
+"setCornerRadius(incBtn, 20)\n"
+"widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
+"\n"
+"const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
+"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"\n"
+"const container = VStack(16, [title, display, controls])\n"
+"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setCornerRadius(container, 16)\n"
+"widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
+"\n"
+"App({\n"
+"    title: \"Styled App\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: container,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:341
+msgid "Composing Styles (imperative helper functions)"
+msgstr ""
+
+#: src/ui/styling.md:343
+msgid "Reduce repetition by creating helper functions:"
+msgstr ""
+
+#: src/ui/styling.md:357
+msgid ""
+"For larger apps, use the `perry-styling` package to define design tokens in "
+"JSON and generate a typed theme file. See [Theming](theming.md) for the full"
+" workflow."
+msgstr ""
+
+#: src/ui/styling.md:359
+msgid "Platform support"
+msgstr ""
+
+#: src/ui/styling.md:361
+msgid ""
+"Per-prop, per-platform support is tracked in the [styling matrix](styling-"
+"matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and"
+" CI-checked against each backend's `lib.rs` exports on every PR."
+msgstr ""
+
+#: src/ui/styling.md:366
+msgid ""
+"Current state (issue [\\#185](https://github.com/PerryTS/perry/issues/185)):"
+msgstr ""
+
+#: src/ui/styling.md:368 src/ui/canvas.md:72 src/ui/canvas.md:73
+#: src/ui/canvas.md:74 src/ui/canvas.md:75 src/ui/canvas.md:76
+#: src/ui/canvas.md:78
+msgid "Wired"
+msgstr ""
+
+#: src/ui/styling.md:368
+msgid "Stub"
+msgstr ""
+
+#: src/ui/styling.md:368
+msgid "Missing"
+msgstr ""
+
+#: src/ui/styling.md:370
+msgid "macOS / iOS / tvOS / visionOS / watchOS / Android / Web"
+msgstr ""
+
+#: src/ui/styling.md:370
+msgid "**43/43**"
+msgstr ""
+
+#: src/ui/styling.md:371
+msgid "GTK4 (Linux)"
+msgstr ""
+
+#: src/ui/styling.md:371
+msgid "39/43"
+msgstr ""
+
+#: src/ui/styling.md:372
+msgid "38/43"
+msgstr ""
+
+#: src/ui/styling.md:374
+msgid ""
+"**GTK4** has 4 styling props (`widget.on_click`, "
+"`button.content_tint_color`, `button.image_position`, "
+"`stack.detaches_hidden`) that need a Linux contributor — tracked in issue "
+"[\\#202](https://github.com/PerryTS/perry/issues/202). Inline `style: {...}`"
+" calls referencing only the wired props compile and run cleanly today; the "
+"missing props silently no-op until that issue lands."
+msgstr ""
+
+#: src/ui/styling.md:375
+msgid ""
+"**Windows** has 5 props in a \"deferred-paint family\" (`shadow`, `opacity`,"
+" `border_color`, `border_width`, `text.decoration`) where the FFI symbol "
+"exists and stores the requested params, but a custom `WM_PAINT` rendering "
+"pass is needed to make them visible — tracked in issue "
+"[\\#210](https://github.com/PerryTS/perry/issues/210). User code authoring "
+"inline styles compiles and links cleanly on Windows; the visual rendering "
+"catches up when that issue lands."
+msgstr ""
+
+#: src/ui/styling.md:380 src/ui/state.md:229 src/ui/table.md:110
+msgid "[Layout](layout.md) — Layout containers"
+msgstr ""
+
+#: src/ui/styling.md:381
+msgid "[Animation](animation.md) — Animate style changes"
+msgstr ""
+
+#: src/ui/styling.md:382
+msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
+msgstr ""
+
+#: src/ui/state.md:3
+msgid ""
+"Perry uses reactive state to automatically update the UI when data changes. "
+"Every snippet below is excerpted from "
+"[`docs/examples/ui/state/snippets.ts`](../../examples/ui/state/snippets.ts) "
+"— CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/state.md:8
+msgid "Creating State"
+msgstr ""
+
+#: src/ui/state.md:10
+msgid ""
+"```typescript\n"
+"const counter = State(0)               // number state\n"
+"const username = State(\"Perry\")        // string state\n"
+"const items = State<string[]>([])      // array state\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:16
+msgid "`State(initialValue)` creates a reactive state container."
+msgstr ""
+
+#: src/ui/state.md:18
+msgid "Reading and Writing"
+msgstr ""
+
+#: src/ui/state.md:20
+msgid ""
+"```typescript\n"
+"const value = counter.value     // Read current value\n"
+"counter.set(42)                  // Set new value → triggers UI update\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:25
+msgid "Every `.set()` call re-renders the widget tree with the new value."
+msgstr ""
+
+#: src/ui/state.md:27
+msgid "Reactive Text"
+msgstr ""
+
+#: src/ui/state.md:29
+msgid "Template literals with `state.value` update automatically:"
+msgstr ""
+
+#: src/ui/state.md:31
+msgid ""
+"```typescript\n"
+"const showCount = State(0)\n"
+"const countLabel = Text(`Count: ${showCount.value}`)\n"
+"// The text updates whenever showCount changes.\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:37
+msgid ""
+"This works because Perry detects `state.value` reads inside template "
+"literals and creates reactive bindings."
+msgstr ""
+
+#: src/ui/state.md:40
+msgid "Binding Inputs to State"
+msgstr ""
+
+#: src/ui/state.md:42
+msgid ""
+"Input widgets expose an `onChange` callback. Forward that into a state's "
+"`.set(...)` to keep the state in sync as the user types/toggles/drags:"
+msgstr ""
+
+#: src/ui/state.md:45
+msgid ""
+"```typescript\n"
+"const input = State(\"\")\n"
+"const field = TextField(\"Type here...\", (v: string) => input.set(v))\n"
+"\n"
+"// Optional: also let input.set(\"hello\") update the field on screen.\n"
+"stateBindTextfield(input, field)\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:53
+msgid "Input control signatures:"
+msgstr ""
+
+#: src/ui/state.md:54
+msgid ""
+"`TextField(placeholder, onChange)` — text input, `onChange: (value: string) "
+"=> void`"
+msgstr ""
+
+#: src/ui/state.md:55
+msgid ""
+"`SecureField(placeholder, onChange)` — password input, `onChange: (value: "
+"string) => void`"
+msgstr ""
+
+#: src/ui/state.md:56
+msgid ""
+"`Toggle(label, onChange)` — boolean toggle, `onChange: (value: boolean) => "
+"void`"
+msgstr ""
+
+#: src/ui/state.md:57
+msgid ""
+"`Slider(min, max, onChange)` — numeric slider, `onChange: (value: number) =>"
+" void`"
+msgstr ""
+
+#: src/ui/state.md:58
+msgid ""
+"`Picker(onChange)` — dropdown, `onChange: (index: number) => void`; items "
+"via `pickerAddItem`"
+msgstr ""
+
+#: src/ui/state.md:60
+msgid ""
+"For programmatic-to-UI sync (state-drives-widget) use the dedicated binders:"
+" `stateBindTextfield`, `stateBindSlider`, `stateBindToggle`, "
+"`stateBindTextNumeric`, `stateBindVisibility`."
+msgstr ""
+
+#: src/ui/state.md:64
+msgid "onChange Callbacks"
+msgstr ""
+
+#: src/ui/state.md:66
+msgid "Listen for state changes with the free-function `stateOnChange`:"
+msgstr ""
+
+#: src/ui/state.md:75 src/widgets/components.md:92 src/widgets/platforms.md:27
+msgid "ForEach"
+msgstr ""
+
+#: src/ui/state.md:77
+msgid "Render a list from numeric state (the index count):"
+msgstr ""
+
+#: src/ui/state.md:79
+msgid ""
+"```typescript\n"
+"const fruits = State([\"Apple\", \"Banana\", \"Cherry\"])\n"
+"const fruitCount = State(3)\n"
+"\n"
+"const fruitList = VStack(16, [\n"
+"    ForEach(fruitCount, (i: number) =>\n"
+"        Text(`${i + 1}. ${fruits.value[i]}`),\n"
+"    ),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:90
+msgid ""
+"**Note:** `ForEach` iterates by index over a numeric state. Keep a count "
+"state in sync with your array, then read the items via `array.value[i]` "
+"inside the closure."
+msgstr ""
+
+#: src/ui/state.md:94
+msgid "`ForEach` re-renders the list when the count state changes:"
+msgstr ""
+
+#: src/ui/state.md:96
+msgid ""
+"```typescript\n"
+"// Add an item:\n"
+"fruits.set([...fruits.value, \"Date\"])\n"
+"fruitCount.set(fruitCount.value + 1)\n"
+"\n"
+"// Remove an item:\n"
+"fruits.set(fruits.value.filter((_, i) => i !== 1))\n"
+"fruitCount.set(fruitCount.value - 1)\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:106
+msgid "Conditional Rendering"
+msgstr ""
+
+#: src/ui/state.md:108
+msgid "Use state to conditionally show widgets:"
+msgstr ""
+
+#: src/ui/state.md:110
+msgid ""
+"```typescript\n"
+"const showDetails = State(false)\n"
+"const detailsLabel: number = showDetails.value\n"
+"    ? Text(\"Details are visible!\")\n"
+"    : Spacer()\n"
+"const detailsPanel = VStack(16, [\n"
+"    Button(\"Toggle\", () => showDetails.set(!showDetails.value)),\n"
+"    detailsLabel,\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:121
+msgid "Multi-State Text"
+msgstr ""
+
+#: src/ui/state.md:123
+msgid "Text can depend on multiple state values:"
+msgstr ""
+
+#: src/ui/state.md:125
+msgid ""
+"```typescript\n"
+"const firstName = State(\"John\")\n"
+"const lastName = State(\"Doe\")\n"
+"\n"
+"const greeting = Text(`Hello, ${firstName.value} ${lastName.value}!`)\n"
+"// Updates when either firstName or lastName changes.\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:133
+msgid "State with Objects and Arrays"
+msgstr ""
+
+#: src/ui/state.md:135
+msgid ""
+"```typescript\n"
+"const user = State({ name: \"Perry\", age: 0 })\n"
+"\n"
+"// Update by replacing the whole object:\n"
+"user.set({ ...user.value, age: 1 })\n"
+"\n"
+"const todos = State<{ text: string; done: boolean }[]>([])\n"
+"\n"
+"// Add a todo:\n"
+"todos.set([...todos.value, { text: \"New task\", done: false }])\n"
+"\n"
+"// Toggle a todo (must produce a new array reference):\n"
+"const next = todos.value.slice()\n"
+"if (next.length > 0) {\n"
+"    next[0] = { ...next[0], done: !next[0].done }\n"
+"    todos.set(next)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:154
+msgid ""
+"**Note**: State uses identity comparison. You must create a new array/object"
+" reference for changes to be detected. Mutating in-place without calling "
+"`.set()` with a new reference won't trigger updates."
+msgstr ""
+
+#: src/ui/state.md:158 src/ui/events.md:113 src/ui/table.md:73
+#: src/widgets/components.md:225
+msgid "Complete Example"
+msgstr ""
+
+#: src/ui/state.md:221
+msgid ""
+"This program is built and run by CI (`scripts/run_doc_tests.sh`), so the "
+"snippet above always matches the compiled artifact under "
+"[`docs/examples/ui/state/todo_app.ts`](../../examples/ui/state/todo_app.ts)."
+msgstr ""
+
+#: src/ui/state.md:227
+msgid "[Events](events.md) — Click, hover, keyboard events"
+msgstr ""
+
+#: src/ui/events.md:3
+msgid ""
+"Perry widgets support native event handlers for user interaction. Every "
+"snippet below is excerpted from "
+"[`docs/examples/ui/events/snippets.ts`](../../examples/ui/events/snippets.ts)"
+" — CI compiles and runs it on every PR, so the API drawn here is the API the"
+" runtime exposes."
+msgstr ""
+
+#: src/ui/events.md:9
+msgid ""
+"Event handlers are registered as **free functions** that take the widget "
+"handle as the first argument. The widget handle itself is opaque (`number` "
+"at the type level); perry's API is function-first throughout."
+msgstr ""
+
+#: src/ui/events.md:13 src/testing/geisterhand.md:100
+msgid "onClick"
+msgstr ""
+
+#: src/ui/events.md:15
+msgid ""
+"```typescript\n"
+"const greet = Button(\"Click me\", () => {\n"
+"    log.set(\"Button clicked\")\n"
+"})\n"
+"\n"
+"// Or attach a click handler to a non-button widget after creation:\n"
+"const label = Text(\"Clickable text\")\n"
+"widgetSetOnClick(label, () => {\n"
+"    log.set(\"Text clicked\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:27 src/testing/geisterhand.md:103
+msgid "onHover"
+msgstr ""
+
+#: src/ui/events.md:29
+msgid "Triggered when the cursor enters the widget."
+msgstr ""
+
+#: src/ui/events.md:31
+msgid ""
+"```typescript\n"
+"const hoverBtn = Button(\"Hover me\", () => {})\n"
+"widgetSetOnHover(hoverBtn, () => {\n"
+"    log.set(\"hovered\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:38
+msgid ""
+"**Note**: Hover events are available on macOS, Windows, Linux, and Web. iOS "
+"and Android use touch interactions instead. The callback fires once on "
+"enter; if you need a \"left\" event you'll have to track it yourself."
+msgstr ""
+
+#: src/ui/events.md:42 src/testing/geisterhand.md:104
+msgid "onDoubleClick"
+msgstr ""
+
+#: src/ui/events.md:44
+msgid ""
+"```typescript\n"
+"const dbl = Text(\"Double-click me\")\n"
+"widgetSetOnDoubleClick(dbl, () => {\n"
+"    log.set(\"double-clicked!\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:51 src/ui/menus.md:64
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: src/ui/events.md:53
+msgid "Register in-app keyboard shortcuts (active when the app is focused):"
+msgstr ""
+
+#: src/ui/events.md:55
+msgid ""
+"```typescript\n"
+"// Cmd+N on macOS, Ctrl+N on other platforms (modifier 1 = Cmd/Ctrl).\n"
+"addKeyboardShortcut(\"n\", 1, () => {\n"
+"    log.set(\"New document\")\n"
+"})\n"
+"\n"
+"// Cmd+Shift+S — modifiers add: 1 (Cmd/Ctrl) + 2 (Shift) = 3.\n"
+"addKeyboardShortcut(\"s\", 3, () => {\n"
+"    log.set(\"Save as...\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:67
+msgid ""
+"**Modifier bits:** `1` = Cmd (macOS) / Ctrl (Windows/Linux), `2` = Shift, "
+"`4` = Option (macOS) / Alt (others), `8` = Control (macOS only). Combine by "
+"adding — `3` = Cmd+Shift, `5` = Cmd+Option, etc."
+msgstr ""
+
+#: src/ui/events.md:71
+msgid "Keyboard shortcuts are also available on [menu items](menus.md):"
+msgstr ""
+
+#: src/ui/events.md:73
+msgid ""
+"```typescript\n"
+"const fileMenu = menuCreate()\n"
+"menuAddItem(fileMenu, \"New\", () => log.set(\"file/new\"))\n"
+"menuAddItem(fileMenu, \"Save As\", () => log.set(\"file/saveAs\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:79
+msgid "Global Hotkeys"
+msgstr ""
+
+#: src/ui/events.md:81
+msgid ""
+"Register a hotkey that fires system-wide, even when the app is in the "
+"background:"
+msgstr ""
+
+#: src/ui/events.md:84
+msgid ""
+"```typescript\n"
+"// System-wide: fires even when the app is in the background.\n"
+"// macOS: real Carbon RegisterEventHotKey. Other platforms: no-op.\n"
+"registerGlobalHotkey(\"F5\", 0, () => {\n"
+"    log.set(\"Global F5 hotkey fired\")\n"
+"})\n"
+"\n"
+"// Cmd+Shift+G (modifiers: 1=Cmd + 2=Shift = 3)\n"
+"registerGlobalHotkey(\"g\", 3, () => {\n"
+"    log.set(\"Global Cmd+Shift+G fired\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:97
+msgid ""
+"**Platform support:** macOS uses Carbon `RegisterEventHotKey` (real "
+"implementation). Linux, Windows, iOS, tvOS, visionOS, watchOS, and Android "
+"log the registration and no-op — global hotkeys on those platforms require "
+"OS-level portal / hook APIs that vary per OS."
+msgstr ""
+
+#: src/ui/events.md:102 src/system/other.md:44
+msgid "Clipboard"
+msgstr ""
+
+#: src/ui/events.md:104 src/system/other.md:48
+msgid ""
+"```typescript\n"
+"// Copy to clipboard\n"
+"clipboardWrite(\"Hello, clipboard!\")\n"
+"\n"
+"// Read from clipboard\n"
+"const text = clipboardRead()\n"
+"log.set(`clipboard length: ${text.length}`)\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:115
+msgid ""
+"```typescript\n"
+"// demonstrates: click + hover + double-click + keyboard shortcut all wired to\n"
+"// a single State-backed status label\n"
+"// docs: docs/src/ui/events.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    VStack,\n"
+"    State,\n"
+"    Spacer,\n"
+"    addKeyboardShortcut,\n"
+"    widgetSetOnHover,\n"
+"    widgetSetOnDoubleClick,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const lastEvent = State(\"No events yet\")\n"
+"\n"
+"// Cmd+R (modifiers: 1 = Cmd/Ctrl).\n"
+"addKeyboardShortcut(\"r\", 1, () => {\n"
+"    lastEvent.set(\"Keyboard: Cmd+R\")\n"
+"})\n"
+"\n"
+"const hoverBtn = Button(\"Hover me\", () => {})\n"
+"widgetSetOnHover(hoverBtn, () => {\n"
+"    lastEvent.set(\"Hover fired\")\n"
+"})\n"
+"\n"
+"const dblLabel = Text(\"Double-click me\")\n"
+"widgetSetOnDoubleClick(dblLabel, () => {\n"
+"    lastEvent.set(\"Double-clicked!\")\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Events Demo\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Last event: ${lastEvent.value}`),\n"
+"        Spacer(),\n"
+"        Button(\"Click me\", () => {\n"
+"            lastEvent.set(\"Button clicked\")\n"
+"        }),\n"
+"        hoverBtn,\n"
+"        dblLabel,\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:169
+msgid "[Menus](menus.md) — Menu bar and context menus with keyboard shortcuts"
+msgstr ""
+
+#: src/ui/events.md:171
+msgid "[State Management](state.md) — Reactive state"
+msgstr ""
+
+#: src/ui/canvas.md:3
+msgid "The `Canvas` widget provides a 2D drawing surface for custom graphics."
+msgstr ""
+
+#: src/ui/canvas.md:5
+msgid ""
+"**Availability**: `Canvas` is wired in the **LLVM** codegen path (macOS, "
+"iOS, Linux, Android) and the **JS / web / wasm** codegen path. Closed via "
+"[\\#190](https://github.com/PerryTS/perry/issues/190). The snippets below "
+"are compile-link verified by the doc-tests harness against "
+"[`docs/examples/ui/canvas/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/ui/canvas/snippets.ts);"
+" see that file for the full standalone program."
+msgstr ""
+
+#: src/ui/canvas.md:12
+msgid ""
+"The drawing API is **method-based** on the canvas handle (matching the FFI "
+"shape — `perry_ui_canvas_set_fill_color(handle, r, g, b, a)` etc.). Colors "
+"are RGBA floats in `[0.0, 1.0]`."
+msgstr ""
+
+#: src/ui/canvas.md:16
+msgid "Creating a Canvas"
+msgstr ""
+
+#: src/ui/canvas.md:24
+msgid ""
+"`Canvas(width, height)` creates a canvas widget; subsequent draw operations "
+"are method calls on the returned handle."
+msgstr ""
+
+#: src/ui/canvas.md:27
+msgid "Drawing Shapes"
+msgstr ""
+
+#: src/ui/canvas.md:29
+msgid "Rectangles"
+msgstr ""
+
+#: src/ui/canvas.md:31
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(1.0, 0.0, 0.0, 1.0)    // red\n"
+"canvas.fillRect(10, 10, 100, 80)\n"
+"\n"
+"canvas.setStrokeColor(0.0, 0.0, 1.0, 1.0)  // blue\n"
+"canvas.setLineWidth(2)\n"
+"canvas.strokeRect(150, 10, 100, 80)\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:40
+msgid "Lines"
+msgstr ""
+
+#: src/ui/canvas.md:51
+msgid "Circles and Arcs"
+msgstr ""
+
+#: src/ui/canvas.md:53
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(0.0, 1.0, 0.0, 1.0)\n"
+"canvas.beginPath()\n"
+"canvas.arc(200, 150, 50, 0, Math.PI * 2)  // x, y, radius, startAngle, endAngle\n"
+"canvas.fill()\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:62
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(0.0, 0.0, 0.0, 1.0)\n"
+"canvas.setFont(\"16px sans-serif\")\n"
+"canvas.fillText(\"Hello Canvas!\", 50, 50)\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:68 src/ui/menus.md:107 src/ui/dialogs.md:106
+#: src/ui/animation.md:60 src/ui/multi-window.md:136
+msgid "Platform Notes"
+msgstr ""
+
+#: src/ui/canvas.md:70 src/ui/animation.md:62 src/ui/multi-window.md:70
+#: src/ui/multi-window.md:87 src/ui/multi-window.md:98
+#: src/ui/multi-window.md:114 src/ui/multi-window.md:130
+#: src/ui/multi-window.md:138 src/ui/camera.md:137 src/system/other.md:18
+msgid "Implementation"
+msgstr ""
+
+#: src/ui/canvas.md:70 src/platforms/overview.md:7 src/system/media.md:84
+#: src/testing/geisterhand.md:298
+msgid "Status"
+msgstr ""
+
+#: src/ui/canvas.md:72
+msgid "HTML5 Canvas"
+msgstr ""
+
+#: src/ui/canvas.md:73
+msgid "WASM"
+msgstr ""
+
+#: src/ui/canvas.md:73
+msgid "HTML5 Canvas via JS bridge"
+msgstr ""
+
+#: src/ui/canvas.md:74 src/ui/canvas.md:75
+msgid "Core Graphics (CGContext)"
+msgstr ""
+
+#: src/ui/canvas.md:76
+msgid "Cairo"
+msgstr ""
+
+#: src/ui/canvas.md:77 src/platforms/windows.md:52
+msgid "GDI"
+msgstr ""
+
+#: src/ui/canvas.md:77
+msgid "Planned"
+msgstr ""
+
+#: src/ui/canvas.md:78
+msgid "Canvas/Bitmap"
+msgstr ""
+
+#: src/ui/canvas.md:83
+msgid "[Animation](animation.md) — Animating widget properties"
+msgstr ""
+
+#: src/ui/canvas.md:84
+msgid "[Styling](styling.md) — Widget styling"
+msgstr ""
+
+#: src/ui/menus.md:3
+msgid ""
+"Perry supports native menu bars, context menus, and toolbars across all "
+"platforms. Every snippet below is excerpted from "
+"[`docs/examples/ui/menus/snippets.ts`](../../examples/ui/menus/snippets.ts) "
+"— CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/menus.md:8
+msgid ""
+"The menu API is **handle-based** and free-function: build menus with "
+"`menuCreate()`, fill them with `menuAddItem` / `menuAddItemWithShortcut`, "
+"and attach them with `menuBarAddMenu(bar, title, menu)`. Submenus go through"
+" `menuAddSubmenu(parent, title, submenu)`."
+msgstr ""
+
+#: src/ui/menus.md:13 src/ui/menus.md:109
+msgid "Menu Bar"
+msgstr ""
+
+#: src/ui/menus.md:15
+msgid ""
+"```typescript\n"
+"// Menus are created independently, then attached. Build child menus first,\n"
+"// then hand them to `menuBarAddMenu(bar, title, menu)`.\n"
+"const menuBar = menuBarCreate()\n"
+"\n"
+"// File menu\n"
+"const fileMenu = menuCreate()\n"
+"menuAddItemWithShortcut(fileMenu, \"New\",         \"n\", () => status.set(\"file/new\"))\n"
+"menuAddItemWithShortcut(fileMenu, \"Open…\",       \"o\", () => status.set(\"file/open\"))\n"
+"menuAddSeparator(fileMenu)\n"
+"menuAddItemWithShortcut(fileMenu, \"Save\",        \"s\", () => status.set(\"file/save\"))\n"
+"menuAddItemWithShortcut(fileMenu, \"Save As…\",    \"S\", () => status.set(\"file/saveAs\"))\n"
+"menuBarAddMenu(menuBar, \"File\", fileMenu)\n"
+"\n"
+"// Edit menu\n"
+"const editMenu = menuCreate()\n"
+"menuAddItemWithShortcut(editMenu, \"Undo\", \"z\", () => status.set(\"edit/undo\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Redo\", \"Z\", () => status.set(\"edit/redo\"))\n"
+"menuAddSeparator(editMenu)\n"
+"menuAddItemWithShortcut(editMenu, \"Cut\",   \"x\", () => status.set(\"edit/cut\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Copy\",  \"c\", () => status.set(\"edit/copy\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Paste\", \"v\", () => status.set(\"edit/paste\"))\n"
+"menuBarAddMenu(menuBar, \"Edit\", editMenu)\n"
+"\n"
+"// Submenu: View → Zoom\n"
+"const viewMenu = menuCreate()\n"
+"const zoomSubmenu = menuCreate()\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Zoom In\",     \"+\", () => status.set(\"zoom/in\"))\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Zoom Out\",    \"-\", () => status.set(\"zoom/out\"))\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Actual Size\", \"0\", () => status.set(\"zoom/reset\"))\n"
+"menuAddSubmenu(viewMenu, \"Zoom\", zoomSubmenu)\n"
+"menuBarAddMenu(menuBar, \"View\", viewMenu)\n"
+"\n"
+"menuBarAttach(menuBar)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:51
+msgid "Menu Bar Functions"
+msgstr ""
+
+#: src/ui/menus.md:55
+msgid "`menuBarCreate()`"
+msgstr ""
+
+#: src/ui/menus.md:55
+msgid "Create a new (empty) menu bar"
+msgstr ""
+
+#: src/ui/menus.md:56
+msgid "`menuCreate()`"
+msgstr ""
+
+#: src/ui/menus.md:56
+msgid "Create a new menu — used as a child of the bar or as a submenu"
+msgstr ""
+
+#: src/ui/menus.md:57
+msgid "`menuBarAddMenu(bar, title, menu)`"
+msgstr ""
+
+#: src/ui/menus.md:57
+msgid "Attach a top-level menu under `title`"
+msgstr ""
+
+#: src/ui/menus.md:58
+msgid "`menuAddItem(menu, label, callback)`"
+msgstr ""
+
+#: src/ui/menus.md:58
+msgid "Append an item without a shortcut"
+msgstr ""
+
+#: src/ui/menus.md:59
+msgid "`menuAddItemWithShortcut(menu, label, shortcut, callback)`"
+msgstr ""
+
+#: src/ui/menus.md:59
+msgid "Append an item with a keyboard shortcut"
+msgstr ""
+
+#: src/ui/menus.md:60
+msgid "`menuAddSeparator(menu)`"
+msgstr ""
+
+#: src/ui/menus.md:60
+msgid "Append a horizontal separator line"
+msgstr ""
+
+#: src/ui/menus.md:61
+msgid "`menuAddSubmenu(parent, title, submenu)`"
+msgstr ""
+
+#: src/ui/menus.md:61
+msgid "Nest a previously-created menu under a label"
+msgstr ""
+
+#: src/ui/menus.md:62
+msgid "`menuBarAttach(bar)`"
+msgstr ""
+
+#: src/ui/menus.md:62
+msgid "Install the bar as the application's main menu"
+msgstr ""
+
+#: src/ui/menus.md:66
+msgid "The third argument to `menuAddItemWithShortcut` is the shortcut key:"
+msgstr ""
+
+#: src/ui/menus.md:68 src/testing/geisterhand.md:92
+#: src/testing/geisterhand.md:295
+msgid "Shortcut"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "`\"n\"`"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "Cmd+N"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "Ctrl+N"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "`\"S\"`"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "Cmd+Shift+S"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "Ctrl+Shift+S"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "`\"+\"`"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "Cmd++"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "Ctrl++"
+msgstr ""
+
+#: src/ui/menus.md:74
+msgid "Uppercase letters imply Shift."
+msgstr ""
+
+#: src/ui/menus.md:76
+msgid "Context Menus"
+msgstr ""
+
+#: src/ui/menus.md:78
+msgid ""
+"Right-click menus are attached to widgets via `widgetSetContextMenu(widget, "
+"menu)`. Build the menu the same way as a menu-bar entry, then bind it:"
+msgstr ""
+
+#: src/ui/menus.md:81
+msgid ""
+"```typescript\n"
+"const label = Text(\"Right-click me\")\n"
+"const ctx = menuCreate()\n"
+"menuAddItem(ctx, \"Copy\",   () => status.set(\"ctx/copy\"))\n"
+"menuAddItem(ctx, \"Paste\",  () => status.set(\"ctx/paste\"))\n"
+"menuAddSeparator(ctx)\n"
+"menuAddItem(ctx, \"Delete\", () => status.set(\"ctx/delete\"))\n"
+"widgetSetContextMenu(label, ctx)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:91 src/ui/menus.md:109
+msgid "Toolbar"
+msgstr ""
+
+#: src/ui/menus.md:93
+msgid ""
+"Add a toolbar to a window. `toolbarAddItem` takes an _identifier_ (used by "
+"AppKit to deduplicate items) and a _label_:"
+msgstr ""
+
+#: src/ui/menus.md:96
+msgid ""
+"```typescript\n"
+"const toolbar = toolbarCreate()\n"
+"toolbarAddItem(toolbar, \"new\",  \"New\",  () => status.set(\"tb/new\"))\n"
+"toolbarAddItem(toolbar, \"save\", \"Save\", () => status.set(\"tb/save\"))\n"
+"toolbarAddItem(toolbar, \"run\",  \"Run\",  () => status.set(\"tb/run\"))\n"
+"\n"
+"// `toolbarAttach(toolbar, window)` mounts onto a specific window.\n"
+"const win = Window(\"Toolbar Demo\", 800, 600)\n"
+"toolbarAttach(toolbar, win as unknown as number)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:109
+msgid "Context Menu"
+msgstr ""
+
+#: src/ui/menus.md:111
+msgid "NSToolbar"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "— (no menu bar)"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "UIMenu"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "UIToolbar"
+msgstr ""
+
+#: src/ui/menus.md:113
+msgid "HMENU/SetMenu"
+msgstr ""
+
+#: src/ui/menus.md:113
+msgid "Horizontal layout"
+msgstr ""
+
+#: src/ui/menus.md:114
+msgid "GMenu/set_menubar"
+msgstr ""
+
+#: src/ui/menus.md:114
+msgid "HeaderBar"
+msgstr ""
+
+#: src/ui/menus.md:117
+msgid ""
+"**iOS**: Menu bars are not applicable. Use toolbar and navigation patterns "
+"instead."
+msgstr ""
+
+#: src/ui/menus.md:121
+msgid "[Events](events.md) — Keyboard shortcuts and interactions"
+msgstr ""
+
+#: src/ui/menus.md:122
+msgid "[Dialogs](dialogs.md) — File dialogs and alerts"
+msgstr ""
+
+#: src/ui/menus.md:123
+msgid "[Layout](layout.md) — Toolbar and navigation patterns"
+msgstr ""
+
+#: src/ui/dialogs.md:3
+msgid ""
+"Perry provides native dialog functions for file selection, alerts, and "
+"sheets. Every snippet below is excerpted from "
+"[`docs/examples/ui/dialogs/snippets.ts`](../../examples/ui/dialogs/snippets.ts)"
+" — CI compiles and links the file on every PR, so the API drawn here is the "
+"API the runtime exposes."
+msgstr ""
+
+#: src/ui/dialogs.md:9
+msgid ""
+"All file dialogs are **callback-based** (the OS-modal panel is non-blocking "
+"on Apple platforms, so a synchronous return wouldn't be possible without "
+"freezing the app's run loop). The callback receives an empty string when the"
+" user cancels."
+msgstr ""
+
+#: src/ui/dialogs.md:14
+msgid "File Open Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:16
+msgid ""
+"```typescript\n"
+"function pickFile(): void {\n"
+"    openFileDialog((path: string) => {\n"
+"        if (path.length > 0) {\n"
+"            console.log(`Selected: ${path}`)\n"
+"        } else {\n"
+"            console.log(\"Open dialog cancelled\")\n"
+"        }\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:28
+msgid "Folder Selection Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:40
+msgid "Save File Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:42
+msgid ""
+"```typescript\n"
+"function pickSaveTarget(): void {\n"
+"    saveFileDialog((path: string) => {\n"
+"        if (path.length > 0) {\n"
+"            console.log(`Will save to: ${path}`)\n"
+"        }\n"
+"    }, \"untitled\", \"txt\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:52
+msgid ""
+"`saveFileDialog(callback, defaultName, extension)` pre-fills the name field "
+"with `defaultName.<extension>`."
+msgstr ""
+
+#: src/ui/dialogs.md:55 src/ui/dialogs.md:113
+msgid "Alert"
+msgstr ""
+
+#: src/ui/dialogs.md:57
+msgid "Display a native alert dialog:"
+msgstr ""
+
+#: src/ui/dialogs.md:59
+msgid ""
+"```typescript\n"
+"function showSimpleAlert(): void {\n"
+"    alert(\"Operation Complete\", \"Your file has been saved successfully.\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:65
+msgid "`alert(title, message)` shows a modal alert with an OK button."
+msgstr ""
+
+#: src/ui/dialogs.md:67
+msgid "Alert with Buttons"
+msgstr ""
+
+#: src/ui/dialogs.md:69
+msgid ""
+"```typescript\n"
+"function confirmDelete(): void {\n"
+"    alertWithButtons(\n"
+"        \"Delete Item?\",\n"
+"        \"This action cannot be undone.\",\n"
+"        [\"Cancel\", \"Delete\"],\n"
+"        (index: number) => {\n"
+"            if (index === 1) {\n"
+"                console.log(\"user confirmed delete\")\n"
+"            }\n"
+"        },\n"
+"    )\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:84
+msgid ""
+"`alertWithButtons(title, message, buttons, callback)` invokes the callback "
+"with the 0-based index of the button the user clicked. By convention put a "
+"destructive label last and check the index in the callback."
+msgstr ""
+
+#: src/ui/dialogs.md:88
+msgid "Sheets"
+msgstr ""
+
+#: src/ui/dialogs.md:90
+msgid ""
+"Sheets are modal panels attached to a window. Build the body, hand it (with "
+"a size) to `sheetCreate`, then `sheetPresent` it. To dismiss "
+"programmatically, keep the handle around and call `sheetDismiss(handle)`:"
+msgstr ""
+
+#: src/ui/dialogs.md:94
+msgid ""
+"```typescript\n"
+"function showSheet(): void {\n"
+"    let sheet = 0\n"
+"    const body = VStack(16, [\n"
+"        Text(\"Sheet Content\"),\n"
+"        Button(\"Close\", () => sheetDismiss(sheet)),\n"
+"    ])\n"
+"    sheet = sheetCreate(body, 320, 200)\n"
+"    sheetPresent(sheet)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:108
+msgid "Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "File Open"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:112
+msgid "NSOpenPanel"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "UIDocumentPicker"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:112
+msgid "IFileOpenDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:111 src/ui/dialogs.md:112
+msgid "GtkFileChooserDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "`<input type=\"file\">`"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "File Save"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "NSSavePanel"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "IFileSaveDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "Download link"
+msgstr ""
+
+#: src/ui/dialogs.md:112
+msgid "Folder"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "NSAlert"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "UIAlertController"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "MessageBoxW"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "MessageDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "`alert()`"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Sheet"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "NSSheet"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal VC"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal Window"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal div"
+msgstr ""
+
+#: src/ui/dialogs.md:116
+msgid "Complete Example: minimal text editor"
+msgstr ""
+
+#: src/ui/dialogs.md:118
+msgid ""
+"A real program that wires `openFileDialog` and `saveFileDialog` into a "
+"state-bound `TextField`:"
+msgstr ""
+
+#: src/ui/dialogs.md:121
+msgid ""
+"```typescript\n"
+"// demonstrates: file-open / save dialogs wired to a tiny text editor\n"
+"// docs: docs/src/ui/dialogs.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack, HStack,\n"
+"    Text, Button, TextField,\n"
+"    State,\n"
+"    openFileDialog, saveFileDialog, alert,\n"
+"} from \"perry/ui\"\n"
+"import { readFileSync, writeFileSync } from \"fs\"\n"
+"\n"
+"const content = State(\"\")\n"
+"const filePath = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"Text Editor\",\n"
+"    width: 800,\n"
+"    height: 600,\n"
+"    body: VStack(12, [\n"
+"        HStack(8, [\n"
+"            Button(\"Open\", () => {\n"
+"                openFileDialog((path: string) => {\n"
+"                    if (path.length === 0) return\n"
+"                    filePath.set(path)\n"
+"                    content.set(readFileSync(path, \"utf-8\") as string)\n"
+"                })\n"
+"            }),\n"
+"            Button(\"Save As\", () => {\n"
+"                saveFileDialog((path: string) => {\n"
+"                    if (path.length === 0) return\n"
+"                    writeFileSync(path, content.value)\n"
+"                    filePath.set(path)\n"
+"                    alert(\"Saved\", `File saved to ${path}`)\n"
+"                }, \"untitled\", \"txt\")\n"
+"            }),\n"
+"        ]),\n"
+"        Text(filePath.value === \"\" ? \"No file open\" : `File: ${filePath.value}`),\n"
+"        TextField(\"Start typing...\", (value: string) => content.set(value)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:168
+msgid "[Menus](menus.md) — Menu bar and context menus"
+msgstr ""
+
+#: src/ui/dialogs.md:169
+msgid "[Multi-Window](multi-window.md) — Multiple windows"
+msgstr ""
+
+#: src/ui/dialogs.md:170
+msgid "[Events](events.md) — User interaction events"
+msgstr ""
+
+#: src/ui/table.md:3
+msgid ""
+"The `Table` widget displays tabular data with columns, headers, and row "
+"selection."
+msgstr ""
+
+#: src/ui/table.md:6
+msgid ""
+"**Platform support:** real implementation lives on **macOS** (`NSTableView` "
+"+ `NSScrollView`); the **Web** target uses an HTML `<table>`. **iOS**, "
+"**Android**, **Linux/GTK4**, **Windows**, **tvOS**, **visionOS**, and "
+"**watchOS** link no-op stubs so cross-platform code compiles everywhere — "
+"the table renders nothing and `tableGetSelectedRow` returns `-1`. For "
+"production lists on platforms without a real impl, use `LazyVStack` (see "
+"[Layout](layout.md))."
+msgstr ""
+
+#: src/ui/table.md:14
+msgid "Creating a Table"
+msgstr ""
+
+#: src/ui/table.md:22
+msgid ""
+"`Table(rowCount, colCount, renderCell)` creates a table. The render callback"
+" receives `(row, col)` and must return a `Widget` (typically `Text(...)`). "
+"The runtime resolves the returned handle as the cell view, which lets cells "
+"render images, stacks, or composites — not just plain strings."
+msgstr ""
+
+#: src/ui/table.md:28
+msgid "Column Headers"
+msgstr ""
+
+#: src/ui/table.md:30
+msgid ""
+"```ts\n"
+"const userTable = Table(users.length, 3, (row: number, col: number) => {\n"
+"    const user = users[row]\n"
+"    if (col === 0) return Text(user.name)\n"
+"    if (col === 1) return Text(user.email)\n"
+"    return Text(user.role)\n"
+"})\n"
+"\n"
+"tableSetColumnHeader(userTable, 0, \"Name\")\n"
+"tableSetColumnHeader(userTable, 1, \"Email\")\n"
+"tableSetColumnHeader(userTable, 2, \"Role\")\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:43
+msgid "Column Widths"
+msgstr ""
+
+#: src/ui/table.md:45
+msgid ""
+"```ts\n"
+"tableSetColumnWidth(userTable, 0, 150)  // Name column\n"
+"tableSetColumnWidth(userTable, 1, 250)  // Email column\n"
+"tableSetColumnWidth(userTable, 2, 100)  // Role column\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:51
+msgid "Row Selection"
+msgstr ""
+
+#: src/ui/table.md:53
+msgid ""
+"```ts\n"
+"const selectedRow = State(-1)\n"
+"\n"
+"tableSetOnRowSelect(userTable, (row: number) => {\n"
+"    selectedRow.set(row)\n"
+"    console.log(`Selected row: ${row}`)\n"
+"})\n"
+"\n"
+"// Read the currently selected row at any time:\n"
+"const current = tableGetSelectedRow(userTable)\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:65
+msgid "Dynamic Row Count"
+msgstr ""
+
+#: src/ui/table.md:67
+msgid "Update the number of rows after creation:"
+msgstr ""
+
+#: src/ui/table.md:75
+msgid ""
+"```ts\n"
+"const selectedName = State(\"None\")\n"
+"\n"
+"const table = Table(users.length, 3, (row: number, col: number) => {\n"
+"    const user = users[row]\n"
+"    if (col === 0) return Text(user.name)\n"
+"    if (col === 1) return Text(user.email)\n"
+"    return Text(user.role)\n"
+"})\n"
+"\n"
+"tableSetColumnHeader(table, 0, \"Name\")\n"
+"tableSetColumnHeader(table, 1, \"Email\")\n"
+"tableSetColumnHeader(table, 2, \"Role\")\n"
+"tableSetColumnWidth(table, 0, 150)\n"
+"tableSetColumnWidth(table, 1, 250)\n"
+"tableSetColumnWidth(table, 2, 100)\n"
+"\n"
+"tableSetOnRowSelect(table, (row: number) => {\n"
+"    selectedName.set(users[row].name)\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Table Demo\",\n"
+"    width: 600,\n"
+"    height: 400,\n"
+"    body: VStack(12, [\n"
+"        table,\n"
+"        Text(`Selected: ${selectedName.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:111
+msgid "[Events](events.md) — Event handling"
+msgstr ""
+
+#: src/ui/animation.md:3
+msgid ""
+"Perry supports animating widget properties for smooth transitions. Every "
+"snippet below is excerpted from "
+"[`docs/examples/ui/animation/snippets.ts`](../../examples/ui/animation/snippets.ts)"
+" — CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/animation.md:8
+msgid ""
+"`animateOpacity` and `animatePosition` are special: they're documented as "
+"methods on the widget handle (the only methods perry/ui exposes), and the "
+"HIR lowers them to `widgetAnimateOpacity` / `widgetAnimatePosition` calls "
+"under the hood."
+msgstr ""
+
+#: src/ui/animation.md:13
+msgid "Opacity Animation"
+msgstr ""
+
+#: src/ui/animation.md:15
+msgid ""
+"```typescript\n"
+"const fading = Text(\"Fading text\")\n"
+"// Animate from the widget's current opacity to `target` over `durationSecs`.\n"
+"fading.animateOpacity(1.0, 0.3) // target, durationSeconds\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:21
+msgid "Position Animation"
+msgstr ""
+
+#: src/ui/animation.md:23
+msgid ""
+"```typescript\n"
+"const moving = Button(\"Moving\", () => {})\n"
+"// Animate by a delta (dx, dy) relative to the widget's current position.\n"
+"moving.animatePosition(100, 200, 0.5) // dx, dy, durationSeconds\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:29
+msgid "Example: Fade-In Effect"
+msgstr ""
+
+#: src/ui/animation.md:31
+msgid ""
+"When the first argument reads from a `State.value`, Perry auto-subscribes "
+"the call to the state — toggling `visible` re-runs the animation."
+msgstr ""
+
+#: src/ui/animation.md:34
+msgid ""
+"```typescript\n"
+"// demonstrates: auto-reactive animateOpacity driven by a State toggle\n"
+"// docs: docs/src/ui/animation.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"\n"
+"import { App, Text, Button, VStack, State } from \"perry/ui\"\n"
+"\n"
+"const visible = State(false)\n"
+"\n"
+"const label = Text(\"Hello!\")\n"
+"label.animateOpacity(visible.value ? 1.0 : 0.0, 0.3)\n"
+"\n"
+"App({\n"
+"    title: \"Animation Demo\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Button(\"Toggle\", () => {\n"
+"            visible.set(!visible.value)\n"
+"        }),\n"
+"        label,\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:64
+msgid "NSAnimationContext / ViewPropertyAnimator"
+msgstr ""
+
+#: src/ui/animation.md:65
+msgid "UIView.animate"
+msgstr ""
+
+#: src/ui/animation.md:66
+msgid "ViewPropertyAnimator"
+msgstr ""
+
+#: src/ui/animation.md:67
+msgid "WM_TIMER-based animation"
+msgstr ""
+
+#: src/ui/animation.md:68
+msgid "CSS transitions (GTK4)"
+msgstr ""
+
+#: src/ui/animation.md:69
+msgid "CSS transitions"
+msgstr ""
+
+#: src/ui/animation.md:73
+msgid "[Styling](styling.md) — Widget styling properties"
+msgstr ""
+
+#: src/ui/animation.md:75
+msgid "[Events](events.md) — User interaction"
+msgstr ""
+
+#: src/ui/multi-window.md:1
+msgid "Multi-Window & Window Management"
+msgstr ""
+
+#: src/ui/multi-window.md:3
+msgid ""
+"Perry supports creating multiple native windows and controlling their "
+"appearance and behavior. Every snippet below is excerpted from "
+"[`docs/examples/ui/multi_window/snippets.ts`](../../examples/ui/multi_window/snippets.ts)"
+" — CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/multi-window.md:8
+msgid "Creating Windows"
+msgstr ""
+
+#: src/ui/multi-window.md:10
+msgid ""
+"`Window(title, width, height)` returns a window handle. Call `.setBody()` to"
+" set its content and `.show()` to display it:"
+msgstr ""
+
+#: src/ui/multi-window.md:13
+msgid ""
+"```typescript\n"
+"const settings = Window(\"Settings\", 500, 400)\n"
+"settings.setBody(VStack(16, [\n"
+"    Text(\"Settings panel\"),\n"
+"]))\n"
+"settings.show()\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:21
+msgid "Window Instance Methods"
+msgstr ""
+
+#: src/ui/multi-window.md:23
+msgid ""
+"```typescript\n"
+"const win = Window(\"My Window\", 600, 400)\n"
+"\n"
+"win.setBody(Text(\"Hello\"))   // Set the root widget\n"
+"win.show()                    // Show the window\n"
+"win.hide()                    // Hide without destroying\n"
+"win.setSize(800, 600)         // Resize dynamically\n"
+"win.onFocusLost(() => {       // Callback when the window loses focus\n"
+"    win.hide()\n"
+"})\n"
+"win.close()                   // Close and destroy\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:36 src/i18n/overview.md:87
+#: src/testing/geisterhand.md:257
+msgid "Method"
+msgstr ""
+
+#: src/ui/multi-window.md:38
+msgid "`setBody(widget)`"
+msgstr ""
+
+#: src/ui/multi-window.md:38
+msgid "Set the root widget of the window"
+msgstr ""
+
+#: src/ui/multi-window.md:39
+msgid "`show()`"
+msgstr ""
+
+#: src/ui/multi-window.md:39
+msgid "Show the window"
+msgstr ""
+
+#: src/ui/multi-window.md:40
+msgid "`hide()`"
+msgstr ""
+
+#: src/ui/multi-window.md:40
+msgid "Hide without destroying — call `show()` again to reveal"
+msgstr ""
+
+#: src/ui/multi-window.md:41
+msgid "`setSize(w, h)`"
+msgstr ""
+
+#: src/ui/multi-window.md:41
+msgid "Resize dynamically"
+msgstr ""
+
+#: src/ui/multi-window.md:42
+msgid "`onFocusLost(cb)`"
+msgstr ""
+
+#: src/ui/multi-window.md:42
+msgid "Register a callback that fires when focus leaves the window"
+msgstr ""
+
+#: src/ui/multi-window.md:43
+msgid "`close()`"
+msgstr ""
+
+#: src/ui/multi-window.md:43
+msgid "Close and destroy"
+msgstr ""
+
+#: src/ui/multi-window.md:45
+msgid "App Window Properties"
+msgstr ""
+
+#: src/ui/multi-window.md:47
+msgid ""
+"The main `App({})` config object accepts the same window properties for "
+"building launcher-style, overlay, or utility apps:"
+msgstr ""
+
+#: src/ui/multi-window.md:50
+msgid ""
+"```typescript\n"
+"App({\n"
+"    title: \"QuickLaunch\",\n"
+"    width: 600,\n"
+"    height: 80,\n"
+"    body: VStack(8, [\n"
+"        Text(\"Search...\"),\n"
+"        Button(\"Open Settings\", () => settings.show()),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:62
+msgid ""
+"`App` additionally accepts the optional fields `frameless`, `level`, "
+"`transparent`, `vibrancy`, `activationPolicy`, and `icon`. They map to the "
+"following native primitives:"
+msgstr ""
+
+#: src/ui/multi-window.md:66
+msgid "`frameless: true`"
+msgstr ""
+
+#: src/ui/multi-window.md:68
+msgid "Removes the window title bar and frame, creating a borderless window."
+msgstr ""
+
+#: src/ui/multi-window.md:72
+msgid "`NSWindowStyleMask::Borderless` + movable by background"
+msgstr ""
+
+#: src/ui/multi-window.md:73
+msgid "`WS_POPUP` window style"
+msgstr ""
+
+#: src/ui/multi-window.md:74
+msgid "`set_decorated(false)`"
+msgstr ""
+
+#: src/ui/multi-window.md:76
+msgid "`level: \"floating\" | \"statusBar\" | \"modal\" | \"normal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:78
+msgid "Controls the window's z-order level relative to other windows."
+msgstr ""
+
+#: src/ui/multi-window.md:80
+msgid "Level"
+msgstr ""
+
+#: src/ui/multi-window.md:82
+msgid "`\"normal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:82
+msgid "Default window level"
+msgstr ""
+
+#: src/ui/multi-window.md:83
+msgid "`\"floating\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:83
+msgid "Stays above normal windows"
+msgstr ""
+
+#: src/ui/multi-window.md:84
+msgid "`\"statusBar\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:84
+msgid "Stays above floating windows"
+msgstr ""
+
+#: src/ui/multi-window.md:85
+msgid "`\"modal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:85
+msgid "Modal panel level"
+msgstr ""
+
+#: src/ui/multi-window.md:89
+msgid "`NSWindow.level` (NSFloatingWindowLevel, etc.)"
+msgstr ""
+
+#: src/ui/multi-window.md:90
+msgid "`SetWindowPos` with `HWND_TOPMOST`"
+msgstr ""
+
+#: src/ui/multi-window.md:91
+msgid "`set_modal(true)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:93
+msgid "`transparent: true`"
+msgstr ""
+
+#: src/ui/multi-window.md:95
+msgid ""
+"Makes the window background transparent, allowing the desktop to show "
+"through non-opaque regions of your UI."
+msgstr ""
+
+#: src/ui/multi-window.md:100
+msgid "`isOpaque = false`, `backgroundColor = .clear`"
+msgstr ""
+
+#: src/ui/multi-window.md:101
+msgid "`WS_EX_LAYERED` with `SetLayeredWindowAttributes`"
+msgstr ""
+
+#: src/ui/multi-window.md:102
+msgid "CSS `background-color: transparent`"
+msgstr ""
+
+#: src/ui/multi-window.md:104
+msgid "`vibrancy: string`"
+msgstr ""
+
+#: src/ui/multi-window.md:106
+msgid ""
+"Applies a native translucent material to the window background. On macOS "
+"this uses the system vibrancy effect; on Windows it uses Mica/Acrylic."
+msgstr ""
+
+#: src/ui/multi-window.md:109
+msgid ""
+"**macOS materials:** `\"sidebar\"`, `\"titlebar\"`, `\"selection\"`, "
+"`\"menu\"`, `\"popover\"`, `\"headerView\"`, `\"sheet\"`, "
+"`\"windowBackground\"`, `\"hudWindow\"`, `\"fullScreenUI\"`, `\"tooltip\"`, "
+"`\"contentBackground\"`, `\"underWindowBackground\"`, "
+"`\"underPageBackground\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:116
+msgid "`NSVisualEffectView` with the specified material"
+msgstr ""
+
+#: src/ui/multi-window.md:117
+msgid ""
+"`DwmSetWindowAttribute(DWMWA_SYSTEMBACKDROP_TYPE)` — Mica, Acrylic, or Mica "
+"Alt depending on material (Windows 11 22H2+)"
+msgstr ""
+
+#: src/ui/multi-window.md:118
+msgid "CSS `alpha(@window_bg_color, 0.85)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:120
+msgid "`activationPolicy: \"regular\" | \"accessory\" | \"background\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:122
+msgid "Controls whether the app appears in the dock/taskbar."
+msgstr ""
+
+#: src/ui/multi-window.md:124 src/widgets/data-fetching.md:125
+msgid "Policy"
+msgstr ""
+
+#: src/ui/multi-window.md:126
+msgid "`\"regular\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:126
+msgid "Normal app with dock icon and menu bar (default)"
+msgstr ""
+
+#: src/ui/multi-window.md:127
+msgid "`\"accessory\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:127
+msgid ""
+"No dock icon, no menu bar activation — ideal for launchers and utilities"
+msgstr ""
+
+#: src/ui/multi-window.md:128
+msgid "`\"background\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:128
+msgid "Fully hidden from dock and app switcher"
+msgstr ""
+
+#: src/ui/multi-window.md:132
+msgid "`NSApp.setActivationPolicy()`"
+msgstr ""
+
+#: src/ui/multi-window.md:133
+msgid "`WS_EX_TOOLWINDOW` (removes from taskbar)"
+msgstr ""
+
+#: src/ui/multi-window.md:134
+msgid "`set_deletable(false)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:140
+msgid "NSWindow"
+msgstr ""
+
+#: src/ui/multi-window.md:141
+msgid "CreateWindowEx (HWND)"
+msgstr ""
+
+#: src/ui/multi-window.md:142
+msgid "GtkWindow"
+msgstr ""
+
+#: src/ui/multi-window.md:143
+msgid "Floating `<div>`"
+msgstr ""
+
+#: src/ui/multi-window.md:144
+msgid "iOS/Android"
+msgstr ""
+
+#: src/ui/multi-window.md:144
+msgid "Modal view controller / Dialog"
+msgstr ""
+
+#: src/ui/multi-window.md:146
+msgid ""
+"On mobile platforms, \"windows\" are presented as modal views or dialogs "
+"since mobile apps typically use a single-window model."
+msgstr ""
+
+#: src/ui/multi-window.md:151
+msgid "[Events](events.md) — Keyboard shortcuts"
+msgstr ""
+
+#: src/ui/multi-window.md:152
+msgid "[Dialogs](dialogs.md) — Modal dialogs and sheets"
+msgstr ""
+
+#: src/ui/multi-window.md:153
+msgid "[Menus](menus.md) — Menu bar and toolbar"
+msgstr ""
+
+#: src/ui/multi-window.md:154
+msgid "[UI Overview](overview.md) — Full UI system overview"
+msgstr ""
+
+#: src/ui/theming.md:3
+msgid ""
+"The `perry-styling` package provides a design system bridge for Perry UI — "
+"design token codegen and ergonomic styling helpers with compile-time "
+"platform detection."
+msgstr ""
+
+#: src/ui/theming.md:11
+msgid "Design Token Codegen"
+msgstr ""
+
+#: src/ui/theming.md:13
+msgid "Generate typed theme files from a JSON token definition:"
+msgstr ""
+
+#: src/ui/theming.md:19
+msgid "Token Format"
+msgstr ""
+
+#: src/ui/theming.md:23
+msgid "\"colors\""
+msgstr ""
+
+#: src/ui/theming.md:24
+msgid "\"primary\""
+msgstr ""
+
+#: src/ui/theming.md:24
+msgid "\"#007AFF\""
+msgstr ""
+
+#: src/ui/theming.md:25
+msgid "\"primary-dark\""
+msgstr ""
+
+#: src/ui/theming.md:25
+msgid "\"#0A84FF\""
+msgstr ""
+
+#: src/ui/theming.md:27
+msgid "\"background-dark\""
+msgstr ""
+
+#: src/ui/theming.md:27
+msgid "\"#1C1C1E\""
+msgstr ""
+
+#: src/ui/theming.md:28 src/testing/geisterhand.md:465
+msgid "\"text\""
+msgstr ""
+
+#: src/ui/theming.md:28
+msgid "\"#000000\""
+msgstr ""
+
+#: src/ui/theming.md:29
+msgid "\"text-dark\""
+msgstr ""
+
+#: src/ui/theming.md:31
+msgid "\"spacing\""
+msgstr ""
+
+#: src/ui/theming.md:32 src/ui/theming.md:38
+msgid "\"sm\""
+msgstr ""
+
+#: src/ui/theming.md:33 src/ui/theming.md:39
+msgid "\"md\""
+msgstr ""
+
+#: src/ui/theming.md:34 src/ui/theming.md:40
+msgid "\"lg\""
+msgstr ""
+
+#: src/ui/theming.md:35
+msgid "\"xl\""
+msgstr ""
+
+#: src/ui/theming.md:37
+msgid "\"radius\""
+msgstr ""
+
+#: src/ui/theming.md:42
+msgid "\"fontSize\""
+msgstr ""
+
+#: src/ui/theming.md:43
+msgid "\"body\""
+msgstr ""
+
+#: src/ui/theming.md:44
+msgid "\"heading\""
+msgstr ""
+
+#: src/ui/theming.md:45
+msgid "\"caption\""
+msgstr ""
+
+#: src/ui/theming.md:47
+msgid "\"borderWidth\""
+msgstr ""
+
+#: src/ui/theming.md:48
+msgid "\"thin\""
+msgstr ""
+
+#: src/ui/theming.md:49
+msgid "\"medium\""
+msgstr ""
+
+#: src/ui/theming.md:54
+msgid ""
+"Colors with a `-dark` suffix are used as the dark mode variant. If no dark "
+"variant is provided, the light value is used for both modes. Supported color"
+" formats: hex (`#RGB`, `#RRGGBB`, `#RRGGBBAA`), `rgb()`/`rgba()`, "
+"`hsl()`/`hsla()`, and CSS named colors."
+msgstr ""
+
+#: src/ui/theming.md:56
+msgid "Generated Types"
+msgstr ""
+
+#: src/ui/theming.md:58
+msgid "The codegen produces typed interfaces:"
+msgstr ""
+
+#: src/ui/theming.md:60
+msgid ""
+"```text\n"
+"interface PerryColor {\n"
+"  r: number; g: number; b: number; a: number; // floats in [0, 1]\n"
+"}\n"
+"\n"
+"interface PerryTheme {\n"
+"  light: { [key: string]: PerryColor };\n"
+"  dark: { [key: string]: PerryColor };\n"
+"  spacing: { [key: string]: number };\n"
+"  radius: { [key: string]: number };\n"
+"  fontSize: { [key: string]: number };\n"
+"  borderWidth: { [key: string]: number };\n"
+"}\n"
+"\n"
+"interface ResolvedTheme {\n"
+"  colors: { [key: string]: PerryColor };\n"
+"  spacing: { [key: string]: number };\n"
+"  radius: { [key: string]: number };\n"
+"  fontSize: { [key: string]: number };\n"
+"  borderWidth: { [key: string]: number };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:83
+msgid "Theme Resolution"
+msgstr ""
+
+#: src/ui/theming.md:85
+msgid "Resolve a theme at runtime based on the system's dark mode setting:"
+msgstr ""
+
+#: src/ui/theming.md:87
+msgid ""
+"```text\n"
+"import { getTheme } from \"perry-styling\";\n"
+"import { theme } from \"./theme\"; // generated file\n"
+"\n"
+"const resolved = getTheme(theme);\n"
+"// resolved.colors.primary → the correct light/dark variant\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:95
+msgid ""
+"`getTheme()` calls `isDarkMode()` from `perry/system` and returns the "
+"appropriate palette."
+msgstr ""
+
+#: src/ui/theming.md:97
+msgid "Styling Helpers"
+msgstr ""
+
+#: src/ui/theming.md:99
+msgid ""
+"Ergonomic functions for applying styles to widget handles. Perry's compiler "
+"doesn't yet support passing `PerryColor` objects as parameters into user "
+"functions, so the helpers take **flat primitives**: extract the channels at "
+"the call site:"
+msgstr ""
+
+#: src/ui/theming.md:104
+msgid ""
+"```text\n"
+"import {\n"
+"  applyBg, applyRadius, applyTextColor, applyFontSize, applyGradient,\n"
+"} from \"perry-styling\";\n"
+"\n"
+"const t = resolved;                    // your ResolvedTheme\n"
+"const c = t.colors.text;               // a PerryColor\n"
+"const bg = t.colors.background;\n"
+"const start = t.colors.primary;\n"
+"const end = t.colors[\"primary-dark\"];\n"
+"\n"
+"const label = Text(\"Hello\");\n"
+"applyTextColor(label, c.r, c.g, c.b, c.a);\n"
+"applyFontSize(label, t.fontSize.heading);\n"
+"\n"
+"const card = VStack(16, []);\n"
+"applyBg(card, bg.r, bg.g, bg.b, bg.a);\n"
+"applyRadius(card, t.radius.md);\n"
+"applyGradient(card,\n"
+"  start.r, start.g, start.b, start.a,\n"
+"  end.r,   end.g,   end.b,   end.a,\n"
+"  0,                                   // 0 = vertical, 1 = horizontal\n"
+");\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:129
+msgid "Available Helpers"
+msgstr ""
+
+#: src/ui/theming.md:131
+msgid "Signature"
+msgstr ""
+
+#: src/ui/theming.md:133
+msgid "`applyBg(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:133
+msgid "Background color"
+msgstr ""
+
+#: src/ui/theming.md:134
+msgid "`applyRadius(handle, radius)`"
+msgstr ""
+
+#: src/ui/theming.md:134
+msgid "Corner radius"
+msgstr ""
+
+#: src/ui/theming.md:135
+msgid "`applyTextColor(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:135
+msgid "Text color"
+msgstr ""
+
+#: src/ui/theming.md:136
+msgid "`applyFontSize(handle, size)`"
+msgstr ""
+
+#: src/ui/theming.md:136
+msgid "Font size (regular weight)"
+msgstr ""
+
+#: src/ui/theming.md:137
+msgid "`applyFontBold(handle, size)`"
+msgstr ""
+
+#: src/ui/theming.md:137
+msgid "Font size with bold weight"
+msgstr ""
+
+#: src/ui/theming.md:138
+msgid "`applyFontFamily(handle, family)`"
+msgstr ""
+
+#: src/ui/theming.md:138
+msgid "Font family"
+msgstr ""
+
+#: src/ui/theming.md:139
+msgid "`applyWidth(handle, width)`"
+msgstr ""
+
+#: src/ui/theming.md:139
+msgid "Fixed width"
+msgstr ""
+
+#: src/ui/theming.md:140
+msgid "`applyTooltip(handle, text)`"
+msgstr ""
+
+#: src/ui/theming.md:140
+msgid "Tooltip (no-op on iOS/Android)"
+msgstr ""
+
+#: src/ui/theming.md:141
+msgid "`applyBorderColor(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:141
+msgid "Border color"
+msgstr ""
+
+#: src/ui/theming.md:142
+msgid "`applyBorderWidth(handle, width)`"
+msgstr ""
+
+#: src/ui/theming.md:142
+msgid "Border width"
+msgstr ""
+
+#: src/ui/theming.md:143
+msgid "`applyEdgeInsets(handle, top, left, bottom, right)`"
+msgstr ""
+
+#: src/ui/theming.md:143
+msgid "Edge insets (padding)"
+msgstr ""
+
+#: src/ui/theming.md:144
+msgid "`applyOpacity(handle, alpha)`"
+msgstr ""
+
+#: src/ui/theming.md:145
+msgid "`applyGradient(handle, r1, g1, b1, a1, r2, g2, b2, a2, direction)`"
+msgstr ""
+
+#: src/ui/theming.md:145
+msgid "Background gradient"
+msgstr ""
+
+#: src/ui/theming.md:146
+msgid "`applyButtonBg(btn, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:146
+msgid "Button background"
+msgstr ""
+
+#: src/ui/theming.md:147
+msgid "`applyButtonTextColor(btn, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:147
+msgid "Button text color"
+msgstr ""
+
+#: src/ui/theming.md:148
+msgid "`applyButtonBordered(btn, bordered)`"
+msgstr ""
+
+#: src/ui/theming.md:148
+msgid "Bordered button style (`true`/`false`)"
+msgstr ""
+
+#: src/ui/theming.md:150
+msgid "Platform Constants"
+msgstr ""
+
+#: src/ui/theming.md:152
+msgid ""
+"`perry-styling` exports compile-time platform constants based on the "
+"`__platform__` built-in:"
+msgstr ""
+
+#: src/ui/theming.md:154
+msgid ""
+"```text\n"
+"import { isMac, isIOS, isAndroid, isWindows, isLinux, isDesktop, isMobile } from \"perry-styling\";\n"
+"\n"
+"if (isMobile) {\n"
+"  applyFontSize(label, 16);\n"
+"} else {\n"
+"  applyFontSize(label, 14);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:164
+msgid ""
+"These are constant-folded by LLVM at compile time — dead branches are "
+"eliminated with zero runtime cost."
+msgstr ""
+
+#: src/ui/theming.md:168
+msgid "[Styling](styling.md) — Widget styling basics"
+msgstr ""
+
+#: src/ui/camera.md:3
+msgid ""
+"The `perry/ui` module provides a live camera preview widget with color "
+"sampling capabilities."
+msgstr ""
+
+#: src/ui/camera.md:6
+msgid ""
+"```ts\n"
+"import {\n"
+"    CameraView,\n"
+"    cameraStart, cameraStop,\n"
+"    cameraFreeze, cameraUnfreeze,\n"
+"    cameraSampleColor, cameraSetOnTap,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:15
+msgid ""
+"**Platform support:** real capture is implemented on **iOS** "
+"(AVCaptureSession) and **Android** (Camera2). On **macOS**, **Linux** "
+"(GTK4), **Windows**, and the **Web** target the runtime exports no-op stubs "
+"so cross-platform code compiles and links cleanly — `CameraView()` returns "
+"handle 0 and `cameraSampleColor` returns `-1`. Wiring real capture on those "
+"platforms (AVFoundation on macOS, GStreamer/V4L2 on Linux, Media Foundation "
+"on Windows, `getUserMedia` on Web) is tracked as a follow-up."
+msgstr ""
+
+#: src/ui/camera.md:24 src/system/overview.md:43 src/plugins/overview.md:25
+msgid "Quick Example"
+msgstr ""
+
+#: src/ui/camera.md:26
+msgid ""
+"```ts\n"
+"const colorHex = State(\"#000000\")\n"
+"\n"
+"const cam = CameraView()\n"
+"cameraStart(cam)\n"
+"\n"
+"cameraSetOnTap(cam, (x: number, y: number) => {\n"
+"    const rgb = cameraSampleColor(x, y)\n"
+"    if (rgb >= 0) {\n"
+"        const r = Math.floor(rgb / 65536)\n"
+"        const g = Math.floor((rgb % 65536) / 256)\n"
+"        const b = Math.floor(rgb % 256)\n"
+"        colorHex.set(`#${r.toString(16).padStart(2, \"0\")}${g.toString(16).padStart(2, \"0\")}${b.toString(16).padStart(2, \"0\")}`)\n"
+"    }\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Color Picker\",\n"
+"    width: 400,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        cam,\n"
+"        Text(`Color: ${colorHex.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:53 src/system/audio.md:21 src/testing/geisterhand.md:45
+msgid "API Reference"
+msgstr ""
+
+#: src/ui/camera.md:55
+msgid "`CameraView()`"
+msgstr ""
+
+#: src/ui/camera.md:57
+msgid "Create a live camera preview widget."
+msgstr ""
+
+#: src/ui/camera.md:63
+msgid ""
+"Returns a widget handle. The camera does not start automatically — call "
+"`cameraStart()` to begin capture."
+msgstr ""
+
+#: src/ui/camera.md:65
+msgid "`cameraStart(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:67
+msgid "Start the live camera feed."
+msgstr ""
+
+#: src/ui/camera.md:73
+msgid ""
+"On iOS, the camera permission dialog is shown automatically on first use."
+msgstr ""
+
+#: src/ui/camera.md:75
+msgid "`cameraStop(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:77
+msgid "Stop the camera feed and release the capture session."
+msgstr ""
+
+#: src/ui/camera.md:83
+msgid "`cameraFreeze(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:85
+msgid "Pause the live preview (freeze the current frame)."
+msgstr ""
+
+#: src/ui/camera.md:91
+msgid ""
+"The camera session remains active but the preview stops updating. Useful for"
+" \"capture\" moments where you want to inspect the frozen frame."
+msgstr ""
+
+#: src/ui/camera.md:93
+msgid "`cameraUnfreeze(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:95
+msgid "Resume the live preview after a freeze."
+msgstr ""
+
+#: src/ui/camera.md:101
+msgid "`cameraSampleColor(x, y)`"
+msgstr ""
+
+#: src/ui/camera.md:103
+msgid "Sample the pixel color at normalized coordinates."
+msgstr ""
+
+#: src/ui/camera.md:105
+msgid ""
+"```ts\n"
+"const rgb = cameraSampleColor(0.5, 0.5) // center of frame\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:109
+msgid "`x`, `y` are normalized coordinates (0.0–1.0)"
+msgstr ""
+
+#: src/ui/camera.md:110
+msgid "Returns packed RGB as a number: `r * 65536 + g * 256 + b`"
+msgstr ""
+
+#: src/ui/camera.md:111
+msgid "Returns `-1` if no frame is available"
+msgstr ""
+
+#: src/ui/camera.md:113
+msgid "To extract individual channels:"
+msgstr ""
+
+#: src/ui/camera.md:121
+msgid ""
+"The color is averaged over a 5x5 pixel region around the sample point for "
+"noise reduction."
+msgstr ""
+
+#: src/ui/camera.md:123
+msgid "`cameraSetOnTap(handle, callback)`"
+msgstr ""
+
+#: src/ui/camera.md:125
+msgid "Register a tap handler on the camera view."
+msgstr ""
+
+#: src/ui/camera.md:127
+msgid ""
+"```ts\n"
+"cameraSetOnTap(preview, (tx: number, ty: number) => {\n"
+"    // tx, ty are normalized coordinates (0.0-1.0)\n"
+"    const tappedRgb = cameraSampleColor(tx, ty)\n"
+"    console.log(`tapped color: ${tappedRgb}`)\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:135
+msgid ""
+"The callback receives normalized coordinates of the tap location, which can "
+"be passed directly to `cameraSampleColor()`."
+msgstr ""
+
+#: src/ui/camera.md:139
+msgid ""
+"On iOS, the camera uses AVCaptureSession with AVCaptureVideoPreviewLayer for"
+" GPU-accelerated live preview, and AVCaptureVideoDataOutput for frame "
+"capture. Color sampling reads pixel data from CVPixelBuffer."
+msgstr ""
+
+#: src/ui/camera.md:141
+msgid ""
+"On Android, the camera uses Camera2 with a TextureView preview surface. "
+"Color sampling reads from the most recent ImageReader frame."
+msgstr ""
+
+#: src/ui/camera.md:146
+msgid ""
+"[Audio Capture](../system/audio.md) — Microphone input and sound metering"
+msgstr ""
+
+#: src/platforms/overview.md:1
+msgid "Platform Overview"
+msgstr ""
+
+#: src/platforms/overview.md:3
+msgid ""
+"Perry compiles TypeScript to native executables for 9 platform families from"
+" the same source code."
+msgstr ""
+
+#: src/platforms/overview.md:5
+msgid "Supported Platforms"
+msgstr ""
+
+#: src/platforms/overview.md:7 src/widgets/platforms.md:9
+msgid "Target Flag"
+msgstr ""
+
+#: src/platforms/overview.md:7 src/platforms/macos.md:20
+#: src/platforms/ios.md:46 src/platforms/tvos.md:46
+#: src/platforms/watchos.md:46 src/platforms/android.md:20
+#: src/platforms/windows.md:38 src/platforms/linux.md:30
+msgid "UI Toolkit"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "_(default)_"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "AppKit"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "Full support (127/127 FFI functions)"
+msgstr ""
+
+#: src/platforms/overview.md:10
+msgid "`--target ios` / `--target ios-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:10 src/platforms/overview.md:12
+#: src/platforms/tvos.md:178
+msgid "UIKit"
+msgstr ""
+
+#: src/platforms/overview.md:10
+msgid "Full support (127/127)"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "`--target visionos` / `--target visionos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "UIKit (2D windows)"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "Core support (2D only)"
+msgstr ""
+
+#: src/platforms/overview.md:12
+msgid "`--target tvos` / `--target tvos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:12
+msgid "Full support (focus engine + game controllers)"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "`--target watchos` / `--target watchos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "SwiftUI (data-driven)"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "Core support (15 widgets)"
+msgstr ""
+
+#: src/platforms/overview.md:14
+msgid "`--target android`"
+msgstr ""
+
+#: src/platforms/overview.md:14
+msgid "JNI/Android SDK"
+msgstr ""
+
+#: src/platforms/overview.md:14 src/platforms/overview.md:15
+#: src/platforms/overview.md:16
+msgid "Full support (112/112)"
+msgstr ""
+
+#: src/platforms/overview.md:15
+msgid "`--target windows`"
+msgstr ""
+
+#: src/platforms/overview.md:15
+msgid "Win32"
+msgstr ""
+
+#: src/platforms/overview.md:16
+msgid "`--target linux`"
+msgstr ""
+
+#: src/platforms/overview.md:16
+msgid "GTK4"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "Web / WebAssembly"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "`--target web` _(alias `--target wasm`)_"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "DOM/CSS via WASM bridge"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "Full support (168 widgets)"
+msgstr ""
+
+#: src/platforms/overview.md:19
+msgid "Cross-Compilation"
+msgstr ""
+
+#: src/platforms/overview.md:22
+msgid "# Default: compile for current platform\n"
+msgstr ""
+
+#: src/platforms/overview.md:24
+msgid "# Compile for a specific target\n"
+msgstr ""
+
+#: src/platforms/overview.md:36 src/platforms/visionos.md:49
+#: src/platforms/tvos.md:133 src/platforms/watchos.md:170
+msgid "Platform Detection"
+msgstr ""
+
+#: src/platforms/overview.md:38
+msgid "Use the `__platform__` compile-time constant to branch by platform:"
+msgstr ""
+
+#: src/platforms/overview.md:40
+msgid ""
+"```typescript\n"
+"declare const __platform__: number\n"
+"\n"
+"// Platform constants:\n"
+"// 0 = macOS\n"
+"// 1 = iOS\n"
+"// 2 = Android\n"
+"// 3 = Windows\n"
+"// 4 = Linux\n"
+"// 5 = Web (browser, --target web / --target wasm)\n"
+"// 6 = tvOS\n"
+"// 7 = watchOS\n"
+"// 8 = visionOS\n"
+"\n"
+"if (__platform__ === 0) {\n"
+"    console.log(\"Running on macOS\")\n"
+"} else if (__platform__ === 1) {\n"
+"    console.log(\"Running on iOS\")\n"
+"} else if (__platform__ === 3) {\n"
+"    console.log(\"Running on Windows\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/overview.md:63
+msgid ""
+"`__platform__` is resolved at compile time. The compiler constant-folds "
+"comparisons and eliminates dead branches, so platform-specific code has zero"
+" runtime cost."
+msgstr ""
+
+#: src/platforms/overview.md:65
+msgid "Platform Feature Matrix"
+msgstr ""
+
+#: src/platforms/overview.md:67
+msgid "Web (WASM)"
+msgstr ""
+
+#: src/platforms/overview.md:69
+msgid "CLI programs"
+msgstr ""
+
+#: src/platforms/overview.md:70
+msgid "Native UI (DOM on web)"
+msgstr ""
+
+#: src/platforms/overview.md:71
+msgid "Game engines"
+msgstr ""
+
+#: src/platforms/overview.md:71
+msgid "Via FFI"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "File system"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "Sandboxed"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "File System Access API"
+msgstr ""
+
+#: src/platforms/overview.md:73
+msgid "Networking"
+msgstr ""
+
+#: src/platforms/overview.md:73
+msgid "`fetch` / `WebSocket`"
+msgstr ""
+
+#: src/platforms/overview.md:74
+msgid "Partial"
+msgstr ""
+
+#: src/platforms/overview.md:74
+msgid "Minimal"
+msgstr ""
+
+#: src/platforms/overview.md:75
+msgid "Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Threading"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Native"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Web Workers"
+msgstr ""
+
+#: src/platforms/overview.md:80
+msgid "[macOS](macos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:81
+msgid "[iOS](ios.md)"
+msgstr ""
+
+#: src/platforms/overview.md:82
+msgid "[visionOS](visionos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:83
+msgid "[tvOS](tvos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:84
+msgid "[watchOS](watchos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:85
+msgid "[Android](android.md)"
+msgstr ""
+
+#: src/platforms/overview.md:86
+msgid "[Windows](windows.md)"
+msgstr ""
+
+#: src/platforms/overview.md:87
+msgid "[Linux (GTK4)](linux.md)"
+msgstr ""
+
+#: src/platforms/overview.md:88
+msgid "[Web](web.md)"
+msgstr ""
+
+#: src/platforms/overview.md:89
+msgid "[WebAssembly](wasm.md)"
+msgstr ""
+
+#: src/platforms/macos.md:3
+msgid ""
+"macOS is Perry's primary development platform. It uses AppKit for native UI."
+msgstr ""
+
+#: src/platforms/macos.md:5 src/platforms/ios.md:5 src/platforms/tvos.md:7
+#: src/platforms/watchos.md:7 src/platforms/android.md:5
+#: src/platforms/windows.md:5 src/platforms/linux.md:5
+#: src/plugins/native-extensions.md:271
+msgid "Requirements"
+msgstr ""
+
+#: src/platforms/macos.md:7
+msgid "macOS 13+ (Ventura or later)"
+msgstr ""
+
+#: src/platforms/macos.md:8
+msgid "Xcode Command Line Tools: `xcode-select --install`"
+msgstr ""
+
+#: src/platforms/macos.md:10 src/platforms/android.md:14
+#: src/platforms/windows.md:32 src/platforms/linux.md:23
+#: src/platforms/wasm.md:7 src/widgets/overview.md:48
+msgid "Building"
+msgstr ""
+
+#: src/platforms/macos.md:13
+msgid "# macOS is the default target\n"
+msgstr ""
+
+#: src/platforms/macos.md:18
+msgid "No additional flags needed — macOS is the default compilation target."
+msgstr ""
+
+#: src/platforms/macos.md:22
+msgid "Perry maps UI widgets to AppKit controls:"
+msgstr ""
+
+#: src/platforms/macos.md:24 src/platforms/ios.md:50 src/platforms/tvos.md:50
+#: src/platforms/watchos.md:50 src/platforms/android.md:24
+#: src/platforms/windows.md:42 src/platforms/linux.md:34
+#: src/platforms/wasm.md:55
+msgid "Perry Widget"
+msgstr ""
+
+#: src/platforms/macos.md:24
+msgid "AppKit Class"
+msgstr ""
+
+#: src/platforms/macos.md:26
+msgid "NSTextField (label mode)"
+msgstr ""
+
+#: src/platforms/macos.md:29
+msgid "NSSecureTextField"
+msgstr ""
+
+#: src/platforms/macos.md:30
+msgid "NSSwitch"
+msgstr ""
+
+#: src/platforms/macos.md:31
+msgid "NSSlider"
+msgstr ""
+
+#: src/platforms/macos.md:32
+msgid "NSPopUpButton"
+msgstr ""
+
+#: src/platforms/macos.md:33 src/platforms/ios.md:59 src/platforms/tvos.md:58
+#: src/platforms/watchos.md:61 src/platforms/android.md:33
+#: src/platforms/windows.md:52 src/platforms/linux.md:44
+#: src/widgets/components.md:83
+msgid "Image"
+msgstr ""
+
+#: src/platforms/macos.md:33
+msgid "NSImageView"
+msgstr ""
+
+#: src/platforms/macos.md:34 src/platforms/ios.md:60 src/platforms/tvos.md:59
+#: src/platforms/windows.md:53
+msgid "VStack/HStack"
+msgstr ""
+
+#: src/platforms/macos.md:35
+msgid "NSScrollView"
+msgstr ""
+
+#: src/platforms/macos.md:36
+msgid "NSTableView"
+msgstr ""
+
+#: src/platforms/macos.md:37
+msgid "NSView + Core Graphics"
+msgstr ""
+
+#: src/platforms/macos.md:39 src/cli/perry-toml.md:179
+#: src/cli/perry-toml.md:258
+msgid "Code Signing"
+msgstr ""
+
+#: src/platforms/macos.md:41
+msgid ""
+"For distribution, apps need to be signed. Perry supports automatic signing:"
+msgstr ""
+
+#: src/platforms/macos.md:47
+msgid ""
+"This auto-detects your signing identity from the macOS Keychain, exports it "
+"to a temporary `.p12` file, and signs the binary."
+msgstr ""
+
+#: src/platforms/macos.md:49
+msgid "For manual signing:"
+msgstr ""
+
+#: src/platforms/macos.md:52
+msgid "\"Developer ID Application: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:55
+msgid "App Store Distribution"
+msgstr ""
+
+#: src/platforms/macos.md:58
+msgid "# Sign with App Store certificate\n"
+msgstr ""
+
+#: src/platforms/macos.md:60
+msgid "\"3rd Party Mac Developer Application: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:60
+msgid "# Package\n"
+msgstr ""
+
+#: src/platforms/macos.md:62
+msgid "\"3rd Party Mac Developer Installer: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:65
+msgid "macOS-Specific Features"
+msgstr ""
+
+#: src/platforms/macos.md:67
+msgid "**Menu bar**: Full NSMenu support with keyboard shortcuts"
+msgstr ""
+
+#: src/platforms/macos.md:68
+msgid "**Toolbar**: NSToolbar integration"
+msgstr ""
+
+#: src/platforms/macos.md:69
+msgid "**Dock icon**: Automatic for GUI apps"
+msgstr ""
+
+#: src/platforms/macos.md:70
+msgid "**Dark mode**: `isDarkMode()` detects system appearance"
+msgstr ""
+
+#: src/platforms/macos.md:71
+msgid "**Keychain**: Secure storage via Security.framework"
+msgstr ""
+
+#: src/platforms/macos.md:72
+msgid "**Notifications**: Local notifications via UNUserNotificationCenter"
+msgstr ""
+
+#: src/platforms/macos.md:73
+msgid "**File dialogs**: NSOpenPanel/NSSavePanel"
+msgstr ""
+
+#: src/platforms/macos.md:77
+msgid ""
+"```typescript\n"
+"import { openURL, isDarkMode, preferencesSet, preferencesGet } from \"perry/system\"\n"
+"\n"
+"openURL(\"https://example.com\")          // Opens in default browser\n"
+"const dark = isDarkMode()               // Check appearance\n"
+"preferencesSet(\"key\", \"value\")          // NSUserDefaults\n"
+"const val = preferencesGet(\"key\")       // NSUserDefaults\n"
+"```"
+msgstr ""
+
+#: src/platforms/macos.md:88
+msgid "[iOS](ios.md) — Cross-compile for iPhone/iPad"
+msgstr ""
+
+#: src/platforms/macos.md:89
+msgid "[UI Overview](../ui/overview.md) — Full UI documentation"
+msgstr ""
+
+#: src/platforms/macos.md:90
+msgid "[System APIs](../system/overview.md) — System integration"
+msgstr ""
+
+#: src/platforms/ios.md:3
+msgid ""
+"Perry can cross-compile TypeScript apps for iOS devices and the iOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/ios.md:7 src/platforms/tvos.md:9 src/platforms/watchos.md:9
+msgid "macOS host (cross-compilation from Linux/Windows is not supported)"
+msgstr ""
+
+#: src/platforms/ios.md:8
+msgid ""
+"Xcode (full install, not just Command Line Tools) for iOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/ios.md:9
+msgid "Rust iOS targets:"
+msgstr ""
+
+#: src/platforms/ios.md:14 src/platforms/tvos.md:16
+#: src/platforms/watchos.md:16
+msgid "Building for Simulator"
+msgstr ""
+
+#: src/platforms/ios.md:20
+msgid ""
+"This uses LLVM cross-compilation with the iOS Simulator SDK. The binary can "
+"be run in the Xcode Simulator."
+msgstr ""
+
+#: src/platforms/ios.md:22 src/platforms/tvos.md:24
+#: src/platforms/watchos.md:24
+msgid "Building for Device"
+msgstr ""
+
+#: src/platforms/ios.md:28
+msgid ""
+"This produces an ARM64 binary for physical iOS devices. You'll need to code "
+"sign and package it in an `.app` bundle for deployment."
+msgstr ""
+
+#: src/platforms/ios.md:30 src/platforms/tvos.md:32
+#: src/platforms/watchos.md:32
+msgid "Running with `perry run`"
+msgstr ""
+
+#: src/platforms/ios.md:32
+msgid "The easiest way to build and run on iOS is `perry run`:"
+msgstr ""
+
+#: src/platforms/ios.md:35
+msgid "# Auto-detect device/simulator\n"
+msgstr ""
+
+#: src/platforms/ios.md:36
+msgid "# Stream live stdout/stderr\n"
+msgstr ""
+
+#: src/platforms/ios.md:37
+msgid "# Use Perry Hub build server\n"
+msgstr ""
+
+#: src/platforms/ios.md:40
+msgid ""
+"Perry auto-discovers available simulators (via `simctl`) and physical "
+"devices (via `devicectl`). When multiple targets are found, an interactive "
+"prompt lets you choose."
+msgstr ""
+
+#: src/platforms/ios.md:42
+msgid ""
+"For physical devices, Perry handles code signing automatically — it reads "
+"your signing identity and team ID from `~/.perry/config.toml` (set up via "
+"`perry setup ios`), embeds the provisioning profile, and signs the `.app` "
+"before installing."
+msgstr ""
+
+#: src/platforms/ios.md:44
+msgid ""
+"If you don't have the iOS cross-compilation toolchain installed locally, "
+"`perry run ios` automatically falls back to Perry Hub's remote build server."
+msgstr ""
+
+#: src/platforms/ios.md:48
+msgid "Perry maps UI widgets to UIKit controls:"
+msgstr ""
+
+#: src/platforms/ios.md:50 src/platforms/tvos.md:50
+msgid "UIKit Class"
+msgstr ""
+
+#: src/platforms/ios.md:53
+msgid "UIButton (TouchUpInside)"
+msgstr ""
+
+#: src/platforms/ios.md:54 src/platforms/tvos.md:54
+msgid "UITextField"
+msgstr ""
+
+#: src/platforms/ios.md:55
+msgid "UITextField (secureTextEntry)"
+msgstr ""
+
+#: src/platforms/ios.md:56 src/platforms/tvos.md:55
+msgid "UISwitch"
+msgstr ""
+
+#: src/platforms/ios.md:57
+msgid "UISlider (Float32, cast at boundary)"
+msgstr ""
+
+#: src/platforms/ios.md:58 src/platforms/tvos.md:57
+msgid "UIPickerView"
+msgstr ""
+
+#: src/platforms/ios.md:59 src/platforms/tvos.md:58
+msgid "UIImageView"
+msgstr ""
+
+#: src/platforms/ios.md:61 src/platforms/tvos.md:60
+msgid "UIScrollView"
+msgstr ""
+
+#: src/platforms/ios.md:65
+msgid "iOS apps use `UIApplicationMain` with a deferred creation pattern:"
+msgstr ""
+
+#: src/platforms/ios.md:67
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My iOS App\",\n"
+"    width: 400,\n"
+"    height: 800,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello, iPhone!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/ios.md:80
+msgid ""
+"The `App()` call triggers `UIApplicationMain`, and your render function is "
+"called via `PerryAppDelegate` once the app is ready."
+msgstr ""
+
+#: src/platforms/ios.md:82
+msgid "iOS Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/ios.md:84
+msgid ""
+"Perry can compile TypeScript widget declarations to native SwiftUI WidgetKit"
+" extensions:"
+msgstr ""
+
+#: src/platforms/ios.md:90
+msgid "See [Widgets (WidgetKit)](../widgets/overview.md) for details."
+msgstr ""
+
+#: src/platforms/ios.md:92 src/platforms/android.md:51
+msgid "Splash Screen"
+msgstr ""
+
+#: src/platforms/ios.md:94
+msgid ""
+"Perry auto-generates a native `LaunchScreen.storyboard` from the "
+"`perry.splash` config in `package.json`. The splash screen appears instantly"
+" during cold start."
+msgstr ""
+
+#: src/platforms/ios.md:107
+msgid ""
+"The image is centered at 128x128pt with `scaleAspectFit`. You can provide a "
+"custom storyboard for full control:"
+msgstr ""
+
+#: src/platforms/ios.md:119 src/platforms/android.md:83
+msgid ""
+"See [Project Configuration](../getting-started/project-config.md#splash) for"
+" the full config reference."
+msgstr ""
+
+#: src/platforms/ios.md:121
+msgid "Resource Bundling"
+msgstr ""
+
+#: src/platforms/ios.md:123
+msgid ""
+"Perry automatically bundles `logo/` and `assets/` directories from your "
+"project root into the `.app` bundle. These resources are available at "
+"runtime via standard file APIs relative to the app bundle path."
+msgstr ""
+
+#: src/platforms/ios.md:125
+msgid "Keyboard Avoidance"
+msgstr ""
+
+#: src/platforms/ios.md:127
+msgid ""
+"Perry apps automatically handle keyboard avoidance on iOS. When the keyboard"
+" appears, the root view adjusts its bottom constraint with an animated "
+"layout transition, and focused TextFields are auto-scrolled into view above "
+"the keyboard."
+msgstr ""
+
+#: src/platforms/ios.md:129
+msgid "Differences from macOS"
+msgstr ""
+
+#: src/platforms/ios.md:131
+msgid ""
+"**No menu bar**: iOS doesn't support menu bars. Use toolbar or navigation "
+"patterns."
+msgstr ""
+
+#: src/platforms/ios.md:132
+msgid ""
+"**Touch events**: `onHover` is not available. Use `onClick` (mapped to "
+"touch)."
+msgstr ""
+
+#: src/platforms/ios.md:133
+msgid ""
+"**Slider precision**: iOS UISlider uses Float32 internally (automatically "
+"converted)."
+msgstr ""
+
+#: src/platforms/ios.md:134
+msgid "**File dialogs**: Limited to UIDocumentPicker."
+msgstr ""
+
+#: src/platforms/ios.md:135
+msgid "**Keyboard shortcuts**: Not applicable on iOS."
+msgstr ""
+
+#: src/platforms/ios.md:139
+msgid ""
+"[Widgets (WidgetKit)](../widgets/overview.md) — iOS home screen widgets"
+msgstr ""
+
+#: src/platforms/ios.md:140 src/platforms/tvos.md:184
+#: src/platforms/watchos.md:217 src/platforms/android.md:94
+#: src/platforms/windows.md:71 src/platforms/linux.md:83
+#: src/platforms/wasm.md:193
+msgid "[Platform Overview](overview.md) — All platforms"
+msgstr ""
+
+#: src/platforms/ios.md:141 src/platforms/watchos.md:218
+#: src/platforms/android.md:95 src/platforms/windows.md:72
+#: src/platforms/linux.md:84 src/platforms/wasm.md:194
+msgid "[UI Overview](../ui/overview.md) — UI system"
+msgstr ""
+
+#: src/platforms/visionos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple Vision Pro devices and the "
+"visionOS Simulator."
+msgstr ""
+
+#: src/platforms/visionos.md:5
+msgid ""
+"This first pass targets **2D windowed apps only**. Perry uses the same "
+"UIKit-style `perry/ui` model as iOS, packaged for visionOS app bundles and "
+"scene lifecycle."
+msgstr ""
+
+#: src/platforms/visionos.md:9
+msgid "macOS with Xcode installed"
+msgstr ""
+
+#: src/platforms/visionos.md:10
+msgid "Rust visionOS targets:"
+msgstr ""
+
+#: src/platforms/visionos.md:16
+msgid "Compile"
+msgstr ""
+
+#: src/platforms/visionos.md:23
+msgid ""
+"This produces a `.app` bundle with visionOS-specific `Info.plist` metadata "
+"and a `UIWindowScene` configuration."
+msgstr ""
+
+#: src/platforms/visionos.md:25
+msgid "Run"
+msgstr ""
+
+#: src/platforms/visionos.md:33
+msgid ""
+"Perry auto-detects booted Apple Vision Pro simulators via `simctl`. Physical"
+" device installs use `devicectl`, like other modern Apple platforms."
+msgstr ""
+
+#: src/platforms/visionos.md:37
+msgid "Configure visionOS-specific settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/visionos.md:39
+msgid ""
+"```toml\n"
+"[visionos]\n"
+"bundle_id = \"com.example.myvisionapp\"\n"
+"deployment_target = \"1.0\"\n"
+"entry = \"src/main_visionos.ts\"\n"
+"encryption_exempt = true\n"
+"```"
+msgstr ""
+
+#: src/platforms/visionos.md:47
+msgid ""
+"Custom `Info.plist` keys can be merged through `[visionos.info_plist]`."
+msgstr ""
+
+#: src/platforms/visionos.md:51
+msgid "Use `__platform__ === 8` to detect visionOS at compile time:"
+msgstr ""
+
+#: src/platforms/visionos.md:53
+msgid ""
+"```typescript\n"
+"function reportVisionos(): void {\n"
+"    if (__platform__ === 8) {\n"
+"        console.log(\"Running on visionOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/visionos.md:61
+msgid "Current Scope"
+msgstr ""
+
+#: src/platforms/visionos.md:63
+msgid ""
+"Supported: 2D windowed apps, simulator/device app bundles, `perry run`, "
+"`perry setup`, `perry publish`"
+msgstr ""
+
+#: src/platforms/visionos.md:64
+msgid ""
+"Not supported yet: immersive spaces, volumes, RealityKit scene generation, "
+"Geisterhand"
+msgstr ""
+
+#: src/platforms/visionos.md:66
+msgid "Related"
+msgstr ""
+
+#: src/platforms/visionos.md:68
+msgid "[iOS](ios.md) — shared UIKit foundation"
+msgstr ""
+
+#: src/platforms/visionos.md:69
+msgid "[Platform Overview](overview.md)"
+msgstr ""
+
+#: src/platforms/tvos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple TV devices and the tvOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/tvos.md:5
+msgid ""
+"tvOS uses UIKit (the same framework as iOS), so Perry's tvOS support shares "
+"the same UIKit-based widget system. The primary difference is input: Apple "
+"TV apps are controlled via the Siri Remote and game controllers rather than "
+"touch, and all apps run full-screen."
+msgstr ""
+
+#: src/platforms/tvos.md:10
+msgid "Xcode (full install) for tvOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/tvos.md:11
+msgid "Rust tvOS targets:"
+msgstr ""
+
+#: src/platforms/tvos.md:22
+msgid ""
+"This produces an ARM64 binary linked with `clang` against the tvOS Simulator"
+" SDK, wrapped in a `.app` bundle."
+msgstr ""
+
+#: src/platforms/tvos.md:30
+msgid "This produces an ARM64 binary for physical Apple TV hardware."
+msgstr ""
+
+#: src/platforms/tvos.md:35
+msgid "# Auto-detect booted Apple TV simulator\n"
+msgstr ""
+
+#: src/platforms/tvos.md:39
+msgid ""
+"Perry auto-discovers booted Apple TV simulators. To install and launch "
+"manually:"
+msgstr ""
+
+#: src/platforms/tvos.md:48
+msgid "Perry maps UI widgets to UIKit controls on tvOS, identical to iOS:"
+msgstr ""
+
+#: src/platforms/tvos.md:50 src/platforms/tvos.md:149
+#: src/platforms/watchos.md:50 src/system/media.md:37
+#: src/testing/geisterhand.md:257 src/cli/flags.md:20
+msgid "Notes"
+msgstr ""
+
+#: src/platforms/tvos.md:53
+msgid "Focus-based navigation"
+msgstr ""
+
+#: src/platforms/tvos.md:54
+msgid "On-screen keyboard via Siri Remote"
+msgstr ""
+
+#: src/platforms/tvos.md:56
+msgid "UISlider"
+msgstr ""
+
+#: src/platforms/tvos.md:60
+msgid "Focus-based scrolling"
+msgstr ""
+
+#: src/platforms/tvos.md:62
+msgid "Focus Engine"
+msgstr ""
+
+#: src/platforms/tvos.md:64
+msgid ""
+"tvOS uses a **focus-based navigation model** instead of direct touch. The "
+"Siri Remote's touchpad and directional buttons move focus between focusable "
+"views. Perry widgets that support interaction (buttons, text fields, "
+"toggles, etc.) are automatically focusable."
+msgstr ""
+
+#: src/platforms/tvos.md:66
+msgid "Game Engine Support"
+msgstr ""
+
+#: src/platforms/tvos.md:68
+msgid ""
+"tvOS is particularly well-suited for game engines. When using a native "
+"library like [Bloom](https://bloomengine.dev), the game engine handles its "
+"own windowing, rendering, and input."
+msgstr ""
+
+#: src/platforms/tvos.md:70
+msgid ""
+"**Status:** illustrative only — Bloom is an external native library (see "
+"[bloomengine.dev](https://bloomengine.dev)). The snippet below is left as "
+"`,no-test` because it depends on Bloom's `.a`/`.so` being available at link "
+"time; the doc-tests harness compiles every other snippet on this page."
+msgstr ""
+
+#: src/platforms/tvos.md:72
+msgid ""
+"```text\n"
+"import { initWindow, windowShouldClose, beginDrawing, endDrawing,\n"
+"         clearBackground, isGamepadButtonDown, Colors } from \"bloom\";\n"
+"\n"
+"initWindow(1920, 1080, \"My Apple TV Game\");\n"
+"\n"
+"while (!windowShouldClose()) {\n"
+"  beginDrawing();\n"
+"  clearBackground(Colors.BLACK);\n"
+"\n"
+"  if (isGamepadButtonDown(0)) {\n"
+"    // A button (Siri Remote select) pressed\n"
+"  }\n"
+"\n"
+"  endDrawing();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:90
+msgid "Input on tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:92
+msgid "The Siri Remote acts as a game controller:"
+msgstr ""
+
+#: src/platforms/tvos.md:94
+msgid "Input"
+msgstr ""
+
+#: src/platforms/tvos.md:94
+msgid "Mapping"
+msgstr ""
+
+#: src/platforms/tvos.md:96
+msgid "Touchpad swipe"
+msgstr ""
+
+#: src/platforms/tvos.md:96
+msgid "Gamepad axes 0/1 (left stick)"
+msgstr ""
+
+#: src/platforms/tvos.md:97
+msgid "Touchpad click (Select)"
+msgstr ""
+
+#: src/platforms/tvos.md:97
+msgid "Gamepad button 0 (A) + mouse button 0"
+msgstr ""
+
+#: src/platforms/tvos.md:98
+msgid "Menu button"
+msgstr ""
+
+#: src/platforms/tvos.md:98
+msgid "Gamepad button 1 (B)"
+msgstr ""
+
+#: src/platforms/tvos.md:99
+msgid "Play/Pause button"
+msgstr ""
+
+#: src/platforms/tvos.md:99
+msgid "Gamepad button 9 (Start)"
+msgstr ""
+
+#: src/platforms/tvos.md:100
+msgid "Arrow presses (up/down/left/right)"
+msgstr ""
+
+#: src/platforms/tvos.md:100
+msgid "Gamepad D-pad buttons (12-15)"
+msgstr ""
+
+#: src/platforms/tvos.md:102
+msgid ""
+"Extended game controllers (MFi, PlayStation, Xbox) are fully supported with "
+"all axes, buttons, triggers, and D-pad mapped through the standard gamepad "
+"API."
+msgstr ""
+
+#: src/platforms/tvos.md:106
+msgid ""
+"tvOS apps use `UIApplicationMain` with the same lifecycle as iOS. When using"
+" `perry/ui`:"
+msgstr ""
+
+#: src/platforms/tvos.md:108
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My TV App\",\n"
+"    width: 1920,\n"
+"    height: 1080,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello, Apple TV!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:121
+msgid ""
+"When using a game engine with `--features ios-game-loop`, the runtime starts"
+" `UIApplicationMain` on the main thread and runs your game code on a "
+"dedicated game thread."
+msgstr ""
+
+#: src/platforms/tvos.md:125
+msgid "Configure tvOS settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/tvos.md:127
+msgid ""
+"```toml\n"
+"[tvos]\n"
+"bundle_id = \"com.example.mytvapp\"\n"
+"deployment_target = \"17.0\"\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:135
+msgid "Use `__platform__ === 6` to detect tvOS at compile time:"
+msgstr ""
+
+#: src/platforms/tvos.md:137
+msgid ""
+"```typescript\n"
+"function reportTvos(): void {\n"
+"    if (__platform__ === 6) {\n"
+"        console.log(\"Running on tvOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:145
+msgid "App Bundle"
+msgstr ""
+
+#: src/platforms/tvos.md:147
+msgid "Perry generates a `.app` bundle with an `Info.plist` containing:"
+msgstr ""
+
+#: src/platforms/tvos.md:149 src/cli/perry-toml.md:367
+msgid "Key"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "`UIDeviceFamily`"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "`[3]`"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "Apple TV"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "`MinimumOSVersion`"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "`17.0`"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "tvOS 17+"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "`UIRequiresFullScreen`"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "`true`"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "All tvOS apps are full-screen"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "`UILaunchStoryboardName`"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "`LaunchScreen`"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "Required by tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:158
+msgid ""
+"tvOS has inherent platform constraints compared to other Perry targets:"
+msgstr ""
+
+#: src/platforms/tvos.md:160
+msgid "**No camera**: Apple TV has no camera hardware"
+msgstr ""
+
+#: src/platforms/tvos.md:161
+msgid "**No clipboard**: UIPasteboard is not available on tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:162
+msgid "**No file dialogs**: No document picker"
+msgstr ""
+
+#: src/platforms/tvos.md:163
+msgid "**No QR code**: No camera for scanning"
+msgstr ""
+
+#: src/platforms/tvos.md:164
+msgid "**No multi-window**: Single full-screen window only"
+msgstr ""
+
+#: src/platforms/tvos.md:165
+msgid ""
+"**No direct touch**: Input is via Siri Remote focus engine and game "
+"controllers"
+msgstr ""
+
+#: src/platforms/tvos.md:166
+msgid ""
+"**Resolution**: Design for 1920x1080 (1080p) or 3840x2160 (4K) displays"
+msgstr ""
+
+#: src/platforms/tvos.md:168 src/platforms/watchos.md:206
+msgid "Differences from iOS"
+msgstr ""
+
+#: src/platforms/tvos.md:170
+msgid "Aspect"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "**Input**"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "Siri Remote + game controllers (focus engine)"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "Direct touch"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "**Display**"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "Full-screen only (1080p/4K)"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "Variable screen sizes"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "**Device family**"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "`[3]` (Apple TV)"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "`[1, 2]` (iPhone/iPad)"
+msgstr ""
+
+#: src/platforms/tvos.md:175
+msgid "**Camera**"
+msgstr ""
+
+#: src/platforms/tvos.md:175 src/platforms/tvos.md:176
+msgid "Not available"
+msgstr ""
+
+#: src/platforms/tvos.md:175 src/platforms/tvos.md:176
+msgid "Available"
+msgstr ""
+
+#: src/platforms/tvos.md:176
+msgid "**Clipboard**"
+msgstr ""
+
+#: src/platforms/tvos.md:177
+msgid "**Deployment target**"
+msgstr ""
+
+#: src/platforms/tvos.md:177
+msgid "17.0"
+msgstr ""
+
+#: src/platforms/tvos.md:178
+msgid "**UI framework**"
+msgstr ""
+
+#: src/platforms/tvos.md:178
+msgid "UIKit (same as iOS)"
+msgstr ""
+
+#: src/platforms/tvos.md:182
+msgid "[iOS](ios.md) — iOS platform reference (shared UIKit base)"
+msgstr ""
+
+#: src/platforms/tvos.md:183
+msgid "[watchOS](watchos.md) — watchOS platform reference"
+msgstr ""
+
+#: src/platforms/watchos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple Watch devices and the watchOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/watchos.md:5
+msgid ""
+"Since watchOS does not support UIKit views, Perry uses a **data-driven "
+"SwiftUI renderer**: your TypeScript code builds a UI tree via the standard "
+"`perry/ui` API, and a fixed SwiftUI runtime (shipped with Perry) queries the"
+" tree and renders it reactively. No code generation or transpilation is "
+"involved — the binary is fully native."
+msgstr ""
+
+#: src/platforms/watchos.md:10
+msgid "Xcode (full install) for watchOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/watchos.md:11
+msgid "Rust watchOS targets:"
+msgstr ""
+
+#: src/platforms/watchos.md:22
+msgid ""
+"This produces an ARM64 binary linked with `swiftc` against the watchOS "
+"Simulator SDK, wrapped in a `.app` bundle."
+msgstr ""
+
+#: src/platforms/watchos.md:30
+msgid ""
+"This produces an arm64_32 (ILP32) binary for physical Apple Watch hardware. "
+"Apple Watch uses 32-bit pointers on 64-bit ARM."
+msgstr ""
+
+#: src/platforms/watchos.md:35
+msgid "# Auto-detect booted watch simulator\n"
+msgstr ""
+
+#: src/platforms/watchos.md:39
+msgid ""
+"Perry auto-discovers booted Apple Watch simulators. To install and launch "
+"manually:"
+msgstr ""
+
+#: src/platforms/watchos.md:48
+msgid "Perry maps UI widgets to SwiftUI views via a data-driven bridge:"
+msgstr ""
+
+#: src/platforms/watchos.md:50
+msgid "SwiftUI View"
+msgstr ""
+
+#: src/platforms/watchos.md:52
+msgid "Font size, weight, color, wrapping"
+msgstr ""
+
+#: src/platforms/watchos.md:53
+msgid "Tap action via native closure callback"
+msgstr ""
+
+#: src/platforms/watchos.md:54 src/platforms/watchos.md:55
+msgid "With spacing"
+msgstr ""
+
+#: src/platforms/watchos.md:56
+msgid "Layered views"
+msgstr ""
+
+#: src/platforms/watchos.md:59
+msgid "Two-way state binding"
+msgstr ""
+
+#: src/platforms/watchos.md:60
+msgid "Min/max/value, state binding"
+msgstr ""
+
+#: src/platforms/watchos.md:61
+msgid "Image(systemName:)"
+msgstr ""
+
+#: src/platforms/watchos.md:61
+msgid "SF Symbols"
+msgstr ""
+
+#: src/platforms/watchos.md:63
+msgid "Linear"
+msgstr ""
+
+#: src/platforms/watchos.md:64
+msgid "Selection list"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "Form"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "List"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "Maps to List on watchOS"
+msgstr ""
+
+#: src/platforms/watchos.md:66 src/platforms/android.md:39
+#: src/platforms/linux.md:50
+msgid "NavigationStack"
+msgstr ""
+
+#: src/platforms/watchos.md:66
+msgid "Push navigation"
+msgstr ""
+
+#: src/platforms/watchos.md:68 src/widgets/components.md:136
+msgid "Modifiers"
+msgstr ""
+
+#: src/platforms/watchos.md:70
+msgid "All widgets support these styling modifiers:"
+msgstr ""
+
+#: src/platforms/watchos.md:72
+msgid "`foregroundColor` / `backgroundColor`"
+msgstr ""
+
+#: src/platforms/watchos.md:73
+msgid "`font` (size, weight, family)"
+msgstr ""
+
+#: src/platforms/watchos.md:74
+msgid "`frame` (width, height)"
+msgstr ""
+
+#: src/platforms/watchos.md:75
+msgid "`padding` (uniform or per-edge)"
+msgstr ""
+
+#: src/platforms/watchos.md:76
+msgid "`cornerRadius`"
+msgstr ""
+
+#: src/platforms/watchos.md:78
+msgid "`hidden` / `disabled`"
+msgstr ""
+
+#: src/platforms/watchos.md:82
+msgid ""
+"watchOS apps use SwiftUI's `@main App` pattern. Perry's PerryWatchApp.swift "
+"runtime handles the app lifecycle automatically:"
+msgstr ""
+
+#: src/platforms/watchos.md:84
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack, Button } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My Watch App\",\n"
+"    width: 200,\n"
+"    height: 200,\n"
+"    body: VStack(8, [\n"
+"        Text(\"Hello, Apple Watch!\"),\n"
+"        Button(\"Tap me\", () => {\n"
+"            console.log(\"Button tapped!\")\n"
+"        }),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:100
+msgid "Under the hood:"
+msgstr ""
+
+#: src/platforms/watchos.md:101
+msgid ""
+"`perry_main_init()` runs your compiled TypeScript, which builds the UI tree "
+"in memory"
+msgstr ""
+
+#: src/platforms/watchos.md:102
+msgid "The SwiftUI `@main` struct observes the tree version and renders it"
+msgstr ""
+
+#: src/platforms/watchos.md:103
+msgid ""
+"User interactions (button taps, toggle changes) call back into native "
+"closures"
+msgstr ""
+
+#: src/platforms/watchos.md:107
+msgid "Reactive state works the same as other platforms:"
+msgstr ""
+
+#: src/platforms/watchos.md:109 src/platforms/wasm.md:166
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack, Button, State } from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"App({\n"
+"    title: \"Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Count: ${count.value}`),\n"
+"        Button(\"Increment\", () => count.set(count.value + 1)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:125
+msgid ""
+"When `state.set()` is called, the tree version increments and SwiftUI re-"
+"renders the affected views automatically."
+msgstr ""
+
+#: src/platforms/watchos.md:129
+msgid ""
+"Unlike iOS (UIKit) and macOS (AppKit), where Perry calls native view APIs "
+"directly via FFI, watchOS uses a **data-driven architecture**:"
+msgstr ""
+
+#: src/platforms/watchos.md:147
+msgid ""
+"The `PerryWatchApp.swift` file is a fixed runtime (~280 lines) that ships "
+"with Perry. It never changes per-app — it's the watchOS equivalent of "
+"`libperry_ui_ios.a`."
+msgstr ""
+
+#: src/platforms/watchos.md:151
+msgid "Configure watchOS settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/watchos.md:153
+msgid ""
+"```toml\n"
+"[watchos]\n"
+"bundle_id = \"com.example.mywatch\"\n"
+"deployment_target = \"10.0\"\n"
+"\n"
+"[watchos.info_plist]\n"
+"NSLocationWhenInUseUsageDescription = \"Used for location features\"\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:162
+msgid "Set up signing credentials with:"
+msgstr ""
+
+#: src/platforms/watchos.md:168
+msgid ""
+"This shares App Store Connect credentials with iOS/macOS (same team, API "
+"key, issuer)."
+msgstr ""
+
+#: src/platforms/watchos.md:172
+msgid "Use `__platform__ === 7` to detect watchOS at compile time:"
+msgstr ""
+
+#: src/platforms/watchos.md:174
+msgid ""
+"```typescript\n"
+"function reportWatchos(): void {\n"
+"    if (__platform__ === 7) {\n"
+"        console.log(\"Running on watchOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:182
+msgid "watchOS Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/watchos.md:184
+msgid ""
+"Perry also supports watchOS WidgetKit complications (separate from full "
+"apps):"
+msgstr ""
+
+#: src/platforms/watchos.md:190
+msgid ""
+"See [watchOS Complications](../widgets/watchos.md) for widget-specific "
+"documentation."
+msgstr ""
+
+#: src/platforms/watchos.md:194
+msgid ""
+"watchOS apps have inherent platform constraints compared to other Perry "
+"targets:"
+msgstr ""
+
+#: src/platforms/watchos.md:196
+msgid "**No Canvas**: CoreGraphics drawing is not available"
+msgstr ""
+
+#: src/platforms/watchos.md:197
+msgid "**No Camera**: watchOS does not support camera APIs"
+msgstr ""
+
+#: src/platforms/watchos.md:198
+msgid "**No TextField**: Text input is extremely limited on Apple Watch"
+msgstr ""
+
+#: src/platforms/watchos.md:199
+msgid "**No File Dialogs**: No document picker"
+msgstr ""
+
+#: src/platforms/watchos.md:200
+msgid "**No Menu Bar / Toolbar**: Not applicable on watch"
+msgstr ""
+
+#: src/platforms/watchos.md:201
+msgid "**No Multi-Window**: Single window only"
+msgstr ""
+
+#: src/platforms/watchos.md:202
+msgid "**No QR Code**: Screen too small for practical QR display"
+msgstr ""
+
+#: src/platforms/watchos.md:203
+msgid ""
+"**Memory**: watchOS devices have ~50-75MB available RAM — keep apps "
+"lightweight"
+msgstr ""
+
+#: src/platforms/watchos.md:204
+msgid "**Screen size**: Design for 40-49mm watch faces"
+msgstr ""
+
+#: src/platforms/watchos.md:208
+msgid ""
+"**SwiftUI vs UIKit**: watchOS uses SwiftUI rendering; iOS uses UIKit "
+"directly"
+msgstr ""
+
+#: src/platforms/watchos.md:209
+msgid "**No splash screen**: watchOS apps don't use launch storyboards"
+msgstr ""
+
+#: src/platforms/watchos.md:210
+msgid ""
+"**Standalone**: watchOS apps are standalone (no iPhone companion required, "
+"`WKWatchOnly = true`)"
+msgstr ""
+
+#: src/platforms/watchos.md:211
+msgid ""
+"**Device family**: `UIDeviceFamily = [4]` (watch) vs `[1, 2]` (iPhone/iPad)"
+msgstr ""
+
+#: src/platforms/watchos.md:215
+msgid ""
+"[watchOS Complications](../widgets/watchos.md) — WidgetKit complications"
+msgstr ""
+
+#: src/platforms/watchos.md:216
+msgid "[iOS](ios.md) — iOS platform reference"
+msgstr ""
+
+#: src/platforms/android.md:3
+msgid ""
+"Perry compiles TypeScript apps for Android using JNI (Java Native "
+"Interface)."
+msgstr ""
+
+#: src/platforms/android.md:7
+msgid "Android NDK"
+msgstr ""
+
+#: src/platforms/android.md:8
+msgid "Android SDK"
+msgstr ""
+
+#: src/platforms/android.md:9
+msgid "Rust Android targets:"
+msgstr ""
+
+#: src/platforms/android.md:22
+msgid "Perry maps UI widgets to Android views via JNI:"
+msgstr ""
+
+#: src/platforms/android.md:24
+msgid "Android Class"
+msgstr ""
+
+#: src/platforms/android.md:26
+msgid "TextView"
+msgstr ""
+
+#: src/platforms/android.md:28
+msgid "EditText"
+msgstr ""
+
+#: src/platforms/android.md:29
+msgid "EditText (ES_PASSWORD)"
+msgstr ""
+
+#: src/platforms/android.md:30
+msgid "Switch"
+msgstr ""
+
+#: src/platforms/android.md:31
+msgid "SeekBar"
+msgstr ""
+
+#: src/platforms/android.md:32
+msgid "Spinner + ArrayAdapter"
+msgstr ""
+
+#: src/platforms/android.md:33
+msgid "ImageView"
+msgstr ""
+
+#: src/platforms/android.md:34
+msgid "LinearLayout (vertical)"
+msgstr ""
+
+#: src/platforms/android.md:35
+msgid "LinearLayout (horizontal)"
+msgstr ""
+
+#: src/platforms/android.md:36 src/platforms/android.md:39
+msgid "FrameLayout"
+msgstr ""
+
+#: src/platforms/android.md:38
+msgid "Canvas + Bitmap"
+msgstr ""
+
+#: src/platforms/android.md:41
+msgid "Android-Specific APIs"
+msgstr ""
+
+#: src/platforms/android.md:43
+msgid "**Dark mode**: `Configuration.uiMode` detection"
+msgstr ""
+
+#: src/platforms/android.md:44
+msgid "**Preferences**: SharedPreferences"
+msgstr ""
+
+#: src/platforms/android.md:45
+msgid "**Keychain**: Android Keystore"
+msgstr ""
+
+#: src/platforms/android.md:46
+msgid "**Notifications**: NotificationManager"
+msgstr ""
+
+#: src/platforms/android.md:47
+msgid "**Open URL**: `Intent.ACTION_VIEW`"
+msgstr ""
+
+#: src/platforms/android.md:48
+msgid "**Alerts**: `PerryBridge.showAlert`"
+msgstr ""
+
+#: src/platforms/android.md:49
+msgid "**Sheets**: Dialog (modal)"
+msgstr ""
+
+#: src/platforms/android.md:53
+msgid ""
+"Perry's Android template includes a splash theme (`Theme.Perry.Splash`) that"
+" displays a `windowBackground` drawable during cold start. Configure it via "
+"`perry.splash` in `package.json`:"
+msgstr ""
+
+#: src/platforms/android.md:66
+msgid ""
+"The image is centered via a `layer-list` drawable with a solid background "
+"color. The activity switches to the normal theme in `onCreate` before "
+"inflating the layout, so the splash disappears as soon as the app is ready."
+msgstr ""
+
+#: src/platforms/android.md:68
+msgid "For full control, provide custom drawable and theme XML files:"
+msgstr ""
+
+#: src/platforms/android.md:85
+msgid "Differences from Desktop"
+msgstr ""
+
+#: src/platforms/android.md:87
+msgid "**Touch-only**: No hover events, no right-click context menus"
+msgstr ""
+
+#: src/platforms/android.md:88
+msgid "**Single window**: Multi-window maps to Dialog views"
+msgstr ""
+
+#: src/platforms/android.md:89
+msgid "**Toolbar**: Horizontal LinearLayout"
+msgstr ""
+
+#: src/platforms/android.md:90
+msgid "**Font**: Typeface-based font family support"
+msgstr ""
+
+#: src/platforms/harmonyos.md:3
+msgid ""
+"Perry compiles TypeScript apps for HarmonyOS NEXT (Huawei's mobile OS) by "
+"emitting **declarative ArkUI** alongside a logic-only `.so` library. The "
+"same TypeScript source that targets macOS, iOS, Android, Linux, and Windows "
+"also runs natively on HarmonyOS — no platform-specific adapters needed in "
+"user code."
+msgstr ""
+
+#: src/platforms/harmonyos.md:7
+msgid ""
+"HarmonyOS NEXT runs apps via the ArkTS runtime, which owns the UI tree. "
+"Perry can't lower `perry/ui` calls to the imperative AppKit/UIKit/etc shape "
+"used on every other platform — it has to play by ArkTS's declarative rules. "
+"So the harmonyos target is structured differently:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:26
+msgid ""
+"The user splices three artifacts into a DevEco Studio project — "
+"`libentry.so`, `pages/Index.ets`, `cpp/types/libentry/Index.d.ts` — and "
+"DevEco signs + runs as usual. Tap interactions, text input, etc. fire NAPI "
+"calls into the `.so`, which dispatch the registered Perry closure bodies."
+msgstr ""
+
+#: src/platforms/harmonyos.md:28
+msgid "What's supported"
+msgstr ""
+
+#: src/platforms/harmonyos.md:30
+msgid "**Widgets** (introduced in v0.5.401, expanded in v0.5.418, v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:32
+msgid "Widget"
+msgstr ""
+
+#: src/platforms/harmonyos.md:32
+msgid "ArkUI emission"
+msgstr ""
+
+#: src/platforms/harmonyos.md:34
+msgid "`Text(content)` / `Text(content, \"id\")`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:34
+msgid "`Text(...).fontSize(20)` (reactive when id is given)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:35
+msgid "`VStack(children)` / `VStack(spacing, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:35
+msgid "`Column({ space })`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:36
+msgid "`HStack(children)` / `HStack(spacing, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:36
+msgid "`Row({ space })`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:37
+msgid "`Button(label, onPress)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:37
+msgid "`Button(...).onClick(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:38
+msgid "`TextField(placeholder, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:38
+msgid "`TextInput(...).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:39
+msgid "`Toggle(label, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:39
+msgid "`Toggle({type: ToggleType.Switch}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:40
+msgid "`Slider(min, max, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:40
+msgid "`Slider({...}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:41
+msgid "`Spacer()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:41
+msgid "`Blank()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:42
+msgid "`Divider()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:43
+msgid "`Image(src)` / `ImageFile(path)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:43
+msgid "`Image(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:44
+msgid "`ScrollView(children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:44
+msgid "`Scroll() { Column() { ... } }`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:45
+msgid "`LazyVStack(children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:45
+msgid "`Column({...})` (eager — see v10 follow-up)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:46
+msgid "`Picker(options, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:46
+msgid "`TextPicker({...}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:47
+msgid "`ProgressView(value, total)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:47
+msgid "`Progress({type: ProgressType.Linear})`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:48
+msgid "`Section(title, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:48
+msgid "`Column({ space: 4 }) { Text(title) ... }`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:50
+msgid "**Event handling** (v0.5.417 + v0.5.421):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:51
+msgid "`Button.onPress` → `invokeCallback(idx)` via NAPI"
+msgstr ""
+
+#: src/platforms/harmonyos.md:52
+msgid ""
+"`Toggle.onChange((isOn: boolean) => ...)` → `invokeCallback1(idx, isOn)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:53
+msgid ""
+"`TextField.onChange((value: string) => ...)` → `invokeCallback1(idx, value)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:54
+msgid ""
+"`Slider.onChange((value: number) => ...)` → `invokeCallback1(idx, value)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:55
+msgid ""
+"`Picker.onChange((idx: number) => ...)` → `invokeCallback1(idx, index)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:57
+msgid "**Reactivity** (v0.5.419 + v0.5.421):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:58
+msgid ""
+"`Text(\"0\", \"counter\")` registers a reactive slot bound to a generated "
+"`@State text_counter: string` field."
+msgstr ""
+
+#: src/platforms/harmonyos.md:59
+msgid ""
+"`setText(\"counter\", \"5\")` from inside any closure updates the Text on-"
+"screen."
+msgstr ""
+
+#: src/platforms/harmonyos.md:61
+msgid "**Toast banners** (v0.5.419):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:62
+msgid ""
+"`showToast(\"Saved!\")` from inside any closure shows an ArkUI "
+"`promptAction.showToast({ message })` banner."
+msgstr ""
+
+#: src/platforms/harmonyos.md:64
+msgid "**Inline styling** (v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:65
+msgid ""
+"`Text(\"hi\", { fontSize: 16, color: \"red\" })` maps to "
+"`.fontSize(16).fontColor('red')`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:66
+msgid ""
+"Supported props: `backgroundColor`, `color`, `fontSize`, `fontWeight`, "
+"`fontFamily`, `borderRadius`, `padding` (number or per-side object), "
+"`opacity`, `hidden`, `borderColor` + `borderWidth` (combined as "
+"`.border({...})`)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:67
+msgid "PerryColor objects (`{r,g,b,a}`) auto-convert to `rgba(...)` strings."
+msgstr ""
+
+#: src/platforms/harmonyos.md:69
+msgid "**Dynamic lists** (v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:70
+msgid ""
+"`VStack(items.map(item => Text(item)))` lowers to ArkUI `ForEach(items, "
+"(__item) => { Text(__item) }, (__item) => __item)`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:71
+msgid ""
+"Single-arg map closures only; complex array sources require Phase 2 v6 state"
+" binding."
+msgstr ""
+
+#: src/platforms/harmonyos.md:73
+msgid "Setup"
+msgstr ""
+
+#: src/platforms/harmonyos.md:75
+msgid ""
+"**Install DevEco Studio** + the OpenHarmony SDK from Huawei. Verified "
+"working with DevEco Studio 6.0.2 + OpenHarmony 5.0+."
+msgstr ""
+
+#: src/platforms/harmonyos.md:77
+msgid "**Run the setup wizard once** (introduced in v0.5.380):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:83
+msgid ""
+"The wizard auto-discovers your DevEco-generated debug certificates from "
+"`~/.ohos/config/`, prompts for the keystore password, and persists the "
+"configuration to `~/.perry/config.toml`. Subsequent `perry compile --target "
+"harmonyos` invocations sign HAPs automatically."
+msgstr ""
+
+#: src/platforms/harmonyos.md:85
+msgid ""
+"**Optional**: install `hdc` (HarmonyOS Device Connector) for emulator "
+"interaction. It ships inside DevEco at "
+"`Contents/sdk/default/openharmony/toolchains/hdc`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:87
+msgid "Compile + run workflow"
+msgstr ""
+
+#: src/platforms/harmonyos.md:89
+msgid "Write a TypeScript program with `App({body: ...})`:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:91
+msgid ""
+"```typescript,no-test\n"
+"// hi.ts\n"
+"import { App, VStack, Text, Button, showToast } from \"perry/ui\";\n"
+"\n"
+"let count = 0;\n"
+"\n"
+"App({\n"
+"  title: \"Perry on HarmonyOS\",\n"
+"  body: VStack([\n"
+"    Text(\"Count: 0\", \"counter\"),\n"
+"    Button(\"+\", () => {\n"
+"      count++;\n"
+"      setText(\"counter\", `Count: ${count}`);\n"
+"    }),\n"
+"    Button(\"Notify\", () => {\n"
+"      showToast(`Counter is ${count}`);\n"
+"    }),\n"
+"  ]),\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/platforms/harmonyos.md:112
+msgid "Compile for HarmonyOS:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:118
+msgid "This produces three artifacts in `/tmp/`:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:120
+msgid "`libentry.so` — the compiled `.so` (8-9 MB typically)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:121
+msgid "`ets/pages/Index.ets` — the auto-emitted ArkUI page"
+msgstr ""
+
+#: src/platforms/harmonyos.md:122
+msgid "`cpp/types/libentry/Index.d.ts` — the NAPI declaration file"
+msgstr ""
+
+#: src/platforms/harmonyos.md:124
+msgid "**Splice** into a DevEco Studio project:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:132
+msgid ""
+"Click ▶ Run in DevEco — DevEco's hvigor signs + bundles the HAP and installs"
+" onto the emulator (or attached device). The app launches, taps fire your TS"
+" closures, and the screen updates reactively."
+msgstr ""
+
+#: src/platforms/harmonyos.md:134
+msgid "Architecture deep dive"
+msgstr ""
+
+#: src/platforms/harmonyos.md:136
+msgid "The harvest model"
+msgstr ""
+
+#: src/platforms/harmonyos.md:138
+msgid ""
+"`perry-codegen-arkts::emit_index_ets` walks `module.init` looking for the "
+"first `App({body: <expr>})` call from `perry/ui`. It extracts the `body` "
+"field, recursively emits ArkUI source for each widget in the tree, and "
+"**destructively replaces the App call with `Stmt::Expr(Expr::Number(0.0))`**"
+" so the LLVM backend never sees `perry_ui_*` FFI calls (which would be "
+"unresolved on the OHOS target — there's no `perry-ui-harmonyos` crate by "
+"design)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:140
+msgid ""
+"The emitted Index.ets is a real ArkUI `@Entry @Component struct Index { "
+"build() { ... } }` page with `@State` declarations for any reactive Text "
+"widgets, `import promptAction from '@ohos.promptAction'` for toast routing, "
+"and per-Button onClick handlers that invoke NAPI callbacks then drain queued"
+" toasts and text updates."
+msgstr ""
+
+#: src/platforms/harmonyos.md:142
+msgid "Closures across the NAPI boundary"
+msgstr ""
+
+#: src/platforms/harmonyos.md:144
+msgid ""
+"Each Button/Toggle/etc onClick closure registers via "
+"`perry_arkts_register_callback(idx, closure_handle)` during `main()` "
+"startup. The `closure_handle` is a NaN-boxed pointer to a real Perry "
+"`*ClosureHeader`. A GC root scanner registered in `gc_init` keeps registered"
+" closures alive across collections."
+msgstr ""
+
+#: src/platforms/harmonyos.md:146
+msgid ""
+"When ArkUI fires an onClick, the auto-emitted `.onClick(() => "
+"perryEntry.invokeCallback(0))` calls back into the `.so` via NAPI. The "
+"`invoke_callback` NAPI handler in `crates/perry-runtime/src/ohos_napi.rs` "
+"reads the int32 idx, looks up the slot, and dispatches via "
+"`js_closure_call0`. Multi-arg variants (Toggle/TextField/Slider) use "
+"`invokeCallback1(idx, value)` with `napi_typeof` dispatch to NaN-box the "
+"value (boolean / string / number) before calling `js_closure_call1`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:148
+msgid "The drain queue pattern"
+msgstr ""
+
+#: src/platforms/harmonyos.md:150
+msgid ""
+"`showToast` and `setText` calls inside a closure body push entries onto "
+"thread-local queues:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:151
+msgid "`PENDING_TOASTS: Mutex<VecDeque<String>>`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:152
+msgid "`PENDING_TEXT_UPDATES: Mutex<VecDeque<(String, String)>>`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:154
+msgid ""
+"After every onClick/onChange invocation, the auto-emitted handler in "
+"Index.ets drains both queues:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:172
+msgid ""
+"`applyTextUpdate(id, value)` is a switch over registered Text ids that "
+"assigns to the matching `@State text_<id>: string` field — ArkUI's "
+"reactivity then rerenders the Text widget."
+msgstr ""
+
+#: src/platforms/harmonyos.md:174
+msgid "Why NAPI?"
+msgstr ""
+
+#: src/platforms/harmonyos.md:176
+msgid ""
+"HarmonyOS NEXT uses the OpenHarmony NAPI binding (modeled on Node's NAPI) to"
+" load native `.so` libraries from ArkTS. Perry's `crates/perry-"
+"runtime/src/ohos_napi.rs` registers a module via `napi_module_register` in "
+"an `.init_array` constructor (Rust's equivalent of "
+"`__attribute__((constructor))`), with the modname auto-derived from the "
+"`.so` filename via `dladdr`. The exported NAPI surface is just `run` / "
+"`invokeCallback` / `invokeCallback1` / `drainToast` / `drainTextUpdate` — "
+"every other Perry runtime call happens within the `.so` itself."
+msgstr ""
+
+#: src/platforms/harmonyos.md:178
+msgid "Known limitations"
+msgstr ""
+
+#: src/platforms/harmonyos.md:180
+msgid ""
+"**LazyVStack is currently rendered eagerly** as a plain `Column`. Real lazy "
+"rendering for big lists needs ArkUI's `LazyForEach` + a custom `IDataSource`"
+" impl — tracked as Phase 2 v10."
+msgstr ""
+
+#: src/platforms/harmonyos.md:181
+msgid ""
+"**State binding is one-way** — `setText(\"id\", value)` from a closure "
+"updates the Text on-screen, but a generic `state<T>` reactive container "
+"(`const count = state(0); count.set(...)`) is Phase 2 v6 follow-up work."
+msgstr ""
+
+#: src/platforms/harmonyos.md:182
+msgid ""
+"**Multi-page navigation** (NavStack / Router across multiple `.ets` files) "
+"is Phase 2 v11."
+msgstr ""
+
+#: src/platforms/harmonyos.md:183
+msgid ""
+"**AppGallery production signing** uses a different cert chain than DevEco's "
+"debug certs and isn't yet plumbed into `perry compile`. The current splice "
+"workflow handles debug-emulator deploy."
+msgstr ""
+
+#: src/platforms/harmonyos.md:184
+msgid ""
+"**Real device validation** is pending — every milestone has been verified on"
+" the Pura 90 Pro Max emulator. AppGallery upload + real-hardware install "
+"will follow."
+msgstr ""
+
+#: src/platforms/harmonyos.md:186
+msgid "Validated on emulator"
+msgstr ""
+
+#: src/platforms/harmonyos.md:188
+msgid ""
+"End-to-end on Pura 90 Pro Max with a 5-widget interactive page (counter + "
+"reset, TextField echoing input live as `You typed: <text>`, Toggle flipping "
+"`Notifications: on/off` with toast feedback, Slider tracking `Volume: N` "
+"continuously, reactive Texts everywhere). Each interaction routes:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:196
+msgid ""
+"This is the first time Perry-compiled TypeScript state mutation has "
+"reactively driven a HarmonyOS NEXT screen."
+msgstr ""
+
+#: src/platforms/harmonyos.md:198
+msgid "Version history"
+msgstr ""
+
+#: src/platforms/harmonyos.md:200
+msgid ""
+"**v0.5.401** — Phase 2 v1.5: full widget set rendering "
+"(Text/VStack/HStack/Button/TextField/Toggle/Slider/Spacer/Divider)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:201
+msgid ""
+"**v0.5.417** — Phase 2 v2 + v3 + v2.5: Button onClick callback bridge, "
+"showToast, reactive Text via setText, multi-arg Toggle/TextField/Slider "
+"value forwarding."
+msgstr ""
+
+#: src/platforms/harmonyos.md:202
+msgid ""
+"**v0.5.418** — Phase 2 v4: Image / ScrollView / LazyVStack / Picker / "
+"ProgressView / Section."
+msgstr ""
+
+#: src/platforms/harmonyos.md:203
+msgid ""
+"**v0.5.420 / .421** — Cross-platform showToast + setText on iOS / tvOS / "
+"visionOS / Android."
+msgstr ""
+
+#: src/platforms/harmonyos.md:204
+msgid ""
+"**v0.5.422 / .423** — Cross-platform showToast + setText on Windows / GTK4."
+msgstr ""
+
+#: src/platforms/harmonyos.md:205
+msgid ""
+"**v0.5.429** — Phase 2 v5: inline `style: { ... }` + ForEach via array.map."
+msgstr ""
+
+#: src/platforms/harmonyos.md:207
+msgid ""
+"For the full per-version detail see "
+"[CHANGELOG.md](https://github.com/PerryTS/perry/blob/main/CHANGELOG.md)."
+msgstr ""
+
+#: src/platforms/windows.md:3
+msgid "Perry compiles TypeScript apps for Windows using the Win32 API."
+msgstr ""
+
+#: src/platforms/windows.md:7
+msgid ""
+"Windows 10 or later by default (Windows 7 SP1 / Windows 8 supported via "
+"`--min-windows-version=7|8` — see [Windows 7 Compatibility](./windows-7.md) "
+"for the trade-offs)"
+msgstr ""
+
+#: src/platforms/windows.md:8
+msgid "A linker toolchain — either of these two options:"
+msgstr ""
+
+#: src/platforms/windows.md:10
+msgid "Option A — Lightweight (recommended, ~1.5 GB, no Visual Studio)"
+msgstr ""
+
+#: src/platforms/windows.md:12
+msgid ""
+"Uses LLVM's `clang` + `lld-link` plus an xwin'd copy of the Microsoft CRT + "
+"Windows SDK libraries. No admin rights, no Visual Studio install."
+msgstr ""
+
+#: src/platforms/windows.md:19
+msgid ""
+"`perry setup windows` downloads ~700 MB (unpacks to ~1.5 GB) at "
+"`%LOCALAPPDATA%\\perry\\windows-sdk` after prompting you to accept the "
+"Microsoft redistributable license. Pass `--accept-license` to skip the "
+"prompt in CI. Partial downloads resume safely on re-run."
+msgstr ""
+
+#: src/platforms/windows.md:21
+msgid "Option B — Visual Studio (~8 GB)"
+msgstr ""
+
+#: src/platforms/windows.md:23
+msgid ""
+"If you already have Visual Studio installed, add the C++ workload via the "
+"Visual Studio Installer → _Modify_ → check **Desktop development with C++**."
+" Or install standalone Build Tools:"
+msgstr ""
+
+#: src/platforms/windows.md:30
+msgid ""
+"Both options produce identical binaries — Perry picks Option A when the "
+"xwin'd sysroot is present, Option B otherwise. Run `perry doctor` to see "
+"which is active."
+msgstr ""
+
+#: src/platforms/windows.md:40
+msgid "Perry maps UI widgets to Win32 controls:"
+msgstr ""
+
+#: src/platforms/windows.md:42
+msgid "Win32 Class"
+msgstr ""
+
+#: src/platforms/windows.md:46
+msgid "Edit HWND"
+msgstr ""
+
+#: src/platforms/windows.md:47
+msgid "Edit (ES_PASSWORD)"
+msgstr ""
+
+#: src/platforms/windows.md:48
+msgid "Checkbox"
+msgstr ""
+
+#: src/platforms/windows.md:49
+msgid "Trackbar (TRACKBAR_CLASSW)"
+msgstr ""
+
+#: src/platforms/windows.md:50
+msgid "ComboBox"
+msgstr ""
+
+#: src/platforms/windows.md:51
+msgid "PROGRESS_CLASSW"
+msgstr ""
+
+#: src/platforms/windows.md:54
+msgid "WS_VSCROLL"
+msgstr ""
+
+#: src/platforms/windows.md:55
+msgid "GDI drawing"
+msgstr ""
+
+#: src/platforms/windows.md:56
+msgid "Form/Section"
+msgstr ""
+
+#: src/platforms/windows.md:56
+msgid "GroupBox"
+msgstr ""
+
+#: src/platforms/windows.md:58
+msgid "Windows-Specific APIs"
+msgstr ""
+
+#: src/platforms/windows.md:60
+msgid "**Menu bar**: HMENU / SetMenu"
+msgstr ""
+
+#: src/platforms/windows.md:61
+msgid "**Dark mode**: Windows Registry detection"
+msgstr ""
+
+#: src/platforms/windows.md:62
+msgid "**Preferences**: Windows Registry"
+msgstr ""
+
+#: src/platforms/windows.md:63
+msgid ""
+"**Keychain**: CredWrite/CredRead/CredDelete (Windows Credential Manager)"
+msgstr ""
+
+#: src/platforms/windows.md:64
+msgid "**Notifications**: Toast notifications"
+msgstr ""
+
+#: src/platforms/windows.md:65
+msgid "**File dialogs**: IFileOpenDialog / IFileSaveDialog (COM)"
+msgstr ""
+
+#: src/platforms/windows.md:66
+msgid "**Alerts**: MessageBoxW"
+msgstr ""
+
+#: src/platforms/windows.md:67
+msgid "**Open URL**: ShellExecuteW"
+msgstr ""
+
+#: src/platforms/windows-7.md:3
+msgid ""
+"Perry supports compiling executables that run on Windows 7 SP1 (and Windows "
+"8 / 8.1) — opt-in via the `--min-windows-version` flag. The default target "
+"stays Windows 10+ to preserve full DPI fidelity and modern OS integration; "
+"legacy support is one flag away when you need it."
+msgstr ""
+
+#: src/platforms/windows-7.md:5
+msgid ""
+"This page covers what works, what degrades, what's outright impossible, and "
+"how to validate your build before shipping."
+msgstr ""
+
+#: src/platforms/windows-7.md:7
+msgid "TL;DR"
+msgstr ""
+
+#: src/platforms/windows-7.md:13
+msgid ""
+"Produces a PE marked Win7-compatible. Perry's UI runtime resolves the "
+"Win10-only DPI APIs lazily at startup and falls back through Win8.1 → Vista "
+"primitives, so the binary starts on Win7 SP1. Most UI widgets work. Some "
+"cosmetic effects (rounded corners, dark titlebar) silently no-op. **No "
+"JavaScript-module imports allowed** on Win7 — the V8 runtime is Win10+ "
+"unconditional."
+msgstr ""
+
+#: src/platforms/windows-7.md:15
+msgid "Why this is opt-in"
+msgstr ""
+
+#: src/platforms/windows-7.md:17
+msgid ""
+"Two things make a Win7-compatible PE different from a default Perry build:"
+msgstr ""
+
+#: src/platforms/windows-7.md:19
+msgid ""
+"**The PE subsystem version field.** Default Perry builds let the linker pick"
+" (currently `/SUBSYSTEM:WINDOWS` with no version, which marks the binary as "
+"needing Win8+). Win7 needs `/SUBSYSTEM:WINDOWS,5.1` or "
+"`/SUBSYSTEM:CONSOLE,5.1`. The `,5.1` suffix is the [PE subsystem "
+"ABI](https://learn.microsoft.com/en-us/windows/win32/debug/pe-"
+"format#optional-header-windows-specific-fields-image-only) declaration of "
+"\"I claim to run on Windows NT 5.1 or higher\" — the OS loader reads this "
+"field before deciding whether to load the binary."
+msgstr ""
+
+#: src/platforms/windows-7.md:21
+msgid ""
+"**Win10-only API calls become runtime-resolved.** Perry's UI library calls "
+"`SetProcessDpiAwarenessContext` (Win10 1607) and `GetDpiForSystem` (Win10 "
+"1607) for per-monitor v2 DPI awareness. Hard-importing them via `extern "
+"\"system\"` would emit IAT entries that the OS resolves _before_ `main()` "
+"runs — on Win7, the loader fails the process with \"entry point not found in"
+" user32.dll\" before any Rust code can run. With `--min-windows-version=7` "
+"(and on default builds too — the retrofit is unconditional), Perry resolves "
+"these symbols lazily via `LoadLibraryW + GetProcAddress` and falls back "
+"through:"
+msgstr ""
+
+#: src/platforms/windows-7.md:23
+msgid "Tier"
+msgstr ""
+
+#: src/platforms/windows-7.md:23 src/plugins/appstore-review.md:54
+msgid "API"
+msgstr ""
+
+#: src/platforms/windows-7.md:23
+msgid "Min Windows"
+msgstr ""
+
+#: src/platforms/windows-7.md:25
+msgid "`SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)`"
+msgstr ""
+
+#: src/platforms/windows-7.md:25
+msgid "Windows 10 1607"
+msgstr ""
+
+#: src/platforms/windows-7.md:26
+msgid "`SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)`"
+msgstr ""
+
+#: src/platforms/windows-7.md:26
+msgid "Windows 8.1"
+msgstr ""
+
+#: src/platforms/windows-7.md:27
+msgid "`SetProcessDPIAware()`"
+msgstr ""
+
+#: src/platforms/windows-7.md:27
+msgid "Windows Vista"
+msgstr ""
+
+#: src/platforms/windows-7.md:29
+msgid ""
+"System DPI lookup uses the same lazy pattern: `GetDpiForSystem` (Win10) → "
+"`GetDC + GetDeviceCaps(LOGPIXELSY)` (Win2000+)."
+msgstr ""
+
+#: src/platforms/windows-7.md:31
+msgid ""
+"The `--min-windows-version` flag controls only (1) — the PE marker. The lazy"
+" DPI resolution from (2) is always active because it costs essentially "
+"nothing and makes default builds more robust against being run on stripped-"
+"down Windows installs."
+msgstr ""
+
+#: src/platforms/windows-7.md:33
+msgid "Accepted values"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "`--min-windows-version`"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Subsystem suffix"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Targets"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Default?"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "`10`"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "(none — linker default)"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "Windows 10+"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "yes"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "`8`"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "`,6.02`"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "Windows 8 / 8.1+"
+msgstr ""
+
+#: src/platforms/windows-7.md:38 src/platforms/windows-7.md:39
+msgid "no"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "`7`"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "`,5.1`"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "Windows 7 SP1+"
+msgstr ""
+
+#: src/platforms/windows-7.md:41
+msgid ""
+"Anything else is a hard error at compile time — typos like `--min-windows-"
+"version=11` fail loudly instead of silently behaving like the default."
+msgstr ""
+
+#: src/platforms/windows-7.md:43
+msgid "What works on Win7"
+msgstr ""
+
+#: src/platforms/windows-7.md:45
+msgid ""
+"The same audit that produced this feature found 12 KLOC of Win32 UI code in "
+"`perry-ui-windows` and 5 calls that touch Win10+ APIs. The 5 break down as 2"
+" hard blockers (now lazy-resolved) and 3 cosmetic-effect calls that already "
+"failed soft and silently no-op on Win7. So the bulk of the UI surface — "
+"every standard widget — works on Win7 SP1:"
+msgstr ""
+
+#: src/platforms/windows-7.md:47
+msgid ""
+"All layout containers (`VStack`, `HStack`, `ZStack`, `ScrollView`, `Spacer`,"
+" `Divider`)"
+msgstr ""
+
+#: src/platforms/windows-7.md:48
+msgid ""
+"All input widgets (`Button`, `TextField`, `SecureField`, `Toggle`, `Slider`,"
+" `Picker`, `ProgressView`)"
+msgstr ""
+
+#: src/platforms/windows-7.md:49
+msgid "`Text`, `Canvas`, `Image` (file + symbol)"
+msgstr ""
+
+#: src/platforms/windows-7.md:50
+msgid "`Form` and `LazyVStack`"
+msgstr ""
+
+#: src/platforms/windows-7.md:51
+msgid "File / folder open / save dialogs"
+msgstr ""
+
+#: src/platforms/windows-7.md:52
+msgid "Clipboard access"
+msgstr ""
+
+#: src/platforms/windows-7.md:53
+msgid "Audio (WASAPI is Vista+)"
+msgstr ""
+
+#: src/platforms/windows-7.md:54
+msgid "Keyboard shortcuts, menus, toolbars"
+msgstr ""
+
+#: src/platforms/windows-7.md:55
+msgid "Multi-window"
+msgstr ""
+
+#: src/platforms/windows-7.md:56
+msgid ""
+"The full `perry-runtime` and `perry-stdlib` surface — `fs`, `http`, "
+"`crypto`, `child_process`, `Date`, `Buffer`, etc."
+msgstr ""
+
+#: src/platforms/windows-7.md:58
+msgid "What degrades silently"
+msgstr ""
+
+#: src/platforms/windows-7.md:60
+msgid ""
+"These behaviors target Win10 / Win11 features. On Win7 the API call returns "
+"an error code that Perry already swallows; the binary runs, but the visual "
+"effect is missing:"
+msgstr ""
+
+#: src/platforms/windows-7.md:62
+msgid ""
+"**DPI quality.** Win7 has system-wide DPI only — moving a window between "
+"monitors with different DPI doesn't trigger re-scaling. Per-monitor v2 (font"
+" hinting, dialog scaling) is Win10 1607+."
+msgstr ""
+
+#: src/platforms/windows-7.md:63
+msgid ""
+"**Dark titlebar.** `DWMWA_USE_IMMERSIVE_DARK_MODE` is Win10 1809+. Titlebar "
+"follows the system theme on Win7 (light only on stock Win7)."
+msgstr ""
+
+#: src/platforms/windows-7.md:64
+msgid ""
+"**Rounded window corners.** `DWMWA_WINDOW_CORNER_PREFERENCE` is Win11+. "
+"Frameless windows have square corners on Win7 / Win10."
+msgstr ""
+
+#: src/platforms/windows-7.md:65
+msgid ""
+"**Mica / Acrylic backdrop.** `DWMWA_SYSTEMBACKDROP_TYPE` is Win11+. Backdrop"
+" falls through to the standard window background on Win7 / Win10."
+msgstr ""
+
+#: src/platforms/windows-7.md:67
+msgid "What is impossible"
+msgstr ""
+
+#: src/platforms/windows-7.md:69
+msgid ""
+"**`perry/jsruntime` (V8 / deno_core) is Win10+ unconditional.** Anything in "
+"your project that imports a `.js` module from `node_modules` triggers "
+"`--enable-jsruntime`, which links against deno_core, which embeds V8, which "
+"won't load on Win7. There's no fallback for this — Win7 builds must avoid "
+"JS-module imports entirely. If your project compiles cleanly without "
+"`--enable-jsruntime` (i.e. only TypeScript imports, only Perry-native "
+"packages), you're good."
+msgstr ""
+
+#: src/platforms/windows-7.md:71
+msgid ""
+"**Universal Windows Platform (UWP / WinRT) APIs.** Perry doesn't currently "
+"use these, but if a future feature does (e.g. modern toast notifications), "
+"it'll be Win10+ only. The runtime + stdlib audit was clean as of v0.5.395."
+msgstr ""
+
+#: src/platforms/windows-7.md:73
+msgid "How the lazy DPI resolution works"
+msgstr ""
+
+#: src/platforms/windows-7.md:75
+msgid ""
+"The retrofit lives in `crates/perry-ui-windows/src/dpi_compat.rs`. It "
+"exposes two functions, both safe to call on any Windows version from Vista "
+"onward:"
+msgstr ""
+
+#: src/platforms/windows-7.md:82
+msgid "Internally each function:"
+msgstr ""
+
+#: src/platforms/windows-7.md:84
+msgid ""
+"Calls `LoadLibraryA(\"user32.dll\")` (and `shcore.dll` for the Win8.1 tier) "
+"— both are loaded into every Win32 process by the kernel before `main`, so "
+"the call is a cheap handle lookup."
+msgstr ""
+
+#: src/platforms/windows-7.md:85
+msgid ""
+"Calls `GetProcAddress` to find the desired symbol. Caches the result "
+"(success or failure) in an `AtomicPtr` + `AtomicU8` pair, so the lookup runs"
+" at most once per process."
+msgstr ""
+
+#: src/platforms/windows-7.md:86
+msgid ""
+"Falls through to the next tier on miss. `set_process_dpi_awareness_compat` "
+"ends with `SetProcessDPIAware()` (Vista+, hard-imported because every "
+"supported Windows has it). `get_system_dpi_compat` ends with "
+"`GetDeviceCaps(LOGPIXELSY)` (Win2000+, dead reliable)."
+msgstr ""
+
+#: src/platforms/windows-7.md:88
+msgid ""
+"After the cache is warm — i.e. after `app_create` runs once — every "
+"subsequent DPI query is a single atomic load + indirect call. No measurable "
+"runtime cost vs. a hard-imported call."
+msgstr ""
+
+#: src/platforms/windows-7.md:90
+msgid "Validating a Win7 build"
+msgstr ""
+
+#: src/platforms/windows-7.md:92
+msgid ""
+"Perry's CI and dev hosts don't have Win7 VMs. If you ship to Win7 you need "
+"to validate the binary yourself. Three checks:"
+msgstr ""
+
+#: src/platforms/windows-7.md:94
+msgid "1. PE subsystem version"
+msgstr ""
+
+#: src/platforms/windows-7.md:96
+msgid ""
+"Use `dumpbin /headers app.exe | findstr \"subsystem\"` (MSVC) or `objdump -p"
+" app.exe | grep \"MajorOSVersion\"` (LLVM):"
+msgstr ""
+
+#: src/platforms/windows-7.md:98
+msgid ""
+"```text\n"
+"$ dumpbin /headers app.exe | findstr \"subsystem\"\n"
+"            5.01 subsystem version\n"
+"               2 subsystem (Windows GUI)\n"
+"```"
+msgstr ""
+
+#: src/platforms/windows-7.md:104
+msgid ""
+"The `5.01` confirms the PE is Win7-compatible. A default build shows `6.00` "
+"or higher."
+msgstr ""
+
+#: src/platforms/windows-7.md:106
+msgid "2. Imports"
+msgstr ""
+
+#: src/platforms/windows-7.md:108
+msgid ""
+"Use `dumpbin /imports app.exe | findstr /i \"user32\"` (MSVC) or `objdump -p"
+" app.exe | grep -A20 \"DLL Name: user32\"` (LLVM). Confirm that "
+"`SetProcessDpiAwarenessContext` and `GetDpiForSystem` are **not** in the "
+"user32.dll import list. If they are, the lazy retrofit isn't taking effect —"
+" likely you've added a `use "
+"windows::Win32::UI::HiDpi::SetProcessDpiAwarenessContext;` somewhere that "
+"pulls the symbol back in."
+msgstr ""
+
+#: src/platforms/windows-7.md:110
+msgid "3. Run on a Win7 SP1 VM"
+msgstr ""
+
+#: src/platforms/windows-7.md:112
+msgid ""
+"There's no substitute for actually launching the binary. Microsoft's free "
+"Win7 evaluation VM (no longer hosted directly by Microsoft, mirrored on "
+"archive.org) is the canonical reference image. Worth keeping a snapshot for "
+"regression checks."
+msgstr ""
+
+#: src/platforms/windows-7.md:114
+msgid "Caveats and gotchas"
+msgstr ""
+
+#: src/platforms/windows-7.md:116
+msgid ""
+"**The MSVC linker may warn** about subsystem version `,5.1` being below the "
+"C runtime's stated minimum on newer toolchains. The warning is benign — the "
+"CRT itself runs on Win7, the warning is conservative. Watch for hard errors,"
+" not warnings."
+msgstr ""
+
+#: src/platforms/windows-7.md:117
+msgid ""
+"**xwin sysroot setup is unchanged.** Cross-compiling from macOS / Linux "
+"still uses the `perry setup windows` xwin'd toolchain. Nothing in `--min-"
+"windows-version` changes the SDK requirements."
+msgstr ""
+
+#: src/platforms/windows-7.md:118
+msgid ""
+"**Static-link the CRT** if you want the binary to run on a clean Win7 SP1 "
+"install with no Visual C++ Redistributable. Confirm the binary doesn't "
+"import `vcruntime140.dll` / `msvcp140.dll` via the dumpbin/objdump check "
+"above."
+msgstr ""
+
+#: src/platforms/windows-7.md:119
+msgid ""
+"**`perry/thread`'s SRWLOCK is Vista+, fine.** Perry's threading primitives "
+"use Rust std, which uses SRWLOCK on Windows since Rust 1.42. No "
+"`WaitOnAddress` (Win8+) involvement on the supported Rust versions."
+msgstr ""
+
+#: src/platforms/windows-7.md:121
+msgid "Issue tracking"
+msgstr ""
+
+#: src/platforms/windows-7.md:123
+msgid ""
+"This feature lands as the resolution to "
+"[\\#303](https://github.com/PerryTS/perry/issues/303). If you hit a "
+"Win7-specific failure that isn't covered here, please file a follow-up "
+"referencing this page so we can extend the audit."
+msgstr ""
+
+#: src/platforms/linux.md:3
+msgid "Perry compiles TypeScript apps for Linux using GTK4."
+msgstr ""
+
+#: src/platforms/linux.md:7
+msgid "GTK4 development libraries:"
+msgstr ""
+
+#: src/platforms/linux.md:15
+msgid "# Arch\n"
+msgstr ""
+
+#: src/platforms/linux.md:18
+msgid "Cairo development libraries (for canvas):"
+msgstr ""
+
+#: src/platforms/linux.md:32
+msgid "Perry maps UI widgets to GTK4 widgets:"
+msgstr ""
+
+#: src/platforms/linux.md:34
+msgid "GTK4 Widget"
+msgstr ""
+
+#: src/platforms/linux.md:38
+msgid "GtkEntry"
+msgstr ""
+
+#: src/platforms/linux.md:39
+msgid "GtkPasswordEntry"
+msgstr ""
+
+#: src/platforms/linux.md:40
+msgid "GtkSwitch"
+msgstr ""
+
+#: src/platforms/linux.md:41
+msgid "GtkScale"
+msgstr ""
+
+#: src/platforms/linux.md:42
+msgid "GtkDropDown"
+msgstr ""
+
+#: src/platforms/linux.md:43
+msgid "GtkProgressBar"
+msgstr ""
+
+#: src/platforms/linux.md:44
+msgid "GtkImage"
+msgstr ""
+
+#: src/platforms/linux.md:45
+msgid "GtkBox (vertical)"
+msgstr ""
+
+#: src/platforms/linux.md:46
+msgid "GtkBox (horizontal)"
+msgstr ""
+
+#: src/platforms/linux.md:47
+msgid "GtkOverlay"
+msgstr ""
+
+#: src/platforms/linux.md:48
+msgid "GtkScrolledWindow"
+msgstr ""
+
+#: src/platforms/linux.md:49
+msgid "Cairo drawing"
+msgstr ""
+
+#: src/platforms/linux.md:50
+msgid "GtkStack"
+msgstr ""
+
+#: src/platforms/linux.md:52
+msgid "Linux-Specific APIs"
+msgstr ""
+
+#: src/platforms/linux.md:54
+msgid "**Menu bar**: GMenu / set_menubar"
+msgstr ""
+
+#: src/platforms/linux.md:55
+msgid "**Toolbar**: GtkHeaderBar"
+msgstr ""
+
+#: src/platforms/linux.md:56
+msgid "**Dark mode**: GTK settings detection"
+msgstr ""
+
+#: src/platforms/linux.md:57
+msgid "**Preferences**: GSettings or file-based"
+msgstr ""
+
+#: src/platforms/linux.md:58
+msgid "**Keychain**: libsecret"
+msgstr ""
+
+#: src/platforms/linux.md:59
+msgid "**Notifications**: GNotification"
+msgstr ""
+
+#: src/platforms/linux.md:60
+msgid "**File dialogs**: GtkFileChooserDialog"
+msgstr ""
+
+#: src/platforms/linux.md:61
+msgid "**Alerts**: GtkMessageDialog"
+msgstr ""
+
+#: src/platforms/linux.md:65
+msgid ""
+"GTK4 styling uses CSS under the hood. Perry's styling methods (colors, "
+"fonts, corner radius) are translated to CSS properties applied via "
+"`CssProvider`."
+msgstr ""
+
+#: src/platforms/linux.md:67
+msgid "Testing with Geisterhand"
+msgstr ""
+
+#: src/platforms/linux.md:69
+msgid ""
+"Perry's built-in UI fuzzer works on Linux/GTK4. Screenshots use "
+"`WidgetPaintable` + `GskRenderer` for pixel-accurate capture."
+msgstr ""
+
+#: src/platforms/linux.md:73
+msgid "# In another terminal:\n"
+msgstr ""
+
+#: src/platforms/linux.md:79
+msgid "See [Geisterhand](../testing/geisterhand.md) for full API reference."
+msgstr ""
+
+#: src/platforms/web.md:3
+msgid ""
+"`--target web` and `--target wasm` are aliases for the same backend. Both "
+"produce a self-contained HTML file with embedded WebAssembly and a "
+"JavaScript bridge for DOM widgets."
+msgstr ""
+
+#: src/platforms/web.md:6
+msgid "# same output as --target wasm\n"
+msgstr ""
+
+#: src/platforms/web.md:10
+msgid ""
+"See **[WebAssembly / Web](wasm.md)** for the full documentation: how it "
+"works, supported features, UI mapping, FFI, threading, limitations, and "
+"examples."
+msgstr ""
+
+#: src/platforms/web.md:12
+msgid "Why one target instead of two?"
+msgstr ""
+
+#: src/platforms/web.md:14
+msgid "Perry used to have two browser backends:"
+msgstr ""
+
+#: src/platforms/web.md:16
+msgid "`--target web` (`perry-codegen-js`) — transpiled HIR to JavaScript"
+msgstr ""
+
+#: src/platforms/web.md:17
+msgid "`--target wasm` (`perry-codegen-wasm`) — compiled HIR to WebAssembly"
+msgstr ""
+
+#: src/platforms/web.md:19
+msgid ""
+"These were consolidated into the WASM target so browser apps get near-native"
+" performance, FFI imports, and Web Worker threading without needing a "
+"separate JS-emit pipeline. The DOM widget runtime that the old `--target "
+"web` provided is now embedded in `wasm_runtime.js`. Both flags route through"
+" `perry-codegen-wasm` and produce identical HTML output."
+msgstr ""
+
+#: src/platforms/web.md:23
+msgid "[WebAssembly / Web](wasm.md) — full target documentation"
+msgstr ""
+
+#: src/platforms/web.md:24
+msgid "[Platform Overview](overview.md) — all platforms"
+msgstr ""
+
+#: src/platforms/wasm.md:1
+msgid "WebAssembly / Web"
+msgstr ""
+
+#: src/platforms/wasm.md:3
+msgid ""
+"Perry compiles TypeScript apps to **WebAssembly** for the browser using "
+"`--target wasm` or its alias `--target web`. Both flags route through the "
+"same backend (`perry-codegen-wasm`) and produce the same output: a self-"
+"contained HTML file with embedded WASM bytecode and a thin JavaScript bridge"
+" for DOM widgets and host APIs."
+msgstr ""
+
+#: src/platforms/wasm.md:5
+msgid ""
+"There used to be a separate JavaScript-emitting `--target web` (`perry-"
+"codegen-js`); it was consolidated into the WASM target so browser apps get "
+"near-native performance, FFI imports, and Web Worker threading \"for free\"."
+msgstr ""
+
+#: src/platforms/wasm.md:10
+msgid "# Self-contained HTML (default)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:13
+msgid "# Same thing\n"
+msgstr ""
+
+#: src/platforms/wasm.md:16
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:21
+msgid ""
+"The default output is a single `.html` file containing a base64-embedded "
+"WASM binary, the `wasm_runtime.js` bridge, and a `bootPerryWasm()` call that"
+" instantiates the module. Open it directly in any modern browser — no build "
+"step, no server required for simple apps."
+msgstr ""
+
+#: src/platforms/wasm.md:23
+msgid ""
+"**Note**: Apps that use `fetch()` or other web platform APIs that depend on "
+"a real origin must be served over HTTP (file:// URLs run into CORS / "
+"\"Failed to fetch\" errors). Any local static server works:"
+msgstr ""
+
+#: src/platforms/wasm.md:31
+msgid ""
+"The `perry-codegen-wasm` crate compiles HIR directly to WASM bytecode using "
+"`wasm-encoder`. The output WASM:"
+msgstr ""
+
+#: src/platforms/wasm.md:33
+msgid ""
+"Imports ~280 host functions under the `rt` namespace (string ops, math, "
+"console, JSON, classes, closures, promises, fetch, etc.)"
+msgstr ""
+
+#: src/platforms/wasm.md:34
+msgid "Imports user-declared FFI functions under the `ffi` namespace"
+msgstr ""
+
+#: src/platforms/wasm.md:35
+msgid ""
+"Exports `_start`, `memory`, `__indirect_function_table`, and every user "
+"function as `__wasm_func_<idx>` (so async function bodies compiled to JS can"
+" call back into WASM)"
+msgstr ""
+
+#: src/platforms/wasm.md:37
+msgid ""
+"The NaN-boxing scheme matches the native `perry-runtime` — f64 values with "
+"STRING_TAG/POINTER_TAG/INT32_TAG — so the same value representation is used "
+"across native and WASM targets. The JS bridge wraps every host import with "
+"bit-level reinterpretation so f64 NaN-boxed values pass through the BigInt-"
+"based JS↔WASM i64 boundary intact (BigInt(NaN) would otherwise throw)."
+msgstr ""
+
+#: src/platforms/wasm.md:41
+msgid ""
+"**Full TypeScript language**: classes (with constructors, methods, "
+"getters/setters, inheritance, fields), async/await, closures (with "
+"captures), generators, destructuring, template literals, generics, enums, "
+"try/catch/finally"
+msgstr ""
+
+#: src/platforms/wasm.md:42
+msgid ""
+"**Module system**: cross-module imports, top-level `const`/`let` (promoted "
+"to WASM globals), circular imports"
+msgstr ""
+
+#: src/platforms/wasm.md:43
+msgid ""
+"**Standard library**: String/Array/Object methods, Map/Set, JSON, Date, "
+"RegExp, Math, Error, URL/URLSearchParams, Buffer, Promise (with "
+"`.then`/`.catch`/`.allSettled`/`.race`/`.any`/`.all`)"
+msgstr ""
+
+#: src/platforms/wasm.md:44
+msgid ""
+"**Async**: `async`/`await` (compiled to JS Promises), "
+"`setTimeout`/`setInterval`, `fetch()` with full request options (method, "
+"headers, body)"
+msgstr ""
+
+#: src/platforms/wasm.md:45
+msgid ""
+"**Threading**: `perry/thread` `parallelMap`/`parallelFilter`/`spawn` via Web"
+" Worker pool with one WASM instance per worker (see "
+"[Threading](../threading/overview.md))"
+msgstr ""
+
+#: src/platforms/wasm.md:46
+msgid ""
+"**DOM-based UI**: every widget in `perry/ui` (`VStack`, `HStack`, `ZStack`, "
+"`Text`, `Button`, `TextField`, `Toggle`, `Slider`, `ScrollView`, `Picker`, "
+"`Image`, `Canvas`, `Form`, `Section`, `NavigationStack`, `Table`, "
+"`LazyVStack`, `TextArea`, etc.) maps to a DOM element with flexbox layout. "
+"State bindings (`bindText`/`bindSlider`/`bindToggle`/`bindForEach`/...) work"
+" via reactive subscribers."
+msgstr ""
+
+#: src/platforms/wasm.md:47
+msgid ""
+"**System APIs**: `localStorage`\\-backed preferences/keychain, dark mode "
+"detection (`prefers-color-scheme`), Web Notifications, clipboard, file "
+"open/save dialogs, File System Access API, Web Audio capture"
+msgstr ""
+
+#: src/platforms/wasm.md:48
+msgid ""
+"**FFI**: `declare function` declarations become WASM imports under the `ffi`"
+" namespace"
+msgstr ""
+
+#: src/platforms/wasm.md:49
+msgid ""
+"**Compile-time i18n**: `perry/i18n` `t()` calls work the same as native "
+"targets"
+msgstr ""
+
+#: src/platforms/wasm.md:51
+msgid "UI Mapping"
+msgstr ""
+
+#: src/platforms/wasm.md:53
+msgid "Perry widgets map to HTML elements:"
+msgstr ""
+
+#: src/platforms/wasm.md:55
+msgid "HTML Element"
+msgstr ""
+
+#: src/platforms/wasm.md:57 src/widgets/wearos.md:24
+msgid "`Text`"
+msgstr ""
+
+#: src/platforms/wasm.md:58
+msgid "`Button`"
+msgstr ""
+
+#: src/platforms/wasm.md:59
+msgid "`TextField`"
+msgstr ""
+
+#: src/platforms/wasm.md:59
+msgid "`<input type=\"text\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:60
+msgid "`SecureField`"
+msgstr ""
+
+#: src/platforms/wasm.md:60
+msgid "`<input type=\"password\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:61
+msgid "`Toggle`"
+msgstr ""
+
+#: src/platforms/wasm.md:61
+msgid "`<input type=\"checkbox\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:62
+msgid "`Slider`"
+msgstr ""
+
+#: src/platforms/wasm.md:62
+msgid "`<input type=\"range\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:63
+msgid "`Picker`"
+msgstr ""
+
+#: src/platforms/wasm.md:63
+msgid "`<select>`"
+msgstr ""
+
+#: src/platforms/wasm.md:64
+msgid "`ProgressView`"
+msgstr ""
+
+#: src/platforms/wasm.md:64
+msgid "`<progress>`"
+msgstr ""
+
+#: src/platforms/wasm.md:65
+msgid "`Image` / `ImageFile`"
+msgstr ""
+
+#: src/platforms/wasm.md:65
+msgid "`<img>`"
+msgstr ""
+
+#: src/platforms/wasm.md:66 src/widgets/wearos.md:25
+msgid "`VStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:66
+msgid "`<div>` (flexbox column)"
+msgstr ""
+
+#: src/platforms/wasm.md:67 src/widgets/wearos.md:26
+msgid "`HStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:67
+msgid "`<div>` (flexbox row)"
+msgstr ""
+
+#: src/platforms/wasm.md:68
+msgid "`ZStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:68
+msgid "`<div>` (position: relative + absolute children)"
+msgstr ""
+
+#: src/platforms/wasm.md:69
+msgid "`ScrollView`"
+msgstr ""
+
+#: src/platforms/wasm.md:69
+msgid "`<div>` (overflow: auto)"
+msgstr ""
+
+#: src/platforms/wasm.md:70
+msgid "`Canvas`"
+msgstr ""
+
+#: src/platforms/wasm.md:70
+msgid "`<canvas>` (2D context)"
+msgstr ""
+
+#: src/platforms/wasm.md:71
+msgid "`Table`"
+msgstr ""
+
+#: src/platforms/wasm.md:71
+msgid "`<table>`"
+msgstr ""
+
+#: src/platforms/wasm.md:72 src/widgets/wearos.md:28
+msgid "`Divider`"
+msgstr ""
+
+#: src/platforms/wasm.md:72
+msgid "`<hr>`"
+msgstr ""
+
+#: src/platforms/wasm.md:73 src/widgets/wearos.md:27
+msgid "`Spacer`"
+msgstr ""
+
+#: src/platforms/wasm.md:73
+msgid "`<div>` (flex: 1)"
+msgstr ""
+
+#: src/platforms/wasm.md:75
+msgid "FFI Support"
+msgstr ""
+
+#: src/platforms/wasm.md:77
+msgid ""
+"The WASM target supports external FFI functions declared with `declare "
+"function`. They become WASM imports under the `\"ffi\"` namespace:"
+msgstr ""
+
+#: src/platforms/wasm.md:85
+msgid "Provide them when instantiating:"
+msgstr ""
+
+#: src/platforms/wasm.md:88
+msgid "// Via __ffiImports global (set before boot)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:90
+msgid "// Or via bootPerryWasm second argument\n"
+msgstr ""
+
+#: src/platforms/wasm.md:95
+msgid ""
+"**Auto-stub for missing imports.** The `ffi` namespace is wrapped in a "
+"`Proxy` so any FFI function the host doesn't provide is auto-stubbed with a "
+"no-op that returns `TAG_UNDEFINED`. This means apps that use native "
+"libraries (e.g. Hone Editor's 56 `hone_editor_*` functions) can still "
+"instantiate and run in the browser even without the native bindings — the "
+"relevant features are simply no-ops."
+msgstr ""
+
+#: src/platforms/wasm.md:97
+msgid "Module-Level Constants"
+msgstr ""
+
+#: src/platforms/wasm.md:99
+msgid ""
+"Top-level `const`/`let` declarations are promoted to dedicated WASM globals "
+"so functions in the same module can read them, and so two modules' identical"
+" `LocalId`s don't collide:"
+msgstr ""
+
+#: src/platforms/wasm.md:101
+msgid ""
+"```typescript\n"
+"// telemetry.ts\n"
+"const CHIRP_URL = 'https://api.chirp247.com/api/v1/event'\n"
+"const API_KEY   = 'my-key'\n"
+"\n"
+"export function trackEvent(event: string): void {\n"
+"    fetch(CHIRP_URL, {\n"
+"        method: 'POST',\n"
+"        headers: { 'Content-Type': 'application/json', 'X-Chirp-Key': API_KEY },\n"
+"        body: JSON.stringify({ event }),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/wasm.md:115
+msgid ""
+"Both `CHIRP_URL` and `API_KEY` become WASM globals indexed by `(module_idx, "
+"LocalId)`. Reading them from `trackEvent` emits a `global.get` instead of "
+"trying to look up a function-local that doesn't exist."
+msgstr ""
+
+#: src/platforms/wasm.md:117
+msgid "JavaScript Runtime Bridge"
+msgstr ""
+
+#: src/platforms/wasm.md:119
+msgid ""
+"The bridge (`wasm_runtime.js`) is embedded in the HTML and provides ~280 "
+"imports across:"
+msgstr ""
+
+#: src/platforms/wasm.md:121
+msgid ""
+"**NaN-boxing helpers**: `f64ToU64` / `u64ToF64` / `nanboxString` / "
+"`nanboxPointer` / `toJsValue` / `fromJsValue`"
+msgstr ""
+
+#: src/platforms/wasm.md:122
+msgid "**String table**: dynamic JS string array indexed by string ID"
+msgstr ""
+
+#: src/platforms/wasm.md:123
+msgid ""
+"**Handle store**: maps integer handle IDs to JS objects, arrays, closures, "
+"promises, DOM elements"
+msgstr ""
+
+#: src/platforms/wasm.md:124
+msgid ""
+"**Core ops**: console, math, JSON, JSON.parse/stringify, Date, RegExp, URL, "
+"Map, Set, Buffer, fetch"
+msgstr ""
+
+#: src/platforms/wasm.md:125
+msgid ""
+"**Closure dispatch**: indirect function table + capture array, with "
+"`closure_call_0/1/2/3/spread`"
+msgstr ""
+
+#: src/platforms/wasm.md:126
+msgid ""
+"**Class dispatch**: `class_new`, `class_call_method`, `class_get_field`, "
+"`class_set_field`, parent table for inheritance"
+msgstr ""
+
+#: src/platforms/wasm.md:127
+msgid ""
+"**DOM widgets**: 168+ `perry_ui_*` functions covering every widget in "
+"`perry/ui`"
+msgstr ""
+
+#: src/platforms/wasm.md:128
+msgid ""
+"**Async functions**: compiled to JS function bodies and merged into the "
+"import object as `__async_<name>`"
+msgstr ""
+
+#: src/platforms/wasm.md:130
+msgid ""
+"All host imports are wrapped via `wrapImportsForI64()` so they automatically"
+" reinterpret BigInt args (from WASM i64 params) into f64 internally and "
+"reinterpret Number returns back into BigInt. Without this wrapping, every "
+"NaN-valued f64 return would crash with \"Cannot convert NaN to a BigInt\"."
+msgstr ""
+
+#: src/platforms/wasm.md:132
+msgid "Web Worker Threading"
+msgstr ""
+
+#: src/platforms/wasm.md:134
+msgid "`perry/thread` works in the browser via a Web Worker pool:"
+msgstr ""
+
+#: src/platforms/wasm.md:144
+msgid ""
+"Each worker instantiates its own WASM module with the same bytecode and "
+"bridge. Values cross between the main thread and workers via structured-"
+"clone serialization. See [Threading](../threading/overview.md)."
+msgstr ""
+
+#: src/platforms/wasm.md:148
+msgid ""
+"**No file system access** beyond the File System Access API "
+"(`window.showDirectoryPicker()`)"
+msgstr ""
+
+#: src/platforms/wasm.md:149
+msgid "**No raw TCP/UDP sockets** — only `fetch()` and `WebSocket`"
+msgstr ""
+
+#: src/platforms/wasm.md:150
+msgid "**No subprocess spawning** — `child_process.exec` etc. are no-ops"
+msgstr ""
+
+#: src/platforms/wasm.md:151
+msgid ""
+"**No native databases** — SQLite, Postgres, MySQL drivers don't compile to "
+"web"
+msgstr ""
+
+#: src/platforms/wasm.md:152
+msgid ""
+"**CORS** applies to all `fetch()` calls — third-party APIs must allow your "
+"origin"
+msgstr ""
+
+#: src/platforms/wasm.md:153
+msgid ""
+"**localStorage**, not real keychain — fine for preferences, not for secrets"
+msgstr ""
+
+#: src/platforms/wasm.md:154
+msgid ""
+"Source-mapped stack traces are JS-only; WASM stack frames show `wasm-"
+"function[N]`"
+msgstr ""
+
+#: src/platforms/wasm.md:156
+msgid "Minification"
+msgstr ""
+
+#: src/platforms/wasm.md:158
+msgid ""
+"Use `--minify` to minify the embedded JS runtime bridge in the HTML output. "
+"The Rust-native JS minifier strips comments, collapses whitespace, and "
+"mangles internal identifiers, compressing the runtime from ~3,400 lines to "
+"~180."
+msgstr ""
+
+#: src/platforms/wasm.md:164
+msgid "Example: Counter App"
+msgstr ""
+
+#: src/platforms/wasm.md:187
+msgid "Example: Real-World App (Mango MongoDB GUI)"
+msgstr ""
+
+#: src/platforms/wasm.md:189
+msgid ""
+"The [Mango](https://github.com/PerryTS/mango) MongoDB GUI — 50 modules, 998 "
+"functions, classes, async functions, fetch with custom headers, the Hone "
+"code editor — compiles to a single 4 MB HTML file via `--target web` and "
+"renders its full UI (welcome screen, query view, edit view) in the browser. "
+"SQLite-backed connection storage gracefully degrades to an in-memory "
+"transient store on web; the rest of the app works the same as the native "
+"version."
+msgstr ""
+
+#: src/platforms/wasm.md:195
+msgid "[Threading](../threading/overview.md) — Web Worker threading"
+msgstr ""
+
+#: src/stdlib/overview.md:1
+msgid "Standard Library Overview"
+msgstr ""
+
+#: src/stdlib/overview.md:3
+msgid ""
+"Perry natively implements many popular npm packages and Node.js APIs. When "
+"you import a supported package, Perry compiles it to native code — no "
+"JavaScript runtime involved."
+msgstr ""
+
+#: src/stdlib/overview.md:7
+msgid ""
+"```typescript\n"
+"import fastify from \"fastify\"\n"
+"import mysql from \"mysql2/promise\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/overview.md:12
+msgid ""
+"Perry recognizes these imports at compile time and routes them to native "
+"Rust implementations in the `perry-stdlib` crate. The API surface matches "
+"the original npm package, so existing code often works unchanged."
+msgstr ""
+
+#: src/stdlib/overview.md:14
+msgid "Supported Packages"
+msgstr ""
+
+#: src/stdlib/overview.md:16
+msgid "Networking & HTTP"
+msgstr ""
+
+#: src/stdlib/overview.md:17
+msgid "**fastify** — HTTP server framework"
+msgstr ""
+
+#: src/stdlib/overview.md:18
+msgid "**axios** — HTTP client"
+msgstr ""
+
+#: src/stdlib/overview.md:19
+msgid "**node-fetch** / **fetch** — HTTP fetch API"
+msgstr ""
+
+#: src/stdlib/overview.md:20
+msgid "**ws** — WebSocket client/server"
+msgstr ""
+
+#: src/stdlib/overview.md:23
+msgid "**mysql2** — MySQL client"
+msgstr ""
+
+#: src/stdlib/overview.md:24
+msgid "**pg** — PostgreSQL client"
+msgstr ""
+
+#: src/stdlib/overview.md:25
+msgid "**better-sqlite3** — SQLite"
+msgstr ""
+
+#: src/stdlib/overview.md:26
+msgid "**mongodb** — MongoDB client"
+msgstr ""
+
+#: src/stdlib/overview.md:27
+msgid "**ioredis** / **redis** — Redis client"
+msgstr ""
+
+#: src/stdlib/overview.md:30
+msgid "**bcrypt** — Password hashing"
+msgstr ""
+
+#: src/stdlib/overview.md:31
+msgid "**argon2** — Password hashing (Argon2)"
+msgstr ""
+
+#: src/stdlib/overview.md:32
+msgid "**jsonwebtoken** — JWT signing/verification"
+msgstr ""
+
+#: src/stdlib/overview.md:33
+msgid "**crypto** — Node.js crypto module"
+msgstr ""
+
+#: src/stdlib/overview.md:34
+msgid "**ethers** — Ethereum library"
+msgstr ""
+
+#: src/stdlib/overview.md:37
+msgid "**lodash** — Utility functions"
+msgstr ""
+
+#: src/stdlib/overview.md:38
+msgid "**dayjs** / **moment** — Date manipulation"
+msgstr ""
+
+#: src/stdlib/overview.md:39
+msgid "**uuid** — UUID generation"
+msgstr ""
+
+#: src/stdlib/overview.md:40
+msgid "**nanoid** — ID generation"
+msgstr ""
+
+#: src/stdlib/overview.md:41
+msgid "**slugify** — String slugification"
+msgstr ""
+
+#: src/stdlib/overview.md:42
+msgid "**validator** — String validation"
+msgstr ""
+
+#: src/stdlib/overview.md:44
+msgid "CLI & Data"
+msgstr ""
+
+#: src/stdlib/overview.md:45
+msgid "**commander** — CLI argument parsing"
+msgstr ""
+
+#: src/stdlib/overview.md:46
+msgid "**decimal.js** — Arbitrary precision decimals"
+msgstr ""
+
+#: src/stdlib/overview.md:47
+msgid "**bignumber.js** — Big number math"
+msgstr ""
+
+#: src/stdlib/overview.md:48
+msgid "**lru-cache** — LRU caching"
+msgstr ""
+
+#: src/stdlib/overview.md:51
+msgid "**sharp** — Image processing"
+msgstr ""
+
+#: src/stdlib/overview.md:52
+msgid "**cheerio** — HTML parsing"
+msgstr ""
+
+#: src/stdlib/overview.md:53
+msgid "**nodemailer** — Email sending"
+msgstr ""
+
+#: src/stdlib/overview.md:54
+msgid "**zlib** — Compression"
+msgstr ""
+
+#: src/stdlib/overview.md:55
+msgid "**cron** — Job scheduling"
+msgstr ""
+
+#: src/stdlib/overview.md:56
+msgid "**worker_threads** — Background workers"
+msgstr ""
+
+#: src/stdlib/overview.md:57
+msgid "**exponential-backoff** — Retry logic"
+msgstr ""
+
+#: src/stdlib/overview.md:58
+msgid "**async_hooks** — AsyncLocalStorage"
+msgstr ""
+
+#: src/stdlib/overview.md:60
+msgid "Node.js Built-ins"
+msgstr ""
+
+#: src/stdlib/overview.md:61
+msgid "**fs** — File system"
+msgstr ""
+
+#: src/stdlib/overview.md:62
+msgid "**path** — Path manipulation"
+msgstr ""
+
+#: src/stdlib/overview.md:63
+msgid "**child_process** — Process spawning"
+msgstr ""
+
+#: src/stdlib/overview.md:64
+msgid "**crypto** — Cryptographic functions"
+msgstr ""
+
+#: src/stdlib/overview.md:68
+msgid "Perry automatically detects which stdlib features your code uses:"
+msgstr ""
+
+#: src/stdlib/overview.md:70 src/system/preferences.md:8
+#: src/system/keychain.md:8
+msgid "Usage"
+msgstr ""
+
+#: src/stdlib/overview.md:72
+msgid "No stdlib imports"
+msgstr ""
+
+#: src/stdlib/overview.md:73
+msgid "fs + path only"
+msgstr ""
+
+#: src/stdlib/overview.md:74
+msgid "Full stdlib"
+msgstr ""
+
+#: src/stdlib/overview.md:76
+msgid "The compiler links only the required runtime components."
+msgstr ""
+
+#: src/stdlib/overview.md:78
+msgid "compilePackages"
+msgstr ""
+
+#: src/stdlib/overview.md:80
+msgid ""
+"For npm packages not natively supported, you can compile pure "
+"TypeScript/JavaScript packages natively:"
+msgstr ""
+
+#: src/stdlib/overview.md:90
+msgid ""
+"See [Project Configuration](../getting-started/project-config.md) for "
+"details."
+msgstr ""
+
+#: src/stdlib/overview.md:92
+msgid "JavaScript Runtime Fallback"
+msgstr ""
+
+#: src/stdlib/overview.md:94
+msgid ""
+"For packages that can't be compiled natively (native addons, dynamic code, "
+"etc.), Perry includes a QuickJS-based JavaScript runtime as a fallback. The "
+"exact API surface is internal-only today; the import below is illustrative:"
+msgstr ""
+
+#: src/stdlib/overview.md:96
+msgid ""
+"```text\n"
+"import { jsEval } from \"perry/jsruntime\"; // illustrative — not yet a public export\n"
+"```"
+msgstr ""
+
+#: src/stdlib/overview.md:102
+msgid "[File System](fs.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:103 src/stdlib/fs.md:90
+msgid "[HTTP & Networking](http.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:104 src/stdlib/http.md:95
+msgid "[Databases](database.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:105 src/stdlib/database.md:109
+msgid "[Cryptography](crypto.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:106 src/stdlib/crypto.md:89
+msgid "[Utilities](utilities.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:107 src/stdlib/utilities.md:106
+msgid "[Other Modules](other.md)"
+msgstr ""
+
+#: src/stdlib/fs.md:3
+msgid ""
+"Perry implements Node.js file system APIs for reading, writing, and managing"
+" files."
+msgstr ""
+
+#: src/stdlib/fs.md:5
+msgid "Reading Files"
+msgstr ""
+
+#: src/stdlib/fs.md:7
+msgid ""
+"```typescript\n"
+"const configPath = join(scratch, \"config.json\")\n"
+"const content = readFileSync(configPath, \"utf-8\")\n"
+"console.log(content)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:13
+msgid "Binary File Reading"
+msgstr ""
+
+#: src/stdlib/fs.md:15
+msgid ""
+"```typescript\n"
+"const imagePath = join(scratch, \"image.png\")\n"
+"const buffer = readFileBuffer(imagePath)\n"
+"console.log(`Read ${buffer.length} bytes`)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:21
+msgid ""
+"`readFileBuffer` reads files as binary data (uses `fs::read()` internally, "
+"not `read_to_string()`)."
+msgstr ""
+
+#: src/stdlib/fs.md:23
+msgid "Writing Files"
+msgstr ""
+
+#: src/stdlib/fs.md:25
+msgid ""
+"```typescript\n"
+"const outputPath = join(scratch, \"output.txt\")\n"
+"const dataPath = join(scratch, \"data.json\")\n"
+"writeFileSync(outputPath, \"Hello, World!\")\n"
+"writeFileSync(dataPath, JSON.stringify({ key: \"value\" }, null, 2))\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:32
+msgid "File Information"
+msgstr ""
+
+#: src/stdlib/fs.md:41
+msgid "Directory Operations"
+msgstr ""
+
+#: src/stdlib/fs.md:43
+msgid ""
+"```typescript\n"
+"// Create directory\n"
+"const outDir = join(scratch, \"output\")\n"
+"if (!existsSync(outDir)) mkdirSync(outDir)\n"
+"\n"
+"// Read directory contents\n"
+"const files = readdirSync(scratch)\n"
+"for (const file of files) {\n"
+"    console.log(file)\n"
+"}\n"
+"\n"
+"// Remove an empty directory\n"
+"rmdirSync(outDir)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:58
+msgid ""
+"For recursive removal Perry exposes `rmRecursive` (a thin wrapper around "
+"`std::fs::remove_dir_all`). Wired via "
+"[\\#193](https://github.com/PerryTS/perry/issues/193) through "
+"`js_fs_rm_recursive` in the LLVM backend."
+msgstr ""
+
+#: src/stdlib/fs.md:63
+msgid ""
+"```typescript,no-test\n"
+"import { rmRecursive } from \"fs\";\n"
+"rmRecursive(\"output\"); // Recursive remove; returns 1 on success, 0 on failure.\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:68
+msgid "Path Utilities"
+msgstr ""
+
+#: src/stdlib/fs.md:70
+msgid ""
+"```typescript\n"
+"const dir = dirname(configPath)\n"
+"const cfgPath = join(dir, \"config.json\")\n"
+"const name = basename(cfgPath)        // \"config.json\"\n"
+"const abs = resolve(\"relative/path\")  // Absolute path\n"
+"console.log(`${name} ${abs.length > 0}`)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:78
+msgid ""
+"For `import.meta.url` → filesystem path conversion, use `fileURLToPath` from"
+" the `url` module:"
+msgstr ""
+
+#: src/stdlib/fs.md:81
+msgid ""
+"```text\n"
+"import { fileURLToPath } from \"url\";\n"
+"import { dirname } from \"path\";\n"
+"\n"
+"const dir = dirname(fileURLToPath(import.meta.url));\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:91 src/stdlib/http.md:96 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:107 src/stdlib/other.md:186
+msgid "[Overview](overview.md) — All stdlib modules"
+msgstr ""
+
+#: src/stdlib/http.md:3
+msgid ""
+"Perry natively implements HTTP servers, clients, and WebSocket support."
+msgstr ""
+
+#: src/stdlib/http.md:5
+msgid "Fastify Server"
+msgstr ""
+
+#: src/stdlib/http.md:7
+msgid ""
+"```typescript\n"
+"import fastify from \"fastify\"\n"
+"\n"
+"const app = fastify()\n"
+"\n"
+"app.get(\"/\", async (request: any, reply: any) => {\n"
+"    return { hello: \"world\" }\n"
+"})\n"
+"\n"
+"app.get(\"/users/:id\", async (request: any, reply: any) => {\n"
+"    const id = request.params.id\n"
+"    return { id, name: \"User \" + id }\n"
+"})\n"
+"\n"
+"app.post(\"/data\", async (request: any, reply: any) => {\n"
+"    const body = request.body\n"
+"    reply.code(201)\n"
+"    return { received: body }\n"
+"})\n"
+"\n"
+"app.listen({ port: 3000 }, () => {\n"
+"    console.log(\"Server running on port 3000\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:32
+msgid ""
+"Perry's Fastify implementation is API-compatible with the npm package. "
+"Routes, request/reply objects, params, query strings, and JSON body parsing "
+"all work."
+msgstr ""
+
+#: src/stdlib/http.md:34
+msgid "Fetch API"
+msgstr ""
+
+#: src/stdlib/http.md:36
+msgid ""
+"```typescript\n"
+"async function fetchExamples(): Promise<void> {\n"
+"    // GET request\n"
+"    const response = await fetch(\"https://jsonplaceholder.typicode.com/posts/1\")\n"
+"    const data = await response.json()\n"
+"\n"
+"    // POST request\n"
+"    const result = await fetch(\"https://jsonplaceholder.typicode.com/posts\", {\n"
+"        method: \"POST\",\n"
+"        headers: { \"Content-Type\": \"application/json\" },\n"
+"        body: JSON.stringify({ title: \"hello\", body: \"world\", userId: 1 }),\n"
+"    })\n"
+"\n"
+"    console.log(`fetch ok: ${data !== null} status=${result.status}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:53
+msgid "Axios"
+msgstr ""
+
+#: src/stdlib/http.md:55
+msgid ""
+"```typescript\n"
+"import axios from \"axios\"\n"
+"\n"
+"async function axiosExamples(): Promise<void> {\n"
+"    const getResp = await axios.get(\"https://jsonplaceholder.typicode.com/users/1\")\n"
+"    const data = getResp.data\n"
+"\n"
+"    const response = await axios.post(\"https://jsonplaceholder.typicode.com/users\", {\n"
+"        name: \"Perry\",\n"
+"        email: \"perry@example.com\",\n"
+"    })\n"
+"\n"
+"    console.log(`axios ok: ${data !== null} status=${response.status}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:71
+msgid "WebSocket"
+msgstr ""
+
+#: src/stdlib/http.md:73
+msgid ""
+"```typescript\n"
+"import { WebSocket } from \"ws\"\n"
+"\n"
+"function wsExample(): void {\n"
+"    const ws = new WebSocket(\"ws://localhost:8080\")\n"
+"\n"
+"    ws.on(\"open\", () => {\n"
+"        ws.send(\"Hello, server!\")\n"
+"    })\n"
+"\n"
+"    ws.on(\"message\", (data: any) => {\n"
+"        console.log(`Received: ${data}`)\n"
+"    })\n"
+"\n"
+"    ws.on(\"close\", () => {\n"
+"        console.log(\"Connection closed\")\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:3
+msgid ""
+"Perry natively implements clients for MySQL, PostgreSQL, SQLite, MongoDB, "
+"and Redis."
+msgstr ""
+
+#: src/stdlib/database.md:5
+msgid "MySQL"
+msgstr ""
+
+#: src/stdlib/database.md:7
+msgid ""
+"```typescript\n"
+"import mysql from \"mysql2/promise\"\n"
+"\n"
+"async function mysqlExample(): Promise<void> {\n"
+"    const connection = await mysql.createConnection({\n"
+"        host: \"localhost\",\n"
+"        user: \"root\",\n"
+"        password: \"password\",\n"
+"        database: \"mydb\",\n"
+"    })\n"
+"\n"
+"    const [rows] = await connection.execute(\"SELECT * FROM users WHERE id = ?\", [1])\n"
+"    console.log(rows)\n"
+"\n"
+"    await connection.end()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:25
+msgid "PostgreSQL"
+msgstr ""
+
+#: src/stdlib/database.md:27
+msgid ""
+"```typescript\n"
+"import { Client } from \"pg\"\n"
+"\n"
+"async function postgresExample(): Promise<void> {\n"
+"    const client = new Client({\n"
+"        host: \"localhost\",\n"
+"        port: 5432,\n"
+"        user: \"postgres\",\n"
+"        password: \"password\",\n"
+"        database: \"mydb\",\n"
+"    })\n"
+"\n"
+"    await client.connect()\n"
+"    const result = await client.query(\"SELECT * FROM users WHERE id = $1\", [1])\n"
+"    console.log(result.rows)\n"
+"    await client.end()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:46
+msgid "SQLite"
+msgstr ""
+
+#: src/stdlib/database.md:48
+msgid ""
+"```typescript\n"
+"import Database from \"better-sqlite3\"\n"
+"\n"
+"function sqliteExample(): void {\n"
+"    const db = new Database(\"mydb.sqlite\")\n"
+"\n"
+"    db.exec(`\n"
+"      CREATE TABLE IF NOT EXISTS users (\n"
+"        id INTEGER PRIMARY KEY,\n"
+"        name TEXT,\n"
+"        email TEXT\n"
+"      )\n"
+"    `)\n"
+"\n"
+"    const insert = db.prepare(\"INSERT INTO users (name, email) VALUES (?, ?)\")\n"
+"    insert.run(\"Perry\", \"perry@example.com\")\n"
+"\n"
+"    const users = db.prepare(\"SELECT * FROM users\").all()\n"
+"    console.log(users)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:70
+msgid "MongoDB"
+msgstr ""
+
+#: src/stdlib/database.md:72
+msgid ""
+"```typescript\n"
+"import { MongoClient } from \"mongodb\"\n"
+"\n"
+"async function mongoExample(): Promise<void> {\n"
+"    const client = new MongoClient(\"mongodb://localhost:27017\")\n"
+"    await client.connect()\n"
+"\n"
+"    const db = client.db(\"mydb\")\n"
+"    const users = db.collection(\"users\")\n"
+"\n"
+"    await users.insertOne({ name: \"Perry\", email: \"perry@example.com\" })\n"
+"    const user = await users.findOne({ name: \"Perry\" })\n"
+"    console.log(user)\n"
+"\n"
+"    await client.close()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:90
+msgid "Redis"
+msgstr ""
+
+#: src/stdlib/database.md:92
+msgid ""
+"```typescript\n"
+"import Redis from \"ioredis\"\n"
+"\n"
+"async function redisExample(): Promise<void> {\n"
+"    const redis = new Redis()\n"
+"\n"
+"    await redis.set(\"key\", \"value\")\n"
+"    const value = await redis.get(\"key\")\n"
+"    console.log(value) // \"value\"\n"
+"\n"
+"    await redis.del(\"key\")\n"
+"    await redis.quit()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:3
+msgid ""
+"Perry natively implements password hashing, JWT tokens, and Ethereum "
+"cryptography."
+msgstr ""
+
+#: src/stdlib/crypto.md:5
+msgid "bcrypt"
+msgstr ""
+
+#: src/stdlib/crypto.md:7
+msgid ""
+"```typescript\n"
+"import bcrypt from \"bcrypt\"\n"
+"\n"
+"async function bcryptExample(): Promise<void> {\n"
+"    const hash = await bcrypt.hash(\"mypassword\", 10)\n"
+"    const match = await bcrypt.compare(\"mypassword\", hash)\n"
+"    console.log(match) // true\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:17
+msgid "Argon2"
+msgstr ""
+
+#: src/stdlib/crypto.md:19
+msgid ""
+"```typescript\n"
+"import argon2 from \"argon2\"\n"
+"\n"
+"async function argon2Example(): Promise<void> {\n"
+"    const hash = await argon2.hash(\"mypassword\")\n"
+"    const valid = await argon2.verify(hash, \"mypassword\")\n"
+"    console.log(valid) // true\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:29
+msgid "JSON Web Tokens"
+msgstr ""
+
+#: src/stdlib/crypto.md:31
+msgid ""
+"```typescript\n"
+"import jwt from \"jsonwebtoken\"\n"
+"\n"
+"function jwtExample(): void {\n"
+"    const secret = \"my-secret-key\"\n"
+"\n"
+"    // Sign a token\n"
+"    const token = jwt.sign({ userId: 123, role: \"admin\" }, secret, {\n"
+"        expiresIn: \"1h\",\n"
+"    })\n"
+"\n"
+"    // Verify a token\n"
+"    const decoded: any = jwt.verify(token, secret)\n"
+"    console.log(decoded.userId) // 123\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:48
+msgid "Node.js Crypto"
+msgstr ""
+
+#: src/stdlib/crypto.md:50
+msgid ""
+"```typescript\n"
+"import crypto from \"crypto\"\n"
+"\n"
+"function cryptoExample(): void {\n"
+"    // Hash\n"
+"    const hash = crypto.createHash(\"sha256\").update(\"data\").digest(\"hex\")\n"
+"\n"
+"    // HMAC\n"
+"    const hmac = crypto.createHmac(\"sha256\", \"secret\").update(\"data\").digest(\"hex\")\n"
+"\n"
+"    // Random bytes\n"
+"    const bytes = crypto.randomBytes(32)\n"
+"\n"
+"    console.log(`hash_len=${hash.length} hmac_len=${hmac.length} bytes_len=${bytes.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:67
+msgid "Ethers"
+msgstr ""
+
+#: src/stdlib/crypto.md:69
+msgid ""
+"```typescript\n"
+"import { ethers } from \"ethers\"\n"
+"\n"
+"function ethersExample(): void {\n"
+"    // Utility functions\n"
+"    const addr = ethers.getAddress(\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\")\n"
+"    const wei = ethers.parseEther(\"1.5\")\n"
+"    const ether = ethers.formatEther(wei)\n"
+"    console.log(`checksum: ${addr}`)\n"
+"    console.log(`1.5 ether in wei → formatted back: ${ether}`)\n"
+"\n"
+"    // Create a random wallet\n"
+"    const wallet = ethers.Wallet.createRandom()\n"
+"    console.log(`address: ${wallet.address}`)\n"
+"    console.log(`privateKey length: ${wallet.privateKey.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:3
+msgid "Perry natively implements common utility packages."
+msgstr ""
+
+#: src/stdlib/utilities.md:5
+msgid "lodash"
+msgstr ""
+
+#: src/stdlib/utilities.md:7
+msgid ""
+"The `lodash` runtime functions are partially implemented (see `crates/perry-"
+"stdlib/src/lodash.rs`) but the user-facing dispatch from `import _ from "
+"\"lodash\"; _.chunk(...)` is not wired into the LLVM backend yet. Track the "
+"follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:12
+msgid ""
+"```text\n"
+"import _ from \"lodash\";\n"
+"\n"
+"_.chunk([1, 2, 3, 4, 5], 2);     // [[1,2], [3,4], [5]]\n"
+"_.uniq([1, 2, 2, 3, 3]);          // [1, 2, 3]\n"
+"_.groupBy(users, \"role\");\n"
+"_.sortBy(users, [\"name\"]);\n"
+"_.cloneDeep(obj);\n"
+"_.merge(defaults, overrides);\n"
+"_.debounce(fn, 300);\n"
+"_.throttle(fn, 100);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:25
+msgid "dayjs"
+msgstr ""
+
+#: src/stdlib/utilities.md:27
+msgid ""
+"`dayjs` runtime functions are declared (`js_dayjs_now`, `js_dayjs_format`, "
+"`js_dayjs_add`, etc.) but the user-facing dispatch from `import dayjs from "
+"\"dayjs\"; dayjs()` chained methods is not wired into the LLVM backend yet. "
+"Track the follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:32
+msgid ""
+"```text\n"
+"import dayjs from \"dayjs\";\n"
+"\n"
+"const now = dayjs();\n"
+"console.log(now.format(\"YYYY-MM-DD\"));\n"
+"console.log(now.add(7, \"day\").format(\"YYYY-MM-DD\"));\n"
+"console.log(now.subtract(1, \"month\").toISOString());\n"
+"\n"
+"const diff = dayjs(\"2025-12-31\").diff(now, \"day\");\n"
+"console.log(`${diff} days until end of year`);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:44
+msgid "moment"
+msgstr ""
+
+#: src/stdlib/utilities.md:46
+msgid ""
+"Same status as `dayjs` — the runtime functions exist but the dispatch path "
+"is not wired yet."
+msgstr ""
+
+#: src/stdlib/utilities.md:49
+msgid ""
+"```text\n"
+"import moment from \"moment\";\n"
+"\n"
+"const now = moment();\n"
+"console.log(now.format(\"MMMM Do YYYY\"));\n"
+"console.log(now.fromNow());\n"
+"console.log(moment(\"2025-01-01\").isBefore(now));\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:58
+msgid "uuid"
+msgstr ""
+
+#: src/stdlib/utilities.md:60
+msgid ""
+"```typescript\n"
+"import { v4 as uuidv4 } from \"uuid\"\n"
+"\n"
+"const id = uuidv4()\n"
+"console.log(id) // e.g., \"550e8400-e29b-41d4-a716-446655440000\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:67
+msgid "nanoid"
+msgstr ""
+
+#: src/stdlib/utilities.md:69
+msgid ""
+"The default-length `nanoid()` call is wired. The custom-length form "
+"`nanoid(10)` has a runtime function (`js_nanoid_sized`) but no dispatch yet "
+"— track at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:73
+msgid ""
+"```typescript\n"
+"import { nanoid } from \"nanoid\"\n"
+"\n"
+"const nid = nanoid() // Default 21 chars\n"
+"console.log(nid)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:80
+msgid "slugify"
+msgstr ""
+
+#: src/stdlib/utilities.md:82
+msgid ""
+"The single-arg form is wired. The options-object form `slugify(\"Hello "
+"World!\", { lower: true })` has a runtime function "
+"(`js_slugify_with_options`) but no dispatch yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:86
+msgid ""
+"```typescript\n"
+"import slugify from \"slugify\"\n"
+"\n"
+"const slug = slugify(\"Hello World!\")\n"
+"console.log(slug) // \"hello-world\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:93
+msgid "validator"
+msgstr ""
+
+#: src/stdlib/utilities.md:95
+msgid ""
+"```typescript\n"
+"import validator from \"validator\"\n"
+"\n"
+"console.log(validator.isEmail(\"test@example.com\"))  // true\n"
+"console.log(validator.isURL(\"https://example.com\")) // true\n"
+"console.log(validator.isUUID(id))                   // true\n"
+"console.log(validator.isEmpty(\"\"))                  // true\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:3
+msgid "Additional npm packages and Node.js APIs supported by Perry."
+msgstr ""
+
+#: src/stdlib/other.md:5
+msgid "sharp (Image Processing)"
+msgstr ""
+
+#: src/stdlib/other.md:7
+msgid ""
+"The `sharp` runtime functions are declared (`js_sharp_resize`, "
+"`js_sharp_blur`, `js_sharp_to_buffer`, etc.) but the user-facing dispatch "
+"from `import sharp from \"sharp\"; sharp(input).resize(...)` is not wired "
+"into the LLVM backend yet. Track the follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:12
+msgid ""
+"```text\n"
+"import sharp from \"sharp\";\n"
+"\n"
+"await sharp(\"input.jpg\")\n"
+"  .resize(300, 200)\n"
+"  .toFile(\"output.png\");\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:20
+msgid "cheerio (HTML Parsing)"
+msgstr ""
+
+#: src/stdlib/other.md:22
+msgid ""
+"The `cheerio` runtime exists (see `crates/perry-stdlib/src/cheerio.rs`) but "
+"the dispatch path is not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:25
+msgid ""
+"```text\n"
+"import cheerio from \"cheerio\";\n"
+"\n"
+"const html = \"<html><body><h1>Hello</h1><p>World</p></body></html>\";\n"
+"const $ = cheerio.load(html);\n"
+"console.log($(\"h1\").text()); // \"Hello\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:33
+msgid "nodemailer (Email)"
+msgstr ""
+
+#: src/stdlib/other.md:35
+msgid ""
+"```typescript\n"
+"import nodemailer from \"nodemailer\"\n"
+"\n"
+"async function nodemailerExample(): Promise<void> {\n"
+"    const transporter = nodemailer.createTransport({\n"
+"        host: \"smtp.example.com\",\n"
+"        port: 587,\n"
+"        auth: { user: \"user\", pass: \"pass\" },\n"
+"    })\n"
+"\n"
+"    await transporter.sendMail({\n"
+"        from: \"sender@example.com\",\n"
+"        to: \"recipient@example.com\",\n"
+"        subject: \"Hello from Perry\",\n"
+"        text: \"This email was sent from a compiled TypeScript binary!\",\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:54
+msgid "zlib (Compression)"
+msgstr ""
+
+#: src/stdlib/other.md:56
+msgid ""
+"The `zlib` runtime exists but dispatch from `import zlib from \"zlib\"` is "
+"not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:59
+msgid ""
+"```text\n"
+"import zlib from \"zlib\";\n"
+"\n"
+"const compressed = zlib.gzipSync(\"Hello, World!\");\n"
+"const decompressed = zlib.gunzipSync(compressed);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:66
+msgid "cron (Job Scheduling)"
+msgstr ""
+
+#: src/stdlib/other.md:68
+msgid ""
+"The `cron` runtime exists but dispatch from `import { CronJob } from "
+"\"cron\"` is not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:71
+msgid ""
+"```text\n"
+"import { CronJob } from \"cron\";\n"
+"\n"
+"const job = new CronJob(\"*/5 * * * *\", () => {\n"
+"  console.log(\"Runs every 5 minutes\");\n"
+"});\n"
+"job.start();\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:80
+msgid "worker_threads"
+msgstr ""
+
+#: src/stdlib/other.md:82
+msgid ""
+"The `worker_threads` API is partially recognized at HIR-lowering time "
+"(`parentPort` / `Worker` shapes) but full dispatch is incomplete. For data-"
+"parallel work today, prefer `parallelMap` / `parallelFilter` / `spawn` from "
+"`perry/thread` (see [Threading](../threading/overview.md))."
+msgstr ""
+
+#: src/stdlib/other.md:87
+msgid ""
+"```text\n"
+"import { Worker, parentPort, workerData } from \"worker_threads\";\n"
+"\n"
+"if (parentPort) {\n"
+"  // Worker thread\n"
+"  const data = workerData;\n"
+"  parentPort.postMessage({ result: data.value * 2 });\n"
+"} else {\n"
+"  // Main thread\n"
+"  const worker = new Worker(\"./worker.ts\", {\n"
+"    workerData: { value: 21 },\n"
+"  });\n"
+"  worker.on(\"message\", (msg) => {\n"
+"    console.log(msg.result); // 42\n"
+"  });\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:105
+msgid "commander (CLI Parsing)"
+msgstr ""
+
+#: src/stdlib/other.md:107
+msgid ""
+"```typescript\n"
+"import { Command } from \"commander\"\n"
+"\n"
+"function commanderExample(): void {\n"
+"    const program = new Command()\n"
+"    program.name(\"my-cli\").version(\"1.0.0\").description(\"My CLI tool\")\n"
+"\n"
+"    program\n"
+"        .command(\"serve\")\n"
+"        .option(\"-p, --port <number>\", \"Port number\")\n"
+"        .option(\"--verbose\", \"Verbose output\")\n"
+"        .action((options: any) => {\n"
+"            console.log(`Starting server on port ${options.port}`)\n"
+"        })\n"
+"\n"
+"    program.parse(process.argv)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:126
+msgid "decimal.js (Arbitrary Precision)"
+msgstr ""
+
+#: src/stdlib/other.md:128
+msgid ""
+"```typescript\n"
+"import Decimal from \"decimal.js\"\n"
+"\n"
+"function decimalExample(): void {\n"
+"    const a = new Decimal(\"0.1\")\n"
+"    const b = new Decimal(\"0.2\")\n"
+"    const sum = a.plus(b) // Exactly 0.3 (no floating point errors)\n"
+"\n"
+"    console.log(sum.toFixed(2))      // \"0.30\"\n"
+"    console.log(sum.toNumber())      // 0.3\n"
+"    console.log(a.times(b).toFixed(2)) // \"0.02\"\n"
+"    console.log(a.div(b).toFixed(1))   // \"0.5\"\n"
+"    console.log(a.pow(10).toString())  // 1e-10\n"
+"    console.log(a.sqrt().toFixed(3))   // \"0.316\"\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:145
+msgid "lru-cache"
+msgstr ""
+
+#: src/stdlib/other.md:147
+msgid ""
+"The wired constructor takes the npm v7+ options-object shape (`new "
+"LRUCache({ max: 100 })`) — the older positional form `new LRUCache(100)` "
+"falls through to a `max=100` default."
+msgstr ""
+
+#: src/stdlib/other.md:151
+msgid ""
+"```typescript\n"
+"import { LRUCache } from \"lru-cache\"\n"
+"\n"
+"function lruCacheExample(): void {\n"
+"    const cache = new LRUCache({ max: 100 }) // max 100 entries\n"
+"\n"
+"    cache.set(\"key\", \"value\")\n"
+"    console.log(cache.get(\"key\"))   // \"value\"\n"
+"    console.log(cache.has(\"key\"))   // true\n"
+"    cache.delete(\"key\")\n"
+"    cache.clear()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:165
+msgid "child_process"
+msgstr ""
+
+#: src/stdlib/other.md:167
+msgid ""
+"```typescript\n"
+"import { spawnBackground, getProcessStatus, killProcess } from \"child_process\"\n"
+"\n"
+"function childProcessExample(): void {\n"
+"    // Spawn a background process\n"
+"    const { pid, handleId } = spawnBackground(\"sleep\", [\"10\"], \"/tmp/log.txt\")\n"
+"\n"
+"    // Check if it's still running\n"
+"    const status = getProcessStatus(handleId)\n"
+"    console.log(status.alive) // true\n"
+"    console.log(`pid=${pid}`)\n"
+"\n"
+"    // Kill it\n"
+"    killProcess(handleId)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:187
+msgid "[File System](fs.md) — fs and path APIs"
+msgstr ""
+
+#: src/i18n/overview.md:1
+msgid "Internationalization (i18n)"
+msgstr ""
+
+#: src/i18n/overview.md:3
+msgid ""
+"Perry's i18n system lets you write natural English strings and have them "
+"automatically translated at compile time. Zero ceremony, near-zero runtime "
+"cost."
+msgstr ""
+
+#: src/i18n/overview.md:5
+msgid ""
+"```typescript\n"
+"// String literals in UI component calls are automatically localizable keys.\n"
+"// (Conceptually the docs write `Button(\"Next\")` / `Text(\"Hello, {name}!\", ...)`\n"
+"// from \"perry/ui\"; we exercise the runtime API that backs them — t() — here.)\n"
+"const next = t(\"Next\")                                  // Automatically localized\n"
+"const hello = t(\"Hello, {name}!\", { name: \"Alice\" })    // With interpolation\n"
+"console.log(next, hello)\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:14
+msgid ""
+"The same key-resolution and interpolation runs through the explicit `t()` "
+"API for non-UI strings:"
+msgstr ""
+
+#: src/i18n/overview.md:16
+msgid ""
+"```typescript\n"
+"import { t, Currency, Percent, ShortDate, LongDate, FormatNumber, FormatTime, Raw } from \"perry/i18n\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:20
+msgid "Design Principles"
+msgstr ""
+
+#: src/i18n/overview.md:22
+msgid ""
+"**Zero ceremony**: String literals in UI components are automatically "
+"localizable keys"
+msgstr ""
+
+#: src/i18n/overview.md:23
+msgid ""
+"**Compile-time validation**: Missing translations, parameter mismatches, and"
+" plural form errors caught during build"
+msgstr ""
+
+#: src/i18n/overview.md:24
+msgid ""
+"**Embedded string table**: All translations baked into the binary as a flat "
+"2D table. Near-zero runtime lookup cost"
+msgstr ""
+
+#: src/i18n/overview.md:25
+msgid ""
+"**Platform-native locale detection**: Uses OS APIs on every platform (no env"
+" vars needed on mobile)"
+msgstr ""
+
+#: src/i18n/overview.md:29
+msgid "1. Add i18n config to perry.toml"
+msgstr ""
+
+#: src/i18n/overview.md:31
+msgid ""
+"```toml\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\"]\n"
+"default_locale = \"en\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:37
+msgid "2. Extract strings from your code"
+msgstr ""
+
+#: src/i18n/overview.md:43
+msgid ""
+"This scans your source files and creates `locales/en.json` and "
+"`locales/de.json`:"
+msgstr ""
+
+#: src/i18n/overview.md:46 src/i18n/interpolation.md:17
+#: src/i18n/interpolation.md:49
+msgid "// locales/en.json\n"
+msgstr ""
+
+#: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
+#: src/i18n/cli.md:38 src/i18n/cli.md:87
+msgid "\"Next\""
+msgstr ""
+
+#: src/i18n/overview.md:49 src/i18n/overview.md:55 src/i18n/overview.md:66
+msgid "\"Back\""
+msgstr ""
+
+#: src/i18n/overview.md:51
+msgid "// locales/de.json (empty values = needs translation)\n"
+msgstr ""
+
+#: src/i18n/overview.md:54 src/i18n/overview.md:55
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:73
+msgid "\"\""
+msgstr ""
+
+#: src/i18n/overview.md:59
+msgid "3. Translate"
+msgstr ""
+
+#: src/i18n/overview.md:61
+msgid "Fill in `locales/de.json`:"
+msgstr ""
+
+#: src/i18n/overview.md:65
+msgid "\"Weiter\""
+msgstr ""
+
+#: src/i18n/overview.md:66
+msgid "\"Zurck\""
+msgstr ""
+
+#: src/i18n/overview.md:70
+msgid "4. Build"
+msgstr ""
+
+#: src/i18n/overview.md:76
+msgid ""
+"Perry validates all translations at compile time and bakes them into the "
+"binary. At runtime, the app detects the user's system locale and shows the "
+"right language."
+msgstr ""
+
+#: src/i18n/overview.md:80
+msgid ""
+"**Detection**: String literals in UI component calls (`Button`, `Text`, "
+"`Label`, etc.) are automatically treated as i18n keys"
+msgstr ""
+
+#: src/i18n/overview.md:81
+msgid ""
+"**Transform**: The compiler replaces `Expr::String(\"Next\")` with "
+"`Expr::I18nString { key: \"Next\", string_idx: 0 }` in the HIR"
+msgstr ""
+
+#: src/i18n/overview.md:82
+msgid ""
+"**Codegen**: For each `I18nString`, the compiler emits a locale branch that "
+"selects the correct translation at runtime"
+msgstr ""
+
+#: src/i18n/overview.md:83
+msgid ""
+"**Locale detection**: At startup, `perry_i18n_init()` detects the system "
+"locale via native APIs and sets the global locale index"
+msgstr ""
+
+#: src/i18n/overview.md:85
+msgid "Locale Detection"
+msgstr ""
+
+#: src/i18n/overview.md:89 src/i18n/overview.md:90
+msgid "`CFLocaleCopyCurrent()` (CoreFoundation)"
+msgstr ""
+
+#: src/i18n/overview.md:91
+msgid "`__system_property_get(\"persist.sys.locale\")`"
+msgstr ""
+
+#: src/i18n/overview.md:92
+msgid "`GetUserDefaultLocaleName()` (Win32)"
+msgstr ""
+
+#: src/i18n/overview.md:93
+msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
+msgstr ""
+
+#: src/i18n/overview.md:95
+msgid ""
+"The detected locale is fuzzy-matched against your configured locales: "
+"`de_DE.UTF-8` matches `de`, `en-US` matches `en`, etc."
+msgstr ""
+
+#: src/i18n/overview.md:97
+msgid "Platform Output"
+msgstr ""
+
+#: src/i18n/overview.md:99
+msgid ""
+"When compiling for mobile targets, Perry generates platform-native locale "
+"resources alongside the binary:"
+msgstr ""
+
+#: src/i18n/overview.md:101 src/widgets/platforms.md:9
+msgid "Output"
+msgstr ""
+
+#: src/i18n/overview.md:103
+msgid "iOS/macOS"
+msgstr ""
+
+#: src/i18n/overview.md:103
+msgid "`{locale}.lproj/Localizable.strings` inside `.app` bundle"
+msgstr ""
+
+#: src/i18n/overview.md:104
+msgid "`res/values-{locale}/strings.xml`"
+msgstr ""
+
+#: src/i18n/overview.md:105
+msgid "Desktop"
+msgstr ""
+
+#: src/i18n/overview.md:105
+msgid "Strings embedded in binary (no extra files)"
+msgstr ""
+
+#: src/i18n/overview.md:109
+msgid "[Interpolation & Plurals](interpolation.md)"
+msgstr ""
+
+#: src/i18n/overview.md:110
+msgid "[Formatting](formatting.md)"
+msgstr ""
+
+#: src/i18n/overview.md:111
+msgid "[CLI Tools](cli.md)"
+msgstr ""
+
+#: src/i18n/interpolation.md:3
+msgid "Parameterized Strings"
+msgstr ""
+
+#: src/i18n/interpolation.md:5
+msgid ""
+"Use `{param}` placeholders in your strings and pass values as a second "
+"argument:"
+msgstr ""
+
+#: src/i18n/interpolation.md:7
+msgid ""
+"```typescript\n"
+"// Use {param} placeholders in your strings and pass values as a second arg.\n"
+"const greeting = t(\"Hello, {name}!\", { name: \"Alice\" })\n"
+"const total = t(\"Total: {price}\", { price: 23.10 })\n"
+"console.log(greeting, total)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:14
+msgid "Translation files use the same `{param}` syntax:"
+msgstr ""
+
+#: src/i18n/interpolation.md:19 src/i18n/interpolation.md:25
+#: src/i18n/cli.md:38 src/i18n/cli.md:88
+msgid "\"Hello, {name}!\""
+msgstr ""
+
+#: src/i18n/interpolation.md:20 src/i18n/interpolation.md:26
+msgid "\"Total: {price}\""
+msgstr ""
+
+#: src/i18n/interpolation.md:22 src/i18n/interpolation.md:54
+msgid "// locales/de.json\n"
+msgstr ""
+
+#: src/i18n/interpolation.md:25
+msgid "\"Hallo, {name}!\""
+msgstr ""
+
+#: src/i18n/interpolation.md:26
+msgid "\"Gesamt: {price}\""
+msgstr ""
+
+#: src/i18n/interpolation.md:30
+msgid ""
+"Parameters are substituted at runtime after the locale-appropriate template "
+"is selected. The substitution handles any value type (numbers, strings, "
+"dates) by converting to string."
+msgstr ""
+
+#: src/i18n/interpolation.md:32 src/i18n/interpolation.md:99
+msgid "Compile-Time Validation"
+msgstr ""
+
+#: src/i18n/interpolation.md:34
+msgid "Perry validates parameters across all locales during compilation:"
+msgstr ""
+
+#: src/i18n/interpolation.md:36 src/i18n/interpolation.md:101
+msgid "Condition"
+msgstr ""
+
+#: src/i18n/interpolation.md:36 src/i18n/interpolation.md:101
+msgid "Severity"
+msgstr ""
+
+#: src/i18n/interpolation.md:38
+msgid "`{param}` in translation but not provided in code"
+msgstr ""
+
+#: src/i18n/interpolation.md:38 src/i18n/interpolation.md:39
+#: src/i18n/interpolation.md:40 src/i18n/interpolation.md:103
+#: src/i18n/interpolation.md:104
+msgid "Error"
+msgstr ""
+
+#: src/i18n/interpolation.md:39
+msgid "Param in code but `{param}` not in translation"
+msgstr ""
+
+#: src/i18n/interpolation.md:40
+msgid "Parameter set differs between locales for same key"
+msgstr ""
+
+#: src/i18n/interpolation.md:42
+msgid "Plural Rules"
+msgstr ""
+
+#: src/i18n/interpolation.md:44
+msgid ""
+"Plural forms use dot-suffix keys based on CLDR plural categories: `.zero`, "
+"`.one`, `.two`, `.few`, `.many`, `.other`."
+msgstr ""
+
+#: src/i18n/interpolation.md:46
+msgid "Locale Files"
+msgstr ""
+
+#: src/i18n/interpolation.md:51 src/i18n/interpolation.md:57
+#: src/i18n/interpolation.md:63
+msgid "\"You have {count} items.one\""
+msgstr ""
+
+#: src/i18n/interpolation.md:51
+msgid "\"You have {count} item.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:52 src/i18n/interpolation.md:58
+#: src/i18n/interpolation.md:66
+msgid "\"You have {count} items.other\""
+msgstr ""
+
+#: src/i18n/interpolation.md:52
+msgid "\"You have {count} items.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:57 src/i18n/interpolation.md:58
+msgid "\"Du hast {count} Artikel.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:60
+msgid "// locales/pl.json (Polish: one, few, many)\n"
+msgstr ""
+
+#: src/i18n/interpolation.md:63
+msgid "\"Masz {count} element.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:64
+msgid "\"You have {count} items.few\""
+msgstr ""
+
+#: src/i18n/interpolation.md:64
+msgid "\"Masz {count} elementy.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:65
+msgid "\"You have {count} items.many\""
+msgstr ""
+
+#: src/i18n/interpolation.md:65
+msgid "\"Masz {count} elementow.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:66
+msgid "\"Masz {count} elementu.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:70
+msgid "Usage in Code"
+msgstr ""
+
+#: src/i18n/interpolation.md:72
+msgid ""
+"Reference the base key without any suffix. Perry detects the plural variants"
+" automatically:"
+msgstr ""
+
+#: src/i18n/interpolation.md:74
+msgid ""
+"```typescript\n"
+"// Reference the base key without any suffix — Perry picks the plural variant\n"
+"// from the `count` parameter and the current locale's CLDR rules.\n"
+"const cartCount = 3\n"
+"const itemMessage = t(\"You have {count} items\", { count: cartCount })\n"
+"console.log(itemMessage)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:82
+msgid ""
+"Perry determines which plural form to use based on the `count` parameter "
+"value and the current locale's CLDR rules."
+msgstr ""
+
+#: src/i18n/interpolation.md:84
+msgid "Supported Locales"
+msgstr ""
+
+#: src/i18n/interpolation.md:86
+msgid "Perry includes hand-rolled CLDR plural rules for 30+ locales:"
+msgstr ""
+
+#: src/i18n/interpolation.md:88
+msgid "Pattern"
+msgstr ""
+
+#: src/i18n/interpolation.md:88
+msgid "Locales"
+msgstr ""
+
+#: src/i18n/interpolation.md:90
+msgid "one/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:90
+msgid ""
+"English, German, Dutch, Swedish, Danish, Norwegian, Finnish, Estonian, "
+"Hungarian, Turkish, Greek, Hebrew, Italian, Spanish, Portuguese, Catalan, "
+"Bulgarian, Hindi, Bengali, Swahili, ..."
+msgstr ""
+
+#: src/i18n/interpolation.md:91
+msgid "one (0-1) / other"
+msgstr ""
+
+#: src/i18n/interpolation.md:91
+msgid "French"
+msgstr ""
+
+#: src/i18n/interpolation.md:92
+msgid "no distinction"
+msgstr ""
+
+#: src/i18n/interpolation.md:92
+msgid "Japanese, Chinese, Korean, Vietnamese, Thai, Indonesian, Malay"
+msgstr ""
+
+#: src/i18n/interpolation.md:93
+msgid "one/few/many"
+msgstr ""
+
+#: src/i18n/interpolation.md:93
+msgid "Russian, Ukrainian, Serbian, Croatian, Bosnian, Polish"
+msgstr ""
+
+#: src/i18n/interpolation.md:94 src/i18n/interpolation.md:96
+msgid "one/few/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:94
+msgid "Czech, Slovak"
+msgstr ""
+
+#: src/i18n/interpolation.md:95
+msgid "zero/one/two/few/many/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:95
+msgid "Arabic"
+msgstr ""
+
+#: src/i18n/interpolation.md:96
+msgid "Romanian, Lithuanian"
+msgstr ""
+
+#: src/i18n/interpolation.md:97
+msgid "zero/one/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:97
+msgid "Latvian"
+msgstr ""
+
+#: src/i18n/interpolation.md:103
+msgid "`.other` form missing for any locale"
+msgstr ""
+
+#: src/i18n/interpolation.md:104
+msgid "Required CLDR category missing (e.g., `.few` for Polish)"
+msgstr ""
+
+#: src/i18n/interpolation.md:105
+msgid "Extra category locale doesn't use (e.g., `.few` for English)"
+msgstr ""
+
+#: src/i18n/interpolation.md:105
+msgid "Warning"
+msgstr ""
+
+#: src/i18n/interpolation.md:107
+msgid "Explicit API for Non-UI Strings"
+msgstr ""
+
+#: src/i18n/interpolation.md:109
+msgid ""
+"For strings outside UI components (API responses, notifications, etc.), use "
+"`t()`:"
+msgstr ""
+
+#: src/i18n/interpolation.md:111
+msgid ""
+"```typescript\n"
+"// For strings outside UI components (API responses, notifications, …), use t():\n"
+"const message = t(\"Your order has been shipped.\")\n"
+"const welcome = t(\"Welcome back, {name}!\", { name: \"Alice\" })\n"
+"console.log(message, welcome)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:118
+msgid ""
+"This uses the same key lookup, validation, and interpolation as UI strings."
+msgstr ""
+
+#: src/i18n/formatting.md:1
+msgid "Locale-Aware Formatting"
+msgstr ""
+
+#: src/i18n/formatting.md:3
+msgid ""
+"Perry provides format wrapper functions that automatically format values "
+"according to the current locale. Import them from `perry/i18n`:"
+msgstr ""
+
+#: src/i18n/formatting.md:5
+msgid ""
+"```typescript\n"
+"// All format wrappers come from perry/i18n.\n"
+"// (The same `Currency`, `Percent`, … you'd pass into a Text(...) param object.)\n"
+"const price = Currency(23.10)\n"
+"const discount = Percent(0.15)\n"
+"const population = FormatNumber(1234567.89)\n"
+"const due = ShortDate(Date.now())\n"
+"const event = LongDate(Date.now())\n"
+"const at = FormatTime(Date.now())\n"
+"const code = Raw(12345)\n"
+"\n"
+"// Compose them with t() the same way you'd compose with Text(...):\n"
+"console.log(t(\"Total: {price}\", { price }))\n"
+"console.log(t(\"Discount: {rate}\", { rate: discount }))\n"
+"console.log(t(\"Population: {n}\", { n: population }))\n"
+"console.log(t(\"Due: {d}\", { d: due }))\n"
+"console.log(t(\"Event: {d}\", { d: event }))\n"
+"console.log(t(\"At: {t}\", { t: at }))\n"
+"console.log(t(\"Code: {amount}\", { amount: code }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:26
+msgid "Format Wrappers"
+msgstr ""
+
+#: src/i18n/formatting.md:28
+msgid "Currency"
+msgstr ""
+
+#: src/i18n/formatting.md:30
+msgid ""
+"Formats a number as currency with the locale's symbol, decimal separator, "
+"and symbol placement:"
+msgstr ""
+
+#: src/i18n/formatting.md:32
+msgid ""
+"```typescript\n"
+"// Currency: locale-appropriate symbol, separator, and placement.\n"
+"//   en: \"$23.10\"   de: \"23,10 €\"   ja: \"¥23.10\"\n"
+"const cur = Currency(23.10)\n"
+"console.log(t(\"Total: {price}\", { price: cur }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:39
+msgid ""
+"```text\n"
+"en: \"Total: $23.10\"\n"
+"de: \"Total: 23,10 €\"\n"
+"fr: \"Total: 23,10 €\"\n"
+"ja: \"Total: ¥23.10\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:46
+msgid "Percent"
+msgstr ""
+
+#: src/i18n/formatting.md:48
+msgid "Formats a decimal as a percentage (value is multiplied by 100):"
+msgstr ""
+
+#: src/i18n/formatting.md:50
+msgid ""
+"```typescript\n"
+"// Percent: input is a decimal (0.15 → 15 %). en omits the space; de/fr add it.\n"
+"const rate = Percent(0.15)\n"
+"console.log(t(\"Discount: {rate}\", { rate }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:56
+msgid ""
+"```text\n"
+"en: \"Discount: 15%\"\n"
+"de: \"Discount: 15 %\"\n"
+"fr: \"Discount: 15 %\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:62
+msgid "FormatNumber"
+msgstr ""
+
+#: src/i18n/formatting.md:64
+msgid ""
+"Formats a number with locale-appropriate grouping and decimal separators:"
+msgstr ""
+
+#: src/i18n/formatting.md:66
+msgid ""
+"```typescript\n"
+"// FormatNumber: locale-appropriate grouping + decimal separators.\n"
+"//   en: \"1,234,567.89\"   de: \"1.234.567,89\"   fr: \"1 234 567,89\"\n"
+"const n = FormatNumber(1234567.89)\n"
+"console.log(t(\"Population: {n}\", { n }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:73
+msgid ""
+"```text\n"
+"en: \"Population: 1,234,567.89\"\n"
+"de: \"Population: 1.234.567,89\"\n"
+"fr: \"Population: 1 234 567,89\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:79
+msgid "ShortDate / LongDate / FormatDate"
+msgstr ""
+
+#: src/i18n/formatting.md:81
+msgid "Formats a timestamp (milliseconds since epoch) as a date:"
+msgstr ""
+
+#: src/i18n/formatting.md:83
+msgid ""
+"```typescript\n"
+"// ShortDate / LongDate take a millisecond timestamp.\n"
+"const now = Date.now()\n"
+"const short = ShortDate(now)   // en: \"3/22/2026\"   de: \"22.03.2026\"\n"
+"const long = LongDate(now)     // en: \"March 22, 2026\"   de: \"22. März 2026\"\n"
+"console.log(t(\"Due: {d}\", { d: short }))\n"
+"console.log(t(\"Event: {d}\", { d: long }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:92
+msgid ""
+"```text\n"
+"ShortDate\n"
+"  en: \"Due: 3/22/2026\"\n"
+"  de: \"Due: 22.03.2026\"\n"
+"  ja: \"Due: 2026/03/22\"\n"
+"\n"
+"LongDate\n"
+"  en: \"Event: March 22, 2026\"\n"
+"  de: \"Event: 22. März 2026\"\n"
+"  fr: \"Event: 22 mars 2026\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:104
+msgid "FormatTime"
+msgstr ""
+
+#: src/i18n/formatting.md:106
+msgid "Formats a timestamp as time (12h vs 24h based on locale):"
+msgstr ""
+
+#: src/i18n/formatting.md:108
+msgid ""
+"```typescript\n"
+"// FormatTime: 12h vs 24h based on the active locale.\n"
+"const ts = Date.now()\n"
+"const formatted = FormatTime(ts)\n"
+"console.log(t(\"At: {t}\", { t: formatted }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:115
+msgid ""
+"```text\n"
+"en: \"At: 3:45 PM\"\n"
+"de: \"At: 15:45\"\n"
+"fr: \"At: 15:45\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:121
+msgid "Raw"
+msgstr ""
+
+#: src/i18n/formatting.md:123
+msgid ""
+"Pass-through — prevents any automatic formatting. Use when a parameter name "
+"might trigger auto-formatting but you want the raw value:"
+msgstr ""
+
+#: src/i18n/formatting.md:125
+msgid ""
+"```typescript\n"
+"// Raw is a pass-through — prevents auto-formatting when the param name\n"
+"// might otherwise trigger it.\n"
+"const orderCode = Raw(12345)\n"
+"console.log(t(\"Code: {amount}\", { amount: orderCode }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:132
+msgid "All locales: `\"Code: 12345\"` (no currency formatting despite the name)."
+msgstr ""
+
+#: src/i18n/formatting.md:134
+msgid "Locale-Specific Formatting Rules"
+msgstr ""
+
+#: src/i18n/formatting.md:136
+msgid "Perry includes hand-rolled formatting rules for 25+ locales:"
+msgstr ""
+
+#: src/i18n/formatting.md:138
+msgid "Example Locales"
+msgstr ""
+
+#: src/i18n/formatting.md:140
+msgid "Decimal: `.` / Thousands: `,`"
+msgstr ""
+
+#: src/i18n/formatting.md:140 src/i18n/formatting.md:144
+msgid "en, ja, zh, ko"
+msgstr ""
+
+#: src/i18n/formatting.md:141
+msgid "Decimal: `,` / Thousands: `.`"
+msgstr ""
+
+#: src/i18n/formatting.md:141
+msgid "de, nl, tr, es, it, pt"
+msgstr ""
+
+#: src/i18n/formatting.md:142
+msgid "Decimal: `,` / Thousands: ` ` (narrow space)"
+msgstr ""
+
+#: src/i18n/formatting.md:142
+msgid "fr"
+msgstr ""
+
+#: src/i18n/formatting.md:143
+msgid "Decimal: `,` / Thousands: ` ` (non-breaking space)"
+msgstr ""
+
+#: src/i18n/formatting.md:143
+msgid "ru, uk, pl, sv, da, no, fi"
+msgstr ""
+
+#: src/i18n/formatting.md:144
+msgid "Currency before number: `$23.10`"
+msgstr ""
+
+#: src/i18n/formatting.md:145
+msgid "Currency after number: `23,10 €`"
+msgstr ""
+
+#: src/i18n/formatting.md:145
+msgid "de, fr, es, it, ru"
+msgstr ""
+
+#: src/i18n/formatting.md:146
+msgid "Percent with space: `42 %`"
+msgstr ""
+
+#: src/i18n/formatting.md:146 src/i18n/formatting.md:149
+msgid "de, fr, es, ru"
+msgstr ""
+
+#: src/i18n/formatting.md:147
+msgid "Percent without space: `42%`"
+msgstr ""
+
+#: src/i18n/formatting.md:147
+msgid "en, ja, zh"
+msgstr ""
+
+#: src/i18n/formatting.md:148
+msgid "Date order: M/D/Y"
+msgstr ""
+
+#: src/i18n/formatting.md:148 src/i18n/formatting.md:152
+msgid "en"
+msgstr ""
+
+#: src/i18n/formatting.md:149
+msgid "Date order: D.M.Y"
+msgstr ""
+
+#: src/i18n/formatting.md:150
+msgid "Date order: Y/M/D"
+msgstr ""
+
+#: src/i18n/formatting.md:150
+msgid "ja, zh, ko, sv"
+msgstr ""
+
+#: src/i18n/formatting.md:151
+msgid "24-hour time"
+msgstr ""
+
+#: src/i18n/formatting.md:151
+msgid "de, fr, es, ja, zh, ru (most)"
+msgstr ""
+
+#: src/i18n/formatting.md:152
+msgid "12-hour time (AM/PM)"
+msgstr ""
+
+#: src/i18n/formatting.md:154
+msgid "Currency Configuration"
+msgstr ""
+
+#: src/i18n/formatting.md:156
+msgid "Configure default currency codes per locale in `perry.toml`:"
+msgstr ""
+
+#: src/i18n/formatting.md:158
+msgid ""
+"```toml\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\", \"fr\"]\n"
+"default_locale = \"en\"\n"
+"\n"
+"[i18n.currencies]\n"
+"en = \"USD\"\n"
+"de = \"EUR\"\n"
+"fr = \"EUR\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:169
+msgid ""
+"When `Currency(value)` is called, the locale's configured currency code "
+"determines the symbol and formatting rules."
+msgstr ""
+
+#: src/i18n/cli.md:1
+msgid "i18n CLI Tools"
+msgstr ""
+
+#: src/i18n/cli.md:3 src/cli/commands.md:308
+msgid "`perry i18n extract`"
+msgstr ""
+
+#: src/i18n/cli.md:5
+msgid ""
+"Scans your TypeScript source files for localizable strings and generates or "
+"updates locale JSON files."
+msgstr ""
+
+#: src/i18n/cli.md:11
+msgid "What It Does"
+msgstr ""
+
+#: src/i18n/cli.md:13
+msgid "Recursively scans all `.ts` and `.tsx` files in the source directory"
+msgstr ""
+
+#: src/i18n/cli.md:14
+msgid ""
+"Detects string literals in UI component calls: `Button(\"...\")`, "
+"`Text(\"...\")`, `Label(\"...\")`, etc."
+msgstr ""
+
+#: src/i18n/cli.md:15
+msgid "Also detects `t(\"...\")` calls from `perry/i18n`"
+msgstr ""
+
+#: src/i18n/cli.md:16
+msgid "Creates `locales/` directory if it doesn't exist"
+msgstr ""
+
+#: src/i18n/cli.md:17
+msgid "For each configured locale, creates or updates a JSON file:"
+msgstr ""
+
+#: src/i18n/cli.md:18
+msgid "**Default locale**: New keys are pre-filled with themselves as values"
+msgstr ""
+
+#: src/i18n/cli.md:19
+msgid ""
+"**Non-default locales**: New keys are added with empty string values "
+"(indicating \"needs translation\")"
+msgstr ""
+
+#: src/i18n/cli.md:21
+msgid "Example Output"
+msgstr ""
+
+#: src/i18n/cli.md:32
+msgid "Workflow"
+msgstr ""
+
+#: src/i18n/cli.md:34
+msgid "Typical translation workflow:"
+msgstr ""
+
+#: src/i18n/cli.md:37
+msgid "# 1. Write code with English strings\n"
+msgstr ""
+
+#: src/i18n/cli.md:39
+msgid "# 2. Extract strings to locale files\n"
+msgstr ""
+
+#: src/i18n/cli.md:42
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
+msgstr ""
+
+#: src/i18n/cli.md:44
+msgid "# 4. Build — Perry validates everything\n"
+msgstr ""
+
+#: src/i18n/cli.md:49
+msgid "Detected Patterns"
+msgstr ""
+
+#: src/i18n/cli.md:51
+msgid "The scanner detects these UI component patterns:"
+msgstr ""
+
+#: src/i18n/cli.md:53
+msgid "`Button(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:54
+msgid "`Text(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:55
+msgid "`Label(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:56
+msgid "`TextField(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:57
+msgid "`TextArea(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:58
+msgid "`Tab(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:59
+msgid "`NavigationTitle(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:60
+msgid "`SectionHeader(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:61
+msgid "`SecureField(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:62
+msgid "`Alert(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:63
+msgid "`t(\"string\")` (explicit i18n API)"
+msgstr ""
+
+#: src/i18n/cli.md:65
+msgid ""
+"Both double-quoted and single-quoted strings are supported. Escaped quotes "
+"are handled correctly."
+msgstr ""
+
+#: src/i18n/cli.md:67
+msgid "Build Output"
+msgstr ""
+
+#: src/i18n/cli.md:69
+msgid "During compilation, Perry reports i18n status:"
+msgstr ""
+
+#: src/i18n/cli.md:71
+msgid ""
+"```\n"
+"  i18n: 2 locale(s) [en, de], default: en\n"
+"    Loaded locales/en.json (12 keys)\n"
+"    Loaded locales/de.json (12 keys)\n"
+"  i18n: 12 localizable string(s) detected\n"
+"  i18n warning: Missing translation for key \"Settings\" in locale \"de\"\n"
+"  i18n warning: Unused i18n key \"Old Label\" in locale \"en\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/cli.md:80
+msgid "Key Registry"
+msgstr ""
+
+#: src/i18n/cli.md:82
+msgid ""
+"Perry maintains a `.perry/i18n-keys.json` file, updated on every build:"
+msgstr ""
+
+#: src/i18n/cli.md:86
+msgid "\"keys\""
+msgstr ""
+
+#: src/i18n/cli.md:87 src/i18n/cli.md:88 src/i18n/cli.md:89
+msgid "\"key\""
+msgstr ""
+
+#: src/i18n/cli.md:87 src/i18n/cli.md:88 src/i18n/cli.md:89
+msgid "\"string_idx\""
+msgstr ""
+
+#: src/i18n/cli.md:89
+msgid "\"You have {count} items\""
+msgstr ""
+
+#: src/i18n/cli.md:94
+msgid ""
+"This file serves as the source of truth for what strings exist in the "
+"codebase."
+msgstr ""
+
+#: src/updater/overview.md:3
+msgid ""
+"Ship updates to your Perry desktop app without rolling your own download + "
+"replace + relaunch flow. Two modules cooperate:"
+msgstr ""
+
+#: src/updater/overview.md:6
+msgid ""
+"**`@perry/updater`** — high-level wrapper. The 90% case: manifest fetch, "
+"semver compare, download, verify, install, relaunch, crash-loop rollback."
+msgstr ""
+
+#: src/updater/overview.md:8
+msgid ""
+"**`perry/updater`** — ambient primitives the wrapper is built on. Reach for "
+"these only when you need a custom flow (multi-channel rollouts, your own "
+"progress UI, an integration with an external supervisor)."
+msgstr ""
+
+#: src/updater/overview.md:12
+msgid ""
+"The trust model and wire format follow [Tauri's "
+"updater](https://v2.tauri.app/plugin/updater/): JSON manifest over HTTPS, "
+"SHA-256 + Ed25519 signature over the digest, atomic binary replace with a "
+"`.prev` backup, detached relaunch. Every snippet below is excerpted from "
+"[`docs/examples/updater/snippets.ts`](../../examples/updater/snippets.ts) — "
+"CI compile-links it on every PR."
+msgstr ""
+
+#: src/updater/overview.md:19
+msgid ""
+"**Desktop only.** iOS / TestFlight, Android Play Store, and sideloaded APKs "
+"own the install pipeline at the OS level — replacing your own binary at "
+"runtime is structurally impossible there. The crate still compiles on mobile"
+" targets so cross-platform code doesn't need `#ifdef`s, but the install path"
+" is a no-op. Gate updater code with `process.platform` if your app ships "
+"everywhere."
+msgstr ""
+
+#: src/updater/overview.md:26 src/system/media.md:8
+#: src/plugins/appstore-review.md:11
+msgid "Quick start"
+msgstr ""
+
+#: src/updater/overview.md:28
+msgid ""
+"```typescript\n"
+"// import { checkForUpdate, initUpdater, markHealthy } from \"@perry/updater\"\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:32
+msgid ""
+"Drop a \"Check for updates\" handler somewhere in your menu or a periodic "
+"timer. `checkForUpdate` returns `null` when up to date or when the manifest "
+"has no entry for the current platform."
+msgstr ""
+
+#: src/updater/overview.md:36
+msgid ""
+"```typescript\n"
+"// Pseudocode using @perry/updater's wrapper. Drop into a \"Check for updates\"\n"
+"// menu item or a periodic timer. The manifest URL must serve over HTTPS.\n"
+"//\n"
+"// const update = await checkForUpdate({\n"
+"//     manifestUrl: \"https://updates.example.com/myapp.json\",\n"
+"//     publicKey: \"BASE64_ED25519_PUBKEY\",\n"
+"//     currentVersion: \"1.4.0\",\n"
+"// })\n"
+"//\n"
+"// if (update !== null) {\n"
+"//     console.log(`v${update.version} is available`)\n"
+"//     console.log(update.notes)\n"
+"//\n"
+"//     await update.download((downloaded, total) => {\n"
+"//         const pct = Math.round((downloaded / total) * 100)\n"
+"//         console.log(`downloading: ${pct}%`)\n"
+"//     })\n"
+"//\n"
+"//     await update.installAndRelaunch()  // never returns — process.exit inside\n"
+"// }\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:59
+msgid ""
+"Call `initUpdater()` once near the top of `main()`. It handles boot-time "
+"crash-loop detection: if the new binary you just installed crashes during "
+"boot more than `crashLoopThreshold` times, the wrapper restores the previous"
+" version and exits so the OS / launcher restarts you on the rollback."
+msgstr ""
+
+#: src/updater/overview.md:64
+msgid ""
+"```typescript\n"
+"// Boot-time: detect a crash-looping new install and roll back. Call this\n"
+"// near the top of `main()`, right after process initialization.\n"
+"//\n"
+"// await initUpdater({\n"
+"//     autoRollback:       true,    // default\n"
+"//     healthCheckMs:      60_000,  // clear sentinel after this many ms alive\n"
+"//     crashLoopThreshold: 2,       // restarts before rollback fires\n"
+"// })\n"
+"//\n"
+"// // Optional: tell the updater explicitly that this version is healthy\n"
+"// // (e.g. after a successful login or migration finished).\n"
+"// // markHealthy()\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:79
+msgid "Manifest"
+msgstr ""
+
+#: src/updater/overview.md:81
+msgid ""
+"Serve a single JSON file over HTTPS. One entry per `<os>-<arch>` you publish"
+" for; clients ignore entries that don't match their platform."
+msgstr ""
+
+#: src/updater/overview.md:84
+msgid ""
+"```typescript\n"
+"// The manifest is a single JSON file you serve over HTTPS. Each platform\n"
+"// triple is `<os>-<arch>` (darwin-aarch64, darwin-x86_64, windows-x86_64,\n"
+"// linux-x86_64, linux-aarch64). The wrapper picks the entry matching the\n"
+"// running host and ignores the rest.\n"
+"//\n"
+"// {\n"
+"//   \"schemaVersion\": 1,\n"
+"//   \"version\": \"1.4.0\",\n"
+"//   \"pubDate\": \"2026-04-27T10:00:00Z\",\n"
+"//   \"notes\": \"Bug fixes and performance improvements\",\n"
+"//   \"platforms\": {\n"
+"//     \"darwin-aarch64\": {\n"
+"//       \"url\":       \"https://example.com/app-1.4.0-darwin-aarch64.bin\",\n"
+"//       \"sha256\":    \"0123456789abcdef...\",\n"
+"//       \"signature\": \"base64sig==\",\n"
+"//       \"size\":      12345678\n"
+"//     }\n"
+"//   }\n"
+"// }\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:106
+msgid "Meaning"
+msgstr ""
+
+#: src/updater/overview.md:108
+msgid "`schemaVersion`"
+msgstr ""
+
+#: src/updater/overview.md:108
+msgid ""
+"`1` (legacy, digest-only signature) or `2` (recommended — version-bound "
+"signature; see below)."
+msgstr ""
+
+#: src/updater/overview.md:109 src/cli/perry-toml.md:117
+msgid "`version`"
+msgstr ""
+
+#: src/updater/overview.md:109
+msgid "Semver string of the offered version (e.g. `\"1.4.0\"`)."
+msgstr ""
+
+#: src/updater/overview.md:110
+msgid "`pubDate`"
+msgstr ""
+
+#: src/updater/overview.md:110
+msgid "ISO-8601 timestamp the build was published — surfaced as metadata."
+msgstr ""
+
+#: src/updater/overview.md:111
+msgid "`notes`"
+msgstr ""
+
+#: src/updater/overview.md:111
+msgid "Markdown release notes shown to the user."
+msgstr ""
+
+#: src/updater/overview.md:112
+msgid "`platforms.<os>-<arch>.url`"
+msgstr ""
+
+#: src/updater/overview.md:112
+msgid "Direct download URL (HTTPS)."
+msgstr ""
+
+#: src/updater/overview.md:113
+msgid "`platforms.<os>-<arch>.sha256`"
+msgstr ""
+
+#: src/updater/overview.md:113
+msgid "Lowercase hex SHA-256 of the binary."
+msgstr ""
+
+#: src/updater/overview.md:114
+msgid "`platforms.<os>-<arch>.signature`"
+msgstr ""
+
+#: src/updater/overview.md:114
+msgid ""
+"Base64 Ed25519 signature. v1: over the raw 32-byte digest. v2: over `digest "
+"\\|\\| version_utf8`."
+msgstr ""
+
+#: src/updater/overview.md:115
+msgid "`platforms.<os>-<arch>.size`"
+msgstr ""
+
+#: src/updater/overview.md:115
+msgid "Byte length of the binary — used for progress reporting."
+msgstr ""
+
+#: src/updater/overview.md:117
+msgid "Platform keys are canonical Rust-style triples:"
+msgstr ""
+
+#: src/updater/overview.md:119
+msgid "Host"
+msgstr ""
+
+#: src/updater/overview.md:119
+msgid "Triple"
+msgstr ""
+
+#: src/updater/overview.md:121
+msgid "Apple Silicon mac"
+msgstr ""
+
+#: src/updater/overview.md:121
+msgid "`darwin-aarch64`"
+msgstr ""
+
+#: src/updater/overview.md:122
+msgid "Intel mac"
+msgstr ""
+
+#: src/updater/overview.md:122
+msgid "`darwin-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:123
+msgid "Windows 10/11 64-bit"
+msgstr ""
+
+#: src/updater/overview.md:123
+msgid "`windows-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:124
+msgid "Linux 64-bit"
+msgstr ""
+
+#: src/updater/overview.md:124
+msgid "`linux-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:125
+msgid "Linux ARM64"
+msgstr ""
+
+#: src/updater/overview.md:125
+msgid "`linux-aarch64`"
+msgstr ""
+
+#: src/updater/overview.md:127
+msgid "Trust model"
+msgstr ""
+
+#: src/updater/overview.md:129
+msgid "`schemaVersion: 2` (recommended) — version-bound signature"
+msgstr ""
+
+#: src/updater/overview.md:131
+msgid ""
+"The signed payload is `SHA256(binary) || version_utf8` — the 32-byte raw "
+"digest concatenated with the UTF-8 bytes of the version string. This binds "
+"the version into the signature, so an on-path attacker can't replay a "
+"previously-signed older binary as a \"new version\" by serving a manifest "
+"that pairs the old binary's URL + signature with a higher version number "
+"([\\#229](https://github.com/PerryTS/perry/issues/229))."
+msgstr ""
+
+#: src/updater/overview.md:138
+msgid "Sign side:"
+msgstr ""
+
+#: src/updater/overview.md:140
+msgid ""
+"```text\n"
+"payload = sha256(binary).digest() + version.encode(\"utf-8\")\n"
+"signature = ed25519_sign(secret_key, payload)  # 64-byte signature\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:145
+msgid "Verification on the client:"
+msgstr ""
+
+#: src/updater/overview.md:147
+msgid ""
+"SHA-256 the downloaded file. Reject if it doesn't match `manifest.sha256`."
+msgstr ""
+
+#: src/updater/overview.md:148
+msgid ""
+"Build the v2 payload (`digest || version_utf8`) using `manifest.version`."
+msgstr ""
+
+#: src/updater/overview.md:149
+msgid "Ed25519-verify the signature against the bundled public key."
+msgstr ""
+
+#: src/updater/overview.md:150
+msgid "Reject on any decode error, size mismatch, or signature failure."
+msgstr ""
+
+#: src/updater/overview.md:152
+msgid ""
+"If an attacker swaps the manifest's `version` field while keeping the old "
+"`signature`, step 3 fails because the signature was made over the _original_"
+" version. If they swap both `version` and `signature` (using a previously-"
+"signed older binary), step 1 fails because `sha256` of the older binary "
+"doesn't match the rewritten higher-version label either — every plausible "
+"attack on the version metadata invalidates something."
+msgstr ""
+
+#: src/updater/overview.md:160
+msgid "`schemaVersion: 1` (legacy, digest-only)"
+msgstr ""
+
+#: src/updater/overview.md:162
+msgid ""
+"The signed payload is the raw 32-byte digest only. **This shape is "
+"vulnerable to old-binary replay** "
+"([\\#229](https://github.com/PerryTS/perry/issues/229)): an on-path attacker"
+" can serve a manifest claiming a higher version while pointing at a "
+"previously-signed older binary, and signature verification still passes "
+"because the version isn't bound into the signature. Existing v1 manifests "
+"stay supported by the client during migration; new deployments should use "
+"v2."
+msgstr ""
+
+#: src/updater/overview.md:170
+msgid "Migration"
+msgstr ""
+
+#: src/updater/overview.md:172
+msgid ""
+"`@perry/updater` v0.5.391+ accepts both `schemaVersion: 1` and "
+"`schemaVersion: 2`. Bumping your manifest from 1 → 2 requires:"
+msgstr ""
+
+#: src/updater/overview.md:175
+msgid ""
+"Update sign-side tooling to compute the new payload (`sha256(binary) + "
+"version.encode(\"utf-8\")`) and sign that."
+msgstr ""
+
+#: src/updater/overview.md:177
+msgid "Bump `schemaVersion` in the manifest from `1` to `2`."
+msgstr ""
+
+#: src/updater/overview.md:178
+msgid ""
+"Make sure all deployed clients are running a perry-updater version that "
+"knows about v2 BEFORE you publish a v2 manifest. Older clients reject "
+"`schemaVersion: 2` with an `unsupported manifest schemaVersion` error. "
+"(Plan: ship a perry-updater bump with v2 support to your users via a v1 "
+"manifest first; once they're on the v2-aware client, the next manifest can "
+"be v2.)"
+msgstr ""
+
+#: src/updater/overview.md:185
+msgid "Keypair"
+msgstr ""
+
+#: src/updater/overview.md:187
+msgid ""
+"You generate the keypair once and bake the public key into your app at build"
+" time; the secret key stays on a release-signing machine alongside the rest "
+"of your build artifacts. Compromise of the manifest server alone never lets "
+"an attacker push a binary your client will accept."
+msgstr ""
+
+#: src/updater/overview.md:192
+msgid "Sign-side CLI (v0.5.395+)"
+msgstr ""
+
+#: src/updater/overview.md:194
+msgid ""
+"`perry updater` ships three subcommands that produce v2-shape signatures "
+"without needing any custom tooling:"
+msgstr ""
+
+#: src/updater/overview.md:198
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
+msgstr ""
+
+#: src/updater/overview.md:201
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
+msgstr ""
+
+#: src/updater/overview.md:219
+msgid ""
+"Compose a final manifest by piping `sign` output through `jq` for each "
+"asset, then merging into the per-platform layout shown above. CI tip: pass "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so"
+" the secret can come from a repository secret without ever hitting the "
+"worker's filesystem."
+msgstr ""
+
+#: src/updater/overview.md:225
+msgid "Install + rollback flow"
+msgstr ""
+
+#: src/updater/overview.md:227
+msgid ""
+"```text\n"
+"manifest fetch  →  semver compare  →  download to <exe>.staged\n"
+"                                          ↓\n"
+"                                      sha256 verify  →  ed25519 verify\n"
+"                                          ↓\n"
+"                                      arm sentinel (state: \"armed\")\n"
+"                                          ↓\n"
+"                                      install:  rename <exe> → <exe>.prev\n"
+"                                                rename <exe>.staged → <exe>\n"
+"                                                chmod +x   (Unix only)\n"
+"                                          ↓\n"
+"                                      detached relaunch  →  process.exit(0)\n"
+"\n"
+"next boot  →  initUpdater() reads sentinel\n"
+"                  ├── healthCheckMs alive  → clearSentinel  (success)\n"
+"                  ├── graceful exit         → clearSentinel  (success)\n"
+"                  └── restartCount ≥ N      → performRollback + exit\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:246
+msgid ""
+"`installUpdate` is atomic where the OS lets us be: POSIX `rename(2)` on the "
+"same filesystem, NTFS rename-while-open (the PE loader opens with "
+"`FILE_SHARE_DELETE` so Windows tolerates this since Vista), and Linux's "
+"mmap'd-inode-stays-alive semantics. If the staging directory ends up on a "
+"different filesystem (a separate mount for `/tmp`, for instance) the rename "
+"falls back to copy + remove, which has a small non-atomic window."
+msgstr ""
+
+#: src/updater/overview.md:253
+msgid "The sentinel is a JSON file at a per-OS user-writable path:"
+msgstr ""
+
+#: src/updater/overview.md:255
+msgid "Default location"
+msgstr ""
+
+#: src/updater/overview.md:257
+msgid "`~/Library/Application Support/<app>/updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:258
+msgid "`%LOCALAPPDATA%\\<app>\\updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:259
+msgid "`$XDG_STATE_HOME/<app>/updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:261
+msgid ""
+"`<app>` comes from the `PERRY_APP_ID` environment variable, falling back to "
+"the basename of the running exe. **Set `PERRY_APP_ID` in your launch "
+"environment** so the sentinel path stays stable across rename / relocation "
+"of the binary."
+msgstr ""
+
+#: src/updater/overview.md:266
+msgid "Low-level primitives"
+msgstr ""
+
+#: src/updater/overview.md:268
+msgid ""
+"Use these when the high-level wrapper doesn't fit — custom progress UI, a "
+"multi-channel manifest, an external supervisor that handles restarts, etc."
+msgstr ""
+
+#: src/updater/overview.md:271
+msgid ""
+"```typescript\n"
+"import {\n"
+"    compareVersions,\n"
+"    verifyHash,\n"
+"    verifySignature,\n"
+"    computeFileSha256,\n"
+"    writeSentinel,\n"
+"    readSentinel,\n"
+"    clearSentinel,\n"
+"    getExePath,\n"
+"    getBackupPath,\n"
+"    getSentinelPath,\n"
+"    installUpdate,\n"
+"    performRollback,\n"
+"    relaunch,\n"
+"} from \"perry/updater\"\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:289
+msgid "`compareVersions(current, candidate)`"
+msgstr ""
+
+#: src/updater/overview.md:291
+msgid ""
+"Returns `-1` (update available), `0` (equal), `1` (downgrade — never "
+"offered), or `-2` (parse error). Prerelease tags handled per the semver "
+"spec."
+msgstr ""
+
+#: src/updater/overview.md:294
+msgid ""
+"```typescript\n"
+"// Returns -1 (current < candidate, update available), 0 (equal),\n"
+"// 1 (current > candidate, never offered as an update), -2 (parse error).\n"
+"const cmp = compareVersions(\"1.4.0\", \"1.4.1\")\n"
+"if (cmp === -1) {\n"
+"    console.log(\"update available\")\n"
+"} else if (cmp === 0) {\n"
+"    console.log(\"up to date\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:305
+msgid "`verifyHash` / `verifySignature` / `computeFileSha256`"
+msgstr ""
+
+#: src/updater/overview.md:307
+msgid ""
+"```typescript\n"
+"// SHA-256 + Ed25519 verification of a binary on disk. The signed payload is\n"
+"// the *raw 32-byte SHA-256 digest* — not the hex string and not the file\n"
+"// bytes themselves. Sign side: `sha256(file) | ed25519_sign(secret_key)`.\n"
+"const stagedPath = getExePath() + \".staged\"\n"
+"const expectedHex = \"0123456789abcdef...\" // from your manifest\n"
+"const sigB64 = \"...base64...\"             // 64-byte signature, base64\n"
+"const pubB64 = \"...base64...\"             // 32-byte public key, base64\n"
+"\n"
+"if (verifyHash(stagedPath, expectedHex) !== 1) {\n"
+"    const actual = computeFileSha256(stagedPath)\n"
+"    console.error(`hash mismatch — expected ${expectedHex}, got ${actual}`)\n"
+"}\n"
+"if (verifySignature(stagedPath, sigB64, pubB64) !== 1) {\n"
+"    console.error(\"signature verification failed\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:325
+msgid ""
+"`verifyHash` and `verifySignature` return `1` on success, `0` on any failure"
+" (file missing, decode error, mismatch). `computeFileSha256` returns the hex"
+" digest as a string, or `\"\"` on failure — useful for logging the _actual_ "
+"hash when a `verifyHash` mismatch fires."
+msgstr ""
+
+#: src/updater/overview.md:330
+msgid "`installUpdate` / `performRollback` / `relaunch`"
+msgstr ""
+
+#: src/updater/overview.md:332
+msgid ""
+"```typescript\n"
+"// `installUpdate` atomically replaces `targetPath` with `stagedPath`,\n"
+"// keeping the displaced version at `<target>.prev` for rollback.\n"
+"const target = getExePath()\n"
+"const staged = target + \".staged\"\n"
+"\n"
+"if (installUpdate(staged, target) !== 1) {\n"
+"    console.error(\"install failed\")\n"
+"} else {\n"
+"    const pid = relaunch(target)\n"
+"    if (pid < 0) {\n"
+"        console.error(\"relaunch failed; restart manually\")\n"
+"    } else {\n"
+"        // Detached child is now running the new binary — get out of its way.\n"
+"        process.exit(0)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:351
+msgid ""
+"```typescript\n"
+"// `performRollback` restores `<target>.prev` over `target` and moves the\n"
+"// current (likely-broken) target to `<target>.broken` as a safety net.\n"
+"if (performRollback(getExePath()) !== 1) {\n"
+"    console.error(\"no backup to roll back to\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:359
+msgid ""
+"`relaunch` returns the child PID, or `-1` on failure. The new process is "
+"fully detached (`setsid` on Unix, `DETACHED_PROCESS | "
+"CREATE_NEW_PROCESS_GROUP` on Windows) so closing the current process doesn't"
+" take it down."
+msgstr ""
+
+#: src/updater/overview.md:363
+msgid "Path resolution"
+msgstr ""
+
+#: src/updater/overview.md:365
+msgid ""
+"```typescript\n"
+"// Resolved per platform. macOS walks up to the surrounding `.app` bundle;\n"
+"// Linux honors $APPIMAGE; Windows / bare ELF returns the canonical exe.\n"
+"console.log(\"running exe   :\", getExePath())\n"
+"console.log(\"backup target :\", getBackupPath())\n"
+"// Sentinel path is keyed off PERRY_APP_ID — set this env var so the path\n"
+"// stays stable across rename/relocation of the binary.\n"
+"console.log(\"sentinel path :\", getSentinelPath())\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:375
+msgid "`getExePath()` accounts for platform quirks:"
+msgstr ""
+
+#: src/updater/overview.md:377
+msgid ""
+"**macOS**: walks up to the surrounding `.app` bundle if applicable — the "
+"`.app` directory is the codesign unit, so that's what you replace."
+msgstr ""
+
+#: src/updater/overview.md:379
+msgid ""
+"**Linux**: honors `$APPIMAGE` when set. The AppImage runtime points "
+"`current_exe()` inside a read-only squashfs mount; the real target to "
+"replace is the AppImage file itself."
+msgstr ""
+
+#: src/updater/overview.md:382
+msgid ""
+"**Windows / bare ELF / bare Mach-O**: returns the canonicalized exe path."
+msgstr ""
+
+#: src/updater/overview.md:384
+msgid "Sentinel"
+msgstr ""
+
+#: src/updater/overview.md:386
+msgid ""
+"```typescript\n"
+"// Low-level sentinel API. Most apps use `initUpdater()` from @perry/updater\n"
+"// instead of touching this directly, but it's here when you need it (custom\n"
+"// rollback policies, multi-process apps, integration with another supervisor).\n"
+"const sentinelPath = getSentinelPath()\n"
+"writeSentinel(sentinelPath, JSON.stringify({ state: \"armed\", restartCount: 0 }))\n"
+"const raw = readSentinel(sentinelPath)\n"
+"if (raw) {\n"
+"    const state = JSON.parse(raw) as { state: string; restartCount: number }\n"
+"    if (state.restartCount >= 2) {\n"
+"        // looks like a crash loop — recover or roll back\n"
+"        clearSentinel(sentinelPath)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:402
+msgid ""
+"`writeSentinel` is atomic (tmp file + rename), creates the parent directory "
+"if needed, and returns `1` on success / `0` on any IO error. `clearSentinel`"
+" is idempotent — returns `1` whether the file existed or not."
+msgstr ""
+
+#: src/updater/overview.md:406
+msgid "What's not here (yet)"
+msgstr ""
+
+#: src/updater/overview.md:408
+msgid ""
+"**UI primitives** — a \"Restart now\" modal with `ProgressView` belongs "
+"inside `perry/ui` proper rather than the updater package. Tracked as a "
+"follow-up."
+msgstr ""
+
+#: src/updater/overview.md:411
+msgid ""
+"**Privileged install** for system-wide locations (`/Applications`, `Program "
+"Files`). The current install path only handles user-writable locations "
+"(`~/Applications`, `~/.local/bin`, `%LOCALAPPDATA%`). UAC / `SMJobBless` is "
+"a separate concern."
+msgstr ""
+
+#: src/updater/overview.md:415
+msgid ""
+"**Delta updates** (bsdiff), **multi-channel** (stable / beta), **staged "
+"rollouts**."
+msgstr ""
+
+#: src/updater/overview.md:417
+msgid ""
+"**Notarization / code-signing** during install. Binaries are expected to "
+"arrive already signed; the updater doesn't try to be a notarization tool."
+msgstr ""
+
+#: src/updater/overview.md:420
+msgid "Testing your update flow"
+msgstr ""
+
+#: src/updater/overview.md:422
+msgid ""
+"The crate ships smoke-test scripts that exercise verify → install → relaunch"
+" end-to-end against a real Perry binary:"
+msgstr ""
+
+#: src/updater/overview.md:425
+msgid "**Unix**: `scripts/smoke_updater.sh`"
+msgstr ""
+
+#: src/updater/overview.md:426
+msgid "**Windows**: `scripts/smoke_updater.ps1`"
+msgstr ""
+
+#: src/updater/overview.md:428
+msgid ""
+"Both spin up a tiny HTTP server, build a v1.0.0 binary that drives the "
+"update flow, build a v1.0.1 binary that proves it ran, and verify the "
+"relaunch handed off correctly. Run them locally before shipping a release "
+"that depends on the updater wiring."
+msgstr ""
+
+#: src/updater/overview.md:435
+msgid "[System APIs](../system/overview.md) — the rest of `perry/system`"
+msgstr ""
+
+#: src/updater/overview.md:436
+msgid ""
+"[HTTP & Networking](../stdlib/http.md) — `fetch()` is what the wrapper uses "
+"internally"
+msgstr ""
+
+#: src/updater/overview.md:438
+msgid ""
+"[Cryptography](../stdlib/crypto.md) — Ed25519 sign / verify primitives for "
+"tooling that builds the manifest"
+msgstr ""
+
+#: src/system/overview.md:1
+msgid "System APIs Overview"
+msgstr ""
+
+#: src/system/overview.md:3
+msgid ""
+"The `perry/system` module provides access to platform-native system "
+"features: preferences, secure storage, notifications, dark-mode detection, "
+"audio capture, and app introspection. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links the file on every PR."
+msgstr ""
+
+#: src/system/overview.md:9
+msgid ""
+"```typescript\n"
+"// import {\n"
+"//     openURL, isDarkMode,\n"
+"//     preferencesGet, preferencesSet,\n"
+"//     keychainSave, keychainGet, keychainDelete,\n"
+"//     notificationSend,\n"
+"//     audioStart, audioStop, audioGetLevel, audioGetPeak, audioGetWaveform,\n"
+"// } from \"perry/system\"\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:19
+msgid "Available APIs"
+msgstr ""
+
+#: src/system/overview.md:23
+msgid "`openURL(url)`"
+msgstr ""
+
+#: src/system/overview.md:23
+msgid "Open URL in default browser/app"
+msgstr ""
+
+#: src/system/overview.md:23 src/system/overview.md:24
+#: src/system/overview.md:25 src/system/overview.md:26
+#: src/system/overview.md:27 src/system/overview.md:29
+#: src/system/overview.md:30 src/system/overview.md:31
+#: src/system/overview.md:32 src/system/overview.md:36
+#: src/system/overview.md:37 src/system/overview.md:38
+msgid "All"
+msgstr ""
+
+#: src/system/overview.md:24
+msgid "`isDarkMode()`"
+msgstr ""
+
+#: src/system/overview.md:24
+msgid "Check system dark mode"
+msgstr ""
+
+#: src/system/overview.md:25
+msgid "`getDeviceIdiom()`"
+msgstr ""
+
+#: src/system/overview.md:25
+msgid "`\"phone\"`, `\"pad\"`, `\"mac\"`, `\"tv\"`, …"
+msgstr ""
+
+#: src/system/overview.md:26
+msgid "`getDeviceModel()`"
+msgstr ""
+
+#: src/system/overview.md:26
+msgid "Device model identifier (e.g. `\"iPhone13,4\"`)"
+msgstr ""
+
+#: src/system/overview.md:27
+msgid "`preferencesSet(key, value)`"
+msgstr ""
+
+#: src/system/overview.md:27
+msgid "Store a preference (string or number)"
+msgstr ""
+
+#: src/system/overview.md:28
+msgid "`preferencesGet(key)`"
+msgstr ""
+
+#: src/system/overview.md:28
+msgid "Read a preference (returns \\`string"
+msgstr ""
+
+#: src/system/overview.md:29
+msgid "`keychainSave(key, value)`"
+msgstr ""
+
+#: src/system/overview.md:29
+msgid "Secure storage write"
+msgstr ""
+
+#: src/system/overview.md:30
+msgid "`keychainGet(key)`"
+msgstr ""
+
+#: src/system/overview.md:30
+msgid "Secure storage read"
+msgstr ""
+
+#: src/system/overview.md:31
+msgid "`keychainDelete(key)`"
+msgstr ""
+
+#: src/system/overview.md:31
+msgid "Secure storage remove"
+msgstr ""
+
+#: src/system/overview.md:32
+msgid "`notificationSend(title, body)`"
+msgstr ""
+
+#: src/system/overview.md:32
+msgid "Local notification"
+msgstr ""
+
+#: src/system/overview.md:33
+msgid "`notificationCancel(id)`"
+msgstr ""
+
+#: src/system/overview.md:33
+msgid "Cancel a scheduled notification"
+msgstr ""
+
+#: src/system/overview.md:33 src/system/overview.md:34
+msgid "Apple"
+msgstr ""
+
+#: src/system/overview.md:34
+msgid "`notificationOnTap(cb)`"
+msgstr ""
+
+#: src/system/overview.md:34
+msgid "Handle banner taps"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "`notificationRegisterRemote(cb)` / `notificationOnReceive(cb)`"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "Push (APNs)"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "iOS, macOS"
+msgstr ""
+
+#: src/system/overview.md:36
+msgid "`audioStart()` / `audioStop()`"
+msgstr ""
+
+#: src/system/overview.md:36
+msgid "Microphone capture"
+msgstr ""
+
+#: src/system/overview.md:37
+msgid "`audioGetLevel()` / `audioGetPeak()`"
+msgstr ""
+
+#: src/system/overview.md:37
+msgid "RMS / peak amplitude (`0..1`)"
+msgstr ""
+
+#: src/system/overview.md:38
+msgid "`audioGetWaveform(n)`"
+msgstr ""
+
+#: src/system/overview.md:38
+msgid "Recent waveform samples for visualization"
+msgstr ""
+
+#: src/system/overview.md:40
+msgid ""
+"**Clipboard** lives in `perry/ui` (not `perry/system`): import "
+"`clipboardRead` and `clipboardWrite` from there."
+msgstr ""
+
+#: src/system/overview.md:45 src/system/other.md:29
+msgid ""
+"```typescript\n"
+"if (isDarkMode()) {\n"
+"    console.log(\"Dark mode is active\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:51 src/system/preferences.md:14
+msgid ""
+"```typescript\n"
+"// Strings and numbers round-trip natively — no manual stringification needed.\n"
+"preferencesSet(\"theme\", \"dark\")\n"
+"preferencesSet(\"font-size\", 14)\n"
+"\n"
+"const theme = preferencesGet(\"theme\")        // string | number | undefined\n"
+"const fontSize = preferencesGet(\"font-size\") // → 14 (number)\n"
+"\n"
+"if (typeof theme === \"string\") {\n"
+"    console.log(`saved theme: ${theme}`)\n"
+"}\n"
+"if (typeof fontSize === \"number\") {\n"
+"    console.log(`saved font-size: ${fontSize}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:67 src/system/other.md:14
+msgid ""
+"```typescript\n"
+"openURL(\"https://example.com\")\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:73
+msgid "[Preferences](preferences.md)"
+msgstr ""
+
+#: src/system/overview.md:74
+msgid "[Keychain](keychain.md)"
+msgstr ""
+
+#: src/system/overview.md:75
+msgid "[Notifications](notifications.md)"
+msgstr ""
+
+#: src/system/overview.md:76
+msgid "[Audio Capture](audio.md)"
+msgstr ""
+
+#: src/system/overview.md:77
+msgid "[Other](other.md)"
+msgstr ""
+
+#: src/system/preferences.md:3
+msgid ""
+"Store and retrieve user preferences using the platform's native storage. "
+"Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/preferences.md:10
+msgid ""
+"`preferencesSet(key, value)` accepts strings **or** numbers and round-trips "
+"them natively (NSUserDefaults / GSettings / Registry preserve the original "
+"type). `preferencesGet(key)` returns `string | number | undefined`:"
+msgstr ""
+
+#: src/system/preferences.md:30 src/system/keychain.md:21
+msgid "Platform Storage"
+msgstr ""
+
+#: src/system/preferences.md:32 src/system/keychain.md:23
+#: src/system/notifications.md:60 src/system/media.md:84
+msgid "Backend"
+msgstr ""
+
+#: src/system/preferences.md:34 src/system/preferences.md:35
+msgid "NSUserDefaults"
+msgstr ""
+
+#: src/system/preferences.md:36
+msgid "SharedPreferences"
+msgstr ""
+
+#: src/system/preferences.md:37
+msgid "Windows Registry"
+msgstr ""
+
+#: src/system/preferences.md:38
+msgid "GSettings / file-based"
+msgstr ""
+
+#: src/system/preferences.md:39
+msgid "localStorage"
+msgstr ""
+
+#: src/system/preferences.md:41
+msgid ""
+"Preferences persist across app launches. They are not encrypted — use "
+"[Keychain](keychain.md) for sensitive data."
+msgstr ""
+
+#: src/system/preferences.md:46 src/system/notifications.md:74
+msgid "[Keychain](keychain.md) — Secure storage"
+msgstr ""
+
+#: src/system/preferences.md:47 src/system/keychain.md:39
+#: src/system/notifications.md:76 src/system/audio.md:74
+#: src/system/media.md:245 src/system/other.md:70
+msgid "[Overview](overview.md) — All system APIs"
+msgstr ""
+
+#: src/system/keychain.md:3
+msgid ""
+"Securely store sensitive data like tokens, passwords, and API keys using the"
+" platform's secure storage. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/keychain.md:10
+msgid ""
+"```typescript\n"
+"keychainSave(\"api_token\", \"sk-...\")\n"
+"const token = keychainGet(\"api_token\")\n"
+"keychainDelete(\"api_token\")\n"
+"console.log(`token length: ${token.length}`)\n"
+"```"
+msgstr ""
+
+#: src/system/keychain.md:17
+msgid ""
+"The free-function API is `keychainSave(key, value)`, `keychainGet(key)` "
+"(returns the stored string, or an empty string if the key isn't present), "
+"and `keychainDelete(key)`."
+msgstr ""
+
+#: src/system/keychain.md:25 src/system/keychain.md:26
+msgid "Security.framework (Keychain)"
+msgstr ""
+
+#: src/system/keychain.md:27
+msgid "Android Keystore"
+msgstr ""
+
+#: src/system/keychain.md:28
+msgid "Windows Credential Manager (CredWrite/CredRead/CredDelete)"
+msgstr ""
+
+#: src/system/keychain.md:29
+msgid "libsecret"
+msgstr ""
+
+#: src/system/keychain.md:30
+msgid "localStorage (not truly secure)"
+msgstr ""
+
+#: src/system/keychain.md:32
+msgid ""
+"**Web**: The web platform uses `localStorage`, which is not encrypted. For "
+"web apps handling sensitive data, consider server-side storage instead."
+msgstr ""
+
+#: src/system/keychain.md:37
+msgid "[Preferences](preferences.md) — Non-sensitive preferences"
+msgstr ""
+
+#: src/system/keychain.md:38
+msgid "[Notifications](notifications.md) — Local notifications"
+msgstr ""
+
+#: src/system/notifications.md:3
+msgid ""
+"Send local notifications using the platform's notification system. Every "
+"snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/notifications.md:8
+msgid "Sending a notification"
+msgstr ""
+
+#: src/system/notifications.md:10
+msgid ""
+"```typescript\n"
+"notificationSend(\"Build complete\", \"All targets compiled in 4.2s.\")\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:14
+msgid "Reacting to a tap"
+msgstr ""
+
+#: src/system/notifications.md:16
+msgid ""
+"```typescript\n"
+"notificationOnTap((id: string, action?: string) => {\n"
+"    console.log(`tapped notification ${id}; action=${action ?? \"(default)\"}`)\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:22
+msgid ""
+"`action` is the action-button identifier when the user picks a button, or "
+"`undefined` for the default banner tap."
+msgstr ""
+
+#: src/system/notifications.md:25
+msgid "Cancelling a scheduled notification"
+msgstr ""
+
+#: src/system/notifications.md:27
+msgid ""
+"```typescript\n"
+"notificationCancel(\"daily-reminder\")\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:31
+msgid ""
+"`notificationCancel(id)` is a no-op if no scheduled notification with that "
+"id exists."
+msgstr ""
+
+#: src/system/notifications.md:34
+msgid "Push notifications (APNs / Firebase)"
+msgstr ""
+
+#: src/system/notifications.md:46
+msgid ""
+"`notificationRegisterRemote(cb)` fires once when the OS returns a device "
+"token — on Apple platforms the token is the canonical uppercase hex string "
+"APNs expects. `notificationOnReceive(cb)` runs whenever a remote payload "
+"arrives while the app is foregrounded; the payload is the APNs `aps` "
+"userInfo dictionary (or equivalent platform shape) converted to a plain "
+"object."
+msgstr ""
+
+#: src/system/notifications.md:52
+msgid ""
+"Requires the relevant platform capability (APNs entitlement on iOS/macOS, "
+"Firebase Messaging on Android — wired via JNI through "
+"`PerryFirebaseMessagingService`, see "
+"[\\#98](https://github.com/PerryTS/perry/issues/98)). No-op on platforms "
+"without a push pipeline (tvOS, visionOS, watchOS, GTK4, Windows, Web)."
+msgstr ""
+
+#: src/system/notifications.md:58
+msgid "Platform Implementation"
+msgstr ""
+
+#: src/system/notifications.md:62 src/system/notifications.md:63
+msgid "UNUserNotificationCenter"
+msgstr ""
+
+#: src/system/notifications.md:64
+msgid "NotificationManager"
+msgstr ""
+
+#: src/system/notifications.md:65
+msgid "Toast notifications"
+msgstr ""
+
+#: src/system/notifications.md:66
+msgid "GNotification"
+msgstr ""
+
+#: src/system/notifications.md:67
+msgid "Web Notification API"
+msgstr ""
+
+#: src/system/notifications.md:69
+msgid ""
+"**Permissions**: On macOS, iOS, and Web, the user may need to grant "
+"notification permissions. On first use, the system will prompt "
+"automatically."
+msgstr ""
+
+#: src/system/notifications.md:75
+msgid "[Other](other.md) — Additional system APIs"
+msgstr ""
+
+#: src/system/audio.md:3
+msgid ""
+"The `perry/system` module provides real-time audio capture from the device "
+"microphone, with A-weighted dB(A) level metering and waveform sampling — "
+"everything needed to build a sound meter, audio visualizer, or voice-level "
+"indicator. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/audio.md:10
+msgid ""
+"```typescript\n"
+"const ok = audioStart() // 1 on success, 0 on failure\n"
+"if (ok === 1) {\n"
+"    const level = audioGetLevel()           // 0..1\n"
+"    const peak = audioGetPeak()             // 0..1\n"
+"    const waveform = audioGetWaveform(64)   // sample-count\n"
+"    console.log(`level=${level} peak=${peak} waveform=${waveform}`)\n"
+"    audioStop()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/audio.md:23
+msgid "`audioStart()`"
+msgstr ""
+
+#: src/system/audio.md:25
+msgid ""
+"Start capturing audio from the device microphone. Returns `1` on success, "
+"`0` on failure (permission denied, no microphone, etc.)."
+msgstr ""
+
+#: src/system/audio.md:28
+msgid ""
+"On platforms that require permission (iOS, Android, Web), the system "
+"permission dialog is shown automatically."
+msgstr ""
+
+#: src/system/audio.md:31
+msgid "`audioStop()`"
+msgstr ""
+
+#: src/system/audio.md:33
+msgid "Stop audio capture and release the microphone."
+msgstr ""
+
+#: src/system/audio.md:35
+msgid "`audioGetLevel()`"
+msgstr ""
+
+#: src/system/audio.md:37
+msgid ""
+"Get the current A-weighted sound level (a smoothed value with a 125 ms time "
+"constant). Typical ranges:"
+msgstr ""
+
+#: src/system/audio.md:40
+msgid "~30 dB — quiet room"
+msgstr ""
+
+#: src/system/audio.md:41
+msgid "~50 dB — normal conversation"
+msgstr ""
+
+#: src/system/audio.md:42
+msgid "~70 dB — busy street"
+msgstr ""
+
+#: src/system/audio.md:43
+msgid "~90 dB — loud music"
+msgstr ""
+
+#: src/system/audio.md:44
+msgid "~110+ dB — dangerously loud"
+msgstr ""
+
+#: src/system/audio.md:46
+msgid "`audioGetPeak()`"
+msgstr ""
+
+#: src/system/audio.md:48
+msgid ""
+"Get the current peak sample amplitude (`0.0`–`1.0`). Useful for simple level"
+" indicators without dB conversion."
+msgstr ""
+
+#: src/system/audio.md:51
+msgid "`audioGetWaveform(sampleCount)`"
+msgstr ""
+
+#: src/system/audio.md:53
+msgid ""
+"Get recent waveform samples for visualization. Pass the number of samples "
+"you want; the runtime returns the most recent N readings from its internal "
+"ring buffer. Useful for drawing waveform displays or level history charts."
+msgstr ""
+
+#: src/system/audio.md:57
+msgid "Platform Implementations"
+msgstr ""
+
+#: src/system/audio.md:59
+msgid "Audio Backend"
+msgstr ""
+
+#: src/system/audio.md:59
+msgid "Permissions"
+msgstr ""
+
+#: src/system/audio.md:61
+msgid "AVAudioEngine"
+msgstr ""
+
+#: src/system/audio.md:61
+msgid "Microphone permission dialog"
+msgstr ""
+
+#: src/system/audio.md:62
+msgid "AVAudioSession + AVAudioEngine"
+msgstr ""
+
+#: src/system/audio.md:62
+msgid "System permission dialog"
+msgstr ""
+
+#: src/system/audio.md:63
+msgid "AudioRecord (JNI)"
+msgstr ""
+
+#: src/system/audio.md:63
+msgid "RECORD_AUDIO permission"
+msgstr ""
+
+#: src/system/audio.md:64
+msgid "PulseAudio (libpulse-simple)"
+msgstr ""
+
+#: src/system/audio.md:64
+msgid "None (system-level)"
+msgstr ""
+
+#: src/system/audio.md:65
+msgid "WASAPI (shared mode)"
+msgstr ""
+
+#: src/system/audio.md:65
+msgid "None"
+msgstr ""
+
+#: src/system/audio.md:66
+msgid "getUserMedia + AnalyserNode"
+msgstr ""
+
+#: src/system/audio.md:66
+msgid "Browser permission dialog"
+msgstr ""
+
+#: src/system/audio.md:68
+msgid ""
+"All platforms capture at 48 kHz mono and apply the same A-weighting filter "
+"(IEC 61672 standard, 3 cascaded biquad sections)."
+msgstr ""
+
+#: src/system/audio.md:73
+msgid "[Camera](../ui/camera.md) — Live camera preview (iOS)"
+msgstr ""
+
+#: src/system/media.md:3
+msgid ""
+"The `perry/media` module provides streaming media playback — HTTP/HTTPS "
+"audio URLs (Subsonic, Icecast, plain MP3/AAC, HLS m3u8), `file://` paths, "
+"lock-screen / Now Playing metadata, and remote-command (Siri Remote / Touch "
+"Bar / Control Center) integration."
+msgstr ""
+
+#: src/system/media.md:10
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"  createPlayer,\n"
+"  play,\n"
+"  pause,\n"
+"  setVolume,\n"
+"  onStateChange,\n"
+"  onTimeUpdate,\n"
+"  setNowPlaying,\n"
+"} from \"perry/media\";\n"
+"\n"
+"const player = createPlayer(\"https://example.com/track.mp3\");\n"
+"if (player === 0) {\n"
+"  console.error(\"createPlayer failed\");\n"
+"} else {\n"
+"  setVolume(player, 0.8);\n"
+"  setNowPlaying(player, \"Track Title\", \"Artist\", \"Album\", \"\");\n"
+"\n"
+"  onStateChange(player, (state) => console.log(\"state:\", state));\n"
+"  onTimeUpdate(player, (cur, dur) => console.log(`${cur}/${dur}s`));\n"
+"\n"
+"  play(player); // begins (or resumes) once buffered\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/media.md:35
+msgid "API surface"
+msgstr ""
+
+#: src/system/media.md:37
+msgid "Returns"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "`createPlayer(url)`"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "handle (1+) or `0` on failure"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "HTTP/HTTPS or `file://`"
+msgstr ""
+
+#: src/system/media.md:40
+msgid "`play(handle)`"
+msgstr ""
+
+#: src/system/media.md:40 src/system/media.md:41 src/system/media.md:42
+#: src/system/media.md:43 src/system/media.md:44 src/system/media.md:45
+#: src/system/media.md:50 src/system/media.md:51 src/system/media.md:52
+#: src/system/media.md:53
+msgid "void"
+msgstr ""
+
+#: src/system/media.md:40
+msgid "Resumes if paused"
+msgstr ""
+
+#: src/system/media.md:41
+msgid "`pause(handle)`"
+msgstr ""
+
+#: src/system/media.md:41
+msgid "Position preserved"
+msgstr ""
+
+#: src/system/media.md:42
+msgid "`stop(handle)`"
+msgstr ""
+
+#: src/system/media.md:42
+msgid "Resets position to 0"
+msgstr ""
+
+#: src/system/media.md:43
+msgid "`seek(handle, seconds)`"
+msgstr ""
+
+#: src/system/media.md:44
+msgid "`setVolume(handle, volume)`"
+msgstr ""
+
+#: src/system/media.md:44
+msgid "0.0–1.0, clamped"
+msgstr ""
+
+#: src/system/media.md:45
+msgid "`setRate(handle, rate)`"
+msgstr ""
+
+#: src/system/media.md:45
+msgid "1.0 = normal; Apple supports 0.5–2.0"
+msgstr ""
+
+#: src/system/media.md:46
+msgid "`getCurrentTime(handle)`"
+msgstr ""
+
+#: src/system/media.md:46 src/system/media.md:47
+msgid "seconds"
+msgstr ""
+
+#: src/system/media.md:47
+msgid "`getDuration(handle)`"
+msgstr ""
+
+#: src/system/media.md:47
+msgid "`0` if live / loading"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "`getState(handle)`"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "`MediaState`"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "See states below"
+msgstr ""
+
+#: src/system/media.md:49
+msgid "`isPlaying(handle)`"
+msgstr ""
+
+#: src/system/media.md:50
+msgid "`onStateChange(h, cb)`"
+msgstr ""
+
+#: src/system/media.md:50
+msgid "Fires on every transition"
+msgstr ""
+
+#: src/system/media.md:51
+msgid "`onTimeUpdate(h, cb)`"
+msgstr ""
+
+#: src/system/media.md:51
+msgid "~10 Hz while playing"
+msgstr ""
+
+#: src/system/media.md:52
+msgid "`setNowPlaying(h, title, artist, album, artworkUrl)`"
+msgstr ""
+
+#: src/system/media.md:52
+msgid "All strings; pass `\"\"` for unknown"
+msgstr ""
+
+#: src/system/media.md:53
+msgid "`destroy(handle)`"
+msgstr ""
+
+#: src/system/media.md:53
+msgid "Frees resources"
+msgstr ""
+
+#: src/system/media.md:55
+msgid "States"
+msgstr ""
+
+#: src/system/media.md:57
+msgid "`MediaState` is one of:"
+msgstr ""
+
+#: src/system/media.md:59
+msgid "`idle` — never started"
+msgstr ""
+
+#: src/system/media.md:60
+msgid "`loading` — buffering / fetching headers"
+msgstr ""
+
+#: src/system/media.md:61
+msgid "`ready` — first chunk decoded, ready to `play()`"
+msgstr ""
+
+#: src/system/media.md:62
+msgid "`playing` — actively rendering"
+msgstr ""
+
+#: src/system/media.md:63
+msgid "`paused` — paused (position preserved)"
+msgstr ""
+
+#: src/system/media.md:64
+msgid "`ended` — reached end of stream"
+msgstr ""
+
+#: src/system/media.md:65
+msgid "`error` — irrecoverable failure (network, codec, …)"
+msgstr ""
+
+#: src/system/media.md:67
+msgid "`ended` reliability"
+msgstr ""
+
+#: src/system/media.md:69
+msgid ""
+"`ended` is fired both from the platform's native end-of-playback signal "
+"**and** from a `currentTime ≈ duration` fallback. Per [issue #351 "
+"discussion](https://github.com/PerryTS/perry/issues/351), the native event "
+"has been historically flaky on the web / Chromecast — the same belt-and-"
+"braces is cheap to apply on every backend so a `perry/media` consumer can "
+"rely on `ended` firing once per track."
+msgstr ""
+
+#: src/system/media.md:76
+msgid ""
+"The fallback engages only after `play()` has been called and `duration` is "
+"known (live streams report `+inf`, which sanitises to `0` and disables the "
+"fallback). Window: 0.25s before duration. The native signal sets the flag "
+"first when it works; the fallback sets the same flag on the polling tick if "
+"the signal hasn't arrived."
+msgstr ""
+
+#: src/system/media.md:82
+msgid "Platform implementations"
+msgstr ""
+
+#: src/system/media.md:86
+msgid "AVPlayer + MPNowPlayingInfoCenter + MPRemoteCommandCenter"
+msgstr ""
+
+#: src/system/media.md:86 src/system/media.md:87 src/system/media.md:89
+#: src/system/media.md:90 src/system/media.md:91
+msgid "**Implemented** + lock-screen"
+msgstr ""
+
+#: src/system/media.md:87 src/system/media.md:93
+msgid "AVPlayer + AVAudioSession Playback + UIImage artwork"
+msgstr ""
+
+#: src/system/media.md:88
+msgid "AVPlayer + Siri Remote play/pause/skip"
+msgstr ""
+
+#: src/system/media.md:88
+msgid "**Implemented** + remote"
+msgstr ""
+
+#: src/system/media.md:89
+msgid "AVPlayer + UIImage artwork"
+msgstr ""
+
+#: src/system/media.md:90
+msgid "`android.media.MediaPlayer` + `MediaSessionCompat` via JNI"
+msgstr ""
+
+#: src/system/media.md:91
+msgid "GTK4 / Linux"
+msgstr ""
+
+#: src/system/media.md:91
+msgid "GStreamer `playbin` element + MPRIS D-Bus"
+msgstr ""
+
+#: src/system/media.md:92
+msgid ""
+"`Windows.Media.Playback.MediaPlayer` (WinRT) + "
+"`SystemMediaTransportControls`"
+msgstr ""
+
+#: src/system/media.md:92
+msgid "**Implemented** + Now Playing"
+msgstr ""
+
+#: src/system/media.md:93
+msgid "**Implemented** + Now Playing complication"
+msgstr ""
+
+#: src/system/media.md:94
+msgid "HarmonyOS"
+msgstr ""
+
+#: src/system/media.md:94
+msgid "`@ohos.multimedia.media.AVPlayer` via napi"
+msgstr ""
+
+#: src/system/media.md:94
+msgid ""
+"**Implemented** (lock-screen via `@ohos.multimedia.avsession` is a follow-"
+"up)"
+msgstr ""
+
+#: src/system/media.md:95
+msgid "`<audio>` element + Media Session API"
+msgstr ""
+
+#: src/system/media.md:95
+msgid ""
+"**Implemented** (`--target web`; `setNowPlaying` populates "
+"`navigator.mediaSession.metadata` + wires play / pause / seekto / "
+"seekforward / seekbackward action handlers)"
+msgstr ""
+
+#: src/system/media.md:97
+msgid ""
+"Stub platforms link cleanly against the same FFI surface — code that imports"
+" `perry/media` compiles on every target. `createPlayer` returns `0` on a "
+"stub backend so `if (player === 0)` is the canonical \"feature not available"
+" here\" check."
+msgstr ""
+
+#: src/system/media.md:102
+msgid ""
+"On Linux, `setNowPlaying` exposes the player to the desktop via MPRIS "
+"(`org.mpris.MediaPlayer2.perry-<pid>` on the session bus). GNOME Shell, KDE "
+"Plasma, `playerctl`, and any Bluetooth-headphone media-key bridge that "
+"speaks MPRIS will see the metadata and route Play / Pause / PlayPause / Stop"
+" / Seek / SetPosition back to the player. The MPRIS server is lazy-"
+"bootstrapped on the first `setNowPlaying` call so apps that don't need lock-"
+"screen integration don't pay the zbus startup cost. `Next` / `Previous` are "
+"no-ops (single-track playback model); playlists are an app-level concern."
+msgstr ""
+
+#: src/system/media.md:112
+msgid "Android — background playback"
+msgstr ""
+
+#: src/system/media.md:114
+msgid ""
+"Perry's Android backend wires `MediaSessionCompat` so the lock-screen tile, "
+"Bluetooth headset, Android Auto, and Wear OS see the metadata pushed by "
+"`setNowPlaying` and route headphone play/pause/stop/seek events back into "
+"the registered `onStateChange` closure. That covers foreground use. Apps "
+"that want playback to survive the activity being backgrounded (a podcast "
+"app, music player, etc.) need a foreground service of their own — Android "
+"will otherwise kill the audio when the process drops to the cached state. "
+"Add the following to your app's `AndroidManifest.xml` and start the service "
+"when playback begins:"
+msgstr ""
+
+#: src/system/media.md:126
+msgid "\".PerryMediaService\""
+msgstr ""
+
+#: src/system/media.md:127
+msgid "\"mediaPlayback\""
+msgstr ""
+
+#: src/system/media.md:128
+msgid "\"false\""
+msgstr ""
+
+#: src/system/media.md:129
+msgid "\"android.permission.FOREGROUND_SERVICE\""
+msgstr ""
+
+#: src/system/media.md:130
+msgid "\"android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK\""
+msgstr ""
+
+#: src/system/media.md:133
+msgid ""
+"The service implementation is app-specific — it should hold a "
+"`MediaSessionCompat.Token` (the same session Perry created), build a "
+"`Notification.MediaStyle` notification from it, and call "
+"`startForeground(...)` on `play` / `stopForeground(false)` on `pause` / "
+"`stopSelf()` on `stop`. We deliberately don't ship a default service because"
+" the notification's branding (small icon, tint, content intent) depends on "
+"the host app."
+msgstr ""
+
+#: src/system/media.md:141
+msgid "Threading notes"
+msgstr ""
+
+#: src/system/media.md:143
+msgid ""
+"The `onStateChange` and `onTimeUpdate` callbacks fire from the platform's "
+"main UI thread on every backend, so they share the same JS heap as the "
+"calling code. Implementation detail varies:"
+msgstr ""
+
+#: src/system/media.md:147
+msgid ""
+"**macOS / iOS / tvOS / visionOS** — driven by an `NSTimer` scheduled on the "
+"main run loop at 10 Hz."
+msgstr ""
+
+#: src/system/media.md:149
+msgid ""
+"**Android** — driven from `Java_com_perry_app_PerryBridge_nativePumpTick` "
+"(the existing 125 Hz UI-thread pump), throttled internally to ~10 Hz. The "
+"`prepare()` call runs on a background worker thread to avoid blocking the UI"
+" on network buffering."
+msgstr ""
+
+#: src/system/media.md:153
+msgid ""
+"**GTK4** — driven by a `glib::timeout_add_local` timer on the GLib main "
+"loop. EOS / error messages arrive on the GStreamer bus and get forwarded to "
+"per-player atomic flags via a `bus.add_watch_local` closure."
+msgstr ""
+
+#: src/system/media.md:157
+msgid ""
+"**Windows** — driven from the `GetMessageW` / `PeekMessageW` message loop "
+"after each dispatch, throttled to 100 ms by wall-clock comparison."
+msgstr ""
+
+#: src/system/media.md:159
+msgid ""
+"**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
+"directly, so `perry/media` calls record intents into Mutex-protected drain "
+"queues in `perry-runtime::media_playback`. The harvested `pages/Index.ets` "
+"(emitted by `perry-codegen-arkts` whenever the module uses `perry/media`) "
+"installs a 100 ms `setInterval` pump in `aboutToAppear` that drains the "
+"queues, dispatches each op against the matching `media.AVPlayer` instance "
+"(allocated lazily on the first `createPlayer` drain), and pushes state "
+"observations back into the runtime via the `pushMediaState(handle, state, "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / `timeUpdate`"
+" / `error` / `endOfStream` events feed the same callback path. The pump runs"
+" on the ArkTS UI thread, so closures fired by "
+"`media_playback::push_media_state` share the same arena as Perry's `main()`."
+" Lock-screen integration (`@ohos.multimedia.avsession`) is a follow-up — the"
+" runtime queues now-playing metadata via `drainNowPlaying` but the ArkTS-"
+"side AVSession dispatch is a no-op beyond a hilog line for now (tracked "
+"under issue #369)."
+msgstr ""
+
+#: src/system/media.md:177
+msgid "Now Playing on Apple platforms"
+msgstr ""
+
+#: src/system/media.md:179
+msgid ""
+"Apple's MPNowPlayingInfoCenter is a process-wide singleton — the most recent"
+" `setNowPlaying` call wins. For a single-player app (Subsonic client, "
+"podcast player) this matches user expectation. The MPRemoteCommandCenter "
+"handlers route `play` / `pause` / `togglePlayPause` events to the **first "
+"live player handle** — multi-player apps that need an explicit \"active "
+"player\" should manage that themselves."
+msgstr ""
+
+#: src/system/media.md:186
+msgid "`artworkUrl` accepts:"
+msgstr ""
+
+#: src/system/media.md:188
+msgid "`file://` paths — loaded synchronously via NSImage / UIImage"
+msgstr ""
+
+#: src/system/media.md:189
+msgid ""
+"`https://` URLs — fetched synchronously via NSData(contentsOf:) and wrapped "
+"in UIImage. The synchronous fetch is acceptable for a one-off artwork load "
+"(the MPNowPlayingInfoCenter dict is consumed synchronously when set)."
+msgstr ""
+
+#: src/system/media.md:194
+msgid "watchOS Info.plist requirements"
+msgstr ""
+
+#: src/system/media.md:196
+msgid ""
+"watchOS keeps the audio engine alive when the watch screen sleeps **only "
+"if** the app's `Info.plist` declares the `audio` background mode under "
+"`WKBackgroundModes` (the WatchKit equivalent of iOS's `UIBackgroundModes`):"
+msgstr ""
+
+#: src/system/media.md:207
+msgid ""
+"Without this entry the OS suspends the watch app a few seconds after the "
+"wrist-down gesture or screen timeout, regardless of whether AVPlayer is "
+"actively rendering. The runtime also auto-activates an `AVAudioSession` with"
+" category `Playback` on the first `createPlayer(...)` call — combined with "
+"the Info.plist entry, this is what tells watchOS the app intends to keep "
+"playing audio in the background."
+msgstr ""
+
+#: src/system/media.md:214
+msgid ""
+"The Now Playing surface on the watch face is independent from the paired "
+"iPhone's lock screen — they're separate processes with separate "
+"`MPNowPlayingInfoCenter` instances. `setNowPlaying` on watchOS targets the "
+"watch's Now Playing complication / glance screen."
+msgstr ""
+
+#: src/system/media.md:219
+msgid "Subsonic example"
+msgstr ""
+
+#: src/system/media.md:221
+msgid ""
+"```typescript,no-test\n"
+"import { createPlayer, play, setNowPlaying, onStateChange } from \"perry/media\";\n"
+"\n"
+"function streamUrl(serverUrl: string, user: string, pass: string, songId: string): string {\n"
+"  const params = new URLSearchParams({\n"
+"    u: user, p: pass, v: \"1.16.1\", c: \"PerryClient\", id: songId, format: \"mp3\",\n"
+"  });\n"
+"  return `${serverUrl}/rest/stream?${params.toString()}`;\n"
+"}\n"
+"\n"
+"const player = createPlayer(streamUrl(\"https://music.example.com\", \"alice\", \"secret\", \"12345\"));\n"
+"setNowPlaying(player, \"All These Things That I've Done\", \"The Killers\", \"Hot Fuss\",\n"
+"              \"https://music.example.com/rest/getCoverArt?id=12345&u=alice&p=secret&v=1.16.1&c=PerryClient\");\n"
+"onStateChange(player, (state) => {\n"
+"  if (state === \"ended\") {\n"
+"    // queue.next() ...\n"
+"  }\n"
+"});\n"
+"play(player);\n"
+"```"
+msgstr ""
+
+#: src/system/media.md:242
+msgid "Next steps"
+msgstr ""
+
+#: src/system/media.md:244
+msgid "[Audio Capture](audio.md) — Microphone input + dB metering"
+msgstr ""
+
+#: src/system/other.md:1
+msgid "Other System APIs"
+msgstr ""
+
+#: src/system/other.md:3
+msgid ""
+"Additional platform-level APIs. Every snippet below is excerpted from a real"
+" file CI compiles on every PR — see "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) for "
+"the perry/system pieces and "
+"[`docs/examples/ui/events/snippets.ts`](../../examples/ui/events/snippets.ts)"
+" for clipboard."
+msgstr ""
+
+#: src/system/other.md:10
+msgid "Open URL"
+msgstr ""
+
+#: src/system/other.md:12
+msgid "Open a URL in the default browser or application:"
+msgstr ""
+
+#: src/system/other.md:20
+msgid "NSWorkspace.open"
+msgstr ""
+
+#: src/system/other.md:21
+msgid "UIApplication.open"
+msgstr ""
+
+#: src/system/other.md:22
+msgid "Intent.ACTION_VIEW"
+msgstr ""
+
+#: src/system/other.md:23
+msgid "ShellExecuteW"
+msgstr ""
+
+#: src/system/other.md:24
+msgid "xdg-open"
+msgstr ""
+
+#: src/system/other.md:25
+msgid "window.open"
+msgstr ""
+
+#: src/system/other.md:27
+msgid "Dark Mode Detection"
+msgstr ""
+
+#: src/system/other.md:35
+msgid "Detection"
+msgstr ""
+
+#: src/system/other.md:37
+msgid "NSApp.effectiveAppearance"
+msgstr ""
+
+#: src/system/other.md:38
+msgid "UITraitCollection"
+msgstr ""
+
+#: src/system/other.md:39
+msgid "Configuration.uiMode"
+msgstr ""
+
+#: src/system/other.md:40
+msgid "Registry (AppsUseLightTheme)"
+msgstr ""
+
+#: src/system/other.md:41
+msgid "GTK settings"
+msgstr ""
+
+#: src/system/other.md:42
+msgid "prefers-color-scheme media query"
+msgstr ""
+
+#: src/system/other.md:46
+msgid "Clipboard helpers live in `perry/ui` (not `perry/system`):"
+msgstr ""
+
+#: src/system/other.md:57
+msgid "Device Identity"
+msgstr ""
+
+#: src/system/other.md:64
+msgid ""
+"`getDeviceIdiom()` returns the broad form factor (`\"phone\"`, `\"pad\"`, "
+"`\"mac\"`, `\"tv\"`, …); `getDeviceModel()` returns the platform-specific "
+"model identifier (`\"iPhone15,2\"`, `\"MacBookPro18,3\"`, etc.)."
+msgstr ""
+
+#: src/system/other.md:71
+msgid "[UI Overview](../ui/overview.md) — Building UIs"
+msgstr ""
+
+#: src/widgets/overview.md:1
+msgid "Widgets (WidgetKit) Overview"
+msgstr ""
+
+#: src/widgets/overview.md:3
+msgid ""
+"Perry can compile TypeScript widget declarations to native widget extensions"
+" across 4 platforms: iOS (WidgetKit), Android (App Widgets), watchOS "
+"(Complications), and Wear OS (Tiles)."
+msgstr ""
+
+#: src/widgets/overview.md:5
+msgid ""
+"**Status:** the `perry/widget` API is wired in the HIR (`crates/perry-"
+"hir/src/lower.rs:try_lower_widget_decl`) and emits via dedicated codegen "
+"crates (`perry-codegen-glance`, `perry-codegen-wear-tiles`, the WidgetKit "
+"emitter). The snippets on the widget docs pages compile-link cleanly on the "
+"host LLVM target — `Widget({...})` lowers to a no-op there — and CI verifies"
+" that via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts)."
+" What CI **cannot** do today is drive the actual cross-compile targets "
+"(`--target ios-widget`, `--target android-widget`, etc.) because each "
+"requires an `--app-bundle-id` not yet surfaced through the doc-tests harness"
+" — tracked in [\\#194](https://github.com/PerryTS/perry/issues/194). For a "
+"working end-to-end reference see "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+msgstr ""
+
+#: src/widgets/overview.md:17
+msgid "What Are Widgets?"
+msgstr ""
+
+#: src/widgets/overview.md:19
+msgid ""
+"Home screen widgets display glanceable information outside your app. Perry's"
+" `perry/widget` module lets you define widgets in TypeScript that compile to"
+" each platform's native widget system."
+msgstr ""
+
+#: src/widgets/overview.md:21
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"MyWidget\",\n"
+"    displayName: \"My Widget\",\n"
+"    description: \"Shows a greeting\",\n"
+"    entryFields: { name: \"string\" },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`Hello, ${entry.name}!`),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/overview.md:46
+msgid ""
+"The compiler generates a complete native widget extension for each platform "
+"— no platform-specific language knowledge required."
+msgstr ""
+
+#: src/widgets/overview.md:51
+msgid "# iOS WidgetKit extension\n"
+msgstr ""
+
+#: src/widgets/overview.md:52
+msgid "# Android App Widget\n"
+msgstr ""
+
+#: src/widgets/overview.md:53
+msgid "# watchOS Complication\n"
+msgstr ""
+
+#: src/widgets/overview.md:54
+msgid "# watchOS Simulator\n"
+msgstr ""
+
+#: src/widgets/overview.md:55
+msgid "# Wear OS Tile\n"
+msgstr ""
+
+#: src/widgets/overview.md:58
+msgid ""
+"Each target produces the appropriate native widget extension for that "
+"platform."
+msgstr ""
+
+#: src/widgets/overview.md:62
+msgid "[Creating Widgets](creating-widgets.md) — Widget() API in detail"
+msgstr ""
+
+#: src/widgets/overview.md:63
+msgid "[Components & Modifiers](components.md) — Available widget components"
+msgstr ""
+
+#: src/widgets/overview.md:64
+msgid "[Configuration](configuration.md) — Widget configuration options"
+msgstr ""
+
+#: src/widgets/overview.md:65
+msgid ""
+"[Data Fetching](data-fetching.md) — Timeline providers and data loading"
+msgstr ""
+
+#: src/widgets/overview.md:66
+msgid "[Cross-Platform Reference](platforms.md) — Platform-specific details"
+msgstr ""
+
+#: src/widgets/overview.md:67
+msgid "[watchOS Complications](watchos.md) — watchOS-specific guide"
+msgstr ""
+
+#: src/widgets/overview.md:68
+msgid "[Wear OS Tiles](wearos.md) — Wear OS-specific guide"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:3
+msgid "Define home screen widgets using the `Widget()` function."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:5
+msgid ""
+"**Status:** the full `Widget({...})` snippets on this page compile-link "
+"cleanly on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the API shapes are verified against the codegen. The actual cross-"
+"compile targets (`--target ios-widget`/`android-widget`/`watchos-"
+"widget`/`wearos-tile`) still aren't driven by the doc-tests harness — each "
+"requires `--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194)). For the canonical "
+"end-to-end shape see "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+" Fragments below that show partial syntax (just the `entryFields` object, "
+"just a `render:` body, etc.) are rendered as plain text — the full "
+"declarations they appear inside are covered by the verified anchors."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:18
+msgid "Widget Declaration"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:20
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"WeatherWidget\",\n"
+"    displayName: \"Weather\",\n"
+"    description: \"Shows current weather\",\n"
+"    entryFields: {\n"
+"        temperature: \"number\",\n"
+"        condition: \"string\",\n"
+"        location: \"string\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            HStack([\n"
+"                Text(entry.location),\n"
+"                Spacer(),\n"
+"                Image(\"cloud.sun.fill\"),\n"
+"            ]),\n"
+"            Text(`${entry.temperature}°`),\n"
+"            Text(entry.condition),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:43
+msgid "Widget Options"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47
+msgid "`kind`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47 src/widgets/creating-widgets.md:48
+#: src/widgets/creating-widgets.md:49 src/widgets/creating-widgets.md:54
+msgid "`string`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47
+msgid "Unique identifier for the widget"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:48
+msgid "`displayName`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:48
+msgid "Name shown in widget gallery"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:49 src/cli/perry-toml.md:119
+#: src/cli/perry-toml.md:349
+msgid "`description`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:49
+msgid "Description in widget gallery"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50
+msgid "`entryFields`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50 src/widgets/creating-widgets.md:52
+msgid "`object`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50
+msgid ""
+"Data fields with types (`\"string\"`, `\"number\"`, `\"boolean\"`, arrays, "
+"optionals, objects)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51
+msgid "`render`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51 src/widgets/creating-widgets.md:53
+msgid "`function`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51
+msgid ""
+"Render function receiving entry data, returns widget tree. Optional 2nd "
+"param for family."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:52
+msgid "`config`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:52
+msgid "Configurable parameters the user can edit (see below)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:53
+msgid "`provider`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:53
+msgid "Timeline provider function for dynamic data (see below)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:54
+msgid "`appGroup`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:54
+msgid "App group identifier for sharing data with the host app"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:56
+msgid "Entry Fields"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:58
+msgid ""
+"Entry fields define the data your widget displays. Each field has a name and"
+" type:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:60
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  title: \"string\",\n"
+"  count: \"number\",\n"
+"  isActive: \"boolean\",\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:68
+msgid "Array, Optional, and Object Fields"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:70
+msgid "Entry fields support richer types beyond primitives:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:72
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  items: [{ name: \"string\", value: \"number\" }],  // Array of objects\n"
+"  subtitle: \"string?\",                             // Optional string\n"
+"  stats: { wins: \"number\", losses: \"number\" },     // Nested object\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:80
+msgid "These compile to a Swift `TimelineEntry` struct:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:91
+msgid "Conditionals in Render"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:93
+msgid "Use ternary expressions for conditional rendering:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:95
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"ConditionalWidget\",\n"
+"    displayName: \"Conditional\",\n"
+"    description: \"Renders based on entry data\",\n"
+"    entryFields: {\n"
+"        isActive: \"boolean\",\n"
+"        count: \"number\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(entry.isActive ? \"Active\" : \"Inactive\"),\n"
+"            entry.count > 0 ? Text(`${entry.count} items`) : Spacer(),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:114
+msgid ""
+"Template literals in widget text are compiled to Swift string interpolation:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:116
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"TemplateLiteralWidget\",\n"
+"    displayName: \"Template Literal\",\n"
+"    description: \"Template literals compile to Swift string interpolation\",\n"
+"    entryFields: {\n"
+"        name: \"string\",\n"
+"        score: \"number\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        // Template literal: `${entry.name}: ${entry.score} points`\n"
+"        // Compiles to: Text(\"\\(entry.name): \\(entry.score) points\")\n"
+"        Text(`${entry.name}: ${entry.score} points`),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:132
+msgid "Configuration Parameters"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:134
+msgid ""
+"The `config` field defines user-editable parameters that appear in the "
+"widget's edit UI:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:136
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"CityWeather\",\n"
+"    displayName: \"City Weather\",\n"
+"    description: \"Weather for a chosen city\",\n"
+"    config: {\n"
+"        city: { type: \"string\", displayName: \"City\", default: \"New York\" },\n"
+"        units: {\n"
+"            type: \"enum\",\n"
+"            displayName: \"Units\",\n"
+"            values: [\"Celsius\", \"Fahrenheit\"],\n"
+"            default: \"Celsius\",\n"
+"        },\n"
+"    },\n"
+"    entryFields: { temperature: \"number\", condition: \"string\" },\n"
+"    render: (entry) => Text(`${entry.temperature}° ${entry.condition}`),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:155
+msgid "Provider Function"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:157
+msgid ""
+"The `provider` field defines a timeline provider that fetches data for the "
+"widget:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:159
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StockWidget\",\n"
+"    displayName: \"Stock Price\",\n"
+"    description: \"Shows current stock price\",\n"
+"    config: {\n"
+"        symbol: { type: \"string\", displayName: \"Symbol\", default: \"AAPL\" },\n"
+"    },\n"
+"    entryFields: { price: \"number\", change: \"string\" },\n"
+"    provider: async (config) => {\n"
+"        const res = await fetch(`https://api.example.com/stock/${config.symbol}`)\n"
+"        const data = await res.json()\n"
+"        return { price: data.price, change: data.change }\n"
+"    },\n"
+"    // Inline-options form — the chain form `.font(\"title\")` parses but is\n"
+"    // dropped at HIR-lowering time (#195).\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`$${entry.price}`, { font: \"title\" }),\n"
+"            Text(entry.change, { color: \"green\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:183
+msgid ""
+"Note: the chain-style modifiers (`.font(\"title\").color(\"green\")`) parse "
+"but are dropped at HIR-lowering time — see "
+"[\\#195](https://github.com/PerryTS/perry/issues/195). The verified extract "
+"above uses the inline-options form `Text(\"...\", { font: \"title\" })`, "
+"which is what actually round-trips through the widget codegen."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:189
+msgid "Placeholder Data"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:191
+msgid ""
+"When the widget has no data yet (e.g., first load), the provider can return "
+"placeholder data by providing a `placeholder` field:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:193
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"NewsWidget\",\n"
+"  entryFields: { headline: \"string\", source: \"string\" },\n"
+"  placeholder: { headline: \"Loading...\", source: \"---\" },\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:202
+msgid "Family-Specific Rendering"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:204
+msgid ""
+"The render function accepts an optional second parameter for the widget "
+"family, allowing different layouts per size:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:206
+msgid ""
+"```text\n"
+"render: (entry, family) =>\n"
+"  family === \"systemLarge\"\n"
+"    ? VStack([\n"
+"        Text(entry.title).font(\"title\"),\n"
+"        ForEach(entry.items, (item) => Text(item.name)),\n"
+"      ])\n"
+"    : HStack([\n"
+"        Image(\"star.fill\"),\n"
+"        Text(entry.title).font(\"headline\"),\n"
+"      ]),\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:219
+msgid ""
+"Supported families: `\"systemSmall\"`, `\"systemMedium\"`, "
+"`\"systemLarge\"`, `\"accessoryCircular\"`, `\"accessoryRectangular\"`, "
+"`\"accessoryInline\"`."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:221
+msgid "App Group"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:223
+msgid ""
+"The `appGroup` field specifies a shared container for data exchange between "
+"the host app and the widget:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:225
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"AppDataWidget\",\n"
+"  appGroup: \"group.com.example.myapp\",\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:233
+msgid "Multiple Widgets"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:235
+msgid ""
+"Define multiple widgets in a single file. They're bundled into a "
+"`WidgetBundle`:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:237
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"SmallWidget\",\n"
+"  // ...\n"
+"});\n"
+"\n"
+"Widget({\n"
+"  kind: \"LargeWidget\",\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:251
+msgid ""
+"[Components](components.md) — Available widget components and modifiers"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:252 src/widgets/components.md:273
+msgid "[Overview](overview.md) — Widget system overview"
+msgstr ""
+
+#: src/widgets/components.md:1
+msgid "Widget Components & Modifiers"
+msgstr ""
+
+#: src/widgets/components.md:3
+msgid "Available components and modifiers for widgets."
+msgstr ""
+
+#: src/widgets/components.md:5
+msgid ""
+"**Status:** this page mixes (a) tiny fragments showing component shape — "
+"rendered as plain `text` because they're not standalone declarations and "
+"can't compile — and (b) one full verified Widget at the bottom that compile-"
+"links via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts)."
+" The doc-tests harness can't drive `--target ios-widget`/`android-widget`/ "
+"`watchos-widget`/`wearos-tile` directly (each needs `--app-bundle-id` and a "
+"platform SDK — [\\#194](https://github.com/PerryTS/perry/issues/194)). Note "
+"also that the modifier parser in `crates/perry-hir/src/lower.rs` "
+"(`parse_modifiers_from_args` / `parse_single_modifier`) only reads modifiers"
+" from **inline option-object arguments** — e.g. `Text(\"hi\", { font: "
+"\"title\", color: \"red\" })` and `VStack([...], { padding: 16 })`. Method-"
+"style chains like `Text(\"hi\").font(\"title\")` shown below parse without "
+"error but **drop the modifier** at HIR-lowering time "
+"([\\#195](https://github.com/PerryTS/perry/issues/195)). The chain form is "
+"documented here because it reads naturally; the verified Complete Example at"
+" the bottom of the page uses the inline-options form that actually round-"
+"trips through the widget codegen path. The end-to-end reference is "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+msgstr ""
+
+#: src/widgets/components.md:27
+msgid ""
+"```text\n"
+"Text(\"Hello, World!\")\n"
+"Text(`${entry.name}: ${entry.value}`)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:32
+msgid "Text Modifiers"
+msgstr ""
+
+#: src/widgets/components.md:34
+msgid ""
+"```text\n"
+"const t = Text(\"Styled\");\n"
+"t.font(\"title\");       // .title, .headline, .body, .caption, etc.\n"
+"t.color(\"blue\");       // Named color or hex\n"
+"t.bold();\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:45
+msgid ""
+"```text\n"
+"VStack([\n"
+"  Text(\"Top\"),\n"
+"  Text(\"Bottom\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:54 src/widgets/components.md:75
+msgid ""
+"```text\n"
+"HStack([\n"
+"  Text(\"Left\"),\n"
+"  Spacer(),\n"
+"  Text(\"Right\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:64
+msgid ""
+"```text\n"
+"ZStack([\n"
+"  Image(\"background\"),\n"
+"  Text(\"Overlay\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:73
+msgid "Flexible space that expands to fill available room:"
+msgstr ""
+
+#: src/widgets/components.md:85
+msgid "Display SF Symbols or asset images:"
+msgstr ""
+
+#: src/widgets/components.md:87
+msgid ""
+"```text\n"
+"Image(\"star.fill\")           // SF Symbol\n"
+"Image(\"cloud.sun.rain.fill\") // SF Symbol\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:94
+msgid "Iterate over array entry fields to render a list of components:"
+msgstr ""
+
+#: src/widgets/components.md:108
+msgid "A visual separator line:"
+msgstr ""
+
+#: src/widgets/components.md:110
+msgid ""
+"```text\n"
+"VStack([\n"
+"  Text(\"Above\"),\n"
+"  Divider(),\n"
+"  Text(\"Below\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:118 src/widgets/platforms.md:28
+msgid "Label"
+msgstr ""
+
+#: src/widgets/components.md:120
+msgid "A label with text and an SF Symbol icon:"
+msgstr ""
+
+#: src/widgets/components.md:122
+msgid ""
+"```text\n"
+"Label(\"Downloads\", \"arrow.down.circle\")\n"
+"Label(`${entry.count} items`, \"folder.fill\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:127 src/widgets/platforms.md:29
+msgid "Gauge"
+msgstr ""
+
+#: src/widgets/components.md:129
+msgid "A circular or linear progress indicator:"
+msgstr ""
+
+#: src/widgets/components.md:131
+msgid ""
+"```text\n"
+"Gauge(entry.progress, 0, 100)       // value, min, max\n"
+"Gauge(entry.battery, 0, 1.0)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:138
+msgid ""
+"Widget components support SwiftUI-style modifiers. The chain forms shown "
+"below parse but drop their modifiers at HIR-lowering time "
+"([\\#195](https://github.com/PerryTS/perry/issues/195)) — use the inline "
+"option-object form (`Text(\"hi\", { font: \"title\" })`, `VStack([...], { "
+"padding: 16 })`) for the form that actually reaches the codegen, as in the "
+"[Complete Example](#complete-example) at the bottom of this page."
+msgstr ""
+
+#: src/widgets/components.md:146
+msgid "Font"
+msgstr ""
+
+#: src/widgets/components.md:148
+msgid ""
+"```text\n"
+"Text(\"Title\").font(\"title\")\n"
+"Text(\"Body\").font(\"body\")\n"
+"Text(\"Caption\").font(\"caption\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:154
+msgid "Color"
+msgstr ""
+
+#: src/widgets/components.md:156
+msgid ""
+"```text\n"
+"Text(\"Red text\").color(\"red\")\n"
+"Text(\"Custom\").color(\"#FF6600\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:161
+msgid "Padding"
+msgstr ""
+
+#: src/widgets/components.md:167
+msgid "Frame"
+msgstr ""
+
+#: src/widgets/components.md:173
+msgid "Max Width"
+msgstr ""
+
+#: src/widgets/components.md:175
+msgid ""
+"```text\n"
+"widget.maxWidth(\"infinity\")   // Expand to fill available width\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:179
+msgid "Minimum Scale Factor"
+msgstr ""
+
+#: src/widgets/components.md:181
+msgid "Allow text to shrink to fit:"
+msgstr ""
+
+#: src/widgets/components.md:183
+msgid ""
+"```text\n"
+"Text(\"Long text\").minimumScaleFactor(0.5)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:187
+msgid "Container Background"
+msgstr ""
+
+#: src/widgets/components.md:189
+msgid "Set background color for the widget container:"
+msgstr ""
+
+#: src/widgets/components.md:191
+msgid ""
+"```text\n"
+"VStack([...]).containerBackground(\"blue\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:195
+msgid "Widget URL"
+msgstr ""
+
+#: src/widgets/components.md:197
+msgid "Make the widget tappable with a deep link:"
+msgstr ""
+
+#: src/widgets/components.md:199
+msgid ""
+"```text\n"
+"VStack([...]).url(\"myapp://detail/123\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:203
+msgid "Edge-Specific Padding"
+msgstr ""
+
+#: src/widgets/components.md:205
+msgid "Apply padding to specific edges:"
+msgstr ""
+
+#: src/widgets/components.md:207
+msgid ""
+"```text\n"
+"VStack([...]).paddingEdge(\"top\", 8)\n"
+"VStack([...]).paddingEdge(\"horizontal\", 16)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:212
+msgid "Conditionals"
+msgstr ""
+
+#: src/widgets/components.md:214
+msgid "Render different components based on entry data:"
+msgstr ""
+
+#: src/widgets/components.md:216
+msgid ""
+"```text\n"
+"render: (entry) =>\n"
+"  VStack([\n"
+"    entry.isOnline\n"
+"      ? Text(\"Online\").color(\"green\")\n"
+"      : Text(\"Offline\").color(\"red\"),\n"
+"  ]),\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:227
+msgid ""
+"The full Widget below is the verified extract — it compile-links on the host"
+" LLVM target and uses the inline-options modifier form that round-trips "
+"through the codegen."
+msgstr ""
+
+#: src/widgets/components.md:231
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StatsWidget\",\n"
+"    displayName: \"Stats\",\n"
+"    description: \"Shows daily stats\",\n"
+"    entryFields: {\n"
+"        steps: \"number\",\n"
+"        calories: \"number\",\n"
+"        distance: \"string\",\n"
+"    },\n"
+"    // Inline-options modifier form — the `.font(\"title\").bold()` chain form\n"
+"    // parses but its modifiers don't reach the codegen (#195).\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            HStack([\n"
+"                Image(\"figure.walk\"),\n"
+"                Text(\"Daily Stats\", { font: \"headline\" }),\n"
+"            ]),\n"
+"            Spacer(),\n"
+"            HStack([\n"
+"                VStack([\n"
+"                    Text(`${entry.steps}`, { font: \"title\", fontWeight: \"bold\" }),\n"
+"                    Text(\"steps\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"                Spacer(),\n"
+"                VStack([\n"
+"                    Text(`${entry.calories}`, { font: \"title\", fontWeight: \"bold\" }),\n"
+"                    Text(\"cal\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"                Spacer(),\n"
+"                VStack([\n"
+"                    Text(entry.distance, { font: \"title\", fontWeight: \"bold\" }),\n"
+"                    Text(\"km\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"            ]),\n"
+"        ], { padding: 16 }),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:272
+msgid "[Creating Widgets](creating-widgets.md) — Widget() API"
+msgstr ""
+
+#: src/widgets/configuration.md:1
+msgid "Widget Configuration"
+msgstr ""
+
+#: src/widgets/configuration.md:3
+msgid ""
+"Perry widgets support user-configurable parameters. On iOS/watchOS, these "
+"compile to AppIntent configurations (the \"Edit Widget\" sheet). On "
+"Android/Wear OS, they compile to a Configuration Activity."
+msgstr ""
+
+#: src/widgets/configuration.md:5
+msgid ""
+"**Status:** the full `TopSitesWidget` declaration below compile-links "
+"cleanly on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `config: { ... }` shape is verified against `parse_config_params` in"
+" `crates/perry-hir/src/lower.rs`. The shorter fragments lower on the page "
+"(just a `provider:` body, just a `config:` object) are rendered as plain "
+"text — they're not standalone declarations. The cross-compile targets "
+"themselves (`--target ios-widget`/ `android-widget`/`watchos-"
+"widget`/`wearos-tile`) still aren't driven by the doc-tests harness — each "
+"needs `--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194))."
+msgstr ""
+
+#: src/widgets/configuration.md:17
+msgid "Defining Config Fields"
+msgstr ""
+
+#: src/widgets/configuration.md:19
+msgid ""
+"Add a `config` object to your `Widget()` declaration. Each field specifies a"
+" type, allowed values, a default, and a display title."
+msgstr ""
+
+#: src/widgets/configuration.md:21
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"TopSitesWidget\",\n"
+"    displayName: \"Top Sites\",\n"
+"    description: \"Your top performing sites\",\n"
+"    supportedFamilies: [\"systemSmall\", \"systemMedium\"],\n"
+"    appGroup: \"group.com.example.shared\",\n"
+"\n"
+"    config: {\n"
+"        sortBy: {\n"
+"            type: \"enum\",\n"
+"            values: [\"clicks\", \"impressions\", \"ctr\", \"position\"],\n"
+"            default: \"clicks\",\n"
+"            title: \"Sort By\",\n"
+"        },\n"
+"        dateRange: {\n"
+"            type: \"enum\",\n"
+"            values: [\"7d\", \"28d\", \"90d\"],\n"
+"            default: \"7d\",\n"
+"            title: \"Date Range\",\n"
+"        },\n"
+"    },\n"
+"\n"
+"    entryFields: {\n"
+"        total: \"number\",\n"
+"        label: \"string\",\n"
+"    },\n"
+"\n"
+"    provider: async (config: { sortBy: string; dateRange: string }) => {\n"
+"        const res = await fetch(\n"
+"            `https://api.example.com/stats?sort=${config.sortBy}&range=${config.dateRange}`,\n"
+"        )\n"
+"        const data = await res.json()\n"
+"        return {\n"
+"            entries: [{ total: data.total, label: data.label }],\n"
+"            reloadPolicy: { after: { minutes: 30 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`${entry.total}`, { font: \"title\", fontWeight: \"bold\" }),\n"
+"            Text(entry.label, { font: \"caption\", color: \"secondary\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:68
+msgid "Supported Parameter Types"
+msgstr ""
+
+#: src/widgets/configuration.md:70
+msgid "TypeScript"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "Enum"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "`{ type: \"enum\", values: [...], default: \"...\", title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "Picker with fixed choices"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "Boolean"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "`{ type: \"bool\", default: true, title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "Toggle switch"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "String"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "`{ type: \"string\", default: \"...\", title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "Free-text input"
+msgstr ""
+
+#: src/widgets/configuration.md:76
+msgid "Accessing Config in the Provider"
+msgstr ""
+
+#: src/widgets/configuration.md:78
+msgid ""
+"The `provider` function receives the current config values as its argument. "
+"The config object keys match the field names you defined:"
+msgstr ""
+
+#: src/widgets/configuration.md:80
+msgid ""
+"```text\n"
+"provider: async (config: { sortBy: string; dateRange: string }) => {\n"
+"  // config.sortBy === \"clicks\" | \"impressions\" | \"ctr\" | \"position\"\n"
+"  // config.dateRange === \"7d\" | \"28d\" | \"90d\"\n"
+"  const url = `https://api.example.com/data?sort=${config.sortBy}`;\n"
+"  const res = await fetch(url);\n"
+"  const data = await res.json();\n"
+"  return { entries: [data] };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:91
+msgid ""
+"When the user changes a config value, the system calls your provider again "
+"with the updated config."
+msgstr ""
+
+#: src/widgets/configuration.md:93
+msgid "Boolean Config Example"
+msgstr ""
+
+#: src/widgets/configuration.md:95
+msgid ""
+"```text\n"
+"config: {\n"
+"  showDetails: {\n"
+"    type: \"bool\",\n"
+"    default: true,\n"
+"    title: \"Show Details\",\n"
+"  },\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:105
+msgid "Platform Mapping"
+msgstr ""
+
+#: src/widgets/configuration.md:107
+msgid "iOS / watchOS (AppIntent)"
+msgstr ""
+
+#: src/widgets/configuration.md:109
+msgid ""
+"Perry generates a Swift `WidgetConfigurationIntent` struct with `@Parameter`"
+" properties and `AppEnum` types for each enum field. The widget uses "
+"`AppIntentConfiguration` instead of `StaticConfiguration`."
+msgstr ""
+
+#: src/widgets/configuration.md:111
+msgid "Generated output (auto-generated, not hand-written):"
+msgstr ""
+
+#: src/widgets/configuration.md:112
+msgid ""
+"`{Name}Intent.swift` -- contains the AppEnum cases and the intent struct"
+msgstr ""
+
+#: src/widgets/configuration.md:113
+msgid ""
+"The provider conforms to `AppIntentTimelineProvider` instead of "
+"`TimelineProvider`"
+msgstr ""
+
+#: src/widgets/configuration.md:114
+msgid ""
+"Config values are serialized to JSON and passed to the native provider "
+"function"
+msgstr ""
+
+#: src/widgets/configuration.md:116
+msgid ""
+"Users configure the widget by long-pressing and selecting \"Edit Widget\", "
+"which presents the system-generated AppIntent UI."
+msgstr ""
+
+#: src/widgets/configuration.md:118
+msgid "Android / Wear OS (Configuration Activity)"
+msgstr ""
+
+#: src/widgets/configuration.md:120
+msgid ""
+"Perry generates a `{Name}ConfigActivity.kt` with Spinner controls for enum "
+"fields and Switch controls for boolean fields. Values are persisted in "
+"SharedPreferences keyed by widget ID."
+msgstr ""
+
+#: src/widgets/configuration.md:122
+msgid "Generated output:"
+msgstr ""
+
+#: src/widgets/configuration.md:123
+msgid ""
+"`{Name}ConfigActivity.kt` -- Activity with UI controls and a Save button"
+msgstr ""
+
+#: src/widgets/configuration.md:124
+msgid ""
+"`widget_info_{name}.xml` -- includes `android:configure` pointing to the "
+"config activity"
+msgstr ""
+
+#: src/widgets/configuration.md:125
+msgid ""
+"AndroidManifest snippet includes an `<activity>` entry with "
+"`APPWIDGET_CONFIGURE` intent filter"
+msgstr ""
+
+#: src/widgets/configuration.md:127
+msgid ""
+"The config activity launches automatically when the user first adds the "
+"widget."
+msgstr ""
+
+#: src/widgets/configuration.md:129
+msgid "Build Commands"
+msgstr ""
+
+#: src/widgets/configuration.md:132
+msgid "# iOS\n"
+msgstr ""
+
+#: src/widgets/configuration.md:134
+msgid "# Android\n"
+msgstr ""
+
+#: src/widgets/configuration.md:141
+msgid ""
+"[Data Fetching](data-fetching.md) -- Provider function and shared storage"
+msgstr ""
+
+#: src/widgets/configuration.md:142
+msgid "[Components](components.md) -- Available widget components"
+msgstr ""
+
+#: src/widgets/configuration.md:143
+msgid ""
+"[Cross-Platform Reference](platforms.md) -- Feature matrix and build targets"
+msgstr ""
+
+#: src/widgets/data-fetching.md:1
+msgid "Provider Function and Data Fetching"
+msgstr ""
+
+#: src/widgets/data-fetching.md:3
+msgid ""
+"The `provider` function is the heart of a dynamic widget. It fetches data, "
+"transforms it, and returns timeline entries that the system renders on "
+"schedule."
+msgstr ""
+
+#: src/widgets/data-fetching.md:5
+msgid ""
+"**Status:** the basic `WeatherWidget` provider below compile-links cleanly "
+"on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `provider`/`reloadPolicy`/`entryFields` shapes are verified against "
+"the codegen. The shorter fragments lower on the page (a bare "
+"`reloadPolicy:`, a `provider:` body without surrounding `Widget({...})`, "
+"etc.) are rendered as plain text. The `sharedStorage()` and "
+"`preferencesSet()` examples are also rendered as plain text — those symbols "
+"are provided by the platform-specific glue (`AppGroupBridge.swift`, "
+"`Bridge.kt`) for `--target ios-widget`/`android-widget`/`watchos-widget`/ "
+"`wearos-tile` and don't link on the host LLVM target. The cross-compile "
+"targets themselves still aren't driven by the doc-tests harness — each needs"
+" `--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194))."
+msgstr ""
+
+#: src/widgets/data-fetching.md:20
+msgid "Provider Lifecycle"
+msgstr ""
+
+#: src/widgets/data-fetching.md:22
+msgid ""
+"The system calls your provider when the widget is first added, when a "
+"snapshot is needed, and when the reload policy expires."
+msgstr ""
+
+#: src/widgets/data-fetching.md:23
+msgid ""
+"Your provider runs as native LLVM-compiled code linked into the widget "
+"extension."
+msgstr ""
+
+#: src/widgets/data-fetching.md:24
+msgid ""
+"The provider returns one or more timeline entries. The system renders each "
+"entry at its scheduled time."
+msgstr ""
+
+#: src/widgets/data-fetching.md:25
+msgid ""
+"After the last entry, the reload policy determines when the provider runs "
+"again."
+msgstr ""
+
+#: src/widgets/data-fetching.md:27
+msgid "Basic Provider"
+msgstr ""
+
+#: src/widgets/data-fetching.md:29
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"WeatherProviderWidget\",\n"
+"    displayName: \"Weather\",\n"
+"    description: \"Current conditions\",\n"
+"    supportedFamilies: [\"systemSmall\"],\n"
+"\n"
+"    entryFields: {\n"
+"        temperature: \"number\",\n"
+"        condition: \"string\",\n"
+"    },\n"
+"\n"
+"    provider: async () => {\n"
+"        const res = await fetch(\"https://api.weather.example.com/current\")\n"
+"        const data = await res.json()\n"
+"        return {\n"
+"            entries: [\n"
+"                { temperature: data.temp, condition: data.description },\n"
+"            ],\n"
+"            reloadPolicy: { after: { minutes: 15 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`${entry.temperature}°`, { font: \"title\" }),\n"
+"            Text(entry.condition, { font: \"caption\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:60
+msgid "Authenticated Requests with Shared Storage"
+msgstr ""
+
+#: src/widgets/data-fetching.md:62
+msgid ""
+"Widgets run in a separate process and cannot access your app's memory. Use "
+"`sharedStorage()` to read values that your app has written to a shared "
+"container."
+msgstr ""
+
+#: src/widgets/data-fetching.md:64
+msgid "iOS / watchOS: App Groups"
+msgstr ""
+
+#: src/widgets/data-fetching.md:66
+msgid ""
+"On Apple platforms, shared storage maps to `UserDefaults(suiteName:)` backed"
+" by an App Group container. Set the `appGroup` field in your widget "
+"declaration:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:68
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"DashboardWidget\",\n"
+"  displayName: \"Dashboard\",\n"
+"  description: \"Account summary\",\n"
+"  appGroup: \"group.com.example.shared\",\n"
+"\n"
+"  entryFields: {\n"
+"    revenue: \"number\",\n"
+"    users: \"number\",\n"
+"  },\n"
+"\n"
+"  provider: async () => {\n"
+"    const token = sharedStorage(\"auth_token\");\n"
+"    const res = await fetch(\"https://api.example.com/dashboard\", {\n"
+"      headers: { Authorization: `Bearer ${token}` },\n"
+"    });\n"
+"    const data = await res.json();\n"
+"    return {\n"
+"      entries: [{ revenue: data.revenue, users: data.activeUsers }],\n"
+"      reloadPolicy: { after: { minutes: 30 } },\n"
+"    };\n"
+"  },\n"
+"\n"
+"  render: (entry) =>\n"
+"    VStack([\n"
+"      Text(`$${entry.revenue}`, { font: \"title\" }),\n"
+"      Text(`${entry.users} active users`, { font: \"caption\" }),\n"
+"    ]),\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:100
+msgid "Your main app writes the token to the shared container:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:102
+msgid ""
+"```text\n"
+"import { preferencesSet } from \"perry/system\";\n"
+"// In your app's login flow:\n"
+"preferencesSet(\"auth_token\", token);\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:108
+msgid ""
+"**Setup requirement (iOS):** Add an App Group capability in Xcode to both "
+"the main app target and the widget extension target. The identifier must "
+"match the `appGroup` value."
+msgstr ""
+
+#: src/widgets/data-fetching.md:110
+msgid "Android / Wear OS: SharedPreferences"
+msgstr ""
+
+#: src/widgets/data-fetching.md:112
+msgid ""
+"On Android, shared storage maps to `SharedPreferences` with the name "
+"`perry_shared`. The generated `Bridge.kt` reads values via "
+"`context.getSharedPreferences(\"perry_shared\", MODE_PRIVATE)`."
+msgstr ""
+
+#: src/widgets/data-fetching.md:114
+msgid "Reload Policies"
+msgstr ""
+
+#: src/widgets/data-fetching.md:116
+msgid ""
+"The `reloadPolicy` field controls when the system next calls your provider:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:127
+msgid "`{ after: { minutes: N } }`"
+msgstr ""
+
+#: src/widgets/data-fetching.md:127
+msgid ""
+"Re-fetch after N minutes. Compiles to "
+"`.after(Date().addingTimeInterval(N*60))` on iOS and "
+"`setFreshnessIntervalMillis(N*60000)` on Wear OS."
+msgstr ""
+
+#: src/widgets/data-fetching.md:128
+msgid "_(omitted)_"
+msgstr ""
+
+#: src/widgets/data-fetching.md:128
+msgid "Defaults to 30 minutes on iOS, 30 minutes on Android/Wear OS."
+msgstr ""
+
+#: src/widgets/data-fetching.md:130
+msgid ""
+"**Budget limits:** iOS restricts widget refreshes. Typical budget is 40--70 "
+"refreshes per day. watchOS is stricter (see [watchOS "
+"Complications](watchos.md)). Request only what you need."
+msgstr ""
+
+#: src/widgets/data-fetching.md:132
+msgid "JSON Response Handling"
+msgstr ""
+
+#: src/widgets/data-fetching.md:134
+msgid ""
+"The provider function receives the parsed JSON directly. Entry field types "
+"must match your `entryFields` declaration:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:136
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  items: { type: \"array\", items: { type: \"object\", fields: { name: \"string\", count: \"number\" } } },\n"
+"  total: \"number\",\n"
+"},\n"
+"\n"
+"provider: async () => {\n"
+"  const res = await fetch(\"https://api.example.com/items\");\n"
+"  const data = await res.json();\n"
+"  return {\n"
+"    entries: [{\n"
+"      items: data.results.map((r: any) => ({ name: r.name, count: r.count })),\n"
+"      total: data.total,\n"
+"    }],\n"
+"  };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:156
+msgid ""
+"If the fetch fails or JSON parsing throws, the widget extension falls back "
+"to the placeholder data:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:158
+msgid ""
+"```text\n"
+"Widget({\n"
+"  // ...\n"
+"  placeholder: { temperature: 0, condition: \"Loading...\" },\n"
+"\n"
+"  provider: async () => {\n"
+"    const res = await fetch(\"https://api.example.com/weather\");\n"
+"    if (!res.ok) {\n"
+"      // Return stale/fallback data with a short retry interval\n"
+"      return {\n"
+"        entries: [{ temperature: 0, condition: \"Unavailable\" }],\n"
+"        reloadPolicy: { after: { minutes: 5 } },\n"
+"      };\n"
+"    }\n"
+"    const data = await res.json();\n"
+"    return {\n"
+"      entries: [{ temperature: data.temp, condition: data.desc }],\n"
+"      reloadPolicy: { after: { minutes: 15 } },\n"
+"    };\n"
+"  },\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:181
+msgid ""
+"The `placeholder` field provides data shown in the widget gallery and during"
+" loading. If the provider throws an unhandled exception, the generated "
+"Swift/Kotlin code catches it and renders the placeholder instead."
+msgstr ""
+
+#: src/widgets/data-fetching.md:183
+msgid "Multiple Timeline Entries"
+msgstr ""
+
+#: src/widgets/data-fetching.md:185
+msgid ""
+"Return multiple entries to schedule future content without re-fetching:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:187
+msgid ""
+"```text\n"
+"provider: async () => {\n"
+"  const res = await fetch(\"https://api.example.com/hourly\");\n"
+"  const hours = await res.json();\n"
+"  return {\n"
+"    entries: hours.map((h: any) => ({\n"
+"      temperature: h.temp,\n"
+"      condition: h.condition,\n"
+"    })),\n"
+"    reloadPolicy: { after: { minutes: 60 } },\n"
+"  };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:201
+msgid ""
+"Each entry is rendered at the corresponding date in the timeline. The system"
+" transitions between entries automatically."
+msgstr ""
+
+#: src/widgets/data-fetching.md:205
+msgid "[Configuration](configuration.md) -- User-configurable parameters"
+msgstr ""
+
+#: src/widgets/data-fetching.md:206
+msgid ""
+"[Cross-Platform Reference](platforms.md) -- Build targets and platform "
+"differences"
+msgstr ""
+
+#: src/widgets/platforms.md:3
+msgid ""
+"Perry widgets compile from a single TypeScript source to four platforms. The"
+" same `Widget({...})` declaration produces native code for each target."
+msgstr ""
+
+#: src/widgets/platforms.md:5
+msgid ""
+"**Status:** this page has no TypeScript fences (only target-flag tables and "
+"shell build commands), so the doc-tests harness has nothing to run here. The"
+" `--target` flags listed below are all wired in "
+"`crates/perry/src/commands/compile.rs`, but the harness still can't exercise"
+" them end-to-end — each requires `--app-bundle-id` and a platform SDK "
+"(Xcode, Android NDK)."
+msgstr ""
+
+#: src/widgets/platforms.md:7
+msgid "Target Flags"
+msgstr ""
+
+#: src/widgets/platforms.md:11
+msgid "`--target ios-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:11
+msgid "SwiftUI `.swift` + Info.plist"
+msgstr ""
+
+#: src/widgets/platforms.md:12 src/plugins/native-extensions.md:274
+#: src/testing/geisterhand.md:341 src/cli/flags.md:23
+msgid "iOS Simulator"
+msgstr ""
+
+#: src/widgets/platforms.md:12
+msgid "`--target ios-widget-simulator`"
+msgstr ""
+
+#: src/widgets/platforms.md:12 src/widgets/platforms.md:15
+msgid "Same, simulator SDK"
+msgstr ""
+
+#: src/widgets/platforms.md:13
+msgid "`--target android-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:13
+msgid "Kotlin/Glance `.kt` + widget_info XML"
+msgstr ""
+
+#: src/widgets/platforms.md:14
+msgid "`--target watchos-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:14
+msgid "SwiftUI `.swift` (accessory families)"
+msgstr ""
+
+#: src/widgets/platforms.md:15
+msgid "watchOS Simulator"
+msgstr ""
+
+#: src/widgets/platforms.md:15
+msgid "`--target watchos-widget-simulator`"
+msgstr ""
+
+#: src/widgets/platforms.md:16 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:55 src/widgets/platforms.md:87
+msgid "Wear OS"
+msgstr ""
+
+#: src/widgets/platforms.md:16
+msgid "`--target wearos-tile`"
+msgstr ""
+
+#: src/widgets/platforms.md:16
+msgid "Kotlin Tiles `.kt` + manifest"
+msgstr ""
+
+#: src/widgets/platforms.md:18
+msgid "Feature Matrix"
+msgstr ""
+
+#: src/widgets/platforms.md:23
+msgid "VStack/HStack/ZStack"
+msgstr ""
+
+#: src/widgets/platforms.md:23
+msgid "Column/Row/Box"
+msgstr ""
+
+#: src/widgets/platforms.md:24
+msgid "Image (SF Symbols)"
+msgstr ""
+
+#: src/widgets/platforms.md:24
+msgid "R.drawable"
+msgstr ""
+
+#: src/widgets/platforms.md:26
+msgid "Spacer+bg"
+msgstr ""
+
+#: src/widgets/platforms.md:27
+msgid "forEach"
+msgstr ""
+
+#: src/widgets/platforms.md:28
+msgid "Row compound"
+msgstr ""
+
+#: src/widgets/platforms.md:28 src/widgets/platforms.md:29
+#: src/widgets/wearos.md:30
+msgid "Text fallback"
+msgstr ""
+
+#: src/widgets/platforms.md:29 src/widgets/platforms.md:35
+msgid "N/A"
+msgstr ""
+
+#: src/widgets/platforms.md:29
+msgid "CircularProgressIndicator"
+msgstr ""
+
+#: src/widgets/platforms.md:30
+msgid "Conditional"
+msgstr ""
+
+#: src/widgets/platforms.md:30
+msgid "if"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "FamilySwitch"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "LocalSize"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "requestedSize"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Config (AppIntent)"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Config Activity"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Yes (10+)"
+msgstr ""
+
+#: src/widgets/platforms.md:32 src/widgets/platforms.md:34
+msgid "SharedPrefs"
+msgstr ""
+
+#: src/widgets/platforms.md:33
+msgid "Native provider"
+msgstr ""
+
+#: src/widgets/platforms.md:33
+msgid "JNI"
+msgstr ""
+
+#: src/widgets/platforms.md:34
+msgid "sharedStorage"
+msgstr ""
+
+#: src/widgets/platforms.md:34
+msgid "UserDefaults"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "Deep linking (url)"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "widgetURL"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "clickable Intent"
+msgstr ""
+
+#: src/widgets/platforms.md:37
+msgid "Platform-Specific Notes"
+msgstr ""
+
+#: src/widgets/platforms.md:40
+msgid "Minimum deployment: iOS 17.0"
+msgstr ""
+
+#: src/widgets/platforms.md:41
+msgid "AppIntentConfiguration requires `import AppIntents`"
+msgstr ""
+
+#: src/widgets/platforms.md:42
+msgid "Widget extension memory limit: ~30MB"
+msgstr ""
+
+#: src/widgets/platforms.md:45
+msgid "Requires Glance dependency: `androidx.glance:glance-appwidget:1.1.0`"
+msgstr ""
+
+#: src/widgets/platforms.md:46
+msgid ""
+"Widget sizes mapped from iOS families: systemSmall=2x2, systemMedium=4x2, "
+"systemLarge=4x4"
+msgstr ""
+
+#: src/widgets/platforms.md:47
+msgid "`minimumScaleFactor` not supported in Glance (skipped with warning)"
+msgstr ""
+
+#: src/widgets/platforms.md:50
+msgid "Minimum deployment: watchOS 9.0"
+msgstr ""
+
+#: src/widgets/platforms.md:51
+msgid "Accessory families only (circular, rectangular, inline)"
+msgstr ""
+
+#: src/widgets/platforms.md:52
+msgid "Tighter memory (~15-20MB) and refresh budgets (hourly)"
+msgstr ""
+
+#: src/widgets/platforms.md:53
+msgid "AppIntent requires watchOS 10+; older versions get StaticConfiguration"
+msgstr ""
+
+#: src/widgets/platforms.md:56
+msgid "Same native compilation as Android phone (Wear OS = Android)"
+msgstr ""
+
+#: src/widgets/platforms.md:57
+msgid "Requires Horologist + Tiles Material 3 dependencies"
+msgstr ""
+
+#: src/widgets/platforms.md:58
+msgid "Tiles are full-screen cards in the carousel"
+msgstr ""
+
+#: src/widgets/platforms.md:59
+msgid "`Gauge` maps to `CircularProgressIndicator`"
+msgstr ""
+
+#: src/widgets/platforms.md:61
+msgid "Build Instructions"
+msgstr ""
+
+#: src/widgets/platforms.md:73
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
+msgstr ""
+
+#: src/widgets/platforms.md:75
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
+msgstr ""
+
+#: src/widgets/platforms.md:89
+msgid "# Copy .kt files to Wear OS module\n"
+msgstr ""
+
+#: src/widgets/platforms.md:91
+msgid "# Merge AndroidManifest_snippet.xml\n"
+msgstr ""
+
+#: src/widgets/watchos.md:3
+msgid ""
+"Perry widgets can compile to watchOS WidgetKit complications using `--target"
+" watchos-widget`. The same `Widget({...})` source produces both iOS and "
+"watchOS widgets — the supported families determine the rendering."
+msgstr ""
+
+#: src/widgets/watchos.md:5
+msgid ""
+"**Status:** the snippet on this page compile-links cleanly on the host LLVM "
+"target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `Widget({...})` shape is verified against the codegen. The actual "
+"`--target watchos-widget` / `--target watchos-widget-simulator` cross-"
+"compile is wired in `crates/perry/src/commands/compile.rs` (emits through "
+"the WidgetKit Swift emitter) but the doc-tests harness can't drive it yet — "
+"each cross-target requires `--app-bundle-id` not yet surfaced through the "
+"harness ([\\#194](https://github.com/PerryTS/perry/issues/194)) plus a "
+"watchOS SDK from Xcode. Build with the `perry` CLI to validate end-to-end."
+msgstr ""
+
+#: src/widgets/watchos.md:15
+msgid "Accessory Families"
+msgstr ""
+
+#: src/widgets/watchos.md:17
+msgid ""
+"watchOS complications use accessory families instead of system families:"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Family"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Size"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Best For"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "`accessoryCircular`"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "~76x76pt"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "Single icon, number, or Gauge"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "`accessoryRectangular`"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "~160x76pt"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "2-3 lines of text"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "`accessoryInline`"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "Single line"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "Short text only"
+msgstr ""
+
+#: src/widgets/watchos.md:25
+msgid "Gauge Component"
+msgstr ""
+
+#: src/widgets/watchos.md:27
+msgid "The `Gauge` component is designed for watchOS circular complications:"
+msgstr ""
+
+#: src/widgets/watchos.md:29
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"QuickStats\",\n"
+"    displayName: \"Quick Stats\",\n"
+"    supportedFamilies: [\"accessoryCircular\", \"accessoryRectangular\"],\n"
+"\n"
+"    render(entry: { progress: number; label: string }, family) {\n"
+"        if (family === \"accessoryCircular\") {\n"
+"            return Gauge(entry.progress, 1.0)\n"
+"        }\n"
+"        return VStack([\n"
+"            Text(entry.label),\n"
+"            Gauge(entry.progress, 1.0),\n"
+"        ])\n"
+"    },\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/watchos.md:47
+msgid "Gauge Styles"
+msgstr ""
+
+#: src/widgets/watchos.md:49
+msgid ""
+"**`circular`** — Ring gauge, maps to "
+"`.gaugeStyle(.accessoryCircularCapacity)` in SwiftUI"
+msgstr ""
+
+#: src/widgets/watchos.md:50
+msgid ""
+"**`linear`** / **`linearCapacity`** — Horizontal bar, maps to "
+"`.gaugeStyle(.linearCapacity)`"
+msgstr ""
+
+#: src/widgets/watchos.md:52
+msgid "Refresh Budgets"
+msgstr ""
+
+#: src/widgets/watchos.md:54
+msgid "watchOS has stricter refresh budgets than iOS:"
+msgstr ""
+
+#: src/widgets/watchos.md:55
+msgid ""
+"Recommended: refresh every 60 minutes (`reloadPolicy: { after: { minutes: 60"
+" } }`)"
+msgstr ""
+
+#: src/widgets/watchos.md:56
+msgid "Maximum: system may throttle more aggressively than iOS"
+msgstr ""
+
+#: src/widgets/watchos.md:57
+msgid "Background refresh uses `BackgroundTask` framework"
+msgstr ""
+
+#: src/widgets/watchos.md:62
+msgid "# For Apple Watch device\n"
+msgstr ""
+
+#: src/widgets/watchos.md:64
+msgid "# For Apple Watch Simulator\n"
+msgstr ""
+
+#: src/widgets/watchos.md:69
+msgid "Build:"
+msgstr ""
+
+#: src/widgets/watchos.md:79
+msgid ""
+"watchOS 10+ supports AppIntent for widget configuration (same as iOS 17+)"
+msgstr ""
+
+#: src/widgets/watchos.md:80
+msgid ""
+"Older watchOS versions automatically get `StaticConfiguration` fallback"
+msgstr ""
+
+#: src/widgets/watchos.md:81
+msgid "`config` params work identically to iOS"
+msgstr ""
+
+#: src/widgets/watchos.md:83
+msgid "Memory Considerations"
+msgstr ""
+
+#: src/widgets/watchos.md:85
+msgid ""
+"watchOS widget extensions have tighter memory limits (~15-20MB) compared to "
+"iOS (~30MB). The provider-only compilation approach is critical — only the "
+"data-fetching code runs natively, keeping memory usage minimal."
+msgstr ""
+
+#: src/widgets/wearos.md:3
+msgid ""
+"Perry widgets can compile to Wear OS Tiles using `--target wearos-tile`. "
+"Tiles are glanceable surfaces in the Wear OS tile carousel and watch face "
+"complications."
+msgstr ""
+
+#: src/widgets/wearos.md:5
+msgid ""
+"**Status:** the snippet on this page compile-links cleanly on the host LLVM "
+"target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `Widget({...})` shape is verified against the codegen. `--target "
+"wearos-tile` itself is wired through `crates/perry-codegen-wear-tiles` but "
+"the doc-tests harness can't drive that cross-target yet — `--app-bundle-id` "
+"plumbing is still pending "
+"([\\#194](https://github.com/PerryTS/perry/issues/194)) and you'll need an "
+"Android NDK + Wear OS Gradle deps. Build with the `perry` CLI to validate "
+"end-to-end."
+msgstr ""
+
+#: src/widgets/wearos.md:14
+msgid "Concepts"
+msgstr ""
+
+#: src/widgets/wearos.md:16
+msgid "**Tiles** are full-screen cards users swipe through on their watch"
+msgstr ""
+
+#: src/widgets/wearos.md:17
+msgid "**Complications** are small data displays on the watch face"
+msgstr ""
+
+#: src/widgets/wearos.md:18
+msgid ""
+"Perry compiles `Widget({...})` to a `SuspendingTileService` with layout "
+"builders"
+msgstr ""
+
+#: src/widgets/wearos.md:20
+msgid "Supported Components"
+msgstr ""
+
+#: src/widgets/wearos.md:22
+msgid "Widget API"
+msgstr ""
+
+#: src/widgets/wearos.md:22
+msgid "Wear OS Mapping"
+msgstr ""
+
+#: src/widgets/wearos.md:24
+msgid "`LayoutElementBuilders.Text`"
+msgstr ""
+
+#: src/widgets/wearos.md:25
+msgid "`LayoutElementBuilders.Column`"
+msgstr ""
+
+#: src/widgets/wearos.md:26
+msgid "`LayoutElementBuilders.Row`"
+msgstr ""
+
+#: src/widgets/wearos.md:27
+msgid "`LayoutElementBuilders.Spacer`"
+msgstr ""
+
+#: src/widgets/wearos.md:28
+msgid "Spacer with 1dp height"
+msgstr ""
+
+#: src/widgets/wearos.md:29
+msgid "`Gauge(circular)`"
+msgstr ""
+
+#: src/widgets/wearos.md:29
+msgid "`LayoutElementBuilders.Arc` + `ArcLine`"
+msgstr ""
+
+#: src/widgets/wearos.md:30
+msgid "`Gauge(linear)`"
+msgstr ""
+
+#: src/widgets/wearos.md:31
+msgid "`Image`"
+msgstr ""
+
+#: src/widgets/wearos.md:31
+msgid "Resource-based (provide drawable)"
+msgstr ""
+
+#: src/widgets/wearos.md:33
+msgid "Example"
+msgstr ""
+
+#: src/widgets/wearos.md:35
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StepsTile\",\n"
+"    displayName: \"Steps\",\n"
+"    description: \"Daily step count\",\n"
+"    supportedFamilies: [\"accessoryCircular\"],\n"
+"\n"
+"    provider: async () => {\n"
+"        return {\n"
+"            entries: [{ steps: 7500, goal: 10000 }],\n"
+"            reloadPolicy: { after: { minutes: 60 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render(entry: { steps: number; goal: number }) {\n"
+"        return VStack([\n"
+"            Gauge(entry.steps / entry.goal, 1.0),\n"
+"            Text(`${entry.steps}`),\n"
+"        ])\n"
+"    },\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/wearos.md:65
+msgid "`{Name}TileService.kt` — `SuspendingTileService` with tile layout"
+msgstr ""
+
+#: src/widgets/wearos.md:66
+msgid ""
+"`{Name}TileBridge.kt` — JNI bridge for native provider (if provider exists)"
+msgstr ""
+
+#: src/widgets/wearos.md:67
+msgid "`AndroidManifest_snippet.xml` — Service declaration"
+msgstr ""
+
+#: src/widgets/wearos.md:69
+msgid "Gradle Integration"
+msgstr ""
+
+#: src/widgets/wearos.md:71
+msgid "Add to your Wear OS module's `build.gradle`:"
+msgstr ""
+
+#: src/widgets/wearos.md:75
+msgid "\"com.google.android.horologist:horologist-tiles:0.6.5\""
+msgstr ""
+
+#: src/widgets/wearos.md:76
+msgid "\"androidx.wear.tiles:tiles-material:1.4.0\""
+msgstr ""
+
+#: src/widgets/wearos.md:77
+msgid "\"androidx.wear.tiles:tiles:1.4.0\""
+msgstr ""
+
+#: src/widgets/wearos.md:81
+msgid "Merge the manifest snippet into your `AndroidManifest.xml`:"
+msgstr ""
+
+#: src/widgets/wearos.md:85
+msgid "\".StepsTileService\""
+msgstr ""
+
+#: src/widgets/wearos.md:86
+msgid "\"true\""
+msgstr ""
+
+#: src/widgets/wearos.md:87
+msgid "\"com.google.android.wearable.permission.BIND_TILE_PROVIDER\""
+msgstr ""
+
+#: src/widgets/wearos.md:89
+msgid "\"androidx.wear.tiles.action.BIND_TILE_PROVIDER\""
+msgstr ""
+
+#: src/widgets/wearos.md:94
+msgid "Native Provider"
+msgstr ""
+
+#: src/widgets/wearos.md:96
+msgid "Same as Android phone widgets — Wear OS is Android:"
+msgstr ""
+
+#: src/widgets/wearos.md:97
+msgid "Target triple: `aarch64-linux-android`"
+msgstr ""
+
+#: src/widgets/wearos.md:98
+msgid "`libwidget_provider.so` loaded via `System.loadLibrary`"
+msgstr ""
+
+#: src/widgets/wearos.md:99
+msgid "JNI bridge pattern identical to phone Glance widgets"
+msgstr ""
+
+#: src/widgets/wearos.md:100
+msgid "`sharedStorage()` uses `SharedPreferences`"
+msgstr ""
+
+#: src/widgets/wearos.md:102
+msgid "Refresh"
+msgstr ""
+
+#: src/widgets/wearos.md:104
+msgid ""
+"Wear Tiles use `freshnessIntervalMillis` on the `Tile` builder. Set via "
+"`reloadPolicy: { after: { minutes: N } }` in the provider return value. "
+"Default: 60 minutes."
+msgstr ""
+
+#: src/plugins/overview.md:1
+msgid "Plugin System Overview"
+msgstr ""
+
+#: src/plugins/overview.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). Receiver-less calls (`loadPlugin`, `listPlugins`, `emitHook`, "
+"`invokeTool`, ...) and `PluginApi` instance methods (`api.registerHook`, "
+"`api.registerTool`, ...) dispatch through `crates/perry-"
+"codegen/src/lower_call.rs::PERRY_PLUGIN_TABLE` and "
+"`PERRY_PLUGIN_INSTANCE_TABLE`. TypeScript surface lives in "
+"`types/perry/plugin/index.d.ts`. Host-side snippets below are compile-link "
+"verified by the doc-tests harness against "
+"[`docs/examples/plugins/host_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/host_snippets.ts);"
+" plugin-side `activate(api)` snippets against "
+"[`docs/examples/plugins/plugin_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/plugin_snippets.ts)."
+msgstr ""
+
+#: src/plugins/overview.md:5
+msgid ""
+"Perry supports native plugins as shared libraries (`.dylib`/`.so`). Plugins "
+"extend Perry applications with custom hooks, tools, services, and routes."
+msgstr ""
+
+#: src/plugins/overview.md:9
+msgid ""
+"A plugin is a Perry-compiled shared library with `activate(api)` and "
+"`deactivate()` entry points"
+msgstr ""
+
+#: src/plugins/overview.md:10
+msgid "The host application loads plugins with `loadPlugin(path)`"
+msgstr ""
+
+#: src/plugins/overview.md:11
+msgid "Plugins register hooks, tools, and services via the API handle"
+msgstr ""
+
+#: src/plugins/overview.md:12
+msgid "The host dispatches events to plugins via `emitHook(name, data)`"
+msgstr ""
+
+#: src/plugins/overview.md:14
+msgid ""
+"```\n"
+"Host Application\n"
+"    ↓ loadPlugin(\"./my-plugin.dylib\")\n"
+"    ↓ calls plugin_activate(api_handle)\n"
+"Plugin\n"
+"    ↓ api.registerHook(\"beforeSave\", callback)\n"
+"    ↓ api.registerTool(\"format\", callback)\n"
+"Host\n"
+"    ↓ emitHook(\"beforeSave\", data) → plugin callback runs\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:27
+msgid "Plugin (compiled with `--output-type dylib`)"
+msgstr ""
+
+#: src/plugins/overview.md:29 src/plugins/creating-plugins.md:9
+msgid ""
+"```typescript\n"
+"let count = 0\n"
+"\n"
+"export function activate(api: PluginApi) {\n"
+"    api.setMetadata(\"counter\", \"1.0.0\", \"Counts hook invocations\")\n"
+"\n"
+"    api.registerHook(\"onRequest\", (data) => {\n"
+"        count++\n"
+"        console.log(`Request #${count}`)\n"
+"        return data\n"
+"    })\n"
+"\n"
+"    api.registerTool(\"getCount\", \"returns request count\", () => count)\n"
+"}\n"
+"\n"
+"export function deactivate() {\n"
+"    console.log(`Total requests processed: ${count}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:53
+msgid "Host Application"
+msgstr ""
+
+#: src/plugins/overview.md:55
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"    loadPlugin, unloadPlugin,\n"
+"    emitHook, emitEvent, invokeTool,\n"
+"    setPluginConfig,\n"
+"    discoverPlugins, listPlugins, listHooks, listTools,\n"
+"    pluginCount, initPlugins,\n"
+"} from \"perry/plugin\"\n"
+"\n"
+"const id = loadPlugin(\"./counter-plugin.dylib\")\n"
+"console.log(`load returned: ${id !== 0 ? \"ok\" : \"fail\"}`)\n"
+"\n"
+"const plugins = listPlugins()\n"
+"const hooks = listHooks()\n"
+"const tools = listTools()\n"
+"console.log(`loaded: ${pluginCount()} plugin(s), ${hooks.length} hook(s), ${tools.length} tool(s)`)\n"
+"\n"
+"const result = emitHook(\"beforeSave\", { content: \"hello world\" })\n"
+"\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:81
+msgid "Plugin ABI"
+msgstr ""
+
+#: src/plugins/overview.md:83
+msgid "Plugins must export these symbols:"
+msgstr ""
+
+#: src/plugins/overview.md:84
+msgid ""
+"`perry_plugin_abi_version()` — Returns ABI version (for compatibility "
+"checking)"
+msgstr ""
+
+#: src/plugins/overview.md:85
+msgid "`plugin_activate(api_handle)` — Called when plugin is loaded"
+msgstr ""
+
+#: src/plugins/overview.md:86
+msgid "`plugin_deactivate()` — Called when plugin is unloaded"
+msgstr ""
+
+#: src/plugins/overview.md:88
+msgid ""
+"Perry generates these automatically from your `activate`/`deactivate` "
+"exports."
+msgstr ""
+
+#: src/plugins/overview.md:92
+msgid ""
+"Perry also supports **native extensions** — packages that bundle platform-"
+"specific Rust/Swift/JNI code and compile directly into your binary. These "
+"are used for accessing platform APIs like the App Store review prompt or "
+"StoreKit in-app purchases."
+msgstr ""
+
+#: src/plugins/overview.md:94
+msgid "See [Native Extensions](native-extensions.md) for details."
+msgstr ""
+
+#: src/plugins/overview.md:98
+msgid "[Creating Plugins](creating-plugins.md) — Build a plugin step by step"
+msgstr ""
+
+#: src/plugins/overview.md:99
+msgid "[Hooks & Events](hooks-and-events.md) — Hook modes, event bus, tools"
+msgstr ""
+
+#: src/plugins/overview.md:100
+msgid ""
+"[Native Extensions](native-extensions.md) — Extensions with platform-native "
+"code"
+msgstr ""
+
+#: src/plugins/overview.md:101
+msgid ""
+"[App Store Review](appstore-review.md) — Native review prompt (iOS/Android)"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). See [Plugin System Overview — Status](overview.md) for the full "
+"surface. Snippets below are compile-link verified by the doc-tests harness "
+"against "
+"[`docs/examples/plugins/plugin_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/plugin_snippets.ts)"
+" and "
+"[`docs/examples/plugins/host_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/host_snippets.ts)."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:5
+msgid "Build Perry plugins as shared libraries that extend host applications."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:7
+msgid "Step 1: Write the Plugin"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:29
+msgid "Step 2: Compile as Shared Library"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:35
+msgid ""
+"The `--output-type dylib` flag tells Perry to produce a `.dylib` (macOS) or "
+"`.so` (Linux) instead of an executable."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:38
+msgid ""
+"Generates `perry_plugin_abi_version()` returning the current ABI version"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:39
+msgid ""
+"Generates `plugin_activate(api_handle)` calling your `activate()` function"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:40
+msgid "Generates `plugin_deactivate()` calling your `deactivate()` function"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:41
+msgid "Exports symbols with `-rdynamic` for the host to find"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:43
+msgid "Step 3: Load from Host"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:45
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"    loadPlugin, unloadPlugin,\n"
+"    emitHook, emitEvent, invokeTool,\n"
+"    setPluginConfig,\n"
+"    discoverPlugins, listPlugins, listHooks, listTools,\n"
+"    pluginCount, initPlugins,\n"
+"} from \"perry/plugin\"\n"
+"\n"
+"const id = loadPlugin(\"./counter-plugin.dylib\")\n"
+"console.log(`load returned: ${id !== 0 ? \"ok\" : \"fail\"}`)\n"
+"\n"
+"const found = discoverPlugins(\"./plugins/\")\n"
+"console.log(`discovered ${found.length} plugin(s)`)\n"
+"\n"
+"const result = emitHook(\"beforeSave\", { content: \"hello world\" })\n"
+"\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:69
+msgid "Plugin API Reference"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:71
+msgid "The `api: PluginApi` passed to `activate()` provides:"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:73
+msgid "Metadata"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:79
+msgid "Hooks"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:86
+msgid ""
+"`registerHook` defaults to priority 10 / mode 0 (filter). Use "
+"`registerHookEx` for explicit priority and mode (0=filter, 1=action, "
+"2=waterfall). Lower priority numbers run first."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:90 src/plugins/hooks-and-events.md:94
+msgid "Tools"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:96
+msgid "Tools are invoked by name from the host."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:100
+msgid ""
+"```typescript,no-test\n"
+"const value = api.getConfig(key: string)  // Read host-provided config\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:106
+msgid ""
+"```typescript,no-test\n"
+"api.on(event: string, handler: (data: unknown) => void): void  // Listen for events\n"
+"api.emit(event: string, data: unknown): void                    // Emit to other plugins\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:113
+msgid "[Hooks & Events](hooks-and-events.md) — Hook modes, event bus"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:114 src/plugins/hooks-and-events.md:147
+#: src/plugins/native-extensions.md:301
+msgid "[Overview](overview.md) — Plugin system overview"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). `api.registerHook`, `api.on`, `emitHook`, `emitEvent`, `invokeTool`"
+" all dispatch to `crates/perry-runtime/src/plugin.rs`. Snippets below are "
+"compile-link verified against "
+"[`docs/examples/plugins/{plugin,host}_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/)."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:5
+msgid "Perry plugins communicate through hooks, events, and tools."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:7
+msgid "Hook Modes"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:9
+msgid "Hooks support three execution modes:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:11
+msgid "Filter Mode (default)"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:13
+msgid ""
+"Each plugin receives data and returns (possibly modified) data. The output "
+"of one plugin becomes the input of the next:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:15
+msgid ""
+"```typescript\n"
+"function registerFilter(api: PluginApi) {\n"
+"    api.registerHook(\"transform\", (data: any) => {\n"
+"        data.content = data.content.toUpperCase()\n"
+"        return data // Returned data goes to next plugin\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:24
+msgid "Action Mode"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:26
+msgid ""
+"Plugins receive data but return value is ignored. Used for side effects. "
+"Pass `mode = 1` to `registerHookEx`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:29
+msgid ""
+"```typescript\n"
+"function registerAction(api: PluginApi) {\n"
+"    api.registerHook(\"onSave\", (data: any) => {\n"
+"        console.log(`Saved: ${data.path}`)\n"
+"        return data\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:38
+msgid "Waterfall Mode"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:40
+msgid ""
+"Like filter mode, but specifically for accumulating/building up a result "
+"through the chain. Pass `mode = 2` to `registerHookEx`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:43
+msgid ""
+"```typescript\n"
+"function registerWaterfall(api: PluginApi) {\n"
+"    api.registerHook(\"buildMenu\", (items: any) => {\n"
+"        items.push({ label: \"My Plugin Action\", action: () => {} })\n"
+"        return items\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:52
+msgid "Hook Priority"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:54
+msgid ""
+"Lower priority numbers run first. Use `registerHookEx` for explicit priority"
+" and mode:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:57
+msgid ""
+"```typescript\n"
+"function registerPriorities(api: PluginApi, validate: (d: any) => any, transform: (d: any) => any, log: (d: any) => any) {\n"
+"    // Lower priority numbers run first; default 10. Mode 0=filter / 1=action / 2=waterfall.\n"
+"    api.registerHookEx(\"beforeSave\", validate, 10, 0)   // Runs first\n"
+"    api.registerHookEx(\"beforeSave\", transform, 20, 0)  // Runs second\n"
+"    api.registerHookEx(\"beforeSave\", log, 100, 1)        // Runs last (action mode)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:66
+msgid "Default priority is 10 (the value `registerHook` passes implicitly)."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:68
+msgid "Event Bus"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:70
+msgid "Plugins can communicate with each other through events:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:72
+msgid "Emitting Events"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:74
+msgid ""
+"```typescript\n"
+"function emitFromPlugin(api: PluginApi) {\n"
+"    api.emit(\"dataUpdated\", { source: \"my-plugin\", records: 42 })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:80
+msgid ""
+"```typescript\n"
+"emitEvent(\"dataUpdated\", { source: \"host\", records: 100 })\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:84
+msgid "Listening for Events"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:86
+msgid ""
+"```typescript\n"
+"function listenForEvent(api: PluginApi) {\n"
+"    api.on(\"dataUpdated\", (data: any) => {\n"
+"        console.log(`${data.source} updated ${data.records} records`)\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:96
+msgid ""
+"Plugins register callable tools (note the 3-arg shape: `name`, "
+"`description`, `handler`):"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:99
+msgid ""
+"```typescript\n"
+"function registerFormatter(api: PluginApi) {\n"
+"    api.registerTool(\"formatCode\", \"format source code\", (args: any) => {\n"
+"        return `// formatted: ${args.code}`\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:107
+msgid ""
+"```typescript\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:117
+msgid "Hosts can pass configuration to plugins via `setPluginConfig`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:119
+msgid ""
+"```typescript\n"
+"initPlugins()\n"
+"setPluginConfig(\"api_key\", \"test-key\")\n"
+"setPluginConfig(\"max_retries\", \"3\")\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:125
+msgid ""
+"```typescript\n"
+"function readConfig(api: PluginApi) {\n"
+"    const theme = api.getConfig(\"theme\")     // \"dark\"\n"
+"    const retries = api.getConfig(\"maxRetries\") // \"3\"\n"
+"    return { theme, retries }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:133
+msgid "Introspection"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:135
+msgid "Query loaded plugins and their registrations:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:146
+msgid "[Creating Plugins](creating-plugins.md) — Build a plugin"
+msgstr ""
+
+#: src/plugins/native-extensions.md:3
+msgid ""
+"**Status: partially wired.** The `--bundle-extensions` flag, the "
+"`perry.nativeLibrary` `package.json` manifest, and `declare function` FFI "
+"imports are all wired into the compiler — see "
+"`crates/perry/src/commands/compile.rs` (the `bundle_extensions` argument, "
+"the `parse_native_library_manifest`/`build_external_native_libraries` "
+"helpers) and `crates/perry-codegen/src/codegen.rs` (the "
+"`nativeLibrary.functions` signature parser). The TypeScript snippets below "
+"assume a fully-populated extension directory exists on disk (e.g. `perry-"
+"appstore-review` cloned under `./extensions/`). They are kept as `,no-test` "
+"because the doc-tests harness doesn't have those external extensions checked"
+" in — a real project that does have them will compile cleanly. Drift "
+"protection for the parts that _don't_ depend on external extensions (the FFI"
+" declare-function shape, etc.) lives in "
+"`docs/examples/platforms/wasm_snippets.ts`."
+msgstr ""
+
+#: src/plugins/native-extensions.md:5
+msgid ""
+"Perry supports native extensions — packages that bundle platform-specific "
+"code (Rust, Swift, JNI) alongside a TypeScript API. Unlike [dynamic "
+"plugins](overview.md) loaded at runtime, native extensions are compiled "
+"directly into your binary."
+msgstr ""
+
+#: src/plugins/native-extensions.md:7
+msgid ""
+"Native extensions are how you access platform APIs that aren't part of "
+"Perry's built-in [System APIs](../system/overview.md) or [Standard "
+"Library](../stdlib/overview.md). Examples include [App Store "
+"Review](appstore-review.md) and StoreKit for in-app purchases."
+msgstr ""
+
+#: src/plugins/native-extensions.md:9
+msgid "Using a native extension"
+msgstr ""
+
+#: src/plugins/native-extensions.md:11
+msgid "1. Add the extension to your project"
+msgstr ""
+
+#: src/plugins/native-extensions.md:13
+msgid ""
+"Place the extension directory alongside your project, or in a shared "
+"extensions directory:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:30
+msgid "2. Compile with `--bundle-extensions`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:32
+msgid "Pass the extensions directory when building:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:38
+msgid ""
+"Perry discovers every subdirectory with a `package.json`, compiles its "
+"native crates for the target platform, and links them into your binary."
+msgstr ""
+
+#: src/plugins/native-extensions.md:40
+msgid "3. Import and use"
+msgstr ""
+
+#: src/plugins/native-extensions.md:42 src/plugins/appstore-review.md:60
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"\n"
+"await requestReview();\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:48
+msgid ""
+"The import resolves at compile time to the extension's entry point. No "
+"runtime module loading is involved — the function compiles to a direct "
+"native call."
+msgstr ""
+
+#: src/plugins/native-extensions.md:50
+msgid "How native extensions work"
+msgstr ""
+
+#: src/plugins/native-extensions.md:52
+msgid ""
+"A native extension is a directory with a `package.json` that declares a "
+"`perry.nativeLibrary` section. This tells Perry which native functions "
+"exist, their signatures, and which Rust crate to compile for each platform."
+msgstr ""
+
+#: src/plugins/native-extensions.md:54
+msgid "package.json manifest"
+msgstr ""
+
+#: src/plugins/native-extensions.md:58
+msgid "\"perry-appstore-review\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:59
+msgid "\"0.1.0\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:62 src/plugins/appstore-review.md:181
+msgid "\"nativeLibrary\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:63 src/plugins/appstore-review.md:182
+msgid "\"functions\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"sb_appreview_request\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"params\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"returns\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"f64\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:66
+msgid "\"targets\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:68 src/plugins/native-extensions.md:73
+#: src/plugins/native-extensions.md:78
+msgid "\"crate\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:68 src/plugins/native-extensions.md:78
+msgid "\"crate-ios\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:69 src/plugins/native-extensions.md:74
+#: src/plugins/native-extensions.md:79
+msgid "\"lib\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:69 src/plugins/native-extensions.md:74
+#: src/plugins/native-extensions.md:79
+msgid "\"libperry_appreview.a\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:70 src/plugins/native-extensions.md:75
+#: src/plugins/native-extensions.md:80
+msgid "\"frameworks\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:70 src/plugins/native-extensions.md:80
+msgid "\"StoreKit\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:73
+msgid "\"crate-android\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:77
+msgid "\"macos\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:88
+msgid "`functions`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:90
+msgid "Each entry declares a native function the extension exports:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:94 src/cli/perry-toml.md:116
+msgid "`name`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:94
+msgid "Symbol name — must match the `#[no_mangle]` Rust function exactly"
+msgstr ""
+
+#: src/plugins/native-extensions.md:95
+msgid "`params`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:95
+msgid ""
+"Array of LLVM types: `\"i64\"` for pointers/strings, `\"f64\"` for numbers, "
+"`\"i32\"` for integers"
+msgstr ""
+
+#: src/plugins/native-extensions.md:96
+msgid "`returns`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:96
+msgid "Return type — typically `\"f64\"` (NaN-boxed value or promise handle)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:98
+msgid "`targets`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:100
+msgid ""
+"Each target platform maps to a Rust crate that implements the native "
+"functions:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:104
+msgid "`crate`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:104
+msgid "Relative path to the Rust crate directory"
+msgstr ""
+
+#: src/plugins/native-extensions.md:105
+msgid "`lib`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:105
+msgid "Name of the static library produced by `cargo build`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:106
+msgid "`frameworks`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:106
+msgid "System frameworks to link (iOS/macOS only)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:108
+msgid ""
+"Multiple targets can share the same crate (e.g., iOS and macOS often share "
+"an implementation). Platforms without an entry fall back to the stub."
+msgstr ""
+
+#: src/plugins/native-extensions.md:110
+msgid "Extension directory layout"
+msgstr ""
+
+#: src/plugins/native-extensions.md:112
+msgid ""
+"```\n"
+"perry-appstore-review/\n"
+"├── package.json              # Manifest with perry.nativeLibrary\n"
+"├── src/\n"
+"│   └── index.ts              # TypeScript API (what users import)\n"
+"├── crate-ios/                # iOS/macOS native implementation\n"
+"│   ├── Cargo.toml            # [lib] crate-type = [\"staticlib\"]\n"
+"│   ├── build.rs              # Compiles Swift if needed\n"
+"│   ├── src/\n"
+"│   │   └── lib.rs            # Rust FFI: #[no_mangle] pub extern \"C\" fn ...\n"
+"│   └── swift/\n"
+"│       └── bridge.swift      # Swift bridge for Apple APIs (@_cdecl)\n"
+"├── crate-android/            # Android native implementation\n"
+"│   ├── Cargo.toml\n"
+"│   └── src/\n"
+"│       └── lib.rs            # Rust FFI with JNI calls\n"
+"└── crate-stub/               # Fallback for unsupported platforms\n"
+"    ├── Cargo.toml\n"
+"    └── src/\n"
+"        └── lib.rs            # Returns error immediately\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:134
+msgid "TypeScript side"
+msgstr ""
+
+#: src/plugins/native-extensions.md:136
+msgid ""
+"The `src/index.ts` declares native functions and optionally wraps them in a "
+"friendlier API:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:138
+msgid ""
+"```text\n"
+"// Declare the native function (name must match package.json)\n"
+"declare function sb_appreview_request(): number;\n"
+"\n"
+"// Wrap it with a proper TypeScript signature\n"
+"export async function requestReview(): Promise<void> {\n"
+"  await (sb_appreview_request() as any);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:148
+msgid ""
+"`declare function` tells Perry the function is provided by native code. The "
+"raw return type is `number` because all values cross the FFI boundary as "
+"NaN-boxed `f64` values. Promise handles are NaN-boxed pointers that Perry's "
+"runtime knows how to `await`."
+msgstr ""
+
+#: src/plugins/native-extensions.md:150
+msgid "Rust side"
+msgstr ""
+
+#: src/plugins/native-extensions.md:152
+msgid ""
+"Each platform crate is a `staticlib` that implements the declared functions "
+"using `#[no_mangle] pub extern \"C\"`:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:155
+msgid "// Perry runtime FFI\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:156 src/plugins/native-extensions.md:164
+#: src/plugins/native-extensions.md:256
+msgid "\"C\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:167
+msgid "// ... call platform API, resolve promise when done ...\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:173
+msgid "Key runtime functions available to native code:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:175 src/contributing/architecture.md:23
+msgid "Purpose"
+msgstr ""
+
+#: src/plugins/native-extensions.md:177
+msgid "`js_promise_new()`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:177
+msgid "Create a new Perry promise, returns pointer"
+msgstr ""
+
+#: src/plugins/native-extensions.md:178
+msgid "`js_promise_resolve(promise, value)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:178
+msgid "Resolve a promise with a NaN-boxed value"
+msgstr ""
+
+#: src/plugins/native-extensions.md:179
+msgid "`js_nanbox_string(ptr)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:179
+msgid "Convert a C string pointer to a NaN-boxed string"
+msgstr ""
+
+#: src/plugins/native-extensions.md:180
+msgid "`js_nanbox_pointer(ptr)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:180
+msgid "Convert a pointer to a NaN-boxed object reference"
+msgstr ""
+
+#: src/plugins/native-extensions.md:181
+msgid "`js_get_string_pointer_unified(val)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:181
+msgid "Extract string pointer from a NaN-boxed value"
+msgstr ""
+
+#: src/plugins/native-extensions.md:182
+msgid "`js_string_from_bytes(ptr, len)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:182
+msgid "Create a Perry string from bytes"
+msgstr ""
+
+#: src/plugins/native-extensions.md:184
+msgid "Swift bridge (iOS/macOS)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:186
+msgid ""
+"Apple platform APIs are often easiest to call from Swift. The pattern is:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:188
+msgid "Write a Swift file with `@_cdecl(\"function_name\")` exports"
+msgstr ""
+
+#: src/plugins/native-extensions.md:189
+msgid "Compile it to a static library in `build.rs`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:190
+msgid "Call the Swift functions from Rust via `extern \"C\"`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:192
+msgid ""
+"```swift\n"
+"import StoreKit\n"
+"\n"
+"typealias Callback = @convention(c) (UnsafeMutableRawPointer, UnsafePointer<CChar>) -> Void\n"
+"\n"
+"@_cdecl(\"swift_appreview_request\")\n"
+"func swiftRequestReview(_ callback: @escaping Callback, _ context: UnsafeMutableRawPointer) {\n"
+"    DispatchQueue.main.async {\n"
+"        if let scene = UIApplication.shared.connectedScenes\n"
+"            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {\n"
+"            SKStoreReviewController.requestReview(in: scene)\n"
+"        }\n"
+"        let result = \"{\\\"success\\\":true}\"\n"
+"        result.withCString { callback(context, $0) }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:210
+msgid ""
+"The `build.rs` compiles the Swift source into a static library using "
+"`swiftc`, targeting the correct platform SDK:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:213
+msgid "// build.rs (simplified)\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:215
+msgid ""
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:221
+msgid "JNI bridge (Android)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:223
+msgid "Android platform APIs are accessed through JNI. The pattern:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:225
+msgid "Get the `JavaVM` via `JNI_GetCreatedJavaVMs()`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:226
+msgid "Attach the current thread to get a `JNIEnv`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:227
+msgid "Call Java/Kotlin APIs through JNI method invocations"
+msgstr ""
+
+#: src/plugins/native-extensions.md:228
+msgid "Resolve the Perry promise with the result"
+msgstr ""
+
+#: src/plugins/native-extensions.md:238
+msgid "// Get Activity from PerryBridge\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:239
+msgid "\"com/perry/app/PerryBridge\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:240
+msgid "\"getActivity\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:240
+msgid "\"()Landroid/app/Activity;\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:243
+msgid "// Call platform APIs via JNI...\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:248
+msgid ""
+"If the Android implementation requires a Java library (e.g., Google Play In-"
+"App Review), the app's `build.gradle` must include the dependency. Document "
+"this requirement clearly for your extension's users."
+msgstr ""
+
+#: src/plugins/native-extensions.md:250
+msgid "Stub crate"
+msgstr ""
+
+#: src/plugins/native-extensions.md:252
+msgid ""
+"For platforms without a native implementation, the stub immediately resolves"
+" the promise with an error:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:259
+msgid "\"{\\\"error\\\":\\\"Not available on this platform\\\"}\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:269
+msgid "Build requirements"
+msgstr ""
+
+#: src/plugins/native-extensions.md:273
+msgid "macOS host, Xcode, `rustup target add aarch64-apple-ios`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:274
+msgid "macOS host, Xcode, `rustup target add aarch64-apple-ios-sim`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:275
+msgid "macOS host, Xcode Command Line Tools"
+msgstr ""
+
+#: src/plugins/native-extensions.md:276
+msgid "Android NDK, `rustup target add aarch64-linux-android`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:278
+msgid ""
+"When Perry encounters a `perry.nativeLibrary` manifest during compilation, "
+"it:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:280
+msgid "Selects the crate for the current `--target` platform"
+msgstr ""
+
+#: src/plugins/native-extensions.md:281
+msgid "Runs `cargo build --release --target <triple>` in the crate directory"
+msgstr ""
+
+#: src/plugins/native-extensions.md:282
+msgid "Links the resulting `.a` static library into the final binary"
+msgstr ""
+
+#: src/plugins/native-extensions.md:283
+msgid "Adds any declared frameworks (e.g., `-framework StoreKit`)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:285
+msgid "Creating your own native extension"
+msgstr ""
+
+#: src/plugins/native-extensions.md:287
+msgid "Create the directory structure shown above"
+msgstr ""
+
+#: src/plugins/native-extensions.md:288
+msgid "Define your functions in `package.json` under `perry.nativeLibrary`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:289
+msgid ""
+"Implement each function in the platform crates with matching `#[no_mangle] "
+"pub extern \"C\"` signatures"
+msgstr ""
+
+#: src/plugins/native-extensions.md:290
+msgid ""
+"Write a TypeScript entry point that declares and optionally wraps the native"
+" functions"
+msgstr ""
+
+#: src/plugins/native-extensions.md:291
+msgid "Add a stub crate for unsupported platforms"
+msgstr ""
+
+#: src/plugins/native-extensions.md:292
+msgid "Test with `--bundle-extensions`:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:299
+msgid ""
+"[App Store Review](appstore-review.md) — Native review prompt extension "
+"(iOS/Android)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:300
+msgid ""
+"[Creating Plugins](creating-plugins.md) — Dynamic plugins loaded at runtime"
+msgstr ""
+
+#: src/plugins/appstore-review.md:3
+msgid ""
+"**Status: extension-dependent.** The compiler-side wiring (`--bundle-"
+"extensions`, `perry.nativeLibrary`, `declare function`) is in place — see "
+"[Native Extensions — Status](native-extensions.md) — but the snippets below "
+"assume the `perry-appstore-review` extension repo has been cloned into "
+"`./extensions/`. The doc-tests harness doesn't ship that repo, so these "
+"snippets are kept as `,no-test`. Once the extension is on disk, they compile"
+" and run on iOS / iOS Simulator / macOS / Android."
+msgstr ""
+
+#: src/plugins/appstore-review.md:5
+msgid ""
+"Prompt users to rate your app using the native app store review dialog on "
+"iOS and Android."
+msgstr ""
+
+#: src/plugins/appstore-review.md:7
+msgid ""
+"The `perry-appstore-review` extension exposes a single function — "
+"`requestReview()` — that opens the platform's native review prompt. It does "
+"nothing else: when and how often to ask is entirely up to you."
+msgstr ""
+
+#: src/plugins/appstore-review.md:9
+msgid ""
+"**Repository:** "
+"[github.com/PerryTS/appstorereview](https://github.com/PerryTS/appstorereview)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:13
+msgid "1. Add the extension"
+msgstr ""
+
+#: src/plugins/appstore-review.md:15
+msgid "Clone or copy the extension into your project's extensions directory:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:24
+msgid "Your project structure:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:35
+msgid "2. Use in your app"
+msgstr ""
+
+#: src/plugins/appstore-review.md:37
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"\n"
+"// Show the review prompt when the user completes a meaningful action\n"
+"async function onLevelComplete() {\n"
+"  await requestReview();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/appstore-review.md:46
+msgid "3. Build"
+msgstr ""
+
+#: src/plugins/appstore-review.md:52
+msgid ""
+"The `--bundle-extensions` flag tells Perry to discover, compile, and link "
+"all native extensions in the given directory. The app store review native "
+"code is compiled and statically linked into your binary — no runtime "
+"dependencies."
+msgstr ""
+
+#: src/plugins/appstore-review.md:56
+msgid "`requestReview(): Promise<void>`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:58
+msgid ""
+"Opens the native app store review prompt. Returns a promise that resolves "
+"when the prompt has been presented (or skipped by the OS)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:66
+msgid "The function only triggers the prompt. It does not:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:67
+msgid "Track whether the user has already reviewed"
+msgstr ""
+
+#: src/plugins/appstore-review.md:68
+msgid ""
+"Throttle how often the prompt appears (iOS does this automatically; Android "
+"does not)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:69
+msgid ""
+"Return whether the user actually left a review (neither platform provides "
+"this)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:71
+msgid "Platform behavior"
+msgstr ""
+
+#: src/plugins/appstore-review.md:75
+msgid ""
+"Uses "
+"[`SKStoreReviewController.requestReview(in:)`](https://developer.apple.com/documentation/storekit/skstorereviewcontroller/requestreview(in:))"
+" from StoreKit."
+msgstr ""
+
+#: src/plugins/appstore-review.md:77 src/plugins/appstore-review.md:93
+#: src/plugins/appstore-review.md:106
+msgid "Detail"
+msgstr ""
+
+#: src/plugins/appstore-review.md:79 src/plugins/appstore-review.md:95
+#: src/plugins/appstore-review.md:108
+msgid "Native API"
+msgstr ""
+
+#: src/plugins/appstore-review.md:79
+msgid "`SKStoreReviewController.requestReview(in: UIWindowScene)`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:80
+msgid "Minimum iOS version"
+msgstr ""
+
+#: src/plugins/appstore-review.md:80
+msgid "14.0"
+msgstr ""
+
+#: src/plugins/appstore-review.md:81 src/plugins/appstore-review.md:97
+msgid "Framework"
+msgstr ""
+
+#: src/plugins/appstore-review.md:81 src/plugins/appstore-review.md:97
+msgid "StoreKit"
+msgstr ""
+
+#: src/plugins/appstore-review.md:82
+msgid "Thread"
+msgstr ""
+
+#: src/plugins/appstore-review.md:82
+msgid "Dispatched to main thread automatically"
+msgstr ""
+
+#: src/plugins/appstore-review.md:83 src/plugins/appstore-review.md:98
+#: src/plugins/appstore-review.md:111
+msgid "Throttling"
+msgstr ""
+
+#: src/plugins/appstore-review.md:83
+msgid ""
+"Apple limits display to 3 times per 365-day period per app. The system may "
+"silently ignore the call."
+msgstr ""
+
+#: src/plugins/appstore-review.md:84
+msgid "Development builds"
+msgstr ""
+
+#: src/plugins/appstore-review.md:84
+msgid "Always shown in debug/TestFlight builds"
+msgstr ""
+
+#: src/plugins/appstore-review.md:85
+msgid "User control"
+msgstr ""
+
+#: src/plugins/appstore-review.md:85
+msgid "Users can disable review prompts in Settings > App Store"
+msgstr ""
+
+#: src/plugins/appstore-review.md:87
+msgid ""
+"**Important:** Apple's throttling means the prompt is not guaranteed to "
+"appear every time `requestReview()` is called. Design your app flow so that "
+"not showing the prompt doesn't break the user experience."
+msgstr ""
+
+#: src/plugins/appstore-review.md:91
+msgid ""
+"Uses the same StoreKit API. Shares the iOS native crate (both compile from "
+"`crate-ios`)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:95
+msgid "`SKStoreReviewController.requestReview()`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:96
+msgid "Minimum macOS version"
+msgstr ""
+
+#: src/plugins/appstore-review.md:96
+msgid "13.0"
+msgstr ""
+
+#: src/plugins/appstore-review.md:98
+msgid "Same as iOS — system-controlled"
+msgstr ""
+
+#: src/plugins/appstore-review.md:100
+msgid "Only works for apps distributed through the Mac App Store."
+msgstr ""
+
+#: src/plugins/appstore-review.md:104
+msgid ""
+"Uses the [Google Play In-App Review "
+"API](https://developer.android.com/guide/playcore/in-app-review)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:108
+msgid "`ReviewManager.requestReviewFlow()` + `launchReviewFlow()`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:109
+msgid "Library"
+msgstr ""
+
+#: src/plugins/appstore-review.md:109
+msgid "`com.google.android.play:review`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:110
+msgid "Minimum API level"
+msgstr ""
+
+#: src/plugins/appstore-review.md:110
+msgid "21 (Android 5.0)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:111
+msgid "Google enforces a quota — the prompt may not appear every time"
+msgstr ""
+
+#: src/plugins/appstore-review.md:112
+msgid "Execution"
+msgstr ""
+
+#: src/plugins/appstore-review.md:112
+msgid "Runs on a background thread to avoid blocking the UI"
+msgstr ""
+
+#: src/plugins/appstore-review.md:114
+msgid ""
+"**Required Gradle dependency:** The Google Play In-App Review API is not "
+"part of the Android SDK. You must add it to your app's `build.gradle`:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:118
+msgid "'com.google.android.play:review:2.0.2'"
+msgstr ""
+
+#: src/plugins/appstore-review.md:122
+msgid ""
+"Without this dependency, `requestReview()` will resolve with an error "
+"explaining the missing library."
+msgstr ""
+
+#: src/plugins/appstore-review.md:124
+msgid "Other platforms"
+msgstr ""
+
+#: src/plugins/appstore-review.md:126
+msgid ""
+"On unsupported platforms (Linux, Windows, Web), `requestReview()` resolves "
+"immediately with an error. It will not throw — your app continues normally."
+msgstr ""
+
+#: src/plugins/appstore-review.md:128
+msgid "Best practices"
+msgstr ""
+
+#: src/plugins/appstore-review.md:130
+msgid ""
+"**Do ask at the right moment.** Prompt after a positive experience — "
+"completing a level, finishing a task, achieving a goal. Don't ask on first "
+"launch or during onboarding."
+msgstr ""
+
+#: src/plugins/appstore-review.md:132
+msgid ""
+"**Don't ask too often.** Even though iOS throttles automatically, Android "
+"does not have the same strict limits. Implement your own logic to track when"
+" you last asked:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:134
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"import { preferencesGet, preferencesSet } from \"perry/system\";\n"
+"\n"
+"async function maybeAskForReview() {\n"
+"  const lastAsked = Number(preferencesGet(\"lastReviewAsk\") || \"0\");\n"
+"  const now = Date.now();\n"
+"  const thirtyDays = 30 * 24 * 60 * 60 * 1000;\n"
+"\n"
+"  if (now - lastAsked > thirtyDays) {\n"
+"    preferencesSet(\"lastReviewAsk\", String(now));\n"
+"    await requestReview();\n"
+"  }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/appstore-review.md:150
+msgid ""
+"**Don't condition app behavior on the review.** Neither iOS nor Android "
+"tells you whether the user left a review, gave a rating, or dismissed the "
+"prompt. The promise resolving does not mean a review was submitted."
+msgstr ""
+
+#: src/plugins/appstore-review.md:152
+msgid ""
+"**Don't use custom review dialogs before the native one.** Both Apple and "
+"Google discourage showing your own \"Rate this app?\" dialog before the "
+"native prompt. The native prompt is designed to be low-friction — adding a "
+"pre-prompt increases abandonment."
+msgstr ""
+
+#: src/plugins/appstore-review.md:154
+msgid "Extension structure"
+msgstr ""
+
+#: src/plugins/appstore-review.md:156
+msgid ""
+"The extension follows the standard [native extension](native-extensions.md) "
+"layout:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:176
+msgid "One native function is declared in `package.json`:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:190
+msgid ""
+"The TypeScript layer wraps this into the public `requestReview()` function. "
+"The native layer creates a Perry promise, calls the platform API, and "
+"resolves the promise when done."
+msgstr ""
+
+#: src/plugins/appstore-review.md:194
+msgid ""
+"[Native Extensions](native-extensions.md) — How native extensions work, "
+"creating your own"
+msgstr ""
+
+#: src/plugins/appstore-review.md:195
+msgid "[iOS Platform](../platforms/ios.md) — iOS platform guide"
+msgstr ""
+
+#: src/plugins/appstore-review.md:196
+msgid "[Android Platform](../platforms/android.md) — Android platform guide"
+msgstr ""
+
+#: src/testing/geisterhand.md:1
+msgid "Geisterhand — In-Process UI Testing"
+msgstr ""
+
+#: src/testing/geisterhand.md:3
+msgid ""
+"Geisterhand (German for \"ghost hand\") embeds a lightweight HTTP server "
+"inside your Perry app that lets you interact with every widget "
+"programmatically. Click buttons, type into text fields, drag sliders, toggle"
+" switches, capture screenshots, and run chaos-mode random fuzzing — all via "
+"simple HTTP calls."
+msgstr ""
+
+#: src/testing/geisterhand.md:5
+msgid ""
+"It works on **all 5 native platforms** (macOS, iOS, Android, Linux/GTK4, "
+"Windows) with zero external dependencies. The server starts automatically "
+"when you compile with `--enable-geisterhand`."
+msgstr ""
+
+#: src/testing/geisterhand.md:12
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:14
+msgid "# 2. Run the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:16
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:18
+msgid "# 3. In another terminal — interact with the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:20
+msgid "# List all widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:21
+msgid "# Click button with handle 3\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:22
+msgid "# Capture window screenshot\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:25
+msgid "Custom Port"
+msgstr ""
+
+#: src/testing/geisterhand.md:27
+msgid ""
+"The default port is **7676**. Use `--geisterhand-port` to change it (this "
+"implies `--enable-geisterhand`, so you don't need both flags):"
+msgstr ""
+
+#: src/testing/geisterhand.md:30
+msgid "# or with perry run:\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:35
+msgid "With `perry run`"
+msgstr ""
+
+#: src/testing/geisterhand.md:47
+msgid ""
+"All endpoints return JSON unless noted otherwise. All responses include "
+"`Access-Control-Allow-Origin: *` for browser-based tools. OPTIONS requests "
+"are supported for CORS preflight."
+msgstr ""
+
+#: src/testing/geisterhand.md:49
+msgid "Health Check"
+msgstr ""
+
+#: src/testing/geisterhand.md:51
+msgid ""
+"```\n"
+"GET /health\n"
+"→ {\"status\":\"ok\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:56
+msgid "Use this to wait for the app to be ready before running tests."
+msgstr ""
+
+#: src/testing/geisterhand.md:58
+msgid "List Widgets"
+msgstr ""
+
+#: src/testing/geisterhand.md:64
+msgid "Returns a JSON array of all registered widgets:"
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"handle\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:458 src/testing/geisterhand.md:459
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"widget_type\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"callback_kind\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"label\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68
+msgid "\"Click Me\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+msgid "\"shortcut\""
+msgstr ""
+
+#: src/testing/geisterhand.md:69
+msgid "\"Type here...\""
+msgstr ""
+
+#: src/testing/geisterhand.md:71
+msgid "\"Enable\""
+msgstr ""
+
+#: src/testing/geisterhand.md:72
+msgid "\"Save\""
+msgstr ""
+
+#: src/testing/geisterhand.md:72
+msgid "\"s\""
+msgstr ""
+
+#: src/testing/geisterhand.md:77
+msgid "Supports query parameter filters:"
+msgstr ""
+
+#: src/testing/geisterhand.md:78
+msgid ""
+"`GET /widgets?label=Save` — filter by label substring (case-insensitive)"
+msgstr ""
+
+#: src/testing/geisterhand.md:79
+msgid "`GET /widgets?type=button` — filter by widget type name or code"
+msgstr ""
+
+#: src/testing/geisterhand.md:80
+msgid "`GET /widgets?label=Save&type=5` — combine filters"
+msgstr ""
+
+#: src/testing/geisterhand.md:82
+msgid "Widget Types"
+msgstr ""
+
+#: src/testing/geisterhand.md:84 src/testing/geisterhand.md:98
+msgid "Code"
+msgstr ""
+
+#: src/testing/geisterhand.md:86
+msgid "Push button with onClick"
+msgstr ""
+
+#: src/testing/geisterhand.md:87
+msgid "Text input field"
+msgstr ""
+
+#: src/testing/geisterhand.md:88
+msgid "Numeric slider"
+msgstr ""
+
+#: src/testing/geisterhand.md:89
+msgid "On/off switch"
+msgstr ""
+
+#: src/testing/geisterhand.md:90
+msgid "Dropdown selector"
+msgstr ""
+
+#: src/testing/geisterhand.md:91 src/testing/geisterhand.md:294
+msgid "Menu"
+msgstr ""
+
+#: src/testing/geisterhand.md:91
+msgid "Menu item"
+msgstr ""
+
+#: src/testing/geisterhand.md:92 src/cli/perry-toml.md:399
+msgid "6"
+msgstr ""
+
+#: src/testing/geisterhand.md:92
+msgid "Keyboard shortcut"
+msgstr ""
+
+#: src/testing/geisterhand.md:93
+msgid "Data table"
+msgstr ""
+
+#: src/testing/geisterhand.md:94
+msgid "8"
+msgstr ""
+
+#: src/testing/geisterhand.md:94
+msgid "Scrollable container"
+msgstr ""
+
+#: src/testing/geisterhand.md:96
+msgid "Callback Kinds"
+msgstr ""
+
+#: src/testing/geisterhand.md:98
+msgid "Kind"
+msgstr ""
+
+#: src/testing/geisterhand.md:100
+msgid "Triggered on click/tap"
+msgstr ""
+
+#: src/testing/geisterhand.md:101
+msgid "onChange"
+msgstr ""
+
+#: src/testing/geisterhand.md:101
+msgid "Triggered on value change"
+msgstr ""
+
+#: src/testing/geisterhand.md:102
+msgid "onSubmit"
+msgstr ""
+
+#: src/testing/geisterhand.md:102
+msgid "Triggered on submit (e.g., pressing Enter)"
+msgstr ""
+
+#: src/testing/geisterhand.md:103
+msgid "Triggered on mouse hover"
+msgstr ""
+
+#: src/testing/geisterhand.md:104
+msgid "Triggered on double-click"
+msgstr ""
+
+#: src/testing/geisterhand.md:105
+msgid "onFocus"
+msgstr ""
+
+#: src/testing/geisterhand.md:105
+msgid "Triggered on focus"
+msgstr ""
+
+#: src/testing/geisterhand.md:107
+msgid ""
+"A single widget may appear multiple times in the list with different "
+"callback kinds. For example, a button with both `onClick` and `onHover` "
+"handlers produces two entries (same handle, different `callback_kind`)."
+msgstr ""
+
+#: src/testing/geisterhand.md:109
+msgid "Click a Widget"
+msgstr ""
+
+#: src/testing/geisterhand.md:111
+msgid ""
+"```\n"
+"POST /click/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:116
+msgid ""
+"Fires the widget's `onClick` callback. Works with buttons, menu items, "
+"shortcuts, and table rows."
+msgstr ""
+
+#: src/testing/geisterhand.md:122
+msgid "Type into a TextField"
+msgstr ""
+
+#: src/testing/geisterhand.md:124
+msgid ""
+"```\n"
+"POST /type/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"text\": \"hello world\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:131
+msgid ""
+"Sets the text field's content and fires its `onChange` callback with the new"
+" text as a NaN-boxed string."
+msgstr ""
+
+#: src/testing/geisterhand.md:139
+msgid "Move a Slider"
+msgstr ""
+
+#: src/testing/geisterhand.md:141
+msgid ""
+"```\n"
+"POST /slide/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"value\": 0.75}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:148
+msgid "Sets the slider position and fires `onChange` with the numeric value."
+msgstr ""
+
+#: src/testing/geisterhand.md:156
+msgid "Toggle a Switch"
+msgstr ""
+
+#: src/testing/geisterhand.md:158
+msgid ""
+"```\n"
+"POST /toggle/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:163
+msgid "Fires the toggle's `onChange` callback with a boolean value."
+msgstr ""
+
+#: src/testing/geisterhand.md:169
+msgid "Set State Directly"
+msgstr ""
+
+#: src/testing/geisterhand.md:171
+msgid ""
+"```\n"
+"POST /state/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"value\": 42}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:178
+msgid ""
+"Directly sets a `State` cell's value, bypassing widget callbacks. This "
+"triggers any reactive bindings attached to the state (bound text labels, "
+"visibility, forEach loops, etc.)."
+msgstr ""
+
+#: src/testing/geisterhand.md:186
+msgid "Hover"
+msgstr ""
+
+#: src/testing/geisterhand.md:188
+msgid ""
+"```\n"
+"POST /hover/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:193
+msgid ""
+"Fires the widget's `onHover` callback. Useful for testing hover-dependent UI"
+" (tooltips, color changes, etc.)."
+msgstr ""
+
+#: src/testing/geisterhand.md:195
+msgid "Double-Click"
+msgstr ""
+
+#: src/testing/geisterhand.md:197
+msgid ""
+"```\n"
+"POST /doubleclick/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:202
+msgid "Fires the widget's `onDoubleClick` callback."
+msgstr ""
+
+#: src/testing/geisterhand.md:204
+msgid "Trigger Keyboard Shortcut"
+msgstr ""
+
+#: src/testing/geisterhand.md:206
+msgid ""
+"```\n"
+"POST /key\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"shortcut\": \"s\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:213
+msgid ""
+"Finds a registered menu item whose shortcut matches and fires its callback. "
+"Shortcut strings are case-insensitive and match the key string passed to "
+"`menuAddItem` (e.g., `\"s\"` for Cmd+S, `\"S\"` for Cmd+Shift+S, `\"n\"` for"
+" Cmd+N)."
+msgstr ""
+
+#: src/testing/geisterhand.md:221
+msgid ""
+"Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no "
+"match."
+msgstr ""
+
+#: src/testing/geisterhand.md:223
+msgid "Scroll a ScrollView"
+msgstr ""
+
+#: src/testing/geisterhand.md:225
+msgid ""
+"```\n"
+"POST /scroll/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"x\": 0, \"y\": 100}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:232
+msgid ""
+"Sets the scroll offset of a ScrollView widget. Both `x` and `y` are in "
+"points."
+msgstr ""
+
+#: src/testing/geisterhand.md:240
+msgid "Capture Screenshot"
+msgstr ""
+
+#: src/testing/geisterhand.md:247
+msgid ""
+"Captures the app window as a PNG image. The response is raw binary data, not"
+" JSON."
+msgstr ""
+
+#: src/testing/geisterhand.md:253
+msgid ""
+"Screenshot capture is synchronous from the caller's perspective — the HTTP "
+"request blocks until the main thread completes the capture (timeout: 5 "
+"seconds)."
+msgstr ""
+
+#: src/testing/geisterhand.md:255
+msgid "**Platform-specific capture methods:**"
+msgstr ""
+
+#: src/testing/geisterhand.md:259
+msgid "`CGWindowListCreateImage`"
+msgstr ""
+
+#: src/testing/geisterhand.md:259
+msgid "Retina resolution, reads from window ID"
+msgstr ""
+
+#: src/testing/geisterhand.md:260
+msgid "`UIGraphicsImageRenderer`"
+msgstr ""
+
+#: src/testing/geisterhand.md:260
+msgid "Draws view hierarchy into image context"
+msgstr ""
+
+#: src/testing/geisterhand.md:261
+msgid "JNI `View.draw()` on Canvas"
+msgstr ""
+
+#: src/testing/geisterhand.md:261
+msgid "Creates Bitmap, compresses to PNG"
+msgstr ""
+
+#: src/testing/geisterhand.md:262
+msgid "`WidgetPaintable` + `GskRenderer`"
+msgstr ""
+
+#: src/testing/geisterhand.md:262
+msgid "Renders to texture, saves as PNG bytes"
+msgstr ""
+
+#: src/testing/geisterhand.md:263
+msgid "`PrintWindow` + `GetDIBits`"
+msgstr ""
+
+#: src/testing/geisterhand.md:263
+msgid "Inline PNG encoder (stored zlib blocks)"
+msgstr ""
+
+#: src/testing/geisterhand.md:265
+msgid "Chaos Mode"
+msgstr ""
+
+#: src/testing/geisterhand.md:267
+msgid ""
+"Chaos mode randomly interacts with widgets at a configurable interval — "
+"useful for stress testing, finding edge cases, and crash hunting."
+msgstr ""
+
+#: src/testing/geisterhand.md:269
+msgid "Start"
+msgstr ""
+
+#: src/testing/geisterhand.md:271
+msgid ""
+"```\n"
+"POST /chaos/start\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"interval_ms\": 200}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:279
+msgid "# Fire random inputs every 200ms\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:285
+msgid ""
+"If `interval_ms` is omitted, a default interval is used. The chaos thread "
+"randomly selects a registered widget and fires an appropriate input based on"
+" widget type:"
+msgstr ""
+
+#: src/testing/geisterhand.md:287
+msgid "Widget Type"
+msgstr ""
+
+#: src/testing/geisterhand.md:287
+msgid "Random Input"
+msgstr ""
+
+#: src/testing/geisterhand.md:289 src/testing/geisterhand.md:294
+#: src/testing/geisterhand.md:295 src/testing/geisterhand.md:296
+msgid "Fires onClick (no args)"
+msgstr ""
+
+#: src/testing/geisterhand.md:290
+msgid "Random alphanumeric string, 5-20 characters"
+msgstr ""
+
+#: src/testing/geisterhand.md:291
+msgid "Random float between 0.0 and 1.0"
+msgstr ""
+
+#: src/testing/geisterhand.md:292
+msgid "Random true/false"
+msgstr ""
+
+#: src/testing/geisterhand.md:293
+msgid "Random index 0-9"
+msgstr ""
+
+#: src/testing/geisterhand.md:300
+msgid ""
+"```\n"
+"GET /chaos/status\n"
+"→ {\"running\":true,\"events_fired\":247,\"uptime_secs\":12}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:305
+msgid ""
+"Returns whether chaos mode is active, how many random events have been "
+"fired, and uptime in seconds."
+msgstr ""
+
+#: src/testing/geisterhand.md:307
+msgid "Stop"
+msgstr ""
+
+#: src/testing/geisterhand.md:309
+msgid ""
+"```\n"
+"POST /chaos/stop\n"
+"→ {\"ok\":true,\"chaos\":\"stopped\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:314
+msgid "Error Responses"
+msgstr ""
+
+#: src/testing/geisterhand.md:316
+msgid ""
+"All endpoints return errors as JSON with an appropriate HTTP status code:"
+msgstr ""
+
+#: src/testing/geisterhand.md:319
+msgid "\"widget handle 99 not found\""
+msgstr ""
+
+#: src/testing/geisterhand.md:322
+msgid "Common errors:"
+msgstr ""
+
+#: src/testing/geisterhand.md:323
+msgid "`404` — widget handle not found"
+msgstr ""
+
+#: src/testing/geisterhand.md:324
+msgid "`400` — malformed JSON body or missing required field"
+msgstr ""
+
+#: src/testing/geisterhand.md:325
+msgid "`405` — unsupported HTTP method"
+msgstr ""
+
+#: src/testing/geisterhand.md:329
+msgid "Platform Setup"
+msgstr ""
+
+#: src/testing/geisterhand.md:333
+msgid ""
+"No extra setup needed. The server binds to `0.0.0.0:7676` and is accessible "
+"on `localhost`."
+msgstr ""
+
+#: src/testing/geisterhand.md:343
+msgid ""
+"The iOS Simulator shares the host's network stack — access the server "
+"directly on `localhost`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:352 src/cli/flags.md:24
+msgid "iOS Device"
+msgstr ""
+
+#: src/testing/geisterhand.md:354
+msgid ""
+"For physical iOS devices, you need a network route to the device (same Wi-Fi"
+" network) or use `iproxy` from `libimobiledevice`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:357
+msgid "# Install and launch via Xcode/devicectl\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:359
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:363
+msgid "Android (Emulator or Device)"
+msgstr ""
+
+#: src/testing/geisterhand.md:365
+msgid ""
+"Use `adb forward` to bridge the port. Ensure `INTERNET` permission is in "
+"your manifest (or add it to `perry.toml`):"
+msgstr ""
+
+#: src/testing/geisterhand.md:367
+msgid ""
+"```toml\n"
+"[android]\n"
+"permissions = [\"INTERNET\"]\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:373
+msgid "# Package into APK and install\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:381
+msgid "Install GTK4 development libraries first:"
+msgstr ""
+
+#: src/testing/geisterhand.md:402
+msgid "Test Automation"
+msgstr ""
+
+#: src/testing/geisterhand.md:404
+msgid ""
+"Geisterhand turns your Perry app into a testable HTTP service. Here are "
+"practical patterns for automated testing."
+msgstr ""
+
+#: src/testing/geisterhand.md:406
+msgid "Shell Script Tests"
+msgstr ""
+
+#: src/testing/geisterhand.md:408
+msgid "A simple end-to-end test using bash:"
+msgstr ""
+
+#: src/testing/geisterhand.md:411
+msgid "#!/bin/bash\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:413
+msgid "# Build with geisterhand\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:416
+msgid "# Start the app in background\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:419
+msgid "$!"
+msgstr ""
+
+#: src/testing/geisterhand.md:420
+msgid "\"kill $APP_PID 2>/dev/null\""
+msgstr ""
+
+#: src/testing/geisterhand.md:421
+msgid "# Wait for the app to be ready\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:427
+msgid "# Get widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:430
+msgid "\"Registered widgets: $WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:431
+msgid "# Find the button labeled \"Submit\"\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
+msgstr ""
+
+#: src/testing/geisterhand.md:434
+msgid "# Click it\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:436
+msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
+msgstr ""
+
+#: src/testing/geisterhand.md:437
+msgid "# Take a screenshot after interaction\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:441
+msgid "\"Test passed\""
+msgstr ""
+
+#: src/testing/geisterhand.md:444
+msgid "Python Test Example"
+msgstr ""
+
+#: src/testing/geisterhand.md:448
+msgid "# Start the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:450
+msgid "\"./testapp\""
+msgstr ""
+
+#: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
+msgid "# Wait for startup\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:454
+msgid "# List widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:455
+msgid "\"http://127.0.0.1:7676/widgets\""
+msgstr ""
+
+#: src/testing/geisterhand.md:457
+msgid "# Find widgets by label\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:461
+msgid "# Type into the first text field\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:464
+msgid "\"http://127.0.0.1:7676/type/"
+msgstr ""
+
+#: src/testing/geisterhand.md:464 src/testing/geisterhand.md:470
+msgid "'handle'"
+msgstr ""
+
+#: src/testing/geisterhand.md:464 src/testing/geisterhand.md:470
+msgid "\""
+msgstr ""
+
+#: src/testing/geisterhand.md:465
+msgid "\"test@example.com\""
+msgstr ""
+
+#: src/testing/geisterhand.md:468
+msgid "# Click the first button\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:470
+msgid "\"http://127.0.0.1:7676/click/"
+msgstr ""
+
+#: src/testing/geisterhand.md:472
+msgid "# Capture screenshot for visual regression\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:473
+msgid "\"http://127.0.0.1:7676/screenshot\""
+msgstr ""
+
+#: src/testing/geisterhand.md:474
+msgid "\"test-result.png\""
+msgstr ""
+
+#: src/testing/geisterhand.md:474
+msgid "\"wb\""
+msgstr ""
+
+#: src/testing/geisterhand.md:477
+msgid "# Assert the app is still healthy\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"http://127.0.0.1:7676/health\""
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"status\""
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"ok\""
+msgstr ""
+
+#: src/testing/geisterhand.md:479
+msgid "\"All tests passed\""
+msgstr ""
+
+#: src/testing/geisterhand.md:484
+msgid "Stress Testing with Chaos Mode"
+msgstr ""
+
+#: src/testing/geisterhand.md:486
+msgid ""
+"Run chaos mode against your app to find crashes, freezes, or unexpected "
+"state:"
+msgstr ""
+
+#: src/testing/geisterhand.md:489
+msgid "# Build and launch\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:495
+msgid "# Start aggressive chaos (every 50ms)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:518
+msgid "Visual Regression Testing"
+msgstr ""
+
+#: src/testing/geisterhand.md:520
+msgid ""
+"Capture screenshots at key interaction points and compare against baselines:"
+msgstr ""
+
+#: src/testing/geisterhand.md:523
+msgid "# Initial state\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:525
+msgid "# Interact\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:528
+msgid "'{\"text\":\"Hello\"}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:529
+msgid "# Capture after interaction\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:532
+msgid "# Compare (using ImageMagick)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:537
+msgid "CI Pipeline Integration"
+msgstr ""
+
+#: src/testing/geisterhand.md:540
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr ""
+
+#: src/testing/geisterhand.md:542
+msgid "ui-test"
+msgstr ""
+
+#: src/testing/geisterhand.md:543
+msgid "runs-on"
+msgstr ""
+
+#: src/testing/geisterhand.md:543
+msgid "macos-latest"
+msgstr ""
+
+#: src/testing/geisterhand.md:544 src/cli/perry-toml.md:602
+msgid "steps"
+msgstr ""
+
+#: src/testing/geisterhand.md:545
+msgid "uses"
+msgstr ""
+
+#: src/testing/geisterhand.md:545
+msgid "actions/checkout@v4"
+msgstr ""
+
+#: src/testing/geisterhand.md:547 src/testing/geisterhand.md:550
+msgid "name"
+msgstr ""
+
+#: src/testing/geisterhand.md:547
+msgid "Build with geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:548 src/testing/geisterhand.md:551
+#: src/cli/commands.md:48 src/cli/perry-toml.md:604 src/cli/perry-toml.md:605
+#: src/cli/perry-toml.md:606
+msgid "run"
+msgstr ""
+
+#: src/testing/geisterhand.md:548
+msgid "perry app.ts -o testapp --enable-geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:550
+msgid "Run UI tests"
+msgstr ""
+
+#: src/testing/geisterhand.md:554
+msgid "# Run your test script\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:568
+msgid "Example App"
+msgstr ""
+
+#: src/testing/geisterhand.md:570
+msgid ""
+"A complete Perry UI app demonstrating every widget type Geisterhand can "
+"interact with — verified by CI:"
+msgstr ""
+
+#: src/testing/geisterhand.md:573
+msgid ""
+"```typescript\n"
+"// demonstrates: Geisterhand-targetable Perry UI app — every common widget\n"
+"// docs: docs/src/testing/geisterhand.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"// A complete Perry UI app exercising every widget type Geisterhand\n"
+"// (the UI fuzzer) can interact with. The doc-tests harness compiles\n"
+"// and runs this on every PR, so the snippet on the docs page can never\n"
+"// drift from the real perry/ui API.\n"
+"\n"
+"import {\n"
+"    App, VStack, HStack,\n"
+"    Text, Button, TextField, Slider, Toggle, Picker,\n"
+"    State, stateOnChange,\n"
+"    pickerAddItem,\n"
+"    textSetString,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// State for reactive UI\n"
+"const counterState = State(0)\n"
+"const textState = State(\"\")\n"
+"\n"
+"// Labels\n"
+"const title = Text(\"Geisterhand Demo\")\n"
+"const counterLabel = Text(\"Count: 0\")\n"
+"\n"
+"// Bind counter state to label via the free-function listener\n"
+"stateOnChange(counterState, (val: number) => {\n"
+"    textSetString(counterLabel, `Count: ${val}`)\n"
+"})\n"
+"\n"
+"// Button — widget_type = 0\n"
+"const incrementBtn = Button(\"Increment\", () => {\n"
+"    counterState.set(counterState.value + 1)\n"
+"})\n"
+"const resetBtn = Button(\"Reset\", () => {\n"
+"    counterState.set(0)\n"
+"})\n"
+"\n"
+"// TextField(placeholder, onChange) — widget_type = 1\n"
+"const nameField = TextField(\"Enter your name\", (text: string) => {\n"
+"    textState.set(text)\n"
+"    console.log(`Name: ${text}`)\n"
+"})\n"
+"\n"
+"// Slider(min, max, onChange) — widget_type = 2\n"
+"const volumeSlider = Slider(0, 100, (value: number) => {\n"
+"    console.log(`Volume: ${value}`)\n"
+"})\n"
+"\n"
+"// Toggle(label, onChange) — widget_type = 3\n"
+"const darkModeToggle = Toggle(\"Dark Mode\", (on: boolean) => {\n"
+"    console.log(`Dark mode: ${on}`)\n"
+"})\n"
+"\n"
+"// Picker(onChange); items added with pickerAddItem.\n"
+"const sizePicker = Picker((index: number) => {\n"
+"    console.log(`Size index: ${index}`)\n"
+"})\n"
+"pickerAddItem(sizePicker, \"Small\")\n"
+"pickerAddItem(sizePicker, \"Medium\")\n"
+"pickerAddItem(sizePicker, \"Large\")\n"
+"\n"
+"// Layout\n"
+"const buttonRow = HStack(8, [incrementBtn, resetBtn])\n"
+"const stack = VStack(12, [\n"
+"    title, counterLabel, buttonRow,\n"
+"    nameField, volumeSlider, darkModeToggle, sizePicker,\n"
+"])\n"
+"\n"
+"App({\n"
+"    title: \"Geisterhand Demo\",\n"
+"    width: 400,\n"
+"    height: 480,\n"
+"    body: stack,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:651
+msgid "After compiling with `--enable-geisterhand` and running:"
+msgstr ""
+
+#: src/testing/geisterhand.md:654
+msgid "# See all interactive widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:655
+msgid "# [\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:657
+msgid "\"Increment\""
+msgstr ""
+
+#: src/testing/geisterhand.md:657
+msgid "#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:659
+msgid "\"Enter your name\""
+msgstr ""
+
+#: src/testing/geisterhand.md:659
+msgid "#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:661
+msgid "\"Dark Mode\""
+msgstr ""
+
+#: src/testing/geisterhand.md:661
+msgid "# ]\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:663
+msgid "# Click Increment 3 times\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:665
+msgid "# Counter label now shows \"Count: 3\"\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:667
+msgid "# Type a name\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:669
+msgid "'{\"text\":\"Perry\"}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:670
+msgid "# Set slider to 80%\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:672
+msgid "'{\"value\":0.8}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:673
+msgid "# Toggle dark mode on\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:676
+msgid "# Screenshot\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:685
+msgid ""
+"Geisterhand operates as three cooperating components connected by thread-"
+"safe queues:"
+msgstr ""
+
+#: src/testing/geisterhand.md:729
+msgid "Lifecycle"
+msgstr ""
+
+#: src/testing/geisterhand.md:731
+msgid ""
+"**Startup**: When `--enable-geisterhand` is used, the compiled binary calls "
+"`perry_geisterhand_start(port)` during initialization. This spawns a "
+"background thread running a `tiny-http` server."
+msgstr ""
+
+#: src/testing/geisterhand.md:733
+msgid ""
+"**Widget Registration**: As UI widgets are created (Button, TextField, "
+"Slider, etc.), each one calls `perry_geisterhand_register(handle, "
+"widget_type, callback_kind, closure_f64, label)` to register its callback in"
+" the global registry. This is gated behind `#[cfg(feature = "
+"\"geisterhand\")]` so normal builds have zero overhead."
+msgstr ""
+
+#: src/testing/geisterhand.md:735
+msgid ""
+"**HTTP Requests**: When a request arrives (e.g., `POST /click/3`), the "
+"server looks up handle 3 in the registry, finds the associated closure, and "
+"pushes a `PendingAction::InvokeCallback` onto the pending actions queue."
+msgstr ""
+
+#: src/testing/geisterhand.md:737
+msgid ""
+"**Main-Thread Dispatch**: The platform's timer (NSTimer on macOS, glib "
+"timeout on GTK4, WM_TIMER on Windows, etc.) calls `perry_geisterhand_pump()`"
+" every ~8ms. This drains the pending actions queue and executes callbacks on"
+" the main thread, which is required for UI safety."
+msgstr ""
+
+#: src/testing/geisterhand.md:739
+msgid ""
+"**Screenshot Capture**: Screenshots use `Condvar` synchronization — the HTTP"
+" thread queues a `CaptureScreenshot` action, then blocks waiting on a "
+"condition variable. The main thread's pump executes the platform-specific "
+"capture, stores the PNG data, and signals the condvar. Timeout: 5 seconds."
+msgstr ""
+
+#: src/testing/geisterhand.md:741
+msgid "Thread Safety"
+msgstr ""
+
+#: src/testing/geisterhand.md:743
+msgid ""
+"**Widget Registry**: Protected by `Mutex`. Read by the HTTP server (to list "
+"widgets and look up handles), written by the main thread (during widget "
+"creation)."
+msgstr ""
+
+#: src/testing/geisterhand.md:744
+msgid ""
+"**Pending Actions Queue**: Protected by `Mutex`. Written by HTTP server "
+"thread, drained by main thread in `pump()`."
+msgstr ""
+
+#: src/testing/geisterhand.md:745
+msgid ""
+"**Screenshot Result**: Protected by `Mutex` + `Condvar`. HTTP thread waits, "
+"main thread signals."
+msgstr ""
+
+#: src/testing/geisterhand.md:746
+msgid ""
+"**Chaos Mode State**: Uses `AtomicBool` (running flag) and `AtomicU64` "
+"(event counter) for lock-free status checks."
+msgstr ""
+
+#: src/testing/geisterhand.md:748
+msgid "NaN-Boxing Bridge"
+msgstr ""
+
+#: src/testing/geisterhand.md:750
+msgid ""
+"When geisterhand needs to pass values to widget callbacks, it must create "
+"properly NaN-boxed values:"
+msgstr ""
+
+#: src/testing/geisterhand.md:752
+msgid ""
+"**Strings** (for TextField): Calls `js_string_from_bytes(ptr, len)` to "
+"allocate a runtime string, then `js_nanbox_string(ptr)` to wrap it with "
+"STRING_TAG (0x7FFF)."
+msgstr ""
+
+#: src/testing/geisterhand.md:753
+msgid ""
+"**Numbers** (for Slider): Passes the raw `f64` value directly (numbers are "
+"their own NaN-boxed representation)."
+msgstr ""
+
+#: src/testing/geisterhand.md:754
+msgid ""
+"**Booleans** (for Toggle/chaos): Uses `TAG_TRUE` (0x7FFC000000000004) or "
+"`TAG_FALSE` (0x7FFC000000000003)."
+msgstr ""
+
+#: src/testing/geisterhand.md:758
+msgid "Build Details"
+msgstr ""
+
+#: src/testing/geisterhand.md:760
+msgid "Auto-Build"
+msgstr ""
+
+#: src/testing/geisterhand.md:762
+msgid ""
+"When you pass `--enable-geisterhand` (or `--geisterhand-port`), Perry "
+"automatically builds the required libraries on first use if they're not "
+"already cached:"
+msgstr ""
+
+#: src/testing/geisterhand.md:771
+msgid "Platform crate selection is automatic based on `--target`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:773 src/cli/flags.md:20
+msgid "Target"
+msgstr ""
+
+#: src/testing/geisterhand.md:773
+msgid "UI Crate"
+msgstr ""
+
+#: src/testing/geisterhand.md:775
+msgid "(default/macOS)"
+msgstr ""
+
+#: src/testing/geisterhand.md:775 src/contributing/architecture.md:37
+msgid "`perry-ui-macos`"
+msgstr ""
+
+#: src/testing/geisterhand.md:776
+msgid "`ios` / `ios-simulator`"
+msgstr ""
+
+#: src/testing/geisterhand.md:776 src/contributing/architecture.md:38
+msgid "`perry-ui-ios`"
+msgstr ""
+
+#: src/testing/geisterhand.md:777 src/cli/commands.md:66
+#: src/cli/commands.md:238 src/cli/flags.md:27
+msgid "`android`"
+msgstr ""
+
+#: src/testing/geisterhand.md:777
+msgid "`perry-ui-android`"
+msgstr ""
+
+#: src/testing/geisterhand.md:778 src/cli/commands.md:239 src/cli/flags.md:37
+msgid "`linux`"
+msgstr ""
+
+#: src/testing/geisterhand.md:778
+msgid "`perry-ui-gtk4`"
+msgstr ""
+
+#: src/testing/geisterhand.md:779 src/cli/flags.md:36
+msgid "`windows`"
+msgstr ""
+
+#: src/testing/geisterhand.md:779
+msgid "`perry-ui-windows`"
+msgstr ""
+
+#: src/testing/geisterhand.md:781
+msgid "Separate Target Directory"
+msgstr ""
+
+#: src/testing/geisterhand.md:783
+msgid ""
+"Geisterhand libraries are built into `target/geisterhand/` (via "
+"`CARGO_TARGET_DIR`) to avoid interfering with normal builds. This means your"
+" first geisterhand build takes a moment, but subsequent builds reuse the "
+"cached libraries."
+msgstr ""
+
+#: src/testing/geisterhand.md:785
+msgid "Feature Flags"
+msgstr ""
+
+#: src/testing/geisterhand.md:787
+msgid ""
+"All geisterhand code is behind `#[cfg(feature = \"geisterhand\")]` feature "
+"gates:"
+msgstr ""
+
+#: src/testing/geisterhand.md:789
+msgid ""
+"**`perry-runtime/geisterhand`**: Compiles the `geisterhand_registry` module "
+"— widget registry, action queue, pump function, screenshot coordination."
+msgstr ""
+
+#: src/testing/geisterhand.md:790
+msgid ""
+"**`perry-ui-{platform}/geisterhand`**: Adds `perry_geisterhand_register()` "
+"calls to widget constructors and `perry_geisterhand_pump()` to the platform "
+"timer."
+msgstr ""
+
+#: src/testing/geisterhand.md:792
+msgid ""
+"When the feature is not enabled, no geisterhand code is compiled — zero "
+"binary size overhead and zero runtime cost."
+msgstr ""
+
+#: src/testing/geisterhand.md:794
+msgid "Linking"
+msgstr ""
+
+#: src/testing/geisterhand.md:796
+msgid "The compiled binary links three additional static libraries:"
+msgstr ""
+
+#: src/testing/geisterhand.md:797
+msgid ""
+"`libperry_runtime.a` (geisterhand-featured build, replaces the normal "
+"runtime)"
+msgstr ""
+
+#: src/testing/geisterhand.md:798
+msgid ""
+"`libperry_ui_{platform}.a` (geisterhand-featured build, replaces the normal "
+"UI lib)"
+msgstr ""
+
+#: src/testing/geisterhand.md:799
+msgid "`libperry_ui_geisterhand.a` (HTTP server + chaos mode)"
+msgstr ""
+
+#: src/testing/geisterhand.md:801
+msgid "Manual Build"
+msgstr ""
+
+#: src/testing/geisterhand.md:803
+msgid "If auto-build fails or you want to cross-compile manually:"
+msgstr ""
+
+#: src/testing/geisterhand.md:806
+msgid "# Build geisterhand libs for macOS\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:807
+msgid "target/geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:822
+msgid "Security"
+msgstr ""
+
+#: src/testing/geisterhand.md:824
+msgid ""
+"Geisterhand binds to `0.0.0.0` on the configured port (default 7676). This "
+"means it is **accessible from the local network** — any device on the same "
+"network can interact with your app, capture screenshots, or trigger chaos "
+"mode."
+msgstr ""
+
+#: src/testing/geisterhand.md:826
+msgid ""
+"**Do not ship geisterhand-enabled binaries to production or to end users.**"
+msgstr ""
+
+#: src/testing/geisterhand.md:828
+msgid ""
+"Geisterhand is a development and testing tool only. The feature-gate system "
+"ensures it cannot accidentally be included in normal builds — you must "
+"explicitly pass `--enable-geisterhand` or `--geisterhand-port`."
+msgstr ""
+
+#: src/testing/geisterhand.md:832
+msgid "Troubleshooting"
+msgstr ""
+
+#: src/testing/geisterhand.md:834
+msgid "\"Connection refused\" on port 7676"
+msgstr ""
+
+#: src/testing/geisterhand.md:836
+msgid ""
+"Ensure you compiled with `--enable-geisterhand` or `--geisterhand-port`"
+msgstr ""
+
+#: src/testing/geisterhand.md:837
+msgid ""
+"Check that the app has fully started (look for `[geisterhand] listening "
+"on...` in stderr)"
+msgstr ""
+
+#: src/testing/geisterhand.md:838
+msgid "Verify the port isn't in use by another process: `lsof -i :7676`"
+msgstr ""
+
+#: src/testing/geisterhand.md:840
+msgid "Widget handles not found"
+msgstr ""
+
+#: src/testing/geisterhand.md:842
+msgid ""
+"Handles are assigned at widget creation time. If you query `/widgets` before"
+" the UI is fully constructed, some widgets may not be registered yet."
+msgstr ""
+
+#: src/testing/geisterhand.md:843
+msgid "Wait for `GET /health` to return `{\"status\":\"ok\"}` before interacting."
+msgstr ""
+
+#: src/testing/geisterhand.md:845
+msgid "Screenshot returns empty data"
+msgstr ""
+
+#: src/testing/geisterhand.md:847
+msgid ""
+"Screenshot capture has a 5-second timeout. If the main thread is blocked "
+"(e.g., by a long-running synchronous operation), the screenshot will time "
+"out and return empty data."
+msgstr ""
+
+#: src/testing/geisterhand.md:848
+msgid ""
+"On macOS, ensure the app has a visible window (minimized windows may not "
+"capture correctly)."
+msgstr ""
+
+#: src/testing/geisterhand.md:850
+msgid "Auto-build fails"
+msgstr ""
+
+#: src/testing/geisterhand.md:852
+msgid "Ensure you have a working Rust toolchain (`rustup show`)"
+msgstr ""
+
+#: src/testing/geisterhand.md:853
+msgid ""
+"For cross-compilation targets, install the appropriate target: `rustup "
+"target add aarch64-apple-ios`"
+msgstr ""
+
+#: src/testing/geisterhand.md:854
+msgid ""
+"Check that the Perry source tree is accessible (auto-build searches upward "
+"from the `perry` executable for the workspace root)"
+msgstr ""
+
+#: src/testing/geisterhand.md:856
+msgid "Chaos mode crashes the app"
+msgstr ""
+
+#: src/testing/geisterhand.md:858
+msgid ""
+"That's the point — chaos mode found a bug. Check the app's stderr output for"
+" panic messages or stack traces. Common causes:"
+msgstr ""
+
+#: src/testing/geisterhand.md:859
+msgid ""
+"Callback handlers that assume valid state but receive unexpected values"
+msgstr ""
+
+#: src/testing/geisterhand.md:860
+msgid "Missing null checks on state values"
+msgstr ""
+
+#: src/testing/geisterhand.md:861
+msgid "Race conditions in state updates"
+msgstr ""
+
+#: src/cli/commands.md:1
+msgid "CLI Commands"
+msgstr ""
+
+#: src/cli/commands.md:3
+msgid ""
+"Perry provides 11 commands for compiling, checking, running, publishing, and"
+" managing your projects."
+msgstr ""
+
+#: src/cli/commands.md:5
+msgid ""
+"See also: [perry.toml Reference](perry-toml.md) for project configuration."
+msgstr ""
+
+#: src/cli/commands.md:7
+msgid "compile"
+msgstr ""
+
+#: src/cli/commands.md:9
+msgid "Compile TypeScript to a native executable."
+msgstr ""
+
+#: src/cli/commands.md:12
+msgid "# Or shorthand (auto-detects compile):\n"
+msgstr ""
+
+#: src/cli/commands.md:17 src/cli/commands.md:109 src/cli/commands.md:148
+#: src/cli/commands.md:181 src/cli/commands.md:195 src/cli/commands.md:248
+#: src/cli/commands.md:260 src/cli/flags.md:9 src/cli/flags.md:50
+#: src/cli/flags.md:58 src/cli/flags.md:66 src/cli/flags.md:73
+msgid "Flag"
+msgstr ""
+
+#: src/cli/commands.md:19 src/cli/commands.md:111 src/cli/commands.md:243
+msgid "`-o, --output <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:19
+msgid "Output file path"
+msgstr ""
+
+#: src/cli/commands.md:20
+msgid "`--target <TARGET>`"
+msgstr ""
+
+#: src/cli/commands.md:20
+msgid "Platform target (see [Compiler Flags](flags.md))"
+msgstr ""
+
+#: src/cli/commands.md:21
+msgid "`--output-type <TYPE>`"
+msgstr ""
+
+#: src/cli/commands.md:21
+msgid "`executable` (default) or `dylib` (plugin)"
+msgstr ""
+
+#: src/cli/commands.md:22 src/cli/flags.md:52
+msgid "`--print-hir`"
+msgstr ""
+
+#: src/cli/commands.md:22
+msgid "Print HIR intermediate representation"
+msgstr ""
+
+#: src/cli/commands.md:23 src/cli/flags.md:53
+msgid "`--no-link`"
+msgstr ""
+
+#: src/cli/commands.md:23
+msgid "Produce object file only, skip linking"
+msgstr ""
+
+#: src/cli/commands.md:24 src/cli/flags.md:54
+msgid "`--keep-intermediates`"
+msgstr ""
+
+#: src/cli/commands.md:24
+msgid "Keep `.o` and `.asm` files"
+msgstr ""
+
+#: src/cli/commands.md:25 src/cli/commands.md:71 src/cli/flags.md:75
+msgid "`--enable-js-runtime`"
+msgstr ""
+
+#: src/cli/commands.md:25
+msgid "Enable V8 JavaScript runtime fallback"
+msgstr ""
+
+#: src/cli/commands.md:26 src/cli/commands.md:72 src/cli/flags.md:76
+msgid "`--type-check`"
+msgstr ""
+
+#: src/cli/commands.md:26 src/cli/commands.md:72
+msgid "Enable type checking via tsgo"
+msgstr ""
+
+#: src/cli/commands.md:27 src/cli/flags.md:60
+msgid "`--minify`"
+msgstr ""
+
+#: src/cli/commands.md:27 src/cli/flags.md:60
+msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
+msgstr ""
+
+#: src/cli/commands.md:28
+msgid "`--app-bundle-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:28
+msgid "Bundle ID (required for widget targets)"
+msgstr ""
+
+#: src/cli/commands.md:29
+msgid "`--bundle-extensions <DIR>`"
+msgstr ""
+
+#: src/cli/commands.md:29
+msgid "Bundle TypeScript extensions from directory"
+msgstr ""
+
+#: src/cli/commands.md:32
+msgid "# Basic compilation\n"
+msgstr ""
+
+#: src/cli/commands.md:34
+msgid "# Cross-compile for iOS Simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:37
+msgid "# Build a plugin\n"
+msgstr ""
+
+#: src/cli/commands.md:40
+msgid "# Debug: view intermediate representation\n"
+msgstr ""
+
+#: src/cli/commands.md:43
+msgid "# Build an iOS widget\n"
+msgstr ""
+
+#: src/cli/commands.md:50
+msgid "Compile and launch your app in one step."
+msgstr ""
+
+#: src/cli/commands.md:53
+msgid "# Auto-detect entry file\n"
+msgstr ""
+
+#: src/cli/commands.md:54
+msgid "# Run on iOS device/simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:55
+msgid "# Run on Apple Vision Pro simulator/device\n"
+msgstr ""
+
+#: src/cli/commands.md:56
+msgid "# Run on Android device\n"
+msgstr ""
+
+#: src/cli/commands.md:57
+msgid "# Forward args to your program\n"
+msgstr ""
+
+#: src/cli/commands.md:60 src/cli/commands.md:233
+msgid "Argument / Flag"
+msgstr ""
+
+#: src/cli/commands.md:62 src/cli/commands.md:236 src/cli/flags.md:24
+msgid "`ios`"
+msgstr ""
+
+#: src/cli/commands.md:62
+msgid "Target iOS (device or simulator)"
+msgstr ""
+
+#: src/cli/commands.md:63 src/cli/commands.md:237 src/cli/flags.md:26
+msgid "`visionos`"
+msgstr ""
+
+#: src/cli/commands.md:63
+msgid "Target visionOS (device or simulator)"
+msgstr ""
+
+#: src/cli/commands.md:64 src/cli/commands.md:235
+msgid "`macos`"
+msgstr ""
+
+#: src/cli/commands.md:64
+msgid "Target macOS (default on macOS host)"
+msgstr ""
+
+#: src/cli/commands.md:65 src/cli/flags.md:35
+msgid "`web`"
+msgstr ""
+
+#: src/cli/commands.md:65
+msgid "Target web (opens in browser)"
+msgstr ""
+
+#: src/cli/commands.md:66
+msgid "Target Android device"
+msgstr ""
+
+#: src/cli/commands.md:67
+msgid "`--simulator <UDID>`"
+msgstr ""
+
+#: src/cli/commands.md:67
+msgid "Specify iOS simulator by UDID"
+msgstr ""
+
+#: src/cli/commands.md:68
+msgid "`--device <UDID>`"
+msgstr ""
+
+#: src/cli/commands.md:68
+msgid "Specify iOS physical device by UDID"
+msgstr ""
+
+#: src/cli/commands.md:69
+msgid "`--local`"
+msgstr ""
+
+#: src/cli/commands.md:69
+msgid "Force local compilation (no remote fallback)"
+msgstr ""
+
+#: src/cli/commands.md:70
+msgid "`--remote`"
+msgstr ""
+
+#: src/cli/commands.md:70
+msgid "Force remote build via Perry Hub"
+msgstr ""
+
+#: src/cli/commands.md:71
+msgid "Enable V8 JavaScript runtime"
+msgstr ""
+
+#: src/cli/commands.md:73 src/cli/commands.md:113
+msgid "`--`"
+msgstr ""
+
+#: src/cli/commands.md:73
+msgid "Separator for program arguments"
+msgstr ""
+
+#: src/cli/commands.md:75
+msgid "**Entry file detection** (checked in order):"
+msgstr ""
+
+#: src/cli/commands.md:76
+msgid "`perry.toml` → `[project] entry` field"
+msgstr ""
+
+#: src/cli/commands.md:77
+msgid "`src/main.ts`"
+msgstr ""
+
+#: src/cli/commands.md:78
+msgid "`main.ts`"
+msgstr ""
+
+#: src/cli/commands.md:80
+msgid ""
+"**Device detection**: When targeting iOS, Perry auto-discovers available "
+"simulators (via `simctl`) and physical devices (via `devicectl`). For "
+"Android, it uses `adb`. When multiple targets are found, an interactive "
+"prompt lets you choose."
+msgstr ""
+
+#: src/cli/commands.md:82
+msgid ""
+"**Remote build fallback**: If cross-compilation toolchains aren't installed "
+"locally (e.g., Apple mobile targets on a machine without Xcode), `perry run "
+"ios` and `perry run visionos` can fall back to Perry Hub's build server when"
+" the backend supports the target. Use `--local` or `--remote` to force "
+"either path."
+msgstr ""
+
+#: src/cli/commands.md:85
+msgid "# Run a CLI program\n"
+msgstr ""
+
+#: src/cli/commands.md:87
+msgid "# Run on a specific simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:90
+msgid "# Force remote build\n"
+msgstr ""
+
+#: src/cli/commands.md:93
+msgid "# Run web target\n"
+msgstr ""
+
+#: src/cli/commands.md:98
+msgid "dev"
+msgstr ""
+
+#: src/cli/commands.md:100
+msgid ""
+"Watch your TypeScript source tree and auto-recompile + relaunch on every "
+"save."
+msgstr ""
+
+#: src/cli/commands.md:103
+msgid "# watch + rebuild + relaunch on save\n"
+msgstr ""
+
+#: src/cli/commands.md:104
+msgid "# forward args to the child\n"
+msgstr ""
+
+#: src/cli/commands.md:105
+msgid "# watch an extra directory\n"
+msgstr ""
+
+#: src/cli/commands.md:106
+msgid "# override output path\n"
+msgstr ""
+
+#: src/cli/commands.md:111
+msgid "Output binary path (default: `.perry-dev/<entry-stem>`)"
+msgstr ""
+
+#: src/cli/commands.md:112
+msgid "`--watch <DIR>`"
+msgstr ""
+
+#: src/cli/commands.md:112
+msgid "Extra directories to watch (comma-separated or repeated)"
+msgstr ""
+
+#: src/cli/commands.md:113
+msgid "Separator — everything after is forwarded to the compiled binary"
+msgstr ""
+
+#: src/cli/commands.md:115
+msgid "**How it works:**"
+msgstr ""
+
+#: src/cli/commands.md:117
+msgid ""
+"Resolves the entry, computes the **project root** (walks up until it finds a"
+" `package.json` or `perry.toml`; falls back to the entry's parent "
+"directory)."
+msgstr ""
+
+#: src/cli/commands.md:118
+msgid ""
+"Does an initial `perry compile`, then spawns the resulting binary with stdio"
+" inherited."
+msgstr ""
+
+#: src/cli/commands.md:119
+msgid ""
+"Watches the project root (plus any `--watch` dirs) recursively using the "
+"`notify` crate. A 300 ms **debounce** window collapses editor \"save "
+"storms\" into one rebuild."
+msgstr ""
+
+#: src/cli/commands.md:120
+msgid ""
+"On each relevant change: kill the running child, recompile, relaunch. A "
+"failed build leaves the old child dead and waits for the next change; no "
+"crash loop."
+msgstr ""
+
+#: src/cli/commands.md:122
+msgid "**What counts as a \"relevant\" change:**"
+msgstr ""
+
+#: src/cli/commands.md:123
+msgid ""
+"**Trigger extensions:** `.ts`, `.tsx`, `.mts`, `.cts`, `.json`, `.toml`"
+msgstr ""
+
+#: src/cli/commands.md:124
+msgid ""
+"**Ignored directories (not watched, never retrigger):** `node_modules`, "
+"`target`, `.git`, `dist`, `build`, `.perry-dev`, `.perry-cache`"
+msgstr ""
+
+#: src/cli/commands.md:126
+msgid "**Benchmarks** (trivial single-file program, macOS):"
+msgstr ""
+
+#: src/cli/commands.md:128
+msgid "Phase"
+msgstr ""
+
+#: src/cli/commands.md:128
+msgid "Time"
+msgstr ""
+
+#: src/cli/commands.md:130
+msgid "Initial build (cold — runtime + stdlib rebuilt by auto-optimize)"
+msgstr ""
+
+#: src/cli/commands.md:130
+msgid "~15 s"
+msgstr ""
+
+#: src/cli/commands.md:131
+msgid "Post-edit rebuild (hot libs cached on disk)"
+msgstr ""
+
+#: src/cli/commands.md:131
+msgid "**~330 ms**"
+msgstr ""
+
+#: src/cli/commands.md:133
+msgid ""
+"The speedup on hot rebuilds comes from Perry's existing auto-optimize "
+"library cache. Multi-module projects will still recompile every changed "
+"module on each save — see the V2 note below for planned incremental work."
+msgstr ""
+
+#: src/cli/commands.md:135
+msgid "**Not yet in scope (V2+):**"
+msgstr ""
+
+#: src/cli/commands.md:136
+msgid "In-memory AST cache (reuse SWC parses across rebuilds)."
+msgstr ""
+
+#: src/cli/commands.md:137
+msgid "Per-module `.o` cache on disk (only re-codegen the changed module)."
+msgstr ""
+
+#: src/cli/commands.md:138
+msgid ""
+"State preservation across rebuilds / HMR — \"fast restart\" is the honest "
+"target."
+msgstr ""
+
+#: src/cli/commands.md:140
+msgid "check"
+msgstr ""
+
+#: src/cli/commands.md:142
+msgid "Validate TypeScript for Perry compatibility without compiling."
+msgstr ""
+
+#: src/cli/commands.md:150
+msgid "`--check-deps`"
+msgstr ""
+
+#: src/cli/commands.md:150
+msgid "Check `node_modules` for compatibility"
+msgstr ""
+
+#: src/cli/commands.md:151
+msgid "`--deep-deps`"
+msgstr ""
+
+#: src/cli/commands.md:151
+msgid "Scan all transitive dependencies"
+msgstr ""
+
+#: src/cli/commands.md:152
+msgid "`--all`"
+msgstr ""
+
+#: src/cli/commands.md:152
+msgid "Show all issues including hints"
+msgstr ""
+
+#: src/cli/commands.md:153
+msgid "`--strict`"
+msgstr ""
+
+#: src/cli/commands.md:153
+msgid "Treat warnings as errors"
+msgstr ""
+
+#: src/cli/commands.md:154
+msgid "`--fix`"
+msgstr ""
+
+#: src/cli/commands.md:154
+msgid "Automatically apply fixes"
+msgstr ""
+
+#: src/cli/commands.md:155
+msgid "`--fix-dry-run`"
+msgstr ""
+
+#: src/cli/commands.md:155
+msgid "Preview fixes without modifying files"
+msgstr ""
+
+#: src/cli/commands.md:156
+msgid "`--fix-unsafe`"
+msgstr ""
+
+#: src/cli/commands.md:156
+msgid "Include medium-confidence fixes"
+msgstr ""
+
+#: src/cli/commands.md:159
+msgid "# Check a single file\n"
+msgstr ""
+
+#: src/cli/commands.md:161
+msgid "# Check with dependency analysis\n"
+msgstr ""
+
+#: src/cli/commands.md:164
+msgid "# Auto-fix issues\n"
+msgstr ""
+
+#: src/cli/commands.md:167
+msgid "# Preview fixes without applying\n"
+msgstr ""
+
+#: src/cli/commands.md:172
+msgid "init"
+msgstr ""
+
+#: src/cli/commands.md:174
+msgid "Create a new Perry project."
+msgstr ""
+
+#: src/cli/commands.md:183
+msgid "`--name <NAME>`"
+msgstr ""
+
+#: src/cli/commands.md:183
+msgid "Project name (defaults to directory name)"
+msgstr ""
+
+#: src/cli/commands.md:185
+msgid "Creates `perry.toml`, `src/main.ts`, and `.gitignore`."
+msgstr ""
+
+#: src/cli/commands.md:187
+msgid "doctor"
+msgstr ""
+
+#: src/cli/commands.md:189
+msgid "Check your Perry installation and environment."
+msgstr ""
+
+#: src/cli/commands.md:197
+msgid "`--quiet`"
+msgstr ""
+
+#: src/cli/commands.md:197
+msgid "Only report failures"
+msgstr ""
+
+#: src/cli/commands.md:199
+msgid "Checks:"
+msgstr ""
+
+#: src/cli/commands.md:200
+msgid "Perry version"
+msgstr ""
+
+#: src/cli/commands.md:201
+msgid "System linker availability (cc/MSVC)"
+msgstr ""
+
+#: src/cli/commands.md:202
+msgid "Runtime library"
+msgstr ""
+
+#: src/cli/commands.md:203
+msgid "Project configuration"
+msgstr ""
+
+#: src/cli/commands.md:204
+msgid "Available updates"
+msgstr ""
+
+#: src/cli/commands.md:206
+msgid "explain"
+msgstr ""
+
+#: src/cli/commands.md:208
+msgid "Get detailed explanations for error codes."
+msgstr ""
+
+#: src/cli/commands.md:214
+msgid "Error code families:"
+msgstr ""
+
+#: src/cli/commands.md:215
+msgid "**P** — Parse errors"
+msgstr ""
+
+#: src/cli/commands.md:216
+msgid "**T** — Type errors"
+msgstr ""
+
+#: src/cli/commands.md:217
+msgid "**U** — Unsupported features"
+msgstr ""
+
+#: src/cli/commands.md:218
+msgid "**D** — Dependency issues"
+msgstr ""
+
+#: src/cli/commands.md:220
+msgid ""
+"Each explanation includes the error description, example code, and suggested"
+" fix."
+msgstr ""
+
+#: src/cli/commands.md:222
+msgid "publish"
+msgstr ""
+
+#: src/cli/commands.md:224
+msgid "Build, sign, and distribute your app."
+msgstr ""
+
+#: src/cli/commands.md:235
+msgid "Build for macOS (App Store/notarization)"
+msgstr ""
+
+#: src/cli/commands.md:236
+msgid "Build for iOS (App Store/TestFlight)"
+msgstr ""
+
+#: src/cli/commands.md:237
+msgid "Build for visionOS"
+msgstr ""
+
+#: src/cli/commands.md:238
+msgid "Build for Android (Google Play)"
+msgstr ""
+
+#: src/cli/commands.md:239
+msgid "Build for Linux (AppImage/deb/rpm)"
+msgstr ""
+
+#: src/cli/commands.md:240
+msgid "`--server <URL>`"
+msgstr ""
+
+#: src/cli/commands.md:240
+msgid "Build server (default: `https://hub.perryts.com`)"
+msgstr ""
+
+#: src/cli/commands.md:241
+msgid "`--license-key <KEY>`"
+msgstr ""
+
+#: src/cli/commands.md:241 src/cli/perry-toml.md:493
+msgid "Perry Hub license key"
+msgstr ""
+
+#: src/cli/commands.md:242
+msgid "`--project <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:242
+msgid "Project directory"
+msgstr ""
+
+#: src/cli/commands.md:243
+msgid "Artifact output directory (default: `dist`)"
+msgstr ""
+
+#: src/cli/commands.md:244
+msgid "`--no-download`"
+msgstr ""
+
+#: src/cli/commands.md:244
+msgid "Skip artifact download"
+msgstr ""
+
+#: src/cli/commands.md:246
+msgid "Apple-specific flags:"
+msgstr ""
+
+#: src/cli/commands.md:250
+msgid "`--apple-team-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:250
+msgid "Developer Team ID"
+msgstr ""
+
+#: src/cli/commands.md:251
+msgid "`--apple-identity <NAME>`"
+msgstr ""
+
+#: src/cli/commands.md:251
+msgid "Signing identity"
+msgstr ""
+
+#: src/cli/commands.md:252
+msgid "`--apple-p8-key <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:252
+msgid "App Store Connect .p8 key"
+msgstr ""
+
+#: src/cli/commands.md:253
+msgid "`--apple-key-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:253
+msgid "App Store Connect API Key ID"
+msgstr ""
+
+#: src/cli/commands.md:254
+msgid "`--apple-issuer-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:254
+msgid "App Store Connect Issuer ID"
+msgstr ""
+
+#: src/cli/commands.md:255
+msgid "`--certificate <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:255
+msgid ".p12 certificate bundle"
+msgstr ""
+
+#: src/cli/commands.md:256
+msgid "`--provisioning-profile <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:256
+msgid ".mobileprovision file (iOS)"
+msgstr ""
+
+#: src/cli/commands.md:258
+msgid "Android-specific flags:"
+msgstr ""
+
+#: src/cli/commands.md:262
+msgid "`--android-keystore <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:262
+msgid ".jks/.keystore file"
+msgstr ""
+
+#: src/cli/commands.md:263
+msgid "`--android-keystore-password <PASS>`"
+msgstr ""
+
+#: src/cli/commands.md:263 src/cli/perry-toml.md:507
+msgid "Keystore password"
+msgstr ""
+
+#: src/cli/commands.md:264
+msgid "`--android-key-alias <ALIAS>`"
+msgstr ""
+
+#: src/cli/commands.md:264
+msgid "Key alias"
+msgstr ""
+
+#: src/cli/commands.md:265
+msgid "`--android-key-password <PASS>`"
+msgstr ""
+
+#: src/cli/commands.md:265
+msgid "Key password"
+msgstr ""
+
+#: src/cli/commands.md:266
+msgid "`--google-play-key <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:266
+msgid "Google Play service account JSON"
+msgstr ""
+
+#: src/cli/commands.md:268
+msgid "On first use, `publish` auto-registers a free license key."
+msgstr ""
+
+#: src/cli/commands.md:270
+msgid "setup"
+msgstr ""
+
+#: src/cli/commands.md:272
+msgid ""
+"Interactive credential wizard for app distribution, plus toolchain setup for"
+" Windows."
+msgstr ""
+
+#: src/cli/commands.md:275
+msgid "# Show platform menu\n"
+msgstr ""
+
+#: src/cli/commands.md:276
+msgid "# macOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:277
+msgid "# iOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:278
+msgid "# visionOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:279
+msgid "# Android setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:280
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
+msgstr ""
+
+#: src/cli/commands.md:283
+msgid ""
+"`perry setup windows` downloads the Microsoft CRT + Windows SDK libraries "
+"(~1.5 GB) so Perry can link without Visual Studio Build Tools. Requires LLVM"
+" (`winget install LLVM.LLVM`) and prompts to accept the Microsoft "
+"redistributable license — pass `--accept-license` to skip the prompt for CI."
+" Output lands at `%LOCALAPPDATA%\\perry\\windows-sdk`. See the [Windows "
+"platform guide](../platforms/windows.md) for the full toolchain comparison."
+msgstr ""
+
+#: src/cli/commands.md:285
+msgid "Credential wizards store their output in `~/.perry/config.toml`."
+msgstr ""
+
+#: src/cli/commands.md:287
+msgid "update"
+msgstr ""
+
+#: src/cli/commands.md:289
+msgid "Check for and install Perry updates."
+msgstr ""
+
+#: src/cli/commands.md:292
+msgid "# Update to latest\n"
+msgstr ""
+
+#: src/cli/commands.md:293
+msgid "# Check without installing\n"
+msgstr ""
+
+#: src/cli/commands.md:294
+msgid "# Ignore 24h cache\n"
+msgstr ""
+
+#: src/cli/commands.md:297
+msgid "Update sources (checked in order):"
+msgstr ""
+
+#: src/cli/commands.md:298
+msgid "Custom server (env/config)"
+msgstr ""
+
+#: src/cli/commands.md:299
+msgid "Perry Hub"
+msgstr ""
+
+#: src/cli/commands.md:300
+msgid "GitHub API"
+msgstr ""
+
+#: src/cli/commands.md:302
+msgid ""
+"Opt out of automatic update checks with `PERRY_NO_UPDATE_CHECK=1` or "
+"`CI=true`."
+msgstr ""
+
+#: src/cli/commands.md:304
+msgid "i18n"
+msgstr ""
+
+#: src/cli/commands.md:306
+msgid ""
+"Internationalization tools for managing locale files and extracting "
+"localizable strings."
+msgstr ""
+
+#: src/cli/commands.md:310
+msgid "Scan source files and generate/update locale JSON scaffolds:"
+msgstr ""
+
+#: src/cli/commands.md:316
+msgid ""
+"Detects string literals in UI component calls (`Button`, `Text`, `Label`, "
+"etc.) and `t()` calls. Creates `locales/*.json` files based on the `[i18n]` "
+"config in `perry.toml`."
+msgstr ""
+
+#: src/cli/commands.md:318
+msgid "See the [i18n documentation](../i18n/overview.md) for full details."
+msgstr ""
+
+#: src/cli/commands.md:322
+msgid "[Compiler Flags](flags.md) — Complete flag reference"
+msgstr ""
+
+#: src/cli/commands.md:323
+msgid "[Getting Started](../getting-started/installation.md) — Installation"
+msgstr ""
+
+#: src/cli/flags.md:3
+msgid "Complete reference for all Perry CLI flags."
+msgstr ""
+
+#: src/cli/flags.md:5
+msgid "Global Flags"
+msgstr ""
+
+#: src/cli/flags.md:7
+msgid "Available on all commands:"
+msgstr ""
+
+#: src/cli/flags.md:11
+msgid "`--format text\\|json`"
+msgstr ""
+
+#: src/cli/flags.md:11
+msgid "Output format (default: `text`)"
+msgstr ""
+
+#: src/cli/flags.md:12
+msgid "`-v, --verbose`"
+msgstr ""
+
+#: src/cli/flags.md:12
+msgid "Increase verbosity (repeatable: `-v`, `-vv`, `-vvv`)"
+msgstr ""
+
+#: src/cli/flags.md:13
+msgid "`-q, --quiet`"
+msgstr ""
+
+#: src/cli/flags.md:13
+msgid "Suppress non-error output"
+msgstr ""
+
+#: src/cli/flags.md:14
+msgid "`--no-color`"
+msgstr ""
+
+#: src/cli/flags.md:14
+msgid "Disable ANSI color codes"
+msgstr ""
+
+#: src/cli/flags.md:16
+msgid "Compilation Targets"
+msgstr ""
+
+#: src/cli/flags.md:18
+msgid "Use `--target` to cross-compile:"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "_(none)_"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "Current platform"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "Default behavior"
+msgstr ""
+
+#: src/cli/flags.md:23
+msgid "`ios-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:23
+msgid "ARM64 simulator binary"
+msgstr ""
+
+#: src/cli/flags.md:24
+msgid "ARM64 device binary"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "`visionos-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "visionOS Simulator"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "Apple Vision Pro simulator build"
+msgstr ""
+
+#: src/cli/flags.md:26
+msgid "visionOS Device"
+msgstr ""
+
+#: src/cli/flags.md:26
+msgid "Apple Vision Pro device build"
+msgstr ""
+
+#: src/cli/flags.md:27
+msgid "ARM64/ARMv7"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "`ios-widget`"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "iOS Widget"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "WidgetKit extension (requires `--app-bundle-id`)"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "`ios-widget-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "iOS Widget (Sim)"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "Widget for simulator"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "`watchos-widget`"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "watchOS Complication"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "WidgetKit extension for Apple Watch"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "`watchos-widget-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "watchOS Widget (Sim)"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "Widget for watchOS simulator"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "`android-widget`"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "Android Widget"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "Android App Widget (AppWidgetProvider)"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "`wearos-tile`"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "Wear OS Tile"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "Wear OS Tile (TileService)"
+msgstr ""
+
+#: src/cli/flags.md:34
+msgid "`wasm`"
+msgstr ""
+
+#: src/cli/flags.md:34
+msgid "Self-contained HTML with WASM or raw `.wasm` binary"
+msgstr ""
+
+#: src/cli/flags.md:35
+msgid "Outputs HTML file with JS"
+msgstr ""
+
+#: src/cli/flags.md:36
+msgid "Win32 executable"
+msgstr ""
+
+#: src/cli/flags.md:37
+msgid "GTK4 executable"
+msgstr ""
+
+#: src/cli/flags.md:39
+msgid "Output Types"
+msgstr ""
+
+#: src/cli/flags.md:41
+msgid "Use `--output-type` to change what's produced:"
+msgstr ""
+
+#: src/cli/flags.md:45
+msgid "`executable`"
+msgstr ""
+
+#: src/cli/flags.md:45
+msgid "Standalone binary (default)"
+msgstr ""
+
+#: src/cli/flags.md:46
+msgid "`dylib`"
+msgstr ""
+
+#: src/cli/flags.md:46
+msgid "Shared library (`.dylib`/`.so`) for [plugins](../plugins/overview.md)"
+msgstr ""
+
+#: src/cli/flags.md:48
+msgid "Debug Flags"
+msgstr ""
+
+#: src/cli/flags.md:52
+msgid "Print HIR (intermediate representation) to stdout"
+msgstr ""
+
+#: src/cli/flags.md:53
+msgid "Produce `.o` object file only, skip linking"
+msgstr ""
+
+#: src/cli/flags.md:54
+msgid "Keep `.o` and `.asm` intermediate files"
+msgstr ""
+
+#: src/cli/flags.md:56
+msgid "Output Optimization"
+msgstr ""
+
+#: src/cli/flags.md:62
+msgid ""
+"Minification strips comments, collapses whitespace, and mangles local "
+"variable/parameter/non-exported function names for smaller output."
+msgstr ""
+
+#: src/cli/flags.md:64
+msgid "Testing Flags"
+msgstr ""
+
+#: src/cli/flags.md:68
+msgid "`--enable-geisterhand`"
+msgstr ""
+
+#: src/cli/flags.md:68
+msgid ""
+"Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
+"programmatic UI testing (default port 7676)"
+msgstr ""
+
+#: src/cli/flags.md:69
+msgid "`--geisterhand-port <PORT>`"
+msgstr ""
+
+#: src/cli/flags.md:69
+msgid ""
+"Set a custom port for the Geisterhand server (implies `--enable-"
+"geisterhand`)"
+msgstr ""
+
+#: src/cli/flags.md:71
+msgid "Runtime Flags"
+msgstr ""
+
+#: src/cli/flags.md:75
+msgid "Enable V8 JavaScript runtime for unsupported npm packages"
+msgstr ""
+
+#: src/cli/flags.md:76
+msgid "Enable type checking via tsgo IPC"
+msgstr ""
+
+#: src/cli/flags.md:78 src/cli/perry-toml.md:485
+msgid "Environment Variables"
+msgstr ""
+
+#: src/cli/flags.md:80 src/cli/perry-toml.md:491 src/cli/perry-toml.md:503
+#: src/cli/perry-toml.md:513
+msgid "Variable"
+msgstr ""
+
+#: src/cli/flags.md:82 src/cli/perry-toml.md:493
+msgid "`PERRY_LICENSE_KEY`"
+msgstr ""
+
+#: src/cli/flags.md:82
+msgid "Perry Hub license key for `perry publish`"
+msgstr ""
+
+#: src/cli/flags.md:83 src/cli/perry-toml.md:495
+msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/flags.md:83
+msgid "Password for .p12 certificate"
+msgstr ""
+
+#: src/cli/flags.md:84
+msgid "`PERRY_NO_UPDATE_CHECK=1`"
+msgstr ""
+
+#: src/cli/flags.md:84
+msgid "Disable automatic update checks"
+msgstr ""
+
+#: src/cli/flags.md:85
+msgid "`PERRY_UPDATE_SERVER`"
+msgstr ""
+
+#: src/cli/flags.md:85
+msgid "Custom update server URL"
+msgstr ""
+
+#: src/cli/flags.md:86
+msgid "`CI=true`"
+msgstr ""
+
+#: src/cli/flags.md:86
+msgid "Auto-skip update checks (set by most CI systems)"
+msgstr ""
+
+#: src/cli/flags.md:87
+msgid "`RUST_LOG`"
+msgstr ""
+
+#: src/cli/flags.md:87
+msgid "Debug logging level (`debug`, `info`, `trace`)"
+msgstr ""
+
+#: src/cli/flags.md:89
+msgid "Configuration Files"
+msgstr ""
+
+#: src/cli/flags.md:91
+msgid "perry.toml (project)"
+msgstr ""
+
+#: src/cli/flags.md:93
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"entry = \"src/main.ts\"\n"
+"version = \"1.0.0\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"build\"\n"
+"\n"
+"[app]\n"
+"name = \"My App\"\n"
+"description = \"A Perry application\"\n"
+"\n"
+"[macos]\n"
+"bundle_id = \"com.example.myapp\"\n"
+"category = \"public.app-category.developer-tools\"\n"
+"minimum_os = \"13.0\"\n"
+"distribute = \"notarize\"  # \"appstore\", \"notarize\", or \"both\"\n"
+"\n"
+"[ios]\n"
+"bundle_id = \"com.example.myapp\"\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = 26\n"
+"target_sdk = 34\n"
+"\n"
+"[linux]\n"
+"format = \"appimage\"  # \"appimage\", \"deb\", \"rpm\"\n"
+"category = \"Development\"\n"
+"```"
+msgstr ""
+
+#: src/cli/flags.md:127
+msgid "~/.perry/config.toml (global)"
+msgstr ""
+
+#: src/cli/flags.md:129
+msgid ""
+"```toml\n"
+"[apple]\n"
+"team_id = \"XXXXXXXXXX\"\n"
+"signing_identity = \"Developer ID Application: Your Name\"\n"
+"\n"
+"[android]\n"
+"keystore_path = \"/path/to/keystore.jks\"\n"
+"key_alias = \"my-key\"\n"
+"```"
+msgstr ""
+
+#: src/cli/flags.md:142
+msgid "# Simple CLI program\n"
+msgstr ""
+
+#: src/cli/flags.md:144
+msgid "# iOS app for simulator\n"
+msgstr ""
+
+#: src/cli/flags.md:147
+msgid "# visionOS app for simulator\n"
+msgstr ""
+
+#: src/cli/flags.md:150
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
+msgstr ""
+
+#: src/cli/flags.md:153
+msgid "# Plugin shared library\n"
+msgstr ""
+
+#: src/cli/flags.md:156
+msgid "# iOS widget with bundle ID\n"
+msgstr ""
+
+#: src/cli/flags.md:159
+msgid "# Debug compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:162
+msgid "# Verbose compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:165
+msgid "# Type-checked compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:168
+msgid "# Raw WASM binary (no HTML wrapper)\n"
+msgstr ""
+
+#: src/cli/flags.md:171
+msgid "# Minified web output (compresses embedded JS bridge)\n"
+msgstr ""
+
+#: src/cli/flags.md:178
+msgid "[Commands](commands.md) — All CLI commands"
+msgstr ""
+
+#: src/cli/flags.md:179
+msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
+msgstr ""
+
+#: src/cli/perry-toml.md:3
+msgid ""
+"`perry.toml` is the project-level configuration file for Perry. It controls "
+"project metadata, build settings, platform-specific options, code signing, "
+"distribution, auditing, and verification."
+msgstr ""
+
+#: src/cli/perry-toml.md:5
+msgid ""
+"Created automatically by `perry init`, it lives at the root of your project "
+"alongside `package.json`."
+msgstr ""
+
+#: src/cli/perry-toml.md:7
+msgid "Minimal Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:9
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"dist\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:18
+msgid "Full Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:20
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"version = \"1.2.0\"\n"
+"build_number = 42\n"
+"bundle_id = \"com.example.myapp\"\n"
+"description = \"A cross-platform Perry application\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[project.icons]\n"
+"source = \"assets/icon.png\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"dist\"\n"
+"\n"
+"[macos]\n"
+"bundle_id = \"com.example.myapp.macos\"\n"
+"category = \"public.app-category.developer-tools\"\n"
+"minimum_os = \"13.0\"\n"
+"entitlements = [\"com.apple.security.network.client\"]\n"
+"distribute = \"both\"\n"
+"signing_identity = \"Developer ID Application: My Company (TEAMID)\"\n"
+"certificate = \"certs/mac-appstore.p12\"\n"
+"notarize_certificate = \"certs/mac-devid.p12\"\n"
+"notarize_signing_identity = \"Developer ID Application: My Company (TEAMID)\"\n"
+"installer_certificate = \"certs/mac-installer.p12\"\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"certs/AuthKey.p8\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[ios]\n"
+"bundle_id = \"com.example.myapp.ios\"\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"orientations = [\"portrait\", \"landscape-left\", \"landscape-right\"]\n"
+"capabilities = [\"push-notification\"]\n"
+"distribute = \"appstore\"\n"
+"entry = \"src/main-ios.ts\"\n"
+"provisioning_profile = \"certs/MyApp.mobileprovision\"\n"
+"certificate = \"certs/ios-distribution.p12\"\n"
+"signing_identity = \"iPhone Distribution: My Company (TEAMID)\"\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"certs/AuthKey.p8\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = \"26\"\n"
+"target_sdk = \"34\"\n"
+"permissions = [\"INTERNET\", \"CAMERA\"]\n"
+"distribute = \"playstore\"\n"
+"keystore = \"certs/release.keystore\"\n"
+"key_alias = \"my-key\"\n"
+"google_play_key = \"certs/play-service-account.json\"\n"
+"entry = \"src/main-android.ts\"\n"
+"\n"
+"[linux]\n"
+"format = \"appimage\"\n"
+"category = \"Development\"\n"
+"description = \"A cross-platform Perry application\"\n"
+"\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\", \"fr\"]\n"
+"default_locale = \"en\"\n"
+"\n"
+"[i18n.currencies]\n"
+"en = \"USD\"\n"
+"de = \"EUR\"\n"
+"fr = \"EUR\"\n"
+"\n"
+"[publish]\n"
+"server = \"https://hub.perryts.com\"\n"
+"\n"
+"[audit]\n"
+"fail_on = \"B\"\n"
+"severity = \"high\"\n"
+"ignore = [\"RULE-001\", \"RULE-002\"]\n"
+"\n"
+"[verify]\n"
+"url = \"https://verify.perryts.com\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:110 src/cli/perry-toml.md:558
+msgid "`[project]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:112
+msgid ""
+"Core project metadata. This is the primary section for identifying your "
+"application."
+msgstr ""
+
+#: src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414
+msgid "Default"
+msgstr ""
+
+#: src/cli/perry-toml.md:116
+msgid "Directory name"
+msgstr ""
+
+#: src/cli/perry-toml.md:116
+msgid "Project name, used for binary output name and default bundle ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:117
+msgid "`\"1.0.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:117
+msgid "Semantic version string (e.g., `\"1.2.3\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "`build_number`"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "integer"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "`1`"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid ""
+"Numeric build number; auto-incremented on `perry publish` for iOS, Android, "
+"and macOS App Store builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:119
+msgid "Human-readable project description"
+msgstr ""
+
+#: src/cli/perry-toml.md:120 src/cli/perry-toml.md:249
+#: src/cli/perry-toml.md:304 src/cli/perry-toml.md:337
+msgid "`entry`"
+msgstr ""
+
+#: src/cli/perry-toml.md:120
+msgid ""
+"TypeScript entry file (e.g., `\"src/main.ts\"`). Used by `perry run` and "
+"`perry publish` when no input file is specified"
+msgstr ""
+
+#: src/cli/perry-toml.md:121 src/cli/perry-toml.md:167
+#: src/cli/perry-toml.md:243 src/cli/perry-toml.md:301
+msgid "`bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:121
+msgid "`com.perry.<name>`"
+msgstr ""
+
+#: src/cli/perry-toml.md:121
+msgid ""
+"Default bundle identifier, used as fallback when platform-specific sections "
+"don't define one"
+msgstr ""
+
+#: src/cli/perry-toml.md:123
+msgid "`[project.icons]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:127
+msgid "`source`"
+msgstr ""
+
+#: src/cli/perry-toml.md:127
+msgid ""
+"Path to a source icon image (PNG or JPG). Perry auto-resizes this to all "
+"required sizes for each platform"
+msgstr ""
+
+#: src/cli/perry-toml.md:129
+msgid "`[app]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:131
+msgid ""
+"Alternative to `[project]` with identical fields. Useful for organizational "
+"clarity — `[app]` takes precedence over `[project]` when both are present:"
+msgstr ""
+
+#: src/cli/perry-toml.md:133
+msgid ""
+"```toml\n"
+"# These two are equivalent:\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"\n"
+"# or:\n"
+"[app]\n"
+"name = \"my-app\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:143
+msgid ""
+"When both exist, resolution order is: `[app]` field -> `[project]` field -> "
+"default."
+msgstr ""
+
+#: src/cli/perry-toml.md:145
+msgid ""
+"`[app]` supports the same fields as `[project]`: `name`, `version`, "
+"`build_number`, `bundle_id`, `description`, `entry`, and `icons`."
+msgstr ""
+
+#: src/cli/perry-toml.md:149 src/cli/perry-toml.md:561
+msgid "`[build]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:151
+msgid "Build output settings."
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "`out_dir`"
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "`\"dist\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "Directory for build artifacts"
+msgstr ""
+
+#: src/cli/perry-toml.md:159
+msgid "`[macos]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:161
+msgid ""
+"macOS-specific configuration for `perry publish macos` and `perry compile "
+"--target macos`."
+msgstr ""
+
+#: src/cli/perry-toml.md:163 src/cli/perry-toml.md:239
+#: src/cli/perry-toml.md:297
+msgid "App Metadata"
+msgstr ""
+
+#: src/cli/perry-toml.md:167 src/cli/perry-toml.md:243
+msgid "Falls back to `[app]`/`[project]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:167
+msgid "macOS-specific bundle identifier (e.g., `\"com.example.myapp\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:348
+msgid "`category`"
+msgstr ""
+
+#: src/cli/perry-toml.md:168
+msgid ""
+"Mac App Store category. Uses Apple's UTI format (see [valid values](#macos-"
+"app-store-categories) below)"
+msgstr ""
+
+#: src/cli/perry-toml.md:169
+msgid "`minimum_os`"
+msgstr ""
+
+#: src/cli/perry-toml.md:169
+msgid "Minimum macOS version required (e.g., `\"13.0\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:170
+msgid "`entitlements`"
+msgstr ""
+
+#: src/cli/perry-toml.md:170 src/cli/perry-toml.md:246
+#: src/cli/perry-toml.md:247 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:332 src/cli/perry-toml.md:359
+#: src/cli/perry-toml.md:391
+msgid "string\\[\\]"
+msgstr ""
+
+#: src/cli/perry-toml.md:170
+msgid ""
+"macOS entitlements to include in the code signature (e.g., "
+"`[\"com.apple.security.network.client\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305
+msgid "`encryption_exempt`"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305
+msgid "bool"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305 src/cli/perry-toml.md:361
+msgid "`false`"
+msgstr ""
+
+#: src/cli/perry-toml.md:171
+msgid ""
+"If `true`, adds `ITSAppUsesNonExemptEncryption = false` to Info.plist, "
+"skipping the export compliance prompt in App Store Connect"
+msgstr ""
+
+#: src/cli/perry-toml.md:173 src/cli/perry-toml.md:252
+msgid "Distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:177 src/cli/perry-toml.md:256
+#: src/cli/perry-toml.md:312 src/cli/perry-toml.md:333
+msgid "`distribute`"
+msgstr ""
+
+#: src/cli/perry-toml.md:177
+msgid ""
+"Distribution method: `\"appstore\"`, `\"notarize\"`, or `\"both\"` (see "
+"[Distribution Modes](#macos-distribution-modes))"
+msgstr ""
+
+#: src/cli/perry-toml.md:183 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:313
+msgid "`signing_identity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:183 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:313
+msgid "Auto-detected from Keychain"
+msgstr ""
+
+#: src/cli/perry-toml.md:183
+msgid ""
+"Code signing identity name (e.g., `\"3rd Party Mac Developer Application: "
+"Company (TEAMID)\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:263
+#: src/cli/perry-toml.md:314
+msgid "`certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:263
+#: src/cli/perry-toml.md:314
+msgid "Auto-exported from Keychain"
+msgstr ""
+
+#: src/cli/perry-toml.md:184
+msgid "Path to `.p12` certificate file for App Store distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:185
+msgid "`notarize_certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:185
+msgid ""
+"Separate `.p12` certificate for notarization (only used with `distribute = "
+"\"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:186
+msgid "`notarize_signing_identity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:186
+msgid "Signing identity for notarization (only used with `distribute = \"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:187
+msgid "`installer_certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:187
+msgid "`.p12` certificate for Mac Installer Distribution (`.pkg` signing)"
+msgstr ""
+
+#: src/cli/perry-toml.md:189 src/cli/perry-toml.md:266
+msgid "App Store Connect"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:270
+#: src/cli/perry-toml.md:316
+msgid "`team_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:194
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:196
+#: src/cli/perry-toml.md:270 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:272 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:316 src/cli/perry-toml.md:317
+#: src/cli/perry-toml.md:318 src/cli/perry-toml.md:319
+msgid "From `~/.perry/config.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:270
+#: src/cli/perry-toml.md:316
+msgid "Apple Developer Team ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:194 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:317
+msgid "`key_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:194 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:497
+msgid "App Store Connect API key ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:272
+#: src/cli/perry-toml.md:318
+msgid "`issuer_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:272
+#: src/cli/perry-toml.md:318
+msgid "App Store Connect issuer ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:196 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:319
+msgid "`p8_key_path`"
+msgstr ""
+
+#: src/cli/perry-toml.md:196
+msgid "Path to App Store Connect `.p8` API key file"
+msgstr ""
+
+#: src/cli/perry-toml.md:198
+msgid "macOS Distribution Modes"
+msgstr ""
+
+#: src/cli/perry-toml.md:200
+msgid ""
+"The `distribute` field controls how your macOS app is signed and "
+"distributed:"
+msgstr ""
+
+#: src/cli/perry-toml.md:202
+msgid ""
+"**`\"appstore\"`** — Signs with an App Store distribution certificate and "
+"uploads to App Store Connect. Requires `team_id`, `key_id`, `issuer_id`, and"
+" `p8_key_path`."
+msgstr ""
+
+#: src/cli/perry-toml.md:204
+msgid ""
+"**`\"notarize\"`** — Signs with a Developer ID certificate and notarizes "
+"with Apple. For direct distribution outside the App Store."
+msgstr ""
+
+#: src/cli/perry-toml.md:206
+msgid ""
+"**`\"both\"`** — Produces **two** signed builds: one for the App Store and "
+"one notarized for direct distribution. Requires **two separate "
+"certificates**:"
+msgstr ""
+
+#: src/cli/perry-toml.md:207
+msgid "`certificate` + `signing_identity` for the App Store build"
+msgstr ""
+
+#: src/cli/perry-toml.md:208
+msgid ""
+"`notarize_certificate` + `notarize_signing_identity` for the notarized build"
+msgstr ""
+
+#: src/cli/perry-toml.md:209
+msgid "Optionally `installer_certificate` for `.pkg` signing"
+msgstr ""
+
+#: src/cli/perry-toml.md:211
+msgid "macOS App Store Categories"
+msgstr ""
+
+#: src/cli/perry-toml.md:213
+msgid "Common values for the `category` field (Apple UTI format):"
+msgstr ""
+
+#: src/cli/perry-toml.md:215
+msgid "Category"
+msgstr ""
+
+#: src/cli/perry-toml.md:217
+msgid "Business"
+msgstr ""
+
+#: src/cli/perry-toml.md:217
+msgid "`public.app-category.business`"
+msgstr ""
+
+#: src/cli/perry-toml.md:218
+msgid "Developer Tools"
+msgstr ""
+
+#: src/cli/perry-toml.md:218
+msgid "`public.app-category.developer-tools`"
+msgstr ""
+
+#: src/cli/perry-toml.md:219
+msgid "Education"
+msgstr ""
+
+#: src/cli/perry-toml.md:219
+msgid "`public.app-category.education`"
+msgstr ""
+
+#: src/cli/perry-toml.md:220
+msgid "Entertainment"
+msgstr ""
+
+#: src/cli/perry-toml.md:220
+msgid "`public.app-category.entertainment`"
+msgstr ""
+
+#: src/cli/perry-toml.md:221
+msgid "Finance"
+msgstr ""
+
+#: src/cli/perry-toml.md:221
+msgid "`public.app-category.finance`"
+msgstr ""
+
+#: src/cli/perry-toml.md:222
+msgid "Games"
+msgstr ""
+
+#: src/cli/perry-toml.md:222
+msgid "`public.app-category.games`"
+msgstr ""
+
+#: src/cli/perry-toml.md:223
+msgid "Graphics & Design"
+msgstr ""
+
+#: src/cli/perry-toml.md:223
+msgid "`public.app-category.graphics-design`"
+msgstr ""
+
+#: src/cli/perry-toml.md:224
+msgid "Health & Fitness"
+msgstr ""
+
+#: src/cli/perry-toml.md:224
+msgid "`public.app-category.healthcare-fitness`"
+msgstr ""
+
+#: src/cli/perry-toml.md:225
+msgid "Lifestyle"
+msgstr ""
+
+#: src/cli/perry-toml.md:225
+msgid "`public.app-category.lifestyle`"
+msgstr ""
+
+#: src/cli/perry-toml.md:226
+msgid "Music"
+msgstr ""
+
+#: src/cli/perry-toml.md:226
+msgid "`public.app-category.music`"
+msgstr ""
+
+#: src/cli/perry-toml.md:227
+msgid "News"
+msgstr ""
+
+#: src/cli/perry-toml.md:227
+msgid "`public.app-category.news`"
+msgstr ""
+
+#: src/cli/perry-toml.md:228
+msgid "Photography"
+msgstr ""
+
+#: src/cli/perry-toml.md:228
+msgid "`public.app-category.photography`"
+msgstr ""
+
+#: src/cli/perry-toml.md:229
+msgid "Productivity"
+msgstr ""
+
+#: src/cli/perry-toml.md:229
+msgid "`public.app-category.productivity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:230
+msgid "Social Networking"
+msgstr ""
+
+#: src/cli/perry-toml.md:230
+msgid "`public.app-category.social-networking`"
+msgstr ""
+
+#: src/cli/perry-toml.md:231
+msgid "`public.app-category.utilities`"
+msgstr ""
+
+#: src/cli/perry-toml.md:235
+msgid "`[ios]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:237
+msgid ""
+"iOS-specific configuration for `perry publish ios`, `perry run ios`, and "
+"`perry compile --target ios`/`--target ios-simulator`."
+msgstr ""
+
+#: src/cli/perry-toml.md:243
+msgid "iOS-specific bundle identifier"
+msgstr ""
+
+#: src/cli/perry-toml.md:244 src/cli/perry-toml.md:302
+msgid "`deployment_target`"
+msgstr ""
+
+#: src/cli/perry-toml.md:244
+msgid "`\"17.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:244
+msgid "Minimum iOS version required (e.g., `\"16.0\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:303
+msgid "`minimum_version`"
+msgstr ""
+
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:303
+msgid "Alias for `deployment_target`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "`device_family`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "`[\"iphone\", \"ipad\"]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "Supported device families"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "`orientations`"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "`[\"portrait\"]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "Supported interface orientations"
+msgstr ""
+
+#: src/cli/perry-toml.md:248
+msgid "`capabilities`"
+msgstr ""
+
+#: src/cli/perry-toml.md:248
+msgid "App capabilities (e.g., `[\"push-notification\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:249 src/cli/perry-toml.md:304
+#: src/cli/perry-toml.md:337 src/cli/perry-toml.md:349
+msgid "Falls back to `[project]`/`[app]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:249
+msgid ""
+"iOS-specific entry file (useful when iOS needs a different entry point)"
+msgstr ""
+
+#: src/cli/perry-toml.md:250 src/cli/perry-toml.md:305
+msgid "If `true`, adds `ITSAppUsesNonExemptEncryption = false` to Info.plist"
+msgstr ""
+
+#: src/cli/perry-toml.md:256
+msgid "Distribution method: `\"appstore\"`, `\"testflight\"`, or `\"development\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:262
+msgid "Code signing identity (e.g., `\"iPhone Distribution: Company (TEAMID)\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:263 src/cli/perry-toml.md:314
+msgid "Path to `.p12` distribution certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:264 src/cli/perry-toml.md:315
+msgid "`provisioning_profile`"
+msgstr ""
+
+#: src/cli/perry-toml.md:264
+msgid ""
+"Path to `.mobileprovision` file. Stored as `{bundle_id}.mobileprovision` in "
+"`~/.perry/` by `perry setup ios`"
+msgstr ""
+
+#: src/cli/perry-toml.md:273 src/cli/perry-toml.md:319
+msgid "Path to `.p8` API key file"
+msgstr ""
+
+#: src/cli/perry-toml.md:275
+msgid "Device Family Values"
+msgstr ""
+
+#: src/cli/perry-toml.md:279
+msgid "`\"iphone\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:279
+msgid "iPhone devices"
+msgstr ""
+
+#: src/cli/perry-toml.md:280
+msgid "`\"ipad\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:280
+msgid "iPad devices"
+msgstr ""
+
+#: src/cli/perry-toml.md:282
+msgid "Orientation Values"
+msgstr ""
+
+#: src/cli/perry-toml.md:286
+msgid "`\"portrait\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:286
+msgid "Device upright"
+msgstr ""
+
+#: src/cli/perry-toml.md:287
+msgid "`\"portrait-upside-down\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:287
+msgid "Device upside down"
+msgstr ""
+
+#: src/cli/perry-toml.md:288
+msgid "`\"landscape-left\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:288
+msgid "Device rotated left"
+msgstr ""
+
+#: src/cli/perry-toml.md:289
+msgid "`\"landscape-right\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:289
+msgid "Device rotated right"
+msgstr ""
+
+#: src/cli/perry-toml.md:293
+msgid "`[visionos]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:295
+msgid ""
+"visionOS-specific configuration for `perry publish visionos`, `perry run "
+"visionos`, and `perry compile --target visionos`/`--target visionos-"
+"simulator`."
+msgstr ""
+
+#: src/cli/perry-toml.md:301
+msgid "Falls back to `[app]`/`[project]`/`[ios]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:301
+msgid "visionOS-specific bundle identifier"
+msgstr ""
+
+#: src/cli/perry-toml.md:302
+msgid "`\"1.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:302
+msgid "Minimum visionOS version required"
+msgstr ""
+
+#: src/cli/perry-toml.md:304
+msgid "visionOS-specific entry file"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "`info_plist`"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "table"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "Custom key-value pairs merged into the generated Info.plist"
+msgstr ""
+
+#: src/cli/perry-toml.md:308
+msgid "Distribution / Signing"
+msgstr ""
+
+#: src/cli/perry-toml.md:312
+msgid "Distribution method for visionOS builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:313
+msgid "Code signing identity"
+msgstr ""
+
+#: src/cli/perry-toml.md:315
+msgid "Path to `.mobileprovision` file"
+msgstr ""
+
+#: src/cli/perry-toml.md:323
+msgid "`[android]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:325
+msgid ""
+"Android-specific configuration for `perry publish android`, `perry run "
+"android`, and `perry compile --target android`."
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "`package_name`"
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "Falls back to bundle_id chain"
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "Java package name (e.g., `\"com.example.myapp\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:330
+msgid "`min_sdk`"
+msgstr ""
+
+#: src/cli/perry-toml.md:330
+msgid "Minimum Android SDK version (e.g., `\"26\"` for Android 8.0)"
+msgstr ""
+
+#: src/cli/perry-toml.md:331
+msgid "`target_sdk`"
+msgstr ""
+
+#: src/cli/perry-toml.md:331
+msgid "Target Android SDK version (e.g., `\"34\"` for Android 14)"
+msgstr ""
+
+#: src/cli/perry-toml.md:332
+msgid "`permissions`"
+msgstr ""
+
+#: src/cli/perry-toml.md:332
+msgid "Android permissions (e.g., `[\"INTERNET\", \"CAMERA\", \"ACCESS_FINE_LOCATION\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:333
+msgid "Distribution method: `\"playstore\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:334
+msgid "`keystore`"
+msgstr ""
+
+#: src/cli/perry-toml.md:334
+msgid "Path to `.jks` or `.keystore` signing keystore"
+msgstr ""
+
+#: src/cli/perry-toml.md:335
+msgid "`key_alias`"
+msgstr ""
+
+#: src/cli/perry-toml.md:335
+msgid "Alias of the signing key within the keystore"
+msgstr ""
+
+#: src/cli/perry-toml.md:336
+msgid "`google_play_key`"
+msgstr ""
+
+#: src/cli/perry-toml.md:336
+msgid "Path to Google Play service account JSON file for automated uploads"
+msgstr ""
+
+#: src/cli/perry-toml.md:337
+msgid "Android-specific entry file"
+msgstr ""
+
+#: src/cli/perry-toml.md:341
+msgid "`[linux]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:343
+msgid "Linux-specific configuration for `perry publish linux`."
+msgstr ""
+
+#: src/cli/perry-toml.md:347
+msgid "`format`"
+msgstr ""
+
+#: src/cli/perry-toml.md:347
+msgid "Package format: `\"appimage\"`, `\"deb\"`, or `\"rpm\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:348
+msgid "Desktop application category (e.g., `\"Development\"`, `\"Utility\"`, `\"Game\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:349
+msgid "Application description for package metadata"
+msgstr ""
+
+#: src/cli/perry-toml.md:353
+msgid "`[i18n]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:355
+msgid ""
+"Internationalization configuration. See the [i18n "
+"documentation](../i18n/overview.md) for full details."
+msgstr ""
+
+#: src/cli/perry-toml.md:359
+msgid "`locales`"
+msgstr ""
+
+#: src/cli/perry-toml.md:359
+msgid ""
+"Supported locale codes (e.g., `[\"en\", \"de\", \"fr\"]`). Locale files must"
+" exist in `/locales`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "`default_locale`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "`\"en\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "Fallback locale. Used when a key is missing in another locale"
+msgstr ""
+
+#: src/cli/perry-toml.md:361
+msgid "`dynamic`"
+msgstr ""
+
+#: src/cli/perry-toml.md:361
+msgid ""
+"`false`: locale set at launch, strings inlined. `true`: locale switchable at"
+" runtime"
+msgstr ""
+
+#: src/cli/perry-toml.md:363
+msgid "`[i18n.currencies]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:365
+msgid ""
+"Maps locale codes to default ISO 4217 currency codes. Used by the "
+"`Currency()` format wrapper."
+msgstr ""
+
+#: src/cli/perry-toml.md:369
+msgid "`{locale}`"
+msgstr ""
+
+#: src/cli/perry-toml.md:369
+msgid "Currency code for the locale (e.g., `en = \"USD\"`, `de = \"EUR\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:373
+msgid "`[publish]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:375
+msgid "Publishing configuration."
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid "`server`"
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid "`https://hub.perryts.com`"
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid ""
+"Custom Perry Hub build server URL. Useful for self-hosted or enterprise "
+"deployments"
+msgstr ""
+
+#: src/cli/perry-toml.md:383
+msgid "`[audit]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:385
+msgid "Security audit configuration for `perry audit` and pre-publish audits."
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid "`fail_on`"
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid "`\"C\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid ""
+"Minimum acceptable audit grade. Build fails if the actual grade is below "
+"this threshold. Values: `\"A\"`, `\"A-\"`, `\"B\"`, `\"C\"`, `\"D\"`, "
+"`\"F\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid "`severity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid "`\"all\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid ""
+"Filter findings by severity: `\"all\"`, `\"critical\"`, `\"high\"`, "
+"`\"medium\"`, `\"low\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:391
+msgid "`ignore`"
+msgstr ""
+
+#: src/cli/perry-toml.md:391
+msgid "List of audit rule IDs to suppress (e.g., `[\"RULE-001\", \"RULE-042\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:393
+msgid "Audit Grade Scale"
+msgstr ""
+
+#: src/cli/perry-toml.md:395
+msgid "Grades are ranked from highest to lowest:"
+msgstr ""
+
+#: src/cli/perry-toml.md:397
+msgid "Grade"
+msgstr ""
+
+#: src/cli/perry-toml.md:397
+msgid "Rank"
+msgstr ""
+
+#: src/cli/perry-toml.md:399
+msgid "A"
+msgstr ""
+
+#: src/cli/perry-toml.md:399
+msgid "Excellent — no significant findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:400
+msgid "A-"
+msgstr ""
+
+#: src/cli/perry-toml.md:400
+msgid "Very good — minor findings only"
+msgstr ""
+
+#: src/cli/perry-toml.md:401
+msgid "B"
+msgstr ""
+
+#: src/cli/perry-toml.md:401
+msgid "Good — some findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:402
+msgid "C"
+msgstr ""
+
+#: src/cli/perry-toml.md:402
+msgid "Acceptable — moderate findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:403
+msgid "D"
+msgstr ""
+
+#: src/cli/perry-toml.md:403
+msgid "Poor — significant findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:404
+msgid "F"
+msgstr ""
+
+#: src/cli/perry-toml.md:404
+msgid "Fail — critical findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:406
+msgid ""
+"Setting `fail_on = \"B\"` means any grade below B (i.e., C, D, or F) will "
+"cause the build to fail."
+msgstr ""
+
+#: src/cli/perry-toml.md:410
+msgid "`[verify]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:412
+msgid "Runtime verification configuration for `perry verify`."
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "`url`"
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "`https://verify.perryts.com`"
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "Verification service endpoint URL"
+msgstr ""
+
+#: src/cli/perry-toml.md:420
+msgid "Bundle ID Resolution"
+msgstr ""
+
+#: src/cli/perry-toml.md:422
+msgid ""
+"Perry resolves the bundle identifier using a cascading priority system. The "
+"first non-empty value wins:"
+msgstr ""
+
+#: src/cli/perry-toml.md:424
+msgid "For iOS builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:425 src/cli/perry-toml.md:441
+msgid "`[ios].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:426 src/cli/perry-toml.md:434
+#: src/cli/perry-toml.md:443
+msgid "`[app].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:427 src/cli/perry-toml.md:435
+#: src/cli/perry-toml.md:444
+msgid "`[project].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:428 src/cli/perry-toml.md:433
+#: src/cli/perry-toml.md:442
+msgid "`[macos].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:429 src/cli/perry-toml.md:436
+msgid "`package.json` `bundleId` field"
+msgstr ""
+
+#: src/cli/perry-toml.md:430 src/cli/perry-toml.md:437
+#: src/cli/perry-toml.md:445
+msgid "`com.perry.<app_name>` (generated default)"
+msgstr ""
+
+#: src/cli/perry-toml.md:432
+msgid "For macOS builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:439
+msgid "For Android builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:440
+msgid "`[android].package_name`"
+msgstr ""
+
+#: src/cli/perry-toml.md:449
+msgid "Entry File Resolution"
+msgstr ""
+
+#: src/cli/perry-toml.md:451
+msgid ""
+"When no input file is specified on the command line, Perry resolves the "
+"entry file in this order:"
+msgstr ""
+
+#: src/cli/perry-toml.md:453
+msgid "`[ios].entry` / `[android].entry` (when targeting that platform)"
+msgstr ""
+
+#: src/cli/perry-toml.md:454
+msgid "`[project].entry` or `[app].entry`"
+msgstr ""
+
+#: src/cli/perry-toml.md:455
+msgid "`src/main.ts` (if it exists)"
+msgstr ""
+
+#: src/cli/perry-toml.md:456
+msgid "`main.ts` (if it exists)"
+msgstr ""
+
+#: src/cli/perry-toml.md:460
+msgid "Build Number Auto-Increment"
+msgstr ""
+
+#: src/cli/perry-toml.md:462
+msgid ""
+"The `build_number` field is automatically incremented by `perry publish` "
+"for:"
+msgstr ""
+
+#: src/cli/perry-toml.md:463
+msgid "iOS builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:464
+msgid "Android builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:465
+msgid "macOS App Store builds (`distribute = \"appstore\"` or `\"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:467
+msgid ""
+"The updated value is written back to `perry.toml` after a successful "
+"publish. This ensures each submission to the App Store / Play Store has a "
+"unique, monotonically increasing build number."
+msgstr ""
+
+#: src/cli/perry-toml.md:469
+msgid ""
+"macOS builds with `distribute = \"notarize\"` (direct distribution) do "
+"**not** auto-increment the build number."
+msgstr ""
+
+#: src/cli/perry-toml.md:473
+msgid "Configuration Priority"
+msgstr ""
+
+#: src/cli/perry-toml.md:475
+msgid ""
+"Perry resolves configuration values using a layered priority system (highest"
+" to lowest):"
+msgstr ""
+
+#: src/cli/perry-toml.md:477
+msgid "**CLI flags** — e.g., `--target`, `--output`"
+msgstr ""
+
+#: src/cli/perry-toml.md:478
+msgid "**Environment variables** — e.g., `PERRY_LICENSE_KEY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:479
+msgid ""
+"**perry.toml** — project-level config (platform-specific sections first, "
+"then `[app]`/`[project]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:480
+msgid "**~/.perry/config.toml** — user-level global config"
+msgstr ""
+
+#: src/cli/perry-toml.md:481
+msgid "**Built-in defaults**"
+msgstr ""
+
+#: src/cli/perry-toml.md:487
+msgid ""
+"These environment variables override perry.toml and global config values:"
+msgstr ""
+
+#: src/cli/perry-toml.md:489
+msgid "Apple / iOS / macOS"
+msgstr ""
+
+#: src/cli/perry-toml.md:494
+msgid "`PERRY_APPLE_CERTIFICATE`"
+msgstr ""
+
+#: src/cli/perry-toml.md:494
+msgid "`.p12` certificate file contents (base64)"
+msgstr ""
+
+#: src/cli/perry-toml.md:495
+msgid "Password for the `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:496
+msgid "`PERRY_APPLE_P8_KEY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:496
+msgid "`.p8` API key file contents"
+msgstr ""
+
+#: src/cli/perry-toml.md:497
+msgid "`PERRY_APPLE_KEY_ID`"
+msgstr ""
+
+#: src/cli/perry-toml.md:498
+msgid "`PERRY_APPLE_NOTARIZE_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:498
+msgid "Password for the notarization `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:499
+msgid "`PERRY_APPLE_INSTALLER_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:499
+msgid "Password for the installer `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:505
+msgid "`PERRY_ANDROID_KEYSTORE`"
+msgstr ""
+
+#: src/cli/perry-toml.md:505
+msgid "Path to `.jks`/`.keystore` file"
+msgstr ""
+
+#: src/cli/perry-toml.md:506
+msgid "`PERRY_ANDROID_KEY_ALIAS`"
+msgstr ""
+
+#: src/cli/perry-toml.md:506
+msgid "Keystore key alias"
+msgstr ""
+
+#: src/cli/perry-toml.md:507
+msgid "`PERRY_ANDROID_KEYSTORE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:508
+msgid "`PERRY_ANDROID_KEY_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:508
+msgid "Key password (within the keystore)"
+msgstr ""
+
+#: src/cli/perry-toml.md:509
+msgid "`PERRY_GOOGLE_PLAY_KEY_PATH`"
+msgstr ""
+
+#: src/cli/perry-toml.md:509
+msgid "Path to Google Play service account JSON"
+msgstr ""
+
+#: src/cli/perry-toml.md:511
+msgid "General"
+msgstr ""
+
+#: src/cli/perry-toml.md:515
+msgid "`PERRY_NO_TELEMETRY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:515
+msgid "Set to `1` to disable anonymous telemetry"
+msgstr ""
+
+#: src/cli/perry-toml.md:516
+msgid "`PERRY_NO_UPDATE_CHECK`"
+msgstr ""
+
+#: src/cli/perry-toml.md:516
+msgid "Set to `1` to disable background update checks"
+msgstr ""
+
+#: src/cli/perry-toml.md:520
+msgid "Global Config: `~/.perry/config.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:522
+msgid ""
+"Separate from the project-level `perry.toml`, Perry maintains a user-level "
+"global config at `~/.perry/config.toml`. This stores credentials and "
+"preferences shared across all projects."
+msgstr ""
+
+#: src/cli/perry-toml.md:524
+msgid ""
+"```toml\n"
+"license_key = \"perry-xxxxxxxx\"\n"
+"server = \"https://hub.perryts.com\"\n"
+"default_target = \"macos\"\n"
+"\n"
+"[apple]\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"/Users/me/.perry/AuthKey.p8\"\n"
+"\n"
+"[android]\n"
+"keystore_path = \"/Users/me/.perry/release.keystore\"\n"
+"key_alias = \"my-key\"\n"
+"google_play_key_path = \"/Users/me/.perry/play-service-account.json\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:541
+msgid ""
+"Fields in perry.toml (project-level) override `~/.perry/config.toml` "
+"(global-level). For example, `[ios].team_id` in perry.toml overrides "
+"`[apple].team_id` in the global config."
+msgstr ""
+
+#: src/cli/perry-toml.md:543
+msgid "The global config is managed by `perry setup` commands:"
+msgstr ""
+
+#: src/cli/perry-toml.md:544
+msgid "`perry setup ios` — configures Apple signing credentials"
+msgstr ""
+
+#: src/cli/perry-toml.md:545
+msgid "`perry setup android` — configures Android signing credentials"
+msgstr ""
+
+#: src/cli/perry-toml.md:546
+msgid "`perry setup macos` — configures macOS distribution settings"
+msgstr ""
+
+#: src/cli/perry-toml.md:550
+msgid "perry.toml vs package.json"
+msgstr ""
+
+#: src/cli/perry-toml.md:552
+msgid "Perry reads configuration from both files. Here's what goes where:"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "Setting"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "File"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "Section"
+msgstr ""
+
+#: src/cli/perry-toml.md:556
+msgid "Compile packages natively"
+msgstr ""
+
+#: src/cli/perry-toml.md:556 src/cli/perry-toml.md:557
+msgid "`package.json`"
+msgstr ""
+
+#: src/cli/perry-toml.md:556
+msgid "`perry.compilePackages`"
+msgstr ""
+
+#: src/cli/perry-toml.md:557
+msgid "Splash screen"
+msgstr ""
+
+#: src/cli/perry-toml.md:557
+msgid "`perry.splash`"
+msgstr ""
+
+#: src/cli/perry-toml.md:558
+msgid "Project name, version, entry"
+msgstr ""
+
+#: src/cli/perry-toml.md:558 src/cli/perry-toml.md:559
+#: src/cli/perry-toml.md:560 src/cli/perry-toml.md:561
+#: src/cli/perry-toml.md:562
+msgid "`perry.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:559
+msgid "Platform-specific settings"
+msgstr ""
+
+#: src/cli/perry-toml.md:559
+msgid "`[ios]`, `[macos]`, `[android]`, `[linux]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:560
+msgid "Code signing & distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:560
+msgid "Platform sections"
+msgstr ""
+
+#: src/cli/perry-toml.md:561
+msgid "Build output directory"
+msgstr ""
+
+#: src/cli/perry-toml.md:562
+msgid "Audit & verification"
+msgstr ""
+
+#: src/cli/perry-toml.md:562
+msgid "`[audit]`, `[verify]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:564
+msgid ""
+"When both files define the same value (e.g., project name), `perry.toml` "
+"takes precedence."
+msgstr ""
+
+#: src/cli/perry-toml.md:568
+msgid "Setup Wizard"
+msgstr ""
+
+#: src/cli/perry-toml.md:570
+msgid ""
+"Running `perry setup <platform>` interactively configures signing "
+"credentials and writes them back to both `perry.toml` and "
+"`~/.perry/config.toml`:"
+msgstr ""
+
+#: src/cli/perry-toml.md:573
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:574
+msgid "# Configure Android signing (keystore, Play Store key)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:575
+msgid "# Configure macOS distribution (App Store, notarization)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:578
+msgid "The wizard automatically:"
+msgstr ""
+
+#: src/cli/perry-toml.md:579
+msgid "Sets `[ios].distribute = \"testflight\"` if not already configured"
+msgstr ""
+
+#: src/cli/perry-toml.md:580
+msgid "Sets `[android].distribute = \"playstore\"` if not already configured"
+msgstr ""
+
+#: src/cli/perry-toml.md:581
+msgid "Stores provisioning profiles as `~/.perry/{bundle_id}.mobileprovision`"
+msgstr ""
+
+#: src/cli/perry-toml.md:582
+msgid "Auto-exports `.p12` certificates from macOS Keychain when possible"
+msgstr ""
+
+#: src/cli/perry-toml.md:586
+msgid "CI/CD Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:588
+msgid ""
+"For CI environments, use environment variables instead of storing "
+"credentials in `perry.toml`:"
+msgstr ""
+
+#: src/cli/perry-toml.md:591
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr ""
+
+#: src/cli/perry-toml.md:593
+msgid "PERRY_LICENSE_KEY"
+msgstr ""
+
+#: src/cli/perry-toml.md:593
+msgid "${{ secrets.PERRY_LICENSE_KEY }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:594
+msgid "PERRY_APPLE_CERTIFICATE"
+msgstr ""
+
+#: src/cli/perry-toml.md:594
+msgid "${{ secrets.APPLE_CERTIFICATE }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:595
+msgid "PERRY_APPLE_CERTIFICATE_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:595
+msgid "${{ secrets.APPLE_CERT_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:596
+msgid "PERRY_APPLE_P8_KEY"
+msgstr ""
+
+#: src/cli/perry-toml.md:596
+msgid "${{ secrets.APPLE_P8_KEY }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:597
+msgid "PERRY_APPLE_KEY_ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:597
+msgid "${{ secrets.APPLE_KEY_ID }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:598
+msgid "PERRY_ANDROID_KEYSTORE"
+msgstr ""
+
+#: src/cli/perry-toml.md:598
+msgid "${{ secrets.ANDROID_KEYSTORE }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:599
+msgid "PERRY_ANDROID_KEYSTORE_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:599
+msgid "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:600
+msgid "PERRY_ANDROID_KEY_ALIAS"
+msgstr ""
+
+#: src/cli/perry-toml.md:600
+msgid "${{ secrets.ANDROID_KEY_ALIAS }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:601
+msgid "PERRY_ANDROID_KEY_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:601
+msgid "${{ secrets.ANDROID_KEY_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:604
+msgid "perry publish ios"
+msgstr ""
+
+#: src/cli/perry-toml.md:605
+msgid "perry publish android"
+msgstr ""
+
+#: src/cli/perry-toml.md:606
+msgid "perry publish macos"
+msgstr ""
+
+#: src/cli/perry-toml.md:609
+msgid "Keep `perry.toml` in version control with non-sensitive fields only:"
+msgstr ""
+
+#: src/cli/perry-toml.md:611
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"version = \"2.1.0\"\n"
+"build_number = 47\n"
+"bundle_id = \"com.example.myapp\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[ios]\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"distribute = \"appstore\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = \"26\"\n"
+"target_sdk = \"34\"\n"
+"distribute = \"playstore\"\n"
+"\n"
+"[macos]\n"
+"distribute = \"both\"\n"
+"category = \"public.app-category.productivity\"\n"
+"minimum_os = \"13.0\"\n"
+"\n"
+"[audit]\n"
+"fail_on = \"B\"\n"
+"```"
+msgstr ""
+
+#: src/contributing/architecture.md:3
+msgid ""
+"This is a brief overview for contributors. For detailed implementation "
+"notes, see the project's `CLAUDE.md`."
+msgstr ""
+
+#: src/contributing/architecture.md:5
+msgid "Compilation Pipeline"
+msgstr ""
+
+#: src/contributing/architecture.md:21
+msgid "Crate Map"
+msgstr ""
+
+#: src/contributing/architecture.md:23
+msgid "Crate"
+msgstr ""
+
+#: src/contributing/architecture.md:25
+msgid "`perry`"
+msgstr ""
+
+#: src/contributing/architecture.md:25
+msgid "CLI driver, command parsing, compilation orchestration"
+msgstr ""
+
+#: src/contributing/architecture.md:26
+msgid "`perry-parser`"
+msgstr ""
+
+#: src/contributing/architecture.md:26
+msgid "SWC wrapper for TypeScript parsing"
+msgstr ""
+
+#: src/contributing/architecture.md:27
+msgid "`perry-types`"
+msgstr ""
+
+#: src/contributing/architecture.md:27
+msgid "Type system definitions"
+msgstr ""
+
+#: src/contributing/architecture.md:28
+msgid "`perry-hir`"
+msgstr ""
+
+#: src/contributing/architecture.md:28
+msgid "HIR data structures (`ir.rs`) and AST→HIR lowering (`lower.rs`)"
+msgstr ""
+
+#: src/contributing/architecture.md:29
+msgid "`perry-transform`"
+msgstr ""
+
+#: src/contributing/architecture.md:29
+msgid "IR passes: function inlining, closure conversion, async lowering"
+msgstr ""
+
+#: src/contributing/architecture.md:30
+msgid "`perry-codegen-llvm`"
+msgstr ""
+
+#: src/contributing/architecture.md:30
+msgid "LLVM-based native code generation"
+msgstr ""
+
+#: src/contributing/architecture.md:31
+msgid "`perry-codegen-wasm`"
+msgstr ""
+
+#: src/contributing/architecture.md:31
+msgid ""
+"WebAssembly code generation for `--target web` / `--target wasm` (HIR → WASM"
+" bytecode + JS bridge)"
+msgstr ""
+
+#: src/contributing/architecture.md:32
+msgid "`perry-codegen-js`"
+msgstr ""
+
+#: src/contributing/architecture.md:32
+msgid ""
+"Legacy JavaScript code generator (still present for the JS minifier; the JS-"
+"emit `--target web` path was consolidated into `perry-codegen-wasm`)"
+msgstr ""
+
+#: src/contributing/architecture.md:33
+msgid "`perry-codegen-swiftui`"
+msgstr ""
+
+#: src/contributing/architecture.md:33
+msgid "SwiftUI code generation for WidgetKit extensions"
+msgstr ""
+
+#: src/contributing/architecture.md:34
+msgid "`perry-runtime`"
+msgstr ""
+
+#: src/contributing/architecture.md:34
+msgid ""
+"Runtime library: NaN-boxed values, GC, arena allocator, objects, arrays, "
+"strings"
+msgstr ""
+
+#: src/contributing/architecture.md:35
+msgid "`perry-stdlib`"
+msgstr ""
+
+#: src/contributing/architecture.md:35
+msgid "Node.js API implementations: mysql2, redis, fastify, bcrypt, etc."
+msgstr ""
+
+#: src/contributing/architecture.md:36
+msgid "`perry-ui`"
+msgstr ""
+
+#: src/contributing/architecture.md:36
+msgid "Shared UI types"
+msgstr ""
+
+#: src/contributing/architecture.md:37
+msgid "macOS UI (AppKit)"
+msgstr ""
+
+#: src/contributing/architecture.md:38
+msgid "iOS UI (UIKit)"
+msgstr ""
+
+#: src/contributing/architecture.md:39
+msgid "`perry-jsruntime`"
+msgstr ""
+
+#: src/contributing/architecture.md:39
+msgid "JavaScript interop via QuickJS"
+msgstr ""
+
+#: src/contributing/architecture.md:41
+msgid "Key Concepts"
+msgstr ""
+
+#: src/contributing/architecture.md:43
+msgid "NaN-Boxing"
+msgstr ""
+
+#: src/contributing/architecture.md:45
+msgid ""
+"All JavaScript values are represented as 64-bit NaN-boxed values. The upper "
+"16 bits encode the type tag:"
+msgstr ""
+
+#: src/contributing/architecture.md:47
+msgid "Tag"
+msgstr ""
+
+#: src/contributing/architecture.md:49
+msgid "`0x7FFF`"
+msgstr ""
+
+#: src/contributing/architecture.md:49
+msgid "String (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:50
+msgid "`0x7FFD`"
+msgstr ""
+
+#: src/contributing/architecture.md:50
+msgid "Pointer/Object (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:51
+msgid "`0x7FFE`"
+msgstr ""
+
+#: src/contributing/architecture.md:51
+msgid "Int32 (lower 32 bits = integer)"
+msgstr ""
+
+#: src/contributing/architecture.md:52
+msgid "`0x7FFA`"
+msgstr ""
+
+#: src/contributing/architecture.md:52
+msgid "BigInt (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:53
+msgid "Special constants"
+msgstr ""
+
+#: src/contributing/architecture.md:53
+msgid "undefined, null, true, false"
+msgstr ""
+
+#: src/contributing/architecture.md:54
+msgid "Any other"
+msgstr ""
+
+#: src/contributing/architecture.md:54
+msgid "Float64 (the full 64 bits)"
+msgstr ""
+
+#: src/contributing/architecture.md:58
+msgid ""
+"Mark-sweep GC with conservative stack scanning. Arena-allocated objects "
+"(arrays, objects) are found by linear block walking. Malloc-allocated "
+"objects (strings, closures, promises) are tracked in a thread-local Vec."
+msgstr ""
+
+#: src/contributing/architecture.md:60
+msgid "Handle-Based UI"
+msgstr ""
+
+#: src/contributing/architecture.md:62
+msgid ""
+"UI widgets are represented as small integer handles NaN-boxed with "
+"`POINTER_TAG`. Each handle maps to a native platform widget (NSButton, "
+"UILabel, GtkButton, etc.). Two dispatch tables route method calls and "
+"property accesses to the correct FFI function."
+msgstr ""
+
+#: src/contributing/architecture.md:64
+msgid "Source Code Organization"
+msgstr ""
+
+#: src/contributing/architecture.md:66
+msgid "The codegen crate is organized into focused modules:"
+msgstr ""
+
+#: src/contributing/architecture.md:83
+msgid "The HIR lowering was split into 8 modules:"
+msgstr ""
+
+#: src/contributing/architecture.md:99
+msgid "[Building from Source](building.md)"
+msgstr ""
+
+#: src/contributing/architecture.md:100
+msgid ""
+"See `CLAUDE.md` in the repository root for detailed implementation notes"
+msgstr ""
+
+#: src/contributing/building.md:5
+msgid "Rust toolchain (stable): [rustup.rs](https://rustup.rs/)"
+msgstr ""
+
+#: src/contributing/building.md:6
+msgid "System C compiler (`cc` on macOS/Linux, MSVC on Windows)"
+msgstr ""
+
+#: src/contributing/building.md:8
+msgid "Build"
+msgstr ""
+
+#: src/contributing/building.md:13
+msgid "# Build all crates (release mode recommended)\n"
+msgstr ""
+
+#: src/contributing/building.md:18
+msgid "The binary is at `target/release/perry`."
+msgstr ""
+
+#: src/contributing/building.md:20
+msgid "Build Specific Crates"
+msgstr ""
+
+#: src/contributing/building.md:23
+msgid "# Runtime only (must rebuild stdlib too!)\n"
+msgstr ""
+
+#: src/contributing/building.md:25
+msgid "# Codegen only\n"
+msgstr ""
+
+#: src/contributing/building.md:30
+msgid ""
+"**Important**: When rebuilding `perry-runtime`, you must also rebuild "
+"`perry-stdlib` because `libperry_stdlib.a` embeds perry-runtime as a static "
+"dependency."
+msgstr ""
+
+#: src/contributing/building.md:32
+msgid "Run Tests"
+msgstr ""
+
+#: src/contributing/building.md:35
+msgid "# All tests (exclude iOS crate on non-iOS host)\n"
+msgstr ""
+
+#: src/contributing/building.md:37
+msgid "# Specific crate\n"
+msgstr ""
+
+#: src/contributing/building.md:43
+msgid "Compile and Run TypeScript"
+msgstr ""
+
+#: src/contributing/building.md:46
+msgid "# Compile a TypeScript file\n"
+msgstr ""
+
+#: src/contributing/building.md:49
+msgid "# Debug: print HIR\n"
+msgstr ""
+
+#: src/contributing/building.md:54
+msgid "Development Workflow"
+msgstr ""
+
+#: src/contributing/building.md:56
+msgid "Make changes to the relevant crate"
+msgstr ""
+
+#: src/contributing/building.md:57
+msgid "`cargo build --release` to build"
+msgstr ""
+
+#: src/contributing/building.md:58
+msgid "`cargo test --workspace --exclude perry-ui-ios` to verify"
+msgstr ""
+
+#: src/contributing/building.md:59
+msgid ""
+"Test with a real TypeScript file: `cargo run --release -- test.ts -o test &&"
+" ./test`"
+msgstr ""
+
+#: src/contributing/building.md:88
+msgid "[Architecture](architecture.md) — Crate map and pipeline overview"
+msgstr ""
+
+#: src/contributing/building.md:89
+msgid "See `CLAUDE.md` for detailed implementation notes and pitfalls"
+msgstr ""

--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -1,0 +1,26617 @@
+
+msgid ""
+msgstr ""
+"Project-Id-Version: Perry Documentation\n"
+"POT-Creation-Date: 2026-05-02T21:12:49+02:00\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/SUMMARY.md:1
+msgid "Summary"
+msgstr ""
+
+#: src/SUMMARY.md:3 src/introduction.md:1
+msgid "Introduction"
+msgstr ""
+
+#: src/SUMMARY.md:7
+msgid "Getting Started"
+msgstr ""
+
+#: src/SUMMARY.md:9 src/getting-started/installation.md:1 src/ui/theming.md:5
+msgid "Installation"
+msgstr ""
+
+#: src/SUMMARY.md:10 src/getting-started/hello-world.md:1
+msgid "Hello World"
+msgstr ""
+
+#: src/SUMMARY.md:11 src/getting-started/first-app.md:1
+msgid "First Native App"
+msgstr ""
+
+#: src/SUMMARY.md:12 src/getting-started/project-config.md:1
+msgid "Project Configuration"
+msgstr ""
+
+#: src/SUMMARY.md:14
+msgid "Language"
+msgstr ""
+
+#: src/SUMMARY.md:16 src/platforms/wasm.md:39
+msgid "Supported Features"
+msgstr ""
+
+#: src/SUMMARY.md:17 src/language/type-system.md:1
+msgid "Type System"
+msgstr ""
+
+#: src/SUMMARY.md:18 src/language/limitations.md:1 src/platforms/tvos.md:156
+#: src/platforms/watchos.md:192 src/platforms/wasm.md:146
+msgid "Limitations"
+msgstr ""
+
+#: src/SUMMARY.md:20
+msgid "npm Packages"
+msgstr ""
+
+#: src/SUMMARY.md:22
+msgid "Porting Packages (experimental)"
+msgstr ""
+
+#: src/SUMMARY.md:24 src/getting-started/hello-world.md:97
+#: src/threading/overview.md:1
+msgid "Multi-Threading"
+msgstr ""
+
+#: src/SUMMARY.md:26 src/SUMMARY.md:33 src/SUMMARY.md:50 src/SUMMARY.md:66
+#: src/SUMMARY.md:76 src/SUMMARY.md:83 src/SUMMARY.md:87 src/SUMMARY.md:108
+msgid "Overview"
+msgstr ""
+
+#: src/SUMMARY.md:27 src/threading/parallel-map.md:1
+msgid "parallelMap"
+msgstr ""
+
+#: src/SUMMARY.md:28 src/threading/parallel-filter.md:1
+msgid "parallelFilter"
+msgstr ""
+
+#: src/SUMMARY.md:29 src/threading/spawn.md:1
+msgid "spawn"
+msgstr ""
+
+#: src/SUMMARY.md:31
+msgid "Native UI"
+msgstr ""
+
+#: src/SUMMARY.md:34 src/SUMMARY.md:95 src/SUMMARY.md:97 src/ui/widgets.md:1
+msgid "Widgets"
+msgstr ""
+
+#: src/SUMMARY.md:35 src/ui/overview.md:174 src/ui/layout.md:1
+#: src/widgets/components.md:41
+msgid "Layout"
+msgstr ""
+
+#: src/SUMMARY.md:36 src/ui/styling.md:1 src/platforms/linux.md:63
+msgid "Styling"
+msgstr ""
+
+#: src/SUMMARY.md:37 src/ui/state.md:1 src/platforms/watchos.md:105
+msgid "State Management"
+msgstr ""
+
+#: src/SUMMARY.md:38 src/ui/events.md:1 src/plugins/creating-plugins.md:104
+msgid "Events"
+msgstr ""
+
+#: src/SUMMARY.md:39 src/ui/canvas.md:1 src/platforms/macos.md:37
+#: src/platforms/android.md:38 src/platforms/windows.md:55
+#: src/platforms/linux.md:49
+msgid "Canvas"
+msgstr ""
+
+#: src/SUMMARY.md:40 src/ui/overview.md:175 src/ui/menus.md:1
+msgid "Menus"
+msgstr ""
+
+#: src/SUMMARY.md:41 src/ui/dialogs.md:1
+msgid "Dialogs"
+msgstr ""
+
+#: src/SUMMARY.md:42 src/ui/table.md:1 src/platforms/macos.md:36
+#: src/testing/geisterhand.md:93 src/testing/geisterhand.md:296
+msgid "Table"
+msgstr ""
+
+#: src/SUMMARY.md:43 src/ui/animation.md:1
+msgid "Animation"
+msgstr ""
+
+#: src/SUMMARY.md:44
+msgid "Multi-Window"
+msgstr ""
+
+#: src/SUMMARY.md:45 src/ui/theming.md:1
+msgid "Theming"
+msgstr ""
+
+#: src/SUMMARY.md:46 src/ui/camera.md:1
+msgid "Camera"
+msgstr ""
+
+#: src/SUMMARY.md:48 src/system/overview.md:21
+msgid "Platforms"
+msgstr ""
+
+#: src/SUMMARY.md:51 src/getting-started/installation.md:103
+#: src/ui/overview.md:170 src/ui/canvas.md:74 src/ui/menus.md:68
+#: src/ui/menus.md:111 src/ui/dialogs.md:108 src/ui/animation.md:64
+#: src/ui/multi-window.md:72 src/ui/multi-window.md:89
+#: src/ui/multi-window.md:100 src/ui/multi-window.md:116
+#: src/ui/multi-window.md:132 src/ui/multi-window.md:140
+#: src/platforms/overview.md:9 src/platforms/overview.md:67
+#: src/platforms/macos.md:1 src/i18n/overview.md:89 src/updater/overview.md:257
+#: src/system/preferences.md:34 src/system/keychain.md:25
+#: src/system/notifications.md:62 src/system/audio.md:61 src/system/media.md:86
+#: src/system/other.md:20 src/system/other.md:37
+#: src/plugins/native-extensions.md:275 src/plugins/appstore-review.md:89
+#: src/testing/geisterhand.md:259 src/testing/geisterhand.md:331
+msgid "macOS"
+msgstr ""
+
+#: src/SUMMARY.md:52 src/ui/overview.md:170 src/ui/canvas.md:75
+#: src/ui/menus.md:112 src/ui/dialogs.md:108 src/ui/animation.md:65
+#: src/platforms/overview.md:10 src/platforms/overview.md:67
+#: src/platforms/ios.md:1 src/platforms/tvos.md:170 src/i18n/overview.md:90
+#: src/system/preferences.md:35 src/system/keychain.md:26
+#: src/system/notifications.md:63 src/system/audio.md:62 src/system/media.md:87
+#: src/system/other.md:21 src/system/other.md:38 src/widgets/platforms.md:11
+#: src/widgets/platforms.md:20 src/widgets/platforms.md:39
+#: src/widgets/platforms.md:63 src/plugins/native-extensions.md:273
+#: src/plugins/appstore-review.md:73 src/testing/geisterhand.md:260
+msgid "iOS"
+msgstr ""
+
+#: src/SUMMARY.md:53 src/platforms/overview.md:11 src/platforms/overview.md:67
+#: src/platforms/visionos.md:1 src/system/media.md:89
+msgid "visionOS"
+msgstr ""
+
+#: src/SUMMARY.md:54 src/platforms/overview.md:12 src/platforms/overview.md:67
+#: src/platforms/tvos.md:1 src/platforms/tvos.md:170 src/system/media.md:88
+msgid "tvOS"
+msgstr ""
+
+#: src/SUMMARY.md:55 src/platforms/overview.md:13 src/platforms/overview.md:67
+#: src/platforms/watchos.md:1 src/system/media.md:93
+#: src/widgets/platforms.md:14 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:49 src/widgets/platforms.md:79
+msgid "watchOS"
+msgstr ""
+
+#: src/SUMMARY.md:56 src/ui/canvas.md:78 src/ui/animation.md:66
+#: src/platforms/overview.md:14 src/platforms/overview.md:67
+#: src/platforms/android.md:1 src/i18n/overview.md:91 src/i18n/overview.md:104
+#: src/system/preferences.md:36 src/system/keychain.md:27
+#: src/system/notifications.md:64 src/system/audio.md:63 src/system/media.md:90
+#: src/system/other.md:22 src/system/other.md:39 src/widgets/platforms.md:13
+#: src/widgets/platforms.md:20 src/widgets/platforms.md:44
+#: src/widgets/platforms.md:71 src/plugins/native-extensions.md:276
+#: src/plugins/appstore-review.md:102 src/testing/geisterhand.md:261
+#: src/cli/flags.md:27 src/cli/perry-toml.md:501
+msgid "Android"
+msgstr ""
+
+#: src/SUMMARY.md:57 src/platforms/harmonyos.md:1
+msgid "HarmonyOS NEXT"
+msgstr ""
+
+#: src/SUMMARY.md:58 src/getting-started/installation.md:121
+#: src/ui/overview.md:170 src/ui/styling.md:372 src/ui/canvas.md:77
+#: src/ui/menus.md:113 src/ui/dialogs.md:108 src/ui/animation.md:67
+#: src/ui/multi-window.md:73 src/ui/multi-window.md:90
+#: src/ui/multi-window.md:101 src/ui/multi-window.md:117
+#: src/ui/multi-window.md:133 src/ui/multi-window.md:141
+#: src/platforms/overview.md:15 src/platforms/overview.md:67
+#: src/platforms/windows.md:1 src/i18n/overview.md:92
+#: src/updater/overview.md:258 src/system/preferences.md:37
+#: src/system/keychain.md:28 src/system/notifications.md:65
+#: src/system/audio.md:65 src/system/media.md:92 src/system/other.md:23
+#: src/system/other.md:40 src/testing/geisterhand.md:263
+#: src/testing/geisterhand.md:392 src/cli/flags.md:36
+msgid "Windows"
+msgstr ""
+
+#: src/SUMMARY.md:59 src/platforms/windows-7.md:1
+msgid "Windows 7 Compatibility"
+msgstr ""
+
+#: src/SUMMARY.md:60 src/platforms/linux.md:1 src/testing/geisterhand.md:262
+#: src/testing/geisterhand.md:379
+msgid "Linux (GTK4)"
+msgstr ""
+
+#: src/SUMMARY.md:61 src/ui/overview.md:170 src/ui/canvas.md:72
+#: src/ui/menus.md:115 src/ui/dialogs.md:108 src/ui/animation.md:69
+#: src/ui/multi-window.md:143 src/platforms/web.md:1
+#: src/system/preferences.md:39 src/system/keychain.md:30
+#: src/system/notifications.md:67 src/system/audio.md:66 src/system/media.md:95
+#: src/system/other.md:25 src/system/other.md:42 src/cli/flags.md:35
+msgid "Web"
+msgstr ""
+
+#: src/SUMMARY.md:62 src/cli/flags.md:34
+msgid "WebAssembly"
+msgstr ""
+
+#: src/SUMMARY.md:64
+msgid "Standard Library"
+msgstr ""
+
+#: src/SUMMARY.md:67 src/stdlib/fs.md:1
+msgid "File System"
+msgstr ""
+
+#: src/SUMMARY.md:68 src/stdlib/http.md:1
+msgid "HTTP & Networking"
+msgstr ""
+
+#: src/SUMMARY.md:69 src/stdlib/overview.md:22 src/stdlib/database.md:1
+msgid "Databases"
+msgstr ""
+
+#: src/SUMMARY.md:70 src/stdlib/overview.md:29 src/stdlib/crypto.md:1
+msgid "Cryptography"
+msgstr ""
+
+#: src/SUMMARY.md:71 src/stdlib/overview.md:36 src/stdlib/utilities.md:1
+#: src/cli/perry-toml.md:231
+msgid "Utilities"
+msgstr ""
+
+#: src/SUMMARY.md:72 src/stdlib/other.md:1
+msgid "Other Modules"
+msgstr ""
+
+#: src/SUMMARY.md:74
+msgid "Internationalization"
+msgstr ""
+
+#: src/SUMMARY.md:77 src/i18n/interpolation.md:1
+msgid "Interpolation & Plurals"
+msgstr ""
+
+#: src/SUMMARY.md:78
+msgid "Formatting"
+msgstr ""
+
+#: src/SUMMARY.md:79
+msgid "CLI Tools"
+msgstr ""
+
+#: src/SUMMARY.md:81 src/updater/overview.md:1
+msgid "Auto-Update"
+msgstr ""
+
+#: src/SUMMARY.md:85 src/platforms/overview.md:74 src/platforms/macos.md:75
+msgid "System APIs"
+msgstr ""
+
+#: src/SUMMARY.md:88 src/system/preferences.md:1
+msgid "Preferences"
+msgstr ""
+
+#: src/SUMMARY.md:89 src/system/keychain.md:1
+msgid "Keychain"
+msgstr ""
+
+#: src/SUMMARY.md:90 src/system/notifications.md:1
+msgid "Notifications"
+msgstr ""
+
+#: src/SUMMARY.md:91 src/system/audio.md:1
+msgid "Audio Capture"
+msgstr ""
+
+#: src/SUMMARY.md:92 src/system/media.md:1
+msgid "Media Playback"
+msgstr ""
+
+#: src/SUMMARY.md:93 src/ui/menus.md:68 src/stdlib/overview.md:50
+msgid "Other"
+msgstr ""
+
+#: src/SUMMARY.md:98 src/widgets/creating-widgets.md:1
+msgid "Creating Widgets"
+msgstr ""
+
+#: src/SUMMARY.md:99
+msgid "Components & Modifiers"
+msgstr ""
+
+#: src/SUMMARY.md:100 src/platforms/visionos.md:35 src/platforms/tvos.md:123
+#: src/platforms/watchos.md:149 src/widgets/watchos.md:77
+#: src/plugins/creating-plugins.md:98 src/plugins/hooks-and-events.md:115
+msgid "Configuration"
+msgstr ""
+
+#: src/SUMMARY.md:101
+msgid "Data Fetching"
+msgstr ""
+
+#: src/SUMMARY.md:102 src/widgets/platforms.md:1
+msgid "Cross-Platform Reference"
+msgstr ""
+
+#: src/SUMMARY.md:103 src/widgets/watchos.md:1
+msgid "watchOS Complications"
+msgstr ""
+
+#: src/SUMMARY.md:104 src/widgets/wearos.md:1
+msgid "Wear OS Tiles"
+msgstr ""
+
+#: src/SUMMARY.md:106
+msgid "Plugins"
+msgstr ""
+
+#: src/SUMMARY.md:109 src/plugins/creating-plugins.md:1
+msgid "Creating Plugins"
+msgstr ""
+
+#: src/SUMMARY.md:110 src/plugins/hooks-and-events.md:1
+msgid "Hooks & Events"
+msgstr ""
+
+#: src/SUMMARY.md:111 src/plugins/overview.md:90
+#: src/plugins/native-extensions.md:1
+msgid "Native Extensions"
+msgstr ""
+
+#: src/SUMMARY.md:112 src/plugins/appstore-review.md:1
+msgid "App Store Review"
+msgstr ""
+
+#: src/SUMMARY.md:114
+msgid "Testing"
+msgstr ""
+
+#: src/SUMMARY.md:116
+msgid "Geisterhand (UI Fuzzer)"
+msgstr ""
+
+#: src/SUMMARY.md:118
+msgid "CLI Reference"
+msgstr ""
+
+#: src/SUMMARY.md:120
+msgid "Commands"
+msgstr ""
+
+#: src/SUMMARY.md:121 src/cli/flags.md:1
+msgid "Compiler Flags"
+msgstr ""
+
+#: src/SUMMARY.md:122 src/cli/perry-toml.md:1
+msgid "perry.toml Reference"
+msgstr ""
+
+#: src/SUMMARY.md:126
+msgid "Contributing"
+msgstr ""
+
+#: src/SUMMARY.md:128 src/platforms/harmonyos.md:5
+#: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
+msgid "Architecture"
+msgstr ""
+
+#: src/SUMMARY.md:129 src/contributing/building.md:1
+msgid "Building from Source"
+msgstr ""
+
+#: src/introduction.md:3
+msgid ""
+"Perry is a native TypeScript compiler that compiles TypeScript source code "
+"directly to native executables. No JavaScript runtime, no JIT warmup, no V8 "
+"— your TypeScript compiles to a real binary."
+msgstr ""
+
+#: src/introduction.md:5
+msgid ""
+"```typescript\n"
+"// demonstrates: the one-liner hello shown on the docs landing page\n"
+"// docs: docs/src/introduction.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"console.log(\"Hello from Perry!\")\n"
+"```"
+msgstr ""
+
+#: src/introduction.md:20
+msgid "Why Perry?"
+msgstr ""
+
+#: src/introduction.md:22
+msgid ""
+"**Native performance** — Compiles to machine code via LLVM. Integer-heavy "
+"code like Fibonacci runs 2x faster than Node.js."
+msgstr ""
+
+#: src/introduction.md:23
+msgid ""
+"**Real multi-threading** — `parallelMap` and `spawn` give you actual OS "
+"threads with compile-time safety. No isolates, no message passing overhead. "
+"[Something no JS runtime can do](threading/overview.md)."
+msgstr ""
+
+#: src/introduction.md:24
+msgid ""
+"**Small binaries** — A hello world is ~300KB. Perry detects what runtime "
+"features you use and only links what's needed."
+msgstr ""
+
+#: src/introduction.md:25
+msgid ""
+"**Native UI** — Build desktop and mobile apps with declarative TypeScript "
+"that compiles to real AppKit, UIKit, GTK4, Win32, or DOM widgets."
+msgstr ""
+
+#: src/introduction.md:26
+msgid ""
+"**7 targets** — macOS, iOS, Android, Windows, Linux, Web, and WebAssembly "
+"from the same source code."
+msgstr ""
+
+#: src/introduction.md:27
+msgid ""
+"**Familiar ecosystem** — Use npm packages like `fastify`, `mysql2`, `redis`, "
+"`bcrypt`, `lodash`, and more — compiled natively."
+msgstr ""
+
+#: src/introduction.md:28
+msgid ""
+"**Zero config** — Point Perry at a `.ts` file and get a binary. No "
+"`tsconfig.json` required."
+msgstr ""
+
+#: src/introduction.md:30
+msgid "What Perry Compiles"
+msgstr ""
+
+#: src/introduction.md:32
+msgid "Perry supports a practical subset of TypeScript:"
+msgstr ""
+
+#: src/introduction.md:34
+msgid "Variables, functions, classes, enums, interfaces"
+msgstr ""
+
+#: src/introduction.md:35
+msgid "Async/await, closures, generators"
+msgstr ""
+
+#: src/introduction.md:36
+msgid "Destructuring, spread, template literals"
+msgstr ""
+
+#: src/introduction.md:37
+msgid "Arrays, Maps, Sets, typed arrays"
+msgstr ""
+
+#: src/introduction.md:38
+msgid "Regular expressions, JSON, Promises"
+msgstr ""
+
+#: src/introduction.md:39
+msgid "Module imports/exports"
+msgstr ""
+
+#: src/introduction.md:40
+msgid "Generic type erasure"
+msgstr ""
+
+#: src/introduction.md:42
+msgid ""
+"See [Supported Features](language/supported-features.md) for the complete "
+"list."
+msgstr ""
+
+#: src/introduction.md:44
+msgid "Quick Example: Native App"
+msgstr ""
+
+#: src/introduction.md:46 src/getting-started/first-app.md:10
+msgid ""
+"```typescript\n"
+"// demonstrates: minimal stateful UI — label + increment button\n"
+"// docs: docs/src/ui/state.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, visionos-simulator, tvos-simulator, "
+"watchos-simulator, android, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Button, State } from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"App({\n"
+"    title: \"Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Count: ${count.value}`),\n"
+"        Button(\"Increment\", () => count.set(count.value + 1)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/introduction.md:69
+msgid "# Opens a native macOS/Windows/Linux window\n"
+msgstr ""
+
+#: src/introduction.md:72
+msgid ""
+"This produces a ~3MB native app with real platform widgets — no Electron, no "
+"WebView."
+msgstr ""
+
+#: src/introduction.md:74 src/getting-started/first-app.md:41
+#: src/threading/overview.md:286 src/threading/parallel-map.md:18
+#: src/threading/parallel-filter.md:18 src/platforms/watchos.md:127
+#: src/platforms/wasm.md:29 src/stdlib/overview.md:5 src/i18n/overview.md:78
+#: src/widgets/overview.md:34 src/plugins/overview.md:7
+msgid "How It Works"
+msgstr ""
+
+#: src/introduction.md:87
+msgid ""
+"Perry uses [SWC](https://swc.rs/) for TypeScript parsing and "
+"[LLVM](https://llvm.org/) for native code generation. Types are erased at "
+"compile time (like `tsc`), and values are represented at runtime using "
+"NaN-boxing for efficient 64-bit tagged values."
+msgstr ""
+
+#: src/introduction.md:89 src/getting-started/hello-world.md:152
+#: src/getting-started/first-app.md:184
+#: src/getting-started/project-config.md:201
+#: src/language/supported-features.md:600 src/language/type-system.md:149
+#: src/language/limitations.md:182 src/threading/overview.md:312
+#: src/ui/overview.md:179 src/ui/widgets.md:396 src/ui/layout.md:367
+#: src/ui/styling.md:377 src/ui/state.md:225 src/ui/events.md:167
+#: src/ui/canvas.md:80 src/ui/menus.md:119 src/ui/dialogs.md:166
+#: src/ui/table.md:107 src/ui/animation.md:71 src/ui/multi-window.md:149
+#: src/ui/theming.md:166 src/ui/camera.md:143 src/platforms/overview.md:78
+#: src/platforms/macos.md:86 src/platforms/ios.md:137 src/platforms/tvos.md:180
+#: src/platforms/watchos.md:213 src/platforms/android.md:92
+#: src/platforms/windows.md:69 src/platforms/linux.md:81
+#: src/platforms/web.md:21 src/platforms/wasm.md:191 src/stdlib/overview.md:100
+#: src/stdlib/fs.md:88 src/stdlib/http.md:93 src/stdlib/database.md:107
+#: src/stdlib/crypto.md:87 src/stdlib/utilities.md:104 src/stdlib/other.md:184
+#: src/i18n/overview.md:107 src/updater/overview.md:433
+#: src/system/overview.md:71 src/system/preferences.md:44
+#: src/system/keychain.md:35 src/system/notifications.md:72
+#: src/system/audio.md:71 src/system/other.md:68 src/widgets/overview.md:60
+#: src/widgets/creating-widgets.md:249 src/widgets/components.md:270
+#: src/widgets/configuration.md:139 src/widgets/data-fetching.md:203
+#: src/plugins/overview.md:96 src/plugins/creating-plugins.md:111
+#: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:297
+#: src/plugins/appstore-review.md:192 src/cli/commands.md:320
+#: src/cli/flags.md:176 src/contributing/architecture.md:97
+#: src/contributing/building.md:86
+msgid "Next Steps"
+msgstr ""
+
+#: src/introduction.md:91
+msgid "[Install Perry](getting-started/installation.md)"
+msgstr ""
+
+#: src/introduction.md:92
+msgid "[Write your first program](getting-started/hello-world.md)"
+msgstr ""
+
+#: src/introduction.md:93
+msgid "[Build a native app](getting-started/first-app.md)"
+msgstr ""
+
+#: src/getting-started/installation.md:3 src/platforms/visionos.md:7
+#: src/contributing/building.md:3
+msgid "Prerequisites"
+msgstr ""
+
+#: src/getting-started/installation.md:5
+msgid ""
+"Perry compiles TypeScript to native binaries by linking with your system's C "
+"toolchain, so every install path needs a linker:"
+msgstr ""
+
+#: src/getting-started/installation.md:7
+msgid "**macOS**: Xcode Command Line Tools (`xcode-select --install`)"
+msgstr ""
+
+#: src/getting-started/installation.md:8
+msgid ""
+"**Linux**: `gcc` or `clang` (`apt install build-essential` on Debian/Ubuntu, "
+"`apk add build-base` on Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:9
+msgid ""
+"**Windows**: LLVM (`winget install LLVM.LLVM`) + `perry setup windows` "
+"(lightweight, ~1.5 GB, no Visual Studio needed), or MSVC Build Tools with "
+"the \"Desktop development with C++\" workload — see the [Windows platform "
+"guide](../platforms/windows.md) for both options"
+msgstr ""
+
+#: src/getting-started/installation.md:11
+msgid ""
+"The source install additionally needs the **Rust toolchain** via "
+"[rustup](https://rustup.rs/)."
+msgstr ""
+
+#: src/getting-started/installation.md:13
+msgid "Install Perry"
+msgstr ""
+
+#: src/getting-started/installation.md:15
+msgid "npm / npx (recommended — any platform)"
+msgstr ""
+
+#: src/getting-started/installation.md:17
+msgid ""
+"Perry ships as a prebuilt-binary npm package. This is the fastest way to get "
+"started and the only path that covers all seven supported platforms (macOS "
+"arm64/x64, Linux x64/arm64 glibc + musl, Windows x64) with a single command:"
+msgstr ""
+
+#: src/getting-started/installation.md:20
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
+msgstr ""
+
+#: src/getting-started/installation.md:23
+msgid "# Global\n"
+msgstr ""
+
+#: src/getting-started/installation.md:27
+msgid "# Zero-install, one-shot\n"
+msgstr ""
+
+#: src/getting-started/installation.md:32
+msgid ""
+"[`@perryts/perry`](https://www.npmjs.com/package/@perryts/perry) is a thin "
+"launcher; npm automatically picks the matching prebuilt via "
+"`optionalDependencies` (`@perryts/perry-darwin-arm64`, "
+"`@perryts/perry-linux-x64-musl`, etc.) based on your `os` / `cpu` / `libc`. "
+"Requires Node.js ≥ 16."
+msgstr ""
+
+#: src/getting-started/installation.md:34 src/ui/styling.md:368
+#: src/ui/canvas.md:70 src/ui/menus.md:109 src/ui/animation.md:62
+#: src/ui/multi-window.md:70 src/ui/multi-window.md:87
+#: src/ui/multi-window.md:98 src/ui/multi-window.md:114
+#: src/ui/multi-window.md:130 src/ui/multi-window.md:138
+#: src/platforms/overview.md:7 src/i18n/overview.md:87 src/i18n/overview.md:101
+#: src/updater/overview.md:255 src/system/preferences.md:32
+#: src/system/keychain.md:23 src/system/notifications.md:60
+#: src/system/audio.md:59 src/system/media.md:84 src/system/other.md:18
+#: src/system/other.md:35 src/widgets/platforms.md:9
+#: src/plugins/native-extensions.md:271 src/testing/geisterhand.md:257
+#: src/cli/flags.md:20
+msgid "Platform"
+msgstr ""
+
+#: src/getting-started/installation.md:34
+msgid "Prebuilt package"
+msgstr ""
+
+#: src/getting-started/installation.md:36
+msgid "macOS arm64 (Apple Silicon)"
+msgstr ""
+
+#: src/getting-started/installation.md:36
+msgid "`@perryts/perry-darwin-arm64`"
+msgstr ""
+
+#: src/getting-started/installation.md:37
+msgid "macOS x64 (Intel)"
+msgstr ""
+
+#: src/getting-started/installation.md:37
+msgid "`@perryts/perry-darwin-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:38
+msgid "Linux x64 (glibc)"
+msgstr ""
+
+#: src/getting-started/installation.md:38
+msgid "`@perryts/perry-linux-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:39
+msgid "Linux arm64 (glibc)"
+msgstr ""
+
+#: src/getting-started/installation.md:39
+msgid "`@perryts/perry-linux-arm64`"
+msgstr ""
+
+#: src/getting-started/installation.md:40
+msgid "Linux x64 (musl / Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:40
+msgid "`@perryts/perry-linux-x64-musl`"
+msgstr ""
+
+#: src/getting-started/installation.md:41
+msgid "Linux arm64 (musl / Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:41
+msgid "`@perryts/perry-linux-arm64-musl`"
+msgstr ""
+
+#: src/getting-started/installation.md:42
+msgid "Windows x64"
+msgstr ""
+
+#: src/getting-started/installation.md:42
+msgid "`@perryts/perry-win32-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:44
+msgid "Homebrew (macOS)"
+msgstr ""
+
+#: src/getting-started/installation.md:50
+msgid "winget (Windows)"
+msgstr ""
+
+#: src/getting-started/installation.md:56
+msgid "APT (Debian / Ubuntu)"
+msgstr ""
+
+#: src/getting-started/installation.md:60
+msgid ""
+"\"deb [signed-by=/usr/share/keyrings/perry.gpg] "
+"https://perryts.github.io/perry-apt stable main\""
+msgstr ""
+
+#: src/getting-started/installation.md:64
+msgid "From Source"
+msgstr ""
+
+#: src/getting-started/installation.md:72
+msgid "The binary is at `target/release/perry`. Add it to your PATH:"
+msgstr ""
+
+#: src/getting-started/installation.md:75
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
+msgstr ""
+
+#: src/getting-started/installation.md:76
+msgid "\"/path/to/perry/target/release:$PATH\""
+msgstr ""
+
+#: src/getting-started/installation.md:79
+msgid "Self-Update"
+msgstr ""
+
+#: src/getting-started/installation.md:81
+msgid "Once installed, Perry can update itself:"
+msgstr ""
+
+#: src/getting-started/installation.md:87
+msgid "This downloads the latest release and atomically replaces the binary."
+msgstr ""
+
+#: src/getting-started/installation.md:89
+msgid "Verify Installation"
+msgstr ""
+
+#: src/getting-started/installation.md:95
+msgid ""
+"This checks your installation, shows the current version, and reports if an "
+"update is available."
+msgstr ""
+
+#: src/getting-started/installation.md:101
+msgid "Platform-Specific Setup"
+msgstr ""
+
+#: src/getting-started/installation.md:105
+msgid ""
+"No additional setup needed. Perry uses the system `cc` linker and AppKit for "
+"UI apps."
+msgstr ""
+
+#: src/getting-started/installation.md:107
+msgid ""
+"For iOS development, install Xcode (not just Command Line Tools) for the iOS "
+"SDK and simulator."
+msgstr ""
+
+#: src/getting-started/installation.md:109 src/ui/overview.md:170
+#: src/ui/canvas.md:76 src/ui/menus.md:114 src/ui/dialogs.md:108
+#: src/ui/animation.md:68 src/ui/multi-window.md:74 src/ui/multi-window.md:91
+#: src/ui/multi-window.md:102 src/ui/multi-window.md:118
+#: src/ui/multi-window.md:134 src/ui/multi-window.md:142
+#: src/platforms/overview.md:16 src/platforms/overview.md:67
+#: src/i18n/overview.md:93 src/updater/overview.md:259
+#: src/system/preferences.md:38 src/system/keychain.md:29
+#: src/system/notifications.md:66 src/system/audio.md:64 src/system/other.md:24
+#: src/system/other.md:41 src/cli/flags.md:37
+msgid "Linux"
+msgstr ""
+
+#: src/getting-started/installation.md:111
+msgid "Install GTK4 development libraries for UI apps:"
+msgstr ""
+
+#: src/getting-started/installation.md:114 src/platforms/linux.md:9
+#: src/testing/geisterhand.md:384
+msgid "# Ubuntu/Debian\n"
+msgstr ""
+
+#: src/getting-started/installation.md:116 src/platforms/linux.md:12
+msgid "# Fedora\n"
+msgstr ""
+
+#: src/getting-started/installation.md:123
+msgid "Two toolchain options — pick one. Both produce identical binaries."
+msgstr ""
+
+#: src/getting-started/installation.md:125
+msgid "**Lightweight (recommended, ~1.5 GB, no Visual Studio):**"
+msgstr ""
+
+#: src/getting-started/installation.md:132
+msgid ""
+"`perry setup windows` downloads the Microsoft CRT + Windows SDK libraries "
+"via xwin after prompting for license acceptance. Pass `--accept-license` to "
+"skip the prompt in CI."
+msgstr ""
+
+#: src/getting-started/installation.md:134
+msgid "**MSVC Build Tools (~8 GB):**"
+msgstr ""
+
+#: src/getting-started/installation.md:136
+msgid ""
+"Install Visual Studio Build Tools with the \"Desktop development with C++\" "
+"workload — via the Visual Studio Installer, or:"
+msgstr ""
+
+#: src/getting-started/installation.md:138 src/platforms/windows.md:25
+msgid ""
+"```powershell\n"
+"winget install Microsoft.VisualStudio.2022.BuildTools --override `\n"
+"  \"--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools "
+"--includeRecommended\"\n"
+"```"
+msgstr ""
+
+#: src/getting-started/installation.md:143
+msgid ""
+"Run `perry doctor` to verify the toolchain. See the [Windows platform "
+"guide](../platforms/windows.md) for details."
+msgstr ""
+
+#: src/getting-started/installation.md:145
+msgid "What's Next"
+msgstr ""
+
+#: src/getting-started/installation.md:147
+msgid "[Write your first program](hello-world.md)"
+msgstr ""
+
+#: src/getting-started/installation.md:148
+msgid "[Build a native app](first-app.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:3
+msgid "Your First Program"
+msgstr ""
+
+#: src/getting-started/hello-world.md:5
+msgid "Create a file called `hello.ts`:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:7
+msgid ""
+"```typescript\n"
+"// demonstrates: the minimal Perry program in the docs\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"console.log(\"Hello, Perry!\")\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:16
+msgid "Compile and run it:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:23 src/threading/spawn.md:46
+#: src/widgets/wearos.md:64
+msgid "Output:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:29
+msgid ""
+"That's it. Perry compiled your TypeScript to a native executable — no "
+"Node.js, no bundler, no runtime."
+msgstr ""
+
+#: src/getting-started/hello-world.md:31
+msgid "A Slightly Bigger Example"
+msgstr ""
+
+#: src/getting-started/hello-world.md:33
+msgid ""
+"```typescript\n"
+"// demonstrates: recursive fib as a perf-vs-node talking point\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"function fibonacci(n: number): number {\n"
+"    if (n <= 1) return n\n"
+"    return fibonacci(n - 1) + fibonacci(n - 2)\n"
+"}\n"
+"\n"
+"const start = Date.now()\n"
+"const result = fibonacci(35)\n"
+"const elapsed = Date.now() - start\n"
+"\n"
+"console.log(`fibonacci(35) = ${result}`)\n"
+"console.log(`Completed in ${elapsed}ms`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:57
+msgid ""
+"This runs about 2x faster than Node.js because Perry compiles to native "
+"machine code with integer specialization."
+msgstr ""
+
+#: src/getting-started/hello-world.md:59
+msgid "Using Variables and Functions"
+msgstr ""
+
+#: src/getting-started/hello-world.md:61
+msgid ""
+"```typescript\n"
+"const name: string = \"World\"\n"
+"const items: number[] = [1, 2, 3, 4, 5]\n"
+"\n"
+"const doubled = items.map((x) => x * 2)\n"
+"const sum = doubled.reduce((acc, x) => acc + x, 0)\n"
+"\n"
+"console.log(`Hello, ${name}!`)\n"
+"console.log(`Sum of doubled: ${sum}`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:72
+msgid "Async Code"
+msgstr ""
+
+#: src/getting-started/hello-world.md:74
+msgid ""
+"```typescript\n"
+"// demonstrates: async/await fetch shown in hello-world.md\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// run: false\n"
+"\n"
+"async function fetchData(): Promise<string> {\n"
+"    const response = await fetch(\"https://httpbin.org/get\")\n"
+"    const data = await response.json() as { origin: string }\n"
+"    return data.origin\n"
+"}\n"
+"\n"
+"const ip = await fetchData()\n"
+"console.log(`Your IP: ${ip}`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:95
+msgid "Perry compiles async/await to a native async runtime backed by Tokio."
+msgstr ""
+
+#: src/getting-started/hello-world.md:99
+msgid ""
+"Perry can do something no JavaScript runtime can — run your code on multiple "
+"CPU cores:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:101
+msgid ""
+"```typescript\n"
+"// demonstrates: parallelMap + spawn shown in hello-world.md\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"import { parallelMap, parallelFilter, spawn } from \"perry/thread\"\n"
+"\n"
+"const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"// Process all elements across all CPU cores\n"
+"const doubled = parallelMap(data, (x: number) => x * 2)\n"
+"console.log(doubled) // [2, 4, 6, 8, 10, 12, 14, 16]\n"
+"\n"
+"// Run heavy work in the background\n"
+"const result = await spawn(() => {\n"
+"    let sum = 0\n"
+"    for (let i = 0; i < 100_000_000; i++) sum += i\n"
+"    return sum\n"
+"})\n"
+"console.log(result)\n"
+"\n"
+"// parallelFilter is also available for the lift-and-parallelize case:\n"
+"const evens = parallelFilter(data, (x: number) => x % 2 === 0)\n"
+"console.log(evens)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:127
+msgid ""
+"This is real OS-level parallelism, not web workers or separate isolates. See "
+"[Multi-Threading](../threading/overview.md) for details."
+msgstr ""
+
+#: src/getting-started/hello-world.md:129
+msgid "What the Compiler Produces"
+msgstr ""
+
+#: src/getting-started/hello-world.md:131
+msgid "When you run `perry file.ts -o output`, Perry:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:133
+msgid "Parses your TypeScript with SWC"
+msgstr ""
+
+#: src/getting-started/hello-world.md:134
+msgid "Lowers the AST to an intermediate representation (HIR)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:135
+msgid "Applies optimizations (inlining, closure conversion, etc.)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:136
+msgid "Generates native machine code with LLVM"
+msgstr ""
+
+#: src/getting-started/hello-world.md:137
+msgid "Links with your system's C compiler"
+msgstr ""
+
+#: src/getting-started/hello-world.md:139
+msgid "The result is a standalone executable with no external dependencies."
+msgstr ""
+
+#: src/getting-started/hello-world.md:141
+#: src/getting-started/hello-world.md:143 src/stdlib/overview.md:66
+#: src/stdlib/overview.md:70
+msgid "Binary Size"
+msgstr ""
+
+#: src/getting-started/hello-world.md:143
+msgid "Program"
+msgstr ""
+
+#: src/getting-started/hello-world.md:145
+msgid "Hello world"
+msgstr ""
+
+#: src/getting-started/hello-world.md:145 src/stdlib/overview.md:72
+msgid "~300KB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:146
+msgid "CLI with fs/path"
+msgstr ""
+
+#: src/getting-started/hello-world.md:146
+#: src/getting-started/hello-world.md:147 src/stdlib/overview.md:73
+msgid "~3MB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:147
+msgid "UI app"
+msgstr ""
+
+#: src/getting-started/hello-world.md:148
+msgid "Full app with stdlib"
+msgstr ""
+
+#: src/getting-started/hello-world.md:148 src/stdlib/overview.md:74
+msgid "~48MB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:150
+msgid ""
+"Perry automatically detects which runtime features you use and only links "
+"what's needed."
+msgstr ""
+
+#: src/getting-started/hello-world.md:154
+msgid "[Build a native UI app](first-app.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:155
+msgid "[Configure your project](project-config.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:156
+msgid ""
+"[Explore supported TypeScript features](../language/supported-features.md)"
+msgstr ""
+
+#: src/getting-started/first-app.md:3
+msgid ""
+"Perry compiles declarative TypeScript UI code to native platform widgets. No "
+"Electron, no WebView — real AppKit on macOS, UIKit on iOS, GTK4 on Linux, "
+"Win32 on Windows. Every example on this page is a real source file under "
+"`docs/examples/` that CI compiles and runs on every PR."
+msgstr ""
+
+#: src/getting-started/first-app.md:8
+msgid "A Simple Counter"
+msgstr ""
+
+#: src/getting-started/first-app.md:31
+msgid "Compile and run:"
+msgstr ""
+
+#: src/getting-started/first-app.md:38
+msgid ""
+"A native window opens with a label and two buttons. Clicking \"Increment\" "
+"updates the count in real-time."
+msgstr ""
+
+#: src/getting-started/first-app.md:43
+msgid ""
+"**`App({ title, width, height, body })`** — Creates a native application "
+"window. `body` is the root widget."
+msgstr ""
+
+#: src/getting-started/first-app.md:44
+msgid ""
+"**`State(initialValue)`** — Creates reactive state. `.value` reads, "
+"`.set(v)` writes and triggers UI updates."
+msgstr ""
+
+#: src/getting-started/first-app.md:45
+msgid ""
+"**`VStack(spacing, [...])`** — Vertical stack layout (like SwiftUI's VStack "
+"or CSS flexbox column). The first arg is the gap in points between children."
+msgstr ""
+
+#: src/getting-started/first-app.md:46
+msgid ""
+"**`Text(string)`** — A text label. Template literals referencing "
+"`${state.value}` bind reactively."
+msgstr ""
+
+#: src/getting-started/first-app.md:47
+msgid "**`Button(label, onClick)`** — A native button with a click handler."
+msgstr ""
+
+#: src/getting-started/first-app.md:49
+msgid "A Todo App"
+msgstr ""
+
+#: src/getting-started/first-app.md:51 src/ui/state.md:160
+msgid ""
+"```typescript\n"
+"// demonstrates: complete reactive todo app combining State, ForEach, and "
+"widget tree mutation\n"
+"// docs: docs/src/ui/state.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    TextField,\n"
+"    VStack,\n"
+"    HStack,\n"
+"    State,\n"
+"    ForEach,\n"
+"    Spacer,\n"
+"    Divider,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const todos = State<string[]>([])\n"
+"const count = State(0)\n"
+"const input = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"Todo App\",\n"
+"    width: 480,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        Text(\"My Todos\"),\n"
+"\n"
+"        HStack(8, [\n"
+"            TextField(\"What needs to be done?\", (value: string) => "
+"input.set(value)),\n"
+"            Button(\"Add\", () => {\n"
+"                const text = input.value\n"
+"                if (text.length > 0) {\n"
+"                    todos.set([...todos.value, text])\n"
+"                    count.set(count.value + 1)\n"
+"                    input.set(\"\")\n"
+"                }\n"
+"            }),\n"
+"        ]),\n"
+"\n"
+"        Divider(),\n"
+"\n"
+"        ForEach(count, (i: number) =>\n"
+"            HStack(8, [\n"
+"                Text(todos.value[i]),\n"
+"                Spacer(),\n"
+"                Button(\"Delete\", () => {\n"
+"                    todos.set(todos.value.filter((_, idx) => idx !== i))\n"
+"                    count.set(count.value - 1)\n"
+"                }),\n"
+"            ]),\n"
+"        ),\n"
+"\n"
+"        Spacer(),\n"
+"        Text(`${count.value} items`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/getting-started/first-app.md:112
+msgid ""
+"`ForEach(count, render)` iterates by index — keep an item array and a count "
+"state in sync, then read items via `array.value[i]` inside the closure. See "
+"[State Management](../ui/state.md) for the full pattern."
+msgstr ""
+
+#: src/getting-started/first-app.md:116
+msgid "Cross-Platform"
+msgstr ""
+
+#: src/getting-started/first-app.md:118
+msgid "The same code runs on all 6 platforms:"
+msgstr ""
+
+#: src/getting-started/first-app.md:121
+msgid "# macOS (default)\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:124
+msgid "# iOS Simulator\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:127
+msgid ""
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:129 src/platforms/overview.md:30
+msgid "# alias: --target wasm\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:131
+msgid "# Other platforms\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:138
+msgid ""
+"Each target compiles to the platform's native widget toolkit. See "
+"[Platforms](../platforms/overview.md) for details."
+msgstr ""
+
+#: src/getting-started/first-app.md:141
+msgid "Adding Styling"
+msgstr ""
+
+#: src/getting-started/first-app.md:143
+msgid ""
+"Styling is applied via free functions that take the widget handle as their "
+"first argument. Colors are RGBA floats in `[0.0, 1.0]` — divide a hex byte "
+"by 255 to convert (`0x33 / 255 ≈ 0.2`)."
+msgstr ""
+
+#: src/getting-started/first-app.md:147
+msgid ""
+"```typescript\n"
+"// demonstrates: counter from getting-started/first-app.md with styled "
+"widgets\n"
+"// docs: docs/src/getting-started/first-app.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"// run: false\n"
+"\n"
+"import {\n"
+"    App, VStack, Text, Button, State,\n"
+"    textSetFontSize, textSetColor,\n"
+"    setCornerRadius, setPadding,\n"
+"    widgetSetBackgroundColor,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"const label = Text(`Count: ${count.value}`)\n"
+"textSetFontSize(label, 24)\n"
+"textSetColor(label, 0.2, 0.2, 0.2, 1.0)        // RGBA in [0,1] — same as "
+"#333333\n"
+"\n"
+"const btn = Button(\"Increment\", () => count.set(count.value + 1))\n"
+"setCornerRadius(btn, 8)\n"
+"widgetSetBackgroundColor(btn, 0.0, 0.478, 1.0, 1.0)  // system blue\n"
+"\n"
+"const stack = VStack(20, [label, btn])\n"
+"setPadding(stack, 20, 20, 20, 20)\n"
+"\n"
+"App({\n"
+"    title: \"Styled Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: stack,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/getting-started/first-app.md:182
+msgid "See [Styling](../ui/styling.md) for all available style properties."
+msgstr ""
+
+#: src/getting-started/first-app.md:186
+msgid ""
+"[Project Configuration](project-config.md) — Set up `package.json` for Perry "
+"projects"
+msgstr ""
+
+#: src/getting-started/first-app.md:187
+msgid "[UI Overview](../ui/overview.md) — Complete guide to Perry's UI system"
+msgstr ""
+
+#: src/getting-started/first-app.md:188
+msgid "[Widgets Reference](../ui/widgets.md) — All available widgets"
+msgstr ""
+
+#: src/getting-started/first-app.md:189
+msgid "[State Management](../ui/state.md) — Reactive state and bindings"
+msgstr ""
+
+#: src/getting-started/project-config.md:3
+msgid ""
+"Perry projects use `perry.toml` and `package.json` for configuration. No "
+"special config file is required for basic usage, but larger projects benefit "
+"from Perry-specific settings."
+msgstr ""
+
+#: src/getting-started/project-config.md:5
+msgid ""
+"**Looking for the full perry.toml reference?** See [perry.toml "
+"Reference](../cli/perry-toml.md) for every field, section, platform option, "
+"and environment variable."
+msgstr ""
+
+#: src/getting-started/project-config.md:7
+msgid "Basic Setup"
+msgstr ""
+
+#: src/getting-started/project-config.md:14
+msgid "This creates a `package.json` and a starter `src/index.ts`."
+msgstr ""
+
+#: src/getting-started/project-config.md:16
+msgid "package.json"
+msgstr ""
+
+#: src/getting-started/project-config.md:20 src/plugins/native-extensions.md:58
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"name\""
+msgstr ""
+
+#: src/getting-started/project-config.md:20
+msgid "\"my-project\""
+msgstr ""
+
+#: src/getting-started/project-config.md:21 src/plugins/native-extensions.md:59
+msgid "\"version\""
+msgstr ""
+
+#: src/getting-started/project-config.md:21
+msgid "\"1.0.0\""
+msgstr ""
+
+#: src/getting-started/project-config.md:22 src/plugins/native-extensions.md:60
+msgid "\"main\""
+msgstr ""
+
+#: src/getting-started/project-config.md:22 src/plugins/native-extensions.md:60
+msgid "\"src/index.ts\""
+msgstr ""
+
+#: src/getting-started/project-config.md:23
+#: src/getting-started/project-config.md:39
+#: src/getting-started/project-config.md:61
+#: src/getting-started/project-config.md:74
+#: src/getting-started/project-config.md:95 src/packages/porting.md:24
+#: src/platforms/ios.md:98 src/platforms/ios.md:111 src/platforms/android.md:57
+#: src/platforms/android.md:72 src/stdlib/overview.md:84
+#: src/plugins/native-extensions.md:61 src/plugins/appstore-review.md:180
+msgid "\"perry\""
+msgstr ""
+
+#: src/getting-started/project-config.md:24
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"compilePackages\""
+msgstr ""
+
+#: src/getting-started/project-config.md:29
+msgid "Perry Configuration"
+msgstr ""
+
+#: src/getting-started/project-config.md:31
+msgid "The `perry` field in `package.json` controls compiler behavior:"
+msgstr ""
+
+#: src/getting-started/project-config.md:33
+msgid "`compilePackages`"
+msgstr ""
+
+#: src/getting-started/project-config.md:35
+msgid ""
+"List npm packages to compile natively instead of routing through the "
+"JavaScript runtime:"
+msgstr ""
+
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"@noble/curves\""
+msgstr ""
+
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"@noble/hashes\""
+msgstr ""
+
+#: src/getting-started/project-config.md:45
+msgid "When a package is listed here, Perry:"
+msgstr ""
+
+#: src/getting-started/project-config.md:46
+msgid "Resolves the package in `node_modules/`"
+msgstr ""
+
+#: src/getting-started/project-config.md:47
+msgid ""
+"Prefers TypeScript source (`src/index.ts`) over compiled JavaScript "
+"(`lib/index.js`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:48
+msgid "Compiles all functions natively through LLVM"
+msgstr ""
+
+#: src/getting-started/project-config.md:49
+msgid ""
+"Deduplicates across nested `node_modules/` to prevent duplicate linker "
+"symbols"
+msgstr ""
+
+#: src/getting-started/project-config.md:51
+msgid ""
+"This is useful for pure TypeScript/JavaScript packages that don't rely on "
+"Node.js APIs. Packages that use native bindings, `eval()`, or dynamic "
+"`require()` won't work."
+msgstr ""
+
+#: src/getting-started/project-config.md:53
+msgid "`splash`"
+msgstr ""
+
+#: src/getting-started/project-config.md:55
+msgid ""
+"Configure a native splash screen for iOS and Android. The splash screen "
+"appears instantly during cold start, before your app code runs."
+msgstr ""
+
+#: src/getting-started/project-config.md:57
+msgid "**Minimal (both platforms share the same splash):**"
+msgstr ""
+
+#: src/getting-started/project-config.md:62
+#: src/getting-started/project-config.md:75
+#: src/getting-started/project-config.md:96 src/platforms/ios.md:99
+#: src/platforms/ios.md:112 src/platforms/android.md:58
+#: src/platforms/android.md:73
+msgid "\"splash\""
+msgstr ""
+
+#: src/getting-started/project-config.md:63
+#: src/getting-started/project-config.md:76
+#: src/getting-started/project-config.md:79
+#: src/getting-started/project-config.md:83 src/platforms/ios.md:100
+#: src/platforms/android.md:59
+msgid "\"image\""
+msgstr ""
+
+#: src/getting-started/project-config.md:63
+#: src/getting-started/project-config.md:76 src/platforms/ios.md:100
+#: src/platforms/android.md:59
+msgid "\"logo/icon-256.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:64
+#: src/getting-started/project-config.md:77
+#: src/getting-started/project-config.md:80
+#: src/getting-started/project-config.md:84 src/ui/theming.md:26
+#: src/platforms/ios.md:101 src/platforms/android.md:60
+msgid "\"background\""
+msgstr ""
+
+#: src/getting-started/project-config.md:64
+#: src/getting-started/project-config.md:77 src/platforms/ios.md:101
+#: src/platforms/android.md:60
+msgid "\"#FFF5EE\""
+msgstr ""
+
+#: src/getting-started/project-config.md:70
+msgid "**Per-platform overrides:**"
+msgstr ""
+
+#: src/getting-started/project-config.md:78
+#: src/getting-started/project-config.md:97 src/platforms/ios.md:113
+#: src/plugins/native-extensions.md:67
+msgid "\"ios\""
+msgstr ""
+
+#: src/getting-started/project-config.md:79
+msgid "\"logo/splash-ios.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:80
+#: src/getting-started/project-config.md:84 src/ui/theming.md:26
+#: src/ui/theming.md:29
+msgid "\"#FFFFFF\""
+msgstr ""
+
+#: src/getting-started/project-config.md:82
+#: src/getting-started/project-config.md:100 src/platforms/android.md:74
+#: src/plugins/native-extensions.md:72
+msgid "\"android\""
+msgstr ""
+
+#: src/getting-started/project-config.md:83
+msgid "\"logo/splash-android.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:91
+msgid "**Full custom override (complete control):**"
+msgstr ""
+
+#: src/getting-started/project-config.md:98 src/platforms/ios.md:113
+msgid "\"storyboard\""
+msgstr ""
+
+#: src/getting-started/project-config.md:98 src/platforms/ios.md:113
+msgid "\"splash/LaunchScreen.storyboard\""
+msgstr ""
+
+#: src/getting-started/project-config.md:101 src/platforms/android.md:75
+msgid "\"layout\""
+msgstr ""
+
+#: src/getting-started/project-config.md:101 src/platforms/android.md:75
+msgid "\"splash/splash_background.xml\""
+msgstr ""
+
+#: src/getting-started/project-config.md:102 src/platforms/android.md:76
+msgid "\"theme\""
+msgstr ""
+
+#: src/getting-started/project-config.md:102 src/platforms/android.md:76
+msgid "\"splash/themes.xml\""
+msgstr ""
+
+#: src/getting-started/project-config.md:109 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414
+msgid "Field"
+msgstr ""
+
+#: src/getting-started/project-config.md:109 src/ui/overview.md:57
+#: src/ui/widgets.md:377 src/ui/layout.md:173 src/ui/menus.md:53
+#: src/ui/multi-window.md:36 src/ui/multi-window.md:80
+#: src/ui/multi-window.md:124 src/system/overview.md:21
+#: src/widgets/creating-widgets.md:45 src/widgets/configuration.md:70
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/testing/geisterhand.md:84 src/testing/geisterhand.md:98
+#: src/cli/commands.md:17 src/cli/commands.md:60 src/cli/commands.md:109
+#: src/cli/commands.md:148 src/cli/commands.md:181 src/cli/commands.md:195
+#: src/cli/commands.md:233 src/cli/commands.md:248 src/cli/commands.md:260
+#: src/cli/flags.md:9 src/cli/flags.md:43 src/cli/flags.md:50
+#: src/cli/flags.md:58 src/cli/flags.md:66 src/cli/flags.md:73
+#: src/cli/flags.md:80 src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:277
+#: src/cli/perry-toml.md:284 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:367 src/cli/perry-toml.md:377
+#: src/cli/perry-toml.md:387 src/cli/perry-toml.md:397
+#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:491
+#: src/cli/perry-toml.md:503 src/cli/perry-toml.md:513
+msgid "Description"
+msgstr ""
+
+#: src/getting-started/project-config.md:111
+msgid "`splash.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:111
+msgid "Path to a PNG image, centered on the splash screen (both platforms)"
+msgstr ""
+
+#: src/getting-started/project-config.md:112
+msgid "`splash.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:112
+msgid "Hex color for the background (default: `#FFFFFF`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:113
+msgid "`splash.ios.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:113
+msgid "iOS-specific image override"
+msgstr ""
+
+#: src/getting-started/project-config.md:114
+msgid "`splash.ios.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:114
+msgid "iOS-specific background color"
+msgstr ""
+
+#: src/getting-started/project-config.md:115
+msgid "`splash.ios.storyboard`"
+msgstr ""
+
+#: src/getting-started/project-config.md:115
+msgid "Custom LaunchScreen.storyboard (compiled with ibtool)"
+msgstr ""
+
+#: src/getting-started/project-config.md:116
+msgid "`splash.android.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:116
+msgid "Android-specific image override"
+msgstr ""
+
+#: src/getting-started/project-config.md:117
+msgid "`splash.android.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:117
+msgid "Android-specific background color"
+msgstr ""
+
+#: src/getting-started/project-config.md:118
+msgid "`splash.android.layout`"
+msgstr ""
+
+#: src/getting-started/project-config.md:118
+msgid "Custom drawable XML for `windowBackground`"
+msgstr ""
+
+#: src/getting-started/project-config.md:119
+msgid "`splash.android.theme`"
+msgstr ""
+
+#: src/getting-started/project-config.md:119
+msgid "Custom themes.xml"
+msgstr ""
+
+#: src/getting-started/project-config.md:121
+msgid "**Resolution order** per platform:"
+msgstr ""
+
+#: src/getting-started/project-config.md:122
+msgid "Custom file override (storyboard / layout+theme)"
+msgstr ""
+
+#: src/getting-started/project-config.md:123
+msgid "Platform-specific image/color (`splash.{platform}.image`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:124
+msgid "Universal image/color (`splash.image`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:125
+msgid "No `splash` key → blank white screen (backward compatible)"
+msgstr ""
+
+#: src/getting-started/project-config.md:127
+msgid "Using npm Packages"
+msgstr ""
+
+#: src/getting-started/project-config.md:129
+msgid ""
+"Perry natively supports many popular npm packages without any configuration:"
+msgstr ""
+
+#: src/getting-started/project-config.md:131
+msgid ""
+"```typescript\n"
+"// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
+"// docs: docs/src/getting-started/project-config.md\n"
+"// platforms: macos, linux, windows\n"
+"// run: false\n"
+"\n"
+"// These four imports are Perry's most-used built-in stdlib shims:\n"
+"// fastify (HTTP server), mysql2 (db), ioredis (Redis), bcrypt (password\n"
+"// hashing). They're compiled to native code via Perry's per-package\n"
+"// implementations — no `compilePackages` needed.\n"
+"//\n"
+"// `// run: false` because each one needs a live external service (DB,\n"
+"// Redis, network port) to actually do anything; the binary still has to\n"
+"// link cleanly, which is the drift check we want.\n"
+"\n"
+"import fastify from \"fastify\"\n"
+"import mysql from \"mysql2/promise\"\n"
+"import Redis from \"ioredis\"\n"
+"import bcrypt from \"bcrypt\"\n"
+"\n"
+"const app = fastify({ logger: false })\n"
+"const db = mysql.createPool({ host: \"localhost\", user: \"root\", database: "
+"\"test\" })\n"
+"const redis = new Redis()\n"
+"const hashed = await bcrypt.hash(\"hunter2\", 10)\n"
+"\n"
+"console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/project-config.md:159
+msgid ""
+"These are compiled to native code using Perry's built-in implementations. "
+"See [Standard Library](../stdlib/overview.md) for the full list."
+msgstr ""
+
+#: src/getting-started/project-config.md:161
+msgid ""
+"For packages not natively supported, use `compilePackages` for pure TS/JS "
+"packages, or the JavaScript runtime fallback for complex packages."
+msgstr ""
+
+#: src/getting-started/project-config.md:163 src/contributing/building.md:61
+msgid "Project Structure"
+msgstr ""
+
+#: src/getting-started/project-config.md:165
+msgid "Perry is flexible about project structure. Common patterns:"
+msgstr ""
+
+#: src/getting-started/project-config.md:175
+msgid "For UI apps:"
+msgstr ""
+
+#: src/getting-started/project-config.md:186 src/widgets/watchos.md:59
+#: src/widgets/wearos.md:58
+msgid "Compilation"
+msgstr ""
+
+#: src/getting-started/project-config.md:189
+msgid "# Compile a file\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:191
+msgid "# Compile with a specific target\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:194
+msgid "# Debug: print intermediate representation\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:199
+msgid "See [CLI Commands](../cli/commands.md) for all options."
+msgstr ""
+
+#: src/getting-started/project-config.md:203
+msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
+msgstr ""
+
+#: src/getting-started/project-config.md:204
+msgid ""
+"[Supported Features](../language/supported-features.md) — What TypeScript "
+"features work"
+msgstr ""
+
+#: src/getting-started/project-config.md:205
+msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
+msgstr ""
+
+#: src/language/supported-features.md:1
+msgid "Supported TypeScript Features"
+msgstr ""
+
+#: src/language/supported-features.md:3
+msgid ""
+"Perry compiles a practical subset of TypeScript to native code. This page "
+"lists what's supported."
+msgstr ""
+
+#: src/language/supported-features.md:5
+msgid "Primitive Types"
+msgstr ""
+
+#: src/language/supported-features.md:7
+msgid ""
+"```typescript\n"
+"function primitives(): void {\n"
+"    const n: number = 42;\n"
+"    const s: string = \"hello\";\n"
+"    const b: boolean = true;\n"
+"    const u: undefined = undefined;\n"
+"    const nl: null = null;\n"
+"\n"
+"    console.log(`primitives: n=${n} s=${s} b=${b} u=${u} nl=${nl}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:19
+msgid "All primitives are represented as 64-bit NaN-boxed values at runtime."
+msgstr ""
+
+#: src/language/supported-features.md:21
+msgid "Variables and Constants"
+msgstr ""
+
+#: src/language/supported-features.md:23
+msgid ""
+"```typescript\n"
+"function variables(): void {\n"
+"    let x = 10;\n"
+"    const y = \"immutable\";\n"
+"    var z = true; // var is supported but let/const preferred\n"
+"\n"
+"    console.log(`variables: x=${x} y=${y} z=${z}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:33
+msgid ""
+"Perry infers types from initializers — `let x = 5` is inferred as `number` "
+"without an explicit annotation."
+msgstr ""
+
+#: src/language/supported-features.md:35
+msgid "Functions"
+msgstr ""
+
+#: src/language/supported-features.md:37
+msgid ""
+"```typescript\n"
+"function functionsDemo(): void {\n"
+"    function add(a: number, b: number): number {\n"
+"        return a + b;\n"
+"    }\n"
+"\n"
+"    // Optional parameters\n"
+"    function greet(name: string, greeting: string = \"Hello\"): string {\n"
+"        return `${greeting}, ${name}!`;\n"
+"    }\n"
+"\n"
+"    // Rest parameters\n"
+"    function sum(...nums: number[]): number {\n"
+"        return nums.reduce((a, b) => a + b, 0);\n"
+"    }\n"
+"\n"
+"    // Arrow functions\n"
+"    const double = (x: number) => x * 2;\n"
+"\n"
+"    console.log(`functions: add=${add(2, 3)} greet=${greet(\"Perry\")} "
+"sum=${sum(1, 2, 3)} double=${double(5)}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:60
+msgid "Classes"
+msgstr ""
+
+#: src/language/supported-features.md:62
+msgid ""
+"```typescript\n"
+"class Animal {\n"
+"    name: string;\n"
+"\n"
+"    constructor(name: string) {\n"
+"        this.name = name;\n"
+"    }\n"
+"\n"
+"    speak(): string {\n"
+"        return `${this.name} makes a noise`;\n"
+"    }\n"
+"}\n"
+"\n"
+"class Dog extends Animal {\n"
+"    speak(): string {\n"
+"        return `${this.name} barks`;\n"
+"    }\n"
+"}\n"
+"\n"
+"// Static methods\n"
+"class Counter {\n"
+"    private static instance: Counter;\n"
+"    private count: number = 0;\n"
+"\n"
+"    static getInstance(): Counter {\n"
+"        if (!Counter.instance) {\n"
+"            Counter.instance = new Counter();\n"
+"        }\n"
+"        return Counter.instance;\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:95
+msgid "Supported class features:"
+msgstr ""
+
+#: src/language/supported-features.md:96
+msgid "Constructors"
+msgstr ""
+
+#: src/language/supported-features.md:97
+msgid "Instance and static methods"
+msgstr ""
+
+#: src/language/supported-features.md:98
+msgid "Instance and static properties"
+msgstr ""
+
+#: src/language/supported-features.md:99
+msgid "Inheritance (`extends`)"
+msgstr ""
+
+#: src/language/supported-features.md:100
+msgid "Method overriding"
+msgstr ""
+
+#: src/language/supported-features.md:101
+msgid "`instanceof` checks (via class ID chain)"
+msgstr ""
+
+#: src/language/supported-features.md:102
+msgid "Singleton patterns (static method return type inference)"
+msgstr ""
+
+#: src/language/supported-features.md:104
+msgid "Enums"
+msgstr ""
+
+#: src/language/supported-features.md:106
+msgid ""
+"```typescript\n"
+"// Numeric enums\n"
+"enum Direction {\n"
+"    Up,\n"
+"    Down,\n"
+"    Left,\n"
+"    Right,\n"
+"}\n"
+"\n"
+"// String enums\n"
+"enum Color {\n"
+"    Red = \"RED\",\n"
+"    Green = \"GREEN\",\n"
+"    Blue = \"BLUE\",\n"
+"}\n"
+"\n"
+"const dir = Direction.Up;\n"
+"const color = Color.Red;\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:126
+msgid "Enums are compiled to constants and work across modules."
+msgstr ""
+
+#: src/language/supported-features.md:128
+msgid "Interfaces and Type Aliases"
+msgstr ""
+
+#: src/language/supported-features.md:142
+msgid ""
+"Interfaces and type aliases are erased at compile time (like `tsc`). They "
+"exist only for documentation and editor tooling."
+msgstr ""
+
+#: src/language/supported-features.md:144 src/threading/overview.md:306
+#: src/threading/parallel-map.md:58
+msgid "Arrays"
+msgstr ""
+
+#: src/language/supported-features.md:146
+msgid ""
+"```typescript\n"
+"function arraysDemo(): void {\n"
+"    const nums: number[] = [1, 2, 3];\n"
+"\n"
+"    // Array methods\n"
+"    nums.push(4);\n"
+"    nums.pop();\n"
+"    const len = nums.length;\n"
+"    const doubled = nums.map((x) => x * 2);\n"
+"    const filtered = nums.filter((x) => x > 2);\n"
+"    const sum = nums.reduce((acc, x) => acc + x, 0);\n"
+"    const found = nums.find((x) => x === 3);\n"
+"    const idx = nums.indexOf(3);\n"
+"    const joined = nums.join(\", \");\n"
+"    const sliced = nums.slice(1, 3);\n"
+"    nums.splice(1, 1);\n"
+"    nums.unshift(0);\n"
+"    const sorted = nums.sort((a, b) => a - b);\n"
+"    const reversed = nums.reverse();\n"
+"    const includes = nums.includes(3);\n"
+"    const every = nums.every((x) => x > 0);\n"
+"    const some = nums.some((x) => x > 2);\n"
+"    nums.forEach((x) => console.log(x));\n"
+"    const flat = [[1, 2], [3]].flat();\n"
+"    const concatted = nums.concat([5, 6]);\n"
+"\n"
+"    // Array.from\n"
+"    const arr = Array.from([10, 20, 30]);\n"
+"\n"
+"    // Array.isArray\n"
+"    const value: any = [1, 2, 3]\n"
+"    if (Array.isArray(value)) { /* ... */ }\n"
+"\n"
+"    // for...of iteration\n"
+"    for (const item of nums) {\n"
+"        console.log(item);\n"
+"    }\n"
+"\n"
+"    console.log(`arrays: len=${len} doubled=${doubled.length} "
+"filtered=${filtered.length} sum=${sum} found=${found} idx=${idx} "
+"joined=${joined} sliced=${sliced.length} sorted=${sorted.length} "
+"reversed=${reversed.length} includes=${includes} every=${every} some=${some} "
+"flat=${flat.length} concatted=${concatted.length} arr=${arr.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:188 src/threading/overview.md:307
+#: src/threading/parallel-map.md:59
+msgid "Objects"
+msgstr ""
+
+#: src/language/supported-features.md:190
+msgid ""
+"```typescript\n"
+"function objectsDemo(): void {\n"
+"    const obj: { name: string; version: number; [k: string]: any } = { name: "
+"\"Perry\", version: 1 };\n"
+"    obj.name = \"Perry 2\";\n"
+"\n"
+"    // Dynamic property access\n"
+"    const key = \"name\";\n"
+"    const val = obj[key];\n"
+"\n"
+"    // Object.keys, Object.values, Object.entries\n"
+"    const keys = Object.keys(obj);\n"
+"    const values = Object.values(obj);\n"
+"    const entries = Object.entries(obj);\n"
+"\n"
+"    // Spread\n"
+"    const copy = { ...obj, extra: true };\n"
+"\n"
+"    // delete\n"
+"    delete obj[key];\n"
+"\n"
+"    console.log(`objects: val=${val} keys=${keys.length} "
+"values=${values.length} entries=${entries.length} copy=${copy.extra}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:214
+msgid "Destructuring"
+msgstr ""
+
+#: src/language/supported-features.md:216
+msgid ""
+"```typescript\n"
+"function destructuringDemo(): void {\n"
+"    // Array destructuring\n"
+"    const [a, b, ...rest] = [1, 2, 3, 4, 5];\n"
+"\n"
+"    const user = { name: \"Alice\", age: 30, email: \"a@example.com\", id: 1 "
+"}\n"
+"    const obj = { id: 2, role: \"admin\", level: 5 }\n"
+"\n"
+"    // Object destructuring\n"
+"    const { name, age, email = \"none\" } = user;\n"
+"\n"
+"    // Rename\n"
+"    const { name: userName } = user;\n"
+"\n"
+"    // Rest pattern\n"
+"    const { id, ...remaining } = obj;\n"
+"\n"
+"    // Function parameter destructuring\n"
+"    function process({ name, age }: { name: string; age: number }) {\n"
+"        console.log(name, age);\n"
+"    }\n"
+"\n"
+"    process(user)\n"
+"    console.log(`destructuring: a=${a} b=${b} rest=${rest.length} "
+"name=${name} age=${age} email=${email} userName=${userName} id=${id}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:243 src/widgets/creating-widgets.md:112
+msgid "Template Literals"
+msgstr ""
+
+#: src/language/supported-features.md:245
+msgid ""
+"```typescript\n"
+"function templateLiteralsDemo(): void {\n"
+"    const name = \"world\";\n"
+"    const greeting = `Hello, ${name}!`;\n"
+"    const multiline = `\n"
+"  Line 1\n"
+"  Line 2\n"
+"`;\n"
+"    const expr = `Result: ${1 + 2}`;\n"
+"\n"
+"    console.log(`template-literals: greeting=${greeting} "
+"multiline_len=${multiline.length} expr=${expr}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:259
+msgid "Spread and Rest"
+msgstr ""
+
+#: src/language/supported-features.md:261
+msgid ""
+"```typescript\n"
+"function spreadRestDemo(): void {\n"
+"    const arr1 = [1, 2]\n"
+"    const arr2 = [3, 4]\n"
+"    const defaults = { theme: \"light\", size: \"md\" }\n"
+"    const overrides = { size: \"lg\" }\n"
+"\n"
+"    // Array spread\n"
+"    const combined = [...arr1, ...arr2];\n"
+"\n"
+"    // Object spread\n"
+"    const merged = { ...defaults, ...overrides };\n"
+"\n"
+"    // Rest parameters\n"
+"    function log(...args: any[]) { /* ... */ }\n"
+"\n"
+"    log(\"a\", \"b\", \"c\")\n"
+"    console.log(`spread-rest: combined=${combined.length} "
+"merged=${merged.size}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:282 src/threading/overview.md:308
+msgid "Closures"
+msgstr ""
+
+#: src/language/supported-features.md:284
+msgid ""
+"```typescript\n"
+"function closuresDemo(): void {\n"
+"    function makeCounter() {\n"
+"        let count = 0;\n"
+"        return {\n"
+"            increment: () => ++count,\n"
+"            get: () => count,\n"
+"        };\n"
+"    }\n"
+"\n"
+"    const counter = makeCounter();\n"
+"    counter.increment();\n"
+"    console.log(counter.get()); // 1\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:300
+msgid ""
+"Perry performs closure conversion — captured variables are stored in "
+"heap-allocated closure objects."
+msgstr ""
+
+#: src/language/supported-features.md:302
+msgid "Async/Await"
+msgstr ""
+
+#: src/language/supported-features.md:304
+msgid ""
+"```typescript\n"
+"async function asyncAwaitDemo(): Promise<void> {\n"
+"    interface Profile { id: number; name: string }\n"
+"\n"
+"    async function fetchUser(id: number): Promise<Profile> {\n"
+"        // The docs example uses fetch(...) here; we inline a synthetic\n"
+"        // result so the snippet compiles and runs hermetically.\n"
+"        return { id, name: `user-${id}` }\n"
+"    }\n"
+"\n"
+"    const data = await fetchUser(1);\n"
+"    console.log(`async-await: id=${data.id} name=${data.name}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:319
+msgid ""
+"Perry compiles async functions to a state machine backed by Tokio's async "
+"runtime."
+msgstr ""
+
+#: src/language/supported-features.md:321
+msgid "Promises"
+msgstr ""
+
+#: src/language/supported-features.md:323
+msgid ""
+"```typescript\n"
+"async function promisesDemo(): Promise<void> {\n"
+"    const p = new Promise<number>((resolve, reject) => {\n"
+"        resolve(42);\n"
+"    });\n"
+"\n"
+"    p.then((value) => console.log(value));\n"
+"\n"
+"    // Promise.all\n"
+"    const results = await Promise.all([\n"
+"        Promise.resolve(\"a\"),\n"
+"        Promise.resolve(\"b\"),\n"
+"    ]);\n"
+"\n"
+"    console.log(`promises: results=${results.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:341
+msgid "Generators"
+msgstr ""
+
+#: src/language/supported-features.md:357
+msgid "Map and Set"
+msgstr ""
+
+#: src/language/supported-features.md:359
+msgid ""
+"```typescript\n"
+"function mapSetDemo(): void {\n"
+"    const map = new Map<string, number>();\n"
+"    map.set(\"a\", 1);\n"
+"    map.get(\"a\");\n"
+"    map.has(\"a\");\n"
+"    map.delete(\"a\");\n"
+"    map.size;\n"
+"\n"
+"    const set = new Set<number>();\n"
+"    set.add(1);\n"
+"    set.has(1);\n"
+"    set.delete(1);\n"
+"    set.size;\n"
+"\n"
+"    console.log(`map-set: map_size=${map.size} set_size=${set.size}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:378
+msgid "Regular Expressions"
+msgstr ""
+
+#: src/language/supported-features.md:380
+msgid ""
+"```typescript\n"
+"function regexDemo(): void {\n"
+"    const re = /hello\\s+(\\w+)/;\n"
+"    const match = \"hello world\".match(re);\n"
+"\n"
+"    if (re.test(\"hello perry\")) {\n"
+"        console.log(\"Matched!\");\n"
+"    }\n"
+"\n"
+"    const replaced = \"hello world\".replace(/world/, \"perry\");\n"
+"\n"
+"    console.log(`regex: match=${match !== null} replaced=${replaced}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:395 src/widgets/data-fetching.md:154
+msgid "Error Handling"
+msgstr ""
+
+#: src/language/supported-features.md:397
+msgid ""
+"```typescript\n"
+"function errorsDemo(): void {\n"
+"    try {\n"
+"        throw new Error(\"something went wrong\");\n"
+"    } catch (e: any) {\n"
+"        console.log(e.message);\n"
+"    } finally {\n"
+"        console.log(\"cleanup\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:409
+msgid "JSON"
+msgstr ""
+
+#: src/language/supported-features.md:411
+msgid ""
+"```typescript\n"
+"function jsonDemo(): void {\n"
+"    const obj = JSON.parse('{\"key\": \"value\"}');\n"
+"    const str = JSON.stringify(obj);\n"
+"    const pretty = JSON.stringify(obj, null, 2);\n"
+"\n"
+"    console.log(`json: str_len=${str.length} pretty_len=${pretty.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:421
+msgid "typeof and instanceof"
+msgstr ""
+
+#: src/language/supported-features.md:423
+msgid ""
+"```typescript\n"
+"function typeofInstanceofDemo(): void {\n"
+"    const x: any = \"hello\"\n"
+"    if (typeof x === \"string\") {\n"
+"        console.log(x.length);\n"
+"    }\n"
+"\n"
+"    const obj: any = new Dog(\"Rex\")\n"
+"    if (obj instanceof Dog) {\n"
+"        obj.speak();\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:437
+msgid ""
+"`typeof` checks NaN-boxing tags at runtime. `instanceof` walks the class ID "
+"chain."
+msgstr ""
+
+#: src/language/supported-features.md:439
+msgid "Modules"
+msgstr ""
+
+#: src/language/supported-features.md:441
+msgid ""
+"ES module syntax is fully supported: named exports, default exports, and "
+"re-exports."
+msgstr ""
+
+#: src/language/supported-features.md:444
+msgid "The exporting module:"
+msgstr ""
+
+#: src/language/supported-features.md:446
+msgid ""
+"```typescript\n"
+"// Named exports\n"
+"export function helper(x: number): number { return x + 1 }\n"
+"export const VALUE = 42\n"
+"\n"
+"// Default export\n"
+"export default class MyClass {\n"
+"    name: string\n"
+"    constructor(name: string) {\n"
+"        this.name = name\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:460
+msgid "The importing module:"
+msgstr ""
+
+#: src/language/supported-features.md:462
+msgid ""
+"```typescript\n"
+"// Default + named imports from a sibling module\n"
+"import MyClass, { helper, VALUE } from \"./utils\"\n"
+"\n"
+"// Re-export\n"
+"export { helper } from \"./utils\"\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:470
+msgid "BigInt"
+msgstr ""
+
+#: src/language/supported-features.md:472
+msgid ""
+"```typescript\n"
+"function bigintDemo(): void {\n"
+"    const big = BigInt(9007199254740991);\n"
+"    const result = big + BigInt(1);\n"
+"\n"
+"    // Bitwise operations\n"
+"    const and = big & BigInt(0xFF);\n"
+"    const or = big | BigInt(0xFF);\n"
+"    const xor = big ^ BigInt(0xFF);\n"
+"    const shl = big << BigInt(2);\n"
+"    const shr = big >> BigInt(2);\n"
+"    const not = ~big;\n"
+"\n"
+"    console.log(`bigint: result_ok=${result !== null} and_ok=${and !== null} "
+"or_ok=${or !== null}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:489
+msgid "String Methods"
+msgstr ""
+
+#: src/language/supported-features.md:491
+msgid ""
+"```typescript\n"
+"function stringMethodsDemo(): void {\n"
+"    const s = \"Hello, World!\";\n"
+"    s.length;\n"
+"    s.toUpperCase();\n"
+"    s.toLowerCase();\n"
+"    s.trim();\n"
+"    s.split(\", \");\n"
+"    s.includes(\"World\");\n"
+"    s.startsWith(\"Hello\");\n"
+"    s.endsWith(\"!\");\n"
+"    s.indexOf(\"World\");\n"
+"    s.slice(0, 5);\n"
+"    s.substring(0, 5);\n"
+"    s.replace(\"World\", \"Perry\");\n"
+"    s.repeat(3);\n"
+"    s.charAt(0);\n"
+"    s.padStart(20);\n"
+"    s.padEnd(20);\n"
+"\n"
+"    console.log(`string-methods: ${s.toUpperCase()}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:515
+msgid "Math"
+msgstr ""
+
+#: src/language/supported-features.md:538
+msgid "Date"
+msgstr ""
+
+#: src/language/supported-features.md:551
+msgid "Console"
+msgstr ""
+
+#: src/language/supported-features.md:553
+msgid ""
+"```typescript\n"
+"function consoleDemo(): void {\n"
+"    console.log(\"message\");\n"
+"    console.error(\"error\");\n"
+"    console.warn(\"warning\");\n"
+"    console.time(\"label\");\n"
+"    console.timeEnd(\"label\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:563 src/contributing/architecture.md:56
+msgid "Garbage Collection"
+msgstr ""
+
+#: src/language/supported-features.md:565
+msgid ""
+"Perry includes a mark-sweep garbage collector. It runs automatically when "
+"memory pressure is detected (~8MB arena blocks), but you can also trigger it "
+"manually:"
+msgstr ""
+
+#: src/language/supported-features.md:567
+msgid ""
+"```typescript\n"
+"function gcDemo(): void {\n"
+"    gc(); // Explicit garbage collection\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:573
+msgid ""
+"The GC uses conservative stack scanning to find roots and supports "
+"arena-allocated objects (arrays, objects) and malloc-allocated objects "
+"(strings, closures, promises, BigInts, errors)."
+msgstr ""
+
+#: src/language/supported-features.md:575
+msgid "JSX/TSX"
+msgstr ""
+
+#: src/language/supported-features.md:577
+msgid ""
+"Perry's parser and HIR understand JSX syntax (parsed via SWC, lowered in "
+"`crates/perry-hir/src/jsx.rs`), but the runtime `_jsx` / `_jsxs` symbols are "
+"not yet linked, so a `.tsx` file fails at the link stage today. The "
+"canonical pattern is the function-call form Perry's UI examples already use "
+"(`Text(\"hi\")` instead of `<Text>hi</Text>`)."
+msgstr ""
+
+#: src/language/supported-features.md:583
+msgid ""
+"```text\n"
+"// Planned JSX shape (parses but doesn't link yet — issue: runtime _jsx "
+"symbols):\n"
+"\n"
+"function Greeting({ name }: { name: string }) {\n"
+"  return <Text>{`Hello, ${name}!`}</Text>;\n"
+"}\n"
+"\n"
+"<Button onClick={() => console.log(\"clicked\")}>Click me</Button>\n"
+"\n"
+"<>\n"
+"  <Text>Line 1</Text>\n"
+"  <Text>Line 2</Text>\n"
+"</>\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:598
+msgid ""
+"JSX elements are transformed to function calls via the `jsx()`/`jsxs()` "
+"runtime."
+msgstr ""
+
+#: src/language/supported-features.md:602
+msgid "[Type System](type-system.md) — Type inference and checking"
+msgstr ""
+
+#: src/language/supported-features.md:603
+msgid "[Limitations](limitations.md) — What's not supported yet"
+msgstr ""
+
+#: src/language/type-system.md:3
+msgid ""
+"Perry erases types at compile time, similar to how `tsc` removes type "
+"annotations when emitting JavaScript. However, Perry also performs type "
+"inference to generate efficient native code."
+msgstr ""
+
+#: src/language/type-system.md:5
+msgid "Type Inference"
+msgstr ""
+
+#: src/language/type-system.md:7
+msgid "Perry infers types from expressions without requiring annotations:"
+msgstr ""
+
+#: src/language/type-system.md:9
+msgid ""
+"```typescript\n"
+"function inferenceBasics(): void {\n"
+"    let x = 5;           // inferred as number\n"
+"    let s = \"hello\";     // inferred as string\n"
+"    let b = true;        // inferred as boolean\n"
+"    let arr = [1, 2, 3]; // inferred as number[]\n"
+"\n"
+"    console.log(`inference: x=${x} s=${s} b=${b} arr_len=${arr.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:20
+msgid "Inference works through:"
+msgstr ""
+
+#: src/language/type-system.md:21
+msgid "**Literal values**: `5` → `number`, `\"hi\"` → `string`"
+msgstr ""
+
+#: src/language/type-system.md:22
+msgid "**Binary operations**: `a + b` where both are numbers → `number`"
+msgstr ""
+
+#: src/language/type-system.md:23
+msgid ""
+"**Variable propagation**: if `x` is `number`, then `let y = x` is `number`"
+msgstr ""
+
+#: src/language/type-system.md:24
+msgid ""
+"**Method returns**: `\"hello\".trim()` → `string`, `[1,2].length` → `number`"
+msgstr ""
+
+#: src/language/type-system.md:25
+msgid ""
+"**Function returns**: user-defined function return types are propagated to "
+"callers"
+msgstr ""
+
+#: src/language/type-system.md:27
+msgid ""
+"```typescript\n"
+"function inferenceFunction(): void {\n"
+"    function double(n: number): number {\n"
+"        return n * 2;\n"
+"    }\n"
+"    let result = double(5); // inferred as number\n"
+"\n"
+"    console.log(`inference-function: result=${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:38
+msgid "Type Annotations"
+msgstr ""
+
+#: src/language/type-system.md:40
+msgid "Standard TypeScript annotations work:"
+msgstr ""
+
+#: src/language/type-system.md:42
+msgid ""
+"```typescript\n"
+"interface Config {\n"
+"    port: number;\n"
+"    host: string;\n"
+"}\n"
+"\n"
+"function annotations(): void {\n"
+"    let name: string = \"Perry\";\n"
+"    let count: number = 0;\n"
+"    let items: string[] = [];\n"
+"\n"
+"    function greet(name: string): string {\n"
+"        return `Hello, ${name}`;\n"
+"    }\n"
+"\n"
+"    const cfg: Config = { port: 8080, host: \"localhost\" }\n"
+"    console.log(`annotations: ${greet(name)} count=${count} "
+"items=${items.length} port=${cfg.port}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:62
+msgid "Utility Types"
+msgstr ""
+
+#: src/language/type-system.md:64
+msgid ""
+"Common TypeScript utility types are erased at compile time (they don't "
+"affect code generation):"
+msgstr ""
+
+#: src/language/type-system.md:75
+msgid ""
+"These are all recognized and erased — they won't cause compilation errors."
+msgstr ""
+
+#: src/language/type-system.md:77
+msgid "Generics"
+msgstr ""
+
+#: src/language/type-system.md:79
+msgid "Generic type parameters are erased:"
+msgstr ""
+
+#: src/language/type-system.md:81
+msgid ""
+"```typescript\n"
+"function identity<T>(value: T): T {\n"
+"    return value;\n"
+"}\n"
+"\n"
+"class Box<T> {\n"
+"    value: T;\n"
+"    constructor(value: T) {\n"
+"        this.value = value;\n"
+"    }\n"
+"}\n"
+"\n"
+"function genericsDemo(): void {\n"
+"    const box = new Box<number>(42);\n"
+"    const id = identity<string>(\"hello\")\n"
+"    console.log(`generics: box.value=${box.value} id=${id}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:100
+msgid ""
+"At runtime, all values are NaN-boxed — the generic parameter doesn't affect "
+"code generation."
+msgstr ""
+
+#: src/language/type-system.md:102
+msgid "Type Checking with `--type-check`"
+msgstr ""
+
+#: src/language/type-system.md:104
+msgid ""
+"For stricter type checking, Perry can integrate with Microsoft's TypeScript "
+"checker:"
+msgstr ""
+
+#: src/language/type-system.md:110
+msgid ""
+"This resolves cross-file types, interfaces, and generics via an IPC "
+"protocol. It falls back gracefully if the type checker is not installed."
+msgstr ""
+
+#: src/language/type-system.md:112
+msgid ""
+"Without `--type-check`, Perry relies on its own inference engine, which "
+"handles common patterns but doesn't perform full TypeScript type checking."
+msgstr ""
+
+#: src/language/type-system.md:114
+msgid "Union and Intersection Types"
+msgstr ""
+
+#: src/language/type-system.md:116
+msgid ""
+"Union types are recognized syntactically but don't affect code generation:"
+msgstr ""
+
+#: src/language/type-system.md:118
+msgid ""
+"```typescript\n"
+"type StringOrNumber = string | number;\n"
+"\n"
+"function process(value: StringOrNumber) {\n"
+"    if (typeof value === \"string\") {\n"
+"        console.log(value.toUpperCase());\n"
+"    } else {\n"
+"        console.log(value + 1);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:130
+msgid "Use `typeof` checks for runtime type narrowing."
+msgstr ""
+
+#: src/language/type-system.md:132
+msgid "Type Guards"
+msgstr ""
+
+#: src/language/type-system.md:134
+msgid ""
+"```typescript\n"
+"function isString(value: any): value is string {\n"
+"    return typeof value === \"string\";\n"
+"}\n"
+"\n"
+"function typeGuardsDemo(): void {\n"
+"    const x: any = \"hello\"\n"
+"    if (isString(x)) {\n"
+"        console.log(x.toUpperCase());\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:147
+msgid ""
+"The `value is string` annotation is erased, but the `typeof` check works at "
+"runtime."
+msgstr ""
+
+#: src/language/type-system.md:151
+msgid "[Supported Features](supported-features.md) — Complete feature list"
+msgstr ""
+
+#: src/language/type-system.md:152
+msgid "[Limitations](limitations.md) — What's not supported"
+msgstr ""
+
+#: src/language/limitations.md:3
+msgid ""
+"Perry compiles a practical subset of TypeScript. This page documents what's "
+"not supported or works differently from Node.js/tsc."
+msgstr ""
+
+#: src/language/limitations.md:5
+msgid "No Runtime Type Checking"
+msgstr ""
+
+#: src/language/limitations.md:7
+msgid ""
+"Types are erased at compile time. There is no runtime type system — Perry "
+"doesn't generate type guards or runtime type metadata."
+msgstr ""
+
+#: src/language/limitations.md:9
+msgid ""
+"```typescript\n"
+"function someFunction(): number {\n"
+"    return 42\n"
+"}\n"
+"\n"
+"function erasedTypes(): void {\n"
+"    // These annotations are erased — no runtime effect\n"
+"    const x: number = someFunction(); // No runtime check that result is "
+"actually a number\n"
+"    console.log(`erased-types: x=${x}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:21
+msgid "Use explicit `typeof` checks where runtime type discrimination is needed."
+msgstr ""
+
+#: src/language/limitations.md:23
+msgid "No eval() or Dynamic Code"
+msgstr ""
+
+#: src/language/limitations.md:25
+msgid ""
+"Perry compiles to native code ahead of time. Dynamic code execution is not "
+"possible:"
+msgstr ""
+
+#: src/language/limitations.md:28
+msgid ""
+"```text\n"
+"// Not supported\n"
+"eval(\"console.log('hi')\");\n"
+"new Function(\"return 42\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:34
+msgid "No Decorators"
+msgstr ""
+
+#: src/language/limitations.md:36
+msgid "TypeScript decorators are not currently supported:"
+msgstr ""
+
+#: src/language/limitations.md:39
+msgid ""
+"```text\n"
+"// Not supported\n"
+"@Component\n"
+"class MyClass {}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:45
+msgid "No Reflection"
+msgstr ""
+
+#: src/language/limitations.md:47
+msgid "There is no `Reflect` API or runtime type metadata:"
+msgstr ""
+
+#: src/language/limitations.md:50
+msgid ""
+"```text\n"
+"// Not supported\n"
+"Reflect.getMetadata(\"design:type\", target, key);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:55
+msgid "No Dynamic require()"
+msgstr ""
+
+#: src/language/limitations.md:57
+msgid "Only static imports are supported:"
+msgstr ""
+
+#: src/language/limitations.md:60
+msgid ""
+"```text\n"
+"// Supported\n"
+"import { foo } from \"./module\";\n"
+"\n"
+"// Not supported\n"
+"const mod = require(\"./module\");\n"
+"const mod = await import(\"./module\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:69
+msgid "No Prototype Manipulation"
+msgstr ""
+
+#: src/language/limitations.md:71
+msgid ""
+"Perry compiles classes to fixed structures. Dynamic prototype modification "
+"is not supported:"
+msgstr ""
+
+#: src/language/limitations.md:74
+msgid ""
+"```text\n"
+"// Not supported\n"
+"MyClass.prototype.newMethod = function() {};\n"
+"Object.setPrototypeOf(obj, proto);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:80
+msgid "No Symbol Type"
+msgstr ""
+
+#: src/language/limitations.md:82
+msgid "The `Symbol` primitive type is not currently supported:"
+msgstr ""
+
+#: src/language/limitations.md:85
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const sym = Symbol(\"description\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:90
+msgid "No WeakMap/WeakRef"
+msgstr ""
+
+#: src/language/limitations.md:92
+msgid "Weak references are not implemented:"
+msgstr ""
+
+#: src/language/limitations.md:95
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const wm = new WeakMap();\n"
+"const wr = new WeakRef(obj);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:101
+msgid "No Proxy"
+msgstr ""
+
+#: src/language/limitations.md:103
+msgid "The `Proxy` object is not supported:"
+msgstr ""
+
+#: src/language/limitations.md:106
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const proxy = new Proxy(target, handler);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:111
+msgid "Limited Error Types"
+msgstr ""
+
+#: src/language/limitations.md:113
+msgid ""
+"`Error` and basic `throw`/`catch` work, but custom error subclasses have "
+"limited support:"
+msgstr ""
+
+#: src/language/limitations.md:125
+msgid "Threading Model"
+msgstr ""
+
+#: src/language/limitations.md:127
+msgid ""
+"Perry supports real multi-threading via `parallelMap` and `spawn` from "
+"`perry/thread`. See [Multi-Threading](../threading/overview.md)."
+msgstr ""
+
+#: src/language/limitations.md:129
+msgid ""
+"Threads do not share mutable state — closures passed to thread primitives "
+"cannot capture mutable variables (enforced at compile time). Values are "
+"deep-copied across thread boundaries. There is no `SharedArrayBuffer` or "
+"`Atomics`."
+msgstr ""
+
+#: src/language/limitations.md:131
+msgid "No Computed Property Names"
+msgstr ""
+
+#: src/language/limitations.md:133
+msgid "Dynamic property keys in object literals are limited:"
+msgstr ""
+
+#: src/language/limitations.md:136
+msgid ""
+"```text\n"
+"// Supported\n"
+"const key = \"name\";\n"
+"obj[key] = \"value\";\n"
+"\n"
+"// Not supported\n"
+"const obj = { [key]: \"value\" };\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:145
+msgid "npm Package Compatibility"
+msgstr ""
+
+#: src/language/limitations.md:147
+msgid "Not all npm packages work with Perry:"
+msgstr ""
+
+#: src/language/limitations.md:149
+msgid ""
+"**Natively supported**: ~50 popular packages (fastify, mysql2, redis, etc.) "
+"— these are compiled natively. See [Standard Library](../stdlib/overview.md)."
+msgstr ""
+
+#: src/language/limitations.md:150
+msgid ""
+"**`compilePackages`**: Pure TS/JS packages can be compiled natively via "
+"[configuration](../getting-started/project-config.md)."
+msgstr ""
+
+#: src/language/limitations.md:151
+msgid ""
+"**Not supported**: Packages requiring native addons (`.node` files), "
+"`eval()`, dynamic `require()`, or Node.js internals."
+msgstr ""
+
+#: src/language/limitations.md:153
+msgid "Workarounds"
+msgstr ""
+
+#: src/language/limitations.md:155
+msgid "Dynamic Behavior"
+msgstr ""
+
+#: src/language/limitations.md:157
+msgid ""
+"For cases where you need dynamic behavior, use the JavaScript runtime "
+"fallback:"
+msgstr ""
+
+#: src/language/limitations.md:160
+msgid ""
+"```text\n"
+"import { jsEval } from \"perry/jsruntime\";\n"
+"// Routes specific code through QuickJS for dynamic evaluation\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:165
+msgid "Type Narrowing"
+msgstr ""
+
+#: src/language/limitations.md:167
+msgid "Since there's no runtime type checking, use explicit checks:"
+msgstr ""
+
+#: src/language/limitations.md:169
+msgid ""
+"```typescript\n"
+"function processValue(value: string | number) {\n"
+"    // Instead of relying on type narrowing from generics\n"
+"    if (typeof value === \"string\") {\n"
+"        // String path\n"
+"        console.log(`string path: ${value}`)\n"
+"    } else if (typeof value === \"number\") {\n"
+"        // Number path\n"
+"        console.log(`number path: ${value}`)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:184
+msgid "[Supported Features](supported-features.md) — What does work"
+msgstr ""
+
+#: src/language/limitations.md:185
+msgid "[Type System](type-system.md) — How types are handled"
+msgstr ""
+
+#: src/packages/porting.md:1
+msgid "Porting npm Packages"
+msgstr ""
+
+#: src/packages/porting.md:3
+msgid ""
+"**Status: experimental.** This guide — and the [`port-npm-to-perry` "
+"skill](https://github.com/PerryTS/perry/tree/main/.claude/skills/port-npm-to-perry) "
+"that ships alongside it — is a first pass at systematizing what Perry "
+"contributors have been doing ad-hoc. Results will vary by package. Feedback "
+"at [issue #115](https://github.com/PerryTS/perry/issues/115)."
+msgstr ""
+
+#: src/packages/porting.md:5
+msgid ""
+"Perry compiles a practical subset of TypeScript. Most pure TS/JS packages "
+"can be pulled into a native compile via `perry.compilePackages`, but some "
+"will need small patches to avoid the constructs Perry doesn't support. This "
+"page is a field guide for doing that port — by hand, or by driving a coding "
+"agent with the prompt template below."
+msgstr ""
+
+#: src/packages/porting.md:7
+msgid "When porting makes sense"
+msgstr ""
+
+#: src/packages/porting.md:9
+msgid "Situation"
+msgstr ""
+
+#: src/packages/porting.md:9
+msgid "Try this first"
+msgstr ""
+
+#: src/packages/porting.md:11
+msgid "Package uses native addons (`.node` files, `binding.gyp`, `node-gyp`)"
+msgstr ""
+
+#: src/packages/porting.md:11
+msgid ""
+"**Don't port** — no path forward. Find an alternative package or use the "
+"[QuickJS fallback](../stdlib/overview.md#javascript-runtime-fallback)."
+msgstr ""
+
+#: src/packages/porting.md:12
+msgid "Package is pure TS/JS with only light use of dynamic features"
+msgstr ""
+
+#: src/packages/porting.md:12
+msgid ""
+"**Good candidate.** Add to `compilePackages`, patch whatever trips the "
+"compiler."
+msgstr ""
+
+#: src/packages/porting.md:13
+msgid ""
+"Package's core API is built on `Proxy` (ORMs, validation DSLs, reactive "
+"stores)"
+msgstr ""
+
+#: src/packages/porting.md:13
+msgid "**Probably not portable.** The surface Perry-users touch is the Proxy."
+msgstr ""
+
+#: src/packages/porting.md:14
+msgid ""
+"Package is pure TS/JS but uses lookbehind regex, `Symbol`, `WeakMap`, etc."
+msgstr ""
+
+#: src/packages/porting.md:14
+msgid "**Patchable.** See [Common gaps](#common-gaps) below."
+msgstr ""
+
+#: src/packages/porting.md:16
+msgid "The workflow"
+msgstr ""
+
+#: src/packages/porting.md:18
+msgid "1. Add it to `compilePackages`"
+msgstr ""
+
+#: src/packages/porting.md:20
+msgid "In your project's `package.json`:"
+msgstr ""
+
+#: src/packages/porting.md:30
+msgid ""
+"This is what tells Perry to pull the package into the native compile instead "
+"of routing it through a JavaScript runtime. See [Project "
+"Configuration](../getting-started/project-config.md#compilepackages) for the "
+"full semantics — including how first-resolved directories get cached so "
+"transitive copies dedup."
+msgstr ""
+
+#: src/packages/porting.md:32
+msgid "2. Try compiling"
+msgstr ""
+
+#: src/packages/porting.md:38
+msgid ""
+"Most of the time this is where you find out what's actually broken. "
+"Compile-time errors cite a file:line in the package — that's your patch list."
+msgstr ""
+
+#: src/packages/porting.md:40
+msgid "3. Patch the gaps"
+msgstr ""
+
+#: src/packages/porting.md:42
+msgid ""
+"See [Common gaps](#common-gaps) for the typical fixes. Keep patches minimal "
+"and localized — the goal is a clean compile, not a refactor."
+msgstr ""
+
+#: src/packages/porting.md:44
+msgid ""
+"**Record each patch** in a file at your project root (convention: "
+"`perry-patches/<package>.md`) so you can reapply them after `npm install` "
+"blows them away. Until `compilePackages` grows a native patch-file "
+"convention, this is the one bit of maintenance overhead."
+msgstr ""
+
+#: src/packages/porting.md:46
+msgid "4. Re-check after each compile"
+msgstr ""
+
+#: src/packages/porting.md:48
+msgid ""
+"Iterate: compile, patch the next error, compile again. Don't try to catch "
+"everything in a single pass — some errors only surface after earlier ones "
+"are fixed."
+msgstr ""
+
+#: src/packages/porting.md:50
+msgid "Common gaps"
+msgstr ""
+
+#: src/packages/porting.md:52
+msgid ""
+"Perry's [full limitations list](../language/limitations.md) is the canonical "
+"reference. In practice, these are the ones you hit when porting:"
+msgstr ""
+
+#: src/packages/porting.md:54
+msgid "Lookbehind regex"
+msgstr ""
+
+#: src/packages/porting.md:56
+msgid ""
+"Perry uses Rust's `regex` crate, which doesn't support lookbehind (`(?<=…)` "
+"/ `(?<!…)`)."
+msgstr ""
+
+#: src/packages/porting.md:58
+msgid ""
+"```text\n"
+"// Not supported\n"
+"str.match(/(?<=prefix)\\w+/);\n"
+"\n"
+"// Rewrite — capture the prefix and slice\n"
+"const m = str.match(/prefix(\\w+)/);\n"
+"const rest = m ? m[1] : null;\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:67
+msgid "`Symbol`"
+msgstr ""
+
+#: src/packages/porting.md:69
+msgid ""
+"Not supported as a primitive. When a package uses `Symbol` as a sentinel "
+"(the common case — e.g., for unique keys in a registry), swap for a string:"
+msgstr ""
+
+#: src/packages/porting.md:71
+msgid ""
+"```text\n"
+"// Before\n"
+"const REGISTRY_KEY = Symbol(\"registry\");\n"
+"\n"
+"// After\n"
+"const REGISTRY_KEY = \"__pkg_registry__\";\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:79
+msgid ""
+"When `Symbol` is used to implement `Symbol.iterator`/`Symbol.asyncIterator`, "
+"check whether the iteration is actually reached in your use case — often the "
+"class has a `for`\\-loop method alongside the iterator and you can ignore "
+"the iterator path."
+msgstr ""
+
+#: src/packages/porting.md:81
+msgid "`Proxy`, `Reflect`"
+msgstr ""
+
+#: src/packages/porting.md:83
+msgid ""
+"Not supported. These are usually load-bearing for the package's public API, "
+"so porting is often not feasible. If the `Proxy` is only in an optional path "
+"(e.g., dev-mode warnings), delete that branch."
+msgstr ""
+
+#: src/packages/porting.md:85
+msgid "`WeakMap` / `WeakRef` / `FinalizationRegistry`"
+msgstr ""
+
+#: src/packages/porting.md:87
+msgid ""
+"Not implemented. Swap `WeakMap` for a regular `Map` if the GC semantics "
+"aren't critical for correctness (most caches can tolerate this — they'll "
+"just hold references slightly longer)."
+msgstr ""
+
+#: src/packages/porting.md:89
+msgid "Decorators"
+msgstr ""
+
+#: src/packages/porting.md:91
+msgid ""
+"```text\n"
+"// Not supported\n"
+"@Component\n"
+"class Foo {}\n"
+"\n"
+"// Remove the decorator and inline the behavior, or use a factory function\n"
+"const Foo = Component(class Foo {});\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:100
+msgid "Dynamic `require()` / `await import(…)`"
+msgstr ""
+
+#: src/packages/porting.md:102
+msgid ""
+"Perry only supports static imports. If a package branches on `typeof require "
+"!== \"undefined\"` for a Node/browser split, pick the branch that works "
+"natively and delete the other."
+msgstr ""
+
+#: src/packages/porting.md:104
+msgid "Prototype manipulation"
+msgstr ""
+
+#: src/packages/porting.md:106
+msgid ""
+"```text\n"
+"// Not supported\n"
+"Object.setPrototypeOf(obj, proto);\n"
+"MyClass.prototype.newMethod = function() {};\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:112
+msgid ""
+"Usually appears in fallback shims for older runtimes. Often dead code in the "
+"Perry path — just delete it."
+msgstr ""
+
+#: src/packages/porting.md:114
+msgid "Computed property keys in object literals"
+msgstr ""
+
+#: src/packages/porting.md:116
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const obj = { [key]: value };\n"
+"\n"
+"// Rewrite\n"
+"const obj: Record<string, V> = {};\n"
+"obj[key] = value;\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:125
+msgid "Using a coding agent"
+msgstr ""
+
+#: src/packages/porting.md:127
+msgid ""
+"A general coding agent (Claude Code, Cursor, Codex, Aider) can drive most of "
+"this workflow. If you're using a skill-aware agent, invoke the "
+"[`port-npm-to-perry` "
+"skill](https://github.com/PerryTS/perry/tree/main/.claude/skills/port-npm-to-perry) "
+"directly. Otherwise, paste this prompt:"
+msgstr ""
+
+#: src/packages/porting.md:129
+msgid ""
+"```\n"
+"I want to port the npm package <NAME> to run under Perry\n"
+"(https://github.com/PerryTS/perry). Perry compiles a subset of TypeScript\n"
+"natively; the subset's gaps are documented at\n"
+"https://github.com/PerryTS/perry/blob/main/docs/src/language/limitations.md.\n"
+"\n"
+"Please:\n"
+"\n"
+"1. Read the package at node_modules/<NAME>/. Check package.json for\n"
+"   native addons (binding.gyp, gypfile, prebuilds/ — stop if present).\n"
+"2. Scan for unsupported constructs: eval, new Function, dynamic require,\n"
+"   Symbol, Proxy, WeakMap, WeakRef, Reflect, decorators, lookbehind\n"
+"   regex (?<= / ?<!), Object.setPrototypeOf, computed property keys.\n"
+"3. Report a triage: what rules the package out vs. what's patchable.\n"
+"4. If patchable: add the package to perry.compilePackages in\n"
+"   package.json, apply minimal localized patches, and record each\n"
+"   patch in perry-patches/<NAME>.md.\n"
+"5. Verify by running `perry compile` against a small file that imports\n"
+"   the package.\n"
+"\n"
+"Don't patch blindly — a grep hit inside a string or comment isn't real.\n"
+"Show me the triage before applying substantial patches.\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:153
+msgid ""
+"This is intentionally an agent-agnostic prompt — it'll work with any "
+"competent coding agent. The skill version bundles the same instructions with "
+"richer context and is auto-discovered by Claude Code."
+msgstr ""
+
+#: src/packages/porting.md:155
+msgid "Giving feedback"
+msgstr ""
+
+#: src/packages/porting.md:157
+msgid ""
+"This whole workflow is experimental. If a port fails in a way that feels "
+"like Perry should handle it — or if the guide misses a common gap — please "
+"comment on [issue #115](https://github.com/PerryTS/perry/issues/115) so we "
+"can iterate."
+msgstr ""
+
+#: src/threading/overview.md:3
+msgid ""
+"Perry gives you real OS threads with a one-line API. No worker setup, no "
+"message ports, no structured clone overhead. Just `parallelMap`, "
+"`parallelFilter`, and `spawn`."
+msgstr ""
+
+#: src/threading/overview.md:5
+msgid ""
+"```typescript\n"
+"async function overviewHeader(): Promise<void> {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"    const records = [\n"
+"        { score: 50, id: 1 },\n"
+"        { score: 90, id: 2 },\n"
+"        { score: 85, id: 3 },\n"
+"    ]\n"
+"    const threshold = 80\n"
+"\n"
+"    // Process a million items across all CPU cores\n"
+"    const results = parallelMap(data, (item: number) => item * item)\n"
+"\n"
+"    // Filter a large dataset in parallel\n"
+"    const valid = parallelFilter(records, (r: { score: number; id: number }) "
+"=> r.score > threshold)\n"
+"\n"
+"    // Run expensive work in the background\n"
+"    const answer = await spawn(() => {\n"
+"        let acc = 0\n"
+"        for (let i = 0; i < 100_000; i++) acc += i\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    console.log(`overview-header results=${results.length} "
+"valid=${valid.length} answer=${answer}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:32
+msgid ""
+"This is something **no JavaScript runtime can do**. V8, Bun, and Deno are "
+"all locked to one thread per isolate. Perry compiles to native code — there "
+"are no isolates, no GIL, no structural limitations. Your code runs on real "
+"OS threads with the full power of every CPU core."
+msgstr ""
+
+#: src/threading/overview.md:34
+msgid "Why This Matters"
+msgstr ""
+
+#: src/threading/overview.md:36
+msgid ""
+"JavaScript's single-threaded model is its biggest performance bottleneck. "
+"Here's how runtimes try to work around it:"
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "Runtime"
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "\"Multi-threading\""
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "Reality"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid "**Node.js**"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid "`worker_threads`"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid ""
+"Separate V8 isolates. Data copied via structured clone. ~2MB RAM per worker. "
+"Complex API."
+msgstr ""
+
+#: src/threading/overview.md:41
+msgid "**Deno**"
+msgstr ""
+
+#: src/threading/overview.md:41 src/threading/overview.md:42
+msgid "`Worker`"
+msgstr ""
+
+#: src/threading/overview.md:41
+msgid "Same as Node — isolated heaps, message passing only."
+msgstr ""
+
+#: src/threading/overview.md:42
+msgid "**Bun**"
+msgstr ""
+
+#: src/threading/overview.md:42
+msgid "Same architecture. Faster structured clone, still isolated."
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid "**Perry**"
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid "`parallelMap` / `spawn`"
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid ""
+"Real OS threads. Lightweight (8MB stack). One-line API. Compile-time safety."
+msgstr ""
+
+#: src/threading/overview.md:45
+msgid ""
+"The fundamental problem: V8 uses a garbage-collected heap that **cannot be "
+"shared** between threads. Every \"worker\" is an entirely separate "
+"JavaScript engine instance with its own heap, its own GC, and its own copy "
+"of your data."
+msgstr ""
+
+#: src/threading/overview.md:47
+msgid ""
+"Perry doesn't have this limitation. It compiles TypeScript to native machine "
+"code. Values are transferred between threads using zero-cost copies for "
+"numbers and efficient serialization for objects — no separate engine "
+"instances, no multi-megabyte overhead per thread."
+msgstr ""
+
+#: src/threading/overview.md:49
+msgid "Three Primitives"
+msgstr ""
+
+#: src/threading/overview.md:51
+msgid "`parallelMap` — Data-Parallel Processing"
+msgstr ""
+
+#: src/threading/overview.md:53
+msgid ""
+"Split an array across all CPU cores. Each element is processed "
+"independently. Results are collected in order."
+msgstr ""
+
+#: src/threading/overview.md:55
+msgid ""
+"```typescript\n"
+"async function overviewParallelMap(): Promise<void> {\n"
+"    const prices = [100, 200, 300, 400, 500, 600, 700, 800]\n"
+"    const adjusted = parallelMap(prices, (price: number) => {\n"
+"        // Heavy computation runs on a worker thread\n"
+"        let result = price\n"
+"        for (let i = 0; i < 1000000; i++) {\n"
+"            result = Math.sqrt(result * result + i)\n"
+"        }\n"
+"        return result\n"
+"    })\n"
+"\n"
+"    console.log(`overview-parallel-map len=${adjusted.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:71 src/plugins/creating-plugins.md:37
+msgid "Perry automatically:"
+msgstr ""
+
+#: src/threading/overview.md:72
+msgid "Detects the number of CPU cores"
+msgstr ""
+
+#: src/threading/overview.md:73
+msgid "Splits the array into chunks (one per core)"
+msgstr ""
+
+#: src/threading/overview.md:74
+msgid "Spawns OS threads to process each chunk"
+msgstr ""
+
+#: src/threading/overview.md:75
+msgid "Collects results in the original order"
+msgstr ""
+
+#: src/threading/overview.md:76
+msgid "Returns a new array"
+msgstr ""
+
+#: src/threading/overview.md:78
+msgid ""
+"For small arrays, Perry skips threading entirely and processes inline — no "
+"overhead for trivial cases."
+msgstr ""
+
+#: src/threading/overview.md:80
+msgid "`parallelFilter` — Data-Parallel Filtering"
+msgstr ""
+
+#: src/threading/overview.md:82
+msgid "Filter a large array across all CPU cores. Like `.filter()` but parallel:"
+msgstr ""
+
+#: src/threading/overview.md:84
+msgid ""
+"```typescript\n"
+"async function overviewParallelFilter(): Promise<void> {\n"
+"    const cutoffDate = 1_700_000_000\n"
+"    const users = [\n"
+"        { lastLogin: 1_710_000_000, score: 150, name: \"alice\" },\n"
+"        { lastLogin: 1_690_000_000, score: 50, name: \"bob\" },\n"
+"        { lastLogin: 1_720_000_000, score: 120, name: \"carol\" },\n"
+"    ]\n"
+"\n"
+"    // Filter across all cores — order is preserved\n"
+"    const active = parallelFilter(users, (user: { lastLogin: number; score: "
+"number; name: string }) => {\n"
+"        return user.lastLogin > cutoffDate && user.score > 100\n"
+"    })\n"
+"\n"
+"    console.log(`overview-parallel-filter active=${active.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:102
+msgid ""
+"Same rules as `parallelMap`: closures cannot capture mutable variables "
+"(compile-time enforced), and values are deep-copied between threads."
+msgstr ""
+
+#: src/threading/overview.md:104
+msgid "`spawn` — Background Threads"
+msgstr ""
+
+#: src/threading/overview.md:106
+msgid ""
+"Run any computation in the background and get a Promise back. The main "
+"thread continues immediately."
+msgstr ""
+
+#: src/threading/overview.md:108
+msgid ""
+"```typescript\n"
+"async function overviewSpawnBg(): Promise<void> {\n"
+"    // Start heavy work in the background\n"
+"    const handle = spawn(() => {\n"
+"        let sum = 0\n"
+"        for (let i = 0; i < 100_000; i++) {\n"
+"            sum += Math.sin(i)\n"
+"        }\n"
+"        return sum\n"
+"    })\n"
+"\n"
+"    // Main thread keeps running — UI stays responsive\n"
+"    console.log(\"Computing...\")\n"
+"\n"
+"    // Get the result when you need it\n"
+"    const result = await handle\n"
+"    console.log(`Done: len=${typeof result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:128
+msgid ""
+"`spawn` returns a standard Promise. You can `await` it, pass it to "
+"`Promise.all`, or chain `.then()` — it works exactly like any other async "
+"operation."
+msgstr ""
+
+#: src/threading/overview.md:130
+msgid "Practical Examples"
+msgstr ""
+
+#: src/threading/overview.md:132
+msgid "Parallel Image Processing"
+msgstr ""
+
+#: src/threading/overview.md:134
+msgid ""
+"```typescript\n"
+"async function overviewImage(): Promise<void> {\n"
+"    const pixels = [\n"
+"        { r: 100, g: 120, b: 140 },\n"
+"        { r: 50, g: 60, b: 70 },\n"
+"        { r: 200, g: 210, b: 220 },\n"
+"    ]\n"
+"\n"
+"    // Each pixel processed on a separate core\n"
+"    const processed = parallelMap(pixels, (pixel: { r: number; g: number; b: "
+"number }) => {\n"
+"        const r = Math.min(255, pixel.r * 1.2)\n"
+"        const g = Math.min(255, pixel.g * 0.8)\n"
+"        const b = Math.min(255, pixel.b * 1.1)\n"
+"        return { r, g, b }\n"
+"    })\n"
+"\n"
+"    console.log(`overview-image processed=${processed.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:154
+msgid "Parallel Cryptographic Hashing"
+msgstr ""
+
+#: src/threading/overview.md:156
+msgid ""
+"```typescript\n"
+"async function overviewCrypto(): Promise<void> {\n"
+"    // Hash thousands of items across all cores\n"
+"    const passwords = [\"pass1\", \"pass2\", \"pass3\"]\n"
+"    const hashed = parallelMap(passwords, (password: string) => {\n"
+"        // Stand-in for a real hash: deterministic FNV-1a over the bytes.\n"
+"        let h = 2166136261\n"
+"        for (let i = 0; i < password.length; i++) {\n"
+"            h ^= password.charCodeAt(i)\n"
+"            h = (h * 16777619) >>> 0\n"
+"        }\n"
+"        return h\n"
+"    })\n"
+"\n"
+"    console.log(`overview-crypto hashed=${hashed.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:174
+msgid "Multiple Independent Computations"
+msgstr ""
+
+#: src/threading/overview.md:176
+msgid ""
+"```typescript\n"
+"async function overviewMultiple(): Promise<void> {\n"
+"    const dataA = [1, 2, 3]\n"
+"    const dataB = [4, 5, 6]\n"
+"    const dataC = [7, 8, 9]\n"
+"\n"
+"    // Three independent tasks run simultaneously on three OS threads\n"
+"    const task1 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataA) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"    const task2 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataB) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"    const task3 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataC) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    // All three run concurrently\n"
+"    const [result1, result2, result3] = await Promise.all([task1, task2, "
+"task3])\n"
+"    console.log(`overview-multiple ${result1} ${result2} ${result3}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:205
+msgid "Keeping UI Responsive"
+msgstr ""
+
+#: src/threading/overview.md:207
+msgid ""
+"```typescript\n"
+"const responsiveButton = Button(\"Start Analysis\", async () => {\n"
+"    status.set(\"Analyzing...\")\n"
+"\n"
+"    // Heavy computation runs on a background thread\n"
+"    // UI stays responsive — user can still interact\n"
+"    const value = await spawn(() => {\n"
+"        let acc = 0\n"
+"        for (let i = 0; i < 1_000_000; i++) acc += i\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    status.set(`Done: ${value}`)\n"
+"})\n"
+"\n"
+"const responsiveText = Text(`Status: ${status.value}`)\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:225
+msgid "Captured Variables"
+msgstr ""
+
+#: src/threading/overview.md:227
+msgid ""
+"Closures can capture outer variables. Captured values are automatically "
+"deep-copied to each worker thread:"
+msgstr ""
+
+#: src/threading/overview.md:229
+msgid ""
+"```typescript\n"
+"async function overviewCaptured(): Promise<void> {\n"
+"    const prices = [100, 200, 300, 400]\n"
+"    const taxRate = 0.08\n"
+"    const discount = 0.15\n"
+"\n"
+"    // taxRate and discount are captured and copied to each thread\n"
+"    const finalPrices = parallelMap(prices, (price: number) => {\n"
+"        const discounted = price * (1 - discount)\n"
+"        return discounted * (1 + taxRate)\n"
+"    })\n"
+"\n"
+"    console.log(`overview-captured len=${finalPrices.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:245
+msgid ""
+"Numbers and booleans are zero-cost copies (just 64-bit values). Strings, "
+"arrays, and objects are deep-copied automatically."
+msgstr ""
+
+#: src/threading/overview.md:247
+msgid "Safety"
+msgstr ""
+
+#: src/threading/overview.md:249
+msgid ""
+"Perry enforces thread safety **at compile time**. You don't need to think "
+"about race conditions, mutexes, or data corruption."
+msgstr ""
+
+#: src/threading/overview.md:251
+msgid "No Shared Mutable State"
+msgstr ""
+
+#: src/threading/overview.md:253
+msgid ""
+"Closures passed to `parallelMap` and `spawn` **cannot capture mutable "
+"variables**. The compiler rejects this:"
+msgstr ""
+
+#: src/threading/overview.md:255
+msgid ""
+"```text\n"
+"// Reject example — Perry rejects this at compile time:\n"
+"\n"
+"let counter = 0;\n"
+"\n"
+"// COMPILE ERROR: Closures passed to parallelMap cannot\n"
+"// capture mutable variable 'counter'\n"
+"parallelMap(data, (item) => {\n"
+"    counter++;  // Not allowed\n"
+"    return item;\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:268
+msgid ""
+"This eliminates data races by design. If you need to aggregate results, use "
+"the return values:"
+msgstr ""
+
+#: src/threading/overview.md:270
+msgid ""
+"```typescript\n"
+"async function overviewReduceInstead(): Promise<void> {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    // Instead of mutating a shared counter, return values and reduce\n"
+"    const results = parallelMap(data, (item: number) => item * item)\n"
+"    const total = results.reduce((sum: number, r: number) => sum + r, 0)\n"
+"\n"
+"    console.log(`overview-reduce-instead total=${total}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:282
+msgid "Independent Thread Arenas"
+msgstr ""
+
+#: src/threading/overview.md:284
+msgid ""
+"Each worker thread has its own memory arena. Objects created on one thread "
+"can never be accessed from another thread. Values cross thread boundaries "
+"only through deep-copy serialization, which Perry handles automatically and "
+"invisibly."
+msgstr ""
+
+#: src/threading/overview.md:288
+msgid "Perry's threading model is built on three pillars:"
+msgstr ""
+
+#: src/threading/overview.md:290
+msgid "**1. Native Code, Not Interpreted**"
+msgstr ""
+
+#: src/threading/overview.md:292
+msgid ""
+"Perry compiles TypeScript to native machine code via LLVM. There's no "
+"interpreter, no VM, no isolate. A function pointer is just a function "
+"pointer — it's valid on any thread."
+msgstr ""
+
+#: src/threading/overview.md:294
+msgid "**2. Thread-Local Memory**"
+msgstr ""
+
+#: src/threading/overview.md:296
+msgid ""
+"Each thread gets its own memory arena (bump allocator) and garbage "
+"collector. No synchronization overhead during computation. When a thread "
+"finishes, its arena is freed automatically."
+msgstr ""
+
+#: src/threading/overview.md:298
+msgid "**3. Serialized Transfer**"
+msgstr ""
+
+#: src/threading/overview.md:300
+msgid ""
+"Values crossing thread boundaries are serialized to a thread-safe "
+"intermediate format and deserialized on the target thread. The cost depends "
+"on the value type:"
+msgstr ""
+
+#: src/threading/overview.md:302
+msgid "Value Type"
+msgstr ""
+
+#: src/threading/overview.md:302
+msgid "Transfer Cost"
+msgstr ""
+
+#: src/threading/overview.md:304
+msgid "Numbers, booleans, null, undefined"
+msgstr ""
+
+#: src/threading/overview.md:304 src/threading/parallel-map.md:55
+msgid "Zero-cost (64-bit copy)"
+msgstr ""
+
+#: src/threading/overview.md:305 src/threading/parallel-map.md:57
+msgid "Strings"
+msgstr ""
+
+#: src/threading/overview.md:305
+msgid "O(n) byte copy"
+msgstr ""
+
+#: src/threading/overview.md:306
+msgid "O(n) deep copy of elements"
+msgstr ""
+
+#: src/threading/overview.md:307
+msgid "O(n) deep copy of fields"
+msgstr ""
+
+#: src/threading/overview.md:308
+msgid "Pointer + captured values"
+msgstr ""
+
+#: src/threading/overview.md:310
+msgid ""
+"For numeric workloads — the most common parallelizable tasks — the threading "
+"overhead is negligible."
+msgstr ""
+
+#: src/threading/overview.md:314
+msgid ""
+"[parallelMap Reference](parallel-map.md) — detailed API and performance tips"
+msgstr ""
+
+#: src/threading/overview.md:315
+msgid "[parallelFilter Reference](parallel-filter.md) — parallel array filtering"
+msgstr ""
+
+#: src/threading/overview.md:316
+msgid "[spawn Reference](spawn.md) — background threads and Promise integration"
+msgstr ""
+
+#: src/threading/parallel-map.md:3
+msgid ""
+"**Signature**: `parallelMap<T, U>(data: T[], fn: (item: T) => U): U[]` — "
+"imported from `perry/thread`."
+msgstr ""
+
+#: src/threading/parallel-map.md:5
+msgid ""
+"Processes every element of an array in parallel across all available CPU "
+"cores. Returns a new array with the results in the same order as the input."
+msgstr ""
+
+#: src/threading/parallel-map.md:7 src/threading/parallel-filter.md:7
+#: src/threading/spawn.md:7
+msgid "Basic Usage"
+msgstr ""
+
+#: src/threading/parallel-map.md:9
+msgid ""
+"```typescript\n"
+"function parallelMapBasic(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"    const doubled = parallelMap(numbers, (x: number) => x * 2)\n"
+"    // [2, 4, 6, 8, 10, 12, 14, 16]\n"
+"    console.log(`parallel-map-basic len=${doubled.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:31
+msgid ""
+"Perry automatically detects the number of CPU cores and splits the array "
+"into equal chunks. Elements within each chunk are processed sequentially; "
+"chunks run concurrently across cores."
+msgstr ""
+
+#: src/threading/parallel-map.md:33 src/threading/parallel-filter.md:53
+#: src/threading/spawn.md:80
+msgid "Capturing Variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:35
+msgid ""
+"The mapping function can reference variables from the outer scope. Captured "
+"values are deep-copied to each worker thread automatically:"
+msgstr ""
+
+#: src/threading/parallel-map.md:37
+msgid ""
+"```typescript\n"
+"function parallelMapCapture(): void {\n"
+"    const prices = [100, 200, 300]\n"
+"    const exchangeRate = 1.12\n"
+"\n"
+"    const converted = parallelMap(prices, (price: number) => {\n"
+"        // exchangeRate is captured and copied to each thread\n"
+"        return price * exchangeRate\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-capture len=${converted.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:51
+msgid "What Can Be Captured"
+msgstr ""
+
+#: src/threading/parallel-map.md:53 src/ui/overview.md:57 src/ui/styling.md:45
+#: src/widgets/creating-widgets.md:45 src/widgets/configuration.md:70
+#: src/testing/geisterhand.md:84 src/cli/flags.md:43 src/cli/perry-toml.md:114
+#: src/cli/perry-toml.md:125 src/cli/perry-toml.md:153
+#: src/cli/perry-toml.md:165 src/cli/perry-toml.md:175
+#: src/cli/perry-toml.md:181 src/cli/perry-toml.md:191
+#: src/cli/perry-toml.md:241 src/cli/perry-toml.md:254
+#: src/cli/perry-toml.md:260 src/cli/perry-toml.md:268
+#: src/cli/perry-toml.md:299 src/cli/perry-toml.md:310
+#: src/cli/perry-toml.md:327 src/cli/perry-toml.md:345
+#: src/cli/perry-toml.md:357 src/cli/perry-toml.md:367
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414 src/contributing/architecture.md:47
+msgid "Type"
+msgstr ""
+
+#: src/threading/parallel-map.md:53
+msgid "Supported"
+msgstr ""
+
+#: src/threading/parallel-map.md:53
+msgid "Transfer"
+msgstr ""
+
+#: src/threading/parallel-map.md:55
+msgid "Numbers"
+msgstr ""
+
+#: src/threading/parallel-map.md:55 src/threading/parallel-map.md:56
+#: src/threading/parallel-map.md:57 src/threading/parallel-map.md:58
+#: src/threading/parallel-map.md:59 src/threading/parallel-map.md:60
+#: src/platforms/overview.md:69 src/platforms/overview.md:70
+#: src/platforms/overview.md:71 src/platforms/overview.md:72
+#: src/platforms/overview.md:73 src/platforms/overview.md:74
+#: src/platforms/overview.md:75 src/widgets/platforms.md:22
+#: src/widgets/platforms.md:23 src/widgets/platforms.md:24
+#: src/widgets/platforms.md:25 src/widgets/platforms.md:26
+#: src/widgets/platforms.md:27 src/widgets/platforms.md:28
+#: src/widgets/platforms.md:29 src/widgets/platforms.md:30
+#: src/widgets/platforms.md:31 src/widgets/platforms.md:32
+#: src/widgets/platforms.md:33
+msgid "Yes"
+msgstr ""
+
+#: src/threading/parallel-map.md:56
+msgid "Booleans"
+msgstr ""
+
+#: src/threading/parallel-map.md:56
+msgid "Zero-cost"
+msgstr ""
+
+#: src/threading/parallel-map.md:57
+msgid "Byte copy"
+msgstr ""
+
+#: src/threading/parallel-map.md:58 src/threading/parallel-map.md:59
+msgid "Deep copy"
+msgstr ""
+
+#: src/threading/parallel-map.md:60
+msgid "`const` variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:60 src/threading/parallel-map.md:61
+msgid "Copied"
+msgstr ""
+
+#: src/threading/parallel-map.md:61
+msgid "`let`/`var` variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:61
+msgid "Only if not reassigned"
+msgstr ""
+
+#: src/threading/parallel-map.md:63
+msgid "What Cannot Be Captured"
+msgstr ""
+
+#: src/threading/parallel-map.md:65
+msgid ""
+"Mutable variables — variables that are reassigned anywhere in the enclosing "
+"scope — are rejected at compile time:"
+msgstr ""
+
+#: src/threading/parallel-map.md:67
+msgid ""
+"```text\n"
+"// Reject example — Perry rejects this at compile time:\n"
+"\n"
+"let total = 0;\n"
+"\n"
+"// COMPILE ERROR: Cannot capture mutable variable 'total'\n"
+"parallelMap(data, (item) => {\n"
+"    total += item;   // Would be a data race\n"
+"    return item;\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:79
+msgid "Instead, return values and reduce:"
+msgstr ""
+
+#: src/threading/parallel-map.md:90 src/threading/parallel-filter.md:155
+msgid "Performance"
+msgstr ""
+
+#: src/threading/parallel-map.md:92
+msgid "When to Use parallelMap"
+msgstr ""
+
+#: src/threading/parallel-map.md:94
+msgid ""
+"Use `parallelMap` when the computation per element is **significantly "
+"heavier** than the cost of copying the element across threads."
+msgstr ""
+
+#: src/threading/parallel-map.md:96
+msgid "**Good candidates** (CPU-bound work per element):"
+msgstr ""
+
+#: src/threading/parallel-map.md:98
+msgid ""
+"```typescript\n"
+"function parallelMapGoodCandidates(): void {\n"
+"    const data = [1.0, 2.0, 3.0, 4.0]\n"
+"    const documents = [\"alpha beta\", \"gamma delta\", \"epsilon\"]\n"
+"    const inputs = [\"a\", \"bb\", \"ccc\"]\n"
+"\n"
+"    // Heavy math\n"
+"    const out1 = parallelMap(data, (x: number) => {\n"
+"        let acc = x\n"
+"        for (let i = 0; i < 1_000; i++) acc = Math.sqrt(acc * acc + i)\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    // String processing on large strings\n"
+"    const out2 = parallelMap(documents, (doc: string) => {\n"
+"        const words = doc.split(\" \")\n"
+"        return { count: words.length, first: words[0] }\n"
+"    })\n"
+"\n"
+"    // Cryptographic operations\n"
+"    const out3 = parallelMap(inputs, (input: string) => {\n"
+"        let h = 0\n"
+"        for (let i = 0; i < input.length; i++) h = (h * 31 + "
+"input.charCodeAt(i)) >>> 0\n"
+"        return h\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-good-candidates ${out1.length} ${out2.length} "
+"${out3.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:128
+msgid "**Poor candidates** (trivial work per element):"
+msgstr ""
+
+#: src/threading/parallel-map.md:130
+msgid ""
+"```typescript\n"
+"function parallelMapPoorCandidate(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5]\n"
+"\n"
+"    // Too simple — threading overhead outweighs the gain\n"
+"    const a = parallelMap(numbers, (x: number) => x + 1)\n"
+"\n"
+"    // For trivial operations, use regular map\n"
+"    const result = numbers.map((x: number) => x + 1)\n"
+"\n"
+"    console.log(`parallel-map-poor-candidate ${a.length} ${result.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:144
+msgid "Small Array Optimization"
+msgstr ""
+
+#: src/threading/parallel-map.md:146
+msgid ""
+"For arrays with fewer elements than CPU cores, Perry skips threading "
+"entirely and processes elements inline on the main thread. There's zero "
+"overhead for small inputs."
+msgstr ""
+
+#: src/threading/parallel-map.md:148
+msgid "Numeric Fast Path"
+msgstr ""
+
+#: src/threading/parallel-map.md:150
+msgid ""
+"When elements are pure numbers (no strings, objects, or arrays), Perry "
+"transfers them between threads at virtually zero cost — just 64-bit value "
+"copies with no serialization."
+msgstr ""
+
+#: src/threading/parallel-map.md:152 src/threading/parallel-filter.md:78
+#: src/threading/spawn.md:183 src/cli/flags.md:139
+msgid "Examples"
+msgstr ""
+
+#: src/threading/parallel-map.md:154
+msgid "Matrix Row Processing"
+msgstr ""
+
+#: src/threading/parallel-map.md:156
+msgid ""
+"```typescript\n"
+"function parallelMapMatrix(): void {\n"
+"    // Process each row of a matrix independently\n"
+"    const rows = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]\n"
+"    const rowSums = parallelMap(rows, (row: number[]) => {\n"
+"        let sum = 0\n"
+"        for (const val of row) sum += val\n"
+"        return sum\n"
+"    })\n"
+"    // [6, 15, 24]\n"
+"    console.log(`parallel-map-matrix "
+"sums=${rowSums[0]},${rowSums[1]},${rowSums[2]}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:170
+msgid "Batch Validation"
+msgstr ""
+
+#: src/threading/parallel-map.md:172
+msgid ""
+"```typescript\n"
+"function parallelMapValidation(): void {\n"
+"    const users = [\n"
+"        { name: \"Alice\", email: \"alice@example.com\" },\n"
+"        { name: \"Bob\", email: \"invalid\" },\n"
+"        { name: \"Charlie\", email: \"charlie@example.com\" },\n"
+"    ]\n"
+"\n"
+"    const validationResults = parallelMap(users, (user: { name: string; "
+"email: string }) => {\n"
+"        const emailValid = user.email.includes(\"@\") && "
+"user.email.includes(\".\")\n"
+"        const nameValid = user.name.length > 0 && user.name.length < 100\n"
+"        return { name: user.name, valid: emailValid && nameValid }\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-validation len=${validationResults.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:190
+msgid "Financial Calculations"
+msgstr ""
+
+#: src/threading/parallel-map.md:192
+msgid ""
+"```typescript\n"
+"function parallelMapMonteCarlo(): void {\n"
+"    const portfolios = [\n"
+"        { id: 1, base: 100 },\n"
+"        { id: 2, base: 200 },\n"
+"        { id: 3, base: 150 },\n"
+"    ] // thousands of portfolios\n"
+"\n"
+"    // Monte Carlo simulation across all cores\n"
+"    const riskScores = parallelMap(portfolios, (portfolio: { id: number; "
+"base: number }) => {\n"
+"        let totalRisk = 0\n"
+"        for (let sim = 0; sim < 1000; sim++) {\n"
+"            // simulateReturns stand-in: deterministic pseudo-random walk.\n"
+"            let s = portfolio.base + sim\n"
+"            s = ((s * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff\n"
+"            totalRisk += s\n"
+"        }\n"
+"        return totalRisk / 1000\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-monte-carlo len=${riskScores.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:3
+msgid ""
+"**Signature**: `parallelFilter<T>(data: T[], predicate: (item: T) => "
+"boolean): T[]` — imported from `perry/thread`."
+msgstr ""
+
+#: src/threading/parallel-filter.md:5
+msgid ""
+"Filters an array in parallel across all available CPU cores. Returns a new "
+"array containing only the elements where the predicate returned a truthy "
+"value. Order is preserved."
+msgstr ""
+
+#: src/threading/parallel-filter.md:9
+msgid ""
+"```typescript\n"
+"function parallelFilterBasic(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n"
+"    const evens = parallelFilter(numbers, (x: number) => x % 2 === 0)\n"
+"    // [2, 4, 6, 8, 10]\n"
+"    console.log(`parallel-filter-basic len=${evens.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:31
+msgid ""
+"Each core independently tests its chunk of elements. Results are merged in "
+"the original element order after all threads complete."
+msgstr ""
+
+#: src/threading/parallel-filter.md:33
+msgid "Why Not Just Use `.filter()`?"
+msgstr ""
+
+#: src/threading/parallel-filter.md:35
+msgid ""
+"Regular `.filter()` runs on a single thread. For large arrays with expensive "
+"predicates, `parallelFilter` distributes the work:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:37
+msgid ""
+"```typescript\n"
+"function parallelFilterVsFilter(): void {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    // Single-threaded — one core does all the work\n"
+"    const a = data.filter((item: number) => item > 3)\n"
+"\n"
+"    // Parallel — all cores share the work\n"
+"    const b = parallelFilter(data, (item: number) => item > 3)\n"
+"\n"
+"    console.log(`parallel-filter-vs-filter ${a.length} ${b.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:51
+msgid ""
+"The tradeoff: `parallelFilter` has overhead from copying values between "
+"threads. Use it when the predicate is expensive enough to justify that cost."
+msgstr ""
+
+#: src/threading/parallel-filter.md:55
+msgid ""
+"Like `parallelMap`, the predicate can capture outer variables. Captures are "
+"deep-copied to each thread:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:57
+msgid ""
+"```typescript\n"
+"function parallelFilterCapture(): void {\n"
+"    const candidates = [\n"
+"        { name: \"Alice\", score: 90, age: 28 },\n"
+"        { name: \"Bob\", score: 80, age: 35 },\n"
+"        { name: \"Carol\", score: 95, age: 25 },\n"
+"    ]\n"
+"    const minScore = 85\n"
+"    const maxAge = 30\n"
+"\n"
+"    // minScore and maxAge are captured and copied to each thread\n"
+"    const qualified = parallelFilter(candidates, (c: { name: string; score: "
+"number; age: number }) => {\n"
+"        return c.score >= minScore && c.age <= maxAge\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-capture len=${qualified.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:76
+msgid ""
+"Mutable variables cannot be captured — the compiler rejects this at compile "
+"time."
+msgstr ""
+
+#: src/threading/parallel-filter.md:80
+msgid "Filtering Large Datasets"
+msgstr ""
+
+#: src/threading/parallel-filter.md:82
+msgid ""
+"```typescript\n"
+"function parallelFilterLarge(): void {\n"
+"    // Stand-in for \"millions of records\" — same shape, smaller list.\n"
+"    const transactions = [\n"
+"        { amount: 15000, country: \"US\", user: { homeCountry: \"DE\" }, "
+"timestamp: { hour: 4 } },\n"
+"        { amount: 200, country: \"DE\", user: { homeCountry: \"DE\" }, "
+"timestamp: { hour: 12 } },\n"
+"        { amount: 50000, country: \"FR\", user: { homeCountry: \"DE\" }, "
+"timestamp: { hour: 3 } },\n"
+"    ]\n"
+"\n"
+"    const suspicious = parallelFilter(transactions, (tx: {\n"
+"        amount: number\n"
+"        country: string\n"
+"        user: { homeCountry: string }\n"
+"        timestamp: { hour: number }\n"
+"    }) => {\n"
+"        return tx.amount > 10000\n"
+"            && tx.country !== tx.user.homeCountry\n"
+"            && tx.timestamp.hour < 6\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-large len=${suspicious.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:106
+msgid "Combined with parallelMap"
+msgstr ""
+
+#: src/threading/parallel-filter.md:108
+msgid ""
+"```typescript\n"
+"function parallelFilterCombined(): void {\n"
+"    const users = [\n"
+"        { name: \"Alice\", isActive: true, age: 28, score: 90 },\n"
+"        { name: \"Bob\", isActive: false, age: 35, score: 80 },\n"
+"        { name: \"Carol\", isActive: true, age: 17, score: 95 },\n"
+"        { name: \"Dave\", isActive: true, age: 40, score: 60 },\n"
+"    ]\n"
+"\n"
+"    // Step 1: Filter to relevant items (parallel)\n"
+"    const active = parallelFilter(users, (u: { isActive: boolean; age: "
+"number }) => u.isActive && u.age >= 18)\n"
+"\n"
+"    // Step 2: Transform the filtered results (parallel)\n"
+"    const profiles = parallelMap(active, (u: { name: string; score: number "
+"}) => ({\n"
+"        name: u.name,\n"
+"        score: u.score * 2,\n"
+"    }))\n"
+"\n"
+"    console.log(`parallel-filter-combined active=${active.length} "
+"profiles=${profiles.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:130
+msgid "Predicate with Heavy Computation"
+msgstr ""
+
+#: src/threading/parallel-filter.md:132
+msgid ""
+"```typescript\n"
+"function parallelFilterHeavy(): void {\n"
+"    const certificates = [\n"
+"        { id: 1, fingerprint: \"aa\", revoked: false },\n"
+"        { id: 2, fingerprint: \"bb\", revoked: true },\n"
+"        { id: 3, fingerprint: \"cc\", revoked: false },\n"
+"    ]\n"
+"\n"
+"    // Each predicate call does significant work — perfect for "
+"parallelization.\n"
+"    const valid = parallelFilter(certificates, (cert: { id: number; "
+"fingerprint: string; revoked: boolean }) => {\n"
+"        // Stand-in for a real chain verification: hash the fingerprint a "
+"bit\n"
+"        // then sanity-check the revocation flag.\n"
+"        let h = 0\n"
+"        for (let i = 0; i < cert.fingerprint.length; i++) {\n"
+"            h = (h * 31 + cert.fingerprint.charCodeAt(i)) >>> 0\n"
+"        }\n"
+"        return h !== 0 && !cert.revoked\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-heavy len=${valid.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:157
+msgid "Use `parallelFilter` when:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:158
+msgid "The array has many elements (hundreds or more)"
+msgstr ""
+
+#: src/threading/parallel-filter.md:159
+msgid "The predicate function does meaningful work per element"
+msgstr ""
+
+#: src/threading/parallel-filter.md:160
+msgid "You need to keep the UI responsive during filtering"
+msgstr ""
+
+#: src/threading/parallel-filter.md:162
+msgid ""
+"For trivial predicates on small arrays, regular `.filter()` is faster (no "
+"threading overhead)."
+msgstr ""
+
+#: src/threading/spawn.md:3
+msgid ""
+"**Signature**: `spawn<T>(fn: () => T): Promise<T>` — imported from "
+"`perry/thread`."
+msgstr ""
+
+#: src/threading/spawn.md:5
+msgid ""
+"Runs a closure on a new OS thread and returns a Promise that resolves when "
+"the thread completes. The main thread continues immediately — UI and other "
+"work are not blocked."
+msgstr ""
+
+#: src/threading/spawn.md:9
+msgid ""
+"```typescript\n"
+"async function spawnBasic(): Promise<void> {\n"
+"    const result = await spawn(() => {\n"
+"        // This runs on a separate OS thread.\n"
+"        let sum = 0\n"
+"        for (let i = 0; i < 100_000_000; i++) {\n"
+"            sum += i\n"
+"        }\n"
+"        return sum\n"
+"    })\n"
+"\n"
+"    console.log(result) // 4999999950000000\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:24
+msgid "Non-Blocking"
+msgstr ""
+
+#: src/threading/spawn.md:26
+msgid "`spawn` returns immediately. The main thread doesn't wait:"
+msgstr ""
+
+#: src/threading/spawn.md:28
+msgid ""
+"```typescript\n"
+"async function spawnNonBlocking(): Promise<void> {\n"
+"    console.log(\"1. Starting background work\")\n"
+"\n"
+"    const handle = spawn(() => {\n"
+"        // Runs on a background thread — heavier work elided here.\n"
+"        let n = 0\n"
+"        for (let i = 0; i < 10_000_000; i++) n++\n"
+"        return n\n"
+"    })\n"
+"\n"
+"    console.log(\"2. Main thread continues immediately\")\n"
+"\n"
+"    const result = await handle\n"
+"    console.log(`3. Got result: ${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:53
+msgid "Multiple Concurrent Tasks"
+msgstr ""
+
+#: src/threading/spawn.md:55
+msgid ""
+"Spawn multiple tasks and they run truly concurrently — one OS thread per "
+"`spawn` call:"
+msgstr ""
+
+#: src/threading/spawn.md:57
+msgid ""
+"```typescript\n"
+"async function spawnMultiple(): Promise<void> {\n"
+"    const t1 = spawn(() => analyseChunk(0, 1_000_000))\n"
+"    const t2 = spawn(() => analyseChunk(1_000_000, 2_000_000))\n"
+"    const t3 = spawn(() => analyseChunk(2_000_000, 3_000_000))\n"
+"\n"
+"    // All three run simultaneously on separate OS threads.\n"
+"    const results = await Promise.all([t1, t2, t3])\n"
+"\n"
+"    console.log(`Region A: ${results[0]}`)\n"
+"    console.log(`Region B: ${results[1]}`)\n"
+"    console.log(`Region C: ${results[2]}`)\n"
+"}\n"
+"\n"
+"function analyseChunk(start: number, end: number): number {\n"
+"    let acc = 0\n"
+"    for (let i = start; i < end; i++) acc += i & 0xff\n"
+"    return acc\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:78
+msgid ""
+"Unlike Node.js `worker_threads`, each `spawn` is a lightweight OS thread "
+"(~8MB stack), not a full V8 isolate (~2MB heap + startup cost)."
+msgstr ""
+
+#: src/threading/spawn.md:82
+msgid ""
+"Like `parallelMap`, `spawn` closures can capture outer variables. They are "
+"deep-copied to the background thread:"
+msgstr ""
+
+#: src/threading/spawn.md:84
+msgid ""
+"```typescript\n"
+"async function spawnCapture(): Promise<void> {\n"
+"    const config = { iterations: 1000, seed: 42 }\n"
+"    const dataset = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    const result = await spawn(() => {\n"
+"        // config and dataset are deep-copied to this thread.\n"
+"        let acc = config.seed\n"
+"        for (let i = 0; i < config.iterations; i++) {\n"
+"            acc = (acc * 1103515245 + 12345) & 0x7fffffff\n"
+"        }\n"
+"        for (const v of dataset) acc ^= v\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-capture: ${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:103
+msgid "Mutable variables cannot be captured — this is enforced at compile time."
+msgstr ""
+
+#: src/threading/spawn.md:105
+msgid "Returning Complex Values"
+msgstr ""
+
+#: src/threading/spawn.md:107
+msgid ""
+"`spawn` can return any value type. Complex values (objects, arrays, strings) "
+"are serialized back to the main thread automatically:"
+msgstr ""
+
+#: src/threading/spawn.md:133
+msgid "UI Integration"
+msgstr ""
+
+#: src/threading/spawn.md:135
+msgid ""
+"`spawn` is ideal for keeping native UIs responsive during heavy computation:"
+msgstr ""
+
+#: src/threading/spawn.md:137
+msgid ""
+"```typescript\n"
+"const analyzeButton = Button(\"Analyze\", async () => {\n"
+"    status.set(\"Processing...\")\n"
+"\n"
+"    // Background thread — UI stays responsive\n"
+"    const data = await spawn(() => {\n"
+"        let count = 0\n"
+"        for (let i = 0; i < 1_000_000; i++) {\n"
+"            if ((i & 0xff) === 0) count++\n"
+"        }\n"
+"        return { count }\n"
+"    })\n"
+"\n"
+"    result.set(`Found ${data.count} patterns`)\n"
+"    status.set(\"Done\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:155
+msgid ""
+"Without `spawn`, the analysis would freeze the UI. With `spawn`, the user "
+"can still scroll, tap other buttons, or navigate while the computation runs."
+msgstr ""
+
+#: src/threading/spawn.md:157
+msgid "Compared to Node.js worker_threads"
+msgstr ""
+
+#: src/threading/spawn.md:160
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
+msgstr ""
+
+#: src/threading/spawn.md:162 src/threading/spawn.md:167
+msgid "\"worker_threads\""
+msgstr ""
+
+#: src/threading/spawn.md:165
+msgid "// main.js\n"
+msgstr ""
+
+#: src/threading/spawn.md:168
+msgid "\"./worker.js\""
+msgstr ""
+
+#: src/threading/spawn.md:171
+msgid "\"message\""
+msgstr ""
+
+#: src/threading/spawn.md:174 src/testing/geisterhand.md:319
+msgid "\"error\""
+msgstr ""
+
+#: src/threading/spawn.md:174
+msgid "/* handle */"
+msgstr ""
+
+#: src/threading/spawn.md:176
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
+msgstr ""
+
+#: src/threading/spawn.md:181
+msgid ""
+"No separate files. No message ports. No event handlers. No structured clone. "
+"One line."
+msgstr ""
+
+#: src/threading/spawn.md:185
+msgid "Background File Processing"
+msgstr ""
+
+#: src/threading/spawn.md:187
+msgid ""
+"```typescript\n"
+"async function spawnBgFile(): Promise<void> {\n"
+"    // Read and process a \"large\" file without blocking. We inline a tiny "
+"CSV\n"
+"    // so the snippet runs hermetically — the docs' real version would call\n"
+"    // readFileSync from \"fs\".\n"
+"    const content = \"id,value\\n"
+"1,10\\n"
+"2,20\\n"
+"3,30\\n"
+"\"\n"
+"    const analysis = await spawn(() => {\n"
+"        const lines = content.split(\"\\n"
+"\").filter((l: string) => l.length > 0).slice(1)\n"
+"        let total = 0\n"
+"        for (const line of lines) {\n"
+"            const parts = line.split(\",\")\n"
+"            total += parseInt(parts[1], 10)\n"
+"        }\n"
+"        return { rows: lines.length, total }\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-bg-file rows=${analysis.rows} "
+"total=${analysis.total}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:207
+msgid "Parallel API Calls with Processing"
+msgstr ""
+
+#: src/threading/spawn.md:209
+msgid ""
+"```typescript\n"
+"async function spawnApiThenProcess(): Promise<void> {\n"
+"    // The docs example fetches a remote API; for a hermetic test we\n"
+"    // just hand-roll the same pipeline shape with synthetic data.\n"
+"    const rawData = { items: [1, 2, 3, 4, 5] }\n"
+"\n"
+"    // CPU-intensive processing happens off the main thread\n"
+"    const processed = await spawn(() => {\n"
+"        let total = 0\n"
+"        for (const v of rawData.items) total += v * v\n"
+"        return { total, count: rawData.items.length }\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-api-then-process total=${processed.total} "
+"count=${processed.count}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:226
+msgid "Deferred Computation"
+msgstr ""
+
+#: src/threading/spawn.md:228
+msgid ""
+"```typescript\n"
+"async function spawnDeferred(): Promise<void> {\n"
+"    const params = { size: 8 }\n"
+"\n"
+"    // Start computation early, use result later\n"
+"    const precomputed = spawn(() => {\n"
+"        const table: number[] = []\n"
+"        for (let i = 0; i < params.size; i++) table.push(i * i)\n"
+"        return table\n"
+"    })\n"
+"\n"
+"    // ... do other setup work ...\n"
+"\n"
+"    // Result is ready (or we wait for it)\n"
+"    const table = await precomputed\n"
+"    console.log(`spawn-deferred len=${table.length} "
+"last=${table[table.length - 1]}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:1
+msgid "UI Overview"
+msgstr ""
+
+#: src/ui/overview.md:3
+msgid ""
+"Perry's `perry/ui` module lets you build native desktop and mobile apps with "
+"declarative TypeScript. Your UI code compiles directly to platform-native "
+"widgets — AppKit on macOS, UIKit on iOS, GTK4 on Linux, Win32 on Windows, "
+"and DOM elements on the web."
+msgstr ""
+
+#: src/ui/overview.md:5 src/i18n/overview.md:27 src/testing/geisterhand.md:9
+msgid "Quick Start"
+msgstr ""
+
+#: src/ui/overview.md:7
+msgid ""
+"```typescript\n"
+"// demonstrates: the smallest complete Perry UI app\n"
+"// docs: docs/src/ui/overview.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My App\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello from Perry!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:29
+msgid "Mental Model"
+msgstr ""
+
+#: src/ui/overview.md:31
+msgid ""
+"Perry's UI follows the same model as SwiftUI and Flutter: you compose native "
+"widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), "
+"control alignment and distribution, and style widgets via free functions "
+"that take the widget handle as their first argument (`textSetColor(label, r, "
+"g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
+"web development, the key shift is:"
+msgstr ""
+
+#: src/ui/overview.md:33
+msgid ""
+"**Layout** is controlled by stack alignment, distribution, and spacers — not "
+"CSS properties. See [Layout](layout.md)."
+msgstr ""
+
+#: src/ui/overview.md:34
+msgid ""
+"**Styling** is applied directly to widgets — not through stylesheets. See "
+"[Styling](styling.md)."
+msgstr ""
+
+#: src/ui/overview.md:35
+msgid ""
+"**Absolute positioning** uses overlays (`widgetAddOverlay` + "
+"`widgetSetOverlayFrame`) — not `position: absolute/relative`."
+msgstr ""
+
+#: src/ui/overview.md:36
+msgid ""
+"**Design tokens** come from the `perry-styling` package. See "
+"[Theming](theming.md)."
+msgstr ""
+
+#: src/ui/overview.md:38 src/platforms/ios.md:63 src/platforms/tvos.md:104
+#: src/platforms/watchos.md:80
+msgid "App Lifecycle"
+msgstr ""
+
+#: src/ui/overview.md:40
+msgid "Every Perry UI app starts with `App()`:"
+msgstr ""
+
+#: src/ui/overview.md:42
+msgid ""
+"```typescript\n"
+"function runAppShell(): void {\n"
+"    App({\n"
+"        title: \"Window Title\",\n"
+"        width: 800,\n"
+"        height: 600,\n"
+"        body: VStack(16, [\n"
+"            Text(\"Content here\"),\n"
+"        ]),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:55
+msgid "`App({})` accepts a config object with the following properties:"
+msgstr ""
+
+#: src/ui/overview.md:57 src/widgets/creating-widgets.md:45
+msgid "Property"
+msgstr ""
+
+#: src/ui/overview.md:59
+msgid "`title`"
+msgstr ""
+
+#: src/ui/overview.md:59 src/ui/overview.md:63 src/ui/overview.md:65
+#: src/ui/overview.md:67 src/ui/overview.md:68 src/ui/styling.md:58
+#: src/cli/perry-toml.md:116 src/cli/perry-toml.md:117
+#: src/cli/perry-toml.md:119 src/cli/perry-toml.md:120
+#: src/cli/perry-toml.md:121 src/cli/perry-toml.md:127
+#: src/cli/perry-toml.md:155 src/cli/perry-toml.md:167
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:169
+#: src/cli/perry-toml.md:177 src/cli/perry-toml.md:183
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:185
+#: src/cli/perry-toml.md:186 src/cli/perry-toml.md:187
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:194
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:196
+#: src/cli/perry-toml.md:243 src/cli/perry-toml.md:244
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:249
+#: src/cli/perry-toml.md:256 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:263 src/cli/perry-toml.md:264
+#: src/cli/perry-toml.md:270 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:272 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:301 src/cli/perry-toml.md:302
+#: src/cli/perry-toml.md:303 src/cli/perry-toml.md:304
+#: src/cli/perry-toml.md:312 src/cli/perry-toml.md:313
+#: src/cli/perry-toml.md:314 src/cli/perry-toml.md:315
+#: src/cli/perry-toml.md:316 src/cli/perry-toml.md:317
+#: src/cli/perry-toml.md:318 src/cli/perry-toml.md:319
+#: src/cli/perry-toml.md:329 src/cli/perry-toml.md:330
+#: src/cli/perry-toml.md:331 src/cli/perry-toml.md:333
+#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:335
+#: src/cli/perry-toml.md:336 src/cli/perry-toml.md:337
+#: src/cli/perry-toml.md:347 src/cli/perry-toml.md:348
+#: src/cli/perry-toml.md:349 src/cli/perry-toml.md:360
+#: src/cli/perry-toml.md:369 src/cli/perry-toml.md:379
+#: src/cli/perry-toml.md:389 src/cli/perry-toml.md:390
+#: src/cli/perry-toml.md:416
+msgid "string"
+msgstr ""
+
+#: src/ui/overview.md:59
+msgid "Window title"
+msgstr ""
+
+#: src/ui/overview.md:60
+msgid "`width`"
+msgstr ""
+
+#: src/ui/overview.md:60 src/ui/overview.md:61 src/ui/styling.md:50
+#: src/ui/styling.md:51 src/system/overview.md:28
+msgid "number"
+msgstr ""
+
+#: src/ui/overview.md:60
+msgid "Initial window width"
+msgstr ""
+
+#: src/ui/overview.md:61
+msgid "`height`"
+msgstr ""
+
+#: src/ui/overview.md:61
+msgid "Initial window height"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "`body`"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "widget"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "Root widget"
+msgstr ""
+
+#: src/ui/overview.md:63
+msgid "`icon`"
+msgstr ""
+
+#: src/ui/overview.md:63
+msgid "App icon file path (optional)"
+msgstr ""
+
+#: src/ui/overview.md:64
+msgid "`frameless`"
+msgstr ""
+
+#: src/ui/overview.md:64 src/ui/overview.md:66 src/ui/styling.md:59
+#: src/ui/styling.md:60 src/system/media.md:49 src/cli/perry-toml.md:361
+msgid "boolean"
+msgstr ""
+
+#: src/ui/overview.md:64
+msgid "Remove title bar (optional)"
+msgstr ""
+
+#: src/ui/overview.md:65
+msgid "`level`"
+msgstr ""
+
+#: src/ui/overview.md:65
+msgid "Window z-order: `\"floating\"`, `\"statusBar\"`, `\"modal\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:66
+msgid "`transparent`"
+msgstr ""
+
+#: src/ui/overview.md:66
+msgid "Transparent background (optional)"
+msgstr ""
+
+#: src/ui/overview.md:67
+msgid "`vibrancy`"
+msgstr ""
+
+#: src/ui/overview.md:67
+msgid "Native blur material, e.g. `\"sidebar\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:68
+msgid "`activationPolicy`"
+msgstr ""
+
+#: src/ui/overview.md:68
+msgid ""
+"`\"regular\"`, `\"accessory\"` (no dock icon), `\"background\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:70
+msgid ""
+"See [Multi-Window](multi-window.md) for full documentation on window "
+"properties."
+msgstr ""
+
+#: src/ui/overview.md:72
+msgid "Lifecycle Hooks"
+msgstr ""
+
+#: src/ui/overview.md:74
+msgid ""
+"```typescript\n"
+"onActivate(() => {\n"
+"    console.log(\"App became active\")\n"
+"})\n"
+"\n"
+"onTerminate(() => {\n"
+"    console.log(\"App is closing\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:84
+msgid "Widget Tree"
+msgstr ""
+
+#: src/ui/overview.md:86
+msgid "Perry UIs are built as a tree of widgets:"
+msgstr ""
+
+#: src/ui/overview.md:88
+msgid ""
+"```typescript\n"
+"function runWidgetTree(): void {\n"
+"    App({\n"
+"        title: \"Layout Demo\",\n"
+"        width: 400,\n"
+"        height: 300,\n"
+"        body: VStack(16, [\n"
+"            Text(\"Header\"),\n"
+"            HStack(8, [\n"
+"                Button(\"Left\", () => console.log(\"left\")),\n"
+"                Button(\"Right\", () => console.log(\"right\")),\n"
+"            ]),\n"
+"            Text(\"Footer\"),\n"
+"        ]),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:106
+msgid ""
+"Widgets are created by calling their constructor functions. Layout "
+"containers (`VStack`, `HStack`, `ZStack`) accept a spacing value (in points) "
+"followed by an array of child widgets."
+msgstr ""
+
+#: src/ui/overview.md:108
+msgid "Handle-Based Architecture"
+msgstr ""
+
+#: src/ui/overview.md:110
+msgid ""
+"Under the hood, each widget is a handle — a small integer that references a "
+"native platform object. When you call `Text(\"hello\")`, Perry creates a "
+"native `NSTextField` (macOS), `UILabel` (iOS), `GtkLabel` (Linux), or "
+"`<span>` (web) and returns a handle you can use to modify it."
+msgstr ""
+
+#: src/ui/overview.md:112
+msgid ""
+"```typescript\n"
+"const label = Text(\"Hello\")\n"
+"textSetFontSize(label, 18)              // Modifies the native widget\n"
+"textSetColor(label, 1.0, 0.0, 0.0, 1.0) // RGBA floats in [0,1]\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:118
+msgid "Imports"
+msgstr ""
+
+#: src/ui/overview.md:120
+msgid "All UI functions are imported from `perry/ui`:"
+msgstr ""
+
+#: src/ui/overview.md:122
+msgid ""
+"```typescript\n"
+"import {\n"
+"    // App lifecycle\n"
+"    App, onActivate, onTerminate,\n"
+"\n"
+"    // Widgets\n"
+"    Text, Button, TextField, SecureField, TextArea,\n"
+"    Toggle, Slider, ProgressView, Picker, ImageFile, ImageSymbol,\n"
+"\n"
+"    // Layout\n"
+"    VStack, HStack, ZStack, ScrollView, Spacer, Divider,\n"
+"    NavStack, TabBar, LazyVStack, Section,\n"
+"    VStackWithInsets, HStackWithInsets, SplitView, splitViewAddChild,\n"
+"\n"
+"    // Layout control\n"
+"    stackSetAlignment, stackSetDistribution, stackSetDetachesHidden,\n"
+"    widgetMatchParentWidth, widgetMatchParentHeight, widgetSetHugging,\n"
+"    widgetAddOverlay, widgetSetOverlayFrame,\n"
+"\n"
+"    // State\n"
+"    State, ForEach,\n"
+"\n"
+"    // Dialogs\n"
+"    openFileDialog, openFolderDialog, saveFileDialog,\n"
+"    alert, alertWithButtons,\n"
+"    sheetCreate, sheetPresent, sheetDismiss,\n"
+"\n"
+"    // Menus\n"
+"    menuCreate, menuAddItem, menuAddSeparator, menuAddSubmenu,\n"
+"    menuBarCreate, menuBarAddMenu, menuBarAttach,\n"
+"    widgetSetContextMenu,\n"
+"\n"
+"    // Window\n"
+"    Window,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:159
+msgid ""
+"[`Canvas`](canvas.md), [`CameraView`](camera.md), and the virtualized "
+"[`Table`](table.md) widget are wired through the LLVM codegen (closed via "
+"[\\#190](https://github.com/PerryTS/perry/issues/190), "
+"[\\#191](https://github.com/PerryTS/perry/issues/191), and "
+"[\\#192](https://github.com/PerryTS/perry/issues/192)). See each widget's "
+"page for the platform-support matrix."
+msgstr ""
+
+#: src/ui/overview.md:166
+msgid "Platform Differences"
+msgstr ""
+
+#: src/ui/overview.md:168
+msgid ""
+"The same code runs on all platforms, but the look and feel matches each "
+"platform's native style:"
+msgstr ""
+
+#: src/ui/overview.md:170 src/platforms/overview.md:67
+#: src/i18n/formatting.md:138 src/widgets/platforms.md:20
+msgid "Feature"
+msgstr ""
+
+#: src/ui/overview.md:172
+msgid "Buttons"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/macos.md:27
+msgid "NSButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/tvos.md:53
+msgid "UIButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/linux.md:37
+msgid "GtkButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/windows.md:45
+msgid "HWND Button"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/wasm.md:58
+msgid "`<button>`"
+msgstr ""
+
+#: src/ui/overview.md:173 src/ui/widgets.md:13 src/ui/canvas.md:60
+#: src/platforms/macos.md:26 src/platforms/ios.md:52 src/platforms/tvos.md:52
+#: src/platforms/watchos.md:52 src/platforms/android.md:26
+#: src/platforms/windows.md:44 src/platforms/linux.md:36
+#: src/widgets/components.md:25 src/widgets/platforms.md:22
+msgid "Text"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/macos.md:28
+msgid "NSTextField"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/ios.md:52 src/platforms/tvos.md:52
+msgid "UILabel"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/linux.md:36
+msgid "GtkLabel"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/windows.md:44
+msgid "Static HWND"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/wasm.md:57
+msgid "`<span>`"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/macos.md:34
+msgid "NSStackView"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/ios.md:60 src/platforms/tvos.md:59
+msgid "UIStackView"
+msgstr ""
+
+#: src/ui/overview.md:174
+msgid "GtkBox"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/windows.md:53
+msgid "Manual layout"
+msgstr ""
+
+#: src/ui/overview.md:174
+msgid "Flexbox"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:111
+msgid "NSMenu"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:113 src/ui/menus.md:114
+#: src/ui/dialogs.md:111 src/ui/dialogs.md:112 src/platforms/overview.md:69
+#: src/platforms/overview.md:71 src/platforms/overview.md:72
+#: src/platforms/overview.md:75 src/cli/perry-toml.md:119
+#: src/cli/perry-toml.md:120 src/cli/perry-toml.md:127
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:169
+#: src/cli/perry-toml.md:170 src/cli/perry-toml.md:177
+#: src/cli/perry-toml.md:185 src/cli/perry-toml.md:186
+#: src/cli/perry-toml.md:187 src/cli/perry-toml.md:245
+#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:256
+#: src/cli/perry-toml.md:264 src/cli/perry-toml.md:303
+#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:312
+#: src/cli/perry-toml.md:315 src/cli/perry-toml.md:330
+#: src/cli/perry-toml.md:331 src/cli/perry-toml.md:332
+#: src/cli/perry-toml.md:333 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:335 src/cli/perry-toml.md:336
+#: src/cli/perry-toml.md:347 src/cli/perry-toml.md:348
+#: src/cli/perry-toml.md:359 src/cli/perry-toml.md:391
+msgid "—"
+msgstr ""
+
+#: src/ui/overview.md:175
+msgid "GMenu"
+msgstr ""
+
+#: src/ui/overview.md:175
+msgid "HMENU"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:115
+msgid "DOM"
+msgstr ""
+
+#: src/ui/overview.md:177
+msgid "Platform-specific behavior is noted on each widget's documentation page."
+msgstr ""
+
+#: src/ui/overview.md:181 src/ui/layout.md:370 src/ui/styling.md:379
+#: src/ui/state.md:228 src/ui/events.md:170 src/ui/canvas.md:82
+#: src/ui/table.md:109 src/ui/animation.md:74 src/ui/camera.md:145
+msgid "[Widgets](widgets.md) — All available widgets"
+msgstr ""
+
+#: src/ui/overview.md:182
+msgid "[Layout](layout.md) — Arranging widgets"
+msgstr ""
+
+#: src/ui/overview.md:183
+msgid "[State Management](state.md) — Reactive state and bindings"
+msgstr ""
+
+#: src/ui/overview.md:184
+msgid "[Styling](styling.md) — Colors, fonts, sizing"
+msgstr ""
+
+#: src/ui/overview.md:185
+msgid "[Events](events.md) — Click, hover, keyboard"
+msgstr ""
+
+#: src/ui/widgets.md:3
+msgid ""
+"Perry provides native widgets that map to each platform's native controls. "
+"Every example on this page is a real runnable program verified by CI "
+"(`scripts/run_doc_tests.sh`) — the snippet you read is the same source "
+"that's compiled and launched."
+msgstr ""
+
+#: src/ui/widgets.md:8
+msgid ""
+"The widget API is **free functions**, not methods. A widget is a 64-bit "
+"opaque handle; you pass it into helpers like `textSetFontSize(widget, 18)` "
+"rather than calling `widget.setFontSize(18)`. That's the only shape perry/ui "
+"supports — no fluent chain, no prototype methods."
+msgstr ""
+
+#: src/ui/widgets.md:15
+msgid "Displays read-only text."
+msgstr ""
+
+#: src/ui/widgets.md:17
+msgid ""
+"```typescript\n"
+"// demonstrates: Text widget styling with the real free-function API\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, textSetFontSize, textSetFontWeight, "
+"textSetColor, textSetFontFamily } from \"perry/ui\"\n"
+"\n"
+"const label = Text(\"Hello, World!\")\n"
+"textSetFontSize(label, 18)\n"
+"textSetColor(label, 0.2, 0.2, 0.2, 1.0) // RGBA in [0, 1]\n"
+"textSetFontFamily(label, \"Menlo\")\n"
+"\n"
+"const bold = Text(\"Bold\")\n"
+"textSetFontWeight(bold, 20, 1.0)\n"
+"\n"
+"App({\n"
+"    title: \"Text\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(8, [label, bold]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:41
+msgid ""
+"Color is RGBA with each channel in `[0.0, 1.0]` — divide a hex byte by 255 "
+"(`0x33 / 255 ≈ 0.2`)."
+msgstr ""
+
+#: src/ui/widgets.md:44
+msgid ""
+"**Helpers:** `textSetString`, `textSetFontSize`, `textSetFontWeight`, "
+"`textSetFontFamily`, `textSetColor`, `textSetWraps`, `textSetSelectable`."
+msgstr ""
+
+#: src/ui/widgets.md:47
+msgid ""
+"Text widgets inside template literals with `state.value` update "
+"automatically — perry detects the state read and rewires the widget to "
+"re-render on change. See [State Management](state.md)."
+msgstr ""
+
+#: src/ui/widgets.md:51 src/platforms/macos.md:27 src/platforms/ios.md:53
+#: src/platforms/tvos.md:53 src/platforms/watchos.md:53
+#: src/platforms/android.md:27 src/platforms/windows.md:45
+#: src/platforms/linux.md:37 src/testing/geisterhand.md:86
+#: src/testing/geisterhand.md:289
+msgid "Button"
+msgstr ""
+
+#: src/ui/widgets.md:53
+msgid "A clickable button."
+msgstr ""
+
+#: src/ui/widgets.md:55
+msgid ""
+"```typescript\n"
+"// demonstrates: Button styling with buttonSet*/widgetSet* helpers\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack,\n"
+"    Button,\n"
+"    buttonSetBordered,\n"
+"    widgetSetEnabled,\n"
+"    setCornerRadius,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// Note: buttonSetContentTintColor is macOS/iOS-only (maps to NSButton /\n"
+"// UIButton tint). GTK4/Win32 don't have an equivalent — set\n"
+"// widgetSetBackgroundColor(btn, r, g, b, a) there instead.\n"
+"const primary = Button(\"Click Me\", () => console.log(\"Clicked!\"))\n"
+"buttonSetBordered(primary, 1)\n"
+"setCornerRadius(primary, 8)\n"
+"\n"
+"const disabled = Button(\"Can't click me\", () => {})\n"
+"widgetSetEnabled(disabled, 0)\n"
+"\n"
+"App({\n"
+"    title: \"Button\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [primary, disabled]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:88
+msgid ""
+"**Helpers:** `buttonSetTitle`, `buttonSetBordered`, `buttonSetImage` (SF "
+"Symbol name on macOS/iOS), `buttonSetImagePosition`, "
+"`buttonSetContentTintColor`, `buttonSetTextColor`, `widgetSetEnabled`."
+msgstr ""
+
+#: src/ui/widgets.md:92 src/platforms/macos.md:28 src/platforms/ios.md:54
+#: src/platforms/tvos.md:54 src/platforms/android.md:28
+#: src/platforms/windows.md:46 src/platforms/linux.md:38
+#: src/testing/geisterhand.md:87 src/testing/geisterhand.md:290
+msgid "TextField"
+msgstr ""
+
+#: src/ui/widgets.md:94
+msgid "An editable single-line text input."
+msgstr ""
+
+#: src/ui/widgets.md:96
+msgid ""
+"```typescript\n"
+"// demonstrates: TextField + two-way binding via stateBindTextfield\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, TextField, State, stateBindTextfield } from "
+"\"perry/ui\"\n"
+"\n"
+"const text = State(\"\")\n"
+"const field = TextField(\"Placeholder...\", (value: string) => "
+"text.set(value))\n"
+"stateBindTextfield(text, field) // programmatic text.set() also updates the "
+"field\n"
+"\n"
+"App({\n"
+"    title: \"TextField\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        field,\n"
+"        Text(`You typed: ${text.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:119
+msgid ""
+"`TextField(placeholder, onChange)` fires `onChange` as the user types. Pair "
+"with `stateBindTextfield(state, field)` for two-way binding so programmatic "
+"`state.set(…)` also updates the visible text."
+msgstr ""
+
+#: src/ui/widgets.md:123
+msgid ""
+"**Helpers:** `textfieldSetString`, `textfieldSetFontSize`, "
+"`textfieldSetTextColor`, `textfieldSetBackgroundColor`, "
+"`textfieldSetBorderless`, `textfieldSetOnSubmit`, `textfieldSetOnFocus`, "
+"`textfieldSetNextKeyView`."
+msgstr ""
+
+#: src/ui/widgets.md:128 src/platforms/macos.md:29 src/platforms/ios.md:55
+#: src/platforms/android.md:29 src/platforms/windows.md:47
+#: src/platforms/linux.md:39
+msgid "SecureField"
+msgstr ""
+
+#: src/ui/widgets.md:130
+msgid ""
+"A password input — identical signature to `TextField`, but text is masked."
+msgstr ""
+
+#: src/ui/widgets.md:132
+msgid ""
+"```typescript\n"
+"// demonstrates: SecureField for password input\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, SecureField, State } from \"perry/ui\"\n"
+"\n"
+"const password = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"SecureField\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        SecureField(\"Enter password...\", (value: string) => "
+"password.set(value)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:152 src/platforms/macos.md:30 src/platforms/ios.md:56
+#: src/platforms/tvos.md:55 src/platforms/watchos.md:59
+#: src/platforms/android.md:30 src/platforms/windows.md:48
+#: src/platforms/linux.md:40 src/testing/geisterhand.md:89
+#: src/testing/geisterhand.md:292
+msgid "Toggle"
+msgstr ""
+
+#: src/ui/widgets.md:154
+msgid "A boolean on/off switch."
+msgstr ""
+
+#: src/ui/widgets.md:156
+msgid ""
+"```typescript\n"
+"// demonstrates: Toggle widget bound to State\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Toggle, State } from \"perry/ui\"\n"
+"\n"
+"const enabled = State(false)\n"
+"\n"
+"App({\n"
+"    title: \"Toggle\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Toggle(\"Enable notifications\", (on: boolean) => enabled.set(on)),\n"
+"        Text(`Enabled: ${enabled.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:177 src/platforms/macos.md:31 src/platforms/ios.md:57
+#: src/platforms/tvos.md:56 src/platforms/watchos.md:60
+#: src/platforms/android.md:31 src/platforms/windows.md:49
+#: src/platforms/linux.md:41 src/testing/geisterhand.md:88
+#: src/testing/geisterhand.md:291
+msgid "Slider"
+msgstr ""
+
+#: src/ui/widgets.md:179
+msgid "A numeric slider."
+msgstr ""
+
+#: src/ui/widgets.md:181
+msgid ""
+"```typescript\n"
+"// demonstrates: Slider with a numeric range\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Slider, State } from \"perry/ui\"\n"
+"\n"
+"const value = State(50)\n"
+"\n"
+"App({\n"
+"    title: \"Slider\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Slider(0, 100, (v: number) => value.set(v)),\n"
+"        Text(`Value: ${value.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:202
+msgid ""
+"`Slider(min, max, onChange)` — `onChange` fires on every drag. Use "
+"`stateBindSlider(state, slider)` for two-way binding."
+msgstr ""
+
+#: src/ui/widgets.md:205 src/platforms/macos.md:32 src/platforms/ios.md:58
+#: src/platforms/tvos.md:57 src/platforms/watchos.md:64
+#: src/platforms/android.md:32 src/platforms/windows.md:50
+#: src/platforms/linux.md:42 src/testing/geisterhand.md:90
+#: src/testing/geisterhand.md:293
+msgid "Picker"
+msgstr ""
+
+#: src/ui/widgets.md:207
+msgid "A dropdown selection control. Items are added with `pickerAddItem`."
+msgstr ""
+
+#: src/ui/widgets.md:209
+msgid ""
+"```typescript\n"
+"// demonstrates: Picker with items added via pickerAddItem\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Picker, State, pickerAddItem } from "
+"\"perry/ui\"\n"
+"\n"
+"const selected = State(0)\n"
+"const picker = Picker((index: number) => selected.set(index))\n"
+"pickerAddItem(picker, \"Option A\")\n"
+"pickerAddItem(picker, \"Option B\")\n"
+"pickerAddItem(picker, \"Option C\")\n"
+"\n"
+"App({\n"
+"    title: \"Picker\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        picker,\n"
+"        Text(`Selected index: ${selected.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:234
+msgid "ImageFile / ImageSymbol"
+msgstr ""
+
+#: src/ui/widgets.md:236
+msgid "Two distinct constructors:"
+msgstr ""
+
+#: src/ui/widgets.md:238
+msgid "`ImageFile(path)` — image from a file path"
+msgstr ""
+
+#: src/ui/widgets.md:239
+msgid "`ImageSymbol(name)` — SF Symbol glyph name (macOS/iOS only)"
+msgstr ""
+
+#: src/ui/widgets.md:241
+msgid ""
+"```typescript\n"
+"// demonstrates: ImageSymbol for SF Symbol glyphs (macOS/iOS)\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos\n"
+"// targets: ios-simulator, visionos-simulator, tvos-simulator\n"
+"\n"
+"import { App, HStack, ImageSymbol, widgetSetWidth, widgetSetHeight } from "
+"\"perry/ui\"\n"
+"\n"
+"const star = ImageSymbol(\"star.fill\")\n"
+"widgetSetWidth(star, 32)\n"
+"widgetSetHeight(star, 32)\n"
+"\n"
+"const heart = ImageSymbol(\"heart.fill\")\n"
+"const bell = ImageSymbol(\"bell.fill\")\n"
+"\n"
+"App({\n"
+"    title: \"ImageSymbol\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: HStack(12, [star, heart, bell]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:264
+msgid ""
+"Use `widgetSetWidth(img, N)` / `widgetSetHeight(img, N)` to size the image."
+msgstr ""
+
+#: src/ui/widgets.md:266 src/platforms/watchos.md:63
+#: src/platforms/windows.md:51 src/platforms/linux.md:43
+msgid "ProgressView"
+msgstr ""
+
+#: src/ui/widgets.md:268
+msgid "An indeterminate or determinate progress indicator."
+msgstr ""
+
+#: src/ui/widgets.md:270
+msgid ""
+"```typescript\n"
+"// demonstrates: ProgressView as an indeterminate spinner\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, ProgressView } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"ProgressView\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Text(\"Loading...\"),\n"
+"        ProgressView(),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:289
+msgid "TextArea"
+msgstr ""
+
+#: src/ui/widgets.md:291
+msgid ""
+"A multi-line text input. Same `(placeholder, onChange)` signature as "
+"`TextField` but renders as a multi-line box."
+msgstr ""
+
+#: src/ui/widgets.md:294
+msgid ""
+"```typescript\n"
+"// demonstrates: TextArea for multi-line input\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, TextArea, State } from \"perry/ui\"\n"
+"\n"
+"const content = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"TextArea\",\n"
+"    width: 500,\n"
+"    height: 400,\n"
+"    body: VStack(12, [\n"
+"        TextArea(\"Enter multi-line text...\", (value: string) => "
+"content.set(value)),\n"
+"        Text(`Length: ${content.value.length}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:315
+msgid "**Helpers:** `textareaSetString`."
+msgstr ""
+
+#: src/ui/widgets.md:317 src/cli/perry-toml.md:108
+msgid "Sections"
+msgstr ""
+
+#: src/ui/widgets.md:319
+msgid ""
+"Group controls into labelled sections. Perry has no `Form()` widget — use a "
+"`VStack` of `Section(title)`s and attach children via `widgetAddChild`."
+msgstr ""
+
+#: src/ui/widgets.md:322
+msgid ""
+"```typescript\n"
+"// demonstrates: Section grouping with widgetAddChild (no Form widget in "
+"Perry)\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack,\n"
+"    Section,\n"
+"    TextField,\n"
+"    Toggle,\n"
+"    State,\n"
+"    widgetAddChild,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const name = State(\"\")\n"
+"const notifications = State(true)\n"
+"\n"
+"const personal = Section(\"Personal Info\")\n"
+"widgetAddChild(personal, TextField(\"Name\", (value: string) => "
+"name.set(value)))\n"
+"\n"
+"const settings = Section(\"Settings\")\n"
+"widgetAddChild(\n"
+"    settings,\n"
+"    Toggle(\"Notifications\", (on: boolean) => notifications.set(on)),\n"
+")\n"
+"\n"
+"App({\n"
+"    title: \"Sections\",\n"
+"    width: 500,\n"
+"    height: 400,\n"
+"    body: VStack(16, [personal, settings]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:358
+msgid "Platform-specific widgets"
+msgstr ""
+
+#: src/ui/widgets.md:360
+msgid ""
+"These exist only on specific platforms and aren't verified by the "
+"cross-platform doc-tests:"
+msgstr ""
+
+#: src/ui/widgets.md:363
+msgid ""
+"**`Table(rows, cols, renderer)`** — macOS only. A data table with rows, "
+"columns, and a cell renderer."
+msgstr ""
+
+#: src/ui/widgets.md:365
+msgid "**`QRCode(data, size)`** — macOS only. Renders a QR code."
+msgstr ""
+
+#: src/ui/widgets.md:366
+msgid ""
+"**`Canvas(width, height, draw)`** — all desktop platforms. A drawing "
+"surface; see [Canvas](canvas.md)."
+msgstr ""
+
+#: src/ui/widgets.md:368
+msgid ""
+"**`CameraView()`** — iOS only (other platforms planned). See "
+"[Camera](camera.md)."
+msgstr ""
+
+#: src/ui/widgets.md:371
+msgid "These are linked from their own pages with platform-specific examples."
+msgstr ""
+
+#: src/ui/widgets.md:373
+msgid "Common widget helpers"
+msgstr ""
+
+#: src/ui/widgets.md:375
+msgid "Every widget handle accepts these:"
+msgstr ""
+
+#: src/ui/widgets.md:377
+msgid "Helper"
+msgstr ""
+
+#: src/ui/widgets.md:379
+msgid "`widgetSetWidth(w, n)` / `widgetSetHeight(w, n)`"
+msgstr ""
+
+#: src/ui/widgets.md:379
+msgid "Explicit size in points"
+msgstr ""
+
+#: src/ui/widgets.md:380
+msgid "`widgetSetBackgroundColor(w, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/widgets.md:380
+msgid "RGBA in \\[0, 1\\]"
+msgstr ""
+
+#: src/ui/widgets.md:381
+msgid "`setCornerRadius(w, r)`"
+msgstr ""
+
+#: src/ui/widgets.md:381
+msgid "Rounded corners in points"
+msgstr ""
+
+#: src/ui/widgets.md:382
+msgid "`widgetSetOpacity(w, alpha)`"
+msgstr ""
+
+#: src/ui/widgets.md:382
+msgid "Opacity in \\[0, 1\\]"
+msgstr ""
+
+#: src/ui/widgets.md:383
+msgid "`widgetSetEnabled(w, flag)`"
+msgstr ""
+
+#: src/ui/widgets.md:383
+msgid "`0` disables, `1` enables"
+msgstr ""
+
+#: src/ui/widgets.md:384
+msgid "`widgetSetHidden(w, flag)`"
+msgstr ""
+
+#: src/ui/widgets.md:384
+msgid "`0` visible, `1` hidden"
+msgstr ""
+
+#: src/ui/widgets.md:385
+msgid "`widgetSetTooltip(w, text)`"
+msgstr ""
+
+#: src/ui/widgets.md:385
+msgid "Tooltip on hover (desktop only)"
+msgstr ""
+
+#: src/ui/widgets.md:386
+msgid "`widgetSetOnClick(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:386
+msgid "Click handler"
+msgstr ""
+
+#: src/ui/widgets.md:387
+msgid "`widgetSetOnHover(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:387
+msgid "Hover enter/leave (desktop only)"
+msgstr ""
+
+#: src/ui/widgets.md:388
+msgid "`widgetSetOnDoubleClick(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:388
+msgid "Double-click handler"
+msgstr ""
+
+#: src/ui/widgets.md:389
+msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+msgstr ""
+
+#: src/ui/widgets.md:389
+msgid "Padding around contents"
+msgstr ""
+
+#: src/ui/widgets.md:390
+msgid "`widgetSetBorderColor(w, r, g, b, a)` / `widgetSetBorderWidth(w, n)`"
+msgstr ""
+
+#: src/ui/widgets.md:390
+msgid "Border"
+msgstr ""
+
+#: src/ui/widgets.md:391 src/ui/layout.md:175
+msgid "`widgetAddChild(parent, child)`"
+msgstr ""
+
+#: src/ui/widgets.md:391
+msgid "Attach a child to a container"
+msgstr ""
+
+#: src/ui/widgets.md:392
+msgid "`widgetSetContextMenu(w, menu)`"
+msgstr ""
+
+#: src/ui/widgets.md:392
+msgid "Right-click menu"
+msgstr ""
+
+#: src/ui/widgets.md:394
+msgid "See [Styling](styling.md) and [Events](events.md) for deeper coverage."
+msgstr ""
+
+#: src/ui/widgets.md:398
+msgid "[Layout](layout.md) — Arranging widgets with stacks and containers"
+msgstr ""
+
+#: src/ui/widgets.md:399
+msgid "[Styling](styling.md) — Colors, fonts, borders"
+msgstr ""
+
+#: src/ui/widgets.md:400 src/ui/theming.md:169
+msgid "[State Management](state.md) — Reactive bindings"
+msgstr ""
+
+#: src/ui/layout.md:3
+msgid ""
+"Perry provides layout containers that arrange child widgets using the "
+"platform's native layout system. Every snippet below is excerpted from "
+"[`docs/examples/ui/layout/snippets.ts`](../../examples/ui/layout/snippets.ts) "
+"— CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/layout.md:8
+msgid ""
+"Layout helpers are free functions: `widgetAddChild(parent, child)`, "
+"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
+"bottom, right)`, etc. Stack constructors take a numeric spacing followed by "
+"a child array; everything else (alignment, distribution, padding, sizing) is "
+"applied post-construction via the free functions on the widget handle."
+msgstr ""
+
+#: src/ui/layout.md:14 src/platforms/watchos.md:54 src/platforms/android.md:34
+#: src/platforms/linux.md:45 src/widgets/components.md:43
+msgid "VStack"
+msgstr ""
+
+#: src/ui/layout.md:16
+msgid "Arranges children vertically (top to bottom)."
+msgstr ""
+
+#: src/ui/layout.md:18
+msgid ""
+"```typescript\n"
+"const stack = VStack(16, [\n"
+"    Text(\"First\"),\n"
+"    Text(\"Second\"),\n"
+"    Text(\"Third\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:26
+msgid ""
+"`VStack(spacing, children)` — the first argument is the gap in points "
+"between children."
+msgstr ""
+
+#: src/ui/layout.md:29 src/platforms/watchos.md:55 src/platforms/android.md:35
+#: src/platforms/linux.md:46 src/widgets/components.md:52
+msgid "HStack"
+msgstr ""
+
+#: src/ui/layout.md:31
+msgid "Arranges children horizontally (left to right)."
+msgstr ""
+
+#: src/ui/layout.md:33
+msgid ""
+"```typescript\n"
+"const row = HStack(8, [\n"
+"    Button(\"Cancel\", noop),\n"
+"    Spacer(),\n"
+"    Button(\"OK\", noop),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:41 src/platforms/watchos.md:56 src/platforms/android.md:36
+#: src/platforms/linux.md:47 src/widgets/components.md:62
+msgid "ZStack"
+msgstr ""
+
+#: src/ui/layout.md:43
+msgid ""
+"Layers children on top of each other (back to front). `ZStack()` takes no "
+"constructor children — populate it with `widgetAddChild`:"
+msgstr ""
+
+#: src/ui/layout.md:46
+msgid ""
+"```typescript\n"
+"const layered = ZStack()\n"
+"widgetAddChild(layered, ImageFile(\"background.png\"))\n"
+"widgetAddChild(layered, Text(\"Overlay text\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:52 src/platforms/macos.md:35 src/platforms/ios.md:61
+#: src/platforms/tvos.md:60 src/platforms/watchos.md:62
+#: src/platforms/android.md:37 src/platforms/windows.md:54
+#: src/platforms/linux.md:48 src/testing/geisterhand.md:94
+msgid "ScrollView"
+msgstr ""
+
+#: src/ui/layout.md:54
+msgid ""
+"A scrollable container. Built empty, then filled via `scrollviewSetChild`:"
+msgstr ""
+
+#: src/ui/layout.md:56
+msgid ""
+"```typescript\n"
+"// ScrollView() takes no args; populate it with `scrollviewSetChild`.\n"
+"const sv = ScrollView()\n"
+"const inner = VStack(8, [Text(\"a\"), Text(\"b\"), Text(\"c\")])\n"
+"scrollviewSetChild(sv, inner)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:63
+msgid "LazyVStack"
+msgstr ""
+
+#: src/ui/layout.md:65
+msgid ""
+"A vertically scrolling list that lazily renders items. More efficient than "
+"`ScrollView` + `VStack` for thousands of rows — on macOS this is backed by "
+"`NSTableView` so only rows in the visible rect are realized."
+msgstr ""
+
+#: src/ui/layout.md:69
+msgid ""
+"```typescript\n"
+"// `render(index)` is invoked lazily — only rows in the visible rect are "
+"realized.\n"
+"const lazy = LazyVStack(1000, (index: number) => Text(`Row ${index}`))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:74
+msgid ""
+"When the underlying data changes, call `lazyvstackUpdate(handle, newCount)` "
+"to refresh. Override the default 44pt row height with "
+"`lazyvstackSetRowHeight`."
+msgstr ""
+
+#: src/ui/layout.md:77
+msgid "NavStack"
+msgstr ""
+
+#: src/ui/layout.md:79
+msgid ""
+"A navigation container that supports push/pop navigation. Push a new view "
+"with `navstackPush(stack, view, title)`; pop with `navstackPop(stack)`:"
+msgstr ""
+
+#: src/ui/layout.md:82
+msgid ""
+"```typescript\n"
+"const home = VStack(16, [\n"
+"    Text(\"Home Screen\"),\n"
+"    Button(\"Go to Details\", () => {\n"
+"        navstackPush(nav, Text(\"Details!\"), \"Details\")\n"
+"    }),\n"
+"])\n"
+"const nav = NavStack()\n"
+"widgetAddChild(nav, home)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:93 src/platforms/watchos.md:57 src/widgets/components.md:71
+#: src/widgets/platforms.md:25 src/widgets/platforms.md:26
+msgid "Spacer"
+msgstr ""
+
+#: src/ui/layout.md:95
+msgid "A flexible space that expands to fill available room."
+msgstr ""
+
+#: src/ui/layout.md:97
+msgid ""
+"```typescript\n"
+"const toolbar = HStack(8, [\n"
+"    Text(\"Left\"),\n"
+"    Spacer(),\n"
+"    Text(\"Right\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:105
+msgid "Use `Spacer()` inside `HStack` or `VStack` to push widgets apart."
+msgstr ""
+
+#: src/ui/layout.md:107 src/platforms/watchos.md:58
+#: src/widgets/components.md:106 src/widgets/platforms.md:26
+msgid "Divider"
+msgstr ""
+
+#: src/ui/layout.md:109
+msgid "A visual separator line."
+msgstr ""
+
+#: src/ui/layout.md:111
+msgid ""
+"```typescript\n"
+"const sections = VStack(12, [\n"
+"    Text(\"Section 1\"),\n"
+"    Divider(),\n"
+"    Text(\"Section 2\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:119
+msgid "Nesting Layouts"
+msgstr ""
+
+#: src/ui/layout.md:121
+msgid "Layouts can be nested freely. This complete example is verified by CI:"
+msgstr ""
+
+#: src/ui/layout.md:123
+msgid ""
+"```typescript\n"
+"// demonstrates: nested VStack/HStack + Spacer + Divider\n"
+"// docs: docs/src/ui/layout.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, HStack, Text, Button, Spacer, Divider } from "
+"\"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"Layout Example\",\n"
+"    width: 800,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        // Header\n"
+"        HStack(8, [\n"
+"            Text(\"My App\"),\n"
+"            Spacer(),\n"
+"            Button(\"Settings\", () => {}),\n"
+"        ]),\n"
+"        Divider(),\n"
+"        // Content\n"
+"        VStack(12, [\n"
+"            Text(\"Welcome!\"),\n"
+"            HStack(8, [\n"
+"                Button(\"Action 1\", () => {}),\n"
+"                Button(\"Action 2\", () => {}),\n"
+"            ]),\n"
+"        ]),\n"
+"        Spacer(),\n"
+"        // Footer\n"
+"        Text(\"v1.0.0\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:158
+msgid "Child Management"
+msgstr ""
+
+#: src/ui/layout.md:160
+msgid "Containers support dynamic child management via free functions:"
+msgstr ""
+
+#: src/ui/layout.md:162
+msgid ""
+"```typescript\n"
+"const list = VStack(16, [])\n"
+"widgetAddChild(list, Text(\"appended\"))            // append\n"
+"widgetAddChildAt(list, Text(\"prepended\"), 0)      // insert at index\n"
+"widgetReorderChild(list, 1, 0)                    // move from→to\n"
+"const removeMe = Text(\"temporary\")\n"
+"widgetAddChild(list, removeMe)\n"
+"widgetRemoveChild(list, removeMe)                 // remove\n"
+"widgetClearChildren(list)                         // remove all\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:173 src/ui/menus.md:53 src/ui/theming.md:131
+#: src/system/overview.md:21 src/system/media.md:37
+#: src/plugins/native-extensions.md:175
+msgid "Function"
+msgstr ""
+
+#: src/ui/layout.md:175
+msgid "Append a child widget"
+msgstr ""
+
+#: src/ui/layout.md:176
+msgid "`widgetAddChildAt(parent, child, index)`"
+msgstr ""
+
+#: src/ui/layout.md:176
+msgid "Insert a child at a specific position"
+msgstr ""
+
+#: src/ui/layout.md:177
+msgid "`widgetRemoveChild(parent, child)`"
+msgstr ""
+
+#: src/ui/layout.md:177
+msgid "Remove a specific child"
+msgstr ""
+
+#: src/ui/layout.md:178
+msgid "`widgetReorderChild(widget, fromIndex, toIndex)`"
+msgstr ""
+
+#: src/ui/layout.md:178
+msgid "Move a child to a new position"
+msgstr ""
+
+#: src/ui/layout.md:179
+msgid "`widgetClearChildren(widget)`"
+msgstr ""
+
+#: src/ui/layout.md:179
+msgid "Remove all children"
+msgstr ""
+
+#: src/ui/layout.md:181
+msgid "Stack Alignment"
+msgstr ""
+
+#: src/ui/layout.md:183
+msgid ""
+"Control how children are aligned within a stack using `stackSetAlignment`:"
+msgstr ""
+
+#: src/ui/layout.md:185
+msgid ""
+"```typescript\n"
+"const centered = VStack(16, [\n"
+"    Text(\"Centered\"),\n"
+"    Text(\"Content\"),\n"
+"])\n"
+"stackSetAlignment(centered, 9) // CenterX\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:193
+msgid "**VStack alignment** (cross-axis = horizontal):"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203 src/ui/layout.md:221
+#: src/platforms/tvos.md:149 src/plugins/appstore-review.md:77
+#: src/plugins/appstore-review.md:93 src/plugins/appstore-review.md:106
+#: src/cli/perry-toml.md:215 src/cli/perry-toml.md:277
+#: src/cli/perry-toml.md:284
+msgid "Value"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203 src/ui/layout.md:221
+msgid "Name"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203
+msgid "Effect"
+msgstr ""
+
+#: src/ui/layout.md:197 src/ui/styling.md:372 src/testing/geisterhand.md:91
+#: src/testing/geisterhand.md:105 src/cli/perry-toml.md:400
+msgid "5"
+msgstr ""
+
+#: src/ui/layout.md:197
+msgid "Leading"
+msgstr ""
+
+#: src/ui/layout.md:197
+msgid "Children align to the leading (left) edge"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "9"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "CenterX"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "Children centered horizontally"
+msgstr ""
+
+#: src/ui/layout.md:199 src/testing/geisterhand.md:93
+msgid "7"
+msgstr ""
+
+#: src/ui/layout.md:199
+msgid "Width"
+msgstr ""
+
+#: src/ui/layout.md:199
+msgid "Children stretch to fill the stack's width"
+msgstr ""
+
+#: src/ui/layout.md:201
+msgid "**HStack alignment** (cross-axis = vertical):"
+msgstr ""
+
+#: src/ui/layout.md:205 src/ui/layout.md:226 src/platforms/windows-7.md:27
+#: src/testing/geisterhand.md:89 src/testing/geisterhand.md:103
+#: src/cli/perry-toml.md:402
+msgid "3"
+msgstr ""
+
+#: src/ui/layout.md:205
+msgid "Top"
+msgstr ""
+
+#: src/ui/layout.md:205
+msgid "Children align to the top"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "12"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "CenterY"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "Children centered vertically"
+msgstr ""
+
+#: src/ui/layout.md:207 src/ui/layout.md:227 src/ui/styling.md:371
+#: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
+#: src/cli/perry-toml.md:401
+msgid "4"
+msgstr ""
+
+#: src/ui/layout.md:207
+msgid "Bottom"
+msgstr ""
+
+#: src/ui/layout.md:207
+msgid "Children align to the bottom"
+msgstr ""
+
+#: src/ui/layout.md:209
+msgid "Stack Distribution"
+msgstr ""
+
+#: src/ui/layout.md:211
+msgid ""
+"Control how children share space within a stack using `stackSetDistribution`:"
+msgstr ""
+
+#: src/ui/layout.md:213
+msgid ""
+"```typescript\n"
+"const buttons = HStack(8, [\n"
+"    Button(\"Cancel\", noop),\n"
+"    Button(\"OK\", noop),\n"
+"])\n"
+"stackSetDistribution(buttons, 1) // FillEqually — both buttons get equal "
+"width\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:221 src/widgets/data-fetching.md:125
+msgid "Behavior"
+msgstr ""
+
+#: src/ui/layout.md:223 src/ui/styling.md:370 src/ui/styling.md:371
+#: src/ui/styling.md:372 src/testing/geisterhand.md:86
+#: src/testing/geisterhand.md:100
+msgid "0"
+msgstr ""
+
+#: src/ui/layout.md:223
+msgid "Fill"
+msgstr ""
+
+#: src/ui/layout.md:223
+msgid "Default. First resizable child fills remaining space"
+msgstr ""
+
+#: src/ui/layout.md:224 src/platforms/windows-7.md:25
+#: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
+#: src/cli/perry-toml.md:404
+msgid "1"
+msgstr ""
+
+#: src/ui/layout.md:224
+msgid "FillEqually"
+msgstr ""
+
+#: src/ui/layout.md:224
+msgid "All children get equal size"
+msgstr ""
+
+#: src/ui/layout.md:225 src/platforms/windows-7.md:26
+#: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
+#: src/cli/perry-toml.md:403
+msgid "2"
+msgstr ""
+
+#: src/ui/layout.md:225
+msgid "FillProportionally"
+msgstr ""
+
+#: src/ui/layout.md:225
+msgid "Children sized proportionally to their intrinsic content"
+msgstr ""
+
+#: src/ui/layout.md:226
+msgid "EqualSpacing"
+msgstr ""
+
+#: src/ui/layout.md:226
+msgid "Equal gaps between children"
+msgstr ""
+
+#: src/ui/layout.md:227
+msgid "EqualCentering"
+msgstr ""
+
+#: src/ui/layout.md:227
+msgid "Equal distance between child centers"
+msgstr ""
+
+#: src/ui/layout.md:229
+msgid "Fill Parent"
+msgstr ""
+
+#: src/ui/layout.md:231
+msgid "Pin a child's edges to its parent container:"
+msgstr ""
+
+#: src/ui/layout.md:233
+msgid ""
+"```typescript\n"
+"const banner = Text(\"Full width banner\")\n"
+"widgetMatchParentWidth(banner)\n"
+"const banneredPage = VStack(16, [banner, Text(\"Normal width\")])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:239
+msgid "`widgetMatchParentWidth(widget)` — stretch to fill parent's width"
+msgstr ""
+
+#: src/ui/layout.md:240
+msgid "`widgetMatchParentHeight(widget)` — stretch to fill parent's height"
+msgstr ""
+
+#: src/ui/layout.md:242
+msgid "Content Hugging"
+msgstr ""
+
+#: src/ui/layout.md:244
+msgid ""
+"Control whether a widget resists being stretched beyond its intrinsic size:"
+msgstr ""
+
+#: src/ui/layout.md:246
+msgid ""
+"```typescript\n"
+"const tight = Text(\"I stay small\")\n"
+"widgetSetHugging(tight, 750) // High priority — resist stretching\n"
+"\n"
+"const stretchy = Text(\"I stretch\")\n"
+"widgetSetHugging(stretchy, 1) // Low priority — stretch to fill\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:254
+msgid ""
+"**High priority** (250–750+): widget resists stretching, stays at its "
+"natural size"
+msgstr ""
+
+#: src/ui/layout.md:255
+msgid "**Low priority** (1–249): widget stretches to fill available space"
+msgstr ""
+
+#: src/ui/layout.md:257
+msgid "Overlay Positioning"
+msgstr ""
+
+#: src/ui/layout.md:259
+msgid "For absolute positioning, add overlay children to any container:"
+msgstr ""
+
+#: src/ui/layout.md:261
+msgid ""
+"```typescript\n"
+"// Overlay parent must be a ZStack — macOS NSView allows `addSubview` on\n"
+"// any view, but GTK4 can only float children above siblings inside\n"
+"// `gtk::Overlay` (which is what ZStack is backed by).\n"
+"const container = ZStack()\n"
+"widgetAddChild(container, VStack(16, [Text(\"Main content\")])) // main "
+"child\n"
+"\n"
+"const badge = Text(\"3\")\n"
+"setCornerRadius(badge, 10)\n"
+"widgetSetBackgroundColor(badge, 1.0, 0.231, 0.188, 1.0) // RGBA red\n"
+"\n"
+"widgetAddOverlay(container, badge)\n"
+"widgetSetOverlayFrame(badge, 280, 10, 20, 20) // x, y, width, height\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:276
+msgid ""
+"Overlay children are positioned absolutely relative to their parent — "
+"similar to CSS `position: absolute`."
+msgstr ""
+
+#: src/ui/layout.md:279
+msgid "Split Views"
+msgstr ""
+
+#: src/ui/layout.md:281
+msgid "Create resizable split panes for sidebar layouts:"
+msgstr ""
+
+#: src/ui/layout.md:283
+msgid ""
+"```typescript\n"
+"const split = SplitView()\n"
+"\n"
+"const sidebar = VStack(8, [Text(\"Navigation\"), Text(\"Item 1\"), "
+"Text(\"Item 2\")])\n"
+"const content = VStack(16, [Text(\"Main Content\")])\n"
+"\n"
+"splitViewAddChild(split, sidebar)\n"
+"splitViewAddChild(split, content)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:293
+msgid ""
+"The user can drag the divider to resize panes. On macOS this maps to "
+"`NSSplitView`."
+msgstr ""
+
+#: src/ui/layout.md:296
+msgid "Stacks with Built-in Padding"
+msgstr ""
+
+#: src/ui/layout.md:298
+msgid ""
+"Create a stack with padding in a single call. The order is **top, left, "
+"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+msgstr ""
+
+#: src/ui/layout.md:301
+msgid ""
+"```typescript\n"
+"// VStackWithInsets(spacing, top, left, bottom, right) — note: order is\n"
+"// top/left/bottom/right (CSS-style), not top/right/bottom/left.\n"
+"const card = VStackWithInsets(12, 16, 16, 16, 16)\n"
+"widgetAddChild(card, Text(\"Padded content\"))\n"
+"widgetAddChild(card, Text(\"More content\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:309
+msgid ""
+"`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
+"counterpart. Equivalent to creating a stack and then calling "
+"`widgetSetEdgeInsets`, but more concise. Children are added via "
+"`widgetAddChild` rather than the constructor array."
+msgstr ""
+
+#: src/ui/layout.md:314
+msgid "Detaching Hidden Views"
+msgstr ""
+
+#: src/ui/layout.md:316
+msgid ""
+"By default, hidden children still occupy space in a stack. To collapse them:"
+msgstr ""
+
+#: src/ui/layout.md:318
+msgid ""
+"```typescript\n"
+"const collapsible = VStack(8, [Text(\"Always visible\"), Text(\"Sometimes "
+"hidden\")])\n"
+"stackSetDetachesHidden(collapsible, 1) // Hidden children leave no gap\n"
+"// You can then toggle a child:\n"
+"const sometimesHidden = Text(\"toggle me\")\n"
+"widgetSetHidden(sometimesHidden, 1) // 1 = hidden, 0 = visible\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:326
+msgid "Common Layout Patterns"
+msgstr ""
+
+#: src/ui/layout.md:328
+msgid "Centered content"
+msgstr ""
+
+#: src/ui/layout.md:330
+msgid ""
+"```typescript\n"
+"const page = VStack(16, [Text(\"Title\"), Text(\"Subtitle\")])\n"
+"stackSetAlignment(page, 9) // CenterX\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:335
+msgid "Search row that fills the width"
+msgstr ""
+
+#: src/ui/layout.md:337
+msgid ""
+"```typescript\n"
+"const searchInput = TextField(\"Search...\", (v: string) => search.set(v))\n"
+"widgetMatchParentWidth(searchInput)\n"
+"const results = VStack(8, [])\n"
+"const searchPage = VStack(12, [searchInput, results])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:344
+msgid "Floating badge / overlay"
+msgstr ""
+
+#: src/ui/layout.md:346
+msgid ""
+"```typescript\n"
+"// Wrap the icon in a ZStack so the badge can float above it on every\n"
+"const icon = ZStack()\n"
+"widgetAddChild(icon, ImageSymbol(\"bell\"))\n"
+"const dotBadge = Text(\"3\")\n"
+"widgetAddOverlay(icon, dotBadge)\n"
+"widgetSetOverlayFrame(dotBadge, 20, -5, 16, 16)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:355
+msgid "Toolbar with spacers"
+msgstr ""
+
+#: src/ui/layout.md:357
+msgid ""
+"```typescript\n"
+"const titleBar = HStack(8, [\n"
+"    Button(\"Back\", noop),\n"
+"    Spacer(),\n"
+"    Text(\"Page Title\"),\n"
+"    Spacer(),\n"
+"    Button(\"Settings\", noop),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:369
+msgid "[Styling](styling.md) — Colors, padding, sizing"
+msgstr ""
+
+#: src/ui/layout.md:371
+msgid "[State Management](state.md) — Dynamic UI with state"
+msgstr ""
+
+#: src/ui/styling.md:3
+msgid ""
+"Perry widgets accept an inline `style: { ... }` object that maps to each "
+"platform's native styling APIs. The same shape works on every Widget "
+"constructor — `Button`, `Text`, `Toggle`, `Slider`, `VStack`/`HStack`, and "
+"friends — so cross-platform styling code stays the same regardless of target."
+msgstr ""
+
+#: src/ui/styling.md:9
+msgid "Inline style — recommended"
+msgstr ""
+
+#: src/ui/styling.md:11
+msgid ""
+"Pass a `StyleProps` object as the trailing argument to any widget "
+"constructor. Codegen destructures the literal at HIR time into a sequence of "
+"native setter calls, so the runtime shape is the same as hand-writing the "
+"imperative pattern below — but the source is much shorter:"
+msgstr ""
+
+#: src/ui/styling.md:17
+msgid ""
+"```typescript\n"
+"const card = Button(\"Save\", () => {\n"
+"    console.log(\"saved\")\n"
+"}, {\n"
+"    backgroundColor: { r: 0.231, g: 0.510, b: 0.965, a: 1.0 },\n"
+"    borderColor: { r: 0.0, g: 0.0, b: 0.0, a: 0.1 },\n"
+"    borderWidth: 1,\n"
+"    borderRadius: 8,\n"
+"    padding: 12,\n"
+"    opacity: 0.95,\n"
+"    shadow: {\n"
+"        color: { r: 0.0, g: 0.0, b: 0.0, a: 0.25 },\n"
+"        blur: 12,\n"
+"        offsetX: 0,\n"
+"        offsetY: 4,\n"
+"    },\n"
+"    tooltip: \"Save the current document\",\n"
+"    enabled: true,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:38
+msgid ""
+"The `style` arg is optional; widgets without it look identical to calls "
+"before this API existed. See "
+"[`docs/examples/ui/styling/button_inline_style.ts`](../../examples/ui/styling/button_inline_style.ts) "
+"for the full file."
+msgstr ""
+
+#: src/ui/styling.md:43
+msgid "What `style` accepts"
+msgstr ""
+
+#: src/ui/styling.md:45
+msgid "Prop"
+msgstr ""
+
+#: src/ui/styling.md:45
+msgid "Maps to"
+msgstr ""
+
+#: src/ui/styling.md:47
+msgid "`backgroundColor`"
+msgstr ""
+
+#: src/ui/styling.md:47 src/ui/styling.md:48 src/ui/styling.md:49
+msgid "string \\| PerryColor"
+msgstr ""
+
+#: src/ui/styling.md:47
+msgid "`widgetSetBackgroundColor`"
+msgstr ""
+
+#: src/ui/styling.md:48
+msgid "`color`"
+msgstr ""
+
+#: src/ui/styling.md:48
+msgid "`textSetColor` / `buttonSetTextColor`"
+msgstr ""
+
+#: src/ui/styling.md:49
+msgid "`borderColor`"
+msgstr ""
+
+#: src/ui/styling.md:49
+msgid "`widgetSetBorderColor`"
+msgstr ""
+
+#: src/ui/styling.md:50
+msgid "`borderWidth`"
+msgstr ""
+
+#: src/ui/styling.md:50
+msgid "`widgetSetBorderWidth`"
+msgstr ""
+
+#: src/ui/styling.md:51
+msgid "`borderRadius`"
+msgstr ""
+
+#: src/ui/styling.md:51
+msgid "`setCornerRadius`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "`padding`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "number \\| `{ top, right, bottom, left }`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "`widgetSetEdgeInsets`"
+msgstr ""
+
+#: src/ui/styling.md:53 src/platforms/watchos.md:77
+msgid "`opacity`"
+msgstr ""
+
+#: src/ui/styling.md:53
+msgid "number (0..=1)"
+msgstr ""
+
+#: src/ui/styling.md:53
+msgid "`widgetSetOpacity`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`shadow`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`{ color, blur, offsetX, offsetY }`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`widgetSetShadow`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`textDecoration`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`\"none\" \\| \"underline\" \\| \"strikethrough\"`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`textSetDecoration`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`gradient`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`{ angle, stops: [c1, c2] }`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`widgetSetBackgroundGradient`"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "`fontSize`, `fontWeight`, `fontFamily`"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "number / string"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "`textSetFont*`"
+msgstr ""
+
+#: src/ui/styling.md:58
+msgid "`tooltip`"
+msgstr ""
+
+#: src/ui/styling.md:58
+msgid "`widgetSetTooltip`"
+msgstr ""
+
+#: src/ui/styling.md:59
+msgid "`hidden`"
+msgstr ""
+
+#: src/ui/styling.md:59
+msgid "`widgetSetHidden`"
+msgstr ""
+
+#: src/ui/styling.md:60
+msgid "`enabled`"
+msgstr ""
+
+#: src/ui/styling.md:60
+msgid "`widgetSetEnabled`"
+msgstr ""
+
+#: src/ui/styling.md:62
+msgid "Color values"
+msgstr ""
+
+#: src/ui/styling.md:64
+msgid "Color props accept four interchangeable shapes:"
+msgstr ""
+
+#: src/ui/styling.md:66
+msgid ""
+"```typescript,no-test\n"
+"backgroundColor: \"#3B82F6\"                                   // hex 6/8\n"
+"backgroundColor: \"#3B82F6FF\"                                 // hex with "
+"alpha\n"
+"backgroundColor: \"blue\"                                      // named "
+"color\n"
+"backgroundColor: { r: 0.231, g: 0.510, b: 0.965, a: 1.0 }   // PerryColor "
+"object\n"
+"backgroundColor: themeColor                                  // runtime "
+"variable\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:74
+msgid ""
+"Named colors: `white`, `black`, `red`, `green`, `blue`, `yellow`, `cyan`, "
+"`magenta`, `gray` / `grey`, `transparent`. Hex forms supported: `#RGB`, "
+"`#RGBA`, `#RRGGBB`, `#RRGGBBAA`."
+msgstr ""
+
+#: src/ui/styling.md:78
+msgid ""
+"Literals (the first four forms) compile-time-fold into 4 baked-in float "
+"arguments — zero runtime cost. Runtime variables resolve through "
+"`js_color_parse_channel` (a small CSS color parser in `perry-runtime`) so "
+"`backgroundColor: someStringVar` works the same as the literal form."
+msgstr ""
+
+#: src/ui/styling.md:83
+msgid "Padding shapes"
+msgstr ""
+
+#: src/ui/styling.md:85
+msgid "A single number applies to all four sides; an object picks per-side:"
+msgstr ""
+
+#: src/ui/styling.md:87
+msgid ""
+"```typescript,no-test\n"
+"padding: 12                                       // all four sides 12\n"
+"padding: { top: 8, right: 16, bottom: 8, left: 16 }  // per-side\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:92
+msgid "Missing sides default to 0."
+msgstr ""
+
+#: src/ui/styling.md:94
+msgid "Container styling"
+msgstr ""
+
+#: src/ui/styling.md:96
+msgid "`VStack` and `HStack` accept `style` after the children array:"
+msgstr ""
+
+#: src/ui/styling.md:98
+msgid ""
+"```typescript\n"
+"// VStack with explicit spacing AND inline style — children + style.\n"
+"const card = VStack(8, [\n"
+"    Text(\"Heading\"),\n"
+"    Text(\"Subtitle\"),\n"
+"    Button(\"Action\", () => { console.log(\"clicked\") }),\n"
+"], {\n"
+"    backgroundColor: { r: 0.96, g: 0.97, b: 0.99, a: 1.0 },\n"
+"    borderRadius: 12,\n"
+"    padding: 16,\n"
+"    shadow: {\n"
+"        color: { r: 0.0, g: 0.0, b: 0.0, a: 0.1 },\n"
+"        blur: 8,\n"
+"        offsetY: 2,\n"
+"    },\n"
+"})\n"
+"\n"
+"// HStack with no explicit spacing (children-array first form) + style.\n"
+"const toolbar = HStack([\n"
+"    Text(\"Left\"),\n"
+"    Text(\"Right\"),\n"
+"], {\n"
+"    backgroundColor: { r: 0.2, g: 0.2, b: 0.2, a: 1.0 },\n"
+"    padding: { top: 8, right: 16, bottom: 8, left: 16 },\n"
+"    borderRadius: 6,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:126
+msgid ""
+"Both shapes work — `VStack(children, style?)` and `VStack(spacing, children, "
+"style?)`."
+msgstr ""
+
+#: src/ui/styling.md:128
+msgid "Coming from CSS"
+msgstr ""
+
+#: src/ui/styling.md:130
+msgid "If you're coming from web, the conceptual mapping is:"
+msgstr ""
+
+#: src/ui/styling.md:132
+msgid "CSS"
+msgstr ""
+
+#: src/ui/styling.md:132
+msgid "Perry inline style"
+msgstr ""
+
+#: src/ui/styling.md:134
+msgid "`display: flex; flex-direction: column`"
+msgstr ""
+
+#: src/ui/styling.md:134
+msgid "`VStack(spacing, [...])`"
+msgstr ""
+
+#: src/ui/styling.md:135
+msgid "`display: flex; flex-direction: row`"
+msgstr ""
+
+#: src/ui/styling.md:135
+msgid "`HStack(spacing, [...])`"
+msgstr ""
+
+#: src/ui/styling.md:136
+msgid "`width: 100%`"
+msgstr ""
+
+#: src/ui/styling.md:136
+msgid "`widgetMatchParentWidth(widget)`"
+msgstr ""
+
+#: src/ui/styling.md:137
+msgid "`padding: 10px 20px`"
+msgstr ""
+
+#: src/ui/styling.md:137
+msgid "`padding: { top: 10, right: 20, bottom: 10, left: 20 }`"
+msgstr ""
+
+#: src/ui/styling.md:138
+msgid "`gap: 16px`"
+msgstr ""
+
+#: src/ui/styling.md:138
+msgid "`VStack(16, [...])` — first argument is the gap"
+msgstr ""
+
+#: src/ui/styling.md:139
+msgid "CSS variables / design tokens"
+msgstr ""
+
+#: src/ui/styling.md:139
+msgid "[`perry-styling`](theming.md) package"
+msgstr ""
+
+#: src/ui/styling.md:140
+msgid "`opacity: 0.5`"
+msgstr ""
+
+#: src/ui/styling.md:141
+msgid "`border-radius: 8px`"
+msgstr ""
+
+#: src/ui/styling.md:141
+msgid "`borderRadius: 8`"
+msgstr ""
+
+#: src/ui/styling.md:142
+msgid "`background: #3B82F6`"
+msgstr ""
+
+#: src/ui/styling.md:142
+msgid "`backgroundColor: \"#3B82F6\"`"
+msgstr ""
+
+#: src/ui/styling.md:143
+msgid "`box-shadow: 0 4px 12px rgba(0,0,0,0.25)`"
+msgstr ""
+
+#: src/ui/styling.md:143
+msgid "`shadow: { color: \"#0004\", blur: 12, offsetY: 4 }`"
+msgstr ""
+
+#: src/ui/styling.md:144
+msgid "`text-decoration: underline`"
+msgstr ""
+
+#: src/ui/styling.md:144
+msgid "`textDecoration: \"underline\"`"
+msgstr ""
+
+#: src/ui/styling.md:146
+msgid ""
+"See [Layout](layout.md) for full details on alignment, distribution, "
+"overlays, and split views."
+msgstr ""
+
+#: src/ui/styling.md:148
+msgid "Imperative API (underlying)"
+msgstr ""
+
+#: src/ui/styling.md:150
+msgid ""
+"The inline `style` object lowers to the same FFI calls as Perry's imperative "
+"free-function setters: `widgetSet*`, `textSet*`, `buttonSet*`. They take the "
+"widget handle as the first argument and remain available for cases where you "
+"want fine-grained control or need to mutate styles after creation. Colors "
+"here are RGBA floats in `[0.0, 1.0]` (divide each hex byte by 255 — "
+"`0xFF3B30` → `(1.0, 0.231, 0.188, 1.0)`)."
+msgstr ""
+
+#: src/ui/styling.md:158
+msgid ""
+"Every snippet below is excerpted from "
+"[`docs/examples/ui/styling/snippets.ts`](../../examples/ui/styling/snippets.ts), "
+"which CI compiles and runs on every PR — so the API drawn here is always the "
+"API the compiler accepts."
+msgstr ""
+
+#: src/ui/styling.md:163
+msgid ""
+"```typescript\n"
+"import {\n"
+"    App,\n"
+"    VStack, VStackWithInsets, HStack, Spacer,\n"
+"    Text, Button,\n"
+"    textSetColor, textSetFontSize, textSetFontFamily, textSetFontWeight,\n"
+"    setCornerRadius, setPadding,\n"
+"    widgetAddChild,\n"
+"    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
+"    widgetSetBorderColor, widgetSetBorderWidth,\n"
+"    widgetSetEdgeInsets,\n"
+"    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
+"    widgetSetOpacity,\n"
+"    widgetSetControlSize,\n"
+"    widgetSetTooltip,\n"
+"    widgetSetEnabled,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:182
+msgid "Colors"
+msgstr ""
+
+#: src/ui/styling.md:184
+msgid ""
+"```typescript\n"
+"const colored = Text(\"Colored text\")\n"
+"textSetColor(colored, 1.0, 0.0, 0.0, 1.0)              // r, g, b, a in "
+"[0,1]\n"
+"widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:190
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/styling.md:192
+msgid ""
+"```typescript\n"
+"const font = Text(\"Styled text\")\n"
+"textSetFontSize(font, 24)                  // Font size in points\n"
+"textSetFontFamily(font, \"Menlo\")           // Font family name\n"
+"textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:199
+msgid "Use `\"monospaced\"` for the system monospaced font."
+msgstr ""
+
+#: src/ui/styling.md:201
+msgid "Corner Radius"
+msgstr ""
+
+#: src/ui/styling.md:203
+msgid ""
+"```typescript\n"
+"const rounded = Button(\"Rounded\", () => {})\n"
+"setCornerRadius(rounded, 12)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:208
+msgid "Borders"
+msgstr ""
+
+#: src/ui/styling.md:216
+msgid "Padding and Insets"
+msgstr ""
+
+#: src/ui/styling.md:218
+msgid ""
+"```typescript\n"
+"const padded = VStack(8, [Text(\"Padded content\")])\n"
+"// Both names accept (widget, top, left, bottom, right):\n"
+"setPadding(padded, 16, 16, 16, 16)\n"
+"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:225
+msgid "Sizing"
+msgstr ""
+
+#: src/ui/styling.md:227
+msgid ""
+"```typescript\n"
+"const sized = VStack(0, [])\n"
+"widgetSetWidth(sized, 300)\n"
+"widgetSetHeight(sized, 200)\n"
+"widgetMatchParentWidth(sized) // expand to fill parent's width\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:234 src/ui/theming.md:144
+msgid "Opacity"
+msgstr ""
+
+#: src/ui/styling.md:236
+msgid ""
+"```typescript\n"
+"const dim = Text(\"Semi-transparent\")\n"
+"widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:241
+msgid "Background Gradient"
+msgstr ""
+
+#: src/ui/styling.md:243
+msgid ""
+"```typescript\n"
+"const grad = VStack(0, [])\n"
+"// Two RGBA stops + angle (degrees, 0 = top-to-bottom).\n"
+"widgetSetBackgroundGradient(grad,\n"
+"    1.0, 0.0, 0.0, 1.0,   // start (red)\n"
+"    0.0, 0.0, 1.0, 1.0,   // end   (blue)\n"
+"    0,                    // angle\n"
+")\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:253
+msgid "Control Size"
+msgstr ""
+
+#: src/ui/styling.md:255
+msgid ""
+"```typescript\n"
+"const small = Button(\"Small\", () => {})\n"
+"widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:260
+msgid ""
+"**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
+"differently."
+msgstr ""
+
+#: src/ui/styling.md:262
+msgid "Tooltips"
+msgstr ""
+
+#: src/ui/styling.md:264
+msgid ""
+"```typescript\n"
+"const tip = Button(\"Hover me\", () => {})\n"
+"widgetSetTooltip(tip, \"Click to perform action\")\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:269
+msgid ""
+"**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
+"support. **Web**: HTML `title` attribute."
+msgstr ""
+
+#: src/ui/styling.md:271
+msgid "Enabled/Disabled"
+msgstr ""
+
+#: src/ui/styling.md:273
+msgid ""
+"```typescript\n"
+"const submit = Button(\"Submit\", () => {})\n"
+"widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:278
+msgid "Complete Imperative Example"
+msgstr ""
+
+#: src/ui/styling.md:280
+msgid ""
+"```typescript\n"
+"// demonstrates: a styled counter card using the real free-function API\n"
+"// docs: docs/src/ui/styling.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    VStack,\n"
+"    HStack,\n"
+"    State,\n"
+"    Spacer,\n"
+"    textSetFontSize,\n"
+"    textSetFontFamily,\n"
+"    textSetColor,\n"
+"    widgetSetBackgroundColor,\n"
+"    widgetSetEdgeInsets,\n"
+"    setCornerRadius,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// Note: widgetSetBorderColor / widgetSetBorderWidth are macOS/iOS/Windows\n"
+"// only — perry-ui-gtk4 doesn't export them (GTK4 borders are CSS-driven).\n"
+"// Omitted from this demo so it compiles everywhere.\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"const title = Text(\"Counter\")\n"
+"textSetFontSize(title, 28)\n"
+"textSetColor(title, 0.1, 0.1, 0.1, 1.0)\n"
+"\n"
+"const display = Text(`${count.value}`)\n"
+"textSetFontSize(display, 48)\n"
+"textSetFontFamily(display, \"monospaced\")\n"
+"textSetColor(display, 0.0, 0.478, 1.0, 1.0)\n"
+"\n"
+"const decBtn = Button(\"-\", () => count.set(count.value - 1))\n"
+"setCornerRadius(decBtn, 20)\n"
+"widgetSetBackgroundColor(decBtn, 1.0, 0.231, 0.188, 1.0)\n"
+"\n"
+"const incBtn = Button(\"+\", () => count.set(count.value + 1))\n"
+"setCornerRadius(incBtn, 20)\n"
+"widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
+"\n"
+"const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
+"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"\n"
+"const container = VStack(16, [title, display, controls])\n"
+"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setCornerRadius(container, 16)\n"
+"widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
+"\n"
+"App({\n"
+"    title: \"Styled App\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: container,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:341
+msgid "Composing Styles (imperative helper functions)"
+msgstr ""
+
+#: src/ui/styling.md:343
+msgid "Reduce repetition by creating helper functions:"
+msgstr ""
+
+#: src/ui/styling.md:357
+msgid ""
+"For larger apps, use the `perry-styling` package to define design tokens in "
+"JSON and generate a typed theme file. See [Theming](theming.md) for the full "
+"workflow."
+msgstr ""
+
+#: src/ui/styling.md:359
+msgid "Platform support"
+msgstr ""
+
+#: src/ui/styling.md:361
+msgid ""
+"Per-prop, per-platform support is tracked in the [styling "
+"matrix](styling-matrix.md) — auto-generated from "
+"`crates/perry-ui/src/styling_matrix.rs` and CI-checked against each "
+"backend's `lib.rs` exports on every PR."
+msgstr ""
+
+#: src/ui/styling.md:366
+msgid ""
+"Current state (issue [\\#185](https://github.com/PerryTS/perry/issues/185)):"
+msgstr ""
+
+#: src/ui/styling.md:368 src/ui/canvas.md:72 src/ui/canvas.md:73
+#: src/ui/canvas.md:74 src/ui/canvas.md:75 src/ui/canvas.md:76
+#: src/ui/canvas.md:78
+msgid "Wired"
+msgstr ""
+
+#: src/ui/styling.md:368
+msgid "Stub"
+msgstr ""
+
+#: src/ui/styling.md:368
+msgid "Missing"
+msgstr ""
+
+#: src/ui/styling.md:370
+msgid "macOS / iOS / tvOS / visionOS / watchOS / Android / Web"
+msgstr ""
+
+#: src/ui/styling.md:370
+msgid "**43/43**"
+msgstr ""
+
+#: src/ui/styling.md:371
+msgid "GTK4 (Linux)"
+msgstr ""
+
+#: src/ui/styling.md:371
+msgid "39/43"
+msgstr ""
+
+#: src/ui/styling.md:372
+msgid "38/43"
+msgstr ""
+
+#: src/ui/styling.md:374
+msgid ""
+"**GTK4** has 4 styling props (`widget.on_click`, "
+"`button.content_tint_color`, `button.image_position`, "
+"`stack.detaches_hidden`) that need a Linux contributor — tracked in issue "
+"[\\#202](https://github.com/PerryTS/perry/issues/202). Inline `style: {...}` "
+"calls referencing only the wired props compile and run cleanly today; the "
+"missing props silently no-op until that issue lands."
+msgstr ""
+
+#: src/ui/styling.md:375
+msgid ""
+"**Windows** has 5 props in a \"deferred-paint family\" (`shadow`, `opacity`, "
+"`border_color`, `border_width`, `text.decoration`) where the FFI symbol "
+"exists and stores the requested params, but a custom `WM_PAINT` rendering "
+"pass is needed to make them visible — tracked in issue "
+"[\\#210](https://github.com/PerryTS/perry/issues/210). User code authoring "
+"inline styles compiles and links cleanly on Windows; the visual rendering "
+"catches up when that issue lands."
+msgstr ""
+
+#: src/ui/styling.md:380 src/ui/state.md:229 src/ui/table.md:110
+msgid "[Layout](layout.md) — Layout containers"
+msgstr ""
+
+#: src/ui/styling.md:381
+msgid "[Animation](animation.md) — Animate style changes"
+msgstr ""
+
+#: src/ui/styling.md:382
+msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
+msgstr ""
+
+#: src/ui/state.md:3
+msgid ""
+"Perry uses reactive state to automatically update the UI when data changes. "
+"Every snippet below is excerpted from "
+"[`docs/examples/ui/state/snippets.ts`](../../examples/ui/state/snippets.ts) "
+"— CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/state.md:8
+msgid "Creating State"
+msgstr ""
+
+#: src/ui/state.md:10
+msgid ""
+"```typescript\n"
+"const counter = State(0)               // number state\n"
+"const username = State(\"Perry\")        // string state\n"
+"const items = State<string[]>([])      // array state\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:16
+msgid "`State(initialValue)` creates a reactive state container."
+msgstr ""
+
+#: src/ui/state.md:18
+msgid "Reading and Writing"
+msgstr ""
+
+#: src/ui/state.md:20
+msgid ""
+"```typescript\n"
+"const value = counter.value     // Read current value\n"
+"counter.set(42)                  // Set new value → triggers UI update\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:25
+msgid "Every `.set()` call re-renders the widget tree with the new value."
+msgstr ""
+
+#: src/ui/state.md:27
+msgid "Reactive Text"
+msgstr ""
+
+#: src/ui/state.md:29
+msgid "Template literals with `state.value` update automatically:"
+msgstr ""
+
+#: src/ui/state.md:31
+msgid ""
+"```typescript\n"
+"const showCount = State(0)\n"
+"const countLabel = Text(`Count: ${showCount.value}`)\n"
+"// The text updates whenever showCount changes.\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:37
+msgid ""
+"This works because Perry detects `state.value` reads inside template "
+"literals and creates reactive bindings."
+msgstr ""
+
+#: src/ui/state.md:40
+msgid "Binding Inputs to State"
+msgstr ""
+
+#: src/ui/state.md:42
+msgid ""
+"Input widgets expose an `onChange` callback. Forward that into a state's "
+"`.set(...)` to keep the state in sync as the user types/toggles/drags:"
+msgstr ""
+
+#: src/ui/state.md:45
+msgid ""
+"```typescript\n"
+"const input = State(\"\")\n"
+"const field = TextField(\"Type here...\", (v: string) => input.set(v))\n"
+"\n"
+"// Optional: also let input.set(\"hello\") update the field on screen.\n"
+"stateBindTextfield(input, field)\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:53
+msgid "Input control signatures:"
+msgstr ""
+
+#: src/ui/state.md:54
+msgid ""
+"`TextField(placeholder, onChange)` — text input, `onChange: (value: string) "
+"=> void`"
+msgstr ""
+
+#: src/ui/state.md:55
+msgid ""
+"`SecureField(placeholder, onChange)` — password input, `onChange: (value: "
+"string) => void`"
+msgstr ""
+
+#: src/ui/state.md:56
+msgid ""
+"`Toggle(label, onChange)` — boolean toggle, `onChange: (value: boolean) => "
+"void`"
+msgstr ""
+
+#: src/ui/state.md:57
+msgid ""
+"`Slider(min, max, onChange)` — numeric slider, `onChange: (value: number) => "
+"void`"
+msgstr ""
+
+#: src/ui/state.md:58
+msgid ""
+"`Picker(onChange)` — dropdown, `onChange: (index: number) => void`; items "
+"via `pickerAddItem`"
+msgstr ""
+
+#: src/ui/state.md:60
+msgid ""
+"For programmatic-to-UI sync (state-drives-widget) use the dedicated binders: "
+"`stateBindTextfield`, `stateBindSlider`, `stateBindToggle`, "
+"`stateBindTextNumeric`, `stateBindVisibility`."
+msgstr ""
+
+#: src/ui/state.md:64
+msgid "onChange Callbacks"
+msgstr ""
+
+#: src/ui/state.md:66
+msgid "Listen for state changes with the free-function `stateOnChange`:"
+msgstr ""
+
+#: src/ui/state.md:75 src/widgets/components.md:92 src/widgets/platforms.md:27
+msgid "ForEach"
+msgstr ""
+
+#: src/ui/state.md:77
+msgid "Render a list from numeric state (the index count):"
+msgstr ""
+
+#: src/ui/state.md:79
+msgid ""
+"```typescript\n"
+"const fruits = State([\"Apple\", \"Banana\", \"Cherry\"])\n"
+"const fruitCount = State(3)\n"
+"\n"
+"const fruitList = VStack(16, [\n"
+"    ForEach(fruitCount, (i: number) =>\n"
+"        Text(`${i + 1}. ${fruits.value[i]}`),\n"
+"    ),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:90
+msgid ""
+"**Note:** `ForEach` iterates by index over a numeric state. Keep a count "
+"state in sync with your array, then read the items via `array.value[i]` "
+"inside the closure."
+msgstr ""
+
+#: src/ui/state.md:94
+msgid "`ForEach` re-renders the list when the count state changes:"
+msgstr ""
+
+#: src/ui/state.md:96
+msgid ""
+"```typescript\n"
+"// Add an item:\n"
+"fruits.set([...fruits.value, \"Date\"])\n"
+"fruitCount.set(fruitCount.value + 1)\n"
+"\n"
+"// Remove an item:\n"
+"fruits.set(fruits.value.filter((_, i) => i !== 1))\n"
+"fruitCount.set(fruitCount.value - 1)\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:106
+msgid "Conditional Rendering"
+msgstr ""
+
+#: src/ui/state.md:108
+msgid "Use state to conditionally show widgets:"
+msgstr ""
+
+#: src/ui/state.md:110
+msgid ""
+"```typescript\n"
+"const showDetails = State(false)\n"
+"const detailsLabel: number = showDetails.value\n"
+"    ? Text(\"Details are visible!\")\n"
+"    : Spacer()\n"
+"const detailsPanel = VStack(16, [\n"
+"    Button(\"Toggle\", () => showDetails.set(!showDetails.value)),\n"
+"    detailsLabel,\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:121
+msgid "Multi-State Text"
+msgstr ""
+
+#: src/ui/state.md:123
+msgid "Text can depend on multiple state values:"
+msgstr ""
+
+#: src/ui/state.md:125
+msgid ""
+"```typescript\n"
+"const firstName = State(\"John\")\n"
+"const lastName = State(\"Doe\")\n"
+"\n"
+"const greeting = Text(`Hello, ${firstName.value} ${lastName.value}!`)\n"
+"// Updates when either firstName or lastName changes.\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:133
+msgid "State with Objects and Arrays"
+msgstr ""
+
+#: src/ui/state.md:135
+msgid ""
+"```typescript\n"
+"const user = State({ name: \"Perry\", age: 0 })\n"
+"\n"
+"// Update by replacing the whole object:\n"
+"user.set({ ...user.value, age: 1 })\n"
+"\n"
+"const todos = State<{ text: string; done: boolean }[]>([])\n"
+"\n"
+"// Add a todo:\n"
+"todos.set([...todos.value, { text: \"New task\", done: false }])\n"
+"\n"
+"// Toggle a todo (must produce a new array reference):\n"
+"const next = todos.value.slice()\n"
+"if (next.length > 0) {\n"
+"    next[0] = { ...next[0], done: !next[0].done }\n"
+"    todos.set(next)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:154
+msgid ""
+"**Note**: State uses identity comparison. You must create a new array/object "
+"reference for changes to be detected. Mutating in-place without calling "
+"`.set()` with a new reference won't trigger updates."
+msgstr ""
+
+#: src/ui/state.md:158 src/ui/events.md:113 src/ui/table.md:73
+#: src/widgets/components.md:225
+msgid "Complete Example"
+msgstr ""
+
+#: src/ui/state.md:221
+msgid ""
+"This program is built and run by CI (`scripts/run_doc_tests.sh`), so the "
+"snippet above always matches the compiled artifact under "
+"[`docs/examples/ui/state/todo_app.ts`](../../examples/ui/state/todo_app.ts)."
+msgstr ""
+
+#: src/ui/state.md:227
+msgid "[Events](events.md) — Click, hover, keyboard events"
+msgstr ""
+
+#: src/ui/events.md:3
+msgid ""
+"Perry widgets support native event handlers for user interaction. Every "
+"snippet below is excerpted from "
+"[`docs/examples/ui/events/snippets.ts`](../../examples/ui/events/snippets.ts) "
+"— CI compiles and runs it on every PR, so the API drawn here is the API the "
+"runtime exposes."
+msgstr ""
+
+#: src/ui/events.md:9
+msgid ""
+"Event handlers are registered as **free functions** that take the widget "
+"handle as the first argument. The widget handle itself is opaque (`number` "
+"at the type level); perry's API is function-first throughout."
+msgstr ""
+
+#: src/ui/events.md:13 src/testing/geisterhand.md:100
+msgid "onClick"
+msgstr ""
+
+#: src/ui/events.md:15
+msgid ""
+"```typescript\n"
+"const greet = Button(\"Click me\", () => {\n"
+"    log.set(\"Button clicked\")\n"
+"})\n"
+"\n"
+"// Or attach a click handler to a non-button widget after creation:\n"
+"const label = Text(\"Clickable text\")\n"
+"widgetSetOnClick(label, () => {\n"
+"    log.set(\"Text clicked\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:27 src/testing/geisterhand.md:103
+msgid "onHover"
+msgstr ""
+
+#: src/ui/events.md:29
+msgid "Triggered when the cursor enters the widget."
+msgstr ""
+
+#: src/ui/events.md:31
+msgid ""
+"```typescript\n"
+"const hoverBtn = Button(\"Hover me\", () => {})\n"
+"widgetSetOnHover(hoverBtn, () => {\n"
+"    log.set(\"hovered\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:38
+msgid ""
+"**Note**: Hover events are available on macOS, Windows, Linux, and Web. iOS "
+"and Android use touch interactions instead. The callback fires once on "
+"enter; if you need a \"left\" event you'll have to track it yourself."
+msgstr ""
+
+#: src/ui/events.md:42 src/testing/geisterhand.md:104
+msgid "onDoubleClick"
+msgstr ""
+
+#: src/ui/events.md:44
+msgid ""
+"```typescript\n"
+"const dbl = Text(\"Double-click me\")\n"
+"widgetSetOnDoubleClick(dbl, () => {\n"
+"    log.set(\"double-clicked!\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:51 src/ui/menus.md:64
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: src/ui/events.md:53
+msgid "Register in-app keyboard shortcuts (active when the app is focused):"
+msgstr ""
+
+#: src/ui/events.md:55
+msgid ""
+"```typescript\n"
+"// Cmd+N on macOS, Ctrl+N on other platforms (modifier 1 = Cmd/Ctrl).\n"
+"addKeyboardShortcut(\"n\", 1, () => {\n"
+"    log.set(\"New document\")\n"
+"})\n"
+"\n"
+"// Cmd+Shift+S — modifiers add: 1 (Cmd/Ctrl) + 2 (Shift) = 3.\n"
+"addKeyboardShortcut(\"s\", 3, () => {\n"
+"    log.set(\"Save as...\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:67
+msgid ""
+"**Modifier bits:** `1` = Cmd (macOS) / Ctrl (Windows/Linux), `2` = Shift, "
+"`4` = Option (macOS) / Alt (others), `8` = Control (macOS only). Combine by "
+"adding — `3` = Cmd+Shift, `5` = Cmd+Option, etc."
+msgstr ""
+
+#: src/ui/events.md:71
+msgid "Keyboard shortcuts are also available on [menu items](menus.md):"
+msgstr ""
+
+#: src/ui/events.md:73
+msgid ""
+"```typescript\n"
+"const fileMenu = menuCreate()\n"
+"menuAddItem(fileMenu, \"New\", () => log.set(\"file/new\"))\n"
+"menuAddItem(fileMenu, \"Save As\", () => log.set(\"file/saveAs\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:79
+msgid "Global Hotkeys"
+msgstr ""
+
+#: src/ui/events.md:81
+msgid ""
+"Register a hotkey that fires system-wide, even when the app is in the "
+"background:"
+msgstr ""
+
+#: src/ui/events.md:84
+msgid ""
+"```typescript\n"
+"// System-wide: fires even when the app is in the background.\n"
+"// macOS: real Carbon RegisterEventHotKey. Other platforms: no-op.\n"
+"registerGlobalHotkey(\"F5\", 0, () => {\n"
+"    log.set(\"Global F5 hotkey fired\")\n"
+"})\n"
+"\n"
+"// Cmd+Shift+G (modifiers: 1=Cmd + 2=Shift = 3)\n"
+"registerGlobalHotkey(\"g\", 3, () => {\n"
+"    log.set(\"Global Cmd+Shift+G fired\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:97
+msgid ""
+"**Platform support:** macOS uses Carbon `RegisterEventHotKey` (real "
+"implementation). Linux, Windows, iOS, tvOS, visionOS, watchOS, and Android "
+"log the registration and no-op — global hotkeys on those platforms require "
+"OS-level portal / hook APIs that vary per OS."
+msgstr ""
+
+#: src/ui/events.md:102 src/system/other.md:44
+msgid "Clipboard"
+msgstr ""
+
+#: src/ui/events.md:104 src/system/other.md:48
+msgid ""
+"```typescript\n"
+"// Copy to clipboard\n"
+"clipboardWrite(\"Hello, clipboard!\")\n"
+"\n"
+"// Read from clipboard\n"
+"const text = clipboardRead()\n"
+"log.set(`clipboard length: ${text.length}`)\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:115
+msgid ""
+"```typescript\n"
+"// demonstrates: click + hover + double-click + keyboard shortcut all wired "
+"to\n"
+"// a single State-backed status label\n"
+"// docs: docs/src/ui/events.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    VStack,\n"
+"    State,\n"
+"    Spacer,\n"
+"    addKeyboardShortcut,\n"
+"    widgetSetOnHover,\n"
+"    widgetSetOnDoubleClick,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const lastEvent = State(\"No events yet\")\n"
+"\n"
+"// Cmd+R (modifiers: 1 = Cmd/Ctrl).\n"
+"addKeyboardShortcut(\"r\", 1, () => {\n"
+"    lastEvent.set(\"Keyboard: Cmd+R\")\n"
+"})\n"
+"\n"
+"const hoverBtn = Button(\"Hover me\", () => {})\n"
+"widgetSetOnHover(hoverBtn, () => {\n"
+"    lastEvent.set(\"Hover fired\")\n"
+"})\n"
+"\n"
+"const dblLabel = Text(\"Double-click me\")\n"
+"widgetSetOnDoubleClick(dblLabel, () => {\n"
+"    lastEvent.set(\"Double-clicked!\")\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Events Demo\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Last event: ${lastEvent.value}`),\n"
+"        Spacer(),\n"
+"        Button(\"Click me\", () => {\n"
+"            lastEvent.set(\"Button clicked\")\n"
+"        }),\n"
+"        hoverBtn,\n"
+"        dblLabel,\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:169
+msgid "[Menus](menus.md) — Menu bar and context menus with keyboard shortcuts"
+msgstr ""
+
+#: src/ui/events.md:171
+msgid "[State Management](state.md) — Reactive state"
+msgstr ""
+
+#: src/ui/canvas.md:3
+msgid "The `Canvas` widget provides a 2D drawing surface for custom graphics."
+msgstr ""
+
+#: src/ui/canvas.md:5
+msgid ""
+"**Availability**: `Canvas` is wired in the **LLVM** codegen path (macOS, "
+"iOS, Linux, Android) and the **JS / web / wasm** codegen path. Closed via "
+"[\\#190](https://github.com/PerryTS/perry/issues/190). The snippets below "
+"are compile-link verified by the doc-tests harness against "
+"[`docs/examples/ui/canvas/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/ui/canvas/snippets.ts); "
+"see that file for the full standalone program."
+msgstr ""
+
+#: src/ui/canvas.md:12
+msgid ""
+"The drawing API is **method-based** on the canvas handle (matching the FFI "
+"shape — `perry_ui_canvas_set_fill_color(handle, r, g, b, a)` etc.). Colors "
+"are RGBA floats in `[0.0, 1.0]`."
+msgstr ""
+
+#: src/ui/canvas.md:16
+msgid "Creating a Canvas"
+msgstr ""
+
+#: src/ui/canvas.md:24
+msgid ""
+"`Canvas(width, height)` creates a canvas widget; subsequent draw operations "
+"are method calls on the returned handle."
+msgstr ""
+
+#: src/ui/canvas.md:27
+msgid "Drawing Shapes"
+msgstr ""
+
+#: src/ui/canvas.md:29
+msgid "Rectangles"
+msgstr ""
+
+#: src/ui/canvas.md:31
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(1.0, 0.0, 0.0, 1.0)    // red\n"
+"canvas.fillRect(10, 10, 100, 80)\n"
+"\n"
+"canvas.setStrokeColor(0.0, 0.0, 1.0, 1.0)  // blue\n"
+"canvas.setLineWidth(2)\n"
+"canvas.strokeRect(150, 10, 100, 80)\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:40
+msgid "Lines"
+msgstr ""
+
+#: src/ui/canvas.md:51
+msgid "Circles and Arcs"
+msgstr ""
+
+#: src/ui/canvas.md:53
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(0.0, 1.0, 0.0, 1.0)\n"
+"canvas.beginPath()\n"
+"canvas.arc(200, 150, 50, 0, Math.PI * 2)  // x, y, radius, startAngle, "
+"endAngle\n"
+"canvas.fill()\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:62
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(0.0, 0.0, 0.0, 1.0)\n"
+"canvas.setFont(\"16px sans-serif\")\n"
+"canvas.fillText(\"Hello Canvas!\", 50, 50)\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:68 src/ui/menus.md:107 src/ui/dialogs.md:106
+#: src/ui/animation.md:60 src/ui/multi-window.md:136
+msgid "Platform Notes"
+msgstr ""
+
+#: src/ui/canvas.md:70 src/ui/animation.md:62 src/ui/multi-window.md:70
+#: src/ui/multi-window.md:87 src/ui/multi-window.md:98
+#: src/ui/multi-window.md:114 src/ui/multi-window.md:130
+#: src/ui/multi-window.md:138 src/ui/camera.md:137 src/system/other.md:18
+msgid "Implementation"
+msgstr ""
+
+#: src/ui/canvas.md:70 src/platforms/overview.md:7 src/system/media.md:84
+#: src/testing/geisterhand.md:298
+msgid "Status"
+msgstr ""
+
+#: src/ui/canvas.md:72
+msgid "HTML5 Canvas"
+msgstr ""
+
+#: src/ui/canvas.md:73
+msgid "WASM"
+msgstr ""
+
+#: src/ui/canvas.md:73
+msgid "HTML5 Canvas via JS bridge"
+msgstr ""
+
+#: src/ui/canvas.md:74 src/ui/canvas.md:75
+msgid "Core Graphics (CGContext)"
+msgstr ""
+
+#: src/ui/canvas.md:76
+msgid "Cairo"
+msgstr ""
+
+#: src/ui/canvas.md:77 src/platforms/windows.md:52
+msgid "GDI"
+msgstr ""
+
+#: src/ui/canvas.md:77
+msgid "Planned"
+msgstr ""
+
+#: src/ui/canvas.md:78
+msgid "Canvas/Bitmap"
+msgstr ""
+
+#: src/ui/canvas.md:83
+msgid "[Animation](animation.md) — Animating widget properties"
+msgstr ""
+
+#: src/ui/canvas.md:84
+msgid "[Styling](styling.md) — Widget styling"
+msgstr ""
+
+#: src/ui/menus.md:3
+msgid ""
+"Perry supports native menu bars, context menus, and toolbars across all "
+"platforms. Every snippet below is excerpted from "
+"[`docs/examples/ui/menus/snippets.ts`](../../examples/ui/menus/snippets.ts) "
+"— CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/menus.md:8
+msgid ""
+"The menu API is **handle-based** and free-function: build menus with "
+"`menuCreate()`, fill them with `menuAddItem` / `menuAddItemWithShortcut`, "
+"and attach them with `menuBarAddMenu(bar, title, menu)`. Submenus go through "
+"`menuAddSubmenu(parent, title, submenu)`."
+msgstr ""
+
+#: src/ui/menus.md:13 src/ui/menus.md:109
+msgid "Menu Bar"
+msgstr ""
+
+#: src/ui/menus.md:15
+msgid ""
+"```typescript\n"
+"// Menus are created independently, then attached. Build child menus first,\n"
+"// then hand them to `menuBarAddMenu(bar, title, menu)`.\n"
+"const menuBar = menuBarCreate()\n"
+"\n"
+"// File menu\n"
+"const fileMenu = menuCreate()\n"
+"menuAddItemWithShortcut(fileMenu, \"New\",         \"n\", () => "
+"status.set(\"file/new\"))\n"
+"menuAddItemWithShortcut(fileMenu, \"Open…\",       \"o\", () => "
+"status.set(\"file/open\"))\n"
+"menuAddSeparator(fileMenu)\n"
+"menuAddItemWithShortcut(fileMenu, \"Save\",        \"s\", () => "
+"status.set(\"file/save\"))\n"
+"menuAddItemWithShortcut(fileMenu, \"Save As…\",    \"S\", () => "
+"status.set(\"file/saveAs\"))\n"
+"menuBarAddMenu(menuBar, \"File\", fileMenu)\n"
+"\n"
+"// Edit menu\n"
+"const editMenu = menuCreate()\n"
+"menuAddItemWithShortcut(editMenu, \"Undo\", \"z\", () => "
+"status.set(\"edit/undo\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Redo\", \"Z\", () => "
+"status.set(\"edit/redo\"))\n"
+"menuAddSeparator(editMenu)\n"
+"menuAddItemWithShortcut(editMenu, \"Cut\",   \"x\", () => "
+"status.set(\"edit/cut\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Copy\",  \"c\", () => "
+"status.set(\"edit/copy\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Paste\", \"v\", () => "
+"status.set(\"edit/paste\"))\n"
+"menuBarAddMenu(menuBar, \"Edit\", editMenu)\n"
+"\n"
+"// Submenu: View → Zoom\n"
+"const viewMenu = menuCreate()\n"
+"const zoomSubmenu = menuCreate()\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Zoom In\",     \"+\", () => "
+"status.set(\"zoom/in\"))\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Zoom Out\",    \"-\", () => "
+"status.set(\"zoom/out\"))\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Actual Size\", \"0\", () => "
+"status.set(\"zoom/reset\"))\n"
+"menuAddSubmenu(viewMenu, \"Zoom\", zoomSubmenu)\n"
+"menuBarAddMenu(menuBar, \"View\", viewMenu)\n"
+"\n"
+"menuBarAttach(menuBar)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:51
+msgid "Menu Bar Functions"
+msgstr ""
+
+#: src/ui/menus.md:55
+msgid "`menuBarCreate()`"
+msgstr ""
+
+#: src/ui/menus.md:55
+msgid "Create a new (empty) menu bar"
+msgstr ""
+
+#: src/ui/menus.md:56
+msgid "`menuCreate()`"
+msgstr ""
+
+#: src/ui/menus.md:56
+msgid "Create a new menu — used as a child of the bar or as a submenu"
+msgstr ""
+
+#: src/ui/menus.md:57
+msgid "`menuBarAddMenu(bar, title, menu)`"
+msgstr ""
+
+#: src/ui/menus.md:57
+msgid "Attach a top-level menu under `title`"
+msgstr ""
+
+#: src/ui/menus.md:58
+msgid "`menuAddItem(menu, label, callback)`"
+msgstr ""
+
+#: src/ui/menus.md:58
+msgid "Append an item without a shortcut"
+msgstr ""
+
+#: src/ui/menus.md:59
+msgid "`menuAddItemWithShortcut(menu, label, shortcut, callback)`"
+msgstr ""
+
+#: src/ui/menus.md:59
+msgid "Append an item with a keyboard shortcut"
+msgstr ""
+
+#: src/ui/menus.md:60
+msgid "`menuAddSeparator(menu)`"
+msgstr ""
+
+#: src/ui/menus.md:60
+msgid "Append a horizontal separator line"
+msgstr ""
+
+#: src/ui/menus.md:61
+msgid "`menuAddSubmenu(parent, title, submenu)`"
+msgstr ""
+
+#: src/ui/menus.md:61
+msgid "Nest a previously-created menu under a label"
+msgstr ""
+
+#: src/ui/menus.md:62
+msgid "`menuBarAttach(bar)`"
+msgstr ""
+
+#: src/ui/menus.md:62
+msgid "Install the bar as the application's main menu"
+msgstr ""
+
+#: src/ui/menus.md:66
+msgid "The third argument to `menuAddItemWithShortcut` is the shortcut key:"
+msgstr ""
+
+#: src/ui/menus.md:68 src/testing/geisterhand.md:92
+#: src/testing/geisterhand.md:295
+msgid "Shortcut"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "`\"n\"`"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "Cmd+N"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "Ctrl+N"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "`\"S\"`"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "Cmd+Shift+S"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "Ctrl+Shift+S"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "`\"+\"`"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "Cmd++"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "Ctrl++"
+msgstr ""
+
+#: src/ui/menus.md:74
+msgid "Uppercase letters imply Shift."
+msgstr ""
+
+#: src/ui/menus.md:76
+msgid "Context Menus"
+msgstr ""
+
+#: src/ui/menus.md:78
+msgid ""
+"Right-click menus are attached to widgets via `widgetSetContextMenu(widget, "
+"menu)`. Build the menu the same way as a menu-bar entry, then bind it:"
+msgstr ""
+
+#: src/ui/menus.md:81
+msgid ""
+"```typescript\n"
+"const label = Text(\"Right-click me\")\n"
+"const ctx = menuCreate()\n"
+"menuAddItem(ctx, \"Copy\",   () => status.set(\"ctx/copy\"))\n"
+"menuAddItem(ctx, \"Paste\",  () => status.set(\"ctx/paste\"))\n"
+"menuAddSeparator(ctx)\n"
+"menuAddItem(ctx, \"Delete\", () => status.set(\"ctx/delete\"))\n"
+"widgetSetContextMenu(label, ctx)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:91 src/ui/menus.md:109
+msgid "Toolbar"
+msgstr ""
+
+#: src/ui/menus.md:93
+msgid ""
+"Add a toolbar to a window. `toolbarAddItem` takes an _identifier_ (used by "
+"AppKit to deduplicate items) and a _label_:"
+msgstr ""
+
+#: src/ui/menus.md:96
+msgid ""
+"```typescript\n"
+"const toolbar = toolbarCreate()\n"
+"toolbarAddItem(toolbar, \"new\",  \"New\",  () => status.set(\"tb/new\"))\n"
+"toolbarAddItem(toolbar, \"save\", \"Save\", () => status.set(\"tb/save\"))\n"
+"toolbarAddItem(toolbar, \"run\",  \"Run\",  () => status.set(\"tb/run\"))\n"
+"\n"
+"// `toolbarAttach(toolbar, window)` mounts onto a specific window.\n"
+"const win = Window(\"Toolbar Demo\", 800, 600)\n"
+"toolbarAttach(toolbar, win as unknown as number)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:109
+msgid "Context Menu"
+msgstr ""
+
+#: src/ui/menus.md:111
+msgid "NSToolbar"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "— (no menu bar)"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "UIMenu"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "UIToolbar"
+msgstr ""
+
+#: src/ui/menus.md:113
+msgid "HMENU/SetMenu"
+msgstr ""
+
+#: src/ui/menus.md:113
+msgid "Horizontal layout"
+msgstr ""
+
+#: src/ui/menus.md:114
+msgid "GMenu/set_menubar"
+msgstr ""
+
+#: src/ui/menus.md:114
+msgid "HeaderBar"
+msgstr ""
+
+#: src/ui/menus.md:117
+msgid ""
+"**iOS**: Menu bars are not applicable. Use toolbar and navigation patterns "
+"instead."
+msgstr ""
+
+#: src/ui/menus.md:121
+msgid "[Events](events.md) — Keyboard shortcuts and interactions"
+msgstr ""
+
+#: src/ui/menus.md:122
+msgid "[Dialogs](dialogs.md) — File dialogs and alerts"
+msgstr ""
+
+#: src/ui/menus.md:123
+msgid "[Layout](layout.md) — Toolbar and navigation patterns"
+msgstr ""
+
+#: src/ui/dialogs.md:3
+msgid ""
+"Perry provides native dialog functions for file selection, alerts, and "
+"sheets. Every snippet below is excerpted from "
+"[`docs/examples/ui/dialogs/snippets.ts`](../../examples/ui/dialogs/snippets.ts) "
+"— CI compiles and links the file on every PR, so the API drawn here is the "
+"API the runtime exposes."
+msgstr ""
+
+#: src/ui/dialogs.md:9
+msgid ""
+"All file dialogs are **callback-based** (the OS-modal panel is non-blocking "
+"on Apple platforms, so a synchronous return wouldn't be possible without "
+"freezing the app's run loop). The callback receives an empty string when the "
+"user cancels."
+msgstr ""
+
+#: src/ui/dialogs.md:14
+msgid "File Open Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:16
+msgid ""
+"```typescript\n"
+"function pickFile(): void {\n"
+"    openFileDialog((path: string) => {\n"
+"        if (path.length > 0) {\n"
+"            console.log(`Selected: ${path}`)\n"
+"        } else {\n"
+"            console.log(\"Open dialog cancelled\")\n"
+"        }\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:28
+msgid "Folder Selection Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:40
+msgid "Save File Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:42
+msgid ""
+"```typescript\n"
+"function pickSaveTarget(): void {\n"
+"    saveFileDialog((path: string) => {\n"
+"        if (path.length > 0) {\n"
+"            console.log(`Will save to: ${path}`)\n"
+"        }\n"
+"    }, \"untitled\", \"txt\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:52
+msgid ""
+"`saveFileDialog(callback, defaultName, extension)` pre-fills the name field "
+"with `defaultName.<extension>`."
+msgstr ""
+
+#: src/ui/dialogs.md:55 src/ui/dialogs.md:113
+msgid "Alert"
+msgstr ""
+
+#: src/ui/dialogs.md:57
+msgid "Display a native alert dialog:"
+msgstr ""
+
+#: src/ui/dialogs.md:59
+msgid ""
+"```typescript\n"
+"function showSimpleAlert(): void {\n"
+"    alert(\"Operation Complete\", \"Your file has been saved "
+"successfully.\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:65
+msgid "`alert(title, message)` shows a modal alert with an OK button."
+msgstr ""
+
+#: src/ui/dialogs.md:67
+msgid "Alert with Buttons"
+msgstr ""
+
+#: src/ui/dialogs.md:69
+msgid ""
+"```typescript\n"
+"function confirmDelete(): void {\n"
+"    alertWithButtons(\n"
+"        \"Delete Item?\",\n"
+"        \"This action cannot be undone.\",\n"
+"        [\"Cancel\", \"Delete\"],\n"
+"        (index: number) => {\n"
+"            if (index === 1) {\n"
+"                console.log(\"user confirmed delete\")\n"
+"            }\n"
+"        },\n"
+"    )\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:84
+msgid ""
+"`alertWithButtons(title, message, buttons, callback)` invokes the callback "
+"with the 0-based index of the button the user clicked. By convention put a "
+"destructive label last and check the index in the callback."
+msgstr ""
+
+#: src/ui/dialogs.md:88
+msgid "Sheets"
+msgstr ""
+
+#: src/ui/dialogs.md:90
+msgid ""
+"Sheets are modal panels attached to a window. Build the body, hand it (with "
+"a size) to `sheetCreate`, then `sheetPresent` it. To dismiss "
+"programmatically, keep the handle around and call `sheetDismiss(handle)`:"
+msgstr ""
+
+#: src/ui/dialogs.md:94
+msgid ""
+"```typescript\n"
+"function showSheet(): void {\n"
+"    let sheet = 0\n"
+"    const body = VStack(16, [\n"
+"        Text(\"Sheet Content\"),\n"
+"        Button(\"Close\", () => sheetDismiss(sheet)),\n"
+"    ])\n"
+"    sheet = sheetCreate(body, 320, 200)\n"
+"    sheetPresent(sheet)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:108
+msgid "Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "File Open"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:112
+msgid "NSOpenPanel"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "UIDocumentPicker"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:112
+msgid "IFileOpenDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:111 src/ui/dialogs.md:112
+msgid "GtkFileChooserDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "`<input type=\"file\">`"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "File Save"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "NSSavePanel"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "IFileSaveDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "Download link"
+msgstr ""
+
+#: src/ui/dialogs.md:112
+msgid "Folder"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "NSAlert"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "UIAlertController"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "MessageBoxW"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "MessageDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "`alert()`"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Sheet"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "NSSheet"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal VC"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal Window"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal div"
+msgstr ""
+
+#: src/ui/dialogs.md:116
+msgid "Complete Example: minimal text editor"
+msgstr ""
+
+#: src/ui/dialogs.md:118
+msgid ""
+"A real program that wires `openFileDialog` and `saveFileDialog` into a "
+"state-bound `TextField`:"
+msgstr ""
+
+#: src/ui/dialogs.md:121
+msgid ""
+"```typescript\n"
+"// demonstrates: file-open / save dialogs wired to a tiny text editor\n"
+"// docs: docs/src/ui/dialogs.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack, HStack,\n"
+"    Text, Button, TextField,\n"
+"    State,\n"
+"    openFileDialog, saveFileDialog, alert,\n"
+"} from \"perry/ui\"\n"
+"import { readFileSync, writeFileSync } from \"fs\"\n"
+"\n"
+"const content = State(\"\")\n"
+"const filePath = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"Text Editor\",\n"
+"    width: 800,\n"
+"    height: 600,\n"
+"    body: VStack(12, [\n"
+"        HStack(8, [\n"
+"            Button(\"Open\", () => {\n"
+"                openFileDialog((path: string) => {\n"
+"                    if (path.length === 0) return\n"
+"                    filePath.set(path)\n"
+"                    content.set(readFileSync(path, \"utf-8\") as string)\n"
+"                })\n"
+"            }),\n"
+"            Button(\"Save As\", () => {\n"
+"                saveFileDialog((path: string) => {\n"
+"                    if (path.length === 0) return\n"
+"                    writeFileSync(path, content.value)\n"
+"                    filePath.set(path)\n"
+"                    alert(\"Saved\", `File saved to ${path}`)\n"
+"                }, \"untitled\", \"txt\")\n"
+"            }),\n"
+"        ]),\n"
+"        Text(filePath.value === \"\" ? \"No file open\" : `File: "
+"${filePath.value}`),\n"
+"        TextField(\"Start typing...\", (value: string) => "
+"content.set(value)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:168
+msgid "[Menus](menus.md) — Menu bar and context menus"
+msgstr ""
+
+#: src/ui/dialogs.md:169
+msgid "[Multi-Window](multi-window.md) — Multiple windows"
+msgstr ""
+
+#: src/ui/dialogs.md:170
+msgid "[Events](events.md) — User interaction events"
+msgstr ""
+
+#: src/ui/table.md:3
+msgid ""
+"The `Table` widget displays tabular data with columns, headers, and row "
+"selection."
+msgstr ""
+
+#: src/ui/table.md:6
+msgid ""
+"**Platform support:** real implementation lives on **macOS** (`NSTableView` "
+"+ `NSScrollView`); the **Web** target uses an HTML `<table>`. **iOS**, "
+"**Android**, **Linux/GTK4**, **Windows**, **tvOS**, **visionOS**, and "
+"**watchOS** link no-op stubs so cross-platform code compiles everywhere — "
+"the table renders nothing and `tableGetSelectedRow` returns `-1`. For "
+"production lists on platforms without a real impl, use `LazyVStack` (see "
+"[Layout](layout.md))."
+msgstr ""
+
+#: src/ui/table.md:14
+msgid "Creating a Table"
+msgstr ""
+
+#: src/ui/table.md:22
+msgid ""
+"`Table(rowCount, colCount, renderCell)` creates a table. The render callback "
+"receives `(row, col)` and must return a `Widget` (typically `Text(...)`). "
+"The runtime resolves the returned handle as the cell view, which lets cells "
+"render images, stacks, or composites — not just plain strings."
+msgstr ""
+
+#: src/ui/table.md:28
+msgid "Column Headers"
+msgstr ""
+
+#: src/ui/table.md:30
+msgid ""
+"```ts\n"
+"const userTable = Table(users.length, 3, (row: number, col: number) => {\n"
+"    const user = users[row]\n"
+"    if (col === 0) return Text(user.name)\n"
+"    if (col === 1) return Text(user.email)\n"
+"    return Text(user.role)\n"
+"})\n"
+"\n"
+"tableSetColumnHeader(userTable, 0, \"Name\")\n"
+"tableSetColumnHeader(userTable, 1, \"Email\")\n"
+"tableSetColumnHeader(userTable, 2, \"Role\")\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:43
+msgid "Column Widths"
+msgstr ""
+
+#: src/ui/table.md:45
+msgid ""
+"```ts\n"
+"tableSetColumnWidth(userTable, 0, 150)  // Name column\n"
+"tableSetColumnWidth(userTable, 1, 250)  // Email column\n"
+"tableSetColumnWidth(userTable, 2, 100)  // Role column\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:51
+msgid "Row Selection"
+msgstr ""
+
+#: src/ui/table.md:53
+msgid ""
+"```ts\n"
+"const selectedRow = State(-1)\n"
+"\n"
+"tableSetOnRowSelect(userTable, (row: number) => {\n"
+"    selectedRow.set(row)\n"
+"    console.log(`Selected row: ${row}`)\n"
+"})\n"
+"\n"
+"// Read the currently selected row at any time:\n"
+"const current = tableGetSelectedRow(userTable)\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:65
+msgid "Dynamic Row Count"
+msgstr ""
+
+#: src/ui/table.md:67
+msgid "Update the number of rows after creation:"
+msgstr ""
+
+#: src/ui/table.md:75
+msgid ""
+"```ts\n"
+"const selectedName = State(\"None\")\n"
+"\n"
+"const table = Table(users.length, 3, (row: number, col: number) => {\n"
+"    const user = users[row]\n"
+"    if (col === 0) return Text(user.name)\n"
+"    if (col === 1) return Text(user.email)\n"
+"    return Text(user.role)\n"
+"})\n"
+"\n"
+"tableSetColumnHeader(table, 0, \"Name\")\n"
+"tableSetColumnHeader(table, 1, \"Email\")\n"
+"tableSetColumnHeader(table, 2, \"Role\")\n"
+"tableSetColumnWidth(table, 0, 150)\n"
+"tableSetColumnWidth(table, 1, 250)\n"
+"tableSetColumnWidth(table, 2, 100)\n"
+"\n"
+"tableSetOnRowSelect(table, (row: number) => {\n"
+"    selectedName.set(users[row].name)\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Table Demo\",\n"
+"    width: 600,\n"
+"    height: 400,\n"
+"    body: VStack(12, [\n"
+"        table,\n"
+"        Text(`Selected: ${selectedName.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:111
+msgid "[Events](events.md) — Event handling"
+msgstr ""
+
+#: src/ui/animation.md:3
+msgid ""
+"Perry supports animating widget properties for smooth transitions. Every "
+"snippet below is excerpted from "
+"[`docs/examples/ui/animation/snippets.ts`](../../examples/ui/animation/snippets.ts) "
+"— CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/animation.md:8
+msgid ""
+"`animateOpacity` and `animatePosition` are special: they're documented as "
+"methods on the widget handle (the only methods perry/ui exposes), and the "
+"HIR lowers them to `widgetAnimateOpacity` / `widgetAnimatePosition` calls "
+"under the hood."
+msgstr ""
+
+#: src/ui/animation.md:13
+msgid "Opacity Animation"
+msgstr ""
+
+#: src/ui/animation.md:15
+msgid ""
+"```typescript\n"
+"const fading = Text(\"Fading text\")\n"
+"// Animate from the widget's current opacity to `target` over "
+"`durationSecs`.\n"
+"fading.animateOpacity(1.0, 0.3) // target, durationSeconds\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:21
+msgid "Position Animation"
+msgstr ""
+
+#: src/ui/animation.md:23
+msgid ""
+"```typescript\n"
+"const moving = Button(\"Moving\", () => {})\n"
+"// Animate by a delta (dx, dy) relative to the widget's current position.\n"
+"moving.animatePosition(100, 200, 0.5) // dx, dy, durationSeconds\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:29
+msgid "Example: Fade-In Effect"
+msgstr ""
+
+#: src/ui/animation.md:31
+msgid ""
+"When the first argument reads from a `State.value`, Perry auto-subscribes "
+"the call to the state — toggling `visible` re-runs the animation."
+msgstr ""
+
+#: src/ui/animation.md:34
+msgid ""
+"```typescript\n"
+"// demonstrates: auto-reactive animateOpacity driven by a State toggle\n"
+"// docs: docs/src/ui/animation.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"\n"
+"import { App, Text, Button, VStack, State } from \"perry/ui\"\n"
+"\n"
+"const visible = State(false)\n"
+"\n"
+"const label = Text(\"Hello!\")\n"
+"label.animateOpacity(visible.value ? 1.0 : 0.0, 0.3)\n"
+"\n"
+"App({\n"
+"    title: \"Animation Demo\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Button(\"Toggle\", () => {\n"
+"            visible.set(!visible.value)\n"
+"        }),\n"
+"        label,\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:64
+msgid "NSAnimationContext / ViewPropertyAnimator"
+msgstr ""
+
+#: src/ui/animation.md:65
+msgid "UIView.animate"
+msgstr ""
+
+#: src/ui/animation.md:66
+msgid "ViewPropertyAnimator"
+msgstr ""
+
+#: src/ui/animation.md:67
+msgid "WM_TIMER-based animation"
+msgstr ""
+
+#: src/ui/animation.md:68
+msgid "CSS transitions (GTK4)"
+msgstr ""
+
+#: src/ui/animation.md:69
+msgid "CSS transitions"
+msgstr ""
+
+#: src/ui/animation.md:73
+msgid "[Styling](styling.md) — Widget styling properties"
+msgstr ""
+
+#: src/ui/animation.md:75
+msgid "[Events](events.md) — User interaction"
+msgstr ""
+
+#: src/ui/multi-window.md:1
+msgid "Multi-Window & Window Management"
+msgstr ""
+
+#: src/ui/multi-window.md:3
+msgid ""
+"Perry supports creating multiple native windows and controlling their "
+"appearance and behavior. Every snippet below is excerpted from "
+"[`docs/examples/ui/multi_window/snippets.ts`](../../examples/ui/multi_window/snippets.ts) "
+"— CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/multi-window.md:8
+msgid "Creating Windows"
+msgstr ""
+
+#: src/ui/multi-window.md:10
+msgid ""
+"`Window(title, width, height)` returns a window handle. Call `.setBody()` to "
+"set its content and `.show()` to display it:"
+msgstr ""
+
+#: src/ui/multi-window.md:13
+msgid ""
+"```typescript\n"
+"const settings = Window(\"Settings\", 500, 400)\n"
+"settings.setBody(VStack(16, [\n"
+"    Text(\"Settings panel\"),\n"
+"]))\n"
+"settings.show()\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:21
+msgid "Window Instance Methods"
+msgstr ""
+
+#: src/ui/multi-window.md:23
+msgid ""
+"```typescript\n"
+"const win = Window(\"My Window\", 600, 400)\n"
+"\n"
+"win.setBody(Text(\"Hello\"))   // Set the root widget\n"
+"win.show()                    // Show the window\n"
+"win.hide()                    // Hide without destroying\n"
+"win.setSize(800, 600)         // Resize dynamically\n"
+"win.onFocusLost(() => {       // Callback when the window loses focus\n"
+"    win.hide()\n"
+"})\n"
+"win.close()                   // Close and destroy\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:36 src/i18n/overview.md:87
+#: src/testing/geisterhand.md:257
+msgid "Method"
+msgstr ""
+
+#: src/ui/multi-window.md:38
+msgid "`setBody(widget)`"
+msgstr ""
+
+#: src/ui/multi-window.md:38
+msgid "Set the root widget of the window"
+msgstr ""
+
+#: src/ui/multi-window.md:39
+msgid "`show()`"
+msgstr ""
+
+#: src/ui/multi-window.md:39
+msgid "Show the window"
+msgstr ""
+
+#: src/ui/multi-window.md:40
+msgid "`hide()`"
+msgstr ""
+
+#: src/ui/multi-window.md:40
+msgid "Hide without destroying — call `show()` again to reveal"
+msgstr ""
+
+#: src/ui/multi-window.md:41
+msgid "`setSize(w, h)`"
+msgstr ""
+
+#: src/ui/multi-window.md:41
+msgid "Resize dynamically"
+msgstr ""
+
+#: src/ui/multi-window.md:42
+msgid "`onFocusLost(cb)`"
+msgstr ""
+
+#: src/ui/multi-window.md:42
+msgid "Register a callback that fires when focus leaves the window"
+msgstr ""
+
+#: src/ui/multi-window.md:43
+msgid "`close()`"
+msgstr ""
+
+#: src/ui/multi-window.md:43
+msgid "Close and destroy"
+msgstr ""
+
+#: src/ui/multi-window.md:45
+msgid "App Window Properties"
+msgstr ""
+
+#: src/ui/multi-window.md:47
+msgid ""
+"The main `App({})` config object accepts the same window properties for "
+"building launcher-style, overlay, or utility apps:"
+msgstr ""
+
+#: src/ui/multi-window.md:50
+msgid ""
+"```typescript\n"
+"App({\n"
+"    title: \"QuickLaunch\",\n"
+"    width: 600,\n"
+"    height: 80,\n"
+"    body: VStack(8, [\n"
+"        Text(\"Search...\"),\n"
+"        Button(\"Open Settings\", () => settings.show()),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:62
+msgid ""
+"`App` additionally accepts the optional fields `frameless`, `level`, "
+"`transparent`, `vibrancy`, `activationPolicy`, and `icon`. They map to the "
+"following native primitives:"
+msgstr ""
+
+#: src/ui/multi-window.md:66
+msgid "`frameless: true`"
+msgstr ""
+
+#: src/ui/multi-window.md:68
+msgid "Removes the window title bar and frame, creating a borderless window."
+msgstr ""
+
+#: src/ui/multi-window.md:72
+msgid "`NSWindowStyleMask::Borderless` + movable by background"
+msgstr ""
+
+#: src/ui/multi-window.md:73
+msgid "`WS_POPUP` window style"
+msgstr ""
+
+#: src/ui/multi-window.md:74
+msgid "`set_decorated(false)`"
+msgstr ""
+
+#: src/ui/multi-window.md:76
+msgid "`level: \"floating\" | \"statusBar\" | \"modal\" | \"normal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:78
+msgid "Controls the window's z-order level relative to other windows."
+msgstr ""
+
+#: src/ui/multi-window.md:80
+msgid "Level"
+msgstr ""
+
+#: src/ui/multi-window.md:82
+msgid "`\"normal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:82
+msgid "Default window level"
+msgstr ""
+
+#: src/ui/multi-window.md:83
+msgid "`\"floating\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:83
+msgid "Stays above normal windows"
+msgstr ""
+
+#: src/ui/multi-window.md:84
+msgid "`\"statusBar\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:84
+msgid "Stays above floating windows"
+msgstr ""
+
+#: src/ui/multi-window.md:85
+msgid "`\"modal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:85
+msgid "Modal panel level"
+msgstr ""
+
+#: src/ui/multi-window.md:89
+msgid "`NSWindow.level` (NSFloatingWindowLevel, etc.)"
+msgstr ""
+
+#: src/ui/multi-window.md:90
+msgid "`SetWindowPos` with `HWND_TOPMOST`"
+msgstr ""
+
+#: src/ui/multi-window.md:91
+msgid "`set_modal(true)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:93
+msgid "`transparent: true`"
+msgstr ""
+
+#: src/ui/multi-window.md:95
+msgid ""
+"Makes the window background transparent, allowing the desktop to show "
+"through non-opaque regions of your UI."
+msgstr ""
+
+#: src/ui/multi-window.md:100
+msgid "`isOpaque = false`, `backgroundColor = .clear`"
+msgstr ""
+
+#: src/ui/multi-window.md:101
+msgid "`WS_EX_LAYERED` with `SetLayeredWindowAttributes`"
+msgstr ""
+
+#: src/ui/multi-window.md:102
+msgid "CSS `background-color: transparent`"
+msgstr ""
+
+#: src/ui/multi-window.md:104
+msgid "`vibrancy: string`"
+msgstr ""
+
+#: src/ui/multi-window.md:106
+msgid ""
+"Applies a native translucent material to the window background. On macOS "
+"this uses the system vibrancy effect; on Windows it uses Mica/Acrylic."
+msgstr ""
+
+#: src/ui/multi-window.md:109
+msgid ""
+"**macOS materials:** `\"sidebar\"`, `\"titlebar\"`, `\"selection\"`, "
+"`\"menu\"`, `\"popover\"`, `\"headerView\"`, `\"sheet\"`, "
+"`\"windowBackground\"`, `\"hudWindow\"`, `\"fullScreenUI\"`, `\"tooltip\"`, "
+"`\"contentBackground\"`, `\"underWindowBackground\"`, "
+"`\"underPageBackground\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:116
+msgid "`NSVisualEffectView` with the specified material"
+msgstr ""
+
+#: src/ui/multi-window.md:117
+msgid ""
+"`DwmSetWindowAttribute(DWMWA_SYSTEMBACKDROP_TYPE)` — Mica, Acrylic, or Mica "
+"Alt depending on material (Windows 11 22H2+)"
+msgstr ""
+
+#: src/ui/multi-window.md:118
+msgid "CSS `alpha(@window_bg_color, 0.85)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:120
+msgid "`activationPolicy: \"regular\" | \"accessory\" | \"background\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:122
+msgid "Controls whether the app appears in the dock/taskbar."
+msgstr ""
+
+#: src/ui/multi-window.md:124 src/widgets/data-fetching.md:125
+msgid "Policy"
+msgstr ""
+
+#: src/ui/multi-window.md:126
+msgid "`\"regular\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:126
+msgid "Normal app with dock icon and menu bar (default)"
+msgstr ""
+
+#: src/ui/multi-window.md:127
+msgid "`\"accessory\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:127
+msgid "No dock icon, no menu bar activation — ideal for launchers and utilities"
+msgstr ""
+
+#: src/ui/multi-window.md:128
+msgid "`\"background\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:128
+msgid "Fully hidden from dock and app switcher"
+msgstr ""
+
+#: src/ui/multi-window.md:132
+msgid "`NSApp.setActivationPolicy()`"
+msgstr ""
+
+#: src/ui/multi-window.md:133
+msgid "`WS_EX_TOOLWINDOW` (removes from taskbar)"
+msgstr ""
+
+#: src/ui/multi-window.md:134
+msgid "`set_deletable(false)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:140
+msgid "NSWindow"
+msgstr ""
+
+#: src/ui/multi-window.md:141
+msgid "CreateWindowEx (HWND)"
+msgstr ""
+
+#: src/ui/multi-window.md:142
+msgid "GtkWindow"
+msgstr ""
+
+#: src/ui/multi-window.md:143
+msgid "Floating `<div>`"
+msgstr ""
+
+#: src/ui/multi-window.md:144
+msgid "iOS/Android"
+msgstr ""
+
+#: src/ui/multi-window.md:144
+msgid "Modal view controller / Dialog"
+msgstr ""
+
+#: src/ui/multi-window.md:146
+msgid ""
+"On mobile platforms, \"windows\" are presented as modal views or dialogs "
+"since mobile apps typically use a single-window model."
+msgstr ""
+
+#: src/ui/multi-window.md:151
+msgid "[Events](events.md) — Keyboard shortcuts"
+msgstr ""
+
+#: src/ui/multi-window.md:152
+msgid "[Dialogs](dialogs.md) — Modal dialogs and sheets"
+msgstr ""
+
+#: src/ui/multi-window.md:153
+msgid "[Menus](menus.md) — Menu bar and toolbar"
+msgstr ""
+
+#: src/ui/multi-window.md:154
+msgid "[UI Overview](overview.md) — Full UI system overview"
+msgstr ""
+
+#: src/ui/theming.md:3
+msgid ""
+"The `perry-styling` package provides a design system bridge for Perry UI — "
+"design token codegen and ergonomic styling helpers with compile-time "
+"platform detection."
+msgstr ""
+
+#: src/ui/theming.md:11
+msgid "Design Token Codegen"
+msgstr ""
+
+#: src/ui/theming.md:13
+msgid "Generate typed theme files from a JSON token definition:"
+msgstr ""
+
+#: src/ui/theming.md:19
+msgid "Token Format"
+msgstr ""
+
+#: src/ui/theming.md:23
+msgid "\"colors\""
+msgstr ""
+
+#: src/ui/theming.md:24
+msgid "\"primary\""
+msgstr ""
+
+#: src/ui/theming.md:24
+msgid "\"#007AFF\""
+msgstr ""
+
+#: src/ui/theming.md:25
+msgid "\"primary-dark\""
+msgstr ""
+
+#: src/ui/theming.md:25
+msgid "\"#0A84FF\""
+msgstr ""
+
+#: src/ui/theming.md:27
+msgid "\"background-dark\""
+msgstr ""
+
+#: src/ui/theming.md:27
+msgid "\"#1C1C1E\""
+msgstr ""
+
+#: src/ui/theming.md:28 src/testing/geisterhand.md:465
+msgid "\"text\""
+msgstr ""
+
+#: src/ui/theming.md:28
+msgid "\"#000000\""
+msgstr ""
+
+#: src/ui/theming.md:29
+msgid "\"text-dark\""
+msgstr ""
+
+#: src/ui/theming.md:31
+msgid "\"spacing\""
+msgstr ""
+
+#: src/ui/theming.md:32 src/ui/theming.md:38
+msgid "\"sm\""
+msgstr ""
+
+#: src/ui/theming.md:33 src/ui/theming.md:39
+msgid "\"md\""
+msgstr ""
+
+#: src/ui/theming.md:34 src/ui/theming.md:40
+msgid "\"lg\""
+msgstr ""
+
+#: src/ui/theming.md:35
+msgid "\"xl\""
+msgstr ""
+
+#: src/ui/theming.md:37
+msgid "\"radius\""
+msgstr ""
+
+#: src/ui/theming.md:42
+msgid "\"fontSize\""
+msgstr ""
+
+#: src/ui/theming.md:43
+msgid "\"body\""
+msgstr ""
+
+#: src/ui/theming.md:44
+msgid "\"heading\""
+msgstr ""
+
+#: src/ui/theming.md:45
+msgid "\"caption\""
+msgstr ""
+
+#: src/ui/theming.md:47
+msgid "\"borderWidth\""
+msgstr ""
+
+#: src/ui/theming.md:48
+msgid "\"thin\""
+msgstr ""
+
+#: src/ui/theming.md:49
+msgid "\"medium\""
+msgstr ""
+
+#: src/ui/theming.md:54
+msgid ""
+"Colors with a `-dark` suffix are used as the dark mode variant. If no dark "
+"variant is provided, the light value is used for both modes. Supported color "
+"formats: hex (`#RGB`, `#RRGGBB`, `#RRGGBBAA`), `rgb()`/`rgba()`, "
+"`hsl()`/`hsla()`, and CSS named colors."
+msgstr ""
+
+#: src/ui/theming.md:56
+msgid "Generated Types"
+msgstr ""
+
+#: src/ui/theming.md:58
+msgid "The codegen produces typed interfaces:"
+msgstr ""
+
+#: src/ui/theming.md:60
+msgid ""
+"```text\n"
+"interface PerryColor {\n"
+"  r: number; g: number; b: number; a: number; // floats in [0, 1]\n"
+"}\n"
+"\n"
+"interface PerryTheme {\n"
+"  light: { [key: string]: PerryColor };\n"
+"  dark: { [key: string]: PerryColor };\n"
+"  spacing: { [key: string]: number };\n"
+"  radius: { [key: string]: number };\n"
+"  fontSize: { [key: string]: number };\n"
+"  borderWidth: { [key: string]: number };\n"
+"}\n"
+"\n"
+"interface ResolvedTheme {\n"
+"  colors: { [key: string]: PerryColor };\n"
+"  spacing: { [key: string]: number };\n"
+"  radius: { [key: string]: number };\n"
+"  fontSize: { [key: string]: number };\n"
+"  borderWidth: { [key: string]: number };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:83
+msgid "Theme Resolution"
+msgstr ""
+
+#: src/ui/theming.md:85
+msgid "Resolve a theme at runtime based on the system's dark mode setting:"
+msgstr ""
+
+#: src/ui/theming.md:87
+msgid ""
+"```text\n"
+"import { getTheme } from \"perry-styling\";\n"
+"import { theme } from \"./theme\"; // generated file\n"
+"\n"
+"const resolved = getTheme(theme);\n"
+"// resolved.colors.primary → the correct light/dark variant\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:95
+msgid ""
+"`getTheme()` calls `isDarkMode()` from `perry/system` and returns the "
+"appropriate palette."
+msgstr ""
+
+#: src/ui/theming.md:97
+msgid "Styling Helpers"
+msgstr ""
+
+#: src/ui/theming.md:99
+msgid ""
+"Ergonomic functions for applying styles to widget handles. Perry's compiler "
+"doesn't yet support passing `PerryColor` objects as parameters into user "
+"functions, so the helpers take **flat primitives**: extract the channels at "
+"the call site:"
+msgstr ""
+
+#: src/ui/theming.md:104
+msgid ""
+"```text\n"
+"import {\n"
+"  applyBg, applyRadius, applyTextColor, applyFontSize, applyGradient,\n"
+"} from \"perry-styling\";\n"
+"\n"
+"const t = resolved;                    // your ResolvedTheme\n"
+"const c = t.colors.text;               // a PerryColor\n"
+"const bg = t.colors.background;\n"
+"const start = t.colors.primary;\n"
+"const end = t.colors[\"primary-dark\"];\n"
+"\n"
+"const label = Text(\"Hello\");\n"
+"applyTextColor(label, c.r, c.g, c.b, c.a);\n"
+"applyFontSize(label, t.fontSize.heading);\n"
+"\n"
+"const card = VStack(16, []);\n"
+"applyBg(card, bg.r, bg.g, bg.b, bg.a);\n"
+"applyRadius(card, t.radius.md);\n"
+"applyGradient(card,\n"
+"  start.r, start.g, start.b, start.a,\n"
+"  end.r,   end.g,   end.b,   end.a,\n"
+"  0,                                   // 0 = vertical, 1 = horizontal\n"
+");\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:129
+msgid "Available Helpers"
+msgstr ""
+
+#: src/ui/theming.md:131
+msgid "Signature"
+msgstr ""
+
+#: src/ui/theming.md:133
+msgid "`applyBg(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:133
+msgid "Background color"
+msgstr ""
+
+#: src/ui/theming.md:134
+msgid "`applyRadius(handle, radius)`"
+msgstr ""
+
+#: src/ui/theming.md:134
+msgid "Corner radius"
+msgstr ""
+
+#: src/ui/theming.md:135
+msgid "`applyTextColor(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:135
+msgid "Text color"
+msgstr ""
+
+#: src/ui/theming.md:136
+msgid "`applyFontSize(handle, size)`"
+msgstr ""
+
+#: src/ui/theming.md:136
+msgid "Font size (regular weight)"
+msgstr ""
+
+#: src/ui/theming.md:137
+msgid "`applyFontBold(handle, size)`"
+msgstr ""
+
+#: src/ui/theming.md:137
+msgid "Font size with bold weight"
+msgstr ""
+
+#: src/ui/theming.md:138
+msgid "`applyFontFamily(handle, family)`"
+msgstr ""
+
+#: src/ui/theming.md:138
+msgid "Font family"
+msgstr ""
+
+#: src/ui/theming.md:139
+msgid "`applyWidth(handle, width)`"
+msgstr ""
+
+#: src/ui/theming.md:139
+msgid "Fixed width"
+msgstr ""
+
+#: src/ui/theming.md:140
+msgid "`applyTooltip(handle, text)`"
+msgstr ""
+
+#: src/ui/theming.md:140
+msgid "Tooltip (no-op on iOS/Android)"
+msgstr ""
+
+#: src/ui/theming.md:141
+msgid "`applyBorderColor(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:141
+msgid "Border color"
+msgstr ""
+
+#: src/ui/theming.md:142
+msgid "`applyBorderWidth(handle, width)`"
+msgstr ""
+
+#: src/ui/theming.md:142
+msgid "Border width"
+msgstr ""
+
+#: src/ui/theming.md:143
+msgid "`applyEdgeInsets(handle, top, left, bottom, right)`"
+msgstr ""
+
+#: src/ui/theming.md:143
+msgid "Edge insets (padding)"
+msgstr ""
+
+#: src/ui/theming.md:144
+msgid "`applyOpacity(handle, alpha)`"
+msgstr ""
+
+#: src/ui/theming.md:145
+msgid "`applyGradient(handle, r1, g1, b1, a1, r2, g2, b2, a2, direction)`"
+msgstr ""
+
+#: src/ui/theming.md:145
+msgid "Background gradient"
+msgstr ""
+
+#: src/ui/theming.md:146
+msgid "`applyButtonBg(btn, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:146
+msgid "Button background"
+msgstr ""
+
+#: src/ui/theming.md:147
+msgid "`applyButtonTextColor(btn, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:147
+msgid "Button text color"
+msgstr ""
+
+#: src/ui/theming.md:148
+msgid "`applyButtonBordered(btn, bordered)`"
+msgstr ""
+
+#: src/ui/theming.md:148
+msgid "Bordered button style (`true`/`false`)"
+msgstr ""
+
+#: src/ui/theming.md:150
+msgid "Platform Constants"
+msgstr ""
+
+#: src/ui/theming.md:152
+msgid ""
+"`perry-styling` exports compile-time platform constants based on the "
+"`__platform__` built-in:"
+msgstr ""
+
+#: src/ui/theming.md:154
+msgid ""
+"```text\n"
+"import { isMac, isIOS, isAndroid, isWindows, isLinux, isDesktop, isMobile } "
+"from \"perry-styling\";\n"
+"\n"
+"if (isMobile) {\n"
+"  applyFontSize(label, 16);\n"
+"} else {\n"
+"  applyFontSize(label, 14);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:164
+msgid ""
+"These are constant-folded by LLVM at compile time — dead branches are "
+"eliminated with zero runtime cost."
+msgstr ""
+
+#: src/ui/theming.md:168
+msgid "[Styling](styling.md) — Widget styling basics"
+msgstr ""
+
+#: src/ui/camera.md:3
+msgid ""
+"The `perry/ui` module provides a live camera preview widget with color "
+"sampling capabilities."
+msgstr ""
+
+#: src/ui/camera.md:6
+msgid ""
+"```ts\n"
+"import {\n"
+"    CameraView,\n"
+"    cameraStart, cameraStop,\n"
+"    cameraFreeze, cameraUnfreeze,\n"
+"    cameraSampleColor, cameraSetOnTap,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:15
+msgid ""
+"**Platform support:** real capture is implemented on **iOS** "
+"(AVCaptureSession) and **Android** (Camera2). On **macOS**, **Linux** "
+"(GTK4), **Windows**, and the **Web** target the runtime exports no-op stubs "
+"so cross-platform code compiles and links cleanly — `CameraView()` returns "
+"handle 0 and `cameraSampleColor` returns `-1`. Wiring real capture on those "
+"platforms (AVFoundation on macOS, GStreamer/V4L2 on Linux, Media Foundation "
+"on Windows, `getUserMedia` on Web) is tracked as a follow-up."
+msgstr ""
+
+#: src/ui/camera.md:24 src/system/overview.md:43 src/plugins/overview.md:25
+msgid "Quick Example"
+msgstr ""
+
+#: src/ui/camera.md:26
+msgid ""
+"```ts\n"
+"const colorHex = State(\"#000000\")\n"
+"\n"
+"const cam = CameraView()\n"
+"cameraStart(cam)\n"
+"\n"
+"cameraSetOnTap(cam, (x: number, y: number) => {\n"
+"    const rgb = cameraSampleColor(x, y)\n"
+"    if (rgb >= 0) {\n"
+"        const r = Math.floor(rgb / 65536)\n"
+"        const g = Math.floor((rgb % 65536) / 256)\n"
+"        const b = Math.floor(rgb % 256)\n"
+"        colorHex.set(`#${r.toString(16).padStart(2, "
+"\"0\")}${g.toString(16).padStart(2, \"0\")}${b.toString(16).padStart(2, "
+"\"0\")}`)\n"
+"    }\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Color Picker\",\n"
+"    width: 400,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        cam,\n"
+"        Text(`Color: ${colorHex.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:53 src/system/audio.md:21 src/testing/geisterhand.md:45
+msgid "API Reference"
+msgstr ""
+
+#: src/ui/camera.md:55
+msgid "`CameraView()`"
+msgstr ""
+
+#: src/ui/camera.md:57
+msgid "Create a live camera preview widget."
+msgstr ""
+
+#: src/ui/camera.md:63
+msgid ""
+"Returns a widget handle. The camera does not start automatically — call "
+"`cameraStart()` to begin capture."
+msgstr ""
+
+#: src/ui/camera.md:65
+msgid "`cameraStart(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:67
+msgid "Start the live camera feed."
+msgstr ""
+
+#: src/ui/camera.md:73
+msgid "On iOS, the camera permission dialog is shown automatically on first use."
+msgstr ""
+
+#: src/ui/camera.md:75
+msgid "`cameraStop(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:77
+msgid "Stop the camera feed and release the capture session."
+msgstr ""
+
+#: src/ui/camera.md:83
+msgid "`cameraFreeze(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:85
+msgid "Pause the live preview (freeze the current frame)."
+msgstr ""
+
+#: src/ui/camera.md:91
+msgid ""
+"The camera session remains active but the preview stops updating. Useful for "
+"\"capture\" moments where you want to inspect the frozen frame."
+msgstr ""
+
+#: src/ui/camera.md:93
+msgid "`cameraUnfreeze(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:95
+msgid "Resume the live preview after a freeze."
+msgstr ""
+
+#: src/ui/camera.md:101
+msgid "`cameraSampleColor(x, y)`"
+msgstr ""
+
+#: src/ui/camera.md:103
+msgid "Sample the pixel color at normalized coordinates."
+msgstr ""
+
+#: src/ui/camera.md:105
+msgid ""
+"```ts\n"
+"const rgb = cameraSampleColor(0.5, 0.5) // center of frame\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:109
+msgid "`x`, `y` are normalized coordinates (0.0–1.0)"
+msgstr ""
+
+#: src/ui/camera.md:110
+msgid "Returns packed RGB as a number: `r * 65536 + g * 256 + b`"
+msgstr ""
+
+#: src/ui/camera.md:111
+msgid "Returns `-1` if no frame is available"
+msgstr ""
+
+#: src/ui/camera.md:113
+msgid "To extract individual channels:"
+msgstr ""
+
+#: src/ui/camera.md:121
+msgid ""
+"The color is averaged over a 5x5 pixel region around the sample point for "
+"noise reduction."
+msgstr ""
+
+#: src/ui/camera.md:123
+msgid "`cameraSetOnTap(handle, callback)`"
+msgstr ""
+
+#: src/ui/camera.md:125
+msgid "Register a tap handler on the camera view."
+msgstr ""
+
+#: src/ui/camera.md:127
+msgid ""
+"```ts\n"
+"cameraSetOnTap(preview, (tx: number, ty: number) => {\n"
+"    // tx, ty are normalized coordinates (0.0-1.0)\n"
+"    const tappedRgb = cameraSampleColor(tx, ty)\n"
+"    console.log(`tapped color: ${tappedRgb}`)\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:135
+msgid ""
+"The callback receives normalized coordinates of the tap location, which can "
+"be passed directly to `cameraSampleColor()`."
+msgstr ""
+
+#: src/ui/camera.md:139
+msgid ""
+"On iOS, the camera uses AVCaptureSession with AVCaptureVideoPreviewLayer for "
+"GPU-accelerated live preview, and AVCaptureVideoDataOutput for frame "
+"capture. Color sampling reads pixel data from CVPixelBuffer."
+msgstr ""
+
+#: src/ui/camera.md:141
+msgid ""
+"On Android, the camera uses Camera2 with a TextureView preview surface. "
+"Color sampling reads from the most recent ImageReader frame."
+msgstr ""
+
+#: src/ui/camera.md:146
+msgid "[Audio Capture](../system/audio.md) — Microphone input and sound metering"
+msgstr ""
+
+#: src/platforms/overview.md:1
+msgid "Platform Overview"
+msgstr ""
+
+#: src/platforms/overview.md:3
+msgid ""
+"Perry compiles TypeScript to native executables for 9 platform families from "
+"the same source code."
+msgstr ""
+
+#: src/platforms/overview.md:5
+msgid "Supported Platforms"
+msgstr ""
+
+#: src/platforms/overview.md:7 src/widgets/platforms.md:9
+msgid "Target Flag"
+msgstr ""
+
+#: src/platforms/overview.md:7 src/platforms/macos.md:20
+#: src/platforms/ios.md:46 src/platforms/tvos.md:46 src/platforms/watchos.md:46
+#: src/platforms/android.md:20 src/platforms/windows.md:38
+#: src/platforms/linux.md:30
+msgid "UI Toolkit"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "_(default)_"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "AppKit"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "Full support (127/127 FFI functions)"
+msgstr ""
+
+#: src/platforms/overview.md:10
+msgid "`--target ios` / `--target ios-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:10 src/platforms/overview.md:12
+#: src/platforms/tvos.md:178
+msgid "UIKit"
+msgstr ""
+
+#: src/platforms/overview.md:10
+msgid "Full support (127/127)"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "`--target visionos` / `--target visionos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "UIKit (2D windows)"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "Core support (2D only)"
+msgstr ""
+
+#: src/platforms/overview.md:12
+msgid "`--target tvos` / `--target tvos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:12
+msgid "Full support (focus engine + game controllers)"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "`--target watchos` / `--target watchos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "SwiftUI (data-driven)"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "Core support (15 widgets)"
+msgstr ""
+
+#: src/platforms/overview.md:14
+msgid "`--target android`"
+msgstr ""
+
+#: src/platforms/overview.md:14
+msgid "JNI/Android SDK"
+msgstr ""
+
+#: src/platforms/overview.md:14 src/platforms/overview.md:15
+#: src/platforms/overview.md:16
+msgid "Full support (112/112)"
+msgstr ""
+
+#: src/platforms/overview.md:15
+msgid "`--target windows`"
+msgstr ""
+
+#: src/platforms/overview.md:15
+msgid "Win32"
+msgstr ""
+
+#: src/platforms/overview.md:16
+msgid "`--target linux`"
+msgstr ""
+
+#: src/platforms/overview.md:16
+msgid "GTK4"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "Web / WebAssembly"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "`--target web` _(alias `--target wasm`)_"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "DOM/CSS via WASM bridge"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "Full support (168 widgets)"
+msgstr ""
+
+#: src/platforms/overview.md:19
+msgid "Cross-Compilation"
+msgstr ""
+
+#: src/platforms/overview.md:22
+msgid "# Default: compile for current platform\n"
+msgstr ""
+
+#: src/platforms/overview.md:24
+msgid "# Compile for a specific target\n"
+msgstr ""
+
+#: src/platforms/overview.md:36 src/platforms/visionos.md:49
+#: src/platforms/tvos.md:133 src/platforms/watchos.md:170
+msgid "Platform Detection"
+msgstr ""
+
+#: src/platforms/overview.md:38
+msgid "Use the `__platform__` compile-time constant to branch by platform:"
+msgstr ""
+
+#: src/platforms/overview.md:40
+msgid ""
+"```typescript\n"
+"declare const __platform__: number\n"
+"\n"
+"// Platform constants:\n"
+"// 0 = macOS\n"
+"// 1 = iOS\n"
+"// 2 = Android\n"
+"// 3 = Windows\n"
+"// 4 = Linux\n"
+"// 5 = Web (browser, --target web / --target wasm)\n"
+"// 6 = tvOS\n"
+"// 7 = watchOS\n"
+"// 8 = visionOS\n"
+"\n"
+"if (__platform__ === 0) {\n"
+"    console.log(\"Running on macOS\")\n"
+"} else if (__platform__ === 1) {\n"
+"    console.log(\"Running on iOS\")\n"
+"} else if (__platform__ === 3) {\n"
+"    console.log(\"Running on Windows\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/overview.md:63
+msgid ""
+"`__platform__` is resolved at compile time. The compiler constant-folds "
+"comparisons and eliminates dead branches, so platform-specific code has zero "
+"runtime cost."
+msgstr ""
+
+#: src/platforms/overview.md:65
+msgid "Platform Feature Matrix"
+msgstr ""
+
+#: src/platforms/overview.md:67
+msgid "Web (WASM)"
+msgstr ""
+
+#: src/platforms/overview.md:69
+msgid "CLI programs"
+msgstr ""
+
+#: src/platforms/overview.md:70
+msgid "Native UI (DOM on web)"
+msgstr ""
+
+#: src/platforms/overview.md:71
+msgid "Game engines"
+msgstr ""
+
+#: src/platforms/overview.md:71
+msgid "Via FFI"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "File system"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "Sandboxed"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "File System Access API"
+msgstr ""
+
+#: src/platforms/overview.md:73
+msgid "Networking"
+msgstr ""
+
+#: src/platforms/overview.md:73
+msgid "`fetch` / `WebSocket`"
+msgstr ""
+
+#: src/platforms/overview.md:74
+msgid "Partial"
+msgstr ""
+
+#: src/platforms/overview.md:74
+msgid "Minimal"
+msgstr ""
+
+#: src/platforms/overview.md:75
+msgid "Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Threading"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Native"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Web Workers"
+msgstr ""
+
+#: src/platforms/overview.md:80
+msgid "[macOS](macos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:81
+msgid "[iOS](ios.md)"
+msgstr ""
+
+#: src/platforms/overview.md:82
+msgid "[visionOS](visionos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:83
+msgid "[tvOS](tvos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:84
+msgid "[watchOS](watchos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:85
+msgid "[Android](android.md)"
+msgstr ""
+
+#: src/platforms/overview.md:86
+msgid "[Windows](windows.md)"
+msgstr ""
+
+#: src/platforms/overview.md:87
+msgid "[Linux (GTK4)](linux.md)"
+msgstr ""
+
+#: src/platforms/overview.md:88
+msgid "[Web](web.md)"
+msgstr ""
+
+#: src/platforms/overview.md:89
+msgid "[WebAssembly](wasm.md)"
+msgstr ""
+
+#: src/platforms/macos.md:3
+msgid ""
+"macOS is Perry's primary development platform. It uses AppKit for native UI."
+msgstr ""
+
+#: src/platforms/macos.md:5 src/platforms/ios.md:5 src/platforms/tvos.md:7
+#: src/platforms/watchos.md:7 src/platforms/android.md:5
+#: src/platforms/windows.md:5 src/platforms/linux.md:5
+#: src/plugins/native-extensions.md:271
+msgid "Requirements"
+msgstr ""
+
+#: src/platforms/macos.md:7
+msgid "macOS 13+ (Ventura or later)"
+msgstr ""
+
+#: src/platforms/macos.md:8
+msgid "Xcode Command Line Tools: `xcode-select --install`"
+msgstr ""
+
+#: src/platforms/macos.md:10 src/platforms/android.md:14
+#: src/platforms/windows.md:32 src/platforms/linux.md:23
+#: src/platforms/wasm.md:7 src/widgets/overview.md:48
+msgid "Building"
+msgstr ""
+
+#: src/platforms/macos.md:13
+msgid "# macOS is the default target\n"
+msgstr ""
+
+#: src/platforms/macos.md:18
+msgid "No additional flags needed — macOS is the default compilation target."
+msgstr ""
+
+#: src/platforms/macos.md:22
+msgid "Perry maps UI widgets to AppKit controls:"
+msgstr ""
+
+#: src/platforms/macos.md:24 src/platforms/ios.md:50 src/platforms/tvos.md:50
+#: src/platforms/watchos.md:50 src/platforms/android.md:24
+#: src/platforms/windows.md:42 src/platforms/linux.md:34
+#: src/platforms/wasm.md:55
+msgid "Perry Widget"
+msgstr ""
+
+#: src/platforms/macos.md:24
+msgid "AppKit Class"
+msgstr ""
+
+#: src/platforms/macos.md:26
+msgid "NSTextField (label mode)"
+msgstr ""
+
+#: src/platforms/macos.md:29
+msgid "NSSecureTextField"
+msgstr ""
+
+#: src/platforms/macos.md:30
+msgid "NSSwitch"
+msgstr ""
+
+#: src/platforms/macos.md:31
+msgid "NSSlider"
+msgstr ""
+
+#: src/platforms/macos.md:32
+msgid "NSPopUpButton"
+msgstr ""
+
+#: src/platforms/macos.md:33 src/platforms/ios.md:59 src/platforms/tvos.md:58
+#: src/platforms/watchos.md:61 src/platforms/android.md:33
+#: src/platforms/windows.md:52 src/platforms/linux.md:44
+#: src/widgets/components.md:83
+msgid "Image"
+msgstr ""
+
+#: src/platforms/macos.md:33
+msgid "NSImageView"
+msgstr ""
+
+#: src/platforms/macos.md:34 src/platforms/ios.md:60 src/platforms/tvos.md:59
+#: src/platforms/windows.md:53
+msgid "VStack/HStack"
+msgstr ""
+
+#: src/platforms/macos.md:35
+msgid "NSScrollView"
+msgstr ""
+
+#: src/platforms/macos.md:36
+msgid "NSTableView"
+msgstr ""
+
+#: src/platforms/macos.md:37
+msgid "NSView + Core Graphics"
+msgstr ""
+
+#: src/platforms/macos.md:39 src/cli/perry-toml.md:179
+#: src/cli/perry-toml.md:258
+msgid "Code Signing"
+msgstr ""
+
+#: src/platforms/macos.md:41
+msgid ""
+"For distribution, apps need to be signed. Perry supports automatic signing:"
+msgstr ""
+
+#: src/platforms/macos.md:47
+msgid ""
+"This auto-detects your signing identity from the macOS Keychain, exports it "
+"to a temporary `.p12` file, and signs the binary."
+msgstr ""
+
+#: src/platforms/macos.md:49
+msgid "For manual signing:"
+msgstr ""
+
+#: src/platforms/macos.md:52
+msgid "\"Developer ID Application: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:55
+msgid "App Store Distribution"
+msgstr ""
+
+#: src/platforms/macos.md:58
+msgid "# Sign with App Store certificate\n"
+msgstr ""
+
+#: src/platforms/macos.md:60
+msgid "\"3rd Party Mac Developer Application: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:60
+msgid "# Package\n"
+msgstr ""
+
+#: src/platforms/macos.md:62
+msgid "\"3rd Party Mac Developer Installer: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:65
+msgid "macOS-Specific Features"
+msgstr ""
+
+#: src/platforms/macos.md:67
+msgid "**Menu bar**: Full NSMenu support with keyboard shortcuts"
+msgstr ""
+
+#: src/platforms/macos.md:68
+msgid "**Toolbar**: NSToolbar integration"
+msgstr ""
+
+#: src/platforms/macos.md:69
+msgid "**Dock icon**: Automatic for GUI apps"
+msgstr ""
+
+#: src/platforms/macos.md:70
+msgid "**Dark mode**: `isDarkMode()` detects system appearance"
+msgstr ""
+
+#: src/platforms/macos.md:71
+msgid "**Keychain**: Secure storage via Security.framework"
+msgstr ""
+
+#: src/platforms/macos.md:72
+msgid "**Notifications**: Local notifications via UNUserNotificationCenter"
+msgstr ""
+
+#: src/platforms/macos.md:73
+msgid "**File dialogs**: NSOpenPanel/NSSavePanel"
+msgstr ""
+
+#: src/platforms/macos.md:77
+msgid ""
+"```typescript\n"
+"import { openURL, isDarkMode, preferencesSet, preferencesGet } from "
+"\"perry/system\"\n"
+"\n"
+"openURL(\"https://example.com\")          // Opens in default browser\n"
+"const dark = isDarkMode()               // Check appearance\n"
+"preferencesSet(\"key\", \"value\")          // NSUserDefaults\n"
+"const val = preferencesGet(\"key\")       // NSUserDefaults\n"
+"```"
+msgstr ""
+
+#: src/platforms/macos.md:88
+msgid "[iOS](ios.md) — Cross-compile for iPhone/iPad"
+msgstr ""
+
+#: src/platforms/macos.md:89
+msgid "[UI Overview](../ui/overview.md) — Full UI documentation"
+msgstr ""
+
+#: src/platforms/macos.md:90
+msgid "[System APIs](../system/overview.md) — System integration"
+msgstr ""
+
+#: src/platforms/ios.md:3
+msgid ""
+"Perry can cross-compile TypeScript apps for iOS devices and the iOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/ios.md:7 src/platforms/tvos.md:9 src/platforms/watchos.md:9
+msgid "macOS host (cross-compilation from Linux/Windows is not supported)"
+msgstr ""
+
+#: src/platforms/ios.md:8
+msgid ""
+"Xcode (full install, not just Command Line Tools) for iOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/ios.md:9
+msgid "Rust iOS targets:"
+msgstr ""
+
+#: src/platforms/ios.md:14 src/platforms/tvos.md:16 src/platforms/watchos.md:16
+msgid "Building for Simulator"
+msgstr ""
+
+#: src/platforms/ios.md:20
+msgid ""
+"This uses LLVM cross-compilation with the iOS Simulator SDK. The binary can "
+"be run in the Xcode Simulator."
+msgstr ""
+
+#: src/platforms/ios.md:22 src/platforms/tvos.md:24 src/platforms/watchos.md:24
+msgid "Building for Device"
+msgstr ""
+
+#: src/platforms/ios.md:28
+msgid ""
+"This produces an ARM64 binary for physical iOS devices. You'll need to code "
+"sign and package it in an `.app` bundle for deployment."
+msgstr ""
+
+#: src/platforms/ios.md:30 src/platforms/tvos.md:32 src/platforms/watchos.md:32
+msgid "Running with `perry run`"
+msgstr ""
+
+#: src/platforms/ios.md:32
+msgid "The easiest way to build and run on iOS is `perry run`:"
+msgstr ""
+
+#: src/platforms/ios.md:35
+msgid "# Auto-detect device/simulator\n"
+msgstr ""
+
+#: src/platforms/ios.md:36
+msgid "# Stream live stdout/stderr\n"
+msgstr ""
+
+#: src/platforms/ios.md:37
+msgid "# Use Perry Hub build server\n"
+msgstr ""
+
+#: src/platforms/ios.md:40
+msgid ""
+"Perry auto-discovers available simulators (via `simctl`) and physical "
+"devices (via `devicectl`). When multiple targets are found, an interactive "
+"prompt lets you choose."
+msgstr ""
+
+#: src/platforms/ios.md:42
+msgid ""
+"For physical devices, Perry handles code signing automatically — it reads "
+"your signing identity and team ID from `~/.perry/config.toml` (set up via "
+"`perry setup ios`), embeds the provisioning profile, and signs the `.app` "
+"before installing."
+msgstr ""
+
+#: src/platforms/ios.md:44
+msgid ""
+"If you don't have the iOS cross-compilation toolchain installed locally, "
+"`perry run ios` automatically falls back to Perry Hub's remote build server."
+msgstr ""
+
+#: src/platforms/ios.md:48
+msgid "Perry maps UI widgets to UIKit controls:"
+msgstr ""
+
+#: src/platforms/ios.md:50 src/platforms/tvos.md:50
+msgid "UIKit Class"
+msgstr ""
+
+#: src/platforms/ios.md:53
+msgid "UIButton (TouchUpInside)"
+msgstr ""
+
+#: src/platforms/ios.md:54 src/platforms/tvos.md:54
+msgid "UITextField"
+msgstr ""
+
+#: src/platforms/ios.md:55
+msgid "UITextField (secureTextEntry)"
+msgstr ""
+
+#: src/platforms/ios.md:56 src/platforms/tvos.md:55
+msgid "UISwitch"
+msgstr ""
+
+#: src/platforms/ios.md:57
+msgid "UISlider (Float32, cast at boundary)"
+msgstr ""
+
+#: src/platforms/ios.md:58 src/platforms/tvos.md:57
+msgid "UIPickerView"
+msgstr ""
+
+#: src/platforms/ios.md:59 src/platforms/tvos.md:58
+msgid "UIImageView"
+msgstr ""
+
+#: src/platforms/ios.md:61 src/platforms/tvos.md:60
+msgid "UIScrollView"
+msgstr ""
+
+#: src/platforms/ios.md:65
+msgid "iOS apps use `UIApplicationMain` with a deferred creation pattern:"
+msgstr ""
+
+#: src/platforms/ios.md:67
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My iOS App\",\n"
+"    width: 400,\n"
+"    height: 800,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello, iPhone!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/ios.md:80
+msgid ""
+"The `App()` call triggers `UIApplicationMain`, and your render function is "
+"called via `PerryAppDelegate` once the app is ready."
+msgstr ""
+
+#: src/platforms/ios.md:82
+msgid "iOS Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/ios.md:84
+msgid ""
+"Perry can compile TypeScript widget declarations to native SwiftUI WidgetKit "
+"extensions:"
+msgstr ""
+
+#: src/platforms/ios.md:90
+msgid "See [Widgets (WidgetKit)](../widgets/overview.md) for details."
+msgstr ""
+
+#: src/platforms/ios.md:92 src/platforms/android.md:51
+msgid "Splash Screen"
+msgstr ""
+
+#: src/platforms/ios.md:94
+msgid ""
+"Perry auto-generates a native `LaunchScreen.storyboard` from the "
+"`perry.splash` config in `package.json`. The splash screen appears instantly "
+"during cold start."
+msgstr ""
+
+#: src/platforms/ios.md:107
+msgid ""
+"The image is centered at 128x128pt with `scaleAspectFit`. You can provide a "
+"custom storyboard for full control:"
+msgstr ""
+
+#: src/platforms/ios.md:119 src/platforms/android.md:83
+msgid ""
+"See [Project Configuration](../getting-started/project-config.md#splash) for "
+"the full config reference."
+msgstr ""
+
+#: src/platforms/ios.md:121
+msgid "Resource Bundling"
+msgstr ""
+
+#: src/platforms/ios.md:123
+msgid ""
+"Perry automatically bundles `logo/` and `assets/` directories from your "
+"project root into the `.app` bundle. These resources are available at "
+"runtime via standard file APIs relative to the app bundle path."
+msgstr ""
+
+#: src/platforms/ios.md:125
+msgid "Keyboard Avoidance"
+msgstr ""
+
+#: src/platforms/ios.md:127
+msgid ""
+"Perry apps automatically handle keyboard avoidance on iOS. When the keyboard "
+"appears, the root view adjusts its bottom constraint with an animated layout "
+"transition, and focused TextFields are auto-scrolled into view above the "
+"keyboard."
+msgstr ""
+
+#: src/platforms/ios.md:129
+msgid "Differences from macOS"
+msgstr ""
+
+#: src/platforms/ios.md:131
+msgid ""
+"**No menu bar**: iOS doesn't support menu bars. Use toolbar or navigation "
+"patterns."
+msgstr ""
+
+#: src/platforms/ios.md:132
+msgid ""
+"**Touch events**: `onHover` is not available. Use `onClick` (mapped to "
+"touch)."
+msgstr ""
+
+#: src/platforms/ios.md:133
+msgid ""
+"**Slider precision**: iOS UISlider uses Float32 internally (automatically "
+"converted)."
+msgstr ""
+
+#: src/platforms/ios.md:134
+msgid "**File dialogs**: Limited to UIDocumentPicker."
+msgstr ""
+
+#: src/platforms/ios.md:135
+msgid "**Keyboard shortcuts**: Not applicable on iOS."
+msgstr ""
+
+#: src/platforms/ios.md:139
+msgid "[Widgets (WidgetKit)](../widgets/overview.md) — iOS home screen widgets"
+msgstr ""
+
+#: src/platforms/ios.md:140 src/platforms/tvos.md:184
+#: src/platforms/watchos.md:217 src/platforms/android.md:94
+#: src/platforms/windows.md:71 src/platforms/linux.md:83
+#: src/platforms/wasm.md:193
+msgid "[Platform Overview](overview.md) — All platforms"
+msgstr ""
+
+#: src/platforms/ios.md:141 src/platforms/watchos.md:218
+#: src/platforms/android.md:95 src/platforms/windows.md:72
+#: src/platforms/linux.md:84 src/platforms/wasm.md:194
+msgid "[UI Overview](../ui/overview.md) — UI system"
+msgstr ""
+
+#: src/platforms/visionos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple Vision Pro devices and the "
+"visionOS Simulator."
+msgstr ""
+
+#: src/platforms/visionos.md:5
+msgid ""
+"This first pass targets **2D windowed apps only**. Perry uses the same "
+"UIKit-style `perry/ui` model as iOS, packaged for visionOS app bundles and "
+"scene lifecycle."
+msgstr ""
+
+#: src/platforms/visionos.md:9
+msgid "macOS with Xcode installed"
+msgstr ""
+
+#: src/platforms/visionos.md:10
+msgid "Rust visionOS targets:"
+msgstr ""
+
+#: src/platforms/visionos.md:16
+msgid "Compile"
+msgstr ""
+
+#: src/platforms/visionos.md:23
+msgid ""
+"This produces a `.app` bundle with visionOS-specific `Info.plist` metadata "
+"and a `UIWindowScene` configuration."
+msgstr ""
+
+#: src/platforms/visionos.md:25
+msgid "Run"
+msgstr ""
+
+#: src/platforms/visionos.md:33
+msgid ""
+"Perry auto-detects booted Apple Vision Pro simulators via `simctl`. Physical "
+"device installs use `devicectl`, like other modern Apple platforms."
+msgstr ""
+
+#: src/platforms/visionos.md:37
+msgid "Configure visionOS-specific settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/visionos.md:39
+msgid ""
+"```toml\n"
+"[visionos]\n"
+"bundle_id = \"com.example.myvisionapp\"\n"
+"deployment_target = \"1.0\"\n"
+"entry = \"src/main_visionos.ts\"\n"
+"encryption_exempt = true\n"
+"```"
+msgstr ""
+
+#: src/platforms/visionos.md:47
+msgid "Custom `Info.plist` keys can be merged through `[visionos.info_plist]`."
+msgstr ""
+
+#: src/platforms/visionos.md:51
+msgid "Use `__platform__ === 8` to detect visionOS at compile time:"
+msgstr ""
+
+#: src/platforms/visionos.md:53
+msgid ""
+"```typescript\n"
+"function reportVisionos(): void {\n"
+"    if (__platform__ === 8) {\n"
+"        console.log(\"Running on visionOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/visionos.md:61
+msgid "Current Scope"
+msgstr ""
+
+#: src/platforms/visionos.md:63
+msgid ""
+"Supported: 2D windowed apps, simulator/device app bundles, `perry run`, "
+"`perry setup`, `perry publish`"
+msgstr ""
+
+#: src/platforms/visionos.md:64
+msgid ""
+"Not supported yet: immersive spaces, volumes, RealityKit scene generation, "
+"Geisterhand"
+msgstr ""
+
+#: src/platforms/visionos.md:66
+msgid "Related"
+msgstr ""
+
+#: src/platforms/visionos.md:68
+msgid "[iOS](ios.md) — shared UIKit foundation"
+msgstr ""
+
+#: src/platforms/visionos.md:69
+msgid "[Platform Overview](overview.md)"
+msgstr ""
+
+#: src/platforms/tvos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple TV devices and the tvOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/tvos.md:5
+msgid ""
+"tvOS uses UIKit (the same framework as iOS), so Perry's tvOS support shares "
+"the same UIKit-based widget system. The primary difference is input: Apple "
+"TV apps are controlled via the Siri Remote and game controllers rather than "
+"touch, and all apps run full-screen."
+msgstr ""
+
+#: src/platforms/tvos.md:10
+msgid "Xcode (full install) for tvOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/tvos.md:11
+msgid "Rust tvOS targets:"
+msgstr ""
+
+#: src/platforms/tvos.md:22
+msgid ""
+"This produces an ARM64 binary linked with `clang` against the tvOS Simulator "
+"SDK, wrapped in a `.app` bundle."
+msgstr ""
+
+#: src/platforms/tvos.md:30
+msgid "This produces an ARM64 binary for physical Apple TV hardware."
+msgstr ""
+
+#: src/platforms/tvos.md:35
+msgid "# Auto-detect booted Apple TV simulator\n"
+msgstr ""
+
+#: src/platforms/tvos.md:39
+msgid ""
+"Perry auto-discovers booted Apple TV simulators. To install and launch "
+"manually:"
+msgstr ""
+
+#: src/platforms/tvos.md:48
+msgid "Perry maps UI widgets to UIKit controls on tvOS, identical to iOS:"
+msgstr ""
+
+#: src/platforms/tvos.md:50 src/platforms/tvos.md:149
+#: src/platforms/watchos.md:50 src/system/media.md:37
+#: src/testing/geisterhand.md:257 src/cli/flags.md:20
+msgid "Notes"
+msgstr ""
+
+#: src/platforms/tvos.md:53
+msgid "Focus-based navigation"
+msgstr ""
+
+#: src/platforms/tvos.md:54
+msgid "On-screen keyboard via Siri Remote"
+msgstr ""
+
+#: src/platforms/tvos.md:56
+msgid "UISlider"
+msgstr ""
+
+#: src/platforms/tvos.md:60
+msgid "Focus-based scrolling"
+msgstr ""
+
+#: src/platforms/tvos.md:62
+msgid "Focus Engine"
+msgstr ""
+
+#: src/platforms/tvos.md:64
+msgid ""
+"tvOS uses a **focus-based navigation model** instead of direct touch. The "
+"Siri Remote's touchpad and directional buttons move focus between focusable "
+"views. Perry widgets that support interaction (buttons, text fields, "
+"toggles, etc.) are automatically focusable."
+msgstr ""
+
+#: src/platforms/tvos.md:66
+msgid "Game Engine Support"
+msgstr ""
+
+#: src/platforms/tvos.md:68
+msgid ""
+"tvOS is particularly well-suited for game engines. When using a native "
+"library like [Bloom](https://bloomengine.dev), the game engine handles its "
+"own windowing, rendering, and input."
+msgstr ""
+
+#: src/platforms/tvos.md:70
+msgid ""
+"**Status:** illustrative only — Bloom is an external native library (see "
+"[bloomengine.dev](https://bloomengine.dev)). The snippet below is left as "
+"`,no-test` because it depends on Bloom's `.a`/`.so` being available at link "
+"time; the doc-tests harness compiles every other snippet on this page."
+msgstr ""
+
+#: src/platforms/tvos.md:72
+msgid ""
+"```text\n"
+"import { initWindow, windowShouldClose, beginDrawing, endDrawing,\n"
+"         clearBackground, isGamepadButtonDown, Colors } from \"bloom\";\n"
+"\n"
+"initWindow(1920, 1080, \"My Apple TV Game\");\n"
+"\n"
+"while (!windowShouldClose()) {\n"
+"  beginDrawing();\n"
+"  clearBackground(Colors.BLACK);\n"
+"\n"
+"  if (isGamepadButtonDown(0)) {\n"
+"    // A button (Siri Remote select) pressed\n"
+"  }\n"
+"\n"
+"  endDrawing();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:90
+msgid "Input on tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:92
+msgid "The Siri Remote acts as a game controller:"
+msgstr ""
+
+#: src/platforms/tvos.md:94
+msgid "Input"
+msgstr ""
+
+#: src/platforms/tvos.md:94
+msgid "Mapping"
+msgstr ""
+
+#: src/platforms/tvos.md:96
+msgid "Touchpad swipe"
+msgstr ""
+
+#: src/platforms/tvos.md:96
+msgid "Gamepad axes 0/1 (left stick)"
+msgstr ""
+
+#: src/platforms/tvos.md:97
+msgid "Touchpad click (Select)"
+msgstr ""
+
+#: src/platforms/tvos.md:97
+msgid "Gamepad button 0 (A) + mouse button 0"
+msgstr ""
+
+#: src/platforms/tvos.md:98
+msgid "Menu button"
+msgstr ""
+
+#: src/platforms/tvos.md:98
+msgid "Gamepad button 1 (B)"
+msgstr ""
+
+#: src/platforms/tvos.md:99
+msgid "Play/Pause button"
+msgstr ""
+
+#: src/platforms/tvos.md:99
+msgid "Gamepad button 9 (Start)"
+msgstr ""
+
+#: src/platforms/tvos.md:100
+msgid "Arrow presses (up/down/left/right)"
+msgstr ""
+
+#: src/platforms/tvos.md:100
+msgid "Gamepad D-pad buttons (12-15)"
+msgstr ""
+
+#: src/platforms/tvos.md:102
+msgid ""
+"Extended game controllers (MFi, PlayStation, Xbox) are fully supported with "
+"all axes, buttons, triggers, and D-pad mapped through the standard gamepad "
+"API."
+msgstr ""
+
+#: src/platforms/tvos.md:106
+msgid ""
+"tvOS apps use `UIApplicationMain` with the same lifecycle as iOS. When using "
+"`perry/ui`:"
+msgstr ""
+
+#: src/platforms/tvos.md:108
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My TV App\",\n"
+"    width: 1920,\n"
+"    height: 1080,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello, Apple TV!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:121
+msgid ""
+"When using a game engine with `--features ios-game-loop`, the runtime starts "
+"`UIApplicationMain` on the main thread and runs your game code on a "
+"dedicated game thread."
+msgstr ""
+
+#: src/platforms/tvos.md:125
+msgid "Configure tvOS settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/tvos.md:127
+msgid ""
+"```toml\n"
+"[tvos]\n"
+"bundle_id = \"com.example.mytvapp\"\n"
+"deployment_target = \"17.0\"\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:135
+msgid "Use `__platform__ === 6` to detect tvOS at compile time:"
+msgstr ""
+
+#: src/platforms/tvos.md:137
+msgid ""
+"```typescript\n"
+"function reportTvos(): void {\n"
+"    if (__platform__ === 6) {\n"
+"        console.log(\"Running on tvOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:145
+msgid "App Bundle"
+msgstr ""
+
+#: src/platforms/tvos.md:147
+msgid "Perry generates a `.app` bundle with an `Info.plist` containing:"
+msgstr ""
+
+#: src/platforms/tvos.md:149 src/cli/perry-toml.md:367
+msgid "Key"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "`UIDeviceFamily`"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "`[3]`"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "Apple TV"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "`MinimumOSVersion`"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "`17.0`"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "tvOS 17+"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "`UIRequiresFullScreen`"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "`true`"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "All tvOS apps are full-screen"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "`UILaunchStoryboardName`"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "`LaunchScreen`"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "Required by tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:158
+msgid "tvOS has inherent platform constraints compared to other Perry targets:"
+msgstr ""
+
+#: src/platforms/tvos.md:160
+msgid "**No camera**: Apple TV has no camera hardware"
+msgstr ""
+
+#: src/platforms/tvos.md:161
+msgid "**No clipboard**: UIPasteboard is not available on tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:162
+msgid "**No file dialogs**: No document picker"
+msgstr ""
+
+#: src/platforms/tvos.md:163
+msgid "**No QR code**: No camera for scanning"
+msgstr ""
+
+#: src/platforms/tvos.md:164
+msgid "**No multi-window**: Single full-screen window only"
+msgstr ""
+
+#: src/platforms/tvos.md:165
+msgid ""
+"**No direct touch**: Input is via Siri Remote focus engine and game "
+"controllers"
+msgstr ""
+
+#: src/platforms/tvos.md:166
+msgid "**Resolution**: Design for 1920x1080 (1080p) or 3840x2160 (4K) displays"
+msgstr ""
+
+#: src/platforms/tvos.md:168 src/platforms/watchos.md:206
+msgid "Differences from iOS"
+msgstr ""
+
+#: src/platforms/tvos.md:170
+msgid "Aspect"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "**Input**"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "Siri Remote + game controllers (focus engine)"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "Direct touch"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "**Display**"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "Full-screen only (1080p/4K)"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "Variable screen sizes"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "**Device family**"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "`[3]` (Apple TV)"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "`[1, 2]` (iPhone/iPad)"
+msgstr ""
+
+#: src/platforms/tvos.md:175
+msgid "**Camera**"
+msgstr ""
+
+#: src/platforms/tvos.md:175 src/platforms/tvos.md:176
+msgid "Not available"
+msgstr ""
+
+#: src/platforms/tvos.md:175 src/platforms/tvos.md:176
+msgid "Available"
+msgstr ""
+
+#: src/platforms/tvos.md:176
+msgid "**Clipboard**"
+msgstr ""
+
+#: src/platforms/tvos.md:177
+msgid "**Deployment target**"
+msgstr ""
+
+#: src/platforms/tvos.md:177
+msgid "17.0"
+msgstr ""
+
+#: src/platforms/tvos.md:178
+msgid "**UI framework**"
+msgstr ""
+
+#: src/platforms/tvos.md:178
+msgid "UIKit (same as iOS)"
+msgstr ""
+
+#: src/platforms/tvos.md:182
+msgid "[iOS](ios.md) — iOS platform reference (shared UIKit base)"
+msgstr ""
+
+#: src/platforms/tvos.md:183
+msgid "[watchOS](watchos.md) — watchOS platform reference"
+msgstr ""
+
+#: src/platforms/watchos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple Watch devices and the watchOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/watchos.md:5
+msgid ""
+"Since watchOS does not support UIKit views, Perry uses a **data-driven "
+"SwiftUI renderer**: your TypeScript code builds a UI tree via the standard "
+"`perry/ui` API, and a fixed SwiftUI runtime (shipped with Perry) queries the "
+"tree and renders it reactively. No code generation or transpilation is "
+"involved — the binary is fully native."
+msgstr ""
+
+#: src/platforms/watchos.md:10
+msgid "Xcode (full install) for watchOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/watchos.md:11
+msgid "Rust watchOS targets:"
+msgstr ""
+
+#: src/platforms/watchos.md:22
+msgid ""
+"This produces an ARM64 binary linked with `swiftc` against the watchOS "
+"Simulator SDK, wrapped in a `.app` bundle."
+msgstr ""
+
+#: src/platforms/watchos.md:30
+msgid ""
+"This produces an arm64_32 (ILP32) binary for physical Apple Watch hardware. "
+"Apple Watch uses 32-bit pointers on 64-bit ARM."
+msgstr ""
+
+#: src/platforms/watchos.md:35
+msgid "# Auto-detect booted watch simulator\n"
+msgstr ""
+
+#: src/platforms/watchos.md:39
+msgid ""
+"Perry auto-discovers booted Apple Watch simulators. To install and launch "
+"manually:"
+msgstr ""
+
+#: src/platforms/watchos.md:48
+msgid "Perry maps UI widgets to SwiftUI views via a data-driven bridge:"
+msgstr ""
+
+#: src/platforms/watchos.md:50
+msgid "SwiftUI View"
+msgstr ""
+
+#: src/platforms/watchos.md:52
+msgid "Font size, weight, color, wrapping"
+msgstr ""
+
+#: src/platforms/watchos.md:53
+msgid "Tap action via native closure callback"
+msgstr ""
+
+#: src/platforms/watchos.md:54 src/platforms/watchos.md:55
+msgid "With spacing"
+msgstr ""
+
+#: src/platforms/watchos.md:56
+msgid "Layered views"
+msgstr ""
+
+#: src/platforms/watchos.md:59
+msgid "Two-way state binding"
+msgstr ""
+
+#: src/platforms/watchos.md:60
+msgid "Min/max/value, state binding"
+msgstr ""
+
+#: src/platforms/watchos.md:61
+msgid "Image(systemName:)"
+msgstr ""
+
+#: src/platforms/watchos.md:61
+msgid "SF Symbols"
+msgstr ""
+
+#: src/platforms/watchos.md:63
+msgid "Linear"
+msgstr ""
+
+#: src/platforms/watchos.md:64
+msgid "Selection list"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "Form"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "List"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "Maps to List on watchOS"
+msgstr ""
+
+#: src/platforms/watchos.md:66 src/platforms/android.md:39
+#: src/platforms/linux.md:50
+msgid "NavigationStack"
+msgstr ""
+
+#: src/platforms/watchos.md:66
+msgid "Push navigation"
+msgstr ""
+
+#: src/platforms/watchos.md:68 src/widgets/components.md:136
+msgid "Modifiers"
+msgstr ""
+
+#: src/platforms/watchos.md:70
+msgid "All widgets support these styling modifiers:"
+msgstr ""
+
+#: src/platforms/watchos.md:72
+msgid "`foregroundColor` / `backgroundColor`"
+msgstr ""
+
+#: src/platforms/watchos.md:73
+msgid "`font` (size, weight, family)"
+msgstr ""
+
+#: src/platforms/watchos.md:74
+msgid "`frame` (width, height)"
+msgstr ""
+
+#: src/platforms/watchos.md:75
+msgid "`padding` (uniform or per-edge)"
+msgstr ""
+
+#: src/platforms/watchos.md:76
+msgid "`cornerRadius`"
+msgstr ""
+
+#: src/platforms/watchos.md:78
+msgid "`hidden` / `disabled`"
+msgstr ""
+
+#: src/platforms/watchos.md:82
+msgid ""
+"watchOS apps use SwiftUI's `@main App` pattern. Perry's PerryWatchApp.swift "
+"runtime handles the app lifecycle automatically:"
+msgstr ""
+
+#: src/platforms/watchos.md:84
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack, Button } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My Watch App\",\n"
+"    width: 200,\n"
+"    height: 200,\n"
+"    body: VStack(8, [\n"
+"        Text(\"Hello, Apple Watch!\"),\n"
+"        Button(\"Tap me\", () => {\n"
+"            console.log(\"Button tapped!\")\n"
+"        }),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:100
+msgid "Under the hood:"
+msgstr ""
+
+#: src/platforms/watchos.md:101
+msgid ""
+"`perry_main_init()` runs your compiled TypeScript, which builds the UI tree "
+"in memory"
+msgstr ""
+
+#: src/platforms/watchos.md:102
+msgid "The SwiftUI `@main` struct observes the tree version and renders it"
+msgstr ""
+
+#: src/platforms/watchos.md:103
+msgid ""
+"User interactions (button taps, toggle changes) call back into native "
+"closures"
+msgstr ""
+
+#: src/platforms/watchos.md:107
+msgid "Reactive state works the same as other platforms:"
+msgstr ""
+
+#: src/platforms/watchos.md:109 src/platforms/wasm.md:166
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack, Button, State } from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"App({\n"
+"    title: \"Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Count: ${count.value}`),\n"
+"        Button(\"Increment\", () => count.set(count.value + 1)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:125
+msgid ""
+"When `state.set()` is called, the tree version increments and SwiftUI "
+"re-renders the affected views automatically."
+msgstr ""
+
+#: src/platforms/watchos.md:129
+msgid ""
+"Unlike iOS (UIKit) and macOS (AppKit), where Perry calls native view APIs "
+"directly via FFI, watchOS uses a **data-driven architecture**:"
+msgstr ""
+
+#: src/platforms/watchos.md:147
+msgid ""
+"The `PerryWatchApp.swift` file is a fixed runtime (~280 lines) that ships "
+"with Perry. It never changes per-app — it's the watchOS equivalent of "
+"`libperry_ui_ios.a`."
+msgstr ""
+
+#: src/platforms/watchos.md:151
+msgid "Configure watchOS settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/watchos.md:153
+msgid ""
+"```toml\n"
+"[watchos]\n"
+"bundle_id = \"com.example.mywatch\"\n"
+"deployment_target = \"10.0\"\n"
+"\n"
+"[watchos.info_plist]\n"
+"NSLocationWhenInUseUsageDescription = \"Used for location features\"\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:162
+msgid "Set up signing credentials with:"
+msgstr ""
+
+#: src/platforms/watchos.md:168
+msgid ""
+"This shares App Store Connect credentials with iOS/macOS (same team, API "
+"key, issuer)."
+msgstr ""
+
+#: src/platforms/watchos.md:172
+msgid "Use `__platform__ === 7` to detect watchOS at compile time:"
+msgstr ""
+
+#: src/platforms/watchos.md:174
+msgid ""
+"```typescript\n"
+"function reportWatchos(): void {\n"
+"    if (__platform__ === 7) {\n"
+"        console.log(\"Running on watchOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:182
+msgid "watchOS Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/watchos.md:184
+msgid ""
+"Perry also supports watchOS WidgetKit complications (separate from full "
+"apps):"
+msgstr ""
+
+#: src/platforms/watchos.md:190
+msgid ""
+"See [watchOS Complications](../widgets/watchos.md) for widget-specific "
+"documentation."
+msgstr ""
+
+#: src/platforms/watchos.md:194
+msgid ""
+"watchOS apps have inherent platform constraints compared to other Perry "
+"targets:"
+msgstr ""
+
+#: src/platforms/watchos.md:196
+msgid "**No Canvas**: CoreGraphics drawing is not available"
+msgstr ""
+
+#: src/platforms/watchos.md:197
+msgid "**No Camera**: watchOS does not support camera APIs"
+msgstr ""
+
+#: src/platforms/watchos.md:198
+msgid "**No TextField**: Text input is extremely limited on Apple Watch"
+msgstr ""
+
+#: src/platforms/watchos.md:199
+msgid "**No File Dialogs**: No document picker"
+msgstr ""
+
+#: src/platforms/watchos.md:200
+msgid "**No Menu Bar / Toolbar**: Not applicable on watch"
+msgstr ""
+
+#: src/platforms/watchos.md:201
+msgid "**No Multi-Window**: Single window only"
+msgstr ""
+
+#: src/platforms/watchos.md:202
+msgid "**No QR Code**: Screen too small for practical QR display"
+msgstr ""
+
+#: src/platforms/watchos.md:203
+msgid ""
+"**Memory**: watchOS devices have ~50-75MB available RAM — keep apps "
+"lightweight"
+msgstr ""
+
+#: src/platforms/watchos.md:204
+msgid "**Screen size**: Design for 40-49mm watch faces"
+msgstr ""
+
+#: src/platforms/watchos.md:208
+msgid ""
+"**SwiftUI vs UIKit**: watchOS uses SwiftUI rendering; iOS uses UIKit directly"
+msgstr ""
+
+#: src/platforms/watchos.md:209
+msgid "**No splash screen**: watchOS apps don't use launch storyboards"
+msgstr ""
+
+#: src/platforms/watchos.md:210
+msgid ""
+"**Standalone**: watchOS apps are standalone (no iPhone companion required, "
+"`WKWatchOnly = true`)"
+msgstr ""
+
+#: src/platforms/watchos.md:211
+msgid ""
+"**Device family**: `UIDeviceFamily = [4]` (watch) vs `[1, 2]` (iPhone/iPad)"
+msgstr ""
+
+#: src/platforms/watchos.md:215
+msgid "[watchOS Complications](../widgets/watchos.md) — WidgetKit complications"
+msgstr ""
+
+#: src/platforms/watchos.md:216
+msgid "[iOS](ios.md) — iOS platform reference"
+msgstr ""
+
+#: src/platforms/android.md:3
+msgid ""
+"Perry compiles TypeScript apps for Android using JNI (Java Native Interface)."
+msgstr ""
+
+#: src/platforms/android.md:7
+msgid "Android NDK"
+msgstr ""
+
+#: src/platforms/android.md:8
+msgid "Android SDK"
+msgstr ""
+
+#: src/platforms/android.md:9
+msgid "Rust Android targets:"
+msgstr ""
+
+#: src/platforms/android.md:22
+msgid "Perry maps UI widgets to Android views via JNI:"
+msgstr ""
+
+#: src/platforms/android.md:24
+msgid "Android Class"
+msgstr ""
+
+#: src/platforms/android.md:26
+msgid "TextView"
+msgstr ""
+
+#: src/platforms/android.md:28
+msgid "EditText"
+msgstr ""
+
+#: src/platforms/android.md:29
+msgid "EditText (ES_PASSWORD)"
+msgstr ""
+
+#: src/platforms/android.md:30
+msgid "Switch"
+msgstr ""
+
+#: src/platforms/android.md:31
+msgid "SeekBar"
+msgstr ""
+
+#: src/platforms/android.md:32
+msgid "Spinner + ArrayAdapter"
+msgstr ""
+
+#: src/platforms/android.md:33
+msgid "ImageView"
+msgstr ""
+
+#: src/platforms/android.md:34
+msgid "LinearLayout (vertical)"
+msgstr ""
+
+#: src/platforms/android.md:35
+msgid "LinearLayout (horizontal)"
+msgstr ""
+
+#: src/platforms/android.md:36 src/platforms/android.md:39
+msgid "FrameLayout"
+msgstr ""
+
+#: src/platforms/android.md:38
+msgid "Canvas + Bitmap"
+msgstr ""
+
+#: src/platforms/android.md:41
+msgid "Android-Specific APIs"
+msgstr ""
+
+#: src/platforms/android.md:43
+msgid "**Dark mode**: `Configuration.uiMode` detection"
+msgstr ""
+
+#: src/platforms/android.md:44
+msgid "**Preferences**: SharedPreferences"
+msgstr ""
+
+#: src/platforms/android.md:45
+msgid "**Keychain**: Android Keystore"
+msgstr ""
+
+#: src/platforms/android.md:46
+msgid "**Notifications**: NotificationManager"
+msgstr ""
+
+#: src/platforms/android.md:47
+msgid "**Open URL**: `Intent.ACTION_VIEW`"
+msgstr ""
+
+#: src/platforms/android.md:48
+msgid "**Alerts**: `PerryBridge.showAlert`"
+msgstr ""
+
+#: src/platforms/android.md:49
+msgid "**Sheets**: Dialog (modal)"
+msgstr ""
+
+#: src/platforms/android.md:53
+msgid ""
+"Perry's Android template includes a splash theme (`Theme.Perry.Splash`) that "
+"displays a `windowBackground` drawable during cold start. Configure it via "
+"`perry.splash` in `package.json`:"
+msgstr ""
+
+#: src/platforms/android.md:66
+msgid ""
+"The image is centered via a `layer-list` drawable with a solid background "
+"color. The activity switches to the normal theme in `onCreate` before "
+"inflating the layout, so the splash disappears as soon as the app is ready."
+msgstr ""
+
+#: src/platforms/android.md:68
+msgid "For full control, provide custom drawable and theme XML files:"
+msgstr ""
+
+#: src/platforms/android.md:85
+msgid "Differences from Desktop"
+msgstr ""
+
+#: src/platforms/android.md:87
+msgid "**Touch-only**: No hover events, no right-click context menus"
+msgstr ""
+
+#: src/platforms/android.md:88
+msgid "**Single window**: Multi-window maps to Dialog views"
+msgstr ""
+
+#: src/platforms/android.md:89
+msgid "**Toolbar**: Horizontal LinearLayout"
+msgstr ""
+
+#: src/platforms/android.md:90
+msgid "**Font**: Typeface-based font family support"
+msgstr ""
+
+#: src/platforms/harmonyos.md:3
+msgid ""
+"Perry compiles TypeScript apps for HarmonyOS NEXT (Huawei's mobile OS) by "
+"emitting **declarative ArkUI** alongside a logic-only `.so` library. The "
+"same TypeScript source that targets macOS, iOS, Android, Linux, and Windows "
+"also runs natively on HarmonyOS — no platform-specific adapters needed in "
+"user code."
+msgstr ""
+
+#: src/platforms/harmonyos.md:7
+msgid ""
+"HarmonyOS NEXT runs apps via the ArkTS runtime, which owns the UI tree. "
+"Perry can't lower `perry/ui` calls to the imperative AppKit/UIKit/etc shape "
+"used on every other platform — it has to play by ArkTS's declarative rules. "
+"So the harmonyos target is structured differently:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:26
+msgid ""
+"The user splices three artifacts into a DevEco Studio project — "
+"`libentry.so`, `pages/Index.ets`, `cpp/types/libentry/Index.d.ts` — and "
+"DevEco signs + runs as usual. Tap interactions, text input, etc. fire NAPI "
+"calls into the `.so`, which dispatch the registered Perry closure bodies."
+msgstr ""
+
+#: src/platforms/harmonyos.md:28
+msgid "What's supported"
+msgstr ""
+
+#: src/platforms/harmonyos.md:30
+msgid "**Widgets** (introduced in v0.5.401, expanded in v0.5.418, v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:32
+msgid "Widget"
+msgstr ""
+
+#: src/platforms/harmonyos.md:32
+msgid "ArkUI emission"
+msgstr ""
+
+#: src/platforms/harmonyos.md:34
+msgid "`Text(content)` / `Text(content, \"id\")`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:34
+msgid "`Text(...).fontSize(20)` (reactive when id is given)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:35
+msgid "`VStack(children)` / `VStack(spacing, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:35
+msgid "`Column({ space })`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:36
+msgid "`HStack(children)` / `HStack(spacing, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:36
+msgid "`Row({ space })`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:37
+msgid "`Button(label, onPress)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:37
+msgid "`Button(...).onClick(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:38
+msgid "`TextField(placeholder, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:38
+msgid "`TextInput(...).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:39
+msgid "`Toggle(label, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:39
+msgid "`Toggle({type: ToggleType.Switch}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:40
+msgid "`Slider(min, max, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:40
+msgid "`Slider({...}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:41
+msgid "`Spacer()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:41
+msgid "`Blank()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:42
+msgid "`Divider()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:43
+msgid "`Image(src)` / `ImageFile(path)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:43
+msgid "`Image(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:44
+msgid "`ScrollView(children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:44
+msgid "`Scroll() { Column() { ... } }`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:45
+msgid "`LazyVStack(children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:45
+msgid "`Column({...})` (eager — see v10 follow-up)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:46
+msgid "`Picker(options, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:46
+msgid "`TextPicker({...}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:47
+msgid "`ProgressView(value, total)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:47
+msgid "`Progress({type: ProgressType.Linear})`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:48
+msgid "`Section(title, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:48
+msgid "`Column({ space: 4 }) { Text(title) ... }`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:50
+msgid "**Event handling** (v0.5.417 + v0.5.421):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:51
+msgid "`Button.onPress` → `invokeCallback(idx)` via NAPI"
+msgstr ""
+
+#: src/platforms/harmonyos.md:52
+msgid "`Toggle.onChange((isOn: boolean) => ...)` → `invokeCallback1(idx, isOn)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:53
+msgid ""
+"`TextField.onChange((value: string) => ...)` → `invokeCallback1(idx, value)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:54
+msgid "`Slider.onChange((value: number) => ...)` → `invokeCallback1(idx, value)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:55
+msgid "`Picker.onChange((idx: number) => ...)` → `invokeCallback1(idx, index)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:57
+msgid "**Reactivity** (v0.5.419 + v0.5.421):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:58
+msgid ""
+"`Text(\"0\", \"counter\")` registers a reactive slot bound to a generated "
+"`@State text_counter: string` field."
+msgstr ""
+
+#: src/platforms/harmonyos.md:59
+msgid ""
+"`setText(\"counter\", \"5\")` from inside any closure updates the Text "
+"on-screen."
+msgstr ""
+
+#: src/platforms/harmonyos.md:61
+msgid "**Toast banners** (v0.5.419):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:62
+msgid ""
+"`showToast(\"Saved!\")` from inside any closure shows an ArkUI "
+"`promptAction.showToast({ message })` banner."
+msgstr ""
+
+#: src/platforms/harmonyos.md:64
+msgid "**Inline styling** (v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:65
+msgid ""
+"`Text(\"hi\", { fontSize: 16, color: \"red\" })` maps to "
+"`.fontSize(16).fontColor('red')`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:66
+msgid ""
+"Supported props: `backgroundColor`, `color`, `fontSize`, `fontWeight`, "
+"`fontFamily`, `borderRadius`, `padding` (number or per-side object), "
+"`opacity`, `hidden`, `borderColor` + `borderWidth` (combined as "
+"`.border({...})`)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:67
+msgid "PerryColor objects (`{r,g,b,a}`) auto-convert to `rgba(...)` strings."
+msgstr ""
+
+#: src/platforms/harmonyos.md:69
+msgid "**Dynamic lists** (v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:70
+msgid ""
+"`VStack(items.map(item => Text(item)))` lowers to ArkUI `ForEach(items, "
+"(__item) => { Text(__item) }, (__item) => __item)`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:71
+msgid ""
+"Single-arg map closures only; complex array sources require Phase 2 v6 state "
+"binding."
+msgstr ""
+
+#: src/platforms/harmonyos.md:73
+msgid "Setup"
+msgstr ""
+
+#: src/platforms/harmonyos.md:75
+msgid ""
+"**Install DevEco Studio** + the OpenHarmony SDK from Huawei. Verified "
+"working with DevEco Studio 6.0.2 + OpenHarmony 5.0+."
+msgstr ""
+
+#: src/platforms/harmonyos.md:77
+msgid "**Run the setup wizard once** (introduced in v0.5.380):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:83
+msgid ""
+"The wizard auto-discovers your DevEco-generated debug certificates from "
+"`~/.ohos/config/`, prompts for the keystore password, and persists the "
+"configuration to `~/.perry/config.toml`. Subsequent `perry compile --target "
+"harmonyos` invocations sign HAPs automatically."
+msgstr ""
+
+#: src/platforms/harmonyos.md:85
+msgid ""
+"**Optional**: install `hdc` (HarmonyOS Device Connector) for emulator "
+"interaction. It ships inside DevEco at "
+"`Contents/sdk/default/openharmony/toolchains/hdc`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:87
+msgid "Compile + run workflow"
+msgstr ""
+
+#: src/platforms/harmonyos.md:89
+msgid "Write a TypeScript program with `App({body: ...})`:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:91
+msgid ""
+"```typescript,no-test\n"
+"// hi.ts\n"
+"import { App, VStack, Text, Button, showToast } from \"perry/ui\";\n"
+"\n"
+"let count = 0;\n"
+"\n"
+"App({\n"
+"  title: \"Perry on HarmonyOS\",\n"
+"  body: VStack([\n"
+"    Text(\"Count: 0\", \"counter\"),\n"
+"    Button(\"+\", () => {\n"
+"      count++;\n"
+"      setText(\"counter\", `Count: ${count}`);\n"
+"    }),\n"
+"    Button(\"Notify\", () => {\n"
+"      showToast(`Counter is ${count}`);\n"
+"    }),\n"
+"  ]),\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/platforms/harmonyos.md:112
+msgid "Compile for HarmonyOS:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:118
+msgid "This produces three artifacts in `/tmp/`:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:120
+msgid "`libentry.so` — the compiled `.so` (8-9 MB typically)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:121
+msgid "`ets/pages/Index.ets` — the auto-emitted ArkUI page"
+msgstr ""
+
+#: src/platforms/harmonyos.md:122
+msgid "`cpp/types/libentry/Index.d.ts` — the NAPI declaration file"
+msgstr ""
+
+#: src/platforms/harmonyos.md:124
+msgid "**Splice** into a DevEco Studio project:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:132
+msgid ""
+"Click ▶ Run in DevEco — DevEco's hvigor signs + bundles the HAP and installs "
+"onto the emulator (or attached device). The app launches, taps fire your TS "
+"closures, and the screen updates reactively."
+msgstr ""
+
+#: src/platforms/harmonyos.md:134
+msgid "Architecture deep dive"
+msgstr ""
+
+#: src/platforms/harmonyos.md:136
+msgid "The harvest model"
+msgstr ""
+
+#: src/platforms/harmonyos.md:138
+msgid ""
+"`perry-codegen-arkts::emit_index_ets` walks `module.init` looking for the "
+"first `App({body: <expr>})` call from `perry/ui`. It extracts the `body` "
+"field, recursively emits ArkUI source for each widget in the tree, and "
+"**destructively replaces the App call with `Stmt::Expr(Expr::Number(0.0))`** "
+"so the LLVM backend never sees `perry_ui_*` FFI calls (which would be "
+"unresolved on the OHOS target — there's no `perry-ui-harmonyos` crate by "
+"design)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:140
+msgid ""
+"The emitted Index.ets is a real ArkUI `@Entry @Component struct Index { "
+"build() { ... } }` page with `@State` declarations for any reactive Text "
+"widgets, `import promptAction from '@ohos.promptAction'` for toast routing, "
+"and per-Button onClick handlers that invoke NAPI callbacks then drain queued "
+"toasts and text updates."
+msgstr ""
+
+#: src/platforms/harmonyos.md:142
+msgid "Closures across the NAPI boundary"
+msgstr ""
+
+#: src/platforms/harmonyos.md:144
+msgid ""
+"Each Button/Toggle/etc onClick closure registers via "
+"`perry_arkts_register_callback(idx, closure_handle)` during `main()` "
+"startup. The `closure_handle` is a NaN-boxed pointer to a real Perry "
+"`*ClosureHeader`. A GC root scanner registered in `gc_init` keeps registered "
+"closures alive across collections."
+msgstr ""
+
+#: src/platforms/harmonyos.md:146
+msgid ""
+"When ArkUI fires an onClick, the auto-emitted `.onClick(() => "
+"perryEntry.invokeCallback(0))` calls back into the `.so` via NAPI. The "
+"`invoke_callback` NAPI handler in `crates/perry-runtime/src/ohos_napi.rs` "
+"reads the int32 idx, looks up the slot, and dispatches via "
+"`js_closure_call0`. Multi-arg variants (Toggle/TextField/Slider) use "
+"`invokeCallback1(idx, value)` with `napi_typeof` dispatch to NaN-box the "
+"value (boolean / string / number) before calling `js_closure_call1`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:148
+msgid "The drain queue pattern"
+msgstr ""
+
+#: src/platforms/harmonyos.md:150
+msgid ""
+"`showToast` and `setText` calls inside a closure body push entries onto "
+"thread-local queues:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:151
+msgid "`PENDING_TOASTS: Mutex<VecDeque<String>>`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:152
+msgid "`PENDING_TEXT_UPDATES: Mutex<VecDeque<(String, String)>>`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:154
+msgid ""
+"After every onClick/onChange invocation, the auto-emitted handler in "
+"Index.ets drains both queues:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:172
+msgid ""
+"`applyTextUpdate(id, value)` is a switch over registered Text ids that "
+"assigns to the matching `@State text_<id>: string` field — ArkUI's "
+"reactivity then rerenders the Text widget."
+msgstr ""
+
+#: src/platforms/harmonyos.md:174
+msgid "Why NAPI?"
+msgstr ""
+
+#: src/platforms/harmonyos.md:176
+msgid ""
+"HarmonyOS NEXT uses the OpenHarmony NAPI binding (modeled on Node's NAPI) to "
+"load native `.so` libraries from ArkTS. Perry's "
+"`crates/perry-runtime/src/ohos_napi.rs` registers a module via "
+"`napi_module_register` in an `.init_array` constructor (Rust's equivalent of "
+"`__attribute__((constructor))`), with the modname auto-derived from the "
+"`.so` filename via `dladdr`. The exported NAPI surface is just `run` / "
+"`invokeCallback` / `invokeCallback1` / `drainToast` / `drainTextUpdate` — "
+"every other Perry runtime call happens within the `.so` itself."
+msgstr ""
+
+#: src/platforms/harmonyos.md:178
+msgid "Known limitations"
+msgstr ""
+
+#: src/platforms/harmonyos.md:180
+msgid ""
+"**LazyVStack is currently rendered eagerly** as a plain `Column`. Real lazy "
+"rendering for big lists needs ArkUI's `LazyForEach` + a custom `IDataSource` "
+"impl — tracked as Phase 2 v10."
+msgstr ""
+
+#: src/platforms/harmonyos.md:181
+msgid ""
+"**State binding is one-way** — `setText(\"id\", value)` from a closure "
+"updates the Text on-screen, but a generic `state<T>` reactive container "
+"(`const count = state(0); count.set(...)`) is Phase 2 v6 follow-up work."
+msgstr ""
+
+#: src/platforms/harmonyos.md:182
+msgid ""
+"**Multi-page navigation** (NavStack / Router across multiple `.ets` files) "
+"is Phase 2 v11."
+msgstr ""
+
+#: src/platforms/harmonyos.md:183
+msgid ""
+"**AppGallery production signing** uses a different cert chain than DevEco's "
+"debug certs and isn't yet plumbed into `perry compile`. The current splice "
+"workflow handles debug-emulator deploy."
+msgstr ""
+
+#: src/platforms/harmonyos.md:184
+msgid ""
+"**Real device validation** is pending — every milestone has been verified on "
+"the Pura 90 Pro Max emulator. AppGallery upload + real-hardware install will "
+"follow."
+msgstr ""
+
+#: src/platforms/harmonyos.md:186
+msgid "Validated on emulator"
+msgstr ""
+
+#: src/platforms/harmonyos.md:188
+msgid ""
+"End-to-end on Pura 90 Pro Max with a 5-widget interactive page (counter + "
+"reset, TextField echoing input live as `You typed: <text>`, Toggle flipping "
+"`Notifications: on/off` with toast feedback, Slider tracking `Volume: N` "
+"continuously, reactive Texts everywhere). Each interaction routes:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:196
+msgid ""
+"This is the first time Perry-compiled TypeScript state mutation has "
+"reactively driven a HarmonyOS NEXT screen."
+msgstr ""
+
+#: src/platforms/harmonyos.md:198
+msgid "Version history"
+msgstr ""
+
+#: src/platforms/harmonyos.md:200
+msgid ""
+"**v0.5.401** — Phase 2 v1.5: full widget set rendering "
+"(Text/VStack/HStack/Button/TextField/Toggle/Slider/Spacer/Divider)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:201
+msgid ""
+"**v0.5.417** — Phase 2 v2 + v3 + v2.5: Button onClick callback bridge, "
+"showToast, reactive Text via setText, multi-arg Toggle/TextField/Slider "
+"value forwarding."
+msgstr ""
+
+#: src/platforms/harmonyos.md:202
+msgid ""
+"**v0.5.418** — Phase 2 v4: Image / ScrollView / LazyVStack / Picker / "
+"ProgressView / Section."
+msgstr ""
+
+#: src/platforms/harmonyos.md:203
+msgid ""
+"**v0.5.420 / .421** — Cross-platform showToast + setText on iOS / tvOS / "
+"visionOS / Android."
+msgstr ""
+
+#: src/platforms/harmonyos.md:204
+msgid ""
+"**v0.5.422 / .423** — Cross-platform showToast + setText on Windows / GTK4."
+msgstr ""
+
+#: src/platforms/harmonyos.md:205
+msgid ""
+"**v0.5.429** — Phase 2 v5: inline `style: { ... }` + ForEach via array.map."
+msgstr ""
+
+#: src/platforms/harmonyos.md:207
+msgid ""
+"For the full per-version detail see "
+"[CHANGELOG.md](https://github.com/PerryTS/perry/blob/main/CHANGELOG.md)."
+msgstr ""
+
+#: src/platforms/windows.md:3
+msgid "Perry compiles TypeScript apps for Windows using the Win32 API."
+msgstr ""
+
+#: src/platforms/windows.md:7
+msgid ""
+"Windows 10 or later by default (Windows 7 SP1 / Windows 8 supported via "
+"`--min-windows-version=7|8` — see [Windows 7 Compatibility](./windows-7.md) "
+"for the trade-offs)"
+msgstr ""
+
+#: src/platforms/windows.md:8
+msgid "A linker toolchain — either of these two options:"
+msgstr ""
+
+#: src/platforms/windows.md:10
+msgid "Option A — Lightweight (recommended, ~1.5 GB, no Visual Studio)"
+msgstr ""
+
+#: src/platforms/windows.md:12
+msgid ""
+"Uses LLVM's `clang` + `lld-link` plus an xwin'd copy of the Microsoft CRT + "
+"Windows SDK libraries. No admin rights, no Visual Studio install."
+msgstr ""
+
+#: src/platforms/windows.md:19
+msgid ""
+"`perry setup windows` downloads ~700 MB (unpacks to ~1.5 GB) at "
+"`%LOCALAPPDATA%\\perry\\windows-sdk` after prompting you to accept the "
+"Microsoft redistributable license. Pass `--accept-license` to skip the "
+"prompt in CI. Partial downloads resume safely on re-run."
+msgstr ""
+
+#: src/platforms/windows.md:21
+msgid "Option B — Visual Studio (~8 GB)"
+msgstr ""
+
+#: src/platforms/windows.md:23
+msgid ""
+"If you already have Visual Studio installed, add the C++ workload via the "
+"Visual Studio Installer → _Modify_ → check **Desktop development with C++**. "
+"Or install standalone Build Tools:"
+msgstr ""
+
+#: src/platforms/windows.md:30
+msgid ""
+"Both options produce identical binaries — Perry picks Option A when the "
+"xwin'd sysroot is present, Option B otherwise. Run `perry doctor` to see "
+"which is active."
+msgstr ""
+
+#: src/platforms/windows.md:40
+msgid "Perry maps UI widgets to Win32 controls:"
+msgstr ""
+
+#: src/platforms/windows.md:42
+msgid "Win32 Class"
+msgstr ""
+
+#: src/platforms/windows.md:46
+msgid "Edit HWND"
+msgstr ""
+
+#: src/platforms/windows.md:47
+msgid "Edit (ES_PASSWORD)"
+msgstr ""
+
+#: src/platforms/windows.md:48
+msgid "Checkbox"
+msgstr ""
+
+#: src/platforms/windows.md:49
+msgid "Trackbar (TRACKBAR_CLASSW)"
+msgstr ""
+
+#: src/platforms/windows.md:50
+msgid "ComboBox"
+msgstr ""
+
+#: src/platforms/windows.md:51
+msgid "PROGRESS_CLASSW"
+msgstr ""
+
+#: src/platforms/windows.md:54
+msgid "WS_VSCROLL"
+msgstr ""
+
+#: src/platforms/windows.md:55
+msgid "GDI drawing"
+msgstr ""
+
+#: src/platforms/windows.md:56
+msgid "Form/Section"
+msgstr ""
+
+#: src/platforms/windows.md:56
+msgid "GroupBox"
+msgstr ""
+
+#: src/platforms/windows.md:58
+msgid "Windows-Specific APIs"
+msgstr ""
+
+#: src/platforms/windows.md:60
+msgid "**Menu bar**: HMENU / SetMenu"
+msgstr ""
+
+#: src/platforms/windows.md:61
+msgid "**Dark mode**: Windows Registry detection"
+msgstr ""
+
+#: src/platforms/windows.md:62
+msgid "**Preferences**: Windows Registry"
+msgstr ""
+
+#: src/platforms/windows.md:63
+msgid "**Keychain**: CredWrite/CredRead/CredDelete (Windows Credential Manager)"
+msgstr ""
+
+#: src/platforms/windows.md:64
+msgid "**Notifications**: Toast notifications"
+msgstr ""
+
+#: src/platforms/windows.md:65
+msgid "**File dialogs**: IFileOpenDialog / IFileSaveDialog (COM)"
+msgstr ""
+
+#: src/platforms/windows.md:66
+msgid "**Alerts**: MessageBoxW"
+msgstr ""
+
+#: src/platforms/windows.md:67
+msgid "**Open URL**: ShellExecuteW"
+msgstr ""
+
+#: src/platforms/windows-7.md:3
+msgid ""
+"Perry supports compiling executables that run on Windows 7 SP1 (and Windows "
+"8 / 8.1) — opt-in via the `--min-windows-version` flag. The default target "
+"stays Windows 10+ to preserve full DPI fidelity and modern OS integration; "
+"legacy support is one flag away when you need it."
+msgstr ""
+
+#: src/platforms/windows-7.md:5
+msgid ""
+"This page covers what works, what degrades, what's outright impossible, and "
+"how to validate your build before shipping."
+msgstr ""
+
+#: src/platforms/windows-7.md:7
+msgid "TL;DR"
+msgstr ""
+
+#: src/platforms/windows-7.md:13
+msgid ""
+"Produces a PE marked Win7-compatible. Perry's UI runtime resolves the "
+"Win10-only DPI APIs lazily at startup and falls back through Win8.1 → Vista "
+"primitives, so the binary starts on Win7 SP1. Most UI widgets work. Some "
+"cosmetic effects (rounded corners, dark titlebar) silently no-op. **No "
+"JavaScript-module imports allowed** on Win7 — the V8 runtime is Win10+ "
+"unconditional."
+msgstr ""
+
+#: src/platforms/windows-7.md:15
+msgid "Why this is opt-in"
+msgstr ""
+
+#: src/platforms/windows-7.md:17
+msgid ""
+"Two things make a Win7-compatible PE different from a default Perry build:"
+msgstr ""
+
+#: src/platforms/windows-7.md:19
+msgid ""
+"**The PE subsystem version field.** Default Perry builds let the linker pick "
+"(currently `/SUBSYSTEM:WINDOWS` with no version, which marks the binary as "
+"needing Win8+). Win7 needs `/SUBSYSTEM:WINDOWS,5.1` or "
+"`/SUBSYSTEM:CONSOLE,5.1`. The `,5.1` suffix is the [PE subsystem "
+"ABI](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-windows-specific-fields-image-only) "
+"declaration of \"I claim to run on Windows NT 5.1 or higher\" — the OS "
+"loader reads this field before deciding whether to load the binary."
+msgstr ""
+
+#: src/platforms/windows-7.md:21
+msgid ""
+"**Win10-only API calls become runtime-resolved.** Perry's UI library calls "
+"`SetProcessDpiAwarenessContext` (Win10 1607) and `GetDpiForSystem` (Win10 "
+"1607) for per-monitor v2 DPI awareness. Hard-importing them via `extern "
+"\"system\"` would emit IAT entries that the OS resolves _before_ `main()` "
+"runs — on Win7, the loader fails the process with \"entry point not found in "
+"user32.dll\" before any Rust code can run. With `--min-windows-version=7` "
+"(and on default builds too — the retrofit is unconditional), Perry resolves "
+"these symbols lazily via `LoadLibraryW + GetProcAddress` and falls back "
+"through:"
+msgstr ""
+
+#: src/platforms/windows-7.md:23
+msgid "Tier"
+msgstr ""
+
+#: src/platforms/windows-7.md:23 src/plugins/appstore-review.md:54
+msgid "API"
+msgstr ""
+
+#: src/platforms/windows-7.md:23
+msgid "Min Windows"
+msgstr ""
+
+#: src/platforms/windows-7.md:25
+msgid "`SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)`"
+msgstr ""
+
+#: src/platforms/windows-7.md:25
+msgid "Windows 10 1607"
+msgstr ""
+
+#: src/platforms/windows-7.md:26
+msgid "`SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)`"
+msgstr ""
+
+#: src/platforms/windows-7.md:26
+msgid "Windows 8.1"
+msgstr ""
+
+#: src/platforms/windows-7.md:27
+msgid "`SetProcessDPIAware()`"
+msgstr ""
+
+#: src/platforms/windows-7.md:27
+msgid "Windows Vista"
+msgstr ""
+
+#: src/platforms/windows-7.md:29
+msgid ""
+"System DPI lookup uses the same lazy pattern: `GetDpiForSystem` (Win10) → "
+"`GetDC + GetDeviceCaps(LOGPIXELSY)` (Win2000+)."
+msgstr ""
+
+#: src/platforms/windows-7.md:31
+msgid ""
+"The `--min-windows-version` flag controls only (1) — the PE marker. The lazy "
+"DPI resolution from (2) is always active because it costs essentially "
+"nothing and makes default builds more robust against being run on "
+"stripped-down Windows installs."
+msgstr ""
+
+#: src/platforms/windows-7.md:33
+msgid "Accepted values"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "`--min-windows-version`"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Subsystem suffix"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Targets"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Default?"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "`10`"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "(none — linker default)"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "Windows 10+"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "yes"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "`8`"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "`,6.02`"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "Windows 8 / 8.1+"
+msgstr ""
+
+#: src/platforms/windows-7.md:38 src/platforms/windows-7.md:39
+msgid "no"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "`7`"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "`,5.1`"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "Windows 7 SP1+"
+msgstr ""
+
+#: src/platforms/windows-7.md:41
+msgid ""
+"Anything else is a hard error at compile time — typos like "
+"`--min-windows-version=11` fail loudly instead of silently behaving like the "
+"default."
+msgstr ""
+
+#: src/platforms/windows-7.md:43
+msgid "What works on Win7"
+msgstr ""
+
+#: src/platforms/windows-7.md:45
+msgid ""
+"The same audit that produced this feature found 12 KLOC of Win32 UI code in "
+"`perry-ui-windows` and 5 calls that touch Win10+ APIs. The 5 break down as 2 "
+"hard blockers (now lazy-resolved) and 3 cosmetic-effect calls that already "
+"failed soft and silently no-op on Win7. So the bulk of the UI surface — "
+"every standard widget — works on Win7 SP1:"
+msgstr ""
+
+#: src/platforms/windows-7.md:47
+msgid ""
+"All layout containers (`VStack`, `HStack`, `ZStack`, `ScrollView`, `Spacer`, "
+"`Divider`)"
+msgstr ""
+
+#: src/platforms/windows-7.md:48
+msgid ""
+"All input widgets (`Button`, `TextField`, `SecureField`, `Toggle`, `Slider`, "
+"`Picker`, `ProgressView`)"
+msgstr ""
+
+#: src/platforms/windows-7.md:49
+msgid "`Text`, `Canvas`, `Image` (file + symbol)"
+msgstr ""
+
+#: src/platforms/windows-7.md:50
+msgid "`Form` and `LazyVStack`"
+msgstr ""
+
+#: src/platforms/windows-7.md:51
+msgid "File / folder open / save dialogs"
+msgstr ""
+
+#: src/platforms/windows-7.md:52
+msgid "Clipboard access"
+msgstr ""
+
+#: src/platforms/windows-7.md:53
+msgid "Audio (WASAPI is Vista+)"
+msgstr ""
+
+#: src/platforms/windows-7.md:54
+msgid "Keyboard shortcuts, menus, toolbars"
+msgstr ""
+
+#: src/platforms/windows-7.md:55
+msgid "Multi-window"
+msgstr ""
+
+#: src/platforms/windows-7.md:56
+msgid ""
+"The full `perry-runtime` and `perry-stdlib` surface — `fs`, `http`, "
+"`crypto`, `child_process`, `Date`, `Buffer`, etc."
+msgstr ""
+
+#: src/platforms/windows-7.md:58
+msgid "What degrades silently"
+msgstr ""
+
+#: src/platforms/windows-7.md:60
+msgid ""
+"These behaviors target Win10 / Win11 features. On Win7 the API call returns "
+"an error code that Perry already swallows; the binary runs, but the visual "
+"effect is missing:"
+msgstr ""
+
+#: src/platforms/windows-7.md:62
+msgid ""
+"**DPI quality.** Win7 has system-wide DPI only — moving a window between "
+"monitors with different DPI doesn't trigger re-scaling. Per-monitor v2 (font "
+"hinting, dialog scaling) is Win10 1607+."
+msgstr ""
+
+#: src/platforms/windows-7.md:63
+msgid ""
+"**Dark titlebar.** `DWMWA_USE_IMMERSIVE_DARK_MODE` is Win10 1809+. Titlebar "
+"follows the system theme on Win7 (light only on stock Win7)."
+msgstr ""
+
+#: src/platforms/windows-7.md:64
+msgid ""
+"**Rounded window corners.** `DWMWA_WINDOW_CORNER_PREFERENCE` is Win11+. "
+"Frameless windows have square corners on Win7 / Win10."
+msgstr ""
+
+#: src/platforms/windows-7.md:65
+msgid ""
+"**Mica / Acrylic backdrop.** `DWMWA_SYSTEMBACKDROP_TYPE` is Win11+. Backdrop "
+"falls through to the standard window background on Win7 / Win10."
+msgstr ""
+
+#: src/platforms/windows-7.md:67
+msgid "What is impossible"
+msgstr ""
+
+#: src/platforms/windows-7.md:69
+msgid ""
+"**`perry/jsruntime` (V8 / deno_core) is Win10+ unconditional.** Anything in "
+"your project that imports a `.js` module from `node_modules` triggers "
+"`--enable-jsruntime`, which links against deno_core, which embeds V8, which "
+"won't load on Win7. There's no fallback for this — Win7 builds must avoid "
+"JS-module imports entirely. If your project compiles cleanly without "
+"`--enable-jsruntime` (i.e. only TypeScript imports, only Perry-native "
+"packages), you're good."
+msgstr ""
+
+#: src/platforms/windows-7.md:71
+msgid ""
+"**Universal Windows Platform (UWP / WinRT) APIs.** Perry doesn't currently "
+"use these, but if a future feature does (e.g. modern toast notifications), "
+"it'll be Win10+ only. The runtime + stdlib audit was clean as of v0.5.395."
+msgstr ""
+
+#: src/platforms/windows-7.md:73
+msgid "How the lazy DPI resolution works"
+msgstr ""
+
+#: src/platforms/windows-7.md:75
+msgid ""
+"The retrofit lives in `crates/perry-ui-windows/src/dpi_compat.rs`. It "
+"exposes two functions, both safe to call on any Windows version from Vista "
+"onward:"
+msgstr ""
+
+#: src/platforms/windows-7.md:82
+msgid "Internally each function:"
+msgstr ""
+
+#: src/platforms/windows-7.md:84
+msgid ""
+"Calls `LoadLibraryA(\"user32.dll\")` (and `shcore.dll` for the Win8.1 tier) "
+"— both are loaded into every Win32 process by the kernel before `main`, so "
+"the call is a cheap handle lookup."
+msgstr ""
+
+#: src/platforms/windows-7.md:85
+msgid ""
+"Calls `GetProcAddress` to find the desired symbol. Caches the result "
+"(success or failure) in an `AtomicPtr` + `AtomicU8` pair, so the lookup runs "
+"at most once per process."
+msgstr ""
+
+#: src/platforms/windows-7.md:86
+msgid ""
+"Falls through to the next tier on miss. `set_process_dpi_awareness_compat` "
+"ends with `SetProcessDPIAware()` (Vista+, hard-imported because every "
+"supported Windows has it). `get_system_dpi_compat` ends with "
+"`GetDeviceCaps(LOGPIXELSY)` (Win2000+, dead reliable)."
+msgstr ""
+
+#: src/platforms/windows-7.md:88
+msgid ""
+"After the cache is warm — i.e. after `app_create` runs once — every "
+"subsequent DPI query is a single atomic load + indirect call. No measurable "
+"runtime cost vs. a hard-imported call."
+msgstr ""
+
+#: src/platforms/windows-7.md:90
+msgid "Validating a Win7 build"
+msgstr ""
+
+#: src/platforms/windows-7.md:92
+msgid ""
+"Perry's CI and dev hosts don't have Win7 VMs. If you ship to Win7 you need "
+"to validate the binary yourself. Three checks:"
+msgstr ""
+
+#: src/platforms/windows-7.md:94
+msgid "1. PE subsystem version"
+msgstr ""
+
+#: src/platforms/windows-7.md:96
+msgid ""
+"Use `dumpbin /headers app.exe | findstr \"subsystem\"` (MSVC) or `objdump -p "
+"app.exe | grep \"MajorOSVersion\"` (LLVM):"
+msgstr ""
+
+#: src/platforms/windows-7.md:98
+msgid ""
+"```text\n"
+"$ dumpbin /headers app.exe | findstr \"subsystem\"\n"
+"            5.01 subsystem version\n"
+"               2 subsystem (Windows GUI)\n"
+"```"
+msgstr ""
+
+#: src/platforms/windows-7.md:104
+msgid ""
+"The `5.01` confirms the PE is Win7-compatible. A default build shows `6.00` "
+"or higher."
+msgstr ""
+
+#: src/platforms/windows-7.md:106
+msgid "2. Imports"
+msgstr ""
+
+#: src/platforms/windows-7.md:108
+msgid ""
+"Use `dumpbin /imports app.exe | findstr /i \"user32\"` (MSVC) or `objdump -p "
+"app.exe | grep -A20 \"DLL Name: user32\"` (LLVM). Confirm that "
+"`SetProcessDpiAwarenessContext` and `GetDpiForSystem` are **not** in the "
+"user32.dll import list. If they are, the lazy retrofit isn't taking effect — "
+"likely you've added a `use "
+"windows::Win32::UI::HiDpi::SetProcessDpiAwarenessContext;` somewhere that "
+"pulls the symbol back in."
+msgstr ""
+
+#: src/platforms/windows-7.md:110
+msgid "3. Run on a Win7 SP1 VM"
+msgstr ""
+
+#: src/platforms/windows-7.md:112
+msgid ""
+"There's no substitute for actually launching the binary. Microsoft's free "
+"Win7 evaluation VM (no longer hosted directly by Microsoft, mirrored on "
+"archive.org) is the canonical reference image. Worth keeping a snapshot for "
+"regression checks."
+msgstr ""
+
+#: src/platforms/windows-7.md:114
+msgid "Caveats and gotchas"
+msgstr ""
+
+#: src/platforms/windows-7.md:116
+msgid ""
+"**The MSVC linker may warn** about subsystem version `,5.1` being below the "
+"C runtime's stated minimum on newer toolchains. The warning is benign — the "
+"CRT itself runs on Win7, the warning is conservative. Watch for hard errors, "
+"not warnings."
+msgstr ""
+
+#: src/platforms/windows-7.md:117
+msgid ""
+"**xwin sysroot setup is unchanged.** Cross-compiling from macOS / Linux "
+"still uses the `perry setup windows` xwin'd toolchain. Nothing in "
+"`--min-windows-version` changes the SDK requirements."
+msgstr ""
+
+#: src/platforms/windows-7.md:118
+msgid ""
+"**Static-link the CRT** if you want the binary to run on a clean Win7 SP1 "
+"install with no Visual C++ Redistributable. Confirm the binary doesn't "
+"import `vcruntime140.dll` / `msvcp140.dll` via the dumpbin/objdump check "
+"above."
+msgstr ""
+
+#: src/platforms/windows-7.md:119
+msgid ""
+"**`perry/thread`'s SRWLOCK is Vista+, fine.** Perry's threading primitives "
+"use Rust std, which uses SRWLOCK on Windows since Rust 1.42. No "
+"`WaitOnAddress` (Win8+) involvement on the supported Rust versions."
+msgstr ""
+
+#: src/platforms/windows-7.md:121
+msgid "Issue tracking"
+msgstr ""
+
+#: src/platforms/windows-7.md:123
+msgid ""
+"This feature lands as the resolution to "
+"[\\#303](https://github.com/PerryTS/perry/issues/303). If you hit a "
+"Win7-specific failure that isn't covered here, please file a follow-up "
+"referencing this page so we can extend the audit."
+msgstr ""
+
+#: src/platforms/linux.md:3
+msgid "Perry compiles TypeScript apps for Linux using GTK4."
+msgstr ""
+
+#: src/platforms/linux.md:7
+msgid "GTK4 development libraries:"
+msgstr ""
+
+#: src/platforms/linux.md:15
+msgid "# Arch\n"
+msgstr ""
+
+#: src/platforms/linux.md:18
+msgid "Cairo development libraries (for canvas):"
+msgstr ""
+
+#: src/platforms/linux.md:32
+msgid "Perry maps UI widgets to GTK4 widgets:"
+msgstr ""
+
+#: src/platforms/linux.md:34
+msgid "GTK4 Widget"
+msgstr ""
+
+#: src/platforms/linux.md:38
+msgid "GtkEntry"
+msgstr ""
+
+#: src/platforms/linux.md:39
+msgid "GtkPasswordEntry"
+msgstr ""
+
+#: src/platforms/linux.md:40
+msgid "GtkSwitch"
+msgstr ""
+
+#: src/platforms/linux.md:41
+msgid "GtkScale"
+msgstr ""
+
+#: src/platforms/linux.md:42
+msgid "GtkDropDown"
+msgstr ""
+
+#: src/platforms/linux.md:43
+msgid "GtkProgressBar"
+msgstr ""
+
+#: src/platforms/linux.md:44
+msgid "GtkImage"
+msgstr ""
+
+#: src/platforms/linux.md:45
+msgid "GtkBox (vertical)"
+msgstr ""
+
+#: src/platforms/linux.md:46
+msgid "GtkBox (horizontal)"
+msgstr ""
+
+#: src/platforms/linux.md:47
+msgid "GtkOverlay"
+msgstr ""
+
+#: src/platforms/linux.md:48
+msgid "GtkScrolledWindow"
+msgstr ""
+
+#: src/platforms/linux.md:49
+msgid "Cairo drawing"
+msgstr ""
+
+#: src/platforms/linux.md:50
+msgid "GtkStack"
+msgstr ""
+
+#: src/platforms/linux.md:52
+msgid "Linux-Specific APIs"
+msgstr ""
+
+#: src/platforms/linux.md:54
+msgid "**Menu bar**: GMenu / set_menubar"
+msgstr ""
+
+#: src/platforms/linux.md:55
+msgid "**Toolbar**: GtkHeaderBar"
+msgstr ""
+
+#: src/platforms/linux.md:56
+msgid "**Dark mode**: GTK settings detection"
+msgstr ""
+
+#: src/platforms/linux.md:57
+msgid "**Preferences**: GSettings or file-based"
+msgstr ""
+
+#: src/platforms/linux.md:58
+msgid "**Keychain**: libsecret"
+msgstr ""
+
+#: src/platforms/linux.md:59
+msgid "**Notifications**: GNotification"
+msgstr ""
+
+#: src/platforms/linux.md:60
+msgid "**File dialogs**: GtkFileChooserDialog"
+msgstr ""
+
+#: src/platforms/linux.md:61
+msgid "**Alerts**: GtkMessageDialog"
+msgstr ""
+
+#: src/platforms/linux.md:65
+msgid ""
+"GTK4 styling uses CSS under the hood. Perry's styling methods (colors, "
+"fonts, corner radius) are translated to CSS properties applied via "
+"`CssProvider`."
+msgstr ""
+
+#: src/platforms/linux.md:67
+msgid "Testing with Geisterhand"
+msgstr ""
+
+#: src/platforms/linux.md:69
+msgid ""
+"Perry's built-in UI fuzzer works on Linux/GTK4. Screenshots use "
+"`WidgetPaintable` + `GskRenderer` for pixel-accurate capture."
+msgstr ""
+
+#: src/platforms/linux.md:73
+msgid "# In another terminal:\n"
+msgstr ""
+
+#: src/platforms/linux.md:79
+msgid "See [Geisterhand](../testing/geisterhand.md) for full API reference."
+msgstr ""
+
+#: src/platforms/web.md:3
+msgid ""
+"`--target web` and `--target wasm` are aliases for the same backend. Both "
+"produce a self-contained HTML file with embedded WebAssembly and a "
+"JavaScript bridge for DOM widgets."
+msgstr ""
+
+#: src/platforms/web.md:6
+msgid "# same output as --target wasm\n"
+msgstr ""
+
+#: src/platforms/web.md:10
+msgid ""
+"See **[WebAssembly / Web](wasm.md)** for the full documentation: how it "
+"works, supported features, UI mapping, FFI, threading, limitations, and "
+"examples."
+msgstr ""
+
+#: src/platforms/web.md:12
+msgid "Why one target instead of two?"
+msgstr ""
+
+#: src/platforms/web.md:14
+msgid "Perry used to have two browser backends:"
+msgstr ""
+
+#: src/platforms/web.md:16
+msgid "`--target web` (`perry-codegen-js`) — transpiled HIR to JavaScript"
+msgstr ""
+
+#: src/platforms/web.md:17
+msgid "`--target wasm` (`perry-codegen-wasm`) — compiled HIR to WebAssembly"
+msgstr ""
+
+#: src/platforms/web.md:19
+msgid ""
+"These were consolidated into the WASM target so browser apps get near-native "
+"performance, FFI imports, and Web Worker threading without needing a "
+"separate JS-emit pipeline. The DOM widget runtime that the old `--target "
+"web` provided is now embedded in `wasm_runtime.js`. Both flags route through "
+"`perry-codegen-wasm` and produce identical HTML output."
+msgstr ""
+
+#: src/platforms/web.md:23
+msgid "[WebAssembly / Web](wasm.md) — full target documentation"
+msgstr ""
+
+#: src/platforms/web.md:24
+msgid "[Platform Overview](overview.md) — all platforms"
+msgstr ""
+
+#: src/platforms/wasm.md:1
+msgid "WebAssembly / Web"
+msgstr ""
+
+#: src/platforms/wasm.md:3
+msgid ""
+"Perry compiles TypeScript apps to **WebAssembly** for the browser using "
+"`--target wasm` or its alias `--target web`. Both flags route through the "
+"same backend (`perry-codegen-wasm`) and produce the same output: a "
+"self-contained HTML file with embedded WASM bytecode and a thin JavaScript "
+"bridge for DOM widgets and host APIs."
+msgstr ""
+
+#: src/platforms/wasm.md:5
+msgid ""
+"There used to be a separate JavaScript-emitting `--target web` "
+"(`perry-codegen-js`); it was consolidated into the WASM target so browser "
+"apps get near-native performance, FFI imports, and Web Worker threading "
+"\"for free\"."
+msgstr ""
+
+#: src/platforms/wasm.md:10
+msgid "# Self-contained HTML (default)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:13
+msgid "# Same thing\n"
+msgstr ""
+
+#: src/platforms/wasm.md:16
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:21
+msgid ""
+"The default output is a single `.html` file containing a base64-embedded "
+"WASM binary, the `wasm_runtime.js` bridge, and a `bootPerryWasm()` call that "
+"instantiates the module. Open it directly in any modern browser — no build "
+"step, no server required for simple apps."
+msgstr ""
+
+#: src/platforms/wasm.md:23
+msgid ""
+"**Note**: Apps that use `fetch()` or other web platform APIs that depend on "
+"a real origin must be served over HTTP (file:// URLs run into CORS / "
+"\"Failed to fetch\" errors). Any local static server works:"
+msgstr ""
+
+#: src/platforms/wasm.md:31
+msgid ""
+"The `perry-codegen-wasm` crate compiles HIR directly to WASM bytecode using "
+"`wasm-encoder`. The output WASM:"
+msgstr ""
+
+#: src/platforms/wasm.md:33
+msgid ""
+"Imports ~280 host functions under the `rt` namespace (string ops, math, "
+"console, JSON, classes, closures, promises, fetch, etc.)"
+msgstr ""
+
+#: src/platforms/wasm.md:34
+msgid "Imports user-declared FFI functions under the `ffi` namespace"
+msgstr ""
+
+#: src/platforms/wasm.md:35
+msgid ""
+"Exports `_start`, `memory`, `__indirect_function_table`, and every user "
+"function as `__wasm_func_<idx>` (so async function bodies compiled to JS can "
+"call back into WASM)"
+msgstr ""
+
+#: src/platforms/wasm.md:37
+msgid ""
+"The NaN-boxing scheme matches the native `perry-runtime` — f64 values with "
+"STRING_TAG/POINTER_TAG/INT32_TAG — so the same value representation is used "
+"across native and WASM targets. The JS bridge wraps every host import with "
+"bit-level reinterpretation so f64 NaN-boxed values pass through the "
+"BigInt-based JS↔WASM i64 boundary intact (BigInt(NaN) would otherwise throw)."
+msgstr ""
+
+#: src/platforms/wasm.md:41
+msgid ""
+"**Full TypeScript language**: classes (with constructors, methods, "
+"getters/setters, inheritance, fields), async/await, closures (with "
+"captures), generators, destructuring, template literals, generics, enums, "
+"try/catch/finally"
+msgstr ""
+
+#: src/platforms/wasm.md:42
+msgid ""
+"**Module system**: cross-module imports, top-level `const`/`let` (promoted "
+"to WASM globals), circular imports"
+msgstr ""
+
+#: src/platforms/wasm.md:43
+msgid ""
+"**Standard library**: String/Array/Object methods, Map/Set, JSON, Date, "
+"RegExp, Math, Error, URL/URLSearchParams, Buffer, Promise (with "
+"`.then`/`.catch`/`.allSettled`/`.race`/`.any`/`.all`)"
+msgstr ""
+
+#: src/platforms/wasm.md:44
+msgid ""
+"**Async**: `async`/`await` (compiled to JS Promises), "
+"`setTimeout`/`setInterval`, `fetch()` with full request options (method, "
+"headers, body)"
+msgstr ""
+
+#: src/platforms/wasm.md:45
+msgid ""
+"**Threading**: `perry/thread` `parallelMap`/`parallelFilter`/`spawn` via Web "
+"Worker pool with one WASM instance per worker (see "
+"[Threading](../threading/overview.md))"
+msgstr ""
+
+#: src/platforms/wasm.md:46
+msgid ""
+"**DOM-based UI**: every widget in `perry/ui` (`VStack`, `HStack`, `ZStack`, "
+"`Text`, `Button`, `TextField`, `Toggle`, `Slider`, `ScrollView`, `Picker`, "
+"`Image`, `Canvas`, `Form`, `Section`, `NavigationStack`, `Table`, "
+"`LazyVStack`, `TextArea`, etc.) maps to a DOM element with flexbox layout. "
+"State bindings (`bindText`/`bindSlider`/`bindToggle`/`bindForEach`/...) work "
+"via reactive subscribers."
+msgstr ""
+
+#: src/platforms/wasm.md:47
+msgid ""
+"**System APIs**: `localStorage`\\-backed preferences/keychain, dark mode "
+"detection (`prefers-color-scheme`), Web Notifications, clipboard, file "
+"open/save dialogs, File System Access API, Web Audio capture"
+msgstr ""
+
+#: src/platforms/wasm.md:48
+msgid ""
+"**FFI**: `declare function` declarations become WASM imports under the `ffi` "
+"namespace"
+msgstr ""
+
+#: src/platforms/wasm.md:49
+msgid ""
+"**Compile-time i18n**: `perry/i18n` `t()` calls work the same as native "
+"targets"
+msgstr ""
+
+#: src/platforms/wasm.md:51
+msgid "UI Mapping"
+msgstr ""
+
+#: src/platforms/wasm.md:53
+msgid "Perry widgets map to HTML elements:"
+msgstr ""
+
+#: src/platforms/wasm.md:55
+msgid "HTML Element"
+msgstr ""
+
+#: src/platforms/wasm.md:57 src/widgets/wearos.md:24
+msgid "`Text`"
+msgstr ""
+
+#: src/platforms/wasm.md:58
+msgid "`Button`"
+msgstr ""
+
+#: src/platforms/wasm.md:59
+msgid "`TextField`"
+msgstr ""
+
+#: src/platforms/wasm.md:59
+msgid "`<input type=\"text\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:60
+msgid "`SecureField`"
+msgstr ""
+
+#: src/platforms/wasm.md:60
+msgid "`<input type=\"password\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:61
+msgid "`Toggle`"
+msgstr ""
+
+#: src/platforms/wasm.md:61
+msgid "`<input type=\"checkbox\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:62
+msgid "`Slider`"
+msgstr ""
+
+#: src/platforms/wasm.md:62
+msgid "`<input type=\"range\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:63
+msgid "`Picker`"
+msgstr ""
+
+#: src/platforms/wasm.md:63
+msgid "`<select>`"
+msgstr ""
+
+#: src/platforms/wasm.md:64
+msgid "`ProgressView`"
+msgstr ""
+
+#: src/platforms/wasm.md:64
+msgid "`<progress>`"
+msgstr ""
+
+#: src/platforms/wasm.md:65
+msgid "`Image` / `ImageFile`"
+msgstr ""
+
+#: src/platforms/wasm.md:65
+msgid "`<img>`"
+msgstr ""
+
+#: src/platforms/wasm.md:66 src/widgets/wearos.md:25
+msgid "`VStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:66
+msgid "`<div>` (flexbox column)"
+msgstr ""
+
+#: src/platforms/wasm.md:67 src/widgets/wearos.md:26
+msgid "`HStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:67
+msgid "`<div>` (flexbox row)"
+msgstr ""
+
+#: src/platforms/wasm.md:68
+msgid "`ZStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:68
+msgid "`<div>` (position: relative + absolute children)"
+msgstr ""
+
+#: src/platforms/wasm.md:69
+msgid "`ScrollView`"
+msgstr ""
+
+#: src/platforms/wasm.md:69
+msgid "`<div>` (overflow: auto)"
+msgstr ""
+
+#: src/platforms/wasm.md:70
+msgid "`Canvas`"
+msgstr ""
+
+#: src/platforms/wasm.md:70
+msgid "`<canvas>` (2D context)"
+msgstr ""
+
+#: src/platforms/wasm.md:71
+msgid "`Table`"
+msgstr ""
+
+#: src/platforms/wasm.md:71
+msgid "`<table>`"
+msgstr ""
+
+#: src/platforms/wasm.md:72 src/widgets/wearos.md:28
+msgid "`Divider`"
+msgstr ""
+
+#: src/platforms/wasm.md:72
+msgid "`<hr>`"
+msgstr ""
+
+#: src/platforms/wasm.md:73 src/widgets/wearos.md:27
+msgid "`Spacer`"
+msgstr ""
+
+#: src/platforms/wasm.md:73
+msgid "`<div>` (flex: 1)"
+msgstr ""
+
+#: src/platforms/wasm.md:75
+msgid "FFI Support"
+msgstr ""
+
+#: src/platforms/wasm.md:77
+msgid ""
+"The WASM target supports external FFI functions declared with `declare "
+"function`. They become WASM imports under the `\"ffi\"` namespace:"
+msgstr ""
+
+#: src/platforms/wasm.md:85
+msgid "Provide them when instantiating:"
+msgstr ""
+
+#: src/platforms/wasm.md:88
+msgid "// Via __ffiImports global (set before boot)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:90
+msgid "// Or via bootPerryWasm second argument\n"
+msgstr ""
+
+#: src/platforms/wasm.md:95
+msgid ""
+"**Auto-stub for missing imports.** The `ffi` namespace is wrapped in a "
+"`Proxy` so any FFI function the host doesn't provide is auto-stubbed with a "
+"no-op that returns `TAG_UNDEFINED`. This means apps that use native "
+"libraries (e.g. Hone Editor's 56 `hone_editor_*` functions) can still "
+"instantiate and run in the browser even without the native bindings — the "
+"relevant features are simply no-ops."
+msgstr ""
+
+#: src/platforms/wasm.md:97
+msgid "Module-Level Constants"
+msgstr ""
+
+#: src/platforms/wasm.md:99
+msgid ""
+"Top-level `const`/`let` declarations are promoted to dedicated WASM globals "
+"so functions in the same module can read them, and so two modules' identical "
+"`LocalId`s don't collide:"
+msgstr ""
+
+#: src/platforms/wasm.md:101
+msgid ""
+"```typescript\n"
+"// telemetry.ts\n"
+"const CHIRP_URL = 'https://api.chirp247.com/api/v1/event'\n"
+"const API_KEY   = 'my-key'\n"
+"\n"
+"export function trackEvent(event: string): void {\n"
+"    fetch(CHIRP_URL, {\n"
+"        method: 'POST',\n"
+"        headers: { 'Content-Type': 'application/json', 'X-Chirp-Key': "
+"API_KEY },\n"
+"        body: JSON.stringify({ event }),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/wasm.md:115
+msgid ""
+"Both `CHIRP_URL` and `API_KEY` become WASM globals indexed by `(module_idx, "
+"LocalId)`. Reading them from `trackEvent` emits a `global.get` instead of "
+"trying to look up a function-local that doesn't exist."
+msgstr ""
+
+#: src/platforms/wasm.md:117
+msgid "JavaScript Runtime Bridge"
+msgstr ""
+
+#: src/platforms/wasm.md:119
+msgid ""
+"The bridge (`wasm_runtime.js`) is embedded in the HTML and provides ~280 "
+"imports across:"
+msgstr ""
+
+#: src/platforms/wasm.md:121
+msgid ""
+"**NaN-boxing helpers**: `f64ToU64` / `u64ToF64` / `nanboxString` / "
+"`nanboxPointer` / `toJsValue` / `fromJsValue`"
+msgstr ""
+
+#: src/platforms/wasm.md:122
+msgid "**String table**: dynamic JS string array indexed by string ID"
+msgstr ""
+
+#: src/platforms/wasm.md:123
+msgid ""
+"**Handle store**: maps integer handle IDs to JS objects, arrays, closures, "
+"promises, DOM elements"
+msgstr ""
+
+#: src/platforms/wasm.md:124
+msgid ""
+"**Core ops**: console, math, JSON, JSON.parse/stringify, Date, RegExp, URL, "
+"Map, Set, Buffer, fetch"
+msgstr ""
+
+#: src/platforms/wasm.md:125
+msgid ""
+"**Closure dispatch**: indirect function table + capture array, with "
+"`closure_call_0/1/2/3/spread`"
+msgstr ""
+
+#: src/platforms/wasm.md:126
+msgid ""
+"**Class dispatch**: `class_new`, `class_call_method`, `class_get_field`, "
+"`class_set_field`, parent table for inheritance"
+msgstr ""
+
+#: src/platforms/wasm.md:127
+msgid ""
+"**DOM widgets**: 168+ `perry_ui_*` functions covering every widget in "
+"`perry/ui`"
+msgstr ""
+
+#: src/platforms/wasm.md:128
+msgid ""
+"**Async functions**: compiled to JS function bodies and merged into the "
+"import object as `__async_<name>`"
+msgstr ""
+
+#: src/platforms/wasm.md:130
+msgid ""
+"All host imports are wrapped via `wrapImportsForI64()` so they automatically "
+"reinterpret BigInt args (from WASM i64 params) into f64 internally and "
+"reinterpret Number returns back into BigInt. Without this wrapping, every "
+"NaN-valued f64 return would crash with \"Cannot convert NaN to a BigInt\"."
+msgstr ""
+
+#: src/platforms/wasm.md:132
+msgid "Web Worker Threading"
+msgstr ""
+
+#: src/platforms/wasm.md:134
+msgid "`perry/thread` works in the browser via a Web Worker pool:"
+msgstr ""
+
+#: src/platforms/wasm.md:144
+msgid ""
+"Each worker instantiates its own WASM module with the same bytecode and "
+"bridge. Values cross between the main thread and workers via "
+"structured-clone serialization. See [Threading](../threading/overview.md)."
+msgstr ""
+
+#: src/platforms/wasm.md:148
+msgid ""
+"**No file system access** beyond the File System Access API "
+"(`window.showDirectoryPicker()`)"
+msgstr ""
+
+#: src/platforms/wasm.md:149
+msgid "**No raw TCP/UDP sockets** — only `fetch()` and `WebSocket`"
+msgstr ""
+
+#: src/platforms/wasm.md:150
+msgid "**No subprocess spawning** — `child_process.exec` etc. are no-ops"
+msgstr ""
+
+#: src/platforms/wasm.md:151
+msgid ""
+"**No native databases** — SQLite, Postgres, MySQL drivers don't compile to "
+"web"
+msgstr ""
+
+#: src/platforms/wasm.md:152
+msgid ""
+"**CORS** applies to all `fetch()` calls — third-party APIs must allow your "
+"origin"
+msgstr ""
+
+#: src/platforms/wasm.md:153
+msgid ""
+"**localStorage**, not real keychain — fine for preferences, not for secrets"
+msgstr ""
+
+#: src/platforms/wasm.md:154
+msgid ""
+"Source-mapped stack traces are JS-only; WASM stack frames show "
+"`wasm-function[N]`"
+msgstr ""
+
+#: src/platforms/wasm.md:156
+msgid "Minification"
+msgstr ""
+
+#: src/platforms/wasm.md:158
+msgid ""
+"Use `--minify` to minify the embedded JS runtime bridge in the HTML output. "
+"The Rust-native JS minifier strips comments, collapses whitespace, and "
+"mangles internal identifiers, compressing the runtime from ~3,400 lines to "
+"~180."
+msgstr ""
+
+#: src/platforms/wasm.md:164
+msgid "Example: Counter App"
+msgstr ""
+
+#: src/platforms/wasm.md:187
+msgid "Example: Real-World App (Mango MongoDB GUI)"
+msgstr ""
+
+#: src/platforms/wasm.md:189
+msgid ""
+"The [Mango](https://github.com/PerryTS/mango) MongoDB GUI — 50 modules, 998 "
+"functions, classes, async functions, fetch with custom headers, the Hone "
+"code editor — compiles to a single 4 MB HTML file via `--target web` and "
+"renders its full UI (welcome screen, query view, edit view) in the browser. "
+"SQLite-backed connection storage gracefully degrades to an in-memory "
+"transient store on web; the rest of the app works the same as the native "
+"version."
+msgstr ""
+
+#: src/platforms/wasm.md:195
+msgid "[Threading](../threading/overview.md) — Web Worker threading"
+msgstr ""
+
+#: src/stdlib/overview.md:1
+msgid "Standard Library Overview"
+msgstr ""
+
+#: src/stdlib/overview.md:3
+msgid ""
+"Perry natively implements many popular npm packages and Node.js APIs. When "
+"you import a supported package, Perry compiles it to native code — no "
+"JavaScript runtime involved."
+msgstr ""
+
+#: src/stdlib/overview.md:7
+msgid ""
+"```typescript\n"
+"import fastify from \"fastify\"\n"
+"import mysql from \"mysql2/promise\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/overview.md:12
+msgid ""
+"Perry recognizes these imports at compile time and routes them to native "
+"Rust implementations in the `perry-stdlib` crate. The API surface matches "
+"the original npm package, so existing code often works unchanged."
+msgstr ""
+
+#: src/stdlib/overview.md:14
+msgid "Supported Packages"
+msgstr ""
+
+#: src/stdlib/overview.md:16
+msgid "Networking & HTTP"
+msgstr ""
+
+#: src/stdlib/overview.md:17
+msgid "**fastify** — HTTP server framework"
+msgstr ""
+
+#: src/stdlib/overview.md:18
+msgid "**axios** — HTTP client"
+msgstr ""
+
+#: src/stdlib/overview.md:19
+msgid "**node-fetch** / **fetch** — HTTP fetch API"
+msgstr ""
+
+#: src/stdlib/overview.md:20
+msgid "**ws** — WebSocket client/server"
+msgstr ""
+
+#: src/stdlib/overview.md:23
+msgid "**mysql2** — MySQL client"
+msgstr ""
+
+#: src/stdlib/overview.md:24
+msgid "**pg** — PostgreSQL client"
+msgstr ""
+
+#: src/stdlib/overview.md:25
+msgid "**better-sqlite3** — SQLite"
+msgstr ""
+
+#: src/stdlib/overview.md:26
+msgid "**mongodb** — MongoDB client"
+msgstr ""
+
+#: src/stdlib/overview.md:27
+msgid "**ioredis** / **redis** — Redis client"
+msgstr ""
+
+#: src/stdlib/overview.md:30
+msgid "**bcrypt** — Password hashing"
+msgstr ""
+
+#: src/stdlib/overview.md:31
+msgid "**argon2** — Password hashing (Argon2)"
+msgstr ""
+
+#: src/stdlib/overview.md:32
+msgid "**jsonwebtoken** — JWT signing/verification"
+msgstr ""
+
+#: src/stdlib/overview.md:33
+msgid "**crypto** — Node.js crypto module"
+msgstr ""
+
+#: src/stdlib/overview.md:34
+msgid "**ethers** — Ethereum library"
+msgstr ""
+
+#: src/stdlib/overview.md:37
+msgid "**lodash** — Utility functions"
+msgstr ""
+
+#: src/stdlib/overview.md:38
+msgid "**dayjs** / **moment** — Date manipulation"
+msgstr ""
+
+#: src/stdlib/overview.md:39
+msgid "**uuid** — UUID generation"
+msgstr ""
+
+#: src/stdlib/overview.md:40
+msgid "**nanoid** — ID generation"
+msgstr ""
+
+#: src/stdlib/overview.md:41
+msgid "**slugify** — String slugification"
+msgstr ""
+
+#: src/stdlib/overview.md:42
+msgid "**validator** — String validation"
+msgstr ""
+
+#: src/stdlib/overview.md:44
+msgid "CLI & Data"
+msgstr ""
+
+#: src/stdlib/overview.md:45
+msgid "**commander** — CLI argument parsing"
+msgstr ""
+
+#: src/stdlib/overview.md:46
+msgid "**decimal.js** — Arbitrary precision decimals"
+msgstr ""
+
+#: src/stdlib/overview.md:47
+msgid "**bignumber.js** — Big number math"
+msgstr ""
+
+#: src/stdlib/overview.md:48
+msgid "**lru-cache** — LRU caching"
+msgstr ""
+
+#: src/stdlib/overview.md:51
+msgid "**sharp** — Image processing"
+msgstr ""
+
+#: src/stdlib/overview.md:52
+msgid "**cheerio** — HTML parsing"
+msgstr ""
+
+#: src/stdlib/overview.md:53
+msgid "**nodemailer** — Email sending"
+msgstr ""
+
+#: src/stdlib/overview.md:54
+msgid "**zlib** — Compression"
+msgstr ""
+
+#: src/stdlib/overview.md:55
+msgid "**cron** — Job scheduling"
+msgstr ""
+
+#: src/stdlib/overview.md:56
+msgid "**worker_threads** — Background workers"
+msgstr ""
+
+#: src/stdlib/overview.md:57
+msgid "**exponential-backoff** — Retry logic"
+msgstr ""
+
+#: src/stdlib/overview.md:58
+msgid "**async_hooks** — AsyncLocalStorage"
+msgstr ""
+
+#: src/stdlib/overview.md:60
+msgid "Node.js Built-ins"
+msgstr ""
+
+#: src/stdlib/overview.md:61
+msgid "**fs** — File system"
+msgstr ""
+
+#: src/stdlib/overview.md:62
+msgid "**path** — Path manipulation"
+msgstr ""
+
+#: src/stdlib/overview.md:63
+msgid "**child_process** — Process spawning"
+msgstr ""
+
+#: src/stdlib/overview.md:64
+msgid "**crypto** — Cryptographic functions"
+msgstr ""
+
+#: src/stdlib/overview.md:68
+msgid "Perry automatically detects which stdlib features your code uses:"
+msgstr ""
+
+#: src/stdlib/overview.md:70 src/system/preferences.md:8
+#: src/system/keychain.md:8
+msgid "Usage"
+msgstr ""
+
+#: src/stdlib/overview.md:72
+msgid "No stdlib imports"
+msgstr ""
+
+#: src/stdlib/overview.md:73
+msgid "fs + path only"
+msgstr ""
+
+#: src/stdlib/overview.md:74
+msgid "Full stdlib"
+msgstr ""
+
+#: src/stdlib/overview.md:76
+msgid "The compiler links only the required runtime components."
+msgstr ""
+
+#: src/stdlib/overview.md:78
+msgid "compilePackages"
+msgstr ""
+
+#: src/stdlib/overview.md:80
+msgid ""
+"For npm packages not natively supported, you can compile pure "
+"TypeScript/JavaScript packages natively:"
+msgstr ""
+
+#: src/stdlib/overview.md:90
+msgid ""
+"See [Project Configuration](../getting-started/project-config.md) for "
+"details."
+msgstr ""
+
+#: src/stdlib/overview.md:92
+msgid "JavaScript Runtime Fallback"
+msgstr ""
+
+#: src/stdlib/overview.md:94
+msgid ""
+"For packages that can't be compiled natively (native addons, dynamic code, "
+"etc.), Perry includes a QuickJS-based JavaScript runtime as a fallback. The "
+"exact API surface is internal-only today; the import below is illustrative:"
+msgstr ""
+
+#: src/stdlib/overview.md:96
+msgid ""
+"```text\n"
+"import { jsEval } from \"perry/jsruntime\"; // illustrative — not yet a "
+"public export\n"
+"```"
+msgstr ""
+
+#: src/stdlib/overview.md:102
+msgid "[File System](fs.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:103 src/stdlib/fs.md:90
+msgid "[HTTP & Networking](http.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:104 src/stdlib/http.md:95
+msgid "[Databases](database.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:105 src/stdlib/database.md:109
+msgid "[Cryptography](crypto.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:106 src/stdlib/crypto.md:89
+msgid "[Utilities](utilities.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:107 src/stdlib/utilities.md:106
+msgid "[Other Modules](other.md)"
+msgstr ""
+
+#: src/stdlib/fs.md:3
+msgid ""
+"Perry implements Node.js file system APIs for reading, writing, and managing "
+"files."
+msgstr ""
+
+#: src/stdlib/fs.md:5
+msgid "Reading Files"
+msgstr ""
+
+#: src/stdlib/fs.md:7
+msgid ""
+"```typescript\n"
+"const configPath = join(scratch, \"config.json\")\n"
+"const content = readFileSync(configPath, \"utf-8\")\n"
+"console.log(content)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:13
+msgid "Binary File Reading"
+msgstr ""
+
+#: src/stdlib/fs.md:15
+msgid ""
+"```typescript\n"
+"const imagePath = join(scratch, \"image.png\")\n"
+"const buffer = readFileBuffer(imagePath)\n"
+"console.log(`Read ${buffer.length} bytes`)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:21
+msgid ""
+"`readFileBuffer` reads files as binary data (uses `fs::read()` internally, "
+"not `read_to_string()`)."
+msgstr ""
+
+#: src/stdlib/fs.md:23
+msgid "Writing Files"
+msgstr ""
+
+#: src/stdlib/fs.md:25
+msgid ""
+"```typescript\n"
+"const outputPath = join(scratch, \"output.txt\")\n"
+"const dataPath = join(scratch, \"data.json\")\n"
+"writeFileSync(outputPath, \"Hello, World!\")\n"
+"writeFileSync(dataPath, JSON.stringify({ key: \"value\" }, null, 2))\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:32
+msgid "File Information"
+msgstr ""
+
+#: src/stdlib/fs.md:41
+msgid "Directory Operations"
+msgstr ""
+
+#: src/stdlib/fs.md:43
+msgid ""
+"```typescript\n"
+"// Create directory\n"
+"const outDir = join(scratch, \"output\")\n"
+"if (!existsSync(outDir)) mkdirSync(outDir)\n"
+"\n"
+"// Read directory contents\n"
+"const files = readdirSync(scratch)\n"
+"for (const file of files) {\n"
+"    console.log(file)\n"
+"}\n"
+"\n"
+"// Remove an empty directory\n"
+"rmdirSync(outDir)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:58
+msgid ""
+"For recursive removal Perry exposes `rmRecursive` (a thin wrapper around "
+"`std::fs::remove_dir_all`). Wired via "
+"[\\#193](https://github.com/PerryTS/perry/issues/193) through "
+"`js_fs_rm_recursive` in the LLVM backend."
+msgstr ""
+
+#: src/stdlib/fs.md:63
+msgid ""
+"```typescript,no-test\n"
+"import { rmRecursive } from \"fs\";\n"
+"rmRecursive(\"output\"); // Recursive remove; returns 1 on success, 0 on "
+"failure.\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:68
+msgid "Path Utilities"
+msgstr ""
+
+#: src/stdlib/fs.md:70
+msgid ""
+"```typescript\n"
+"const dir = dirname(configPath)\n"
+"const cfgPath = join(dir, \"config.json\")\n"
+"const name = basename(cfgPath)        // \"config.json\"\n"
+"const abs = resolve(\"relative/path\")  // Absolute path\n"
+"console.log(`${name} ${abs.length > 0}`)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:78
+msgid ""
+"For `import.meta.url` → filesystem path conversion, use `fileURLToPath` from "
+"the `url` module:"
+msgstr ""
+
+#: src/stdlib/fs.md:81
+msgid ""
+"```text\n"
+"import { fileURLToPath } from \"url\";\n"
+"import { dirname } from \"path\";\n"
+"\n"
+"const dir = dirname(fileURLToPath(import.meta.url));\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:91 src/stdlib/http.md:96 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:107 src/stdlib/other.md:186
+msgid "[Overview](overview.md) — All stdlib modules"
+msgstr ""
+
+#: src/stdlib/http.md:3
+msgid "Perry natively implements HTTP servers, clients, and WebSocket support."
+msgstr ""
+
+#: src/stdlib/http.md:5
+msgid "Fastify Server"
+msgstr ""
+
+#: src/stdlib/http.md:7
+msgid ""
+"```typescript\n"
+"import fastify from \"fastify\"\n"
+"\n"
+"const app = fastify()\n"
+"\n"
+"app.get(\"/\", async (request: any, reply: any) => {\n"
+"    return { hello: \"world\" }\n"
+"})\n"
+"\n"
+"app.get(\"/users/:id\", async (request: any, reply: any) => {\n"
+"    const id = request.params.id\n"
+"    return { id, name: \"User \" + id }\n"
+"})\n"
+"\n"
+"app.post(\"/data\", async (request: any, reply: any) => {\n"
+"    const body = request.body\n"
+"    reply.code(201)\n"
+"    return { received: body }\n"
+"})\n"
+"\n"
+"app.listen({ port: 3000 }, () => {\n"
+"    console.log(\"Server running on port 3000\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:32
+msgid ""
+"Perry's Fastify implementation is API-compatible with the npm package. "
+"Routes, request/reply objects, params, query strings, and JSON body parsing "
+"all work."
+msgstr ""
+
+#: src/stdlib/http.md:34
+msgid "Fetch API"
+msgstr ""
+
+#: src/stdlib/http.md:36
+msgid ""
+"```typescript\n"
+"async function fetchExamples(): Promise<void> {\n"
+"    // GET request\n"
+"    const response = await "
+"fetch(\"https://jsonplaceholder.typicode.com/posts/1\")\n"
+"    const data = await response.json()\n"
+"\n"
+"    // POST request\n"
+"    const result = await "
+"fetch(\"https://jsonplaceholder.typicode.com/posts\", {\n"
+"        method: \"POST\",\n"
+"        headers: { \"Content-Type\": \"application/json\" },\n"
+"        body: JSON.stringify({ title: \"hello\", body: \"world\", userId: 1 "
+"}),\n"
+"    })\n"
+"\n"
+"    console.log(`fetch ok: ${data !== null} status=${result.status}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:53
+msgid "Axios"
+msgstr ""
+
+#: src/stdlib/http.md:55
+msgid ""
+"```typescript\n"
+"import axios from \"axios\"\n"
+"\n"
+"async function axiosExamples(): Promise<void> {\n"
+"    const getResp = await "
+"axios.get(\"https://jsonplaceholder.typicode.com/users/1\")\n"
+"    const data = getResp.data\n"
+"\n"
+"    const response = await "
+"axios.post(\"https://jsonplaceholder.typicode.com/users\", {\n"
+"        name: \"Perry\",\n"
+"        email: \"perry@example.com\",\n"
+"    })\n"
+"\n"
+"    console.log(`axios ok: ${data !== null} status=${response.status}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:71
+msgid "WebSocket"
+msgstr ""
+
+#: src/stdlib/http.md:73
+msgid ""
+"```typescript\n"
+"import { WebSocket } from \"ws\"\n"
+"\n"
+"function wsExample(): void {\n"
+"    const ws = new WebSocket(\"ws://localhost:8080\")\n"
+"\n"
+"    ws.on(\"open\", () => {\n"
+"        ws.send(\"Hello, server!\")\n"
+"    })\n"
+"\n"
+"    ws.on(\"message\", (data: any) => {\n"
+"        console.log(`Received: ${data}`)\n"
+"    })\n"
+"\n"
+"    ws.on(\"close\", () => {\n"
+"        console.log(\"Connection closed\")\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:3
+msgid ""
+"Perry natively implements clients for MySQL, PostgreSQL, SQLite, MongoDB, "
+"and Redis."
+msgstr ""
+
+#: src/stdlib/database.md:5
+msgid "MySQL"
+msgstr ""
+
+#: src/stdlib/database.md:7
+msgid ""
+"```typescript\n"
+"import mysql from \"mysql2/promise\"\n"
+"\n"
+"async function mysqlExample(): Promise<void> {\n"
+"    const connection = await mysql.createConnection({\n"
+"        host: \"localhost\",\n"
+"        user: \"root\",\n"
+"        password: \"password\",\n"
+"        database: \"mydb\",\n"
+"    })\n"
+"\n"
+"    const [rows] = await connection.execute(\"SELECT * FROM users WHERE id = "
+"?\", [1])\n"
+"    console.log(rows)\n"
+"\n"
+"    await connection.end()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:25
+msgid "PostgreSQL"
+msgstr ""
+
+#: src/stdlib/database.md:27
+msgid ""
+"```typescript\n"
+"import { Client } from \"pg\"\n"
+"\n"
+"async function postgresExample(): Promise<void> {\n"
+"    const client = new Client({\n"
+"        host: \"localhost\",\n"
+"        port: 5432,\n"
+"        user: \"postgres\",\n"
+"        password: \"password\",\n"
+"        database: \"mydb\",\n"
+"    })\n"
+"\n"
+"    await client.connect()\n"
+"    const result = await client.query(\"SELECT * FROM users WHERE id = $1\", "
+"[1])\n"
+"    console.log(result.rows)\n"
+"    await client.end()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:46
+msgid "SQLite"
+msgstr ""
+
+#: src/stdlib/database.md:48
+msgid ""
+"```typescript\n"
+"import Database from \"better-sqlite3\"\n"
+"\n"
+"function sqliteExample(): void {\n"
+"    const db = new Database(\"mydb.sqlite\")\n"
+"\n"
+"    db.exec(`\n"
+"      CREATE TABLE IF NOT EXISTS users (\n"
+"        id INTEGER PRIMARY KEY,\n"
+"        name TEXT,\n"
+"        email TEXT\n"
+"      )\n"
+"    `)\n"
+"\n"
+"    const insert = db.prepare(\"INSERT INTO users (name, email) VALUES (?, "
+"?)\")\n"
+"    insert.run(\"Perry\", \"perry@example.com\")\n"
+"\n"
+"    const users = db.prepare(\"SELECT * FROM users\").all()\n"
+"    console.log(users)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:70
+msgid "MongoDB"
+msgstr ""
+
+#: src/stdlib/database.md:72
+msgid ""
+"```typescript\n"
+"import { MongoClient } from \"mongodb\"\n"
+"\n"
+"async function mongoExample(): Promise<void> {\n"
+"    const client = new MongoClient(\"mongodb://localhost:27017\")\n"
+"    await client.connect()\n"
+"\n"
+"    const db = client.db(\"mydb\")\n"
+"    const users = db.collection(\"users\")\n"
+"\n"
+"    await users.insertOne({ name: \"Perry\", email: \"perry@example.com\" "
+"})\n"
+"    const user = await users.findOne({ name: \"Perry\" })\n"
+"    console.log(user)\n"
+"\n"
+"    await client.close()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:90
+msgid "Redis"
+msgstr ""
+
+#: src/stdlib/database.md:92
+msgid ""
+"```typescript\n"
+"import Redis from \"ioredis\"\n"
+"\n"
+"async function redisExample(): Promise<void> {\n"
+"    const redis = new Redis()\n"
+"\n"
+"    await redis.set(\"key\", \"value\")\n"
+"    const value = await redis.get(\"key\")\n"
+"    console.log(value) // \"value\"\n"
+"\n"
+"    await redis.del(\"key\")\n"
+"    await redis.quit()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:3
+msgid ""
+"Perry natively implements password hashing, JWT tokens, and Ethereum "
+"cryptography."
+msgstr ""
+
+#: src/stdlib/crypto.md:5
+msgid "bcrypt"
+msgstr ""
+
+#: src/stdlib/crypto.md:7
+msgid ""
+"```typescript\n"
+"import bcrypt from \"bcrypt\"\n"
+"\n"
+"async function bcryptExample(): Promise<void> {\n"
+"    const hash = await bcrypt.hash(\"mypassword\", 10)\n"
+"    const match = await bcrypt.compare(\"mypassword\", hash)\n"
+"    console.log(match) // true\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:17
+msgid "Argon2"
+msgstr ""
+
+#: src/stdlib/crypto.md:19
+msgid ""
+"```typescript\n"
+"import argon2 from \"argon2\"\n"
+"\n"
+"async function argon2Example(): Promise<void> {\n"
+"    const hash = await argon2.hash(\"mypassword\")\n"
+"    const valid = await argon2.verify(hash, \"mypassword\")\n"
+"    console.log(valid) // true\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:29
+msgid "JSON Web Tokens"
+msgstr ""
+
+#: src/stdlib/crypto.md:31
+msgid ""
+"```typescript\n"
+"import jwt from \"jsonwebtoken\"\n"
+"\n"
+"function jwtExample(): void {\n"
+"    const secret = \"my-secret-key\"\n"
+"\n"
+"    // Sign a token\n"
+"    const token = jwt.sign({ userId: 123, role: \"admin\" }, secret, {\n"
+"        expiresIn: \"1h\",\n"
+"    })\n"
+"\n"
+"    // Verify a token\n"
+"    const decoded: any = jwt.verify(token, secret)\n"
+"    console.log(decoded.userId) // 123\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:48
+msgid "Node.js Crypto"
+msgstr ""
+
+#: src/stdlib/crypto.md:50
+msgid ""
+"```typescript\n"
+"import crypto from \"crypto\"\n"
+"\n"
+"function cryptoExample(): void {\n"
+"    // Hash\n"
+"    const hash = "
+"crypto.createHash(\"sha256\").update(\"data\").digest(\"hex\")\n"
+"\n"
+"    // HMAC\n"
+"    const hmac = crypto.createHmac(\"sha256\", "
+"\"secret\").update(\"data\").digest(\"hex\")\n"
+"\n"
+"    // Random bytes\n"
+"    const bytes = crypto.randomBytes(32)\n"
+"\n"
+"    console.log(`hash_len=${hash.length} hmac_len=${hmac.length} "
+"bytes_len=${bytes.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:67
+msgid "Ethers"
+msgstr ""
+
+#: src/stdlib/crypto.md:69
+msgid ""
+"```typescript\n"
+"import { ethers } from \"ethers\"\n"
+"\n"
+"function ethersExample(): void {\n"
+"    // Utility functions\n"
+"    const addr = "
+"ethers.getAddress(\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\")\n"
+"    const wei = ethers.parseEther(\"1.5\")\n"
+"    const ether = ethers.formatEther(wei)\n"
+"    console.log(`checksum: ${addr}`)\n"
+"    console.log(`1.5 ether in wei → formatted back: ${ether}`)\n"
+"\n"
+"    // Create a random wallet\n"
+"    const wallet = ethers.Wallet.createRandom()\n"
+"    console.log(`address: ${wallet.address}`)\n"
+"    console.log(`privateKey length: ${wallet.privateKey.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:3
+msgid "Perry natively implements common utility packages."
+msgstr ""
+
+#: src/stdlib/utilities.md:5
+msgid "lodash"
+msgstr ""
+
+#: src/stdlib/utilities.md:7
+msgid ""
+"The `lodash` runtime functions are partially implemented (see "
+"`crates/perry-stdlib/src/lodash.rs`) but the user-facing dispatch from "
+"`import _ from \"lodash\"; _.chunk(...)` is not wired into the LLVM backend "
+"yet. Track the follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:12
+msgid ""
+"```text\n"
+"import _ from \"lodash\";\n"
+"\n"
+"_.chunk([1, 2, 3, 4, 5], 2);     // [[1,2], [3,4], [5]]\n"
+"_.uniq([1, 2, 2, 3, 3]);          // [1, 2, 3]\n"
+"_.groupBy(users, \"role\");\n"
+"_.sortBy(users, [\"name\"]);\n"
+"_.cloneDeep(obj);\n"
+"_.merge(defaults, overrides);\n"
+"_.debounce(fn, 300);\n"
+"_.throttle(fn, 100);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:25
+msgid "dayjs"
+msgstr ""
+
+#: src/stdlib/utilities.md:27
+msgid ""
+"`dayjs` runtime functions are declared (`js_dayjs_now`, `js_dayjs_format`, "
+"`js_dayjs_add`, etc.) but the user-facing dispatch from `import dayjs from "
+"\"dayjs\"; dayjs()` chained methods is not wired into the LLVM backend yet. "
+"Track the follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:32
+msgid ""
+"```text\n"
+"import dayjs from \"dayjs\";\n"
+"\n"
+"const now = dayjs();\n"
+"console.log(now.format(\"YYYY-MM-DD\"));\n"
+"console.log(now.add(7, \"day\").format(\"YYYY-MM-DD\"));\n"
+"console.log(now.subtract(1, \"month\").toISOString());\n"
+"\n"
+"const diff = dayjs(\"2025-12-31\").diff(now, \"day\");\n"
+"console.log(`${diff} days until end of year`);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:44
+msgid "moment"
+msgstr ""
+
+#: src/stdlib/utilities.md:46
+msgid ""
+"Same status as `dayjs` — the runtime functions exist but the dispatch path "
+"is not wired yet."
+msgstr ""
+
+#: src/stdlib/utilities.md:49
+msgid ""
+"```text\n"
+"import moment from \"moment\";\n"
+"\n"
+"const now = moment();\n"
+"console.log(now.format(\"MMMM Do YYYY\"));\n"
+"console.log(now.fromNow());\n"
+"console.log(moment(\"2025-01-01\").isBefore(now));\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:58
+msgid "uuid"
+msgstr ""
+
+#: src/stdlib/utilities.md:60
+msgid ""
+"```typescript\n"
+"import { v4 as uuidv4 } from \"uuid\"\n"
+"\n"
+"const id = uuidv4()\n"
+"console.log(id) // e.g., \"550e8400-e29b-41d4-a716-446655440000\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:67
+msgid "nanoid"
+msgstr ""
+
+#: src/stdlib/utilities.md:69
+msgid ""
+"The default-length `nanoid()` call is wired. The custom-length form "
+"`nanoid(10)` has a runtime function (`js_nanoid_sized`) but no dispatch yet "
+"— track at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:73
+msgid ""
+"```typescript\n"
+"import { nanoid } from \"nanoid\"\n"
+"\n"
+"const nid = nanoid() // Default 21 chars\n"
+"console.log(nid)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:80
+msgid "slugify"
+msgstr ""
+
+#: src/stdlib/utilities.md:82
+msgid ""
+"The single-arg form is wired. The options-object form `slugify(\"Hello "
+"World!\", { lower: true })` has a runtime function "
+"(`js_slugify_with_options`) but no dispatch yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:86
+msgid ""
+"```typescript\n"
+"import slugify from \"slugify\"\n"
+"\n"
+"const slug = slugify(\"Hello World!\")\n"
+"console.log(slug) // \"hello-world\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:93
+msgid "validator"
+msgstr ""
+
+#: src/stdlib/utilities.md:95
+msgid ""
+"```typescript\n"
+"import validator from \"validator\"\n"
+"\n"
+"console.log(validator.isEmail(\"test@example.com\"))  // true\n"
+"console.log(validator.isURL(\"https://example.com\")) // true\n"
+"console.log(validator.isUUID(id))                   // true\n"
+"console.log(validator.isEmpty(\"\"))                  // true\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:3
+msgid "Additional npm packages and Node.js APIs supported by Perry."
+msgstr ""
+
+#: src/stdlib/other.md:5
+msgid "sharp (Image Processing)"
+msgstr ""
+
+#: src/stdlib/other.md:7
+msgid ""
+"The `sharp` runtime functions are declared (`js_sharp_resize`, "
+"`js_sharp_blur`, `js_sharp_to_buffer`, etc.) but the user-facing dispatch "
+"from `import sharp from \"sharp\"; sharp(input).resize(...)` is not wired "
+"into the LLVM backend yet. Track the follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:12
+msgid ""
+"```text\n"
+"import sharp from \"sharp\";\n"
+"\n"
+"await sharp(\"input.jpg\")\n"
+"  .resize(300, 200)\n"
+"  .toFile(\"output.png\");\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:20
+msgid "cheerio (HTML Parsing)"
+msgstr ""
+
+#: src/stdlib/other.md:22
+msgid ""
+"The `cheerio` runtime exists (see `crates/perry-stdlib/src/cheerio.rs`) but "
+"the dispatch path is not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:25
+msgid ""
+"```text\n"
+"import cheerio from \"cheerio\";\n"
+"\n"
+"const html = \"<html><body><h1>Hello</h1><p>World</p></body></html>\";\n"
+"const $ = cheerio.load(html);\n"
+"console.log($(\"h1\").text()); // \"Hello\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:33
+msgid "nodemailer (Email)"
+msgstr ""
+
+#: src/stdlib/other.md:35
+msgid ""
+"```typescript\n"
+"import nodemailer from \"nodemailer\"\n"
+"\n"
+"async function nodemailerExample(): Promise<void> {\n"
+"    const transporter = nodemailer.createTransport({\n"
+"        host: \"smtp.example.com\",\n"
+"        port: 587,\n"
+"        auth: { user: \"user\", pass: \"pass\" },\n"
+"    })\n"
+"\n"
+"    await transporter.sendMail({\n"
+"        from: \"sender@example.com\",\n"
+"        to: \"recipient@example.com\",\n"
+"        subject: \"Hello from Perry\",\n"
+"        text: \"This email was sent from a compiled TypeScript binary!\",\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:54
+msgid "zlib (Compression)"
+msgstr ""
+
+#: src/stdlib/other.md:56
+msgid ""
+"The `zlib` runtime exists but dispatch from `import zlib from \"zlib\"` is "
+"not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:59
+msgid ""
+"```text\n"
+"import zlib from \"zlib\";\n"
+"\n"
+"const compressed = zlib.gzipSync(\"Hello, World!\");\n"
+"const decompressed = zlib.gunzipSync(compressed);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:66
+msgid "cron (Job Scheduling)"
+msgstr ""
+
+#: src/stdlib/other.md:68
+msgid ""
+"The `cron` runtime exists but dispatch from `import { CronJob } from "
+"\"cron\"` is not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:71
+msgid ""
+"```text\n"
+"import { CronJob } from \"cron\";\n"
+"\n"
+"const job = new CronJob(\"*/5 * * * *\", () => {\n"
+"  console.log(\"Runs every 5 minutes\");\n"
+"});\n"
+"job.start();\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:80
+msgid "worker_threads"
+msgstr ""
+
+#: src/stdlib/other.md:82
+msgid ""
+"The `worker_threads` API is partially recognized at HIR-lowering time "
+"(`parentPort` / `Worker` shapes) but full dispatch is incomplete. For "
+"data-parallel work today, prefer `parallelMap` / `parallelFilter` / `spawn` "
+"from `perry/thread` (see [Threading](../threading/overview.md))."
+msgstr ""
+
+#: src/stdlib/other.md:87
+msgid ""
+"```text\n"
+"import { Worker, parentPort, workerData } from \"worker_threads\";\n"
+"\n"
+"if (parentPort) {\n"
+"  // Worker thread\n"
+"  const data = workerData;\n"
+"  parentPort.postMessage({ result: data.value * 2 });\n"
+"} else {\n"
+"  // Main thread\n"
+"  const worker = new Worker(\"./worker.ts\", {\n"
+"    workerData: { value: 21 },\n"
+"  });\n"
+"  worker.on(\"message\", (msg) => {\n"
+"    console.log(msg.result); // 42\n"
+"  });\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:105
+msgid "commander (CLI Parsing)"
+msgstr ""
+
+#: src/stdlib/other.md:107
+msgid ""
+"```typescript\n"
+"import { Command } from \"commander\"\n"
+"\n"
+"function commanderExample(): void {\n"
+"    const program = new Command()\n"
+"    program.name(\"my-cli\").version(\"1.0.0\").description(\"My CLI "
+"tool\")\n"
+"\n"
+"    program\n"
+"        .command(\"serve\")\n"
+"        .option(\"-p, --port <number>\", \"Port number\")\n"
+"        .option(\"--verbose\", \"Verbose output\")\n"
+"        .action((options: any) => {\n"
+"            console.log(`Starting server on port ${options.port}`)\n"
+"        })\n"
+"\n"
+"    program.parse(process.argv)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:126
+msgid "decimal.js (Arbitrary Precision)"
+msgstr ""
+
+#: src/stdlib/other.md:128
+msgid ""
+"```typescript\n"
+"import Decimal from \"decimal.js\"\n"
+"\n"
+"function decimalExample(): void {\n"
+"    const a = new Decimal(\"0.1\")\n"
+"    const b = new Decimal(\"0.2\")\n"
+"    const sum = a.plus(b) // Exactly 0.3 (no floating point errors)\n"
+"\n"
+"    console.log(sum.toFixed(2))      // \"0.30\"\n"
+"    console.log(sum.toNumber())      // 0.3\n"
+"    console.log(a.times(b).toFixed(2)) // \"0.02\"\n"
+"    console.log(a.div(b).toFixed(1))   // \"0.5\"\n"
+"    console.log(a.pow(10).toString())  // 1e-10\n"
+"    console.log(a.sqrt().toFixed(3))   // \"0.316\"\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:145
+msgid "lru-cache"
+msgstr ""
+
+#: src/stdlib/other.md:147
+msgid ""
+"The wired constructor takes the npm v7+ options-object shape (`new "
+"LRUCache({ max: 100 })`) — the older positional form `new LRUCache(100)` "
+"falls through to a `max=100` default."
+msgstr ""
+
+#: src/stdlib/other.md:151
+msgid ""
+"```typescript\n"
+"import { LRUCache } from \"lru-cache\"\n"
+"\n"
+"function lruCacheExample(): void {\n"
+"    const cache = new LRUCache({ max: 100 }) // max 100 entries\n"
+"\n"
+"    cache.set(\"key\", \"value\")\n"
+"    console.log(cache.get(\"key\"))   // \"value\"\n"
+"    console.log(cache.has(\"key\"))   // true\n"
+"    cache.delete(\"key\")\n"
+"    cache.clear()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:165
+msgid "child_process"
+msgstr ""
+
+#: src/stdlib/other.md:167
+msgid ""
+"```typescript\n"
+"import { spawnBackground, getProcessStatus, killProcess } from "
+"\"child_process\"\n"
+"\n"
+"function childProcessExample(): void {\n"
+"    // Spawn a background process\n"
+"    const { pid, handleId } = spawnBackground(\"sleep\", [\"10\"], "
+"\"/tmp/log.txt\")\n"
+"\n"
+"    // Check if it's still running\n"
+"    const status = getProcessStatus(handleId)\n"
+"    console.log(status.alive) // true\n"
+"    console.log(`pid=${pid}`)\n"
+"\n"
+"    // Kill it\n"
+"    killProcess(handleId)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:187
+msgid "[File System](fs.md) — fs and path APIs"
+msgstr ""
+
+#: src/i18n/overview.md:1
+msgid "Internationalization (i18n)"
+msgstr ""
+
+#: src/i18n/overview.md:3
+msgid ""
+"Perry's i18n system lets you write natural English strings and have them "
+"automatically translated at compile time. Zero ceremony, near-zero runtime "
+"cost."
+msgstr ""
+
+#: src/i18n/overview.md:5
+msgid ""
+"```typescript\n"
+"// String literals in UI component calls are automatically localizable "
+"keys.\n"
+"// (Conceptually the docs write `Button(\"Next\")` / `Text(\"Hello, "
+"{name}!\", ...)`\n"
+"// from \"perry/ui\"; we exercise the runtime API that backs them — t() — "
+"here.)\n"
+"const next = t(\"Next\")                                  // Automatically "
+"localized\n"
+"const hello = t(\"Hello, {name}!\", { name: \"Alice\" })    // With "
+"interpolation\n"
+"console.log(next, hello)\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:14
+msgid ""
+"The same key-resolution and interpolation runs through the explicit `t()` "
+"API for non-UI strings:"
+msgstr ""
+
+#: src/i18n/overview.md:16
+msgid ""
+"```typescript\n"
+"import { t, Currency, Percent, ShortDate, LongDate, FormatNumber, "
+"FormatTime, Raw } from \"perry/i18n\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:20
+msgid "Design Principles"
+msgstr ""
+
+#: src/i18n/overview.md:22
+msgid ""
+"**Zero ceremony**: String literals in UI components are automatically "
+"localizable keys"
+msgstr ""
+
+#: src/i18n/overview.md:23
+msgid ""
+"**Compile-time validation**: Missing translations, parameter mismatches, and "
+"plural form errors caught during build"
+msgstr ""
+
+#: src/i18n/overview.md:24
+msgid ""
+"**Embedded string table**: All translations baked into the binary as a flat "
+"2D table. Near-zero runtime lookup cost"
+msgstr ""
+
+#: src/i18n/overview.md:25
+msgid ""
+"**Platform-native locale detection**: Uses OS APIs on every platform (no env "
+"vars needed on mobile)"
+msgstr ""
+
+#: src/i18n/overview.md:29
+msgid "1. Add i18n config to perry.toml"
+msgstr ""
+
+#: src/i18n/overview.md:31
+msgid ""
+"```toml\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\"]\n"
+"default_locale = \"en\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:37
+msgid "2. Extract strings from your code"
+msgstr ""
+
+#: src/i18n/overview.md:43
+msgid ""
+"This scans your source files and creates `locales/en.json` and "
+"`locales/de.json`:"
+msgstr ""
+
+#: src/i18n/overview.md:46 src/i18n/interpolation.md:17
+#: src/i18n/interpolation.md:49
+msgid "// locales/en.json\n"
+msgstr ""
+
+#: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
+#: src/i18n/cli.md:38 src/i18n/cli.md:87
+msgid "\"Next\""
+msgstr ""
+
+#: src/i18n/overview.md:49 src/i18n/overview.md:55 src/i18n/overview.md:66
+msgid "\"Back\""
+msgstr ""
+
+#: src/i18n/overview.md:51
+msgid "// locales/de.json (empty values = needs translation)\n"
+msgstr ""
+
+#: src/i18n/overview.md:54 src/i18n/overview.md:55
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:73
+msgid "\"\""
+msgstr ""
+
+#: src/i18n/overview.md:59
+msgid "3. Translate"
+msgstr ""
+
+#: src/i18n/overview.md:61
+msgid "Fill in `locales/de.json`:"
+msgstr ""
+
+#: src/i18n/overview.md:65
+msgid "\"Weiter\""
+msgstr ""
+
+#: src/i18n/overview.md:66
+msgid "\"Zurck\""
+msgstr ""
+
+#: src/i18n/overview.md:70
+msgid "4. Build"
+msgstr ""
+
+#: src/i18n/overview.md:76
+msgid ""
+"Perry validates all translations at compile time and bakes them into the "
+"binary. At runtime, the app detects the user's system locale and shows the "
+"right language."
+msgstr ""
+
+#: src/i18n/overview.md:80
+msgid ""
+"**Detection**: String literals in UI component calls (`Button`, `Text`, "
+"`Label`, etc.) are automatically treated as i18n keys"
+msgstr ""
+
+#: src/i18n/overview.md:81
+msgid ""
+"**Transform**: The compiler replaces `Expr::String(\"Next\")` with "
+"`Expr::I18nString { key: \"Next\", string_idx: 0 }` in the HIR"
+msgstr ""
+
+#: src/i18n/overview.md:82
+msgid ""
+"**Codegen**: For each `I18nString`, the compiler emits a locale branch that "
+"selects the correct translation at runtime"
+msgstr ""
+
+#: src/i18n/overview.md:83
+msgid ""
+"**Locale detection**: At startup, `perry_i18n_init()` detects the system "
+"locale via native APIs and sets the global locale index"
+msgstr ""
+
+#: src/i18n/overview.md:85
+msgid "Locale Detection"
+msgstr ""
+
+#: src/i18n/overview.md:89 src/i18n/overview.md:90
+msgid "`CFLocaleCopyCurrent()` (CoreFoundation)"
+msgstr ""
+
+#: src/i18n/overview.md:91
+msgid "`__system_property_get(\"persist.sys.locale\")`"
+msgstr ""
+
+#: src/i18n/overview.md:92
+msgid "`GetUserDefaultLocaleName()` (Win32)"
+msgstr ""
+
+#: src/i18n/overview.md:93
+msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
+msgstr ""
+
+#: src/i18n/overview.md:95
+msgid ""
+"The detected locale is fuzzy-matched against your configured locales: "
+"`de_DE.UTF-8` matches `de`, `en-US` matches `en`, etc."
+msgstr ""
+
+#: src/i18n/overview.md:97
+msgid "Platform Output"
+msgstr ""
+
+#: src/i18n/overview.md:99
+msgid ""
+"When compiling for mobile targets, Perry generates platform-native locale "
+"resources alongside the binary:"
+msgstr ""
+
+#: src/i18n/overview.md:101 src/widgets/platforms.md:9
+msgid "Output"
+msgstr ""
+
+#: src/i18n/overview.md:103
+msgid "iOS/macOS"
+msgstr ""
+
+#: src/i18n/overview.md:103
+msgid "`{locale}.lproj/Localizable.strings` inside `.app` bundle"
+msgstr ""
+
+#: src/i18n/overview.md:104
+msgid "`res/values-{locale}/strings.xml`"
+msgstr ""
+
+#: src/i18n/overview.md:105
+msgid "Desktop"
+msgstr ""
+
+#: src/i18n/overview.md:105
+msgid "Strings embedded in binary (no extra files)"
+msgstr ""
+
+#: src/i18n/overview.md:109
+msgid "[Interpolation & Plurals](interpolation.md)"
+msgstr ""
+
+#: src/i18n/overview.md:110
+msgid "[Formatting](formatting.md)"
+msgstr ""
+
+#: src/i18n/overview.md:111
+msgid "[CLI Tools](cli.md)"
+msgstr ""
+
+#: src/i18n/interpolation.md:3
+msgid "Parameterized Strings"
+msgstr ""
+
+#: src/i18n/interpolation.md:5
+msgid ""
+"Use `{param}` placeholders in your strings and pass values as a second "
+"argument:"
+msgstr ""
+
+#: src/i18n/interpolation.md:7
+msgid ""
+"```typescript\n"
+"// Use {param} placeholders in your strings and pass values as a second "
+"arg.\n"
+"const greeting = t(\"Hello, {name}!\", { name: \"Alice\" })\n"
+"const total = t(\"Total: {price}\", { price: 23.10 })\n"
+"console.log(greeting, total)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:14
+msgid "Translation files use the same `{param}` syntax:"
+msgstr ""
+
+#: src/i18n/interpolation.md:19 src/i18n/interpolation.md:25 src/i18n/cli.md:38
+#: src/i18n/cli.md:88
+msgid "\"Hello, {name}!\""
+msgstr ""
+
+#: src/i18n/interpolation.md:20 src/i18n/interpolation.md:26
+msgid "\"Total: {price}\""
+msgstr ""
+
+#: src/i18n/interpolation.md:22 src/i18n/interpolation.md:54
+msgid "// locales/de.json\n"
+msgstr ""
+
+#: src/i18n/interpolation.md:25
+msgid "\"Hallo, {name}!\""
+msgstr ""
+
+#: src/i18n/interpolation.md:26
+msgid "\"Gesamt: {price}\""
+msgstr ""
+
+#: src/i18n/interpolation.md:30
+msgid ""
+"Parameters are substituted at runtime after the locale-appropriate template "
+"is selected. The substitution handles any value type (numbers, strings, "
+"dates) by converting to string."
+msgstr ""
+
+#: src/i18n/interpolation.md:32 src/i18n/interpolation.md:99
+msgid "Compile-Time Validation"
+msgstr ""
+
+#: src/i18n/interpolation.md:34
+msgid "Perry validates parameters across all locales during compilation:"
+msgstr ""
+
+#: src/i18n/interpolation.md:36 src/i18n/interpolation.md:101
+msgid "Condition"
+msgstr ""
+
+#: src/i18n/interpolation.md:36 src/i18n/interpolation.md:101
+msgid "Severity"
+msgstr ""
+
+#: src/i18n/interpolation.md:38
+msgid "`{param}` in translation but not provided in code"
+msgstr ""
+
+#: src/i18n/interpolation.md:38 src/i18n/interpolation.md:39
+#: src/i18n/interpolation.md:40 src/i18n/interpolation.md:103
+#: src/i18n/interpolation.md:104
+msgid "Error"
+msgstr ""
+
+#: src/i18n/interpolation.md:39
+msgid "Param in code but `{param}` not in translation"
+msgstr ""
+
+#: src/i18n/interpolation.md:40
+msgid "Parameter set differs between locales for same key"
+msgstr ""
+
+#: src/i18n/interpolation.md:42
+msgid "Plural Rules"
+msgstr ""
+
+#: src/i18n/interpolation.md:44
+msgid ""
+"Plural forms use dot-suffix keys based on CLDR plural categories: `.zero`, "
+"`.one`, `.two`, `.few`, `.many`, `.other`."
+msgstr ""
+
+#: src/i18n/interpolation.md:46
+msgid "Locale Files"
+msgstr ""
+
+#: src/i18n/interpolation.md:51 src/i18n/interpolation.md:57
+#: src/i18n/interpolation.md:63
+msgid "\"You have {count} items.one\""
+msgstr ""
+
+#: src/i18n/interpolation.md:51
+msgid "\"You have {count} item.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:52 src/i18n/interpolation.md:58
+#: src/i18n/interpolation.md:66
+msgid "\"You have {count} items.other\""
+msgstr ""
+
+#: src/i18n/interpolation.md:52
+msgid "\"You have {count} items.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:57 src/i18n/interpolation.md:58
+msgid "\"Du hast {count} Artikel.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:60
+msgid "// locales/pl.json (Polish: one, few, many)\n"
+msgstr ""
+
+#: src/i18n/interpolation.md:63
+msgid "\"Masz {count} element.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:64
+msgid "\"You have {count} items.few\""
+msgstr ""
+
+#: src/i18n/interpolation.md:64
+msgid "\"Masz {count} elementy.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:65
+msgid "\"You have {count} items.many\""
+msgstr ""
+
+#: src/i18n/interpolation.md:65
+msgid "\"Masz {count} elementow.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:66
+msgid "\"Masz {count} elementu.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:70
+msgid "Usage in Code"
+msgstr ""
+
+#: src/i18n/interpolation.md:72
+msgid ""
+"Reference the base key without any suffix. Perry detects the plural variants "
+"automatically:"
+msgstr ""
+
+#: src/i18n/interpolation.md:74
+msgid ""
+"```typescript\n"
+"// Reference the base key without any suffix — Perry picks the plural "
+"variant\n"
+"// from the `count` parameter and the current locale's CLDR rules.\n"
+"const cartCount = 3\n"
+"const itemMessage = t(\"You have {count} items\", { count: cartCount })\n"
+"console.log(itemMessage)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:82
+msgid ""
+"Perry determines which plural form to use based on the `count` parameter "
+"value and the current locale's CLDR rules."
+msgstr ""
+
+#: src/i18n/interpolation.md:84
+msgid "Supported Locales"
+msgstr ""
+
+#: src/i18n/interpolation.md:86
+msgid "Perry includes hand-rolled CLDR plural rules for 30+ locales:"
+msgstr ""
+
+#: src/i18n/interpolation.md:88
+msgid "Pattern"
+msgstr ""
+
+#: src/i18n/interpolation.md:88
+msgid "Locales"
+msgstr ""
+
+#: src/i18n/interpolation.md:90
+msgid "one/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:90
+msgid ""
+"English, German, Dutch, Swedish, Danish, Norwegian, Finnish, Estonian, "
+"Hungarian, Turkish, Greek, Hebrew, Italian, Spanish, Portuguese, Catalan, "
+"Bulgarian, Hindi, Bengali, Swahili, ..."
+msgstr ""
+
+#: src/i18n/interpolation.md:91
+msgid "one (0-1) / other"
+msgstr ""
+
+#: src/i18n/interpolation.md:91
+msgid "French"
+msgstr ""
+
+#: src/i18n/interpolation.md:92
+msgid "no distinction"
+msgstr ""
+
+#: src/i18n/interpolation.md:92
+msgid "Japanese, Chinese, Korean, Vietnamese, Thai, Indonesian, Malay"
+msgstr ""
+
+#: src/i18n/interpolation.md:93
+msgid "one/few/many"
+msgstr ""
+
+#: src/i18n/interpolation.md:93
+msgid "Russian, Ukrainian, Serbian, Croatian, Bosnian, Polish"
+msgstr ""
+
+#: src/i18n/interpolation.md:94 src/i18n/interpolation.md:96
+msgid "one/few/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:94
+msgid "Czech, Slovak"
+msgstr ""
+
+#: src/i18n/interpolation.md:95
+msgid "zero/one/two/few/many/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:95
+msgid "Arabic"
+msgstr ""
+
+#: src/i18n/interpolation.md:96
+msgid "Romanian, Lithuanian"
+msgstr ""
+
+#: src/i18n/interpolation.md:97
+msgid "zero/one/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:97
+msgid "Latvian"
+msgstr ""
+
+#: src/i18n/interpolation.md:103
+msgid "`.other` form missing for any locale"
+msgstr ""
+
+#: src/i18n/interpolation.md:104
+msgid "Required CLDR category missing (e.g., `.few` for Polish)"
+msgstr ""
+
+#: src/i18n/interpolation.md:105
+msgid "Extra category locale doesn't use (e.g., `.few` for English)"
+msgstr ""
+
+#: src/i18n/interpolation.md:105
+msgid "Warning"
+msgstr ""
+
+#: src/i18n/interpolation.md:107
+msgid "Explicit API for Non-UI Strings"
+msgstr ""
+
+#: src/i18n/interpolation.md:109
+msgid ""
+"For strings outside UI components (API responses, notifications, etc.), use "
+"`t()`:"
+msgstr ""
+
+#: src/i18n/interpolation.md:111
+msgid ""
+"```typescript\n"
+"// For strings outside UI components (API responses, notifications, …), use "
+"t():\n"
+"const message = t(\"Your order has been shipped.\")\n"
+"const welcome = t(\"Welcome back, {name}!\", { name: \"Alice\" })\n"
+"console.log(message, welcome)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:118
+msgid ""
+"This uses the same key lookup, validation, and interpolation as UI strings."
+msgstr ""
+
+#: src/i18n/formatting.md:1
+msgid "Locale-Aware Formatting"
+msgstr ""
+
+#: src/i18n/formatting.md:3
+msgid ""
+"Perry provides format wrapper functions that automatically format values "
+"according to the current locale. Import them from `perry/i18n`:"
+msgstr ""
+
+#: src/i18n/formatting.md:5
+msgid ""
+"```typescript\n"
+"// All format wrappers come from perry/i18n.\n"
+"// (The same `Currency`, `Percent`, … you'd pass into a Text(...) param "
+"object.)\n"
+"const price = Currency(23.10)\n"
+"const discount = Percent(0.15)\n"
+"const population = FormatNumber(1234567.89)\n"
+"const due = ShortDate(Date.now())\n"
+"const event = LongDate(Date.now())\n"
+"const at = FormatTime(Date.now())\n"
+"const code = Raw(12345)\n"
+"\n"
+"// Compose them with t() the same way you'd compose with Text(...):\n"
+"console.log(t(\"Total: {price}\", { price }))\n"
+"console.log(t(\"Discount: {rate}\", { rate: discount }))\n"
+"console.log(t(\"Population: {n}\", { n: population }))\n"
+"console.log(t(\"Due: {d}\", { d: due }))\n"
+"console.log(t(\"Event: {d}\", { d: event }))\n"
+"console.log(t(\"At: {t}\", { t: at }))\n"
+"console.log(t(\"Code: {amount}\", { amount: code }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:26
+msgid "Format Wrappers"
+msgstr ""
+
+#: src/i18n/formatting.md:28
+msgid "Currency"
+msgstr ""
+
+#: src/i18n/formatting.md:30
+msgid ""
+"Formats a number as currency with the locale's symbol, decimal separator, "
+"and symbol placement:"
+msgstr ""
+
+#: src/i18n/formatting.md:32
+msgid ""
+"```typescript\n"
+"// Currency: locale-appropriate symbol, separator, and placement.\n"
+"//   en: \"$23.10\"   de: \"23,10 €\"   ja: \"¥23.10\"\n"
+"const cur = Currency(23.10)\n"
+"console.log(t(\"Total: {price}\", { price: cur }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:39
+msgid ""
+"```text\n"
+"en: \"Total: $23.10\"\n"
+"de: \"Total: 23,10 €\"\n"
+"fr: \"Total: 23,10 €\"\n"
+"ja: \"Total: ¥23.10\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:46
+msgid "Percent"
+msgstr ""
+
+#: src/i18n/formatting.md:48
+msgid "Formats a decimal as a percentage (value is multiplied by 100):"
+msgstr ""
+
+#: src/i18n/formatting.md:50
+msgid ""
+"```typescript\n"
+"// Percent: input is a decimal (0.15 → 15 %). en omits the space; de/fr add "
+"it.\n"
+"const rate = Percent(0.15)\n"
+"console.log(t(\"Discount: {rate}\", { rate }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:56
+msgid ""
+"```text\n"
+"en: \"Discount: 15%\"\n"
+"de: \"Discount: 15 %\"\n"
+"fr: \"Discount: 15 %\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:62
+msgid "FormatNumber"
+msgstr ""
+
+#: src/i18n/formatting.md:64
+msgid "Formats a number with locale-appropriate grouping and decimal separators:"
+msgstr ""
+
+#: src/i18n/formatting.md:66
+msgid ""
+"```typescript\n"
+"// FormatNumber: locale-appropriate grouping + decimal separators.\n"
+"//   en: \"1,234,567.89\"   de: \"1.234.567,89\"   fr: \"1 234 567,89\"\n"
+"const n = FormatNumber(1234567.89)\n"
+"console.log(t(\"Population: {n}\", { n }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:73
+msgid ""
+"```text\n"
+"en: \"Population: 1,234,567.89\"\n"
+"de: \"Population: 1.234.567,89\"\n"
+"fr: \"Population: 1 234 567,89\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:79
+msgid "ShortDate / LongDate / FormatDate"
+msgstr ""
+
+#: src/i18n/formatting.md:81
+msgid "Formats a timestamp (milliseconds since epoch) as a date:"
+msgstr ""
+
+#: src/i18n/formatting.md:83
+msgid ""
+"```typescript\n"
+"// ShortDate / LongDate take a millisecond timestamp.\n"
+"const now = Date.now()\n"
+"const short = ShortDate(now)   // en: \"3/22/2026\"   de: \"22.03.2026\"\n"
+"const long = LongDate(now)     // en: \"March 22, 2026\"   de: \"22. März "
+"2026\"\n"
+"console.log(t(\"Due: {d}\", { d: short }))\n"
+"console.log(t(\"Event: {d}\", { d: long }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:92
+msgid ""
+"```text\n"
+"ShortDate\n"
+"  en: \"Due: 3/22/2026\"\n"
+"  de: \"Due: 22.03.2026\"\n"
+"  ja: \"Due: 2026/03/22\"\n"
+"\n"
+"LongDate\n"
+"  en: \"Event: March 22, 2026\"\n"
+"  de: \"Event: 22. März 2026\"\n"
+"  fr: \"Event: 22 mars 2026\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:104
+msgid "FormatTime"
+msgstr ""
+
+#: src/i18n/formatting.md:106
+msgid "Formats a timestamp as time (12h vs 24h based on locale):"
+msgstr ""
+
+#: src/i18n/formatting.md:108
+msgid ""
+"```typescript\n"
+"// FormatTime: 12h vs 24h based on the active locale.\n"
+"const ts = Date.now()\n"
+"const formatted = FormatTime(ts)\n"
+"console.log(t(\"At: {t}\", { t: formatted }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:115
+msgid ""
+"```text\n"
+"en: \"At: 3:45 PM\"\n"
+"de: \"At: 15:45\"\n"
+"fr: \"At: 15:45\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:121
+msgid "Raw"
+msgstr ""
+
+#: src/i18n/formatting.md:123
+msgid ""
+"Pass-through — prevents any automatic formatting. Use when a parameter name "
+"might trigger auto-formatting but you want the raw value:"
+msgstr ""
+
+#: src/i18n/formatting.md:125
+msgid ""
+"```typescript\n"
+"// Raw is a pass-through — prevents auto-formatting when the param name\n"
+"// might otherwise trigger it.\n"
+"const orderCode = Raw(12345)\n"
+"console.log(t(\"Code: {amount}\", { amount: orderCode }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:132
+msgid "All locales: `\"Code: 12345\"` (no currency formatting despite the name)."
+msgstr ""
+
+#: src/i18n/formatting.md:134
+msgid "Locale-Specific Formatting Rules"
+msgstr ""
+
+#: src/i18n/formatting.md:136
+msgid "Perry includes hand-rolled formatting rules for 25+ locales:"
+msgstr ""
+
+#: src/i18n/formatting.md:138
+msgid "Example Locales"
+msgstr ""
+
+#: src/i18n/formatting.md:140
+msgid "Decimal: `.` / Thousands: `,`"
+msgstr ""
+
+#: src/i18n/formatting.md:140 src/i18n/formatting.md:144
+msgid "en, ja, zh, ko"
+msgstr ""
+
+#: src/i18n/formatting.md:141
+msgid "Decimal: `,` / Thousands: `.`"
+msgstr ""
+
+#: src/i18n/formatting.md:141
+msgid "de, nl, tr, es, it, pt"
+msgstr ""
+
+#: src/i18n/formatting.md:142
+msgid "Decimal: `,` / Thousands: ` ` (narrow space)"
+msgstr ""
+
+#: src/i18n/formatting.md:142
+msgid "fr"
+msgstr ""
+
+#: src/i18n/formatting.md:143
+msgid "Decimal: `,` / Thousands: ` ` (non-breaking space)"
+msgstr ""
+
+#: src/i18n/formatting.md:143
+msgid "ru, uk, pl, sv, da, no, fi"
+msgstr ""
+
+#: src/i18n/formatting.md:144
+msgid "Currency before number: `$23.10`"
+msgstr ""
+
+#: src/i18n/formatting.md:145
+msgid "Currency after number: `23,10 €`"
+msgstr ""
+
+#: src/i18n/formatting.md:145
+msgid "de, fr, es, it, ru"
+msgstr ""
+
+#: src/i18n/formatting.md:146
+msgid "Percent with space: `42 %`"
+msgstr ""
+
+#: src/i18n/formatting.md:146 src/i18n/formatting.md:149
+msgid "de, fr, es, ru"
+msgstr ""
+
+#: src/i18n/formatting.md:147
+msgid "Percent without space: `42%`"
+msgstr ""
+
+#: src/i18n/formatting.md:147
+msgid "en, ja, zh"
+msgstr ""
+
+#: src/i18n/formatting.md:148
+msgid "Date order: M/D/Y"
+msgstr ""
+
+#: src/i18n/formatting.md:148 src/i18n/formatting.md:152
+msgid "en"
+msgstr ""
+
+#: src/i18n/formatting.md:149
+msgid "Date order: D.M.Y"
+msgstr ""
+
+#: src/i18n/formatting.md:150
+msgid "Date order: Y/M/D"
+msgstr ""
+
+#: src/i18n/formatting.md:150
+msgid "ja, zh, ko, sv"
+msgstr ""
+
+#: src/i18n/formatting.md:151
+msgid "24-hour time"
+msgstr ""
+
+#: src/i18n/formatting.md:151
+msgid "de, fr, es, ja, zh, ru (most)"
+msgstr ""
+
+#: src/i18n/formatting.md:152
+msgid "12-hour time (AM/PM)"
+msgstr ""
+
+#: src/i18n/formatting.md:154
+msgid "Currency Configuration"
+msgstr ""
+
+#: src/i18n/formatting.md:156
+msgid "Configure default currency codes per locale in `perry.toml`:"
+msgstr ""
+
+#: src/i18n/formatting.md:158
+msgid ""
+"```toml\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\", \"fr\"]\n"
+"default_locale = \"en\"\n"
+"\n"
+"[i18n.currencies]\n"
+"en = \"USD\"\n"
+"de = \"EUR\"\n"
+"fr = \"EUR\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:169
+msgid ""
+"When `Currency(value)` is called, the locale's configured currency code "
+"determines the symbol and formatting rules."
+msgstr ""
+
+#: src/i18n/cli.md:1
+msgid "i18n CLI Tools"
+msgstr ""
+
+#: src/i18n/cli.md:3 src/cli/commands.md:308
+msgid "`perry i18n extract`"
+msgstr ""
+
+#: src/i18n/cli.md:5
+msgid ""
+"Scans your TypeScript source files for localizable strings and generates or "
+"updates locale JSON files."
+msgstr ""
+
+#: src/i18n/cli.md:11
+msgid "What It Does"
+msgstr ""
+
+#: src/i18n/cli.md:13
+msgid "Recursively scans all `.ts` and `.tsx` files in the source directory"
+msgstr ""
+
+#: src/i18n/cli.md:14
+msgid ""
+"Detects string literals in UI component calls: `Button(\"...\")`, "
+"`Text(\"...\")`, `Label(\"...\")`, etc."
+msgstr ""
+
+#: src/i18n/cli.md:15
+msgid "Also detects `t(\"...\")` calls from `perry/i18n`"
+msgstr ""
+
+#: src/i18n/cli.md:16
+msgid "Creates `locales/` directory if it doesn't exist"
+msgstr ""
+
+#: src/i18n/cli.md:17
+msgid "For each configured locale, creates or updates a JSON file:"
+msgstr ""
+
+#: src/i18n/cli.md:18
+msgid "**Default locale**: New keys are pre-filled with themselves as values"
+msgstr ""
+
+#: src/i18n/cli.md:19
+msgid ""
+"**Non-default locales**: New keys are added with empty string values "
+"(indicating \"needs translation\")"
+msgstr ""
+
+#: src/i18n/cli.md:21
+msgid "Example Output"
+msgstr ""
+
+#: src/i18n/cli.md:32
+msgid "Workflow"
+msgstr ""
+
+#: src/i18n/cli.md:34
+msgid "Typical translation workflow:"
+msgstr ""
+
+#: src/i18n/cli.md:37
+msgid "# 1. Write code with English strings\n"
+msgstr ""
+
+#: src/i18n/cli.md:39
+msgid "# 2. Extract strings to locale files\n"
+msgstr ""
+
+#: src/i18n/cli.md:42
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
+msgstr ""
+
+#: src/i18n/cli.md:44
+msgid "# 4. Build — Perry validates everything\n"
+msgstr ""
+
+#: src/i18n/cli.md:49
+msgid "Detected Patterns"
+msgstr ""
+
+#: src/i18n/cli.md:51
+msgid "The scanner detects these UI component patterns:"
+msgstr ""
+
+#: src/i18n/cli.md:53
+msgid "`Button(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:54
+msgid "`Text(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:55
+msgid "`Label(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:56
+msgid "`TextField(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:57
+msgid "`TextArea(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:58
+msgid "`Tab(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:59
+msgid "`NavigationTitle(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:60
+msgid "`SectionHeader(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:61
+msgid "`SecureField(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:62
+msgid "`Alert(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:63
+msgid "`t(\"string\")` (explicit i18n API)"
+msgstr ""
+
+#: src/i18n/cli.md:65
+msgid ""
+"Both double-quoted and single-quoted strings are supported. Escaped quotes "
+"are handled correctly."
+msgstr ""
+
+#: src/i18n/cli.md:67
+msgid "Build Output"
+msgstr ""
+
+#: src/i18n/cli.md:69
+msgid "During compilation, Perry reports i18n status:"
+msgstr ""
+
+#: src/i18n/cli.md:71
+msgid ""
+"```\n"
+"  i18n: 2 locale(s) [en, de], default: en\n"
+"    Loaded locales/en.json (12 keys)\n"
+"    Loaded locales/de.json (12 keys)\n"
+"  i18n: 12 localizable string(s) detected\n"
+"  i18n warning: Missing translation for key \"Settings\" in locale \"de\"\n"
+"  i18n warning: Unused i18n key \"Old Label\" in locale \"en\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/cli.md:80
+msgid "Key Registry"
+msgstr ""
+
+#: src/i18n/cli.md:82
+msgid "Perry maintains a `.perry/i18n-keys.json` file, updated on every build:"
+msgstr ""
+
+#: src/i18n/cli.md:86
+msgid "\"keys\""
+msgstr ""
+
+#: src/i18n/cli.md:87 src/i18n/cli.md:88 src/i18n/cli.md:89
+msgid "\"key\""
+msgstr ""
+
+#: src/i18n/cli.md:87 src/i18n/cli.md:88 src/i18n/cli.md:89
+msgid "\"string_idx\""
+msgstr ""
+
+#: src/i18n/cli.md:89
+msgid "\"You have {count} items\""
+msgstr ""
+
+#: src/i18n/cli.md:94
+msgid ""
+"This file serves as the source of truth for what strings exist in the "
+"codebase."
+msgstr ""
+
+#: src/updater/overview.md:3
+msgid ""
+"Ship updates to your Perry desktop app without rolling your own download + "
+"replace + relaunch flow. Two modules cooperate:"
+msgstr ""
+
+#: src/updater/overview.md:6
+msgid ""
+"**`@perry/updater`** — high-level wrapper. The 90% case: manifest fetch, "
+"semver compare, download, verify, install, relaunch, crash-loop rollback."
+msgstr ""
+
+#: src/updater/overview.md:8
+msgid ""
+"**`perry/updater`** — ambient primitives the wrapper is built on. Reach for "
+"these only when you need a custom flow (multi-channel rollouts, your own "
+"progress UI, an integration with an external supervisor)."
+msgstr ""
+
+#: src/updater/overview.md:12
+msgid ""
+"The trust model and wire format follow [Tauri's "
+"updater](https://v2.tauri.app/plugin/updater/): JSON manifest over HTTPS, "
+"SHA-256 + Ed25519 signature over the digest, atomic binary replace with a "
+"`.prev` backup, detached relaunch. Every snippet below is excerpted from "
+"[`docs/examples/updater/snippets.ts`](../../examples/updater/snippets.ts) — "
+"CI compile-links it on every PR."
+msgstr ""
+
+#: src/updater/overview.md:19
+msgid ""
+"**Desktop only.** iOS / TestFlight, Android Play Store, and sideloaded APKs "
+"own the install pipeline at the OS level — replacing your own binary at "
+"runtime is structurally impossible there. The crate still compiles on mobile "
+"targets so cross-platform code doesn't need `#ifdef`s, but the install path "
+"is a no-op. Gate updater code with `process.platform` if your app ships "
+"everywhere."
+msgstr ""
+
+#: src/updater/overview.md:26 src/system/media.md:8
+#: src/plugins/appstore-review.md:11
+msgid "Quick start"
+msgstr ""
+
+#: src/updater/overview.md:28
+msgid ""
+"```typescript\n"
+"// import { checkForUpdate, initUpdater, markHealthy } from "
+"\"@perry/updater\"\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:32
+msgid ""
+"Drop a \"Check for updates\" handler somewhere in your menu or a periodic "
+"timer. `checkForUpdate` returns `null` when up to date or when the manifest "
+"has no entry for the current platform."
+msgstr ""
+
+#: src/updater/overview.md:36
+msgid ""
+"```typescript\n"
+"// Pseudocode using @perry/updater's wrapper. Drop into a \"Check for "
+"updates\"\n"
+"// menu item or a periodic timer. The manifest URL must serve over HTTPS.\n"
+"//\n"
+"// const update = await checkForUpdate({\n"
+"//     manifestUrl: \"https://updates.example.com/myapp.json\",\n"
+"//     publicKey: \"BASE64_ED25519_PUBKEY\",\n"
+"//     currentVersion: \"1.4.0\",\n"
+"// })\n"
+"//\n"
+"// if (update !== null) {\n"
+"//     console.log(`v${update.version} is available`)\n"
+"//     console.log(update.notes)\n"
+"//\n"
+"//     await update.download((downloaded, total) => {\n"
+"//         const pct = Math.round((downloaded / total) * 100)\n"
+"//         console.log(`downloading: ${pct}%`)\n"
+"//     })\n"
+"//\n"
+"//     await update.installAndRelaunch()  // never returns — process.exit "
+"inside\n"
+"// }\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:59
+msgid ""
+"Call `initUpdater()` once near the top of `main()`. It handles boot-time "
+"crash-loop detection: if the new binary you just installed crashes during "
+"boot more than `crashLoopThreshold` times, the wrapper restores the previous "
+"version and exits so the OS / launcher restarts you on the rollback."
+msgstr ""
+
+#: src/updater/overview.md:64
+msgid ""
+"```typescript\n"
+"// Boot-time: detect a crash-looping new install and roll back. Call this\n"
+"// near the top of `main()`, right after process initialization.\n"
+"//\n"
+"// await initUpdater({\n"
+"//     autoRollback:       true,    // default\n"
+"//     healthCheckMs:      60_000,  // clear sentinel after this many ms "
+"alive\n"
+"//     crashLoopThreshold: 2,       // restarts before rollback fires\n"
+"// })\n"
+"//\n"
+"// // Optional: tell the updater explicitly that this version is healthy\n"
+"// // (e.g. after a successful login or migration finished).\n"
+"// // markHealthy()\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:79
+msgid "Manifest"
+msgstr ""
+
+#: src/updater/overview.md:81
+msgid ""
+"Serve a single JSON file over HTTPS. One entry per `<os>-<arch>` you publish "
+"for; clients ignore entries that don't match their platform."
+msgstr ""
+
+#: src/updater/overview.md:84
+msgid ""
+"```typescript\n"
+"// The manifest is a single JSON file you serve over HTTPS. Each platform\n"
+"// triple is `<os>-<arch>` (darwin-aarch64, darwin-x86_64, windows-x86_64,\n"
+"// linux-x86_64, linux-aarch64). The wrapper picks the entry matching the\n"
+"// running host and ignores the rest.\n"
+"//\n"
+"// {\n"
+"//   \"schemaVersion\": 1,\n"
+"//   \"version\": \"1.4.0\",\n"
+"//   \"pubDate\": \"2026-04-27T10:00:00Z\",\n"
+"//   \"notes\": \"Bug fixes and performance improvements\",\n"
+"//   \"platforms\": {\n"
+"//     \"darwin-aarch64\": {\n"
+"//       \"url\":       "
+"\"https://example.com/app-1.4.0-darwin-aarch64.bin\",\n"
+"//       \"sha256\":    \"0123456789abcdef...\",\n"
+"//       \"signature\": \"base64sig==\",\n"
+"//       \"size\":      12345678\n"
+"//     }\n"
+"//   }\n"
+"// }\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:106
+msgid "Meaning"
+msgstr ""
+
+#: src/updater/overview.md:108
+msgid "`schemaVersion`"
+msgstr ""
+
+#: src/updater/overview.md:108
+msgid ""
+"`1` (legacy, digest-only signature) or `2` (recommended — version-bound "
+"signature; see below)."
+msgstr ""
+
+#: src/updater/overview.md:109 src/cli/perry-toml.md:117
+msgid "`version`"
+msgstr ""
+
+#: src/updater/overview.md:109
+msgid "Semver string of the offered version (e.g. `\"1.4.0\"`)."
+msgstr ""
+
+#: src/updater/overview.md:110
+msgid "`pubDate`"
+msgstr ""
+
+#: src/updater/overview.md:110
+msgid "ISO-8601 timestamp the build was published — surfaced as metadata."
+msgstr ""
+
+#: src/updater/overview.md:111
+msgid "`notes`"
+msgstr ""
+
+#: src/updater/overview.md:111
+msgid "Markdown release notes shown to the user."
+msgstr ""
+
+#: src/updater/overview.md:112
+msgid "`platforms.<os>-<arch>.url`"
+msgstr ""
+
+#: src/updater/overview.md:112
+msgid "Direct download URL (HTTPS)."
+msgstr ""
+
+#: src/updater/overview.md:113
+msgid "`platforms.<os>-<arch>.sha256`"
+msgstr ""
+
+#: src/updater/overview.md:113
+msgid "Lowercase hex SHA-256 of the binary."
+msgstr ""
+
+#: src/updater/overview.md:114
+msgid "`platforms.<os>-<arch>.signature`"
+msgstr ""
+
+#: src/updater/overview.md:114
+msgid ""
+"Base64 Ed25519 signature. v1: over the raw 32-byte digest. v2: over `digest "
+"\\|\\| version_utf8`."
+msgstr ""
+
+#: src/updater/overview.md:115
+msgid "`platforms.<os>-<arch>.size`"
+msgstr ""
+
+#: src/updater/overview.md:115
+msgid "Byte length of the binary — used for progress reporting."
+msgstr ""
+
+#: src/updater/overview.md:117
+msgid "Platform keys are canonical Rust-style triples:"
+msgstr ""
+
+#: src/updater/overview.md:119
+msgid "Host"
+msgstr ""
+
+#: src/updater/overview.md:119
+msgid "Triple"
+msgstr ""
+
+#: src/updater/overview.md:121
+msgid "Apple Silicon mac"
+msgstr ""
+
+#: src/updater/overview.md:121
+msgid "`darwin-aarch64`"
+msgstr ""
+
+#: src/updater/overview.md:122
+msgid "Intel mac"
+msgstr ""
+
+#: src/updater/overview.md:122
+msgid "`darwin-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:123
+msgid "Windows 10/11 64-bit"
+msgstr ""
+
+#: src/updater/overview.md:123
+msgid "`windows-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:124
+msgid "Linux 64-bit"
+msgstr ""
+
+#: src/updater/overview.md:124
+msgid "`linux-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:125
+msgid "Linux ARM64"
+msgstr ""
+
+#: src/updater/overview.md:125
+msgid "`linux-aarch64`"
+msgstr ""
+
+#: src/updater/overview.md:127
+msgid "Trust model"
+msgstr ""
+
+#: src/updater/overview.md:129
+msgid "`schemaVersion: 2` (recommended) — version-bound signature"
+msgstr ""
+
+#: src/updater/overview.md:131
+msgid ""
+"The signed payload is `SHA256(binary) || version_utf8` — the 32-byte raw "
+"digest concatenated with the UTF-8 bytes of the version string. This binds "
+"the version into the signature, so an on-path attacker can't replay a "
+"previously-signed older binary as a \"new version\" by serving a manifest "
+"that pairs the old binary's URL + signature with a higher version number "
+"([\\#229](https://github.com/PerryTS/perry/issues/229))."
+msgstr ""
+
+#: src/updater/overview.md:138
+msgid "Sign side:"
+msgstr ""
+
+#: src/updater/overview.md:140
+msgid ""
+"```text\n"
+"payload = sha256(binary).digest() + version.encode(\"utf-8\")\n"
+"signature = ed25519_sign(secret_key, payload)  # 64-byte signature\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:145
+msgid "Verification on the client:"
+msgstr ""
+
+#: src/updater/overview.md:147
+msgid ""
+"SHA-256 the downloaded file. Reject if it doesn't match `manifest.sha256`."
+msgstr ""
+
+#: src/updater/overview.md:148
+msgid "Build the v2 payload (`digest || version_utf8`) using `manifest.version`."
+msgstr ""
+
+#: src/updater/overview.md:149
+msgid "Ed25519-verify the signature against the bundled public key."
+msgstr ""
+
+#: src/updater/overview.md:150
+msgid "Reject on any decode error, size mismatch, or signature failure."
+msgstr ""
+
+#: src/updater/overview.md:152
+msgid ""
+"If an attacker swaps the manifest's `version` field while keeping the old "
+"`signature`, step 3 fails because the signature was made over the _original_ "
+"version. If they swap both `version` and `signature` (using a "
+"previously-signed older binary), step 1 fails because `sha256` of the older "
+"binary doesn't match the rewritten higher-version label either — every "
+"plausible attack on the version metadata invalidates something."
+msgstr ""
+
+#: src/updater/overview.md:160
+msgid "`schemaVersion: 1` (legacy, digest-only)"
+msgstr ""
+
+#: src/updater/overview.md:162
+msgid ""
+"The signed payload is the raw 32-byte digest only. **This shape is "
+"vulnerable to old-binary replay** "
+"([\\#229](https://github.com/PerryTS/perry/issues/229)): an on-path attacker "
+"can serve a manifest claiming a higher version while pointing at a "
+"previously-signed older binary, and signature verification still passes "
+"because the version isn't bound into the signature. Existing v1 manifests "
+"stay supported by the client during migration; new deployments should use v2."
+msgstr ""
+
+#: src/updater/overview.md:170
+msgid "Migration"
+msgstr ""
+
+#: src/updater/overview.md:172
+msgid ""
+"`@perry/updater` v0.5.391+ accepts both `schemaVersion: 1` and "
+"`schemaVersion: 2`. Bumping your manifest from 1 → 2 requires:"
+msgstr ""
+
+#: src/updater/overview.md:175
+msgid ""
+"Update sign-side tooling to compute the new payload (`sha256(binary) + "
+"version.encode(\"utf-8\")`) and sign that."
+msgstr ""
+
+#: src/updater/overview.md:177
+msgid "Bump `schemaVersion` in the manifest from `1` to `2`."
+msgstr ""
+
+#: src/updater/overview.md:178
+msgid ""
+"Make sure all deployed clients are running a perry-updater version that "
+"knows about v2 BEFORE you publish a v2 manifest. Older clients reject "
+"`schemaVersion: 2` with an `unsupported manifest schemaVersion` error. "
+"(Plan: ship a perry-updater bump with v2 support to your users via a v1 "
+"manifest first; once they're on the v2-aware client, the next manifest can "
+"be v2.)"
+msgstr ""
+
+#: src/updater/overview.md:185
+msgid "Keypair"
+msgstr ""
+
+#: src/updater/overview.md:187
+msgid ""
+"You generate the keypair once and bake the public key into your app at build "
+"time; the secret key stays on a release-signing machine alongside the rest "
+"of your build artifacts. Compromise of the manifest server alone never lets "
+"an attacker push a binary your client will accept."
+msgstr ""
+
+#: src/updater/overview.md:192
+msgid "Sign-side CLI (v0.5.395+)"
+msgstr ""
+
+#: src/updater/overview.md:194
+msgid ""
+"`perry updater` ships three subcommands that produce v2-shape signatures "
+"without needing any custom tooling:"
+msgstr ""
+
+#: src/updater/overview.md:198
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
+msgstr ""
+
+#: src/updater/overview.md:201
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
+msgstr ""
+
+#: src/updater/overview.md:219
+msgid ""
+"Compose a final manifest by piping `sign` output through `jq` for each "
+"asset, then merging into the per-platform layout shown above. CI tip: pass "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so "
+"the secret can come from a repository secret without ever hitting the "
+"worker's filesystem."
+msgstr ""
+
+#: src/updater/overview.md:225
+msgid "Install + rollback flow"
+msgstr ""
+
+#: src/updater/overview.md:227
+msgid ""
+"```text\n"
+"manifest fetch  →  semver compare  →  download to <exe>.staged\n"
+"                                          ↓\n"
+"                                      sha256 verify  →  ed25519 verify\n"
+"                                          ↓\n"
+"                                      arm sentinel (state: \"armed\")\n"
+"                                          ↓\n"
+"                                      install:  rename <exe> → <exe>.prev\n"
+"                                                rename <exe>.staged → <exe>\n"
+"                                                chmod +x   (Unix only)\n"
+"                                          ↓\n"
+"                                      detached relaunch  →  process.exit(0)\n"
+"\n"
+"next boot  →  initUpdater() reads sentinel\n"
+"                  ├── healthCheckMs alive  → clearSentinel  (success)\n"
+"                  ├── graceful exit         → clearSentinel  (success)\n"
+"                  └── restartCount ≥ N      → performRollback + exit\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:246
+msgid ""
+"`installUpdate` is atomic where the OS lets us be: POSIX `rename(2)` on the "
+"same filesystem, NTFS rename-while-open (the PE loader opens with "
+"`FILE_SHARE_DELETE` so Windows tolerates this since Vista), and Linux's "
+"mmap'd-inode-stays-alive semantics. If the staging directory ends up on a "
+"different filesystem (a separate mount for `/tmp`, for instance) the rename "
+"falls back to copy + remove, which has a small non-atomic window."
+msgstr ""
+
+#: src/updater/overview.md:253
+msgid "The sentinel is a JSON file at a per-OS user-writable path:"
+msgstr ""
+
+#: src/updater/overview.md:255
+msgid "Default location"
+msgstr ""
+
+#: src/updater/overview.md:257
+msgid "`~/Library/Application Support/<app>/updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:258
+msgid "`%LOCALAPPDATA%\\<app>\\updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:259
+msgid "`$XDG_STATE_HOME/<app>/updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:261
+msgid ""
+"`<app>` comes from the `PERRY_APP_ID` environment variable, falling back to "
+"the basename of the running exe. **Set `PERRY_APP_ID` in your launch "
+"environment** so the sentinel path stays stable across rename / relocation "
+"of the binary."
+msgstr ""
+
+#: src/updater/overview.md:266
+msgid "Low-level primitives"
+msgstr ""
+
+#: src/updater/overview.md:268
+msgid ""
+"Use these when the high-level wrapper doesn't fit — custom progress UI, a "
+"multi-channel manifest, an external supervisor that handles restarts, etc."
+msgstr ""
+
+#: src/updater/overview.md:271
+msgid ""
+"```typescript\n"
+"import {\n"
+"    compareVersions,\n"
+"    verifyHash,\n"
+"    verifySignature,\n"
+"    computeFileSha256,\n"
+"    writeSentinel,\n"
+"    readSentinel,\n"
+"    clearSentinel,\n"
+"    getExePath,\n"
+"    getBackupPath,\n"
+"    getSentinelPath,\n"
+"    installUpdate,\n"
+"    performRollback,\n"
+"    relaunch,\n"
+"} from \"perry/updater\"\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:289
+msgid "`compareVersions(current, candidate)`"
+msgstr ""
+
+#: src/updater/overview.md:291
+msgid ""
+"Returns `-1` (update available), `0` (equal), `1` (downgrade — never "
+"offered), or `-2` (parse error). Prerelease tags handled per the semver spec."
+msgstr ""
+
+#: src/updater/overview.md:294
+msgid ""
+"```typescript\n"
+"// Returns -1 (current < candidate, update available), 0 (equal),\n"
+"// 1 (current > candidate, never offered as an update), -2 (parse error).\n"
+"const cmp = compareVersions(\"1.4.0\", \"1.4.1\")\n"
+"if (cmp === -1) {\n"
+"    console.log(\"update available\")\n"
+"} else if (cmp === 0) {\n"
+"    console.log(\"up to date\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:305
+msgid "`verifyHash` / `verifySignature` / `computeFileSha256`"
+msgstr ""
+
+#: src/updater/overview.md:307
+msgid ""
+"```typescript\n"
+"// SHA-256 + Ed25519 verification of a binary on disk. The signed payload "
+"is\n"
+"// the *raw 32-byte SHA-256 digest* — not the hex string and not the file\n"
+"// bytes themselves. Sign side: `sha256(file) | ed25519_sign(secret_key)`.\n"
+"const stagedPath = getExePath() + \".staged\"\n"
+"const expectedHex = \"0123456789abcdef...\" // from your manifest\n"
+"const sigB64 = \"...base64...\"             // 64-byte signature, base64\n"
+"const pubB64 = \"...base64...\"             // 32-byte public key, base64\n"
+"\n"
+"if (verifyHash(stagedPath, expectedHex) !== 1) {\n"
+"    const actual = computeFileSha256(stagedPath)\n"
+"    console.error(`hash mismatch — expected ${expectedHex}, got ${actual}`)\n"
+"}\n"
+"if (verifySignature(stagedPath, sigB64, pubB64) !== 1) {\n"
+"    console.error(\"signature verification failed\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:325
+msgid ""
+"`verifyHash` and `verifySignature` return `1` on success, `0` on any failure "
+"(file missing, decode error, mismatch). `computeFileSha256` returns the hex "
+"digest as a string, or `\"\"` on failure — useful for logging the _actual_ "
+"hash when a `verifyHash` mismatch fires."
+msgstr ""
+
+#: src/updater/overview.md:330
+msgid "`installUpdate` / `performRollback` / `relaunch`"
+msgstr ""
+
+#: src/updater/overview.md:332
+msgid ""
+"```typescript\n"
+"// `installUpdate` atomically replaces `targetPath` with `stagedPath`,\n"
+"// keeping the displaced version at `<target>.prev` for rollback.\n"
+"const target = getExePath()\n"
+"const staged = target + \".staged\"\n"
+"\n"
+"if (installUpdate(staged, target) !== 1) {\n"
+"    console.error(\"install failed\")\n"
+"} else {\n"
+"    const pid = relaunch(target)\n"
+"    if (pid < 0) {\n"
+"        console.error(\"relaunch failed; restart manually\")\n"
+"    } else {\n"
+"        // Detached child is now running the new binary — get out of its "
+"way.\n"
+"        process.exit(0)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:351
+msgid ""
+"```typescript\n"
+"// `performRollback` restores `<target>.prev` over `target` and moves the\n"
+"// current (likely-broken) target to `<target>.broken` as a safety net.\n"
+"if (performRollback(getExePath()) !== 1) {\n"
+"    console.error(\"no backup to roll back to\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:359
+msgid ""
+"`relaunch` returns the child PID, or `-1` on failure. The new process is "
+"fully detached (`setsid` on Unix, `DETACHED_PROCESS | "
+"CREATE_NEW_PROCESS_GROUP` on Windows) so closing the current process doesn't "
+"take it down."
+msgstr ""
+
+#: src/updater/overview.md:363
+msgid "Path resolution"
+msgstr ""
+
+#: src/updater/overview.md:365
+msgid ""
+"```typescript\n"
+"// Resolved per platform. macOS walks up to the surrounding `.app` bundle;\n"
+"// Linux honors $APPIMAGE; Windows / bare ELF returns the canonical exe.\n"
+"console.log(\"running exe   :\", getExePath())\n"
+"console.log(\"backup target :\", getBackupPath())\n"
+"// Sentinel path is keyed off PERRY_APP_ID — set this env var so the path\n"
+"// stays stable across rename/relocation of the binary.\n"
+"console.log(\"sentinel path :\", getSentinelPath())\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:375
+msgid "`getExePath()` accounts for platform quirks:"
+msgstr ""
+
+#: src/updater/overview.md:377
+msgid ""
+"**macOS**: walks up to the surrounding `.app` bundle if applicable — the "
+"`.app` directory is the codesign unit, so that's what you replace."
+msgstr ""
+
+#: src/updater/overview.md:379
+msgid ""
+"**Linux**: honors `$APPIMAGE` when set. The AppImage runtime points "
+"`current_exe()` inside a read-only squashfs mount; the real target to "
+"replace is the AppImage file itself."
+msgstr ""
+
+#: src/updater/overview.md:382
+msgid "**Windows / bare ELF / bare Mach-O**: returns the canonicalized exe path."
+msgstr ""
+
+#: src/updater/overview.md:384
+msgid "Sentinel"
+msgstr ""
+
+#: src/updater/overview.md:386
+msgid ""
+"```typescript\n"
+"// Low-level sentinel API. Most apps use `initUpdater()` from "
+"@perry/updater\n"
+"// instead of touching this directly, but it's here when you need it "
+"(custom\n"
+"// rollback policies, multi-process apps, integration with another "
+"supervisor).\n"
+"const sentinelPath = getSentinelPath()\n"
+"writeSentinel(sentinelPath, JSON.stringify({ state: \"armed\", restartCount: "
+"0 }))\n"
+"const raw = readSentinel(sentinelPath)\n"
+"if (raw) {\n"
+"    const state = JSON.parse(raw) as { state: string; restartCount: number "
+"}\n"
+"    if (state.restartCount >= 2) {\n"
+"        // looks like a crash loop — recover or roll back\n"
+"        clearSentinel(sentinelPath)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:402
+msgid ""
+"`writeSentinel` is atomic (tmp file + rename), creates the parent directory "
+"if needed, and returns `1` on success / `0` on any IO error. `clearSentinel` "
+"is idempotent — returns `1` whether the file existed or not."
+msgstr ""
+
+#: src/updater/overview.md:406
+msgid "What's not here (yet)"
+msgstr ""
+
+#: src/updater/overview.md:408
+msgid ""
+"**UI primitives** — a \"Restart now\" modal with `ProgressView` belongs "
+"inside `perry/ui` proper rather than the updater package. Tracked as a "
+"follow-up."
+msgstr ""
+
+#: src/updater/overview.md:411
+msgid ""
+"**Privileged install** for system-wide locations (`/Applications`, `Program "
+"Files`). The current install path only handles user-writable locations "
+"(`~/Applications`, `~/.local/bin`, `%LOCALAPPDATA%`). UAC / `SMJobBless` is "
+"a separate concern."
+msgstr ""
+
+#: src/updater/overview.md:415
+msgid ""
+"**Delta updates** (bsdiff), **multi-channel** (stable / beta), **staged "
+"rollouts**."
+msgstr ""
+
+#: src/updater/overview.md:417
+msgid ""
+"**Notarization / code-signing** during install. Binaries are expected to "
+"arrive already signed; the updater doesn't try to be a notarization tool."
+msgstr ""
+
+#: src/updater/overview.md:420
+msgid "Testing your update flow"
+msgstr ""
+
+#: src/updater/overview.md:422
+msgid ""
+"The crate ships smoke-test scripts that exercise verify → install → relaunch "
+"end-to-end against a real Perry binary:"
+msgstr ""
+
+#: src/updater/overview.md:425
+msgid "**Unix**: `scripts/smoke_updater.sh`"
+msgstr ""
+
+#: src/updater/overview.md:426
+msgid "**Windows**: `scripts/smoke_updater.ps1`"
+msgstr ""
+
+#: src/updater/overview.md:428
+msgid ""
+"Both spin up a tiny HTTP server, build a v1.0.0 binary that drives the "
+"update flow, build a v1.0.1 binary that proves it ran, and verify the "
+"relaunch handed off correctly. Run them locally before shipping a release "
+"that depends on the updater wiring."
+msgstr ""
+
+#: src/updater/overview.md:435
+msgid "[System APIs](../system/overview.md) — the rest of `perry/system`"
+msgstr ""
+
+#: src/updater/overview.md:436
+msgid ""
+"[HTTP & Networking](../stdlib/http.md) — `fetch()` is what the wrapper uses "
+"internally"
+msgstr ""
+
+#: src/updater/overview.md:438
+msgid ""
+"[Cryptography](../stdlib/crypto.md) — Ed25519 sign / verify primitives for "
+"tooling that builds the manifest"
+msgstr ""
+
+#: src/system/overview.md:1
+msgid "System APIs Overview"
+msgstr ""
+
+#: src/system/overview.md:3
+msgid ""
+"The `perry/system` module provides access to platform-native system "
+"features: preferences, secure storage, notifications, dark-mode detection, "
+"audio capture, and app introspection. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI "
+"links the file on every PR."
+msgstr ""
+
+#: src/system/overview.md:9
+msgid ""
+"```typescript\n"
+"// import {\n"
+"//     openURL, isDarkMode,\n"
+"//     preferencesGet, preferencesSet,\n"
+"//     keychainSave, keychainGet, keychainDelete,\n"
+"//     notificationSend,\n"
+"//     audioStart, audioStop, audioGetLevel, audioGetPeak, "
+"audioGetWaveform,\n"
+"// } from \"perry/system\"\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:19
+msgid "Available APIs"
+msgstr ""
+
+#: src/system/overview.md:23
+msgid "`openURL(url)`"
+msgstr ""
+
+#: src/system/overview.md:23
+msgid "Open URL in default browser/app"
+msgstr ""
+
+#: src/system/overview.md:23 src/system/overview.md:24
+#: src/system/overview.md:25 src/system/overview.md:26
+#: src/system/overview.md:27 src/system/overview.md:29
+#: src/system/overview.md:30 src/system/overview.md:31
+#: src/system/overview.md:32 src/system/overview.md:36
+#: src/system/overview.md:37 src/system/overview.md:38
+msgid "All"
+msgstr ""
+
+#: src/system/overview.md:24
+msgid "`isDarkMode()`"
+msgstr ""
+
+#: src/system/overview.md:24
+msgid "Check system dark mode"
+msgstr ""
+
+#: src/system/overview.md:25
+msgid "`getDeviceIdiom()`"
+msgstr ""
+
+#: src/system/overview.md:25
+msgid "`\"phone\"`, `\"pad\"`, `\"mac\"`, `\"tv\"`, …"
+msgstr ""
+
+#: src/system/overview.md:26
+msgid "`getDeviceModel()`"
+msgstr ""
+
+#: src/system/overview.md:26
+msgid "Device model identifier (e.g. `\"iPhone13,4\"`)"
+msgstr ""
+
+#: src/system/overview.md:27
+msgid "`preferencesSet(key, value)`"
+msgstr ""
+
+#: src/system/overview.md:27
+msgid "Store a preference (string or number)"
+msgstr ""
+
+#: src/system/overview.md:28
+msgid "`preferencesGet(key)`"
+msgstr ""
+
+#: src/system/overview.md:28
+msgid "Read a preference (returns \\`string"
+msgstr ""
+
+#: src/system/overview.md:29
+msgid "`keychainSave(key, value)`"
+msgstr ""
+
+#: src/system/overview.md:29
+msgid "Secure storage write"
+msgstr ""
+
+#: src/system/overview.md:30
+msgid "`keychainGet(key)`"
+msgstr ""
+
+#: src/system/overview.md:30
+msgid "Secure storage read"
+msgstr ""
+
+#: src/system/overview.md:31
+msgid "`keychainDelete(key)`"
+msgstr ""
+
+#: src/system/overview.md:31
+msgid "Secure storage remove"
+msgstr ""
+
+#: src/system/overview.md:32
+msgid "`notificationSend(title, body)`"
+msgstr ""
+
+#: src/system/overview.md:32
+msgid "Local notification"
+msgstr ""
+
+#: src/system/overview.md:33
+msgid "`notificationCancel(id)`"
+msgstr ""
+
+#: src/system/overview.md:33
+msgid "Cancel a scheduled notification"
+msgstr ""
+
+#: src/system/overview.md:33 src/system/overview.md:34
+msgid "Apple"
+msgstr ""
+
+#: src/system/overview.md:34
+msgid "`notificationOnTap(cb)`"
+msgstr ""
+
+#: src/system/overview.md:34
+msgid "Handle banner taps"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "`notificationRegisterRemote(cb)` / `notificationOnReceive(cb)`"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "Push (APNs)"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "iOS, macOS"
+msgstr ""
+
+#: src/system/overview.md:36
+msgid "`audioStart()` / `audioStop()`"
+msgstr ""
+
+#: src/system/overview.md:36
+msgid "Microphone capture"
+msgstr ""
+
+#: src/system/overview.md:37
+msgid "`audioGetLevel()` / `audioGetPeak()`"
+msgstr ""
+
+#: src/system/overview.md:37
+msgid "RMS / peak amplitude (`0..1`)"
+msgstr ""
+
+#: src/system/overview.md:38
+msgid "`audioGetWaveform(n)`"
+msgstr ""
+
+#: src/system/overview.md:38
+msgid "Recent waveform samples for visualization"
+msgstr ""
+
+#: src/system/overview.md:40
+msgid ""
+"**Clipboard** lives in `perry/ui` (not `perry/system`): import "
+"`clipboardRead` and `clipboardWrite` from there."
+msgstr ""
+
+#: src/system/overview.md:45 src/system/other.md:29
+msgid ""
+"```typescript\n"
+"if (isDarkMode()) {\n"
+"    console.log(\"Dark mode is active\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:51 src/system/preferences.md:14
+msgid ""
+"```typescript\n"
+"// Strings and numbers round-trip natively — no manual stringification "
+"needed.\n"
+"preferencesSet(\"theme\", \"dark\")\n"
+"preferencesSet(\"font-size\", 14)\n"
+"\n"
+"const theme = preferencesGet(\"theme\")        // string | number | "
+"undefined\n"
+"const fontSize = preferencesGet(\"font-size\") // → 14 (number)\n"
+"\n"
+"if (typeof theme === \"string\") {\n"
+"    console.log(`saved theme: ${theme}`)\n"
+"}\n"
+"if (typeof fontSize === \"number\") {\n"
+"    console.log(`saved font-size: ${fontSize}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:67 src/system/other.md:14
+msgid ""
+"```typescript\n"
+"openURL(\"https://example.com\")\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:73
+msgid "[Preferences](preferences.md)"
+msgstr ""
+
+#: src/system/overview.md:74
+msgid "[Keychain](keychain.md)"
+msgstr ""
+
+#: src/system/overview.md:75
+msgid "[Notifications](notifications.md)"
+msgstr ""
+
+#: src/system/overview.md:76
+msgid "[Audio Capture](audio.md)"
+msgstr ""
+
+#: src/system/overview.md:77
+msgid "[Other](other.md)"
+msgstr ""
+
+#: src/system/preferences.md:3
+msgid ""
+"Store and retrieve user preferences using the platform's native storage. "
+"Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI "
+"links it on every PR."
+msgstr ""
+
+#: src/system/preferences.md:10
+msgid ""
+"`preferencesSet(key, value)` accepts strings **or** numbers and round-trips "
+"them natively (NSUserDefaults / GSettings / Registry preserve the original "
+"type). `preferencesGet(key)` returns `string | number | undefined`:"
+msgstr ""
+
+#: src/system/preferences.md:30 src/system/keychain.md:21
+msgid "Platform Storage"
+msgstr ""
+
+#: src/system/preferences.md:32 src/system/keychain.md:23
+#: src/system/notifications.md:60 src/system/media.md:84
+msgid "Backend"
+msgstr ""
+
+#: src/system/preferences.md:34 src/system/preferences.md:35
+msgid "NSUserDefaults"
+msgstr ""
+
+#: src/system/preferences.md:36
+msgid "SharedPreferences"
+msgstr ""
+
+#: src/system/preferences.md:37
+msgid "Windows Registry"
+msgstr ""
+
+#: src/system/preferences.md:38
+msgid "GSettings / file-based"
+msgstr ""
+
+#: src/system/preferences.md:39
+msgid "localStorage"
+msgstr ""
+
+#: src/system/preferences.md:41
+msgid ""
+"Preferences persist across app launches. They are not encrypted — use "
+"[Keychain](keychain.md) for sensitive data."
+msgstr ""
+
+#: src/system/preferences.md:46 src/system/notifications.md:74
+msgid "[Keychain](keychain.md) — Secure storage"
+msgstr ""
+
+#: src/system/preferences.md:47 src/system/keychain.md:39
+#: src/system/notifications.md:76 src/system/audio.md:74
+#: src/system/media.md:245 src/system/other.md:70
+msgid "[Overview](overview.md) — All system APIs"
+msgstr ""
+
+#: src/system/keychain.md:3
+msgid ""
+"Securely store sensitive data like tokens, passwords, and API keys using the "
+"platform's secure storage. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI "
+"links it on every PR."
+msgstr ""
+
+#: src/system/keychain.md:10
+msgid ""
+"```typescript\n"
+"keychainSave(\"api_token\", \"sk-...\")\n"
+"const token = keychainGet(\"api_token\")\n"
+"keychainDelete(\"api_token\")\n"
+"console.log(`token length: ${token.length}`)\n"
+"```"
+msgstr ""
+
+#: src/system/keychain.md:17
+msgid ""
+"The free-function API is `keychainSave(key, value)`, `keychainGet(key)` "
+"(returns the stored string, or an empty string if the key isn't present), "
+"and `keychainDelete(key)`."
+msgstr ""
+
+#: src/system/keychain.md:25 src/system/keychain.md:26
+msgid "Security.framework (Keychain)"
+msgstr ""
+
+#: src/system/keychain.md:27
+msgid "Android Keystore"
+msgstr ""
+
+#: src/system/keychain.md:28
+msgid "Windows Credential Manager (CredWrite/CredRead/CredDelete)"
+msgstr ""
+
+#: src/system/keychain.md:29
+msgid "libsecret"
+msgstr ""
+
+#: src/system/keychain.md:30
+msgid "localStorage (not truly secure)"
+msgstr ""
+
+#: src/system/keychain.md:32
+msgid ""
+"**Web**: The web platform uses `localStorage`, which is not encrypted. For "
+"web apps handling sensitive data, consider server-side storage instead."
+msgstr ""
+
+#: src/system/keychain.md:37
+msgid "[Preferences](preferences.md) — Non-sensitive preferences"
+msgstr ""
+
+#: src/system/keychain.md:38
+msgid "[Notifications](notifications.md) — Local notifications"
+msgstr ""
+
+#: src/system/notifications.md:3
+msgid ""
+"Send local notifications using the platform's notification system. Every "
+"snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI "
+"links it on every PR."
+msgstr ""
+
+#: src/system/notifications.md:8
+msgid "Sending a notification"
+msgstr ""
+
+#: src/system/notifications.md:10
+msgid ""
+"```typescript\n"
+"notificationSend(\"Build complete\", \"All targets compiled in 4.2s.\")\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:14
+msgid "Reacting to a tap"
+msgstr ""
+
+#: src/system/notifications.md:16
+msgid ""
+"```typescript\n"
+"notificationOnTap((id: string, action?: string) => {\n"
+"    console.log(`tapped notification ${id}; action=${action ?? "
+"\"(default)\"}`)\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:22
+msgid ""
+"`action` is the action-button identifier when the user picks a button, or "
+"`undefined` for the default banner tap."
+msgstr ""
+
+#: src/system/notifications.md:25
+msgid "Cancelling a scheduled notification"
+msgstr ""
+
+#: src/system/notifications.md:27
+msgid ""
+"```typescript\n"
+"notificationCancel(\"daily-reminder\")\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:31
+msgid ""
+"`notificationCancel(id)` is a no-op if no scheduled notification with that "
+"id exists."
+msgstr ""
+
+#: src/system/notifications.md:34
+msgid "Push notifications (APNs / Firebase)"
+msgstr ""
+
+#: src/system/notifications.md:46
+msgid ""
+"`notificationRegisterRemote(cb)` fires once when the OS returns a device "
+"token — on Apple platforms the token is the canonical uppercase hex string "
+"APNs expects. `notificationOnReceive(cb)` runs whenever a remote payload "
+"arrives while the app is foregrounded; the payload is the APNs `aps` "
+"userInfo dictionary (or equivalent platform shape) converted to a plain "
+"object."
+msgstr ""
+
+#: src/system/notifications.md:52
+msgid ""
+"Requires the relevant platform capability (APNs entitlement on iOS/macOS, "
+"Firebase Messaging on Android — wired via JNI through "
+"`PerryFirebaseMessagingService`, see "
+"[\\#98](https://github.com/PerryTS/perry/issues/98)). No-op on platforms "
+"without a push pipeline (tvOS, visionOS, watchOS, GTK4, Windows, Web)."
+msgstr ""
+
+#: src/system/notifications.md:58
+msgid "Platform Implementation"
+msgstr ""
+
+#: src/system/notifications.md:62 src/system/notifications.md:63
+msgid "UNUserNotificationCenter"
+msgstr ""
+
+#: src/system/notifications.md:64
+msgid "NotificationManager"
+msgstr ""
+
+#: src/system/notifications.md:65
+msgid "Toast notifications"
+msgstr ""
+
+#: src/system/notifications.md:66
+msgid "GNotification"
+msgstr ""
+
+#: src/system/notifications.md:67
+msgid "Web Notification API"
+msgstr ""
+
+#: src/system/notifications.md:69
+msgid ""
+"**Permissions**: On macOS, iOS, and Web, the user may need to grant "
+"notification permissions. On first use, the system will prompt automatically."
+msgstr ""
+
+#: src/system/notifications.md:75
+msgid "[Other](other.md) — Additional system APIs"
+msgstr ""
+
+#: src/system/audio.md:3
+msgid ""
+"The `perry/system` module provides real-time audio capture from the device "
+"microphone, with A-weighted dB(A) level metering and waveform sampling — "
+"everything needed to build a sound meter, audio visualizer, or voice-level "
+"indicator. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI "
+"links it on every PR."
+msgstr ""
+
+#: src/system/audio.md:10
+msgid ""
+"```typescript\n"
+"const ok = audioStart() // 1 on success, 0 on failure\n"
+"if (ok === 1) {\n"
+"    const level = audioGetLevel()           // 0..1\n"
+"    const peak = audioGetPeak()             // 0..1\n"
+"    const waveform = audioGetWaveform(64)   // sample-count\n"
+"    console.log(`level=${level} peak=${peak} waveform=${waveform}`)\n"
+"    audioStop()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/audio.md:23
+msgid "`audioStart()`"
+msgstr ""
+
+#: src/system/audio.md:25
+msgid ""
+"Start capturing audio from the device microphone. Returns `1` on success, "
+"`0` on failure (permission denied, no microphone, etc.)."
+msgstr ""
+
+#: src/system/audio.md:28
+msgid ""
+"On platforms that require permission (iOS, Android, Web), the system "
+"permission dialog is shown automatically."
+msgstr ""
+
+#: src/system/audio.md:31
+msgid "`audioStop()`"
+msgstr ""
+
+#: src/system/audio.md:33
+msgid "Stop audio capture and release the microphone."
+msgstr ""
+
+#: src/system/audio.md:35
+msgid "`audioGetLevel()`"
+msgstr ""
+
+#: src/system/audio.md:37
+msgid ""
+"Get the current A-weighted sound level (a smoothed value with a 125 ms time "
+"constant). Typical ranges:"
+msgstr ""
+
+#: src/system/audio.md:40
+msgid "~30 dB — quiet room"
+msgstr ""
+
+#: src/system/audio.md:41
+msgid "~50 dB — normal conversation"
+msgstr ""
+
+#: src/system/audio.md:42
+msgid "~70 dB — busy street"
+msgstr ""
+
+#: src/system/audio.md:43
+msgid "~90 dB — loud music"
+msgstr ""
+
+#: src/system/audio.md:44
+msgid "~110+ dB — dangerously loud"
+msgstr ""
+
+#: src/system/audio.md:46
+msgid "`audioGetPeak()`"
+msgstr ""
+
+#: src/system/audio.md:48
+msgid ""
+"Get the current peak sample amplitude (`0.0`–`1.0`). Useful for simple level "
+"indicators without dB conversion."
+msgstr ""
+
+#: src/system/audio.md:51
+msgid "`audioGetWaveform(sampleCount)`"
+msgstr ""
+
+#: src/system/audio.md:53
+msgid ""
+"Get recent waveform samples for visualization. Pass the number of samples "
+"you want; the runtime returns the most recent N readings from its internal "
+"ring buffer. Useful for drawing waveform displays or level history charts."
+msgstr ""
+
+#: src/system/audio.md:57
+msgid "Platform Implementations"
+msgstr ""
+
+#: src/system/audio.md:59
+msgid "Audio Backend"
+msgstr ""
+
+#: src/system/audio.md:59
+msgid "Permissions"
+msgstr ""
+
+#: src/system/audio.md:61
+msgid "AVAudioEngine"
+msgstr ""
+
+#: src/system/audio.md:61
+msgid "Microphone permission dialog"
+msgstr ""
+
+#: src/system/audio.md:62
+msgid "AVAudioSession + AVAudioEngine"
+msgstr ""
+
+#: src/system/audio.md:62
+msgid "System permission dialog"
+msgstr ""
+
+#: src/system/audio.md:63
+msgid "AudioRecord (JNI)"
+msgstr ""
+
+#: src/system/audio.md:63
+msgid "RECORD_AUDIO permission"
+msgstr ""
+
+#: src/system/audio.md:64
+msgid "PulseAudio (libpulse-simple)"
+msgstr ""
+
+#: src/system/audio.md:64
+msgid "None (system-level)"
+msgstr ""
+
+#: src/system/audio.md:65
+msgid "WASAPI (shared mode)"
+msgstr ""
+
+#: src/system/audio.md:65
+msgid "None"
+msgstr ""
+
+#: src/system/audio.md:66
+msgid "getUserMedia + AnalyserNode"
+msgstr ""
+
+#: src/system/audio.md:66
+msgid "Browser permission dialog"
+msgstr ""
+
+#: src/system/audio.md:68
+msgid ""
+"All platforms capture at 48 kHz mono and apply the same A-weighting filter "
+"(IEC 61672 standard, 3 cascaded biquad sections)."
+msgstr ""
+
+#: src/system/audio.md:73
+msgid "[Camera](../ui/camera.md) — Live camera preview (iOS)"
+msgstr ""
+
+#: src/system/media.md:3
+msgid ""
+"The `perry/media` module provides streaming media playback — HTTP/HTTPS "
+"audio URLs (Subsonic, Icecast, plain MP3/AAC, HLS m3u8), `file://` paths, "
+"lock-screen / Now Playing metadata, and remote-command (Siri Remote / Touch "
+"Bar / Control Center) integration."
+msgstr ""
+
+#: src/system/media.md:10
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"  createPlayer,\n"
+"  play,\n"
+"  pause,\n"
+"  setVolume,\n"
+"  onStateChange,\n"
+"  onTimeUpdate,\n"
+"  setNowPlaying,\n"
+"} from \"perry/media\";\n"
+"\n"
+"const player = createPlayer(\"https://example.com/track.mp3\");\n"
+"if (player === 0) {\n"
+"  console.error(\"createPlayer failed\");\n"
+"} else {\n"
+"  setVolume(player, 0.8);\n"
+"  setNowPlaying(player, \"Track Title\", \"Artist\", \"Album\", \"\");\n"
+"\n"
+"  onStateChange(player, (state) => console.log(\"state:\", state));\n"
+"  onTimeUpdate(player, (cur, dur) => console.log(`${cur}/${dur}s`));\n"
+"\n"
+"  play(player); // begins (or resumes) once buffered\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/media.md:35
+msgid "API surface"
+msgstr ""
+
+#: src/system/media.md:37
+msgid "Returns"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "`createPlayer(url)`"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "handle (1+) or `0` on failure"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "HTTP/HTTPS or `file://`"
+msgstr ""
+
+#: src/system/media.md:40
+msgid "`play(handle)`"
+msgstr ""
+
+#: src/system/media.md:40 src/system/media.md:41 src/system/media.md:42
+#: src/system/media.md:43 src/system/media.md:44 src/system/media.md:45
+#: src/system/media.md:50 src/system/media.md:51 src/system/media.md:52
+#: src/system/media.md:53
+msgid "void"
+msgstr ""
+
+#: src/system/media.md:40
+msgid "Resumes if paused"
+msgstr ""
+
+#: src/system/media.md:41
+msgid "`pause(handle)`"
+msgstr ""
+
+#: src/system/media.md:41
+msgid "Position preserved"
+msgstr ""
+
+#: src/system/media.md:42
+msgid "`stop(handle)`"
+msgstr ""
+
+#: src/system/media.md:42
+msgid "Resets position to 0"
+msgstr ""
+
+#: src/system/media.md:43
+msgid "`seek(handle, seconds)`"
+msgstr ""
+
+#: src/system/media.md:44
+msgid "`setVolume(handle, volume)`"
+msgstr ""
+
+#: src/system/media.md:44
+msgid "0.0–1.0, clamped"
+msgstr ""
+
+#: src/system/media.md:45
+msgid "`setRate(handle, rate)`"
+msgstr ""
+
+#: src/system/media.md:45
+msgid "1.0 = normal; Apple supports 0.5–2.0"
+msgstr ""
+
+#: src/system/media.md:46
+msgid "`getCurrentTime(handle)`"
+msgstr ""
+
+#: src/system/media.md:46 src/system/media.md:47
+msgid "seconds"
+msgstr ""
+
+#: src/system/media.md:47
+msgid "`getDuration(handle)`"
+msgstr ""
+
+#: src/system/media.md:47
+msgid "`0` if live / loading"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "`getState(handle)`"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "`MediaState`"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "See states below"
+msgstr ""
+
+#: src/system/media.md:49
+msgid "`isPlaying(handle)`"
+msgstr ""
+
+#: src/system/media.md:50
+msgid "`onStateChange(h, cb)`"
+msgstr ""
+
+#: src/system/media.md:50
+msgid "Fires on every transition"
+msgstr ""
+
+#: src/system/media.md:51
+msgid "`onTimeUpdate(h, cb)`"
+msgstr ""
+
+#: src/system/media.md:51
+msgid "~10 Hz while playing"
+msgstr ""
+
+#: src/system/media.md:52
+msgid "`setNowPlaying(h, title, artist, album, artworkUrl)`"
+msgstr ""
+
+#: src/system/media.md:52
+msgid "All strings; pass `\"\"` for unknown"
+msgstr ""
+
+#: src/system/media.md:53
+msgid "`destroy(handle)`"
+msgstr ""
+
+#: src/system/media.md:53
+msgid "Frees resources"
+msgstr ""
+
+#: src/system/media.md:55
+msgid "States"
+msgstr ""
+
+#: src/system/media.md:57
+msgid "`MediaState` is one of:"
+msgstr ""
+
+#: src/system/media.md:59
+msgid "`idle` — never started"
+msgstr ""
+
+#: src/system/media.md:60
+msgid "`loading` — buffering / fetching headers"
+msgstr ""
+
+#: src/system/media.md:61
+msgid "`ready` — first chunk decoded, ready to `play()`"
+msgstr ""
+
+#: src/system/media.md:62
+msgid "`playing` — actively rendering"
+msgstr ""
+
+#: src/system/media.md:63
+msgid "`paused` — paused (position preserved)"
+msgstr ""
+
+#: src/system/media.md:64
+msgid "`ended` — reached end of stream"
+msgstr ""
+
+#: src/system/media.md:65
+msgid "`error` — irrecoverable failure (network, codec, …)"
+msgstr ""
+
+#: src/system/media.md:67
+msgid "`ended` reliability"
+msgstr ""
+
+#: src/system/media.md:69
+msgid ""
+"`ended` is fired both from the platform's native end-of-playback signal "
+"**and** from a `currentTime ≈ duration` fallback. Per [issue #351 "
+"discussion](https://github.com/PerryTS/perry/issues/351), the native event "
+"has been historically flaky on the web / Chromecast — the same "
+"belt-and-braces is cheap to apply on every backend so a `perry/media` "
+"consumer can rely on `ended` firing once per track."
+msgstr ""
+
+#: src/system/media.md:76
+msgid ""
+"The fallback engages only after `play()` has been called and `duration` is "
+"known (live streams report `+inf`, which sanitises to `0` and disables the "
+"fallback). Window: 0.25s before duration. The native signal sets the flag "
+"first when it works; the fallback sets the same flag on the polling tick if "
+"the signal hasn't arrived."
+msgstr ""
+
+#: src/system/media.md:82
+msgid "Platform implementations"
+msgstr ""
+
+#: src/system/media.md:86
+msgid "AVPlayer + MPNowPlayingInfoCenter + MPRemoteCommandCenter"
+msgstr ""
+
+#: src/system/media.md:86 src/system/media.md:87 src/system/media.md:89
+#: src/system/media.md:90 src/system/media.md:91
+msgid "**Implemented** + lock-screen"
+msgstr ""
+
+#: src/system/media.md:87 src/system/media.md:93
+msgid "AVPlayer + AVAudioSession Playback + UIImage artwork"
+msgstr ""
+
+#: src/system/media.md:88
+msgid "AVPlayer + Siri Remote play/pause/skip"
+msgstr ""
+
+#: src/system/media.md:88
+msgid "**Implemented** + remote"
+msgstr ""
+
+#: src/system/media.md:89
+msgid "AVPlayer + UIImage artwork"
+msgstr ""
+
+#: src/system/media.md:90
+msgid "`android.media.MediaPlayer` + `MediaSessionCompat` via JNI"
+msgstr ""
+
+#: src/system/media.md:91
+msgid "GTK4 / Linux"
+msgstr ""
+
+#: src/system/media.md:91
+msgid "GStreamer `playbin` element + MPRIS D-Bus"
+msgstr ""
+
+#: src/system/media.md:92
+msgid ""
+"`Windows.Media.Playback.MediaPlayer` (WinRT) + `SystemMediaTransportControls`"
+msgstr ""
+
+#: src/system/media.md:92
+msgid "**Implemented** + Now Playing"
+msgstr ""
+
+#: src/system/media.md:93
+msgid "**Implemented** + Now Playing complication"
+msgstr ""
+
+#: src/system/media.md:94
+msgid "HarmonyOS"
+msgstr ""
+
+#: src/system/media.md:94
+msgid "`@ohos.multimedia.media.AVPlayer` via napi"
+msgstr ""
+
+#: src/system/media.md:94
+msgid ""
+"**Implemented** (lock-screen via `@ohos.multimedia.avsession` is a follow-up)"
+msgstr ""
+
+#: src/system/media.md:95
+msgid "`<audio>` element + Media Session API"
+msgstr ""
+
+#: src/system/media.md:95
+msgid ""
+"**Implemented** (`--target web`; `setNowPlaying` populates "
+"`navigator.mediaSession.metadata` + wires play / pause / seekto / "
+"seekforward / seekbackward action handlers)"
+msgstr ""
+
+#: src/system/media.md:97
+msgid ""
+"Stub platforms link cleanly against the same FFI surface — code that imports "
+"`perry/media` compiles on every target. `createPlayer` returns `0` on a stub "
+"backend so `if (player === 0)` is the canonical \"feature not available "
+"here\" check."
+msgstr ""
+
+#: src/system/media.md:102
+msgid ""
+"On Linux, `setNowPlaying` exposes the player to the desktop via MPRIS "
+"(`org.mpris.MediaPlayer2.perry-<pid>` on the session bus). GNOME Shell, KDE "
+"Plasma, `playerctl`, and any Bluetooth-headphone media-key bridge that "
+"speaks MPRIS will see the metadata and route Play / Pause / PlayPause / Stop "
+"/ Seek / SetPosition back to the player. The MPRIS server is "
+"lazy-bootstrapped on the first `setNowPlaying` call so apps that don't need "
+"lock-screen integration don't pay the zbus startup cost. `Next` / `Previous` "
+"are no-ops (single-track playback model); playlists are an app-level concern."
+msgstr ""
+
+#: src/system/media.md:112
+msgid "Android — background playback"
+msgstr ""
+
+#: src/system/media.md:114
+msgid ""
+"Perry's Android backend wires `MediaSessionCompat` so the lock-screen tile, "
+"Bluetooth headset, Android Auto, and Wear OS see the metadata pushed by "
+"`setNowPlaying` and route headphone play/pause/stop/seek events back into "
+"the registered `onStateChange` closure. That covers foreground use. Apps "
+"that want playback to survive the activity being backgrounded (a podcast "
+"app, music player, etc.) need a foreground service of their own — Android "
+"will otherwise kill the audio when the process drops to the cached state. "
+"Add the following to your app's `AndroidManifest.xml` and start the service "
+"when playback begins:"
+msgstr ""
+
+#: src/system/media.md:126
+msgid "\".PerryMediaService\""
+msgstr ""
+
+#: src/system/media.md:127
+msgid "\"mediaPlayback\""
+msgstr ""
+
+#: src/system/media.md:128
+msgid "\"false\""
+msgstr ""
+
+#: src/system/media.md:129
+msgid "\"android.permission.FOREGROUND_SERVICE\""
+msgstr ""
+
+#: src/system/media.md:130
+msgid "\"android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK\""
+msgstr ""
+
+#: src/system/media.md:133
+msgid ""
+"The service implementation is app-specific — it should hold a "
+"`MediaSessionCompat.Token` (the same session Perry created), build a "
+"`Notification.MediaStyle` notification from it, and call "
+"`startForeground(...)` on `play` / `stopForeground(false)` on `pause` / "
+"`stopSelf()` on `stop`. We deliberately don't ship a default service because "
+"the notification's branding (small icon, tint, content intent) depends on "
+"the host app."
+msgstr ""
+
+#: src/system/media.md:141
+msgid "Threading notes"
+msgstr ""
+
+#: src/system/media.md:143
+msgid ""
+"The `onStateChange` and `onTimeUpdate` callbacks fire from the platform's "
+"main UI thread on every backend, so they share the same JS heap as the "
+"calling code. Implementation detail varies:"
+msgstr ""
+
+#: src/system/media.md:147
+msgid ""
+"**macOS / iOS / tvOS / visionOS** — driven by an `NSTimer` scheduled on the "
+"main run loop at 10 Hz."
+msgstr ""
+
+#: src/system/media.md:149
+msgid ""
+"**Android** — driven from `Java_com_perry_app_PerryBridge_nativePumpTick` "
+"(the existing 125 Hz UI-thread pump), throttled internally to ~10 Hz. The "
+"`prepare()` call runs on a background worker thread to avoid blocking the UI "
+"on network buffering."
+msgstr ""
+
+#: src/system/media.md:153
+msgid ""
+"**GTK4** — driven by a `glib::timeout_add_local` timer on the GLib main "
+"loop. EOS / error messages arrive on the GStreamer bus and get forwarded to "
+"per-player atomic flags via a `bus.add_watch_local` closure."
+msgstr ""
+
+#: src/system/media.md:157
+msgid ""
+"**Windows** — driven from the `GetMessageW` / `PeekMessageW` message loop "
+"after each dispatch, throttled to 100 ms by wall-clock comparison."
+msgstr ""
+
+#: src/system/media.md:159
+msgid ""
+"**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
+"directly, so `perry/media` calls record intents into Mutex-protected drain "
+"queues in `perry-runtime::media_playback`. The harvested `pages/Index.ets` "
+"(emitted by `perry-codegen-arkts` whenever the module uses `perry/media`) "
+"installs a 100 ms `setInterval` pump in `aboutToAppear` that drains the "
+"queues, dispatches each op against the matching `media.AVPlayer` instance "
+"(allocated lazily on the first `createPlayer` drain), and pushes state "
+"observations back into the runtime via the `pushMediaState(handle, state, "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / `timeUpdate` "
+"/ `error` / `endOfStream` events feed the same callback path. The pump runs "
+"on the ArkTS UI thread, so closures fired by "
+"`media_playback::push_media_state` share the same arena as Perry's `main()`. "
+"Lock-screen integration (`@ohos.multimedia.avsession`) is a follow-up — the "
+"runtime queues now-playing metadata via `drainNowPlaying` but the ArkTS-side "
+"AVSession dispatch is a no-op beyond a hilog line for now (tracked under "
+"issue #369)."
+msgstr ""
+
+#: src/system/media.md:177
+msgid "Now Playing on Apple platforms"
+msgstr ""
+
+#: src/system/media.md:179
+msgid ""
+"Apple's MPNowPlayingInfoCenter is a process-wide singleton — the most recent "
+"`setNowPlaying` call wins. For a single-player app (Subsonic client, podcast "
+"player) this matches user expectation. The MPRemoteCommandCenter handlers "
+"route `play` / `pause` / `togglePlayPause` events to the **first live player "
+"handle** — multi-player apps that need an explicit \"active player\" should "
+"manage that themselves."
+msgstr ""
+
+#: src/system/media.md:186
+msgid "`artworkUrl` accepts:"
+msgstr ""
+
+#: src/system/media.md:188
+msgid "`file://` paths — loaded synchronously via NSImage / UIImage"
+msgstr ""
+
+#: src/system/media.md:189
+msgid ""
+"`https://` URLs — fetched synchronously via NSData(contentsOf:) and wrapped "
+"in UIImage. The synchronous fetch is acceptable for a one-off artwork load "
+"(the MPNowPlayingInfoCenter dict is consumed synchronously when set)."
+msgstr ""
+
+#: src/system/media.md:194
+msgid "watchOS Info.plist requirements"
+msgstr ""
+
+#: src/system/media.md:196
+msgid ""
+"watchOS keeps the audio engine alive when the watch screen sleeps **only "
+"if** the app's `Info.plist` declares the `audio` background mode under "
+"`WKBackgroundModes` (the WatchKit equivalent of iOS's `UIBackgroundModes`):"
+msgstr ""
+
+#: src/system/media.md:207
+msgid ""
+"Without this entry the OS suspends the watch app a few seconds after the "
+"wrist-down gesture or screen timeout, regardless of whether AVPlayer is "
+"actively rendering. The runtime also auto-activates an `AVAudioSession` with "
+"category `Playback` on the first `createPlayer(...)` call — combined with "
+"the Info.plist entry, this is what tells watchOS the app intends to keep "
+"playing audio in the background."
+msgstr ""
+
+#: src/system/media.md:214
+msgid ""
+"The Now Playing surface on the watch face is independent from the paired "
+"iPhone's lock screen — they're separate processes with separate "
+"`MPNowPlayingInfoCenter` instances. `setNowPlaying` on watchOS targets the "
+"watch's Now Playing complication / glance screen."
+msgstr ""
+
+#: src/system/media.md:219
+msgid "Subsonic example"
+msgstr ""
+
+#: src/system/media.md:221
+msgid ""
+"```typescript,no-test\n"
+"import { createPlayer, play, setNowPlaying, onStateChange } from "
+"\"perry/media\";\n"
+"\n"
+"function streamUrl(serverUrl: string, user: string, pass: string, songId: "
+"string): string {\n"
+"  const params = new URLSearchParams({\n"
+"    u: user, p: pass, v: \"1.16.1\", c: \"PerryClient\", id: songId, format: "
+"\"mp3\",\n"
+"  });\n"
+"  return `${serverUrl}/rest/stream?${params.toString()}`;\n"
+"}\n"
+"\n"
+"const player = createPlayer(streamUrl(\"https://music.example.com\", "
+"\"alice\", \"secret\", \"12345\"));\n"
+"setNowPlaying(player, \"All These Things That I've Done\", \"The Killers\", "
+"\"Hot Fuss\",\n"
+"              "
+"\"https://music.example.com/rest/getCoverArt?id=12345&u=alice&p=secret&v=1.16.1&c=PerryClient\");\n"
+"onStateChange(player, (state) => {\n"
+"  if (state === \"ended\") {\n"
+"    // queue.next() ...\n"
+"  }\n"
+"});\n"
+"play(player);\n"
+"```"
+msgstr ""
+
+#: src/system/media.md:242
+msgid "Next steps"
+msgstr ""
+
+#: src/system/media.md:244
+msgid "[Audio Capture](audio.md) — Microphone input + dB metering"
+msgstr ""
+
+#: src/system/other.md:1
+msgid "Other System APIs"
+msgstr ""
+
+#: src/system/other.md:3
+msgid ""
+"Additional platform-level APIs. Every snippet below is excerpted from a real "
+"file CI compiles on every PR — see "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) for "
+"the perry/system pieces and "
+"[`docs/examples/ui/events/snippets.ts`](../../examples/ui/events/snippets.ts) "
+"for clipboard."
+msgstr ""
+
+#: src/system/other.md:10
+msgid "Open URL"
+msgstr ""
+
+#: src/system/other.md:12
+msgid "Open a URL in the default browser or application:"
+msgstr ""
+
+#: src/system/other.md:20
+msgid "NSWorkspace.open"
+msgstr ""
+
+#: src/system/other.md:21
+msgid "UIApplication.open"
+msgstr ""
+
+#: src/system/other.md:22
+msgid "Intent.ACTION_VIEW"
+msgstr ""
+
+#: src/system/other.md:23
+msgid "ShellExecuteW"
+msgstr ""
+
+#: src/system/other.md:24
+msgid "xdg-open"
+msgstr ""
+
+#: src/system/other.md:25
+msgid "window.open"
+msgstr ""
+
+#: src/system/other.md:27
+msgid "Dark Mode Detection"
+msgstr ""
+
+#: src/system/other.md:35
+msgid "Detection"
+msgstr ""
+
+#: src/system/other.md:37
+msgid "NSApp.effectiveAppearance"
+msgstr ""
+
+#: src/system/other.md:38
+msgid "UITraitCollection"
+msgstr ""
+
+#: src/system/other.md:39
+msgid "Configuration.uiMode"
+msgstr ""
+
+#: src/system/other.md:40
+msgid "Registry (AppsUseLightTheme)"
+msgstr ""
+
+#: src/system/other.md:41
+msgid "GTK settings"
+msgstr ""
+
+#: src/system/other.md:42
+msgid "prefers-color-scheme media query"
+msgstr ""
+
+#: src/system/other.md:46
+msgid "Clipboard helpers live in `perry/ui` (not `perry/system`):"
+msgstr ""
+
+#: src/system/other.md:57
+msgid "Device Identity"
+msgstr ""
+
+#: src/system/other.md:64
+msgid ""
+"`getDeviceIdiom()` returns the broad form factor (`\"phone\"`, `\"pad\"`, "
+"`\"mac\"`, `\"tv\"`, …); `getDeviceModel()` returns the platform-specific "
+"model identifier (`\"iPhone15,2\"`, `\"MacBookPro18,3\"`, etc.)."
+msgstr ""
+
+#: src/system/other.md:71
+msgid "[UI Overview](../ui/overview.md) — Building UIs"
+msgstr ""
+
+#: src/widgets/overview.md:1
+msgid "Widgets (WidgetKit) Overview"
+msgstr ""
+
+#: src/widgets/overview.md:3
+msgid ""
+"Perry can compile TypeScript widget declarations to native widget extensions "
+"across 4 platforms: iOS (WidgetKit), Android (App Widgets), watchOS "
+"(Complications), and Wear OS (Tiles)."
+msgstr ""
+
+#: src/widgets/overview.md:5
+msgid ""
+"**Status:** the `perry/widget` API is wired in the HIR "
+"(`crates/perry-hir/src/lower.rs:try_lower_widget_decl`) and emits via "
+"dedicated codegen crates (`perry-codegen-glance`, "
+"`perry-codegen-wear-tiles`, the WidgetKit emitter). The snippets on the "
+"widget docs pages compile-link cleanly on the host LLVM target — "
+"`Widget({...})` lowers to a no-op there — and CI verifies that via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts). "
+"What CI **cannot** do today is drive the actual cross-compile targets "
+"(`--target ios-widget`, `--target android-widget`, etc.) because each "
+"requires an `--app-bundle-id` not yet surfaced through the doc-tests harness "
+"— tracked in [\\#194](https://github.com/PerryTS/perry/issues/194). For a "
+"working end-to-end reference see "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+msgstr ""
+
+#: src/widgets/overview.md:17
+msgid "What Are Widgets?"
+msgstr ""
+
+#: src/widgets/overview.md:19
+msgid ""
+"Home screen widgets display glanceable information outside your app. Perry's "
+"`perry/widget` module lets you define widgets in TypeScript that compile to "
+"each platform's native widget system."
+msgstr ""
+
+#: src/widgets/overview.md:21
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"MyWidget\",\n"
+"    displayName: \"My Widget\",\n"
+"    description: \"Shows a greeting\",\n"
+"    entryFields: { name: \"string\" },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`Hello, ${entry.name}!`),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/overview.md:46
+msgid ""
+"The compiler generates a complete native widget extension for each platform "
+"— no platform-specific language knowledge required."
+msgstr ""
+
+#: src/widgets/overview.md:51
+msgid "# iOS WidgetKit extension\n"
+msgstr ""
+
+#: src/widgets/overview.md:52
+msgid "# Android App Widget\n"
+msgstr ""
+
+#: src/widgets/overview.md:53
+msgid "# watchOS Complication\n"
+msgstr ""
+
+#: src/widgets/overview.md:54
+msgid "# watchOS Simulator\n"
+msgstr ""
+
+#: src/widgets/overview.md:55
+msgid "# Wear OS Tile\n"
+msgstr ""
+
+#: src/widgets/overview.md:58
+msgid ""
+"Each target produces the appropriate native widget extension for that "
+"platform."
+msgstr ""
+
+#: src/widgets/overview.md:62
+msgid "[Creating Widgets](creating-widgets.md) — Widget() API in detail"
+msgstr ""
+
+#: src/widgets/overview.md:63
+msgid "[Components & Modifiers](components.md) — Available widget components"
+msgstr ""
+
+#: src/widgets/overview.md:64
+msgid "[Configuration](configuration.md) — Widget configuration options"
+msgstr ""
+
+#: src/widgets/overview.md:65
+msgid "[Data Fetching](data-fetching.md) — Timeline providers and data loading"
+msgstr ""
+
+#: src/widgets/overview.md:66
+msgid "[Cross-Platform Reference](platforms.md) — Platform-specific details"
+msgstr ""
+
+#: src/widgets/overview.md:67
+msgid "[watchOS Complications](watchos.md) — watchOS-specific guide"
+msgstr ""
+
+#: src/widgets/overview.md:68
+msgid "[Wear OS Tiles](wearos.md) — Wear OS-specific guide"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:3
+msgid "Define home screen widgets using the `Widget()` function."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:5
+msgid ""
+"**Status:** the full `Widget({...})` snippets on this page compile-link "
+"cleanly on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts), "
+"so the API shapes are verified against the codegen. The actual cross-compile "
+"targets (`--target "
+"ios-widget`/`android-widget`/`watchos-widget`/`wearos-tile`) still aren't "
+"driven by the doc-tests harness — each requires `--app-bundle-id` and a "
+"platform SDK ([\\#194](https://github.com/PerryTS/perry/issues/194)). For "
+"the canonical end-to-end shape see "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts). "
+"Fragments below that show partial syntax (just the `entryFields` object, "
+"just a `render:` body, etc.) are rendered as plain text — the full "
+"declarations they appear inside are covered by the verified anchors."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:18
+msgid "Widget Declaration"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:20
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"WeatherWidget\",\n"
+"    displayName: \"Weather\",\n"
+"    description: \"Shows current weather\",\n"
+"    entryFields: {\n"
+"        temperature: \"number\",\n"
+"        condition: \"string\",\n"
+"        location: \"string\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            HStack([\n"
+"                Text(entry.location),\n"
+"                Spacer(),\n"
+"                Image(\"cloud.sun.fill\"),\n"
+"            ]),\n"
+"            Text(`${entry.temperature}°`),\n"
+"            Text(entry.condition),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:43
+msgid "Widget Options"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47
+msgid "`kind`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47 src/widgets/creating-widgets.md:48
+#: src/widgets/creating-widgets.md:49 src/widgets/creating-widgets.md:54
+msgid "`string`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47
+msgid "Unique identifier for the widget"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:48
+msgid "`displayName`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:48
+msgid "Name shown in widget gallery"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:49 src/cli/perry-toml.md:119
+#: src/cli/perry-toml.md:349
+msgid "`description`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:49
+msgid "Description in widget gallery"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50
+msgid "`entryFields`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50 src/widgets/creating-widgets.md:52
+msgid "`object`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50
+msgid ""
+"Data fields with types (`\"string\"`, `\"number\"`, `\"boolean\"`, arrays, "
+"optionals, objects)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51
+msgid "`render`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51 src/widgets/creating-widgets.md:53
+msgid "`function`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51
+msgid ""
+"Render function receiving entry data, returns widget tree. Optional 2nd "
+"param for family."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:52
+msgid "`config`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:52
+msgid "Configurable parameters the user can edit (see below)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:53
+msgid "`provider`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:53
+msgid "Timeline provider function for dynamic data (see below)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:54
+msgid "`appGroup`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:54
+msgid "App group identifier for sharing data with the host app"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:56
+msgid "Entry Fields"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:58
+msgid ""
+"Entry fields define the data your widget displays. Each field has a name and "
+"type:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:60
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  title: \"string\",\n"
+"  count: \"number\",\n"
+"  isActive: \"boolean\",\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:68
+msgid "Array, Optional, and Object Fields"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:70
+msgid "Entry fields support richer types beyond primitives:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:72
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  items: [{ name: \"string\", value: \"number\" }],  // Array of objects\n"
+"  subtitle: \"string?\",                             // Optional string\n"
+"  stats: { wins: \"number\", losses: \"number\" },     // Nested object\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:80
+msgid "These compile to a Swift `TimelineEntry` struct:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:91
+msgid "Conditionals in Render"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:93
+msgid "Use ternary expressions for conditional rendering:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:95
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"ConditionalWidget\",\n"
+"    displayName: \"Conditional\",\n"
+"    description: \"Renders based on entry data\",\n"
+"    entryFields: {\n"
+"        isActive: \"boolean\",\n"
+"        count: \"number\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(entry.isActive ? \"Active\" : \"Inactive\"),\n"
+"            entry.count > 0 ? Text(`${entry.count} items`) : Spacer(),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:114
+msgid ""
+"Template literals in widget text are compiled to Swift string interpolation:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:116
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"TemplateLiteralWidget\",\n"
+"    displayName: \"Template Literal\",\n"
+"    description: \"Template literals compile to Swift string "
+"interpolation\",\n"
+"    entryFields: {\n"
+"        name: \"string\",\n"
+"        score: \"number\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        // Template literal: `${entry.name}: ${entry.score} points`\n"
+"        // Compiles to: Text(\"\\(entry.name): \\(entry.score) points\")\n"
+"        Text(`${entry.name}: ${entry.score} points`),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:132
+msgid "Configuration Parameters"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:134
+msgid ""
+"The `config` field defines user-editable parameters that appear in the "
+"widget's edit UI:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:136
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"CityWeather\",\n"
+"    displayName: \"City Weather\",\n"
+"    description: \"Weather for a chosen city\",\n"
+"    config: {\n"
+"        city: { type: \"string\", displayName: \"City\", default: \"New "
+"York\" },\n"
+"        units: {\n"
+"            type: \"enum\",\n"
+"            displayName: \"Units\",\n"
+"            values: [\"Celsius\", \"Fahrenheit\"],\n"
+"            default: \"Celsius\",\n"
+"        },\n"
+"    },\n"
+"    entryFields: { temperature: \"number\", condition: \"string\" },\n"
+"    render: (entry) => Text(`${entry.temperature}° ${entry.condition}`),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:155
+msgid "Provider Function"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:157
+msgid ""
+"The `provider` field defines a timeline provider that fetches data for the "
+"widget:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:159
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StockWidget\",\n"
+"    displayName: \"Stock Price\",\n"
+"    description: \"Shows current stock price\",\n"
+"    config: {\n"
+"        symbol: { type: \"string\", displayName: \"Symbol\", default: "
+"\"AAPL\" },\n"
+"    },\n"
+"    entryFields: { price: \"number\", change: \"string\" },\n"
+"    provider: async (config) => {\n"
+"        const res = await "
+"fetch(`https://api.example.com/stock/${config.symbol}`)\n"
+"        const data = await res.json()\n"
+"        return { price: data.price, change: data.change }\n"
+"    },\n"
+"    // Inline-options form — the chain form `.font(\"title\")` parses but "
+"is\n"
+"    // dropped at HIR-lowering time (#195).\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`$${entry.price}`, { font: \"title\" }),\n"
+"            Text(entry.change, { color: \"green\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:183
+msgid ""
+"Note: the chain-style modifiers (`.font(\"title\").color(\"green\")`) parse "
+"but are dropped at HIR-lowering time — see "
+"[\\#195](https://github.com/PerryTS/perry/issues/195). The verified extract "
+"above uses the inline-options form `Text(\"...\", { font: \"title\" })`, "
+"which is what actually round-trips through the widget codegen."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:189
+msgid "Placeholder Data"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:191
+msgid ""
+"When the widget has no data yet (e.g., first load), the provider can return "
+"placeholder data by providing a `placeholder` field:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:193
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"NewsWidget\",\n"
+"  entryFields: { headline: \"string\", source: \"string\" },\n"
+"  placeholder: { headline: \"Loading...\", source: \"---\" },\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:202
+msgid "Family-Specific Rendering"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:204
+msgid ""
+"The render function accepts an optional second parameter for the widget "
+"family, allowing different layouts per size:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:206
+msgid ""
+"```text\n"
+"render: (entry, family) =>\n"
+"  family === \"systemLarge\"\n"
+"    ? VStack([\n"
+"        Text(entry.title).font(\"title\"),\n"
+"        ForEach(entry.items, (item) => Text(item.name)),\n"
+"      ])\n"
+"    : HStack([\n"
+"        Image(\"star.fill\"),\n"
+"        Text(entry.title).font(\"headline\"),\n"
+"      ]),\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:219
+msgid ""
+"Supported families: `\"systemSmall\"`, `\"systemMedium\"`, "
+"`\"systemLarge\"`, `\"accessoryCircular\"`, `\"accessoryRectangular\"`, "
+"`\"accessoryInline\"`."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:221
+msgid "App Group"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:223
+msgid ""
+"The `appGroup` field specifies a shared container for data exchange between "
+"the host app and the widget:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:225
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"AppDataWidget\",\n"
+"  appGroup: \"group.com.example.myapp\",\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:233
+msgid "Multiple Widgets"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:235
+msgid ""
+"Define multiple widgets in a single file. They're bundled into a "
+"`WidgetBundle`:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:237
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"SmallWidget\",\n"
+"  // ...\n"
+"});\n"
+"\n"
+"Widget({\n"
+"  kind: \"LargeWidget\",\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:251
+msgid "[Components](components.md) — Available widget components and modifiers"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:252 src/widgets/components.md:273
+msgid "[Overview](overview.md) — Widget system overview"
+msgstr ""
+
+#: src/widgets/components.md:1
+msgid "Widget Components & Modifiers"
+msgstr ""
+
+#: src/widgets/components.md:3
+msgid "Available components and modifiers for widgets."
+msgstr ""
+
+#: src/widgets/components.md:5
+msgid ""
+"**Status:** this page mixes (a) tiny fragments showing component shape — "
+"rendered as plain `text` because they're not standalone declarations and "
+"can't compile — and (b) one full verified Widget at the bottom that "
+"compile-links via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts). "
+"The doc-tests harness can't drive `--target ios-widget`/`android-widget`/ "
+"`watchos-widget`/`wearos-tile` directly (each needs `--app-bundle-id` and a "
+"platform SDK — [\\#194](https://github.com/PerryTS/perry/issues/194)). Note "
+"also that the modifier parser in `crates/perry-hir/src/lower.rs` "
+"(`parse_modifiers_from_args` / `parse_single_modifier`) only reads modifiers "
+"from **inline option-object arguments** — e.g. `Text(\"hi\", { font: "
+"\"title\", color: \"red\" })` and `VStack([...], { padding: 16 })`. "
+"Method-style chains like `Text(\"hi\").font(\"title\")` shown below parse "
+"without error but **drop the modifier** at HIR-lowering time "
+"([\\#195](https://github.com/PerryTS/perry/issues/195)). The chain form is "
+"documented here because it reads naturally; the verified Complete Example at "
+"the bottom of the page uses the inline-options form that actually "
+"round-trips through the widget codegen path. The end-to-end reference is "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+msgstr ""
+
+#: src/widgets/components.md:27
+msgid ""
+"```text\n"
+"Text(\"Hello, World!\")\n"
+"Text(`${entry.name}: ${entry.value}`)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:32
+msgid "Text Modifiers"
+msgstr ""
+
+#: src/widgets/components.md:34
+msgid ""
+"```text\n"
+"const t = Text(\"Styled\");\n"
+"t.font(\"title\");       // .title, .headline, .body, .caption, etc.\n"
+"t.color(\"blue\");       // Named color or hex\n"
+"t.bold();\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:45
+msgid ""
+"```text\n"
+"VStack([\n"
+"  Text(\"Top\"),\n"
+"  Text(\"Bottom\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:54 src/widgets/components.md:75
+msgid ""
+"```text\n"
+"HStack([\n"
+"  Text(\"Left\"),\n"
+"  Spacer(),\n"
+"  Text(\"Right\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:64
+msgid ""
+"```text\n"
+"ZStack([\n"
+"  Image(\"background\"),\n"
+"  Text(\"Overlay\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:73
+msgid "Flexible space that expands to fill available room:"
+msgstr ""
+
+#: src/widgets/components.md:85
+msgid "Display SF Symbols or asset images:"
+msgstr ""
+
+#: src/widgets/components.md:87
+msgid ""
+"```text\n"
+"Image(\"star.fill\")           // SF Symbol\n"
+"Image(\"cloud.sun.rain.fill\") // SF Symbol\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:94
+msgid "Iterate over array entry fields to render a list of components:"
+msgstr ""
+
+#: src/widgets/components.md:108
+msgid "A visual separator line:"
+msgstr ""
+
+#: src/widgets/components.md:110
+msgid ""
+"```text\n"
+"VStack([\n"
+"  Text(\"Above\"),\n"
+"  Divider(),\n"
+"  Text(\"Below\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:118 src/widgets/platforms.md:28
+msgid "Label"
+msgstr ""
+
+#: src/widgets/components.md:120
+msgid "A label with text and an SF Symbol icon:"
+msgstr ""
+
+#: src/widgets/components.md:122
+msgid ""
+"```text\n"
+"Label(\"Downloads\", \"arrow.down.circle\")\n"
+"Label(`${entry.count} items`, \"folder.fill\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:127 src/widgets/platforms.md:29
+msgid "Gauge"
+msgstr ""
+
+#: src/widgets/components.md:129
+msgid "A circular or linear progress indicator:"
+msgstr ""
+
+#: src/widgets/components.md:131
+msgid ""
+"```text\n"
+"Gauge(entry.progress, 0, 100)       // value, min, max\n"
+"Gauge(entry.battery, 0, 1.0)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:138
+msgid ""
+"Widget components support SwiftUI-style modifiers. The chain forms shown "
+"below parse but drop their modifiers at HIR-lowering time "
+"([\\#195](https://github.com/PerryTS/perry/issues/195)) — use the inline "
+"option-object form (`Text(\"hi\", { font: \"title\" })`, `VStack([...], { "
+"padding: 16 })`) for the form that actually reaches the codegen, as in the "
+"[Complete Example](#complete-example) at the bottom of this page."
+msgstr ""
+
+#: src/widgets/components.md:146
+msgid "Font"
+msgstr ""
+
+#: src/widgets/components.md:148
+msgid ""
+"```text\n"
+"Text(\"Title\").font(\"title\")\n"
+"Text(\"Body\").font(\"body\")\n"
+"Text(\"Caption\").font(\"caption\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:154
+msgid "Color"
+msgstr ""
+
+#: src/widgets/components.md:156
+msgid ""
+"```text\n"
+"Text(\"Red text\").color(\"red\")\n"
+"Text(\"Custom\").color(\"#FF6600\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:161
+msgid "Padding"
+msgstr ""
+
+#: src/widgets/components.md:167
+msgid "Frame"
+msgstr ""
+
+#: src/widgets/components.md:173
+msgid "Max Width"
+msgstr ""
+
+#: src/widgets/components.md:175
+msgid ""
+"```text\n"
+"widget.maxWidth(\"infinity\")   // Expand to fill available width\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:179
+msgid "Minimum Scale Factor"
+msgstr ""
+
+#: src/widgets/components.md:181
+msgid "Allow text to shrink to fit:"
+msgstr ""
+
+#: src/widgets/components.md:183
+msgid ""
+"```text\n"
+"Text(\"Long text\").minimumScaleFactor(0.5)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:187
+msgid "Container Background"
+msgstr ""
+
+#: src/widgets/components.md:189
+msgid "Set background color for the widget container:"
+msgstr ""
+
+#: src/widgets/components.md:191
+msgid ""
+"```text\n"
+"VStack([...]).containerBackground(\"blue\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:195
+msgid "Widget URL"
+msgstr ""
+
+#: src/widgets/components.md:197
+msgid "Make the widget tappable with a deep link:"
+msgstr ""
+
+#: src/widgets/components.md:199
+msgid ""
+"```text\n"
+"VStack([...]).url(\"myapp://detail/123\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:203
+msgid "Edge-Specific Padding"
+msgstr ""
+
+#: src/widgets/components.md:205
+msgid "Apply padding to specific edges:"
+msgstr ""
+
+#: src/widgets/components.md:207
+msgid ""
+"```text\n"
+"VStack([...]).paddingEdge(\"top\", 8)\n"
+"VStack([...]).paddingEdge(\"horizontal\", 16)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:212
+msgid "Conditionals"
+msgstr ""
+
+#: src/widgets/components.md:214
+msgid "Render different components based on entry data:"
+msgstr ""
+
+#: src/widgets/components.md:216
+msgid ""
+"```text\n"
+"render: (entry) =>\n"
+"  VStack([\n"
+"    entry.isOnline\n"
+"      ? Text(\"Online\").color(\"green\")\n"
+"      : Text(\"Offline\").color(\"red\"),\n"
+"  ]),\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:227
+msgid ""
+"The full Widget below is the verified extract — it compile-links on the host "
+"LLVM target and uses the inline-options modifier form that round-trips "
+"through the codegen."
+msgstr ""
+
+#: src/widgets/components.md:231
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StatsWidget\",\n"
+"    displayName: \"Stats\",\n"
+"    description: \"Shows daily stats\",\n"
+"    entryFields: {\n"
+"        steps: \"number\",\n"
+"        calories: \"number\",\n"
+"        distance: \"string\",\n"
+"    },\n"
+"    // Inline-options modifier form — the `.font(\"title\").bold()` chain "
+"form\n"
+"    // parses but its modifiers don't reach the codegen (#195).\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            HStack([\n"
+"                Image(\"figure.walk\"),\n"
+"                Text(\"Daily Stats\", { font: \"headline\" }),\n"
+"            ]),\n"
+"            Spacer(),\n"
+"            HStack([\n"
+"                VStack([\n"
+"                    Text(`${entry.steps}`, { font: \"title\", fontWeight: "
+"\"bold\" }),\n"
+"                    Text(\"steps\", { font: \"caption\", color: \"gray\" "
+"}),\n"
+"                ]),\n"
+"                Spacer(),\n"
+"                VStack([\n"
+"                    Text(`${entry.calories}`, { font: \"title\", fontWeight: "
+"\"bold\" }),\n"
+"                    Text(\"cal\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"                Spacer(),\n"
+"                VStack([\n"
+"                    Text(entry.distance, { font: \"title\", fontWeight: "
+"\"bold\" }),\n"
+"                    Text(\"km\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"            ]),\n"
+"        ], { padding: 16 }),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:272
+msgid "[Creating Widgets](creating-widgets.md) — Widget() API"
+msgstr ""
+
+#: src/widgets/configuration.md:1
+msgid "Widget Configuration"
+msgstr ""
+
+#: src/widgets/configuration.md:3
+msgid ""
+"Perry widgets support user-configurable parameters. On iOS/watchOS, these "
+"compile to AppIntent configurations (the \"Edit Widget\" sheet). On "
+"Android/Wear OS, they compile to a Configuration Activity."
+msgstr ""
+
+#: src/widgets/configuration.md:5
+msgid ""
+"**Status:** the full `TopSitesWidget` declaration below compile-links "
+"cleanly on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts), "
+"so the `config: { ... }` shape is verified against `parse_config_params` in "
+"`crates/perry-hir/src/lower.rs`. The shorter fragments lower on the page "
+"(just a `provider:` body, just a `config:` object) are rendered as plain "
+"text — they're not standalone declarations. The cross-compile targets "
+"themselves (`--target ios-widget`/ "
+"`android-widget`/`watchos-widget`/`wearos-tile`) still aren't driven by the "
+"doc-tests harness — each needs `--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194))."
+msgstr ""
+
+#: src/widgets/configuration.md:17
+msgid "Defining Config Fields"
+msgstr ""
+
+#: src/widgets/configuration.md:19
+msgid ""
+"Add a `config` object to your `Widget()` declaration. Each field specifies a "
+"type, allowed values, a default, and a display title."
+msgstr ""
+
+#: src/widgets/configuration.md:21
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"TopSitesWidget\",\n"
+"    displayName: \"Top Sites\",\n"
+"    description: \"Your top performing sites\",\n"
+"    supportedFamilies: [\"systemSmall\", \"systemMedium\"],\n"
+"    appGroup: \"group.com.example.shared\",\n"
+"\n"
+"    config: {\n"
+"        sortBy: {\n"
+"            type: \"enum\",\n"
+"            values: [\"clicks\", \"impressions\", \"ctr\", \"position\"],\n"
+"            default: \"clicks\",\n"
+"            title: \"Sort By\",\n"
+"        },\n"
+"        dateRange: {\n"
+"            type: \"enum\",\n"
+"            values: [\"7d\", \"28d\", \"90d\"],\n"
+"            default: \"7d\",\n"
+"            title: \"Date Range\",\n"
+"        },\n"
+"    },\n"
+"\n"
+"    entryFields: {\n"
+"        total: \"number\",\n"
+"        label: \"string\",\n"
+"    },\n"
+"\n"
+"    provider: async (config: { sortBy: string; dateRange: string }) => {\n"
+"        const res = await fetch(\n"
+"            "
+"`https://api.example.com/stats?sort=${config.sortBy}&range=${config.dateRange}`,\n"
+"        )\n"
+"        const data = await res.json()\n"
+"        return {\n"
+"            entries: [{ total: data.total, label: data.label }],\n"
+"            reloadPolicy: { after: { minutes: 30 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`${entry.total}`, { font: \"title\", fontWeight: \"bold\" "
+"}),\n"
+"            Text(entry.label, { font: \"caption\", color: \"secondary\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:68
+msgid "Supported Parameter Types"
+msgstr ""
+
+#: src/widgets/configuration.md:70
+msgid "TypeScript"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "Enum"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "`{ type: \"enum\", values: [...], default: \"...\", title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "Picker with fixed choices"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "Boolean"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "`{ type: \"bool\", default: true, title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "Toggle switch"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "String"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "`{ type: \"string\", default: \"...\", title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "Free-text input"
+msgstr ""
+
+#: src/widgets/configuration.md:76
+msgid "Accessing Config in the Provider"
+msgstr ""
+
+#: src/widgets/configuration.md:78
+msgid ""
+"The `provider` function receives the current config values as its argument. "
+"The config object keys match the field names you defined:"
+msgstr ""
+
+#: src/widgets/configuration.md:80
+msgid ""
+"```text\n"
+"provider: async (config: { sortBy: string; dateRange: string }) => {\n"
+"  // config.sortBy === \"clicks\" | \"impressions\" | \"ctr\" | "
+"\"position\"\n"
+"  // config.dateRange === \"7d\" | \"28d\" | \"90d\"\n"
+"  const url = `https://api.example.com/data?sort=${config.sortBy}`;\n"
+"  const res = await fetch(url);\n"
+"  const data = await res.json();\n"
+"  return { entries: [data] };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:91
+msgid ""
+"When the user changes a config value, the system calls your provider again "
+"with the updated config."
+msgstr ""
+
+#: src/widgets/configuration.md:93
+msgid "Boolean Config Example"
+msgstr ""
+
+#: src/widgets/configuration.md:95
+msgid ""
+"```text\n"
+"config: {\n"
+"  showDetails: {\n"
+"    type: \"bool\",\n"
+"    default: true,\n"
+"    title: \"Show Details\",\n"
+"  },\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:105
+msgid "Platform Mapping"
+msgstr ""
+
+#: src/widgets/configuration.md:107
+msgid "iOS / watchOS (AppIntent)"
+msgstr ""
+
+#: src/widgets/configuration.md:109
+msgid ""
+"Perry generates a Swift `WidgetConfigurationIntent` struct with `@Parameter` "
+"properties and `AppEnum` types for each enum field. The widget uses "
+"`AppIntentConfiguration` instead of `StaticConfiguration`."
+msgstr ""
+
+#: src/widgets/configuration.md:111
+msgid "Generated output (auto-generated, not hand-written):"
+msgstr ""
+
+#: src/widgets/configuration.md:112
+msgid "`{Name}Intent.swift` -- contains the AppEnum cases and the intent struct"
+msgstr ""
+
+#: src/widgets/configuration.md:113
+msgid ""
+"The provider conforms to `AppIntentTimelineProvider` instead of "
+"`TimelineProvider`"
+msgstr ""
+
+#: src/widgets/configuration.md:114
+msgid ""
+"Config values are serialized to JSON and passed to the native provider "
+"function"
+msgstr ""
+
+#: src/widgets/configuration.md:116
+msgid ""
+"Users configure the widget by long-pressing and selecting \"Edit Widget\", "
+"which presents the system-generated AppIntent UI."
+msgstr ""
+
+#: src/widgets/configuration.md:118
+msgid "Android / Wear OS (Configuration Activity)"
+msgstr ""
+
+#: src/widgets/configuration.md:120
+msgid ""
+"Perry generates a `{Name}ConfigActivity.kt` with Spinner controls for enum "
+"fields and Switch controls for boolean fields. Values are persisted in "
+"SharedPreferences keyed by widget ID."
+msgstr ""
+
+#: src/widgets/configuration.md:122
+msgid "Generated output:"
+msgstr ""
+
+#: src/widgets/configuration.md:123
+msgid "`{Name}ConfigActivity.kt` -- Activity with UI controls and a Save button"
+msgstr ""
+
+#: src/widgets/configuration.md:124
+msgid ""
+"`widget_info_{name}.xml` -- includes `android:configure` pointing to the "
+"config activity"
+msgstr ""
+
+#: src/widgets/configuration.md:125
+msgid ""
+"AndroidManifest snippet includes an `<activity>` entry with "
+"`APPWIDGET_CONFIGURE` intent filter"
+msgstr ""
+
+#: src/widgets/configuration.md:127
+msgid ""
+"The config activity launches automatically when the user first adds the "
+"widget."
+msgstr ""
+
+#: src/widgets/configuration.md:129
+msgid "Build Commands"
+msgstr ""
+
+#: src/widgets/configuration.md:132
+msgid "# iOS\n"
+msgstr ""
+
+#: src/widgets/configuration.md:134
+msgid "# Android\n"
+msgstr ""
+
+#: src/widgets/configuration.md:141
+msgid "[Data Fetching](data-fetching.md) -- Provider function and shared storage"
+msgstr ""
+
+#: src/widgets/configuration.md:142
+msgid "[Components](components.md) -- Available widget components"
+msgstr ""
+
+#: src/widgets/configuration.md:143
+msgid ""
+"[Cross-Platform Reference](platforms.md) -- Feature matrix and build targets"
+msgstr ""
+
+#: src/widgets/data-fetching.md:1
+msgid "Provider Function and Data Fetching"
+msgstr ""
+
+#: src/widgets/data-fetching.md:3
+msgid ""
+"The `provider` function is the heart of a dynamic widget. It fetches data, "
+"transforms it, and returns timeline entries that the system renders on "
+"schedule."
+msgstr ""
+
+#: src/widgets/data-fetching.md:5
+msgid ""
+"**Status:** the basic `WeatherWidget` provider below compile-links cleanly "
+"on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts), "
+"so the `provider`/`reloadPolicy`/`entryFields` shapes are verified against "
+"the codegen. The shorter fragments lower on the page (a bare "
+"`reloadPolicy:`, a `provider:` body without surrounding `Widget({...})`, "
+"etc.) are rendered as plain text. The `sharedStorage()` and "
+"`preferencesSet()` examples are also rendered as plain text — those symbols "
+"are provided by the platform-specific glue (`AppGroupBridge.swift`, "
+"`Bridge.kt`) for `--target ios-widget`/`android-widget`/`watchos-widget`/ "
+"`wearos-tile` and don't link on the host LLVM target. The cross-compile "
+"targets themselves still aren't driven by the doc-tests harness — each needs "
+"`--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194))."
+msgstr ""
+
+#: src/widgets/data-fetching.md:20
+msgid "Provider Lifecycle"
+msgstr ""
+
+#: src/widgets/data-fetching.md:22
+msgid ""
+"The system calls your provider when the widget is first added, when a "
+"snapshot is needed, and when the reload policy expires."
+msgstr ""
+
+#: src/widgets/data-fetching.md:23
+msgid ""
+"Your provider runs as native LLVM-compiled code linked into the widget "
+"extension."
+msgstr ""
+
+#: src/widgets/data-fetching.md:24
+msgid ""
+"The provider returns one or more timeline entries. The system renders each "
+"entry at its scheduled time."
+msgstr ""
+
+#: src/widgets/data-fetching.md:25
+msgid ""
+"After the last entry, the reload policy determines when the provider runs "
+"again."
+msgstr ""
+
+#: src/widgets/data-fetching.md:27
+msgid "Basic Provider"
+msgstr ""
+
+#: src/widgets/data-fetching.md:29
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"WeatherProviderWidget\",\n"
+"    displayName: \"Weather\",\n"
+"    description: \"Current conditions\",\n"
+"    supportedFamilies: [\"systemSmall\"],\n"
+"\n"
+"    entryFields: {\n"
+"        temperature: \"number\",\n"
+"        condition: \"string\",\n"
+"    },\n"
+"\n"
+"    provider: async () => {\n"
+"        const res = await "
+"fetch(\"https://api.weather.example.com/current\")\n"
+"        const data = await res.json()\n"
+"        return {\n"
+"            entries: [\n"
+"                { temperature: data.temp, condition: data.description },\n"
+"            ],\n"
+"            reloadPolicy: { after: { minutes: 15 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`${entry.temperature}°`, { font: \"title\" }),\n"
+"            Text(entry.condition, { font: \"caption\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:60
+msgid "Authenticated Requests with Shared Storage"
+msgstr ""
+
+#: src/widgets/data-fetching.md:62
+msgid ""
+"Widgets run in a separate process and cannot access your app's memory. Use "
+"`sharedStorage()` to read values that your app has written to a shared "
+"container."
+msgstr ""
+
+#: src/widgets/data-fetching.md:64
+msgid "iOS / watchOS: App Groups"
+msgstr ""
+
+#: src/widgets/data-fetching.md:66
+msgid ""
+"On Apple platforms, shared storage maps to `UserDefaults(suiteName:)` backed "
+"by an App Group container. Set the `appGroup` field in your widget "
+"declaration:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:68
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"DashboardWidget\",\n"
+"  displayName: \"Dashboard\",\n"
+"  description: \"Account summary\",\n"
+"  appGroup: \"group.com.example.shared\",\n"
+"\n"
+"  entryFields: {\n"
+"    revenue: \"number\",\n"
+"    users: \"number\",\n"
+"  },\n"
+"\n"
+"  provider: async () => {\n"
+"    const token = sharedStorage(\"auth_token\");\n"
+"    const res = await fetch(\"https://api.example.com/dashboard\", {\n"
+"      headers: { Authorization: `Bearer ${token}` },\n"
+"    });\n"
+"    const data = await res.json();\n"
+"    return {\n"
+"      entries: [{ revenue: data.revenue, users: data.activeUsers }],\n"
+"      reloadPolicy: { after: { minutes: 30 } },\n"
+"    };\n"
+"  },\n"
+"\n"
+"  render: (entry) =>\n"
+"    VStack([\n"
+"      Text(`$${entry.revenue}`, { font: \"title\" }),\n"
+"      Text(`${entry.users} active users`, { font: \"caption\" }),\n"
+"    ]),\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:100
+msgid "Your main app writes the token to the shared container:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:102
+msgid ""
+"```text\n"
+"import { preferencesSet } from \"perry/system\";\n"
+"// In your app's login flow:\n"
+"preferencesSet(\"auth_token\", token);\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:108
+msgid ""
+"**Setup requirement (iOS):** Add an App Group capability in Xcode to both "
+"the main app target and the widget extension target. The identifier must "
+"match the `appGroup` value."
+msgstr ""
+
+#: src/widgets/data-fetching.md:110
+msgid "Android / Wear OS: SharedPreferences"
+msgstr ""
+
+#: src/widgets/data-fetching.md:112
+msgid ""
+"On Android, shared storage maps to `SharedPreferences` with the name "
+"`perry_shared`. The generated `Bridge.kt` reads values via "
+"`context.getSharedPreferences(\"perry_shared\", MODE_PRIVATE)`."
+msgstr ""
+
+#: src/widgets/data-fetching.md:114
+msgid "Reload Policies"
+msgstr ""
+
+#: src/widgets/data-fetching.md:116
+msgid ""
+"The `reloadPolicy` field controls when the system next calls your provider:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:127
+msgid "`{ after: { minutes: N } }`"
+msgstr ""
+
+#: src/widgets/data-fetching.md:127
+msgid ""
+"Re-fetch after N minutes. Compiles to "
+"`.after(Date().addingTimeInterval(N*60))` on iOS and "
+"`setFreshnessIntervalMillis(N*60000)` on Wear OS."
+msgstr ""
+
+#: src/widgets/data-fetching.md:128
+msgid "_(omitted)_"
+msgstr ""
+
+#: src/widgets/data-fetching.md:128
+msgid "Defaults to 30 minutes on iOS, 30 minutes on Android/Wear OS."
+msgstr ""
+
+#: src/widgets/data-fetching.md:130
+msgid ""
+"**Budget limits:** iOS restricts widget refreshes. Typical budget is 40--70 "
+"refreshes per day. watchOS is stricter (see [watchOS "
+"Complications](watchos.md)). Request only what you need."
+msgstr ""
+
+#: src/widgets/data-fetching.md:132
+msgid "JSON Response Handling"
+msgstr ""
+
+#: src/widgets/data-fetching.md:134
+msgid ""
+"The provider function receives the parsed JSON directly. Entry field types "
+"must match your `entryFields` declaration:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:136
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  items: { type: \"array\", items: { type: \"object\", fields: { name: "
+"\"string\", count: \"number\" } } },\n"
+"  total: \"number\",\n"
+"},\n"
+"\n"
+"provider: async () => {\n"
+"  const res = await fetch(\"https://api.example.com/items\");\n"
+"  const data = await res.json();\n"
+"  return {\n"
+"    entries: [{\n"
+"      items: data.results.map((r: any) => ({ name: r.name, count: r.count "
+"})),\n"
+"      total: data.total,\n"
+"    }],\n"
+"  };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:156
+msgid ""
+"If the fetch fails or JSON parsing throws, the widget extension falls back "
+"to the placeholder data:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:158
+msgid ""
+"```text\n"
+"Widget({\n"
+"  // ...\n"
+"  placeholder: { temperature: 0, condition: \"Loading...\" },\n"
+"\n"
+"  provider: async () => {\n"
+"    const res = await fetch(\"https://api.example.com/weather\");\n"
+"    if (!res.ok) {\n"
+"      // Return stale/fallback data with a short retry interval\n"
+"      return {\n"
+"        entries: [{ temperature: 0, condition: \"Unavailable\" }],\n"
+"        reloadPolicy: { after: { minutes: 5 } },\n"
+"      };\n"
+"    }\n"
+"    const data = await res.json();\n"
+"    return {\n"
+"      entries: [{ temperature: data.temp, condition: data.desc }],\n"
+"      reloadPolicy: { after: { minutes: 15 } },\n"
+"    };\n"
+"  },\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:181
+msgid ""
+"The `placeholder` field provides data shown in the widget gallery and during "
+"loading. If the provider throws an unhandled exception, the generated "
+"Swift/Kotlin code catches it and renders the placeholder instead."
+msgstr ""
+
+#: src/widgets/data-fetching.md:183
+msgid "Multiple Timeline Entries"
+msgstr ""
+
+#: src/widgets/data-fetching.md:185
+msgid "Return multiple entries to schedule future content without re-fetching:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:187
+msgid ""
+"```text\n"
+"provider: async () => {\n"
+"  const res = await fetch(\"https://api.example.com/hourly\");\n"
+"  const hours = await res.json();\n"
+"  return {\n"
+"    entries: hours.map((h: any) => ({\n"
+"      temperature: h.temp,\n"
+"      condition: h.condition,\n"
+"    })),\n"
+"    reloadPolicy: { after: { minutes: 60 } },\n"
+"  };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:201
+msgid ""
+"Each entry is rendered at the corresponding date in the timeline. The system "
+"transitions between entries automatically."
+msgstr ""
+
+#: src/widgets/data-fetching.md:205
+msgid "[Configuration](configuration.md) -- User-configurable parameters"
+msgstr ""
+
+#: src/widgets/data-fetching.md:206
+msgid ""
+"[Cross-Platform Reference](platforms.md) -- Build targets and platform "
+"differences"
+msgstr ""
+
+#: src/widgets/platforms.md:3
+msgid ""
+"Perry widgets compile from a single TypeScript source to four platforms. The "
+"same `Widget({...})` declaration produces native code for each target."
+msgstr ""
+
+#: src/widgets/platforms.md:5
+msgid ""
+"**Status:** this page has no TypeScript fences (only target-flag tables and "
+"shell build commands), so the doc-tests harness has nothing to run here. The "
+"`--target` flags listed below are all wired in "
+"`crates/perry/src/commands/compile.rs`, but the harness still can't exercise "
+"them end-to-end — each requires `--app-bundle-id` and a platform SDK (Xcode, "
+"Android NDK)."
+msgstr ""
+
+#: src/widgets/platforms.md:7
+msgid "Target Flags"
+msgstr ""
+
+#: src/widgets/platforms.md:11
+msgid "`--target ios-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:11
+msgid "SwiftUI `.swift` + Info.plist"
+msgstr ""
+
+#: src/widgets/platforms.md:12 src/plugins/native-extensions.md:274
+#: src/testing/geisterhand.md:341 src/cli/flags.md:23
+msgid "iOS Simulator"
+msgstr ""
+
+#: src/widgets/platforms.md:12
+msgid "`--target ios-widget-simulator`"
+msgstr ""
+
+#: src/widgets/platforms.md:12 src/widgets/platforms.md:15
+msgid "Same, simulator SDK"
+msgstr ""
+
+#: src/widgets/platforms.md:13
+msgid "`--target android-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:13
+msgid "Kotlin/Glance `.kt` + widget_info XML"
+msgstr ""
+
+#: src/widgets/platforms.md:14
+msgid "`--target watchos-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:14
+msgid "SwiftUI `.swift` (accessory families)"
+msgstr ""
+
+#: src/widgets/platforms.md:15
+msgid "watchOS Simulator"
+msgstr ""
+
+#: src/widgets/platforms.md:15
+msgid "`--target watchos-widget-simulator`"
+msgstr ""
+
+#: src/widgets/platforms.md:16 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:55 src/widgets/platforms.md:87
+msgid "Wear OS"
+msgstr ""
+
+#: src/widgets/platforms.md:16
+msgid "`--target wearos-tile`"
+msgstr ""
+
+#: src/widgets/platforms.md:16
+msgid "Kotlin Tiles `.kt` + manifest"
+msgstr ""
+
+#: src/widgets/platforms.md:18
+msgid "Feature Matrix"
+msgstr ""
+
+#: src/widgets/platforms.md:23
+msgid "VStack/HStack/ZStack"
+msgstr ""
+
+#: src/widgets/platforms.md:23
+msgid "Column/Row/Box"
+msgstr ""
+
+#: src/widgets/platforms.md:24
+msgid "Image (SF Symbols)"
+msgstr ""
+
+#: src/widgets/platforms.md:24
+msgid "R.drawable"
+msgstr ""
+
+#: src/widgets/platforms.md:26
+msgid "Spacer+bg"
+msgstr ""
+
+#: src/widgets/platforms.md:27
+msgid "forEach"
+msgstr ""
+
+#: src/widgets/platforms.md:28
+msgid "Row compound"
+msgstr ""
+
+#: src/widgets/platforms.md:28 src/widgets/platforms.md:29
+#: src/widgets/wearos.md:30
+msgid "Text fallback"
+msgstr ""
+
+#: src/widgets/platforms.md:29 src/widgets/platforms.md:35
+msgid "N/A"
+msgstr ""
+
+#: src/widgets/platforms.md:29
+msgid "CircularProgressIndicator"
+msgstr ""
+
+#: src/widgets/platforms.md:30
+msgid "Conditional"
+msgstr ""
+
+#: src/widgets/platforms.md:30
+msgid "if"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "FamilySwitch"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "LocalSize"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "requestedSize"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Config (AppIntent)"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Config Activity"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Yes (10+)"
+msgstr ""
+
+#: src/widgets/platforms.md:32 src/widgets/platforms.md:34
+msgid "SharedPrefs"
+msgstr ""
+
+#: src/widgets/platforms.md:33
+msgid "Native provider"
+msgstr ""
+
+#: src/widgets/platforms.md:33
+msgid "JNI"
+msgstr ""
+
+#: src/widgets/platforms.md:34
+msgid "sharedStorage"
+msgstr ""
+
+#: src/widgets/platforms.md:34
+msgid "UserDefaults"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "Deep linking (url)"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "widgetURL"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "clickable Intent"
+msgstr ""
+
+#: src/widgets/platforms.md:37
+msgid "Platform-Specific Notes"
+msgstr ""
+
+#: src/widgets/platforms.md:40
+msgid "Minimum deployment: iOS 17.0"
+msgstr ""
+
+#: src/widgets/platforms.md:41
+msgid "AppIntentConfiguration requires `import AppIntents`"
+msgstr ""
+
+#: src/widgets/platforms.md:42
+msgid "Widget extension memory limit: ~30MB"
+msgstr ""
+
+#: src/widgets/platforms.md:45
+msgid "Requires Glance dependency: `androidx.glance:glance-appwidget:1.1.0`"
+msgstr ""
+
+#: src/widgets/platforms.md:46
+msgid ""
+"Widget sizes mapped from iOS families: systemSmall=2x2, systemMedium=4x2, "
+"systemLarge=4x4"
+msgstr ""
+
+#: src/widgets/platforms.md:47
+msgid "`minimumScaleFactor` not supported in Glance (skipped with warning)"
+msgstr ""
+
+#: src/widgets/platforms.md:50
+msgid "Minimum deployment: watchOS 9.0"
+msgstr ""
+
+#: src/widgets/platforms.md:51
+msgid "Accessory families only (circular, rectangular, inline)"
+msgstr ""
+
+#: src/widgets/platforms.md:52
+msgid "Tighter memory (~15-20MB) and refresh budgets (hourly)"
+msgstr ""
+
+#: src/widgets/platforms.md:53
+msgid "AppIntent requires watchOS 10+; older versions get StaticConfiguration"
+msgstr ""
+
+#: src/widgets/platforms.md:56
+msgid "Same native compilation as Android phone (Wear OS = Android)"
+msgstr ""
+
+#: src/widgets/platforms.md:57
+msgid "Requires Horologist + Tiles Material 3 dependencies"
+msgstr ""
+
+#: src/widgets/platforms.md:58
+msgid "Tiles are full-screen cards in the carousel"
+msgstr ""
+
+#: src/widgets/platforms.md:59
+msgid "`Gauge` maps to `CircularProgressIndicator`"
+msgstr ""
+
+#: src/widgets/platforms.md:61
+msgid "Build Instructions"
+msgstr ""
+
+#: src/widgets/platforms.md:73
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
+msgstr ""
+
+#: src/widgets/platforms.md:75
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
+msgstr ""
+
+#: src/widgets/platforms.md:89
+msgid "# Copy .kt files to Wear OS module\n"
+msgstr ""
+
+#: src/widgets/platforms.md:91
+msgid "# Merge AndroidManifest_snippet.xml\n"
+msgstr ""
+
+#: src/widgets/watchos.md:3
+msgid ""
+"Perry widgets can compile to watchOS WidgetKit complications using `--target "
+"watchos-widget`. The same `Widget({...})` source produces both iOS and "
+"watchOS widgets — the supported families determine the rendering."
+msgstr ""
+
+#: src/widgets/watchos.md:5
+msgid ""
+"**Status:** the snippet on this page compile-links cleanly on the host LLVM "
+"target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts), "
+"so the `Widget({...})` shape is verified against the codegen. The actual "
+"`--target watchos-widget` / `--target watchos-widget-simulator` "
+"cross-compile is wired in `crates/perry/src/commands/compile.rs` (emits "
+"through the WidgetKit Swift emitter) but the doc-tests harness can't drive "
+"it yet — each cross-target requires `--app-bundle-id` not yet surfaced "
+"through the harness ([\\#194](https://github.com/PerryTS/perry/issues/194)) "
+"plus a watchOS SDK from Xcode. Build with the `perry` CLI to validate "
+"end-to-end."
+msgstr ""
+
+#: src/widgets/watchos.md:15
+msgid "Accessory Families"
+msgstr ""
+
+#: src/widgets/watchos.md:17
+msgid "watchOS complications use accessory families instead of system families:"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Family"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Size"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Best For"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "`accessoryCircular`"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "~76x76pt"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "Single icon, number, or Gauge"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "`accessoryRectangular`"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "~160x76pt"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "2-3 lines of text"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "`accessoryInline`"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "Single line"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "Short text only"
+msgstr ""
+
+#: src/widgets/watchos.md:25
+msgid "Gauge Component"
+msgstr ""
+
+#: src/widgets/watchos.md:27
+msgid "The `Gauge` component is designed for watchOS circular complications:"
+msgstr ""
+
+#: src/widgets/watchos.md:29
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"QuickStats\",\n"
+"    displayName: \"Quick Stats\",\n"
+"    supportedFamilies: [\"accessoryCircular\", \"accessoryRectangular\"],\n"
+"\n"
+"    render(entry: { progress: number; label: string }, family) {\n"
+"        if (family === \"accessoryCircular\") {\n"
+"            return Gauge(entry.progress, 1.0)\n"
+"        }\n"
+"        return VStack([\n"
+"            Text(entry.label),\n"
+"            Gauge(entry.progress, 1.0),\n"
+"        ])\n"
+"    },\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/watchos.md:47
+msgid "Gauge Styles"
+msgstr ""
+
+#: src/widgets/watchos.md:49
+msgid ""
+"**`circular`** — Ring gauge, maps to "
+"`.gaugeStyle(.accessoryCircularCapacity)` in SwiftUI"
+msgstr ""
+
+#: src/widgets/watchos.md:50
+msgid ""
+"**`linear`** / **`linearCapacity`** — Horizontal bar, maps to "
+"`.gaugeStyle(.linearCapacity)`"
+msgstr ""
+
+#: src/widgets/watchos.md:52
+msgid "Refresh Budgets"
+msgstr ""
+
+#: src/widgets/watchos.md:54
+msgid "watchOS has stricter refresh budgets than iOS:"
+msgstr ""
+
+#: src/widgets/watchos.md:55
+msgid ""
+"Recommended: refresh every 60 minutes (`reloadPolicy: { after: { minutes: 60 "
+"} }`)"
+msgstr ""
+
+#: src/widgets/watchos.md:56
+msgid "Maximum: system may throttle more aggressively than iOS"
+msgstr ""
+
+#: src/widgets/watchos.md:57
+msgid "Background refresh uses `BackgroundTask` framework"
+msgstr ""
+
+#: src/widgets/watchos.md:62
+msgid "# For Apple Watch device\n"
+msgstr ""
+
+#: src/widgets/watchos.md:64
+msgid "# For Apple Watch Simulator\n"
+msgstr ""
+
+#: src/widgets/watchos.md:69
+msgid "Build:"
+msgstr ""
+
+#: src/widgets/watchos.md:79
+msgid "watchOS 10+ supports AppIntent for widget configuration (same as iOS 17+)"
+msgstr ""
+
+#: src/widgets/watchos.md:80
+msgid "Older watchOS versions automatically get `StaticConfiguration` fallback"
+msgstr ""
+
+#: src/widgets/watchos.md:81
+msgid "`config` params work identically to iOS"
+msgstr ""
+
+#: src/widgets/watchos.md:83
+msgid "Memory Considerations"
+msgstr ""
+
+#: src/widgets/watchos.md:85
+msgid ""
+"watchOS widget extensions have tighter memory limits (~15-20MB) compared to "
+"iOS (~30MB). The provider-only compilation approach is critical — only the "
+"data-fetching code runs natively, keeping memory usage minimal."
+msgstr ""
+
+#: src/widgets/wearos.md:3
+msgid ""
+"Perry widgets can compile to Wear OS Tiles using `--target wearos-tile`. "
+"Tiles are glanceable surfaces in the Wear OS tile carousel and watch face "
+"complications."
+msgstr ""
+
+#: src/widgets/wearos.md:5
+msgid ""
+"**Status:** the snippet on this page compile-links cleanly on the host LLVM "
+"target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts), "
+"so the `Widget({...})` shape is verified against the codegen. `--target "
+"wearos-tile` itself is wired through `crates/perry-codegen-wear-tiles` but "
+"the doc-tests harness can't drive that cross-target yet — `--app-bundle-id` "
+"plumbing is still pending "
+"([\\#194](https://github.com/PerryTS/perry/issues/194)) and you'll need an "
+"Android NDK + Wear OS Gradle deps. Build with the `perry` CLI to validate "
+"end-to-end."
+msgstr ""
+
+#: src/widgets/wearos.md:14
+msgid "Concepts"
+msgstr ""
+
+#: src/widgets/wearos.md:16
+msgid "**Tiles** are full-screen cards users swipe through on their watch"
+msgstr ""
+
+#: src/widgets/wearos.md:17
+msgid "**Complications** are small data displays on the watch face"
+msgstr ""
+
+#: src/widgets/wearos.md:18
+msgid ""
+"Perry compiles `Widget({...})` to a `SuspendingTileService` with layout "
+"builders"
+msgstr ""
+
+#: src/widgets/wearos.md:20
+msgid "Supported Components"
+msgstr ""
+
+#: src/widgets/wearos.md:22
+msgid "Widget API"
+msgstr ""
+
+#: src/widgets/wearos.md:22
+msgid "Wear OS Mapping"
+msgstr ""
+
+#: src/widgets/wearos.md:24
+msgid "`LayoutElementBuilders.Text`"
+msgstr ""
+
+#: src/widgets/wearos.md:25
+msgid "`LayoutElementBuilders.Column`"
+msgstr ""
+
+#: src/widgets/wearos.md:26
+msgid "`LayoutElementBuilders.Row`"
+msgstr ""
+
+#: src/widgets/wearos.md:27
+msgid "`LayoutElementBuilders.Spacer`"
+msgstr ""
+
+#: src/widgets/wearos.md:28
+msgid "Spacer with 1dp height"
+msgstr ""
+
+#: src/widgets/wearos.md:29
+msgid "`Gauge(circular)`"
+msgstr ""
+
+#: src/widgets/wearos.md:29
+msgid "`LayoutElementBuilders.Arc` + `ArcLine`"
+msgstr ""
+
+#: src/widgets/wearos.md:30
+msgid "`Gauge(linear)`"
+msgstr ""
+
+#: src/widgets/wearos.md:31
+msgid "`Image`"
+msgstr ""
+
+#: src/widgets/wearos.md:31
+msgid "Resource-based (provide drawable)"
+msgstr ""
+
+#: src/widgets/wearos.md:33
+msgid "Example"
+msgstr ""
+
+#: src/widgets/wearos.md:35
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StepsTile\",\n"
+"    displayName: \"Steps\",\n"
+"    description: \"Daily step count\",\n"
+"    supportedFamilies: [\"accessoryCircular\"],\n"
+"\n"
+"    provider: async () => {\n"
+"        return {\n"
+"            entries: [{ steps: 7500, goal: 10000 }],\n"
+"            reloadPolicy: { after: { minutes: 60 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render(entry: { steps: number; goal: number }) {\n"
+"        return VStack([\n"
+"            Gauge(entry.steps / entry.goal, 1.0),\n"
+"            Text(`${entry.steps}`),\n"
+"        ])\n"
+"    },\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/wearos.md:65
+msgid "`{Name}TileService.kt` — `SuspendingTileService` with tile layout"
+msgstr ""
+
+#: src/widgets/wearos.md:66
+msgid ""
+"`{Name}TileBridge.kt` — JNI bridge for native provider (if provider exists)"
+msgstr ""
+
+#: src/widgets/wearos.md:67
+msgid "`AndroidManifest_snippet.xml` — Service declaration"
+msgstr ""
+
+#: src/widgets/wearos.md:69
+msgid "Gradle Integration"
+msgstr ""
+
+#: src/widgets/wearos.md:71
+msgid "Add to your Wear OS module's `build.gradle`:"
+msgstr ""
+
+#: src/widgets/wearos.md:75
+msgid "\"com.google.android.horologist:horologist-tiles:0.6.5\""
+msgstr ""
+
+#: src/widgets/wearos.md:76
+msgid "\"androidx.wear.tiles:tiles-material:1.4.0\""
+msgstr ""
+
+#: src/widgets/wearos.md:77
+msgid "\"androidx.wear.tiles:tiles:1.4.0\""
+msgstr ""
+
+#: src/widgets/wearos.md:81
+msgid "Merge the manifest snippet into your `AndroidManifest.xml`:"
+msgstr ""
+
+#: src/widgets/wearos.md:85
+msgid "\".StepsTileService\""
+msgstr ""
+
+#: src/widgets/wearos.md:86
+msgid "\"true\""
+msgstr ""
+
+#: src/widgets/wearos.md:87
+msgid "\"com.google.android.wearable.permission.BIND_TILE_PROVIDER\""
+msgstr ""
+
+#: src/widgets/wearos.md:89
+msgid "\"androidx.wear.tiles.action.BIND_TILE_PROVIDER\""
+msgstr ""
+
+#: src/widgets/wearos.md:94
+msgid "Native Provider"
+msgstr ""
+
+#: src/widgets/wearos.md:96
+msgid "Same as Android phone widgets — Wear OS is Android:"
+msgstr ""
+
+#: src/widgets/wearos.md:97
+msgid "Target triple: `aarch64-linux-android`"
+msgstr ""
+
+#: src/widgets/wearos.md:98
+msgid "`libwidget_provider.so` loaded via `System.loadLibrary`"
+msgstr ""
+
+#: src/widgets/wearos.md:99
+msgid "JNI bridge pattern identical to phone Glance widgets"
+msgstr ""
+
+#: src/widgets/wearos.md:100
+msgid "`sharedStorage()` uses `SharedPreferences`"
+msgstr ""
+
+#: src/widgets/wearos.md:102
+msgid "Refresh"
+msgstr ""
+
+#: src/widgets/wearos.md:104
+msgid ""
+"Wear Tiles use `freshnessIntervalMillis` on the `Tile` builder. Set via "
+"`reloadPolicy: { after: { minutes: N } }` in the provider return value. "
+"Default: 60 minutes."
+msgstr ""
+
+#: src/plugins/overview.md:1
+msgid "Plugin System Overview"
+msgstr ""
+
+#: src/plugins/overview.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). Receiver-less calls (`loadPlugin`, `listPlugins`, `emitHook`, "
+"`invokeTool`, ...) and `PluginApi` instance methods (`api.registerHook`, "
+"`api.registerTool`, ...) dispatch through "
+"`crates/perry-codegen/src/lower_call.rs::PERRY_PLUGIN_TABLE` and "
+"`PERRY_PLUGIN_INSTANCE_TABLE`. TypeScript surface lives in "
+"`types/perry/plugin/index.d.ts`. Host-side snippets below are compile-link "
+"verified by the doc-tests harness against "
+"[`docs/examples/plugins/host_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/host_snippets.ts); "
+"plugin-side `activate(api)` snippets against "
+"[`docs/examples/plugins/plugin_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/plugin_snippets.ts)."
+msgstr ""
+
+#: src/plugins/overview.md:5
+msgid ""
+"Perry supports native plugins as shared libraries (`.dylib`/`.so`). Plugins "
+"extend Perry applications with custom hooks, tools, services, and routes."
+msgstr ""
+
+#: src/plugins/overview.md:9
+msgid ""
+"A plugin is a Perry-compiled shared library with `activate(api)` and "
+"`deactivate()` entry points"
+msgstr ""
+
+#: src/plugins/overview.md:10
+msgid "The host application loads plugins with `loadPlugin(path)`"
+msgstr ""
+
+#: src/plugins/overview.md:11
+msgid "Plugins register hooks, tools, and services via the API handle"
+msgstr ""
+
+#: src/plugins/overview.md:12
+msgid "The host dispatches events to plugins via `emitHook(name, data)`"
+msgstr ""
+
+#: src/plugins/overview.md:14
+msgid ""
+"```\n"
+"Host Application\n"
+"    ↓ loadPlugin(\"./my-plugin.dylib\")\n"
+"    ↓ calls plugin_activate(api_handle)\n"
+"Plugin\n"
+"    ↓ api.registerHook(\"beforeSave\", callback)\n"
+"    ↓ api.registerTool(\"format\", callback)\n"
+"Host\n"
+"    ↓ emitHook(\"beforeSave\", data) → plugin callback runs\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:27
+msgid "Plugin (compiled with `--output-type dylib`)"
+msgstr ""
+
+#: src/plugins/overview.md:29 src/plugins/creating-plugins.md:9
+msgid ""
+"```typescript\n"
+"let count = 0\n"
+"\n"
+"export function activate(api: PluginApi) {\n"
+"    api.setMetadata(\"counter\", \"1.0.0\", \"Counts hook invocations\")\n"
+"\n"
+"    api.registerHook(\"onRequest\", (data) => {\n"
+"        count++\n"
+"        console.log(`Request #${count}`)\n"
+"        return data\n"
+"    })\n"
+"\n"
+"    api.registerTool(\"getCount\", \"returns request count\", () => count)\n"
+"}\n"
+"\n"
+"export function deactivate() {\n"
+"    console.log(`Total requests processed: ${count}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:53
+msgid "Host Application"
+msgstr ""
+
+#: src/plugins/overview.md:55
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"    loadPlugin, unloadPlugin,\n"
+"    emitHook, emitEvent, invokeTool,\n"
+"    setPluginConfig,\n"
+"    discoverPlugins, listPlugins, listHooks, listTools,\n"
+"    pluginCount, initPlugins,\n"
+"} from \"perry/plugin\"\n"
+"\n"
+"const id = loadPlugin(\"./counter-plugin.dylib\")\n"
+"console.log(`load returned: ${id !== 0 ? \"ok\" : \"fail\"}`)\n"
+"\n"
+"const plugins = listPlugins()\n"
+"const hooks = listHooks()\n"
+"const tools = listTools()\n"
+"console.log(`loaded: ${pluginCount()} plugin(s), ${hooks.length} hook(s), "
+"${tools.length} tool(s)`)\n"
+"\n"
+"const result = emitHook(\"beforeSave\", { content: \"hello world\" })\n"
+"\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:81
+msgid "Plugin ABI"
+msgstr ""
+
+#: src/plugins/overview.md:83
+msgid "Plugins must export these symbols:"
+msgstr ""
+
+#: src/plugins/overview.md:84
+msgid ""
+"`perry_plugin_abi_version()` — Returns ABI version (for compatibility "
+"checking)"
+msgstr ""
+
+#: src/plugins/overview.md:85
+msgid "`plugin_activate(api_handle)` — Called when plugin is loaded"
+msgstr ""
+
+#: src/plugins/overview.md:86
+msgid "`plugin_deactivate()` — Called when plugin is unloaded"
+msgstr ""
+
+#: src/plugins/overview.md:88
+msgid ""
+"Perry generates these automatically from your `activate`/`deactivate` "
+"exports."
+msgstr ""
+
+#: src/plugins/overview.md:92
+msgid ""
+"Perry also supports **native extensions** — packages that bundle "
+"platform-specific Rust/Swift/JNI code and compile directly into your binary. "
+"These are used for accessing platform APIs like the App Store review prompt "
+"or StoreKit in-app purchases."
+msgstr ""
+
+#: src/plugins/overview.md:94
+msgid "See [Native Extensions](native-extensions.md) for details."
+msgstr ""
+
+#: src/plugins/overview.md:98
+msgid "[Creating Plugins](creating-plugins.md) — Build a plugin step by step"
+msgstr ""
+
+#: src/plugins/overview.md:99
+msgid "[Hooks & Events](hooks-and-events.md) — Hook modes, event bus, tools"
+msgstr ""
+
+#: src/plugins/overview.md:100
+msgid ""
+"[Native Extensions](native-extensions.md) — Extensions with platform-native "
+"code"
+msgstr ""
+
+#: src/plugins/overview.md:101
+msgid ""
+"[App Store Review](appstore-review.md) — Native review prompt (iOS/Android)"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). See [Plugin System Overview — Status](overview.md) for the full "
+"surface. Snippets below are compile-link verified by the doc-tests harness "
+"against "
+"[`docs/examples/plugins/plugin_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/plugin_snippets.ts) "
+"and "
+"[`docs/examples/plugins/host_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/host_snippets.ts)."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:5
+msgid "Build Perry plugins as shared libraries that extend host applications."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:7
+msgid "Step 1: Write the Plugin"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:29
+msgid "Step 2: Compile as Shared Library"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:35
+msgid ""
+"The `--output-type dylib` flag tells Perry to produce a `.dylib` (macOS) or "
+"`.so` (Linux) instead of an executable."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:38
+msgid "Generates `perry_plugin_abi_version()` returning the current ABI version"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:39
+msgid ""
+"Generates `plugin_activate(api_handle)` calling your `activate()` function"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:40
+msgid "Generates `plugin_deactivate()` calling your `deactivate()` function"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:41
+msgid "Exports symbols with `-rdynamic` for the host to find"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:43
+msgid "Step 3: Load from Host"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:45
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"    loadPlugin, unloadPlugin,\n"
+"    emitHook, emitEvent, invokeTool,\n"
+"    setPluginConfig,\n"
+"    discoverPlugins, listPlugins, listHooks, listTools,\n"
+"    pluginCount, initPlugins,\n"
+"} from \"perry/plugin\"\n"
+"\n"
+"const id = loadPlugin(\"./counter-plugin.dylib\")\n"
+"console.log(`load returned: ${id !== 0 ? \"ok\" : \"fail\"}`)\n"
+"\n"
+"const found = discoverPlugins(\"./plugins/\")\n"
+"console.log(`discovered ${found.length} plugin(s)`)\n"
+"\n"
+"const result = emitHook(\"beforeSave\", { content: \"hello world\" })\n"
+"\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:69
+msgid "Plugin API Reference"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:71
+msgid "The `api: PluginApi` passed to `activate()` provides:"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:73
+msgid "Metadata"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:79
+msgid "Hooks"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:86
+msgid ""
+"`registerHook` defaults to priority 10 / mode 0 (filter). Use "
+"`registerHookEx` for explicit priority and mode (0=filter, 1=action, "
+"2=waterfall). Lower priority numbers run first."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:90 src/plugins/hooks-and-events.md:94
+msgid "Tools"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:96
+msgid "Tools are invoked by name from the host."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:100
+msgid ""
+"```typescript,no-test\n"
+"const value = api.getConfig(key: string)  // Read host-provided config\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:106
+msgid ""
+"```typescript,no-test\n"
+"api.on(event: string, handler: (data: unknown) => void): void  // Listen for "
+"events\n"
+"api.emit(event: string, data: unknown): void                    // Emit to "
+"other plugins\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:113
+msgid "[Hooks & Events](hooks-and-events.md) — Hook modes, event bus"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:114 src/plugins/hooks-and-events.md:147
+#: src/plugins/native-extensions.md:301
+msgid "[Overview](overview.md) — Plugin system overview"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). `api.registerHook`, `api.on`, `emitHook`, `emitEvent`, `invokeTool` "
+"all dispatch to `crates/perry-runtime/src/plugin.rs`. Snippets below are "
+"compile-link verified against "
+"[`docs/examples/plugins/{plugin,host}_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/)."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:5
+msgid "Perry plugins communicate through hooks, events, and tools."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:7
+msgid "Hook Modes"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:9
+msgid "Hooks support three execution modes:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:11
+msgid "Filter Mode (default)"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:13
+msgid ""
+"Each plugin receives data and returns (possibly modified) data. The output "
+"of one plugin becomes the input of the next:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:15
+msgid ""
+"```typescript\n"
+"function registerFilter(api: PluginApi) {\n"
+"    api.registerHook(\"transform\", (data: any) => {\n"
+"        data.content = data.content.toUpperCase()\n"
+"        return data // Returned data goes to next plugin\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:24
+msgid "Action Mode"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:26
+msgid ""
+"Plugins receive data but return value is ignored. Used for side effects. "
+"Pass `mode = 1` to `registerHookEx`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:29
+msgid ""
+"```typescript\n"
+"function registerAction(api: PluginApi) {\n"
+"    api.registerHook(\"onSave\", (data: any) => {\n"
+"        console.log(`Saved: ${data.path}`)\n"
+"        return data\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:38
+msgid "Waterfall Mode"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:40
+msgid ""
+"Like filter mode, but specifically for accumulating/building up a result "
+"through the chain. Pass `mode = 2` to `registerHookEx`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:43
+msgid ""
+"```typescript\n"
+"function registerWaterfall(api: PluginApi) {\n"
+"    api.registerHook(\"buildMenu\", (items: any) => {\n"
+"        items.push({ label: \"My Plugin Action\", action: () => {} })\n"
+"        return items\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:52
+msgid "Hook Priority"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:54
+msgid ""
+"Lower priority numbers run first. Use `registerHookEx` for explicit priority "
+"and mode:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:57
+msgid ""
+"```typescript\n"
+"function registerPriorities(api: PluginApi, validate: (d: any) => any, "
+"transform: (d: any) => any, log: (d: any) => any) {\n"
+"    // Lower priority numbers run first; default 10. Mode 0=filter / "
+"1=action / 2=waterfall.\n"
+"    api.registerHookEx(\"beforeSave\", validate, 10, 0)   // Runs first\n"
+"    api.registerHookEx(\"beforeSave\", transform, 20, 0)  // Runs second\n"
+"    api.registerHookEx(\"beforeSave\", log, 100, 1)        // Runs last "
+"(action mode)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:66
+msgid "Default priority is 10 (the value `registerHook` passes implicitly)."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:68
+msgid "Event Bus"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:70
+msgid "Plugins can communicate with each other through events:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:72
+msgid "Emitting Events"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:74
+msgid ""
+"```typescript\n"
+"function emitFromPlugin(api: PluginApi) {\n"
+"    api.emit(\"dataUpdated\", { source: \"my-plugin\", records: 42 })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:80
+msgid ""
+"```typescript\n"
+"emitEvent(\"dataUpdated\", { source: \"host\", records: 100 })\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:84
+msgid "Listening for Events"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:86
+msgid ""
+"```typescript\n"
+"function listenForEvent(api: PluginApi) {\n"
+"    api.on(\"dataUpdated\", (data: any) => {\n"
+"        console.log(`${data.source} updated ${data.records} records`)\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:96
+msgid ""
+"Plugins register callable tools (note the 3-arg shape: `name`, "
+"`description`, `handler`):"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:99
+msgid ""
+"```typescript\n"
+"function registerFormatter(api: PluginApi) {\n"
+"    api.registerTool(\"formatCode\", \"format source code\", (args: any) => "
+"{\n"
+"        return `// formatted: ${args.code}`\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:107
+msgid ""
+"```typescript\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:117
+msgid "Hosts can pass configuration to plugins via `setPluginConfig`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:119
+msgid ""
+"```typescript\n"
+"initPlugins()\n"
+"setPluginConfig(\"api_key\", \"test-key\")\n"
+"setPluginConfig(\"max_retries\", \"3\")\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:125
+msgid ""
+"```typescript\n"
+"function readConfig(api: PluginApi) {\n"
+"    const theme = api.getConfig(\"theme\")     // \"dark\"\n"
+"    const retries = api.getConfig(\"maxRetries\") // \"3\"\n"
+"    return { theme, retries }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:133
+msgid "Introspection"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:135
+msgid "Query loaded plugins and their registrations:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:146
+msgid "[Creating Plugins](creating-plugins.md) — Build a plugin"
+msgstr ""
+
+#: src/plugins/native-extensions.md:3
+msgid ""
+"**Status: partially wired.** The `--bundle-extensions` flag, the "
+"`perry.nativeLibrary` `package.json` manifest, and `declare function` FFI "
+"imports are all wired into the compiler — see "
+"`crates/perry/src/commands/compile.rs` (the `bundle_extensions` argument, "
+"the `parse_native_library_manifest`/`build_external_native_libraries` "
+"helpers) and `crates/perry-codegen/src/codegen.rs` (the "
+"`nativeLibrary.functions` signature parser). The TypeScript snippets below "
+"assume a fully-populated extension directory exists on disk (e.g. "
+"`perry-appstore-review` cloned under `./extensions/`). They are kept as "
+"`,no-test` because the doc-tests harness doesn't have those external "
+"extensions checked in — a real project that does have them will compile "
+"cleanly. Drift protection for the parts that _don't_ depend on external "
+"extensions (the FFI declare-function shape, etc.) lives in "
+"`docs/examples/platforms/wasm_snippets.ts`."
+msgstr ""
+
+#: src/plugins/native-extensions.md:5
+msgid ""
+"Perry supports native extensions — packages that bundle platform-specific "
+"code (Rust, Swift, JNI) alongside a TypeScript API. Unlike [dynamic "
+"plugins](overview.md) loaded at runtime, native extensions are compiled "
+"directly into your binary."
+msgstr ""
+
+#: src/plugins/native-extensions.md:7
+msgid ""
+"Native extensions are how you access platform APIs that aren't part of "
+"Perry's built-in [System APIs](../system/overview.md) or [Standard "
+"Library](../stdlib/overview.md). Examples include [App Store "
+"Review](appstore-review.md) and StoreKit for in-app purchases."
+msgstr ""
+
+#: src/plugins/native-extensions.md:9
+msgid "Using a native extension"
+msgstr ""
+
+#: src/plugins/native-extensions.md:11
+msgid "1. Add the extension to your project"
+msgstr ""
+
+#: src/plugins/native-extensions.md:13
+msgid ""
+"Place the extension directory alongside your project, or in a shared "
+"extensions directory:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:30
+msgid "2. Compile with `--bundle-extensions`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:32
+msgid "Pass the extensions directory when building:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:38
+msgid ""
+"Perry discovers every subdirectory with a `package.json`, compiles its "
+"native crates for the target platform, and links them into your binary."
+msgstr ""
+
+#: src/plugins/native-extensions.md:40
+msgid "3. Import and use"
+msgstr ""
+
+#: src/plugins/native-extensions.md:42 src/plugins/appstore-review.md:60
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"\n"
+"await requestReview();\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:48
+msgid ""
+"The import resolves at compile time to the extension's entry point. No "
+"runtime module loading is involved — the function compiles to a direct "
+"native call."
+msgstr ""
+
+#: src/plugins/native-extensions.md:50
+msgid "How native extensions work"
+msgstr ""
+
+#: src/plugins/native-extensions.md:52
+msgid ""
+"A native extension is a directory with a `package.json` that declares a "
+"`perry.nativeLibrary` section. This tells Perry which native functions "
+"exist, their signatures, and which Rust crate to compile for each platform."
+msgstr ""
+
+#: src/plugins/native-extensions.md:54
+msgid "package.json manifest"
+msgstr ""
+
+#: src/plugins/native-extensions.md:58
+msgid "\"perry-appstore-review\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:59
+msgid "\"0.1.0\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:62 src/plugins/appstore-review.md:181
+msgid "\"nativeLibrary\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:63 src/plugins/appstore-review.md:182
+msgid "\"functions\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"sb_appreview_request\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"params\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"returns\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"f64\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:66
+msgid "\"targets\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:68 src/plugins/native-extensions.md:73
+#: src/plugins/native-extensions.md:78
+msgid "\"crate\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:68 src/plugins/native-extensions.md:78
+msgid "\"crate-ios\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:69 src/plugins/native-extensions.md:74
+#: src/plugins/native-extensions.md:79
+msgid "\"lib\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:69 src/plugins/native-extensions.md:74
+#: src/plugins/native-extensions.md:79
+msgid "\"libperry_appreview.a\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:70 src/plugins/native-extensions.md:75
+#: src/plugins/native-extensions.md:80
+msgid "\"frameworks\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:70 src/plugins/native-extensions.md:80
+msgid "\"StoreKit\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:73
+msgid "\"crate-android\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:77
+msgid "\"macos\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:88
+msgid "`functions`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:90
+msgid "Each entry declares a native function the extension exports:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:94 src/cli/perry-toml.md:116
+msgid "`name`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:94
+msgid "Symbol name — must match the `#[no_mangle]` Rust function exactly"
+msgstr ""
+
+#: src/plugins/native-extensions.md:95
+msgid "`params`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:95
+msgid ""
+"Array of LLVM types: `\"i64\"` for pointers/strings, `\"f64\"` for numbers, "
+"`\"i32\"` for integers"
+msgstr ""
+
+#: src/plugins/native-extensions.md:96
+msgid "`returns`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:96
+msgid "Return type — typically `\"f64\"` (NaN-boxed value or promise handle)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:98
+msgid "`targets`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:100
+msgid ""
+"Each target platform maps to a Rust crate that implements the native "
+"functions:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:104
+msgid "`crate`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:104
+msgid "Relative path to the Rust crate directory"
+msgstr ""
+
+#: src/plugins/native-extensions.md:105
+msgid "`lib`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:105
+msgid "Name of the static library produced by `cargo build`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:106
+msgid "`frameworks`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:106
+msgid "System frameworks to link (iOS/macOS only)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:108
+msgid ""
+"Multiple targets can share the same crate (e.g., iOS and macOS often share "
+"an implementation). Platforms without an entry fall back to the stub."
+msgstr ""
+
+#: src/plugins/native-extensions.md:110
+msgid "Extension directory layout"
+msgstr ""
+
+#: src/plugins/native-extensions.md:112
+msgid ""
+"```\n"
+"perry-appstore-review/\n"
+"├── package.json              # Manifest with perry.nativeLibrary\n"
+"├── src/\n"
+"│   └── index.ts              # TypeScript API (what users import)\n"
+"├── crate-ios/                # iOS/macOS native implementation\n"
+"│   ├── Cargo.toml            # [lib] crate-type = [\"staticlib\"]\n"
+"│   ├── build.rs              # Compiles Swift if needed\n"
+"│   ├── src/\n"
+"│   │   └── lib.rs            # Rust FFI: #[no_mangle] pub extern \"C\" fn "
+"...\n"
+"│   └── swift/\n"
+"│       └── bridge.swift      # Swift bridge for Apple APIs (@_cdecl)\n"
+"├── crate-android/            # Android native implementation\n"
+"│   ├── Cargo.toml\n"
+"│   └── src/\n"
+"│       └── lib.rs            # Rust FFI with JNI calls\n"
+"└── crate-stub/               # Fallback for unsupported platforms\n"
+"    ├── Cargo.toml\n"
+"    └── src/\n"
+"        └── lib.rs            # Returns error immediately\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:134
+msgid "TypeScript side"
+msgstr ""
+
+#: src/plugins/native-extensions.md:136
+msgid ""
+"The `src/index.ts` declares native functions and optionally wraps them in a "
+"friendlier API:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:138
+msgid ""
+"```text\n"
+"// Declare the native function (name must match package.json)\n"
+"declare function sb_appreview_request(): number;\n"
+"\n"
+"// Wrap it with a proper TypeScript signature\n"
+"export async function requestReview(): Promise<void> {\n"
+"  await (sb_appreview_request() as any);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:148
+msgid ""
+"`declare function` tells Perry the function is provided by native code. The "
+"raw return type is `number` because all values cross the FFI boundary as "
+"NaN-boxed `f64` values. Promise handles are NaN-boxed pointers that Perry's "
+"runtime knows how to `await`."
+msgstr ""
+
+#: src/plugins/native-extensions.md:150
+msgid "Rust side"
+msgstr ""
+
+#: src/plugins/native-extensions.md:152
+msgid ""
+"Each platform crate is a `staticlib` that implements the declared functions "
+"using `#[no_mangle] pub extern \"C\"`:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:155
+msgid "// Perry runtime FFI\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:156 src/plugins/native-extensions.md:164
+#: src/plugins/native-extensions.md:256
+msgid "\"C\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:167
+msgid "// ... call platform API, resolve promise when done ...\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:173
+msgid "Key runtime functions available to native code:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:175 src/contributing/architecture.md:23
+msgid "Purpose"
+msgstr ""
+
+#: src/plugins/native-extensions.md:177
+msgid "`js_promise_new()`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:177
+msgid "Create a new Perry promise, returns pointer"
+msgstr ""
+
+#: src/plugins/native-extensions.md:178
+msgid "`js_promise_resolve(promise, value)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:178
+msgid "Resolve a promise with a NaN-boxed value"
+msgstr ""
+
+#: src/plugins/native-extensions.md:179
+msgid "`js_nanbox_string(ptr)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:179
+msgid "Convert a C string pointer to a NaN-boxed string"
+msgstr ""
+
+#: src/plugins/native-extensions.md:180
+msgid "`js_nanbox_pointer(ptr)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:180
+msgid "Convert a pointer to a NaN-boxed object reference"
+msgstr ""
+
+#: src/plugins/native-extensions.md:181
+msgid "`js_get_string_pointer_unified(val)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:181
+msgid "Extract string pointer from a NaN-boxed value"
+msgstr ""
+
+#: src/plugins/native-extensions.md:182
+msgid "`js_string_from_bytes(ptr, len)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:182
+msgid "Create a Perry string from bytes"
+msgstr ""
+
+#: src/plugins/native-extensions.md:184
+msgid "Swift bridge (iOS/macOS)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:186
+msgid "Apple platform APIs are often easiest to call from Swift. The pattern is:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:188
+msgid "Write a Swift file with `@_cdecl(\"function_name\")` exports"
+msgstr ""
+
+#: src/plugins/native-extensions.md:189
+msgid "Compile it to a static library in `build.rs`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:190
+msgid "Call the Swift functions from Rust via `extern \"C\"`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:192
+msgid ""
+"```swift\n"
+"import StoreKit\n"
+"\n"
+"typealias Callback = @convention(c) (UnsafeMutableRawPointer, "
+"UnsafePointer<CChar>) -> Void\n"
+"\n"
+"@_cdecl(\"swift_appreview_request\")\n"
+"func swiftRequestReview(_ callback: @escaping Callback, _ context: "
+"UnsafeMutableRawPointer) {\n"
+"    DispatchQueue.main.async {\n"
+"        if let scene = UIApplication.shared.connectedScenes\n"
+"            .first(where: { $0.activationState == .foregroundActive }) as? "
+"UIWindowScene {\n"
+"            SKStoreReviewController.requestReview(in: scene)\n"
+"        }\n"
+"        let result = \"{\\\"success\\\":true}\"\n"
+"        result.withCString { callback(context, $0) }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:210
+msgid ""
+"The `build.rs` compiles the Swift source into a static library using "
+"`swiftc`, targeting the correct platform SDK:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:213
+msgid "// build.rs (simplified)\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:215
+msgid ""
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:221
+msgid "JNI bridge (Android)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:223
+msgid "Android platform APIs are accessed through JNI. The pattern:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:225
+msgid "Get the `JavaVM` via `JNI_GetCreatedJavaVMs()`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:226
+msgid "Attach the current thread to get a `JNIEnv`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:227
+msgid "Call Java/Kotlin APIs through JNI method invocations"
+msgstr ""
+
+#: src/plugins/native-extensions.md:228
+msgid "Resolve the Perry promise with the result"
+msgstr ""
+
+#: src/plugins/native-extensions.md:238
+msgid "// Get Activity from PerryBridge\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:239
+msgid "\"com/perry/app/PerryBridge\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:240
+msgid "\"getActivity\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:240
+msgid "\"()Landroid/app/Activity;\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:243
+msgid "// Call platform APIs via JNI...\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:248
+msgid ""
+"If the Android implementation requires a Java library (e.g., Google Play "
+"In-App Review), the app's `build.gradle` must include the dependency. "
+"Document this requirement clearly for your extension's users."
+msgstr ""
+
+#: src/plugins/native-extensions.md:250
+msgid "Stub crate"
+msgstr ""
+
+#: src/plugins/native-extensions.md:252
+msgid ""
+"For platforms without a native implementation, the stub immediately resolves "
+"the promise with an error:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:259
+msgid "\"{\\\"error\\\":\\\"Not available on this platform\\\"}\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:269
+msgid "Build requirements"
+msgstr ""
+
+#: src/plugins/native-extensions.md:273
+msgid "macOS host, Xcode, `rustup target add aarch64-apple-ios`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:274
+msgid "macOS host, Xcode, `rustup target add aarch64-apple-ios-sim`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:275
+msgid "macOS host, Xcode Command Line Tools"
+msgstr ""
+
+#: src/plugins/native-extensions.md:276
+msgid "Android NDK, `rustup target add aarch64-linux-android`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:278
+msgid ""
+"When Perry encounters a `perry.nativeLibrary` manifest during compilation, "
+"it:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:280
+msgid "Selects the crate for the current `--target` platform"
+msgstr ""
+
+#: src/plugins/native-extensions.md:281
+msgid "Runs `cargo build --release --target <triple>` in the crate directory"
+msgstr ""
+
+#: src/plugins/native-extensions.md:282
+msgid "Links the resulting `.a` static library into the final binary"
+msgstr ""
+
+#: src/plugins/native-extensions.md:283
+msgid "Adds any declared frameworks (e.g., `-framework StoreKit`)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:285
+msgid "Creating your own native extension"
+msgstr ""
+
+#: src/plugins/native-extensions.md:287
+msgid "Create the directory structure shown above"
+msgstr ""
+
+#: src/plugins/native-extensions.md:288
+msgid "Define your functions in `package.json` under `perry.nativeLibrary`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:289
+msgid ""
+"Implement each function in the platform crates with matching `#[no_mangle] "
+"pub extern \"C\"` signatures"
+msgstr ""
+
+#: src/plugins/native-extensions.md:290
+msgid ""
+"Write a TypeScript entry point that declares and optionally wraps the native "
+"functions"
+msgstr ""
+
+#: src/plugins/native-extensions.md:291
+msgid "Add a stub crate for unsupported platforms"
+msgstr ""
+
+#: src/plugins/native-extensions.md:292
+msgid "Test with `--bundle-extensions`:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:299
+msgid ""
+"[App Store Review](appstore-review.md) — Native review prompt extension "
+"(iOS/Android)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:300
+msgid ""
+"[Creating Plugins](creating-plugins.md) — Dynamic plugins loaded at runtime"
+msgstr ""
+
+#: src/plugins/appstore-review.md:3
+msgid ""
+"**Status: extension-dependent.** The compiler-side wiring "
+"(`--bundle-extensions`, `perry.nativeLibrary`, `declare function`) is in "
+"place — see [Native Extensions — Status](native-extensions.md) — but the "
+"snippets below assume the `perry-appstore-review` extension repo has been "
+"cloned into `./extensions/`. The doc-tests harness doesn't ship that repo, "
+"so these snippets are kept as `,no-test`. Once the extension is on disk, "
+"they compile and run on iOS / iOS Simulator / macOS / Android."
+msgstr ""
+
+#: src/plugins/appstore-review.md:5
+msgid ""
+"Prompt users to rate your app using the native app store review dialog on "
+"iOS and Android."
+msgstr ""
+
+#: src/plugins/appstore-review.md:7
+msgid ""
+"The `perry-appstore-review` extension exposes a single function — "
+"`requestReview()` — that opens the platform's native review prompt. It does "
+"nothing else: when and how often to ask is entirely up to you."
+msgstr ""
+
+#: src/plugins/appstore-review.md:9
+msgid ""
+"**Repository:** "
+"[github.com/PerryTS/appstorereview](https://github.com/PerryTS/appstorereview)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:13
+msgid "1. Add the extension"
+msgstr ""
+
+#: src/plugins/appstore-review.md:15
+msgid "Clone or copy the extension into your project's extensions directory:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:24
+msgid "Your project structure:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:35
+msgid "2. Use in your app"
+msgstr ""
+
+#: src/plugins/appstore-review.md:37
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"\n"
+"// Show the review prompt when the user completes a meaningful action\n"
+"async function onLevelComplete() {\n"
+"  await requestReview();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/appstore-review.md:46
+msgid "3. Build"
+msgstr ""
+
+#: src/plugins/appstore-review.md:52
+msgid ""
+"The `--bundle-extensions` flag tells Perry to discover, compile, and link "
+"all native extensions in the given directory. The app store review native "
+"code is compiled and statically linked into your binary — no runtime "
+"dependencies."
+msgstr ""
+
+#: src/plugins/appstore-review.md:56
+msgid "`requestReview(): Promise<void>`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:58
+msgid ""
+"Opens the native app store review prompt. Returns a promise that resolves "
+"when the prompt has been presented (or skipped by the OS)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:66
+msgid "The function only triggers the prompt. It does not:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:67
+msgid "Track whether the user has already reviewed"
+msgstr ""
+
+#: src/plugins/appstore-review.md:68
+msgid ""
+"Throttle how often the prompt appears (iOS does this automatically; Android "
+"does not)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:69
+msgid ""
+"Return whether the user actually left a review (neither platform provides "
+"this)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:71
+msgid "Platform behavior"
+msgstr ""
+
+#: src/plugins/appstore-review.md:75
+msgid ""
+"Uses "
+"[`SKStoreReviewController.requestReview(in:)`](https://developer.apple.com/documentation/storekit/skstorereviewcontroller/requestreview(in:)) "
+"from StoreKit."
+msgstr ""
+
+#: src/plugins/appstore-review.md:77 src/plugins/appstore-review.md:93
+#: src/plugins/appstore-review.md:106
+msgid "Detail"
+msgstr ""
+
+#: src/plugins/appstore-review.md:79 src/plugins/appstore-review.md:95
+#: src/plugins/appstore-review.md:108
+msgid "Native API"
+msgstr ""
+
+#: src/plugins/appstore-review.md:79
+msgid "`SKStoreReviewController.requestReview(in: UIWindowScene)`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:80
+msgid "Minimum iOS version"
+msgstr ""
+
+#: src/plugins/appstore-review.md:80
+msgid "14.0"
+msgstr ""
+
+#: src/plugins/appstore-review.md:81 src/plugins/appstore-review.md:97
+msgid "Framework"
+msgstr ""
+
+#: src/plugins/appstore-review.md:81 src/plugins/appstore-review.md:97
+msgid "StoreKit"
+msgstr ""
+
+#: src/plugins/appstore-review.md:82
+msgid "Thread"
+msgstr ""
+
+#: src/plugins/appstore-review.md:82
+msgid "Dispatched to main thread automatically"
+msgstr ""
+
+#: src/plugins/appstore-review.md:83 src/plugins/appstore-review.md:98
+#: src/plugins/appstore-review.md:111
+msgid "Throttling"
+msgstr ""
+
+#: src/plugins/appstore-review.md:83
+msgid ""
+"Apple limits display to 3 times per 365-day period per app. The system may "
+"silently ignore the call."
+msgstr ""
+
+#: src/plugins/appstore-review.md:84
+msgid "Development builds"
+msgstr ""
+
+#: src/plugins/appstore-review.md:84
+msgid "Always shown in debug/TestFlight builds"
+msgstr ""
+
+#: src/plugins/appstore-review.md:85
+msgid "User control"
+msgstr ""
+
+#: src/plugins/appstore-review.md:85
+msgid "Users can disable review prompts in Settings > App Store"
+msgstr ""
+
+#: src/plugins/appstore-review.md:87
+msgid ""
+"**Important:** Apple's throttling means the prompt is not guaranteed to "
+"appear every time `requestReview()` is called. Design your app flow so that "
+"not showing the prompt doesn't break the user experience."
+msgstr ""
+
+#: src/plugins/appstore-review.md:91
+msgid ""
+"Uses the same StoreKit API. Shares the iOS native crate (both compile from "
+"`crate-ios`)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:95
+msgid "`SKStoreReviewController.requestReview()`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:96
+msgid "Minimum macOS version"
+msgstr ""
+
+#: src/plugins/appstore-review.md:96
+msgid "13.0"
+msgstr ""
+
+#: src/plugins/appstore-review.md:98
+msgid "Same as iOS — system-controlled"
+msgstr ""
+
+#: src/plugins/appstore-review.md:100
+msgid "Only works for apps distributed through the Mac App Store."
+msgstr ""
+
+#: src/plugins/appstore-review.md:104
+msgid ""
+"Uses the [Google Play In-App Review "
+"API](https://developer.android.com/guide/playcore/in-app-review)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:108
+msgid "`ReviewManager.requestReviewFlow()` + `launchReviewFlow()`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:109
+msgid "Library"
+msgstr ""
+
+#: src/plugins/appstore-review.md:109
+msgid "`com.google.android.play:review`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:110
+msgid "Minimum API level"
+msgstr ""
+
+#: src/plugins/appstore-review.md:110
+msgid "21 (Android 5.0)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:111
+msgid "Google enforces a quota — the prompt may not appear every time"
+msgstr ""
+
+#: src/plugins/appstore-review.md:112
+msgid "Execution"
+msgstr ""
+
+#: src/plugins/appstore-review.md:112
+msgid "Runs on a background thread to avoid blocking the UI"
+msgstr ""
+
+#: src/plugins/appstore-review.md:114
+msgid ""
+"**Required Gradle dependency:** The Google Play In-App Review API is not "
+"part of the Android SDK. You must add it to your app's `build.gradle`:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:118
+msgid "'com.google.android.play:review:2.0.2'"
+msgstr ""
+
+#: src/plugins/appstore-review.md:122
+msgid ""
+"Without this dependency, `requestReview()` will resolve with an error "
+"explaining the missing library."
+msgstr ""
+
+#: src/plugins/appstore-review.md:124
+msgid "Other platforms"
+msgstr ""
+
+#: src/plugins/appstore-review.md:126
+msgid ""
+"On unsupported platforms (Linux, Windows, Web), `requestReview()` resolves "
+"immediately with an error. It will not throw — your app continues normally."
+msgstr ""
+
+#: src/plugins/appstore-review.md:128
+msgid "Best practices"
+msgstr ""
+
+#: src/plugins/appstore-review.md:130
+msgid ""
+"**Do ask at the right moment.** Prompt after a positive experience — "
+"completing a level, finishing a task, achieving a goal. Don't ask on first "
+"launch or during onboarding."
+msgstr ""
+
+#: src/plugins/appstore-review.md:132
+msgid ""
+"**Don't ask too often.** Even though iOS throttles automatically, Android "
+"does not have the same strict limits. Implement your own logic to track when "
+"you last asked:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:134
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"import { preferencesGet, preferencesSet } from \"perry/system\";\n"
+"\n"
+"async function maybeAskForReview() {\n"
+"  const lastAsked = Number(preferencesGet(\"lastReviewAsk\") || \"0\");\n"
+"  const now = Date.now();\n"
+"  const thirtyDays = 30 * 24 * 60 * 60 * 1000;\n"
+"\n"
+"  if (now - lastAsked > thirtyDays) {\n"
+"    preferencesSet(\"lastReviewAsk\", String(now));\n"
+"    await requestReview();\n"
+"  }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/appstore-review.md:150
+msgid ""
+"**Don't condition app behavior on the review.** Neither iOS nor Android "
+"tells you whether the user left a review, gave a rating, or dismissed the "
+"prompt. The promise resolving does not mean a review was submitted."
+msgstr ""
+
+#: src/plugins/appstore-review.md:152
+msgid ""
+"**Don't use custom review dialogs before the native one.** Both Apple and "
+"Google discourage showing your own \"Rate this app?\" dialog before the "
+"native prompt. The native prompt is designed to be low-friction — adding a "
+"pre-prompt increases abandonment."
+msgstr ""
+
+#: src/plugins/appstore-review.md:154
+msgid "Extension structure"
+msgstr ""
+
+#: src/plugins/appstore-review.md:156
+msgid ""
+"The extension follows the standard [native extension](native-extensions.md) "
+"layout:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:176
+msgid "One native function is declared in `package.json`:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:190
+msgid ""
+"The TypeScript layer wraps this into the public `requestReview()` function. "
+"The native layer creates a Perry promise, calls the platform API, and "
+"resolves the promise when done."
+msgstr ""
+
+#: src/plugins/appstore-review.md:194
+msgid ""
+"[Native Extensions](native-extensions.md) — How native extensions work, "
+"creating your own"
+msgstr ""
+
+#: src/plugins/appstore-review.md:195
+msgid "[iOS Platform](../platforms/ios.md) — iOS platform guide"
+msgstr ""
+
+#: src/plugins/appstore-review.md:196
+msgid "[Android Platform](../platforms/android.md) — Android platform guide"
+msgstr ""
+
+#: src/testing/geisterhand.md:1
+msgid "Geisterhand — In-Process UI Testing"
+msgstr ""
+
+#: src/testing/geisterhand.md:3
+msgid ""
+"Geisterhand (German for \"ghost hand\") embeds a lightweight HTTP server "
+"inside your Perry app that lets you interact with every widget "
+"programmatically. Click buttons, type into text fields, drag sliders, toggle "
+"switches, capture screenshots, and run chaos-mode random fuzzing — all via "
+"simple HTTP calls."
+msgstr ""
+
+#: src/testing/geisterhand.md:5
+msgid ""
+"It works on **all 5 native platforms** (macOS, iOS, Android, Linux/GTK4, "
+"Windows) with zero external dependencies. The server starts automatically "
+"when you compile with `--enable-geisterhand`."
+msgstr ""
+
+#: src/testing/geisterhand.md:12
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:14
+msgid "# 2. Run the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:16
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:18
+msgid "# 3. In another terminal — interact with the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:20
+msgid "# List all widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:21
+msgid "# Click button with handle 3\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:22
+msgid "# Capture window screenshot\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:25
+msgid "Custom Port"
+msgstr ""
+
+#: src/testing/geisterhand.md:27
+msgid ""
+"The default port is **7676**. Use `--geisterhand-port` to change it (this "
+"implies `--enable-geisterhand`, so you don't need both flags):"
+msgstr ""
+
+#: src/testing/geisterhand.md:30
+msgid "# or with perry run:\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:35
+msgid "With `perry run`"
+msgstr ""
+
+#: src/testing/geisterhand.md:47
+msgid ""
+"All endpoints return JSON unless noted otherwise. All responses include "
+"`Access-Control-Allow-Origin: *` for browser-based tools. OPTIONS requests "
+"are supported for CORS preflight."
+msgstr ""
+
+#: src/testing/geisterhand.md:49
+msgid "Health Check"
+msgstr ""
+
+#: src/testing/geisterhand.md:51
+msgid ""
+"```\n"
+"GET /health\n"
+"→ {\"status\":\"ok\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:56
+msgid "Use this to wait for the app to be ready before running tests."
+msgstr ""
+
+#: src/testing/geisterhand.md:58
+msgid "List Widgets"
+msgstr ""
+
+#: src/testing/geisterhand.md:64
+msgid "Returns a JSON array of all registered widgets:"
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"handle\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:458 src/testing/geisterhand.md:459
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"widget_type\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"callback_kind\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"label\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68
+msgid "\"Click Me\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+msgid "\"shortcut\""
+msgstr ""
+
+#: src/testing/geisterhand.md:69
+msgid "\"Type here...\""
+msgstr ""
+
+#: src/testing/geisterhand.md:71
+msgid "\"Enable\""
+msgstr ""
+
+#: src/testing/geisterhand.md:72
+msgid "\"Save\""
+msgstr ""
+
+#: src/testing/geisterhand.md:72
+msgid "\"s\""
+msgstr ""
+
+#: src/testing/geisterhand.md:77
+msgid "Supports query parameter filters:"
+msgstr ""
+
+#: src/testing/geisterhand.md:78
+msgid "`GET /widgets?label=Save` — filter by label substring (case-insensitive)"
+msgstr ""
+
+#: src/testing/geisterhand.md:79
+msgid "`GET /widgets?type=button` — filter by widget type name or code"
+msgstr ""
+
+#: src/testing/geisterhand.md:80
+msgid "`GET /widgets?label=Save&type=5` — combine filters"
+msgstr ""
+
+#: src/testing/geisterhand.md:82
+msgid "Widget Types"
+msgstr ""
+
+#: src/testing/geisterhand.md:84 src/testing/geisterhand.md:98
+msgid "Code"
+msgstr ""
+
+#: src/testing/geisterhand.md:86
+msgid "Push button with onClick"
+msgstr ""
+
+#: src/testing/geisterhand.md:87
+msgid "Text input field"
+msgstr ""
+
+#: src/testing/geisterhand.md:88
+msgid "Numeric slider"
+msgstr ""
+
+#: src/testing/geisterhand.md:89
+msgid "On/off switch"
+msgstr ""
+
+#: src/testing/geisterhand.md:90
+msgid "Dropdown selector"
+msgstr ""
+
+#: src/testing/geisterhand.md:91 src/testing/geisterhand.md:294
+msgid "Menu"
+msgstr ""
+
+#: src/testing/geisterhand.md:91
+msgid "Menu item"
+msgstr ""
+
+#: src/testing/geisterhand.md:92 src/cli/perry-toml.md:399
+msgid "6"
+msgstr ""
+
+#: src/testing/geisterhand.md:92
+msgid "Keyboard shortcut"
+msgstr ""
+
+#: src/testing/geisterhand.md:93
+msgid "Data table"
+msgstr ""
+
+#: src/testing/geisterhand.md:94
+msgid "8"
+msgstr ""
+
+#: src/testing/geisterhand.md:94
+msgid "Scrollable container"
+msgstr ""
+
+#: src/testing/geisterhand.md:96
+msgid "Callback Kinds"
+msgstr ""
+
+#: src/testing/geisterhand.md:98
+msgid "Kind"
+msgstr ""
+
+#: src/testing/geisterhand.md:100
+msgid "Triggered on click/tap"
+msgstr ""
+
+#: src/testing/geisterhand.md:101
+msgid "onChange"
+msgstr ""
+
+#: src/testing/geisterhand.md:101
+msgid "Triggered on value change"
+msgstr ""
+
+#: src/testing/geisterhand.md:102
+msgid "onSubmit"
+msgstr ""
+
+#: src/testing/geisterhand.md:102
+msgid "Triggered on submit (e.g., pressing Enter)"
+msgstr ""
+
+#: src/testing/geisterhand.md:103
+msgid "Triggered on mouse hover"
+msgstr ""
+
+#: src/testing/geisterhand.md:104
+msgid "Triggered on double-click"
+msgstr ""
+
+#: src/testing/geisterhand.md:105
+msgid "onFocus"
+msgstr ""
+
+#: src/testing/geisterhand.md:105
+msgid "Triggered on focus"
+msgstr ""
+
+#: src/testing/geisterhand.md:107
+msgid ""
+"A single widget may appear multiple times in the list with different "
+"callback kinds. For example, a button with both `onClick` and `onHover` "
+"handlers produces two entries (same handle, different `callback_kind`)."
+msgstr ""
+
+#: src/testing/geisterhand.md:109
+msgid "Click a Widget"
+msgstr ""
+
+#: src/testing/geisterhand.md:111
+msgid ""
+"```\n"
+"POST /click/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:116
+msgid ""
+"Fires the widget's `onClick` callback. Works with buttons, menu items, "
+"shortcuts, and table rows."
+msgstr ""
+
+#: src/testing/geisterhand.md:122
+msgid "Type into a TextField"
+msgstr ""
+
+#: src/testing/geisterhand.md:124
+msgid ""
+"```\n"
+"POST /type/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"text\": \"hello world\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:131
+msgid ""
+"Sets the text field's content and fires its `onChange` callback with the new "
+"text as a NaN-boxed string."
+msgstr ""
+
+#: src/testing/geisterhand.md:139
+msgid "Move a Slider"
+msgstr ""
+
+#: src/testing/geisterhand.md:141
+msgid ""
+"```\n"
+"POST /slide/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"value\": 0.75}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:148
+msgid "Sets the slider position and fires `onChange` with the numeric value."
+msgstr ""
+
+#: src/testing/geisterhand.md:156
+msgid "Toggle a Switch"
+msgstr ""
+
+#: src/testing/geisterhand.md:158
+msgid ""
+"```\n"
+"POST /toggle/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:163
+msgid "Fires the toggle's `onChange` callback with a boolean value."
+msgstr ""
+
+#: src/testing/geisterhand.md:169
+msgid "Set State Directly"
+msgstr ""
+
+#: src/testing/geisterhand.md:171
+msgid ""
+"```\n"
+"POST /state/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"value\": 42}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:178
+msgid ""
+"Directly sets a `State` cell's value, bypassing widget callbacks. This "
+"triggers any reactive bindings attached to the state (bound text labels, "
+"visibility, forEach loops, etc.)."
+msgstr ""
+
+#: src/testing/geisterhand.md:186
+msgid "Hover"
+msgstr ""
+
+#: src/testing/geisterhand.md:188
+msgid ""
+"```\n"
+"POST /hover/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:193
+msgid ""
+"Fires the widget's `onHover` callback. Useful for testing hover-dependent UI "
+"(tooltips, color changes, etc.)."
+msgstr ""
+
+#: src/testing/geisterhand.md:195
+msgid "Double-Click"
+msgstr ""
+
+#: src/testing/geisterhand.md:197
+msgid ""
+"```\n"
+"POST /doubleclick/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:202
+msgid "Fires the widget's `onDoubleClick` callback."
+msgstr ""
+
+#: src/testing/geisterhand.md:204
+msgid "Trigger Keyboard Shortcut"
+msgstr ""
+
+#: src/testing/geisterhand.md:206
+msgid ""
+"```\n"
+"POST /key\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"shortcut\": \"s\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:213
+msgid ""
+"Finds a registered menu item whose shortcut matches and fires its callback. "
+"Shortcut strings are case-insensitive and match the key string passed to "
+"`menuAddItem` (e.g., `\"s\"` for Cmd+S, `\"S\"` for Cmd+Shift+S, `\"n\"` for "
+"Cmd+N)."
+msgstr ""
+
+#: src/testing/geisterhand.md:221
+msgid ""
+"Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no match."
+msgstr ""
+
+#: src/testing/geisterhand.md:223
+msgid "Scroll a ScrollView"
+msgstr ""
+
+#: src/testing/geisterhand.md:225
+msgid ""
+"```\n"
+"POST /scroll/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"x\": 0, \"y\": 100}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:232
+msgid ""
+"Sets the scroll offset of a ScrollView widget. Both `x` and `y` are in "
+"points."
+msgstr ""
+
+#: src/testing/geisterhand.md:240
+msgid "Capture Screenshot"
+msgstr ""
+
+#: src/testing/geisterhand.md:247
+msgid ""
+"Captures the app window as a PNG image. The response is raw binary data, not "
+"JSON."
+msgstr ""
+
+#: src/testing/geisterhand.md:253
+msgid ""
+"Screenshot capture is synchronous from the caller's perspective — the HTTP "
+"request blocks until the main thread completes the capture (timeout: 5 "
+"seconds)."
+msgstr ""
+
+#: src/testing/geisterhand.md:255
+msgid "**Platform-specific capture methods:**"
+msgstr ""
+
+#: src/testing/geisterhand.md:259
+msgid "`CGWindowListCreateImage`"
+msgstr ""
+
+#: src/testing/geisterhand.md:259
+msgid "Retina resolution, reads from window ID"
+msgstr ""
+
+#: src/testing/geisterhand.md:260
+msgid "`UIGraphicsImageRenderer`"
+msgstr ""
+
+#: src/testing/geisterhand.md:260
+msgid "Draws view hierarchy into image context"
+msgstr ""
+
+#: src/testing/geisterhand.md:261
+msgid "JNI `View.draw()` on Canvas"
+msgstr ""
+
+#: src/testing/geisterhand.md:261
+msgid "Creates Bitmap, compresses to PNG"
+msgstr ""
+
+#: src/testing/geisterhand.md:262
+msgid "`WidgetPaintable` + `GskRenderer`"
+msgstr ""
+
+#: src/testing/geisterhand.md:262
+msgid "Renders to texture, saves as PNG bytes"
+msgstr ""
+
+#: src/testing/geisterhand.md:263
+msgid "`PrintWindow` + `GetDIBits`"
+msgstr ""
+
+#: src/testing/geisterhand.md:263
+msgid "Inline PNG encoder (stored zlib blocks)"
+msgstr ""
+
+#: src/testing/geisterhand.md:265
+msgid "Chaos Mode"
+msgstr ""
+
+#: src/testing/geisterhand.md:267
+msgid ""
+"Chaos mode randomly interacts with widgets at a configurable interval — "
+"useful for stress testing, finding edge cases, and crash hunting."
+msgstr ""
+
+#: src/testing/geisterhand.md:269
+msgid "Start"
+msgstr ""
+
+#: src/testing/geisterhand.md:271
+msgid ""
+"```\n"
+"POST /chaos/start\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"interval_ms\": 200}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:279
+msgid "# Fire random inputs every 200ms\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:285
+msgid ""
+"If `interval_ms` is omitted, a default interval is used. The chaos thread "
+"randomly selects a registered widget and fires an appropriate input based on "
+"widget type:"
+msgstr ""
+
+#: src/testing/geisterhand.md:287
+msgid "Widget Type"
+msgstr ""
+
+#: src/testing/geisterhand.md:287
+msgid "Random Input"
+msgstr ""
+
+#: src/testing/geisterhand.md:289 src/testing/geisterhand.md:294
+#: src/testing/geisterhand.md:295 src/testing/geisterhand.md:296
+msgid "Fires onClick (no args)"
+msgstr ""
+
+#: src/testing/geisterhand.md:290
+msgid "Random alphanumeric string, 5-20 characters"
+msgstr ""
+
+#: src/testing/geisterhand.md:291
+msgid "Random float between 0.0 and 1.0"
+msgstr ""
+
+#: src/testing/geisterhand.md:292
+msgid "Random true/false"
+msgstr ""
+
+#: src/testing/geisterhand.md:293
+msgid "Random index 0-9"
+msgstr ""
+
+#: src/testing/geisterhand.md:300
+msgid ""
+"```\n"
+"GET /chaos/status\n"
+"→ {\"running\":true,\"events_fired\":247,\"uptime_secs\":12}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:305
+msgid ""
+"Returns whether chaos mode is active, how many random events have been "
+"fired, and uptime in seconds."
+msgstr ""
+
+#: src/testing/geisterhand.md:307
+msgid "Stop"
+msgstr ""
+
+#: src/testing/geisterhand.md:309
+msgid ""
+"```\n"
+"POST /chaos/stop\n"
+"→ {\"ok\":true,\"chaos\":\"stopped\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:314
+msgid "Error Responses"
+msgstr ""
+
+#: src/testing/geisterhand.md:316
+msgid "All endpoints return errors as JSON with an appropriate HTTP status code:"
+msgstr ""
+
+#: src/testing/geisterhand.md:319
+msgid "\"widget handle 99 not found\""
+msgstr ""
+
+#: src/testing/geisterhand.md:322
+msgid "Common errors:"
+msgstr ""
+
+#: src/testing/geisterhand.md:323
+msgid "`404` — widget handle not found"
+msgstr ""
+
+#: src/testing/geisterhand.md:324
+msgid "`400` — malformed JSON body or missing required field"
+msgstr ""
+
+#: src/testing/geisterhand.md:325
+msgid "`405` — unsupported HTTP method"
+msgstr ""
+
+#: src/testing/geisterhand.md:329
+msgid "Platform Setup"
+msgstr ""
+
+#: src/testing/geisterhand.md:333
+msgid ""
+"No extra setup needed. The server binds to `0.0.0.0:7676` and is accessible "
+"on `localhost`."
+msgstr ""
+
+#: src/testing/geisterhand.md:343
+msgid ""
+"The iOS Simulator shares the host's network stack — access the server "
+"directly on `localhost`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:352 src/cli/flags.md:24
+msgid "iOS Device"
+msgstr ""
+
+#: src/testing/geisterhand.md:354
+msgid ""
+"For physical iOS devices, you need a network route to the device (same Wi-Fi "
+"network) or use `iproxy` from `libimobiledevice`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:357
+msgid "# Install and launch via Xcode/devicectl\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:359
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:363
+msgid "Android (Emulator or Device)"
+msgstr ""
+
+#: src/testing/geisterhand.md:365
+msgid ""
+"Use `adb forward` to bridge the port. Ensure `INTERNET` permission is in "
+"your manifest (or add it to `perry.toml`):"
+msgstr ""
+
+#: src/testing/geisterhand.md:367
+msgid ""
+"```toml\n"
+"[android]\n"
+"permissions = [\"INTERNET\"]\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:373
+msgid "# Package into APK and install\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:381
+msgid "Install GTK4 development libraries first:"
+msgstr ""
+
+#: src/testing/geisterhand.md:402
+msgid "Test Automation"
+msgstr ""
+
+#: src/testing/geisterhand.md:404
+msgid ""
+"Geisterhand turns your Perry app into a testable HTTP service. Here are "
+"practical patterns for automated testing."
+msgstr ""
+
+#: src/testing/geisterhand.md:406
+msgid "Shell Script Tests"
+msgstr ""
+
+#: src/testing/geisterhand.md:408
+msgid "A simple end-to-end test using bash:"
+msgstr ""
+
+#: src/testing/geisterhand.md:411
+msgid "#!/bin/bash\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:413
+msgid "# Build with geisterhand\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:416
+msgid "# Start the app in background\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:419
+msgid "$!"
+msgstr ""
+
+#: src/testing/geisterhand.md:420
+msgid "\"kill $APP_PID 2>/dev/null\""
+msgstr ""
+
+#: src/testing/geisterhand.md:421
+msgid "# Wait for the app to be ready\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:427
+msgid "# Get widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:430
+msgid "\"Registered widgets: $WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:431
+msgid "# Find the button labeled \"Submit\"\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
+msgstr ""
+
+#: src/testing/geisterhand.md:434
+msgid "# Click it\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:436
+msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
+msgstr ""
+
+#: src/testing/geisterhand.md:437
+msgid "# Take a screenshot after interaction\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:441
+msgid "\"Test passed\""
+msgstr ""
+
+#: src/testing/geisterhand.md:444
+msgid "Python Test Example"
+msgstr ""
+
+#: src/testing/geisterhand.md:448
+msgid "# Start the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:450
+msgid "\"./testapp\""
+msgstr ""
+
+#: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
+msgid "# Wait for startup\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:454
+msgid "# List widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:455
+msgid "\"http://127.0.0.1:7676/widgets\""
+msgstr ""
+
+#: src/testing/geisterhand.md:457
+msgid "# Find widgets by label\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:461
+msgid "# Type into the first text field\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:464
+msgid "\"http://127.0.0.1:7676/type/"
+msgstr ""
+
+#: src/testing/geisterhand.md:464 src/testing/geisterhand.md:470
+msgid "'handle'"
+msgstr ""
+
+#: src/testing/geisterhand.md:464 src/testing/geisterhand.md:470
+msgid "\""
+msgstr ""
+
+#: src/testing/geisterhand.md:465
+msgid "\"test@example.com\""
+msgstr ""
+
+#: src/testing/geisterhand.md:468
+msgid "# Click the first button\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:470
+msgid "\"http://127.0.0.1:7676/click/"
+msgstr ""
+
+#: src/testing/geisterhand.md:472
+msgid "# Capture screenshot for visual regression\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:473
+msgid "\"http://127.0.0.1:7676/screenshot\""
+msgstr ""
+
+#: src/testing/geisterhand.md:474
+msgid "\"test-result.png\""
+msgstr ""
+
+#: src/testing/geisterhand.md:474
+msgid "\"wb\""
+msgstr ""
+
+#: src/testing/geisterhand.md:477
+msgid "# Assert the app is still healthy\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"http://127.0.0.1:7676/health\""
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"status\""
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"ok\""
+msgstr ""
+
+#: src/testing/geisterhand.md:479
+msgid "\"All tests passed\""
+msgstr ""
+
+#: src/testing/geisterhand.md:484
+msgid "Stress Testing with Chaos Mode"
+msgstr ""
+
+#: src/testing/geisterhand.md:486
+msgid ""
+"Run chaos mode against your app to find crashes, freezes, or unexpected "
+"state:"
+msgstr ""
+
+#: src/testing/geisterhand.md:489
+msgid "# Build and launch\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:495
+msgid "# Start aggressive chaos (every 50ms)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:518
+msgid "Visual Regression Testing"
+msgstr ""
+
+#: src/testing/geisterhand.md:520
+msgid ""
+"Capture screenshots at key interaction points and compare against baselines:"
+msgstr ""
+
+#: src/testing/geisterhand.md:523
+msgid "# Initial state\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:525
+msgid "# Interact\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:528
+msgid "'{\"text\":\"Hello\"}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:529
+msgid "# Capture after interaction\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:532
+msgid "# Compare (using ImageMagick)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:537
+msgid "CI Pipeline Integration"
+msgstr ""
+
+#: src/testing/geisterhand.md:540
+msgid "# GitHub Actions example\njobs"
+msgstr ""
+
+#: src/testing/geisterhand.md:542
+msgid "ui-test"
+msgstr ""
+
+#: src/testing/geisterhand.md:543
+msgid "runs-on"
+msgstr ""
+
+#: src/testing/geisterhand.md:543
+msgid "macos-latest"
+msgstr ""
+
+#: src/testing/geisterhand.md:544 src/cli/perry-toml.md:602
+msgid "steps"
+msgstr ""
+
+#: src/testing/geisterhand.md:545
+msgid "uses"
+msgstr ""
+
+#: src/testing/geisterhand.md:545
+msgid "actions/checkout@v4"
+msgstr ""
+
+#: src/testing/geisterhand.md:547 src/testing/geisterhand.md:550
+msgid "name"
+msgstr ""
+
+#: src/testing/geisterhand.md:547
+msgid "Build with geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:548 src/testing/geisterhand.md:551
+#: src/cli/commands.md:48 src/cli/perry-toml.md:604 src/cli/perry-toml.md:605
+#: src/cli/perry-toml.md:606
+msgid "run"
+msgstr ""
+
+#: src/testing/geisterhand.md:548
+msgid "perry app.ts -o testapp --enable-geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:550
+msgid "Run UI tests"
+msgstr ""
+
+#: src/testing/geisterhand.md:554
+msgid "# Run your test script\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:568
+msgid "Example App"
+msgstr ""
+
+#: src/testing/geisterhand.md:570
+msgid ""
+"A complete Perry UI app demonstrating every widget type Geisterhand can "
+"interact with — verified by CI:"
+msgstr ""
+
+#: src/testing/geisterhand.md:573
+msgid ""
+"```typescript\n"
+"// demonstrates: Geisterhand-targetable Perry UI app — every common widget\n"
+"// docs: docs/src/testing/geisterhand.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"// A complete Perry UI app exercising every widget type Geisterhand\n"
+"// (the UI fuzzer) can interact with. The doc-tests harness compiles\n"
+"// and runs this on every PR, so the snippet on the docs page can never\n"
+"// drift from the real perry/ui API.\n"
+"\n"
+"import {\n"
+"    App, VStack, HStack,\n"
+"    Text, Button, TextField, Slider, Toggle, Picker,\n"
+"    State, stateOnChange,\n"
+"    pickerAddItem,\n"
+"    textSetString,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// State for reactive UI\n"
+"const counterState = State(0)\n"
+"const textState = State(\"\")\n"
+"\n"
+"// Labels\n"
+"const title = Text(\"Geisterhand Demo\")\n"
+"const counterLabel = Text(\"Count: 0\")\n"
+"\n"
+"// Bind counter state to label via the free-function listener\n"
+"stateOnChange(counterState, (val: number) => {\n"
+"    textSetString(counterLabel, `Count: ${val}`)\n"
+"})\n"
+"\n"
+"// Button — widget_type = 0\n"
+"const incrementBtn = Button(\"Increment\", () => {\n"
+"    counterState.set(counterState.value + 1)\n"
+"})\n"
+"const resetBtn = Button(\"Reset\", () => {\n"
+"    counterState.set(0)\n"
+"})\n"
+"\n"
+"// TextField(placeholder, onChange) — widget_type = 1\n"
+"const nameField = TextField(\"Enter your name\", (text: string) => {\n"
+"    textState.set(text)\n"
+"    console.log(`Name: ${text}`)\n"
+"})\n"
+"\n"
+"// Slider(min, max, onChange) — widget_type = 2\n"
+"const volumeSlider = Slider(0, 100, (value: number) => {\n"
+"    console.log(`Volume: ${value}`)\n"
+"})\n"
+"\n"
+"// Toggle(label, onChange) — widget_type = 3\n"
+"const darkModeToggle = Toggle(\"Dark Mode\", (on: boolean) => {\n"
+"    console.log(`Dark mode: ${on}`)\n"
+"})\n"
+"\n"
+"// Picker(onChange); items added with pickerAddItem.\n"
+"const sizePicker = Picker((index: number) => {\n"
+"    console.log(`Size index: ${index}`)\n"
+"})\n"
+"pickerAddItem(sizePicker, \"Small\")\n"
+"pickerAddItem(sizePicker, \"Medium\")\n"
+"pickerAddItem(sizePicker, \"Large\")\n"
+"\n"
+"// Layout\n"
+"const buttonRow = HStack(8, [incrementBtn, resetBtn])\n"
+"const stack = VStack(12, [\n"
+"    title, counterLabel, buttonRow,\n"
+"    nameField, volumeSlider, darkModeToggle, sizePicker,\n"
+"])\n"
+"\n"
+"App({\n"
+"    title: \"Geisterhand Demo\",\n"
+"    width: 400,\n"
+"    height: 480,\n"
+"    body: stack,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:651
+msgid "After compiling with `--enable-geisterhand` and running:"
+msgstr ""
+
+#: src/testing/geisterhand.md:654
+msgid "# See all interactive widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:655
+msgid "# [\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:657
+msgid "\"Increment\""
+msgstr ""
+
+#: src/testing/geisterhand.md:657
+msgid ""
+"#   "
+"{\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:659
+msgid "\"Enter your name\""
+msgstr ""
+
+#: src/testing/geisterhand.md:659
+msgid ""
+"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:661
+msgid "\"Dark Mode\""
+msgstr ""
+
+#: src/testing/geisterhand.md:661
+msgid "# ]\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:663
+msgid "# Click Increment 3 times\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:665
+msgid "# Counter label now shows \"Count: 3\"\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:667
+msgid "# Type a name\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:669
+msgid "'{\"text\":\"Perry\"}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:670
+msgid "# Set slider to 80%\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:672
+msgid "'{\"value\":0.8}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:673
+msgid "# Toggle dark mode on\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:676
+msgid "# Screenshot\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:685
+msgid ""
+"Geisterhand operates as three cooperating components connected by "
+"thread-safe queues:"
+msgstr ""
+
+#: src/testing/geisterhand.md:729
+msgid "Lifecycle"
+msgstr ""
+
+#: src/testing/geisterhand.md:731
+msgid ""
+"**Startup**: When `--enable-geisterhand` is used, the compiled binary calls "
+"`perry_geisterhand_start(port)` during initialization. This spawns a "
+"background thread running a `tiny-http` server."
+msgstr ""
+
+#: src/testing/geisterhand.md:733
+msgid ""
+"**Widget Registration**: As UI widgets are created (Button, TextField, "
+"Slider, etc.), each one calls `perry_geisterhand_register(handle, "
+"widget_type, callback_kind, closure_f64, label)` to register its callback in "
+"the global registry. This is gated behind `#[cfg(feature = "
+"\"geisterhand\")]` so normal builds have zero overhead."
+msgstr ""
+
+#: src/testing/geisterhand.md:735
+msgid ""
+"**HTTP Requests**: When a request arrives (e.g., `POST /click/3`), the "
+"server looks up handle 3 in the registry, finds the associated closure, and "
+"pushes a `PendingAction::InvokeCallback` onto the pending actions queue."
+msgstr ""
+
+#: src/testing/geisterhand.md:737
+msgid ""
+"**Main-Thread Dispatch**: The platform's timer (NSTimer on macOS, glib "
+"timeout on GTK4, WM_TIMER on Windows, etc.) calls `perry_geisterhand_pump()` "
+"every ~8ms. This drains the pending actions queue and executes callbacks on "
+"the main thread, which is required for UI safety."
+msgstr ""
+
+#: src/testing/geisterhand.md:739
+msgid ""
+"**Screenshot Capture**: Screenshots use `Condvar` synchronization — the HTTP "
+"thread queues a `CaptureScreenshot` action, then blocks waiting on a "
+"condition variable. The main thread's pump executes the platform-specific "
+"capture, stores the PNG data, and signals the condvar. Timeout: 5 seconds."
+msgstr ""
+
+#: src/testing/geisterhand.md:741
+msgid "Thread Safety"
+msgstr ""
+
+#: src/testing/geisterhand.md:743
+msgid ""
+"**Widget Registry**: Protected by `Mutex`. Read by the HTTP server (to list "
+"widgets and look up handles), written by the main thread (during widget "
+"creation)."
+msgstr ""
+
+#: src/testing/geisterhand.md:744
+msgid ""
+"**Pending Actions Queue**: Protected by `Mutex`. Written by HTTP server "
+"thread, drained by main thread in `pump()`."
+msgstr ""
+
+#: src/testing/geisterhand.md:745
+msgid ""
+"**Screenshot Result**: Protected by `Mutex` + `Condvar`. HTTP thread waits, "
+"main thread signals."
+msgstr ""
+
+#: src/testing/geisterhand.md:746
+msgid ""
+"**Chaos Mode State**: Uses `AtomicBool` (running flag) and `AtomicU64` "
+"(event counter) for lock-free status checks."
+msgstr ""
+
+#: src/testing/geisterhand.md:748
+msgid "NaN-Boxing Bridge"
+msgstr ""
+
+#: src/testing/geisterhand.md:750
+msgid ""
+"When geisterhand needs to pass values to widget callbacks, it must create "
+"properly NaN-boxed values:"
+msgstr ""
+
+#: src/testing/geisterhand.md:752
+msgid ""
+"**Strings** (for TextField): Calls `js_string_from_bytes(ptr, len)` to "
+"allocate a runtime string, then `js_nanbox_string(ptr)` to wrap it with "
+"STRING_TAG (0x7FFF)."
+msgstr ""
+
+#: src/testing/geisterhand.md:753
+msgid ""
+"**Numbers** (for Slider): Passes the raw `f64` value directly (numbers are "
+"their own NaN-boxed representation)."
+msgstr ""
+
+#: src/testing/geisterhand.md:754
+msgid ""
+"**Booleans** (for Toggle/chaos): Uses `TAG_TRUE` (0x7FFC000000000004) or "
+"`TAG_FALSE` (0x7FFC000000000003)."
+msgstr ""
+
+#: src/testing/geisterhand.md:758
+msgid "Build Details"
+msgstr ""
+
+#: src/testing/geisterhand.md:760
+msgid "Auto-Build"
+msgstr ""
+
+#: src/testing/geisterhand.md:762
+msgid ""
+"When you pass `--enable-geisterhand` (or `--geisterhand-port`), Perry "
+"automatically builds the required libraries on first use if they're not "
+"already cached:"
+msgstr ""
+
+#: src/testing/geisterhand.md:771
+msgid "Platform crate selection is automatic based on `--target`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:773 src/cli/flags.md:20
+msgid "Target"
+msgstr ""
+
+#: src/testing/geisterhand.md:773
+msgid "UI Crate"
+msgstr ""
+
+#: src/testing/geisterhand.md:775
+msgid "(default/macOS)"
+msgstr ""
+
+#: src/testing/geisterhand.md:775 src/contributing/architecture.md:37
+msgid "`perry-ui-macos`"
+msgstr ""
+
+#: src/testing/geisterhand.md:776
+msgid "`ios` / `ios-simulator`"
+msgstr ""
+
+#: src/testing/geisterhand.md:776 src/contributing/architecture.md:38
+msgid "`perry-ui-ios`"
+msgstr ""
+
+#: src/testing/geisterhand.md:777 src/cli/commands.md:66
+#: src/cli/commands.md:238 src/cli/flags.md:27
+msgid "`android`"
+msgstr ""
+
+#: src/testing/geisterhand.md:777
+msgid "`perry-ui-android`"
+msgstr ""
+
+#: src/testing/geisterhand.md:778 src/cli/commands.md:239 src/cli/flags.md:37
+msgid "`linux`"
+msgstr ""
+
+#: src/testing/geisterhand.md:778
+msgid "`perry-ui-gtk4`"
+msgstr ""
+
+#: src/testing/geisterhand.md:779 src/cli/flags.md:36
+msgid "`windows`"
+msgstr ""
+
+#: src/testing/geisterhand.md:779
+msgid "`perry-ui-windows`"
+msgstr ""
+
+#: src/testing/geisterhand.md:781
+msgid "Separate Target Directory"
+msgstr ""
+
+#: src/testing/geisterhand.md:783
+msgid ""
+"Geisterhand libraries are built into `target/geisterhand/` (via "
+"`CARGO_TARGET_DIR`) to avoid interfering with normal builds. This means your "
+"first geisterhand build takes a moment, but subsequent builds reuse the "
+"cached libraries."
+msgstr ""
+
+#: src/testing/geisterhand.md:785
+msgid "Feature Flags"
+msgstr ""
+
+#: src/testing/geisterhand.md:787
+msgid ""
+"All geisterhand code is behind `#[cfg(feature = \"geisterhand\")]` feature "
+"gates:"
+msgstr ""
+
+#: src/testing/geisterhand.md:789
+msgid ""
+"**`perry-runtime/geisterhand`**: Compiles the `geisterhand_registry` module "
+"— widget registry, action queue, pump function, screenshot coordination."
+msgstr ""
+
+#: src/testing/geisterhand.md:790
+msgid ""
+"**`perry-ui-{platform}/geisterhand`**: Adds `perry_geisterhand_register()` "
+"calls to widget constructors and `perry_geisterhand_pump()` to the platform "
+"timer."
+msgstr ""
+
+#: src/testing/geisterhand.md:792
+msgid ""
+"When the feature is not enabled, no geisterhand code is compiled — zero "
+"binary size overhead and zero runtime cost."
+msgstr ""
+
+#: src/testing/geisterhand.md:794
+msgid "Linking"
+msgstr ""
+
+#: src/testing/geisterhand.md:796
+msgid "The compiled binary links three additional static libraries:"
+msgstr ""
+
+#: src/testing/geisterhand.md:797
+msgid ""
+"`libperry_runtime.a` (geisterhand-featured build, replaces the normal "
+"runtime)"
+msgstr ""
+
+#: src/testing/geisterhand.md:798
+msgid ""
+"`libperry_ui_{platform}.a` (geisterhand-featured build, replaces the normal "
+"UI lib)"
+msgstr ""
+
+#: src/testing/geisterhand.md:799
+msgid "`libperry_ui_geisterhand.a` (HTTP server + chaos mode)"
+msgstr ""
+
+#: src/testing/geisterhand.md:801
+msgid "Manual Build"
+msgstr ""
+
+#: src/testing/geisterhand.md:803
+msgid "If auto-build fails or you want to cross-compile manually:"
+msgstr ""
+
+#: src/testing/geisterhand.md:806
+msgid "# Build geisterhand libs for macOS\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:807
+msgid "target/geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:822
+msgid "Security"
+msgstr ""
+
+#: src/testing/geisterhand.md:824
+msgid ""
+"Geisterhand binds to `0.0.0.0` on the configured port (default 7676). This "
+"means it is **accessible from the local network** — any device on the same "
+"network can interact with your app, capture screenshots, or trigger chaos "
+"mode."
+msgstr ""
+
+#: src/testing/geisterhand.md:826
+msgid ""
+"**Do not ship geisterhand-enabled binaries to production or to end users.**"
+msgstr ""
+
+#: src/testing/geisterhand.md:828
+msgid ""
+"Geisterhand is a development and testing tool only. The feature-gate system "
+"ensures it cannot accidentally be included in normal builds — you must "
+"explicitly pass `--enable-geisterhand` or `--geisterhand-port`."
+msgstr ""
+
+#: src/testing/geisterhand.md:832
+msgid "Troubleshooting"
+msgstr ""
+
+#: src/testing/geisterhand.md:834
+msgid "\"Connection refused\" on port 7676"
+msgstr ""
+
+#: src/testing/geisterhand.md:836
+msgid "Ensure you compiled with `--enable-geisterhand` or `--geisterhand-port`"
+msgstr ""
+
+#: src/testing/geisterhand.md:837
+msgid ""
+"Check that the app has fully started (look for `[geisterhand] listening "
+"on...` in stderr)"
+msgstr ""
+
+#: src/testing/geisterhand.md:838
+msgid "Verify the port isn't in use by another process: `lsof -i :7676`"
+msgstr ""
+
+#: src/testing/geisterhand.md:840
+msgid "Widget handles not found"
+msgstr ""
+
+#: src/testing/geisterhand.md:842
+msgid ""
+"Handles are assigned at widget creation time. If you query `/widgets` before "
+"the UI is fully constructed, some widgets may not be registered yet."
+msgstr ""
+
+#: src/testing/geisterhand.md:843
+msgid ""
+"Wait for `GET /health` to return `{\"status\":\"ok\"}` before interacting."
+msgstr ""
+
+#: src/testing/geisterhand.md:845
+msgid "Screenshot returns empty data"
+msgstr ""
+
+#: src/testing/geisterhand.md:847
+msgid ""
+"Screenshot capture has a 5-second timeout. If the main thread is blocked "
+"(e.g., by a long-running synchronous operation), the screenshot will time "
+"out and return empty data."
+msgstr ""
+
+#: src/testing/geisterhand.md:848
+msgid ""
+"On macOS, ensure the app has a visible window (minimized windows may not "
+"capture correctly)."
+msgstr ""
+
+#: src/testing/geisterhand.md:850
+msgid "Auto-build fails"
+msgstr ""
+
+#: src/testing/geisterhand.md:852
+msgid "Ensure you have a working Rust toolchain (`rustup show`)"
+msgstr ""
+
+#: src/testing/geisterhand.md:853
+msgid ""
+"For cross-compilation targets, install the appropriate target: `rustup "
+"target add aarch64-apple-ios`"
+msgstr ""
+
+#: src/testing/geisterhand.md:854
+msgid ""
+"Check that the Perry source tree is accessible (auto-build searches upward "
+"from the `perry` executable for the workspace root)"
+msgstr ""
+
+#: src/testing/geisterhand.md:856
+msgid "Chaos mode crashes the app"
+msgstr ""
+
+#: src/testing/geisterhand.md:858
+msgid ""
+"That's the point — chaos mode found a bug. Check the app's stderr output for "
+"panic messages or stack traces. Common causes:"
+msgstr ""
+
+#: src/testing/geisterhand.md:859
+msgid "Callback handlers that assume valid state but receive unexpected values"
+msgstr ""
+
+#: src/testing/geisterhand.md:860
+msgid "Missing null checks on state values"
+msgstr ""
+
+#: src/testing/geisterhand.md:861
+msgid "Race conditions in state updates"
+msgstr ""
+
+#: src/cli/commands.md:1
+msgid "CLI Commands"
+msgstr ""
+
+#: src/cli/commands.md:3
+msgid ""
+"Perry provides 11 commands for compiling, checking, running, publishing, and "
+"managing your projects."
+msgstr ""
+
+#: src/cli/commands.md:5
+msgid ""
+"See also: [perry.toml Reference](perry-toml.md) for project configuration."
+msgstr ""
+
+#: src/cli/commands.md:7
+msgid "compile"
+msgstr ""
+
+#: src/cli/commands.md:9
+msgid "Compile TypeScript to a native executable."
+msgstr ""
+
+#: src/cli/commands.md:12
+msgid "# Or shorthand (auto-detects compile):\n"
+msgstr ""
+
+#: src/cli/commands.md:17 src/cli/commands.md:109 src/cli/commands.md:148
+#: src/cli/commands.md:181 src/cli/commands.md:195 src/cli/commands.md:248
+#: src/cli/commands.md:260 src/cli/flags.md:9 src/cli/flags.md:50
+#: src/cli/flags.md:58 src/cli/flags.md:66 src/cli/flags.md:73
+msgid "Flag"
+msgstr ""
+
+#: src/cli/commands.md:19 src/cli/commands.md:111 src/cli/commands.md:243
+msgid "`-o, --output <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:19
+msgid "Output file path"
+msgstr ""
+
+#: src/cli/commands.md:20
+msgid "`--target <TARGET>`"
+msgstr ""
+
+#: src/cli/commands.md:20
+msgid "Platform target (see [Compiler Flags](flags.md))"
+msgstr ""
+
+#: src/cli/commands.md:21
+msgid "`--output-type <TYPE>`"
+msgstr ""
+
+#: src/cli/commands.md:21
+msgid "`executable` (default) or `dylib` (plugin)"
+msgstr ""
+
+#: src/cli/commands.md:22 src/cli/flags.md:52
+msgid "`--print-hir`"
+msgstr ""
+
+#: src/cli/commands.md:22
+msgid "Print HIR intermediate representation"
+msgstr ""
+
+#: src/cli/commands.md:23 src/cli/flags.md:53
+msgid "`--no-link`"
+msgstr ""
+
+#: src/cli/commands.md:23
+msgid "Produce object file only, skip linking"
+msgstr ""
+
+#: src/cli/commands.md:24 src/cli/flags.md:54
+msgid "`--keep-intermediates`"
+msgstr ""
+
+#: src/cli/commands.md:24
+msgid "Keep `.o` and `.asm` files"
+msgstr ""
+
+#: src/cli/commands.md:25 src/cli/commands.md:71 src/cli/flags.md:75
+msgid "`--enable-js-runtime`"
+msgstr ""
+
+#: src/cli/commands.md:25
+msgid "Enable V8 JavaScript runtime fallback"
+msgstr ""
+
+#: src/cli/commands.md:26 src/cli/commands.md:72 src/cli/flags.md:76
+msgid "`--type-check`"
+msgstr ""
+
+#: src/cli/commands.md:26 src/cli/commands.md:72
+msgid "Enable type checking via tsgo"
+msgstr ""
+
+#: src/cli/commands.md:27 src/cli/flags.md:60
+msgid "`--minify`"
+msgstr ""
+
+#: src/cli/commands.md:27 src/cli/flags.md:60
+msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
+msgstr ""
+
+#: src/cli/commands.md:28
+msgid "`--app-bundle-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:28
+msgid "Bundle ID (required for widget targets)"
+msgstr ""
+
+#: src/cli/commands.md:29
+msgid "`--bundle-extensions <DIR>`"
+msgstr ""
+
+#: src/cli/commands.md:29
+msgid "Bundle TypeScript extensions from directory"
+msgstr ""
+
+#: src/cli/commands.md:32
+msgid "# Basic compilation\n"
+msgstr ""
+
+#: src/cli/commands.md:34
+msgid "# Cross-compile for iOS Simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:37
+msgid "# Build a plugin\n"
+msgstr ""
+
+#: src/cli/commands.md:40
+msgid "# Debug: view intermediate representation\n"
+msgstr ""
+
+#: src/cli/commands.md:43
+msgid "# Build an iOS widget\n"
+msgstr ""
+
+#: src/cli/commands.md:50
+msgid "Compile and launch your app in one step."
+msgstr ""
+
+#: src/cli/commands.md:53
+msgid "# Auto-detect entry file\n"
+msgstr ""
+
+#: src/cli/commands.md:54
+msgid "# Run on iOS device/simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:55
+msgid "# Run on Apple Vision Pro simulator/device\n"
+msgstr ""
+
+#: src/cli/commands.md:56
+msgid "# Run on Android device\n"
+msgstr ""
+
+#: src/cli/commands.md:57
+msgid "# Forward args to your program\n"
+msgstr ""
+
+#: src/cli/commands.md:60 src/cli/commands.md:233
+msgid "Argument / Flag"
+msgstr ""
+
+#: src/cli/commands.md:62 src/cli/commands.md:236 src/cli/flags.md:24
+msgid "`ios`"
+msgstr ""
+
+#: src/cli/commands.md:62
+msgid "Target iOS (device or simulator)"
+msgstr ""
+
+#: src/cli/commands.md:63 src/cli/commands.md:237 src/cli/flags.md:26
+msgid "`visionos`"
+msgstr ""
+
+#: src/cli/commands.md:63
+msgid "Target visionOS (device or simulator)"
+msgstr ""
+
+#: src/cli/commands.md:64 src/cli/commands.md:235
+msgid "`macos`"
+msgstr ""
+
+#: src/cli/commands.md:64
+msgid "Target macOS (default on macOS host)"
+msgstr ""
+
+#: src/cli/commands.md:65 src/cli/flags.md:35
+msgid "`web`"
+msgstr ""
+
+#: src/cli/commands.md:65
+msgid "Target web (opens in browser)"
+msgstr ""
+
+#: src/cli/commands.md:66
+msgid "Target Android device"
+msgstr ""
+
+#: src/cli/commands.md:67
+msgid "`--simulator <UDID>`"
+msgstr ""
+
+#: src/cli/commands.md:67
+msgid "Specify iOS simulator by UDID"
+msgstr ""
+
+#: src/cli/commands.md:68
+msgid "`--device <UDID>`"
+msgstr ""
+
+#: src/cli/commands.md:68
+msgid "Specify iOS physical device by UDID"
+msgstr ""
+
+#: src/cli/commands.md:69
+msgid "`--local`"
+msgstr ""
+
+#: src/cli/commands.md:69
+msgid "Force local compilation (no remote fallback)"
+msgstr ""
+
+#: src/cli/commands.md:70
+msgid "`--remote`"
+msgstr ""
+
+#: src/cli/commands.md:70
+msgid "Force remote build via Perry Hub"
+msgstr ""
+
+#: src/cli/commands.md:71
+msgid "Enable V8 JavaScript runtime"
+msgstr ""
+
+#: src/cli/commands.md:73 src/cli/commands.md:113
+msgid "`--`"
+msgstr ""
+
+#: src/cli/commands.md:73
+msgid "Separator for program arguments"
+msgstr ""
+
+#: src/cli/commands.md:75
+msgid "**Entry file detection** (checked in order):"
+msgstr ""
+
+#: src/cli/commands.md:76
+msgid "`perry.toml` → `[project] entry` field"
+msgstr ""
+
+#: src/cli/commands.md:77
+msgid "`src/main.ts`"
+msgstr ""
+
+#: src/cli/commands.md:78
+msgid "`main.ts`"
+msgstr ""
+
+#: src/cli/commands.md:80
+msgid ""
+"**Device detection**: When targeting iOS, Perry auto-discovers available "
+"simulators (via `simctl`) and physical devices (via `devicectl`). For "
+"Android, it uses `adb`. When multiple targets are found, an interactive "
+"prompt lets you choose."
+msgstr ""
+
+#: src/cli/commands.md:82
+msgid ""
+"**Remote build fallback**: If cross-compilation toolchains aren't installed "
+"locally (e.g., Apple mobile targets on a machine without Xcode), `perry run "
+"ios` and `perry run visionos` can fall back to Perry Hub's build server when "
+"the backend supports the target. Use `--local` or `--remote` to force either "
+"path."
+msgstr ""
+
+#: src/cli/commands.md:85
+msgid "# Run a CLI program\n"
+msgstr ""
+
+#: src/cli/commands.md:87
+msgid "# Run on a specific simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:90
+msgid "# Force remote build\n"
+msgstr ""
+
+#: src/cli/commands.md:93
+msgid "# Run web target\n"
+msgstr ""
+
+#: src/cli/commands.md:98
+msgid "dev"
+msgstr ""
+
+#: src/cli/commands.md:100
+msgid ""
+"Watch your TypeScript source tree and auto-recompile + relaunch on every "
+"save."
+msgstr ""
+
+#: src/cli/commands.md:103
+msgid "# watch + rebuild + relaunch on save\n"
+msgstr ""
+
+#: src/cli/commands.md:104
+msgid "# forward args to the child\n"
+msgstr ""
+
+#: src/cli/commands.md:105
+msgid "# watch an extra directory\n"
+msgstr ""
+
+#: src/cli/commands.md:106
+msgid "# override output path\n"
+msgstr ""
+
+#: src/cli/commands.md:111
+msgid "Output binary path (default: `.perry-dev/<entry-stem>`)"
+msgstr ""
+
+#: src/cli/commands.md:112
+msgid "`--watch <DIR>`"
+msgstr ""
+
+#: src/cli/commands.md:112
+msgid "Extra directories to watch (comma-separated or repeated)"
+msgstr ""
+
+#: src/cli/commands.md:113
+msgid "Separator — everything after is forwarded to the compiled binary"
+msgstr ""
+
+#: src/cli/commands.md:115
+msgid "**How it works:**"
+msgstr ""
+
+#: src/cli/commands.md:117
+msgid ""
+"Resolves the entry, computes the **project root** (walks up until it finds a "
+"`package.json` or `perry.toml`; falls back to the entry's parent directory)."
+msgstr ""
+
+#: src/cli/commands.md:118
+msgid ""
+"Does an initial `perry compile`, then spawns the resulting binary with stdio "
+"inherited."
+msgstr ""
+
+#: src/cli/commands.md:119
+msgid ""
+"Watches the project root (plus any `--watch` dirs) recursively using the "
+"`notify` crate. A 300 ms **debounce** window collapses editor \"save "
+"storms\" into one rebuild."
+msgstr ""
+
+#: src/cli/commands.md:120
+msgid ""
+"On each relevant change: kill the running child, recompile, relaunch. A "
+"failed build leaves the old child dead and waits for the next change; no "
+"crash loop."
+msgstr ""
+
+#: src/cli/commands.md:122
+msgid "**What counts as a \"relevant\" change:**"
+msgstr ""
+
+#: src/cli/commands.md:123
+msgid "**Trigger extensions:** `.ts`, `.tsx`, `.mts`, `.cts`, `.json`, `.toml`"
+msgstr ""
+
+#: src/cli/commands.md:124
+msgid ""
+"**Ignored directories (not watched, never retrigger):** `node_modules`, "
+"`target`, `.git`, `dist`, `build`, `.perry-dev`, `.perry-cache`"
+msgstr ""
+
+#: src/cli/commands.md:126
+msgid "**Benchmarks** (trivial single-file program, macOS):"
+msgstr ""
+
+#: src/cli/commands.md:128
+msgid "Phase"
+msgstr ""
+
+#: src/cli/commands.md:128
+msgid "Time"
+msgstr ""
+
+#: src/cli/commands.md:130
+msgid "Initial build (cold — runtime + stdlib rebuilt by auto-optimize)"
+msgstr ""
+
+#: src/cli/commands.md:130
+msgid "~15 s"
+msgstr ""
+
+#: src/cli/commands.md:131
+msgid "Post-edit rebuild (hot libs cached on disk)"
+msgstr ""
+
+#: src/cli/commands.md:131
+msgid "**~330 ms**"
+msgstr ""
+
+#: src/cli/commands.md:133
+msgid ""
+"The speedup on hot rebuilds comes from Perry's existing auto-optimize "
+"library cache. Multi-module projects will still recompile every changed "
+"module on each save — see the V2 note below for planned incremental work."
+msgstr ""
+
+#: src/cli/commands.md:135
+msgid "**Not yet in scope (V2+):**"
+msgstr ""
+
+#: src/cli/commands.md:136
+msgid "In-memory AST cache (reuse SWC parses across rebuilds)."
+msgstr ""
+
+#: src/cli/commands.md:137
+msgid "Per-module `.o` cache on disk (only re-codegen the changed module)."
+msgstr ""
+
+#: src/cli/commands.md:138
+msgid ""
+"State preservation across rebuilds / HMR — \"fast restart\" is the honest "
+"target."
+msgstr ""
+
+#: src/cli/commands.md:140
+msgid "check"
+msgstr ""
+
+#: src/cli/commands.md:142
+msgid "Validate TypeScript for Perry compatibility without compiling."
+msgstr ""
+
+#: src/cli/commands.md:150
+msgid "`--check-deps`"
+msgstr ""
+
+#: src/cli/commands.md:150
+msgid "Check `node_modules` for compatibility"
+msgstr ""
+
+#: src/cli/commands.md:151
+msgid "`--deep-deps`"
+msgstr ""
+
+#: src/cli/commands.md:151
+msgid "Scan all transitive dependencies"
+msgstr ""
+
+#: src/cli/commands.md:152
+msgid "`--all`"
+msgstr ""
+
+#: src/cli/commands.md:152
+msgid "Show all issues including hints"
+msgstr ""
+
+#: src/cli/commands.md:153
+msgid "`--strict`"
+msgstr ""
+
+#: src/cli/commands.md:153
+msgid "Treat warnings as errors"
+msgstr ""
+
+#: src/cli/commands.md:154
+msgid "`--fix`"
+msgstr ""
+
+#: src/cli/commands.md:154
+msgid "Automatically apply fixes"
+msgstr ""
+
+#: src/cli/commands.md:155
+msgid "`--fix-dry-run`"
+msgstr ""
+
+#: src/cli/commands.md:155
+msgid "Preview fixes without modifying files"
+msgstr ""
+
+#: src/cli/commands.md:156
+msgid "`--fix-unsafe`"
+msgstr ""
+
+#: src/cli/commands.md:156
+msgid "Include medium-confidence fixes"
+msgstr ""
+
+#: src/cli/commands.md:159
+msgid "# Check a single file\n"
+msgstr ""
+
+#: src/cli/commands.md:161
+msgid "# Check with dependency analysis\n"
+msgstr ""
+
+#: src/cli/commands.md:164
+msgid "# Auto-fix issues\n"
+msgstr ""
+
+#: src/cli/commands.md:167
+msgid "# Preview fixes without applying\n"
+msgstr ""
+
+#: src/cli/commands.md:172
+msgid "init"
+msgstr ""
+
+#: src/cli/commands.md:174
+msgid "Create a new Perry project."
+msgstr ""
+
+#: src/cli/commands.md:183
+msgid "`--name <NAME>`"
+msgstr ""
+
+#: src/cli/commands.md:183
+msgid "Project name (defaults to directory name)"
+msgstr ""
+
+#: src/cli/commands.md:185
+msgid "Creates `perry.toml`, `src/main.ts`, and `.gitignore`."
+msgstr ""
+
+#: src/cli/commands.md:187
+msgid "doctor"
+msgstr ""
+
+#: src/cli/commands.md:189
+msgid "Check your Perry installation and environment."
+msgstr ""
+
+#: src/cli/commands.md:197
+msgid "`--quiet`"
+msgstr ""
+
+#: src/cli/commands.md:197
+msgid "Only report failures"
+msgstr ""
+
+#: src/cli/commands.md:199
+msgid "Checks:"
+msgstr ""
+
+#: src/cli/commands.md:200
+msgid "Perry version"
+msgstr ""
+
+#: src/cli/commands.md:201
+msgid "System linker availability (cc/MSVC)"
+msgstr ""
+
+#: src/cli/commands.md:202
+msgid "Runtime library"
+msgstr ""
+
+#: src/cli/commands.md:203
+msgid "Project configuration"
+msgstr ""
+
+#: src/cli/commands.md:204
+msgid "Available updates"
+msgstr ""
+
+#: src/cli/commands.md:206
+msgid "explain"
+msgstr ""
+
+#: src/cli/commands.md:208
+msgid "Get detailed explanations for error codes."
+msgstr ""
+
+#: src/cli/commands.md:214
+msgid "Error code families:"
+msgstr ""
+
+#: src/cli/commands.md:215
+msgid "**P** — Parse errors"
+msgstr ""
+
+#: src/cli/commands.md:216
+msgid "**T** — Type errors"
+msgstr ""
+
+#: src/cli/commands.md:217
+msgid "**U** — Unsupported features"
+msgstr ""
+
+#: src/cli/commands.md:218
+msgid "**D** — Dependency issues"
+msgstr ""
+
+#: src/cli/commands.md:220
+msgid ""
+"Each explanation includes the error description, example code, and suggested "
+"fix."
+msgstr ""
+
+#: src/cli/commands.md:222
+msgid "publish"
+msgstr ""
+
+#: src/cli/commands.md:224
+msgid "Build, sign, and distribute your app."
+msgstr ""
+
+#: src/cli/commands.md:235
+msgid "Build for macOS (App Store/notarization)"
+msgstr ""
+
+#: src/cli/commands.md:236
+msgid "Build for iOS (App Store/TestFlight)"
+msgstr ""
+
+#: src/cli/commands.md:237
+msgid "Build for visionOS"
+msgstr ""
+
+#: src/cli/commands.md:238
+msgid "Build for Android (Google Play)"
+msgstr ""
+
+#: src/cli/commands.md:239
+msgid "Build for Linux (AppImage/deb/rpm)"
+msgstr ""
+
+#: src/cli/commands.md:240
+msgid "`--server <URL>`"
+msgstr ""
+
+#: src/cli/commands.md:240
+msgid "Build server (default: `https://hub.perryts.com`)"
+msgstr ""
+
+#: src/cli/commands.md:241
+msgid "`--license-key <KEY>`"
+msgstr ""
+
+#: src/cli/commands.md:241 src/cli/perry-toml.md:493
+msgid "Perry Hub license key"
+msgstr ""
+
+#: src/cli/commands.md:242
+msgid "`--project <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:242
+msgid "Project directory"
+msgstr ""
+
+#: src/cli/commands.md:243
+msgid "Artifact output directory (default: `dist`)"
+msgstr ""
+
+#: src/cli/commands.md:244
+msgid "`--no-download`"
+msgstr ""
+
+#: src/cli/commands.md:244
+msgid "Skip artifact download"
+msgstr ""
+
+#: src/cli/commands.md:246
+msgid "Apple-specific flags:"
+msgstr ""
+
+#: src/cli/commands.md:250
+msgid "`--apple-team-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:250
+msgid "Developer Team ID"
+msgstr ""
+
+#: src/cli/commands.md:251
+msgid "`--apple-identity <NAME>`"
+msgstr ""
+
+#: src/cli/commands.md:251
+msgid "Signing identity"
+msgstr ""
+
+#: src/cli/commands.md:252
+msgid "`--apple-p8-key <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:252
+msgid "App Store Connect .p8 key"
+msgstr ""
+
+#: src/cli/commands.md:253
+msgid "`--apple-key-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:253
+msgid "App Store Connect API Key ID"
+msgstr ""
+
+#: src/cli/commands.md:254
+msgid "`--apple-issuer-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:254
+msgid "App Store Connect Issuer ID"
+msgstr ""
+
+#: src/cli/commands.md:255
+msgid "`--certificate <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:255
+msgid ".p12 certificate bundle"
+msgstr ""
+
+#: src/cli/commands.md:256
+msgid "`--provisioning-profile <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:256
+msgid ".mobileprovision file (iOS)"
+msgstr ""
+
+#: src/cli/commands.md:258
+msgid "Android-specific flags:"
+msgstr ""
+
+#: src/cli/commands.md:262
+msgid "`--android-keystore <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:262
+msgid ".jks/.keystore file"
+msgstr ""
+
+#: src/cli/commands.md:263
+msgid "`--android-keystore-password <PASS>`"
+msgstr ""
+
+#: src/cli/commands.md:263 src/cli/perry-toml.md:507
+msgid "Keystore password"
+msgstr ""
+
+#: src/cli/commands.md:264
+msgid "`--android-key-alias <ALIAS>`"
+msgstr ""
+
+#: src/cli/commands.md:264
+msgid "Key alias"
+msgstr ""
+
+#: src/cli/commands.md:265
+msgid "`--android-key-password <PASS>`"
+msgstr ""
+
+#: src/cli/commands.md:265
+msgid "Key password"
+msgstr ""
+
+#: src/cli/commands.md:266
+msgid "`--google-play-key <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:266
+msgid "Google Play service account JSON"
+msgstr ""
+
+#: src/cli/commands.md:268
+msgid "On first use, `publish` auto-registers a free license key."
+msgstr ""
+
+#: src/cli/commands.md:270
+msgid "setup"
+msgstr ""
+
+#: src/cli/commands.md:272
+msgid ""
+"Interactive credential wizard for app distribution, plus toolchain setup for "
+"Windows."
+msgstr ""
+
+#: src/cli/commands.md:275
+msgid "# Show platform menu\n"
+msgstr ""
+
+#: src/cli/commands.md:276
+msgid "# macOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:277
+msgid "# iOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:278
+msgid "# visionOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:279
+msgid "# Android setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:280
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
+msgstr ""
+
+#: src/cli/commands.md:283
+msgid ""
+"`perry setup windows` downloads the Microsoft CRT + Windows SDK libraries "
+"(~1.5 GB) so Perry can link without Visual Studio Build Tools. Requires LLVM "
+"(`winget install LLVM.LLVM`) and prompts to accept the Microsoft "
+"redistributable license — pass `--accept-license` to skip the prompt for CI. "
+"Output lands at `%LOCALAPPDATA%\\perry\\windows-sdk`. See the [Windows "
+"platform guide](../platforms/windows.md) for the full toolchain comparison."
+msgstr ""
+
+#: src/cli/commands.md:285
+msgid "Credential wizards store their output in `~/.perry/config.toml`."
+msgstr ""
+
+#: src/cli/commands.md:287
+msgid "update"
+msgstr ""
+
+#: src/cli/commands.md:289
+msgid "Check for and install Perry updates."
+msgstr ""
+
+#: src/cli/commands.md:292
+msgid "# Update to latest\n"
+msgstr ""
+
+#: src/cli/commands.md:293
+msgid "# Check without installing\n"
+msgstr ""
+
+#: src/cli/commands.md:294
+msgid "# Ignore 24h cache\n"
+msgstr ""
+
+#: src/cli/commands.md:297
+msgid "Update sources (checked in order):"
+msgstr ""
+
+#: src/cli/commands.md:298
+msgid "Custom server (env/config)"
+msgstr ""
+
+#: src/cli/commands.md:299
+msgid "Perry Hub"
+msgstr ""
+
+#: src/cli/commands.md:300
+msgid "GitHub API"
+msgstr ""
+
+#: src/cli/commands.md:302
+msgid ""
+"Opt out of automatic update checks with `PERRY_NO_UPDATE_CHECK=1` or "
+"`CI=true`."
+msgstr ""
+
+#: src/cli/commands.md:304
+msgid "i18n"
+msgstr ""
+
+#: src/cli/commands.md:306
+msgid ""
+"Internationalization tools for managing locale files and extracting "
+"localizable strings."
+msgstr ""
+
+#: src/cli/commands.md:310
+msgid "Scan source files and generate/update locale JSON scaffolds:"
+msgstr ""
+
+#: src/cli/commands.md:316
+msgid ""
+"Detects string literals in UI component calls (`Button`, `Text`, `Label`, "
+"etc.) and `t()` calls. Creates `locales/*.json` files based on the `[i18n]` "
+"config in `perry.toml`."
+msgstr ""
+
+#: src/cli/commands.md:318
+msgid "See the [i18n documentation](../i18n/overview.md) for full details."
+msgstr ""
+
+#: src/cli/commands.md:322
+msgid "[Compiler Flags](flags.md) — Complete flag reference"
+msgstr ""
+
+#: src/cli/commands.md:323
+msgid "[Getting Started](../getting-started/installation.md) — Installation"
+msgstr ""
+
+#: src/cli/flags.md:3
+msgid "Complete reference for all Perry CLI flags."
+msgstr ""
+
+#: src/cli/flags.md:5
+msgid "Global Flags"
+msgstr ""
+
+#: src/cli/flags.md:7
+msgid "Available on all commands:"
+msgstr ""
+
+#: src/cli/flags.md:11
+msgid "`--format text\\|json`"
+msgstr ""
+
+#: src/cli/flags.md:11
+msgid "Output format (default: `text`)"
+msgstr ""
+
+#: src/cli/flags.md:12
+msgid "`-v, --verbose`"
+msgstr ""
+
+#: src/cli/flags.md:12
+msgid "Increase verbosity (repeatable: `-v`, `-vv`, `-vvv`)"
+msgstr ""
+
+#: src/cli/flags.md:13
+msgid "`-q, --quiet`"
+msgstr ""
+
+#: src/cli/flags.md:13
+msgid "Suppress non-error output"
+msgstr ""
+
+#: src/cli/flags.md:14
+msgid "`--no-color`"
+msgstr ""
+
+#: src/cli/flags.md:14
+msgid "Disable ANSI color codes"
+msgstr ""
+
+#: src/cli/flags.md:16
+msgid "Compilation Targets"
+msgstr ""
+
+#: src/cli/flags.md:18
+msgid "Use `--target` to cross-compile:"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "_(none)_"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "Current platform"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "Default behavior"
+msgstr ""
+
+#: src/cli/flags.md:23
+msgid "`ios-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:23
+msgid "ARM64 simulator binary"
+msgstr ""
+
+#: src/cli/flags.md:24
+msgid "ARM64 device binary"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "`visionos-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "visionOS Simulator"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "Apple Vision Pro simulator build"
+msgstr ""
+
+#: src/cli/flags.md:26
+msgid "visionOS Device"
+msgstr ""
+
+#: src/cli/flags.md:26
+msgid "Apple Vision Pro device build"
+msgstr ""
+
+#: src/cli/flags.md:27
+msgid "ARM64/ARMv7"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "`ios-widget`"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "iOS Widget"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "WidgetKit extension (requires `--app-bundle-id`)"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "`ios-widget-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "iOS Widget (Sim)"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "Widget for simulator"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "`watchos-widget`"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "watchOS Complication"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "WidgetKit extension for Apple Watch"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "`watchos-widget-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "watchOS Widget (Sim)"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "Widget for watchOS simulator"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "`android-widget`"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "Android Widget"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "Android App Widget (AppWidgetProvider)"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "`wearos-tile`"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "Wear OS Tile"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "Wear OS Tile (TileService)"
+msgstr ""
+
+#: src/cli/flags.md:34
+msgid "`wasm`"
+msgstr ""
+
+#: src/cli/flags.md:34
+msgid "Self-contained HTML with WASM or raw `.wasm` binary"
+msgstr ""
+
+#: src/cli/flags.md:35
+msgid "Outputs HTML file with JS"
+msgstr ""
+
+#: src/cli/flags.md:36
+msgid "Win32 executable"
+msgstr ""
+
+#: src/cli/flags.md:37
+msgid "GTK4 executable"
+msgstr ""
+
+#: src/cli/flags.md:39
+msgid "Output Types"
+msgstr ""
+
+#: src/cli/flags.md:41
+msgid "Use `--output-type` to change what's produced:"
+msgstr ""
+
+#: src/cli/flags.md:45
+msgid "`executable`"
+msgstr ""
+
+#: src/cli/flags.md:45
+msgid "Standalone binary (default)"
+msgstr ""
+
+#: src/cli/flags.md:46
+msgid "`dylib`"
+msgstr ""
+
+#: src/cli/flags.md:46
+msgid "Shared library (`.dylib`/`.so`) for [plugins](../plugins/overview.md)"
+msgstr ""
+
+#: src/cli/flags.md:48
+msgid "Debug Flags"
+msgstr ""
+
+#: src/cli/flags.md:52
+msgid "Print HIR (intermediate representation) to stdout"
+msgstr ""
+
+#: src/cli/flags.md:53
+msgid "Produce `.o` object file only, skip linking"
+msgstr ""
+
+#: src/cli/flags.md:54
+msgid "Keep `.o` and `.asm` intermediate files"
+msgstr ""
+
+#: src/cli/flags.md:56
+msgid "Output Optimization"
+msgstr ""
+
+#: src/cli/flags.md:62
+msgid ""
+"Minification strips comments, collapses whitespace, and mangles local "
+"variable/parameter/non-exported function names for smaller output."
+msgstr ""
+
+#: src/cli/flags.md:64
+msgid "Testing Flags"
+msgstr ""
+
+#: src/cli/flags.md:68
+msgid "`--enable-geisterhand`"
+msgstr ""
+
+#: src/cli/flags.md:68
+msgid ""
+"Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
+"programmatic UI testing (default port 7676)"
+msgstr ""
+
+#: src/cli/flags.md:69
+msgid "`--geisterhand-port <PORT>`"
+msgstr ""
+
+#: src/cli/flags.md:69
+msgid ""
+"Set a custom port for the Geisterhand server (implies `--enable-geisterhand`)"
+msgstr ""
+
+#: src/cli/flags.md:71
+msgid "Runtime Flags"
+msgstr ""
+
+#: src/cli/flags.md:75
+msgid "Enable V8 JavaScript runtime for unsupported npm packages"
+msgstr ""
+
+#: src/cli/flags.md:76
+msgid "Enable type checking via tsgo IPC"
+msgstr ""
+
+#: src/cli/flags.md:78 src/cli/perry-toml.md:485
+msgid "Environment Variables"
+msgstr ""
+
+#: src/cli/flags.md:80 src/cli/perry-toml.md:491 src/cli/perry-toml.md:503
+#: src/cli/perry-toml.md:513
+msgid "Variable"
+msgstr ""
+
+#: src/cli/flags.md:82 src/cli/perry-toml.md:493
+msgid "`PERRY_LICENSE_KEY`"
+msgstr ""
+
+#: src/cli/flags.md:82
+msgid "Perry Hub license key for `perry publish`"
+msgstr ""
+
+#: src/cli/flags.md:83 src/cli/perry-toml.md:495
+msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/flags.md:83
+msgid "Password for .p12 certificate"
+msgstr ""
+
+#: src/cli/flags.md:84
+msgid "`PERRY_NO_UPDATE_CHECK=1`"
+msgstr ""
+
+#: src/cli/flags.md:84
+msgid "Disable automatic update checks"
+msgstr ""
+
+#: src/cli/flags.md:85
+msgid "`PERRY_UPDATE_SERVER`"
+msgstr ""
+
+#: src/cli/flags.md:85
+msgid "Custom update server URL"
+msgstr ""
+
+#: src/cli/flags.md:86
+msgid "`CI=true`"
+msgstr ""
+
+#: src/cli/flags.md:86
+msgid "Auto-skip update checks (set by most CI systems)"
+msgstr ""
+
+#: src/cli/flags.md:87
+msgid "`RUST_LOG`"
+msgstr ""
+
+#: src/cli/flags.md:87
+msgid "Debug logging level (`debug`, `info`, `trace`)"
+msgstr ""
+
+#: src/cli/flags.md:89
+msgid "Configuration Files"
+msgstr ""
+
+#: src/cli/flags.md:91
+msgid "perry.toml (project)"
+msgstr ""
+
+#: src/cli/flags.md:93
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"entry = \"src/main.ts\"\n"
+"version = \"1.0.0\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"build\"\n"
+"\n"
+"[app]\n"
+"name = \"My App\"\n"
+"description = \"A Perry application\"\n"
+"\n"
+"[macos]\n"
+"bundle_id = \"com.example.myapp\"\n"
+"category = \"public.app-category.developer-tools\"\n"
+"minimum_os = \"13.0\"\n"
+"distribute = \"notarize\"  # \"appstore\", \"notarize\", or \"both\"\n"
+"\n"
+"[ios]\n"
+"bundle_id = \"com.example.myapp\"\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = 26\n"
+"target_sdk = 34\n"
+"\n"
+"[linux]\n"
+"format = \"appimage\"  # \"appimage\", \"deb\", \"rpm\"\n"
+"category = \"Development\"\n"
+"```"
+msgstr ""
+
+#: src/cli/flags.md:127
+msgid "~/.perry/config.toml (global)"
+msgstr ""
+
+#: src/cli/flags.md:129
+msgid ""
+"```toml\n"
+"[apple]\n"
+"team_id = \"XXXXXXXXXX\"\n"
+"signing_identity = \"Developer ID Application: Your Name\"\n"
+"\n"
+"[android]\n"
+"keystore_path = \"/path/to/keystore.jks\"\n"
+"key_alias = \"my-key\"\n"
+"```"
+msgstr ""
+
+#: src/cli/flags.md:142
+msgid "# Simple CLI program\n"
+msgstr ""
+
+#: src/cli/flags.md:144
+msgid "# iOS app for simulator\n"
+msgstr ""
+
+#: src/cli/flags.md:147
+msgid "# visionOS app for simulator\n"
+msgstr ""
+
+#: src/cli/flags.md:150
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
+msgstr ""
+
+#: src/cli/flags.md:153
+msgid "# Plugin shared library\n"
+msgstr ""
+
+#: src/cli/flags.md:156
+msgid "# iOS widget with bundle ID\n"
+msgstr ""
+
+#: src/cli/flags.md:159
+msgid "# Debug compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:162
+msgid "# Verbose compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:165
+msgid "# Type-checked compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:168
+msgid "# Raw WASM binary (no HTML wrapper)\n"
+msgstr ""
+
+#: src/cli/flags.md:171
+msgid "# Minified web output (compresses embedded JS bridge)\n"
+msgstr ""
+
+#: src/cli/flags.md:178
+msgid "[Commands](commands.md) — All CLI commands"
+msgstr ""
+
+#: src/cli/flags.md:179
+msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
+msgstr ""
+
+#: src/cli/perry-toml.md:3
+msgid ""
+"`perry.toml` is the project-level configuration file for Perry. It controls "
+"project metadata, build settings, platform-specific options, code signing, "
+"distribution, auditing, and verification."
+msgstr ""
+
+#: src/cli/perry-toml.md:5
+msgid ""
+"Created automatically by `perry init`, it lives at the root of your project "
+"alongside `package.json`."
+msgstr ""
+
+#: src/cli/perry-toml.md:7
+msgid "Minimal Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:9
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"dist\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:18
+msgid "Full Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:20
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"version = \"1.2.0\"\n"
+"build_number = 42\n"
+"bundle_id = \"com.example.myapp\"\n"
+"description = \"A cross-platform Perry application\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[project.icons]\n"
+"source = \"assets/icon.png\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"dist\"\n"
+"\n"
+"[macos]\n"
+"bundle_id = \"com.example.myapp.macos\"\n"
+"category = \"public.app-category.developer-tools\"\n"
+"minimum_os = \"13.0\"\n"
+"entitlements = [\"com.apple.security.network.client\"]\n"
+"distribute = \"both\"\n"
+"signing_identity = \"Developer ID Application: My Company (TEAMID)\"\n"
+"certificate = \"certs/mac-appstore.p12\"\n"
+"notarize_certificate = \"certs/mac-devid.p12\"\n"
+"notarize_signing_identity = \"Developer ID Application: My Company "
+"(TEAMID)\"\n"
+"installer_certificate = \"certs/mac-installer.p12\"\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"certs/AuthKey.p8\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[ios]\n"
+"bundle_id = \"com.example.myapp.ios\"\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"orientations = [\"portrait\", \"landscape-left\", \"landscape-right\"]\n"
+"capabilities = [\"push-notification\"]\n"
+"distribute = \"appstore\"\n"
+"entry = \"src/main-ios.ts\"\n"
+"provisioning_profile = \"certs/MyApp.mobileprovision\"\n"
+"certificate = \"certs/ios-distribution.p12\"\n"
+"signing_identity = \"iPhone Distribution: My Company (TEAMID)\"\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"certs/AuthKey.p8\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = \"26\"\n"
+"target_sdk = \"34\"\n"
+"permissions = [\"INTERNET\", \"CAMERA\"]\n"
+"distribute = \"playstore\"\n"
+"keystore = \"certs/release.keystore\"\n"
+"key_alias = \"my-key\"\n"
+"google_play_key = \"certs/play-service-account.json\"\n"
+"entry = \"src/main-android.ts\"\n"
+"\n"
+"[linux]\n"
+"format = \"appimage\"\n"
+"category = \"Development\"\n"
+"description = \"A cross-platform Perry application\"\n"
+"\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\", \"fr\"]\n"
+"default_locale = \"en\"\n"
+"\n"
+"[i18n.currencies]\n"
+"en = \"USD\"\n"
+"de = \"EUR\"\n"
+"fr = \"EUR\"\n"
+"\n"
+"[publish]\n"
+"server = \"https://hub.perryts.com\"\n"
+"\n"
+"[audit]\n"
+"fail_on = \"B\"\n"
+"severity = \"high\"\n"
+"ignore = [\"RULE-001\", \"RULE-002\"]\n"
+"\n"
+"[verify]\n"
+"url = \"https://verify.perryts.com\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:110 src/cli/perry-toml.md:558
+msgid "`[project]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:112
+msgid ""
+"Core project metadata. This is the primary section for identifying your "
+"application."
+msgstr ""
+
+#: src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414
+msgid "Default"
+msgstr ""
+
+#: src/cli/perry-toml.md:116
+msgid "Directory name"
+msgstr ""
+
+#: src/cli/perry-toml.md:116
+msgid "Project name, used for binary output name and default bundle ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:117
+msgid "`\"1.0.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:117
+msgid "Semantic version string (e.g., `\"1.2.3\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "`build_number`"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "integer"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "`1`"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid ""
+"Numeric build number; auto-incremented on `perry publish` for iOS, Android, "
+"and macOS App Store builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:119
+msgid "Human-readable project description"
+msgstr ""
+
+#: src/cli/perry-toml.md:120 src/cli/perry-toml.md:249
+#: src/cli/perry-toml.md:304 src/cli/perry-toml.md:337
+msgid "`entry`"
+msgstr ""
+
+#: src/cli/perry-toml.md:120
+msgid ""
+"TypeScript entry file (e.g., `\"src/main.ts\"`). Used by `perry run` and "
+"`perry publish` when no input file is specified"
+msgstr ""
+
+#: src/cli/perry-toml.md:121 src/cli/perry-toml.md:167
+#: src/cli/perry-toml.md:243 src/cli/perry-toml.md:301
+msgid "`bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:121
+msgid "`com.perry.<name>`"
+msgstr ""
+
+#: src/cli/perry-toml.md:121
+msgid ""
+"Default bundle identifier, used as fallback when platform-specific sections "
+"don't define one"
+msgstr ""
+
+#: src/cli/perry-toml.md:123
+msgid "`[project.icons]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:127
+msgid "`source`"
+msgstr ""
+
+#: src/cli/perry-toml.md:127
+msgid ""
+"Path to a source icon image (PNG or JPG). Perry auto-resizes this to all "
+"required sizes for each platform"
+msgstr ""
+
+#: src/cli/perry-toml.md:129
+msgid "`[app]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:131
+msgid ""
+"Alternative to `[project]` with identical fields. Useful for organizational "
+"clarity — `[app]` takes precedence over `[project]` when both are present:"
+msgstr ""
+
+#: src/cli/perry-toml.md:133
+msgid ""
+"```toml\n"
+"# These two are equivalent:\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"\n"
+"# or:\n"
+"[app]\n"
+"name = \"my-app\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:143
+msgid ""
+"When both exist, resolution order is: `[app]` field -> `[project]` field -> "
+"default."
+msgstr ""
+
+#: src/cli/perry-toml.md:145
+msgid ""
+"`[app]` supports the same fields as `[project]`: `name`, `version`, "
+"`build_number`, `bundle_id`, `description`, `entry`, and `icons`."
+msgstr ""
+
+#: src/cli/perry-toml.md:149 src/cli/perry-toml.md:561
+msgid "`[build]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:151
+msgid "Build output settings."
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "`out_dir`"
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "`\"dist\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "Directory for build artifacts"
+msgstr ""
+
+#: src/cli/perry-toml.md:159
+msgid "`[macos]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:161
+msgid ""
+"macOS-specific configuration for `perry publish macos` and `perry compile "
+"--target macos`."
+msgstr ""
+
+#: src/cli/perry-toml.md:163 src/cli/perry-toml.md:239
+#: src/cli/perry-toml.md:297
+msgid "App Metadata"
+msgstr ""
+
+#: src/cli/perry-toml.md:167 src/cli/perry-toml.md:243
+msgid "Falls back to `[app]`/`[project]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:167
+msgid "macOS-specific bundle identifier (e.g., `\"com.example.myapp\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:348
+msgid "`category`"
+msgstr ""
+
+#: src/cli/perry-toml.md:168
+msgid ""
+"Mac App Store category. Uses Apple's UTI format (see [valid "
+"values](#macos-app-store-categories) below)"
+msgstr ""
+
+#: src/cli/perry-toml.md:169
+msgid "`minimum_os`"
+msgstr ""
+
+#: src/cli/perry-toml.md:169
+msgid "Minimum macOS version required (e.g., `\"13.0\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:170
+msgid "`entitlements`"
+msgstr ""
+
+#: src/cli/perry-toml.md:170 src/cli/perry-toml.md:246
+#: src/cli/perry-toml.md:247 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:332 src/cli/perry-toml.md:359
+#: src/cli/perry-toml.md:391
+msgid "string\\[\\]"
+msgstr ""
+
+#: src/cli/perry-toml.md:170
+msgid ""
+"macOS entitlements to include in the code signature (e.g., "
+"`[\"com.apple.security.network.client\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305
+msgid "`encryption_exempt`"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305
+msgid "bool"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305 src/cli/perry-toml.md:361
+msgid "`false`"
+msgstr ""
+
+#: src/cli/perry-toml.md:171
+msgid ""
+"If `true`, adds `ITSAppUsesNonExemptEncryption = false` to Info.plist, "
+"skipping the export compliance prompt in App Store Connect"
+msgstr ""
+
+#: src/cli/perry-toml.md:173 src/cli/perry-toml.md:252
+msgid "Distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:177 src/cli/perry-toml.md:256
+#: src/cli/perry-toml.md:312 src/cli/perry-toml.md:333
+msgid "`distribute`"
+msgstr ""
+
+#: src/cli/perry-toml.md:177
+msgid ""
+"Distribution method: `\"appstore\"`, `\"notarize\"`, or `\"both\"` (see "
+"[Distribution Modes](#macos-distribution-modes))"
+msgstr ""
+
+#: src/cli/perry-toml.md:183 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:313
+msgid "`signing_identity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:183 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:313
+msgid "Auto-detected from Keychain"
+msgstr ""
+
+#: src/cli/perry-toml.md:183
+msgid ""
+"Code signing identity name (e.g., `\"3rd Party Mac Developer Application: "
+"Company (TEAMID)\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:263
+#: src/cli/perry-toml.md:314
+msgid "`certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:263
+#: src/cli/perry-toml.md:314
+msgid "Auto-exported from Keychain"
+msgstr ""
+
+#: src/cli/perry-toml.md:184
+msgid "Path to `.p12` certificate file for App Store distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:185
+msgid "`notarize_certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:185
+msgid ""
+"Separate `.p12` certificate for notarization (only used with `distribute = "
+"\"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:186
+msgid "`notarize_signing_identity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:186
+msgid ""
+"Signing identity for notarization (only used with `distribute = \"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:187
+msgid "`installer_certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:187
+msgid "`.p12` certificate for Mac Installer Distribution (`.pkg` signing)"
+msgstr ""
+
+#: src/cli/perry-toml.md:189 src/cli/perry-toml.md:266
+msgid "App Store Connect"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:270
+#: src/cli/perry-toml.md:316
+msgid "`team_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:194
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:196
+#: src/cli/perry-toml.md:270 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:272 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:316 src/cli/perry-toml.md:317
+#: src/cli/perry-toml.md:318 src/cli/perry-toml.md:319
+msgid "From `~/.perry/config.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:270
+#: src/cli/perry-toml.md:316
+msgid "Apple Developer Team ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:194 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:317
+msgid "`key_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:194 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:497
+msgid "App Store Connect API key ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:272
+#: src/cli/perry-toml.md:318
+msgid "`issuer_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:272
+#: src/cli/perry-toml.md:318
+msgid "App Store Connect issuer ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:196 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:319
+msgid "`p8_key_path`"
+msgstr ""
+
+#: src/cli/perry-toml.md:196
+msgid "Path to App Store Connect `.p8` API key file"
+msgstr ""
+
+#: src/cli/perry-toml.md:198
+msgid "macOS Distribution Modes"
+msgstr ""
+
+#: src/cli/perry-toml.md:200
+msgid ""
+"The `distribute` field controls how your macOS app is signed and distributed:"
+msgstr ""
+
+#: src/cli/perry-toml.md:202
+msgid ""
+"**`\"appstore\"`** — Signs with an App Store distribution certificate and "
+"uploads to App Store Connect. Requires `team_id`, `key_id`, `issuer_id`, and "
+"`p8_key_path`."
+msgstr ""
+
+#: src/cli/perry-toml.md:204
+msgid ""
+"**`\"notarize\"`** — Signs with a Developer ID certificate and notarizes "
+"with Apple. For direct distribution outside the App Store."
+msgstr ""
+
+#: src/cli/perry-toml.md:206
+msgid ""
+"**`\"both\"`** — Produces **two** signed builds: one for the App Store and "
+"one notarized for direct distribution. Requires **two separate "
+"certificates**:"
+msgstr ""
+
+#: src/cli/perry-toml.md:207
+msgid "`certificate` + `signing_identity` for the App Store build"
+msgstr ""
+
+#: src/cli/perry-toml.md:208
+msgid ""
+"`notarize_certificate` + `notarize_signing_identity` for the notarized build"
+msgstr ""
+
+#: src/cli/perry-toml.md:209
+msgid "Optionally `installer_certificate` for `.pkg` signing"
+msgstr ""
+
+#: src/cli/perry-toml.md:211
+msgid "macOS App Store Categories"
+msgstr ""
+
+#: src/cli/perry-toml.md:213
+msgid "Common values for the `category` field (Apple UTI format):"
+msgstr ""
+
+#: src/cli/perry-toml.md:215
+msgid "Category"
+msgstr ""
+
+#: src/cli/perry-toml.md:217
+msgid "Business"
+msgstr ""
+
+#: src/cli/perry-toml.md:217
+msgid "`public.app-category.business`"
+msgstr ""
+
+#: src/cli/perry-toml.md:218
+msgid "Developer Tools"
+msgstr ""
+
+#: src/cli/perry-toml.md:218
+msgid "`public.app-category.developer-tools`"
+msgstr ""
+
+#: src/cli/perry-toml.md:219
+msgid "Education"
+msgstr ""
+
+#: src/cli/perry-toml.md:219
+msgid "`public.app-category.education`"
+msgstr ""
+
+#: src/cli/perry-toml.md:220
+msgid "Entertainment"
+msgstr ""
+
+#: src/cli/perry-toml.md:220
+msgid "`public.app-category.entertainment`"
+msgstr ""
+
+#: src/cli/perry-toml.md:221
+msgid "Finance"
+msgstr ""
+
+#: src/cli/perry-toml.md:221
+msgid "`public.app-category.finance`"
+msgstr ""
+
+#: src/cli/perry-toml.md:222
+msgid "Games"
+msgstr ""
+
+#: src/cli/perry-toml.md:222
+msgid "`public.app-category.games`"
+msgstr ""
+
+#: src/cli/perry-toml.md:223
+msgid "Graphics & Design"
+msgstr ""
+
+#: src/cli/perry-toml.md:223
+msgid "`public.app-category.graphics-design`"
+msgstr ""
+
+#: src/cli/perry-toml.md:224
+msgid "Health & Fitness"
+msgstr ""
+
+#: src/cli/perry-toml.md:224
+msgid "`public.app-category.healthcare-fitness`"
+msgstr ""
+
+#: src/cli/perry-toml.md:225
+msgid "Lifestyle"
+msgstr ""
+
+#: src/cli/perry-toml.md:225
+msgid "`public.app-category.lifestyle`"
+msgstr ""
+
+#: src/cli/perry-toml.md:226
+msgid "Music"
+msgstr ""
+
+#: src/cli/perry-toml.md:226
+msgid "`public.app-category.music`"
+msgstr ""
+
+#: src/cli/perry-toml.md:227
+msgid "News"
+msgstr ""
+
+#: src/cli/perry-toml.md:227
+msgid "`public.app-category.news`"
+msgstr ""
+
+#: src/cli/perry-toml.md:228
+msgid "Photography"
+msgstr ""
+
+#: src/cli/perry-toml.md:228
+msgid "`public.app-category.photography`"
+msgstr ""
+
+#: src/cli/perry-toml.md:229
+msgid "Productivity"
+msgstr ""
+
+#: src/cli/perry-toml.md:229
+msgid "`public.app-category.productivity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:230
+msgid "Social Networking"
+msgstr ""
+
+#: src/cli/perry-toml.md:230
+msgid "`public.app-category.social-networking`"
+msgstr ""
+
+#: src/cli/perry-toml.md:231
+msgid "`public.app-category.utilities`"
+msgstr ""
+
+#: src/cli/perry-toml.md:235
+msgid "`[ios]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:237
+msgid ""
+"iOS-specific configuration for `perry publish ios`, `perry run ios`, and "
+"`perry compile --target ios`/`--target ios-simulator`."
+msgstr ""
+
+#: src/cli/perry-toml.md:243
+msgid "iOS-specific bundle identifier"
+msgstr ""
+
+#: src/cli/perry-toml.md:244 src/cli/perry-toml.md:302
+msgid "`deployment_target`"
+msgstr ""
+
+#: src/cli/perry-toml.md:244
+msgid "`\"17.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:244
+msgid "Minimum iOS version required (e.g., `\"16.0\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:303
+msgid "`minimum_version`"
+msgstr ""
+
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:303
+msgid "Alias for `deployment_target`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "`device_family`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "`[\"iphone\", \"ipad\"]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "Supported device families"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "`orientations`"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "`[\"portrait\"]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "Supported interface orientations"
+msgstr ""
+
+#: src/cli/perry-toml.md:248
+msgid "`capabilities`"
+msgstr ""
+
+#: src/cli/perry-toml.md:248
+msgid "App capabilities (e.g., `[\"push-notification\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:249 src/cli/perry-toml.md:304
+#: src/cli/perry-toml.md:337 src/cli/perry-toml.md:349
+msgid "Falls back to `[project]`/`[app]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:249
+msgid "iOS-specific entry file (useful when iOS needs a different entry point)"
+msgstr ""
+
+#: src/cli/perry-toml.md:250 src/cli/perry-toml.md:305
+msgid "If `true`, adds `ITSAppUsesNonExemptEncryption = false` to Info.plist"
+msgstr ""
+
+#: src/cli/perry-toml.md:256
+msgid ""
+"Distribution method: `\"appstore\"`, `\"testflight\"`, or `\"development\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:262
+msgid "Code signing identity (e.g., `\"iPhone Distribution: Company (TEAMID)\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:263 src/cli/perry-toml.md:314
+msgid "Path to `.p12` distribution certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:264 src/cli/perry-toml.md:315
+msgid "`provisioning_profile`"
+msgstr ""
+
+#: src/cli/perry-toml.md:264
+msgid ""
+"Path to `.mobileprovision` file. Stored as `{bundle_id}.mobileprovision` in "
+"`~/.perry/` by `perry setup ios`"
+msgstr ""
+
+#: src/cli/perry-toml.md:273 src/cli/perry-toml.md:319
+msgid "Path to `.p8` API key file"
+msgstr ""
+
+#: src/cli/perry-toml.md:275
+msgid "Device Family Values"
+msgstr ""
+
+#: src/cli/perry-toml.md:279
+msgid "`\"iphone\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:279
+msgid "iPhone devices"
+msgstr ""
+
+#: src/cli/perry-toml.md:280
+msgid "`\"ipad\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:280
+msgid "iPad devices"
+msgstr ""
+
+#: src/cli/perry-toml.md:282
+msgid "Orientation Values"
+msgstr ""
+
+#: src/cli/perry-toml.md:286
+msgid "`\"portrait\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:286
+msgid "Device upright"
+msgstr ""
+
+#: src/cli/perry-toml.md:287
+msgid "`\"portrait-upside-down\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:287
+msgid "Device upside down"
+msgstr ""
+
+#: src/cli/perry-toml.md:288
+msgid "`\"landscape-left\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:288
+msgid "Device rotated left"
+msgstr ""
+
+#: src/cli/perry-toml.md:289
+msgid "`\"landscape-right\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:289
+msgid "Device rotated right"
+msgstr ""
+
+#: src/cli/perry-toml.md:293
+msgid "`[visionos]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:295
+msgid ""
+"visionOS-specific configuration for `perry publish visionos`, `perry run "
+"visionos`, and `perry compile --target visionos`/`--target "
+"visionos-simulator`."
+msgstr ""
+
+#: src/cli/perry-toml.md:301
+msgid "Falls back to `[app]`/`[project]`/`[ios]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:301
+msgid "visionOS-specific bundle identifier"
+msgstr ""
+
+#: src/cli/perry-toml.md:302
+msgid "`\"1.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:302
+msgid "Minimum visionOS version required"
+msgstr ""
+
+#: src/cli/perry-toml.md:304
+msgid "visionOS-specific entry file"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "`info_plist`"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "table"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "Custom key-value pairs merged into the generated Info.plist"
+msgstr ""
+
+#: src/cli/perry-toml.md:308
+msgid "Distribution / Signing"
+msgstr ""
+
+#: src/cli/perry-toml.md:312
+msgid "Distribution method for visionOS builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:313
+msgid "Code signing identity"
+msgstr ""
+
+#: src/cli/perry-toml.md:315
+msgid "Path to `.mobileprovision` file"
+msgstr ""
+
+#: src/cli/perry-toml.md:323
+msgid "`[android]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:325
+msgid ""
+"Android-specific configuration for `perry publish android`, `perry run "
+"android`, and `perry compile --target android`."
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "`package_name`"
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "Falls back to bundle_id chain"
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "Java package name (e.g., `\"com.example.myapp\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:330
+msgid "`min_sdk`"
+msgstr ""
+
+#: src/cli/perry-toml.md:330
+msgid "Minimum Android SDK version (e.g., `\"26\"` for Android 8.0)"
+msgstr ""
+
+#: src/cli/perry-toml.md:331
+msgid "`target_sdk`"
+msgstr ""
+
+#: src/cli/perry-toml.md:331
+msgid "Target Android SDK version (e.g., `\"34\"` for Android 14)"
+msgstr ""
+
+#: src/cli/perry-toml.md:332
+msgid "`permissions`"
+msgstr ""
+
+#: src/cli/perry-toml.md:332
+msgid ""
+"Android permissions (e.g., `[\"INTERNET\", \"CAMERA\", "
+"\"ACCESS_FINE_LOCATION\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:333
+msgid "Distribution method: `\"playstore\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:334
+msgid "`keystore`"
+msgstr ""
+
+#: src/cli/perry-toml.md:334
+msgid "Path to `.jks` or `.keystore` signing keystore"
+msgstr ""
+
+#: src/cli/perry-toml.md:335
+msgid "`key_alias`"
+msgstr ""
+
+#: src/cli/perry-toml.md:335
+msgid "Alias of the signing key within the keystore"
+msgstr ""
+
+#: src/cli/perry-toml.md:336
+msgid "`google_play_key`"
+msgstr ""
+
+#: src/cli/perry-toml.md:336
+msgid "Path to Google Play service account JSON file for automated uploads"
+msgstr ""
+
+#: src/cli/perry-toml.md:337
+msgid "Android-specific entry file"
+msgstr ""
+
+#: src/cli/perry-toml.md:341
+msgid "`[linux]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:343
+msgid "Linux-specific configuration for `perry publish linux`."
+msgstr ""
+
+#: src/cli/perry-toml.md:347
+msgid "`format`"
+msgstr ""
+
+#: src/cli/perry-toml.md:347
+msgid "Package format: `\"appimage\"`, `\"deb\"`, or `\"rpm\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:348
+msgid ""
+"Desktop application category (e.g., `\"Development\"`, `\"Utility\"`, "
+"`\"Game\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:349
+msgid "Application description for package metadata"
+msgstr ""
+
+#: src/cli/perry-toml.md:353
+msgid "`[i18n]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:355
+msgid ""
+"Internationalization configuration. See the [i18n "
+"documentation](../i18n/overview.md) for full details."
+msgstr ""
+
+#: src/cli/perry-toml.md:359
+msgid "`locales`"
+msgstr ""
+
+#: src/cli/perry-toml.md:359
+msgid ""
+"Supported locale codes (e.g., `[\"en\", \"de\", \"fr\"]`). Locale files must "
+"exist in `/locales`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "`default_locale`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "`\"en\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "Fallback locale. Used when a key is missing in another locale"
+msgstr ""
+
+#: src/cli/perry-toml.md:361
+msgid "`dynamic`"
+msgstr ""
+
+#: src/cli/perry-toml.md:361
+msgid ""
+"`false`: locale set at launch, strings inlined. `true`: locale switchable at "
+"runtime"
+msgstr ""
+
+#: src/cli/perry-toml.md:363
+msgid "`[i18n.currencies]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:365
+msgid ""
+"Maps locale codes to default ISO 4217 currency codes. Used by the "
+"`Currency()` format wrapper."
+msgstr ""
+
+#: src/cli/perry-toml.md:369
+msgid "`{locale}`"
+msgstr ""
+
+#: src/cli/perry-toml.md:369
+msgid "Currency code for the locale (e.g., `en = \"USD\"`, `de = \"EUR\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:373
+msgid "`[publish]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:375
+msgid "Publishing configuration."
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid "`server`"
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid "`https://hub.perryts.com`"
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid ""
+"Custom Perry Hub build server URL. Useful for self-hosted or enterprise "
+"deployments"
+msgstr ""
+
+#: src/cli/perry-toml.md:383
+msgid "`[audit]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:385
+msgid "Security audit configuration for `perry audit` and pre-publish audits."
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid "`fail_on`"
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid "`\"C\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid ""
+"Minimum acceptable audit grade. Build fails if the actual grade is below "
+"this threshold. Values: `\"A\"`, `\"A-\"`, `\"B\"`, `\"C\"`, `\"D\"`, `\"F\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid "`severity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid "`\"all\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid ""
+"Filter findings by severity: `\"all\"`, `\"critical\"`, `\"high\"`, "
+"`\"medium\"`, `\"low\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:391
+msgid "`ignore`"
+msgstr ""
+
+#: src/cli/perry-toml.md:391
+msgid "List of audit rule IDs to suppress (e.g., `[\"RULE-001\", \"RULE-042\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:393
+msgid "Audit Grade Scale"
+msgstr ""
+
+#: src/cli/perry-toml.md:395
+msgid "Grades are ranked from highest to lowest:"
+msgstr ""
+
+#: src/cli/perry-toml.md:397
+msgid "Grade"
+msgstr ""
+
+#: src/cli/perry-toml.md:397
+msgid "Rank"
+msgstr ""
+
+#: src/cli/perry-toml.md:399
+msgid "A"
+msgstr ""
+
+#: src/cli/perry-toml.md:399
+msgid "Excellent — no significant findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:400
+msgid "A-"
+msgstr ""
+
+#: src/cli/perry-toml.md:400
+msgid "Very good — minor findings only"
+msgstr ""
+
+#: src/cli/perry-toml.md:401
+msgid "B"
+msgstr ""
+
+#: src/cli/perry-toml.md:401
+msgid "Good — some findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:402
+msgid "C"
+msgstr ""
+
+#: src/cli/perry-toml.md:402
+msgid "Acceptable — moderate findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:403
+msgid "D"
+msgstr ""
+
+#: src/cli/perry-toml.md:403
+msgid "Poor — significant findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:404
+msgid "F"
+msgstr ""
+
+#: src/cli/perry-toml.md:404
+msgid "Fail — critical findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:406
+msgid ""
+"Setting `fail_on = \"B\"` means any grade below B (i.e., C, D, or F) will "
+"cause the build to fail."
+msgstr ""
+
+#: src/cli/perry-toml.md:410
+msgid "`[verify]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:412
+msgid "Runtime verification configuration for `perry verify`."
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "`url`"
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "`https://verify.perryts.com`"
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "Verification service endpoint URL"
+msgstr ""
+
+#: src/cli/perry-toml.md:420
+msgid "Bundle ID Resolution"
+msgstr ""
+
+#: src/cli/perry-toml.md:422
+msgid ""
+"Perry resolves the bundle identifier using a cascading priority system. The "
+"first non-empty value wins:"
+msgstr ""
+
+#: src/cli/perry-toml.md:424
+msgid "For iOS builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:425 src/cli/perry-toml.md:441
+msgid "`[ios].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:426 src/cli/perry-toml.md:434
+#: src/cli/perry-toml.md:443
+msgid "`[app].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:427 src/cli/perry-toml.md:435
+#: src/cli/perry-toml.md:444
+msgid "`[project].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:428 src/cli/perry-toml.md:433
+#: src/cli/perry-toml.md:442
+msgid "`[macos].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:429 src/cli/perry-toml.md:436
+msgid "`package.json` `bundleId` field"
+msgstr ""
+
+#: src/cli/perry-toml.md:430 src/cli/perry-toml.md:437
+#: src/cli/perry-toml.md:445
+msgid "`com.perry.<app_name>` (generated default)"
+msgstr ""
+
+#: src/cli/perry-toml.md:432
+msgid "For macOS builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:439
+msgid "For Android builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:440
+msgid "`[android].package_name`"
+msgstr ""
+
+#: src/cli/perry-toml.md:449
+msgid "Entry File Resolution"
+msgstr ""
+
+#: src/cli/perry-toml.md:451
+msgid ""
+"When no input file is specified on the command line, Perry resolves the "
+"entry file in this order:"
+msgstr ""
+
+#: src/cli/perry-toml.md:453
+msgid "`[ios].entry` / `[android].entry` (when targeting that platform)"
+msgstr ""
+
+#: src/cli/perry-toml.md:454
+msgid "`[project].entry` or `[app].entry`"
+msgstr ""
+
+#: src/cli/perry-toml.md:455
+msgid "`src/main.ts` (if it exists)"
+msgstr ""
+
+#: src/cli/perry-toml.md:456
+msgid "`main.ts` (if it exists)"
+msgstr ""
+
+#: src/cli/perry-toml.md:460
+msgid "Build Number Auto-Increment"
+msgstr ""
+
+#: src/cli/perry-toml.md:462
+msgid ""
+"The `build_number` field is automatically incremented by `perry publish` for:"
+msgstr ""
+
+#: src/cli/perry-toml.md:463
+msgid "iOS builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:464
+msgid "Android builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:465
+msgid "macOS App Store builds (`distribute = \"appstore\"` or `\"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:467
+msgid ""
+"The updated value is written back to `perry.toml` after a successful "
+"publish. This ensures each submission to the App Store / Play Store has a "
+"unique, monotonically increasing build number."
+msgstr ""
+
+#: src/cli/perry-toml.md:469
+msgid ""
+"macOS builds with `distribute = \"notarize\"` (direct distribution) do "
+"**not** auto-increment the build number."
+msgstr ""
+
+#: src/cli/perry-toml.md:473
+msgid "Configuration Priority"
+msgstr ""
+
+#: src/cli/perry-toml.md:475
+msgid ""
+"Perry resolves configuration values using a layered priority system (highest "
+"to lowest):"
+msgstr ""
+
+#: src/cli/perry-toml.md:477
+msgid "**CLI flags** — e.g., `--target`, `--output`"
+msgstr ""
+
+#: src/cli/perry-toml.md:478
+msgid "**Environment variables** — e.g., `PERRY_LICENSE_KEY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:479
+msgid ""
+"**perry.toml** — project-level config (platform-specific sections first, "
+"then `[app]`/`[project]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:480
+msgid "**~/.perry/config.toml** — user-level global config"
+msgstr ""
+
+#: src/cli/perry-toml.md:481
+msgid "**Built-in defaults**"
+msgstr ""
+
+#: src/cli/perry-toml.md:487
+msgid "These environment variables override perry.toml and global config values:"
+msgstr ""
+
+#: src/cli/perry-toml.md:489
+msgid "Apple / iOS / macOS"
+msgstr ""
+
+#: src/cli/perry-toml.md:494
+msgid "`PERRY_APPLE_CERTIFICATE`"
+msgstr ""
+
+#: src/cli/perry-toml.md:494
+msgid "`.p12` certificate file contents (base64)"
+msgstr ""
+
+#: src/cli/perry-toml.md:495
+msgid "Password for the `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:496
+msgid "`PERRY_APPLE_P8_KEY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:496
+msgid "`.p8` API key file contents"
+msgstr ""
+
+#: src/cli/perry-toml.md:497
+msgid "`PERRY_APPLE_KEY_ID`"
+msgstr ""
+
+#: src/cli/perry-toml.md:498
+msgid "`PERRY_APPLE_NOTARIZE_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:498
+msgid "Password for the notarization `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:499
+msgid "`PERRY_APPLE_INSTALLER_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:499
+msgid "Password for the installer `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:505
+msgid "`PERRY_ANDROID_KEYSTORE`"
+msgstr ""
+
+#: src/cli/perry-toml.md:505
+msgid "Path to `.jks`/`.keystore` file"
+msgstr ""
+
+#: src/cli/perry-toml.md:506
+msgid "`PERRY_ANDROID_KEY_ALIAS`"
+msgstr ""
+
+#: src/cli/perry-toml.md:506
+msgid "Keystore key alias"
+msgstr ""
+
+#: src/cli/perry-toml.md:507
+msgid "`PERRY_ANDROID_KEYSTORE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:508
+msgid "`PERRY_ANDROID_KEY_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:508
+msgid "Key password (within the keystore)"
+msgstr ""
+
+#: src/cli/perry-toml.md:509
+msgid "`PERRY_GOOGLE_PLAY_KEY_PATH`"
+msgstr ""
+
+#: src/cli/perry-toml.md:509
+msgid "Path to Google Play service account JSON"
+msgstr ""
+
+#: src/cli/perry-toml.md:511
+msgid "General"
+msgstr ""
+
+#: src/cli/perry-toml.md:515
+msgid "`PERRY_NO_TELEMETRY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:515
+msgid "Set to `1` to disable anonymous telemetry"
+msgstr ""
+
+#: src/cli/perry-toml.md:516
+msgid "`PERRY_NO_UPDATE_CHECK`"
+msgstr ""
+
+#: src/cli/perry-toml.md:516
+msgid "Set to `1` to disable background update checks"
+msgstr ""
+
+#: src/cli/perry-toml.md:520
+msgid "Global Config: `~/.perry/config.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:522
+msgid ""
+"Separate from the project-level `perry.toml`, Perry maintains a user-level "
+"global config at `~/.perry/config.toml`. This stores credentials and "
+"preferences shared across all projects."
+msgstr ""
+
+#: src/cli/perry-toml.md:524
+msgid ""
+"```toml\n"
+"license_key = \"perry-xxxxxxxx\"\n"
+"server = \"https://hub.perryts.com\"\n"
+"default_target = \"macos\"\n"
+"\n"
+"[apple]\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"/Users/me/.perry/AuthKey.p8\"\n"
+"\n"
+"[android]\n"
+"keystore_path = \"/Users/me/.perry/release.keystore\"\n"
+"key_alias = \"my-key\"\n"
+"google_play_key_path = \"/Users/me/.perry/play-service-account.json\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:541
+msgid ""
+"Fields in perry.toml (project-level) override `~/.perry/config.toml` "
+"(global-level). For example, `[ios].team_id` in perry.toml overrides "
+"`[apple].team_id` in the global config."
+msgstr ""
+
+#: src/cli/perry-toml.md:543
+msgid "The global config is managed by `perry setup` commands:"
+msgstr ""
+
+#: src/cli/perry-toml.md:544
+msgid "`perry setup ios` — configures Apple signing credentials"
+msgstr ""
+
+#: src/cli/perry-toml.md:545
+msgid "`perry setup android` — configures Android signing credentials"
+msgstr ""
+
+#: src/cli/perry-toml.md:546
+msgid "`perry setup macos` — configures macOS distribution settings"
+msgstr ""
+
+#: src/cli/perry-toml.md:550
+msgid "perry.toml vs package.json"
+msgstr ""
+
+#: src/cli/perry-toml.md:552
+msgid "Perry reads configuration from both files. Here's what goes where:"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "Setting"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "File"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "Section"
+msgstr ""
+
+#: src/cli/perry-toml.md:556
+msgid "Compile packages natively"
+msgstr ""
+
+#: src/cli/perry-toml.md:556 src/cli/perry-toml.md:557
+msgid "`package.json`"
+msgstr ""
+
+#: src/cli/perry-toml.md:556
+msgid "`perry.compilePackages`"
+msgstr ""
+
+#: src/cli/perry-toml.md:557
+msgid "Splash screen"
+msgstr ""
+
+#: src/cli/perry-toml.md:557
+msgid "`perry.splash`"
+msgstr ""
+
+#: src/cli/perry-toml.md:558
+msgid "Project name, version, entry"
+msgstr ""
+
+#: src/cli/perry-toml.md:558 src/cli/perry-toml.md:559
+#: src/cli/perry-toml.md:560 src/cli/perry-toml.md:561
+#: src/cli/perry-toml.md:562
+msgid "`perry.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:559
+msgid "Platform-specific settings"
+msgstr ""
+
+#: src/cli/perry-toml.md:559
+msgid "`[ios]`, `[macos]`, `[android]`, `[linux]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:560
+msgid "Code signing & distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:560
+msgid "Platform sections"
+msgstr ""
+
+#: src/cli/perry-toml.md:561
+msgid "Build output directory"
+msgstr ""
+
+#: src/cli/perry-toml.md:562
+msgid "Audit & verification"
+msgstr ""
+
+#: src/cli/perry-toml.md:562
+msgid "`[audit]`, `[verify]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:564
+msgid ""
+"When both files define the same value (e.g., project name), `perry.toml` "
+"takes precedence."
+msgstr ""
+
+#: src/cli/perry-toml.md:568
+msgid "Setup Wizard"
+msgstr ""
+
+#: src/cli/perry-toml.md:570
+msgid ""
+"Running `perry setup <platform>` interactively configures signing "
+"credentials and writes them back to both `perry.toml` and "
+"`~/.perry/config.toml`:"
+msgstr ""
+
+#: src/cli/perry-toml.md:573
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:574
+msgid "# Configure Android signing (keystore, Play Store key)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:575
+msgid "# Configure macOS distribution (App Store, notarization)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:578
+msgid "The wizard automatically:"
+msgstr ""
+
+#: src/cli/perry-toml.md:579
+msgid "Sets `[ios].distribute = \"testflight\"` if not already configured"
+msgstr ""
+
+#: src/cli/perry-toml.md:580
+msgid "Sets `[android].distribute = \"playstore\"` if not already configured"
+msgstr ""
+
+#: src/cli/perry-toml.md:581
+msgid "Stores provisioning profiles as `~/.perry/{bundle_id}.mobileprovision`"
+msgstr ""
+
+#: src/cli/perry-toml.md:582
+msgid "Auto-exports `.p12` certificates from macOS Keychain when possible"
+msgstr ""
+
+#: src/cli/perry-toml.md:586
+msgid "CI/CD Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:588
+msgid ""
+"For CI environments, use environment variables instead of storing "
+"credentials in `perry.toml`:"
+msgstr ""
+
+#: src/cli/perry-toml.md:591
+msgid "# GitHub Actions example\nenv"
+msgstr ""
+
+#: src/cli/perry-toml.md:593
+msgid "PERRY_LICENSE_KEY"
+msgstr ""
+
+#: src/cli/perry-toml.md:593
+msgid "${{ secrets.PERRY_LICENSE_KEY }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:594
+msgid "PERRY_APPLE_CERTIFICATE"
+msgstr ""
+
+#: src/cli/perry-toml.md:594
+msgid "${{ secrets.APPLE_CERTIFICATE }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:595
+msgid "PERRY_APPLE_CERTIFICATE_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:595
+msgid "${{ secrets.APPLE_CERT_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:596
+msgid "PERRY_APPLE_P8_KEY"
+msgstr ""
+
+#: src/cli/perry-toml.md:596
+msgid "${{ secrets.APPLE_P8_KEY }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:597
+msgid "PERRY_APPLE_KEY_ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:597
+msgid "${{ secrets.APPLE_KEY_ID }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:598
+msgid "PERRY_ANDROID_KEYSTORE"
+msgstr ""
+
+#: src/cli/perry-toml.md:598
+msgid "${{ secrets.ANDROID_KEYSTORE }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:599
+msgid "PERRY_ANDROID_KEYSTORE_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:599
+msgid "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:600
+msgid "PERRY_ANDROID_KEY_ALIAS"
+msgstr ""
+
+#: src/cli/perry-toml.md:600
+msgid "${{ secrets.ANDROID_KEY_ALIAS }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:601
+msgid "PERRY_ANDROID_KEY_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:601
+msgid "${{ secrets.ANDROID_KEY_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:604
+msgid "perry publish ios"
+msgstr ""
+
+#: src/cli/perry-toml.md:605
+msgid "perry publish android"
+msgstr ""
+
+#: src/cli/perry-toml.md:606
+msgid "perry publish macos"
+msgstr ""
+
+#: src/cli/perry-toml.md:609
+msgid "Keep `perry.toml` in version control with non-sensitive fields only:"
+msgstr ""
+
+#: src/cli/perry-toml.md:611
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"version = \"2.1.0\"\n"
+"build_number = 47\n"
+"bundle_id = \"com.example.myapp\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[ios]\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"distribute = \"appstore\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = \"26\"\n"
+"target_sdk = \"34\"\n"
+"distribute = \"playstore\"\n"
+"\n"
+"[macos]\n"
+"distribute = \"both\"\n"
+"category = \"public.app-category.productivity\"\n"
+"minimum_os = \"13.0\"\n"
+"\n"
+"[audit]\n"
+"fail_on = \"B\"\n"
+"```"
+msgstr ""
+
+#: src/contributing/architecture.md:3
+msgid ""
+"This is a brief overview for contributors. For detailed implementation "
+"notes, see the project's `CLAUDE.md`."
+msgstr ""
+
+#: src/contributing/architecture.md:5
+msgid "Compilation Pipeline"
+msgstr ""
+
+#: src/contributing/architecture.md:21
+msgid "Crate Map"
+msgstr ""
+
+#: src/contributing/architecture.md:23
+msgid "Crate"
+msgstr ""
+
+#: src/contributing/architecture.md:25
+msgid "`perry`"
+msgstr ""
+
+#: src/contributing/architecture.md:25
+msgid "CLI driver, command parsing, compilation orchestration"
+msgstr ""
+
+#: src/contributing/architecture.md:26
+msgid "`perry-parser`"
+msgstr ""
+
+#: src/contributing/architecture.md:26
+msgid "SWC wrapper for TypeScript parsing"
+msgstr ""
+
+#: src/contributing/architecture.md:27
+msgid "`perry-types`"
+msgstr ""
+
+#: src/contributing/architecture.md:27
+msgid "Type system definitions"
+msgstr ""
+
+#: src/contributing/architecture.md:28
+msgid "`perry-hir`"
+msgstr ""
+
+#: src/contributing/architecture.md:28
+msgid "HIR data structures (`ir.rs`) and AST→HIR lowering (`lower.rs`)"
+msgstr ""
+
+#: src/contributing/architecture.md:29
+msgid "`perry-transform`"
+msgstr ""
+
+#: src/contributing/architecture.md:29
+msgid "IR passes: function inlining, closure conversion, async lowering"
+msgstr ""
+
+#: src/contributing/architecture.md:30
+msgid "`perry-codegen-llvm`"
+msgstr ""
+
+#: src/contributing/architecture.md:30
+msgid "LLVM-based native code generation"
+msgstr ""
+
+#: src/contributing/architecture.md:31
+msgid "`perry-codegen-wasm`"
+msgstr ""
+
+#: src/contributing/architecture.md:31
+msgid ""
+"WebAssembly code generation for `--target web` / `--target wasm` (HIR → WASM "
+"bytecode + JS bridge)"
+msgstr ""
+
+#: src/contributing/architecture.md:32
+msgid "`perry-codegen-js`"
+msgstr ""
+
+#: src/contributing/architecture.md:32
+msgid ""
+"Legacy JavaScript code generator (still present for the JS minifier; the "
+"JS-emit `--target web` path was consolidated into `perry-codegen-wasm`)"
+msgstr ""
+
+#: src/contributing/architecture.md:33
+msgid "`perry-codegen-swiftui`"
+msgstr ""
+
+#: src/contributing/architecture.md:33
+msgid "SwiftUI code generation for WidgetKit extensions"
+msgstr ""
+
+#: src/contributing/architecture.md:34
+msgid "`perry-runtime`"
+msgstr ""
+
+#: src/contributing/architecture.md:34
+msgid ""
+"Runtime library: NaN-boxed values, GC, arena allocator, objects, arrays, "
+"strings"
+msgstr ""
+
+#: src/contributing/architecture.md:35
+msgid "`perry-stdlib`"
+msgstr ""
+
+#: src/contributing/architecture.md:35
+msgid "Node.js API implementations: mysql2, redis, fastify, bcrypt, etc."
+msgstr ""
+
+#: src/contributing/architecture.md:36
+msgid "`perry-ui`"
+msgstr ""
+
+#: src/contributing/architecture.md:36
+msgid "Shared UI types"
+msgstr ""
+
+#: src/contributing/architecture.md:37
+msgid "macOS UI (AppKit)"
+msgstr ""
+
+#: src/contributing/architecture.md:38
+msgid "iOS UI (UIKit)"
+msgstr ""
+
+#: src/contributing/architecture.md:39
+msgid "`perry-jsruntime`"
+msgstr ""
+
+#: src/contributing/architecture.md:39
+msgid "JavaScript interop via QuickJS"
+msgstr ""
+
+#: src/contributing/architecture.md:41
+msgid "Key Concepts"
+msgstr ""
+
+#: src/contributing/architecture.md:43
+msgid "NaN-Boxing"
+msgstr ""
+
+#: src/contributing/architecture.md:45
+msgid ""
+"All JavaScript values are represented as 64-bit NaN-boxed values. The upper "
+"16 bits encode the type tag:"
+msgstr ""
+
+#: src/contributing/architecture.md:47
+msgid "Tag"
+msgstr ""
+
+#: src/contributing/architecture.md:49
+msgid "`0x7FFF`"
+msgstr ""
+
+#: src/contributing/architecture.md:49
+msgid "String (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:50
+msgid "`0x7FFD`"
+msgstr ""
+
+#: src/contributing/architecture.md:50
+msgid "Pointer/Object (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:51
+msgid "`0x7FFE`"
+msgstr ""
+
+#: src/contributing/architecture.md:51
+msgid "Int32 (lower 32 bits = integer)"
+msgstr ""
+
+#: src/contributing/architecture.md:52
+msgid "`0x7FFA`"
+msgstr ""
+
+#: src/contributing/architecture.md:52
+msgid "BigInt (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:53
+msgid "Special constants"
+msgstr ""
+
+#: src/contributing/architecture.md:53
+msgid "undefined, null, true, false"
+msgstr ""
+
+#: src/contributing/architecture.md:54
+msgid "Any other"
+msgstr ""
+
+#: src/contributing/architecture.md:54
+msgid "Float64 (the full 64 bits)"
+msgstr ""
+
+#: src/contributing/architecture.md:58
+msgid ""
+"Mark-sweep GC with conservative stack scanning. Arena-allocated objects "
+"(arrays, objects) are found by linear block walking. Malloc-allocated "
+"objects (strings, closures, promises) are tracked in a thread-local Vec."
+msgstr ""
+
+#: src/contributing/architecture.md:60
+msgid "Handle-Based UI"
+msgstr ""
+
+#: src/contributing/architecture.md:62
+msgid ""
+"UI widgets are represented as small integer handles NaN-boxed with "
+"`POINTER_TAG`. Each handle maps to a native platform widget (NSButton, "
+"UILabel, GtkButton, etc.). Two dispatch tables route method calls and "
+"property accesses to the correct FFI function."
+msgstr ""
+
+#: src/contributing/architecture.md:64
+msgid "Source Code Organization"
+msgstr ""
+
+#: src/contributing/architecture.md:66
+msgid "The codegen crate is organized into focused modules:"
+msgstr ""
+
+#: src/contributing/architecture.md:83
+msgid "The HIR lowering was split into 8 modules:"
+msgstr ""
+
+#: src/contributing/architecture.md:99
+msgid "[Building from Source](building.md)"
+msgstr ""
+
+#: src/contributing/architecture.md:100
+msgid "See `CLAUDE.md` in the repository root for detailed implementation notes"
+msgstr ""
+
+#: src/contributing/building.md:5
+msgid "Rust toolchain (stable): [rustup.rs](https://rustup.rs/)"
+msgstr ""
+
+#: src/contributing/building.md:6
+msgid "System C compiler (`cc` on macOS/Linux, MSVC on Windows)"
+msgstr ""
+
+#: src/contributing/building.md:8
+msgid "Build"
+msgstr ""
+
+#: src/contributing/building.md:13
+msgid "# Build all crates (release mode recommended)\n"
+msgstr ""
+
+#: src/contributing/building.md:18
+msgid "The binary is at `target/release/perry`."
+msgstr ""
+
+#: src/contributing/building.md:20
+msgid "Build Specific Crates"
+msgstr ""
+
+#: src/contributing/building.md:23
+msgid "# Runtime only (must rebuild stdlib too!)\n"
+msgstr ""
+
+#: src/contributing/building.md:25
+msgid "# Codegen only\n"
+msgstr ""
+
+#: src/contributing/building.md:30
+msgid ""
+"**Important**: When rebuilding `perry-runtime`, you must also rebuild "
+"`perry-stdlib` because `libperry_stdlib.a` embeds perry-runtime as a static "
+"dependency."
+msgstr ""
+
+#: src/contributing/building.md:32
+msgid "Run Tests"
+msgstr ""
+
+#: src/contributing/building.md:35
+msgid "# All tests (exclude iOS crate on non-iOS host)\n"
+msgstr ""
+
+#: src/contributing/building.md:37
+msgid "# Specific crate\n"
+msgstr ""
+
+#: src/contributing/building.md:43
+msgid "Compile and Run TypeScript"
+msgstr ""
+
+#: src/contributing/building.md:46
+msgid "# Compile a TypeScript file\n"
+msgstr ""
+
+#: src/contributing/building.md:49
+msgid "# Debug: print HIR\n"
+msgstr ""
+
+#: src/contributing/building.md:54
+msgid "Development Workflow"
+msgstr ""
+
+#: src/contributing/building.md:56
+msgid "Make changes to the relevant crate"
+msgstr ""
+
+#: src/contributing/building.md:57
+msgid "`cargo build --release` to build"
+msgstr ""
+
+#: src/contributing/building.md:58
+msgid "`cargo test --workspace --exclude perry-ui-ios` to verify"
+msgstr ""
+
+#: src/contributing/building.md:59
+msgid ""
+"Test with a real TypeScript file: `cargo run --release -- test.ts -o test && "
+"./test`"
+msgstr ""
+
+#: src/contributing/building.md:88
+msgid "[Architecture](architecture.md) — Crate map and pipeline overview"
+msgstr ""
+
+#: src/contributing/building.md:89
+msgid "See `CLAUDE.md` for detailed implementation notes and pitfalls"
+msgstr ""
+

--- a/docs/po/zh-CN.po
+++ b/docs/po/zh-CN.po
@@ -1,0 +1,26511 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Perry Documentation\n"
+"POT-Creation-Date: 2026-05-02T21:12:49+02:00\n"
+"PO-Revision-Date: 2026-05-02T21:12:49+02:00\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh-CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/SUMMARY.md:1
+msgid "Summary"
+msgstr "目录"
+
+#: src/SUMMARY.md:3 src/introduction.md:1
+msgid "Introduction"
+msgstr "简介"
+
+#: src/SUMMARY.md:7
+msgid "Getting Started"
+msgstr "入门"
+
+#: src/SUMMARY.md:9 src/getting-started/installation.md:1 src/ui/theming.md:5
+msgid "Installation"
+msgstr "安装"
+
+#: src/SUMMARY.md:10 src/getting-started/hello-world.md:1
+msgid "Hello World"
+msgstr "Hello World"
+
+#: src/SUMMARY.md:11 src/getting-started/first-app.md:1
+msgid "First Native App"
+msgstr "第一个原生应用"
+
+#: src/SUMMARY.md:12 src/getting-started/project-config.md:1
+msgid "Project Configuration"
+msgstr "项目配置"
+
+#: src/SUMMARY.md:14
+msgid "Language"
+msgstr "语言"
+
+#: src/SUMMARY.md:16 src/platforms/wasm.md:39
+msgid "Supported Features"
+msgstr "支持的功能"
+
+#: src/SUMMARY.md:17 src/language/type-system.md:1
+msgid "Type System"
+msgstr "类型系统"
+
+#: src/SUMMARY.md:18 src/language/limitations.md:1 src/platforms/tvos.md:156
+#: src/platforms/watchos.md:192 src/platforms/wasm.md:146
+msgid "Limitations"
+msgstr "限制"
+
+#: src/SUMMARY.md:20
+msgid "npm Packages"
+msgstr "npm 包"
+
+#: src/SUMMARY.md:22
+msgid "Porting Packages (experimental)"
+msgstr "移植包(实验性)"
+
+#: src/SUMMARY.md:24 src/getting-started/hello-world.md:97
+#: src/threading/overview.md:1
+msgid "Multi-Threading"
+msgstr "多线程"
+
+#: src/SUMMARY.md:26 src/SUMMARY.md:33 src/SUMMARY.md:50 src/SUMMARY.md:66
+#: src/SUMMARY.md:76 src/SUMMARY.md:83 src/SUMMARY.md:87 src/SUMMARY.md:108
+msgid "Overview"
+msgstr "概述"
+
+#: src/SUMMARY.md:27 src/threading/parallel-map.md:1
+msgid "parallelMap"
+msgstr ""
+
+#: src/SUMMARY.md:28 src/threading/parallel-filter.md:1
+msgid "parallelFilter"
+msgstr ""
+
+#: src/SUMMARY.md:29 src/threading/spawn.md:1
+msgid "spawn"
+msgstr ""
+
+#: src/SUMMARY.md:31
+msgid "Native UI"
+msgstr "原生 UI"
+
+#: src/SUMMARY.md:34 src/SUMMARY.md:95 src/SUMMARY.md:97 src/ui/widgets.md:1
+msgid "Widgets"
+msgstr "控件"
+
+#: src/SUMMARY.md:35 src/ui/overview.md:174 src/ui/layout.md:1
+#: src/widgets/components.md:41
+msgid "Layout"
+msgstr "布局"
+
+#: src/SUMMARY.md:36 src/ui/styling.md:1 src/platforms/linux.md:63
+msgid "Styling"
+msgstr "样式"
+
+#: src/SUMMARY.md:37 src/ui/state.md:1 src/platforms/watchos.md:105
+msgid "State Management"
+msgstr "状态管理"
+
+#: src/SUMMARY.md:38 src/ui/events.md:1 src/plugins/creating-plugins.md:104
+msgid "Events"
+msgstr "事件"
+
+#: src/SUMMARY.md:39 src/ui/canvas.md:1 src/platforms/macos.md:37
+#: src/platforms/android.md:38 src/platforms/windows.md:55
+#: src/platforms/linux.md:49
+msgid "Canvas"
+msgstr "画布"
+
+#: src/SUMMARY.md:40 src/ui/overview.md:175 src/ui/menus.md:1
+msgid "Menus"
+msgstr "菜单"
+
+#: src/SUMMARY.md:41 src/ui/dialogs.md:1
+msgid "Dialogs"
+msgstr "对话框"
+
+#: src/SUMMARY.md:42 src/ui/table.md:1 src/platforms/macos.md:36
+#: src/testing/geisterhand.md:93 src/testing/geisterhand.md:296
+msgid "Table"
+msgstr "表格"
+
+#: src/SUMMARY.md:43 src/ui/animation.md:1
+msgid "Animation"
+msgstr "动画"
+
+#: src/SUMMARY.md:44
+msgid "Multi-Window"
+msgstr "多窗口"
+
+#: src/SUMMARY.md:45 src/ui/theming.md:1
+msgid "Theming"
+msgstr "主题"
+
+#: src/SUMMARY.md:46 src/ui/camera.md:1
+msgid "Camera"
+msgstr "相机"
+
+#: src/SUMMARY.md:48 src/system/overview.md:21
+msgid "Platforms"
+msgstr "平台"
+
+#: src/SUMMARY.md:51 src/getting-started/installation.md:103
+#: src/ui/overview.md:170 src/ui/canvas.md:74 src/ui/menus.md:68
+#: src/ui/menus.md:111 src/ui/dialogs.md:108 src/ui/animation.md:64
+#: src/ui/multi-window.md:72 src/ui/multi-window.md:89
+#: src/ui/multi-window.md:100 src/ui/multi-window.md:116
+#: src/ui/multi-window.md:132 src/ui/multi-window.md:140
+#: src/platforms/overview.md:9 src/platforms/overview.md:67
+#: src/platforms/macos.md:1 src/i18n/overview.md:89
+#: src/updater/overview.md:257 src/system/preferences.md:34
+#: src/system/keychain.md:25 src/system/notifications.md:62
+#: src/system/audio.md:61 src/system/media.md:86 src/system/other.md:20
+#: src/system/other.md:37 src/plugins/native-extensions.md:275
+#: src/plugins/appstore-review.md:89 src/testing/geisterhand.md:259
+#: src/testing/geisterhand.md:331
+msgid "macOS"
+msgstr ""
+
+#: src/SUMMARY.md:52 src/ui/overview.md:170 src/ui/canvas.md:75
+#: src/ui/menus.md:112 src/ui/dialogs.md:108 src/ui/animation.md:65
+#: src/platforms/overview.md:10 src/platforms/overview.md:67
+#: src/platforms/ios.md:1 src/platforms/tvos.md:170 src/i18n/overview.md:90
+#: src/system/preferences.md:35 src/system/keychain.md:26
+#: src/system/notifications.md:63 src/system/audio.md:62
+#: src/system/media.md:87 src/system/other.md:21 src/system/other.md:38
+#: src/widgets/platforms.md:11 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:39 src/widgets/platforms.md:63
+#: src/plugins/native-extensions.md:273 src/plugins/appstore-review.md:73
+#: src/testing/geisterhand.md:260
+msgid "iOS"
+msgstr ""
+
+#: src/SUMMARY.md:53 src/platforms/overview.md:11 src/platforms/overview.md:67
+#: src/platforms/visionos.md:1 src/system/media.md:89
+msgid "visionOS"
+msgstr ""
+
+#: src/SUMMARY.md:54 src/platforms/overview.md:12 src/platforms/overview.md:67
+#: src/platforms/tvos.md:1 src/platforms/tvos.md:170 src/system/media.md:88
+msgid "tvOS"
+msgstr ""
+
+#: src/SUMMARY.md:55 src/platforms/overview.md:13 src/platforms/overview.md:67
+#: src/platforms/watchos.md:1 src/system/media.md:93
+#: src/widgets/platforms.md:14 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:49 src/widgets/platforms.md:79
+msgid "watchOS"
+msgstr ""
+
+#: src/SUMMARY.md:56 src/ui/canvas.md:78 src/ui/animation.md:66
+#: src/platforms/overview.md:14 src/platforms/overview.md:67
+#: src/platforms/android.md:1 src/i18n/overview.md:91 src/i18n/overview.md:104
+#: src/system/preferences.md:36 src/system/keychain.md:27
+#: src/system/notifications.md:64 src/system/audio.md:63
+#: src/system/media.md:90 src/system/other.md:22 src/system/other.md:39
+#: src/widgets/platforms.md:13 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:44 src/widgets/platforms.md:71
+#: src/plugins/native-extensions.md:276 src/plugins/appstore-review.md:102
+#: src/testing/geisterhand.md:261 src/cli/flags.md:27
+#: src/cli/perry-toml.md:501
+msgid "Android"
+msgstr ""
+
+#: src/SUMMARY.md:57 src/platforms/harmonyos.md:1
+msgid "HarmonyOS NEXT"
+msgstr "HarmonyOS NEXT"
+
+#: src/SUMMARY.md:58 src/getting-started/installation.md:121
+#: src/ui/overview.md:170 src/ui/styling.md:372 src/ui/canvas.md:77
+#: src/ui/menus.md:113 src/ui/dialogs.md:108 src/ui/animation.md:67
+#: src/ui/multi-window.md:73 src/ui/multi-window.md:90
+#: src/ui/multi-window.md:101 src/ui/multi-window.md:117
+#: src/ui/multi-window.md:133 src/ui/multi-window.md:141
+#: src/platforms/overview.md:15 src/platforms/overview.md:67
+#: src/platforms/windows.md:1 src/i18n/overview.md:92
+#: src/updater/overview.md:258 src/system/preferences.md:37
+#: src/system/keychain.md:28 src/system/notifications.md:65
+#: src/system/audio.md:65 src/system/media.md:92 src/system/other.md:23
+#: src/system/other.md:40 src/testing/geisterhand.md:263
+#: src/testing/geisterhand.md:392 src/cli/flags.md:36
+msgid "Windows"
+msgstr ""
+
+#: src/SUMMARY.md:59 src/platforms/windows-7.md:1
+msgid "Windows 7 Compatibility"
+msgstr "Windows 7 兼容性"
+
+#: src/SUMMARY.md:60 src/platforms/linux.md:1 src/testing/geisterhand.md:262
+#: src/testing/geisterhand.md:379
+msgid "Linux (GTK4)"
+msgstr ""
+
+#: src/SUMMARY.md:61 src/ui/overview.md:170 src/ui/canvas.md:72
+#: src/ui/menus.md:115 src/ui/dialogs.md:108 src/ui/animation.md:69
+#: src/ui/multi-window.md:143 src/platforms/web.md:1
+#: src/system/preferences.md:39 src/system/keychain.md:30
+#: src/system/notifications.md:67 src/system/audio.md:66
+#: src/system/media.md:95 src/system/other.md:25 src/system/other.md:42
+#: src/cli/flags.md:35
+msgid "Web"
+msgstr ""
+
+#: src/SUMMARY.md:62 src/cli/flags.md:34
+msgid "WebAssembly"
+msgstr "WebAssembly"
+
+#: src/SUMMARY.md:64
+msgid "Standard Library"
+msgstr "标准库"
+
+#: src/SUMMARY.md:67 src/stdlib/fs.md:1
+msgid "File System"
+msgstr "文件系统"
+
+#: src/SUMMARY.md:68 src/stdlib/http.md:1
+msgid "HTTP & Networking"
+msgstr "HTTP 与网络"
+
+#: src/SUMMARY.md:69 src/stdlib/overview.md:22 src/stdlib/database.md:1
+msgid "Databases"
+msgstr "数据库"
+
+#: src/SUMMARY.md:70 src/stdlib/overview.md:29 src/stdlib/crypto.md:1
+msgid "Cryptography"
+msgstr "加密"
+
+#: src/SUMMARY.md:71 src/stdlib/overview.md:36 src/stdlib/utilities.md:1
+#: src/cli/perry-toml.md:231
+msgid "Utilities"
+msgstr "工具"
+
+#: src/SUMMARY.md:72 src/stdlib/other.md:1
+msgid "Other Modules"
+msgstr "其他模块"
+
+#: src/SUMMARY.md:74
+msgid "Internationalization"
+msgstr "国际化"
+
+#: src/SUMMARY.md:77 src/i18n/interpolation.md:1
+msgid "Interpolation & Plurals"
+msgstr "插值与复数"
+
+#: src/SUMMARY.md:78
+msgid "Formatting"
+msgstr "格式化"
+
+#: src/SUMMARY.md:79
+msgid "CLI Tools"
+msgstr "CLI 工具"
+
+#: src/SUMMARY.md:81 src/updater/overview.md:1
+msgid "Auto-Update"
+msgstr "自动更新"
+
+#: src/SUMMARY.md:85 src/platforms/overview.md:74 src/platforms/macos.md:75
+msgid "System APIs"
+msgstr "系统 API"
+
+#: src/SUMMARY.md:88 src/system/preferences.md:1
+msgid "Preferences"
+msgstr "偏好设置"
+
+#: src/SUMMARY.md:89 src/system/keychain.md:1
+msgid "Keychain"
+msgstr "钥匙串"
+
+#: src/SUMMARY.md:90 src/system/notifications.md:1
+msgid "Notifications"
+msgstr "通知"
+
+#: src/SUMMARY.md:91 src/system/audio.md:1
+msgid "Audio Capture"
+msgstr "音频捕获"
+
+#: src/SUMMARY.md:92 src/system/media.md:1
+msgid "Media Playback"
+msgstr "媒体播放"
+
+#: src/SUMMARY.md:93 src/ui/menus.md:68 src/stdlib/overview.md:50
+msgid "Other"
+msgstr "其他"
+
+#: src/SUMMARY.md:98 src/widgets/creating-widgets.md:1
+msgid "Creating Widgets"
+msgstr "创建控件"
+
+#: src/SUMMARY.md:99
+msgid "Components & Modifiers"
+msgstr "组件与修饰符"
+
+#: src/SUMMARY.md:100 src/platforms/visionos.md:35 src/platforms/tvos.md:123
+#: src/platforms/watchos.md:149 src/widgets/watchos.md:77
+#: src/plugins/creating-plugins.md:98 src/plugins/hooks-and-events.md:115
+msgid "Configuration"
+msgstr "配置"
+
+#: src/SUMMARY.md:101
+msgid "Data Fetching"
+msgstr "数据获取"
+
+#: src/SUMMARY.md:102 src/widgets/platforms.md:1
+msgid "Cross-Platform Reference"
+msgstr "跨平台参考"
+
+#: src/SUMMARY.md:103 src/widgets/watchos.md:1
+msgid "watchOS Complications"
+msgstr "watchOS 复杂功能"
+
+#: src/SUMMARY.md:104 src/widgets/wearos.md:1
+msgid "Wear OS Tiles"
+msgstr "Wear OS 卡片"
+
+#: src/SUMMARY.md:106
+msgid "Plugins"
+msgstr "插件"
+
+#: src/SUMMARY.md:109 src/plugins/creating-plugins.md:1
+msgid "Creating Plugins"
+msgstr "创建插件"
+
+#: src/SUMMARY.md:110 src/plugins/hooks-and-events.md:1
+msgid "Hooks & Events"
+msgstr "钩子与事件"
+
+#: src/SUMMARY.md:111 src/plugins/overview.md:90
+#: src/plugins/native-extensions.md:1
+msgid "Native Extensions"
+msgstr "原生扩展"
+
+#: src/SUMMARY.md:112 src/plugins/appstore-review.md:1
+msgid "App Store Review"
+msgstr "App Store 审核"
+
+#: src/SUMMARY.md:114
+msgid "Testing"
+msgstr "测试"
+
+#: src/SUMMARY.md:116
+msgid "Geisterhand (UI Fuzzer)"
+msgstr "Geisterhand(UI 模糊测试)"
+
+#: src/SUMMARY.md:118
+msgid "CLI Reference"
+msgstr "CLI 参考"
+
+#: src/SUMMARY.md:120
+msgid "Commands"
+msgstr "命令"
+
+#: src/SUMMARY.md:121 src/cli/flags.md:1
+msgid "Compiler Flags"
+msgstr "编译器标志"
+
+#: src/SUMMARY.md:122 src/cli/perry-toml.md:1
+msgid "perry.toml Reference"
+msgstr "perry.toml 参考"
+
+#: src/SUMMARY.md:126
+msgid "Contributing"
+msgstr "贡献"
+
+#: src/SUMMARY.md:128 src/platforms/harmonyos.md:5
+#: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
+msgid "Architecture"
+msgstr "架构"
+
+#: src/SUMMARY.md:129 src/contributing/building.md:1
+msgid "Building from Source"
+msgstr "从源码构建"
+
+#: src/introduction.md:3
+msgid ""
+"Perry is a native TypeScript compiler that compiles TypeScript source code "
+"directly to native executables. No JavaScript runtime, no JIT warmup, no V8 "
+"— your TypeScript compiles to a real binary."
+msgstr ""
+"Perry 是一个原生 TypeScript 编译器,可将 TypeScript 源代码直接编译为原生可执行文件。无需 JavaScript "
+"运行时、无需 JIT 预热、无需 V8 — 您的 TypeScript 将编译成真正的二进制文件。"
+
+#: src/introduction.md:5
+msgid ""
+"```typescript\n"
+"// demonstrates: the one-liner hello shown on the docs landing page\n"
+"// docs: docs/src/introduction.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"console.log(\"Hello from Perry!\")\n"
+"```"
+msgstr ""
+
+#: src/introduction.md:20
+msgid "Why Perry?"
+msgstr "为什么选择 Perry?"
+
+#: src/introduction.md:22
+msgid ""
+"**Native performance** — Compiles to machine code via LLVM. Integer-heavy "
+"code like Fibonacci runs 2x faster than Node.js."
+msgstr "**原生性能** — 通过 LLVM 编译为机器码。像斐波那契这种整数密集型代码运行速度是 Node.js 的 2 倍。"
+
+#: src/introduction.md:23
+msgid ""
+"**Real multi-threading** — `parallelMap` and `spawn` give you actual OS "
+"threads with compile-time safety. No isolates, no message passing overhead. "
+"[Something no JS runtime can do](threading/overview.md)."
+msgstr ""
+"**真正的多线程** — `parallelMap` 和 `spawn` 在保证编译期安全的同时提供真实的操作系统线程。无 "
+"isolate,无消息传递开销。[其他 JS 运行时做不到的事](threading/overview.md)。"
+
+#: src/introduction.md:24
+msgid ""
+"**Small binaries** — A hello world is ~300KB. Perry detects what runtime "
+"features you use and only links what's needed."
+msgstr "**小巧的二进制文件** — Hello World 仅约 300KB。Perry 会检测您使用了哪些运行时功能,只链接需要的部分。"
+
+#: src/introduction.md:25
+msgid ""
+"**Native UI** — Build desktop and mobile apps with declarative TypeScript "
+"that compiles to real AppKit, UIKit, GTK4, Win32, or DOM widgets."
+msgstr ""
+"**原生 UI** — 用声明式 TypeScript 构建桌面和移动应用,编译为真正的 AppKit、UIKit、GTK4、Win32 或 DOM "
+"控件。"
+
+#: src/introduction.md:26
+msgid ""
+"**7 targets** — macOS, iOS, Android, Windows, Linux, Web, and WebAssembly "
+"from the same source code."
+msgstr ""
+"**7 个目标平台** — 相同源代码可输出至 macOS、iOS、Android、Windows、Linux、Web 和 WebAssembly。"
+
+#: src/introduction.md:27
+msgid ""
+"**Familiar ecosystem** — Use npm packages like `fastify`, `mysql2`, `redis`,"
+" `bcrypt`, `lodash`, and more — compiled natively."
+msgstr ""
+"**熟悉的生态** — 原生编译使用 `fastify`、`mysql2`、`redis`、`bcrypt`、`lodash` 等 npm 包。"
+
+#: src/introduction.md:28
+msgid ""
+"**Zero config** — Point Perry at a `.ts` file and get a binary. No "
+"`tsconfig.json` required."
+msgstr "**零配置** — 把 `.ts` 文件交给 Perry 即可获得二进制文件。无需 `tsconfig.json`。"
+
+#: src/introduction.md:30
+msgid "What Perry Compiles"
+msgstr "Perry 能编译什么"
+
+#: src/introduction.md:32
+msgid "Perry supports a practical subset of TypeScript:"
+msgstr "Perry 支持 TypeScript 的一个实用子集:"
+
+#: src/introduction.md:34
+msgid "Variables, functions, classes, enums, interfaces"
+msgstr "变量、函数、类、枚举、接口"
+
+#: src/introduction.md:35
+msgid "Async/await, closures, generators"
+msgstr "Async/await、闭包、生成器"
+
+#: src/introduction.md:36
+msgid "Destructuring, spread, template literals"
+msgstr "解构、展开、模板字面量"
+
+#: src/introduction.md:37
+msgid "Arrays, Maps, Sets, typed arrays"
+msgstr "数组、Map、Set、类型化数组"
+
+#: src/introduction.md:38
+msgid "Regular expressions, JSON, Promises"
+msgstr "正则表达式、JSON、Promise"
+
+#: src/introduction.md:39
+msgid "Module imports/exports"
+msgstr "模块导入/导出"
+
+#: src/introduction.md:40
+msgid "Generic type erasure"
+msgstr "泛型类型擦除"
+
+#: src/introduction.md:42
+msgid ""
+"See [Supported Features](language/supported-features.md) for the complete "
+"list."
+msgstr "完整列表请参见[支持的功能](language/supported-features.md)。"
+
+#: src/introduction.md:44
+msgid "Quick Example: Native App"
+msgstr "快速示例：原生应用"
+
+#: src/introduction.md:46 src/getting-started/first-app.md:10
+msgid ""
+"```typescript\n"
+"// demonstrates: minimal stateful UI — label + increment button\n"
+"// docs: docs/src/ui/state.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, visionos-simulator, tvos-simulator, watchos-simulator, android, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Button, State } from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"App({\n"
+"    title: \"Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Count: ${count.value}`),\n"
+"        Button(\"Increment\", () => count.set(count.value + 1)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/introduction.md:69
+msgid "# Opens a native macOS/Windows/Linux window\n"
+msgstr ""
+
+#: src/introduction.md:72
+msgid ""
+"This produces a ~3MB native app with real platform widgets — no Electron, no"
+" WebView."
+msgstr "这会生成一个约 3MB 的原生应用,使用真正的平台控件 — 无 Electron,无 WebView。"
+
+#: src/introduction.md:74 src/getting-started/first-app.md:41
+#: src/threading/overview.md:286 src/threading/parallel-map.md:18
+#: src/threading/parallel-filter.md:18 src/platforms/watchos.md:127
+#: src/platforms/wasm.md:29 src/stdlib/overview.md:5 src/i18n/overview.md:78
+#: src/widgets/overview.md:34 src/plugins/overview.md:7
+msgid "How It Works"
+msgstr "工作原理"
+
+#: src/introduction.md:87
+msgid ""
+"Perry uses [SWC](https://swc.rs/) for TypeScript parsing and "
+"[LLVM](https://llvm.org/) for native code generation. Types are erased at "
+"compile time (like `tsc`), and values are represented at runtime using NaN-"
+"boxing for efficient 64-bit tagged values."
+msgstr ""
+"Perry 使用 [SWC](https://swc.rs/) 解析 TypeScript,使用 [LLVM](https://llvm.org/) "
+"生成原生代码。类型在编译时被擦除(类似 `tsc`),运行时使用 NaN 装箱将值表示为高效的 64 位标记值。"
+
+#: src/introduction.md:89 src/getting-started/hello-world.md:152
+#: src/getting-started/first-app.md:184
+#: src/getting-started/project-config.md:201
+#: src/language/supported-features.md:600 src/language/type-system.md:149
+#: src/language/limitations.md:182 src/threading/overview.md:312
+#: src/ui/overview.md:179 src/ui/widgets.md:396 src/ui/layout.md:367
+#: src/ui/styling.md:377 src/ui/state.md:225 src/ui/events.md:167
+#: src/ui/canvas.md:80 src/ui/menus.md:119 src/ui/dialogs.md:166
+#: src/ui/table.md:107 src/ui/animation.md:71 src/ui/multi-window.md:149
+#: src/ui/theming.md:166 src/ui/camera.md:143 src/platforms/overview.md:78
+#: src/platforms/macos.md:86 src/platforms/ios.md:137
+#: src/platforms/tvos.md:180 src/platforms/watchos.md:213
+#: src/platforms/android.md:92 src/platforms/windows.md:69
+#: src/platforms/linux.md:81 src/platforms/web.md:21 src/platforms/wasm.md:191
+#: src/stdlib/overview.md:100 src/stdlib/fs.md:88 src/stdlib/http.md:93
+#: src/stdlib/database.md:107 src/stdlib/crypto.md:87
+#: src/stdlib/utilities.md:104 src/stdlib/other.md:184
+#: src/i18n/overview.md:107 src/updater/overview.md:433
+#: src/system/overview.md:71 src/system/preferences.md:44
+#: src/system/keychain.md:35 src/system/notifications.md:72
+#: src/system/audio.md:71 src/system/other.md:68 src/widgets/overview.md:60
+#: src/widgets/creating-widgets.md:249 src/widgets/components.md:270
+#: src/widgets/configuration.md:139 src/widgets/data-fetching.md:203
+#: src/plugins/overview.md:96 src/plugins/creating-plugins.md:111
+#: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:297
+#: src/plugins/appstore-review.md:192 src/cli/commands.md:320
+#: src/cli/flags.md:176 src/contributing/architecture.md:97
+#: src/contributing/building.md:86
+msgid "Next Steps"
+msgstr "后续步骤"
+
+#: src/introduction.md:91
+msgid "[Install Perry](getting-started/installation.md)"
+msgstr "[安装 Perry](getting-started/installation.md)"
+
+#: src/introduction.md:92
+msgid "[Write your first program](getting-started/hello-world.md)"
+msgstr "[编写您的第一个程序](getting-started/hello-world.md)"
+
+#: src/introduction.md:93
+msgid "[Build a native app](getting-started/first-app.md)"
+msgstr "[构建原生应用](getting-started/first-app.md)"
+
+#: src/getting-started/installation.md:3 src/platforms/visionos.md:7
+#: src/contributing/building.md:3
+msgid "Prerequisites"
+msgstr "前置条件"
+
+#: src/getting-started/installation.md:5
+msgid ""
+"Perry compiles TypeScript to native binaries by linking with your system's C"
+" toolchain, so every install path needs a linker:"
+msgstr ""
+
+#: src/getting-started/installation.md:7
+msgid "**macOS**: Xcode Command Line Tools (`xcode-select --install`)"
+msgstr ""
+
+#: src/getting-started/installation.md:8
+msgid ""
+"**Linux**: `gcc` or `clang` (`apt install build-essential` on Debian/Ubuntu,"
+" `apk add build-base` on Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:9
+msgid ""
+"**Windows**: LLVM (`winget install LLVM.LLVM`) + `perry setup windows` "
+"(lightweight, ~1.5 GB, no Visual Studio needed), or MSVC Build Tools with "
+"the \"Desktop development with C++\" workload — see the [Windows platform "
+"guide](../platforms/windows.md) for both options"
+msgstr ""
+
+#: src/getting-started/installation.md:11
+msgid ""
+"The source install additionally needs the **Rust toolchain** via "
+"[rustup](https://rustup.rs/)."
+msgstr ""
+
+#: src/getting-started/installation.md:13
+msgid "Install Perry"
+msgstr "安装 Perry"
+
+#: src/getting-started/installation.md:15
+msgid "npm / npx (recommended — any platform)"
+msgstr ""
+
+#: src/getting-started/installation.md:17
+msgid ""
+"Perry ships as a prebuilt-binary npm package. This is the fastest way to get"
+" started and the only path that covers all seven supported platforms (macOS "
+"arm64/x64, Linux x64/arm64 glibc + musl, Windows x64) with a single command:"
+msgstr ""
+
+#: src/getting-started/installation.md:20
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
+msgstr ""
+
+#: src/getting-started/installation.md:23
+msgid "# Global\n"
+msgstr ""
+
+#: src/getting-started/installation.md:27
+msgid "# Zero-install, one-shot\n"
+msgstr ""
+
+#: src/getting-started/installation.md:32
+msgid ""
+"[`@perryts/perry`](https://www.npmjs.com/package/@perryts/perry) is a thin "
+"launcher; npm automatically picks the matching prebuilt via "
+"`optionalDependencies` (`@perryts/perry-darwin-arm64`, `@perryts/perry-"
+"linux-x64-musl`, etc.) based on your `os` / `cpu` / `libc`. Requires Node.js"
+" ≥ 16."
+msgstr ""
+
+#: src/getting-started/installation.md:34 src/ui/styling.md:368
+#: src/ui/canvas.md:70 src/ui/menus.md:109 src/ui/animation.md:62
+#: src/ui/multi-window.md:70 src/ui/multi-window.md:87
+#: src/ui/multi-window.md:98 src/ui/multi-window.md:114
+#: src/ui/multi-window.md:130 src/ui/multi-window.md:138
+#: src/platforms/overview.md:7 src/i18n/overview.md:87
+#: src/i18n/overview.md:101 src/updater/overview.md:255
+#: src/system/preferences.md:32 src/system/keychain.md:23
+#: src/system/notifications.md:60 src/system/audio.md:59
+#: src/system/media.md:84 src/system/other.md:18 src/system/other.md:35
+#: src/widgets/platforms.md:9 src/plugins/native-extensions.md:271
+#: src/testing/geisterhand.md:257 src/cli/flags.md:20
+msgid "Platform"
+msgstr ""
+
+#: src/getting-started/installation.md:34
+msgid "Prebuilt package"
+msgstr ""
+
+#: src/getting-started/installation.md:36
+msgid "macOS arm64 (Apple Silicon)"
+msgstr ""
+
+#: src/getting-started/installation.md:36
+msgid "`@perryts/perry-darwin-arm64`"
+msgstr ""
+
+#: src/getting-started/installation.md:37
+msgid "macOS x64 (Intel)"
+msgstr ""
+
+#: src/getting-started/installation.md:37
+msgid "`@perryts/perry-darwin-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:38
+msgid "Linux x64 (glibc)"
+msgstr ""
+
+#: src/getting-started/installation.md:38
+msgid "`@perryts/perry-linux-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:39
+msgid "Linux arm64 (glibc)"
+msgstr ""
+
+#: src/getting-started/installation.md:39
+msgid "`@perryts/perry-linux-arm64`"
+msgstr ""
+
+#: src/getting-started/installation.md:40
+msgid "Linux x64 (musl / Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:40
+msgid "`@perryts/perry-linux-x64-musl`"
+msgstr ""
+
+#: src/getting-started/installation.md:41
+msgid "Linux arm64 (musl / Alpine)"
+msgstr ""
+
+#: src/getting-started/installation.md:41
+msgid "`@perryts/perry-linux-arm64-musl`"
+msgstr ""
+
+#: src/getting-started/installation.md:42
+msgid "Windows x64"
+msgstr ""
+
+#: src/getting-started/installation.md:42
+msgid "`@perryts/perry-win32-x64`"
+msgstr ""
+
+#: src/getting-started/installation.md:44
+msgid "Homebrew (macOS)"
+msgstr ""
+
+#: src/getting-started/installation.md:50
+msgid "winget (Windows)"
+msgstr ""
+
+#: src/getting-started/installation.md:56
+msgid "APT (Debian / Ubuntu)"
+msgstr ""
+
+#: src/getting-started/installation.md:60
+msgid ""
+"\"deb [signed-by=/usr/share/keyrings/perry.gpg] "
+"https://perryts.github.io/perry-apt stable main\""
+msgstr ""
+
+#: src/getting-started/installation.md:64
+msgid "From Source"
+msgstr ""
+
+#: src/getting-started/installation.md:72
+msgid "The binary is at `target/release/perry`. Add it to your PATH:"
+msgstr ""
+
+#: src/getting-started/installation.md:75
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
+msgstr ""
+
+#: src/getting-started/installation.md:76
+msgid "\"/path/to/perry/target/release:$PATH\""
+msgstr ""
+
+#: src/getting-started/installation.md:79
+msgid "Self-Update"
+msgstr ""
+
+#: src/getting-started/installation.md:81
+msgid "Once installed, Perry can update itself:"
+msgstr ""
+
+#: src/getting-started/installation.md:87
+msgid "This downloads the latest release and atomically replaces the binary."
+msgstr ""
+
+#: src/getting-started/installation.md:89
+msgid "Verify Installation"
+msgstr ""
+
+#: src/getting-started/installation.md:95
+msgid ""
+"This checks your installation, shows the current version, and reports if an "
+"update is available."
+msgstr ""
+
+#: src/getting-started/installation.md:101
+msgid "Platform-Specific Setup"
+msgstr ""
+
+#: src/getting-started/installation.md:105
+msgid ""
+"No additional setup needed. Perry uses the system `cc` linker and AppKit for"
+" UI apps."
+msgstr ""
+
+#: src/getting-started/installation.md:107
+msgid ""
+"For iOS development, install Xcode (not just Command Line Tools) for the iOS"
+" SDK and simulator."
+msgstr ""
+
+#: src/getting-started/installation.md:109 src/ui/overview.md:170
+#: src/ui/canvas.md:76 src/ui/menus.md:114 src/ui/dialogs.md:108
+#: src/ui/animation.md:68 src/ui/multi-window.md:74 src/ui/multi-window.md:91
+#: src/ui/multi-window.md:102 src/ui/multi-window.md:118
+#: src/ui/multi-window.md:134 src/ui/multi-window.md:142
+#: src/platforms/overview.md:16 src/platforms/overview.md:67
+#: src/i18n/overview.md:93 src/updater/overview.md:259
+#: src/system/preferences.md:38 src/system/keychain.md:29
+#: src/system/notifications.md:66 src/system/audio.md:64
+#: src/system/other.md:24 src/system/other.md:41 src/cli/flags.md:37
+msgid "Linux"
+msgstr ""
+
+#: src/getting-started/installation.md:111
+msgid "Install GTK4 development libraries for UI apps:"
+msgstr ""
+
+#: src/getting-started/installation.md:114 src/platforms/linux.md:9
+#: src/testing/geisterhand.md:384
+msgid "# Ubuntu/Debian\n"
+msgstr ""
+
+#: src/getting-started/installation.md:116 src/platforms/linux.md:12
+msgid "# Fedora\n"
+msgstr ""
+
+#: src/getting-started/installation.md:123
+msgid "Two toolchain options — pick one. Both produce identical binaries."
+msgstr ""
+
+#: src/getting-started/installation.md:125
+msgid "**Lightweight (recommended, ~1.5 GB, no Visual Studio):**"
+msgstr ""
+
+#: src/getting-started/installation.md:132
+msgid ""
+"`perry setup windows` downloads the Microsoft CRT + Windows SDK libraries "
+"via xwin after prompting for license acceptance. Pass `--accept-license` to "
+"skip the prompt in CI."
+msgstr ""
+
+#: src/getting-started/installation.md:134
+msgid "**MSVC Build Tools (~8 GB):**"
+msgstr ""
+
+#: src/getting-started/installation.md:136
+msgid ""
+"Install Visual Studio Build Tools with the \"Desktop development with C++\" "
+"workload — via the Visual Studio Installer, or:"
+msgstr ""
+
+#: src/getting-started/installation.md:138 src/platforms/windows.md:25
+msgid ""
+"```powershell\n"
+"winget install Microsoft.VisualStudio.2022.BuildTools --override `\n"
+"  \"--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended\"\n"
+"```"
+msgstr ""
+
+#: src/getting-started/installation.md:143
+msgid ""
+"Run `perry doctor` to verify the toolchain. See the [Windows platform "
+"guide](../platforms/windows.md) for details."
+msgstr ""
+
+#: src/getting-started/installation.md:145
+msgid "What's Next"
+msgstr ""
+
+#: src/getting-started/installation.md:147
+msgid "[Write your first program](hello-world.md)"
+msgstr ""
+
+#: src/getting-started/installation.md:148
+msgid "[Build a native app](first-app.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:3
+msgid "Your First Program"
+msgstr "您的第一个程序"
+
+#: src/getting-started/hello-world.md:5
+msgid "Create a file called `hello.ts`:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:7
+msgid ""
+"```typescript\n"
+"// demonstrates: the minimal Perry program in the docs\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"console.log(\"Hello, Perry!\")\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:16
+msgid "Compile and run it:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:23 src/threading/spawn.md:46
+#: src/widgets/wearos.md:64
+msgid "Output:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:29
+msgid ""
+"That's it. Perry compiled your TypeScript to a native executable — no "
+"Node.js, no bundler, no runtime."
+msgstr ""
+
+#: src/getting-started/hello-world.md:31
+msgid "A Slightly Bigger Example"
+msgstr "稍大一些的示例"
+
+#: src/getting-started/hello-world.md:33
+msgid ""
+"```typescript\n"
+"// demonstrates: recursive fib as a perf-vs-node talking point\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: wasm, web, android\n"
+"\n"
+"function fibonacci(n: number): number {\n"
+"    if (n <= 1) return n\n"
+"    return fibonacci(n - 1) + fibonacci(n - 2)\n"
+"}\n"
+"\n"
+"const start = Date.now()\n"
+"const result = fibonacci(35)\n"
+"const elapsed = Date.now() - start\n"
+"\n"
+"console.log(`fibonacci(35) = ${result}`)\n"
+"console.log(`Completed in ${elapsed}ms`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:57
+msgid ""
+"This runs about 2x faster than Node.js because Perry compiles to native "
+"machine code with integer specialization."
+msgstr ""
+
+#: src/getting-started/hello-world.md:59
+msgid "Using Variables and Functions"
+msgstr "使用变量和函数"
+
+#: src/getting-started/hello-world.md:61
+msgid ""
+"```typescript\n"
+"const name: string = \"World\"\n"
+"const items: number[] = [1, 2, 3, 4, 5]\n"
+"\n"
+"const doubled = items.map((x) => x * 2)\n"
+"const sum = doubled.reduce((acc, x) => acc + x, 0)\n"
+"\n"
+"console.log(`Hello, ${name}!`)\n"
+"console.log(`Sum of doubled: ${sum}`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:72
+msgid "Async Code"
+msgstr "异步代码"
+
+#: src/getting-started/hello-world.md:74
+msgid ""
+"```typescript\n"
+"// demonstrates: async/await fetch shown in hello-world.md\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"// run: false\n"
+"\n"
+"async function fetchData(): Promise<string> {\n"
+"    const response = await fetch(\"https://httpbin.org/get\")\n"
+"    const data = await response.json() as { origin: string }\n"
+"    return data.origin\n"
+"}\n"
+"\n"
+"const ip = await fetchData()\n"
+"console.log(`Your IP: ${ip}`)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:95
+msgid "Perry compiles async/await to a native async runtime backed by Tokio."
+msgstr ""
+
+#: src/getting-started/hello-world.md:99
+msgid ""
+"Perry can do something no JavaScript runtime can — run your code on multiple"
+" CPU cores:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:101
+msgid ""
+"```typescript\n"
+"// demonstrates: parallelMap + spawn shown in hello-world.md\n"
+"// docs: docs/src/getting-started/hello-world.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"import { parallelMap, parallelFilter, spawn } from \"perry/thread\"\n"
+"\n"
+"const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"// Process all elements across all CPU cores\n"
+"const doubled = parallelMap(data, (x: number) => x * 2)\n"
+"console.log(doubled) // [2, 4, 6, 8, 10, 12, 14, 16]\n"
+"\n"
+"// Run heavy work in the background\n"
+"const result = await spawn(() => {\n"
+"    let sum = 0\n"
+"    for (let i = 0; i < 100_000_000; i++) sum += i\n"
+"    return sum\n"
+"})\n"
+"console.log(result)\n"
+"\n"
+"// parallelFilter is also available for the lift-and-parallelize case:\n"
+"const evens = parallelFilter(data, (x: number) => x % 2 === 0)\n"
+"console.log(evens)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/hello-world.md:127
+msgid ""
+"This is real OS-level parallelism, not web workers or separate isolates. See"
+" [Multi-Threading](../threading/overview.md) for details."
+msgstr ""
+
+#: src/getting-started/hello-world.md:129
+msgid "What the Compiler Produces"
+msgstr "编译器生成什么"
+
+#: src/getting-started/hello-world.md:131
+msgid "When you run `perry file.ts -o output`, Perry:"
+msgstr ""
+
+#: src/getting-started/hello-world.md:133
+msgid "Parses your TypeScript with SWC"
+msgstr ""
+
+#: src/getting-started/hello-world.md:134
+msgid "Lowers the AST to an intermediate representation (HIR)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:135
+msgid "Applies optimizations (inlining, closure conversion, etc.)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:136
+msgid "Generates native machine code with LLVM"
+msgstr ""
+
+#: src/getting-started/hello-world.md:137
+msgid "Links with your system's C compiler"
+msgstr ""
+
+#: src/getting-started/hello-world.md:139
+msgid "The result is a standalone executable with no external dependencies."
+msgstr ""
+
+#: src/getting-started/hello-world.md:141
+#: src/getting-started/hello-world.md:143 src/stdlib/overview.md:66
+#: src/stdlib/overview.md:70
+msgid "Binary Size"
+msgstr "二进制大小"
+
+#: src/getting-started/hello-world.md:143
+msgid "Program"
+msgstr ""
+
+#: src/getting-started/hello-world.md:145
+msgid "Hello world"
+msgstr ""
+
+#: src/getting-started/hello-world.md:145 src/stdlib/overview.md:72
+msgid "~300KB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:146
+msgid "CLI with fs/path"
+msgstr ""
+
+#: src/getting-started/hello-world.md:146
+#: src/getting-started/hello-world.md:147 src/stdlib/overview.md:73
+msgid "~3MB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:147
+msgid "UI app"
+msgstr ""
+
+#: src/getting-started/hello-world.md:148
+msgid "Full app with stdlib"
+msgstr ""
+
+#: src/getting-started/hello-world.md:148 src/stdlib/overview.md:74
+msgid "~48MB"
+msgstr ""
+
+#: src/getting-started/hello-world.md:150
+msgid ""
+"Perry automatically detects which runtime features you use and only links "
+"what's needed."
+msgstr ""
+
+#: src/getting-started/hello-world.md:154
+msgid "[Build a native UI app](first-app.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:155
+msgid "[Configure your project](project-config.md)"
+msgstr ""
+
+#: src/getting-started/hello-world.md:156
+msgid ""
+"[Explore supported TypeScript features](../language/supported-features.md)"
+msgstr ""
+
+#: src/getting-started/first-app.md:3
+msgid ""
+"Perry compiles declarative TypeScript UI code to native platform widgets. No"
+" Electron, no WebView — real AppKit on macOS, UIKit on iOS, GTK4 on Linux, "
+"Win32 on Windows. Every example on this page is a real source file under "
+"`docs/examples/` that CI compiles and runs on every PR."
+msgstr ""
+
+#: src/getting-started/first-app.md:8
+msgid "A Simple Counter"
+msgstr "简单计数器"
+
+#: src/getting-started/first-app.md:31
+msgid "Compile and run:"
+msgstr ""
+
+#: src/getting-started/first-app.md:38
+msgid ""
+"A native window opens with a label and two buttons. Clicking \"Increment\" "
+"updates the count in real-time."
+msgstr ""
+
+#: src/getting-started/first-app.md:43
+msgid ""
+"**`App({ title, width, height, body })`** — Creates a native application "
+"window. `body` is the root widget."
+msgstr ""
+
+#: src/getting-started/first-app.md:44
+msgid ""
+"**`State(initialValue)`** — Creates reactive state. `.value` reads, "
+"`.set(v)` writes and triggers UI updates."
+msgstr ""
+
+#: src/getting-started/first-app.md:45
+msgid ""
+"**`VStack(spacing, [...])`** — Vertical stack layout (like SwiftUI's VStack "
+"or CSS flexbox column). The first arg is the gap in points between children."
+msgstr ""
+
+#: src/getting-started/first-app.md:46
+msgid ""
+"**`Text(string)`** — A text label. Template literals referencing "
+"`${state.value}` bind reactively."
+msgstr ""
+
+#: src/getting-started/first-app.md:47
+msgid "**`Button(label, onClick)`** — A native button with a click handler."
+msgstr ""
+
+#: src/getting-started/first-app.md:49
+msgid "A Todo App"
+msgstr "一个待办应用"
+
+#: src/getting-started/first-app.md:51 src/ui/state.md:160
+msgid ""
+"```typescript\n"
+"// demonstrates: complete reactive todo app combining State, ForEach, and widget tree mutation\n"
+"// docs: docs/src/ui/state.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    TextField,\n"
+"    VStack,\n"
+"    HStack,\n"
+"    State,\n"
+"    ForEach,\n"
+"    Spacer,\n"
+"    Divider,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const todos = State<string[]>([])\n"
+"const count = State(0)\n"
+"const input = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"Todo App\",\n"
+"    width: 480,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        Text(\"My Todos\"),\n"
+"\n"
+"        HStack(8, [\n"
+"            TextField(\"What needs to be done?\", (value: string) => input.set(value)),\n"
+"            Button(\"Add\", () => {\n"
+"                const text = input.value\n"
+"                if (text.length > 0) {\n"
+"                    todos.set([...todos.value, text])\n"
+"                    count.set(count.value + 1)\n"
+"                    input.set(\"\")\n"
+"                }\n"
+"            }),\n"
+"        ]),\n"
+"\n"
+"        Divider(),\n"
+"\n"
+"        ForEach(count, (i: number) =>\n"
+"            HStack(8, [\n"
+"                Text(todos.value[i]),\n"
+"                Spacer(),\n"
+"                Button(\"Delete\", () => {\n"
+"                    todos.set(todos.value.filter((_, idx) => idx !== i))\n"
+"                    count.set(count.value - 1)\n"
+"                }),\n"
+"            ]),\n"
+"        ),\n"
+"\n"
+"        Spacer(),\n"
+"        Text(`${count.value} items`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/getting-started/first-app.md:112
+msgid ""
+"`ForEach(count, render)` iterates by index — keep an item array and a count "
+"state in sync, then read items via `array.value[i]` inside the closure. See "
+"[State Management](../ui/state.md) for the full pattern."
+msgstr ""
+
+#: src/getting-started/first-app.md:116
+msgid "Cross-Platform"
+msgstr "跨平台"
+
+#: src/getting-started/first-app.md:118
+msgid "The same code runs on all 6 platforms:"
+msgstr ""
+
+#: src/getting-started/first-app.md:121
+msgid "# macOS (default)\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:124
+msgid "# iOS Simulator\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:127
+msgid ""
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:129 src/platforms/overview.md:30
+msgid "# alias: --target wasm\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:131
+msgid "# Other platforms\n"
+msgstr ""
+
+#: src/getting-started/first-app.md:138
+msgid ""
+"Each target compiles to the platform's native widget toolkit. See "
+"[Platforms](../platforms/overview.md) for details."
+msgstr ""
+
+#: src/getting-started/first-app.md:141
+msgid "Adding Styling"
+msgstr ""
+
+#: src/getting-started/first-app.md:143
+msgid ""
+"Styling is applied via free functions that take the widget handle as their "
+"first argument. Colors are RGBA floats in `[0.0, 1.0]` — divide a hex byte "
+"by 255 to convert (`0x33 / 255 ≈ 0.2`)."
+msgstr ""
+
+#: src/getting-started/first-app.md:147
+msgid ""
+"```typescript\n"
+"// demonstrates: counter from getting-started/first-app.md with styled widgets\n"
+"// docs: docs/src/getting-started/first-app.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"// run: false\n"
+"\n"
+"import {\n"
+"    App, VStack, Text, Button, State,\n"
+"    textSetFontSize, textSetColor,\n"
+"    setCornerRadius, setPadding,\n"
+"    widgetSetBackgroundColor,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"const label = Text(`Count: ${count.value}`)\n"
+"textSetFontSize(label, 24)\n"
+"textSetColor(label, 0.2, 0.2, 0.2, 1.0)        // RGBA in [0,1] — same as #333333\n"
+"\n"
+"const btn = Button(\"Increment\", () => count.set(count.value + 1))\n"
+"setCornerRadius(btn, 8)\n"
+"widgetSetBackgroundColor(btn, 0.0, 0.478, 1.0, 1.0)  // system blue\n"
+"\n"
+"const stack = VStack(20, [label, btn])\n"
+"setPadding(stack, 20, 20, 20, 20)\n"
+"\n"
+"App({\n"
+"    title: \"Styled Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: stack,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/getting-started/first-app.md:182
+msgid "See [Styling](../ui/styling.md) for all available style properties."
+msgstr ""
+
+#: src/getting-started/first-app.md:186
+msgid ""
+"[Project Configuration](project-config.md) — Set up `package.json` for Perry"
+" projects"
+msgstr ""
+
+#: src/getting-started/first-app.md:187
+msgid "[UI Overview](../ui/overview.md) — Complete guide to Perry's UI system"
+msgstr ""
+
+#: src/getting-started/first-app.md:188
+msgid "[Widgets Reference](../ui/widgets.md) — All available widgets"
+msgstr ""
+
+#: src/getting-started/first-app.md:189
+msgid "[State Management](../ui/state.md) — Reactive state and bindings"
+msgstr ""
+
+#: src/getting-started/project-config.md:3
+msgid ""
+"Perry projects use `perry.toml` and `package.json` for configuration. No "
+"special config file is required for basic usage, but larger projects benefit"
+" from Perry-specific settings."
+msgstr ""
+
+#: src/getting-started/project-config.md:5
+msgid ""
+"**Looking for the full perry.toml reference?** See [perry.toml "
+"Reference](../cli/perry-toml.md) for every field, section, platform option, "
+"and environment variable."
+msgstr ""
+
+#: src/getting-started/project-config.md:7
+msgid "Basic Setup"
+msgstr "基本设置"
+
+#: src/getting-started/project-config.md:14
+msgid "This creates a `package.json` and a starter `src/index.ts`."
+msgstr ""
+
+#: src/getting-started/project-config.md:16
+msgid "package.json"
+msgstr "package.json"
+
+#: src/getting-started/project-config.md:20
+#: src/plugins/native-extensions.md:58 src/plugins/native-extensions.md:64
+#: src/plugins/appstore-review.md:183
+msgid "\"name\""
+msgstr ""
+
+#: src/getting-started/project-config.md:20
+msgid "\"my-project\""
+msgstr ""
+
+#: src/getting-started/project-config.md:21
+#: src/plugins/native-extensions.md:59
+msgid "\"version\""
+msgstr ""
+
+#: src/getting-started/project-config.md:21
+msgid "\"1.0.0\""
+msgstr ""
+
+#: src/getting-started/project-config.md:22
+#: src/plugins/native-extensions.md:60
+msgid "\"main\""
+msgstr ""
+
+#: src/getting-started/project-config.md:22
+#: src/plugins/native-extensions.md:60
+msgid "\"src/index.ts\""
+msgstr ""
+
+#: src/getting-started/project-config.md:23
+#: src/getting-started/project-config.md:39
+#: src/getting-started/project-config.md:61
+#: src/getting-started/project-config.md:74
+#: src/getting-started/project-config.md:95 src/packages/porting.md:24
+#: src/platforms/ios.md:98 src/platforms/ios.md:111
+#: src/platforms/android.md:57 src/platforms/android.md:72
+#: src/stdlib/overview.md:84 src/plugins/native-extensions.md:61
+#: src/plugins/appstore-review.md:180
+msgid "\"perry\""
+msgstr ""
+
+#: src/getting-started/project-config.md:24
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"compilePackages\""
+msgstr ""
+
+#: src/getting-started/project-config.md:29
+msgid "Perry Configuration"
+msgstr "Perry 配置"
+
+#: src/getting-started/project-config.md:31
+msgid "The `perry` field in `package.json` controls compiler behavior:"
+msgstr ""
+
+#: src/getting-started/project-config.md:33
+msgid "`compilePackages`"
+msgstr ""
+
+#: src/getting-started/project-config.md:35
+msgid ""
+"List npm packages to compile natively instead of routing through the "
+"JavaScript runtime:"
+msgstr ""
+
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"@noble/curves\""
+msgstr ""
+
+#: src/getting-started/project-config.md:40 src/packages/porting.md:25
+#: src/stdlib/overview.md:85
+msgid "\"@noble/hashes\""
+msgstr ""
+
+#: src/getting-started/project-config.md:45
+msgid "When a package is listed here, Perry:"
+msgstr ""
+
+#: src/getting-started/project-config.md:46
+msgid "Resolves the package in `node_modules/`"
+msgstr ""
+
+#: src/getting-started/project-config.md:47
+msgid ""
+"Prefers TypeScript source (`src/index.ts`) over compiled JavaScript "
+"(`lib/index.js`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:48
+msgid "Compiles all functions natively through LLVM"
+msgstr ""
+
+#: src/getting-started/project-config.md:49
+msgid ""
+"Deduplicates across nested `node_modules/` to prevent duplicate linker "
+"symbols"
+msgstr ""
+
+#: src/getting-started/project-config.md:51
+msgid ""
+"This is useful for pure TypeScript/JavaScript packages that don't rely on "
+"Node.js APIs. Packages that use native bindings, `eval()`, or dynamic "
+"`require()` won't work."
+msgstr ""
+
+#: src/getting-started/project-config.md:53
+msgid "`splash`"
+msgstr ""
+
+#: src/getting-started/project-config.md:55
+msgid ""
+"Configure a native splash screen for iOS and Android. The splash screen "
+"appears instantly during cold start, before your app code runs."
+msgstr ""
+
+#: src/getting-started/project-config.md:57
+msgid "**Minimal (both platforms share the same splash):**"
+msgstr ""
+
+#: src/getting-started/project-config.md:62
+#: src/getting-started/project-config.md:75
+#: src/getting-started/project-config.md:96 src/platforms/ios.md:99
+#: src/platforms/ios.md:112 src/platforms/android.md:58
+#: src/platforms/android.md:73
+msgid "\"splash\""
+msgstr ""
+
+#: src/getting-started/project-config.md:63
+#: src/getting-started/project-config.md:76
+#: src/getting-started/project-config.md:79
+#: src/getting-started/project-config.md:83 src/platforms/ios.md:100
+#: src/platforms/android.md:59
+msgid "\"image\""
+msgstr ""
+
+#: src/getting-started/project-config.md:63
+#: src/getting-started/project-config.md:76 src/platforms/ios.md:100
+#: src/platforms/android.md:59
+msgid "\"logo/icon-256.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:64
+#: src/getting-started/project-config.md:77
+#: src/getting-started/project-config.md:80
+#: src/getting-started/project-config.md:84 src/ui/theming.md:26
+#: src/platforms/ios.md:101 src/platforms/android.md:60
+msgid "\"background\""
+msgstr ""
+
+#: src/getting-started/project-config.md:64
+#: src/getting-started/project-config.md:77 src/platforms/ios.md:101
+#: src/platforms/android.md:60
+msgid "\"#FFF5EE\""
+msgstr ""
+
+#: src/getting-started/project-config.md:70
+msgid "**Per-platform overrides:**"
+msgstr ""
+
+#: src/getting-started/project-config.md:78
+#: src/getting-started/project-config.md:97 src/platforms/ios.md:113
+#: src/plugins/native-extensions.md:67
+msgid "\"ios\""
+msgstr ""
+
+#: src/getting-started/project-config.md:79
+msgid "\"logo/splash-ios.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:80
+#: src/getting-started/project-config.md:84 src/ui/theming.md:26
+#: src/ui/theming.md:29
+msgid "\"#FFFFFF\""
+msgstr ""
+
+#: src/getting-started/project-config.md:82
+#: src/getting-started/project-config.md:100 src/platforms/android.md:74
+#: src/plugins/native-extensions.md:72
+msgid "\"android\""
+msgstr ""
+
+#: src/getting-started/project-config.md:83
+msgid "\"logo/splash-android.png\""
+msgstr ""
+
+#: src/getting-started/project-config.md:91
+msgid "**Full custom override (complete control):**"
+msgstr ""
+
+#: src/getting-started/project-config.md:98 src/platforms/ios.md:113
+msgid "\"storyboard\""
+msgstr ""
+
+#: src/getting-started/project-config.md:98 src/platforms/ios.md:113
+msgid "\"splash/LaunchScreen.storyboard\""
+msgstr ""
+
+#: src/getting-started/project-config.md:101 src/platforms/android.md:75
+msgid "\"layout\""
+msgstr ""
+
+#: src/getting-started/project-config.md:101 src/platforms/android.md:75
+msgid "\"splash/splash_background.xml\""
+msgstr ""
+
+#: src/getting-started/project-config.md:102 src/platforms/android.md:76
+msgid "\"theme\""
+msgstr ""
+
+#: src/getting-started/project-config.md:102 src/platforms/android.md:76
+msgid "\"splash/themes.xml\""
+msgstr ""
+
+#: src/getting-started/project-config.md:109 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414
+msgid "Field"
+msgstr ""
+
+#: src/getting-started/project-config.md:109 src/ui/overview.md:57
+#: src/ui/widgets.md:377 src/ui/layout.md:173 src/ui/menus.md:53
+#: src/ui/multi-window.md:36 src/ui/multi-window.md:80
+#: src/ui/multi-window.md:124 src/system/overview.md:21
+#: src/widgets/creating-widgets.md:45 src/widgets/configuration.md:70
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/testing/geisterhand.md:84 src/testing/geisterhand.md:98
+#: src/cli/commands.md:17 src/cli/commands.md:60 src/cli/commands.md:109
+#: src/cli/commands.md:148 src/cli/commands.md:181 src/cli/commands.md:195
+#: src/cli/commands.md:233 src/cli/commands.md:248 src/cli/commands.md:260
+#: src/cli/flags.md:9 src/cli/flags.md:43 src/cli/flags.md:50
+#: src/cli/flags.md:58 src/cli/flags.md:66 src/cli/flags.md:73
+#: src/cli/flags.md:80 src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:277
+#: src/cli/perry-toml.md:284 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:367 src/cli/perry-toml.md:377
+#: src/cli/perry-toml.md:387 src/cli/perry-toml.md:397
+#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:491
+#: src/cli/perry-toml.md:503 src/cli/perry-toml.md:513
+msgid "Description"
+msgstr ""
+
+#: src/getting-started/project-config.md:111
+msgid "`splash.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:111
+msgid "Path to a PNG image, centered on the splash screen (both platforms)"
+msgstr ""
+
+#: src/getting-started/project-config.md:112
+msgid "`splash.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:112
+msgid "Hex color for the background (default: `#FFFFFF`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:113
+msgid "`splash.ios.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:113
+msgid "iOS-specific image override"
+msgstr ""
+
+#: src/getting-started/project-config.md:114
+msgid "`splash.ios.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:114
+msgid "iOS-specific background color"
+msgstr ""
+
+#: src/getting-started/project-config.md:115
+msgid "`splash.ios.storyboard`"
+msgstr ""
+
+#: src/getting-started/project-config.md:115
+msgid "Custom LaunchScreen.storyboard (compiled with ibtool)"
+msgstr ""
+
+#: src/getting-started/project-config.md:116
+msgid "`splash.android.image`"
+msgstr ""
+
+#: src/getting-started/project-config.md:116
+msgid "Android-specific image override"
+msgstr ""
+
+#: src/getting-started/project-config.md:117
+msgid "`splash.android.background`"
+msgstr ""
+
+#: src/getting-started/project-config.md:117
+msgid "Android-specific background color"
+msgstr ""
+
+#: src/getting-started/project-config.md:118
+msgid "`splash.android.layout`"
+msgstr ""
+
+#: src/getting-started/project-config.md:118
+msgid "Custom drawable XML for `windowBackground`"
+msgstr ""
+
+#: src/getting-started/project-config.md:119
+msgid "`splash.android.theme`"
+msgstr ""
+
+#: src/getting-started/project-config.md:119
+msgid "Custom themes.xml"
+msgstr ""
+
+#: src/getting-started/project-config.md:121
+msgid "**Resolution order** per platform:"
+msgstr ""
+
+#: src/getting-started/project-config.md:122
+msgid "Custom file override (storyboard / layout+theme)"
+msgstr ""
+
+#: src/getting-started/project-config.md:123
+msgid "Platform-specific image/color (`splash.{platform}.image`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:124
+msgid "Universal image/color (`splash.image`)"
+msgstr ""
+
+#: src/getting-started/project-config.md:125
+msgid "No `splash` key → blank white screen (backward compatible)"
+msgstr ""
+
+#: src/getting-started/project-config.md:127
+msgid "Using npm Packages"
+msgstr "使用 npm 包"
+
+#: src/getting-started/project-config.md:129
+msgid ""
+"Perry natively supports many popular npm packages without any configuration:"
+msgstr ""
+
+#: src/getting-started/project-config.md:131
+msgid ""
+"```typescript\n"
+"// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
+"// docs: docs/src/getting-started/project-config.md\n"
+"// platforms: macos, linux, windows\n"
+"// run: false\n"
+"\n"
+"// These four imports are Perry's most-used built-in stdlib shims:\n"
+"// fastify (HTTP server), mysql2 (db), ioredis (Redis), bcrypt (password\n"
+"// hashing). They're compiled to native code via Perry's per-package\n"
+"// implementations — no `compilePackages` needed.\n"
+"//\n"
+"// `// run: false` because each one needs a live external service (DB,\n"
+"// Redis, network port) to actually do anything; the binary still has to\n"
+"// link cleanly, which is the drift check we want.\n"
+"\n"
+"import fastify from \"fastify\"\n"
+"import mysql from \"mysql2/promise\"\n"
+"import Redis from \"ioredis\"\n"
+"import bcrypt from \"bcrypt\"\n"
+"\n"
+"const app = fastify({ logger: false })\n"
+"const db = mysql.createPool({ host: \"localhost\", user: \"root\", database: \"test\" })\n"
+"const redis = new Redis()\n"
+"const hashed = await bcrypt.hash(\"hunter2\", 10)\n"
+"\n"
+"console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
+"```"
+msgstr ""
+
+#: src/getting-started/project-config.md:159
+msgid ""
+"These are compiled to native code using Perry's built-in implementations. "
+"See [Standard Library](../stdlib/overview.md) for the full list."
+msgstr ""
+
+#: src/getting-started/project-config.md:161
+msgid ""
+"For packages not natively supported, use `compilePackages` for pure TS/JS "
+"packages, or the JavaScript runtime fallback for complex packages."
+msgstr ""
+
+#: src/getting-started/project-config.md:163 src/contributing/building.md:61
+msgid "Project Structure"
+msgstr "项目结构"
+
+#: src/getting-started/project-config.md:165
+msgid "Perry is flexible about project structure. Common patterns:"
+msgstr ""
+
+#: src/getting-started/project-config.md:175
+msgid "For UI apps:"
+msgstr ""
+
+#: src/getting-started/project-config.md:186 src/widgets/watchos.md:59
+#: src/widgets/wearos.md:58
+msgid "Compilation"
+msgstr ""
+
+#: src/getting-started/project-config.md:189
+msgid "# Compile a file\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:191
+msgid "# Compile with a specific target\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:194
+msgid "# Debug: print intermediate representation\n"
+msgstr ""
+
+#: src/getting-started/project-config.md:199
+msgid "See [CLI Commands](../cli/commands.md) for all options."
+msgstr ""
+
+#: src/getting-started/project-config.md:203
+msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
+msgstr ""
+
+#: src/getting-started/project-config.md:204
+msgid ""
+"[Supported Features](../language/supported-features.md) — What TypeScript "
+"features work"
+msgstr ""
+
+#: src/getting-started/project-config.md:205
+msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
+msgstr ""
+
+#: src/language/supported-features.md:1
+msgid "Supported TypeScript Features"
+msgstr ""
+
+#: src/language/supported-features.md:3
+msgid ""
+"Perry compiles a practical subset of TypeScript to native code. This page "
+"lists what's supported."
+msgstr ""
+
+#: src/language/supported-features.md:5
+msgid "Primitive Types"
+msgstr ""
+
+#: src/language/supported-features.md:7
+msgid ""
+"```typescript\n"
+"function primitives(): void {\n"
+"    const n: number = 42;\n"
+"    const s: string = \"hello\";\n"
+"    const b: boolean = true;\n"
+"    const u: undefined = undefined;\n"
+"    const nl: null = null;\n"
+"\n"
+"    console.log(`primitives: n=${n} s=${s} b=${b} u=${u} nl=${nl}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:19
+msgid "All primitives are represented as 64-bit NaN-boxed values at runtime."
+msgstr ""
+
+#: src/language/supported-features.md:21
+msgid "Variables and Constants"
+msgstr ""
+
+#: src/language/supported-features.md:23
+msgid ""
+"```typescript\n"
+"function variables(): void {\n"
+"    let x = 10;\n"
+"    const y = \"immutable\";\n"
+"    var z = true; // var is supported but let/const preferred\n"
+"\n"
+"    console.log(`variables: x=${x} y=${y} z=${z}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:33
+msgid ""
+"Perry infers types from initializers — `let x = 5` is inferred as `number` "
+"without an explicit annotation."
+msgstr ""
+
+#: src/language/supported-features.md:35
+msgid "Functions"
+msgstr ""
+
+#: src/language/supported-features.md:37
+msgid ""
+"```typescript\n"
+"function functionsDemo(): void {\n"
+"    function add(a: number, b: number): number {\n"
+"        return a + b;\n"
+"    }\n"
+"\n"
+"    // Optional parameters\n"
+"    function greet(name: string, greeting: string = \"Hello\"): string {\n"
+"        return `${greeting}, ${name}!`;\n"
+"    }\n"
+"\n"
+"    // Rest parameters\n"
+"    function sum(...nums: number[]): number {\n"
+"        return nums.reduce((a, b) => a + b, 0);\n"
+"    }\n"
+"\n"
+"    // Arrow functions\n"
+"    const double = (x: number) => x * 2;\n"
+"\n"
+"    console.log(`functions: add=${add(2, 3)} greet=${greet(\"Perry\")} sum=${sum(1, 2, 3)} double=${double(5)}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:60
+msgid "Classes"
+msgstr ""
+
+#: src/language/supported-features.md:62
+msgid ""
+"```typescript\n"
+"class Animal {\n"
+"    name: string;\n"
+"\n"
+"    constructor(name: string) {\n"
+"        this.name = name;\n"
+"    }\n"
+"\n"
+"    speak(): string {\n"
+"        return `${this.name} makes a noise`;\n"
+"    }\n"
+"}\n"
+"\n"
+"class Dog extends Animal {\n"
+"    speak(): string {\n"
+"        return `${this.name} barks`;\n"
+"    }\n"
+"}\n"
+"\n"
+"// Static methods\n"
+"class Counter {\n"
+"    private static instance: Counter;\n"
+"    private count: number = 0;\n"
+"\n"
+"    static getInstance(): Counter {\n"
+"        if (!Counter.instance) {\n"
+"            Counter.instance = new Counter();\n"
+"        }\n"
+"        return Counter.instance;\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:95
+msgid "Supported class features:"
+msgstr ""
+
+#: src/language/supported-features.md:96
+msgid "Constructors"
+msgstr ""
+
+#: src/language/supported-features.md:97
+msgid "Instance and static methods"
+msgstr ""
+
+#: src/language/supported-features.md:98
+msgid "Instance and static properties"
+msgstr ""
+
+#: src/language/supported-features.md:99
+msgid "Inheritance (`extends`)"
+msgstr ""
+
+#: src/language/supported-features.md:100
+msgid "Method overriding"
+msgstr ""
+
+#: src/language/supported-features.md:101
+msgid "`instanceof` checks (via class ID chain)"
+msgstr ""
+
+#: src/language/supported-features.md:102
+msgid "Singleton patterns (static method return type inference)"
+msgstr ""
+
+#: src/language/supported-features.md:104
+msgid "Enums"
+msgstr ""
+
+#: src/language/supported-features.md:106
+msgid ""
+"```typescript\n"
+"// Numeric enums\n"
+"enum Direction {\n"
+"    Up,\n"
+"    Down,\n"
+"    Left,\n"
+"    Right,\n"
+"}\n"
+"\n"
+"// String enums\n"
+"enum Color {\n"
+"    Red = \"RED\",\n"
+"    Green = \"GREEN\",\n"
+"    Blue = \"BLUE\",\n"
+"}\n"
+"\n"
+"const dir = Direction.Up;\n"
+"const color = Color.Red;\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:126
+msgid "Enums are compiled to constants and work across modules."
+msgstr ""
+
+#: src/language/supported-features.md:128
+msgid "Interfaces and Type Aliases"
+msgstr ""
+
+#: src/language/supported-features.md:142
+msgid ""
+"Interfaces and type aliases are erased at compile time (like `tsc`). They "
+"exist only for documentation and editor tooling."
+msgstr ""
+
+#: src/language/supported-features.md:144 src/threading/overview.md:306
+#: src/threading/parallel-map.md:58
+msgid "Arrays"
+msgstr ""
+
+#: src/language/supported-features.md:146
+msgid ""
+"```typescript\n"
+"function arraysDemo(): void {\n"
+"    const nums: number[] = [1, 2, 3];\n"
+"\n"
+"    // Array methods\n"
+"    nums.push(4);\n"
+"    nums.pop();\n"
+"    const len = nums.length;\n"
+"    const doubled = nums.map((x) => x * 2);\n"
+"    const filtered = nums.filter((x) => x > 2);\n"
+"    const sum = nums.reduce((acc, x) => acc + x, 0);\n"
+"    const found = nums.find((x) => x === 3);\n"
+"    const idx = nums.indexOf(3);\n"
+"    const joined = nums.join(\", \");\n"
+"    const sliced = nums.slice(1, 3);\n"
+"    nums.splice(1, 1);\n"
+"    nums.unshift(0);\n"
+"    const sorted = nums.sort((a, b) => a - b);\n"
+"    const reversed = nums.reverse();\n"
+"    const includes = nums.includes(3);\n"
+"    const every = nums.every((x) => x > 0);\n"
+"    const some = nums.some((x) => x > 2);\n"
+"    nums.forEach((x) => console.log(x));\n"
+"    const flat = [[1, 2], [3]].flat();\n"
+"    const concatted = nums.concat([5, 6]);\n"
+"\n"
+"    // Array.from\n"
+"    const arr = Array.from([10, 20, 30]);\n"
+"\n"
+"    // Array.isArray\n"
+"    const value: any = [1, 2, 3]\n"
+"    if (Array.isArray(value)) { /* ... */ }\n"
+"\n"
+"    // for...of iteration\n"
+"    for (const item of nums) {\n"
+"        console.log(item);\n"
+"    }\n"
+"\n"
+"    console.log(`arrays: len=${len} doubled=${doubled.length} filtered=${filtered.length} sum=${sum} found=${found} idx=${idx} joined=${joined} sliced=${sliced.length} sorted=${sorted.length} reversed=${reversed.length} includes=${includes} every=${every} some=${some} flat=${flat.length} concatted=${concatted.length} arr=${arr.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:188 src/threading/overview.md:307
+#: src/threading/parallel-map.md:59
+msgid "Objects"
+msgstr ""
+
+#: src/language/supported-features.md:190
+msgid ""
+"```typescript\n"
+"function objectsDemo(): void {\n"
+"    const obj: { name: string; version: number; [k: string]: any } = { name: \"Perry\", version: 1 };\n"
+"    obj.name = \"Perry 2\";\n"
+"\n"
+"    // Dynamic property access\n"
+"    const key = \"name\";\n"
+"    const val = obj[key];\n"
+"\n"
+"    // Object.keys, Object.values, Object.entries\n"
+"    const keys = Object.keys(obj);\n"
+"    const values = Object.values(obj);\n"
+"    const entries = Object.entries(obj);\n"
+"\n"
+"    // Spread\n"
+"    const copy = { ...obj, extra: true };\n"
+"\n"
+"    // delete\n"
+"    delete obj[key];\n"
+"\n"
+"    console.log(`objects: val=${val} keys=${keys.length} values=${values.length} entries=${entries.length} copy=${copy.extra}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:214
+msgid "Destructuring"
+msgstr ""
+
+#: src/language/supported-features.md:216
+msgid ""
+"```typescript\n"
+"function destructuringDemo(): void {\n"
+"    // Array destructuring\n"
+"    const [a, b, ...rest] = [1, 2, 3, 4, 5];\n"
+"\n"
+"    const user = { name: \"Alice\", age: 30, email: \"a@example.com\", id: 1 }\n"
+"    const obj = { id: 2, role: \"admin\", level: 5 }\n"
+"\n"
+"    // Object destructuring\n"
+"    const { name, age, email = \"none\" } = user;\n"
+"\n"
+"    // Rename\n"
+"    const { name: userName } = user;\n"
+"\n"
+"    // Rest pattern\n"
+"    const { id, ...remaining } = obj;\n"
+"\n"
+"    // Function parameter destructuring\n"
+"    function process({ name, age }: { name: string; age: number }) {\n"
+"        console.log(name, age);\n"
+"    }\n"
+"\n"
+"    process(user)\n"
+"    console.log(`destructuring: a=${a} b=${b} rest=${rest.length} name=${name} age=${age} email=${email} userName=${userName} id=${id}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:243 src/widgets/creating-widgets.md:112
+msgid "Template Literals"
+msgstr ""
+
+#: src/language/supported-features.md:245
+msgid ""
+"```typescript\n"
+"function templateLiteralsDemo(): void {\n"
+"    const name = \"world\";\n"
+"    const greeting = `Hello, ${name}!`;\n"
+"    const multiline = `\n"
+"  Line 1\n"
+"  Line 2\n"
+"`;\n"
+"    const expr = `Result: ${1 + 2}`;\n"
+"\n"
+"    console.log(`template-literals: greeting=${greeting} multiline_len=${multiline.length} expr=${expr}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:259
+msgid "Spread and Rest"
+msgstr ""
+
+#: src/language/supported-features.md:261
+msgid ""
+"```typescript\n"
+"function spreadRestDemo(): void {\n"
+"    const arr1 = [1, 2]\n"
+"    const arr2 = [3, 4]\n"
+"    const defaults = { theme: \"light\", size: \"md\" }\n"
+"    const overrides = { size: \"lg\" }\n"
+"\n"
+"    // Array spread\n"
+"    const combined = [...arr1, ...arr2];\n"
+"\n"
+"    // Object spread\n"
+"    const merged = { ...defaults, ...overrides };\n"
+"\n"
+"    // Rest parameters\n"
+"    function log(...args: any[]) { /* ... */ }\n"
+"\n"
+"    log(\"a\", \"b\", \"c\")\n"
+"    console.log(`spread-rest: combined=${combined.length} merged=${merged.size}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:282 src/threading/overview.md:308
+msgid "Closures"
+msgstr ""
+
+#: src/language/supported-features.md:284
+msgid ""
+"```typescript\n"
+"function closuresDemo(): void {\n"
+"    function makeCounter() {\n"
+"        let count = 0;\n"
+"        return {\n"
+"            increment: () => ++count,\n"
+"            get: () => count,\n"
+"        };\n"
+"    }\n"
+"\n"
+"    const counter = makeCounter();\n"
+"    counter.increment();\n"
+"    console.log(counter.get()); // 1\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:300
+msgid ""
+"Perry performs closure conversion — captured variables are stored in heap-"
+"allocated closure objects."
+msgstr ""
+
+#: src/language/supported-features.md:302
+msgid "Async/Await"
+msgstr ""
+
+#: src/language/supported-features.md:304
+msgid ""
+"```typescript\n"
+"async function asyncAwaitDemo(): Promise<void> {\n"
+"    interface Profile { id: number; name: string }\n"
+"\n"
+"    async function fetchUser(id: number): Promise<Profile> {\n"
+"        // The docs example uses fetch(...) here; we inline a synthetic\n"
+"        // result so the snippet compiles and runs hermetically.\n"
+"        return { id, name: `user-${id}` }\n"
+"    }\n"
+"\n"
+"    const data = await fetchUser(1);\n"
+"    console.log(`async-await: id=${data.id} name=${data.name}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:319
+msgid ""
+"Perry compiles async functions to a state machine backed by Tokio's async "
+"runtime."
+msgstr ""
+
+#: src/language/supported-features.md:321
+msgid "Promises"
+msgstr ""
+
+#: src/language/supported-features.md:323
+msgid ""
+"```typescript\n"
+"async function promisesDemo(): Promise<void> {\n"
+"    const p = new Promise<number>((resolve, reject) => {\n"
+"        resolve(42);\n"
+"    });\n"
+"\n"
+"    p.then((value) => console.log(value));\n"
+"\n"
+"    // Promise.all\n"
+"    const results = await Promise.all([\n"
+"        Promise.resolve(\"a\"),\n"
+"        Promise.resolve(\"b\"),\n"
+"    ]);\n"
+"\n"
+"    console.log(`promises: results=${results.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:341
+msgid "Generators"
+msgstr ""
+
+#: src/language/supported-features.md:357
+msgid "Map and Set"
+msgstr ""
+
+#: src/language/supported-features.md:359
+msgid ""
+"```typescript\n"
+"function mapSetDemo(): void {\n"
+"    const map = new Map<string, number>();\n"
+"    map.set(\"a\", 1);\n"
+"    map.get(\"a\");\n"
+"    map.has(\"a\");\n"
+"    map.delete(\"a\");\n"
+"    map.size;\n"
+"\n"
+"    const set = new Set<number>();\n"
+"    set.add(1);\n"
+"    set.has(1);\n"
+"    set.delete(1);\n"
+"    set.size;\n"
+"\n"
+"    console.log(`map-set: map_size=${map.size} set_size=${set.size}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:378
+msgid "Regular Expressions"
+msgstr ""
+
+#: src/language/supported-features.md:380
+msgid ""
+"```typescript\n"
+"function regexDemo(): void {\n"
+"    const re = /hello\\s+(\\w+)/;\n"
+"    const match = \"hello world\".match(re);\n"
+"\n"
+"    if (re.test(\"hello perry\")) {\n"
+"        console.log(\"Matched!\");\n"
+"    }\n"
+"\n"
+"    const replaced = \"hello world\".replace(/world/, \"perry\");\n"
+"\n"
+"    console.log(`regex: match=${match !== null} replaced=${replaced}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:395 src/widgets/data-fetching.md:154
+msgid "Error Handling"
+msgstr ""
+
+#: src/language/supported-features.md:397
+msgid ""
+"```typescript\n"
+"function errorsDemo(): void {\n"
+"    try {\n"
+"        throw new Error(\"something went wrong\");\n"
+"    } catch (e: any) {\n"
+"        console.log(e.message);\n"
+"    } finally {\n"
+"        console.log(\"cleanup\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:409
+msgid "JSON"
+msgstr ""
+
+#: src/language/supported-features.md:411
+msgid ""
+"```typescript\n"
+"function jsonDemo(): void {\n"
+"    const obj = JSON.parse('{\"key\": \"value\"}');\n"
+"    const str = JSON.stringify(obj);\n"
+"    const pretty = JSON.stringify(obj, null, 2);\n"
+"\n"
+"    console.log(`json: str_len=${str.length} pretty_len=${pretty.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:421
+msgid "typeof and instanceof"
+msgstr ""
+
+#: src/language/supported-features.md:423
+msgid ""
+"```typescript\n"
+"function typeofInstanceofDemo(): void {\n"
+"    const x: any = \"hello\"\n"
+"    if (typeof x === \"string\") {\n"
+"        console.log(x.length);\n"
+"    }\n"
+"\n"
+"    const obj: any = new Dog(\"Rex\")\n"
+"    if (obj instanceof Dog) {\n"
+"        obj.speak();\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:437
+msgid ""
+"`typeof` checks NaN-boxing tags at runtime. `instanceof` walks the class ID "
+"chain."
+msgstr ""
+
+#: src/language/supported-features.md:439
+msgid "Modules"
+msgstr ""
+
+#: src/language/supported-features.md:441
+msgid ""
+"ES module syntax is fully supported: named exports, default exports, and re-"
+"exports."
+msgstr ""
+
+#: src/language/supported-features.md:444
+msgid "The exporting module:"
+msgstr ""
+
+#: src/language/supported-features.md:446
+msgid ""
+"```typescript\n"
+"// Named exports\n"
+"export function helper(x: number): number { return x + 1 }\n"
+"export const VALUE = 42\n"
+"\n"
+"// Default export\n"
+"export default class MyClass {\n"
+"    name: string\n"
+"    constructor(name: string) {\n"
+"        this.name = name\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:460
+msgid "The importing module:"
+msgstr ""
+
+#: src/language/supported-features.md:462
+msgid ""
+"```typescript\n"
+"// Default + named imports from a sibling module\n"
+"import MyClass, { helper, VALUE } from \"./utils\"\n"
+"\n"
+"// Re-export\n"
+"export { helper } from \"./utils\"\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:470
+msgid "BigInt"
+msgstr ""
+
+#: src/language/supported-features.md:472
+msgid ""
+"```typescript\n"
+"function bigintDemo(): void {\n"
+"    const big = BigInt(9007199254740991);\n"
+"    const result = big + BigInt(1);\n"
+"\n"
+"    // Bitwise operations\n"
+"    const and = big & BigInt(0xFF);\n"
+"    const or = big | BigInt(0xFF);\n"
+"    const xor = big ^ BigInt(0xFF);\n"
+"    const shl = big << BigInt(2);\n"
+"    const shr = big >> BigInt(2);\n"
+"    const not = ~big;\n"
+"\n"
+"    console.log(`bigint: result_ok=${result !== null} and_ok=${and !== null} or_ok=${or !== null}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:489
+msgid "String Methods"
+msgstr ""
+
+#: src/language/supported-features.md:491
+msgid ""
+"```typescript\n"
+"function stringMethodsDemo(): void {\n"
+"    const s = \"Hello, World!\";\n"
+"    s.length;\n"
+"    s.toUpperCase();\n"
+"    s.toLowerCase();\n"
+"    s.trim();\n"
+"    s.split(\", \");\n"
+"    s.includes(\"World\");\n"
+"    s.startsWith(\"Hello\");\n"
+"    s.endsWith(\"!\");\n"
+"    s.indexOf(\"World\");\n"
+"    s.slice(0, 5);\n"
+"    s.substring(0, 5);\n"
+"    s.replace(\"World\", \"Perry\");\n"
+"    s.repeat(3);\n"
+"    s.charAt(0);\n"
+"    s.padStart(20);\n"
+"    s.padEnd(20);\n"
+"\n"
+"    console.log(`string-methods: ${s.toUpperCase()}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:515
+msgid "Math"
+msgstr ""
+
+#: src/language/supported-features.md:538
+msgid "Date"
+msgstr ""
+
+#: src/language/supported-features.md:551
+msgid "Console"
+msgstr ""
+
+#: src/language/supported-features.md:553
+msgid ""
+"```typescript\n"
+"function consoleDemo(): void {\n"
+"    console.log(\"message\");\n"
+"    console.error(\"error\");\n"
+"    console.warn(\"warning\");\n"
+"    console.time(\"label\");\n"
+"    console.timeEnd(\"label\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:563 src/contributing/architecture.md:56
+msgid "Garbage Collection"
+msgstr ""
+
+#: src/language/supported-features.md:565
+msgid ""
+"Perry includes a mark-sweep garbage collector. It runs automatically when "
+"memory pressure is detected (~8MB arena blocks), but you can also trigger it"
+" manually:"
+msgstr ""
+
+#: src/language/supported-features.md:567
+msgid ""
+"```typescript\n"
+"function gcDemo(): void {\n"
+"    gc(); // Explicit garbage collection\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:573
+msgid ""
+"The GC uses conservative stack scanning to find roots and supports arena-"
+"allocated objects (arrays, objects) and malloc-allocated objects (strings, "
+"closures, promises, BigInts, errors)."
+msgstr ""
+
+#: src/language/supported-features.md:575
+msgid "JSX/TSX"
+msgstr ""
+
+#: src/language/supported-features.md:577
+msgid ""
+"Perry's parser and HIR understand JSX syntax (parsed via SWC, lowered in "
+"`crates/perry-hir/src/jsx.rs`), but the runtime `_jsx` / `_jsxs` symbols are"
+" not yet linked, so a `.tsx` file fails at the link stage today. The "
+"canonical pattern is the function-call form Perry's UI examples already use "
+"(`Text(\"hi\")` instead of `<Text>hi</Text>`)."
+msgstr ""
+
+#: src/language/supported-features.md:583
+msgid ""
+"```text\n"
+"// Planned JSX shape (parses but doesn't link yet — issue: runtime _jsx symbols):\n"
+"\n"
+"function Greeting({ name }: { name: string }) {\n"
+"  return <Text>{`Hello, ${name}!`}</Text>;\n"
+"}\n"
+"\n"
+"<Button onClick={() => console.log(\"clicked\")}>Click me</Button>\n"
+"\n"
+"<>\n"
+"  <Text>Line 1</Text>\n"
+"  <Text>Line 2</Text>\n"
+"</>\n"
+"```"
+msgstr ""
+
+#: src/language/supported-features.md:598
+msgid ""
+"JSX elements are transformed to function calls via the `jsx()`/`jsxs()` "
+"runtime."
+msgstr ""
+
+#: src/language/supported-features.md:602
+msgid "[Type System](type-system.md) — Type inference and checking"
+msgstr ""
+
+#: src/language/supported-features.md:603
+msgid "[Limitations](limitations.md) — What's not supported yet"
+msgstr ""
+
+#: src/language/type-system.md:3
+msgid ""
+"Perry erases types at compile time, similar to how `tsc` removes type "
+"annotations when emitting JavaScript. However, Perry also performs type "
+"inference to generate efficient native code."
+msgstr ""
+
+#: src/language/type-system.md:5
+msgid "Type Inference"
+msgstr ""
+
+#: src/language/type-system.md:7
+msgid "Perry infers types from expressions without requiring annotations:"
+msgstr ""
+
+#: src/language/type-system.md:9
+msgid ""
+"```typescript\n"
+"function inferenceBasics(): void {\n"
+"    let x = 5;           // inferred as number\n"
+"    let s = \"hello\";     // inferred as string\n"
+"    let b = true;        // inferred as boolean\n"
+"    let arr = [1, 2, 3]; // inferred as number[]\n"
+"\n"
+"    console.log(`inference: x=${x} s=${s} b=${b} arr_len=${arr.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:20
+msgid "Inference works through:"
+msgstr ""
+
+#: src/language/type-system.md:21
+msgid "**Literal values**: `5` → `number`, `\"hi\"` → `string`"
+msgstr ""
+
+#: src/language/type-system.md:22
+msgid "**Binary operations**: `a + b` where both are numbers → `number`"
+msgstr ""
+
+#: src/language/type-system.md:23
+msgid ""
+"**Variable propagation**: if `x` is `number`, then `let y = x` is `number`"
+msgstr ""
+
+#: src/language/type-system.md:24
+msgid ""
+"**Method returns**: `\"hello\".trim()` → `string`, `[1,2].length` → `number`"
+msgstr ""
+
+#: src/language/type-system.md:25
+msgid ""
+"**Function returns**: user-defined function return types are propagated to "
+"callers"
+msgstr ""
+
+#: src/language/type-system.md:27
+msgid ""
+"```typescript\n"
+"function inferenceFunction(): void {\n"
+"    function double(n: number): number {\n"
+"        return n * 2;\n"
+"    }\n"
+"    let result = double(5); // inferred as number\n"
+"\n"
+"    console.log(`inference-function: result=${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:38
+msgid "Type Annotations"
+msgstr ""
+
+#: src/language/type-system.md:40
+msgid "Standard TypeScript annotations work:"
+msgstr ""
+
+#: src/language/type-system.md:42
+msgid ""
+"```typescript\n"
+"interface Config {\n"
+"    port: number;\n"
+"    host: string;\n"
+"}\n"
+"\n"
+"function annotations(): void {\n"
+"    let name: string = \"Perry\";\n"
+"    let count: number = 0;\n"
+"    let items: string[] = [];\n"
+"\n"
+"    function greet(name: string): string {\n"
+"        return `Hello, ${name}`;\n"
+"    }\n"
+"\n"
+"    const cfg: Config = { port: 8080, host: \"localhost\" }\n"
+"    console.log(`annotations: ${greet(name)} count=${count} items=${items.length} port=${cfg.port}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:62
+msgid "Utility Types"
+msgstr ""
+
+#: src/language/type-system.md:64
+msgid ""
+"Common TypeScript utility types are erased at compile time (they don't "
+"affect code generation):"
+msgstr ""
+
+#: src/language/type-system.md:75
+msgid ""
+"These are all recognized and erased — they won't cause compilation errors."
+msgstr ""
+
+#: src/language/type-system.md:77
+msgid "Generics"
+msgstr ""
+
+#: src/language/type-system.md:79
+msgid "Generic type parameters are erased:"
+msgstr ""
+
+#: src/language/type-system.md:81
+msgid ""
+"```typescript\n"
+"function identity<T>(value: T): T {\n"
+"    return value;\n"
+"}\n"
+"\n"
+"class Box<T> {\n"
+"    value: T;\n"
+"    constructor(value: T) {\n"
+"        this.value = value;\n"
+"    }\n"
+"}\n"
+"\n"
+"function genericsDemo(): void {\n"
+"    const box = new Box<number>(42);\n"
+"    const id = identity<string>(\"hello\")\n"
+"    console.log(`generics: box.value=${box.value} id=${id}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:100
+msgid ""
+"At runtime, all values are NaN-boxed — the generic parameter doesn't affect "
+"code generation."
+msgstr ""
+
+#: src/language/type-system.md:102
+msgid "Type Checking with `--type-check`"
+msgstr ""
+
+#: src/language/type-system.md:104
+msgid ""
+"For stricter type checking, Perry can integrate with Microsoft's TypeScript "
+"checker:"
+msgstr ""
+
+#: src/language/type-system.md:110
+msgid ""
+"This resolves cross-file types, interfaces, and generics via an IPC "
+"protocol. It falls back gracefully if the type checker is not installed."
+msgstr ""
+
+#: src/language/type-system.md:112
+msgid ""
+"Without `--type-check`, Perry relies on its own inference engine, which "
+"handles common patterns but doesn't perform full TypeScript type checking."
+msgstr ""
+
+#: src/language/type-system.md:114
+msgid "Union and Intersection Types"
+msgstr ""
+
+#: src/language/type-system.md:116
+msgid ""
+"Union types are recognized syntactically but don't affect code generation:"
+msgstr ""
+
+#: src/language/type-system.md:118
+msgid ""
+"```typescript\n"
+"type StringOrNumber = string | number;\n"
+"\n"
+"function process(value: StringOrNumber) {\n"
+"    if (typeof value === \"string\") {\n"
+"        console.log(value.toUpperCase());\n"
+"    } else {\n"
+"        console.log(value + 1);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:130
+msgid "Use `typeof` checks for runtime type narrowing."
+msgstr ""
+
+#: src/language/type-system.md:132
+msgid "Type Guards"
+msgstr ""
+
+#: src/language/type-system.md:134
+msgid ""
+"```typescript\n"
+"function isString(value: any): value is string {\n"
+"    return typeof value === \"string\";\n"
+"}\n"
+"\n"
+"function typeGuardsDemo(): void {\n"
+"    const x: any = \"hello\"\n"
+"    if (isString(x)) {\n"
+"        console.log(x.toUpperCase());\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/type-system.md:147
+msgid ""
+"The `value is string` annotation is erased, but the `typeof` check works at "
+"runtime."
+msgstr ""
+
+#: src/language/type-system.md:151
+msgid "[Supported Features](supported-features.md) — Complete feature list"
+msgstr ""
+
+#: src/language/type-system.md:152
+msgid "[Limitations](limitations.md) — What's not supported"
+msgstr ""
+
+#: src/language/limitations.md:3
+msgid ""
+"Perry compiles a practical subset of TypeScript. This page documents what's "
+"not supported or works differently from Node.js/tsc."
+msgstr ""
+
+#: src/language/limitations.md:5
+msgid "No Runtime Type Checking"
+msgstr ""
+
+#: src/language/limitations.md:7
+msgid ""
+"Types are erased at compile time. There is no runtime type system — Perry "
+"doesn't generate type guards or runtime type metadata."
+msgstr ""
+
+#: src/language/limitations.md:9
+msgid ""
+"```typescript\n"
+"function someFunction(): number {\n"
+"    return 42\n"
+"}\n"
+"\n"
+"function erasedTypes(): void {\n"
+"    // These annotations are erased — no runtime effect\n"
+"    const x: number = someFunction(); // No runtime check that result is actually a number\n"
+"    console.log(`erased-types: x=${x}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:21
+msgid ""
+"Use explicit `typeof` checks where runtime type discrimination is needed."
+msgstr ""
+
+#: src/language/limitations.md:23
+msgid "No eval() or Dynamic Code"
+msgstr ""
+
+#: src/language/limitations.md:25
+msgid ""
+"Perry compiles to native code ahead of time. Dynamic code execution is not "
+"possible:"
+msgstr ""
+
+#: src/language/limitations.md:28
+msgid ""
+"```text\n"
+"// Not supported\n"
+"eval(\"console.log('hi')\");\n"
+"new Function(\"return 42\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:34
+msgid "No Decorators"
+msgstr ""
+
+#: src/language/limitations.md:36
+msgid "TypeScript decorators are not currently supported:"
+msgstr ""
+
+#: src/language/limitations.md:39
+msgid ""
+"```text\n"
+"// Not supported\n"
+"@Component\n"
+"class MyClass {}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:45
+msgid "No Reflection"
+msgstr ""
+
+#: src/language/limitations.md:47
+msgid "There is no `Reflect` API or runtime type metadata:"
+msgstr ""
+
+#: src/language/limitations.md:50
+msgid ""
+"```text\n"
+"// Not supported\n"
+"Reflect.getMetadata(\"design:type\", target, key);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:55
+msgid "No Dynamic require()"
+msgstr ""
+
+#: src/language/limitations.md:57
+msgid "Only static imports are supported:"
+msgstr ""
+
+#: src/language/limitations.md:60
+msgid ""
+"```text\n"
+"// Supported\n"
+"import { foo } from \"./module\";\n"
+"\n"
+"// Not supported\n"
+"const mod = require(\"./module\");\n"
+"const mod = await import(\"./module\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:69
+msgid "No Prototype Manipulation"
+msgstr ""
+
+#: src/language/limitations.md:71
+msgid ""
+"Perry compiles classes to fixed structures. Dynamic prototype modification "
+"is not supported:"
+msgstr ""
+
+#: src/language/limitations.md:74
+msgid ""
+"```text\n"
+"// Not supported\n"
+"MyClass.prototype.newMethod = function() {};\n"
+"Object.setPrototypeOf(obj, proto);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:80
+msgid "No Symbol Type"
+msgstr ""
+
+#: src/language/limitations.md:82
+msgid "The `Symbol` primitive type is not currently supported:"
+msgstr ""
+
+#: src/language/limitations.md:85
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const sym = Symbol(\"description\");\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:90
+msgid "No WeakMap/WeakRef"
+msgstr ""
+
+#: src/language/limitations.md:92
+msgid "Weak references are not implemented:"
+msgstr ""
+
+#: src/language/limitations.md:95
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const wm = new WeakMap();\n"
+"const wr = new WeakRef(obj);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:101
+msgid "No Proxy"
+msgstr ""
+
+#: src/language/limitations.md:103
+msgid "The `Proxy` object is not supported:"
+msgstr ""
+
+#: src/language/limitations.md:106
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const proxy = new Proxy(target, handler);\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:111
+msgid "Limited Error Types"
+msgstr ""
+
+#: src/language/limitations.md:113
+msgid ""
+"`Error` and basic `throw`/`catch` work, but custom error subclasses have "
+"limited support:"
+msgstr ""
+
+#: src/language/limitations.md:125
+msgid "Threading Model"
+msgstr ""
+
+#: src/language/limitations.md:127
+msgid ""
+"Perry supports real multi-threading via `parallelMap` and `spawn` from "
+"`perry/thread`. See [Multi-Threading](../threading/overview.md)."
+msgstr ""
+
+#: src/language/limitations.md:129
+msgid ""
+"Threads do not share mutable state — closures passed to thread primitives "
+"cannot capture mutable variables (enforced at compile time). Values are "
+"deep-copied across thread boundaries. There is no `SharedArrayBuffer` or "
+"`Atomics`."
+msgstr ""
+
+#: src/language/limitations.md:131
+msgid "No Computed Property Names"
+msgstr ""
+
+#: src/language/limitations.md:133
+msgid "Dynamic property keys in object literals are limited:"
+msgstr ""
+
+#: src/language/limitations.md:136
+msgid ""
+"```text\n"
+"// Supported\n"
+"const key = \"name\";\n"
+"obj[key] = \"value\";\n"
+"\n"
+"// Not supported\n"
+"const obj = { [key]: \"value\" };\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:145
+msgid "npm Package Compatibility"
+msgstr ""
+
+#: src/language/limitations.md:147
+msgid "Not all npm packages work with Perry:"
+msgstr ""
+
+#: src/language/limitations.md:149
+msgid ""
+"**Natively supported**: ~50 popular packages (fastify, mysql2, redis, etc.) "
+"— these are compiled natively. See [Standard "
+"Library](../stdlib/overview.md)."
+msgstr ""
+
+#: src/language/limitations.md:150
+msgid ""
+"**`compilePackages`**: Pure TS/JS packages can be compiled natively via "
+"[configuration](../getting-started/project-config.md)."
+msgstr ""
+
+#: src/language/limitations.md:151
+msgid ""
+"**Not supported**: Packages requiring native addons (`.node` files), "
+"`eval()`, dynamic `require()`, or Node.js internals."
+msgstr ""
+
+#: src/language/limitations.md:153
+msgid "Workarounds"
+msgstr ""
+
+#: src/language/limitations.md:155
+msgid "Dynamic Behavior"
+msgstr ""
+
+#: src/language/limitations.md:157
+msgid ""
+"For cases where you need dynamic behavior, use the JavaScript runtime "
+"fallback:"
+msgstr ""
+
+#: src/language/limitations.md:160
+msgid ""
+"```text\n"
+"import { jsEval } from \"perry/jsruntime\";\n"
+"// Routes specific code through QuickJS for dynamic evaluation\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:165
+msgid "Type Narrowing"
+msgstr ""
+
+#: src/language/limitations.md:167
+msgid "Since there's no runtime type checking, use explicit checks:"
+msgstr ""
+
+#: src/language/limitations.md:169
+msgid ""
+"```typescript\n"
+"function processValue(value: string | number) {\n"
+"    // Instead of relying on type narrowing from generics\n"
+"    if (typeof value === \"string\") {\n"
+"        // String path\n"
+"        console.log(`string path: ${value}`)\n"
+"    } else if (typeof value === \"number\") {\n"
+"        // Number path\n"
+"        console.log(`number path: ${value}`)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/language/limitations.md:184
+msgid "[Supported Features](supported-features.md) — What does work"
+msgstr ""
+
+#: src/language/limitations.md:185
+msgid "[Type System](type-system.md) — How types are handled"
+msgstr ""
+
+#: src/packages/porting.md:1
+msgid "Porting npm Packages"
+msgstr ""
+
+#: src/packages/porting.md:3
+msgid ""
+"**Status: experimental.** This guide — and the [`port-npm-to-perry` "
+"skill](https://github.com/PerryTS/perry/tree/main/.claude/skills/port-npm-"
+"to-perry) that ships alongside it — is a first pass at systematizing what "
+"Perry contributors have been doing ad-hoc. Results will vary by package. "
+"Feedback at [issue #115](https://github.com/PerryTS/perry/issues/115)."
+msgstr ""
+
+#: src/packages/porting.md:5
+msgid ""
+"Perry compiles a practical subset of TypeScript. Most pure TS/JS packages "
+"can be pulled into a native compile via `perry.compilePackages`, but some "
+"will need small patches to avoid the constructs Perry doesn't support. This "
+"page is a field guide for doing that port — by hand, or by driving a coding "
+"agent with the prompt template below."
+msgstr ""
+
+#: src/packages/porting.md:7
+msgid "When porting makes sense"
+msgstr ""
+
+#: src/packages/porting.md:9
+msgid "Situation"
+msgstr ""
+
+#: src/packages/porting.md:9
+msgid "Try this first"
+msgstr ""
+
+#: src/packages/porting.md:11
+msgid "Package uses native addons (`.node` files, `binding.gyp`, `node-gyp`)"
+msgstr ""
+
+#: src/packages/porting.md:11
+msgid ""
+"**Don't port** — no path forward. Find an alternative package or use the "
+"[QuickJS fallback](../stdlib/overview.md#javascript-runtime-fallback)."
+msgstr ""
+
+#: src/packages/porting.md:12
+msgid "Package is pure TS/JS with only light use of dynamic features"
+msgstr ""
+
+#: src/packages/porting.md:12
+msgid ""
+"**Good candidate.** Add to `compilePackages`, patch whatever trips the "
+"compiler."
+msgstr ""
+
+#: src/packages/porting.md:13
+msgid ""
+"Package's core API is built on `Proxy` (ORMs, validation DSLs, reactive "
+"stores)"
+msgstr ""
+
+#: src/packages/porting.md:13
+msgid "**Probably not portable.** The surface Perry-users touch is the Proxy."
+msgstr ""
+
+#: src/packages/porting.md:14
+msgid ""
+"Package is pure TS/JS but uses lookbehind regex, `Symbol`, `WeakMap`, etc."
+msgstr ""
+
+#: src/packages/porting.md:14
+msgid "**Patchable.** See [Common gaps](#common-gaps) below."
+msgstr ""
+
+#: src/packages/porting.md:16
+msgid "The workflow"
+msgstr ""
+
+#: src/packages/porting.md:18
+msgid "1. Add it to `compilePackages`"
+msgstr ""
+
+#: src/packages/porting.md:20
+msgid "In your project's `package.json`:"
+msgstr ""
+
+#: src/packages/porting.md:30
+msgid ""
+"This is what tells Perry to pull the package into the native compile instead"
+" of routing it through a JavaScript runtime. See [Project "
+"Configuration](../getting-started/project-config.md#compilepackages) for the"
+" full semantics — including how first-resolved directories get cached so "
+"transitive copies dedup."
+msgstr ""
+
+#: src/packages/porting.md:32
+msgid "2. Try compiling"
+msgstr ""
+
+#: src/packages/porting.md:38
+msgid ""
+"Most of the time this is where you find out what's actually broken. Compile-"
+"time errors cite a file:line in the package — that's your patch list."
+msgstr ""
+
+#: src/packages/porting.md:40
+msgid "3. Patch the gaps"
+msgstr ""
+
+#: src/packages/porting.md:42
+msgid ""
+"See [Common gaps](#common-gaps) for the typical fixes. Keep patches minimal "
+"and localized — the goal is a clean compile, not a refactor."
+msgstr ""
+
+#: src/packages/porting.md:44
+msgid ""
+"**Record each patch** in a file at your project root (convention: `perry-"
+"patches/<package>.md`) so you can reapply them after `npm install` blows "
+"them away. Until `compilePackages` grows a native patch-file convention, "
+"this is the one bit of maintenance overhead."
+msgstr ""
+
+#: src/packages/porting.md:46
+msgid "4. Re-check after each compile"
+msgstr ""
+
+#: src/packages/porting.md:48
+msgid ""
+"Iterate: compile, patch the next error, compile again. Don't try to catch "
+"everything in a single pass — some errors only surface after earlier ones "
+"are fixed."
+msgstr ""
+
+#: src/packages/porting.md:50
+msgid "Common gaps"
+msgstr ""
+
+#: src/packages/porting.md:52
+msgid ""
+"Perry's [full limitations list](../language/limitations.md) is the canonical"
+" reference. In practice, these are the ones you hit when porting:"
+msgstr ""
+
+#: src/packages/porting.md:54
+msgid "Lookbehind regex"
+msgstr ""
+
+#: src/packages/porting.md:56
+msgid ""
+"Perry uses Rust's `regex` crate, which doesn't support lookbehind (`(?<=…)` "
+"/ `(?<!…)`)."
+msgstr ""
+
+#: src/packages/porting.md:58
+msgid ""
+"```text\n"
+"// Not supported\n"
+"str.match(/(?<=prefix)\\w+/);\n"
+"\n"
+"// Rewrite — capture the prefix and slice\n"
+"const m = str.match(/prefix(\\w+)/);\n"
+"const rest = m ? m[1] : null;\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:67
+msgid "`Symbol`"
+msgstr ""
+
+#: src/packages/porting.md:69
+msgid ""
+"Not supported as a primitive. When a package uses `Symbol` as a sentinel "
+"(the common case — e.g., for unique keys in a registry), swap for a string:"
+msgstr ""
+
+#: src/packages/porting.md:71
+msgid ""
+"```text\n"
+"// Before\n"
+"const REGISTRY_KEY = Symbol(\"registry\");\n"
+"\n"
+"// After\n"
+"const REGISTRY_KEY = \"__pkg_registry__\";\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:79
+msgid ""
+"When `Symbol` is used to implement `Symbol.iterator`/`Symbol.asyncIterator`,"
+" check whether the iteration is actually reached in your use case — often "
+"the class has a `for`\\-loop method alongside the iterator and you can "
+"ignore the iterator path."
+msgstr ""
+
+#: src/packages/porting.md:81
+msgid "`Proxy`, `Reflect`"
+msgstr ""
+
+#: src/packages/porting.md:83
+msgid ""
+"Not supported. These are usually load-bearing for the package's public API, "
+"so porting is often not feasible. If the `Proxy` is only in an optional path"
+" (e.g., dev-mode warnings), delete that branch."
+msgstr ""
+
+#: src/packages/porting.md:85
+msgid "`WeakMap` / `WeakRef` / `FinalizationRegistry`"
+msgstr ""
+
+#: src/packages/porting.md:87
+msgid ""
+"Not implemented. Swap `WeakMap` for a regular `Map` if the GC semantics "
+"aren't critical for correctness (most caches can tolerate this — they'll "
+"just hold references slightly longer)."
+msgstr ""
+
+#: src/packages/porting.md:89
+msgid "Decorators"
+msgstr ""
+
+#: src/packages/porting.md:91
+msgid ""
+"```text\n"
+"// Not supported\n"
+"@Component\n"
+"class Foo {}\n"
+"\n"
+"// Remove the decorator and inline the behavior, or use a factory function\n"
+"const Foo = Component(class Foo {});\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:100
+msgid "Dynamic `require()` / `await import(…)`"
+msgstr ""
+
+#: src/packages/porting.md:102
+msgid ""
+"Perry only supports static imports. If a package branches on `typeof require"
+" !== \"undefined\"` for a Node/browser split, pick the branch that works "
+"natively and delete the other."
+msgstr ""
+
+#: src/packages/porting.md:104
+msgid "Prototype manipulation"
+msgstr ""
+
+#: src/packages/porting.md:106
+msgid ""
+"```text\n"
+"// Not supported\n"
+"Object.setPrototypeOf(obj, proto);\n"
+"MyClass.prototype.newMethod = function() {};\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:112
+msgid ""
+"Usually appears in fallback shims for older runtimes. Often dead code in the"
+" Perry path — just delete it."
+msgstr ""
+
+#: src/packages/porting.md:114
+msgid "Computed property keys in object literals"
+msgstr ""
+
+#: src/packages/porting.md:116
+msgid ""
+"```text\n"
+"// Not supported\n"
+"const obj = { [key]: value };\n"
+"\n"
+"// Rewrite\n"
+"const obj: Record<string, V> = {};\n"
+"obj[key] = value;\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:125
+msgid "Using a coding agent"
+msgstr ""
+
+#: src/packages/porting.md:127
+msgid ""
+"A general coding agent (Claude Code, Cursor, Codex, Aider) can drive most of"
+" this workflow. If you're using a skill-aware agent, invoke the [`port-npm-"
+"to-perry` "
+"skill](https://github.com/PerryTS/perry/tree/main/.claude/skills/port-npm-"
+"to-perry) directly. Otherwise, paste this prompt:"
+msgstr ""
+
+#: src/packages/porting.md:129
+msgid ""
+"```\n"
+"I want to port the npm package <NAME> to run under Perry\n"
+"(https://github.com/PerryTS/perry). Perry compiles a subset of TypeScript\n"
+"natively; the subset's gaps are documented at\n"
+"https://github.com/PerryTS/perry/blob/main/docs/src/language/limitations.md.\n"
+"\n"
+"Please:\n"
+"\n"
+"1. Read the package at node_modules/<NAME>/. Check package.json for\n"
+"   native addons (binding.gyp, gypfile, prebuilds/ — stop if present).\n"
+"2. Scan for unsupported constructs: eval, new Function, dynamic require,\n"
+"   Symbol, Proxy, WeakMap, WeakRef, Reflect, decorators, lookbehind\n"
+"   regex (?<= / ?<!), Object.setPrototypeOf, computed property keys.\n"
+"3. Report a triage: what rules the package out vs. what's patchable.\n"
+"4. If patchable: add the package to perry.compilePackages in\n"
+"   package.json, apply minimal localized patches, and record each\n"
+"   patch in perry-patches/<NAME>.md.\n"
+"5. Verify by running `perry compile` against a small file that imports\n"
+"   the package.\n"
+"\n"
+"Don't patch blindly — a grep hit inside a string or comment isn't real.\n"
+"Show me the triage before applying substantial patches.\n"
+"```"
+msgstr ""
+
+#: src/packages/porting.md:153
+msgid ""
+"This is intentionally an agent-agnostic prompt — it'll work with any "
+"competent coding agent. The skill version bundles the same instructions with"
+" richer context and is auto-discovered by Claude Code."
+msgstr ""
+
+#: src/packages/porting.md:155
+msgid "Giving feedback"
+msgstr ""
+
+#: src/packages/porting.md:157
+msgid ""
+"This whole workflow is experimental. If a port fails in a way that feels "
+"like Perry should handle it — or if the guide misses a common gap — please "
+"comment on [issue #115](https://github.com/PerryTS/perry/issues/115) so we "
+"can iterate."
+msgstr ""
+
+#: src/threading/overview.md:3
+msgid ""
+"Perry gives you real OS threads with a one-line API. No worker setup, no "
+"message ports, no structured clone overhead. Just `parallelMap`, "
+"`parallelFilter`, and `spawn`."
+msgstr ""
+
+#: src/threading/overview.md:5
+msgid ""
+"```typescript\n"
+"async function overviewHeader(): Promise<void> {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"    const records = [\n"
+"        { score: 50, id: 1 },\n"
+"        { score: 90, id: 2 },\n"
+"        { score: 85, id: 3 },\n"
+"    ]\n"
+"    const threshold = 80\n"
+"\n"
+"    // Process a million items across all CPU cores\n"
+"    const results = parallelMap(data, (item: number) => item * item)\n"
+"\n"
+"    // Filter a large dataset in parallel\n"
+"    const valid = parallelFilter(records, (r: { score: number; id: number }) => r.score > threshold)\n"
+"\n"
+"    // Run expensive work in the background\n"
+"    const answer = await spawn(() => {\n"
+"        let acc = 0\n"
+"        for (let i = 0; i < 100_000; i++) acc += i\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    console.log(`overview-header results=${results.length} valid=${valid.length} answer=${answer}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:32
+msgid ""
+"This is something **no JavaScript runtime can do**. V8, Bun, and Deno are "
+"all locked to one thread per isolate. Perry compiles to native code — there "
+"are no isolates, no GIL, no structural limitations. Your code runs on real "
+"OS threads with the full power of every CPU core."
+msgstr ""
+
+#: src/threading/overview.md:34
+msgid "Why This Matters"
+msgstr ""
+
+#: src/threading/overview.md:36
+msgid ""
+"JavaScript's single-threaded model is its biggest performance bottleneck. "
+"Here's how runtimes try to work around it:"
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "Runtime"
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "\"Multi-threading\""
+msgstr ""
+
+#: src/threading/overview.md:38
+msgid "Reality"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid "**Node.js**"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid "`worker_threads`"
+msgstr ""
+
+#: src/threading/overview.md:40
+msgid ""
+"Separate V8 isolates. Data copied via structured clone. ~2MB RAM per worker."
+" Complex API."
+msgstr ""
+
+#: src/threading/overview.md:41
+msgid "**Deno**"
+msgstr ""
+
+#: src/threading/overview.md:41 src/threading/overview.md:42
+msgid "`Worker`"
+msgstr ""
+
+#: src/threading/overview.md:41
+msgid "Same as Node — isolated heaps, message passing only."
+msgstr ""
+
+#: src/threading/overview.md:42
+msgid "**Bun**"
+msgstr ""
+
+#: src/threading/overview.md:42
+msgid "Same architecture. Faster structured clone, still isolated."
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid "**Perry**"
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid "`parallelMap` / `spawn`"
+msgstr ""
+
+#: src/threading/overview.md:43
+msgid ""
+"Real OS threads. Lightweight (8MB stack). One-line API. Compile-time safety."
+msgstr ""
+
+#: src/threading/overview.md:45
+msgid ""
+"The fundamental problem: V8 uses a garbage-collected heap that **cannot be "
+"shared** between threads. Every \"worker\" is an entirely separate "
+"JavaScript engine instance with its own heap, its own GC, and its own copy "
+"of your data."
+msgstr ""
+
+#: src/threading/overview.md:47
+msgid ""
+"Perry doesn't have this limitation. It compiles TypeScript to native machine"
+" code. Values are transferred between threads using zero-cost copies for "
+"numbers and efficient serialization for objects — no separate engine "
+"instances, no multi-megabyte overhead per thread."
+msgstr ""
+
+#: src/threading/overview.md:49
+msgid "Three Primitives"
+msgstr ""
+
+#: src/threading/overview.md:51
+msgid "`parallelMap` — Data-Parallel Processing"
+msgstr ""
+
+#: src/threading/overview.md:53
+msgid ""
+"Split an array across all CPU cores. Each element is processed "
+"independently. Results are collected in order."
+msgstr ""
+
+#: src/threading/overview.md:55
+msgid ""
+"```typescript\n"
+"async function overviewParallelMap(): Promise<void> {\n"
+"    const prices = [100, 200, 300, 400, 500, 600, 700, 800]\n"
+"    const adjusted = parallelMap(prices, (price: number) => {\n"
+"        // Heavy computation runs on a worker thread\n"
+"        let result = price\n"
+"        for (let i = 0; i < 1000000; i++) {\n"
+"            result = Math.sqrt(result * result + i)\n"
+"        }\n"
+"        return result\n"
+"    })\n"
+"\n"
+"    console.log(`overview-parallel-map len=${adjusted.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:71 src/plugins/creating-plugins.md:37
+msgid "Perry automatically:"
+msgstr ""
+
+#: src/threading/overview.md:72
+msgid "Detects the number of CPU cores"
+msgstr ""
+
+#: src/threading/overview.md:73
+msgid "Splits the array into chunks (one per core)"
+msgstr ""
+
+#: src/threading/overview.md:74
+msgid "Spawns OS threads to process each chunk"
+msgstr ""
+
+#: src/threading/overview.md:75
+msgid "Collects results in the original order"
+msgstr ""
+
+#: src/threading/overview.md:76
+msgid "Returns a new array"
+msgstr ""
+
+#: src/threading/overview.md:78
+msgid ""
+"For small arrays, Perry skips threading entirely and processes inline — no "
+"overhead for trivial cases."
+msgstr ""
+
+#: src/threading/overview.md:80
+msgid "`parallelFilter` — Data-Parallel Filtering"
+msgstr ""
+
+#: src/threading/overview.md:82
+msgid ""
+"Filter a large array across all CPU cores. Like `.filter()` but parallel:"
+msgstr ""
+
+#: src/threading/overview.md:84
+msgid ""
+"```typescript\n"
+"async function overviewParallelFilter(): Promise<void> {\n"
+"    const cutoffDate = 1_700_000_000\n"
+"    const users = [\n"
+"        { lastLogin: 1_710_000_000, score: 150, name: \"alice\" },\n"
+"        { lastLogin: 1_690_000_000, score: 50, name: \"bob\" },\n"
+"        { lastLogin: 1_720_000_000, score: 120, name: \"carol\" },\n"
+"    ]\n"
+"\n"
+"    // Filter across all cores — order is preserved\n"
+"    const active = parallelFilter(users, (user: { lastLogin: number; score: number; name: string }) => {\n"
+"        return user.lastLogin > cutoffDate && user.score > 100\n"
+"    })\n"
+"\n"
+"    console.log(`overview-parallel-filter active=${active.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:102
+msgid ""
+"Same rules as `parallelMap`: closures cannot capture mutable variables "
+"(compile-time enforced), and values are deep-copied between threads."
+msgstr ""
+
+#: src/threading/overview.md:104
+msgid "`spawn` — Background Threads"
+msgstr ""
+
+#: src/threading/overview.md:106
+msgid ""
+"Run any computation in the background and get a Promise back. The main "
+"thread continues immediately."
+msgstr ""
+
+#: src/threading/overview.md:108
+msgid ""
+"```typescript\n"
+"async function overviewSpawnBg(): Promise<void> {\n"
+"    // Start heavy work in the background\n"
+"    const handle = spawn(() => {\n"
+"        let sum = 0\n"
+"        for (let i = 0; i < 100_000; i++) {\n"
+"            sum += Math.sin(i)\n"
+"        }\n"
+"        return sum\n"
+"    })\n"
+"\n"
+"    // Main thread keeps running — UI stays responsive\n"
+"    console.log(\"Computing...\")\n"
+"\n"
+"    // Get the result when you need it\n"
+"    const result = await handle\n"
+"    console.log(`Done: len=${typeof result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:128
+msgid ""
+"`spawn` returns a standard Promise. You can `await` it, pass it to "
+"`Promise.all`, or chain `.then()` — it works exactly like any other async "
+"operation."
+msgstr ""
+
+#: src/threading/overview.md:130
+msgid "Practical Examples"
+msgstr ""
+
+#: src/threading/overview.md:132
+msgid "Parallel Image Processing"
+msgstr ""
+
+#: src/threading/overview.md:134
+msgid ""
+"```typescript\n"
+"async function overviewImage(): Promise<void> {\n"
+"    const pixels = [\n"
+"        { r: 100, g: 120, b: 140 },\n"
+"        { r: 50, g: 60, b: 70 },\n"
+"        { r: 200, g: 210, b: 220 },\n"
+"    ]\n"
+"\n"
+"    // Each pixel processed on a separate core\n"
+"    const processed = parallelMap(pixels, (pixel: { r: number; g: number; b: number }) => {\n"
+"        const r = Math.min(255, pixel.r * 1.2)\n"
+"        const g = Math.min(255, pixel.g * 0.8)\n"
+"        const b = Math.min(255, pixel.b * 1.1)\n"
+"        return { r, g, b }\n"
+"    })\n"
+"\n"
+"    console.log(`overview-image processed=${processed.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:154
+msgid "Parallel Cryptographic Hashing"
+msgstr ""
+
+#: src/threading/overview.md:156
+msgid ""
+"```typescript\n"
+"async function overviewCrypto(): Promise<void> {\n"
+"    // Hash thousands of items across all cores\n"
+"    const passwords = [\"pass1\", \"pass2\", \"pass3\"]\n"
+"    const hashed = parallelMap(passwords, (password: string) => {\n"
+"        // Stand-in for a real hash: deterministic FNV-1a over the bytes.\n"
+"        let h = 2166136261\n"
+"        for (let i = 0; i < password.length; i++) {\n"
+"            h ^= password.charCodeAt(i)\n"
+"            h = (h * 16777619) >>> 0\n"
+"        }\n"
+"        return h\n"
+"    })\n"
+"\n"
+"    console.log(`overview-crypto hashed=${hashed.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:174
+msgid "Multiple Independent Computations"
+msgstr ""
+
+#: src/threading/overview.md:176
+msgid ""
+"```typescript\n"
+"async function overviewMultiple(): Promise<void> {\n"
+"    const dataA = [1, 2, 3]\n"
+"    const dataB = [4, 5, 6]\n"
+"    const dataC = [7, 8, 9]\n"
+"\n"
+"    // Three independent tasks run simultaneously on three OS threads\n"
+"    const task1 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataA) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"    const task2 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataB) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"    const task3 = spawn(() => {\n"
+"        let acc = 0\n"
+"        for (const v of dataC) acc += v * v\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    // All three run concurrently\n"
+"    const [result1, result2, result3] = await Promise.all([task1, task2, task3])\n"
+"    console.log(`overview-multiple ${result1} ${result2} ${result3}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:205
+msgid "Keeping UI Responsive"
+msgstr ""
+
+#: src/threading/overview.md:207
+msgid ""
+"```typescript\n"
+"const responsiveButton = Button(\"Start Analysis\", async () => {\n"
+"    status.set(\"Analyzing...\")\n"
+"\n"
+"    // Heavy computation runs on a background thread\n"
+"    // UI stays responsive — user can still interact\n"
+"    const value = await spawn(() => {\n"
+"        let acc = 0\n"
+"        for (let i = 0; i < 1_000_000; i++) acc += i\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    status.set(`Done: ${value}`)\n"
+"})\n"
+"\n"
+"const responsiveText = Text(`Status: ${status.value}`)\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:225
+msgid "Captured Variables"
+msgstr ""
+
+#: src/threading/overview.md:227
+msgid ""
+"Closures can capture outer variables. Captured values are automatically "
+"deep-copied to each worker thread:"
+msgstr ""
+
+#: src/threading/overview.md:229
+msgid ""
+"```typescript\n"
+"async function overviewCaptured(): Promise<void> {\n"
+"    const prices = [100, 200, 300, 400]\n"
+"    const taxRate = 0.08\n"
+"    const discount = 0.15\n"
+"\n"
+"    // taxRate and discount are captured and copied to each thread\n"
+"    const finalPrices = parallelMap(prices, (price: number) => {\n"
+"        const discounted = price * (1 - discount)\n"
+"        return discounted * (1 + taxRate)\n"
+"    })\n"
+"\n"
+"    console.log(`overview-captured len=${finalPrices.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:245
+msgid ""
+"Numbers and booleans are zero-cost copies (just 64-bit values). Strings, "
+"arrays, and objects are deep-copied automatically."
+msgstr ""
+
+#: src/threading/overview.md:247
+msgid "Safety"
+msgstr ""
+
+#: src/threading/overview.md:249
+msgid ""
+"Perry enforces thread safety **at compile time**. You don't need to think "
+"about race conditions, mutexes, or data corruption."
+msgstr ""
+
+#: src/threading/overview.md:251
+msgid "No Shared Mutable State"
+msgstr ""
+
+#: src/threading/overview.md:253
+msgid ""
+"Closures passed to `parallelMap` and `spawn` **cannot capture mutable "
+"variables**. The compiler rejects this:"
+msgstr ""
+
+#: src/threading/overview.md:255
+msgid ""
+"```text\n"
+"// Reject example — Perry rejects this at compile time:\n"
+"\n"
+"let counter = 0;\n"
+"\n"
+"// COMPILE ERROR: Closures passed to parallelMap cannot\n"
+"// capture mutable variable 'counter'\n"
+"parallelMap(data, (item) => {\n"
+"    counter++;  // Not allowed\n"
+"    return item;\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:268
+msgid ""
+"This eliminates data races by design. If you need to aggregate results, use "
+"the return values:"
+msgstr ""
+
+#: src/threading/overview.md:270
+msgid ""
+"```typescript\n"
+"async function overviewReduceInstead(): Promise<void> {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    // Instead of mutating a shared counter, return values and reduce\n"
+"    const results = parallelMap(data, (item: number) => item * item)\n"
+"    const total = results.reduce((sum: number, r: number) => sum + r, 0)\n"
+"\n"
+"    console.log(`overview-reduce-instead total=${total}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/overview.md:282
+msgid "Independent Thread Arenas"
+msgstr ""
+
+#: src/threading/overview.md:284
+msgid ""
+"Each worker thread has its own memory arena. Objects created on one thread "
+"can never be accessed from another thread. Values cross thread boundaries "
+"only through deep-copy serialization, which Perry handles automatically and "
+"invisibly."
+msgstr ""
+
+#: src/threading/overview.md:288
+msgid "Perry's threading model is built on three pillars:"
+msgstr ""
+
+#: src/threading/overview.md:290
+msgid "**1. Native Code, Not Interpreted**"
+msgstr ""
+
+#: src/threading/overview.md:292
+msgid ""
+"Perry compiles TypeScript to native machine code via LLVM. There's no "
+"interpreter, no VM, no isolate. A function pointer is just a function "
+"pointer — it's valid on any thread."
+msgstr ""
+
+#: src/threading/overview.md:294
+msgid "**2. Thread-Local Memory**"
+msgstr ""
+
+#: src/threading/overview.md:296
+msgid ""
+"Each thread gets its own memory arena (bump allocator) and garbage "
+"collector. No synchronization overhead during computation. When a thread "
+"finishes, its arena is freed automatically."
+msgstr ""
+
+#: src/threading/overview.md:298
+msgid "**3. Serialized Transfer**"
+msgstr ""
+
+#: src/threading/overview.md:300
+msgid ""
+"Values crossing thread boundaries are serialized to a thread-safe "
+"intermediate format and deserialized on the target thread. The cost depends "
+"on the value type:"
+msgstr ""
+
+#: src/threading/overview.md:302
+msgid "Value Type"
+msgstr ""
+
+#: src/threading/overview.md:302
+msgid "Transfer Cost"
+msgstr ""
+
+#: src/threading/overview.md:304
+msgid "Numbers, booleans, null, undefined"
+msgstr ""
+
+#: src/threading/overview.md:304 src/threading/parallel-map.md:55
+msgid "Zero-cost (64-bit copy)"
+msgstr ""
+
+#: src/threading/overview.md:305 src/threading/parallel-map.md:57
+msgid "Strings"
+msgstr ""
+
+#: src/threading/overview.md:305
+msgid "O(n) byte copy"
+msgstr ""
+
+#: src/threading/overview.md:306
+msgid "O(n) deep copy of elements"
+msgstr ""
+
+#: src/threading/overview.md:307
+msgid "O(n) deep copy of fields"
+msgstr ""
+
+#: src/threading/overview.md:308
+msgid "Pointer + captured values"
+msgstr ""
+
+#: src/threading/overview.md:310
+msgid ""
+"For numeric workloads — the most common parallelizable tasks — the threading"
+" overhead is negligible."
+msgstr ""
+
+#: src/threading/overview.md:314
+msgid ""
+"[parallelMap Reference](parallel-map.md) — detailed API and performance tips"
+msgstr ""
+
+#: src/threading/overview.md:315
+msgid ""
+"[parallelFilter Reference](parallel-filter.md) — parallel array filtering"
+msgstr ""
+
+#: src/threading/overview.md:316
+msgid ""
+"[spawn Reference](spawn.md) — background threads and Promise integration"
+msgstr ""
+
+#: src/threading/parallel-map.md:3
+msgid ""
+"**Signature**: `parallelMap<T, U>(data: T[], fn: (item: T) => U): U[]` — "
+"imported from `perry/thread`."
+msgstr ""
+
+#: src/threading/parallel-map.md:5
+msgid ""
+"Processes every element of an array in parallel across all available CPU "
+"cores. Returns a new array with the results in the same order as the input."
+msgstr ""
+
+#: src/threading/parallel-map.md:7 src/threading/parallel-filter.md:7
+#: src/threading/spawn.md:7
+msgid "Basic Usage"
+msgstr ""
+
+#: src/threading/parallel-map.md:9
+msgid ""
+"```typescript\n"
+"function parallelMapBasic(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"    const doubled = parallelMap(numbers, (x: number) => x * 2)\n"
+"    // [2, 4, 6, 8, 10, 12, 14, 16]\n"
+"    console.log(`parallel-map-basic len=${doubled.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:31
+msgid ""
+"Perry automatically detects the number of CPU cores and splits the array "
+"into equal chunks. Elements within each chunk are processed sequentially; "
+"chunks run concurrently across cores."
+msgstr ""
+
+#: src/threading/parallel-map.md:33 src/threading/parallel-filter.md:53
+#: src/threading/spawn.md:80
+msgid "Capturing Variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:35
+msgid ""
+"The mapping function can reference variables from the outer scope. Captured "
+"values are deep-copied to each worker thread automatically:"
+msgstr ""
+
+#: src/threading/parallel-map.md:37
+msgid ""
+"```typescript\n"
+"function parallelMapCapture(): void {\n"
+"    const prices = [100, 200, 300]\n"
+"    const exchangeRate = 1.12\n"
+"\n"
+"    const converted = parallelMap(prices, (price: number) => {\n"
+"        // exchangeRate is captured and copied to each thread\n"
+"        return price * exchangeRate\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-capture len=${converted.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:51
+msgid "What Can Be Captured"
+msgstr ""
+
+#: src/threading/parallel-map.md:53 src/ui/overview.md:57 src/ui/styling.md:45
+#: src/widgets/creating-widgets.md:45 src/widgets/configuration.md:70
+#: src/testing/geisterhand.md:84 src/cli/flags.md:43 src/cli/perry-toml.md:114
+#: src/cli/perry-toml.md:125 src/cli/perry-toml.md:153
+#: src/cli/perry-toml.md:165 src/cli/perry-toml.md:175
+#: src/cli/perry-toml.md:181 src/cli/perry-toml.md:191
+#: src/cli/perry-toml.md:241 src/cli/perry-toml.md:254
+#: src/cli/perry-toml.md:260 src/cli/perry-toml.md:268
+#: src/cli/perry-toml.md:299 src/cli/perry-toml.md:310
+#: src/cli/perry-toml.md:327 src/cli/perry-toml.md:345
+#: src/cli/perry-toml.md:357 src/cli/perry-toml.md:367
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414 src/contributing/architecture.md:47
+msgid "Type"
+msgstr ""
+
+#: src/threading/parallel-map.md:53
+msgid "Supported"
+msgstr ""
+
+#: src/threading/parallel-map.md:53
+msgid "Transfer"
+msgstr ""
+
+#: src/threading/parallel-map.md:55
+msgid "Numbers"
+msgstr ""
+
+#: src/threading/parallel-map.md:55 src/threading/parallel-map.md:56
+#: src/threading/parallel-map.md:57 src/threading/parallel-map.md:58
+#: src/threading/parallel-map.md:59 src/threading/parallel-map.md:60
+#: src/platforms/overview.md:69 src/platforms/overview.md:70
+#: src/platforms/overview.md:71 src/platforms/overview.md:72
+#: src/platforms/overview.md:73 src/platforms/overview.md:74
+#: src/platforms/overview.md:75 src/widgets/platforms.md:22
+#: src/widgets/platforms.md:23 src/widgets/platforms.md:24
+#: src/widgets/platforms.md:25 src/widgets/platforms.md:26
+#: src/widgets/platforms.md:27 src/widgets/platforms.md:28
+#: src/widgets/platforms.md:29 src/widgets/platforms.md:30
+#: src/widgets/platforms.md:31 src/widgets/platforms.md:32
+#: src/widgets/platforms.md:33
+msgid "Yes"
+msgstr ""
+
+#: src/threading/parallel-map.md:56
+msgid "Booleans"
+msgstr ""
+
+#: src/threading/parallel-map.md:56
+msgid "Zero-cost"
+msgstr ""
+
+#: src/threading/parallel-map.md:57
+msgid "Byte copy"
+msgstr ""
+
+#: src/threading/parallel-map.md:58 src/threading/parallel-map.md:59
+msgid "Deep copy"
+msgstr ""
+
+#: src/threading/parallel-map.md:60
+msgid "`const` variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:60 src/threading/parallel-map.md:61
+msgid "Copied"
+msgstr ""
+
+#: src/threading/parallel-map.md:61
+msgid "`let`/`var` variables"
+msgstr ""
+
+#: src/threading/parallel-map.md:61
+msgid "Only if not reassigned"
+msgstr ""
+
+#: src/threading/parallel-map.md:63
+msgid "What Cannot Be Captured"
+msgstr ""
+
+#: src/threading/parallel-map.md:65
+msgid ""
+"Mutable variables — variables that are reassigned anywhere in the enclosing "
+"scope — are rejected at compile time:"
+msgstr ""
+
+#: src/threading/parallel-map.md:67
+msgid ""
+"```text\n"
+"// Reject example — Perry rejects this at compile time:\n"
+"\n"
+"let total = 0;\n"
+"\n"
+"// COMPILE ERROR: Cannot capture mutable variable 'total'\n"
+"parallelMap(data, (item) => {\n"
+"    total += item;   // Would be a data race\n"
+"    return item;\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:79
+msgid "Instead, return values and reduce:"
+msgstr ""
+
+#: src/threading/parallel-map.md:90 src/threading/parallel-filter.md:155
+msgid "Performance"
+msgstr ""
+
+#: src/threading/parallel-map.md:92
+msgid "When to Use parallelMap"
+msgstr ""
+
+#: src/threading/parallel-map.md:94
+msgid ""
+"Use `parallelMap` when the computation per element is **significantly "
+"heavier** than the cost of copying the element across threads."
+msgstr ""
+
+#: src/threading/parallel-map.md:96
+msgid "**Good candidates** (CPU-bound work per element):"
+msgstr ""
+
+#: src/threading/parallel-map.md:98
+msgid ""
+"```typescript\n"
+"function parallelMapGoodCandidates(): void {\n"
+"    const data = [1.0, 2.0, 3.0, 4.0]\n"
+"    const documents = [\"alpha beta\", \"gamma delta\", \"epsilon\"]\n"
+"    const inputs = [\"a\", \"bb\", \"ccc\"]\n"
+"\n"
+"    // Heavy math\n"
+"    const out1 = parallelMap(data, (x: number) => {\n"
+"        let acc = x\n"
+"        for (let i = 0; i < 1_000; i++) acc = Math.sqrt(acc * acc + i)\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    // String processing on large strings\n"
+"    const out2 = parallelMap(documents, (doc: string) => {\n"
+"        const words = doc.split(\" \")\n"
+"        return { count: words.length, first: words[0] }\n"
+"    })\n"
+"\n"
+"    // Cryptographic operations\n"
+"    const out3 = parallelMap(inputs, (input: string) => {\n"
+"        let h = 0\n"
+"        for (let i = 0; i < input.length; i++) h = (h * 31 + input.charCodeAt(i)) >>> 0\n"
+"        return h\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-good-candidates ${out1.length} ${out2.length} ${out3.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:128
+msgid "**Poor candidates** (trivial work per element):"
+msgstr ""
+
+#: src/threading/parallel-map.md:130
+msgid ""
+"```typescript\n"
+"function parallelMapPoorCandidate(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5]\n"
+"\n"
+"    // Too simple — threading overhead outweighs the gain\n"
+"    const a = parallelMap(numbers, (x: number) => x + 1)\n"
+"\n"
+"    // For trivial operations, use regular map\n"
+"    const result = numbers.map((x: number) => x + 1)\n"
+"\n"
+"    console.log(`parallel-map-poor-candidate ${a.length} ${result.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:144
+msgid "Small Array Optimization"
+msgstr ""
+
+#: src/threading/parallel-map.md:146
+msgid ""
+"For arrays with fewer elements than CPU cores, Perry skips threading "
+"entirely and processes elements inline on the main thread. There's zero "
+"overhead for small inputs."
+msgstr ""
+
+#: src/threading/parallel-map.md:148
+msgid "Numeric Fast Path"
+msgstr ""
+
+#: src/threading/parallel-map.md:150
+msgid ""
+"When elements are pure numbers (no strings, objects, or arrays), Perry "
+"transfers them between threads at virtually zero cost — just 64-bit value "
+"copies with no serialization."
+msgstr ""
+
+#: src/threading/parallel-map.md:152 src/threading/parallel-filter.md:78
+#: src/threading/spawn.md:183 src/cli/flags.md:139
+msgid "Examples"
+msgstr ""
+
+#: src/threading/parallel-map.md:154
+msgid "Matrix Row Processing"
+msgstr ""
+
+#: src/threading/parallel-map.md:156
+msgid ""
+"```typescript\n"
+"function parallelMapMatrix(): void {\n"
+"    // Process each row of a matrix independently\n"
+"    const rows = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]\n"
+"    const rowSums = parallelMap(rows, (row: number[]) => {\n"
+"        let sum = 0\n"
+"        for (const val of row) sum += val\n"
+"        return sum\n"
+"    })\n"
+"    // [6, 15, 24]\n"
+"    console.log(`parallel-map-matrix sums=${rowSums[0]},${rowSums[1]},${rowSums[2]}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:170
+msgid "Batch Validation"
+msgstr ""
+
+#: src/threading/parallel-map.md:172
+msgid ""
+"```typescript\n"
+"function parallelMapValidation(): void {\n"
+"    const users = [\n"
+"        { name: \"Alice\", email: \"alice@example.com\" },\n"
+"        { name: \"Bob\", email: \"invalid\" },\n"
+"        { name: \"Charlie\", email: \"charlie@example.com\" },\n"
+"    ]\n"
+"\n"
+"    const validationResults = parallelMap(users, (user: { name: string; email: string }) => {\n"
+"        const emailValid = user.email.includes(\"@\") && user.email.includes(\".\")\n"
+"        const nameValid = user.name.length > 0 && user.name.length < 100\n"
+"        return { name: user.name, valid: emailValid && nameValid }\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-validation len=${validationResults.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-map.md:190
+msgid "Financial Calculations"
+msgstr ""
+
+#: src/threading/parallel-map.md:192
+msgid ""
+"```typescript\n"
+"function parallelMapMonteCarlo(): void {\n"
+"    const portfolios = [\n"
+"        { id: 1, base: 100 },\n"
+"        { id: 2, base: 200 },\n"
+"        { id: 3, base: 150 },\n"
+"    ] // thousands of portfolios\n"
+"\n"
+"    // Monte Carlo simulation across all cores\n"
+"    const riskScores = parallelMap(portfolios, (portfolio: { id: number; base: number }) => {\n"
+"        let totalRisk = 0\n"
+"        for (let sim = 0; sim < 1000; sim++) {\n"
+"            // simulateReturns stand-in: deterministic pseudo-random walk.\n"
+"            let s = portfolio.base + sim\n"
+"            s = ((s * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff\n"
+"            totalRisk += s\n"
+"        }\n"
+"        return totalRisk / 1000\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-map-monte-carlo len=${riskScores.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:3
+msgid ""
+"**Signature**: `parallelFilter<T>(data: T[], predicate: (item: T) => "
+"boolean): T[]` — imported from `perry/thread`."
+msgstr ""
+
+#: src/threading/parallel-filter.md:5
+msgid ""
+"Filters an array in parallel across all available CPU cores. Returns a new "
+"array containing only the elements where the predicate returned a truthy "
+"value. Order is preserved."
+msgstr ""
+
+#: src/threading/parallel-filter.md:9
+msgid ""
+"```typescript\n"
+"function parallelFilterBasic(): void {\n"
+"    const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n"
+"    const evens = parallelFilter(numbers, (x: number) => x % 2 === 0)\n"
+"    // [2, 4, 6, 8, 10]\n"
+"    console.log(`parallel-filter-basic len=${evens.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:31
+msgid ""
+"Each core independently tests its chunk of elements. Results are merged in "
+"the original element order after all threads complete."
+msgstr ""
+
+#: src/threading/parallel-filter.md:33
+msgid "Why Not Just Use `.filter()`?"
+msgstr ""
+
+#: src/threading/parallel-filter.md:35
+msgid ""
+"Regular `.filter()` runs on a single thread. For large arrays with expensive"
+" predicates, `parallelFilter` distributes the work:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:37
+msgid ""
+"```typescript\n"
+"function parallelFilterVsFilter(): void {\n"
+"    const data = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    // Single-threaded — one core does all the work\n"
+"    const a = data.filter((item: number) => item > 3)\n"
+"\n"
+"    // Parallel — all cores share the work\n"
+"    const b = parallelFilter(data, (item: number) => item > 3)\n"
+"\n"
+"    console.log(`parallel-filter-vs-filter ${a.length} ${b.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:51
+msgid ""
+"The tradeoff: `parallelFilter` has overhead from copying values between "
+"threads. Use it when the predicate is expensive enough to justify that cost."
+msgstr ""
+
+#: src/threading/parallel-filter.md:55
+msgid ""
+"Like `parallelMap`, the predicate can capture outer variables. Captures are "
+"deep-copied to each thread:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:57
+msgid ""
+"```typescript\n"
+"function parallelFilterCapture(): void {\n"
+"    const candidates = [\n"
+"        { name: \"Alice\", score: 90, age: 28 },\n"
+"        { name: \"Bob\", score: 80, age: 35 },\n"
+"        { name: \"Carol\", score: 95, age: 25 },\n"
+"    ]\n"
+"    const minScore = 85\n"
+"    const maxAge = 30\n"
+"\n"
+"    // minScore and maxAge are captured and copied to each thread\n"
+"    const qualified = parallelFilter(candidates, (c: { name: string; score: number; age: number }) => {\n"
+"        return c.score >= minScore && c.age <= maxAge\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-capture len=${qualified.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:76
+msgid ""
+"Mutable variables cannot be captured — the compiler rejects this at compile "
+"time."
+msgstr ""
+
+#: src/threading/parallel-filter.md:80
+msgid "Filtering Large Datasets"
+msgstr ""
+
+#: src/threading/parallel-filter.md:82
+msgid ""
+"```typescript\n"
+"function parallelFilterLarge(): void {\n"
+"    // Stand-in for \"millions of records\" — same shape, smaller list.\n"
+"    const transactions = [\n"
+"        { amount: 15000, country: \"US\", user: { homeCountry: \"DE\" }, timestamp: { hour: 4 } },\n"
+"        { amount: 200, country: \"DE\", user: { homeCountry: \"DE\" }, timestamp: { hour: 12 } },\n"
+"        { amount: 50000, country: \"FR\", user: { homeCountry: \"DE\" }, timestamp: { hour: 3 } },\n"
+"    ]\n"
+"\n"
+"    const suspicious = parallelFilter(transactions, (tx: {\n"
+"        amount: number\n"
+"        country: string\n"
+"        user: { homeCountry: string }\n"
+"        timestamp: { hour: number }\n"
+"    }) => {\n"
+"        return tx.amount > 10000\n"
+"            && tx.country !== tx.user.homeCountry\n"
+"            && tx.timestamp.hour < 6\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-large len=${suspicious.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:106
+msgid "Combined with parallelMap"
+msgstr ""
+
+#: src/threading/parallel-filter.md:108
+msgid ""
+"```typescript\n"
+"function parallelFilterCombined(): void {\n"
+"    const users = [\n"
+"        { name: \"Alice\", isActive: true, age: 28, score: 90 },\n"
+"        { name: \"Bob\", isActive: false, age: 35, score: 80 },\n"
+"        { name: \"Carol\", isActive: true, age: 17, score: 95 },\n"
+"        { name: \"Dave\", isActive: true, age: 40, score: 60 },\n"
+"    ]\n"
+"\n"
+"    // Step 1: Filter to relevant items (parallel)\n"
+"    const active = parallelFilter(users, (u: { isActive: boolean; age: number }) => u.isActive && u.age >= 18)\n"
+"\n"
+"    // Step 2: Transform the filtered results (parallel)\n"
+"    const profiles = parallelMap(active, (u: { name: string; score: number }) => ({\n"
+"        name: u.name,\n"
+"        score: u.score * 2,\n"
+"    }))\n"
+"\n"
+"    console.log(`parallel-filter-combined active=${active.length} profiles=${profiles.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:130
+msgid "Predicate with Heavy Computation"
+msgstr ""
+
+#: src/threading/parallel-filter.md:132
+msgid ""
+"```typescript\n"
+"function parallelFilterHeavy(): void {\n"
+"    const certificates = [\n"
+"        { id: 1, fingerprint: \"aa\", revoked: false },\n"
+"        { id: 2, fingerprint: \"bb\", revoked: true },\n"
+"        { id: 3, fingerprint: \"cc\", revoked: false },\n"
+"    ]\n"
+"\n"
+"    // Each predicate call does significant work — perfect for parallelization.\n"
+"    const valid = parallelFilter(certificates, (cert: { id: number; fingerprint: string; revoked: boolean }) => {\n"
+"        // Stand-in for a real chain verification: hash the fingerprint a bit\n"
+"        // then sanity-check the revocation flag.\n"
+"        let h = 0\n"
+"        for (let i = 0; i < cert.fingerprint.length; i++) {\n"
+"            h = (h * 31 + cert.fingerprint.charCodeAt(i)) >>> 0\n"
+"        }\n"
+"        return h !== 0 && !cert.revoked\n"
+"    })\n"
+"\n"
+"    console.log(`parallel-filter-heavy len=${valid.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/parallel-filter.md:157
+msgid "Use `parallelFilter` when:"
+msgstr ""
+
+#: src/threading/parallel-filter.md:158
+msgid "The array has many elements (hundreds or more)"
+msgstr ""
+
+#: src/threading/parallel-filter.md:159
+msgid "The predicate function does meaningful work per element"
+msgstr ""
+
+#: src/threading/parallel-filter.md:160
+msgid "You need to keep the UI responsive during filtering"
+msgstr ""
+
+#: src/threading/parallel-filter.md:162
+msgid ""
+"For trivial predicates on small arrays, regular `.filter()` is faster (no "
+"threading overhead)."
+msgstr ""
+
+#: src/threading/spawn.md:3
+msgid ""
+"**Signature**: `spawn<T>(fn: () => T): Promise<T>` — imported from "
+"`perry/thread`."
+msgstr ""
+
+#: src/threading/spawn.md:5
+msgid ""
+"Runs a closure on a new OS thread and returns a Promise that resolves when "
+"the thread completes. The main thread continues immediately — UI and other "
+"work are not blocked."
+msgstr ""
+
+#: src/threading/spawn.md:9
+msgid ""
+"```typescript\n"
+"async function spawnBasic(): Promise<void> {\n"
+"    const result = await spawn(() => {\n"
+"        // This runs on a separate OS thread.\n"
+"        let sum = 0\n"
+"        for (let i = 0; i < 100_000_000; i++) {\n"
+"            sum += i\n"
+"        }\n"
+"        return sum\n"
+"    })\n"
+"\n"
+"    console.log(result) // 4999999950000000\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:24
+msgid "Non-Blocking"
+msgstr ""
+
+#: src/threading/spawn.md:26
+msgid "`spawn` returns immediately. The main thread doesn't wait:"
+msgstr ""
+
+#: src/threading/spawn.md:28
+msgid ""
+"```typescript\n"
+"async function spawnNonBlocking(): Promise<void> {\n"
+"    console.log(\"1. Starting background work\")\n"
+"\n"
+"    const handle = spawn(() => {\n"
+"        // Runs on a background thread — heavier work elided here.\n"
+"        let n = 0\n"
+"        for (let i = 0; i < 10_000_000; i++) n++\n"
+"        return n\n"
+"    })\n"
+"\n"
+"    console.log(\"2. Main thread continues immediately\")\n"
+"\n"
+"    const result = await handle\n"
+"    console.log(`3. Got result: ${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:53
+msgid "Multiple Concurrent Tasks"
+msgstr ""
+
+#: src/threading/spawn.md:55
+msgid ""
+"Spawn multiple tasks and they run truly concurrently — one OS thread per "
+"`spawn` call:"
+msgstr ""
+
+#: src/threading/spawn.md:57
+msgid ""
+"```typescript\n"
+"async function spawnMultiple(): Promise<void> {\n"
+"    const t1 = spawn(() => analyseChunk(0, 1_000_000))\n"
+"    const t2 = spawn(() => analyseChunk(1_000_000, 2_000_000))\n"
+"    const t3 = spawn(() => analyseChunk(2_000_000, 3_000_000))\n"
+"\n"
+"    // All three run simultaneously on separate OS threads.\n"
+"    const results = await Promise.all([t1, t2, t3])\n"
+"\n"
+"    console.log(`Region A: ${results[0]}`)\n"
+"    console.log(`Region B: ${results[1]}`)\n"
+"    console.log(`Region C: ${results[2]}`)\n"
+"}\n"
+"\n"
+"function analyseChunk(start: number, end: number): number {\n"
+"    let acc = 0\n"
+"    for (let i = start; i < end; i++) acc += i & 0xff\n"
+"    return acc\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:78
+msgid ""
+"Unlike Node.js `worker_threads`, each `spawn` is a lightweight OS thread "
+"(~8MB stack), not a full V8 isolate (~2MB heap + startup cost)."
+msgstr ""
+
+#: src/threading/spawn.md:82
+msgid ""
+"Like `parallelMap`, `spawn` closures can capture outer variables. They are "
+"deep-copied to the background thread:"
+msgstr ""
+
+#: src/threading/spawn.md:84
+msgid ""
+"```typescript\n"
+"async function spawnCapture(): Promise<void> {\n"
+"    const config = { iterations: 1000, seed: 42 }\n"
+"    const dataset = [1, 2, 3, 4, 5, 6, 7, 8]\n"
+"\n"
+"    const result = await spawn(() => {\n"
+"        // config and dataset are deep-copied to this thread.\n"
+"        let acc = config.seed\n"
+"        for (let i = 0; i < config.iterations; i++) {\n"
+"            acc = (acc * 1103515245 + 12345) & 0x7fffffff\n"
+"        }\n"
+"        for (const v of dataset) acc ^= v\n"
+"        return acc\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-capture: ${result}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:103
+msgid ""
+"Mutable variables cannot be captured — this is enforced at compile time."
+msgstr ""
+
+#: src/threading/spawn.md:105
+msgid "Returning Complex Values"
+msgstr ""
+
+#: src/threading/spawn.md:107
+msgid ""
+"`spawn` can return any value type. Complex values (objects, arrays, strings)"
+" are serialized back to the main thread automatically:"
+msgstr ""
+
+#: src/threading/spawn.md:133
+msgid "UI Integration"
+msgstr ""
+
+#: src/threading/spawn.md:135
+msgid ""
+"`spawn` is ideal for keeping native UIs responsive during heavy computation:"
+msgstr ""
+
+#: src/threading/spawn.md:137
+msgid ""
+"```typescript\n"
+"const analyzeButton = Button(\"Analyze\", async () => {\n"
+"    status.set(\"Processing...\")\n"
+"\n"
+"    // Background thread — UI stays responsive\n"
+"    const data = await spawn(() => {\n"
+"        let count = 0\n"
+"        for (let i = 0; i < 1_000_000; i++) {\n"
+"            if ((i & 0xff) === 0) count++\n"
+"        }\n"
+"        return { count }\n"
+"    })\n"
+"\n"
+"    result.set(`Found ${data.count} patterns`)\n"
+"    status.set(\"Done\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:155
+msgid ""
+"Without `spawn`, the analysis would freeze the UI. With `spawn`, the user "
+"can still scroll, tap other buttons, or navigate while the computation runs."
+msgstr ""
+
+#: src/threading/spawn.md:157
+msgid "Compared to Node.js worker_threads"
+msgstr ""
+
+#: src/threading/spawn.md:160
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
+msgstr ""
+
+#: src/threading/spawn.md:162 src/threading/spawn.md:167
+msgid "\"worker_threads\""
+msgstr ""
+
+#: src/threading/spawn.md:165
+msgid "// main.js\n"
+msgstr ""
+
+#: src/threading/spawn.md:168
+msgid "\"./worker.js\""
+msgstr ""
+
+#: src/threading/spawn.md:171
+msgid "\"message\""
+msgstr ""
+
+#: src/threading/spawn.md:174 src/testing/geisterhand.md:319
+msgid "\"error\""
+msgstr ""
+
+#: src/threading/spawn.md:174
+msgid "/* handle */"
+msgstr ""
+
+#: src/threading/spawn.md:176
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
+msgstr ""
+
+#: src/threading/spawn.md:181
+msgid ""
+"No separate files. No message ports. No event handlers. No structured clone."
+" One line."
+msgstr ""
+
+#: src/threading/spawn.md:185
+msgid "Background File Processing"
+msgstr ""
+
+#: src/threading/spawn.md:187
+msgid ""
+"```typescript\n"
+"async function spawnBgFile(): Promise<void> {\n"
+"    // Read and process a \"large\" file without blocking. We inline a tiny CSV\n"
+"    // so the snippet runs hermetically — the docs' real version would call\n"
+"    // readFileSync from \"fs\".\n"
+"    const content = \"id,value\\n1,10\\n2,20\\n3,30\\n\"\n"
+"    const analysis = await spawn(() => {\n"
+"        const lines = content.split(\"\\n\").filter((l: string) => l.length > 0).slice(1)\n"
+"        let total = 0\n"
+"        for (const line of lines) {\n"
+"            const parts = line.split(\",\")\n"
+"            total += parseInt(parts[1], 10)\n"
+"        }\n"
+"        return { rows: lines.length, total }\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-bg-file rows=${analysis.rows} total=${analysis.total}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:207
+msgid "Parallel API Calls with Processing"
+msgstr ""
+
+#: src/threading/spawn.md:209
+msgid ""
+"```typescript\n"
+"async function spawnApiThenProcess(): Promise<void> {\n"
+"    // The docs example fetches a remote API; for a hermetic test we\n"
+"    // just hand-roll the same pipeline shape with synthetic data.\n"
+"    const rawData = { items: [1, 2, 3, 4, 5] }\n"
+"\n"
+"    // CPU-intensive processing happens off the main thread\n"
+"    const processed = await spawn(() => {\n"
+"        let total = 0\n"
+"        for (const v of rawData.items) total += v * v\n"
+"        return { total, count: rawData.items.length }\n"
+"    })\n"
+"\n"
+"    console.log(`spawn-api-then-process total=${processed.total} count=${processed.count}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/threading/spawn.md:226
+msgid "Deferred Computation"
+msgstr ""
+
+#: src/threading/spawn.md:228
+msgid ""
+"```typescript\n"
+"async function spawnDeferred(): Promise<void> {\n"
+"    const params = { size: 8 }\n"
+"\n"
+"    // Start computation early, use result later\n"
+"    const precomputed = spawn(() => {\n"
+"        const table: number[] = []\n"
+"        for (let i = 0; i < params.size; i++) table.push(i * i)\n"
+"        return table\n"
+"    })\n"
+"\n"
+"    // ... do other setup work ...\n"
+"\n"
+"    // Result is ready (or we wait for it)\n"
+"    const table = await precomputed\n"
+"    console.log(`spawn-deferred len=${table.length} last=${table[table.length - 1]}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:1
+msgid "UI Overview"
+msgstr ""
+
+#: src/ui/overview.md:3
+msgid ""
+"Perry's `perry/ui` module lets you build native desktop and mobile apps with"
+" declarative TypeScript. Your UI code compiles directly to platform-native "
+"widgets — AppKit on macOS, UIKit on iOS, GTK4 on Linux, Win32 on Windows, "
+"and DOM elements on the web."
+msgstr ""
+
+#: src/ui/overview.md:5 src/i18n/overview.md:27 src/testing/geisterhand.md:9
+msgid "Quick Start"
+msgstr ""
+
+#: src/ui/overview.md:7
+msgid ""
+"```typescript\n"
+"// demonstrates: the smallest complete Perry UI app\n"
+"// docs: docs/src/ui/overview.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My App\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello from Perry!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:29
+msgid "Mental Model"
+msgstr ""
+
+#: src/ui/overview.md:31
+msgid ""
+"Perry's UI follows the same model as SwiftUI and Flutter: you compose native"
+" widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`),"
+" control alignment and distribution, and style widgets via free functions "
+"that take the widget handle as their first argument (`textSetColor(label, r,"
+" g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
+"web development, the key shift is:"
+msgstr ""
+
+#: src/ui/overview.md:33
+msgid ""
+"**Layout** is controlled by stack alignment, distribution, and spacers — not"
+" CSS properties. See [Layout](layout.md)."
+msgstr ""
+
+#: src/ui/overview.md:34
+msgid ""
+"**Styling** is applied directly to widgets — not through stylesheets. See "
+"[Styling](styling.md)."
+msgstr ""
+
+#: src/ui/overview.md:35
+msgid ""
+"**Absolute positioning** uses overlays (`widgetAddOverlay` + "
+"`widgetSetOverlayFrame`) — not `position: absolute/relative`."
+msgstr ""
+
+#: src/ui/overview.md:36
+msgid ""
+"**Design tokens** come from the `perry-styling` package. See "
+"[Theming](theming.md)."
+msgstr ""
+
+#: src/ui/overview.md:38 src/platforms/ios.md:63 src/platforms/tvos.md:104
+#: src/platforms/watchos.md:80
+msgid "App Lifecycle"
+msgstr ""
+
+#: src/ui/overview.md:40
+msgid "Every Perry UI app starts with `App()`:"
+msgstr ""
+
+#: src/ui/overview.md:42
+msgid ""
+"```typescript\n"
+"function runAppShell(): void {\n"
+"    App({\n"
+"        title: \"Window Title\",\n"
+"        width: 800,\n"
+"        height: 600,\n"
+"        body: VStack(16, [\n"
+"            Text(\"Content here\"),\n"
+"        ]),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:55
+msgid "`App({})` accepts a config object with the following properties:"
+msgstr ""
+
+#: src/ui/overview.md:57 src/widgets/creating-widgets.md:45
+msgid "Property"
+msgstr ""
+
+#: src/ui/overview.md:59
+msgid "`title`"
+msgstr ""
+
+#: src/ui/overview.md:59 src/ui/overview.md:63 src/ui/overview.md:65
+#: src/ui/overview.md:67 src/ui/overview.md:68 src/ui/styling.md:58
+#: src/cli/perry-toml.md:116 src/cli/perry-toml.md:117
+#: src/cli/perry-toml.md:119 src/cli/perry-toml.md:120
+#: src/cli/perry-toml.md:121 src/cli/perry-toml.md:127
+#: src/cli/perry-toml.md:155 src/cli/perry-toml.md:167
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:169
+#: src/cli/perry-toml.md:177 src/cli/perry-toml.md:183
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:185
+#: src/cli/perry-toml.md:186 src/cli/perry-toml.md:187
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:194
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:196
+#: src/cli/perry-toml.md:243 src/cli/perry-toml.md:244
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:249
+#: src/cli/perry-toml.md:256 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:263 src/cli/perry-toml.md:264
+#: src/cli/perry-toml.md:270 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:272 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:301 src/cli/perry-toml.md:302
+#: src/cli/perry-toml.md:303 src/cli/perry-toml.md:304
+#: src/cli/perry-toml.md:312 src/cli/perry-toml.md:313
+#: src/cli/perry-toml.md:314 src/cli/perry-toml.md:315
+#: src/cli/perry-toml.md:316 src/cli/perry-toml.md:317
+#: src/cli/perry-toml.md:318 src/cli/perry-toml.md:319
+#: src/cli/perry-toml.md:329 src/cli/perry-toml.md:330
+#: src/cli/perry-toml.md:331 src/cli/perry-toml.md:333
+#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:335
+#: src/cli/perry-toml.md:336 src/cli/perry-toml.md:337
+#: src/cli/perry-toml.md:347 src/cli/perry-toml.md:348
+#: src/cli/perry-toml.md:349 src/cli/perry-toml.md:360
+#: src/cli/perry-toml.md:369 src/cli/perry-toml.md:379
+#: src/cli/perry-toml.md:389 src/cli/perry-toml.md:390
+#: src/cli/perry-toml.md:416
+msgid "string"
+msgstr ""
+
+#: src/ui/overview.md:59
+msgid "Window title"
+msgstr ""
+
+#: src/ui/overview.md:60
+msgid "`width`"
+msgstr ""
+
+#: src/ui/overview.md:60 src/ui/overview.md:61 src/ui/styling.md:50
+#: src/ui/styling.md:51 src/system/overview.md:28
+msgid "number"
+msgstr ""
+
+#: src/ui/overview.md:60
+msgid "Initial window width"
+msgstr ""
+
+#: src/ui/overview.md:61
+msgid "`height`"
+msgstr ""
+
+#: src/ui/overview.md:61
+msgid "Initial window height"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "`body`"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "widget"
+msgstr ""
+
+#: src/ui/overview.md:62
+msgid "Root widget"
+msgstr ""
+
+#: src/ui/overview.md:63
+msgid "`icon`"
+msgstr ""
+
+#: src/ui/overview.md:63
+msgid "App icon file path (optional)"
+msgstr ""
+
+#: src/ui/overview.md:64
+msgid "`frameless`"
+msgstr ""
+
+#: src/ui/overview.md:64 src/ui/overview.md:66 src/ui/styling.md:59
+#: src/ui/styling.md:60 src/system/media.md:49 src/cli/perry-toml.md:361
+msgid "boolean"
+msgstr ""
+
+#: src/ui/overview.md:64
+msgid "Remove title bar (optional)"
+msgstr ""
+
+#: src/ui/overview.md:65
+msgid "`level`"
+msgstr ""
+
+#: src/ui/overview.md:65
+msgid "Window z-order: `\"floating\"`, `\"statusBar\"`, `\"modal\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:66
+msgid "`transparent`"
+msgstr ""
+
+#: src/ui/overview.md:66
+msgid "Transparent background (optional)"
+msgstr ""
+
+#: src/ui/overview.md:67
+msgid "`vibrancy`"
+msgstr ""
+
+#: src/ui/overview.md:67
+msgid "Native blur material, e.g. `\"sidebar\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:68
+msgid "`activationPolicy`"
+msgstr ""
+
+#: src/ui/overview.md:68
+msgid "`\"regular\"`, `\"accessory\"` (no dock icon), `\"background\"` (optional)"
+msgstr ""
+
+#: src/ui/overview.md:70
+msgid ""
+"See [Multi-Window](multi-window.md) for full documentation on window "
+"properties."
+msgstr ""
+
+#: src/ui/overview.md:72
+msgid "Lifecycle Hooks"
+msgstr ""
+
+#: src/ui/overview.md:74
+msgid ""
+"```typescript\n"
+"onActivate(() => {\n"
+"    console.log(\"App became active\")\n"
+"})\n"
+"\n"
+"onTerminate(() => {\n"
+"    console.log(\"App is closing\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:84
+msgid "Widget Tree"
+msgstr ""
+
+#: src/ui/overview.md:86
+msgid "Perry UIs are built as a tree of widgets:"
+msgstr ""
+
+#: src/ui/overview.md:88
+msgid ""
+"```typescript\n"
+"function runWidgetTree(): void {\n"
+"    App({\n"
+"        title: \"Layout Demo\",\n"
+"        width: 400,\n"
+"        height: 300,\n"
+"        body: VStack(16, [\n"
+"            Text(\"Header\"),\n"
+"            HStack(8, [\n"
+"                Button(\"Left\", () => console.log(\"left\")),\n"
+"                Button(\"Right\", () => console.log(\"right\")),\n"
+"            ]),\n"
+"            Text(\"Footer\"),\n"
+"        ]),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:106
+msgid ""
+"Widgets are created by calling their constructor functions. Layout "
+"containers (`VStack`, `HStack`, `ZStack`) accept a spacing value (in points)"
+" followed by an array of child widgets."
+msgstr ""
+
+#: src/ui/overview.md:108
+msgid "Handle-Based Architecture"
+msgstr ""
+
+#: src/ui/overview.md:110
+msgid ""
+"Under the hood, each widget is a handle — a small integer that references a "
+"native platform object. When you call `Text(\"hello\")`, Perry creates a "
+"native `NSTextField` (macOS), `UILabel` (iOS), `GtkLabel` (Linux), or "
+"`<span>` (web) and returns a handle you can use to modify it."
+msgstr ""
+
+#: src/ui/overview.md:112
+msgid ""
+"```typescript\n"
+"const label = Text(\"Hello\")\n"
+"textSetFontSize(label, 18)              // Modifies the native widget\n"
+"textSetColor(label, 1.0, 0.0, 0.0, 1.0) // RGBA floats in [0,1]\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:118
+msgid "Imports"
+msgstr ""
+
+#: src/ui/overview.md:120
+msgid "All UI functions are imported from `perry/ui`:"
+msgstr ""
+
+#: src/ui/overview.md:122
+msgid ""
+"```typescript\n"
+"import {\n"
+"    // App lifecycle\n"
+"    App, onActivate, onTerminate,\n"
+"\n"
+"    // Widgets\n"
+"    Text, Button, TextField, SecureField, TextArea,\n"
+"    Toggle, Slider, ProgressView, Picker, ImageFile, ImageSymbol,\n"
+"\n"
+"    // Layout\n"
+"    VStack, HStack, ZStack, ScrollView, Spacer, Divider,\n"
+"    NavStack, TabBar, LazyVStack, Section,\n"
+"    VStackWithInsets, HStackWithInsets, SplitView, splitViewAddChild,\n"
+"\n"
+"    // Layout control\n"
+"    stackSetAlignment, stackSetDistribution, stackSetDetachesHidden,\n"
+"    widgetMatchParentWidth, widgetMatchParentHeight, widgetSetHugging,\n"
+"    widgetAddOverlay, widgetSetOverlayFrame,\n"
+"\n"
+"    // State\n"
+"    State, ForEach,\n"
+"\n"
+"    // Dialogs\n"
+"    openFileDialog, openFolderDialog, saveFileDialog,\n"
+"    alert, alertWithButtons,\n"
+"    sheetCreate, sheetPresent, sheetDismiss,\n"
+"\n"
+"    // Menus\n"
+"    menuCreate, menuAddItem, menuAddSeparator, menuAddSubmenu,\n"
+"    menuBarCreate, menuBarAddMenu, menuBarAttach,\n"
+"    widgetSetContextMenu,\n"
+"\n"
+"    // Window\n"
+"    Window,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/overview.md:159
+msgid ""
+"[`Canvas`](canvas.md), [`CameraView`](camera.md), and the virtualized "
+"[`Table`](table.md) widget are wired through the LLVM codegen (closed via "
+"[\\#190](https://github.com/PerryTS/perry/issues/190), "
+"[\\#191](https://github.com/PerryTS/perry/issues/191), and "
+"[\\#192](https://github.com/PerryTS/perry/issues/192)). See each widget's "
+"page for the platform-support matrix."
+msgstr ""
+
+#: src/ui/overview.md:166
+msgid "Platform Differences"
+msgstr ""
+
+#: src/ui/overview.md:168
+msgid ""
+"The same code runs on all platforms, but the look and feel matches each "
+"platform's native style:"
+msgstr ""
+
+#: src/ui/overview.md:170 src/platforms/overview.md:67
+#: src/i18n/formatting.md:138 src/widgets/platforms.md:20
+msgid "Feature"
+msgstr ""
+
+#: src/ui/overview.md:172
+msgid "Buttons"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/macos.md:27
+msgid "NSButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/tvos.md:53
+msgid "UIButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/linux.md:37
+msgid "GtkButton"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/windows.md:45
+msgid "HWND Button"
+msgstr ""
+
+#: src/ui/overview.md:172 src/platforms/wasm.md:58
+msgid "`<button>`"
+msgstr ""
+
+#: src/ui/overview.md:173 src/ui/widgets.md:13 src/ui/canvas.md:60
+#: src/platforms/macos.md:26 src/platforms/ios.md:52 src/platforms/tvos.md:52
+#: src/platforms/watchos.md:52 src/platforms/android.md:26
+#: src/platforms/windows.md:44 src/platforms/linux.md:36
+#: src/widgets/components.md:25 src/widgets/platforms.md:22
+msgid "Text"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/macos.md:28
+msgid "NSTextField"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/ios.md:52 src/platforms/tvos.md:52
+msgid "UILabel"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/linux.md:36
+msgid "GtkLabel"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/windows.md:44
+msgid "Static HWND"
+msgstr ""
+
+#: src/ui/overview.md:173 src/platforms/wasm.md:57
+msgid "`<span>`"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/macos.md:34
+msgid "NSStackView"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/ios.md:60 src/platforms/tvos.md:59
+msgid "UIStackView"
+msgstr ""
+
+#: src/ui/overview.md:174
+msgid "GtkBox"
+msgstr ""
+
+#: src/ui/overview.md:174 src/platforms/windows.md:53
+msgid "Manual layout"
+msgstr ""
+
+#: src/ui/overview.md:174
+msgid "Flexbox"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:111
+msgid "NSMenu"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:113 src/ui/menus.md:114
+#: src/ui/dialogs.md:111 src/ui/dialogs.md:112 src/platforms/overview.md:69
+#: src/platforms/overview.md:71 src/platforms/overview.md:72
+#: src/platforms/overview.md:75 src/cli/perry-toml.md:119
+#: src/cli/perry-toml.md:120 src/cli/perry-toml.md:127
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:169
+#: src/cli/perry-toml.md:170 src/cli/perry-toml.md:177
+#: src/cli/perry-toml.md:185 src/cli/perry-toml.md:186
+#: src/cli/perry-toml.md:187 src/cli/perry-toml.md:245
+#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:256
+#: src/cli/perry-toml.md:264 src/cli/perry-toml.md:303
+#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:312
+#: src/cli/perry-toml.md:315 src/cli/perry-toml.md:330
+#: src/cli/perry-toml.md:331 src/cli/perry-toml.md:332
+#: src/cli/perry-toml.md:333 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:335 src/cli/perry-toml.md:336
+#: src/cli/perry-toml.md:347 src/cli/perry-toml.md:348
+#: src/cli/perry-toml.md:359 src/cli/perry-toml.md:391
+msgid "—"
+msgstr ""
+
+#: src/ui/overview.md:175
+msgid "GMenu"
+msgstr ""
+
+#: src/ui/overview.md:175
+msgid "HMENU"
+msgstr ""
+
+#: src/ui/overview.md:175 src/ui/menus.md:115
+msgid "DOM"
+msgstr ""
+
+#: src/ui/overview.md:177
+msgid ""
+"Platform-specific behavior is noted on each widget's documentation page."
+msgstr ""
+
+#: src/ui/overview.md:181 src/ui/layout.md:370 src/ui/styling.md:379
+#: src/ui/state.md:228 src/ui/events.md:170 src/ui/canvas.md:82
+#: src/ui/table.md:109 src/ui/animation.md:74 src/ui/camera.md:145
+msgid "[Widgets](widgets.md) — All available widgets"
+msgstr ""
+
+#: src/ui/overview.md:182
+msgid "[Layout](layout.md) — Arranging widgets"
+msgstr ""
+
+#: src/ui/overview.md:183
+msgid "[State Management](state.md) — Reactive state and bindings"
+msgstr ""
+
+#: src/ui/overview.md:184
+msgid "[Styling](styling.md) — Colors, fonts, sizing"
+msgstr ""
+
+#: src/ui/overview.md:185
+msgid "[Events](events.md) — Click, hover, keyboard"
+msgstr ""
+
+#: src/ui/widgets.md:3
+msgid ""
+"Perry provides native widgets that map to each platform's native controls. "
+"Every example on this page is a real runnable program verified by CI "
+"(`scripts/run_doc_tests.sh`) — the snippet you read is the same source "
+"that's compiled and launched."
+msgstr ""
+
+#: src/ui/widgets.md:8
+msgid ""
+"The widget API is **free functions**, not methods. A widget is a 64-bit "
+"opaque handle; you pass it into helpers like `textSetFontSize(widget, 18)` "
+"rather than calling `widget.setFontSize(18)`. That's the only shape perry/ui"
+" supports — no fluent chain, no prototype methods."
+msgstr ""
+
+#: src/ui/widgets.md:15
+msgid "Displays read-only text."
+msgstr ""
+
+#: src/ui/widgets.md:17
+msgid ""
+"```typescript\n"
+"// demonstrates: Text widget styling with the real free-function API\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, textSetFontSize, textSetFontWeight, textSetColor, textSetFontFamily } from \"perry/ui\"\n"
+"\n"
+"const label = Text(\"Hello, World!\")\n"
+"textSetFontSize(label, 18)\n"
+"textSetColor(label, 0.2, 0.2, 0.2, 1.0) // RGBA in [0, 1]\n"
+"textSetFontFamily(label, \"Menlo\")\n"
+"\n"
+"const bold = Text(\"Bold\")\n"
+"textSetFontWeight(bold, 20, 1.0)\n"
+"\n"
+"App({\n"
+"    title: \"Text\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(8, [label, bold]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:41
+msgid ""
+"Color is RGBA with each channel in `[0.0, 1.0]` — divide a hex byte by 255 "
+"(`0x33 / 255 ≈ 0.2`)."
+msgstr ""
+
+#: src/ui/widgets.md:44
+msgid ""
+"**Helpers:** `textSetString`, `textSetFontSize`, `textSetFontWeight`, "
+"`textSetFontFamily`, `textSetColor`, `textSetWraps`, `textSetSelectable`."
+msgstr ""
+
+#: src/ui/widgets.md:47
+msgid ""
+"Text widgets inside template literals with `state.value` update "
+"automatically — perry detects the state read and rewires the widget to re-"
+"render on change. See [State Management](state.md)."
+msgstr ""
+
+#: src/ui/widgets.md:51 src/platforms/macos.md:27 src/platforms/ios.md:53
+#: src/platforms/tvos.md:53 src/platforms/watchos.md:53
+#: src/platforms/android.md:27 src/platforms/windows.md:45
+#: src/platforms/linux.md:37 src/testing/geisterhand.md:86
+#: src/testing/geisterhand.md:289
+msgid "Button"
+msgstr ""
+
+#: src/ui/widgets.md:53
+msgid "A clickable button."
+msgstr ""
+
+#: src/ui/widgets.md:55
+msgid ""
+"```typescript\n"
+"// demonstrates: Button styling with buttonSet*/widgetSet* helpers\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack,\n"
+"    Button,\n"
+"    buttonSetBordered,\n"
+"    widgetSetEnabled,\n"
+"    setCornerRadius,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// Note: buttonSetContentTintColor is macOS/iOS-only (maps to NSButton /\n"
+"// UIButton tint). GTK4/Win32 don't have an equivalent — set\n"
+"// widgetSetBackgroundColor(btn, r, g, b, a) there instead.\n"
+"const primary = Button(\"Click Me\", () => console.log(\"Clicked!\"))\n"
+"buttonSetBordered(primary, 1)\n"
+"setCornerRadius(primary, 8)\n"
+"\n"
+"const disabled = Button(\"Can't click me\", () => {})\n"
+"widgetSetEnabled(disabled, 0)\n"
+"\n"
+"App({\n"
+"    title: \"Button\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [primary, disabled]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:88
+msgid ""
+"**Helpers:** `buttonSetTitle`, `buttonSetBordered`, `buttonSetImage` (SF "
+"Symbol name on macOS/iOS), `buttonSetImagePosition`, "
+"`buttonSetContentTintColor`, `buttonSetTextColor`, `widgetSetEnabled`."
+msgstr ""
+
+#: src/ui/widgets.md:92 src/platforms/macos.md:28 src/platforms/ios.md:54
+#: src/platforms/tvos.md:54 src/platforms/android.md:28
+#: src/platforms/windows.md:46 src/platforms/linux.md:38
+#: src/testing/geisterhand.md:87 src/testing/geisterhand.md:290
+msgid "TextField"
+msgstr ""
+
+#: src/ui/widgets.md:94
+msgid "An editable single-line text input."
+msgstr ""
+
+#: src/ui/widgets.md:96
+msgid ""
+"```typescript\n"
+"// demonstrates: TextField + two-way binding via stateBindTextfield\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, TextField, State, stateBindTextfield } from \"perry/ui\"\n"
+"\n"
+"const text = State(\"\")\n"
+"const field = TextField(\"Placeholder...\", (value: string) => text.set(value))\n"
+"stateBindTextfield(text, field) // programmatic text.set() also updates the field\n"
+"\n"
+"App({\n"
+"    title: \"TextField\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        field,\n"
+"        Text(`You typed: ${text.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:119
+msgid ""
+"`TextField(placeholder, onChange)` fires `onChange` as the user types. Pair "
+"with `stateBindTextfield(state, field)` for two-way binding so programmatic "
+"`state.set(…)` also updates the visible text."
+msgstr ""
+
+#: src/ui/widgets.md:123
+msgid ""
+"**Helpers:** `textfieldSetString`, `textfieldSetFontSize`, "
+"`textfieldSetTextColor`, `textfieldSetBackgroundColor`, "
+"`textfieldSetBorderless`, `textfieldSetOnSubmit`, `textfieldSetOnFocus`, "
+"`textfieldSetNextKeyView`."
+msgstr ""
+
+#: src/ui/widgets.md:128 src/platforms/macos.md:29 src/platforms/ios.md:55
+#: src/platforms/android.md:29 src/platforms/windows.md:47
+#: src/platforms/linux.md:39
+msgid "SecureField"
+msgstr ""
+
+#: src/ui/widgets.md:130
+msgid ""
+"A password input — identical signature to `TextField`, but text is masked."
+msgstr ""
+
+#: src/ui/widgets.md:132
+msgid ""
+"```typescript\n"
+"// demonstrates: SecureField for password input\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, SecureField, State } from \"perry/ui\"\n"
+"\n"
+"const password = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"SecureField\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        SecureField(\"Enter password...\", (value: string) => password.set(value)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:152 src/platforms/macos.md:30 src/platforms/ios.md:56
+#: src/platforms/tvos.md:55 src/platforms/watchos.md:59
+#: src/platforms/android.md:30 src/platforms/windows.md:48
+#: src/platforms/linux.md:40 src/testing/geisterhand.md:89
+#: src/testing/geisterhand.md:292
+msgid "Toggle"
+msgstr ""
+
+#: src/ui/widgets.md:154
+msgid "A boolean on/off switch."
+msgstr ""
+
+#: src/ui/widgets.md:156
+msgid ""
+"```typescript\n"
+"// demonstrates: Toggle widget bound to State\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Toggle, State } from \"perry/ui\"\n"
+"\n"
+"const enabled = State(false)\n"
+"\n"
+"App({\n"
+"    title: \"Toggle\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Toggle(\"Enable notifications\", (on: boolean) => enabled.set(on)),\n"
+"        Text(`Enabled: ${enabled.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:177 src/platforms/macos.md:31 src/platforms/ios.md:57
+#: src/platforms/tvos.md:56 src/platforms/watchos.md:60
+#: src/platforms/android.md:31 src/platforms/windows.md:49
+#: src/platforms/linux.md:41 src/testing/geisterhand.md:88
+#: src/testing/geisterhand.md:291
+msgid "Slider"
+msgstr ""
+
+#: src/ui/widgets.md:179
+msgid "A numeric slider."
+msgstr ""
+
+#: src/ui/widgets.md:181
+msgid ""
+"```typescript\n"
+"// demonstrates: Slider with a numeric range\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Slider, State } from \"perry/ui\"\n"
+"\n"
+"const value = State(50)\n"
+"\n"
+"App({\n"
+"    title: \"Slider\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Slider(0, 100, (v: number) => value.set(v)),\n"
+"        Text(`Value: ${value.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:202
+msgid ""
+"`Slider(min, max, onChange)` — `onChange` fires on every drag. Use "
+"`stateBindSlider(state, slider)` for two-way binding."
+msgstr ""
+
+#: src/ui/widgets.md:205 src/platforms/macos.md:32 src/platforms/ios.md:58
+#: src/platforms/tvos.md:57 src/platforms/watchos.md:64
+#: src/platforms/android.md:32 src/platforms/windows.md:50
+#: src/platforms/linux.md:42 src/testing/geisterhand.md:90
+#: src/testing/geisterhand.md:293
+msgid "Picker"
+msgstr ""
+
+#: src/ui/widgets.md:207
+msgid "A dropdown selection control. Items are added with `pickerAddItem`."
+msgstr ""
+
+#: src/ui/widgets.md:209
+msgid ""
+"```typescript\n"
+"// demonstrates: Picker with items added via pickerAddItem\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, Picker, State, pickerAddItem } from \"perry/ui\"\n"
+"\n"
+"const selected = State(0)\n"
+"const picker = Picker((index: number) => selected.set(index))\n"
+"pickerAddItem(picker, \"Option A\")\n"
+"pickerAddItem(picker, \"Option B\")\n"
+"pickerAddItem(picker, \"Option C\")\n"
+"\n"
+"App({\n"
+"    title: \"Picker\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        picker,\n"
+"        Text(`Selected index: ${selected.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:234
+msgid "ImageFile / ImageSymbol"
+msgstr ""
+
+#: src/ui/widgets.md:236
+msgid "Two distinct constructors:"
+msgstr ""
+
+#: src/ui/widgets.md:238
+msgid "`ImageFile(path)` — image from a file path"
+msgstr ""
+
+#: src/ui/widgets.md:239
+msgid "`ImageSymbol(name)` — SF Symbol glyph name (macOS/iOS only)"
+msgstr ""
+
+#: src/ui/widgets.md:241
+msgid ""
+"```typescript\n"
+"// demonstrates: ImageSymbol for SF Symbol glyphs (macOS/iOS)\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos\n"
+"// targets: ios-simulator, visionos-simulator, tvos-simulator\n"
+"\n"
+"import { App, HStack, ImageSymbol, widgetSetWidth, widgetSetHeight } from \"perry/ui\"\n"
+"\n"
+"const star = ImageSymbol(\"star.fill\")\n"
+"widgetSetWidth(star, 32)\n"
+"widgetSetHeight(star, 32)\n"
+"\n"
+"const heart = ImageSymbol(\"heart.fill\")\n"
+"const bell = ImageSymbol(\"bell.fill\")\n"
+"\n"
+"App({\n"
+"    title: \"ImageSymbol\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: HStack(12, [star, heart, bell]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:264
+msgid ""
+"Use `widgetSetWidth(img, N)` / `widgetSetHeight(img, N)` to size the image."
+msgstr ""
+
+#: src/ui/widgets.md:266 src/platforms/watchos.md:63
+#: src/platforms/windows.md:51 src/platforms/linux.md:43
+msgid "ProgressView"
+msgstr ""
+
+#: src/ui/widgets.md:268
+msgid "An indeterminate or determinate progress indicator."
+msgstr ""
+
+#: src/ui/widgets.md:270
+msgid ""
+"```typescript\n"
+"// demonstrates: ProgressView as an indeterminate spinner\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, ProgressView } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"ProgressView\",\n"
+"    width: 400,\n"
+"    height: 200,\n"
+"    body: VStack(12, [\n"
+"        Text(\"Loading...\"),\n"
+"        ProgressView(),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:289
+msgid "TextArea"
+msgstr ""
+
+#: src/ui/widgets.md:291
+msgid ""
+"A multi-line text input. Same `(placeholder, onChange)` signature as "
+"`TextField` but renders as a multi-line box."
+msgstr ""
+
+#: src/ui/widgets.md:294
+msgid ""
+"```typescript\n"
+"// demonstrates: TextArea for multi-line input\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, Text, TextArea, State } from \"perry/ui\"\n"
+"\n"
+"const content = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"TextArea\",\n"
+"    width: 500,\n"
+"    height: 400,\n"
+"    body: VStack(12, [\n"
+"        TextArea(\"Enter multi-line text...\", (value: string) => content.set(value)),\n"
+"        Text(`Length: ${content.value.length}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:315
+msgid "**Helpers:** `textareaSetString`."
+msgstr ""
+
+#: src/ui/widgets.md:317 src/cli/perry-toml.md:108
+msgid "Sections"
+msgstr ""
+
+#: src/ui/widgets.md:319
+msgid ""
+"Group controls into labelled sections. Perry has no `Form()` widget — use a "
+"`VStack` of `Section(title)`s and attach children via `widgetAddChild`."
+msgstr ""
+
+#: src/ui/widgets.md:322
+msgid ""
+"```typescript\n"
+"// demonstrates: Section grouping with widgetAddChild (no Form widget in Perry)\n"
+"// docs: docs/src/ui/widgets.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack,\n"
+"    Section,\n"
+"    TextField,\n"
+"    Toggle,\n"
+"    State,\n"
+"    widgetAddChild,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const name = State(\"\")\n"
+"const notifications = State(true)\n"
+"\n"
+"const personal = Section(\"Personal Info\")\n"
+"widgetAddChild(personal, TextField(\"Name\", (value: string) => name.set(value)))\n"
+"\n"
+"const settings = Section(\"Settings\")\n"
+"widgetAddChild(\n"
+"    settings,\n"
+"    Toggle(\"Notifications\", (on: boolean) => notifications.set(on)),\n"
+")\n"
+"\n"
+"App({\n"
+"    title: \"Sections\",\n"
+"    width: 500,\n"
+"    height: 400,\n"
+"    body: VStack(16, [personal, settings]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/widgets.md:358
+msgid "Platform-specific widgets"
+msgstr ""
+
+#: src/ui/widgets.md:360
+msgid ""
+"These exist only on specific platforms and aren't verified by the cross-"
+"platform doc-tests:"
+msgstr ""
+
+#: src/ui/widgets.md:363
+msgid ""
+"**`Table(rows, cols, renderer)`** — macOS only. A data table with rows, "
+"columns, and a cell renderer."
+msgstr ""
+
+#: src/ui/widgets.md:365
+msgid "**`QRCode(data, size)`** — macOS only. Renders a QR code."
+msgstr ""
+
+#: src/ui/widgets.md:366
+msgid ""
+"**`Canvas(width, height, draw)`** — all desktop platforms. A drawing "
+"surface; see [Canvas](canvas.md)."
+msgstr ""
+
+#: src/ui/widgets.md:368
+msgid ""
+"**`CameraView()`** — iOS only (other platforms planned). See "
+"[Camera](camera.md)."
+msgstr ""
+
+#: src/ui/widgets.md:371
+msgid "These are linked from their own pages with platform-specific examples."
+msgstr ""
+
+#: src/ui/widgets.md:373
+msgid "Common widget helpers"
+msgstr ""
+
+#: src/ui/widgets.md:375
+msgid "Every widget handle accepts these:"
+msgstr ""
+
+#: src/ui/widgets.md:377
+msgid "Helper"
+msgstr ""
+
+#: src/ui/widgets.md:379
+msgid "`widgetSetWidth(w, n)` / `widgetSetHeight(w, n)`"
+msgstr ""
+
+#: src/ui/widgets.md:379
+msgid "Explicit size in points"
+msgstr ""
+
+#: src/ui/widgets.md:380
+msgid "`widgetSetBackgroundColor(w, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/widgets.md:380
+msgid "RGBA in \\[0, 1\\]"
+msgstr ""
+
+#: src/ui/widgets.md:381
+msgid "`setCornerRadius(w, r)`"
+msgstr ""
+
+#: src/ui/widgets.md:381
+msgid "Rounded corners in points"
+msgstr ""
+
+#: src/ui/widgets.md:382
+msgid "`widgetSetOpacity(w, alpha)`"
+msgstr ""
+
+#: src/ui/widgets.md:382
+msgid "Opacity in \\[0, 1\\]"
+msgstr ""
+
+#: src/ui/widgets.md:383
+msgid "`widgetSetEnabled(w, flag)`"
+msgstr ""
+
+#: src/ui/widgets.md:383
+msgid "`0` disables, `1` enables"
+msgstr ""
+
+#: src/ui/widgets.md:384
+msgid "`widgetSetHidden(w, flag)`"
+msgstr ""
+
+#: src/ui/widgets.md:384
+msgid "`0` visible, `1` hidden"
+msgstr ""
+
+#: src/ui/widgets.md:385
+msgid "`widgetSetTooltip(w, text)`"
+msgstr ""
+
+#: src/ui/widgets.md:385
+msgid "Tooltip on hover (desktop only)"
+msgstr ""
+
+#: src/ui/widgets.md:386
+msgid "`widgetSetOnClick(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:386
+msgid "Click handler"
+msgstr ""
+
+#: src/ui/widgets.md:387
+msgid "`widgetSetOnHover(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:387
+msgid "Hover enter/leave (desktop only)"
+msgstr ""
+
+#: src/ui/widgets.md:388
+msgid "`widgetSetOnDoubleClick(w, cb)`"
+msgstr ""
+
+#: src/ui/widgets.md:388
+msgid "Double-click handler"
+msgstr ""
+
+#: src/ui/widgets.md:389
+msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+msgstr ""
+
+#: src/ui/widgets.md:389
+msgid "Padding around contents"
+msgstr ""
+
+#: src/ui/widgets.md:390
+msgid "`widgetSetBorderColor(w, r, g, b, a)` / `widgetSetBorderWidth(w, n)`"
+msgstr ""
+
+#: src/ui/widgets.md:390
+msgid "Border"
+msgstr ""
+
+#: src/ui/widgets.md:391 src/ui/layout.md:175
+msgid "`widgetAddChild(parent, child)`"
+msgstr ""
+
+#: src/ui/widgets.md:391
+msgid "Attach a child to a container"
+msgstr ""
+
+#: src/ui/widgets.md:392
+msgid "`widgetSetContextMenu(w, menu)`"
+msgstr ""
+
+#: src/ui/widgets.md:392
+msgid "Right-click menu"
+msgstr ""
+
+#: src/ui/widgets.md:394
+msgid "See [Styling](styling.md) and [Events](events.md) for deeper coverage."
+msgstr ""
+
+#: src/ui/widgets.md:398
+msgid "[Layout](layout.md) — Arranging widgets with stacks and containers"
+msgstr ""
+
+#: src/ui/widgets.md:399
+msgid "[Styling](styling.md) — Colors, fonts, borders"
+msgstr ""
+
+#: src/ui/widgets.md:400 src/ui/theming.md:169
+msgid "[State Management](state.md) — Reactive bindings"
+msgstr ""
+
+#: src/ui/layout.md:3
+msgid ""
+"Perry provides layout containers that arrange child widgets using the "
+"platform's native layout system. Every snippet below is excerpted from "
+"[`docs/examples/ui/layout/snippets.ts`](../../examples/ui/layout/snippets.ts)"
+" — CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/layout.md:8
+msgid ""
+"Layout helpers are free functions: `widgetAddChild(parent, child)`, "
+"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
+"bottom, right)`, etc. Stack constructors take a numeric spacing followed by "
+"a child array; everything else (alignment, distribution, padding, sizing) is"
+" applied post-construction via the free functions on the widget handle."
+msgstr ""
+
+#: src/ui/layout.md:14 src/platforms/watchos.md:54 src/platforms/android.md:34
+#: src/platforms/linux.md:45 src/widgets/components.md:43
+msgid "VStack"
+msgstr ""
+
+#: src/ui/layout.md:16
+msgid "Arranges children vertically (top to bottom)."
+msgstr ""
+
+#: src/ui/layout.md:18
+msgid ""
+"```typescript\n"
+"const stack = VStack(16, [\n"
+"    Text(\"First\"),\n"
+"    Text(\"Second\"),\n"
+"    Text(\"Third\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:26
+msgid ""
+"`VStack(spacing, children)` — the first argument is the gap in points "
+"between children."
+msgstr ""
+
+#: src/ui/layout.md:29 src/platforms/watchos.md:55 src/platforms/android.md:35
+#: src/platforms/linux.md:46 src/widgets/components.md:52
+msgid "HStack"
+msgstr ""
+
+#: src/ui/layout.md:31
+msgid "Arranges children horizontally (left to right)."
+msgstr ""
+
+#: src/ui/layout.md:33
+msgid ""
+"```typescript\n"
+"const row = HStack(8, [\n"
+"    Button(\"Cancel\", noop),\n"
+"    Spacer(),\n"
+"    Button(\"OK\", noop),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:41 src/platforms/watchos.md:56 src/platforms/android.md:36
+#: src/platforms/linux.md:47 src/widgets/components.md:62
+msgid "ZStack"
+msgstr ""
+
+#: src/ui/layout.md:43
+msgid ""
+"Layers children on top of each other (back to front). `ZStack()` takes no "
+"constructor children — populate it with `widgetAddChild`:"
+msgstr ""
+
+#: src/ui/layout.md:46
+msgid ""
+"```typescript\n"
+"const layered = ZStack()\n"
+"widgetAddChild(layered, ImageFile(\"background.png\"))\n"
+"widgetAddChild(layered, Text(\"Overlay text\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:52 src/platforms/macos.md:35 src/platforms/ios.md:61
+#: src/platforms/tvos.md:60 src/platforms/watchos.md:62
+#: src/platforms/android.md:37 src/platforms/windows.md:54
+#: src/platforms/linux.md:48 src/testing/geisterhand.md:94
+msgid "ScrollView"
+msgstr ""
+
+#: src/ui/layout.md:54
+msgid ""
+"A scrollable container. Built empty, then filled via `scrollviewSetChild`:"
+msgstr ""
+
+#: src/ui/layout.md:56
+msgid ""
+"```typescript\n"
+"// ScrollView() takes no args; populate it with `scrollviewSetChild`.\n"
+"const sv = ScrollView()\n"
+"const inner = VStack(8, [Text(\"a\"), Text(\"b\"), Text(\"c\")])\n"
+"scrollviewSetChild(sv, inner)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:63
+msgid "LazyVStack"
+msgstr ""
+
+#: src/ui/layout.md:65
+msgid ""
+"A vertically scrolling list that lazily renders items. More efficient than "
+"`ScrollView` + `VStack` for thousands of rows — on macOS this is backed by "
+"`NSTableView` so only rows in the visible rect are realized."
+msgstr ""
+
+#: src/ui/layout.md:69
+msgid ""
+"```typescript\n"
+"// `render(index)` is invoked lazily — only rows in the visible rect are realized.\n"
+"const lazy = LazyVStack(1000, (index: number) => Text(`Row ${index}`))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:74
+msgid ""
+"When the underlying data changes, call `lazyvstackUpdate(handle, newCount)` "
+"to refresh. Override the default 44pt row height with "
+"`lazyvstackSetRowHeight`."
+msgstr ""
+
+#: src/ui/layout.md:77
+msgid "NavStack"
+msgstr ""
+
+#: src/ui/layout.md:79
+msgid ""
+"A navigation container that supports push/pop navigation. Push a new view "
+"with `navstackPush(stack, view, title)`; pop with `navstackPop(stack)`:"
+msgstr ""
+
+#: src/ui/layout.md:82
+msgid ""
+"```typescript\n"
+"const home = VStack(16, [\n"
+"    Text(\"Home Screen\"),\n"
+"    Button(\"Go to Details\", () => {\n"
+"        navstackPush(nav, Text(\"Details!\"), \"Details\")\n"
+"    }),\n"
+"])\n"
+"const nav = NavStack()\n"
+"widgetAddChild(nav, home)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:93 src/platforms/watchos.md:57
+#: src/widgets/components.md:71 src/widgets/platforms.md:25
+#: src/widgets/platforms.md:26
+msgid "Spacer"
+msgstr ""
+
+#: src/ui/layout.md:95
+msgid "A flexible space that expands to fill available room."
+msgstr ""
+
+#: src/ui/layout.md:97
+msgid ""
+"```typescript\n"
+"const toolbar = HStack(8, [\n"
+"    Text(\"Left\"),\n"
+"    Spacer(),\n"
+"    Text(\"Right\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:105
+msgid "Use `Spacer()` inside `HStack` or `VStack` to push widgets apart."
+msgstr ""
+
+#: src/ui/layout.md:107 src/platforms/watchos.md:58
+#: src/widgets/components.md:106 src/widgets/platforms.md:26
+msgid "Divider"
+msgstr ""
+
+#: src/ui/layout.md:109
+msgid "A visual separator line."
+msgstr ""
+
+#: src/ui/layout.md:111
+msgid ""
+"```typescript\n"
+"const sections = VStack(12, [\n"
+"    Text(\"Section 1\"),\n"
+"    Divider(),\n"
+"    Text(\"Section 2\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:119
+msgid "Nesting Layouts"
+msgstr ""
+
+#: src/ui/layout.md:121
+msgid "Layouts can be nested freely. This complete example is verified by CI:"
+msgstr ""
+
+#: src/ui/layout.md:123
+msgid ""
+"```typescript\n"
+"// demonstrates: nested VStack/HStack + Spacer + Divider\n"
+"// docs: docs/src/ui/layout.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import { App, VStack, HStack, Text, Button, Spacer, Divider } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"Layout Example\",\n"
+"    width: 800,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        // Header\n"
+"        HStack(8, [\n"
+"            Text(\"My App\"),\n"
+"            Spacer(),\n"
+"            Button(\"Settings\", () => {}),\n"
+"        ]),\n"
+"        Divider(),\n"
+"        // Content\n"
+"        VStack(12, [\n"
+"            Text(\"Welcome!\"),\n"
+"            HStack(8, [\n"
+"                Button(\"Action 1\", () => {}),\n"
+"                Button(\"Action 2\", () => {}),\n"
+"            ]),\n"
+"        ]),\n"
+"        Spacer(),\n"
+"        // Footer\n"
+"        Text(\"v1.0.0\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:158
+msgid "Child Management"
+msgstr ""
+
+#: src/ui/layout.md:160
+msgid "Containers support dynamic child management via free functions:"
+msgstr ""
+
+#: src/ui/layout.md:162
+msgid ""
+"```typescript\n"
+"const list = VStack(16, [])\n"
+"widgetAddChild(list, Text(\"appended\"))            // append\n"
+"widgetAddChildAt(list, Text(\"prepended\"), 0)      // insert at index\n"
+"widgetReorderChild(list, 1, 0)                    // move from→to\n"
+"const removeMe = Text(\"temporary\")\n"
+"widgetAddChild(list, removeMe)\n"
+"widgetRemoveChild(list, removeMe)                 // remove\n"
+"widgetClearChildren(list)                         // remove all\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:173 src/ui/menus.md:53 src/ui/theming.md:131
+#: src/system/overview.md:21 src/system/media.md:37
+#: src/plugins/native-extensions.md:175
+msgid "Function"
+msgstr ""
+
+#: src/ui/layout.md:175
+msgid "Append a child widget"
+msgstr ""
+
+#: src/ui/layout.md:176
+msgid "`widgetAddChildAt(parent, child, index)`"
+msgstr ""
+
+#: src/ui/layout.md:176
+msgid "Insert a child at a specific position"
+msgstr ""
+
+#: src/ui/layout.md:177
+msgid "`widgetRemoveChild(parent, child)`"
+msgstr ""
+
+#: src/ui/layout.md:177
+msgid "Remove a specific child"
+msgstr ""
+
+#: src/ui/layout.md:178
+msgid "`widgetReorderChild(widget, fromIndex, toIndex)`"
+msgstr ""
+
+#: src/ui/layout.md:178
+msgid "Move a child to a new position"
+msgstr ""
+
+#: src/ui/layout.md:179
+msgid "`widgetClearChildren(widget)`"
+msgstr ""
+
+#: src/ui/layout.md:179
+msgid "Remove all children"
+msgstr ""
+
+#: src/ui/layout.md:181
+msgid "Stack Alignment"
+msgstr ""
+
+#: src/ui/layout.md:183
+msgid ""
+"Control how children are aligned within a stack using `stackSetAlignment`:"
+msgstr ""
+
+#: src/ui/layout.md:185
+msgid ""
+"```typescript\n"
+"const centered = VStack(16, [\n"
+"    Text(\"Centered\"),\n"
+"    Text(\"Content\"),\n"
+"])\n"
+"stackSetAlignment(centered, 9) // CenterX\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:193
+msgid "**VStack alignment** (cross-axis = horizontal):"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203 src/ui/layout.md:221
+#: src/platforms/tvos.md:149 src/plugins/appstore-review.md:77
+#: src/plugins/appstore-review.md:93 src/plugins/appstore-review.md:106
+#: src/cli/perry-toml.md:215 src/cli/perry-toml.md:277
+#: src/cli/perry-toml.md:284
+msgid "Value"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203 src/ui/layout.md:221
+msgid "Name"
+msgstr ""
+
+#: src/ui/layout.md:195 src/ui/layout.md:203
+msgid "Effect"
+msgstr ""
+
+#: src/ui/layout.md:197 src/ui/styling.md:372 src/testing/geisterhand.md:91
+#: src/testing/geisterhand.md:105 src/cli/perry-toml.md:400
+msgid "5"
+msgstr ""
+
+#: src/ui/layout.md:197
+msgid "Leading"
+msgstr ""
+
+#: src/ui/layout.md:197
+msgid "Children align to the leading (left) edge"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "9"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "CenterX"
+msgstr ""
+
+#: src/ui/layout.md:198
+msgid "Children centered horizontally"
+msgstr ""
+
+#: src/ui/layout.md:199 src/testing/geisterhand.md:93
+msgid "7"
+msgstr ""
+
+#: src/ui/layout.md:199
+msgid "Width"
+msgstr ""
+
+#: src/ui/layout.md:199
+msgid "Children stretch to fill the stack's width"
+msgstr ""
+
+#: src/ui/layout.md:201
+msgid "**HStack alignment** (cross-axis = vertical):"
+msgstr ""
+
+#: src/ui/layout.md:205 src/ui/layout.md:226 src/platforms/windows-7.md:27
+#: src/testing/geisterhand.md:89 src/testing/geisterhand.md:103
+#: src/cli/perry-toml.md:402
+msgid "3"
+msgstr ""
+
+#: src/ui/layout.md:205
+msgid "Top"
+msgstr ""
+
+#: src/ui/layout.md:205
+msgid "Children align to the top"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "12"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "CenterY"
+msgstr ""
+
+#: src/ui/layout.md:206
+msgid "Children centered vertically"
+msgstr ""
+
+#: src/ui/layout.md:207 src/ui/layout.md:227 src/ui/styling.md:371
+#: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
+#: src/cli/perry-toml.md:401
+msgid "4"
+msgstr ""
+
+#: src/ui/layout.md:207
+msgid "Bottom"
+msgstr ""
+
+#: src/ui/layout.md:207
+msgid "Children align to the bottom"
+msgstr ""
+
+#: src/ui/layout.md:209
+msgid "Stack Distribution"
+msgstr ""
+
+#: src/ui/layout.md:211
+msgid ""
+"Control how children share space within a stack using "
+"`stackSetDistribution`:"
+msgstr ""
+
+#: src/ui/layout.md:213
+msgid ""
+"```typescript\n"
+"const buttons = HStack(8, [\n"
+"    Button(\"Cancel\", noop),\n"
+"    Button(\"OK\", noop),\n"
+"])\n"
+"stackSetDistribution(buttons, 1) // FillEqually — both buttons get equal width\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:221 src/widgets/data-fetching.md:125
+msgid "Behavior"
+msgstr ""
+
+#: src/ui/layout.md:223 src/ui/styling.md:370 src/ui/styling.md:371
+#: src/ui/styling.md:372 src/testing/geisterhand.md:86
+#: src/testing/geisterhand.md:100
+msgid "0"
+msgstr ""
+
+#: src/ui/layout.md:223
+msgid "Fill"
+msgstr ""
+
+#: src/ui/layout.md:223
+msgid "Default. First resizable child fills remaining space"
+msgstr ""
+
+#: src/ui/layout.md:224 src/platforms/windows-7.md:25
+#: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
+#: src/cli/perry-toml.md:404
+msgid "1"
+msgstr ""
+
+#: src/ui/layout.md:224
+msgid "FillEqually"
+msgstr ""
+
+#: src/ui/layout.md:224
+msgid "All children get equal size"
+msgstr ""
+
+#: src/ui/layout.md:225 src/platforms/windows-7.md:26
+#: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
+#: src/cli/perry-toml.md:403
+msgid "2"
+msgstr ""
+
+#: src/ui/layout.md:225
+msgid "FillProportionally"
+msgstr ""
+
+#: src/ui/layout.md:225
+msgid "Children sized proportionally to their intrinsic content"
+msgstr ""
+
+#: src/ui/layout.md:226
+msgid "EqualSpacing"
+msgstr ""
+
+#: src/ui/layout.md:226
+msgid "Equal gaps between children"
+msgstr ""
+
+#: src/ui/layout.md:227
+msgid "EqualCentering"
+msgstr ""
+
+#: src/ui/layout.md:227
+msgid "Equal distance between child centers"
+msgstr ""
+
+#: src/ui/layout.md:229
+msgid "Fill Parent"
+msgstr ""
+
+#: src/ui/layout.md:231
+msgid "Pin a child's edges to its parent container:"
+msgstr ""
+
+#: src/ui/layout.md:233
+msgid ""
+"```typescript\n"
+"const banner = Text(\"Full width banner\")\n"
+"widgetMatchParentWidth(banner)\n"
+"const banneredPage = VStack(16, [banner, Text(\"Normal width\")])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:239
+msgid "`widgetMatchParentWidth(widget)` — stretch to fill parent's width"
+msgstr ""
+
+#: src/ui/layout.md:240
+msgid "`widgetMatchParentHeight(widget)` — stretch to fill parent's height"
+msgstr ""
+
+#: src/ui/layout.md:242
+msgid "Content Hugging"
+msgstr ""
+
+#: src/ui/layout.md:244
+msgid ""
+"Control whether a widget resists being stretched beyond its intrinsic size:"
+msgstr ""
+
+#: src/ui/layout.md:246
+msgid ""
+"```typescript\n"
+"const tight = Text(\"I stay small\")\n"
+"widgetSetHugging(tight, 750) // High priority — resist stretching\n"
+"\n"
+"const stretchy = Text(\"I stretch\")\n"
+"widgetSetHugging(stretchy, 1) // Low priority — stretch to fill\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:254
+msgid ""
+"**High priority** (250–750+): widget resists stretching, stays at its "
+"natural size"
+msgstr ""
+
+#: src/ui/layout.md:255
+msgid "**Low priority** (1–249): widget stretches to fill available space"
+msgstr ""
+
+#: src/ui/layout.md:257
+msgid "Overlay Positioning"
+msgstr ""
+
+#: src/ui/layout.md:259
+msgid "For absolute positioning, add overlay children to any container:"
+msgstr ""
+
+#: src/ui/layout.md:261
+msgid ""
+"```typescript\n"
+"// Overlay parent must be a ZStack — macOS NSView allows `addSubview` on\n"
+"// any view, but GTK4 can only float children above siblings inside\n"
+"// `gtk::Overlay` (which is what ZStack is backed by).\n"
+"const container = ZStack()\n"
+"widgetAddChild(container, VStack(16, [Text(\"Main content\")])) // main child\n"
+"\n"
+"const badge = Text(\"3\")\n"
+"setCornerRadius(badge, 10)\n"
+"widgetSetBackgroundColor(badge, 1.0, 0.231, 0.188, 1.0) // RGBA red\n"
+"\n"
+"widgetAddOverlay(container, badge)\n"
+"widgetSetOverlayFrame(badge, 280, 10, 20, 20) // x, y, width, height\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:276
+msgid ""
+"Overlay children are positioned absolutely relative to their parent — "
+"similar to CSS `position: absolute`."
+msgstr ""
+
+#: src/ui/layout.md:279
+msgid "Split Views"
+msgstr ""
+
+#: src/ui/layout.md:281
+msgid "Create resizable split panes for sidebar layouts:"
+msgstr ""
+
+#: src/ui/layout.md:283
+msgid ""
+"```typescript\n"
+"const split = SplitView()\n"
+"\n"
+"const sidebar = VStack(8, [Text(\"Navigation\"), Text(\"Item 1\"), Text(\"Item 2\")])\n"
+"const content = VStack(16, [Text(\"Main Content\")])\n"
+"\n"
+"splitViewAddChild(split, sidebar)\n"
+"splitViewAddChild(split, content)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:293
+msgid ""
+"The user can drag the divider to resize panes. On macOS this maps to "
+"`NSSplitView`."
+msgstr ""
+
+#: src/ui/layout.md:296
+msgid "Stacks with Built-in Padding"
+msgstr ""
+
+#: src/ui/layout.md:298
+msgid ""
+"Create a stack with padding in a single call. The order is **top, left, "
+"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+msgstr ""
+
+#: src/ui/layout.md:301
+msgid ""
+"```typescript\n"
+"// VStackWithInsets(spacing, top, left, bottom, right) — note: order is\n"
+"// top/left/bottom/right (CSS-style), not top/right/bottom/left.\n"
+"const card = VStackWithInsets(12, 16, 16, 16, 16)\n"
+"widgetAddChild(card, Text(\"Padded content\"))\n"
+"widgetAddChild(card, Text(\"More content\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:309
+msgid ""
+"`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
+"counterpart. Equivalent to creating a stack and then calling "
+"`widgetSetEdgeInsets`, but more concise. Children are added via "
+"`widgetAddChild` rather than the constructor array."
+msgstr ""
+
+#: src/ui/layout.md:314
+msgid "Detaching Hidden Views"
+msgstr ""
+
+#: src/ui/layout.md:316
+msgid ""
+"By default, hidden children still occupy space in a stack. To collapse them:"
+msgstr ""
+
+#: src/ui/layout.md:318
+msgid ""
+"```typescript\n"
+"const collapsible = VStack(8, [Text(\"Always visible\"), Text(\"Sometimes hidden\")])\n"
+"stackSetDetachesHidden(collapsible, 1) // Hidden children leave no gap\n"
+"// You can then toggle a child:\n"
+"const sometimesHidden = Text(\"toggle me\")\n"
+"widgetSetHidden(sometimesHidden, 1) // 1 = hidden, 0 = visible\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:326
+msgid "Common Layout Patterns"
+msgstr ""
+
+#: src/ui/layout.md:328
+msgid "Centered content"
+msgstr ""
+
+#: src/ui/layout.md:330
+msgid ""
+"```typescript\n"
+"const page = VStack(16, [Text(\"Title\"), Text(\"Subtitle\")])\n"
+"stackSetAlignment(page, 9) // CenterX\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:335
+msgid "Search row that fills the width"
+msgstr ""
+
+#: src/ui/layout.md:337
+msgid ""
+"```typescript\n"
+"const searchInput = TextField(\"Search...\", (v: string) => search.set(v))\n"
+"widgetMatchParentWidth(searchInput)\n"
+"const results = VStack(8, [])\n"
+"const searchPage = VStack(12, [searchInput, results])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:344
+msgid "Floating badge / overlay"
+msgstr ""
+
+#: src/ui/layout.md:346
+msgid ""
+"```typescript\n"
+"// Wrap the icon in a ZStack so the badge can float above it on every\n"
+"const icon = ZStack()\n"
+"widgetAddChild(icon, ImageSymbol(\"bell\"))\n"
+"const dotBadge = Text(\"3\")\n"
+"widgetAddOverlay(icon, dotBadge)\n"
+"widgetSetOverlayFrame(dotBadge, 20, -5, 16, 16)\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:355
+msgid "Toolbar with spacers"
+msgstr ""
+
+#: src/ui/layout.md:357
+msgid ""
+"```typescript\n"
+"const titleBar = HStack(8, [\n"
+"    Button(\"Back\", noop),\n"
+"    Spacer(),\n"
+"    Text(\"Page Title\"),\n"
+"    Spacer(),\n"
+"    Button(\"Settings\", noop),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/layout.md:369
+msgid "[Styling](styling.md) — Colors, padding, sizing"
+msgstr ""
+
+#: src/ui/layout.md:371
+msgid "[State Management](state.md) — Dynamic UI with state"
+msgstr ""
+
+#: src/ui/styling.md:3
+msgid ""
+"Perry widgets accept an inline `style: { ... }` object that maps to each "
+"platform's native styling APIs. The same shape works on every Widget "
+"constructor — `Button`, `Text`, `Toggle`, `Slider`, `VStack`/`HStack`, and "
+"friends — so cross-platform styling code stays the same regardless of "
+"target."
+msgstr ""
+
+#: src/ui/styling.md:9
+msgid "Inline style — recommended"
+msgstr ""
+
+#: src/ui/styling.md:11
+msgid ""
+"Pass a `StyleProps` object as the trailing argument to any widget "
+"constructor. Codegen destructures the literal at HIR time into a sequence of"
+" native setter calls, so the runtime shape is the same as hand-writing the "
+"imperative pattern below — but the source is much shorter:"
+msgstr ""
+
+#: src/ui/styling.md:17
+msgid ""
+"```typescript\n"
+"const card = Button(\"Save\", () => {\n"
+"    console.log(\"saved\")\n"
+"}, {\n"
+"    backgroundColor: { r: 0.231, g: 0.510, b: 0.965, a: 1.0 },\n"
+"    borderColor: { r: 0.0, g: 0.0, b: 0.0, a: 0.1 },\n"
+"    borderWidth: 1,\n"
+"    borderRadius: 8,\n"
+"    padding: 12,\n"
+"    opacity: 0.95,\n"
+"    shadow: {\n"
+"        color: { r: 0.0, g: 0.0, b: 0.0, a: 0.25 },\n"
+"        blur: 12,\n"
+"        offsetX: 0,\n"
+"        offsetY: 4,\n"
+"    },\n"
+"    tooltip: \"Save the current document\",\n"
+"    enabled: true,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:38
+msgid ""
+"The `style` arg is optional; widgets without it look identical to calls "
+"before this API existed. See "
+"[`docs/examples/ui/styling/button_inline_style.ts`](../../examples/ui/styling/button_inline_style.ts)"
+" for the full file."
+msgstr ""
+
+#: src/ui/styling.md:43
+msgid "What `style` accepts"
+msgstr ""
+
+#: src/ui/styling.md:45
+msgid "Prop"
+msgstr ""
+
+#: src/ui/styling.md:45
+msgid "Maps to"
+msgstr ""
+
+#: src/ui/styling.md:47
+msgid "`backgroundColor`"
+msgstr ""
+
+#: src/ui/styling.md:47 src/ui/styling.md:48 src/ui/styling.md:49
+msgid "string \\| PerryColor"
+msgstr ""
+
+#: src/ui/styling.md:47
+msgid "`widgetSetBackgroundColor`"
+msgstr ""
+
+#: src/ui/styling.md:48
+msgid "`color`"
+msgstr ""
+
+#: src/ui/styling.md:48
+msgid "`textSetColor` / `buttonSetTextColor`"
+msgstr ""
+
+#: src/ui/styling.md:49
+msgid "`borderColor`"
+msgstr ""
+
+#: src/ui/styling.md:49
+msgid "`widgetSetBorderColor`"
+msgstr ""
+
+#: src/ui/styling.md:50
+msgid "`borderWidth`"
+msgstr ""
+
+#: src/ui/styling.md:50
+msgid "`widgetSetBorderWidth`"
+msgstr ""
+
+#: src/ui/styling.md:51
+msgid "`borderRadius`"
+msgstr ""
+
+#: src/ui/styling.md:51
+msgid "`setCornerRadius`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "`padding`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "number \\| `{ top, right, bottom, left }`"
+msgstr ""
+
+#: src/ui/styling.md:52
+msgid "`widgetSetEdgeInsets`"
+msgstr ""
+
+#: src/ui/styling.md:53 src/platforms/watchos.md:77
+msgid "`opacity`"
+msgstr ""
+
+#: src/ui/styling.md:53
+msgid "number (0..=1)"
+msgstr ""
+
+#: src/ui/styling.md:53
+msgid "`widgetSetOpacity`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`shadow`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`{ color, blur, offsetX, offsetY }`"
+msgstr ""
+
+#: src/ui/styling.md:54
+msgid "`widgetSetShadow`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`textDecoration`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`\"none\" \\| \"underline\" \\| \"strikethrough\"`"
+msgstr ""
+
+#: src/ui/styling.md:55
+msgid "`textSetDecoration`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`gradient`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`{ angle, stops: [c1, c2] }`"
+msgstr ""
+
+#: src/ui/styling.md:56
+msgid "`widgetSetBackgroundGradient`"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "`fontSize`, `fontWeight`, `fontFamily`"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "number / string"
+msgstr ""
+
+#: src/ui/styling.md:57
+msgid "`textSetFont*`"
+msgstr ""
+
+#: src/ui/styling.md:58
+msgid "`tooltip`"
+msgstr ""
+
+#: src/ui/styling.md:58
+msgid "`widgetSetTooltip`"
+msgstr ""
+
+#: src/ui/styling.md:59
+msgid "`hidden`"
+msgstr ""
+
+#: src/ui/styling.md:59
+msgid "`widgetSetHidden`"
+msgstr ""
+
+#: src/ui/styling.md:60
+msgid "`enabled`"
+msgstr ""
+
+#: src/ui/styling.md:60
+msgid "`widgetSetEnabled`"
+msgstr ""
+
+#: src/ui/styling.md:62
+msgid "Color values"
+msgstr ""
+
+#: src/ui/styling.md:64
+msgid "Color props accept four interchangeable shapes:"
+msgstr ""
+
+#: src/ui/styling.md:66
+msgid ""
+"```typescript,no-test\n"
+"backgroundColor: \"#3B82F6\"                                   // hex 6/8\n"
+"backgroundColor: \"#3B82F6FF\"                                 // hex with alpha\n"
+"backgroundColor: \"blue\"                                      // named color\n"
+"backgroundColor: { r: 0.231, g: 0.510, b: 0.965, a: 1.0 }   // PerryColor object\n"
+"backgroundColor: themeColor                                  // runtime variable\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:74
+msgid ""
+"Named colors: `white`, `black`, `red`, `green`, `blue`, `yellow`, `cyan`, "
+"`magenta`, `gray` / `grey`, `transparent`. Hex forms supported: `#RGB`, "
+"`#RGBA`, `#RRGGBB`, `#RRGGBBAA`."
+msgstr ""
+
+#: src/ui/styling.md:78
+msgid ""
+"Literals (the first four forms) compile-time-fold into 4 baked-in float "
+"arguments — zero runtime cost. Runtime variables resolve through "
+"`js_color_parse_channel` (a small CSS color parser in `perry-runtime`) so "
+"`backgroundColor: someStringVar` works the same as the literal form."
+msgstr ""
+
+#: src/ui/styling.md:83
+msgid "Padding shapes"
+msgstr ""
+
+#: src/ui/styling.md:85
+msgid "A single number applies to all four sides; an object picks per-side:"
+msgstr ""
+
+#: src/ui/styling.md:87
+msgid ""
+"```typescript,no-test\n"
+"padding: 12                                       // all four sides 12\n"
+"padding: { top: 8, right: 16, bottom: 8, left: 16 }  // per-side\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:92
+msgid "Missing sides default to 0."
+msgstr ""
+
+#: src/ui/styling.md:94
+msgid "Container styling"
+msgstr ""
+
+#: src/ui/styling.md:96
+msgid "`VStack` and `HStack` accept `style` after the children array:"
+msgstr ""
+
+#: src/ui/styling.md:98
+msgid ""
+"```typescript\n"
+"// VStack with explicit spacing AND inline style — children + style.\n"
+"const card = VStack(8, [\n"
+"    Text(\"Heading\"),\n"
+"    Text(\"Subtitle\"),\n"
+"    Button(\"Action\", () => { console.log(\"clicked\") }),\n"
+"], {\n"
+"    backgroundColor: { r: 0.96, g: 0.97, b: 0.99, a: 1.0 },\n"
+"    borderRadius: 12,\n"
+"    padding: 16,\n"
+"    shadow: {\n"
+"        color: { r: 0.0, g: 0.0, b: 0.0, a: 0.1 },\n"
+"        blur: 8,\n"
+"        offsetY: 2,\n"
+"    },\n"
+"})\n"
+"\n"
+"// HStack with no explicit spacing (children-array first form) + style.\n"
+"const toolbar = HStack([\n"
+"    Text(\"Left\"),\n"
+"    Text(\"Right\"),\n"
+"], {\n"
+"    backgroundColor: { r: 0.2, g: 0.2, b: 0.2, a: 1.0 },\n"
+"    padding: { top: 8, right: 16, bottom: 8, left: 16 },\n"
+"    borderRadius: 6,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:126
+msgid ""
+"Both shapes work — `VStack(children, style?)` and `VStack(spacing, children,"
+" style?)`."
+msgstr ""
+
+#: src/ui/styling.md:128
+msgid "Coming from CSS"
+msgstr ""
+
+#: src/ui/styling.md:130
+msgid "If you're coming from web, the conceptual mapping is:"
+msgstr ""
+
+#: src/ui/styling.md:132
+msgid "CSS"
+msgstr ""
+
+#: src/ui/styling.md:132
+msgid "Perry inline style"
+msgstr ""
+
+#: src/ui/styling.md:134
+msgid "`display: flex; flex-direction: column`"
+msgstr ""
+
+#: src/ui/styling.md:134
+msgid "`VStack(spacing, [...])`"
+msgstr ""
+
+#: src/ui/styling.md:135
+msgid "`display: flex; flex-direction: row`"
+msgstr ""
+
+#: src/ui/styling.md:135
+msgid "`HStack(spacing, [...])`"
+msgstr ""
+
+#: src/ui/styling.md:136
+msgid "`width: 100%`"
+msgstr ""
+
+#: src/ui/styling.md:136
+msgid "`widgetMatchParentWidth(widget)`"
+msgstr ""
+
+#: src/ui/styling.md:137
+msgid "`padding: 10px 20px`"
+msgstr ""
+
+#: src/ui/styling.md:137
+msgid "`padding: { top: 10, right: 20, bottom: 10, left: 20 }`"
+msgstr ""
+
+#: src/ui/styling.md:138
+msgid "`gap: 16px`"
+msgstr ""
+
+#: src/ui/styling.md:138
+msgid "`VStack(16, [...])` — first argument is the gap"
+msgstr ""
+
+#: src/ui/styling.md:139
+msgid "CSS variables / design tokens"
+msgstr ""
+
+#: src/ui/styling.md:139
+msgid "[`perry-styling`](theming.md) package"
+msgstr ""
+
+#: src/ui/styling.md:140
+msgid "`opacity: 0.5`"
+msgstr ""
+
+#: src/ui/styling.md:141
+msgid "`border-radius: 8px`"
+msgstr ""
+
+#: src/ui/styling.md:141
+msgid "`borderRadius: 8`"
+msgstr ""
+
+#: src/ui/styling.md:142
+msgid "`background: #3B82F6`"
+msgstr ""
+
+#: src/ui/styling.md:142
+msgid "`backgroundColor: \"#3B82F6\"`"
+msgstr ""
+
+#: src/ui/styling.md:143
+msgid "`box-shadow: 0 4px 12px rgba(0,0,0,0.25)`"
+msgstr ""
+
+#: src/ui/styling.md:143
+msgid "`shadow: { color: \"#0004\", blur: 12, offsetY: 4 }`"
+msgstr ""
+
+#: src/ui/styling.md:144
+msgid "`text-decoration: underline`"
+msgstr ""
+
+#: src/ui/styling.md:144
+msgid "`textDecoration: \"underline\"`"
+msgstr ""
+
+#: src/ui/styling.md:146
+msgid ""
+"See [Layout](layout.md) for full details on alignment, distribution, "
+"overlays, and split views."
+msgstr ""
+
+#: src/ui/styling.md:148
+msgid "Imperative API (underlying)"
+msgstr ""
+
+#: src/ui/styling.md:150
+msgid ""
+"The inline `style` object lowers to the same FFI calls as Perry's imperative"
+" free-function setters: `widgetSet*`, `textSet*`, `buttonSet*`. They take "
+"the widget handle as the first argument and remain available for cases where"
+" you want fine-grained control or need to mutate styles after creation. "
+"Colors here are RGBA floats in `[0.0, 1.0]` (divide each hex byte by 255 — "
+"`0xFF3B30` → `(1.0, 0.231, 0.188, 1.0)`)."
+msgstr ""
+
+#: src/ui/styling.md:158
+msgid ""
+"Every snippet below is excerpted from "
+"[`docs/examples/ui/styling/snippets.ts`](../../examples/ui/styling/snippets.ts),"
+" which CI compiles and runs on every PR — so the API drawn here is always "
+"the API the compiler accepts."
+msgstr ""
+
+#: src/ui/styling.md:163
+msgid ""
+"```typescript\n"
+"import {\n"
+"    App,\n"
+"    VStack, VStackWithInsets, HStack, Spacer,\n"
+"    Text, Button,\n"
+"    textSetColor, textSetFontSize, textSetFontFamily, textSetFontWeight,\n"
+"    setCornerRadius, setPadding,\n"
+"    widgetAddChild,\n"
+"    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
+"    widgetSetBorderColor, widgetSetBorderWidth,\n"
+"    widgetSetEdgeInsets,\n"
+"    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
+"    widgetSetOpacity,\n"
+"    widgetSetControlSize,\n"
+"    widgetSetTooltip,\n"
+"    widgetSetEnabled,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:182
+msgid "Colors"
+msgstr ""
+
+#: src/ui/styling.md:184
+msgid ""
+"```typescript\n"
+"const colored = Text(\"Colored text\")\n"
+"textSetColor(colored, 1.0, 0.0, 0.0, 1.0)              // r, g, b, a in [0,1]\n"
+"widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:190
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/styling.md:192
+msgid ""
+"```typescript\n"
+"const font = Text(\"Styled text\")\n"
+"textSetFontSize(font, 24)                  // Font size in points\n"
+"textSetFontFamily(font, \"Menlo\")           // Font family name\n"
+"textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:199
+msgid "Use `\"monospaced\"` for the system monospaced font."
+msgstr ""
+
+#: src/ui/styling.md:201
+msgid "Corner Radius"
+msgstr ""
+
+#: src/ui/styling.md:203
+msgid ""
+"```typescript\n"
+"const rounded = Button(\"Rounded\", () => {})\n"
+"setCornerRadius(rounded, 12)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:208
+msgid "Borders"
+msgstr ""
+
+#: src/ui/styling.md:216
+msgid "Padding and Insets"
+msgstr ""
+
+#: src/ui/styling.md:218
+msgid ""
+"```typescript\n"
+"const padded = VStack(8, [Text(\"Padded content\")])\n"
+"// Both names accept (widget, top, left, bottom, right):\n"
+"setPadding(padded, 16, 16, 16, 16)\n"
+"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:225
+msgid "Sizing"
+msgstr ""
+
+#: src/ui/styling.md:227
+msgid ""
+"```typescript\n"
+"const sized = VStack(0, [])\n"
+"widgetSetWidth(sized, 300)\n"
+"widgetSetHeight(sized, 200)\n"
+"widgetMatchParentWidth(sized) // expand to fill parent's width\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:234 src/ui/theming.md:144
+msgid "Opacity"
+msgstr ""
+
+#: src/ui/styling.md:236
+msgid ""
+"```typescript\n"
+"const dim = Text(\"Semi-transparent\")\n"
+"widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:241
+msgid "Background Gradient"
+msgstr ""
+
+#: src/ui/styling.md:243
+msgid ""
+"```typescript\n"
+"const grad = VStack(0, [])\n"
+"// Two RGBA stops + angle (degrees, 0 = top-to-bottom).\n"
+"widgetSetBackgroundGradient(grad,\n"
+"    1.0, 0.0, 0.0, 1.0,   // start (red)\n"
+"    0.0, 0.0, 1.0, 1.0,   // end   (blue)\n"
+"    0,                    // angle\n"
+")\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:253
+msgid "Control Size"
+msgstr ""
+
+#: src/ui/styling.md:255
+msgid ""
+"```typescript\n"
+"const small = Button(\"Small\", () => {})\n"
+"widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:260
+msgid ""
+"**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
+"differently."
+msgstr ""
+
+#: src/ui/styling.md:262
+msgid "Tooltips"
+msgstr ""
+
+#: src/ui/styling.md:264
+msgid ""
+"```typescript\n"
+"const tip = Button(\"Hover me\", () => {})\n"
+"widgetSetTooltip(tip, \"Click to perform action\")\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:269
+msgid ""
+"**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
+"support. **Web**: HTML `title` attribute."
+msgstr ""
+
+#: src/ui/styling.md:271
+msgid "Enabled/Disabled"
+msgstr ""
+
+#: src/ui/styling.md:273
+msgid ""
+"```typescript\n"
+"const submit = Button(\"Submit\", () => {})\n"
+"widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:278
+msgid "Complete Imperative Example"
+msgstr ""
+
+#: src/ui/styling.md:280
+msgid ""
+"```typescript\n"
+"// demonstrates: a styled counter card using the real free-function API\n"
+"// docs: docs/src/ui/styling.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    VStack,\n"
+"    HStack,\n"
+"    State,\n"
+"    Spacer,\n"
+"    textSetFontSize,\n"
+"    textSetFontFamily,\n"
+"    textSetColor,\n"
+"    widgetSetBackgroundColor,\n"
+"    widgetSetEdgeInsets,\n"
+"    setCornerRadius,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// Note: widgetSetBorderColor / widgetSetBorderWidth are macOS/iOS/Windows\n"
+"// only — perry-ui-gtk4 doesn't export them (GTK4 borders are CSS-driven).\n"
+"// Omitted from this demo so it compiles everywhere.\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"const title = Text(\"Counter\")\n"
+"textSetFontSize(title, 28)\n"
+"textSetColor(title, 0.1, 0.1, 0.1, 1.0)\n"
+"\n"
+"const display = Text(`${count.value}`)\n"
+"textSetFontSize(display, 48)\n"
+"textSetFontFamily(display, \"monospaced\")\n"
+"textSetColor(display, 0.0, 0.478, 1.0, 1.0)\n"
+"\n"
+"const decBtn = Button(\"-\", () => count.set(count.value - 1))\n"
+"setCornerRadius(decBtn, 20)\n"
+"widgetSetBackgroundColor(decBtn, 1.0, 0.231, 0.188, 1.0)\n"
+"\n"
+"const incBtn = Button(\"+\", () => count.set(count.value + 1))\n"
+"setCornerRadius(incBtn, 20)\n"
+"widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
+"\n"
+"const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
+"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"\n"
+"const container = VStack(16, [title, display, controls])\n"
+"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setCornerRadius(container, 16)\n"
+"widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
+"\n"
+"App({\n"
+"    title: \"Styled App\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: container,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/styling.md:341
+msgid "Composing Styles (imperative helper functions)"
+msgstr ""
+
+#: src/ui/styling.md:343
+msgid "Reduce repetition by creating helper functions:"
+msgstr ""
+
+#: src/ui/styling.md:357
+msgid ""
+"For larger apps, use the `perry-styling` package to define design tokens in "
+"JSON and generate a typed theme file. See [Theming](theming.md) for the full"
+" workflow."
+msgstr ""
+
+#: src/ui/styling.md:359
+msgid "Platform support"
+msgstr ""
+
+#: src/ui/styling.md:361
+msgid ""
+"Per-prop, per-platform support is tracked in the [styling matrix](styling-"
+"matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and"
+" CI-checked against each backend's `lib.rs` exports on every PR."
+msgstr ""
+
+#: src/ui/styling.md:366
+msgid ""
+"Current state (issue [\\#185](https://github.com/PerryTS/perry/issues/185)):"
+msgstr ""
+
+#: src/ui/styling.md:368 src/ui/canvas.md:72 src/ui/canvas.md:73
+#: src/ui/canvas.md:74 src/ui/canvas.md:75 src/ui/canvas.md:76
+#: src/ui/canvas.md:78
+msgid "Wired"
+msgstr ""
+
+#: src/ui/styling.md:368
+msgid "Stub"
+msgstr ""
+
+#: src/ui/styling.md:368
+msgid "Missing"
+msgstr ""
+
+#: src/ui/styling.md:370
+msgid "macOS / iOS / tvOS / visionOS / watchOS / Android / Web"
+msgstr ""
+
+#: src/ui/styling.md:370
+msgid "**43/43**"
+msgstr ""
+
+#: src/ui/styling.md:371
+msgid "GTK4 (Linux)"
+msgstr ""
+
+#: src/ui/styling.md:371
+msgid "39/43"
+msgstr ""
+
+#: src/ui/styling.md:372
+msgid "38/43"
+msgstr ""
+
+#: src/ui/styling.md:374
+msgid ""
+"**GTK4** has 4 styling props (`widget.on_click`, "
+"`button.content_tint_color`, `button.image_position`, "
+"`stack.detaches_hidden`) that need a Linux contributor — tracked in issue "
+"[\\#202](https://github.com/PerryTS/perry/issues/202). Inline `style: {...}`"
+" calls referencing only the wired props compile and run cleanly today; the "
+"missing props silently no-op until that issue lands."
+msgstr ""
+
+#: src/ui/styling.md:375
+msgid ""
+"**Windows** has 5 props in a \"deferred-paint family\" (`shadow`, `opacity`,"
+" `border_color`, `border_width`, `text.decoration`) where the FFI symbol "
+"exists and stores the requested params, but a custom `WM_PAINT` rendering "
+"pass is needed to make them visible — tracked in issue "
+"[\\#210](https://github.com/PerryTS/perry/issues/210). User code authoring "
+"inline styles compiles and links cleanly on Windows; the visual rendering "
+"catches up when that issue lands."
+msgstr ""
+
+#: src/ui/styling.md:380 src/ui/state.md:229 src/ui/table.md:110
+msgid "[Layout](layout.md) — Layout containers"
+msgstr ""
+
+#: src/ui/styling.md:381
+msgid "[Animation](animation.md) — Animate style changes"
+msgstr ""
+
+#: src/ui/styling.md:382
+msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
+msgstr ""
+
+#: src/ui/state.md:3
+msgid ""
+"Perry uses reactive state to automatically update the UI when data changes. "
+"Every snippet below is excerpted from "
+"[`docs/examples/ui/state/snippets.ts`](../../examples/ui/state/snippets.ts) "
+"— CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/state.md:8
+msgid "Creating State"
+msgstr ""
+
+#: src/ui/state.md:10
+msgid ""
+"```typescript\n"
+"const counter = State(0)               // number state\n"
+"const username = State(\"Perry\")        // string state\n"
+"const items = State<string[]>([])      // array state\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:16
+msgid "`State(initialValue)` creates a reactive state container."
+msgstr ""
+
+#: src/ui/state.md:18
+msgid "Reading and Writing"
+msgstr ""
+
+#: src/ui/state.md:20
+msgid ""
+"```typescript\n"
+"const value = counter.value     // Read current value\n"
+"counter.set(42)                  // Set new value → triggers UI update\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:25
+msgid "Every `.set()` call re-renders the widget tree with the new value."
+msgstr ""
+
+#: src/ui/state.md:27
+msgid "Reactive Text"
+msgstr ""
+
+#: src/ui/state.md:29
+msgid "Template literals with `state.value` update automatically:"
+msgstr ""
+
+#: src/ui/state.md:31
+msgid ""
+"```typescript\n"
+"const showCount = State(0)\n"
+"const countLabel = Text(`Count: ${showCount.value}`)\n"
+"// The text updates whenever showCount changes.\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:37
+msgid ""
+"This works because Perry detects `state.value` reads inside template "
+"literals and creates reactive bindings."
+msgstr ""
+
+#: src/ui/state.md:40
+msgid "Binding Inputs to State"
+msgstr ""
+
+#: src/ui/state.md:42
+msgid ""
+"Input widgets expose an `onChange` callback. Forward that into a state's "
+"`.set(...)` to keep the state in sync as the user types/toggles/drags:"
+msgstr ""
+
+#: src/ui/state.md:45
+msgid ""
+"```typescript\n"
+"const input = State(\"\")\n"
+"const field = TextField(\"Type here...\", (v: string) => input.set(v))\n"
+"\n"
+"// Optional: also let input.set(\"hello\") update the field on screen.\n"
+"stateBindTextfield(input, field)\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:53
+msgid "Input control signatures:"
+msgstr ""
+
+#: src/ui/state.md:54
+msgid ""
+"`TextField(placeholder, onChange)` — text input, `onChange: (value: string) "
+"=> void`"
+msgstr ""
+
+#: src/ui/state.md:55
+msgid ""
+"`SecureField(placeholder, onChange)` — password input, `onChange: (value: "
+"string) => void`"
+msgstr ""
+
+#: src/ui/state.md:56
+msgid ""
+"`Toggle(label, onChange)` — boolean toggle, `onChange: (value: boolean) => "
+"void`"
+msgstr ""
+
+#: src/ui/state.md:57
+msgid ""
+"`Slider(min, max, onChange)` — numeric slider, `onChange: (value: number) =>"
+" void`"
+msgstr ""
+
+#: src/ui/state.md:58
+msgid ""
+"`Picker(onChange)` — dropdown, `onChange: (index: number) => void`; items "
+"via `pickerAddItem`"
+msgstr ""
+
+#: src/ui/state.md:60
+msgid ""
+"For programmatic-to-UI sync (state-drives-widget) use the dedicated binders:"
+" `stateBindTextfield`, `stateBindSlider`, `stateBindToggle`, "
+"`stateBindTextNumeric`, `stateBindVisibility`."
+msgstr ""
+
+#: src/ui/state.md:64
+msgid "onChange Callbacks"
+msgstr ""
+
+#: src/ui/state.md:66
+msgid "Listen for state changes with the free-function `stateOnChange`:"
+msgstr ""
+
+#: src/ui/state.md:75 src/widgets/components.md:92 src/widgets/platforms.md:27
+msgid "ForEach"
+msgstr ""
+
+#: src/ui/state.md:77
+msgid "Render a list from numeric state (the index count):"
+msgstr ""
+
+#: src/ui/state.md:79
+msgid ""
+"```typescript\n"
+"const fruits = State([\"Apple\", \"Banana\", \"Cherry\"])\n"
+"const fruitCount = State(3)\n"
+"\n"
+"const fruitList = VStack(16, [\n"
+"    ForEach(fruitCount, (i: number) =>\n"
+"        Text(`${i + 1}. ${fruits.value[i]}`),\n"
+"    ),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:90
+msgid ""
+"**Note:** `ForEach` iterates by index over a numeric state. Keep a count "
+"state in sync with your array, then read the items via `array.value[i]` "
+"inside the closure."
+msgstr ""
+
+#: src/ui/state.md:94
+msgid "`ForEach` re-renders the list when the count state changes:"
+msgstr ""
+
+#: src/ui/state.md:96
+msgid ""
+"```typescript\n"
+"// Add an item:\n"
+"fruits.set([...fruits.value, \"Date\"])\n"
+"fruitCount.set(fruitCount.value + 1)\n"
+"\n"
+"// Remove an item:\n"
+"fruits.set(fruits.value.filter((_, i) => i !== 1))\n"
+"fruitCount.set(fruitCount.value - 1)\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:106
+msgid "Conditional Rendering"
+msgstr ""
+
+#: src/ui/state.md:108
+msgid "Use state to conditionally show widgets:"
+msgstr ""
+
+#: src/ui/state.md:110
+msgid ""
+"```typescript\n"
+"const showDetails = State(false)\n"
+"const detailsLabel: number = showDetails.value\n"
+"    ? Text(\"Details are visible!\")\n"
+"    : Spacer()\n"
+"const detailsPanel = VStack(16, [\n"
+"    Button(\"Toggle\", () => showDetails.set(!showDetails.value)),\n"
+"    detailsLabel,\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:121
+msgid "Multi-State Text"
+msgstr ""
+
+#: src/ui/state.md:123
+msgid "Text can depend on multiple state values:"
+msgstr ""
+
+#: src/ui/state.md:125
+msgid ""
+"```typescript\n"
+"const firstName = State(\"John\")\n"
+"const lastName = State(\"Doe\")\n"
+"\n"
+"const greeting = Text(`Hello, ${firstName.value} ${lastName.value}!`)\n"
+"// Updates when either firstName or lastName changes.\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:133
+msgid "State with Objects and Arrays"
+msgstr ""
+
+#: src/ui/state.md:135
+msgid ""
+"```typescript\n"
+"const user = State({ name: \"Perry\", age: 0 })\n"
+"\n"
+"// Update by replacing the whole object:\n"
+"user.set({ ...user.value, age: 1 })\n"
+"\n"
+"const todos = State<{ text: string; done: boolean }[]>([])\n"
+"\n"
+"// Add a todo:\n"
+"todos.set([...todos.value, { text: \"New task\", done: false }])\n"
+"\n"
+"// Toggle a todo (must produce a new array reference):\n"
+"const next = todos.value.slice()\n"
+"if (next.length > 0) {\n"
+"    next[0] = { ...next[0], done: !next[0].done }\n"
+"    todos.set(next)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/state.md:154
+msgid ""
+"**Note**: State uses identity comparison. You must create a new array/object"
+" reference for changes to be detected. Mutating in-place without calling "
+"`.set()` with a new reference won't trigger updates."
+msgstr ""
+
+#: src/ui/state.md:158 src/ui/events.md:113 src/ui/table.md:73
+#: src/widgets/components.md:225
+msgid "Complete Example"
+msgstr ""
+
+#: src/ui/state.md:221
+msgid ""
+"This program is built and run by CI (`scripts/run_doc_tests.sh`), so the "
+"snippet above always matches the compiled artifact under "
+"[`docs/examples/ui/state/todo_app.ts`](../../examples/ui/state/todo_app.ts)."
+msgstr ""
+
+#: src/ui/state.md:227
+msgid "[Events](events.md) — Click, hover, keyboard events"
+msgstr ""
+
+#: src/ui/events.md:3
+msgid ""
+"Perry widgets support native event handlers for user interaction. Every "
+"snippet below is excerpted from "
+"[`docs/examples/ui/events/snippets.ts`](../../examples/ui/events/snippets.ts)"
+" — CI compiles and runs it on every PR, so the API drawn here is the API the"
+" runtime exposes."
+msgstr ""
+
+#: src/ui/events.md:9
+msgid ""
+"Event handlers are registered as **free functions** that take the widget "
+"handle as the first argument. The widget handle itself is opaque (`number` "
+"at the type level); perry's API is function-first throughout."
+msgstr ""
+
+#: src/ui/events.md:13 src/testing/geisterhand.md:100
+msgid "onClick"
+msgstr ""
+
+#: src/ui/events.md:15
+msgid ""
+"```typescript\n"
+"const greet = Button(\"Click me\", () => {\n"
+"    log.set(\"Button clicked\")\n"
+"})\n"
+"\n"
+"// Or attach a click handler to a non-button widget after creation:\n"
+"const label = Text(\"Clickable text\")\n"
+"widgetSetOnClick(label, () => {\n"
+"    log.set(\"Text clicked\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:27 src/testing/geisterhand.md:103
+msgid "onHover"
+msgstr ""
+
+#: src/ui/events.md:29
+msgid "Triggered when the cursor enters the widget."
+msgstr ""
+
+#: src/ui/events.md:31
+msgid ""
+"```typescript\n"
+"const hoverBtn = Button(\"Hover me\", () => {})\n"
+"widgetSetOnHover(hoverBtn, () => {\n"
+"    log.set(\"hovered\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:38
+msgid ""
+"**Note**: Hover events are available on macOS, Windows, Linux, and Web. iOS "
+"and Android use touch interactions instead. The callback fires once on "
+"enter; if you need a \"left\" event you'll have to track it yourself."
+msgstr ""
+
+#: src/ui/events.md:42 src/testing/geisterhand.md:104
+msgid "onDoubleClick"
+msgstr ""
+
+#: src/ui/events.md:44
+msgid ""
+"```typescript\n"
+"const dbl = Text(\"Double-click me\")\n"
+"widgetSetOnDoubleClick(dbl, () => {\n"
+"    log.set(\"double-clicked!\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:51 src/ui/menus.md:64
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: src/ui/events.md:53
+msgid "Register in-app keyboard shortcuts (active when the app is focused):"
+msgstr ""
+
+#: src/ui/events.md:55
+msgid ""
+"```typescript\n"
+"// Cmd+N on macOS, Ctrl+N on other platforms (modifier 1 = Cmd/Ctrl).\n"
+"addKeyboardShortcut(\"n\", 1, () => {\n"
+"    log.set(\"New document\")\n"
+"})\n"
+"\n"
+"// Cmd+Shift+S — modifiers add: 1 (Cmd/Ctrl) + 2 (Shift) = 3.\n"
+"addKeyboardShortcut(\"s\", 3, () => {\n"
+"    log.set(\"Save as...\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:67
+msgid ""
+"**Modifier bits:** `1` = Cmd (macOS) / Ctrl (Windows/Linux), `2` = Shift, "
+"`4` = Option (macOS) / Alt (others), `8` = Control (macOS only). Combine by "
+"adding — `3` = Cmd+Shift, `5` = Cmd+Option, etc."
+msgstr ""
+
+#: src/ui/events.md:71
+msgid "Keyboard shortcuts are also available on [menu items](menus.md):"
+msgstr ""
+
+#: src/ui/events.md:73
+msgid ""
+"```typescript\n"
+"const fileMenu = menuCreate()\n"
+"menuAddItem(fileMenu, \"New\", () => log.set(\"file/new\"))\n"
+"menuAddItem(fileMenu, \"Save As\", () => log.set(\"file/saveAs\"))\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:79
+msgid "Global Hotkeys"
+msgstr ""
+
+#: src/ui/events.md:81
+msgid ""
+"Register a hotkey that fires system-wide, even when the app is in the "
+"background:"
+msgstr ""
+
+#: src/ui/events.md:84
+msgid ""
+"```typescript\n"
+"// System-wide: fires even when the app is in the background.\n"
+"// macOS: real Carbon RegisterEventHotKey. Other platforms: no-op.\n"
+"registerGlobalHotkey(\"F5\", 0, () => {\n"
+"    log.set(\"Global F5 hotkey fired\")\n"
+"})\n"
+"\n"
+"// Cmd+Shift+G (modifiers: 1=Cmd + 2=Shift = 3)\n"
+"registerGlobalHotkey(\"g\", 3, () => {\n"
+"    log.set(\"Global Cmd+Shift+G fired\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:97
+msgid ""
+"**Platform support:** macOS uses Carbon `RegisterEventHotKey` (real "
+"implementation). Linux, Windows, iOS, tvOS, visionOS, watchOS, and Android "
+"log the registration and no-op — global hotkeys on those platforms require "
+"OS-level portal / hook APIs that vary per OS."
+msgstr ""
+
+#: src/ui/events.md:102 src/system/other.md:44
+msgid "Clipboard"
+msgstr ""
+
+#: src/ui/events.md:104 src/system/other.md:48
+msgid ""
+"```typescript\n"
+"// Copy to clipboard\n"
+"clipboardWrite(\"Hello, clipboard!\")\n"
+"\n"
+"// Read from clipboard\n"
+"const text = clipboardRead()\n"
+"log.set(`clipboard length: ${text.length}`)\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:115
+msgid ""
+"```typescript\n"
+"// demonstrates: click + hover + double-click + keyboard shortcut all wired to\n"
+"// a single State-backed status label\n"
+"// docs: docs/src/ui/events.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, web, wasm\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    Text,\n"
+"    Button,\n"
+"    VStack,\n"
+"    State,\n"
+"    Spacer,\n"
+"    addKeyboardShortcut,\n"
+"    widgetSetOnHover,\n"
+"    widgetSetOnDoubleClick,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"const lastEvent = State(\"No events yet\")\n"
+"\n"
+"// Cmd+R (modifiers: 1 = Cmd/Ctrl).\n"
+"addKeyboardShortcut(\"r\", 1, () => {\n"
+"    lastEvent.set(\"Keyboard: Cmd+R\")\n"
+"})\n"
+"\n"
+"const hoverBtn = Button(\"Hover me\", () => {})\n"
+"widgetSetOnHover(hoverBtn, () => {\n"
+"    lastEvent.set(\"Hover fired\")\n"
+"})\n"
+"\n"
+"const dblLabel = Text(\"Double-click me\")\n"
+"widgetSetOnDoubleClick(dblLabel, () => {\n"
+"    lastEvent.set(\"Double-clicked!\")\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Events Demo\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Last event: ${lastEvent.value}`),\n"
+"        Spacer(),\n"
+"        Button(\"Click me\", () => {\n"
+"            lastEvent.set(\"Button clicked\")\n"
+"        }),\n"
+"        hoverBtn,\n"
+"        dblLabel,\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/events.md:169
+msgid "[Menus](menus.md) — Menu bar and context menus with keyboard shortcuts"
+msgstr ""
+
+#: src/ui/events.md:171
+msgid "[State Management](state.md) — Reactive state"
+msgstr ""
+
+#: src/ui/canvas.md:3
+msgid "The `Canvas` widget provides a 2D drawing surface for custom graphics."
+msgstr ""
+
+#: src/ui/canvas.md:5
+msgid ""
+"**Availability**: `Canvas` is wired in the **LLVM** codegen path (macOS, "
+"iOS, Linux, Android) and the **JS / web / wasm** codegen path. Closed via "
+"[\\#190](https://github.com/PerryTS/perry/issues/190). The snippets below "
+"are compile-link verified by the doc-tests harness against "
+"[`docs/examples/ui/canvas/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/ui/canvas/snippets.ts);"
+" see that file for the full standalone program."
+msgstr ""
+
+#: src/ui/canvas.md:12
+msgid ""
+"The drawing API is **method-based** on the canvas handle (matching the FFI "
+"shape — `perry_ui_canvas_set_fill_color(handle, r, g, b, a)` etc.). Colors "
+"are RGBA floats in `[0.0, 1.0]`."
+msgstr ""
+
+#: src/ui/canvas.md:16
+msgid "Creating a Canvas"
+msgstr ""
+
+#: src/ui/canvas.md:24
+msgid ""
+"`Canvas(width, height)` creates a canvas widget; subsequent draw operations "
+"are method calls on the returned handle."
+msgstr ""
+
+#: src/ui/canvas.md:27
+msgid "Drawing Shapes"
+msgstr ""
+
+#: src/ui/canvas.md:29
+msgid "Rectangles"
+msgstr ""
+
+#: src/ui/canvas.md:31
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(1.0, 0.0, 0.0, 1.0)    // red\n"
+"canvas.fillRect(10, 10, 100, 80)\n"
+"\n"
+"canvas.setStrokeColor(0.0, 0.0, 1.0, 1.0)  // blue\n"
+"canvas.setLineWidth(2)\n"
+"canvas.strokeRect(150, 10, 100, 80)\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:40
+msgid "Lines"
+msgstr ""
+
+#: src/ui/canvas.md:51
+msgid "Circles and Arcs"
+msgstr ""
+
+#: src/ui/canvas.md:53
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(0.0, 1.0, 0.0, 1.0)\n"
+"canvas.beginPath()\n"
+"canvas.arc(200, 150, 50, 0, Math.PI * 2)  // x, y, radius, startAngle, endAngle\n"
+"canvas.fill()\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:62
+msgid ""
+"```typescript\n"
+"canvas.setFillColor(0.0, 0.0, 0.0, 1.0)\n"
+"canvas.setFont(\"16px sans-serif\")\n"
+"canvas.fillText(\"Hello Canvas!\", 50, 50)\n"
+"```"
+msgstr ""
+
+#: src/ui/canvas.md:68 src/ui/menus.md:107 src/ui/dialogs.md:106
+#: src/ui/animation.md:60 src/ui/multi-window.md:136
+msgid "Platform Notes"
+msgstr ""
+
+#: src/ui/canvas.md:70 src/ui/animation.md:62 src/ui/multi-window.md:70
+#: src/ui/multi-window.md:87 src/ui/multi-window.md:98
+#: src/ui/multi-window.md:114 src/ui/multi-window.md:130
+#: src/ui/multi-window.md:138 src/ui/camera.md:137 src/system/other.md:18
+msgid "Implementation"
+msgstr ""
+
+#: src/ui/canvas.md:70 src/platforms/overview.md:7 src/system/media.md:84
+#: src/testing/geisterhand.md:298
+msgid "Status"
+msgstr ""
+
+#: src/ui/canvas.md:72
+msgid "HTML5 Canvas"
+msgstr ""
+
+#: src/ui/canvas.md:73
+msgid "WASM"
+msgstr ""
+
+#: src/ui/canvas.md:73
+msgid "HTML5 Canvas via JS bridge"
+msgstr ""
+
+#: src/ui/canvas.md:74 src/ui/canvas.md:75
+msgid "Core Graphics (CGContext)"
+msgstr ""
+
+#: src/ui/canvas.md:76
+msgid "Cairo"
+msgstr ""
+
+#: src/ui/canvas.md:77 src/platforms/windows.md:52
+msgid "GDI"
+msgstr ""
+
+#: src/ui/canvas.md:77
+msgid "Planned"
+msgstr ""
+
+#: src/ui/canvas.md:78
+msgid "Canvas/Bitmap"
+msgstr ""
+
+#: src/ui/canvas.md:83
+msgid "[Animation](animation.md) — Animating widget properties"
+msgstr ""
+
+#: src/ui/canvas.md:84
+msgid "[Styling](styling.md) — Widget styling"
+msgstr ""
+
+#: src/ui/menus.md:3
+msgid ""
+"Perry supports native menu bars, context menus, and toolbars across all "
+"platforms. Every snippet below is excerpted from "
+"[`docs/examples/ui/menus/snippets.ts`](../../examples/ui/menus/snippets.ts) "
+"— CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/menus.md:8
+msgid ""
+"The menu API is **handle-based** and free-function: build menus with "
+"`menuCreate()`, fill them with `menuAddItem` / `menuAddItemWithShortcut`, "
+"and attach them with `menuBarAddMenu(bar, title, menu)`. Submenus go through"
+" `menuAddSubmenu(parent, title, submenu)`."
+msgstr ""
+
+#: src/ui/menus.md:13 src/ui/menus.md:109
+msgid "Menu Bar"
+msgstr ""
+
+#: src/ui/menus.md:15
+msgid ""
+"```typescript\n"
+"// Menus are created independently, then attached. Build child menus first,\n"
+"// then hand them to `menuBarAddMenu(bar, title, menu)`.\n"
+"const menuBar = menuBarCreate()\n"
+"\n"
+"// File menu\n"
+"const fileMenu = menuCreate()\n"
+"menuAddItemWithShortcut(fileMenu, \"New\",         \"n\", () => status.set(\"file/new\"))\n"
+"menuAddItemWithShortcut(fileMenu, \"Open…\",       \"o\", () => status.set(\"file/open\"))\n"
+"menuAddSeparator(fileMenu)\n"
+"menuAddItemWithShortcut(fileMenu, \"Save\",        \"s\", () => status.set(\"file/save\"))\n"
+"menuAddItemWithShortcut(fileMenu, \"Save As…\",    \"S\", () => status.set(\"file/saveAs\"))\n"
+"menuBarAddMenu(menuBar, \"File\", fileMenu)\n"
+"\n"
+"// Edit menu\n"
+"const editMenu = menuCreate()\n"
+"menuAddItemWithShortcut(editMenu, \"Undo\", \"z\", () => status.set(\"edit/undo\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Redo\", \"Z\", () => status.set(\"edit/redo\"))\n"
+"menuAddSeparator(editMenu)\n"
+"menuAddItemWithShortcut(editMenu, \"Cut\",   \"x\", () => status.set(\"edit/cut\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Copy\",  \"c\", () => status.set(\"edit/copy\"))\n"
+"menuAddItemWithShortcut(editMenu, \"Paste\", \"v\", () => status.set(\"edit/paste\"))\n"
+"menuBarAddMenu(menuBar, \"Edit\", editMenu)\n"
+"\n"
+"// Submenu: View → Zoom\n"
+"const viewMenu = menuCreate()\n"
+"const zoomSubmenu = menuCreate()\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Zoom In\",     \"+\", () => status.set(\"zoom/in\"))\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Zoom Out\",    \"-\", () => status.set(\"zoom/out\"))\n"
+"menuAddItemWithShortcut(zoomSubmenu, \"Actual Size\", \"0\", () => status.set(\"zoom/reset\"))\n"
+"menuAddSubmenu(viewMenu, \"Zoom\", zoomSubmenu)\n"
+"menuBarAddMenu(menuBar, \"View\", viewMenu)\n"
+"\n"
+"menuBarAttach(menuBar)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:51
+msgid "Menu Bar Functions"
+msgstr ""
+
+#: src/ui/menus.md:55
+msgid "`menuBarCreate()`"
+msgstr ""
+
+#: src/ui/menus.md:55
+msgid "Create a new (empty) menu bar"
+msgstr ""
+
+#: src/ui/menus.md:56
+msgid "`menuCreate()`"
+msgstr ""
+
+#: src/ui/menus.md:56
+msgid "Create a new menu — used as a child of the bar or as a submenu"
+msgstr ""
+
+#: src/ui/menus.md:57
+msgid "`menuBarAddMenu(bar, title, menu)`"
+msgstr ""
+
+#: src/ui/menus.md:57
+msgid "Attach a top-level menu under `title`"
+msgstr ""
+
+#: src/ui/menus.md:58
+msgid "`menuAddItem(menu, label, callback)`"
+msgstr ""
+
+#: src/ui/menus.md:58
+msgid "Append an item without a shortcut"
+msgstr ""
+
+#: src/ui/menus.md:59
+msgid "`menuAddItemWithShortcut(menu, label, shortcut, callback)`"
+msgstr ""
+
+#: src/ui/menus.md:59
+msgid "Append an item with a keyboard shortcut"
+msgstr ""
+
+#: src/ui/menus.md:60
+msgid "`menuAddSeparator(menu)`"
+msgstr ""
+
+#: src/ui/menus.md:60
+msgid "Append a horizontal separator line"
+msgstr ""
+
+#: src/ui/menus.md:61
+msgid "`menuAddSubmenu(parent, title, submenu)`"
+msgstr ""
+
+#: src/ui/menus.md:61
+msgid "Nest a previously-created menu under a label"
+msgstr ""
+
+#: src/ui/menus.md:62
+msgid "`menuBarAttach(bar)`"
+msgstr ""
+
+#: src/ui/menus.md:62
+msgid "Install the bar as the application's main menu"
+msgstr ""
+
+#: src/ui/menus.md:66
+msgid "The third argument to `menuAddItemWithShortcut` is the shortcut key:"
+msgstr ""
+
+#: src/ui/menus.md:68 src/testing/geisterhand.md:92
+#: src/testing/geisterhand.md:295
+msgid "Shortcut"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "`\"n\"`"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "Cmd+N"
+msgstr ""
+
+#: src/ui/menus.md:70
+msgid "Ctrl+N"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "`\"S\"`"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "Cmd+Shift+S"
+msgstr ""
+
+#: src/ui/menus.md:71
+msgid "Ctrl+Shift+S"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "`\"+\"`"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "Cmd++"
+msgstr ""
+
+#: src/ui/menus.md:72
+msgid "Ctrl++"
+msgstr ""
+
+#: src/ui/menus.md:74
+msgid "Uppercase letters imply Shift."
+msgstr ""
+
+#: src/ui/menus.md:76
+msgid "Context Menus"
+msgstr ""
+
+#: src/ui/menus.md:78
+msgid ""
+"Right-click menus are attached to widgets via `widgetSetContextMenu(widget, "
+"menu)`. Build the menu the same way as a menu-bar entry, then bind it:"
+msgstr ""
+
+#: src/ui/menus.md:81
+msgid ""
+"```typescript\n"
+"const label = Text(\"Right-click me\")\n"
+"const ctx = menuCreate()\n"
+"menuAddItem(ctx, \"Copy\",   () => status.set(\"ctx/copy\"))\n"
+"menuAddItem(ctx, \"Paste\",  () => status.set(\"ctx/paste\"))\n"
+"menuAddSeparator(ctx)\n"
+"menuAddItem(ctx, \"Delete\", () => status.set(\"ctx/delete\"))\n"
+"widgetSetContextMenu(label, ctx)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:91 src/ui/menus.md:109
+msgid "Toolbar"
+msgstr ""
+
+#: src/ui/menus.md:93
+msgid ""
+"Add a toolbar to a window. `toolbarAddItem` takes an _identifier_ (used by "
+"AppKit to deduplicate items) and a _label_:"
+msgstr ""
+
+#: src/ui/menus.md:96
+msgid ""
+"```typescript\n"
+"const toolbar = toolbarCreate()\n"
+"toolbarAddItem(toolbar, \"new\",  \"New\",  () => status.set(\"tb/new\"))\n"
+"toolbarAddItem(toolbar, \"save\", \"Save\", () => status.set(\"tb/save\"))\n"
+"toolbarAddItem(toolbar, \"run\",  \"Run\",  () => status.set(\"tb/run\"))\n"
+"\n"
+"// `toolbarAttach(toolbar, window)` mounts onto a specific window.\n"
+"const win = Window(\"Toolbar Demo\", 800, 600)\n"
+"toolbarAttach(toolbar, win as unknown as number)\n"
+"```"
+msgstr ""
+
+#: src/ui/menus.md:109
+msgid "Context Menu"
+msgstr ""
+
+#: src/ui/menus.md:111
+msgid "NSToolbar"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "— (no menu bar)"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "UIMenu"
+msgstr ""
+
+#: src/ui/menus.md:112
+msgid "UIToolbar"
+msgstr ""
+
+#: src/ui/menus.md:113
+msgid "HMENU/SetMenu"
+msgstr ""
+
+#: src/ui/menus.md:113
+msgid "Horizontal layout"
+msgstr ""
+
+#: src/ui/menus.md:114
+msgid "GMenu/set_menubar"
+msgstr ""
+
+#: src/ui/menus.md:114
+msgid "HeaderBar"
+msgstr ""
+
+#: src/ui/menus.md:117
+msgid ""
+"**iOS**: Menu bars are not applicable. Use toolbar and navigation patterns "
+"instead."
+msgstr ""
+
+#: src/ui/menus.md:121
+msgid "[Events](events.md) — Keyboard shortcuts and interactions"
+msgstr ""
+
+#: src/ui/menus.md:122
+msgid "[Dialogs](dialogs.md) — File dialogs and alerts"
+msgstr ""
+
+#: src/ui/menus.md:123
+msgid "[Layout](layout.md) — Toolbar and navigation patterns"
+msgstr ""
+
+#: src/ui/dialogs.md:3
+msgid ""
+"Perry provides native dialog functions for file selection, alerts, and "
+"sheets. Every snippet below is excerpted from "
+"[`docs/examples/ui/dialogs/snippets.ts`](../../examples/ui/dialogs/snippets.ts)"
+" — CI compiles and links the file on every PR, so the API drawn here is the "
+"API the runtime exposes."
+msgstr ""
+
+#: src/ui/dialogs.md:9
+msgid ""
+"All file dialogs are **callback-based** (the OS-modal panel is non-blocking "
+"on Apple platforms, so a synchronous return wouldn't be possible without "
+"freezing the app's run loop). The callback receives an empty string when the"
+" user cancels."
+msgstr ""
+
+#: src/ui/dialogs.md:14
+msgid "File Open Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:16
+msgid ""
+"```typescript\n"
+"function pickFile(): void {\n"
+"    openFileDialog((path: string) => {\n"
+"        if (path.length > 0) {\n"
+"            console.log(`Selected: ${path}`)\n"
+"        } else {\n"
+"            console.log(\"Open dialog cancelled\")\n"
+"        }\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:28
+msgid "Folder Selection Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:40
+msgid "Save File Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:42
+msgid ""
+"```typescript\n"
+"function pickSaveTarget(): void {\n"
+"    saveFileDialog((path: string) => {\n"
+"        if (path.length > 0) {\n"
+"            console.log(`Will save to: ${path}`)\n"
+"        }\n"
+"    }, \"untitled\", \"txt\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:52
+msgid ""
+"`saveFileDialog(callback, defaultName, extension)` pre-fills the name field "
+"with `defaultName.<extension>`."
+msgstr ""
+
+#: src/ui/dialogs.md:55 src/ui/dialogs.md:113
+msgid "Alert"
+msgstr ""
+
+#: src/ui/dialogs.md:57
+msgid "Display a native alert dialog:"
+msgstr ""
+
+#: src/ui/dialogs.md:59
+msgid ""
+"```typescript\n"
+"function showSimpleAlert(): void {\n"
+"    alert(\"Operation Complete\", \"Your file has been saved successfully.\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:65
+msgid "`alert(title, message)` shows a modal alert with an OK button."
+msgstr ""
+
+#: src/ui/dialogs.md:67
+msgid "Alert with Buttons"
+msgstr ""
+
+#: src/ui/dialogs.md:69
+msgid ""
+"```typescript\n"
+"function confirmDelete(): void {\n"
+"    alertWithButtons(\n"
+"        \"Delete Item?\",\n"
+"        \"This action cannot be undone.\",\n"
+"        [\"Cancel\", \"Delete\"],\n"
+"        (index: number) => {\n"
+"            if (index === 1) {\n"
+"                console.log(\"user confirmed delete\")\n"
+"            }\n"
+"        },\n"
+"    )\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:84
+msgid ""
+"`alertWithButtons(title, message, buttons, callback)` invokes the callback "
+"with the 0-based index of the button the user clicked. By convention put a "
+"destructive label last and check the index in the callback."
+msgstr ""
+
+#: src/ui/dialogs.md:88
+msgid "Sheets"
+msgstr ""
+
+#: src/ui/dialogs.md:90
+msgid ""
+"Sheets are modal panels attached to a window. Build the body, hand it (with "
+"a size) to `sheetCreate`, then `sheetPresent` it. To dismiss "
+"programmatically, keep the handle around and call `sheetDismiss(handle)`:"
+msgstr ""
+
+#: src/ui/dialogs.md:94
+msgid ""
+"```typescript\n"
+"function showSheet(): void {\n"
+"    let sheet = 0\n"
+"    const body = VStack(16, [\n"
+"        Text(\"Sheet Content\"),\n"
+"        Button(\"Close\", () => sheetDismiss(sheet)),\n"
+"    ])\n"
+"    sheet = sheetCreate(body, 320, 200)\n"
+"    sheetPresent(sheet)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:108
+msgid "Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "File Open"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:112
+msgid "NSOpenPanel"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "UIDocumentPicker"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:112
+msgid "IFileOpenDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110 src/ui/dialogs.md:111 src/ui/dialogs.md:112
+msgid "GtkFileChooserDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:110
+msgid "`<input type=\"file\">`"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "File Save"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "NSSavePanel"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "IFileSaveDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:111
+msgid "Download link"
+msgstr ""
+
+#: src/ui/dialogs.md:112
+msgid "Folder"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "NSAlert"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "UIAlertController"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "MessageBoxW"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "MessageDialog"
+msgstr ""
+
+#: src/ui/dialogs.md:113
+msgid "`alert()`"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Sheet"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "NSSheet"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal VC"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal Dialog"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal Window"
+msgstr ""
+
+#: src/ui/dialogs.md:114
+msgid "Modal div"
+msgstr ""
+
+#: src/ui/dialogs.md:116
+msgid "Complete Example: minimal text editor"
+msgstr ""
+
+#: src/ui/dialogs.md:118
+msgid ""
+"A real program that wires `openFileDialog` and `saveFileDialog` into a "
+"state-bound `TextField`:"
+msgstr ""
+
+#: src/ui/dialogs.md:121
+msgid ""
+"```typescript\n"
+"// demonstrates: file-open / save dialogs wired to a tiny text editor\n"
+"// docs: docs/src/ui/dialogs.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"import {\n"
+"    App,\n"
+"    VStack, HStack,\n"
+"    Text, Button, TextField,\n"
+"    State,\n"
+"    openFileDialog, saveFileDialog, alert,\n"
+"} from \"perry/ui\"\n"
+"import { readFileSync, writeFileSync } from \"fs\"\n"
+"\n"
+"const content = State(\"\")\n"
+"const filePath = State(\"\")\n"
+"\n"
+"App({\n"
+"    title: \"Text Editor\",\n"
+"    width: 800,\n"
+"    height: 600,\n"
+"    body: VStack(12, [\n"
+"        HStack(8, [\n"
+"            Button(\"Open\", () => {\n"
+"                openFileDialog((path: string) => {\n"
+"                    if (path.length === 0) return\n"
+"                    filePath.set(path)\n"
+"                    content.set(readFileSync(path, \"utf-8\") as string)\n"
+"                })\n"
+"            }),\n"
+"            Button(\"Save As\", () => {\n"
+"                saveFileDialog((path: string) => {\n"
+"                    if (path.length === 0) return\n"
+"                    writeFileSync(path, content.value)\n"
+"                    filePath.set(path)\n"
+"                    alert(\"Saved\", `File saved to ${path}`)\n"
+"                }, \"untitled\", \"txt\")\n"
+"            }),\n"
+"        ]),\n"
+"        Text(filePath.value === \"\" ? \"No file open\" : `File: ${filePath.value}`),\n"
+"        TextField(\"Start typing...\", (value: string) => content.set(value)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/dialogs.md:168
+msgid "[Menus](menus.md) — Menu bar and context menus"
+msgstr ""
+
+#: src/ui/dialogs.md:169
+msgid "[Multi-Window](multi-window.md) — Multiple windows"
+msgstr ""
+
+#: src/ui/dialogs.md:170
+msgid "[Events](events.md) — User interaction events"
+msgstr ""
+
+#: src/ui/table.md:3
+msgid ""
+"The `Table` widget displays tabular data with columns, headers, and row "
+"selection."
+msgstr ""
+
+#: src/ui/table.md:6
+msgid ""
+"**Platform support:** real implementation lives on **macOS** (`NSTableView` "
+"+ `NSScrollView`); the **Web** target uses an HTML `<table>`. **iOS**, "
+"**Android**, **Linux/GTK4**, **Windows**, **tvOS**, **visionOS**, and "
+"**watchOS** link no-op stubs so cross-platform code compiles everywhere — "
+"the table renders nothing and `tableGetSelectedRow` returns `-1`. For "
+"production lists on platforms without a real impl, use `LazyVStack` (see "
+"[Layout](layout.md))."
+msgstr ""
+
+#: src/ui/table.md:14
+msgid "Creating a Table"
+msgstr ""
+
+#: src/ui/table.md:22
+msgid ""
+"`Table(rowCount, colCount, renderCell)` creates a table. The render callback"
+" receives `(row, col)` and must return a `Widget` (typically `Text(...)`). "
+"The runtime resolves the returned handle as the cell view, which lets cells "
+"render images, stacks, or composites — not just plain strings."
+msgstr ""
+
+#: src/ui/table.md:28
+msgid "Column Headers"
+msgstr ""
+
+#: src/ui/table.md:30
+msgid ""
+"```ts\n"
+"const userTable = Table(users.length, 3, (row: number, col: number) => {\n"
+"    const user = users[row]\n"
+"    if (col === 0) return Text(user.name)\n"
+"    if (col === 1) return Text(user.email)\n"
+"    return Text(user.role)\n"
+"})\n"
+"\n"
+"tableSetColumnHeader(userTable, 0, \"Name\")\n"
+"tableSetColumnHeader(userTable, 1, \"Email\")\n"
+"tableSetColumnHeader(userTable, 2, \"Role\")\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:43
+msgid "Column Widths"
+msgstr ""
+
+#: src/ui/table.md:45
+msgid ""
+"```ts\n"
+"tableSetColumnWidth(userTable, 0, 150)  // Name column\n"
+"tableSetColumnWidth(userTable, 1, 250)  // Email column\n"
+"tableSetColumnWidth(userTable, 2, 100)  // Role column\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:51
+msgid "Row Selection"
+msgstr ""
+
+#: src/ui/table.md:53
+msgid ""
+"```ts\n"
+"const selectedRow = State(-1)\n"
+"\n"
+"tableSetOnRowSelect(userTable, (row: number) => {\n"
+"    selectedRow.set(row)\n"
+"    console.log(`Selected row: ${row}`)\n"
+"})\n"
+"\n"
+"// Read the currently selected row at any time:\n"
+"const current = tableGetSelectedRow(userTable)\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:65
+msgid "Dynamic Row Count"
+msgstr ""
+
+#: src/ui/table.md:67
+msgid "Update the number of rows after creation:"
+msgstr ""
+
+#: src/ui/table.md:75
+msgid ""
+"```ts\n"
+"const selectedName = State(\"None\")\n"
+"\n"
+"const table = Table(users.length, 3, (row: number, col: number) => {\n"
+"    const user = users[row]\n"
+"    if (col === 0) return Text(user.name)\n"
+"    if (col === 1) return Text(user.email)\n"
+"    return Text(user.role)\n"
+"})\n"
+"\n"
+"tableSetColumnHeader(table, 0, \"Name\")\n"
+"tableSetColumnHeader(table, 1, \"Email\")\n"
+"tableSetColumnHeader(table, 2, \"Role\")\n"
+"tableSetColumnWidth(table, 0, 150)\n"
+"tableSetColumnWidth(table, 1, 250)\n"
+"tableSetColumnWidth(table, 2, 100)\n"
+"\n"
+"tableSetOnRowSelect(table, (row: number) => {\n"
+"    selectedName.set(users[row].name)\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Table Demo\",\n"
+"    width: 600,\n"
+"    height: 400,\n"
+"    body: VStack(12, [\n"
+"        table,\n"
+"        Text(`Selected: ${selectedName.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/table.md:111
+msgid "[Events](events.md) — Event handling"
+msgstr ""
+
+#: src/ui/animation.md:3
+msgid ""
+"Perry supports animating widget properties for smooth transitions. Every "
+"snippet below is excerpted from "
+"[`docs/examples/ui/animation/snippets.ts`](../../examples/ui/animation/snippets.ts)"
+" — CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/animation.md:8
+msgid ""
+"`animateOpacity` and `animatePosition` are special: they're documented as "
+"methods on the widget handle (the only methods perry/ui exposes), and the "
+"HIR lowers them to `widgetAnimateOpacity` / `widgetAnimatePosition` calls "
+"under the hood."
+msgstr ""
+
+#: src/ui/animation.md:13
+msgid "Opacity Animation"
+msgstr ""
+
+#: src/ui/animation.md:15
+msgid ""
+"```typescript\n"
+"const fading = Text(\"Fading text\")\n"
+"// Animate from the widget's current opacity to `target` over `durationSecs`.\n"
+"fading.animateOpacity(1.0, 0.3) // target, durationSeconds\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:21
+msgid "Position Animation"
+msgstr ""
+
+#: src/ui/animation.md:23
+msgid ""
+"```typescript\n"
+"const moving = Button(\"Moving\", () => {})\n"
+"// Animate by a delta (dx, dy) relative to the widget's current position.\n"
+"moving.animatePosition(100, 200, 0.5) // dx, dy, durationSeconds\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:29
+msgid "Example: Fade-In Effect"
+msgstr ""
+
+#: src/ui/animation.md:31
+msgid ""
+"When the first argument reads from a `State.value`, Perry auto-subscribes "
+"the call to the state — toggling `visible` re-runs the animation."
+msgstr ""
+
+#: src/ui/animation.md:34
+msgid ""
+"```typescript\n"
+"// demonstrates: auto-reactive animateOpacity driven by a State toggle\n"
+"// docs: docs/src/ui/animation.md\n"
+"// platforms: macos, linux, windows\n"
+"// targets: ios-simulator, tvos-simulator, watchos-simulator, web, wasm\n"
+"\n"
+"import { App, Text, Button, VStack, State } from \"perry/ui\"\n"
+"\n"
+"const visible = State(false)\n"
+"\n"
+"const label = Text(\"Hello!\")\n"
+"label.animateOpacity(visible.value ? 1.0 : 0.0, 0.3)\n"
+"\n"
+"App({\n"
+"    title: \"Animation Demo\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Button(\"Toggle\", () => {\n"
+"            visible.set(!visible.value)\n"
+"        }),\n"
+"        label,\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/animation.md:64
+msgid "NSAnimationContext / ViewPropertyAnimator"
+msgstr ""
+
+#: src/ui/animation.md:65
+msgid "UIView.animate"
+msgstr ""
+
+#: src/ui/animation.md:66
+msgid "ViewPropertyAnimator"
+msgstr ""
+
+#: src/ui/animation.md:67
+msgid "WM_TIMER-based animation"
+msgstr ""
+
+#: src/ui/animation.md:68
+msgid "CSS transitions (GTK4)"
+msgstr ""
+
+#: src/ui/animation.md:69
+msgid "CSS transitions"
+msgstr ""
+
+#: src/ui/animation.md:73
+msgid "[Styling](styling.md) — Widget styling properties"
+msgstr ""
+
+#: src/ui/animation.md:75
+msgid "[Events](events.md) — User interaction"
+msgstr ""
+
+#: src/ui/multi-window.md:1
+msgid "Multi-Window & Window Management"
+msgstr ""
+
+#: src/ui/multi-window.md:3
+msgid ""
+"Perry supports creating multiple native windows and controlling their "
+"appearance and behavior. Every snippet below is excerpted from "
+"[`docs/examples/ui/multi_window/snippets.ts`](../../examples/ui/multi_window/snippets.ts)"
+" — CI compiles and runs it on every PR."
+msgstr ""
+
+#: src/ui/multi-window.md:8
+msgid "Creating Windows"
+msgstr ""
+
+#: src/ui/multi-window.md:10
+msgid ""
+"`Window(title, width, height)` returns a window handle. Call `.setBody()` to"
+" set its content and `.show()` to display it:"
+msgstr ""
+
+#: src/ui/multi-window.md:13
+msgid ""
+"```typescript\n"
+"const settings = Window(\"Settings\", 500, 400)\n"
+"settings.setBody(VStack(16, [\n"
+"    Text(\"Settings panel\"),\n"
+"]))\n"
+"settings.show()\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:21
+msgid "Window Instance Methods"
+msgstr ""
+
+#: src/ui/multi-window.md:23
+msgid ""
+"```typescript\n"
+"const win = Window(\"My Window\", 600, 400)\n"
+"\n"
+"win.setBody(Text(\"Hello\"))   // Set the root widget\n"
+"win.show()                    // Show the window\n"
+"win.hide()                    // Hide without destroying\n"
+"win.setSize(800, 600)         // Resize dynamically\n"
+"win.onFocusLost(() => {       // Callback when the window loses focus\n"
+"    win.hide()\n"
+"})\n"
+"win.close()                   // Close and destroy\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:36 src/i18n/overview.md:87
+#: src/testing/geisterhand.md:257
+msgid "Method"
+msgstr ""
+
+#: src/ui/multi-window.md:38
+msgid "`setBody(widget)`"
+msgstr ""
+
+#: src/ui/multi-window.md:38
+msgid "Set the root widget of the window"
+msgstr ""
+
+#: src/ui/multi-window.md:39
+msgid "`show()`"
+msgstr ""
+
+#: src/ui/multi-window.md:39
+msgid "Show the window"
+msgstr ""
+
+#: src/ui/multi-window.md:40
+msgid "`hide()`"
+msgstr ""
+
+#: src/ui/multi-window.md:40
+msgid "Hide without destroying — call `show()` again to reveal"
+msgstr ""
+
+#: src/ui/multi-window.md:41
+msgid "`setSize(w, h)`"
+msgstr ""
+
+#: src/ui/multi-window.md:41
+msgid "Resize dynamically"
+msgstr ""
+
+#: src/ui/multi-window.md:42
+msgid "`onFocusLost(cb)`"
+msgstr ""
+
+#: src/ui/multi-window.md:42
+msgid "Register a callback that fires when focus leaves the window"
+msgstr ""
+
+#: src/ui/multi-window.md:43
+msgid "`close()`"
+msgstr ""
+
+#: src/ui/multi-window.md:43
+msgid "Close and destroy"
+msgstr ""
+
+#: src/ui/multi-window.md:45
+msgid "App Window Properties"
+msgstr ""
+
+#: src/ui/multi-window.md:47
+msgid ""
+"The main `App({})` config object accepts the same window properties for "
+"building launcher-style, overlay, or utility apps:"
+msgstr ""
+
+#: src/ui/multi-window.md:50
+msgid ""
+"```typescript\n"
+"App({\n"
+"    title: \"QuickLaunch\",\n"
+"    width: 600,\n"
+"    height: 80,\n"
+"    body: VStack(8, [\n"
+"        Text(\"Search...\"),\n"
+"        Button(\"Open Settings\", () => settings.show()),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/multi-window.md:62
+msgid ""
+"`App` additionally accepts the optional fields `frameless`, `level`, "
+"`transparent`, `vibrancy`, `activationPolicy`, and `icon`. They map to the "
+"following native primitives:"
+msgstr ""
+
+#: src/ui/multi-window.md:66
+msgid "`frameless: true`"
+msgstr ""
+
+#: src/ui/multi-window.md:68
+msgid "Removes the window title bar and frame, creating a borderless window."
+msgstr ""
+
+#: src/ui/multi-window.md:72
+msgid "`NSWindowStyleMask::Borderless` + movable by background"
+msgstr ""
+
+#: src/ui/multi-window.md:73
+msgid "`WS_POPUP` window style"
+msgstr ""
+
+#: src/ui/multi-window.md:74
+msgid "`set_decorated(false)`"
+msgstr ""
+
+#: src/ui/multi-window.md:76
+msgid "`level: \"floating\" | \"statusBar\" | \"modal\" | \"normal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:78
+msgid "Controls the window's z-order level relative to other windows."
+msgstr ""
+
+#: src/ui/multi-window.md:80
+msgid "Level"
+msgstr ""
+
+#: src/ui/multi-window.md:82
+msgid "`\"normal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:82
+msgid "Default window level"
+msgstr ""
+
+#: src/ui/multi-window.md:83
+msgid "`\"floating\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:83
+msgid "Stays above normal windows"
+msgstr ""
+
+#: src/ui/multi-window.md:84
+msgid "`\"statusBar\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:84
+msgid "Stays above floating windows"
+msgstr ""
+
+#: src/ui/multi-window.md:85
+msgid "`\"modal\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:85
+msgid "Modal panel level"
+msgstr ""
+
+#: src/ui/multi-window.md:89
+msgid "`NSWindow.level` (NSFloatingWindowLevel, etc.)"
+msgstr ""
+
+#: src/ui/multi-window.md:90
+msgid "`SetWindowPos` with `HWND_TOPMOST`"
+msgstr ""
+
+#: src/ui/multi-window.md:91
+msgid "`set_modal(true)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:93
+msgid "`transparent: true`"
+msgstr ""
+
+#: src/ui/multi-window.md:95
+msgid ""
+"Makes the window background transparent, allowing the desktop to show "
+"through non-opaque regions of your UI."
+msgstr ""
+
+#: src/ui/multi-window.md:100
+msgid "`isOpaque = false`, `backgroundColor = .clear`"
+msgstr ""
+
+#: src/ui/multi-window.md:101
+msgid "`WS_EX_LAYERED` with `SetLayeredWindowAttributes`"
+msgstr ""
+
+#: src/ui/multi-window.md:102
+msgid "CSS `background-color: transparent`"
+msgstr ""
+
+#: src/ui/multi-window.md:104
+msgid "`vibrancy: string`"
+msgstr ""
+
+#: src/ui/multi-window.md:106
+msgid ""
+"Applies a native translucent material to the window background. On macOS "
+"this uses the system vibrancy effect; on Windows it uses Mica/Acrylic."
+msgstr ""
+
+#: src/ui/multi-window.md:109
+msgid ""
+"**macOS materials:** `\"sidebar\"`, `\"titlebar\"`, `\"selection\"`, "
+"`\"menu\"`, `\"popover\"`, `\"headerView\"`, `\"sheet\"`, "
+"`\"windowBackground\"`, `\"hudWindow\"`, `\"fullScreenUI\"`, `\"tooltip\"`, "
+"`\"contentBackground\"`, `\"underWindowBackground\"`, "
+"`\"underPageBackground\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:116
+msgid "`NSVisualEffectView` with the specified material"
+msgstr ""
+
+#: src/ui/multi-window.md:117
+msgid ""
+"`DwmSetWindowAttribute(DWMWA_SYSTEMBACKDROP_TYPE)` — Mica, Acrylic, or Mica "
+"Alt depending on material (Windows 11 22H2+)"
+msgstr ""
+
+#: src/ui/multi-window.md:118
+msgid "CSS `alpha(@window_bg_color, 0.85)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:120
+msgid "`activationPolicy: \"regular\" | \"accessory\" | \"background\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:122
+msgid "Controls whether the app appears in the dock/taskbar."
+msgstr ""
+
+#: src/ui/multi-window.md:124 src/widgets/data-fetching.md:125
+msgid "Policy"
+msgstr ""
+
+#: src/ui/multi-window.md:126
+msgid "`\"regular\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:126
+msgid "Normal app with dock icon and menu bar (default)"
+msgstr ""
+
+#: src/ui/multi-window.md:127
+msgid "`\"accessory\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:127
+msgid ""
+"No dock icon, no menu bar activation — ideal for launchers and utilities"
+msgstr ""
+
+#: src/ui/multi-window.md:128
+msgid "`\"background\"`"
+msgstr ""
+
+#: src/ui/multi-window.md:128
+msgid "Fully hidden from dock and app switcher"
+msgstr ""
+
+#: src/ui/multi-window.md:132
+msgid "`NSApp.setActivationPolicy()`"
+msgstr ""
+
+#: src/ui/multi-window.md:133
+msgid "`WS_EX_TOOLWINDOW` (removes from taskbar)"
+msgstr ""
+
+#: src/ui/multi-window.md:134
+msgid "`set_deletable(false)` (best-effort)"
+msgstr ""
+
+#: src/ui/multi-window.md:140
+msgid "NSWindow"
+msgstr ""
+
+#: src/ui/multi-window.md:141
+msgid "CreateWindowEx (HWND)"
+msgstr ""
+
+#: src/ui/multi-window.md:142
+msgid "GtkWindow"
+msgstr ""
+
+#: src/ui/multi-window.md:143
+msgid "Floating `<div>`"
+msgstr ""
+
+#: src/ui/multi-window.md:144
+msgid "iOS/Android"
+msgstr ""
+
+#: src/ui/multi-window.md:144
+msgid "Modal view controller / Dialog"
+msgstr ""
+
+#: src/ui/multi-window.md:146
+msgid ""
+"On mobile platforms, \"windows\" are presented as modal views or dialogs "
+"since mobile apps typically use a single-window model."
+msgstr ""
+
+#: src/ui/multi-window.md:151
+msgid "[Events](events.md) — Keyboard shortcuts"
+msgstr ""
+
+#: src/ui/multi-window.md:152
+msgid "[Dialogs](dialogs.md) — Modal dialogs and sheets"
+msgstr ""
+
+#: src/ui/multi-window.md:153
+msgid "[Menus](menus.md) — Menu bar and toolbar"
+msgstr ""
+
+#: src/ui/multi-window.md:154
+msgid "[UI Overview](overview.md) — Full UI system overview"
+msgstr ""
+
+#: src/ui/theming.md:3
+msgid ""
+"The `perry-styling` package provides a design system bridge for Perry UI — "
+"design token codegen and ergonomic styling helpers with compile-time "
+"platform detection."
+msgstr ""
+
+#: src/ui/theming.md:11
+msgid "Design Token Codegen"
+msgstr ""
+
+#: src/ui/theming.md:13
+msgid "Generate typed theme files from a JSON token definition:"
+msgstr ""
+
+#: src/ui/theming.md:19
+msgid "Token Format"
+msgstr ""
+
+#: src/ui/theming.md:23
+msgid "\"colors\""
+msgstr ""
+
+#: src/ui/theming.md:24
+msgid "\"primary\""
+msgstr ""
+
+#: src/ui/theming.md:24
+msgid "\"#007AFF\""
+msgstr ""
+
+#: src/ui/theming.md:25
+msgid "\"primary-dark\""
+msgstr ""
+
+#: src/ui/theming.md:25
+msgid "\"#0A84FF\""
+msgstr ""
+
+#: src/ui/theming.md:27
+msgid "\"background-dark\""
+msgstr ""
+
+#: src/ui/theming.md:27
+msgid "\"#1C1C1E\""
+msgstr ""
+
+#: src/ui/theming.md:28 src/testing/geisterhand.md:465
+msgid "\"text\""
+msgstr ""
+
+#: src/ui/theming.md:28
+msgid "\"#000000\""
+msgstr ""
+
+#: src/ui/theming.md:29
+msgid "\"text-dark\""
+msgstr ""
+
+#: src/ui/theming.md:31
+msgid "\"spacing\""
+msgstr ""
+
+#: src/ui/theming.md:32 src/ui/theming.md:38
+msgid "\"sm\""
+msgstr ""
+
+#: src/ui/theming.md:33 src/ui/theming.md:39
+msgid "\"md\""
+msgstr ""
+
+#: src/ui/theming.md:34 src/ui/theming.md:40
+msgid "\"lg\""
+msgstr ""
+
+#: src/ui/theming.md:35
+msgid "\"xl\""
+msgstr ""
+
+#: src/ui/theming.md:37
+msgid "\"radius\""
+msgstr ""
+
+#: src/ui/theming.md:42
+msgid "\"fontSize\""
+msgstr ""
+
+#: src/ui/theming.md:43
+msgid "\"body\""
+msgstr ""
+
+#: src/ui/theming.md:44
+msgid "\"heading\""
+msgstr ""
+
+#: src/ui/theming.md:45
+msgid "\"caption\""
+msgstr ""
+
+#: src/ui/theming.md:47
+msgid "\"borderWidth\""
+msgstr ""
+
+#: src/ui/theming.md:48
+msgid "\"thin\""
+msgstr ""
+
+#: src/ui/theming.md:49
+msgid "\"medium\""
+msgstr ""
+
+#: src/ui/theming.md:54
+msgid ""
+"Colors with a `-dark` suffix are used as the dark mode variant. If no dark "
+"variant is provided, the light value is used for both modes. Supported color"
+" formats: hex (`#RGB`, `#RRGGBB`, `#RRGGBBAA`), `rgb()`/`rgba()`, "
+"`hsl()`/`hsla()`, and CSS named colors."
+msgstr ""
+
+#: src/ui/theming.md:56
+msgid "Generated Types"
+msgstr ""
+
+#: src/ui/theming.md:58
+msgid "The codegen produces typed interfaces:"
+msgstr ""
+
+#: src/ui/theming.md:60
+msgid ""
+"```text\n"
+"interface PerryColor {\n"
+"  r: number; g: number; b: number; a: number; // floats in [0, 1]\n"
+"}\n"
+"\n"
+"interface PerryTheme {\n"
+"  light: { [key: string]: PerryColor };\n"
+"  dark: { [key: string]: PerryColor };\n"
+"  spacing: { [key: string]: number };\n"
+"  radius: { [key: string]: number };\n"
+"  fontSize: { [key: string]: number };\n"
+"  borderWidth: { [key: string]: number };\n"
+"}\n"
+"\n"
+"interface ResolvedTheme {\n"
+"  colors: { [key: string]: PerryColor };\n"
+"  spacing: { [key: string]: number };\n"
+"  radius: { [key: string]: number };\n"
+"  fontSize: { [key: string]: number };\n"
+"  borderWidth: { [key: string]: number };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:83
+msgid "Theme Resolution"
+msgstr ""
+
+#: src/ui/theming.md:85
+msgid "Resolve a theme at runtime based on the system's dark mode setting:"
+msgstr ""
+
+#: src/ui/theming.md:87
+msgid ""
+"```text\n"
+"import { getTheme } from \"perry-styling\";\n"
+"import { theme } from \"./theme\"; // generated file\n"
+"\n"
+"const resolved = getTheme(theme);\n"
+"// resolved.colors.primary → the correct light/dark variant\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:95
+msgid ""
+"`getTheme()` calls `isDarkMode()` from `perry/system` and returns the "
+"appropriate palette."
+msgstr ""
+
+#: src/ui/theming.md:97
+msgid "Styling Helpers"
+msgstr ""
+
+#: src/ui/theming.md:99
+msgid ""
+"Ergonomic functions for applying styles to widget handles. Perry's compiler "
+"doesn't yet support passing `PerryColor` objects as parameters into user "
+"functions, so the helpers take **flat primitives**: extract the channels at "
+"the call site:"
+msgstr ""
+
+#: src/ui/theming.md:104
+msgid ""
+"```text\n"
+"import {\n"
+"  applyBg, applyRadius, applyTextColor, applyFontSize, applyGradient,\n"
+"} from \"perry-styling\";\n"
+"\n"
+"const t = resolved;                    // your ResolvedTheme\n"
+"const c = t.colors.text;               // a PerryColor\n"
+"const bg = t.colors.background;\n"
+"const start = t.colors.primary;\n"
+"const end = t.colors[\"primary-dark\"];\n"
+"\n"
+"const label = Text(\"Hello\");\n"
+"applyTextColor(label, c.r, c.g, c.b, c.a);\n"
+"applyFontSize(label, t.fontSize.heading);\n"
+"\n"
+"const card = VStack(16, []);\n"
+"applyBg(card, bg.r, bg.g, bg.b, bg.a);\n"
+"applyRadius(card, t.radius.md);\n"
+"applyGradient(card,\n"
+"  start.r, start.g, start.b, start.a,\n"
+"  end.r,   end.g,   end.b,   end.a,\n"
+"  0,                                   // 0 = vertical, 1 = horizontal\n"
+");\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:129
+msgid "Available Helpers"
+msgstr ""
+
+#: src/ui/theming.md:131
+msgid "Signature"
+msgstr ""
+
+#: src/ui/theming.md:133
+msgid "`applyBg(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:133
+msgid "Background color"
+msgstr ""
+
+#: src/ui/theming.md:134
+msgid "`applyRadius(handle, radius)`"
+msgstr ""
+
+#: src/ui/theming.md:134
+msgid "Corner radius"
+msgstr ""
+
+#: src/ui/theming.md:135
+msgid "`applyTextColor(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:135
+msgid "Text color"
+msgstr ""
+
+#: src/ui/theming.md:136
+msgid "`applyFontSize(handle, size)`"
+msgstr ""
+
+#: src/ui/theming.md:136
+msgid "Font size (regular weight)"
+msgstr ""
+
+#: src/ui/theming.md:137
+msgid "`applyFontBold(handle, size)`"
+msgstr ""
+
+#: src/ui/theming.md:137
+msgid "Font size with bold weight"
+msgstr ""
+
+#: src/ui/theming.md:138
+msgid "`applyFontFamily(handle, family)`"
+msgstr ""
+
+#: src/ui/theming.md:138
+msgid "Font family"
+msgstr ""
+
+#: src/ui/theming.md:139
+msgid "`applyWidth(handle, width)`"
+msgstr ""
+
+#: src/ui/theming.md:139
+msgid "Fixed width"
+msgstr ""
+
+#: src/ui/theming.md:140
+msgid "`applyTooltip(handle, text)`"
+msgstr ""
+
+#: src/ui/theming.md:140
+msgid "Tooltip (no-op on iOS/Android)"
+msgstr ""
+
+#: src/ui/theming.md:141
+msgid "`applyBorderColor(handle, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:141
+msgid "Border color"
+msgstr ""
+
+#: src/ui/theming.md:142
+msgid "`applyBorderWidth(handle, width)`"
+msgstr ""
+
+#: src/ui/theming.md:142
+msgid "Border width"
+msgstr ""
+
+#: src/ui/theming.md:143
+msgid "`applyEdgeInsets(handle, top, left, bottom, right)`"
+msgstr ""
+
+#: src/ui/theming.md:143
+msgid "Edge insets (padding)"
+msgstr ""
+
+#: src/ui/theming.md:144
+msgid "`applyOpacity(handle, alpha)`"
+msgstr ""
+
+#: src/ui/theming.md:145
+msgid "`applyGradient(handle, r1, g1, b1, a1, r2, g2, b2, a2, direction)`"
+msgstr ""
+
+#: src/ui/theming.md:145
+msgid "Background gradient"
+msgstr ""
+
+#: src/ui/theming.md:146
+msgid "`applyButtonBg(btn, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:146
+msgid "Button background"
+msgstr ""
+
+#: src/ui/theming.md:147
+msgid "`applyButtonTextColor(btn, r, g, b, a)`"
+msgstr ""
+
+#: src/ui/theming.md:147
+msgid "Button text color"
+msgstr ""
+
+#: src/ui/theming.md:148
+msgid "`applyButtonBordered(btn, bordered)`"
+msgstr ""
+
+#: src/ui/theming.md:148
+msgid "Bordered button style (`true`/`false`)"
+msgstr ""
+
+#: src/ui/theming.md:150
+msgid "Platform Constants"
+msgstr ""
+
+#: src/ui/theming.md:152
+msgid ""
+"`perry-styling` exports compile-time platform constants based on the "
+"`__platform__` built-in:"
+msgstr ""
+
+#: src/ui/theming.md:154
+msgid ""
+"```text\n"
+"import { isMac, isIOS, isAndroid, isWindows, isLinux, isDesktop, isMobile } from \"perry-styling\";\n"
+"\n"
+"if (isMobile) {\n"
+"  applyFontSize(label, 16);\n"
+"} else {\n"
+"  applyFontSize(label, 14);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ui/theming.md:164
+msgid ""
+"These are constant-folded by LLVM at compile time — dead branches are "
+"eliminated with zero runtime cost."
+msgstr ""
+
+#: src/ui/theming.md:168
+msgid "[Styling](styling.md) — Widget styling basics"
+msgstr ""
+
+#: src/ui/camera.md:3
+msgid ""
+"The `perry/ui` module provides a live camera preview widget with color "
+"sampling capabilities."
+msgstr ""
+
+#: src/ui/camera.md:6
+msgid ""
+"```ts\n"
+"import {\n"
+"    CameraView,\n"
+"    cameraStart, cameraStop,\n"
+"    cameraFreeze, cameraUnfreeze,\n"
+"    cameraSampleColor, cameraSetOnTap,\n"
+"} from \"perry/ui\"\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:15
+msgid ""
+"**Platform support:** real capture is implemented on **iOS** "
+"(AVCaptureSession) and **Android** (Camera2). On **macOS**, **Linux** "
+"(GTK4), **Windows**, and the **Web** target the runtime exports no-op stubs "
+"so cross-platform code compiles and links cleanly — `CameraView()` returns "
+"handle 0 and `cameraSampleColor` returns `-1`. Wiring real capture on those "
+"platforms (AVFoundation on macOS, GStreamer/V4L2 on Linux, Media Foundation "
+"on Windows, `getUserMedia` on Web) is tracked as a follow-up."
+msgstr ""
+
+#: src/ui/camera.md:24 src/system/overview.md:43 src/plugins/overview.md:25
+msgid "Quick Example"
+msgstr ""
+
+#: src/ui/camera.md:26
+msgid ""
+"```ts\n"
+"const colorHex = State(\"#000000\")\n"
+"\n"
+"const cam = CameraView()\n"
+"cameraStart(cam)\n"
+"\n"
+"cameraSetOnTap(cam, (x: number, y: number) => {\n"
+"    const rgb = cameraSampleColor(x, y)\n"
+"    if (rgb >= 0) {\n"
+"        const r = Math.floor(rgb / 65536)\n"
+"        const g = Math.floor((rgb % 65536) / 256)\n"
+"        const b = Math.floor(rgb % 256)\n"
+"        colorHex.set(`#${r.toString(16).padStart(2, \"0\")}${g.toString(16).padStart(2, \"0\")}${b.toString(16).padStart(2, \"0\")}`)\n"
+"    }\n"
+"})\n"
+"\n"
+"App({\n"
+"    title: \"Color Picker\",\n"
+"    width: 400,\n"
+"    height: 600,\n"
+"    body: VStack(16, [\n"
+"        cam,\n"
+"        Text(`Color: ${colorHex.value}`),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:53 src/system/audio.md:21 src/testing/geisterhand.md:45
+msgid "API Reference"
+msgstr ""
+
+#: src/ui/camera.md:55
+msgid "`CameraView()`"
+msgstr ""
+
+#: src/ui/camera.md:57
+msgid "Create a live camera preview widget."
+msgstr ""
+
+#: src/ui/camera.md:63
+msgid ""
+"Returns a widget handle. The camera does not start automatically — call "
+"`cameraStart()` to begin capture."
+msgstr ""
+
+#: src/ui/camera.md:65
+msgid "`cameraStart(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:67
+msgid "Start the live camera feed."
+msgstr ""
+
+#: src/ui/camera.md:73
+msgid ""
+"On iOS, the camera permission dialog is shown automatically on first use."
+msgstr ""
+
+#: src/ui/camera.md:75
+msgid "`cameraStop(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:77
+msgid "Stop the camera feed and release the capture session."
+msgstr ""
+
+#: src/ui/camera.md:83
+msgid "`cameraFreeze(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:85
+msgid "Pause the live preview (freeze the current frame)."
+msgstr ""
+
+#: src/ui/camera.md:91
+msgid ""
+"The camera session remains active but the preview stops updating. Useful for"
+" \"capture\" moments where you want to inspect the frozen frame."
+msgstr ""
+
+#: src/ui/camera.md:93
+msgid "`cameraUnfreeze(handle)`"
+msgstr ""
+
+#: src/ui/camera.md:95
+msgid "Resume the live preview after a freeze."
+msgstr ""
+
+#: src/ui/camera.md:101
+msgid "`cameraSampleColor(x, y)`"
+msgstr ""
+
+#: src/ui/camera.md:103
+msgid "Sample the pixel color at normalized coordinates."
+msgstr ""
+
+#: src/ui/camera.md:105
+msgid ""
+"```ts\n"
+"const rgb = cameraSampleColor(0.5, 0.5) // center of frame\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:109
+msgid "`x`, `y` are normalized coordinates (0.0–1.0)"
+msgstr ""
+
+#: src/ui/camera.md:110
+msgid "Returns packed RGB as a number: `r * 65536 + g * 256 + b`"
+msgstr ""
+
+#: src/ui/camera.md:111
+msgid "Returns `-1` if no frame is available"
+msgstr ""
+
+#: src/ui/camera.md:113
+msgid "To extract individual channels:"
+msgstr ""
+
+#: src/ui/camera.md:121
+msgid ""
+"The color is averaged over a 5x5 pixel region around the sample point for "
+"noise reduction."
+msgstr ""
+
+#: src/ui/camera.md:123
+msgid "`cameraSetOnTap(handle, callback)`"
+msgstr ""
+
+#: src/ui/camera.md:125
+msgid "Register a tap handler on the camera view."
+msgstr ""
+
+#: src/ui/camera.md:127
+msgid ""
+"```ts\n"
+"cameraSetOnTap(preview, (tx: number, ty: number) => {\n"
+"    // tx, ty are normalized coordinates (0.0-1.0)\n"
+"    const tappedRgb = cameraSampleColor(tx, ty)\n"
+"    console.log(`tapped color: ${tappedRgb}`)\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/ui/camera.md:135
+msgid ""
+"The callback receives normalized coordinates of the tap location, which can "
+"be passed directly to `cameraSampleColor()`."
+msgstr ""
+
+#: src/ui/camera.md:139
+msgid ""
+"On iOS, the camera uses AVCaptureSession with AVCaptureVideoPreviewLayer for"
+" GPU-accelerated live preview, and AVCaptureVideoDataOutput for frame "
+"capture. Color sampling reads pixel data from CVPixelBuffer."
+msgstr ""
+
+#: src/ui/camera.md:141
+msgid ""
+"On Android, the camera uses Camera2 with a TextureView preview surface. "
+"Color sampling reads from the most recent ImageReader frame."
+msgstr ""
+
+#: src/ui/camera.md:146
+msgid ""
+"[Audio Capture](../system/audio.md) — Microphone input and sound metering"
+msgstr ""
+
+#: src/platforms/overview.md:1
+msgid "Platform Overview"
+msgstr ""
+
+#: src/platforms/overview.md:3
+msgid ""
+"Perry compiles TypeScript to native executables for 9 platform families from"
+" the same source code."
+msgstr ""
+
+#: src/platforms/overview.md:5
+msgid "Supported Platforms"
+msgstr ""
+
+#: src/platforms/overview.md:7 src/widgets/platforms.md:9
+msgid "Target Flag"
+msgstr ""
+
+#: src/platforms/overview.md:7 src/platforms/macos.md:20
+#: src/platforms/ios.md:46 src/platforms/tvos.md:46
+#: src/platforms/watchos.md:46 src/platforms/android.md:20
+#: src/platforms/windows.md:38 src/platforms/linux.md:30
+msgid "UI Toolkit"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "_(default)_"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "AppKit"
+msgstr ""
+
+#: src/platforms/overview.md:9
+msgid "Full support (127/127 FFI functions)"
+msgstr ""
+
+#: src/platforms/overview.md:10
+msgid "`--target ios` / `--target ios-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:10 src/platforms/overview.md:12
+#: src/platforms/tvos.md:178
+msgid "UIKit"
+msgstr ""
+
+#: src/platforms/overview.md:10
+msgid "Full support (127/127)"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "`--target visionos` / `--target visionos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "UIKit (2D windows)"
+msgstr ""
+
+#: src/platforms/overview.md:11
+msgid "Core support (2D only)"
+msgstr ""
+
+#: src/platforms/overview.md:12
+msgid "`--target tvos` / `--target tvos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:12
+msgid "Full support (focus engine + game controllers)"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "`--target watchos` / `--target watchos-simulator`"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "SwiftUI (data-driven)"
+msgstr ""
+
+#: src/platforms/overview.md:13
+msgid "Core support (15 widgets)"
+msgstr ""
+
+#: src/platforms/overview.md:14
+msgid "`--target android`"
+msgstr ""
+
+#: src/platforms/overview.md:14
+msgid "JNI/Android SDK"
+msgstr ""
+
+#: src/platforms/overview.md:14 src/platforms/overview.md:15
+#: src/platforms/overview.md:16
+msgid "Full support (112/112)"
+msgstr ""
+
+#: src/platforms/overview.md:15
+msgid "`--target windows`"
+msgstr ""
+
+#: src/platforms/overview.md:15
+msgid "Win32"
+msgstr ""
+
+#: src/platforms/overview.md:16
+msgid "`--target linux`"
+msgstr ""
+
+#: src/platforms/overview.md:16
+msgid "GTK4"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "Web / WebAssembly"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "`--target web` _(alias `--target wasm`)_"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "DOM/CSS via WASM bridge"
+msgstr ""
+
+#: src/platforms/overview.md:17
+msgid "Full support (168 widgets)"
+msgstr ""
+
+#: src/platforms/overview.md:19
+msgid "Cross-Compilation"
+msgstr ""
+
+#: src/platforms/overview.md:22
+msgid "# Default: compile for current platform\n"
+msgstr ""
+
+#: src/platforms/overview.md:24
+msgid "# Compile for a specific target\n"
+msgstr ""
+
+#: src/platforms/overview.md:36 src/platforms/visionos.md:49
+#: src/platforms/tvos.md:133 src/platforms/watchos.md:170
+msgid "Platform Detection"
+msgstr ""
+
+#: src/platforms/overview.md:38
+msgid "Use the `__platform__` compile-time constant to branch by platform:"
+msgstr ""
+
+#: src/platforms/overview.md:40
+msgid ""
+"```typescript\n"
+"declare const __platform__: number\n"
+"\n"
+"// Platform constants:\n"
+"// 0 = macOS\n"
+"// 1 = iOS\n"
+"// 2 = Android\n"
+"// 3 = Windows\n"
+"// 4 = Linux\n"
+"// 5 = Web (browser, --target web / --target wasm)\n"
+"// 6 = tvOS\n"
+"// 7 = watchOS\n"
+"// 8 = visionOS\n"
+"\n"
+"if (__platform__ === 0) {\n"
+"    console.log(\"Running on macOS\")\n"
+"} else if (__platform__ === 1) {\n"
+"    console.log(\"Running on iOS\")\n"
+"} else if (__platform__ === 3) {\n"
+"    console.log(\"Running on Windows\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/overview.md:63
+msgid ""
+"`__platform__` is resolved at compile time. The compiler constant-folds "
+"comparisons and eliminates dead branches, so platform-specific code has zero"
+" runtime cost."
+msgstr ""
+
+#: src/platforms/overview.md:65
+msgid "Platform Feature Matrix"
+msgstr ""
+
+#: src/platforms/overview.md:67
+msgid "Web (WASM)"
+msgstr ""
+
+#: src/platforms/overview.md:69
+msgid "CLI programs"
+msgstr ""
+
+#: src/platforms/overview.md:70
+msgid "Native UI (DOM on web)"
+msgstr ""
+
+#: src/platforms/overview.md:71
+msgid "Game engines"
+msgstr ""
+
+#: src/platforms/overview.md:71
+msgid "Via FFI"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "File system"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "Sandboxed"
+msgstr ""
+
+#: src/platforms/overview.md:72
+msgid "File System Access API"
+msgstr ""
+
+#: src/platforms/overview.md:73
+msgid "Networking"
+msgstr ""
+
+#: src/platforms/overview.md:73
+msgid "`fetch` / `WebSocket`"
+msgstr ""
+
+#: src/platforms/overview.md:74
+msgid "Partial"
+msgstr ""
+
+#: src/platforms/overview.md:74
+msgid "Minimal"
+msgstr ""
+
+#: src/platforms/overview.md:75
+msgid "Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Threading"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Native"
+msgstr ""
+
+#: src/platforms/overview.md:76
+msgid "Web Workers"
+msgstr ""
+
+#: src/platforms/overview.md:80
+msgid "[macOS](macos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:81
+msgid "[iOS](ios.md)"
+msgstr ""
+
+#: src/platforms/overview.md:82
+msgid "[visionOS](visionos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:83
+msgid "[tvOS](tvos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:84
+msgid "[watchOS](watchos.md)"
+msgstr ""
+
+#: src/platforms/overview.md:85
+msgid "[Android](android.md)"
+msgstr ""
+
+#: src/platforms/overview.md:86
+msgid "[Windows](windows.md)"
+msgstr ""
+
+#: src/platforms/overview.md:87
+msgid "[Linux (GTK4)](linux.md)"
+msgstr ""
+
+#: src/platforms/overview.md:88
+msgid "[Web](web.md)"
+msgstr ""
+
+#: src/platforms/overview.md:89
+msgid "[WebAssembly](wasm.md)"
+msgstr ""
+
+#: src/platforms/macos.md:3
+msgid ""
+"macOS is Perry's primary development platform. It uses AppKit for native UI."
+msgstr ""
+
+#: src/platforms/macos.md:5 src/platforms/ios.md:5 src/platforms/tvos.md:7
+#: src/platforms/watchos.md:7 src/platforms/android.md:5
+#: src/platforms/windows.md:5 src/platforms/linux.md:5
+#: src/plugins/native-extensions.md:271
+msgid "Requirements"
+msgstr ""
+
+#: src/platforms/macos.md:7
+msgid "macOS 13+ (Ventura or later)"
+msgstr ""
+
+#: src/platforms/macos.md:8
+msgid "Xcode Command Line Tools: `xcode-select --install`"
+msgstr ""
+
+#: src/platforms/macos.md:10 src/platforms/android.md:14
+#: src/platforms/windows.md:32 src/platforms/linux.md:23
+#: src/platforms/wasm.md:7 src/widgets/overview.md:48
+msgid "Building"
+msgstr ""
+
+#: src/platforms/macos.md:13
+msgid "# macOS is the default target\n"
+msgstr ""
+
+#: src/platforms/macos.md:18
+msgid "No additional flags needed — macOS is the default compilation target."
+msgstr ""
+
+#: src/platforms/macos.md:22
+msgid "Perry maps UI widgets to AppKit controls:"
+msgstr ""
+
+#: src/platforms/macos.md:24 src/platforms/ios.md:50 src/platforms/tvos.md:50
+#: src/platforms/watchos.md:50 src/platforms/android.md:24
+#: src/platforms/windows.md:42 src/platforms/linux.md:34
+#: src/platforms/wasm.md:55
+msgid "Perry Widget"
+msgstr ""
+
+#: src/platforms/macos.md:24
+msgid "AppKit Class"
+msgstr ""
+
+#: src/platforms/macos.md:26
+msgid "NSTextField (label mode)"
+msgstr ""
+
+#: src/platforms/macos.md:29
+msgid "NSSecureTextField"
+msgstr ""
+
+#: src/platforms/macos.md:30
+msgid "NSSwitch"
+msgstr ""
+
+#: src/platforms/macos.md:31
+msgid "NSSlider"
+msgstr ""
+
+#: src/platforms/macos.md:32
+msgid "NSPopUpButton"
+msgstr ""
+
+#: src/platforms/macos.md:33 src/platforms/ios.md:59 src/platforms/tvos.md:58
+#: src/platforms/watchos.md:61 src/platforms/android.md:33
+#: src/platforms/windows.md:52 src/platforms/linux.md:44
+#: src/widgets/components.md:83
+msgid "Image"
+msgstr ""
+
+#: src/platforms/macos.md:33
+msgid "NSImageView"
+msgstr ""
+
+#: src/platforms/macos.md:34 src/platforms/ios.md:60 src/platforms/tvos.md:59
+#: src/platforms/windows.md:53
+msgid "VStack/HStack"
+msgstr ""
+
+#: src/platforms/macos.md:35
+msgid "NSScrollView"
+msgstr ""
+
+#: src/platforms/macos.md:36
+msgid "NSTableView"
+msgstr ""
+
+#: src/platforms/macos.md:37
+msgid "NSView + Core Graphics"
+msgstr ""
+
+#: src/platforms/macos.md:39 src/cli/perry-toml.md:179
+#: src/cli/perry-toml.md:258
+msgid "Code Signing"
+msgstr ""
+
+#: src/platforms/macos.md:41
+msgid ""
+"For distribution, apps need to be signed. Perry supports automatic signing:"
+msgstr ""
+
+#: src/platforms/macos.md:47
+msgid ""
+"This auto-detects your signing identity from the macOS Keychain, exports it "
+"to a temporary `.p12` file, and signs the binary."
+msgstr ""
+
+#: src/platforms/macos.md:49
+msgid "For manual signing:"
+msgstr ""
+
+#: src/platforms/macos.md:52
+msgid "\"Developer ID Application: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:55
+msgid "App Store Distribution"
+msgstr ""
+
+#: src/platforms/macos.md:58
+msgid "# Sign with App Store certificate\n"
+msgstr ""
+
+#: src/platforms/macos.md:60
+msgid "\"3rd Party Mac Developer Application: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:60
+msgid "# Package\n"
+msgstr ""
+
+#: src/platforms/macos.md:62
+msgid "\"3rd Party Mac Developer Installer: Your Name\""
+msgstr ""
+
+#: src/platforms/macos.md:65
+msgid "macOS-Specific Features"
+msgstr ""
+
+#: src/platforms/macos.md:67
+msgid "**Menu bar**: Full NSMenu support with keyboard shortcuts"
+msgstr ""
+
+#: src/platforms/macos.md:68
+msgid "**Toolbar**: NSToolbar integration"
+msgstr ""
+
+#: src/platforms/macos.md:69
+msgid "**Dock icon**: Automatic for GUI apps"
+msgstr ""
+
+#: src/platforms/macos.md:70
+msgid "**Dark mode**: `isDarkMode()` detects system appearance"
+msgstr ""
+
+#: src/platforms/macos.md:71
+msgid "**Keychain**: Secure storage via Security.framework"
+msgstr ""
+
+#: src/platforms/macos.md:72
+msgid "**Notifications**: Local notifications via UNUserNotificationCenter"
+msgstr ""
+
+#: src/platforms/macos.md:73
+msgid "**File dialogs**: NSOpenPanel/NSSavePanel"
+msgstr ""
+
+#: src/platforms/macos.md:77
+msgid ""
+"```typescript\n"
+"import { openURL, isDarkMode, preferencesSet, preferencesGet } from \"perry/system\"\n"
+"\n"
+"openURL(\"https://example.com\")          // Opens in default browser\n"
+"const dark = isDarkMode()               // Check appearance\n"
+"preferencesSet(\"key\", \"value\")          // NSUserDefaults\n"
+"const val = preferencesGet(\"key\")       // NSUserDefaults\n"
+"```"
+msgstr ""
+
+#: src/platforms/macos.md:88
+msgid "[iOS](ios.md) — Cross-compile for iPhone/iPad"
+msgstr ""
+
+#: src/platforms/macos.md:89
+msgid "[UI Overview](../ui/overview.md) — Full UI documentation"
+msgstr ""
+
+#: src/platforms/macos.md:90
+msgid "[System APIs](../system/overview.md) — System integration"
+msgstr ""
+
+#: src/platforms/ios.md:3
+msgid ""
+"Perry can cross-compile TypeScript apps for iOS devices and the iOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/ios.md:7 src/platforms/tvos.md:9 src/platforms/watchos.md:9
+msgid "macOS host (cross-compilation from Linux/Windows is not supported)"
+msgstr ""
+
+#: src/platforms/ios.md:8
+msgid ""
+"Xcode (full install, not just Command Line Tools) for iOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/ios.md:9
+msgid "Rust iOS targets:"
+msgstr ""
+
+#: src/platforms/ios.md:14 src/platforms/tvos.md:16
+#: src/platforms/watchos.md:16
+msgid "Building for Simulator"
+msgstr ""
+
+#: src/platforms/ios.md:20
+msgid ""
+"This uses LLVM cross-compilation with the iOS Simulator SDK. The binary can "
+"be run in the Xcode Simulator."
+msgstr ""
+
+#: src/platforms/ios.md:22 src/platforms/tvos.md:24
+#: src/platforms/watchos.md:24
+msgid "Building for Device"
+msgstr ""
+
+#: src/platforms/ios.md:28
+msgid ""
+"This produces an ARM64 binary for physical iOS devices. You'll need to code "
+"sign and package it in an `.app` bundle for deployment."
+msgstr ""
+
+#: src/platforms/ios.md:30 src/platforms/tvos.md:32
+#: src/platforms/watchos.md:32
+msgid "Running with `perry run`"
+msgstr ""
+
+#: src/platforms/ios.md:32
+msgid "The easiest way to build and run on iOS is `perry run`:"
+msgstr ""
+
+#: src/platforms/ios.md:35
+msgid "# Auto-detect device/simulator\n"
+msgstr ""
+
+#: src/platforms/ios.md:36
+msgid "# Stream live stdout/stderr\n"
+msgstr ""
+
+#: src/platforms/ios.md:37
+msgid "# Use Perry Hub build server\n"
+msgstr ""
+
+#: src/platforms/ios.md:40
+msgid ""
+"Perry auto-discovers available simulators (via `simctl`) and physical "
+"devices (via `devicectl`). When multiple targets are found, an interactive "
+"prompt lets you choose."
+msgstr ""
+
+#: src/platforms/ios.md:42
+msgid ""
+"For physical devices, Perry handles code signing automatically — it reads "
+"your signing identity and team ID from `~/.perry/config.toml` (set up via "
+"`perry setup ios`), embeds the provisioning profile, and signs the `.app` "
+"before installing."
+msgstr ""
+
+#: src/platforms/ios.md:44
+msgid ""
+"If you don't have the iOS cross-compilation toolchain installed locally, "
+"`perry run ios` automatically falls back to Perry Hub's remote build server."
+msgstr ""
+
+#: src/platforms/ios.md:48
+msgid "Perry maps UI widgets to UIKit controls:"
+msgstr ""
+
+#: src/platforms/ios.md:50 src/platforms/tvos.md:50
+msgid "UIKit Class"
+msgstr ""
+
+#: src/platforms/ios.md:53
+msgid "UIButton (TouchUpInside)"
+msgstr ""
+
+#: src/platforms/ios.md:54 src/platforms/tvos.md:54
+msgid "UITextField"
+msgstr ""
+
+#: src/platforms/ios.md:55
+msgid "UITextField (secureTextEntry)"
+msgstr ""
+
+#: src/platforms/ios.md:56 src/platforms/tvos.md:55
+msgid "UISwitch"
+msgstr ""
+
+#: src/platforms/ios.md:57
+msgid "UISlider (Float32, cast at boundary)"
+msgstr ""
+
+#: src/platforms/ios.md:58 src/platforms/tvos.md:57
+msgid "UIPickerView"
+msgstr ""
+
+#: src/platforms/ios.md:59 src/platforms/tvos.md:58
+msgid "UIImageView"
+msgstr ""
+
+#: src/platforms/ios.md:61 src/platforms/tvos.md:60
+msgid "UIScrollView"
+msgstr ""
+
+#: src/platforms/ios.md:65
+msgid "iOS apps use `UIApplicationMain` with a deferred creation pattern:"
+msgstr ""
+
+#: src/platforms/ios.md:67
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My iOS App\",\n"
+"    width: 400,\n"
+"    height: 800,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello, iPhone!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/ios.md:80
+msgid ""
+"The `App()` call triggers `UIApplicationMain`, and your render function is "
+"called via `PerryAppDelegate` once the app is ready."
+msgstr ""
+
+#: src/platforms/ios.md:82
+msgid "iOS Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/ios.md:84
+msgid ""
+"Perry can compile TypeScript widget declarations to native SwiftUI WidgetKit"
+" extensions:"
+msgstr ""
+
+#: src/platforms/ios.md:90
+msgid "See [Widgets (WidgetKit)](../widgets/overview.md) for details."
+msgstr ""
+
+#: src/platforms/ios.md:92 src/platforms/android.md:51
+msgid "Splash Screen"
+msgstr ""
+
+#: src/platforms/ios.md:94
+msgid ""
+"Perry auto-generates a native `LaunchScreen.storyboard` from the "
+"`perry.splash` config in `package.json`. The splash screen appears instantly"
+" during cold start."
+msgstr ""
+
+#: src/platforms/ios.md:107
+msgid ""
+"The image is centered at 128x128pt with `scaleAspectFit`. You can provide a "
+"custom storyboard for full control:"
+msgstr ""
+
+#: src/platforms/ios.md:119 src/platforms/android.md:83
+msgid ""
+"See [Project Configuration](../getting-started/project-config.md#splash) for"
+" the full config reference."
+msgstr ""
+
+#: src/platforms/ios.md:121
+msgid "Resource Bundling"
+msgstr ""
+
+#: src/platforms/ios.md:123
+msgid ""
+"Perry automatically bundles `logo/` and `assets/` directories from your "
+"project root into the `.app` bundle. These resources are available at "
+"runtime via standard file APIs relative to the app bundle path."
+msgstr ""
+
+#: src/platforms/ios.md:125
+msgid "Keyboard Avoidance"
+msgstr ""
+
+#: src/platforms/ios.md:127
+msgid ""
+"Perry apps automatically handle keyboard avoidance on iOS. When the keyboard"
+" appears, the root view adjusts its bottom constraint with an animated "
+"layout transition, and focused TextFields are auto-scrolled into view above "
+"the keyboard."
+msgstr ""
+
+#: src/platforms/ios.md:129
+msgid "Differences from macOS"
+msgstr ""
+
+#: src/platforms/ios.md:131
+msgid ""
+"**No menu bar**: iOS doesn't support menu bars. Use toolbar or navigation "
+"patterns."
+msgstr ""
+
+#: src/platforms/ios.md:132
+msgid ""
+"**Touch events**: `onHover` is not available. Use `onClick` (mapped to "
+"touch)."
+msgstr ""
+
+#: src/platforms/ios.md:133
+msgid ""
+"**Slider precision**: iOS UISlider uses Float32 internally (automatically "
+"converted)."
+msgstr ""
+
+#: src/platforms/ios.md:134
+msgid "**File dialogs**: Limited to UIDocumentPicker."
+msgstr ""
+
+#: src/platforms/ios.md:135
+msgid "**Keyboard shortcuts**: Not applicable on iOS."
+msgstr ""
+
+#: src/platforms/ios.md:139
+msgid ""
+"[Widgets (WidgetKit)](../widgets/overview.md) — iOS home screen widgets"
+msgstr ""
+
+#: src/platforms/ios.md:140 src/platforms/tvos.md:184
+#: src/platforms/watchos.md:217 src/platforms/android.md:94
+#: src/platforms/windows.md:71 src/platforms/linux.md:83
+#: src/platforms/wasm.md:193
+msgid "[Platform Overview](overview.md) — All platforms"
+msgstr ""
+
+#: src/platforms/ios.md:141 src/platforms/watchos.md:218
+#: src/platforms/android.md:95 src/platforms/windows.md:72
+#: src/platforms/linux.md:84 src/platforms/wasm.md:194
+msgid "[UI Overview](../ui/overview.md) — UI system"
+msgstr ""
+
+#: src/platforms/visionos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple Vision Pro devices and the "
+"visionOS Simulator."
+msgstr ""
+
+#: src/platforms/visionos.md:5
+msgid ""
+"This first pass targets **2D windowed apps only**. Perry uses the same "
+"UIKit-style `perry/ui` model as iOS, packaged for visionOS app bundles and "
+"scene lifecycle."
+msgstr ""
+
+#: src/platforms/visionos.md:9
+msgid "macOS with Xcode installed"
+msgstr ""
+
+#: src/platforms/visionos.md:10
+msgid "Rust visionOS targets:"
+msgstr ""
+
+#: src/platforms/visionos.md:16
+msgid "Compile"
+msgstr ""
+
+#: src/platforms/visionos.md:23
+msgid ""
+"This produces a `.app` bundle with visionOS-specific `Info.plist` metadata "
+"and a `UIWindowScene` configuration."
+msgstr ""
+
+#: src/platforms/visionos.md:25
+msgid "Run"
+msgstr ""
+
+#: src/platforms/visionos.md:33
+msgid ""
+"Perry auto-detects booted Apple Vision Pro simulators via `simctl`. Physical"
+" device installs use `devicectl`, like other modern Apple platforms."
+msgstr ""
+
+#: src/platforms/visionos.md:37
+msgid "Configure visionOS-specific settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/visionos.md:39
+msgid ""
+"```toml\n"
+"[visionos]\n"
+"bundle_id = \"com.example.myvisionapp\"\n"
+"deployment_target = \"1.0\"\n"
+"entry = \"src/main_visionos.ts\"\n"
+"encryption_exempt = true\n"
+"```"
+msgstr ""
+
+#: src/platforms/visionos.md:47
+msgid ""
+"Custom `Info.plist` keys can be merged through `[visionos.info_plist]`."
+msgstr ""
+
+#: src/platforms/visionos.md:51
+msgid "Use `__platform__ === 8` to detect visionOS at compile time:"
+msgstr ""
+
+#: src/platforms/visionos.md:53
+msgid ""
+"```typescript\n"
+"function reportVisionos(): void {\n"
+"    if (__platform__ === 8) {\n"
+"        console.log(\"Running on visionOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/visionos.md:61
+msgid "Current Scope"
+msgstr ""
+
+#: src/platforms/visionos.md:63
+msgid ""
+"Supported: 2D windowed apps, simulator/device app bundles, `perry run`, "
+"`perry setup`, `perry publish`"
+msgstr ""
+
+#: src/platforms/visionos.md:64
+msgid ""
+"Not supported yet: immersive spaces, volumes, RealityKit scene generation, "
+"Geisterhand"
+msgstr ""
+
+#: src/platforms/visionos.md:66
+msgid "Related"
+msgstr ""
+
+#: src/platforms/visionos.md:68
+msgid "[iOS](ios.md) — shared UIKit foundation"
+msgstr ""
+
+#: src/platforms/visionos.md:69
+msgid "[Platform Overview](overview.md)"
+msgstr ""
+
+#: src/platforms/tvos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple TV devices and the tvOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/tvos.md:5
+msgid ""
+"tvOS uses UIKit (the same framework as iOS), so Perry's tvOS support shares "
+"the same UIKit-based widget system. The primary difference is input: Apple "
+"TV apps are controlled via the Siri Remote and game controllers rather than "
+"touch, and all apps run full-screen."
+msgstr ""
+
+#: src/platforms/tvos.md:10
+msgid "Xcode (full install) for tvOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/tvos.md:11
+msgid "Rust tvOS targets:"
+msgstr ""
+
+#: src/platforms/tvos.md:22
+msgid ""
+"This produces an ARM64 binary linked with `clang` against the tvOS Simulator"
+" SDK, wrapped in a `.app` bundle."
+msgstr ""
+
+#: src/platforms/tvos.md:30
+msgid "This produces an ARM64 binary for physical Apple TV hardware."
+msgstr ""
+
+#: src/platforms/tvos.md:35
+msgid "# Auto-detect booted Apple TV simulator\n"
+msgstr ""
+
+#: src/platforms/tvos.md:39
+msgid ""
+"Perry auto-discovers booted Apple TV simulators. To install and launch "
+"manually:"
+msgstr ""
+
+#: src/platforms/tvos.md:48
+msgid "Perry maps UI widgets to UIKit controls on tvOS, identical to iOS:"
+msgstr ""
+
+#: src/platforms/tvos.md:50 src/platforms/tvos.md:149
+#: src/platforms/watchos.md:50 src/system/media.md:37
+#: src/testing/geisterhand.md:257 src/cli/flags.md:20
+msgid "Notes"
+msgstr ""
+
+#: src/platforms/tvos.md:53
+msgid "Focus-based navigation"
+msgstr ""
+
+#: src/platforms/tvos.md:54
+msgid "On-screen keyboard via Siri Remote"
+msgstr ""
+
+#: src/platforms/tvos.md:56
+msgid "UISlider"
+msgstr ""
+
+#: src/platforms/tvos.md:60
+msgid "Focus-based scrolling"
+msgstr ""
+
+#: src/platforms/tvos.md:62
+msgid "Focus Engine"
+msgstr ""
+
+#: src/platforms/tvos.md:64
+msgid ""
+"tvOS uses a **focus-based navigation model** instead of direct touch. The "
+"Siri Remote's touchpad and directional buttons move focus between focusable "
+"views. Perry widgets that support interaction (buttons, text fields, "
+"toggles, etc.) are automatically focusable."
+msgstr ""
+
+#: src/platforms/tvos.md:66
+msgid "Game Engine Support"
+msgstr ""
+
+#: src/platforms/tvos.md:68
+msgid ""
+"tvOS is particularly well-suited for game engines. When using a native "
+"library like [Bloom](https://bloomengine.dev), the game engine handles its "
+"own windowing, rendering, and input."
+msgstr ""
+
+#: src/platforms/tvos.md:70
+msgid ""
+"**Status:** illustrative only — Bloom is an external native library (see "
+"[bloomengine.dev](https://bloomengine.dev)). The snippet below is left as "
+"`,no-test` because it depends on Bloom's `.a`/`.so` being available at link "
+"time; the doc-tests harness compiles every other snippet on this page."
+msgstr ""
+
+#: src/platforms/tvos.md:72
+msgid ""
+"```text\n"
+"import { initWindow, windowShouldClose, beginDrawing, endDrawing,\n"
+"         clearBackground, isGamepadButtonDown, Colors } from \"bloom\";\n"
+"\n"
+"initWindow(1920, 1080, \"My Apple TV Game\");\n"
+"\n"
+"while (!windowShouldClose()) {\n"
+"  beginDrawing();\n"
+"  clearBackground(Colors.BLACK);\n"
+"\n"
+"  if (isGamepadButtonDown(0)) {\n"
+"    // A button (Siri Remote select) pressed\n"
+"  }\n"
+"\n"
+"  endDrawing();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:90
+msgid "Input on tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:92
+msgid "The Siri Remote acts as a game controller:"
+msgstr ""
+
+#: src/platforms/tvos.md:94
+msgid "Input"
+msgstr ""
+
+#: src/platforms/tvos.md:94
+msgid "Mapping"
+msgstr ""
+
+#: src/platforms/tvos.md:96
+msgid "Touchpad swipe"
+msgstr ""
+
+#: src/platforms/tvos.md:96
+msgid "Gamepad axes 0/1 (left stick)"
+msgstr ""
+
+#: src/platforms/tvos.md:97
+msgid "Touchpad click (Select)"
+msgstr ""
+
+#: src/platforms/tvos.md:97
+msgid "Gamepad button 0 (A) + mouse button 0"
+msgstr ""
+
+#: src/platforms/tvos.md:98
+msgid "Menu button"
+msgstr ""
+
+#: src/platforms/tvos.md:98
+msgid "Gamepad button 1 (B)"
+msgstr ""
+
+#: src/platforms/tvos.md:99
+msgid "Play/Pause button"
+msgstr ""
+
+#: src/platforms/tvos.md:99
+msgid "Gamepad button 9 (Start)"
+msgstr ""
+
+#: src/platforms/tvos.md:100
+msgid "Arrow presses (up/down/left/right)"
+msgstr ""
+
+#: src/platforms/tvos.md:100
+msgid "Gamepad D-pad buttons (12-15)"
+msgstr ""
+
+#: src/platforms/tvos.md:102
+msgid ""
+"Extended game controllers (MFi, PlayStation, Xbox) are fully supported with "
+"all axes, buttons, triggers, and D-pad mapped through the standard gamepad "
+"API."
+msgstr ""
+
+#: src/platforms/tvos.md:106
+msgid ""
+"tvOS apps use `UIApplicationMain` with the same lifecycle as iOS. When using"
+" `perry/ui`:"
+msgstr ""
+
+#: src/platforms/tvos.md:108
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My TV App\",\n"
+"    width: 1920,\n"
+"    height: 1080,\n"
+"    body: VStack(16, [\n"
+"        Text(\"Hello, Apple TV!\"),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:121
+msgid ""
+"When using a game engine with `--features ios-game-loop`, the runtime starts"
+" `UIApplicationMain` on the main thread and runs your game code on a "
+"dedicated game thread."
+msgstr ""
+
+#: src/platforms/tvos.md:125
+msgid "Configure tvOS settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/tvos.md:127
+msgid ""
+"```toml\n"
+"[tvos]\n"
+"bundle_id = \"com.example.mytvapp\"\n"
+"deployment_target = \"17.0\"\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:135
+msgid "Use `__platform__ === 6` to detect tvOS at compile time:"
+msgstr ""
+
+#: src/platforms/tvos.md:137
+msgid ""
+"```typescript\n"
+"function reportTvos(): void {\n"
+"    if (__platform__ === 6) {\n"
+"        console.log(\"Running on tvOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/tvos.md:145
+msgid "App Bundle"
+msgstr ""
+
+#: src/platforms/tvos.md:147
+msgid "Perry generates a `.app` bundle with an `Info.plist` containing:"
+msgstr ""
+
+#: src/platforms/tvos.md:149 src/cli/perry-toml.md:367
+msgid "Key"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "`UIDeviceFamily`"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "`[3]`"
+msgstr ""
+
+#: src/platforms/tvos.md:151
+msgid "Apple TV"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "`MinimumOSVersion`"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "`17.0`"
+msgstr ""
+
+#: src/platforms/tvos.md:152
+msgid "tvOS 17+"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "`UIRequiresFullScreen`"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "`true`"
+msgstr ""
+
+#: src/platforms/tvos.md:153
+msgid "All tvOS apps are full-screen"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "`UILaunchStoryboardName`"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "`LaunchScreen`"
+msgstr ""
+
+#: src/platforms/tvos.md:154
+msgid "Required by tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:158
+msgid ""
+"tvOS has inherent platform constraints compared to other Perry targets:"
+msgstr ""
+
+#: src/platforms/tvos.md:160
+msgid "**No camera**: Apple TV has no camera hardware"
+msgstr ""
+
+#: src/platforms/tvos.md:161
+msgid "**No clipboard**: UIPasteboard is not available on tvOS"
+msgstr ""
+
+#: src/platforms/tvos.md:162
+msgid "**No file dialogs**: No document picker"
+msgstr ""
+
+#: src/platforms/tvos.md:163
+msgid "**No QR code**: No camera for scanning"
+msgstr ""
+
+#: src/platforms/tvos.md:164
+msgid "**No multi-window**: Single full-screen window only"
+msgstr ""
+
+#: src/platforms/tvos.md:165
+msgid ""
+"**No direct touch**: Input is via Siri Remote focus engine and game "
+"controllers"
+msgstr ""
+
+#: src/platforms/tvos.md:166
+msgid ""
+"**Resolution**: Design for 1920x1080 (1080p) or 3840x2160 (4K) displays"
+msgstr ""
+
+#: src/platforms/tvos.md:168 src/platforms/watchos.md:206
+msgid "Differences from iOS"
+msgstr ""
+
+#: src/platforms/tvos.md:170
+msgid "Aspect"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "**Input**"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "Siri Remote + game controllers (focus engine)"
+msgstr ""
+
+#: src/platforms/tvos.md:172
+msgid "Direct touch"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "**Display**"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "Full-screen only (1080p/4K)"
+msgstr ""
+
+#: src/platforms/tvos.md:173
+msgid "Variable screen sizes"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "**Device family**"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "`[3]` (Apple TV)"
+msgstr ""
+
+#: src/platforms/tvos.md:174
+msgid "`[1, 2]` (iPhone/iPad)"
+msgstr ""
+
+#: src/platforms/tvos.md:175
+msgid "**Camera**"
+msgstr ""
+
+#: src/platforms/tvos.md:175 src/platforms/tvos.md:176
+msgid "Not available"
+msgstr ""
+
+#: src/platforms/tvos.md:175 src/platforms/tvos.md:176
+msgid "Available"
+msgstr ""
+
+#: src/platforms/tvos.md:176
+msgid "**Clipboard**"
+msgstr ""
+
+#: src/platforms/tvos.md:177
+msgid "**Deployment target**"
+msgstr ""
+
+#: src/platforms/tvos.md:177
+msgid "17.0"
+msgstr ""
+
+#: src/platforms/tvos.md:178
+msgid "**UI framework**"
+msgstr ""
+
+#: src/platforms/tvos.md:178
+msgid "UIKit (same as iOS)"
+msgstr ""
+
+#: src/platforms/tvos.md:182
+msgid "[iOS](ios.md) — iOS platform reference (shared UIKit base)"
+msgstr ""
+
+#: src/platforms/tvos.md:183
+msgid "[watchOS](watchos.md) — watchOS platform reference"
+msgstr ""
+
+#: src/platforms/watchos.md:3
+msgid ""
+"Perry can compile TypeScript apps for Apple Watch devices and the watchOS "
+"Simulator."
+msgstr ""
+
+#: src/platforms/watchos.md:5
+msgid ""
+"Since watchOS does not support UIKit views, Perry uses a **data-driven "
+"SwiftUI renderer**: your TypeScript code builds a UI tree via the standard "
+"`perry/ui` API, and a fixed SwiftUI runtime (shipped with Perry) queries the"
+" tree and renders it reactively. No code generation or transpilation is "
+"involved — the binary is fully native."
+msgstr ""
+
+#: src/platforms/watchos.md:10
+msgid "Xcode (full install) for watchOS SDK and Simulator"
+msgstr ""
+
+#: src/platforms/watchos.md:11
+msgid "Rust watchOS targets:"
+msgstr ""
+
+#: src/platforms/watchos.md:22
+msgid ""
+"This produces an ARM64 binary linked with `swiftc` against the watchOS "
+"Simulator SDK, wrapped in a `.app` bundle."
+msgstr ""
+
+#: src/platforms/watchos.md:30
+msgid ""
+"This produces an arm64_32 (ILP32) binary for physical Apple Watch hardware. "
+"Apple Watch uses 32-bit pointers on 64-bit ARM."
+msgstr ""
+
+#: src/platforms/watchos.md:35
+msgid "# Auto-detect booted watch simulator\n"
+msgstr ""
+
+#: src/platforms/watchos.md:39
+msgid ""
+"Perry auto-discovers booted Apple Watch simulators. To install and launch "
+"manually:"
+msgstr ""
+
+#: src/platforms/watchos.md:48
+msgid "Perry maps UI widgets to SwiftUI views via a data-driven bridge:"
+msgstr ""
+
+#: src/platforms/watchos.md:50
+msgid "SwiftUI View"
+msgstr ""
+
+#: src/platforms/watchos.md:52
+msgid "Font size, weight, color, wrapping"
+msgstr ""
+
+#: src/platforms/watchos.md:53
+msgid "Tap action via native closure callback"
+msgstr ""
+
+#: src/platforms/watchos.md:54 src/platforms/watchos.md:55
+msgid "With spacing"
+msgstr ""
+
+#: src/platforms/watchos.md:56
+msgid "Layered views"
+msgstr ""
+
+#: src/platforms/watchos.md:59
+msgid "Two-way state binding"
+msgstr ""
+
+#: src/platforms/watchos.md:60
+msgid "Min/max/value, state binding"
+msgstr ""
+
+#: src/platforms/watchos.md:61
+msgid "Image(systemName:)"
+msgstr ""
+
+#: src/platforms/watchos.md:61
+msgid "SF Symbols"
+msgstr ""
+
+#: src/platforms/watchos.md:63
+msgid "Linear"
+msgstr ""
+
+#: src/platforms/watchos.md:64
+msgid "Selection list"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "Form"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "List"
+msgstr ""
+
+#: src/platforms/watchos.md:65
+msgid "Maps to List on watchOS"
+msgstr ""
+
+#: src/platforms/watchos.md:66 src/platforms/android.md:39
+#: src/platforms/linux.md:50
+msgid "NavigationStack"
+msgstr ""
+
+#: src/platforms/watchos.md:66
+msgid "Push navigation"
+msgstr ""
+
+#: src/platforms/watchos.md:68 src/widgets/components.md:136
+msgid "Modifiers"
+msgstr ""
+
+#: src/platforms/watchos.md:70
+msgid "All widgets support these styling modifiers:"
+msgstr ""
+
+#: src/platforms/watchos.md:72
+msgid "`foregroundColor` / `backgroundColor`"
+msgstr ""
+
+#: src/platforms/watchos.md:73
+msgid "`font` (size, weight, family)"
+msgstr ""
+
+#: src/platforms/watchos.md:74
+msgid "`frame` (width, height)"
+msgstr ""
+
+#: src/platforms/watchos.md:75
+msgid "`padding` (uniform or per-edge)"
+msgstr ""
+
+#: src/platforms/watchos.md:76
+msgid "`cornerRadius`"
+msgstr ""
+
+#: src/platforms/watchos.md:78
+msgid "`hidden` / `disabled`"
+msgstr ""
+
+#: src/platforms/watchos.md:82
+msgid ""
+"watchOS apps use SwiftUI's `@main App` pattern. Perry's PerryWatchApp.swift "
+"runtime handles the app lifecycle automatically:"
+msgstr ""
+
+#: src/platforms/watchos.md:84
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack, Button } from \"perry/ui\"\n"
+"\n"
+"App({\n"
+"    title: \"My Watch App\",\n"
+"    width: 200,\n"
+"    height: 200,\n"
+"    body: VStack(8, [\n"
+"        Text(\"Hello, Apple Watch!\"),\n"
+"        Button(\"Tap me\", () => {\n"
+"            console.log(\"Button tapped!\")\n"
+"        }),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:100
+msgid "Under the hood:"
+msgstr ""
+
+#: src/platforms/watchos.md:101
+msgid ""
+"`perry_main_init()` runs your compiled TypeScript, which builds the UI tree "
+"in memory"
+msgstr ""
+
+#: src/platforms/watchos.md:102
+msgid "The SwiftUI `@main` struct observes the tree version and renders it"
+msgstr ""
+
+#: src/platforms/watchos.md:103
+msgid ""
+"User interactions (button taps, toggle changes) call back into native "
+"closures"
+msgstr ""
+
+#: src/platforms/watchos.md:107
+msgid "Reactive state works the same as other platforms:"
+msgstr ""
+
+#: src/platforms/watchos.md:109 src/platforms/wasm.md:166
+msgid ""
+"```typescript\n"
+"import { App, Text, VStack, Button, State } from \"perry/ui\"\n"
+"\n"
+"const count = State(0)\n"
+"\n"
+"App({\n"
+"    title: \"Counter\",\n"
+"    width: 400,\n"
+"    height: 300,\n"
+"    body: VStack(16, [\n"
+"        Text(`Count: ${count.value}`),\n"
+"        Button(\"Increment\", () => count.set(count.value + 1)),\n"
+"    ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:125
+msgid ""
+"When `state.set()` is called, the tree version increments and SwiftUI re-"
+"renders the affected views automatically."
+msgstr ""
+
+#: src/platforms/watchos.md:129
+msgid ""
+"Unlike iOS (UIKit) and macOS (AppKit), where Perry calls native view APIs "
+"directly via FFI, watchOS uses a **data-driven architecture**:"
+msgstr ""
+
+#: src/platforms/watchos.md:147
+msgid ""
+"The `PerryWatchApp.swift` file is a fixed runtime (~280 lines) that ships "
+"with Perry. It never changes per-app — it's the watchOS equivalent of "
+"`libperry_ui_ios.a`."
+msgstr ""
+
+#: src/platforms/watchos.md:151
+msgid "Configure watchOS settings in `perry.toml`:"
+msgstr ""
+
+#: src/platforms/watchos.md:153
+msgid ""
+"```toml\n"
+"[watchos]\n"
+"bundle_id = \"com.example.mywatch\"\n"
+"deployment_target = \"10.0\"\n"
+"\n"
+"[watchos.info_plist]\n"
+"NSLocationWhenInUseUsageDescription = \"Used for location features\"\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:162
+msgid "Set up signing credentials with:"
+msgstr ""
+
+#: src/platforms/watchos.md:168
+msgid ""
+"This shares App Store Connect credentials with iOS/macOS (same team, API "
+"key, issuer)."
+msgstr ""
+
+#: src/platforms/watchos.md:172
+msgid "Use `__platform__ === 7` to detect watchOS at compile time:"
+msgstr ""
+
+#: src/platforms/watchos.md:174
+msgid ""
+"```typescript\n"
+"function reportWatchos(): void {\n"
+"    if (__platform__ === 7) {\n"
+"        console.log(\"Running on watchOS\")\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/watchos.md:182
+msgid "watchOS Widgets (WidgetKit)"
+msgstr ""
+
+#: src/platforms/watchos.md:184
+msgid ""
+"Perry also supports watchOS WidgetKit complications (separate from full "
+"apps):"
+msgstr ""
+
+#: src/platforms/watchos.md:190
+msgid ""
+"See [watchOS Complications](../widgets/watchos.md) for widget-specific "
+"documentation."
+msgstr ""
+
+#: src/platforms/watchos.md:194
+msgid ""
+"watchOS apps have inherent platform constraints compared to other Perry "
+"targets:"
+msgstr ""
+
+#: src/platforms/watchos.md:196
+msgid "**No Canvas**: CoreGraphics drawing is not available"
+msgstr ""
+
+#: src/platforms/watchos.md:197
+msgid "**No Camera**: watchOS does not support camera APIs"
+msgstr ""
+
+#: src/platforms/watchos.md:198
+msgid "**No TextField**: Text input is extremely limited on Apple Watch"
+msgstr ""
+
+#: src/platforms/watchos.md:199
+msgid "**No File Dialogs**: No document picker"
+msgstr ""
+
+#: src/platforms/watchos.md:200
+msgid "**No Menu Bar / Toolbar**: Not applicable on watch"
+msgstr ""
+
+#: src/platforms/watchos.md:201
+msgid "**No Multi-Window**: Single window only"
+msgstr ""
+
+#: src/platforms/watchos.md:202
+msgid "**No QR Code**: Screen too small for practical QR display"
+msgstr ""
+
+#: src/platforms/watchos.md:203
+msgid ""
+"**Memory**: watchOS devices have ~50-75MB available RAM — keep apps "
+"lightweight"
+msgstr ""
+
+#: src/platforms/watchos.md:204
+msgid "**Screen size**: Design for 40-49mm watch faces"
+msgstr ""
+
+#: src/platforms/watchos.md:208
+msgid ""
+"**SwiftUI vs UIKit**: watchOS uses SwiftUI rendering; iOS uses UIKit "
+"directly"
+msgstr ""
+
+#: src/platforms/watchos.md:209
+msgid "**No splash screen**: watchOS apps don't use launch storyboards"
+msgstr ""
+
+#: src/platforms/watchos.md:210
+msgid ""
+"**Standalone**: watchOS apps are standalone (no iPhone companion required, "
+"`WKWatchOnly = true`)"
+msgstr ""
+
+#: src/platforms/watchos.md:211
+msgid ""
+"**Device family**: `UIDeviceFamily = [4]` (watch) vs `[1, 2]` (iPhone/iPad)"
+msgstr ""
+
+#: src/platforms/watchos.md:215
+msgid ""
+"[watchOS Complications](../widgets/watchos.md) — WidgetKit complications"
+msgstr ""
+
+#: src/platforms/watchos.md:216
+msgid "[iOS](ios.md) — iOS platform reference"
+msgstr ""
+
+#: src/platforms/android.md:3
+msgid ""
+"Perry compiles TypeScript apps for Android using JNI (Java Native "
+"Interface)."
+msgstr ""
+
+#: src/platforms/android.md:7
+msgid "Android NDK"
+msgstr ""
+
+#: src/platforms/android.md:8
+msgid "Android SDK"
+msgstr ""
+
+#: src/platforms/android.md:9
+msgid "Rust Android targets:"
+msgstr ""
+
+#: src/platforms/android.md:22
+msgid "Perry maps UI widgets to Android views via JNI:"
+msgstr ""
+
+#: src/platforms/android.md:24
+msgid "Android Class"
+msgstr ""
+
+#: src/platforms/android.md:26
+msgid "TextView"
+msgstr ""
+
+#: src/platforms/android.md:28
+msgid "EditText"
+msgstr ""
+
+#: src/platforms/android.md:29
+msgid "EditText (ES_PASSWORD)"
+msgstr ""
+
+#: src/platforms/android.md:30
+msgid "Switch"
+msgstr ""
+
+#: src/platforms/android.md:31
+msgid "SeekBar"
+msgstr ""
+
+#: src/platforms/android.md:32
+msgid "Spinner + ArrayAdapter"
+msgstr ""
+
+#: src/platforms/android.md:33
+msgid "ImageView"
+msgstr ""
+
+#: src/platforms/android.md:34
+msgid "LinearLayout (vertical)"
+msgstr ""
+
+#: src/platforms/android.md:35
+msgid "LinearLayout (horizontal)"
+msgstr ""
+
+#: src/platforms/android.md:36 src/platforms/android.md:39
+msgid "FrameLayout"
+msgstr ""
+
+#: src/platforms/android.md:38
+msgid "Canvas + Bitmap"
+msgstr ""
+
+#: src/platforms/android.md:41
+msgid "Android-Specific APIs"
+msgstr ""
+
+#: src/platforms/android.md:43
+msgid "**Dark mode**: `Configuration.uiMode` detection"
+msgstr ""
+
+#: src/platforms/android.md:44
+msgid "**Preferences**: SharedPreferences"
+msgstr ""
+
+#: src/platforms/android.md:45
+msgid "**Keychain**: Android Keystore"
+msgstr ""
+
+#: src/platforms/android.md:46
+msgid "**Notifications**: NotificationManager"
+msgstr ""
+
+#: src/platforms/android.md:47
+msgid "**Open URL**: `Intent.ACTION_VIEW`"
+msgstr ""
+
+#: src/platforms/android.md:48
+msgid "**Alerts**: `PerryBridge.showAlert`"
+msgstr ""
+
+#: src/platforms/android.md:49
+msgid "**Sheets**: Dialog (modal)"
+msgstr ""
+
+#: src/platforms/android.md:53
+msgid ""
+"Perry's Android template includes a splash theme (`Theme.Perry.Splash`) that"
+" displays a `windowBackground` drawable during cold start. Configure it via "
+"`perry.splash` in `package.json`:"
+msgstr ""
+
+#: src/platforms/android.md:66
+msgid ""
+"The image is centered via a `layer-list` drawable with a solid background "
+"color. The activity switches to the normal theme in `onCreate` before "
+"inflating the layout, so the splash disappears as soon as the app is ready."
+msgstr ""
+
+#: src/platforms/android.md:68
+msgid "For full control, provide custom drawable and theme XML files:"
+msgstr ""
+
+#: src/platforms/android.md:85
+msgid "Differences from Desktop"
+msgstr ""
+
+#: src/platforms/android.md:87
+msgid "**Touch-only**: No hover events, no right-click context menus"
+msgstr ""
+
+#: src/platforms/android.md:88
+msgid "**Single window**: Multi-window maps to Dialog views"
+msgstr ""
+
+#: src/platforms/android.md:89
+msgid "**Toolbar**: Horizontal LinearLayout"
+msgstr ""
+
+#: src/platforms/android.md:90
+msgid "**Font**: Typeface-based font family support"
+msgstr ""
+
+#: src/platforms/harmonyos.md:3
+msgid ""
+"Perry compiles TypeScript apps for HarmonyOS NEXT (Huawei's mobile OS) by "
+"emitting **declarative ArkUI** alongside a logic-only `.so` library. The "
+"same TypeScript source that targets macOS, iOS, Android, Linux, and Windows "
+"also runs natively on HarmonyOS — no platform-specific adapters needed in "
+"user code."
+msgstr ""
+
+#: src/platforms/harmonyos.md:7
+msgid ""
+"HarmonyOS NEXT runs apps via the ArkTS runtime, which owns the UI tree. "
+"Perry can't lower `perry/ui` calls to the imperative AppKit/UIKit/etc shape "
+"used on every other platform — it has to play by ArkTS's declarative rules. "
+"So the harmonyos target is structured differently:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:26
+msgid ""
+"The user splices three artifacts into a DevEco Studio project — "
+"`libentry.so`, `pages/Index.ets`, `cpp/types/libentry/Index.d.ts` — and "
+"DevEco signs + runs as usual. Tap interactions, text input, etc. fire NAPI "
+"calls into the `.so`, which dispatch the registered Perry closure bodies."
+msgstr ""
+
+#: src/platforms/harmonyos.md:28
+msgid "What's supported"
+msgstr ""
+
+#: src/platforms/harmonyos.md:30
+msgid "**Widgets** (introduced in v0.5.401, expanded in v0.5.418, v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:32
+msgid "Widget"
+msgstr ""
+
+#: src/platforms/harmonyos.md:32
+msgid "ArkUI emission"
+msgstr ""
+
+#: src/platforms/harmonyos.md:34
+msgid "`Text(content)` / `Text(content, \"id\")`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:34
+msgid "`Text(...).fontSize(20)` (reactive when id is given)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:35
+msgid "`VStack(children)` / `VStack(spacing, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:35
+msgid "`Column({ space })`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:36
+msgid "`HStack(children)` / `HStack(spacing, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:36
+msgid "`Row({ space })`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:37
+msgid "`Button(label, onPress)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:37
+msgid "`Button(...).onClick(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:38
+msgid "`TextField(placeholder, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:38
+msgid "`TextInput(...).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:39
+msgid "`Toggle(label, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:39
+msgid "`Toggle({type: ToggleType.Switch}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:40
+msgid "`Slider(min, max, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:40
+msgid "`Slider({...}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:41
+msgid "`Spacer()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:41
+msgid "`Blank()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:42
+msgid "`Divider()`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:43
+msgid "`Image(src)` / `ImageFile(path)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:43
+msgid "`Image(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:44
+msgid "`ScrollView(children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:44
+msgid "`Scroll() { Column() { ... } }`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:45
+msgid "`LazyVStack(children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:45
+msgid "`Column({...})` (eager — see v10 follow-up)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:46
+msgid "`Picker(options, onChange)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:46
+msgid "`TextPicker({...}).onChange(...)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:47
+msgid "`ProgressView(value, total)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:47
+msgid "`Progress({type: ProgressType.Linear})`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:48
+msgid "`Section(title, children)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:48
+msgid "`Column({ space: 4 }) { Text(title) ... }`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:50
+msgid "**Event handling** (v0.5.417 + v0.5.421):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:51
+msgid "`Button.onPress` → `invokeCallback(idx)` via NAPI"
+msgstr ""
+
+#: src/platforms/harmonyos.md:52
+msgid ""
+"`Toggle.onChange((isOn: boolean) => ...)` → `invokeCallback1(idx, isOn)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:53
+msgid ""
+"`TextField.onChange((value: string) => ...)` → `invokeCallback1(idx, value)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:54
+msgid ""
+"`Slider.onChange((value: number) => ...)` → `invokeCallback1(idx, value)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:55
+msgid ""
+"`Picker.onChange((idx: number) => ...)` → `invokeCallback1(idx, index)`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:57
+msgid "**Reactivity** (v0.5.419 + v0.5.421):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:58
+msgid ""
+"`Text(\"0\", \"counter\")` registers a reactive slot bound to a generated "
+"`@State text_counter: string` field."
+msgstr ""
+
+#: src/platforms/harmonyos.md:59
+msgid ""
+"`setText(\"counter\", \"5\")` from inside any closure updates the Text on-"
+"screen."
+msgstr ""
+
+#: src/platforms/harmonyos.md:61
+msgid "**Toast banners** (v0.5.419):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:62
+msgid ""
+"`showToast(\"Saved!\")` from inside any closure shows an ArkUI "
+"`promptAction.showToast({ message })` banner."
+msgstr ""
+
+#: src/platforms/harmonyos.md:64
+msgid "**Inline styling** (v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:65
+msgid ""
+"`Text(\"hi\", { fontSize: 16, color: \"red\" })` maps to "
+"`.fontSize(16).fontColor('red')`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:66
+msgid ""
+"Supported props: `backgroundColor`, `color`, `fontSize`, `fontWeight`, "
+"`fontFamily`, `borderRadius`, `padding` (number or per-side object), "
+"`opacity`, `hidden`, `borderColor` + `borderWidth` (combined as "
+"`.border({...})`)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:67
+msgid "PerryColor objects (`{r,g,b,a}`) auto-convert to `rgba(...)` strings."
+msgstr ""
+
+#: src/platforms/harmonyos.md:69
+msgid "**Dynamic lists** (v0.5.429):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:70
+msgid ""
+"`VStack(items.map(item => Text(item)))` lowers to ArkUI `ForEach(items, "
+"(__item) => { Text(__item) }, (__item) => __item)`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:71
+msgid ""
+"Single-arg map closures only; complex array sources require Phase 2 v6 state"
+" binding."
+msgstr ""
+
+#: src/platforms/harmonyos.md:73
+msgid "Setup"
+msgstr ""
+
+#: src/platforms/harmonyos.md:75
+msgid ""
+"**Install DevEco Studio** + the OpenHarmony SDK from Huawei. Verified "
+"working with DevEco Studio 6.0.2 + OpenHarmony 5.0+."
+msgstr ""
+
+#: src/platforms/harmonyos.md:77
+msgid "**Run the setup wizard once** (introduced in v0.5.380):"
+msgstr ""
+
+#: src/platforms/harmonyos.md:83
+msgid ""
+"The wizard auto-discovers your DevEco-generated debug certificates from "
+"`~/.ohos/config/`, prompts for the keystore password, and persists the "
+"configuration to `~/.perry/config.toml`. Subsequent `perry compile --target "
+"harmonyos` invocations sign HAPs automatically."
+msgstr ""
+
+#: src/platforms/harmonyos.md:85
+msgid ""
+"**Optional**: install `hdc` (HarmonyOS Device Connector) for emulator "
+"interaction. It ships inside DevEco at "
+"`Contents/sdk/default/openharmony/toolchains/hdc`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:87
+msgid "Compile + run workflow"
+msgstr ""
+
+#: src/platforms/harmonyos.md:89
+msgid "Write a TypeScript program with `App({body: ...})`:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:91
+msgid ""
+"```typescript,no-test\n"
+"// hi.ts\n"
+"import { App, VStack, Text, Button, showToast } from \"perry/ui\";\n"
+"\n"
+"let count = 0;\n"
+"\n"
+"App({\n"
+"  title: \"Perry on HarmonyOS\",\n"
+"  body: VStack([\n"
+"    Text(\"Count: 0\", \"counter\"),\n"
+"    Button(\"+\", () => {\n"
+"      count++;\n"
+"      setText(\"counter\", `Count: ${count}`);\n"
+"    }),\n"
+"    Button(\"Notify\", () => {\n"
+"      showToast(`Counter is ${count}`);\n"
+"    }),\n"
+"  ]),\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/platforms/harmonyos.md:112
+msgid "Compile for HarmonyOS:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:118
+msgid "This produces three artifacts in `/tmp/`:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:120
+msgid "`libentry.so` — the compiled `.so` (8-9 MB typically)"
+msgstr ""
+
+#: src/platforms/harmonyos.md:121
+msgid "`ets/pages/Index.ets` — the auto-emitted ArkUI page"
+msgstr ""
+
+#: src/platforms/harmonyos.md:122
+msgid "`cpp/types/libentry/Index.d.ts` — the NAPI declaration file"
+msgstr ""
+
+#: src/platforms/harmonyos.md:124
+msgid "**Splice** into a DevEco Studio project:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:132
+msgid ""
+"Click ▶ Run in DevEco — DevEco's hvigor signs + bundles the HAP and installs"
+" onto the emulator (or attached device). The app launches, taps fire your TS"
+" closures, and the screen updates reactively."
+msgstr ""
+
+#: src/platforms/harmonyos.md:134
+msgid "Architecture deep dive"
+msgstr ""
+
+#: src/platforms/harmonyos.md:136
+msgid "The harvest model"
+msgstr ""
+
+#: src/platforms/harmonyos.md:138
+msgid ""
+"`perry-codegen-arkts::emit_index_ets` walks `module.init` looking for the "
+"first `App({body: <expr>})` call from `perry/ui`. It extracts the `body` "
+"field, recursively emits ArkUI source for each widget in the tree, and "
+"**destructively replaces the App call with `Stmt::Expr(Expr::Number(0.0))`**"
+" so the LLVM backend never sees `perry_ui_*` FFI calls (which would be "
+"unresolved on the OHOS target — there's no `perry-ui-harmonyos` crate by "
+"design)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:140
+msgid ""
+"The emitted Index.ets is a real ArkUI `@Entry @Component struct Index { "
+"build() { ... } }` page with `@State` declarations for any reactive Text "
+"widgets, `import promptAction from '@ohos.promptAction'` for toast routing, "
+"and per-Button onClick handlers that invoke NAPI callbacks then drain queued"
+" toasts and text updates."
+msgstr ""
+
+#: src/platforms/harmonyos.md:142
+msgid "Closures across the NAPI boundary"
+msgstr ""
+
+#: src/platforms/harmonyos.md:144
+msgid ""
+"Each Button/Toggle/etc onClick closure registers via "
+"`perry_arkts_register_callback(idx, closure_handle)` during `main()` "
+"startup. The `closure_handle` is a NaN-boxed pointer to a real Perry "
+"`*ClosureHeader`. A GC root scanner registered in `gc_init` keeps registered"
+" closures alive across collections."
+msgstr ""
+
+#: src/platforms/harmonyos.md:146
+msgid ""
+"When ArkUI fires an onClick, the auto-emitted `.onClick(() => "
+"perryEntry.invokeCallback(0))` calls back into the `.so` via NAPI. The "
+"`invoke_callback` NAPI handler in `crates/perry-runtime/src/ohos_napi.rs` "
+"reads the int32 idx, looks up the slot, and dispatches via "
+"`js_closure_call0`. Multi-arg variants (Toggle/TextField/Slider) use "
+"`invokeCallback1(idx, value)` with `napi_typeof` dispatch to NaN-box the "
+"value (boolean / string / number) before calling `js_closure_call1`."
+msgstr ""
+
+#: src/platforms/harmonyos.md:148
+msgid "The drain queue pattern"
+msgstr ""
+
+#: src/platforms/harmonyos.md:150
+msgid ""
+"`showToast` and `setText` calls inside a closure body push entries onto "
+"thread-local queues:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:151
+msgid "`PENDING_TOASTS: Mutex<VecDeque<String>>`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:152
+msgid "`PENDING_TEXT_UPDATES: Mutex<VecDeque<(String, String)>>`"
+msgstr ""
+
+#: src/platforms/harmonyos.md:154
+msgid ""
+"After every onClick/onChange invocation, the auto-emitted handler in "
+"Index.ets drains both queues:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:172
+msgid ""
+"`applyTextUpdate(id, value)` is a switch over registered Text ids that "
+"assigns to the matching `@State text_<id>: string` field — ArkUI's "
+"reactivity then rerenders the Text widget."
+msgstr ""
+
+#: src/platforms/harmonyos.md:174
+msgid "Why NAPI?"
+msgstr ""
+
+#: src/platforms/harmonyos.md:176
+msgid ""
+"HarmonyOS NEXT uses the OpenHarmony NAPI binding (modeled on Node's NAPI) to"
+" load native `.so` libraries from ArkTS. Perry's `crates/perry-"
+"runtime/src/ohos_napi.rs` registers a module via `napi_module_register` in "
+"an `.init_array` constructor (Rust's equivalent of "
+"`__attribute__((constructor))`), with the modname auto-derived from the "
+"`.so` filename via `dladdr`. The exported NAPI surface is just `run` / "
+"`invokeCallback` / `invokeCallback1` / `drainToast` / `drainTextUpdate` — "
+"every other Perry runtime call happens within the `.so` itself."
+msgstr ""
+
+#: src/platforms/harmonyos.md:178
+msgid "Known limitations"
+msgstr ""
+
+#: src/platforms/harmonyos.md:180
+msgid ""
+"**LazyVStack is currently rendered eagerly** as a plain `Column`. Real lazy "
+"rendering for big lists needs ArkUI's `LazyForEach` + a custom `IDataSource`"
+" impl — tracked as Phase 2 v10."
+msgstr ""
+
+#: src/platforms/harmonyos.md:181
+msgid ""
+"**State binding is one-way** — `setText(\"id\", value)` from a closure "
+"updates the Text on-screen, but a generic `state<T>` reactive container "
+"(`const count = state(0); count.set(...)`) is Phase 2 v6 follow-up work."
+msgstr ""
+
+#: src/platforms/harmonyos.md:182
+msgid ""
+"**Multi-page navigation** (NavStack / Router across multiple `.ets` files) "
+"is Phase 2 v11."
+msgstr ""
+
+#: src/platforms/harmonyos.md:183
+msgid ""
+"**AppGallery production signing** uses a different cert chain than DevEco's "
+"debug certs and isn't yet plumbed into `perry compile`. The current splice "
+"workflow handles debug-emulator deploy."
+msgstr ""
+
+#: src/platforms/harmonyos.md:184
+msgid ""
+"**Real device validation** is pending — every milestone has been verified on"
+" the Pura 90 Pro Max emulator. AppGallery upload + real-hardware install "
+"will follow."
+msgstr ""
+
+#: src/platforms/harmonyos.md:186
+msgid "Validated on emulator"
+msgstr ""
+
+#: src/platforms/harmonyos.md:188
+msgid ""
+"End-to-end on Pura 90 Pro Max with a 5-widget interactive page (counter + "
+"reset, TextField echoing input live as `You typed: <text>`, Toggle flipping "
+"`Notifications: on/off` with toast feedback, Slider tracking `Volume: N` "
+"continuously, reactive Texts everywhere). Each interaction routes:"
+msgstr ""
+
+#: src/platforms/harmonyos.md:196
+msgid ""
+"This is the first time Perry-compiled TypeScript state mutation has "
+"reactively driven a HarmonyOS NEXT screen."
+msgstr ""
+
+#: src/platforms/harmonyos.md:198
+msgid "Version history"
+msgstr ""
+
+#: src/platforms/harmonyos.md:200
+msgid ""
+"**v0.5.401** — Phase 2 v1.5: full widget set rendering "
+"(Text/VStack/HStack/Button/TextField/Toggle/Slider/Spacer/Divider)."
+msgstr ""
+
+#: src/platforms/harmonyos.md:201
+msgid ""
+"**v0.5.417** — Phase 2 v2 + v3 + v2.5: Button onClick callback bridge, "
+"showToast, reactive Text via setText, multi-arg Toggle/TextField/Slider "
+"value forwarding."
+msgstr ""
+
+#: src/platforms/harmonyos.md:202
+msgid ""
+"**v0.5.418** — Phase 2 v4: Image / ScrollView / LazyVStack / Picker / "
+"ProgressView / Section."
+msgstr ""
+
+#: src/platforms/harmonyos.md:203
+msgid ""
+"**v0.5.420 / .421** — Cross-platform showToast + setText on iOS / tvOS / "
+"visionOS / Android."
+msgstr ""
+
+#: src/platforms/harmonyos.md:204
+msgid ""
+"**v0.5.422 / .423** — Cross-platform showToast + setText on Windows / GTK4."
+msgstr ""
+
+#: src/platforms/harmonyos.md:205
+msgid ""
+"**v0.5.429** — Phase 2 v5: inline `style: { ... }` + ForEach via array.map."
+msgstr ""
+
+#: src/platforms/harmonyos.md:207
+msgid ""
+"For the full per-version detail see "
+"[CHANGELOG.md](https://github.com/PerryTS/perry/blob/main/CHANGELOG.md)."
+msgstr ""
+
+#: src/platforms/windows.md:3
+msgid "Perry compiles TypeScript apps for Windows using the Win32 API."
+msgstr ""
+
+#: src/platforms/windows.md:7
+msgid ""
+"Windows 10 or later by default (Windows 7 SP1 / Windows 8 supported via "
+"`--min-windows-version=7|8` — see [Windows 7 Compatibility](./windows-7.md) "
+"for the trade-offs)"
+msgstr ""
+
+#: src/platforms/windows.md:8
+msgid "A linker toolchain — either of these two options:"
+msgstr ""
+
+#: src/platforms/windows.md:10
+msgid "Option A — Lightweight (recommended, ~1.5 GB, no Visual Studio)"
+msgstr ""
+
+#: src/platforms/windows.md:12
+msgid ""
+"Uses LLVM's `clang` + `lld-link` plus an xwin'd copy of the Microsoft CRT + "
+"Windows SDK libraries. No admin rights, no Visual Studio install."
+msgstr ""
+
+#: src/platforms/windows.md:19
+msgid ""
+"`perry setup windows` downloads ~700 MB (unpacks to ~1.5 GB) at "
+"`%LOCALAPPDATA%\\perry\\windows-sdk` after prompting you to accept the "
+"Microsoft redistributable license. Pass `--accept-license` to skip the "
+"prompt in CI. Partial downloads resume safely on re-run."
+msgstr ""
+
+#: src/platforms/windows.md:21
+msgid "Option B — Visual Studio (~8 GB)"
+msgstr ""
+
+#: src/platforms/windows.md:23
+msgid ""
+"If you already have Visual Studio installed, add the C++ workload via the "
+"Visual Studio Installer → _Modify_ → check **Desktop development with C++**."
+" Or install standalone Build Tools:"
+msgstr ""
+
+#: src/platforms/windows.md:30
+msgid ""
+"Both options produce identical binaries — Perry picks Option A when the "
+"xwin'd sysroot is present, Option B otherwise. Run `perry doctor` to see "
+"which is active."
+msgstr ""
+
+#: src/platforms/windows.md:40
+msgid "Perry maps UI widgets to Win32 controls:"
+msgstr ""
+
+#: src/platforms/windows.md:42
+msgid "Win32 Class"
+msgstr ""
+
+#: src/platforms/windows.md:46
+msgid "Edit HWND"
+msgstr ""
+
+#: src/platforms/windows.md:47
+msgid "Edit (ES_PASSWORD)"
+msgstr ""
+
+#: src/platforms/windows.md:48
+msgid "Checkbox"
+msgstr ""
+
+#: src/platforms/windows.md:49
+msgid "Trackbar (TRACKBAR_CLASSW)"
+msgstr ""
+
+#: src/platforms/windows.md:50
+msgid "ComboBox"
+msgstr ""
+
+#: src/platforms/windows.md:51
+msgid "PROGRESS_CLASSW"
+msgstr ""
+
+#: src/platforms/windows.md:54
+msgid "WS_VSCROLL"
+msgstr ""
+
+#: src/platforms/windows.md:55
+msgid "GDI drawing"
+msgstr ""
+
+#: src/platforms/windows.md:56
+msgid "Form/Section"
+msgstr ""
+
+#: src/platforms/windows.md:56
+msgid "GroupBox"
+msgstr ""
+
+#: src/platforms/windows.md:58
+msgid "Windows-Specific APIs"
+msgstr ""
+
+#: src/platforms/windows.md:60
+msgid "**Menu bar**: HMENU / SetMenu"
+msgstr ""
+
+#: src/platforms/windows.md:61
+msgid "**Dark mode**: Windows Registry detection"
+msgstr ""
+
+#: src/platforms/windows.md:62
+msgid "**Preferences**: Windows Registry"
+msgstr ""
+
+#: src/platforms/windows.md:63
+msgid ""
+"**Keychain**: CredWrite/CredRead/CredDelete (Windows Credential Manager)"
+msgstr ""
+
+#: src/platforms/windows.md:64
+msgid "**Notifications**: Toast notifications"
+msgstr ""
+
+#: src/platforms/windows.md:65
+msgid "**File dialogs**: IFileOpenDialog / IFileSaveDialog (COM)"
+msgstr ""
+
+#: src/platforms/windows.md:66
+msgid "**Alerts**: MessageBoxW"
+msgstr ""
+
+#: src/platforms/windows.md:67
+msgid "**Open URL**: ShellExecuteW"
+msgstr ""
+
+#: src/platforms/windows-7.md:3
+msgid ""
+"Perry supports compiling executables that run on Windows 7 SP1 (and Windows "
+"8 / 8.1) — opt-in via the `--min-windows-version` flag. The default target "
+"stays Windows 10+ to preserve full DPI fidelity and modern OS integration; "
+"legacy support is one flag away when you need it."
+msgstr ""
+
+#: src/platforms/windows-7.md:5
+msgid ""
+"This page covers what works, what degrades, what's outright impossible, and "
+"how to validate your build before shipping."
+msgstr ""
+
+#: src/platforms/windows-7.md:7
+msgid "TL;DR"
+msgstr ""
+
+#: src/platforms/windows-7.md:13
+msgid ""
+"Produces a PE marked Win7-compatible. Perry's UI runtime resolves the "
+"Win10-only DPI APIs lazily at startup and falls back through Win8.1 → Vista "
+"primitives, so the binary starts on Win7 SP1. Most UI widgets work. Some "
+"cosmetic effects (rounded corners, dark titlebar) silently no-op. **No "
+"JavaScript-module imports allowed** on Win7 — the V8 runtime is Win10+ "
+"unconditional."
+msgstr ""
+
+#: src/platforms/windows-7.md:15
+msgid "Why this is opt-in"
+msgstr ""
+
+#: src/platforms/windows-7.md:17
+msgid ""
+"Two things make a Win7-compatible PE different from a default Perry build:"
+msgstr ""
+
+#: src/platforms/windows-7.md:19
+msgid ""
+"**The PE subsystem version field.** Default Perry builds let the linker pick"
+" (currently `/SUBSYSTEM:WINDOWS` with no version, which marks the binary as "
+"needing Win8+). Win7 needs `/SUBSYSTEM:WINDOWS,5.1` or "
+"`/SUBSYSTEM:CONSOLE,5.1`. The `,5.1` suffix is the [PE subsystem "
+"ABI](https://learn.microsoft.com/en-us/windows/win32/debug/pe-"
+"format#optional-header-windows-specific-fields-image-only) declaration of "
+"\"I claim to run on Windows NT 5.1 or higher\" — the OS loader reads this "
+"field before deciding whether to load the binary."
+msgstr ""
+
+#: src/platforms/windows-7.md:21
+msgid ""
+"**Win10-only API calls become runtime-resolved.** Perry's UI library calls "
+"`SetProcessDpiAwarenessContext` (Win10 1607) and `GetDpiForSystem` (Win10 "
+"1607) for per-monitor v2 DPI awareness. Hard-importing them via `extern "
+"\"system\"` would emit IAT entries that the OS resolves _before_ `main()` "
+"runs — on Win7, the loader fails the process with \"entry point not found in"
+" user32.dll\" before any Rust code can run. With `--min-windows-version=7` "
+"(and on default builds too — the retrofit is unconditional), Perry resolves "
+"these symbols lazily via `LoadLibraryW + GetProcAddress` and falls back "
+"through:"
+msgstr ""
+
+#: src/platforms/windows-7.md:23
+msgid "Tier"
+msgstr ""
+
+#: src/platforms/windows-7.md:23 src/plugins/appstore-review.md:54
+msgid "API"
+msgstr ""
+
+#: src/platforms/windows-7.md:23
+msgid "Min Windows"
+msgstr ""
+
+#: src/platforms/windows-7.md:25
+msgid "`SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)`"
+msgstr ""
+
+#: src/platforms/windows-7.md:25
+msgid "Windows 10 1607"
+msgstr ""
+
+#: src/platforms/windows-7.md:26
+msgid "`SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)`"
+msgstr ""
+
+#: src/platforms/windows-7.md:26
+msgid "Windows 8.1"
+msgstr ""
+
+#: src/platforms/windows-7.md:27
+msgid "`SetProcessDPIAware()`"
+msgstr ""
+
+#: src/platforms/windows-7.md:27
+msgid "Windows Vista"
+msgstr ""
+
+#: src/platforms/windows-7.md:29
+msgid ""
+"System DPI lookup uses the same lazy pattern: `GetDpiForSystem` (Win10) → "
+"`GetDC + GetDeviceCaps(LOGPIXELSY)` (Win2000+)."
+msgstr ""
+
+#: src/platforms/windows-7.md:31
+msgid ""
+"The `--min-windows-version` flag controls only (1) — the PE marker. The lazy"
+" DPI resolution from (2) is always active because it costs essentially "
+"nothing and makes default builds more robust against being run on stripped-"
+"down Windows installs."
+msgstr ""
+
+#: src/platforms/windows-7.md:33
+msgid "Accepted values"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "`--min-windows-version`"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Subsystem suffix"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Targets"
+msgstr ""
+
+#: src/platforms/windows-7.md:35
+msgid "Default?"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "`10`"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "(none — linker default)"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "Windows 10+"
+msgstr ""
+
+#: src/platforms/windows-7.md:37
+msgid "yes"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "`8`"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "`,6.02`"
+msgstr ""
+
+#: src/platforms/windows-7.md:38
+msgid "Windows 8 / 8.1+"
+msgstr ""
+
+#: src/platforms/windows-7.md:38 src/platforms/windows-7.md:39
+msgid "no"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "`7`"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "`,5.1`"
+msgstr ""
+
+#: src/platforms/windows-7.md:39
+msgid "Windows 7 SP1+"
+msgstr ""
+
+#: src/platforms/windows-7.md:41
+msgid ""
+"Anything else is a hard error at compile time — typos like `--min-windows-"
+"version=11` fail loudly instead of silently behaving like the default."
+msgstr ""
+
+#: src/platforms/windows-7.md:43
+msgid "What works on Win7"
+msgstr ""
+
+#: src/platforms/windows-7.md:45
+msgid ""
+"The same audit that produced this feature found 12 KLOC of Win32 UI code in "
+"`perry-ui-windows` and 5 calls that touch Win10+ APIs. The 5 break down as 2"
+" hard blockers (now lazy-resolved) and 3 cosmetic-effect calls that already "
+"failed soft and silently no-op on Win7. So the bulk of the UI surface — "
+"every standard widget — works on Win7 SP1:"
+msgstr ""
+
+#: src/platforms/windows-7.md:47
+msgid ""
+"All layout containers (`VStack`, `HStack`, `ZStack`, `ScrollView`, `Spacer`,"
+" `Divider`)"
+msgstr ""
+
+#: src/platforms/windows-7.md:48
+msgid ""
+"All input widgets (`Button`, `TextField`, `SecureField`, `Toggle`, `Slider`,"
+" `Picker`, `ProgressView`)"
+msgstr ""
+
+#: src/platforms/windows-7.md:49
+msgid "`Text`, `Canvas`, `Image` (file + symbol)"
+msgstr ""
+
+#: src/platforms/windows-7.md:50
+msgid "`Form` and `LazyVStack`"
+msgstr ""
+
+#: src/platforms/windows-7.md:51
+msgid "File / folder open / save dialogs"
+msgstr ""
+
+#: src/platforms/windows-7.md:52
+msgid "Clipboard access"
+msgstr ""
+
+#: src/platforms/windows-7.md:53
+msgid "Audio (WASAPI is Vista+)"
+msgstr ""
+
+#: src/platforms/windows-7.md:54
+msgid "Keyboard shortcuts, menus, toolbars"
+msgstr ""
+
+#: src/platforms/windows-7.md:55
+msgid "Multi-window"
+msgstr ""
+
+#: src/platforms/windows-7.md:56
+msgid ""
+"The full `perry-runtime` and `perry-stdlib` surface — `fs`, `http`, "
+"`crypto`, `child_process`, `Date`, `Buffer`, etc."
+msgstr ""
+
+#: src/platforms/windows-7.md:58
+msgid "What degrades silently"
+msgstr ""
+
+#: src/platforms/windows-7.md:60
+msgid ""
+"These behaviors target Win10 / Win11 features. On Win7 the API call returns "
+"an error code that Perry already swallows; the binary runs, but the visual "
+"effect is missing:"
+msgstr ""
+
+#: src/platforms/windows-7.md:62
+msgid ""
+"**DPI quality.** Win7 has system-wide DPI only — moving a window between "
+"monitors with different DPI doesn't trigger re-scaling. Per-monitor v2 (font"
+" hinting, dialog scaling) is Win10 1607+."
+msgstr ""
+
+#: src/platforms/windows-7.md:63
+msgid ""
+"**Dark titlebar.** `DWMWA_USE_IMMERSIVE_DARK_MODE` is Win10 1809+. Titlebar "
+"follows the system theme on Win7 (light only on stock Win7)."
+msgstr ""
+
+#: src/platforms/windows-7.md:64
+msgid ""
+"**Rounded window corners.** `DWMWA_WINDOW_CORNER_PREFERENCE` is Win11+. "
+"Frameless windows have square corners on Win7 / Win10."
+msgstr ""
+
+#: src/platforms/windows-7.md:65
+msgid ""
+"**Mica / Acrylic backdrop.** `DWMWA_SYSTEMBACKDROP_TYPE` is Win11+. Backdrop"
+" falls through to the standard window background on Win7 / Win10."
+msgstr ""
+
+#: src/platforms/windows-7.md:67
+msgid "What is impossible"
+msgstr ""
+
+#: src/platforms/windows-7.md:69
+msgid ""
+"**`perry/jsruntime` (V8 / deno_core) is Win10+ unconditional.** Anything in "
+"your project that imports a `.js` module from `node_modules` triggers "
+"`--enable-jsruntime`, which links against deno_core, which embeds V8, which "
+"won't load on Win7. There's no fallback for this — Win7 builds must avoid "
+"JS-module imports entirely. If your project compiles cleanly without "
+"`--enable-jsruntime` (i.e. only TypeScript imports, only Perry-native "
+"packages), you're good."
+msgstr ""
+
+#: src/platforms/windows-7.md:71
+msgid ""
+"**Universal Windows Platform (UWP / WinRT) APIs.** Perry doesn't currently "
+"use these, but if a future feature does (e.g. modern toast notifications), "
+"it'll be Win10+ only. The runtime + stdlib audit was clean as of v0.5.395."
+msgstr ""
+
+#: src/platforms/windows-7.md:73
+msgid "How the lazy DPI resolution works"
+msgstr ""
+
+#: src/platforms/windows-7.md:75
+msgid ""
+"The retrofit lives in `crates/perry-ui-windows/src/dpi_compat.rs`. It "
+"exposes two functions, both safe to call on any Windows version from Vista "
+"onward:"
+msgstr ""
+
+#: src/platforms/windows-7.md:82
+msgid "Internally each function:"
+msgstr ""
+
+#: src/platforms/windows-7.md:84
+msgid ""
+"Calls `LoadLibraryA(\"user32.dll\")` (and `shcore.dll` for the Win8.1 tier) "
+"— both are loaded into every Win32 process by the kernel before `main`, so "
+"the call is a cheap handle lookup."
+msgstr ""
+
+#: src/platforms/windows-7.md:85
+msgid ""
+"Calls `GetProcAddress` to find the desired symbol. Caches the result "
+"(success or failure) in an `AtomicPtr` + `AtomicU8` pair, so the lookup runs"
+" at most once per process."
+msgstr ""
+
+#: src/platforms/windows-7.md:86
+msgid ""
+"Falls through to the next tier on miss. `set_process_dpi_awareness_compat` "
+"ends with `SetProcessDPIAware()` (Vista+, hard-imported because every "
+"supported Windows has it). `get_system_dpi_compat` ends with "
+"`GetDeviceCaps(LOGPIXELSY)` (Win2000+, dead reliable)."
+msgstr ""
+
+#: src/platforms/windows-7.md:88
+msgid ""
+"After the cache is warm — i.e. after `app_create` runs once — every "
+"subsequent DPI query is a single atomic load + indirect call. No measurable "
+"runtime cost vs. a hard-imported call."
+msgstr ""
+
+#: src/platforms/windows-7.md:90
+msgid "Validating a Win7 build"
+msgstr ""
+
+#: src/platforms/windows-7.md:92
+msgid ""
+"Perry's CI and dev hosts don't have Win7 VMs. If you ship to Win7 you need "
+"to validate the binary yourself. Three checks:"
+msgstr ""
+
+#: src/platforms/windows-7.md:94
+msgid "1. PE subsystem version"
+msgstr ""
+
+#: src/platforms/windows-7.md:96
+msgid ""
+"Use `dumpbin /headers app.exe | findstr \"subsystem\"` (MSVC) or `objdump -p"
+" app.exe | grep \"MajorOSVersion\"` (LLVM):"
+msgstr ""
+
+#: src/platforms/windows-7.md:98
+msgid ""
+"```text\n"
+"$ dumpbin /headers app.exe | findstr \"subsystem\"\n"
+"            5.01 subsystem version\n"
+"               2 subsystem (Windows GUI)\n"
+"```"
+msgstr ""
+
+#: src/platforms/windows-7.md:104
+msgid ""
+"The `5.01` confirms the PE is Win7-compatible. A default build shows `6.00` "
+"or higher."
+msgstr ""
+
+#: src/platforms/windows-7.md:106
+msgid "2. Imports"
+msgstr ""
+
+#: src/platforms/windows-7.md:108
+msgid ""
+"Use `dumpbin /imports app.exe | findstr /i \"user32\"` (MSVC) or `objdump -p"
+" app.exe | grep -A20 \"DLL Name: user32\"` (LLVM). Confirm that "
+"`SetProcessDpiAwarenessContext` and `GetDpiForSystem` are **not** in the "
+"user32.dll import list. If they are, the lazy retrofit isn't taking effect —"
+" likely you've added a `use "
+"windows::Win32::UI::HiDpi::SetProcessDpiAwarenessContext;` somewhere that "
+"pulls the symbol back in."
+msgstr ""
+
+#: src/platforms/windows-7.md:110
+msgid "3. Run on a Win7 SP1 VM"
+msgstr ""
+
+#: src/platforms/windows-7.md:112
+msgid ""
+"There's no substitute for actually launching the binary. Microsoft's free "
+"Win7 evaluation VM (no longer hosted directly by Microsoft, mirrored on "
+"archive.org) is the canonical reference image. Worth keeping a snapshot for "
+"regression checks."
+msgstr ""
+
+#: src/platforms/windows-7.md:114
+msgid "Caveats and gotchas"
+msgstr ""
+
+#: src/platforms/windows-7.md:116
+msgid ""
+"**The MSVC linker may warn** about subsystem version `,5.1` being below the "
+"C runtime's stated minimum on newer toolchains. The warning is benign — the "
+"CRT itself runs on Win7, the warning is conservative. Watch for hard errors,"
+" not warnings."
+msgstr ""
+
+#: src/platforms/windows-7.md:117
+msgid ""
+"**xwin sysroot setup is unchanged.** Cross-compiling from macOS / Linux "
+"still uses the `perry setup windows` xwin'd toolchain. Nothing in `--min-"
+"windows-version` changes the SDK requirements."
+msgstr ""
+
+#: src/platforms/windows-7.md:118
+msgid ""
+"**Static-link the CRT** if you want the binary to run on a clean Win7 SP1 "
+"install with no Visual C++ Redistributable. Confirm the binary doesn't "
+"import `vcruntime140.dll` / `msvcp140.dll` via the dumpbin/objdump check "
+"above."
+msgstr ""
+
+#: src/platforms/windows-7.md:119
+msgid ""
+"**`perry/thread`'s SRWLOCK is Vista+, fine.** Perry's threading primitives "
+"use Rust std, which uses SRWLOCK on Windows since Rust 1.42. No "
+"`WaitOnAddress` (Win8+) involvement on the supported Rust versions."
+msgstr ""
+
+#: src/platforms/windows-7.md:121
+msgid "Issue tracking"
+msgstr ""
+
+#: src/platforms/windows-7.md:123
+msgid ""
+"This feature lands as the resolution to "
+"[\\#303](https://github.com/PerryTS/perry/issues/303). If you hit a "
+"Win7-specific failure that isn't covered here, please file a follow-up "
+"referencing this page so we can extend the audit."
+msgstr ""
+
+#: src/platforms/linux.md:3
+msgid "Perry compiles TypeScript apps for Linux using GTK4."
+msgstr ""
+
+#: src/platforms/linux.md:7
+msgid "GTK4 development libraries:"
+msgstr ""
+
+#: src/platforms/linux.md:15
+msgid "# Arch\n"
+msgstr ""
+
+#: src/platforms/linux.md:18
+msgid "Cairo development libraries (for canvas):"
+msgstr ""
+
+#: src/platforms/linux.md:32
+msgid "Perry maps UI widgets to GTK4 widgets:"
+msgstr ""
+
+#: src/platforms/linux.md:34
+msgid "GTK4 Widget"
+msgstr ""
+
+#: src/platforms/linux.md:38
+msgid "GtkEntry"
+msgstr ""
+
+#: src/platforms/linux.md:39
+msgid "GtkPasswordEntry"
+msgstr ""
+
+#: src/platforms/linux.md:40
+msgid "GtkSwitch"
+msgstr ""
+
+#: src/platforms/linux.md:41
+msgid "GtkScale"
+msgstr ""
+
+#: src/platforms/linux.md:42
+msgid "GtkDropDown"
+msgstr ""
+
+#: src/platforms/linux.md:43
+msgid "GtkProgressBar"
+msgstr ""
+
+#: src/platforms/linux.md:44
+msgid "GtkImage"
+msgstr ""
+
+#: src/platforms/linux.md:45
+msgid "GtkBox (vertical)"
+msgstr ""
+
+#: src/platforms/linux.md:46
+msgid "GtkBox (horizontal)"
+msgstr ""
+
+#: src/platforms/linux.md:47
+msgid "GtkOverlay"
+msgstr ""
+
+#: src/platforms/linux.md:48
+msgid "GtkScrolledWindow"
+msgstr ""
+
+#: src/platforms/linux.md:49
+msgid "Cairo drawing"
+msgstr ""
+
+#: src/platforms/linux.md:50
+msgid "GtkStack"
+msgstr ""
+
+#: src/platforms/linux.md:52
+msgid "Linux-Specific APIs"
+msgstr ""
+
+#: src/platforms/linux.md:54
+msgid "**Menu bar**: GMenu / set_menubar"
+msgstr ""
+
+#: src/platforms/linux.md:55
+msgid "**Toolbar**: GtkHeaderBar"
+msgstr ""
+
+#: src/platforms/linux.md:56
+msgid "**Dark mode**: GTK settings detection"
+msgstr ""
+
+#: src/platforms/linux.md:57
+msgid "**Preferences**: GSettings or file-based"
+msgstr ""
+
+#: src/platforms/linux.md:58
+msgid "**Keychain**: libsecret"
+msgstr ""
+
+#: src/platforms/linux.md:59
+msgid "**Notifications**: GNotification"
+msgstr ""
+
+#: src/platforms/linux.md:60
+msgid "**File dialogs**: GtkFileChooserDialog"
+msgstr ""
+
+#: src/platforms/linux.md:61
+msgid "**Alerts**: GtkMessageDialog"
+msgstr ""
+
+#: src/platforms/linux.md:65
+msgid ""
+"GTK4 styling uses CSS under the hood. Perry's styling methods (colors, "
+"fonts, corner radius) are translated to CSS properties applied via "
+"`CssProvider`."
+msgstr ""
+
+#: src/platforms/linux.md:67
+msgid "Testing with Geisterhand"
+msgstr ""
+
+#: src/platforms/linux.md:69
+msgid ""
+"Perry's built-in UI fuzzer works on Linux/GTK4. Screenshots use "
+"`WidgetPaintable` + `GskRenderer` for pixel-accurate capture."
+msgstr ""
+
+#: src/platforms/linux.md:73
+msgid "# In another terminal:\n"
+msgstr ""
+
+#: src/platforms/linux.md:79
+msgid "See [Geisterhand](../testing/geisterhand.md) for full API reference."
+msgstr ""
+
+#: src/platforms/web.md:3
+msgid ""
+"`--target web` and `--target wasm` are aliases for the same backend. Both "
+"produce a self-contained HTML file with embedded WebAssembly and a "
+"JavaScript bridge for DOM widgets."
+msgstr ""
+
+#: src/platforms/web.md:6
+msgid "# same output as --target wasm\n"
+msgstr ""
+
+#: src/platforms/web.md:10
+msgid ""
+"See **[WebAssembly / Web](wasm.md)** for the full documentation: how it "
+"works, supported features, UI mapping, FFI, threading, limitations, and "
+"examples."
+msgstr ""
+
+#: src/platforms/web.md:12
+msgid "Why one target instead of two?"
+msgstr ""
+
+#: src/platforms/web.md:14
+msgid "Perry used to have two browser backends:"
+msgstr ""
+
+#: src/platforms/web.md:16
+msgid "`--target web` (`perry-codegen-js`) — transpiled HIR to JavaScript"
+msgstr ""
+
+#: src/platforms/web.md:17
+msgid "`--target wasm` (`perry-codegen-wasm`) — compiled HIR to WebAssembly"
+msgstr ""
+
+#: src/platforms/web.md:19
+msgid ""
+"These were consolidated into the WASM target so browser apps get near-native"
+" performance, FFI imports, and Web Worker threading without needing a "
+"separate JS-emit pipeline. The DOM widget runtime that the old `--target "
+"web` provided is now embedded in `wasm_runtime.js`. Both flags route through"
+" `perry-codegen-wasm` and produce identical HTML output."
+msgstr ""
+
+#: src/platforms/web.md:23
+msgid "[WebAssembly / Web](wasm.md) — full target documentation"
+msgstr ""
+
+#: src/platforms/web.md:24
+msgid "[Platform Overview](overview.md) — all platforms"
+msgstr ""
+
+#: src/platforms/wasm.md:1
+msgid "WebAssembly / Web"
+msgstr ""
+
+#: src/platforms/wasm.md:3
+msgid ""
+"Perry compiles TypeScript apps to **WebAssembly** for the browser using "
+"`--target wasm` or its alias `--target web`. Both flags route through the "
+"same backend (`perry-codegen-wasm`) and produce the same output: a self-"
+"contained HTML file with embedded WASM bytecode and a thin JavaScript bridge"
+" for DOM widgets and host APIs."
+msgstr ""
+
+#: src/platforms/wasm.md:5
+msgid ""
+"There used to be a separate JavaScript-emitting `--target web` (`perry-"
+"codegen-js`); it was consolidated into the WASM target so browser apps get "
+"near-native performance, FFI imports, and Web Worker threading \"for free\"."
+msgstr ""
+
+#: src/platforms/wasm.md:10
+msgid "# Self-contained HTML (default)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:13
+msgid "# Same thing\n"
+msgstr ""
+
+#: src/platforms/wasm.md:16
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:21
+msgid ""
+"The default output is a single `.html` file containing a base64-embedded "
+"WASM binary, the `wasm_runtime.js` bridge, and a `bootPerryWasm()` call that"
+" instantiates the module. Open it directly in any modern browser — no build "
+"step, no server required for simple apps."
+msgstr ""
+
+#: src/platforms/wasm.md:23
+msgid ""
+"**Note**: Apps that use `fetch()` or other web platform APIs that depend on "
+"a real origin must be served over HTTP (file:// URLs run into CORS / "
+"\"Failed to fetch\" errors). Any local static server works:"
+msgstr ""
+
+#: src/platforms/wasm.md:31
+msgid ""
+"The `perry-codegen-wasm` crate compiles HIR directly to WASM bytecode using "
+"`wasm-encoder`. The output WASM:"
+msgstr ""
+
+#: src/platforms/wasm.md:33
+msgid ""
+"Imports ~280 host functions under the `rt` namespace (string ops, math, "
+"console, JSON, classes, closures, promises, fetch, etc.)"
+msgstr ""
+
+#: src/platforms/wasm.md:34
+msgid "Imports user-declared FFI functions under the `ffi` namespace"
+msgstr ""
+
+#: src/platforms/wasm.md:35
+msgid ""
+"Exports `_start`, `memory`, `__indirect_function_table`, and every user "
+"function as `__wasm_func_<idx>` (so async function bodies compiled to JS can"
+" call back into WASM)"
+msgstr ""
+
+#: src/platforms/wasm.md:37
+msgid ""
+"The NaN-boxing scheme matches the native `perry-runtime` — f64 values with "
+"STRING_TAG/POINTER_TAG/INT32_TAG — so the same value representation is used "
+"across native and WASM targets. The JS bridge wraps every host import with "
+"bit-level reinterpretation so f64 NaN-boxed values pass through the BigInt-"
+"based JS↔WASM i64 boundary intact (BigInt(NaN) would otherwise throw)."
+msgstr ""
+
+#: src/platforms/wasm.md:41
+msgid ""
+"**Full TypeScript language**: classes (with constructors, methods, "
+"getters/setters, inheritance, fields), async/await, closures (with "
+"captures), generators, destructuring, template literals, generics, enums, "
+"try/catch/finally"
+msgstr ""
+
+#: src/platforms/wasm.md:42
+msgid ""
+"**Module system**: cross-module imports, top-level `const`/`let` (promoted "
+"to WASM globals), circular imports"
+msgstr ""
+
+#: src/platforms/wasm.md:43
+msgid ""
+"**Standard library**: String/Array/Object methods, Map/Set, JSON, Date, "
+"RegExp, Math, Error, URL/URLSearchParams, Buffer, Promise (with "
+"`.then`/`.catch`/`.allSettled`/`.race`/`.any`/`.all`)"
+msgstr ""
+
+#: src/platforms/wasm.md:44
+msgid ""
+"**Async**: `async`/`await` (compiled to JS Promises), "
+"`setTimeout`/`setInterval`, `fetch()` with full request options (method, "
+"headers, body)"
+msgstr ""
+
+#: src/platforms/wasm.md:45
+msgid ""
+"**Threading**: `perry/thread` `parallelMap`/`parallelFilter`/`spawn` via Web"
+" Worker pool with one WASM instance per worker (see "
+"[Threading](../threading/overview.md))"
+msgstr ""
+
+#: src/platforms/wasm.md:46
+msgid ""
+"**DOM-based UI**: every widget in `perry/ui` (`VStack`, `HStack`, `ZStack`, "
+"`Text`, `Button`, `TextField`, `Toggle`, `Slider`, `ScrollView`, `Picker`, "
+"`Image`, `Canvas`, `Form`, `Section`, `NavigationStack`, `Table`, "
+"`LazyVStack`, `TextArea`, etc.) maps to a DOM element with flexbox layout. "
+"State bindings (`bindText`/`bindSlider`/`bindToggle`/`bindForEach`/...) work"
+" via reactive subscribers."
+msgstr ""
+
+#: src/platforms/wasm.md:47
+msgid ""
+"**System APIs**: `localStorage`\\-backed preferences/keychain, dark mode "
+"detection (`prefers-color-scheme`), Web Notifications, clipboard, file "
+"open/save dialogs, File System Access API, Web Audio capture"
+msgstr ""
+
+#: src/platforms/wasm.md:48
+msgid ""
+"**FFI**: `declare function` declarations become WASM imports under the `ffi`"
+" namespace"
+msgstr ""
+
+#: src/platforms/wasm.md:49
+msgid ""
+"**Compile-time i18n**: `perry/i18n` `t()` calls work the same as native "
+"targets"
+msgstr ""
+
+#: src/platforms/wasm.md:51
+msgid "UI Mapping"
+msgstr ""
+
+#: src/platforms/wasm.md:53
+msgid "Perry widgets map to HTML elements:"
+msgstr ""
+
+#: src/platforms/wasm.md:55
+msgid "HTML Element"
+msgstr ""
+
+#: src/platforms/wasm.md:57 src/widgets/wearos.md:24
+msgid "`Text`"
+msgstr ""
+
+#: src/platforms/wasm.md:58
+msgid "`Button`"
+msgstr ""
+
+#: src/platforms/wasm.md:59
+msgid "`TextField`"
+msgstr ""
+
+#: src/platforms/wasm.md:59
+msgid "`<input type=\"text\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:60
+msgid "`SecureField`"
+msgstr ""
+
+#: src/platforms/wasm.md:60
+msgid "`<input type=\"password\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:61
+msgid "`Toggle`"
+msgstr ""
+
+#: src/platforms/wasm.md:61
+msgid "`<input type=\"checkbox\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:62
+msgid "`Slider`"
+msgstr ""
+
+#: src/platforms/wasm.md:62
+msgid "`<input type=\"range\">`"
+msgstr ""
+
+#: src/platforms/wasm.md:63
+msgid "`Picker`"
+msgstr ""
+
+#: src/platforms/wasm.md:63
+msgid "`<select>`"
+msgstr ""
+
+#: src/platforms/wasm.md:64
+msgid "`ProgressView`"
+msgstr ""
+
+#: src/platforms/wasm.md:64
+msgid "`<progress>`"
+msgstr ""
+
+#: src/platforms/wasm.md:65
+msgid "`Image` / `ImageFile`"
+msgstr ""
+
+#: src/platforms/wasm.md:65
+msgid "`<img>`"
+msgstr ""
+
+#: src/platforms/wasm.md:66 src/widgets/wearos.md:25
+msgid "`VStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:66
+msgid "`<div>` (flexbox column)"
+msgstr ""
+
+#: src/platforms/wasm.md:67 src/widgets/wearos.md:26
+msgid "`HStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:67
+msgid "`<div>` (flexbox row)"
+msgstr ""
+
+#: src/platforms/wasm.md:68
+msgid "`ZStack`"
+msgstr ""
+
+#: src/platforms/wasm.md:68
+msgid "`<div>` (position: relative + absolute children)"
+msgstr ""
+
+#: src/platforms/wasm.md:69
+msgid "`ScrollView`"
+msgstr ""
+
+#: src/platforms/wasm.md:69
+msgid "`<div>` (overflow: auto)"
+msgstr ""
+
+#: src/platforms/wasm.md:70
+msgid "`Canvas`"
+msgstr ""
+
+#: src/platforms/wasm.md:70
+msgid "`<canvas>` (2D context)"
+msgstr ""
+
+#: src/platforms/wasm.md:71
+msgid "`Table`"
+msgstr ""
+
+#: src/platforms/wasm.md:71
+msgid "`<table>`"
+msgstr ""
+
+#: src/platforms/wasm.md:72 src/widgets/wearos.md:28
+msgid "`Divider`"
+msgstr ""
+
+#: src/platforms/wasm.md:72
+msgid "`<hr>`"
+msgstr ""
+
+#: src/platforms/wasm.md:73 src/widgets/wearos.md:27
+msgid "`Spacer`"
+msgstr ""
+
+#: src/platforms/wasm.md:73
+msgid "`<div>` (flex: 1)"
+msgstr ""
+
+#: src/platforms/wasm.md:75
+msgid "FFI Support"
+msgstr ""
+
+#: src/platforms/wasm.md:77
+msgid ""
+"The WASM target supports external FFI functions declared with `declare "
+"function`. They become WASM imports under the `\"ffi\"` namespace:"
+msgstr ""
+
+#: src/platforms/wasm.md:85
+msgid "Provide them when instantiating:"
+msgstr ""
+
+#: src/platforms/wasm.md:88
+msgid "// Via __ffiImports global (set before boot)\n"
+msgstr ""
+
+#: src/platforms/wasm.md:90
+msgid "// Or via bootPerryWasm second argument\n"
+msgstr ""
+
+#: src/platforms/wasm.md:95
+msgid ""
+"**Auto-stub for missing imports.** The `ffi` namespace is wrapped in a "
+"`Proxy` so any FFI function the host doesn't provide is auto-stubbed with a "
+"no-op that returns `TAG_UNDEFINED`. This means apps that use native "
+"libraries (e.g. Hone Editor's 56 `hone_editor_*` functions) can still "
+"instantiate and run in the browser even without the native bindings — the "
+"relevant features are simply no-ops."
+msgstr ""
+
+#: src/platforms/wasm.md:97
+msgid "Module-Level Constants"
+msgstr ""
+
+#: src/platforms/wasm.md:99
+msgid ""
+"Top-level `const`/`let` declarations are promoted to dedicated WASM globals "
+"so functions in the same module can read them, and so two modules' identical"
+" `LocalId`s don't collide:"
+msgstr ""
+
+#: src/platforms/wasm.md:101
+msgid ""
+"```typescript\n"
+"// telemetry.ts\n"
+"const CHIRP_URL = 'https://api.chirp247.com/api/v1/event'\n"
+"const API_KEY   = 'my-key'\n"
+"\n"
+"export function trackEvent(event: string): void {\n"
+"    fetch(CHIRP_URL, {\n"
+"        method: 'POST',\n"
+"        headers: { 'Content-Type': 'application/json', 'X-Chirp-Key': API_KEY },\n"
+"        body: JSON.stringify({ event }),\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/platforms/wasm.md:115
+msgid ""
+"Both `CHIRP_URL` and `API_KEY` become WASM globals indexed by `(module_idx, "
+"LocalId)`. Reading them from `trackEvent` emits a `global.get` instead of "
+"trying to look up a function-local that doesn't exist."
+msgstr ""
+
+#: src/platforms/wasm.md:117
+msgid "JavaScript Runtime Bridge"
+msgstr ""
+
+#: src/platforms/wasm.md:119
+msgid ""
+"The bridge (`wasm_runtime.js`) is embedded in the HTML and provides ~280 "
+"imports across:"
+msgstr ""
+
+#: src/platforms/wasm.md:121
+msgid ""
+"**NaN-boxing helpers**: `f64ToU64` / `u64ToF64` / `nanboxString` / "
+"`nanboxPointer` / `toJsValue` / `fromJsValue`"
+msgstr ""
+
+#: src/platforms/wasm.md:122
+msgid "**String table**: dynamic JS string array indexed by string ID"
+msgstr ""
+
+#: src/platforms/wasm.md:123
+msgid ""
+"**Handle store**: maps integer handle IDs to JS objects, arrays, closures, "
+"promises, DOM elements"
+msgstr ""
+
+#: src/platforms/wasm.md:124
+msgid ""
+"**Core ops**: console, math, JSON, JSON.parse/stringify, Date, RegExp, URL, "
+"Map, Set, Buffer, fetch"
+msgstr ""
+
+#: src/platforms/wasm.md:125
+msgid ""
+"**Closure dispatch**: indirect function table + capture array, with "
+"`closure_call_0/1/2/3/spread`"
+msgstr ""
+
+#: src/platforms/wasm.md:126
+msgid ""
+"**Class dispatch**: `class_new`, `class_call_method`, `class_get_field`, "
+"`class_set_field`, parent table for inheritance"
+msgstr ""
+
+#: src/platforms/wasm.md:127
+msgid ""
+"**DOM widgets**: 168+ `perry_ui_*` functions covering every widget in "
+"`perry/ui`"
+msgstr ""
+
+#: src/platforms/wasm.md:128
+msgid ""
+"**Async functions**: compiled to JS function bodies and merged into the "
+"import object as `__async_<name>`"
+msgstr ""
+
+#: src/platforms/wasm.md:130
+msgid ""
+"All host imports are wrapped via `wrapImportsForI64()` so they automatically"
+" reinterpret BigInt args (from WASM i64 params) into f64 internally and "
+"reinterpret Number returns back into BigInt. Without this wrapping, every "
+"NaN-valued f64 return would crash with \"Cannot convert NaN to a BigInt\"."
+msgstr ""
+
+#: src/platforms/wasm.md:132
+msgid "Web Worker Threading"
+msgstr ""
+
+#: src/platforms/wasm.md:134
+msgid "`perry/thread` works in the browser via a Web Worker pool:"
+msgstr ""
+
+#: src/platforms/wasm.md:144
+msgid ""
+"Each worker instantiates its own WASM module with the same bytecode and "
+"bridge. Values cross between the main thread and workers via structured-"
+"clone serialization. See [Threading](../threading/overview.md)."
+msgstr ""
+
+#: src/platforms/wasm.md:148
+msgid ""
+"**No file system access** beyond the File System Access API "
+"(`window.showDirectoryPicker()`)"
+msgstr ""
+
+#: src/platforms/wasm.md:149
+msgid "**No raw TCP/UDP sockets** — only `fetch()` and `WebSocket`"
+msgstr ""
+
+#: src/platforms/wasm.md:150
+msgid "**No subprocess spawning** — `child_process.exec` etc. are no-ops"
+msgstr ""
+
+#: src/platforms/wasm.md:151
+msgid ""
+"**No native databases** — SQLite, Postgres, MySQL drivers don't compile to "
+"web"
+msgstr ""
+
+#: src/platforms/wasm.md:152
+msgid ""
+"**CORS** applies to all `fetch()` calls — third-party APIs must allow your "
+"origin"
+msgstr ""
+
+#: src/platforms/wasm.md:153
+msgid ""
+"**localStorage**, not real keychain — fine for preferences, not for secrets"
+msgstr ""
+
+#: src/platforms/wasm.md:154
+msgid ""
+"Source-mapped stack traces are JS-only; WASM stack frames show `wasm-"
+"function[N]`"
+msgstr ""
+
+#: src/platforms/wasm.md:156
+msgid "Minification"
+msgstr ""
+
+#: src/platforms/wasm.md:158
+msgid ""
+"Use `--minify` to minify the embedded JS runtime bridge in the HTML output. "
+"The Rust-native JS minifier strips comments, collapses whitespace, and "
+"mangles internal identifiers, compressing the runtime from ~3,400 lines to "
+"~180."
+msgstr ""
+
+#: src/platforms/wasm.md:164
+msgid "Example: Counter App"
+msgstr ""
+
+#: src/platforms/wasm.md:187
+msgid "Example: Real-World App (Mango MongoDB GUI)"
+msgstr ""
+
+#: src/platforms/wasm.md:189
+msgid ""
+"The [Mango](https://github.com/PerryTS/mango) MongoDB GUI — 50 modules, 998 "
+"functions, classes, async functions, fetch with custom headers, the Hone "
+"code editor — compiles to a single 4 MB HTML file via `--target web` and "
+"renders its full UI (welcome screen, query view, edit view) in the browser. "
+"SQLite-backed connection storage gracefully degrades to an in-memory "
+"transient store on web; the rest of the app works the same as the native "
+"version."
+msgstr ""
+
+#: src/platforms/wasm.md:195
+msgid "[Threading](../threading/overview.md) — Web Worker threading"
+msgstr ""
+
+#: src/stdlib/overview.md:1
+msgid "Standard Library Overview"
+msgstr ""
+
+#: src/stdlib/overview.md:3
+msgid ""
+"Perry natively implements many popular npm packages and Node.js APIs. When "
+"you import a supported package, Perry compiles it to native code — no "
+"JavaScript runtime involved."
+msgstr ""
+
+#: src/stdlib/overview.md:7
+msgid ""
+"```typescript\n"
+"import fastify from \"fastify\"\n"
+"import mysql from \"mysql2/promise\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/overview.md:12
+msgid ""
+"Perry recognizes these imports at compile time and routes them to native "
+"Rust implementations in the `perry-stdlib` crate. The API surface matches "
+"the original npm package, so existing code often works unchanged."
+msgstr ""
+
+#: src/stdlib/overview.md:14
+msgid "Supported Packages"
+msgstr ""
+
+#: src/stdlib/overview.md:16
+msgid "Networking & HTTP"
+msgstr ""
+
+#: src/stdlib/overview.md:17
+msgid "**fastify** — HTTP server framework"
+msgstr ""
+
+#: src/stdlib/overview.md:18
+msgid "**axios** — HTTP client"
+msgstr ""
+
+#: src/stdlib/overview.md:19
+msgid "**node-fetch** / **fetch** — HTTP fetch API"
+msgstr ""
+
+#: src/stdlib/overview.md:20
+msgid "**ws** — WebSocket client/server"
+msgstr ""
+
+#: src/stdlib/overview.md:23
+msgid "**mysql2** — MySQL client"
+msgstr ""
+
+#: src/stdlib/overview.md:24
+msgid "**pg** — PostgreSQL client"
+msgstr ""
+
+#: src/stdlib/overview.md:25
+msgid "**better-sqlite3** — SQLite"
+msgstr ""
+
+#: src/stdlib/overview.md:26
+msgid "**mongodb** — MongoDB client"
+msgstr ""
+
+#: src/stdlib/overview.md:27
+msgid "**ioredis** / **redis** — Redis client"
+msgstr ""
+
+#: src/stdlib/overview.md:30
+msgid "**bcrypt** — Password hashing"
+msgstr ""
+
+#: src/stdlib/overview.md:31
+msgid "**argon2** — Password hashing (Argon2)"
+msgstr ""
+
+#: src/stdlib/overview.md:32
+msgid "**jsonwebtoken** — JWT signing/verification"
+msgstr ""
+
+#: src/stdlib/overview.md:33
+msgid "**crypto** — Node.js crypto module"
+msgstr ""
+
+#: src/stdlib/overview.md:34
+msgid "**ethers** — Ethereum library"
+msgstr ""
+
+#: src/stdlib/overview.md:37
+msgid "**lodash** — Utility functions"
+msgstr ""
+
+#: src/stdlib/overview.md:38
+msgid "**dayjs** / **moment** — Date manipulation"
+msgstr ""
+
+#: src/stdlib/overview.md:39
+msgid "**uuid** — UUID generation"
+msgstr ""
+
+#: src/stdlib/overview.md:40
+msgid "**nanoid** — ID generation"
+msgstr ""
+
+#: src/stdlib/overview.md:41
+msgid "**slugify** — String slugification"
+msgstr ""
+
+#: src/stdlib/overview.md:42
+msgid "**validator** — String validation"
+msgstr ""
+
+#: src/stdlib/overview.md:44
+msgid "CLI & Data"
+msgstr ""
+
+#: src/stdlib/overview.md:45
+msgid "**commander** — CLI argument parsing"
+msgstr ""
+
+#: src/stdlib/overview.md:46
+msgid "**decimal.js** — Arbitrary precision decimals"
+msgstr ""
+
+#: src/stdlib/overview.md:47
+msgid "**bignumber.js** — Big number math"
+msgstr ""
+
+#: src/stdlib/overview.md:48
+msgid "**lru-cache** — LRU caching"
+msgstr ""
+
+#: src/stdlib/overview.md:51
+msgid "**sharp** — Image processing"
+msgstr ""
+
+#: src/stdlib/overview.md:52
+msgid "**cheerio** — HTML parsing"
+msgstr ""
+
+#: src/stdlib/overview.md:53
+msgid "**nodemailer** — Email sending"
+msgstr ""
+
+#: src/stdlib/overview.md:54
+msgid "**zlib** — Compression"
+msgstr ""
+
+#: src/stdlib/overview.md:55
+msgid "**cron** — Job scheduling"
+msgstr ""
+
+#: src/stdlib/overview.md:56
+msgid "**worker_threads** — Background workers"
+msgstr ""
+
+#: src/stdlib/overview.md:57
+msgid "**exponential-backoff** — Retry logic"
+msgstr ""
+
+#: src/stdlib/overview.md:58
+msgid "**async_hooks** — AsyncLocalStorage"
+msgstr ""
+
+#: src/stdlib/overview.md:60
+msgid "Node.js Built-ins"
+msgstr ""
+
+#: src/stdlib/overview.md:61
+msgid "**fs** — File system"
+msgstr ""
+
+#: src/stdlib/overview.md:62
+msgid "**path** — Path manipulation"
+msgstr ""
+
+#: src/stdlib/overview.md:63
+msgid "**child_process** — Process spawning"
+msgstr ""
+
+#: src/stdlib/overview.md:64
+msgid "**crypto** — Cryptographic functions"
+msgstr ""
+
+#: src/stdlib/overview.md:68
+msgid "Perry automatically detects which stdlib features your code uses:"
+msgstr ""
+
+#: src/stdlib/overview.md:70 src/system/preferences.md:8
+#: src/system/keychain.md:8
+msgid "Usage"
+msgstr ""
+
+#: src/stdlib/overview.md:72
+msgid "No stdlib imports"
+msgstr ""
+
+#: src/stdlib/overview.md:73
+msgid "fs + path only"
+msgstr ""
+
+#: src/stdlib/overview.md:74
+msgid "Full stdlib"
+msgstr ""
+
+#: src/stdlib/overview.md:76
+msgid "The compiler links only the required runtime components."
+msgstr ""
+
+#: src/stdlib/overview.md:78
+msgid "compilePackages"
+msgstr ""
+
+#: src/stdlib/overview.md:80
+msgid ""
+"For npm packages not natively supported, you can compile pure "
+"TypeScript/JavaScript packages natively:"
+msgstr ""
+
+#: src/stdlib/overview.md:90
+msgid ""
+"See [Project Configuration](../getting-started/project-config.md) for "
+"details."
+msgstr ""
+
+#: src/stdlib/overview.md:92
+msgid "JavaScript Runtime Fallback"
+msgstr ""
+
+#: src/stdlib/overview.md:94
+msgid ""
+"For packages that can't be compiled natively (native addons, dynamic code, "
+"etc.), Perry includes a QuickJS-based JavaScript runtime as a fallback. The "
+"exact API surface is internal-only today; the import below is illustrative:"
+msgstr ""
+
+#: src/stdlib/overview.md:96
+msgid ""
+"```text\n"
+"import { jsEval } from \"perry/jsruntime\"; // illustrative — not yet a public export\n"
+"```"
+msgstr ""
+
+#: src/stdlib/overview.md:102
+msgid "[File System](fs.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:103 src/stdlib/fs.md:90
+msgid "[HTTP & Networking](http.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:104 src/stdlib/http.md:95
+msgid "[Databases](database.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:105 src/stdlib/database.md:109
+msgid "[Cryptography](crypto.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:106 src/stdlib/crypto.md:89
+msgid "[Utilities](utilities.md)"
+msgstr ""
+
+#: src/stdlib/overview.md:107 src/stdlib/utilities.md:106
+msgid "[Other Modules](other.md)"
+msgstr ""
+
+#: src/stdlib/fs.md:3
+msgid ""
+"Perry implements Node.js file system APIs for reading, writing, and managing"
+" files."
+msgstr ""
+
+#: src/stdlib/fs.md:5
+msgid "Reading Files"
+msgstr ""
+
+#: src/stdlib/fs.md:7
+msgid ""
+"```typescript\n"
+"const configPath = join(scratch, \"config.json\")\n"
+"const content = readFileSync(configPath, \"utf-8\")\n"
+"console.log(content)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:13
+msgid "Binary File Reading"
+msgstr ""
+
+#: src/stdlib/fs.md:15
+msgid ""
+"```typescript\n"
+"const imagePath = join(scratch, \"image.png\")\n"
+"const buffer = readFileBuffer(imagePath)\n"
+"console.log(`Read ${buffer.length} bytes`)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:21
+msgid ""
+"`readFileBuffer` reads files as binary data (uses `fs::read()` internally, "
+"not `read_to_string()`)."
+msgstr ""
+
+#: src/stdlib/fs.md:23
+msgid "Writing Files"
+msgstr ""
+
+#: src/stdlib/fs.md:25
+msgid ""
+"```typescript\n"
+"const outputPath = join(scratch, \"output.txt\")\n"
+"const dataPath = join(scratch, \"data.json\")\n"
+"writeFileSync(outputPath, \"Hello, World!\")\n"
+"writeFileSync(dataPath, JSON.stringify({ key: \"value\" }, null, 2))\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:32
+msgid "File Information"
+msgstr ""
+
+#: src/stdlib/fs.md:41
+msgid "Directory Operations"
+msgstr ""
+
+#: src/stdlib/fs.md:43
+msgid ""
+"```typescript\n"
+"// Create directory\n"
+"const outDir = join(scratch, \"output\")\n"
+"if (!existsSync(outDir)) mkdirSync(outDir)\n"
+"\n"
+"// Read directory contents\n"
+"const files = readdirSync(scratch)\n"
+"for (const file of files) {\n"
+"    console.log(file)\n"
+"}\n"
+"\n"
+"// Remove an empty directory\n"
+"rmdirSync(outDir)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:58
+msgid ""
+"For recursive removal Perry exposes `rmRecursive` (a thin wrapper around "
+"`std::fs::remove_dir_all`). Wired via "
+"[\\#193](https://github.com/PerryTS/perry/issues/193) through "
+"`js_fs_rm_recursive` in the LLVM backend."
+msgstr ""
+
+#: src/stdlib/fs.md:63
+msgid ""
+"```typescript,no-test\n"
+"import { rmRecursive } from \"fs\";\n"
+"rmRecursive(\"output\"); // Recursive remove; returns 1 on success, 0 on failure.\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:68
+msgid "Path Utilities"
+msgstr ""
+
+#: src/stdlib/fs.md:70
+msgid ""
+"```typescript\n"
+"const dir = dirname(configPath)\n"
+"const cfgPath = join(dir, \"config.json\")\n"
+"const name = basename(cfgPath)        // \"config.json\"\n"
+"const abs = resolve(\"relative/path\")  // Absolute path\n"
+"console.log(`${name} ${abs.length > 0}`)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:78
+msgid ""
+"For `import.meta.url` → filesystem path conversion, use `fileURLToPath` from"
+" the `url` module:"
+msgstr ""
+
+#: src/stdlib/fs.md:81
+msgid ""
+"```text\n"
+"import { fileURLToPath } from \"url\";\n"
+"import { dirname } from \"path\";\n"
+"\n"
+"const dir = dirname(fileURLToPath(import.meta.url));\n"
+"```"
+msgstr ""
+
+#: src/stdlib/fs.md:91 src/stdlib/http.md:96 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:107 src/stdlib/other.md:186
+msgid "[Overview](overview.md) — All stdlib modules"
+msgstr ""
+
+#: src/stdlib/http.md:3
+msgid ""
+"Perry natively implements HTTP servers, clients, and WebSocket support."
+msgstr ""
+
+#: src/stdlib/http.md:5
+msgid "Fastify Server"
+msgstr ""
+
+#: src/stdlib/http.md:7
+msgid ""
+"```typescript\n"
+"import fastify from \"fastify\"\n"
+"\n"
+"const app = fastify()\n"
+"\n"
+"app.get(\"/\", async (request: any, reply: any) => {\n"
+"    return { hello: \"world\" }\n"
+"})\n"
+"\n"
+"app.get(\"/users/:id\", async (request: any, reply: any) => {\n"
+"    const id = request.params.id\n"
+"    return { id, name: \"User \" + id }\n"
+"})\n"
+"\n"
+"app.post(\"/data\", async (request: any, reply: any) => {\n"
+"    const body = request.body\n"
+"    reply.code(201)\n"
+"    return { received: body }\n"
+"})\n"
+"\n"
+"app.listen({ port: 3000 }, () => {\n"
+"    console.log(\"Server running on port 3000\")\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:32
+msgid ""
+"Perry's Fastify implementation is API-compatible with the npm package. "
+"Routes, request/reply objects, params, query strings, and JSON body parsing "
+"all work."
+msgstr ""
+
+#: src/stdlib/http.md:34
+msgid "Fetch API"
+msgstr ""
+
+#: src/stdlib/http.md:36
+msgid ""
+"```typescript\n"
+"async function fetchExamples(): Promise<void> {\n"
+"    // GET request\n"
+"    const response = await fetch(\"https://jsonplaceholder.typicode.com/posts/1\")\n"
+"    const data = await response.json()\n"
+"\n"
+"    // POST request\n"
+"    const result = await fetch(\"https://jsonplaceholder.typicode.com/posts\", {\n"
+"        method: \"POST\",\n"
+"        headers: { \"Content-Type\": \"application/json\" },\n"
+"        body: JSON.stringify({ title: \"hello\", body: \"world\", userId: 1 }),\n"
+"    })\n"
+"\n"
+"    console.log(`fetch ok: ${data !== null} status=${result.status}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:53
+msgid "Axios"
+msgstr ""
+
+#: src/stdlib/http.md:55
+msgid ""
+"```typescript\n"
+"import axios from \"axios\"\n"
+"\n"
+"async function axiosExamples(): Promise<void> {\n"
+"    const getResp = await axios.get(\"https://jsonplaceholder.typicode.com/users/1\")\n"
+"    const data = getResp.data\n"
+"\n"
+"    const response = await axios.post(\"https://jsonplaceholder.typicode.com/users\", {\n"
+"        name: \"Perry\",\n"
+"        email: \"perry@example.com\",\n"
+"    })\n"
+"\n"
+"    console.log(`axios ok: ${data !== null} status=${response.status}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/http.md:71
+msgid "WebSocket"
+msgstr ""
+
+#: src/stdlib/http.md:73
+msgid ""
+"```typescript\n"
+"import { WebSocket } from \"ws\"\n"
+"\n"
+"function wsExample(): void {\n"
+"    const ws = new WebSocket(\"ws://localhost:8080\")\n"
+"\n"
+"    ws.on(\"open\", () => {\n"
+"        ws.send(\"Hello, server!\")\n"
+"    })\n"
+"\n"
+"    ws.on(\"message\", (data: any) => {\n"
+"        console.log(`Received: ${data}`)\n"
+"    })\n"
+"\n"
+"    ws.on(\"close\", () => {\n"
+"        console.log(\"Connection closed\")\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:3
+msgid ""
+"Perry natively implements clients for MySQL, PostgreSQL, SQLite, MongoDB, "
+"and Redis."
+msgstr ""
+
+#: src/stdlib/database.md:5
+msgid "MySQL"
+msgstr ""
+
+#: src/stdlib/database.md:7
+msgid ""
+"```typescript\n"
+"import mysql from \"mysql2/promise\"\n"
+"\n"
+"async function mysqlExample(): Promise<void> {\n"
+"    const connection = await mysql.createConnection({\n"
+"        host: \"localhost\",\n"
+"        user: \"root\",\n"
+"        password: \"password\",\n"
+"        database: \"mydb\",\n"
+"    })\n"
+"\n"
+"    const [rows] = await connection.execute(\"SELECT * FROM users WHERE id = ?\", [1])\n"
+"    console.log(rows)\n"
+"\n"
+"    await connection.end()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:25
+msgid "PostgreSQL"
+msgstr ""
+
+#: src/stdlib/database.md:27
+msgid ""
+"```typescript\n"
+"import { Client } from \"pg\"\n"
+"\n"
+"async function postgresExample(): Promise<void> {\n"
+"    const client = new Client({\n"
+"        host: \"localhost\",\n"
+"        port: 5432,\n"
+"        user: \"postgres\",\n"
+"        password: \"password\",\n"
+"        database: \"mydb\",\n"
+"    })\n"
+"\n"
+"    await client.connect()\n"
+"    const result = await client.query(\"SELECT * FROM users WHERE id = $1\", [1])\n"
+"    console.log(result.rows)\n"
+"    await client.end()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:46
+msgid "SQLite"
+msgstr ""
+
+#: src/stdlib/database.md:48
+msgid ""
+"```typescript\n"
+"import Database from \"better-sqlite3\"\n"
+"\n"
+"function sqliteExample(): void {\n"
+"    const db = new Database(\"mydb.sqlite\")\n"
+"\n"
+"    db.exec(`\n"
+"      CREATE TABLE IF NOT EXISTS users (\n"
+"        id INTEGER PRIMARY KEY,\n"
+"        name TEXT,\n"
+"        email TEXT\n"
+"      )\n"
+"    `)\n"
+"\n"
+"    const insert = db.prepare(\"INSERT INTO users (name, email) VALUES (?, ?)\")\n"
+"    insert.run(\"Perry\", \"perry@example.com\")\n"
+"\n"
+"    const users = db.prepare(\"SELECT * FROM users\").all()\n"
+"    console.log(users)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:70
+msgid "MongoDB"
+msgstr ""
+
+#: src/stdlib/database.md:72
+msgid ""
+"```typescript\n"
+"import { MongoClient } from \"mongodb\"\n"
+"\n"
+"async function mongoExample(): Promise<void> {\n"
+"    const client = new MongoClient(\"mongodb://localhost:27017\")\n"
+"    await client.connect()\n"
+"\n"
+"    const db = client.db(\"mydb\")\n"
+"    const users = db.collection(\"users\")\n"
+"\n"
+"    await users.insertOne({ name: \"Perry\", email: \"perry@example.com\" })\n"
+"    const user = await users.findOne({ name: \"Perry\" })\n"
+"    console.log(user)\n"
+"\n"
+"    await client.close()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/database.md:90
+msgid "Redis"
+msgstr ""
+
+#: src/stdlib/database.md:92
+msgid ""
+"```typescript\n"
+"import Redis from \"ioredis\"\n"
+"\n"
+"async function redisExample(): Promise<void> {\n"
+"    const redis = new Redis()\n"
+"\n"
+"    await redis.set(\"key\", \"value\")\n"
+"    const value = await redis.get(\"key\")\n"
+"    console.log(value) // \"value\"\n"
+"\n"
+"    await redis.del(\"key\")\n"
+"    await redis.quit()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:3
+msgid ""
+"Perry natively implements password hashing, JWT tokens, and Ethereum "
+"cryptography."
+msgstr ""
+
+#: src/stdlib/crypto.md:5
+msgid "bcrypt"
+msgstr ""
+
+#: src/stdlib/crypto.md:7
+msgid ""
+"```typescript\n"
+"import bcrypt from \"bcrypt\"\n"
+"\n"
+"async function bcryptExample(): Promise<void> {\n"
+"    const hash = await bcrypt.hash(\"mypassword\", 10)\n"
+"    const match = await bcrypt.compare(\"mypassword\", hash)\n"
+"    console.log(match) // true\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:17
+msgid "Argon2"
+msgstr ""
+
+#: src/stdlib/crypto.md:19
+msgid ""
+"```typescript\n"
+"import argon2 from \"argon2\"\n"
+"\n"
+"async function argon2Example(): Promise<void> {\n"
+"    const hash = await argon2.hash(\"mypassword\")\n"
+"    const valid = await argon2.verify(hash, \"mypassword\")\n"
+"    console.log(valid) // true\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:29
+msgid "JSON Web Tokens"
+msgstr ""
+
+#: src/stdlib/crypto.md:31
+msgid ""
+"```typescript\n"
+"import jwt from \"jsonwebtoken\"\n"
+"\n"
+"function jwtExample(): void {\n"
+"    const secret = \"my-secret-key\"\n"
+"\n"
+"    // Sign a token\n"
+"    const token = jwt.sign({ userId: 123, role: \"admin\" }, secret, {\n"
+"        expiresIn: \"1h\",\n"
+"    })\n"
+"\n"
+"    // Verify a token\n"
+"    const decoded: any = jwt.verify(token, secret)\n"
+"    console.log(decoded.userId) // 123\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:48
+msgid "Node.js Crypto"
+msgstr ""
+
+#: src/stdlib/crypto.md:50
+msgid ""
+"```typescript\n"
+"import crypto from \"crypto\"\n"
+"\n"
+"function cryptoExample(): void {\n"
+"    // Hash\n"
+"    const hash = crypto.createHash(\"sha256\").update(\"data\").digest(\"hex\")\n"
+"\n"
+"    // HMAC\n"
+"    const hmac = crypto.createHmac(\"sha256\", \"secret\").update(\"data\").digest(\"hex\")\n"
+"\n"
+"    // Random bytes\n"
+"    const bytes = crypto.randomBytes(32)\n"
+"\n"
+"    console.log(`hash_len=${hash.length} hmac_len=${hmac.length} bytes_len=${bytes.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/crypto.md:67
+msgid "Ethers"
+msgstr ""
+
+#: src/stdlib/crypto.md:69
+msgid ""
+"```typescript\n"
+"import { ethers } from \"ethers\"\n"
+"\n"
+"function ethersExample(): void {\n"
+"    // Utility functions\n"
+"    const addr = ethers.getAddress(\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\")\n"
+"    const wei = ethers.parseEther(\"1.5\")\n"
+"    const ether = ethers.formatEther(wei)\n"
+"    console.log(`checksum: ${addr}`)\n"
+"    console.log(`1.5 ether in wei → formatted back: ${ether}`)\n"
+"\n"
+"    // Create a random wallet\n"
+"    const wallet = ethers.Wallet.createRandom()\n"
+"    console.log(`address: ${wallet.address}`)\n"
+"    console.log(`privateKey length: ${wallet.privateKey.length}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:3
+msgid "Perry natively implements common utility packages."
+msgstr ""
+
+#: src/stdlib/utilities.md:5
+msgid "lodash"
+msgstr ""
+
+#: src/stdlib/utilities.md:7
+msgid ""
+"The `lodash` runtime functions are partially implemented (see `crates/perry-"
+"stdlib/src/lodash.rs`) but the user-facing dispatch from `import _ from "
+"\"lodash\"; _.chunk(...)` is not wired into the LLVM backend yet. Track the "
+"follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:12
+msgid ""
+"```text\n"
+"import _ from \"lodash\";\n"
+"\n"
+"_.chunk([1, 2, 3, 4, 5], 2);     // [[1,2], [3,4], [5]]\n"
+"_.uniq([1, 2, 2, 3, 3]);          // [1, 2, 3]\n"
+"_.groupBy(users, \"role\");\n"
+"_.sortBy(users, [\"name\"]);\n"
+"_.cloneDeep(obj);\n"
+"_.merge(defaults, overrides);\n"
+"_.debounce(fn, 300);\n"
+"_.throttle(fn, 100);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:25
+msgid "dayjs"
+msgstr ""
+
+#: src/stdlib/utilities.md:27
+msgid ""
+"`dayjs` runtime functions are declared (`js_dayjs_now`, `js_dayjs_format`, "
+"`js_dayjs_add`, etc.) but the user-facing dispatch from `import dayjs from "
+"\"dayjs\"; dayjs()` chained methods is not wired into the LLVM backend yet. "
+"Track the follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:32
+msgid ""
+"```text\n"
+"import dayjs from \"dayjs\";\n"
+"\n"
+"const now = dayjs();\n"
+"console.log(now.format(\"YYYY-MM-DD\"));\n"
+"console.log(now.add(7, \"day\").format(\"YYYY-MM-DD\"));\n"
+"console.log(now.subtract(1, \"month\").toISOString());\n"
+"\n"
+"const diff = dayjs(\"2025-12-31\").diff(now, \"day\");\n"
+"console.log(`${diff} days until end of year`);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:44
+msgid "moment"
+msgstr ""
+
+#: src/stdlib/utilities.md:46
+msgid ""
+"Same status as `dayjs` — the runtime functions exist but the dispatch path "
+"is not wired yet."
+msgstr ""
+
+#: src/stdlib/utilities.md:49
+msgid ""
+"```text\n"
+"import moment from \"moment\";\n"
+"\n"
+"const now = moment();\n"
+"console.log(now.format(\"MMMM Do YYYY\"));\n"
+"console.log(now.fromNow());\n"
+"console.log(moment(\"2025-01-01\").isBefore(now));\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:58
+msgid "uuid"
+msgstr ""
+
+#: src/stdlib/utilities.md:60
+msgid ""
+"```typescript\n"
+"import { v4 as uuidv4 } from \"uuid\"\n"
+"\n"
+"const id = uuidv4()\n"
+"console.log(id) // e.g., \"550e8400-e29b-41d4-a716-446655440000\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:67
+msgid "nanoid"
+msgstr ""
+
+#: src/stdlib/utilities.md:69
+msgid ""
+"The default-length `nanoid()` call is wired. The custom-length form "
+"`nanoid(10)` has a runtime function (`js_nanoid_sized`) but no dispatch yet "
+"— track at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:73
+msgid ""
+"```typescript\n"
+"import { nanoid } from \"nanoid\"\n"
+"\n"
+"const nid = nanoid() // Default 21 chars\n"
+"console.log(nid)\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:80
+msgid "slugify"
+msgstr ""
+
+#: src/stdlib/utilities.md:82
+msgid ""
+"The single-arg form is wired. The options-object form `slugify(\"Hello "
+"World!\", { lower: true })` has a runtime function "
+"(`js_slugify_with_options`) but no dispatch yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/utilities.md:86
+msgid ""
+"```typescript\n"
+"import slugify from \"slugify\"\n"
+"\n"
+"const slug = slugify(\"Hello World!\")\n"
+"console.log(slug) // \"hello-world\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/utilities.md:93
+msgid "validator"
+msgstr ""
+
+#: src/stdlib/utilities.md:95
+msgid ""
+"```typescript\n"
+"import validator from \"validator\"\n"
+"\n"
+"console.log(validator.isEmail(\"test@example.com\"))  // true\n"
+"console.log(validator.isURL(\"https://example.com\")) // true\n"
+"console.log(validator.isUUID(id))                   // true\n"
+"console.log(validator.isEmpty(\"\"))                  // true\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:3
+msgid "Additional npm packages and Node.js APIs supported by Perry."
+msgstr ""
+
+#: src/stdlib/other.md:5
+msgid "sharp (Image Processing)"
+msgstr ""
+
+#: src/stdlib/other.md:7
+msgid ""
+"The `sharp` runtime functions are declared (`js_sharp_resize`, "
+"`js_sharp_blur`, `js_sharp_to_buffer`, etc.) but the user-facing dispatch "
+"from `import sharp from \"sharp\"; sharp(input).resize(...)` is not wired "
+"into the LLVM backend yet. Track the follow-up at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:12
+msgid ""
+"```text\n"
+"import sharp from \"sharp\";\n"
+"\n"
+"await sharp(\"input.jpg\")\n"
+"  .resize(300, 200)\n"
+"  .toFile(\"output.png\");\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:20
+msgid "cheerio (HTML Parsing)"
+msgstr ""
+
+#: src/stdlib/other.md:22
+msgid ""
+"The `cheerio` runtime exists (see `crates/perry-stdlib/src/cheerio.rs`) but "
+"the dispatch path is not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:25
+msgid ""
+"```text\n"
+"import cheerio from \"cheerio\";\n"
+"\n"
+"const html = \"<html><body><h1>Hello</h1><p>World</p></body></html>\";\n"
+"const $ = cheerio.load(html);\n"
+"console.log($(\"h1\").text()); // \"Hello\"\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:33
+msgid "nodemailer (Email)"
+msgstr ""
+
+#: src/stdlib/other.md:35
+msgid ""
+"```typescript\n"
+"import nodemailer from \"nodemailer\"\n"
+"\n"
+"async function nodemailerExample(): Promise<void> {\n"
+"    const transporter = nodemailer.createTransport({\n"
+"        host: \"smtp.example.com\",\n"
+"        port: 587,\n"
+"        auth: { user: \"user\", pass: \"pass\" },\n"
+"    })\n"
+"\n"
+"    await transporter.sendMail({\n"
+"        from: \"sender@example.com\",\n"
+"        to: \"recipient@example.com\",\n"
+"        subject: \"Hello from Perry\",\n"
+"        text: \"This email was sent from a compiled TypeScript binary!\",\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:54
+msgid "zlib (Compression)"
+msgstr ""
+
+#: src/stdlib/other.md:56
+msgid ""
+"The `zlib` runtime exists but dispatch from `import zlib from \"zlib\"` is "
+"not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:59
+msgid ""
+"```text\n"
+"import zlib from \"zlib\";\n"
+"\n"
+"const compressed = zlib.gzipSync(\"Hello, World!\");\n"
+"const decompressed = zlib.gunzipSync(compressed);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:66
+msgid "cron (Job Scheduling)"
+msgstr ""
+
+#: src/stdlib/other.md:68
+msgid ""
+"The `cron` runtime exists but dispatch from `import { CronJob } from "
+"\"cron\"` is not wired yet — track at issue #200."
+msgstr ""
+
+#: src/stdlib/other.md:71
+msgid ""
+"```text\n"
+"import { CronJob } from \"cron\";\n"
+"\n"
+"const job = new CronJob(\"*/5 * * * *\", () => {\n"
+"  console.log(\"Runs every 5 minutes\");\n"
+"});\n"
+"job.start();\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:80
+msgid "worker_threads"
+msgstr ""
+
+#: src/stdlib/other.md:82
+msgid ""
+"The `worker_threads` API is partially recognized at HIR-lowering time "
+"(`parentPort` / `Worker` shapes) but full dispatch is incomplete. For data-"
+"parallel work today, prefer `parallelMap` / `parallelFilter` / `spawn` from "
+"`perry/thread` (see [Threading](../threading/overview.md))."
+msgstr ""
+
+#: src/stdlib/other.md:87
+msgid ""
+"```text\n"
+"import { Worker, parentPort, workerData } from \"worker_threads\";\n"
+"\n"
+"if (parentPort) {\n"
+"  // Worker thread\n"
+"  const data = workerData;\n"
+"  parentPort.postMessage({ result: data.value * 2 });\n"
+"} else {\n"
+"  // Main thread\n"
+"  const worker = new Worker(\"./worker.ts\", {\n"
+"    workerData: { value: 21 },\n"
+"  });\n"
+"  worker.on(\"message\", (msg) => {\n"
+"    console.log(msg.result); // 42\n"
+"  });\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:105
+msgid "commander (CLI Parsing)"
+msgstr ""
+
+#: src/stdlib/other.md:107
+msgid ""
+"```typescript\n"
+"import { Command } from \"commander\"\n"
+"\n"
+"function commanderExample(): void {\n"
+"    const program = new Command()\n"
+"    program.name(\"my-cli\").version(\"1.0.0\").description(\"My CLI tool\")\n"
+"\n"
+"    program\n"
+"        .command(\"serve\")\n"
+"        .option(\"-p, --port <number>\", \"Port number\")\n"
+"        .option(\"--verbose\", \"Verbose output\")\n"
+"        .action((options: any) => {\n"
+"            console.log(`Starting server on port ${options.port}`)\n"
+"        })\n"
+"\n"
+"    program.parse(process.argv)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:126
+msgid "decimal.js (Arbitrary Precision)"
+msgstr ""
+
+#: src/stdlib/other.md:128
+msgid ""
+"```typescript\n"
+"import Decimal from \"decimal.js\"\n"
+"\n"
+"function decimalExample(): void {\n"
+"    const a = new Decimal(\"0.1\")\n"
+"    const b = new Decimal(\"0.2\")\n"
+"    const sum = a.plus(b) // Exactly 0.3 (no floating point errors)\n"
+"\n"
+"    console.log(sum.toFixed(2))      // \"0.30\"\n"
+"    console.log(sum.toNumber())      // 0.3\n"
+"    console.log(a.times(b).toFixed(2)) // \"0.02\"\n"
+"    console.log(a.div(b).toFixed(1))   // \"0.5\"\n"
+"    console.log(a.pow(10).toString())  // 1e-10\n"
+"    console.log(a.sqrt().toFixed(3))   // \"0.316\"\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:145
+msgid "lru-cache"
+msgstr ""
+
+#: src/stdlib/other.md:147
+msgid ""
+"The wired constructor takes the npm v7+ options-object shape (`new "
+"LRUCache({ max: 100 })`) — the older positional form `new LRUCache(100)` "
+"falls through to a `max=100` default."
+msgstr ""
+
+#: src/stdlib/other.md:151
+msgid ""
+"```typescript\n"
+"import { LRUCache } from \"lru-cache\"\n"
+"\n"
+"function lruCacheExample(): void {\n"
+"    const cache = new LRUCache({ max: 100 }) // max 100 entries\n"
+"\n"
+"    cache.set(\"key\", \"value\")\n"
+"    console.log(cache.get(\"key\"))   // \"value\"\n"
+"    console.log(cache.has(\"key\"))   // true\n"
+"    cache.delete(\"key\")\n"
+"    cache.clear()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:165
+msgid "child_process"
+msgstr ""
+
+#: src/stdlib/other.md:167
+msgid ""
+"```typescript\n"
+"import { spawnBackground, getProcessStatus, killProcess } from \"child_process\"\n"
+"\n"
+"function childProcessExample(): void {\n"
+"    // Spawn a background process\n"
+"    const { pid, handleId } = spawnBackground(\"sleep\", [\"10\"], \"/tmp/log.txt\")\n"
+"\n"
+"    // Check if it's still running\n"
+"    const status = getProcessStatus(handleId)\n"
+"    console.log(status.alive) // true\n"
+"    console.log(`pid=${pid}`)\n"
+"\n"
+"    // Kill it\n"
+"    killProcess(handleId)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:187
+msgid "[File System](fs.md) — fs and path APIs"
+msgstr ""
+
+#: src/i18n/overview.md:1
+msgid "Internationalization (i18n)"
+msgstr ""
+
+#: src/i18n/overview.md:3
+msgid ""
+"Perry's i18n system lets you write natural English strings and have them "
+"automatically translated at compile time. Zero ceremony, near-zero runtime "
+"cost."
+msgstr ""
+
+#: src/i18n/overview.md:5
+msgid ""
+"```typescript\n"
+"// String literals in UI component calls are automatically localizable keys.\n"
+"// (Conceptually the docs write `Button(\"Next\")` / `Text(\"Hello, {name}!\", ...)`\n"
+"// from \"perry/ui\"; we exercise the runtime API that backs them — t() — here.)\n"
+"const next = t(\"Next\")                                  // Automatically localized\n"
+"const hello = t(\"Hello, {name}!\", { name: \"Alice\" })    // With interpolation\n"
+"console.log(next, hello)\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:14
+msgid ""
+"The same key-resolution and interpolation runs through the explicit `t()` "
+"API for non-UI strings:"
+msgstr ""
+
+#: src/i18n/overview.md:16
+msgid ""
+"```typescript\n"
+"import { t, Currency, Percent, ShortDate, LongDate, FormatNumber, FormatTime, Raw } from \"perry/i18n\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:20
+msgid "Design Principles"
+msgstr ""
+
+#: src/i18n/overview.md:22
+msgid ""
+"**Zero ceremony**: String literals in UI components are automatically "
+"localizable keys"
+msgstr ""
+
+#: src/i18n/overview.md:23
+msgid ""
+"**Compile-time validation**: Missing translations, parameter mismatches, and"
+" plural form errors caught during build"
+msgstr ""
+
+#: src/i18n/overview.md:24
+msgid ""
+"**Embedded string table**: All translations baked into the binary as a flat "
+"2D table. Near-zero runtime lookup cost"
+msgstr ""
+
+#: src/i18n/overview.md:25
+msgid ""
+"**Platform-native locale detection**: Uses OS APIs on every platform (no env"
+" vars needed on mobile)"
+msgstr ""
+
+#: src/i18n/overview.md:29
+msgid "1. Add i18n config to perry.toml"
+msgstr ""
+
+#: src/i18n/overview.md:31
+msgid ""
+"```toml\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\"]\n"
+"default_locale = \"en\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/overview.md:37
+msgid "2. Extract strings from your code"
+msgstr ""
+
+#: src/i18n/overview.md:43
+msgid ""
+"This scans your source files and creates `locales/en.json` and "
+"`locales/de.json`:"
+msgstr ""
+
+#: src/i18n/overview.md:46 src/i18n/interpolation.md:17
+#: src/i18n/interpolation.md:49
+msgid "// locales/en.json\n"
+msgstr ""
+
+#: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
+#: src/i18n/cli.md:38 src/i18n/cli.md:87
+msgid "\"Next\""
+msgstr ""
+
+#: src/i18n/overview.md:49 src/i18n/overview.md:55 src/i18n/overview.md:66
+msgid "\"Back\""
+msgstr ""
+
+#: src/i18n/overview.md:51
+msgid "// locales/de.json (empty values = needs translation)\n"
+msgstr ""
+
+#: src/i18n/overview.md:54 src/i18n/overview.md:55
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:73
+msgid "\"\""
+msgstr ""
+
+#: src/i18n/overview.md:59
+msgid "3. Translate"
+msgstr ""
+
+#: src/i18n/overview.md:61
+msgid "Fill in `locales/de.json`:"
+msgstr ""
+
+#: src/i18n/overview.md:65
+msgid "\"Weiter\""
+msgstr ""
+
+#: src/i18n/overview.md:66
+msgid "\"Zurck\""
+msgstr ""
+
+#: src/i18n/overview.md:70
+msgid "4. Build"
+msgstr ""
+
+#: src/i18n/overview.md:76
+msgid ""
+"Perry validates all translations at compile time and bakes them into the "
+"binary. At runtime, the app detects the user's system locale and shows the "
+"right language."
+msgstr ""
+
+#: src/i18n/overview.md:80
+msgid ""
+"**Detection**: String literals in UI component calls (`Button`, `Text`, "
+"`Label`, etc.) are automatically treated as i18n keys"
+msgstr ""
+
+#: src/i18n/overview.md:81
+msgid ""
+"**Transform**: The compiler replaces `Expr::String(\"Next\")` with "
+"`Expr::I18nString { key: \"Next\", string_idx: 0 }` in the HIR"
+msgstr ""
+
+#: src/i18n/overview.md:82
+msgid ""
+"**Codegen**: For each `I18nString`, the compiler emits a locale branch that "
+"selects the correct translation at runtime"
+msgstr ""
+
+#: src/i18n/overview.md:83
+msgid ""
+"**Locale detection**: At startup, `perry_i18n_init()` detects the system "
+"locale via native APIs and sets the global locale index"
+msgstr ""
+
+#: src/i18n/overview.md:85
+msgid "Locale Detection"
+msgstr ""
+
+#: src/i18n/overview.md:89 src/i18n/overview.md:90
+msgid "`CFLocaleCopyCurrent()` (CoreFoundation)"
+msgstr ""
+
+#: src/i18n/overview.md:91
+msgid "`__system_property_get(\"persist.sys.locale\")`"
+msgstr ""
+
+#: src/i18n/overview.md:92
+msgid "`GetUserDefaultLocaleName()` (Win32)"
+msgstr ""
+
+#: src/i18n/overview.md:93
+msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
+msgstr ""
+
+#: src/i18n/overview.md:95
+msgid ""
+"The detected locale is fuzzy-matched against your configured locales: "
+"`de_DE.UTF-8` matches `de`, `en-US` matches `en`, etc."
+msgstr ""
+
+#: src/i18n/overview.md:97
+msgid "Platform Output"
+msgstr ""
+
+#: src/i18n/overview.md:99
+msgid ""
+"When compiling for mobile targets, Perry generates platform-native locale "
+"resources alongside the binary:"
+msgstr ""
+
+#: src/i18n/overview.md:101 src/widgets/platforms.md:9
+msgid "Output"
+msgstr ""
+
+#: src/i18n/overview.md:103
+msgid "iOS/macOS"
+msgstr ""
+
+#: src/i18n/overview.md:103
+msgid "`{locale}.lproj/Localizable.strings` inside `.app` bundle"
+msgstr ""
+
+#: src/i18n/overview.md:104
+msgid "`res/values-{locale}/strings.xml`"
+msgstr ""
+
+#: src/i18n/overview.md:105
+msgid "Desktop"
+msgstr ""
+
+#: src/i18n/overview.md:105
+msgid "Strings embedded in binary (no extra files)"
+msgstr ""
+
+#: src/i18n/overview.md:109
+msgid "[Interpolation & Plurals](interpolation.md)"
+msgstr ""
+
+#: src/i18n/overview.md:110
+msgid "[Formatting](formatting.md)"
+msgstr ""
+
+#: src/i18n/overview.md:111
+msgid "[CLI Tools](cli.md)"
+msgstr ""
+
+#: src/i18n/interpolation.md:3
+msgid "Parameterized Strings"
+msgstr ""
+
+#: src/i18n/interpolation.md:5
+msgid ""
+"Use `{param}` placeholders in your strings and pass values as a second "
+"argument:"
+msgstr ""
+
+#: src/i18n/interpolation.md:7
+msgid ""
+"```typescript\n"
+"// Use {param} placeholders in your strings and pass values as a second arg.\n"
+"const greeting = t(\"Hello, {name}!\", { name: \"Alice\" })\n"
+"const total = t(\"Total: {price}\", { price: 23.10 })\n"
+"console.log(greeting, total)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:14
+msgid "Translation files use the same `{param}` syntax:"
+msgstr ""
+
+#: src/i18n/interpolation.md:19 src/i18n/interpolation.md:25
+#: src/i18n/cli.md:38 src/i18n/cli.md:88
+msgid "\"Hello, {name}!\""
+msgstr ""
+
+#: src/i18n/interpolation.md:20 src/i18n/interpolation.md:26
+msgid "\"Total: {price}\""
+msgstr ""
+
+#: src/i18n/interpolation.md:22 src/i18n/interpolation.md:54
+msgid "// locales/de.json\n"
+msgstr ""
+
+#: src/i18n/interpolation.md:25
+msgid "\"Hallo, {name}!\""
+msgstr ""
+
+#: src/i18n/interpolation.md:26
+msgid "\"Gesamt: {price}\""
+msgstr ""
+
+#: src/i18n/interpolation.md:30
+msgid ""
+"Parameters are substituted at runtime after the locale-appropriate template "
+"is selected. The substitution handles any value type (numbers, strings, "
+"dates) by converting to string."
+msgstr ""
+
+#: src/i18n/interpolation.md:32 src/i18n/interpolation.md:99
+msgid "Compile-Time Validation"
+msgstr ""
+
+#: src/i18n/interpolation.md:34
+msgid "Perry validates parameters across all locales during compilation:"
+msgstr ""
+
+#: src/i18n/interpolation.md:36 src/i18n/interpolation.md:101
+msgid "Condition"
+msgstr ""
+
+#: src/i18n/interpolation.md:36 src/i18n/interpolation.md:101
+msgid "Severity"
+msgstr ""
+
+#: src/i18n/interpolation.md:38
+msgid "`{param}` in translation but not provided in code"
+msgstr ""
+
+#: src/i18n/interpolation.md:38 src/i18n/interpolation.md:39
+#: src/i18n/interpolation.md:40 src/i18n/interpolation.md:103
+#: src/i18n/interpolation.md:104
+msgid "Error"
+msgstr ""
+
+#: src/i18n/interpolation.md:39
+msgid "Param in code but `{param}` not in translation"
+msgstr ""
+
+#: src/i18n/interpolation.md:40
+msgid "Parameter set differs between locales for same key"
+msgstr ""
+
+#: src/i18n/interpolation.md:42
+msgid "Plural Rules"
+msgstr ""
+
+#: src/i18n/interpolation.md:44
+msgid ""
+"Plural forms use dot-suffix keys based on CLDR plural categories: `.zero`, "
+"`.one`, `.two`, `.few`, `.many`, `.other`."
+msgstr ""
+
+#: src/i18n/interpolation.md:46
+msgid "Locale Files"
+msgstr ""
+
+#: src/i18n/interpolation.md:51 src/i18n/interpolation.md:57
+#: src/i18n/interpolation.md:63
+msgid "\"You have {count} items.one\""
+msgstr ""
+
+#: src/i18n/interpolation.md:51
+msgid "\"You have {count} item.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:52 src/i18n/interpolation.md:58
+#: src/i18n/interpolation.md:66
+msgid "\"You have {count} items.other\""
+msgstr ""
+
+#: src/i18n/interpolation.md:52
+msgid "\"You have {count} items.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:57 src/i18n/interpolation.md:58
+msgid "\"Du hast {count} Artikel.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:60
+msgid "// locales/pl.json (Polish: one, few, many)\n"
+msgstr ""
+
+#: src/i18n/interpolation.md:63
+msgid "\"Masz {count} element.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:64
+msgid "\"You have {count} items.few\""
+msgstr ""
+
+#: src/i18n/interpolation.md:64
+msgid "\"Masz {count} elementy.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:65
+msgid "\"You have {count} items.many\""
+msgstr ""
+
+#: src/i18n/interpolation.md:65
+msgid "\"Masz {count} elementow.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:66
+msgid "\"Masz {count} elementu.\""
+msgstr ""
+
+#: src/i18n/interpolation.md:70
+msgid "Usage in Code"
+msgstr ""
+
+#: src/i18n/interpolation.md:72
+msgid ""
+"Reference the base key without any suffix. Perry detects the plural variants"
+" automatically:"
+msgstr ""
+
+#: src/i18n/interpolation.md:74
+msgid ""
+"```typescript\n"
+"// Reference the base key without any suffix — Perry picks the plural variant\n"
+"// from the `count` parameter and the current locale's CLDR rules.\n"
+"const cartCount = 3\n"
+"const itemMessage = t(\"You have {count} items\", { count: cartCount })\n"
+"console.log(itemMessage)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:82
+msgid ""
+"Perry determines which plural form to use based on the `count` parameter "
+"value and the current locale's CLDR rules."
+msgstr ""
+
+#: src/i18n/interpolation.md:84
+msgid "Supported Locales"
+msgstr ""
+
+#: src/i18n/interpolation.md:86
+msgid "Perry includes hand-rolled CLDR plural rules for 30+ locales:"
+msgstr ""
+
+#: src/i18n/interpolation.md:88
+msgid "Pattern"
+msgstr ""
+
+#: src/i18n/interpolation.md:88
+msgid "Locales"
+msgstr ""
+
+#: src/i18n/interpolation.md:90
+msgid "one/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:90
+msgid ""
+"English, German, Dutch, Swedish, Danish, Norwegian, Finnish, Estonian, "
+"Hungarian, Turkish, Greek, Hebrew, Italian, Spanish, Portuguese, Catalan, "
+"Bulgarian, Hindi, Bengali, Swahili, ..."
+msgstr ""
+
+#: src/i18n/interpolation.md:91
+msgid "one (0-1) / other"
+msgstr ""
+
+#: src/i18n/interpolation.md:91
+msgid "French"
+msgstr ""
+
+#: src/i18n/interpolation.md:92
+msgid "no distinction"
+msgstr ""
+
+#: src/i18n/interpolation.md:92
+msgid "Japanese, Chinese, Korean, Vietnamese, Thai, Indonesian, Malay"
+msgstr ""
+
+#: src/i18n/interpolation.md:93
+msgid "one/few/many"
+msgstr ""
+
+#: src/i18n/interpolation.md:93
+msgid "Russian, Ukrainian, Serbian, Croatian, Bosnian, Polish"
+msgstr ""
+
+#: src/i18n/interpolation.md:94 src/i18n/interpolation.md:96
+msgid "one/few/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:94
+msgid "Czech, Slovak"
+msgstr ""
+
+#: src/i18n/interpolation.md:95
+msgid "zero/one/two/few/many/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:95
+msgid "Arabic"
+msgstr ""
+
+#: src/i18n/interpolation.md:96
+msgid "Romanian, Lithuanian"
+msgstr ""
+
+#: src/i18n/interpolation.md:97
+msgid "zero/one/other"
+msgstr ""
+
+#: src/i18n/interpolation.md:97
+msgid "Latvian"
+msgstr ""
+
+#: src/i18n/interpolation.md:103
+msgid "`.other` form missing for any locale"
+msgstr ""
+
+#: src/i18n/interpolation.md:104
+msgid "Required CLDR category missing (e.g., `.few` for Polish)"
+msgstr ""
+
+#: src/i18n/interpolation.md:105
+msgid "Extra category locale doesn't use (e.g., `.few` for English)"
+msgstr ""
+
+#: src/i18n/interpolation.md:105
+msgid "Warning"
+msgstr ""
+
+#: src/i18n/interpolation.md:107
+msgid "Explicit API for Non-UI Strings"
+msgstr ""
+
+#: src/i18n/interpolation.md:109
+msgid ""
+"For strings outside UI components (API responses, notifications, etc.), use "
+"`t()`:"
+msgstr ""
+
+#: src/i18n/interpolation.md:111
+msgid ""
+"```typescript\n"
+"// For strings outside UI components (API responses, notifications, …), use t():\n"
+"const message = t(\"Your order has been shipped.\")\n"
+"const welcome = t(\"Welcome back, {name}!\", { name: \"Alice\" })\n"
+"console.log(message, welcome)\n"
+"```"
+msgstr ""
+
+#: src/i18n/interpolation.md:118
+msgid ""
+"This uses the same key lookup, validation, and interpolation as UI strings."
+msgstr ""
+
+#: src/i18n/formatting.md:1
+msgid "Locale-Aware Formatting"
+msgstr ""
+
+#: src/i18n/formatting.md:3
+msgid ""
+"Perry provides format wrapper functions that automatically format values "
+"according to the current locale. Import them from `perry/i18n`:"
+msgstr ""
+
+#: src/i18n/formatting.md:5
+msgid ""
+"```typescript\n"
+"// All format wrappers come from perry/i18n.\n"
+"// (The same `Currency`, `Percent`, … you'd pass into a Text(...) param object.)\n"
+"const price = Currency(23.10)\n"
+"const discount = Percent(0.15)\n"
+"const population = FormatNumber(1234567.89)\n"
+"const due = ShortDate(Date.now())\n"
+"const event = LongDate(Date.now())\n"
+"const at = FormatTime(Date.now())\n"
+"const code = Raw(12345)\n"
+"\n"
+"// Compose them with t() the same way you'd compose with Text(...):\n"
+"console.log(t(\"Total: {price}\", { price }))\n"
+"console.log(t(\"Discount: {rate}\", { rate: discount }))\n"
+"console.log(t(\"Population: {n}\", { n: population }))\n"
+"console.log(t(\"Due: {d}\", { d: due }))\n"
+"console.log(t(\"Event: {d}\", { d: event }))\n"
+"console.log(t(\"At: {t}\", { t: at }))\n"
+"console.log(t(\"Code: {amount}\", { amount: code }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:26
+msgid "Format Wrappers"
+msgstr ""
+
+#: src/i18n/formatting.md:28
+msgid "Currency"
+msgstr ""
+
+#: src/i18n/formatting.md:30
+msgid ""
+"Formats a number as currency with the locale's symbol, decimal separator, "
+"and symbol placement:"
+msgstr ""
+
+#: src/i18n/formatting.md:32
+msgid ""
+"```typescript\n"
+"// Currency: locale-appropriate symbol, separator, and placement.\n"
+"//   en: \"$23.10\"   de: \"23,10 €\"   ja: \"¥23.10\"\n"
+"const cur = Currency(23.10)\n"
+"console.log(t(\"Total: {price}\", { price: cur }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:39
+msgid ""
+"```text\n"
+"en: \"Total: $23.10\"\n"
+"de: \"Total: 23,10 €\"\n"
+"fr: \"Total: 23,10 €\"\n"
+"ja: \"Total: ¥23.10\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:46
+msgid "Percent"
+msgstr ""
+
+#: src/i18n/formatting.md:48
+msgid "Formats a decimal as a percentage (value is multiplied by 100):"
+msgstr ""
+
+#: src/i18n/formatting.md:50
+msgid ""
+"```typescript\n"
+"// Percent: input is a decimal (0.15 → 15 %). en omits the space; de/fr add it.\n"
+"const rate = Percent(0.15)\n"
+"console.log(t(\"Discount: {rate}\", { rate }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:56
+msgid ""
+"```text\n"
+"en: \"Discount: 15%\"\n"
+"de: \"Discount: 15 %\"\n"
+"fr: \"Discount: 15 %\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:62
+msgid "FormatNumber"
+msgstr ""
+
+#: src/i18n/formatting.md:64
+msgid ""
+"Formats a number with locale-appropriate grouping and decimal separators:"
+msgstr ""
+
+#: src/i18n/formatting.md:66
+msgid ""
+"```typescript\n"
+"// FormatNumber: locale-appropriate grouping + decimal separators.\n"
+"//   en: \"1,234,567.89\"   de: \"1.234.567,89\"   fr: \"1 234 567,89\"\n"
+"const n = FormatNumber(1234567.89)\n"
+"console.log(t(\"Population: {n}\", { n }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:73
+msgid ""
+"```text\n"
+"en: \"Population: 1,234,567.89\"\n"
+"de: \"Population: 1.234.567,89\"\n"
+"fr: \"Population: 1 234 567,89\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:79
+msgid "ShortDate / LongDate / FormatDate"
+msgstr ""
+
+#: src/i18n/formatting.md:81
+msgid "Formats a timestamp (milliseconds since epoch) as a date:"
+msgstr ""
+
+#: src/i18n/formatting.md:83
+msgid ""
+"```typescript\n"
+"// ShortDate / LongDate take a millisecond timestamp.\n"
+"const now = Date.now()\n"
+"const short = ShortDate(now)   // en: \"3/22/2026\"   de: \"22.03.2026\"\n"
+"const long = LongDate(now)     // en: \"March 22, 2026\"   de: \"22. März 2026\"\n"
+"console.log(t(\"Due: {d}\", { d: short }))\n"
+"console.log(t(\"Event: {d}\", { d: long }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:92
+msgid ""
+"```text\n"
+"ShortDate\n"
+"  en: \"Due: 3/22/2026\"\n"
+"  de: \"Due: 22.03.2026\"\n"
+"  ja: \"Due: 2026/03/22\"\n"
+"\n"
+"LongDate\n"
+"  en: \"Event: March 22, 2026\"\n"
+"  de: \"Event: 22. März 2026\"\n"
+"  fr: \"Event: 22 mars 2026\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:104
+msgid "FormatTime"
+msgstr ""
+
+#: src/i18n/formatting.md:106
+msgid "Formats a timestamp as time (12h vs 24h based on locale):"
+msgstr ""
+
+#: src/i18n/formatting.md:108
+msgid ""
+"```typescript\n"
+"// FormatTime: 12h vs 24h based on the active locale.\n"
+"const ts = Date.now()\n"
+"const formatted = FormatTime(ts)\n"
+"console.log(t(\"At: {t}\", { t: formatted }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:115
+msgid ""
+"```text\n"
+"en: \"At: 3:45 PM\"\n"
+"de: \"At: 15:45\"\n"
+"fr: \"At: 15:45\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:121
+msgid "Raw"
+msgstr ""
+
+#: src/i18n/formatting.md:123
+msgid ""
+"Pass-through — prevents any automatic formatting. Use when a parameter name "
+"might trigger auto-formatting but you want the raw value:"
+msgstr ""
+
+#: src/i18n/formatting.md:125
+msgid ""
+"```typescript\n"
+"// Raw is a pass-through — prevents auto-formatting when the param name\n"
+"// might otherwise trigger it.\n"
+"const orderCode = Raw(12345)\n"
+"console.log(t(\"Code: {amount}\", { amount: orderCode }))\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:132
+msgid "All locales: `\"Code: 12345\"` (no currency formatting despite the name)."
+msgstr ""
+
+#: src/i18n/formatting.md:134
+msgid "Locale-Specific Formatting Rules"
+msgstr ""
+
+#: src/i18n/formatting.md:136
+msgid "Perry includes hand-rolled formatting rules for 25+ locales:"
+msgstr ""
+
+#: src/i18n/formatting.md:138
+msgid "Example Locales"
+msgstr ""
+
+#: src/i18n/formatting.md:140
+msgid "Decimal: `.` / Thousands: `,`"
+msgstr ""
+
+#: src/i18n/formatting.md:140 src/i18n/formatting.md:144
+msgid "en, ja, zh, ko"
+msgstr ""
+
+#: src/i18n/formatting.md:141
+msgid "Decimal: `,` / Thousands: `.`"
+msgstr ""
+
+#: src/i18n/formatting.md:141
+msgid "de, nl, tr, es, it, pt"
+msgstr ""
+
+#: src/i18n/formatting.md:142
+msgid "Decimal: `,` / Thousands: ` ` (narrow space)"
+msgstr ""
+
+#: src/i18n/formatting.md:142
+msgid "fr"
+msgstr ""
+
+#: src/i18n/formatting.md:143
+msgid "Decimal: `,` / Thousands: ` ` (non-breaking space)"
+msgstr ""
+
+#: src/i18n/formatting.md:143
+msgid "ru, uk, pl, sv, da, no, fi"
+msgstr ""
+
+#: src/i18n/formatting.md:144
+msgid "Currency before number: `$23.10`"
+msgstr ""
+
+#: src/i18n/formatting.md:145
+msgid "Currency after number: `23,10 €`"
+msgstr ""
+
+#: src/i18n/formatting.md:145
+msgid "de, fr, es, it, ru"
+msgstr ""
+
+#: src/i18n/formatting.md:146
+msgid "Percent with space: `42 %`"
+msgstr ""
+
+#: src/i18n/formatting.md:146 src/i18n/formatting.md:149
+msgid "de, fr, es, ru"
+msgstr ""
+
+#: src/i18n/formatting.md:147
+msgid "Percent without space: `42%`"
+msgstr ""
+
+#: src/i18n/formatting.md:147
+msgid "en, ja, zh"
+msgstr ""
+
+#: src/i18n/formatting.md:148
+msgid "Date order: M/D/Y"
+msgstr ""
+
+#: src/i18n/formatting.md:148 src/i18n/formatting.md:152
+msgid "en"
+msgstr ""
+
+#: src/i18n/formatting.md:149
+msgid "Date order: D.M.Y"
+msgstr ""
+
+#: src/i18n/formatting.md:150
+msgid "Date order: Y/M/D"
+msgstr ""
+
+#: src/i18n/formatting.md:150
+msgid "ja, zh, ko, sv"
+msgstr ""
+
+#: src/i18n/formatting.md:151
+msgid "24-hour time"
+msgstr ""
+
+#: src/i18n/formatting.md:151
+msgid "de, fr, es, ja, zh, ru (most)"
+msgstr ""
+
+#: src/i18n/formatting.md:152
+msgid "12-hour time (AM/PM)"
+msgstr ""
+
+#: src/i18n/formatting.md:154
+msgid "Currency Configuration"
+msgstr ""
+
+#: src/i18n/formatting.md:156
+msgid "Configure default currency codes per locale in `perry.toml`:"
+msgstr ""
+
+#: src/i18n/formatting.md:158
+msgid ""
+"```toml\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\", \"fr\"]\n"
+"default_locale = \"en\"\n"
+"\n"
+"[i18n.currencies]\n"
+"en = \"USD\"\n"
+"de = \"EUR\"\n"
+"fr = \"EUR\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/formatting.md:169
+msgid ""
+"When `Currency(value)` is called, the locale's configured currency code "
+"determines the symbol and formatting rules."
+msgstr ""
+
+#: src/i18n/cli.md:1
+msgid "i18n CLI Tools"
+msgstr ""
+
+#: src/i18n/cli.md:3 src/cli/commands.md:308
+msgid "`perry i18n extract`"
+msgstr ""
+
+#: src/i18n/cli.md:5
+msgid ""
+"Scans your TypeScript source files for localizable strings and generates or "
+"updates locale JSON files."
+msgstr ""
+
+#: src/i18n/cli.md:11
+msgid "What It Does"
+msgstr ""
+
+#: src/i18n/cli.md:13
+msgid "Recursively scans all `.ts` and `.tsx` files in the source directory"
+msgstr ""
+
+#: src/i18n/cli.md:14
+msgid ""
+"Detects string literals in UI component calls: `Button(\"...\")`, "
+"`Text(\"...\")`, `Label(\"...\")`, etc."
+msgstr ""
+
+#: src/i18n/cli.md:15
+msgid "Also detects `t(\"...\")` calls from `perry/i18n`"
+msgstr ""
+
+#: src/i18n/cli.md:16
+msgid "Creates `locales/` directory if it doesn't exist"
+msgstr ""
+
+#: src/i18n/cli.md:17
+msgid "For each configured locale, creates or updates a JSON file:"
+msgstr ""
+
+#: src/i18n/cli.md:18
+msgid "**Default locale**: New keys are pre-filled with themselves as values"
+msgstr ""
+
+#: src/i18n/cli.md:19
+msgid ""
+"**Non-default locales**: New keys are added with empty string values "
+"(indicating \"needs translation\")"
+msgstr ""
+
+#: src/i18n/cli.md:21
+msgid "Example Output"
+msgstr ""
+
+#: src/i18n/cli.md:32
+msgid "Workflow"
+msgstr ""
+
+#: src/i18n/cli.md:34
+msgid "Typical translation workflow:"
+msgstr ""
+
+#: src/i18n/cli.md:37
+msgid "# 1. Write code with English strings\n"
+msgstr ""
+
+#: src/i18n/cli.md:39
+msgid "# 2. Extract strings to locale files\n"
+msgstr ""
+
+#: src/i18n/cli.md:42
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
+msgstr ""
+
+#: src/i18n/cli.md:44
+msgid "# 4. Build — Perry validates everything\n"
+msgstr ""
+
+#: src/i18n/cli.md:49
+msgid "Detected Patterns"
+msgstr ""
+
+#: src/i18n/cli.md:51
+msgid "The scanner detects these UI component patterns:"
+msgstr ""
+
+#: src/i18n/cli.md:53
+msgid "`Button(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:54
+msgid "`Text(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:55
+msgid "`Label(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:56
+msgid "`TextField(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:57
+msgid "`TextArea(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:58
+msgid "`Tab(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:59
+msgid "`NavigationTitle(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:60
+msgid "`SectionHeader(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:61
+msgid "`SecureField(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:62
+msgid "`Alert(\"string\")`"
+msgstr ""
+
+#: src/i18n/cli.md:63
+msgid "`t(\"string\")` (explicit i18n API)"
+msgstr ""
+
+#: src/i18n/cli.md:65
+msgid ""
+"Both double-quoted and single-quoted strings are supported. Escaped quotes "
+"are handled correctly."
+msgstr ""
+
+#: src/i18n/cli.md:67
+msgid "Build Output"
+msgstr ""
+
+#: src/i18n/cli.md:69
+msgid "During compilation, Perry reports i18n status:"
+msgstr ""
+
+#: src/i18n/cli.md:71
+msgid ""
+"```\n"
+"  i18n: 2 locale(s) [en, de], default: en\n"
+"    Loaded locales/en.json (12 keys)\n"
+"    Loaded locales/de.json (12 keys)\n"
+"  i18n: 12 localizable string(s) detected\n"
+"  i18n warning: Missing translation for key \"Settings\" in locale \"de\"\n"
+"  i18n warning: Unused i18n key \"Old Label\" in locale \"en\"\n"
+"```"
+msgstr ""
+
+#: src/i18n/cli.md:80
+msgid "Key Registry"
+msgstr ""
+
+#: src/i18n/cli.md:82
+msgid ""
+"Perry maintains a `.perry/i18n-keys.json` file, updated on every build:"
+msgstr ""
+
+#: src/i18n/cli.md:86
+msgid "\"keys\""
+msgstr ""
+
+#: src/i18n/cli.md:87 src/i18n/cli.md:88 src/i18n/cli.md:89
+msgid "\"key\""
+msgstr ""
+
+#: src/i18n/cli.md:87 src/i18n/cli.md:88 src/i18n/cli.md:89
+msgid "\"string_idx\""
+msgstr ""
+
+#: src/i18n/cli.md:89
+msgid "\"You have {count} items\""
+msgstr ""
+
+#: src/i18n/cli.md:94
+msgid ""
+"This file serves as the source of truth for what strings exist in the "
+"codebase."
+msgstr ""
+
+#: src/updater/overview.md:3
+msgid ""
+"Ship updates to your Perry desktop app without rolling your own download + "
+"replace + relaunch flow. Two modules cooperate:"
+msgstr ""
+
+#: src/updater/overview.md:6
+msgid ""
+"**`@perry/updater`** — high-level wrapper. The 90% case: manifest fetch, "
+"semver compare, download, verify, install, relaunch, crash-loop rollback."
+msgstr ""
+
+#: src/updater/overview.md:8
+msgid ""
+"**`perry/updater`** — ambient primitives the wrapper is built on. Reach for "
+"these only when you need a custom flow (multi-channel rollouts, your own "
+"progress UI, an integration with an external supervisor)."
+msgstr ""
+
+#: src/updater/overview.md:12
+msgid ""
+"The trust model and wire format follow [Tauri's "
+"updater](https://v2.tauri.app/plugin/updater/): JSON manifest over HTTPS, "
+"SHA-256 + Ed25519 signature over the digest, atomic binary replace with a "
+"`.prev` backup, detached relaunch. Every snippet below is excerpted from "
+"[`docs/examples/updater/snippets.ts`](../../examples/updater/snippets.ts) — "
+"CI compile-links it on every PR."
+msgstr ""
+
+#: src/updater/overview.md:19
+msgid ""
+"**Desktop only.** iOS / TestFlight, Android Play Store, and sideloaded APKs "
+"own the install pipeline at the OS level — replacing your own binary at "
+"runtime is structurally impossible there. The crate still compiles on mobile"
+" targets so cross-platform code doesn't need `#ifdef`s, but the install path"
+" is a no-op. Gate updater code with `process.platform` if your app ships "
+"everywhere."
+msgstr ""
+
+#: src/updater/overview.md:26 src/system/media.md:8
+#: src/plugins/appstore-review.md:11
+msgid "Quick start"
+msgstr ""
+
+#: src/updater/overview.md:28
+msgid ""
+"```typescript\n"
+"// import { checkForUpdate, initUpdater, markHealthy } from \"@perry/updater\"\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:32
+msgid ""
+"Drop a \"Check for updates\" handler somewhere in your menu or a periodic "
+"timer. `checkForUpdate` returns `null` when up to date or when the manifest "
+"has no entry for the current platform."
+msgstr ""
+
+#: src/updater/overview.md:36
+msgid ""
+"```typescript\n"
+"// Pseudocode using @perry/updater's wrapper. Drop into a \"Check for updates\"\n"
+"// menu item or a periodic timer. The manifest URL must serve over HTTPS.\n"
+"//\n"
+"// const update = await checkForUpdate({\n"
+"//     manifestUrl: \"https://updates.example.com/myapp.json\",\n"
+"//     publicKey: \"BASE64_ED25519_PUBKEY\",\n"
+"//     currentVersion: \"1.4.0\",\n"
+"// })\n"
+"//\n"
+"// if (update !== null) {\n"
+"//     console.log(`v${update.version} is available`)\n"
+"//     console.log(update.notes)\n"
+"//\n"
+"//     await update.download((downloaded, total) => {\n"
+"//         const pct = Math.round((downloaded / total) * 100)\n"
+"//         console.log(`downloading: ${pct}%`)\n"
+"//     })\n"
+"//\n"
+"//     await update.installAndRelaunch()  // never returns — process.exit inside\n"
+"// }\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:59
+msgid ""
+"Call `initUpdater()` once near the top of `main()`. It handles boot-time "
+"crash-loop detection: if the new binary you just installed crashes during "
+"boot more than `crashLoopThreshold` times, the wrapper restores the previous"
+" version and exits so the OS / launcher restarts you on the rollback."
+msgstr ""
+
+#: src/updater/overview.md:64
+msgid ""
+"```typescript\n"
+"// Boot-time: detect a crash-looping new install and roll back. Call this\n"
+"// near the top of `main()`, right after process initialization.\n"
+"//\n"
+"// await initUpdater({\n"
+"//     autoRollback:       true,    // default\n"
+"//     healthCheckMs:      60_000,  // clear sentinel after this many ms alive\n"
+"//     crashLoopThreshold: 2,       // restarts before rollback fires\n"
+"// })\n"
+"//\n"
+"// // Optional: tell the updater explicitly that this version is healthy\n"
+"// // (e.g. after a successful login or migration finished).\n"
+"// // markHealthy()\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:79
+msgid "Manifest"
+msgstr ""
+
+#: src/updater/overview.md:81
+msgid ""
+"Serve a single JSON file over HTTPS. One entry per `<os>-<arch>` you publish"
+" for; clients ignore entries that don't match their platform."
+msgstr ""
+
+#: src/updater/overview.md:84
+msgid ""
+"```typescript\n"
+"// The manifest is a single JSON file you serve over HTTPS. Each platform\n"
+"// triple is `<os>-<arch>` (darwin-aarch64, darwin-x86_64, windows-x86_64,\n"
+"// linux-x86_64, linux-aarch64). The wrapper picks the entry matching the\n"
+"// running host and ignores the rest.\n"
+"//\n"
+"// {\n"
+"//   \"schemaVersion\": 1,\n"
+"//   \"version\": \"1.4.0\",\n"
+"//   \"pubDate\": \"2026-04-27T10:00:00Z\",\n"
+"//   \"notes\": \"Bug fixes and performance improvements\",\n"
+"//   \"platforms\": {\n"
+"//     \"darwin-aarch64\": {\n"
+"//       \"url\":       \"https://example.com/app-1.4.0-darwin-aarch64.bin\",\n"
+"//       \"sha256\":    \"0123456789abcdef...\",\n"
+"//       \"signature\": \"base64sig==\",\n"
+"//       \"size\":      12345678\n"
+"//     }\n"
+"//   }\n"
+"// }\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:106
+msgid "Meaning"
+msgstr ""
+
+#: src/updater/overview.md:108
+msgid "`schemaVersion`"
+msgstr ""
+
+#: src/updater/overview.md:108
+msgid ""
+"`1` (legacy, digest-only signature) or `2` (recommended — version-bound "
+"signature; see below)."
+msgstr ""
+
+#: src/updater/overview.md:109 src/cli/perry-toml.md:117
+msgid "`version`"
+msgstr ""
+
+#: src/updater/overview.md:109
+msgid "Semver string of the offered version (e.g. `\"1.4.0\"`)."
+msgstr ""
+
+#: src/updater/overview.md:110
+msgid "`pubDate`"
+msgstr ""
+
+#: src/updater/overview.md:110
+msgid "ISO-8601 timestamp the build was published — surfaced as metadata."
+msgstr ""
+
+#: src/updater/overview.md:111
+msgid "`notes`"
+msgstr ""
+
+#: src/updater/overview.md:111
+msgid "Markdown release notes shown to the user."
+msgstr ""
+
+#: src/updater/overview.md:112
+msgid "`platforms.<os>-<arch>.url`"
+msgstr ""
+
+#: src/updater/overview.md:112
+msgid "Direct download URL (HTTPS)."
+msgstr ""
+
+#: src/updater/overview.md:113
+msgid "`platforms.<os>-<arch>.sha256`"
+msgstr ""
+
+#: src/updater/overview.md:113
+msgid "Lowercase hex SHA-256 of the binary."
+msgstr ""
+
+#: src/updater/overview.md:114
+msgid "`platforms.<os>-<arch>.signature`"
+msgstr ""
+
+#: src/updater/overview.md:114
+msgid ""
+"Base64 Ed25519 signature. v1: over the raw 32-byte digest. v2: over `digest "
+"\\|\\| version_utf8`."
+msgstr ""
+
+#: src/updater/overview.md:115
+msgid "`platforms.<os>-<arch>.size`"
+msgstr ""
+
+#: src/updater/overview.md:115
+msgid "Byte length of the binary — used for progress reporting."
+msgstr ""
+
+#: src/updater/overview.md:117
+msgid "Platform keys are canonical Rust-style triples:"
+msgstr ""
+
+#: src/updater/overview.md:119
+msgid "Host"
+msgstr ""
+
+#: src/updater/overview.md:119
+msgid "Triple"
+msgstr ""
+
+#: src/updater/overview.md:121
+msgid "Apple Silicon mac"
+msgstr ""
+
+#: src/updater/overview.md:121
+msgid "`darwin-aarch64`"
+msgstr ""
+
+#: src/updater/overview.md:122
+msgid "Intel mac"
+msgstr ""
+
+#: src/updater/overview.md:122
+msgid "`darwin-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:123
+msgid "Windows 10/11 64-bit"
+msgstr ""
+
+#: src/updater/overview.md:123
+msgid "`windows-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:124
+msgid "Linux 64-bit"
+msgstr ""
+
+#: src/updater/overview.md:124
+msgid "`linux-x86_64`"
+msgstr ""
+
+#: src/updater/overview.md:125
+msgid "Linux ARM64"
+msgstr ""
+
+#: src/updater/overview.md:125
+msgid "`linux-aarch64`"
+msgstr ""
+
+#: src/updater/overview.md:127
+msgid "Trust model"
+msgstr ""
+
+#: src/updater/overview.md:129
+msgid "`schemaVersion: 2` (recommended) — version-bound signature"
+msgstr ""
+
+#: src/updater/overview.md:131
+msgid ""
+"The signed payload is `SHA256(binary) || version_utf8` — the 32-byte raw "
+"digest concatenated with the UTF-8 bytes of the version string. This binds "
+"the version into the signature, so an on-path attacker can't replay a "
+"previously-signed older binary as a \"new version\" by serving a manifest "
+"that pairs the old binary's URL + signature with a higher version number "
+"([\\#229](https://github.com/PerryTS/perry/issues/229))."
+msgstr ""
+
+#: src/updater/overview.md:138
+msgid "Sign side:"
+msgstr ""
+
+#: src/updater/overview.md:140
+msgid ""
+"```text\n"
+"payload = sha256(binary).digest() + version.encode(\"utf-8\")\n"
+"signature = ed25519_sign(secret_key, payload)  # 64-byte signature\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:145
+msgid "Verification on the client:"
+msgstr ""
+
+#: src/updater/overview.md:147
+msgid ""
+"SHA-256 the downloaded file. Reject if it doesn't match `manifest.sha256`."
+msgstr ""
+
+#: src/updater/overview.md:148
+msgid ""
+"Build the v2 payload (`digest || version_utf8`) using `manifest.version`."
+msgstr ""
+
+#: src/updater/overview.md:149
+msgid "Ed25519-verify the signature against the bundled public key."
+msgstr ""
+
+#: src/updater/overview.md:150
+msgid "Reject on any decode error, size mismatch, or signature failure."
+msgstr ""
+
+#: src/updater/overview.md:152
+msgid ""
+"If an attacker swaps the manifest's `version` field while keeping the old "
+"`signature`, step 3 fails because the signature was made over the _original_"
+" version. If they swap both `version` and `signature` (using a previously-"
+"signed older binary), step 1 fails because `sha256` of the older binary "
+"doesn't match the rewritten higher-version label either — every plausible "
+"attack on the version metadata invalidates something."
+msgstr ""
+
+#: src/updater/overview.md:160
+msgid "`schemaVersion: 1` (legacy, digest-only)"
+msgstr ""
+
+#: src/updater/overview.md:162
+msgid ""
+"The signed payload is the raw 32-byte digest only. **This shape is "
+"vulnerable to old-binary replay** "
+"([\\#229](https://github.com/PerryTS/perry/issues/229)): an on-path attacker"
+" can serve a manifest claiming a higher version while pointing at a "
+"previously-signed older binary, and signature verification still passes "
+"because the version isn't bound into the signature. Existing v1 manifests "
+"stay supported by the client during migration; new deployments should use "
+"v2."
+msgstr ""
+
+#: src/updater/overview.md:170
+msgid "Migration"
+msgstr ""
+
+#: src/updater/overview.md:172
+msgid ""
+"`@perry/updater` v0.5.391+ accepts both `schemaVersion: 1` and "
+"`schemaVersion: 2`. Bumping your manifest from 1 → 2 requires:"
+msgstr ""
+
+#: src/updater/overview.md:175
+msgid ""
+"Update sign-side tooling to compute the new payload (`sha256(binary) + "
+"version.encode(\"utf-8\")`) and sign that."
+msgstr ""
+
+#: src/updater/overview.md:177
+msgid "Bump `schemaVersion` in the manifest from `1` to `2`."
+msgstr ""
+
+#: src/updater/overview.md:178
+msgid ""
+"Make sure all deployed clients are running a perry-updater version that "
+"knows about v2 BEFORE you publish a v2 manifest. Older clients reject "
+"`schemaVersion: 2` with an `unsupported manifest schemaVersion` error. "
+"(Plan: ship a perry-updater bump with v2 support to your users via a v1 "
+"manifest first; once they're on the v2-aware client, the next manifest can "
+"be v2.)"
+msgstr ""
+
+#: src/updater/overview.md:185
+msgid "Keypair"
+msgstr ""
+
+#: src/updater/overview.md:187
+msgid ""
+"You generate the keypair once and bake the public key into your app at build"
+" time; the secret key stays on a release-signing machine alongside the rest "
+"of your build artifacts. Compromise of the manifest server alone never lets "
+"an attacker push a binary your client will accept."
+msgstr ""
+
+#: src/updater/overview.md:192
+msgid "Sign-side CLI (v0.5.395+)"
+msgstr ""
+
+#: src/updater/overview.md:194
+msgid ""
+"`perry updater` ships three subcommands that produce v2-shape signatures "
+"without needing any custom tooling:"
+msgstr ""
+
+#: src/updater/overview.md:198
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
+msgstr ""
+
+#: src/updater/overview.md:201
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
+msgstr ""
+
+#: src/updater/overview.md:219
+msgid ""
+"Compose a final manifest by piping `sign` output through `jq` for each "
+"asset, then merging into the per-platform layout shown above. CI tip: pass "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so"
+" the secret can come from a repository secret without ever hitting the "
+"worker's filesystem."
+msgstr ""
+
+#: src/updater/overview.md:225
+msgid "Install + rollback flow"
+msgstr ""
+
+#: src/updater/overview.md:227
+msgid ""
+"```text\n"
+"manifest fetch  →  semver compare  →  download to <exe>.staged\n"
+"                                          ↓\n"
+"                                      sha256 verify  →  ed25519 verify\n"
+"                                          ↓\n"
+"                                      arm sentinel (state: \"armed\")\n"
+"                                          ↓\n"
+"                                      install:  rename <exe> → <exe>.prev\n"
+"                                                rename <exe>.staged → <exe>\n"
+"                                                chmod +x   (Unix only)\n"
+"                                          ↓\n"
+"                                      detached relaunch  →  process.exit(0)\n"
+"\n"
+"next boot  →  initUpdater() reads sentinel\n"
+"                  ├── healthCheckMs alive  → clearSentinel  (success)\n"
+"                  ├── graceful exit         → clearSentinel  (success)\n"
+"                  └── restartCount ≥ N      → performRollback + exit\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:246
+msgid ""
+"`installUpdate` is atomic where the OS lets us be: POSIX `rename(2)` on the "
+"same filesystem, NTFS rename-while-open (the PE loader opens with "
+"`FILE_SHARE_DELETE` so Windows tolerates this since Vista), and Linux's "
+"mmap'd-inode-stays-alive semantics. If the staging directory ends up on a "
+"different filesystem (a separate mount for `/tmp`, for instance) the rename "
+"falls back to copy + remove, which has a small non-atomic window."
+msgstr ""
+
+#: src/updater/overview.md:253
+msgid "The sentinel is a JSON file at a per-OS user-writable path:"
+msgstr ""
+
+#: src/updater/overview.md:255
+msgid "Default location"
+msgstr ""
+
+#: src/updater/overview.md:257
+msgid "`~/Library/Application Support/<app>/updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:258
+msgid "`%LOCALAPPDATA%\\<app>\\updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:259
+msgid "`$XDG_STATE_HOME/<app>/updater.sentinel`"
+msgstr ""
+
+#: src/updater/overview.md:261
+msgid ""
+"`<app>` comes from the `PERRY_APP_ID` environment variable, falling back to "
+"the basename of the running exe. **Set `PERRY_APP_ID` in your launch "
+"environment** so the sentinel path stays stable across rename / relocation "
+"of the binary."
+msgstr ""
+
+#: src/updater/overview.md:266
+msgid "Low-level primitives"
+msgstr ""
+
+#: src/updater/overview.md:268
+msgid ""
+"Use these when the high-level wrapper doesn't fit — custom progress UI, a "
+"multi-channel manifest, an external supervisor that handles restarts, etc."
+msgstr ""
+
+#: src/updater/overview.md:271
+msgid ""
+"```typescript\n"
+"import {\n"
+"    compareVersions,\n"
+"    verifyHash,\n"
+"    verifySignature,\n"
+"    computeFileSha256,\n"
+"    writeSentinel,\n"
+"    readSentinel,\n"
+"    clearSentinel,\n"
+"    getExePath,\n"
+"    getBackupPath,\n"
+"    getSentinelPath,\n"
+"    installUpdate,\n"
+"    performRollback,\n"
+"    relaunch,\n"
+"} from \"perry/updater\"\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:289
+msgid "`compareVersions(current, candidate)`"
+msgstr ""
+
+#: src/updater/overview.md:291
+msgid ""
+"Returns `-1` (update available), `0` (equal), `1` (downgrade — never "
+"offered), or `-2` (parse error). Prerelease tags handled per the semver "
+"spec."
+msgstr ""
+
+#: src/updater/overview.md:294
+msgid ""
+"```typescript\n"
+"// Returns -1 (current < candidate, update available), 0 (equal),\n"
+"// 1 (current > candidate, never offered as an update), -2 (parse error).\n"
+"const cmp = compareVersions(\"1.4.0\", \"1.4.1\")\n"
+"if (cmp === -1) {\n"
+"    console.log(\"update available\")\n"
+"} else if (cmp === 0) {\n"
+"    console.log(\"up to date\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:305
+msgid "`verifyHash` / `verifySignature` / `computeFileSha256`"
+msgstr ""
+
+#: src/updater/overview.md:307
+msgid ""
+"```typescript\n"
+"// SHA-256 + Ed25519 verification of a binary on disk. The signed payload is\n"
+"// the *raw 32-byte SHA-256 digest* — not the hex string and not the file\n"
+"// bytes themselves. Sign side: `sha256(file) | ed25519_sign(secret_key)`.\n"
+"const stagedPath = getExePath() + \".staged\"\n"
+"const expectedHex = \"0123456789abcdef...\" // from your manifest\n"
+"const sigB64 = \"...base64...\"             // 64-byte signature, base64\n"
+"const pubB64 = \"...base64...\"             // 32-byte public key, base64\n"
+"\n"
+"if (verifyHash(stagedPath, expectedHex) !== 1) {\n"
+"    const actual = computeFileSha256(stagedPath)\n"
+"    console.error(`hash mismatch — expected ${expectedHex}, got ${actual}`)\n"
+"}\n"
+"if (verifySignature(stagedPath, sigB64, pubB64) !== 1) {\n"
+"    console.error(\"signature verification failed\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:325
+msgid ""
+"`verifyHash` and `verifySignature` return `1` on success, `0` on any failure"
+" (file missing, decode error, mismatch). `computeFileSha256` returns the hex"
+" digest as a string, or `\"\"` on failure — useful for logging the _actual_ "
+"hash when a `verifyHash` mismatch fires."
+msgstr ""
+
+#: src/updater/overview.md:330
+msgid "`installUpdate` / `performRollback` / `relaunch`"
+msgstr ""
+
+#: src/updater/overview.md:332
+msgid ""
+"```typescript\n"
+"// `installUpdate` atomically replaces `targetPath` with `stagedPath`,\n"
+"// keeping the displaced version at `<target>.prev` for rollback.\n"
+"const target = getExePath()\n"
+"const staged = target + \".staged\"\n"
+"\n"
+"if (installUpdate(staged, target) !== 1) {\n"
+"    console.error(\"install failed\")\n"
+"} else {\n"
+"    const pid = relaunch(target)\n"
+"    if (pid < 0) {\n"
+"        console.error(\"relaunch failed; restart manually\")\n"
+"    } else {\n"
+"        // Detached child is now running the new binary — get out of its way.\n"
+"        process.exit(0)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:351
+msgid ""
+"```typescript\n"
+"// `performRollback` restores `<target>.prev` over `target` and moves the\n"
+"// current (likely-broken) target to `<target>.broken` as a safety net.\n"
+"if (performRollback(getExePath()) !== 1) {\n"
+"    console.error(\"no backup to roll back to\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:359
+msgid ""
+"`relaunch` returns the child PID, or `-1` on failure. The new process is "
+"fully detached (`setsid` on Unix, `DETACHED_PROCESS | "
+"CREATE_NEW_PROCESS_GROUP` on Windows) so closing the current process doesn't"
+" take it down."
+msgstr ""
+
+#: src/updater/overview.md:363
+msgid "Path resolution"
+msgstr ""
+
+#: src/updater/overview.md:365
+msgid ""
+"```typescript\n"
+"// Resolved per platform. macOS walks up to the surrounding `.app` bundle;\n"
+"// Linux honors $APPIMAGE; Windows / bare ELF returns the canonical exe.\n"
+"console.log(\"running exe   :\", getExePath())\n"
+"console.log(\"backup target :\", getBackupPath())\n"
+"// Sentinel path is keyed off PERRY_APP_ID — set this env var so the path\n"
+"// stays stable across rename/relocation of the binary.\n"
+"console.log(\"sentinel path :\", getSentinelPath())\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:375
+msgid "`getExePath()` accounts for platform quirks:"
+msgstr ""
+
+#: src/updater/overview.md:377
+msgid ""
+"**macOS**: walks up to the surrounding `.app` bundle if applicable — the "
+"`.app` directory is the codesign unit, so that's what you replace."
+msgstr ""
+
+#: src/updater/overview.md:379
+msgid ""
+"**Linux**: honors `$APPIMAGE` when set. The AppImage runtime points "
+"`current_exe()` inside a read-only squashfs mount; the real target to "
+"replace is the AppImage file itself."
+msgstr ""
+
+#: src/updater/overview.md:382
+msgid ""
+"**Windows / bare ELF / bare Mach-O**: returns the canonicalized exe path."
+msgstr ""
+
+#: src/updater/overview.md:384
+msgid "Sentinel"
+msgstr ""
+
+#: src/updater/overview.md:386
+msgid ""
+"```typescript\n"
+"// Low-level sentinel API. Most apps use `initUpdater()` from @perry/updater\n"
+"// instead of touching this directly, but it's here when you need it (custom\n"
+"// rollback policies, multi-process apps, integration with another supervisor).\n"
+"const sentinelPath = getSentinelPath()\n"
+"writeSentinel(sentinelPath, JSON.stringify({ state: \"armed\", restartCount: 0 }))\n"
+"const raw = readSentinel(sentinelPath)\n"
+"if (raw) {\n"
+"    const state = JSON.parse(raw) as { state: string; restartCount: number }\n"
+"    if (state.restartCount >= 2) {\n"
+"        // looks like a crash loop — recover or roll back\n"
+"        clearSentinel(sentinelPath)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/updater/overview.md:402
+msgid ""
+"`writeSentinel` is atomic (tmp file + rename), creates the parent directory "
+"if needed, and returns `1` on success / `0` on any IO error. `clearSentinel`"
+" is idempotent — returns `1` whether the file existed or not."
+msgstr ""
+
+#: src/updater/overview.md:406
+msgid "What's not here (yet)"
+msgstr ""
+
+#: src/updater/overview.md:408
+msgid ""
+"**UI primitives** — a \"Restart now\" modal with `ProgressView` belongs "
+"inside `perry/ui` proper rather than the updater package. Tracked as a "
+"follow-up."
+msgstr ""
+
+#: src/updater/overview.md:411
+msgid ""
+"**Privileged install** for system-wide locations (`/Applications`, `Program "
+"Files`). The current install path only handles user-writable locations "
+"(`~/Applications`, `~/.local/bin`, `%LOCALAPPDATA%`). UAC / `SMJobBless` is "
+"a separate concern."
+msgstr ""
+
+#: src/updater/overview.md:415
+msgid ""
+"**Delta updates** (bsdiff), **multi-channel** (stable / beta), **staged "
+"rollouts**."
+msgstr ""
+
+#: src/updater/overview.md:417
+msgid ""
+"**Notarization / code-signing** during install. Binaries are expected to "
+"arrive already signed; the updater doesn't try to be a notarization tool."
+msgstr ""
+
+#: src/updater/overview.md:420
+msgid "Testing your update flow"
+msgstr ""
+
+#: src/updater/overview.md:422
+msgid ""
+"The crate ships smoke-test scripts that exercise verify → install → relaunch"
+" end-to-end against a real Perry binary:"
+msgstr ""
+
+#: src/updater/overview.md:425
+msgid "**Unix**: `scripts/smoke_updater.sh`"
+msgstr ""
+
+#: src/updater/overview.md:426
+msgid "**Windows**: `scripts/smoke_updater.ps1`"
+msgstr ""
+
+#: src/updater/overview.md:428
+msgid ""
+"Both spin up a tiny HTTP server, build a v1.0.0 binary that drives the "
+"update flow, build a v1.0.1 binary that proves it ran, and verify the "
+"relaunch handed off correctly. Run them locally before shipping a release "
+"that depends on the updater wiring."
+msgstr ""
+
+#: src/updater/overview.md:435
+msgid "[System APIs](../system/overview.md) — the rest of `perry/system`"
+msgstr ""
+
+#: src/updater/overview.md:436
+msgid ""
+"[HTTP & Networking](../stdlib/http.md) — `fetch()` is what the wrapper uses "
+"internally"
+msgstr ""
+
+#: src/updater/overview.md:438
+msgid ""
+"[Cryptography](../stdlib/crypto.md) — Ed25519 sign / verify primitives for "
+"tooling that builds the manifest"
+msgstr ""
+
+#: src/system/overview.md:1
+msgid "System APIs Overview"
+msgstr ""
+
+#: src/system/overview.md:3
+msgid ""
+"The `perry/system` module provides access to platform-native system "
+"features: preferences, secure storage, notifications, dark-mode detection, "
+"audio capture, and app introspection. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links the file on every PR."
+msgstr ""
+
+#: src/system/overview.md:9
+msgid ""
+"```typescript\n"
+"// import {\n"
+"//     openURL, isDarkMode,\n"
+"//     preferencesGet, preferencesSet,\n"
+"//     keychainSave, keychainGet, keychainDelete,\n"
+"//     notificationSend,\n"
+"//     audioStart, audioStop, audioGetLevel, audioGetPeak, audioGetWaveform,\n"
+"// } from \"perry/system\"\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:19
+msgid "Available APIs"
+msgstr ""
+
+#: src/system/overview.md:23
+msgid "`openURL(url)`"
+msgstr ""
+
+#: src/system/overview.md:23
+msgid "Open URL in default browser/app"
+msgstr ""
+
+#: src/system/overview.md:23 src/system/overview.md:24
+#: src/system/overview.md:25 src/system/overview.md:26
+#: src/system/overview.md:27 src/system/overview.md:29
+#: src/system/overview.md:30 src/system/overview.md:31
+#: src/system/overview.md:32 src/system/overview.md:36
+#: src/system/overview.md:37 src/system/overview.md:38
+msgid "All"
+msgstr ""
+
+#: src/system/overview.md:24
+msgid "`isDarkMode()`"
+msgstr ""
+
+#: src/system/overview.md:24
+msgid "Check system dark mode"
+msgstr ""
+
+#: src/system/overview.md:25
+msgid "`getDeviceIdiom()`"
+msgstr ""
+
+#: src/system/overview.md:25
+msgid "`\"phone\"`, `\"pad\"`, `\"mac\"`, `\"tv\"`, …"
+msgstr ""
+
+#: src/system/overview.md:26
+msgid "`getDeviceModel()`"
+msgstr ""
+
+#: src/system/overview.md:26
+msgid "Device model identifier (e.g. `\"iPhone13,4\"`)"
+msgstr ""
+
+#: src/system/overview.md:27
+msgid "`preferencesSet(key, value)`"
+msgstr ""
+
+#: src/system/overview.md:27
+msgid "Store a preference (string or number)"
+msgstr ""
+
+#: src/system/overview.md:28
+msgid "`preferencesGet(key)`"
+msgstr ""
+
+#: src/system/overview.md:28
+msgid "Read a preference (returns \\`string"
+msgstr ""
+
+#: src/system/overview.md:29
+msgid "`keychainSave(key, value)`"
+msgstr ""
+
+#: src/system/overview.md:29
+msgid "Secure storage write"
+msgstr ""
+
+#: src/system/overview.md:30
+msgid "`keychainGet(key)`"
+msgstr ""
+
+#: src/system/overview.md:30
+msgid "Secure storage read"
+msgstr ""
+
+#: src/system/overview.md:31
+msgid "`keychainDelete(key)`"
+msgstr ""
+
+#: src/system/overview.md:31
+msgid "Secure storage remove"
+msgstr ""
+
+#: src/system/overview.md:32
+msgid "`notificationSend(title, body)`"
+msgstr ""
+
+#: src/system/overview.md:32
+msgid "Local notification"
+msgstr ""
+
+#: src/system/overview.md:33
+msgid "`notificationCancel(id)`"
+msgstr ""
+
+#: src/system/overview.md:33
+msgid "Cancel a scheduled notification"
+msgstr ""
+
+#: src/system/overview.md:33 src/system/overview.md:34
+msgid "Apple"
+msgstr ""
+
+#: src/system/overview.md:34
+msgid "`notificationOnTap(cb)`"
+msgstr ""
+
+#: src/system/overview.md:34
+msgid "Handle banner taps"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "`notificationRegisterRemote(cb)` / `notificationOnReceive(cb)`"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "Push (APNs)"
+msgstr ""
+
+#: src/system/overview.md:35
+msgid "iOS, macOS"
+msgstr ""
+
+#: src/system/overview.md:36
+msgid "`audioStart()` / `audioStop()`"
+msgstr ""
+
+#: src/system/overview.md:36
+msgid "Microphone capture"
+msgstr ""
+
+#: src/system/overview.md:37
+msgid "`audioGetLevel()` / `audioGetPeak()`"
+msgstr ""
+
+#: src/system/overview.md:37
+msgid "RMS / peak amplitude (`0..1`)"
+msgstr ""
+
+#: src/system/overview.md:38
+msgid "`audioGetWaveform(n)`"
+msgstr ""
+
+#: src/system/overview.md:38
+msgid "Recent waveform samples for visualization"
+msgstr ""
+
+#: src/system/overview.md:40
+msgid ""
+"**Clipboard** lives in `perry/ui` (not `perry/system`): import "
+"`clipboardRead` and `clipboardWrite` from there."
+msgstr ""
+
+#: src/system/overview.md:45 src/system/other.md:29
+msgid ""
+"```typescript\n"
+"if (isDarkMode()) {\n"
+"    console.log(\"Dark mode is active\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:51 src/system/preferences.md:14
+msgid ""
+"```typescript\n"
+"// Strings and numbers round-trip natively — no manual stringification needed.\n"
+"preferencesSet(\"theme\", \"dark\")\n"
+"preferencesSet(\"font-size\", 14)\n"
+"\n"
+"const theme = preferencesGet(\"theme\")        // string | number | undefined\n"
+"const fontSize = preferencesGet(\"font-size\") // → 14 (number)\n"
+"\n"
+"if (typeof theme === \"string\") {\n"
+"    console.log(`saved theme: ${theme}`)\n"
+"}\n"
+"if (typeof fontSize === \"number\") {\n"
+"    console.log(`saved font-size: ${fontSize}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:67 src/system/other.md:14
+msgid ""
+"```typescript\n"
+"openURL(\"https://example.com\")\n"
+"```"
+msgstr ""
+
+#: src/system/overview.md:73
+msgid "[Preferences](preferences.md)"
+msgstr ""
+
+#: src/system/overview.md:74
+msgid "[Keychain](keychain.md)"
+msgstr ""
+
+#: src/system/overview.md:75
+msgid "[Notifications](notifications.md)"
+msgstr ""
+
+#: src/system/overview.md:76
+msgid "[Audio Capture](audio.md)"
+msgstr ""
+
+#: src/system/overview.md:77
+msgid "[Other](other.md)"
+msgstr ""
+
+#: src/system/preferences.md:3
+msgid ""
+"Store and retrieve user preferences using the platform's native storage. "
+"Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/preferences.md:10
+msgid ""
+"`preferencesSet(key, value)` accepts strings **or** numbers and round-trips "
+"them natively (NSUserDefaults / GSettings / Registry preserve the original "
+"type). `preferencesGet(key)` returns `string | number | undefined`:"
+msgstr ""
+
+#: src/system/preferences.md:30 src/system/keychain.md:21
+msgid "Platform Storage"
+msgstr ""
+
+#: src/system/preferences.md:32 src/system/keychain.md:23
+#: src/system/notifications.md:60 src/system/media.md:84
+msgid "Backend"
+msgstr ""
+
+#: src/system/preferences.md:34 src/system/preferences.md:35
+msgid "NSUserDefaults"
+msgstr ""
+
+#: src/system/preferences.md:36
+msgid "SharedPreferences"
+msgstr ""
+
+#: src/system/preferences.md:37
+msgid "Windows Registry"
+msgstr ""
+
+#: src/system/preferences.md:38
+msgid "GSettings / file-based"
+msgstr ""
+
+#: src/system/preferences.md:39
+msgid "localStorage"
+msgstr ""
+
+#: src/system/preferences.md:41
+msgid ""
+"Preferences persist across app launches. They are not encrypted — use "
+"[Keychain](keychain.md) for sensitive data."
+msgstr ""
+
+#: src/system/preferences.md:46 src/system/notifications.md:74
+msgid "[Keychain](keychain.md) — Secure storage"
+msgstr ""
+
+#: src/system/preferences.md:47 src/system/keychain.md:39
+#: src/system/notifications.md:76 src/system/audio.md:74
+#: src/system/media.md:245 src/system/other.md:70
+msgid "[Overview](overview.md) — All system APIs"
+msgstr ""
+
+#: src/system/keychain.md:3
+msgid ""
+"Securely store sensitive data like tokens, passwords, and API keys using the"
+" platform's secure storage. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/keychain.md:10
+msgid ""
+"```typescript\n"
+"keychainSave(\"api_token\", \"sk-...\")\n"
+"const token = keychainGet(\"api_token\")\n"
+"keychainDelete(\"api_token\")\n"
+"console.log(`token length: ${token.length}`)\n"
+"```"
+msgstr ""
+
+#: src/system/keychain.md:17
+msgid ""
+"The free-function API is `keychainSave(key, value)`, `keychainGet(key)` "
+"(returns the stored string, or an empty string if the key isn't present), "
+"and `keychainDelete(key)`."
+msgstr ""
+
+#: src/system/keychain.md:25 src/system/keychain.md:26
+msgid "Security.framework (Keychain)"
+msgstr ""
+
+#: src/system/keychain.md:27
+msgid "Android Keystore"
+msgstr ""
+
+#: src/system/keychain.md:28
+msgid "Windows Credential Manager (CredWrite/CredRead/CredDelete)"
+msgstr ""
+
+#: src/system/keychain.md:29
+msgid "libsecret"
+msgstr ""
+
+#: src/system/keychain.md:30
+msgid "localStorage (not truly secure)"
+msgstr ""
+
+#: src/system/keychain.md:32
+msgid ""
+"**Web**: The web platform uses `localStorage`, which is not encrypted. For "
+"web apps handling sensitive data, consider server-side storage instead."
+msgstr ""
+
+#: src/system/keychain.md:37
+msgid "[Preferences](preferences.md) — Non-sensitive preferences"
+msgstr ""
+
+#: src/system/keychain.md:38
+msgid "[Notifications](notifications.md) — Local notifications"
+msgstr ""
+
+#: src/system/notifications.md:3
+msgid ""
+"Send local notifications using the platform's notification system. Every "
+"snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/notifications.md:8
+msgid "Sending a notification"
+msgstr ""
+
+#: src/system/notifications.md:10
+msgid ""
+"```typescript\n"
+"notificationSend(\"Build complete\", \"All targets compiled in 4.2s.\")\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:14
+msgid "Reacting to a tap"
+msgstr ""
+
+#: src/system/notifications.md:16
+msgid ""
+"```typescript\n"
+"notificationOnTap((id: string, action?: string) => {\n"
+"    console.log(`tapped notification ${id}; action=${action ?? \"(default)\"}`)\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:22
+msgid ""
+"`action` is the action-button identifier when the user picks a button, or "
+"`undefined` for the default banner tap."
+msgstr ""
+
+#: src/system/notifications.md:25
+msgid "Cancelling a scheduled notification"
+msgstr ""
+
+#: src/system/notifications.md:27
+msgid ""
+"```typescript\n"
+"notificationCancel(\"daily-reminder\")\n"
+"```"
+msgstr ""
+
+#: src/system/notifications.md:31
+msgid ""
+"`notificationCancel(id)` is a no-op if no scheduled notification with that "
+"id exists."
+msgstr ""
+
+#: src/system/notifications.md:34
+msgid "Push notifications (APNs / Firebase)"
+msgstr ""
+
+#: src/system/notifications.md:46
+msgid ""
+"`notificationRegisterRemote(cb)` fires once when the OS returns a device "
+"token — on Apple platforms the token is the canonical uppercase hex string "
+"APNs expects. `notificationOnReceive(cb)` runs whenever a remote payload "
+"arrives while the app is foregrounded; the payload is the APNs `aps` "
+"userInfo dictionary (or equivalent platform shape) converted to a plain "
+"object."
+msgstr ""
+
+#: src/system/notifications.md:52
+msgid ""
+"Requires the relevant platform capability (APNs entitlement on iOS/macOS, "
+"Firebase Messaging on Android — wired via JNI through "
+"`PerryFirebaseMessagingService`, see "
+"[\\#98](https://github.com/PerryTS/perry/issues/98)). No-op on platforms "
+"without a push pipeline (tvOS, visionOS, watchOS, GTK4, Windows, Web)."
+msgstr ""
+
+#: src/system/notifications.md:58
+msgid "Platform Implementation"
+msgstr ""
+
+#: src/system/notifications.md:62 src/system/notifications.md:63
+msgid "UNUserNotificationCenter"
+msgstr ""
+
+#: src/system/notifications.md:64
+msgid "NotificationManager"
+msgstr ""
+
+#: src/system/notifications.md:65
+msgid "Toast notifications"
+msgstr ""
+
+#: src/system/notifications.md:66
+msgid "GNotification"
+msgstr ""
+
+#: src/system/notifications.md:67
+msgid "Web Notification API"
+msgstr ""
+
+#: src/system/notifications.md:69
+msgid ""
+"**Permissions**: On macOS, iOS, and Web, the user may need to grant "
+"notification permissions. On first use, the system will prompt "
+"automatically."
+msgstr ""
+
+#: src/system/notifications.md:75
+msgid "[Other](other.md) — Additional system APIs"
+msgstr ""
+
+#: src/system/audio.md:3
+msgid ""
+"The `perry/system` module provides real-time audio capture from the device "
+"microphone, with A-weighted dB(A) level metering and waveform sampling — "
+"everything needed to build a sound meter, audio visualizer, or voice-level "
+"indicator. Every snippet below is excerpted from "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) — CI"
+" links it on every PR."
+msgstr ""
+
+#: src/system/audio.md:10
+msgid ""
+"```typescript\n"
+"const ok = audioStart() // 1 on success, 0 on failure\n"
+"if (ok === 1) {\n"
+"    const level = audioGetLevel()           // 0..1\n"
+"    const peak = audioGetPeak()             // 0..1\n"
+"    const waveform = audioGetWaveform(64)   // sample-count\n"
+"    console.log(`level=${level} peak=${peak} waveform=${waveform}`)\n"
+"    audioStop()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/audio.md:23
+msgid "`audioStart()`"
+msgstr ""
+
+#: src/system/audio.md:25
+msgid ""
+"Start capturing audio from the device microphone. Returns `1` on success, "
+"`0` on failure (permission denied, no microphone, etc.)."
+msgstr ""
+
+#: src/system/audio.md:28
+msgid ""
+"On platforms that require permission (iOS, Android, Web), the system "
+"permission dialog is shown automatically."
+msgstr ""
+
+#: src/system/audio.md:31
+msgid "`audioStop()`"
+msgstr ""
+
+#: src/system/audio.md:33
+msgid "Stop audio capture and release the microphone."
+msgstr ""
+
+#: src/system/audio.md:35
+msgid "`audioGetLevel()`"
+msgstr ""
+
+#: src/system/audio.md:37
+msgid ""
+"Get the current A-weighted sound level (a smoothed value with a 125 ms time "
+"constant). Typical ranges:"
+msgstr ""
+
+#: src/system/audio.md:40
+msgid "~30 dB — quiet room"
+msgstr ""
+
+#: src/system/audio.md:41
+msgid "~50 dB — normal conversation"
+msgstr ""
+
+#: src/system/audio.md:42
+msgid "~70 dB — busy street"
+msgstr ""
+
+#: src/system/audio.md:43
+msgid "~90 dB — loud music"
+msgstr ""
+
+#: src/system/audio.md:44
+msgid "~110+ dB — dangerously loud"
+msgstr ""
+
+#: src/system/audio.md:46
+msgid "`audioGetPeak()`"
+msgstr ""
+
+#: src/system/audio.md:48
+msgid ""
+"Get the current peak sample amplitude (`0.0`–`1.0`). Useful for simple level"
+" indicators without dB conversion."
+msgstr ""
+
+#: src/system/audio.md:51
+msgid "`audioGetWaveform(sampleCount)`"
+msgstr ""
+
+#: src/system/audio.md:53
+msgid ""
+"Get recent waveform samples for visualization. Pass the number of samples "
+"you want; the runtime returns the most recent N readings from its internal "
+"ring buffer. Useful for drawing waveform displays or level history charts."
+msgstr ""
+
+#: src/system/audio.md:57
+msgid "Platform Implementations"
+msgstr ""
+
+#: src/system/audio.md:59
+msgid "Audio Backend"
+msgstr ""
+
+#: src/system/audio.md:59
+msgid "Permissions"
+msgstr ""
+
+#: src/system/audio.md:61
+msgid "AVAudioEngine"
+msgstr ""
+
+#: src/system/audio.md:61
+msgid "Microphone permission dialog"
+msgstr ""
+
+#: src/system/audio.md:62
+msgid "AVAudioSession + AVAudioEngine"
+msgstr ""
+
+#: src/system/audio.md:62
+msgid "System permission dialog"
+msgstr ""
+
+#: src/system/audio.md:63
+msgid "AudioRecord (JNI)"
+msgstr ""
+
+#: src/system/audio.md:63
+msgid "RECORD_AUDIO permission"
+msgstr ""
+
+#: src/system/audio.md:64
+msgid "PulseAudio (libpulse-simple)"
+msgstr ""
+
+#: src/system/audio.md:64
+msgid "None (system-level)"
+msgstr ""
+
+#: src/system/audio.md:65
+msgid "WASAPI (shared mode)"
+msgstr ""
+
+#: src/system/audio.md:65
+msgid "None"
+msgstr ""
+
+#: src/system/audio.md:66
+msgid "getUserMedia + AnalyserNode"
+msgstr ""
+
+#: src/system/audio.md:66
+msgid "Browser permission dialog"
+msgstr ""
+
+#: src/system/audio.md:68
+msgid ""
+"All platforms capture at 48 kHz mono and apply the same A-weighting filter "
+"(IEC 61672 standard, 3 cascaded biquad sections)."
+msgstr ""
+
+#: src/system/audio.md:73
+msgid "[Camera](../ui/camera.md) — Live camera preview (iOS)"
+msgstr ""
+
+#: src/system/media.md:3
+msgid ""
+"The `perry/media` module provides streaming media playback — HTTP/HTTPS "
+"audio URLs (Subsonic, Icecast, plain MP3/AAC, HLS m3u8), `file://` paths, "
+"lock-screen / Now Playing metadata, and remote-command (Siri Remote / Touch "
+"Bar / Control Center) integration."
+msgstr ""
+
+#: src/system/media.md:10
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"  createPlayer,\n"
+"  play,\n"
+"  pause,\n"
+"  setVolume,\n"
+"  onStateChange,\n"
+"  onTimeUpdate,\n"
+"  setNowPlaying,\n"
+"} from \"perry/media\";\n"
+"\n"
+"const player = createPlayer(\"https://example.com/track.mp3\");\n"
+"if (player === 0) {\n"
+"  console.error(\"createPlayer failed\");\n"
+"} else {\n"
+"  setVolume(player, 0.8);\n"
+"  setNowPlaying(player, \"Track Title\", \"Artist\", \"Album\", \"\");\n"
+"\n"
+"  onStateChange(player, (state) => console.log(\"state:\", state));\n"
+"  onTimeUpdate(player, (cur, dur) => console.log(`${cur}/${dur}s`));\n"
+"\n"
+"  play(player); // begins (or resumes) once buffered\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/system/media.md:35
+msgid "API surface"
+msgstr ""
+
+#: src/system/media.md:37
+msgid "Returns"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "`createPlayer(url)`"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "handle (1+) or `0` on failure"
+msgstr ""
+
+#: src/system/media.md:39
+msgid "HTTP/HTTPS or `file://`"
+msgstr ""
+
+#: src/system/media.md:40
+msgid "`play(handle)`"
+msgstr ""
+
+#: src/system/media.md:40 src/system/media.md:41 src/system/media.md:42
+#: src/system/media.md:43 src/system/media.md:44 src/system/media.md:45
+#: src/system/media.md:50 src/system/media.md:51 src/system/media.md:52
+#: src/system/media.md:53
+msgid "void"
+msgstr ""
+
+#: src/system/media.md:40
+msgid "Resumes if paused"
+msgstr ""
+
+#: src/system/media.md:41
+msgid "`pause(handle)`"
+msgstr ""
+
+#: src/system/media.md:41
+msgid "Position preserved"
+msgstr ""
+
+#: src/system/media.md:42
+msgid "`stop(handle)`"
+msgstr ""
+
+#: src/system/media.md:42
+msgid "Resets position to 0"
+msgstr ""
+
+#: src/system/media.md:43
+msgid "`seek(handle, seconds)`"
+msgstr ""
+
+#: src/system/media.md:44
+msgid "`setVolume(handle, volume)`"
+msgstr ""
+
+#: src/system/media.md:44
+msgid "0.0–1.0, clamped"
+msgstr ""
+
+#: src/system/media.md:45
+msgid "`setRate(handle, rate)`"
+msgstr ""
+
+#: src/system/media.md:45
+msgid "1.0 = normal; Apple supports 0.5–2.0"
+msgstr ""
+
+#: src/system/media.md:46
+msgid "`getCurrentTime(handle)`"
+msgstr ""
+
+#: src/system/media.md:46 src/system/media.md:47
+msgid "seconds"
+msgstr ""
+
+#: src/system/media.md:47
+msgid "`getDuration(handle)`"
+msgstr ""
+
+#: src/system/media.md:47
+msgid "`0` if live / loading"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "`getState(handle)`"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "`MediaState`"
+msgstr ""
+
+#: src/system/media.md:48
+msgid "See states below"
+msgstr ""
+
+#: src/system/media.md:49
+msgid "`isPlaying(handle)`"
+msgstr ""
+
+#: src/system/media.md:50
+msgid "`onStateChange(h, cb)`"
+msgstr ""
+
+#: src/system/media.md:50
+msgid "Fires on every transition"
+msgstr ""
+
+#: src/system/media.md:51
+msgid "`onTimeUpdate(h, cb)`"
+msgstr ""
+
+#: src/system/media.md:51
+msgid "~10 Hz while playing"
+msgstr ""
+
+#: src/system/media.md:52
+msgid "`setNowPlaying(h, title, artist, album, artworkUrl)`"
+msgstr ""
+
+#: src/system/media.md:52
+msgid "All strings; pass `\"\"` for unknown"
+msgstr ""
+
+#: src/system/media.md:53
+msgid "`destroy(handle)`"
+msgstr ""
+
+#: src/system/media.md:53
+msgid "Frees resources"
+msgstr ""
+
+#: src/system/media.md:55
+msgid "States"
+msgstr ""
+
+#: src/system/media.md:57
+msgid "`MediaState` is one of:"
+msgstr ""
+
+#: src/system/media.md:59
+msgid "`idle` — never started"
+msgstr ""
+
+#: src/system/media.md:60
+msgid "`loading` — buffering / fetching headers"
+msgstr ""
+
+#: src/system/media.md:61
+msgid "`ready` — first chunk decoded, ready to `play()`"
+msgstr ""
+
+#: src/system/media.md:62
+msgid "`playing` — actively rendering"
+msgstr ""
+
+#: src/system/media.md:63
+msgid "`paused` — paused (position preserved)"
+msgstr ""
+
+#: src/system/media.md:64
+msgid "`ended` — reached end of stream"
+msgstr ""
+
+#: src/system/media.md:65
+msgid "`error` — irrecoverable failure (network, codec, …)"
+msgstr ""
+
+#: src/system/media.md:67
+msgid "`ended` reliability"
+msgstr ""
+
+#: src/system/media.md:69
+msgid ""
+"`ended` is fired both from the platform's native end-of-playback signal "
+"**and** from a `currentTime ≈ duration` fallback. Per [issue #351 "
+"discussion](https://github.com/PerryTS/perry/issues/351), the native event "
+"has been historically flaky on the web / Chromecast — the same belt-and-"
+"braces is cheap to apply on every backend so a `perry/media` consumer can "
+"rely on `ended` firing once per track."
+msgstr ""
+
+#: src/system/media.md:76
+msgid ""
+"The fallback engages only after `play()` has been called and `duration` is "
+"known (live streams report `+inf`, which sanitises to `0` and disables the "
+"fallback). Window: 0.25s before duration. The native signal sets the flag "
+"first when it works; the fallback sets the same flag on the polling tick if "
+"the signal hasn't arrived."
+msgstr ""
+
+#: src/system/media.md:82
+msgid "Platform implementations"
+msgstr ""
+
+#: src/system/media.md:86
+msgid "AVPlayer + MPNowPlayingInfoCenter + MPRemoteCommandCenter"
+msgstr ""
+
+#: src/system/media.md:86 src/system/media.md:87 src/system/media.md:89
+#: src/system/media.md:90 src/system/media.md:91
+msgid "**Implemented** + lock-screen"
+msgstr ""
+
+#: src/system/media.md:87 src/system/media.md:93
+msgid "AVPlayer + AVAudioSession Playback + UIImage artwork"
+msgstr ""
+
+#: src/system/media.md:88
+msgid "AVPlayer + Siri Remote play/pause/skip"
+msgstr ""
+
+#: src/system/media.md:88
+msgid "**Implemented** + remote"
+msgstr ""
+
+#: src/system/media.md:89
+msgid "AVPlayer + UIImage artwork"
+msgstr ""
+
+#: src/system/media.md:90
+msgid "`android.media.MediaPlayer` + `MediaSessionCompat` via JNI"
+msgstr ""
+
+#: src/system/media.md:91
+msgid "GTK4 / Linux"
+msgstr ""
+
+#: src/system/media.md:91
+msgid "GStreamer `playbin` element + MPRIS D-Bus"
+msgstr ""
+
+#: src/system/media.md:92
+msgid ""
+"`Windows.Media.Playback.MediaPlayer` (WinRT) + "
+"`SystemMediaTransportControls`"
+msgstr ""
+
+#: src/system/media.md:92
+msgid "**Implemented** + Now Playing"
+msgstr ""
+
+#: src/system/media.md:93
+msgid "**Implemented** + Now Playing complication"
+msgstr ""
+
+#: src/system/media.md:94
+msgid "HarmonyOS"
+msgstr ""
+
+#: src/system/media.md:94
+msgid "`@ohos.multimedia.media.AVPlayer` via napi"
+msgstr ""
+
+#: src/system/media.md:94
+msgid ""
+"**Implemented** (lock-screen via `@ohos.multimedia.avsession` is a follow-"
+"up)"
+msgstr ""
+
+#: src/system/media.md:95
+msgid "`<audio>` element + Media Session API"
+msgstr ""
+
+#: src/system/media.md:95
+msgid ""
+"**Implemented** (`--target web`; `setNowPlaying` populates "
+"`navigator.mediaSession.metadata` + wires play / pause / seekto / "
+"seekforward / seekbackward action handlers)"
+msgstr ""
+
+#: src/system/media.md:97
+msgid ""
+"Stub platforms link cleanly against the same FFI surface — code that imports"
+" `perry/media` compiles on every target. `createPlayer` returns `0` on a "
+"stub backend so `if (player === 0)` is the canonical \"feature not available"
+" here\" check."
+msgstr ""
+
+#: src/system/media.md:102
+msgid ""
+"On Linux, `setNowPlaying` exposes the player to the desktop via MPRIS "
+"(`org.mpris.MediaPlayer2.perry-<pid>` on the session bus). GNOME Shell, KDE "
+"Plasma, `playerctl`, and any Bluetooth-headphone media-key bridge that "
+"speaks MPRIS will see the metadata and route Play / Pause / PlayPause / Stop"
+" / Seek / SetPosition back to the player. The MPRIS server is lazy-"
+"bootstrapped on the first `setNowPlaying` call so apps that don't need lock-"
+"screen integration don't pay the zbus startup cost. `Next` / `Previous` are "
+"no-ops (single-track playback model); playlists are an app-level concern."
+msgstr ""
+
+#: src/system/media.md:112
+msgid "Android — background playback"
+msgstr ""
+
+#: src/system/media.md:114
+msgid ""
+"Perry's Android backend wires `MediaSessionCompat` so the lock-screen tile, "
+"Bluetooth headset, Android Auto, and Wear OS see the metadata pushed by "
+"`setNowPlaying` and route headphone play/pause/stop/seek events back into "
+"the registered `onStateChange` closure. That covers foreground use. Apps "
+"that want playback to survive the activity being backgrounded (a podcast "
+"app, music player, etc.) need a foreground service of their own — Android "
+"will otherwise kill the audio when the process drops to the cached state. "
+"Add the following to your app's `AndroidManifest.xml` and start the service "
+"when playback begins:"
+msgstr ""
+
+#: src/system/media.md:126
+msgid "\".PerryMediaService\""
+msgstr ""
+
+#: src/system/media.md:127
+msgid "\"mediaPlayback\""
+msgstr ""
+
+#: src/system/media.md:128
+msgid "\"false\""
+msgstr ""
+
+#: src/system/media.md:129
+msgid "\"android.permission.FOREGROUND_SERVICE\""
+msgstr ""
+
+#: src/system/media.md:130
+msgid "\"android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK\""
+msgstr ""
+
+#: src/system/media.md:133
+msgid ""
+"The service implementation is app-specific — it should hold a "
+"`MediaSessionCompat.Token` (the same session Perry created), build a "
+"`Notification.MediaStyle` notification from it, and call "
+"`startForeground(...)` on `play` / `stopForeground(false)` on `pause` / "
+"`stopSelf()` on `stop`. We deliberately don't ship a default service because"
+" the notification's branding (small icon, tint, content intent) depends on "
+"the host app."
+msgstr ""
+
+#: src/system/media.md:141
+msgid "Threading notes"
+msgstr ""
+
+#: src/system/media.md:143
+msgid ""
+"The `onStateChange` and `onTimeUpdate` callbacks fire from the platform's "
+"main UI thread on every backend, so they share the same JS heap as the "
+"calling code. Implementation detail varies:"
+msgstr ""
+
+#: src/system/media.md:147
+msgid ""
+"**macOS / iOS / tvOS / visionOS** — driven by an `NSTimer` scheduled on the "
+"main run loop at 10 Hz."
+msgstr ""
+
+#: src/system/media.md:149
+msgid ""
+"**Android** — driven from `Java_com_perry_app_PerryBridge_nativePumpTick` "
+"(the existing 125 Hz UI-thread pump), throttled internally to ~10 Hz. The "
+"`prepare()` call runs on a background worker thread to avoid blocking the UI"
+" on network buffering."
+msgstr ""
+
+#: src/system/media.md:153
+msgid ""
+"**GTK4** — driven by a `glib::timeout_add_local` timer on the GLib main "
+"loop. EOS / error messages arrive on the GStreamer bus and get forwarded to "
+"per-player atomic flags via a `bus.add_watch_local` closure."
+msgstr ""
+
+#: src/system/media.md:157
+msgid ""
+"**Windows** — driven from the `GetMessageW` / `PeekMessageW` message loop "
+"after each dispatch, throttled to 100 ms by wall-clock comparison."
+msgstr ""
+
+#: src/system/media.md:159
+msgid ""
+"**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
+"directly, so `perry/media` calls record intents into Mutex-protected drain "
+"queues in `perry-runtime::media_playback`. The harvested `pages/Index.ets` "
+"(emitted by `perry-codegen-arkts` whenever the module uses `perry/media`) "
+"installs a 100 ms `setInterval` pump in `aboutToAppear` that drains the "
+"queues, dispatches each op against the matching `media.AVPlayer` instance "
+"(allocated lazily on the first `createPlayer` drain), and pushes state "
+"observations back into the runtime via the `pushMediaState(handle, state, "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / `timeUpdate`"
+" / `error` / `endOfStream` events feed the same callback path. The pump runs"
+" on the ArkTS UI thread, so closures fired by "
+"`media_playback::push_media_state` share the same arena as Perry's `main()`."
+" Lock-screen integration (`@ohos.multimedia.avsession`) is a follow-up — the"
+" runtime queues now-playing metadata via `drainNowPlaying` but the ArkTS-"
+"side AVSession dispatch is a no-op beyond a hilog line for now (tracked "
+"under issue #369)."
+msgstr ""
+
+#: src/system/media.md:177
+msgid "Now Playing on Apple platforms"
+msgstr ""
+
+#: src/system/media.md:179
+msgid ""
+"Apple's MPNowPlayingInfoCenter is a process-wide singleton — the most recent"
+" `setNowPlaying` call wins. For a single-player app (Subsonic client, "
+"podcast player) this matches user expectation. The MPRemoteCommandCenter "
+"handlers route `play` / `pause` / `togglePlayPause` events to the **first "
+"live player handle** — multi-player apps that need an explicit \"active "
+"player\" should manage that themselves."
+msgstr ""
+
+#: src/system/media.md:186
+msgid "`artworkUrl` accepts:"
+msgstr ""
+
+#: src/system/media.md:188
+msgid "`file://` paths — loaded synchronously via NSImage / UIImage"
+msgstr ""
+
+#: src/system/media.md:189
+msgid ""
+"`https://` URLs — fetched synchronously via NSData(contentsOf:) and wrapped "
+"in UIImage. The synchronous fetch is acceptable for a one-off artwork load "
+"(the MPNowPlayingInfoCenter dict is consumed synchronously when set)."
+msgstr ""
+
+#: src/system/media.md:194
+msgid "watchOS Info.plist requirements"
+msgstr ""
+
+#: src/system/media.md:196
+msgid ""
+"watchOS keeps the audio engine alive when the watch screen sleeps **only "
+"if** the app's `Info.plist` declares the `audio` background mode under "
+"`WKBackgroundModes` (the WatchKit equivalent of iOS's `UIBackgroundModes`):"
+msgstr ""
+
+#: src/system/media.md:207
+msgid ""
+"Without this entry the OS suspends the watch app a few seconds after the "
+"wrist-down gesture or screen timeout, regardless of whether AVPlayer is "
+"actively rendering. The runtime also auto-activates an `AVAudioSession` with"
+" category `Playback` on the first `createPlayer(...)` call — combined with "
+"the Info.plist entry, this is what tells watchOS the app intends to keep "
+"playing audio in the background."
+msgstr ""
+
+#: src/system/media.md:214
+msgid ""
+"The Now Playing surface on the watch face is independent from the paired "
+"iPhone's lock screen — they're separate processes with separate "
+"`MPNowPlayingInfoCenter` instances. `setNowPlaying` on watchOS targets the "
+"watch's Now Playing complication / glance screen."
+msgstr ""
+
+#: src/system/media.md:219
+msgid "Subsonic example"
+msgstr ""
+
+#: src/system/media.md:221
+msgid ""
+"```typescript,no-test\n"
+"import { createPlayer, play, setNowPlaying, onStateChange } from \"perry/media\";\n"
+"\n"
+"function streamUrl(serverUrl: string, user: string, pass: string, songId: string): string {\n"
+"  const params = new URLSearchParams({\n"
+"    u: user, p: pass, v: \"1.16.1\", c: \"PerryClient\", id: songId, format: \"mp3\",\n"
+"  });\n"
+"  return `${serverUrl}/rest/stream?${params.toString()}`;\n"
+"}\n"
+"\n"
+"const player = createPlayer(streamUrl(\"https://music.example.com\", \"alice\", \"secret\", \"12345\"));\n"
+"setNowPlaying(player, \"All These Things That I've Done\", \"The Killers\", \"Hot Fuss\",\n"
+"              \"https://music.example.com/rest/getCoverArt?id=12345&u=alice&p=secret&v=1.16.1&c=PerryClient\");\n"
+"onStateChange(player, (state) => {\n"
+"  if (state === \"ended\") {\n"
+"    // queue.next() ...\n"
+"  }\n"
+"});\n"
+"play(player);\n"
+"```"
+msgstr ""
+
+#: src/system/media.md:242
+msgid "Next steps"
+msgstr ""
+
+#: src/system/media.md:244
+msgid "[Audio Capture](audio.md) — Microphone input + dB metering"
+msgstr ""
+
+#: src/system/other.md:1
+msgid "Other System APIs"
+msgstr ""
+
+#: src/system/other.md:3
+msgid ""
+"Additional platform-level APIs. Every snippet below is excerpted from a real"
+" file CI compiles on every PR — see "
+"[`docs/examples/system/snippets.ts`](../../examples/system/snippets.ts) for "
+"the perry/system pieces and "
+"[`docs/examples/ui/events/snippets.ts`](../../examples/ui/events/snippets.ts)"
+" for clipboard."
+msgstr ""
+
+#: src/system/other.md:10
+msgid "Open URL"
+msgstr ""
+
+#: src/system/other.md:12
+msgid "Open a URL in the default browser or application:"
+msgstr ""
+
+#: src/system/other.md:20
+msgid "NSWorkspace.open"
+msgstr ""
+
+#: src/system/other.md:21
+msgid "UIApplication.open"
+msgstr ""
+
+#: src/system/other.md:22
+msgid "Intent.ACTION_VIEW"
+msgstr ""
+
+#: src/system/other.md:23
+msgid "ShellExecuteW"
+msgstr ""
+
+#: src/system/other.md:24
+msgid "xdg-open"
+msgstr ""
+
+#: src/system/other.md:25
+msgid "window.open"
+msgstr ""
+
+#: src/system/other.md:27
+msgid "Dark Mode Detection"
+msgstr ""
+
+#: src/system/other.md:35
+msgid "Detection"
+msgstr ""
+
+#: src/system/other.md:37
+msgid "NSApp.effectiveAppearance"
+msgstr ""
+
+#: src/system/other.md:38
+msgid "UITraitCollection"
+msgstr ""
+
+#: src/system/other.md:39
+msgid "Configuration.uiMode"
+msgstr ""
+
+#: src/system/other.md:40
+msgid "Registry (AppsUseLightTheme)"
+msgstr ""
+
+#: src/system/other.md:41
+msgid "GTK settings"
+msgstr ""
+
+#: src/system/other.md:42
+msgid "prefers-color-scheme media query"
+msgstr ""
+
+#: src/system/other.md:46
+msgid "Clipboard helpers live in `perry/ui` (not `perry/system`):"
+msgstr ""
+
+#: src/system/other.md:57
+msgid "Device Identity"
+msgstr ""
+
+#: src/system/other.md:64
+msgid ""
+"`getDeviceIdiom()` returns the broad form factor (`\"phone\"`, `\"pad\"`, "
+"`\"mac\"`, `\"tv\"`, …); `getDeviceModel()` returns the platform-specific "
+"model identifier (`\"iPhone15,2\"`, `\"MacBookPro18,3\"`, etc.)."
+msgstr ""
+
+#: src/system/other.md:71
+msgid "[UI Overview](../ui/overview.md) — Building UIs"
+msgstr ""
+
+#: src/widgets/overview.md:1
+msgid "Widgets (WidgetKit) Overview"
+msgstr ""
+
+#: src/widgets/overview.md:3
+msgid ""
+"Perry can compile TypeScript widget declarations to native widget extensions"
+" across 4 platforms: iOS (WidgetKit), Android (App Widgets), watchOS "
+"(Complications), and Wear OS (Tiles)."
+msgstr ""
+
+#: src/widgets/overview.md:5
+msgid ""
+"**Status:** the `perry/widget` API is wired in the HIR (`crates/perry-"
+"hir/src/lower.rs:try_lower_widget_decl`) and emits via dedicated codegen "
+"crates (`perry-codegen-glance`, `perry-codegen-wear-tiles`, the WidgetKit "
+"emitter). The snippets on the widget docs pages compile-link cleanly on the "
+"host LLVM target — `Widget({...})` lowers to a no-op there — and CI verifies"
+" that via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts)."
+" What CI **cannot** do today is drive the actual cross-compile targets "
+"(`--target ios-widget`, `--target android-widget`, etc.) because each "
+"requires an `--app-bundle-id` not yet surfaced through the doc-tests harness"
+" — tracked in [\\#194](https://github.com/PerryTS/perry/issues/194). For a "
+"working end-to-end reference see "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+msgstr ""
+
+#: src/widgets/overview.md:17
+msgid "What Are Widgets?"
+msgstr ""
+
+#: src/widgets/overview.md:19
+msgid ""
+"Home screen widgets display glanceable information outside your app. Perry's"
+" `perry/widget` module lets you define widgets in TypeScript that compile to"
+" each platform's native widget system."
+msgstr ""
+
+#: src/widgets/overview.md:21
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"MyWidget\",\n"
+"    displayName: \"My Widget\",\n"
+"    description: \"Shows a greeting\",\n"
+"    entryFields: { name: \"string\" },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`Hello, ${entry.name}!`),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/overview.md:46
+msgid ""
+"The compiler generates a complete native widget extension for each platform "
+"— no platform-specific language knowledge required."
+msgstr ""
+
+#: src/widgets/overview.md:51
+msgid "# iOS WidgetKit extension\n"
+msgstr ""
+
+#: src/widgets/overview.md:52
+msgid "# Android App Widget\n"
+msgstr ""
+
+#: src/widgets/overview.md:53
+msgid "# watchOS Complication\n"
+msgstr ""
+
+#: src/widgets/overview.md:54
+msgid "# watchOS Simulator\n"
+msgstr ""
+
+#: src/widgets/overview.md:55
+msgid "# Wear OS Tile\n"
+msgstr ""
+
+#: src/widgets/overview.md:58
+msgid ""
+"Each target produces the appropriate native widget extension for that "
+"platform."
+msgstr ""
+
+#: src/widgets/overview.md:62
+msgid "[Creating Widgets](creating-widgets.md) — Widget() API in detail"
+msgstr ""
+
+#: src/widgets/overview.md:63
+msgid "[Components & Modifiers](components.md) — Available widget components"
+msgstr ""
+
+#: src/widgets/overview.md:64
+msgid "[Configuration](configuration.md) — Widget configuration options"
+msgstr ""
+
+#: src/widgets/overview.md:65
+msgid ""
+"[Data Fetching](data-fetching.md) — Timeline providers and data loading"
+msgstr ""
+
+#: src/widgets/overview.md:66
+msgid "[Cross-Platform Reference](platforms.md) — Platform-specific details"
+msgstr ""
+
+#: src/widgets/overview.md:67
+msgid "[watchOS Complications](watchos.md) — watchOS-specific guide"
+msgstr ""
+
+#: src/widgets/overview.md:68
+msgid "[Wear OS Tiles](wearos.md) — Wear OS-specific guide"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:3
+msgid "Define home screen widgets using the `Widget()` function."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:5
+msgid ""
+"**Status:** the full `Widget({...})` snippets on this page compile-link "
+"cleanly on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the API shapes are verified against the codegen. The actual cross-"
+"compile targets (`--target ios-widget`/`android-widget`/`watchos-"
+"widget`/`wearos-tile`) still aren't driven by the doc-tests harness — each "
+"requires `--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194)). For the canonical "
+"end-to-end shape see "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+" Fragments below that show partial syntax (just the `entryFields` object, "
+"just a `render:` body, etc.) are rendered as plain text — the full "
+"declarations they appear inside are covered by the verified anchors."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:18
+msgid "Widget Declaration"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:20
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"WeatherWidget\",\n"
+"    displayName: \"Weather\",\n"
+"    description: \"Shows current weather\",\n"
+"    entryFields: {\n"
+"        temperature: \"number\",\n"
+"        condition: \"string\",\n"
+"        location: \"string\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            HStack([\n"
+"                Text(entry.location),\n"
+"                Spacer(),\n"
+"                Image(\"cloud.sun.fill\"),\n"
+"            ]),\n"
+"            Text(`${entry.temperature}°`),\n"
+"            Text(entry.condition),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:43
+msgid "Widget Options"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47
+msgid "`kind`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47 src/widgets/creating-widgets.md:48
+#: src/widgets/creating-widgets.md:49 src/widgets/creating-widgets.md:54
+msgid "`string`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:47
+msgid "Unique identifier for the widget"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:48
+msgid "`displayName`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:48
+msgid "Name shown in widget gallery"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:49 src/cli/perry-toml.md:119
+#: src/cli/perry-toml.md:349
+msgid "`description`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:49
+msgid "Description in widget gallery"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50
+msgid "`entryFields`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50 src/widgets/creating-widgets.md:52
+msgid "`object`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:50
+msgid ""
+"Data fields with types (`\"string\"`, `\"number\"`, `\"boolean\"`, arrays, "
+"optionals, objects)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51
+msgid "`render`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51 src/widgets/creating-widgets.md:53
+msgid "`function`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:51
+msgid ""
+"Render function receiving entry data, returns widget tree. Optional 2nd "
+"param for family."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:52
+msgid "`config`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:52
+msgid "Configurable parameters the user can edit (see below)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:53
+msgid "`provider`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:53
+msgid "Timeline provider function for dynamic data (see below)"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:54
+msgid "`appGroup`"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:54
+msgid "App group identifier for sharing data with the host app"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:56
+msgid "Entry Fields"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:58
+msgid ""
+"Entry fields define the data your widget displays. Each field has a name and"
+" type:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:60
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  title: \"string\",\n"
+"  count: \"number\",\n"
+"  isActive: \"boolean\",\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:68
+msgid "Array, Optional, and Object Fields"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:70
+msgid "Entry fields support richer types beyond primitives:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:72
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  items: [{ name: \"string\", value: \"number\" }],  // Array of objects\n"
+"  subtitle: \"string?\",                             // Optional string\n"
+"  stats: { wins: \"number\", losses: \"number\" },     // Nested object\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:80
+msgid "These compile to a Swift `TimelineEntry` struct:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:91
+msgid "Conditionals in Render"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:93
+msgid "Use ternary expressions for conditional rendering:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:95
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"ConditionalWidget\",\n"
+"    displayName: \"Conditional\",\n"
+"    description: \"Renders based on entry data\",\n"
+"    entryFields: {\n"
+"        isActive: \"boolean\",\n"
+"        count: \"number\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(entry.isActive ? \"Active\" : \"Inactive\"),\n"
+"            entry.count > 0 ? Text(`${entry.count} items`) : Spacer(),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:114
+msgid ""
+"Template literals in widget text are compiled to Swift string interpolation:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:116
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"TemplateLiteralWidget\",\n"
+"    displayName: \"Template Literal\",\n"
+"    description: \"Template literals compile to Swift string interpolation\",\n"
+"    entryFields: {\n"
+"        name: \"string\",\n"
+"        score: \"number\",\n"
+"    },\n"
+"    render: (entry) =>\n"
+"        // Template literal: `${entry.name}: ${entry.score} points`\n"
+"        // Compiles to: Text(\"\\(entry.name): \\(entry.score) points\")\n"
+"        Text(`${entry.name}: ${entry.score} points`),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:132
+msgid "Configuration Parameters"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:134
+msgid ""
+"The `config` field defines user-editable parameters that appear in the "
+"widget's edit UI:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:136
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"CityWeather\",\n"
+"    displayName: \"City Weather\",\n"
+"    description: \"Weather for a chosen city\",\n"
+"    config: {\n"
+"        city: { type: \"string\", displayName: \"City\", default: \"New York\" },\n"
+"        units: {\n"
+"            type: \"enum\",\n"
+"            displayName: \"Units\",\n"
+"            values: [\"Celsius\", \"Fahrenheit\"],\n"
+"            default: \"Celsius\",\n"
+"        },\n"
+"    },\n"
+"    entryFields: { temperature: \"number\", condition: \"string\" },\n"
+"    render: (entry) => Text(`${entry.temperature}° ${entry.condition}`),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:155
+msgid "Provider Function"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:157
+msgid ""
+"The `provider` field defines a timeline provider that fetches data for the "
+"widget:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:159
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StockWidget\",\n"
+"    displayName: \"Stock Price\",\n"
+"    description: \"Shows current stock price\",\n"
+"    config: {\n"
+"        symbol: { type: \"string\", displayName: \"Symbol\", default: \"AAPL\" },\n"
+"    },\n"
+"    entryFields: { price: \"number\", change: \"string\" },\n"
+"    provider: async (config) => {\n"
+"        const res = await fetch(`https://api.example.com/stock/${config.symbol}`)\n"
+"        const data = await res.json()\n"
+"        return { price: data.price, change: data.change }\n"
+"    },\n"
+"    // Inline-options form — the chain form `.font(\"title\")` parses but is\n"
+"    // dropped at HIR-lowering time (#195).\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`$${entry.price}`, { font: \"title\" }),\n"
+"            Text(entry.change, { color: \"green\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:183
+msgid ""
+"Note: the chain-style modifiers (`.font(\"title\").color(\"green\")`) parse "
+"but are dropped at HIR-lowering time — see "
+"[\\#195](https://github.com/PerryTS/perry/issues/195). The verified extract "
+"above uses the inline-options form `Text(\"...\", { font: \"title\" })`, "
+"which is what actually round-trips through the widget codegen."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:189
+msgid "Placeholder Data"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:191
+msgid ""
+"When the widget has no data yet (e.g., first load), the provider can return "
+"placeholder data by providing a `placeholder` field:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:193
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"NewsWidget\",\n"
+"  entryFields: { headline: \"string\", source: \"string\" },\n"
+"  placeholder: { headline: \"Loading...\", source: \"---\" },\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:202
+msgid "Family-Specific Rendering"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:204
+msgid ""
+"The render function accepts an optional second parameter for the widget "
+"family, allowing different layouts per size:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:206
+msgid ""
+"```text\n"
+"render: (entry, family) =>\n"
+"  family === \"systemLarge\"\n"
+"    ? VStack([\n"
+"        Text(entry.title).font(\"title\"),\n"
+"        ForEach(entry.items, (item) => Text(item.name)),\n"
+"      ])\n"
+"    : HStack([\n"
+"        Image(\"star.fill\"),\n"
+"        Text(entry.title).font(\"headline\"),\n"
+"      ]),\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:219
+msgid ""
+"Supported families: `\"systemSmall\"`, `\"systemMedium\"`, "
+"`\"systemLarge\"`, `\"accessoryCircular\"`, `\"accessoryRectangular\"`, "
+"`\"accessoryInline\"`."
+msgstr ""
+
+#: src/widgets/creating-widgets.md:221
+msgid "App Group"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:223
+msgid ""
+"The `appGroup` field specifies a shared container for data exchange between "
+"the host app and the widget:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:225
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"AppDataWidget\",\n"
+"  appGroup: \"group.com.example.myapp\",\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:233
+msgid "Multiple Widgets"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:235
+msgid ""
+"Define multiple widgets in a single file. They're bundled into a "
+"`WidgetBundle`:"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:237
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"SmallWidget\",\n"
+"  // ...\n"
+"});\n"
+"\n"
+"Widget({\n"
+"  kind: \"LargeWidget\",\n"
+"  // ...\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:251
+msgid ""
+"[Components](components.md) — Available widget components and modifiers"
+msgstr ""
+
+#: src/widgets/creating-widgets.md:252 src/widgets/components.md:273
+msgid "[Overview](overview.md) — Widget system overview"
+msgstr ""
+
+#: src/widgets/components.md:1
+msgid "Widget Components & Modifiers"
+msgstr ""
+
+#: src/widgets/components.md:3
+msgid "Available components and modifiers for widgets."
+msgstr ""
+
+#: src/widgets/components.md:5
+msgid ""
+"**Status:** this page mixes (a) tiny fragments showing component shape — "
+"rendered as plain `text` because they're not standalone declarations and "
+"can't compile — and (b) one full verified Widget at the bottom that compile-"
+"links via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts)."
+" The doc-tests harness can't drive `--target ios-widget`/`android-widget`/ "
+"`watchos-widget`/`wearos-tile` directly (each needs `--app-bundle-id` and a "
+"platform SDK — [\\#194](https://github.com/PerryTS/perry/issues/194)). Note "
+"also that the modifier parser in `crates/perry-hir/src/lower.rs` "
+"(`parse_modifiers_from_args` / `parse_single_modifier`) only reads modifiers"
+" from **inline option-object arguments** — e.g. `Text(\"hi\", { font: "
+"\"title\", color: \"red\" })` and `VStack([...], { padding: 16 })`. Method-"
+"style chains like `Text(\"hi\").font(\"title\")` shown below parse without "
+"error but **drop the modifier** at HIR-lowering time "
+"([\\#195](https://github.com/PerryTS/perry/issues/195)). The chain form is "
+"documented here because it reads naturally; the verified Complete Example at"
+" the bottom of the page uses the inline-options form that actually round-"
+"trips through the widget codegen path. The end-to-end reference is "
+"[`examples/widget_demo.ts`](https://github.com/PerryTS/perry/blob/main/examples/widget_demo.ts)."
+msgstr ""
+
+#: src/widgets/components.md:27
+msgid ""
+"```text\n"
+"Text(\"Hello, World!\")\n"
+"Text(`${entry.name}: ${entry.value}`)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:32
+msgid "Text Modifiers"
+msgstr ""
+
+#: src/widgets/components.md:34
+msgid ""
+"```text\n"
+"const t = Text(\"Styled\");\n"
+"t.font(\"title\");       // .title, .headline, .body, .caption, etc.\n"
+"t.color(\"blue\");       // Named color or hex\n"
+"t.bold();\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:45
+msgid ""
+"```text\n"
+"VStack([\n"
+"  Text(\"Top\"),\n"
+"  Text(\"Bottom\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:54 src/widgets/components.md:75
+msgid ""
+"```text\n"
+"HStack([\n"
+"  Text(\"Left\"),\n"
+"  Spacer(),\n"
+"  Text(\"Right\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:64
+msgid ""
+"```text\n"
+"ZStack([\n"
+"  Image(\"background\"),\n"
+"  Text(\"Overlay\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:73
+msgid "Flexible space that expands to fill available room:"
+msgstr ""
+
+#: src/widgets/components.md:85
+msgid "Display SF Symbols or asset images:"
+msgstr ""
+
+#: src/widgets/components.md:87
+msgid ""
+"```text\n"
+"Image(\"star.fill\")           // SF Symbol\n"
+"Image(\"cloud.sun.rain.fill\") // SF Symbol\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:94
+msgid "Iterate over array entry fields to render a list of components:"
+msgstr ""
+
+#: src/widgets/components.md:108
+msgid "A visual separator line:"
+msgstr ""
+
+#: src/widgets/components.md:110
+msgid ""
+"```text\n"
+"VStack([\n"
+"  Text(\"Above\"),\n"
+"  Divider(),\n"
+"  Text(\"Below\"),\n"
+"])\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:118 src/widgets/platforms.md:28
+msgid "Label"
+msgstr ""
+
+#: src/widgets/components.md:120
+msgid "A label with text and an SF Symbol icon:"
+msgstr ""
+
+#: src/widgets/components.md:122
+msgid ""
+"```text\n"
+"Label(\"Downloads\", \"arrow.down.circle\")\n"
+"Label(`${entry.count} items`, \"folder.fill\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:127 src/widgets/platforms.md:29
+msgid "Gauge"
+msgstr ""
+
+#: src/widgets/components.md:129
+msgid "A circular or linear progress indicator:"
+msgstr ""
+
+#: src/widgets/components.md:131
+msgid ""
+"```text\n"
+"Gauge(entry.progress, 0, 100)       // value, min, max\n"
+"Gauge(entry.battery, 0, 1.0)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:138
+msgid ""
+"Widget components support SwiftUI-style modifiers. The chain forms shown "
+"below parse but drop their modifiers at HIR-lowering time "
+"([\\#195](https://github.com/PerryTS/perry/issues/195)) — use the inline "
+"option-object form (`Text(\"hi\", { font: \"title\" })`, `VStack([...], { "
+"padding: 16 })`) for the form that actually reaches the codegen, as in the "
+"[Complete Example](#complete-example) at the bottom of this page."
+msgstr ""
+
+#: src/widgets/components.md:146
+msgid "Font"
+msgstr ""
+
+#: src/widgets/components.md:148
+msgid ""
+"```text\n"
+"Text(\"Title\").font(\"title\")\n"
+"Text(\"Body\").font(\"body\")\n"
+"Text(\"Caption\").font(\"caption\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:154
+msgid "Color"
+msgstr ""
+
+#: src/widgets/components.md:156
+msgid ""
+"```text\n"
+"Text(\"Red text\").color(\"red\")\n"
+"Text(\"Custom\").color(\"#FF6600\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:161
+msgid "Padding"
+msgstr ""
+
+#: src/widgets/components.md:167
+msgid "Frame"
+msgstr ""
+
+#: src/widgets/components.md:173
+msgid "Max Width"
+msgstr ""
+
+#: src/widgets/components.md:175
+msgid ""
+"```text\n"
+"widget.maxWidth(\"infinity\")   // Expand to fill available width\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:179
+msgid "Minimum Scale Factor"
+msgstr ""
+
+#: src/widgets/components.md:181
+msgid "Allow text to shrink to fit:"
+msgstr ""
+
+#: src/widgets/components.md:183
+msgid ""
+"```text\n"
+"Text(\"Long text\").minimumScaleFactor(0.5)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:187
+msgid "Container Background"
+msgstr ""
+
+#: src/widgets/components.md:189
+msgid "Set background color for the widget container:"
+msgstr ""
+
+#: src/widgets/components.md:191
+msgid ""
+"```text\n"
+"VStack([...]).containerBackground(\"blue\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:195
+msgid "Widget URL"
+msgstr ""
+
+#: src/widgets/components.md:197
+msgid "Make the widget tappable with a deep link:"
+msgstr ""
+
+#: src/widgets/components.md:199
+msgid ""
+"```text\n"
+"VStack([...]).url(\"myapp://detail/123\")\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:203
+msgid "Edge-Specific Padding"
+msgstr ""
+
+#: src/widgets/components.md:205
+msgid "Apply padding to specific edges:"
+msgstr ""
+
+#: src/widgets/components.md:207
+msgid ""
+"```text\n"
+"VStack([...]).paddingEdge(\"top\", 8)\n"
+"VStack([...]).paddingEdge(\"horizontal\", 16)\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:212
+msgid "Conditionals"
+msgstr ""
+
+#: src/widgets/components.md:214
+msgid "Render different components based on entry data:"
+msgstr ""
+
+#: src/widgets/components.md:216
+msgid ""
+"```text\n"
+"render: (entry) =>\n"
+"  VStack([\n"
+"    entry.isOnline\n"
+"      ? Text(\"Online\").color(\"green\")\n"
+"      : Text(\"Offline\").color(\"red\"),\n"
+"  ]),\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:227
+msgid ""
+"The full Widget below is the verified extract — it compile-links on the host"
+" LLVM target and uses the inline-options modifier form that round-trips "
+"through the codegen."
+msgstr ""
+
+#: src/widgets/components.md:231
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StatsWidget\",\n"
+"    displayName: \"Stats\",\n"
+"    description: \"Shows daily stats\",\n"
+"    entryFields: {\n"
+"        steps: \"number\",\n"
+"        calories: \"number\",\n"
+"        distance: \"string\",\n"
+"    },\n"
+"    // Inline-options modifier form — the `.font(\"title\").bold()` chain form\n"
+"    // parses but its modifiers don't reach the codegen (#195).\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            HStack([\n"
+"                Image(\"figure.walk\"),\n"
+"                Text(\"Daily Stats\", { font: \"headline\" }),\n"
+"            ]),\n"
+"            Spacer(),\n"
+"            HStack([\n"
+"                VStack([\n"
+"                    Text(`${entry.steps}`, { font: \"title\", fontWeight: \"bold\" }),\n"
+"                    Text(\"steps\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"                Spacer(),\n"
+"                VStack([\n"
+"                    Text(`${entry.calories}`, { font: \"title\", fontWeight: \"bold\" }),\n"
+"                    Text(\"cal\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"                Spacer(),\n"
+"                VStack([\n"
+"                    Text(entry.distance, { font: \"title\", fontWeight: \"bold\" }),\n"
+"                    Text(\"km\", { font: \"caption\", color: \"gray\" }),\n"
+"                ]),\n"
+"            ]),\n"
+"        ], { padding: 16 }),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/components.md:272
+msgid "[Creating Widgets](creating-widgets.md) — Widget() API"
+msgstr ""
+
+#: src/widgets/configuration.md:1
+msgid "Widget Configuration"
+msgstr ""
+
+#: src/widgets/configuration.md:3
+msgid ""
+"Perry widgets support user-configurable parameters. On iOS/watchOS, these "
+"compile to AppIntent configurations (the \"Edit Widget\" sheet). On "
+"Android/Wear OS, they compile to a Configuration Activity."
+msgstr ""
+
+#: src/widgets/configuration.md:5
+msgid ""
+"**Status:** the full `TopSitesWidget` declaration below compile-links "
+"cleanly on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `config: { ... }` shape is verified against `parse_config_params` in"
+" `crates/perry-hir/src/lower.rs`. The shorter fragments lower on the page "
+"(just a `provider:` body, just a `config:` object) are rendered as plain "
+"text — they're not standalone declarations. The cross-compile targets "
+"themselves (`--target ios-widget`/ `android-widget`/`watchos-"
+"widget`/`wearos-tile`) still aren't driven by the doc-tests harness — each "
+"needs `--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194))."
+msgstr ""
+
+#: src/widgets/configuration.md:17
+msgid "Defining Config Fields"
+msgstr ""
+
+#: src/widgets/configuration.md:19
+msgid ""
+"Add a `config` object to your `Widget()` declaration. Each field specifies a"
+" type, allowed values, a default, and a display title."
+msgstr ""
+
+#: src/widgets/configuration.md:21
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"TopSitesWidget\",\n"
+"    displayName: \"Top Sites\",\n"
+"    description: \"Your top performing sites\",\n"
+"    supportedFamilies: [\"systemSmall\", \"systemMedium\"],\n"
+"    appGroup: \"group.com.example.shared\",\n"
+"\n"
+"    config: {\n"
+"        sortBy: {\n"
+"            type: \"enum\",\n"
+"            values: [\"clicks\", \"impressions\", \"ctr\", \"position\"],\n"
+"            default: \"clicks\",\n"
+"            title: \"Sort By\",\n"
+"        },\n"
+"        dateRange: {\n"
+"            type: \"enum\",\n"
+"            values: [\"7d\", \"28d\", \"90d\"],\n"
+"            default: \"7d\",\n"
+"            title: \"Date Range\",\n"
+"        },\n"
+"    },\n"
+"\n"
+"    entryFields: {\n"
+"        total: \"number\",\n"
+"        label: \"string\",\n"
+"    },\n"
+"\n"
+"    provider: async (config: { sortBy: string; dateRange: string }) => {\n"
+"        const res = await fetch(\n"
+"            `https://api.example.com/stats?sort=${config.sortBy}&range=${config.dateRange}`,\n"
+"        )\n"
+"        const data = await res.json()\n"
+"        return {\n"
+"            entries: [{ total: data.total, label: data.label }],\n"
+"            reloadPolicy: { after: { minutes: 30 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`${entry.total}`, { font: \"title\", fontWeight: \"bold\" }),\n"
+"            Text(entry.label, { font: \"caption\", color: \"secondary\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:68
+msgid "Supported Parameter Types"
+msgstr ""
+
+#: src/widgets/configuration.md:70
+msgid "TypeScript"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "Enum"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "`{ type: \"enum\", values: [...], default: \"...\", title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:72
+msgid "Picker with fixed choices"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "Boolean"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "`{ type: \"bool\", default: true, title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:73
+msgid "Toggle switch"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "String"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "`{ type: \"string\", default: \"...\", title: \"...\" }`"
+msgstr ""
+
+#: src/widgets/configuration.md:74
+msgid "Free-text input"
+msgstr ""
+
+#: src/widgets/configuration.md:76
+msgid "Accessing Config in the Provider"
+msgstr ""
+
+#: src/widgets/configuration.md:78
+msgid ""
+"The `provider` function receives the current config values as its argument. "
+"The config object keys match the field names you defined:"
+msgstr ""
+
+#: src/widgets/configuration.md:80
+msgid ""
+"```text\n"
+"provider: async (config: { sortBy: string; dateRange: string }) => {\n"
+"  // config.sortBy === \"clicks\" | \"impressions\" | \"ctr\" | \"position\"\n"
+"  // config.dateRange === \"7d\" | \"28d\" | \"90d\"\n"
+"  const url = `https://api.example.com/data?sort=${config.sortBy}`;\n"
+"  const res = await fetch(url);\n"
+"  const data = await res.json();\n"
+"  return { entries: [data] };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:91
+msgid ""
+"When the user changes a config value, the system calls your provider again "
+"with the updated config."
+msgstr ""
+
+#: src/widgets/configuration.md:93
+msgid "Boolean Config Example"
+msgstr ""
+
+#: src/widgets/configuration.md:95
+msgid ""
+"```text\n"
+"config: {\n"
+"  showDetails: {\n"
+"    type: \"bool\",\n"
+"    default: true,\n"
+"    title: \"Show Details\",\n"
+"  },\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/configuration.md:105
+msgid "Platform Mapping"
+msgstr ""
+
+#: src/widgets/configuration.md:107
+msgid "iOS / watchOS (AppIntent)"
+msgstr ""
+
+#: src/widgets/configuration.md:109
+msgid ""
+"Perry generates a Swift `WidgetConfigurationIntent` struct with `@Parameter`"
+" properties and `AppEnum` types for each enum field. The widget uses "
+"`AppIntentConfiguration` instead of `StaticConfiguration`."
+msgstr ""
+
+#: src/widgets/configuration.md:111
+msgid "Generated output (auto-generated, not hand-written):"
+msgstr ""
+
+#: src/widgets/configuration.md:112
+msgid ""
+"`{Name}Intent.swift` -- contains the AppEnum cases and the intent struct"
+msgstr ""
+
+#: src/widgets/configuration.md:113
+msgid ""
+"The provider conforms to `AppIntentTimelineProvider` instead of "
+"`TimelineProvider`"
+msgstr ""
+
+#: src/widgets/configuration.md:114
+msgid ""
+"Config values are serialized to JSON and passed to the native provider "
+"function"
+msgstr ""
+
+#: src/widgets/configuration.md:116
+msgid ""
+"Users configure the widget by long-pressing and selecting \"Edit Widget\", "
+"which presents the system-generated AppIntent UI."
+msgstr ""
+
+#: src/widgets/configuration.md:118
+msgid "Android / Wear OS (Configuration Activity)"
+msgstr ""
+
+#: src/widgets/configuration.md:120
+msgid ""
+"Perry generates a `{Name}ConfigActivity.kt` with Spinner controls for enum "
+"fields and Switch controls for boolean fields. Values are persisted in "
+"SharedPreferences keyed by widget ID."
+msgstr ""
+
+#: src/widgets/configuration.md:122
+msgid "Generated output:"
+msgstr ""
+
+#: src/widgets/configuration.md:123
+msgid ""
+"`{Name}ConfigActivity.kt` -- Activity with UI controls and a Save button"
+msgstr ""
+
+#: src/widgets/configuration.md:124
+msgid ""
+"`widget_info_{name}.xml` -- includes `android:configure` pointing to the "
+"config activity"
+msgstr ""
+
+#: src/widgets/configuration.md:125
+msgid ""
+"AndroidManifest snippet includes an `<activity>` entry with "
+"`APPWIDGET_CONFIGURE` intent filter"
+msgstr ""
+
+#: src/widgets/configuration.md:127
+msgid ""
+"The config activity launches automatically when the user first adds the "
+"widget."
+msgstr ""
+
+#: src/widgets/configuration.md:129
+msgid "Build Commands"
+msgstr ""
+
+#: src/widgets/configuration.md:132
+msgid "# iOS\n"
+msgstr ""
+
+#: src/widgets/configuration.md:134
+msgid "# Android\n"
+msgstr ""
+
+#: src/widgets/configuration.md:141
+msgid ""
+"[Data Fetching](data-fetching.md) -- Provider function and shared storage"
+msgstr ""
+
+#: src/widgets/configuration.md:142
+msgid "[Components](components.md) -- Available widget components"
+msgstr ""
+
+#: src/widgets/configuration.md:143
+msgid ""
+"[Cross-Platform Reference](platforms.md) -- Feature matrix and build targets"
+msgstr ""
+
+#: src/widgets/data-fetching.md:1
+msgid "Provider Function and Data Fetching"
+msgstr ""
+
+#: src/widgets/data-fetching.md:3
+msgid ""
+"The `provider` function is the heart of a dynamic widget. It fetches data, "
+"transforms it, and returns timeline entries that the system renders on "
+"schedule."
+msgstr ""
+
+#: src/widgets/data-fetching.md:5
+msgid ""
+"**Status:** the basic `WeatherWidget` provider below compile-links cleanly "
+"on the host LLVM target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `provider`/`reloadPolicy`/`entryFields` shapes are verified against "
+"the codegen. The shorter fragments lower on the page (a bare "
+"`reloadPolicy:`, a `provider:` body without surrounding `Widget({...})`, "
+"etc.) are rendered as plain text. The `sharedStorage()` and "
+"`preferencesSet()` examples are also rendered as plain text — those symbols "
+"are provided by the platform-specific glue (`AppGroupBridge.swift`, "
+"`Bridge.kt`) for `--target ios-widget`/`android-widget`/`watchos-widget`/ "
+"`wearos-tile` and don't link on the host LLVM target. The cross-compile "
+"targets themselves still aren't driven by the doc-tests harness — each needs"
+" `--app-bundle-id` and a platform SDK "
+"([\\#194](https://github.com/PerryTS/perry/issues/194))."
+msgstr ""
+
+#: src/widgets/data-fetching.md:20
+msgid "Provider Lifecycle"
+msgstr ""
+
+#: src/widgets/data-fetching.md:22
+msgid ""
+"The system calls your provider when the widget is first added, when a "
+"snapshot is needed, and when the reload policy expires."
+msgstr ""
+
+#: src/widgets/data-fetching.md:23
+msgid ""
+"Your provider runs as native LLVM-compiled code linked into the widget "
+"extension."
+msgstr ""
+
+#: src/widgets/data-fetching.md:24
+msgid ""
+"The provider returns one or more timeline entries. The system renders each "
+"entry at its scheduled time."
+msgstr ""
+
+#: src/widgets/data-fetching.md:25
+msgid ""
+"After the last entry, the reload policy determines when the provider runs "
+"again."
+msgstr ""
+
+#: src/widgets/data-fetching.md:27
+msgid "Basic Provider"
+msgstr ""
+
+#: src/widgets/data-fetching.md:29
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"WeatherProviderWidget\",\n"
+"    displayName: \"Weather\",\n"
+"    description: \"Current conditions\",\n"
+"    supportedFamilies: [\"systemSmall\"],\n"
+"\n"
+"    entryFields: {\n"
+"        temperature: \"number\",\n"
+"        condition: \"string\",\n"
+"    },\n"
+"\n"
+"    provider: async () => {\n"
+"        const res = await fetch(\"https://api.weather.example.com/current\")\n"
+"        const data = await res.json()\n"
+"        return {\n"
+"            entries: [\n"
+"                { temperature: data.temp, condition: data.description },\n"
+"            ],\n"
+"            reloadPolicy: { after: { minutes: 15 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render: (entry) =>\n"
+"        VStack([\n"
+"            Text(`${entry.temperature}°`, { font: \"title\" }),\n"
+"            Text(entry.condition, { font: \"caption\" }),\n"
+"        ]),\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:60
+msgid "Authenticated Requests with Shared Storage"
+msgstr ""
+
+#: src/widgets/data-fetching.md:62
+msgid ""
+"Widgets run in a separate process and cannot access your app's memory. Use "
+"`sharedStorage()` to read values that your app has written to a shared "
+"container."
+msgstr ""
+
+#: src/widgets/data-fetching.md:64
+msgid "iOS / watchOS: App Groups"
+msgstr ""
+
+#: src/widgets/data-fetching.md:66
+msgid ""
+"On Apple platforms, shared storage maps to `UserDefaults(suiteName:)` backed"
+" by an App Group container. Set the `appGroup` field in your widget "
+"declaration:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:68
+msgid ""
+"```text\n"
+"Widget({\n"
+"  kind: \"DashboardWidget\",\n"
+"  displayName: \"Dashboard\",\n"
+"  description: \"Account summary\",\n"
+"  appGroup: \"group.com.example.shared\",\n"
+"\n"
+"  entryFields: {\n"
+"    revenue: \"number\",\n"
+"    users: \"number\",\n"
+"  },\n"
+"\n"
+"  provider: async () => {\n"
+"    const token = sharedStorage(\"auth_token\");\n"
+"    const res = await fetch(\"https://api.example.com/dashboard\", {\n"
+"      headers: { Authorization: `Bearer ${token}` },\n"
+"    });\n"
+"    const data = await res.json();\n"
+"    return {\n"
+"      entries: [{ revenue: data.revenue, users: data.activeUsers }],\n"
+"      reloadPolicy: { after: { minutes: 30 } },\n"
+"    };\n"
+"  },\n"
+"\n"
+"  render: (entry) =>\n"
+"    VStack([\n"
+"      Text(`$${entry.revenue}`, { font: \"title\" }),\n"
+"      Text(`${entry.users} active users`, { font: \"caption\" }),\n"
+"    ]),\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:100
+msgid "Your main app writes the token to the shared container:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:102
+msgid ""
+"```text\n"
+"import { preferencesSet } from \"perry/system\";\n"
+"// In your app's login flow:\n"
+"preferencesSet(\"auth_token\", token);\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:108
+msgid ""
+"**Setup requirement (iOS):** Add an App Group capability in Xcode to both "
+"the main app target and the widget extension target. The identifier must "
+"match the `appGroup` value."
+msgstr ""
+
+#: src/widgets/data-fetching.md:110
+msgid "Android / Wear OS: SharedPreferences"
+msgstr ""
+
+#: src/widgets/data-fetching.md:112
+msgid ""
+"On Android, shared storage maps to `SharedPreferences` with the name "
+"`perry_shared`. The generated `Bridge.kt` reads values via "
+"`context.getSharedPreferences(\"perry_shared\", MODE_PRIVATE)`."
+msgstr ""
+
+#: src/widgets/data-fetching.md:114
+msgid "Reload Policies"
+msgstr ""
+
+#: src/widgets/data-fetching.md:116
+msgid ""
+"The `reloadPolicy` field controls when the system next calls your provider:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:127
+msgid "`{ after: { minutes: N } }`"
+msgstr ""
+
+#: src/widgets/data-fetching.md:127
+msgid ""
+"Re-fetch after N minutes. Compiles to "
+"`.after(Date().addingTimeInterval(N*60))` on iOS and "
+"`setFreshnessIntervalMillis(N*60000)` on Wear OS."
+msgstr ""
+
+#: src/widgets/data-fetching.md:128
+msgid "_(omitted)_"
+msgstr ""
+
+#: src/widgets/data-fetching.md:128
+msgid "Defaults to 30 minutes on iOS, 30 minutes on Android/Wear OS."
+msgstr ""
+
+#: src/widgets/data-fetching.md:130
+msgid ""
+"**Budget limits:** iOS restricts widget refreshes. Typical budget is 40--70 "
+"refreshes per day. watchOS is stricter (see [watchOS "
+"Complications](watchos.md)). Request only what you need."
+msgstr ""
+
+#: src/widgets/data-fetching.md:132
+msgid "JSON Response Handling"
+msgstr ""
+
+#: src/widgets/data-fetching.md:134
+msgid ""
+"The provider function receives the parsed JSON directly. Entry field types "
+"must match your `entryFields` declaration:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:136
+msgid ""
+"```text\n"
+"entryFields: {\n"
+"  items: { type: \"array\", items: { type: \"object\", fields: { name: \"string\", count: \"number\" } } },\n"
+"  total: \"number\",\n"
+"},\n"
+"\n"
+"provider: async () => {\n"
+"  const res = await fetch(\"https://api.example.com/items\");\n"
+"  const data = await res.json();\n"
+"  return {\n"
+"    entries: [{\n"
+"      items: data.results.map((r: any) => ({ name: r.name, count: r.count })),\n"
+"      total: data.total,\n"
+"    }],\n"
+"  };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:156
+msgid ""
+"If the fetch fails or JSON parsing throws, the widget extension falls back "
+"to the placeholder data:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:158
+msgid ""
+"```text\n"
+"Widget({\n"
+"  // ...\n"
+"  placeholder: { temperature: 0, condition: \"Loading...\" },\n"
+"\n"
+"  provider: async () => {\n"
+"    const res = await fetch(\"https://api.example.com/weather\");\n"
+"    if (!res.ok) {\n"
+"      // Return stale/fallback data with a short retry interval\n"
+"      return {\n"
+"        entries: [{ temperature: 0, condition: \"Unavailable\" }],\n"
+"        reloadPolicy: { after: { minutes: 5 } },\n"
+"      };\n"
+"    }\n"
+"    const data = await res.json();\n"
+"    return {\n"
+"      entries: [{ temperature: data.temp, condition: data.desc }],\n"
+"      reloadPolicy: { after: { minutes: 15 } },\n"
+"    };\n"
+"  },\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:181
+msgid ""
+"The `placeholder` field provides data shown in the widget gallery and during"
+" loading. If the provider throws an unhandled exception, the generated "
+"Swift/Kotlin code catches it and renders the placeholder instead."
+msgstr ""
+
+#: src/widgets/data-fetching.md:183
+msgid "Multiple Timeline Entries"
+msgstr ""
+
+#: src/widgets/data-fetching.md:185
+msgid ""
+"Return multiple entries to schedule future content without re-fetching:"
+msgstr ""
+
+#: src/widgets/data-fetching.md:187
+msgid ""
+"```text\n"
+"provider: async () => {\n"
+"  const res = await fetch(\"https://api.example.com/hourly\");\n"
+"  const hours = await res.json();\n"
+"  return {\n"
+"    entries: hours.map((h: any) => ({\n"
+"      temperature: h.temp,\n"
+"      condition: h.condition,\n"
+"    })),\n"
+"    reloadPolicy: { after: { minutes: 60 } },\n"
+"  };\n"
+"},\n"
+"```"
+msgstr ""
+
+#: src/widgets/data-fetching.md:201
+msgid ""
+"Each entry is rendered at the corresponding date in the timeline. The system"
+" transitions between entries automatically."
+msgstr ""
+
+#: src/widgets/data-fetching.md:205
+msgid "[Configuration](configuration.md) -- User-configurable parameters"
+msgstr ""
+
+#: src/widgets/data-fetching.md:206
+msgid ""
+"[Cross-Platform Reference](platforms.md) -- Build targets and platform "
+"differences"
+msgstr ""
+
+#: src/widgets/platforms.md:3
+msgid ""
+"Perry widgets compile from a single TypeScript source to four platforms. The"
+" same `Widget({...})` declaration produces native code for each target."
+msgstr ""
+
+#: src/widgets/platforms.md:5
+msgid ""
+"**Status:** this page has no TypeScript fences (only target-flag tables and "
+"shell build commands), so the doc-tests harness has nothing to run here. The"
+" `--target` flags listed below are all wired in "
+"`crates/perry/src/commands/compile.rs`, but the harness still can't exercise"
+" them end-to-end — each requires `--app-bundle-id` and a platform SDK "
+"(Xcode, Android NDK)."
+msgstr ""
+
+#: src/widgets/platforms.md:7
+msgid "Target Flags"
+msgstr ""
+
+#: src/widgets/platforms.md:11
+msgid "`--target ios-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:11
+msgid "SwiftUI `.swift` + Info.plist"
+msgstr ""
+
+#: src/widgets/platforms.md:12 src/plugins/native-extensions.md:274
+#: src/testing/geisterhand.md:341 src/cli/flags.md:23
+msgid "iOS Simulator"
+msgstr ""
+
+#: src/widgets/platforms.md:12
+msgid "`--target ios-widget-simulator`"
+msgstr ""
+
+#: src/widgets/platforms.md:12 src/widgets/platforms.md:15
+msgid "Same, simulator SDK"
+msgstr ""
+
+#: src/widgets/platforms.md:13
+msgid "`--target android-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:13
+msgid "Kotlin/Glance `.kt` + widget_info XML"
+msgstr ""
+
+#: src/widgets/platforms.md:14
+msgid "`--target watchos-widget`"
+msgstr ""
+
+#: src/widgets/platforms.md:14
+msgid "SwiftUI `.swift` (accessory families)"
+msgstr ""
+
+#: src/widgets/platforms.md:15
+msgid "watchOS Simulator"
+msgstr ""
+
+#: src/widgets/platforms.md:15
+msgid "`--target watchos-widget-simulator`"
+msgstr ""
+
+#: src/widgets/platforms.md:16 src/widgets/platforms.md:20
+#: src/widgets/platforms.md:55 src/widgets/platforms.md:87
+msgid "Wear OS"
+msgstr ""
+
+#: src/widgets/platforms.md:16
+msgid "`--target wearos-tile`"
+msgstr ""
+
+#: src/widgets/platforms.md:16
+msgid "Kotlin Tiles `.kt` + manifest"
+msgstr ""
+
+#: src/widgets/platforms.md:18
+msgid "Feature Matrix"
+msgstr ""
+
+#: src/widgets/platforms.md:23
+msgid "VStack/HStack/ZStack"
+msgstr ""
+
+#: src/widgets/platforms.md:23
+msgid "Column/Row/Box"
+msgstr ""
+
+#: src/widgets/platforms.md:24
+msgid "Image (SF Symbols)"
+msgstr ""
+
+#: src/widgets/platforms.md:24
+msgid "R.drawable"
+msgstr ""
+
+#: src/widgets/platforms.md:26
+msgid "Spacer+bg"
+msgstr ""
+
+#: src/widgets/platforms.md:27
+msgid "forEach"
+msgstr ""
+
+#: src/widgets/platforms.md:28
+msgid "Row compound"
+msgstr ""
+
+#: src/widgets/platforms.md:28 src/widgets/platforms.md:29
+#: src/widgets/wearos.md:30
+msgid "Text fallback"
+msgstr ""
+
+#: src/widgets/platforms.md:29 src/widgets/platforms.md:35
+msgid "N/A"
+msgstr ""
+
+#: src/widgets/platforms.md:29
+msgid "CircularProgressIndicator"
+msgstr ""
+
+#: src/widgets/platforms.md:30
+msgid "Conditional"
+msgstr ""
+
+#: src/widgets/platforms.md:30
+msgid "if"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "FamilySwitch"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "LocalSize"
+msgstr ""
+
+#: src/widgets/platforms.md:31
+msgid "requestedSize"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Config (AppIntent)"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Config Activity"
+msgstr ""
+
+#: src/widgets/platforms.md:32
+msgid "Yes (10+)"
+msgstr ""
+
+#: src/widgets/platforms.md:32 src/widgets/platforms.md:34
+msgid "SharedPrefs"
+msgstr ""
+
+#: src/widgets/platforms.md:33
+msgid "Native provider"
+msgstr ""
+
+#: src/widgets/platforms.md:33
+msgid "JNI"
+msgstr ""
+
+#: src/widgets/platforms.md:34
+msgid "sharedStorage"
+msgstr ""
+
+#: src/widgets/platforms.md:34
+msgid "UserDefaults"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "Deep linking (url)"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "widgetURL"
+msgstr ""
+
+#: src/widgets/platforms.md:35
+msgid "clickable Intent"
+msgstr ""
+
+#: src/widgets/platforms.md:37
+msgid "Platform-Specific Notes"
+msgstr ""
+
+#: src/widgets/platforms.md:40
+msgid "Minimum deployment: iOS 17.0"
+msgstr ""
+
+#: src/widgets/platforms.md:41
+msgid "AppIntentConfiguration requires `import AppIntents`"
+msgstr ""
+
+#: src/widgets/platforms.md:42
+msgid "Widget extension memory limit: ~30MB"
+msgstr ""
+
+#: src/widgets/platforms.md:45
+msgid "Requires Glance dependency: `androidx.glance:glance-appwidget:1.1.0`"
+msgstr ""
+
+#: src/widgets/platforms.md:46
+msgid ""
+"Widget sizes mapped from iOS families: systemSmall=2x2, systemMedium=4x2, "
+"systemLarge=4x4"
+msgstr ""
+
+#: src/widgets/platforms.md:47
+msgid "`minimumScaleFactor` not supported in Glance (skipped with warning)"
+msgstr ""
+
+#: src/widgets/platforms.md:50
+msgid "Minimum deployment: watchOS 9.0"
+msgstr ""
+
+#: src/widgets/platforms.md:51
+msgid "Accessory families only (circular, rectangular, inline)"
+msgstr ""
+
+#: src/widgets/platforms.md:52
+msgid "Tighter memory (~15-20MB) and refresh budgets (hourly)"
+msgstr ""
+
+#: src/widgets/platforms.md:53
+msgid "AppIntent requires watchOS 10+; older versions get StaticConfiguration"
+msgstr ""
+
+#: src/widgets/platforms.md:56
+msgid "Same native compilation as Android phone (Wear OS = Android)"
+msgstr ""
+
+#: src/widgets/platforms.md:57
+msgid "Requires Horologist + Tiles Material 3 dependencies"
+msgstr ""
+
+#: src/widgets/platforms.md:58
+msgid "Tiles are full-screen cards in the carousel"
+msgstr ""
+
+#: src/widgets/platforms.md:59
+msgid "`Gauge` maps to `CircularProgressIndicator`"
+msgstr ""
+
+#: src/widgets/platforms.md:61
+msgid "Build Instructions"
+msgstr ""
+
+#: src/widgets/platforms.md:73
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
+msgstr ""
+
+#: src/widgets/platforms.md:75
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
+msgstr ""
+
+#: src/widgets/platforms.md:89
+msgid "# Copy .kt files to Wear OS module\n"
+msgstr ""
+
+#: src/widgets/platforms.md:91
+msgid "# Merge AndroidManifest_snippet.xml\n"
+msgstr ""
+
+#: src/widgets/watchos.md:3
+msgid ""
+"Perry widgets can compile to watchOS WidgetKit complications using `--target"
+" watchos-widget`. The same `Widget({...})` source produces both iOS and "
+"watchOS widgets — the supported families determine the rendering."
+msgstr ""
+
+#: src/widgets/watchos.md:5
+msgid ""
+"**Status:** the snippet on this page compile-links cleanly on the host LLVM "
+"target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `Widget({...})` shape is verified against the codegen. The actual "
+"`--target watchos-widget` / `--target watchos-widget-simulator` cross-"
+"compile is wired in `crates/perry/src/commands/compile.rs` (emits through "
+"the WidgetKit Swift emitter) but the doc-tests harness can't drive it yet — "
+"each cross-target requires `--app-bundle-id` not yet surfaced through the "
+"harness ([\\#194](https://github.com/PerryTS/perry/issues/194)) plus a "
+"watchOS SDK from Xcode. Build with the `perry` CLI to validate end-to-end."
+msgstr ""
+
+#: src/widgets/watchos.md:15
+msgid "Accessory Families"
+msgstr ""
+
+#: src/widgets/watchos.md:17
+msgid ""
+"watchOS complications use accessory families instead of system families:"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Family"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Size"
+msgstr ""
+
+#: src/widgets/watchos.md:19
+msgid "Best For"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "`accessoryCircular`"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "~76x76pt"
+msgstr ""
+
+#: src/widgets/watchos.md:21
+msgid "Single icon, number, or Gauge"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "`accessoryRectangular`"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "~160x76pt"
+msgstr ""
+
+#: src/widgets/watchos.md:22
+msgid "2-3 lines of text"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "`accessoryInline`"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "Single line"
+msgstr ""
+
+#: src/widgets/watchos.md:23
+msgid "Short text only"
+msgstr ""
+
+#: src/widgets/watchos.md:25
+msgid "Gauge Component"
+msgstr ""
+
+#: src/widgets/watchos.md:27
+msgid "The `Gauge` component is designed for watchOS circular complications:"
+msgstr ""
+
+#: src/widgets/watchos.md:29
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"QuickStats\",\n"
+"    displayName: \"Quick Stats\",\n"
+"    supportedFamilies: [\"accessoryCircular\", \"accessoryRectangular\"],\n"
+"\n"
+"    render(entry: { progress: number; label: string }, family) {\n"
+"        if (family === \"accessoryCircular\") {\n"
+"            return Gauge(entry.progress, 1.0)\n"
+"        }\n"
+"        return VStack([\n"
+"            Text(entry.label),\n"
+"            Gauge(entry.progress, 1.0),\n"
+"        ])\n"
+"    },\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/watchos.md:47
+msgid "Gauge Styles"
+msgstr ""
+
+#: src/widgets/watchos.md:49
+msgid ""
+"**`circular`** — Ring gauge, maps to "
+"`.gaugeStyle(.accessoryCircularCapacity)` in SwiftUI"
+msgstr ""
+
+#: src/widgets/watchos.md:50
+msgid ""
+"**`linear`** / **`linearCapacity`** — Horizontal bar, maps to "
+"`.gaugeStyle(.linearCapacity)`"
+msgstr ""
+
+#: src/widgets/watchos.md:52
+msgid "Refresh Budgets"
+msgstr ""
+
+#: src/widgets/watchos.md:54
+msgid "watchOS has stricter refresh budgets than iOS:"
+msgstr ""
+
+#: src/widgets/watchos.md:55
+msgid ""
+"Recommended: refresh every 60 minutes (`reloadPolicy: { after: { minutes: 60"
+" } }`)"
+msgstr ""
+
+#: src/widgets/watchos.md:56
+msgid "Maximum: system may throttle more aggressively than iOS"
+msgstr ""
+
+#: src/widgets/watchos.md:57
+msgid "Background refresh uses `BackgroundTask` framework"
+msgstr ""
+
+#: src/widgets/watchos.md:62
+msgid "# For Apple Watch device\n"
+msgstr ""
+
+#: src/widgets/watchos.md:64
+msgid "# For Apple Watch Simulator\n"
+msgstr ""
+
+#: src/widgets/watchos.md:69
+msgid "Build:"
+msgstr ""
+
+#: src/widgets/watchos.md:79
+msgid ""
+"watchOS 10+ supports AppIntent for widget configuration (same as iOS 17+)"
+msgstr ""
+
+#: src/widgets/watchos.md:80
+msgid ""
+"Older watchOS versions automatically get `StaticConfiguration` fallback"
+msgstr ""
+
+#: src/widgets/watchos.md:81
+msgid "`config` params work identically to iOS"
+msgstr ""
+
+#: src/widgets/watchos.md:83
+msgid "Memory Considerations"
+msgstr ""
+
+#: src/widgets/watchos.md:85
+msgid ""
+"watchOS widget extensions have tighter memory limits (~15-20MB) compared to "
+"iOS (~30MB). The provider-only compilation approach is critical — only the "
+"data-fetching code runs natively, keeping memory usage minimal."
+msgstr ""
+
+#: src/widgets/wearos.md:3
+msgid ""
+"Perry widgets can compile to Wear OS Tiles using `--target wearos-tile`. "
+"Tiles are glanceable surfaces in the Wear OS tile carousel and watch face "
+"complications."
+msgstr ""
+
+#: src/widgets/wearos.md:5
+msgid ""
+"**Status:** the snippet on this page compile-links cleanly on the host LLVM "
+"target via "
+"[`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts),"
+" so the `Widget({...})` shape is verified against the codegen. `--target "
+"wearos-tile` itself is wired through `crates/perry-codegen-wear-tiles` but "
+"the doc-tests harness can't drive that cross-target yet — `--app-bundle-id` "
+"plumbing is still pending "
+"([\\#194](https://github.com/PerryTS/perry/issues/194)) and you'll need an "
+"Android NDK + Wear OS Gradle deps. Build with the `perry` CLI to validate "
+"end-to-end."
+msgstr ""
+
+#: src/widgets/wearos.md:14
+msgid "Concepts"
+msgstr ""
+
+#: src/widgets/wearos.md:16
+msgid "**Tiles** are full-screen cards users swipe through on their watch"
+msgstr ""
+
+#: src/widgets/wearos.md:17
+msgid "**Complications** are small data displays on the watch face"
+msgstr ""
+
+#: src/widgets/wearos.md:18
+msgid ""
+"Perry compiles `Widget({...})` to a `SuspendingTileService` with layout "
+"builders"
+msgstr ""
+
+#: src/widgets/wearos.md:20
+msgid "Supported Components"
+msgstr ""
+
+#: src/widgets/wearos.md:22
+msgid "Widget API"
+msgstr ""
+
+#: src/widgets/wearos.md:22
+msgid "Wear OS Mapping"
+msgstr ""
+
+#: src/widgets/wearos.md:24
+msgid "`LayoutElementBuilders.Text`"
+msgstr ""
+
+#: src/widgets/wearos.md:25
+msgid "`LayoutElementBuilders.Column`"
+msgstr ""
+
+#: src/widgets/wearos.md:26
+msgid "`LayoutElementBuilders.Row`"
+msgstr ""
+
+#: src/widgets/wearos.md:27
+msgid "`LayoutElementBuilders.Spacer`"
+msgstr ""
+
+#: src/widgets/wearos.md:28
+msgid "Spacer with 1dp height"
+msgstr ""
+
+#: src/widgets/wearos.md:29
+msgid "`Gauge(circular)`"
+msgstr ""
+
+#: src/widgets/wearos.md:29
+msgid "`LayoutElementBuilders.Arc` + `ArcLine`"
+msgstr ""
+
+#: src/widgets/wearos.md:30
+msgid "`Gauge(linear)`"
+msgstr ""
+
+#: src/widgets/wearos.md:31
+msgid "`Image`"
+msgstr ""
+
+#: src/widgets/wearos.md:31
+msgid "Resource-based (provide drawable)"
+msgstr ""
+
+#: src/widgets/wearos.md:33
+msgid "Example"
+msgstr ""
+
+#: src/widgets/wearos.md:35
+msgid ""
+"```typescript\n"
+"Widget({\n"
+"    kind: \"StepsTile\",\n"
+"    displayName: \"Steps\",\n"
+"    description: \"Daily step count\",\n"
+"    supportedFamilies: [\"accessoryCircular\"],\n"
+"\n"
+"    provider: async () => {\n"
+"        return {\n"
+"            entries: [{ steps: 7500, goal: 10000 }],\n"
+"            reloadPolicy: { after: { minutes: 60 } },\n"
+"        }\n"
+"    },\n"
+"\n"
+"    render(entry: { steps: number; goal: number }) {\n"
+"        return VStack([\n"
+"            Gauge(entry.steps / entry.goal, 1.0),\n"
+"            Text(`${entry.steps}`),\n"
+"        ])\n"
+"    },\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/widgets/wearos.md:65
+msgid "`{Name}TileService.kt` — `SuspendingTileService` with tile layout"
+msgstr ""
+
+#: src/widgets/wearos.md:66
+msgid ""
+"`{Name}TileBridge.kt` — JNI bridge for native provider (if provider exists)"
+msgstr ""
+
+#: src/widgets/wearos.md:67
+msgid "`AndroidManifest_snippet.xml` — Service declaration"
+msgstr ""
+
+#: src/widgets/wearos.md:69
+msgid "Gradle Integration"
+msgstr ""
+
+#: src/widgets/wearos.md:71
+msgid "Add to your Wear OS module's `build.gradle`:"
+msgstr ""
+
+#: src/widgets/wearos.md:75
+msgid "\"com.google.android.horologist:horologist-tiles:0.6.5\""
+msgstr ""
+
+#: src/widgets/wearos.md:76
+msgid "\"androidx.wear.tiles:tiles-material:1.4.0\""
+msgstr ""
+
+#: src/widgets/wearos.md:77
+msgid "\"androidx.wear.tiles:tiles:1.4.0\""
+msgstr ""
+
+#: src/widgets/wearos.md:81
+msgid "Merge the manifest snippet into your `AndroidManifest.xml`:"
+msgstr ""
+
+#: src/widgets/wearos.md:85
+msgid "\".StepsTileService\""
+msgstr ""
+
+#: src/widgets/wearos.md:86
+msgid "\"true\""
+msgstr ""
+
+#: src/widgets/wearos.md:87
+msgid "\"com.google.android.wearable.permission.BIND_TILE_PROVIDER\""
+msgstr ""
+
+#: src/widgets/wearos.md:89
+msgid "\"androidx.wear.tiles.action.BIND_TILE_PROVIDER\""
+msgstr ""
+
+#: src/widgets/wearos.md:94
+msgid "Native Provider"
+msgstr ""
+
+#: src/widgets/wearos.md:96
+msgid "Same as Android phone widgets — Wear OS is Android:"
+msgstr ""
+
+#: src/widgets/wearos.md:97
+msgid "Target triple: `aarch64-linux-android`"
+msgstr ""
+
+#: src/widgets/wearos.md:98
+msgid "`libwidget_provider.so` loaded via `System.loadLibrary`"
+msgstr ""
+
+#: src/widgets/wearos.md:99
+msgid "JNI bridge pattern identical to phone Glance widgets"
+msgstr ""
+
+#: src/widgets/wearos.md:100
+msgid "`sharedStorage()` uses `SharedPreferences`"
+msgstr ""
+
+#: src/widgets/wearos.md:102
+msgid "Refresh"
+msgstr ""
+
+#: src/widgets/wearos.md:104
+msgid ""
+"Wear Tiles use `freshnessIntervalMillis` on the `Tile` builder. Set via "
+"`reloadPolicy: { after: { minutes: N } }` in the provider return value. "
+"Default: 60 minutes."
+msgstr ""
+
+#: src/plugins/overview.md:1
+msgid "Plugin System Overview"
+msgstr ""
+
+#: src/plugins/overview.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). Receiver-less calls (`loadPlugin`, `listPlugins`, `emitHook`, "
+"`invokeTool`, ...) and `PluginApi` instance methods (`api.registerHook`, "
+"`api.registerTool`, ...) dispatch through `crates/perry-"
+"codegen/src/lower_call.rs::PERRY_PLUGIN_TABLE` and "
+"`PERRY_PLUGIN_INSTANCE_TABLE`. TypeScript surface lives in "
+"`types/perry/plugin/index.d.ts`. Host-side snippets below are compile-link "
+"verified by the doc-tests harness against "
+"[`docs/examples/plugins/host_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/host_snippets.ts);"
+" plugin-side `activate(api)` snippets against "
+"[`docs/examples/plugins/plugin_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/plugin_snippets.ts)."
+msgstr ""
+
+#: src/plugins/overview.md:5
+msgid ""
+"Perry supports native plugins as shared libraries (`.dylib`/`.so`). Plugins "
+"extend Perry applications with custom hooks, tools, services, and routes."
+msgstr ""
+
+#: src/plugins/overview.md:9
+msgid ""
+"A plugin is a Perry-compiled shared library with `activate(api)` and "
+"`deactivate()` entry points"
+msgstr ""
+
+#: src/plugins/overview.md:10
+msgid "The host application loads plugins with `loadPlugin(path)`"
+msgstr ""
+
+#: src/plugins/overview.md:11
+msgid "Plugins register hooks, tools, and services via the API handle"
+msgstr ""
+
+#: src/plugins/overview.md:12
+msgid "The host dispatches events to plugins via `emitHook(name, data)`"
+msgstr ""
+
+#: src/plugins/overview.md:14
+msgid ""
+"```\n"
+"Host Application\n"
+"    ↓ loadPlugin(\"./my-plugin.dylib\")\n"
+"    ↓ calls plugin_activate(api_handle)\n"
+"Plugin\n"
+"    ↓ api.registerHook(\"beforeSave\", callback)\n"
+"    ↓ api.registerTool(\"format\", callback)\n"
+"Host\n"
+"    ↓ emitHook(\"beforeSave\", data) → plugin callback runs\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:27
+msgid "Plugin (compiled with `--output-type dylib`)"
+msgstr ""
+
+#: src/plugins/overview.md:29 src/plugins/creating-plugins.md:9
+msgid ""
+"```typescript\n"
+"let count = 0\n"
+"\n"
+"export function activate(api: PluginApi) {\n"
+"    api.setMetadata(\"counter\", \"1.0.0\", \"Counts hook invocations\")\n"
+"\n"
+"    api.registerHook(\"onRequest\", (data) => {\n"
+"        count++\n"
+"        console.log(`Request #${count}`)\n"
+"        return data\n"
+"    })\n"
+"\n"
+"    api.registerTool(\"getCount\", \"returns request count\", () => count)\n"
+"}\n"
+"\n"
+"export function deactivate() {\n"
+"    console.log(`Total requests processed: ${count}`)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:53
+msgid "Host Application"
+msgstr ""
+
+#: src/plugins/overview.md:55
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"    loadPlugin, unloadPlugin,\n"
+"    emitHook, emitEvent, invokeTool,\n"
+"    setPluginConfig,\n"
+"    discoverPlugins, listPlugins, listHooks, listTools,\n"
+"    pluginCount, initPlugins,\n"
+"} from \"perry/plugin\"\n"
+"\n"
+"const id = loadPlugin(\"./counter-plugin.dylib\")\n"
+"console.log(`load returned: ${id !== 0 ? \"ok\" : \"fail\"}`)\n"
+"\n"
+"const plugins = listPlugins()\n"
+"const hooks = listHooks()\n"
+"const tools = listTools()\n"
+"console.log(`loaded: ${pluginCount()} plugin(s), ${hooks.length} hook(s), ${tools.length} tool(s)`)\n"
+"\n"
+"const result = emitHook(\"beforeSave\", { content: \"hello world\" })\n"
+"\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/overview.md:81
+msgid "Plugin ABI"
+msgstr ""
+
+#: src/plugins/overview.md:83
+msgid "Plugins must export these symbols:"
+msgstr ""
+
+#: src/plugins/overview.md:84
+msgid ""
+"`perry_plugin_abi_version()` — Returns ABI version (for compatibility "
+"checking)"
+msgstr ""
+
+#: src/plugins/overview.md:85
+msgid "`plugin_activate(api_handle)` — Called when plugin is loaded"
+msgstr ""
+
+#: src/plugins/overview.md:86
+msgid "`plugin_deactivate()` — Called when plugin is unloaded"
+msgstr ""
+
+#: src/plugins/overview.md:88
+msgid ""
+"Perry generates these automatically from your `activate`/`deactivate` "
+"exports."
+msgstr ""
+
+#: src/plugins/overview.md:92
+msgid ""
+"Perry also supports **native extensions** — packages that bundle platform-"
+"specific Rust/Swift/JNI code and compile directly into your binary. These "
+"are used for accessing platform APIs like the App Store review prompt or "
+"StoreKit in-app purchases."
+msgstr ""
+
+#: src/plugins/overview.md:94
+msgid "See [Native Extensions](native-extensions.md) for details."
+msgstr ""
+
+#: src/plugins/overview.md:98
+msgid "[Creating Plugins](creating-plugins.md) — Build a plugin step by step"
+msgstr ""
+
+#: src/plugins/overview.md:99
+msgid "[Hooks & Events](hooks-and-events.md) — Hook modes, event bus, tools"
+msgstr ""
+
+#: src/plugins/overview.md:100
+msgid ""
+"[Native Extensions](native-extensions.md) — Extensions with platform-native "
+"code"
+msgstr ""
+
+#: src/plugins/overview.md:101
+msgid ""
+"[App Store Review](appstore-review.md) — Native review prompt (iOS/Android)"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). See [Plugin System Overview — Status](overview.md) for the full "
+"surface. Snippets below are compile-link verified by the doc-tests harness "
+"against "
+"[`docs/examples/plugins/plugin_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/plugin_snippets.ts)"
+" and "
+"[`docs/examples/plugins/host_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/host_snippets.ts)."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:5
+msgid "Build Perry plugins as shared libraries that extend host applications."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:7
+msgid "Step 1: Write the Plugin"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:29
+msgid "Step 2: Compile as Shared Library"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:35
+msgid ""
+"The `--output-type dylib` flag tells Perry to produce a `.dylib` (macOS) or "
+"`.so` (Linux) instead of an executable."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:38
+msgid ""
+"Generates `perry_plugin_abi_version()` returning the current ABI version"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:39
+msgid ""
+"Generates `plugin_activate(api_handle)` calling your `activate()` function"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:40
+msgid "Generates `plugin_deactivate()` calling your `deactivate()` function"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:41
+msgid "Exports symbols with `-rdynamic` for the host to find"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:43
+msgid "Step 3: Load from Host"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:45
+msgid ""
+"```typescript,no-test\n"
+"import {\n"
+"    loadPlugin, unloadPlugin,\n"
+"    emitHook, emitEvent, invokeTool,\n"
+"    setPluginConfig,\n"
+"    discoverPlugins, listPlugins, listHooks, listTools,\n"
+"    pluginCount, initPlugins,\n"
+"} from \"perry/plugin\"\n"
+"\n"
+"const id = loadPlugin(\"./counter-plugin.dylib\")\n"
+"console.log(`load returned: ${id !== 0 ? \"ok\" : \"fail\"}`)\n"
+"\n"
+"const found = discoverPlugins(\"./plugins/\")\n"
+"console.log(`discovered ${found.length} plugin(s)`)\n"
+"\n"
+"const result = emitHook(\"beforeSave\", { content: \"hello world\" })\n"
+"\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:69
+msgid "Plugin API Reference"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:71
+msgid "The `api: PluginApi` passed to `activate()` provides:"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:73
+msgid "Metadata"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:79
+msgid "Hooks"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:86
+msgid ""
+"`registerHook` defaults to priority 10 / mode 0 (filter). Use "
+"`registerHookEx` for explicit priority and mode (0=filter, 1=action, "
+"2=waterfall). Lower priority numbers run first."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:90 src/plugins/hooks-and-events.md:94
+msgid "Tools"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:96
+msgid "Tools are invoked by name from the host."
+msgstr ""
+
+#: src/plugins/creating-plugins.md:100
+msgid ""
+"```typescript,no-test\n"
+"const value = api.getConfig(key: string)  // Read host-provided config\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:106
+msgid ""
+"```typescript,no-test\n"
+"api.on(event: string, handler: (data: unknown) => void): void  // Listen for events\n"
+"api.emit(event: string, data: unknown): void                    // Emit to other plugins\n"
+"```"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:113
+msgid "[Hooks & Events](hooks-and-events.md) — Hook modes, event bus"
+msgstr ""
+
+#: src/plugins/creating-plugins.md:114 src/plugins/hooks-and-events.md:147
+#: src/plugins/native-extensions.md:301
+msgid "[Overview](overview.md) — Plugin system overview"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:3
+msgid ""
+"**Status: wired** ([\\#189](https://github.com/PerryTS/perry/issues/189) "
+"closed). `api.registerHook`, `api.on`, `emitHook`, `emitEvent`, `invokeTool`"
+" all dispatch to `crates/perry-runtime/src/plugin.rs`. Snippets below are "
+"compile-link verified against "
+"[`docs/examples/plugins/{plugin,host}_snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/plugins/)."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:5
+msgid "Perry plugins communicate through hooks, events, and tools."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:7
+msgid "Hook Modes"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:9
+msgid "Hooks support three execution modes:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:11
+msgid "Filter Mode (default)"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:13
+msgid ""
+"Each plugin receives data and returns (possibly modified) data. The output "
+"of one plugin becomes the input of the next:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:15
+msgid ""
+"```typescript\n"
+"function registerFilter(api: PluginApi) {\n"
+"    api.registerHook(\"transform\", (data: any) => {\n"
+"        data.content = data.content.toUpperCase()\n"
+"        return data // Returned data goes to next plugin\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:24
+msgid "Action Mode"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:26
+msgid ""
+"Plugins receive data but return value is ignored. Used for side effects. "
+"Pass `mode = 1` to `registerHookEx`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:29
+msgid ""
+"```typescript\n"
+"function registerAction(api: PluginApi) {\n"
+"    api.registerHook(\"onSave\", (data: any) => {\n"
+"        console.log(`Saved: ${data.path}`)\n"
+"        return data\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:38
+msgid "Waterfall Mode"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:40
+msgid ""
+"Like filter mode, but specifically for accumulating/building up a result "
+"through the chain. Pass `mode = 2` to `registerHookEx`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:43
+msgid ""
+"```typescript\n"
+"function registerWaterfall(api: PluginApi) {\n"
+"    api.registerHook(\"buildMenu\", (items: any) => {\n"
+"        items.push({ label: \"My Plugin Action\", action: () => {} })\n"
+"        return items\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:52
+msgid "Hook Priority"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:54
+msgid ""
+"Lower priority numbers run first. Use `registerHookEx` for explicit priority"
+" and mode:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:57
+msgid ""
+"```typescript\n"
+"function registerPriorities(api: PluginApi, validate: (d: any) => any, transform: (d: any) => any, log: (d: any) => any) {\n"
+"    // Lower priority numbers run first; default 10. Mode 0=filter / 1=action / 2=waterfall.\n"
+"    api.registerHookEx(\"beforeSave\", validate, 10, 0)   // Runs first\n"
+"    api.registerHookEx(\"beforeSave\", transform, 20, 0)  // Runs second\n"
+"    api.registerHookEx(\"beforeSave\", log, 100, 1)        // Runs last (action mode)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:66
+msgid "Default priority is 10 (the value `registerHook` passes implicitly)."
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:68
+msgid "Event Bus"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:70
+msgid "Plugins can communicate with each other through events:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:72
+msgid "Emitting Events"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:74
+msgid ""
+"```typescript\n"
+"function emitFromPlugin(api: PluginApi) {\n"
+"    api.emit(\"dataUpdated\", { source: \"my-plugin\", records: 42 })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:80
+msgid ""
+"```typescript\n"
+"emitEvent(\"dataUpdated\", { source: \"host\", records: 100 })\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:84
+msgid "Listening for Events"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:86
+msgid ""
+"```typescript\n"
+"function listenForEvent(api: PluginApi) {\n"
+"    api.on(\"dataUpdated\", (data: any) => {\n"
+"        console.log(`${data.source} updated ${data.records} records`)\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:96
+msgid ""
+"Plugins register callable tools (note the 3-arg shape: `name`, "
+"`description`, `handler`):"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:99
+msgid ""
+"```typescript\n"
+"function registerFormatter(api: PluginApi) {\n"
+"    api.registerTool(\"formatCode\", \"format source code\", (args: any) => {\n"
+"        return `// formatted: ${args.code}`\n"
+"    })\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:107
+msgid ""
+"```typescript\n"
+"const greeting = invokeTool(\"greet\", { name: \"Perry\" })\n"
+"const formatted = invokeTool(\"formatCode\", {\n"
+"    code: \"const x=1\",\n"
+"    language: \"typescript\",\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:117
+msgid "Hosts can pass configuration to plugins via `setPluginConfig`:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:119
+msgid ""
+"```typescript\n"
+"initPlugins()\n"
+"setPluginConfig(\"api_key\", \"test-key\")\n"
+"setPluginConfig(\"max_retries\", \"3\")\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:125
+msgid ""
+"```typescript\n"
+"function readConfig(api: PluginApi) {\n"
+"    const theme = api.getConfig(\"theme\")     // \"dark\"\n"
+"    const retries = api.getConfig(\"maxRetries\") // \"3\"\n"
+"    return { theme, retries }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:133
+msgid "Introspection"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:135
+msgid "Query loaded plugins and their registrations:"
+msgstr ""
+
+#: src/plugins/hooks-and-events.md:146
+msgid "[Creating Plugins](creating-plugins.md) — Build a plugin"
+msgstr ""
+
+#: src/plugins/native-extensions.md:3
+msgid ""
+"**Status: partially wired.** The `--bundle-extensions` flag, the "
+"`perry.nativeLibrary` `package.json` manifest, and `declare function` FFI "
+"imports are all wired into the compiler — see "
+"`crates/perry/src/commands/compile.rs` (the `bundle_extensions` argument, "
+"the `parse_native_library_manifest`/`build_external_native_libraries` "
+"helpers) and `crates/perry-codegen/src/codegen.rs` (the "
+"`nativeLibrary.functions` signature parser). The TypeScript snippets below "
+"assume a fully-populated extension directory exists on disk (e.g. `perry-"
+"appstore-review` cloned under `./extensions/`). They are kept as `,no-test` "
+"because the doc-tests harness doesn't have those external extensions checked"
+" in — a real project that does have them will compile cleanly. Drift "
+"protection for the parts that _don't_ depend on external extensions (the FFI"
+" declare-function shape, etc.) lives in "
+"`docs/examples/platforms/wasm_snippets.ts`."
+msgstr ""
+
+#: src/plugins/native-extensions.md:5
+msgid ""
+"Perry supports native extensions — packages that bundle platform-specific "
+"code (Rust, Swift, JNI) alongside a TypeScript API. Unlike [dynamic "
+"plugins](overview.md) loaded at runtime, native extensions are compiled "
+"directly into your binary."
+msgstr ""
+
+#: src/plugins/native-extensions.md:7
+msgid ""
+"Native extensions are how you access platform APIs that aren't part of "
+"Perry's built-in [System APIs](../system/overview.md) or [Standard "
+"Library](../stdlib/overview.md). Examples include [App Store "
+"Review](appstore-review.md) and StoreKit for in-app purchases."
+msgstr ""
+
+#: src/plugins/native-extensions.md:9
+msgid "Using a native extension"
+msgstr ""
+
+#: src/plugins/native-extensions.md:11
+msgid "1. Add the extension to your project"
+msgstr ""
+
+#: src/plugins/native-extensions.md:13
+msgid ""
+"Place the extension directory alongside your project, or in a shared "
+"extensions directory:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:30
+msgid "2. Compile with `--bundle-extensions`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:32
+msgid "Pass the extensions directory when building:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:38
+msgid ""
+"Perry discovers every subdirectory with a `package.json`, compiles its "
+"native crates for the target platform, and links them into your binary."
+msgstr ""
+
+#: src/plugins/native-extensions.md:40
+msgid "3. Import and use"
+msgstr ""
+
+#: src/plugins/native-extensions.md:42 src/plugins/appstore-review.md:60
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"\n"
+"await requestReview();\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:48
+msgid ""
+"The import resolves at compile time to the extension's entry point. No "
+"runtime module loading is involved — the function compiles to a direct "
+"native call."
+msgstr ""
+
+#: src/plugins/native-extensions.md:50
+msgid "How native extensions work"
+msgstr ""
+
+#: src/plugins/native-extensions.md:52
+msgid ""
+"A native extension is a directory with a `package.json` that declares a "
+"`perry.nativeLibrary` section. This tells Perry which native functions "
+"exist, their signatures, and which Rust crate to compile for each platform."
+msgstr ""
+
+#: src/plugins/native-extensions.md:54
+msgid "package.json manifest"
+msgstr ""
+
+#: src/plugins/native-extensions.md:58
+msgid "\"perry-appstore-review\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:59
+msgid "\"0.1.0\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:62 src/plugins/appstore-review.md:181
+msgid "\"nativeLibrary\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:63 src/plugins/appstore-review.md:182
+msgid "\"functions\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"sb_appreview_request\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"params\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"returns\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:64 src/plugins/appstore-review.md:183
+msgid "\"f64\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:66
+msgid "\"targets\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:68 src/plugins/native-extensions.md:73
+#: src/plugins/native-extensions.md:78
+msgid "\"crate\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:68 src/plugins/native-extensions.md:78
+msgid "\"crate-ios\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:69 src/plugins/native-extensions.md:74
+#: src/plugins/native-extensions.md:79
+msgid "\"lib\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:69 src/plugins/native-extensions.md:74
+#: src/plugins/native-extensions.md:79
+msgid "\"libperry_appreview.a\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:70 src/plugins/native-extensions.md:75
+#: src/plugins/native-extensions.md:80
+msgid "\"frameworks\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:70 src/plugins/native-extensions.md:80
+msgid "\"StoreKit\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:73
+msgid "\"crate-android\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:77
+msgid "\"macos\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:88
+msgid "`functions`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:90
+msgid "Each entry declares a native function the extension exports:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:94 src/cli/perry-toml.md:116
+msgid "`name`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:94
+msgid "Symbol name — must match the `#[no_mangle]` Rust function exactly"
+msgstr ""
+
+#: src/plugins/native-extensions.md:95
+msgid "`params`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:95
+msgid ""
+"Array of LLVM types: `\"i64\"` for pointers/strings, `\"f64\"` for numbers, "
+"`\"i32\"` for integers"
+msgstr ""
+
+#: src/plugins/native-extensions.md:96
+msgid "`returns`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:96
+msgid "Return type — typically `\"f64\"` (NaN-boxed value or promise handle)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:98
+msgid "`targets`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:100
+msgid ""
+"Each target platform maps to a Rust crate that implements the native "
+"functions:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:104
+msgid "`crate`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:104
+msgid "Relative path to the Rust crate directory"
+msgstr ""
+
+#: src/plugins/native-extensions.md:105
+msgid "`lib`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:105
+msgid "Name of the static library produced by `cargo build`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:106
+msgid "`frameworks`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:106
+msgid "System frameworks to link (iOS/macOS only)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:108
+msgid ""
+"Multiple targets can share the same crate (e.g., iOS and macOS often share "
+"an implementation). Platforms without an entry fall back to the stub."
+msgstr ""
+
+#: src/plugins/native-extensions.md:110
+msgid "Extension directory layout"
+msgstr ""
+
+#: src/plugins/native-extensions.md:112
+msgid ""
+"```\n"
+"perry-appstore-review/\n"
+"├── package.json              # Manifest with perry.nativeLibrary\n"
+"├── src/\n"
+"│   └── index.ts              # TypeScript API (what users import)\n"
+"├── crate-ios/                # iOS/macOS native implementation\n"
+"│   ├── Cargo.toml            # [lib] crate-type = [\"staticlib\"]\n"
+"│   ├── build.rs              # Compiles Swift if needed\n"
+"│   ├── src/\n"
+"│   │   └── lib.rs            # Rust FFI: #[no_mangle] pub extern \"C\" fn ...\n"
+"│   └── swift/\n"
+"│       └── bridge.swift      # Swift bridge for Apple APIs (@_cdecl)\n"
+"├── crate-android/            # Android native implementation\n"
+"│   ├── Cargo.toml\n"
+"│   └── src/\n"
+"│       └── lib.rs            # Rust FFI with JNI calls\n"
+"└── crate-stub/               # Fallback for unsupported platforms\n"
+"    ├── Cargo.toml\n"
+"    └── src/\n"
+"        └── lib.rs            # Returns error immediately\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:134
+msgid "TypeScript side"
+msgstr ""
+
+#: src/plugins/native-extensions.md:136
+msgid ""
+"The `src/index.ts` declares native functions and optionally wraps them in a "
+"friendlier API:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:138
+msgid ""
+"```text\n"
+"// Declare the native function (name must match package.json)\n"
+"declare function sb_appreview_request(): number;\n"
+"\n"
+"// Wrap it with a proper TypeScript signature\n"
+"export async function requestReview(): Promise<void> {\n"
+"  await (sb_appreview_request() as any);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:148
+msgid ""
+"`declare function` tells Perry the function is provided by native code. The "
+"raw return type is `number` because all values cross the FFI boundary as "
+"NaN-boxed `f64` values. Promise handles are NaN-boxed pointers that Perry's "
+"runtime knows how to `await`."
+msgstr ""
+
+#: src/plugins/native-extensions.md:150
+msgid "Rust side"
+msgstr ""
+
+#: src/plugins/native-extensions.md:152
+msgid ""
+"Each platform crate is a `staticlib` that implements the declared functions "
+"using `#[no_mangle] pub extern \"C\"`:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:155
+msgid "// Perry runtime FFI\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:156 src/plugins/native-extensions.md:164
+#: src/plugins/native-extensions.md:256
+msgid "\"C\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:167
+msgid "// ... call platform API, resolve promise when done ...\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:173
+msgid "Key runtime functions available to native code:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:175 src/contributing/architecture.md:23
+msgid "Purpose"
+msgstr ""
+
+#: src/plugins/native-extensions.md:177
+msgid "`js_promise_new()`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:177
+msgid "Create a new Perry promise, returns pointer"
+msgstr ""
+
+#: src/plugins/native-extensions.md:178
+msgid "`js_promise_resolve(promise, value)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:178
+msgid "Resolve a promise with a NaN-boxed value"
+msgstr ""
+
+#: src/plugins/native-extensions.md:179
+msgid "`js_nanbox_string(ptr)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:179
+msgid "Convert a C string pointer to a NaN-boxed string"
+msgstr ""
+
+#: src/plugins/native-extensions.md:180
+msgid "`js_nanbox_pointer(ptr)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:180
+msgid "Convert a pointer to a NaN-boxed object reference"
+msgstr ""
+
+#: src/plugins/native-extensions.md:181
+msgid "`js_get_string_pointer_unified(val)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:181
+msgid "Extract string pointer from a NaN-boxed value"
+msgstr ""
+
+#: src/plugins/native-extensions.md:182
+msgid "`js_string_from_bytes(ptr, len)`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:182
+msgid "Create a Perry string from bytes"
+msgstr ""
+
+#: src/plugins/native-extensions.md:184
+msgid "Swift bridge (iOS/macOS)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:186
+msgid ""
+"Apple platform APIs are often easiest to call from Swift. The pattern is:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:188
+msgid "Write a Swift file with `@_cdecl(\"function_name\")` exports"
+msgstr ""
+
+#: src/plugins/native-extensions.md:189
+msgid "Compile it to a static library in `build.rs`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:190
+msgid "Call the Swift functions from Rust via `extern \"C\"`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:192
+msgid ""
+"```swift\n"
+"import StoreKit\n"
+"\n"
+"typealias Callback = @convention(c) (UnsafeMutableRawPointer, UnsafePointer<CChar>) -> Void\n"
+"\n"
+"@_cdecl(\"swift_appreview_request\")\n"
+"func swiftRequestReview(_ callback: @escaping Callback, _ context: UnsafeMutableRawPointer) {\n"
+"    DispatchQueue.main.async {\n"
+"        if let scene = UIApplication.shared.connectedScenes\n"
+"            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {\n"
+"            SKStoreReviewController.requestReview(in: scene)\n"
+"        }\n"
+"        let result = \"{\\\"success\\\":true}\"\n"
+"        result.withCString { callback(context, $0) }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/native-extensions.md:210
+msgid ""
+"The `build.rs` compiles the Swift source into a static library using "
+"`swiftc`, targeting the correct platform SDK:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:213
+msgid "// build.rs (simplified)\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:215
+msgid ""
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:221
+msgid "JNI bridge (Android)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:223
+msgid "Android platform APIs are accessed through JNI. The pattern:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:225
+msgid "Get the `JavaVM` via `JNI_GetCreatedJavaVMs()`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:226
+msgid "Attach the current thread to get a `JNIEnv`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:227
+msgid "Call Java/Kotlin APIs through JNI method invocations"
+msgstr ""
+
+#: src/plugins/native-extensions.md:228
+msgid "Resolve the Perry promise with the result"
+msgstr ""
+
+#: src/plugins/native-extensions.md:238
+msgid "// Get Activity from PerryBridge\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:239
+msgid "\"com/perry/app/PerryBridge\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:240
+msgid "\"getActivity\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:240
+msgid "\"()Landroid/app/Activity;\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:243
+msgid "// Call platform APIs via JNI...\n"
+msgstr ""
+
+#: src/plugins/native-extensions.md:248
+msgid ""
+"If the Android implementation requires a Java library (e.g., Google Play In-"
+"App Review), the app's `build.gradle` must include the dependency. Document "
+"this requirement clearly for your extension's users."
+msgstr ""
+
+#: src/plugins/native-extensions.md:250
+msgid "Stub crate"
+msgstr ""
+
+#: src/plugins/native-extensions.md:252
+msgid ""
+"For platforms without a native implementation, the stub immediately resolves"
+" the promise with an error:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:259
+msgid "\"{\\\"error\\\":\\\"Not available on this platform\\\"}\""
+msgstr ""
+
+#: src/plugins/native-extensions.md:269
+msgid "Build requirements"
+msgstr ""
+
+#: src/plugins/native-extensions.md:273
+msgid "macOS host, Xcode, `rustup target add aarch64-apple-ios`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:274
+msgid "macOS host, Xcode, `rustup target add aarch64-apple-ios-sim`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:275
+msgid "macOS host, Xcode Command Line Tools"
+msgstr ""
+
+#: src/plugins/native-extensions.md:276
+msgid "Android NDK, `rustup target add aarch64-linux-android`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:278
+msgid ""
+"When Perry encounters a `perry.nativeLibrary` manifest during compilation, "
+"it:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:280
+msgid "Selects the crate for the current `--target` platform"
+msgstr ""
+
+#: src/plugins/native-extensions.md:281
+msgid "Runs `cargo build --release --target <triple>` in the crate directory"
+msgstr ""
+
+#: src/plugins/native-extensions.md:282
+msgid "Links the resulting `.a` static library into the final binary"
+msgstr ""
+
+#: src/plugins/native-extensions.md:283
+msgid "Adds any declared frameworks (e.g., `-framework StoreKit`)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:285
+msgid "Creating your own native extension"
+msgstr ""
+
+#: src/plugins/native-extensions.md:287
+msgid "Create the directory structure shown above"
+msgstr ""
+
+#: src/plugins/native-extensions.md:288
+msgid "Define your functions in `package.json` under `perry.nativeLibrary`"
+msgstr ""
+
+#: src/plugins/native-extensions.md:289
+msgid ""
+"Implement each function in the platform crates with matching `#[no_mangle] "
+"pub extern \"C\"` signatures"
+msgstr ""
+
+#: src/plugins/native-extensions.md:290
+msgid ""
+"Write a TypeScript entry point that declares and optionally wraps the native"
+" functions"
+msgstr ""
+
+#: src/plugins/native-extensions.md:291
+msgid "Add a stub crate for unsupported platforms"
+msgstr ""
+
+#: src/plugins/native-extensions.md:292
+msgid "Test with `--bundle-extensions`:"
+msgstr ""
+
+#: src/plugins/native-extensions.md:299
+msgid ""
+"[App Store Review](appstore-review.md) — Native review prompt extension "
+"(iOS/Android)"
+msgstr ""
+
+#: src/plugins/native-extensions.md:300
+msgid ""
+"[Creating Plugins](creating-plugins.md) — Dynamic plugins loaded at runtime"
+msgstr ""
+
+#: src/plugins/appstore-review.md:3
+msgid ""
+"**Status: extension-dependent.** The compiler-side wiring (`--bundle-"
+"extensions`, `perry.nativeLibrary`, `declare function`) is in place — see "
+"[Native Extensions — Status](native-extensions.md) — but the snippets below "
+"assume the `perry-appstore-review` extension repo has been cloned into "
+"`./extensions/`. The doc-tests harness doesn't ship that repo, so these "
+"snippets are kept as `,no-test`. Once the extension is on disk, they compile"
+" and run on iOS / iOS Simulator / macOS / Android."
+msgstr ""
+
+#: src/plugins/appstore-review.md:5
+msgid ""
+"Prompt users to rate your app using the native app store review dialog on "
+"iOS and Android."
+msgstr ""
+
+#: src/plugins/appstore-review.md:7
+msgid ""
+"The `perry-appstore-review` extension exposes a single function — "
+"`requestReview()` — that opens the platform's native review prompt. It does "
+"nothing else: when and how often to ask is entirely up to you."
+msgstr ""
+
+#: src/plugins/appstore-review.md:9
+msgid ""
+"**Repository:** "
+"[github.com/PerryTS/appstorereview](https://github.com/PerryTS/appstorereview)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:13
+msgid "1. Add the extension"
+msgstr ""
+
+#: src/plugins/appstore-review.md:15
+msgid "Clone or copy the extension into your project's extensions directory:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:24
+msgid "Your project structure:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:35
+msgid "2. Use in your app"
+msgstr ""
+
+#: src/plugins/appstore-review.md:37
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"\n"
+"// Show the review prompt when the user completes a meaningful action\n"
+"async function onLevelComplete() {\n"
+"  await requestReview();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/appstore-review.md:46
+msgid "3. Build"
+msgstr ""
+
+#: src/plugins/appstore-review.md:52
+msgid ""
+"The `--bundle-extensions` flag tells Perry to discover, compile, and link "
+"all native extensions in the given directory. The app store review native "
+"code is compiled and statically linked into your binary — no runtime "
+"dependencies."
+msgstr ""
+
+#: src/plugins/appstore-review.md:56
+msgid "`requestReview(): Promise<void>`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:58
+msgid ""
+"Opens the native app store review prompt. Returns a promise that resolves "
+"when the prompt has been presented (or skipped by the OS)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:66
+msgid "The function only triggers the prompt. It does not:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:67
+msgid "Track whether the user has already reviewed"
+msgstr ""
+
+#: src/plugins/appstore-review.md:68
+msgid ""
+"Throttle how often the prompt appears (iOS does this automatically; Android "
+"does not)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:69
+msgid ""
+"Return whether the user actually left a review (neither platform provides "
+"this)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:71
+msgid "Platform behavior"
+msgstr ""
+
+#: src/plugins/appstore-review.md:75
+msgid ""
+"Uses "
+"[`SKStoreReviewController.requestReview(in:)`](https://developer.apple.com/documentation/storekit/skstorereviewcontroller/requestreview(in:))"
+" from StoreKit."
+msgstr ""
+
+#: src/plugins/appstore-review.md:77 src/plugins/appstore-review.md:93
+#: src/plugins/appstore-review.md:106
+msgid "Detail"
+msgstr ""
+
+#: src/plugins/appstore-review.md:79 src/plugins/appstore-review.md:95
+#: src/plugins/appstore-review.md:108
+msgid "Native API"
+msgstr ""
+
+#: src/plugins/appstore-review.md:79
+msgid "`SKStoreReviewController.requestReview(in: UIWindowScene)`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:80
+msgid "Minimum iOS version"
+msgstr ""
+
+#: src/plugins/appstore-review.md:80
+msgid "14.0"
+msgstr ""
+
+#: src/plugins/appstore-review.md:81 src/plugins/appstore-review.md:97
+msgid "Framework"
+msgstr ""
+
+#: src/plugins/appstore-review.md:81 src/plugins/appstore-review.md:97
+msgid "StoreKit"
+msgstr ""
+
+#: src/plugins/appstore-review.md:82
+msgid "Thread"
+msgstr ""
+
+#: src/plugins/appstore-review.md:82
+msgid "Dispatched to main thread automatically"
+msgstr ""
+
+#: src/plugins/appstore-review.md:83 src/plugins/appstore-review.md:98
+#: src/plugins/appstore-review.md:111
+msgid "Throttling"
+msgstr ""
+
+#: src/plugins/appstore-review.md:83
+msgid ""
+"Apple limits display to 3 times per 365-day period per app. The system may "
+"silently ignore the call."
+msgstr ""
+
+#: src/plugins/appstore-review.md:84
+msgid "Development builds"
+msgstr ""
+
+#: src/plugins/appstore-review.md:84
+msgid "Always shown in debug/TestFlight builds"
+msgstr ""
+
+#: src/plugins/appstore-review.md:85
+msgid "User control"
+msgstr ""
+
+#: src/plugins/appstore-review.md:85
+msgid "Users can disable review prompts in Settings > App Store"
+msgstr ""
+
+#: src/plugins/appstore-review.md:87
+msgid ""
+"**Important:** Apple's throttling means the prompt is not guaranteed to "
+"appear every time `requestReview()` is called. Design your app flow so that "
+"not showing the prompt doesn't break the user experience."
+msgstr ""
+
+#: src/plugins/appstore-review.md:91
+msgid ""
+"Uses the same StoreKit API. Shares the iOS native crate (both compile from "
+"`crate-ios`)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:95
+msgid "`SKStoreReviewController.requestReview()`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:96
+msgid "Minimum macOS version"
+msgstr ""
+
+#: src/plugins/appstore-review.md:96
+msgid "13.0"
+msgstr ""
+
+#: src/plugins/appstore-review.md:98
+msgid "Same as iOS — system-controlled"
+msgstr ""
+
+#: src/plugins/appstore-review.md:100
+msgid "Only works for apps distributed through the Mac App Store."
+msgstr ""
+
+#: src/plugins/appstore-review.md:104
+msgid ""
+"Uses the [Google Play In-App Review "
+"API](https://developer.android.com/guide/playcore/in-app-review)."
+msgstr ""
+
+#: src/plugins/appstore-review.md:108
+msgid "`ReviewManager.requestReviewFlow()` + `launchReviewFlow()`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:109
+msgid "Library"
+msgstr ""
+
+#: src/plugins/appstore-review.md:109
+msgid "`com.google.android.play:review`"
+msgstr ""
+
+#: src/plugins/appstore-review.md:110
+msgid "Minimum API level"
+msgstr ""
+
+#: src/plugins/appstore-review.md:110
+msgid "21 (Android 5.0)"
+msgstr ""
+
+#: src/plugins/appstore-review.md:111
+msgid "Google enforces a quota — the prompt may not appear every time"
+msgstr ""
+
+#: src/plugins/appstore-review.md:112
+msgid "Execution"
+msgstr ""
+
+#: src/plugins/appstore-review.md:112
+msgid "Runs on a background thread to avoid blocking the UI"
+msgstr ""
+
+#: src/plugins/appstore-review.md:114
+msgid ""
+"**Required Gradle dependency:** The Google Play In-App Review API is not "
+"part of the Android SDK. You must add it to your app's `build.gradle`:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:118
+msgid "'com.google.android.play:review:2.0.2'"
+msgstr ""
+
+#: src/plugins/appstore-review.md:122
+msgid ""
+"Without this dependency, `requestReview()` will resolve with an error "
+"explaining the missing library."
+msgstr ""
+
+#: src/plugins/appstore-review.md:124
+msgid "Other platforms"
+msgstr ""
+
+#: src/plugins/appstore-review.md:126
+msgid ""
+"On unsupported platforms (Linux, Windows, Web), `requestReview()` resolves "
+"immediately with an error. It will not throw — your app continues normally."
+msgstr ""
+
+#: src/plugins/appstore-review.md:128
+msgid "Best practices"
+msgstr ""
+
+#: src/plugins/appstore-review.md:130
+msgid ""
+"**Do ask at the right moment.** Prompt after a positive experience — "
+"completing a level, finishing a task, achieving a goal. Don't ask on first "
+"launch or during onboarding."
+msgstr ""
+
+#: src/plugins/appstore-review.md:132
+msgid ""
+"**Don't ask too often.** Even though iOS throttles automatically, Android "
+"does not have the same strict limits. Implement your own logic to track when"
+" you last asked:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:134
+msgid ""
+"```text\n"
+"import { requestReview } from \"perry-appstore-review\";\n"
+"import { preferencesGet, preferencesSet } from \"perry/system\";\n"
+"\n"
+"async function maybeAskForReview() {\n"
+"  const lastAsked = Number(preferencesGet(\"lastReviewAsk\") || \"0\");\n"
+"  const now = Date.now();\n"
+"  const thirtyDays = 30 * 24 * 60 * 60 * 1000;\n"
+"\n"
+"  if (now - lastAsked > thirtyDays) {\n"
+"    preferencesSet(\"lastReviewAsk\", String(now));\n"
+"    await requestReview();\n"
+"  }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/plugins/appstore-review.md:150
+msgid ""
+"**Don't condition app behavior on the review.** Neither iOS nor Android "
+"tells you whether the user left a review, gave a rating, or dismissed the "
+"prompt. The promise resolving does not mean a review was submitted."
+msgstr ""
+
+#: src/plugins/appstore-review.md:152
+msgid ""
+"**Don't use custom review dialogs before the native one.** Both Apple and "
+"Google discourage showing your own \"Rate this app?\" dialog before the "
+"native prompt. The native prompt is designed to be low-friction — adding a "
+"pre-prompt increases abandonment."
+msgstr ""
+
+#: src/plugins/appstore-review.md:154
+msgid "Extension structure"
+msgstr ""
+
+#: src/plugins/appstore-review.md:156
+msgid ""
+"The extension follows the standard [native extension](native-extensions.md) "
+"layout:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:176
+msgid "One native function is declared in `package.json`:"
+msgstr ""
+
+#: src/plugins/appstore-review.md:190
+msgid ""
+"The TypeScript layer wraps this into the public `requestReview()` function. "
+"The native layer creates a Perry promise, calls the platform API, and "
+"resolves the promise when done."
+msgstr ""
+
+#: src/plugins/appstore-review.md:194
+msgid ""
+"[Native Extensions](native-extensions.md) — How native extensions work, "
+"creating your own"
+msgstr ""
+
+#: src/plugins/appstore-review.md:195
+msgid "[iOS Platform](../platforms/ios.md) — iOS platform guide"
+msgstr ""
+
+#: src/plugins/appstore-review.md:196
+msgid "[Android Platform](../platforms/android.md) — Android platform guide"
+msgstr ""
+
+#: src/testing/geisterhand.md:1
+msgid "Geisterhand — In-Process UI Testing"
+msgstr ""
+
+#: src/testing/geisterhand.md:3
+msgid ""
+"Geisterhand (German for \"ghost hand\") embeds a lightweight HTTP server "
+"inside your Perry app that lets you interact with every widget "
+"programmatically. Click buttons, type into text fields, drag sliders, toggle"
+" switches, capture screenshots, and run chaos-mode random fuzzing — all via "
+"simple HTTP calls."
+msgstr ""
+
+#: src/testing/geisterhand.md:5
+msgid ""
+"It works on **all 5 native platforms** (macOS, iOS, Android, Linux/GTK4, "
+"Windows) with zero external dependencies. The server starts automatically "
+"when you compile with `--enable-geisterhand`."
+msgstr ""
+
+#: src/testing/geisterhand.md:12
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:14
+msgid "# 2. Run the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:16
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:18
+msgid "# 3. In another terminal — interact with the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:20
+msgid "# List all widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:21
+msgid "# Click button with handle 3\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:22
+msgid "# Capture window screenshot\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:25
+msgid "Custom Port"
+msgstr ""
+
+#: src/testing/geisterhand.md:27
+msgid ""
+"The default port is **7676**. Use `--geisterhand-port` to change it (this "
+"implies `--enable-geisterhand`, so you don't need both flags):"
+msgstr ""
+
+#: src/testing/geisterhand.md:30
+msgid "# or with perry run:\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:35
+msgid "With `perry run`"
+msgstr ""
+
+#: src/testing/geisterhand.md:47
+msgid ""
+"All endpoints return JSON unless noted otherwise. All responses include "
+"`Access-Control-Allow-Origin: *` for browser-based tools. OPTIONS requests "
+"are supported for CORS preflight."
+msgstr ""
+
+#: src/testing/geisterhand.md:49
+msgid "Health Check"
+msgstr ""
+
+#: src/testing/geisterhand.md:51
+msgid ""
+"```\n"
+"GET /health\n"
+"→ {\"status\":\"ok\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:56
+msgid "Use this to wait for the app to be ready before running tests."
+msgstr ""
+
+#: src/testing/geisterhand.md:58
+msgid "List Widgets"
+msgstr ""
+
+#: src/testing/geisterhand.md:64
+msgid "Returns a JSON array of all registered widgets:"
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"handle\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:458 src/testing/geisterhand.md:459
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"widget_type\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"callback_kind\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+#: src/testing/geisterhand.md:657 src/testing/geisterhand.md:659
+#: src/testing/geisterhand.md:661
+msgid "\"label\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68
+msgid "\"Click Me\""
+msgstr ""
+
+#: src/testing/geisterhand.md:68 src/testing/geisterhand.md:69
+#: src/testing/geisterhand.md:70 src/testing/geisterhand.md:71
+#: src/testing/geisterhand.md:72 src/testing/geisterhand.md:73
+msgid "\"shortcut\""
+msgstr ""
+
+#: src/testing/geisterhand.md:69
+msgid "\"Type here...\""
+msgstr ""
+
+#: src/testing/geisterhand.md:71
+msgid "\"Enable\""
+msgstr ""
+
+#: src/testing/geisterhand.md:72
+msgid "\"Save\""
+msgstr ""
+
+#: src/testing/geisterhand.md:72
+msgid "\"s\""
+msgstr ""
+
+#: src/testing/geisterhand.md:77
+msgid "Supports query parameter filters:"
+msgstr ""
+
+#: src/testing/geisterhand.md:78
+msgid ""
+"`GET /widgets?label=Save` — filter by label substring (case-insensitive)"
+msgstr ""
+
+#: src/testing/geisterhand.md:79
+msgid "`GET /widgets?type=button` — filter by widget type name or code"
+msgstr ""
+
+#: src/testing/geisterhand.md:80
+msgid "`GET /widgets?label=Save&type=5` — combine filters"
+msgstr ""
+
+#: src/testing/geisterhand.md:82
+msgid "Widget Types"
+msgstr ""
+
+#: src/testing/geisterhand.md:84 src/testing/geisterhand.md:98
+msgid "Code"
+msgstr ""
+
+#: src/testing/geisterhand.md:86
+msgid "Push button with onClick"
+msgstr ""
+
+#: src/testing/geisterhand.md:87
+msgid "Text input field"
+msgstr ""
+
+#: src/testing/geisterhand.md:88
+msgid "Numeric slider"
+msgstr ""
+
+#: src/testing/geisterhand.md:89
+msgid "On/off switch"
+msgstr ""
+
+#: src/testing/geisterhand.md:90
+msgid "Dropdown selector"
+msgstr ""
+
+#: src/testing/geisterhand.md:91 src/testing/geisterhand.md:294
+msgid "Menu"
+msgstr ""
+
+#: src/testing/geisterhand.md:91
+msgid "Menu item"
+msgstr ""
+
+#: src/testing/geisterhand.md:92 src/cli/perry-toml.md:399
+msgid "6"
+msgstr ""
+
+#: src/testing/geisterhand.md:92
+msgid "Keyboard shortcut"
+msgstr ""
+
+#: src/testing/geisterhand.md:93
+msgid "Data table"
+msgstr ""
+
+#: src/testing/geisterhand.md:94
+msgid "8"
+msgstr ""
+
+#: src/testing/geisterhand.md:94
+msgid "Scrollable container"
+msgstr ""
+
+#: src/testing/geisterhand.md:96
+msgid "Callback Kinds"
+msgstr ""
+
+#: src/testing/geisterhand.md:98
+msgid "Kind"
+msgstr ""
+
+#: src/testing/geisterhand.md:100
+msgid "Triggered on click/tap"
+msgstr ""
+
+#: src/testing/geisterhand.md:101
+msgid "onChange"
+msgstr ""
+
+#: src/testing/geisterhand.md:101
+msgid "Triggered on value change"
+msgstr ""
+
+#: src/testing/geisterhand.md:102
+msgid "onSubmit"
+msgstr ""
+
+#: src/testing/geisterhand.md:102
+msgid "Triggered on submit (e.g., pressing Enter)"
+msgstr ""
+
+#: src/testing/geisterhand.md:103
+msgid "Triggered on mouse hover"
+msgstr ""
+
+#: src/testing/geisterhand.md:104
+msgid "Triggered on double-click"
+msgstr ""
+
+#: src/testing/geisterhand.md:105
+msgid "onFocus"
+msgstr ""
+
+#: src/testing/geisterhand.md:105
+msgid "Triggered on focus"
+msgstr ""
+
+#: src/testing/geisterhand.md:107
+msgid ""
+"A single widget may appear multiple times in the list with different "
+"callback kinds. For example, a button with both `onClick` and `onHover` "
+"handlers produces two entries (same handle, different `callback_kind`)."
+msgstr ""
+
+#: src/testing/geisterhand.md:109
+msgid "Click a Widget"
+msgstr ""
+
+#: src/testing/geisterhand.md:111
+msgid ""
+"```\n"
+"POST /click/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:116
+msgid ""
+"Fires the widget's `onClick` callback. Works with buttons, menu items, "
+"shortcuts, and table rows."
+msgstr ""
+
+#: src/testing/geisterhand.md:122
+msgid "Type into a TextField"
+msgstr ""
+
+#: src/testing/geisterhand.md:124
+msgid ""
+"```\n"
+"POST /type/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"text\": \"hello world\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:131
+msgid ""
+"Sets the text field's content and fires its `onChange` callback with the new"
+" text as a NaN-boxed string."
+msgstr ""
+
+#: src/testing/geisterhand.md:139
+msgid "Move a Slider"
+msgstr ""
+
+#: src/testing/geisterhand.md:141
+msgid ""
+"```\n"
+"POST /slide/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"value\": 0.75}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:148
+msgid "Sets the slider position and fires `onChange` with the numeric value."
+msgstr ""
+
+#: src/testing/geisterhand.md:156
+msgid "Toggle a Switch"
+msgstr ""
+
+#: src/testing/geisterhand.md:158
+msgid ""
+"```\n"
+"POST /toggle/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:163
+msgid "Fires the toggle's `onChange` callback with a boolean value."
+msgstr ""
+
+#: src/testing/geisterhand.md:169
+msgid "Set State Directly"
+msgstr ""
+
+#: src/testing/geisterhand.md:171
+msgid ""
+"```\n"
+"POST /state/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"value\": 42}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:178
+msgid ""
+"Directly sets a `State` cell's value, bypassing widget callbacks. This "
+"triggers any reactive bindings attached to the state (bound text labels, "
+"visibility, forEach loops, etc.)."
+msgstr ""
+
+#: src/testing/geisterhand.md:186
+msgid "Hover"
+msgstr ""
+
+#: src/testing/geisterhand.md:188
+msgid ""
+"```\n"
+"POST /hover/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:193
+msgid ""
+"Fires the widget's `onHover` callback. Useful for testing hover-dependent UI"
+" (tooltips, color changes, etc.)."
+msgstr ""
+
+#: src/testing/geisterhand.md:195
+msgid "Double-Click"
+msgstr ""
+
+#: src/testing/geisterhand.md:197
+msgid ""
+"```\n"
+"POST /doubleclick/:handle\n"
+"→ {\"ok\":true}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:202
+msgid "Fires the widget's `onDoubleClick` callback."
+msgstr ""
+
+#: src/testing/geisterhand.md:204
+msgid "Trigger Keyboard Shortcut"
+msgstr ""
+
+#: src/testing/geisterhand.md:206
+msgid ""
+"```\n"
+"POST /key\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"shortcut\": \"s\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:213
+msgid ""
+"Finds a registered menu item whose shortcut matches and fires its callback. "
+"Shortcut strings are case-insensitive and match the key string passed to "
+"`menuAddItem` (e.g., `\"s\"` for Cmd+S, `\"S\"` for Cmd+Shift+S, `\"n\"` for"
+" Cmd+N)."
+msgstr ""
+
+#: src/testing/geisterhand.md:221
+msgid ""
+"Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no "
+"match."
+msgstr ""
+
+#: src/testing/geisterhand.md:223
+msgid "Scroll a ScrollView"
+msgstr ""
+
+#: src/testing/geisterhand.md:225
+msgid ""
+"```\n"
+"POST /scroll/:handle\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"x\": 0, \"y\": 100}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:232
+msgid ""
+"Sets the scroll offset of a ScrollView widget. Both `x` and `y` are in "
+"points."
+msgstr ""
+
+#: src/testing/geisterhand.md:240
+msgid "Capture Screenshot"
+msgstr ""
+
+#: src/testing/geisterhand.md:247
+msgid ""
+"Captures the app window as a PNG image. The response is raw binary data, not"
+" JSON."
+msgstr ""
+
+#: src/testing/geisterhand.md:253
+msgid ""
+"Screenshot capture is synchronous from the caller's perspective — the HTTP "
+"request blocks until the main thread completes the capture (timeout: 5 "
+"seconds)."
+msgstr ""
+
+#: src/testing/geisterhand.md:255
+msgid "**Platform-specific capture methods:**"
+msgstr ""
+
+#: src/testing/geisterhand.md:259
+msgid "`CGWindowListCreateImage`"
+msgstr ""
+
+#: src/testing/geisterhand.md:259
+msgid "Retina resolution, reads from window ID"
+msgstr ""
+
+#: src/testing/geisterhand.md:260
+msgid "`UIGraphicsImageRenderer`"
+msgstr ""
+
+#: src/testing/geisterhand.md:260
+msgid "Draws view hierarchy into image context"
+msgstr ""
+
+#: src/testing/geisterhand.md:261
+msgid "JNI `View.draw()` on Canvas"
+msgstr ""
+
+#: src/testing/geisterhand.md:261
+msgid "Creates Bitmap, compresses to PNG"
+msgstr ""
+
+#: src/testing/geisterhand.md:262
+msgid "`WidgetPaintable` + `GskRenderer`"
+msgstr ""
+
+#: src/testing/geisterhand.md:262
+msgid "Renders to texture, saves as PNG bytes"
+msgstr ""
+
+#: src/testing/geisterhand.md:263
+msgid "`PrintWindow` + `GetDIBits`"
+msgstr ""
+
+#: src/testing/geisterhand.md:263
+msgid "Inline PNG encoder (stored zlib blocks)"
+msgstr ""
+
+#: src/testing/geisterhand.md:265
+msgid "Chaos Mode"
+msgstr ""
+
+#: src/testing/geisterhand.md:267
+msgid ""
+"Chaos mode randomly interacts with widgets at a configurable interval — "
+"useful for stress testing, finding edge cases, and crash hunting."
+msgstr ""
+
+#: src/testing/geisterhand.md:269
+msgid "Start"
+msgstr ""
+
+#: src/testing/geisterhand.md:271
+msgid ""
+"```\n"
+"POST /chaos/start\n"
+"Content-Type: application/json\n"
+"\n"
+"{\"interval_ms\": 200}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:279
+msgid "# Fire random inputs every 200ms\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:285
+msgid ""
+"If `interval_ms` is omitted, a default interval is used. The chaos thread "
+"randomly selects a registered widget and fires an appropriate input based on"
+" widget type:"
+msgstr ""
+
+#: src/testing/geisterhand.md:287
+msgid "Widget Type"
+msgstr ""
+
+#: src/testing/geisterhand.md:287
+msgid "Random Input"
+msgstr ""
+
+#: src/testing/geisterhand.md:289 src/testing/geisterhand.md:294
+#: src/testing/geisterhand.md:295 src/testing/geisterhand.md:296
+msgid "Fires onClick (no args)"
+msgstr ""
+
+#: src/testing/geisterhand.md:290
+msgid "Random alphanumeric string, 5-20 characters"
+msgstr ""
+
+#: src/testing/geisterhand.md:291
+msgid "Random float between 0.0 and 1.0"
+msgstr ""
+
+#: src/testing/geisterhand.md:292
+msgid "Random true/false"
+msgstr ""
+
+#: src/testing/geisterhand.md:293
+msgid "Random index 0-9"
+msgstr ""
+
+#: src/testing/geisterhand.md:300
+msgid ""
+"```\n"
+"GET /chaos/status\n"
+"→ {\"running\":true,\"events_fired\":247,\"uptime_secs\":12}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:305
+msgid ""
+"Returns whether chaos mode is active, how many random events have been "
+"fired, and uptime in seconds."
+msgstr ""
+
+#: src/testing/geisterhand.md:307
+msgid "Stop"
+msgstr ""
+
+#: src/testing/geisterhand.md:309
+msgid ""
+"```\n"
+"POST /chaos/stop\n"
+"→ {\"ok\":true,\"chaos\":\"stopped\"}\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:314
+msgid "Error Responses"
+msgstr ""
+
+#: src/testing/geisterhand.md:316
+msgid ""
+"All endpoints return errors as JSON with an appropriate HTTP status code:"
+msgstr ""
+
+#: src/testing/geisterhand.md:319
+msgid "\"widget handle 99 not found\""
+msgstr ""
+
+#: src/testing/geisterhand.md:322
+msgid "Common errors:"
+msgstr ""
+
+#: src/testing/geisterhand.md:323
+msgid "`404` — widget handle not found"
+msgstr ""
+
+#: src/testing/geisterhand.md:324
+msgid "`400` — malformed JSON body or missing required field"
+msgstr ""
+
+#: src/testing/geisterhand.md:325
+msgid "`405` — unsupported HTTP method"
+msgstr ""
+
+#: src/testing/geisterhand.md:329
+msgid "Platform Setup"
+msgstr ""
+
+#: src/testing/geisterhand.md:333
+msgid ""
+"No extra setup needed. The server binds to `0.0.0.0:7676` and is accessible "
+"on `localhost`."
+msgstr ""
+
+#: src/testing/geisterhand.md:343
+msgid ""
+"The iOS Simulator shares the host's network stack — access the server "
+"directly on `localhost`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:352 src/cli/flags.md:24
+msgid "iOS Device"
+msgstr ""
+
+#: src/testing/geisterhand.md:354
+msgid ""
+"For physical iOS devices, you need a network route to the device (same Wi-Fi"
+" network) or use `iproxy` from `libimobiledevice`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:357
+msgid "# Install and launch via Xcode/devicectl\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:359
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:363
+msgid "Android (Emulator or Device)"
+msgstr ""
+
+#: src/testing/geisterhand.md:365
+msgid ""
+"Use `adb forward` to bridge the port. Ensure `INTERNET` permission is in "
+"your manifest (or add it to `perry.toml`):"
+msgstr ""
+
+#: src/testing/geisterhand.md:367
+msgid ""
+"```toml\n"
+"[android]\n"
+"permissions = [\"INTERNET\"]\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:373
+msgid "# Package into APK and install\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:381
+msgid "Install GTK4 development libraries first:"
+msgstr ""
+
+#: src/testing/geisterhand.md:402
+msgid "Test Automation"
+msgstr ""
+
+#: src/testing/geisterhand.md:404
+msgid ""
+"Geisterhand turns your Perry app into a testable HTTP service. Here are "
+"practical patterns for automated testing."
+msgstr ""
+
+#: src/testing/geisterhand.md:406
+msgid "Shell Script Tests"
+msgstr ""
+
+#: src/testing/geisterhand.md:408
+msgid "A simple end-to-end test using bash:"
+msgstr ""
+
+#: src/testing/geisterhand.md:411
+msgid "#!/bin/bash\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:413
+msgid "# Build with geisterhand\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:416
+msgid "# Start the app in background\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:419
+msgid "$!"
+msgstr ""
+
+#: src/testing/geisterhand.md:420
+msgid "\"kill $APP_PID 2>/dev/null\""
+msgstr ""
+
+#: src/testing/geisterhand.md:421
+msgid "# Wait for the app to be ready\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:427
+msgid "# Get widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:430
+msgid "\"Registered widgets: $WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:431
+msgid "# Find the button labeled \"Submit\"\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
+msgstr ""
+
+#: src/testing/geisterhand.md:434
+msgid "# Click it\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:436
+msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
+msgstr ""
+
+#: src/testing/geisterhand.md:437
+msgid "# Take a screenshot after interaction\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:441
+msgid "\"Test passed\""
+msgstr ""
+
+#: src/testing/geisterhand.md:444
+msgid "Python Test Example"
+msgstr ""
+
+#: src/testing/geisterhand.md:448
+msgid "# Start the app\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:450
+msgid "\"./testapp\""
+msgstr ""
+
+#: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
+msgid "# Wait for startup\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:454
+msgid "# List widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:455
+msgid "\"http://127.0.0.1:7676/widgets\""
+msgstr ""
+
+#: src/testing/geisterhand.md:457
+msgid "# Find widgets by label\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:461
+msgid "# Type into the first text field\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:464
+msgid "\"http://127.0.0.1:7676/type/"
+msgstr ""
+
+#: src/testing/geisterhand.md:464 src/testing/geisterhand.md:470
+msgid "'handle'"
+msgstr ""
+
+#: src/testing/geisterhand.md:464 src/testing/geisterhand.md:470
+msgid "\""
+msgstr ""
+
+#: src/testing/geisterhand.md:465
+msgid "\"test@example.com\""
+msgstr ""
+
+#: src/testing/geisterhand.md:468
+msgid "# Click the first button\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:470
+msgid "\"http://127.0.0.1:7676/click/"
+msgstr ""
+
+#: src/testing/geisterhand.md:472
+msgid "# Capture screenshot for visual regression\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:473
+msgid "\"http://127.0.0.1:7676/screenshot\""
+msgstr ""
+
+#: src/testing/geisterhand.md:474
+msgid "\"test-result.png\""
+msgstr ""
+
+#: src/testing/geisterhand.md:474
+msgid "\"wb\""
+msgstr ""
+
+#: src/testing/geisterhand.md:477
+msgid "# Assert the app is still healthy\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"http://127.0.0.1:7676/health\""
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"status\""
+msgstr ""
+
+#: src/testing/geisterhand.md:478
+msgid "\"ok\""
+msgstr ""
+
+#: src/testing/geisterhand.md:479
+msgid "\"All tests passed\""
+msgstr ""
+
+#: src/testing/geisterhand.md:484
+msgid "Stress Testing with Chaos Mode"
+msgstr ""
+
+#: src/testing/geisterhand.md:486
+msgid ""
+"Run chaos mode against your app to find crashes, freezes, or unexpected "
+"state:"
+msgstr ""
+
+#: src/testing/geisterhand.md:489
+msgid "# Build and launch\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:495
+msgid "# Start aggressive chaos (every 50ms)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:518
+msgid "Visual Regression Testing"
+msgstr ""
+
+#: src/testing/geisterhand.md:520
+msgid ""
+"Capture screenshots at key interaction points and compare against baselines:"
+msgstr ""
+
+#: src/testing/geisterhand.md:523
+msgid "# Initial state\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:525
+msgid "# Interact\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:528
+msgid "'{\"text\":\"Hello\"}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:529
+msgid "# Capture after interaction\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:532
+msgid "# Compare (using ImageMagick)\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:537
+msgid "CI Pipeline Integration"
+msgstr ""
+
+#: src/testing/geisterhand.md:540
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr ""
+
+#: src/testing/geisterhand.md:542
+msgid "ui-test"
+msgstr ""
+
+#: src/testing/geisterhand.md:543
+msgid "runs-on"
+msgstr ""
+
+#: src/testing/geisterhand.md:543
+msgid "macos-latest"
+msgstr ""
+
+#: src/testing/geisterhand.md:544 src/cli/perry-toml.md:602
+msgid "steps"
+msgstr ""
+
+#: src/testing/geisterhand.md:545
+msgid "uses"
+msgstr ""
+
+#: src/testing/geisterhand.md:545
+msgid "actions/checkout@v4"
+msgstr ""
+
+#: src/testing/geisterhand.md:547 src/testing/geisterhand.md:550
+msgid "name"
+msgstr ""
+
+#: src/testing/geisterhand.md:547
+msgid "Build with geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:548 src/testing/geisterhand.md:551
+#: src/cli/commands.md:48 src/cli/perry-toml.md:604 src/cli/perry-toml.md:605
+#: src/cli/perry-toml.md:606
+msgid "run"
+msgstr ""
+
+#: src/testing/geisterhand.md:548
+msgid "perry app.ts -o testapp --enable-geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:550
+msgid "Run UI tests"
+msgstr ""
+
+#: src/testing/geisterhand.md:554
+msgid "# Run your test script\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:568
+msgid "Example App"
+msgstr ""
+
+#: src/testing/geisterhand.md:570
+msgid ""
+"A complete Perry UI app demonstrating every widget type Geisterhand can "
+"interact with — verified by CI:"
+msgstr ""
+
+#: src/testing/geisterhand.md:573
+msgid ""
+"```typescript\n"
+"// demonstrates: Geisterhand-targetable Perry UI app — every common widget\n"
+"// docs: docs/src/testing/geisterhand.md\n"
+"// platforms: macos, linux, windows\n"
+"\n"
+"// A complete Perry UI app exercising every widget type Geisterhand\n"
+"// (the UI fuzzer) can interact with. The doc-tests harness compiles\n"
+"// and runs this on every PR, so the snippet on the docs page can never\n"
+"// drift from the real perry/ui API.\n"
+"\n"
+"import {\n"
+"    App, VStack, HStack,\n"
+"    Text, Button, TextField, Slider, Toggle, Picker,\n"
+"    State, stateOnChange,\n"
+"    pickerAddItem,\n"
+"    textSetString,\n"
+"} from \"perry/ui\"\n"
+"\n"
+"// State for reactive UI\n"
+"const counterState = State(0)\n"
+"const textState = State(\"\")\n"
+"\n"
+"// Labels\n"
+"const title = Text(\"Geisterhand Demo\")\n"
+"const counterLabel = Text(\"Count: 0\")\n"
+"\n"
+"// Bind counter state to label via the free-function listener\n"
+"stateOnChange(counterState, (val: number) => {\n"
+"    textSetString(counterLabel, `Count: ${val}`)\n"
+"})\n"
+"\n"
+"// Button — widget_type = 0\n"
+"const incrementBtn = Button(\"Increment\", () => {\n"
+"    counterState.set(counterState.value + 1)\n"
+"})\n"
+"const resetBtn = Button(\"Reset\", () => {\n"
+"    counterState.set(0)\n"
+"})\n"
+"\n"
+"// TextField(placeholder, onChange) — widget_type = 1\n"
+"const nameField = TextField(\"Enter your name\", (text: string) => {\n"
+"    textState.set(text)\n"
+"    console.log(`Name: ${text}`)\n"
+"})\n"
+"\n"
+"// Slider(min, max, onChange) — widget_type = 2\n"
+"const volumeSlider = Slider(0, 100, (value: number) => {\n"
+"    console.log(`Volume: ${value}`)\n"
+"})\n"
+"\n"
+"// Toggle(label, onChange) — widget_type = 3\n"
+"const darkModeToggle = Toggle(\"Dark Mode\", (on: boolean) => {\n"
+"    console.log(`Dark mode: ${on}`)\n"
+"})\n"
+"\n"
+"// Picker(onChange); items added with pickerAddItem.\n"
+"const sizePicker = Picker((index: number) => {\n"
+"    console.log(`Size index: ${index}`)\n"
+"})\n"
+"pickerAddItem(sizePicker, \"Small\")\n"
+"pickerAddItem(sizePicker, \"Medium\")\n"
+"pickerAddItem(sizePicker, \"Large\")\n"
+"\n"
+"// Layout\n"
+"const buttonRow = HStack(8, [incrementBtn, resetBtn])\n"
+"const stack = VStack(12, [\n"
+"    title, counterLabel, buttonRow,\n"
+"    nameField, volumeSlider, darkModeToggle, sizePicker,\n"
+"])\n"
+"\n"
+"App({\n"
+"    title: \"Geisterhand Demo\",\n"
+"    width: 400,\n"
+"    height: 480,\n"
+"    body: stack,\n"
+"})\n"
+"```"
+msgstr ""
+
+#: src/testing/geisterhand.md:651
+msgid "After compiling with `--enable-geisterhand` and running:"
+msgstr ""
+
+#: src/testing/geisterhand.md:654
+msgid "# See all interactive widgets\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:655
+msgid "# [\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:657
+msgid "\"Increment\""
+msgstr ""
+
+#: src/testing/geisterhand.md:657
+msgid "#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:659
+msgid "\"Enter your name\""
+msgstr ""
+
+#: src/testing/geisterhand.md:659
+msgid "#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:661
+msgid "\"Dark Mode\""
+msgstr ""
+
+#: src/testing/geisterhand.md:661
+msgid "# ]\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:663
+msgid "# Click Increment 3 times\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:665
+msgid "# Counter label now shows \"Count: 3\"\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:667
+msgid "# Type a name\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:669
+msgid "'{\"text\":\"Perry\"}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:670
+msgid "# Set slider to 80%\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:672
+msgid "'{\"value\":0.8}'"
+msgstr ""
+
+#: src/testing/geisterhand.md:673
+msgid "# Toggle dark mode on\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:676
+msgid "# Screenshot\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:685
+msgid ""
+"Geisterhand operates as three cooperating components connected by thread-"
+"safe queues:"
+msgstr ""
+
+#: src/testing/geisterhand.md:729
+msgid "Lifecycle"
+msgstr ""
+
+#: src/testing/geisterhand.md:731
+msgid ""
+"**Startup**: When `--enable-geisterhand` is used, the compiled binary calls "
+"`perry_geisterhand_start(port)` during initialization. This spawns a "
+"background thread running a `tiny-http` server."
+msgstr ""
+
+#: src/testing/geisterhand.md:733
+msgid ""
+"**Widget Registration**: As UI widgets are created (Button, TextField, "
+"Slider, etc.), each one calls `perry_geisterhand_register(handle, "
+"widget_type, callback_kind, closure_f64, label)` to register its callback in"
+" the global registry. This is gated behind `#[cfg(feature = "
+"\"geisterhand\")]` so normal builds have zero overhead."
+msgstr ""
+
+#: src/testing/geisterhand.md:735
+msgid ""
+"**HTTP Requests**: When a request arrives (e.g., `POST /click/3`), the "
+"server looks up handle 3 in the registry, finds the associated closure, and "
+"pushes a `PendingAction::InvokeCallback` onto the pending actions queue."
+msgstr ""
+
+#: src/testing/geisterhand.md:737
+msgid ""
+"**Main-Thread Dispatch**: The platform's timer (NSTimer on macOS, glib "
+"timeout on GTK4, WM_TIMER on Windows, etc.) calls `perry_geisterhand_pump()`"
+" every ~8ms. This drains the pending actions queue and executes callbacks on"
+" the main thread, which is required for UI safety."
+msgstr ""
+
+#: src/testing/geisterhand.md:739
+msgid ""
+"**Screenshot Capture**: Screenshots use `Condvar` synchronization — the HTTP"
+" thread queues a `CaptureScreenshot` action, then blocks waiting on a "
+"condition variable. The main thread's pump executes the platform-specific "
+"capture, stores the PNG data, and signals the condvar. Timeout: 5 seconds."
+msgstr ""
+
+#: src/testing/geisterhand.md:741
+msgid "Thread Safety"
+msgstr ""
+
+#: src/testing/geisterhand.md:743
+msgid ""
+"**Widget Registry**: Protected by `Mutex`. Read by the HTTP server (to list "
+"widgets and look up handles), written by the main thread (during widget "
+"creation)."
+msgstr ""
+
+#: src/testing/geisterhand.md:744
+msgid ""
+"**Pending Actions Queue**: Protected by `Mutex`. Written by HTTP server "
+"thread, drained by main thread in `pump()`."
+msgstr ""
+
+#: src/testing/geisterhand.md:745
+msgid ""
+"**Screenshot Result**: Protected by `Mutex` + `Condvar`. HTTP thread waits, "
+"main thread signals."
+msgstr ""
+
+#: src/testing/geisterhand.md:746
+msgid ""
+"**Chaos Mode State**: Uses `AtomicBool` (running flag) and `AtomicU64` "
+"(event counter) for lock-free status checks."
+msgstr ""
+
+#: src/testing/geisterhand.md:748
+msgid "NaN-Boxing Bridge"
+msgstr ""
+
+#: src/testing/geisterhand.md:750
+msgid ""
+"When geisterhand needs to pass values to widget callbacks, it must create "
+"properly NaN-boxed values:"
+msgstr ""
+
+#: src/testing/geisterhand.md:752
+msgid ""
+"**Strings** (for TextField): Calls `js_string_from_bytes(ptr, len)` to "
+"allocate a runtime string, then `js_nanbox_string(ptr)` to wrap it with "
+"STRING_TAG (0x7FFF)."
+msgstr ""
+
+#: src/testing/geisterhand.md:753
+msgid ""
+"**Numbers** (for Slider): Passes the raw `f64` value directly (numbers are "
+"their own NaN-boxed representation)."
+msgstr ""
+
+#: src/testing/geisterhand.md:754
+msgid ""
+"**Booleans** (for Toggle/chaos): Uses `TAG_TRUE` (0x7FFC000000000004) or "
+"`TAG_FALSE` (0x7FFC000000000003)."
+msgstr ""
+
+#: src/testing/geisterhand.md:758
+msgid "Build Details"
+msgstr ""
+
+#: src/testing/geisterhand.md:760
+msgid "Auto-Build"
+msgstr ""
+
+#: src/testing/geisterhand.md:762
+msgid ""
+"When you pass `--enable-geisterhand` (or `--geisterhand-port`), Perry "
+"automatically builds the required libraries on first use if they're not "
+"already cached:"
+msgstr ""
+
+#: src/testing/geisterhand.md:771
+msgid "Platform crate selection is automatic based on `--target`:"
+msgstr ""
+
+#: src/testing/geisterhand.md:773 src/cli/flags.md:20
+msgid "Target"
+msgstr ""
+
+#: src/testing/geisterhand.md:773
+msgid "UI Crate"
+msgstr ""
+
+#: src/testing/geisterhand.md:775
+msgid "(default/macOS)"
+msgstr ""
+
+#: src/testing/geisterhand.md:775 src/contributing/architecture.md:37
+msgid "`perry-ui-macos`"
+msgstr ""
+
+#: src/testing/geisterhand.md:776
+msgid "`ios` / `ios-simulator`"
+msgstr ""
+
+#: src/testing/geisterhand.md:776 src/contributing/architecture.md:38
+msgid "`perry-ui-ios`"
+msgstr ""
+
+#: src/testing/geisterhand.md:777 src/cli/commands.md:66
+#: src/cli/commands.md:238 src/cli/flags.md:27
+msgid "`android`"
+msgstr ""
+
+#: src/testing/geisterhand.md:777
+msgid "`perry-ui-android`"
+msgstr ""
+
+#: src/testing/geisterhand.md:778 src/cli/commands.md:239 src/cli/flags.md:37
+msgid "`linux`"
+msgstr ""
+
+#: src/testing/geisterhand.md:778
+msgid "`perry-ui-gtk4`"
+msgstr ""
+
+#: src/testing/geisterhand.md:779 src/cli/flags.md:36
+msgid "`windows`"
+msgstr ""
+
+#: src/testing/geisterhand.md:779
+msgid "`perry-ui-windows`"
+msgstr ""
+
+#: src/testing/geisterhand.md:781
+msgid "Separate Target Directory"
+msgstr ""
+
+#: src/testing/geisterhand.md:783
+msgid ""
+"Geisterhand libraries are built into `target/geisterhand/` (via "
+"`CARGO_TARGET_DIR`) to avoid interfering with normal builds. This means your"
+" first geisterhand build takes a moment, but subsequent builds reuse the "
+"cached libraries."
+msgstr ""
+
+#: src/testing/geisterhand.md:785
+msgid "Feature Flags"
+msgstr ""
+
+#: src/testing/geisterhand.md:787
+msgid ""
+"All geisterhand code is behind `#[cfg(feature = \"geisterhand\")]` feature "
+"gates:"
+msgstr ""
+
+#: src/testing/geisterhand.md:789
+msgid ""
+"**`perry-runtime/geisterhand`**: Compiles the `geisterhand_registry` module "
+"— widget registry, action queue, pump function, screenshot coordination."
+msgstr ""
+
+#: src/testing/geisterhand.md:790
+msgid ""
+"**`perry-ui-{platform}/geisterhand`**: Adds `perry_geisterhand_register()` "
+"calls to widget constructors and `perry_geisterhand_pump()` to the platform "
+"timer."
+msgstr ""
+
+#: src/testing/geisterhand.md:792
+msgid ""
+"When the feature is not enabled, no geisterhand code is compiled — zero "
+"binary size overhead and zero runtime cost."
+msgstr ""
+
+#: src/testing/geisterhand.md:794
+msgid "Linking"
+msgstr ""
+
+#: src/testing/geisterhand.md:796
+msgid "The compiled binary links three additional static libraries:"
+msgstr ""
+
+#: src/testing/geisterhand.md:797
+msgid ""
+"`libperry_runtime.a` (geisterhand-featured build, replaces the normal "
+"runtime)"
+msgstr ""
+
+#: src/testing/geisterhand.md:798
+msgid ""
+"`libperry_ui_{platform}.a` (geisterhand-featured build, replaces the normal "
+"UI lib)"
+msgstr ""
+
+#: src/testing/geisterhand.md:799
+msgid "`libperry_ui_geisterhand.a` (HTTP server + chaos mode)"
+msgstr ""
+
+#: src/testing/geisterhand.md:801
+msgid "Manual Build"
+msgstr ""
+
+#: src/testing/geisterhand.md:803
+msgid "If auto-build fails or you want to cross-compile manually:"
+msgstr ""
+
+#: src/testing/geisterhand.md:806
+msgid "# Build geisterhand libs for macOS\n"
+msgstr ""
+
+#: src/testing/geisterhand.md:807
+msgid "target/geisterhand"
+msgstr ""
+
+#: src/testing/geisterhand.md:822
+msgid "Security"
+msgstr ""
+
+#: src/testing/geisterhand.md:824
+msgid ""
+"Geisterhand binds to `0.0.0.0` on the configured port (default 7676). This "
+"means it is **accessible from the local network** — any device on the same "
+"network can interact with your app, capture screenshots, or trigger chaos "
+"mode."
+msgstr ""
+
+#: src/testing/geisterhand.md:826
+msgid ""
+"**Do not ship geisterhand-enabled binaries to production or to end users.**"
+msgstr ""
+
+#: src/testing/geisterhand.md:828
+msgid ""
+"Geisterhand is a development and testing tool only. The feature-gate system "
+"ensures it cannot accidentally be included in normal builds — you must "
+"explicitly pass `--enable-geisterhand` or `--geisterhand-port`."
+msgstr ""
+
+#: src/testing/geisterhand.md:832
+msgid "Troubleshooting"
+msgstr ""
+
+#: src/testing/geisterhand.md:834
+msgid "\"Connection refused\" on port 7676"
+msgstr ""
+
+#: src/testing/geisterhand.md:836
+msgid ""
+"Ensure you compiled with `--enable-geisterhand` or `--geisterhand-port`"
+msgstr ""
+
+#: src/testing/geisterhand.md:837
+msgid ""
+"Check that the app has fully started (look for `[geisterhand] listening "
+"on...` in stderr)"
+msgstr ""
+
+#: src/testing/geisterhand.md:838
+msgid "Verify the port isn't in use by another process: `lsof -i :7676`"
+msgstr ""
+
+#: src/testing/geisterhand.md:840
+msgid "Widget handles not found"
+msgstr ""
+
+#: src/testing/geisterhand.md:842
+msgid ""
+"Handles are assigned at widget creation time. If you query `/widgets` before"
+" the UI is fully constructed, some widgets may not be registered yet."
+msgstr ""
+
+#: src/testing/geisterhand.md:843
+msgid "Wait for `GET /health` to return `{\"status\":\"ok\"}` before interacting."
+msgstr ""
+
+#: src/testing/geisterhand.md:845
+msgid "Screenshot returns empty data"
+msgstr ""
+
+#: src/testing/geisterhand.md:847
+msgid ""
+"Screenshot capture has a 5-second timeout. If the main thread is blocked "
+"(e.g., by a long-running synchronous operation), the screenshot will time "
+"out and return empty data."
+msgstr ""
+
+#: src/testing/geisterhand.md:848
+msgid ""
+"On macOS, ensure the app has a visible window (minimized windows may not "
+"capture correctly)."
+msgstr ""
+
+#: src/testing/geisterhand.md:850
+msgid "Auto-build fails"
+msgstr ""
+
+#: src/testing/geisterhand.md:852
+msgid "Ensure you have a working Rust toolchain (`rustup show`)"
+msgstr ""
+
+#: src/testing/geisterhand.md:853
+msgid ""
+"For cross-compilation targets, install the appropriate target: `rustup "
+"target add aarch64-apple-ios`"
+msgstr ""
+
+#: src/testing/geisterhand.md:854
+msgid ""
+"Check that the Perry source tree is accessible (auto-build searches upward "
+"from the `perry` executable for the workspace root)"
+msgstr ""
+
+#: src/testing/geisterhand.md:856
+msgid "Chaos mode crashes the app"
+msgstr ""
+
+#: src/testing/geisterhand.md:858
+msgid ""
+"That's the point — chaos mode found a bug. Check the app's stderr output for"
+" panic messages or stack traces. Common causes:"
+msgstr ""
+
+#: src/testing/geisterhand.md:859
+msgid ""
+"Callback handlers that assume valid state but receive unexpected values"
+msgstr ""
+
+#: src/testing/geisterhand.md:860
+msgid "Missing null checks on state values"
+msgstr ""
+
+#: src/testing/geisterhand.md:861
+msgid "Race conditions in state updates"
+msgstr ""
+
+#: src/cli/commands.md:1
+msgid "CLI Commands"
+msgstr ""
+
+#: src/cli/commands.md:3
+msgid ""
+"Perry provides 11 commands for compiling, checking, running, publishing, and"
+" managing your projects."
+msgstr ""
+
+#: src/cli/commands.md:5
+msgid ""
+"See also: [perry.toml Reference](perry-toml.md) for project configuration."
+msgstr ""
+
+#: src/cli/commands.md:7
+msgid "compile"
+msgstr ""
+
+#: src/cli/commands.md:9
+msgid "Compile TypeScript to a native executable."
+msgstr ""
+
+#: src/cli/commands.md:12
+msgid "# Or shorthand (auto-detects compile):\n"
+msgstr ""
+
+#: src/cli/commands.md:17 src/cli/commands.md:109 src/cli/commands.md:148
+#: src/cli/commands.md:181 src/cli/commands.md:195 src/cli/commands.md:248
+#: src/cli/commands.md:260 src/cli/flags.md:9 src/cli/flags.md:50
+#: src/cli/flags.md:58 src/cli/flags.md:66 src/cli/flags.md:73
+msgid "Flag"
+msgstr ""
+
+#: src/cli/commands.md:19 src/cli/commands.md:111 src/cli/commands.md:243
+msgid "`-o, --output <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:19
+msgid "Output file path"
+msgstr ""
+
+#: src/cli/commands.md:20
+msgid "`--target <TARGET>`"
+msgstr ""
+
+#: src/cli/commands.md:20
+msgid "Platform target (see [Compiler Flags](flags.md))"
+msgstr ""
+
+#: src/cli/commands.md:21
+msgid "`--output-type <TYPE>`"
+msgstr ""
+
+#: src/cli/commands.md:21
+msgid "`executable` (default) or `dylib` (plugin)"
+msgstr ""
+
+#: src/cli/commands.md:22 src/cli/flags.md:52
+msgid "`--print-hir`"
+msgstr ""
+
+#: src/cli/commands.md:22
+msgid "Print HIR intermediate representation"
+msgstr ""
+
+#: src/cli/commands.md:23 src/cli/flags.md:53
+msgid "`--no-link`"
+msgstr ""
+
+#: src/cli/commands.md:23
+msgid "Produce object file only, skip linking"
+msgstr ""
+
+#: src/cli/commands.md:24 src/cli/flags.md:54
+msgid "`--keep-intermediates`"
+msgstr ""
+
+#: src/cli/commands.md:24
+msgid "Keep `.o` and `.asm` files"
+msgstr ""
+
+#: src/cli/commands.md:25 src/cli/commands.md:71 src/cli/flags.md:75
+msgid "`--enable-js-runtime`"
+msgstr ""
+
+#: src/cli/commands.md:25
+msgid "Enable V8 JavaScript runtime fallback"
+msgstr ""
+
+#: src/cli/commands.md:26 src/cli/commands.md:72 src/cli/flags.md:76
+msgid "`--type-check`"
+msgstr ""
+
+#: src/cli/commands.md:26 src/cli/commands.md:72
+msgid "Enable type checking via tsgo"
+msgstr ""
+
+#: src/cli/commands.md:27 src/cli/flags.md:60
+msgid "`--minify`"
+msgstr ""
+
+#: src/cli/commands.md:27 src/cli/flags.md:60
+msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
+msgstr ""
+
+#: src/cli/commands.md:28
+msgid "`--app-bundle-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:28
+msgid "Bundle ID (required for widget targets)"
+msgstr ""
+
+#: src/cli/commands.md:29
+msgid "`--bundle-extensions <DIR>`"
+msgstr ""
+
+#: src/cli/commands.md:29
+msgid "Bundle TypeScript extensions from directory"
+msgstr ""
+
+#: src/cli/commands.md:32
+msgid "# Basic compilation\n"
+msgstr ""
+
+#: src/cli/commands.md:34
+msgid "# Cross-compile for iOS Simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:37
+msgid "# Build a plugin\n"
+msgstr ""
+
+#: src/cli/commands.md:40
+msgid "# Debug: view intermediate representation\n"
+msgstr ""
+
+#: src/cli/commands.md:43
+msgid "# Build an iOS widget\n"
+msgstr ""
+
+#: src/cli/commands.md:50
+msgid "Compile and launch your app in one step."
+msgstr ""
+
+#: src/cli/commands.md:53
+msgid "# Auto-detect entry file\n"
+msgstr ""
+
+#: src/cli/commands.md:54
+msgid "# Run on iOS device/simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:55
+msgid "# Run on Apple Vision Pro simulator/device\n"
+msgstr ""
+
+#: src/cli/commands.md:56
+msgid "# Run on Android device\n"
+msgstr ""
+
+#: src/cli/commands.md:57
+msgid "# Forward args to your program\n"
+msgstr ""
+
+#: src/cli/commands.md:60 src/cli/commands.md:233
+msgid "Argument / Flag"
+msgstr ""
+
+#: src/cli/commands.md:62 src/cli/commands.md:236 src/cli/flags.md:24
+msgid "`ios`"
+msgstr ""
+
+#: src/cli/commands.md:62
+msgid "Target iOS (device or simulator)"
+msgstr ""
+
+#: src/cli/commands.md:63 src/cli/commands.md:237 src/cli/flags.md:26
+msgid "`visionos`"
+msgstr ""
+
+#: src/cli/commands.md:63
+msgid "Target visionOS (device or simulator)"
+msgstr ""
+
+#: src/cli/commands.md:64 src/cli/commands.md:235
+msgid "`macos`"
+msgstr ""
+
+#: src/cli/commands.md:64
+msgid "Target macOS (default on macOS host)"
+msgstr ""
+
+#: src/cli/commands.md:65 src/cli/flags.md:35
+msgid "`web`"
+msgstr ""
+
+#: src/cli/commands.md:65
+msgid "Target web (opens in browser)"
+msgstr ""
+
+#: src/cli/commands.md:66
+msgid "Target Android device"
+msgstr ""
+
+#: src/cli/commands.md:67
+msgid "`--simulator <UDID>`"
+msgstr ""
+
+#: src/cli/commands.md:67
+msgid "Specify iOS simulator by UDID"
+msgstr ""
+
+#: src/cli/commands.md:68
+msgid "`--device <UDID>`"
+msgstr ""
+
+#: src/cli/commands.md:68
+msgid "Specify iOS physical device by UDID"
+msgstr ""
+
+#: src/cli/commands.md:69
+msgid "`--local`"
+msgstr ""
+
+#: src/cli/commands.md:69
+msgid "Force local compilation (no remote fallback)"
+msgstr ""
+
+#: src/cli/commands.md:70
+msgid "`--remote`"
+msgstr ""
+
+#: src/cli/commands.md:70
+msgid "Force remote build via Perry Hub"
+msgstr ""
+
+#: src/cli/commands.md:71
+msgid "Enable V8 JavaScript runtime"
+msgstr ""
+
+#: src/cli/commands.md:73 src/cli/commands.md:113
+msgid "`--`"
+msgstr ""
+
+#: src/cli/commands.md:73
+msgid "Separator for program arguments"
+msgstr ""
+
+#: src/cli/commands.md:75
+msgid "**Entry file detection** (checked in order):"
+msgstr ""
+
+#: src/cli/commands.md:76
+msgid "`perry.toml` → `[project] entry` field"
+msgstr ""
+
+#: src/cli/commands.md:77
+msgid "`src/main.ts`"
+msgstr ""
+
+#: src/cli/commands.md:78
+msgid "`main.ts`"
+msgstr ""
+
+#: src/cli/commands.md:80
+msgid ""
+"**Device detection**: When targeting iOS, Perry auto-discovers available "
+"simulators (via `simctl`) and physical devices (via `devicectl`). For "
+"Android, it uses `adb`. When multiple targets are found, an interactive "
+"prompt lets you choose."
+msgstr ""
+
+#: src/cli/commands.md:82
+msgid ""
+"**Remote build fallback**: If cross-compilation toolchains aren't installed "
+"locally (e.g., Apple mobile targets on a machine without Xcode), `perry run "
+"ios` and `perry run visionos` can fall back to Perry Hub's build server when"
+" the backend supports the target. Use `--local` or `--remote` to force "
+"either path."
+msgstr ""
+
+#: src/cli/commands.md:85
+msgid "# Run a CLI program\n"
+msgstr ""
+
+#: src/cli/commands.md:87
+msgid "# Run on a specific simulator\n"
+msgstr ""
+
+#: src/cli/commands.md:90
+msgid "# Force remote build\n"
+msgstr ""
+
+#: src/cli/commands.md:93
+msgid "# Run web target\n"
+msgstr ""
+
+#: src/cli/commands.md:98
+msgid "dev"
+msgstr ""
+
+#: src/cli/commands.md:100
+msgid ""
+"Watch your TypeScript source tree and auto-recompile + relaunch on every "
+"save."
+msgstr ""
+
+#: src/cli/commands.md:103
+msgid "# watch + rebuild + relaunch on save\n"
+msgstr ""
+
+#: src/cli/commands.md:104
+msgid "# forward args to the child\n"
+msgstr ""
+
+#: src/cli/commands.md:105
+msgid "# watch an extra directory\n"
+msgstr ""
+
+#: src/cli/commands.md:106
+msgid "# override output path\n"
+msgstr ""
+
+#: src/cli/commands.md:111
+msgid "Output binary path (default: `.perry-dev/<entry-stem>`)"
+msgstr ""
+
+#: src/cli/commands.md:112
+msgid "`--watch <DIR>`"
+msgstr ""
+
+#: src/cli/commands.md:112
+msgid "Extra directories to watch (comma-separated or repeated)"
+msgstr ""
+
+#: src/cli/commands.md:113
+msgid "Separator — everything after is forwarded to the compiled binary"
+msgstr ""
+
+#: src/cli/commands.md:115
+msgid "**How it works:**"
+msgstr ""
+
+#: src/cli/commands.md:117
+msgid ""
+"Resolves the entry, computes the **project root** (walks up until it finds a"
+" `package.json` or `perry.toml`; falls back to the entry's parent "
+"directory)."
+msgstr ""
+
+#: src/cli/commands.md:118
+msgid ""
+"Does an initial `perry compile`, then spawns the resulting binary with stdio"
+" inherited."
+msgstr ""
+
+#: src/cli/commands.md:119
+msgid ""
+"Watches the project root (plus any `--watch` dirs) recursively using the "
+"`notify` crate. A 300 ms **debounce** window collapses editor \"save "
+"storms\" into one rebuild."
+msgstr ""
+
+#: src/cli/commands.md:120
+msgid ""
+"On each relevant change: kill the running child, recompile, relaunch. A "
+"failed build leaves the old child dead and waits for the next change; no "
+"crash loop."
+msgstr ""
+
+#: src/cli/commands.md:122
+msgid "**What counts as a \"relevant\" change:**"
+msgstr ""
+
+#: src/cli/commands.md:123
+msgid ""
+"**Trigger extensions:** `.ts`, `.tsx`, `.mts`, `.cts`, `.json`, `.toml`"
+msgstr ""
+
+#: src/cli/commands.md:124
+msgid ""
+"**Ignored directories (not watched, never retrigger):** `node_modules`, "
+"`target`, `.git`, `dist`, `build`, `.perry-dev`, `.perry-cache`"
+msgstr ""
+
+#: src/cli/commands.md:126
+msgid "**Benchmarks** (trivial single-file program, macOS):"
+msgstr ""
+
+#: src/cli/commands.md:128
+msgid "Phase"
+msgstr ""
+
+#: src/cli/commands.md:128
+msgid "Time"
+msgstr ""
+
+#: src/cli/commands.md:130
+msgid "Initial build (cold — runtime + stdlib rebuilt by auto-optimize)"
+msgstr ""
+
+#: src/cli/commands.md:130
+msgid "~15 s"
+msgstr ""
+
+#: src/cli/commands.md:131
+msgid "Post-edit rebuild (hot libs cached on disk)"
+msgstr ""
+
+#: src/cli/commands.md:131
+msgid "**~330 ms**"
+msgstr ""
+
+#: src/cli/commands.md:133
+msgid ""
+"The speedup on hot rebuilds comes from Perry's existing auto-optimize "
+"library cache. Multi-module projects will still recompile every changed "
+"module on each save — see the V2 note below for planned incremental work."
+msgstr ""
+
+#: src/cli/commands.md:135
+msgid "**Not yet in scope (V2+):**"
+msgstr ""
+
+#: src/cli/commands.md:136
+msgid "In-memory AST cache (reuse SWC parses across rebuilds)."
+msgstr ""
+
+#: src/cli/commands.md:137
+msgid "Per-module `.o` cache on disk (only re-codegen the changed module)."
+msgstr ""
+
+#: src/cli/commands.md:138
+msgid ""
+"State preservation across rebuilds / HMR — \"fast restart\" is the honest "
+"target."
+msgstr ""
+
+#: src/cli/commands.md:140
+msgid "check"
+msgstr ""
+
+#: src/cli/commands.md:142
+msgid "Validate TypeScript for Perry compatibility without compiling."
+msgstr ""
+
+#: src/cli/commands.md:150
+msgid "`--check-deps`"
+msgstr ""
+
+#: src/cli/commands.md:150
+msgid "Check `node_modules` for compatibility"
+msgstr ""
+
+#: src/cli/commands.md:151
+msgid "`--deep-deps`"
+msgstr ""
+
+#: src/cli/commands.md:151
+msgid "Scan all transitive dependencies"
+msgstr ""
+
+#: src/cli/commands.md:152
+msgid "`--all`"
+msgstr ""
+
+#: src/cli/commands.md:152
+msgid "Show all issues including hints"
+msgstr ""
+
+#: src/cli/commands.md:153
+msgid "`--strict`"
+msgstr ""
+
+#: src/cli/commands.md:153
+msgid "Treat warnings as errors"
+msgstr ""
+
+#: src/cli/commands.md:154
+msgid "`--fix`"
+msgstr ""
+
+#: src/cli/commands.md:154
+msgid "Automatically apply fixes"
+msgstr ""
+
+#: src/cli/commands.md:155
+msgid "`--fix-dry-run`"
+msgstr ""
+
+#: src/cli/commands.md:155
+msgid "Preview fixes without modifying files"
+msgstr ""
+
+#: src/cli/commands.md:156
+msgid "`--fix-unsafe`"
+msgstr ""
+
+#: src/cli/commands.md:156
+msgid "Include medium-confidence fixes"
+msgstr ""
+
+#: src/cli/commands.md:159
+msgid "# Check a single file\n"
+msgstr ""
+
+#: src/cli/commands.md:161
+msgid "# Check with dependency analysis\n"
+msgstr ""
+
+#: src/cli/commands.md:164
+msgid "# Auto-fix issues\n"
+msgstr ""
+
+#: src/cli/commands.md:167
+msgid "# Preview fixes without applying\n"
+msgstr ""
+
+#: src/cli/commands.md:172
+msgid "init"
+msgstr ""
+
+#: src/cli/commands.md:174
+msgid "Create a new Perry project."
+msgstr ""
+
+#: src/cli/commands.md:183
+msgid "`--name <NAME>`"
+msgstr ""
+
+#: src/cli/commands.md:183
+msgid "Project name (defaults to directory name)"
+msgstr ""
+
+#: src/cli/commands.md:185
+msgid "Creates `perry.toml`, `src/main.ts`, and `.gitignore`."
+msgstr ""
+
+#: src/cli/commands.md:187
+msgid "doctor"
+msgstr ""
+
+#: src/cli/commands.md:189
+msgid "Check your Perry installation and environment."
+msgstr ""
+
+#: src/cli/commands.md:197
+msgid "`--quiet`"
+msgstr ""
+
+#: src/cli/commands.md:197
+msgid "Only report failures"
+msgstr ""
+
+#: src/cli/commands.md:199
+msgid "Checks:"
+msgstr ""
+
+#: src/cli/commands.md:200
+msgid "Perry version"
+msgstr ""
+
+#: src/cli/commands.md:201
+msgid "System linker availability (cc/MSVC)"
+msgstr ""
+
+#: src/cli/commands.md:202
+msgid "Runtime library"
+msgstr ""
+
+#: src/cli/commands.md:203
+msgid "Project configuration"
+msgstr ""
+
+#: src/cli/commands.md:204
+msgid "Available updates"
+msgstr ""
+
+#: src/cli/commands.md:206
+msgid "explain"
+msgstr ""
+
+#: src/cli/commands.md:208
+msgid "Get detailed explanations for error codes."
+msgstr ""
+
+#: src/cli/commands.md:214
+msgid "Error code families:"
+msgstr ""
+
+#: src/cli/commands.md:215
+msgid "**P** — Parse errors"
+msgstr ""
+
+#: src/cli/commands.md:216
+msgid "**T** — Type errors"
+msgstr ""
+
+#: src/cli/commands.md:217
+msgid "**U** — Unsupported features"
+msgstr ""
+
+#: src/cli/commands.md:218
+msgid "**D** — Dependency issues"
+msgstr ""
+
+#: src/cli/commands.md:220
+msgid ""
+"Each explanation includes the error description, example code, and suggested"
+" fix."
+msgstr ""
+
+#: src/cli/commands.md:222
+msgid "publish"
+msgstr ""
+
+#: src/cli/commands.md:224
+msgid "Build, sign, and distribute your app."
+msgstr ""
+
+#: src/cli/commands.md:235
+msgid "Build for macOS (App Store/notarization)"
+msgstr ""
+
+#: src/cli/commands.md:236
+msgid "Build for iOS (App Store/TestFlight)"
+msgstr ""
+
+#: src/cli/commands.md:237
+msgid "Build for visionOS"
+msgstr ""
+
+#: src/cli/commands.md:238
+msgid "Build for Android (Google Play)"
+msgstr ""
+
+#: src/cli/commands.md:239
+msgid "Build for Linux (AppImage/deb/rpm)"
+msgstr ""
+
+#: src/cli/commands.md:240
+msgid "`--server <URL>`"
+msgstr ""
+
+#: src/cli/commands.md:240
+msgid "Build server (default: `https://hub.perryts.com`)"
+msgstr ""
+
+#: src/cli/commands.md:241
+msgid "`--license-key <KEY>`"
+msgstr ""
+
+#: src/cli/commands.md:241 src/cli/perry-toml.md:493
+msgid "Perry Hub license key"
+msgstr ""
+
+#: src/cli/commands.md:242
+msgid "`--project <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:242
+msgid "Project directory"
+msgstr ""
+
+#: src/cli/commands.md:243
+msgid "Artifact output directory (default: `dist`)"
+msgstr ""
+
+#: src/cli/commands.md:244
+msgid "`--no-download`"
+msgstr ""
+
+#: src/cli/commands.md:244
+msgid "Skip artifact download"
+msgstr ""
+
+#: src/cli/commands.md:246
+msgid "Apple-specific flags:"
+msgstr ""
+
+#: src/cli/commands.md:250
+msgid "`--apple-team-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:250
+msgid "Developer Team ID"
+msgstr ""
+
+#: src/cli/commands.md:251
+msgid "`--apple-identity <NAME>`"
+msgstr ""
+
+#: src/cli/commands.md:251
+msgid "Signing identity"
+msgstr ""
+
+#: src/cli/commands.md:252
+msgid "`--apple-p8-key <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:252
+msgid "App Store Connect .p8 key"
+msgstr ""
+
+#: src/cli/commands.md:253
+msgid "`--apple-key-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:253
+msgid "App Store Connect API Key ID"
+msgstr ""
+
+#: src/cli/commands.md:254
+msgid "`--apple-issuer-id <ID>`"
+msgstr ""
+
+#: src/cli/commands.md:254
+msgid "App Store Connect Issuer ID"
+msgstr ""
+
+#: src/cli/commands.md:255
+msgid "`--certificate <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:255
+msgid ".p12 certificate bundle"
+msgstr ""
+
+#: src/cli/commands.md:256
+msgid "`--provisioning-profile <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:256
+msgid ".mobileprovision file (iOS)"
+msgstr ""
+
+#: src/cli/commands.md:258
+msgid "Android-specific flags:"
+msgstr ""
+
+#: src/cli/commands.md:262
+msgid "`--android-keystore <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:262
+msgid ".jks/.keystore file"
+msgstr ""
+
+#: src/cli/commands.md:263
+msgid "`--android-keystore-password <PASS>`"
+msgstr ""
+
+#: src/cli/commands.md:263 src/cli/perry-toml.md:507
+msgid "Keystore password"
+msgstr ""
+
+#: src/cli/commands.md:264
+msgid "`--android-key-alias <ALIAS>`"
+msgstr ""
+
+#: src/cli/commands.md:264
+msgid "Key alias"
+msgstr ""
+
+#: src/cli/commands.md:265
+msgid "`--android-key-password <PASS>`"
+msgstr ""
+
+#: src/cli/commands.md:265
+msgid "Key password"
+msgstr ""
+
+#: src/cli/commands.md:266
+msgid "`--google-play-key <PATH>`"
+msgstr ""
+
+#: src/cli/commands.md:266
+msgid "Google Play service account JSON"
+msgstr ""
+
+#: src/cli/commands.md:268
+msgid "On first use, `publish` auto-registers a free license key."
+msgstr ""
+
+#: src/cli/commands.md:270
+msgid "setup"
+msgstr ""
+
+#: src/cli/commands.md:272
+msgid ""
+"Interactive credential wizard for app distribution, plus toolchain setup for"
+" Windows."
+msgstr ""
+
+#: src/cli/commands.md:275
+msgid "# Show platform menu\n"
+msgstr ""
+
+#: src/cli/commands.md:276
+msgid "# macOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:277
+msgid "# iOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:278
+msgid "# visionOS setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:279
+msgid "# Android setup (signing credentials)\n"
+msgstr ""
+
+#: src/cli/commands.md:280
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
+msgstr ""
+
+#: src/cli/commands.md:283
+msgid ""
+"`perry setup windows` downloads the Microsoft CRT + Windows SDK libraries "
+"(~1.5 GB) so Perry can link without Visual Studio Build Tools. Requires LLVM"
+" (`winget install LLVM.LLVM`) and prompts to accept the Microsoft "
+"redistributable license — pass `--accept-license` to skip the prompt for CI."
+" Output lands at `%LOCALAPPDATA%\\perry\\windows-sdk`. See the [Windows "
+"platform guide](../platforms/windows.md) for the full toolchain comparison."
+msgstr ""
+
+#: src/cli/commands.md:285
+msgid "Credential wizards store their output in `~/.perry/config.toml`."
+msgstr ""
+
+#: src/cli/commands.md:287
+msgid "update"
+msgstr ""
+
+#: src/cli/commands.md:289
+msgid "Check for and install Perry updates."
+msgstr ""
+
+#: src/cli/commands.md:292
+msgid "# Update to latest\n"
+msgstr ""
+
+#: src/cli/commands.md:293
+msgid "# Check without installing\n"
+msgstr ""
+
+#: src/cli/commands.md:294
+msgid "# Ignore 24h cache\n"
+msgstr ""
+
+#: src/cli/commands.md:297
+msgid "Update sources (checked in order):"
+msgstr ""
+
+#: src/cli/commands.md:298
+msgid "Custom server (env/config)"
+msgstr ""
+
+#: src/cli/commands.md:299
+msgid "Perry Hub"
+msgstr ""
+
+#: src/cli/commands.md:300
+msgid "GitHub API"
+msgstr ""
+
+#: src/cli/commands.md:302
+msgid ""
+"Opt out of automatic update checks with `PERRY_NO_UPDATE_CHECK=1` or "
+"`CI=true`."
+msgstr ""
+
+#: src/cli/commands.md:304
+msgid "i18n"
+msgstr ""
+
+#: src/cli/commands.md:306
+msgid ""
+"Internationalization tools for managing locale files and extracting "
+"localizable strings."
+msgstr ""
+
+#: src/cli/commands.md:310
+msgid "Scan source files and generate/update locale JSON scaffolds:"
+msgstr ""
+
+#: src/cli/commands.md:316
+msgid ""
+"Detects string literals in UI component calls (`Button`, `Text`, `Label`, "
+"etc.) and `t()` calls. Creates `locales/*.json` files based on the `[i18n]` "
+"config in `perry.toml`."
+msgstr ""
+
+#: src/cli/commands.md:318
+msgid "See the [i18n documentation](../i18n/overview.md) for full details."
+msgstr ""
+
+#: src/cli/commands.md:322
+msgid "[Compiler Flags](flags.md) — Complete flag reference"
+msgstr ""
+
+#: src/cli/commands.md:323
+msgid "[Getting Started](../getting-started/installation.md) — Installation"
+msgstr ""
+
+#: src/cli/flags.md:3
+msgid "Complete reference for all Perry CLI flags."
+msgstr ""
+
+#: src/cli/flags.md:5
+msgid "Global Flags"
+msgstr ""
+
+#: src/cli/flags.md:7
+msgid "Available on all commands:"
+msgstr ""
+
+#: src/cli/flags.md:11
+msgid "`--format text\\|json`"
+msgstr ""
+
+#: src/cli/flags.md:11
+msgid "Output format (default: `text`)"
+msgstr ""
+
+#: src/cli/flags.md:12
+msgid "`-v, --verbose`"
+msgstr ""
+
+#: src/cli/flags.md:12
+msgid "Increase verbosity (repeatable: `-v`, `-vv`, `-vvv`)"
+msgstr ""
+
+#: src/cli/flags.md:13
+msgid "`-q, --quiet`"
+msgstr ""
+
+#: src/cli/flags.md:13
+msgid "Suppress non-error output"
+msgstr ""
+
+#: src/cli/flags.md:14
+msgid "`--no-color`"
+msgstr ""
+
+#: src/cli/flags.md:14
+msgid "Disable ANSI color codes"
+msgstr ""
+
+#: src/cli/flags.md:16
+msgid "Compilation Targets"
+msgstr ""
+
+#: src/cli/flags.md:18
+msgid "Use `--target` to cross-compile:"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "_(none)_"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "Current platform"
+msgstr ""
+
+#: src/cli/flags.md:22
+msgid "Default behavior"
+msgstr ""
+
+#: src/cli/flags.md:23
+msgid "`ios-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:23
+msgid "ARM64 simulator binary"
+msgstr ""
+
+#: src/cli/flags.md:24
+msgid "ARM64 device binary"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "`visionos-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "visionOS Simulator"
+msgstr ""
+
+#: src/cli/flags.md:25
+msgid "Apple Vision Pro simulator build"
+msgstr ""
+
+#: src/cli/flags.md:26
+msgid "visionOS Device"
+msgstr ""
+
+#: src/cli/flags.md:26
+msgid "Apple Vision Pro device build"
+msgstr ""
+
+#: src/cli/flags.md:27
+msgid "ARM64/ARMv7"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "`ios-widget`"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "iOS Widget"
+msgstr ""
+
+#: src/cli/flags.md:28
+msgid "WidgetKit extension (requires `--app-bundle-id`)"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "`ios-widget-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "iOS Widget (Sim)"
+msgstr ""
+
+#: src/cli/flags.md:29
+msgid "Widget for simulator"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "`watchos-widget`"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "watchOS Complication"
+msgstr ""
+
+#: src/cli/flags.md:30
+msgid "WidgetKit extension for Apple Watch"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "`watchos-widget-simulator`"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "watchOS Widget (Sim)"
+msgstr ""
+
+#: src/cli/flags.md:31
+msgid "Widget for watchOS simulator"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "`android-widget`"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "Android Widget"
+msgstr ""
+
+#: src/cli/flags.md:32
+msgid "Android App Widget (AppWidgetProvider)"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "`wearos-tile`"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "Wear OS Tile"
+msgstr ""
+
+#: src/cli/flags.md:33
+msgid "Wear OS Tile (TileService)"
+msgstr ""
+
+#: src/cli/flags.md:34
+msgid "`wasm`"
+msgstr ""
+
+#: src/cli/flags.md:34
+msgid "Self-contained HTML with WASM or raw `.wasm` binary"
+msgstr ""
+
+#: src/cli/flags.md:35
+msgid "Outputs HTML file with JS"
+msgstr ""
+
+#: src/cli/flags.md:36
+msgid "Win32 executable"
+msgstr ""
+
+#: src/cli/flags.md:37
+msgid "GTK4 executable"
+msgstr ""
+
+#: src/cli/flags.md:39
+msgid "Output Types"
+msgstr ""
+
+#: src/cli/flags.md:41
+msgid "Use `--output-type` to change what's produced:"
+msgstr ""
+
+#: src/cli/flags.md:45
+msgid "`executable`"
+msgstr ""
+
+#: src/cli/flags.md:45
+msgid "Standalone binary (default)"
+msgstr ""
+
+#: src/cli/flags.md:46
+msgid "`dylib`"
+msgstr ""
+
+#: src/cli/flags.md:46
+msgid "Shared library (`.dylib`/`.so`) for [plugins](../plugins/overview.md)"
+msgstr ""
+
+#: src/cli/flags.md:48
+msgid "Debug Flags"
+msgstr ""
+
+#: src/cli/flags.md:52
+msgid "Print HIR (intermediate representation) to stdout"
+msgstr ""
+
+#: src/cli/flags.md:53
+msgid "Produce `.o` object file only, skip linking"
+msgstr ""
+
+#: src/cli/flags.md:54
+msgid "Keep `.o` and `.asm` intermediate files"
+msgstr ""
+
+#: src/cli/flags.md:56
+msgid "Output Optimization"
+msgstr ""
+
+#: src/cli/flags.md:62
+msgid ""
+"Minification strips comments, collapses whitespace, and mangles local "
+"variable/parameter/non-exported function names for smaller output."
+msgstr ""
+
+#: src/cli/flags.md:64
+msgid "Testing Flags"
+msgstr ""
+
+#: src/cli/flags.md:68
+msgid "`--enable-geisterhand`"
+msgstr ""
+
+#: src/cli/flags.md:68
+msgid ""
+"Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
+"programmatic UI testing (default port 7676)"
+msgstr ""
+
+#: src/cli/flags.md:69
+msgid "`--geisterhand-port <PORT>`"
+msgstr ""
+
+#: src/cli/flags.md:69
+msgid ""
+"Set a custom port for the Geisterhand server (implies `--enable-"
+"geisterhand`)"
+msgstr ""
+
+#: src/cli/flags.md:71
+msgid "Runtime Flags"
+msgstr ""
+
+#: src/cli/flags.md:75
+msgid "Enable V8 JavaScript runtime for unsupported npm packages"
+msgstr ""
+
+#: src/cli/flags.md:76
+msgid "Enable type checking via tsgo IPC"
+msgstr ""
+
+#: src/cli/flags.md:78 src/cli/perry-toml.md:485
+msgid "Environment Variables"
+msgstr ""
+
+#: src/cli/flags.md:80 src/cli/perry-toml.md:491 src/cli/perry-toml.md:503
+#: src/cli/perry-toml.md:513
+msgid "Variable"
+msgstr ""
+
+#: src/cli/flags.md:82 src/cli/perry-toml.md:493
+msgid "`PERRY_LICENSE_KEY`"
+msgstr ""
+
+#: src/cli/flags.md:82
+msgid "Perry Hub license key for `perry publish`"
+msgstr ""
+
+#: src/cli/flags.md:83 src/cli/perry-toml.md:495
+msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/flags.md:83
+msgid "Password for .p12 certificate"
+msgstr ""
+
+#: src/cli/flags.md:84
+msgid "`PERRY_NO_UPDATE_CHECK=1`"
+msgstr ""
+
+#: src/cli/flags.md:84
+msgid "Disable automatic update checks"
+msgstr ""
+
+#: src/cli/flags.md:85
+msgid "`PERRY_UPDATE_SERVER`"
+msgstr ""
+
+#: src/cli/flags.md:85
+msgid "Custom update server URL"
+msgstr ""
+
+#: src/cli/flags.md:86
+msgid "`CI=true`"
+msgstr ""
+
+#: src/cli/flags.md:86
+msgid "Auto-skip update checks (set by most CI systems)"
+msgstr ""
+
+#: src/cli/flags.md:87
+msgid "`RUST_LOG`"
+msgstr ""
+
+#: src/cli/flags.md:87
+msgid "Debug logging level (`debug`, `info`, `trace`)"
+msgstr ""
+
+#: src/cli/flags.md:89
+msgid "Configuration Files"
+msgstr ""
+
+#: src/cli/flags.md:91
+msgid "perry.toml (project)"
+msgstr ""
+
+#: src/cli/flags.md:93
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"entry = \"src/main.ts\"\n"
+"version = \"1.0.0\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"build\"\n"
+"\n"
+"[app]\n"
+"name = \"My App\"\n"
+"description = \"A Perry application\"\n"
+"\n"
+"[macos]\n"
+"bundle_id = \"com.example.myapp\"\n"
+"category = \"public.app-category.developer-tools\"\n"
+"minimum_os = \"13.0\"\n"
+"distribute = \"notarize\"  # \"appstore\", \"notarize\", or \"both\"\n"
+"\n"
+"[ios]\n"
+"bundle_id = \"com.example.myapp\"\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = 26\n"
+"target_sdk = 34\n"
+"\n"
+"[linux]\n"
+"format = \"appimage\"  # \"appimage\", \"deb\", \"rpm\"\n"
+"category = \"Development\"\n"
+"```"
+msgstr ""
+
+#: src/cli/flags.md:127
+msgid "~/.perry/config.toml (global)"
+msgstr ""
+
+#: src/cli/flags.md:129
+msgid ""
+"```toml\n"
+"[apple]\n"
+"team_id = \"XXXXXXXXXX\"\n"
+"signing_identity = \"Developer ID Application: Your Name\"\n"
+"\n"
+"[android]\n"
+"keystore_path = \"/path/to/keystore.jks\"\n"
+"key_alias = \"my-key\"\n"
+"```"
+msgstr ""
+
+#: src/cli/flags.md:142
+msgid "# Simple CLI program\n"
+msgstr ""
+
+#: src/cli/flags.md:144
+msgid "# iOS app for simulator\n"
+msgstr ""
+
+#: src/cli/flags.md:147
+msgid "# visionOS app for simulator\n"
+msgstr ""
+
+#: src/cli/flags.md:150
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
+msgstr ""
+
+#: src/cli/flags.md:153
+msgid "# Plugin shared library\n"
+msgstr ""
+
+#: src/cli/flags.md:156
+msgid "# iOS widget with bundle ID\n"
+msgstr ""
+
+#: src/cli/flags.md:159
+msgid "# Debug compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:162
+msgid "# Verbose compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:165
+msgid "# Type-checked compilation\n"
+msgstr ""
+
+#: src/cli/flags.md:168
+msgid "# Raw WASM binary (no HTML wrapper)\n"
+msgstr ""
+
+#: src/cli/flags.md:171
+msgid "# Minified web output (compresses embedded JS bridge)\n"
+msgstr ""
+
+#: src/cli/flags.md:178
+msgid "[Commands](commands.md) — All CLI commands"
+msgstr ""
+
+#: src/cli/flags.md:179
+msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
+msgstr ""
+
+#: src/cli/perry-toml.md:3
+msgid ""
+"`perry.toml` is the project-level configuration file for Perry. It controls "
+"project metadata, build settings, platform-specific options, code signing, "
+"distribution, auditing, and verification."
+msgstr ""
+
+#: src/cli/perry-toml.md:5
+msgid ""
+"Created automatically by `perry init`, it lives at the root of your project "
+"alongside `package.json`."
+msgstr ""
+
+#: src/cli/perry-toml.md:7
+msgid "Minimal Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:9
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"dist\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:18
+msgid "Full Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:20
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"version = \"1.2.0\"\n"
+"build_number = 42\n"
+"bundle_id = \"com.example.myapp\"\n"
+"description = \"A cross-platform Perry application\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[project.icons]\n"
+"source = \"assets/icon.png\"\n"
+"\n"
+"[build]\n"
+"out_dir = \"dist\"\n"
+"\n"
+"[macos]\n"
+"bundle_id = \"com.example.myapp.macos\"\n"
+"category = \"public.app-category.developer-tools\"\n"
+"minimum_os = \"13.0\"\n"
+"entitlements = [\"com.apple.security.network.client\"]\n"
+"distribute = \"both\"\n"
+"signing_identity = \"Developer ID Application: My Company (TEAMID)\"\n"
+"certificate = \"certs/mac-appstore.p12\"\n"
+"notarize_certificate = \"certs/mac-devid.p12\"\n"
+"notarize_signing_identity = \"Developer ID Application: My Company (TEAMID)\"\n"
+"installer_certificate = \"certs/mac-installer.p12\"\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"certs/AuthKey.p8\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[ios]\n"
+"bundle_id = \"com.example.myapp.ios\"\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"orientations = [\"portrait\", \"landscape-left\", \"landscape-right\"]\n"
+"capabilities = [\"push-notification\"]\n"
+"distribute = \"appstore\"\n"
+"entry = \"src/main-ios.ts\"\n"
+"provisioning_profile = \"certs/MyApp.mobileprovision\"\n"
+"certificate = \"certs/ios-distribution.p12\"\n"
+"signing_identity = \"iPhone Distribution: My Company (TEAMID)\"\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"certs/AuthKey.p8\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = \"26\"\n"
+"target_sdk = \"34\"\n"
+"permissions = [\"INTERNET\", \"CAMERA\"]\n"
+"distribute = \"playstore\"\n"
+"keystore = \"certs/release.keystore\"\n"
+"key_alias = \"my-key\"\n"
+"google_play_key = \"certs/play-service-account.json\"\n"
+"entry = \"src/main-android.ts\"\n"
+"\n"
+"[linux]\n"
+"format = \"appimage\"\n"
+"category = \"Development\"\n"
+"description = \"A cross-platform Perry application\"\n"
+"\n"
+"[i18n]\n"
+"locales = [\"en\", \"de\", \"fr\"]\n"
+"default_locale = \"en\"\n"
+"\n"
+"[i18n.currencies]\n"
+"en = \"USD\"\n"
+"de = \"EUR\"\n"
+"fr = \"EUR\"\n"
+"\n"
+"[publish]\n"
+"server = \"https://hub.perryts.com\"\n"
+"\n"
+"[audit]\n"
+"fail_on = \"B\"\n"
+"severity = \"high\"\n"
+"ignore = [\"RULE-001\", \"RULE-002\"]\n"
+"\n"
+"[verify]\n"
+"url = \"https://verify.perryts.com\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:110 src/cli/perry-toml.md:558
+msgid "`[project]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:112
+msgid ""
+"Core project metadata. This is the primary section for identifying your "
+"application."
+msgstr ""
+
+#: src/cli/perry-toml.md:114 src/cli/perry-toml.md:125
+#: src/cli/perry-toml.md:153 src/cli/perry-toml.md:165
+#: src/cli/perry-toml.md:175 src/cli/perry-toml.md:181
+#: src/cli/perry-toml.md:191 src/cli/perry-toml.md:241
+#: src/cli/perry-toml.md:254 src/cli/perry-toml.md:260
+#: src/cli/perry-toml.md:268 src/cli/perry-toml.md:299
+#: src/cli/perry-toml.md:310 src/cli/perry-toml.md:327
+#: src/cli/perry-toml.md:345 src/cli/perry-toml.md:357
+#: src/cli/perry-toml.md:377 src/cli/perry-toml.md:387
+#: src/cli/perry-toml.md:414
+msgid "Default"
+msgstr ""
+
+#: src/cli/perry-toml.md:116
+msgid "Directory name"
+msgstr ""
+
+#: src/cli/perry-toml.md:116
+msgid "Project name, used for binary output name and default bundle ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:117
+msgid "`\"1.0.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:117
+msgid "Semantic version string (e.g., `\"1.2.3\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "`build_number`"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "integer"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid "`1`"
+msgstr ""
+
+#: src/cli/perry-toml.md:118
+msgid ""
+"Numeric build number; auto-incremented on `perry publish` for iOS, Android, "
+"and macOS App Store builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:119
+msgid "Human-readable project description"
+msgstr ""
+
+#: src/cli/perry-toml.md:120 src/cli/perry-toml.md:249
+#: src/cli/perry-toml.md:304 src/cli/perry-toml.md:337
+msgid "`entry`"
+msgstr ""
+
+#: src/cli/perry-toml.md:120
+msgid ""
+"TypeScript entry file (e.g., `\"src/main.ts\"`). Used by `perry run` and "
+"`perry publish` when no input file is specified"
+msgstr ""
+
+#: src/cli/perry-toml.md:121 src/cli/perry-toml.md:167
+#: src/cli/perry-toml.md:243 src/cli/perry-toml.md:301
+msgid "`bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:121
+msgid "`com.perry.<name>`"
+msgstr ""
+
+#: src/cli/perry-toml.md:121
+msgid ""
+"Default bundle identifier, used as fallback when platform-specific sections "
+"don't define one"
+msgstr ""
+
+#: src/cli/perry-toml.md:123
+msgid "`[project.icons]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:127
+msgid "`source`"
+msgstr ""
+
+#: src/cli/perry-toml.md:127
+msgid ""
+"Path to a source icon image (PNG or JPG). Perry auto-resizes this to all "
+"required sizes for each platform"
+msgstr ""
+
+#: src/cli/perry-toml.md:129
+msgid "`[app]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:131
+msgid ""
+"Alternative to `[project]` with identical fields. Useful for organizational "
+"clarity — `[app]` takes precedence over `[project]` when both are present:"
+msgstr ""
+
+#: src/cli/perry-toml.md:133
+msgid ""
+"```toml\n"
+"# These two are equivalent:\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"\n"
+"# or:\n"
+"[app]\n"
+"name = \"my-app\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:143
+msgid ""
+"When both exist, resolution order is: `[app]` field -> `[project]` field -> "
+"default."
+msgstr ""
+
+#: src/cli/perry-toml.md:145
+msgid ""
+"`[app]` supports the same fields as `[project]`: `name`, `version`, "
+"`build_number`, `bundle_id`, `description`, `entry`, and `icons`."
+msgstr ""
+
+#: src/cli/perry-toml.md:149 src/cli/perry-toml.md:561
+msgid "`[build]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:151
+msgid "Build output settings."
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "`out_dir`"
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "`\"dist\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:155
+msgid "Directory for build artifacts"
+msgstr ""
+
+#: src/cli/perry-toml.md:159
+msgid "`[macos]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:161
+msgid ""
+"macOS-specific configuration for `perry publish macos` and `perry compile "
+"--target macos`."
+msgstr ""
+
+#: src/cli/perry-toml.md:163 src/cli/perry-toml.md:239
+#: src/cli/perry-toml.md:297
+msgid "App Metadata"
+msgstr ""
+
+#: src/cli/perry-toml.md:167 src/cli/perry-toml.md:243
+msgid "Falls back to `[app]`/`[project]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:167
+msgid "macOS-specific bundle identifier (e.g., `\"com.example.myapp\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:168 src/cli/perry-toml.md:348
+msgid "`category`"
+msgstr ""
+
+#: src/cli/perry-toml.md:168
+msgid ""
+"Mac App Store category. Uses Apple's UTI format (see [valid values](#macos-"
+"app-store-categories) below)"
+msgstr ""
+
+#: src/cli/perry-toml.md:169
+msgid "`minimum_os`"
+msgstr ""
+
+#: src/cli/perry-toml.md:169
+msgid "Minimum macOS version required (e.g., `\"13.0\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:170
+msgid "`entitlements`"
+msgstr ""
+
+#: src/cli/perry-toml.md:170 src/cli/perry-toml.md:246
+#: src/cli/perry-toml.md:247 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:332 src/cli/perry-toml.md:359
+#: src/cli/perry-toml.md:391
+msgid "string\\[\\]"
+msgstr ""
+
+#: src/cli/perry-toml.md:170
+msgid ""
+"macOS entitlements to include in the code signature (e.g., "
+"`[\"com.apple.security.network.client\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305
+msgid "`encryption_exempt`"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305
+msgid "bool"
+msgstr ""
+
+#: src/cli/perry-toml.md:171 src/cli/perry-toml.md:250
+#: src/cli/perry-toml.md:305 src/cli/perry-toml.md:361
+msgid "`false`"
+msgstr ""
+
+#: src/cli/perry-toml.md:171
+msgid ""
+"If `true`, adds `ITSAppUsesNonExemptEncryption = false` to Info.plist, "
+"skipping the export compliance prompt in App Store Connect"
+msgstr ""
+
+#: src/cli/perry-toml.md:173 src/cli/perry-toml.md:252
+msgid "Distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:177 src/cli/perry-toml.md:256
+#: src/cli/perry-toml.md:312 src/cli/perry-toml.md:333
+msgid "`distribute`"
+msgstr ""
+
+#: src/cli/perry-toml.md:177
+msgid ""
+"Distribution method: `\"appstore\"`, `\"notarize\"`, or `\"both\"` (see "
+"[Distribution Modes](#macos-distribution-modes))"
+msgstr ""
+
+#: src/cli/perry-toml.md:183 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:313
+msgid "`signing_identity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:183 src/cli/perry-toml.md:262
+#: src/cli/perry-toml.md:313
+msgid "Auto-detected from Keychain"
+msgstr ""
+
+#: src/cli/perry-toml.md:183
+msgid ""
+"Code signing identity name (e.g., `\"3rd Party Mac Developer Application: "
+"Company (TEAMID)\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:263
+#: src/cli/perry-toml.md:314
+msgid "`certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:184 src/cli/perry-toml.md:263
+#: src/cli/perry-toml.md:314
+msgid "Auto-exported from Keychain"
+msgstr ""
+
+#: src/cli/perry-toml.md:184
+msgid "Path to `.p12` certificate file for App Store distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:185
+msgid "`notarize_certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:185
+msgid ""
+"Separate `.p12` certificate for notarization (only used with `distribute = "
+"\"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:186
+msgid "`notarize_signing_identity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:186
+msgid "Signing identity for notarization (only used with `distribute = \"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:187
+msgid "`installer_certificate`"
+msgstr ""
+
+#: src/cli/perry-toml.md:187
+msgid "`.p12` certificate for Mac Installer Distribution (`.pkg` signing)"
+msgstr ""
+
+#: src/cli/perry-toml.md:189 src/cli/perry-toml.md:266
+msgid "App Store Connect"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:270
+#: src/cli/perry-toml.md:316
+msgid "`team_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:194
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:196
+#: src/cli/perry-toml.md:270 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:272 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:316 src/cli/perry-toml.md:317
+#: src/cli/perry-toml.md:318 src/cli/perry-toml.md:319
+msgid "From `~/.perry/config.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:193 src/cli/perry-toml.md:270
+#: src/cli/perry-toml.md:316
+msgid "Apple Developer Team ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:194 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:317
+msgid "`key_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:194 src/cli/perry-toml.md:271
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:497
+msgid "App Store Connect API key ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:272
+#: src/cli/perry-toml.md:318
+msgid "`issuer_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:195 src/cli/perry-toml.md:272
+#: src/cli/perry-toml.md:318
+msgid "App Store Connect issuer ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:196 src/cli/perry-toml.md:273
+#: src/cli/perry-toml.md:319
+msgid "`p8_key_path`"
+msgstr ""
+
+#: src/cli/perry-toml.md:196
+msgid "Path to App Store Connect `.p8` API key file"
+msgstr ""
+
+#: src/cli/perry-toml.md:198
+msgid "macOS Distribution Modes"
+msgstr ""
+
+#: src/cli/perry-toml.md:200
+msgid ""
+"The `distribute` field controls how your macOS app is signed and "
+"distributed:"
+msgstr ""
+
+#: src/cli/perry-toml.md:202
+msgid ""
+"**`\"appstore\"`** — Signs with an App Store distribution certificate and "
+"uploads to App Store Connect. Requires `team_id`, `key_id`, `issuer_id`, and"
+" `p8_key_path`."
+msgstr ""
+
+#: src/cli/perry-toml.md:204
+msgid ""
+"**`\"notarize\"`** — Signs with a Developer ID certificate and notarizes "
+"with Apple. For direct distribution outside the App Store."
+msgstr ""
+
+#: src/cli/perry-toml.md:206
+msgid ""
+"**`\"both\"`** — Produces **two** signed builds: one for the App Store and "
+"one notarized for direct distribution. Requires **two separate "
+"certificates**:"
+msgstr ""
+
+#: src/cli/perry-toml.md:207
+msgid "`certificate` + `signing_identity` for the App Store build"
+msgstr ""
+
+#: src/cli/perry-toml.md:208
+msgid ""
+"`notarize_certificate` + `notarize_signing_identity` for the notarized build"
+msgstr ""
+
+#: src/cli/perry-toml.md:209
+msgid "Optionally `installer_certificate` for `.pkg` signing"
+msgstr ""
+
+#: src/cli/perry-toml.md:211
+msgid "macOS App Store Categories"
+msgstr ""
+
+#: src/cli/perry-toml.md:213
+msgid "Common values for the `category` field (Apple UTI format):"
+msgstr ""
+
+#: src/cli/perry-toml.md:215
+msgid "Category"
+msgstr ""
+
+#: src/cli/perry-toml.md:217
+msgid "Business"
+msgstr ""
+
+#: src/cli/perry-toml.md:217
+msgid "`public.app-category.business`"
+msgstr ""
+
+#: src/cli/perry-toml.md:218
+msgid "Developer Tools"
+msgstr ""
+
+#: src/cli/perry-toml.md:218
+msgid "`public.app-category.developer-tools`"
+msgstr ""
+
+#: src/cli/perry-toml.md:219
+msgid "Education"
+msgstr ""
+
+#: src/cli/perry-toml.md:219
+msgid "`public.app-category.education`"
+msgstr ""
+
+#: src/cli/perry-toml.md:220
+msgid "Entertainment"
+msgstr ""
+
+#: src/cli/perry-toml.md:220
+msgid "`public.app-category.entertainment`"
+msgstr ""
+
+#: src/cli/perry-toml.md:221
+msgid "Finance"
+msgstr ""
+
+#: src/cli/perry-toml.md:221
+msgid "`public.app-category.finance`"
+msgstr ""
+
+#: src/cli/perry-toml.md:222
+msgid "Games"
+msgstr ""
+
+#: src/cli/perry-toml.md:222
+msgid "`public.app-category.games`"
+msgstr ""
+
+#: src/cli/perry-toml.md:223
+msgid "Graphics & Design"
+msgstr ""
+
+#: src/cli/perry-toml.md:223
+msgid "`public.app-category.graphics-design`"
+msgstr ""
+
+#: src/cli/perry-toml.md:224
+msgid "Health & Fitness"
+msgstr ""
+
+#: src/cli/perry-toml.md:224
+msgid "`public.app-category.healthcare-fitness`"
+msgstr ""
+
+#: src/cli/perry-toml.md:225
+msgid "Lifestyle"
+msgstr ""
+
+#: src/cli/perry-toml.md:225
+msgid "`public.app-category.lifestyle`"
+msgstr ""
+
+#: src/cli/perry-toml.md:226
+msgid "Music"
+msgstr ""
+
+#: src/cli/perry-toml.md:226
+msgid "`public.app-category.music`"
+msgstr ""
+
+#: src/cli/perry-toml.md:227
+msgid "News"
+msgstr ""
+
+#: src/cli/perry-toml.md:227
+msgid "`public.app-category.news`"
+msgstr ""
+
+#: src/cli/perry-toml.md:228
+msgid "Photography"
+msgstr ""
+
+#: src/cli/perry-toml.md:228
+msgid "`public.app-category.photography`"
+msgstr ""
+
+#: src/cli/perry-toml.md:229
+msgid "Productivity"
+msgstr ""
+
+#: src/cli/perry-toml.md:229
+msgid "`public.app-category.productivity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:230
+msgid "Social Networking"
+msgstr ""
+
+#: src/cli/perry-toml.md:230
+msgid "`public.app-category.social-networking`"
+msgstr ""
+
+#: src/cli/perry-toml.md:231
+msgid "`public.app-category.utilities`"
+msgstr ""
+
+#: src/cli/perry-toml.md:235
+msgid "`[ios]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:237
+msgid ""
+"iOS-specific configuration for `perry publish ios`, `perry run ios`, and "
+"`perry compile --target ios`/`--target ios-simulator`."
+msgstr ""
+
+#: src/cli/perry-toml.md:243
+msgid "iOS-specific bundle identifier"
+msgstr ""
+
+#: src/cli/perry-toml.md:244 src/cli/perry-toml.md:302
+msgid "`deployment_target`"
+msgstr ""
+
+#: src/cli/perry-toml.md:244
+msgid "`\"17.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:244
+msgid "Minimum iOS version required (e.g., `\"16.0\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:303
+msgid "`minimum_version`"
+msgstr ""
+
+#: src/cli/perry-toml.md:245 src/cli/perry-toml.md:303
+msgid "Alias for `deployment_target`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "`device_family`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "`[\"iphone\", \"ipad\"]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:246
+msgid "Supported device families"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "`orientations`"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "`[\"portrait\"]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:247
+msgid "Supported interface orientations"
+msgstr ""
+
+#: src/cli/perry-toml.md:248
+msgid "`capabilities`"
+msgstr ""
+
+#: src/cli/perry-toml.md:248
+msgid "App capabilities (e.g., `[\"push-notification\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:249 src/cli/perry-toml.md:304
+#: src/cli/perry-toml.md:337 src/cli/perry-toml.md:349
+msgid "Falls back to `[project]`/`[app]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:249
+msgid ""
+"iOS-specific entry file (useful when iOS needs a different entry point)"
+msgstr ""
+
+#: src/cli/perry-toml.md:250 src/cli/perry-toml.md:305
+msgid "If `true`, adds `ITSAppUsesNonExemptEncryption = false` to Info.plist"
+msgstr ""
+
+#: src/cli/perry-toml.md:256
+msgid "Distribution method: `\"appstore\"`, `\"testflight\"`, or `\"development\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:262
+msgid "Code signing identity (e.g., `\"iPhone Distribution: Company (TEAMID)\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:263 src/cli/perry-toml.md:314
+msgid "Path to `.p12` distribution certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:264 src/cli/perry-toml.md:315
+msgid "`provisioning_profile`"
+msgstr ""
+
+#: src/cli/perry-toml.md:264
+msgid ""
+"Path to `.mobileprovision` file. Stored as `{bundle_id}.mobileprovision` in "
+"`~/.perry/` by `perry setup ios`"
+msgstr ""
+
+#: src/cli/perry-toml.md:273 src/cli/perry-toml.md:319
+msgid "Path to `.p8` API key file"
+msgstr ""
+
+#: src/cli/perry-toml.md:275
+msgid "Device Family Values"
+msgstr ""
+
+#: src/cli/perry-toml.md:279
+msgid "`\"iphone\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:279
+msgid "iPhone devices"
+msgstr ""
+
+#: src/cli/perry-toml.md:280
+msgid "`\"ipad\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:280
+msgid "iPad devices"
+msgstr ""
+
+#: src/cli/perry-toml.md:282
+msgid "Orientation Values"
+msgstr ""
+
+#: src/cli/perry-toml.md:286
+msgid "`\"portrait\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:286
+msgid "Device upright"
+msgstr ""
+
+#: src/cli/perry-toml.md:287
+msgid "`\"portrait-upside-down\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:287
+msgid "Device upside down"
+msgstr ""
+
+#: src/cli/perry-toml.md:288
+msgid "`\"landscape-left\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:288
+msgid "Device rotated left"
+msgstr ""
+
+#: src/cli/perry-toml.md:289
+msgid "`\"landscape-right\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:289
+msgid "Device rotated right"
+msgstr ""
+
+#: src/cli/perry-toml.md:293
+msgid "`[visionos]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:295
+msgid ""
+"visionOS-specific configuration for `perry publish visionos`, `perry run "
+"visionos`, and `perry compile --target visionos`/`--target visionos-"
+"simulator`."
+msgstr ""
+
+#: src/cli/perry-toml.md:301
+msgid "Falls back to `[app]`/`[project]`/`[ios]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:301
+msgid "visionOS-specific bundle identifier"
+msgstr ""
+
+#: src/cli/perry-toml.md:302
+msgid "`\"1.0\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:302
+msgid "Minimum visionOS version required"
+msgstr ""
+
+#: src/cli/perry-toml.md:304
+msgid "visionOS-specific entry file"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "`info_plist`"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "table"
+msgstr ""
+
+#: src/cli/perry-toml.md:306
+msgid "Custom key-value pairs merged into the generated Info.plist"
+msgstr ""
+
+#: src/cli/perry-toml.md:308
+msgid "Distribution / Signing"
+msgstr ""
+
+#: src/cli/perry-toml.md:312
+msgid "Distribution method for visionOS builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:313
+msgid "Code signing identity"
+msgstr ""
+
+#: src/cli/perry-toml.md:315
+msgid "Path to `.mobileprovision` file"
+msgstr ""
+
+#: src/cli/perry-toml.md:323
+msgid "`[android]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:325
+msgid ""
+"Android-specific configuration for `perry publish android`, `perry run "
+"android`, and `perry compile --target android`."
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "`package_name`"
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "Falls back to bundle_id chain"
+msgstr ""
+
+#: src/cli/perry-toml.md:329
+msgid "Java package name (e.g., `\"com.example.myapp\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:330
+msgid "`min_sdk`"
+msgstr ""
+
+#: src/cli/perry-toml.md:330
+msgid "Minimum Android SDK version (e.g., `\"26\"` for Android 8.0)"
+msgstr ""
+
+#: src/cli/perry-toml.md:331
+msgid "`target_sdk`"
+msgstr ""
+
+#: src/cli/perry-toml.md:331
+msgid "Target Android SDK version (e.g., `\"34\"` for Android 14)"
+msgstr ""
+
+#: src/cli/perry-toml.md:332
+msgid "`permissions`"
+msgstr ""
+
+#: src/cli/perry-toml.md:332
+msgid "Android permissions (e.g., `[\"INTERNET\", \"CAMERA\", \"ACCESS_FINE_LOCATION\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:333
+msgid "Distribution method: `\"playstore\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:334
+msgid "`keystore`"
+msgstr ""
+
+#: src/cli/perry-toml.md:334
+msgid "Path to `.jks` or `.keystore` signing keystore"
+msgstr ""
+
+#: src/cli/perry-toml.md:335
+msgid "`key_alias`"
+msgstr ""
+
+#: src/cli/perry-toml.md:335
+msgid "Alias of the signing key within the keystore"
+msgstr ""
+
+#: src/cli/perry-toml.md:336
+msgid "`google_play_key`"
+msgstr ""
+
+#: src/cli/perry-toml.md:336
+msgid "Path to Google Play service account JSON file for automated uploads"
+msgstr ""
+
+#: src/cli/perry-toml.md:337
+msgid "Android-specific entry file"
+msgstr ""
+
+#: src/cli/perry-toml.md:341
+msgid "`[linux]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:343
+msgid "Linux-specific configuration for `perry publish linux`."
+msgstr ""
+
+#: src/cli/perry-toml.md:347
+msgid "`format`"
+msgstr ""
+
+#: src/cli/perry-toml.md:347
+msgid "Package format: `\"appimage\"`, `\"deb\"`, or `\"rpm\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:348
+msgid "Desktop application category (e.g., `\"Development\"`, `\"Utility\"`, `\"Game\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:349
+msgid "Application description for package metadata"
+msgstr ""
+
+#: src/cli/perry-toml.md:353
+msgid "`[i18n]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:355
+msgid ""
+"Internationalization configuration. See the [i18n "
+"documentation](../i18n/overview.md) for full details."
+msgstr ""
+
+#: src/cli/perry-toml.md:359
+msgid "`locales`"
+msgstr ""
+
+#: src/cli/perry-toml.md:359
+msgid ""
+"Supported locale codes (e.g., `[\"en\", \"de\", \"fr\"]`). Locale files must"
+" exist in `/locales`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "`default_locale`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "`\"en\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:360
+msgid "Fallback locale. Used when a key is missing in another locale"
+msgstr ""
+
+#: src/cli/perry-toml.md:361
+msgid "`dynamic`"
+msgstr ""
+
+#: src/cli/perry-toml.md:361
+msgid ""
+"`false`: locale set at launch, strings inlined. `true`: locale switchable at"
+" runtime"
+msgstr ""
+
+#: src/cli/perry-toml.md:363
+msgid "`[i18n.currencies]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:365
+msgid ""
+"Maps locale codes to default ISO 4217 currency codes. Used by the "
+"`Currency()` format wrapper."
+msgstr ""
+
+#: src/cli/perry-toml.md:369
+msgid "`{locale}`"
+msgstr ""
+
+#: src/cli/perry-toml.md:369
+msgid "Currency code for the locale (e.g., `en = \"USD\"`, `de = \"EUR\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:373
+msgid "`[publish]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:375
+msgid "Publishing configuration."
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid "`server`"
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid "`https://hub.perryts.com`"
+msgstr ""
+
+#: src/cli/perry-toml.md:379
+msgid ""
+"Custom Perry Hub build server URL. Useful for self-hosted or enterprise "
+"deployments"
+msgstr ""
+
+#: src/cli/perry-toml.md:383
+msgid "`[audit]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:385
+msgid "Security audit configuration for `perry audit` and pre-publish audits."
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid "`fail_on`"
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid "`\"C\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:389
+msgid ""
+"Minimum acceptable audit grade. Build fails if the actual grade is below "
+"this threshold. Values: `\"A\"`, `\"A-\"`, `\"B\"`, `\"C\"`, `\"D\"`, "
+"`\"F\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid "`severity`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid "`\"all\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:390
+msgid ""
+"Filter findings by severity: `\"all\"`, `\"critical\"`, `\"high\"`, "
+"`\"medium\"`, `\"low\"`"
+msgstr ""
+
+#: src/cli/perry-toml.md:391
+msgid "`ignore`"
+msgstr ""
+
+#: src/cli/perry-toml.md:391
+msgid "List of audit rule IDs to suppress (e.g., `[\"RULE-001\", \"RULE-042\"]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:393
+msgid "Audit Grade Scale"
+msgstr ""
+
+#: src/cli/perry-toml.md:395
+msgid "Grades are ranked from highest to lowest:"
+msgstr ""
+
+#: src/cli/perry-toml.md:397
+msgid "Grade"
+msgstr ""
+
+#: src/cli/perry-toml.md:397
+msgid "Rank"
+msgstr ""
+
+#: src/cli/perry-toml.md:399
+msgid "A"
+msgstr ""
+
+#: src/cli/perry-toml.md:399
+msgid "Excellent — no significant findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:400
+msgid "A-"
+msgstr ""
+
+#: src/cli/perry-toml.md:400
+msgid "Very good — minor findings only"
+msgstr ""
+
+#: src/cli/perry-toml.md:401
+msgid "B"
+msgstr ""
+
+#: src/cli/perry-toml.md:401
+msgid "Good — some findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:402
+msgid "C"
+msgstr ""
+
+#: src/cli/perry-toml.md:402
+msgid "Acceptable — moderate findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:403
+msgid "D"
+msgstr ""
+
+#: src/cli/perry-toml.md:403
+msgid "Poor — significant findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:404
+msgid "F"
+msgstr ""
+
+#: src/cli/perry-toml.md:404
+msgid "Fail — critical findings"
+msgstr ""
+
+#: src/cli/perry-toml.md:406
+msgid ""
+"Setting `fail_on = \"B\"` means any grade below B (i.e., C, D, or F) will "
+"cause the build to fail."
+msgstr ""
+
+#: src/cli/perry-toml.md:410
+msgid "`[verify]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:412
+msgid "Runtime verification configuration for `perry verify`."
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "`url`"
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "`https://verify.perryts.com`"
+msgstr ""
+
+#: src/cli/perry-toml.md:416
+msgid "Verification service endpoint URL"
+msgstr ""
+
+#: src/cli/perry-toml.md:420
+msgid "Bundle ID Resolution"
+msgstr ""
+
+#: src/cli/perry-toml.md:422
+msgid ""
+"Perry resolves the bundle identifier using a cascading priority system. The "
+"first non-empty value wins:"
+msgstr ""
+
+#: src/cli/perry-toml.md:424
+msgid "For iOS builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:425 src/cli/perry-toml.md:441
+msgid "`[ios].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:426 src/cli/perry-toml.md:434
+#: src/cli/perry-toml.md:443
+msgid "`[app].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:427 src/cli/perry-toml.md:435
+#: src/cli/perry-toml.md:444
+msgid "`[project].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:428 src/cli/perry-toml.md:433
+#: src/cli/perry-toml.md:442
+msgid "`[macos].bundle_id`"
+msgstr ""
+
+#: src/cli/perry-toml.md:429 src/cli/perry-toml.md:436
+msgid "`package.json` `bundleId` field"
+msgstr ""
+
+#: src/cli/perry-toml.md:430 src/cli/perry-toml.md:437
+#: src/cli/perry-toml.md:445
+msgid "`com.perry.<app_name>` (generated default)"
+msgstr ""
+
+#: src/cli/perry-toml.md:432
+msgid "For macOS builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:439
+msgid "For Android builds:"
+msgstr ""
+
+#: src/cli/perry-toml.md:440
+msgid "`[android].package_name`"
+msgstr ""
+
+#: src/cli/perry-toml.md:449
+msgid "Entry File Resolution"
+msgstr ""
+
+#: src/cli/perry-toml.md:451
+msgid ""
+"When no input file is specified on the command line, Perry resolves the "
+"entry file in this order:"
+msgstr ""
+
+#: src/cli/perry-toml.md:453
+msgid "`[ios].entry` / `[android].entry` (when targeting that platform)"
+msgstr ""
+
+#: src/cli/perry-toml.md:454
+msgid "`[project].entry` or `[app].entry`"
+msgstr ""
+
+#: src/cli/perry-toml.md:455
+msgid "`src/main.ts` (if it exists)"
+msgstr ""
+
+#: src/cli/perry-toml.md:456
+msgid "`main.ts` (if it exists)"
+msgstr ""
+
+#: src/cli/perry-toml.md:460
+msgid "Build Number Auto-Increment"
+msgstr ""
+
+#: src/cli/perry-toml.md:462
+msgid ""
+"The `build_number` field is automatically incremented by `perry publish` "
+"for:"
+msgstr ""
+
+#: src/cli/perry-toml.md:463
+msgid "iOS builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:464
+msgid "Android builds"
+msgstr ""
+
+#: src/cli/perry-toml.md:465
+msgid "macOS App Store builds (`distribute = \"appstore\"` or `\"both\"`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:467
+msgid ""
+"The updated value is written back to `perry.toml` after a successful "
+"publish. This ensures each submission to the App Store / Play Store has a "
+"unique, monotonically increasing build number."
+msgstr ""
+
+#: src/cli/perry-toml.md:469
+msgid ""
+"macOS builds with `distribute = \"notarize\"` (direct distribution) do "
+"**not** auto-increment the build number."
+msgstr ""
+
+#: src/cli/perry-toml.md:473
+msgid "Configuration Priority"
+msgstr ""
+
+#: src/cli/perry-toml.md:475
+msgid ""
+"Perry resolves configuration values using a layered priority system (highest"
+" to lowest):"
+msgstr ""
+
+#: src/cli/perry-toml.md:477
+msgid "**CLI flags** — e.g., `--target`, `--output`"
+msgstr ""
+
+#: src/cli/perry-toml.md:478
+msgid "**Environment variables** — e.g., `PERRY_LICENSE_KEY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:479
+msgid ""
+"**perry.toml** — project-level config (platform-specific sections first, "
+"then `[app]`/`[project]`)"
+msgstr ""
+
+#: src/cli/perry-toml.md:480
+msgid "**~/.perry/config.toml** — user-level global config"
+msgstr ""
+
+#: src/cli/perry-toml.md:481
+msgid "**Built-in defaults**"
+msgstr ""
+
+#: src/cli/perry-toml.md:487
+msgid ""
+"These environment variables override perry.toml and global config values:"
+msgstr ""
+
+#: src/cli/perry-toml.md:489
+msgid "Apple / iOS / macOS"
+msgstr ""
+
+#: src/cli/perry-toml.md:494
+msgid "`PERRY_APPLE_CERTIFICATE`"
+msgstr ""
+
+#: src/cli/perry-toml.md:494
+msgid "`.p12` certificate file contents (base64)"
+msgstr ""
+
+#: src/cli/perry-toml.md:495
+msgid "Password for the `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:496
+msgid "`PERRY_APPLE_P8_KEY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:496
+msgid "`.p8` API key file contents"
+msgstr ""
+
+#: src/cli/perry-toml.md:497
+msgid "`PERRY_APPLE_KEY_ID`"
+msgstr ""
+
+#: src/cli/perry-toml.md:498
+msgid "`PERRY_APPLE_NOTARIZE_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:498
+msgid "Password for the notarization `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:499
+msgid "`PERRY_APPLE_INSTALLER_CERTIFICATE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:499
+msgid "Password for the installer `.p12` certificate"
+msgstr ""
+
+#: src/cli/perry-toml.md:505
+msgid "`PERRY_ANDROID_KEYSTORE`"
+msgstr ""
+
+#: src/cli/perry-toml.md:505
+msgid "Path to `.jks`/`.keystore` file"
+msgstr ""
+
+#: src/cli/perry-toml.md:506
+msgid "`PERRY_ANDROID_KEY_ALIAS`"
+msgstr ""
+
+#: src/cli/perry-toml.md:506
+msgid "Keystore key alias"
+msgstr ""
+
+#: src/cli/perry-toml.md:507
+msgid "`PERRY_ANDROID_KEYSTORE_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:508
+msgid "`PERRY_ANDROID_KEY_PASSWORD`"
+msgstr ""
+
+#: src/cli/perry-toml.md:508
+msgid "Key password (within the keystore)"
+msgstr ""
+
+#: src/cli/perry-toml.md:509
+msgid "`PERRY_GOOGLE_PLAY_KEY_PATH`"
+msgstr ""
+
+#: src/cli/perry-toml.md:509
+msgid "Path to Google Play service account JSON"
+msgstr ""
+
+#: src/cli/perry-toml.md:511
+msgid "General"
+msgstr ""
+
+#: src/cli/perry-toml.md:515
+msgid "`PERRY_NO_TELEMETRY`"
+msgstr ""
+
+#: src/cli/perry-toml.md:515
+msgid "Set to `1` to disable anonymous telemetry"
+msgstr ""
+
+#: src/cli/perry-toml.md:516
+msgid "`PERRY_NO_UPDATE_CHECK`"
+msgstr ""
+
+#: src/cli/perry-toml.md:516
+msgid "Set to `1` to disable background update checks"
+msgstr ""
+
+#: src/cli/perry-toml.md:520
+msgid "Global Config: `~/.perry/config.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:522
+msgid ""
+"Separate from the project-level `perry.toml`, Perry maintains a user-level "
+"global config at `~/.perry/config.toml`. This stores credentials and "
+"preferences shared across all projects."
+msgstr ""
+
+#: src/cli/perry-toml.md:524
+msgid ""
+"```toml\n"
+"license_key = \"perry-xxxxxxxx\"\n"
+"server = \"https://hub.perryts.com\"\n"
+"default_target = \"macos\"\n"
+"\n"
+"[apple]\n"
+"team_id = \"ABCDE12345\"\n"
+"key_id = \"KEYID123\"\n"
+"issuer_id = \"issuer-uuid-here\"\n"
+"p8_key_path = \"/Users/me/.perry/AuthKey.p8\"\n"
+"\n"
+"[android]\n"
+"keystore_path = \"/Users/me/.perry/release.keystore\"\n"
+"key_alias = \"my-key\"\n"
+"google_play_key_path = \"/Users/me/.perry/play-service-account.json\"\n"
+"```"
+msgstr ""
+
+#: src/cli/perry-toml.md:541
+msgid ""
+"Fields in perry.toml (project-level) override `~/.perry/config.toml` "
+"(global-level). For example, `[ios].team_id` in perry.toml overrides "
+"`[apple].team_id` in the global config."
+msgstr ""
+
+#: src/cli/perry-toml.md:543
+msgid "The global config is managed by `perry setup` commands:"
+msgstr ""
+
+#: src/cli/perry-toml.md:544
+msgid "`perry setup ios` — configures Apple signing credentials"
+msgstr ""
+
+#: src/cli/perry-toml.md:545
+msgid "`perry setup android` — configures Android signing credentials"
+msgstr ""
+
+#: src/cli/perry-toml.md:546
+msgid "`perry setup macos` — configures macOS distribution settings"
+msgstr ""
+
+#: src/cli/perry-toml.md:550
+msgid "perry.toml vs package.json"
+msgstr ""
+
+#: src/cli/perry-toml.md:552
+msgid "Perry reads configuration from both files. Here's what goes where:"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "Setting"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "File"
+msgstr ""
+
+#: src/cli/perry-toml.md:554
+msgid "Section"
+msgstr ""
+
+#: src/cli/perry-toml.md:556
+msgid "Compile packages natively"
+msgstr ""
+
+#: src/cli/perry-toml.md:556 src/cli/perry-toml.md:557
+msgid "`package.json`"
+msgstr ""
+
+#: src/cli/perry-toml.md:556
+msgid "`perry.compilePackages`"
+msgstr ""
+
+#: src/cli/perry-toml.md:557
+msgid "Splash screen"
+msgstr ""
+
+#: src/cli/perry-toml.md:557
+msgid "`perry.splash`"
+msgstr ""
+
+#: src/cli/perry-toml.md:558
+msgid "Project name, version, entry"
+msgstr ""
+
+#: src/cli/perry-toml.md:558 src/cli/perry-toml.md:559
+#: src/cli/perry-toml.md:560 src/cli/perry-toml.md:561
+#: src/cli/perry-toml.md:562
+msgid "`perry.toml`"
+msgstr ""
+
+#: src/cli/perry-toml.md:559
+msgid "Platform-specific settings"
+msgstr ""
+
+#: src/cli/perry-toml.md:559
+msgid "`[ios]`, `[macos]`, `[android]`, `[linux]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:560
+msgid "Code signing & distribution"
+msgstr ""
+
+#: src/cli/perry-toml.md:560
+msgid "Platform sections"
+msgstr ""
+
+#: src/cli/perry-toml.md:561
+msgid "Build output directory"
+msgstr ""
+
+#: src/cli/perry-toml.md:562
+msgid "Audit & verification"
+msgstr ""
+
+#: src/cli/perry-toml.md:562
+msgid "`[audit]`, `[verify]`"
+msgstr ""
+
+#: src/cli/perry-toml.md:564
+msgid ""
+"When both files define the same value (e.g., project name), `perry.toml` "
+"takes precedence."
+msgstr ""
+
+#: src/cli/perry-toml.md:568
+msgid "Setup Wizard"
+msgstr ""
+
+#: src/cli/perry-toml.md:570
+msgid ""
+"Running `perry setup <platform>` interactively configures signing "
+"credentials and writes them back to both `perry.toml` and "
+"`~/.perry/config.toml`:"
+msgstr ""
+
+#: src/cli/perry-toml.md:573
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:574
+msgid "# Configure Android signing (keystore, Play Store key)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:575
+msgid "# Configure macOS distribution (App Store, notarization)\n"
+msgstr ""
+
+#: src/cli/perry-toml.md:578
+msgid "The wizard automatically:"
+msgstr ""
+
+#: src/cli/perry-toml.md:579
+msgid "Sets `[ios].distribute = \"testflight\"` if not already configured"
+msgstr ""
+
+#: src/cli/perry-toml.md:580
+msgid "Sets `[android].distribute = \"playstore\"` if not already configured"
+msgstr ""
+
+#: src/cli/perry-toml.md:581
+msgid "Stores provisioning profiles as `~/.perry/{bundle_id}.mobileprovision`"
+msgstr ""
+
+#: src/cli/perry-toml.md:582
+msgid "Auto-exports `.p12` certificates from macOS Keychain when possible"
+msgstr ""
+
+#: src/cli/perry-toml.md:586
+msgid "CI/CD Example"
+msgstr ""
+
+#: src/cli/perry-toml.md:588
+msgid ""
+"For CI environments, use environment variables instead of storing "
+"credentials in `perry.toml`:"
+msgstr ""
+
+#: src/cli/perry-toml.md:591
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr ""
+
+#: src/cli/perry-toml.md:593
+msgid "PERRY_LICENSE_KEY"
+msgstr ""
+
+#: src/cli/perry-toml.md:593
+msgid "${{ secrets.PERRY_LICENSE_KEY }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:594
+msgid "PERRY_APPLE_CERTIFICATE"
+msgstr ""
+
+#: src/cli/perry-toml.md:594
+msgid "${{ secrets.APPLE_CERTIFICATE }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:595
+msgid "PERRY_APPLE_CERTIFICATE_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:595
+msgid "${{ secrets.APPLE_CERT_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:596
+msgid "PERRY_APPLE_P8_KEY"
+msgstr ""
+
+#: src/cli/perry-toml.md:596
+msgid "${{ secrets.APPLE_P8_KEY }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:597
+msgid "PERRY_APPLE_KEY_ID"
+msgstr ""
+
+#: src/cli/perry-toml.md:597
+msgid "${{ secrets.APPLE_KEY_ID }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:598
+msgid "PERRY_ANDROID_KEYSTORE"
+msgstr ""
+
+#: src/cli/perry-toml.md:598
+msgid "${{ secrets.ANDROID_KEYSTORE }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:599
+msgid "PERRY_ANDROID_KEYSTORE_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:599
+msgid "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:600
+msgid "PERRY_ANDROID_KEY_ALIAS"
+msgstr ""
+
+#: src/cli/perry-toml.md:600
+msgid "${{ secrets.ANDROID_KEY_ALIAS }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:601
+msgid "PERRY_ANDROID_KEY_PASSWORD"
+msgstr ""
+
+#: src/cli/perry-toml.md:601
+msgid "${{ secrets.ANDROID_KEY_PASSWORD }}"
+msgstr ""
+
+#: src/cli/perry-toml.md:604
+msgid "perry publish ios"
+msgstr ""
+
+#: src/cli/perry-toml.md:605
+msgid "perry publish android"
+msgstr ""
+
+#: src/cli/perry-toml.md:606
+msgid "perry publish macos"
+msgstr ""
+
+#: src/cli/perry-toml.md:609
+msgid "Keep `perry.toml` in version control with non-sensitive fields only:"
+msgstr ""
+
+#: src/cli/perry-toml.md:611
+msgid ""
+"```toml\n"
+"[project]\n"
+"name = \"my-app\"\n"
+"version = \"2.1.0\"\n"
+"build_number = 47\n"
+"bundle_id = \"com.example.myapp\"\n"
+"entry = \"src/main.ts\"\n"
+"\n"
+"[ios]\n"
+"deployment_target = \"16.0\"\n"
+"device_family = [\"iphone\", \"ipad\"]\n"
+"distribute = \"appstore\"\n"
+"encryption_exempt = true\n"
+"\n"
+"[android]\n"
+"package_name = \"com.example.myapp\"\n"
+"min_sdk = \"26\"\n"
+"target_sdk = \"34\"\n"
+"distribute = \"playstore\"\n"
+"\n"
+"[macos]\n"
+"distribute = \"both\"\n"
+"category = \"public.app-category.productivity\"\n"
+"minimum_os = \"13.0\"\n"
+"\n"
+"[audit]\n"
+"fail_on = \"B\"\n"
+"```"
+msgstr ""
+
+#: src/contributing/architecture.md:3
+msgid ""
+"This is a brief overview for contributors. For detailed implementation "
+"notes, see the project's `CLAUDE.md`."
+msgstr ""
+
+#: src/contributing/architecture.md:5
+msgid "Compilation Pipeline"
+msgstr ""
+
+#: src/contributing/architecture.md:21
+msgid "Crate Map"
+msgstr ""
+
+#: src/contributing/architecture.md:23
+msgid "Crate"
+msgstr ""
+
+#: src/contributing/architecture.md:25
+msgid "`perry`"
+msgstr ""
+
+#: src/contributing/architecture.md:25
+msgid "CLI driver, command parsing, compilation orchestration"
+msgstr ""
+
+#: src/contributing/architecture.md:26
+msgid "`perry-parser`"
+msgstr ""
+
+#: src/contributing/architecture.md:26
+msgid "SWC wrapper for TypeScript parsing"
+msgstr ""
+
+#: src/contributing/architecture.md:27
+msgid "`perry-types`"
+msgstr ""
+
+#: src/contributing/architecture.md:27
+msgid "Type system definitions"
+msgstr ""
+
+#: src/contributing/architecture.md:28
+msgid "`perry-hir`"
+msgstr ""
+
+#: src/contributing/architecture.md:28
+msgid "HIR data structures (`ir.rs`) and AST→HIR lowering (`lower.rs`)"
+msgstr ""
+
+#: src/contributing/architecture.md:29
+msgid "`perry-transform`"
+msgstr ""
+
+#: src/contributing/architecture.md:29
+msgid "IR passes: function inlining, closure conversion, async lowering"
+msgstr ""
+
+#: src/contributing/architecture.md:30
+msgid "`perry-codegen-llvm`"
+msgstr ""
+
+#: src/contributing/architecture.md:30
+msgid "LLVM-based native code generation"
+msgstr ""
+
+#: src/contributing/architecture.md:31
+msgid "`perry-codegen-wasm`"
+msgstr ""
+
+#: src/contributing/architecture.md:31
+msgid ""
+"WebAssembly code generation for `--target web` / `--target wasm` (HIR → WASM"
+" bytecode + JS bridge)"
+msgstr ""
+
+#: src/contributing/architecture.md:32
+msgid "`perry-codegen-js`"
+msgstr ""
+
+#: src/contributing/architecture.md:32
+msgid ""
+"Legacy JavaScript code generator (still present for the JS minifier; the JS-"
+"emit `--target web` path was consolidated into `perry-codegen-wasm`)"
+msgstr ""
+
+#: src/contributing/architecture.md:33
+msgid "`perry-codegen-swiftui`"
+msgstr ""
+
+#: src/contributing/architecture.md:33
+msgid "SwiftUI code generation for WidgetKit extensions"
+msgstr ""
+
+#: src/contributing/architecture.md:34
+msgid "`perry-runtime`"
+msgstr ""
+
+#: src/contributing/architecture.md:34
+msgid ""
+"Runtime library: NaN-boxed values, GC, arena allocator, objects, arrays, "
+"strings"
+msgstr ""
+
+#: src/contributing/architecture.md:35
+msgid "`perry-stdlib`"
+msgstr ""
+
+#: src/contributing/architecture.md:35
+msgid "Node.js API implementations: mysql2, redis, fastify, bcrypt, etc."
+msgstr ""
+
+#: src/contributing/architecture.md:36
+msgid "`perry-ui`"
+msgstr ""
+
+#: src/contributing/architecture.md:36
+msgid "Shared UI types"
+msgstr ""
+
+#: src/contributing/architecture.md:37
+msgid "macOS UI (AppKit)"
+msgstr ""
+
+#: src/contributing/architecture.md:38
+msgid "iOS UI (UIKit)"
+msgstr ""
+
+#: src/contributing/architecture.md:39
+msgid "`perry-jsruntime`"
+msgstr ""
+
+#: src/contributing/architecture.md:39
+msgid "JavaScript interop via QuickJS"
+msgstr ""
+
+#: src/contributing/architecture.md:41
+msgid "Key Concepts"
+msgstr ""
+
+#: src/contributing/architecture.md:43
+msgid "NaN-Boxing"
+msgstr ""
+
+#: src/contributing/architecture.md:45
+msgid ""
+"All JavaScript values are represented as 64-bit NaN-boxed values. The upper "
+"16 bits encode the type tag:"
+msgstr ""
+
+#: src/contributing/architecture.md:47
+msgid "Tag"
+msgstr ""
+
+#: src/contributing/architecture.md:49
+msgid "`0x7FFF`"
+msgstr ""
+
+#: src/contributing/architecture.md:49
+msgid "String (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:50
+msgid "`0x7FFD`"
+msgstr ""
+
+#: src/contributing/architecture.md:50
+msgid "Pointer/Object (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:51
+msgid "`0x7FFE`"
+msgstr ""
+
+#: src/contributing/architecture.md:51
+msgid "Int32 (lower 32 bits = integer)"
+msgstr ""
+
+#: src/contributing/architecture.md:52
+msgid "`0x7FFA`"
+msgstr ""
+
+#: src/contributing/architecture.md:52
+msgid "BigInt (lower 48 bits = pointer)"
+msgstr ""
+
+#: src/contributing/architecture.md:53
+msgid "Special constants"
+msgstr ""
+
+#: src/contributing/architecture.md:53
+msgid "undefined, null, true, false"
+msgstr ""
+
+#: src/contributing/architecture.md:54
+msgid "Any other"
+msgstr ""
+
+#: src/contributing/architecture.md:54
+msgid "Float64 (the full 64 bits)"
+msgstr ""
+
+#: src/contributing/architecture.md:58
+msgid ""
+"Mark-sweep GC with conservative stack scanning. Arena-allocated objects "
+"(arrays, objects) are found by linear block walking. Malloc-allocated "
+"objects (strings, closures, promises) are tracked in a thread-local Vec."
+msgstr ""
+
+#: src/contributing/architecture.md:60
+msgid "Handle-Based UI"
+msgstr ""
+
+#: src/contributing/architecture.md:62
+msgid ""
+"UI widgets are represented as small integer handles NaN-boxed with "
+"`POINTER_TAG`. Each handle maps to a native platform widget (NSButton, "
+"UILabel, GtkButton, etc.). Two dispatch tables route method calls and "
+"property accesses to the correct FFI function."
+msgstr ""
+
+#: src/contributing/architecture.md:64
+msgid "Source Code Organization"
+msgstr ""
+
+#: src/contributing/architecture.md:66
+msgid "The codegen crate is organized into focused modules:"
+msgstr ""
+
+#: src/contributing/architecture.md:83
+msgid "The HIR lowering was split into 8 modules:"
+msgstr ""
+
+#: src/contributing/architecture.md:99
+msgid "[Building from Source](building.md)"
+msgstr ""
+
+#: src/contributing/architecture.md:100
+msgid ""
+"See `CLAUDE.md` in the repository root for detailed implementation notes"
+msgstr ""
+
+#: src/contributing/building.md:5
+msgid "Rust toolchain (stable): [rustup.rs](https://rustup.rs/)"
+msgstr ""
+
+#: src/contributing/building.md:6
+msgid "System C compiler (`cc` on macOS/Linux, MSVC on Windows)"
+msgstr ""
+
+#: src/contributing/building.md:8
+msgid "Build"
+msgstr ""
+
+#: src/contributing/building.md:13
+msgid "# Build all crates (release mode recommended)\n"
+msgstr ""
+
+#: src/contributing/building.md:18
+msgid "The binary is at `target/release/perry`."
+msgstr ""
+
+#: src/contributing/building.md:20
+msgid "Build Specific Crates"
+msgstr ""
+
+#: src/contributing/building.md:23
+msgid "# Runtime only (must rebuild stdlib too!)\n"
+msgstr ""
+
+#: src/contributing/building.md:25
+msgid "# Codegen only\n"
+msgstr ""
+
+#: src/contributing/building.md:30
+msgid ""
+"**Important**: When rebuilding `perry-runtime`, you must also rebuild "
+"`perry-stdlib` because `libperry_stdlib.a` embeds perry-runtime as a static "
+"dependency."
+msgstr ""
+
+#: src/contributing/building.md:32
+msgid "Run Tests"
+msgstr ""
+
+#: src/contributing/building.md:35
+msgid "# All tests (exclude iOS crate on non-iOS host)\n"
+msgstr ""
+
+#: src/contributing/building.md:37
+msgid "# Specific crate\n"
+msgstr ""
+
+#: src/contributing/building.md:43
+msgid "Compile and Run TypeScript"
+msgstr ""
+
+#: src/contributing/building.md:46
+msgid "# Compile a TypeScript file\n"
+msgstr ""
+
+#: src/contributing/building.md:49
+msgid "# Debug: print HIR\n"
+msgstr ""
+
+#: src/contributing/building.md:54
+msgid "Development Workflow"
+msgstr ""
+
+#: src/contributing/building.md:56
+msgid "Make changes to the relevant crate"
+msgstr ""
+
+#: src/contributing/building.md:57
+msgid "`cargo build --release` to build"
+msgstr ""
+
+#: src/contributing/building.md:58
+msgid "`cargo test --workspace --exclude perry-ui-ios` to verify"
+msgstr ""
+
+#: src/contributing/building.md:59
+msgid ""
+"Test with a real TypeScript file: `cargo run --release -- test.ts -o test &&"
+" ./test`"
+msgstr ""
+
+#: src/contributing/building.md:88
+msgid "[Architecture](architecture.md) — Crate map and pipeline overview"
+msgstr ""
+
+#: src/contributing/building.md:89
+msgid "See `CLAUDE.md` for detailed implementation notes and pitfalls"
+msgstr ""

--- a/docs/theme/language-switcher.js
+++ b/docs/theme/language-switcher.js
@@ -1,0 +1,67 @@
+// Injects a language picker into the mdBook menu bar.
+// Languages are inferred from the deployed site layout: English at the root,
+// translations under /<lang-code>/. Add new languages to LANGS to expose them.
+(function () {
+  var LANGS = [
+    { code: "en", label: "English" },
+    { code: "de", label: "Deutsch" },
+    { code: "ja", label: "日本語" },
+    { code: "ko", label: "한국어" },
+    { code: "zh-CN", label: "简体中文" },
+  ];
+
+  function detect() {
+    var path = window.location.pathname;
+    var codes = LANGS.map(function (l) { return l.code; }).filter(function (c) { return c !== "en"; });
+    for (var i = 0; i < codes.length; i++) {
+      var prefix = "/" + codes[i];
+      if (path === prefix || path.indexOf(prefix + "/") === 0) {
+        return { current: codes[i], rest: path.slice(prefix.length) || "/" };
+      }
+    }
+    return { current: "en", rest: path };
+  }
+
+  function pathFor(code, rest) {
+    if (code === "en") return rest;
+    var trimmed = rest.startsWith("/") ? rest : "/" + rest;
+    return "/" + code + trimmed;
+  }
+
+  function build() {
+    var bar = document.querySelector(".right-buttons");
+    if (!bar || document.getElementById("language-switcher")) return;
+    var state = detect();
+
+    var wrap = document.createElement("div");
+    wrap.id = "language-switcher";
+    wrap.style.cssText = "display:inline-block;margin:0 8px;";
+
+    var sel = document.createElement("select");
+    sel.setAttribute("aria-label", "Language");
+    sel.style.cssText =
+      "background:transparent;color:inherit;border:1px solid var(--sidebar-bg,#ccc);" +
+      "border-radius:4px;padding:2px 6px;font:inherit;cursor:pointer;";
+
+    LANGS.forEach(function (l) {
+      var opt = document.createElement("option");
+      opt.value = l.code;
+      opt.textContent = l.label;
+      if (l.code === state.current) opt.selected = true;
+      sel.appendChild(opt);
+    });
+
+    sel.addEventListener("change", function () {
+      window.location.pathname = pathFor(sel.value, state.rest);
+    });
+
+    wrap.appendChild(sel);
+    bar.insertBefore(wrap, bar.firstChild);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", build);
+  } else {
+    build();
+  }
+})();


### PR DESCRIPTION
Wires mdbook-i18n-helpers (gettext) into the docs pipeline. English stays at the root; translations render under /<lang>/ subdirectories of docs.perryts.com via a single workflow build over po/*.po.

Adds a seed translation (116 entries × 4 languages) covering the sidebar navigation, the introduction page, and the Getting Started chapter headings — enough for /de/, /ja/, /ko/, /zh-CN/ to feel like real localized sites. Untranslated entries fall through to English so partial contributor PRs don't break pages.

A small <select> language picker is injected into the menu bar via docs/theme/language-switcher.js — adding a new language is one line in the LANGS array plus a po/<lang>.po file.

docs/i18n.sh wraps the contributor + maintainer flows:
  ./docs/i18n.sh add <lang>     create po/<lang>.po
  ./docs/i18n.sh build <lang>   preview locally
  ./docs/i18n.sh extract        regenerate po/messages.pot
  ./docs/i18n.sh sync           merge .pot into every po/<lang>.po

See docs/TRANSLATING.md for the contributor workflow.

<!--
Thanks for contributing to Perry! A few things to know before you submit:

1. Please do NOT bump `[workspace.package] version` in Cargo.toml.
2. Please do NOT edit the "**Current Version:**" line or add a "Recent
   Changes" entry in CLAUDE.md.
3. Please do NOT edit CHANGELOG.md.

The maintainer folds all of that metadata in at merge time — Perry
releases frequently, and version bumps conflict if they live on the
PR branch. See CONTRIBUTING.md for the reasoning.
-->

## Summary

<!-- One or two sentences on what this PR changes and why. -->

## Changes

<!--
- Bullet list of concrete changes, one per logical item.
- File paths optional but appreciated for non-trivial PRs.
-->

## Related issue

<!-- Fixes #123 / Closes #123 / Refs #123 — or "n/a" if standalone. -->

## Test plan

<!--
How did you verify this works? A paste of the commands you ran is perfect.
-->

- [ ] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [ ] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/`
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform

## Screenshots / output

<!-- Optional. If the change is visible (UI, CLI output, error messages), paste before/after. -->

## Checklist

- [ ] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [ ] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [ ] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
