### PR TITLE
fix: #797 — restructure known_failures.json with audit metadata

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,7 +230,22 @@ jobs:
           # spurious "NEW FAILURES:  - " line and fail this gate.
           jq -r '(.failures.parity // []) + (.failures.compile // []) | .[] | select(. != "")' "$REPORT" | sort -u > /tmp/all_fails.txt
           if [[ -f "$KNOWN" ]]; then
-            jq -r 'keys[]' "$KNOWN" | sort -u > /tmp/known.txt
+            # Issue #797 — known_failures.json moved from flat strings to
+            # structured records. Keep the audit metadata (the `_schema`
+            # key at the top of the file) out of the test-name set so
+            # CI doesn't try to match a real test against it.
+            jq -r 'keys[] | select(. != "_schema")' "$KNOWN" | sort -u > /tmp/known.txt
+
+            # Schema sanity check — every non-_schema entry must be an
+            # object with non-empty `category` and `reason`. Fails the
+            # build on malformed entries so the format doesn't silently
+            # drift back to the legacy flat-string shape.
+            bad="$(jq -r 'to_entries | map(select(.key != "_schema")) | .[] | select((.value | type) != "object" or (.value.category // "") == "" or (.value.reason // "") == "") | .key' "$KNOWN")"
+            if [[ -n "$bad" ]]; then
+              echo "Malformed known_failures.json entries (missing category/reason or not an object):"
+              echo "$bad" | sed 's/^/  - /'
+              exit 1
+            fi
           else
             : > /tmp/known.txt
           fi

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1,60 +1,359 @@
 {
-  "issue_655_repro": "issue #655 repro \u2014 kept as the canonical regression-catcher; will flip to PASS when #655 lands.",
-  "test_gap_array_methods": "Array method coverage probe \u2014 small divergences (e.g. flat/flatMap/finally specific edge cases). Targeted bisect needed; not a recent regression.",
-  "test_issue_233_async_array_param_push": "Async array-param push edge case (#233) regresses on Linux CI but passes locally on macOS. Bisect to pin Linux-only divergence.",
-  "test_issue_561_sigv4_chain": "SigV4 chain test (#561) regresses on Linux CI but passes locally on macOS. Likely related to crypto/HMAC ordering. Bisect needed.",
-  "test_issue_654_typed_array_dispatch": "Typed array dispatch test (#654) regresses on Linux CI but passes locally on macOS. Bisect needed for Linux-specific dispatch divergence.",
-  "test_edge_regression": "Broad edge-case bundle covering multiple historical regressions; bisect needed to pin which sub-case still fails. Not a recent regression.",
-  "test_edge_type_narrowing": "Several TS type-narrowing patterns (control-flow narrowing, discriminated unions through generics, `in` operator narrowing) Perry's HIR doesn't track yet. Surfaced multiple narrow-fix candidates.",
-  "test_gap_regexp_advanced": "Lookbehind regex assertions \u2014 Rust's `regex` crate doesn't support `(?<=)` / `(?<!)`. Documented in CLAUDE.md as a known categorical gap.",
-  "test_issue_422_socket_connect": "Net test passes locally with echo server running, fails on Linux CI (no echo fixture server). Environmental.",
-  "test_issue_462_nullish_property_access": "TypeError stack-trace format diverges from Node \u2014 see #616. Behavior is correct (TypeError thrown, UNREACHABLE never prints); only the framing differs (Node emits file:line header + source line + caret + file-URL stack frames; Perry emits `<Name>: <msg>` + `at <anonymous>`). Matching Node byte-for-byte requires source-text retention through the runtime.",
-  "test_issue_510_primitive_method_typeerror": "Same root cause as test_issue_462 \u2014 see #616. Behavior correct; framing differs. Regression vector: v0.5.702 (#596) routed throw helpers through js_throw which exposed the format gap.",
-  "test_issue_685_nested_class_static_param": "#685 nested-class static-field init closed in v0.5.814 on macOS; Linux CI still surfaces an adjacent shape (different sub-case). Needs targeted Linux-side bisect.",
-  "test_net_min": "Net test passes locally with echo server running, fails on Linux CI (no echo fixture server). Environmental.",
-  "test_net_socket": "Net test passes locally with echo server running, fails on Linux CI (no echo fixture server). Environmental.",
-  "test_net_upgrade_tls": "Net test needs a TLS-capable echo server fixture; not available on CI. Environmental.",
-  "test_parity_assert": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:assert` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_async_hooks": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:async_hooks` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_buffer": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:buffer` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_child_process": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:child_process` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_cluster": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:cluster` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_console": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:console` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_crypto": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:crypto` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_dgram": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:dgram` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_diagnostics_channel": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:diagnostics_channel` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_dns": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:dns` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_dns_promises": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:dns_promises` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_events": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:events` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_fs": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:fs` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_fs_promises": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:fs_promises` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_http": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:http` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_http2": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:http2` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_https": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:https` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_module": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:module` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_net": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:net` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_os": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:os` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_path": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:path` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_perf_hooks": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:perf_hooks` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_process": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:process` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_querystring": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:querystring` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_readline": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:readline` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_readline_promises": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:readline_promises` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_sqlite": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:sqlite` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_stream": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:stream` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_stream_consumers": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:stream_consumers` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_stream_promises": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:stream_promises` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_stream_web": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:stream_web` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_string_decoder": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:string_decoder` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_sys": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:sys` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_test": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:test` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_timers": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:timers` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_timers_promises": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:timers_promises` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_tls": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:tls` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_tty": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:tty` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_url": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:url` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_util": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:util` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_worker_threads": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:worker_threads` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_parity_zlib": "Node.js module inventory \u2014 Perry hasn't implemented the full `node:zlib` surface yet. Tracker for surface coverage; flips to PASS as each module's API lands. Not a regression.",
-  "test_sock_write_map": "Net test passes locally with echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 issue #91 dispatch fix landed in v0.5.581."
+  "_schema": {
+    "description": "Each entry maps a parity-suite test name to a structured record. The CI gate in .github/workflows/test.yml reads `keys[]` from this file — a test that fails AND is not a key here breaks CI. Add entries here only with full provenance (issue + added date) so we can revalidate.",
+    "fields": {
+      "issue": "Open GitHub issue number tracking this failure (e.g. \"793\"), or null when the failure is environmental / pending triage. Closed issues must be re-evaluated — flag the entry as `category: bug-stale` until a new tracking issue is filed.",
+      "added": "ISO date (YYYY-MM-DD) when the test was first skip-listed. Use 2026-05-15 for entries inherited from the pre-audit format where the historical date is unknown.",
+      "category": "ci-env | module-inventory | bug-open | bug-stale | gap-categorical | gap-bisect — see test-parity/README.md for definitions.",
+      "reason": "Free-text explanation. Keep the most-actionable signal first — what changes the verdict (a fixture, a Perry fix, a Node spec change)."
+    }
+  },
+  "issue_655_repro": {
+    "issue": "655",
+    "added": "2026-05-15",
+    "category": "bug-open",
+    "reason": "Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict — it's a deliberate failing repro."
+  },
+  "test_gap_array_methods": {
+    "issue": null,
+    "added": "2026-05-15",
+    "category": "gap-bisect",
+    "reason": "Array method coverage probe — small divergences (flat/flatMap/finally specific edge cases). Targeted bisect needed; not a recent regression. File a tracking issue once a specific sub-case is pinned."
+  },
+  "test_issue_233_async_array_param_push": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "bug-stale",
+    "reason": "#233 (16-element cap on async array-param push) closed on macOS. Linux CI still surfaces a divergence — bisect needed to pin the Linux-only sub-case before filing a new tracking issue. Rolled under the parity roadmap (#793) in the meantime."
+  },
+  "test_issue_561_sigv4_chain": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "bug-stale",
+    "reason": "#561 (Web Crypto subtle.digest/sign for HMAC-SHA-256) closed but the SigV4 chain test still regresses on Linux CI. Bisect needed for crypto/HMAC ordering on Linux; file a Linux-specific tracking issue once the divergence is identified."
+  },
+  "test_issue_654_typed_array_dispatch": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "bug-stale",
+    "reason": "#654 (Float64Array typeof + .sort/.at dispatch) closed but the typed-array dispatch test still regresses on Linux CI. Linux-specific dispatch divergence; bisect needed before re-filing."
+  },
+  "test_edge_regression": {
+    "issue": null,
+    "added": "2026-05-15",
+    "category": "gap-bisect",
+    "reason": "Broad edge-case bundle covering multiple historical regressions. Bisect needed to pin which sub-case still fails so a tracking issue can be filed against that specific behavior. Not a recent regression."
+  },
+  "test_edge_type_narrowing": {
+    "issue": null,
+    "added": "2026-05-15",
+    "category": "gap-bisect",
+    "reason": "Several TS type-narrowing patterns (control-flow narrowing, discriminated unions through generics, `in` operator narrowing) Perry's HIR doesn't track yet. Surfaced multiple narrow-fix candidates; split into per-pattern issues before tackling."
+  },
+  "test_gap_regexp_advanced": {
+    "issue": null,
+    "added": "2026-05-15",
+    "category": "gap-categorical",
+    "reason": "Lookbehind regex assertions — Rust's `regex` crate doesn't support `(?<=)` / `(?<!)`. Documented in CLAUDE.md as a known categorical gap. Unblocking requires swapping the regex backend or implementing a separate matcher for lookbehind."
+  },
+  "test_issue_422_socket_connect": {
+    "issue": null,
+    "added": "2026-05-15",
+    "category": "ci-env",
+    "reason": "#422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental — needs a CI-side fixture, not a Perry fix."
+  },
+  "test_issue_462_nullish_property_access": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "bug-stale",
+    "reason": "Behavior is correct (TypeError thrown, UNREACHABLE never prints). Only stack-trace format diverges from Node — #616 closed with framing improvements but byte-for-byte parity requires source-text retention through the runtime. Track under the parity roadmap; file a dedicated stack-format issue if/when it becomes a real blocker."
+  },
+  "test_issue_510_primitive_method_typeerror": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "bug-stale",
+    "reason": "Same root cause as test_issue_462 — see #616 (closed). Behavior correct; framing differs. Regression vector: v0.5.702 (#596) routed throw helpers through js_throw which exposed the format gap. Track under the parity roadmap until a stack-format issue is filed."
+  },
+  "test_issue_685_nested_class_static_param": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "bug-stale",
+    "reason": "#685 (nested-class static-field init) closed in v0.5.814 on macOS; Linux CI still surfaces an adjacent shape (different sub-case). Targeted Linux-side bisect needed; file a Linux-specific issue once the sub-case is pinned."
+  },
+  "test_net_min": {
+    "issue": null,
+    "added": "2026-05-15",
+    "category": "ci-env",
+    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
+  },
+  "test_net_socket": {
+    "issue": null,
+    "added": "2026-05-15",
+    "category": "ci-env",
+    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
+  },
+  "test_net_upgrade_tls": {
+    "issue": null,
+    "added": "2026-05-15",
+    "category": "ci-env",
+    "reason": "Net test needs a TLS-capable echo server fixture; not available on CI. Environmental — needs a CI-side fixture."
+  },
+  "test_parity_assert": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:assert` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_async_hooks": {
+    "issue": "789",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:async_hooks` createHook lifecycle + asyncId tracking missing. Tracked in #789. Flips to PASS once createHook fires."
+  },
+  "test_parity_buffer": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:buffer` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_child_process": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:child_process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_cluster": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:cluster` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_console": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:console` surface not fully implemented (console.dir/group* formatting noted as a categorical gap in CLAUDE.md). Tracker for surface coverage; flips to PASS as each API lands."
+  },
+  "test_parity_crypto": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:crypto` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_dgram": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:dgram` (UDP) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_diagnostics_channel": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:diagnostics_channel` not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_dns": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:dns` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_dns_promises": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:dns/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_events": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:events` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_fs": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:fs` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_fs_promises": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:fs/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_http": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:http` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_http2": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:http2` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_https": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:https` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_module": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:module` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_net": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:net` socket-layer surface not implemented (Server/Socket classes, BlockList, SocketAddress). Classification helpers landed via #811. Tracker for surface coverage; flips to PASS as each API lands."
+  },
+  "test_parity_os": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:os` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_path": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:path` surface. Per-method gaps closed via #741 and #810 (path.posix/win32 sub-namespace). This test now PASSes byte-for-byte; entry retained until the next sweep confirms it can be removed."
+  },
+  "test_parity_perf_hooks": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:perf_hooks` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_process": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_querystring": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:querystring` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_readline": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:readline` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_readline_promises": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:readline/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_sqlite": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:sqlite` (Node 22.5+ built-in) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_stream": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:stream` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_stream_consumers": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:stream/consumers` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_stream_promises": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:stream/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_stream_web": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:stream/web` (WHATWG streams) surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_string_decoder": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:string_decoder` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_sys": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:sys` (legacy alias for util) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_test": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:test` (built-in test runner) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_timers": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:timers` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_timers_promises": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:timers/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_tls": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:tls` surface not fully implemented (Socket-level TLS upgrade works via net.upgradeToTLS; the higher-level tls.connect/Server is partial). Tracker for surface coverage."
+  },
+  "test_parity_tty": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:tty` surface. Recent CLAUDE.md note indicates this test currently PASSes; entry retained until the next sweep confirms it can be removed."
+  },
+  "test_parity_url": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:url` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_util": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:util` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_parity_worker_threads": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:worker_threads` surface not implemented (perry/thread provides a Perry-native alternative). Tracker for surface coverage; flips to PASS as each API lands."
+  },
+  "test_parity_zlib": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:zlib` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_sock_write_map": {
+    "issue": null,
+    "added": "2026-05-15",
+    "category": "ci-env",
+    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — issue #91 dispatch fix landed in v0.5.581 and is no longer the cause; needs a CI-side fixture."
+  }
 }


### PR DESCRIPTION
## Summary
- `test-parity/known_failures.json` moves from a flat string-to-string map to per-entry structured records with `issue`, `added` (date skip-listed), `category`, and `reason`.
- Adds an inline `_schema` block at the top of the file (we don't generally add free-standing READMEs without an explicit ask, so the schema lives in the file it documents).
- Updates `.github/workflows/test.yml` to filter `_schema` out of the test-name set and to validate every other entry has non-empty `category` + `reason` — fails the build on malformed entries so the format can't silently drift back.

## Audit findings (relayed in the entry `reason` strings)
- Every cross-referenced issue was checked. **#233, #422, #462, #510, #561, #616, #654, #685, #91 are all CLOSED.** Their entries are now tagged `bug-stale` and parked under the parity roadmap meta (#793) until a Linux-specific tracking issue is filed for the surviving sub-case in each.
- Net tests that need a live fixture (`test_net_min`, `test_net_socket`, `test_net_upgrade_tls`, `test_issue_422_socket_connect`, `test_sock_write_map`) are now `ci-env` with `issue: null` — they pass locally with an echo server; CI just lacks the fixture.
- Module-inventory trackers point at #789 (async_hooks createHook) or #793 (everything else).
- A couple of entries (`test_parity_path`, `test_parity_tty`) appear to currently PASS after the recent landings — entries retained until the next sweep confirms they can be removed, so the diff stays focused on format/provenance.

## Test plan
- [x] `jq -r 'keys[] | select(. != \"_schema\")' test-parity/known_failures.json | wc -l` → 58 (matches original 59 minus the new `_schema` key).
- [x] Schema-validator jq returns no malformed entries.
- [x] CI gate logic unchanged for the failure-diff computation.

Closes #797.