### PR TITLE
fix(windows): target-aware ext-binding staticlib name (lib*.a vs *.lib)

### DIFF
--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -657,7 +657,13 @@ pub(super) fn build_optimized_libs(
     // bundled in. The linker will dedup duplicate tokio symbols
     // across the staticlibs because the mangled hashes match.
     for (krate, lib, _tracking) in &tokio_using_bindings {
-        let lib_path = release_dir.join(format!("lib{}.a", lib));
+        // Cargo emits `lib<lib>.a` on Unix but `<lib>.lib` on Windows/MSVC.
+        // Hardcoding the Unix name here meant a Windows build never found
+        // the rebuilt ext staticlib (e.g. perry-ext-ws), silently skipped
+        // it, and failed the final link with unresolved `js_*` symbols.
+        let lib_filename =
+            super::well_known::ext_staticlib_filename(lib, rust_target_triple(target));
+        let lib_path = release_dir.join(&lib_filename);
         if !lib_path.exists() {
             // Fall back to the workspace target copy. The linker will
             // still produce a working binary for this wrapper if the
@@ -670,36 +676,36 @@ pub(super) fn build_optimized_libs(
                     .join("target")
                     .join(triple)
                     .join("release")
-                    .join(format!("lib{}.a", lib));
+                    .join(&lib_filename);
                 if triple_path.exists() {
                     triple_path
                 } else {
                     workspace_root
                         .join("target")
                         .join("release")
-                        .join(format!("lib{}.a", lib))
+                        .join(&lib_filename)
                 }
             } else {
                 workspace_root
                     .join("target")
                     .join("release")
-                    .join(format!("lib{}.a", lib))
+                    .join(&lib_filename)
             };
             if fallback.exists() {
                 if matches!(format, OutputFormat::Text) {
                     eprintln!(
-                        "  well-known: rebuild produced no `lib{}.a` in {} — \
+                        "  well-known: rebuild produced no `{}` in {} — \
                          using workspace fallback (CONTEXT panic risk on tokio I/O)",
-                        lib,
+                        lib_filename,
                         release_dir.display()
                     );
                 }
                 well_known_libs.push(fallback);
             } else if matches!(format, OutputFormat::Text) {
                 eprintln!(
-                    "  well-known: rebuild produced no `lib{}.a` for `{}`; \
+                    "  well-known: rebuild produced no `{}` for `{}`; \
                      skipping — link will likely fail with unresolved js_* symbols.",
-                    lib, krate
+                    lib_filename, krate
                 );
             }
             continue;

--- a/crates/perry/src/commands/compile/well_known.rs
+++ b/crates/perry/src/commands/compile/well_known.rs
@@ -67,7 +67,30 @@ pub fn iter_well_known() -> impl Iterator<Item = &'static WellKnownBinding> {
     registry().values()
 }
 
-/// Resolve the bundled `.a` path for `binding`, given the perry
+/// Platform-correct static-library filename for an ext-binding lib stem.
+///
+/// Cargo emits `lib<stem>.a` on Unix-likes but `<stem>.lib` on
+/// Windows/MSVC. `target_triple` is the rust triple being built for
+/// (`None` = host build → use the host OS). Every call site that locates
+/// a well-known binding's staticlib must go through this: previously the
+/// `lib<stem>.a` name was hardcoded, so on a Windows build the real
+/// `<stem>.lib` artifact was looked up under a name that never exists,
+/// the binding was silently skipped, and the final link failed with
+/// unresolved `js_*` symbols (e.g. perry-ext-ws's `js_ws_*` when a
+/// program `import`s `ws`).
+pub fn ext_staticlib_filename(lib_stem: &str, target_triple: Option<&str>) -> String {
+    let is_windows = match target_triple {
+        Some(t) => t.contains("windows"),
+        None => cfg!(target_os = "windows"),
+    };
+    if is_windows {
+        format!("{}.lib", lib_stem)
+    } else {
+        format!("lib{}.a", lib_stem)
+    }
+}
+
+/// Resolve the bundled staticlib path for `binding`, given the perry
 /// workspace root (from `find_perry_workspace_root`) and an optional
 /// rust target triple. When `target_triple` is `Some`, look in the
 /// per-target output dir (`target/<triple>/release/`); otherwise the
@@ -83,7 +106,7 @@ pub fn bundled_staticlib_path_for_target(
     } else {
         workspace_root.join("target").join("release")
     };
-    let path = release_dir.join(format!("lib{}.a", binding.lib));
+    let path = release_dir.join(ext_staticlib_filename(&binding.lib, target_triple));
     if path.exists() {
         Some(path)
     } else {


### PR DESCRIPTION
## Problem

Well-known native bindings (perry-ext-ws and friends) are located by a **hardcoded Unix staticlib name** `lib<name>.a` in two places:

- `well_known.rs` `bundled_staticlib_path_for_target` — CPU-only bindings
- `optimized_libs.rs` tokio-using-binding resolution (the #507 path, e.g. `ws`)

Cargo emits `<name>.lib` (no `lib` prefix, `.lib` ext) on **Windows/MSVC**. So on a Windows build the freshly auto-rebuilt ext staticlib was looked up under a name that never exists, the binding was silently skipped, and the final link failed with unresolved `js_*` symbols.

Concretely: an app that `import`s `ws` (routed to `perry-ext-ws`) failed to link for `--target windows` with undefined `js_ws_connect_start`, `js_ws_has_pending`, `js_ws_process_pending`, `js_ws_send_to_client`, `js_ws_close_client` — **even though `perry_ext_ws.lib` was built** right next to `perry_stdlib.lib` in the auto-optimize dir.

## Fix

Adds a shared `ext_staticlib_filename(stem, target_triple)` helper (`<stem>.lib` on Windows, `lib<stem>.a` otherwise) and routes both locations through it — primary path, the cross-compile/workspace fallbacks, and the diagnostic messages. POSIX/macOS naming is byte-for-byte unchanged (zero risk to the working platforms).

## Validation

Compiled a large real-world `ws`-using application (the Hone IDE, ~125 modules) with `perry compile … --target windows`: the five `js_ws_*` undefined-symbol errors are gone and `perry_ext_ws.lib` is correctly picked up and linked. `cargo check --release -p perry` clean.

Per CONTRIBUTING / CLAUDE.md external-contributor rule, this PR intentionally does not touch `[workspace.package] version`, `CLAUDE.md`, or `CHANGELOG.md` — maintainer to fold in at merge.