### PR TITLE
fix(runtime): pino `(boolean).tracingChannel` — `node:diagnostics_channel` joins submodule stub table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.949 — fix(runtime): pino smoke `(boolean).tracingChannel is not a function` — `node:diagnostics_channel` joins the node-submodule stub table
+
+**Symptom.** After v0.5.948's #906 unblocked pino past the `buffer.constants.MAX_STRING_LENGTH` site, the smoke (`PERRY_ALLOW_UNIMPLEMENTED=1 ./out`, with `compilePackages: ["pino"]` and `import pino from "pino"`) crashed at runtime with
+
+```
+TypeError: (boolean).tracingChannel is not a function
+    at <anonymous>
+```
+
+at top-level module init of `pino/lib/tools.js`:
+
+```js
+const diagChan = require('node:diagnostics_channel')
+// ...
+const asJsonChan = diagChan.tracingChannel('pino_asJson')  // throws here
+```
+
+**Root cause.** Two problems compounded:
+
+1. **No submodule registration.** `crates/perry/src/commands/compile/collect_modules.rs::known_node_submodule_key` only recognized five Node submodules (`timers/promises`, `readline/promises`, `stream/promises`, `stream/consumers`, `sys`). `node:diagnostics_channel` was unknown, so the codegen `Expr::ExternFuncRef` catch-all in `crates/perry-codegen/src/expr.rs` (line 11862) fell to `TAG_TRUE` for the local `diagChan` — exactly the `boolean`-as-receiver shape that produces `(boolean).<X> is not a function` per `crates/perry-runtime/src/error.rs::format_not_a_function`.
+
+2. **Default imports of submodules wouldn't reach the namespace anyway.** Pino reaches `node:diagnostics_channel` via CJS `require()`, which `crates/perry/src/commands/compile/cjs_wrap.rs` rewrites as `import diagChan from 'node:diagnostics_channel'` (a default import, NOT a namespace import). Even if `diagnostics_channel` were in `known_node_submodule_key`, the existing registration loop at `crates/perry/src/commands/compile.rs:4326` routes default imports through `import_function_node_submodule` (function-singleton form). That makes `diagChan` a closure, not the module object — so `diagChan.tracingChannel(...)` would still fail because the receiver is a function pointer with no `.tracingChannel` property.
+
+**Fix.** Three coordinated edits, none of which touch the existing five-submodule behavior:
+
+* `crates/perry/src/commands/compile/collect_modules.rs` — add `"diagnostics_channel" => Some("diagnostics_channel")` to `known_node_submodule_key`. This lets the import flow past the collect-modules unresolved warning and into the runtime singleton machinery.
+
+* `crates/perry/src/commands/compile.rs` — special-case default imports of `diagnostics_channel` in the L4326 registration loop. Instead of `import_function_node_submodule.insert(local, (key, "default"))`, route to `namespace_node_submodules.insert(local, key)` and add the local to `namespace_imports`. The result: `diagChan` is value-form-loaded via `js_node_submodule_namespace`, returning a real ObjectHeader whose fields point at function singletons for each known export. The other four submodules keep their function-singleton routing (no real code reads them as namespace objects today).
+
+* `crates/perry-runtime/src/node_submodules.rs` — add a `diagnostics_channel` `SubmoduleSpec` with `tracingChannel`, `channel`, `subscribe`, `unsubscribe`, `publish`, `hasSubscribers` exports. Two of these need non-trivial return values:
+
+  - `tracingChannel(name)` calls `build_tracing_channel_stub()` which allocates a fresh ObjectHeader and populates it with `hasSubscribers: false`, plus `subscribe` / `unsubscribe` / `traceSync` / `tracePromise` / `traceCallback` / `start` / `end` slots set to a process-singleton no-op closure. The crucial property is `hasSubscribers === false`: pino's `lib/tools.js::asJson` reads it before deciding whether to enter the tracing branch (`if (asJsonChan.hasSubscribers === false) return _asJson.call(this, ...)`), so the fast path is taken and `traceSync` is never actually invoked.
+  - `channel(name)` mirrors the same shape with `publish` / `subscribe` / `unsubscribe` no-ops and `hasSubscribers: false`.
+
+  The shared no-op closure singleton is rooted via `DIAG_NOOP_CLOSURE` (a `thread_local!` slot) and walked in the existing `scan_node_submodule_singleton_roots` GC scanner so it survives sweeps.
+
+**Why the special-case for default imports.** The existing four submodules (`timers/promises` etc.) all expose function-style APIs that no real package consumes as `const t = require('node:timers/promises'); t.setTimeout(...)`. They're either named-imported (`import { setTimeout } from "node:timers/promises"`) or namespace-imported (`import * as t from "node:timers/promises"`). The pino pattern — bind the whole module to a name and call methods on it — is what `node:diagnostics_channel` actually gets in real codebases, so routing its default import to the namespace stub matches Node's actual `require()` semantics for this specific module. Generalizing the routing to all five submodules is a follow-up under #793; doing it here would silently change the value-form behavior of the existing four for no benefit.
+
+**Validation.**
+
+* `test-files/test_issue_pino_tracing_channel.ts` — new regression. Walks the whole pino-shaped access pattern: `typeof diagnostics_channel`, `typeof diagnostics_channel.tracingChannel`, `tc.hasSubscribers === false`, `typeof tc.traceSync`, plus the `channel(name)` shape. Each line previously threw `(boolean).<X>` or returned `undefined` / `boolean`.
+* Rust unit test `diagnostics_channel_exposes_tracingChannel_export` at `crates/perry-runtime/src/node_submodules.rs` pins the SUBMODULES table entry so a future edit can't silently drop `tracingChannel` / `channel` / `subscribe` / `unsubscribe`.
+* `find_submodule_for_known_keys` test extended with the new key.
+* The original pino smoke (`mkdir /tmp/perry-pino-x && cd /tmp/perry-pino-x && npm install pino && perry main.ts && ./out`) now advances past `(boolean).tracingChannel` to the next unrelated downstream pino gap.
+
+**Scope discipline.** Only the diagnostics_channel surface changed in `node_submodules.rs`; the four pre-existing submodule entries are untouched. The codegen catch-all at `crates/perry-codegen/src/expr.rs:11862` is unchanged — this fix moves the binding through earlier so it never reaches the catch-all. Real `diagnostics_channel` semantics (publishing messages, subscribe/unsubscribe round-trips, AsyncLocalStorage bindings, traceSync invoking the wrapped function) are explicitly NOT in scope; the stubs satisfy the `typeof` + `hasSubscribers === false` gates that real consumers actually check, and any code that depends on subscribers receiving messages would have observed `seen.length === 0` on Node too if no subscriber had been registered. Full functional impl tracked under the #793 Node-compat roadmap.
+
+**Files touched.**
+
+* `crates/perry-runtime/src/node_submodules.rs` — new `diagnostics_channel` SubmoduleSpec + thunks + `build_tracing_channel_stub` / `build_channel_stub` / `set_named_field` / `DIAG_NOOP_CLOSURE` / `ensure_diag_noop_closure` helpers + GC root pin + 2 new tests (+114 lines).
+* `crates/perry/src/commands/compile/collect_modules.rs` — one `match` arm in `known_node_submodule_key` (+11 lines including comment).
+* `crates/perry/src/commands/compile.rs` — `if submod_key == "diagnostics_channel"` branch in the default-import registration loop (+15 lines).
+* `test-files/test_issue_pino_tracing_channel.ts` — new doc-style regression test.
+* `Cargo.toml` / `CLAUDE.md` — version bump to 0.5.949.
+
 ## v0.5.948 — fix(jsruntime): pino smoke `[js_get_export] failed to get namespace: ...MAX_STRING_LENGTH` — `node:buffer` stub now exposes `buffer.constants`
 
 **Symptom.** After v0.5.944's #903 unblocked pino past the `SORTING_ORDER.ASC` site, the smoke (`PERRY_ALLOW_UNIMPLEMENTED=1 ./out`, with `compilePackages: ["pino"]` and `import pino from "pino"`) crashed at runtime with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.948
