### PR TITLE
feat(runtime): #789 — real async_hooks createHook lifecycle + asyncId tracking

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -536,11 +536,25 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("commander", "action", true, None),
     method("commander", "parse", true, None),
     method("commander", "opts", true, None),
+    method("async_hooks", "createHook", false, None),
+    method("async_hooks", "executionAsyncId", false, None),
+    method("async_hooks", "triggerAsyncId", false, None),
+    method("async_hooks", "enable", true, Some("AsyncHook")),
     method("async_hooks", "run", true, None),
     method("async_hooks", "getStore", true, None),
     method("async_hooks", "enterWith", true, None),
     method("async_hooks", "exit", true, None),
     method("async_hooks", "disable", true, None),
+    method("async_hooks", "asyncId", true, Some("AsyncResource")),
+    method("async_hooks", "triggerAsyncId", true, Some("AsyncResource")),
+    method("async_hooks", "emitDestroy", true, Some("AsyncResource")),
+    method(
+        "async_hooks",
+        "runInAsyncScope",
+        true,
+        Some("AsyncResource"),
+    ),
+    method("async_hooks", "bind", true, Some("AsyncResource")),
     // AsyncResource — Nest's `@nestjs/core` request-scoped DI uses
     // this to bind a callback to a synthetic async resource. The
     // stub in `node:async_hooks` JS module satisfies callers that

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -6675,7 +6675,12 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let cb_box = lower_expr(ctx, cb)?;
             let blk = ctx.block();
             let cb_handle = unbox_to_i64(blk, &cb_box);
-            blk.call_void("js_queue_microtask", &[(I64, &cb_handle)]);
+            let runtime = match expr {
+                Expr::QueueMicrotask(_) => "js_queue_microtask",
+                Expr::ProcessNextTick(_) => "js_queue_next_tick",
+                _ => unreachable!(),
+            };
+            blk.call_void(runtime, &[(I64, &cb_handle)]);
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }
 

--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -800,11 +800,7 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
                 if args.len() == 1 {
                     let blk = ctx.block();
                     let cb_handle = unbox_to_i64(blk, &cb_box);
-                    let id = blk.call(
-                        I64,
-                        "js_set_timeout_callback",
-                        &[(I64, &cb_handle), (DOUBLE, "0.0")],
-                    );
+                    let id = blk.call(I64, "js_set_immediate_callback", &[(I64, &cb_handle)]);
                     return Ok(nanbox_pointer_inline(blk, &id));
                 }
 
@@ -825,13 +821,8 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
                 let cb_handle = unbox_to_i64(blk, &cb_box);
                 let id = blk.call(
                     I64,
-                    "js_set_timeout_callback_args",
-                    &[
-                        (I64, &cb_handle),
-                        (DOUBLE, "0.0"),
-                        (PTR, &ptr_reg),
-                        (I32, &n.to_string()),
-                    ],
+                    "js_set_immediate_callback_args",
+                    &[(I64, &cb_handle), (PTR, &ptr_reg), (I32, &n.to_string())],
                 );
                 return Ok(nanbox_pointer_inline(blk, &id));
             }
@@ -7485,6 +7476,96 @@ const NATIVE_MODULE_TABLE: &[NativeModSig] = &[
         runtime: "js_async_local_storage_disable",
         args: &[],
         ret: NR_VOID,
+    },
+    NativeModSig {
+        module: "async_hooks",
+        has_receiver: false,
+        method: "createHook",
+        class_filter: None,
+        runtime: "js_async_hooks_create_hook",
+        args: &[NA_F64],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "async_hooks",
+        has_receiver: false,
+        method: "executionAsyncId",
+        class_filter: None,
+        runtime: "js_async_hooks_execution_async_id",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "async_hooks",
+        has_receiver: false,
+        method: "triggerAsyncId",
+        class_filter: None,
+        runtime: "js_async_hooks_trigger_async_id",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "async_hooks",
+        has_receiver: true,
+        method: "enable",
+        class_filter: Some("AsyncHook"),
+        runtime: "js_async_hook_enable",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "async_hooks",
+        has_receiver: true,
+        method: "disable",
+        class_filter: Some("AsyncHook"),
+        runtime: "js_async_hook_disable",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "async_hooks",
+        has_receiver: true,
+        method: "asyncId",
+        class_filter: Some("AsyncResource"),
+        runtime: "js_async_resource_async_id",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "async_hooks",
+        has_receiver: true,
+        method: "triggerAsyncId",
+        class_filter: Some("AsyncResource"),
+        runtime: "js_async_resource_trigger_async_id",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "async_hooks",
+        has_receiver: true,
+        method: "emitDestroy",
+        class_filter: Some("AsyncResource"),
+        runtime: "js_async_resource_emit_destroy",
+        args: &[],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "async_hooks",
+        has_receiver: true,
+        method: "runInAsyncScope",
+        class_filter: Some("AsyncResource"),
+        runtime: "js_async_resource_run_in_async_scope",
+        args: &[NA_PTR, NA_F64, NA_VARARGS],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "async_hooks",
+        has_receiver: true,
+        method: "bind",
+        class_filter: Some("AsyncResource"),
+        runtime: "js_async_resource_bind",
+        args: &[NA_PTR],
+        ret: NR_PTR,
     },
     // ========== decimal.js (arbitrary-precision math) ==========
     // `new Decimal(value)` is dispatched by `lower_builtin_new` (calls

--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -303,6 +303,25 @@ pub(super) fn lower_builtin_new(
             let handle = blk.call(I64, "js_async_local_storage_new", &[]);
             Ok(Some(nanbox_pointer_inline(blk, &handle)))
         }
+        "AsyncResource" => {
+            let type_value = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            let options_value = if let Some(arg) = args.get(1) {
+                lower_expr(ctx, arg)?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            let blk = ctx.block();
+            let handle = blk.call(
+                I64,
+                "js_async_resource_new",
+                &[(DOUBLE, &type_value), (DOUBLE, &options_value)],
+            );
+            Ok(Some(nanbox_pointer_inline(blk, &handle)))
+        }
         // decimal.js Decimal — `new Decimal(value)` where value is a number,
         // string, or another Decimal. Routes through `js_decimal_coerce_to_handle`
         // which NaN-decodes the JSValue and dispatches to `from_number` /

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -817,6 +817,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_text_decoder_decode_llvm", I64, &[DOUBLE]);
     // Microtask queue (queueMicrotask / process.nextTick).
     module.declare_function("js_queue_microtask", VOID, &[I64]);
+    module.declare_function("js_queue_next_tick", VOID, &[I64]);
     module.declare_function("js_drain_queued_microtasks", VOID, &[]);
     // Uint8Array constructor wrapper that flags the resulting buffer so the
     // formatter prints `Uint8Array(N) [ ... ]` instead of `<Buffer ...>`.
@@ -1118,6 +1119,12 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         "js_set_timeout_callback_args",
         I64,
         &[I64, DOUBLE, crate::types::PTR, I32],
+    );
+    module.declare_function("js_set_immediate_callback", I64, &[I64]);
+    module.declare_function(
+        "js_set_immediate_callback_args",
+        I64,
+        &[I64, crate::types::PTR, I32],
     );
     module.declare_function("setInterval", I64, &[I64, DOUBLE]);
     module.declare_function("clearTimeout", VOID, &[I64]);
@@ -1846,6 +1853,22 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_cron_validate", DOUBLE, &[I64]);
 
     // ========== async_hooks / AsyncLocalStorage ==========
+    module.declare_function("js_async_hooks_create_hook", I64, &[DOUBLE]);
+    module.declare_function("js_async_hooks_execution_async_id", DOUBLE, &[]);
+    module.declare_function("js_async_hooks_trigger_async_id", DOUBLE, &[]);
+    module.declare_function("js_async_hook_enable", I64, &[I64]);
+    module.declare_function("js_async_hook_disable", I64, &[I64]);
+    module.declare_function("js_async_resource_new", I64, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_async_resource_async_id", DOUBLE, &[I64]);
+    module.declare_function("js_async_resource_trigger_async_id", DOUBLE, &[I64]);
+    module.declare_function("js_async_resource_emit_destroy", I64, &[I64]);
+    module.declare_function(
+        "js_async_resource_run_in_async_scope",
+        DOUBLE,
+        &[I64, I64, DOUBLE, I64],
+    );
+    module.declare_function("js_async_resource_bind", I64, &[I64, I64]);
+    module.declare_function("js_async_resource_static_bind", I64, &[I64, DOUBLE]);
     module.declare_function("js_async_local_storage_disable", VOID, &[I64]);
     module.declare_function("js_async_local_storage_enter_with", VOID, &[I64, DOUBLE]);
     module.declare_function("js_async_local_storage_exit", DOUBLE, &[I64, I64]);

--- a/crates/perry-hir/src/destructuring.rs
+++ b/crates/perry-hir/src/destructuring.rs
@@ -1233,6 +1233,7 @@ pub(crate) fn lower_var_decl_with_destructuring(
                             match class_name {
                                 "EventEmitter" => Some("events".to_string()),
                                 "AsyncLocalStorage" => Some("async_hooks".to_string()),
+                                "AsyncResource" => Some("async_hooks".to_string()),
                                 "WebSocket" | "WebSocketServer" => Some("ws".to_string()),
                                 "Redis" => Some("ioredis".to_string()),
                                 "LRUCache" => Some("lru-cache".to_string()),
@@ -1249,6 +1250,28 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                 module,
                                 class_name.to_string(),
                             );
+                        }
+                    } else if let ast::Expr::Member(member) = new_expr.callee.as_ref() {
+                        if let (
+                            ast::Expr::Ident(module_ident),
+                            ast::MemberProp::Ident(class_ident),
+                        ) = (member.obj.as_ref(), &member.prop)
+                        {
+                            let module_alias = module_ident.sym.as_ref();
+                            if let Some((module_name, _)) = ctx.lookup_native_module(module_alias) {
+                                let class_name = class_ident.sym.as_ref();
+                                let is_known_native_class = matches!(
+                                    (module_name, class_name),
+                                    ("async_hooks", "AsyncLocalStorage" | "AsyncResource")
+                                );
+                                if is_known_native_class {
+                                    ctx.register_native_instance(
+                                        name.clone(),
+                                        module_name.to_string(),
+                                        class_name.to_string(),
+                                    );
+                                }
+                            }
                         }
                     }
                 }
