### PR TITLE
fix(windows): link standalone perry_runtime.lib first so runtime fixes aren't shadowed

### DIFF
--- a/crates/perry/src/commands/compile/link.rs
+++ b/crates/perry/src/commands/compile/link.rs
@@ -919,6 +919,24 @@ pub(super) fn build_and_run_link(
             // declares all stdlib extern functions, creating import references that MSVC
             // won't dead-strip. On macOS/Linux, the linker ignores unreferenced archives.
             if let Some(ref stdlib) = stdlib_lib {
+                // Windows: link the standalone perry_runtime.lib FIRST so
+                // its symbols win lld-link's /FORCE:MULTIPLE "first
+                // definition wins" rule over the perry-runtime copies
+                // *bundled* inside perry_stdlib.lib and the
+                // /WHOLEARCHIVE'd perry_ui_windows.lib. Auto-optimize
+                // refreshes perry-runtime + perry-stdlib but NOT
+                // perry-ui-windows, so the UI lib's bundled runtime is
+                // perpetually stale; the /WHOLEARCHIVE force-includes its
+                // js_* symbols, and without this the stale copy shadows a
+                // genuine runtime fix (e.g. the js_shadow_frame_pop bounds
+                // guard, #880) — the crash it fixes still fires because the
+                // guarded function never gets linked. The standalone
+                // runtime_lib is the canonical / auto-optimize-fresh
+                // source; making it authoritative on Windows matches every
+                // other platform (all of which already link runtime_lib).
+                if is_windows {
+                    cmd.arg(runtime_lib);
+                }
                 cmd.arg(stdlib);
                 // #466 Phase 4 step 2: well-known bindings join the
                 // link line right after perry-stdlib so they cover


### PR DESCRIPTION
## Problem

On Windows the link never places the standalone `perry_runtime.lib` on the command line — it relies on perry-runtime being *bundled* inside `perry_stdlib.lib`. `perry_ui_windows.lib` **also** bundles perry-runtime and is added via `/WHOLEARCHIVE`, force-including its copy of every `js_*` symbol. Auto-optimize rebuilds perry-runtime + perry-stdlib per compile but **not** perry-ui-windows, so the UI lib's bundled runtime is perpetually stale relative to the fresh one. Under `/FORCE:MULTIPLE` a stale bundled copy can win symbol resolution and silently shadow a genuine perry-runtime fix.

This is a real correctness hazard: making the canonical/auto-optimize-fresh `perry_runtime.lib` authoritative on Windows (as it already is on every other platform — all link `runtime_lib`) removes a class of "the fixed source compiled but the old body got linked" bugs.

## Change

On Windows, link the standalone `perry_runtime.lib` **first** — before `perry_stdlib.lib` and the `/WHOLEARCHIVE`'d UI lib — so its symbols win the first-definition rule. `/FORCE:MULTIPLE` already tolerates the duplicate definitions; this only controls *which* wins. No behavior change off Windows. `cargo check -p perry` clean.

## Honest verification result

This was developed to make the merged `js_shadow_frame_pop` guard (#880) actually take effect in a Windows app where a stale bundled copy was shadowing it. **It did not achieve that in end-to-end testing**: with this change applied (release build, auto-optimize), the downstream app still aborts with the exact `panic_bounds_check` in `js_shadow_frame_pop` — and in a release build the optimizer would have *removed* that bounds check entirely if the #880-guarded body were the one linked, which proves the **unguarded copy is still being linked** despite this reorder. So the `/WHOLEARCHIVE` shadowing is more subtle than simple command-line order (likely the whole-archived UI objects' definitions are taken regardless of the earlier normal-archive `runtime_lib`), and/or the true fix lies in the underlying codegen bug that passes a bad `frame_handle` in the first place.

I'm keeping this PR open as a **standalone correctness improvement** (canonical runtime authoritative on Windows, matching other platforms) — it is sound on its own merits — but explicitly **not** claiming it resolves the shadow-stack crash. Flagging for maintainer judgment on whether the cleaner fix is stripping perry-runtime objects out of `perry_ui_windows.lib` (as the Apple platforms already do via strip-dedup) rather than relying on link order.

Per CONTRIBUTING / CLAUDE.md external-contributor rule, this PR does not touch `[workspace.package] version`, `CLAUDE.md`, or `CHANGELOG.md`.
