### PR TITLE
feat(crypto): randomFillSync + subtle.encrypt/decrypt (AES-GCM) — unblock axios + jose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.972 — feat(crypto): randomFillSync + subtle.encrypt/decrypt (AES-GCM) — unblocks axios + jose under `perry.compilePackages`
+
+**Symptom.** Two of the three "compile this npm package natively" smoke tests were hitting the strict-API gate (#463) at the same surface:
+
+```
+$ perry main.ts -o out   # main.ts: `import axios from "axios"`
+Error: `crypto.randomFillSync` is not implemented in Perry
+
+$ perry main.ts -o out   # main.ts: `import * as jose from "jose"`
+Error: `crypto.subtle.encrypt` is not implemented in Perry — supported subtle methods are digest, importKey, sign, verify
+```
+
+axios's `lib/platform/node/index.js` builds request IDs via `crypto.randomFillSync(new Uint32Array(size))`. jose's `gcmEncrypt` / `gcmDecrypt` in `dist/webapi/lib/content_encryption.js` route through `crypto.subtle.encrypt({ name: 'AES-GCM', iv, additionalData, tagLength: 128 }, key, plaintext)` and the matching `decrypt`. Both calls were rejected at HIR-lowering time by the strict-API gate because the manifest didn't declare them and the `crypto.subtle.<method>` chain matcher in `expr_call.rs` only had explicit arms for `digest` / `importKey` / `sign` / `verify`.
+
+**Implementation.**
+
+1. **`crypto.randomFillSync(buffer, offset?, size?)`** —
+   - New `Expr::CryptoRandomFillSync { buffer, offset, size }` IR variant (walker.rs both `walk_expr` arms, stable_hash.rs tag 468).
+   - HIR lowering in `crates/perry-hir/src/lower/expr_call.rs` matches alongside the existing `crypto.randomBytes` / `randomUUID` / `getRandomValues` arms. Missing offset/size lower as `Expr::Undefined` so the runtime defaulting path keeps working.
+   - Codegen in `crates/perry-codegen/src/expr.rs` emits a direct call to the new FFI helper.
+   - Runtime helper `js_crypto_random_fill_sync` in `crates/perry-stdlib/src/crypto.rs` handles **both** the Buffer / Uint8Array path (`BUFFER_REGISTRY`-tagged BufferHeader) and the TypedArrayHeader path (Uint32Array etc — axios's actual shape). Critically, the function accepts the value in two representations: NaN-boxed POINTER_TAG (the form Buffer / Uint8Array arrive as) AND raw heap pointer in the low 48 bits (the form `Expr::TypedArrayNew` codegen emits — see the `bitcast_i64_to_double` in `expr.rs`, no tag). The first iteration missed the raw-pointer case and silently no-op'd on Uint32Array; the probe `crypto.randomFillSync(new Uint32Array(4))` returned all-zeros until I widened the top16 check from `== 0x7FFD` to `>= 0x7FF8`.
+   - Optional `offset`/`size` args go through `nanboxed_to_usize` which handles INT32_TAG, plain `f64`, and the `undefined` / `null` sentinels; out-of-range values are clamped to the buffer's byte length (`resolve_range`) rather than throwing, matching Node's lenient bounds behavior.
+   - Manifest entry `method("crypto", "randomFillSync", false, None)` in `crates/perry-api-manifest/src/entries.rs`.
+
+2. **`crypto.subtle.encrypt(algorithm, key, data)` / `decrypt(...)`** — AES-GCM only this pass; AES-CBC, AES-CTR, and RSA-OAEP are TODO follow-ups tracked alongside #561.
+   - Two new IR variants `Expr::WebCryptoEncrypt` / `Expr::WebCryptoDecrypt` (same 3-arg shape as `WebCryptoSign`).
+   - HIR lowering extends the `crypto.subtle.<method>` chain matcher with `"encrypt"` / `"decrypt"` arms. Updated the "unsupported subtle method" diagnostic to list the new methods.
+   - Codegen mirrors `WebCryptoSign`: each emits a `js_webcrypto_encrypt`/`_decrypt` FFI call and NaN-boxes the returned `*mut Promise` with POINTER_TAG. Runtime helpers declared in `crates/perry-codegen/src/runtime_decls.rs`.
+   - Runtime implementation in `crates/perry-stdlib/src/webcrypto.rs`. Extended the existing `KeyAlgo` enum with `AesGcm` and taught `importKey` to accept either the object form `{ name: "AES-GCM" }` or the shorthand string `"AES-GCM"` (jose passes the shorthand). The encrypt/decrypt FFIs:
+     1. Read the algorithm's `name` via `extract_algo_name` (shared with importKey) — must equal "AES-GCM".
+     2. Read the required `iv` field and the optional `additionalData` field from the algorithm object via `object_field_bytes`.
+     3. Verify the key was imported as AES-GCM (`lookup_crypto_key` + `KeyAlgo::AesGcm` check).
+     4. Route to `aes_gcm_encrypt` / `aes_gcm_decrypt` which dispatch to `Aes128Gcm` or `Aes256Gcm` based on key length (192-bit AES-GCM is intentionally not in the `aes-gcm 0.10` type set; documented + tested as rejected). Output is `ciphertext || tag` per the WebCrypto spec; decrypt expects the same layout.
+   - Anything that doesn't fit the AES-GCM shape resolves to undefined rather than panicking — the existing `digest`/`sign`/`verify` rejection pattern.
+
+**Validation.**
+- New `test-files/test_crypto_randomFillSync.ts` — fills both `Uint8Array(16)` and `Uint32Array(8)`, asserts identity equality of the returned buffer and that the sum of bytes/elements is non-zero (2⁻¹²⁸ false-negative probability).
+- New `test-files/test_crypto_subtle_encrypt_decrypt.ts` — AES-GCM-128 round-trip with a 10-byte plaintext, verifies `ct.length == 26` (10 + 16-byte tag) and that decrypt recovers the plaintext byte-for-byte.
+- Four new unit tests in `webcrypto::tests`: 128-bit and 256-bit AES-GCM round-trips, short-IV rejection, and 192-bit key rejection (regression guard for the `aes-gcm 0.10` type-set decision).
+- Repro for axios now advances past `crypto.randomFillSync` and stops at `zlib.constants` (a separate known unimplemented). Repro for jose now advances past `crypto.subtle.encrypt` and stops at `crypto.subtle.generateKey` (out of scope per #561).
+- Manifest consistency suite + `webcrypto` lib tests green.
+
+**Out of scope.** AES-CBC, AES-CTR, AES-KW, and RSA-OAEP encrypt/decrypt; `subtle.generateKey`, `wrapKey`, `unwrapKey`, `deriveKey`; asymmetric sign/verify (RSA, ECDSA). The diagnostic message names the supported surface so callers see exactly what's missing.
+
 ## v0.5.971 — fix(jsruntime): define `URL` / `URLSearchParams` as V8-fallback globals (unblocks `import "joi"`)
 
 **Symptom.** `import Joi from "joi"` against the V8-fallback jsruntime crashed at module-init with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.971
+**Current Version:** 0.5.972
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.971"
+version = "0.5.972"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.971"
+version = "0.5.972"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.971"
+version = "0.5.972"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.971"
+version = "0.5.972"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.971"
+version = "0.5.972"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1597,6 +1597,11 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("crypto", "sha256", false, None),
     method("crypto", "md5", false, None),
     method("crypto", "getRandomValues", false, None),
+    // crypto.randomFillSync(buffer, offset?, size?) — fills the
+    // typed-array / Buffer with cryptographically strong random
+    // bytes in-place and returns the same object. Required by
+    // axios (Uint32Array) for ID generation.
+    method("crypto", "randomFillSync", false, None),
     method("crypto", "createHash", false, None),
     method("crypto", "createHmac", false, None),
     method("crypto", "pbkdf2Sync", false, None),

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -8491,6 +8491,58 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             );
             Ok(nanbox_pointer_inline(blk, &promise))
         }
+        Expr::WebCryptoEncrypt {
+            algorithm,
+            key,
+            data,
+        } => {
+            let algo_box = lower_expr(ctx, algorithm)?;
+            let key_box = lower_expr(ctx, key)?;
+            let data_box = lower_expr(ctx, data)?;
+            let blk = ctx.block();
+            let promise = blk.call(
+                I64,
+                "js_webcrypto_encrypt",
+                &[(DOUBLE, &algo_box), (DOUBLE, &key_box), (DOUBLE, &data_box)],
+            );
+            Ok(nanbox_pointer_inline(blk, &promise))
+        }
+        Expr::WebCryptoDecrypt {
+            algorithm,
+            key,
+            data,
+        } => {
+            let algo_box = lower_expr(ctx, algorithm)?;
+            let key_box = lower_expr(ctx, key)?;
+            let data_box = lower_expr(ctx, data)?;
+            let blk = ctx.block();
+            let promise = blk.call(
+                I64,
+                "js_webcrypto_decrypt",
+                &[(DOUBLE, &algo_box), (DOUBLE, &key_box), (DOUBLE, &data_box)],
+            );
+            Ok(nanbox_pointer_inline(blk, &promise))
+        }
+        Expr::CryptoRandomFillSync {
+            buffer,
+            offset,
+            size,
+        } => {
+            // Fill `buffer` (Buffer or TypedArray) with random bytes
+            // in-place; return the same NaN-boxed buffer value. `offset`
+            // and `size` are NaN-boxed JS values (Undefined → use
+            // defaults). The runtime accepts both layouts.
+            let buf_box = lower_expr(ctx, buffer)?;
+            let off_box = lower_expr(ctx, offset)?;
+            let sz_box = lower_expr(ctx, size)?;
+            let blk = ctx.block();
+            let result = blk.call(
+                DOUBLE,
+                "js_crypto_random_fill_sync",
+                &[(DOUBLE, &buf_box), (DOUBLE, &off_box), (DOUBLE, &sz_box)],
+            );
+            Ok(result)
+        }
 
         // -------- arr.indexOf(value) -> number --------
         // Issue #214: route through `_jsvalue` so string elements

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -1056,6 +1056,17 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         I64,
         &[DOUBLE, DOUBLE, DOUBLE, DOUBLE],
     );
+    // AES-GCM encrypt / decrypt (issue #561 follow-up). Same Promise
+    // shape as sign/verify; runtime resolves synchronously.
+    module.declare_function("js_webcrypto_encrypt", I64, &[DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function("js_webcrypto_decrypt", I64, &[DOUBLE, DOUBLE, DOUBLE]);
+    // crypto.randomFillSync(buf, offset?, size?) → returns the same
+    // NaN-boxed buffer with random bytes written in-place.
+    module.declare_function(
+        "js_crypto_random_fill_sync",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, DOUBLE],
+    );
     // Hash-handle form (issue #86): `const h = crypto.createHash(alg);
     // h.update(x); h.digest()`. Returns a NaN-boxed POINTER_TAG handle id;
     // subsequent method dispatch flows through HANDLE_METHOD_DISPATCH.

--- a/crates/perry-hir/src/ir.rs
+++ b/crates/perry-hir/src/ir.rs
@@ -1612,6 +1612,31 @@ pub enum Expr {
         signature: Box<Expr>,
         data: Box<Expr>,
     },
+    /// `crypto.subtle.encrypt(algorithm, key, data)` -> Promise<ArrayBuffer>
+    ///
+    /// Initial implementation covers AES-GCM (the surface jose's
+    /// `gcmEncrypt` / `rsaes` reach for); AES-CBC, AES-CTR, and
+    /// RSA-OAEP are TODO follow-ups tracked alongside #561.
+    WebCryptoEncrypt {
+        algorithm: Box<Expr>,
+        key: Box<Expr>,
+        data: Box<Expr>,
+    },
+    /// `crypto.subtle.decrypt(algorithm, key, data)` -> Promise<ArrayBuffer>
+    WebCryptoDecrypt {
+        algorithm: Box<Expr>,
+        key: Box<Expr>,
+        data: Box<Expr>,
+    },
+    /// `crypto.randomFillSync(buffer, offset?, size?)` — fills the
+    /// provided Buffer/TypedArray with random bytes in-place and
+    /// returns the same buffer. `offset` and `size` are optional
+    /// JS values (undefined sentinels OK).
+    CryptoRandomFillSync {
+        buffer: Box<Expr>,
+        offset: Box<Expr>,
+        size: Box<Expr>,
+    },
 
     // OS operations
     OsPlatform,          // os.platform() -> string ("darwin", "linux", "win32")

--- a/crates/perry-hir/src/lower/expr_call.rs
+++ b/crates/perry-hir/src/lower/expr_call.rs
@@ -603,6 +603,28 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                                                     data: Box::new(data),
                                                 });
                                             }
+                                            "encrypt" if args.len() >= 3 => {
+                                                let mut iter = args.into_iter();
+                                                let algorithm = iter.next().unwrap();
+                                                let key = iter.next().unwrap();
+                                                let data = iter.next().unwrap();
+                                                return Ok(Expr::WebCryptoEncrypt {
+                                                    algorithm: Box::new(algorithm),
+                                                    key: Box::new(key),
+                                                    data: Box::new(data),
+                                                });
+                                            }
+                                            "decrypt" if args.len() >= 3 => {
+                                                let mut iter = args.into_iter();
+                                                let algorithm = iter.next().unwrap();
+                                                let key = iter.next().unwrap();
+                                                let data = iter.next().unwrap();
+                                                return Ok(Expr::WebCryptoDecrypt {
+                                                    algorithm: Box::new(algorithm),
+                                                    key: Box::new(key),
+                                                    data: Box::new(data),
+                                                });
+                                            }
                                             _ => {
                                                 // Unsupported subtle method —
                                                 // fail loudly. The supported
@@ -619,7 +641,7 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                                                 if !allow_unimplemented {
                                                     crate::lower_bail!(
                                                         outer_member.span,
-                                                        "`crypto.subtle.{}` is not implemented in Perry — supported subtle methods are digest, importKey, sign, verify (HMAC + SHA-1/256/384/512). \
+                                                        "`crypto.subtle.{}` is not implemented in Perry — supported subtle methods are digest, importKey, sign, verify, encrypt, decrypt (HMAC + SHA-1/256/384/512; encrypt/decrypt currently AES-GCM only). \
                                                          See `perry --print-api-manifest` and #561, or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore.",
                                                         method,
                                                     );
@@ -2877,6 +2899,27 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                                             }),
                                             args: vec![],
                                             type_args: vec![],
+                                        });
+                                    }
+                                }
+                                // `crypto.randomFillSync(buf, offset?, size?)`
+                                // — fills `buf` in-place with random bytes
+                                // and returns it. Handles BufferHeader and
+                                // TypedArrayHeader (Uint8Array, Uint32Array,
+                                // etc — axios uses Uint32Array). The
+                                // offset/size args are optional; absent
+                                // values lower as Undefined and the runtime
+                                // treats them as 0 / full-length.
+                                "randomFillSync" => {
+                                    if !args.is_empty() {
+                                        let mut iter = args.into_iter();
+                                        let buffer = iter.next().unwrap();
+                                        let offset = iter.next().unwrap_or(Expr::Undefined);
+                                        let size = iter.next().unwrap_or(Expr::Undefined);
+                                        return Ok(Expr::CryptoRandomFillSync {
+                                            buffer: Box::new(buffer),
+                                            offset: Box::new(offset),
+                                            size: Box::new(size),
                                         });
                                     }
                                 }

--- a/crates/perry-hir/src/stable_hash.rs
+++ b/crates/perry-hir/src/stable_hash.rs
@@ -2240,6 +2240,36 @@ impl SH for Expr {
                 signature.as_ref().hash(h);
                 data.as_ref().hash(h);
             }
+            Expr::WebCryptoEncrypt {
+                algorithm,
+                key,
+                data,
+            } => {
+                tag(h, 466);
+                algorithm.as_ref().hash(h);
+                key.as_ref().hash(h);
+                data.as_ref().hash(h);
+            }
+            Expr::WebCryptoDecrypt {
+                algorithm,
+                key,
+                data,
+            } => {
+                tag(h, 467);
+                algorithm.as_ref().hash(h);
+                key.as_ref().hash(h);
+                data.as_ref().hash(h);
+            }
+            Expr::CryptoRandomFillSync {
+                buffer,
+                offset,
+                size,
+            } => {
+                tag(h, 468);
+                buffer.as_ref().hash(h);
+                offset.as_ref().hash(h);
+                size.as_ref().hash(h);
+            }
             Expr::OsPlatform => tag(h, 201),
             Expr::OsArch => tag(h, 202),
             Expr::OsHostname => tag(h, 203),

--- a/crates/perry-hir/src/walker.rs
+++ b/crates/perry-hir/src/walker.rs
@@ -387,6 +387,29 @@ where
             f(signature);
             f(data);
         }
+        Expr::WebCryptoEncrypt {
+            algorithm,
+            key,
+            data,
+        }
+        | Expr::WebCryptoDecrypt {
+            algorithm,
+            key,
+            data,
+        } => {
+            f(algorithm);
+            f(key);
+            f(data);
+        }
+        Expr::CryptoRandomFillSync {
+            buffer,
+            offset,
+            size,
+        } => {
+            f(buffer);
+            f(offset);
+            f(size);
+        }
 
         // ─── Two-child variants ───────────────────────────────────────────
         Expr::Binary { left, right, .. }
@@ -1670,6 +1693,29 @@ where
             f(key);
             f(signature);
             f(data);
+        }
+        Expr::WebCryptoEncrypt {
+            algorithm,
+            key,
+            data,
+        }
+        | Expr::WebCryptoDecrypt {
+            algorithm,
+            key,
+            data,
+        } => {
+            f(algorithm);
+            f(key);
+            f(data);
+        }
+        Expr::CryptoRandomFillSync {
+            buffer,
+            offset,
+            size,
+        } => {
+            f(buffer);
+            f(offset);
+            f(size);
         }
 
         // ─── Multi-child variants — same shape as the mut variant ─────────

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -207,6 +207,119 @@ pub extern "C" fn js_crypto_random_uuid() -> *mut StringHeader {
     js_string_from_bytes(uuid_str.as_ptr(), uuid_str.len() as u32)
 }
 
