### PR TITLE
fix(hir): mixin factories must register grandparent edge at runtime

### DIFF
--- a/crates/perry-hir/src/lower.rs
+++ b/crates/perry-hir/src/lower.rs
@@ -8572,8 +8572,31 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
             let synthetic_name =
                 ident_name.unwrap_or_else(|| format!("__anon_class_{}", ctx.fresh_class()));
             let class = lower_class_from_ast(ctx, &class_expr.class, &synthetic_name, false)?;
+            // Mixin factories like `function WithA(B) { return class extends B {} }`
+            // produce a class whose super is the function-parameter `B` — a
+            // runtime value, not a statically-known class. The class-decl arm
+            // at the top of this file only pushes a `RegisterClassParentDynamic`
+            // statement for top-level class declarations; an anonymous class
+            // expression inside a function body never has that side effect
+            // fire, so `new (class extends WithA(Base) {})().baseMethod()`
+            // walks subclass → inner factory class and stops at the unwired
+            // grandparent edge (TypeError on the inherited method). Sequence
+            // the dynamic-parent registration in front of the ClassRef so the
+            // edge is wired every time the factory function executes; the
+            // Sequence yields its last element, so the value remains the
+            // ClassRef the call site expects.
+            let parent_expr = class.extends_expr.clone();
             ctx.pending_classes.push(class);
-            Ok(Expr::ClassRef(synthetic_name))
+            match parent_expr {
+                Some(p) => Ok(Expr::Sequence(vec![
+                    Expr::RegisterClassParentDynamic {
+                        class_name: synthetic_name.clone(),
+                        parent_expr: p,
+                    },
+                    Expr::ClassRef(synthetic_name),
+                ])),
+                None => Ok(Expr::ClassRef(synthetic_name)),
+            }
         }
         ast::Expr::JSXElement(jsx) => lower_jsx_element(ctx, jsx),
         ast::Expr::JSXFragment(jsx) => lower_jsx_fragment(ctx, jsx),


### PR DESCRIPTION
## Summary
Fixes the chained-mixin `TypeError: value is not a function` that the #806 harness surfaced on PR #822. Root cause: class expressions inside a function body (the canonical mixin shape) had their `extends_expr` captured at HIR level but never evaluated — only top-level class declarations had a `RegisterClassParentDynamic` statement emitted for them. So in

```ts
function WithA<TBase extends Ctor>(B: TBase) {
  return class extends B { a() { return "a"; } };
}
class Chained extends WithA(WithB(WithC(CoreBase))) {}
```

`Chained → Anon3` got wired (via the top-level class-decl arm), but `Anon3 → Anon2 → Anon1 → CoreBase` was never registered. `chained.a()` worked; `chained.core()` walked one level and threw.

## Minimal repro
```ts
class Base { m() { return "base"; } }
function Mix<T extends new(...a:any[])=>{}>(B: T) {
  return class extends B { x() { return "x"; } };
}
class Sub extends Mix(Base) {}
new Sub().m();  // TypeError before; "base" after
```

The `const M = Mix(Base); class Sub extends M {}` form already worked because the const path takes a different lowering branch that synthesizes a named class.

## Fix
One arm in `crates/perry-hir/src/lower.rs` (the `ast::Expr::Class` lowering). When the lowered class has `extends_expr`, return

```rust
Expr::Sequence([
  Expr::RegisterClassParentDynamic { class_name, parent_expr },
  Expr::ClassRef(class_name),
])
```

instead of a bare `Expr::ClassRef`. `Sequence` is the existing comma-operator primitive whose codegen evaluates each element in order and returns the last — so the side effect runs every time the factory function executes, and the value the call site sees is unchanged. No new HIR variant, no codegen changes, no boilerplate through walker/monomorph/analysis/stable_hash/js_transform.

## Test plan
- [x] 1-deep mixin (`class X extends Mix(Base) {}`) — `new X().m()` returns `"base"` (was TypeError).
- [x] 3-deep chained mixin (`extends WithA(WithB(WithC(Base)))`) — all 4 methods (core/a/b/c) dispatch correctly.
- [x] `cargo test --release -p perry-hir -p perry-codegen` — all green.
- [x] 4-test class smoke (test_simple_class, test_get_prototype_of_instance, test_issue_711_function_prototype, test_gap_class_advanced) — all PASS byte-for-byte vs Node.

## What the #806 harness still surfaces
Four unrelated gaps stay visible (no longer cascading from the TypeError):
- Bare-factory base-class field initializer is dropped (`bare.kind: undefined`).
- `super(arg)` in a mixin constructor doesn't propagate the arg.
- Static method dispatch on a factory-returned class returns garbage.
- Effect double-call factory (`TaggedError<X>()("tag", schema)`) doesn't bind `_tag`.

Each is now independently visible — they'd been masked by the cascading TypeError.

Refs #321, closes the chained-mixin sub-case of #806's harness.