### PR TITLE
feat(runtime): Function.prototype.apply + .call dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.983 — feat(runtime): `Function.prototype.apply` + `Function.prototype.call` dispatch
+
+**Symptom.** `add.apply(null, [2, 3])` and `add.call(null, 2, 3)` both returned an opaque `[object Object]` stub instead of `5`. The dynamic method-dispatch path (`js_native_call_method` in `crates/perry-runtime/src/object.rs`) had a `bind` arm and the closure dynamic-prop lookup, but no `apply` / `call` arms — so any `fn.apply(thisArg, argsArr)` / `fn.call(thisArg, …)` on a closure receiver fell through the `is_closure` branch and returned the `NULL_OBJECT_BYTES` stub. This is what blocked ramda end-to-end: `_curry1`, `_curry2`, `_curry3` all wrap their bodies in `fn.apply(this, arguments)`, so the very first call to any curried export (`R.sum`, `R.add`, etc.) returned a stub instead of the dispatch result.
+
+**Fix.** Two complementary changes:
+
+1. `crates/perry-runtime/src/object.rs::js_native_call_method` — new `"call"` and `"apply"` arms, guarded on `jsval.is_pointer() && is_closure_ptr(raw_ptr)`. Both rebind `IMPLICIT_THIS` to the first arg, restore it on return, and dispatch through `js_native_call_value`:
+   - `call(thisArg, …rest)` → pass `&args_ptr[1..]` (length `args_len-1`) as positional args.
+   - `apply(thisArg, argsArr)` → if `argsArr` is a pointer to `ArrayHeader`, copy the elements into a `Vec<f64>` and forward; treat `null`/`undefined`/non-array as zero args.
+
+2. `crates/perry-hir/src/lower_decl.rs` — skip TypeScript `this:` type-only annotations at the two `FnDecl` parameter-lowering sites (top-level and nested-decl-inside-function). The `expr_function.rs` site already skipped these per `#915`, but the `lower_decl.rs` sites still treated `function greet(this: …, prefix)` as a 2-arg function, shifting every real param by one. Without this, `greet.call({name:'Bob'}, 'Hi')` bound `prefix=undefined` because the runtime call passed `'Hi'` into the synthetic `this` slot.
+
+**Verification.** `test-files/test_function_apply_call.ts` — 7 assertions covering plain `apply`/`call`, multiple invocations, `this`-rebinding on a method with a TS `this:` annotation, and method calls on arrow functions. All match Node byte-for-byte.
+
+**Ramda status.** Compile succeeds (≈2.6 MB binary). Execution still throws `TypeError: Cannot read properties of undefined (reading 'call')` during ramda's module init — a deeper issue distinct from this fix (likely CommonJS `require()` resolution returning `undefined` for an internal helper before ramda's bootstrap `.call()`s through it). Tracked as the next blocker.
+
 ## v0.5.982 — fix(codegen): `export default <namedFn>` wrapper now forwards to the real body so `const fn = defaultImport; fn(…)` works
 
 **Symptom.** Calling a cross-module default-exported function through a local alias dropped the call. With `function add(a,b){return a+b}; export default add;` in one module and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.982
+**Current Version:** 0.5.983
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.982"
+version = "0.5.983"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "base64",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5564,11 +5564,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.982"
+version = "0.5.983"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "itoa",
  "jni",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "block2",
  "libc",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "block2",
  "libc",
@@ -5645,11 +5645,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.982"
+version = "0.5.983"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "block2",
  "libc",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "block2",
  "libc",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "block2",
  "libc",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.982"
+version = "0.5.983"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.982"
+version = "0.5.983"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-hir/src/lower_decl.rs
+++ b/crates/perry-hir/src/lower_decl.rs
@@ -378,10 +378,20 @@ pub(crate) fn lower_fn_decl(ctx: &mut LoweringContext, fn_decl: &ast::FnDecl) ->
             .unwrap_or(false);
 
     // Lower parameters with type extraction (using context for type param resolution)
