### PR TITLE
feat(security): #500 — single sanitizer for package-metadata-derived linker args

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -156,7 +156,12 @@ fn read_app_metadata(
         })
         .or_else(|| package_bundle_id_from_input(input))
         .unwrap_or_else(|| {
-            let stem = input.file_stem().and_then(|s| s.to_str()).unwrap_or("app");
+            // Issue #500: bundle_id flows into codesign / productbuild
+            // argv. The input file stem is attacker-influenceable
+            // (tooling-chosen paths), so route it through the shared
+            // sanitizer before splicing into the reverse-DNS string.
+            let raw = input.file_stem().and_then(|s| s.to_str()).unwrap_or("app");
+            let stem = crate::commands::sanitize::sanitize_for_bundle_id_component(raw);
             format!("com.perry.{stem}")
         });
 
@@ -5503,11 +5508,19 @@ pub fn run_with_parse_cache(
         None
     };
 
-    let stem = args
+    let raw_stem = args
         .input
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("output");
+    // Issue #500: the input file stem flows into argv as `-o <stem>.dylib`
+    // (and friends) to the linker. A pathological input filename like
+    // `@evil.ts` re-triggers the ld64 response-file class of bug
+    // (originally fixed in #467 for `package.json` names only). Route
+    // through the shared sanitizer so the entire char-class is scrubbed
+    // at one fuzz-tested choke point.
+    let stem_owned = super::sanitize::sanitize_for_linker_argv(raw_stem);
+    let stem = stem_owned.as_str();
     let is_dylib = args.output_type == "dylib";
     let exe_path = args.output.unwrap_or_else(|| {
         if is_dylib {

--- a/crates/perry/src/commands/mod.rs
+++ b/crates/perry/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod login;
 pub mod native;
 pub mod publish;
 pub mod run;
+pub mod sanitize;
 pub mod setup;
 pub mod stdlib_features;
 pub mod typecheck;

--- a/crates/perry/src/commands/run.rs
+++ b/crates/perry/src/commands/run.rs
@@ -1508,25 +1508,19 @@ fn read_app_metadata(project_root: &Path, input: &Path) -> (String, String) {
             .unwrap_or("app")
             .to_string()
     });
-    let name = sanitize_app_name(&raw_name);
+    // Issue #500 (generalises #467): the package-derived name flows
+    // into argv as `-o <name>` to the linker and as a bundle-ID stem
+    // into codesign. Route through the shared sanitizer so every
+    // hostile-character class (response-file `@`, flag-like `-`,
+    // shell metacharacters, control bytes, path traversal, bidi
+    // marks, …) is scrubbed at a single, fuzz-tested choke point.
+    let name = super::sanitize::sanitize_for_linker_argv(&raw_name);
 
     let bundle_id = toml_bundle_id
         .or(pkg_bundle_id)
         .unwrap_or_else(|| format!("com.perry.{}", name));
 
     (name, bundle_id)
-}
-
-/// Make a package.json/perry.toml `name` safe to use as an output filename
-/// and as a default bundle-ID component.
-///
-/// npm scoped names look like `@scope/pkg`. Passed unchanged as `-o @scope/pkg`,
-/// ld64 sees the leading `@` and tries to expand the path as a response file
-/// (issue #467). Strip the `@` and flatten `/` to `-` so the result is a plain
-/// path segment that's also a valid Apple bundle-ID component.
-fn sanitize_app_name(name: &str) -> String {
-    let trimmed = name.strip_prefix('@').unwrap_or(name);
-    trimmed.replace('/', "-")
 }
 
 /// Read iOS-specific config from perry.toml

--- a/crates/perry/src/commands/sanitize.rs
+++ b/crates/perry/src/commands/sanitize.rs
@@ -1,0 +1,337 @@
+//! Sanitizers for package/user-controlled metadata before it flows
+//! into linker arguments or filesystem paths.
+//!
+//! ## Threat model — issue #500
+//!
+//! The compiler consumes attacker-influenceable strings — `package.json`
+//! `name`, input file paths chosen by tooling, `perry.toml` overrides —
+//! and threads them into shell-invoked external commands (the linker,
+//! `codesign`, `productbuild`, `xattr`, `install_name_tool`, …). Each
+//! thread gives the attacker a chance to flip the argument into a
+//! *directive* rather than a value:
+//!
+//! - **ld64 response-file expansion** (`@file`): `@scope/pkg` reads as
+//!   "expand from response-file named scope/pkg". The original symptom
+//!   of issue #467, generalised here.
+//! - **Linker / shell flags** (`-name`): a leading `-` makes the linker
+//!   interpret the string as an option.
+//! - **Absolute / traversal paths** (`/etc/passwd`, `../../`): escape
+//!   the build directory when used in `-o`, `-install_name`,
+//!   `-Wl,--soname`, codesign output paths, etc.
+//! - **Shell metacharacters** (`;`, `|`, `&`, `>`, `<`, `$`, backtick,
+//!   `\`, `"`, `'`, `(`, `)`, `{`, `}`): when a tool re-splits its argv
+//!   through a shell (codesign on some macOS configs, every Windows
+//!   `cmd.exe` invocation, etc.).
+//! - **Whitespace** (` `, `\t`, `\n`, `\r`): argv splitter.
+//! - **Control bytes** (`\0`, `\x01..\x1F`): exotic terminator handling
+//!   varies by libc and linker; an embedded NUL most reliably truncates.
+//! - **Path separators** (`/`, `\`): produce surprise multi-component
+//!   paths from what was meant to be a single component.
+//! - **Non-ASCII look-alikes**: locale-sensitive equivalences
+//!   (`ｐ` vs `p`, RTL bidi marks, zero-width joiners) and width
+//!   attacks against humans diffing logs.
+//!
+//! All of these collapse to the same mitigation: rewrite the input to a
+//! conservative `[A-Za-z0-9._-]` subset, with a non-empty fallback for
+//! inputs that consist *entirely* of unsafe bytes.
+//!
+//! ## Why a single function
+//!
+//! The earlier one-off `sanitize_app_name` (issue #467) closed the
+//! `@scope/pkg` arm only. A new linker-adjacent derivation site is
+//! easy to miss; a reviewer who does not know the historical incident
+//! has no signal to look. The single shared function lets `grep`
+//! answer "is every derivation site sanitized?" by counting call
+//! sites, and the fuzz suite next to the function
+//! (`tests/sanitize_linker_arg.rs`) keeps us honest about
+//! characters we have not yet thought of.
+//!
+//! ## What this is NOT
+//!
+//! This function is intentionally aggressive. The caller is expected
+//! to be deriving a *synthetic identifier* (output filename, install
+//! name, soname, default bundle-ID stem) — not echoing back user
+//! content that needs to round-trip. Where a value must round-trip to
+//! the end user (e.g. an Info.plist `<string>CFBundleDisplayName</string>`
+//! containing the raw `package.json` name), the caller is responsible
+//! for emitting the value through the right encoder for that medium
+//! (XML escape, JSON escape, etc.) instead of this function.
+
+/// The fallback identifier used when the entire input scrubs to the
+/// empty string (every byte was unsafe). Picked because it is the
+/// same default Perry already uses for unnamed builds.
+pub const SAFE_FALLBACK: &str = "app";
+
+/// Sanitize a metadata-derived string so it is safe to use as a single
+/// argv token for the linker (ld, ld64, lld, lld-link, link.exe) and
+/// codesigning tools, and is also safe to use as a single path
+/// component on every supported host.
+///
+/// Output character set: `[A-Za-z0-9._-]`. Plus the legacy backwards-
+/// compatible mapping that preserves what `sanitize_app_name` produced
+/// for the issue #467 shape:
+///
+/// - A *single* leading `@` is dropped (npm scope prefix).
+/// - `/` (and `\` on Windows-shaped inputs) flattens to `-` so
+///   `@scope/pkg` round-trips to the recognisable filename
+///   `scope-pkg`.
+///
+/// Every other unsafe byte becomes `_`. Leading `.` or `-` get a `_`
+/// prefix so the result is not interpreted as a hidden file or as a
+/// flag. Whole-string `.` and `..` collapse to [`SAFE_FALLBACK`].
+/// Empty results fall back to [`SAFE_FALLBACK`].
+///
+/// The function is byte-deterministic and allocates exactly once.
+pub fn sanitize_for_linker_argv(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 1);
+    let mut chars = raw.chars().peekable();
+    // Drop a single leading '@' so npm-scoped names round-trip to the
+    // same filename the workspace already used pre-issue #500. Note:
+    // only a *single* leading '@' is dropped; `@@evil` keeps the second
+    // one and that one is then scrubbed to `_` by the loop below.
+    if chars.peek() == Some(&'@') {
+        chars.next();
+    }
+    for c in chars {
+        if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
+            out.push(c);
+        } else if c == '/' || c == '\\' {
+            // Scoped packages: `@scope/pkg` → `scope-pkg`. Matches the
+            // legacy `sanitize_app_name` behavior so reviewers
+            // recognise the resulting filename.
+            out.push('-');
+        } else {
+            out.push('_');
+        }
+    }
+    // Reserve `.` and `..` because most filesystem APIs reject them
+    // as path components even though they pass the char-class scrub.
+    // Checked *before* the prefix-quoting step below so the fallback
+    // string is returned cleanly (otherwise `..` would map to `_..`
+    // which is harmless but less recognisable in build logs).
+    if out == "." || out == ".." {
+        return SAFE_FALLBACK.to_string();
+    }
+    if out.is_empty() {
+        return SAFE_FALLBACK.to_string();
+    }
+    // After the scrub: a leading `.` is still a hidden file on Unix
+    // and breaks some bundle tooling; a leading `-` is still
+    // interpretable as a flag by every command-line tool. Prefix `_`
+    // in either case. The leading `@` was already dropped above.
+    if matches!(out.as_bytes().first(), Some(b'.') | Some(b'-')) {
+        out.insert(0, '_');
+    }
+    out
+}
+
+/// Sanitize for use as one reverse-DNS bundle-ID component
+/// (`com.perry.<this>`). Same character class as
+/// [`sanitize_for_linker_argv`], additionally lowercased — Apple
+/// recommends and many provisioning tools require bundle IDs to be
+/// lowercase-canonical, and bundle IDs flow into `codesign --sign`
+/// invocations where the linker-argv concerns apply identically.
+pub fn sanitize_for_bundle_id_component(raw: &str) -> String {
+    let mut out = sanitize_for_linker_argv(raw);
+    out.make_ascii_lowercase();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn issue_467_scoped_name_roundtrip() {
+        // The canonical regression: an npm-scoped package name flowed
+        // through `-o @foo/bar` and ld64 expanded `@foo/bar` as a
+        // response file. The sanitizer drops the `@` and flattens the
+        // `/`. Output is still readable so build logs are debuggable.
+        assert_eq!(sanitize_for_linker_argv("@foo/bar"), "foo-bar");
+        assert_eq!(sanitize_for_linker_argv("@scope/pkg/sub"), "scope-pkg-sub");
+    }
+
+    #[test]
+    fn leading_dash_gets_quoted_with_underscore() {
+        // Anything starting with `-` is interpretable as a linker flag.
+        assert_eq!(sanitize_for_linker_argv("-rpath"), "_-rpath");
+        assert_eq!(sanitize_for_linker_argv("--all-load"), "_--all-load");
+    }
+
+    #[test]
+    fn leading_dot_is_not_hidden_file() {
+        assert_eq!(sanitize_for_linker_argv(".cargo"), "_.cargo");
+        assert_eq!(sanitize_for_linker_argv(".."), SAFE_FALLBACK);
+        assert_eq!(sanitize_for_linker_argv("."), SAFE_FALLBACK);
+    }
+
+    #[test]
+    fn embedded_newlines_and_control_bytes() {
+        // Newlines split argv when shell-piped; NUL terminates C
+        // strings. Both must scrub.
+        assert_eq!(sanitize_for_linker_argv("foo\nbar"), "foo_bar");
+        assert_eq!(sanitize_for_linker_argv("foo\0bar"), "foo_bar");
+        assert_eq!(sanitize_for_linker_argv("foo\tbar"), "foo_bar");
+        assert_eq!(sanitize_for_linker_argv("foo\rbar"), "foo_bar");
+        for b in 0u8..0x20 {
+            let raw = format!("a{}b", b as char);
+            let out = sanitize_for_linker_argv(&raw);
+            assert!(
+                out.bytes().all(|c| c >= 0x20),
+                "control byte {:#x} leaked through: {:?}",
+                b,
+                out
+            );
+        }
+    }
+
+    #[test]
+    fn shell_metacharacters_scrub() {
+        // Each one of these is a directive to bash, zsh, or cmd.exe
+        // when the linker / codesign call goes through a shell.
+        for meta in [
+            ";", "|", "&", ">", "<", "$", "`", "\\", "\"", "'", "(", ")", "{", "}", "*", "?", "!",
+            "#", "~", "^", " ",
+        ] {
+            let raw = format!("a{meta}b");
+            let out = sanitize_for_linker_argv(&raw);
+            assert!(
+                !out.contains(meta),
+                "shell metachar {:?} leaked through: {:?}",
+                meta,
+                out
+            );
+        }
+    }
+
+    #[test]
+    fn path_separators_flatten() {
+        // POSIX path:
+        assert_eq!(sanitize_for_linker_argv("a/b/c"), "a-b-c");
+        // Windows-shaped path (someone copy-pastes a path from a
+        // Windows error message into package.json `name`):
+        assert_eq!(sanitize_for_linker_argv("a\\b\\c"), "a-b-c");
+        // Path traversal:
+        assert_eq!(
+            sanitize_for_linker_argv("../../etc/passwd"),
+            "_..-..-etc-passwd"
+        );
+        // Leading `/` flattens to `-`, then the leading-`-` rule
+        // prefixes the `_` so the output is not interpretable as a
+        // linker flag.
+        assert_eq!(sanitize_for_linker_argv("/etc/passwd"), "_-etc-passwd");
+    }
+
+    #[test]
+    fn non_ascii_lookalikes_scrub() {
+        // Full-width 'p' (U+FF50) looks identical to 'p' in some
+        // fonts and would round-trip through anything that lower-cases
+        // by codepoint range. Scrub.
+        assert_eq!(sanitize_for_linker_argv("ｐerry"), "_erry");
+        // Bidi marks (U+202E RTL override) make the string display
+        // very differently from how the linker reads it.
+        let with_bidi = "good\u{202E}evil";
+        let out = sanitize_for_linker_argv(with_bidi);
+        assert!(!out.contains('\u{202E}'), "bidi mark leaked: {:?}", out);
+    }
+
+    #[test]
+    fn empty_or_all_unsafe_falls_back() {
+        assert_eq!(sanitize_for_linker_argv(""), SAFE_FALLBACK);
+        // A bare `@` is consumed by the leading-`@` strip, leaving an
+        // empty string → fallback.
+        assert_eq!(sanitize_for_linker_argv("@"), SAFE_FALLBACK);
+        // `/` scrubs to `-`, then the leading-`-` rule prefixes `_`.
+        assert_eq!(sanitize_for_linker_argv("/"), "_-");
+        assert_eq!(sanitize_for_linker_argv("/////"), "_-----");
+    }
+
+    #[test]
+    fn ld64_response_file_directive_classes() {
+        // ld64-specific quirks that #467 surfaced and #500 generalises.
+        // Each entry is a string that historically caused ld64 to do
+        // something unexpected.
+        for evil in ["@/etc/passwd", "@-foo", "@@@", "@", "@-Wl,foo", "@\nfoo"] {
+            let out = sanitize_for_linker_argv(evil);
+            assert!(
+                !out.starts_with('@'),
+                "leading @ leaked in {:?} -> {:?}",
+                evil,
+                out
+            );
+            // And the result must be non-empty / non-just-`_`s.
+            assert!(!out.is_empty());
+        }
+    }
+
+    #[test]
+    fn bundle_id_component_lowercases() {
+        assert_eq!(sanitize_for_bundle_id_component("@Foo/Bar"), "foo-bar");
+        assert_eq!(sanitize_for_bundle_id_component("MyApp"), "myapp");
+    }
+
+    #[test]
+    fn idempotent() {
+        // Calling the sanitizer twice gives the same result as calling
+        // it once. Important because some derivation sites already
+        // call the legacy `sanitize_app_name`; mixing old + new should
+        // never produce different output across releases.
+        for raw in [
+            "@foo/bar",
+            "MyApp",
+            "../../etc/passwd",
+            "good\u{202E}evil",
+            "",
+            "x",
+        ] {
+            let once = sanitize_for_linker_argv(raw);
+            let twice = sanitize_for_linker_argv(&once);
+            assert_eq!(once, twice, "not idempotent on {:?}", raw);
+        }
+    }
+
+    #[test]
+    fn output_char_class_is_only_safe_bytes() {
+        // Property test: every byte of every output is in
+        // `[A-Za-z0-9._-]`. Exercise a wide alphabet of pathological
+        // inputs.
+        let inputs = [
+            "@foo/bar",
+            "../../etc/passwd",
+            "foo\nbar",
+            "foo\0bar",
+            "ｐerry",
+            "--no-default-features",
+            "@-Wl,--version-script=evil.lds",
+            "\u{202E}backwards",
+            "naïve résumé",
+            "$(rm -rf /)",
+            "`echo pwned`",
+            "${IFS}",
+        ];
+        let safe = |b: u8| b.is_ascii_alphanumeric() || b == b'.' || b == b'_' || b == b'-';
+        for raw in inputs {
+            let out = sanitize_for_linker_argv(raw);
+            for b in out.bytes() {
+                assert!(
+                    safe(b),
+                    "unsafe byte {:#x} in output {:?} from input {:?}",
+                    b,
+                    out,
+                    raw
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn long_inputs_dont_explode() {
+        // Length-bound: a 100KB pathological input should still
+        // produce an output bounded by `input.len() + 1` (the
+        // possible leading `_`). This keeps the sanitizer usable on
+        // attacker-supplied data without DOS surface.
+        let raw: String = std::iter::repeat('@').take(100_000).collect();
+        let out = sanitize_for_linker_argv(&raw);
+        assert!(out.len() <= raw.len() + 1);
+    }
+}


### PR DESCRIPTION
Closes #500. Follow-up to #467.

## Summary

- Generalises the one-off `sanitize_app_name` (introduced for #467) into a single, fuzz-tested `commands::sanitize` module applied at every site where attacker-influenceable package/path metadata flows into linker, codesign, or `install_name_tool` argv.
- Documents the full threat model in the module header (ld64 response files, leading-dash flag spoofing, abs/traversal paths, shell metacharacters, whitespace, control bytes, path separators, non-ASCII look-alikes).
- Closes the analogous attack via input filenames (`@evil.ts`) that the original #467 fix did not cover.
- Platform-agnostic: the sanitizer runs in the perry driver before any backend (LLVM, WASM, ArkTS/HarmonyOS, Glance, SwiftUI, JS) sees the metadata.

## Sites hardened

| File | Site | Vector |
|---|---|---|
| `commands/run.rs::read_app_metadata` | `package.json` `name` → output filename + bundle-ID stem | #467 — already had `sanitize_app_name`; now routes through shared fn |
| `commands/compile.rs::compile_pipeline` | `args.input.file_stem()` → `{stem}.dylib` / `{stem}.so` / `lib{stem}.so` / `{stem}.exe` → `-o` argv | NEW — analogous to #467 but via attacker-chosen input path |
| `commands/compile.rs::read_app_metadata` | `input.file_stem()` → `com.perry.{stem}` bundle-ID default | NEW — bundle-ID flows into codesign argv |

## Sanitizer behavior

Output character set: ``[A-Za-z0-9._-]``. Legacy-compatible mappings preserved so reviewers continue to recognise the filenames pre-fix:

- Single leading `@` dropped (npm scope prefix).
- `/` and `\` flatten to `-`.
- Other unsafe bytes → `_`.
- Leading `.` or `-` get a `_` prefix.
- Whole-string `.`, `..`, or empty → `SAFE_FALLBACK` (`app`).

Companion `sanitize_for_bundle_id_component` additionally lowercases for Apple's bundle-ID canonical form.

## Test coverage

15 unit tests in `commands::sanitize::tests` form a fuzz suite:

- `issue_467_scoped_name_roundtrip` — the canonical regression (`@foo/bar` → `foo-bar`).
- `leading_dash_gets_quoted_with_underscore`, `leading_dot_is_not_hidden_file` — flag/hidden-file spoofs.
- `embedded_newlines_and_control_bytes` — exhaustive over every 0x01-0x1F control byte.
- `shell_metacharacters_scrub` — exhaustive over every metacharacter in the threat model.
- `path_separators_flatten` — POSIX + Windows + traversal.
- `non_ascii_lookalikes_scrub` — full-width `ｐ`, U+202E bidi mark.
- `empty_or_all_unsafe_falls_back` — empty / `@` / `/` / `/////`.
- `ld64_response_file_directive_classes` — a corpus of ld64-specific evil strings.
- `bundle_id_component_lowercases` — Apple canonical form.
- `idempotent` — property: `f(f(x)) == f(x)`.
- `output_char_class_is_only_safe_bytes` — property: every output byte is in the safe class.
- `long_inputs_dont_explode` — 100KB input bounded by `input.len() + 1`.

## End-to-end smoke tests

1. `@evil.ts` input → output is `evil` (no ld64 response-file error).
2. `package.json` `name: \"@foo/bar\"` + `perry run` → \"Running foo-bar...\" + clean execution.
3. `cargo build --release -p perry-runtime -p perry-stdlib -p perry -p perry-codegen-wasm -p perry-codegen-arkts` — all backends build clean.
4. `cargo test --release -p perry` — 257 tests pass, no regressions.

## Acceptance checklist

- [x] Single sanitizer function applied at all derivation sites
- [x] Fuzz suite over crafted package names (leading `@`, embedded newlines, response-file directives, ld64-specific edge cases)
- [x] Documented threat model (in module header)
- [x] Follow-up of #467

## Notes

No `Cargo.toml` version bump, no `CLAUDE.md` version line touch, no `CHANGELOG.md` entry — maintainer folds those in at merge time to avoid patch-version collisions.