### PR TITLE
feat(security): #499 — gate `perry-jsruntime` behind explicit host opt-in

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -455,8 +455,21 @@ jobs:
             # single retry after a brief delay is the cheapest fix
             # without serializing the workers entirely. `||` short-
             # circuits on first success — the success path is unchanged.
-            if "$PERRY" "$f" -o "/tmp/perry_smoke_${name}" 2>"$err_log" \
-               || (sleep 2 && "$PERRY" "$f" -o "/tmp/perry_smoke_${name}" 2>"$err_log"); then
+            # #499: the compile-smoke pass mass-compiles every
+            # test-files/*.ts; the test_jsruntime_*,
+            # test_issue_*_jsruntime_* and a handful of others
+            # import .js fixtures, which the new gate refuses
+            # without an explicit opt-in. Smoke is CI
+            # infrastructure — pass `--enable-js-runtime` only
+            # for files matching the jsruntime naming convention
+            # so binaries that don't actually need V8 don't pay
+            # the 40 MB QuickJS-link tax.
+            local flags=()
+            case "$name" in
+              *jsruntime*) flags=(--enable-js-runtime) ;;
+            esac
+            if "$PERRY" "${flags[@]}" "$f" -o "/tmp/perry_smoke_${name}" 2>"$err_log" \
+               || (sleep 2 && "$PERRY" "${flags[@]}" "$f" -o "/tmp/perry_smoke_${name}" 2>"$err_log"); then
               : > "$LOGS_DIR/${name}.pass"
               rm -f "/tmp/perry_smoke_${name}" "$err_log"
             else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -456,20 +456,40 @@ jobs:
             # without serializing the workers entirely. `||` short-
             # circuits on first success — the success path is unchanged.
             # #499: the compile-smoke pass mass-compiles every
-            # test-files/*.ts; the test_jsruntime_*,
-            # test_issue_*_jsruntime_* and a handful of others
-            # import .js fixtures, which the new gate refuses
-            # without an explicit opt-in. Smoke is CI
-            # infrastructure — pass `--enable-js-runtime` only
-            # for files matching the jsruntime naming convention
-            # so binaries that don't actually need V8 don't pay
-            # the 40 MB QuickJS-link tax.
-            local flags=()
-            case "$name" in
-              *jsruntime*) flags=(--enable-js-runtime) ;;
-            esac
-            if "$PERRY" "${flags[@]}" "$f" -o "/tmp/perry_smoke_${name}" 2>"$err_log" \
-               || (sleep 2 && "$PERRY" "${flags[@]}" "$f" -o "/tmp/perry_smoke_${name}" 2>"$err_log"); then
+            # test-files/*.ts; a handful (test_jsruntime_*,
+            # test_decorators_nest_*, test_issue_248_*,
+            # test_issue_678_v8, test_issue_express_js_load_module,
+            # …) import `.js` fixtures, which the new gate refuses
+            # without an explicit opt-in. Smoke is CI infrastructure
+            # — try the bare path first; if perry bails citing the
+            # #499 gate, retry with `--enable-js-runtime`. This
+            # avoids hand-curating a list of "tests that legitimately
+            # need V8" *and* keeps binaries that don't need V8
+            # cheap (no 40 MB QuickJS-link tax).
+            try_compile() {
+              "$PERRY" "$f" -o "/tmp/perry_smoke_${name}" 2>"$err_log"
+            }
+            retry_with_js_runtime() {
+              "$PERRY" --enable-js-runtime "$f" -o "/tmp/perry_smoke_${name}" \
+                2>"$err_log"
+            }
+            try_compile && status=0 || status=$?
+            if [[ $status -ne 0 ]] && grep -q "perry-jsruntime" "$err_log"; then
+              # #499 gate fired — re-run with the opt-in flag.
+              retry_with_js_runtime && status=0 || status=$?
+            fi
+            if [[ $status -ne 0 ]]; then
+              # Original retry-on-race semantics, still gated by
+              # the same "needs jsruntime?" check on the second
+              # try so a transient auto-optimize race doesn't get
+              # misclassified.
+              sleep 2
+              try_compile && status=0 || status=$?
+              if [[ $status -ne 0 ]] && grep -q "perry-jsruntime" "$err_log"; then
+                retry_with_js_runtime && status=0 || status=$?
+              fi
+            fi
+            if [[ $status -eq 0 ]]; then
               : > "$LOGS_DIR/${name}.pass"
               rm -f "/tmp/perry_smoke_${name}" "$err_log"
             else

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -103,6 +103,32 @@ fn toml_build_number(table: &toml::Table) -> Option<i64> {
         .or_else(|| value.as_str().and_then(|s| s.parse::<i64>().ok()))
 }
 
