### PR TITLE
fix(hir): #904 — bare `Array(n)` no longer throws `TypeError: value is not a function`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.946 — fix(hir): #904 — bare `Array(n)` no longer throws `TypeError: value is not a function`
+
+**Symptom.** Downstream of the v0.5.943 (#902) `getDay` fix, dayjs's `format("YYYY-MM")` advanced into its `padStart` utility and then threw `TypeError: value is not a function` on the bare `Array(...)` call:
+
+```js
+var padStart = function padStart(string, length, pad) {
+  var s = String(string);
+  if (!s || s.length >= length) return string;
+  return "" + Array(length + 1 - s.length).join(pad) + string;
+};
+```
+
+Every 2-digit format token (`MM`, `DD`, `HH`, `mm`, `ss`) hits `Array(2 + 1 - s.length).join(pad)` when the source number is single-digit, so the throw fired the first time `format` had to zero-pad anything sub-10 — i.e. for any date in the first 9 months / first 9 days / etc.
+
+**Root cause.** HIR lowering at `crates/perry-hir/src/lower/expr_call.rs`'s "global built-in function calls" arm (the `parseInt` / `Number` / `String` / `Boolean` / `isNaN` family) listed every primitive coercer except `Array`. ES2015 §22.1.1.1–§22.1.1.2 mandates that `Array(...)` and `new Array(...)` produce identical results, but bare `Array(n)` fell through to the unknown-ident sentinel path that issue #668's comment documents: `Call { callee: GlobalGet(0), args: [...] }`. The runtime closure-call dispatcher (`crates/perry-runtime/src/closure.rs`) then validated the closure pointer, found it wasn't a real `ClosureHeader` (it was just the synthetic GlobalGet-0 sentinel), and routed through `throw_not_callable` → `js_throw_type_error_not_a_function(null, 0, b"value", 5)` → `TypeError: value is not a function`.
+
+The runtime-side closure validator is doing the right thing (issue #648 hardened it to throw rather than silently no-op), so the fix has to land at the HIR layer: recognise bare `Array(...)` as a global built-in call and route it through the same `Expr::New { class_name: "Array", ... }` HIR variant that `new Array(...)` already uses. The downstream codegen at `crates/perry-codegen/src/lower_call/builtin.rs:363` ("Array" arm) is shared and handles the no-arg / single-numeric-arg cases identically for both syntactic shapes.
+
+**Fix.** One new arm in `crates/perry-hir/src/lower/expr_call.rs`'s ident-callee match (sibling to `Number` / `String` / `Boolean`):
+
+```rust
+"Array"
+    if ctx.lookup_local("Array").is_none()
+        && ctx.lookup_func("Array").is_none()
+        && ctx.lookup_imported_func("Array").is_none() =>
+{
+    return Ok(Expr::New {
+        class_name: "Array".to_string(),
+        args,
+        type_args: Vec::new(),
+    });
+}
+```
+
+The shadow guard (lookups for a local / user function / imported function named `Array`) preserves user-shadowing semantics: `function Array(...) { ... }; Array(3)` still resolves to the user's `Array` rather than the built-in.
+
+**Scope discipline.** Per the issue's "don't expand scope; just get past this one error" constraint, the dayjs smoke after this fix now hits a separate downstream error — `TypeError: (number).replace is not a function` — which is a different perry bug in the same `format()` execution path (presumably in how the regex-callback's return value is coerced before re-entering `str.replace`'s slot-substitution machinery). That follow-up is tracked separately. The pre-existing `Array(n).join(pad)` semantics gap (the runtime's `join` walks the f64 slots without checking the empty/undefined sentinel and produces `"[object Object]0[object Object]0[object Object]"` instead of `"00"`) was already present for `new Array(n).join(pad)` and is left untouched here — that's an `Array.prototype.join` runtime fix, not part of the `Array` callable-vs-new front-end.
+
+**Validation.**
+
+* New regression test `test-files/test_issue_dayjs_format_value_not_fn.ts` mirrors the padStart shape standalone: a bare `Array(n)` with `.length` readback, a bare `Array()` with zero args, and the full padStart loop wrapped in a try/catch. Pre-fix the second call threw the value-is-not-a-function TypeError immediately; post-fix all three calls execute and the `threw:` line prints `false`. Byte-for-byte matches `node --experimental-strip-types` output.
+* The dayjs smoke (`/tmp/perry-dayjs-x/main.ts` from the issue body) advances past the `value is not a function` throw and now hits the unrelated `(number).replace is not a function` downstream — confirming the fix is targeted and the error class moved past this site.
+
+**Files touched.**
+
+* `crates/perry-hir/src/lower/expr_call.rs` — new `"Array"` arm in the ident-callee match (~12 LOC + comment).
+* `test-files/test_issue_dayjs_format_value_not_fn.ts` — new regression test.
+
 ## v0.5.945 — hotfix: resolve stray Cargo.toml + CLAUDE.md conflict markers from #903 squash-merge that left the workspace unbuildable (`cargo metadata` errored with `key with no value, expected =` at Cargo.toml:193). Direct-push admin hotfix; no code change.
 
 ## v0.5.944 — fix(hir+cli): #901 — two same-file default imports no longer collide on the literal `"default"` key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.945
+**Current Version:** 0.5.946
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.945"
+version = "0.5.946"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.945"
+version = "0.5.946"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.945"
+version = "0.5.946"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.945"
+version = "0.5.946"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.945"
+version = "0.5.946"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-hir/src/lower/expr_call.rs
+++ b/crates/perry-hir/src/lower/expr_call.rs
@@ -5592,6 +5592,32 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                             return Ok(Expr::Bool(false));
                         }
                     }
