### PR TITLE
fix(fastify): catch thrown route errors

### DIFF
--- a/crates/perry-ext-fastify/src/server.rs
+++ b/crates/perry-ext-fastify/src/server.rs
@@ -10,6 +10,7 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::os::raw::c_int;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -33,6 +34,19 @@ const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 const PTR_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
 const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+const GC_HEADER_SIZE: usize = 8;
+const GC_TYPE_ERROR: u8 = 7;
+
+struct ClosureCallResult {
+    value: f64,
+    thrown: Option<f64>,
+}
+
+enum HookOutcome {
+    Continue,
+    Sent,
+    Error(f64),
+}
 
 // Runtime symbols not yet wrapped by perry-ffi — we declare them
 // locally as `extern "C"`. Same pattern perry-ext-{net,http,ws}
@@ -91,12 +105,34 @@ extern "C" {
     fn js_timer_tick() -> i32;
     fn js_callback_timer_tick() -> i32;
     fn js_interval_timer_tick() -> i32;
+
+    fn js_try_push() -> *mut c_int;
+    fn js_try_end();
+    fn js_get_exception() -> f64;
+    fn js_clear_exception();
+    fn js_error_get_message(error: *mut ErrorHeader) -> *mut StringHeader;
+}
+
+#[cfg(target_vendor = "apple")]
+extern "C" {
+    #[link_name = "_setjmp"]
+    fn setjmp(env: *mut c_int) -> c_int;
+}
+
+#[cfg(not(target_vendor = "apple"))]
+extern "C" {
+    fn setjmp(env: *mut c_int) -> c_int;
 }
 
 /// Opaque marker for the runtime's Promise struct. We never read its
 /// fields directly — only pass pointers to runtime helpers above.
 #[repr(C)]
 pub struct Promise {
+    _opaque: [u8; 0],
+}
+
+#[repr(C)]
+pub struct ErrorHeader {
     _opaque: [u8; 0],
 }
 
