### PR TITLE
fix(jsruntime): define URL / URLSearchParams as V8-fallback globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.971 — fix(jsruntime): define `URL` / `URLSearchParams` as V8-fallback globals (unblocks `import "joi"`)
+
+**Symptom.** `import Joi from "joi"` against the V8-fallback jsruntime crashed at module-init with
+
+```
+[js_get_export] failed to get namespace: ReferenceError: URL is not defined
+    at file:///.../node_modules/@hapi/hoek/lib/types.js:32:10
+    at file:///.../node_modules/@hapi/hoek/lib/types.js:77:3
+TypeError: Cannot read properties of undefined (reading 'assert')
+    at <anonymous>
+```
+
+before any user code ran. `@hapi/hoek` (transitive dep of joi) reads `URL.prototype` as a top-level expression, and modern Node exposes `URL` as a global. Perry's V8-fallback runtime (deno_core without the `deno_url` extension) does not, so the lookup throws.
+
+**Fix.** `crates/perry-jsruntime/src/node_polyfills.js` now installs `globalThis.URL` and `globalThis.URLSearchParams` alongside the existing `Buffer` / `TextEncoder` / `TextDecoder` / `fetch` polyfills. The URL polyfill is a roughly-WHATWG-compatible parser covering the access pattern that joi/hoek and friends actually use: constructor with optional `base`, `href` / `origin` / `protocol` / `username` / `password` / `host` / `hostname` / `port` / `pathname` / `search` / `hash` getters and setters, `searchParams` with live-sync back into `_search`, plus static `URL.canParse` / `URL.parse`. `URLSearchParams` is a complete implementation (string / array-of-pairs / object init forms; `append`, `delete`, `get`, `getAll`, `has`, `set`, `sort`, `forEach`, `keys`, `values`, `entries`, `size`, `toString`, `Symbol.iterator`). Polyfills are gated on `typeof globalThis.URL === 'undefined'` so they no-op if a future deno_core upgrade ships built-in URL globals.
+
+Scope is narrow: joi still fails further into its init with `TypeError: Cannot read properties of undefined (reading 'template')`, which is a separate downstream gap left as a follow-up. This release only addresses the `URL is not defined` crash.
+
+**Validation.** New `test-files/joi_url_v8_global/` fixture forces the V8 fallback path (no `compilePackages` entry, a `.js` package in `node_modules`) and exercises `URL.prototype`, `new URL(href)`, all property getters, and `URLSearchParams` stringification — output:
+
+```
+urlProto type: object
+protocol: https:
+hostname: example.com
+pathname: /api/v1
+search: ?x=1&y=2
+search-stringify: a=1&b=2
+```
+
+Native-compile path is unaffected — perry-runtime's own `js_url_*` impl still owns native URL semantics. Manual repro (`/tmp/perry-joi-916`, `import Joi from "joi"`) confirms the V8 binary now passes the `URL is not defined` error and reaches the next downstream blocker.
+
 ## v0.5.970 — feat(util): add `util.formatWithOptions(options, format, ...args)` (unblocks the `debug` npm package)
 
 **Background.** `node:util.formatWithOptions(inspectOptions, format[, ...args])` is documented at <https://nodejs.org/api/util.html#utilformatwithoptionsinspectoptions-format-args>. It's identical to `util.format` except the first argument is an `util.inspect`-options bag that gets applied to any `%o` / `%O` placeholders in the format string. Despite being a relatively obscure API on its own, it's required by the `debug` npm package — a top-1k-by-downloads logger that is a transitive dependency of `express`, `socket.io`, and roughly half of the Node ecosystem. Without this entry, any compile that pulls in `debug` (directly or transitively, even when `debug` is listed in `perry.compilePackages`) bails at HIR-lower time with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.970
+**Current Version:** 0.5.971
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.970"
+version = "0.5.971"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.970"
+version = "0.5.971"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.970"
+version = "0.5.971"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.970"
+version = "0.5.971"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.970"
+version = "0.5.971"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-jsruntime/src/node_polyfills.js
+++ b/crates/perry-jsruntime/src/node_polyfills.js
@@ -337,6 +337,345 @@
         };
     }
 
+    // URL / URLSearchParams polyfill -- needed for `@hapi/hoek` and friends
+    // that reference `URL.prototype` at module-init time. Modern Node exposes these as
+    // globals; deno_core does not, so without this `import "joi"` crashes with
+    // `ReferenceError: URL is not defined`.
+    if (typeof globalThis.URLSearchParams === 'undefined') {
+        const __decodePlus = (s) => decodeURIComponent(String(s).replace(/\+/g, ' '));
+        const __enc = (s) => encodeURIComponent(String(s)).replace(/%20/g, '+');
+        globalThis.URLSearchParams = class URLSearchParams {
+            constructor(init) {
+                this._list = [];
+                if (init === undefined || init === null) return;
+                if (typeof init === 'string') {
+                    let s = init;
+                    if (s.length > 0 && s.charCodeAt(0) === 63 /* '?' */) s = s.slice(1);
+                    if (s.length === 0) return;
+                    for (const pair of s.split('&')) {
+                        if (pair.length === 0) continue;
+                        const eq = pair.indexOf('=');
+                        if (eq === -1) {
+                            this._list.push([__decodePlus(pair), '']);
+                        } else {
+                            this._list.push([__decodePlus(pair.slice(0, eq)), __decodePlus(pair.slice(eq + 1))]);
+                        }
+                    }
+                } else if (Array.isArray(init)) {
+                    for (const pair of init) {
+                        if (!Array.isArray(pair) || pair.length !== 2) {
+                            throw new TypeError('URLSearchParams: invalid init pair');
+                        }
+                        this._list.push([String(pair[0]), String(pair[1])]);
+                    }
+                } else if (typeof init === 'object') {
+                    for (const k of Object.keys(init)) {
+                        this._list.push([String(k), String(init[k])]);
+                    }
+                }
+            }
+            append(name, value) { this._list.push([String(name), String(value)]); }
+            delete(name) { this._list = this._list.filter(([k]) => k !== String(name)); }
+            get(name) { const e = this._list.find(([k]) => k === String(name)); return e ? e[1] : null; }
+            getAll(name) { return this._list.filter(([k]) => k === String(name)).map(([, v]) => v); }
+            has(name) { return this._list.some(([k]) => k === String(name)); }
+            set(name, value) {
+                const n = String(name);
+                let found = false;
+                this._list = this._list.filter(([k]) => {
+                    if (k !== n) return true;
+                    if (!found) { found = true; return true; }
+                    return false;
+                });
+                if (found) {
+                    for (const e of this._list) { if (e[0] === n) { e[1] = String(value); break; } }
+                } else {
+                    this._list.push([n, String(value)]);
+                }
+            }
+            sort() { this._list.sort((a, b) => a[0] < b[0] ? -1 : (a[0] > b[0] ? 1 : 0)); }
+            forEach(cb, thisArg) { for (const [k, v] of this._list.slice()) cb.call(thisArg, v, k, this); }
+            keys() { return this._list.map(([k]) => k)[Symbol.iterator](); }
+            values() { return this._list.map(([, v]) => v)[Symbol.iterator](); }
+            entries() { return this._list.slice()[Symbol.iterator](); }
+            [Symbol.iterator]() { return this.entries(); }
+            get size() { return this._list.length; }
+            toString() { return this._list.map(([k, v]) => __enc(k) + '=' + __enc(v)).join('&'); }
+            get [Symbol.toStringTag]() { return 'URLSearchParams'; }
+        };
+    }
+    if (typeof globalThis.URL === 'undefined') {
+        // RFC-3986-ish parser. Good enough for joi's `URL.prototype` reference,
+        // `instanceof URL`, `Object.prototype.toString.call(u) === '[object URL]'`,
+        // and the common `new URL(href[, base]).{href,origin,protocol,host,hostname,port,pathname,search,hash,searchParams}` access pattern.
+        const __defaultPorts = { 'http:': '80', 'https:': '443', 'ws:': '80', 'wss:': '443', 'ftp:': '21' };
+        const __parseUrl = (input, base) => {
+            let s = String(input).trim();
+            // If base supplied and input is not absolute, resolve.
+            const schemeMatch = s.match(/^([a-zA-Z][a-zA-Z0-9+.\-]*):/);
+            if (!schemeMatch) {
+                if (base === undefined || base === null) {
+                    throw new TypeError('Invalid URL: ' + input);
+                }
+                const baseParsed = (base instanceof globalThis.URL) ? base : __parseUrl(base, undefined);
+                const u = Object.create(URL.prototype);
+                u._protocol = baseParsed._protocol;
+                u._username = baseParsed._username;
+                u._password = baseParsed._password;
+                u._hostname = baseParsed._hostname;
+                u._port = baseParsed._port;
+                u._pathname = baseParsed._pathname;
+                u._search = '';
+                u._hash = '';
+                if (s.length === 0) {
+                    u._search = baseParsed._search;
+                    u._hash = baseParsed._hash;
+                } else if (s.charCodeAt(0) === 35 /* '#' */) {
+                    u._search = baseParsed._search;
+                    u._hash = s;
+                } else if (s.charCodeAt(0) === 63 /* '?' */) {
+                    const hashIdx = s.indexOf('#');
+                    if (hashIdx === -1) { u._search = s; u._hash = ''; }
+                    else { u._search = s.slice(0, hashIdx); u._hash = s.slice(hashIdx); }
+                } else if (s.charCodeAt(0) === 47 /* '/' */) {
+                    // path-relative
+                    const { path, search, hash } = __splitPath(s);
+                    u._pathname = path;
+                    u._search = search;
+                    u._hash = hash;
+                } else {
+                    // resolve against base path directory
+                    const basePath = baseParsed._pathname || '/';
+                    const slash = basePath.lastIndexOf('/');
+                    const dir = slash === -1 ? '/' : basePath.slice(0, slash + 1);
+                    const { path, search, hash } = __splitPath(dir + s);
+                    u._pathname = __normalizePath(path);
+                    u._search = search;
+                    u._hash = hash;
+                }
+                return u;
+            }
+            const u = Object.create(URL.prototype);
+            u._protocol = schemeMatch[1].toLowerCase() + ':';
+            s = s.slice(schemeMatch[0].length);
+            u._username = '';
+            u._password = '';
+            u._hostname = '';
+            u._port = '';
+            u._pathname = '';
+            u._search = '';
+            u._hash = '';
+            const isSpecial = __defaultPorts.hasOwnProperty(u._protocol) || u._protocol === 'file:';
+            if (s.startsWith('//')) {
+                s = s.slice(2);
+                // authority ends at first '/', '?', or '#'
+                let authEnd = s.length;
+                for (let i = 0; i < s.length; i++) {
+                    const c = s.charCodeAt(i);
+                    if (c === 47 || c === 63 || c === 35) { authEnd = i; break; }
+                }
+                const auth = s.slice(0, authEnd);
+                s = s.slice(authEnd);
+                const atIdx = auth.lastIndexOf('@');
+                let hostPart = auth;
+                if (atIdx !== -1) {
+                    const userInfo = auth.slice(0, atIdx);
+                    hostPart = auth.slice(atIdx + 1);
+                    const colonIdx = userInfo.indexOf(':');
+                    if (colonIdx === -1) {
+                        u._username = userInfo;
+                    } else {
+                        u._username = userInfo.slice(0, colonIdx);
+                        u._password = userInfo.slice(colonIdx + 1);
+                    }
+                }
+                // IPv6 in brackets?
+                if (hostPart.startsWith('[')) {
+                    const closeIdx = hostPart.indexOf(']');
+                    if (closeIdx === -1) throw new TypeError('Invalid URL: ' + input);
+                    u._hostname = hostPart.slice(0, closeIdx + 1).toLowerCase();
+                    const rest = hostPart.slice(closeIdx + 1);
+                    if (rest.startsWith(':')) u._port = rest.slice(1);
+                } else {
+                    const colonIdx = hostPart.lastIndexOf(':');
+                    if (colonIdx === -1) {
+                        u._hostname = hostPart.toLowerCase();
+                    } else {
+                        u._hostname = hostPart.slice(0, colonIdx).toLowerCase();
+                        u._port = hostPart.slice(colonIdx + 1);
+                    }
+                }
+                // strip default port
+                if (u._port !== '' && __defaultPorts[u._protocol] === u._port) u._port = '';
+                if (s.length === 0) {
+                    u._pathname = isSpecial ? '/' : '';
+                } else {
+                    const { path, search, hash } = __splitPath(s);
+                    u._pathname = path === '' && isSpecial ? '/' : path;
+                    u._search = search;
+                    u._hash = hash;
+                }
+            } else {
+                // No authority -- e.g. mailto:foo@bar, data:text/plain;...
+                const { path, search, hash } = __splitPath(s);
+                u._pathname = path;
+                u._search = search;
+                u._hash = hash;
+            }
+            return u;
+        };
+        const __splitPath = (s) => {
+            let hash = '';
+            let search = '';
+            const hashIdx = s.indexOf('#');
+            if (hashIdx !== -1) { hash = s.slice(hashIdx); s = s.slice(0, hashIdx); }
+            const qIdx = s.indexOf('?');
+            if (qIdx !== -1) { search = s.slice(qIdx); s = s.slice(0, qIdx); }
+            return { path: s, search, hash };
+        };
+        const __normalizePath = (p) => {
+            // Collapse '.' and '..' segments per WHATWG (close enough).
+            if (p === '') return '';
+            const leading = p.charCodeAt(0) === 47;
+            const parts = p.split('/');
+            const out = [];
+            for (const part of parts) {
+                if (part === '.') continue;
+                if (part === '..') { if (out.length > 0 && out[out.length - 1] !== '') out.pop(); continue; }
+                out.push(part);
+            }
+            let result = out.join('/');
+            if (leading && !result.startsWith('/')) result = '/' + result;
+            return result;
+        };
+
+        class URL {
+            constructor(input, base) {
+                const parsed = __parseUrl(input, base);
+                this._protocol = parsed._protocol;
+                this._username = parsed._username;
+                this._password = parsed._password;
+                this._hostname = parsed._hostname;
+                this._port = parsed._port;
+                this._pathname = parsed._pathname;
+                this._search = parsed._search;
+                this._hash = parsed._hash;
+            }
+            get protocol() { return this._protocol; }
+            set protocol(v) { const s = String(v); this._protocol = s.endsWith(':') ? s : s + ':'; }
+            get username() { return this._username; }
+            set username(v) { this._username = String(v); }
+            get password() { return this._password; }
+            set password(v) { this._password = String(v); }
+            get host() {
+                if (this._hostname === '') return '';
+                return this._port === '' ? this._hostname : this._hostname + ':' + this._port;
+            }
+            set host(v) {
+                const s = String(v);
+                const colon = s.lastIndexOf(':');
+                if (colon === -1 || s.startsWith('[')) {
+                    this._hostname = s.toLowerCase();
+                    this._port = '';
+                } else {
+                    this._hostname = s.slice(0, colon).toLowerCase();
+                    this._port = s.slice(colon + 1);
+                }
+            }
+            get hostname() { return this._hostname; }
+            set hostname(v) { this._hostname = String(v).toLowerCase(); }
+            get port() { return this._port; }
+            set port(v) {
+                const s = String(v);
+                if (s === '' || /^[0-9]+$/.test(s)) this._port = s;
+            }
+            get pathname() { return this._pathname; }
+            set pathname(v) {
+                let s = String(v);
+                const hasAuthority = this._hostname !== '';
+                if (hasAuthority && !s.startsWith('/')) s = '/' + s;
+                this._pathname = s;
+            }
+            get search() { return this._search; }
+            set search(v) {
+                let s = String(v);
+                if (s === '') { this._search = ''; return; }
+                if (!s.startsWith('?')) s = '?' + s;
+                this._search = s;
+            }
+            get searchParams() {
+                if (!this._searchParams) {
+                    const owner = this;
+                    const sp = new globalThis.URLSearchParams(this._search);
+                    // Live-sync -- every mutation rewrites _search.
+                    const sync = () => { owner._search = sp._list.length === 0 ? '' : '?' + sp.toString(); };
+                    const wrap = (name) => {
+                        const orig = sp[name];
+                        sp[name] = function (...args) { const r = orig.apply(sp, args); sync(); return r; };
+                    };
+                    ['append', 'delete', 'set', 'sort'].forEach(wrap);
+                    this._searchParams = sp;
+                }
+                return this._searchParams;
+            }
+            get hash() { return this._hash; }
+            set hash(v) {
+                let s = String(v);
+                if (s === '') { this._hash = ''; return; }
+                if (!s.startsWith('#')) s = '#' + s;
+                this._hash = s;
+            }
+            get origin() {
+                if (this._protocol === 'http:' || this._protocol === 'https:' || this._protocol === 'ws:' || this._protocol === 'wss:' || this._protocol === 'ftp:') {
+                    return this._protocol + '//' + this.host;
+                }
+                if (this._protocol === 'file:') return 'null';
+                return 'null';
+            }
+            get href() {
+                let out = this._protocol;
+                if (this._hostname !== '' || this._protocol === 'file:') {
+                    out += '//';
+                    if (this._username !== '' || this._password !== '') {
+                        out += this._username;
+                        if (this._password !== '') out += ':' + this._password;
+                        out += '@';
+                    }
+                    out += this._hostname;
+                    if (this._port !== '') out += ':' + this._port;
+                }
+                out += this._pathname;
+                out += this._search;
+                out += this._hash;
+                return out;
+            }
+            set href(v) {
+                const parsed = __parseUrl(v, undefined);
+                this._protocol = parsed._protocol;
+                this._username = parsed._username;
+                this._password = parsed._password;
+                this._hostname = parsed._hostname;
+                this._port = parsed._port;
+                this._pathname = parsed._pathname;
+                this._search = parsed._search;
+                this._hash = parsed._hash;
+                this._searchParams = undefined;
+            }
+            toString() { return this.href; }
+            toJSON() { return this.href; }
+            get [Symbol.toStringTag]() { return 'URL'; }
+        }
+        URL.canParse = function (input, base) {
+            try { __parseUrl(input, base); return true; } catch (_e) { return false; }
+        };
+        URL.parse = function (input, base) {
+            try { return new URL(input, base); } catch (_e) { return null; }
+        };
+        URL.createObjectURL = function () { return ''; };
+        URL.revokeObjectURL = function () {};
+        globalThis.URL = URL;
+    }
+
     // Also provide process.env and process.version if not present
     if (typeof globalThis.process === 'undefined') {
         globalThis.process = {

--- a/test-files/joi_url_v8_global/main.ts
+++ b/test-files/joi_url_v8_global/main.ts
@@ -1,0 +1,15 @@
+// V8-fallback jsruntime now defines `URL` and `URLSearchParams` as globals
+// so packages routed through the V8 fallback (anything in node_modules not
+// listed in `perry.compilePackages`) can read `URL.prototype` at module-init
+// time. This was the `import Joi from "joi"` crash path: joi's transitive
+// dep `@hapi/hoek/lib/types.js` reads `URL.prototype` as a top-level
+// expression and v8 (without `deno_url`) threw `ReferenceError`.
+import * as pkg from "url-init-pkg";
+
+console.log("urlProto type:", typeof pkg.urlProto);
+const parsed = pkg.parseHref("https://example.com:8443/api/v1?x=1&y=2");
+console.log("protocol:", parsed.protocol);
+console.log("hostname:", parsed.hostname);
+console.log("pathname:", parsed.pathname);
+console.log("search:", parsed.search);
+console.log("search-stringify:", pkg.searchToString({ a: "1", b: "2" }));

--- a/test-files/joi_url_v8_global/node_modules/url-init-pkg/index.js
+++ b/test-files/joi_url_v8_global/node_modules/url-init-pkg/index.js
@@ -1,0 +1,19 @@
+'use strict';
+// Reproduces the joi/@hapi/hoek init-time pattern: package compiled
+// through perry.compilePackages references `URL` as a global at module
+// load time. Without the V8 jsruntime URL polyfill this throws
+// `ReferenceError: URL is not defined` before the consumer code runs.
+
+exports.urlProto = URL.prototype;
+exports.parseHref = function (href) {
+    const u = new URL(href);
+    return {
+        protocol: u.protocol,
+        hostname: u.hostname,
+        pathname: u.pathname,
+        search: u.search,
+    };
+};
+exports.searchToString = function (init) {
+    return new URLSearchParams(init).toString();
+};

--- a/test-files/joi_url_v8_global/node_modules/url-init-pkg/package.json
+++ b/test-files/joi_url_v8_global/node_modules/url-init-pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "url-init-pkg",
+  "version": "0.1.0",
+  "main": "index.js"
+}

--- a/test-files/joi_url_v8_global/package.json
+++ b/test-files/joi_url_v8_global/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "joi-url-v8-global-probe",
+  "version": "0.0.1",
+  "perry": { "compilePackages": [] }
+}


