### PR TITLE
fix(hir): #925 — unimplemented-API errors point at the supported replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.964 — fix(hir): #925 — unimplemented-API errors point at the supported replacement
+
+**Symptom.** Two error-emission paths land users in a 15-minute debug loop because the message is accurate but unhelpful:
+
+1. `crypto.hmacSha256(payload, secret)` (a shortcut Perry recognized in an earlier version) bails with `crypto.hmacSha256 is not implemented in Perry — see perry --print-api-manifest`. The manifest does list `createHmac`, but with `params: []` and `returns: any`, so the actual `crypto.createHmac("sha256", key).update(data).digest("hex")` chain isn't obvious from grepping the output.
+2. `require("jose")` bails with `CommonJS require("jose") is not supported under perry compile — use a static import instead`. The static-import swap *compiles*, but every method call (`jose.importX509`, `jose.jwtVerify`) returns silent `undefined` because `jose` isn't in the stdlib at all — and the user discovers that 5 minutes later at first `TypeError: value is not a function` (cf. #922).
+
+Both reported by Ralph while porting a production service.
+
+**Fix.** New `crates/perry-hir/src/lower/unimpl_hints.rs` keys (module, prop) and require-spec to a small replacement-hint table; the existing three #463 emission sites (`expr_member.rs`'s `lower_member` for property reads, `expr_call.rs`'s 2-deep `mod.method()` and 3-deep `mod.Class.method()` call forms) and the #668 require() rejection in `expr_call.rs` append the hint when one is available. Scope is intentionally narrow — exactly the cases #925 calls out:
+
+- `crypto.hmacSha256` → "Use `crypto.createHmac(\"sha256\", key).update(data).digest(\"hex\")` instead (Perry recognizes this Node-shaped chain). For raw bytes, omit the `\"hex\"` argument to `.digest()`."
+- `require("crypto")` / `require("node:crypto")` → "`crypto` is in Perry's stdlib — switch the `require` call to a static ESM import: `import * as crypto from \"node:crypto\"` (or named: `import { createHmac, randomUUID } from \"node:crypto\"`)."
+- `require("jose")` → "`jose` is not in Perry's stdlib — there is no shim for `importX509` / `jwtVerify` / etc. Switching to a static `import * as jose from \"jose\"` will compile, but every method call will be `undefined` at runtime."
+
+The hint table normalizes `node:` prefixes, so `crypto.hmacSha256` and `node:crypto.hmacSha256` route to the same entry without duplicating rows. Unknown lookups return `None`, so the generic "see `perry --print-api-manifest`" pointer still fires for everything not on the explicit list.
+
+Validation: 7 new unit tests in `lower::unimpl_hints::tests` cover the lookup matrix; end-to-end-verified by compiling fixtures for each shape and inspecting stderr. Test-files fixture `test_issue_925_error_message_replacement.ts` documents the three user-visible shapes (commented blocks — file is meant to be uncommented one block at a time, since each is an intentionally-failing compile).
+
 ## v0.5.963 — fix(runtime): #922 — circuit-breaker for runaway `value is not a function` / `[WARN_NULL_PTR]` loops in async-step driver
 
 **Symptom.** `gscmaster-api` (Fastify + mysql2 + fetch, ~5k LoC) compiled cleanly with Perry HEAD but every `/api/*` request entered a tight loop of:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.963
+**Current Version:** 0.5.964
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.963"
+version = "0.5.964"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.963"
+version = "0.5.964"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.963"
+version = "0.5.964"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.963"
+version = "0.5.964"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.963"
+version = "0.5.964"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-hir/src/lower.rs
+++ b/crates/perry-hir/src/lower.rs
@@ -28,6 +28,7 @@ mod expr_member;
 mod expr_misc;
 mod expr_new;
 mod expr_object;
