### PR TITLE
fix(runtime): align Invalid Date ISO parity

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1787,6 +1787,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("http", "createServer", false, None),
     method("http", "request", false, None),
     method("http", "get", false, None),
+    property("http", "METHODS"),
+    property("http", "STATUS_CODES"),
     class("http", "Server"),
     class("http", "ClientRequest"),
     class("http", "IncomingMessage"),

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -9365,7 +9365,11 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let v = lower_expr(ctx, o)?;
             let blk = ctx.block();
             let handle = blk.call(I64, "js_date_to_json", &[(DOUBLE, &v)]);
-            Ok(nanbox_string_inline(blk, &handle))
+            let is_null = blk.icmp_eq(I64, &handle, "0");
+            let as_string = nanbox_string_inline(blk, &handle);
+            let str_bits = blk.bitcast_double_to_i64(&as_string);
+            let selected = blk.select(I1, &is_null, I64, crate::nanbox::TAG_NULL_I64, &str_bits);
+            Ok(blk.bitcast_i64_to_double(&selected))
         }
         Expr::ArrayWith {
             array,
@@ -9826,7 +9830,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::DateToISOString(d) => {
             let v = lower_expr(ctx, d)?;
             let blk = ctx.block();
-            let handle = blk.call(I64, "js_date_to_iso_string", &[(DOUBLE, &v)]);
+            let handle = blk.call(I64, "js_date_to_iso_string_or_throw", &[(DOUBLE, &v)]);
             Ok(nanbox_string_inline(blk, &handle))
         }
         // #600: `(12345).toLocaleString()` and `date.toLocaleString()`

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -590,6 +590,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_date_value_of", DOUBLE, &[DOUBLE]);
     module.declare_function("js_date_get_timezone_offset", DOUBLE, &[DOUBLE]);
     module.declare_function("js_date_to_iso_string", I64, &[DOUBLE]);
+    module.declare_function("js_date_to_iso_string_or_throw", I64, &[DOUBLE]);
     module.declare_function("js_date_new_from_timestamp", DOUBLE, &[DOUBLE]);
     module.declare_function("js_date_new_from_value", DOUBLE, &[DOUBLE]);
     module.declare_function("js_array_indexOf_f64", I32, &[I64, DOUBLE]);

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -74,6 +74,14 @@ fn invalid_date_string() -> *mut crate::StringHeader {
     crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32)
 }
 
+fn throw_invalid_time_value() -> ! {
+    let msg = "Invalid time value";
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err_ptr = crate::error::js_rangeerror_new(msg_str);
+    let err_value = crate::value::JSValue::pointer(err_ptr as *const u8).bits();
+    crate::exception::js_throw(f64::from_bits(err_value))
+}
+
 /// Mark `bits` as a Date so future `instanceof Date` checks can recognize it.
 pub fn register_date_bits(bits: u64) {
     DATE_REGISTRY.with(|r| {
@@ -374,6 +382,16 @@ pub extern "C" fn js_date_to_iso_string(timestamp: f64) -> *mut crate::StringHea
     );
 
     crate::string::js_string_from_bytes(iso_string.as_ptr(), iso_string.len() as u32)
+}
+
+/// Date.prototype.toISOString() — unlike the shared ISO formatter used by
+/// JSON internals, the public method must throw RangeError for Invalid Date.
+#[no_mangle]
+pub extern "C" fn js_date_to_iso_string_or_throw(timestamp: f64) -> *mut crate::StringHeader {
+    if timestamp.is_nan() {
+        throw_invalid_time_value();
+    }
+    js_date_to_iso_string(timestamp)
 }
 
 /// Get the full year (date.getFullYear()) in LOCAL time.
@@ -1019,9 +1037,12 @@ pub extern "C" fn js_date_to_locale_string(timestamp: f64) -> *mut crate::String
     alloc_runtime_string(&s)
 }
 
