### PR TITLE
fix(hir): #923 — block-export of native-factory const matches inline-export shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.960 — fix(hir): #923 — block-export of `mysql.createPool` / native-factory const links + runs as value
+
+**Symptom.** Two ways of exporting a module-level binding produced different results, where the spec says they're interchangeable. With `mysql2/promise`:
+
+```ts
+// db.ts — block-export form
+import mysql from "mysql2/promise";
+const pool = mysql.createPool({ ...cfg });
+export async function query<T>(sql: string) {
+  const [rows] = await pool.execute(sql);
+  return rows as T[];
+}
+export { pool };  // ← link error on Linux, "typeof pool === 'function'" on macOS
+
+// db.ts — inline-export form (works)
+export const pool = mysql.createPool({ ...cfg });
+```
+
+Pre-fix the block form link-failed on `__perry_wrap_perry_fn_db_ts__pool` on x86_64 Linux (before #836's Sub-bug B landed) and silently misbehaved on macOS post-#836 — the wrapper-emission loop at `codegen.rs:~2942` emitted a no-op wrapper returning NaN-boxed undefined, so consumers reading `pool` as a value (e.g. `pool.execute(sql)` lowers `pool` to `ExternFuncRef { name: "pool" }`, which goes through `js_closure_alloc_singleton(@__perry_wrap_...)` when the binding isn't in `imported_vars`) got a closure handle instead of the Pool. `typeof pool` read "function" and any property access on it segfaulted.
+
+**Why the two forms diverged.** `export const pool = mysql.createPool(...)` lowers via the `ModuleDecl::ExportDecl` arm in `crates/perry-hir/src/lower.rs:4450`, which unconditionally pushes the binding into `module.exported_objects` at line 5087. That single list controls everything downstream: codegen's `exported_var_names` set keys off it (codegen.rs:1582), which gates both the producer-side global slot (`perry_global_<src>__<id>`) and the value-getter (`perry_fn_<src>__<name>`); and the CLI driver's consumer-side `imported_vars` set (compile.rs:3462) is populated from `exported_var_names` (compile.rs:2306), which controls whether `Expr::ExternFuncRef { name }` lowers to a getter call (expr.rs:11783) or falls through to the closure-wrapper path (expr.rs:11815).
+
+`const pool = ...; export { pool };` lowers via the bare `Stmt::Decl(Decl::Var)` path (the `Let` is pushed first by `lower_stmt` at line 6117) and then the `ModuleDecl::ExportNamed` arm at line 5200. That arm contains an explicit init-expression whitelist at line 5355 — only certain HIR expression shapes register the binding as an exported value. The whitelist covered `Closure / Object / Array / Call / New / JsNew / LocalGet / FuncRef / ExternFuncRef / PropertyGet / String / Number / Bool / BigInt / Null / Undefined / SymbolFor` but NOT `NativeMethodCall`.
+
+`mysql.createPool(...)` lowers to `Expr::NativeMethodCall { module: "mysql2/promise", class_name: None, object: None, method: "createPool", args: [...] }` because `mysql` is a registered native-module alias and the call resolves to the stdlib FFI dispatch. So the `is_exportable` check failed, `pool` never landed in `exported_objects`, no producer-side global / getter was emitted, and consumers fell off the value-getter path into the no-op wrapper — link succeeded post-#836 but runtime was wrong.
+
+**Fix.** Extend the `is_exportable` matcher at `crates/perry-hir/src/lower.rs:5355` with `Expr::NativeMethodCall { .. }`. The block-export form now mirrors the inline-export form for every stdlib factory pattern: `mysql2/promise.createPool` / `createConnection`, `net.createConnection`, `http.createServer`, `pg.connect`, `tls.connect`, `ioredis` constructors, and any other factory `lookup_native_module` resolves.
+
+**Validation.**
+- New regression test `test-files/test_issue_923_block_export_form.ts` + fixture `test-files/fixtures/issue_923_pkg/producer.ts` exercises the producer/consumer shape with a plain const so it stays self-contained (no DB required). Both `pool.<prop>` (value-getter path) and `typeof pool` (closure-singleton path) succeed; `typeof pool` correctly reads `"object"` instead of `"function"`.
+- `test-files/test_issue_836_zod_class_reexports.ts` still passes — the zod namespace-import-re-export and `$`-prefixed sanitize-mismatch paths are untouched.
+- Local repro under `probe_mysql/` (`import mysql from "mysql2/promise"; const pool = mysql.createPool(...); export { pool };`) now reports `typeof pool: object` from a consumer module instead of `function`.
+- `cargo build --release -p perry` clean, `cargo test --release -p perry-hir -p perry-codegen` green.
+
+Refs #836, #890, #905.
+
 ## v0.5.959 — fix(stdlib): #924 — silence happy-path stderr spam from `jwt.verify` + fastify + box/object runtime warns
 
 **Symptom.** Production services built with Perry's stdlib filled their PM2 error logs with per-request stderr lines that buried real crashes. The operator's 7-day sample was 80 MB of error log, ~95% of it stdlib noise. Three sources:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.959
+**Current Version:** 0.5.960
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.959"
+version = "0.5.960"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.959"
+version = "0.5.960"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.959"
+version = "0.5.960"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.959"
+version = "0.5.960"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.959"
+version = "0.5.960"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-hir/src/lower.rs
+++ b/crates/perry-hir/src/lower.rs
@@ -5386,6 +5386,30 @@ fn lower_module_decl(
                                             // pick it up via `imported_vars` (and route through the
                                             // getter, not as a closure pointer).
                                             | Expr::SymbolFor(_)
+                                            // Issue #923: `const pool = mysql.createPool(...)`
+                                            // followed by `export { pool }` lowers the init to
+                                            // `Expr::NativeMethodCall` (not `Expr::Call`) because
+                                            // `mysql` is a registered native-module alias and the
+                                            // factory call resolves to the stdlib FFI dispatch.
+                                            // Without this branch, `pool` never lands in
+                                            // `exported_objects`, the producer-side getter
+                                            // `perry_fn_<src>__pool` is never emitted, and the
+                                            // consumer-side `ExternFuncRef { name: "pool" }` falls
+                                            // through to the closure-wrapper path
+                                            // (`__perry_wrap_perry_fn_<src>__pool`) which #836's
+                                            // Sub-bug B emits as a no-op returning undefined. End
+                                            // result: link succeeds but `typeof pool === "function"`
+                                            // and `pool.execute(...)` segfaults. Mirroring the
+                                            // inline-export shape (`export const pool = ...` at
+                                            // line ~5087) makes both export forms equivalent.
+                                            //
+                                            // Covers every stdlib factory pattern: `mysql2/promise`
+                                            // `createPool` / `createConnection`, `net.createConnection`,
+                                            // `http.createServer`, `pg.connect`, `ioredis`
+                                            // constructors, `tls.connect`, and any other
+                                            // factory the codegen already lowers to a
+                                            // `NativeMethodCall` via lookup_native_module.
+                                            | Expr::NativeMethodCall { .. }
                                     );
                                     if is_exportable {
                                         module.exported_objects.push(exported.clone());

--- a/test-files/fixtures/issue_923_pkg/producer.ts
+++ b/test-files/fixtures/issue_923_pkg/producer.ts
@@ -1,0 +1,13 @@
+// Issue #923 fixture — block-export form `const x = ...; export { x };`
+// Pre-fix this lowered to `Export::Named { local: "pool", exported: "pool" }`
+// for a non-function local, which the wrapper-emission loops in codegen
+// skipped, leaving `__perry_wrap_perry_fn_<src>__pool` undefined and the
+// link failing when consumers passed `pool` as a value.
+
+const pool = { name: "shared-pool", tag: 42 };
+
+export function poolName(): string {
+  return pool.name;
+}
+
+export { pool };

--- a/test-files/test_issue_923_block_export_form.ts
+++ b/test-files/test_issue_923_block_export_form.ts
@@ -1,0 +1,38 @@
+// Issue #923 — `const x = ...; export { x };` (block-export form) failed
+// to link with `undefined reference to __perry_wrap_perry_fn_<src>__pool`,
+// while the inline-export form `export const x = ...` linked fine. The
+// two are interchangeable in ECMAScript; Perry should treat them as such.
+//
+// Root cause is the same family as #836 — the block-export form lowers
+// to `Export::Named { local: "pool", exported: "pool" }` for a non-
+// function local, which the existing wrapper-emission loops in codegen
+// skipped (the `local != exported` rename loop and the
+// `local == exported && local is namespace import` no-op loop both
+// missed the case where `local == exported` and `local` is a plain
+// module-level const). The fix extends the codegen no-op-wrapper
+// emission to also cover plain const-locals exported via a block.
+//
+// The bar for this regression test is purely link-time: the binary
+// must compile, link, and run. The runtime value is also asserted so
+// we know the producer-side getter (`perry_fn_<src>__pool`) and
+// closure wrapper still agree on what the binding points at.
+
+import { pool, poolName } from "./fixtures/issue_923_pkg/producer.ts";
+
+// Read `pool` as a property — exercises the value-getter symbol.
+console.log("pool.name:", pool.name);
+console.log("pool.tag:", pool.tag);
+
+// Read `pool` as a value — exercises the closure-wrapper symbol
+// (`__perry_wrap_perry_fn_<src>__pool`), which was the missing
+// symbol called out in the link error.
+function describe(obj: any): string {
+  return typeof obj;
+}
+console.log("typeof pool:", describe(pool));
+
+// Sibling export still works (sanity check that we didn't break the
+// regular `export function` path).
+console.log("poolName():", poolName());
+
+console.log("done");


### PR DESCRIPTION
## Summary

- Adds `Expr::NativeMethodCall { .. }` to the `is_exportable` whitelist in the `ModuleDecl::ExportNamed` lowerer at `crates/perry-hir/src/lower.rs:5355`, so `const pool = mysql.createPool(...); export { pool };` mirrors the inline `export const pool = ...` form and lands `pool` in `module.exported_objects`.
- Closes #923. Without this, native-factory consts exported via the block form fell through `imported_vars` into the closure-wrapper path (`js_closure_alloc_singleton(@__perry_wrap_perry_fn_<src>__<name>)`), which #836's Sub-bug B emits as a no-op returning NaN-boxed undefined — `typeof pool === "function"` post-link, property access segfaulted. Pre-#836 the link itself failed on `__perry_wrap_perry_fn_<src>__<name>`.

## Why the two export forms diverged

`export const pool = ...` lowers via the `ModuleDecl::ExportDecl::Var` arm (line 4496) which unconditionally pushes the binding into `module.exported_objects` at line 5087. `const pool = ...; export { pool };` lowers via the bare `Stmt::Decl(Decl::Var)` path (line 6117 — the `Let` is pushed first) then through `ModuleDecl::ExportNamed` (line 5200), which has an init-expression whitelist gating registration. The whitelist covered `Closure / Object / Array / Call / New / JsNew / LocalGet / FuncRef / ExternFuncRef / PropertyGet / String / Number / Bool / BigInt / Null / Undefined / SymbolFor` but NOT `NativeMethodCall`, even though `mysql.createPool(...)` lowers to `Expr::NativeMethodCall` (not `Expr::Call`) because `mysql` is a registered native-module alias.

## Test plan

- [x] New regression test `test-files/test_issue_923_block_export_form.ts` + fixture `test-files/fixtures/issue_923_pkg/producer.ts` (self-contained plain const, no DB required). Both `pool.<prop>` (value-getter path) and `typeof pool` (closure-singleton path) succeed; `typeof pool` reads `"object"` (was `"function"` pre-fix).
- [x] `test_issue_836_zod_class_reexports.ts` still passes (namespace-import + `$`-sanitize paths unchanged).
- [x] Local `mysql2/promise` repro (`import mysql from "mysql2/promise"; const pool = mysql.createPool(...); export { pool };`) now reports `typeof pool: object` from a consumer module instead of `"function"`.
- [x] `cargo build --release -p perry` clean.
- [x] `cargo test --release -p perry-hir -p perry-codegen` green.

Refs #836, #890, #905.