### PR TITLE
feat(security): #503 — refuse compile-time dynamic dispatch on stdlib namespaces

### DIFF
--- a/crates/perry-hir/src/ir.rs
+++ b/crates/perry-hir/src/ir.rs
@@ -73,6 +73,154 @@ pub fn clear_compile_packages_override() {
     COMPILE_PACKAGES_OVERRIDE.with(|cell| cell.borrow_mut().clear());
 }
 
+// ---- #503 dynamic-stdlib-dispatch refusal config ----
+
+thread_local! {
+    /// #503: when true, HIR lowering refuses compile-time `obj[expr]()` /
+    /// `obj[expr]` on known stdlib namespace receivers (`process`, `fs`,
+    /// `crypto`, `child_process`, `net`, `os`, `path`, `http`, `https`,
+    /// `stream`, `url`, `util`, `buffer`, `events`, `dns`, `tls`,
+    /// `querystring`, `zlib`) unless the index is a string literal or
+    /// compile-time-foldable string. Catches the dispatch-by-string class
+    /// of supply-chain evasion. Set to false by `perry.allowDynamicStdlibDispatch: true`
+    /// or `PERRY_ALLOW_DYNAMIC_STDLIB=1`.
+    static REFUSE_DYNAMIC_STDLIB_DISPATCH: std::cell::Cell<bool> = const { std::cell::Cell::new(true) };
+
+    /// #503: per-thread set of npm package names that opted out of the
+    /// dynamic-stdlib-dispatch refusal (`perry.allowDynamicStdlibDispatch:
+    /// ["@scope/pkg", ...]`). When the currently-lowering source file
+    /// belongs to one of these packages, the check is skipped.
+    static ALLOW_DYNAMIC_STDLIB_PACKAGES: std::cell::RefCell<std::collections::HashSet<String>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
+
+    /// #503: source text of the module currently being lowered. Used by
+    /// the dynamic-dispatch check to look up `// @perry-allow-dynamic`
+    /// line annotations adjacent to violation sites. Set once per
+    /// `lower_module_full` invocation by the compiler driver.
+    static CURRENT_MODULE_SOURCE: std::cell::RefCell<Option<String>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// #503: enable (true) or disable (false) the dynamic-stdlib-dispatch
+/// refusal pass. Default is true (refusal active). The compile driver
+/// calls this once with the resolved configuration before kicking off
+/// HIR lowering for the build.
+pub fn set_refuse_dynamic_stdlib_dispatch(refuse: bool) {
+    REFUSE_DYNAMIC_STDLIB_DISPATCH.with(|c| c.set(refuse));
+}
+
+/// #503: is the dynamic-stdlib-dispatch refusal pass currently enabled
+/// for this thread?
+pub fn refuse_dynamic_stdlib_dispatch_enabled() -> bool {
+    REFUSE_DYNAMIC_STDLIB_DISPATCH.with(|c| c.get())
+}
+
+/// #503: install the per-thread allow-list of package names whose
+/// modules may legitimately use dynamic dispatch on stdlib namespaces.
+pub fn set_allow_dynamic_stdlib_packages(set: std::collections::HashSet<String>) {
+    ALLOW_DYNAMIC_STDLIB_PACKAGES.with(|c| *c.borrow_mut() = set);
+}
+
+/// #503: clear the per-thread allow-list.
+pub fn clear_allow_dynamic_stdlib_packages() {
+    ALLOW_DYNAMIC_STDLIB_PACKAGES.with(|c| c.borrow_mut().clear());
+}
+
+/// #503: is the given package name on the allow-list? `package_name_of`
+/// is the canonical extractor (scope-aware).
+pub fn dynamic_stdlib_allowed_for_package(pkg: &str) -> bool {
+    ALLOW_DYNAMIC_STDLIB_PACKAGES.with(|c| c.borrow().contains(pkg))
+}
+
+/// #503: install the source text of the module about to be lowered.
+/// The dynamic-dispatch check reads this to look up site annotations
+/// without re-reading the file from disk.
+pub fn set_current_module_source(src: String) {
+    CURRENT_MODULE_SOURCE.with(|c| *c.borrow_mut() = Some(src));
+}
+
+/// #503: clear the source-text thread-local.
+pub fn clear_current_module_source() {
+    CURRENT_MODULE_SOURCE.with(|c| *c.borrow_mut() = None);
+}
+
+/// #503: look up `// @perry-allow-dynamic` near `byte_offset` in the
+/// currently-installed module source. Returns true if the annotation
+/// appears on the same line as the offending site, or on any of the
+/// contiguous comment/blank lines immediately above it (so authors can
+/// stack other line comments like `// @ts-ignore` alongside the
+/// annotation without losing the opt-out).
+pub fn current_module_has_allow_dynamic_at(byte_offset: u32) -> bool {
+    CURRENT_MODULE_SOURCE.with(|cell| {
+        let borrowed = cell.borrow();
+        let Some(src) = borrowed.as_ref() else {
+            return false;
+        };
+        let offset = byte_offset as usize;
+        if offset > src.len() {
+            return false;
+        }
+        // Walk back to the start of the line containing `offset`.
+        let line_start = src[..offset].rfind('\n').map(|i| i + 1).unwrap_or(0);
+        let line_end = src[offset..]
+            .find('\n')
+            .map(|i| offset + i)
+            .unwrap_or(src.len());
+        if src[line_start..line_end].contains("@perry-allow-dynamic") {
+            return true;
+        }
+        // Walk up through contiguous comment-only and blank lines.
+        // A "comment-only" line trims to either an empty string or a
+        // string starting with `//`. The walk stops at the first line
+        // that contains executable code — anything stronger would let
+        // an annotation drift arbitrarily far from its target.
+        let mut cursor = line_start;
+        while cursor > 0 {
+            let prev_end = cursor - 1; // index of '\n'
+            let prev_start = src[..prev_end].rfind('\n').map(|i| i + 1).unwrap_or(0);
+            let prev = &src[prev_start..prev_end];
+            let trimmed = prev.trim();
+            let is_comment_or_blank = trimmed.is_empty() || trimmed.starts_with("//");
+            if !is_comment_or_blank {
+                return false;
+            }
+            if prev.contains("@perry-allow-dynamic") {
+                return true;
+            }
+            cursor = prev_start;
+        }
+        false
+    })
+}
+
+/// #503: extract the package name from a source file path, if any. The
+/// path is searched for the rightmost `node_modules/` segment; the
+/// segment(s) immediately following it form the package name
+/// (scope-aware). Returns `None` for user-source files (no
+/// `node_modules/` in the path).
+pub fn package_name_for_source_path(source_path: &str) -> Option<&str> {
+    let idx = source_path.rfind("node_modules/")?;
+    let after = &source_path[idx + "node_modules/".len()..];
+    if let Some(stripped) = after.strip_prefix('@') {
+        // Scoped: `@scope/pkg/...` → `@scope/pkg`
+        let mut parts = stripped.splitn(3, '/');
+        let scope = parts.next().unwrap_or("");
+        let pkg = parts.next().unwrap_or("");
+        if scope.is_empty() || pkg.is_empty() {
+            return None;
+        }
+        let end = idx + "node_modules/".len() + 1 + scope.len() + 1 + pkg.len();
+        Some(&source_path[idx + "node_modules/".len()..end])
+    } else {
+        let pkg = after.split('/').next()?;
+        if pkg.is_empty() {
+            None
+        } else {
+            Some(pkg)
+        }
+    }
+}
+
 /// Parse the package name out of an import specifier. Mirrors the
 /// `parse_package_specifier` helper in `crates/perry/src/commands/compile/resolve.rs`
 /// but lives here so `is_native_module` doesn't gain a perry-crate dep.

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -721,9 +721,8 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                         let pkg_allowed = pkg
                             .map(crate::ir::dynamic_stdlib_allowed_for_package)
                             .unwrap_or(false);
-                        let site_allowed = crate::ir::current_module_has_allow_dynamic_at(
-                            member.span.lo.0,
-                        );
+                        let site_allowed =
+                            crate::ir::current_module_has_allow_dynamic_at(member.span.lo.0);
                         if !pkg_allowed && !site_allowed {
                             let pkg_label = pkg
                                 .map(|p| format!(" (in package `{}`)", p))
@@ -890,7 +889,10 @@ pub(super) fn stdlib_namespace_receiver(
     // canonical specifier.
     for (local, module) in ctx.builtin_module_aliases.iter() {
         if local == name {
-            if let Some(canon) = STDLIB_NAMESPACE_NAMES.iter().find(|n| **n == module.as_str()) {
+            if let Some(canon) = STDLIB_NAMESPACE_NAMES
+                .iter()
+                .find(|n| **n == module.as_str())
+            {
                 return Some(*canon);
             }
         }
@@ -900,7 +902,10 @@ pub(super) fn stdlib_namespace_receiver(
     // native_modules entry with method_name = None.
     for (local, module, method) in ctx.native_modules.iter() {
         if local == name && method.is_none() {
-            if let Some(canon) = STDLIB_NAMESPACE_NAMES.iter().find(|n| **n == module.as_str()) {
+            if let Some(canon) = STDLIB_NAMESPACE_NAMES
+                .iter()
+                .find(|n| **n == module.as_str())
+            {
                 return Some(*canon);
             }
         }

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -695,6 +695,64 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
             Ok(Expr::PropertyGet { object, property })
         }
         ast::MemberProp::Computed(computed) => {
+            // #503: refuse compile-time dynamic dispatch on stdlib namespace
+            // receivers — `process[runtimeVar]`, `fs[atob(...)]()`, etc. —
+            // the dispatch-by-string class of supply-chain evasion. The check
+            // runs on the AST so it sees the un-folded shape, and bails before
+            // we lower the index (lowering can have side effects we want to
+            // avoid for refused code).
+            //
+            // Only fires when:
+            //   - the receiver AST is a bare ident naming a stdlib namespace
+            //     (or an alias bound to one via `import x from 'fs'`),
+            //   - the index is NOT a string literal at the source level
+            //     (literal keys are caught by the fold below, and never
+            //     constitute string-obfuscation),
+            //   - the refusal pass is enabled (`PERRY_ALLOW_DYNAMIC_STDLIB=0` /
+            //     `perry.allowDynamicStdlibDispatch: false`; on by default),
+            //   - the currently-lowering source file does NOT belong to a
+            //     package on the per-package allow-list, and
+            //   - there is no `// @perry-allow-dynamic` line annotation on
+            //     or immediately above the offending site.
+            if crate::ir::refuse_dynamic_stdlib_dispatch_enabled() {
+                if let Some(ns) = stdlib_namespace_receiver(ctx, member.obj.as_ref()) {
+                    if !matches!(*computed.expr, ast::Expr::Lit(ast::Lit::Str(_))) {
+                        let pkg = crate::ir::package_name_for_source_path(&ctx.source_file_path);
+                        let pkg_allowed = pkg
+                            .map(crate::ir::dynamic_stdlib_allowed_for_package)
+                            .unwrap_or(false);
+                        let site_allowed = crate::ir::current_module_has_allow_dynamic_at(
+                            member.span.lo.0,
+                        );
+                        if !pkg_allowed && !site_allowed {
+                            let pkg_label = pkg
+                                .map(|p| format!(" (in package `{}`)", p))
+                                .unwrap_or_default();
+                            crate::lower_bail!(
+                                member.span,
+                                "dynamic dispatch on stdlib namespace `{}` is refused at \
+                                 compile time{} — this catches the obfuscation pattern \
+                                 `{}[runtimeVar]()` used by malicious npm packages. (#503)\n\
+                                 \n\
+                                 Options:\n\
+                                 - Replace with a static call: `{}.<methodName>(...)`.\n\
+                                 - If the indirection is intentional, add `// @perry-allow-dynamic` \
+                                   on the line above the call.\n\
+                                 - To opt an entire dependency out, add its name to \
+                                   `perry.allowDynamicStdlibDispatch` in the host package.json, \
+                                   or set `perry.allowDynamicStdlibDispatch: true` to disable \
+                                   the check globally.\n\
+                                 - Or set `PERRY_ALLOW_DYNAMIC_STDLIB=1` for a one-off build.",
+                                ns,
+                                pkg_label,
+                                ns,
+                                ns,
+                            );
+                        }
+                    }
+                }
+            }
+
             let index = Box::new(lower_expr(ctx, &computed.expr)?);
             // Specialize for Uint8Array/Buffer variables → byte-level access.
             // Params declared `Buffer` (e.g. `function f(src: Buffer)`)
@@ -746,6 +804,109 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
             Ok(Expr::PropertyGet { object, property })
         }
     }
+}
+
+/// #503 — Node-core stdlib namespace receivers whose dynamic (`obj[x]`)
+/// member access is refused at compile time. These are the namespaces
+/// the issue calls out: the well-known shapes used by string-based
+/// obfuscation in malicious npm packages. Globals (`process`, `Buffer`)
+/// and `require`-imported core modules are both covered — Buffer is
+/// intentionally omitted because it is a class constructor (`new Buffer`)
+/// rather than a namespace; the meaningful attack surface there is the
+/// constructor itself, not dynamic property access. Keep this list in
+/// sync with the docs in `docs/src/security/dynamic-dispatch.md`.
+const STDLIB_NAMESPACE_NAMES: &[&str] = &[
+    "process",
+    "fs",
+    "crypto",
+    "child_process",
+    "net",
+    "os",
+    "path",
+    "http",
+    "https",
+    "http2",
+    "stream",
+    "url",
+    "util",
+    "events",
+    "dns",
+    "tls",
+    "querystring",
+    "zlib",
+    "async_hooks",
+    "readline",
+    "string_decoder",
+    "tty",
+    "worker_threads",
+];
+
+/// #503 — does the given AST receiver expression resolve to a known
+/// stdlib namespace? Recognised shapes:
+///   - bare ident matching one of `STDLIB_NAMESPACE_NAMES` (global
+///     `process` or top-level imported `fs` etc.),
+///   - bare ident bound to a stdlib alias via `import x from 'fs'`
+///     (`ctx.builtin_module_aliases` populated by `require()` and ESM
+///     default imports), or
+///   - bare ident bound to a namespace import (`import * as fs from
+///     'fs'`) via `ctx.native_modules` with a `None` method-name.
+///
+/// Returns the canonical stdlib namespace name (e.g. `"fs"`) when a
+/// match is found, so the diagnostic can name the namespace concretely.
+pub(super) fn stdlib_namespace_receiver(
+    ctx: &super::LoweringContext,
+    obj: &ast::Expr,
+) -> Option<&'static str> {
+    // TS type-position wrappers like `(process as any)` and
+    // `<any>process` parse as `TsAsExpr` / `TsTypeAssertion`, and the
+    // `(...)` itself shows up as a `Paren`. Strip them so an idiomatic
+    // `(process as any)[k]()` still surfaces `process` as the receiver.
+    let mut current = obj;
+    loop {
+        match current {
+            ast::Expr::Paren(p) => current = p.expr.as_ref(),
+            ast::Expr::TsAs(a) => current = a.expr.as_ref(),
+            ast::Expr::TsTypeAssertion(a) => current = a.expr.as_ref(),
+            ast::Expr::TsNonNull(a) => current = a.expr.as_ref(),
+            ast::Expr::TsConstAssertion(a) => current = a.expr.as_ref(),
+            ast::Expr::TsSatisfies(a) => current = a.expr.as_ref(),
+            _ => break,
+        }
+    }
+    let ident = match current {
+        ast::Expr::Ident(ident) => ident,
+        _ => return None,
+    };
+    let name = ident.sym.as_ref();
+
+    // Direct global / module specifier match.
+    if let Some(canon) = STDLIB_NAMESPACE_NAMES.iter().find(|n| **n == name) {
+        return Some(*canon);
+    }
+
+    // `require()` / default-import alias: `import fs from 'fs'` →
+    // builtin_module_aliases["fs"] = "fs", but the user may rename:
+    // `import myFs from 'fs'` → ["myFs"] = "fs". Resolve to the
+    // canonical specifier.
+    for (local, module) in ctx.builtin_module_aliases.iter() {
+        if local == name {
+            if let Some(canon) = STDLIB_NAMESPACE_NAMES.iter().find(|n| **n == module.as_str()) {
+                return Some(*canon);
+            }
+        }
+    }
+
+    // Namespace import: `import * as fs from 'fs'` — tracked as a
+    // native_modules entry with method_name = None.
+    for (local, module, method) in ctx.native_modules.iter() {
+        if local == name && method.is_none() {
+            if let Some(canon) = STDLIB_NAMESPACE_NAMES.iter().find(|n| **n == module.as_str()) {
+                return Some(*canon);
+            }
+        }
+    }
+
+    None
 }
 
 /// Issue #562 — does `prop` name a stream-API method or property on the

--- a/crates/perry-hir/tests/dynamic_stdlib_dispatch.rs
+++ b/crates/perry-hir/tests/dynamic_stdlib_dispatch.rs
@@ -179,9 +179,7 @@ fn package_name_extraction() {
     );
     // Nested node_modules → rightmost wins (matches package resolution).
     assert_eq!(
-        package_name_for_source_path(
-            "/repo/node_modules/outer/node_modules/inner/lib/x.ts"
-        ),
+        package_name_for_source_path("/repo/node_modules/outer/node_modules/inner/lib/x.ts"),
         Some("inner")
     );
     assert_eq!(package_name_for_source_path("/repo/src/main.ts"), None);

--- a/crates/perry-hir/tests/dynamic_stdlib_dispatch.rs
+++ b/crates/perry-hir/tests/dynamic_stdlib_dispatch.rs
@@ -1,0 +1,214 @@
+//! #503 — refuse compile-time dynamic dispatch on stdlib namespaces.
+//!
+//! Verifies the supply-chain-hardening HIR pass: `process[runtimeVar]()` and
+//! similar shapes fail compilation, while user-side dynamic dispatch on user
+//! objects, literal-keyed dispatch, and explicitly opted-out sites pass.
+
+use perry_diagnostics::SourceCache;
+use perry_hir::{
+    clear_allow_dynamic_stdlib_packages, clear_current_module_source, lower_module,
+    set_allow_dynamic_stdlib_packages, set_current_module_source,
+    set_refuse_dynamic_stdlib_dispatch,
+};
+use perry_parser::parse_typescript_with_cache;
+
+/// Try to lower `src`. Pin every relevant thread-local around the call so
+/// test ordering can't poison subsequent tests (and so other tests in the
+/// crate can't leak state into ours).
+fn try_lower(src: &str, source_path: &str) -> Result<(), String> {
+    let mut cache = SourceCache::new();
+    let parsed = parse_typescript_with_cache(src, source_path, &mut cache)
+        .map_err(|e| format!("parse failed: {}", e))?;
+    set_refuse_dynamic_stdlib_dispatch(true);
+    set_current_module_source(src.to_string());
+    let outcome = lower_module(&parsed.module, "test", source_path);
+    clear_current_module_source();
+    clear_allow_dynamic_stdlib_packages();
+    set_refuse_dynamic_stdlib_dispatch(true);
+    outcome.map(|_| ()).map_err(|e| e.to_string())
+}
+
+#[test]
+fn refuses_process_dynamic_dispatch() {
+    let src = r#"
+        const k: string = "exit";
+        // @ts-ignore
+        (process as any)[k](0);
+    "#;
+    let err = try_lower(src, "/tmp/host.ts").expect_err("should fail");
+    assert!(
+        err.contains("dynamic dispatch on stdlib namespace `process`"),
+        "unexpected error: {err}"
+    );
+    assert!(err.contains("#503"), "error should cite issue: {err}");
+}
+
+#[test]
+fn refuses_fs_dynamic_dispatch() {
+    let src = r#"
+        import fs from "fs";
+        const name: string = "readFileSync";
+        // @ts-ignore
+        (fs as any)[name]("/tmp/x");
+    "#;
+    let err = try_lower(src, "/tmp/host.ts").expect_err("should fail");
+    assert!(
+        err.contains("dynamic dispatch on stdlib namespace `fs`"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn refuses_namespace_imported_alias() {
+    let src = r#"
+        import * as myFs from "fs";
+        const m: string = "readFileSync";
+        // @ts-ignore
+        (myFs as any)[m]("/tmp");
+    "#;
+    let err = try_lower(src, "/tmp/host.ts").expect_err("should fail");
+    assert!(
+        err.contains("dynamic dispatch on stdlib namespace `fs`"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn allows_literal_string_dispatch() {
+    // `obj["literal"]` folds to PropertyGet → indistinguishable from
+    // `obj.literal`. Never refused.
+    let src = r#"
+        // @ts-ignore
+        const v = (process as any)["version"];
+    "#;
+    try_lower(src, "/tmp/host.ts").expect("literal-key dispatch must compile");
+}
+
+#[test]
+fn allows_user_object_dispatch() {
+    // The check is scoped to stdlib namespaces only. Dynamic dispatch on
+    // user-defined identifiers must remain untouched — that is the
+    // single most important non-regression of this pass.
+    let src = r#"
+        const me = { greet: (n: string) => "hi " + n };
+        const k: string = "greet";
+        // @ts-ignore
+        const r = (me as any)[k]("world");
+    "#;
+    try_lower(src, "/tmp/host.ts").expect("user-object dispatch must compile");
+}
+
+#[test]
+fn site_annotation_opts_out() {
+    let src = r#"
+        const k: string = "exit";
+        // @perry-allow-dynamic
+        // @ts-ignore
+        (process as any)[k](0);
+    "#;
+    try_lower(src, "/tmp/host.ts").expect("site annotation must allow the call");
+}
+
+#[test]
+fn site_annotation_same_line_opts_out() {
+    // Same-line annotation is also recognised — covers the case where
+    // the offending site is on a single line with a trailing comment.
+    let src = r#"
+        const k: string = "exit";
+        // @ts-ignore
+        (process as any)[k](0); // @perry-allow-dynamic
+    "#;
+    try_lower(src, "/tmp/host.ts").expect("trailing annotation must allow the call");
+}
+
+#[test]
+fn per_package_allow_list_opts_out() {
+    // Modules whose source path lies under `node_modules/<pkg>/` resolve
+    // their owning package via `package_name_for_source_path`. If the
+    // package is on the allow list, the check is skipped.
+    let src = r#"
+        const k: string = "exit";
+        // @ts-ignore
+        (process as any)[k](0);
+    "#;
+    let mut cache = SourceCache::new();
+    let parsed = parse_typescript_with_cache(src, "test.ts", &mut cache).unwrap();
+    set_refuse_dynamic_stdlib_dispatch(true);
+    let mut allow = std::collections::HashSet::new();
+    allow.insert("legacy-dep".to_string());
+    set_allow_dynamic_stdlib_packages(allow);
+    set_current_module_source(src.to_string());
+
+    // Path lives under node_modules/legacy-dep → covered by the allow list.
+    let path = "/repo/node_modules/legacy-dep/src/index.ts";
+    let outcome = lower_module(&parsed.module, "legacy-dep", path);
+    clear_current_module_source();
+    clear_allow_dynamic_stdlib_packages();
+    outcome.expect("per-package allow list must opt the dep out");
+}
+
+#[test]
+fn global_disable_opts_out() {
+    let src = r#"
+        const k: string = "exit";
+        // @ts-ignore
+        (process as any)[k](0);
+    "#;
+    let mut cache = SourceCache::new();
+    let parsed = parse_typescript_with_cache(src, "test.ts", &mut cache).unwrap();
+    set_refuse_dynamic_stdlib_dispatch(false);
+    set_current_module_source(src.to_string());
+    let outcome = lower_module(&parsed.module, "test", "/tmp/host.ts");
+    clear_current_module_source();
+    // Re-arm the default so we don't poison subsequent tests on the same
+    // thread (cargo may run multiple tests serially in this binary).
+    set_refuse_dynamic_stdlib_dispatch(true);
+    outcome.expect("disabling refusal must allow the call");
+}
+
+#[test]
+fn package_name_extraction() {
+    use perry_hir::package_name_for_source_path;
+    assert_eq!(
+        package_name_for_source_path("/repo/node_modules/lodash/lib/x.ts"),
+        Some("lodash")
+    );
+    assert_eq!(
+        package_name_for_source_path("/repo/node_modules/@scope/pkg/src/x.ts"),
+        Some("@scope/pkg")
+    );
+    // Nested node_modules → rightmost wins (matches package resolution).
+    assert_eq!(
+        package_name_for_source_path(
+            "/repo/node_modules/outer/node_modules/inner/lib/x.ts"
+        ),
+        Some("inner")
+    );
+    assert_eq!(package_name_for_source_path("/repo/src/main.ts"), None);
+}
+
+#[test]
+fn diagnostic_names_the_namespace() {
+    // The error message must name the offending namespace so reviewers
+    // grepping CI logs can attribute the failure without reading the
+    // surrounding source.
+    let src = r#"
+        import * as crypto from "crypto";
+        const m: string = "randomBytes";
+        // @ts-ignore
+        (crypto as any)[m](16);
+    "#;
+    let err = try_lower(src, "/tmp/host.ts").expect_err("should fail");
+    assert!(
+        err.contains("`crypto`"),
+        "diagnostic should name `crypto`: {err}"
+    );
+    assert!(
+        err.contains("@perry-allow-dynamic"),
+        "diagnostic should mention the opt-out: {err}"
+    );
+    assert!(
+        err.contains("allowDynamicStdlibDispatch"),
+        "diagnostic should mention the package.json key: {err}"
+    );
+}

--- a/crates/perry/src/commands/check.rs
+++ b/crates/perry/src/commands/check.rs
@@ -248,7 +248,13 @@ pub fn run(args: CheckArgs, format: OutputFormat, use_color: bool, verbose: u8) 
 
         // Try to lower to HIR to catch more errors
         let file_id = parse_result.file_id;
-        match perry_hir::lower_module(&parse_result.module, &filename, &filename) {
+        // #503: stash the source text so the dynamic-dispatch check can
+        // resolve `// @perry-allow-dynamic` annotations during `perry check`
+        // the same way it does during a real build.
+        perry_hir::set_current_module_source(source.clone());
+        let lower_outcome = perry_hir::lower_module(&parse_result.module, &filename, &filename);
+        perry_hir::clear_current_module_source();
+        match lower_outcome {
             Ok(_hir_module) => {
                 // Successfully lowered
             }

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -499,6 +499,19 @@ pub struct CompilationContext {
     /// rebuild without the `bundled-streams` feature. This set lets
     /// the registry drain inject the missing feature directly.
     pub extra_stdlib_features: BTreeSet<&'static str>,
+    /// #503: when true, HIR lowering refuses dynamic-dispatch on known
+    /// stdlib namespaces (`process[runtimeVar]()` and similar). Default
+    /// true. Sources, last wins: `perry.allowDynamicStdlibDispatch: true`
+    /// in package.json → env `PERRY_ALLOW_DYNAMIC_STDLIB=1` flips this
+    /// off. An array value (`["@scope/pkg", ...]`) keeps refusal on but
+    /// allows the listed packages — captured in
+    /// `allow_dynamic_stdlib_packages`.
+    pub refuse_dynamic_stdlib_dispatch: bool,
+    /// #503: package names whose modules may legitimately use dynamic
+    /// stdlib dispatch (`perry.allowDynamicStdlibDispatch: [...]`).
+    /// Consulted per-module during HIR lowering; ignored when
+    /// `refuse_dynamic_stdlib_dispatch` is false.
+    pub allow_dynamic_stdlib_packages: HashSet<String>,
 }
 
 impl std::fmt::Debug for CompilationContext {
@@ -543,6 +556,8 @@ impl CompilationContext {
             min_windows_version: "10".to_string(),
             entry_canonical: None,
             extra_stdlib_features: BTreeSet::new(),
+            refuse_dynamic_stdlib_dispatch: true,
+            allow_dynamic_stdlib_packages: HashSet::new(),
         }
     }
 }
@@ -1006,6 +1021,40 @@ pub fn run_with_parse_cache(
                 {
                     ctx.fast_math = fm;
                 }
+                // #503: perry.allowDynamicStdlibDispatch — either a boolean
+                // (`true` disables the refusal globally) or an array of
+                // npm package names allowed to use dynamic dispatch on
+                // stdlib namespaces. Absent / `false` keeps the default
+                // (refusal active for all packages including the host).
+                if let Some(v) = pkg
+                    .get("perry")
+                    .and_then(|p| p.get("allowDynamicStdlibDispatch"))
+                {
+                    if let Some(b) = v.as_bool() {
+                        ctx.refuse_dynamic_stdlib_dispatch = !b;
+                        if b {
+                            match format {
+                                OutputFormat::Text => println!(
+                                    "  Dynamic stdlib dispatch: ALLOWED globally (perry.allowDynamicStdlibDispatch: true)"
+                                ),
+                                OutputFormat::Json => {}
+                            }
+                        }
+                    } else if let Some(arr) = v.as_array() {
+                        for entry in arr {
+                            if let Some(name) = entry.as_str() {
+                                match format {
+                                    OutputFormat::Text => println!(
+                                        "  Dynamic stdlib dispatch: ALLOWED for `{}`",
+                                        name
+                                    ),
+                                    OutputFormat::Json => {}
+                                }
+                                ctx.allow_dynamic_stdlib_packages.insert(name.to_string());
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -1021,6 +1070,26 @@ pub fn run_with_parse_cache(
     if args.fast_math {
         ctx.fast_math = true;
     }
+
+    // #503: `PERRY_ALLOW_DYNAMIC_STDLIB=1` disables the dynamic-dispatch
+    // refusal pass globally (env var beats package.json). `=0` keeps the
+    // refusal on even if the host has opted out, so CI can enforce.
+    match std::env::var("PERRY_ALLOW_DYNAMIC_STDLIB") {
+        Ok(v) if v == "1" || v.eq_ignore_ascii_case("true") => {
+            ctx.refuse_dynamic_stdlib_dispatch = false;
+        }
+        Ok(v) if v == "0" || v.eq_ignore_ascii_case("false") => {
+            ctx.refuse_dynamic_stdlib_dispatch = true;
+        }
+        _ => {}
+    }
+    // #503: install the resolved configuration into the HIR thread-locals
+    // before any module lowering begins. Re-installed per-thread by
+    // `collect_modules.rs` (rayon workers don't inherit thread-locals),
+    // but this set covers the driver thread's own lowering work and
+    // serves as documentation of the source of truth.
+    perry_hir::set_refuse_dynamic_stdlib_dispatch(ctx.refuse_dynamic_stdlib_dispatch);
+    perry_hir::set_allow_dynamic_stdlib_packages(ctx.allow_dynamic_stdlib_packages.clone());
 
     // --- i18n: parse [i18n] config from perry.toml and load locale files ---
     let mut i18n_config: Option<perry_transform::i18n::I18nConfig> = None;

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -286,6 +286,17 @@ pub(super) fn collect_modules(
     // immediately after the lower call so it can't leak to subsequent
     // unrelated work on the same thread.
     perry_hir::set_compile_packages_override(ctx.compile_packages.clone());
+    // #503: re-install the dynamic-stdlib-dispatch config on the current
+    // thread before each lower. Driver may be a rayon worker that didn't
+    // inherit the thread-local set on the main thread by `compile.rs`.
+    perry_hir::set_refuse_dynamic_stdlib_dispatch(ctx.refuse_dynamic_stdlib_dispatch);
+    perry_hir::set_allow_dynamic_stdlib_packages(ctx.allow_dynamic_stdlib_packages.clone());
+    // #503: stash the module source text so the dynamic-dispatch check
+    // can look up `// @perry-allow-dynamic` line annotations adjacent to
+    // any violation site without re-reading the file. Cleared right
+    // after the lower call so it can't leak to unrelated work on this
+    // thread.
+    perry_hir::set_current_module_source(source.clone());
     let lower_result = perry_hir::lower_module_full(
         ast_module,
         &module_name,
@@ -297,6 +308,7 @@ pub(super) fn collect_modules(
         is_external_module,
     );
     perry_hir::clear_compile_packages_override();
+    perry_hir::clear_current_module_source();
     let (mut hir_module, new_next_class_id) = lower_result?;
     *next_class_id = new_next_class_id; // Update the global class_id counter
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -137,6 +137,7 @@
 - [Commands](cli/commands.md)
 - [Compiler Flags](cli/flags.md)
 - [Fast-math (`--fast-math`)](cli/fast-math.md)
+- [Dynamic Stdlib Dispatch](cli/dynamic-dispatch.md)
 - [perry.toml Reference](cli/perry-toml.md)
 
 ---

--- a/docs/src/cli/dynamic-dispatch.md
+++ b/docs/src/cli/dynamic-dispatch.md
@@ -3,7 +3,7 @@
 Perry refuses compile-time *dynamic dispatch* on Node-core stdlib namespaces.
 A call site like
 
-```ts
+```typescript,no-test
 const m = "exit";
 (process as any)[m](0);
 ```
@@ -32,7 +32,7 @@ Dynamic dispatch is refused when **all** of the following hold:
 
 User-code reflection on user-defined objects is unaffected:
 
-```ts
+```typescript,no-test
 const me = { greet: (n: string) => "hi " + n };
 const k = "greet";
 me[k]("world"); // ✓ user object, not a stdlib namespace
@@ -47,7 +47,7 @@ The error message lists the available opt-outs in priority order:
 The preferred fix. The check exists precisely because static calls are
 auditable.
 
-```ts
+```typescript,no-test
 process.exit(0);                // ✓
 fs.readFileSync("/tmp/x");       // ✓
 ```
@@ -57,7 +57,7 @@ fs.readFileSync("/tmp/x");       // ✓
 For legitimate one-off dispatch, drop a line comment on or immediately
 above the offending site:
 
-```ts
+```typescript,no-test
 const k = pickHandler();
 // @perry-allow-dynamic
 (process as any)[k](0);

--- a/docs/src/cli/dynamic-dispatch.md
+++ b/docs/src/cli/dynamic-dispatch.md
@@ -1,0 +1,116 @@
+# Dynamic Stdlib Dispatch (`@perry-allow-dynamic`)
+
+Perry refuses compile-time *dynamic dispatch* on Node-core stdlib namespaces.
+A call site like
+
+```ts
+const m = "exit";
+(process as any)[m](0);
+```
+
+fails to compile. The check exists to catch the standard string-based
+obfuscation pattern used by malicious npm packages:
+`process["bind" + "ing"]("dns")`, `globalThis[atob("ZXZhbA==")]()`,
+`fs[methodName]()` where `methodName` is computed at runtime.
+
+The pass is purely compile-time — **zero runtime cost** — and is on by
+default. Issue [#503](https://github.com/PerryTS/perry/issues/503) tracks the
+design.
+
+## What's checked
+
+Dynamic dispatch is refused when **all** of the following hold:
+
+1. The receiver resolves to a known Node-core stdlib namespace:
+   `process`, `fs`, `crypto`, `child_process`, `net`, `os`, `path`, `http`,
+   `https`, `http2`, `stream`, `url`, `util`, `events`, `dns`, `tls`,
+   `querystring`, `zlib`, `async_hooks`, `readline`, `string_decoder`,
+   `tty`, `worker_threads`.
+2. The index expression is *not* a string literal — `fs["readFileSync"]`
+   is treated identically to `fs.readFileSync` and always passes.
+3. The user has not opted out (see below).
+
+User-code reflection on user-defined objects is unaffected:
+
+```ts
+const me = { greet: (n: string) => "hi " + n };
+const k = "greet";
+me[k]("world"); // ✓ user object, not a stdlib namespace
+```
+
+## Opt-outs
+
+The error message lists the available opt-outs in priority order:
+
+### 1. Replace with a static call
+
+The preferred fix. The check exists precisely because static calls are
+auditable.
+
+```ts
+process.exit(0);                // ✓
+fs.readFileSync("/tmp/x");       // ✓
+```
+
+### 2. `// @perry-allow-dynamic` annotation
+
+For legitimate one-off dispatch, drop a line comment on or immediately
+above the offending site:
+
+```ts
+const k = pickHandler();
+// @perry-allow-dynamic
+(process as any)[k](0);
+```
+
+Contiguous comment lines above the call also count, so the annotation
+can sit alongside an `// @ts-ignore` or similar.
+
+### 3. Per-package allow list in `package.json`
+
+To opt one or more npm dependencies out, list them under
+`perry.allowDynamicStdlibDispatch` in the **host** application's
+`package.json`:
+
+```json
+{
+  "perry": {
+    "allowDynamicStdlibDispatch": ["legacy-dep", "@scope/other-dep"]
+  }
+}
+```
+
+Modules whose source path lives under
+`node_modules/<pkg>/…` are matched against this list. Host code is
+*not* covered — opting host code out requires the global flag below
+or the site annotation.
+
+### 4. Global opt-out
+
+To disable the check across the entire build, set the boolean form:
+
+```json
+{ "perry": { "allowDynamicStdlibDispatch": true } }
+```
+
+…or set the env var for a one-off build:
+
+```bash
+PERRY_ALLOW_DYNAMIC_STDLIB=1 perry build src/main.ts
+```
+
+CI can enforce the check by setting `PERRY_ALLOW_DYNAMIC_STDLIB=0`,
+which beats any package.json opt-out.
+
+## Why on by default
+
+The check is the cheapest possible defense against the
+dispatch-by-string class of supply-chain evasion. The cost to legitimate
+code is essentially zero — static calls and literal-keyed access compile
+unchanged. Code that genuinely needs the indirection has four ways to
+say so explicitly, and the failure mode is a build error rather than a
+silent miss in detection.
+
+See [`#503`](https://github.com/PerryTS/perry/issues/503) for design
+discussion and the broader supply-chain hardening series ([`#495`–`#506`]
+(https://github.com/PerryTS/perry/issues?q=is%3Aissue+label%3Aenhancement+security)).


### PR DESCRIPTION
Closes #503.

## Summary

- Compile-time HIR pass refuses `obj[runtimeVar]()` and `obj[atob(...)]()` shapes when `obj` resolves to a Node-core stdlib namespace (`process`, `fs`, `crypto`, `child_process`, `net`, `os`, `path`, `http`, `https`, `http2`, `stream`, `url`, `util`, `events`, `dns`, `tls`, `querystring`, `zlib`, `async_hooks`, `readline`, `string_decoder`, `tty`, `worker_threads`).
- Catches the dispatch-by-string class of supply-chain evasion: `process["bind"+"ing"]("dns")`, `fs[atob("...")]()`, `child_process[methodName]()`.
- Zero runtime cost — purely a compile-time refusal. Lives in the platform-agnostic HIR pass, so it applies uniformly to **every backend**: native LLVM, WASM, ArkTS / HarmonyOS, JS, Glance, SwiftUI.

## What's untouched

- Literal-string keys (`fs["readFileSync"]("/tmp/x")`) fold to `PropertyGet` and always pass.
- Dynamic dispatch on **user objects** is unaffected — that's the single most important non-regression.
- The check only fires when the receiver resolves to a known stdlib namespace (bare ident, default import alias, or `import * as ns` namespace import).

## Opt-outs (listed in the error message itself)

1. **Static call** (preferred): `process.exit(0)`.
2. **Site annotation**: `// @perry-allow-dynamic` on or above the call site. Stacks with `// @ts-ignore` and similar.
3. **Per-package allow list**: `perry.allowDynamicStdlibDispatch: ["@scope/dep"]` in the host `package.json`, matched against `node_modules/<pkg>/…`.
4. **Global disable**: `perry.allowDynamicStdlibDispatch: true` in the host `package.json`.
5. **Env var**: `PERRY_ALLOW_DYNAMIC_STDLIB=1` for one-off builds; `=0` enforces the check even when `package.json` opts out, so CI can gate.

## Implementation

Plumbing follows the existing #665 thread-local pattern in `collect_modules.rs`:
- Per-thread config (`set_refuse_dynamic_stdlib_dispatch`, `set_allow_dynamic_stdlib_packages`) installed before each `lower_module_full` call.
- Per-module source-text stash (`set_current_module_source`) lets the annotation lookup resolve `// @perry-allow-dynamic` without re-reading the file from disk.
- All thread-locals cleared after the lower call so rayon worker state can't leak across modules.

The check sits in `lower_member.rs::lower_member`'s `MemberProp::Computed` arm, before index lowering, and unwraps TS type wrappers (`Paren`, `TsAs`, `TsTypeAssertion`, `TsNonNull`, `TsConstAssertion`, `TsSatisfies`) so idiomatic `(process as any)[k]()` still surfaces `process` as the receiver.

The error message names the namespace, cites issue #503, and walks the user through every opt-out path.

## Files

- `crates/perry-hir/src/ir.rs` — thread-locals + `package_name_for_source_path` helper + annotation-lookup helper.
- `crates/perry-hir/src/lower/expr_member.rs` — the refusal check + `stdlib_namespace_receiver` helper (handles bare ident, `builtin_module_aliases`, namespace imports, TS-wrapper unwrapping).
- `crates/perry/src/commands/compile.rs` — parses `perry.allowDynamicStdlibDispatch` from `package.json` (boolean or array), env-var override, applies config to the driver thread.
- `crates/perry/src/commands/compile/collect_modules.rs` — re-installs config on each rayon worker before lowering.
- `crates/perry/src/commands/check.rs` — installs the source-text thread-local during `perry check` so site annotations resolve there too.
- `crates/perry-hir/tests/dynamic_stdlib_dispatch.rs` — 11 unit tests covering refusal, every opt-out path, namespace-extraction edge cases, and the diagnostic text.
- `docs/src/cli/dynamic-dispatch.md` + `docs/src/SUMMARY.md` — user-facing documentation.

## Test plan

- [x] `cargo test -p perry-hir` — 118 tests pass (incl. 11 new).
- [x] `cargo test --release -p perry --tests` — 244 tests pass.
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry -p perry-codegen-wasm -p perry-codegen-arkts -p perry-codegen-swiftui -p perry-codegen-glance -p perry-codegen-js` — all platform backends build clean.
- [x] End-to-end smoke test: `(process as any)[k](0)` fails with the new diagnostic; literal-key, `// @perry-allow-dynamic`, and `PERRY_ALLOW_DYNAMIC_STDLIB=1` all compile cleanly.
- [x] No new warnings introduced.

## Notes

- No `Cargo.toml` version bump, no `CLAUDE.md` version line touch, no `CHANGELOG.md` entry — per the external-contributor PR policy / to avoid version-bump collisions while this is in review. Maintainer will fold those in at merge time.