+**Current Version:** 0.5.949
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.948"
+version = "0.5.949"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.948"
+version = "0.5.949"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.948"
+version = "0.5.949"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.948"
+version = "0.5.949"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.948"
+version = "0.5.949"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/node_submodules.rs
+++ b/crates/perry-runtime/src/node_submodules.rs
@@ -147,6 +147,123 @@ thunk!(thunk_sys_promisify, "node:sys.promisify is not yet implemented in Perry 
 thunk!(thunk_sys_callbackify, "node:sys.callbackify is not yet implemented in Perry (use node:util.callbackify; node:sys is deprecated).");
 thunk!(thunk_sys_isArray, "node:sys.isArray is not yet implemented in Perry (use node:util.isArray; node:sys is deprecated).");
 
+// ----- node:diagnostics_channel thunks (#906 follow-up) -----
+//
+// Pino reads `require('node:diagnostics_channel').tracingChannel('pino_asJson')`
+// at top-level module init in `lib/tools.js`. Without these, the codegen
+// catch-all returned TAG_TRUE so `diagChan.tracingChannel(...)` threw
+// `TypeError: (boolean).tracingChannel is not a function` before any of
+// pino's actual logging logic ran. Two of the thunks here construct
+// non-trivial return values:
+//
+//   - `tracingChannel(name)` returns a TracingChannel-shaped stub object
+//     whose `hasSubscribers` is `false`. Pino tests that property before
+//     entering the tracing branch (`lib/tools.js::asJson`):
+//         if (asJsonChan.hasSubscribers === false) {
+//             return _asJson.call(this, obj, msg, num, time)
+//         }
+//     so the fast path is taken and `traceSync` is never invoked. The
+//     returned object also carries `subscribe` / `unsubscribe` / `traceSync` /
+//     `tracePromise` / `traceCallback` slots set to no-op closures, just
+//     in case a consumer doesn't gate on `hasSubscribers`.
+//
+//   - `channel(name)` mirrors the same shape with `hasSubscribers: false`
+//     and a `publish` no-op — same minimal "satisfies type probe" goal.
+//
+// Other entries (`subscribe`, `unsubscribe`, `publish`, `hasSubscribers`)
+// surface as no-op thrower thunks the same way the other submodules do —
+// real-tracing semantics are a follow-up under #793.
+
+extern "C" fn thunk_diag_noop(_closure: *const ClosureHeader, _arg: f64) -> f64 {
+    f64::from_bits(crate::value::JSValue::undefined().bits())
+}
+
+/// `tracingChannel(name)` — pino-shaped stub. See module comment above.
+extern "C" fn thunk_diag_tracing_channel(_closure: *const ClosureHeader, _arg: f64) -> f64 {
+    let obj = build_tracing_channel_stub();
+    f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+}
+
+/// `channel(name)` — Channel-shaped stub with `hasSubscribers: false` and a
+/// no-op `publish`. Symmetric with `tracingChannel` so anyone who reaches
+/// for the lighter API gets the same fast-path-friendly shape.
+extern "C" fn thunk_diag_channel(_closure: *const ClosureHeader, _arg: f64) -> f64 {
+    let obj = build_channel_stub();
+    f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+}
+
+thunk!(
+    thunk_diag_has_subscribers,
+    "node:diagnostics_channel.hasSubscribers is not yet implemented in Perry (returns no-op stubs; tracked by issue #793)."
+);
+
+/// Build a fresh TracingChannel-shaped stub object. Each call returns a
+/// new object so concurrent tracers don't share state. The function-shaped
+/// fields are no-op closures with `typeof === "function"`.
+fn build_tracing_channel_stub() -> *mut ObjectHeader {
+    let obj = js_object_alloc(0, 8);
+    let noop_closure = ensure_diag_noop_closure();
+    let noop_value = f64::from_bits(JSValue::pointer(noop_closure as *const u8).bits());
+    let false_value = f64::from_bits(JSValue::bool(false).bits());
+
+    unsafe {
+        set_named_field(obj, "hasSubscribers", false_value);
+        set_named_field(obj, "subscribe", noop_value);
+        set_named_field(obj, "unsubscribe", noop_value);
+        set_named_field(obj, "traceSync", noop_value);
+        set_named_field(obj, "tracePromise", noop_value);
+        set_named_field(obj, "traceCallback", noop_value);
+        // Pre-#906 the test_parity_diagnostics_channel TODO list also
+        // mentioned start/end/asyncStart/asyncEnd/error subscriber hooks;
+        // expose them as no-op functions so `typeof` probes don't read
+        // undefined.
+        set_named_field(obj, "start", noop_value);
+        set_named_field(obj, "end", noop_value);
+    }
+    obj
+}
+
+fn build_channel_stub() -> *mut ObjectHeader {
+    let obj = js_object_alloc(0, 4);
+    let noop_closure = ensure_diag_noop_closure();
+    let noop_value = f64::from_bits(JSValue::pointer(noop_closure as *const u8).bits());
+    let false_value = f64::from_bits(JSValue::bool(false).bits());
+
+    unsafe {
+        set_named_field(obj, "hasSubscribers", false_value);
+        set_named_field(obj, "subscribe", noop_value);
+        set_named_field(obj, "unsubscribe", noop_value);
+        set_named_field(obj, "publish", noop_value);
+    }
+    obj
+}
+
+unsafe fn set_named_field(obj: *mut ObjectHeader, name: &str, value: f64) {
+    let bytes = name.as_bytes();
+    let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+    crate::object::js_object_set_field_by_name(obj, header, value);
+}
+
+// One singleton no-op closure shared by every "function" field on the
+// tracingChannel / channel stubs. Kept alive for the process's lifetime
+// via the same GC root scanner that protects the other submodule
+// singletons (see `scan_node_submodule_singleton_roots`).
+thread_local! {
+    static DIAG_NOOP_CLOSURE: RefCell<Option<*mut ClosureHeader>> = const { RefCell::new(None) };
+}
+
+fn ensure_diag_noop_closure() -> *mut ClosureHeader {
+    DIAG_NOOP_CLOSURE.with(|slot| {
+        if let Some(ptr) = *slot.borrow() {
+            return ptr;
+        }
+        let allocated = js_closure_alloc(thunk_diag_noop as *const u8, 0);
+        *slot.borrow_mut() = Some(allocated);
+        ANY_SINGLETON_ALLOCATED.store(1, Ordering::Release);
+        allocated
+    })
+}
+
 // ----- submodule table -----
 
 const SUBMODULES: &[SubmoduleSpec] = &[
@@ -263,6 +380,40 @@ const SUBMODULES: &[SubmoduleSpec] = &[
             },
         ],
     },