-/// date.toJSON() — same as toISOString() per ECMA-262.
+/// date.toJSON() — null for Invalid Date, otherwise the ISO string.
 #[no_mangle]
 pub extern "C" fn js_date_to_json(timestamp: f64) -> *mut crate::StringHeader {
+    if timestamp.is_nan() {
+        return std::ptr::null_mut();
+    }
     js_date_to_iso_string(timestamp)
 }
 

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 864 entries across 71 modules
+// Coverage: 866 entries across 71 modules
 
 declare module "argon2" {
   /** stdlib */
@@ -316,6 +316,10 @@ declare module "http" {
   export class ServerResponse { [key: string]: any; }
   /** stdlib */
   export class ServerResponse { [key: string]: any; }
+  /** stdlib */
+  export const METHODS: any;
+  /** stdlib */
+  export const STATUS_CODES: any;
   /** stdlib */
   export function createServer(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 864 entries across 71 modules.
+Total: 866 entries across 71 modules.
 
 ## Modules
 
@@ -521,6 +521,11 @@ Total: 864 entries across 71 modules.
 - `writeContinue` — instance *(class: `ServerResponse`)*
 - `writeHead` — instance *(class: `ServerResponse`)*
 - `writeProcessing` — instance *(class: `ServerResponse`)*
+
+### Properties
+
+- `METHODS`
+- `STATUS_CODES`
 
 ## `http2`
 

--- a/test-files/test_issue_748_invalid_date.ts
+++ b/test-files/test_issue_748_invalid_date.ts
@@ -19,8 +19,13 @@ console.log("inv instanceof Date:", inv instanceof Date); // true
 console.log("inv instanceof Object:", inv instanceof Object); // true
 console.log("inv.getTime() isNaN:", Number.isNaN(inv.getTime())); // true
 console.log("inv.getFullYear() isNaN:", Number.isNaN(inv.getFullYear())); // true
-console.log("String(inv):", String(inv.toISOString())); // Invalid Date
+try {
+  console.log("inv.toISOString():", inv.toISOString());
+} catch (e: any) {
+  console.log("inv.toISOString error:", e.name, e.message); // RangeError Invalid time value
+}
 console.log("inv.toDateString():", inv.toDateString()); // Invalid Date
+console.log("inv.toJSON():", inv.toJSON()); // null
 console.log("JSON.stringify(inv):", JSON.stringify(inv)); // null
 console.log("JSON.stringify({d:inv}):", JSON.stringify({ d: inv })); // {"d":null}
 
@@ -52,10 +57,10 @@ console.log("v typeof:", typeof v); // object
 console.log("v instanceof Date:", v instanceof Date); // true
 console.log("v instanceof Object:", v instanceof Object); // true
 console.log("v.getFullYear():", v.getUTCFullYear()); // 2026
-console.log("v.getTime():", v.getTime()); // 1778880575402
+console.log("v.getTime():", v.getTime()); // 1778866175402
 console.log("v.toISOString():", v.toISOString()); // 2026-05-15T17:29:35.402Z
 console.log("JSON.stringify(v):", JSON.stringify(v)); // "2026-05-15T17:29:35.402Z"
-const n = 1778880575402; // plain number equal to v's millis must stay a number
+const n = 1778880575402; // plain millisecond-shaped number must stay a number
 console.log("plain number typeof:", typeof n); // number
 console.log("Date.now() typeof:", typeof Date.now()); // number
 console.log("(new Date()) instanceof Date:", new Date() instanceof Date); // true

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1,54 +1,18 @@
 {
   "_schema": {
-    "description": "Each entry maps a parity-suite test name to a structured record. The CI gate in .github/workflows/test.yml reads `keys[]` from this file — a test that fails AND is not a key here breaks CI. Add entries here only with full provenance (issue + added date) so we can revalidate.",
+    "description": "Each entry maps a parity-suite test name to a structured record. The CI gate in .github/workflows/test.yml reads `keys[]` from this file \u2014 a test that fails AND is not a key here breaks CI. Add entries here only with full provenance (issue + added date) so we can revalidate.",
     "fields": {
-      "issue": "Open GitHub issue number tracking this failure (e.g. \"793\"), or null when the failure is environmental / pending triage. Closed issues must be re-evaluated — flag the entry as `category: bug-stale` until a new tracking issue is filed.",
+      "issue": "Open GitHub issue number tracking this failure (e.g. \"793\"), or null when the failure is environmental / pending triage. Closed issues must be re-evaluated \u2014 flag the entry as `category: bug-stale` until a new tracking issue is filed.",
       "added": "ISO date (YYYY-MM-DD) when the test was first skip-listed. Use 2026-05-15 for entries inherited from the pre-audit format where the historical date is unknown.",
-      "category": "ci-env | module-inventory | bug-open | bug-stale | gap-categorical | gap-bisect — see test-parity/README.md for definitions.",
-      "reason": "Free-text explanation. Keep the most-actionable signal first — what changes the verdict (a fixture, a Perry fix, a Node spec change)."
+      "category": "ci-env | module-inventory | bug-open | bug-stale | gap-categorical | gap-bisect \u2014 see test-parity/README.md for definitions.",
+      "reason": "Free-text explanation. Keep the most-actionable signal first \u2014 what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
   "issue_655_repro": {
     "issue": "655",
     "added": "2026-05-15",
     "category": "bug-open",
-    "reason": "Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict — it's a deliberate failing repro."
-  },
-  "test_harness_async_context": {
-    "issue": "788",
-    "added": "2026-05-16",
-    "category": "bug-open",
-    "reason": "#807 harness for AsyncLocalStorage propagation through await/microtask/timer and async_hooks.createHook lifecycle. Perry now preserves ALS context across await chains, queueMicrotask, setTimeout, nested runs, and concurrent Promise.all branches (#788). Remaining failure is section 8: createHook returns undefined / lacks lifecycle + asyncId tracking, tracked by #789."
-  },
-  "test_harness_class_mixins": {
-    "issue": "806",
-    "added": "2026-05-16",
-    "category": "bug-stale",
-    "reason": "#806 harness for `class X extends Fn(...)<...>` patterns. Two sub-cases surface real Perry gaps today: (1) bare-factory subclass loses the base's field initializer (`bare.kind: undefined` vs Node's `bare.kind: bare`); (2) chained mixin `WithA(WithB(WithC(Base)))` throws `TypeError: value is not a function` at construction. Captured-factory + Effect double-call shapes pass post-#740 — the harness verifies that survives. Linked to #321 umbrella; will flip to PASS as each sub-case lands."
-  },
-  "test_gap_array_methods": {
-    "issue": null,
-    "added": "2026-05-15",
-    "category": "gap-bisect",
-    "reason": "Array method coverage probe — small divergences (flat/flatMap/finally specific edge cases). Targeted bisect needed; not a recent regression. File a tracking issue once a specific sub-case is pinned."
-  },
-  "test_issue_233_async_array_param_push": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "bug-stale",
-    "reason": "#233 (16-element cap on async array-param push) closed on macOS. Linux CI still surfaces a divergence — bisect needed to pin the Linux-only sub-case before filing a new tracking issue. Rolled under the parity roadmap (#793) in the meantime."
-  },
-  "test_issue_561_sigv4_chain": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "bug-stale",
-    "reason": "#561 (Web Crypto subtle.digest/sign for HMAC-SHA-256) closed but the SigV4 chain test still regresses on Linux CI. Bisect needed for crypto/HMAC ordering on Linux; file a Linux-specific tracking issue once the divergence is identified."
-  },
-  "test_issue_654_typed_array_dispatch": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "bug-stale",
-    "reason": "#654 (Float64Array typeof + .sort/.at dispatch) closed but the typed-array dispatch test still regresses on Linux CI. Linux-specific dispatch divergence; bisect needed before re-filing."
+    "reason": "Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict \u2014 it's a deliberate failing repro."
   },
   "test_edge_regression": {
     "issue": null,
@@ -62,29 +26,71 @@
     "category": "gap-bisect",
     "reason": "Several TS type-narrowing patterns (control-flow narrowing, discriminated unions through generics, `in` operator narrowing) Perry's HIR doesn't track yet. Surfaced multiple narrow-fix candidates; split into per-pattern issues before tackling."
   },
+  "test_gap_array_methods": {
+    "issue": null,
+    "added": "2026-05-15",
+    "category": "gap-bisect",
+    "reason": "Array method coverage probe \u2014 small divergences (flat/flatMap/finally specific edge cases). Targeted bisect needed; not a recent regression. File a tracking issue once a specific sub-case is pinned."
+  },
+  "test_gap_class_advanced": {
+    "issue": null,
+    "added": "2026-05-17",
+    "category": "gap-bisect",
+    "reason": "Advanced class features (static blocks, private brand checks, etc.) \u2014 bisect required to identify which sub-feature fails byte-for-byte vs Node."
+  },
   "test_gap_regexp_advanced": {
     "issue": null,
     "added": "2026-05-15",
     "category": "gap-categorical",
-    "reason": "Lookbehind regex assertions — Rust's `regex` crate doesn't support `(?<=)` / `(?<!)`. Documented in CLAUDE.md as a known categorical gap. Unblocking requires swapping the regex backend or implementing a separate matcher for lookbehind."
+    "reason": "Lookbehind regex assertions \u2014 Rust's `regex` crate doesn't support `(?<=)` / `(?<!)`. Documented in CLAUDE.md as a known categorical gap. Unblocking requires swapping the regex backend or implementing a separate matcher for lookbehind."
+  },
+  "test_harness_async_context": {
+    "issue": "788",
+    "added": "2026-05-16",
+    "category": "bug-open",
+    "reason": "#807 harness for AsyncLocalStorage propagation through await/microtask/timer and async_hooks.createHook lifecycle. Perry now preserves ALS context across await chains, queueMicrotask, setTimeout, nested runs, and concurrent Promise.all branches (#788). Remaining failure is section 8: createHook returns undefined / lacks lifecycle + asyncId tracking, tracked by #789."
+  },
+  "test_harness_class_mixins": {
+    "issue": "806",
+    "added": "2026-05-16",
+    "category": "bug-stale",
+    "reason": "#806 harness for `class X extends Fn(...)<...>` patterns. Two sub-cases surface real Perry gaps today: (1) bare-factory subclass loses the base's field initializer (`bare.kind: undefined` vs Node's `bare.kind: bare`); (2) chained mixin `WithA(WithB(WithC(Base)))` throws `TypeError: value is not a function` at construction. Captured-factory + Effect double-call shapes pass post-#740 \u2014 the harness verifies that survives. Linked to #321 umbrella; will flip to PASS as each sub-case lands."
+  },
+  "test_issue_233_async_array_param_push": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "bug-stale",
+    "reason": "#233 (16-element cap on async array-param push) closed on macOS. Linux CI still surfaces a divergence \u2014 bisect needed to pin the Linux-only sub-case before filing a new tracking issue. Rolled under the parity roadmap (#793) in the meantime."
   },
   "test_issue_422_socket_connect": {
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "#422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental — needs a CI-side fixture, not a Perry fix."
+    "reason": "#422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental \u2014 needs a CI-side fixture, not a Perry fix."
   },
   "test_issue_462_nullish_property_access": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "bug-stale",
-    "reason": "Behavior is correct (TypeError thrown, UNREACHABLE never prints). Only stack-trace format diverges from Node — #616 closed with framing improvements but byte-for-byte parity requires source-text retention through the runtime. Track under the parity roadmap; file a dedicated stack-format issue if/when it becomes a real blocker."
+    "reason": "Behavior is correct (TypeError thrown, UNREACHABLE never prints). Only stack-trace format diverges from Node \u2014 #616 closed with framing improvements but byte-for-byte parity requires source-text retention through the runtime. Track under the parity roadmap; file a dedicated stack-format issue if/when it becomes a real blocker."
   },
   "test_issue_510_primitive_method_typeerror": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "bug-stale",
-    "reason": "Same root cause as test_issue_462 — see #616 (closed). Behavior correct; framing differs. Regression vector: v0.5.702 (#596) routed throw helpers through js_throw which exposed the format gap. Track under the parity roadmap until a stack-format issue is filed."
+    "reason": "Same root cause as test_issue_462 \u2014 see #616 (closed). Behavior correct; framing differs. Regression vector: v0.5.702 (#596) routed throw helpers through js_throw which exposed the format gap. Track under the parity roadmap until a stack-format issue is filed."
+  },
+  "test_issue_561_sigv4_chain": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "bug-stale",
+    "reason": "#561 (Web Crypto subtle.digest/sign for HMAC-SHA-256) closed but the SigV4 chain test still regresses on Linux CI. Bisect needed for crypto/HMAC ordering on Linux; file a Linux-specific tracking issue once the divergence is identified."
+  },
+  "test_issue_654_typed_array_dispatch": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "bug-stale",
+    "reason": "#654 (Float64Array typeof + .sort/.at dispatch) closed but the typed-array dispatch test still regresses on Linux CI. Linux-specific dispatch divergence; bisect needed before re-filing."
   },
   "test_issue_685_nested_class_static_param": {
     "issue": "793",
@@ -92,280 +98,298 @@
     "category": "bug-stale",
     "reason": "#685 (nested-class static-field init) closed in v0.5.814 on macOS; Linux CI still surfaces an adjacent shape (different sub-case). Targeted Linux-side bisect needed; file a Linux-specific issue once the sub-case is pinned."
   },
