### PR TITLE
test(regression): #678 — exhaustive V8-fallback symbol-link coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.968 — test(regression): #678 — exhaustive V8-fallback symbol-link coverage
+
+**Background.** Issue #678 reported `Undefined symbols: _perry_fn_node_modules_ink_build_render_js__render` for ink + react when imports landed on the V8 fallback (modules outside `perry.compilePackages`, or modules pulled in transitively where some sibling fell back to V8). Two fixes have already landed:
+
+- v0.5.785 — `fix(codegen): #678 — re-export rename resolves to origin export name` (suffix tracking across `export { default as X } from "./Y.js"` barrels).
+- v0.5.796 followup (`fix(codegen): #678 — V8-fallback callsites route through V8 bridge`) — every consumer-side codegen site that previously formed a bare `perry_fn_<v8src>__<name>` extern now consults `import_function_v8_specifiers` first and short-circuits to `js_call_v8_export(specifier, name, args, argc)` when the source module was demoted to `ModuleKind::Interpreted`.
+
+The ink + react repro from the issue now links cleanly (the link-error symptom is gone; the entry binary fails downstream on a React-internal `Activity` runtime gap, which is a separate issue).
+
+**This release.** Adds `test-files/test_issue_678_v8_fallback_symbols.ts` — an exhaustive regression test that exercises every codegen site the V8-bridge fix has to cover so a future refactor can't silently regress one shape:
+
+1. **Named import + direct call** — `greet(...)`, `add(...)` from `./fixtures/issue_678_v8/mod.js`. Hits `lower_call.rs:~1197` (the `import_function_v8_specifiers.get(name)` short-circuit before forming `perry_fn_<src>__<name>`).
+2. **Default import + direct call** — `defaultFn(...)` from `./fixtures/issue_678_v8/default_mod.js`. Same call-site, but with `name == "default"`; pre-fix this formed `perry_fn_<default_mod_js>__default` and link-failed.
+3. **Namespace import + member call** — `ns.greet(...)` / `ns.add(...)` from `import * as ns from "./mod.js"`. Hits the separate codegen path at `lower_call.rs:~560` (member-access through a registered namespace).
+4. **Function-as-value (closure-wrapper)** — `apply1(greet, "world")`, `apply2(add, 100, 23)`. Forces the codegen to materialise `js_closure_alloc_singleton(@__perry_wrap_perry_fn_<src>__<name>)`; pre-fix the wrapper stub symbol referenced here was also missing for V8-routed imports.
+
+Paired with a new fixture `test-files/fixtures/issue_678_v8/default_mod.js` (default function export + a named export) alongside the existing `mod.js` (named-only). Both fixtures are `.js` files outside `perry.compilePackages`, so the import-collection pass mandatorily lands them in `ModuleKind::Interpreted`.
+
+**Validation.**
+
+```
+$ ./target/release/perry compile test-files/test_issue_678_v8_fallback_symbols.ts -o /tmp/t678s
+Found 3 module(s): 1 native, 2 JavaScript
+Wrote executable: /tmp/t678s
+$ diff <(/tmp/t678s) <(node --experimental-strip-types test-files/test_issue_678_v8_fallback_symbols.ts) && echo OK
+OK
+```
+
+Output:
+
+```
+named: hello perry
+named-arity2: 42
+default: v8-default: hi
+default-mod-named: v8-named: ho
+ns-named: hello ns
+ns-arity2: 30
+apply-named: hello world
+apply-default: v8-default: world
+apply-add: 123
+done
+```
+
+The existing `test-files/test_issue_678_v8_fallback.ts` (named-only smoke) and `test-files/test_issue_678_reexport_default.ts` (re-export rename) still pass unchanged. Ink + react also links cleanly (`Found 91 module(s): 68 native, 23 JavaScript` → `Wrote executable: counter`); the React `Activity` runtime gap that surfaces post-link is a separate issue.
+
 ## v0.5.967 — fix(codegen): #321 — factory-returned-class `.staticMethod(args)` bundles args into synthetic `arguments` rest
 
 **Symptom.** `import { Effect } from "effect"; console.log("smoke:", typeof (Effect as any).succeed)` advanced through Schema.ts module init past the post-#912 (gap 1 + gap 2) sites but still threw

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.967
+**Current Version:** 0.5.968
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.967"
+version = "0.5.968"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.967"
+version = "0.5.968"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.967"
+version = "0.5.968"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.967"
+version = "0.5.968"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.967"
+version = "0.5.968"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/test-files/fixtures/issue_678_v8/default_mod.js
+++ b/test-files/fixtures/issue_678_v8/default_mod.js
@@ -1,0 +1,20 @@
+// Issue #678 followup: V8-fallback module with a *default function*
+// export plus a named export. Pre-fix, the consumer-side codegen for
+// `import defaultFn from "./default_mod.js"` formed an undefined
+// `perry_fn_<src>__default` extern; the linker failed with
+// `Undefined symbols: _perry_fn_..._default`. With the V8 bridge
+// fix, the same call lowers to `js_call_v8_export(specifier,
+// "default", args, argc)` and the link succeeds.
+//
+// Paired with the existing `mod.js` fixture (named-only exports) so
+// `test_issue_678_v8_fallback_symbols.ts` can exercise every
+// codegen site that previously emitted a `perry_fn_<v8src>__<name>`
+// symbol — named, default, and namespace-member.
+
+export default function defaultFn(x) {
+  return "v8-default: " + x;
+}
+
+export function named(x) {
+  return "v8-named: " + x;
+}