+mod unimpl_hints;
 
 /// Context for lowering, tracks variable bindings
 pub struct LoweringContext {

--- a/crates/perry-hir/src/lower/expr_call.rs
+++ b/crates/perry-hir/src/lower/expr_call.rs
@@ -266,15 +266,22 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
             {
                 if let ast::Expr::Lit(ast::Lit::Str(s)) = call.args[0].expr.as_ref() {
                     let spec = s.value.as_str().unwrap_or("");
+                    // #925: when we have a module-specific hint (e.g.
+                    // distinguishing "this is in stdlib, just swap to
+                    // ESM" from "this isn't shimmed at all"), append it.
+                    let hint = super::unimpl_hints::require_module_hint(spec)
+                        .map(|h| format!(" {h}"))
+                        .unwrap_or_default();
                     crate::lower_bail!(
                         call.span,
                         "CommonJS `require(\"{}\")` is not supported under `perry compile` \
                          — use a static `import` instead \
                          (e.g. `import * as m from \"{}\"` \
-                         or `import {{ x }} from \"{}\"`). Closes #668.",
+                         or `import {{ x }} from \"{}\"`). Closes #668.{}",
                         spec,
                         spec,
                         spec,
+                        hint,
                     );
                 }
             }
@@ -839,12 +846,21 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                                     )
                                     .is_none()
                                 {
+                                    // #925: append a replacement hint if
+                                    // we have one for this exact shape.
+                                    let hint = super::unimpl_hints::module_member_hint(
+                                        module_name,
+                                        &class_name,
+                                    )
+                                    .map(|h| format!(" {h}"))
+                                    .unwrap_or_default();
                                     crate::lower_bail!(
                                         outer_member.span,
                                         "`{}.{}` is not implemented in Perry — see `perry --print-api-manifest` for the supported surface, \
-                                         or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463)",
+                                         or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463){}",
                                         module_name,
                                         class_name,
+                                        hint,
                                     );
                                 }
                                 if !is_sub_namespace {
@@ -1711,12 +1727,21 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                                     )
                                     .is_none()
                                 {
+                                    // #925: this is the gate that fires
+                                    // for `crypto.hmacSha256(data, key)`.
+                                    let hint = super::unimpl_hints::module_member_hint(
+                                        module_name,
+                                        &method_name,
+                                    )
+                                    .map(|h| format!(" {h}"))
+                                    .unwrap_or_default();
                                     crate::lower_bail!(
                                         member.span,
                                         "`{}.{}` is not implemented in Perry — see `perry --print-api-manifest` for the supported surface, \
-                                         or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463)",
+                                         or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463){}",
                                         module_name,
                                         method_name,
+                                        hint,
                                     );
                                 }
                                 return Ok(Expr::NativeMethodCall {

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -672,12 +672,19 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
             && perry_api_manifest::module_has_any_entries(module)
             && perry_api_manifest::module_has_symbol(module, prop).is_none()
         {
+            // #925: when there's a known supported equivalent for this
+            // shape, append it to the error so the user doesn't have to
+            // grep through the manifest to find the replacement.
+            let hint = super::unimpl_hints::module_member_hint(module, prop)
+                .map(|h| format!(" {h}"))
+                .unwrap_or_default();
             crate::lower_bail!(
                 member.span,
                 "`{}.{}` is not implemented in Perry — see `perry --print-api-manifest` for the supported surface, \
-                 or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463)",
+                 or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463){}",
                 module,
                 prop,
+                hint,
             );
         }
     }