+                    "Array"
+                        if ctx.lookup_local("Array").is_none()
+                            && ctx.lookup_func("Array").is_none()
+                            && ctx.lookup_imported_func("Array").is_none() =>
+                    {
+                        // Issue #904: `Array(n)` (bare call, no `new`) must
+                        // behave identically to `new Array(n)` per spec
+                        // (ES2015 §22.1.1.1 / §22.1.1.2). Pre-fix the call
+                        // fell through to the unknown-ident sentinel path,
+                        // which lowers to `Call { callee: GlobalGet(0), ... }`
+                        // and explodes at runtime via `js_closure_callN`'s
+                        // `throw_not_callable` → `TypeError: value is not a
+                        // function`. dayjs's `format()` hits this through
+                        // `padStart`'s `Array(length + 1 - s.length).join(pad)`
+                        // every time it formats a sub-10 number (e.g. month
+                        // "07" in "YYYY-MM"). Route through `Expr::New` so the
+                        // existing Array-constructor codegen in
+                        // `crates/perry-codegen/src/lower_call/builtin.rs`
+                        // handles it. Shadow-safe: only fires when no local
+                        // / user fn / imported fn named `Array` is in scope.
+                        return Ok(Expr::New {
+                            class_name: "Array".to_string(),
+                            args,
+                            type_args: Vec::new(),
+                        });
+                    }
                     "isNaN" => {
                         if !args.is_empty() {
                             return Ok(Expr::IsNaN(Box::new(args.remove(0))));

--- a/test-files/test_issue_dayjs_format_value_not_fn.ts
+++ b/test-files/test_issue_dayjs_format_value_not_fn.ts
@@ -1,0 +1,51 @@
+// Regression for the dayjs `format("YYYY-MM")` crash where calling the
+// global `Array` builtin without `new` threw `TypeError: value is not a
+// function`. dayjs's `padStart` utility (used by every `format()` for any
+// 2-digit field like the "MM" in "YYYY-MM") does:
+//
+//   var padStart = function padStart(string, length, pad) {
+//     var s = String(string);
+//     if (!s || s.length >= length) return string;
+//     return "" + Array(length + 1 - s.length).join(pad) + string;
+//   };
+//
+// Pre-fix, perry lowered the bare `Array(...)` call to the unknown-ident
+// sentinel (`Call { callee: GlobalGet(0), ... }`); the runtime closure-call
+// dispatcher then validated the closure pointer, found it wasn't a real
+// closure, and routed through `throw_not_callable` → `TypeError: value is
+// not a function`. ES2015 §22.1.1 mandates that `Array(...)` and
+// `new Array(...)` produce identical results, so we now route the bare-call
+// shape through the same `Expr::New { class_name: "Array", ... }` HIR variant
+// that `new Array(...)` already used.
+//
+// This standalone shape mirrors dayjs's padStart pattern: bare-call `Array`
+// with a numeric length, then `.join(...)` against the resulting array.
+
+// Bare `Array(n)` must return an array of length n (per spec, slots NaN-boxed
+// undefined). Mirrors `padStart`'s `Array(length + 1 - s.length)`.
+const a = Array(3);
+console.log("a.length:", a.length);
+
+// Bare `Array()` with no args returns `[]`.
+const empty = Array();
+console.log("empty.length:", empty.length);
+
+// The full dayjs padStart shape, inline.
+function padStart(s: any, length: number, pad: string): string {
+  const str = String(s);
+  if (!str || str.length >= length) return str;
+  return "" + Array(length + 1 - str.length).join(pad) + str;
+}
+
+// dayjs uses this for every 2-digit field (MM, DD, HH, mm, ss).
+// We only check that the call doesn't throw — perry's pre-existing
+// `Array(n).join(pad)` semantics gap (#-tracked separately) means the
+// padding bytes themselves may not match Node yet, but the throw is gone.
+let threw = false;
+try {
+  padStart(8, 2, "0");
+  padStart(2024, 4, "0");
+} catch (_e) {
+  threw = true;
+}
+console.log("threw:", threw);


### PR DESCRIPTION
## Summary

- Downstream of #902 (v0.5.943 `getDay` fix), dayjs's `format("YYYY-MM")` reached its `padStart` utility and threw `TypeError: value is not a function` on the bare `Array(length + 1 - s.length).join(pad)` call. ES2015 §22.1.1 mandates `Array(...)` ≡ `new Array(...)`, but perry's HIR ident-callee match (alongside `Number` / `String` / `Boolean`) lacked an `Array` arm; the bare call fell through to the unknown-ident sentinel path and got rejected by the runtime closure-call dispatcher.
- New arm in `crates/perry-hir/src/lower/expr_call.rs` routes bare `Array(...)` through the same `Expr::New { class_name: "Array", ... }` HIR variant that `new Array(...)` already uses. Shadow-safe — only fires when no local / user fn / imported fn named `Array` is in scope.
- Per the issue's "don't expand scope" constraint, this gets past the one error. The dayjs smoke now advances and hits a separate `(number).replace is not a function` downstream, which is a different perry bug in the same `format()` path (follow-up).

## Test plan

- [x] New regression test `test-files/test_issue_dayjs_format_value_not_fn.ts` mirrors the padStart shape standalone (bare `Array(n).length`, bare `Array()`, full padStart in try/catch). Byte-for-byte matches `node --experimental-strip-types` (`a.length: 3` / `empty.length: 0` / `threw: false`).
- [x] Dayjs smoke (`/tmp/perry-dayjs-x/main.ts` from issue body): pre-fix throws `TypeError: value is not a function`; post-fix advances past and hits the separate `(number).replace is not a function` downstream error.
- [x] `cargo fmt --all`
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry`