### PR TITLE
fix(jsruntime): express smoke `[js_load_module] FAILED to load` — optional require() soft-throws inside CJS wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.957 — fix(jsruntime): express smoke `[js_load_module] FAILED to load` — optional/peer `require()` of unresolved bare module now soft-throws inside CJS wrapper
+
+**Symptom.** Express smoke (downstream of #909/#911/#912) aborted at module-load time with:
+
+```
+$ PERRY_ALLOW_UNIMPLEMENTED=1 ./out
+[js_load_module] FAILED to load '/private/tmp/.../express/node_modules/debug/src/index.js':
+    Cannot find module 'supports-color' in node_modules
+TypeError: value is not a function
+    at <anonymous>
+```
+
+The path in the error pointed at express's transitive dep `debug/src/index.js`, which (via `debug/src/node.js`) issues `require('supports-color')` inside a `try/catch` — `supports-color` is declared as an `optionalPeerDependency`, doesn't have to be installed, and `debug` explicitly swallows the resulting `MODULE_NOT_FOUND`. Node.js handles this correctly because `require()` is synchronous and the throw happens at the call site. Perry's V8-fallback layer broke that pattern.
+
+**Root cause.** `crates/perry-jsruntime/src/modules.rs::wrap_commonjs` translates every CJS `require("X")` callsite into a static top-of-file ESM `import * as _req_N from "X";`, then in the wrapped IIFE the synthetic `require(specifier)` returns `_req_N`. This hoist breaks the optional-require pattern: when V8 instantiates the wrapper module, it calls our `ModuleLoader::resolve()` for the bare specifier `"supports-color"`. `resolve_from_node_modules()` walked the tree, found nothing, and returned `Err("Cannot find module 'supports-color' in node_modules")`. That error propagated out of V8 module instantiation and aborted `js_load_module` for the parent module (`debug/src/index.js`) — i.e., before any user JS runs. The CJS try/catch around `require('supports-color')` never had a chance to catch it because the static import failed at link time, not runtime.
+
+**Fix.** Three coordinated changes route missing bare imports through a synthetic stub that defers the throw to the require() callsite:
+
+1. **`NodeModuleLoader::resolve()`** — when `resolve_module_path()` fails for a *bare* specifier (no `./`, `../`, `/`, `file://`, or `<scheme>://` prefix), instead of returning `Err`, return a synthetic `ModuleSpecifier::parse("perry-missing:<spec>")`. Relative/absolute paths and node: builtins are unaffected. A `log::warn!` records the substitution.
+
+2. **`NodeModuleLoader::load()`** — detect `scheme() == "perry-missing"` and synthesize an ESM stub:
+
+   ```js
+   export const __perry_missing = true;
+   export const __perry_specifier = 'supports-color';
+   export default undefined;
+   ```
+
+   This lets `import * as _req_N from 'supports-color'` succeed with a benign namespace carrying a marker.
+
+3. **`wrap_commonjs()` codegen** — the per-specifier require-lookup case is rewritten to consult the marker BEFORE returning the namespace:
+
+   ```js
+   if (specifier === 'supports-color') {
+       if (_req_0 && _req_0.__perry_missing === true) {
+           var __err = new Error("Cannot find module '" + _req_0.__perry_specifier + "'");
+           __err.code = 'MODULE_NOT_FOUND';
+           throw __err;
+       }
+       return __perry_require_namespace(_req_0);
+   }
+   ```
+
+   The throw now happens *inside* the wrapper's `require()` function body, which is called from inside the CJS module's user code — exactly the position where Node would throw, so a wrapping `try/catch` catches it cleanly.
+
+4. **`js_load_module` entry point in `interop.rs`** — the top-level entry where Perry's stub bridges TS `import x from "..."` to V8 must NOT silently substitute missing modules (that would mask legitimate user errors). Added an explicit check: if `loader.resolve()` returns a `perry-missing:` scheme, hard-fail with the original `[js_load_module] FAILED to load '<spec>': bare module not found in node_modules` message. Only nested V8 graph resolution (which originates from the CJS wrapper's hoisted imports) benefits from the soft-throw stub.
+
+**Validation.**
+- `test-files/test_issue_express_js_load_module.ts` + fixture `optional_dep.js` exercise the soft-throw end-to-end: a `.js` module wraps `require("non-existent-optional-pkg-xyz")` in `try/catch`, falls onto the catch arm, and exports a sentinel. Byte-for-byte parity with `node --experimental-strip-types`.
+- Express smoke at the top of this changelog no longer prints `[js_load_module] FAILED to load`. (The downstream `TypeError: value is not a function` is a separate, pre-existing express gap unrelated to module loading.)
+
+**Files touched.**
+- `crates/perry-jsruntime/src/modules.rs` — resolve() bare-miss → `perry-missing:` scheme, load() stub-module emission, wrap_commonjs() per-require marker check
+- `crates/perry-jsruntime/src/interop.rs` — top-level `js_load_module` rejects `perry-missing:` resolutions with the original error message
+- `test-files/test_issue_express_js_load_module.ts` + `test-files/fixtures/issue_express_js_load_module/optional_dep.js` — regression test mirroring debug → supports-color shape
+
 ## v0.5.956 — fix(runtime): #856 — single canonical `_setjmp` extern shared by gc.rs + promise.rs
 
 **Symptom.** `cargo build --release -p perry-runtime` emitted a `clashing_extern_declarations` warning:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.956