--- a/test-files/test_issue_678_v8_fallback_symbols.ts
+++ b/test-files/test_issue_678_v8_fallback_symbols.ts
@@ -1,0 +1,55 @@
+// Issue #678 followup: exhaustive coverage of the codegen sites that
+// previously emitted bare `perry_fn_<v8src>__<name>` extern references
+// for imports landing in `ModuleKind::Interpreted`. The V8 fallback
+// path never emits those native symbols (the module is loaded through
+// `js_load_module`), so the link failed with `Undefined symbols:
+// _perry_fn_..._<name>`.
+//
+// The fix at crates/perry-codegen/src/{lower_call,expr,codegen}.rs
+// threads `import_function_v8_specifiers` through every call site that
+// builds a `perry_fn_<src>__<name>` symbol and short-circuits to
+// `js_call_v8_export(specifier, name, args, argc)` for V8-routed
+// imports. This regression locks in the link + runtime behavior for
+// the four codegen shapes the bridge has to cover:
+//
+//   1. Named import + direct call             →  lower_call.rs:1197
+//   2. Default import + direct call           →  lower_call.rs:1197 (name="default")
+//   3. Namespace import + member call         →  lower_call.rs:560
+//   4. Named import + function-as-value       →  expr.rs `js_closure_alloc_singleton`
+//                                                wrapper (`__perry_wrap_perry_fn_<src>__<name>`)
+//
+// Acceptance: byte-for-byte parity with `node --experimental-strip-types`.
+
+import defaultFn, { named } from "./fixtures/issue_678_v8/default_mod.js";
+import { greet, add } from "./fixtures/issue_678_v8/mod.js";
+import * as ns from "./fixtures/issue_678_v8/mod.js";
+
+// 1. Named-from-V8 + direct call.
+console.log("named:", greet("perry"));
+console.log("named-arity2:", add(40, 2));
+
+// 2. Default-from-V8 + direct call. Pre-fix this site formed
+// `perry_fn_<default_mod_js>__default` and link-failed.
+console.log("default:", defaultFn("hi"));
+console.log("default-mod-named:", named("ho"));
+
+// 3. Namespace member call. Pre-fix `ns.greet(...)` formed
+// `perry_fn_<mod_js>__greet` through the member-access codegen path.
+console.log("ns-named:", ns.greet("ns"));
+console.log("ns-arity2:", ns.add(10, 20));
+
+// 4. Function-as-value: hand the imported binding to another helper
+// so the codegen takes the `js_closure_alloc_singleton(
+// @__perry_wrap_perry_fn_<src>__<name>)` path. Pre-fix the wrapper
+// stub symbol referenced here was also missing.
+function apply1(fn: (s: string) => string, value: string): string {
+  return fn(value);
+}
+function apply2(fn: (a: number, b: number) => number, a: number, b: number): number {
+  return fn(a, b);
+}
+console.log("apply-named:", apply1(greet, "world"));
+console.log("apply-default:", apply1(defaultFn, "world"));
+console.log("apply-add:", apply2(add, 100, 23));
+
+console.log("done");


### PR DESCRIPTION
## Summary

- Adds `test-files/test_issue_678_v8_fallback_symbols.ts` — exhaustive regression that exercises all four codegen sites the V8-bridge fix has to satisfy (named direct call, default direct call, namespace member call, function-as-value/closure wrapper) so a future refactor can't silently regress one shape.
- Adds `test-files/fixtures/issue_678_v8/default_mod.js` — companion fixture with a default function export, paired with the existing `mod.js` (named-only).
- Bumps version to 0.5.968 + CHANGELOG entry. No source-code changes — the underlying fixes shipped in v0.5.785 + v0.5.796; this is the regression net under them.

The ink+react repro from the original issue links cleanly post-fix (`Found 91 module(s): 68 native, 23 JavaScript` → `Wrote executable: counter`); the React `Activity` runtime gap that surfaces after link is a separate issue.

## Test plan

- [x] `cargo fmt`
- [x] `cargo build --release -p perry`
- [x] `./target/release/perry compile test-files/test_issue_678_v8_fallback_symbols.ts -o /tmp/t678s` — links cleanly, 1 native + 2 JavaScript modules.
- [x] `diff <(/tmp/t678s) <(node --experimental-strip-types test-files/test_issue_678_v8_fallback_symbols.ts)` — byte-for-byte parity.
- [x] Existing `test_issue_678_v8_fallback.ts` (named-only) + `test_issue_678_reexport_default.ts` (re-export rename) still pass.
- [x] ink+react repro (`import { render, Text, Box } from "ink"`) still links.