### PR TITLE
fix(runtime): #922 — circuit breaker for runaway value-not-a-function loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.963 — fix(runtime): #922 — circuit-breaker for runaway `value is not a function` / `[WARN_NULL_PTR]` loops in async-step driver
+
+**Symptom.** `gscmaster-api` (Fastify + mysql2 + fetch, ~5k LoC) compiled cleanly with Perry HEAD but every `/api/*` request entered a tight loop of:
+
+```
+[WARN_NULL_PTR] js_object_set_field: null POINTER_TAG at obj=0x200002114a0 field_index=0 class_id=0 -- replacing with undefined
+TypeError: value is not a function
+    at <anonymous>
+[WARN_NULL_PTR] js_object_set_field: null POINTER_TAG at obj=0x200002114a0 field_index=0 class_id=0 -- replacing with undefined
+TypeError: value is not a function
+    at <anonymous>
+... (5.7M+ identical lines, PM2 declared the process `errored`)
+```
+
+`GET /health` returned 200 fine; every other route looped. Adding `console.log` at the top of the handler showed nothing -- the crash was before any user code ran. The `at <anonymous>` had no symbol so the user had no path forward from the stderr stream. Same root mechanism as #921 ("async fn with `throw new Error` crashes the process when caller has try/catch around the await"): production gscmaster-api crashed every 30 minutes for 7 days (330 PM2 restarts) on the same shape, with stderr full of `[PERRY WARN] js_box_get: invalid box pointer` and `[WARN_NULL_PTR]` but no thrown error reaching the catch block.
+
+**Root cause (two co-occurring bugs).**
+
+1. **`js_object_set_field` printed unbounded `eprintln!`s.** Each call with a null POINTER_TAG (`(value.bits() >> 48) == 0x7FFD && low_48 == 0`) emitted one line and let the caller continue with an undefined slot. The downstream call site then read that slot, dispatched as a function, and `throw_not_callable` re-raised. Codegen for the user's specific pattern (async fastify route handler with `throw` across `await` inside `try`/`catch`) re-entered the same write+throw sequence forever -- no bound, no abort. With ~50 bytes per stderr line and 5.7M iterations, that's ~280MB of stderr per request before PM2 noticed. #924 gated the per-call log behind `PERRY_DEBUG=1` (which silences the noise) but did NOT bound the loop -- the runaway behavior of the downstream call still wedges the process.
+
+2. **`ASYNC_STEP_GUARD` from #712 only counted same-`step_closure` errors.** The production loop alternates between two step closures (outer route-handler async-step + inner middleware async-step), each rethrowing the same TypeError. With the same-closure check at `promise.rs:1334`, the counter reset every other dispatch (`prev.last_closure == step_closure as usize` failed every iteration) and the 10K bound never tripped. The original `5.7M observed in #712` comment was prescient -- the guard's narrow predicate let exactly this category of loop slip through.
+
+**Fix.** Three layered circuit breakers in the runtime:
+
+- **`crates/perry-runtime/src/object.rs::record_warn_null_ptr`** -- per-thread state tracking total + consecutive-same-site null POINTER_TAG writes. Per-call log gated behind `PERRY_DEBUG=1` (preserves #924's quieter happy-path stderr) AND rate-limited to `WARN_NULL_PTR_LOG_LIMIT = 64` occurrences even under PERRY_DEBUG, with a one-time `further entries suppressed` notice. Above `WARN_NULL_PTR_ABORT_LIMIT = 100_000` consecutive same-site writes the process aborts unconditionally with a single diagnostic line naming `obj` / `field_index` / `class_id` and pointing at the result-tag workaround.
+- **`crates/perry-runtime/src/closure.rs::throw_not_callable`** -- per-thread `THROW_NOT_CALLABLE_COUNT` counter. After `THROW_NOT_CALLABLE_ABORT_LIMIT = 100_000` consecutive throws, abort with a diagnostic that names the `js_throw_type_error_not_a_function` breakpoint. New `reset_throw_not_callable_counter()` is called from `promise.rs::js_promise_run_microtasks` on every non-error `Task::AsyncStep` dispatch so legitimate cumulative throws across a long-running process don't false-positive.
+- **`crates/perry-runtime/src/promise.rs` ASYNC_STEP_GUARD** -- drop the same-closure check. Count ANY consecutive `is_error=true` dispatches; reject the chain at `ASYNC_STEP_REENTRY_BOUND = 10_000` regardless of which step closure caught the error. Legitimate throw-in-a-loop patterns (`for (x of arr) try { await fail() } catch {}`) still interleave `is_error=false` steps between throws (the for-loop's post-catch state), so their consecutive count never grows beyond 1.
+
+Together: a 100K-iteration runaway loop -- a real corruption signal -- now aborts with a single useful line in ~0.5s instead of 5.7M lines over several minutes. Operators see the diagnostic, identify the call site (or convert to the result-tag pattern per #921's workaround), and ship a fix. Legitimate throws (1-100 per request, even sustained) cost nothing -- a single thread-local counter increment in the cold-throw path.
+
+**Why circuit-breaker not surgical fix.** The user's underlying codegen pattern (fastify route handler with `throw` across `await` + `try/catch`) is a known compiler-level bug (#921 root cause is suspected `_setjmp` ABI mismatch, fixed in #856 / #914 but the surface area is large). Without the actual gscmaster-api source we cannot bisect to the specific codegen regression that started producing null POINTER_TAGs after May 10. The circuit breakers convert the silent infinite loop into an explicit crash with actionable text -- exactly what the user asked for in #921 ask #2 (`a way to dump the offending callsite -- currently the user has no path forward from at <anonymous>`). The surgical codegen fix can land separately on top.
+
+**Test plan.**
+
+- New regression test `test-files/test_issue_922_api_route_crash.ts` -- 200K-iteration sync loop calling `undefined(i)` inside `try/catch`. Exit code 134 (SIGABRT) + the `[PERRY ABORT] throw_not_callable` line on stderr, verified with `timeout 30`.
+- Existing `test_issue_express_value_not_fn.ts` (#909), `test_issue_859_module_arrow_in_async_resume.ts`, `test_issue_915_native_module_after_async_resume.ts`, `test_async*.ts`, `test_iife_*.ts` all still pass byte-for-byte.
+- `cargo test --release -p perry-runtime --lib` -- 261 passed.
+- `scripts/run_fastify_tests.sh` -- 5/5 pass (GET /hello, GET /users/:id, POST /echo status+body, 404).
+- `cargo build --release -p perry-runtime -p perry-stdlib -p perry` clean.
+
+**Files touched.** `crates/perry-runtime/src/object.rs` (record_warn_null_ptr + state + WARN_NULL_PTR_LOG_LIMIT/ABORT_LIMIT), `crates/perry-runtime/src/closure.rs` (THROW_NOT_CALLABLE_COUNT + reset_throw_not_callable_counter + abort path), `crates/perry-runtime/src/promise.rs` (ASYNC_STEP_GUARD: drop same-closure check + call reset on success), `test-files/test_issue_922_api_route_crash.ts` (new regression test).
+
+Closes #922. Refs #921 (same root cause, complementary fix), #712 (the original 5.7M-line guard this PR extends), #924 (PERRY_DEBUG gating preserved), #856 / #914 (`_setjmp` ABI suspected as the underlying codegen regression behind #921/#922).
+
 ## v0.5.962 — fix(stdlib): #921 — `await fetch(...)` silently exited before resolution
 
 **Symptom.** A binary that `await`s any `perry-stdlib::common::async_bridge::spawn(...)`-backed binding (`fetch`, `ioredis`, `zlib`, `ws`, `net`, `bcrypt`, `http`) exits silently with code 0 between the spawn and the eventual `queue_promise_resolution`. The awaiter's Promise is never settled. From the issue body:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.962
+**Current Version:** 0.5.963
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.962"
+version = "0.5.963"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.962"
+version = "0.5.963"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.962"
+version = "0.5.963"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.962"
+version = "0.5.963"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.962"
+version = "0.5.963"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/closure.rs
+++ b/crates/perry-runtime/src/closure.rs
@@ -829,10 +829,51 @@ unsafe fn dispatch_bound_method(closure: *const ClosureHeader, args: &[f64]) -> 
 /// Now we throw via the existing `js_throw_type_error_not_a_function`
 /// machinery, which routes through Perry's exception system so a
 /// surrounding `try`/`catch` catches it (per #596).
+// Issue #922 circuit breaker. Track consecutive `throw_not_callable`
+// invocations on the current thread; abort if the count crosses the
+// runaway bound. Mirrors the `record_warn_null_ptr` pattern in
+// `object.rs` — production gscmaster-api Fastify route handlers
+// (#921/#922) entered a 5.7M-iteration loop where every async-step
+// catch arm re-fired the same TypeError, and the per-step-closure
+// reentry guard at `promise.rs::ASYNC_STEP_GUARD` missed it because
+// the loop alternated between two step closures. With this fixed
+// upper bound the loop terminates in milliseconds with a single
+// useful stderr line, instead of 5.7M `TypeError: value is not a
+// function at <anonymous>` lines that drown out the diagnostic.
+const THROW_NOT_CALLABLE_ABORT_LIMIT: u64 = 100_000;
+
+thread_local! {
+    static THROW_NOT_CALLABLE_COUNT: std::cell::Cell<u64>
+        = const { std::cell::Cell::new(0) };
+}
+
 #[cold]
 #[inline(never)]
 fn throw_not_callable() -> ! {
+    let count = THROW_NOT_CALLABLE_COUNT.with(|c| {
+        let n = c.get().saturating_add(1);
+        c.set(n);
+        n
+    });
+    if count >= THROW_NOT_CALLABLE_ABORT_LIMIT {
+        eprintln!(
+            "[PERRY ABORT] throw_not_callable: detected runaway TypeError loop ({}+ consecutive 'value is not a function' throws -- issue #922 circuit breaker). Common cause: an async function throws across an await boundary inside try/catch where the catch arm re-enters the same await. Convert to a result-tag pattern (see issue #921 workaround). To find the offending callsite: recompile with --debug-symbols and run under a debugger -- set a breakpoint on js_throw_type_error_not_a_function.",
+            THROW_NOT_CALLABLE_ABORT_LIMIT
+        );
+        std::process::abort();
+    }
     crate::error::js_throw_type_error_not_a_function(std::ptr::null(), 0, b"value".as_ptr(), 5)
+}
+
+/// Reset the throw_not_callable counter — called by the async-step
+/// driver whenever a non-error `is_error=false` step dispatches, which
+/// signals progress (the catch arm advanced past the bad await). Lives
+/// here so the thread-local is private to this module.
+///
+/// This exists as a `pub fn` (not `extern "C"`) — it's an internal
+/// runtime-side reset called from `promise.rs::js_promise_run_microtasks`.
+pub(crate) fn reset_throw_not_callable_counter() {
+    THROW_NOT_CALLABLE_COUNT.with(|c| c.set(0));
 }
 
 /// Validate a closure pointer and return its func_ptr if the closure is valid.

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -2830,6 +2830,99 @@ pub extern "C" fn js_object_get_field(obj: *const ObjectHeader, field_index: u32
     }
 }
 
+// Issue #922: Rate-limit and bound the [WARN_NULL_PTR] message stream
+// + abort the process when a runaway loop is detected.
+//
+// Background: when codegen emits an `Expr::New { ... }` whose constructor
+// args include a NULL POINTER_TAG (typically the result of a cross-module
+// reference to an export that didn't link, or an async-step rejected-
+// before-resolved capture), every constructor invocation calls
+// `js_object_set_field` once per field. Each call previously emitted one
+// `eprintln!` line. The gscmaster-api production loop (#922) printed
+// 5.7M+ identical lines on a single Fastify route hit before PM2
+// declared the process dead -- actionable signal drowned in noise.
+//
+// Hard limits + circuit breaker:
+//   * The per-call [WARN_NULL_PTR] log line is gated behind PERRY_DEBUG=1
+//     (issue #924) and ALSO rate-limited to `WARN_NULL_PTR_LOG_LIMIT`
+//     (=64) per thread under PERRY_DEBUG so even debug runs don't drown
+//     in noise. After the limit a one-time `...further entries suppressed`
+//     notice fires.
+//   * `WARN_NULL_PTR_ABORT_LIMIT` (=100_000) -- if the SAME obj+
+//     field_index has been written with a null POINTER_TAG this many
+//     times consecutively, eprintln a one-line diagnostic and trigger
+//     `std::process::abort()`. This is UNCONDITIONAL (not gated by
+//     PERRY_DEBUG) because a 100K-iteration same-site loop is real
+//     corruption, not happy-path noise. The async-step reentry guard
+//     at `crates/perry-runtime/src/promise.rs::ASYNC_STEP_REENTRY_BOUND`
+//     bounds the loop at 10K iterations BEFORE this fires in the normal
+//     case; this is the catch-all for paths the async-step guard misses
+//     (e.g. sync `throw_not_callable` inside a non-async fastify hook).
+const WARN_NULL_PTR_LOG_LIMIT: u64 = 64;
+const WARN_NULL_PTR_ABORT_LIMIT: u64 = 100_000;
+
+thread_local! {
+    static WARN_NULL_PTR_STATE: std::cell::Cell<WarnNullPtrState>
+        = const { std::cell::Cell::new(WarnNullPtrState {
+            total_count: 0,
+            last_obj: 0,
+            last_field_index: u32::MAX,
+            consecutive_same_site: 0,
+        }) };
+}
+
+#[derive(Copy, Clone)]
+struct WarnNullPtrState {
+    total_count: u64,
+    last_obj: usize,
+    last_field_index: u32,
+    consecutive_same_site: u64,
+}
+
+#[cold]
+#[inline(never)]
+fn record_warn_null_ptr(obj: *mut ObjectHeader, field_index: u32, class_id: u32) {
+    let (total_count, should_abort) = WARN_NULL_PTR_STATE.with(|cell| {
+        let mut s = cell.get();
+        s.total_count = s.total_count.saturating_add(1);
+        let same_site = s.last_obj == obj as usize && s.last_field_index == field_index;
+        s.consecutive_same_site = if same_site {
+            s.consecutive_same_site.saturating_add(1)
+        } else {
+            1
+        };
+        s.last_obj = obj as usize;
+        s.last_field_index = field_index;
+        let total = s.total_count;
+        let abort = s.consecutive_same_site >= WARN_NULL_PTR_ABORT_LIMIT;
+        cell.set(s);
+        (total, abort)
+    });
+    // perry#924: the per-call log is gated behind PERRY_DEBUG=1. Even
+    // under PERRY_DEBUG we cap at WARN_NULL_PTR_LOG_LIMIT occurrences
+    // per thread (issue #922 -- the production loop produced 5.7M of
+    // these and the actionable signal got buried).
+    if total_count <= WARN_NULL_PTR_LOG_LIMIT && std::env::var_os("PERRY_DEBUG").is_some() {
+        eprintln!(
+            "[WARN_NULL_PTR] js_object_set_field: null POINTER_TAG at obj={:p} field_index={} class_id={} -- replacing with undefined",
+            obj, field_index, class_id
+        );
+        if total_count == WARN_NULL_PTR_LOG_LIMIT {
+            eprintln!(
+                "[WARN_NULL_PTR] further entries suppressed after {} occurrences -- this usually indicates an unresolved import or an uninitialized cross-module export being constructed into an object field",
+                WARN_NULL_PTR_LOG_LIMIT
+            );
+        }
+    }
+    if should_abort {
+        eprintln!(
+            "[PERRY ABORT] js_object_set_field: detected runaway null POINTER_TAG writes at obj={:p} field_index={} class_id={} ({}+ consecutive same-site writes -- issue #922 circuit breaker). Common cause: an async function throws across an await boundary inside try/catch AND the catch arm re-enters the same await, OR an unresolved import was constructed into a field. Convert to a result-tag pattern (see issue #921 workaround) or check perry --print-hir for an uninitialized capture.",
+            obj, field_index, class_id, WARN_NULL_PTR_ABORT_LIMIT
+        );
+        std::process::abort();
+    }
+}
+
 /// Set a field on an object by index
 #[no_mangle]
 pub extern "C" fn js_object_set_field(obj: *mut ObjectHeader, field_index: u32, value: JSValue) {
@@ -2867,17 +2960,15 @@ pub extern "C" fn js_object_set_field(obj: *mut ObjectHeader, field_index: u32, 
             );
             return;
         }
-        // Guard: null POINTER_TAG (0x7FFD_0000_0000_0000) is never legitimate — replace with undefined.
-        // perry#924: this triggers on the happy path (e.g. when codegen
-        // emits `undefined` as a freshly-constructed null POINTER_TAG
-        // before the receiver is fully initialized); the swap-to-undefined
-        // fixes it silently so the operator sees nothing useful. Gate the
-        // diagnostic behind `PERRY_DEBUG=1` for bisection.
+        // Guard: null POINTER_TAG (0x7FFD_0000_0000_0000) is never legitimate -- replace with undefined.
+        // The diagnostic + circuit breaker live in `record_warn_null_ptr` (issue #922).
+        // perry#924: the [WARN_NULL_PTR] log line itself is gated behind
+        // `PERRY_DEBUG=1` inside `record_warn_null_ptr`; the circuit
+        // breaker abort path is unconditional (it's a real corruption
+        // signal, not happy-path noise).
         let vbits = value.bits();
         let value = if (vbits >> 48) == 0x7FFD && (vbits & 0x0000_FFFF_FFFF_FFFF) == 0 {
-            if std::env::var_os("PERRY_DEBUG").is_some() {
-                eprintln!("[WARN_NULL_PTR] js_object_set_field: null POINTER_TAG at obj={:p} field_index={} class_id={} — replacing with undefined", obj, field_index, (*obj).class_id);
-            }
+            record_warn_null_ptr(obj, field_index, (*obj).class_id);
             JSValue::undefined()
         } else {
             value

--- a/crates/perry-runtime/src/promise.rs
+++ b/crates/perry-runtime/src/promise.rs
@@ -1325,17 +1325,29 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                     ran += 1;
                     continue;
                 }
-                // Issue #712 defensive guard. Track consecutive
-                // same-closure is_error=true dispatches; reject the
-                // chain if it crosses ASYNC_STEP_REENTRY_BOUND. See
-                // the `ASYNC_STEP_GUARD` doc comment for the rationale.
+                // Issue #712 + #921 + #922 defensive guard. Track
+                // consecutive is_error=true dispatches; reject the
+                // chain if it crosses ASYNC_STEP_REENTRY_BOUND.
+                //
+                // Originally (#712) the guard required SAME `step_closure`
+                // to count up — but the #921/#922 production loops
+                // (gscmaster-api Fastify route handlers) alternate
+                // between two async-step closures (route handler ↔
+                // middleware ↔ inner await), each one rethrowing the
+                // same TypeError. With the same-closure check, the
+                // counter resets every other dispatch and the loop
+                // never trips the guard — the user observed 5.7M
+                // identical `value is not a function` lines before PM2
+                // restarted the process.
+                //
+                // Drop the same-closure check: count ANY consecutive
+                // run of `is_error=true` dispatches. A legitimate
+                // throw-in-a-loop pattern interleaves `is_error=false`
+                // steps (the loop's post-catch state) between throws,
+                // so its consecutive count never grows beyond 1.
                 if is_error {
                     let prev = ASYNC_STEP_GUARD.with(|c| c.get());
-                    let new_count = if prev.last_closure == step_closure as usize {
-                        prev.consecutive_error_count.saturating_add(1)
-                    } else {
-                        1
-                    };
+                    let new_count = prev.consecutive_error_count.saturating_add(1);
                     if new_count > ASYNC_STEP_REENTRY_BOUND {
                         ASYNC_STEP_GUARD.with(|c| {
                             c.set(AsyncStepGuard {
@@ -1344,7 +1356,7 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                             })
                         });
                         if !next.is_null() {
-                            let msg = b"async step driver detected runaway re-entry (issue #712 guard); rejecting Promise to prevent unbounded loop";
+                            let msg = b"async step driver detected runaway re-entry (issue #712/#921/#922 guard); rejecting Promise to prevent unbounded loop. Common cause: throw across an await boundary inside try/catch; convert to a result-tag pattern.";
                             let msg_str =
                                 crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
                             let err = crate::error::js_typeerror_new(msg_str);
@@ -1368,6 +1380,13 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                             consecutive_error_count: 0,
                         })
                     });
+                    // Issue #922: a non-error step dispatched, signalling
+                    // forward progress through the user's async state
+                    // machine. Reset the throw_not_callable counter so a
+                    // legitimate later throw-in-a-loop doesn't trip the
+                    // circuit breaker just because the program threw
+                    // 100_000 cumulative times across the whole run.
+                    crate::closure::reset_throw_not_callable_counter();
                 }
                 // Stash both trap_next + current_step in a single TLS
                 // write so the hot path doesn't pay two `.with()` calls

--- a/test-files/test_issue_922_api_route_crash.ts
+++ b/test-files/test_issue_922_api_route_crash.ts
@@ -1,0 +1,86 @@
+// Regression test for issue #922 — every /api/* request crashes the
+// process with an infinite loop of:
+//
+//   [WARN_NULL_PTR] js_object_set_field: null POINTER_TAG at obj=... field_index=0 class_id=0
+//   TypeError: value is not a function
+//       at <anonymous>
+//   [WARN_NULL_PTR] js_object_set_field: null POINTER_TAG at obj=... field_index=0 class_id=0
+//   TypeError: value is not a function
+//       at <anonymous>
+//   ... (5.7M+ lines, PM2 declares the process errored)
+//
+// The user's gscmaster-api Fastify service entered this loop on every
+// /api/* hit after re-compiling under a fresh Perry. The May 10 binary
+// of the byte-identical source worked; a May 15+ rebuild looped.
+//
+// The infinite loop has two co-occurring root causes:
+//
+//   1. `js_object_set_field` saw a null POINTER_TAG (0x7FFD_0000_0000_0000)
+//      coming through as the value, emitted ONE `eprintln!` per write, and
+//      let the caller continue with an undefined slot. The downstream call
+//      site then read that slot, dispatched as a function, and
+//      `throw_not_callable` re-raised. Codegen for the user's specific
+//      pattern (async fastify route handler with `throw` across `await`
+//      inside `try`/`catch`) re-entered the same write+throw sequence
+//      forever — no bound, no abort.
+//
+//   2. The async-step driver's `ASYNC_STEP_GUARD` from #712 only counted
+//      consecutive same-`step_closure` errors; the production loop
+//      alternated between two step closures, so the counter reset every
+//      other dispatch and never tripped the 10K bound.
+//
+// Fix (this PR):
+//
+//   * `js_object_set_field` rate-limits the [WARN_NULL_PTR] log lines to
+//     64 occurrences (then prints a one-time "suppressed" notice) AND
+//     aborts the process with a clear diagnostic line after 100K
+//     consecutive same-site writes (issue #922 circuit breaker).
+//   * `throw_not_callable` aborts after 100K consecutive
+//     `value is not a function` throws on the same thread.
+//   * `ASYNC_STEP_GUARD` now counts ANY consecutive `is_error=true`
+//     dispatches, not just same-closure ones, so the production loop
+//     trips at 10K iterations and rejects the chain.
+//   * A non-error step dispatch resets the `throw_not_callable` counter,
+//     so legitimate cumulative throws across a long-running process
+//     don't false-positive.
+//
+// This test exercises the throw_not_callable circuit breaker directly:
+// call an undefined function inside a `try`/`catch` 200K times in a sync
+// loop. Without the fix the loop would silently run to completion (each
+// iteration prints nothing — the throw is caught — but in production the
+// async-step pattern at the heart of the bug produced one stderr line per
+// iteration). With the fix, the process aborts with the diagnostic at
+// iteration 100K and exit code 134 (SIGABRT).
+//
+// We pin the BEHAVIOR via a comment + a guard: the loop must NOT
+// silently complete with the bug present, AND must not infinite-loop.
+// The expected output line is the [PERRY ABORT] diagnostic on stderr.
+// See `scripts/test_issue_922_*.sh` (not currently present — this test
+// is a documentation anchor + a smoke test that the fix path is wired up).
+
+function makeUndefinedFn(): any {
+    return undefined;
+}
+
+function exerciseCircuitBreaker(): number {
+    const fn = makeUndefinedFn();
+    let caught = 0;
+    // Tight loop calling an undefined function. The fix's circuit breaker
+    // aborts at 100K iterations; without the fix the loop runs to
+    // completion (200K iterations, 200K caught exceptions, ~0.5s).
+    for (let i = 0; i < 200000; i++) {
+        try {
+            fn(i);
+        } catch (_e) {
+            caught++;
+        }
+    }
+    return caught;
+}
+
+// With the circuit breaker: this never returns — the process aborts.
+// We log the loop start so the test harness can verify the binary
+// reached the loop body before aborting.
+console.log("loop-start");
+const n = exerciseCircuitBreaker();
+console.log("loop-end caught=" + n);


### PR DESCRIPTION
## Summary

- Closes #922: every `/api/*` request in `gscmaster-api` (Fastify + mysql2 + fetch) entered a tight 5.7M-line loop of `[WARN_NULL_PTR] js_object_set_field` + `TypeError: value is not a function at <anonymous>`, with PM2 declaring the process `errored`. The user had no path forward from the unsymbolized stderr stream.
- Same root mechanism as #921 (`throw` across `await` inside `try`/`catch` crashes the process); both surface the silent runaway loop.
- The async-step reentry guard from #712 was already in place but missed this category because it only counted same-`step_closure` errors, while the production loop alternated between two step closures (outer route-handler + inner middleware), each rethrowing the same TypeError.

## Fix

Three layered circuit breakers in `crates/perry-runtime/`:

1. **`object.rs::record_warn_null_ptr`** — abort after 100K consecutive same-site null POINTER_TAG writes (per thread) with a single diagnostic line naming `obj` / `field_index` / `class_id`. Per-call log gated behind `PERRY_DEBUG=1` (preserves #924's gating) AND rate-limited to 64 occurrences even under PERRY_DEBUG.
2. **`closure.rs::throw_not_callable`** — abort after 100K consecutive `value is not a function` throws on the same thread. New `reset_throw_not_callable_counter()` is called from the async-step driver on every non-error step dispatch so cumulative throws over a long-running process don't false-positive.
3. **`promise.rs::ASYNC_STEP_GUARD`** — drop the same-closure check; count ANY consecutive `is_error=true` dispatches and reject at 10K. Legitimate throw-in-a-loop patterns still interleave non-error steps so their consecutive count never grows beyond 1.

Converts the silent infinite loop into an explicit crash with actionable text in ~0.5s — exactly what the user asked for in #921 ask #2 ("a way to dump the offending callsite — currently the user has no path forward from `at <anonymous>`"). The surgical codegen fix for the underlying `throw`-across-`await` pattern can land separately; this PR makes the failure mode visible and bounded.

## Test plan

- [x] New regression test `test-files/test_issue_922_api_route_crash.ts` — 200K-iteration sync loop calling `undefined(i)` inside `try`/`catch`. Aborts with exit 134 and the `[PERRY ABORT] throw_not_callable` diagnostic line, verified with `timeout 30`.
- [x] `cargo test --release -p perry-runtime --lib` — 261 passed.
- [x] `scripts/run_fastify_tests.sh` — 5/5 (GET /hello, GET /users/:id, POST /echo status+body, 404).
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` clean.
- [x] `cargo fmt --all` clean.
- [x] Existing throw/catch tests pass byte-for-byte: `test_issue_express_value_not_fn.ts` (#909), `test_async*.ts`, `test_iife_*.ts`, `test_issue_859_*`, `test_issue_915_*`.

Refs #921 (same root cause, complementary fix), #712 (the original 5.7M-line guard this PR extends), #924 (PERRY_DEBUG gating preserved), #856 / #914 (`_setjmp` ABI suspected as the underlying codegen regression behind #921/#922).