### PR TITLE
fix(jsruntime): pino `[js_get_export]` — `node:buffer` stub exposes `buffer.constants`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ After the fix, `buffer.constants.MAX_STRING_LENGTH` evaluates cleanly inside thr
 
 * `crates/perry-jsruntime/src/modules.rs` — `get_builtin_stub("buffer")` arm (+12 lines body, +6 lines comment) + new `test_buffer_stub_exposes_constants` (+25 lines).
 * `test-files/test_issue_pino_js_get_export.ts` — new doc-style regression test.
-* `Cargo.toml` / `CLAUDE.md` — version bump to 0.5.947.
+* `Cargo.toml` / `CLAUDE.md` — version bump to 0.5.948.
 
 ## v0.5.947 — fix(compile): #903 follow-up — uuid regression: emit closure-wrapper stubs for failed modules' named exports
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.948 — fix(jsruntime): pino smoke `[js_get_export] failed to get namespace: ...MAX_STRING_LENGTH` — `node:buffer` stub now exposes `buffer.constants`
+
+**Symptom.** After v0.5.944's #903 unblocked pino past the `SORTING_ORDER.ASC` site, the smoke (`PERRY_ALLOW_UNIMPLEMENTED=1 ./out`, with `compilePackages: ["pino"]` and `import pino from "pino"`) crashed at runtime with
+
+```
+[js_get_export] failed to get namespace: TypeError: Cannot read properties of undefined (reading 'MAX_STRING_LENGTH')
+    at file:///private/tmp/perry-pino-x2/node_modules/thread-stream/index.js:52:37
+    at file:///private/tmp/perry-pino-x2/node_modules/thread-stream/index.js:681:3
+```
+
+**Root cause.** thread-stream's `index.js` evaluates `const MAX_STRING = buffer.constants.MAX_STRING_LENGTH` at top-level module init. thread-stream sits behind Perry's V8 fallback (the CJS-wrapped module is loaded through `perry-jsruntime`'s `NodeModuleLoader`), and its `require('buffer')` resolves to the `node:buffer` stub at `crates/perry-jsruntime/src/modules.rs`'s `get_builtin_stub("buffer")` arm. That stub exported `Buffer` only — no `constants` namespace. So `buffer.constants` was `undefined`, and reading `.MAX_STRING_LENGTH` on `undefined` threw `TypeError` at top-level.
+
+V8 then marked thread-stream's module record as failed-to-evaluate. The next `state.runtime.get_module_namespace(module_id)` call inside `js_get_export` (`crates/perry-jsruntime/src/interop.rs:1072`) bubbled the same TypeError back across the FFI boundary as the `[js_get_export] failed to get namespace: ...` log line, and the caller saw `undefined` for the thread-stream namespace — collapsing pino's downstream evaluation.
+
+**Fix.** Extend the V8-fallback `node:buffer` stub to export Node's real `buffer.constants` object as both a named export and a default-export member, mirroring Node 20+'s `buffer.constants`:
+
+* `MAX_LENGTH = 9007199254740991` (Number.MAX_SAFE_INTEGER, the largest `Buffer.alloc` size).
+* `MAX_STRING_LENGTH = 536870888` (2^29 - 24, the largest decodable `Buffer.toString()` length).
+* `kMaxLength` / `kStringMaxLength` named aliases included for the older Node-API shape some packages reach for.
+
+After the fix, `buffer.constants.MAX_STRING_LENGTH` evaluates cleanly inside thread-stream's V8-evaluated module, the module record finishes loading, and the smoke advances past the `[js_get_export]` site to the next unrelated downstream gap (`TypeError: (boolean).tracingChannel is not a function` — that's the `diagnostics_channel` stub returning a boolean instead of an object with `.tracingChannel`; tracked as a follow-up, not addressed here per #903's scope notes).
+
+**Scope discipline.** Only the V8-fallback `node:buffer` stub body changed (the `get_builtin_stub("buffer")` arm). Perry's native `node:buffer` import (handled by `js_native_module_property_by_name` + `get_native_module_constant` at `crates/perry-runtime/src/object.rs`) is untouched — adding native `buffer.constants` support is a separate task. The fix is byte-equivalent to what Node ships: tests against Node confirm the new values match (`node -e "console.log(JSON.stringify(require('buffer').constants))"` → `{"MAX_LENGTH":9007199254740991,"MAX_STRING_LENGTH":536870888}`).
+
+**Validation.**
+
+* Rust unit test `test_buffer_stub_exposes_constants` at `crates/perry-jsruntime/src/modules.rs` asserts the stub source carries both the named `constants` export and its presence on the default export, with the exact Node values pinned.
+* `test-files/test_issue_pino_js_get_export.ts` documents the bug shape and exercises a sanity-only `import * as buffer from "node:buffer"` round-trip (the V8 fallback path isn't reachable from a single standalone `.ts` file — it only fires for V8-evaluated modules inside `compilePackages` targets). Compares byte-for-byte against Node.
+* The original pino smoke (`mkdir /tmp/perry-pino-x2 && cd /tmp/perry-pino-x2 && npm install pino && perry main.ts && ./out`) now advances past the `[js_get_export]` log line to the next unrelated downstream error.
+
+**Files touched.**
+
+* `crates/perry-jsruntime/src/modules.rs` — `get_builtin_stub("buffer")` arm (+12 lines body, +6 lines comment) + new `test_buffer_stub_exposes_constants` (+25 lines).
+* `test-files/test_issue_pino_js_get_export.ts` — new doc-style regression test.
+* `Cargo.toml` / `CLAUDE.md` — version bump to 0.5.947.
+
 ## v0.5.947 — fix(compile): #903 follow-up — uuid regression: emit closure-wrapper stubs for failed modules' named exports
 
 **Symptom.** Compiling a project that uses `uuid` under `perry.compilePackages` link-failed at v0.5.946 with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.947
+**Current Version:** 0.5.948
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.947"
+version = "0.5.948"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.947"
+version = "0.5.948"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.947"
+version = "0.5.948"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.947"
+version = "0.5.948"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.947"
+version = "0.5.948"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-jsruntime/src/modules.rs
+++ b/crates/perry-jsruntime/src/modules.rs
@@ -955,7 +955,19 @@ export const Buffer = globalThis.Buffer || {
         return result;
     },
 };
-export default { Buffer };
+// Node's buffer.constants — pino / thread-stream read MAX_STRING_LENGTH at
+// module init time (`const MAX_STRING = buffer.constants.MAX_STRING_LENGTH`).
+// Without this, the V8-fallback evaluation throws TypeError at top-level
+// and the whole module namespace is lost — surfaces as
+// `[js_get_export] failed to get namespace: ...MAX_STRING_LENGTH`.
+// Values mirror Node 20+: MAX_LENGTH = 2^53-1, MAX_STRING_LENGTH = 2^29-24.
+export const constants = {
+    MAX_LENGTH: 9007199254740991,
+    MAX_STRING_LENGTH: 536870888,
+};
+export const kMaxLength = constants.MAX_LENGTH;
+export const kStringMaxLength = constants.MAX_STRING_LENGTH;
+export default { Buffer, constants, kMaxLength, kStringMaxLength };
 "#.to_string(),
         "util" => r#"
 // Stub implementation for Node.js 'util' module
@@ -1619,6 +1631,40 @@ mod tests {
             !stub.contains("executionAsyncId() { return 0; }")
                 && !stub.contains("executionAsyncId() {return 0;}"),
             "async_hooks executionAsyncId must not be the old constant-zero stub"
+        );
+    }
+
+    /// Regression for the pino smoke `[js_get_export] failed to get namespace`
+    /// failure downstream of #903. `thread-stream/index.js` reads
+    /// `const MAX_STRING = buffer.constants.MAX_STRING_LENGTH` at top-level
+    /// module init, so the V8-fallback `node:buffer` stub MUST expose
+    /// `constants.MAX_STRING_LENGTH` (and `MAX_LENGTH`). When it didn't, the
+    /// module-init evaluation threw `TypeError: Cannot read properties of
+    /// undefined (reading 'MAX_STRING_LENGTH')`, V8 marked the module as
+    /// failed-to-eval, and `state.runtime.get_module_namespace(module_id)`
+    /// bubbled that error through `js_get_export` for any downstream import
+    /// reaching into thread-stream. Values mirror Node 20+'s
+    /// `buffer.constants` to keep parity with the real Node module.
+    #[test]
+    fn test_buffer_stub_exposes_constants() {
+        let stub = get_builtin_stub("buffer");
+        assert!(
+            stub.contains("export const constants"),
+            "buffer stub must export `constants` (named) for `buffer.constants.X` reads"
+        );
+        assert!(
+            stub.contains("MAX_STRING_LENGTH: 536870888"),
+            "buffer.constants.MAX_STRING_LENGTH must match Node's value (2^29 - 24)"
+        );
+        assert!(
+            stub.contains("MAX_LENGTH: 9007199254740991"),
+            "buffer.constants.MAX_LENGTH must match Node's value (Number.MAX_SAFE_INTEGER)"
+        );
+        // default export must also carry constants so `require('buffer')`
+        // unwrap-via-default and the named-namespace path both work.
+        assert!(
+            stub.contains("export default { Buffer, constants"),
+            "buffer stub default export must carry `constants` for CJS-wrap consumers"
         );
     }
 }

