### PR TITLE
fix(codegen): #927 — jwt.verify returns parsed object, not JSON-stringified string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.965 — fix(codegen): #927 — `jwt.verify(token, key, opts)` returns parsed object, not JSON-stringified string
+
+**Symptom.** Authenticated `/api/*` routes in shop-admin's native server returned 401 after the very first request, even though signup itself worked end-to-end (HTTP 201, full JWT JSON written, all 5 tables populated). Minimal repro:
+
+```ts
+import jwt from "jsonwebtoken";
+const TOK = jwt.sign({ sub: "u-001" }, "secret", { algorithm: "HS256" });
+const decoded = jwt.verify(TOK, "secret", { algorithms: ["HS256"] }) as any;
+console.log("typeof:", typeof decoded);  // Perry: string,    Node: object
+console.log("sub:",    decoded.sub);     // Perry: undefined, Node: u-001
+```
+
+Perry's binding successfully decoded the JWT internally (the `[jwt-verify] success, claims={"acc":"a-001","sub":"u-001"}` log line under `PERRY_DEBUG=1` shows the right claim shape) but handed the JSON *text* back to user code instead of a parsed object. `decoded.sub` therefore read `undefined`, the auth middleware's `typeof decoded.sub !== "string"` short-circuit fired, `req.user` never got populated, and `requireUser(req)` threw on every authenticated route.
+
+**Root cause.** The `jsonwebtoken.verify` entry in `NATIVE_MODULE_TABLE` (crates/perry-codegen/src/lower_call.rs) was the symmetric counterpart of #915's argument-side bug:
+
+```rust
+NativeModSig {
+    module: "jsonwebtoken",
+    method: "verify",
+    runtime: "js_jwt_verify",
+    args: &[NA_STR, NA_STR],
+    ret: NR_STR,                 // <-- treated the JSON-text return as a plain string.
+},
+```
+
+`js_jwt_verify` (`crates/perry-ext-jsonwebtoken/src/lib.rs`) decodes the token, calls `serde_json::to_string(&token_data.claims)`, and returns a `*mut StringHeader` holding that JSON text. The `NR_STR` dispatch arm in `lower_native_module_dispatch` then NaN-boxed the pointer with `STRING_TAG` and handed it back as a string. The comment on the row even acknowledged the gap: "Caller must JSON.parse the result." — but user code per the jsonwebtoken README expects a parsed object, not the JSON text.
+
+**Fix.** Add a new return-kind tag `NR_OBJ_FROM_JSON_STR` (variant `NativeRetKind::ObjFromJsonStr`) that automatically pipes the runtime's `*mut StringHeader` JSON-text result through a JSON-parse on the way out, then flips the `jsonwebtoken.verify` and `jsonwebtoken.decode` rows from `NR_STR` to the new return kind. Symmetric to the `NA_JSON` arg coercion that #915 added on the call-in side.
+
+To keep failure-mode behavior intact (`jwt.verify` returns a null `*mut StringHeader` for bad signatures), the dispatch routes the parse through a new `js_json_parse_or_null` shim in `crates/perry-runtime/src/json.rs` that returns `JSValue::null()` for null input instead of throwing `Unexpected end of JSON input` like plain `js_json_parse` does. Without the shim, calling `js_json_parse(null)` triggers `js_throw` with no surrounding try/catch, which exits the process — exactly the wrong behavior for an authentication path.
+
+**Files touched.**
+
+- `crates/perry-codegen/src/lower_call.rs` — new `NativeRetKind::ObjFromJsonStr` variant + `NR_OBJ_FROM_JSON_STR` const + dispatch arm in `lower_native_module_dispatch`; `jsonwebtoken.verify` and `jsonwebtoken.decode` table rows flipped from `NR_STR` to the new kind.
+- `crates/perry-runtime/src/json.rs` — `js_json_parse_or_null` shim that returns null instead of throwing on null input.
+- `crates/perry-codegen/src/runtime_decls.rs` — declare `js_json_parse_or_null` in the global runtime symbol table.
+- `test-files/test_issue_927_jwt_verify_returns_object.ts` — regression: round-trip HS256 sign+verify, asserts `typeof decoded === "object"` and `decoded.sub === "u-001"`.
+
+**Validation.** Compile + run the regression fixture under release perry. Bad-signature path still surfaces `null` to user code (no thrown exception that aborts the process); happy path now produces the expected `{ sub: "u-001", acc: "a-001", iat: ... }` shape with `.sub` indexable. Unblocks the shop-admin auth middleware and any other consumer of `jwt.verify(token, key, opts).<claim>` property access.
+
 ## v0.5.964 — fix(hir): #925 — unimplemented-API errors point at the supported replacement
 
 **Symptom.** Two error-emission paths land users in a 15-minute debug loop because the message is accurate but unhelpful:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.964
