### PR TITLE
fix(codegen): #321 — factory-returned-class .staticMethod(args) bundles synth-arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.967 — fix(codegen): #321 — factory-returned-class `.staticMethod(args)` bundles args into synthetic `arguments` rest
+
+**Symptom.** `import { Effect } from "effect"; console.log("smoke:", typeof (Effect as any).succeed)` advanced through Schema.ts module init past the post-#912 (gap 1 + gap 2) sites but still threw
+
+```
+TypeError: Cannot read properties of undefined (reading '_tag')
+    at <anonymous>
+```
+
+before either `console.log` line ran. Bisection (PERRY_DBG_PROPERTY_ACCESS + symbolicated backtrace + per-statement console.log probes in Schema.ts) traced the throw to `getDefaultTypeLiteralAST` inside Schema.ts's top-level `const DurationValueMillis = TaggedStruct("Millis", { millis: NonNegativeInt })`. The crashing line is
+
+```ts
+const ast: PropertySignature.AST = field.ast
+switch (ast._tag) { … }
+```
+
+where `field` is the value at key `"_tag"` inside `TaggedStruct`'s synthesized object `{ _tag: tag(value), ...fields }`. The probes showed `field` was a `function` (not a `PropertySignature` object), which percolated from `tag("Millis") = Literal("Millis").pipe(propertySignature, withConstructorDefault(() => "Millis"))` returning the inner curried function instead of a real `PropertySignature`. The curry came from `dual(2, body)`'s `if (arguments.length >= 2) { return body(a, b) } return function (self) { return body(self, a) }` arm taking the wrong branch.
+
+**Root cause (this gap, "gap 3" in the #321 numbering).** Effect's `Literal(value)` is a factory that returns `class LiteralClass extends make(ast) {}`. The base class is itself returned by `make(ast)` and has a `static pipe() { return pipeArguments(this, arguments) }` method whose body reads `arguments`. The HIR's `lower_class_method` + `append_synthetic_arguments_param` (#677 / #899 / #912 gap 1) correctly appends a synthesized `arguments` rest param to the static method's HIR `Function`, but the static-method dispatch path in `crates/perry-codegen/src/lower_call.rs` (added by #912 gap 2 for the `const C = make(); C.pipe(...)` shape) had three gaps:
+
+1. **Receiver-shape recognition.** The pre-fix `static_dispatch_cls` only matched `Expr::ClassRef(name)` and `Expr::LocalGet(id)` (resolved via `local_class_aliases`). Effect's `Literal(value).pipe(...)` arrives at the call site as `Expr::Call { callee: FuncRef(Literal), … }`, or — when the inliner collapses the factory body inline — as `Expr::Sequence([RegisterClassParentDynamic, ClassRef])`. Neither shape matched, so dispatch fell through to dynamic dispatch and the static body never ran (the dispatch tower returned a default value like `2` or `undefined`).
+
+2. **Synthetic-arguments rest bundling at the call site.** Even when the static dispatch tower DID resolve (the post-#912 LocalGet path), the args were forwarded 1-to-1 to the underlying function. The static `pipe()` body declares a single synthetic-arguments rest param, so `Cls.pipe(f1, f2)` was emitting `perry_static_…__pipe(f1, f2)` — the function received `arg0 = f1` and the body read `.length` on that double (a function → `undefined`). Mirror the existing arg-bundling logic from the regular `Call` lowering (lines ~720–765 of `lower_call.rs`) so the synth-args slot receives a real Array of all call args.
+
+3. **Receiver `this` for dynamic factory results.** For Call / Sequence receivers, each `Literal(value)` call returns a fresh anonymous class with unique static fields (`static literals = [...]`, `static ast = ...`). The pre-existing LocalGet branch synthesizes a ClassRef NaN-box from the resolved class name — that's correct for `const C = make()` (where the ClassRef identity is the only thing static bodies read), but wrong for factory-call receivers because it loses the per-call data. Use `lower_expr(object)` to capture the actual runtime class value for `Call` / `Sequence` receivers.
+
+**Fix.**
+
+- `crates/perry-codegen/src/codegen.rs` — fixed-point pass over `hir.functions` that tags functions whose body unconditionally returns a `ClassRef` (or a `Call` / `Conditional` / `Sequence` shape that transitively resolves to one). Exposes the resulting map as `CrossModuleCtx::func_returns_class` so per-`FnCtx` lowering can consult it. The pass handles transitive chains (`Literal` → `makeLiteralClass` → returns class) and the inliner-collapsed `Sequence([…, ClassRef])` shape; `Conditional` is included because Effect's actual `Literal` body is `isNonEmptyReadonlyArray(literals) ? makeLiteralClass(literals) : Never` — both branches resolve to a class. Disqualifies functions whose returns are mixed (some class, some not) so we don't mis-classify a non-factory.
+
+- `crates/perry-codegen/src/lower_call.rs::lower_call`'s static-method dispatch tower:
+  - Extends `static_dispatch_cls` to recognise `Expr::Call { callee: FuncRef(fid) }` (consults `func_returns_class`) and `Expr::Sequence` (walks the trailing expression). Refactored into a small recursive helper so the resolver composes correctly for nested Sequence / Call wrapping.
+  - Adds synth-args rest bundling (and the non-synthetic rest path for completeness): when the resolved static method ends in a rest param, allocate a `js_array_alloc` array, push every call arg via `js_array_push_f64`, and pass the resulting NaN-boxed pointer as the single rest slot.
+  - For `Call` / `Sequence` receivers, lowers the object expression directly so the runtime `this` carries the per-call factory result. For `ClassRef` / `LocalGet`, retains the pre-existing ClassRef-NaN-box synthesis.
+
+- `crates/perry-codegen/src/expr.rs::FnCtx` — new `func_returns_class: &'a HashMap<u32, String>` field backed by `cross_module.func_returns_class`.
+
+**Test plan.**
+
+- `test-files/test_issue_effect_tag_deeper.ts` — three patterns standalone:
+  1. Direct factory + static-method `Literal(value).pipe(f1, f2)` exercises the new `Expr::Call` recognition + arg bundling.
+  2. Two-deep factory chain `Outer(value).pipe(…)` exercises the fixed-point pass.
+  3. Pre-existing `const C = make(); C.pipe(…)` (post-#912 gap 2) — regression guard.
+  All 5 assertions match Node `--experimental-strip-types` output byte-for-byte.
+- `test-files/test_issue_effect_arguments_length_returned_fn.ts` (#912 gap 1) — still passes.
+- `test-files/test_issue_effect_factory_static_dispatch.ts` (#912 gap 2) — still passes.
+
+**Known next blocker (documented in the test file, not closed in this PR).** The Effect `typeof (Effect as any).succeed` smoke STILL fails after this lands, with the same `_tag` error but at a different site: `Predicate.hasProperty(field, PropertySignatureTypeId)` from inside `isPropertySignature(field)`. `hasProperty` is exported as `const hasProperty = dual(2, body)` — a const-bound closure. The cross-module ExternFuncRef dispatch for `hasProperty` doesn't bundle args into the closure's synthetic-arguments rest, so the dual-returned function sees `arguments.length === 1` (or undefined) and takes the curried path. The likely fix is in the ExternFuncRef call site in `lower_call.rs` (~line 1260): when the imported binding's source is a `dual(...)`-shaped closure with synth-args, emit the same bundling the FuncRef + static-method paths now do. Or emit a thin LLVM wrapper at the export side that performs the bundling before forwarding to the closure body. Filed as a follow-up under #321.
+
 ## v0.5.966 — fix(runtime): #928 — `JSON.stringify(new Error(...))` segfaulted on the built-in Error layout
 
 **Symptom.** `JSON.stringify(new Error("test"))` killed the process with SIGSEGV instead of returning `"{}"`. Same root cause surfaced as the user-visible "throw new Error from Fastify async route handler crashes the server" report in #928: PR #937 ("fix(fastify): catch thrown route errors") fixed the Fastify dispatch path to catch rejections + route them through `render_rejection_body`, but the rejection-body renderer's `js_json_stringify(reason, 0)` fallback still segfaulted on built-in Error reasons. The general `JSON.stringify(error)` call also still crashed, regardless of Fastify.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.966
+**Current Version:** 0.5.967
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.966"
+version = "0.5.967"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.966"
+version = "0.5.967"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.966"
+version = "0.5.967"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.966"
+version = "0.5.967"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.966"
+version = "0.5.967"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/codegen.rs
+++ b/crates/perry-codegen/src/codegen.rs
@@ -468,6 +468,15 @@ pub(crate) struct CrossModuleCtx {
     /// site in `lower_call.rs` to pack trailing args into a rest array.
     pub imported_func_has_rest: std::collections::HashSet<String>,
     pub imported_func_return_types: std::collections::HashMap<String, perry_types::Type>,
+    /// Refs #915 (gap 3 / #321 follow-up): function ids in THIS module
+    /// whose body unconditionally returns a `ClassRef` (or transitively
+    /// returns another such factory). Maps function id → produced
+    /// class name. Lets `lower_call`'s static-method dispatch tower
+    /// recognise `Literal(...).pipe(...)` (where `Literal` is a
+    /// factory) and route the `.pipe` lookup through the produced
+    /// class's static methods. Built once in `compile_module` via a
+    /// fixed-point pass over `hir.functions`.
+    pub func_returns_class: std::collections::HashMap<u32, String>,
     /// Per-method explicit param counts, keyed by `(class_name, method_name)`.
     /// Built once in `compile_module` from BOTH local `hir.classes` AND
     /// `opts.imported_classes`. Used at every method-call dispatch site in
@@ -1274,6 +1283,42 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         }
     }
 
+    // Refs #915 (gap 3 / #321 follow-up): tag functions whose body
+    // unconditionally returns a `ClassRef` (or transitively returns
+    // another such factory) so call sites of the form
+    // `Literal(value).pipe(...)` can dispatch the `.pipe` lookup as a
+    // static-method call on the returned class. Iterate until
+    // fixed-point so `Literal(value)` (which calls `makeLiteralClass`)
+    // resolves to the same class as `makeLiteralClass(...)`.
+    let mut func_returns_class_map: std::collections::HashMap<u32, String> =
+        std::collections::HashMap::new();
+    let n_funcs_for_factory_pass = hir.functions.len();
+    for _ in 0..n_funcs_for_factory_pass {
+        let mut changed = false;
+        for f in &hir.functions {
+            if func_returns_class_map.contains_key(&f.id) {
+                continue;
+            }
+            let mut produced: Option<String> = None;
+            let mut disqualified = false;
+            collect_return_class(
+                &f.body,
+                &mut produced,
+                &mut disqualified,
+                &func_returns_class_map,
+            );
+            if !disqualified {
+                if let Some(class_name) = produced {
+                    func_returns_class_map.insert(f.id, class_name);
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
     // Build the cross-module context bundle from CompileOptions.
     let cross_module = CrossModuleCtx {
         namespace_imports: opts.namespace_imports.iter().cloned().collect(),
@@ -1289,6 +1334,7 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         namespace_node_submodules: opts.namespace_node_submodules.clone(),
         imported_func_has_rest: opts.imported_func_has_rest,
         imported_func_return_types: opts.imported_func_return_types,
+        func_returns_class: func_returns_class_map,
         method_param_counts,
         method_has_rest,
         class_keys_globals: class_keys_globals_map,
@@ -3630,6 +3676,7 @@ fn compile_function(
         imported_class_ctors: &cross_module.imported_class_ctors,
         func_signatures,
         func_synthetic_arguments,
+        func_returns_class: &cross_module.func_returns_class,
         boxed_vars,
         prealloc_boxes: std::collections::HashSet::new(),
         closure_rest_params,
@@ -4019,6 +4066,7 @@ fn compile_closure(
         imported_class_ctors: &cross_module.imported_class_ctors,
         func_signatures,
         func_synthetic_arguments,
+        func_returns_class: &cross_module.func_returns_class,
         boxed_vars: closure_boxed_vars,
         prealloc_boxes: std::collections::HashSet::new(),
         closure_rest_params,
@@ -4252,6 +4300,7 @@ fn compile_method(
         imported_class_ctors: &cross_module.imported_class_ctors,
         func_signatures,
         func_synthetic_arguments,
+        func_returns_class: &cross_module.func_returns_class,
         boxed_vars: method_boxed_vars,
         prealloc_boxes: std::collections::HashSet::new(),
         closure_rest_params,
@@ -4730,6 +4779,7 @@ fn compile_module_entry(
             imported_class_ctors: &cross_module.imported_class_ctors,
             func_signatures,
             func_synthetic_arguments,
+            func_returns_class: &cross_module.func_returns_class,
             boxed_vars: main_boxed_vars,
             prealloc_boxes: std::collections::HashSet::new(),
             closure_rest_params: closure_rest_params,
@@ -5109,6 +5159,7 @@ fn compile_module_entry(
             imported_class_ctors: &cross_module.imported_class_ctors,
             func_signatures,
             func_synthetic_arguments,
+            func_returns_class: &cross_module.func_returns_class,
             boxed_vars: init_boxed_vars,
             prealloc_boxes: std::collections::HashSet::new(),
             closure_rest_params: closure_rest_params,
@@ -5893,6 +5944,7 @@ fn compile_static_method(
         imported_class_ctors: &cross_module.imported_class_ctors,
         func_signatures,
         func_synthetic_arguments,
+        func_returns_class: &cross_module.func_returns_class,
         boxed_vars: static_boxed_vars,
         prealloc_boxes: std::collections::HashSet::new(),
         closure_rest_params,
@@ -6418,6 +6470,133 @@ fn emit_namespace_populator(
 
 fn scoped_fn_name(module_prefix: &str, hir_name: &str) -> String {
     format!("perry_fn_{}__{}", module_prefix, sanitize(hir_name))
+}
+
+/// Walk a function body looking for `Return(Some(expr))` shapes that
+/// identify the function as a factory returning a class. Sets
+/// `*produced` to the resolved class name when the first qualifying
+/// return is seen; sets `*disqualified` when a return points at
+/// something we can't classify as a class. Used by
+/// `func_returns_class_map` fixed-point in `compile_module` to recognise
+/// Effect's `Literal` / `makeLiteralClass` / `make` factories. Refs
+/// #915 (gap 3 / #321 follow-up).
+///
+/// Recognised return shapes:
+///   - `Return(Some(ClassRef(name)))` — direct class literal return.
+///   - `Return(Some(Call { callee: FuncRef(other_fid), .. }))` — call
+///     to another already-tagged factory (transitive).
+///   - `Return(Some(Conditional { then, else, .. }))` — both branches
+///     must independently resolve to the same class. Effect's
+///     `Literal(...)` has this shape — the body is
+///     `array_.isNonEmptyReadonlyArray(literals) ? makeLiteralClass(literals) : Never`.
+///   - `Return(Some(Sequence([..., ClassRef(name)])))` — the HIR's
+///     inliner sometimes collapses a factory call to
+///     `Sequence([RegisterClassParentDynamic, ClassRef(name)])`. Treat
+///     the trailing class as the produced value.
+///
+/// Anything else inside a `Return(Some(_))` disqualifies the function:
+/// we'd rather miss a factory than mis-classify a non-factory.
+/// Returns inside nested closures are SKIPPED — those belong to the
+/// inner function (the walker doesn't recurse into Expr).
+fn collect_return_class(
+    stmts: &[perry_hir::Stmt],
+    produced: &mut Option<String>,
+    disqualified: &mut bool,
+    func_returns_class: &std::collections::HashMap<u32, String>,
+) {
+    use perry_hir::{Expr, Stmt};
+
+    fn resolve_class(
+        expr: &perry_hir::Expr,
+        func_returns_class: &std::collections::HashMap<u32, String>,
+    ) -> Option<String> {
+        match expr {
+            Expr::ClassRef(name) => Some(name.clone()),
+            Expr::Call { callee, .. } => match callee.as_ref() {
+                Expr::FuncRef(fid) => func_returns_class.get(fid).cloned(),
+                _ => None,
+            },
+            Expr::Conditional {
+                then_expr,
+                else_expr,
+                ..
+            } => {
+                let lhs = resolve_class(then_expr, func_returns_class)?;
+                let rhs = resolve_class(else_expr, func_returns_class)?;
+                if lhs == rhs {
+                    Some(lhs)
+                } else {
+                    None
+                }
+            }
+            Expr::Sequence(exprs) => exprs
+                .last()
+                .and_then(|e| resolve_class(e, func_returns_class)),
+            _ => None,
+        }
+    }
+
+    for stmt in stmts {
+        if *disqualified {
+            return;
+        }
+        match stmt {
+            Stmt::Return(Some(expr)) => {
+                let resolved = resolve_class(expr, func_returns_class);
+                match resolved {
+                    Some(name) => match produced {
+                        None => *produced = Some(name),
+                        Some(existing) if *existing == name => {}
+                        Some(_) => {
+                            // Mixed return shapes — bail.
+                            *disqualified = true;
+                        }
+                    },
+                    None => {
+                        *disqualified = true;
+                    }
+                }
+            }
+            Stmt::Return(None) => {
+                // Returning undefined — disqualify (caller can't
+                // depend on the receiver being a class).
+                *disqualified = true;
+            }
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                collect_return_class(then_branch, produced, disqualified, func_returns_class);
+                if let Some(eb) = else_branch {
+                    collect_return_class(eb, produced, disqualified, func_returns_class);
+                }
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                collect_return_class(body, produced, disqualified, func_returns_class);
+                if let Some(cc) = catch {
+                    collect_return_class(&cc.body, produced, disqualified, func_returns_class);
+                }
+                if let Some(blk) = finally {
+                    collect_return_class(blk, produced, disqualified, func_returns_class);
+                }
+            }
+            Stmt::Switch { cases, .. } => {
+                for case in cases {
+                    collect_return_class(&case.body, produced, disqualified, func_returns_class);
+                }
+            }
+            Stmt::Labeled { body, .. } => {
+                let slice = std::slice::from_ref(body.as_ref());
+                collect_return_class(slice, produced, disqualified, func_returns_class);
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Mangle a class method name into an LLVM symbol, scoped by module

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -453,6 +453,15 @@ pub(crate) struct FnCtx<'a> {
     /// every actual argument while fixed parameters still receive their
     /// normal positional values.
     pub func_synthetic_arguments: &'a std::collections::HashSet<u32>,
+    /// Refs #915 (gap 3 / #321 follow-up): factory functions in THIS
+    /// module — those whose body unconditionally returns a `ClassRef`
+    /// (or transitively returns another such factory). Maps function
+    /// id → produced class name. Lets `lower_call`'s static-method
+    /// dispatch tower recognise `Literal(...).pipe(...)` (where
+    /// `Literal` is a factory) and route the `.pipe` lookup through
+    /// the produced class's static methods, matching the post-#912
+    /// `Cls = make(); Cls.pipe(...)` shape.
+    pub func_returns_class: &'a std::collections::HashMap<u32, String>,
     /// LocalIds that must be stored in heap boxes (`js_box_alloc`)
     /// instead of stack allocas. A local gets boxed when at least
     /// one closure captures it AND it's written to (either by the

--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -1995,28 +1995,77 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
         //         C.staticMethod(...)
         //       Refs #915 (gap 2 from #899). The local→class map is the
         //       same one `lower_new`'s alias rerouting consults below.
-        let static_dispatch_cls: Option<String> = match object.as_ref() {
-            Expr::ClassRef(cls_name) => Some(cls_name.clone()),
-            Expr::LocalGet(id) => ctx
-                .local_id_to_name
-                .get(id)
-                .and_then(|name| ctx.local_class_aliases.get(name).cloned()),
-            _ => None,
-        };
+        // Refs #915 (gap 3 / #321 follow-up): walk the receiver to
+        // recognise the "static-method on a class produced by a
+        // factory" pattern. Covered shapes:
+        //   - `Expr::ClassRef(name)` — direct class literal.
+        //   - `Expr::LocalGet(id)` whose let-init was a ClassRef (the
+        //     post-#912 `const Cls = make(); Cls.foo(...)` shape).
+        //   - `Expr::Call { callee: FuncRef(fid) }` where `fid` is a
+        //     factory function tagged via `func_returns_class`. The
+        //     HIR inliner sometimes leaves these calls in place
+        //     (Effect's `Literal(value).pipe(...)`); the
+        //     `func_returns_class` fixed-point pass tags Literal,
+        //     makeLiteralClass, make, etc.
+        //   - `Expr::Sequence` whose trailing expression itself
+        //     resolves to a class. The inliner sometimes collapses
+        //     `Literal(value)` to
+        //     `Sequence([RegisterClassParentDynamic, ClassRef(L)])`
+        //     so the call site sees the class without an outer Call.
+        fn resolve_static_dispatch_cls(
+            expr: &Expr,
+            local_id_to_name: &std::collections::HashMap<u32, String>,
+            local_class_aliases: &std::collections::HashMap<String, String>,
+            func_returns_class: &std::collections::HashMap<u32, String>,
+        ) -> Option<String> {
+            match expr {
+                Expr::ClassRef(name) => Some(name.clone()),
+                Expr::LocalGet(id) => local_id_to_name
+                    .get(id)
+                    .and_then(|name| local_class_aliases.get(name).cloned()),
+                Expr::Call { callee, .. } => match callee.as_ref() {
+                    Expr::FuncRef(fid) => func_returns_class.get(fid).cloned(),
+                    _ => None,
+                },
+                Expr::Sequence(exprs) => exprs.last().and_then(|e| {
+                    resolve_static_dispatch_cls(
+                        e,
+                        local_id_to_name,
+                        local_class_aliases,
+                        func_returns_class,
+                    )
+                }),
+                _ => None,
+            }
+        }
+        let static_dispatch_cls: Option<String> = resolve_static_dispatch_cls(
+            object,
+            &ctx.local_id_to_name,
+            &ctx.local_class_aliases,
+            ctx.func_returns_class,
+        );
         if let Some(cls_name) = static_dispatch_cls {
-            let mut resolved: Option<(String, bool)> = None; // (fn_name, is_static)
+            // (fn_name, is_static, declared_param_count, has_rest, is_synthetic_arguments)
+            let mut resolved: Option<(String, bool, usize, bool, bool)> = None;
             let mut cur = Some(cls_name.clone());
             while let Some(c) = cur {
                 if let Some(class_info) = ctx.classes.get(&c) {
-                    let is_static = class_info
+                    let sm = class_info
                         .static_methods
                         .iter()
-                        .any(|m| m.name == *property);
-                    if is_static {
+                        .find(|m| m.name == *property);
+                    if let Some(sm) = sm {
                         if let Some(fname) =
                             ctx.methods.get(&(c.clone(), property.clone())).cloned()
                         {
-                            resolved = Some((fname, true));
+                            let declared = sm.params.len();
+                            let has_rest = sm.params.last().map(|p| p.is_rest).unwrap_or(false);
+                            let is_synth_args = sm
+                                .params
+                                .last()
+                                .map(|p| p.is_rest && p.name == "arguments")
+                                .unwrap_or(false);
+                            resolved = Some((fname, true, declared, has_rest, is_synth_args));
                             break;
                         }
                     }
@@ -2026,14 +2075,28 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
                     .get(&c.clone())
                     .and_then(|cc| cc.extends_name.clone());
             }
-            if let Some((fn_name, _is_static)) = resolved {
-                // For LocalGet receivers we still want the runtime `this`
-                // to be the underlying ClassRef so the static body's
-                // `this` matches the direct-ClassRef path's semantics.
-                // For ClassRef receivers, `lower_expr(object)` already
-                // yields the INT32-NaN-boxed class id.
+            if let Some((fn_name, _is_static, declared, has_rest, is_synth_args)) = resolved {
+                // Receiver-box selection (`this` inside the static body):
+                //   - `ClassRef`: `lower_expr` already yields the
+                //     INT32-NaN-boxed class id; `this === ClassRef`.
+                //   - `Call` (factory return): `lower_expr` returns the
+                //     dynamic class produced by the factory, so each
+                //     `Literal(value)` / `make(ast)` call carries
+                //     unique static fields (`static literals = […]`,
+                //     `static ast = …`). The static body reads those
+                //     through `this.<field>`, so passing the synthesized
+                //     ClassRef would lose the per-call data — use the
+                //     actual lowered call result instead.
+                //   - Everything else (`LocalGet` after a
+                //     `const Cls = make()` collapse, etc.): synthesize
+                //     a fresh ClassRef NaN-box. The static body's
+                //     `this.<field>` then dispatches through the
+                //     ClassRef's class-keys + class-field side-table,
+                //     which is the post-#912 (gap 2) shape.
                 let recv_box = match object.as_ref() {
                     Expr::ClassRef(_) => lower_expr(ctx, object)?,
+                    Expr::Call { .. } => lower_expr(ctx, object)?,
+                    Expr::Sequence(_) => lower_expr(ctx, object)?,
                     _ => {
                         // Synthesize a ClassRef NaN-box from the resolved class.
                         let cid = ctx.class_ids.get(&cls_name).copied().unwrap_or(0);
@@ -2041,9 +2104,55 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
                         crate::nanbox::double_literal(f64::from_bits(bits))
                     }
                 };
+                // Refs #915 (gap 3 / #321 follow-up): Effect's `class
+                // SchemaClass { static pipe() { ... arguments ... } }`
+                // factory returns an anon class whose `pipe` reads
+                // `arguments.length` to dispatch. The HIR appends a
+                // synthesized `arguments` rest param (#677 / #899). The
+                // direct-call dispatch here previously forwarded the
+                // call args 1:1 to the function whose only declared
+                // parameter is the rest array — so for
+                // `Cls.pipe(f1, f2)` the function got `arg0 = f1` (then
+                // read .length = "function" → undefined). Mirror the
+                // arg-bundling logic from the regular Call lowering
+                // (lines ~720–765) so the rest slot receives a real
+                // array of all call args, matching JS `arguments`
+                // semantics. The non-synthetic rest path (e.g.
+                // `static foo(a, ...rest)`) follows the same shape:
+                // pass the first `declared-1` positional args as-is,
+                // then bundle the trailing args into an Array.
                 let mut lowered: Vec<String> = Vec::with_capacity(args.len());
-                for a in args {
-                    lowered.push(lower_expr(ctx, a)?);
+                if has_rest && is_synth_args {
+                    let cap = (args.len() as u32).to_string();
+                    let mut current = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap)]);
+                    for a in args {
+                        let v = lower_expr(ctx, a)?;
+                        let blk = ctx.block();
+                        current =
+                            blk.call(I64, "js_array_push_f64", &[(I64, &current), (DOUBLE, &v)]);
+                    }
+                    let arguments_box = nanbox_pointer_inline(ctx.block(), &current);
+                    lowered.push(arguments_box);
+                } else if has_rest {
+                    let fixed_count = declared.saturating_sub(1);
+                    for a in args.iter().take(fixed_count) {
+                        lowered.push(lower_expr(ctx, a)?);
+                    }
+                    let rest_count = args.len().saturating_sub(fixed_count);
+                    let cap = (rest_count as u32).to_string();
+                    let mut current = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap)]);
+                    for a in args.iter().skip(fixed_count) {
+                        let v = lower_expr(ctx, a)?;
+                        let blk = ctx.block();
+                        current =
+                            blk.call(I64, "js_array_push_f64", &[(I64, &current), (DOUBLE, &v)]);
+                    }
+                    let rest_box = nanbox_pointer_inline(ctx.block(), &current);
+                    lowered.push(rest_box);
+                } else {
+                    for a in args {
+                        lowered.push(lower_expr(ctx, a)?);
+                    }
                 }
                 let prev_this =
                     ctx.block()

--- a/test-files/test_issue_effect_tag_deeper.ts
+++ b/test-files/test_issue_effect_tag_deeper.ts
@@ -1,0 +1,140 @@
+// Regression for the post-#915 Effect smoke gap (gap 3): factory-returned
+// class + static method that reads `arguments`.
+//
+// Effect's `Literal(value).pipe(propertySignature, withConstructorDefault(...))`
+// expands to:
+//   1. `Literal(value)` — factory returning `class L extends make(ast) {}`.
+//   2. `.pipe(a, b)` — static method on the returned class whose body is
+//      `pipeArguments(this, arguments)` (a 2-arg curry helper that reads
+//      `arguments.length`).
+//
+// Pre-fix, the static-method dispatch tower in
+// `crates/perry-codegen/src/lower_call.rs` only recognised receivers of
+// shape `Expr::ClassRef` and `Expr::LocalGet` (via class aliases).
+// `Literal(value)` arrives as `Expr::Call` (or as
+// `Expr::Sequence([RegisterClassParentDynamic, ClassRef])` after the
+// inliner collapses the factory body inline), so dispatch fell through
+// to dynamic dispatch and the synth-arguments rest slot was passed the
+// raw call args one-per-slot instead of bundled into an array. Inside
+// the static body, `arguments.length` therefore read `.length` on the
+// first arg (a function → undefined) and the `if (arguments.length >= 2)`
+// branch took the curried path with `a = undefined`, producing a
+// function value where Effect expected a Schema (or PropertySignature).
+// Subsequent `getDefaultTypeLiteralAST` iteration over the resulting
+// `{_tag: <function>, …}` saw a function in an `_tag` slot, called
+// `isPropertySignature(field)` which (via `Predicate.hasProperty`'s
+// `dual(2, …)` curry shape) also mis-evaluated `arguments.length` and
+// returned a curried function; the `if (isPS)` branch took that as
+// truthy and read `field.ast._tag`, throwing
+//   `TypeError: Cannot read properties of undefined (reading '_tag')`.
+//
+// This fixture covers the dispatch-side cases standalone (Effect itself
+// isn't installed in test-files):
+//   - Direct factory call `Literal(value).pipe(...)` — Expr::Call form.
+//   - Two-deep factory chain `Outer(value).pipe(...)` — exercises the
+//     `func_returns_class` fixed-point pass.
+//   - Local-binding alias `const C = make(); C.pipe(...)` — the
+//     pre-existing #912 (gap 2) shape, validated to still work.
+
+// ---------------------------------------------------------------------
+// Pattern A: direct factory + static-method dispatch
+// ---------------------------------------------------------------------
+function makeSchemaClass() {
+  return class SchemaClass {
+    static pipe() {
+      // JS spec: `arguments.length` counts every passed arg.
+      const args = arguments;
+      let result: any = "BASE";
+      for (let i = 0; i < args.length; i++) {
+        result = (args as any)[i](result);
+      }
+      return result;
+    }
+    static getArity() {
+      return arguments.length;
+    }
+  };
+}
+
+function Literal(_value: any) {
+  // Returns a fresh class each call — exactly matches Effect's
+  // `makeLiteralClass`.
+  return class L extends makeSchemaClass() {};
+}
+
+const f1 = (x: any) => "f1(" + x + ")";
+const f2 = (x: any) => "f2(" + x + ")";
+
+const result_a = Literal("foo").pipe(f1, f2);
+console.log("A1:", result_a);
+// Expected: f2(f1(BASE))
+
+const arity_a = Literal("bar").getArity(1, 2, 3);
+console.log("A2:", arity_a);
+// Expected: 3
+
+// ---------------------------------------------------------------------
+// Pattern B: transitive factory chain (mirrors Effect's
+// `Literal → makeLiteralClass → returns class`)
+// ---------------------------------------------------------------------
+function makeOuterClass() {
+  return class Outer {
+    static fold() {
+      return arguments.length;
+    }
+  };
+}
+
+function indirect() {
+  return makeOuterClass();
+}
+
+function Outer(_v: any) {
+  return indirect();
+}
+
+console.log("B1:", Outer("x").fold("a", "b", "c", "d"));
+// Expected: 4
+
+// ---------------------------------------------------------------------
+// Pattern C: pre-existing #912 (gap 2) local-binding alias — must still work
+// ---------------------------------------------------------------------
+const C = makeSchemaClass();
+console.log("C1:", C.pipe(f1, f2, f1));
+// Expected: f1(f2(f1(BASE)))
+console.log("C2:", C.getArity("a", "b"));
+// Expected: 2
+
+// ---------------------------------------------------------------------
+// Next blocker for the Effect `typeof Effect.succeed === "function"` smoke
+// ---------------------------------------------------------------------
+// After this fix lands, `import { Effect } from "effect"; typeof
+// Effect.succeed` STILL throws `TypeError: Cannot read properties of
+// undefined (reading '_tag')` during Schema.ts module init. The fault
+// has moved from the static-method dispatch site fixed here to a
+// cross-module ExternFuncRef call chain: `Predicate.hasProperty` is
+// exported as `const hasProperty = dual(2, (self, property) =>
+// isObject(self) && property in self)`. `Schema.ts` calls
+// `Predicate.hasProperty(field, PropertySignatureTypeId)` from inside
+// `isPropertySignature(field) = hasProperty(field, PSTypeId)`, expecting a
+// boolean. Empirically the call returns the dual's inner curried
+// function — i.e. `arguments.length` inside the dual-returned closure
+// reads as `1` (or undefined) instead of `2`. The closure is created at
+// `Predicate.ts` module init by `dual(2, body)` and assigned to a const,
+// so the cross-module dispatch goes through whatever stub Perry emits
+// for const-exported function values — that stub is not bundling the
+// args into a synthetic-`arguments` array the way `lower_call.rs`'s
+// FuncRef + static-method paths now do post-#915 (gap 1) and post-this
+// gap (gap 3). Likely fix area:
+//   - `crates/perry-codegen/src/lower_call.rs`: ExternFuncRef call site
+//     (~line 1260) needs to consult the imported module's
+//     `func_synthetic_arguments` set when the imported binding's source
+//     is a `dual(...)` (or any `arguments`-reading closure) and bundle
+//     the args into the rest array.
+//   - Or: detect at the export side that the const binding stores a
+//     closure with synth-args and have `compile_module` emit a thin
+//     LLVM wrapper that performs the bundling before forwarding to
+//     the closure body. This avoids per-importer machinery.
+// The same gap surfaces ANY time a cross-module call lands on a
+// dual-returned closure, so a follow-up issue tracking this is
+// warranted (file under the #321 Effect tracker).


### PR DESCRIPTION
## Summary

- Closes the next layer of Effect's `typeof Effect.succeed === "function"` smoke gap (post-#915 / gap 3 under tracker #321) for the static-method-on-factory-returned-class pattern: `Literal(value).pipe(propertySignature, …)` etc.
- Three coordinated fixes in `crates/perry-codegen/`:
  1. `lower_call.rs::lower_call` static-method dispatch now recognises `Expr::Call { callee: FuncRef }` and `Expr::Sequence` receivers via a new `func_returns_class` map (fixed-point pass tagging factories whose body unconditionally returns a `ClassRef`, including transitive chains and the inliner-collapsed `Sequence([RegisterClassParentDynamic, ClassRef])` form).
  2. Args are bundled into the static method's synthetic-`arguments` rest array at the dispatch site, mirroring the regular `Call` lowering — `arguments.length` now reads the actual call arity.
  3. For Call/Sequence receivers, the runtime `this` is the lowered call result (carries per-call static fields like `static literals = […]`). ClassRef/LocalGet paths retain the synthesized ClassRef NaN-box from #912.

The Effect smoke STILL fails post-this-PR with the same `_tag` error at a different call site (cross-module `Predicate.hasProperty` is a `dual(2, …)`-shaped const-bound closure whose synth-args aren't bundled at the ExternFuncRef dispatch). Documented as the next blocker in `test-files/test_issue_effect_tag_deeper.ts` and the CHANGELOG entry.

## Test plan

- [x] `cargo build --release -p perry-codegen -p perry-runtime -p perry-stdlib -p perry` — clean, 42 pre-existing warnings.
- [x] `test_issue_effect_tag_deeper.ts` — 5 assertions match Node `--experimental-strip-types` byte-for-byte (direct factory + static dispatch, two-deep factory chain, pre-existing #912 local-binding alias regression guard).
- [x] `test_issue_effect_arguments_length_returned_fn.ts` (#912 gap 1) — still PASS.
- [x] `test_issue_effect_factory_static_dispatch.ts` (#912 gap 2) — still PASS.
- [x] Sanity sweep: `test_gap_closures`, `test_gap_array_methods` — PASS. No new regressions in the gap suite.
- [x] No conflict markers in `Cargo.toml` / `CLAUDE.md` / `CHANGELOG.md` post-rebase.