@@ -1277,6 +1300,7 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                     match class_name {
                                         "EventEmitter" => Some("events".to_string()),
                                         "AsyncLocalStorage" => Some("async_hooks".to_string()),
+                                        "AsyncResource" => Some("async_hooks".to_string()),
                                         "WebSocket" | "WebSocketServer" => Some("ws".to_string()),
                                         "Redis" => Some("ioredis".to_string()),
                                         "LRUCache" => Some("lru-cache".to_string()),
@@ -1312,6 +1336,7 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                         let method_name = method_ident.sym.as_ref();
                                         // Map factory functions to their class names
                                         let class_name = match (module_name, method_name) {
+                                            ("async_hooks", "createHook") => Some("AsyncHook"),
                                             ("mysql2" | "mysql2/promise", "createPool") => {
                                                 Some("Pool")
                                             }
@@ -1459,6 +1484,7 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                     ("http", "createServer") => Some("HttpServer"),
                                     ("https", "createServer") => Some("HttpsServer"),
                                     ("http2", "createSecureServer") => Some("Http2SecureServer"),
+                                    ("async_hooks", "createHook") => Some("AsyncHook"),
                                     _ => None,
                                 };
                                 if let Some(cn) = http_class {

--- a/crates/perry-hir/src/lower.rs
+++ b/crates/perry-hir/src/lower.rs
@@ -4214,28 +4214,6 @@ See docs/src/language/decorators.md."
     );
 }
 
-/// Emit a one-shot note when the user imports `node:async_hooks`. Perry
-/// ships a structural stub (see crates/perry-jsruntime/src/modules.rs)
-/// now has real AsyncLocalStorage propagation, but the observability
-/// half of async_hooks (createHook lifecycle and real async IDs) is still
-/// tracked separately in #789. Warning at compile time keeps APM/tracing
-/// users from mistaking the remaining stub surface for full Node parity.
-fn emit_async_hooks_shim_note() {
-    use std::sync::atomic::{AtomicBool, Ordering};
-    static EMITTED: AtomicBool = AtomicBool::new(false);
-    if EMITTED.swap(true, Ordering::Relaxed) {
-        return;
-    }
-    eprintln!(
-        "[perry] note: `import \"node:async_hooks\"` is satisfied by Perry's structural \
-stub plus AsyncLocalStorage context propagation across await/microtasks/timers. \
-Remaining gap: createHook lifecycle callbacks and real executionAsyncId/\
-triggerAsyncId tracking are still stubs, so APM/tracing tools that observe \
-async resource lifecycles are not fully supported yet. See \
-https://github.com/PerryTS/perry/issues/789."
-    );
-}
-
 fn lower_module_decl(
     ctx: &mut LoweringContext,
     module: &mut Module,
@@ -4254,13 +4232,6 @@ fn lower_module_decl(
             if source == "reflect-metadata" {
                 emit_reflect_metadata_shim_note();
                 return Ok(());
-            }
-
-            if source == "async_hooks" {
-                emit_async_hooks_shim_note();
-                // Fall through — the import still needs to bind
-                // AsyncLocalStorage / AsyncResource so calling code
-                // compiles against the structural stub.
             }
 
             // Check if this is a native module import
@@ -4484,6 +4455,7 @@ fn lower_module_decl(
                                         match class_name {
                                             "EventEmitter" => Some("events".to_string()),
                                             "AsyncLocalStorage" => Some("async_hooks".to_string()),
+                                            "AsyncResource" => Some("async_hooks".to_string()),
                                             "WebSocket" | "WebSocketServer" => {
                                                 Some("ws".to_string())
                                             }
@@ -4532,6 +4504,7 @@ fn lower_module_decl(
                                                 "AsyncLocalStorage" => {
                                                     Some("async_hooks".to_string())
                                                 }
+                                                "AsyncResource" => Some("async_hooks".to_string()),
                                                 "WebSocket" | "WebSocketServer" => {
                                                     Some("ws".to_string())
                                                 }
@@ -4619,6 +4592,9 @@ fn lower_module_decl(
                                                         ("http2", "createSecureServer") => {
                                                             Some("Http2SecureServer")
                                                         }
+                                                        ("async_hooks", "createHook") => {
+                                                            Some("AsyncHook")
+                                                        }
                                                         _ => None,
                                                     };
                                                     if let Some(class_name) = class_name {
@@ -4692,6 +4668,9 @@ fn lower_module_decl(
                                                 }
                                                 ("http2", Some("createSecureServer")) => {
                                                     Some("Http2SecureServer")
+                                                }
+                                                ("async_hooks", Some("createHook")) => {
+                                                    Some("AsyncHook")
                                                 }
                                                 _ => None,
                                             });
@@ -4793,6 +4772,39 @@ fn lower_module_decl(
                                             module_name,
                                             class_name_str.to_string(),
                                         ));
+                                    }
+                                } else if let ast::Expr::Member(member) = new_expr.callee.as_ref() {
+                                    if let (
+                                        ast::Expr::Ident(module_ident),
+                                        ast::MemberProp::Ident(class_ident),
+                                    ) = (member.obj.as_ref(), &member.prop)
+                                    {
+                                        let module_alias = module_ident.sym.as_ref();
+                                        if let Some(module_name) = ctx
+                                            .lookup_native_module(module_alias)
+                                            .map(|(m, _)| m.to_string())
+                                        {
+                                            let class_name_str = class_ident.sym.as_ref();
+                                            let is_known_native_class = matches!(
+                                                (module_name.as_str(), class_name_str),
+                                                (
+                                                    "async_hooks",
+                                                    "AsyncLocalStorage" | "AsyncResource"
+                                                )
+                                            );
+                                            if is_known_native_class {
+                                                ctx.register_native_instance(
+                                                    name.clone(),
+                                                    module_name.clone(),
+                                                    class_name_str.to_string(),
+                                                );
+                                                ctx.module_native_instances.push((
+                                                    name.clone(),
+                                                    module_name,
+                                                    class_name_str.to_string(),
+                                                ));
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -6318,6 +6330,7 @@ fn lower_stmt(ctx: &mut LoweringContext, module: &mut Module, stmt: &ast::Stmt) 
                                     ("http", "createServer") => Some("HttpServer"),
                                     ("https", "createServer") => Some("HttpsServer"),
                                     ("http2", "createSecureServer") => Some("Http2SecureServer"),
+                                    ("async_hooks", "createHook") => Some("AsyncHook"),
                                     _ => None,
                                 };
                                 if let Some(cn) = http_class {
@@ -8196,6 +8209,26 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                             if (obj_name == "Object" && is_known_object_static_method(prop_name))
                                 || (obj_name == "Array" && is_known_array_static_method(prop_name))
                             {
+                                return Ok(Expr::String("function".to_string()));
+                            }
+                            if matches!(
+                                ctx.lookup_native_instance(obj_name),
+                                Some(("async_hooks", "AsyncHook"))
+                            ) && matches!(prop_name, "enable" | "disable")
+                            {
+                                return Ok(Expr::String("function".to_string()));
+                            }
+                            if matches!(
+                                ctx.lookup_native_instance(obj_name),
+                                Some(("async_hooks", "AsyncResource"))
+                            ) && matches!(
+                                prop_name,
+                                "asyncId"
+                                    | "triggerAsyncId"
+                                    | "runInAsyncScope"
+                                    | "emitDestroy"
+                                    | "bind"
+                            ) {
                                 return Ok(Expr::String("function".to_string()));
                             }
                             // #677: `typeof Function.prototype` → "object".

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -56,6 +56,30 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     args,
                 });
             }
+            let module_alias = obj_ident.sym.as_ref();
+            if let Some((module_name, _)) = ctx.lookup_native_module(module_alias) {
+                let class_name = prop_ident.sym.as_ref();
+                if matches!(
+                    (module_name, class_name),
+                    ("async_hooks", "AsyncLocalStorage" | "AsyncResource")
+                ) {
+                    let args = new_expr
+                        .args
+                        .as_ref()
+                        .map(|args| {
+                            args.iter()
+                                .map(|a| lower_expr(ctx, &a.expr))
+                                .collect::<Result<Vec<_>>>()
+                        })
+                        .transpose()?
+                        .unwrap_or_default();
+                    return Ok(Expr::New {
+                        class_name: class_name.to_string(),
+                        args,
+                        type_args: Vec::new(),
+                    });
+                }
+            }
         }
     }
 