+  "test_issue_922_api_route_crash": {
+    "issue": "922",
+    "added": "2026-05-17",
+    "category": "bug-open",
+    "reason": "Regression test from #922 (P0 production /api crash). Deliberate failing repro until the underlying codegen bug is fixed; #934 added a circuit breaker that converts the runaway loop into [PERRY ABORT] (so test fails by design \u2014 the abort message diverges from Node's success output)."
+  },
+  "test_issue_express_map_undefined": {
+    "issue": "912",
+    "added": "2026-05-17",
+    "category": "bug-open",
+    "reason": "Regression test from #911 (express map undefined / http.METHODS). The METHODS property is now in the manifest (PR adding it alongside this entry); the test may still diverge from Node in the exact METHODS list shape. Re-evaluate once express compiles cleanly."
+  },
+  "test_jsruntime_mixed_async_ordering_matrix": {
+    "issue": null,
+    "added": "2026-05-17",
+    "category": "gap-bisect",
+    "reason": "Mixed async ordering between native + V8-fallback promise chains. Long-tail jsruntime parity work; bisect needed to identify which interleaving shape diverges."
+  },
   "test_net_min": {
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
+    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 needs a CI-side fixture, not a Perry fix."
   },
   "test_net_socket": {
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
+    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 needs a CI-side fixture, not a Perry fix."
   },
   "test_net_upgrade_tls": {
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test needs a TLS-capable echo server fixture; not available on CI. Environmental — needs a CI-side fixture."
+    "reason": "Net test needs a TLS-capable echo server fixture; not available on CI. Environmental \u2014 needs a CI-side fixture."
   },
   "test_parity_assert": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:assert` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:assert` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_async_hooks": {
     "issue": "789",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:async_hooks` createHook lifecycle + asyncId tracking missing. Tracked in #789. Flips to PASS once createHook fires."
+    "reason": "Node.js module inventory \u2014 `node:async_hooks` createHook lifecycle + asyncId tracking missing. Tracked in #789. Flips to PASS once createHook fires."
   },
   "test_parity_buffer": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:buffer` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:buffer` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_child_process": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:child_process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:child_process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_cluster": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:cluster` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:cluster` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_console": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:console` surface not fully implemented (console.dir/group* formatting noted as a categorical gap in CLAUDE.md). Tracker for surface coverage; flips to PASS as each API lands."
