### PR TITLE
fix(jsruntime): harden JS export snapshots

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -314,6 +314,12 @@ jobs:
           PERRY_NO_AUTO_OPTIMIZE=1 \
           scripts/run_native_no_fallback_tests.sh
 
+      - name: Jsruntime promise gate
+        run: |
+          PERRY_BIN="$PWD/target/release/perry" \
+          PERRY_NO_AUTO_OPTIMIZE=1 \
+          scripts/run_jsruntime_promise_tests.sh
+
       - name: Compile all test files
         run: |
           set -uo pipefail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -308,6 +308,12 @@ jobs:
       - name: Build compiler
         run: cargo build --release
 
+      - name: Native no-fallback gate
+        run: |
+          PERRY_BIN="$PWD/target/release/perry" \
+          PERRY_NO_AUTO_OPTIMIZE=1 \
+          scripts/run_native_no_fallback_tests.sh
+
       - name: Compile all test files
         run: |
           set -uo pipefail

--- a/crates/perry-codegen/src/codegen.rs
+++ b/crates/perry-codegen/src/codegen.rs
@@ -4793,6 +4793,7 @@ fn compile_module_entry(
                     let _ = ctx.block().call(I32, "js_interval_timer_tick", &[]);
                 }
                 ctx.block().call_void("js_run_stdlib_pump", &[]);
+                ctx.block().call_void("js_run_jsruntime_pump", &[]);
                 ctx.block().br(&header_label);
 
                 // loop_header: check if there's any reason to keep running