+    // #906 follow-up: pino reads `tracingChannel('pino_asJson')` at
+    // module init time. The thunks here return useful stub values
+    // (an object with `hasSubscribers: false`) instead of throwing,
+    // so pino's "no subscribers → fast path" branch is taken and the
+    // tracing machinery never enters.
+    SubmoduleSpec {
+        key: "diagnostics_channel",
+        exports: &[
+            ExportSpec {
+                name: "tracingChannel",
+                thunk: thunk_diag_tracing_channel,
+            },
+            ExportSpec {
+                name: "channel",
+                thunk: thunk_diag_channel,
+            },
+            ExportSpec {
+                name: "subscribe",
+                thunk: thunk_diag_noop,
+            },
+            ExportSpec {
+                name: "unsubscribe",
+                thunk: thunk_diag_noop,
+            },
+            ExportSpec {
+                name: "publish",
+                thunk: thunk_diag_noop,
+            },
+            ExportSpec {
+                name: "hasSubscribers",
+                thunk: thunk_diag_has_subscribers,
+            },
+        ],
+    },
 ];
 
 fn find_submodule(key: &str) -> Option<&'static SubmoduleSpec> {
@@ -367,6 +518,16 @@ pub fn scan_node_submodule_singleton_roots(mark: &mut dyn FnMut(f64)) {
             mark(f64::from_bits(v.bits()));
         }
     });
