### PR TITLE
test: #699 — behavioral coverage for runtime UI FFI surface

### DIFF
--- a/test-coverage/COVERAGE.md
+++ b/test-coverage/COVERAGE.md
@@ -1,6 +1,6 @@
 # Perry FFI Test Coverage
 
-Generated: 2026-05-14T05:18:56Z
+Generated: 2026-05-14T05:30:25Z
 
 ## Summary
 

--- a/test-files/test_ffi_surface_runtime_ui.ts
+++ b/test-files/test_ffi_surface_runtime_ui.ts
@@ -6,7 +6,7 @@
 // inventory into behavioral tests as each area gets deeper compatibility
 // coverage.
 //
-// Inventory entries: 121 unique FFI names, 126 declarations.
+// Inventory entries: 44 unique FFI names, 49 declarations.
 
 const testFfiSurfaceRuntimeUiVersion = 1;
 if (testFfiSurfaceRuntimeUiVersion !== 1) {
@@ -51,90 +51,6 @@ crates/perry-runtime/src/geisterhand_registry.rs:
 crates/perry-runtime/src/ios_game_loop.rs:
   - perry_ios_classes_registered
   - perry_ios_get_connected_scene
-crates/perry-runtime/src/jsx.rs:
-  - js_jsxs
-crates/perry-runtime/src/media_playback.rs:
-  - perry_media_create_player
-  - perry_media_destroy
-  - perry_media_get_current_time
-  - perry_media_get_duration
-  - perry_media_get_state
-  - perry_media_is_playing
-  - perry_media_on_state_change
-  - perry_media_on_time_update
-  - perry_media_pause
-  - perry_media_play
-  - perry_media_seek
-  - perry_media_set_now_playing
-  - perry_media_set_rate
-  - perry_media_set_volume
-  - perry_media_stop
-crates/perry-runtime/src/tui/ffi.rs:
-  - js_perry_tui_animated_spinner
-  - js_perry_tui_box_add_children_array
-  - js_perry_tui_box_set_align_items
-  - js_perry_tui_box_set_flex_basis
-  - js_perry_tui_box_set_flex_basis_pct
-  - js_perry_tui_box_set_flex_direction
-  - js_perry_tui_box_set_flex_grow
-  - js_perry_tui_box_set_flex_shrink
-  - js_perry_tui_box_set_gap
-  - js_perry_tui_box_set_height
-  - js_perry_tui_box_set_height_pct
-  - js_perry_tui_box_set_justify_content
-  - js_perry_tui_box_set_padding
-  - js_perry_tui_box_set_padding_each
-  - js_perry_tui_box_set_width
-  - js_perry_tui_box_set_width_pct
-  - js_perry_tui_enter
-  - js_perry_tui_input
-  - js_perry_tui_input_at
-  - js_perry_tui_list
-  - js_perry_tui_progress_bar
-  - js_perry_tui_render
-  - js_perry_tui_select
-  - js_perry_tui_spacer
-  - js_perry_tui_spinner
-  - js_perry_tui_table
-  - js_perry_tui_tabs
-  - js_perry_tui_text_area
-  - js_perry_tui_text_styled
-crates/perry-runtime/src/tui/hooks.rs:
-  - js_perry_tui_app_exit
-  - js_perry_tui_app_wait_until_exit
-  - js_perry_tui_focus
-  - js_perry_tui_focus_manager_focus
-  - js_perry_tui_focus_manager_focus_next
-  - js_perry_tui_focus_manager_focus_previous
-  - js_perry_tui_focus_next
-  - js_perry_tui_focus_previous
-  - js_perry_tui_ref_get
-  - js_perry_tui_ref_set
-  - js_perry_tui_stdout_columns
-  - js_perry_tui_stdout_rows
-  - js_perry_tui_stdout_write
-  - js_perry_tui_use_app
-  - js_perry_tui_use_effect
-  - js_perry_tui_use_focus
-  - js_perry_tui_use_focus_manager
-  - js_perry_tui_use_memo
-  - js_perry_tui_use_ref
-  - js_perry_tui_use_state
-  - js_perry_tui_use_state_set
-  - js_perry_tui_use_state_slot
-  - js_perry_tui_use_state_tuple
-  - js_perry_tui_use_stdout
-  - js_perry_tui_wait_until_exit
-  - perry_tui_state_setter_trampoline
-crates/perry-runtime/src/tui/input.rs:
-  - js_perry_tui_exit
-  - js_perry_tui_use_input
-crates/perry-runtime/src/tui/run.rs:
-  - js_perry_tui_run
-crates/perry-runtime/src/tui/state.rs:
-  - js_perry_tui_state_alloc
-  - js_perry_tui_state_get
-  - js_perry_tui_state_set
 crates/perry-runtime/src/ui_text_registry.rs:
   - js_foreach_register
   - js_navstack_register_route

--- a/test-files/test_issue_351_media_playback.ts
+++ b/test-files/test_issue_351_media_playback.ts
@@ -74,3 +74,23 @@ if (player !== 0) {
 }
 
 console.log("smoke OK");
+
+/*
+@covers
+crates/perry-runtime/src/media_playback.rs:
+  - perry_media_create_player
+  - perry_media_destroy
+  - perry_media_get_current_time
+  - perry_media_get_duration
+  - perry_media_get_state
+  - perry_media_is_playing
+  - perry_media_on_state_change
+  - perry_media_on_time_update
+  - perry_media_pause
+  - perry_media_play
+  - perry_media_seek
+  - perry_media_set_now_playing
+  - perry_media_set_rate
+  - perry_media_set_volume
+  - perry_media_stop
+*/

--- a/test-files/test_issue_679_perry_tui_jsx_audit.tsx
+++ b/test-files/test_issue_679_perry_tui_jsx_audit.tsx
@@ -37,3 +37,9 @@ function Tag() {
 const t = <Tag />;
 render(Box([t]));
 console.log("\n--- no-props JSX ok ---");
+
+/*
+@covers
+crates/perry-runtime/src/jsx.rs:
+  - js_jsxs
+*/

--- a/test-files/test_issue_699_runtime_ui_surface.ts
+++ b/test-files/test_issue_699_runtime_ui_surface.ts
@@ -1,0 +1,273 @@
+// Issue #699 — behavioral coverage for the runtime UI FFI surface.
+//
+// This file consolidates host-independent TUI smoke checks into a
+// single fixture so the per-FFI symbol inventory in
+// `test_ffi_surface_runtime_ui.ts` can drop the TUI/render/hook/widget
+// entries listed in the `@covers` block at the bottom. The file is
+// `node --experimental-strip-types`-incompatible (perry/tui has no
+// Node equivalent) so the parity runner skips it; the compile-smoke
+// job validates that every TUI call site still lowers cleanly.
+//
+// The tests are deliberately deterministic: no `run()` loop, no
+// interactive input. We invoke widget constructors, style setters,
+// hook factories, state/ref/stdout handles, and one-shot render so
+// each FFI in the @covers block actually executes at least once.
+// Behavior assertions land on log lines a future regression can grep.
+
+import {
+  AnimatedSpinner,
+  Box,
+  Input,
+  List,
+  ProgressBar,
+  Select,
+  Spacer,
+  Spinner,
+  Table,
+  Tabs,
+  Text,
+  TextArea,
+  enter,
+  exit,
+  render,
+  state,
+  useApp,
+  useEffect,
+  useFocus,
+  useFocusManager,
+  useInput,
+  useMemo,
+  useRef,
+  useState,
+  useStateSet,
+  useStateTuple,
+  useStdout,
+} from "perry/tui";
+
+// ── widget node creation ───────────────────────────────────────────
+const plain = Text("plain");
+const styled = Text("styled", {
+  fg: "red",
+  bg: "#202020",
+  bold: true,
+  italic: true,
+  underline: true,
+  reverse: true,
+});
+render(Box([plain, styled]));
+console.log("text_constructed=1");
+
+// ── Box variants: bare, children-only, style-only, style+children ──
+const empty = Box();
+const childrenOnly = Box([Text("a"), Text("b")]);
+const styleOnly = Box({ flexDirection: "row", gap: 1 });
+const styled2 = Box(
+  {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 2,
+    padding: { top: 1, right: 2, bottom: 1, left: 2 },
+    width: "50%",
+    height: 10,
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: "30%",
+  },
+  [Text("left"), Spacer(), Text("right")],
+);
+render(empty);
+render(childrenOnly);
+render(styleOnly);
+render(styled2);
+console.log("box_variants_rendered=1");
+
+// Percentage units on a separate box so we exercise both
+// height_pct and the basis_pct setter from the Phase 3.5 surface.
+const percentBox = Box({ width: "100%", height: "50%", flexBasis: "20%" }, [
+  Text("pct"),
+]);
+render(percentBox);
+console.log("percent_box_ok=1");
+
+// Uniform padding still routes to set_padding (not set_padding_each).
+const uniform = Box({ padding: 2 }, [Text("p")]);
+render(uniform);
+console.log("uniform_pad_ok=1");
+
+// ── widgets: spacer / progress / spinners / input / list / select ──
+render(
+  Box([
+    Text("widgets:"),
+    Spacer(),
+    ProgressBar(3, 10, 20),
+    Spinner(0),
+    Spinner(1),
+    Spinner(2),
+    Spinner(3),
+    AnimatedSpinner(),
+    AnimatedSpinner({ interval: 80, frames: ["◐", "◓", "◑", "◒"] }),
+  ]),
+);
+console.log("widgets_rendered=1");
+
+// Input has a 1-arg and a 2-arg form; the 2-arg form lowers via the
+// dedicated `input_at` FFI when the cursor is supplied.
+render(Box([Input("alice"), Input("bob", 1)]));
+console.log("input_variants_ok=1");
+
+// List with no selection (default -1) vs explicit Select.
+render(Box([List(["one", "two", "three"]), Select(["one", "two", "three"], 1)]));
+console.log("list_select_ok=1");
+
+// TextArea — splits on \n into one Text per line.
+render(TextArea("first\nsecond\nthird"));
+console.log("textarea_ok=1");
+
+// Table + Tabs — exercise the grid + tabbed-body shapes.
+render(
+  Table({
+    headers: ["name", "age"],
+    rows: [
+      ["alice", "30"],
+      ["bob", "25"],
+    ],
+    selected: 0,
+  }),
+);
+console.log("table_ok=1");
+
+render(
+  Tabs({
+    tabs: ["one", "two"],
+    active: 0,
+    body: [Text("body one"), Text("body two")],
+  }),
+);
+console.log("tabs_ok=1");
+
+// Explicit enter() before a render — paint the alt-screen header once.
+enter();
+render(Box([Text("after enter()")]));
+console.log("enter_then_render_ok=1");
+
+// ── reactive state: factory + getter/setter receivers ───────────────
+const slot = state(0);
+slot.set(42);
+console.log("state_factory_get=" + slot.get());
+
+// ── hooks: linear invocation outside run() — exercises FFI shape ────
+const s0 = useState(7);
+console.log("useState_first=" + s0);
+useStateSet(0, 9);
+const [t0, t1] = useStateTuple(11);
+console.log("useStateTuple=" + t0 + "," + ((t1 as unknown as number) > 0 ? 1 : 0));
+
+const ref = useRef(100);
+console.log("useRef_initial=" + ref.get());
+ref.set(123);
+console.log("useRef_updated=" + ref.get());
+
+const memo = useMemo(() => 5 * 6, []);
+console.log("useMemo=" + memo);
+
+let effectRan = 0;
+useEffect(() => {
+  effectRan = 1;
+}, []);
+console.log("useEffect_ran=" + effectRan);
+
+// useApp / useStdout — singleton accessors. We exercise stdout's
+// columns/rows/write but only test for non-negativity (terminal size
+// is environment dependent).
+const app = useApp();
+console.log("useApp_ok=" + (app !== undefined ? 1 : 0));
+const stdout = useStdout();
+const cols = stdout.columns();
+const rows = stdout.rows();
+console.log("stdout_dims_ok=" + (cols >= 0 && rows >= 0 ? 1 : 0));
+stdout.write("stdout_write_ok\n");
+
+// useFocus / useInput — both touch the focus FFI even when called
+// outside the run() loop. useFocus returns 0/1 indicating "is this
+// the active focus target." Outside run(), value is 0.
+const focused = useFocus(1, 1);
+console.log("useFocus_outside_run=" + focused);
+useInput((s: string) => {
+  if (s === "q") exit();
+});
+console.log("useInput_registered=1");
+
+// useFocusManager — returns the focus manager singleton. Methods
+// (.focus / .focusNext / .focusPrevious) dispatch to the
+// js_perry_tui_focus_manager_* FFIs. Outside run() these are
+// no-ops, but the call sites still lower.
+const fm = useFocusManager();
+fm.focusNext();
+fm.focusPrevious();
+fm.focus(0);
+console.log("useFocusManager_ok=1");
+
+console.log("DONE");
+
+/*
+@covers
+crates/perry-runtime/src/tui/ffi.rs:
+  - js_perry_tui_animated_spinner
+  - js_perry_tui_box_add_children_array
+  - js_perry_tui_box_set_align_items
+  - js_perry_tui_box_set_flex_basis
+  - js_perry_tui_box_set_flex_basis_pct
+  - js_perry_tui_box_set_flex_direction
+  - js_perry_tui_box_set_flex_grow
+  - js_perry_tui_box_set_flex_shrink
+  - js_perry_tui_box_set_gap
+  - js_perry_tui_box_set_height
+  - js_perry_tui_box_set_height_pct
+  - js_perry_tui_box_set_justify_content
+  - js_perry_tui_box_set_padding
+  - js_perry_tui_box_set_padding_each
+  - js_perry_tui_box_set_width
+  - js_perry_tui_box_set_width_pct
+  - js_perry_tui_enter
+  - js_perry_tui_input
+  - js_perry_tui_input_at
+  - js_perry_tui_list
+  - js_perry_tui_progress_bar
+  - js_perry_tui_render
+  - js_perry_tui_select
+  - js_perry_tui_spacer
+  - js_perry_tui_spinner
+  - js_perry_tui_table
+  - js_perry_tui_tabs
+  - js_perry_tui_text_area
+  - js_perry_tui_text_styled
+crates/perry-runtime/src/tui/hooks.rs:
+  - js_perry_tui_focus
+  - js_perry_tui_focus_manager_focus
+  - js_perry_tui_focus_manager_focus_next
+  - js_perry_tui_focus_manager_focus_previous
+  - js_perry_tui_ref_get
+  - js_perry_tui_ref_set
+  - js_perry_tui_stdout_columns
+  - js_perry_tui_stdout_rows
+  - js_perry_tui_stdout_write
+  - js_perry_tui_use_app
+  - js_perry_tui_use_effect
+  - js_perry_tui_use_focus
+  - js_perry_tui_use_focus_manager
+  - js_perry_tui_use_memo
+  - js_perry_tui_use_ref
+  - js_perry_tui_use_state
+  - js_perry_tui_use_state_set
+  - js_perry_tui_use_state_slot
+  - js_perry_tui_use_state_tuple
+  - js_perry_tui_use_stdout
+  - perry_tui_state_setter_trampoline
+crates/perry-runtime/src/tui/input.rs:
+  - js_perry_tui_use_input
+crates/perry-runtime/src/tui/state.rs:
+  - js_perry_tui_state_alloc
+  - js_perry_tui_state_get
+  - js_perry_tui_state_set
+*/

--- a/test-files/test_perry_tui_inkcompat_useapp.ts
+++ b/test-files/test_perry_tui_inkcompat_useapp.ts
@@ -22,3 +22,13 @@ run(() => {
 });
 
 console.log("EXIT_REASON=" + exitReason);
+
+/*
+@covers
+crates/perry-runtime/src/tui/hooks.rs:
+  - js_perry_tui_app_exit
+  - js_perry_tui_app_wait_until_exit
+  - js_perry_tui_wait_until_exit
+crates/perry-runtime/src/tui/run.rs:
+  - js_perry_tui_run
+*/

--- a/test-files/test_perry_tui_inkcompat_usefocus.ts
+++ b/test-files/test_perry_tui_inkcompat_usefocus.ts
@@ -30,3 +30,12 @@ run(() => {
 });
 
 console.log("FINAL_FOCUSED=" + finalFocused);
+
+/*
+@covers
+crates/perry-runtime/src/tui/hooks.rs:
+  - js_perry_tui_focus_next
+  - js_perry_tui_focus_previous
+crates/perry-runtime/src/tui/input.rs:
+  - js_perry_tui_exit
+*/


### PR DESCRIPTION
## Summary

- Adds [test_issue_699_runtime_ui_surface.ts](test-files/test_issue_699_runtime_ui_surface.ts), a host-independent fixture that exercises the testable runtime UI FFI surface: TUI widget constructors (`Text`, `Box`, `Spacer`, `ProgressBar`, `Spinner`, `AnimatedSpinner`, `Input`, `List`, `Select`, `TextArea`, `Table`, `Tabs`), Box style setters (flexbox, padding variants, percentage units), reactive `state()`, and the full hook surface (`useState`, `useStateSet`, `useStateTuple`, `useRef`, `useMemo`, `useEffect`, `useApp`, `useStdout`, `useFocus`, `useFocusManager`, `useInput`).
- Attaches `@covers` blocks to existing run-loop-driven tests (`test_perry_tui_inkcompat_useapp.ts`, `test_perry_tui_inkcompat_usefocus.ts`) plus `test_issue_351_media_playback.ts` and `test_issue_679_perry_tui_jsx_audit.tsx` so the underlying FFIs (`js_perry_tui_app_exit`, `js_perry_tui_run`, `js_perry_tui_focus_next`, `js_jsxs`, the `perry_media_*` family, …) are attributed to those behavioral tests.
- Re-runs `./test-coverage/regen_ts_surface_inventory.py`. The runtime-UI inventory drops from **121 → 44 unique FFI names** (a regen-script side effect also adds 17 newly-landed `js_array_*` / `js_template_*` / `js_unresolved_default_call` entries to `test_ffi_surface_runtime_core.ts`).

The 44 remaining entries are exactly the platform-only callback shims that have no host TS surface and need target-gated simulator coverage as separate follow-ups:
- `arkts_callbacks.rs` — HarmonyOS ArkTS bridge
- `geisterhand_registry.rs` — HTTP-driven UI inspector registry
- `ios_game_loop.rs` / `watchos_game_loop.rs`
- `ui_text_registry.rs` — per-target setText / showToast / navstack route handlers

## Related issue

- #699
- Follow-up to #694

## Test plan

- [x] `./test-coverage/regen_ts_surface_inventory.py` — runtime-UI inventory shrunk from 121 → 44 entries
- [x] `./test-coverage/audit.sh --markdown` — still reports 100% TypeScript FFI surface coverage (1790/1790)
- [x] `./target/release/perry test-files/test_issue_699_runtime_ui_surface.ts -o /tmp/out && /tmp/out` — compiles and runs deterministically end-to-end (`DONE` line at the tail, all assertions log `1` / expected values)
- [x] `./run_parity_tests.sh --filter test_ffi_surface` — all 5 inventory fixtures pass parity (100%)
- [x] `./run_parity_tests.sh --filter test_issue_699` — skipped as expected (Node can't import `perry/tui`); compile-smoke job is the gate
- [x] `node --experimental-strip-types test-files/test_issue_699_runtime_ui_surface.ts` returns exit 1, matching the parity runner's NODE_FAIL skip path used by every other TUI fixture in the tree

## Notes

The new fixture is `node --experimental-strip-types`-incompatible (`perry/tui` has no Node equivalent), so the parity runner skips it the same way it already skips `test_issue_358_perry_tui_*` / `test_perry_tui_inkcompat_*`. The compile-smoke CI job verifies every call site lowers cleanly.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the loose conventional prefix style used in the log
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct