### PR TITLE
feat(globalThis): expose built-in constructors as properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.979 — feat(globalThis): expose built-in constructors as properties so `globalThis.Array`, `context.Object`, etc. stop returning `undefined`
+
+**Symptom.** PR #963 (v0.5.977) closed the `Function('return this')()` recogniser, so the lodash module-init IIFE no longer threw `TypeError: value is not a function`. The next blocker surfaced one frame down, inside `runInContext`:
+
+```js
+var Array  = context.Array,   // context is `globalThis`
+    Object = context.Object,
+    ...
+var arrayProto = Array.prototype;   // TypeError: Cannot read properties of undefined (reading 'prototype')
+```
+
+`context` resolved to the `js_get_global_this()` singleton (the same object `globalThis[k] = v` writes target after #611). But the built-in constructors — `Array`, `Object`, `Function`, `RegExp`, `Math`, `JSON`, ... — were never *registered* as properties on that singleton, so every `context.X` read returned `undefined`. The follow-on `.prototype` access tripped the spec-shaped `TypeError: Cannot read properties of undefined (reading 'prototype')` gate (`crates/perry-runtime/src/error.rs::js_throw_type_error_property_access`) and the program exited 1 before any user code executed.
+
+The same gap surfaced through the static AST shape too: `globalThis.Array` (and `(globalThis as any).Array`) lowered to `Expr::PropertyGet { GlobalGet(0), "Array" }` and the codegen `Expr::PropertyGet` arm in `expr.rs` returned the `0.0` no-value placeholder for every property except `log` (the lone special-cased `console.log`-as-closure singleton from #236).
+
+**Fix.** Two coordinated pieces — runtime population + codegen routing — turn `globalThis.X` reads into a non-`undefined` value for the canonical JS built-ins:
+
+1. **Runtime** (`crates/perry-runtime/src/object.rs`): on first access, `js_get_global_this`'s CAS winner now calls `populate_global_this_builtins(singleton)`. Constructors (~50 names from the standard ECMA-262 list + Node / web platform globals) get a `ClosureHeader`-backed sentinel via `js_closure_alloc(global_this_builtin_noop_thunk, 0)`; namespaces (`Math` / `JSON` / `Reflect`) get a plain `js_object_alloc(0, 0)`. Each constructor closure carries a `prototype` dynamic property pointing at an empty ObjectHeader so the lodash `var arrayProto = Array.prototype` chained read sees a real pointer instead of throwing. The thunk itself is a deliberate no-op returning `undefined` — bare `new Array(n)` continues to flow through codegen's existing `lower_new` arm, so callers using the spec-canonical `new <Ident>(...)` shape are unaffected.
+
+2. **Codegen** (`crates/perry-codegen/src/expr.rs`): the `Expr::PropertyGet { GlobalGet(_), <name> }` arm now consults `is_global_this_builtin_name(<name>)` before falling through to the `0.0` placeholder. When the name matches, it routes the read through `js_get_global_this` + `js_object_get_field_by_name_f64` (same shape as the existing IndexGet arm at line ~2381 that handles `globalThis[<string>]` reads from #611). The `typeof PropertyGet { GlobalGet, X }` short-circuit gains a parallel arm: constructor names return `"function"`, the three namespace names stay `"object"`.
+
+**Why a closure, not a plain object?** `js_value_typeof` for pointer values walks the CLOSURE_MAGIC tag at offset 12 — closures report `"function"` for free, a regular `ObjectHeader` would report `"object"`. Picking a closure backing also future-proofs the call form (`globalThis.Array(3)` as a function-call rather than `new Array(3)`); right now the thunk is a no-op, but later PRs can make it dispatch into the right constructor without changing how callers see the value.
+
+**Caveats / known follow-ups.** The backing objects are *sentinels*, not the real constructors. Reading deep into them returns `undefined`:
+
+- `Array.prototype.toString` is `undefined` (real Node returns a function). lodash's `var funcToString = funcProto.toString; funcToString.call(Object)` therefore still throws — but at a later line than before. The blocker after this PR is `Cannot read properties of undefined (reading 'call')` from `lodash.js` line 1493 (`var objectCtorString = funcToString.call(Object)`), which needs real `Function.prototype.toString` support to clear.
+- `globalThis.Array === Array` is `false`. Bare `Array` still lowers to `Expr::GlobalGet(0)` → `0.0`; the singleton form returns a closure pointer. Unifying these would require widening Perry's first-class representation of built-in constructors (or rewriting bare `Array` to read off the singleton) — a separate, wider change.
+- `Math.PI` / `Number.MAX_SAFE_INTEGER` and the other static-resolution shapes are unchanged. The HIR-level constant fold in `expr_member.rs` (lines ~262-318) still fires before this codegen path is reached.
+
+**Validation.** `test-files/test_globalthis_builtins.ts` covers `typeof globalThis.{Array,Object,Function,Math,JSON}` + `Array.prototype` + `new Array(3).length` and matches `node --experimental-strip-types` byte-for-byte. The lodash `_.chunk([1,2,3,4], 2)` repro (`/tmp/perry-lodash-2`) still fails to load `_` at module init, but the throw point moved from `var arrayProto = Array.prototype` (line 1463) to `var objectCtorString = funcToString.call(Object)` (line 1493) — three property reads + one call deeper into `runInContext`.
+
 ## v0.5.978 — fix(crypto/jsruntime): bare named-import `randomFillSync(buf)` (and `randomUUID()` / `randomBytes(n)`) routes to native FFI + V8 fallback ESM re-export
 
 **Symptom.** `jose` (and any package that does `import { randomFillSync } from 'node:crypto'; randomFillSync(buf)`) silently produced all-zero buffers. v0.5.952 added `randomFillSync` to Perry's native crypto code path via `Expr::CryptoRandomFillSync` → `js_crypto_random_fill_sync`, but that HIR recogniser only fired for the **object-method** form `crypto.randomFillSync(...)` (in `expr_call.rs:3118`, gated on `is_crypto_module && member.prop == "randomFillSync"`). The **bare named-import** form `randomFillSync(buf)` fell through to the generic aliased-named-import arm (`expr_call.rs:6463`) which built `Expr::NativeMethodCall { module: "crypto", method: "randomFillSync", object: None, args: [buf] }`. The codegen `NativeMethodCall` dispatcher has no `crypto` arm, so it lowered to a no-op returning `undefined` — the buffer was never touched, and `jose` happily signed JWTs with all-zero IVs.
@@ -33,7 +64,6 @@ For Hint-1, `typeof === "object"` instead of `"function"` is the same `NativeMod
 **Out of scope (follow-ups).**
 - `Uint8Array.prototype.some` returning `undefined` is a separate typed-array method-dispatch gap; track separately.
 - The V8 fallback's `getRandomValues` polyfill in `node_polyfills.js` uses `Math.random()`-derived bytes and is NOT cryptographically secure — the V8 fallback path is for testing/diagnostics only. Real crypto strength is on the native FFI path that this PR also unblocks.
-
 ## v0.5.977 — fix(#957 followup): `Function('return this')()` + bare `RegExp(...)` recognisers — moves real lodash past module-init `TypeError: value is not a function`
 
 **Symptom.** PR #959 closed two of lodash's three module-init bugs (`.call(this)` IIFE bodies + `Expr::IndexUpdate` codegen) but the commit explicitly flagged the next gap: `import _ from "lodash"` still threw

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.978
+**Current Version:** 0.5.979
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.978"
+version = "0.5.979"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "base64",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5564,11 +5564,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.978"
+version = "0.5.979"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "itoa",
  "jni",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "block2",
  "libc",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "block2",
  "libc",
@@ -5645,11 +5645,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.978"
+version = "0.5.979"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "block2",
  "libc",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "block2",
  "libc",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "block2",
  "libc",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.978"
+version = "0.5.979"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.978"
+version = "0.5.979"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -1168,8 +1168,21 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         // (Buffer, Promise, URL, etc.) intentionally fall
                         // through so `typeof Buffer === "function"` keeps
                         // working through the existing class-ref path.
+                        //
+                        // lodash followup: built-in constructors exposed on
+                        // globalThis (`Array`, `Object`, `Function`, …) now
+                        // also lower the bare PropertyGet to a real value
+                        // (a backing-object pointer materialized by
+                        // `js_get_global_this`'s singleton populator).
+                        // Without the typeof short-circuit, `typeof
+                        // globalThis.Array` would read "object" (the value
+                        // is a real pointer); spec says "function". Math /
+                        // JSON / Reflect stay "object" — they're namespaces,
+                        // not constructors.
                         match property.as_str() {
                             "process" | "console" | "globalThis" | "performance" => Some("object"),
+                            "Math" | "JSON" | "Reflect" => Some("object"),
+                            n if is_global_this_builtin_function_name(n) => Some("function"),
                             _ => None,
                         }
                     } else {
@@ -3808,6 +3821,37 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         vec![],
                     ));
                     return Ok(ctx.block().call(DOUBLE, "js_console_log_as_closure", &[]));
+                }
+                // Built-in constructors / namespaces exposed on globalThis
+                // (`Array`, `Object`, `Math`, `JSON`, ...): route the read
+                // through the singleton so `globalThis.Array` (and the
+                // identical `(globalThis as any).X` shape) returns the
+                // pre-populated constructor backing-object instead of the
+                // `0.0` no-value placeholder. Mirrors the IndexGet arm above
+                // (Expr::IndexGet at ~2381) which already routes
+                // `globalThis[<string>]` through `js_get_global_this`. The
+                // runtime populates these on first init — see
+                // `populate_global_this_builtins` in
+                // crates/perry-runtime/src/object.rs. Unblocks lodash's
+                // `runInContext` (`var Array = context.Array; var arrayProto
+                // = Array.prototype`) — the prior `0.0` placeholder caused
+                // the `.prototype` chained read on the locally-bound
+                // alias to throw `Cannot read properties of undefined`.
+                if is_global_this_builtin_name(property) {
+                    let global_box = ctx.block().call(DOUBLE, "js_get_global_this", &[]);
+                    let key_idx = ctx.strings.intern(property);
+                    let key_handle_global =
+                        format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                    let blk = ctx.block();
+                    let obj_handle = unbox_to_i64(blk, &global_box);
+                    let key_box = blk.load(DOUBLE, &key_handle_global);
+                    let key_bits = blk.bitcast_double_to_i64(&key_box);
+                    let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+                    return Ok(blk.call(
+                        DOUBLE,
+                        "js_object_get_field_by_name_f64",
+                        &[(I64, &obj_handle), (I64, &key_raw)],
+                    ));
                 }
                 return Ok(double_literal(0.0));
             }