--- a/crates/perry-hir/src/lower_decl.rs
+++ b/crates/perry-hir/src/lower_decl.rs
@@ -991,109 +991,111 @@ pub(crate) fn lower_class_decl(
     ctx.enter_type_param_scope(&type_params);
 
     // Handle extends clause
-    let (extends, extends_name, native_extends, extends_expr) =
-        if let Some(ref super_class) = class_decl.class.super_class {
-            if let ast::Expr::Ident(ident) = super_class.as_ref() {
-                let parent_name = ident.sym.to_string();
-                // First check if it's a native module class
-                let native_parent = match parent_name.as_str() {
-                    "EventEmitter" => Some(("events".to_string(), "EventEmitter".to_string())),
-                    "AsyncLocalStorage" => {
-                        Some(("async_hooks".to_string(), "AsyncLocalStorage".to_string()))
-                    }
-                    "WebSocketServer" => Some(("ws".to_string(), "WebSocketServer".to_string())),
-                    // Issue #562: user classes extending the Web Streams
-                    // base classes get a runtime-side subclass-init shim
-                    // wired through `Expr::SuperCall` (codegen). The
-                    // `extends_name` is also retained so the existing
-                    // `native_extends.is_some()` branch below still
-                    // populates it for the inheritance walks elsewhere
-                    // (vtable, hasOwn, etc.) that key on the parent name.
-                    "ReadableStream" => {
-                        Some(("readable_stream".to_string(), "ReadableStream".to_string()))
-                    }
-                    "WritableStream" => {
-                        Some(("writable_stream".to_string(), "WritableStream".to_string()))
-                    }
-                    "TransformStream" => Some((
-                        "transform_stream".to_string(),
-                        "TransformStream".to_string(),
-                    )),
-                    _ => None,
-                };
-                if native_parent.is_some() {
-                    // Keep `extends_name` populated alongside `native_extends`
-                    // so SuperCall codegen + downstream chain walks still
-                    // see the parent name (mirrors how stream-class
-                    // dispatch resolves through the existing extends_name
-                    // path while the native_extends carries the (module,
-                    // class) tag for the runtime shim).
-                    (None, Some(parent_name), native_parent, None)
-                } else {
-                    let parent_cid = ctx.lookup_class(&parent_name);
-                    if parent_cid.is_none() {
-                        // Issue #711 part 2: the Ident doesn't resolve to
-                        // any known class. The common case is Effect's
-                        // `const Base = (function() { function Base(){}; Base.prototype = X; return Base })()` pattern —
-                        // `Base` is a function value with a prototype
-                        // object attached via `js_set_function_prototype`.
-                        // Capture the Ident as `extends_expr` so the
-                        // dynamic parent-registration helper can resolve
-                        // it through `function_class_id` at runtime.
-                        // `extends_name` stays populated for the rare
-                        // cases where downstream code paths key on the
-                        // textual parent name (super-call codegen, etc.)
-                        // but extends_expr takes precedence on the
-                        // method-dispatch path.
-                        match lower_expr(ctx, super_class) {
-                            Ok(expr) => (None, Some(parent_name), None, Some(Box::new(expr))),
-                            Err(_) => (None, Some(parent_name), None, None),
-                        }
-                    } else {
-                        // Always capture the parent name for imported classes that may not have a ClassId
-                        (parent_cid, Some(parent_name), None, None)
-                    }
+    let (extends, extends_name, native_extends, extends_expr) = if let Some(ref super_class) =
+        class_decl.class.super_class
+    {
+        if let ast::Expr::Ident(ident) = super_class.as_ref() {
+            let parent_name = ident.sym.to_string();
+            // First check if it's a native module class
+            let native_parent = match parent_name.as_str() {
+                "EventEmitter" => Some(("events".to_string(), "EventEmitter".to_string())),
+                "AsyncLocalStorage" => {
+                    Some(("async_hooks".to_string(), "AsyncLocalStorage".to_string()))
                 }
-            } else if let ast::Expr::Member(member) = super_class.as_ref() {
-                // Handle member expression like ethers.JsonRpcProvider or module.ClassName
-                let parent_name = extract_member_class_name(member);
-                // Refs #488 drizzle-sqlite: also try resolving the parent
-                // class by name across modules. Pre-fix the Member arm set
-                // `extends = None`, so `class SQLiteIntegerBuilder extends
-                // import_mid.SQLiteColumnBuilder { ... }` lost its parent
-                // link entirely — inherited methods (drizzle's
-                // ColumnBuilder.setName etc.) were unreachable on instances.
-                // Class names are unique enough in practice that `lookup_class`
-                // resolves; if it doesn't, we fall back to the prior
-                // name-only behavior (no regression for unknown parents).
-                (
-                    ctx.lookup_class(&parent_name),
-                    Some(parent_name),
-                    None,
-                    None,
-                )
+                "AsyncResource" => Some(("async_hooks".to_string(), "AsyncResource".to_string())),
+                "WebSocketServer" => Some(("ws".to_string(), "WebSocketServer".to_string())),
+                // Issue #562: user classes extending the Web Streams
+                // base classes get a runtime-side subclass-init shim
+                // wired through `Expr::SuperCall` (codegen). The
+                // `extends_name` is also retained so the existing
+                // `native_extends.is_some()` branch below still
+                // populates it for the inheritance walks elsewhere
+                // (vtable, hasOwn, etc.) that key on the parent name.
+                "ReadableStream" => {
+                    Some(("readable_stream".to_string(), "ReadableStream".to_string()))
+                }
+                "WritableStream" => {
+                    Some(("writable_stream".to_string(), "WritableStream".to_string()))
+                }
+                "TransformStream" => Some((
+                    "transform_stream".to_string(),
+                    "TransformStream".to_string(),
+                )),
+                _ => None,
+            };
+            if native_parent.is_some() {
+                // Keep `extends_name` populated alongside `native_extends`
+                // so SuperCall codegen + downstream chain walks still
+                // see the parent name (mirrors how stream-class
+                // dispatch resolves through the existing extends_name
+                // path while the native_extends carries the (module,
+                // class) tag for the runtime shim).
+                (None, Some(parent_name), native_parent, None)
             } else {
-                // Issue #711: `class X extends fn(...)` / `class X extends
-                // new Foo(...)` etc. The super-class expression isn't
-                // statically resolvable to a known class. Lower the
-                // expression so codegen can evaluate it at the class
-                // declaration site and call
-                // `js_register_class_parent_dynamic` to wire the parent
-                // edge into CLASS_REGISTRY at runtime. Both `extends` and
-                // `extends_name` stay None — the parent class_id is only
-                // known once the expression evaluates. Lowering errors
-                // here are non-fatal: fall back to a parentless class so
-                // the rest of the program still compiles (the
-                // method-dispatch catch-all in object.rs surfaces the
-                // missing-method case clearly enough).
-                match lower_expr(ctx, super_class) {
-                    Ok(expr) => (None, None, None, Some(Box::new(expr))),
-                    Err(_) => (None, None, None, None),
+                let parent_cid = ctx.lookup_class(&parent_name);
+                if parent_cid.is_none() {
+                    // Issue #711 part 2: the Ident doesn't resolve to
+                    // any known class. The common case is Effect's
+                    // `const Base = (function() { function Base(){}; Base.prototype = X; return Base })()` pattern —
+                    // `Base` is a function value with a prototype
+                    // object attached via `js_set_function_prototype`.
+                    // Capture the Ident as `extends_expr` so the
+                    // dynamic parent-registration helper can resolve
+                    // it through `function_class_id` at runtime.
+                    // `extends_name` stays populated for the rare
+                    // cases where downstream code paths key on the
+                    // textual parent name (super-call codegen, etc.)
+                    // but extends_expr takes precedence on the
+                    // method-dispatch path.
+                    match lower_expr(ctx, super_class) {
+                        Ok(expr) => (None, Some(parent_name), None, Some(Box::new(expr))),
+                        Err(_) => (None, Some(parent_name), None, None),
+                    }
+                } else {
+                    // Always capture the parent name for imported classes that may not have a ClassId
+                    (parent_cid, Some(parent_name), None, None)
                 }
             }
+        } else if let ast::Expr::Member(member) = super_class.as_ref() {
+            // Handle member expression like ethers.JsonRpcProvider or module.ClassName
+            let parent_name = extract_member_class_name(member);
+            // Refs #488 drizzle-sqlite: also try resolving the parent
+            // class by name across modules. Pre-fix the Member arm set
+            // `extends = None`, so `class SQLiteIntegerBuilder extends
+            // import_mid.SQLiteColumnBuilder { ... }` lost its parent
+            // link entirely — inherited methods (drizzle's
+            // ColumnBuilder.setName etc.) were unreachable on instances.
+            // Class names are unique enough in practice that `lookup_class`
+            // resolves; if it doesn't, we fall back to the prior
+            // name-only behavior (no regression for unknown parents).
+            (
+                ctx.lookup_class(&parent_name),
+                Some(parent_name),
+                None,
+                None,
+            )
         } else {
-            (None, None, None, None)
-        };
+            // Issue #711: `class X extends fn(...)` / `class X extends
+            // new Foo(...)` etc. The super-class expression isn't
+            // statically resolvable to a known class. Lower the
+            // expression so codegen can evaluate it at the class
+            // declaration site and call
+            // `js_register_class_parent_dynamic` to wire the parent
+            // edge into CLASS_REGISTRY at runtime. Both `extends` and
+            // `extends_name` stay None — the parent class_id is only
+            // known once the expression evaluates. Lowering errors
+            // here are non-fatal: fall back to a parentless class so
+            // the rest of the program still compiles (the
+            // method-dispatch catch-all in object.rs surfaces the
+            // missing-method case clearly enough).
+            match lower_expr(ctx, super_class) {
+                Ok(expr) => (None, None, None, Some(Box::new(expr))),
+                Err(_) => (None, None, None, None),
+            }
+        }
+    } else {
+        (None, None, None, None)
+    };
 
     // First pass: collect static field/method names for early registration
     // This allows static method bodies to reference static fields
@@ -1744,74 +1746,76 @@ pub(crate) fn lower_class_from_ast(
 
     ctx.enter_type_param_scope(&type_params);
 
-    let (extends, extends_name, native_extends, extends_expr) =
-        if let Some(ref super_class) = class.super_class {
-            if let ast::Expr::Ident(ident) = super_class.as_ref() {
-                let parent_name = ident.sym.to_string();
-                let native_parent = match parent_name.as_str() {
-                    "EventEmitter" => Some(("events".to_string(), "EventEmitter".to_string())),
-                    "AsyncLocalStorage" => {
-                        Some(("async_hooks".to_string(), "AsyncLocalStorage".to_string()))
-                    }
-                    "WebSocketServer" => Some(("ws".to_string(), "WebSocketServer".to_string())),
-                    // Issue #562: keep in lockstep with the parallel arm in
-                    // `lower_class_decl` above.
-                    "ReadableStream" => {
-                        Some(("readable_stream".to_string(), "ReadableStream".to_string()))
-                    }
-                    "WritableStream" => {
-                        Some(("writable_stream".to_string(), "WritableStream".to_string()))
-                    }
-                    "TransformStream" => Some((
-                        "transform_stream".to_string(),
-                        "TransformStream".to_string(),
-                    )),
-                    _ => None,
-                };
-                if native_parent.is_some() {
-                    (None, Some(parent_name), native_parent, None)
-                } else {
-                    let parent_cid = ctx.lookup_class(&parent_name);
-                    if parent_cid.is_none() {
-                        // Issue #711 part 2: see the parallel arm in
-                        // `lower_class_decl` above. Unknown Ident super-class
-                        // falls through to extends_expr capture so a
-                        // function-with-prototype value can be resolved at
-                        // runtime via `function_class_id`.
-                        match lower_expr(ctx, super_class) {
-                            Ok(expr) => (None, Some(parent_name), None, Some(Box::new(expr))),
-                            Err(_) => (None, Some(parent_name), None, None),
-                        }
-                    } else {
-                        (parent_cid, Some(parent_name), None, None)
-                    }
+    let (extends, extends_name, native_extends, extends_expr) = if let Some(ref super_class) =
+        class.super_class
+    {
+        if let ast::Expr::Ident(ident) = super_class.as_ref() {
+            let parent_name = ident.sym.to_string();
+            let native_parent = match parent_name.as_str() {
+                "EventEmitter" => Some(("events".to_string(), "EventEmitter".to_string())),
+                "AsyncLocalStorage" => {
+                    Some(("async_hooks".to_string(), "AsyncLocalStorage".to_string()))
                 }
-            } else if let ast::Expr::Member(member) = super_class.as_ref() {
-                // Refs #488 drizzle-sqlite: try cross-module class lookup. See
-                // the matching arm in `lower_class_decl` (above) for the full
-                // rationale — without this, the parent link is lost and
-                // inherited methods don't reach instances.
-                let parent_name = extract_member_class_name(member);
-                (
-                    ctx.lookup_class(&parent_name),
-                    Some(parent_name),
-                    None,
-                    None,
-                )
+                "AsyncResource" => Some(("async_hooks".to_string(), "AsyncResource".to_string())),
+                "WebSocketServer" => Some(("ws".to_string(), "WebSocketServer".to_string())),
+                // Issue #562: keep in lockstep with the parallel arm in
+                // `lower_class_decl` above.
+                "ReadableStream" => {
+                    Some(("readable_stream".to_string(), "ReadableStream".to_string()))
+                }
+                "WritableStream" => {
+                    Some(("writable_stream".to_string(), "WritableStream".to_string()))
+                }
+                "TransformStream" => Some((
+                    "transform_stream".to_string(),
+                    "TransformStream".to_string(),
+                )),
+                _ => None,
+            };
+            if native_parent.is_some() {
+                (None, Some(parent_name), native_parent, None)
             } else {
-                // Issue #711: see the matching arm in `lower_class_decl` above
-                // for the full rationale. Capture the lowered extends
-                // expression so codegen can evaluate it at the class
-                // declaration site and call
-                // `js_register_class_parent_dynamic` at runtime.
-                match lower_expr(ctx, super_class) {
-                    Ok(expr) => (None, None, None, Some(Box::new(expr))),
-                    Err(_) => (None, None, None, None),
+                let parent_cid = ctx.lookup_class(&parent_name);
+                if parent_cid.is_none() {
+                    // Issue #711 part 2: see the parallel arm in
+                    // `lower_class_decl` above. Unknown Ident super-class
+                    // falls through to extends_expr capture so a
+                    // function-with-prototype value can be resolved at
+                    // runtime via `function_class_id`.
+                    match lower_expr(ctx, super_class) {
+                        Ok(expr) => (None, Some(parent_name), None, Some(Box::new(expr))),
+                        Err(_) => (None, Some(parent_name), None, None),
+                    }
+                } else {
+                    (parent_cid, Some(parent_name), None, None)
                 }
             }
+        } else if let ast::Expr::Member(member) = super_class.as_ref() {
+            // Refs #488 drizzle-sqlite: try cross-module class lookup. See
+            // the matching arm in `lower_class_decl` (above) for the full
+            // rationale — without this, the parent link is lost and
+            // inherited methods don't reach instances.
+            let parent_name = extract_member_class_name(member);
+            (
+                ctx.lookup_class(&parent_name),
+                Some(parent_name),
+                None,
+                None,
+            )
         } else {
-            (None, None, None, None)
-        };
+            // Issue #711: see the matching arm in `lower_class_decl` above
+            // for the full rationale. Capture the lowered extends
+            // expression so codegen can evaluate it at the class
+            // declaration site and call
+            // `js_register_class_parent_dynamic` at runtime.
+            match lower_expr(ctx, super_class) {
+                Ok(expr) => (None, None, None, Some(Box::new(expr))),
+                Err(_) => (None, None, None, None),
+            }
+        }
+    } else {
+        (None, None, None, None)
+    };
 
     let mut static_field_names = Vec::new();
     let mut static_method_names = Vec::new();

--- a/crates/perry-jsruntime/src/modules.rs
+++ b/crates/perry-jsruntime/src/modules.rs
@@ -1085,16 +1085,95 @@ export function createInflate() { throw new Error('zlib.createInflate not suppor
 export default { gzip, gunzip, gzipSync, gunzipSync, deflate, inflate, deflateSync, inflateSync, brotliCompress, brotliDecompress, brotliCompressSync, brotliDecompressSync, createGzip, createGunzip, createDeflate, createInflate };
 "#.to_string(),
         "async_hooks" => r#"
-// Stub implementation for Node.js 'async_hooks' module
-// Used by @nestjs/core for request-scoped DI context propagation (PR #754).
-// No real async-context tracking here: each AsyncResource is a thin
-// wrapper that just runs the callback in the current context.
+// Lightweight implementation for Node.js 'async_hooks' module.
+// This is intentionally self-contained because built-in modules are loaded as
+// synthetic ESM sources by perry-jsruntime. It models the public lifecycle
+// enough for tracers that use createHook(), AsyncResource, and async ids.
+let __perryNextAsyncId = 1;
+let __perryExecutionAsyncId = 0;
+let __perryTriggerAsyncId = 0;
+let __perryInHookCallback = false;
+const __perryExecutionStack = [];
+const __perryHooks = [];
+
+function __perryEnabledHooks() {
+    return __perryHooks.filter((hook) => hook && hook.enabled);
+}
+
+function __perryEmit(name, ...args) {
+    if (__perryInHookCallback) return;
+    const enabled = __perryEnabledHooks();
+    if (enabled.length === 0) return;
+    __perryInHookCallback = true;
+    try {
+        for (const hook of enabled) {
+            const cb = hook.callbacks && hook.callbacks[name];
+            if (typeof cb === "function") cb(...args);
+        }
+    } finally {
+        __perryInHookCallback = false;
+    }
+}
+
+function __perryEnter(asyncId, triggerAsyncId) {
+    __perryExecutionStack.push([__perryExecutionAsyncId, __perryTriggerAsyncId]);
+    __perryExecutionAsyncId = asyncId;
+    __perryTriggerAsyncId = triggerAsyncId;
+    __perryEmit("before", asyncId);
+}
+
+function __perryLeave(asyncId) {
+    try {
+        __perryEmit("after", asyncId);
+    } finally {
+        const previous = __perryExecutionStack.pop() || [0, 0];
+        __perryExecutionAsyncId = previous[0];
+        __perryTriggerAsyncId = previous[1];
+    }
+}
+
+function __perryAllocateResource(type, resource, triggerAsyncId = __perryExecutionAsyncId) {
+    const asyncId = __perryNextAsyncId++;
+    __perryEmit("init", asyncId, String(type || "AsyncResource"), triggerAsyncId, resource);
+    return { asyncId, triggerAsyncId, destroyed: false };
+}
+
+function __perryDestroy(state) {
+    if (!state || state.destroyed) return;
+    state.destroyed = true;
+    __perryEmit("destroy", state.asyncId);
+}
+
+function __perryWrapCallback(type, callback) {
+    if (typeof callback !== "function") return callback;
+    const state = __perryAllocateResource(type, callback);
+    return function (...args) {
+        __perryEnter(state.asyncId, state.triggerAsyncId);
+        try {
+            return callback.apply(this, args);
+        } finally {
+            __perryLeave(state.asyncId);
+            __perryDestroy(state);
+        }
+    };
+}
+
 export class AsyncResource {
-    constructor(_type, _options) {}
-    runInAsyncScope(fn, thisArg, ...args) { return fn.apply(thisArg, args); }
-    emitDestroy() { return this; }
-    asyncId() { return 0; }
-    triggerAsyncId() { return 0; }
+    constructor(type, options = {}) {
+        const triggerAsyncId = options && Object.prototype.hasOwnProperty.call(options, "triggerAsyncId")
+            ? Number(options.triggerAsyncId)
+            : __perryExecutionAsyncId;
+        this.__perryAsyncState = __perryAllocateResource(type || "AsyncResource", this, triggerAsyncId);
+    }
+    runInAsyncScope(fn, thisArg, ...args) {
+        const state = this.__perryAsyncState;
+        __perryEnter(state.asyncId, state.triggerAsyncId);
+        try { return fn.apply(thisArg, args); }
+        finally { __perryLeave(state.asyncId); }
+    }
+    emitDestroy() { __perryDestroy(this.__perryAsyncState); return this; }
+    asyncId() { return this.__perryAsyncState.asyncId; }
+    triggerAsyncId() { return this.__perryAsyncState.triggerAsyncId; }
     bind(fn) {
         const ar = this;
         return function (...args) { return ar.runInAsyncScope(fn, this, ...args); };
@@ -1104,6 +1183,7 @@ export class AsyncResource {
         return ar.bind(thisArg !== undefined ? fn.bind(thisArg) : fn);
     }
 }
+
 export class AsyncLocalStorage {
     constructor() { this._store = undefined; }
     run(store, fn, ...args) {
@@ -1120,10 +1200,75 @@ export class AsyncLocalStorage {
     enterWith(store) { this._store = store; }
     disable() { this._store = undefined; }
 }
-export function executionAsyncId() { return 0; }
+
+export function executionAsyncId() { return __perryExecutionAsyncId; }
 export function executionAsyncResource() { return {}; }
-export function triggerAsyncId() { return 0; }
-export function createHook() { return { enable() { return this; }, disable() { return this; } }; }
+export function triggerAsyncId() { return __perryTriggerAsyncId; }
+export function createHook(callbacks = {}) {
+    const hook = {
+        callbacks,
+        enabled: false,
+        enable() {
+            if (!__perryHooks.includes(hook)) __perryHooks.push(hook);
+            hook.enabled = true;
+            return hook;
+        },
+        disable() { hook.enabled = false; return hook; },
+    };
+    return hook;
+}
+
+const __perryNativeSetTimeout = globalThis.setTimeout;
+if (typeof __perryNativeSetTimeout === "function" && !__perryNativeSetTimeout.__perryAsyncHooksWrapped) {
+    const wrapped = function (callback, delay, ...args) {
+        return __perryNativeSetTimeout.call(this, __perryWrapCallback("Timeout", callback), delay, ...args);
+    };
+    wrapped.__perryAsyncHooksWrapped = true;
+    globalThis.setTimeout = wrapped;
+}
+
+const __perryNativeSetImmediate = globalThis.setImmediate;
+if (typeof __perryNativeSetImmediate === "function" && !__perryNativeSetImmediate.__perryAsyncHooksWrapped) {
+    const wrapped = function (callback, ...args) {
+        return __perryNativeSetImmediate.call(this, __perryWrapCallback("Immediate", callback), ...args);
+    };
+    wrapped.__perryAsyncHooksWrapped = true;
+    globalThis.setImmediate = wrapped;
+}
+
+if (globalThis.process && typeof globalThis.process.nextTick === "function" && !globalThis.process.nextTick.__perryAsyncHooksWrapped) {
+    const nativeNextTick = globalThis.process.nextTick;
+    const wrapped = function (callback, ...args) {
+        return nativeNextTick.call(this, __perryWrapCallback("TickObject", callback), ...args);
+    };
+    wrapped.__perryAsyncHooksWrapped = true;
+    globalThis.process.nextTick = wrapped;
+}
+
+const __perryNativePromise = globalThis.Promise;
+if (typeof __perryNativePromise === "function" && !__perryNativePromise.__perryAsyncHooksWrapped) {
+    class PerryAsyncHookPromise extends __perryNativePromise {
+        constructor(executor) {
+            let state;
+            super((resolve, reject) => {
+                state = __perryAllocateResource("PROMISE", undefined);
+                const settle = (fn) => (value) => {
+                    if (!state.destroyed) {
+                        __perryEmit("promiseResolve", state.asyncId);
+                        __perryDestroy(state);
+                    }
+                    return fn(value);
+                };
+                return executor(settle(resolve), settle(reject));
+            });
+            this.__perryAsyncState = state;
+        }
+        static get [Symbol.species]() { return __perryNativePromise; }
+    }
+    PerryAsyncHookPromise.__perryAsyncHooksWrapped = true;
+    globalThis.Promise = PerryAsyncHookPromise;
+}
+
 export default { AsyncResource, AsyncLocalStorage, executionAsyncId, executionAsyncResource, triggerAsyncId, createHook };
 "#.to_string(),
         // Issue #755: Node built-in subpath aliases. These ship in real Node
@@ -1448,5 +1593,32 @@ mod tests {
                 name
             );
         }
+    }
+
+    /// Issue #789: the async_hooks builtin must not regress to the old
+    /// structural no-op stub. Tracing libraries need lifecycle callbacks and
+    /// non-zero AsyncResource ids even when Perry is executing JS through the
+    /// embedded V8 runtime.
+    #[test]
+    fn test_async_hooks_stub_exposes_lifecycle_polyfill() {
+        let stub = get_builtin_stub("async_hooks");
+
+        assert!(
+            stub.contains("function __perryEmit"),
+            "async_hooks stub should emit createHook lifecycle callbacks"
+        );
+        assert!(
+            stub.contains("let __perryNextAsyncId = 1"),
+            "async_hooks stub should allocate monotonically increasing ids"
+        );
+        assert!(
+            stub.contains("globalThis.Promise = PerryAsyncHookPromise"),
+            "async_hooks stub should hook Promise settlement for promiseResolve"
+        );
+        assert!(
+            !stub.contains("executionAsyncId() { return 0; }")
+                && !stub.contains("executionAsyncId() {return 0;}"),
+            "async_hooks executionAsyncId must not be the old constant-zero stub"
+        );
     }
 }

--- a/crates/perry-runtime/src/async_hooks.rs
+++ b/crates/perry-runtime/src/async_hooks.rs
@@ -1,0 +1,602 @@
+//! Native async_hooks lifecycle support.
+//!
+//! This module owns the process-wide hook list, async resource ids, and the
+//! thread-local execution/trigger id stack used by the compiled runtime.
+
+use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, VecDeque};
+use std::ptr;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{LazyLock, Mutex};
+
+use crate::array::{js_array_length, ArrayHeader};
+use crate::closure::{
+    js_closure_alloc, js_closure_call1, js_closure_call4, js_closure_call_array,
+    js_closure_get_capture_ptr, js_closure_set_capture_ptr, js_register_closure_rest,
+    ClosureHeader,
+};
+use crate::object::{js_object_get_field_by_name, ObjectHeader};
+use crate::string::{js_string_from_bytes, StringHeader};
+use crate::value::POINTER_MASK;
+
+const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
+const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
+const INT32_MASK: u64 = 0x0000_0000_FFFF_FFFF;
+const TAG_MASK: u64 = 0xFFFF_0000_0000_0000;
+const TAG_UNDEFINED_F64: f64 = f64::from_bits(crate::value::TAG_UNDEFINED);
+
+static NEXT_ASYNC_ID: AtomicU64 = AtomicU64::new(1);
+pub static HOOKS_ACTIVE: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Clone, Copy)]
+pub struct AsyncResourceIds {
+    pub async_id: u64,
+    pub trigger_async_id: u64,
+}
+
+#[derive(Clone)]
+struct ResourceMeta {
+    type_name: String,
+    trigger_async_id: u64,
+    resource: f64,
+    destroyed: bool,
+}
+
+#[derive(Clone, Copy)]
+struct HookCallbacks {
+    init: *const ClosureHeader,
+    before: *const ClosureHeader,
+    after: *const ClosureHeader,
+    destroy: *const ClosureHeader,
+    promise_resolve: *const ClosureHeader,
+}
+
+unsafe impl Send for HookCallbacks {}
+unsafe impl Sync for HookCallbacks {}
+
+impl HookCallbacks {
+    fn empty() -> Self {
+        Self {
+            init: ptr::null(),
+            before: ptr::null(),
+            after: ptr::null(),
+            destroy: ptr::null(),
+            promise_resolve: ptr::null(),
+        }
+    }
+
+    fn has_any(&self) -> bool {
+        !self.init.is_null()
+            || !self.before.is_null()
+            || !self.after.is_null()
+            || !self.destroy.is_null()
+            || !self.promise_resolve.is_null()
+    }
+}
+
+struct HookRecord {
+    callbacks: HookCallbacks,
+    enabled: bool,
+}
+
+static HOOKS: LazyLock<Mutex<Vec<HookRecord>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+static RESOURCES: LazyLock<Mutex<HashMap<u64, ResourceMeta>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static GC_DESTROY_QUEUE: LazyLock<Mutex<VecDeque<u64>>> =
+    LazyLock::new(|| Mutex::new(VecDeque::new()));
+
+thread_local! {
+    static EXECUTION_STACK: RefCell<Vec<(u64, u64)>> = const { RefCell::new(Vec::new()) };
+    static CURRENT_EXECUTION_ID: Cell<u64> = const { Cell::new(0) };
+    static CURRENT_TRIGGER_ID: Cell<u64> = const { Cell::new(0) };
+    static IN_HOOK_CALLBACK: Cell<bool> = const { Cell::new(false) };
+}
+
+pub struct AsyncHookHandle {
+    index: usize,
+}
+
+pub struct AsyncResourceHandle {
+    ids: AsyncResourceIds,
+}
+
+#[inline(always)]
+pub fn hooks_active() -> bool {
+    HOOKS_ACTIVE.load(Ordering::Relaxed) != 0
+}
+
+#[inline]
+pub fn execution_async_id_u64() -> u64 {
+    CURRENT_EXECUTION_ID.with(Cell::get)
+}
+
+#[inline]
+pub fn trigger_async_id_u64() -> u64 {
+    CURRENT_TRIGGER_ID.with(Cell::get)
+}
+
+#[no_mangle]
+pub extern "C" fn js_async_hooks_execution_async_id() -> f64 {
+    execution_async_id_u64() as f64
+}
+
+#[no_mangle]
+pub extern "C" fn js_async_hooks_trigger_async_id() -> f64 {
+    trigger_async_id_u64() as f64
+}
+
+#[inline]
+fn box_ptr(ptr: *const u8) -> f64 {
+    f64::from_bits(POINTER_TAG | (ptr as u64 & POINTER_MASK))
+}
+
+fn ptr_from_nanboxed(value: f64) -> *const u8 {
+    let bits = value.to_bits();
+    let tag = bits & TAG_MASK;
+    if tag != POINTER_TAG && tag != STRING_TAG {
+        return ptr::null();
+    }
+    (bits & POINTER_MASK) as *const u8
+}
+
+fn closure_from_value(value: f64) -> *const ClosureHeader {
+    ptr_from_nanboxed(value) as *const ClosureHeader
+}
+
+fn string_from_value(value: f64, default: &str) -> String {
+    let bits = value.to_bits();
+    let tag = bits & TAG_MASK;
+    if tag != STRING_TAG && tag != POINTER_TAG {
+        return default.to_string();
+    }
+    let ptr = (bits & POINTER_MASK) as *const StringHeader;
+    if ptr.is_null() || (ptr as usize) < 0x1000 {
+        return default.to_string();
+    }
+    unsafe {
+        let len = (*ptr).byte_len as usize;
+        let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        std::str::from_utf8(std::slice::from_raw_parts(data, len))
+            .unwrap_or(default)
+            .to_string()
+    }
+}
+
+fn object_field(obj_value: f64, name: &[u8]) -> f64 {
+    let obj = ptr_from_nanboxed(obj_value) as *const ObjectHeader;
+    if obj.is_null() {
+        return TAG_UNDEFINED_F64;
+    }
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32) as *const StringHeader;
+    unsafe { f64::from_bits(js_object_get_field_by_name(obj, key).bits()) }
+}
+
+fn callbacks_from_options(options: f64) -> HookCallbacks {
+    let mut callbacks = HookCallbacks::empty();
+    callbacks.init = closure_from_value(object_field(options, b"init"));
+    callbacks.before = closure_from_value(object_field(options, b"before"));
+    callbacks.after = closure_from_value(object_field(options, b"after"));
+    callbacks.destroy = closure_from_value(object_field(options, b"destroy"));
+    callbacks.promise_resolve = closure_from_value(object_field(options, b"promiseResolve"));
+    callbacks
+}
+
+#[no_mangle]
+pub extern "C" fn js_async_hooks_create_hook(options: f64) -> i64 {
+    let callbacks = callbacks_from_options(options);
+    let mut hooks = HOOKS.lock().unwrap();
+    let index = hooks.len();
+    hooks.push(HookRecord {
+        callbacks,
+        enabled: false,
+    });
+    Box::into_raw(Box::new(AsyncHookHandle { index })) as i64
+}
+
+#[no_mangle]
+pub extern "C" fn js_async_hook_enable(handle: i64) -> i64 {
+    if handle == 0 {
+        return handle;
+    }
+    let hook = unsafe { &*(handle as *const AsyncHookHandle) };
+    let mut hooks = HOOKS.lock().unwrap();
+    if let Some(record) = hooks.get_mut(hook.index) {
+        if !record.enabled && record.callbacks.has_any() {
+            HOOKS_ACTIVE.fetch_add(1, Ordering::Relaxed);
+        }
+        record.enabled = true;
+    }
+    handle
+}
+
+#[no_mangle]
+pub extern "C" fn js_async_hook_disable(handle: i64) -> i64 {
+    if handle == 0 {
+        return handle;
+    }
+    let hook = unsafe { &*(handle as *const AsyncHookHandle) };
+    let mut hooks = HOOKS.lock().unwrap();
+    if let Some(record) = hooks.get_mut(hook.index) {
+        if record.enabled && record.callbacks.has_any() {
+            HOOKS_ACTIVE.fetch_sub(1, Ordering::Relaxed);
+        }
+        record.enabled = false;
+    }
+    handle
+}
+
+fn enabled_callbacks() -> Vec<HookCallbacks> {
+    if !hooks_active() {
+        return Vec::new();
+    }
+    HOOKS
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|hook| hook.enabled)
+        .map(|hook| hook.callbacks)
+        .collect()
+}
+
+fn with_hook_callbacks(mut f: impl FnMut(HookCallbacks)) {
+    if !hooks_active() {
+        return;
+    }
+    IN_HOOK_CALLBACK.with(|guard| {
+        if guard.get() {
+            return;
+        }
+        guard.set(true);
+        for callbacks in enabled_callbacks() {
+            f(callbacks);
+        }
+        guard.set(false);
+    });
+}
+
+pub fn init_resource(type_name: &str, resource: f64, force_allocate: bool) -> AsyncResourceIds {
+    init_resource_with_trigger(
+        type_name,
+        resource,
+        force_allocate,
+        execution_async_id_u64(),
+    )
+}
+
+pub fn init_resource_with_trigger(
+    type_name: &str,
+    resource: f64,
+    force_allocate: bool,
+    trigger_async_id: u64,
+) -> AsyncResourceIds {
+    if !force_allocate && !hooks_active() {
+        return AsyncResourceIds {
+            async_id: 0,
+            trigger_async_id,
+        };
+    }
+
+    let async_id = NEXT_ASYNC_ID.fetch_add(1, Ordering::Relaxed);
+    RESOURCES.lock().unwrap().insert(
+        async_id,
+        ResourceMeta {
+            type_name: type_name.to_string(),
+            trigger_async_id,
+            resource,
+            destroyed: false,
+        },
+    );
+
+    emit_init(async_id, type_name, trigger_async_id, resource);
+    AsyncResourceIds {
+        async_id,
+        trigger_async_id,
+    }
+}
+
+fn emit_init(async_id: u64, type_name: &str, trigger_async_id: u64, resource: f64) {
+    let type_ptr = js_string_from_bytes(type_name.as_ptr(), type_name.len() as u32);
+    let type_value = box_ptr(type_ptr as *const u8);
+    with_hook_callbacks(|callbacks| {
+        if !callbacks.init.is_null() {
+            unsafe {
+                js_closure_call4(
+                    callbacks.init,
+                    async_id as f64,
+                    type_value,
+                    trigger_async_id as f64,
+                    resource,
+                );
+            }
+        }
+    });
+}
+
+pub fn before(async_id: u64, trigger_async_id: u64) {
+    if async_id == 0 {
+        return;
+    }
+    EXECUTION_STACK.with(|stack| {
+        stack
+            .borrow_mut()
+            .push((execution_async_id_u64(), trigger_async_id_u64()));
+    });
+    CURRENT_EXECUTION_ID.with(|c| c.set(async_id));
+    CURRENT_TRIGGER_ID.with(|c| c.set(trigger_async_id));
+    with_hook_callbacks(|callbacks| {
+        if !callbacks.before.is_null() {
+            unsafe { js_closure_call1(callbacks.before, async_id as f64) };
+        }
+    });
+}
+
+pub fn after(async_id: u64) {
+    if async_id == 0 {
+        return;
+    }
+    with_hook_callbacks(|callbacks| {
+        if !callbacks.after.is_null() {
+            unsafe { js_closure_call1(callbacks.after, async_id as f64) };
+        }
+    });
+    let prev = EXECUTION_STACK
+        .with(|stack| stack.borrow_mut().pop())
+        .unwrap_or((0, 0));
+    CURRENT_EXECUTION_ID.with(|c| c.set(prev.0));
+    CURRENT_TRIGGER_ID.with(|c| c.set(prev.1));
+}
+
+pub fn promise_resolve(async_id: u64) {
+    if async_id == 0 {
+        return;
+    }
+    with_hook_callbacks(|callbacks| {
+        if !callbacks.promise_resolve.is_null() {
+            unsafe { js_closure_call1(callbacks.promise_resolve, async_id as f64) };
+        }
+    });
+}
+
+pub fn destroy(async_id: u64) {
+    if async_id == 0 {
+        return;
+    }
+    let should_emit = {
+        let mut resources = RESOURCES.lock().unwrap();
+        match resources.get_mut(&async_id) {
+            Some(meta) if !meta.destroyed => {
+                meta.destroyed = true;
+                true
+            }
+            Some(_) => false,
+            None => true,
+        }
+    };
+    if !should_emit {
+        return;
+    }
+    with_hook_callbacks(|callbacks| {
+        if !callbacks.destroy.is_null() {
+            unsafe { js_closure_call1(callbacks.destroy, async_id as f64) };
+        }
+    });
+    RESOURCES.lock().unwrap().remove(&async_id);
+}
+
+pub fn enqueue_gc_destroy(async_id: u64) {
+    if async_id != 0 {
+        GC_DESTROY_QUEUE.lock().unwrap().push_back(async_id);
+    }
+}
+
+pub fn drain_gc_destroy_queue() -> i32 {
+    let ids: Vec<u64> = {
+        let mut q = GC_DESTROY_QUEUE.lock().unwrap();
+        q.drain(..).collect()
+    };
+    let count = ids.len() as i32;
+    for id in ids {
+        destroy(id);
+    }
+    count
+}
+
+fn value_to_u64(value: f64) -> Option<u64> {
+    let bits = value.to_bits();
+    if (bits & !INT32_MASK) == INT32_TAG {
+        return Some((bits & INT32_MASK) as i32 as u64);
+    }
+    if (bits >> 48) < 0x7FFC {
+        let n = f64::from_bits(bits);
+        if n.is_finite() && n >= 0.0 {
+            return Some(n as u64);
+        }
+    }
+    None
+}
+
+fn trigger_id_from_options(options: f64) -> u64 {
+    value_to_u64(object_field(options, b"triggerAsyncId")).unwrap_or_else(execution_async_id_u64)
+}
+
+#[no_mangle]
+pub extern "C" fn js_async_resource_new(type_value: f64, options: f64) -> i64 {
+    let type_name = string_from_value(type_value, "AsyncResource");
+    let trigger_async_id = trigger_id_from_options(options);
+    let ids = init_resource_with_trigger(&type_name, TAG_UNDEFINED_F64, true, trigger_async_id);
+    Box::into_raw(Box::new(AsyncResourceHandle { ids })) as i64
+}
+
+#[no_mangle]
+pub extern "C" fn js_async_resource_async_id(handle: i64) -> f64 {
+    if handle == 0 {
+        return 0.0;
+    }
+    let resource = unsafe { &*(handle as *const AsyncResourceHandle) };
+    resource.ids.async_id as f64
+}
+
+#[no_mangle]
+pub extern "C" fn js_async_resource_trigger_async_id(handle: i64) -> f64 {
+    if handle == 0 {
+        return 0.0;
+    }
+    let resource = unsafe { &*(handle as *const AsyncResourceHandle) };
+    resource.ids.trigger_async_id as f64
+}
+
+#[no_mangle]
+pub extern "C" fn js_async_resource_emit_destroy(handle: i64) -> i64 {
+    if handle != 0 {
+        let resource = unsafe { &*(handle as *const AsyncResourceHandle) };
+        destroy(resource.ids.async_id);
+    }
+    handle
+}
+
+#[no_mangle]
+pub extern "C" fn js_async_resource_run_in_async_scope(
+    handle: i64,
+    callback: i64,
+    this_arg: f64,
+    args_array: i64,
+) -> f64 {
+    let _ = this_arg;
+    if handle == 0 || callback == 0 {
+        return TAG_UNDEFINED_F64;
+    }
+    let resource = unsafe { &*(handle as *const AsyncResourceHandle) };
+    before(resource.ids.async_id, resource.ids.trigger_async_id);
+    let result = if args_array == 0 {
+        unsafe { js_closure_call_array(callback, ptr::null(), 0) }
+    } else {
+        let arr = args_array as *const ArrayHeader;
+        let len = js_array_length(arr) as i64;
+        let data = if arr.is_null() {
+            ptr::null()
+        } else {
+            unsafe { (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64 }
+        };
+        unsafe { js_closure_call_array(callback, data, len) }
+    };
+    after(resource.ids.async_id);
+    result
+}
+
+/// Trampoline body for `AsyncResource#bind`. Stored as the `func_ptr` of the
+/// synthesized closure; receives the rest array of forwarded args and replays
+/// the call through `runInAsyncScope` so init/before/after/destroy fire with
+/// the bound resource's async id active.
+extern "C" fn async_resource_bind_trampoline(closure: *const ClosureHeader, rest: f64) -> f64 {
+    if closure.is_null() {
+        return TAG_UNDEFINED_F64;
+    }
+    let handle = js_closure_get_capture_ptr(closure, 0);
+    let callback = js_closure_get_capture_ptr(closure, 1);
+    if handle == 0 || callback == 0 {
+        return TAG_UNDEFINED_F64;
+    }
+    let args_array_ptr = ptr_from_nanboxed(rest) as i64;
+    js_async_resource_run_in_async_scope(handle, callback, TAG_UNDEFINED_F64, args_array_ptr)
+}
+
+fn register_bind_trampoline_once() {
+    thread_local! {
+        // CLOSURE_REST_REGISTRY is thread-local, so each thread that
+        // synthesizes a bind() trampoline must register the func_ptr once.
+        static REGISTERED: Cell<bool> = const { Cell::new(false) };
+    }
+    REGISTERED.with(|flag| {
+        if !flag.get() {
+            // fixed_arity=0 → dispatch_rest_bundled calls
+            // `f(closure, rest_array)` regardless of forwarded arity.
+            js_register_closure_rest(async_resource_bind_trampoline as *const u8, 0);
+            flag.set(true);
+        }
+    });
+}
+
+#[no_mangle]
+pub extern "C" fn js_async_resource_bind(handle: i64, callback: i64) -> i64 {
+    if handle == 0 || callback == 0 {
+        return callback;
+    }
+    register_bind_trampoline_once();
+    let closure = js_closure_alloc(async_resource_bind_trampoline as *const u8, 2);
+    if closure.is_null() {
+        return callback;
+    }
+    js_closure_set_capture_ptr(closure, 0, handle);
+    js_closure_set_capture_ptr(closure, 1, callback);
+    closure as i64
+}
+
+#[no_mangle]
+pub extern "C" fn js_async_resource_static_bind(callback: i64, type_value: f64) -> i64 {
+    let handle = js_async_resource_new(type_value, TAG_UNDEFINED_F64);
+    js_async_resource_bind(handle, callback)
+}
+
+pub fn scan_async_hooks_roots(mark: &mut dyn FnMut(f64)) {
+    let hooks = HOOKS.lock().unwrap();
+    for hook in hooks.iter() {
+        for cb in [
+            hook.callbacks.init,
+            hook.callbacks.before,
+            hook.callbacks.after,
+            hook.callbacks.destroy,
+            hook.callbacks.promise_resolve,
+        ] {
+            if !cb.is_null() {
+                mark(box_ptr(cb as *const u8));
+            }
+        }
+    }
+    drop(hooks);
+    let resources = RESOURCES.lock().unwrap();
+    for meta in resources.values() {
+        mark(meta.resource);
+    }
+}
+
+#[cfg(test)]
+pub fn reset_for_tests() {
+    HOOKS.lock().unwrap().clear();
+    RESOURCES.lock().unwrap().clear();
+    GC_DESTROY_QUEUE.lock().unwrap().clear();
+    HOOKS_ACTIVE.store(0, Ordering::Relaxed);
+    NEXT_ASYNC_ID.store(1, Ordering::Relaxed);
+    CURRENT_EXECUTION_ID.with(|c| c.set(0));
+    CURRENT_TRIGGER_ID.with(|c| c.set(0));
+    EXECUTION_STACK.with(|s| s.borrow_mut().clear());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{LazyLock, Mutex};
+
+    static TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    #[test]
+    fn resource_ids_are_monotonic_even_without_hooks() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_for_tests();
+        let a = init_resource("A", TAG_UNDEFINED_F64, true);
+        let b = init_resource("B", TAG_UNDEFINED_F64, true);
+        assert_eq!(a.async_id, 1);
+        assert_eq!(b.async_id, 2);
+    }
+
+    #[test]
+    fn before_after_restore_execution_ids() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_for_tests();
+        let ids = init_resource("A", TAG_UNDEFINED_F64, true);
+        before(ids.async_id, ids.trigger_async_id);
+        assert_eq!(execution_async_id_u64(), ids.async_id);
+        after(ids.async_id);
+        assert_eq!(execution_async_id_u64(), 0);
+    }
+}

--- a/crates/perry-runtime/src/builtins.rs
+++ b/crates/perry-runtime/src/builtins.rs
@@ -2795,14 +2795,29 @@ pub extern "C" fn js_structured_clone(value: f64) -> f64 {
 /// should print "sync" then "micro", not "micro" then "sync".
 #[no_mangle]
 pub extern "C" fn js_queue_microtask(callback: i64) {
+    queue_microtask_with_type(callback, "Microtask");
+}
+
+#[no_mangle]
+pub extern "C" fn js_queue_next_tick(callback: i64) {
+    queue_microtask_with_type(callback, "TickObject");
+}
+
+fn queue_microtask_with_type(callback: i64, type_name: &str) {
     let context = crate::async_context::capture_context();
+    let ids = crate::async_hooks::init_resource(
+        type_name,
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+        false,
+    );
     QUEUED_MICROTASKS.with(|q| {
-        q.borrow_mut().push((callback, context));
+        q.borrow_mut()
+            .push((callback, context, ids.async_id, ids.trigger_async_id));
     });
 }
 
 thread_local! {
-    static QUEUED_MICROTASKS: std::cell::RefCell<Vec<(i64, crate::async_context::AsyncContextSnapshot)>> = const { std::cell::RefCell::new(Vec::new()) };
+    static QUEUED_MICROTASKS: std::cell::RefCell<Vec<(i64, crate::async_context::AsyncContextSnapshot, u64, u64)>> = const { std::cell::RefCell::new(Vec::new()) };
     static QUEUED_MICROTASK_PREV_CONTEXTS: std::cell::RefCell<Vec<crate::async_context::AsyncContextSnapshot>> = const { std::cell::RefCell::new(Vec::new()) };
 }
 
@@ -2829,12 +2844,15 @@ pub extern "C" fn js_drain_queued_microtasks() {
             }
         });
         match task {
-            Some((cb, context)) => {
+            Some((cb, context, async_id, trigger_async_id)) => {
                 let previous = crate::async_context::enter_context(&context);
                 QUEUED_MICROTASK_PREV_CONTEXTS.with(|stack| {
                     stack.borrow_mut().push(previous);
                 });
+                crate::async_hooks::before(async_id, trigger_async_id);
                 js_closure_call0(cb as *const crate::closure::ClosureHeader);
+                crate::async_hooks::after(async_id);
+                crate::async_hooks::destroy(async_id);
                 QUEUED_MICROTASK_PREV_CONTEXTS.with(|stack| {
                     if let Some(previous) = stack.borrow_mut().pop() {
                         crate::async_context::restore_context(previous);
@@ -2848,7 +2866,7 @@ pub extern "C" fn js_drain_queued_microtasks() {
 
 pub fn scan_queued_microtask_roots(mark: &mut dyn FnMut(f64)) {
     QUEUED_MICROTASKS.with(|q| {
-        for (callback, context) in q.borrow().iter() {
+        for (callback, context, _, _) in q.borrow().iter() {
             if *callback != 0 {
                 let boxed = f64::from_bits(
                     0x7FFD_0000_0000_0000 | (*callback as u64 & 0x0000_FFFF_FFFF_FFFF),

--- a/crates/perry-runtime/src/gc.rs
+++ b/crates/perry-runtime/src/gc.rs
@@ -2978,9 +2978,9 @@ fn sweep_with_age_bump(do_age_bump: bool) -> u64 {
                     }
                     if (*header).obj_type == GC_TYPE_PROMISE {
                         let user_ptr = (header as *mut u8).add(GC_HEADER_SIZE);
-                        crate::promise::clear_promise_context_for_gc(
-                            user_ptr as *mut crate::promise::Promise,
-                        );
+                        let promise = user_ptr as *mut crate::promise::Promise;
+                        crate::async_hooks::enqueue_gc_destroy((*promise).async_id);
+                        crate::promise::clear_promise_context_for_gc(promise);
                     }
 
                     let layout = Layout::from_size_align(total_size, 8).unwrap();
@@ -3232,6 +3232,11 @@ pub fn exception_root_scanner(mark: &mut dyn FnMut(f64)) {
 pub fn async_context_root_scanner(mark: &mut dyn FnMut(f64)) {
     crate::async_context::scan_active_context_roots(mark);
     crate::builtins::scan_queued_microtask_roots(mark);
+}
+
+/// Root scanner for async_hooks hook callbacks and user resource references.
+pub fn async_hooks_root_scanner(mark: &mut dyn FnMut(f64)) {
+    crate::async_hooks::scan_async_hooks_roots(mark);
 }
 
 /// Root scanner for object shape cache (keys arrays shared across objects with same shape)
@@ -3875,6 +3880,7 @@ pub fn gc_init() {
     gc_register_root_scanner(timer_root_scanner);
     gc_register_root_scanner(exception_root_scanner);
     gc_register_root_scanner(async_context_root_scanner);
+    gc_register_root_scanner(async_hooks_root_scanner);
     gc_register_root_scanner(shape_cache_root_scanner);
     gc_register_root_scanner(crate::regex::scan_last_exec_groups_root);
     gc_register_root_scanner(crate::array::scan_template_raw_roots);

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -24,6 +24,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 pub mod arena;
 pub mod array;
 pub mod async_context;
+pub mod async_hooks;
 pub mod bigint;
 pub mod r#box;
 pub mod buffer;

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -473,12 +473,7 @@ pub extern "C" fn js_process_on(
 /// process.nextTick(callback) — schedule callback as a microtask.
 #[no_mangle]
 pub extern "C" fn js_process_next_tick(callback: *const crate::closure::ClosureHeader) {
-    use crate::promise::{js_promise_new, js_promise_schedule_resolve, js_promise_then};
-    use crate::value::JSValue;
-
-    let p = js_promise_new();
-    let _chain = js_promise_then(p, callback, std::ptr::null());
-    js_promise_schedule_resolve(p, f64::from_bits(JSValue::undefined().bits()));
+    crate::builtins::js_queue_next_tick(callback as i64);
 }
 
 /// process.chdir(directory) — change working directory.

--- a/crates/perry-runtime/src/promise.rs
+++ b/crates/perry-runtime/src/promise.rs
@@ -241,6 +241,10 @@ pub struct Promise {
     pub(crate) on_rejected: ClosurePtr,
     /// Next promise in the chain (for .then())
     pub(crate) next: *mut Promise,
+    /// async_hooks asyncId for this Promise, 0 when hooks were inactive.
+    pub(crate) async_id: u64,
+    /// async_hooks triggerAsyncId captured at Promise creation.
+    pub(crate) trigger_async_id: u64,
 }
 
 impl Promise {
@@ -252,6 +256,8 @@ impl Promise {
             on_fulfilled: ptr::null(),
             on_rejected: ptr::null(),
             next: ptr::null_mut(),
+            async_id: 0,
+            trigger_async_id: 0,
         }
     }
 }
@@ -467,6 +473,13 @@ pub extern "C" fn js_promise_new() -> *mut Promise {
     let promise = raw as *mut Promise;
     unsafe {
         ptr::write(promise, Promise::new());
+        if crate::async_hooks::hooks_active() {
+            let resource =
+                f64::from_bits(0x7FFD_0000_0000_0000 | (promise as u64 & 0x0000_FFFF_FFFF_FFFF));
+            let ids = crate::async_hooks::init_resource("PROMISE", resource, false);
+            (*promise).async_id = ids.async_id;
+            (*promise).trigger_async_id = ids.trigger_async_id;
+        }
     }
     promise
 }
@@ -536,6 +549,7 @@ pub extern "C" fn js_promise_resolve(promise: *mut Promise, value: f64) {
         }
         (*promise).state = PromiseState::Fulfilled;
         (*promise).value = value;
+        crate::async_hooks::promise_resolve((*promise).async_id);
 
         // Schedule callbacks. Push to TASK_QUEUE whenever there's anything
         // for the microtask runner to do — either invoke the user callback,
@@ -562,6 +576,9 @@ pub extern "C" fn js_promise_resolve(promise: *mut Promise, value: f64) {
     // 1 s idle cap before the loop re-checks promise state. The notify
     // sets the flag so the immediately-following wait returns at once.
     crate::event_pump::js_notify_main_thread();
+    unsafe {
+        crate::async_hooks::destroy((*promise).async_id);
+    }
 }
 
 /// Resolve a promise with another promise (Promise chaining/unwrapping)
@@ -671,6 +688,7 @@ pub extern "C" fn js_promise_reject(promise: *mut Promise, reason: f64) {
         }
         (*promise).state = PromiseState::Rejected;
         (*promise).reason = reason;
+        crate::async_hooks::promise_resolve((*promise).async_id);
 
         // Schedule callbacks. Same propagation rule as `js_promise_resolve`
         // (#236): push to the queue whenever there's a callback to invoke
@@ -688,6 +706,9 @@ pub extern "C" fn js_promise_reject(promise: *mut Promise, reason: f64) {
     }
     // Issue #84: see js_promise_resolve — same wake reasoning.
     crate::event_pump::js_notify_main_thread();
+    unsafe {
+        crate::async_hooks::destroy((*promise).async_id);
+    }
 }
 
 /// Register fulfillment callback, returns a new promise for chaining
@@ -996,6 +1017,8 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
     mt_profile_register();
     let mut ran = 0;
 
+    ran += crate::async_hooks::drain_gc_destroy_queue();
+
     // First, tick timers to resolve any expired timer promises
     ran += crate::timer::js_timer_tick();
 
@@ -1168,7 +1191,9 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                     } else {
                         None
                     };
+                    crate::async_hooks::before((*promise).async_id, (*promise).trigger_async_id);
                     let result = crate::closure::js_closure_call1(callback, value);
+                    crate::async_hooks::after((*promise).async_id);
                     if let Some(t) = t1 {
                         MT_TIME_NS_CALLBACK
                             .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);

--- a/crates/perry-runtime/src/timer.rs
+++ b/crates/perry-runtime/src/timer.rs
@@ -169,6 +169,9 @@ struct CallbackTimer {
     args: Vec<f64>,
     /// AsyncLocalStorage context captured when the timer was scheduled.
     context: crate::async_context::AsyncContextSnapshot,
+    /// async_hooks ids for this timer callback resource.
+    async_id: u64,
+    trigger_async_id: u64,
     /// Whether this timer has been cleared
     cleared: bool,
 }
@@ -184,6 +187,15 @@ static NEXT_CALLBACK_TIMER_ID: Mutex<i64> = Mutex::new(1);
 /// Returns a timer ID
 #[no_mangle]
 pub extern "C" fn js_set_timeout_callback(callback: i64, delay_ms: f64) -> i64 {
+    schedule_callback_timer(callback, delay_ms, Vec::new(), "Timeout")
+}
+
+#[no_mangle]
+pub extern "C" fn js_set_immediate_callback(callback: i64) -> i64 {
+    schedule_callback_timer(callback, 0.0, Vec::new(), "Immediate")
+}
+
+fn schedule_callback_timer(callback: i64, delay_ms: f64, args: Vec<f64>, type_name: &str) -> i64 {
     ensure_initialized();
 
     let delay = Duration::from_millis(delay_ms.max(0.0) as u64);
@@ -196,12 +208,20 @@ pub extern "C" fn js_set_timeout_callback(callback: i64, delay_ms: f64) -> i64 {
         current
     };
 
+    let ids = crate::async_hooks::init_resource(
+        type_name,
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+        false,
+    );
+
     CALLBACK_TIMERS.lock().unwrap().push(CallbackTimer {
         id,
         deadline,
         callback,
-        args: Vec::new(),
+        args,
         context: crate::async_context::capture_context(),
+        async_id: ids.async_id,
+        trigger_async_id: ids.trigger_async_id,
         cleared: false,
     });
 
@@ -225,34 +245,26 @@ pub unsafe extern "C" fn js_set_timeout_callback_args(
     args_ptr: *const f64,
     n_args: i32,
 ) -> i64 {
-    ensure_initialized();
-
-    let delay = Duration::from_millis(delay_ms.max(0.0) as u64);
-    let deadline = Instant::now() + delay;
-
     let args: Vec<f64> = if args_ptr.is_null() || n_args <= 0 {
         Vec::new()
     } else {
         std::slice::from_raw_parts(args_ptr, n_args as usize).to_vec()
     };
+    schedule_callback_timer(callback, delay_ms, args, "Timeout")
+}
 
-    let id = {
-        let mut next = NEXT_CALLBACK_TIMER_ID.lock().unwrap();
-        let current = *next;
-        *next += 1;
-        current
+#[no_mangle]
+pub unsafe extern "C" fn js_set_immediate_callback_args(
+    callback: i64,
+    args_ptr: *const f64,
+    n_args: i32,
+) -> i64 {
+    let args: Vec<f64> = if args_ptr.is_null() || n_args <= 0 {
+        Vec::new()
+    } else {
+        std::slice::from_raw_parts(args_ptr, n_args as usize).to_vec()
     };
-
-    CALLBACK_TIMERS.lock().unwrap().push(CallbackTimer {
-        id,
-        deadline,
-        callback,
-        args,
-        context: crate::async_context::capture_context(),
-        cleared: false,
-    });
-
-    id
+    schedule_callback_timer(callback, 0.0, args, "Immediate")
 }
 
 /// Process any expired callback timers
@@ -291,41 +303,46 @@ pub extern "C" fn js_callback_timer_tick() -> i32 {
             let cb = timer.callback as *const crate::closure::ClosureHeader;
             let a = &timer.args;
             let previous = crate::async_context::enter_context(&timer.context);
-            match a.len() {
-                0 => {
-                    js_closure_call0(cb);
-                }
-                1 => {
-                    js_closure_call1(cb, a[0]);
-                }
-                2 => {
-                    js_closure_call2(cb, a[0], a[1]);
-                }
-                3 => {
-                    js_closure_call3(cb, a[0], a[1], a[2]);
-                }
-                4 => {
-                    js_closure_call4(cb, a[0], a[1], a[2], a[3]);
-                }
-                5 => {
-                    js_closure_call5(cb, a[0], a[1], a[2], a[3], a[4]);
-                }
-                6 => {
-                    js_closure_call6(cb, a[0], a[1], a[2], a[3], a[4], a[5]);
-                }
-                7 => {
-                    js_closure_call7(cb, a[0], a[1], a[2], a[3], a[4], a[5], a[6]);
-                }
-                8 => {
-                    js_closure_call8(cb, a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]);
-                }
-                _ => {
-                    // >= 9 args: clamp to 9. Real-world setTimeout
-                    // rarely exceeds 1-2 trailing args; this is a
-                    // conservative safety net rather than spec coverage.
-                    js_closure_call9(cb, a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8]);
+            crate::async_hooks::before(timer.async_id, timer.trigger_async_id);
+            unsafe {
+                match a.len() {
+                    0 => {
+                        js_closure_call0(cb);
+                    }
+                    1 => {
+                        js_closure_call1(cb, a[0]);
+                    }
+                    2 => {
+                        js_closure_call2(cb, a[0], a[1]);
+                    }
+                    3 => {
+                        js_closure_call3(cb, a[0], a[1], a[2]);
+                    }
+                    4 => {
+                        js_closure_call4(cb, a[0], a[1], a[2], a[3]);
+                    }
+                    5 => {
+                        js_closure_call5(cb, a[0], a[1], a[2], a[3], a[4]);
+                    }
+                    6 => {
+                        js_closure_call6(cb, a[0], a[1], a[2], a[3], a[4], a[5]);
+                    }
+                    7 => {
+                        js_closure_call7(cb, a[0], a[1], a[2], a[3], a[4], a[5], a[6]);
+                    }
+                    8 => {
+                        js_closure_call8(cb, a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]);
+                    }
+                    _ => {
+                        // >= 9 args: clamp to 9. Real-world setTimeout
+                        // rarely exceeds 1-2 trailing args; this is a
+                        // conservative safety net rather than spec coverage.
+                        js_closure_call9(cb, a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8]);
+                    }
                 }
             }
+            crate::async_hooks::after(timer.async_id);
+            crate::async_hooks::destroy(timer.async_id);
             crate::async_context::restore_context(previous);
             fired += 1;
         }
@@ -483,7 +500,9 @@ pub extern "C" fn js_interval_timer_tick() -> i32 {
     // Call the callbacks outside of the lock
     for (callback, context) in callbacks_to_call {
         let previous = crate::async_context::enter_context(&context);
-        js_closure_call0(callback as *const crate::closure::ClosureHeader);
+        unsafe {
+            js_closure_call0(callback as *const crate::closure::ClosureHeader);
+        }
         crate::async_context::restore_context(previous);
         fired += 1;
     }

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 833 entries across 70 modules
+// Coverage: 842 entries across 70 modules
 
 declare module "argon2" {
   /** stdlib */
@@ -14,6 +14,12 @@ declare module "async_hooks" {
   export class AsyncLocalStorage { [key: string]: any; }
   /** stdlib */
   export class AsyncResource { [key: string]: any; }
+  /** stdlib */
+  export function createHook(...args: any[]): any;
+  /** stdlib */
+  export function executionAsyncId(...args: any[]): any;
+  /** stdlib */
+  export function triggerAsyncId(...args: any[]): any;
 }
 
 declare module "axios" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 833 entries across 70 modules.
+Total: 842 entries across 70 modules.
 
 ## Modules
 
@@ -95,11 +95,20 @@ Total: 833 entries across 70 modules.
 
 ### Methods
 
+- `asyncId` — instance *(class: `AsyncResource`)*
+- `bind` — instance *(class: `AsyncResource`)*
+- `createHook` — module
 - `disable` — instance
+- `emitDestroy` — instance *(class: `AsyncResource`)*
+- `enable` — instance *(class: `AsyncHook`)*
 - `enterWith` — instance
+- `executionAsyncId` — module
 - `exit` — instance
 - `getStore` — instance
 - `run` — instance
+- `runInAsyncScope` — instance *(class: `AsyncResource`)*
+- `triggerAsyncId` — module
+- `triggerAsyncId` — instance *(class: `AsyncResource`)*
 
 ## `axios`
 

--- a/test-files/test_parity_async_hooks.ts
+++ b/test-files/test_parity_async_hooks.ts
@@ -50,6 +50,62 @@ try {
   console.log("AsyncResource.emitDestroy OK");
 } catch (e: any) { console.log("AsyncResource ERR:", e && e.message); }
 
+try {
+  let parentId = 0;
+  const events: string[] = [];
+  const hook = async_hooks.createHook({
+    init(asyncId: number, type: string, triggerAsyncId: number) {
+      if (type === "ParentResource") events.push(`init-parent:${asyncId > 0}`);
+      if (type === "ChildResource") events.push(`init-child:${triggerAsyncId === parentId}`);
+    },
+    before(asyncId: number) {
+      if (asyncId === parentId) events.push("before-parent");
+    },
+    after(asyncId: number) {
+      if (asyncId === parentId) events.push("after-parent");
+    },
+  });
+  hook.enable();
+  const parent = new async_hooks.AsyncResource("ParentResource");
+  parentId = parent.asyncId();
+  let execMatched = false;
+  let childTriggerMatched = false;
+  const scoped = parent.runInAsyncScope((a: number, b: number) => {
+    execMatched = async_hooks.executionAsyncId() === parentId;
+    const child = new async_hooks.AsyncResource("ChildResource");
+    childTriggerMatched = child.triggerAsyncId() === parentId;
+    child.emitDestroy();
+    return a + b;
+  }, null, 20, 22);
+  parent.emitDestroy();
+  hook.disable();
+  console.log("AsyncResource lifecycle result:", scoped, execMatched, childTriggerMatched, events.join("|"));
+} catch (e: any) { console.log("AsyncResource lifecycle ERR:", e && e.message); }
+
+try {
+  const order: string[] = [];
+  const h1 = async_hooks.createHook({ init(_id: number, type: string) { if (type === "OrderResource") order.push("A"); } });
+  const h2 = async_hooks.createHook({ init(_id: number, type: string) { if (type === "OrderResource") order.push("B"); } });
+  h1.enable();
+  h2.enable();
+  new async_hooks.AsyncResource("OrderResource").emitDestroy();
+  h1.disable();
+  h2.disable();
+  console.log("multiple hooks order:", order.join(""));
+} catch (e: any) { console.log("multiple hooks ERR:", e && e.message); }
+
+try {
+  const seen: string[] = [];
+  const h1 = async_hooks.createHook({ init(_id: number, type: string) { if (type === "DisableResource") seen.push("A"); } });
+  const h2 = async_hooks.createHook({ init(_id: number, type: string) { if (type === "DisableResource") seen.push("B"); } });
+  h1.enable();
+  h2.enable();
+  h1.disable();
+  new async_hooks.AsyncResource("DisableResource").emitDestroy();
+  h2.disable();
+  console.log("disable one hook:", seen.join(""));
+} catch (e: any) { console.log("disable hook ERR:", e && e.message); }
+
 // PERRY-SKIP: AsyncResource.bind / static AsyncResource.bind — newer API surface, not exercised here.
 
 // ── Class: AsyncLocalStorage ──


### PR DESCRIPTION
## Summary

Closes #789. Implements the observability half of `node:async_hooks` — `createHook` callbacks, real `executionAsyncId()` / `triggerAsyncId()`, and the full `AsyncResource` surface — on top of the AsyncLocalStorage context propagation that landed in #788.

- Process-wide hook registry with registration-order iteration and a zero-hook fast path (single relaxed atomic load + branch).
- Monotonic asyncId allocator + per-thread execution/trigger id stack.
- `init` / `before` / `after` / `destroy` / `promiseResolve` emitted at Promise construction & settlement, timer scheduling & firing, `AsyncResource` construction, `runInAsyncScope`, and `emitDestroy`.
- Eager `destroy` for settled Promises, fired timers, and explicit `emitDestroy()`; GC-driven `destroy` for dropped/unsettled Promises via a new finalizer queue in `perry-runtime/src/gc.rs`.
- `AsyncResource#bind(fn)` synthesizes a native closure trampoline that replays through `runInAsyncScope`, so bound callbacks fire `before` / `after` with the bound resource's async id active.
- V8 fallback (`perry-jsruntime/src/modules.rs`) mirrors the same surface for code running through the embedded runtime.
- Drops the compile-time `[perry] note:` shim warning for `node:async_hooks` — it's no longer accurate once both #788 and this issue land.

## Test plan

- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry`
- [x] `test-files/test_parity_async_hooks.ts` byte-for-byte parity vs `node --experimental-strip-types`
- [x] Ad-hoc `AsyncResource#bind` exercise — bound callback observes the bound resource's `executionAsyncId()` and fires `before` / `after`
- [ ] CI parity sweep