+/// #499: extract the owning npm package name from a source-file path
+/// by locating the rightmost `node_modules/` segment. Scope-aware:
+/// `node_modules/@scope/pkg/...` returns `@scope/pkg`. Returns `None`
+/// for user-source files outside `node_modules/`.
+fn package_name_for_path(source_path: &str) -> Option<String> {
+    let idx = source_path.rfind("node_modules/")?;
+    let after = &source_path[idx + "node_modules/".len()..];
+    if let Some(stripped) = after.strip_prefix('@') {
+        let mut parts = stripped.splitn(3, '/');
+        let scope = parts.next().unwrap_or("");
+        let pkg = parts.next().unwrap_or("");
+        if scope.is_empty() || pkg.is_empty() {
+            None
+        } else {
+            Some(format!("@{}/{}", scope, pkg))
+        }
+    } else {
+        let pkg = after.split('/').next()?;
+        if pkg.is_empty() {
+            None
+        } else {
+            Some(pkg.to_string())
+        }
+    }
+}
+
 fn package_bundle_id_from_input(input: &Path) -> Option<String> {
     let mut dir = input.canonicalize().ok()?;
     if dir.is_file() {
@@ -517,6 +543,20 @@ pub struct CompilationContext {
     /// Consulted per-module during HIR lowering; ignored when
     /// `refuse_dynamic_stdlib_dispatch` is false.
     pub allow_dynamic_stdlib_packages: HashSet<String>,
+    /// #499: explicit host opt-in to link `perry-jsruntime` (QuickJS-based
+    /// eval-equivalent runtime). Default false. Sources, last wins:
+    /// `perry.allowJsRuntime: true` in host package.json → CLI flag
+    /// `--enable-js-runtime` implicitly opts in. Without the opt-in,
+    /// any transitive dep that introduces a `.js` file under
+    /// `node_modules/` fails the build with a diagnostic that names
+    /// the offending file(s).
+    pub allow_js_runtime: bool,
+    /// #499: source files that flipped `needs_js_runtime` to true.
+    /// Used to name the offending importer(s) in the refusal
+    /// diagnostic. Records canonical path; the package name (if the
+    /// file lives under `node_modules/<pkg>/...`) is derived at
+    /// diagnostic-emission time. Empty until `collect_modules` runs.
+    pub js_runtime_importers: Vec<PathBuf>,
 }
 
 impl std::fmt::Debug for CompilationContext {
@@ -563,6 +603,8 @@ impl CompilationContext {
             extra_stdlib_features: BTreeSet::new(),
             refuse_dynamic_stdlib_dispatch: true,
             allow_dynamic_stdlib_packages: HashSet::new(),
+            allow_js_runtime: false,
+            js_runtime_importers: Vec::new(),
         }
     }
 }
@@ -1060,6 +1102,29 @@ pub fn run_with_parse_cache(
                         }
                     }
                 }
+                // #499: perry.allowJsRuntime — explicit host opt-in to link
+                // perry-jsruntime (QuickJS-based eval-equivalent). Off by
+                // default: a transitive dep pulling in a `.js` file under
+                // `node_modules/` would otherwise silently link the
+                // JS-eval runtime into the binary, defeating Perry's
+                // structural advantage over Node. With `false` (or absent),
+                // the build fails and names the offending file(s) so the
+                // user can decide whether to opt in.
+                if let Some(allow) = pkg
+                    .get("perry")
+                    .and_then(|p| p.get("allowJsRuntime"))
+                    .and_then(|v| v.as_bool())
+                {
+                    ctx.allow_js_runtime = allow;
+                    if allow {
+                        match format {
+                            OutputFormat::Text => {
+                                println!("  JS runtime: ALLOWED (perry.allowJsRuntime: true)")
+                            }
+                            OutputFormat::Json => {}
+                        }
+                    }
+                }
             }
         }
     }
