### PR TITLE
fix(crypto/jsruntime): bare named-import randomFillSync(buf) routes to native FFI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.978 — fix(crypto/jsruntime): bare named-import `randomFillSync(buf)` (and `randomUUID()` / `randomBytes(n)`) routes to native FFI + V8 fallback ESM re-export
+
+**Symptom.** `jose` (and any package that does `import { randomFillSync } from 'node:crypto'; randomFillSync(buf)`) silently produced all-zero buffers. v0.5.952 added `randomFillSync` to Perry's native crypto code path via `Expr::CryptoRandomFillSync` → `js_crypto_random_fill_sync`, but that HIR recogniser only fired for the **object-method** form `crypto.randomFillSync(...)` (in `expr_call.rs:3118`, gated on `is_crypto_module && member.prop == "randomFillSync"`). The **bare named-import** form `randomFillSync(buf)` fell through to the generic aliased-named-import arm (`expr_call.rs:6463`) which built `Expr::NativeMethodCall { module: "crypto", method: "randomFillSync", object: None, args: [buf] }`. The codegen `NativeMethodCall` dispatcher has no `crypto` arm, so it lowered to a no-op returning `undefined` — the buffer was never touched, and `jose` happily signed JWTs with all-zero IVs.
+
+Repro before the fix:
+```ts
+import { randomFillSync } from 'node:crypto';
+const buf = new Uint8Array(8);
+randomFillSync(buf);
+console.log(typeof randomFillSync);                 // "object"   (Node: "function")
+console.log(buf[0], buf[1], buf[2], buf[3]);        // 0 0 0 0    (Node: random)
+```
+
+For Hint-1, `typeof === "object"` instead of `"function"` is the same `NativeModuleRef`-without-codegen-arm shape that's bitten `child_process` / `fs` named imports before; the existing pattern in `expr_call.rs` (~line 6150 onwards) routes those through dedicated HIR variants per module.
+
+**Root cause.** The HIR named-import recogniser had arms for `child_process`, `path`, `url`, and `fs` after the `lookup_native_module` check, but no `crypto` arm. The matching `crypto.method()` recogniser exists 3000 lines earlier (line 3060) but only sees object-member calls — bare identifiers from named imports never reach it.
+
+**Fix.**
+1. **`crates/perry-hir/src/lower/expr_call.rs`** — added a `module_name == "crypto"` arm alongside `child_process` / `path` / `url` / `fs` (line ~6458). Handles `randomFillSync` (→ `Expr::CryptoRandomFillSync`), `randomUUID` (→ `Expr::CryptoRandomUUID`), and `randomBytes` (→ `Expr::CryptoRandomBytes`). Mirrors the existing object-method arm at line 3118 so both call shapes share one codegen path. Offset/size args for `randomFillSync` default to `Expr::Undefined` (runtime maps that to "use full buffer").
+2. **`crates/perry-jsruntime/src/modules.rs`** — added `randomFillSync` and `randomUUID` to the V8/JS-runtime fallback's `node:crypto` ESM stub. Required because the fallback path (when a module isn't recognized as a native module, or runs in a non-native-eligible context) re-parses imports against `node_modules`-style ESM exports, and the stub previously only exposed `randomBytes`/`createHash`/`createHmac`/`pbkdf2Sync`/`pbkdf2`. The `randomFillSync` shim delegates to the `globalThis.crypto.getRandomValues` polyfill that `node_polyfills.js` already installs; `randomUUID` derives RFC 4122 v4 from a 16-byte `getRandomValues` block.
+
+**Files.**
+- `crates/perry-hir/src/lower/expr_call.rs` — new `if module_name == "crypto" { ... }` arm in the named-import dispatcher (lines ~6460).
+- `crates/perry-jsruntime/src/modules.rs` — `crypto` ESM stub gains `randomFillSync` + `randomUUID` named exports plus both in the default-export object.
+- `test-files/test_crypto_randomFillSync_esm.ts` — minimal repro that compiles natively, fills an 8-byte Uint8Array via the bare-named-import form, and checks `length` + at-least-one-nonzero-byte via a manual for-loop (Perry's `Uint8Array.prototype.some` is a separate pre-existing gap that returns `undefined`).
+
+**Validation.** Native compile + run of `test-files/test_crypto_randomFillSync_esm.ts` prints `8 true` matching `node --experimental-strip-types`. Probe `typeof randomFillSync` now reports `"function"` from a bare named-import binding.
+
+**Out of scope (follow-ups).**
+- `Uint8Array.prototype.some` returning `undefined` is a separate typed-array method-dispatch gap; track separately.
+- The V8 fallback's `getRandomValues` polyfill in `node_polyfills.js` uses `Math.random()`-derived bytes and is NOT cryptographically secure — the V8 fallback path is for testing/diagnostics only. Real crypto strength is on the native FFI path that this PR also unblocks.
+
 ## v0.5.977 — fix(#957 followup): `Function('return this')()` + bare `RegExp(...)` recognisers — moves real lodash past module-init `TypeError: value is not a function`
 
 **Symptom.** PR #959 closed two of lodash's three module-init bugs (`.call(this)` IIFE bodies + `Expr::IndexUpdate` codegen) but the commit explicitly flagged the next gap: `import _ from "lodash"` still threw

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.977
+**Current Version:** 0.5.978
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.977"
+version = "0.5.978"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "base64",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5564,11 +5564,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.977"
+version = "0.5.978"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "itoa",
  "jni",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "block2",
  "libc",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "block2",
  "libc",
@@ -5645,11 +5645,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.977"
+version = "0.5.978"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "block2",
  "libc",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "block2",
  "libc",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "block2",
  "libc",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.977"
+version = "0.5.978"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.977"
+version = "0.5.978"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-hir/src/lower/expr_call.rs
+++ b/crates/perry-hir/src/lower/expr_call.rs
@@ -6456,6 +6456,47 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                             _ => {} // Fall through
                         }
                     }
+
+                    // Named imports from `node:crypto` (e.g.
+                    // `import { randomFillSync, randomUUID, randomBytes }
+                    //  from 'node:crypto'`). Without these arms the bare
+                    // call `randomFillSync(buf)` falls into the generic
+                    // `NativeMethodCall` path, which has no `crypto`
+                    // dispatcher and returns `undefined` — so the buffer
+                    // never gets filled (jose's signing flow silently
+                    // produces all-zero IVs / nonces). Route each call
+                    // straight to the dedicated `Expr::CryptoRandom*`
+                    // variant that the `crypto.xxx(...)` (object-method)
+                    // arm above (line ~3060) uses, so both call shapes
+                    // share one codegen path.
+                    if module_name == "crypto" {
+                        match func_name {
+                            "randomFillSync" => {
+                                if !args.is_empty() {
+                                    let mut iter = args.into_iter();
+                                    let buffer = iter.next().unwrap();
+                                    let offset = iter.next().unwrap_or(Expr::Undefined);
+                                    let size = iter.next().unwrap_or(Expr::Undefined);
+                                    return Ok(Expr::CryptoRandomFillSync {
+                                        buffer: Box::new(buffer),
+                                        offset: Box::new(offset),
+                                        size: Box::new(size),
+                                    });
+                                }
+                            }
+                            "randomUUID" => {
+                                return Ok(Expr::CryptoRandomUUID);
+                            }
+                            "randomBytes" => {
+                                if !args.is_empty() {
+                                    return Ok(Expr::CryptoRandomBytes(Box::new(
+                                        args.into_iter().next().unwrap(),
+                                    )));
+                                }
+                            }
+                            _ => {} // Fall through
+                        }
+                    }
                 }
 
                 // Check if this is a direct call on an aliased named import

--- a/crates/perry-jsruntime/src/modules.rs
+++ b/crates/perry-jsruntime/src/modules.rs
@@ -918,6 +918,35 @@ export function randomBytes(size) {
     crypto.getRandomValues(arr);
     return arr;
 }
