### PR TITLE
fix(#774): resolve super.<prop> value form via parent vtable lookup

### DIFF
--- a/crates/perry-codegen/src/codegen.rs
+++ b/crates/perry-codegen/src/codegen.rs
@@ -2550,6 +2550,50 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         blk.ret(DOUBLE, &result);
     }
 
+    // Issue #774: emit closure-call wrappers for class instance methods
+    // so `Expr::SuperPropertyGet` (value-form `super.<method>`) can
+    // materialize them via `js_closure_alloc_singleton(@__perry_wrap_<method>)`.
+    // Methods have signature `perry_method_<...>(this_box, args...)`;
+    // the closure-call ABI is `(i64 closure, double a0, ...)` and
+    // doesn't carry a separate `this`. Strict JS for `const fn =
+    // super.greet; fn(x)` calls the method with `this=undefined`,
+    // which is what we forward here.
+    let mut emitted_wrappers: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for class in &hir.classes {
+        for method in &class.methods {
+            let Some(method_fn_name) = method_names
+                .get(&(class.name.clone(), method.name.clone()))
+                .cloned()
+            else {
+                continue;
+            };
+            let wrap_name = format!("__perry_wrap_{}", method_fn_name);
+            if !emitted_wrappers.insert(wrap_name.clone()) {
+                continue;
+            }
+            let arity = method.params.len().min(5);
+            let mut wrap_params: Vec<(LlvmType, String)> = vec![(I64, "%this_closure".to_string())];
+            for i in 0..arity {
+                wrap_params.push((DOUBLE, format!("%a{}", i)));
+            }
+            let wf = llmod.define_function(&wrap_name, DOUBLE, wrap_params);
+            let _ = wf.create_block("entry");
+            let blk = wf.block_mut(0).unwrap();
+            // Forward `this=undefined` then the args.
+            let undef_lit = crate::nanbox::i64_literal(crate::nanbox::TAG_UNDEFINED);
+            let undef_double = blk.bitcast_i64_to_double(&undef_lit);
+            let mut call_args: Vec<(LlvmType, String)> = Vec::with_capacity(arity + 1);
+            call_args.push((DOUBLE, undef_double));
+            for i in 0..arity {
+                call_args.push((DOUBLE, format!("%a{}", i)));
+            }
+            let call_args_ref: Vec<(LlvmType, &str)> =
+                call_args.iter().map(|(t, s)| (*t, s.as_str())).collect();
+            let result = blk.call(DOUBLE, &method_fn_name, &call_args_ref);
+            blk.ret(DOUBLE, &result);
+        }
+    }
+
     // #337: emit an always-defined fallback wrapper for the
     // `perry_unknown_func` sentinel. `expr.rs::Expr::FuncRef` falls
     // through to `wrap_name = "__perry_wrap_perry_unknown_func"` when the

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -6131,6 +6131,54 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(ctx.block().call(DOUBLE, &fn_name, &arg_slices))
         }
 