@@ -13536,6 +13580,84 @@ fn lower_js_args_array(ctx: &mut FnCtx<'_>, lowered_args: &[String]) -> (String,
 pub(crate) fn unbox_to_i64(blk: &mut LlBlock, boxed: &str) -> String {
     let bits = blk.bitcast_double_to_i64(boxed);
     blk.and(I64, &bits, POINTER_MASK_I64)
+}
+
+/// Built-in constructor / namespace names that the runtime pre-populates
+/// on the globalThis singleton (`populate_global_this_builtins` in
+/// crates/perry-runtime/src/object.rs). Used by codegen to decide whether
+/// `globalThis.<Name>` should route through `js_get_global_this`
+/// (returning the populated backing-object) or fall through to the `0.0`
+/// no-value placeholder. Keep this list in sync with
+/// `GLOBAL_THIS_BUILTIN_CONSTRUCTORS` + `GLOBAL_THIS_BUILTIN_NAMESPACES`
+/// in object.rs — the codegen check and the runtime population together
+/// implement the lodash `runInContext` blocker fix.
+pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
+    matches!(
+        name,
+        // Constructors (typeof === "function" in spec).
+        "Array"
+            | "Object"
+            | "String"
+            | "Number"
+            | "Boolean"
+            | "Function"
+            | "RegExp"
+            | "Date"
+            | "Error"
+            | "TypeError"
+            | "RangeError"
+            | "SyntaxError"
+            | "ReferenceError"
+            | "EvalError"
+            | "URIError"
+            | "Symbol"
+            | "Promise"
+            | "Map"
+            | "Set"
+            | "WeakMap"
+            | "WeakSet"
+            | "WeakRef"
+            | "Proxy"
+            | "BigInt"
+            | "Uint8Array"
+            | "Int8Array"
+            | "Uint16Array"
+            | "Int16Array"
+            | "Uint32Array"
+            | "Int32Array"
+            | "Float32Array"
+            | "Float64Array"
+            | "Uint8ClampedArray"
+            | "BigInt64Array"
+            | "BigUint64Array"
+            | "ArrayBuffer"
+            | "SharedArrayBuffer"
+            | "DataView"
+            | "TextEncoder"
+            | "TextDecoder"
+            | "URL"
+            | "URLSearchParams"
+            | "AbortController"
+            | "AbortSignal"
+            | "FormData"
+            | "Headers"
+            | "Request"
+            | "Response"
+            | "FinalizationRegistry"
+            // Namespaces (typeof === "object" in spec).
+            | "Math"
+            | "JSON"
+            | "Reflect"
+    )
+}
+
+/// Subset of `is_global_this_builtin_name` whose `typeof` is `"function"`
+/// in spec (constructors). Used by the `Expr::TypeOf` short-circuit so
+/// `typeof globalThis.Array === "function"`. Math/JSON/Reflect are
+/// namespaces — they keep `typeof === "object"` via the existing match
+/// arms.
+pub(crate) fn is_global_this_builtin_function_name(name: &str) -> bool {
+    is_global_this_builtin_name(name) && !matches!(name, "Math" | "JSON" | "Reflect")
 }
 
 /// SSO-safe variant of `unbox_to_i64` for NaN-boxed string operands.

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -9776,11 +9776,164 @@ pub extern "C" fn js_get_global_this() -> f64 {
         // both threads see the winner's pointer afterward via CAS.
         let new_ptr = js_object_alloc(0, 0) as i64;
         match GLOBAL_THIS_PTR.compare_exchange(0, new_ptr, Ordering::AcqRel, Ordering::Acquire) {
-            Ok(_) => new_ptr,
+            Ok(_) => {
+                // Winner: populate built-in constructor properties on the
+                // singleton so `globalThis.Array` / `context.Array` (lodash's
+                // `runInContext` pattern) return non-undefined values. Each
+                // value is a tiny ObjectHeader carrying a `prototype` field
+                // pointing at another empty object — enough that
+                // `var arrayProto = Array.prototype` doesn't throw and the
+                // chained `.toString` reads return undefined rather than
+                // tripping the "Cannot read properties of undefined" gate at
+                // module-init time. Full constructor dispatch on these
+                // sentinels still falls through to existing code paths (bare
+                // `new Array(n)` continues to work through `lower_new`); the
+                // goal here is just to unblock libraries that read the
+                // constructors off `globalThis` as values. Refs lodash
+                // `runInContext` blocker after PR #963.
+                populate_global_this_builtins(new_ptr as *mut ObjectHeader);
+                new_ptr
+            }
             Err(other) => other,
         }
     };
     crate::value::js_nanbox_pointer(ptr)
