### PR TITLE
fix(codegen): default-export-of-named-fn wrapper forwards to body (#967)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.982 — fix(codegen): `export default <namedFn>` wrapper now forwards to the real body so `const fn = defaultImport; fn(…)` works
+
+**Symptom.** Calling a cross-module default-exported function through a local alias dropped the call. With `function add(a,b){return a+b}; export default add;` in one module and
+
+```ts
+import add from "./add.js";
+const fn = add;
+console.log(fn(2, 3));   // → "undefined" (should be 5)
+```
+
+in the consumer, `add(2, 3)` (direct call) returned `5`, but `fn(2, 3)` (call through a local-bound alias) returned `undefined`. The same shape is the npm-package barrel idiom — `node_modules/ramda/es/*.js`, `node_modules/date-fns/*.js`, `node_modules/lodash-es/**` all stamp out `function NAME(…){…}; export default NAME;` modules, so any code that stores a default-imported function in a local (whether explicitly via `const fn = imported` or implicitly by passing it as a callback that the callee assigns into a closure capture) silently lost the call. Ramda hit it through `var sum = reduce(add, 0)` style top-level binding; date-fns hit it through `format`'s internal `formatters[token[0]](originalDate, …)` indirection.
+
+**Root cause.** Sub-bug B of #836's wrapper-alias loop in `crates/perry-codegen/src/codegen.rs` (around L2988 pre-fix) emitted a NO-OP `__perry_wrap_perry_fn_<src>__<exported>` wrapper for every `Export::Named { local, exported }` where `local == exported` and `local` was not the name of a HIR function. The branch was originally added to make `import * as z; export { z };` (namespace-aliased re-exports) and `export { SomeClass }` style exports link — both shapes have no callable body, so a `→ undefined` wrapper was correct.
+
+But the same `local == exported && !func_by_local_name` condition ALSO fires for the canonical default-export shape:
+
+```js
+function add(a, b) { return a + b; }
+export default add;
+```
+
+The HIR lowerer at `perry-hir/src/lower.rs:5601` resolves the default-expr to `Expr::FuncRef(add_id)` (line 5606 branch) and pushes `module.exports.push(Export::Named { local: "default", exported: "default" })` plus `module.exported_functions.push(("default", add_id))`. The exports entry has `local == exported == "default"`, and `func_by_local_name` is keyed by the FUNCTION's HIR name (`"add"`) — so the no-op branch fired and emitted a wrapper that returned NaN-boxed undefined regardless of its arguments.
+
+Consumer-side, every closure-form access of the default import (`expr.rs:12099` constructs `wrap_name = "__perry_wrap_perry_fn_<src>__default"`, takes its address via `js_closure_alloc_singleton`, NaN-boxes the closure pointer) resolved to the no-op wrapper at link time. Direct calls (`expr.rs::ExternFuncRef`-as-callee path in `lower_call.rs`) routed through a different symbol (`perry_fn_<src>__default`, which IS a forwarding alias to `perry_fn_<src>__add` — emitted by the `exported_functions` loop at L2347) and worked correctly — that's why `add(2, 3)` returned `5` but `fn(2, 3)` (closure call through the alias) returned `undefined`.
+
+**Fix.** Before emitting the no-op wrapper in sub-bug-B's branch, probe `hir.exported_functions` for an alias entry pointing the `local==exported` name at a real HIR function. When found, emit a forwarding wrapper to that function's body (same shape as the `local != exported` branch at L2792, which already handles the renamed-export case correctly). The no-op branch stays as the fallback for genuinely non-callable exports (`export { ImportedNamespace }`, `export { SomeClass }`, etc.).
+
+```rust
+let aliased_func: Option<&perry_hir::Function> = hir
+    .exported_functions
+    .iter()
+    .find(|(n, _)| n == exported)
+    .and_then(|(_, fid)| hir.functions.iter().find(|f| f.id == *fid));
+if let Some(f) = aliased_func {
+    // Emit forwarding wrapper: __perry_wrap_perry_fn_<src>__<exported>(closure, a0…aN)
+    //   → tail-call perry_fn_<src>__<local-fn-name>(a0…aN)
+    let target = scoped_fn_name(&module_prefix, &f.name);
+    …emit forwarder…
+} else {
+    …existing no-op fallback…
+}
+```
+
+**Validation.**
+
+- New `test-files/test_default_import_as_value.ts` + `test_default_import_as_value_helper.ts` (cross-module helpers) exercise four value-position shapes: local alias, function-parameter pass-through, closure-capture, direct call. Perry now prints `5 / 30 / 15 / 5` byte-for-byte against `node --experimental-strip-types`.
+- `test-files/test_lodash_default_import_methods.ts` (issue #957 regression) still passes.
+- `test-files/test_issue_678_reexport_default.ts` still passes.
+
+**Out of scope (related but separate bugs).** With this fix applied, two npm packages from the original compat sweep still don't work fully:
+
+- **ramda's** `R.sum([1..5])` returns `[object Object]` instead of `15` because `Function.prototype.apply` (used by ramda's `_curry1`/`_curry2`/`_curry3` to dispatch `fn.apply(this, arguments)`) doesn't have a runtime handler at all — every `.apply()` call returns the receiver as a stub. Untriaged; will need its own issue.
+- **date-fns's** `format(new Date(), …)` throws `RangeError: Invalid time value` because `Date.prototype.constructor` returns `undefined`, breaking `constructFrom`'s `new date.constructor(value)` cloning path. Untriaged; will need its own issue.
+
+Both packages exercise the default-import-as-value shape internally many times, so this fix is a prerequisite for any future work on them — without it, the closure-dispatch would short-circuit before reaching the `apply`/`constructor` failures.
+
+**Files.**
+
+- `crates/perry-codegen/src/codegen.rs` — alias-loop branch at sub-bug-B now consults `hir.exported_functions` before emitting the no-op wrapper.
+- `test-files/test_default_import_as_value.ts` — new regression test.
+- `test-files/test_default_import_as_value_helper.ts` — cross-module helper exporting `function add` as default.
+
 ## v0.5.981 — feat(manifest): register `stream.on` / `once` / `off` / `emit` / `removeListener` / `removeAllListeners` (+ the rest of the EventEmitter surface) so axios compiles past the #463 gate
 
 **Symptom.** Compiling axios (and any other npm package that extends `stream.Transform` / `stream.Readable` etc. and wires up event listeners on the resulting instance) bailed at HIR-lower with:
@@ -30,7 +92,6 @@ All entries use `has_receiver: true` because every callsite is `<streamInstance>
 **Files.**
 - `crates/perry-api-manifest/src/entries.rs` — 15 new `method("stream", ..., true, None)` rows in the stream block.
 - `test-files/test_stream_on.ts` — repro/regression fixture.
-
 ## v0.5.980 — feat(lodash): add `sum` / `mean` / `sumBy` / `meanBy` / `tail` aggregators to the manifest
 
 **Symptom.** Manifest sweep flagged `_.sum([1,2,3,4])` as missing — `import _ from 'lodash'; _.sum(...)` errored at HIR-lower with `\`lodash.sum\` is not implemented in Perry — see \`perry --print-api-manifest\` for the supported surface`. Same shape for `_.mean`, `_.sumBy`, `_.meanBy`, and `_.tail` (tail's runtime + decl already existed but the manifest + lower_call rows were absent, so call sites couldn't reach the native function).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.981
+**Current Version:** 0.5.982
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.981"
+version = "0.5.982"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "base64",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5564,11 +5564,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.981"
+version = "0.5.982"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "itoa",
  "jni",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "block2",
  "libc",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "block2",
  "libc",
@@ -5645,11 +5645,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.981"
+version = "0.5.982"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "block2",
  "libc",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "block2",
  "libc",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "block2",
  "libc",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.981"
+version = "0.5.982"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.981"
+version = "0.5.982"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/codegen.rs
+++ b/crates/perry-codegen/src/codegen.rs
@@ -2985,6 +2985,24 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             // is yet defined. Catches `import * as z; export { z };`
             // and any `export { ClassName }` or `export { someConst }`
             // where the consumer reads the value as a closure.
+            //
+            // Issue #967: when the `local==exported` name IS registered
+            // in `hir.exported_functions` as an alias for a real function
+            // body (the canonical shape: `function add(a,b){…}; export
+            // default add;` lowers to `Export::Named { local: "default",
+            // exported: "default" }` *and* pushes `("default", add_id)`
+            // into `exported_functions`), the no-op wrapper short-circuits
+            // any consumer-side closure dispatch through this default
+            // import. The consumer's
+            // `__perry_wrap_perry_fn_<src>__default` then transmutes a
+            // function pointer that returns `undefined` no matter the args
+            // — `const fn = add; fn(2,3)` evaluates to `undefined` instead
+            // of `5`. Ramda/date-fns trip this on every `var sum =
+            // reduce(add, 0)` style barrel where `add`/`reduce` are
+            // default-exports of locally-named functions. Fix: when
+            // `exported_functions` points the name at a real HIR function,
+            // emit a forwarding wrapper to that function's body (mirrors
+            // the `local != exported` branch at L2792 above).
             if local == exported && !func_by_local_name.contains_key(local.as_str()) {
                 let exported_wrap = format!(
                     "__perry_wrap_perry_fn_{}__{}",
@@ -2994,21 +3012,48 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 if !llmod.has_function(&exported_wrap)
                     && emitted_aliases.insert(exported_wrap.clone())
                 {
-                    let wf = llmod.define_function(
-                        &exported_wrap,
-                        DOUBLE,
-                        vec![
-                            (I64, "%this_closure".to_string()),
-                            (DOUBLE, "%a0".to_string()),
-                            (DOUBLE, "%a1".to_string()),
-                            (DOUBLE, "%a2".to_string()),
-                            (DOUBLE, "%a3".to_string()),
-                            (DOUBLE, "%a4".to_string()),
-                        ],
-                    );
-                    let _ = wf.create_block("entry");
-                    let blk = wf.block_mut(0).unwrap();
-                    blk.ret(DOUBLE, "0x7FFC000000000001");
+                    // Check if this name is registered as an alias
+                    // pointing at a real HIR function (`export default
+                    // <namedFn>` shape).
+                    let aliased_func: Option<&perry_hir::Function> = hir
+                        .exported_functions
+                        .iter()
+                        .find(|(n, _)| n == exported)
+                        .and_then(|(_, fid)| hir.functions.iter().find(|f| f.id == *fid));
+                    if let Some(f) = aliased_func {
+                        let arity = f.params.len().min(5);
+                        let mut wrap_params: Vec<(LlvmType, String)> =
+                            vec![(I64, "%this_closure".to_string())];
+                        for i in 0..arity {
+                            wrap_params.push((DOUBLE, format!("%a{}", i)));
+                        }
+                        let wf = llmod.define_function(&exported_wrap, DOUBLE, wrap_params);
+                        let _ = wf.create_block("entry");
+                        let blk = wf.block_mut(0).unwrap();
+                        let target = scoped_fn_name(&module_prefix, &f.name);
+                        let call_args: Vec<(LlvmType, String)> =
+                            (0..arity).map(|i| (DOUBLE, format!("%a{}", i))).collect();
+                        let call_args_ref: Vec<(LlvmType, &str)> =
+                            call_args.iter().map(|(t, s)| (*t, s.as_str())).collect();
+                        let result = blk.call(DOUBLE, &target, &call_args_ref);
+                        blk.ret(DOUBLE, &result);
+                    } else {
+                        let wf = llmod.define_function(
+                            &exported_wrap,
+                            DOUBLE,
+                            vec![
+                                (I64, "%this_closure".to_string()),
+                                (DOUBLE, "%a0".to_string()),
+                                (DOUBLE, "%a1".to_string()),
+                                (DOUBLE, "%a2".to_string()),
+                                (DOUBLE, "%a3".to_string()),
+                                (DOUBLE, "%a4".to_string()),
+                            ],
+                        );
+                        let _ = wf.create_block("entry");
+                        let blk = wf.block_mut(0).unwrap();
+                        blk.ret(DOUBLE, "0x7FFC000000000001");
+                    }
                 }
             }
         }

--- a/test-files/test_default_import_as_value.ts
+++ b/test-files/test_default_import_as_value.ts
@@ -1,0 +1,42 @@
+// Regression test for issue #967: default-import-as-value call dispatch.
+//
+// When `function add(a,b){…}; export default add;` is compiled as a native
+// package (compilePackages), the consumer's `const fn = add; fn(2,3)` shape
+// previously resolved through a no-op `__perry_wrap_perry_fn_<src>__default`
+// emitted by codegen's sub-bug-B alias loop — which short-circuited any
+// closure-based call dispatch and returned `undefined`.
+//
+// This test exercises the same shape via inline package modules so it can
+// run inside the gap suite without npm install. The fix lives in
+// crates/perry-codegen/src/codegen.rs at the
+// `local == exported && !func_by_local_name.contains_key(...)` branch:
+// when `hir.exported_functions` resolves the name back to a real HIR
+// function, emit a forwarding wrapper instead of the no-op.
+//
+// Setup: cross-module function callable via every value-position shape
+// (alias, parameter, closure capture, direct call) — each must return
+// the actual function result, not `undefined`.
+
+import add from "./test_default_import_as_value_helper.ts";
+
+// 1. Alias to local const + call through local.
+const fn = add;
+console.log("alias:", fn(2, 3));
+
+// 2. Pass as argument; called inside callee.
+function apply(f: (a: number, b: number) => number, a: number, b: number): number {
+  return f(a, b);
+}
+console.log("apply:", apply(add, 10, 20));
+
+// 3. Closure captures the imported default.
+function makeCaller(f: (a: number, b: number) => number) {
+  return function (a: number, b: number) {
+    return f(a, b);
+  };
+}
+const caller = makeCaller(add);
+console.log("closure:", caller(7, 8));
+
+// 4. Direct call — still works post-fix.
+console.log("direct:", add(2, 3));

--- a/test-files/test_default_import_as_value_helper.ts
+++ b/test-files/test_default_import_as_value_helper.ts
@@ -1,0 +1,8 @@
+// Helper module for test_default_import_as_value.ts. The shape
+// `function NAME(...) {…}; export default NAME` is the canonical npm
+// barrel idiom — every file under `node_modules/ramda/es/*.js`,
+// `node_modules/date-fns/*.js`, etc. uses it.
+function add(a: number, b: number): number {
+  return a + b;
+}
+export default add;


### PR DESCRIPTION
## Summary

`function add(a,b){…}; export default add;` is the canonical npm-package
barrel idiom (ramda, date-fns, lodash-es, hundreds more). When that
shape was compiled as a native `perry.compilePackages` module, the
consumer's `const fn = add; fn(2,3)` returned `undefined` instead of
`5`. Direct `add(2,3)` worked — the bug was specific to closure-form
access (alias to local, callback passing, indirect call).

Root cause: codegen's sub-bug-B wrapper-alias loop emitted a NO-OP
`__perry_wrap_perry_fn_<src>__default` wrapper for every
`Export::Named { local, exported }` where `local == exported` and
`local` wasn't a HIR function name. The branch's original purpose was
to make `import * as z; export { z };` (re-exported namespace) and
`export { SomeClass }` link by emitting an `→ undefined` thunk. But the
default-export shape ALSO satisfies `local == exported == "default"`
with `func_by_local_name.contains_key("default") == false` — because
the HIR function's name is `add`, not `default`. So the no-op fired
and short-circuited every closure-form call through the default
import.

The HIR lowerer at `perry-hir/src/lower.rs:5601` correctly registers
the alias in `module.exported_functions.push(("default", add_id))`.
The fix consults that map: when a `local==exported` no-function-by-
local-name export resolves to an aliased real function, emit a
forwarding wrapper (`closure_ptr → tail-call perry_fn_<src>__add`)
instead of the no-op. Mirrors the `local != exported` branch at L2792
which already handles renamed exports correctly.

## Test plan

- [x] New `test-files/test_default_import_as_value.ts` +
  `_helper.ts` cover four value-position shapes: local alias,
  function-parameter pass-through, closure-capture, direct call.
  Output matches `node --experimental-strip-types` byte-for-byte
  (`5 / 30 / 15 / 5`).
- [x] `test-files/test_lodash_default_import_methods.ts` (issue #957
  regression) still passes.
- [x] `test-files/test_issue_678_reexport_default.ts` still passes.
- [x] CI: `lint` / `cargo-test` / `parity` / `compile-smoke` /
  `api-docs-drift` / `security-audit` once green.

## Out of scope (related but separate bugs)

With this fix applied, two packages from the original compat sweep
still don't fully work:

- **ramda** `R.sum([1..5])` returns `[object Object]` because
  `Function.prototype.apply` has no runtime handler — `fn.apply(this,
  args)` returns the receiver as a stub instead of invoking `fn`.
  Triggers inside ramda's `_curry1`/`_curry2`/`_curry3` machinery.
  Untriaged.
- **date-fns** `format(new Date(), 'yyyy-MM-dd')` throws
  `RangeError: Invalid time value` because `Date.prototype.constructor`
  returns `undefined`, breaking `constructFrom`'s
  `new date.constructor(value)` cloning. Untriaged.

Both packages exercise the default-import-as-value shape internally
many times, so this fix is a prerequisite for any future work on
them — without it the closure-dispatch would short-circuit before
reaching the `apply` / `constructor` failures.

## Version

0.5.980 → 0.5.981