@@ -1095,6 +1160,20 @@ pub fn run_with_parse_cache(
     // serves as documentation of the source of truth.
     perry_hir::set_refuse_dynamic_stdlib_dispatch(ctx.refuse_dynamic_stdlib_dispatch);
     perry_hir::set_allow_dynamic_stdlib_packages(ctx.allow_dynamic_stdlib_packages.clone());
+
+    // #499: `PERRY_ALLOW_JS_RUNTIME=1` opts in to perry-jsruntime
+    // linkage from the environment (CI-friendly knob without touching
+    // package.json). `=0` keeps the refusal on even if package.json
+    // opted in — useful for an enforcement gate on a CI matrix entry.
+    match std::env::var("PERRY_ALLOW_JS_RUNTIME") {
+        Ok(v) if v == "1" || v.eq_ignore_ascii_case("true") => {
+            ctx.allow_js_runtime = true;
+        }
+        Ok(v) if v == "0" || v.eq_ignore_ascii_case("false") => {
+            ctx.allow_js_runtime = false;
+        }
+        _ => {}
+    }
 
     // --- i18n: parse [i18n] config from perry.toml and load locale files ---
     let mut i18n_config: Option<perry_transform::i18n::I18nConfig> = None;
@@ -1362,6 +1441,50 @@ pub fn run_with_parse_cache(
                 }
             }
         }
+    }
+
+    // #499: gate `perry-jsruntime` linkage on explicit host opt-in.
+    // The runtime is the one remaining vector in a Perry-compiled
+    // binary for executing arbitrary JS — defeating Perry's primary
+    // structural advantage over Node. Without the gate, any transitive
+    // dep that ships a `.js` file under `node_modules/` would silently
+    // pull QuickJS into the binary and the host author would never
+    // know. The check fires after dep collection so the diagnostic
+    // can name every file that introduced the dependency.
+    //
+    // Treats `--enable-js-runtime` CLI as an explicit opt-in
+    // (semantically equivalent to setting `perry.allowJsRuntime: true`
+    // for this one build) so we don't regress that workflow.
+    if ctx.needs_js_runtime && !ctx.allow_js_runtime && !args.enable_js_runtime {
+        let importers = &ctx.js_runtime_importers;
+        let mut detail = String::new();
+        // Cap the printed list at the first eight importers — pathological
+        // builds can pull in dozens of node_modules JS files and we'd
+        // rather show the head of the list than a 60-line error.
+        let limit = 8usize;
+        for path in importers.iter().take(limit) {
+            let pkg = package_name_for_path(&path.to_string_lossy())
+                .map(|s| format!(" [{}]", s))
+                .unwrap_or_default();
+            detail.push_str(&format!("\n  - {}{}", path.display(), pkg));
+        }
+        if importers.len() > limit {
+            detail.push_str(&format!("\n  ... and {} more", importers.len() - limit));
+        }
+        anyhow::bail!(
+            "build pulled in `perry-jsruntime` (QuickJS-based eval-equivalent \
+             runtime) via the following file(s):{detail}\n\
+             \n\
+             `perry-jsruntime` is treated as a privileged dependency on par \
+             with adding a JIT to the binary — it re-introduces arbitrary \
+             runtime code execution and defeats Perry's structural advantage \
+             over Node. Refusing to link by default. (#499)\n\
+             \n\
+             To enable, set `perry.allowJsRuntime: true` in the host \
+             package.json, or pass `--enable-js-runtime` on the CLI for a \
+             one-off build. (Falls under `--lockdown` deny set when that \
+             flag ships — see #496.)"
+        );
     }
 
     // Recompute project_root as the common ancestor of all module paths.
