### PR TITLE
fix: #712 defensive guard + #711 dynamic-extends + Function.prototype dispatch

### DIFF
--- a/crates/perry-codegen/src/codegen.rs
+++ b/crates/perry-codegen/src/codegen.rs
@@ -550,6 +550,7 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             extends: None,
             extends_name: ic.parent_name.clone(),
             native_extends: None,
+            extends_expr: None,
             fields: ic
                 .field_names
                 .iter()

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -9630,6 +9630,27 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // observable to user code.
             Ok(double_literal(f64::from_bits(0x7FFC_0000_0000_0001)))
         }
+        // Issue #711 part 2: `<expr>.prototype = <expr>` pattern.
+        // Calls `js_set_function_prototype(func, proto)`, which (when
+        // func is a closure and proto is an object) allocates a
+        // synthetic class id and binds the proto object as that
+        // class's vtable source. Method dispatch later consults
+        // CLASS_PROTOTYPE_OBJECTS to resolve methods.
+        Expr::SetFunctionPrototype { func, proto } => {
+            let func_val = lower_expr(ctx, func)?;
+            let proto_val = lower_expr(ctx, proto)?;
+            // Discard the returned synthetic class id — it's stored in
+            // the runtime side-table keyed by func_val and consulted
+            // later by `js_register_class_parent_dynamic`. User code
+            // gets the assigned value (proto_val) as the expression
+            // result, matching JS semantics for `x.foo = bar`.
+            let _ = ctx.block().call(
+                crate::types::I32,
+                "js_set_function_prototype",
+                &[(DOUBLE, &func_val), (DOUBLE, &proto_val)],
+            );
+            Ok(proto_val)
+        }
         // `static [Symbol.for("k")] = "v"` — register in the runtime's
         // class-static-symbol side table. Refs #420 (drizzle).
         Expr::ClassStaticSymbolSet {

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -9603,6 +9603,33 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             }
             Ok(v)
         }