+/// `crypto.randomFillSync(buffer, offset?, size?)` — fills the given
+/// Buffer or TypedArray with cryptographically strong random bytes
+/// in-place and returns the **same** NaN-boxed buffer value.
+///
+/// All three arguments arrive as NaN-boxed `f64`. `offset` and `size`
+/// may be `undefined` (Node's defaults are `offset = 0`, `size =
+/// buffer.byteLength - offset`). Bounds-clamping mirrors Node: out-of-
+/// range offsets/sizes are clamped to the buffer's byte length rather
+/// than throwing, so misuse degrades to "fewer bytes filled" instead
+/// of an opaque crash.
+///
+/// Required by axios (#? jose / axios native compile) — axios's
+/// `generateString` passes a `Uint32Array`; jose can pass a `Buffer`.
+#[no_mangle]
+pub extern "C" fn js_crypto_random_fill_sync(
+    buf_bits: f64,
+    offset_bits: f64,
+    size_bits: f64,
+) -> f64 {
+    let bits = buf_bits.to_bits();
+    // Accept either form the codegen can hand us:
+    //   - NaN-boxed POINTER_TAG (top16 0x7FFD) → Buffer / Uint8Array
+    //   - Raw heap pointer in low 48 bits (top16 == 0) → TypedArray
+    //     (Uint32Array etc — see `Expr::TypedArrayNew` codegen, the
+    //     pointer is `bitcast_i64_to_double` without a tag).
+    let top16 = (bits >> 48) as u16;
+    let raw = if top16 >= 0x7FF8 {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else {
+        bits as usize
+    };
+    if raw < 0x1000 {
+        return buf_bits;
+    }
+
+    // Read optional numeric args; undefined / NaN → use default.
+    let offset_arg = nanboxed_to_usize(offset_bits);
+    let size_arg = nanboxed_to_usize(size_bits);
+
+    unsafe {
+        // BufferHeader / Uint8Array path.
+        if perry_runtime::buffer::is_registered_buffer(raw) {
+            let buf = raw as *mut perry_runtime::buffer::BufferHeader;
+            let total = (*buf).length as usize;
+            let (start, end) = resolve_range(total, offset_arg, size_arg);
+            if end > start {
+                let data = perry_runtime::buffer::buffer_data_mut(buf);
+                let slice = std::slice::from_raw_parts_mut(data.add(start), end - start);
+                rand::thread_rng().fill_bytes(slice);
+            }
+            // Hand back the same NaN-boxed value the caller passed.
+            return buf_bits;
+        }
+        // TypedArrayHeader path (Uint8Array, Uint32Array, Float32Array, …).
+        if perry_runtime::typedarray::lookup_typed_array_kind(raw).is_some() {
+            let ta = raw as *mut perry_runtime::typedarray::TypedArrayHeader;
+            let len = (*ta).length as usize;
+            let elem_size = (*ta).elem_size as usize;
+            let total = len * elem_size;
+            let (start, end) = resolve_range(total, offset_arg, size_arg);
+            if end > start {
+                let data = (raw as *mut u8).add(std::mem::size_of::<
+                    perry_runtime::typedarray::TypedArrayHeader,
+                >());
+                let slice = std::slice::from_raw_parts_mut(data.add(start), end - start);
+                rand::thread_rng().fill_bytes(slice);
+            }
+            return buf_bits;
+        }
+    }
+
+    // Unsupported value shape — return the original (no-op) rather
+    // than crashing. The HIR-level type check is "any", so the
+    // compiler can't statically rule this out.
+    buf_bits
+}
+
+/// Best-effort extract a non-negative integer from a NaN-boxed `f64`.
+/// `undefined`, `null`, NaN, negatives → `None` (caller picks default).
+fn nanboxed_to_usize(bits: f64) -> Option<usize> {
+    let raw = bits.to_bits();
+    let top16 = (raw >> 48) as u16;
+    // Undefined / null / false / true sentinels.
+    if matches!(raw, 0x7FFC_0000_0000_0001 | 0x7FFC_0000_0000_0002) {
+        return None;
+    }
+    // Int32 tag (0x7FFE).
+    if top16 == 0x7FFE {
+        let i = (raw & 0xFFFF_FFFF) as u32 as i32;
+        if i < 0 {
+            return None;
+        }
+        return Some(i as usize);
+    }
+    // Otherwise treat as plain f64.
+    if bits.is_nan() || bits.is_sign_negative() || bits.is_infinite() {
+        return None;
+    }
+    Some(bits as usize)
+}
+
+/// Resolve `(start, end)` byte indices from Node-style `offset` / `size`
+/// arguments against a buffer of `total` bytes. Out-of-range values are
+/// clamped to `[0, total]`.
+fn resolve_range(total: usize, offset: Option<usize>, size: Option<usize>) -> (usize, usize) {
+    let start = offset.unwrap_or(0).min(total);
+    let end = match size {
+        Some(s) => start.saturating_add(s).min(total),
+        None => total,
+    };
+    (start, end)
+}
+
 /// Create HMAC-SHA256
 /// crypto.createHmac('sha256', key).update(data).digest('hex') -> string
 #[no_mangle]

--- a/crates/perry-stdlib/src/webcrypto.rs
+++ b/crates/perry-stdlib/src/webcrypto.rs
@@ -1,4 +1,5 @@
-//! Web Crypto API: `crypto.subtle.digest` / `importKey` / `sign` / `verify`.
+//! Web Crypto API: `crypto.subtle.digest` / `importKey` / `sign` / `verify`
+//! / `encrypt` / `decrypt`.
 //!
 //! Issue #561 — sigv4 / JWT / web-push consumers (s3-lite-client,
 //! aws4fetch, jose, oidc-client-ts, web-push) all route through
@@ -8,13 +9,18 @@
 //! - `digest("SHA-1" | "SHA-256" | "SHA-384" | "SHA-512", data)` →
 //!   Promise<Uint8Array>
 //! - `importKey("raw", key, { name: "HMAC", hash: { name: "SHA-256" } },
-//!   ...)` → Promise<CryptoKey>
+//!   ...)` → Promise<CryptoKey>  (HMAC and AES-GCM both supported)
 //! - `sign("HMAC", key, data)` → Promise<Uint8Array>
 //! - `verify("HMAC", key, signature, data)` → Promise<boolean>
+//! - `encrypt({ name: "AES-GCM", iv, additionalData?, tagLength? }, key, data)`
+//!   → Promise<Uint8Array> (jose `gcmEncrypt`)
+//! - `decrypt({ name: "AES-GCM", iv, additionalData?, tagLength? }, key, data)`
+//!   → Promise<Uint8Array>
 //!
-//! Asymmetric algorithms (RSA / ECDSA / RSA-OAEP), `generateKey`,
-//! `wrapKey`, `unwrapKey`, `deriveKey`, `encrypt`, and `decrypt` are
-//! out of scope per the issue.
+//! AES-CBC, AES-CTR, and RSA-OAEP encrypt/decrypt remain TODO follow-
+//! ups. `generateKey`, `wrapKey`, `unwrapKey`, `deriveKey`, and
+//! asymmetric signing (RSA / ECDSA) are still out of scope per the
+//! issue.
 //!
 //! `CryptoKey` is represented as a Buffer holding the raw key bytes,
 //! with an entry in `CRYPTO_KEY_REGISTRY` recording `(algo, hash)` so
@@ -63,11 +69,15 @@ enum HashAlgo {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum KeyAlgo {
     Hmac,
+    AesGcm,
 }
 
 #[derive(Copy, Clone, Debug)]
 struct CryptoKeyMaterial {
     algo: KeyAlgo,
+    /// For HMAC: the underlying hash. For AES-GCM the hash slot is
+    /// unused (we keep `HashAlgo::Sha256` as a harmless placeholder so
+    /// the struct stays `Copy`).
     hash: HashAlgo,
 }
 
@@ -309,11 +319,15 @@ pub unsafe extern "C" fn js_webcrypto_digest(algo_bits: f64, data_bits: f64) -> 
 /// `crypto.subtle.importKey("raw", keyBytes, algorithm, extractable, keyUsages)`
 /// → Promise<CryptoKey>
 ///
-/// Only the `format == "raw"` + HMAC algorithm path is supported (the
-/// surface every sigv4 / JWT signer uses). `extractable` and `keyUsages`
-/// are accepted but not enforced — perry's threat model treats them as
-/// documentation. Unsupported shapes resolve to undefined (callers that
-/// then pass that into `sign` will reject there with a clear error).
+/// `format == "raw"` only. Supported algorithms:
+/// - `{ name: "HMAC", hash: "SHA-256" }` (and SHA-1/384/512)
+/// - `"AES-GCM"` or `{ name: "AES-GCM" }` — keyed by 128/192/256-bit
+///   bytes; the IV / additionalData come in at encrypt/decrypt time.
+///
+/// `extractable` and `keyUsages` are accepted but not enforced —
+/// perry's threat model treats them as documentation. Unsupported
+/// shapes resolve to undefined (callers that then pass that into
+/// `sign`/`encrypt` will reject there with a clear error).
 #[no_mangle]
 pub unsafe extern "C" fn js_webcrypto_import_key(
     format_bits: f64,
@@ -330,24 +344,27 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
     if format != "raw" {
         return resolve_undefined();
     }
-    // Algorithm — must be HMAC for now.
-    let algo_obj = strip_ptr(algo_bits.to_bits()) as *const perry_runtime::ObjectHeader;
-    if (algo_obj as usize) < 0x1000 {
-        return resolve_undefined();
-    }
-    let name_key_ptr = perry_runtime::js_string_from_bytes(b"name".as_ptr(), 4);
-    let algo_name_val = perry_runtime::js_object_get_field_by_name(algo_obj, name_key_ptr);
-    let algo_name = match string_from_jsvalue(algo_name_val.bits()) {
+    // Algorithm name — accepts string shorthand ("AES-GCM") or
+    // `{ name: "..." }` object form.
+    let algo_name = match extract_algo_name(algo_bits.to_bits()) {
         Some(s) => s,
         None => return resolve_undefined(),
     };
-    if algo_name.to_ascii_uppercase() != "HMAC" {
+    let algo_upper = algo_name.to_ascii_uppercase();
+    let (key_algo, hash) = if algo_upper == "HMAC" {
+        let hash = match extract_hmac_hash(algo_bits.to_bits()) {
+            Some(h) => h,
+            None => return resolve_undefined(),
+        };
+        (KeyAlgo::Hmac, hash)
+    } else if algo_upper == "AES-GCM" {
+        // AES-GCM: 128, 192, or 256-bit keys. We accept any length
+        // here and let encrypt/decrypt fail loudly on mismatch.
+        (KeyAlgo::AesGcm, HashAlgo::Sha256)
+    } else {
         return resolve_undefined();
-    }
-    let hash = match extract_hmac_hash(algo_bits.to_bits()) {
-        Some(h) => h,
-        None => return resolve_undefined(),
     };
+
     let key_bytes = bytes_from_jsvalue(key_bits.to_bits());
     let buf = alloc_uint8array_from_slice(&key_bytes);
     if buf.is_null() {
@@ -356,12 +373,29 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
     register_crypto_key(
         buf as usize,
         CryptoKeyMaterial {
-            algo: KeyAlgo::Hmac,
+            algo: key_algo,
             hash,
         },
     );
     let val = JSValue::pointer(buf as *const u8).bits();
     resolve_with_bits(val)
+}
+
+/// Extract the algorithm name from a `string | { name }` argument.
+/// Used by importKey / encrypt / decrypt where jose passes the shorthand
+/// `"AES-GCM"` to importKey but a full `{ name: "AES-GCM", iv: ... }`
+/// at encrypt time.
+unsafe fn extract_algo_name(bits: u64) -> Option<String> {
+    if let Some(s) = string_from_jsvalue(bits) {
+        return Some(s);
+    }
+    let obj_ptr = strip_ptr(bits) as *const perry_runtime::ObjectHeader;
+    if (obj_ptr as usize) < 0x1000 {
+        return None;
+    }
+    let key_ptr = perry_runtime::js_string_from_bytes(b"name".as_ptr(), 4);
+    let name_val = perry_runtime::js_object_get_field_by_name(obj_ptr, key_ptr);
+    string_from_jsvalue(name_val.bits())
 }
 
 /// `crypto.subtle.sign(algorithm, key, data)` → Promise<Uint8Array>
@@ -454,6 +488,157 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
+// =====================================================================
+// AES-GCM encrypt / decrypt
+//
+// jose's `gcmEncrypt` / `gcmDecrypt` pass:
+//   { name: 'AES-GCM', iv: <Uint8Array>, additionalData?: <Uint8Array>,
+//     tagLength?: 128 }, key, data
+// The IV is a 12-byte nonce (the only length the underlying `aes-gcm`
+// crate's `Nonce` type accepts); we surface a clean "undefined" reject
+// for other lengths rather than panicking.
+//
+// The output of encrypt is `ciphertext || tag` (the WebCrypto spec
+// appends the 16-byte GCM tag); decrypt expects the same layout.
+// =====================================================================
+
+/// Read an optional object field by name and return its raw bytes, or
+/// `None` if the field is absent / not a buffer-like value.
+unsafe fn object_field_bytes(obj_bits: u64, name: &[u8]) -> Option<Vec<u8>> {
+    let obj_ptr = strip_ptr(obj_bits) as *const perry_runtime::ObjectHeader;
+    if (obj_ptr as usize) < 0x1000 {
+        return None;
+    }
+    let key_ptr = perry_runtime::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let val = perry_runtime::js_object_get_field_by_name(obj_ptr, key_ptr);
+    let bytes = bytes_from_jsvalue(val.bits());
+    if bytes.is_empty() {
+        // Distinguish "field missing" from "field present but empty":
+        // for our callers an empty AAD / IV is semantically equivalent
+        // to "missing", and the caller's defaulting path is fine.
+        None
+    } else {
+        Some(bytes)
+    }
+}
+
+/// AES-GCM encrypt. Returns ciphertext || tag (matches WebCrypto spec).
+fn aes_gcm_encrypt(key: &[u8], iv: &[u8], aad: &[u8], plaintext: &[u8]) -> Option<Vec<u8>> {
+    use aes_gcm::aead::{Aead, KeyInit, Payload};
+    use aes_gcm::{Aes128Gcm, Aes256Gcm, Nonce};
+
+    if iv.len() != 12 {
+        return None;
+    }
+    let nonce = Nonce::from_slice(iv);
+    let payload = Payload {
+        msg: plaintext,
+        aad,
+    };
+    match key.len() {
+        16 => {
+            let cipher = Aes128Gcm::new_from_slice(key).ok()?;
+            cipher.encrypt(nonce, payload).ok()
+        }
+        32 => {
+            let cipher = Aes256Gcm::new_from_slice(key).ok()?;
+            cipher.encrypt(nonce, payload).ok()
+        }
+        _ => None, // 192-bit AES-GCM not in the aes-gcm 0.10 type set.
+    }
+}
+
+/// AES-GCM decrypt. Expects `ciphertext || tag` per the WebCrypto spec.
+fn aes_gcm_decrypt(key: &[u8], iv: &[u8], aad: &[u8], ciphertext: &[u8]) -> Option<Vec<u8>> {
+    use aes_gcm::aead::{Aead, KeyInit, Payload};
+    use aes_gcm::{Aes128Gcm, Aes256Gcm, Nonce};
+
+    if iv.len() != 12 {
+        return None;
+    }
+    let nonce = Nonce::from_slice(iv);
+    let payload = Payload {
+        msg: ciphertext,
+        aad,
+    };
+    match key.len() {
+        16 => {
+            let cipher = Aes128Gcm::new_from_slice(key).ok()?;
+            cipher.decrypt(nonce, payload).ok()
+        }
+        32 => {
+            let cipher = Aes256Gcm::new_from_slice(key).ok()?;
+            cipher.decrypt(nonce, payload).ok()
+        }
+        _ => None,
+    }
+}
+
+/// Shared AES-GCM arg-extraction for encrypt / decrypt: pulls the
+/// algorithm-name + iv (+ optional aad) from the algorithm object, plus
+/// the raw key bytes (validating they came from an AES-GCM importKey)
+/// and the data bytes. Returns `None` if any required piece is missing.
+unsafe fn extract_aes_gcm_args(
+    algo_bits: u64,
+    key_bits: u64,
+    data_bits: u64,
+) -> Option<(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>)> {
+    let algo_name = extract_algo_name(algo_bits)?;
+    if !algo_name.eq_ignore_ascii_case("AES-GCM") {
+        return None;
+    }
+    let iv = object_field_bytes(algo_bits, b"iv")?;
+    let aad = object_field_bytes(algo_bits, b"additionalData").unwrap_or_default();
+    let key_addr = strip_ptr(key_bits);
+    let mat = lookup_crypto_key(key_addr)?;
+    if mat.algo != KeyAlgo::AesGcm {
+        return None;
+    }
+    let key_bytes = bytes_from_jsvalue(key_bits);
+    let data_bytes = bytes_from_jsvalue(data_bits);
+    Some((key_bytes, iv, aad, data_bytes))
+}
+
+/// `crypto.subtle.encrypt({ name: "AES-GCM", iv, additionalData? }, key, data)`
+/// → Promise<Uint8Array>
+#[no_mangle]
+pub unsafe extern "C" fn js_webcrypto_encrypt(
+    algo_bits: f64,
+    key_bits: f64,
+    data_bits: f64,
+) -> *mut Promise {
+    let (key, iv, aad, data) =
+        match extract_aes_gcm_args(algo_bits.to_bits(), key_bits.to_bits(), data_bits.to_bits()) {
+            Some(t) => t,
+            None => return resolve_undefined(),
+        };
+    let ciphertext = match aes_gcm_encrypt(&key, &iv, &aad, &data) {
+        Some(c) => c,
+        None => return resolve_undefined(),
+    };
+    resolve_with_bytes(&ciphertext)
+}
+
+/// `crypto.subtle.decrypt({ name: "AES-GCM", iv, additionalData? }, key, data)`
+/// → Promise<Uint8Array>
+#[no_mangle]
+pub unsafe extern "C" fn js_webcrypto_decrypt(
+    algo_bits: f64,
+    key_bits: f64,
+    data_bits: f64,
+) -> *mut Promise {
+    let (key, iv, aad, data) =
+        match extract_aes_gcm_args(algo_bits.to_bits(), key_bits.to_bits(), data_bits.to_bits()) {
+            Some(t) => t,
+            None => return resolve_undefined(),
+        };
+    let plaintext = match aes_gcm_decrypt(&key, &iv, &aad, &data) {
+        Some(p) => p,
+        None => return resolve_undefined(),
+    };
+    resolve_with_bytes(&plaintext)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -510,5 +695,45 @@ mod tests {
         assert!(!constant_time_eq(b"abc", b"abd"));
         assert!(!constant_time_eq(b"abc", b"abcd"));
         assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn aes_gcm_round_trip_128() {
+        let key = [0x42u8; 16];
+        let iv = [0x11u8; 12];
+        let aad = b"context";
+        let plaintext = b"hello aes-gcm";
+        let ct = aes_gcm_encrypt(&key, &iv, aad, plaintext).expect("encrypt");
+        assert_eq!(ct.len(), plaintext.len() + 16); // ciphertext || tag
+        let pt = aes_gcm_decrypt(&key, &iv, aad, &ct).expect("decrypt");
+        assert_eq!(pt, plaintext);
+    }
+
+    #[test]
+    fn aes_gcm_round_trip_256_no_aad() {
+        let key = [0x37u8; 32];
+        let iv = [0x22u8; 12];
+        let plaintext = b"";
+        let ct = aes_gcm_encrypt(&key, &iv, b"", plaintext).expect("encrypt");
+        assert_eq!(ct.len(), 16); // empty payload + tag
+        let pt = aes_gcm_decrypt(&key, &iv, b"", &ct).expect("decrypt");
+        assert_eq!(pt, plaintext);
+    }
+
+    #[test]
+    fn aes_gcm_rejects_short_iv() {
+        let key = [0u8; 16];
+        let iv = [0u8; 8]; // wrong length
+        assert!(aes_gcm_encrypt(&key, &iv, b"", b"x").is_none());
+        assert!(aes_gcm_decrypt(&key, &iv, b"", b"xxxxxxxxxxxxxxxx").is_none());
+    }
+
+    #[test]
+    fn aes_gcm_rejects_192_bit_key() {
+        // 192-bit AES-GCM is intentionally not in the aes-gcm 0.10
+        // type set; document the rejection so we notice if it changes.
+        let key = [0u8; 24];
+        let iv = [0u8; 12];
+        assert!(aes_gcm_encrypt(&key, &iv, b"", b"x").is_none());
     }
 }

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -136,6 +136,8 @@ declare module "crypto" {
   /** stdlib */
   export function randomBytes(...args: any[]): any;
   /** stdlib */
+  export function randomFillSync(...args: any[]): any;
+  /** stdlib */
   export function randomUUID(...args: any[]): any;
   /** stdlib */
   export function sha256(...args: any[]): any;

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -235,6 +235,7 @@ Total: 867 entries across 71 modules.
 - `pbkdf2` — module
 - `pbkdf2Sync` — module
 - `randomBytes` — module
+- `randomFillSync` — module
 - `randomUUID` — module
 - `sha256` — module
 

--- a/test-files/test_crypto_randomFillSync.ts
+++ b/test-files/test_crypto_randomFillSync.ts
@@ -1,0 +1,23 @@
+// Regression test for crypto.randomFillSync — required by axios.
+// Fills a typed array in-place with cryptographically strong random
+// bytes and returns the same buffer.
+
+import * as crypto from "crypto";
+
+const u8 = new Uint8Array(16);
+const ret8 = crypto.randomFillSync(u8);
+console.log("u8.length =", u8.length);
+console.log("ret is same array =", ret8 === u8);
+// Probability of all-zeros for 16 cryptographically random bytes is
+// 2^-128 — effectively never. Sum > 0 is the cheap "non-zero" check.
+let sum8 = 0;
+for (let i = 0; i < u8.length; i++) sum8 += u8[i];
+console.log("u8 nonzero =", sum8 > 0);
+
+// Uint32Array path (the shape axios actually uses).
+const u32 = new Uint32Array(8);
+crypto.randomFillSync(u32);
+console.log("u32.length =", u32.length);
+let sum32 = 0;
+for (let i = 0; i < u32.length; i++) sum32 += u32[i];
+console.log("u32 nonzero =", sum32 > 0);

--- a/test-files/test_crypto_subtle_encrypt_decrypt.ts
+++ b/test-files/test_crypto_subtle_encrypt_decrypt.ts
@@ -1,0 +1,27 @@
+// Regression test for crypto.subtle.encrypt / decrypt (AES-GCM).
+// jose's `gcmEncrypt` / `gcmDecrypt` exercise this exact shape.
+
+async function main() {
+  const keyBytes = new Uint8Array(16); // 128-bit key — zero-filled is fine for the round-trip
+  for (let i = 0; i < keyBytes.length; i++) keyBytes[i] = i;
+  const iv = new Uint8Array(12);
+  for (let i = 0; i < iv.length; i++) iv[i] = i + 100;
+
+  const key = await crypto.subtle.importKey("raw", keyBytes, "AES-GCM", false, ["encrypt", "decrypt"]);
+
+  const plaintext = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  const ct = await crypto.subtle.encrypt({ name: "AES-GCM", iv: iv }, key, plaintext);
+  const ctView = new Uint8Array(ct);
+  console.log("ct.length =", ctView.length); // 10 plaintext + 16 tag
+
+  const pt = await crypto.subtle.decrypt({ name: "AES-GCM", iv: iv }, key, ctView);
+  const ptView = new Uint8Array(pt);
+  console.log("pt.length =", ptView.length);
+  let ok = ptView.length === plaintext.length;
+  for (let i = 0; i < plaintext.length; i++) {
+    if (ptView[i] !== plaintext[i]) ok = false;
+  }
+  console.log("round-trip ok =", ok);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds `crypto.randomFillSync(buffer, offset?, size?)` to the manifest + runtime — required by **axios** (`Uint32Array` ID generation). Handles both `BufferHeader` (`Buffer`/`Uint8Array`) and `TypedArrayHeader` (Uint32Array etc) call shapes; optional `offset`/`size` are clamped to byte length per Node's lenient bounds.
- Adds `crypto.subtle.encrypt(...)` / `crypto.subtle.decrypt(...)` — AES-GCM only this pass, the surface **jose**'s `gcmEncrypt`/`gcmDecrypt` reach for. `importKey` extended to accept either the object form `{ name: "AES-GCM" }` or the string shorthand `"AES-GCM"` (jose passes the shorthand at importKey time).
- AES-CBC, AES-CTR, AES-KW, RSA-OAEP encrypt/decrypt and `subtle.generateKey`/`wrapKey`/`unwrapKey`/`deriveKey` remain TODO follow-ups tracked alongside #561. The diagnostic message names the supported surface so callers see exactly what's missing.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --release` clean
- [x] `cargo test --release -p perry-stdlib --lib webcrypto` — 9/9 pass (4 new AES-GCM unit tests + 5 existing)
- [x] `cargo test --release -p perry-codegen --test manifest_consistency` — 4/4 pass
- [x] `test-files/test_crypto_randomFillSync.ts` — `Uint8Array(16)` + `Uint32Array(8)` both fill correctly; returned buffer is identity-equal
- [x] `test-files/test_crypto_subtle_encrypt_decrypt.ts` — AES-GCM-128 round-trip recovers plaintext byte-for-byte; ciphertext is 16 bytes longer than plaintext (the appended tag)
- [x] axios smoke (`import axios from "axios"` with `perry.compilePackages: ["axios"]`) — was: `Error: crypto.randomFillSync is not implemented` — now advances past, stops at `zlib.constants` (separate gap)
- [x] jose smoke (`import * as jose from "jose"` with `perry.compilePackages: ["jose"]`) — was: `Error: crypto.subtle.encrypt is not implemented` — now advances past, stops at `crypto.subtle.generateKey` (out of scope per #561)