### PR TITLE
fix(#957): CJS IIFE .call(this) + IndexUpdate codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.975 — fix(#957): CJS IIFE `.call(this)` + `Expr::IndexUpdate` codegen — `import _ from "lodash"` advances past `_.add` undefined
+
+**Symptom.** `import _ from "lodash"; _.add(1, 2)` under `perry.compilePackages: ["lodash"]` threw `TypeError: Cannot read properties of undefined (reading 'add')`. `typeof _` was literally `undefined`: the default import binding was empty.
+
+**Root cause — two distinct bugs surfaced on the same package.**
+
+1. **IIFE `.call(this)` body silently skipped.** Lodash (and every UMD-prelude CJS package) wraps its body in `;(function() { ... }.call(this));`. HIR lowered this as `Call { callee: PropertyGet { object: Closure {...}, property: "call" }, args: [This] }`. Codegen's generic call dispatch read `Closure.call` via `js_native_call_method`, found no `call` method on the closure handle, and silently fell through — the function body never executed. Inside the CJS-wrap's `const _cjs = (function() { ... return module.exports; })()` this meant `module.exports = _` (set by the lodash body inside the inner IIFE) was lost, so `_cjs` came back as the initial `{ exports: {} }` and `export default _cjs` resolved to that empty object. The default import bound to the wrap's *outer* `_cjs` — but accessing `.add` on it of course returned undefined. `fn.call(thisArg, ...args)` was the same shape and equally broken.
+
+2. **`Expr::IndexUpdate` bailed at codegen.** Lodash's `countBy` does `++result[key]`. HIR lowered this as `IndexUpdate { object: result, index: key, op: Add, prefix: true }`. The codegen's catch-all bailed with `perry-codegen Phase 2: expression IndexUpdate not yet supported`, and the entire lodash module got linker-stubbed under `PERRY_ALLOW_UNIMPLEMENTED=1` — so the default-import binding pointed at an empty init stub. Even after fix (1), this gate kept `_` undefined.
+
+**Fix.**
+
+1. **HIR rewrite for inline-function `.call(thisArg, ...args)` IIFE pattern.** In `expr_call.rs::lower_call`, when the callee is `Member { obj: <FnExpr | ArrowExpr>, prop: "call" }` (Paren-unwrapped) and the lowered receiver is a `Closure { captures_this: false, ... }`, rewrite to a direct `Call { callee: closure, args: args[1..] }` — drop the `thisArg`. Safe because `captures_this == false` means the body has no `this` references that depend on the bound value, and Perry has no `this`-binding mechanism through `.call()` for ordinary functions anyway. Class-method `obj.method.call(otherObj, args)` shapes keep their existing semantics (callee is a `PropertyGet`, not an inline function literal).
+
+2. **`Expr::IndexUpdate` LLVM codegen.** Added an arm in `expr.rs` modeled on `Expr::PropertyUpdate`: lower `object` + `index` into SSA registers once, call `js_dyn_index_get(obj, idx)` for the old value, `fadd`/`fsub 1.0` for the new, `js_dyn_index_set(obj, idx, new)` to write back. Return new for prefix (`++x`), old for postfix (`x++`). Added a new `js_dyn_index_set` runtime helper next to `js_dyn_index_get` that routes by `gc_type`: arrays → `js_array_set_index_or_string`, non-array objects → stringify numeric/string-key index + `js_object_set_field_by_name`, strings → no-op (matches strict-mode no-write). Extended `js_dyn_index_get` to handle string-tagged index NaN-box values (route through `js_object_get_field_by_name_f64`) — pre-fix it coerced the string box's bits via `index as i32`, producing garbage offsets, so `++obj["foo"]` returned undefined.
+
+**Validation.**
+
+- `test-files/test_lodash_default_import_methods.ts` — covers both fixes (IIFE writes-outer, IIFE arrow call with args, prefix/postfix inc/dec on object-string-key + array-numeric-index). Byte-matches `node --experimental-strip-types`.
+- The repro from the bug report (`import _ from "lodash"; _.add(1, 2)`) now advances past the `_.add` undefined symptom. Real lodash still hits separate runtime gaps (`Function('return this')()` not callable; bare `global` / `self` lower to `0.0` so `freeGlobal`/`freeSelf` come back false-y; `runInContext()` then throws `value is not a function` on `root.Object()`) — those are tracked downstream and are *not* CJS-default-import bugs.
+
+**Files touched.** `crates/perry-hir/src/lower/expr_call.rs` (IIFE `.call(this)` rewrite), `crates/perry-codegen/src/expr.rs` (`Expr::IndexUpdate` arm), `crates/perry-codegen/src/runtime_decls.rs` (extern decl for `js_dyn_index_set`), `crates/perry-runtime/src/value.rs` (`js_dyn_index_set` helper + string-key handling in `js_dyn_index_get`), `test-files/test_lodash_default_import_methods.ts` (regression).
+
 ## v0.5.974 — feat(zlib/crypto): zlib.constants + subtle.generateKey (AES-GCM) — moves axios + jose past the next compile gates
 
 **Symptom.** After #952 wired `randomFillSync` + `subtle.encrypt`/`decrypt`, the two `compilePackages` smoke targets advanced one step and tripped on the next gap:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.974
+**Current Version:** 0.5.975
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "base64",
@@ -4845,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "log",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "base64",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "serde",
  "serde_json",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.974"
+version = "0.5.975"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "clap",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -4997,14 +4997,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "chrono",
  "cron",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5045,21 +5045,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "bson",
  "futures-util",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "base64",
  "image",
@@ -5230,14 +5230,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "base64",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5447,11 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.974"
+version = "0.5.975"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "itoa",
  "jni",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "block2",
  "libc",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "block2",
  "libc",
@@ -5528,11 +5528,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.974"
+version = "0.5.975"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "block2",
  "libc",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "block2",
  "libc",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "block2",
  "libc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.974"
+version = "0.5.975"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.974"
+version = "0.5.975"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -7217,6 +7217,43 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(if *prefix { new } else { old })
         }
 
