### PR TITLE
fix(#957 followup): Function('return this')() + bare RegExp(...) recognisers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.977 — fix(#957 followup): `Function('return this')()` + bare `RegExp(...)` recognisers — moves real lodash past module-init `TypeError: value is not a function`
+
+**Symptom.** PR #959 closed two of lodash's three module-init bugs (`.call(this)` IIFE bodies + `Expr::IndexUpdate` codegen) but the commit explicitly flagged the next gap: `import _ from "lodash"` still threw
+
+```
+TypeError: value is not a function
+    at <anonymous>
+```
+
+from the top-level IIFE before any user code ran, and `_` resolved to `undefined`. Two distinct call sites hit the same null-closure-handle path:
+
+1. **`var root = freeGlobal || freeSelf || Function('return this')();`** (lodash.js line 436) — the canonical "give me whatever the host calls `globalThis` here" idiom every CJS/UMD library copies. The bare `Function` ident lowered to `Expr::GlobalGet(0)` (the no-resolution sentinel; `lower.rs:8174` already lists Function in the no-warn allowlist), so the inner `Function('return this')` lowered to `Call { callee: GlobalGet(0), args: [String("return this")] }`. The generic call path dispatched through `js_closure_call1` with a null closure handle, validated, and threw via `throw_not_callable` (which hard-codes `b"value"` as the property name — hence the "value is not a function" diagnostic with no usable receiver name).
+
+2. **`var reHasEscapedHtml = RegExp(reEscapedHtml.source);`** (lodash.js line 136; ~5 more sibling sites at lines 137 / 154 / 266 / 272 / 275 / 290 / 1499 / 4613) — bare `RegExp(...)` function-call form (not `new RegExp(...)`). The `RegExp` ident lowered the same way as `Function` (GlobalGet(0)), so the call form crashed identically. `new RegExp(<non-literal>)` had a parallel hole: the `expr_new.rs` recogniser only fired for string-literal `pattern` args and otherwise fell through to generic class-instantiation, which produced an empty ObjectHeader placeholder that any subsequent `.test()` / `.exec()` would silently no-op or SIGSEGV on.
+
+**Root cause (1).** Codegen's `Call { callee: Closure }` path goes through `js_closure_callN(closure_handle, args...)` with `unbox_to_i64(callee_value)` as the handle. When the callee is `Expr::GlobalGet(0)` (which lowers to `0.0`), the handle is `0`. `js_closure_callN`'s `get_valid_func_ptr` rejects null and calls `throw_not_callable` → `js_throw_type_error_not_a_function("", "value", 5)` → the user sees the line-less "value is not a function" panic with `at <anonymous>`. Found by `nm`-grepping the debug-symbols binary for `throw_not_callable` and walking up the lldb backtrace inside `perry_closure_node_modules_lodash_lodash_js__3` (the inner IIFE body); the call site disassembled to `RegExp.source → orr STRING_TAG → js_closure_call1(closure=0, source)`.
+
+**Root cause (2).** `RegExp(...)` had no AST-shape recognizer at HIR lower time, so it fell through to the same null-callee path. `new RegExp(<dynExpr>)` was handled at the HIR level (`expr_new.rs::lower_new`) but only fired on string-literal `pattern`; the dynamic-arg case left the comment "That path is currently broken too, but at least doesn't regress on the literal case" — confirmed broken here.
+
+**Fix.**
+
+1. **New `Expr::GlobalThisExpr` HIR variant** in `crates/perry-hir/src/ir.rs` (plus walker, stable_hash tag 474, analysis, collectors arms). Codegen lowers to a single `js_get_global_this()` call — the same lazy singleton `globalThis[X] = V` already writes to (see #611, `crates/perry-runtime/src/object.rs:9767`). The HIR-side recognizer in `crates/perry-hir/src/lower/expr_call.rs` matches `Call { callee: Call { callee: Ident("Function"), args: [Lit::Str(s)] }, args: [] }` where `s.trim().trim_end_matches(';').trim() == "return this"` AND `Function` is not shadowed by a local/func binding. Whitespace and trailing semicolon variants both fold through the same path (covered by the new regression test).
+
+2. **New `Expr::RegExpDynamic { pattern: Box<Expr>, flags: Option<Box<Expr>> }` HIR variant** (walker + stable_hash 475/476/477 + analysis arms). Codegen lowers to `js_regexp_new(pattern_handle, flags_handle)` — the same runtime entry the static `/foo/g` arm uses. Missing flags fall back to interning the empty string at codegen so `js_regexp_new` always sees a real `StringHeader*` (the LLVM type system rejects a `null`-typed `ptr` in the `i64` slot). Two callsites fold into this variant:
+   - `crates/perry-hir/src/lower/expr_call.rs`: `RegExp(pattern[, flags])` with 1 or 2 args, no spread, and `RegExp` not shadowed.
+   - `crates/perry-hir/src/lower/expr_new.rs`: the existing `class_name == "RegExp"` arm now folds through `RegExpDynamic` when the literal-pattern path doesn't match (so `new RegExp(varExpr)` / `new RegExp(varExpr, varFlagsExpr)` work).
+
+**Validation.**
+
+- New regression test `test-files/test_lodash_function_return_this_regexp.ts` — 12 assertions all match `node --experimental-strip-types` byte-for-byte. Exercises `Function('return this')()` identity (the runtime cache must return the same singleton across calls), trailing-semicolon and whitespace variants, write-then-read through the singleton, `RegExp(literal)` / `RegExp(literal, "g")` / `RegExp(varPattern)` / `RegExp(/foo/.source)` (the literal lodash shape), and `new RegExp(varPattern, varFlags)` / `new RegExp(literal)` (regression guard for the path that already worked).
+- Existing `test-files/test_regex.ts` parity output unchanged (20/20 lines match node).
+- `import _ from "lodash"` no longer throws at module init — the IIFE body completes and `module.exports = _` propagates. lodash itself still hits additional unrelated compat gaps further into `runInContext()` (the empty `globalThis` doesn't expose `Array`/`Function`/`Object`/etc. as readable properties, so `var Array = context.Array` reads undefined and the subsequent `Array.prototype` throws "Cannot read properties of undefined (reading 'prototype')"); those are deeper compat work tracked separately. This PR is the IIFE-init slice — the rest of lodash needs `globalThis.Array === Array` and friends, which is its own architectural change.
+
+**Files touched.** `crates/perry-hir/src/ir.rs`, `crates/perry-hir/src/walker.rs`, `crates/perry-hir/src/stable_hash.rs`, `crates/perry-hir/src/analysis.rs`, `crates/perry-hir/src/lower/expr_call.rs`, `crates/perry-hir/src/lower/expr_new.rs`, `crates/perry-codegen/src/collectors.rs`, `crates/perry-codegen/src/expr.rs`, plus the new test fixture.
+
 ## v0.5.976 — feat(zlib/crypto): `zlib.createBrotliDecompress` + `crypto.subtle.wrapKey`/`unwrapKey` — moves axios + jose past the next compile gates
 
 **Symptom.** After #955 wired `zlib.constants` + `subtle.generateKey`, the two `compilePackages` smoke targets advanced one step and tripped on the next gap:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.976
+**Current Version:** 0.5.977
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.976"
+version = "0.5.977"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "base64",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5564,11 +5564,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.976"
+version = "0.5.977"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "itoa",
  "jni",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "block2",
  "libc",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "block2",
  "libc",
@@ -5645,11 +5645,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.976"
+version = "0.5.977"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "block2",
  "libc",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "block2",
  "libc",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "block2",
  "libc",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.976"
+version = "0.5.977"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.976"
+version = "0.5.977"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/collectors.rs
+++ b/crates/perry-codegen/src/collectors.rs
@@ -6234,6 +6234,7 @@ fn check_object_literal_escapes_in_expr(
         | Expr::ProcessVersion | Expr::ProcessVersions | Expr::ProcessHrtimeBigint
         | Expr::ProcessStdin | Expr::ProcessStdout | Expr::ProcessStderr
         | Expr::ProcessEnv
+        | Expr::GlobalThisExpr
         // Path / encoding / OS leaf intrinsics
         | Expr::PathSep | Expr::PathDelimiter
         | Expr::TextEncoderNew | Expr::TextDecoderNew

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -6262,6 +6262,42 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &result))
         }
 
+        // `RegExp(<dynExpr>)` / `RegExp(<dynExpr>, <dynFlagsExpr>)` /
+        // `new RegExp(<non-literal>)`. Folded at HIR (lower/expr_call.rs +
+        // lower/expr_new.rs) from any callsite where the pattern (or
+        // flags) come in as runtime values rather than string literals.
+        // Both `pattern` and `flags` are NaN-boxed strings; missing
+        // flags fall back to interning an empty string at codegen so
+        // `js_regexp_new` always sees a real `StringHeader*`. Followup
+        // to #957 / PR #959.
+        Expr::RegExpDynamic { pattern, flags } => {
+            let pattern_box = lower_expr(ctx, pattern)?;
+            let flags_handle = if let Some(flags_expr) = flags {
+                let flags_box = lower_expr(ctx, flags_expr)?;
+                let blk = ctx.block();
+                unbox_str_handle(blk, &flags_box)
+            } else {
+                // Intern an empty string and use its handle so the
+                // runtime sees a valid `StringHeader*` (the
+                // `is_valid_ptr` check inside `js_regexp_new` already
+                // accepts null, but the LLVM type system needs a real
+                // i64 here, not a `null` typed `ptr`).
+                let empty_idx = ctx.strings.intern("");
+                let empty_global = format!("@{}", ctx.strings.entry(empty_idx).handle_global);
+                let blk = ctx.block();
+                let empty_box = blk.load(DOUBLE, &empty_global);
+                unbox_to_i64(blk, &empty_box)
+            };
+            let blk = ctx.block();
+            let pattern_handle = unbox_str_handle(blk, &pattern_box);
+            let result = blk.call(
+                I64,
+                "js_regexp_new",
+                &[(I64, &pattern_handle), (I64, &flags_handle)],
+            );
+            Ok(nanbox_pointer_inline(blk, &result))
+        }
+
         // -------- ObjectSpread literal --------
         // `{ ...a, key: val, ...b }`. The HIR carries an ordered
         // Vec<(Option<String>, Expr)>. Static props use the same
@@ -9999,6 +10035,16 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // first call. Subsequent PropertyGet dispatch on it works
             // via the normal object field path.
             Ok(ctx.block().call(DOUBLE, "js_process_env", &[]))
+        }
+        Expr::GlobalThisExpr => {
+            // `Function('return this')()` (and any other AST shape we
+            // recognise as "get the global this") materialises here as
+            // the runtime's lazily-allocated `globalThis` singleton —
+            // same object that `globalThis[...]= v` writes target via
+            // the IndexSet arm above. Returns an already-NaN-boxed
+            // f64 POINTER_TAG; the property-get arms route through
+            // this same singleton for `globalThis.process.env` etc.
+            Ok(ctx.block().call(DOUBLE, "js_get_global_this", &[]))
         }
         Expr::DateToISOString(d) => {
             let v = lower_expr(ctx, d)?;

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -949,6 +949,7 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
         | Expr::ProcessCwd
         | Expr::ProcessMemoryUsage
         | Expr::ProcessEnv
+        | Expr::GlobalThisExpr
         | Expr::NativeModuleRef(_)
         | Expr::RegExp { .. } => {}
         Expr::ObjectKeys(obj) | Expr::ObjectValues(obj) | Expr::ObjectEntries(obj) => {
@@ -968,6 +969,12 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
         Expr::RegExpTest { regex, string } => {
             collect_assigned_locals_expr(regex, assigned);
             collect_assigned_locals_expr(string, assigned);
+        }
+        Expr::RegExpDynamic { pattern, flags } => {
+            collect_assigned_locals_expr(pattern, assigned);
+            if let Some(f) = flags {
+                collect_assigned_locals_expr(f, assigned);
+            }
         }
         Expr::StringMatch { string, regex } => {
             collect_assigned_locals_expr(string, assigned);

--- a/crates/perry-hir/src/ir.rs
+++ b/crates/perry-hir/src/ir.rs
@@ -1230,6 +1230,19 @@ pub enum Expr {
     // access through `globalThis`/aliases where the static `.KEY` fast
     // path doesn't fire.
     ProcessEnv,
+    // `globalThis` materialized as an actual object value (not the
+    // `Expr::GlobalGet(0)` sentinel — that one routes by property
+    // name from the parent PropertyGet/Call context and lowers to
+    // the `0.0` placeholder when used bare). This variant lowers to
+    // a real `js_get_global_this()` call so that
+    // `Function('return this')()` (the canonical "get globalThis"
+    // idiom every CJS/UMD library copies — lodash, underscore,
+    // Effect, …) actually evaluates to the lazily-allocated global
+    // singleton instead of `undefined`/`0.0`. Without this fold the
+    // double call lowers as `GlobalGet(0)(literal)(): TypeError:
+    // value is not a function` at module init and the import
+    // resolves to undefined. Followup to #957 / PR #959.
+    GlobalThisExpr,
     // Process uptime: process.uptime() -> number (seconds)
     ProcessUptime,
     // Process current working directory: process.cwd() -> string
@@ -2284,6 +2297,25 @@ pub enum Expr {
     RegExp {
         pattern: String,
         flags: String,
+    },
+    /// Dynamic RegExp construction: `RegExp(pattern)` /
+    /// `RegExp(pattern, flags)` / `new RegExp(pattern, flags?)` where the
+    /// pattern (and optional flags) are runtime values, not string
+    /// literals. lodash 4 builds half a dozen of these at module init
+    /// from `someLiteralRegex.source`:
+    ///   var reHasEscapedHtml = RegExp(reEscapedHtml.source);
+    /// Pre-fix the bare `RegExp` ident lowered to `Expr::GlobalGet(0)`
+    /// and the function-call form dispatched to a null closure, which
+    /// `js_closure_call1` rejected as
+    /// `TypeError: value is not a function` at module init. The
+    /// `new RegExp(<non-literal>)` arm in `expr_new.rs` similarly fell
+    /// through to the generic class-instantiation placeholder. Both now
+    /// fold to this variant which lowers to `js_regexp_new(pattern,
+    /// flags)` (the same runtime entrypoint the static `/foo/` arm
+    /// uses). Followup to #957 / PR #959.
+    RegExpDynamic {
+        pattern: Box<Expr>,
+        flags: Option<Box<Expr>>,
     },
     /// regex.test(string) -> boolean
     RegExpTest {

--- a/crates/perry-hir/src/lower/expr_call.rs
+++ b/crates/perry-hir/src/lower/expr_call.rs
@@ -385,6 +385,112 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
         }
     }
 
+    // Followup to #957 / PR #959 — `Function('return this')()`.
+    //
+    // Every CJS/UMD-shaped library (lodash, underscore, Effect, …)
+    // computes its "give me whatever the host calls `globalThis` here"
+    // root with the double-call idiom:
+    //   var root = freeGlobal || freeSelf || Function('return this')();
+    // Pre-fix the bare `Function` ident lowers to `Expr::GlobalGet(0)`
+    // (the no-resolution sentinel), then the inner `Function('return this')`
+    // lowers to `Call { callee: GlobalGet(0), args: [String("return this")] }`
+    // which codegen treats as "call a non-callable" — the outer `()` then
+    // tries to call the returned value and the closure validator throws
+    // `TypeError: value is not a function` at module init, leaving the
+    // import resolved to undefined.
+    //
+    // PR #959 closed the sibling `.call(this)` IIFE bug and called this
+    // one out in its commit message ("the next runtime gap"); fix here.
+    // Match the full two-call shape at the AST level (the inner `Function`
+    // ident still carries its name, so we can verify it really is the
+    // builtin) and fold to `Expr::GlobalThisExpr`, which lowers to the
+    // runtime's `js_get_global_this()` singleton — the same object
+    // `globalThis[X] = V` already writes to (see #611).
+    //
+    // Conservative: requires the LITERAL "return this" (with optional
+    // semicolon / whitespace) AND the outer Call must have no args. Any
+    // other `Function(...)` shape (e.g. dynamic body, real `new Function`)
+    // falls through to the existing GlobalGet(0) path; arbitrary
+    // `new Function(body)` is still not supported (an architectural
+    // change — issue #960 / future work).
+    if !has_spread && call.args.is_empty() {
+        if let ast::Callee::Expr(outer_callee) = &call.callee {
+            let mut inner = outer_callee.as_ref();
+            while let ast::Expr::Paren(p) = inner {
+                inner = p.expr.as_ref();
+            }
+            if let ast::Expr::Call(inner_call) = inner {
+                let inner_args_ok =
+                    inner_call.args.len() == 1 && inner_call.args[0].spread.is_none();
+                if inner_args_ok {
+                    if let ast::Callee::Expr(inner_callee) = &inner_call.callee {
+                        let mut inner_target = inner_callee.as_ref();
+                        while let ast::Expr::Paren(p) = inner_target {
+                            inner_target = p.expr.as_ref();
+                        }
+                        if let ast::Expr::Ident(ident) = inner_target {
+                            if ident.sym.as_ref() == "Function"
+                                && ctx.lookup_local("Function").is_none()
+                                && ctx.lookup_func("Function").is_none()
+                            {
+                                if let ast::Expr::Lit(ast::Lit::Str(s)) =
+                                    inner_call.args[0].expr.as_ref()
+                                {
+                                    let body = s.value.as_str().unwrap_or("").trim();
+                                    let body = body.trim_end_matches(';').trim();
+                                    if body == "return this" {
+                                        return Ok(Expr::GlobalThisExpr);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Followup to #957 / PR #959 — `RegExp(<args>)` as a bare function call.
+    //
+    // lodash 4 builds half a dozen of these at module init:
+    //   var reEscapedHtml = /&(?:amp|lt|gt|quot|#39);/g,
+    //       reHasEscapedHtml = RegExp(reEscapedHtml.source);
+    // The bare `RegExp` ident lowers to `Expr::GlobalGet(0)` (no resolved
+    // value), so the function-call form dispatches through
+    // `js_closure_call1` with a null closure handle and throws
+    // `TypeError: value is not a function`. Fold here to
+    // `Expr::RegExpDynamic` which lowers to the same `js_regexp_new`
+    // runtime entrypoint the static `/foo/g` arm uses.
+    //
+    // Conservative: only `RegExp(pattern)` and `RegExp(pattern, flags)`
+    // with no spread. Any local/import named `RegExp` shadows the
+    // builtin and falls through to its normal dispatch.
+    if !has_spread && !call.args.is_empty() && call.args.len() <= 2 {
+        if let ast::Callee::Expr(callee_expr) = &call.callee {
+            let mut callee_inner = callee_expr.as_ref();
+            while let ast::Expr::Paren(p) = callee_inner {
+                callee_inner = p.expr.as_ref();
+            }
+            if let ast::Expr::Ident(ident) = callee_inner {
+                if ident.sym.as_ref() == "RegExp"
+                    && ctx.lookup_local("RegExp").is_none()
+                    && ctx.lookup_func("RegExp").is_none()
+                {
+                    let pattern = lower_expr(ctx, &call.args[0].expr)?;
+                    let flags = if call.args.len() == 2 {
+                        Some(Box::new(lower_expr(ctx, &call.args[1].expr)?))
+                    } else {
+                        None
+                    };
+                    return Ok(Expr::RegExpDynamic {
+                        pattern: Box::new(pattern),
+                        flags,
+                    });
+                }
+            }
+        }
+    }
+
     let mut args = call
         .args
         .iter()

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -284,11 +284,26 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                         flags: flags_lit,
                     });
                 }
-                // Fall through to generic class instantiation for
-                // non-literal args (e.g. `new RegExp(userInput)`).
-                // That path is currently broken too, but at least
-                // doesn't regress on the literal case which is far
-                // more common.
+                // Dynamic-arg `new RegExp(...)`: pattern (or flags) is
+                // a runtime value. Fold to the same `RegExpDynamic`
+                // variant the bare-call recognizer in expr_call.rs
+                // produces — both lower to `js_regexp_new` with
+                // dynamically-resolved string handles. Followup to
+                // #957 / PR #959.
+                if let Some(args) = args_ast {
+                    if !args.is_empty() && args.iter().all(|a| a.spread.is_none()) {
+                        let pattern = lower_expr(ctx, &args[0].expr)?;
+                        let flags = if args.len() >= 2 {
+                            Some(Box::new(lower_expr(ctx, &args[1].expr)?))
+                        } else {
+                            None
+                        };
+                        return Ok(Expr::RegExpDynamic {
+                            pattern: Box::new(pattern),
+                            flags,
+                        });
+                    }
+                }
             }
             if class_name == "Proxy" {
                 let args = new_expr

--- a/crates/perry-hir/src/stable_hash.rs
+++ b/crates/perry-hir/src/stable_hash.rs
@@ -1637,6 +1637,7 @@ impl SH for Expr {
                 e.as_ref().hash(h);
             }
             Expr::ProcessEnv => tag(h, 55),
+            Expr::GlobalThisExpr => tag(h, 474),
             Expr::ProcessUptime => tag(h, 56),
             Expr::ProcessCwd => tag(h, 57),
             Expr::ProcessArgv => tag(h, 58),
@@ -3217,6 +3218,16 @@ impl SH for Expr {
                 tag(h, 383);
                 pattern.hash(h);
                 flags.hash(h);
+            }
+            Expr::RegExpDynamic { pattern, flags } => {
+                tag(h, 475);
+                pattern.as_ref().hash(h);
+                if let Some(f_box) = flags {
+                    tag(h, 476);
+                    f_box.as_ref().hash(h);
+                } else {
+                    tag(h, 477);
+                }
             }
             Expr::RegExpTest { regex, string } => {
                 tag(h, 384);

--- a/crates/perry-hir/src/walker.rs
+++ b/crates/perry-hir/src/walker.rs
@@ -76,6 +76,7 @@ where
         | Expr::Update { .. }
         | Expr::EnvGet(_)
         | Expr::ProcessEnv
+        | Expr::GlobalThisExpr
         | Expr::ProcessUptime
         | Expr::ProcessCwd
         | Expr::ProcessArgv
@@ -812,6 +813,12 @@ where
             f(regex);
             f(string);
         }
+        Expr::RegExpDynamic { pattern, flags } => {
+            f(pattern);
+            if let Some(flags_box) = flags {
+                f(flags_box);
+            }
+        }
         Expr::RegExpSetLastIndex { regex, value } => {
             f(regex);
             f(value);
@@ -1420,6 +1427,7 @@ where
         | Expr::Update { .. }
         | Expr::EnvGet(_)
         | Expr::ProcessEnv
+        | Expr::GlobalThisExpr
         | Expr::ProcessUptime
         | Expr::ProcessCwd
         | Expr::ProcessArgv
@@ -2141,6 +2149,12 @@ where
         | Expr::StringMatchAll { string, regex } => {
             f(regex);
             f(string);
+        }
+        Expr::RegExpDynamic { pattern, flags } => {
+            f(pattern);
+            if let Some(flags_box) = flags {
+                f(flags_box);
+            }
         }
         Expr::RegExpSetLastIndex { regex, value } => {
             f(regex);

--- a/test-files/test_lodash_function_return_this_regexp.ts
+++ b/test-files/test_lodash_function_return_this_regexp.ts
@@ -1,0 +1,74 @@
+// Followup to #957 / PR #959 — `Function('return this')()` + bare
+// `RegExp(pattern[, flags])` recognisers.
+//
+// Real lodash 4 builds two stubborn module-init expressions that, before
+// this commit, both threw `TypeError: value is not a function` at module
+// init and left `_` undefined:
+//
+//   1. `var root = freeGlobal || freeSelf || Function('return this')();`
+//      The inner `Function('return this')` call was a `Call { callee:
+//      GlobalGet(0), args: [String("return this")] }` (the `Function`
+//      ident resolved to the no-resolution sentinel). The double-call
+//      dispatched through `js_closure_call1` on a null closure handle
+//      → throw.
+//
+//   2. `var reHasEscapedHtml = RegExp(reEscapedHtml.source);` (and
+//      ~5 sibling `RegExp(...)` bare-call sites). The `RegExp`
+//      ident lowered the same way as `Function` (GlobalGet(0)
+//      sentinel), so the call form crashed identically.
+//
+// Both are now AST-shape recognised at HIR lower time. (1) folds to
+// `Expr::GlobalThisExpr` (lazy `js_get_global_this()` singleton — same
+// object `globalThis[X] = V` already writes to under #611). (2) folds
+// to a new `Expr::RegExpDynamic { pattern, flags }` that lowers to the
+// same `js_regexp_new(pattern_handle, flags_handle)` the static `/foo/g`
+// arm uses. `new RegExp(<non-literal>)` was rerouted the same way (the
+// literal-only `Expr::RegExp` arm in `expr_new.rs` previously fell
+// through to generic class-instantiation when the pattern was an Expr).
+
+// ── (1) `Function('return this')()` evaluates to the global singleton.
+const g: any = Function("return this")();
+console.log("global_is_object:", typeof g === "object" && g !== null);
+// Identity: the runtime caches the singleton so two double-call sites
+// resolve to the same JS object.
+console.log("global_identity:", Function("return this")() === g);
+// Whitespace + trailing semicolon variants the recognizer also accepts.
+console.log("global_with_semi:", typeof Function("return this;")() === "object");
+console.log("global_with_ws:", typeof Function("  return this  ")() === "object");
+
+// Writes through the singleton are visible on subsequent reads.
+(g as { [k: string]: number })["__perry_test_957_b"] = 7;
+console.log(
+    "global_write_then_read:",
+    (g as { [k: string]: number })["__perry_test_957_b"],
+);
+
+// ── (2) `RegExp(pattern)` + `RegExp(pattern, flags)` bare function-call.
+const r1 = RegExp("ab+c");
+console.log("regexp_call_basic:", r1.test("xabbbc"));
+
+const r2 = RegExp("ab+c", "g");
+console.log("regexp_call_with_flags:", r2.test("xabbbc"));
+
+// Dynamic pattern from another variable (the lodash shape).
+const pat = "ab+c";
+const r3 = RegExp(pat);
+console.log("regexp_call_dynamic_pattern:", r3.test("xabbbc"));
+
+// The literal lodash shape — `RegExp(otherRegex.source)` — the exact
+// AST that hit the GlobalGet(0) callee bug in the original repro.
+const litRegex = /xyz/g;
+const r4 = RegExp(litRegex.source);
+console.log("regexp_from_source:", r4.test("xyz"));
+
+// `new RegExp(<non-literal>)` rerouted through the same dynamic arm.
+const r5 = new RegExp(pat);
+console.log("new_regexp_dynamic:", r5.test("xabbbc"));
+
+const r6 = new RegExp(pat, "g");
+console.log("new_regexp_dynamic_with_flags:", r6.test("xabbbc"));
+
+// `new RegExp(literal)` (the path that already worked via `Expr::RegExp`)
+// keeps working — guard against accidentally regressing.
+const r7 = new RegExp("xyz");
+console.log("new_regexp_literal:", r7.test("xyz"));


### PR DESCRIPTION
## Summary

Closes two distinct module-init holes flagged in PR #959's commit message ("the next runtime gap") that kept real lodash throwing `TypeError: value is not a function` at `<anonymous>` before any user code ran.

- **`Function('return this')()`** — the canonical "give me globalThis" idiom every CJS/UMD library copies (lodash.js:436, also underscore + Effect prelude). Bare `Function` lowers to `Expr::GlobalGet(0)` (no-resolution sentinel), so the inner call dispatches through `js_closure_call1` on a null closure handle and `throw_not_callable` fires with the hardcoded `b"value"` property name — hence the line-less `TypeError: value is not a function`. AST-match the two-call shape at HIR lower time and fold to a new `Expr::GlobalThisExpr` variant that lowers to `js_get_global_this()` — the same lazy singleton `globalThis[X] = V` already writes to (#611).

- **`RegExp(pattern[, flags])` bare function call** + **`new RegExp(<non-literal>)`** — lodash builds ~6 of these at module init (e.g. `var reHasEscapedHtml = RegExp(reEscapedHtml.source);`). Both hit the same null-callee path because `RegExp` lowered identically to `Function`. Fold both to a new `Expr::RegExpDynamic { pattern, flags }` that lowers to the existing `js_regexp_new(pattern, flags)` runtime entry — the same entry the static `/foo/g` arm uses. Missing flags fall back to interning the empty string at codegen so `js_regexp_new` always sees a real `StringHeader*`.

## Test plan
- [x] New regression `test-files/test_lodash_function_return_this_regexp.ts` (12 assertions, byte-for-byte match with `node --experimental-strip-types`):
  - `Function('return this')()` identity + write-then-read through the singleton
  - Whitespace + trailing-semicolon variants of the inner literal
  - `RegExp(literal)` / `RegExp(literal, 'g')` / `RegExp(varPattern)` / `RegExp(/foo/.source)` (the literal lodash shape)
  - `new RegExp(varPattern[, varFlags])` (the previously-broken dynamic-arg `new` form)
  - `new RegExp(literal)` (regression guard for the path that already worked)
- [x] `test-files/test_regex.ts` parity unchanged (20/20 lines match node)
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` green
- [x] `cargo fmt --all` clean

## Known follow-up

`import _ from "lodash"` no longer throws at IIFE init — `module.exports = _` propagates correctly. Real lodash still hits a separate compat gap further inside `runInContext()`: `var Array = context.Array` reads `undefined` because the empty globalThis singleton doesn't expose JS built-in constructors as properties, and the subsequent `Array.prototype` throws `Cannot read properties of undefined (reading 'prototype')`. Tracked separately — this PR is the IIFE-init slice (the bug PR #959 explicitly flagged); the `globalThis.Array === Array` work is its own architectural change. The other tier3 sweep failure (`debug` package silent — `process.stderr` is undefined under perry) is independent of these recognizers and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)