### PR TITLE
fix(native-init): #863 — scaffolded native-library packages resolve + link to FFI symbols

### DIFF
--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -966,7 +966,13 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
         // directly against the runtime library — bypass the import-
         // map lookup and emit a direct LLVM call with an f64/f64 ABI.
         // (The declarations are added centrally in runtime_decls.rs.)
-        if name.starts_with("js_") {
+        //
+        // External `perry.nativeLibrary` packages commonly export their
+        // symbols with the same `js_*` prefix. If the manifest declares
+        // this name, let the native-library path below emit the call and
+        // declaration from `ffi_signatures` instead of treating it as a
+        // runtime builtin.
+        if name.starts_with("js_") && !ctx.ffi_signatures.contains_key(name) {
             let mut lowered: Vec<String> = Vec::with_capacity(args.len());
             for a in args {
                 lowered.push(lower_expr(ctx, a)?);

--- a/crates/perry/src/commands/native/init.rs
+++ b/crates/perry/src/commands/native/init.rs
@@ -242,4 +242,16 @@ mod tests {
         assert_eq!(y.len(), 4);
         assert!(y.chars().all(|c| c.is_ascii_digit()));
     }
+
+    #[test]
+    fn package_template_points_resolvers_at_ts_surface() {
+        assert!(TPL_PKG.contains(r#""main": "src/index.ts""#));
+        assert!(TPL_PKG.contains(r#""types": "src/index.ts""#));
+    }
+
+    #[test]
+    fn index_template_forwards_to_manifest_symbol() {
+        assert!(TPL_INDEX_TS.contains("declare function js_{{crate_name}}_hello"));
+        assert!(TPL_INDEX_TS.contains("return js_{{crate_name}}_hello(name);"));
+    }
 }

--- a/crates/perry/templates/native-package/README.md.tmpl
+++ b/crates/perry/templates/native-package/README.md.tmpl
@@ -27,7 +27,7 @@ console.log(hello("perry"));  // → "Hello, perry!"
 This package was scaffolded by `perry native init`. To add new bindings:
 
 1. Add a `js_<name>` function in `src/lib.rs` with `#[no_mangle] pub extern "C"`. Use only `perry_ffi` types — never reach into `perry-runtime` directly.
-2. Add the matching declaration to `src/index.ts` so user code can import it.
+2. Add the matching `declare function js_<name>(...)` to `src/index.ts`, then export a wrapper that calls that `js_*` symbol.
 3. Add the function to the `perry.nativeLibrary.functions[]` array in `package.json` so the Perry compiler knows the calling convention.
 4. Run `perry native validate` to confirm symbols + signatures match between the three.
 

--- a/crates/perry/templates/native-package/package.json.tmpl
+++ b/crates/perry/templates/native-package/package.json.tmpl
@@ -2,6 +2,8 @@
   "name": "{{npm_name}}",
   "version": "0.1.0",
   "description": "{{description}}",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/crates/perry/templates/native-package/src/index.ts.tmpl
+++ b/crates/perry/templates/native-package/src/index.ts.tmpl
@@ -1,16 +1,15 @@
 // TypeScript surface for `import { ... } from "{{npm_name}}"`.
 //
-// These declarations describe the FFI signatures user code calls;
-// at compile time Perry resolves them against the `functions[]`
-// block in package.json and links the staticlib directly. The bodies
-// here only run under V8 / Node fallback, never under perry-compiled
-// binaries.
+// Declare each FFI symbol listed in package.json, then export a
+// TypeScript-friendly wrapper that calls it explicitly. Perry keys FFI
+// dispatch on the call-site identifier, so the wrapper body must call
+// the `js_*` symbol named in `perry.nativeLibrary.functions[]`.
+
+declare function js_{{crate_name}}_hello(name: string): string;
 
 /**
  * Example binding. Replace with your own.
  */
 export function hello(name: string): string {
-  // The body is unreachable under perry — it links directly to
-  // `js_{{crate_name}}_hello` instead.
-  return `Hello, ${name}!`;
+  return js_{{crate_name}}_hello(name);
 }

--- a/crates/perry/templates/native-package/src/lib.rs.tmpl
+++ b/crates/perry/templates/native-package/src/lib.rs.tmpl
@@ -1,10 +1,10 @@
 //! Native bindings for {{description}}
 //!
-//! Skeleton emitted by `perry native init`. Each `js_*` function
-//! is what user TypeScript code resolves to via the
+//! Skeleton emitted by `perry native init`. Each TypeScript wrapper
+//! in `src/index.ts` should call a `js_*` symbol declared in the
 //! `perry.nativeLibrary` block in package.json. Add one
-//! `#[no_mangle] pub extern "C"` entry per binding and remove
-//! the `hello` example.
+//! `#[no_mangle] pub extern "C"` entry per binding and remove the
+//! `hello` example.
 
 use perry_ffi::{alloc_string, read_string, JsString, StringHeader};
 

--- a/docs/examples/_fixtures/native-libraries/my-bindings/package.json
+++ b/docs/examples/_fixtures/native-libraries/my-bindings/package.json
@@ -2,6 +2,8 @@
   "name": "my-bindings",
   "version": "0.1.0",
   "description": "Doc fixture backing the native-libraries authoring guide.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "license": "MIT",
   "private": true,
   "files": [

--- a/docs/examples/_fixtures/native-libraries/my-bindings/src/index.ts
+++ b/docs/examples/_fixtures/native-libraries/my-bindings/src/index.ts
@@ -1,7 +1,8 @@
+declare function js_pdf_parse(buf: Uint8Array): string;
+
 /**
  * Extract text from a PDF buffer.
  */
 export function parse(buf: Uint8Array): string {
-  // Unreachable under perry — links to js_pdf_parse instead.
-  throw new Error("Not implemented under V8 fallback");
+  return js_pdf_parse(buf);
 }

--- a/docs/src/native-libraries/authoring-guide.md
+++ b/docs/src/native-libraries/authoring-guide.md
@@ -44,7 +44,7 @@ my-bindings/
 
 ## 2. Add bindings
 
-Each TypeScript-visible function maps to one `extern "C"` Rust export.
+Each TypeScript-visible function should forward to one `extern "C"` Rust export.
 
 ### `src/lib.rs`
 
@@ -89,10 +89,10 @@ Key rules:
 
 ### `src/index.ts`
 
-Declare the TypeScript surface user code imports. Bodies here only
-run under V8 / Node fallback; Perry's compiler resolves the function
-calls directly to the `js_*` symbols at link time, never executing
-the TS body.
+Declare the FFI symbol from your manifest, then export the TypeScript
+surface user code imports. Perry's FFI dispatch keys on the call-site
+identifier, so the wrapper body must explicitly call the `js_*` symbol
+listed in `perry.nativeLibrary.functions[]`.
 
 ```typescript
 {{#include ../../examples/_fixtures/native-libraries/my-bindings/src/index.ts}}
@@ -108,6 +108,8 @@ The `perry.nativeLibrary` block tells Perry's compiler about every
 {
   "name": "my-bindings",
   "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "perry": {
     "nativeLibrary": {
       "abiVersion": "0.5",

--- a/tests/test_native_library_package_entry_forwarder.sh
+++ b/tests/test_native_library_package_entry_forwarder.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Regression: external native-library packages must be resolvable from the
+# package root and TypeScript exports must explicitly forward to manifest
+# `js_*` symbols. This mirrors the shape emitted by `perry native init`.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+
+if ! command -v cc >/dev/null 2>&1; then
+  echo "SKIP: cc not available"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+LIBDIR="$TMPDIR/node_modules/entry-test-lib"
+mkdir -p "$LIBDIR/src" "$LIBDIR/target/release"
+
+cat > "$LIBDIR/native.c" << 'EOF'
+double js_entry_test_answer(double value) {
+    return value + 1.0;
+}
+EOF
+
+cc -c "$LIBDIR/native.c" -o "$LIBDIR/native.o"
+ar rcs "$LIBDIR/target/release/libentry_test.a" "$LIBDIR/native.o"
+
+cat > "$LIBDIR/package.json" << 'EOF'
+{
+  "name": "entry-test-lib",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "perry": {
+    "nativeLibrary": {
+      "module": "entry-test-lib",
+      "functions": [
+        { "name": "js_entry_test_answer", "params": ["f64"], "returns": "f64" }
+      ],
+      "targets": {
+        "macos": { "crate": "", "lib": "libentry_test.a" },
+        "linux": { "crate": "", "lib": "libentry_test.a" }
+      }
+    }
+  }
+}
+EOF
+
+cat > "$LIBDIR/src/index.ts" << 'EOF'
+declare function js_entry_test_answer(value: number): number;
+
+export function answer(): number {
+  return js_entry_test_answer(41);
+}
+EOF
+
+cat > "$TMPDIR/main.ts" << 'EOF'
+import { answer } from "entry-test-lib";
+console.log("answer=" + answer());
+EOF
+
+cat > "$TMPDIR/package.json" << 'EOF'
+{
+  "name": "entry-test-app",
+  "version": "0.1.0",
+  "dependencies": { "entry-test-lib": "0.1.0" }
+}
+EOF
+
+cd "$TMPDIR"
+COMPILE_OUTPUT=$("$PERRY" compile main.ts --output test_bin --no-cache 2>&1) || {
+  echo "FAIL: compile error"
+  echo "$COMPILE_OUTPUT" | tail -20
+  exit 1
+}
+
+RUN_OUTPUT=$(./test_bin 2>&1)
+EXPECTED="answer=42"
+
+if [ "$RUN_OUTPUT" = "$EXPECTED" ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: package-root native binding did not call the FFI symbol"
+echo "Expected: $EXPECTED"
+echo "Got:      $RUN_OUTPUT"
+exit 1


### PR DESCRIPTION
## Summary

Closes #863. Takes Option A from the issue: fix the template, the docs fixture, and the authoring guide so a freshly-scaffolded `perry native init` package actually works end-to-end without manual edits.

## Changes

- **Template `package.json`** + **`my-bindings` fixture**: add `"main": "src/index.ts"` and `"types": "src/index.ts"`. Without these, no resolver in the npm ecosystem (Node, Bun, Deno, TS, esbuild, Perry) finds the entry point — Perry's `resolve_package_entry` only falls through to `<pkg>/index.{ts,…}`, never `<pkg>/src/index.ts`.
- **Template `src/index.ts`** + **fixture**: declare the manifest `js_*` symbol and forward the exported wrapper to it explicitly. Perry's FFI dispatch keys on the call-site identifier (`lower_call.rs`), and there is no rewrite layer that maps the TS export name to the manifest symbol. The previous template body returned a JS-fallback string, which is what produced the `Hello, undefined!` bug from #792.
- **`crates/perry-codegen/src/lower_call.rs`**: the `name.starts_with("js_")` shortcut that emits a direct runtime-builtin call now skips when `ffi_signatures` already declares the name, so manifest-declared `js_*` symbols route through the native-library path instead of colliding with the runtime builtin dispatch.
- **README + `authoring-guide.md`**: drop the inaccurate "Perry resolves the function calls directly to the `js_*` symbols at link time, never executing the TS body" wording. Document the explicit-forwarder pattern that matches what the compiler actually does today.
- **Tests**:
  - Unit tests in `init.rs` verifying the template contains the required `main`/`types` fields and the explicit forwarder.
  - `tests/test_native_library_package_entry_forwarder.sh`: builds a fake `entry-test-lib` native package with a real `.a`, scaffolds a consumer, compiles with `perry compile`, and asserts the FFI symbol is actually invoked (`answer=42`).

## Out of scope

Option B from the issue (teach the compiler to implicitly map TS export names to manifest `js_*` symbols, removing the need for the explicit forwarder) is left for a follow-up. Option A is sufficient to unbreak the scaffold and the docs fixture.

## Test plan

- [ ] `cargo test --release -p perry` (covers the new template unit tests)
- [ ] `bash tests/test_native_library_package_entry_forwarder.sh` prints `PASS`
- [ ] `perry native init demo && cd demo && cargo build --release`, then in a sibling dir `pnpm add ../demo` + `perry compile main.ts -o main && ./main` prints `Hello, world!` per the issue's validation plan.