+        // -------- arr[idx]++ / arr[idx]-- / ++arr[idx] / --arr[idx] --------
+        //
+        // Issue #957: lodash's `countBy` uses `++result[key]` which previously
+        // bailed `expression IndexUpdate not yet supported` and stubbed the
+        // entire module, leaving `import _ from "lodash"` resolving to
+        // undefined. Lower as a tag-aware read+modify+write through the
+        // `js_dyn_index_get` / `js_dyn_index_set` runtime helpers — they
+        // dispatch by gc_type at runtime, so the same emission works for
+        // arrays, plain objects, and TypedArrays without static type
+        // knowledge. `object` and `index` lower once into SSA registers so
+        // side effects are not re-evaluated.
+        Expr::IndexUpdate {
+            object,
+            index,
+            op,
+            prefix,
+        } => {
+            let obj_box = lower_expr(ctx, object)?;
+            let idx_box = lower_expr(ctx, index)?;
+            let blk = ctx.block();
+            let old = blk.call(
+                DOUBLE,
+                "js_dyn_index_get",
+                &[(DOUBLE, &obj_box), (DOUBLE, &idx_box)],
+            );
+            let new = match op {
+                BinaryOp::Sub => blk.fsub(&old, "1.0"),
+                _ => blk.fadd(&old, "1.0"),
+            };
+            blk.call(
+                DOUBLE,
+                "js_dyn_index_set",
+                &[(DOUBLE, &obj_box), (DOUBLE, &idx_box), (DOUBLE, &new)],
+            );
+            Ok(if *prefix { new } else { old })
+        }
+
         // -------- path.basename --------
         Expr::PathBasename(p) => {
             let p_box = lower_expr(ctx, p)?;

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -433,6 +433,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // based on the receiver's NaN-box tag at runtime. Used by IndexGet's
     // fallback path when codegen can't statically prove the receiver type.
     module.declare_function("js_dyn_index_get", DOUBLE, &[DOUBLE, DOUBLE]);
+    // Issue #957: tag-aware dynamic index write. Used by `Expr::IndexUpdate`
+    // codegen to write back the incremented value without rebuilding the
+    // IndexSet dispatch tree. Routes to `js_array_set_index_or_string` for
+    // arrays and `js_object_set_field_by_name` for plain objects.
+    module.declare_function("js_dyn_index_set", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_string_to_char_array", I64, &[I64]);
     module.declare_function("js_string_repeat", I64, &[I64, I32]);
     module.declare_function("js_string_replace_string", I64, &[I64, I64, I64]);

--- a/crates/perry-hir/src/lower/expr_call.rs
+++ b/crates/perry-hir/src/lower/expr_call.rs
@@ -329,6 +329,62 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
         }
     }
 
