### PR TITLE
Improve async Promise fan-out performance

### DIFF
--- a/crates/perry-runtime/src/array.rs
+++ b/crates/perry-runtime/src/array.rs
@@ -2612,7 +2612,7 @@ pub extern "C" fn js_array_join(
         };
 
         // Build result string
-        let mut result = String::new();
+        let mut result = String::with_capacity(join_initial_capacity(length, sep_str.len()));
         for i in 0..length as usize {
             if i > 0 {
                 result.push_str(sep_str);
@@ -2700,6 +2700,14 @@ pub extern "C" fn js_array_join(
         drop(result);
         ret
     }
+}
+
+#[inline]
+fn join_initial_capacity(length: u32, sep_len: usize) -> usize {
+    let len = length as usize;
+    sep_len
+        .saturating_mul(len.saturating_sub(1))
+        .saturating_add(len.saturating_mul(8))
 }
 
 /// Check if a value is an array (Array.isArray)

--- a/crates/perry-runtime/src/gc.rs
+++ b/crates/perry-runtime/src/gc.rs
@@ -1535,8 +1535,7 @@ impl ValidPointerSet {
         // `maybe_contains` still prefilters correctly for malloc
         // pointers (closures/promises) that fall outside the
         // arena address span.
-        if let (Some(&first), Some(&last)) =
-            (self.merged_sorted.first(), self.merged_sorted.last())
+        if let (Some(&first), Some(&last)) = (self.merged_sorted.first(), self.merged_sorted.last())
         {
             if first < self.range_min {
                 self.range_min = first;
@@ -2789,6 +2788,42 @@ unsafe fn trace_promise(
             }
         }
     }
+
+    let all_result = (*promise).all_result;
+    if !all_result.is_null() {
+        let ptr_usize = all_result as usize;
+        if valid_ptrs.contains(&ptr_usize) {
+            let header = header_from_user_ptr(all_result as *const u8);
+            if (*header).gc_flags & GC_FLAG_MARKED == 0 {
+                (*header).gc_flags |= GC_FLAG_MARKED;
+                worklist.push(header);
+            }
+        }
+    }
+
+    let all_results_arr = (*promise).all_results_arr;
+    if !all_results_arr.is_null() {
+        let ptr_usize = all_results_arr as usize;
+        if valid_ptrs.contains(&ptr_usize) {
+            let header = header_from_user_ptr(all_results_arr as *const u8);
+            if (*header).gc_flags & GC_FLAG_MARKED == 0 {
+                (*header).gc_flags |= GC_FLAG_MARKED;
+                worklist.push(header);
+            }
+        }
+    }
+
+    let all_state_arr = (*promise).all_state_arr;
+    if !all_state_arr.is_null() {
+        let ptr_usize = all_state_arr as usize;
+        if valid_ptrs.contains(&ptr_usize) {
+            let header = header_from_user_ptr(all_state_arr as *const u8);
+            if (*header).gc_flags & GC_FLAG_MARKED == 0 {
+                (*header).gc_flags |= GC_FLAG_MARKED;
+                worklist.push(header);
+            }
+        }
+    }
 }
 
 /// Trace error fields (message, name, stack are StringHeader pointers; cause is f64; errors is array)
@@ -3480,6 +3515,15 @@ unsafe fn rewrite_promise_fields(user_ptr: *mut u8, valid_ptrs: &ValidPointerSet
     rewrite_slot(&(*promise).on_fulfilled as *const _ as *mut u64, valid_ptrs);
     rewrite_slot(&(*promise).on_rejected as *const _ as *mut u64, valid_ptrs);
     rewrite_slot(&(*promise).next as *const _ as *mut u64, valid_ptrs);
+    rewrite_slot(&(*promise).all_result as *const _ as *mut u64, valid_ptrs);
+    rewrite_slot(
+        &(*promise).all_results_arr as *const _ as *mut u64,
+        valid_ptrs,
+    );
+    rewrite_slot(
+        &(*promise).all_state_arr as *const _ as *mut u64,
+        valid_ptrs,
+    );
 }
 
 unsafe fn rewrite_error_fields(user_ptr: *mut u8, valid_ptrs: &ValidPointerSet) {

--- a/crates/perry-runtime/src/promise.rs
+++ b/crates/perry-runtime/src/promise.rs
@@ -76,6 +76,7 @@ pub static MT_STEP_CHAIN_REUSE_MISS: AtomicU64 = AtomicU64::new(0);
 /// `Promise.resolve(value)` would have done.
 pub static MT_STEP_DONE_REUSE_HIT: AtomicU64 = AtomicU64::new(0);
 pub static MT_STEP_DONE_REUSE_MISS: AtomicU64 = AtomicU64::new(0);
+pub static MT_PROMISE_ALL_DIRECT_FULFILL: AtomicU64 = AtomicU64::new(0);
 
 extern "C" fn mt_profile_atexit() {
     if std::env::var_os("PERRY_MT_PROFILE").is_none() {
@@ -119,6 +120,10 @@ extern "C" fn mt_profile_atexit() {
         "[mt-profile] step_done_reuse: hit={} miss={}",
         MT_STEP_DONE_REUSE_HIT.load(Ordering::Relaxed),
         MT_STEP_DONE_REUSE_MISS.load(Ordering::Relaxed),
+    );
+    eprintln!(
+        "[mt-profile] promise_all_direct_fulfill={}",
+        MT_PROMISE_ALL_DIRECT_FULFILL.load(Ordering::Relaxed),
     );
 }
 
@@ -236,6 +241,14 @@ pub struct Promise {
     pub(crate) on_rejected: ClosurePtr,
     /// Next promise in the chain (for .then())
     pub(crate) next: *mut Promise,
+    /// Promise.all direct-fulfill target promise.
+    pub(crate) all_result: *mut Promise,
+    /// Promise.all direct-fulfill result array.
+    pub(crate) all_results_arr: *mut crate::array::ArrayHeader,
+    /// Promise.all direct-fulfill shared state array.
+    pub(crate) all_state_arr: *mut crate::array::ArrayHeader,
+    /// Promise.all direct-fulfill result index.
+    pub(crate) all_index: u32,
 }
 
 impl Promise {
@@ -247,8 +260,32 @@ impl Promise {
             on_fulfilled: ptr::null(),
             on_rejected: ptr::null(),
             next: ptr::null_mut(),
+            all_result: ptr::null_mut(),
+            all_results_arr: ptr::null_mut(),
+            all_state_arr: ptr::null_mut(),
+            all_index: 0,
         }
     }
+}
+
+#[inline(always)]
+fn promise_all_fulfill_sentinel() -> ClosurePtr {
+    promise_all_fulfill_marker as *const () as usize as ClosurePtr
+}
+
+#[inline(always)]
+fn is_promise_all_fulfill_sentinel(callback: ClosurePtr) -> bool {
+    callback as usize == promise_all_fulfill_marker as *const () as usize
+}
+
+extern "C" fn promise_all_fulfill_marker() {}
+
+#[inline(always)]
+unsafe fn clear_promise_all_link(promise: *mut Promise) {
+    (*promise).all_result = ptr::null_mut();
+    (*promise).all_results_arr = ptr::null_mut();
+    (*promise).all_state_arr = ptr::null_mut();
+    (*promise).all_index = 0;
 }
 
 /// One entry in the microtask queue. Two shapes:
@@ -515,6 +552,7 @@ pub extern "C" fn js_promise_resolve_with_promise(outer: *mut Promise, inner: *m
                 (*inner).on_fulfilled = resolve_closure;
                 (*inner).on_rejected = reject_closure;
                 (*inner).next = ptr::null_mut(); // Don't chain, we handle resolution ourselves
+                clear_promise_all_link(inner);
             }
         }
     }
