### PR TITLE
fix(stdlib): #921 — await fetch(...) silently exited before resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.962 — fix(stdlib): #921 — `await fetch(...)` silently exited before resolution
+
+**Symptom.** A binary that `await`s any `perry-stdlib::common::async_bridge::spawn(...)`-backed binding (`fetch`, `ioredis`, `zlib`, `ws`, `net`, `bcrypt`, `http`) exits silently with code 0 between the spawn and the eventual `queue_promise_resolution`. The awaiter's Promise is never settled. From the issue body:
+
+```
+[bg-refresh] Refreshing user 2/10: 7ba959e7-...
+[bg-refresh] Starting refresh for user 7ba959e7-...
+<— process exits here, no error from any catch block —>
+Server listening on http://0.0.0.0:3004
+```
+
+Production service `gscmaster-api` (Fastify + Perry) crashed every 30 minutes for 7 days (330 PM2 restarts). The cron called `refreshAllUsers()` which `await`ed `fetch(googleOAuthURL)` for one user whose `refresh_token` had been revoked (401 `invalid_grant`). The 401 path's `throw new Error("refresh failed: " + r.status + " " + txt)` should have surfaced through the outer `try/catch` around the `await`, but instead the process died clean. PM2 restarted, the cron re-fired 30 min later, same user, same crash. The first stable repro:
+
+```ts
+async function main() {
+  const r = await fetch("https://httpbin.org/status/401");
+  console.log("status:", r.status);  // never prints — process exits silently
+}
+main();
+```
+
+**Root cause.** Two-step race between codegen's event-loop bootstrap and the tokio fetch worker:
+
+1. Entry-module init calls `main()` (top-level fire-and-forget).
+2. `main()` hits `await fetch(...)` — `js_fetch_get` allocates a fresh `Promise`, `async_bridge::spawn(future)` schedules the network roundtrip on a tokio worker, and `js_fetch_get` returns the Promise pointer.
+3. Codegen's async lowering yields control back to the entry-module init from the current step.
+4. The entry-module init finishes (the top-level call site was just `main();` — no `await`), so codegen drops into the event-loop bootstrap.
+5. The event-loop's `js_stdlib_has_active_handles()` check (`crates/perry-codegen/src/codegen.rs:4879`) reads `PENDING_RESOLUTIONS` (empty), `PENDING_DEFERRED` (empty), `EXT_BLOCKING_TASKS_INFLIGHT` (0 — `async_bridge::spawn` never bumped it), WS / NET / HTTP / readline (none). All zero → loop exits clean.
+6. The tokio worker eventually finishes the fetch and calls `queue_promise_resolution(...)`, but no one is listening anymore — the process has already exited.
+
+`perry_ffi_spawn_blocking` (used by external `perry-ext-*` wrapper crates) has bumped `EXT_BLOCKING_TASKS_INFLIGHT` for the closure lifetime since #591, exactly to plug this race. `async_bridge::spawn` / `spawn_for_promise` / `spawn_for_promise_deferred` — the in-tree wrappers used by `fetch.rs`, `ioredis.rs`, `bcrypt.rs`, `zlib.rs`, `ws.rs`, `net/mod.rs`, `http.rs` — just hadn't been wired through the same gate.
+
+**Fix.** `crates/perry-stdlib/src/common/async_bridge.rs` — wrap the spawned future in an `async move { future.await; EXT_BLOCKING_TASKS_INFLIGHT.fetch_sub(1, AcqRel); js_notify_main_thread(); }` shim and `fetch_add(1, AcqRel)` synchronously before `RUNTIME.spawn`. Applies to all three helpers (`spawn`, `spawn_for_promise`, `spawn_for_promise_deferred`). The `js_notify_main_thread()` at the tail covers the niche case where the future resolves without going through `queue_promise_resolution` — flipping the active-handle gate so the event loop re-evaluates.
+
+This makes the event-loop active-handle check pessimistically wait for the future to finish (or to queue its resolution and decrement INFLIGHT). Same mechanism that already worked for external wrapper crates — just unified across both paths.
+
+**Validation.**
+
+- New test `test-files/test_issue_921_throw_across_await.ts` exercises `await fetch(...)` against `httpbin.org/status/401` inside an async function whose caller has `try/catch` around the await + a `throw new Error("refresh failed: " + r.status)` across the await boundary. Pre-fix the process exited silently with no `result:` line; post-fix it prints `result: caught:refresh failed: 401`.
+- Spot-checked existing async paths still pass: `test_gap_async_advanced.ts`, `test_gap_closures.ts`, `test_edge_promises.ts`, `test_parity_argon2.ts` (covers `spawn_for_promise`).
+
 ## v0.5.961 — fix(codegen+hir): dayjs `format("YYYY-MM")` returned `292278994-08` instead of `2024-01`
 
 **Symptom.** `dayjs("2024-01-02").format("YYYY-MM")` printed `292278994-08` under Perry vs. `2024-01` under Node. dayjs technically passed the smoke (no exception), but every formatted year/month was garbage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.961
+**Current Version:** 0.5.962
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.961"
+version = "0.5.962"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.961"
+version = "0.5.962"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.961"
+version = "0.5.962"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.961"
+version = "0.5.962"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.961"
+version = "0.5.962"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-stdlib/src/common/async_bridge.rs
+++ b/crates/perry-stdlib/src/common/async_bridge.rs
@@ -154,13 +154,56 @@ pub fn runtime() -> &'static Runtime {
     &RUNTIME
 }
 
-/// Spawn an async task on the global runtime
+/// Spawn an async task on the global runtime.
+///
+/// Issue #921: bump `EXT_BLOCKING_TASKS_INFLIGHT` for the lifetime of
+/// the future so `js_stdlib_has_active_handles()` keeps the codegen-
+/// emitted event loop alive while the task is running.
+///
+/// Without the bump, the race window is:
+///
+/// 1. `main()` is async, calls `await fetch(...)` (or any other
+///    `spawn(...)`-backed binding) — `js_fetch_*` returns a fresh
+///    Promise and `spawn(future)` schedules the network roundtrip
+///    on a tokio worker.
+/// 2. Codegen's async lowering returns from the current step,
+///    yielding control back to the entry-module init.
+/// 3. The entry-module init finishes (top-level `main()` was
+///    fire-and-forget), so codegen drops into its event-loop
+///    bootstrap.
+/// 4. The event loop's `js_stdlib_has_active_handles()` check sees
+///    `PENDING_RESOLUTIONS` empty, no WS / NET / HTTP / readline,
+///    no `EXT_BLOCKING_TASKS_INFLIGHT` increment from `spawn(...)`,
+///    so it returns 0.
+/// 5. The loop exits cleanly (exit code 0). The tokio worker
+///    eventually queues its resolution, but no one is listening
+///    anymore.
+///
+/// User-visible symptom: `await fetch(...)` silently exits the
+/// process with no JS error and no stderr from the network
+/// callback. Production hosts (PM2, systemd) interpret the clean
+/// exit as a crash and restart the binary.
+///
+/// Bumping INFLIGHT around the spawned future fixes this by making
+/// the event-loop active-handle check pessimistically wait for the
+/// future to finish (or queue its resolution and decrement INFLIGHT).
+/// Same mechanism `perry_ffi_spawn_blocking` already uses for
+/// external wrapper crates (#591); fetch / ioredis / zlib / etc.
+/// just hadn't been wired through it yet.
 pub fn spawn<F>(future: F)
 where
     F: Future<Output = ()> + Send + 'static,
 {
     ensure_pump_registered();
-    RUNTIME.spawn(future);
+    EXT_BLOCKING_TASKS_INFLIGHT.fetch_add(1, Ordering::AcqRel);
+    RUNTIME.spawn(async move {
+        future.await;
+        EXT_BLOCKING_TASKS_INFLIGHT.fetch_sub(1, Ordering::AcqRel);
+        // Notify in case the future resolved without going through
+        // `queue_promise_resolution` — flip the active-handle gate
+        // so the loop re-evaluates.
+        perry_runtime::event_pump::js_notify_main_thread();
+    });
 }
 
 /// Block on an async task (use sparingly, mainly for initialization)
@@ -543,6 +586,11 @@ where
     // See `pin_promise_for_native_resolution` for the full rationale.
     pin_promise_for_native_resolution(ptr);
 
+    // Issue #921: same race-window mitigation as the plain
+    // `spawn()` above — bump INFLIGHT for the lifetime of the
+    // future so the event loop's `js_stdlib_has_active_handles`
+    // check stays truthy until the resolution is queued.
+    EXT_BLOCKING_TASKS_INFLIGHT.fetch_add(1, Ordering::AcqRel);
     RUNTIME.spawn(async move {
         match future.await {
             Ok(result_bits) => {
@@ -560,6 +608,8 @@ where
                 });
             }
         }