+}
+
+/// JS built-in constructor names exposed on `globalThis`. Pre-populated by
+/// the singleton init in `js_get_global_this` so libraries that read these
+/// off the global (lodash's `var Array = context.Array; var arrayProto =
+/// Array.prototype`, the same `(globalThis as any).X` read shape) see a
+/// non-undefined backing object. Codegen mirrors this list in
+/// `perry-codegen/src/expr.rs::is_global_this_builtin_name` to decide when
+/// `globalThis.<Name>` should route through the singleton instead of the
+/// legacy `0.0` no-value placeholder.
+pub(crate) const GLOBAL_THIS_BUILTIN_CONSTRUCTORS: &[&str] = &[
+    "Array",
+    "Object",
+    "String",
+    "Number",
+    "Boolean",
+    "Function",
+    "RegExp",
+    "Date",
+    "Error",
+    "TypeError",
+    "RangeError",
+    "SyntaxError",
+    "ReferenceError",
+    "EvalError",
+    "URIError",
+    "Symbol",
+    "Promise",
+    "Map",
+    "Set",
+    "WeakMap",
+    "WeakSet",
+    "WeakRef",
+    "Proxy",
+    "BigInt",
+    "Uint8Array",
+    "Int8Array",
+    "Uint16Array",
+    "Int16Array",
+    "Uint32Array",
+    "Int32Array",
+    "Float32Array",
+    "Float64Array",
+    "Uint8ClampedArray",
+    "BigInt64Array",
+    "BigUint64Array",
+    "ArrayBuffer",
+    "SharedArrayBuffer",
+    "DataView",
+    "TextEncoder",
+    "TextDecoder",
+    "URL",
+    "URLSearchParams",
+    "AbortController",
+    "AbortSignal",
+    "FormData",
+    "Headers",
+    "Request",
+    "Response",
+    "FinalizationRegistry",
+];
+
+/// JS built-in namespaces (typeof === "object", not "function"). Same
+/// shape on the singleton — a backing object with `prototype` so chained
+/// reads degrade gracefully — but typeof reports "object".
+pub(crate) const GLOBAL_THIS_BUILTIN_NAMESPACES: &[&str] = &["Math", "JSON", "Reflect"];
+
+/// No-op thunk used as the function body for the singleton globalThis
+/// built-in constructor values. Lets `globalThis.Array` carry a real
+/// ClosureHeader (so `typeof globalThis.Array === "function"`) without
+/// implementing actual constructor dispatch through this path — bare
+/// `new Array(n)` continues to flow through codegen's `lower_new` arm and
+/// the runtime `js_array_alloc` machinery, so callers that follow the
+/// usual `new <Ident>(...)` pattern are unaffected. Calling these
+/// sentinels directly (e.g. `globalThis.Array(3)`) returns undefined —
+/// best-effort no-op rather than throwing — and is a known gap for
+/// libraries that rely on call-form constructors after re-binding the
+/// global to a local.
+extern "C" fn global_this_builtin_noop_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    _arg: f64,
+) -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// Populate the freshly-allocated globalThis singleton with built-in
+/// constructor / namespace properties. Called exactly once from the CAS
+/// winner in `js_get_global_this`. Constructors get a ClosureHeader-
+/// backed value so `typeof globalThis.Array === "function"`; namespaces
+/// (`Math`, `JSON`, `Reflect`) get a plain ObjectHeader (`typeof ===
+/// "object"`). Both shapes carry a `prototype` dynamic property pointing
+/// at an empty object so `<Builtin>.prototype` reads return a real
+/// pointer instead of undefined, which is what unblocks lodash's
+/// `var arrayProto = Array.prototype` chained read inside
+/// `runInContext`.
+fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
+    if singleton.is_null() {
+        return;
+    }
+    let proto_key_bytes = b"prototype";
+    let proto_key =
+        crate::string::js_string_from_bytes(proto_key_bytes.as_ptr(), proto_key_bytes.len() as u32);
+    // Constructors: ClosureHeader-backed so typeof is "function".
+    for name in GLOBAL_THIS_BUILTIN_CONSTRUCTORS.iter().copied() {
+        let closure_ptr =
+            crate::closure::js_closure_alloc(global_this_builtin_noop_thunk as *const u8, 0);
+        if closure_ptr.is_null() {
+            continue;
+        }
+        // Stash `prototype` on the closure's dynamic-prop side table.
+        // `js_object_set_field_by_name` detects the CLOSURE_MAGIC tag
+        // at offset 12 and dispatches into `closure_set_dynamic_prop`
+        // for us; both reads and writes share that side table.
+        let proto_obj = js_object_alloc(0, 0);
+        if !proto_obj.is_null() {
+            let proto_value = crate::value::js_nanbox_pointer(proto_obj as i64);
+            js_object_set_field_by_name(closure_ptr as *mut ObjectHeader, proto_key, proto_value);
+        }
+        let name_bytes = name.as_bytes();
+        let name_key =
+            crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);
+        let ctor_value = crate::value::js_nanbox_pointer(closure_ptr as i64);
+        js_object_set_field_by_name(singleton, name_key, ctor_value);
+    }
+    // Namespaces: plain ObjectHeader so typeof is "object" per spec.
+    for name in GLOBAL_THIS_BUILTIN_NAMESPACES.iter().copied() {
+        let ns_obj = js_object_alloc(0, 0);
+        if ns_obj.is_null() {
+            continue;
+        }
+        let name_bytes = name.as_bytes();
+        let name_key =
+            crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);
+        let ns_value = crate::value::js_nanbox_pointer(ns_obj as i64);
+        js_object_set_field_by_name(singleton, name_key, ns_value);
+    }
 }
 
 /// Object.getOwnPropertyNames(obj) — returns all own property names (including non-enumerable).

