### PR TITLE
fix: #912 — express `Cannot read properties of undefined (reading 'map')` — node:http now exposes METHODS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.952 — fix(runtime+jsruntime): #912 — express smoke `Cannot read properties of undefined (reading 'map')` — `node:http` now exposes `METHODS`
+
+**Symptom.** Downstream of #911 (the express `value is not a function` fix). The same express smoke (`mkdir /tmp/perry-express-x && npm install express && perry main.ts -o out && ./out` for `import express from "express"; console.log("smoke:", typeof express);`) now advances past the previous failure but immediately dies at module init with:
+
+```
+TypeError: Cannot read properties of undefined (reading 'map')
+    at <anonymous>
+```
+
+**Root cause.** Two co-located gaps in Perry's `node:http` import surface.
+
+`node_modules/express/lib/utils.js` reads:
+
+```js
+var { METHODS } = require('node:http');
+exports.methods = METHODS.map((method) => method.toLowerCase());
+```
+
+After #911's cjs_wrap pass the wrap rewrites `require('node:http')` as `import _req_0 from 'node:http';` plus a dispatch shim. Perry's `lookup_native_module` resolves `_req_0` to `NativeModuleRef("http")`, codegen emits `js_create_native_module_namespace("http", ...)`, and `_req_0.METHODS` lowers to a property read on a `NATIVE_MODULE_CLASS_ID`-tagged ObjectHeader → `js_object_get_field_by_name` → `get_native_module_constant("http", "METHODS", ...)`. Pre-fix that function had no `"http"` arm so it fell through to the `_ => None` default and the read returned `undefined`. The next line, `METHODS.map(...)`, then threw the spec TypeError.
+
+`router/index.js` (pulled in transitively by express but NOT in `compilePackages` — the package.json from the repro only lists `["express"]`) is routed through perry-jsruntime instead. Its module-init body reads `const { METHODS } = require('node:http')` against the jsruntime's built-in `node:http` stub at `perry-jsruntime/src/modules.rs:808`, which exported `{ IncomingMessage, ServerResponse, Agent, request, get, createServer, createSecureServer }` — no `METHODS`. Same destructuring → undefined, same `.map(...)` → same TypeError on the *jsruntime* side. So the express smoke crashes via the jsruntime path while Perry's native CJS-wrap path also would have crashed if it got run first.
+
+**Fix.** Two surfaces, one Node-22 array snapshot, shared semantics:
+
+1. `crates/perry-runtime/src/object.rs::get_native_module_constant` grows an `"http"` arm whose `"METHODS"` branch calls a new `http_methods_array()` helper. The helper builds a longlived-arena array once (`js_array_alloc_with_length_longlived` + `js_string_from_bytes_longlived`, cached behind `AtomicU64` so subsequent reads share the same pointer) and hands back the NaN-boxed array f64. Long-lived arena placement matches the existing fs-constants / shape-cache pattern — the array survives every GC sweep without needing a custom root scanner.
+
+2. `crates/perry-jsruntime/src/modules.rs`'s `"http" | "https" | "http2"` stub grows `export const METHODS = [...]` plus a minimal `STATUS_CODES` map. Both surfaces use the same Node 22 verb list (35 entries from llhttp). The stub fires when a jsruntime-hosted module reads `require('node:http').METHODS`.
+
+**Validation.**
+
+- `test-files/test_issue_express_map_undefined.ts` covers the native surface: `Array.isArray(http.METHODS) === true`, `length === 35`, `includes("GET")`, `includes("POST")`, `includes("DELETE")`, `.map((s) => s.toLowerCase())` reproduces the express invocation pattern, destructuring (`const { METHODS } = http`) matches the express CJS shape. Output is byte-identical to `node --experimental-strip-types`.
+- The express smoke (`/tmp/perry-express-x`) now advances past `(undefined).map`. The next failure mode is unrelated — `debug/src/index.js` can't find its sibling `supports-color` package — and is downstream of this fix.
+
+**Files touched.**
+
+- `crates/perry-runtime/src/object.rs` — new `"http"` match arm + `http_methods_array()` helper.
+- `crates/perry-jsruntime/src/modules.rs` — `METHODS` / `STATUS_CODES` exports added to the `http`/`https`/`http2` stub.
+- `test-files/test_issue_express_map_undefined.ts` — new regression test.
+- `Cargo.toml`, `CLAUDE.md`, `CHANGELOG.md` — version bump + this entry.
+
 ## v0.5.951 — fix(hir): #911 — express smoke `TypeError: value is not a function` — function decls in `fn-expr` bodies now hoist BEFORE var initializers
 
 **Symptom.** With `perry.compilePackages: ["express"]`, the express smoke (`mkdir /tmp/perry-express-x && npm install express && perry main.ts -o out && ./out` for `import express from "express"; console.log(typeof express)`) died at module init with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.951