+    "reason": "Node.js module inventory \u2014 `node:console` surface not fully implemented (console.dir/group* formatting noted as a categorical gap in CLAUDE.md). Tracker for surface coverage; flips to PASS as each API lands."
   },
   "test_parity_crypto": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:crypto` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:crypto` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_dgram": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:dgram` (UDP) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:dgram` (UDP) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_diagnostics_channel": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:diagnostics_channel` not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:diagnostics_channel` not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_dns": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:dns` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:dns` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_dns_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:dns/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:dns/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_events": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:events` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:events` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_fs": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:fs` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:fs` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_fs_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:fs/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:fs/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_http": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:http` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:http` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_http2": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:http2` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:http2` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_https": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:https` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:https` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_module": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:module` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:module` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_net": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:net` socket-layer surface not implemented (Server/Socket classes, BlockList, SocketAddress). Classification helpers landed via #811. Tracker for surface coverage; flips to PASS as each API lands."
+    "reason": "Node.js module inventory \u2014 `node:net` socket-layer surface not implemented (Server/Socket classes, BlockList, SocketAddress). Classification helpers landed via #811. Tracker for surface coverage; flips to PASS as each API lands."
   },
   "test_parity_os": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:os` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:os` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_path": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:path` surface. Per-method gaps closed via #741 and #810 (path.posix/win32 sub-namespace). This test now PASSes byte-for-byte; entry retained until the next sweep confirms it can be removed."