+    //
+    // Mirrors the `expr_function.rs` site: TypeScript's `this: T` is a
+    // TYPE-only marker (SWC emits it as a regular `Param { pat: Ident("this") }`),
+    // so skip it up front. Without this skip, `function greet(this: ..., prefix)`
+    // is lowered as a 2-arg function and `.call(obj, 'Hi')` binds `this=obj,
+    // prefix=undefined` — which breaks `Function.prototype.{call,apply}` on
+    // FnDecls that use TS `this:` annotations.
     let mut params = Vec::new();
     let mut destructuring_params: Vec<(LocalId, ast::Pat)> = Vec::new();
     for param in fn_decl.function.params.iter() {
         let param_name = get_pat_name(&param.pat)?;
+        if param_name == "this" {
+            continue;
+        }
         let param_type = extract_param_type_with_ctx(&param.pat, Some(ctx));
         let param_default = get_param_default(ctx, &param.pat)?;
         let param_id = ctx.define_local(param_name.clone(), param_type.clone());
@@ -4131,11 +4141,16 @@ pub(crate) fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Re
                     .map(|(name, id, _)| (name.clone(), *id))
                     .collect();
 
-                // Lower parameters
+                // Lower parameters. Skip the TypeScript `this:` annotation —
+                // it has no runtime existence (see the sibling site above for
+                // the full rationale).
                 let mut params = Vec::new();
                 let mut destructuring_params: Vec<(LocalId, ast::Pat)> = Vec::new();
                 for param in &fn_decl.function.params {
                     let param_name = get_pat_name(&param.pat)?;
+                    if param_name == "this" {
+                        continue;
+                    }
                     let param_default = get_param_default(ctx, &param.pat)?;
                     let is_rest = is_rest_param(&param.pat);
                     let param_id = ctx.define_local(param_name.clone(), Type::Any);

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -7055,6 +7055,80 @@ pub unsafe extern "C" fn js_native_call_method(
             return object;
         }
 
+        // Function.prototype.call(thisArg, ...args) — invoke the receiver
+        // closure with `thisArg` bound as `this` and the remaining args
+        // passed positionally. Ramda's curry helpers (`_curry1`, `_curry2`,
+        // `_curry3`) build their dispatch chain around
+        // `fn.apply(this, arguments)` / `fn.call(this, x)`, so without these
+        // arms ramda fails immediately on the first curried export.
+        "call" if jsval.is_pointer() => {
+            let raw_ptr = (object.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+            if crate::closure::is_closure_ptr(raw_ptr) {
+                let this_arg = if args_len >= 1 && !args_ptr.is_null() {
+                    *args_ptr
+                } else {
+                    f64::from_bits(crate::value::TAG_UNDEFINED)
+                };
+                let rest_ptr = if args_len > 1 && !args_ptr.is_null() {
+                    args_ptr.add(1)
+                } else {
+                    std::ptr::null()
+                };
+                let rest_len = if args_len > 1 { args_len - 1 } else { 0 };
+                let prev_this = IMPLICIT_THIS.with(|c| c.replace(this_arg.to_bits()));
+                let result = crate::closure::js_native_call_value(object, rest_ptr, rest_len);
+                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                return result;
+            }
+        }
+
+        // Function.prototype.apply(thisArg, argsArray) — invoke the receiver
+        // closure with `thisArg` bound as `this` and the elements of
+        // `argsArray` spread as positional arguments. `argsArray` may be
+        // null / undefined (treat as no args). Mirrors `js_native_call_method_apply`
+        // but for the `Function.prototype.apply` path rather than the
+        // dynamic-spread method-call codegen path.
+        "apply" if jsval.is_pointer() => {
+            let raw_ptr = (object.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+            if crate::closure::is_closure_ptr(raw_ptr) {
+                let this_arg = if args_len >= 1 && !args_ptr.is_null() {
+                    *args_ptr
+                } else {
+                    f64::from_bits(crate::value::TAG_UNDEFINED)
+                };
+                let args_arr_val = if args_len >= 2 && !args_ptr.is_null() {
+                    *args_ptr.add(1)
+                } else {
+                    f64::from_bits(crate::value::TAG_UNDEFINED)
+                };
+                let args_arr_jsval = JSValue::from_bits(args_arr_val.to_bits());
+                let buf: Vec<f64> = if args_arr_jsval.is_pointer() {
+                    let arr_ptr = (args_arr_val.to_bits() & 0x0000_FFFF_FFFF_FFFF)
+                        as *const crate::array::ArrayHeader;
+                    if arr_ptr.is_null() {
+                        Vec::new()
+                    } else {
+                        let n = crate::array::js_array_length(arr_ptr) as usize;
+                        (0..n)
+                            .map(|i| crate::array::js_array_get_f64(arr_ptr, i as u32))
+                            .collect()
+                    }
+                } else {
+                    Vec::new()
+                };
+                let (call_args_ptr, call_args_len) = if buf.is_empty() {
+                    (std::ptr::null::<f64>(), 0_usize)
+                } else {
+                    (buf.as_ptr(), buf.len())
+                };
+                let prev_this = IMPLICIT_THIS.with(|c| c.replace(this_arg.to_bits()));
+                let result =
+                    crate::closure::js_native_call_value(object, call_args_ptr, call_args_len);
+                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                return result;
+            }
+        }
+
         // Common string methods on string values
         "toString" => {
             if jsval.is_string() {

--- a/test-files/test_function_apply_call.ts
+++ b/test-files/test_function_apply_call.ts
@@ -1,0 +1,13 @@
+function add(a: number, b: number) { return a + b; }
+function greet(this: { name: string }, prefix: string) { return prefix + ' ' + this.name; }
+
+console.log(add.apply(null, [2, 3]));        // 5
+console.log(add.call(null, 2, 3));            // 5
+console.log(add.apply(null, [10, 20]));       // 30
+console.log(greet.call({ name: 'Bob' }, 'Hi')); // 'Hi Bob'
+console.log(greet.apply({ name: 'Sue' }, ['Hello'])); // 'Hello Sue'
+
+// Method on arrow function (no this rebind)
+const sq = (x: number) => x * x;
+console.log(sq.apply(null, [4]));  // 16
+console.log(sq.call(null, 5));     // 25


### PR DESCRIPTION
## Summary

- Add `Function.prototype.call(thisArg, ...args)` and `Function.prototype.apply(thisArg, argsArr)` dispatch in `js_native_call_method` (`crates/perry-runtime/src/object.rs`). Both rebind `IMPLICIT_THIS` and forward through `js_native_call_value`; `apply` materialises `ArrayHeader` elements into a `Vec<f64>` and tolerates null/undefined/non-array as zero-args.
- Skip TypeScript `this:` type-only parameter annotation at both `FnDecl` parameter-lowering sites in `crates/perry-hir/src/lower_decl.rs`. Without this, `function greet(this:…, prefix)` was lowered as a 2-arg function and `.call(obj,'Hi')` bound `prefix=undefined` because the runtime call passed `'Hi'` into the synthetic `this` slot. The `expr_function.rs` site already skipped these per #915.

## Why

Pre-fix, `add.apply(null, [2,3])` and `add.call(null, 2, 3)` both returned `[object Object]` (the `NULL_OBJECT_BYTES` stub) because the closure path in `js_native_call_method` returned the null-object stub when a method name wasn't found in the closure's dynamic-prop side table. This is the core reason ramda fails to bootstrap: `_curry1` / `_curry2` / `_curry3` all wrap their bodies in `fn.apply(this, arguments)`, so the very first invocation of any curried ramda export (`R.sum`, `R.add`, etc.) returned a stub instead of the dispatch result.

## Test plan

- [x] `test-files/test_function_apply_call.ts` (7 assertions) — matches Node byte-for-byte (`add.apply`, `add.call`, multiple invocations, `greet.call({name:'Bob'},'Hi')`, `greet.apply({name:'Sue'},['Hello'])`, arrow-fn `sq.apply(null,[4])`, `sq.call(null,5)`).
- [x] No regression on `test_gap_closures.ts`, `test_gap_object_methods.ts`, `test_gap_array_methods.ts`, `test_gap_async_advanced.ts`.

## Ramda outcome

- [x] `import * as R from 'ramda'; console.log(R.sum([1,2,3,4,5]))` now **compiles** under `perry.compilePackages` (2.6 MB binary).
- [ ] Execution still throws `TypeError: Cannot read properties of undefined (reading 'call')` during ramda's module init — a deeper, separate issue. Likely the CommonJS `require()` resolution returning `undefined` for an internal helper, then ramda's bootstrap calls `.call()` on the undefined value. This is the next blocker and is **not** covered by this PR.