+**Current Version:** 0.5.957
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.956"
+version = "0.5.957"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.956"
+version = "0.5.957"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.956"
+version = "0.5.957"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.956"
+version = "0.5.957"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.956"
+version = "0.5.957"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-jsruntime/src/interop.rs
+++ b/crates/perry-jsruntime/src/interop.rs
@@ -913,24 +913,40 @@ pub unsafe extern "C" fn js_load_module(path_ptr: *const i8, path_len: usize) ->
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
     // Try to resolve the module path
-    let resolved_path: PathBuf =
-        if path_str.starts_with("./") || path_str.starts_with("../") || path_str.starts_with('/') {
-            // Relative or absolute path - resolve directly
-            let path = PathBuf::from(path_str);
-            std::fs::canonicalize(&path).unwrap_or(path)
-        } else {
-            // Bare module specifier (like "ethers") - use node_modules resolution
-            let referrer = format!("file://{}/index.js", cwd.display());
-            match loader.resolve(path_str, &referrer, deno_core::ResolutionKind::Import) {
-                Ok(specifier) => specifier
-                    .to_file_path()
-                    .unwrap_or_else(|_| PathBuf::from(path_str)),
-                Err(e) => {
-                    log::error!("Failed to resolve module '{}': {}", path_str, e);
+    let resolved_path: PathBuf = if path_str.starts_with("./")
+        || path_str.starts_with("../")
+        || path_str.starts_with('/')
+    {
+        // Relative or absolute path - resolve directly
+        let path = PathBuf::from(path_str);
+        std::fs::canonicalize(&path).unwrap_or(path)
+    } else {
+        // Bare module specifier (like "ethers") - use node_modules resolution
+        let referrer = format!("file://{}/index.js", cwd.display());
+        match loader.resolve(path_str, &referrer, deno_core::ResolutionKind::Import) {
+            Ok(specifier) => {
+                // Top-level user imports of bare specifiers that the
+                // loader couldn't find produce a `perry-missing:` stub
+                // (so nested V8 graph resolution can soft-throw). At
+                // the top-level entry, a real failure is correct —
+                // surface it as the existing hard error.
+                if specifier.scheme() == "perry-missing" {
+                    eprintln!(
+                            "[js_load_module] FAILED to load '{}': bare module not found in node_modules",
+                            path_str
+                        );
                     return 0;
                 }
+                specifier
+                    .to_file_path()
+                    .unwrap_or_else(|_| PathBuf::from(path_str))
             }
-        };
+            Err(e) => {
+                log::error!("Failed to resolve module '{}': {}", path_str, e);
+                return 0;
+            }
+        }
+    };
 
     let canonical = resolved_path.clone();
 

--- a/crates/perry-jsruntime/src/modules.rs
+++ b/crates/perry-jsruntime/src/modules.rs
@@ -407,13 +407,43 @@ impl ModuleLoader for NodeModuleLoader {
         } else if referrer.starts_with("node:") {
             // If referrer is a built-in, use current directory
             self.base_dir.join("index.js")
+        } else if referrer.starts_with("perry-missing:") {
+            // Missing-stub referrer: anchor further lookups at the project root.
+            self.base_dir.join("index.js")
         } else {
             PathBuf::from(referrer)
         };
 
-        let resolved_path = self
-            .resolve_module_path(specifier, &referrer_path)
-            .map_err(|e| JsErrorBox::generic(e.to_string()))?;
+        let resolved_path = match self.resolve_module_path(specifier, &referrer_path) {
+            Ok(p) => p,
+            Err(e) => {
+                // V8-fallback graceful-degradation: bare specifiers that fail to
+                // resolve in node_modules (common case: optional/peer deps like
+                // debug → `require('supports-color')` inside a try/catch) become
+                // synthetic `perry-missing:<spec>` modules. `load()` returns a
+                // marker stub; the CJS wrapper's `require()` function then
+                // throws a JS MODULE_NOT_FOUND error inside the user's
+                // try/catch instead of aborting the whole module graph at
+                // static-import time. Only applies to bare specifiers (no
+                // ./, ../, /, or file:// prefix) — relative/absolute path
+                // failures stay hard errors.
+                let is_bare = !specifier.starts_with("./")
+                    && !specifier.starts_with("../")
+                    && !specifier.starts_with('/')
+                    && !specifier.starts_with("file://")
+                    && !specifier.contains("://");
+                if is_bare {
+                    log::warn!(
+                        "[js_load_module] missing bare module '{}' — returning soft-throw stub ({})",
+                        specifier,
+                        e
+                    );
+                    return ModuleSpecifier::parse(&format!("perry-missing:{}", specifier))
+                        .map_err(|err| JsErrorBox::generic(err.to_string()));
+                }
+                return Err(JsErrorBox::generic(e.to_string()));
+            }
+        };
 
         let canonical = std::fs::canonicalize(&resolved_path).unwrap_or(resolved_path);
         let canonical = if canonical.is_dir() {
@@ -441,6 +471,30 @@ impl ModuleLoader for NodeModuleLoader {
         if module_specifier.scheme() == "node" {
             let builtin_name = module_specifier.path();
             let stub_code = get_builtin_stub(builtin_name);
+            return ModuleLoadResponse::Sync(Ok(ModuleSource::new(
+                ModuleType::JavaScript,
+                ModuleSourceCode::String(stub_code.into()),
+                module_specifier,
+                None,
+            )));
+        }
+
+        // Handle missing-module stubs. The synthetic `perry-missing:<spec>`
+        // scheme is produced by resolve() when a bare specifier can't be
+        // located in node_modules. The stub exposes a marker so the
+        // wrap_commonjs() generated `require()` can throw a JS
+        // MODULE_NOT_FOUND error (caught by the caller's try/catch)
+        // instead of failing static-import time.
+        if module_specifier.scheme() == "perry-missing" {
+            let spec = module_specifier.path();
+            // Escape single quotes / backslashes for embedding in the JS string.
+            let escaped = spec.replace('\\', "\\\\").replace('\'', "\\'");
+            let stub_code = format!(
+                "export const __perry_missing = true;\n\
+                 export const __perry_specifier = '{}';\n\
+                 export default undefined;\n",
+                escaped
+            );
             return ModuleLoadResponse::Sync(Ok(ModuleSource::new(
                 ModuleType::JavaScript,
                 ModuleSourceCode::String(stub_code.into()),
@@ -595,17 +649,33 @@ fn wrap_commonjs(code: &str) -> String {
         .collect::<Vec<_>>()
         .join("\n");
 
-    // Generate require() lookup cases
+    // Generate require() lookup cases. Each non-JSON case first checks
+    // whether the imported namespace carries the `perry-missing:` stub
+    // marker — if so we throw a Node-compatible MODULE_NOT_FOUND error
+    // INSIDE the require() function body so a wrapping try/catch (the
+    // optional-dependency pattern used by debug, etc.) can catch it.
     let require_cases = require_specs
         .iter()
         .enumerate()
         .map(|(i, spec)| {
+            let escaped_spec = spec.replace('\\', "\\\\").replace('\'', "\\'");
             if spec.ends_with(".json") {
-                format!("        if (specifier === '{}') return _req_{};", spec, i)
+                format!(
+                    "        if (specifier === '{}') return _req_{};",
+                    escaped_spec, i
+                )
             } else {
                 format!(
-                    "        if (specifier === '{}') return __perry_require_namespace(_req_{});",
-                    spec, i
+                    "        if (specifier === '{spec}') {{\n\
+                     \x20           if (_req_{idx} && _req_{idx}.__perry_missing === true) {{\n\
+                     \x20               var __err = new Error(\"Cannot find module '\" + _req_{idx}.__perry_specifier + \"'\");\n\
+                     \x20               __err.code = 'MODULE_NOT_FOUND';\n\
+                     \x20               throw __err;\n\
+                     \x20           }}\n\
+                     \x20           return __perry_require_namespace(_req_{idx});\n\
+                     \x20       }}",
+                    spec = escaped_spec,
+                    idx = i
                 )
             }
         })

--- a/test-files/fixtures/issue_express_js_load_module/optional_dep.js
+++ b/test-files/fixtures/issue_express_js_load_module/optional_dep.js
@@ -1,0 +1,26 @@
+// V8-fallback CJS module that mirrors `debug/src/node.js`'s optional-dep
+// pattern: a top-level `require()` for a peer dep that may not be installed,
+// wrapped in a try/catch. Before the fix, the CJS-wrapped module hoisted
+// `require('non-existent-optional-pkg-xyz')` to a static
+// `import * as _req_0 from 'non-existent-optional-pkg-xyz'` at the top of
+// the wrapper, and the unresolved bare specifier aborted module loading
+// with `[js_load_module] FAILED to load`. After the fix, missing bare
+// specifiers resolve to a `perry-missing:` stub and the require() call
+// throws a MODULE_NOT_FOUND error from INSIDE the wrapper's `require()`
+// function — caught by user `try/catch` exactly like Node.js.
+
+var colorLevel = 0;
+
+try {
+  // eslint-disable-next-line global-require
+  var supportsColor = require("non-existent-optional-pkg-xyz");
+  if (supportsColor && supportsColor.level >= 2) {
+    colorLevel = supportsColor.level;
+  }
+} catch (e) {
+  // Swallow — optional dep, doesn't have to be installed.
+  colorLevel = -1;
+}
+
+exports.colorLevel = colorLevel;
+exports.label = "optional-dep-ok";

--- a/test-files/test_issue_express_js_load_module.ts
+++ b/test-files/test_issue_express_js_load_module.ts
@@ -1,0 +1,38 @@
+// Regression test for express V8-fallback `[js_load_module] FAILED to load`.
+//
+// Symptom on main pre-fix (express smoke):
+//
+//   $ perry main.ts -o out && ./out
+//   [js_load_module] FAILED to load '/.../debug/src/index.js':
+//     Cannot find module 'supports-color' in node_modules
+//   TypeError: value is not a function
+//
+// Root cause: Perry's CJS→ESM wrapper (`wrap_commonjs` in
+// `crates/perry-jsruntime/src/modules.rs`) hoists every `require("...")`
+// call to a top-of-file `import * as _req_N from "..."` so the wrapped
+// IIFE can do synchronous lookups. That static import means a bare
+// specifier that can't be resolved in node_modules (a missing OPTIONAL
+// peer dep like `supports-color` in `debug`, gated by `try/catch`)
+// aborts module loading at instantiation time instead of throwing a
+// catchable JS error at the require() callsite — opposite of Node.js
+// semantics, where `require()` of an absent optional dep throws
+// `MODULE_NOT_FOUND` synchronously and can be swallowed.
+//
+// Fix: `resolve()` substitutes a synthetic `perry-missing:<spec>` stub
+// specifier for unresolvable bare imports; `load()` returns an ESM
+// module that exports `__perry_missing: true` + `__perry_specifier`;
+// `wrap_commonjs` emits a per-require-case marker check that throws
+// `MODULE_NOT_FOUND` from inside the wrapper's `require()` body so
+// user-level `try/catch` catches it. Top-level user imports (entry-point
+// `js_load_module` calls) still hard-error so genuinely missing modules
+// aren't silently masked.
+//
+// This test exercises the soft-throw path end-to-end via a fixture .js
+// module that wraps `require("non-existent-optional-pkg-xyz")` in
+// try/catch and reports whether it landed on the catch arm.
+
+import { colorLevel, label } from "./fixtures/issue_express_js_load_module/optional_dep.js";
+
+console.log("label:", label);
+console.log("colorLevel:", colorLevel);
+console.log("OK");


### PR DESCRIPTION
## Summary
- Downstream of #909/#911/#912: the express smoke aborted at module-load time because `debug/src/node.js` does `require('supports-color')` inside a try/catch, but the V8-fallback CJS wrapper hoists every require() into a static top-of-file `import * as _req_N` — so the missing optional peer dep aborted V8 module instantiation BEFORE the try/catch wrapped the call. Result: `[js_load_module] FAILED to load '.../debug/src/index.js': Cannot find module 'supports-color' in node_modules`.
- Fix routes unresolved bare imports through a synthetic `perry-missing:<spec>` stub: `NodeModuleLoader::resolve()` returns the stub on bare-miss, `load()` emits a marker ESM module (`__perry_missing: true`), and `wrap_commonjs()`'s per-specifier require-case now consults the marker and throws `MODULE_NOT_FOUND` from INSIDE the wrapper's `require()` body — caught by user `try/catch` exactly like Node. The top-level `js_load_module` entry rejects `perry-missing:` resolutions with the original hard error so genuine user-import misses aren't silently masked.
- Regression: `test-files/test_issue_express_js_load_module.ts` + fixture mirrors the debug → supports-color pattern standalone, byte-for-byte parity with `node --experimental-strip-types`.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo build --release -p perry-jsruntime -p perry-runtime -p perry-stdlib -p perry` green
- [x] Express smoke (`mkdir /tmp/X && npm i express`, compile + run) no longer emits `[js_load_module] FAILED to load`. Downstream `TypeError: value is not a function` remains as a separate pre-existing express gap.
- [x] `test-files/test_issue_express_js_load_module.ts` byte-for-byte parity with Node.