### PR TITLE
docs: #798 — refresh CLAUDE.md parity status section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,13 @@ Perry is a native TypeScript compiler written in Rust that compiles TypeScript s
 
 Tracked via the gap test suite (`test-files/test_gap_*.ts`, 28 tests). Compared byte-for-byte against `node --experimental-strip-types`. Run via `/tmp/run_gap_tests.sh` after `cargo build --release -p perry-runtime -p perry-stdlib -p perry`.
 
-**Last full sweep:** run `./run_parity_tests.sh` for the current snapshot — the gap-suite top-line has shifted with recent landings; see open issues #447 (nested-async hang masking `test_async`), #448 (`*[Symbol.iterator]()` class hang), #449 (`new.target` → NaN), #450 (`defineProperty` accessor `this`), #451 (`test_gap_json_advanced` SIGSEGV), and #452 (`Array.fromAsync` / Proxy/Reflect / JSON ordering). Several of these are pre-existing bugs that the parity skip-list and gap-suite output truncation hid from earlier numbers.
+**Last full sweep:** run `./run_parity_tests.sh` for the current snapshot. The umbrella tracker is #793 (Node.js + TypeScript compatibility roadmap); the previously-cited #447–#452 batch closed on 2026-05-04. Currently-open trackers worth knowing about:
+
+- **Effect framework end-to-end (#321)** — `#684` (Schema.ts ~310th-init `(number).slice` regression) and `#809` (object-literal computed-keys + cross-module spread) are the live HashRing/Schema blockers.
+- **Async context** — `#788` (real `AsyncLocalStorage` tracking across `await`/microtasks/timers) and `#789` (real `async_hooks.createHook` lifecycle + asyncId). Today these are name-only stubs.
+- **Compile-as-package** — `#348` (ink TUI end-to-end), `#488/#489` (Drizzle + MySQL), `#678` (linker emits native callsites for V8-fallback modules).
+- **Test/CI mechanics** — `#794` (per-category parity thresholds), `#796` (gap-suite output truncation + O(n²) `normalize_output`), `#812` (42-module behavioral matrix), `#806/#807/#808` (test harnesses for mixins / async context / ≥300-init scale).
+- **Skip-list audit** — `#797` covers `test-parity/known_failures.json` provenance (issue # + date per entry).
 
 **Known categorical gaps**: lookbehind regex (Rust `regex` crate), `console.dir`/`console.group*` formatting, lone surrogate handling (WTF-8).
 


### PR DESCRIPTION
## Summary
- Replaces the stale #447–#452 batch (all closed on 2026-05-04) with the current open parity trackers, grouped by category.
- Leads with #793 (the umbrella roadmap) so new contributors land on the right entry point first.
- No parity numbers changed — the section is orientation/links only.

## Categories now linked
- **Effect end-to-end** — #321, #684, #809
- **Async context** — #788, #789
- **Compile-as-package** — #348, #488/#489, #678
- **Test/CI mechanics** — #794, #796, #806/#807/#808, #812
- **Skip-list audit** — #797

## Test plan
- [x] No code changes; CLAUDE.md edit only.
- [x] All referenced issues confirmed OPEN via `gh issue view`.

Closes #798.