+    // Issue #957 — `(function(...) { ... }.call(<thisArg>, ...args))` IIFE
+    // pattern used at the top of older CJS packages (lodash, underscore, and
+    // every package that copies their UMD prelude). Pre-fix the inner
+    // function expression lowers to a Closure, then `.call(thisArg, ...args)`
+    // falls through to `js_native_call_method` on the closure handle which
+    // doesn't recognize Function.prototype.call — the body never runs and
+    // mutations to outer captures (e.g. `module.exports = _` inside the
+    // wrap) are silently dropped, so `import _ from "lodash"` resolves to
+    // `undefined` and `_.add` throws. Rewrite the AST shape directly to a
+    // plain Call on the inner function expression, dropping the thisArg.
+    //
+    // Conservative scope: only fires when the callee's receiver is a
+    // FunctionExpression or ArrowExpression literal AND the inner function
+    // does NOT reference `this` (`captures_this == false` after lowering).
+    // Method dispatch like `obj.fn.call(otherObj, args)` keeps its existing
+    // semantics — those go through the generic property-call path. We can
+    // safely drop the thisArg because `captures_this == false` means the
+    // body has no `this` references that depend on the bound value.
+    if !has_spread {
+        if let ast::Callee::Expr(callee_expr) = &call.callee {
+            if let ast::Expr::Member(member) = callee_expr.as_ref() {
+                if let ast::MemberProp::Ident(prop) = &member.prop {
+                    if prop.sym.as_ref() == "call" && !call.args.is_empty() {
+                        // Unwrap `(`...`)` parens so `((a,b) => a+b).call(...)`
+                        // matches the same shape as `(function(){...}).call(...)`.
+                        let mut inner = member.obj.as_ref();
+                        while let ast::Expr::Paren(p) = inner {
+                            inner = p.expr.as_ref();
+                        }
+                        let is_fn_lit = matches!(inner, ast::Expr::Fn(_) | ast::Expr::Arrow(_));
+                        if is_fn_lit {
+                            let lowered_callee = lower_expr(ctx, inner)?;
+                            if let Expr::Closure {
+                                captures_this: false,
+                                ..
+                            } = &lowered_callee
+                            {
+                                let rest_args = call
+                                    .args
+                                    .iter()
+                                    .skip(1)
+                                    .map(|arg| lower_expr(ctx, &arg.expr))
+                                    .collect::<Result<Vec<_>>>()?;
+                                return Ok(Expr::Call {
+                                    callee: Box::new(lowered_callee),
+                                    args: rest_args,
+                                    type_args: Vec::new(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     let mut args = call
         .args
         .iter()

--- a/crates/perry-runtime/src/value.rs
+++ b/crates/perry-runtime/src/value.rs
@@ -1107,12 +1107,32 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
     } else {
         return f64::from_bits(TAG_UNDEFINED);
     };
+    if raw_ptr < 0x10000 {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    // Issue #957: if the index itself is a string, route through the
+    // by-name object getter. Pre-fix, `obj["foo"]` lowered through
+    // `IndexUpdate` re-entered this helper with a NaN-boxed string index
+    // and the `index as i32` coercion produced garbage offsets, so
+    // `++obj["foo"]` silently returned undefined.
+    let idx_bits = index.to_bits();
+    let idx_top16 = idx_bits >> 48;
+    if idx_top16 == 0x7FFF || idx_top16 == 0x7FF9 {
+        let key_ptr = js_get_string_pointer_unified(index) as *const crate::StringHeader;
+        if !key_ptr.is_null() {
+            return crate::object::js_object_get_field_by_name_f64(
+                raw_ptr as *const crate::object::ObjectHeader,
+                key_ptr,
+            );
+        }
+        return f64::from_bits(TAG_UNDEFINED);
+    }
     let idx_i32 = if index.is_nan() || index.is_infinite() {
         return f64::from_bits(TAG_UNDEFINED);
     } else {
         index as i32
     };
-    if idx_i32 < 0 || raw_ptr < 0x10000 {
+    if idx_i32 < 0 {
         return f64::from_bits(TAG_UNDEFINED);
     }
     if raw_ptr >= crate::gc::GC_HEADER_SIZE {
@@ -1134,6 +1154,79 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
         return f64::from_bits(TAG_UNDEFINED);
     }
     v
+}
+
+/// Issue #957 — tag-aware dynamic index write counterpart to
+/// `js_dyn_index_get`. Used by `Expr::IndexUpdate` codegen to write back
+/// the incremented value without duplicating the IndexSet dispatch tree.
+///
+/// Routes by the receiver's `gc_type` byte: arrays go through
+/// `js_array_set_index_or_string` (numeric/string-key spec dispatch);
+/// everything else stringifies the index and routes through
+/// `js_object_set_field_by_name`. Strings are immutable — no-op (matches
+/// strict-mode `s[i] = x` semantics, close enough for the `++result[key]`
+/// pattern this is added for).
+#[no_mangle]
+pub extern "C" fn js_dyn_index_set(obj: f64, index: f64, value: f64) -> f64 {
+    let bits = obj.to_bits();
+    let jsval = JSValue::from_bits(bits);
+    if jsval.is_string() || jsval.is_short_string() {
+        return value;
+    }
+    let raw_ptr = if jsval.is_pointer() {
+        (bits & POINTER_MASK) as usize
+    } else if !obj.is_nan()
+        && bits != 0
+        && bits < 0x0001_0000_0000_0000
+        && (bits & 0x3) == 0
+        && bits >= 0x10000
+    {
+        bits as usize
+    } else {
+        return value;
+    };
+    if raw_ptr < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return value;
+    }
+    let is_array = unsafe {
+        let gc_header =
+            (raw_ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY
+    };
+    if is_array {
+        crate::array::js_array_set_index_or_string(
+            raw_ptr as *mut crate::array::ArrayHeader,
+            index,
+            value,
+        );
+        return value;
+    }
+    // Non-array object: stringify the index and write via the object setter.
+    let bits = index.to_bits();
+    let top16 = bits >> 48;
+    let key_ptr: *const crate::StringHeader = if top16 == 0x7FFF {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::StringHeader
+    } else if top16 == 0x7FF9 {
+        crate::value::js_get_string_pointer_unified(index) as *const crate::StringHeader
+    } else {
+        // Numeric (or other) index — stringify and intern as a UTF-8 key.
+        let idx_i32 = if index.is_nan() || index.is_infinite() {
+            0
+        } else {
+            index as i32
+        };
+        let s = idx_i32.to_string();
+        crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32)
+    };
+    if key_ptr.is_null() {
+        return value;
+    }
+    crate::object::js_object_set_field_by_name(
+        raw_ptr as *mut crate::object::ObjectHeader,
+        key_ptr,
+        value,
+    );
+    value
 }
 
 /// Check if a value should trigger a destructuring default.

--- a/test-files/test_lodash_default_import_methods.ts
+++ b/test-files/test_lodash_default_import_methods.ts
@@ -1,0 +1,61 @@
+// Issue #957 — `import _ from "lodash"; _.add(1, 2)` regression test.
+//
+// Real lodash exercises two distinct codegen bugs that, before this commit,
+// caused `import _ from "lodash"` to resolve to `undefined`:
+//
+//   1. `(function() { ... }.call(this))` IIFE wrapper — the function body
+//      never executed, so the wrap module's `module.exports = _` write was
+//      silently dropped and the cjs_wrap-generated `const _cjs = (function()
+//      { ...; return module.exports; })()` returned the initial empty
+//      `{ exports: {} }` instead of the package's actual export.
+//
+//   2. `++result[key]` (`Expr::IndexUpdate`) bailed at codegen with
+//      `expression IndexUpdate not yet supported`. Because Perry's
+//      compile-as-package pipeline runs in `PERRY_ALLOW_UNIMPLEMENTED=1`
+//      mode (linker stubs out failed modules), the entire lodash module
+//      compiled to an empty init stub — so `_` never got assigned.
+//
+// This test exercises both fixes via the minimum CJS shape lodash uses.
+// Real lodash still hits separate unrelated issues at runtime (no usable
+// `global` / `Function('return this')()`); those are tracked downstream.
+
+// ── (1) IIFE.call(this) executes its body and propagates outer-capture writes
+const captured: { value: number } = { value: 0 };
+(function () {
+    captured.value = 42;
+}.call(this));
+console.log("iife_call_writes_outer:", captured.value);
+
+// Pass args through .call() on an inline arrow function — should run the body
+// with the user-supplied args and return the body's result.
+console.log(
+    "iife_arrow_call_with_args:",
+    ((a: number, b: number) => a + b).call(null, 3, 4),
+);
+
+// ── (2) IndexUpdate: ++obj[key] / obj[key]++ / --obj[key] / ++arr[i]
+const acc: { [k: string]: number } = { foo: 5, bar: 10 };
+++acc["foo"];
+console.log("prefix_inc_object_string_key:", acc.foo);
+
+acc["bar"]++;
+console.log("postfix_inc_object_string_key:", acc.bar);
+
+--acc["foo"];
+console.log("prefix_dec_object_string_key:", acc.foo);
+
+const arr = [10, 20, 30];
+++arr[0];
+console.log("prefix_inc_array_numeric_index:", arr[0]);
+
+arr[1]++;
+console.log("postfix_inc_array_numeric_index:", arr[1]);
+
+// Prefix returns the NEW value; postfix returns the OLD value. Confirm via
+// the assignment-target's value capture below.
+const counter: { [k: string]: number } = { n: 5 };
+const pre = ++counter["n"];
+const post = counter["n"]++;
+console.log("prefix_returns_new:", pre); // 6
+console.log("postfix_returns_old:", post); // 6 (after pre==6; postfix returns old 6, then n→7)
+console.log("counter_final:", counter.n); // 7


### PR DESCRIPTION
## Summary

- **Fixes #957** — `import _ from "lodash"; _.add(1, 2)` resolved `_` to `undefined` under `perry.compilePackages`. Two distinct bugs combined; the first is the inline-IIFE CJS-prelude pattern that every UMD package uses, the second is a missing codegen arm that stubbed the entire package.
- HIR: rewrite `<FnExpr | ArrowExpr>.call(thisArg, ...args)` (paren-unwrapped) to a direct call when the closure doesn't capture `this` — drops the `thisArg`. Catches the `;(function() { ... }.call(this))` shape lodash + every UMD prelude uses; pre-fix the body never ran and `module.exports = _` was silently dropped inside the cjs_wrap IIFE.
- Codegen: implement `Expr::IndexUpdate` (`++obj[key]` / `obj[key]++` / `++arr[i]`). Pre-fix it bailed `not yet supported`, which (under `PERRY_ALLOW_UNIMPLEMENTED=1`) linker-stubbed the whole lodash module so the default-import bound to nothing.
- Runtime: extend `js_dyn_index_get` to dispatch string-keyed reads through `js_object_get_field_by_name_f64`, and add `js_dyn_index_set` (gc_type-aware) so the read-modify-write codegen handles arrays, plain objects, and TypedArrays uniformly.

## Test plan

- [x] `test-files/test_lodash_default_import_methods.ts` byte-matches `node --experimental-strip-types` (IIFE.call writes-outer + arrow.call(thisArg, args); prefix/postfix inc/dec on object string-key and array numeric index; prefix-returns-new vs postfix-returns-old).
- [x] Reproduction (`import _ from "lodash"; _.add(1, 2)`) advances past the `_.add` undefined symptom. Next runtime gap inside lodash itself (`Function('return this')()`, bare `global`) is tracked separately — not a CJS-default-import issue.
- [x] Sample gap-suite tests still pass (array methods, class advanced).

## Out of scope

Real lodash still throws `TypeError: value is not a function` during init because `runInContext()` calls `root.Object()` where `root = freeGlobal || freeSelf || Function('return this')()` and Perry: (a) lowers bare `global` / `self` to the `0.0` sentinel, (b) doesn't support `Function(string)` as a runtime function constructor, (c) returns a non-truthy stub for `globalThis`. These are pre-existing gaps unrelated to CJS default-import resolution.