### PR TITLE
fix(runtime): #928 — JSON.stringify(new Error(...)) segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.966 — fix(runtime): #928 — `JSON.stringify(new Error(...))` segfaulted on the built-in Error layout
+
+**Symptom.** `JSON.stringify(new Error("test"))` killed the process with SIGSEGV instead of returning `"{}"`. Same root cause surfaced as the user-visible "throw new Error from Fastify async route handler crashes the server" report in #928: PR #937 ("fix(fastify): catch thrown route errors") fixed the Fastify dispatch path to catch rejections + route them through `render_rejection_body`, but the rejection-body renderer's `js_json_stringify(reason, 0)` fallback still segfaulted on built-in Error reasons. The general `JSON.stringify(error)` call also still crashed, regardless of Fastify.
+
+**Root cause.** `stringify_value` and `stringify_value_depth` in `crates/perry-runtime/src/json.rs` dispatched on `gc_obj_type(ptr)` with arms for `GC_TYPE_ARRAY`, `GC_TYPE_OBJECT`, `GC_TYPE_STRING`, and a catch-all `_ =>`. Built-in `Error` (and `TypeError`/`RangeError`/etc.) allocations use a dedicated `ErrorHeader` struct with `GC_TYPE_ERROR = 7`, and the catch-all routed through `is_object_pointer(ptr)` → `stringify_object`, which assumed the JSObject keys/values layout. `stringify_object` derefed `ErrorHeader::error_kind` (the second u32 of an ErrorHeader) as a `keys_array` pointer and segfaulted on first access.
+
+User-defined subclasses (`class HttpError extends Error`) and primitive throws (`throw "msg"`, `throw { ... }`) all worked because they go through the regular Object/string paths — only the built-in `Error` constructor returns the special `ErrorHeader` layout. That matches the issue body's variant matrix exactly.
+
+**Fix.** `stringify_value` and `stringify_value_depth` add an explicit `GC_TYPE_ERROR` match arm that emits `"{}"`. Node's `JSON.stringify(new Error("x"))` returns `"{}"` (Error's intrinsic props `message`/`name`/`stack` are non-enumerable per spec); mirror that.
+
+**Validation.**
+
+- `JSON.stringify(new Error("test"))` returns `"{}"` (matches Node byte-for-byte).
+- `JSON.stringify(new TypeError("nope"))` returns `"{}"` (same path via `GC_TYPE_ERROR`).
+- Fastify repro from #928 (`throw new Error("Unauthorized")` from `app.get("/go", async () => {...})`) now returns HTTP 500 with `{"statusCode":500,"error":"Internal Server Error","message":"Unauthorized"}` — server stays alive, subsequent `/healthz` still serves 200. (PR #937 added the Fastify try-push + `error_message` short-circuit; this runtime fix closes the `js_json_stringify` fallback hole.)
+- Re-ran `test_compat_async_errors`, `test_edge_error_handling`, `test_gap_error_extensions`, `test_gap_json_advanced`, `test_json_sso_strings`, `test_issue_307_json_stringify_overflow_fields`, `test_issue_639_json_stringify_buffer`, `test_compat_strings_regex_json` — all match Node byte-for-byte.
+
+**Files touched.**
+
+- `crates/perry-runtime/src/json.rs` — explicit `GC_TYPE_ERROR` arm in both `stringify_value` and `stringify_value_depth`.
+- `test-files/test_issue_928_throw_in_async_arrow.ts` — regression test covering (1) async-arrow throw → rejection → catch, (2) `JSON.stringify(new Error(...))`, (3) `JSON.stringify(new TypeError(...))`.
+
 ## v0.5.965 — fix(codegen): #927 — `jwt.verify(token, key, opts)` returns parsed object, not JSON-stringified string
 
 **Symptom.** Authenticated `/api/*` routes in shop-admin's native server returned 401 after the very first request, even though signup itself worked end-to-end (HTTP 201, full JWT JSON written, all 5 tables populated). Minimal repro:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.965
+**Current Version:** 0.5.966
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.965"
+version = "0.5.966"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.965"
+version = "0.5.966"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.965"
+version = "0.5.966"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.965"
+version = "0.5.966"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.965"
+version = "0.5.966"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/json.rs
+++ b/crates/perry-runtime/src/json.rs
@@ -1813,6 +1813,17 @@ unsafe fn stringify_value(value: f64, type_hint: u32, buf: &mut String) {
                     buf.push_str("null");
                 }
             }