--- a/crates/perry-hir/src/lower/unimpl_hints.rs
+++ b/crates/perry-hir/src/lower/unimpl_hints.rs
@@ -1,0 +1,150 @@
+//! Replacement-suggestion hints for the unimplemented-API gate (#925).
+//!
+//! Goal: when the #463 gate fires for a known-bad pattern that has a
+//! direct supported equivalent, append a one-liner pointing at the
+//! replacement. Without this, the error message is accurate ("X is not
+//! implemented") but unhelpful — users have to grep through
+//! `perry --print-api-manifest` (often >2 MB of output) to find the
+//! Node-shaped surface Perry actually understands.
+//!
+//! Scope is intentionally narrow. Start with the two cases #925 calls
+//! out by name; grow the table when other reports identify another
+//! "compiled yesterday, doesn't today" pattern. Speculative entries are
+//! not free: every wrong hint costs a user 30+ seconds of confusion, so
+//! we only add entries we're confident about.
+//!
+//! Two distinct surfaces:
+//!
+//! 1. **Module-qualified unimplemented method/property** (e.g.
+//!    `crypto.hmacSha256`). Looked up by `(module, prop)` via
+//!    [`module_member_hint`]. The hint is appended to the existing
+//!    `#463` error message at all three gate sites
+//!    (`expr_member.rs::lower_member` for property reads,
+//!    `expr_call.rs` for the 2-deep `mod.method()` and 3-deep
+//!    `mod.Class.method()` call forms).
+//!
+//! 2. **Top-level `require("modname")`** (CJS-under-perry-compile, #668).
+//!    Looked up by `modname` via [`require_module_hint`]. The hint is
+//!    appended to the existing `Closes #668` error message in
+//!    `expr_call.rs`.
+
+/// Replacement hint for `module.prop` patterns that the #463 gate
+/// rejects. Returns `None` if no specific hint is available — the
+/// caller falls back to the generic "see `perry --print-api-manifest`"
+/// pointer.
+pub(crate) fn module_member_hint(module: &str, prop: &str) -> Option<&'static str> {
+    // Normalize `node:crypto` and `crypto` to the same hint set; the
+    // user typed whichever import shape they happened to copy off
+    // StackOverflow and shouldn't have to care which one we keyed on.
+    let m = strip_node_prefix(module);
+    match (m, prop) {
+        // #925 case 1: `crypto.hmacSha256(data, key)` was a Perry
+        // shortcut in an earlier version. The Node-shaped chain Perry
+        // recognizes today is `createHmac(algo, key).update(data).digest(enc)`.
+        ("crypto", "hmacSha256") => Some(
+            "Use `crypto.createHmac(\"sha256\", key).update(data).digest(\"hex\")` \
+             instead (Perry recognizes this Node-shaped chain). For raw bytes, \
+             omit the `\"hex\"` argument to `.digest()`.",
+        ),
+        _ => None,
+    }
+}
+
+/// Replacement hint for `require("modname")` calls under
+/// `perry compile`. Returns `None` if no specific hint is available —
+/// the caller falls back to the generic
+/// "use a static `import` instead" message.
+///
+/// The distinction this draws is: for a module that lives in Perry's
+/// stdlib surface (`crypto`, `fs`, `path`, ...), swapping `require` for
+/// a static `import` will Just Work, and the hint just nudges the user
+/// toward the ESM form. For a module that ISN'T in Perry's stdlib at
+/// all (e.g. `jose`), the static-import swap will compile but the
+/// runtime call site will explode with `TypeError: value is not a
+/// function` — so the hint warns explicitly about that.
+pub(crate) fn require_module_hint(spec: &str) -> Option<String> {
+    // Match the bare module name, ignoring any `node:` prefix the user
+    // may have typed.
+    let bare = strip_node_prefix(spec);
+    match bare {
+        // #925 case 2a: `require("crypto")` / `require("node:crypto")`.
+        // The crypto stdlib surface exists, so ESM swap is enough.
+        "crypto" => Some(format!(
+            "`{spec}` is in Perry's stdlib — switch the `require` call to \
+             a static ESM import: `import * as crypto from \"node:crypto\"` \
+             (or named: `import {{ createHmac, randomUUID }} from \"node:crypto\"`)."
+        )),
+        // #925 case 2b: `require("jose")`. NOT in Perry's stdlib.
+        // The static-import swap will compile (it's just an unresolved
+        // import warning) but every method call will be a silent
+        // undefined that blows up at runtime as
+        // `TypeError: value is not a function` (#922). Warn explicitly.
+        "jose" => Some(format!(
+            "`{spec}` is not in Perry's stdlib — there is no shim for \
+             `importX509` / `jwtVerify` / etc. Switching to a static \
+             `import * as jose from \"jose\"` will compile, but every \
+             method call will be `undefined` at runtime. \
+             See `perry --print-api-manifest` for the supported surface."
+        )),
+        _ => None,
+    }
+}
+
+/// Strip a leading `node:` prefix from a module specifier so the hint
+/// table can key on the bare name without duplicating every entry.
+fn strip_node_prefix(spec: &str) -> &str {
+    spec.strip_prefix("node:").unwrap_or(spec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crypto_hmac_sha256_has_hint() {
+        let hint = module_member_hint("crypto", "hmacSha256").expect("hint exists");
+        assert!(hint.contains("createHmac"));
+        assert!(hint.contains("update"));
+        assert!(hint.contains("digest"));
+    }
+
+    #[test]
+    fn crypto_hmac_sha256_hint_normalizes_node_prefix() {
+        // `node:crypto.hmacSha256` should route to the same hint.
+        let hint = module_member_hint("node:crypto", "hmacSha256").expect("hint exists");
+        assert!(hint.contains("createHmac"));
+    }
+
+    #[test]
+    fn unknown_module_member_has_no_hint() {
+        assert!(module_member_hint("fs", "doesNotExist").is_none());
+        assert!(module_member_hint("nonexistent", "anything").is_none());
+    }
+
+    #[test]
+    fn require_crypto_has_hint() {
+        let hint = require_module_hint("crypto").expect("hint exists");
+        assert!(hint.contains("stdlib"));
+        assert!(hint.contains("import"));
+        assert!(hint.contains("node:crypto"));
+    }
+
+    #[test]
+    fn require_node_crypto_has_hint() {
+        // `require("node:crypto")` should also be recognized.
+        let hint = require_module_hint("node:crypto").expect("hint exists");
+        assert!(hint.contains("import"));
+    }
+
+    #[test]
+    fn require_jose_warns_about_runtime_undefined() {
+        let hint = require_module_hint("jose").expect("hint exists");
+        assert!(hint.contains("not in Perry"));
+        assert!(hint.contains("undefined"));
+    }
+
+    #[test]
+    fn require_unknown_module_has_no_hint() {
+        assert!(require_module_hint("totally-fictional-pkg").is_none());
+    }
+}

--- a/test-files/test_issue_925_error_message_replacement.ts
+++ b/test-files/test_issue_925_error_message_replacement.ts
@@ -1,0 +1,39 @@
+// Issue #925: compiler-rejected APIs should include a replacement hint
+// in the error message so users find the supported form without grepping
+// `perry --print-api-manifest`.
+//
+// This file is NOT meant to compile cleanly — each block triggers one of
+// the error-emission paths the fix targets. The Rust-side unit tests in
+// `crates/perry-hir/src/lower/unimpl_hints.rs` assert the actual hint
+// payload; this file documents the user-visible shapes for posterity.
+//
+// To verify by hand:
+//   1. Uncomment one block at a time.
+//   2. Run `./target/release/perry test-files/test_issue_925_error_message_replacement.ts -o /tmp/x`.
+//   3. Confirm the error contains the trailing "Use ..."/"is in/not in Perry's stdlib" hint.
+
+// --- Case 1: crypto.hmacSha256 (2-deep `mod.method()` shape) ---
+// Expected: error includes
+//   "Use `crypto.createHmac(\"sha256\", key).update(data).digest(\"hex\")`"
+//
+// import * as crypto from "node:crypto";
+// const sig = (crypto as any).hmacSha256("data", "key");
+
+// --- Case 2a: require("crypto") used inline ---
+// (`const x = require("crypto")` is silently rewritten to an ESM import
+//  by a pre-existing path, so to hit the CJS-rejection gate the require
+//  must appear in expression position.)
+// Expected: error includes
+//   "`crypto` is in Perry's stdlib — switch the `require` call to a static ESM import"
+//
+// const hmac = require("crypto").createHmac("sha256", "key");
+
+// --- Case 2b: require("jose") (not in stdlib) ---
+// Expected: error includes
+//   "`jose` is not in Perry's stdlib"
+//   "every method call will be `undefined` at runtime"
+//
+// const jose = require("jose");
+// console.log(jose);
+
+export {};


### PR DESCRIPTION
## Summary

- Adds a narrow replacement-hint table (`crates/perry-hir/src/lower/unimpl_hints.rs`) that the #463 unimplemented-API gate + #668 `require()` rejection consult and append to their existing error messages.
- Scope is intentionally just the two cases #925 calls out by name; everything else still falls back to the generic "see `perry --print-api-manifest`" pointer.
- New entries:
  - `crypto.hmacSha256` → `crypto.createHmac("sha256", key).update(data).digest("hex")`.
  - `require("crypto")` / `require("node:crypto")` → "in stdlib, swap to ESM `import * as crypto from \"node:crypto\"`".
  - `require("jose")` → "not in stdlib, static import compiles but every call is `undefined` at runtime".

## Test plan

- [x] 7 new unit tests in `lower::unimpl_hints::tests` covering the lookup matrix (pass).
- [x] Manual end-to-end verification: compile `/tmp/test_925_crypto_hmac.ts`, `/tmp/test_925_require_jose.ts`, and a `require("crypto")` fixture; confirm each error message carries the trailing hint sentence.
- [x] `cargo build --release -p perry-hir -p perry` clean.
- [x] `cargo fmt` clean.
- [x] No conflict markers left in `Cargo.toml` / `CLAUDE.md` / `Cargo.lock` after rebase onto current `main`.