### PR TITLE
fix(codegen+hir): dayjs format() returned 292278994-08 instead of 2024-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.961 — fix(codegen+hir): dayjs `format("YYYY-MM")` returned `292278994-08` instead of `2024-01`
+
+**Symptom.** `dayjs("2024-01-02").format("YYYY-MM")` printed `292278994-08` under Perry vs. `2024-01` under Node. dayjs technically passed the smoke (no exception), but every formatted year/month was garbage.
+
+**Root cause** — two compounding bugs:
+
+1. `Expr::DateNew` carried `Option<Box<Expr>>` and `lower_new`'s "Date" arm did `args.into_iter().next().unwrap()` — silently dropping every argument past the first. dayjs's `parseDate` issues `new Date(r[1], i, r[3]||1, r[4]||0, r[5]||0, r[6]||0, s)` (the 7-arg local-time form). Perry compiled that to `new Date(r[1])`, parsing the year string "2024" as 2024 ms-since-epoch and treating the result as a Date.
+
+2. With (1) fixed (multi-arg form lowered to a new `js_date_new_local_components(year, month, day, hour, min, sec, ms)` runtime function), dayjs *still* printed garbage — but now garbage of a different shape, with `$d.getTime() === NaN` and bytes of the strings "millisecond"/"second"/"minute" leaking into the f64 args. Tracing the runtime arrivals showed those strings were being passed where year/month/day belonged. The minified bundle declares module-level constants `var i = "second", s = "minute", r = "millisecond", …`, and inside `parseDate` re-declares `var i = r[2]-1||0` and `var s = (r[7]||"0").substring(0,3)`. `LocalId`s are scope-local — each function's `fresh_local()` counter starts at 0 — so the inner `i` got the same id (`10`) as the outer constant, and the inner `s` got the same id (`11`) as the outer constant. `compute_closure_captures` in `lower/expr_function.rs` filtered the closure's free-variable set by `outer_local_ids` and `param_ids` but did not exclude ids *redeclared* by an inner `let`/`var`/`function` — so the inner closure was wired up to capture the outer constants. The closure body's `LocalGet(10)` then resolved to "second", `LocalGet(11)` to "minute", and the multi-arg `new Date(...)` site (now correctly passing 7 args) handed those strings to the runtime.
+
+**Fix:**
+
+- `crates/perry-hir/src/ir.rs`: change `Expr::DateNew(Option<Box<Expr>>)` to `Expr::DateNew(Vec<Expr>)`. Propagate through `monomorph.rs`, `walker.rs`, `analysis.rs`, `js_transform.rs`, `stable_hash.rs`, `collectors.rs`, plus the JS / WASM emitters.
+- `crates/perry-hir/src/lower/expr_new.rs`: drop the `take-first-arg` collapse and return `Expr::DateNew(args)` with the full lowered arg vector.
+- `crates/perry-codegen/src/expr.rs`: branch on `args.len()` — 0 → `js_date_new`, 1 → `js_date_new_from_value` (preserves existing semantics for `new Date(timestamp)` / `new Date(string)`), `>=2` → `js_date_new_local_components(year, month, day, hour, min, sec, ms)` with padding via NaN-boxed `undefined` for the missing tail.
+- `crates/perry-runtime/src/date.rs`: new `js_date_new_local_components` that coerces NaN-boxed strings via `s.parse::<f64>()` (so dayjs's regex-captured `"2024"` becomes the year `2024`, not a 2024-ms timestamp), folds out-of-range months via `(year*12 + month).div_euclid(12)`, applies the local-tz offset at the local instant, registers the result in `DATE_REGISTRY` so `instanceof Date` keeps working, and remaps the canonical Invalid-Date sentinel for NaN coercion failures.
+- `crates/perry-codegen/src/runtime_decls.rs`: declare `js_date_new_local_components(d, d, d, d, d, d, d) -> d`.
+- `crates/perry-hir/src/lower/expr_function.rs` + `crates/perry-hir/src/lower_decl.rs`: `compute_closure_captures` (the central capture detector used by both arrow and `function` expressions) plus the body-statement arrow handler now filter the capture set by an additional `inner_decls` set computed by a new shared `collect_let_decls_in_stmt` helper. The helper walks the closure body without recursing into nested closures and emits every `Stmt::Let { id, .. }` (plus `For`-init lets and catch-clause params) it finds. The `mutable_captures` filter is updated for the same reason.
+
+The fix is bidirectional — both the multi-arg lowering and the capture detector had to land in the same change because either alone leaves dayjs broken: without the lowering fix, `$d` is `new Date("2024")` (1970 with `getTime() === 2024`); without the capture fix the multi-arg form passes the outer-constant strings as components and `$d.getTime()` is NaN. Together, `dayjs("2024-01-02").format("YYYY-MM")` matches Node byte-for-byte.
+
+**Regression test** — `test-files/test_issue_dayjs_year_overflow.ts` reproduces both shapes: a `parseDate(date: string)` whose local `var i = r[2]-1||0` / `var s = (r[7]||"0").substring(0,3)` shadow same-named outer `i = "outerI"` / `s = "outerS"` constants, plus the bare-number 3-arg `new Date(2024, 0, 2)` and 7-arg `new Date(2024, 5, 15, 12, 30, 45, 500)` calls. Output matches `node --experimental-strip-types` byte-for-byte.
+
+**Validation.**
+
+- `cargo fmt` + `cargo build --release` clean.
+- dayjs smoke (`PERRY_ALLOW_UNIMPLEMENTED=1 perry main.ts -o out`): `2024-01` (was `292278994-08`) — matches Node.
+- Gap suite: 34/36 unchanged from pre-fix baseline; the two pre-existing DIFFs (`test_gap_class_advanced`'s `static block initialized: 0 vs true` boolean→0 coercion + `test_gap_console_methods`'s `console.time` timing skew) are unaffected.
+
 ## v0.5.960 — fix(hir): #923 — block-export of `mysql.createPool` / native-factory const links + runs as value
 
 **Symptom.** Two ways of exporting a module-level binding produced different results, where the spec says they're interchangeable. With `mysql2/promise`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.960
+**Current Version:** 0.5.961
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.960"
+version = "0.5.961"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.960"
+version = "0.5.961"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.960"
+version = "0.5.961"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.960"
+version = "0.5.961"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.960"
+version = "0.5.961"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen-js/src/emit.rs
+++ b/crates/perry-codegen-js/src/emit.rs
@@ -2150,13 +2150,18 @@ impl JsEmitter {
 
             // --- Date ---
             Expr::DateNow => self.output.push_str("Date.now()"),
-            Expr::DateNew(val) => {
-                if let Some(v) = val {
-                    self.output.push_str("new Date(");
-                    self.emit_expr(v);
-                    self.output.push(')');
-                } else {
+            Expr::DateNew(args) => {
+                if args.is_empty() {
                     self.output.push_str("new Date()");
+                } else {
+                    self.output.push_str("new Date(");
+                    for (i, a) in args.iter().enumerate() {
+                        if i > 0 {
+                            self.output.push_str(", ");
+                        }
+                        self.emit_expr(a);
+                    }
+                    self.output.push(')');
                 }
             }
             Expr::DateGetTime(d) => { self.emit_expr(d); self.output.push_str(".getTime()"); }

--- a/crates/perry-codegen-wasm/src/emit.rs
+++ b/crates/perry-codegen-wasm/src/emit.rs
@@ -3684,8 +3684,8 @@ impl WasmModuleEmitter {
                 self.collect_strings_in_expr(set);
                 self.collect_strings_in_expr(value);
             }
-            Expr::DateNew(arg) => {
-                if let Some(a) = arg {
+            Expr::DateNew(args) => {
+                for a in args {
                     self.collect_strings_in_expr(a);
                 }
             }
@@ -7903,8 +7903,11 @@ impl<'a> FuncEmitCtx<'a> {
             }
 
             // --- Date ---
-            Expr::DateNew(arg) => {
-                if let Some(a) = arg {
+            // WASM target only handles the 0/1-arg forms. The multi-arg
+            // `new Date(year, month, ...)` form (used by dayjs) is not
+            // supported on this target; we pass the first arg only.
+            Expr::DateNew(args) => {
+                if let Some(a) = args.first() {
                     self.emit_expr(func, a);
                 } else {
                     func.instruction(&Instruction::I64Const(TAG_UNDEFINED as i64));

--- a/crates/perry-codegen/src/collectors.rs
+++ b/crates/perry-codegen/src/collectors.rs
@@ -987,7 +987,11 @@ pub(crate) fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32
             walk(message, out);
             walk(cause, out);
         }
-        Expr::DateNew(Some(arg)) => walk(arg, out),
+        Expr::DateNew(args) => {
+            for a in args {
+                walk(a, out);
+            }
+        }
         Expr::Uint8ArrayGet { array, index } => {
             walk(array, out);
             walk(index, out);
@@ -3440,7 +3444,11 @@ fn collect_localset_ids_in_expr_filtered(
             walk(message, out);
             walk(cause, out);
         }
-        Expr::DateNew(Some(arg)) => walk(arg, out),
+        Expr::DateNew(args) => {
+            for a in args {
+                walk(a, out);
+            }
+        }
         Expr::Uint8ArrayGet { array, index } => {
             walk(array, out);
             walk(index, out);

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -7345,17 +7345,34 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(blk.bitcast_i64_to_double(&result_i64))
         }
 
-        // -------- new Date() --------
-        Expr::DateNew(arg) => {
-            if let Some(ts_expr) = arg {
-                let ts = lower_expr(ctx, ts_expr)?;
+        // -------- new Date() / new Date(ts) / new Date(year, month, ...) --------
+        Expr::DateNew(args) => match args.len() {
+            0 => Ok(ctx.block().call(DOUBLE, "js_date_new", &[])),
+            1 => {
+                let ts = lower_expr(ctx, &args[0])?;
                 Ok(ctx
                     .block()
                     .call(DOUBLE, "js_date_new_from_value", &[(DOUBLE, &ts)]))
-            } else {
-                Ok(ctx.block().call(DOUBLE, "js_date_new", &[]))
             }
-        }
+            _ => {
+                // Multi-arg constructor: `new Date(year, month, day?, hour?,
+                // minute?, second?, ms?)` in local time. dayjs's parseDate
+                // takes this branch with regex-captured string args — see
+                // js_date_new_local_components for the coercion path.
+                let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+                let mut vals: Vec<String> = Vec::with_capacity(7);
+                for a in args.iter().take(7) {
+                    vals.push(lower_expr(ctx, a)?);
+                }
+                while vals.len() < 7 {
+                    vals.push(undef.clone());
+                }
+                let blk = ctx.block();
+                let call_args: Vec<(crate::types::LlvmType, &str)> =
+                    vals.iter().map(|v| (DOUBLE, v.as_str())).collect();
+                Ok(blk.call(DOUBLE, "js_date_new_local_components", &call_args))
+            }
+        },
 
         // -------- arr.find(cb) / findIndex(cb) / findLast(cb) / findLastIndex(cb) --------
         Expr::ArrayFind { array, callback } => {

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -817,6 +817,12 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE],
     );
+    // `new Date(year, month, day?, hour?, min?, sec?, ms?)` (local time).
+    module.declare_function(
+        "js_date_new_local_components",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE],
+    );
     module.declare_function("js_date_set_utc_full_year", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_date_set_utc_month", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_date_set_utc_date", DOUBLE, &[DOUBLE, DOUBLE]);

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -853,9 +853,9 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
         }
         // Date operations
         Expr::DateNow => {}
-        Expr::DateNew(timestamp) => {
-            if let Some(ts) = timestamp {
-                collect_assigned_locals_expr(ts, assigned);
+        Expr::DateNew(args) => {
+            for a in args {
+                collect_assigned_locals_expr(a, assigned);
             }
         }
         Expr::DateGetTime(date)

--- a/crates/perry-hir/src/ir.rs
+++ b/crates/perry-hir/src/ir.rs
@@ -2003,16 +2003,16 @@ pub enum Expr {
 
     // Date operations
     DateNow,                        // Date.now() -> number (timestamp in ms)
-    DateNew(Option<Box<Expr>>),     // new Date() or new Date(timestamp) -> Date object
-    DateGetTime(Box<Expr>),         // date.getTime() -> number
-    DateToISOString(Box<Expr>),     // date.toISOString() -> string
-    DateGetFullYear(Box<Expr>),     // date.getFullYear() -> number
-    DateGetMonth(Box<Expr>),        // date.getMonth() -> number (0-11)
-    DateGetDate(Box<Expr>),         // date.getDate() -> number (1-31)
-    DateGetDay(Box<Expr>),          // date.getDay() -> number (0-6, Sunday=0)
-    DateGetHours(Box<Expr>),        // date.getHours() -> number (0-23)
-    DateGetMinutes(Box<Expr>),      // date.getMinutes() -> number (0-59)
-    DateGetSeconds(Box<Expr>),      // date.getSeconds() -> number (0-59)
+    DateNew(Vec<Expr>), // new Date() / new Date(ts) / new Date(year, month, day, h?, m?, s?, ms?) -> Date object
+    DateGetTime(Box<Expr>), // date.getTime() -> number
+    DateToISOString(Box<Expr>), // date.toISOString() -> string
+    DateGetFullYear(Box<Expr>), // date.getFullYear() -> number
+    DateGetMonth(Box<Expr>), // date.getMonth() -> number (0-11)
+    DateGetDate(Box<Expr>), // date.getDate() -> number (1-31)
+    DateGetDay(Box<Expr>), // date.getDay() -> number (0-6, Sunday=0)
+    DateGetHours(Box<Expr>), // date.getHours() -> number (0-23)
+    DateGetMinutes(Box<Expr>), // date.getMinutes() -> number (0-59)
+    DateGetSeconds(Box<Expr>), // date.getSeconds() -> number (0-59)
     DateGetMilliseconds(Box<Expr>), // date.getMilliseconds() -> number (0-999)
 
     // Date static methods

--- a/crates/perry-hir/src/js_transform.rs
+++ b/crates/perry-hir/src/js_transform.rs
@@ -1060,8 +1060,10 @@ fn transform_expr(
             transform_expr(e, js_imports, extern_func_to_js, local_name_to_js, tracker);
         }
         // Date methods
-        Expr::DateNew(Some(e)) => {
-            transform_expr(e, js_imports, extern_func_to_js, local_name_to_js, tracker);
+        Expr::DateNew(args) => {
+            for a in args {
+                transform_expr(a, js_imports, extern_func_to_js, local_name_to_js, tracker);
+            }
         }
         Expr::DateGetTime(e) | Expr::DateToISOString(e) | Expr::DateGetFullYear(e) |
         Expr::DateGetMonth(e) | Expr::DateGetDate(e) | Expr::DateGetDay(e) | Expr::DateGetHours(e) |
@@ -1198,7 +1200,7 @@ fn transform_expr(
         Expr::FuncRef(_) | Expr::ClassRef(_) | Expr::EnumMember { .. } |
         Expr::RegExp { .. } | Expr::NativeModuleRef(_) | Expr::StaticFieldGet { .. } |
         Expr::EnvGet(_) | Expr::ProcessUptime | Expr::ProcessMemoryUsage | Expr::ProcessEnv | Expr::MathRandom | Expr::CryptoRandomUUID | Expr::DateNow |
-        Expr::DateNew(None) | Expr::MapNew | Expr::SetNew | Expr::Update { .. } |
+        Expr::MapNew | Expr::SetNew | Expr::Update { .. } |
         Expr::ArrayPop(_) | Expr::ArrayShift(_) |
         // OS module expressions
         Expr::OsPlatform | Expr::OsArch | Expr::OsHostname | Expr::OsType | Expr::OsRelease |

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -554,10 +554,31 @@ fn compute_closure_captures(
         outer_locals.iter().map(|(_, id)| *id).collect();
     let param_ids: std::collections::HashSet<LocalId> = params.iter().map(|p| p.id).collect();
 
-    // Find unique captures: refs that are in outer_locals but not params.
+    // dayjs (issue: format() returned `292278994-08`): local IDs are
+    // scope-local — each function's `fresh_local()` counter starts at 0,
+    // so an inner closure can legitimately reuse an outer-scope id (e.g.
+    // dayjs's minified `parseDate` declares `var i = r[2]-1||0` with id
+    // 10, while the surrounding IIFE has a module-level `var i = "second"`
+    // also at id 10). Without filtering by *inner-declared* ids, the
+    // capture detector misidentifies the inner `i` as a free reference
+    // to the outer constant and the closure ends up reading "second"
+    // where it expected a month. Strip locally-declared ids from the
+    // capture set.
+    let inner_decls: std::collections::HashSet<LocalId> = {
+        let mut s = std::collections::HashSet::new();
+        for stmt in body {
+            crate::lower_decl::collect_let_decls_in_stmt(stmt, &mut s);
+        }
+        s
+    };
+
+    // Find unique captures: refs that are in outer_locals but not params
+    // and not locally re-declared by an inner `let`/`var`.
     let mut captures: Vec<LocalId> = all_refs
         .into_iter()
-        .filter(|id| outer_local_ids.contains(id) && !param_ids.contains(id))
+        .filter(|id| {
+            outer_local_ids.contains(id) && !param_ids.contains(id) && !inner_decls.contains(id)
+        })
         .collect();
     captures.sort();
     captures.dedup();
@@ -571,7 +592,10 @@ fn compute_closure_captures(
     let assigned_set: std::collections::HashSet<LocalId> = all_assigned.into_iter().collect();
     let mutable_captures: Vec<LocalId> = captures
         .iter()
-        .filter(|id| assigned_set.contains(id) || ctx.var_hoisted_ids.contains(id))
+        .filter(|id| {
+            (assigned_set.contains(id) || ctx.var_hoisted_ids.contains(id))
+                && !inner_decls.contains(id)
+        })
         .copied()
         .collect();
 

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -228,7 +228,13 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 }
             }
             if class_name == "Date" {
-                // new Date() or new Date(timestamp)
+                // new Date() / new Date(ts) / new Date(year, month, day, h?, m?, s?, ms?).
+                // The multi-arg form is what dayjs's parseDate uses
+                // (`new Date(d[1], m, d[3] || 1, ...)`) — without it the
+                // codegen used to silently discard all but the first
+                // argument, so a string year "2024" got parsed as
+                // 2024 ms-since-epoch (issue: dayjs format prints
+                // "292278994-08" because $d.getTime() ends up garbage).
                 let args = new_expr
                     .args
                     .as_ref()
@@ -239,13 +245,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     })
                     .transpose()?
                     .unwrap_or_default();
-                if args.is_empty() {
-                    return Ok(Expr::DateNew(None));
-                } else {
-                    return Ok(Expr::DateNew(Some(Box::new(
-                        args.into_iter().next().unwrap(),
-                    ))));
-                }
+                return Ok(Expr::DateNew(args));
             }
             if class_name == "RegExp" {
                 // new RegExp(pattern[, flags]) — for string-literal args,

--- a/crates/perry-hir/src/lower_decl.rs
+++ b/crates/perry-hir/src/lower_decl.rs
@@ -27,6 +27,80 @@ use crate::lower_types::*;
 /// standard `inst.exports.<method>(...)` syntactic match in
 /// `lower/expr_call.rs` doesn't fire on unrelated `obj.exports.method()`
 /// calls (notably CJS aggregator output). Issue #76.
+/// Collect local IDs declared anywhere inside this statement tree (Let
+/// statements, for-init Lets, catch-clause variables, etc.) — but do NOT
+/// recurse into nested closures, since those introduce their own scope.
+///
+/// Used by the closure capture detector to filter out ids that are
+/// shadowed by inner declarations. See the dayjs-#920 comment in the
+/// closure-lowering site for context.
+pub(crate) fn collect_let_decls_in_stmt(stmt: &Stmt, out: &mut std::collections::HashSet<LocalId>) {
+    match stmt {
+        Stmt::Let { id, .. } => {
+            out.insert(*id);
+        }
+        Stmt::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            for s in then_branch {
+                collect_let_decls_in_stmt(s, out);
+            }
+            if let Some(else_stmts) = else_branch {
+                for s in else_stmts {
+                    collect_let_decls_in_stmt(s, out);
+                }
+            }
+        }
+        Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
+            for s in body {
+                collect_let_decls_in_stmt(s, out);
+            }
+        }
+        Stmt::Labeled { body, .. } => collect_let_decls_in_stmt(body, out),
+        Stmt::For { init, body, .. } => {
+            if let Some(init_stmt) = init {
+                collect_let_decls_in_stmt(init_stmt, out);
+            }
+            for s in body {
+                collect_let_decls_in_stmt(s, out);
+            }
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            for s in body {
+                collect_let_decls_in_stmt(s, out);
+            }
+            if let Some(catch_clause) = catch {
+                if let Some((id, _)) = catch_clause.param {
+                    out.insert(id);
+                }
+                for s in &catch_clause.body {
+                    collect_let_decls_in_stmt(s, out);
+                }
+            }
+            if let Some(finally_stmts) = finally {
+                for s in finally_stmts {
+                    collect_let_decls_in_stmt(s, out);
+                }
+            }
+        }
+        Stmt::Switch { cases, .. } => {
+            for case in cases {
+                for s in &case.body {
+                    collect_let_decls_in_stmt(s, out);
+                }
+            }
+        }
+        // Other forms don't introduce new bindings or only have expression payloads.
+        _ => {}
+    }
+}
+
 pub(crate) fn init_is_webassembly_instantiate(expr: &ast::Expr) -> bool {
     let call = match expr {
         ast::Expr::Call(c) => c,
@@ -4137,9 +4211,27 @@ pub(crate) fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Re
                 let param_ids: std::collections::HashSet<LocalId> =
                     params.iter().map(|p| p.id).collect();
 
+                // dayjs (issue: format() returned `292278994-08`): local
+                // IDs are scope-local — see expr_function.rs
+                // compute_closure_captures for the long explanation.
+                // Strip locally-declared ids from the capture set so an
+                // inner `var i = ...` doesn't collide with a same-id
+                // outer constant.
+                let inner_decls: std::collections::HashSet<LocalId> = {
+                    let mut s = std::collections::HashSet::new();
+                    for stmt in &body {
+                        collect_let_decls_in_stmt(stmt, &mut s);
+                    }
+                    s
+                };
+
                 let mut captures: Vec<LocalId> = all_refs
                     .into_iter()
-                    .filter(|id| outer_local_ids.contains(id) && !param_ids.contains(id))
+                    .filter(|id| {
+                        outer_local_ids.contains(id)
+                            && !param_ids.contains(id)
+                            && !inner_decls.contains(id)
+                    })
                     .collect();
                 captures.sort();
                 captures.dedup();

--- a/crates/perry-hir/src/monomorph.rs
+++ b/crates/perry-hir/src/monomorph.rs
@@ -1529,10 +1529,10 @@ fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>) -> Expr {
 
         // Date operations
         Expr::DateNow => Expr::DateNow,
-        Expr::DateNew(timestamp) => Expr::DateNew(
-            timestamp
-                .as_ref()
-                .map(|ts| Box::new(substitute_expr(ts, substitutions))),
+        Expr::DateNew(args) => Expr::DateNew(
+            args.iter()
+                .map(|a| substitute_expr(a, substitutions))
+                .collect(),
         ),
         Expr::DateGetTime(date) => {
             Expr::DateGetTime(Box::new(substitute_expr(date, substitutions)))
@@ -2542,9 +2542,9 @@ fn collect_instantiations_in_expr(
         Expr::CryptoRandomUUID => {}
         // Date operations
         Expr::DateNow => {}
-        Expr::DateNew(timestamp) => {
-            if let Some(ts) = timestamp {
-                collect_instantiations_in_expr(ts, ctx, module, idx);
+        Expr::DateNew(args) => {
+            for a in args {
+                collect_instantiations_in_expr(a, ctx, module, idx);
             }
         }
         Expr::DateGetTime(date)
@@ -3065,9 +3065,9 @@ fn update_call_sites_in_expr(
         Expr::CryptoRandomUUID => {}
         // Date operations
         Expr::DateNow => {}
-        Expr::DateNew(timestamp) => {
-            if let Some(ts) = timestamp {
-                update_call_sites_in_expr(ts, ctx, lookup);
+        Expr::DateNew(args) => {
+            for a in args {
+                update_call_sites_in_expr(a, ctx, lookup);
             }
         }
         Expr::DateGetTime(date)

--- a/crates/perry-hir/src/stable_hash.rs
+++ b/crates/perry-hir/src/stable_hash.rs
@@ -2804,9 +2804,9 @@ impl SH for Expr {
                 es.hash(h);
             }
             Expr::DateNow => tag(h, 310),
-            Expr::DateNew(e) => {
+            Expr::DateNew(es) => {
                 tag(h, 311);
-                e.hash(h);
+                es.hash(h);
             }
             Expr::DateGetTime(e) => {
                 tag(h, 312);

--- a/crates/perry-hir/src/walker.rs
+++ b/crates/perry-hir/src/walker.rs
@@ -679,9 +679,9 @@ where
         }
 
         // ─── Date constructors / setters ─────────────────────────────────
-        Expr::DateNew(opt) => {
-            if let Some(v) = opt {
-                f(v);
+        Expr::DateNew(args) => {
+            for a in args {
+                f(a);
             }
         }
         Expr::DateSetUtcFullYear { date, value }
@@ -1955,9 +1955,9 @@ where
                 f(v);
             }
         }
-        Expr::DateNew(opt) => {
-            if let Some(v) = opt {
-                f(v);
+        Expr::DateNew(args) => {
+            for a in args {
+                f(a);
             }
         }
         Expr::DateSetUtcFullYear { date, value }

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -536,6 +536,112 @@ pub extern "C" fn js_date_utc(
     (secs * 1000 + ms) as f64
 }
 
+/// `new Date(year, month, day?, hour?, minute?, second?, ms?)` — local time.
+///
+/// JS semantics: month is 0-indexed, defaults are day=1, hour/min/sec/ms=0,
+/// year < 100 is rebased to 1900+year. Arguments arrive as NaN-boxed f64
+/// values — strings (which dayjs's parseDate uses, capturing regex groups
+/// `r[1] = "2024"` etc.) need to be coerced via the string→number path so
+/// that the `(year, month, ...)` form is taken instead of falling back to
+/// the single-arg "timestamp" form. Without this, dayjs's `format()` ends
+/// up reading garbage out of a `getTime()` like `1.9e+214` and reports the
+/// year as `292278994`.
+///
+/// Returns a millisecond timestamp; the caller registers it in the
+/// DATE_REGISTRY so future `instanceof Date` checks succeed.
+#[no_mangle]
+pub extern "C" fn js_date_new_local_components(
+    year: f64,
+    month: f64,
+    day: f64,
+    hour: f64,
+    minute: f64,
+    second: f64,
+    millisecond: f64,
+) -> f64 {
+    fn coerce(v: f64, default: f64) -> f64 {
+        let bits = v.to_bits();
+        let tag = (bits >> 48) & 0xFFFF;
+        if tag == 0x7FFF {
+            // NaN-boxed string — parse via the same path Number(str) uses.
+            let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::StringHeader;
+            if ptr.is_null() || (ptr as usize) < 0x1000 {
+                return f64::NAN;
+            }
+            unsafe {
+                let len = (*ptr).byte_len as usize;
+                let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                let bytes = std::slice::from_raw_parts(data, len);
+                match std::str::from_utf8(bytes) {
+                    Ok(s) => {
+                        let s = s.trim();
+                        if s.is_empty() {
+                            default
+                        } else {
+                            s.parse::<f64>().unwrap_or(f64::NAN)
+                        }
+                    }
+                    Err(_) => f64::NAN,
+                }
+            }
+        } else if tag == 0x7FFC && (bits & 0xFF) == 0x01 {
+            // undefined — for required args this is NaN, for optional ones default
+            default
+        } else {
+            v
+        }
+    }
+    let y = coerce(year, f64::NAN);
+    let m = coerce(month, f64::NAN);
+    let d = coerce(day, 1.0);
+    let h = coerce(hour, 0.0);
+    let mi = coerce(minute, 0.0);
+    let s = coerce(second, 0.0);
+    let ms = coerce(millisecond, 0.0);
+    if y.is_nan()
+        || m.is_nan()
+        || d.is_nan()
+        || h.is_nan()
+        || mi.is_nan()
+        || s.is_nan()
+        || ms.is_nan()
+    {
+        return f64::NAN;
+    }
+    let mut year_i = y as i32;
+    // ECMA-262: if 0 <= year < 100, year = 1900 + year.
+    if (0..100).contains(&year_i) {
+        year_i += 1900;
+    }
+    let month_i = m as i32;
+    let day_u = d as u32;
+    let hour_u = h as u32;
+    let minute_u = mi as u32;
+    let second_u = s as u32;
+    let ms_i = ms as i64;
+    // JS month is 0-based; components_to_timestamp wants 1-based. Months
+    // outside 1..=12 normalize (e.g. month=12 → next year January) via
+    // year/month rollover, mirroring the way JS resolves out-of-range
+    // components.
+    let total_months = year_i as i64 * 12 + month_i as i64;
+    let rolled_year = total_months.div_euclid(12) as i32;
+    let rolled_month = (total_months.rem_euclid(12) + 1) as u32;
+    let local_secs =
+        components_to_timestamp(rolled_year, rolled_month, day_u, hour_u, minute_u, second_u);
+    // Reinterpret the local-clock components as UTC by subtracting the
+    // local tz offset at that instant. We find the offset by asking
+    // localtime_r for the local components of the bare `local_secs`
+    // (treated as a UTC epoch); the resulting tz_offset is the delta.
+    let (_, _, _, _, _, _, tz_offset) = timestamp_to_local_components(local_secs);
+    let utc_secs = local_secs - tz_offset;
+    let result = (utc_secs * 1000 + ms_i) as f64;
+    let result = date_or_invalid(result);
+    if !result.is_nan() {
+        register_date_bits(result.to_bits());
+    }
+    result
+}
+
 // --- UTC getters: same impl as the regular getters since we store UTC internally ---
 
 #[no_mangle]

--- a/test-files/test_issue_dayjs_year_overflow.ts
+++ b/test-files/test_issue_dayjs_year_overflow.ts
@@ -1,0 +1,59 @@
+// Regression test: dayjs.format("YYYY-MM") returned "292278994-08" instead
+// of "2024-01" because:
+//   1. `new Date(year, month, day, ...)` (multi-arg form) silently dropped
+//      everything past the first arg, so dayjs's parseDate ended up calling
+//      `new Date(year_str)` which parsed "2024" as 2024 ms-since-epoch.
+//   2. Inside dayjs's minified IIFE the local `var i = r[2]-1||0` shares the
+//      same scope-local LocalId (10) as the outer module-level
+//      `var i = "second"`. The closure-capture detector picked up the
+//      outer constant, so even with the multi-arg form fixed, the call
+//      received "second"/"minute" strings as the month/ms args, which
+//      coerce to NaN → Invalid Date.
+//
+// Both bugs are exercised here: a multi-arg `new Date(...)` whose inner
+// var-decl names collide with outer-scope variables.
+(function () {
+  var i = "outerI";
+  var s = "outerS";
+  function parse(date: string): Date {
+    var r = date.match(
+      /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[Tt\s]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/,
+    );
+    if (r) {
+      var i = ((r[2] as any) - 1) || 0;
+      var s = (r[7] || "0").substring(0, 3);
+      return new Date(
+        r[1] as any,
+        i,
+        r[3] || 1,
+        r[4] || 0,
+        r[5] || 0,
+        r[6] || 0,
+        s,
+      );
+    }
+    return new Date(NaN);
+  }
+
+  const d = parse("2024-01-02");
+  console.log("year:", d.getFullYear());
+  console.log("month:", d.getMonth());
+  console.log("date:", d.getDate());
+})();
+
+// Also exercise the multi-arg form with plain numeric args to confirm we
+// didn't regress the common path.
+{
+  const d = new Date(2024, 0, 2);
+  console.log("plain.year:", d.getFullYear());
+  console.log("plain.month:", d.getMonth());
+  console.log("plain.date:", d.getDate());
+}
+
+// And the 7-arg form with milliseconds.
+{
+  const d = new Date(2024, 5, 15, 12, 30, 45, 500);
+  console.log("seven.year:", d.getFullYear());
+  console.log("seven.month:", d.getMonth());
+  console.log("seven.ms:", d.getMilliseconds());
+}


### PR DESCRIPTION
## Summary

- `Expr::DateNew` only carried `Option<Box<Expr>>` — the multi-arg `new Date(year, month, day, ...)` form was silently collapsed to `new Date(year_str)`, breaking dayjs's `parseDate` which emits `new Date(r[1], i, r[3]||1, r[4]||0, r[5]||0, r[6]||0, s)`.
- After fixing the lowering, closure-capture detection was still picking up outer-scope constants whose `LocalId` happened to collide with inner-declared variables (dayjs's minified bundle has `var i = "second"` at module scope and `var i = r[2]-1||0` inside `parseDate`, both id `10`). The capture detector now excludes ids redeclared by an inner `let`/`var`/`function`.
- Combined fix turns `dayjs("2024-01-02").format("YYYY-MM")` from `292278994-08` into `2024-01`, matching Node byte-for-byte.

## Test plan

- [x] `test-files/test_issue_dayjs_year_overflow.ts` — new regression: parseDate clone with inner-`var i`/`var s` shadowing outer `i = "outerI"` / `s = "outerS"`, plus plain 3-arg and 7-arg numeric `new Date(...)`. Matches `node --experimental-strip-types` byte-for-byte.
- [x] dayjs smoke (`PERRY_ALLOW_UNIMPLEMENTED=1 perry main.ts -o out && ./out`): `2024-01` (was `292278994-08`).
- [x] `cargo fmt` + `cargo build --release` clean.
- [x] Gap suite: 34/36 unchanged from pre-fix baseline. The two pre-existing DIFFs (`test_gap_class_advanced` static-block boolean→0 + `test_gap_console_methods` timer skew) reproduce on a clean checkout of the pre-PR HEAD too.