+            crate::gc::GC_TYPE_ERROR => {
+                // Issue #928: Built-in Error objects (and subclasses
+                // like TypeError) have a dedicated `ErrorHeader` layout —
+                // not the JSObject keys/values layout. Routing them
+                // through `stringify_object` derefs garbage as a
+                // `keys_array` pointer and segfaults the process.
+                // Node's `JSON.stringify(new Error("x"))` returns "{}"
+                // because Error's intrinsic props (`message`, `name`,
+                // `stack`) are non-enumerable; mirror that.
+                buf.push_str("{}");
+            }
             _ => {
                 // Unknown/untagged pointer: fall back to the structural
                 // heuristics for safety (e.g. pointers to non-GC-tracked
@@ -1926,6 +1937,10 @@ unsafe fn stringify_value_depth(value: f64, type_hint: u32, buf: &mut String, de
                 } else {
                     buf.push_str("null");
                 }
+            }
+            crate::gc::GC_TYPE_ERROR => {
+                // Issue #928: see the matching branch in `stringify_value`.
+                buf.push_str("{}");
             }
             _ => {
                 if is_object_pointer(ptr) {

--- a/test-files/test_issue_928_throw_in_async_arrow.ts
+++ b/test-files/test_issue_928_throw_in_async_arrow.ts
@@ -1,0 +1,27 @@
+// Issue #928: `throw new Error(...)` inside an async ARROW handler must
+// flow through the Promise rejection path AND JSON.stringify of a
+// built-in Error must not segfault (the Fastify rejection-body renderer
+// invokes JSON.stringify on the rejection reason; before this fix it
+// dereferenced ErrorHeader as a JSObject and crashed the process).
+
+// 1. async-arrow throw flows through rejected Promise (was already
+// working in the simple case — kept here as a guard against regressions).
+const handler = async () => {
+  throw new Error("test");
+};
+try {
+  await handler();
+  console.log("no-throw");
+} catch (e: any) {
+  console.log("caught:", e.message);
+}
+
+// 2. JSON.stringify of a built-in Error: Node returns "{}" because
+// Error's intrinsic props are non-enumerable. Before #928 this
+// segfaulted the process.
+const err = new Error("boom");
+console.log("json:", JSON.stringify(err));
+
+// 3. Built-in Error subclasses use the same ErrorHeader layout.
+const te = new TypeError("nope");
+console.log("type:", JSON.stringify(te));


### PR DESCRIPTION
## Summary

- `JSON.stringify(new Error("test"))` segfaulted because `stringify_value` routed `GC_TYPE_ERROR` through the catch-all → `stringify_object` path, which derefed `ErrorHeader::error_kind` as a `keys_array` pointer and crashed.
- Add an explicit `GC_TYPE_ERROR` arm to both `stringify_value` and `stringify_value_depth` that emits `"{}"` — matches Node's `JSON.stringify(new Error("x"))` behavior (intrinsic Error props are non-enumerable per spec).
- Closes the `js_json_stringify` fallback hole in PR #937's Fastify rejection-body renderer: with #937 alone, the renderer's `js_json_stringify(reason, 0)` fallback still segfaulted on built-in Error reasons whose message was null.

## Test plan

- [x] `JSON.stringify(new Error("test"))` returns `"{}"` (matches Node byte-for-byte).
- [x] `JSON.stringify(new TypeError("nope"))` returns `"{}"` (same path via `GC_TYPE_ERROR`).
- [x] Fastify issue #928 repro (`throw new Error("Unauthorized")` from `app.get("/go", async () => {...})`) returns HTTP 500 with `{"statusCode":500,"error":"Internal Server Error","message":"Unauthorized"}`; server stays alive; subsequent `/healthz` still serves 200.
- [x] Re-ran `test_compat_async_errors`, `test_edge_error_handling`, `test_gap_error_extensions`, `test_gap_json_advanced`, `test_json_sso_strings`, `test_issue_307_json_stringify_overflow_fields`, `test_issue_639_json_stringify_buffer`, `test_compat_strings_regex_json` — all match Node byte-for-byte.
- [x] New regression test `test-files/test_issue_928_throw_in_async_arrow.ts` covers (1) async-arrow throw → rejection → catch, (2) `JSON.stringify(new Error(...))`, (3) `JSON.stringify(new TypeError(...))`.