### PR TITLE
fix(runtime): #748 — preserve INLINE_TRAP across microtask drain to keep outer async step's current_step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.969 — fix(runtime): #748 — async closure's busy-wait microtask drain no longer clobbers outer state-machine's `current_step`
+
+**Symptom.** skelpo-shop-admin's `/v1/auth/signup` Fastify route (Fastify 4.28 + @perryts/mysql + argon2 + jsonwebtoken) returned HTTP 200 with the single-byte body `0` instead of the explicit `return { accessToken, user, account, session, … }` payload. The first `await pool.exec("INSERT INTO users …")` committed (row visible in MySQL), but every subsequent `await pool.exec(…)` silently no-op'd — no rows in `accounts`, `sessions`, `members`, `auditLog`. tsx + node on the same source against the same DB returned the correct JSON with HTTP 201. Reported against perry 0.5.899; reproduced through 0.5.967.
+
+**Root cause.** Async closures (arrow / function-expression async functions assigned to consts / map values / object properties) are NOT rewritten by the `async_to_generator` pass — the pre-pass only iterates `module.functions` and skips closures by design (see comment at `crates/perry-transform/src/async_to_generator.rs:47-49`: *"Top-level functions only: nested async closures (arrow/function expressions assigned to locals) are NOT yet rewritten. They keep the pre-fix direct-call/busy-wait behavior. Follow-up."*). When such a closure executes inside an outer top-level async function's state-machine step body, the closure's `Expr::Await` lowers to the busy-wait loop in `crates/perry-codegen/src/expr.rs:10094+`, which polls via `js_promise_run_microtasks()` until the awaited Promise settles.
+
+Inside the microtask runner, every `Task::AsyncStep` dispatch wrote `INLINE_TRAP = {trap_next: next, current_step: step_closure}` before invoking the step and unconditionally cleared `INLINE_TRAP = empty` afterwards (`promise.rs:1407-1429`). That clear was correct in isolation — between dispatches the runner has no active activation — but it leaked back to whatever code had called `js_promise_run_microtasks()`. The outer top-level async function's state-machine step closure was active at the time: it was entered through `js_async_first_call(outer_step)`, which had installed `INLINE_TRAP = {trap_next: null, current_step: outer_step}` on the stack-saved value. Once control returned from the busy-wait, the outer step body's `Expr::CurrentStepClosure` (lowered to `js_get_current_step_closure`) read `INLINE_TRAP.current_step` and saw `0` instead of `outer_step` — because the inner microtask drain had wiped it.
+
+The outer step then returned `Expr::AsyncStepChain { value, step_closure: <NULL> }` for the await of the closure's result. `js_async_step_chain` queued `Task::AsyncStep(NULL, value, next, false)` onto the task queue. When the event loop drained that task, the null-step short-circuit at `promise.rs:1316-1326` fired:
+
+```rust
+if step_closure.is_null() {
+    if !next.is_null() {
+        if is_error { js_promise_reject(next, value); } else { js_promise_resolve(next, value); }
+    }
+    restore_microtask_context();
+    ran += 1;
+    continue;
+}
+```
+
+The outer step body's state-1 code (the `return { … }` and every statement after the first `await`) NEVER ran — `next` settled with whatever the awaited Promise resolved to. In the Fastify signup case that was `{ insertId: <first INSERT>, affectedRows: 1 }`, which `JSON.stringify` rendered as something that ultimately serialized to ASCII `0` (the `next`'s value flowed through Fastify's reply pipeline as the response body). The "subsequent INSERTs silently no-op" symptom is consistent: those `await pool.exec(...)` calls live in state-1+ of the outer step body, which the null-step short-circuit prevented from ever executing — `await pool.exec(...)` and `JSON.stringify` and `void reply.code(201)` and `return {...}` all became dead code at runtime.
+
+**Reproducer (no fastify / no mysql).** `test-files/test_issue_748_multi_step_await_return.ts` exercises the minimum shape: a top-level `async function main()` awaits a `Map<string, Handler>`-stored async arrow closure that itself awaits three async helpers (`createUser` / `createAccount` / `createSession`), each of which awaits a `Pool.exec` async method that awaits a `setTimeout` Promise. Pre-fix the outer `await app.inject(...)` returned `undefined`, the post-await `console.log(out)` printed nothing (the line was dead code). Post-fix it prints the full `{"ok":true,"user":{...},"account":{...},"session":{...}}` JSON byte-identical to `node --experimental-strip-types`.
+
+**Fix.** `crates/perry-runtime/src/promise.rs`: save `INLINE_TRAP` before each `Task::AsyncStep` / `Task::Inline` dispatch and restore it afterwards, instead of unconditionally clearing to empty. In the common case (no outer activation), the saved value IS empty so the restore is a no-op — but when the runner is invoked re-entrantly from inside an outer state-machine step's busy-wait, the outer's `current_step` survives. The outer step's later `Expr::CurrentStepClosure` then sees the correct `outer_step` pointer, `AsyncStepChain` queues `Task::AsyncStep(outer_step, value, next, false)` with a non-null step, and state-1 (the return-value path) runs normally.
+
+**Scope.** Runtime-only change. The fix is in the microtask runner; codegen and HIR are unchanged. The longer-term fix (extending `async_to_generator` to also rewrite async closures so they don't busy-wait at all) is tracked separately — for now this restores correctness for the busy-wait re-entrancy case without touching the transform's scope.
+
+**Validation.**
+- `test-files/test_issue_748_multi_step_await_return.ts` byte-identical to `node --experimental-strip-types`.
+- `test-files/test_issue_256_microtask_ordering.ts` — PARITY (no regression on the original async-step driver fix).
+- `/tmp/run_gap_tests.sh` — 34/36 PASS, same baseline as pre-fix (the 2 failures — `test_gap_class_advanced`, `test_gap_console_methods` — are unrelated pre-existing gaps).
+
 ## v0.5.968 — test(regression): #678 — exhaustive V8-fallback symbol-link coverage
 
 **Background.** Issue #678 reported `Undefined symbols: _perry_fn_node_modules_ink_build_render_js__render` for ink + react when imports landed on the V8 fallback (modules outside `perry.compilePackages`, or modules pulled in transitively where some sibling fell back to V8). Two fixes have already landed:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.968
+**Current Version:** 0.5.969
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.968"
+version = "0.5.969"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.968"
+version = "0.5.969"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.968"
+version = "0.5.969"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.968"
+version = "0.5.969"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.968"
+version = "0.5.969"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/promise.rs
+++ b/crates/perry-runtime/src/promise.rs
@@ -1270,6 +1270,13 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                 // valid `*mut Promise`. This is rarely hit (only on
                 // user-throw inside the inline callback) and we can
                 // afford the alloc on the slow path.
+                //
+                // Issue #748: same save/restore reasoning as the
+                // Task::AsyncStep arm below — preserve any outer
+                // INLINE_TRAP (set by an enclosing `js_async_first_call`)
+                // when the runner is invoked re-entrantly from inside
+                // a non-transformed async closure's busy-wait.
+                let prev_trap = INLINE_TRAP.with(|c| c.get());
                 INLINE_TRAP.with(|c| {
                     c.set(InlineTrap {
                         trap_next: next,
@@ -1287,7 +1294,7 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                     MT_TIME_NS_CALLBACK.fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
                 }
 
-                INLINE_TRAP.with(|c| c.set(InlineTrap::empty()));
+                INLINE_TRAP.with(|c| c.set(prev_trap));
 
                 let t2 = if prof {
                     Some(std::time::Instant::now())
@@ -1395,6 +1402,30 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                 // path: nested async-fn calls pass a DIFFERENT step
                 // closure → fail the gate → alloc their own next, so
                 // their settlement can't collapse onto the parent's.
+                //
+                // Issue #748: save the previous INLINE_TRAP value and
+                // restore it after step dispatch. The microtask runner
+                // can be called RE-ENTRANTLY from inside an outer
+                // async-step body — specifically when a non-transformed
+                // async closure's `await` busy-waits on
+                // `js_promise_run_microtasks()`. The outer body
+                // (e.g. a top-level async function's state machine
+                // closure) was entered via `js_async_first_call` which
+                // set INLINE_TRAP to `{trap_next: null, current_step:
+                // outer_step}`. Without save/restore, clearing to empty
+                // after the inner Task::AsyncStep dispatch would leak
+                // back to the outer body — `Expr::CurrentStepClosure`
+                // (lowered to `js_get_current_step_closure`) returns
+                // NULL after control returns from the busy-wait, and
+                // the outer's `AsyncStepChain` queues a Task::AsyncStep
+                // with step=NULL. That task hits the null-step short
+                // circuit (line 1316) which only propagates the value
+                // to `next` without ever calling the outer step body's
+                // state-1 code — symptom: the outer body's post-await
+                // statements never execute and the returned Promise
+                // settles with the awaited value rather than the
+                // explicit return expression.
+                let prev_trap = INLINE_TRAP.with(|c| c.get());
                 INLINE_TRAP.with(|c| {
                     c.set(InlineTrap {
                         trap_next: next,
@@ -1417,7 +1448,7 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                     MT_TIME_NS_CALLBACK.fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
                 }
 
-                INLINE_TRAP.with(|c| c.set(InlineTrap::empty()));
+                INLINE_TRAP.with(|c| c.set(prev_trap));
 
                 let t2 = if prof {
                     Some(std::time::Instant::now())

--- a/test-files/test_issue_748_multi_step_await_return.ts
+++ b/test-files/test_issue_748_multi_step_await_return.ts
@@ -1,0 +1,116 @@
+// Issue #748: native-compiled multi-step await inside async closure
+// dropped the explicit return value (body resolved with `0` / undefined
+// and downstream awaits silently no-op'd).
+//
+// Root cause: when an async closure (arrow function `const h: any =
+// async (...) => ...`) ran inside an outer top-level async function, the
+// closure's busy-wait `await` drained microtasks via
+// `js_promise_run_microtasks()`. Each `Task::AsyncStep` dispatch in the
+// runner cleared `INLINE_TRAP` to empty after the step returned —
+// clobbering the outer async function's
+// `{trap_next, current_step: outer_step}` that
+// `js_async_first_call` had installed. When the outer step resumed
+// after the busy-wait, `CurrentStepClosure` (which reads
+// `INLINE_TRAP.current_step` via `js_get_current_step_closure`) returned
+// NULL. The outer step then queued a `Task::AsyncStep` with
+// `step_closure = NULL`, which the runner's null-step short-circuit
+// (promise.rs:1316) propagates straight to `next` without ever calling
+// the outer step body's state-1 continuation. Symptom in the original
+// repro (skelpo-shop-admin /v1/auth/signup): first DB write commits,
+// the explicit `return { ok, user, account, session }` never runs, and
+// the Fastify response body is the byte `0` (the propagated value).
+//
+// Fix: save/restore `INLINE_TRAP` around each `Task::AsyncStep` /
+// `Task::Inline` dispatch in `js_promise_run_microtasks` so an outer
+// activation's `current_step` survives a re-entrant microtask drain
+// triggered from inside a non-transformed async closure's busy-wait
+// (the async-to-generator pass skips arrow/function-expression closures
+// — see crates/perry-transform/src/async_to_generator.rs:47-49).
+//
+// This test exercises the minimum reproducer: a top-level async
+// function awaits an async closure that itself awaits a separate async
+// helper that itself awaits. Pre-fix the post-await statements after
+// the closure call never ran; post-fix they do, and the explicit
+// return value flows through to the outer call site.
+
+interface RowResult {
+  insertId: number;
+  affectedRows: number;
+}
+
+class Pool {
+  private counter: number = 0;
+  async exec(_sql: string): Promise<RowResult> {
+    this.counter = this.counter + 1;
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 1));
+    return { insertId: this.counter, affectedRows: 1 };
+  }
+}
+
+const pool = new Pool();
+
+async function createUser(email: string) {
+  const r = await pool.exec(`INSERT INTO users (email) VALUES ('${email}')`);
+  return { id: r.insertId, email };
+}
+
+async function createAccount(name: string) {
+  const r = await pool.exec(`INSERT INTO accounts (name) VALUES ('${name}')`);
+  return { id: r.insertId, name };
+}
+
+async function createSession(userId: number) {
+  const r = await pool.exec(`INSERT INTO sessions (userId) VALUES (${userId})`);
+  return { id: r.insertId, refreshToken: "rt-" + userId.toString() };
+}
+
+// Generic-container dispatch path: this is the shape Fastify uses
+// (`routes.get(path)(req, reply)`). The handler is stored as `any` in a
+// Map and read back out before being awaited. The closure type and
+// dispatch path are what disqualify the async-to-generator transform
+// (it's a closure, not a top-level function decl).
+type Handler = (req: any, reply: any) => Promise<unknown>;
+
+class FakeServer {
+  private routes: Map<string, Handler> = new Map();
+  register(path: string, h: Handler) {
+    this.routes.set(path, h);
+  }
+  async inject(path: string, body: any): Promise<string> {
+    const handler = this.routes.get(path);
+    if (!handler) throw new Error("404");
+    const reply = {
+      code: (_n: number) => {
+        /* no-op */
+      },
+    };
+    const req = { body };
+    const result = await handler(req, reply);
+    return JSON.stringify(result);
+  }
+}
+
+const app = new FakeServer();
+
+app.register("/v1/auth/signup", async (req: any, _reply: any) => {
+  const body = req.body;
+  const user = await createUser(body.email);
+  const account = await createAccount(body.accountName);
+  const session = await createSession(user.id);
+  return {
+    ok: true,
+    user,
+    account,
+    session,
+  };
+});
+
+async function main() {
+  const out = await app.inject("/v1/auth/signup", {
+    email: "foo@bar.com",
+    accountName: "Acme",
+  });
+  console.log(out);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Async closures (arrow / function-expression async functions assigned to locals) are not rewritten by `async_to_generator` — they keep the busy-wait `await` path. When such a closure runs inside an outer top-level async function's state-machine step body, its busy-wait calls `js_promise_run_microtasks()`. Each `Task::AsyncStep` / `Task::Inline` dispatch in the runner used to unconditionally clear `INLINE_TRAP` to empty after the step returned — leaking back to the outer step body whose `js_async_first_call` had installed `{trap_next: null, current_step: outer_step}`. The outer step's `Expr::CurrentStepClosure` then read `current_step = 0` and queued `Task::AsyncStep(NULL, ...)`. The runner's null-step short-circuit settles `next` with the awaited value and skips state-1 entirely — so the explicit `return { ok, user, ... }` and every other post-await statement become dead code.
- Symptom from the original reporter (skelpo-shop-admin `/v1/auth/signup`): first DB write commits, subsequent awaits silently no-op, response body is the byte `0`, HTTP 200 instead of 201.
- Fix: save the previous `INLINE_TRAP` before each `Task::AsyncStep` / `Task::Inline` dispatch and restore it afterwards, instead of clearing to empty. The common case is unchanged (saved value IS empty so restore is a no-op); the re-entrant case preserves the outer activation's `current_step`. Runtime-only — codegen and HIR untouched.

## Test plan

- [x] `test-files/test_issue_748_multi_step_await_return.ts` — new regression covering Map-stored async closure + multi-step await + explicit return-object (no fastify / no mysql; native repro of the issue's shape). Byte-identical to `node --experimental-strip-types`.
- [x] `test-files/test_issue_256_microtask_ordering.ts` — PARITY (no regression on the original async-step driver fix that this trap state-machine was built for).
- [x] `/tmp/run_gap_tests.sh` — 34/36 PASS, same baseline as pre-fix (the 2 failures — `test_gap_class_advanced`, `test_gap_console_methods` — are unrelated pre-existing gaps).
- [x] `cargo fmt --check` clean; `cargo build --release -p perry-runtime -p perry-stdlib -p perry` clean.

Closes #748.