### PR TITLE
fix(compile): #684 — type-only imports must not load as runtime modules

### DIFF
--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -334,6 +334,21 @@ pub(super) fn collect_modules(
 
     // Process imports and update their resolved paths and module kinds
     for import in &mut hir_module.imports {
+        // Skip type-only imports — they were recorded for class-metadata flow
+        // (see lower.rs's #446 comment: a per-specifier `import { type Foo }`
+        // is preserved so Foo's class info reaches `imported_classes` for
+        // method dispatch) but they MUST NOT be loaded as runtime modules.
+        // Without this skip, `import type { StandardSchemaV1 } from
+        // "@standard-schema/spec"` (Effect's only `@standard-schema` use,
+        // a type-only reference) queued the package's V8 fallback. The
+        // spec ships an empty `src_exports = {}` at runtime, so any
+        // `something._tag` from the import binding then threw
+        // `TypeError: Cannot read properties of undefined (reading '_tag')`
+        // during Effect's module init. Refs #321, #684.
+        if import.type_only {
+            continue;
+        }
+
         // Apply package alias (e.g., @parse/node-apn → perry-push from perry.packageAliases)
         if let Some(alias) = ctx.package_aliases.get(import.source.as_str()).cloned() {
             import.source = alias;


### PR DESCRIPTION
## Summary
The module collector iterated every `hir_module.imports` entry through `cached_resolve_import` and queued them all as runtime modules, ignoring `import.type_only`. So `import type { … } from \"…\"` triggered V8 fallback for type-only packages, and any access to the (non-existent) named imports during init threw `TypeError`.

## Deterministic repro
```bash
bun add effect@3.21.2
echo 'import {} from \"effect\"; console.log(\"ok\")' > test.ts
perry compile test.ts -o /tmp/out
/tmp/out
# before:  TypeError: Cannot read properties of undefined (reading '_tag')
```

Effect's `Schema.ts` has exactly one `@standard-schema/spec` reference — `import type { StandardSchemaV1 } from \"@standard-schema/spec\"`. The package ships an empty `var src_exports = {}` at runtime (type-only by design). The collector saw the import and routed the package through V8 (only JS module among 363), so any `<StandardSchemaV1>._tag` read inside Effect's compiled code threw V8's exact wording. That uncaught TypeError is the #684 symptom in its current form — the original `(number).slice` message dissolved once intervening landings advanced Effect's init past the old crash point.

## Fix
One guard at the top of the import-processing loop in `collect_modules.rs` — skip entries with `type_only: true`. Class-metadata flow is unaffected: the HIR layer at `lower.rs:4151` already captures type-only specifiers into `imported_classes` for method dispatch (#446 path). The collector only governs whether the module's `.o` (or JS bundle) participates in linking and runtime init.

## Test plan
- [x] `import type { Foo } from \"./does_not_exist\"` now compiles cleanly (was rejected at the resolve step).
- [x] Mixed `import { x }` + `import type { T }` from the same file still resolves the value side correctly.
- [x] `cargo test --release -p perry-hir -p perry-codegen -p perry` — all green (223 + 29 + 4 + 41 + 1 + 40 + 10 + 6, 0 failed).
- [x] 7-test class+import smoke set byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` — clean.

## Follow-up
The Effect repro now advances past the `_tag` crash and exposes a separate **link-time** gap: `js_readable_stream_*` symbols are unresolved because Effect uses the global `ReadableStream` constructor (no literal `import \"streams\"`), and `compute_required_features` only triggers `bundled-streams` on the named import. Auto-enabling the streams feature on global `new ReadableStream()` / `new WritableStream()` / `new TransformStream()` is a separate Effect-e2e (#321) follow-up.

Closes #684.