--- a/test-files/test_globalthis_builtins.ts
+++ b/test-files/test_globalthis_builtins.ts
@@ -1,0 +1,27 @@
+// Built-in constructor reads via `globalThis` — unblocks lodash's
+// `runInContext` factory which binds `var Array = context.Array; var
+// arrayProto = Array.prototype` and similar pre-ES6 patterns. Pre-fix
+// these reads returned `undefined`, so the chained `.prototype` access
+// threw `TypeError: Cannot read properties of undefined`.
+const ArrayRef = globalThis.Array;
+const ObjectRef = globalThis.Object;
+const FunctionRef = globalThis.Function;
+console.log(typeof ArrayRef);
+console.log(typeof ObjectRef);
+console.log(typeof FunctionRef);
+console.log(typeof globalThis.Math);
+console.log(typeof globalThis.JSON);
+
+// `.prototype` reads on the locally-bound aliases must return an
+// object (the singleton populator stashes an empty object under
+// `prototype` for each constructor); pre-fix this read threw because
+// the alias was `undefined`. Chained `.toString` etc. still return
+// `undefined` rather than the real method — best-effort enough that
+// lodash's `var funcToString = funcProto.toString` no longer throws.
+const arrayProto = ArrayRef.prototype;
+console.log(typeof arrayProto);
+
+// Bare `new Array(n)` still flows through codegen's `lower_new` arm —
+// the singleton constructor sentinels don't intercept this path.
+const arr = new Array(3);
+console.log(arr.length);