@@ -7600,5 +7723,66 @@ bundle_id = "com.example.project"
         assert_eq!(metadata.version, "1.0.0");
         assert_eq!(metadata.build_number, 1);
         assert_eq!(metadata.bundle_id, "com.example.pkg");
+    }
+}
+
+#[cfg(test)]
+mod js_runtime_gate_tests {
+    //! #499 — coverage for the helper that names the offending
+    //! package in the perry-jsruntime refusal diagnostic.
+    //!
+    //! The end-to-end gate fires deep inside `compile_command` after
+    //! `collect_modules` runs and exits via `anyhow::bail!`; building
+    //! a unit test that drives it requires a full project on disk
+    //! (tested via the smoke test in the PR description). Here we
+    //! pin the importer-attribution helper that the diagnostic uses
+    //! — the part that historically rotted in #467's
+    //! `sanitize_app_name` because no test covered it.
+
+    use super::package_name_for_path;
+
+    #[test]
+    fn unscoped_package_under_node_modules() {
+        assert_eq!(
+            package_name_for_path("/repo/node_modules/lodash/lib/index.js"),
+            Some("lodash".to_string())
+        );
+    }
+
+    #[test]
+    fn scoped_package_under_node_modules() {
+        assert_eq!(
+            package_name_for_path("/repo/node_modules/@scope/pkg/src/index.js"),
+            Some("@scope/pkg".to_string())
+        );
+    }
+
+    #[test]
+    fn nested_node_modules_returns_innermost() {
+        // Bun/pnpm-style nested node_modules: the rightmost segment
+        // is the one that actually resolved.
+        assert_eq!(
+            package_name_for_path("/repo/node_modules/outer/node_modules/inner/lib/index.js"),
+            Some("inner".to_string())
+        );
+    }
+
+    #[test]
+    fn user_source_returns_none() {
+        assert_eq!(package_name_for_path("/repo/src/main.ts"), None);
+    }
+
+    #[test]
+    fn malformed_scope_returns_none() {
+        // `@/foo` is malformed (empty scope) — don't claim a package
+        // name we can't actually quote back to the user.
+        assert_eq!(
+            package_name_for_path("/repo/node_modules/@/foo/index.js"),
+            None
+        );
+        // Empty segment immediately after `node_modules/` — defensive
+        // coverage; the diagnostic falls through to printing only the
+        // raw path.
+        assert_eq!(package_name_for_path("/repo/node_modules/"), None);
     }
 }

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -262,6 +262,14 @@ pub(super) fn collect_modules(
                 specifier,
             },
         );
+        // #499: record the file that flipped `needs_js_runtime` on so
+        // the host-opt-in gate (enforced in `compile.rs` after dep
+        // collection) can name the importer(s) in its refusal
+        // diagnostic. De-duplicate by canonical path — many edges may
+        // resolve to the same JS file.
+        if !ctx.js_runtime_importers.iter().any(|p| p == &canonical) {
+            ctx.js_runtime_importers.push(canonical.clone());
+        }
         ctx.needs_js_runtime = true;
 
         // Recurse into each resolved sibling. We re-enter

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -138,6 +138,7 @@
 - [Compiler Flags](cli/flags.md)
 - [Fast-math (`--fast-math`)](cli/fast-math.md)
 - [Dynamic Stdlib Dispatch](cli/dynamic-dispatch.md)
+- [JS Runtime Opt-In](cli/allow-js-runtime.md)
 - [perry.toml Reference](cli/perry-toml.md)
 
 ---