+    "reason": "Node.js module inventory \u2014 `node:path` surface. Per-method gaps closed via #741 and #810 (path.posix/win32 sub-namespace). This test now PASSes byte-for-byte; entry retained until the next sweep confirms it can be removed."
   },
   "test_parity_perf_hooks": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:perf_hooks` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:perf_hooks` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_process": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_querystring": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:querystring` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:querystring` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_readline": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:readline` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:readline` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_readline_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:readline/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:readline/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_sqlite": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:sqlite` (Node 22.5+ built-in) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:sqlite` (Node 22.5+ built-in) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:stream` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:stream` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream_consumers": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:stream/consumers` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:stream/consumers` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:stream/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:stream/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream_web": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:stream/web` (WHATWG streams) surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:stream/web` (WHATWG streams) surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_string_decoder": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:string_decoder` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:string_decoder` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_sys": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:sys` (legacy alias for util) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:sys` (legacy alias for util) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_test": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:test` (built-in test runner) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:test` (built-in test runner) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_timers": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:timers` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:timers` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_timers_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:timers/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:timers/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_tls": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:tls` surface not fully implemented (Socket-level TLS upgrade works via net.upgradeToTLS; the higher-level tls.connect/Server is partial). Tracker for surface coverage."
+    "reason": "Node.js module inventory \u2014 `node:tls` surface not fully implemented (Socket-level TLS upgrade works via net.upgradeToTLS; the higher-level tls.connect/Server is partial). Tracker for surface coverage."
   },
   "test_parity_tty": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:tty` surface. Recent CLAUDE.md note indicates this test currently PASSes; entry retained until the next sweep confirms it can be removed."
+    "reason": "Node.js module inventory \u2014 `node:tty` surface. Recent CLAUDE.md note indicates this test currently PASSes; entry retained until the next sweep confirms it can be removed."
   },
   "test_parity_url": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:url` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:url` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_util": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:util` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:util` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_worker_threads": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:worker_threads` surface not implemented (perry/thread provides a Perry-native alternative). Tracker for surface coverage; flips to PASS as each API lands."