@@ -585,6 +623,7 @@ pub extern "C" fn js_promise_then(
         (*promise).on_fulfilled = on_fulfilled;
         (*promise).on_rejected = on_rejected;
         (*promise).next = next;
+        clear_promise_all_link(promise);
 
         // If already settled, schedule callback immediately. Same propagation
         // rule as `js_promise_resolve`/`js_promise_reject` (#236): push to the
@@ -633,6 +672,7 @@ pub(crate) fn js_promise_attach_handlers(
     unsafe {
         (*promise).on_fulfilled = on_fulfilled;
         (*promise).on_rejected = on_rejected;
+        clear_promise_all_link(promise);
         // No next — caller doesn't want a chained promise.
 
         match (*promise).state {
@@ -643,6 +683,46 @@ pub(crate) fn js_promise_attach_handlers(
                             .push_back(Task::Promise(promise, (*promise).value, true));
                     });
                 }
+            }
+            PromiseState::Rejected => {
+                if !on_rejected.is_null() {
+                    TASK_QUEUE.with(|q| {
+                        q.borrow_mut()
+                            .push_back(Task::Promise(promise, (*promise).reason, false));
+                    });
+                }
+            }
+            PromiseState::Pending => {}
+        }
+    }
+}
+
+fn js_promise_attach_all_fulfill(
+    promise: *mut Promise,
+    result_promise: *mut Promise,
+    results_arr: *mut crate::array::ArrayHeader,
+    state_arr: *mut crate::array::ArrayHeader,
+    index: u32,
+    on_rejected: ClosurePtr,
+) {
+    if promise.is_null() {
+        return;
+    }
+    unsafe {
+        (*promise).on_fulfilled = promise_all_fulfill_sentinel();
+        (*promise).on_rejected = on_rejected;
+        (*promise).next = ptr::null_mut();
+        (*promise).all_result = result_promise;
+        (*promise).all_results_arr = results_arr;
+        (*promise).all_state_arr = state_arr;
+        (*promise).all_index = index;
+
+        match (*promise).state {
+            PromiseState::Fulfilled => {
+                TASK_QUEUE.with(|q| {
+                    q.borrow_mut()
+                        .push_back(Task::Promise(promise, (*promise).value, true));
+                });
             }
             PromiseState::Rejected => {
                 if !on_rejected.is_null() {
@@ -710,6 +790,7 @@ pub extern "C" fn js_promise_finally(
         (*promise).on_fulfilled = fulfill_wrap;
         (*promise).on_rejected = reject_wrap;
         (*promise).next = ptr::null_mut(); // wrappers own next; runner must not touch it
+        clear_promise_all_link(promise);
 
         // If the promise is already settled, push its task now.
         match (*promise).state {
@@ -1002,6 +1083,12 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                                 js_promise_reject((*promise).next, value);
                             }
                         }
+                        ran += 1;
+                        continue;
+                    }
+
+                    if is_fulfilled && is_promise_all_fulfill_sentinel(callback) {
+                        promise_all_fulfill_direct(promise, value);
                         ran += 1;
                         continue;
                     }
@@ -1886,9 +1973,7 @@ extern "C" fn promise_reject_fn(closure: *const crate::closure::ClosureHeader, r
 #[no_mangle]
 pub extern "C" fn js_promise_all(promises_arr: *const crate::array::ArrayHeader) -> *mut Promise {
     use crate::array::{js_array_alloc, js_array_get_f64, js_array_length, js_array_set_f64};
-    use crate::closure::{
-        js_closure_alloc, js_closure_set_capture_f64, js_closure_set_capture_ptr,
-    };
+    use crate::closure::{js_closure_alloc, js_closure_set_capture_ptr};
     use crate::value::js_nanbox_get_pointer;
 
     // Create the result promise
@@ -1966,19 +2051,17 @@ pub extern "C" fn js_promise_all(promises_arr: *const crate::array::ArrayHeader)
 
         let promise_ptr = js_nanbox_get_pointer(promise_f64) as *mut Promise;
 
-        // Create fulfill closure for this promise
-        // Captures: [result_promise, results_arr, state_arr, index]
-        let fulfill_closure = js_closure_alloc(promise_all_fulfill_handler as *const u8, 4);
-        js_closure_set_capture_ptr(fulfill_closure, 0, result_promise as i64);
-        js_closure_set_capture_ptr(fulfill_closure, 1, results_arr as i64);
-        js_closure_set_capture_ptr(fulfill_closure, 2, state_arr as i64);
-        js_closure_set_capture_f64(fulfill_closure, 3, i as f64);
-
-        // Attach handlers to the promise WITHOUT allocating a `next`
-        // Promise — the return of `then` is unused here. Saves one
-        // promise alloc per input on Promise.all (50k for the
-        // 1000-batch × 50-input bench).
-        js_promise_attach_handlers(promise_ptr, fulfill_closure, shared_reject_closure);
+        // Attach a direct Promise.all fulfillment continuation without a
+        // per-input Closure allocation. Rejections still share one closure
+        // across the whole Promise.all call because they do not carry an index.
+        js_promise_attach_all_fulfill(
+            promise_ptr,
+            result_promise,
+            results_arr,
+            state_arr,
+            i,
+            shared_reject_closure,
+        );
     }
 
     // Check if all were non-promises (already resolved)
@@ -1991,42 +2074,38 @@ pub extern "C" fn js_promise_all(promises_arr: *const crate::array::ArrayHeader)
     result_promise
 }
 
-/// Internal handler called when a promise in Promise.all fulfills
-extern "C" fn promise_all_fulfill_handler(
-    closure: *const crate::closure::ClosureHeader,
-    value: f64,
-) -> f64 {
-    use crate::array::{js_array_get_f64, js_array_set_f64, ArrayHeader};
-    use crate::closure::{js_closure_get_capture_f64, js_closure_get_capture_ptr};
+#[inline(always)]
+unsafe fn promise_all_fulfill_direct(promise: *mut Promise, value: f64) {
+    use crate::array::js_array_set_f64;
 
-    let result_promise = js_closure_get_capture_ptr(closure, 0) as *mut Promise;
-    let results_arr = js_closure_get_capture_ptr(closure, 1) as *mut ArrayHeader;
-    let state_arr = js_closure_get_capture_ptr(closure, 2) as *mut ArrayHeader;
+    bump(&MT_PROMISE_ALL_DIRECT_FULFILL);
+
+    let result_promise = (*promise).all_result;
+    let results_arr = (*promise).all_results_arr;
+    let state_arr = (*promise).all_state_arr;
+    let index = (*promise).all_index;
     if result_promise.is_null() || results_arr.is_null() || state_arr.is_null() {
-        return 0.0;
+        return;
     }
-    let index = js_closure_get_capture_f64(closure, 3) as u32;
 
-    // Check if already rejected
-    let rejected = js_array_get_f64(state_arr, 1);
+    // Check if already rejected.
+    let rejected = crate::array::js_array_get_f64(state_arr, 1);
     if rejected != 0.0 {
-        return 0.0;
+        clear_promise_all_link(promise);
+        return;
     }
 
-    // Store the resolved value
     js_array_set_f64(results_arr, index, value);
 
-    // Decrement remaining count
-    let remaining = js_array_get_f64(state_arr, 0) - 1.0;
+    let remaining = crate::array::js_array_get_f64(state_arr, 0) - 1.0;
     js_array_set_f64(state_arr, 0, remaining);
 
-    // If all promises have resolved, resolve the result promise with the array
     if remaining == 0.0 {
         let arr_f64 = crate::value::js_nanbox_pointer(results_arr as i64);
         js_promise_resolve(result_promise, arr_f64);
     }
 
-    0.0
+    clear_promise_all_link(promise);
 }
 
 /// Internal handler called when a promise in Promise.all rejects

--- a/crates/perry-runtime/src/string.rs
+++ b/crates/perry-runtime/src/string.rs
@@ -2428,72 +2428,80 @@ pub extern "C" fn js_string_split_n(
         string_as_str(delimiter)
     };
 
-    const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
-    const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
     let header_size = std::mem::size_of::<StringHeader>();
+    let src_is_ascii = is_ascii_string(s);
 
     if delim.is_empty() {
-        // Empty delimiter: split into individual characters (single pass)
-        let mut parts: Vec<*mut StringHeader> = str_data
-            .chars()
-            .map(|c| {
+        let char_count = str_data.chars().count();
+        let n = if limit > 0 {
+            char_count.min(limit as usize)
+        } else {
+            char_count
+        };
+
+        let arr = crate::array::js_array_alloc(n as u32);
+        unsafe {
+            (*arr).length = n as u32;
+            let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+            for (i, c) in str_data.chars().take(n).enumerate() {
                 let mut buf = [0u8; 4];
                 let char_str = c.encode_utf8(&mut buf);
-                js_string_from_bytes(char_str.as_ptr(), char_str.len() as u32)
-            })
-            .collect();
-        if limit > 0 && (parts.len() as i64) > (limit as i64) {
-            parts.truncate(limit as usize);
-        }
-
-        let arr = crate::array::js_array_alloc(parts.len() as u32);
-        unsafe {
-            (*arr).length = parts.len() as u32;
-            let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-            for (i, p) in parts.iter().enumerate() {
-                let nanboxed = STRING_TAG | (*p as u64 & POINTER_MASK);
-                std::ptr::write(elements_ptr.add(i), f64::from_bits(nanboxed));
+                write_split_part(elements_ptr, i, char_str, true, header_size);
             }
         }
         return arr;
     }
 
-    // Non-empty delimiter: arena-allocate parts (bump-pointer, no tracking overhead)
     let mut part_slices: Vec<&str> = str_data.split(delim).collect();
-    if limit > 0 && (part_slices.len() as i64) > (limit as i64) {
+    if limit > 0 && part_slices.len() > limit as usize {
         part_slices.truncate(limit as usize);
     }
     let n = part_slices.len();
-
-    let src_is_ascii = is_ascii_string(s);
 
     let arr = crate::array::js_array_alloc(n as u32);
     unsafe {
         (*arr).length = n as u32;
         let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
         for (i, part) in part_slices.iter().enumerate() {
-            let byte_len = part.len() as u32;
-            let alloc_size = header_size + byte_len as usize;
-            let raw = crate::arena::arena_alloc_gc(alloc_size, 8, crate::gc::GC_TYPE_STRING);
-            let sh = raw as *mut StringHeader;
-            (*sh).byte_len = byte_len;
-            (*sh).capacity = byte_len;
-            (*sh).refcount = 0;
-            (*sh).utf16_len = if src_is_ascii {
-                byte_len
-            } else {
-                compute_utf16_len(part.as_ptr(), byte_len)
-            };
-            if byte_len > 0 {
-                let data_ptr = (sh as *mut u8).add(header_size);
-                ptr::copy_nonoverlapping(part.as_ptr(), data_ptr, byte_len as usize);
-            }
-            let nanboxed = STRING_TAG | (raw as u64 & POINTER_MASK);
-            std::ptr::write(elements_ptr.add(i), f64::from_bits(nanboxed));
+            write_split_part(elements_ptr, i, part, src_is_ascii, header_size);
         }
     }
 
     arr
+}
+
+#[inline]
+unsafe fn write_split_part(
+    elements_ptr: *mut f64,
+    index: usize,
+    part: &str,
+    src_is_ascii: bool,
+    header_size: usize,
+) {
+    if let Some(value) = crate::value::JSValue::try_short_string(part.as_bytes()) {
+        std::ptr::write(elements_ptr.add(index), f64::from_bits(value.bits()));
+        return;
+    }
+
+    let byte_len = part.len() as u32;
+    let alloc_size = header_size + byte_len as usize;
+    let raw = crate::arena::arena_alloc_gc(alloc_size, 8, crate::gc::GC_TYPE_STRING);
+    let sh = raw as *mut StringHeader;
+    (*sh).byte_len = byte_len;
+    (*sh).capacity = byte_len;
+    (*sh).refcount = 0;
+    (*sh).flags = 0;
+    (*sh).utf16_len = if src_is_ascii {
+        byte_len
+    } else {
+        compute_utf16_len(part.as_ptr(), byte_len)
+    };
+    if byte_len > 0 {
+        let data_ptr = (sh as *mut u8).add(header_size);
+        ptr::copy_nonoverlapping(part.as_ptr(), data_ptr, byte_len as usize);
+    }
+    let nanboxed = crate::value::STRING_TAG | (raw as u64 & crate::value::POINTER_MASK);
+    std::ptr::write(elements_ptr.add(index), f64::from_bits(nanboxed));
 }
 
 /// Allocate a string containing a single space character " "
@@ -2820,6 +2828,23 @@ pub fn scan_intern_table_roots(mark: &mut dyn FnMut(f64)) {
 mod tests {
     use super::*;
 
+    fn split_value_to_string(value: f64) -> String {
+        let jsvalue = crate::value::JSValue::from_bits(value.to_bits());
+        if jsvalue.is_short_string() {
+            let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+            let n = jsvalue.short_string_to_buf(&mut scratch);
+            return std::str::from_utf8(&scratch[..n]).unwrap().to_string();
+        }
+        if jsvalue.is_string() {
+            let ptr = jsvalue.as_pointer() as *const StringHeader;
+            return string_as_str(ptr).to_string();
+        }
+        panic!(
+            "split returned non-string value: 0x{:016x}",
+            value.to_bits()
+        );
+    }
+
     #[test]
     fn test_string_create() {
         let data = b"hello";
@@ -2866,21 +2891,9 @@ mod tests {
 
         assert_eq!(js_array_length(arr), 3);
 
-        // Get the string pointers from the array and verify their contents
-        // Note: split() stores NaN-boxed string pointers with STRING_TAG
-        const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
-        const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
-
-        unsafe {
-            // Extract pointer from NaN-boxed value by masking off STRING_TAG
-            let ptr0 = (js_array_get_f64(arr, 0).to_bits() & POINTER_MASK) as *const StringHeader;
-            let ptr1 = (js_array_get_f64(arr, 1).to_bits() & POINTER_MASK) as *const StringHeader;
-            let ptr2 = (js_array_get_f64(arr, 2).to_bits() & POINTER_MASK) as *const StringHeader;
-
-            assert_eq!(string_as_str(ptr0), "a");
-            assert_eq!(string_as_str(ptr1), "b");
-            assert_eq!(string_as_str(ptr2), "c");
-        }
+        assert_eq!(split_value_to_string(js_array_get_f64(arr, 0)), "a");
+        assert_eq!(split_value_to_string(js_array_get_f64(arr, 1)), "b");
+        assert_eq!(split_value_to_string(js_array_get_f64(arr, 2)), "c");
     }
 
     #[test]

--- a/crates/perry-transform/src/generator.rs
+++ b/crates/perry-transform/src/generator.rs
@@ -1208,19 +1208,30 @@ fn transform_generator_function(
         // into the step closure body — eliminating the per-call
         // `__next` allocation, the closure dispatch, and the captures-
         // box re-lookup that the separate closure-call path required.
-        // The throw path stays as a separate closure (cold), since its
-        // catch routing is tangled with state-machine post-catch
-        // transitions and the fusion benefit there is marginal.
+        // The throw path only stays as a separate closure when it has
+        // real catch-routing work. The common no-catch shape is just
+        // `throw(value)`, so the step closure can emit that directly
+        // and skip one closure allocation per async invocation.
         let mut throw_closure_for_step = throw_closure;
         rewrite_iter_results_to_scratch(&mut throw_closure_for_step);
+        let direct_throw = is_simple_rethrow_closure(&throw_closure_for_step);
         let mut next_body_for_step = next_body;
         rewrite_iter_results_in_stmts(&mut next_body_for_step);
+        let await_fetch_ids: Vec<LocalId> = hoisted
+            .iter()
+            .filter_map(|(id, name, _)| name.starts_with("__await_fetch_").then_some(*id))
+            .collect();
+        rewrite_await_promise_resolve(&mut next_body_for_step, &await_fetch_ids);
         let wrapper_stmts = build_async_step_driver_direct(
             next_body_for_step,
             next_param_id,
             captures.clone(),
             mutable_captures.clone(),
-            throw_closure_for_step,
+            if direct_throw {
+                None
+            } else {
+                Some(throw_closure_for_step)
+            },
             next_local_id,
             next_func_id,
         );
@@ -1531,6 +1542,138 @@ fn build_async_step_driver(
     ]
 }
 
+fn is_simple_rethrow_closure(expr: &Expr) -> bool {
+    let Expr::Closure { params, body, .. } = expr else {
+        return false;
+    };
+    if params.len() != 1 || body.len() != 1 {
+        return false;
+    }
+    matches!(&body[0], Stmt::Throw(Expr::LocalGet(id)) if *id == params[0].id)
+}
+
+fn rewrite_await_promise_resolve(stmts: &mut Vec<Stmt>, await_fetch_ids: &[LocalId]) {
+    for stmt in stmts.iter_mut() {
+        match stmt {
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                rewrite_await_promise_resolve(then_branch, await_fetch_ids);
+                if let Some(else_branch) = else_branch {
+                    rewrite_await_promise_resolve(else_branch, await_fetch_ids);
+                }
+            }
+            Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
+                rewrite_await_promise_resolve(body, await_fetch_ids);
+            }
+            Stmt::For { init, body, .. } => {
+                if let Some(init) = init.as_mut() {
+                    rewrite_await_promise_resolve_stmt(init, await_fetch_ids);
+                }
+                rewrite_await_promise_resolve(body, await_fetch_ids);
+            }
+            Stmt::Labeled { body, .. } => rewrite_await_promise_resolve_stmt(body, await_fetch_ids),
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                rewrite_await_promise_resolve(body, await_fetch_ids);
+                if let Some(catch) = catch {
+                    rewrite_await_promise_resolve(&mut catch.body, await_fetch_ids);
+                }
+                if let Some(finally) = finally {
+                    rewrite_await_promise_resolve(finally, await_fetch_ids);
+                }
+            }
+            Stmt::Switch { cases, .. } => {
+                for case in cases {
+                    rewrite_await_promise_resolve(&mut case.body, await_fetch_ids);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let len = stmts.len();
+    for i in 0..len {
+        let Some((target_id, resolved_arg)) = await_resolve_assignment(&stmts[i]) else {
+            continue;
+        };
+        if await_fetch_ids.contains(&target_id)
+            && block_yields_local_before_rewrite(stmts, i + 1, target_id)
+        {
+            if let Stmt::Expr(Expr::LocalSet(_, rhs)) = &mut stmts[i] {
+                **rhs = resolved_arg;
+            }
+        }
+    }
+}
+
+fn rewrite_await_promise_resolve_stmt(stmt: &mut Stmt, await_fetch_ids: &[LocalId]) {
+    let mut one = vec![stmt.clone()];
+    rewrite_await_promise_resolve(&mut one, await_fetch_ids);
+    if let Some(updated) = one.pop() {
+        *stmt = updated;
+    }
+}
+
+fn await_resolve_assignment(stmt: &Stmt) -> Option<(LocalId, Expr)> {
+    let Stmt::Expr(Expr::LocalSet(target_id, rhs)) = stmt else {
+        return None;
+    };
+    promise_resolve_arg(rhs).map(|arg| (*target_id, arg))
+}
+
+fn promise_resolve_arg(expr: &Expr) -> Option<Expr> {
+    let Expr::Call {
+        callee,
+        args,
+        type_args,
+    } = expr
+    else {
+        return None;
+    };
+    if !type_args.is_empty() || args.len() != 1 {
+        return None;
+    }
+    match callee.as_ref() {
+        Expr::PropertyGet { object, property }
+            if property == "resolve" && matches!(object.as_ref(), Expr::GlobalGet(0)) =>
+        {
+            Some(args[0].clone())
+        }
+        _ => None,
+    }
+}
+
+fn block_yields_local_before_rewrite(stmts: &[Stmt], start: usize, target_id: LocalId) -> bool {
+    for stmt in &stmts[start..] {
+        if iter_result_yields_local(stmt, target_id) {
+            return true;
+        }
+        if stmt_writes_local(stmt, target_id) {
+            return false;
+        }
+    }
+    false
+}
+
+fn iter_result_yields_local(stmt: &Stmt, target_id: LocalId) -> bool {
+    let value = match stmt {
+        Stmt::Expr(Expr::IterResultSet(value, false)) => value.as_ref(),
+        Stmt::Return(Some(Expr::IterResultSet(value, false))) => value.as_ref(),
+        _ => return false,
+    };
+    matches!(value, Expr::LocalGet(id) if *id == target_id)
+}
+
+fn stmt_writes_local(stmt: &Stmt, target_id: LocalId) -> bool {
+    matches!(stmt, Stmt::Expr(Expr::LocalSet(id, _)) if *id == target_id)
+}
+
 /// Like `build_async_step_driver` but skips the `__iter` object
 /// allocation entirely. Used for `was_plain_async = true` generators
 /// where the iter object is never observable from user code (the
@@ -1546,11 +1689,13 @@ fn build_async_step_driver_direct(
     next_param_id: LocalId,
     next_captures: Vec<LocalId>,
     next_mutable_captures: Vec<LocalId>,
-    throw_closure_expr: Expr,
+    throw_closure_expr: Option<Expr>,
     next_local_id: &mut u32,
     next_func_id: &mut u32,
 ) -> Vec<Stmt> {
-    let throw_id = alloc_local(next_local_id);
+    let throw_id = throw_closure_expr
+        .as_ref()
+        .map(|_| alloc_local(next_local_id));
     let step_id = alloc_local(next_local_id);
 
     // Step closure params + locals
@@ -1568,14 +1713,6 @@ fn build_async_step_driver_direct(
     let bool_ty = Type::Boolean;
 
     let promise_global = || Expr::GlobalGet(0);
-    let promise_resolve = |arg: Expr| Expr::Call {
-        callee: Box::new(Expr::PropertyGet {
-            object: Box::new(promise_global()),
-            property: "resolve".to_string(),
-        }),
-        args: vec![arg],
-        type_args: vec![],
-    };
     let promise_reject = |arg: Expr| Expr::Call {
         callee: Box::new(Expr::PropertyGet {
             object: Box::new(promise_global()),
@@ -1617,13 +1754,18 @@ fn build_async_step_driver_direct(
     //   }
     //   if (js_iter_result_get_done()) return Promise.resolve(js_iter_result_get_value());
     //   return AsyncStepChain(js_iter_result_get_value(), __step);
-    let dispatch_inner = Stmt::If {
-        condition: Expr::LocalGet(is_error_param_id),
-        then_branch: vec![Stmt::Expr(Expr::Call {
+    let throw_branch = if let Some(throw_id) = throw_id {
+        vec![Stmt::Expr(Expr::Call {
             callee: Box::new(Expr::LocalGet(throw_id)),
             args: vec![Expr::LocalGet(value_param_id)],
             type_args: vec![],
-        })],
+        })]
+    } else {
+        vec![Stmt::Throw(Expr::LocalGet(value_param_id))]
+    };
+    let dispatch_inner = Stmt::If {
+        condition: Expr::LocalGet(is_error_param_id),
+        then_branch: throw_branch,
         else_branch: Some(else_branch),
     };
 
@@ -1681,9 +1823,11 @@ fn build_async_step_driver_direct(
         })),
     ];
 
-    // step closure captures = next_captures + [throw_id, step_id]
+    // step closure captures = next_captures + [optional throw_id, step_id]
     let mut step_captures: Vec<LocalId> = next_captures;
-    step_captures.push(throw_id);
+    if let Some(throw_id) = throw_id {
+        step_captures.push(throw_id);
+    }
     step_captures.push(step_id);
     step_captures.sort();
     step_captures.dedup();
@@ -1720,18 +1864,21 @@ fn build_async_step_driver_direct(
     };
 
     // Outer wrapper:
-    //   let __throw = <throw_closure>;
+    //   let __throw = <throw_closure>; // only when catch routing needs it
     //   let __step;
     //   __step = <step_closure>;
     //   return __step(undefined, false);
-    vec![
-        Stmt::Let {
+    let mut out = Vec::with_capacity(if throw_closure_expr.is_some() { 4 } else { 3 });
+    if let (Some(throw_id), Some(throw_closure_expr)) = (throw_id, throw_closure_expr) {
+        out.push(Stmt::Let {
             id: throw_id,
             name: "__async_throw".to_string(),
             ty: any_ty.clone(),
             mutable: false,
             init: Some(throw_closure_expr),
-        },
+        });
+    }
+    out.extend([
         Stmt::Let {
             id: step_id,
             name: "__async_step".to_string(),
@@ -1745,7 +1892,8 @@ fn build_async_step_driver_direct(
             args: vec![Expr::Undefined, Expr::Bool(false)],
             type_args: vec![],
         })),
-    ]
+    ]);
+    out
 }
 
 struct State {


### PR DESCRIPTION
## Summary

This PR improves Perry's async Promise fan-out hot path and applies a couple of smaller string/array allocation optimizations found while profiling app-pattern benchmarks.

Changes included:

- Avoid per-input fulfillment closure allocation in `Promise.all` by attaching a direct fulfillment continuation to each input promise.
- Teach the GC to trace and rewrite the new `Promise.all` direct-fulfillment links.
- Optimize the plain async generator driver by:
  - skipping the generated throw closure when the throw path is only a direct rethrow;
  - rewriting internal `await Promise.resolve(x)` temporaries to `await x`, preserving the async step while avoiding already-resolved Promise allocation.
- Use short-string storage for small `String.prototype.split` results.
- Pre-size `Array.prototype.join` output to reduce reallocations.

## Performance

Primary benchmark: `benchmarks/app-patterns/kernels/promise_all_chains.ts`.

Before/after with local Perry binaries, `hyperfine --warmup 5 --runs 25`:

| Version | Mean | Min | Stddev |
| --- | ---: | ---: | ---: |
| Before | 39.0 ms | 36.8 ms | 1.4 ms |
| After | 31.7 ms | 29.4 ms | 2.6 ms |

That is about **1.23x faster** on this workload, or roughly **18.7% lower mean wall time**.

Internal microtask profile for the same benchmark:

| Metric | Before | After |
| --- | ---: | ---: |
| Promise allocations | 201,899 | 51,949 |
| Resolved microtasks | 149,951 | 1 |
| Closure allocations | 150,849 | 50,949 |

Manual runtime comparison after the change, because the app-pattern runner uses `timeout`, which is unavailable in this macOS environment:

| Runtime | Mean | Min | Stddev |
| --- | ---: | ---: | ---: |
| Perry | 13.9 ms | 10.5 ms | 1.3 ms |
| Bun | 25.1 ms | 14.7 ms | 10.3 ms |
| Node | 63.7 ms | 53.3 ms | 15.7 ms |

## Validation

- `cargo check -p perry-transform -p perry-runtime`
- `git diff --check`
- Compiled and ran `benchmarks/app-patterns/kernels/promise_all_chains.ts`; checksum stayed `2500050000`.
- Confirmed the generated HIR no longer emits `Promise.resolve(...)` for the internal await temporaries in `unitOfWork`.