+        // -------- super.<prop> as a value (issue #774) --------
+        // Walk the parent-class chain. If a parent declares a method
+        // with the requested name, materialize it as a closure value
+        // via the singleton wrapper (mirroring `Expr::FuncRef`).
+        // Otherwise return `undefined` — which is the strict-JS
+        // result for instance-field shadows like:
+        //
+        //     class A { foo = "A"; }
+        //     class B extends A { foo = "B"; m() { return super.foo; } }
+        //
+        // The previous lowering rewrote `super.foo` to `this.foo`, so
+        // it silently returned the child override ("B") instead of
+        // `undefined`. See issue #774 / PR #774 follow-up.
+        //
+        // Call-form `super.method(...)` never reaches this arm — it
+        // is lowered to `Expr::SuperMethodCall` in lower_call.rs.
+        Expr::SuperPropertyGet { property } => {
+            let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+            let Some(current_class_name) = ctx.class_stack.last().cloned() else {
+                return Ok(undef);
+            };
+            let mut parent = ctx
+                .classes
+                .get(&current_class_name)
+                .and_then(|c| c.extends_name.clone());
+            let mut resolved_fn: Option<String> = None;
+            while let Some(p) = parent {
+                let key = (p.clone(), property.clone());
+                if let Some(fname) = ctx.methods.get(&key).cloned() {
+                    resolved_fn = Some(fname);
+                    break;
+                }
+                parent = ctx.classes.get(&p).and_then(|c| c.extends_name.clone());
+            }
+            let Some(fn_name) = resolved_fn else {
+                return Ok(undef);
+            };
+            // Mirror Expr::FuncRef: route through the singleton wrapper
+            // so callers can invoke via the closure-call ABI. The
+            // `__perry_wrap_<fn>` symbol is emitted by compile_module
+            // for every user function.
+            let wrap_name = format!("__perry_wrap_{}", fn_name);
+            let blk = ctx.block();
+            let wrap_ptr = format!("@{}", wrap_name);
+            let closure_handle = blk.call(I64, "js_closure_alloc_singleton", &[(PTR, &wrap_ptr)]);
+            Ok(nanbox_pointer_inline(blk, &closure_handle))
+        }
+
         // -------- fs.readFileSync(path) -> Buffer (no encoding) --------
         // Node returns a Buffer when no encoding is supplied; mirror that.
         // js_fs_read_file_binary returns a raw *mut BufferHeader registered

--- a/crates/perry-hir/src/ir.rs
+++ b/crates/perry-hir/src/ir.rs
@@ -1161,6 +1161,12 @@ pub enum Expr {
         args: Vec<Expr>,
     },
 
+    // Super property read (value form). super.<prop>. Resolved at
+    // codegen by walking the parent class's method table (issue #774).
+    SuperPropertyGet {
+        property: String,
+    },
+
     // Environment variable access: process.env.VARNAME
     EnvGet(String),
     // Dynamic environment variable access: process.env[expr]