--- a/test-files/test_issue_pino_js_get_export.ts
+++ b/test-files/test_issue_pino_js_get_export.ts
@@ -1,0 +1,69 @@
+// Regression for the pino smoke `[js_get_export]` namespace failure
+// downstream of #903 (v0.5.945). After the same-file default-import
+// collision was fixed, `import pino from "pino"` advanced past
+// `SORTING_ORDER.ASC` into `thread-stream/index.js`, which evaluates
+//
+//     const MAX_STRING = buffer.constants.MAX_STRING_LENGTH
+//
+// at top-level module init. thread-stream is loaded through Perry's
+// V8 fallback (perry-jsruntime), and its `require('buffer')` resolves
+// to the `node:buffer` stub at `crates/perry-jsruntime/src/modules.rs`
+// (the `get_builtin_stub("buffer")` arm).
+//
+// Pre-fix that stub exported `Buffer` only — no `constants` namespace.
+// `buffer.constants` was therefore `undefined`, and reading
+// `.MAX_STRING_LENGTH` on `undefined` threw `TypeError: Cannot read
+// properties of undefined (reading 'MAX_STRING_LENGTH')` at top-level.
+// V8 marked thread-stream's module as failed-to-evaluate, so the next
+// `state.runtime.get_module_namespace(module_id)` call inside
+// `js_get_export` (`crates/perry-jsruntime/src/interop.rs:1072`)
+// bubbled the same TypeError back to native code as
+//
+//     [js_get_export] failed to get namespace: TypeError: Cannot read
+//     properties of undefined (reading 'MAX_STRING_LENGTH')
+//
+// pino then sees `undefined` for the thread-stream namespace and its
+// downstream evaluation aborts (the next blocker — `(boolean).
+// tracingChannel` — is an unrelated `diagnostics_channel` gap, tracked
+// separately).
+//
+// Fix: extend the V8-fallback `node:buffer` stub to export Node's
+// real `buffer.constants` object as both a named export and a default-
+// export member. Values mirror Node 20+:
+//   - MAX_LENGTH        = Number.MAX_SAFE_INTEGER (= 2^53 - 1)
+//   - MAX_STRING_LENGTH = 2^29 - 24 = 536870888
+//
+// The actual byte-level regression is guarded by the Rust unit test
+// `test_buffer_stub_exposes_constants` at
+// `crates/perry-jsruntime/src/modules.rs`, which asserts the stub
+// source emits both the named `constants` export and its presence on
+// the default export. The V8 fallback path isn't reachable from a
+// single standalone .ts file (it only fires for V8-evaluated modules
+// inside `compilePackages` targets like pino+thread-stream), so this
+// file documents the shape and pins the public-API expectations the
+// fix puts in place. The pino smoke at the top of this comment is
+// what verifies the wiring end-to-end during release validation.
+//
+// Sanity-only checks below — they exercise the natively-compiled
+// `node:buffer` import surface, not the V8 fallback. They guard
+// against the `buffer` module ceasing to import at all and against
+// the existing `Buffer` export becoming undefined.
+
+import * as buffer from "node:buffer";
+import { Buffer } from "node:buffer";
+
+// 1. `node:buffer` resolves without throwing. The shape is whatever
+//    Perry's native module returns; we just confirm the import didn't
+//    explode at module-init.
+console.log("buffer_module_defined:", typeof (buffer as any) !== "undefined");
+
+// 2. The `Buffer` named export must still be reachable — pino's
+//    upstream chain reads `Buffer.alloc`, `Buffer.from`, etc. on it.
+//    Perry reports `typeof Buffer === "object"` today while Node says
+//    "function"; we just want a non-undefined result here.
+console.log("Buffer_defined:", typeof Buffer !== "undefined");
+
+// 3. Round-trip a Buffer through `.from` / `.toString` so we know the
+//    native side is fully wired (not just module-load wired).
+const bb = Buffer.from("hi", "utf8");
+console.log("Buffer.from('hi').toString:", bb.toString("utf8"));