+**Current Version:** 0.5.965
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.964"
+version = "0.5.965"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.964"
+version = "0.5.965"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.964"
+version = "0.5.965"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.964"
+version = "0.5.965"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.964"
+version = "0.5.965"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -5918,6 +5918,13 @@ enum NativeRetKind {
     /// caller (and `JSON.stringify`, string-comparison, etc.) needs the
     /// STRING_TAG to recognize it as a string rather than a heap object.
     Str,
+    /// Returns `*mut StringHeader` containing JSON → automatically pipe
+    /// through `js_json_parse` so the user-visible value is a parsed
+    /// object/array, not the JSON-encoded string. Symmetric to `NA_JSON`
+    /// on the argument side (#915). Null pointer → TAG_NULL so a failed
+    /// verify (`jwt.verify` on bad signature) still reads as `null`
+    /// rather than dereferencing a dangling pointer. Issue #927.
+    ObjFromJsonStr,
     /// Returns `*mut BigIntHeader` → NaN-box as BIGINT (0x7FFA tag). Use
     /// for functions like `parseEther`/`parseUnits` that return bigint values.
     BigInt,
@@ -5952,6 +5959,7 @@ const NA_JSV: NativeArgKind = NativeArgKind::JsvalI64;
 const NA_VARARGS: NativeArgKind = NativeArgKind::VarArgsAsArray;
 const NR_PTR: NativeRetKind = NativeRetKind::Ptr;
 const NR_STR: NativeRetKind = NativeRetKind::Str;
+const NR_OBJ_FROM_JSON_STR: NativeRetKind = NativeRetKind::ObjFromJsonStr;
 const NR_BIGINT: NativeRetKind = NativeRetKind::BigInt;
 const NR_F64: NativeRetKind = NativeRetKind::F64;
 const NR_I32: NativeRetKind = NativeRetKind::I32Void;
@@ -8130,11 +8138,13 @@ const NATIVE_MODULE_TABLE: &[NativeModSig] = &[
         class_filter: None,
         runtime: "js_jwt_verify",
         // js_jwt_verify(token_ptr: *const StringHeader, secret_ptr: *const StringHeader)
-        // -> *mut StringHeader (JSON of claims). NA_F64/NR_F64 caused
-        // calling-convention mismatch on both args and return; NA_STR/NR_STR
-        // matches the actual Rust ABI. Caller must JSON.parse the result.
+        // -> *mut StringHeader (JSON of claims). NR_OBJ_FROM_JSON_STR pipes
+        // the returned JSON through js_json_parse so the value visible to
+        // user code is a real object (decoded.sub works), not the JSON
+        // text. Per the jsonwebtoken README, `jwt.verify` returns the
+        // payload as an object. Issue #927.
         args: &[NA_STR, NA_STR],
-        ret: NR_STR,
+        ret: NR_OBJ_FROM_JSON_STR,
     },
     NativeModSig {
         module: "jsonwebtoken",
@@ -8142,9 +8152,10 @@ const NATIVE_MODULE_TABLE: &[NativeModSig] = &[
         method: "decode",
         class_filter: None,
         runtime: "js_jwt_decode",
-        // js_jwt_decode(token_ptr) -> *mut StringHeader (JSON). Same fix.
+        // js_jwt_decode(token_ptr) -> *mut StringHeader (JSON of payload).
+        // Mirror `verify` — returns an object to user code. Issue #927.
         args: &[NA_STR],
-        ret: NR_STR,
+        ret: NR_OBJ_FROM_JSON_STR,
     },
     // ========== nodemailer ==========
     NativeModSig {
@@ -10750,6 +10761,7 @@ fn ret_kind_tag(r: &NativeRetKind) -> &'static str {
     match r {
         NativeRetKind::Ptr => "NR_PTR",
         NativeRetKind::Str => "NR_STR",
+        NativeRetKind::ObjFromJsonStr => "NR_OBJ_FROM_JSON_STR",
         NativeRetKind::BigInt => "NR_BIGINT",
         NativeRetKind::F64 => "NR_F64",
         NativeRetKind::I32Void => "NR_I32",
@@ -10897,7 +10909,10 @@ pub(super) fn lower_native_module_dispatch(
 
     // Determine return type for the declare
     let ret_type = match sig.ret {
-        NativeRetKind::Ptr | NativeRetKind::Str | NativeRetKind::BigInt => I64,
+        NativeRetKind::Ptr
+        | NativeRetKind::Str
+        | NativeRetKind::ObjFromJsonStr
+        | NativeRetKind::BigInt => I64,
         NativeRetKind::F64 => DOUBLE,
         NativeRetKind::I32Void => I32,
         NativeRetKind::Void => crate::types::VOID,
@@ -10927,6 +10942,28 @@ pub(super) fn lower_native_module_dispatch(
             let boxed = nanbox_string_inline(blk, &raw);
             let null_val = double_literal(f64::from_bits(crate::nanbox::TAG_NULL));
             Ok(blk.select(crate::types::I1, &is_null, DOUBLE, &null_val, &boxed))
+        }
+        NativeRetKind::ObjFromJsonStr => {
+            // Returned raw *mut StringHeader containing JSON — pipe
+            // through `js_json_parse_or_null` so user code sees a real
+            // object (e.g. `jwt.verify(...).sub` works). Symmetric
+            // counterpart to the NA_JSON arg coercion landed in #915.
+            // Null pointer (failure mode — e.g. `jwt.verify` on a bad
+            // signature) is returned as TAG_NULL without throwing,
+            // matching the previous NR_STR null-handling. #927.
+            //
+            // `js_json_parse_or_null` takes `*const StringHeader` (i64
+            // on the FFI side) and returns the NaN-boxed JSValue bits
+            // as i64. It returns TAG_NULL for null input (instead of
+            // the throw that plain `js_json_parse` does). Declare
+            // BEFORE grabbing `blk` so the mutable borrow on
+            // pending_declares doesn't overlap the block borrow.
+            ctx.pending_declares
+                .push(("js_json_parse_or_null".to_string(), I64, vec![I64]));
+            let blk = ctx.block();
+            let raw = blk.call(I64, sig.runtime, &arg_slices);
+            let parsed_bits = blk.call(I64, "js_json_parse_or_null", &[(I64, &raw)]);
+            Ok(blk.bitcast_i64_to_double(&parsed_bits))
         }
         NativeRetKind::BigInt => {
             // Returned raw *mut BigIntHeader — NaN-box with BIGINT_TAG (0x7FFA).

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -792,6 +792,10 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // JSON.parse returns JSValue (u64) via integer register on ARM64,
     // not f64. Use I64 return + bitcast to avoid ABI mismatch crash.
     module.declare_function("js_json_parse", I64, &[I64]);
+    // JSON.parse(text) shim that returns `null` for a null `text_ptr`
+    // instead of throwing. Used by NR_OBJ_FROM_JSON_STR dispatch rows
+    // (e.g. `jwt.verify` on bad signature) — see issue #927.
+    module.declare_function("js_json_parse_or_null", I64, &[I64]);
     // JSON.parse<T[]> schema-directed parse: same return semantics.
     // Args: text_ptr (i64), packed_keys (i64), packed_keys_len (i32),
     // field_count (i32).

--- a/crates/perry-runtime/src/json.rs
+++ b/crates/perry-runtime/src/json.rs
@@ -1020,6 +1020,24 @@ impl<'a> DirectParser<'a> {
 
 // ─── JSON.parse ───────────────────────────────────────────────────────────────
 
+/// JSON.parse(text) shim that returns `null` for a null input instead
+/// of throwing `Unexpected end of JSON input`. Used by codegen dispatch
+/// rows whose runtime FFI returns `*mut StringHeader` containing JSON
+/// for the success path and a null pointer for the failure path (e.g.
+/// `jwt.verify` on a bad signature). User code expects a null-return,
+/// not an uncaught exception that aborts the process. Issue #927.
+///
+/// # Safety
+///
+/// `text_ptr` must be null or a Perry-runtime `StringHeader`.
+#[no_mangle]
+pub unsafe extern "C" fn js_json_parse_or_null(text_ptr: *const StringHeader) -> JSValue {
+    if text_ptr.is_null() {
+        return JSValue::null();
+    }
+    js_json_parse(text_ptr)
+}
+
 /// JSON.parse(text) -> any
 ///
 /// Uses a direct recursive-descent parser that constructs Perry JSValues

--- a/test-files/test_issue_927_jwt_verify_returns_object.ts
+++ b/test-files/test_issue_927_jwt_verify_returns_object.ts
@@ -1,0 +1,36 @@
+// Issue #927 regression: jsonwebtoken.verify must return the decoded
+// payload as a parsed OBJECT, not the JSON-stringified text. The runtime
+// FFI returns `*mut StringHeader` containing the JSON form; the codegen
+// dispatch (NR_OBJ_FROM_JSON_STR return kind) must pipe that through
+// js_json_parse so user code sees a real object — otherwise
+// `decoded.sub` reads as `undefined` and auth middleware breaks.
+//
+// Symmetric counterpart to #915 on the return side.
+
+import jwt from "jsonwebtoken";
+
+function assert(condition: boolean, message: string) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const token = jwt.sign({ sub: "u-001", acc: "a-001" }, "secret", {
+  algorithm: "HS256",
+});
+console.log("token typeof:", typeof token);
+assert(typeof token === "string", "sign should produce a string token");
+assert(token.length > 0, "token should be non-empty");
+
+const decoded = jwt.verify(token, "secret", { algorithms: ["HS256"] }) as any;
+
+console.log("decoded typeof:", typeof decoded);
+console.log("decoded.sub:", decoded.sub);
+console.log("decoded.acc:", decoded.acc);
+
+assert(typeof decoded === "object", "verify must return an object, not a string");
+assert(decoded !== null, "verify must not return null on success");
+assert(decoded.sub === "u-001", "decoded.sub should be 'u-001'");
+assert(decoded.acc === "a-001", "decoded.acc should be 'a-001'");
+
+console.log("issue 927 jwt.verify: ok");


### PR DESCRIPTION
## Summary

- Fixes #927. `jwt.verify(token, key, opts)` (and `jwt.decode(token)`) now return a parsed object instead of the JSON-stringified text. `decoded.sub` is indexable, auth middleware unblocks.
- Adds `NativeRetKind::ObjFromJsonStr` to the native dispatch table — symmetric counterpart of #915's `NA_JSON` on the argument side. The arm pipes the runtime's `*mut StringHeader` JSON-text return through a new `js_json_parse_or_null` shim so bad-signature failures still surface as `null` instead of throwing `Unexpected end of JSON input` and aborting the process.
- Regression fixture `test-files/test_issue_927_jwt_verify_returns_object.ts` exercises HS256 round-trip sign+verify and asserts `typeof decoded === "object"`, `decoded.sub === "u-001"`, `decoded.acc === "a-001"`.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` succeeds
- [x] `./target/release/perry test-files/test_issue_927_jwt_verify_returns_object.ts -o /tmp/test_927 && /tmp/test_927` prints `decoded typeof: object`, `decoded.sub: u-001`, `decoded.acc: a-001`, `issue 927 jwt.verify: ok`
- [x] Existing #915 regression `test_issue_915_jwt_sign.ts` still passes
- [x] Bad-secret path (verify with wrong secret) returns `null` without throwing/aborting
- [x] `jwt.decode(token)` also returns object (mirror change)