+        EXT_BLOCKING_TASKS_INFLIGHT.fetch_sub(1, Ordering::AcqRel);
+        perry_runtime::event_pump::js_notify_main_thread();
     });
 }
 
@@ -592,6 +642,9 @@ where
     // Issue #859: pin the promise BEFORE crossing the tokio boundary.
     pin_promise_for_native_resolution(ptr);
 
+    // Issue #921: same race-window mitigation as `spawn_for_promise`
+    // above — bump INFLIGHT for the lifetime of the future.
+    EXT_BLOCKING_TASKS_INFLIGHT.fetch_add(1, Ordering::AcqRel);
     RUNTIME.spawn(async move {
         match future.await {
             Ok(data) => {
@@ -610,5 +663,7 @@ where
                 });
             }
         }
+        EXT_BLOCKING_TASKS_INFLIGHT.fetch_sub(1, Ordering::AcqRel);
+        perry_runtime::event_pump::js_notify_main_thread();
     });
 }

--- a/test-files/test_issue_921_throw_across_await.ts
+++ b/test-files/test_issue_921_throw_across_await.ts
@@ -1,0 +1,39 @@
+// Issue #921: throw new Error("...") inside an async function silently
+// exited the process instead of surfacing the JS error when the awaited
+// value came from a perry-stdlib `spawn()`-backed binding such as
+// `fetch()`.
+//
+// Root cause: perry-stdlib's `spawn()` helper (used by fetch, ioredis,
+// zlib, …) scheduled the tokio task without bumping
+// EXT_BLOCKING_TASKS_INFLIGHT. The codegen-emitted event loop sees no
+// active stdlib handles between the spawn and the eventual
+// `queue_promise_resolution` and exits cleanly with code 0 — leaving
+// the awaiter pending forever and PM2 / systemd interpreting the
+// exit-0 as a crash.
+//
+// Pre-fix output: process exits silently with no "result:" line.
+// Post-fix output: "result: caught:refresh failed: 401"
+
+async function refreshToken(): Promise<string> {
+  const r = await fetch("https://httpbin.org/status/401");
+  if (!r.ok) {
+    throw new Error("refresh failed: " + r.status);
+  }
+  return await r.text();
+}
+
+async function getAll(): Promise<string> {
+  try {
+    const tokens = await refreshToken();
+    return "tokens:" + tokens;
+  } catch (e: any) {
+    return "caught:" + e.message;
+  }
+}
+
+async function main(): Promise<void> {
+  const result = await getAll();
+  console.log("result:", result);
+}
+
+main();


### PR DESCRIPTION
Fixes #921.

## Summary

- `perry-stdlib`'s `spawn()` / `spawn_for_promise[_deferred]` helpers (used by `fetch`, `ioredis`, `bcrypt`, `zlib`, `ws`, `net/mod`, `http`) scheduled their tokio tasks without bumping `EXT_BLOCKING_TASKS_INFLIGHT`. Between the spawn and the eventual `queue_promise_resolution`, codegen's event loop saw zero active stdlib handles and exited cleanly with code 0 — leaving the awaiter pending forever.
- User-visible symptom: `await fetch(...)` inside an async function silently exited the whole process. PM2 / systemd read the exit-0 as a crash and restarted. Production service hit this on every cron call to a 401-returning OAuth endpoint and crashed every 30 min for 7 days.
- Fix: wrap each helper's spawned future in a shim that `fetch_add(1)` synchronously before `RUNTIME.spawn` and `fetch_sub(1) + js_notify_main_thread()` after the future completes. Same mechanism `perry_ffi_spawn_blocking` already used for external wrapper crates since #591 — just unified across the in-tree helpers too.

## Test plan

- [x] New `test-files/test_issue_921_throw_across_await.ts` — `await fetch("https://httpbin.org/status/401")` inside `refreshToken()`, outer `getAll()` has try/catch around the await, throw across the await boundary. Pre-fix: silent exit code 0 with no `result:` line. Post-fix: `result: caught:refresh failed: 401`.
- [x] Spot-checked existing async paths still pass: `test_gap_async_advanced.ts`, `test_gap_closures.ts`, `test_edge_promises.ts`, `test_parity_argon2.ts` (covers `spawn_for_promise`).
- [x] `cargo fmt --all -- --check` clean, `cargo build --release -p perry-runtime -p perry-stdlib -p perry` clean.