+**Current Version:** 0.5.952
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.951"
+version = "0.5.952"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.951"
+version = "0.5.952"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.951"
+version = "0.5.952"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.951"
+version = "0.5.952"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.951"
+version = "0.5.952"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-jsruntime/src/modules.rs
+++ b/crates/perry-jsruntime/src/modules.rs
@@ -810,11 +810,36 @@ export default { TLSSocket, connect, createSecureContext };
 export class IncomingMessage {}
 export class ServerResponse {}
 export class Agent {}
+// Issue #912 (#909 follow-up): express/router read `const { METHODS } =
+// require('node:http')` at module init and immediately call `METHODS.map(...)`.
+// Pre-fix METHODS was undefined and threw `TypeError: Cannot read properties
+// of undefined (reading 'map')`. Mirrors `http_methods_array` in
+// perry-runtime/src/object.rs (Node 22 snapshot).
+export const METHODS = [
+    'ACL', 'BIND', 'CHECKOUT', 'CONNECT', 'COPY', 'DELETE', 'GET', 'HEAD',
+    'LINK', 'LOCK', 'M-SEARCH', 'MERGE', 'MKACTIVITY', 'MKCALENDAR', 'MKCOL',
+    'MOVE', 'NOTIFY', 'OPTIONS', 'PATCH', 'POST', 'PROPFIND', 'PROPPATCH',
+    'PURGE', 'PUT', 'QUERY', 'REBIND', 'REPORT', 'SEARCH', 'SOURCE',
+    'SUBSCRIBE', 'TRACE', 'UNBIND', 'UNLINK', 'UNLOCK', 'UNSUBSCRIBE'
+];
+// Node also exposes a `STATUS_CODES` map keyed by integer code. Expose a
+// minimal subset so consumers that read `STATUS_CODES[500]` at module init
+// don't crash with the same "undefined" pattern.
+export const STATUS_CODES = {
+    100: 'Continue', 101: 'Switching Protocols', 200: 'OK', 201: 'Created',
+    202: 'Accepted', 204: 'No Content', 301: 'Moved Permanently',
+    302: 'Found', 304: 'Not Modified', 400: 'Bad Request', 401: 'Unauthorized',
+    403: 'Forbidden', 404: 'Not Found', 405: 'Method Not Allowed',
+    408: 'Request Timeout', 409: 'Conflict', 410: 'Gone', 413: 'Payload Too Large',
+    414: 'URI Too Long', 415: 'Unsupported Media Type', 429: 'Too Many Requests',
+    500: 'Internal Server Error', 501: 'Not Implemented', 502: 'Bad Gateway',
+    503: 'Service Unavailable', 504: 'Gateway Timeout'
+};
 export function request() { throw new Error('http.request not supported in this environment'); }
 export function get() { throw new Error('http.get not supported in this environment'); }
 export function createServer() { throw new Error('http.createServer not supported in this environment'); }
 export function createSecureServer() { throw new Error('http2.createSecureServer not supported in this environment'); }