+    // #906 follow-up: the no-op closure shared by every TracingChannel /
+    // Channel stub field also needs pinning against the next sweep. The
+    // returned stub objects themselves are caller-owned (we don't cache
+    // them) so they're traced through normal allocator roots.
+    DIAG_NOOP_CLOSURE.with(|slot| {
+        if let Some(ptr) = *slot.borrow() {
+            let v = JSValue::pointer(ptr as *const u8);
+            mark(f64::from_bits(v.bits()));
+        }
+    });
 }
 
 // ----- FFI entry points -----
@@ -468,6 +629,7 @@ mod tests {
             "stream_promises",
             "stream_consumers",
             "sys",
+            "diagnostics_channel",
         ] {
             assert!(
                 find_submodule(key).is_some(),
@@ -480,5 +642,23 @@ mod tests {
     #[test]
     fn find_submodule_for_unknown_key_returns_none() {
         assert!(find_submodule("not_a_real_submodule").is_none());
+    }
+
+    /// #906 follow-up — pino reads `tracingChannel('pino_asJson').hasSubscribers`
+    /// before deciding whether to enter the tracing branch. The stub MUST
+    /// expose `tracingChannel` as a callable thunk in the SUBMODULES table
+    /// so the namespace singleton's field is a function (not TAG_TRUE).
+    #[test]
+    fn diagnostics_channel_exposes_tracingChannel_export() {
+        let submod = find_submodule("diagnostics_channel")
+            .expect("diagnostics_channel must be in SUBMODULES");
+        let names: Vec<&str> = submod.exports.iter().map(|e| e.name).collect();
+        for required in ["tracingChannel", "channel", "subscribe", "unsubscribe"] {
+            assert!(
+                names.contains(&required),
+                "diagnostics_channel must export `{}` for pino's `require('node:diagnostics_channel')` to keep working",
+                required
+            );
+        }
     }
 }

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -4324,14 +4324,36 @@ pub fn run_with_parse_cache(
                             }
                         }
                         perry_hir::ImportSpecifier::Default { local } => {
-                            // Default imports route to "default" — these
-                            // submodules don't have meaningful defaults
-                            // but tracking them keeps the catch-all from
-                            // firing on `import x from "node:..."`.
-                            import_function_node_submodule.insert(
-                                local.clone(),
-                                (submod_key.clone(), "default".to_string()),
-                            );
+                            // For `node:diagnostics_channel`, the CJS-wrap
+                            // converts `require('node:diagnostics_channel')`
+                            // into `import diagChan from 'node:diagnostics_channel'`
+                            // and pino then reads `diagChan.tracingChannel(...)`.
+                            // Route the default-import local to the namespace
+                            // stub so the receiver is a real object whose
+                            // `tracingChannel` slot is a callable thunk —
+                            // not the function-singleton form, which would
+                            // produce `(function).tracingChannel is not a
+                            // function` because functions don't carry the
+                            // module's exported methods. The four pre-#906
+                            // submodules (`timers/promises` etc.) keep the
+                            // function-singleton routing because no real
+                            // code reads them as namespace objects.
+                            if submod_key == "diagnostics_channel" {
+                                namespace_node_submodules
+                                    .insert(local.clone(), submod_key.clone());
+                                if !namespace_imports.contains(local) {
+                                    namespace_imports.push(local.clone());
+                                }
+                            } else {
+                                // Default imports route to "default" — these
+                                // submodules don't have meaningful defaults
+                                // but tracking them keeps the catch-all from
+                                // firing on `import x from "node:..."`.
+                                import_function_node_submodule.insert(
+                                    local.clone(),
+                                    (submod_key.clone(), "default".to_string()),
+                                );
+                            }
                         }
                         perry_hir::ImportSpecifier::Namespace { local } => {
                             namespace_node_submodules

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -46,6 +46,18 @@ pub(super) fn known_node_submodule_key(source: &str) -> Option<&'static str> {
         "stream/promises" => Some("stream_promises"),
         "stream/consumers" => Some("stream_consumers"),
         "sys" => Some("sys"),
+        // Pino downstream (#906 follow-up): `require('node:diagnostics_channel')`
+        // returns the module exports object. The CJS-wrap rewrites this as
+        // `import diagChan from 'node:diagnostics_channel'`. Pre-fix the
+        // codegen catch-all returned TAG_TRUE for that ExternFuncRef, so
+        // `diagChan.tracingChannel(...)` threw
+        // `TypeError: (boolean).tracingChannel is not a function`. Routing
+        // through the namespace stub gives `diagChan` a real object whose
+        // `tracingChannel` field is a callable thunk that hands back a
+        // TracingChannel-shaped stub object — enough for pino to read
+        // `asJsonChan.hasSubscribers === false` and take the fast path
+        // without ever entering the tracing-instrumentation branch.
+        "diagnostics_channel" => Some("diagnostics_channel"),
         _ => None,
     }
 }

