### PR TITLE
test(#774): pin super.<prop> child-override regression net

### DIFF
--- a/test-files/test_super_property_override.ts
+++ b/test-files/test_super_property_override.ts
@@ -1,0 +1,24 @@
+// Regression net for issue #774 — super.<prop> value-form lowering
+// currently rewrites `super.foo` to `this.foo` (see PR #754,
+// crates/perry-hir/src/lower/expr_misc.rs lower_super_prop). When the
+// child overrides the parent's property, the approximation silently
+// returns the child override instead of doing a real super-vtable
+// lookup. Strict JS semantics: `super.foo` looks up `foo` on the
+// parent prototype, which for an instance field is `undefined`.
+//
+// Expected (node --experimental-strip-types): undefined
+// Actual (perry HEAD):                        B
+//
+// This test is listed in test-parity/known_failures.json until the
+// codegen-side super-vtable path lands; the fix should flip it green.
+
+class A {
+    foo = "A";
+}
+class B extends A {
+    foo = "B";
+    parentFoo() {
+        return super.foo;
+    }
+}
+console.log(new B().parentFoo());

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1,5 +1,6 @@
 {
   "issue_655_repro": "issue #655 repro \u2014 kept as the canonical regression-catcher; will flip to PASS when #655 lands.",
+  "test_super_property_override": "issue #774 \u2014 value-form `super.<prop>` is rewritten to `this.<prop>` (PR #754, lower_super_prop in expr_misc.rs), so a child override silently shadows the parent. Strict JS returns `undefined` for an instance-field parent; perry returns the child value. Flips to PASS when codegen grows an explicit super-vtable path.",
   "test_gap_array_methods": "Array method coverage probe \u2014 small divergences (e.g. flat/flatMap/finally specific edge cases). Targeted bisect needed; not a recent regression.",
   "test_issue_233_async_array_param_push": "Async array-param push edge case (#233) regresses on Linux CI but passes locally on macOS. Bisect to pin Linux-only divergence.",
   "test_issue_561_sigv4_chain": "SigV4 chain test (#561) regresses on Linux CI but passes locally on macOS. Likely related to crypto/HMAC ordering. Bisect needed.",


### PR DESCRIPTION
## Summary

Adds a parity regression test for #774. Value-form `super.<prop>` is currently lowered to `this.<prop>` in `lower_super_prop` (PR #754, `crates/perry-hir/src/lower/expr_misc.rs`), which silently returns the child override instead of resolving through the parent's prototype.

- `test-files/test_super_property_override.ts` — the override snippet from the issue.
- `test-parity/known_failures.json` — entry pointing at #774; the test flips to PASS once codegen grows an explicit super-vtable path.

Strict JS returns `undefined` for an instance-field parent; perry HEAD returns the child value (`B`). Verified locally:

- `node --experimental-strip-types test-files/test_super_property_override.ts` → `undefined`
- `./target/release/perry test-files/test_super_property_override.ts -o /tmp/t && /tmp/t` → `B`

Scope is intentionally just the regression net (the "Regression net" section of the issue). The codegen fix — new `Expr::SuperPropertyGet` HIR variant that walks the parent class's vtable — is left for a follow-up.

## Test plan

- [ ] CI `parity` job picks up the new test and records it as a known failure (no red).
- [ ] Manually re-run after a future super-vtable codegen lands: expect the entry in `known_failures.json` to be removed and the test to PASS.