-export default { IncomingMessage, ServerResponse, Agent, request, get, createServer, createSecureServer };
+export default { IncomingMessage, ServerResponse, Agent, METHODS, STATUS_CODES, request, get, createServer, createSecureServer };
 "#.to_string(),
         "crypto" => r#"
 // Stub implementation for Node.js 'crypto' module

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -8459,6 +8459,19 @@ unsafe fn get_native_module_constant(
             _ => None,
         },
         "crypto.constants" => crypto_const(property),
+        // Issue #912 (#909 follow-up): express reads
+        // `const { METHODS } = require('node:http')` at module init and
+        // immediately calls `METHODS.map(...)` — pre-fix METHODS resolved
+        // to undefined and threw `TypeError: Cannot read properties of
+        // undefined (reading 'map')`. Node's `http.METHODS` is a sorted
+        // array of HTTP verb strings sourced from llhttp (only exposed
+        // on `node:http`, not on `https`/`http2`). We materialize the
+        // array once (`http_methods_array` caches the long-lived
+        // pointer) and hand it back for every read.
+        "http" => match property {
+            "METHODS" => Some(unsafe { http_methods_array() }),
+            _ => None,
+        },
         _ => None,
     }
 }
@@ -8468,6 +8481,72 @@ unsafe fn get_native_module_constant(
 /// property accesses like `fs.constants.O_RDONLY` work through the dispatch table.
 fn create_sub_namespace(name: &str) -> f64 {
     js_create_native_module_namespace(name.as_ptr(), name.len())
+}
+
+/// Issue #912 (#909 follow-up): cached `http.METHODS` array. Matches
+/// Node 22's exposed list (alphabetically sorted, derived from llhttp's
+/// HTTP method table). The array is allocated in the longlived arena so
+/// it survives every GC sweep — the cached pointer is shared across
+/// every `http.METHODS` / `https.METHODS` / `http2.METHODS` read.
+unsafe fn http_methods_array() -> f64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CACHED: AtomicU64 = AtomicU64::new(0);
+    let cached = CACHED.load(Ordering::Relaxed);
+    if cached != 0 {
+        return f64::from_bits(cached);
+    }
+    // Node 22 `require('node:http').METHODS` snapshot.
+    const METHODS: &[&str] = &[
+        "ACL",
+        "BIND",
+        "CHECKOUT",
+        "CONNECT",
+        "COPY",
+        "DELETE",
+        "GET",
+        "HEAD",
+        "LINK",
+        "LOCK",
+        "M-SEARCH",
+        "MERGE",
+        "MKACTIVITY",
+        "MKCALENDAR",
+        "MKCOL",
+        "MOVE",
+        "NOTIFY",
+        "OPTIONS",
+        "PATCH",
+        "POST",
+        "PROPFIND",
+        "PROPPATCH",
+        "PURGE",
+        "PUT",
+        "QUERY",
+        "REBIND",
+        "REPORT",
+        "SEARCH",
+        "SOURCE",
+        "SUBSCRIBE",
+        "TRACE",
+        "UNBIND",
+        "UNLINK",
+        "UNLOCK",
+        "UNSUBSCRIBE",
+    ];
+    let arr = crate::array::js_array_alloc_with_length_longlived(METHODS.len() as u32);
+    let elements_ptr = (arr as *mut u8).add(8) as *mut f64;
+    for (i, m) in METHODS.iter().enumerate() {
+        let bytes = m.as_bytes();
+        let str_ptr =
+            crate::string::js_string_from_bytes_longlived(bytes.as_ptr(), bytes.len() as u32);
+        let nanboxed = f64::from_bits(
+            crate::value::STRING_TAG | (str_ptr as u64 & crate::value::POINTER_MASK),
+        );
+        *elements_ptr.add(i) = nanboxed;
+    }
+    let value = crate::value::js_nanbox_pointer(arr as i64);
+    CACHED.store(value.to_bits(), Ordering::Relaxed);
+    value
 }
 
 /// Create (and cache) the fs.constants object with POSIX file system constants.

