### PR TITLE
fix(perry-ext-ws): #813 — deliver server-level wss.on('message'/'close') events

### DIFF
--- a/crates/perry-ext-ws/src/lib.rs
+++ b/crates/perry-ext-ws/src/lib.rs
@@ -778,13 +778,28 @@ fn drive_server_client_io<S>(
                                 // listener-registration site can drain it
                                 // synchronously.
                                 let text_str = text.to_string();
-                                let has_listener = WS_CLIENT_LISTENERS
+                                let client_has_listener = WS_CLIENT_LISTENERS
                                     .lock()
                                     .unwrap()
                                     .get(&ws_id)
                                     .map(|l| l.listeners.get("message").map(|v| !v.is_empty()).unwrap_or(false))
                                     .unwrap_or(false);
-                                if has_listener {
+                                // #746 follow-up: a server-level
+                                // `wss.on('message', (ws, data) => ...)` handler
+                                // (perry-stdlib::ws parity) registers on the parent
+                                // WsServerHandle, not on WS_CLIENT_LISTENERS. The
+                                // original #577 Phase 4 race-guard only checked the
+                                // per-client map, so a server-only message handler
+                                // never produced a PendingWsEvent::Message — the
+                                // frame was parked on c.messages forever.
+                                let server_has_listener = WS_CLIENT_PARENT_SERVER
+                                    .lock()
+                                    .unwrap()
+                                    .get(&ws_id)
+                                    .copied()
+                                    .map(|sh| !listeners_on_server(sh, "message").is_empty())
+                                    .unwrap_or(false);
+                                if client_has_listener || server_has_listener {
                                     push_ws_event(PendingWsEvent::Message(ws_id, text_str));
                                 } else if let Some(c) = WS_CONNECTIONS.lock().unwrap().get_mut(&ws_id) {
                                     c.messages.push(text_str);
@@ -910,25 +925,61 @@ pub extern "C" fn js_ws_process_pending() -> i32 {
             }
             PendingWsEvent::Message(ws_id, text) => {
                 let listeners = listeners_on_client(ws_id, "message");
-                for cb in listeners {
-                    if cb != 0 {
-                        let closure = unsafe { JsClosure::from_raw(cb as *const RawClosureHeader) };
-                        let s = alloc_string(&text);
-                        let _ = unsafe {
-                            closure
-                                .call1(f64::from_bits(JsValue::from_string_ptr(s.as_raw()).bits()))
-                        };
-                        fired += 1;
+                let s = alloc_string(&text);
+                let msg_f64 = f64::from_bits(JsValue::from_string_ptr(s.as_raw()).bits());
+                if !listeners.is_empty() {
+                    for cb in listeners {
+                        if cb != 0 {
+                            let closure =
+                                unsafe { JsClosure::from_raw(cb as *const RawClosureHeader) };
+                            let _ = unsafe { closure.call1(msg_f64) };
+                            fired += 1;
+                        }
+                    }
+                } else {
+                    // #746 follow-up: server-level `wss.on('message',
+                    // (ws, data) => ...)` parity with perry-stdlib::ws.
+                    let parent =
+                        WS_CLIENT_PARENT_SERVER.lock().unwrap().get(&ws_id).copied();
+                    if let Some(server_handle) = parent {
+                        for cb in listeners_on_server(server_handle, "message") {
+                            if cb != 0 {
+                                let closure = unsafe {
+                                    JsClosure::from_raw(cb as *const RawClosureHeader)
+                                };
+                                let _ = unsafe { closure.call2(ws_id as f64, msg_f64) };
+                                fired += 1;
+                            }
+                        }
                     }
                 }
             }
             PendingWsEvent::Close(ws_id, _code, _reason) => {
                 let listeners = listeners_on_client(ws_id, "close");
-                for cb in listeners {
-                    if cb != 0 {
-                        let closure = unsafe { JsClosure::from_raw(cb as *const RawClosureHeader) };
-                        let _ = unsafe { closure.call0() };
-                        fired += 1;
+                if !listeners.is_empty() {
+                    for cb in listeners {
+                        if cb != 0 {
+                            let closure =
+                                unsafe { JsClosure::from_raw(cb as *const RawClosureHeader) };
+                            let _ = unsafe { closure.call0() };
+                            fired += 1;
+                        }
+                    }
+                } else {
+                    // #746 follow-up: server-level `wss.on('close',
+                    // (ws) => ...)` parity with perry-stdlib::ws.
+                    let parent =
+                        WS_CLIENT_PARENT_SERVER.lock().unwrap().get(&ws_id).copied();
+                    if let Some(server_handle) = parent {
+                        for cb in listeners_on_server(server_handle, "close") {
+                            if cb != 0 {
+                                let closure = unsafe {
+                                    JsClosure::from_raw(cb as *const RawClosureHeader)
+                                };
+                                let _ = unsafe { closure.call1(ws_id as f64) };
+                                fired += 1;
+                            }
+                        }
                     }
                 }
                 WS_CONNECTIONS.lock().unwrap().remove(&ws_id);

--- a/crates/perry-ext-ws/src/lib.rs
+++ b/crates/perry-ext-ws/src/lib.rs
@@ -939,14 +939,12 @@ pub extern "C" fn js_ws_process_pending() -> i32 {
                 } else {
                     // #746 follow-up: server-level `wss.on('message',
                     // (ws, data) => ...)` parity with perry-stdlib::ws.
-                    let parent =
-                        WS_CLIENT_PARENT_SERVER.lock().unwrap().get(&ws_id).copied();
+                    let parent = WS_CLIENT_PARENT_SERVER.lock().unwrap().get(&ws_id).copied();
                     if let Some(server_handle) = parent {
                         for cb in listeners_on_server(server_handle, "message") {
                             if cb != 0 {
-                                let closure = unsafe {
-                                    JsClosure::from_raw(cb as *const RawClosureHeader)
-                                };
+                                let closure =
+                                    unsafe { JsClosure::from_raw(cb as *const RawClosureHeader) };
                                 let _ = unsafe { closure.call2(ws_id as f64, msg_f64) };
                                 fired += 1;
                             }
@@ -968,14 +966,12 @@ pub extern "C" fn js_ws_process_pending() -> i32 {
                 } else {
                     // #746 follow-up: server-level `wss.on('close',
                     // (ws) => ...)` parity with perry-stdlib::ws.
-                    let parent =
-                        WS_CLIENT_PARENT_SERVER.lock().unwrap().get(&ws_id).copied();
+                    let parent = WS_CLIENT_PARENT_SERVER.lock().unwrap().get(&ws_id).copied();
                     if let Some(server_handle) = parent {
                         for cb in listeners_on_server(server_handle, "close") {
                             if cb != 0 {
-                                let closure = unsafe {
-                                    JsClosure::from_raw(cb as *const RawClosureHeader)
-                                };
+                                let closure =
+                                    unsafe { JsClosure::from_raw(cb as *const RawClosureHeader) };
                                 let _ = unsafe { closure.call1(ws_id as f64) };
                                 fired += 1;
                             }


### PR DESCRIPTION
## Summary

Fixes #813 — the residual root cause behind #746 that persisted after the #747 fastify-pump fix (v0.5.904) shipped in v0.5.912.

`perry-ext-ws` only delivered `message`/`close` events to **per-client** listeners (`WS_CLIENT_LISTENERS`). A **server-level** `wss.on('message', (ws, data) => …)` / `wss.on('close', (ws) => …)` handler — valid in `perry-stdlib::ws` and used by `perry-hub` — never fired. (`connection` already worked because it dispatches via `listeners_on_server`.) The v0.5.572 perry-stdlib→perry-ext port dropped this server-level path.

## Two defects, both fixed (mirroring `crates/perry-stdlib/src/ws.rs`)

1. **`drive_server_client_io` race-guard** — the #577 Phase 4 `has_listener` guard only checked the per-client map, so an inbound frame for a server-only handler was parked on `c.messages` forever and no `PendingWsEvent::Message` was ever pushed. Now also checks the parent `WsServerHandle` (`WS_CLIENT_PARENT_SERVER` → `listeners_on_server(sh, "message")`).
2. **`js_ws_process_pending` `Message`/`Close` arms** — no parent-server fall-through. When per-client listeners are empty, fall through to the parent server's listeners: `message` → `call2(ws_id, data)`, `close` → `call1(ws_id)`, matching perry-stdlib::ws.

## Validation

- `cargo check -p perry-ext-ws --release` — clean.
- End-to-end: `perry-hub` recompiled on Linux x86_64 with v0.5.912 + this patch. Before: `wss.on('connection')` fired but `wss.on('message')` never did (no `Worker connected`). After: `connection`, server-level `message` (worker_hello → `Worker connected`), and real workers (oakhost-tart, azure-sign-win) all connect and round-trip correctly. Hub has been serving production traffic on this build.

## Notes / follow-ups

- The `'error'` server fall-through is intentionally **not** included here (perry-stdlib uses server `"client_error"` for per-client errors vs `"error"` for `ServerError`; the hub doesn't depend on it). Worth a parity pass separately.
- A regression test (server-only `wss.on('message')` echo + single-frame client) would lock this down — happy to add if you'd like it in this PR.

Closes #813. Refs #746, #747.