### PR TITLE
fix(compile): #684 — type-only imports must not register exports into cross-module name map

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -3310,7 +3310,20 @@ pub fn run_with_parse_cache(
             // `typeof fsp === "boolean"`. Registering here lets the
             // catch-all route through `js_unresolved_namespace_stub`
             // (typeof "object", missing properties → undefined).
+            //
+            // Issue #684: skip WHOLE-DECL type-only imports
+            // (`import type * as X from "..."`). They're erased at
+            // runtime — the local binding never appears in any
+            // value-position expression, so registering it as a
+            // namespace would only widen the per-namespace member
+            // map below. Per-specifier type-only (`import { type Foo,
+            // bar }`) is still handled because the same import has
+            // value specifiers; the whole-decl flag is the one that
+            // makes the entire import a no-op.
             for import in &hir_module.imports {
+                if import.type_only {
+                    continue;
+                }
                 for spec in &import.specifiers {
                     if let perry_hir::ImportSpecifier::Namespace { local } = spec {
                         if !namespace_imports.contains(local) {
@@ -3322,6 +3335,34 @@ pub fn run_with_parse_cache(
 
             for import in &hir_module.imports {
                 if import.module_kind != perry_hir::ModuleKind::NativeCompiled {
+                    continue;
+                }
+                // Issue #684: skip WHOLE-DECL type-only imports
+                // (`import type * as X`, `import type { Foo }`). They
+                // contribute zero runtime state — neither the namespace
+                // binding nor the named members ever appear in a
+                // value-position expression after type erasure. Pre-fix
+                // the loop below treated them like value imports and
+                // registered every export of the source module into
+                // `import_function_prefixes` / `namespace_member_prefixes`,
+                // which collided with later named-import registrations:
+                //   effect's `ParseResult.ts` has both
+                //     `import { TaggedError } from "./Data.js"`
+                //     `import type * as Schema from "./Schema.js"`
+                //   Schema.ts also exports `TaggedError`, so the type-only
+                //   loop iteration registered `TaggedError → Schema_ts`
+                //   into `import_function_prefixes`. If Schema.ts was
+                //   processed AFTER Data.ts (HashMap iteration order is
+                //   unstable), the Schema entry won — and top-level
+                //   `class ParseError extends TaggedError("ParseError")`
+                //   dispatched into Schema.ts's `TaggedError` instead of
+                //   Data.ts's. Worse, Schema.ts is type-only so it isn't
+                //   in `module_init_deps` either, meaning its backing
+                //   global was still 0.0 — `js_closure_call1(0.0, ...)`
+                //   threw `TypeError: value is not a function` during
+                //   `ParseResult.ts__init`. Closes #684 (companion to
+                //   #680's `module_init_deps` filter at L3234).
+                if import.type_only {
                     continue;
                 }
                 let resolved_path = match &import.resolved_path {

--- a/tests/test_684_type_only_namespace_collision.sh
+++ b/tests/test_684_type_only_namespace_collision.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Regression for #684: type-only namespace imports must not register their
+# source module's exports into `import_function_prefixes` (or
+# `namespace_member_prefixes`).
+#
+# Bug: `import type * as Schema from "./Schema.js"` was iterated like a
+# value namespace import in compile.rs's resolution loop, so Schema's
+# exports were registered into the flat name→source-prefix map. When the
+# same module also had a real `import { TaggedError } from "./Data.js"`
+# AND Schema.ts also exported `TaggedError`, HashMap iteration order
+# determined the winner — and when Schema's entry won, top-level
+# `TaggedError(...)` dispatched into Schema's TaggedError instead of
+# Data's. Worse, Schema is type-only so it isn't in `module_init_deps`
+# either, meaning its backing global is still 0.0 — the call threw
+# `TypeError: value is not a function` from `js_closure_call1`.
+#
+# Fix: skip whole-decl type-only imports in compile.rs's resolution loop
+# (mirroring the L3234 `module_init_deps` filter from #680).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+# Data.ts: the REAL `kindOf` that the importer wants.
+cat > "$TMPDIR/Data.ts" << 'EOF'
+export const kindOf = (x: unknown): string => "data:" + typeof x;
+EOF
+
+# Schema.ts: a DIFFERENT `kindOf` that exists only so the type-only
+# import can collide. Importantly, Schema.ts is NOT initialized at
+# runtime (no value-position reference), so `Schema_ts__init` never
+# runs and the backing global stays uninitialized. Pre-fix, the
+# importer would call _into_ this uninitialized symbol and throw
+# `TypeError: value is not a function`.
+cat > "$TMPDIR/Schema.ts" << 'EOF'
+export const kindOf = (_x: unknown): string => {
+  throw new Error("Schema.kindOf must never be reached at runtime");
+};
+EOF
+
+# main.ts: imports `kindOf` as a value FROM Data, AND imports Schema
+# as a TYPE-ONLY namespace. The type-only line should be erased at
+# runtime — `kindOf(42)` must dispatch to Data's kindOf and return
+# the expected `"data:number"`. Pre-fix, Schema.ts's type-only import
+# leaked into the name→prefix map and (depending on HashMap order)
+# the call landed on Schema_ts's uninitialized global slot.
+cat > "$TMPDIR/main.ts" << 'EOF'
+import { kindOf } from "./Data";
+import type * as Schema from "./Schema";
+
+console.log(kindOf(42));
+console.log(kindOf("hi"));
+
+// Reference the type-only binding so TS keeps the import, but only
+// in type position — the resulting JS is a noop.
+type _Unused = ReturnType<typeof Schema.kindOf>;
+EOF
+
+cd "$TMPDIR"
+"$PERRY" compile main.ts --output test_bin >/dev/null 2>&1
+RUN_OUTPUT=$(./test_bin 2>&1)
+
+EXPECTED="data:number
+data:string"
+
+if [ "$RUN_OUTPUT" = "$EXPECTED" ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: #684 type-only namespace collision still leaks"
+echo "Expected:"
+echo "$EXPECTED"
+echo ""
+echo "Got:"
+echo "$RUN_OUTPUT"
+exit 1


### PR DESCRIPTION
## Summary

- Closes the `#680`-shape regression that surfaced at the 308th module init when Effect's `import {} from "effect"` ran post-v0.5.807: `import type * as Schema from "./Schema.js"` was iterated like a value namespace import, so Schema's `TaggedError` clobbered Data's `TaggedError` in the flat `import_function_prefixes` map. Schema is type-only and therefore not in `module_init_deps` either, so its backing global stayed at 0.0 and `js_closure_call1(0.0, ...)` threw `TypeError: value is not a function` during `ParseResult.ts__init`.
- Two narrow `if import.type_only { continue; }` guards in `crates/perry/src/commands/compile.rs` (early namespace-pre-pass + main resolution loop), mirroring the existing #680 filter at L3234.
- New `tests/test_684_type_only_namespace_collision.sh` regression test (~60 LoC, 3 files) reproduces the failure shape and passes post-fix.

## Root cause

`compile.rs`'s cross-module resolution loop did not consult `import.type_only`, so it iterated whole-decl type-only imports like value imports and registered every export of the source module into `import_function_prefixes` and `namespace_member_prefixes`. When two modules export the same name (Effect's `Data.ts` and `Schema.ts` both export `TaggedError`), HashMap iteration order decided which entry won. If Schema's type-only registration ran after Data's real `import { TaggedError } from "./Data.js"` registration, the consumer dispatched `TaggedError(...)` into Schema's symbol — and because Schema is type-only, its `__init` never ran, leaving the backing global at 0.0.

The `objdump -r` reloc inside `ParseResult.ts__init` directly confirmed this: the `bl` at the call site resolved to `_perry_fn_node_modules_effect_src_Schema_ts__TaggedError` rather than `_perry_fn_..._Data_ts__TaggedError`.

## Fix

Two `if import.type_only { continue; }` guards in `crates/perry/src/commands/compile.rs`:

1. Early namespace-pre-pass loop at L3313 — pre-fix it populated `namespace_imports` for type-only specifiers too, which routed value-position references through the unresolved-namespace stub.
2. Main resolution loop at L3323 — the big one that fills `import_function_prefixes`, `namespace_member_prefixes`, `imported_vars`, `imported_classes`, etc.

Both mirror the existing #680 `module_init_deps` filter at L3234. The fix is intentionally minimal: type-only imports contribute zero runtime state, so skipping them in every cross-module resolution path is strictly correct, not a band-aid.

## New failure point (partial fix)

This PR closes the #684 type-only-collision blocker and moves init forward by ~50 modules. The Effect repro now advances past ParseResult.ts (308 module inits — matches issue #684's "~310th init" estimate) and reaches `Schema.ts__init`, where it throws a different error:

```
TypeError: Cannot read properties of undefined (reading '_tag')
```

That's a separate downstream issue (touching `_tag` on an undefined value somewhere in Schema.ts's top-level expressions) and is NOT in scope for this PR. A follow-up issue should be filed to track it once #684 is closed.

Refs #321, #680, #671.

## Test plan

- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry -p perry-jsruntime`
- [x] `cargo test --release -p perry-codegen -p perry-runtime -p perry` — all 440 tests pass
- [x] `bash tests/test_684_type_only_namespace_collision.sh` — PASS
- [x] `bash tests/test_chained_cross_module_getter.sh` — PASS
- [x] `bash tests/test_cross_module_getter.sh` — PASS
- [x] `/tmp/run_gap_tests.sh` — 34/36 pass, same set as pre-fix (no regression)
- [x] Existing type-only-related test files match Node output byte-for-byte:
  - `test-files/test_issue_446_import_type_method_typeof.ts`
  - `test-files/test_issue_623.ts`
  - `test-files/test_issue_392_followup_map_field.ts`
- [x] Verified `test_684_type_only_namespace_collision.sh` FAILS pre-fix with the expected `TypeError: value is not a function`, PASSES post-fix.
- [x] Effect `import {} from "effect"` repro: init now reaches Schema.ts (308th __init) before failing on the downstream `_tag` issue.