### PR TITLE
fix: #775 — emit shim note when async_hooks is imported

### DIFF
--- a/crates/perry-hir/src/lower.rs
+++ b/crates/perry-hir/src/lower.rs
@@ -4004,6 +4004,33 @@ See docs/src/language/decorators.md."
     );
 }
 
+/// Emit a one-shot note when the user imports `node:async_hooks`. Perry
+/// ships a structural stub (see crates/perry-jsruntime/src/modules.rs)
+/// that satisfies the NestJS bootstrap path, but does NOT yet implement
+/// real async-context tracking. Anything relying on `AsyncLocalStorage`
+/// for context propagation across `await` / `setImmediate` /
+/// `process.nextTick` boundaries (Sentry request scopes, OpenTelemetry
+/// trace propagation, NestJS request-scoped providers, pino child
+/// loggers) will compile and run but silently lose context. Warning at
+/// compile time avoids the production surprise.
+fn emit_async_hooks_shim_note() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static EMITTED: AtomicBool = AtomicBool::new(false);
+    if EMITTED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    eprintln!(
+        "[perry] note: `import \"node:async_hooks\"` is satisfied by Perry's structural \
+stub. Implemented surface: AsyncResource, AsyncLocalStorage, executionAsyncId, \
+and createHook shapes — enough that NestJS bootstrap compiles. \
+AsyncLocalStorage.run() does NOT propagate context across \
+`await`/`setImmediate`/`process.nextTick` boundaries, so anything that \
+relies on async-context tracking (Sentry request scopes, OpenTelemetry \
+trace propagation, NestJS request-scoped providers, pino child loggers) \
+will silently lose context. See https://github.com/PerryTS/perry/issues/775."
+    );
+}
+
 fn lower_module_decl(
     ctx: &mut LoweringContext,
     module: &mut Module,
@@ -4022,6 +4049,13 @@ fn lower_module_decl(
             if source == "reflect-metadata" {
                 emit_reflect_metadata_shim_note();
                 return Ok(());
+            }
+
+            if source == "async_hooks" {
+                emit_async_hooks_shim_note();
+                // Fall through — the import still needs to bind
+                // AsyncLocalStorage / AsyncResource so calling code
+                // compiles against the structural stub.
             }
 
             // Check if this is a native module import


### PR DESCRIPTION
## Summary

Closes #775.

The `node:async_hooks` stub added in #754 is structural — it provides `AsyncResource`, `AsyncLocalStorage`, `executionAsyncId`, and `createHook` shapes so NestJS bootstrap compiles, but it does **not** track async context across `await` / `setImmediate` / `process.nextTick`. Anything that relies on `AsyncLocalStorage` for context propagation (Sentry request scopes, OpenTelemetry trace propagation, NestJS request-scoped providers, pino child loggers) compiles, runs, and silently loses context.

This PR mirrors the reflect-metadata 2a mitigation: a one-shot `[perry] note:` to stderr at compile time when `async_hooks` (or `node:async_hooks`) is imported.

- New `emit_async_hooks_shim_note()` in [crates/perry-hir/src/lower.rs](crates/perry-hir/src/lower.rs), same `AtomicBool::swap` one-shot pattern as `emit_reflect_metadata_shim_note()`.
- Wired into `lower_module_decl` next to the reflect-metadata branch. Source is already normalized to strip the `node:` prefix, so a single `source == "async_hooks"` check covers both spellings.
- Unlike the reflect-metadata branch, this one falls through (no `return Ok(())`) — the import still needs to bind `AsyncLocalStorage` / `AsyncResource` against the existing structural stub.

Real async-context tracking via tokio `task_local!` (or via Perry's promise/microtask scheduler) is the proper long-term fix; this is the minimum-viable mitigation so the silent-failure surface doesn't grow.

## Test plan

- [x] `cargo build --release -p perry-hir` — clean.
- [x] `cargo build --release -p perry` — clean.
- [x] Compiled a fixture with `import { AsyncLocalStorage } from "node:async_hooks"` and confirmed the `[perry] note: ...` line prints once to stderr during the compile.
- [ ] CI: `lint`, `cargo-test`, `parity`, `compile-smoke`, `api-docs-drift`, `security-audit`.