### PR DESCRIPTION
## Summary

- Downstream of #903 (v0.5.944): pino smoke advanced past `SORTING_ORDER.ASC` and hit `[js_get_export] failed to get namespace: TypeError: Cannot read properties of undefined (reading 'MAX_STRING_LENGTH')`. `thread-stream/index.js` evaluates `const MAX_STRING = buffer.constants.MAX_STRING_LENGTH` at top-level — V8 fallback's `node:buffer` stub only exported `Buffer`, so `buffer.constants` was `undefined` and the module record went into failed-to-evaluate state.
- Fix: V8-fallback `get_builtin_stub("buffer")` arm now exports Node's real `buffer.constants` object (named + on default), with `MAX_LENGTH = 9007199254740991`, `MAX_STRING_LENGTH = 536870888`, plus `kMaxLength` / `kStringMaxLength` aliases.
- Scope-disciplined: only the V8-fallback stub changed; Perry's native `node:buffer` import surface is untouched. Pino smoke now stops at the unrelated `(boolean).tracingChannel` follow-up, not at `[js_get_export]`.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry -p perry-jsruntime` clean
- [x] `cargo test --release -p perry-jsruntime --lib test_buffer_stub` — new `test_buffer_stub_exposes_constants` passes
- [x] Pino smoke from the task body advances past `[js_get_export]` log line to the next unrelated downstream error
- [x] `test-files/test_issue_pino_js_get_export.ts` byte-for-byte matches `node --experimental-strip-types`
- [x] No conflict markers in `Cargo.toml` / `CLAUDE.md` after rebase