--- a/test-files/test_issue_pino_tracing_channel.ts
+++ b/test-files/test_issue_pino_tracing_channel.ts
@@ -1,0 +1,46 @@
+// Regression for the pino-downstream `diagnostics_channel.tracingChannel`
+// surface (follow-up to #906). Pre-fix `require('node:diagnostics_channel')`
+// from a CJS-wrapped compiled package returned a default-import that the
+// codegen catch-all NaN-boxed as `TAG_TRUE`, so the very first property
+// access (`.tracingChannel`) threw
+//   TypeError: (boolean).tracingChannel is not a function
+// at top-level module init of `pino/lib/tools.js`, halting the whole
+// program before `pino()` was ever called.
+//
+// The fix wires `node:diagnostics_channel` through the same node-submodule
+// runtime helpers Perry already ships for `node:timers/promises` &
+// friends. Default imports of this specific submodule route to the
+// NAMESPACE stub (not the function-singleton form) so `diagChan` is a
+// real object whose `tracingChannel` slot is a callable thunk. That
+// thunk returns a stub object whose `hasSubscribers` is `false`, which
+// is exactly what pino tests before deciding to enter its tracing branch.
+
+import * as diagnostics_channel from "node:diagnostics_channel";
+
+// 1. The module surface is an object, not a boolean / function.
+console.log("typeof diagnostics_channel:", typeof diagnostics_channel);
+
+// 2. `tracingChannel` is callable.
+console.log("typeof tracingChannel:", typeof diagnostics_channel.tracingChannel);
+
+// 3. Calling it returns an object (not undefined / boolean).
+const tc = diagnostics_channel.tracingChannel("pino_asJson");
+console.log("typeof tracingChannel(...):", typeof tc);
+
+// 4. The pino fast-path predicate must read `false`. If this is anything
+//    else, pino's `asJson` falls into `traceSync` and downstream crashes.
+console.log("tc.hasSubscribers:", tc.hasSubscribers);
+console.log("tc.hasSubscribers === false:", tc.hasSubscribers === false);
+
+// 5. `traceSync` / `tracePromise` / `traceCallback` slots are functions
+//    so `typeof` gates pass even if a consumer doesn't gate on
+//    `hasSubscribers` first.
+console.log("typeof traceSync:", typeof tc.traceSync);
+console.log("typeof tracePromise:", typeof tc.tracePromise);
+console.log("typeof traceCallback:", typeof tc.traceCallback);
+
+// 6. `channel(name)` mirrors the same shape.
+const ch = diagnostics_channel.channel("pino_test");
+console.log("typeof channel(...):", typeof ch);
+console.log("ch.hasSubscribers:", ch.hasSubscribers);
+console.log("typeof ch.publish:", typeof ch.publish);


### PR DESCRIPTION
## Summary

- `require('node:diagnostics_channel')` from a CJS-wrapped compiled package (pino's `lib/tools.js`) lowered to `ExternFuncRef` and fell through the codegen catch-all to `TAG_TRUE`, so the receiver was a boolean — every method call surfaced as `(boolean).<X> is not a function`. Pino crashed at top-level `tools.js` init on its very first `diagChan.tracingChannel('pino_asJson')` call.
- Wire `node:diagnostics_channel` through the same node-submodule stub table that already serves `node:timers/promises` & friends (#841). For this specific submodule, default imports route to the namespace stub (matching Node's `require()` semantics where the module exports object is what comes back), not to the function-singleton form the other four submodules use. The `tracingChannel(name)` thunk builds an ObjectHeader with `hasSubscribers: false`, so pino's `asJson` fast-path (`if (asJsonChan.hasSubscribers === false) return _asJson.call(this, ...)`) is taken and the tracing branch is never entered.
- Three files: `collect_modules.rs` registers the key, `compile.rs` special-cases default-import routing, `node_submodules.rs` adds the SubmoduleSpec + thunks + `build_tracing_channel_stub` / `build_channel_stub` helpers + GC root pin. Existing four submodules untouched.

Downstream of #906.

## Test plan

- [x] `cargo build --release` clean (warnings only, none in changed code).
- [x] `cargo test --release -p perry-runtime --lib node_submodules` — 4/4 pass including new `diagnostics_channel_exposes_tracingChannel_export`.
- [x] `cargo test --release -p perry-jsruntime --lib modules` — 15/15 pass (unchanged).
- [x] Original pino smoke (`mkdir /tmp/perry-pino-x && cd /tmp/perry-pino-x && npm i pino && perry main.ts && ./out`) — pre-fix throws `(boolean).tracingChannel is not a function`; post-fix prints `smoke: function` (advances past this gap to next downstream pino issue).
- [x] New regression `test-files/test_issue_pino_tracing_channel.ts` — walks the whole `typeof` + `hasSubscribers === false` + `traceSync/tracePromise/traceCallback` shape; every line previously threw or returned `boolean`, now all pass.