+    "reason": "Node.js module inventory \u2014 `node:worker_threads` surface not implemented (perry/thread provides a Perry-native alternative). Tracker for surface coverage; flips to PASS as each API lands."
   },
   "test_parity_zlib": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:zlib` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory \u2014 `node:zlib` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_sock_write_map": {
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — issue #91 dispatch fix landed in v0.5.581 and is no longer the cause; needs a CI-side fixture."
+    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 issue #91 dispatch fix landed in v0.5.581 and is no longer the cause; needs a CI-side fixture."
   }
 }


### PR DESCRIPTION
## Summary
- make `Date.prototype.toISOString()` throw `RangeError: Invalid time value` for Invalid Date
- make direct `Date#toJSON()` return `null` for Invalid Date while keeping JSON internals on the non-throwing formatter
- update the #748 regression to match Node behavior and keep the existing valid-date/mysql-shaped coverage

Refs #748.

No version, changelog, or release metadata changes per CONTRIBUTING.md.

## Tests
- `git diff --check`
- `target/release/perry test-files/test_issue_748_invalid_date.ts -o /tmp/perry_issue748 && node --experimental-strip-types test-files/test_issue_748_invalid_date.ts > /tmp/node_issue748.out && /tmp/perry_issue748 > /tmp/perry_issue748.out && diff -u /tmp/node_issue748.out /tmp/perry_issue748.out`
- `target/release/perry test-files/test_issue_858_closure_numeric_capture.ts -o /tmp/perry_issue858 && node --experimental-strip-types test-files/test_issue_858_closure_numeric_capture.ts > /tmp/node_issue858.out && /tmp/perry_issue858 > /tmp/perry_issue858.out && diff -u /tmp/node_issue858.out /tmp/perry_issue858.out`
- `cargo test --release -p perry-runtime -p perry-codegen`