### PR TITLE
fix(hir): #911 — express `value is not a function` — hoist function decls before var initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,93 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
-<<<<<<< HEAD
+## v0.5.951 — fix(hir): #911 — express smoke `TypeError: value is not a function` — function decls in `fn-expr` bodies now hoist BEFORE var initializers
+
+**Symptom.** With `perry.compilePackages: ["express"]`, the express smoke (`mkdir /tmp/perry-express-x && npm install express && perry main.ts -o out && ./out` for `import express from "express"; console.log(typeof express)`) died at module init with:
+
+```
+TypeError: value is not a function
+    at <anonymous>
+```
+
+The chalk PR (#891) wired up `ObjectSetPrototypeOf` / `ObjectDefineProperties` recognizers and noted "Express still fails inside the V8 fallback (unrelated, pre-existing limitation)". This issue is the next step.
+
+**Root cause.** Bisected through `PERRY_DBG_NOT_CALLABLE_ABORT=1` + lldb stack capture to the express CJS-wrap of `node_modules/express/lib/utils.js`. The cjs_wrap pass produces this IIFE shape (paraphrased):
+
+```js
+const _cjs = (function() {
+    const module = { exports: {} };
+    const exports = module.exports;
+    function require(specifier) { ... return _req_N; }   // ← source order #1
+    var { METHODS } = require('node:http');               // ← source order #2
+    ...
+})();
+```
+
+`crates/perry-hir/src/lower/expr_function.rs::lower_fn_expr` bucketed the body's statements into `var_hoisted` (every `var` decl), `func_decls` (every `function` decl), and `exec_stmts`, then emitted them as `var_hoisted + func_decls + exec_stmts`. That ran the `var { METHODS } = require('node:http')` Let — initializer and all — BEFORE the `function require` Let, so the call site `Call { callee: LocalGet("require"), args: [String("node:http")] }` ran when `require`'s closure slot was still null. The runtime closure dispatcher (`js_closure_callN`) routed the null pointer through `throw_not_callable`, which threw `TypeError: value is not a function` — express never finished evaluating its very first imported file.
+
+This violated JS spec: function declarations are fully hoisted (binding + initialized value) at function entry, while `var` declarations only hoist their *binding* (initialized to `undefined`); their *initializer* expressions run at source position.
+
+**Fix.** `lower_fn_expr` now buckets only function declarations separately (`func_decls`) and emits them BEFORE all other statements (`exec_stmts`), preserving source order between var-inits and executable statements:
+
+```rust
+let mut func_decls = Vec::new();
+let mut exec_stmts = Vec::new();
+for stmt in &block.stmts {
+    let lowered = crate::lower_decl::lower_body_stmt(ctx, stmt)?;
+    match stmt {
+        ast::Stmt::Decl(ast::Decl::Fn(_)) => func_decls.extend(lowered),
+        _ => exec_stmts.extend(lowered),
+    }
+}
+let mut combined: Vec<Stmt> = func_decls;
+combined.extend(exec_stmts);
+```
+
+The `var_hoisted_ids` machinery (already populated for `var` decls at lines 366–411 of the same file) continues to drive `PreallocateBoxes` for nested-closure forward-capture, so `var` bindings remain pre-allocated as `undefined` for code that runs before the source-position initializer. The arrow-fn / fn-decl-body paths (`lower_arrow` + `lower_fn_body_block_stmt`) already followed the correct ordering — only the `function() { ... }` *expression* path was buggy.
+
+**Validation.**
+
+* `test-files/test_issue_express_value_not_fn.ts` exercises the failing shape standalone: `function getThing() { ... }` followed by `var { value } = getThing();` inside an IIFE, plus a destructure-free variant. Output matches Node byte-for-byte.
+* The express smoke (`PERRY_ALLOW_UNIMPLEMENTED=1 ./out`) now advances past `TypeError: value is not a function` to the next unrelated downstream error: `TypeError: Cannot read properties of undefined (reading 'map')` (Perry's `node:http` doesn't expose `METHODS` — separate, narrow follow-up not addressed here).
+* IIFE/hoisting regression suite (`test_iife_arrow`, `test_iife_class_or_pattern`, `test_iife_export`, `test_edge_scope_hoisting`, `test_issue_645_iife_xmod_static_props`) all still match Node.
+* `test_gap_*` suite: 34/36 match (the two diffs — `test_gap_class_advanced` and `test_gap_console_methods` — exist on `main` without this patch and are unrelated to function/var hoisting).
+
+**Scope discipline.** Only `lower_fn_expr` was changed; arrow-fn (`lower_arrow`) and fn-decl-body (`lower_fn_body_block_stmt`) paths were already correct. Express will hit many more downstream gaps (`METHODS` on node:http, etc.) — those are not in scope for this fix. The PR pins the current state with a regression test.
+
+**Files touched.**
+
+* `crates/perry-hir/src/lower/expr_function.rs` — `lower_fn_expr` body-lowering bucket logic, -7/+12 lines, +9-line comment block referencing #911.
+* `test-files/test_issue_express_value_not_fn.ts` — new regression test.
+* `Cargo.toml` / `CLAUDE.md` — version bump to 0.5.951.
+
+## v0.5.950 — fix(codegen+runtime): #908 — dayjs `format("YYYY-MM")` no longer throws `TypeError: (number).replace is not a function`
+
+**Symptom.** After v0.5.948's #904 unblocked dayjs past the bare `Array(...)` call inside its `padStart`-style `m(t,e,n)` utility, the smoke (`PERRY_ALLOW_UNIMPLEMENTED=1 ./out`, with `compilePackages: ["dayjs"]` and `import dayjs from "dayjs"; dayjs("2024-01-02").format("YYYY-MM")`) crashed at runtime with
+
+```
+TypeError: (number).replace is not a function
+    at <anonymous>
+```
+
+**Diagnosis.** Two cooperating bugs were at play, both surfaced by dayjs's `format()` method:
+
+1. **`Array(n).join(sep)` emitted `"[object Object]"` for each hole slot.** `js_array_alloc_with_length` initialises every slot to `TAG_HOLE` (`0x7FFC_0000_0000_0010` — a NaN-boxed sentinel distinct from UNDEFINED). The hole-aware reader `js_array_get_f64` already translates `TAG_HOLE → TAG_UNDEFINED` on read, but `js_array_join` (`crates/perry-runtime/src/array.rs:2734`) had no `TAG_HOLE` arm in its type-dispatch chain, so every hole fell through to the catch-all `else` branch that emits the literal `"[object Object]"` placeholder. dayjs's `m(t,e,n)` pads a number to width `e` via `"" + Array(e+1-r.length).join(n) + t`, so `Array(2).join("0")` returned `"[object Object]0[object Object]"` instead of `"00"`. This silently corrupted `b.z(this)` (the UTC offset zone string `"+02:00"` that gets captured as `i` inside `format`) into something like `"+[object Object]0[object Object]2:..."`. Still a string, still nominally valid — but…
+
+2. **The module-wide `boxed_vars` set missed every `Stmt::PreallocateBoxes` inside a closure registered via `Expr::RegisterFunctionPrototypeMethod`.** The HIR lowers `Constructor.prototype.method = function () {...}` (dayjs's class-method-via-prototype pattern) to `Expr::RegisterFunctionPrototypeMethod { func, method_name, value: Closure { ... } }`. `crates/perry-codegen/src/boxed_vars.rs::collect_nested_closure_boxed_vars_in_expr` had an unconditional `_ => {}` catch-all that silently skipped this Expr variant, so the format closure's body — which holds `Stmt::PreallocateBoxes([147, 148, 149, 150, 151, 152, ...])` for `var e, n, r, i, s, u, a, ...` — never had its boxed-let ids unioned into `module_boxed_vars`. At codegen time the inner replace-callback closure (`r.replace(y, function(t,r){... return ... || i.replace(":","")})`) then saw `boxed_vars.contains(150 /* outer `i` */) == false`, took the raw-f64 capture path instead of `js_box_get(box_ptr)`, and the box-pointer bits leaked through `typeof` as a tiny denormal `number` (≈ `1.08e-311`, raw bits `0x0000020000c70858`). The replace callback's `i.replace(":","")` fallback path then dispatched on a number-typed receiver and threw the `TypeError: (number).replace is not a function` from runtime/string.rs.
+
+The two bugs reinforced each other: bug 1 corrupted the captured string's content (visible to outside-the-callback reads), bug 2 corrupted the captured value's TYPE (visible only inside the callback). Either alone would have produced a wrong-but-different result; together they synthesised the precise "(number).replace" shape.
+
+**Fixes.**
+
+1. `crates/perry-runtime/src/array.rs` — `js_array_join` now early-`continue`s on `element_bits == TAG_HOLE` so holes contribute the empty string per ES2015 §22.1.3.13 step 7. Already-known undefined/null arms keep their existing empty-string emit, so the JS-spec semantics for non-hole undefineds are preserved.
+
+2. `crates/perry-codegen/src/boxed_vars.rs` — `collect_nested_closure_boxed_vars_in_expr`'s catch-all now delegates to `perry_hir::walker::walk_expr_children` (matching the pattern the sibling collectors `collect_closure_refs_and_writes_in_expr`, `collect_outer_writes_in_expr`, and `collect_write_ids_in_expr` already use). The walker covers `Register{,Function}PrototypeMethod`, `Switch`-discriminant, `Await`, `Yield`, `TypeOf`, `Void`, `InstanceOf`, etc., so future Expr additions automatically inherit traversal — no more silent skips when a new lowering shape ships.
+
+**Validation.** New regression test `test-files/test_issue_dayjs_number_replace.ts` exercises both shapes with plain TypeScript (no dayjs dependency): the `Array(n).join(sep)` sparse-hole semantics for `n ∈ {0,1,2,3}`, a `pad`-style helper that mirrors dayjs's `m`, and a `Constructor.prototype.format = function (t) {...}` whose inner replace callback asserts `typeof i === "string"` and would throw if the captured string-typed local degraded to a number. Both perry and `node --experimental-strip-types` produce byte-identical output for the test. The original `dayjs("2024-01-02").format("YYYY-MM")` smoke no longer throws — it now reaches the dayjs `Date` parse path and emits a (separate, downstream) wrong-year result (`"292278994-08"`), tracked as the next dayjs gap, not addressed here.
+
+**Scope discipline.** Two narrow changes: one hole-check arm in `js_array_join`, one catch-all fallback in `collect_nested_closure_boxed_vars_in_expr`. No HIR or transform changes. The boxed-vars walker change widens coverage (more ids may now be boxed) — this is monotone-safe: every previously-boxed id stays boxed, and the newly-boxed ids match a `Stmt::PreallocateBoxes` that the HIR explicitly emitted because the body needs them boxed.
+
 ## v0.5.949 — fix(runtime): pino smoke `(boolean).tracingChannel is not a function` — `node:diagnostics_channel` joins the node-submodule stub table
 
 **Symptom.** After v0.5.948's #906 unblocked pino past the `buffer.constants.MAX_STRING_LENGTH` site, the smoke (`PERRY_ALLOW_UNIMPLEMENTED=1 ./out`, with `compilePackages: ["pino"]` and `import pino from "pino"`) crashed at runtime with
@@ -57,34 +143,6 @@ const asJsonChan = diagChan.tracingChannel('pino_asJson')  // throws here
 * `crates/perry/src/commands/compile.rs` — `if submod_key == "diagnostics_channel"` branch in the default-import registration loop (+15 lines).
 * `test-files/test_issue_pino_tracing_channel.ts` — new doc-style regression test.
 * `Cargo.toml` / `CLAUDE.md` — version bump to 0.5.949.
-=======
-## v0.5.950 — fix(codegen+runtime): #908 — dayjs `format("YYYY-MM")` no longer throws `TypeError: (number).replace is not a function`
-
-**Symptom.** After v0.5.948's #904 unblocked dayjs past the bare `Array(...)` call inside its `padStart`-style `m(t,e,n)` utility, the smoke (`PERRY_ALLOW_UNIMPLEMENTED=1 ./out`, with `compilePackages: ["dayjs"]` and `import dayjs from "dayjs"; dayjs("2024-01-02").format("YYYY-MM")`) crashed at runtime with
-
-```
-TypeError: (number).replace is not a function
-    at <anonymous>
-```
-
-**Diagnosis.** Two cooperating bugs were at play, both surfaced by dayjs's `format()` method:
-
-1. **`Array(n).join(sep)` emitted `"[object Object]"` for each hole slot.** `js_array_alloc_with_length` initialises every slot to `TAG_HOLE` (`0x7FFC_0000_0000_0010` — a NaN-boxed sentinel distinct from UNDEFINED). The hole-aware reader `js_array_get_f64` already translates `TAG_HOLE → TAG_UNDEFINED` on read, but `js_array_join` (`crates/perry-runtime/src/array.rs:2734`) had no `TAG_HOLE` arm in its type-dispatch chain, so every hole fell through to the catch-all `else` branch that emits the literal `"[object Object]"` placeholder. dayjs's `m(t,e,n)` pads a number to width `e` via `"" + Array(e+1-r.length).join(n) + t`, so `Array(2).join("0")` returned `"[object Object]0[object Object]"` instead of `"00"`. This silently corrupted `b.z(this)` (the UTC offset zone string `"+02:00"` that gets captured as `i` inside `format`) into something like `"+[object Object]0[object Object]2:..."`. Still a string, still nominally valid — but…
-
-2. **The module-wide `boxed_vars` set missed every `Stmt::PreallocateBoxes` inside a closure registered via `Expr::RegisterFunctionPrototypeMethod`.** The HIR lowers `Constructor.prototype.method = function () {...}` (dayjs's class-method-via-prototype pattern) to `Expr::RegisterFunctionPrototypeMethod { func, method_name, value: Closure { ... } }`. `crates/perry-codegen/src/boxed_vars.rs::collect_nested_closure_boxed_vars_in_expr` had an unconditional `_ => {}` catch-all that silently skipped this Expr variant, so the format closure's body — which holds `Stmt::PreallocateBoxes([147, 148, 149, 150, 151, 152, ...])` for `var e, n, r, i, s, u, a, ...` — never had its boxed-let ids unioned into `module_boxed_vars`. At codegen time the inner replace-callback closure (`r.replace(y, function(t,r){... return ... || i.replace(":","")})`) then saw `boxed_vars.contains(150 /* outer `i` */) == false`, took the raw-f64 capture path instead of `js_box_get(box_ptr)`, and the box-pointer bits leaked through `typeof` as a tiny denormal `number` (≈ `1.08e-311`, raw bits `0x0000020000c70858`). The replace callback's `i.replace(":","")` fallback path then dispatched on a number-typed receiver and threw the `TypeError: (number).replace is not a function` from runtime/string.rs.
-
-The two bugs reinforced each other: bug 1 corrupted the captured string's content (visible to outside-the-callback reads), bug 2 corrupted the captured value's TYPE (visible only inside the callback). Either alone would have produced a wrong-but-different result; together they synthesised the precise "(number).replace" shape.
-
-**Fixes.**
-
-1. `crates/perry-runtime/src/array.rs` — `js_array_join` now early-`continue`s on `element_bits == TAG_HOLE` so holes contribute the empty string per ES2015 §22.1.3.13 step 7. Already-known undefined/null arms keep their existing empty-string emit, so the JS-spec semantics for non-hole undefineds are preserved.
-
-2. `crates/perry-codegen/src/boxed_vars.rs` — `collect_nested_closure_boxed_vars_in_expr`'s catch-all now delegates to `perry_hir::walker::walk_expr_children` (matching the pattern the sibling collectors `collect_closure_refs_and_writes_in_expr`, `collect_outer_writes_in_expr`, and `collect_write_ids_in_expr` already use). The walker covers `Register{,Function}PrototypeMethod`, `Switch`-discriminant, `Await`, `Yield`, `TypeOf`, `Void`, `InstanceOf`, etc., so future Expr additions automatically inherit traversal — no more silent skips when a new lowering shape ships.
-
-**Validation.** New regression test `test-files/test_issue_dayjs_number_replace.ts` exercises both shapes with plain TypeScript (no dayjs dependency): the `Array(n).join(sep)` sparse-hole semantics for `n ∈ {0,1,2,3}`, a `pad`-style helper that mirrors dayjs's `m`, and a `Constructor.prototype.format = function (t) {...}` whose inner replace callback asserts `typeof i === "string"` and would throw if the captured string-typed local degraded to a number. Both perry and `node --experimental-strip-types` produce byte-identical output for the test. The original `dayjs("2024-01-02").format("YYYY-MM")` smoke no longer throws — it now reaches the dayjs `Date` parse path and emits a (separate, downstream) wrong-year result (`"292278994-08"`), tracked as the next dayjs gap, not addressed here.
-
-**Scope discipline.** Two narrow changes: one hole-check arm in `js_array_join`, one catch-all fallback in `collect_nested_closure_boxed_vars_in_expr`. No HIR or transform changes. The boxed-vars walker change widens coverage (more ids may now be boxed) — this is monotone-safe: every previously-boxed id stays boxed, and the newly-boxed ids match a `Stmt::PreallocateBoxes` that the HIR explicitly emitted because the body needs them boxed.
->>>>>>> 30239667 (fix(codegen+runtime): #907 — dayjs `format("YYYY-MM")` no longer throws `TypeError: (number).replace is not a function`)
 
 ## v0.5.948 — fix(jsruntime): pino smoke `[js_get_export] failed to get namespace: ...MAX_STRING_LENGTH` — `node:buffer` stub now exposes `buffer.constants`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.950
+**Current Version:** 0.5.951
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.950"
+version = "0.5.951"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.950"
+version = "0.5.951"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.950"
+version = "0.5.951"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.950"
+version = "0.5.951"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.950"
+version = "0.5.951"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -431,43 +431,52 @@ pub(super) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) ->
         }
     }
 
-    // Lower body with JS hoisting: only `var` declarations and function
-    // declarations are hoisted per JS semantics. `let`/`const` MUST remain
-    // at their lexical position because their init expressions are only
-    // evaluated when control flow reaches them — hoisting `const x = fn()`
-    // out of a conditional branch would eagerly run the call.
+    // Lower body with JS hoisting: only function declarations are fully
+    // hoisted per JS semantics (binding + initialization at function
+    // entry). `var` bindings are also hoisted, but their *initializer*
+    // expressions run at source position — pre-allocating the slot is
+    // already handled by `var_hoisted_ids` + the `PreallocateBoxes` pass
+    // below. `let`/`const` MUST remain at their lexical position because
+    // their init expressions are only evaluated when control flow reaches
+    // them — hoisting `const x = fn()` out of a conditional branch would
+    // eagerly run the call.
+    //
+    // Issue #911: previously this pass split `var` declarations into a
+    // separate `var_hoisted` bucket and emitted them BEFORE function
+    // declarations, so the express CJS-wrap shape
+    //   function require(s) { ... }
+    //   var { METHODS } = require('node:http');
+    // ran the `require('node:http')` call before `require` was bound and
+    // threw `TypeError: value is not a function`. Function declarations
+    // must run before any var-init in the body, then var-inits and other
+    // executable statements run in source order.
     let mut body = if let Some(ref block) = fn_expr.function.body {
-        let mut var_hoisted = Vec::new();
         let mut func_decls = Vec::new();
         let mut exec_stmts = Vec::new();
         for stmt in &block.stmts {
             let lowered = crate::lower_decl::lower_body_stmt(ctx, stmt)?;
             match stmt {
                 ast::Stmt::Decl(ast::Decl::Fn(_)) => func_decls.extend(lowered),
-                ast::Stmt::Decl(ast::Decl::Var(var_decl))
-                    if var_decl.kind == ast::VarDeclKind::Var =>
-                {
-                    var_hoisted.extend(lowered);
-                }
                 _ => exec_stmts.extend(lowered),
             }
         }
-        var_hoisted.extend(func_decls);
-        var_hoisted.extend(exec_stmts);
+        let mut combined: Vec<Stmt> = Vec::with_capacity(func_decls.len() + exec_stmts.len());
+        combined.extend(func_decls);
+        combined.extend(exec_stmts);
         // Issue #633: prealloc-box for sibling/forward captures.
         if !hoisted_id_set.is_empty() {
             let prealloc = crate::lower_decl::compute_prealloc_for_hoisted_closures(
-                &var_hoisted,
+                &combined,
                 &hoisted_id_set,
             );
             if !prealloc.is_empty() {
-                let mut with_prealloc: Vec<Stmt> = Vec::with_capacity(var_hoisted.len() + 1);
+                let mut with_prealloc: Vec<Stmt> = Vec::with_capacity(combined.len() + 1);
                 with_prealloc.push(Stmt::PreallocateBoxes(prealloc));
-                with_prealloc.extend(var_hoisted);
-                var_hoisted = with_prealloc;
+                with_prealloc.extend(combined);
+                combined = with_prealloc;
             }
         }
-        var_hoisted
+        combined
     } else {
         Vec::new()
     };

--- a/test-files/test_issue_express_value_not_fn.ts
+++ b/test-files/test_issue_express_value_not_fn.ts
@@ -1,0 +1,53 @@
+// Regression test for the express `TypeError: value is not a function` crash.
+//
+// Express 5.x's CJS-wrapped `node_modules/express/lib/utils.js` IIFE body has
+// shape (paraphrased):
+//
+//   (function() {
+//       function require(specifier) { ... return _req_N; }
+//       var { METHODS } = require('node:http');
+//       ...
+//   })();
+//
+// Perry's `lower_fn_expr` previously bucketed the body into
+// `var_hoisted + func_decls + exec_stmts`, which reordered the var
+// declaration (with its initializer) to run BEFORE the function declaration
+// in the lowered HIR. The `require('node:http')` call then ran when `require`
+// was still null, and the closure dispatcher's null-callable check threw
+// `TypeError: value is not a function` — express's module init died on the
+// very first import.
+//
+// Per JS spec, function declarations are FULLY hoisted (binding + value)
+// at function entry, while `var` declarations only hoist their BINDING
+// (to `undefined`); their initializer expressions run at source position.
+// `lower_fn_expr` now emits `func_decls` ahead of all other statements and
+// keeps `var` initializers in source order, matching that spec.
+
+(function () {
+    // Function declaration FIRST in source order, var-destructure SECOND.
+    // Both forms (with and without destructuring) must work.
+    function getThing(): { value: number } {
+        return { value: 42 };
+    }
+
+    var { value } = getThing();
+    console.log("value:", value);
+
+    var plain = getThing();
+    console.log("plain.value:", plain.value);
+})();
+
+// Run as an IIFE assigned to a const (matches express's `const _cjs =
+// (function(){...})();` shape exactly).
+const result = (function () {
+    function reqHelper(spec: string): { items: number[] } {
+        if (spec === "list") return { items: [1, 2, 3] };
+        return { items: [] };
+    }
+
+    var { items } = reqHelper("list");
+    return items.length;
+})();
+
+console.log("result:", result);
+console.log("OK");


### PR DESCRIPTION
## Summary

- Fixes the express smoke (`TypeError: value is not a function` at module init, chalk PR #891 noted "Express still fails inside the V8 fallback").
- Root cause: `lower_fn_expr` (function-expression body lowering) bucketed body statements as `var_hoisted + func_decls + exec_stmts`, running `var` initializers BEFORE function declarations. Express's CJS-wrapped `lib/utils.js` IIFE has `function require(s) { ... }` followed by `var { METHODS } = require('node:http')`, so the destructure ran when `require` was still null and `js_closure_callN` threw the title TypeError.
- Per JS spec, function declarations are fully hoisted (binding + value); `var` only hoists its binding. Fix: only function decls go ahead of other statements; `var` initializers stay in source order.
- Express now advances past this error to the next downstream gap (`METHODS` not exposed on Perry's node:http — separate follow-up).

## Test plan

- [x] `test-files/test_issue_express_value_not_fn.ts` — standalone repro of the failing shape (matches Node byte-for-byte).
- [x] Express smoke (`mkdir /tmp/perry-express-x && npm install express && perry main.ts -o out && ./out`) no longer throws `value is not a function`.
- [x] IIFE/hoisting regression tests (`test_iife_arrow`, `test_iife_class_or_pattern`, `test_iife_export`, `test_edge_scope_hoisting`, `test_issue_645_iife_xmod_static_props`) all still match Node.
- [x] Gap suite: 34/36 match (two pre-existing diffs unrelated to fn/var hoisting confirmed against `main` without this patch).
- [x] Only `lower_fn_expr` changed; arrow-fn (`lower_arrow`) and fn-decl-body (`lower_fn_body_block_stmt`) paths were already correct.