@@ -4801,6 +4802,9 @@ fn compile_module_entry(
                 let has_callbacks = ctx.block().call(I32, "js_callback_timer_has_pending", &[]);
                 let has_intervals = ctx.block().call(I32, "js_interval_timer_has_pending", &[]);
                 let has_stdlib = ctx.block().call(I32, "js_stdlib_has_active_handles", &[]);
+                let has_jsruntime = ctx
+                    .block()
+                    .call(I32, "js_jsruntime_has_active_handles", &[]);
                 // #591: TASK_QUEUE may carry a pending `.then` continuation
                 // that was queued by `js_run_stdlib_pump`'s resolution path
                 // in the SAME body iteration that already drained the inflight
@@ -4810,7 +4814,8 @@ fn compile_module_entry(
                 let has_microtasks = ctx.block().call(I32, "js_microtasks_pending", &[]);
                 let any1 = ctx.block().or(I32, &has_timers, &has_callbacks);
                 let any2 = ctx.block().or(I32, &has_intervals, &has_stdlib);
-                let any3 = ctx.block().or(I32, &any1, &any2);
+                let any_js = ctx.block().or(I32, &any2, &has_jsruntime);
+                let any3 = ctx.block().or(I32, &any1, &any_js);
                 let any = ctx.block().or(I32, &any3, &has_microtasks);
                 let zero = "0".to_string();
                 let cmp = ctx.block().icmp_ne(I32, &any, &zero);
@@ -4823,6 +4828,7 @@ fn compile_module_entry(
                 let _ = ctx.block().call(I32, "js_callback_timer_tick", &[]);
                 let _ = ctx.block().call(I32, "js_interval_timer_tick", &[]);
                 ctx.block().call_void("js_run_stdlib_pump", &[]);
+                ctx.block().call_void("js_run_jsruntime_pump", &[]);
                 // Issue #84: condvar-backed wait. Returns immediately when
                 // a tokio worker (net/ws/http/fetch/redis/spawn) notifies
                 // after pushing to its queue; otherwise blocks until the

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -9985,9 +9985,17 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // and the await would resolve with the object instead of
             // calling its `.then` (drizzle-orm's `QueryPromise.execute()`
             // never ran for `await db.select().from(users)`).
-            let promise_box =
+            let assimilated_box =
                 ctx.block()
                     .call(DOUBLE, "js_assimilate_thenable", &[(DOUBLE, &raw_operand)]);
+            // V8 fallback promises cross into native code as JS_HANDLE_TAG
+            // values. Route the value through the registered adapter before
+            // the native Promise check so await polls a real Perry Promise.
+            let promise_box = ctx.block().call(
+                DOUBLE,
+                "js_await_any_promise",
+                &[(DOUBLE, &assimilated_box)],
+            );
 
             // Defensive guard: if the operand is not actually a
             // Promise (e.g. `await someNumber` or an unsupported
@@ -10073,6 +10081,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // results via queue_promise_resolution and need this pump
             // to actually resolve the promises on the main thread.
             ctx.block().call_void("js_run_stdlib_pump", &[]);
+            ctx.block().call_void("js_run_jsruntime_pump", &[]);
             let _ = ctx.block().call(I32, "js_timer_tick", &[]);
             let _ = ctx.block().call(I32, "js_callback_timer_tick", &[]);
             let _ = ctx.block().call(I32, "js_interval_timer_tick", &[]);

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -1084,6 +1084,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // perry-runtime as a thin function-pointer trampoline so it's
     // safe to call even when perry-stdlib is not linked (no-op).
     module.declare_function("js_run_stdlib_pump", VOID, &[]);
+    // Drain perry-jsruntime's V8 promise adapter queue. Also a thin
+    // perry-runtime trampoline, so non-jsruntime builds pay only a no-op.
+    module.declare_function("js_run_jsruntime_pump", VOID, &[]);
     module.declare_function("js_sleep_ms", VOID, &[DOUBLE]);
     // Issue #84: condvar-backed wait for the event loop / await busy-wait.
     // Replaces fixed-quantum `js_sleep_ms(10.0)` / `js_sleep_ms(1.0)`.
@@ -1148,6 +1151,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // Stdlib has-active-handles — returns 1 if WS servers, pending
     // HTTP events, etc. need the loop to keep running.
     module.declare_function("js_stdlib_has_active_handles", I32, &[]);
+    // JS runtime has-active-handles — returns 1 if V8 fallback promises are
+    // adapted into native Promises and still pending.
+    module.declare_function("js_jsruntime_has_active_handles", I32, &[]);
     // #591: returns 1 iff perry-runtime's per-thread microtask
     // TASK_QUEUE has a pending entry. The codegen-emitted event-loop
     // header check ORs this in so the loop doesn't exit between the

--- a/crates/perry-jsruntime/src/bridge.rs
+++ b/crates/perry-jsruntime/src/bridge.rs
@@ -58,6 +58,17 @@ struct ExportSnapshotIntrinsics {
 
 pub fn capture_export_snapshot_intrinsics(scope: &mut v8::PinScope<'_, '_>) {
     let Some(intrinsics) = load_export_snapshot_intrinsics(scope) else {
+        // If the lookup of `globalThis.Object` / its `prototype` / `isFrozen`
+        // ever fails at runtime init, every export-data-object fast-path
+        // eligibility check will silently return false (`is_plain_object`
+        // requires the intrinsics cell to be set). That would manifest as a
+        // perf cliff rather than a correctness bug — surface it loudly so
+        // regressions don't hide as "slow but still working".
+        eprintln!(
+            "perry-jsruntime: failed to capture Object intrinsics at init; \
+             JS export-data-object snapshot fast path disabled \
+             (every export read will go through V8 fallback)"
+        );
         return;
     };
     EXPORT_SNAPSHOT_INTRINSICS.with(|cell| {

--- a/crates/perry-jsruntime/src/bridge.rs
+++ b/crates/perry-jsruntime/src/bridge.rs
@@ -14,7 +14,7 @@ use perry_runtime::JSValue;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 
-use crate::interop::{bump_v8_entry, V8EntryKind};
+use crate::interop::{bump_js_handle_released, bump_js_handle_stored, bump_v8_entry, V8EntryKind};
 
 // NaN-boxing constants (must match perry-runtime/src/value.rs)
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
@@ -158,6 +158,7 @@ pub fn store_js_handle(scope: &mut v8::PinScope<'_, '_>, value: v8::Local<v8::Va
     JS_OBJECT_HANDLES.with(|handles| {
         handles.borrow_mut().insert(handle_id, global);
     });
+    bump_js_handle_stored();
     handle_id
 }
 
@@ -176,7 +177,11 @@ pub fn get_js_handle<'s>(
 
 /// Release a V8 handle from the table
 pub fn release_js_handle(handle: u64) -> bool {
-    JS_OBJECT_HANDLES.with(|handles| handles.borrow_mut().remove(&handle).is_some())
+    let released = JS_OBJECT_HANDLES.with(|handles| handles.borrow_mut().remove(&handle).is_some());
+    if released {
+        bump_js_handle_released();
+    }
+    released
 }
 
 /// Check if a NaN-boxed value is a JS handle
@@ -504,11 +509,13 @@ fn native_promise_to_v8<'s>(
     let v8_promise = resolver.get_promise(scope);
     match perry_runtime::promise::js_promise_state(promise) {
         1 => {
+            bump_v8_entry(V8EntryKind::NativePromiseResolve);
             let value = perry_runtime::promise::js_promise_value(promise);
             let v8_value = native_to_v8(scope, value);
             let _ = resolver.resolve(scope, v8_value);
         }
         2 => {
+            bump_v8_entry(V8EntryKind::NativePromiseReject);
             let reason = perry_runtime::promise::js_promise_reason(promise);
             let v8_reason = native_to_v8(scope, reason);
             let _ = resolver.reject(scope, v8_reason);

--- a/crates/perry-jsruntime/src/bridge.rs
+++ b/crates/perry-jsruntime/src/bridge.rs
@@ -14,6 +14,8 @@ use perry_runtime::JSValue;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 
+use crate::interop::{bump_v8_entry, V8EntryKind};
+
 // NaN-boxing constants (must match perry-runtime/src/value.rs)
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
@@ -462,6 +464,7 @@ extern "C" fn native_promise_v8_resolve(
     closure: *const perry_runtime::closure::ClosureHeader,
     value: f64,
 ) -> f64 {
+    bump_v8_entry(V8EntryKind::NativePromiseResolve);
     let resolver_id = perry_runtime::closure::js_closure_get_capture_f64(closure, 0) as u64;
     crate::with_runtime(|state| {
         deno_core::scope!(scope, &mut state.runtime);
@@ -478,6 +481,7 @@ extern "C" fn native_promise_v8_reject(
     closure: *const perry_runtime::closure::ClosureHeader,
     reason: f64,
 ) -> f64 {
+    bump_v8_entry(V8EntryKind::NativePromiseReject);
     let resolver_id = perry_runtime::closure::js_closure_get_capture_f64(closure, 0) as u64;
     crate::with_runtime(|state| {
         deno_core::scope!(scope, &mut state.runtime);

--- a/crates/perry-jsruntime/src/bridge.rs
+++ b/crates/perry-jsruntime/src/bridge.rs
@@ -38,8 +38,11 @@ thread_local! {
     static JS_OBJECT_HANDLES: RefCell<HashMap<u64, v8::Global<v8::Value>>> = RefCell::new(HashMap::new());
     /// Stable V8 constructor-like wrappers for Perry class references.
     static NATIVE_CLASS_HANDLES: RefCell<HashMap<u32, v8::Global<v8::Value>>> = RefCell::new(HashMap::new());
+    /// V8 Promise resolvers waiting on native Perry promises returned through callbacks.
+    static NATIVE_PROMISE_RESOLVERS: RefCell<HashMap<u64, v8::Global<v8::PromiseResolver>>> = RefCell::new(HashMap::new());
     /// Counter for generating unique handle IDs
     static NEXT_HANDLE_ID: Cell<u64> = const { Cell::new(1) };
+    static NEXT_NATIVE_PROMISE_RESOLVER_ID: Cell<u64> = const { Cell::new(1) };
 }
 
 fn native_class_constructor(
@@ -193,6 +196,35 @@ pub fn get_handle_id(value: f64) -> Option<u64> {
 /// Create a NaN-boxed value representing a JS handle
 pub fn make_js_handle_value(handle_id: u64) -> f64 {
     f64::from_bits(JS_HANDLE_TAG | (handle_id & POINTER_MASK))
+}
+
+fn store_native_promise_resolver(
+    scope: &mut v8::PinScope<'_, '_>,
+    resolver: v8::Local<v8::PromiseResolver>,
+) -> u64 {
+    let resolver_id = NEXT_NATIVE_PROMISE_RESOLVER_ID.with(|id| {
+        let current = id.get();
+        id.set(current + 1);
+        current
+    });
+    NATIVE_PROMISE_RESOLVERS.with(|resolvers| {
+        resolvers
+            .borrow_mut()
+            .insert(resolver_id, v8::Global::new(scope, resolver));
+    });
+    resolver_id
+}
+
+fn take_native_promise_resolver<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    resolver_id: u64,
+) -> Option<v8::Local<'s, v8::PromiseResolver>> {
+    NATIVE_PROMISE_RESOLVERS.with(|resolvers| {
+        resolvers
+            .borrow_mut()
+            .remove(&resolver_id)
+            .map(|resolver| v8::Local::new(scope, resolver))
+    })
 }
 
 /// Fix up a native value for JS interop boundary.
@@ -426,6 +458,80 @@ fn rust_string_to_native(s: &str) -> *const u8 {
     js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) as *const u8
 }
 
+extern "C" fn native_promise_v8_resolve(
+    closure: *const perry_runtime::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    let resolver_id = perry_runtime::closure::js_closure_get_capture_f64(closure, 0) as u64;
+    crate::with_runtime(|state| {
+        deno_core::scope!(scope, &mut state.runtime);
+        if let Some(resolver) = take_native_promise_resolver(scope, resolver_id) {
+            let v8_value = native_to_v8(scope, value);
+            let _ = resolver.resolve(scope, v8_value);
+        }
+    });
+    perry_runtime::event_pump::js_notify_main_thread();
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn native_promise_v8_reject(
+    closure: *const perry_runtime::closure::ClosureHeader,
+    reason: f64,
+) -> f64 {
+    let resolver_id = perry_runtime::closure::js_closure_get_capture_f64(closure, 0) as u64;
+    crate::with_runtime(|state| {
+        deno_core::scope!(scope, &mut state.runtime);
+        if let Some(resolver) = take_native_promise_resolver(scope, resolver_id) {
+            let v8_reason = native_to_v8(scope, reason);
+            let _ = resolver.reject(scope, v8_reason);
+        }
+    });
+    perry_runtime::event_pump::js_notify_main_thread();
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+fn native_promise_to_v8<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    promise: *mut perry_runtime::promise::Promise,
+) -> v8::Local<'s, v8::Value> {
+    let Some(resolver) = v8::PromiseResolver::new(scope) else {
+        return v8::undefined(scope).into();
+    };
+    let v8_promise = resolver.get_promise(scope);
+    match perry_runtime::promise::js_promise_state(promise) {
+        1 => {
+            let value = perry_runtime::promise::js_promise_value(promise);
+            let v8_value = native_to_v8(scope, value);
+            let _ = resolver.resolve(scope, v8_value);
+        }
+        2 => {
+            let reason = perry_runtime::promise::js_promise_reason(promise);
+            let v8_reason = native_to_v8(scope, reason);
+            let _ = resolver.reject(scope, v8_reason);
+        }
+        _ => {
+            let resolver_id = store_native_promise_resolver(scope, resolver);
+            let resolve_closure =
+                perry_runtime::closure::js_closure_alloc(native_promise_v8_resolve as *const u8, 1);
+            let reject_closure =
+                perry_runtime::closure::js_closure_alloc(native_promise_v8_reject as *const u8, 1);
+            perry_runtime::closure::js_closure_set_capture_f64(
+                resolve_closure,
+                0,
+                resolver_id as f64,
+            );
+            perry_runtime::closure::js_closure_set_capture_f64(
+                reject_closure,
+                0,
+                resolver_id as f64,
+            );
+            let _ =
+                perry_runtime::promise::js_promise_then(promise, resolve_closure, reject_closure);
+        }
+    }
+    v8_promise.into()
+}
+
 /// Convert a native object pointer to a V8 object
 fn native_object_to_v8<'s>(
     scope: &mut v8::PinScope<'s, '_>,
@@ -441,6 +547,10 @@ fn native_object_to_v8<'s>(
     if gc_header_ptr > 0x1000 {
         let gc_header = unsafe { &*(gc_header_ptr as *const perry_runtime::gc::GcHeader) };
         let is_arena = (gc_header.gc_flags & perry_runtime::gc::GC_FLAG_ARENA) != 0;
+
+        if gc_header.obj_type == perry_runtime::gc::GC_TYPE_PROMISE {
+            return native_promise_to_v8(scope, ptr as *mut perry_runtime::promise::Promise);
+        }
 
         if is_arena && gc_header.obj_type == perry_runtime::gc::GC_TYPE_ARRAY {
             // GC-tracked array: ArrayHeader { length: u32, capacity: u32 } + f64 elements

--- a/crates/perry-jsruntime/src/bridge.rs
+++ b/crates/perry-jsruntime/src/bridge.rs
@@ -42,9 +42,48 @@ thread_local! {
     static NATIVE_CLASS_HANDLES: RefCell<HashMap<u32, v8::Global<v8::Value>>> = RefCell::new(HashMap::new());
     /// V8 Promise resolvers waiting on native Perry promises returned through callbacks.
     static NATIVE_PROMISE_RESOLVERS: RefCell<HashMap<u64, v8::Global<v8::PromiseResolver>>> = RefCell::new(HashMap::new());
+    /// Snapshot of untampered intrinsics used by the conservative JS export
+    /// data-object fast path. Captured during `js_runtime_init`, before user
+    /// modules can replace `globalThis.Object` or its methods.
+    static EXPORT_SNAPSHOT_INTRINSICS: RefCell<Option<ExportSnapshotIntrinsics>> = const { RefCell::new(None) };
     /// Counter for generating unique handle IDs
     static NEXT_HANDLE_ID: Cell<u64> = const { Cell::new(1) };
     static NEXT_NATIVE_PROMISE_RESOLVER_ID: Cell<u64> = const { Cell::new(1) };
+}
+
+struct ExportSnapshotIntrinsics {
+    object_prototype: v8::Global<v8::Value>,
+    object_is_frozen: v8::Global<v8::Function>,
+}
+
+pub fn capture_export_snapshot_intrinsics(scope: &mut v8::PinScope<'_, '_>) {
+    let Some(intrinsics) = load_export_snapshot_intrinsics(scope) else {
+        return;
+    };
+    EXPORT_SNAPSHOT_INTRINSICS.with(|cell| {
+        *cell.borrow_mut() = Some(intrinsics);
+    });
+}
+
+fn load_export_snapshot_intrinsics(
+    scope: &mut v8::PinScope<'_, '_>,
+) -> Option<ExportSnapshotIntrinsics> {
+    let global = scope.get_current_context().global(scope);
+    let object_key = v8::String::new(scope, "Object")?;
+    let object_value = global.get(scope, object_key.into())?;
+    let object_ctor = v8::Local::<v8::Object>::try_from(object_value).ok()?;
+
+    let prototype_key = v8::String::new(scope, "prototype")?;
+    let object_prototype = object_ctor.get(scope, prototype_key.into())?;
+
+    let is_frozen_key = v8::String::new(scope, "isFrozen")?;
+    let is_frozen_value = object_ctor.get(scope, is_frozen_key.into())?;
+    let object_is_frozen = v8::Local::<v8::Function>::try_from(is_frozen_value).ok()?;
+
+    Some(ExportSnapshotIntrinsics {
+        object_prototype: v8::Global::new(scope, object_prototype),
+        object_is_frozen: v8::Global::new(scope, object_is_frozen),
+    })
 }
 
 fn native_class_constructor(
@@ -416,6 +455,24 @@ pub fn v8_to_native(scope: &mut v8::PinScope<'_, '_>, value: v8::Local<v8::Value
     f64::from_bits(TAG_UNDEFINED)
 }
 
+/// Convert JS module-export values to Perry values.
+///
+/// Frozen plain data objects exported from JS modules are safe to snapshot into
+/// native Perry objects. That keeps follow-on property reads on constants like
+/// `MODULE_METADATA.PROVIDERS` native instead of bouncing back into V8 for each
+/// field. Mutable objects, accessors, proxies, custom prototypes, functions,
+/// promises, arrays, symbols, or nested non-data values stay as V8 handles.
+pub fn v8_to_native_export_value(
+    scope: &mut v8::PinScope<'_, '_>,
+    value: v8::Local<v8::Value>,
+) -> f64 {
+    if let Some(snapshot) = v8_plain_data_object_to_native(scope, value, 0) {
+        return snapshot;
+    }
+
+    v8_to_native(scope, value)
+}
+
 /// Convert a V8 value to a native NaN-boxed value, converting arrays to native arrays
 ///
 /// This variant converts arrays to native Perry arrays instead of JS handles.
@@ -431,6 +488,226 @@ pub fn v8_to_native_array(scope: &mut v8::PinScope<'_, '_>, value: v8::Local<v8:
 
     // For everything else, use the standard conversion
     v8_to_native(scope, value)
+}
+
+fn v8_plain_data_object_to_native(
+    scope: &mut v8::PinScope<'_, '_>,
+    value: v8::Local<v8::Value>,
+    depth: usize,
+) -> Option<f64> {
+    if depth > 4
+        || value.is_function()
+        || value.is_array()
+        || value.is_promise()
+        || v8_value_is_proxy(scope, value)
+        || !value.is_object()
+    {
+        return None;
+    }
+
+    let obj = v8::Local::<v8::Object>::try_from(value).ok()?;
+    if !is_plain_object(scope, obj) {
+        return None;
+    }
+    if !v8_object_is_frozen(scope, obj)? {
+        return None;
+    }
+
+    let mut names_args = v8::GetPropertyNamesArgsBuilder::new();
+    let names = obj.get_own_property_names(
+        scope,
+        names_args
+            .mode(v8::KeyCollectionMode::OwnOnly)
+            .property_filter(v8::PropertyFilter::ALL_PROPERTIES)
+            .index_filter(v8::IndexFilter::IncludeIndices)
+            .key_conversion(v8::KeyConversionMode::ConvertToString)
+            .build(),
+    )?;
+    if names.length() == 0 {
+        return None;
+    }
+    let mut fields: Vec<(String, f64)> = Vec::with_capacity(names.length() as usize);
+
+    for i in 0..names.length() {
+        let key = names.get_index(scope, i)?;
+        if key.is_symbol() {
+            return None;
+        }
+        let key_string = key.to_string(scope)?.to_rust_string_lossy(scope);
+        let field_value = frozen_data_descriptor_value(scope, obj, key)?;
+        let native_value =
+            if let Some(snapshot) = v8_plain_data_object_to_native(scope, field_value, depth + 1) {
+                snapshot
+            } else if is_plain_data_leaf(field_value) {
+                v8_to_native(scope, field_value)
+            } else {
+                return None;
+            };
+        fields.push((key_string, native_value));
+    }
+
+    let native_obj = perry_runtime::js_object_alloc(0, 0);
+    for (key, value) in fields {
+        let key_ptr = perry_runtime::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+        perry_runtime::js_object_set_field_by_name(native_obj, key_ptr, value);
+    }
+
+    Some(f64::from_bits(
+        POINTER_TAG | (native_obj as u64 & POINTER_MASK),
+    ))
+}
+
+fn is_plain_data_leaf(value: v8::Local<v8::Value>) -> bool {
+    value.is_undefined()
+        || value.is_null()
+        || value.is_boolean()
+        || value.is_number()
+        || value.is_string()
+        || value.is_big_int()
+}
+
+fn v8_value_is_proxy(scope: &mut v8::PinScope<'_, '_>, value: v8::Local<v8::Value>) -> bool {
+    if value.is_proxy() {
+        return true;
+    }
+
+    let global = scope.get_current_context().global(scope);
+    let Some(deno_key) = v8::String::new(scope, "Deno") else {
+        return false;
+    };
+    let Some(deno_value) = global.get(scope, deno_key.into()) else {
+        return false;
+    };
+    let Ok(deno) = v8::Local::<v8::Object>::try_from(deno_value) else {
+        return false;
+    };
+    let Some(core_key) = v8::String::new(scope, "core") else {
+        return false;
+    };
+    let Some(core_value) = deno.get(scope, core_key.into()) else {
+        return false;
+    };
+    let Ok(core) = v8::Local::<v8::Object>::try_from(core_value) else {
+        return false;
+    };
+
+    if call_v8_boolean_method(scope, core, "isProxy", value).unwrap_or(false) {
+        return true;
+    }
+
+    let Some(ops_key) = v8::String::new(scope, "ops") else {
+        return false;
+    };
+    let Some(ops_value) = core.get(scope, ops_key.into()) else {
+        return false;
+    };
+    let Ok(ops) = v8::Local::<v8::Object>::try_from(ops_value) else {
+        return false;
+    };
+    call_v8_boolean_method(scope, ops, "op_is_proxy", value).unwrap_or(false)
+}
+
+fn call_v8_boolean_method(
+    scope: &mut v8::PinScope<'_, '_>,
+    receiver: v8::Local<v8::Object>,
+    method_name: &str,
+    arg: v8::Local<v8::Value>,
+) -> Option<bool> {
+    let key = v8::String::new(scope, method_name)?;
+    let method_value = receiver.get(scope, key.into())?;
+    let method = v8::Local::<v8::Function>::try_from(method_value).ok()?;
+    let result = method.call(scope, receiver.into(), &[arg])?;
+    if result.is_boolean() {
+        Some(result.boolean_value(scope))
+    } else {
+        None
+    }
+}
+
+fn is_plain_object(scope: &mut v8::PinScope<'_, '_>, obj: v8::Local<v8::Object>) -> bool {
+    let Some(proto) = obj.get_prototype(scope) else {
+        return false;
+    };
+    if proto.is_null() {
+        return true;
+    }
+
+    EXPORT_SNAPSHOT_INTRINSICS.with(|cell| {
+        let intrinsics = cell.borrow();
+        let Some(intrinsics) = intrinsics.as_ref() else {
+            return false;
+        };
+        let object_proto = v8::Local::new(scope, &intrinsics.object_prototype);
+        proto.strict_equals(object_proto)
+    })
+}
+
+fn v8_object_is_frozen(
+    scope: &mut v8::PinScope<'_, '_>,
+    obj: v8::Local<v8::Object>,
+) -> Option<bool> {
+    EXPORT_SNAPSHOT_INTRINSICS.with(|cell| {
+        let intrinsics = cell.borrow();
+        let intrinsics = intrinsics.as_ref()?;
+        let is_frozen = v8::Local::new(scope, &intrinsics.object_is_frozen);
+        let receiver = v8::undefined(scope).into();
+        let obj_value: v8::Local<v8::Value> = obj.into();
+        let result = is_frozen.call(scope, receiver, &[obj_value])?;
+        if result.is_boolean() {
+            Some(result.boolean_value(scope))
+        } else {
+            None
+        }
+    })
+}
+
+fn frozen_data_descriptor_value<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    obj: v8::Local<v8::Object>,
+    key: v8::Local<v8::Value>,
+) -> Option<v8::Local<'s, v8::Value>> {
+    let name = v8::Local::<v8::Name>::try_from(key).ok()?;
+    let descriptor_value = obj.get_own_property_descriptor(scope, name)?;
+    if descriptor_value.is_undefined() || !descriptor_value.is_object() {
+        return None;
+    }
+    let descriptor = v8::Local::<v8::Object>::try_from(descriptor_value).ok()?;
+
+    let get_key = v8::String::new(scope, "get")?;
+    let getter = descriptor.get(scope, get_key.into())?;
+    if !getter.is_undefined() {
+        return None;
+    }
+
+    let set_key = v8::String::new(scope, "set")?;
+    let setter = descriptor.get(scope, set_key.into())?;
+    if !setter.is_undefined() {
+        return None;
+    }
+
+    let writable_key = v8::String::new(scope, "writable")?;
+    let writable = descriptor.get(scope, writable_key.into())?;
+    if !writable.is_boolean() || writable.boolean_value(scope) {
+        return None;
+    }
+
+    let configurable_key = v8::String::new(scope, "configurable")?;
+    let configurable = descriptor.get(scope, configurable_key.into())?;
+    if !configurable.is_boolean() || configurable.boolean_value(scope) {
+        return None;
+    }
+
+    let value_key = v8::String::new(scope, "value")?;
+    if !descriptor.has(scope, value_key.into())? {
+        return None;
+    }
+    let descriptor_value = descriptor.get(scope, value_key.into())?;
+    let current_value = obj.get(scope, key)?;
+    if !current_value.same_value(descriptor_value) {
+        return None;
+    }
+
+    Some(descriptor_value)
 }
 
 /// Convert a native string pointer to a Rust String

--- a/crates/perry-jsruntime/src/interop.rs
+++ b/crates/perry-jsruntime/src/interop.rs
@@ -41,10 +41,67 @@ static JSRUNTIME_ADAPTERS_CREATED: AtomicU64 = AtomicU64::new(0);
 static JSRUNTIME_ADAPTERS_RESOLVED: AtomicU64 = AtomicU64::new(0);
 static JSRUNTIME_ADAPTERS_REJECTED: AtomicU64 = AtomicU64::new(0);
 static JSRUNTIME_LEGACY_BLOCKING_AWAITS: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_V8_ENTRIES_TOTAL: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_RUNTIME_INIT: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_RUNTIME_SHUTDOWN: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_MODULE_LOAD: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_EXPORT_GET: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_FUNCTION_CALL: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_V8_EXPORT_CALL: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_METHOD_CALL: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_VALUE_CALL: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_ARRAY_GET: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_ARRAY_LENGTH: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_OBJECT_PROPERTY_GET: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_HANDLE_TO_STRING: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_PROPERTY_SET: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_NEW_INSTANCE: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_NEW_FROM_HANDLE: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_CALLBACK_CREATE: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_NATIVE_FUNCTION_REGISTER: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_CALLBACK_INVOKE: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_NATIVE_MODULE_PROPERTY_LOAD: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_TYPEOF_PROBE: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_HANDLE_CONSTRUCTOR: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_SHOULD_USE_RUNTIME: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_NATIVE_PROMISE_RESOLVE: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_NATIVE_PROMISE_REJECT: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_FOREIGN_PROMISE_ADAPTER: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ENTRY_LEGACY_BLOCKING_AWAIT: AtomicU64 = AtomicU64::new(0);
 
 unsafe extern "C" {
     fn js_register_jsruntime_pump(f: extern "C" fn() -> i32);
     fn js_register_jsruntime_has_active(f: extern "C" fn() -> i32);
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum V8EntryKind {
+    RuntimeInit,
+    RuntimeShutdown,
+    ModuleLoad,
+    ExportGet,
+    FunctionCall,
+    V8ExportCall,
+    MethodCall,
+    ValueCall,
+    ArrayGet,
+    ArrayLength,
+    ObjectPropertyGet,
+    HandleToString,
+    PropertySet,
+    NewInstance,
+    NewFromHandle,
+    CallbackCreate,
+    NativeFunctionRegister,
+    CallbackInvoke,
+    NativeModulePropertyLoad,
+    TypeofProbe,
+    HandleConstructor,
+    ShouldUseRuntime,
+    NativePromiseResolve,
+    NativePromiseReject,
+    ForeignPromiseAdapter,
+    LegacyBlockingAwait,
 }
 
 fn jsruntime_profile_enabled() -> bool {
@@ -57,17 +114,77 @@ fn bump_jsruntime(counter: &AtomicU64) {
     }
 }
 
+pub(crate) fn bump_v8_entry(kind: V8EntryKind) {
+    jsruntime_profile_register();
+    bump_jsruntime(&JSRUNTIME_V8_ENTRIES_TOTAL);
+    bump_jsruntime(match kind {
+        V8EntryKind::RuntimeInit => &JSRUNTIME_ENTRY_RUNTIME_INIT,
+        V8EntryKind::RuntimeShutdown => &JSRUNTIME_ENTRY_RUNTIME_SHUTDOWN,
+        V8EntryKind::ModuleLoad => &JSRUNTIME_ENTRY_MODULE_LOAD,
+        V8EntryKind::ExportGet => &JSRUNTIME_ENTRY_EXPORT_GET,
+        V8EntryKind::FunctionCall => &JSRUNTIME_ENTRY_FUNCTION_CALL,
+        V8EntryKind::V8ExportCall => &JSRUNTIME_ENTRY_V8_EXPORT_CALL,
+        V8EntryKind::MethodCall => &JSRUNTIME_ENTRY_METHOD_CALL,
+        V8EntryKind::ValueCall => &JSRUNTIME_ENTRY_VALUE_CALL,
+        V8EntryKind::ArrayGet => &JSRUNTIME_ENTRY_ARRAY_GET,
+        V8EntryKind::ArrayLength => &JSRUNTIME_ENTRY_ARRAY_LENGTH,
+        V8EntryKind::ObjectPropertyGet => &JSRUNTIME_ENTRY_OBJECT_PROPERTY_GET,
+        V8EntryKind::HandleToString => &JSRUNTIME_ENTRY_HANDLE_TO_STRING,
+        V8EntryKind::PropertySet => &JSRUNTIME_ENTRY_PROPERTY_SET,
+        V8EntryKind::NewInstance => &JSRUNTIME_ENTRY_NEW_INSTANCE,
+        V8EntryKind::NewFromHandle => &JSRUNTIME_ENTRY_NEW_FROM_HANDLE,
+        V8EntryKind::CallbackCreate => &JSRUNTIME_ENTRY_CALLBACK_CREATE,
+        V8EntryKind::NativeFunctionRegister => &JSRUNTIME_ENTRY_NATIVE_FUNCTION_REGISTER,
+        V8EntryKind::CallbackInvoke => &JSRUNTIME_ENTRY_CALLBACK_INVOKE,
+        V8EntryKind::NativeModulePropertyLoad => &JSRUNTIME_ENTRY_NATIVE_MODULE_PROPERTY_LOAD,
+        V8EntryKind::TypeofProbe => &JSRUNTIME_ENTRY_TYPEOF_PROBE,
+        V8EntryKind::HandleConstructor => &JSRUNTIME_ENTRY_HANDLE_CONSTRUCTOR,
+        V8EntryKind::ShouldUseRuntime => &JSRUNTIME_ENTRY_SHOULD_USE_RUNTIME,
+        V8EntryKind::NativePromiseResolve => &JSRUNTIME_ENTRY_NATIVE_PROMISE_RESOLVE,
+        V8EntryKind::NativePromiseReject => &JSRUNTIME_ENTRY_NATIVE_PROMISE_REJECT,
+        V8EntryKind::ForeignPromiseAdapter => &JSRUNTIME_ENTRY_FOREIGN_PROMISE_ADAPTER,
+        V8EntryKind::LegacyBlockingAwait => &JSRUNTIME_ENTRY_LEGACY_BLOCKING_AWAIT,
+    });
+}
+
 extern "C" fn jsruntime_profile_atexit() {
     if std::env::var_os("PERRY_JSRUNTIME_PROFILE").is_none() {
         return;
     }
     eprintln!(
-        "[jsruntime-profile] pump_ticks={} adapters_created={} adapters_resolved={} adapters_rejected={} legacy_blocking_awaits={}",
+        "[jsruntime-profile] pump_ticks={} adapters_created={} adapters_resolved={} adapters_rejected={} legacy_blocking_awaits={} v8_entries_total={} runtime_inits={} runtime_shutdowns={} module_loads={} export_gets={} function_calls={} v8_export_calls={} method_calls={} value_calls={} array_gets={} array_lengths={} object_property_gets={} handle_to_strings={} property_sets={} new_instances={} new_from_handles={} callback_creates={} native_function_registers={} callback_invokes={} native_module_property_loads={} typeof_probes={} handle_constructors={} should_use_runtime={} native_promise_resolves={} native_promise_rejects={} foreign_promise_adapters={} legacy_blocking_await_entries={}",
         JSRUNTIME_PUMP_TICKS.load(Ordering::Relaxed),
         JSRUNTIME_ADAPTERS_CREATED.load(Ordering::Relaxed),
         JSRUNTIME_ADAPTERS_RESOLVED.load(Ordering::Relaxed),
         JSRUNTIME_ADAPTERS_REJECTED.load(Ordering::Relaxed),
         JSRUNTIME_LEGACY_BLOCKING_AWAITS.load(Ordering::Relaxed),
+        JSRUNTIME_V8_ENTRIES_TOTAL.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_RUNTIME_INIT.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_RUNTIME_SHUTDOWN.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_MODULE_LOAD.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_EXPORT_GET.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_FUNCTION_CALL.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_V8_EXPORT_CALL.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_METHOD_CALL.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_VALUE_CALL.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_ARRAY_GET.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_ARRAY_LENGTH.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_OBJECT_PROPERTY_GET.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_HANDLE_TO_STRING.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_PROPERTY_SET.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_NEW_INSTANCE.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_NEW_FROM_HANDLE.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_CALLBACK_CREATE.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_NATIVE_FUNCTION_REGISTER.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_CALLBACK_INVOKE.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_NATIVE_MODULE_PROPERTY_LOAD.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_TYPEOF_PROBE.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_HANDLE_CONSTRUCTOR.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_SHOULD_USE_RUNTIME.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_NATIVE_PROMISE_RESOLVE.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_NATIVE_PROMISE_REJECT.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_FOREIGN_PROMISE_ADAPTER.load(Ordering::Relaxed),
+        JSRUNTIME_ENTRY_LEGACY_BLOCKING_AWAIT.load(Ordering::Relaxed),
     );
 }
 
@@ -245,6 +362,7 @@ fn nanbox_to_v8<'s>(
 #[no_mangle]
 pub extern "C" fn js_runtime_init() {
     jsruntime_profile_register();
+    bump_v8_entry(V8EntryKind::RuntimeInit);
     // Force initialization of the Tokio runtime
     let _ = get_tokio_runtime();
     // Force initialization of the JS runtime on this thread
@@ -507,6 +625,7 @@ fn reflect_delete_metadata_bridge(
 /// 0 for everything else. Wired into `js_value_typeof` so user-visible `typeof gp`
 /// returns `"function"` when `gp` is a V8 callable handle. (Issue #258.)
 unsafe extern "C" fn js_handle_typeof(value: f64) -> i32 {
+    bump_v8_entry(V8EntryKind::TypeofProbe);
     with_runtime(|state| {
         deno_core::scope!(scope, &mut state.runtime);
         let v = native_to_v8(scope, value);
@@ -525,6 +644,7 @@ unsafe extern "C" fn js_new_from_handle_v8_impl(
     args_ptr: *const f64,
     args_len: usize,
 ) -> f64 {
+    bump_v8_entry(V8EntryKind::HandleConstructor);
     let args = if args_ptr.is_null() || args_len == 0 {
         Vec::new()
     } else {
@@ -571,6 +691,7 @@ unsafe extern "C" fn native_module_js_property_loader(
     property_name_ptr: *const u8,
     property_name_len: usize,
 ) -> f64 {
+    bump_v8_entry(V8EntryKind::NativeModulePropertyLoad);
     let module_name =
         std::str::from_utf8_unchecked(std::slice::from_raw_parts(module_name_ptr, module_name_len));
     let property_name = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
@@ -614,6 +735,7 @@ unsafe extern "C" fn native_module_js_property_loader(
 /// Shutdown the JavaScript runtime and release resources
 #[no_mangle]
 pub extern "C" fn js_runtime_shutdown() {
+    bump_v8_entry(V8EntryKind::RuntimeShutdown);
     // The runtime will be cleaned up when the thread exits
     log::debug!("JS runtime shutdown requested");
 }
@@ -623,6 +745,7 @@ pub extern "C" fn js_runtime_shutdown() {
 /// Returns 0 on failure
 #[no_mangle]
 pub unsafe extern "C" fn js_load_module(path_ptr: *const i8, path_len: usize) -> u64 {
+    bump_v8_entry(V8EntryKind::ModuleLoad);
     let path_slice = if path_ptr.is_null() {
         return 0;
     } else if path_len > 0 {
@@ -786,6 +909,7 @@ pub unsafe extern "C" fn js_get_export(
     export_name_ptr: *const i8,
     export_name_len: usize,
 ) -> f64 {
+    bump_v8_entry(V8EntryKind::ExportGet);
     let name_slice = if export_name_ptr.is_null() {
         return f64::from_bits(0x7FFC_0000_0000_0001); // undefined
     } else if export_name_len > 0 {
@@ -842,6 +966,7 @@ pub unsafe extern "C" fn js_call_function(
     args_ptr: *const f64,
     args_len: usize,
 ) -> f64 {
+    bump_v8_entry(V8EntryKind::FunctionCall);
     let name_slice = if func_name_ptr.is_null() {
         return f64::from_bits(0x7FFC_0000_0000_0001); // undefined
     } else if func_name_len > 0 {
@@ -896,6 +1021,7 @@ pub unsafe extern "C" fn js_call_v8_export(
     args_ptr: *const f64,
     args_len: usize,
 ) -> f64 {
+    bump_v8_entry(V8EntryKind::V8ExportCall);
     let module_handle = js_load_module(specifier_ptr, specifier_len);
     if module_handle == 0 {
         return f64::from_bits(0x7FFC_0000_0000_0001);
@@ -1008,6 +1134,7 @@ pub unsafe extern "C" fn js_call_method(
     args_ptr: *const f64,
     args_len: usize,
 ) -> f64 {
+    bump_v8_entry(V8EntryKind::MethodCall);
     let name_slice = if method_name_ptr.is_null() {
         return f64::from_bits(0x7FFC_0000_0000_0001);
     } else if method_name_len > 0 {
@@ -1089,6 +1216,7 @@ pub unsafe extern "C" fn js_call_value(
     args_ptr: *const f64,
     args_len: usize,
 ) -> f64 {
+    bump_v8_entry(V8EntryKind::ValueCall);
     let args = if args_ptr.is_null() || args_len == 0 {
         Vec::new()
     } else {
@@ -1165,6 +1293,7 @@ pub unsafe extern "C" fn js_register_native_function(
     func_ptr: *const u8,
     param_count: usize,
 ) {
+    bump_v8_entry(V8EntryKind::NativeFunctionRegister);
     let name_slice = if name_ptr.is_null() {
         return;
     } else if name_len > 0 {
@@ -1194,6 +1323,7 @@ pub unsafe extern "C" fn js_register_native_function(
 /// Returns the element value as a NaN-boxed f64
 #[no_mangle]
 pub extern "C" fn js_handle_array_get(array_handle: f64, index: i32) -> f64 {
+    bump_v8_entry(V8EntryKind::ArrayGet);
     with_runtime(|state| {
         deno_core::scope!(scope, &mut state.runtime);
 
@@ -1221,6 +1351,7 @@ pub extern "C" fn js_handle_array_get(array_handle: f64, index: i32) -> f64 {
 /// Returns the length as i32
 #[no_mangle]
 pub extern "C" fn js_handle_array_length(array_handle: f64) -> i32 {
+    bump_v8_entry(V8EntryKind::ArrayLength);
     with_runtime(|state| {
         deno_core::scope!(scope, &mut state.runtime);
 
@@ -1258,6 +1389,7 @@ pub extern "C" fn js_handle_object_get_property(
     property_name_ptr: *const i8,
     property_name_len: usize,
 ) -> f64 {
+    bump_v8_entry(V8EntryKind::ObjectPropertyGet);
     let name_slice = if property_name_ptr.is_null() {
         return f64::from_bits(0x7FFC_0000_0000_0001); // undefined
     } else if property_name_len > 0 {
@@ -1323,6 +1455,7 @@ fn get_property_with_scope(
 /// Returns a pointer to a native StringHeader
 #[no_mangle]
 pub extern "C" fn js_handle_to_string(handle: f64) -> *mut perry_runtime::string::StringHeader {
+    bump_v8_entry(V8EntryKind::HandleToString);
     with_runtime(|state| {
         deno_core::scope!(scope, &mut state.runtime);
 
@@ -1358,6 +1491,7 @@ pub unsafe extern "C" fn js_set_property(
     property_name_len: usize,
     value: f64,
 ) {
+    bump_v8_entry(V8EntryKind::PropertySet);
     let name_slice = if property_name_ptr.is_null() {
         return;
     } else if property_name_len > 0 {
@@ -1407,6 +1541,7 @@ pub unsafe extern "C" fn js_new_instance(
     args_ptr: *const f64,
     args_len: usize,
 ) -> f64 {
+    bump_v8_entry(V8EntryKind::NewInstance);
     let name_slice = if class_name_ptr.is_null() {
         return f64::from_bits(0x7FFC_0000_0000_0001); // undefined
     } else if class_name_len > 0 {
@@ -1489,6 +1624,7 @@ pub unsafe extern "C" fn js_new_from_handle(
     args_ptr: *const f64,
     args_len: usize,
 ) -> f64 {
+    bump_v8_entry(V8EntryKind::NewFromHandle);
     let ctor_bits = constructor_handle.to_bits();
     let tag = ctor_bits >> 48;
 
@@ -1556,6 +1692,7 @@ pub unsafe extern "C" fn js_create_callback(
     closure_env: i64,
     param_count: i64,
 ) -> f64 {
+    bump_v8_entry(V8EntryKind::CallbackCreate);
     // Store the callback info
     let callback_id = NEXT_CALLBACK_ID.with(|id| {
         let current = id.get();
@@ -1603,6 +1740,7 @@ fn native_callback_trampoline(
     args: v8::FunctionCallbackArguments,
     mut retval: v8::ReturnValue,
 ) {
+    bump_v8_entry(V8EntryKind::CallbackInvoke);
     // Get the callback ID and param count from the data
     let data = args.data();
     if !data.is_array() {
@@ -1667,6 +1805,7 @@ fn native_callback_trampoline(
 /// Returns 1 if it should use JS runtime, 0 if it should be compiled natively
 #[no_mangle]
 pub unsafe extern "C" fn js_should_use_runtime(path_ptr: *const i8, path_len: usize) -> i32 {
+    bump_v8_entry(V8EntryKind::ShouldUseRuntime);
     let path_slice = if path_ptr.is_null() {
         return 0;
     } else if path_len > 0 {
@@ -1712,6 +1851,7 @@ pub unsafe extern "C" fn js_should_use_runtime(path_ptr: *const i8, path_len: us
 #[no_mangle]
 pub extern "C" fn js_await_js_promise(value: f64) -> f64 {
     jsruntime_profile_register();
+    bump_v8_entry(V8EntryKind::LegacyBlockingAwait);
     bump_jsruntime(&JSRUNTIME_LEGACY_BLOCKING_AWAITS);
     let handle_id = match get_handle_id(value) {
         Some(id) => id,
@@ -1838,6 +1978,7 @@ pub extern "C" fn js_await_any_promise(value: f64) -> f64 {
                 native_promise,
             });
         });
+        bump_v8_entry(V8EntryKind::ForeignPromiseAdapter);
         bump_jsruntime(&JSRUNTIME_ADAPTERS_CREATED);
         perry_runtime::event_pump::js_notify_main_thread();
         return boxed_native_promise(native_promise);

--- a/crates/perry-jsruntime/src/interop.rs
+++ b/crates/perry-jsruntime/src/interop.rs
@@ -4,8 +4,9 @@
 //! JavaScript modules loaded in the V8 runtime.
 
 use crate::bridge::{
-    fixup_native_for_v8, get_handle_id, get_js_handle, is_js_handle, make_js_handle_value,
-    native_to_v8, release_js_handle, store_js_handle, v8_to_native, v8_to_native_metadata_target,
+    capture_export_snapshot_intrinsics, fixup_native_for_v8, get_handle_id, get_js_handle,
+    is_js_handle, make_js_handle_value, native_to_v8, release_js_handle, store_js_handle,
+    v8_to_native, v8_to_native_export_value, v8_to_native_metadata_target,
     v8_to_native_metadata_value,
 };
 use crate::{
@@ -507,6 +508,12 @@ pub extern "C" fn js_runtime_init() {
     }
 
     with_runtime(install_reflect_metadata_bridge);
+    with_runtime(capture_intrinsics_for_export_snapshots);
+}
+
+fn capture_intrinsics_for_export_snapshots(state: &mut JsRuntimeState) {
+    deno_core::scope!(scope, &mut state.runtime);
+    capture_export_snapshot_intrinsics(scope);
 }
 
 fn install_reflect_metadata_bridge(state: &mut JsRuntimeState) {
@@ -1089,7 +1096,7 @@ pub unsafe extern "C" fn js_get_export(
             None => return f64::from_bits(0x7FFC_0000_0000_0001),
         };
 
-        v8_to_native(scope, value)
+        v8_to_native_export_value(scope, value)
     })
 }
 

--- a/crates/perry-jsruntime/src/interop.rs
+++ b/crates/perry-jsruntime/src/interop.rs
@@ -5,7 +5,7 @@
 
 use crate::bridge::{
     fixup_native_for_v8, get_handle_id, get_js_handle, is_js_handle, make_js_handle_value,
-    native_to_v8, store_js_handle, v8_to_native, v8_to_native_metadata_target,
+    native_to_v8, release_js_handle, store_js_handle, v8_to_native, v8_to_native_metadata_target,
     v8_to_native_metadata_value,
 };
 use crate::{
@@ -32,6 +32,7 @@ struct ForeignPromiseAdapter {
 
 thread_local! {
     static FOREIGN_PROMISE_ADAPTERS: RefCell<Vec<ForeignPromiseAdapter>> = const { RefCell::new(Vec::new()) };
+    static PENDING_JSRUNTIME_TICKS: RefCell<Vec<v8::Global<v8::PromiseResolver>>> = const { RefCell::new(Vec::new()) };
 }
 
 static JSRUNTIME_PROFILE_ENABLED: AtomicBool = AtomicBool::new(false);
@@ -40,7 +41,14 @@ static JSRUNTIME_PUMP_TICKS: AtomicU64 = AtomicU64::new(0);
 static JSRUNTIME_ADAPTERS_CREATED: AtomicU64 = AtomicU64::new(0);
 static JSRUNTIME_ADAPTERS_RESOLVED: AtomicU64 = AtomicU64::new(0);
 static JSRUNTIME_ADAPTERS_REJECTED: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_MODULE_EVALS_STARTED: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_MODULE_EVALS_RESOLVED: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_MODULE_EVALS_REJECTED: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_BLOCKING_MODULE_EVALS: AtomicU64 = AtomicU64::new(0);
 static JSRUNTIME_LEGACY_BLOCKING_AWAITS: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_HANDLES_STORED: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_HANDLES_RELEASED: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_FOREIGN_PROMISE_HANDLES_RELEASED: AtomicU64 = AtomicU64::new(0);
 static JSRUNTIME_V8_ENTRIES_TOTAL: AtomicU64 = AtomicU64::new(0);
 static JSRUNTIME_ENTRY_RUNTIME_INIT: AtomicU64 = AtomicU64::new(0);
 static JSRUNTIME_ENTRY_RUNTIME_SHUTDOWN: AtomicU64 = AtomicU64::new(0);
@@ -147,17 +155,42 @@ pub(crate) fn bump_v8_entry(kind: V8EntryKind) {
     });
 }
 
+pub(crate) fn bump_js_handle_stored() {
+    jsruntime_profile_register();
+    bump_jsruntime(&JSRUNTIME_HANDLES_STORED);
+}
+
+pub(crate) fn bump_js_handle_released() {
+    jsruntime_profile_register();
+    bump_jsruntime(&JSRUNTIME_HANDLES_RELEASED);
+}
+
 extern "C" fn jsruntime_profile_atexit() {
     if std::env::var_os("PERRY_JSRUNTIME_PROFILE").is_none() {
         return;
     }
+    let handles_stored = JSRUNTIME_HANDLES_STORED.load(Ordering::Relaxed);
+    let handles_released = JSRUNTIME_HANDLES_RELEASED.load(Ordering::Relaxed);
+    let handles_retained = handles_stored.saturating_sub(handles_released);
+    let foreign_promise_handles_retained = JSRUNTIME_ADAPTERS_CREATED
+        .load(Ordering::Relaxed)
+        .saturating_sub(JSRUNTIME_FOREIGN_PROMISE_HANDLES_RELEASED.load(Ordering::Relaxed));
     eprintln!(
-        "[jsruntime-profile] pump_ticks={} adapters_created={} adapters_resolved={} adapters_rejected={} legacy_blocking_awaits={} v8_entries_total={} runtime_inits={} runtime_shutdowns={} module_loads={} export_gets={} function_calls={} v8_export_calls={} method_calls={} value_calls={} array_gets={} array_lengths={} object_property_gets={} handle_to_strings={} property_sets={} new_instances={} new_from_handles={} callback_creates={} native_function_registers={} callback_invokes={} native_module_property_loads={} typeof_probes={} handle_constructors={} should_use_runtime={} native_promise_resolves={} native_promise_rejects={} foreign_promise_adapters={} legacy_blocking_await_entries={}",
+        "[jsruntime-profile] pump_ticks={} adapters_created={} adapters_resolved={} adapters_rejected={} module_evals_started={} module_evals_resolved={} module_evals_rejected={} blocking_module_evals={} legacy_blocking_awaits={} handles_stored={} handles_released={} handles_retained={} foreign_promise_handles_released={} foreign_promise_handles_retained={} v8_entries_total={} runtime_inits={} runtime_shutdowns={} module_loads={} export_gets={} function_calls={} v8_export_calls={} method_calls={} value_calls={} array_gets={} array_lengths={} object_property_gets={} handle_to_strings={} property_sets={} new_instances={} new_from_handles={} callback_creates={} native_function_registers={} callback_invokes={} native_module_property_loads={} typeof_probes={} handle_constructors={} should_use_runtime={} native_promise_resolves={} native_promise_rejects={} foreign_promise_adapters={} legacy_blocking_await_entries={}",
         JSRUNTIME_PUMP_TICKS.load(Ordering::Relaxed),
         JSRUNTIME_ADAPTERS_CREATED.load(Ordering::Relaxed),
         JSRUNTIME_ADAPTERS_RESOLVED.load(Ordering::Relaxed),
         JSRUNTIME_ADAPTERS_REJECTED.load(Ordering::Relaxed),
+        JSRUNTIME_MODULE_EVALS_STARTED.load(Ordering::Relaxed),
+        JSRUNTIME_MODULE_EVALS_RESOLVED.load(Ordering::Relaxed),
+        JSRUNTIME_MODULE_EVALS_REJECTED.load(Ordering::Relaxed),
+        JSRUNTIME_BLOCKING_MODULE_EVALS.load(Ordering::Relaxed),
         JSRUNTIME_LEGACY_BLOCKING_AWAITS.load(Ordering::Relaxed),
+        handles_stored,
+        handles_released,
+        handles_retained,
+        JSRUNTIME_FOREIGN_PROMISE_HANDLES_RELEASED.load(Ordering::Relaxed),
+        foreign_promise_handles_retained,
         JSRUNTIME_V8_ENTRIES_TOTAL.load(Ordering::Relaxed),
         JSRUNTIME_ENTRY_RUNTIME_INIT.load(Ordering::Relaxed),
         JSRUNTIME_ENTRY_RUNTIME_SHUTDOWN.load(Ordering::Relaxed),
@@ -241,8 +274,8 @@ fn notifying_waker() -> Waker {
 }
 
 enum AdapterSettlement {
-    Resolve(*mut perry_runtime::promise::Promise, f64),
-    Reject(*mut perry_runtime::promise::Promise, f64),
+    Resolve(u64, *mut perry_runtime::promise::Promise, f64),
+    Reject(u64, *mut perry_runtime::promise::Promise, f64),
 }
 
 fn collect_foreign_promise_settlements(state: &mut JsRuntimeState) -> Vec<AdapterSettlement> {
@@ -260,6 +293,7 @@ fn collect_foreign_promise_settlements(state: &mut JsRuntimeState) -> Vec<Adapte
                         v8::PromiseState::Fulfilled => {
                             let result = promise.result(scope);
                             Some(AdapterSettlement::Resolve(
+                                adapter.handle_id,
                                 adapter.native_promise,
                                 v8_to_native(scope, result),
                             ))
@@ -267,6 +301,7 @@ fn collect_foreign_promise_settlements(state: &mut JsRuntimeState) -> Vec<Adapte
                         v8::PromiseState::Rejected => {
                             let reason = promise.result(scope);
                             Some(AdapterSettlement::Reject(
+                                adapter.handle_id,
                                 adapter.native_promise,
                                 v8_to_native(scope, reason),
                             ))
@@ -275,10 +310,12 @@ fn collect_foreign_promise_settlements(state: &mut JsRuntimeState) -> Vec<Adapte
                     }
                 }
                 Some(v8_val) => Some(AdapterSettlement::Resolve(
+                    adapter.handle_id,
                     adapter.native_promise,
                     v8_to_native(scope, v8_val),
                 )),
                 None => Some(AdapterSettlement::Reject(
+                    adapter.handle_id,
                     adapter.native_promise,
                     undefined_value(),
                 )),
@@ -300,11 +337,17 @@ fn settle_foreign_promise_adapters(state: &mut JsRuntimeState) -> i32 {
     let count = settlements.len() as i32;
     for settlement in settlements {
         match settlement {
-            AdapterSettlement::Resolve(promise, value) => {
+            AdapterSettlement::Resolve(handle_id, promise, value) => {
+                if release_js_handle(handle_id) {
+                    bump_jsruntime(&JSRUNTIME_FOREIGN_PROMISE_HANDLES_RELEASED);
+                }
                 bump_jsruntime(&JSRUNTIME_ADAPTERS_RESOLVED);
                 perry_runtime::promise::js_promise_resolve(promise, value);
             }
-            AdapterSettlement::Reject(promise, reason) => {
+            AdapterSettlement::Reject(handle_id, promise, reason) => {
+                if release_js_handle(handle_id) {
+                    bump_jsruntime(&JSRUNTIME_FOREIGN_PROMISE_HANDLES_RELEASED);
+                }
                 bump_jsruntime(&JSRUNTIME_ADAPTERS_REJECTED);
                 perry_runtime::promise::js_promise_reject(promise, reason);
             }
@@ -326,18 +369,98 @@ fn poll_v8_event_loop_once(state: &mut JsRuntimeState) -> i32 {
     }
 }
 
+fn resolve_pending_jsruntime_ticks(state: &mut JsRuntimeState) -> i32 {
+    let resolvers =
+        PENDING_JSRUNTIME_TICKS.with(|ticks| ticks.borrow_mut().drain(..).collect::<Vec<_>>());
+    if resolvers.is_empty() {
+        return 0;
+    }
+
+    let count = resolvers.len() as i32;
+    deno_core::scope!(scope, &mut state.runtime);
+    let undefined = v8::undefined(scope).into();
+    for resolver in resolvers {
+        let resolver = v8::Local::new(scope, resolver);
+        let _ = resolver.resolve(scope, undefined);
+    }
+    scope.perform_microtask_checkpoint();
+    count
+}
+
+fn poll_pending_module_evaluations(state: &mut JsRuntimeState) -> i32 {
+    let waker = notifying_waker();
+    let mut cx = TaskContext::from_waker(&waker);
+    let mut completed = Vec::new();
+
+    for (module_id, pending) in state.pending_module_evaluations.iter_mut() {
+        match pending.future.as_mut().poll(&mut cx) {
+            Poll::Ready(Ok(())) => {
+                completed.push((
+                    *module_id,
+                    pending.canonical_path.display().to_string(),
+                    None,
+                ));
+            }
+            Poll::Ready(Err(e)) => {
+                completed.push((
+                    *module_id,
+                    pending.canonical_path.display().to_string(),
+                    Some(e.to_string()),
+                ));
+            }
+            Poll::Pending => {}
+        }
+    }
+
+    let count = completed.len() as i32;
+    for (module_id, path, error) in completed {
+        state.pending_module_evaluations.remove(&module_id);
+        match error {
+            Some(error) => {
+                bump_jsruntime(&JSRUNTIME_MODULE_EVALS_REJECTED);
+                eprintln!(
+                    "[jsruntime_pump] module evaluation error for '{}': {}",
+                    path, error
+                );
+            }
+            None => {
+                bump_jsruntime(&JSRUNTIME_MODULE_EVALS_RESOLVED);
+            }
+        }
+    }
+    count
+}
+
 extern "C" fn jsruntime_process_pending() -> i32 {
     jsruntime_profile_register();
     bump_jsruntime(&JSRUNTIME_PUMP_TICKS);
     with_runtime(|state| {
         let mut ran = poll_v8_event_loop_once(state);
+        let resolved_ticks = resolve_pending_jsruntime_ticks(state);
+        ran += resolved_ticks;
+        if resolved_ticks > 0 {
+            ran += poll_v8_event_loop_once(state);
+        }
+        ran += poll_pending_module_evaluations(state);
         ran += settle_foreign_promise_adapters(state);
         ran
     })
 }
 
 extern "C" fn jsruntime_has_active_handles() -> i32 {
-    FOREIGN_PROMISE_ADAPTERS.with(|adapters| if adapters.borrow().is_empty() { 0 } else { 1 })
+    let has_foreign_adapters =
+        FOREIGN_PROMISE_ADAPTERS.with(|adapters| !adapters.borrow().is_empty());
+    let has_pending_ticks = PENDING_JSRUNTIME_TICKS.with(|ticks| !ticks.borrow().is_empty());
+    let has_module_evaluations = JS_RUNTIME.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .is_some_and(|state| !state.pending_module_evaluations.is_empty())
+    });
+    if has_foreign_adapters || has_pending_ticks || has_module_evaluations {
+        1
+    } else {
+        0
+    }
 }
 
 /// Convert a NaN-boxed f64 to a V8 value, returning None if the conversion fails
@@ -427,6 +550,7 @@ fn install_reflect_metadata_bridge(state: &mut JsRuntimeState) {
         "__perryReflectDeleteMetadata",
         reflect_delete_metadata_bridge
     );
+    define_global_function!("__perryAsyncTick", perry_async_tick_bridge);
 
     let Some(source) = v8::String::new(
         scope,
@@ -524,6 +648,23 @@ fn install_reflect_metadata_bridge(state: &mut JsRuntimeState) {
         return;
     };
     let _ = v8::Script::compile(scope, source, None).and_then(|script| script.run(scope));
+}
+
+fn perry_async_tick_bridge(
+    scope: &mut v8::PinScope<'_, '_>,
+    _args: v8::FunctionCallbackArguments,
+    mut retval: v8::ReturnValue,
+) {
+    let Some(resolver) = v8::PromiseResolver::new(scope) else {
+        retval.set(v8::undefined(scope).into());
+        return;
+    };
+    let promise = resolver.get_promise(scope);
+    PENDING_JSRUNTIME_TICKS.with(|ticks| {
+        ticks.borrow_mut().push(v8::Global::new(scope, resolver));
+    });
+    perry_runtime::event_pump::js_notify_main_thread();
+    retval.set(promise.into());
 }
 
 fn reflect_define_metadata_bridge(
@@ -745,7 +886,6 @@ pub extern "C" fn js_runtime_shutdown() {
 /// Returns 0 on failure
 #[no_mangle]
 pub unsafe extern "C" fn js_load_module(path_ptr: *const i8, path_len: usize) -> u64 {
-    bump_v8_entry(V8EntryKind::ModuleLoad);
     let path_slice = if path_ptr.is_null() {
         return 0;
     } else if path_len > 0 {
@@ -846,6 +986,7 @@ export * from {target:?};
             if let Some(&module_id) = state.loaded_modules.get(&canonical) {
                 return Ok(module_id as u64);
             }
+            bump_v8_entry(V8EntryKind::ModuleLoad);
 
             // Use a dedicated current-thread Tokio runtime to avoid thread pool starvation deadlock.
             tokio::task::block_in_place(|| {
@@ -870,27 +1011,23 @@ export * from {target:?};
                         }
                     };
 
-                    // Evaluate the module
-                    let result = state.runtime.mod_evaluate(module_id);
-                    if let Err(e) = state.runtime.run_event_loop(Default::default()).await {
-                        eprintln!(
-                            "[js_load_module] event loop error for '{}': {}",
-                            path_str, e
-                        );
-                        return Err(());
-                    }
-                    if let Err(e) = result.await {
-                        eprintln!(
-                            "[js_load_module] evaluation error for '{}': {}",
-                            path_str, e
-                        );
-                        return Err(());
-                    }
+                    // Start evaluation, but let Perry's main event loop drive
+                    // the returned future via js_run_jsruntime_pump().
+                    let eval_future = state.runtime.mod_evaluate(module_id);
+                    state.pending_module_evaluations.insert(
+                        module_id,
+                        crate::PendingModuleEvaluation {
+                            canonical_path: canonical.clone(),
+                            future: Box::pin(eval_future),
+                        },
+                    );
+                    bump_jsruntime(&JSRUNTIME_MODULE_EVALS_STARTED);
 
-                    install_reflect_metadata_bridge(state);
-
-                    // Cache the module
+                    // Cache the module immediately so repeated imports reuse
+                    // the same module id while evaluation is pump-driven.
                     state.loaded_modules.insert(canonical.clone(), module_id);
+                    perry_runtime::event_pump::js_notify_main_thread();
+                    let _ = poll_pending_module_evaluations(state);
 
                     Ok(module_id as u64)
                 })
@@ -1845,13 +1982,17 @@ pub unsafe extern "C" fn js_should_use_runtime(path_ptr: *const i8, path_len: us
 
 /// Await a V8 JavaScript Promise that was returned as a JS handle.
 /// Takes a NaN-boxed f64 containing a JS handle to a V8 Promise.
-/// Runs the V8 event loop until the Promise settles, then returns the resolved value.
+/// Legacy/debug path: when explicitly enabled, runs the V8 event loop until
+/// the Promise settles, then returns the resolved value.
 /// If the value is not a Promise, returns it as-is.
 /// Returns the resolved value as NaN-boxed f64.
 #[no_mangle]
 pub extern "C" fn js_await_js_promise(value: f64) -> f64 {
     jsruntime_profile_register();
     bump_v8_entry(V8EntryKind::LegacyBlockingAwait);
+    if std::env::var_os("PERRY_JSRUNTIME_ENABLE_LEGACY_BLOCKING_AWAIT").is_none() {
+        return js_await_any_promise(value);
+    }
     bump_jsruntime(&JSRUNTIME_LEGACY_BLOCKING_AWAITS);
     let handle_id = match get_handle_id(value) {
         Some(id) => id,
@@ -1955,26 +2096,26 @@ pub extern "C" fn js_await_any_promise(value: f64) -> f64 {
             None => return value,
         };
 
-        let is_promise = with_runtime(|state| {
+        let adapter_handle_id = with_runtime(|state| {
             deno_core::scope!(scope, &mut state.runtime);
-            get_js_handle(scope, handle_id).is_some_and(|v| {
+            get_js_handle(scope, handle_id).and_then(|v| {
                 if !v.is_promise() {
-                    return false;
+                    return None;
                 }
                 let promise = v8::Local::<v8::Promise>::try_from(v).unwrap();
                 promise.mark_as_handled();
-                true
+                Some(store_js_handle(scope, v))
             })
         });
 
-        if !is_promise {
+        let Some(adapter_handle_id) = adapter_handle_id else {
             return value;
-        }
+        };
 
         let native_promise = perry_runtime::promise::js_promise_new();
         FOREIGN_PROMISE_ADAPTERS.with(|adapters| {
             adapters.borrow_mut().push(ForeignPromiseAdapter {
-                handle_id,
+                handle_id: adapter_handle_id,
                 native_promise,
             });
         });

--- a/crates/perry-jsruntime/src/interop.rs
+++ b/crates/perry-jsruntime/src/interop.rs
@@ -12,10 +12,216 @@ use crate::{
     ensure_runtime_initialized, get_tokio_runtime, with_runtime, JsRuntimeState, JS_RUNTIME,
 };
 use deno_core::v8;
+use std::cell::RefCell;
 use std::collections::hash_map::DefaultHasher;
 use std::ffi::{c_char, CStr};
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Once;
+use std::task::{Context as TaskContext, Poll, RawWaker, RawWakerVTable, Waker};
+
+const TAG_UNDEFINED_BITS: u64 = 0x7FFC_0000_0000_0001;
+const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+
+struct ForeignPromiseAdapter {
+    handle_id: u64,
+    native_promise: *mut perry_runtime::promise::Promise,
+}
+
+thread_local! {
+    static FOREIGN_PROMISE_ADAPTERS: RefCell<Vec<ForeignPromiseAdapter>> = const { RefCell::new(Vec::new()) };
+}
+
+static JSRUNTIME_PROFILE_ENABLED: AtomicBool = AtomicBool::new(false);
+static JSRUNTIME_PROFILE_REG: Once = Once::new();
+static JSRUNTIME_PUMP_TICKS: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ADAPTERS_CREATED: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ADAPTERS_RESOLVED: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_ADAPTERS_REJECTED: AtomicU64 = AtomicU64::new(0);
+static JSRUNTIME_LEGACY_BLOCKING_AWAITS: AtomicU64 = AtomicU64::new(0);
+
+unsafe extern "C" {
+    fn js_register_jsruntime_pump(f: extern "C" fn() -> i32);
+    fn js_register_jsruntime_has_active(f: extern "C" fn() -> i32);
+}
+
+fn jsruntime_profile_enabled() -> bool {
+    JSRUNTIME_PROFILE_ENABLED.load(Ordering::Relaxed)
+}
+
+fn bump_jsruntime(counter: &AtomicU64) {
+    if jsruntime_profile_enabled() {
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+extern "C" fn jsruntime_profile_atexit() {
+    if std::env::var_os("PERRY_JSRUNTIME_PROFILE").is_none() {
+        return;
+    }
+    eprintln!(
+        "[jsruntime-profile] pump_ticks={} adapters_created={} adapters_resolved={} adapters_rejected={} legacy_blocking_awaits={}",
+        JSRUNTIME_PUMP_TICKS.load(Ordering::Relaxed),
+        JSRUNTIME_ADAPTERS_CREATED.load(Ordering::Relaxed),
+        JSRUNTIME_ADAPTERS_RESOLVED.load(Ordering::Relaxed),
+        JSRUNTIME_ADAPTERS_REJECTED.load(Ordering::Relaxed),
+        JSRUNTIME_LEGACY_BLOCKING_AWAITS.load(Ordering::Relaxed),
+    );
+}
+
+fn jsruntime_profile_register() {
+    JSRUNTIME_PROFILE_REG.call_once(|| {
+        let enabled = std::env::var_os("PERRY_JSRUNTIME_PROFILE").is_some();
+        JSRUNTIME_PROFILE_ENABLED.store(enabled, Ordering::Relaxed);
+        if enabled {
+            unsafe {
+                unsafe extern "C" {
+                    fn atexit(cb: extern "C" fn()) -> i32;
+                }
+                atexit(jsruntime_profile_atexit);
+            }
+        }
+    });
+}
+
+fn boxed_native_promise(promise: *mut perry_runtime::promise::Promise) -> f64 {
+    f64::from_bits(POINTER_TAG | (promise as u64 & POINTER_MASK))
+}
+
+fn undefined_value() -> f64 {
+    f64::from_bits(TAG_UNDEFINED_BITS)
+}
+
+unsafe fn notifying_waker_clone(_: *const ()) -> RawWaker {
+    notifying_raw_waker()
+}
+
+unsafe fn notifying_waker_wake(_: *const ()) {
+    perry_runtime::event_pump::js_notify_main_thread();
+}
+
+unsafe fn notifying_waker_wake_by_ref(_: *const ()) {
+    perry_runtime::event_pump::js_notify_main_thread();
+}
+
+unsafe fn notifying_waker_drop(_: *const ()) {}
+
+static NOTIFYING_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    notifying_waker_clone,
+    notifying_waker_wake,
+    notifying_waker_wake_by_ref,
+    notifying_waker_drop,
+);
+
+fn notifying_raw_waker() -> RawWaker {
+    RawWaker::new(std::ptr::null(), &NOTIFYING_WAKER_VTABLE)
+}
+
+fn notifying_waker() -> Waker {
+    unsafe { Waker::from_raw(notifying_raw_waker()) }
+}
+
+enum AdapterSettlement {
+    Resolve(*mut perry_runtime::promise::Promise, f64),
+    Reject(*mut perry_runtime::promise::Promise, f64),
+}
+
+fn collect_foreign_promise_settlements(state: &mut JsRuntimeState) -> Vec<AdapterSettlement> {
+    deno_core::scope!(scope, &mut state.runtime);
+    FOREIGN_PROMISE_ADAPTERS.with(|adapters| {
+        let mut adapters = adapters.borrow_mut();
+        let mut settlements = Vec::new();
+        let mut i = 0;
+        while i < adapters.len() {
+            let adapter = &adapters[i];
+            let settlement = match get_js_handle(scope, adapter.handle_id) {
+                Some(v8_val) if v8_val.is_promise() => {
+                    let promise = v8::Local::<v8::Promise>::try_from(v8_val).unwrap();
+                    match promise.state() {
+                        v8::PromiseState::Fulfilled => {
+                            let result = promise.result(scope);
+                            Some(AdapterSettlement::Resolve(
+                                adapter.native_promise,
+                                v8_to_native(scope, result),
+                            ))
+                        }
+                        v8::PromiseState::Rejected => {
+                            let reason = promise.result(scope);
+                            Some(AdapterSettlement::Reject(
+                                adapter.native_promise,
+                                v8_to_native(scope, reason),
+                            ))
+                        }
+                        v8::PromiseState::Pending => None,
+                    }
+                }
+                Some(v8_val) => Some(AdapterSettlement::Resolve(
+                    adapter.native_promise,
+                    v8_to_native(scope, v8_val),
+                )),
+                None => Some(AdapterSettlement::Reject(
+                    adapter.native_promise,
+                    undefined_value(),
+                )),
+            };
+
+            if let Some(settlement) = settlement {
+                settlements.push(settlement);
+                adapters.remove(i);
+            } else {
+                i += 1;
+            }
+        }
+        settlements
+    })
+}
+
+fn settle_foreign_promise_adapters(state: &mut JsRuntimeState) -> i32 {
+    let settlements = collect_foreign_promise_settlements(state);
+    let count = settlements.len() as i32;
+    for settlement in settlements {
+        match settlement {
+            AdapterSettlement::Resolve(promise, value) => {
+                bump_jsruntime(&JSRUNTIME_ADAPTERS_RESOLVED);
+                perry_runtime::promise::js_promise_resolve(promise, value);
+            }
+            AdapterSettlement::Reject(promise, reason) => {
+                bump_jsruntime(&JSRUNTIME_ADAPTERS_REJECTED);
+                perry_runtime::promise::js_promise_reject(promise, reason);
+            }
+        }
+    }
+    count
+}
+
+fn poll_v8_event_loop_once(state: &mut JsRuntimeState) -> i32 {
+    let waker = notifying_waker();
+    let mut cx = TaskContext::from_waker(&waker);
+    match state.runtime.poll_event_loop(&mut cx, Default::default()) {
+        Poll::Ready(Ok(())) => 0,
+        Poll::Ready(Err(e)) => {
+            eprintln!("[jsruntime_pump] event loop error: {}", e);
+            1
+        }
+        Poll::Pending => 0,
+    }
+}
+
+extern "C" fn jsruntime_process_pending() -> i32 {
+    jsruntime_profile_register();
+    bump_jsruntime(&JSRUNTIME_PUMP_TICKS);
+    with_runtime(|state| {
+        let mut ran = poll_v8_event_loop_once(state);
+        ran += settle_foreign_promise_adapters(state);
+        ran
+    })
+}
+
+extern "C" fn jsruntime_has_active_handles() -> i32 {
+    FOREIGN_PROMISE_ADAPTERS.with(|adapters| if adapters.borrow().is_empty() { 0 } else { 1 })
+}
 
 /// Convert a NaN-boxed f64 to a V8 value, returning None if the conversion fails
 /// This is specifically for cases where we need to handle the error explicitly
@@ -38,6 +244,7 @@ fn nanbox_to_v8<'s>(
 /// Must be called once before any other jsruntime functions
 #[no_mangle]
 pub extern "C" fn js_runtime_init() {
+    jsruntime_profile_register();
     // Force initialization of the Tokio runtime
     let _ = get_tokio_runtime();
     // Force initialization of the JS runtime on this thread
@@ -52,6 +259,11 @@ pub extern "C" fn js_runtime_init() {
     perry_runtime::js_set_native_module_js_loader(native_module_js_property_loader);
     perry_runtime::js_set_new_from_handle_v8(js_new_from_handle_v8_impl);
     perry_runtime::js_set_handle_typeof(js_handle_typeof);
+    perry_runtime::promise::js_register_foreign_promise_adapter(js_await_any_promise);
+    unsafe {
+        js_register_jsruntime_pump(jsruntime_process_pending);
+        js_register_jsruntime_has_active(jsruntime_has_active_handles);
+    }
 
     with_runtime(install_reflect_metadata_bridge);
 }
@@ -1499,6 +1711,8 @@ pub unsafe extern "C" fn js_should_use_runtime(path_ptr: *const i8, path_len: us
 /// Returns the resolved value as NaN-boxed f64.
 #[no_mangle]
 pub extern "C" fn js_await_js_promise(value: f64) -> f64 {
+    jsruntime_profile_register();
+    bump_jsruntime(&JSRUNTIME_LEGACY_BLOCKING_AWAITS);
     let handle_id = match get_handle_id(value) {
         Some(id) => id,
         None => {
@@ -1587,19 +1801,46 @@ pub extern "C" fn js_await_js_promise(value: f64) -> f64 {
 /// (e.g., generic method dispatch returning either JS or native promises).
 #[no_mangle]
 pub extern "C" fn js_await_any_promise(value: f64) -> f64 {
+    jsruntime_profile_register();
     let bits = value.to_bits();
     let tag = bits >> 48;
 
     if tag == 0x7FFB {
-        // JS_HANDLE_TAG — delegate to js_await_js_promise (runs V8 event loop).
-        // This returns the resolved value directly (not a Promise).
-        // Wrap it in a fulfilled native Promise so the codegen busy-wait loop
-        // can find state=Fulfilled immediately and read the value.
-        let resolved_value = js_await_js_promise(value);
-        let promise_ptr = perry_runtime::promise::js_promise_resolved(resolved_value);
-        // NaN-box with POINTER_TAG so js_nanbox_get_pointer can extract it
-        let ptr_bits = 0x7FFD_0000_0000_0000u64 | (promise_ptr as u64 & 0x0000_FFFF_FFFF_FFFF);
-        return f64::from_bits(ptr_bits);
+        // JS_HANDLE_TAG: if the handle is a V8 Promise, create a native
+        // pending Promise and let the jsruntime pump settle it. This keeps
+        // V8 promise progress inside Perry's existing event pump instead of
+        // blocking inside await lowering.
+        let handle_id = match get_handle_id(value) {
+            Some(id) => id,
+            None => return value,
+        };
+
+        let is_promise = with_runtime(|state| {
+            deno_core::scope!(scope, &mut state.runtime);
+            get_js_handle(scope, handle_id).is_some_and(|v| {
+                if !v.is_promise() {
+                    return false;
+                }
+                let promise = v8::Local::<v8::Promise>::try_from(v).unwrap();
+                promise.mark_as_handled();
+                true
+            })
+        });
+
+        if !is_promise {
+            return value;
+        }
+
+        let native_promise = perry_runtime::promise::js_promise_new();
+        FOREIGN_PROMISE_ADAPTERS.with(|adapters| {
+            adapters.borrow_mut().push(ForeignPromiseAdapter {
+                handle_id,
+                native_promise,
+            });
+        });
+        bump_jsruntime(&JSRUNTIME_ADAPTERS_CREATED);
+        perry_runtime::event_pump::js_notify_main_thread();
+        return boxed_native_promise(native_promise);
     }
 
     // For POINTER_TAG (native promises) and all other values, return as-is.

--- a/crates/perry-jsruntime/src/lib.rs
+++ b/crates/perry-jsruntime/src/lib.rs
@@ -32,7 +32,9 @@ use deno_core::{JsRuntime, RuntimeOptions};
 use once_cell::sync::OnceCell;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::PathBuf;
+use std::pin::Pin;
 use tokio::runtime::Runtime as TokioRuntime;
 
 /// Global Tokio runtime for async operations
@@ -76,8 +78,16 @@ pub struct JsRuntimeState {
     pub runtime: JsRuntime,
     /// Map of loaded module paths to their V8 module IDs
     pub loaded_modules: HashMap<PathBuf, deno_core::ModuleId>,
+    /// Module evaluation futures started by `js_load_module` and driven by
+    /// Perry's jsruntime pump instead of a blocking V8 event loop.
+    pub pending_module_evaluations: HashMap<deno_core::ModuleId, PendingModuleEvaluation>,
     /// Whether the runtime has been initialized
     pub initialized: bool,
+}
+
+pub struct PendingModuleEvaluation {
+    pub canonical_path: PathBuf,
+    pub future: Pin<Box<dyn Future<Output = Result<(), deno_core::error::CoreError>>>>,
 }
 
 impl JsRuntimeState {
@@ -110,6 +120,7 @@ impl JsRuntimeState {
         Self {
             runtime,
             loaded_modules: HashMap::new(),
+            pending_module_evaluations: HashMap::new(),
             initialized: true,
         }
     }

--- a/crates/perry-jsruntime/src/ops.rs
+++ b/crates/perry-jsruntime/src/ops.rs
@@ -5,6 +5,7 @@
 use deno_core::{extension, op2};
 use deno_error::JsErrorBox;
 use std::collections::HashMap;
+use std::io::{self, Write};
 
 #[op2]
 #[string]
@@ -22,6 +23,13 @@ fn op_perry_call_native(
     log::debug!("Native call: {} with {} args", func_name, args.len());
     // TODO: Look up function in registry and call it
     serde_json::Value::Null
+}
+
+#[op2(fast)]
+fn op_perry_print(#[string] message: String) {
+    let mut stdout = io::stdout();
+    let _ = writeln!(stdout, "{}", message);
+    let _ = stdout.flush();
 }
 
 /// Synchronous HTTP fetch op for V8's fetch() polyfill.
@@ -90,5 +98,10 @@ fn op_perry_fetch(
 
 extension!(
     perry_ops,
-    ops = [op_perry_log, op_perry_call_native, op_perry_fetch,],
+    ops = [
+        op_perry_log,
+        op_perry_call_native,
+        op_perry_print,
+        op_perry_fetch,
+    ],
 );

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -231,6 +231,58 @@ mod stdlib_pump {
     }
 }
 
+// JS runtime pump registration — mirrors the stdlib pump trampoline, but is
+// owned separately so V8 fallback work can keep Perry's main event loop alive
+// only when perry-jsruntime is linked and has pending adapters.
+mod jsruntime_pump {
+    use std::ptr::null_mut;
+    use std::sync::atomic::{AtomicPtr, Ordering};
+
+    static JSRUNTIME_PUMP_FN: AtomicPtr<()> = AtomicPtr::new(null_mut());
+
+    /// Register perry-jsruntime's pump function.
+    #[no_mangle]
+    pub extern "C" fn js_register_jsruntime_pump(f: extern "C" fn() -> i32) {
+        JSRUNTIME_PUMP_FN.store(f as *mut (), Ordering::Release);
+    }
+
+    /// Run the registered jsruntime pump if available. Safe when
+    /// perry-jsruntime is not linked.
+    #[no_mangle]
+    pub extern "C" fn js_run_jsruntime_pump() {
+        let f = JSRUNTIME_PUMP_FN.load(Ordering::Acquire);
+        if !f.is_null() {
+            unsafe {
+                let func: extern "C" fn() -> i32 = std::mem::transmute(f);
+                func();
+            }
+        }
+    }
+
+    static JSRUNTIME_HAS_ACTIVE_FN: AtomicPtr<()> = AtomicPtr::new(null_mut());
+
+    /// Register perry-jsruntime's active-handle check.
+    #[no_mangle]
+    pub extern "C" fn js_register_jsruntime_has_active(f: extern "C" fn() -> i32) {
+        JSRUNTIME_HAS_ACTIVE_FN.store(f as *mut (), Ordering::Release);
+    }
+
+    /// Returns 1 when perry-jsruntime has pending work that should keep the
+    /// generated event loop alive.
+    #[no_mangle]
+    pub extern "C" fn js_jsruntime_has_active_handles() -> i32 {
+        let f = JSRUNTIME_HAS_ACTIVE_FN.load(Ordering::Acquire);
+        if !f.is_null() {
+            unsafe {
+                let func: extern "C" fn() -> i32 = std::mem::transmute(f);
+                func()
+            }
+        } else {
+            0
+        }
+    }
+}
+
 // Module init guard for preventing circular dependency stack overflow.
 // Uses a simple bitset in the runtime so the compiler cannot optimize it away.
 mod init_guard {

--- a/crates/perry-runtime/src/promise.rs
+++ b/crates/perry-runtime/src/promise.rs
@@ -6,7 +6,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
 
 use crate::async_context::{
     capture_context, enter_context, restore_context, scan_snapshot_roots, AsyncContextSnapshot,
@@ -81,6 +81,36 @@ pub static MT_STEP_CHAIN_REUSE_MISS: AtomicU64 = AtomicU64::new(0);
 /// `Promise.resolve(value)` would have done.
 pub static MT_STEP_DONE_REUSE_HIT: AtomicU64 = AtomicU64::new(0);
 pub static MT_STEP_DONE_REUSE_MISS: AtomicU64 = AtomicU64::new(0);
+
+type ForeignPromiseAdapterFn = extern "C" fn(f64) -> f64;
+
+static FOREIGN_PROMISE_ADAPTER_FN: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+
+/// Register an adapter for Promise-like values owned by another runtime.
+/// perry-jsruntime uses this to turn a V8 `JS_HANDLE_TAG` Promise into a
+/// native pending `Promise` before native await / Promise combinators inspect
+/// the value.
+#[no_mangle]
+pub extern "C" fn js_register_foreign_promise_adapter(f: ForeignPromiseAdapterFn) {
+    FOREIGN_PROMISE_ADAPTER_FN.store(f as *mut (), Ordering::Release);
+}
+
+fn adapt_foreign_promise_value(value: f64) -> f64 {
+    let bits = value.to_bits();
+    if (bits & crate::value::TAG_MASK) != crate::value::JS_HANDLE_TAG {
+        return value;
+    }
+
+    let f = FOREIGN_PROMISE_ADAPTER_FN.load(Ordering::Acquire);
+    if f.is_null() {
+        return value;
+    }
+
+    unsafe {
+        let func: ForeignPromiseAdapterFn = std::mem::transmute(f);
+        func(value)
+    }
+}
 
 extern "C" fn mt_profile_atexit() {
     if std::env::var_os("PERRY_MT_PROFILE").is_none() {
@@ -1447,6 +1477,8 @@ fn propagate_callback_result(result: f64, next: *mut Promise) {
 #[no_mangle]
 pub extern "C" fn js_promise_resolved(value: f64) -> *mut Promise {
     bump(&MT_PROMISE_RESOLVED_COUNT);
+    let value = adapt_foreign_promise_value(value);
+
     // FAST PATH: NaN-boxed primitives (numbers, undefined, null, bool,
     // raw f64s) are not pointers to thenables/promises. We can build a
     // pre-fulfilled promise and skip the `is_promise` + `assimilate`
@@ -2284,7 +2316,7 @@ pub extern "C" fn js_promise_all(promises_arr: *const crate::array::ArrayHeader)
 
     // For each promise in the array, attach a .then handler
     for i in 0..count {
-        let promise_f64 = js_array_get_f64(promises_arr, i);
+        let promise_f64 = adapt_foreign_promise_value(js_array_get_f64(promises_arr, i));
 
         // Discriminate via the GC-header obj_type, not via raw pointer
         // extraction: string/bigint NaN-boxed values produce non-null
@@ -2427,7 +2459,7 @@ pub extern "C" fn js_promise_race(promises_arr: *const crate::array::ArrayHeader
     // causing race / any results to appear too early in the output when compared against
     // Node's microtask-ordered output.
     for i in 0..count {
-        let promise_f64 = js_array_get_f64(promises_arr, i);
+        let promise_f64 = adapt_foreign_promise_value(js_array_get_f64(promises_arr, i));
         // Discriminate via GC-header obj_type — string/bigint NaN-boxed
         // values would otherwise pass through pointer extraction and crash
         // js_promise_then.
@@ -2700,7 +2732,7 @@ pub extern "C" fn js_promise_all_settled(
     js_array_set_f64(state_arr, 0, count as f64);
 
     for i in 0..count {
-        let promise_f64 = js_array_get_f64(promises_arr, i);
+        let promise_f64 = adapt_foreign_promise_value(js_array_get_f64(promises_arr, i));
 
         // Only treat as a Promise if the value is a POINTER_TAG that walks
         // back to a GcHeader with obj_type == GC_TYPE_PROMISE. Otherwise
@@ -2865,7 +2897,7 @@ pub extern "C" fn js_promise_any(promises_arr: *const crate::array::ArrayHeader)
     js_closure_set_capture_ptr(shared_fulfill, 1, state_arr as i64);
 
     for i in 0..count {
-        let promise_f64 = js_array_get_f64(promises_arr, i);
+        let promise_f64 = adapt_foreign_promise_value(js_array_get_f64(promises_arr, i));
         // Discriminate via GC-header obj_type — string/bigint NaN-boxed
         // values would otherwise pass through pointer extraction and crash
         // js_promise_then.

--- a/scripts/rank_jsruntime_fallbacks.sh
+++ b/scripts/rank_jsruntime_fallbacks.sh
@@ -178,6 +178,7 @@ check_fixture_semantics() {
             require_stdout_line "$name" "$stdout_path" "function: function:ok" || return 1
             require_stdout_line "$name" "$stdout_path" "promise: promise:ok" || return 1
             require_stdout_line "$name" "$stdout_path" "symbol: symbol:ok" || return 1
+            require_stdout_line "$name" "$stdout_path" "deep: deep-leaf" || return 1
             require_stdout_line "$name" "$stdout_path" "tampered-intrinsics: own:tampered-proto:added" || return 1
             ;;
     esac

--- a/scripts/rank_jsruntime_fallbacks.sh
+++ b/scripts/rank_jsruntime_fallbacks.sh
@@ -38,13 +38,30 @@ DEFAULT_FIXTURES=(
     test-files/test_jsruntime_mixed_async_ordering_matrix.ts
     test-files/test_jsruntime_mixed_rejection_semantics_matrix.ts
     test-files/test_jsruntime_async_liveness_stress.ts
+    test-files/test_issue_248_phase2_js_interop.ts
+    test-files/test_issue_248_phase2b_js_callback.ts
+    test-files/test_issue_255_jsruntime_reentrancy.ts
+    test-files/test_decorators_nest_js_common_canary.ts
+    test-files/test_jsruntime_export_hardening.ts
+    test-files/test_issue_678_v8_fallback.ts
 )
 
-SELECTED_COUNTER="module_loads_after_cache_warmup"
-SELECTED_SOURCE_COUNTER="module_loads"
-SELECTED_FIXTURE_PATH="test-files/test_jsruntime_module_load_cache_counter.ts"
-SELECTED_FIXTURE_NAME="$(basename "${SELECTED_FIXTURE_PATH%.ts}")"
-SELECTED_EXPECTED_BASELINE=1
+SELECTED_COUNTERS=(
+    module_loads_after_cache_warmup
+    js_export_plain_object_property_gets
+)
+SELECTED_SOURCE_COUNTERS=(
+    module_loads
+    object_property_gets
+)
+SELECTED_FIXTURE_PATHS=(
+    test-files/test_jsruntime_module_load_cache_counter.ts
+    test-files/test_decorators_nest_js_common_canary.ts
+)
+SELECTED_EXPECTED_BASELINES=(
+    1
+    0
+)
 
 if [[ "$#" -gt 0 ]]; then
     FIXTURES=("$@")
@@ -100,6 +117,72 @@ profile_value() {
     tr ' ' '\n' <"$profile_path" | sed -n "s/^${key}=//p" | tail -n 1
 }
 
+counter_classification() {
+    local counter="$1"
+    case "$counter" in
+        module_loads)
+            printf 'intentional\tReal JS module cache misses; selected warmup proof gates excess loads.'
+            ;;
+        export_gets)
+            printf 'intentional\tJS-hosted module export boundary; values are classified by conversion hardening.'
+            ;;
+        function_calls|v8_export_calls|method_calls|value_calls)
+            printf 'intentional\tCallable JS exports and V8-owned methods stay in the V8 runtime.'
+            ;;
+        callback_creates|callback_invokes)
+            printf 'intentional\tNative callback handles are exercised by mixed native/V8 callback fixtures.'
+            ;;
+        native_promise_resolves|native_promise_rejects|foreign_promise_adapters)
+            printf 'intentional\tMixed native/V8 promise fixtures require the unified adapter and pump path.'
+            ;;
+        object_property_gets)
+            printf 'unsafe-to-replace\tRemaining reads are V8-owned dynamic/reentry objects; safe frozen export data is separately proven native.'
+            ;;
+        array_gets|array_lengths)
+            printf 'unsafe-to-replace\tV8-owned arrays retain JS identity and prototype behavior.'
+            ;;
+        handle_to_strings|property_sets|new_instances|new_from_handles|native_function_registers|native_module_property_loads|typeof_probes|handle_constructors|should_use_runtime)
+            printf 'intentional\tInterop support counter for JS handles or runtime boundary plumbing.'
+            ;;
+        legacy_blocking_await_entries)
+            printf 'forbidden\tLegacy blocking await entry must remain zero; the promise gate also enforces this.'
+            ;;
+        *)
+            printf 'unclassified\tCounter needs semantic review before it can be treated as accepted fallback.'
+            ;;
+    esac
+}
+
+require_stdout_line() {
+    local name="$1"
+    local stdout_path="$2"
+    local expected="$3"
+    if ! grep -Fxq "$expected" "$stdout_path"; then
+        echo "FAIL $name: missing stdout line: $expected"
+        dump_file "$stdout_path"
+        return 1
+    fi
+}
+
+check_fixture_semantics() {
+    local name="$1"
+    local stdout_path="$2"
+    case "$name" in
+        test_jsruntime_export_hardening)
+            require_stdout_line "$name" "$stdout_path" "safe: safe 7 true nested" || return 1
+            require_stdout_line "$name" "$stdout_path" "mutable: after" || return 1
+            require_stdout_line "$name" "$stdout_path" "accessor: accessor:1,accessor:2" || return 1
+            require_stdout_line "$name" "$stdout_path" "custom-proto: own:from-proto" || return 1
+            require_stdout_line "$name" "$stdout_path" "proxy: proxy:1,proxy:2" || return 1
+            require_stdout_line "$name" "$stdout_path" "array: 2:a:b" || return 1
+            require_stdout_line "$name" "$stdout_path" "function: function:ok" || return 1
+            require_stdout_line "$name" "$stdout_path" "promise: promise:ok" || return 1
+            require_stdout_line "$name" "$stdout_path" "symbol: symbol:ok" || return 1
+            require_stdout_line "$name" "$stdout_path" "tampered-intrinsics: own:tampered-proto:added" || return 1
+            ;;
+    esac
+}
+
 for fixture in "${FIXTURES[@]}"; do
     name="$(basename "${fixture%.ts}")"
     bin="$TMP_DIR/$name"
@@ -135,6 +218,11 @@ for fixture in "${FIXTURES[@]}"; do
         continue
     fi
 
+    if ! check_fixture_semantics "$name" "$stdout_path"; then
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
     grep -F "[jsruntime-profile]" "$stderr_path" >"$profile_path" || true
     if [[ ! -s "$profile_path" ]]; then
         echo "FAIL $name: missing jsruntime profile line"
@@ -162,36 +250,80 @@ if [[ "$FAIL" -ne 0 ]]; then
     exit 1
 fi
 
-selected_fixture_seen=0
-selected_counter_value=0
-while IFS=$'\t' read -r counter value fixture_name; do
-    if [[ "$counter" == "$SELECTED_SOURCE_COUNTER" && "$fixture_name" == "$SELECTED_FIXTURE_NAME" ]]; then
-        selected_fixture_seen=1
-        selected_counter_value=$((selected_counter_value + value))
-    fi
-done <"$ROWS"
+TOTALS="$TMP_DIR/totals.tsv"
+awk -F '\t' '{ sum[$1] += $2 } END { for (counter in sum) print sum[counter] "\t" counter }' "$ROWS" \
+    | sort -nr >"$TOTALS"
 
-if [[ "$selected_fixture_seen" -eq 1 ]]; then
-    selected_counter_observed=$((selected_counter_value - SELECTED_EXPECTED_BASELINE))
-    if [[ "$selected_counter_observed" -ne 0 ]]; then
-        echo "FAIL selected fallback proof: counter=$SELECTED_COUNTER fixture=$SELECTED_FIXTURE_PATH observed=$selected_counter_observed source_counter=$SELECTED_SOURCE_COUNTER source_observed=$selected_counter_value expected_baseline=$SELECTED_EXPECTED_BASELINE"
-        exit 1
+SELECTED_PROOF_LINES=()
+for proof_idx in "${!SELECTED_COUNTERS[@]}"; do
+    selected_counter="${SELECTED_COUNTERS[$proof_idx]}"
+    selected_source_counter="${SELECTED_SOURCE_COUNTERS[$proof_idx]}"
+    selected_fixture_path="${SELECTED_FIXTURE_PATHS[$proof_idx]}"
+    selected_fixture_name="$(basename "${selected_fixture_path%.ts}")"
+    selected_expected_baseline="${SELECTED_EXPECTED_BASELINES[$proof_idx]}"
+
+    selected_fixture_seen=0
+    selected_counter_value=0
+    while IFS=$'\t' read -r counter value fixture_name; do
+        if [[ "$counter" == "$selected_source_counter" && "$fixture_name" == "$selected_fixture_name" ]]; then
+            selected_fixture_seen=1
+            selected_counter_value=$((selected_counter_value + value))
+        fi
+    done <"$ROWS"
+
+    if [[ "$selected_fixture_seen" -eq 1 ]]; then
+        selected_counter_observed=$((selected_counter_value - selected_expected_baseline))
+        if [[ "$selected_counter_observed" -ne 0 ]]; then
+            echo "FAIL selected fallback proof: counter=$selected_counter fixture=$selected_fixture_path observed=$selected_counter_observed source_counter=$selected_source_counter source_observed=$selected_counter_value expected_baseline=$selected_expected_baseline"
+            exit 1
+        fi
+        SELECTED_PROOF_LINES+=("selected-fallback-proof: counter=$selected_counter fixture=$selected_fixture_path observed=0 source_counter=$selected_source_counter source_observed=$selected_counter_value expected_baseline=$selected_expected_baseline")
     fi
-fi
+done
 
 echo "fallback-counter-ranking:"
-awk -F '\t' '{ sum[$1] += $2 } END { for (counter in sum) print sum[counter] "\t" counter }' "$ROWS" \
-    | sort -nr \
-    | awk -F '\t' 'BEGIN { printf "%10s  %s\n", "count", "counter" } { printf "%10d  %s\n", $1, $2 }'
+awk -F '\t' 'BEGIN { printf "%10s  %s\n", "count", "counter" } { printf "%10d  %s\n", $1, $2 }' "$TOTALS"
 
 echo
-if [[ "$selected_fixture_seen" -eq 1 ]]; then
-    echo "selected-fallback-proof: counter=$SELECTED_COUNTER fixture=$SELECTED_FIXTURE_PATH observed=0 source_counter=$SELECTED_SOURCE_COUNTER source_observed=$selected_counter_value expected_baseline=$SELECTED_EXPECTED_BASELINE"
+if [[ "${#SELECTED_PROOF_LINES[@]}" -gt 0 ]]; then
+    printf '%s\n' "${SELECTED_PROOF_LINES[@]}"
     echo
 fi
 
 echo
+echo "fallback-counter-classification:"
+printf '%10s  %-32s  %-18s  %s\n' "count" "counter" "classification" "reason"
+CLASSIFICATION_FAIL=0
+while IFS=$'\t' read -r count counter; do
+    if [[ "$count" -eq 0 ]]; then
+        continue
+    fi
+    classification_line="$(counter_classification "$counter")"
+    classification="${classification_line%%$'\t'*}"
+    reason="${classification_line#*$'\t'}"
+    if [[ "$classification" == "unclassified" ]]; then
+        CLASSIFICATION_FAIL=$((CLASSIFICATION_FAIL + 1))
+    fi
+    printf '%10d  %-32s  %-18s  %s\n' "$count" "$counter" "$classification" "$reason"
+done <"$TOTALS"
+
+if [[ "$CLASSIFICATION_FAIL" -ne 0 ]]; then
+    echo "FAIL fallback classification: $CLASSIFICATION_FAIL nonzero counter(s) are unclassified"
+    exit 1
+fi
+
+echo
+echo "fallback-fixture-matrix:"
+printf '%10s  %-44s  %-30s  %s\n' "count" "fixture" "counter" "classification"
+sort -t $'\t' -k2,2nr "$ROWS" | while IFS=$'\t' read -r counter value fixture_name; do
+    if [[ "$value" -eq 0 ]]; then
+        continue
+    fi
+    classification_line="$(counter_classification "$counter")"
+    classification="${classification_line%%$'\t'*}"
+    printf '%10d  %-44s  %-30s  %s\n' "$value" "$fixture_name" "$counter" "$classification"
+done
+
+echo
 echo "fallback-counter-ranking-jsonl:"
-awk -F '\t' '{ sum[$1] += $2 } END { for (counter in sum) print sum[counter] "\t" counter }' "$ROWS" \
-    | sort -nr \
-    | awk -F '\t' '{ printf "{\"counter\":\"%s\",\"count\":%d}\n", $2, $1 }'
+awk -F '\t' '{ printf "{\"counter\":\"%s\",\"count\":%d}\n", $2, $1 }' "$TOTALS"

--- a/scripts/rank_jsruntime_fallbacks.sh
+++ b/scripts/rank_jsruntime_fallbacks.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Rank V8 fallback entry counters for selected Perry fixtures.
+#
+# Usage:
+#   scripts/rank_jsruntime_fallbacks.sh
+#   PERRY_BIN=./target/release/perry scripts/rank_jsruntime_fallbacks.sh test-files/foo.ts ...
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ -n "${PERRY_BIN:-}" ]]; then
+    if [[ ! -x "$PERRY_BIN" ]]; then
+        echo "error: PERRY_BIN is not executable: $PERRY_BIN" >&2
+        exit 2
+    fi
+    PERRY_CMD=("$PERRY_BIN")
+else
+    PERRY_CMD=(cargo run --quiet --bin perry --)
+fi
+
+TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="$(command -v timeout)"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="$(command -v gtimeout)"
+fi
+
+DEFAULT_FIXTURES=(
+    test-files/test_jsruntime_await_pending_promise.ts
+    test-files/test_jsruntime_mixed_native_v8_promise_all.ts
+    test-files/test_jsruntime_callback_returns_native_promise.ts
+    test-files/test_jsruntime_module_eval_pump_liveness.ts
+    test-files/test_jsruntime_module_load_cache_counter.ts
+    test-files/test_jsruntime_foreign_promise_handle_stress.ts
+    test-files/test_jsruntime_mixed_async_ordering_matrix.ts
+    test-files/test_jsruntime_mixed_rejection_semantics_matrix.ts
+    test-files/test_jsruntime_async_liveness_stress.ts
+)
+
+SELECTED_COUNTER="module_loads_after_cache_warmup"
+SELECTED_SOURCE_COUNTER="module_loads"
+SELECTED_FIXTURE_PATH="test-files/test_jsruntime_module_load_cache_counter.ts"
+SELECTED_FIXTURE_NAME="$(basename "${SELECTED_FIXTURE_PATH%.ts}")"
+SELECTED_EXPECTED_BASELINE=1
+
+if [[ "$#" -gt 0 ]]; then
+    FIXTURES=("$@")
+else
+    FIXTURES=("${DEFAULT_FIXTURES[@]}")
+fi
+
+COUNTERS=(
+    module_loads
+    export_gets
+    function_calls
+    v8_export_calls
+    method_calls
+    value_calls
+    array_gets
+    array_lengths
+    object_property_gets
+    handle_to_strings
+    property_sets
+    new_instances
+    new_from_handles
+    callback_creates
+    native_function_registers
+    callback_invokes
+    native_module_property_loads
+    typeof_probes
+    handle_constructors
+    should_use_runtime
+    native_promise_resolves
+    native_promise_rejects
+    foreign_promise_adapters
+    legacy_blocking_await_entries
+)
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/perry-jsruntime-rank.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+ROWS="$TMP_DIR/rows.tsv"
+: >"$ROWS"
+
+FAIL=0
+
+dump_file() {
+    local path="$1"
+    if [[ -s "$path" ]]; then
+        sed 's/^/    /' "$path"
+    fi
+}
+
+profile_value() {
+    local profile_path="$1"
+    local key="$2"
+    tr ' ' '\n' <"$profile_path" | sed -n "s/^${key}=//p" | tail -n 1
+}
+
+for fixture in "${FIXTURES[@]}"; do
+    name="$(basename "${fixture%.ts}")"
+    bin="$TMP_DIR/$name"
+    compile_log="$TMP_DIR/$name.compile.log"
+    stdout_path="$TMP_DIR/$name.stdout"
+    stderr_path="$TMP_DIR/$name.stderr"
+    profile_path="$TMP_DIR/$name.profile"
+
+    if [[ ! -f "$fixture" ]]; then
+        echo "FAIL $name: missing fixture $fixture"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    if ! "${PERRY_CMD[@]}" "$fixture" --no-cache -o "$bin" >"$compile_log" 2>&1; then
+        echo "FAIL $name: compile failed"
+        dump_file "$compile_log"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    if [[ -n "$TIMEOUT_BIN" ]]; then
+        PERRY_JSRUNTIME_PROFILE=1 "$TIMEOUT_BIN" 30 "$bin" >"$stdout_path" 2>"$stderr_path"
+    else
+        PERRY_JSRUNTIME_PROFILE=1 "$bin" >"$stdout_path" 2>"$stderr_path"
+    fi
+    exit_code=$?
+    if [[ "$exit_code" -ne 0 ]]; then
+        echo "FAIL $name: runtime exited $exit_code"
+        dump_file "$stdout_path"
+        dump_file "$stderr_path"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    grep -F "[jsruntime-profile]" "$stderr_path" >"$profile_path" || true
+    if [[ ! -s "$profile_path" ]]; then
+        echo "FAIL $name: missing jsruntime profile line"
+        dump_file "$stderr_path"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    legacy_blocking="$(profile_value "$profile_path" legacy_blocking_await_entries)"
+    if [[ "${legacy_blocking:-0}" -ne 0 ]]; then
+        echo "FAIL $name: legacy_blocking_await_entries=$legacy_blocking"
+        dump_file "$profile_path"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    for counter in "${COUNTERS[@]}"; do
+        value="$(profile_value "$profile_path" "$counter")"
+        value="${value:-0}"
+        printf '%s\t%s\t%s\n' "$counter" "$value" "$name" >>"$ROWS"
+    done
+done
+
+if [[ "$FAIL" -ne 0 ]]; then
+    exit 1
+fi
+
+selected_fixture_seen=0
+selected_counter_value=0
+while IFS=$'\t' read -r counter value fixture_name; do
+    if [[ "$counter" == "$SELECTED_SOURCE_COUNTER" && "$fixture_name" == "$SELECTED_FIXTURE_NAME" ]]; then
+        selected_fixture_seen=1
+        selected_counter_value=$((selected_counter_value + value))
+    fi
+done <"$ROWS"
+
+if [[ "$selected_fixture_seen" -eq 1 ]]; then
+    selected_counter_observed=$((selected_counter_value - SELECTED_EXPECTED_BASELINE))
+    if [[ "$selected_counter_observed" -ne 0 ]]; then
+        echo "FAIL selected fallback proof: counter=$SELECTED_COUNTER fixture=$SELECTED_FIXTURE_PATH observed=$selected_counter_observed source_counter=$SELECTED_SOURCE_COUNTER source_observed=$selected_counter_value expected_baseline=$SELECTED_EXPECTED_BASELINE"
+        exit 1
+    fi
+fi
+
+echo "fallback-counter-ranking:"
+awk -F '\t' '{ sum[$1] += $2 } END { for (counter in sum) print sum[counter] "\t" counter }' "$ROWS" \
+    | sort -nr \
+    | awk -F '\t' 'BEGIN { printf "%10s  %s\n", "count", "counter" } { printf "%10d  %s\n", $1, $2 }'
+
+echo
+if [[ "$selected_fixture_seen" -eq 1 ]]; then
+    echo "selected-fallback-proof: counter=$SELECTED_COUNTER fixture=$SELECTED_FIXTURE_PATH observed=0 source_counter=$SELECTED_SOURCE_COUNTER source_observed=$selected_counter_value expected_baseline=$SELECTED_EXPECTED_BASELINE"
+    echo
+fi
+
+echo
+echo "fallback-counter-ranking-jsonl:"
+awk -F '\t' '{ sum[$1] += $2 } END { for (counter in sum) print sum[counter] "\t" counter }' "$ROWS" \
+    | sort -nr \
+    | awk -F '\t' '{ printf "{\"counter\":\"%s\",\"count\":%d}\n", $2, $1 }'

--- a/scripts/run_jsruntime_promise_tests.sh
+++ b/scripts/run_jsruntime_promise_tests.sh
@@ -93,6 +93,13 @@ run_fixture() {
         return
     fi
 
+    if ! grep -Eq '(^|[[:space:]])v8_entries_total=[1-9][0-9]*([[:space:]]|$)' "$profile_path"; then
+        echo "FAIL $name: v8_entries_total was missing or zero"
+        dump_file "$profile_path"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
     echo "PASS $name"
     PASS=$((PASS + 1))
 }

--- a/scripts/run_jsruntime_promise_tests.sh
+++ b/scripts/run_jsruntime_promise_tests.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# V8-backed jsruntime promise-surface regression tests.
+#
+# Compiles and runs the five native/V8 promise fixtures with profiling enabled.
+# Each run must print the expected stdout marker, emit a jsruntime profile line,
+# and keep legacy_blocking_awaits at exactly zero.
+#
+# Usage:
+#   scripts/run_jsruntime_promise_tests.sh
+#   PERRY_BIN=./target/debug/perry scripts/run_jsruntime_promise_tests.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ -n "${PERRY_BIN:-}" ]]; then
+    if [[ ! -x "$PERRY_BIN" ]]; then
+        echo "error: PERRY_BIN is not executable: $PERRY_BIN" >&2
+        exit 2
+    fi
+    PERRY_CMD=("$PERRY_BIN")
+else
+    PERRY_CMD=(cargo run --quiet --bin perry --)
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/perry-jsruntime-promises.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+dump_file() {
+    local path="$1"
+    if [[ -s "$path" ]]; then
+        sed 's/^/    /' "$path"
+    fi
+}
+
+run_fixture() {
+    local name="$1"
+    local src_path="$2"
+    local expected_stdout="$3"
+
+    local bin="$TMP_DIR/$name"
+    local compile_log="$TMP_DIR/$name.compile.log"
+    local stdout_path="$TMP_DIR/$name.stdout"
+    local stderr_path="$TMP_DIR/$name.stderr"
+    local profile_path="$TMP_DIR/$name.profile"
+
+    if ! "${PERRY_CMD[@]}" "$src_path" -o "$bin" >"$compile_log" 2>&1; then
+        echo "FAIL $name: compile failed"
+        dump_file "$compile_log"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    PERRY_JSRUNTIME_PROFILE=1 "$bin" >"$stdout_path" 2>"$stderr_path"
+    local exit_code=$?
+    if [[ "$exit_code" -ne 0 ]]; then
+        echo "FAIL $name: runtime exited $exit_code"
+        echo "  stdout:"
+        dump_file "$stdout_path"
+        echo "  stderr:"
+        dump_file "$stderr_path"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    if ! grep -qF "$expected_stdout" "$stdout_path"; then
+        echo "FAIL $name: stdout missing expected snippet"
+        echo "  expected: $expected_stdout"
+        echo "  actual stdout:"
+        dump_file "$stdout_path"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    grep -F "[jsruntime-profile]" "$stderr_path" >"$profile_path" || true
+    if [[ ! -s "$profile_path" ]]; then
+        echo "FAIL $name: missing jsruntime profile line"
+        echo "  stderr:"
+        dump_file "$stderr_path"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    if grep -Ev '(^|[[:space:]])legacy_blocking_awaits=0([[:space:]]|$)' "$profile_path" >/dev/null; then
+        echo "FAIL $name: legacy_blocking_awaits was not zero"
+        dump_file "$profile_path"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    echo "PASS $name"
+    PASS=$((PASS + 1))
+}
+
+run_fixture await_pending_promise \
+    test-files/test_jsruntime_await_pending_promise.ts \
+    "awaited: v8-pending"
+
+run_fixture rejection_propagation \
+    test-files/test_jsruntime_rejection_propagation.ts \
+    "caught: v8-reject"
+
+run_fixture mixed_native_v8_promise_all \
+    test-files/test_jsruntime_mixed_native_v8_promise_all.ts \
+    "all: native-first v8-second"
+
+run_fixture callback_returns_native_promise \
+    test-files/test_jsruntime_callback_returns_native_promise.ts \
+    "callback: callback:inner-native"
+
+run_fixture module_eval_async \
+    test-files/test_jsruntime_module_eval_async.ts \
+    "module: module-ready"
+
+echo
+echo "jsruntime-promise-tests: $PASS passed, $FAIL failed"
+
+if [[ -n "${PERRY_TEST_SUMMARY_OUT:-}" ]]; then
+    cat >"$PERRY_TEST_SUMMARY_OUT" <<EOF
+{"script": "run_jsruntime_promise_tests.sh", "passed": $PASS, "failed": $FAIL, "skipped": 0}
+EOF
+fi
+
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/run_jsruntime_promise_tests.sh
+++ b/scripts/run_jsruntime_promise_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # V8-backed jsruntime promise-surface regression tests.
 #
-# Compiles and runs the five native/V8 promise fixtures with profiling enabled.
+# Compiles and runs the native/V8 promise fixtures with profiling enabled.
 # Each run must print the expected stdout marker, emit a jsruntime profile line,
 # and keep legacy_blocking_awaits at exactly zero.
 #
@@ -25,6 +25,13 @@ else
     PERRY_CMD=(cargo run --quiet --bin perry --)
 fi
 
+TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="$(command -v timeout)"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="$(command -v gtimeout)"
+fi
+
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/perry-jsruntime-promises.XXXXXX")"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -38,6 +45,62 @@ dump_file() {
     fi
 }
 
+profile_value() {
+    local profile_path="$1"
+    local key="$2"
+    tr ' ' '\n' <"$profile_path" | sed -n "s/^${key}=//p" | tail -n 1
+}
+
+require_profile_nonzero() {
+    local name="$1"
+    local profile_path="$2"
+    local key="$3"
+    if ! grep -Eq "(^|[[:space:]])${key}=[1-9][0-9]*([[:space:]]|$)" "$profile_path"; then
+        echo "FAIL $name: $key was missing or zero"
+        dump_file "$profile_path"
+        FAIL=$((FAIL + 1))
+        return 1
+    fi
+    return 0
+}
+
+require_profile_value() {
+    local name="$1"
+    local profile_path="$2"
+    local key="$3"
+    local expected="$4"
+    local value
+    value="$(profile_value "$profile_path" "$key")"
+    if [[ -z "$value" || "$value" -ne "$expected" ]]; then
+        echo "FAIL $name: expected $key=$expected, saw ${value:-missing}"
+        dump_file "$profile_path"
+        FAIL=$((FAIL + 1))
+        return 1
+    fi
+    return 0
+}
+
+stdout_occurrences() {
+    local path="$1"
+    local needle="$2"
+    grep -oF "$needle" "$path" | wc -l | tr -d '[:space:]'
+}
+
+require_stdout_once() {
+    local name="$1"
+    local stdout_path="$2"
+    local needle="$3"
+    local count
+    count="$(stdout_occurrences "$stdout_path" "$needle")"
+    if [[ "$count" -ne 1 ]]; then
+        echo "FAIL $name: expected exactly one stdout occurrence of '$needle', saw $count"
+        dump_file "$stdout_path"
+        FAIL=$((FAIL + 1))
+        return 1
+    fi
+    return 0
+}
+
 run_fixture() {
     local name="$1"
     local src_path="$2"
@@ -49,14 +112,18 @@ run_fixture() {
     local stderr_path="$TMP_DIR/$name.stderr"
     local profile_path="$TMP_DIR/$name.profile"
 
-    if ! "${PERRY_CMD[@]}" "$src_path" -o "$bin" >"$compile_log" 2>&1; then
+    if ! "${PERRY_CMD[@]}" "$src_path" --no-cache -o "$bin" >"$compile_log" 2>&1; then
         echo "FAIL $name: compile failed"
         dump_file "$compile_log"
         FAIL=$((FAIL + 1))
         return
     fi
 
-    PERRY_JSRUNTIME_PROFILE=1 "$bin" >"$stdout_path" 2>"$stderr_path"
+    if [[ -n "$TIMEOUT_BIN" ]]; then
+        PERRY_JSRUNTIME_PROFILE=1 "$TIMEOUT_BIN" 30 "$bin" >"$stdout_path" 2>"$stderr_path"
+    else
+        PERRY_JSRUNTIME_PROFILE=1 "$bin" >"$stdout_path" 2>"$stderr_path"
+    fi
     local exit_code=$?
     if [[ "$exit_code" -ne 0 ]]; then
         echo "FAIL $name: runtime exited $exit_code"
@@ -77,6 +144,26 @@ run_fixture() {
         return
     fi
 
+    if [[ "$name" == "mixed_rejection_semantics_matrix" ]]; then
+        if grep -Eq 'missing|undefined|duplicate|wrong' "$stdout_path"; then
+            echo "FAIL $name: stdout contained forbidden rejection marker"
+            dump_file "$stdout_path"
+            FAIL=$((FAIL + 1))
+            return
+        fi
+        require_stdout_once "$name" "$stdout_path" "v8-catch:v8-direct" || return
+        require_stdout_once "$name" "$stdout_path" "native-callback-caught:native-callback" || return
+        require_stdout_once "$name" "$stdout_path" "all-catch:v8-all" || return
+        require_stdout_once "$name" "$stdout_path" "late:v8-late:v8-late" || return
+        require_stdout_once "$name" "$stdout_path" "counts: 1,1,1,1" || return
+        if grep -Eiq 'Unhandled|unhandled|\[jsruntime_pump\] event loop error' "$stderr_path"; then
+            echo "FAIL $name: stderr contained unintended unhandled rejection output"
+            dump_file "$stderr_path"
+            FAIL=$((FAIL + 1))
+            return
+        fi
+    fi
+
     grep -F "[jsruntime-profile]" "$stderr_path" >"$profile_path" || true
     if [[ ! -s "$profile_path" ]]; then
         echo "FAIL $name: missing jsruntime profile line"
@@ -93,11 +180,82 @@ run_fixture() {
         return
     fi
 
+    if grep -Ev '(^|[[:space:]])legacy_blocking_await_entries=0([[:space:]]|$)' "$profile_path" >/dev/null; then
+        echo "FAIL $name: legacy_blocking_await_entries was not zero"
+        dump_file "$profile_path"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    if grep -Ev '(^|[[:space:]])blocking_module_evals=0([[:space:]]|$)' "$profile_path" >/dev/null; then
+        echo "FAIL $name: blocking_module_evals was not zero"
+        dump_file "$profile_path"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
     if ! grep -Eq '(^|[[:space:]])v8_entries_total=[1-9][0-9]*([[:space:]]|$)' "$profile_path"; then
         echo "FAIL $name: v8_entries_total was missing or zero"
         dump_file "$profile_path"
         FAIL=$((FAIL + 1))
         return
+    fi
+
+    if [[ "$name" == "module_eval_pump_liveness" ]]; then
+        require_profile_nonzero "$name" "$profile_path" pump_ticks || return
+        require_profile_nonzero "$name" "$profile_path" module_evals_started || return
+        require_profile_nonzero "$name" "$profile_path" module_evals_resolved || return
+    fi
+
+    if [[ "$name" == "foreign_promise_handle_stress" || "$name" == "async_liveness_stress" ]]; then
+        local created resolved rejected retained released
+        created="$(profile_value "$profile_path" adapters_created)"
+        resolved="$(profile_value "$profile_path" adapters_resolved)"
+        rejected="$(profile_value "$profile_path" adapters_rejected)"
+        retained="$(profile_value "$profile_path" foreign_promise_handles_retained)"
+        released="$(profile_value "$profile_path" foreign_promise_handles_released)"
+        if [[ -z "$created" || -z "$resolved" || -z "$rejected" || -z "$retained" || -z "$released" ]]; then
+            echo "FAIL $name: missing adapter/handle balance counters"
+            dump_file "$profile_path"
+            FAIL=$((FAIL + 1))
+            return
+        fi
+        if [[ "$created" -ne $((resolved + rejected)) ]]; then
+            echo "FAIL $name: adapter settlement imbalance created=$created resolved=$resolved rejected=$rejected"
+            dump_file "$profile_path"
+            FAIL=$((FAIL + 1))
+            return
+        fi
+        if [[ "$retained" -ne 0 ]]; then
+            echo "FAIL $name: foreign promise handles retained=$retained"
+            dump_file "$profile_path"
+            FAIL=$((FAIL + 1))
+            return
+        fi
+        if [[ "$released" -le 0 ]]; then
+            echo "FAIL $name: no foreign promise handles were released"
+            dump_file "$profile_path"
+            FAIL=$((FAIL + 1))
+            return
+        fi
+    fi
+
+    if [[ "$name" == "mixed_async_ordering_matrix" ]]; then
+        require_profile_nonzero "$name" "$profile_path" foreign_promise_adapters || return
+        require_profile_nonzero "$name" "$profile_path" callback_invokes || return
+        require_profile_nonzero "$name" "$profile_path" native_promise_resolves || return
+    fi
+
+    if [[ "$name" == "mixed_rejection_semantics_matrix" ]]; then
+        require_profile_nonzero "$name" "$profile_path" adapters_rejected || return
+        require_profile_nonzero "$name" "$profile_path" callback_invokes || return
+        require_profile_nonzero "$name" "$profile_path" native_promise_rejects || return
+    fi
+
+    if [[ "$name" == "module_load_cache_counter" ]]; then
+        require_profile_value "$name" "$profile_path" module_loads 1 || return
+        require_profile_nonzero "$name" "$profile_path" function_calls || return
+        require_profile_nonzero "$name" "$profile_path" foreign_promise_adapters || return
     fi
 
     echo "PASS $name"
@@ -123,6 +281,30 @@ run_fixture callback_returns_native_promise \
 run_fixture module_eval_async \
     test-files/test_jsruntime_module_eval_async.ts \
     "module: module-ready"
+
+run_fixture module_eval_pump_liveness \
+    test-files/test_jsruntime_module_eval_pump_liveness.ts \
+    "module-pump: ready"
+
+run_fixture module_load_cache_counter \
+    test-files/test_jsruntime_module_load_cache_counter.ts \
+    "module-cache-counter: 20"
+
+run_fixture foreign_promise_handle_stress \
+    test-files/test_jsruntime_foreign_promise_handle_stress.ts \
+    "foreign-stress: 1000 same same same|same"
+
+run_fixture mixed_async_ordering_matrix \
+    test-files/test_jsruntime_mixed_async_ordering_matrix.ts \
+    "ordering: sync>after-native-await>before-v8>native-micro>v8:one>before-timer>timer:done>callback:callback:inner>all:native|v8|timer"
+
+run_fixture mixed_rejection_semantics_matrix \
+    test-files/test_jsruntime_mixed_rejection_semantics_matrix.ts \
+    "rejections: v8-catch:v8-direct | native-callback-caught:native-callback | all-catch:v8-all | late:v8-late:v8-late | counts: 1,1,1,1"
+
+run_fixture async_liveness_stress \
+    test-files/test_jsruntime_async_liveness_stress.ts \
+    "liveness-stress: 800"
 
 echo
 echo "jsruntime-promise-tests: $PASS passed, $FAIL failed"

--- a/scripts/run_native_no_fallback_tests.sh
+++ b/scripts/run_native_no_fallback_tests.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Native-first regression gate.
+#
+# Compiles and runs a curated set of TypeScript-only fixtures with
+# PERRY_JSRUNTIME_PROFILE=1. Each fixture must compile with zero JavaScript
+# modules and must not emit a jsruntime profile line at runtime. A profile line
+# means the V8 fallback was linked and initialized.
+#
+# Usage:
+#   scripts/run_native_no_fallback_tests.sh
+#   PERRY_BIN=./target/release/perry scripts/run_native_no_fallback_tests.sh
+#   scripts/run_native_no_fallback_tests.sh test-files/test_async.ts ...
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ -n "${PERRY_BIN:-}" ]]; then
+    if [[ ! -x "$PERRY_BIN" ]]; then
+        echo "error: PERRY_BIN is not executable: $PERRY_BIN" >&2
+        exit 2
+    fi
+    PERRY_CMD=("$PERRY_BIN")
+else
+    PERRY_CMD=(cargo run --quiet --bin perry --)
+fi
+
+DEFAULT_FIXTURES=(
+    test-files/test_async.ts
+    test-files/test_edge_promises.ts
+    test-files/test_microtask_inv_07_promise_all_mixed.ts
+    test-files/test_spread.ts
+    test-files/test_math.ts
+)
+
+if [[ "$#" -gt 0 ]]; then
+    FIXTURES=("$@")
+else
+    FIXTURES=("${DEFAULT_FIXTURES[@]}")
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/perry-native-no-fallback.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+dump_file() {
+    local path="$1"
+    if [[ -s "$path" ]]; then
+        sed 's/^/    /' "$path"
+    fi
+}
+
+run_fixture() {
+    local src_path="$1"
+    local name
+    name="$(basename "${src_path%.ts}")"
+
+    local bin="$TMP_DIR/$name"
+    local compile_log="$TMP_DIR/$name.compile.log"
+    local stdout_path="$TMP_DIR/$name.stdout"
+    local stderr_path="$TMP_DIR/$name.stderr"
+
+    if [[ ! -f "$src_path" ]]; then
+        echo "FAIL $name: missing fixture $src_path"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    if ! "${PERRY_CMD[@]}" "$src_path" --no-cache -o "$bin" >"$compile_log" 2>&1; then
+        echo "FAIL $name: compile failed"
+        dump_file "$compile_log"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    if ! grep -Eq 'Found [0-9]+ module\(s\): [0-9]+ native, 0 JavaScript' "$compile_log"; then
+        echo "FAIL $name: compile did not report zero JavaScript modules"
+        grep -E 'Found [0-9]+ module\(s\):|JavaScript|V8' "$compile_log" | sed 's/^/    /' || true
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    if grep -qF "Using V8 JavaScript runtime" "$compile_log"; then
+        echo "FAIL $name: compile linked the V8 jsruntime fallback"
+        grep -F "Using V8 JavaScript runtime" "$compile_log" | sed 's/^/    /'
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    PERRY_JSRUNTIME_PROFILE=1 "$bin" >"$stdout_path" 2>"$stderr_path"
+    local exit_code=$?
+    if [[ "$exit_code" -ne 0 ]]; then
+        echo "FAIL $name: runtime exited $exit_code"
+        echo "  stdout:"
+        dump_file "$stdout_path"
+        echo "  stderr:"
+        dump_file "$stderr_path"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    if grep -qF "[jsruntime-profile]" "$stderr_path"; then
+        echo "FAIL $name: runtime entered jsruntime fallback"
+        grep -F "[jsruntime-profile]" "$stderr_path" | sed 's/^/    /'
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    echo "PASS $name"
+    PASS=$((PASS + 1))
+}
+
+for fixture in "${FIXTURES[@]}"; do
+    run_fixture "$fixture"
+done
+
+echo
+echo "native-no-fallback-tests: $PASS passed, $FAIL failed"
+
+if [[ -n "${PERRY_TEST_SUMMARY_OUT:-}" ]]; then
+    cat >"$PERRY_TEST_SUMMARY_OUT" <<EOF
+{"script": "run_native_no_fallback_tests.sh", "passed": $PASS, "failed": $FAIL, "skipped": 0}
+EOF
+fi
+
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/run_native_no_fallback_tests.sh
+++ b/scripts/run_native_no_fallback_tests.sh
@@ -27,18 +27,94 @@ else
     PERRY_CMD=(cargo run --quiet --bin perry --)
 fi
 
-DEFAULT_FIXTURES=(
+DEFAULT_FIXTURE_NAMES=(
+    async
+    edge-promises
+    microtask-07-promise-all-mixed
+    spread
+    math
+    async-chain
+    microtask-01
+    microtask-02
+    microtask-03
+    microtask-04
+    microtask-05
+    microtask-06
+    edge-arrays
+    edge-objects-records
+    edge-classes
+    edge-closures
+    edge-control-flow
+    edge-destructuring
+    edge-map-set
+    edge-json-regex
+    edge-strings
+    edge-type-coercion
+    optional-chain
+    try-catch
+    map
+    set
+    json
+    rest-params
+    multi-basic
+    multi-edge
+    jsruntime-stub-no-v8
+    compat-core
+    compat-objects-symbols
+    compat-strings-regex-json
+    compat-url-date-math
+)
+
+DEFAULT_FIXTURE_PATHS=(
     test-files/test_async.ts
     test-files/test_edge_promises.ts
     test-files/test_microtask_inv_07_promise_all_mixed.ts
     test-files/test_spread.ts
     test-files/test_math.ts
+    test-files/test_async_chain.ts
+    test-files/test_microtask_inv_01_two_fn_interleave.ts
+    test-files/test_microtask_inv_02_then_vs_await_fifo.ts
+    test-files/test_microtask_inv_03_chained_then_interleave.ts
+    test-files/test_microtask_inv_04_await_caller_callee.ts
+    test-files/test_microtask_inv_05_nested_promise_unwrap.ts
+    test-files/test_microtask_inv_06_finally_after_await.ts
+    test-files/test_edge_arrays.ts
+    test-files/test_edge_objects_records.ts
+    test-files/test_edge_classes.ts
+    test-files/test_edge_closures.ts
+    test-files/test_edge_control_flow.ts
+    test-files/test_edge_destructuring.ts
+    test-files/test_edge_map_set.ts
+    test-files/test_edge_json_regex.ts
+    test-files/test_edge_strings.ts
+    test-files/test_edge_type_coercion.ts
+    test-files/test_optional_chain.ts
+    test-files/test_try_catch.ts
+    test-files/test_map.ts
+    test-files/test_set.ts
+    test-files/test_json.ts
+    test-files/test_rest_params.ts
+    test-files/multi/index.ts
+    test-files/multi-edge/index.ts
+    test-files/test_issue_257_jsruntime_stub_no_v8.ts
+    test-files/test_compat_core_surface.ts
+    test-files/test_compat_objects_symbols.ts
+    test-files/test_compat_strings_regex_json.ts
+    test-files/test_compat_url_date_math.ts
 )
 
-if [[ "$#" -gt 0 ]]; then
-    FIXTURES=("$@")
-else
-    FIXTURES=("${DEFAULT_FIXTURES[@]}")
+EXCLUDED_FALLBACK_FIXTURES=(
+    test-files/test_jsruntime_*.ts
+    test-files/test_issue_248_phase2_js_interop.ts
+    test-files/test_issue_248_phase2b_js_callback.ts
+    test-files/test_issue_255_jsruntime_reentrancy.ts
+    test-files/test_issue_678_v8_fallback.ts
+    test-files/test_decorators_nest_js_common_canary.ts
+)
+
+if [[ "${#DEFAULT_FIXTURE_NAMES[@]}" -ne "${#DEFAULT_FIXTURE_PATHS[@]}" ]]; then
+    echo "error: native no-fallback manifest names/paths length mismatch" >&2
+    exit 2
 fi
 
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/perry-native-no-fallback.XXXXXX")"
@@ -55,9 +131,8 @@ dump_file() {
 }
 
 run_fixture() {
-    local src_path="$1"
-    local name
-    name="$(basename "${src_path%.ts}")"
+    local name="$1"
+    local src_path="$2"
 
     local bin="$TMP_DIR/$name"
     local compile_log="$TMP_DIR/$name.compile.log"
@@ -114,9 +189,20 @@ run_fixture() {
     PASS=$((PASS + 1))
 }
 
-for fixture in "${FIXTURES[@]}"; do
-    run_fixture "$fixture"
-done
+if [[ "$#" -gt 0 ]]; then
+    for fixture in "$@"; do
+        run_fixture "$(basename "${fixture%.ts}")" "$fixture"
+    done
+else
+    echo "native-no-fallback excluded fallback fixtures:"
+    for fixture in "${EXCLUDED_FALLBACK_FIXTURES[@]}"; do
+        echo "  $fixture"
+    done
+    echo
+    for i in "${!DEFAULT_FIXTURE_PATHS[@]}"; do
+        run_fixture "${DEFAULT_FIXTURE_NAMES[$i]}" "${DEFAULT_FIXTURE_PATHS[$i]}"
+    done
+fi
 
 echo
 echo "native-no-fallback-tests: $PASS passed, $FAIL failed"

--- a/test-files/fixtures/jsruntime_export_hardening.js
+++ b/test-files/fixtures/jsruntime_export_hardening.js
@@ -1,0 +1,117 @@
+export const SAFE_DATA = Object.freeze({
+  label: "safe",
+  count: 7,
+  nested: Object.freeze({
+    flag: true,
+    text: "nested",
+  }),
+});
+
+export const MUTABLE_DATA = {
+  value: "before",
+};
+
+export function mutateMutable() {
+  MUTABLE_DATA.value = "after";
+  return MUTABLE_DATA.value;
+}
+
+export function readMutable(value) {
+  return value.value;
+}
+
+let accessorReads = 0;
+export const ACCESSOR_DATA = Object.freeze(
+  Object.defineProperty({}, "value", {
+    enumerable: true,
+    configurable: false,
+    get() {
+      accessorReads++;
+      return `accessor:${accessorReads}`;
+    },
+  }),
+);
+
+export function readAccessorTwice(value) {
+  return `${value.value},${value.value}`;
+}
+
+const customProto = {
+  inherited: "from-proto",
+};
+export const CUSTOM_PROTO_DATA = Object.freeze(
+  Object.assign(Object.create(customProto), {
+    own: "own",
+  }),
+);
+
+export function readCustomProto(value) {
+  return `${value.own}:${value.inherited}`;
+}
+
+let proxyReads = 0;
+function proxyTarget() {
+  return "proxy-target";
+}
+export const PROXY_DATA = new Proxy(proxyTarget, {
+  get(target, property, receiver) {
+    if (property === "value") {
+      proxyReads++;
+      return `proxy:${proxyReads}`;
+    }
+    return Reflect.get(target, property, receiver);
+  },
+});
+
+export function readProxyTwice(value) {
+  proxyReads = 0;
+  return `${value.value},${value.value}`;
+}
+
+export const ARRAY_DATA = Object.freeze(["a", "b"]);
+
+export function readArray(value) {
+  return `${value.length}:${value[0]}:${value[1]}`;
+}
+
+export function FUNCTION_DATA() {
+  return "function:ok";
+}
+
+export const PROMISE_DATA = Promise.resolve("promise:ok");
+
+const hardeningSymbol = Symbol.for("perry.exportHardening");
+export const SYMBOL_DATA = Object.freeze({
+  [hardeningSymbol]: "symbol:ok",
+  value: "visible",
+});
+
+export function readSymbol(value) {
+  return value[hardeningSymbol];
+}
+
+const originalObject = Object;
+const tamperedPrototype = {
+  inherited: "tampered-proto",
+};
+const tamperedIntrinsicsData = originalObject.create(tamperedPrototype);
+originalObject.defineProperty(tamperedIntrinsicsData, "own", {
+  value: "own",
+  enumerable: true,
+  writable: false,
+  configurable: false,
+});
+
+export const TAMPERED_INTRINSICS_DATA = tamperedIntrinsicsData;
+
+globalThis.Object = {
+  prototype: tamperedPrototype,
+  isFrozen() {
+    return true;
+  },
+};
+
+export function readTamperedIntrinsics(value) {
+  value.extra = "added";
+  return `${value.own}:${value.inherited}:${value.extra}`;
+}

--- a/test-files/fixtures/jsruntime_export_hardening.js
+++ b/test-files/fixtures/jsruntime_export_hardening.js
@@ -104,6 +104,28 @@ originalObject.defineProperty(tamperedIntrinsicsData, "own", {
 
 export const TAMPERED_INTRINSICS_DATA = tamperedIntrinsicsData;
 
+// A 5-deep frozen tree — exceeds the depth=4 cap in
+// `v8_plain_data_object_to_native`. The snapshot path should refuse this
+// (return None) and fall through to a JS handle, so the consumer can still
+// read every leaf via V8 fallback. Pinning this prevents a regression
+// where someone bumps the depth limit (or removes it) and quietly pulls
+// arbitrarily-deep object graphs into native memory at module-load time.
+export const DEEP_DATA = Object.freeze({
+  l1: Object.freeze({
+    l2: Object.freeze({
+      l3: Object.freeze({
+        l4: Object.freeze({
+          l5: "deep-leaf",
+        }),
+      }),
+    }),
+  }),
+});
+
+export function readDeep(value) {
+  return value.l1.l2.l3.l4.l5;
+}
+
 globalThis.Object = {
   prototype: tamperedPrototype,
   isFrozen() {

--- a/test-files/fixtures/jsruntime_promise_surface/mod.js
+++ b/test-files/fixtures/jsruntime_promise_surface/mod.js
@@ -1,0 +1,17 @@
+export function delayedValue(value) {
+  return Promise.resolve().then(() => value);
+}
+
+export function rejectLater(reason) {
+  return Promise.resolve().then(() => {
+    throw reason;
+  });
+}
+
+export function awaitCallback(cb) {
+  return Promise.resolve()
+    .then(() => cb())
+    .then((value) => "callback:" + value);
+}
+
+export const moduleValue = await Promise.resolve().then(() => "module-ready");

--- a/test-files/fixtures/jsruntime_promise_surface/module_eval_pump.js
+++ b/test-files/fixtures/jsruntime_promise_surface/module_eval_pump.js
@@ -1,0 +1,6 @@
+export function touchModuleEvalPump() {
+  return "loaded";
+}
+
+await globalThis.__perryAsyncTick();
+Deno.core.ops.op_perry_print("module-pump: ready");

--- a/test-files/fixtures/jsruntime_promise_surface/rejections.js
+++ b/test-files/fixtures/jsruntime_promise_surface/rejections.js
@@ -1,0 +1,37 @@
+export function rejectDirect(reason) {
+  return Promise.resolve().then(() => {
+    throw reason;
+  });
+}
+
+let rejectingCallbackCatchCount = 0;
+
+export function resetRejectingCallbackCatchCount() {
+  rejectingCallbackCatchCount = 0;
+}
+
+export function getRejectingCallbackCatchCount() {
+  return rejectingCallbackCatchCount;
+}
+
+export function awaitRejectingCallback(cb) {
+  return Promise.resolve()
+    .then(() => cb())
+    .then(() => "missing")
+    .catch((reason) => {
+      rejectingCallbackCatchCount += 1;
+      if (rejectingCallbackCatchCount !== 1) {
+        return "native-callback-caught:duplicate:" + rejectingCallbackCatchCount;
+      }
+      if (reason === undefined) {
+        return "native-callback-caught:undefined";
+      }
+      return "native-callback-caught:" + reason;
+    });
+}
+
+export function rejectLate(reason) {
+  return globalThis.__perryAsyncTick().then(() => {
+    throw reason;
+  });
+}

--- a/test-files/fixtures/nest_like_common.js
+++ b/test-files/fixtures/nest_like_common.js
@@ -1,7 +1,7 @@
-export const MODULE_METADATA = {
+export const MODULE_METADATA = Object.freeze({
   PROVIDERS: "providers",
   CONTROLLERS: "controllers",
-};
+});
 
 export const PATH_METADATA = "path";
 export const METHOD_METADATA = "method";

--- a/test-files/test_jsruntime_async_liveness_stress.ts
+++ b/test-files/test_jsruntime_async_liveness_stress.ts
@@ -1,0 +1,21 @@
+import { awaitCallback, delayedValue } from "./fixtures/jsruntime_promise_surface/mod.js";
+
+let completed = 0;
+
+for (let i = 0; i < 200; i++) {
+  const values = await Promise.all([
+    Promise.resolve("native"),
+    delayedValue("v8"),
+    new Promise<string>((resolve) => {
+      setTimeout(resolve, 1, "timer");
+    }),
+    awaitCallback(() => {
+      return new Promise<string>((resolve) => {
+        setTimeout(resolve, 1, "callback");
+      });
+    }),
+  ]);
+  completed += values.length;
+}
+
+console.log("liveness-stress:", completed);

--- a/test-files/test_jsruntime_await_pending_promise.ts
+++ b/test-files/test_jsruntime_await_pending_promise.ts
@@ -1,0 +1,4 @@
+import { delayedValue } from "./fixtures/jsruntime_promise_surface/mod.js";
+
+const value = await delayedValue("v8-pending");
+console.log("awaited:", value);

--- a/test-files/test_jsruntime_callback_returns_native_promise.ts
+++ b/test-files/test_jsruntime_callback_returns_native_promise.ts
@@ -1,0 +1,8 @@
+import { awaitCallback } from "./fixtures/jsruntime_promise_surface/mod.js";
+
+const value = await awaitCallback(() => {
+  return new Promise<string>((resolve) => {
+    setTimeout(resolve, 1, "inner-native");
+  });
+});
+console.log("callback:", value);

--- a/test-files/test_jsruntime_export_hardening.ts
+++ b/test-files/test_jsruntime_export_hardening.ts
@@ -1,0 +1,40 @@
+import {
+  ACCESSOR_DATA,
+  ARRAY_DATA,
+  CUSTOM_PROTO_DATA,
+  FUNCTION_DATA,
+  MUTABLE_DATA,
+  PROMISE_DATA,
+  PROXY_DATA,
+  SAFE_DATA,
+  SYMBOL_DATA,
+  TAMPERED_INTRINSICS_DATA,
+  mutateMutable,
+  readAccessorTwice,
+  readArray,
+  readCustomProto,
+  readSymbol,
+  readMutable,
+  readProxyTwice,
+  readTamperedIntrinsics,
+} from "./fixtures/jsruntime_export_hardening.js";
+
+console.log(
+  "safe:",
+  SAFE_DATA.label,
+  SAFE_DATA.count,
+  SAFE_DATA.nested.flag,
+  SAFE_DATA.nested.text,
+);
+
+mutateMutable();
+console.log("mutable:", readMutable(MUTABLE_DATA));
+
+console.log("accessor:", readAccessorTwice(ACCESSOR_DATA));
+console.log("custom-proto:", readCustomProto(CUSTOM_PROTO_DATA));
+console.log("proxy:", readProxyTwice(PROXY_DATA));
+console.log("array:", readArray(ARRAY_DATA));
+console.log("function:", FUNCTION_DATA());
+console.log("promise:", await PROMISE_DATA);
+console.log("symbol:", readSymbol(SYMBOL_DATA));
+console.log("tampered-intrinsics:", readTamperedIntrinsics(TAMPERED_INTRINSICS_DATA));

--- a/test-files/test_jsruntime_export_hardening.ts
+++ b/test-files/test_jsruntime_export_hardening.ts
@@ -2,6 +2,7 @@ import {
   ACCESSOR_DATA,
   ARRAY_DATA,
   CUSTOM_PROTO_DATA,
+  DEEP_DATA,
   FUNCTION_DATA,
   MUTABLE_DATA,
   PROMISE_DATA,
@@ -13,6 +14,7 @@ import {
   readAccessorTwice,
   readArray,
   readCustomProto,
+  readDeep,
   readSymbol,
   readMutable,
   readProxyTwice,
@@ -37,4 +39,5 @@ console.log("array:", readArray(ARRAY_DATA));
 console.log("function:", FUNCTION_DATA());
 console.log("promise:", await PROMISE_DATA);
 console.log("symbol:", readSymbol(SYMBOL_DATA));
+console.log("deep:", readDeep(DEEP_DATA));
 console.log("tampered-intrinsics:", readTamperedIntrinsics(TAMPERED_INTRINSICS_DATA));

--- a/test-files/test_jsruntime_foreign_promise_handle_stress.ts
+++ b/test-files/test_jsruntime_foreign_promise_handle_stress.ts
@@ -1,0 +1,19 @@
+import { delayedValue } from "./fixtures/jsruntime_promise_surface/mod.js";
+
+let total = 0;
+
+for (let batch = 0; batch < 20; batch++) {
+  const promises: Promise<string>[] = [];
+  for (let i = 0; i < 50; i++) {
+    promises.push(delayedValue("x"));
+  }
+  const values = await Promise.all(promises);
+  total += values.length;
+}
+
+const reused = delayedValue("same");
+const first = await reused;
+const second = await reused;
+const both = await Promise.all([reused, reused]);
+
+console.log("foreign-stress:", total, first, second, both.join("|"));

--- a/test-files/test_jsruntime_mixed_async_ordering_matrix.ts
+++ b/test-files/test_jsruntime_mixed_async_ordering_matrix.ts
@@ -1,0 +1,37 @@
+import { awaitCallback, delayedValue } from "./fixtures/jsruntime_promise_surface/mod.js";
+
+const events: string[] = [];
+
+events.push("sync");
+Promise.resolve().then(() => events.push("native-micro"));
+
+await Promise.resolve();
+events.push("after-native-await");
+
+events.push("before-v8");
+const v8Value = await delayedValue("one");
+events.push("v8:" + v8Value);
+
+events.push("before-timer");
+const timerValue = await new Promise<string>((resolve) => {
+  setTimeout(resolve, 1, "done");
+});
+events.push("timer:" + timerValue);
+
+const callbackValue = await awaitCallback(() => {
+  return new Promise<string>((resolve) => {
+    setTimeout(resolve, 1, "inner");
+  });
+});
+events.push("callback:" + callbackValue);
+
+const allValues = await Promise.all([
+  Promise.resolve("native"),
+  delayedValue("v8"),
+  new Promise<string>((resolve) => {
+    setTimeout(resolve, 1, "timer");
+  }),
+]);
+events.push("all:" + allValues.join("|"));
+
+console.log("ordering:", events.join(">"));

--- a/test-files/test_jsruntime_mixed_native_v8_promise_all.ts
+++ b/test-files/test_jsruntime_mixed_native_v8_promise_all.ts
@@ -1,0 +1,8 @@
+import { delayedValue } from "./fixtures/jsruntime_promise_surface/mod.js";
+
+const values = await Promise.all([
+  Promise.resolve("native-first"),
+  delayedValue("v8-second"),
+]);
+
+console.log("all:", values[0], values[1]);

--- a/test-files/test_jsruntime_mixed_rejection_semantics_matrix.ts
+++ b/test-files/test_jsruntime_mixed_rejection_semantics_matrix.ts
@@ -1,0 +1,75 @@
+import {
+  awaitRejectingCallback,
+  getRejectingCallbackCatchCount,
+  rejectDirect,
+  rejectLate,
+  resetRejectingCallbackCatchCount,
+} from "./fixtures/jsruntime_promise_surface/rejections.js";
+
+function exact(label, value, expected, count) {
+  const countText = "" + count;
+  if (countText === "0") {
+    return label + ":missing";
+  }
+  if (countText !== "1") {
+    return label + ":duplicate:" + countText;
+  }
+  if (value === undefined) {
+    return label + ":undefined";
+  }
+  if (value !== expected) {
+    return label + ":wrong:" + value;
+  }
+  return value;
+}
+
+let directCount = 0;
+let allCount = 0;
+let lateCount = 0;
+
+const directRaw = await rejectDirect("v8-direct").catch((reason) => {
+  directCount += 1;
+  return "v8-catch:" + reason;
+});
+const direct = exact("direct", directRaw, "v8-catch:v8-direct", directCount);
+
+resetRejectingCallbackCatchCount();
+const callbackRaw = await awaitRejectingCallback(() => {
+  return Promise.reject("native-callback");
+});
+const callbackCount = getRejectingCallbackCatchCount();
+const callback = exact(
+  "callback",
+  callbackRaw,
+  "native-callback-caught:native-callback",
+  callbackCount,
+);
+
+const allRaw = await Promise.all([
+  Promise.resolve("ok"),
+  rejectDirect("v8-all"),
+]).catch((reason) => {
+  allCount += 1;
+  return "all-catch:" + reason;
+});
+const all = exact("all", allRaw, "all-catch:v8-all", allCount);
+
+const lateRaw = await rejectLate("v8-late").catch((reason) => {
+  lateCount += 1;
+  return "late:v8-late:" + reason;
+});
+const late = exact("late", lateRaw, "late:v8-late:v8-late", lateCount);
+
+console.log(
+  "rejections:",
+  direct,
+  "|",
+  callback,
+  "|",
+  all,
+  "|",
+  late,
+  "|",
+  "counts:",
+  directCount + "," + callbackCount + "," + allCount + "," + lateCount,
+);

--- a/test-files/test_jsruntime_module_eval_async.ts
+++ b/test-files/test_jsruntime_module_eval_async.ts
@@ -1,0 +1,3 @@
+import { moduleValue } from "./fixtures/jsruntime_promise_surface/mod.js";
+
+console.log("module:", moduleValue);

--- a/test-files/test_jsruntime_module_eval_pump_liveness.ts
+++ b/test-files/test_jsruntime_module_eval_pump_liveness.ts
@@ -1,0 +1,6 @@
+import { touchModuleEvalPump } from "./fixtures/jsruntime_promise_surface/module_eval_pump.js";
+
+const loaded = touchModuleEvalPump();
+if (loaded !== "loaded") {
+  console.log("module-pump: missing");
+}

--- a/test-files/test_jsruntime_module_load_cache_counter.ts
+++ b/test-files/test_jsruntime_module_load_cache_counter.ts
@@ -1,0 +1,9 @@
+import { delayedValue } from "./fixtures/jsruntime_promise_surface/mod.js";
+
+let total = "";
+
+for (let i = 0; i < 20; i += 1) {
+  total += await delayedValue("x");
+}
+
+console.log("module-cache-counter:", total.length);

--- a/test-files/test_jsruntime_rejection_propagation.ts
+++ b/test-files/test_jsruntime_rejection_propagation.ts
@@ -1,0 +1,8 @@
+import { rejectLater } from "./fixtures/jsruntime_promise_surface/mod.js";
+
+try {
+  await rejectLater("v8-reject");
+  console.log("missing rejection");
+} catch (err: any) {
+  console.log("caught:", err);
+}


### PR DESCRIPTION
## Summary

Safely snapshots frozen plain JS-exported data objects into native Perry objects so static metadata reads can avoid V8 property-get fallback, while dynamic JS surfaces remain V8-owned.

## Changes

- Captures trusted JS intrinsics during `js_runtime_init()` and uses them when deciding whether JS export data is safe to snapshot.
- Hardens export snapshot eligibility around frozen plain data objects, descriptor-backed values, proxies, accessors, symbols, arrays, functions, promises, custom prototypes, and spoofed `globalThis.Object`.
- Freezes the Nest-style `MODULE_METADATA` fixture and enforces the selected fallback proof in the ranking script.
- Adds a jsruntime export hardening fixture, including a tampered-intrinsics regression case.

## Related issue

Refs #678, #793.

## Test plan

- [x] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [x] Added or updated a test under `test-files/`
- [ ] Updated `docs/src/` — n/a, no user-facing CLI / stdlib / runtime API change
- [ ] Built `-p perry-ui-<backend>` locally — n/a, no platform UI backend change

Additional verification run:

```bash
cargo fmt --all -- --check
bash -n scripts/run_native_no_fallback_tests.sh scripts/run_jsruntime_promise_tests.sh scripts/rank_jsruntime_fallbacks.sh
cargo check -p perry-runtime -p perry-jsruntime -p perry-codegen
PERRY_BIN=./target/release/perry scripts/run_native_no_fallback_tests.sh
PERRY_BIN=./target/release/perry scripts/run_jsruntime_promise_tests.sh
PERRY_BIN=./target/release/perry scripts/rank_jsruntime_fallbacks.sh
git diff --check
```

## Screenshots / output

Selected fallback proof from the ranking gate:

```text
selected-fallback-proof: counter=js_export_plain_object_property_gets fixture=test-files/test_decorators_nest_js_common_canary.ts observed=0 source_counter=object_property_gets source_observed=0 expected_baseline=0
```

The hardening fixture also verifies spoofed `globalThis.Object` cannot make unsafe data pass the native snapshot gate.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct
