### PR TITLE
feat(security): #497 — host allowlist for `perry.nativeLibrary` + `perry.compilePackages`

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -153,6 +153,39 @@ fn write_audit_manifest(ctx: &CompilationContext) -> std::io::Result<()> {
     Ok(())
 }
 
+/// #497: does `name` match any entry in the host allowlist?
+///
+/// Pattern syntax:
+/// - exact match (`"lodash"`, `"@perryts/perry-prisma"`)
+/// - scope wildcard (`"@scope/*"` matches any package under `@scope/`)
+/// - universal `"*"` escape hatch (matches every name)
+///
+/// Empty allowlists never match anything — the supply-chain default
+/// is "nothing allowed" per the issue's "Default behavior on
+/// greenfield projects" acceptance bullet.
+pub(crate) fn allowlist_matches(name: &str, patterns: &[String]) -> bool {
+    for pat in patterns {
+        if pat == "*" {
+            return true;
+        }
+        if pat == name {
+            return true;
+        }
+        // Scope wildcard `@scope/*` — matches anything under `@scope/`.
+        if let Some(prefix) = pat.strip_suffix("/*") {
+            // Both `prefix/anything` and the bare prefix (an unscoped
+            // package author publishing `@scope` itself, rare but
+            // representable) match.
+            if let Some(rest) = name.strip_prefix(prefix) {
+                if rest.starts_with('/') || rest.is_empty() {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
 fn package_bundle_id_from_input(input: &Path) -> Option<String> {
     let mut dir = input.canonicalize().ok()?;
     if dir.is_file() {
@@ -677,6 +710,20 @@ pub struct CompilationContext {
     /// guarantee. Source: `perry.allowDynamicHosts: true` in host
     /// `package.json`.
     pub allow_dynamic_hosts: bool,
+    /// #497: host-controlled allowlist for transitive deps that ship a
+    /// `perry.nativeLibrary` manifest. Default empty = nothing allowed.
+    /// Read from `perry.allow.nativeLibrary` (array of strings) in the
+    /// host's `package.json` only. Patterns: exact match, prefix `*`
+    /// (allow-all escape hatch), or scope-style `@scope/*`.
+    pub allow_native_library: Vec<String>,
+    /// #497: host-controlled allowlist for package names that may be
+    /// added to `perry.compilePackages`. Default empty = nothing
+    /// allowed. Same pattern syntax as `allow_native_library`. Each
+    /// entry the user puts in `perry.compilePackages` must also be
+    /// matched by an entry here, otherwise the build refuses. This
+    /// makes the dangerous "compile this random npm package into the
+    /// binary" surface a two-key opt-in.
+    pub allow_compile_packages: Vec<String>,
 }
 
 impl std::fmt::Debug for CompilationContext {
@@ -733,6 +780,8 @@ impl CompilationContext {
             lockdown: false,
             allowed_hosts: Vec::new(),
             allow_dynamic_hosts: false,
+            allow_native_library: Vec::new(),
+            allow_compile_packages: Vec::new(),
         }
     }
 }
@@ -1171,11 +1220,41 @@ pub fn run_with_parse_cache(
                         }
                     }
                 }
+                // #497: host-controlled allowlists for the two
+                // attack surfaces Perry itself introduced over Node:
+                // `perry.nativeLibrary` (transitive deps that link
+                // arbitrary native code) and `perry.compilePackages`
+                // (compiling untrusted TS into the binary). Both
+                // arrays default empty (= nothing allowed); patterns
+                // accept exact names, scope wildcards (`@scope/*`),
+                // or the universal `*` escape hatch.
+                if let Some(allow) = pkg.get("perry").and_then(|p| p.get("allow")) {
+                    if let Some(arr) = allow.get("nativeLibrary").and_then(|v| v.as_array()) {
+                        for entry in arr {
+                            if let Some(s) = entry.as_str() {
+                                ctx.allow_native_library.push(s.to_string());
+                            }
+                        }
+                    }
+                    if let Some(arr) = allow.get("compilePackages").and_then(|v| v.as_array()) {
+                        for entry in arr {
+                            if let Some(s) = entry.as_str() {
+                                ctx.allow_compile_packages.push(s.to_string());
+                            }
+                        }
+                    }
+                }
                 if let Some(compile_pkgs) = pkg
                     .get("perry")
                     .and_then(|p| p.get("compilePackages"))
                     .and_then(|a| a.as_array())
                 {
+                    // #497: collect compilePackages entries here but
+                    // defer the allowlist check until after env-var
+                    // overrides apply (otherwise
+                    // `PERRY_ALLOW_PERRY_FEATURES=1` couldn't unblock
+                    // a build whose host hasn't opted in via
+                    // package.json yet).
                     for pkg_name in compile_pkgs {
                         if let Some(name) = pkg_name.as_str() {
                             match format {
@@ -1424,6 +1503,27 @@ pub fn run_with_parse_cache(
         _ => {}
     }
 
+    // #497: `PERRY_ALLOW_PERRY_FEATURES=1` opts every name into both
+    // host allowlists at once — emergency escape hatch for builds
+    // where editing `package.json` isn't an option (one-off CI run,
+    // bisect script, etc.). `=0` enforces the refusal even when
+    // `package.json` opted in (fail-closed CI gate).
+    match std::env::var("PERRY_ALLOW_PERRY_FEATURES") {
+        Ok(v) if v == "1" || v.eq_ignore_ascii_case("true") => {
+            if !ctx.allow_native_library.iter().any(|s| s == "*") {
+                ctx.allow_native_library.push("*".to_string());
+            }
+            if !ctx.allow_compile_packages.iter().any(|s| s == "*") {
+                ctx.allow_compile_packages.push("*".to_string());
+            }
+        }
+        Ok(v) if v == "0" || v.eq_ignore_ascii_case("false") => {
+            ctx.allow_native_library.clear();
+            ctx.allow_compile_packages.clear();
+        }
+        _ => {}
+    }
+
     // #504 — precedence ladder (last wins): package.json
     // `perry.emitAttest` → env `PERRY_EMIT_ATTEST=1` → CLI
     // `--emit-attest`.
@@ -1458,6 +1558,37 @@ pub fn run_with_parse_cache(
     }
     if args.lockdown {
         ctx.lockdown = true;
+    }
+
+    // #497: deferred allowlist check for `perry.compilePackages` (the
+    // parse loop populated `ctx.compile_packages` above; we validate
+    // after env-var overrides). Every entry that flowed in needs a
+    // match in `ctx.allow_compile_packages` — the two-key opt-in.
+    // Default-empty allowlist = nothing allowed = matches the
+    // "greenfield projects: nothing allowed" acceptance bullet.
+    for name in ctx.compile_packages.iter() {
+        if !allowlist_matches(name, &ctx.allow_compile_packages) {
+            anyhow::bail!(
+                "package `{name}` is in `perry.compilePackages` but not in \
+                 `perry.allow.compilePackages` — compiling untrusted TS into the \
+                 binary is a privileged operation and requires explicit host \
+                 opt-in. (#497)\n\
+                 \n\
+                 Review the package, then add it to your host `package.json`:\n\
+                 \n\
+                   {{\n\
+                     \"perry\": {{\n\
+                       \"allow\": {{ \"compilePackages\": [\"{name}\"] }}\n\
+                     }}\n\
+                   }}\n\
+                 \n\
+                 Scope wildcard (`\"@scope/*\"`) and the universal `\"*\"` escape \
+                 hatch are both supported.\n\
+                 \n\
+                 For a one-off build, set `PERRY_ALLOW_PERRY_FEATURES=1` in the \
+                 environment."
+            );
+        }
     }
 
     // --- i18n: parse [i18n] config from perry.toml and load locale files ---
@@ -8360,5 +8491,82 @@ mod js_runtime_gate_tests {
         // coverage; the diagnostic falls through to printing only the
         // raw path.
         assert_eq!(package_name_for_path("/repo/node_modules/"), None);
+    }
+}
+
+#[cfg(test)]
+mod allowlist_tests {
+    //! #497 — coverage for the host-allowlist matcher used to gate
+    //! `perry.nativeLibrary` and `perry.compilePackages`.
+    use super::allowlist_matches;
+
+    fn pats(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn empty_allowlist_blocks_everything() {
+        // Acceptance bullet: "Default behavior on greenfield
+        // projects: nothing allowed." The empty list never matches.
+        assert!(!allowlist_matches("lodash", &[]));
+        assert!(!allowlist_matches("@scope/pkg", &[]));
+        assert!(!allowlist_matches("", &[]));
+    }
+
+    #[test]
+    fn exact_match() {
+        let allow = pats(&["lodash", "@scope/pkg"]);
+        assert!(allowlist_matches("lodash", &allow));
+        assert!(allowlist_matches("@scope/pkg", &allow));
+        assert!(!allowlist_matches("not-listed", &allow));
+        assert!(!allowlist_matches("lodash-suffix", &allow));
+    }
+
+    #[test]
+    fn universal_wildcard() {
+        // Emergency escape hatch. Matches every name including the
+        // empty string (defensive).
+        let allow = pats(&["*"]);
+        assert!(allowlist_matches("anything", &allow));
+        assert!(allowlist_matches("@scope/whatever", &allow));
+        assert!(allowlist_matches("", &allow));
+    }
+
+    #[test]
+    fn scope_wildcard() {
+        // `@scope/*` matches any package under the scope, but NOT
+        // arbitrary other scopes or unrelated names.
+        let allow = pats(&["@perryts/*"]);
+        assert!(allowlist_matches("@perryts/perry-prisma", &allow));
+        assert!(allowlist_matches("@perryts/redis", &allow));
+        // Subpath-style names within the scope: `@perryts/foo/bar` is
+        // *not* a valid npm package name, but if someone slips one
+        // through the patterns still match the leading scope.
+        assert!(allowlist_matches("@perryts/foo/bar", &allow));
+        // Different scope must not match.
+        assert!(!allowlist_matches("@other/pkg", &allow));
+        // Unscoped names must not match a scoped pattern.
+        assert!(!allowlist_matches("perryts-redis", &allow));
+        // Bare scope must not match `@perryts-foo` (different scope).
+        assert!(!allowlist_matches("@perryts-foo/pkg", &allow));
+    }
+
+    #[test]
+    fn non_scoped_wildcards_dont_match() {
+        // Only the slash-anchored `prefix/*` shape is supported. A
+        // freeform `lodash-*` pattern matches nothing — kept simple
+        // on purpose so reviewers can read the rule at a glance:
+        // exact, universal, or scope-wildcard.
+        let allow = pats(&["lodash-*", "*-tests"]);
+        assert!(!allowlist_matches("lodash-es", &allow));
+        assert!(!allowlist_matches("foo-tests", &allow));
+    }
+
+    #[test]
+    fn multiple_patterns_or_together() {
+        let allow = pats(&["lodash", "@scope/*"]);
+        assert!(allowlist_matches("lodash", &allow));
+        assert!(allowlist_matches("@scope/anything", &allow));
+        assert!(!allowlist_matches("other-pkg", &allow));
     }
 }

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -722,6 +722,39 @@ pub(super) fn collect_modules(
                                     {
                                         return Err(anyhow::anyhow!("{}", msg));
                                     }
+                                    // #497: gate transitive
+                                    // `perry.nativeLibrary` linkage on
+                                    // host-controlled allowlist. The
+                                    // package declared the manifest
+                                    // itself; the host must
+                                    // explicitly allow it.
+                                    if !super::allowlist_matches(
+                                        &manifest.module,
+                                        &ctx.allow_native_library,
+                                    ) {
+                                        anyhow::bail!(
+                                            "package `{}` declares `perry.nativeLibrary` \
+                                             (links arbitrary native code into the binary) \
+                                             but is not in your host \
+                                             `perry.allow.nativeLibrary`. Review the package, \
+                                             then add it to your host `package.json`:\n\
+                                             \n\
+                                               {{\n\
+                                                 \"perry\": {{\n\
+                                                   \"allow\": {{ \"nativeLibrary\": [\"{}\"] }}\n\
+                                                 }}\n\
+                                               }}\n\
+                                             \n\
+                                             Scope wildcard (`\"@scope/*\"`) and the universal \
+                                             `\"*\"` escape hatch are both supported.\n\
+                                             \n\
+                                             For a one-off build, set \
+                                             `PERRY_ALLOW_PERRY_FEATURES=1` in the environment. \
+                                             (#497)",
+                                            manifest.module,
+                                            manifest.module,
+                                        );
+                                    }
                                     match format {
                                         OutputFormat::Text => println!(
                                             "  Native library: {} ({} FFI functions)",
@@ -791,6 +824,39 @@ pub(super) fn collect_modules(
                                         super::resolve::validate_abi_version(&manifest)
                                     {
                                         return Err(anyhow::anyhow!("{}", msg));
+                                    }
+                                    // #497: gate transitive
+                                    // `perry.nativeLibrary` linkage on
+                                    // host-controlled allowlist. The
+                                    // package declared the manifest
+                                    // itself; the host must
+                                    // explicitly allow it.
+                                    if !super::allowlist_matches(
+                                        &manifest.module,
+                                        &ctx.allow_native_library,
+                                    ) {
+                                        anyhow::bail!(
+                                            "package `{}` declares `perry.nativeLibrary` \
+                                             (links arbitrary native code into the binary) \
+                                             but is not in your host \
+                                             `perry.allow.nativeLibrary`. Review the package, \
+                                             then add it to your host `package.json`:\n\
+                                             \n\
+                                               {{\n\
+                                                 \"perry\": {{\n\
+                                                   \"allow\": {{ \"nativeLibrary\": [\"{}\"] }}\n\
+                                                 }}\n\
+                                               }}\n\
+                                             \n\
+                                             Scope wildcard (`\"@scope/*\"`) and the universal \
+                                             `\"*\"` escape hatch are both supported.\n\
+                                             \n\
+                                             For a one-off build, set \
+                                             `PERRY_ALLOW_PERRY_FEATURES=1` in the environment. \
+                                             (#497)",
+                                            manifest.module,
+                                            manifest.module,
+                                        );
                                     }
                                     match format {
                                         OutputFormat::Text => println!(

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -146,6 +146,7 @@
 - [Egress Allowlist (`allowedHosts`)](cli/allowed-hosts.md)
 - [Per-Package Capabilities (`perry.permissions`)](cli/capabilities.md)
 - [`perry audit --sbom`](cli/perry-audit-sbom.md)
+- [Host Allowlist (nativeLibrary, compilePackages)](cli/allow-perry-features.md)
 - [perry.toml Reference](cli/perry-toml.md)
 
 ---

--- a/docs/src/cli/allow-perry-features.md
+++ b/docs/src/cli/allow-perry-features.md
@@ -1,0 +1,112 @@
+# Host Allowlist for `nativeLibrary` and `compilePackages`
+
+Perry refuses to honor two privileged dependency features — the two
+attack surfaces Perry itself introduced over Node — unless the host
+application has explicitly opted in to each consumer:
+
+- `perry.nativeLibrary` — a transitive dep linking arbitrary native
+  code into the binary.
+- `perry.compilePackages` — compiling untrusted TS source from an npm
+  package into the binary as if it were first-party code.
+
+Both checks fire at compile time. **Zero runtime cost.**
+
+## How a build hits this
+
+### `nativeLibrary` (transitive dep declares it)
+
+A package shipped with `perry.nativeLibrary` in its own `package.json`
+is detected during dependency collection. Without an entry in the
+host's `perry.allow.nativeLibrary`, the build fails:
+
+```text
+Error: package `@bloomengine/engine` declares `perry.nativeLibrary`
+(links arbitrary native code into the binary) but is not in your host
+`perry.allow.nativeLibrary`. Review the package, then add it to your
+host `package.json`:
+
+  {
+    "perry": {
+      "allow": { "nativeLibrary": ["@bloomengine/engine"] }
+    }
+  }
+```
+
+### `compilePackages` (host or workspace root declares it)
+
+Every entry in `perry.compilePackages` must also be matched by an
+entry in `perry.allow.compilePackages` — a two-key opt-in:
+
+```text
+Error: package `hono` is in `perry.compilePackages` but not in
+`perry.allow.compilePackages` — compiling untrusted TS into the binary
+is a privileged operation and requires explicit host opt-in. (#497)
+```
+
+## Opt-in mechanisms
+
+### 1. Host `package.json` (persistent, recommended)
+
+```json
+{
+  "perry": {
+    "compilePackages": ["hono"],
+    "nativeLibrary": "...",
+    "allow": {
+      "compilePackages": ["hono"],
+      "nativeLibrary": ["@bloomengine/engine"]
+    }
+  }
+}
+```
+
+### 2. Scope wildcard
+
+`"@scope/*"` matches any package under `@scope/`:
+
+```json
+{
+  "perry": {
+    "allow": {
+      "compilePackages": ["@nestjs/*", "reflect-metadata", "rxjs"]
+    }
+  }
+}
+```
+
+### 3. Universal escape hatch
+
+`"*"` matches every name. Use sparingly — defeats the purpose of the
+allowlist.
+
+```json
+{ "perry": { "allow": { "compilePackages": ["*"] } } }
+```
+
+### 4. Environment variable
+
+`PERRY_ALLOW_PERRY_FEATURES=1` opts every package into both
+allowlists for the current build — emergency knob for one-off builds
+where editing `package.json` isn't an option. `=0` enforces refusal
+even when `package.json` opted in (fail-closed CI gate).
+
+## Default-deny rationale
+
+Both features escape Perry's structural guarantees:
+
+- `nativeLibrary` lets a transitive dep ship arbitrary machine code
+  that runs at the same trust level as the host application.
+- `compilePackages` runs the dep's TypeScript through Perry's full
+  native pipeline (HIR / codegen / linker) instead of routing it
+  through QuickJS, eliminating the runtime sandbox.
+
+Both are useful features, but they're *privileged* operations. The
+allowlist makes that privilege explicit and auditable: a reviewer
+diffing a PR can see exactly which deps have been granted native
+access, and `git blame` records who approved each one.
+
+## See also
+
+- [`#497`](https://github.com/PerryTS/perry/issues/497) — design discussion.
+- The wider supply-chain hardening series
+  ([`#495`–`#506`](https://github.com/PerryTS/perry/issues?q=is%3Aissue+label%3Aenhancement+security)).

--- a/test-files/issue_652/package.json
+++ b/test-files/issue_652/package.json
@@ -1,5 +1,8 @@
 {
   "name": "issue-652-probe",
   "version": "0.0.1",
-  "perry": { "compilePackages": ["minilib"] }
+  "perry": {
+    "compilePackages": ["minilib"],
+    "allow": { "compilePackages": ["minilib"] }
+  }
 }

--- a/tests/release/packages/axios-get/package.json
+++ b/tests/release/packages/axios-get/package.json
@@ -8,6 +8,9 @@
     "axios": "^1.7.0"
   },
   "perry": {
-    "compilePackages": ["axios"]
+    "compilePackages": ["axios"],
+    "allow": {
+      "compilePackages": ["axios"]
+    }
   }
 }

--- a/tests/release/packages/drizzle-sqlite/package.json
+++ b/tests/release/packages/drizzle-sqlite/package.json
@@ -9,6 +9,9 @@
     "better-sqlite3": "^11.0.0"
   },
   "perry": {
-    "compilePackages": ["drizzle-orm"]
+    "compilePackages": ["drizzle-orm"],
+    "allow": {
+      "compilePackages": ["drizzle-orm"]
+    }
   }
 }

--- a/tests/release/packages/hono-basic/package.json
+++ b/tests/release/packages/hono-basic/package.json
@@ -8,6 +8,9 @@
     "hono": "^4.6.0"
   },
   "perry": {
-    "compilePackages": ["hono"]
+    "compilePackages": ["hono"],
+    "allow": {
+      "compilePackages": ["hono"]
+    }
   }
 }

--- a/tests/release/packages/ink-link-smoke/package.json
+++ b/tests/release/packages/ink-link-smoke/package.json
@@ -12,6 +12,12 @@
     "compilePackages": [
       "react",
       "ink"
-    ]
+    ],
+    "allow": {
+      "compilePackages": [
+        "react",
+        "ink"
+      ]
+    }
   }
 }

--- a/tests/release/packages/nestjs-hello/package.json
+++ b/tests/release/packages/nestjs-hello/package.json
@@ -18,6 +18,13 @@
       "@nestjs/platform-express",
       "reflect-metadata",
       "rxjs"
-    ]
+    ],
+    "allow": {
+      "compilePackages": [
+        "@nestjs/*",
+        "reflect-metadata",
+        "rxjs"
+      ]
+    }
   }
 }

--- a/tests/release/packages/redis-pubsub/package.json
+++ b/tests/release/packages/redis-pubsub/package.json
@@ -8,6 +8,9 @@
     "redis": "^4.7.0"
   },
   "perry": {
-    "compilePackages": ["redis"]
+    "compilePackages": ["redis"],
+    "allow": {
+      "compilePackages": ["redis"]
+    }
   }
 }


### PR DESCRIPTION
Closes #497.

## Summary

The two attack surfaces Perry itself introduced over Node — linking arbitrary native code (`perry.nativeLibrary`) and compiling untrusted TS source into the binary (`perry.compilePackages`) — were silently honored from any package in the dep graph. This PR makes both privileged operations require explicit host-app opt-in via two new `perry.allow.*` arrays in the host `package.json`.

**Zero runtime cost** — purely compile-time refusal.

**Cross-platform**: both gates run in the platform-agnostic `compile_command` driver and `collect_modules.rs` before any backend (LLVM / WASM / ArkTS / HarmonyOS / Glance / SwiftUI / JS) is invoked.

## Refusal diagnostic example

```text
Error: package `hono` is in `perry.compilePackages` but not in
`perry.allow.compilePackages` — compiling untrusted TS into the
binary is a privileged operation and requires explicit host
opt-in. (#497)

Review the package, then add it to your host `package.json`:

  {
    "perry": {
      "allow": { "compilePackages": ["hono"] }
    }
  }

Scope wildcard (`"@scope/*"`) and the universal `"*"` escape hatch
are both supported.

For a one-off build, set `PERRY_ALLOW_PERRY_FEATURES=1` in the
environment.
```

## Pattern syntax

- Exact match — `"lodash"`.
- Scope wildcard — `"@scope/*"`.
- Universal escape hatch — `"*"`.

Default-empty allowlist = nothing allowed (per the issue's "greenfield projects: nothing allowed" acceptance bullet).

## Env-var override

`PERRY_ALLOW_PERRY_FEATURES=1` opts every name into both allowlists for one build. `=0` enforces refusal even when `package.json` opted in (fail-closed CI gate).

## Test coverage

**7 unit tests** for `allowlist_matches`:
- `empty_allowlist_blocks_everything` — default-deny invariant.
- `exact_match`, `universal_wildcard`, `scope_wildcard` — primary patterns.
- `non_scoped_wildcards_dont_match` — documents the matcher's intentionally narrow shape (no freeform `prefix-*`).
- `multiple_patterns_or_together` — OR semantics across the list.

**End-to-end smoke** against five shapes (all pass against the release binary):
1. No `compilePackages` → clean.
2. `compilePackages` without `allow` → fails with full diagnostic.
3. `compilePackages` + matching `allow` → compiles.
4. Scope wildcard (`"@foo/*"` matches `@foo/bar`, `@foo/baz`) → compiles.
5. `PERRY_ALLOW_PERRY_FEATURES=1` → compiles regardless of `package.json`.

## Test-fixture migration

7 existing release-test fixtures updated to add `perry.allow.compilePackages` alongside their existing `compilePackages`:
- `hono-basic`, `ink-link-smoke`, `nestjs-hello`, `redis-pubsub`, `axios-get`, `drizzle-sqlite`, `test-files/issue_652`.

NestJS fixture uses the scope-wildcard form (`"@nestjs/*"`) to demonstrate that mechanism in a real fixture and keep the allow-list short.

## Acceptance

- [x] Host `package.json` keys: `perry.allow.nativeLibrary`, `perry.allow.compilePackages`.
- [x] Transitive dep introducing either fails build with clear message naming the package + exact JSON to add.
- [x] Wildcards supported (`@scope/*` + universal `*`).
- [x] Default behavior on greenfield projects: nothing allowed.
- [x] Documented (`docs/src/cli/allow-perry-features.md`).

`perry audit` integration (also in the acceptance list) deferred — the `perry audit` subcommand itself is #495, not yet implemented.

## Notes

No `Cargo.toml` version bump, no `CLAUDE.md` version line touch, no `CHANGELOG.md` entry — maintainer folds those in at merge time to avoid patch-version collisions.