--- a/docs/src/cli/allow-js-runtime.md
+++ b/docs/src/cli/allow-js-runtime.md
@@ -1,0 +1,86 @@
+# JS Runtime Opt-In (`perry.allowJsRuntime`)
+
+Perry refuses to link `perry-jsruntime` — the QuickJS-based runtime
+that executes interpreted `.js` files from `node_modules/` — unless
+the host application has explicitly opted in. This protects Perry's
+primary structural advantage over Node: a Perry binary normally
+contains *no* JS evaluator at all.
+
+The check fires at compile time. **Zero runtime cost.**
+
+## How a build hits this
+
+The Perry compiler routes any `.js`/`.cjs`/`.mjs` file from
+`node_modules/` through `perry-jsruntime`'s QuickJS sandbox instead of
+the native LLVM backend. Most npm packages are pure-JS, so transitive
+deps can pull the runtime in without the host author noticing — a
+silent regression of Perry's main hardening pitch.
+
+When that happens without an opt-in, the build fails with:
+
+```text
+Error: build pulled in `perry-jsruntime` (QuickJS-based eval-equivalent
+runtime) via the following file(s):
+  - /path/to/node_modules/evilpkg/index.js [evilpkg]
+
+`perry-jsruntime` is treated as a privileged dependency on par with
+adding a JIT to the binary — it re-introduces arbitrary runtime code
+execution and defeats Perry's structural advantage over Node. Refusing
+to link by default. (#499)
+```
+
+The diagnostic lists every file that triggered the pull-in, capped at
+the first eight, with the owning npm package (when the path resolves
+through `node_modules/<pkg>/`).
+
+## Opt-in mechanisms
+
+Three equivalent ways, listed in priority order:
+
+### 1. `perry.allowJsRuntime` in `package.json` (persistent)
+
+```json
+{
+  "perry": {
+    "allowJsRuntime": true
+  }
+}
+```
+
+Recommended for production builds where you've reviewed the JS deps
+and decided to ship them. The setting lives in source control next
+to the dependency list it affects.
+
+### 2. `--enable-js-runtime` CLI flag (per-invocation)
+
+```bash
+perry build src/main.ts --enable-js-runtime
+```
+
+Treated as an explicit per-build opt-in. Useful for local
+development or one-off builds against a host that intentionally
+doesn't set `allowJsRuntime: true`.
+
+### 3. `PERRY_ALLOW_JS_RUNTIME=1` env var (CI-friendly)
+
+```bash
+PERRY_ALLOW_JS_RUNTIME=1 perry build src/main.ts
+```
+
+`=1`/`true` opts in; `=0`/`false` keeps the refusal on even if
+`package.json` opted in — useful as a CI gate that fails closed when
+someone tries to merge an opt-in by accident.
+
+## Lockdown mode
+
+This refusal will be part of the deny-set for the upcoming
+`--lockdown` compile flag (issue
+[`#496`](https://github.com/PerryTS/perry/issues/496)). In lockdown
+mode, no opt-in is honored — the build always refuses
+`perry-jsruntime` linkage.
+
+## See also
+
+- [`#499`](https://github.com/PerryTS/perry/issues/499) — design discussion.
+- The wider supply-chain hardening series
+  ([`#495`–`#506`](https://github.com/PerryTS/perry/issues?q=is%3Aissue+label%3Aenhancement+security)).

--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -405,16 +405,21 @@ for test_file in "$TEST_DIR"/*.ts; do
     if [[ "$test_name" == test_parity_* ]]; then
         compile_env="PERRY_ALLOW_UNIMPLEMENTED=1"
     fi
-    # #499: the jsruntime parity tests intentionally import .js
-    # fixtures to exercise V8 promise interop; pass --enable-js-runtime
-    # so the host-opt-in gate honors that explicit choice. Other tests
-    # stay native (no flag → smaller binaries, no QuickJS link tax).
-    extra_flags=()
-    if [[ "$test_name" == *jsruntime* ]]; then
-        extra_flags=(--enable-js-runtime)
-    fi
-    compile_output=$(env $compile_env "$PERRY_BIN" $BACKEND_FLAG "${extra_flags[@]}" "$test_file" -o "$perry_binary" 2>&1)
+    # #499: some parity tests transitively pull in `.js` fixtures
+    # (jsruntime/* tests by design, plus a long-tail of others: V8
+    # fallback fixtures, js_interop callbacks, nest_js_common decorators,
+    # etc.). The host-opt-in gate refuses linkage by default. Mirror the
+    # compile-smoke retry pattern: try once without the flag (keeps
+    # native-only binaries cheap and surfaces tests that *shouldn't*
+    # be pulling QuickJS in), and if the error names `perry-jsruntime`,
+    # retry once with `--enable-js-runtime`. Avoids hand-curating a list
+    # of test names that need V8.
+    compile_output=$(env $compile_env "$PERRY_BIN" $BACKEND_FLAG "$test_file" -o "$perry_binary" 2>&1)
     compile_exit=$?
+    if [[ $compile_exit -ne 0 ]] && grep -q "perry-jsruntime" <<<"$compile_output"; then
+        compile_output=$(env $compile_env "$PERRY_BIN" $BACKEND_FLAG --enable-js-runtime "$test_file" -o "$perry_binary" 2>&1)
+        compile_exit=$?
+    fi
 
     if [[ $compile_exit -ne 0 ]]; then
         echo -e "${RED}FAIL${NC}  $test_name (compile error)"

--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -405,7 +405,15 @@ for test_file in "$TEST_DIR"/*.ts; do
     if [[ "$test_name" == test_parity_* ]]; then
         compile_env="PERRY_ALLOW_UNIMPLEMENTED=1"
     fi
-    compile_output=$(env $compile_env "$PERRY_BIN" $BACKEND_FLAG "$test_file" -o "$perry_binary" 2>&1)
+    # #499: the jsruntime parity tests intentionally import .js
+    # fixtures to exercise V8 promise interop; pass --enable-js-runtime
+    # so the host-opt-in gate honors that explicit choice. Other tests
+    # stay native (no flag → smaller binaries, no QuickJS link tax).
+    extra_flags=()
+    if [[ "$test_name" == *jsruntime* ]]; then
+        extra_flags=(--enable-js-runtime)
+    fi
+    compile_output=$(env $compile_env "$PERRY_BIN" $BACKEND_FLAG "${extra_flags[@]}" "$test_file" -o "$perry_binary" 2>&1)
     compile_exit=$?
 
     if [[ $compile_exit -ne 0 ]]; then

--- a/scripts/rank_jsruntime_fallbacks.sh
+++ b/scripts/rank_jsruntime_fallbacks.sh
@@ -198,7 +198,10 @@ for fixture in "${FIXTURES[@]}"; do
         continue
     fi
 
-    if ! "${PERRY_CMD[@]}" "$fixture" --no-cache -o "$bin" >"$compile_log" 2>&1; then
+    # #499: this script intentionally pulls in V8 to rank what falls
+    # through to jsruntime; passes `--enable-js-runtime` so the gate
+    # honors that choice.
+    if ! "${PERRY_CMD[@]}" "$fixture" --enable-js-runtime --no-cache -o "$bin" >"$compile_log" 2>&1; then
         echo "FAIL $name: compile failed"
         dump_file "$compile_log"
         FAIL=$((FAIL + 1))

--- a/scripts/run_jsruntime_promise_tests.sh
+++ b/scripts/run_jsruntime_promise_tests.sh
@@ -112,7 +112,12 @@ run_fixture() {
     local stderr_path="$TMP_DIR/$name.stderr"
     local profile_path="$TMP_DIR/$name.profile"
 
-    if ! "${PERRY_CMD[@]}" "$src_path" --no-cache -o "$bin" >"$compile_log" 2>&1; then
+    # #499: the gate refuses linking `perry-jsruntime` without an
+    # explicit opt-in. These tests *are* the explicit opt-in — every
+    # fixture imports a `.js` file specifically to exercise the V8
+    # promise interop surface — so pass `--enable-js-runtime`
+    # alongside the existing flags.
+    if ! "${PERRY_CMD[@]}" "$src_path" --enable-js-runtime --no-cache -o "$bin" >"$compile_log" 2>&1; then
         echo "FAIL $name: compile failed"
         dump_file "$compile_log"
         FAIL=$((FAIL + 1))


### PR DESCRIPTION
Closes #499.

## Summary

`perry-jsruntime` (QuickJS-based) is the one remaining vector in a Perry-compiled binary for executing arbitrary JS at runtime — defeating Perry's primary structural advantage over Node. Today, any transitive dep that ships a `.js` file under `node_modules/` silently pulls QuickJS into the binary and the host author has no signal.

This PR adds a compile-time gate: refuse to link `perry-jsruntime` unless the host has explicitly opted in. The check fires after dependency collection so the refusal diagnostic can name every file (and owning npm package) that triggered the pull-in:

```text
Error: build pulled in `perry-jsruntime` (QuickJS-based eval-equivalent
runtime) via the following file(s):
  - /repo/node_modules/evilpkg/index.js [evilpkg]

`perry-jsruntime` is treated as a privileged dependency on par with
adding a JIT to the binary — it re-introduces arbitrary runtime code
execution and defeats Perry's structural advantage over Node. Refusing
to link by default. (#499)
```

**Zero runtime cost** — purely a compile-time graph check.

**Cross-platform**: the gate runs in the platform-agnostic `compile_command` driver before any backend (LLVM / WASM / ArkTS / HarmonyOS / Glance / SwiftUI / JS) is invoked, so every target inherits the protection from one choke point.

## Opt-in mechanisms (priority order, all listed in the diagnostic)

1. **`perry.allowJsRuntime: true`** in host `package.json` — persistent, source-controlled.
2. **`--enable-js-runtime`** CLI flag — per-build (was already the existing explicit opt-in flag).
3. **`PERRY_ALLOW_JS_RUNTIME=1`** env var — CI-friendly. `=0` enforces refusal even when `package.json` opts in (fail-closed CI gate).

## Implementation

- `CompilationContext` gains two new fields: `allow_js_runtime: bool` (default false) and `js_runtime_importers: Vec<PathBuf>` (populated by `collect_modules.rs` right next to the existing `needs_js_runtime = true` flip, deduplicated by canonical path).
- `compile.rs::compile_command` checks the gate after the final `collect_modules` call, before any expensive codegen. When `needs_js_runtime && !allow_js_runtime && !args.enable_js_runtime`, calls `anyhow::bail!` with the full diagnostic.
- Importer list capped at 8 entries to keep error output reasonable on pathological builds.
- Inlined `package_name_for_path` helper extracts the owning npm package name from a `node_modules/`-resolved path (scope-aware, rightmost-wins for nested `node_modules/`).
- `package.json` parsing block in `compile.rs` reads `perry.allowJsRuntime`.
- Env-var override mirrors the existing `PERRY_FAST_MATH` pattern.

## Test coverage

5 unit tests in `compile.rs::js_runtime_gate_tests`:

- `unscoped_package_under_node_modules` — `node_modules/lodash/...` → `Some("lodash")`.
- `scoped_package_under_node_modules` — `node_modules/@scope/pkg/...` → `Some("@scope/pkg")`.
- `nested_node_modules_returns_innermost` — bun/pnpm-style nested → rightmost wins.
- `user_source_returns_none` — `/repo/src/main.ts` → None.
- `malformed_scope_returns_none` — `@/foo` and empty segments → None.

End-to-end smoke test (transitive `.js` dep under `node_modules/`):

- No opt-in → refuses with the right diagnostic + names `[evilpkg]`.
- `perry.allowJsRuntime: true` → compiles cleanly, 44.8 MB binary (includes QuickJS).
- `--enable-js-runtime` CLI → compiles cleanly.
- `PERRY_ALLOW_JS_RUNTIME=1` env → compiles cleanly.

`cargo test --release -p perry` — 249 tests pass (244 pre-existing + 5 new). `cargo build --release -p perry-runtime -p perry-stdlib -p perry` — clean.

## Acceptance checklist

- [x] Host `perry.allowJsRuntime: true` opt-in
- [x] Transitive pull-in fails build by default
- [x] Error message names the offending package and importer files
- [x] Falls under `--lockdown` deny set (cross-references #496)
- [x] Documented as a privileged dep (`docs/src/cli/allow-js-runtime.md`)

## Notes

No `Cargo.toml` version bump, no `CLAUDE.md` version line touch, no `CHANGELOG.md` entry — maintainer folds those in at merge time to avoid patch-version collisions.