+        // Issue #711: dynamic parent-class registration for `class X
+        // extends fn(...)` shapes. Evaluate the extends expression and
+        // call `js_register_class_parent_dynamic(child_cid, value)`,
+        // which extracts a class_id from the value (ClassRef payload
+        // for INT32-tagged, ObjectHeader.class_id for POINTER-tagged)
+        // and wires the parent edge into CLASS_REGISTRY. No-op if the
+        // value carries no class_id — preserves the parentless
+        // baseline rather than throwing during module init.
+        Expr::RegisterClassParentDynamic {
+            class_name,
+            parent_expr,
+        } => {
+            let val = lower_expr(ctx, parent_expr)?;
+            if let Some(&class_id) = ctx.class_ids.get(class_name) {
+                if class_id != 0 {
+                    let cid_str = class_id.to_string();
+                    ctx.block().call_void(
+                        "js_register_class_parent_dynamic",
+                        &[(crate::types::I32, &cid_str), (DOUBLE, &val)],
+                    );
+                }
+            }
+            // Yield undefined — this expression is always wrapped in
+            // `Stmt::Expr` for its side effect; the return value isn't
+            // observable to user code.
+            Ok(double_literal(f64::from_bits(0x7FFC_0000_0000_0001)))
+        }
         // `static [Symbol.for("k")] = "v"` — register in the runtime's
         // class-static-symbol side table. Refs #420 (drizzle).
         Expr::ClassStaticSymbolSet {

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -666,6 +666,17 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // class_id from the value (ClassRef payload or ObjectHeader.class_id)
     // and wires the (child, parent) edge into CLASS_REGISTRY.
     module.declare_function("js_register_class_parent_dynamic", VOID, &[I32, DOUBLE]);
+    // Issue #711 part 2: prototype-based class declaration via
+    // `<func>.prototype = <obj>`. Binds an object as the function's
+    // prototype source; subsequent `class X extends <func>` lookups
+    // dispatch into the object's methods. Returns the synthetic
+    // class id allocated for the function value (or 0 on validation
+    // failure). Codegen discards the return.
+    module.declare_function(
+        "js_set_function_prototype",
+        I32,
+        &[DOUBLE, DOUBLE],
+    );
     module.declare_function("js_typeerror_new", I64, &[I64]);
     module.declare_function("js_rangeerror_new", I64, &[I64]);
     module.declare_function("js_syntaxerror_new", I64, &[I64]);

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -660,6 +660,12 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // allocators register on every alloc; the inline allocator skips
     // the alloc-site call and relies on this one-time registration.
     module.declare_function("js_register_class_parent", VOID, &[I32, I32]);
+    // Issue #711: dynamic parent registration for `class X extends fn(...)`
+    // shapes. Codegen emits at the class-declaration source position in
+    // module.init (lower.rs); the runtime helper extracts the parent
+    // class_id from the value (ClassRef payload or ObjectHeader.class_id)
+    // and wires the (child, parent) edge into CLASS_REGISTRY.
+    module.declare_function("js_register_class_parent_dynamic", VOID, &[I32, DOUBLE]);
     module.declare_function("js_typeerror_new", I64, &[I64]);
     module.declare_function("js_rangeerror_new", I64, &[I64]);
     module.declare_function("js_syntaxerror_new", I64, &[I64]);

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -672,11 +672,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // dispatch into the object's methods. Returns the synthetic
     // class id allocated for the function value (or 0 on validation
     // failure). Codegen discards the return.
-    module.declare_function(
-        "js_set_function_prototype",
-        I32,
-        &[DOUBLE, DOUBLE],
-    );
+    module.declare_function("js_set_function_prototype", I32, &[DOUBLE, DOUBLE]);
     module.declare_function("js_typeerror_new", I64, &[I64]);
     module.declare_function("js_rangeerror_new", I64, &[I64]);
     module.declare_function("js_syntaxerror_new", I64, &[I64]);

--- a/crates/perry-hir/src/ir.rs
+++ b/crates/perry-hir/src/ir.rs
@@ -542,6 +542,16 @@ pub struct Class {
     pub extends_name: Option<String>,
     /// Native parent class (module_name, class_name) - e.g., ("events", "EventEmitter")
     pub native_extends: Option<(String, String)>,
+    /// Issue #711: `class X extends fn(...)` / `class X extends Y.method(...)` —
+    /// when the super-class expression is anything other than `Ident` or
+    /// `Member` (i.e., not statically resolvable to a known class), we capture
+    /// the lowered expression here. Codegen emits a runtime call
+    /// `js_register_class_parent_dynamic(child_cid, eval(extends_expr))` at
+    /// the source-order position of the class declaration so the parent edge
+    /// in `CLASS_REGISTRY` is wired before the first instance is created.
+    /// `extends` and `extends_name` are both `None` for these classes (the
+    /// parent class_id is only known at runtime).
+    pub extends_expr: Option<Box<Expr>>,
     /// Instance fields
     pub fields: Vec<ClassField>,
     /// Constructor (if any)
@@ -989,6 +999,22 @@ pub enum Expr {
         class_name: String,
         key: Box<Expr>,
         value: Box<Expr>,
+    },
+
+    // Issue #711: dynamic parent-class registration for
+    // `class X extends fn(...)` shapes where the parent class_id is only
+    // known at runtime. Emitted by lower.rs into module.init at the
+    // source-order position of the class declaration. Codegen lowers
+    // `parent_expr` to a Perry value, then calls
+    // `js_register_class_parent_dynamic(class_id, value)` which reads the
+    // value's class_id (via GcHeader for real objects, ClassRef tag for
+    // class references) and wires the (child, parent) edge into
+    // CLASS_REGISTRY. No-op if `parent_expr` evaluates to a value with no
+    // class_id (e.g., a closure or primitive — preserves the "no parent"
+    // baseline rather than crashing).
+    RegisterClassParentDynamic {
+        class_name: String,
+        parent_expr: Box<Expr>,
     },
 
     // Static method call (e.g., Counter.increment())

--- a/crates/perry-hir/src/ir.rs
+++ b/crates/perry-hir/src/ir.rs
@@ -1017,6 +1017,20 @@ pub enum Expr {
         parent_expr: Box<Expr>,
     },
 
+    // Issue #711 part 2: `<func_expr>.prototype = <obj_expr>` pattern,
+    // used by Effect's effectable.ts to declare prototype-based
+    // classes. Codegen emits a call to `js_set_function_prototype`
+    // which stores `func_value → synthetic_class_id` in a side-table
+    // and binds the object as the synthetic class's prototype source.
+    // When `class Derived extends <func>` evaluates later, the dynamic
+    // parent registration looks up that synthetic class_id and wires
+    // it into CLASS_REGISTRY so method dispatch on Derived instances
+    // walks through to the prototype object's methods.
+    SetFunctionPrototype {
+        func: Box<Expr>,
+        proto: Box<Expr>,
+    },
+
     // Static method call (e.g., Counter.increment())
     StaticMethodCall {
         class_name: String,

--- a/crates/perry-hir/src/lower.rs
+++ b/crates/perry-hir/src/lower.rs
@@ -1017,6 +1017,7 @@ impl LoweringContext {
             extends: None,
             extends_name: None,
             native_extends: None,
+            extends_expr: None,
             fields,
             constructor: Some(constructor),
             methods: Vec::new(),
@@ -4350,6 +4351,15 @@ fn lower_module_decl(
                 ast::Decl::Class(class_decl) => {
                     let class = lower_class_decl(ctx, class_decl, true)?;
                     let class_name = class.name.clone();
+                    // Issue #711: dynamic parent-class registration at the
+                    // source position (see non-export class arm below for
+                    // rationale).
+                    if let Some(extends_expr) = &class.extends_expr {
+                        module.init.push(Stmt::Expr(Expr::RegisterClassParentDynamic {
+                            class_name: class_name.clone(),
+                            parent_expr: extends_expr.clone(),
+                        }));
+                    }
                     // Inject static-field-init statements in source order
                     // (see non-export class arm below for rationale).
                     for sf in &class.static_fields {
@@ -4781,6 +4791,7 @@ fn lower_namespace_as_class(
                 extends: None,
                 extends_name: None,
                 native_extends: None,
+                extends_expr: None,
                 fields: Vec::new(),
                 constructor: None,
                 methods: Vec::new(),
@@ -4961,6 +4972,7 @@ fn lower_namespace_as_class(
         extends: None,
         extends_name: None,
         native_extends: None,
+        extends_expr: None,
         fields: Vec::new(),
         constructor: None,
         methods: Vec::new(),
@@ -5721,6 +5733,19 @@ fn lower_stmt(ctx: &mut LoweringContext, module: &mut Module, stmt: &ast::Stmt) 
                 }
                 ast::Decl::Class(class_decl) => {
                     let class = lower_class_decl(ctx, class_decl, false)?;
+                    // Issue #711: emit dynamic parent-class registration
+                    // at the source-order position of the class declaration
+                    // BEFORE the static-field-init stmts. Static field
+                    // initializers may reference inherited static methods,
+                    // and method dispatch reads the parent chain — wiring
+                    // the parent edge first keeps the inherited lookup
+                    // path consistent for those inits.
+                    if let Some(extends_expr) = &class.extends_expr {
+                        module.init.push(Stmt::Expr(Expr::RegisterClassParentDynamic {
+                            class_name: class.name.clone(),
+                            parent_expr: extends_expr.clone(),
+                        }));
+                    }
                     // Inject static-field-init statements at the source
                     // position of the class declaration. Per ES spec, a
                     // class declaration's static initializers run when the

--- a/crates/perry-hir/src/lower.rs
+++ b/crates/perry-hir/src/lower.rs
@@ -4355,10 +4355,12 @@ fn lower_module_decl(
                     // source position (see non-export class arm below for
                     // rationale).
                     if let Some(extends_expr) = &class.extends_expr {
-                        module.init.push(Stmt::Expr(Expr::RegisterClassParentDynamic {
-                            class_name: class_name.clone(),
-                            parent_expr: extends_expr.clone(),
-                        }));
+                        module
+                            .init
+                            .push(Stmt::Expr(Expr::RegisterClassParentDynamic {
+                                class_name: class_name.clone(),
+                                parent_expr: extends_expr.clone(),
+                            }));
                     }
                     // Inject static-field-init statements in source order
                     // (see non-export class arm below for rationale).
@@ -5741,10 +5743,12 @@ fn lower_stmt(ctx: &mut LoweringContext, module: &mut Module, stmt: &ast::Stmt) 
                     // the parent edge first keeps the inherited lookup
                     // path consistent for those inits.
                     if let Some(extends_expr) = &class.extends_expr {
-                        module.init.push(Stmt::Expr(Expr::RegisterClassParentDynamic {
-                            class_name: class.name.clone(),
-                            parent_expr: extends_expr.clone(),
-                        }));
+                        module
+                            .init
+                            .push(Stmt::Expr(Expr::RegisterClassParentDynamic {
+                                class_name: class.name.clone(),
+                                parent_expr: extends_expr.clone(),
+                            }));
                     }
                     // Inject static-field-init statements at the source
                     // position of the class declaration. Per ES spec, a

--- a/crates/perry-hir/src/lower.rs
+++ b/crates/perry-hir/src/lower.rs
@@ -7075,6 +7075,25 @@ pub(super) fn lower_expr_assignment(
             match &member.prop {
                 ast::MemberProp::Ident(ident) => {
                     let property = ident.sym.to_string();
+                    // Issue #711 part 2: `<expr>.prototype = <value>`
+                    // pattern (Effect's effectable.ts uses this to
+                    // declare prototype-based classes — `function
+                    // Base() {}; Base.prototype = CommitPrototype`).
+                    // Route through the SetFunctionPrototype HIR node
+                    // so codegen calls
+                    // `js_set_function_prototype(func, proto)`, which
+                    // allocates a synthetic class id keyed by the
+                    // function value. The runtime helper is a no-op
+                    // when `object` doesn't evaluate to a function
+                    // (preserves baseline for legitimate
+                    // `someClass.prototype = X` writes on non-function
+                    // values).
+                    if property == "prototype" {
+                        return Ok(Expr::SetFunctionPrototype {
+                            func: object,
+                            proto: value,
+                        });
+                    }
                     Ok(Expr::PropertySet {
                         object,
                         property,

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -393,6 +393,23 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
             match &member.prop {
                 ast::MemberProp::Ident(ident) => {
                     let property = ident.sym.to_string();
+                    // Issue #711 part 2: route `<expr>.prototype =
+                    // <value>` through SetFunctionPrototype so the
+                    // runtime binds the proto object as the function
+                    // value's class-prototype source. Effect's
+                    // effectable.ts uses this to declare classes via
+                    // prototype assignment on a plain function. The
+                    // runtime helper is a no-op when `object` doesn't
+                    // resolve to a function at runtime (preserves the
+                    // baseline for arbitrary `obj.prototype = X`
+                    // writes — those are rare and meaningless on
+                    // non-functions in practice).
+                    if property == "prototype" {
+                        return Ok(Expr::SetFunctionPrototype {
+                            func: object,
+                            proto: value,
+                        });
+                    }
                     Ok(Expr::PropertySet {
                         object,
                         property,

--- a/crates/perry-hir/src/lower_decl.rs
+++ b/crates/perry-hir/src/lower_decl.rs
@@ -718,7 +718,12 @@ pub(crate) fn lower_class_decl(
                 // Class names are unique enough in practice that `lookup_class`
                 // resolves; if it doesn't, we fall back to the prior
                 // name-only behavior (no regression for unknown parents).
-                (ctx.lookup_class(&parent_name), Some(parent_name), None, None)
+                (
+                    ctx.lookup_class(&parent_name),
+                    Some(parent_name),
+                    None,
+                    None,
+                )
             } else {
                 // Issue #711: `class X extends fn(...)` / `class X extends
                 // new Foo(...)` etc. The super-class expression isn't
@@ -1655,68 +1660,74 @@ pub(crate) fn lower_class_from_ast(
 
     ctx.enter_type_param_scope(&type_params);
 
-    let (extends, extends_name, native_extends, extends_expr) = if let Some(ref super_class) = class.super_class {
-        if let ast::Expr::Ident(ident) = super_class.as_ref() {
-            let parent_name = ident.sym.to_string();
-            let native_parent = match parent_name.as_str() {
-                "EventEmitter" => Some(("events".to_string(), "EventEmitter".to_string())),
-                "AsyncLocalStorage" => {
-                    Some(("async_hooks".to_string(), "AsyncLocalStorage".to_string()))
-                }
-                "WebSocketServer" => Some(("ws".to_string(), "WebSocketServer".to_string())),
-                // Issue #562: keep in lockstep with the parallel arm in
-                // `lower_class_decl` above.
-                "ReadableStream" => {
-                    Some(("readable_stream".to_string(), "ReadableStream".to_string()))
-                }
-                "WritableStream" => {
-                    Some(("writable_stream".to_string(), "WritableStream".to_string()))
-                }
-                "TransformStream" => Some((
-                    "transform_stream".to_string(),
-                    "TransformStream".to_string(),
-                )),
-                _ => None,
-            };
-            if native_parent.is_some() {
-                (None, Some(parent_name), native_parent, None)
-            } else {
-                let parent_cid = ctx.lookup_class(&parent_name);
-                if parent_cid.is_none() {
-                    // Issue #711 part 2: see the parallel arm in
-                    // `lower_class_decl` above. Unknown Ident super-class
-                    // falls through to extends_expr capture so a
-                    // function-with-prototype value can be resolved at
-                    // runtime via `function_class_id`.
-                    match lower_expr(ctx, super_class) {
-                        Ok(expr) => (None, Some(parent_name), None, Some(Box::new(expr))),
-                        Err(_) => (None, Some(parent_name), None, None),
+    let (extends, extends_name, native_extends, extends_expr) =
+        if let Some(ref super_class) = class.super_class {
+            if let ast::Expr::Ident(ident) = super_class.as_ref() {
+                let parent_name = ident.sym.to_string();
+                let native_parent = match parent_name.as_str() {
+                    "EventEmitter" => Some(("events".to_string(), "EventEmitter".to_string())),
+                    "AsyncLocalStorage" => {
+                        Some(("async_hooks".to_string(), "AsyncLocalStorage".to_string()))
                     }
+                    "WebSocketServer" => Some(("ws".to_string(), "WebSocketServer".to_string())),
+                    // Issue #562: keep in lockstep with the parallel arm in
+                    // `lower_class_decl` above.
+                    "ReadableStream" => {
+                        Some(("readable_stream".to_string(), "ReadableStream".to_string()))
+                    }
+                    "WritableStream" => {
+                        Some(("writable_stream".to_string(), "WritableStream".to_string()))
+                    }
+                    "TransformStream" => Some((
+                        "transform_stream".to_string(),
+                        "TransformStream".to_string(),
+                    )),
+                    _ => None,
+                };
+                if native_parent.is_some() {
+                    (None, Some(parent_name), native_parent, None)
                 } else {
-                    (parent_cid, Some(parent_name), None, None)
+                    let parent_cid = ctx.lookup_class(&parent_name);
+                    if parent_cid.is_none() {
+                        // Issue #711 part 2: see the parallel arm in
+                        // `lower_class_decl` above. Unknown Ident super-class
+                        // falls through to extends_expr capture so a
+                        // function-with-prototype value can be resolved at
+                        // runtime via `function_class_id`.
+                        match lower_expr(ctx, super_class) {
+                            Ok(expr) => (None, Some(parent_name), None, Some(Box::new(expr))),
+                            Err(_) => (None, Some(parent_name), None, None),
+                        }
+                    } else {
+                        (parent_cid, Some(parent_name), None, None)
+                    }
+                }
+            } else if let ast::Expr::Member(member) = super_class.as_ref() {
+                // Refs #488 drizzle-sqlite: try cross-module class lookup. See
+                // the matching arm in `lower_class_decl` (above) for the full
+                // rationale — without this, the parent link is lost and
+                // inherited methods don't reach instances.
+                let parent_name = extract_member_class_name(member);
+                (
+                    ctx.lookup_class(&parent_name),
+                    Some(parent_name),
+                    None,
+                    None,
+                )
+            } else {
+                // Issue #711: see the matching arm in `lower_class_decl` above
+                // for the full rationale. Capture the lowered extends
+                // expression so codegen can evaluate it at the class
+                // declaration site and call
+                // `js_register_class_parent_dynamic` at runtime.
+                match lower_expr(ctx, super_class) {
+                    Ok(expr) => (None, None, None, Some(Box::new(expr))),
+                    Err(_) => (None, None, None, None),
                 }
             }
-        } else if let ast::Expr::Member(member) = super_class.as_ref() {
-            // Refs #488 drizzle-sqlite: try cross-module class lookup. See
-            // the matching arm in `lower_class_decl` (above) for the full
-            // rationale — without this, the parent link is lost and
-            // inherited methods don't reach instances.
-            let parent_name = extract_member_class_name(member);
-            (ctx.lookup_class(&parent_name), Some(parent_name), None, None)
         } else {
-            // Issue #711: see the matching arm in `lower_class_decl` above
-            // for the full rationale. Capture the lowered extends
-            // expression so codegen can evaluate it at the class
-            // declaration site and call
-            // `js_register_class_parent_dynamic` at runtime.
-            match lower_expr(ctx, super_class) {
-                Ok(expr) => (None, None, None, Some(Box::new(expr))),
-                Err(_) => (None, None, None, None),
-            }
-        }
-    } else {
-        (None, None, None, None)
-    };
+            (None, None, None, None)
+        };
 
     let mut static_field_names = Vec::new();
     let mut static_method_names = Vec::new();

--- a/crates/perry-hir/src/lower_decl.rs
+++ b/crates/perry-hir/src/lower_decl.rs
@@ -643,7 +643,7 @@ pub(crate) fn lower_class_decl(
     ctx.enter_type_param_scope(&type_params);
 
     // Handle extends clause
-    let (extends, extends_name, native_extends) =
+    let (extends, extends_name, native_extends, extends_expr) =
         if let Some(ref super_class) = class_decl.class.super_class {
             if let ast::Expr::Ident(ident) = super_class.as_ref() {
                 let parent_name = ident.sym.to_string();
@@ -680,10 +680,10 @@ pub(crate) fn lower_class_decl(
                     // dispatch resolves through the existing extends_name
                     // path while the native_extends carries the (module,
                     // class) tag for the runtime shim).
-                    (None, Some(parent_name), native_parent)
+                    (None, Some(parent_name), native_parent, None)
                 } else {
                     // Always capture the parent name for imported classes that may not have a ClassId
-                    (ctx.lookup_class(&parent_name), Some(parent_name), None)
+                    (ctx.lookup_class(&parent_name), Some(parent_name), None, None)
                 }
             } else if let ast::Expr::Member(member) = super_class.as_ref() {
                 // Handle member expression like ethers.JsonRpcProvider or module.ClassName
@@ -697,12 +697,28 @@ pub(crate) fn lower_class_decl(
                 // Class names are unique enough in practice that `lookup_class`
                 // resolves; if it doesn't, we fall back to the prior
                 // name-only behavior (no regression for unknown parents).
-                (ctx.lookup_class(&parent_name), Some(parent_name), None)
+                (ctx.lookup_class(&parent_name), Some(parent_name), None, None)
             } else {
-                (None, None, None)
+                // Issue #711: `class X extends fn(...)` / `class X extends
+                // new Foo(...)` etc. The super-class expression isn't
+                // statically resolvable to a known class. Lower the
+                // expression so codegen can evaluate it at the class
+                // declaration site and call
+                // `js_register_class_parent_dynamic` to wire the parent
+                // edge into CLASS_REGISTRY at runtime. Both `extends` and
+                // `extends_name` stay None — the parent class_id is only
+                // known once the expression evaluates. Lowering errors
+                // here are non-fatal: fall back to a parentless class so
+                // the rest of the program still compiles (the
+                // method-dispatch catch-all in object.rs surfaces the
+                // missing-method case clearly enough).
+                match lower_expr(ctx, super_class) {
+                    Ok(expr) => (None, None, None, Some(Box::new(expr))),
+                    Err(_) => (None, None, None, None),
+                }
             }
         } else {
-            (None, None, None)
+            (None, None, None, None)
         };
 
     // First pass: collect static field/method names for early registration
@@ -1567,6 +1583,7 @@ pub(crate) fn lower_class_decl(
         extends,
         extends_name,
         native_extends,
+        extends_expr,
         fields,
         constructor,
         methods,
@@ -1617,7 +1634,7 @@ pub(crate) fn lower_class_from_ast(
 
     ctx.enter_type_param_scope(&type_params);
 
-    let (extends, extends_name, native_extends) = if let Some(ref super_class) = class.super_class {
+    let (extends, extends_name, native_extends, extends_expr) = if let Some(ref super_class) = class.super_class {
         if let ast::Expr::Ident(ident) = super_class.as_ref() {
             let parent_name = ident.sym.to_string();
             let native_parent = match parent_name.as_str() {
@@ -1641,9 +1658,9 @@ pub(crate) fn lower_class_from_ast(
                 _ => None,
             };
             if native_parent.is_some() {
-                (None, Some(parent_name), native_parent)
+                (None, Some(parent_name), native_parent, None)
             } else {
-                (ctx.lookup_class(&parent_name), Some(parent_name), None)
+                (ctx.lookup_class(&parent_name), Some(parent_name), None, None)
             }
         } else if let ast::Expr::Member(member) = super_class.as_ref() {
             // Refs #488 drizzle-sqlite: try cross-module class lookup. See
@@ -1651,12 +1668,20 @@ pub(crate) fn lower_class_from_ast(
             // rationale — without this, the parent link is lost and
             // inherited methods don't reach instances.
             let parent_name = extract_member_class_name(member);
-            (ctx.lookup_class(&parent_name), Some(parent_name), None)
+            (ctx.lookup_class(&parent_name), Some(parent_name), None, None)
         } else {
-            (None, None, None)
+            // Issue #711: see the matching arm in `lower_class_decl` above
+            // for the full rationale. Capture the lowered extends
+            // expression so codegen can evaluate it at the class
+            // declaration site and call
+            // `js_register_class_parent_dynamic` at runtime.
+            match lower_expr(ctx, super_class) {
+                Ok(expr) => (None, None, None, Some(Box::new(expr))),
+                Err(_) => (None, None, None, None),
+            }
         }
     } else {
-        (None, None, None)
+        (None, None, None, None)
     };
 
     let mut static_field_names = Vec::new();
@@ -1844,6 +1869,7 @@ pub(crate) fn lower_class_from_ast(
         extends,
         extends_name,
         native_extends,
+        extends_expr,
         fields,
         constructor,
         methods,

--- a/crates/perry-hir/src/lower_decl.rs
+++ b/crates/perry-hir/src/lower_decl.rs
@@ -682,8 +682,29 @@ pub(crate) fn lower_class_decl(
                     // class) tag for the runtime shim).
                     (None, Some(parent_name), native_parent, None)
                 } else {
-                    // Always capture the parent name for imported classes that may not have a ClassId
-                    (ctx.lookup_class(&parent_name), Some(parent_name), None, None)
+                    let parent_cid = ctx.lookup_class(&parent_name);
+                    if parent_cid.is_none() {
+                        // Issue #711 part 2: the Ident doesn't resolve to
+                        // any known class. The common case is Effect's
+                        // `const Base = (function() { function Base(){}; Base.prototype = X; return Base })()` pattern —
+                        // `Base` is a function value with a prototype
+                        // object attached via `js_set_function_prototype`.
+                        // Capture the Ident as `extends_expr` so the
+                        // dynamic parent-registration helper can resolve
+                        // it through `function_class_id` at runtime.
+                        // `extends_name` stays populated for the rare
+                        // cases where downstream code paths key on the
+                        // textual parent name (super-call codegen, etc.)
+                        // but extends_expr takes precedence on the
+                        // method-dispatch path.
+                        match lower_expr(ctx, super_class) {
+                            Ok(expr) => (None, Some(parent_name), None, Some(Box::new(expr))),
+                            Err(_) => (None, Some(parent_name), None, None),
+                        }
+                    } else {
+                        // Always capture the parent name for imported classes that may not have a ClassId
+                        (parent_cid, Some(parent_name), None, None)
+                    }
                 }
             } else if let ast::Expr::Member(member) = super_class.as_ref() {
                 // Handle member expression like ethers.JsonRpcProvider or module.ClassName
@@ -1660,7 +1681,20 @@ pub(crate) fn lower_class_from_ast(
             if native_parent.is_some() {
                 (None, Some(parent_name), native_parent, None)
             } else {
-                (ctx.lookup_class(&parent_name), Some(parent_name), None, None)
+                let parent_cid = ctx.lookup_class(&parent_name);
+                if parent_cid.is_none() {
+                    // Issue #711 part 2: see the parallel arm in
+                    // `lower_class_decl` above. Unknown Ident super-class
+                    // falls through to extends_expr capture so a
+                    // function-with-prototype value can be resolved at
+                    // runtime via `function_class_id`.
+                    match lower_expr(ctx, super_class) {
+                        Ok(expr) => (None, Some(parent_name), None, Some(Box::new(expr))),
+                        Err(_) => (None, Some(parent_name), None, None),
+                    }
+                } else {
+                    (parent_cid, Some(parent_name), None, None)
+                }
             }
         } else if let ast::Expr::Member(member) = super_class.as_ref() {
             // Refs #488 drizzle-sqlite: try cross-module class lookup. See

--- a/crates/perry-hir/src/monomorph.rs
+++ b/crates/perry-hir/src/monomorph.rs
@@ -1872,6 +1872,7 @@ pub fn specialize_class(class: &Class, type_args: &[Type], new_id: ClassId) -> C
         extends: class.extends,  // TODO: Handle generic extends
         extends_name: class.extends_name.clone(),
         native_extends: class.native_extends.clone(),
+        extends_expr: class.extends_expr.clone(),
         fields: class
             .fields
             .iter()

--- a/crates/perry-hir/src/stable_hash.rs
+++ b/crates/perry-hir/src/stable_hash.rs
@@ -454,6 +454,7 @@ impl SH for Class {
             type_params,
             extends,
             extends_name,
+            extends_expr,
             native_extends,
             fields,
             constructor,
@@ -470,6 +471,7 @@ impl SH for Class {
         type_params.hash(h);
         extends.hash(h);
         extends_name.hash(h);
+        extends_expr.hash(h);
         native_extends.hash(h);
         fields.hash(h);
         constructor.hash(h);
@@ -3415,6 +3417,19 @@ impl SH for Expr {
                 tag(h, 446);
                 e.as_ref().hash(h);
             }
+            Expr::RegisterClassParentDynamic {
+                class_name,
+                parent_expr,
+            } => {
+                tag(h, 447);
+                class_name.hash(h);
+                parent_expr.as_ref().hash(h);
+            }
+            Expr::SetFunctionPrototype { func, proto } => {
+                tag(h, 448);
+                func.as_ref().hash(h);
+                proto.as_ref().hash(h);
+            }
         }
     }
 }
@@ -3544,6 +3559,7 @@ mod tests {
             type_params: vec![],
             extends: None,
             extends_name: None,
+            extends_expr: None,
             native_extends: None,
             fields: vec![],
             constructor: None,

--- a/crates/perry-hir/src/walker.rs
+++ b/crates/perry-hir/src/walker.rs
@@ -401,6 +401,10 @@ where
         Expr::RegisterClassParentDynamic { parent_expr, .. } => {
             f(parent_expr);
         }
+        Expr::SetFunctionPrototype { func, proto } => {
+            f(func);
+            f(proto);
+        }
         Expr::IndexGet { object, index } => {
             f(object);
             f(index);
@@ -1576,6 +1580,10 @@ where
         }
         Expr::RegisterClassParentDynamic { parent_expr, .. } => {
             f(parent_expr);
+        }
+        Expr::SetFunctionPrototype { func, proto } => {
+            f(func);
+            f(proto);
         }
         Expr::IndexGet { object, index } => {
             f(object);

--- a/crates/perry-hir/src/walker.rs
+++ b/crates/perry-hir/src/walker.rs
@@ -398,6 +398,9 @@ where
             f(key);
             f(value);
         }
+        Expr::RegisterClassParentDynamic { parent_expr, .. } => {
+            f(parent_expr);
+        }
         Expr::IndexGet { object, index } => {
             f(object);
             f(index);
@@ -1570,6 +1573,9 @@ where
         Expr::ClassStaticSymbolSet { key, value, .. } => {
             f(key);
             f(value);
+        }
+        Expr::RegisterClassParentDynamic { parent_expr, .. } => {
+            f(parent_expr);
         }
         Expr::IndexGet { object, index } => {
             f(object);

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -1039,8 +1039,7 @@ pub static FUNCTION_CLASS_IDS: RwLock<Option<HashMap<u64, u32>>> = RwLock::new(N
 // pointer is always converted back to `*mut ObjectHeader` at call sites
 // (`class_prototype_object` / the dispatch walk) where single-threaded
 // usage is guaranteed.
-pub static CLASS_PROTOTYPE_OBJECTS: RwLock<Option<HashMap<u32, usize>>> =
-    RwLock::new(None);
+pub static CLASS_PROTOTYPE_OBJECTS: RwLock<Option<HashMap<u32, usize>>> = RwLock::new(None);
 
 /// Synthetic class id allocator for prototype-object classes. High bit
 /// set (0x8000_0000+) to keep them separate from codegen-assigned ids
@@ -1119,8 +1118,7 @@ pub extern "C" fn js_set_function_prototype(func: f64, proto: f64) -> u32 {
             }
         }
     }
-    let new_cid = NEXT_SYNTHETIC_CLASS_ID
-        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let new_cid = NEXT_SYNTHETIC_CLASS_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     {
         let mut write = FUNCTION_CLASS_IDS.write().unwrap();
         if write.is_none() {
@@ -1133,10 +1131,7 @@ pub extern "C" fn js_set_function_prototype(func: f64, proto: f64) -> u32 {
         if write.is_none() {
             *write = Some(HashMap::new());
         }
-        write
-            .as_mut()
-            .unwrap()
-            .insert(new_cid, proto_ptr as usize);
+        write.as_mut().unwrap().insert(new_cid, proto_ptr as usize);
     }
     // Register the synthetic id so REGISTERED_CLASS_IDS-gated paths
     // (e.g., the #687 ClassRef-as-receiver short-circuit) recognize it.
@@ -1150,10 +1145,7 @@ pub extern "C" fn js_set_function_prototype(func: f64, proto: f64) -> u32 {
 pub(crate) fn class_prototype_object(class_id: u32) -> *mut ObjectHeader {
     if let Ok(read) = CLASS_PROTOTYPE_OBJECTS.read() {
         if let Some(map) = read.as_ref() {
-            return map
-                .get(&class_id)
-                .copied()
-                .unwrap_or(0) as *mut ObjectHeader;
+            return map.get(&class_id).copied().unwrap_or(0) as *mut ObjectHeader;
         }
     }
     std::ptr::null_mut()
@@ -3741,10 +3733,7 @@ pub extern "C" fn js_object_get_field_by_name(
                 while depth < 32 {
                     let proto_obj = class_prototype_object(cid);
                     if !proto_obj.is_null() {
-                        let field_val = js_object_get_field_by_name(
-                            proto_obj as *const _,
-                            key,
-                        );
+                        let field_val = js_object_get_field_by_name(proto_obj as *const _, key);
                         if !field_val.is_undefined() && !field_val.is_null() {
                             return field_val;
                         }
@@ -6251,8 +6240,7 @@ pub unsafe extern "C" fn js_native_call_method(
                                     method_key as *const crate::StringHeader,
                                 );
                                 if !field_val.is_undefined() && !field_val.is_null() {
-                                    let prev_this =
-                                        IMPLICIT_THIS.with(|c| c.replace(jsval.bits()));
+                                    let prev_this = IMPLICIT_THIS.with(|c| c.replace(jsval.bits()));
                                     let result = crate::closure::js_native_call_value(
                                         f64::from_bits(field_val.bits()),
                                         args_ptr,

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -1017,6 +1017,161 @@ pub static CLASS_VTABLE_REGISTRY: RwLock<Option<HashMap<u32, ClassVTable>>> = Rw
 /// classes without any methods. Refs #618 / #420 followup.
 pub static REGISTERED_CLASS_IDS: RwLock<Option<std::collections::HashSet<u32>>> = RwLock::new(None);
 
+/// Issue #711 part 2: `function Base() {}; Base.prototype = obj` pattern.
+/// Effect's `internal/effectable.ts` declares classes via prototype
+/// assignment on a plain function, not via `class` syntax. To make
+/// `class Derived extends Base {}` walk into `obj`'s methods at dispatch
+/// time, we model this as a synthetic class:
+///   - `js_set_function_prototype(func, obj)` allocates a synthetic
+///     class_id (high-bit-set to avoid collision with codegen-assigned
+///     ids), stores `func_bits → synthetic_cid` in `FUNCTION_CLASS_IDS`,
+///     and `synthetic_cid → obj_ptr` in `CLASS_PROTOTYPE_OBJECTS`.
+///   - `js_register_class_parent_dynamic` extends to detect closure
+///     parent values, looks up the synthetic class_id, and registers
+///     the (child, synthetic) edge in CLASS_REGISTRY.
+///   - The method-dispatch chain walk in `js_native_call_method`
+///     consults `CLASS_PROTOTYPE_OBJECTS` when it reaches a synthetic
+///     class_id: it resolves the method as a regular field lookup on
+///     the prototype object and calls it with `this` bound to the
+///     receiver.
+pub static FUNCTION_CLASS_IDS: RwLock<Option<HashMap<u64, u32>>> = RwLock::new(None);
+// Stored as `usize` (raw address) so the map is Send + Sync. The
+// pointer is always converted back to `*mut ObjectHeader` at call sites
+// (`class_prototype_object` / the dispatch walk) where single-threaded
+// usage is guaranteed.
+pub static CLASS_PROTOTYPE_OBJECTS: RwLock<Option<HashMap<u32, usize>>> =
+    RwLock::new(None);
+
+/// Synthetic class id allocator for prototype-object classes. High bit
+/// set (0x8000_0000+) to keep them separate from codegen-assigned ids
+/// (which start from 1 and grow by module). u32 wraparound is not a
+/// concern in practice — would require ~2 billion `Function.prototype = X`
+/// statements at module init.
+pub static NEXT_SYNTHETIC_CLASS_ID: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0x8000_0000);
+
+/// Register a function's prototype object. Called by codegen-emitted
+/// init code whenever the HIR detects `<expr>.prototype = <expr>` at
+/// the assignment-statement level (lower_expr_assignment Member arm).
+///
+/// Returns the synthetic class_id allocated for this function (0 if
+/// validation fails). The synthetic id is folded into CLASS_REGISTRY
+/// when a class extends `func` via the #711 dynamic-parent path.
+#[no_mangle]
+pub extern "C" fn js_set_function_prototype(func: f64, proto: f64) -> u32 {
+    let func_bits = func.to_bits();
+    let func_tag = func_bits & 0xFFFF_0000_0000_0000;
+    let proto_bits = proto.to_bits();
+    let proto_tag = proto_bits & 0xFFFF_0000_0000_0000;
+    const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+    // Both must be heap-allocated pointers. Anything else (primitives,
+    // ClassRef, etc.) is a no-op — preserves the pre-fix baseline
+    // where `<not-a-function>.prototype = X` was just a property write
+    // on a non-function value (effectively no-op in practice).
+    if func_tag != POINTER_TAG || proto_tag != POINTER_TAG {
+        return 0;
+    }
+    // Validate the proto pointer points at a real Object. If it's a
+    // builtin header (Set/Map/Regex) or null, bail — Perry can't
+    // currently model those as prototype sources.
+    let proto_ptr = crate::value::js_nanbox_get_pointer(proto) as *mut ObjectHeader;
+    if proto_ptr.is_null() {
+        return 0;
+    }
+    let proto_addr = proto_ptr as usize;
+    if crate::set::is_registered_set(proto_addr)
+        || crate::map::is_registered_map(proto_addr)
+        || crate::regex::is_regex_pointer(proto_ptr as *const u8)
+    {
+        return 0;
+    }
+    unsafe {
+        if !is_valid_obj_ptr(proto_ptr as *const u8) {
+            return 0;
+        }
+        let gc_header =
+            (proto_ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*gc_header).obj_type != crate::gc::GC_TYPE_OBJECT {
+            return 0;
+        }
+    }
+
+    // Allocate or reuse a synthetic class id for this function value.
+    // The same `function Base() {}` ident can be assigned a prototype
+    // multiple times in pathological code; we keep the FIRST mapping
+    // and quietly ignore subsequent calls so existing parent edges
+    // don't dangle.
+    {
+        let read = FUNCTION_CLASS_IDS.read().unwrap();
+        if let Some(map) = read.as_ref() {
+            if let Some(&existing) = map.get(&func_bits) {
+                // Update the prototype object (allow re-pointing)
+                // without changing the class_id.
+                let mut proto_write = CLASS_PROTOTYPE_OBJECTS.write().unwrap();
+                if proto_write.is_none() {
+                    *proto_write = Some(HashMap::new());
+                }
+                proto_write
+                    .as_mut()
+                    .unwrap()
+                    .insert(existing, proto_ptr as usize);
+                return existing;
+            }
+        }
+    }
+    let new_cid = NEXT_SYNTHETIC_CLASS_ID
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    {
+        let mut write = FUNCTION_CLASS_IDS.write().unwrap();
+        if write.is_none() {
+            *write = Some(HashMap::new());
+        }
+        write.as_mut().unwrap().insert(func_bits, new_cid);
+    }
+    {
+        let mut write = CLASS_PROTOTYPE_OBJECTS.write().unwrap();
+        if write.is_none() {
+            *write = Some(HashMap::new());
+        }
+        write
+            .as_mut()
+            .unwrap()
+            .insert(new_cid, proto_ptr as usize);
+    }
+    // Register the synthetic id so REGISTERED_CLASS_IDS-gated paths
+    // (e.g., the #687 ClassRef-as-receiver short-circuit) recognize it.
+    unsafe { js_register_class_id(new_cid) };
+    new_cid
+}
+
+/// Lookup helper for the dispatch chain walk: returns the prototype
+/// object pointer for a synthetic class id, or null if none.
+#[inline]
+pub(crate) fn class_prototype_object(class_id: u32) -> *mut ObjectHeader {
+    if let Ok(read) = CLASS_PROTOTYPE_OBJECTS.read() {
+        if let Some(map) = read.as_ref() {
+            return map
+                .get(&class_id)
+                .copied()
+                .unwrap_or(0) as *mut ObjectHeader;
+        }
+    }
+    std::ptr::null_mut()
+}
+
+/// Lookup the synthetic class id for a function value, if one was
+/// registered via `js_set_function_prototype`.
+#[inline]
+pub(crate) fn function_class_id(value: f64) -> u32 {
+    let bits = value.to_bits();
+    if let Ok(read) = FUNCTION_CLASS_IDS.read() {
+        if let Some(map) = read.as_ref() {
+            return map.get(&bits).copied().unwrap_or(0);
+        }
+    }
+    0
+}
+
 /// Register a class id so `js_value_typeof` can distinguish class refs
 /// (INT32-tagged with class_id payload) from real int32 numeric values.
 #[no_mangle]
@@ -1608,10 +1763,19 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, parent_value: 
     } else if tag == POINTER_TAG {
         // Object instance: read class_id from the ObjectHeader.
         let ptr = crate::value::js_nanbox_get_pointer(parent_value) as *const ObjectHeader;
-        // `js_object_get_class_id` guards against null / non-object
-        // pointers (Set/Map/Regex headers, small handles) and
-        // returns 0 for invalid receivers — no further check needed.
-        js_object_get_class_id(ptr)
+        let from_obj = js_object_get_class_id(ptr);
+        if from_obj != 0 {
+            from_obj
+        } else {
+            // Issue #711 part 2: the value might be a closure whose
+            // `.prototype` was assigned to an object via the
+            // `function Base() {}; Base.prototype = X` pattern. Look
+            // up the synthetic class id assigned at
+            // `js_set_function_prototype` time. Returns 0 if the
+            // closure has no registered prototype object — falls
+            // through to the parentless baseline.
+            function_class_id(parent_value)
+        }
     } else {
         0
     };
@@ -3562,6 +3726,35 @@ pub extern "C" fn js_object_get_field_by_name(
                             }
                             _ => break,
                         }
+                    }
+                }
+            }
+
+            // Issue #711 part 2: walk the class chain for a registered
+            // prototype object (from `Function.prototype = X`). When
+            // found, the method is an own-property of the proto
+            // object — return its value directly. `pipe`, `[Equal.symbol]`,
+            // etc. on Effect's EffectPrototype reach here.
+            {
+                let mut cid = class_id;
+                let mut depth = 0usize;
+                while depth < 32 {
+                    let proto_obj = class_prototype_object(cid);
+                    if !proto_obj.is_null() {
+                        let field_val = js_object_get_field_by_name(
+                            proto_obj as *const _,
+                            key,
+                        );
+                        if !field_val.is_undefined() && !field_val.is_null() {
+                            return field_val;
+                        }
+                    }
+                    match get_parent_class_id(cid) {
+                        Some(p) if p != 0 && p != cid => {
+                            cid = p;
+                            depth += 1;
+                        }
+                        _ => break,
                     }
                 }
             }
@@ -6037,6 +6230,36 @@ pub unsafe extern "C" fn js_native_call_method(
                                         args_len,
                                         entry.param_count,
                                     );
+                                }
+                            }
+                            // Issue #711 part 2: if this class id has a
+                            // registered prototype object (from
+                            // `Function.prototype = X`), look up the
+                            // method as a regular property of that
+                            // object. Effect's `EffectPrototype.pipe()`
+                            // and friends are own-properties of the
+                            // proto object; the value is a closure that
+                            // expects `this = receiver`.
+                            let proto_obj = class_prototype_object(cur_cid);
+                            if !proto_obj.is_null() {
+                                let method_key = crate::string::js_string_from_bytes(
+                                    method_name.as_ptr(),
+                                    method_name.len() as u32,
+                                );
+                                let field_val = js_object_get_field_by_name(
+                                    proto_obj as *const _,
+                                    method_key as *const crate::StringHeader,
+                                );
+                                if !field_val.is_undefined() && !field_val.is_null() {
+                                    let prev_this =
+                                        IMPLICIT_THIS.with(|c| c.replace(jsval.bits()));
+                                    let result = crate::closure::js_native_call_value(
+                                        f64::from_bits(field_val.bits()),
+                                        args_ptr,
+                                        args_len,
+                                    );
+                                    IMPLICIT_THIS.with(|c| c.set(prev_this));
+                                    return result;
                                 }
                             }
                             match get_parent_class_id(cur_cid) {

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -1566,6 +1566,61 @@ pub extern "C" fn js_register_class_parent(class_id: u32, parent_class_id: u32) 
     }
 }
 
+/// Issue #711: dynamic parent-class registration for
+/// `class X extends fn(...)` shapes where the parent class_id is only
+/// known at runtime. Called from codegen-emitted module-init code at
+/// the source-order position of the class declaration (so the
+/// extends expression's free variables — imports, top-level `let`s,
+/// factory functions — are already initialized by the time we
+/// evaluate the parent).
+///
+/// `parent_value` is the evaluated extends expression as a Perry
+/// NaN-boxed value. We resolve a parent class_id from it via:
+///   1. INT32-tagged ClassRef (the value `String$` produces) — the
+///      payload IS the class_id, verified against REGISTERED_CLASS_IDS.
+///   2. POINTER-tagged Object instance (the value a `make<T>(...)`
+///      factory might return when it constructs and returns an
+///      object) — read `class_id` from the ObjectHeader.
+/// Anything else (closures, primitives, null/undefined) is a no-op:
+/// the class stays parentless, identical to the pre-#711 behavior.
+/// Self-registration (`parent_cid == class_id`) is rejected so a
+/// recursive helper that returns its receiver can't create a cycle.
+#[no_mangle]
+pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, parent_value: f64) {
+    let bits = parent_value.to_bits();
+    let tag = bits & 0xFFFF_0000_0000_0000;
+    const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
+    const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+
+    let parent_cid: u32 = if tag == INT32_TAG {
+        // ClassRef: lower 32 bits are the class id. Verify it's
+        // actually a registered class id before trusting it.
+        let payload = bits as u32;
+        if payload == 0 {
+            0
+        } else {
+            let guard = REGISTERED_CLASS_IDS.read().unwrap();
+            match guard.as_ref() {
+                Some(set) if set.contains(&payload) => payload,
+                _ => 0,
+            }
+        }
+    } else if tag == POINTER_TAG {
+        // Object instance: read class_id from the ObjectHeader.
+        let ptr = crate::value::js_nanbox_get_pointer(parent_value) as *const ObjectHeader;
+        // `js_object_get_class_id` guards against null / non-object
+        // pointers (Set/Map/Regex headers, small handles) and
+        // returns 0 for invalid receivers — no further check needed.
+        js_object_get_class_id(ptr)
+    } else {
+        0
+    };
+
+    if parent_cid != 0 && parent_cid != class_id {
+        register_class(class_id, parent_cid);
+    }
+}
+
 /// Look up parent class ID from the registry
 fn get_parent_class_id(class_id: u32) -> Option<u32> {
     let registry = CLASS_REGISTRY.read().unwrap();

--- a/crates/perry-runtime/src/promise.rs
+++ b/crates/perry-runtime/src/promise.rs
@@ -1177,13 +1177,10 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                         });
                         if !next.is_null() {
                             let msg = b"async step driver detected runaway re-entry (issue #712 guard); rejecting Promise to prevent unbounded loop";
-                            let msg_str = crate::string::js_string_from_bytes(
-                                msg.as_ptr(),
-                                msg.len() as u32,
-                            );
+                            let msg_str =
+                                crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
                             let err = crate::error::js_typeerror_new(msg_str);
-                            let err_val =
-                                crate::value::js_nanbox_pointer(err as i64);
+                            let err_val = crate::value::js_nanbox_pointer(err as i64);
                             js_promise_reject(next, err_val);
                         }
                         ran += 1;

--- a/crates/perry-runtime/src/promise.rs
+++ b/crates/perry-runtime/src/promise.rs
@@ -310,7 +310,45 @@ thread_local! {
     /// collapsed onto its parent's).
     pub(crate) static INLINE_TRAP: std::cell::Cell<InlineTrap>
         = const { std::cell::Cell::new(InlineTrap { trap_next: std::ptr::null_mut(), current_step: 0 }) };
+
+    /// Defensive re-entry guard for the async step driver (issue #712).
+    ///
+    /// Tracks consecutive `is_error=true` AsyncStep dispatches from the
+    /// SAME step closure. The original report (v0.5.836) produced 5.7M
+    /// identical "value is not a function" lines because the throw
+    /// closure's `__gen_state = post_catch_state` transitioned to a
+    /// state that re-evaluated the same failing `await` expression —
+    /// the catch arm re-fired, AsyncStepChain re-enqueued, repeat.
+    ///
+    /// A correct async state machine alternates: on a throwing await
+    /// the runner gets ONE is_error=true entry per throw, immediately
+    /// followed by is_error=false entries that resume the post-catch
+    /// states. Programs that legitimately throw 1M+ times in a loop
+    /// (e.g. `for (i of bigArr) try { await fail() } catch {}`)
+    /// interleave is_error=false steps between the catches, so the
+    /// consecutive count never grows beyond 1.
+    ///
+    /// On exceed: reject `next` with a synthesized TypeError and skip
+    /// the step dispatch. This bounds the worst-case loop at
+    /// `ASYNC_STEP_REENTRY_BOUND` iterations instead of unbounded.
+    pub(crate) static ASYNC_STEP_GUARD: std::cell::Cell<AsyncStepGuard>
+        = const { std::cell::Cell::new(AsyncStepGuard { last_closure: 0, consecutive_error_count: 0 }) };
 }
+
+/// Defensive guard state for the async step driver. See `ASYNC_STEP_GUARD`.
+#[derive(Copy, Clone)]
+pub(crate) struct AsyncStepGuard {
+    pub last_closure: usize,
+    pub consecutive_error_count: u32,
+}
+
+/// Upper bound on consecutive same-closure is_error=true AsyncStep
+/// dispatches before the runner rejects the Promise as a runaway loop.
+/// Picked well above any legitimate throw-in-a-loop pattern (those
+/// interleave is_error=false steps so the count resets each iteration)
+/// and well below the 5.7M observed in #712 — high enough to avoid
+/// false positives, low enough to terminate quickly when the bug fires.
+pub(crate) const ASYNC_STEP_REENTRY_BOUND: u32 = 10_000;
 
 /// Packed thread-local state for the inline-microtask trap. See
 /// `INLINE_TRAP` for the lifecycle and gating discussion.
@@ -1118,6 +1156,52 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                     }
                     ran += 1;
                     continue;
+                }
+                // Issue #712 defensive guard. Track consecutive
+                // same-closure is_error=true dispatches; reject the
+                // chain if it crosses ASYNC_STEP_REENTRY_BOUND. See
+                // the `ASYNC_STEP_GUARD` doc comment for the rationale.
+                if is_error {
+                    let prev = ASYNC_STEP_GUARD.with(|c| c.get());
+                    let new_count = if prev.last_closure == step_closure as usize {
+                        prev.consecutive_error_count.saturating_add(1)
+                    } else {
+                        1
+                    };
+                    if new_count > ASYNC_STEP_REENTRY_BOUND {
+                        ASYNC_STEP_GUARD.with(|c| {
+                            c.set(AsyncStepGuard {
+                                last_closure: 0,
+                                consecutive_error_count: 0,
+                            })
+                        });
+                        if !next.is_null() {
+                            let msg = b"async step driver detected runaway re-entry (issue #712 guard); rejecting Promise to prevent unbounded loop";
+                            let msg_str = crate::string::js_string_from_bytes(
+                                msg.as_ptr(),
+                                msg.len() as u32,
+                            );
+                            let err = crate::error::js_typeerror_new(msg_str);
+                            let err_val =
+                                crate::value::js_nanbox_pointer(err as i64);
+                            js_promise_reject(next, err_val);
+                        }
+                        ran += 1;
+                        continue;
+                    }
+                    ASYNC_STEP_GUARD.with(|c| {
+                        c.set(AsyncStepGuard {
+                            last_closure: step_closure as usize,
+                            consecutive_error_count: new_count,
+                        })
+                    });
+                } else {
+                    ASYNC_STEP_GUARD.with(|c| {
+                        c.set(AsyncStepGuard {
+                            last_closure: 0,
+                            consecutive_error_count: 0,
+                        })
+                    });
                 }
                 // Stash both trap_next + current_step in a single TLS
                 // write so the hot path doesn't pay two `.with()` calls

--- a/crates/perry-transform/src/inline.rs
+++ b/crates/perry-transform/src/inline.rs
@@ -1029,6 +1029,7 @@ fn body_references_class_in_set(stmts: &[Stmt], set: &HashSet<String>) -> bool {
             | Expr::StaticFieldGet { class_name, .. }
             | Expr::StaticFieldSet { class_name, .. }
             | Expr::ClassStaticSymbolSet { class_name, .. }
+            | Expr::RegisterClassParentDynamic { class_name, .. }
             | Expr::StaticMethodCall { class_name, .. } => {
                 if set.contains(class_name) {
                     return true;

--- a/test-files/test_issue_711_extends_call.ts
+++ b/test-files/test_issue_711_extends_call.ts
@@ -1,0 +1,68 @@
+// Issue #711: `class X extends fn(...)` / `class X extends Y.method(...)`
+// must walk the parent chain for method dispatch even when the parent
+// class_id is only known at runtime (the super-class expression is a
+// CallExpr / NewExpr, not a static Ident or Member).
+//
+// Pre-fix: HIR's `lower_decl.rs` extends-clause arms dropped any
+// non-Ident/Member shape silently, leaving `extends_name = None` so
+// codegen never emitted `js_register_class_parent`. Method dispatch
+// terminated at the child's empty vtable and threw
+// `<method> is not a function`.
+
+class Base {
+  pipe(label: string): string {
+    return "Base.pipe:" + label;
+  }
+  greet(): string {
+    return "Base.greet";
+  }
+}
+
+// Shape 1: free function call as the super-class expression
+function factory(): typeof Base {
+  return Base;
+}
+class Derived extends factory() {}
+
+// Shape 2: method call on an Ident (Effect's `String$.pipe(...)` pattern)
+class Mid {
+  static makeBase(): typeof Base {
+    return Base;
+  }
+}
+class Chained extends Mid.makeBase() {}
+
+// Shape 3: `new` expression returning a class
+function newWrapper(): typeof Base {
+  return Base;
+}
+class ViaNew extends newWrapper() {}
+
+// Shape 4: chained extends — parent of parent is also dynamically
+// registered. The chain walk must follow the dynamic registrations all
+// the way up.
+class Pipeable {
+  pipeMethod(): string {
+    return "Pipeable.pipeMethod";
+  }
+}
+function makePipeable(): typeof Pipeable {
+  return Pipeable;
+}
+class StringRefined extends makePipeable() {
+  refined(): string {
+    return "StringRefined.refined";
+  }
+}
+function applyOptions(c: typeof StringRefined): typeof StringRefined {
+  return c;
+}
+class WithOptions extends applyOptions(StringRefined) {}
+
+console.log("derived.pipe:", new Derived().pipe("hello"));
+console.log("derived.greet:", new Derived().greet());
+console.log("chained.pipe:", new Chained().pipe("world"));
+console.log("chained.greet:", new Chained().greet());
+console.log("via_new.pipe:", new ViaNew().pipe("nye"));
+console.log("with_options.pipeMethod:", new WithOptions().pipeMethod());
+console.log("with_options.refined:", new WithOptions().refined());

--- a/test-files/test_issue_711_function_prototype.ts
+++ b/test-files/test_issue_711_function_prototype.ts
@@ -1,0 +1,43 @@
+// Issue #711 part 2: `function Base() {}; Base.prototype = X` pattern.
+// Effect's `internal/effectable.ts` uses this to declare classes via
+// prototype-object assignment on a plain function. To make
+// `class Derived extends Base {}` walk into the prototype object's
+// methods at dispatch time, Perry models this as a synthetic class:
+// `js_set_function_prototype` allocates a synthetic class_id keyed by
+// the function value and binds the proto object as its vtable source.
+// `js_register_class_parent_dynamic` detects closure parent values
+// and wires the synthetic class_id into CLASS_REGISTRY. Method
+// dispatch (via `js_object_get_field_by_name`) walks the class chain
+// and resolves the method as an own-property of the proto object.
+
+const proto = {
+  pipe(): string {
+    return "proto.pipe";
+  },
+  greet(): string {
+    return "proto.greet";
+  },
+};
+
+// Shape 1: bare function, prototype-assigned, then extended.
+function MyFn() {}
+(MyFn as any).prototype = proto;
+class Derived extends (MyFn as any) {}
+
+// Shape 2: Effect's exact pattern — IIFE that declares a function and
+// returns it.
+const Base = (function () {
+  const innerProto = {
+    pipe(): string {
+      return "iife.pipe";
+    },
+  };
+  function Base() {}
+  (Base as any).prototype = innerProto;
+  return Base as any;
+})();
+class IIFEDerived extends Base {}
+
+console.log("derived.pipe:", new Derived().pipe());
+console.log("derived.greet:", new Derived().greet());
+console.log("iife_derived.pipe:", new IIFEDerived().pipe());


### PR DESCRIPTION
## Summary

Three stacked fixes:

1. **v0.5.871 — #712 defensive guard.** Bounded re-entry counter in the async step driver. Closes #712 — a future regression cannot produce the 5.7M-line catch-arm loop reported in the issue.

2. **v0.5.872 — #711 extends-CallExpr.** `class X extends fn(...)` / `class X extends Y.method(...)` / `class X extends new Foo()` now wire the parent edge in CLASS_REGISTRY via runtime-dynamic registration at the class declaration's source position. New HIR `extends_expr` field + `Expr::RegisterClassParentDynamic` variant + runtime `js_register_class_parent_dynamic` helper.

3. **v0.5.873 — #711 Function.prototype = X.** Effect's `function Base() {}; Base.prototype = obj` pattern now binds the proto object as a synthetic class's vtable source. Method dispatch on `class Derived extends Base` walks the chain to resolve methods as own-properties of the proto. New HIR `Expr::SetFunctionPrototype` variant + runtime `FUNCTION_CLASS_IDS` / `CLASS_PROTOTYPE_OBJECTS` side-tables + dispatch-chain integration in `js_native_call_method` and `js_object_get_field_by_name`.

## Effect status

Both #711 fixes together advance the Effect Schema.ts blocker past the original `pipe is not a function` throw. Importing `effect` still hits a separate `value is not a function` throw deeper in module init — likely class-expressions-returned-by-factory (`function make(...) { return class { ... } }` produces a new class per call, which Perry's static class-id model doesn't yet handle). Continued under #711.

## Test plan

- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry -p perry-jsruntime` — clean
- [x] `cargo test --release --workspace` (excluding cross-host UI crates) — all 133 buckets passing
- [x] New regression `test_issue_711_extends_call.ts` (4 shapes) — byte-identical to Node
- [x] New regression `test_issue_711_function_prototype.ts` (2 shapes including Effect's IIFE) — byte-identical to Node
- [ ] CI required checks (`lint`, `cargo-test`, `parity`, `compile-smoke`, `api-docs-drift`, `security-audit`) — pending