### PR DESCRIPTION
## Summary
- `import Joi from "joi"` (and any package whose transitive deps reference `URL` at module-init time) crashed in the V8 fallback with `ReferenceError: URL is not defined`. `@hapi/hoek/lib/types.js` reads `URL.prototype` as a top-level expression; modern Node exposes `URL` as a global but `deno_core` (without the `deno_url` extension) does not.
- Install `globalThis.URL` and `globalThis.URLSearchParams` from `crates/perry-jsruntime/src/node_polyfills.js` alongside the existing `Buffer`/`TextEncoder`/`TextDecoder`/`fetch` polyfills. Roughly-WHATWG `new URL(href[, base])` with all property getters/setters, live-sync `searchParams`, static `URL.canParse`/`URL.parse`, plus a complete `URLSearchParams` (string/array-of-pairs/object init; `append`/`delete`/`get`/`getAll`/`has`/`set`/`sort`/`forEach`/`keys`/`values`/`entries`/`size`/`toString`/`Symbol.iterator`).
- Both polyfills are gated on `typeof globalThis.URL === 'undefined'`, so they no-op if a future `deno_core` upgrade ships built-in URL globals.
- New `test-files/joi_url_v8_global/` fixture forces V8 fallback (no `compilePackages` entry, `.js` package in `node_modules`) and exercises `URL.prototype`, `new URL(href)`, all getters, and `URLSearchParams` stringification. Native-compile path is unchanged -- perry-runtime's own `js_url_*` impl still owns native URL semantics.

Scope is narrow: joi still fails further into its init with `TypeError: Cannot read properties of undefined (reading 'template')`. That downstream gap is left as a follow-up.

## Test plan
- [x] Reproduce against pre-fix `target/release/perry`: `import Joi from "joi"` (with `perry.compilePackages: ["joi"]`) fails at module-init with `ReferenceError: URL is not defined`.
- [x] Apply fix, rebuild `perry-jsruntime` + `perry`, re-run repro: joi now advances past the URL error and reaches the next downstream blocker (`Cannot read properties of undefined (reading 'template')`).
- [x] `test-files/joi_url_v8_global/main.ts` compiles + runs cleanly via V8 fallback path; prints expected `URL.prototype` access, parsed-URL property values, and `URLSearchParams.toString()` output.
- [x] `cargo fmt --all`.
- [x] No conflict markers in Cargo.toml / CLAUDE.md / CHANGELOG.md / Cargo.lock.
- [x] Version bumped to `0.5.971` in `Cargo.toml`, `Cargo.lock`, and `CLAUDE.md`; new `## v0.5.971` block prepended to `CHANGELOG.md`.