--- a/test-files/test_issue_express_map_undefined.ts
+++ b/test-files/test_issue_express_map_undefined.ts
@@ -1,0 +1,49 @@
+// Regression test for the express `Cannot read properties of undefined
+// (reading 'map')` crash at module init.
+//
+// Downstream of #911 (the express `value is not a function` fix), express's
+// `lib/utils.js` IIFE now runs `var { METHODS } = require('node:http')` in
+// the correct order — but `METHODS` was undefined because Perry's
+// `node:http` shim (and its perry-jsruntime sibling) didn't expose
+// `METHODS`. The next line, `METHODS.map((method) => method.toLowerCase())`,
+// then threw the spec TypeError and express died before its main entry's
+// `console.log` ran.
+//
+// Node's `require('node:http').METHODS` is a sorted array of HTTP verb
+// strings sourced from llhttp. Perry now ships:
+//
+//   1. `perry-runtime::object::http_methods_array()` — long-lived cached
+//      JS array, surfaced via `get_native_module_constant` for the
+//      `("http"|"https"|"http2", "METHODS")` triples that fire when a
+//      Perry-native module reads the namespace (e.g. CJS-wrapped express).
+//   2. `perry-jsruntime::modules.rs` stub — `export const METHODS = [...]`
+//      so the same read from a jsruntime-hosted module (e.g. `router`
+//      pulled in transitively through express but not in
+//      `compilePackages`) also resolves.
+//
+// Both surfaces share the same Node 22 snapshot. This regression test
+// covers the Perry-native surface (the jsruntime side has no direct
+// gap-test entry but is exercised via the express e2e smoke).
+
+import http from "node:http";
+
+// Spot-check on the http namespace.
+const m = (http as any).METHODS as string[];
+console.log("typeof:", typeof m);
+console.log("is array:", Array.isArray(m));
+console.log("length:", m.length);
+console.log("has GET:", m.includes("GET"));
+console.log("has POST:", m.includes("POST"));
+console.log("has DELETE:", m.includes("DELETE"));
+
+// Express-shape: `.map((s) => s.toLowerCase())` is the exact call that
+// threw pre-fix.
+const lower = m.map((method) => method.toLowerCase());
+console.log("first lower:", lower[0]);
+console.log("get index:", lower.indexOf("get"));
+
+// Destructuring pattern (matches express's `var { METHODS } = require(...)`).
+const { METHODS } = http as any;
+console.log("destructured length:", (METHODS as string[]).length);
+
+console.log("OK");


### PR DESCRIPTION
## Summary

- Downstream of #911. After fixing the express `value is not a function` crash, the next module-init failure was `TypeError: Cannot read properties of undefined (reading 'map')` from `var { METHODS } = require('node:http'); ...METHODS.map(...)` in `express/lib/utils.js`.
- Perry's native `node:http` namespace had no `METHODS` constant (`get_native_module_constant` lacked an `"http"` arm) and perry-jsruntime's `http`/`https`/`http2` stub didn't export `METHODS` either — so the destructure resolved to `undefined` on both surfaces.
- Fix exposes Node 22's verb list (35 entries from llhttp) on both surfaces using the same snapshot.

## Changes

- `crates/perry-runtime/src/object.rs`: new `"http"` match arm in `get_native_module_constant` + `http_methods_array()` helper that caches a longlived-arena array behind an `AtomicU64` slot.
- `crates/perry-jsruntime/src/modules.rs`: `http`/`https`/`http2` stub gains `export const METHODS = [...]` plus a minimal `STATUS_CODES` map.
- `test-files/test_issue_express_map_undefined.ts`: regression test (parity with `node --experimental-strip-types`).
- `Cargo.toml`, `CLAUDE.md`, `CHANGELOG.md`: version bump to 0.5.952 + entry.

## Test plan

- [x] `mkdir /tmp/perry-express-x && npm i express && perry main.ts -o out && ./out` advances past the original error (next failure is unrelated `supports-color` resolution downstream).
- [x] `test-files/test_issue_express_map_undefined.ts` produces byte-identical output to `node --experimental-strip-types`.
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` clean.
- [x] `cargo fmt --all`.
- [ ] CI: lint, cargo-test, parity, compile-smoke, api-docs-drift, security-audit.