### PR DESCRIPTION
## Summary

- Populate the `globalThis` singleton with built-in constructor properties on first init so `globalThis.Array` / `context.Object` (lodash's `runInContext` pattern) no longer return `undefined`.
- Route `Expr::PropertyGet { GlobalGet(_), <Builtin> }` through `js_get_global_this` + `js_object_get_field_by_name_f64` so the static AST shape sees the same populated singleton (mirrors the IndexGet arm added in #611).
- Constructors get a `ClosureHeader`-backed sentinel (`typeof === "function"` via the existing CLOSURE_MAGIC tag); `Math` / `JSON` / `Reflect` get a plain `ObjectHeader` (`typeof === "object"`). Each constructor carries a `prototype` dynamic property pointing at an empty backing object so `<Builtin>.prototype` reads don't trip the spec-shaped `TypeError: Cannot read properties of undefined`.

Follows PR #963 (v0.5.977) which closed the `Function('return this')()` IIFE recogniser. Today's blocker for `import _ from "lodash"` was the next line down — `var Array = context.Array; var arrayProto = Array.prototype` — because the built-in constructors were never registered as properties on the singleton.

## Test plan

- [x] `test-files/test_globalthis_builtins.ts` — byte-for-byte parity with `node --experimental-strip-types` for `typeof globalThis.{Array,Object,Function,Math,JSON}` + `Array.prototype` + `new Array(3).length`.
- [x] lodash repro: `_.chunk([1,2,3,4], 2)` still fails to load `_`, but the throw point advanced from `lodash.js:1463` (`var arrayProto = Array.prototype`) to `lodash.js:1493` (`funcToString.call(Object)`). The new blocker needs real `Function.prototype.toString` support — tracked alongside the broader lodash compile-as-package work.

## Caveats

- The backing objects are *sentinels*, not the real constructors. `Array.prototype.toString === undefined` (Node returns a function).
- `globalThis.Array === Array` is `false`. Bare `Array` still lowers to `Expr::GlobalGet(0)`; the singleton form returns a closure pointer. Unifying these requires widening Perry's first-class representation of built-in constructors.
- Bare `new Array(n)` is unaffected — it flows through `lower_new` like before. The thunk underneath each sentinel is a no-op returning `undefined`, so `globalThis.Array(3)` as a *call* (not a `new`) returns `undefined` rather than constructing an array (best-effort, known gap).

## Version

- `Cargo.toml` `[workspace.package].version` → `0.5.978`
- `CLAUDE.md` `**Current Version:**` → `0.5.978`
- `CHANGELOG.md` — prepended `## v0.5.978 — feat(globalThis): ...` block with full context