### PR TITLE
fix(object): skip misaligned non-object pointers in js_object_assign_one

### DIFF
--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -2470,7 +2470,16 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
     } else {
         tgt_bits as usize
     };
-    if tgt_raw < 0x10000 {
+    // A real `ObjectHeader` is heap-allocated and #[repr(C)] with u64 /
+    // pointer fields, so a valid object pointer is always 8-byte aligned.
+    // The tag / `< 0x10000` checks let an untagged, unaligned bit pattern
+    // through (observed on Windows: a non-pointer value reaches here as
+    // `source`, e.g. 0x1d81ff6950a). Dereferencing it as `*ObjectHeader`
+    // is a misaligned read — a hard abort under debug pointer-alignment
+    // checks, silent memory corruption (→ later GC out-of-bounds) in
+    // release. Treat a misaligned value as a non-object and skip, exactly
+    // the documented behaviour for `Object.assign(t, <non-object>)`.
+    if tgt_raw < 0x10000 || tgt_raw % 8 != 0 {
         return target_f64;
     }
 
@@ -2485,7 +2494,10 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
     } else {
         src_bits as usize
     };
-    if src_raw < 0x10000 || src_raw == tgt_raw {
+    // Same alignment guard as the target above — `src` is dereferenced at
+    // `(*src).keys_array` just below; an unaligned non-object source must
+    // be skipped, not dereferenced.
+    if src_raw < 0x10000 || src_raw % 8 != 0 || src_raw == tgt_raw {
         return target_f64;
     }
 


### PR DESCRIPTION
## Problem

`js_object_assign_one` (the single-source `Object.assign` helper) decodes its target/source args permissively and is **documented** to skip non-object sources (`Object.assign(t, 5)` / `null` are spec-allowed no-ops). Its bailout only rejected NaN-boxed specials (`top16 >= 0x7FF8`) and small values (`< 0x10000`). An **untagged, unaligned** bit pattern slipped through and was dereferenced as `*const ObjectHeader` at `(*src).keys_array`.

A real `ObjectHeader` is heap-allocated `#[repr(C)]` with `u64`/pointer fields, so any valid object pointer is 8-byte aligned. Reproduced on a **Windows release build** of a large Perry app (Hone IDE): a non-pointer value (e.g. `0x1d81ff6950a`, `0x25ab669950a`) reached `source`, and `(*src).keys_array` is then a misaligned read —

```
panicked at crates/perry-runtime/src/object.rs:2497:20:
misaligned pointer dereference: address must be a multiple of 0x8 but is 0x1d81ff6950a
```

— a hard abort under debug pointer-alignment checks, and in **release** a silent misaligned read that corrupts state and surfaces later as an unrelated GC out-of-bounds panic.

## Fix

Add an 8-byte alignment check to the existing defensive bailout for **both** target and source: a misaligned value is not a real object pointer, so skip it — exactly the no-op this function already documents for non-object arguments. Turns the crash into the spec-correct behaviour. POSIX/macOS unaffected (aligned pointers pass unchanged).

## Validation

Verified end-to-end: with this patch the `object.rs:2497` misaligned-deref panic **no longer occurs** in the Windows build that reproduced it 100% before (confirmed across multiple runs; the app now progresses past this point).

## Scope note

This hardens the runtime entry point and is correct on its own merits (consistent with the function's documented contract). *Why* a non-pointer value reaches `source` on Windows release builds is a separate codegen question worth root-causing independently.

Per CONTRIBUTING / CLAUDE.md external-contributor rule, this PR intentionally does not touch `[workspace.package] version`, `CLAUDE.md`, or `CHANGELOG.md`.