### PR TITLE
feat(compile): add --debug-symbols to retain symbols / emit PDB

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -269,6 +269,18 @@ pub struct CompileArgs {
     #[arg(long)]
     pub no_auto_optimize: bool,
 
+    /// Retain debug symbols in the output binary instead of stripping
+    /// them for size. On Windows this adds `/DEBUG` to the lld-link
+    /// invocation so a `.pdb` is emitted and `RUST_BACKTRACE` panics in
+    /// the compiled app (including perry-runtime frames) symbolize to
+    /// `file:line` — essential for diagnosing runtime crashes that are
+    /// otherwise an unreadable wall of `<unknown>`. Also skips `/OPT:ICF`
+    /// (identical-COMDAT folding) so distinct functions don't collapse
+    /// to one symbol in the backtrace. Larger binary; off by default.
+    /// (Non-Windows targets: reserved — no behavior change today.)
+    #[arg(long)]
+    pub debug_symbols: bool,
+
     /// Disable the per-module object cache at `.perry-cache/objects/`.
     /// By default Perry caches each module's object bytes keyed by a
     /// hash of the source plus every `CompileOptions` field that can
@@ -5720,6 +5732,7 @@ pub fn run_with_parse_cache(
         &wasm_host_lib,
         &exe_path,
         format,
+        args.debug_symbols,
     )?;
 
     // HarmonyOS: emit the ArkTS EntryAbility + Index page next to the .so,

--- a/crates/perry/src/commands/compile/link.rs
+++ b/crates/perry/src/commands/compile/link.rs
@@ -60,6 +60,9 @@ pub(super) fn build_and_run_link(
     wasm_host_lib: &Option<PathBuf>,
     exe_path: &Path,
     format: OutputFormat,
+    // `--debug-symbols`: keep symbols / emit a PDB so RUST_BACKTRACE
+    // panics in the compiled app symbolize. Windows-active today.
+    debug_symbols: bool,
 ) -> Result<()> {
     let is_ios = matches!(target, Some("ios-simulator") | Some("ios"));
     let is_visionos = matches!(target, Some("visionos-simulator") | Some("visionos"));
@@ -827,7 +830,20 @@ pub(super) fn build_and_run_link(
         // These are documented as defaults under /RELEASE, but Perry doesn't
         // pass /RELEASE so the linker falls back to /OPT:NOREF, pulling in the
         // entire perry-stdlib archive even when only a fraction is used.
-        cmd.arg("/OPT:REF").arg("/OPT:ICF");
+        cmd.arg("/OPT:REF");
+        if debug_symbols {
+            // `/DEBUG` makes lld-link emit a PDB next to the .exe from the
+            // debug info already present in the input objects/libs. Without
+            // it, perry binaries have no symbol table and a RUST_BACKTRACE
+            // panic is an unreadable list of `<unknown>` — there is no other
+            // way to diagnose a runtime crash in a compiled Windows app.
+            // Skip /OPT:ICF here: COMDAT folding collapses distinct
+            // identical-bodied functions to one symbol, which would make the
+            // very backtrace this flag exists to produce ambiguous.
+            cmd.arg("/DEBUG");
+        } else {
+            cmd.arg("/OPT:ICF");
+        }
     }
 
     // Link libraries - jsruntime bundles V8 + stdlib; runtime provides base FFI symbols.

--- a/crates/perry/src/commands/dev.rs
+++ b/crates/perry/src/commands/dev.rs
@@ -295,6 +295,7 @@ fn build_once(
         geisterhand_port: None,
         minimal_stdlib: false,
         no_auto_optimize: false,
+        debug_symbols: false,
         no_cache: false,
         fast_math: false,
         min_windows_version: "10".to_string(),

--- a/crates/perry/src/commands/run.rs
+++ b/crates/perry/src/commands/run.rs
@@ -188,6 +188,7 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
         geisterhand_port: args.geisterhand_port,
         minimal_stdlib: false,
         no_auto_optimize: false,
+        debug_symbols: false,
         no_cache: false,
         fast_math: false,
         min_windows_version: "10".to_string(),


### PR DESCRIPTION
## Problem

Perry-compiled binaries on Windows have **no symbol table**: the link step never passes `/DEBUG`, so lld-link emits no `.pdb`. A `RUST_BACKTRACE` panic in a compiled app — including perry-runtime frames — is then an unreadable list of `<unknown>` addresses:

```
thread '<unnamed>' panicked at crates/perry-runtime/src/gc.rs:438:29:
index out of bounds: ...
stack backtrace:
   0:     0x7ff6... - <unknown>
   1:     0x7ff6... - <unknown>
   ...
```

There is currently **no supported way** to get a symbolized backtrace from a runtime crash in a compiled Windows app. (`--keep-intermediates` keeps `.o` files but not a linked, symbolized binary.) This blocks diagnosing Windows-only runtime crashes entirely.

## Change

Add `--debug-symbols`:

- **Windows:** pass `/DEBUG` so lld-link emits a `.pdb` next to the `.exe` from the debug info already in the input objects/libs → panic backtraces symbolize to `file:line`. Also skip `/OPT:ICF` under this flag (COMDAT folding collapses distinct identical-bodied functions to one symbol, making the very backtrace this flag exists to produce ambiguous). `/OPT:REF` still applied either way.
- **Off by default** (larger binary).
- **Non-Windows:** reserved — no behavior change today (POSIX `dead_strip` removes unreferenced code, not the symbol table; those backtraces already symbolize when libs carry debuginfo).

Threaded `CompileArgs.debug_symbols` → `build_and_run_link`; the two internal `CompileArgs` constructors (`dev`, `run`) default it to `false`. `cargo check -p perry` clean.

## Why

Diagnosing a Windows-only runtime crash in a large Perry app (Hone IDE) was blocked purely because no symbolized backtrace was obtainable. This is the missing tool for that triage and any future Windows runtime-crash investigation. Verified end to end: with `--debug-symbols` the same app now produces a symbolized `file:line` backtrace where it previously showed only `<unknown>`.

Per CONTRIBUTING / CLAUDE.md external-contributor rule, this PR does not touch `[workspace.package] version`, `CLAUDE.md`, or `CHANGELOG.md`.