--- a/crates/perry-hir/src/lower/expr_misc.rs
+++ b/crates/perry-hir/src/lower/expr_misc.rs
@@ -56,21 +56,19 @@ pub(super) fn lower_super_prop(
     // here for value-form reads like `super._next` (rxjs's
     // OperatorSubscriber), `super.value` (NestJS adapter chains), etc.
     //
-    // Strict JS semantics would resolve through the parent class's
-    // prototype, bypassing any override on the child. Perry currently
-    // doesn't carry a runtime parent-vtable lookup separate from the
-    // instance's own vtable chain, so we approximate by lowering to
-    // `this.<prop>` — the instance method dispatch already walks the
-    // class chain and returns the inherited method when the child does
-    // not override. The substitution is correct when the child does
-    // not override the property (the dominant rxjs / NestJS pattern;
-    // see PR #754 maintainer review on the NestJS smoke test). When
-    // the child *does* override, this approximation will resolve to
-    // the override rather than the parent — a TODO for a future
-    // explicit super-vtable path in codegen.
+    // Ident form (`super.foo`) routes through Expr::SuperPropertyGet so
+    // codegen can do an explicit parent-class vtable lookup (issue
+    // #774). The previous `this.<prop>` approximation silently
+    // returned the child override when the child shadowed the
+    // property; strict JS resolves through the parent prototype.
+    //
+    // Computed form (`super[expr]`) is kept on the `this[expr]`
+    // fallback for now — computed super needs a runtime dispatch
+    // that's out of scope for #774 (the dominant PR #754 rxjs /
+    // NestJS patterns are all ident-form method calls, which go
+    // through SuperMethodCall anyway).
     match &super_prop.prop {
-        ast::SuperProp::Ident(ident) => Ok(Expr::PropertyGet {
-            object: Box::new(Expr::This),
+        ast::SuperProp::Ident(ident) => Ok(Expr::SuperPropertyGet {
             property: ident.sym.to_string(),
         }),
         ast::SuperProp::Computed(computed) => {

--- a/crates/perry-hir/src/stable_hash.rs
+++ b/crates/perry-hir/src/stable_hash.rs
@@ -1624,6 +1624,10 @@ impl SH for Expr {
                 method.hash(h);
                 args.hash(h);
             }
+            Expr::SuperPropertyGet { property } => {
+                tag(h, 461);
+                property.hash(h);
+            }
             Expr::EnvGet(s) => {
                 tag(h, 53);
                 s.hash(h);

--- a/crates/perry-hir/src/walker.rs
+++ b/crates/perry-hir/src/walker.rs
@@ -70,6 +70,7 @@ where
         | Expr::NativeModuleRef(_)
         | Expr::ClassRef(_)
         | Expr::This
+        | Expr::SuperPropertyGet { .. }
         | Expr::EnumMember { .. }
         | Expr::StaticFieldGet { .. }
         | Expr::Update { .. }
@@ -1334,6 +1335,7 @@ where
         | Expr::NativeModuleRef(_)
         | Expr::ClassRef(_)
         | Expr::This
+        | Expr::SuperPropertyGet { .. }
         | Expr::EnumMember { .. }
         | Expr::StaticFieldGet { .. }
         | Expr::Update { .. }

--- a/test-files/test_super_property_override.ts
+++ b/test-files/test_super_property_override.ts
@@ -1,0 +1,23 @@
+// Parity test for issue #774 — value-form `super.<prop>` must resolve
+// through the parent's prototype, not the child's instance slot.
+//
+// Pre-fix (PR #754 lowering): rewrote `super.foo` to `this.foo`, so a
+// child override silently shadowed the parent ("B" instead of
+// `undefined`).
+//
+// Strict JS semantics: `super.foo` looks up `foo` on the parent's
+// prototype. For an instance-field parent (no method, no getter) the
+// prototype slot is empty, so the result is `undefined`. The codegen
+// fix in `Expr::SuperPropertyGet` (perry-codegen/src/expr.rs) walks
+// the parent class chain explicitly and returns `undefined` here.
+
+class A {
+    foo = "A";
+}
+class B extends A {
+    foo = "B";
+    parentFoo() {
+        return super.foo;
+    }
+}
+console.log(new B().parentFoo());


### PR DESCRIPTION
## Summary

Closes #774. Value-form `super.<prop>` was lowered to `this.<prop>` in PR #754 (`crates/perry-hir/src/lower/expr_misc.rs::lower_super_prop`), so a child override silently shadowed the parent. Strict JS resolves the read through the parent's prototype.

## What changed

- **HIR**: new `Expr::SuperPropertyGet { property }` variant. Ident-form `super.foo` lowers to it; computed `super[expr]` keeps its `this[expr]` fallback (out of scope here).
- **Codegen** (`Expr::SuperPropertyGet` in `crates/perry-codegen/src/expr.rs`): walks the parent class chain in `ctx.classes` / `ctx.methods`. When a parent declares a method `<prop>`, materializes it as a closure value via `js_closure_alloc_singleton` (mirroring `Expr::FuncRef`); otherwise returns `undefined`.
- **Method closure wrappers**: emits `__perry_wrap_<method>` for every class instance method in `compile_module`, alongside the existing `hir.functions` wrapper loop. Forwards to `perry_method_<…>(this_box, args)` with `this=undefined`, matching strict-JS plain-invocation semantics for `const fn = super.greet; fn(arg)`.

Call-form `super.method(args)` continues to route through `Expr::SuperMethodCall` unchanged — the rxjs / NestJS canaries from PR #754 are unaffected.

## Validation

- `node --experimental-strip-types test-files/test_super_property_override.ts` → `undefined`
- `./target/release/perry test-files/test_super_property_override.ts -o /tmp/t && /tmp/t` → `undefined`
- `./run_parity_tests.sh --filter test_decorators` — all NestJS decorator canaries from PR #754 PASS (`test_decorators_nest_js_common_canary` is a pre-existing compile failure unrelated to this PR).
- `./run_parity_tests.sh --filter test_super` / `--filter test_inherit` — all PASS.
- `cargo fmt --check`

## Test plan

- [ ] CI `parity` job green.
- [ ] CI `cargo-test` green.