@@ -428,9 +464,10 @@ fn process_request(app_handle: Handle, pending: FastifyPendingRequest) {
 
     // Snapshot hooks + matched route (need to drop the borrow before
     // invoking user closures, which may mutate the app).
-    let (on_request_hooks, pre_handler_hooks, matched_handler): (
+    let (on_request_hooks, pre_handler_hooks, matched_handler, error_handler): (
         Vec<ClosurePtr>,
         Vec<ClosurePtr>,
+        Option<ClosurePtr>,
         Option<ClosurePtr>,
     ) = match get_handle::<FastifyApp>(app_handle) {
         Some(app) => {
@@ -439,9 +476,9 @@ fn process_request(app_handle: Handle, pending: FastifyPendingRequest) {
             let matched = app
                 .match_route(&pending.method, &pending.path)
                 .map(|(r, _)| r.handler);
-            (on_req, pre, matched)
+            (on_req, pre, matched, app.error_handler)
         }
-        None => (Vec::new(), Vec::new(), None),
+        None => (Vec::new(), Vec::new(), None, None),
     };
 
     // NaN-box the context handle — POINTER_TAG so codegen-side
@@ -450,16 +487,32 @@ fn process_request(app_handle: Handle, pending: FastifyPendingRequest) {
 
     let mut response_sent = false;
     for hook in &on_request_hooks {
-        if call_hook_awaiting(*hook, ctx_f64, ctx_handle) {
-            response_sent = true;
-            break;
+        match call_hook_awaiting(*hook, ctx_f64, ctx_handle) {
+            HookOutcome::Continue => {}
+            HookOutcome::Sent => {
+                response_sent = true;
+                break;
+            }
+            HookOutcome::Error(reason) => {
+                handle_error_response(error_handler, ctx_f64, ctx_handle, reason);
+                response_sent = true;
+                break;
+            }
         }
     }
     if !response_sent {
         for hook in &pre_handler_hooks {
-            if call_hook_awaiting(*hook, ctx_f64, ctx_handle) {
-                response_sent = true;
-                break;
+            match call_hook_awaiting(*hook, ctx_f64, ctx_handle) {
+                HookOutcome::Continue => {}
+                HookOutcome::Sent => {
+                    response_sent = true;
+                    break;
+                }
+                HookOutcome::Error(reason) => {
+                    handle_error_response(error_handler, ctx_f64, ctx_handle, reason);
+                    response_sent = true;
+                    break;
+                }
             }
         }
     }
@@ -467,23 +520,32 @@ fn process_request(app_handle: Handle, pending: FastifyPendingRequest) {
     let mut final_result = f64::from_bits(TAG_UNDEFINED);
     if !response_sent {
         if let Some(handler) = matched_handler {
-            let result = unsafe {
+            let call = unsafe {
                 let raw = handler as *const RawClosureHeader;
                 let closure = JsClosure::from_raw(raw);
                 if closure.is_null() {
-                    f64::from_bits(TAG_UNDEFINED)
+                    ClosureCallResult {
+                        value: f64::from_bits(TAG_UNDEFINED),
+                        thrown: None,
+                    }
                 } else {
-                    closure.call2(ctx_f64, ctx_f64)
+                    call_closure2_catching(closure, ctx_f64, ctx_f64)
                 }
             };
+            if let Some(reason) = call.thrown {
+                handle_error_response(error_handler, ctx_f64, ctx_handle, reason);
+                response_sent = true;
+            }
             unsafe {
                 js_promise_run_microtasks();
             }
-            final_result = result;
+            if !response_sent {
+                final_result = call.value;
+            }
 
             // If the handler returned a Promise, wait for it.
-            let jsv = JsValue::from_bits(result.to_bits());
-            if jsv.is_pointer() {
+            let jsv = JsValue::from_bits(call.value.to_bits());
+            if !response_sent && jsv.is_pointer() {
                 let ptr = jsv.as_pointer::<Promise>();
                 if !ptr.is_null() && unsafe { js_is_promise(ptr) } != 0 {
                     wait_for_promise(ptr);
@@ -510,11 +572,8 @@ fn process_request(app_handle: Handle, pending: FastifyPendingRequest) {
                         // envelope to avoid spilling raw stack traces
                         // into the wire. Mirrors `fastify`'s default
                         // error handler shape.
-                        if let Some(ctx) = perry_ffi::get_handle_mut::<FastifyContext>(ctx_handle) {
-                            ctx.status_code = 500;
-                            let reason = unsafe { js_promise_reason(ptr) };
-                            ctx.response_body = Some(unsafe { render_rejection_body(reason) });
-                        }
+                        let reason = unsafe { js_promise_reason(ptr) };
+                        handle_error_response(error_handler, ctx_f64, ctx_handle, reason);
                         final_result = f64::from_bits(TAG_UNDEFINED);
                     } else {
                         final_result = unsafe { js_promise_value(ptr) };
@@ -550,33 +609,159 @@ fn process_request(app_handle: Handle, pending: FastifyPendingRequest) {
     perry_ffi::drop_handle(ctx_handle);
 }
 
-/// Call a hook closure, await any returned Promise, and return whether
-/// `ctx.sent` is true (i.e. the hook produced a response, e.g. an
-/// auth-middleware 401).
-fn call_hook_awaiting(hook: ClosurePtr, ctx_f64: f64, ctx_handle: Handle) -> bool {
+/// Call a hook closure, await any returned Promise, and report whether it
+/// sent a response or threw/rejected.
+fn call_hook_awaiting(hook: ClosurePtr, ctx_f64: f64, ctx_handle: Handle) -> HookOutcome {
     if hook == 0 {
-        return false;
+        return HookOutcome::Continue;
     }
-    let result = unsafe {
+    let call = unsafe {
         let closure = JsClosure::from_raw(hook as *const RawClosureHeader);
         if closure.is_null() {
-            return false;
+            return HookOutcome::Continue;
         }
-        closure.call2(ctx_f64, ctx_f64)
+        call_closure2_catching(closure, ctx_f64, ctx_f64)
     };
+    if let Some(reason) = call.thrown {
+        return HookOutcome::Error(reason);
+    }
     unsafe {
         js_promise_run_microtasks();
     }
-    let jsv = JsValue::from_bits(result.to_bits());
+    let jsv = JsValue::from_bits(call.value.to_bits());
     if jsv.is_pointer() {
         let ptr = jsv.as_pointer::<Promise>();
         if !ptr.is_null() && unsafe { js_is_promise(ptr) } != 0 {
             wait_for_promise(ptr);
+            if unsafe { js_promise_state(ptr) } == 2 {
+                return HookOutcome::Error(unsafe { js_promise_reason(ptr) });
+            }
         }
     }
-    get_handle::<FastifyContext>(ctx_handle)
+    if get_handle::<FastifyContext>(ctx_handle)
         .map(|c| c.sent)
         .unwrap_or(false)
+    {
+        HookOutcome::Sent
+    } else {
+        HookOutcome::Continue
+    }
+}
+
+unsafe fn call_closure2_catching(closure: JsClosure, arg0: f64, arg1: f64) -> ClosureCallResult {
+    let trap_buf = js_try_push();
+    let jumped = setjmp(trap_buf);
+    if jumped != 0 {
+        let exc = js_get_exception();
+        js_clear_exception();
+        js_try_end();
+        return ClosureCallResult {
+            value: f64::from_bits(TAG_UNDEFINED),
+            thrown: Some(exc),
+        };
+    }
+
+    let value = closure.call2(arg0, arg1);
+    js_try_end();
+    ClosureCallResult {
+        value,
+        thrown: None,
+    }
+}
+
+unsafe fn call_closure3_catching(
+    closure: JsClosure,
+    arg0: f64,
+    arg1: f64,
+    arg2: f64,
+) -> ClosureCallResult {
+    let trap_buf = js_try_push();
+    let jumped = setjmp(trap_buf);
+    if jumped != 0 {
+        let exc = js_get_exception();
+        js_clear_exception();
+        js_try_end();
+        return ClosureCallResult {
+            value: f64::from_bits(TAG_UNDEFINED),
+            thrown: Some(exc),
+        };
+    }
+
+    let value = closure.call3(arg0, arg1, arg2);
+    js_try_end();
+    ClosureCallResult {
+        value,
+        thrown: None,
+    }
+}
+
+fn handle_error_response(
+    error_handler: Option<ClosurePtr>,
+    ctx_f64: f64,
+    ctx_handle: Handle,
+    reason: f64,
+) {
+    if let Some(ctx) = perry_ffi::get_handle_mut::<FastifyContext>(ctx_handle) {
+        ctx.status_code = 500;
+    }
+
+    if let Some(handler) = error_handler {
+        let call = unsafe {
+            let closure = JsClosure::from_raw(handler as *const RawClosureHeader);
+            if closure.is_null() {
+                ClosureCallResult {
+                    value: f64::from_bits(TAG_UNDEFINED),
+                    thrown: Some(reason),
+                }
+            } else {
+                call_closure3_catching(closure, reason, ctx_f64, ctx_f64)
+            }
+        };
+        let mut fallback_reason = call.thrown;
+
+        if fallback_reason.is_none() {
+            unsafe {
+                js_run_stdlib_pump();
+                js_promise_run_microtasks();
+            }
+
+            let mut final_result = call.value;
+            let jsv = JsValue::from_bits(call.value.to_bits());
+            if jsv.is_pointer() {
+                let ptr = jsv.as_pointer::<Promise>();
+                if !ptr.is_null() && unsafe { js_is_promise(ptr) } != 0 {
+                    wait_for_promise(ptr);
+                    if unsafe { js_promise_state(ptr) } == 2 {
+                        fallback_reason = Some(unsafe { js_promise_reason(ptr) });
+                    } else {
+                        final_result = unsafe { js_promise_value(ptr) };
+                    }
+                }
+            }
+
+            if fallback_reason.is_none() {
+                if let Some(ctx) = perry_ffi::get_handle_mut::<FastifyContext>(ctx_handle) {
+                    if ctx.response_body.is_none() {
+                        ctx.response_body = Some(unsafe { build_response_body(final_result) });
+                    }
+                }
+                return;
+            }
+        }
+
+        if let Some(reason) = fallback_reason {
+            apply_default_error_response(ctx_handle, reason);
+        }
+    } else {
+        apply_default_error_response(ctx_handle, reason);
+    }
+}
+
+fn apply_default_error_response(ctx_handle: Handle, reason: f64) {
+    if let Some(ctx) = perry_ffi::get_handle_mut::<FastifyContext>(ctx_handle) {
+        ctx.status_code = 500;
+        ctx.response_body = Some(unsafe { render_rejection_body(reason) });
+    }
 }
 
 /// Wait until a promise settles, driving microtasks, the stdlib pump,
@@ -646,6 +831,14 @@ fn wait_for_promise(promise_ptr: *mut Promise) {
 /// generic envelope if the reason can't be stringified (e.g. opaque
 /// pointer that JSON.stringify rejects).
 unsafe fn render_rejection_body(reason: f64) -> Vec<u8> {
+    if let Some(message) = error_message(reason) {
+        let mut out =
+            b"{\"statusCode\":500,\"error\":\"Internal Server Error\",\"message\":".to_vec();
+        push_json_string(&mut out, message.as_bytes());
+        out.push(b'}');
+        return out;
+    }
+
     // Strings: wrap the user's message verbatim.
     let jsv = JsValue::from_bits(reason.to_bits());
     if jsv.is_string() {
@@ -698,6 +891,51 @@ unsafe fn render_rejection_body(reason: f64) -> Vec<u8> {
     }
     out.push(b'}');
     out
+}
+
+unsafe fn error_message(reason: f64) -> Option<String> {
+    let jsv = JsValue::from_bits(reason.to_bits());
+    if jsv.is_pointer() {
+        let ptr = jsv.as_pointer::<u8>();
+        if gc_obj_type(ptr) == GC_TYPE_ERROR {
+            let msg = js_error_get_message(ptr as *mut ErrorHeader);
+            return string_header_to_string(msg);
+        }
+    }
+    None
+}
+
+unsafe fn gc_obj_type(ptr: *const u8) -> u8 {
+    if ptr.is_null() || (ptr as usize) < 0x1000 {
+        return 0;
+    }
+    *ptr.sub(GC_HEADER_SIZE)
+}
+
+unsafe fn string_header_to_string(ptr: *const StringHeader) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    let len = (*ptr).byte_len as usize;
+    let data_ptr = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+    let bytes = std::slice::from_raw_parts(data_ptr, len);
+    Some(String::from_utf8_lossy(bytes).to_string())
+}
+
+fn push_json_string(out: &mut Vec<u8>, bytes: &[u8]) {
+    out.push(b'"');
+    for &b in bytes {
+        match b {
+            b'"' => out.extend_from_slice(b"\\\""),
+            b'\\' => out.extend_from_slice(b"\\\\"),
+            b'\n' => out.extend_from_slice(b"\\n"),
+            b'\r' => out.extend_from_slice(b"\\r"),
+            b'\t' => out.extend_from_slice(b"\\t"),
+            0x00..=0x1f => out.extend_from_slice(format!("\\u{:04x}", b).as_bytes()),
+            _ => out.push(b),
+        }
+    }
+    out.push(b'"');
 }
 
 /// Render the handler return value as response bytes. Handlers can

--- a/crates/perry-stdlib/src/fastify/server.rs
+++ b/crates/perry-stdlib/src/fastify/server.rs
@@ -10,6 +10,7 @@ use hyper::{body::Incoming, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::os::raw::c_int;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
@@ -18,6 +19,17 @@ use perry_runtime::{js_string_from_bytes, JSValue, StringHeader};
 
 use super::{ClosurePtr, FastifyApp, FastifyContext};
 use crate::common::{get_handle, register_handle, Handle, RUNTIME};
+
+struct ClosureCallResult {
+    value: f64,
+    thrown: Option<f64>,
+}
+
+enum HookOutcome {
+    Continue,
+    Sent,
+    Error(f64),
+}
 
 /// Server handle for managing the running server
 pub struct FastifyServerHandle {
@@ -306,6 +318,7 @@ fn event_loop(app_handle: Handle, request_rx: &mut mpsc::Receiver<FastifyPending
             let ctx_handle = register_handle(ctx);
 
             // Find matching route and call handler
+            let error_handler = app.error_handler;
             let mut response_sent = false;
 
             // NaN-box the context handle with POINTER_TAG for hook calls
@@ -318,18 +331,44 @@ fn event_loop(app_handle: Handle, request_rx: &mut mpsc::Receiver<FastifyPending
 
             // Run onRequest hooks (e.g., auth middleware, rate limiting, CORS)
             for hook in &on_request_hooks {
-                if unsafe { call_hook_awaiting(*hook, nanboxed_ctx_for_hooks, ctx_handle) } {
-                    response_sent = true;
-                    break;
+                match unsafe { call_hook_awaiting(*hook, nanboxed_ctx_for_hooks, ctx_handle) } {
+                    HookOutcome::Continue => {}
+                    HookOutcome::Sent => {
+                        response_sent = true;
+                        break;
+                    }
+                    HookOutcome::Error(reason) => {
+                        handle_error_response(
+                            error_handler,
+                            nanboxed_ctx_for_hooks,
+                            ctx_handle,
+                            reason,
+                        );
+                        response_sent = true;
+                        break;
+                    }
                 }
             }
 
             // Run preHandler hooks (if no response sent yet)
             if !response_sent {
                 for hook in &pre_handler_hooks {
-                    if unsafe { call_hook_awaiting(*hook, nanboxed_ctx_for_hooks, ctx_handle) } {
-                        response_sent = true;
-                        break;
+                    match unsafe { call_hook_awaiting(*hook, nanboxed_ctx_for_hooks, ctx_handle) } {
+                        HookOutcome::Continue => {}
+                        HookOutcome::Sent => {
+                            response_sent = true;
+                            break;
+                        }
+                        HookOutcome::Error(reason) => {
+                            handle_error_response(
+                                error_handler,
+                                nanboxed_ctx_for_hooks,
+                                ctx_handle,
+                                reason,
+                            );
+                            response_sent = true;
+                            break;
+                        }
                     }
                 }
             }
@@ -348,19 +387,25 @@ fn event_loop(app_handle: Handle, request_rx: &mut mpsc::Receiver<FastifyPending
                     let nanboxed_ctx = nanboxed_ctx_for_hooks; // same value, different name for clarity
 
                     // Call handler(request, reply) - both are the context handle
-                    let result = {
+                    let call = {
                         let closure_ptr = handler as *const perry_runtime::ClosureHeader;
-                        perry_runtime::js_closure_call2(closure_ptr, nanboxed_ctx, nanboxed_ctx)
+                        unsafe { call_closure2_catching(closure_ptr, nanboxed_ctx, nanboxed_ctx) }
                     };
+                    if let Some(reason) = call.thrown {
+                        handle_error_response(error_handler, nanboxed_ctx, ctx_handle, reason);
+                        response_sent = true;
+                    }
 
                     // Process any async operations
                     crate::common::js_stdlib_process_pending();
                     perry_runtime::js_promise_run_microtasks();
 
                     // Check if handler returned a promise (NaN-boxed pointer to a Promise)
-                    final_result = result;
-                    let jsv = JSValue::from_bits(result.to_bits());
-                    if jsv.is_pointer() {
+                    if !response_sent {
+                        final_result = call.value;
+                    }
+                    let jsv = JSValue::from_bits(call.value.to_bits());
+                    if !response_sent && jsv.is_pointer() {
                         let ptr = jsv.as_pointer::<perry_runtime::Promise>();
                         // Try to treat it as a promise and wait for it
                         if { perry_runtime::js_is_promise(ptr as *mut perry_runtime::Promise) } != 0
@@ -378,17 +423,17 @@ fn event_loop(app_handle: Handle, request_rx: &mut mpsc::Receiver<FastifyPending
                                 perry_runtime::js_promise_state(ptr as *mut perry_runtime::Promise)
                             };
                             if st == 2 {
-                                if let Some(ctx) =
-                                    { crate::common::get_handle_mut::<FastifyContext>(ctx_handle) }
-                                {
-                                    ctx.status_code = 500;
-                                    let reason = {
-                                        perry_runtime::promise::js_promise_reason(
-                                            ptr as *mut perry_runtime::Promise,
-                                        )
-                                    };
-                                    ctx.response_body = Some(render_rejection_body(reason));
-                                }
+                                let reason = {
+                                    perry_runtime::promise::js_promise_reason(
+                                        ptr as *mut perry_runtime::Promise,
+                                    )
+                                };
+                                handle_error_response(
+                                    error_handler,
+                                    nanboxed_ctx,
+                                    ctx_handle,
+                                    reason,
+                                );
                                 final_result = f64::from_bits(0x7FFC_0000_0000_0001);
                             } else {
                                 final_result = {
@@ -434,30 +479,154 @@ fn event_loop(app_handle: Handle, request_rx: &mut mpsc::Receiver<FastifyPending
     }
 }
 
-/// Call a hook closure, await any returned Promise, and return whether ctx.sent is true.
-/// Returns true if the hook sent a response (e.g., 401 from auth middleware).
-unsafe fn call_hook_awaiting(hook: ClosurePtr, ctx_f64: f64, ctx_handle: Handle) -> bool {
+/// Call a hook closure, await any returned Promise, and report whether it
+/// sent a response or threw/rejected.
+unsafe fn call_hook_awaiting(hook: ClosurePtr, ctx_f64: f64, ctx_handle: Handle) -> HookOutcome {
     let closure_ptr = hook as *const perry_runtime::ClosureHeader;
-    let result = perry_runtime::js_closure_call2(closure_ptr, ctx_f64, ctx_f64);
+    let call = call_closure2_catching(closure_ptr, ctx_f64, ctx_f64);
+    if let Some(reason) = call.thrown {
+        return HookOutcome::Error(reason);
+    }
 
     // Process pending async operations
     crate::common::js_stdlib_process_pending();
     perry_runtime::js_promise_run_microtasks();
 
     // If hook returned a Promise, wait for it to resolve/reject
-    let jsv = JSValue::from_bits(result.to_bits());
+    let jsv = JSValue::from_bits(call.value.to_bits());
     if jsv.is_pointer() {
         let ptr = jsv.as_pointer::<perry_runtime::Promise>();
         if perry_runtime::js_is_promise(ptr as *mut perry_runtime::Promise) != 0 {
             wait_for_promise(ptr as *mut perry_runtime::Promise);
+            if perry_runtime::js_promise_state(ptr as *mut perry_runtime::Promise) == 2 {
+                return HookOutcome::Error(perry_runtime::promise::js_promise_reason(
+                    ptr as *mut perry_runtime::Promise,
+                ));
+            }
         }
     }
 
     // Return whether the hook sent a response (e.g., auth middleware sent 401)
     if let Some(ctx) = get_handle::<FastifyContext>(ctx_handle) {
-        ctx.sent
+        if ctx.sent {
+            HookOutcome::Sent
+        } else {
+            HookOutcome::Continue
+        }
     } else {
-        false
+        HookOutcome::Continue
+    }
+}
+
+unsafe fn call_closure2_catching(
+    closure_ptr: *const perry_runtime::ClosureHeader,
+    arg0: f64,
+    arg1: f64,
+) -> ClosureCallResult {
+    let trap_buf = perry_runtime::exception::js_try_push();
+    let jumped = perry_runtime::ffi::setjmp::setjmp(trap_buf as *mut c_int);
+    if jumped != 0 {
+        let exc = perry_runtime::exception::js_get_exception();
+        perry_runtime::exception::js_clear_exception();
+        perry_runtime::exception::js_try_end();
+        return ClosureCallResult {
+            value: f64::from_bits(0x7FFC_0000_0000_0001),
+            thrown: Some(exc),
+        };
+    }
+
+    let value = perry_runtime::js_closure_call2(closure_ptr, arg0, arg1);
+    perry_runtime::exception::js_try_end();
+    ClosureCallResult {
+        value,
+        thrown: None,
+    }
+}
+
+unsafe fn call_closure3_catching(
+    closure_ptr: *const perry_runtime::ClosureHeader,
+    arg0: f64,
+    arg1: f64,
+    arg2: f64,
+) -> ClosureCallResult {
+    let trap_buf = perry_runtime::exception::js_try_push();
+    let jumped = perry_runtime::ffi::setjmp::setjmp(trap_buf as *mut c_int);
+    if jumped != 0 {
+        let exc = perry_runtime::exception::js_get_exception();
+        perry_runtime::exception::js_clear_exception();
+        perry_runtime::exception::js_try_end();
+        return ClosureCallResult {
+            value: f64::from_bits(0x7FFC_0000_0000_0001),
+            thrown: Some(exc),
+        };
+    }
+
+    let value = perry_runtime::js_closure_call3(closure_ptr, arg0, arg1, arg2);
+    perry_runtime::exception::js_try_end();
+    ClosureCallResult {
+        value,
+        thrown: None,
+    }
+}
+
+fn handle_error_response(
+    error_handler: Option<ClosurePtr>,
+    ctx_f64: f64,
+    ctx_handle: Handle,
+    reason: f64,
+) {
+    if let Some(ctx) = crate::common::get_handle_mut::<FastifyContext>(ctx_handle) {
+        ctx.status_code = 500;
+    }
+
+    if let Some(handler) = error_handler {
+        let closure_ptr = handler as *const perry_runtime::ClosureHeader;
+        let call = unsafe { call_closure3_catching(closure_ptr, reason, ctx_f64, ctx_f64) };
+        let mut fallback_reason = call.thrown;
+
+        if fallback_reason.is_none() {
+            crate::common::js_stdlib_process_pending();
+            perry_runtime::js_promise_run_microtasks();
+
+            let mut final_result = call.value;
+            let jsv = JSValue::from_bits(call.value.to_bits());
+            if jsv.is_pointer() {
+                let ptr = jsv.as_pointer::<perry_runtime::Promise>();
+                if perry_runtime::js_is_promise(ptr as *mut perry_runtime::Promise) != 0 {
+                    wait_for_promise(ptr as *mut perry_runtime::Promise);
+                    if perry_runtime::js_promise_state(ptr as *mut perry_runtime::Promise) == 2 {
+                        fallback_reason = Some(perry_runtime::promise::js_promise_reason(
+                            ptr as *mut perry_runtime::Promise,
+                        ));
+                    } else {
+                        final_result =
+                            perry_runtime::js_promise_value(ptr as *mut perry_runtime::Promise);
+                    }
+                }
+            }
+
+            if fallback_reason.is_none() {
+                if let Some(ctx) = crate::common::get_handle_mut::<FastifyContext>(ctx_handle) {
+                    if ctx.response_body.is_none() {
+                        ctx.response_body = Some(build_response_body(final_result));
+                    }
+                }
+                return;
+            }
+        }
+
+        if let Some(reason) = fallback_reason {
+            apply_default_error_response(ctx_handle, reason);
+        }
+    } else {
+        apply_default_error_response(ctx_handle, reason);
+    }
+}
+
+fn apply_default_error_response(ctx_handle: Handle, reason: f64) {
+    if let Some(ctx) = crate::common::get_handle_mut::<FastifyContext>(ctx_handle) {
+        ctx.status_code = 500;
+        ctx.response_body = Some(render_rejection_body(reason));
     }
 }
 
@@ -522,6 +691,14 @@ fn wait_for_promise(promise_ptr: *mut perry_runtime::Promise) {
 /// for the 500 response surfaced by the dispatcher on async-handler
 /// rejection (issue #748).
 fn render_rejection_body(reason: f64) -> Vec<u8> {
+    if let Some(message) = error_message(reason) {
+        let mut out =
+            b"{\"statusCode\":500,\"error\":\"Internal Server Error\",\"message\":".to_vec();
+        push_json_string(&mut out, message.as_bytes());
+        out.push(b'}');
+        return out;
+    }
+
     let jsv = JSValue::from_bits(reason.to_bits());
     if jsv.is_string() {
         let s = build_response_body(reason);
@@ -576,6 +753,52 @@ fn render_rejection_body(reason: f64) -> Vec<u8> {
     }
     out.push(b'}');
     out
+}
+
+fn error_message(reason: f64) -> Option<String> {
+    let jsv = JSValue::from_bits(reason.to_bits());
+    if jsv.is_pointer() {
+        let ptr = jsv.as_pointer::<u8>();
+        if unsafe { gc_obj_type(ptr) } == perry_runtime::gc::GC_TYPE_ERROR {
+            let err = ptr as *mut perry_runtime::error::ErrorHeader;
+            let msg = perry_runtime::error::js_error_get_message(err);
+            return unsafe { string_header_to_string(msg) };
+        }
+    }
+    None
+}
+
+unsafe fn gc_obj_type(ptr: *const u8) -> u8 {
+    if ptr.is_null() || (ptr as usize) < 0x1000 {
+        return 0;
+    }
+    *ptr.sub(perry_runtime::gc::GC_HEADER_SIZE)
+}
+
+unsafe fn string_header_to_string(ptr: *const StringHeader) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    let len = (*ptr).byte_len as usize;
+    let data_ptr = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+    let bytes = std::slice::from_raw_parts(data_ptr, len);
+    Some(String::from_utf8_lossy(bytes).to_string())
+}
+
+fn push_json_string(out: &mut Vec<u8>, bytes: &[u8]) {
+    out.push(b'"');
+    for &b in bytes {
+        match b {
+            b'"' => out.extend_from_slice(b"\\\""),
+            b'\\' => out.extend_from_slice(b"\\\\"),
+            b'\n' => out.extend_from_slice(b"\\n"),
+            b'\r' => out.extend_from_slice(b"\\r"),
+            b'\t' => out.extend_from_slice(b"\\t"),
+            0x00..=0x1f => out.extend_from_slice(format!("\\u{:04x}", b).as_bytes()),
+            _ => out.push(b),
+        }
+    }
+    out.push(b'"');
 }
 
 /// Build response body from handler return value

--- a/scripts/run_fastify_tests.sh
+++ b/scripts/run_fastify_tests.sh
@@ -132,6 +132,28 @@ code="$(curl -s --max-time 5 -o /dev/null -w '%{http_code}' \
     "http://127.0.0.1:$PORT/does-not-exist" || true)"
 check "GET /does-not-exist -> 404" "404" "$code"
 
+# Test 5: sync throw is caught by Fastify boundary and does not kill the server.
+code_and_body="$(curl -s --max-time 5 -o "$TMP_DIR/throw_sync_body" -w '%{http_code}' \
+    "http://127.0.0.1:$PORT/throw-sync" || true)"
+throw_sync_body="$(cat "$TMP_DIR/throw_sync_body" 2>/dev/null || true)"
+check "GET /throw-sync status" "500" "$code_and_body"
+check "GET /throw-sync body" \
+    '{"statusCode":500,"error":"Internal Server Error","message":"sync route boom"}' \
+    "$throw_sync_body"
+
+# Test 6: async throw/rejection follows the same default error response path.
+code_and_body="$(curl -s --max-time 5 -o "$TMP_DIR/throw_async_body" -w '%{http_code}' \
+    "http://127.0.0.1:$PORT/throw-async" || true)"
+throw_async_body="$(cat "$TMP_DIR/throw_async_body" 2>/dev/null || true)"
+check "GET /throw-async status" "500" "$code_and_body"
+check "GET /throw-async body" \
+    '{"statusCode":500,"error":"Internal Server Error","message":"async route boom"}' \
+    "$throw_async_body"
+
+# Test 7: server remains alive after thrown route errors.
+actual="$(curl -s --max-time 5 "http://127.0.0.1:$PORT/hello" || true)"
+check "GET /hello after throw" '{"hello":"world"}' "$actual"
+
 echo
 echo "fastify-tests: $pass passed, $fail failed"
 

--- a/test-files/test_fastify_integration.ts
+++ b/test-files/test_fastify_integration.ts
@@ -22,6 +22,14 @@ app.post("/echo", async (request, reply) => {
   return { received: request.body };
 });
 
+app.get("/throw-sync", (_request, _reply) => {
+  throw new Error("sync route boom");
+});
+
+app.get("/throw-async", async (_request, _reply) => {
+  throw new Error("async route boom");
+});
+
 app.listen({ port: port }, () => {
   // Sentinel line the harness waits for before starting curl assertions.
   console.log("ready port=" + port);


### PR DESCRIPTION
## Summary

Closes #928.

- Add Perry `try`/`setjmp` traps around native Fastify route handlers, `onRequest`/`preHandler` hooks, and custom `setErrorHandler` callbacks in both `perry-ext-fastify` and the in-tree stdlib Fastify implementation.
- Normalize sync throws and rejected Promises into Fastify-style error responses instead of letting `js_throw` exit the process when no try frame is active.
- Render built-in runtime `Error` values through `js_error_get_message` so default 500 bodies are stable and do not use generic JSON stringify on `ErrorHeader`.
- Add sync/async thrown-route regression coverage and assert the server remains alive after both failures.

## Root Cause

Async flag propagation was not the primary issue: async arrows/functions already reject their returned Promise for top-level throws. The native Fastify bridge was missing the framework error boundary. It invoked raw Perry closures from Rust without an active `js_try_push` frame, so sync throws from handlers, hooks, or nested helpers reached `js_throw` with `TRY_DEPTH == 0` and terminated the process.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo check -p perry-stdlib -p perry-ext-fastify`
- [x] `cargo build --release -p perry -p perry-runtime -p perry-stdlib -p perry-ext-fastify`
- [x] `PERRY_BIN="$PWD/target/release/perry" scripts/run_fastify_tests.sh` — `fastify-tests: 10 passed, 0 failed`
- [x] `cargo test --release -p perry-ext-fastify` — 10 passed
- [x] `cargo test --release -p perry-stdlib fastify` — 22 passed

## Contributor Metadata

Per `CONTRIBUTING.md`, this PR does not bump `[workspace.package]`, `CLAUDE.md`, or `CHANGELOG.md`; release metadata is left for the maintainer at merge time.