+// Issue: jose imports `randomFillSync` from `node:crypto` via the V8/JS
+// fallback path. Node's `randomFillSync(buffer, offset?, size?)` fills the
+// given TypedArray/Buffer with cryptographically secure random bytes in
+// place and returns the buffer.
+export function randomFillSync(buf, offset, size) {
+    const o = offset || 0;
+    const len = (buf && typeof buf.length === 'number') ? buf.length : 0;
+    const n = (size != null) ? size : (len - o);
+    let view;
+    if (typeof buf.subarray === 'function') {
+        view = buf.subarray(o, o + n);
+    } else if (buf && buf.buffer) {
+        view = new Uint8Array(buf.buffer, (buf.byteOffset || 0) + o, n);
+    } else {
+        view = buf;
+    }
+    crypto.getRandomValues(view);
+    return buf;
+}
+export function randomUUID() {
+    // RFC 4122 v4 UUID using getRandomValues
+    const b = new Uint8Array(16);
+    crypto.getRandomValues(b);
+    b[6] = (b[6] & 0x0f) | 0x40;
+    b[8] = (b[8] & 0x3f) | 0x80;
+    const h = [];
+    for (let i = 0; i < 16; i++) h.push((b[i] + 0x100).toString(16).slice(1));
+    return h[0]+h[1]+h[2]+h[3]+'-'+h[4]+h[5]+'-'+h[6]+h[7]+'-'+h[8]+h[9]+'-'+h[10]+h[11]+h[12]+h[13]+h[14]+h[15];
+}
 export function createHash(algorithm) {
     return {
         update(data) { this._data = (this._data || '') + data; return this; },
@@ -932,7 +961,42 @@ export function createHmac(algorithm, key) {
 }
 export function pbkdf2Sync() { return new Uint8Array(32); }
 export function pbkdf2() { return Promise.resolve(new Uint8Array(32)); }
-export default { randomBytes, createHash, createHmac, pbkdf2Sync, pbkdf2 };
+// Best-effort stubs for additional `node:crypto` named exports that
+// libraries like `jose` import at module-init time. Returning sane
+// no-ops lets the import resolve (so ESM linking succeeds and the
+// library can load), even when the underlying primitive isn't wired
+// through Perry's native crypto path. Calling them at runtime in the
+// V8 fallback path will throw or no-op deterministically, NOT crash
+// the JS module loader. Real implementations live behind the native
+// FFI path (`Expr::Crypto*` in HIR / `js_crypto_*` in perry-stdlib).
+export function timingSafeEqual(a, b) {
+    if (!a || !b || a.length !== b.length) return false;
+    let r = 0;
+    for (let i = 0; i < a.length; i++) r |= a[i] ^ b[i];
+    return r === 0;
+}
+export function createCipheriv() { throw new Error('crypto.createCipheriv not supported in V8 fallback'); }
+export function createDecipheriv() { throw new Error('crypto.createDecipheriv not supported in V8 fallback'); }
+export function createSecretKey(key) { return { _key: key, type: 'secret', asymmetricKeyType: undefined, symmetricKeySize: (key && key.length) || 0, export() { return key; } }; }
+export function createPrivateKey() { throw new Error('crypto.createPrivateKey not supported in V8 fallback'); }
+export function createPublicKey() { throw new Error('crypto.createPublicKey not supported in V8 fallback'); }
+export function generateKeyPair() { throw new Error('crypto.generateKeyPair not supported in V8 fallback'); }
+export function diffieHellman() { throw new Error('crypto.diffieHellman not supported in V8 fallback'); }
+export function publicEncrypt() { throw new Error('crypto.publicEncrypt not supported in V8 fallback'); }
+export function privateDecrypt() { throw new Error('crypto.privateDecrypt not supported in V8 fallback'); }
+export function getCiphers() { return []; }
+export class KeyObject {
+    constructor() { this.type = 'secret'; this.asymmetricKeyType = undefined; this.symmetricKeySize = 0; }
+    export() { return new Uint8Array(0); }
+}
+export const constants = {
+    RSA_PKCS1_PADDING: 1,
+    RSA_PKCS1_OAEP_PADDING: 4,
+    RSA_PSS_SALTLEN_DIGEST: -1,
+    RSA_PSS_SALTLEN_MAX_SIGN: -2,
+    RSA_PSS_SALTLEN_AUTO: -2,
+};
+export default { randomBytes, randomFillSync, randomUUID, createHash, createHmac, pbkdf2Sync, pbkdf2, timingSafeEqual, createCipheriv, createDecipheriv, createSecretKey, createPrivateKey, createPublicKey, generateKeyPair, diffieHellman, publicEncrypt, privateDecrypt, getCiphers, KeyObject, constants };
 "#.to_string(),
         "fs" => r#"
 // Stub implementation for Node.js 'fs' module

--- a/test-files/test_crypto_randomFillSync_esm.ts
+++ b/test-files/test_crypto_randomFillSync_esm.ts
@@ -1,0 +1,12 @@
+import { randomFillSync } from 'node:crypto';
+const buf = new Uint8Array(8);
+randomFillSync(buf);
+// Avoid `Uint8Array.prototype.some` — Perry's typed-array dispatch
+// currently returns `undefined` from `.some()` on Uint8Array, which
+// makes this test diverge from Node even when randomFillSync itself
+// works. Iterate manually and accumulate the result.
+let anyNonZero = false;
+for (let i = 0; i < buf.length; i++) {
+    if (buf[i] !== 0) { anyNonZero = true; break; }
+}
+console.log(buf.length, anyNonZero);  // 8 true


### PR DESCRIPTION
## Summary

`import { randomFillSync } from 'node:crypto'; randomFillSync(buf)` (the call shape jose uses) silently produced all-zero buffers. v0.5.952 added `randomFillSync` to Perry's native crypto path, but the HIR recogniser only fires for the **object-method** form `crypto.randomFillSync(...)`. The **bare named-import** form fell through to a generic `NativeMethodCall` with no codegen dispatcher and lowered to `undefined` — the buffer was never touched, and jose happily signed JWTs with all-zero IVs.

Before this PR:
```ts
import { randomFillSync } from 'node:crypto';
const buf = new Uint8Array(8);
randomFillSync(buf);
console.log(typeof randomFillSync);                 // "object"   (Node: "function")
console.log(buf[0], buf[1], buf[2], buf[3]);        // 0 0 0 0    (Node: random)
```

## What changed

- **`crates/perry-hir/src/lower/expr_call.rs`** — added a `module_name == "crypto"` arm to the named-import dispatcher (alongside the existing `child_process` / `path` / `url` / `fs` arms at ~line 6150). Handles `randomFillSync` (→ `Expr::CryptoRandomFillSync`), `randomUUID` (→ `Expr::CryptoRandomUUID`), and `randomBytes` (→ `Expr::CryptoRandomBytes`). Mirrors the object-method recogniser at line ~3060 so both call shapes share one codegen path.
- **`crates/perry-jsruntime/src/modules.rs`** — V8/JS-runtime fallback's `node:crypto` ESM stub gains `randomFillSync` + `randomUUID` named exports (matching the native side), plus stubs for the rest of the crypto surface jose imports at module-init (`timingSafeEqual`, `KeyObject`, `constants`, `createCipheriv`, `createDecipheriv`, `createSecretKey`, `createPrivateKey`, `createPublicKey`, `generateKeyPair`, `diffieHellman`, `publicEncrypt`, `privateDecrypt`, `getCiphers`). Calls that are unsupported throw a clear "not supported in V8 fallback" error at call time instead of crashing the ESM linker with `SyntaxError: does not provide an export named X` at module-load time.
- **`test-files/test_crypto_randomFillSync_esm.ts`** — repro that compiles natively, fills an 8-byte Uint8Array via the bare-named-import form, and matches `node --experimental-strip-types` byte-for-byte.

## Validation

- Native compile + run of the new test prints `8 true` matching Node.
- Probe `typeof randomFillSync` now reports `"function"` (was `"object"`).
- jose 5.9.6 module-init now gets past the `randomFillSync is undefined` and `does not provide an export named 'timingSafeEqual'` crashes. Next crash is `util.types.isKeyObject is not a function` — separate `util.types` gap, out of scope here.

## Out of scope follow-ups

- `Uint8Array.prototype.some` returns `undefined` (separate typed-array method-dispatch gap; the test sidesteps with a manual for-loop).
- `util.types.isKeyObject` and the wider `node:crypto` API surface (createCipheriv/etc) — only ESM linking is unblocked here, the V8 fallback's runtime crypto is still placeholder.
- V8 fallback's `globalThis.crypto.getRandomValues` uses `Math.random()`-derived bytes and is NOT cryptographically secure. The native FFI path (which this PR unblocks for the named-import shape) uses `rand::thread_rng`.

## Test plan

- [x] `node --experimental-strip-types test-files/test_crypto_randomFillSync_esm.ts` → `8 true`
- [x] `perry test-files/test_crypto_randomFillSync_esm.ts -o out && ./out` → `8 true`
- [ ] CI: `lint`, `cargo-test`, `parity`, `compile-smoke`, `api-docs-drift`, `security-audit`