### PR TITLE
feat(perry/system): #918 — `takeScreenshot()` programmatic screen capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5629,6 +5629,7 @@ dependencies = [
 name = "perry-ui-macos"
 version = "0.5.982"
 dependencies = [
+ "base64",
  "block2",
  "libc",
  "objc2",

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2039,6 +2039,11 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("perry/system", "getBundleId", false, None),
     method("perry/system", "getAppIcon", false, None),
     method("perry/system", "openURL", false, None),
+    // #918 — programmatic screen capture. Returns a base64-encoded
+    // PNG of the key window's contents on platforms with a native
+    // capture path (macOS); other platforms return the empty string
+    // and the runtime emits a one-time stub warning on first call.
+    method("perry/system", "takeScreenshot", false, None),
     method("perry/system", "keychainSave", false, None),
     method("perry/system", "keychainGet", false, None),
     method("perry/system", "keychainDelete", false, None),

--- a/crates/perry-dispatch/src/lib.rs
+++ b/crates/perry-dispatch/src/lib.rs
@@ -2102,6 +2102,17 @@ pub static PERRY_SYSTEM_TABLE: &[MethodRow] = &[
         args: &[ArgKind::Str],
         ret: ReturnKind::Void,
     },
+    // #918 — programmatic screen capture. Returns a NaN-boxed string
+    // pointer (base64-encoded PNG of the key window) on platforms
+    // with a native capture path; empty string on platforms where the
+    // build.rs-generated stub fires (HarmonyOS + every non-Apple
+    // platform UI crate in this MVP).
+    MethodRow {
+        method: "takeScreenshot",
+        runtime: "perry_system_take_screenshot",
+        args: &[],
+        ret: ReturnKind::Str,
+    },
     MethodRow {
         method: "keychainSave",
         runtime: "perry_system_keychain_save",

--- a/crates/perry-ui-android/src/lib.rs
+++ b/crates/perry-ui-android/src/lib.rs
@@ -1414,6 +1414,23 @@ pub extern "C" fn perry_system_open_url(url_ptr: i64) {
     system::open_url(url_ptr as *const u8);
 }
 
+/// #918 — programmatic screen capture stub on Android. The native
+/// implementation will use `PixelCopy.request` on the activity's
+/// window via JNI; landed as a follow-up under #918. MVP returns
+/// the empty string + first-call warning.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_take_screenshot",
+        "Android screen capture not yet implemented (#918 follow-up)",
+        Some("#918"),
+    );
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+
 #[no_mangle]
 pub extern "C" fn perry_system_is_dark_mode() -> i64 {
     system::is_dark_mode()

--- a/crates/perry-ui-gtk4/src/lib.rs
+++ b/crates/perry-ui-gtk4/src/lib.rs
@@ -1711,6 +1711,23 @@ pub extern "C" fn perry_system_open_url(url_ptr: i64) {
     system::open_url(url_ptr as *const u8);
 }
 
+/// #918 — programmatic screen capture stub on GTK4 / Linux. A real
+/// implementation would render the window's `gdk::Surface` to a
+/// `cairo::ImageSurface`; landed as a #918 follow-up. MVP returns
+/// the empty string + first-call warning.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_take_screenshot",
+        "GTK4/Linux screen capture not yet implemented (#918 follow-up)",
+        Some("#918"),
+    );
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+
 /// Check if dark mode is enabled.
 #[no_mangle]
 pub extern "C" fn perry_system_is_dark_mode() -> i64 {

--- a/crates/perry-ui-ios/src/lib.rs
+++ b/crates/perry-ui-ios/src/lib.rs
@@ -1370,6 +1370,25 @@ pub extern "C" fn perry_ui_state_on_change(state_handle: i64, callback: f64) {
 // System APIs (perry/system module)
 // =============================================================================
 
+/// #918 — programmatic screen capture. MVP stub on iOS: returns the
+/// empty string and emits a first-call diagnostic. The native
+/// implementation will use `UIGraphicsImageRenderer` on the key
+/// window's layer (`drawHierarchy:afterScreenUpdates:` for fidelity)
+/// — landed as a follow-up so this PR can stay focused on the API
+/// surface across every platform.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_take_screenshot",
+        "iOS screen capture not yet implemented (#918 follow-up)",
+        Some("#918"),
+    );
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+
 /// Open a URL in the default browser/app.
 #[no_mangle]
 pub extern "C" fn perry_system_open_url(url_ptr: i64) {

--- a/crates/perry-ui-macos/Cargo.toml
+++ b/crates/perry-ui-macos/Cargo.toml
@@ -14,6 +14,7 @@ geisterhand = []
 [dependencies]
 perry-ui = { path = "../perry-ui" }
 perry-ui-testkit = { workspace = true }
+base64 = "0.22"
 block2 = "0.6"
 libc = "0.2"
 objc2 = "0.6"

--- a/crates/perry-ui-macos/src/lib.rs
+++ b/crates/perry-ui-macos/src/lib.rs
@@ -1544,6 +1544,79 @@ pub extern "C" fn perry_ui_state_on_change(state_handle: i64, callback: f64) {
 // System APIs (perry/system module)
 // =============================================================================
 
+/// #918 — programmatic screen capture. Renders the key NSWindow's
+/// content view into a bitmap representation, encodes as PNG, and
+/// returns the base64-encoded result as a Perry-managed string
+/// (i64 pointer, returned as the `Str` dispatch shape). Returns the
+/// empty string when there is no key window (e.g. headless tests,
+/// app launching before the window is shown).
+///
+/// AppKit implementation: `bitmapImageRepForCachingDisplayInRect:`
+/// + `cacheDisplayInRect:toBitmapImageRep:` is the documented path
+/// for retina-correct capture of a single view tree.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    use base64::Engine;
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    let empty = || unsafe { js_string_from_bytes(std::ptr::null(), 0) };
+    unsafe {
+        let app_cls = objc2::runtime::AnyClass::get(c"NSApplication").unwrap();
+        let app: *mut objc2::runtime::AnyObject = objc2::msg_send![app_cls, sharedApplication];
+        if app.is_null() {
+            return empty();
+        }
+        let key_window: *mut objc2::runtime::AnyObject = objc2::msg_send![app, keyWindow];
+        if key_window.is_null() {
+            return empty();
+        }
+        let content_view: *mut objc2::runtime::AnyObject =
+            objc2::msg_send![key_window, contentView];
+        if content_view.is_null() {
+            return empty();
+        }
+        let bounds: objc2_foundation::NSRect = objc2::msg_send![content_view, bounds];
+        let bitmap: *mut objc2::runtime::AnyObject = objc2::msg_send![
+            content_view,
+            bitmapImageRepForCachingDisplayInRect: bounds
+        ];
+        if bitmap.is_null() {
+            return empty();
+        }
+        let _: () = objc2::msg_send![
+            content_view,
+            cacheDisplayInRect: bounds,
+            toBitmapImageRep: bitmap
+        ];
+        // NSBitmapImageRep → PNG NSData. `representationUsingType:properties:`
+        // takes `NSBitmapImageFileTypePNG` (= 4) and an empty
+        // NSDictionary. Spelling the integer directly because the
+        // matching `NSBitmapImageFileType` Rust binding isn't pulled
+        // in by this crate's existing `objc2` surface — it's a
+        // documented stable public constant.
+        const NS_BITMAP_IMAGE_FILE_TYPE_PNG: u64 = 4;
+        let dict_cls = objc2::runtime::AnyClass::get(c"NSDictionary").unwrap();
+        let empty_dict: *mut objc2::runtime::AnyObject = objc2::msg_send![dict_cls, dictionary];
+        let png_data: *mut objc2::runtime::AnyObject = objc2::msg_send![
+            bitmap,
+            representationUsingType: NS_BITMAP_IMAGE_FILE_TYPE_PNG,
+            properties: empty_dict
+        ];
+        if png_data.is_null() {
+            return empty();
+        }
+        let len: usize = objc2::msg_send![png_data, length];
+        let bytes: *const u8 = objc2::msg_send![png_data, bytes];
+        if bytes.is_null() || len == 0 {
+            return empty();
+        }
+        let slice = std::slice::from_raw_parts(bytes, len);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(slice);
+        js_string_from_bytes(encoded.as_ptr(), encoded.len() as i32)
+    }
+}
+
 /// Open a URL in the default browser/app.
 #[no_mangle]
 pub extern "C" fn perry_system_open_url(url_ptr: i64) {

--- a/crates/perry-ui-test/src/lib.rs
+++ b/crates/perry-ui-test/src/lib.rs
@@ -1452,6 +1452,21 @@ pub const FEATURES: &[Feature] = &[
         web: S,
         web_name: None,
     },
+    // #918: programmatic screen capture. macOS has the real
+    // AppKit-backed implementation; every other platform is a no-op
+    // stub today (follow-ups will land per-platform native impls
+    // tracked under #918).
+    Feature {
+        name: "perry_system_take_screenshot",
+        category: SystemApi,
+        macos: S,
+        ios: S,
+        android: S,
+        gtk4: S,
+        windows: S,
+        web: S,
+        web_name: None,
+    },
     Feature {
         name: "perry_system_is_dark_mode",
         category: SystemApi,

--- a/crates/perry-ui-tvos/src/lib.rs
+++ b/crates/perry-ui-tvos/src/lib.rs
@@ -1260,6 +1260,23 @@ pub extern "C" fn perry_ui_state_on_change(state_handle: i64, callback: f64) {
 // System APIs (perry/system module)
 // =============================================================================
 
+/// #918 — programmatic screen capture. MVP stub on tvOS: no native
+/// API is offered to capture the focus engine's render tree from a
+/// user app (Apple gates the screenshot API behind broadcast/replay
+/// extensions). Returns empty string + first-call warning.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_take_screenshot",
+        "tvOS does not expose an in-app screen capture API (#918)",
+        Some("#918"),
+    );
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+
 /// Open a URL in the default browser/app.
 #[no_mangle]
 pub extern "C" fn perry_system_open_url(url_ptr: i64) {

--- a/crates/perry-ui-visionos/src/lib.rs
+++ b/crates/perry-ui-visionos/src/lib.rs
@@ -1381,6 +1381,22 @@ pub extern "C" fn perry_ui_state_on_change(state_handle: i64, callback: f64) {
 // System APIs (perry/system module)
 // =============================================================================
 
+/// #918 — programmatic screen capture stub on visionOS. RealityKit
+/// + UIKit don't expose a public in-app capture path; returns empty
+/// string + first-call warning.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_take_screenshot",
+        "visionOS does not expose a public screen capture API (#918)",
+        Some("#918"),
+    );
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+
 /// Open a URL in the default browser/app.
 #[no_mangle]
 pub extern "C" fn perry_system_open_url(url_ptr: i64) {

--- a/crates/perry-ui-watchos/src/lib.rs
+++ b/crates/perry-ui-watchos/src/lib.rs
@@ -1174,6 +1174,21 @@ pub extern "C" fn perry_ui_table_get_selected_row(_h: i64) -> i64 {
 
 #[no_mangle]
 pub extern "C" fn perry_system_open_url(_url: i64) {}
+/// #918 — programmatic screen capture stub on watchOS. WatchKit
+/// doesn't expose a public capture API; returns empty string +
+/// first-call warning.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_take_screenshot",
+        "watchOS does not expose a public screen capture API (#918)",
+        Some("#918"),
+    );
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
 #[no_mangle]
 pub extern "C" fn perry_system_request_location(_cb: f64) {}
 #[no_mangle]

--- a/crates/perry-ui-windows/src/lib.rs
+++ b/crates/perry-ui-windows/src/lib.rs
@@ -1556,6 +1556,23 @@ pub extern "C" fn perry_system_open_url(url_ptr: i64) {
     system::open_url(url_ptr as *const u8);
 }
 
+/// #918 — programmatic screen capture stub on Windows. A real
+/// implementation would use `BitBlt` from `GetDC(hwnd)` or
+/// DXGI `DesktopDuplication`; landed as a #918 follow-up. MVP
+/// returns the empty string + first-call warning.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_take_screenshot",
+        "Windows screen capture not yet implemented (#918 follow-up)",
+        Some("#918"),
+    );
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+
 /// Check if dark mode is enabled.
 #[no_mangle]
 pub extern "C" fn perry_system_is_dark_mode() -> i64 {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 870 entries across 71 modules
+// Coverage: 891 entries across 71 modules
 
 declare module "argon2" {
   /** stdlib */
@@ -403,6 +403,10 @@ declare module "lodash" {
   /** stdlib */
   export function last(p0: any): any;
   /** stdlib */
+  export function mean(p0: any): number;
+  /** stdlib */
+  export function meanBy(p0: any, p1: any): number;
+  /** stdlib */
   export function range(p0: any, p1: any, p2: any): any;
   /** stdlib */
   export function reverse(p0: any): any;
@@ -410,6 +414,12 @@ declare module "lodash" {
   export function size(p0: any): any;
   /** stdlib */
   export function snakeCase(p0: string): string;
+  /** stdlib */
+  export function sum(p0: any): number;
+  /** stdlib */
+  export function sumBy(p0: any, p1: any): number;
+  /** stdlib */
+  export function tail(p0: any): any;
   /** stdlib */
   export function take(p0: any, p1: any): any;
   /** stdlib */
@@ -745,6 +755,8 @@ declare module "perry/system" {
   export function preferencesGet(...args: any[]): any;
   /** stdlib */
   export function preferencesSet(...args: any[]): any;
+  /** stdlib */
+  export function takeScreenshot(...args: any[]): any;
 }
 
 declare module "perry/thread" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 870 entries across 71 modules.
+Total: 891 entries across 71 modules.
 
 ## Modules
 
@@ -621,10 +621,15 @@ Total: 870 entries across 71 modules.
 - `head` — module
 - `kebabCase` — module
 - `last` — module
+- `mean` — module
+- `meanBy` — module
 - `range` — module
 - `reverse` — module
 - `size` — module
 - `snakeCase` — module
+- `sum` — module
+- `sumBy` — module
+- `tail` — module
 - `take` — module
 - `times` — module
 - `uniq` — module
@@ -926,6 +931,7 @@ Total: 870 entries across 71 modules.
 - `openURL` — module
 - `preferencesGet` — module
 - `preferencesSet` — module
+- `takeScreenshot` — module
 
 ## `perry/thread`
 
@@ -1228,9 +1234,24 @@ Total: 870 entries across 71 modules.
 
 ### Methods
 
+- `addListener` — instance
+- `emit` — instance
+- `eventNames` — instance
 - `finished` — module
 - `from` — module
+- `getMaxListeners` — instance
+- `listenerCount` — instance
+- `listeners` — instance
+- `off` — instance
+- `on` — instance
+- `once` — instance
 - `pipeline` — module
+- `prependListener` — instance
+- `prependOnceListener` — instance
+- `rawListeners` — instance
+- `removeAllListeners` — instance
+- `removeListener` — instance
+- `setMaxListeners` — instance
 
 ## `streams`
 


### PR DESCRIPTION
Closes #918 (MVP — see follow-up matrix).

## Summary

Adds a new `perry/system` API:

```typescript,no-test
import { takeScreenshot } from "perry/system";
const base64Png = takeScreenshot();
```

Returns a base64-encoded PNG of the key window's contents on platforms with a native capture path; empty string on platforms where the native path hasn't landed yet. Use case: bug-report flows that attach "the screen the user was looking at" to the report so triage can see what state the app was in.

## Cross-platform coverage

| Platform   | Status                                                |
|------------|-------------------------------------------------------|
| **macOS**  | **Real impl** — `NSWindow.contentView` bitmap → PNG → base64 |
| iOS        | Stub + #918 follow-up warning                         |
| tvOS       | Stub (Apple doesn't expose in-app capture API)        |
| watchOS    | Stub (WatchKit doesn't expose a public API)           |
| visionOS   | Stub (RealityKit/UIKit don't expose in-app capture)   |
| Android    | Stub + #918 follow-up warning                         |
| Windows    | Stub + #918 follow-up warning                         |
| Linux/GTK4 | Stub + #918 follow-up warning                         |
| WASM       | Stub via dispatch table fallback                      |
| HarmonyOS  | Stub auto-generated by `perry-runtime/build.rs`     |

Every stub funnels through `perry_runtime::stub_diag::perry_stub_warn`, so the first call per process prints a `[perry] warning` line naming the platform and the #918 tracker.

## macOS implementation detail

`bitmapImageRepForCachingDisplayInRect` + `cacheDisplayInRect:toBitmapImageRep:` is the documented retina-correct capture path for a single view tree. Result is encoded as PNG via `representationUsingType:NSBitmapImageFileTypePNG properties:{}`, base64-encoded with `base64::engine::general_purpose::STANDARD`, and returned through the standard perry string allocator (`js_string_from_bytes`) so the result behaves as a normal JS string in user code. Returns empty string when there is no key window (headless tests, app launching before the window is shown).

## Plumbing (every layer touched)

- **API manifest** (`perry-api-manifest/src/entries.rs`) — `method("perry/system", "takeScreenshot", ...)` row.
- **Dispatch table** (`perry-dispatch/src/lib.rs`) — `MethodRow` with `ReturnKind::Str` + no args. WASM falls through to `ui_method_to_runtime()` in `perry-codegen-wasm/src/emit.rs` — symbol mapping for free.
- **Per-platform exports**: `perry-ui-macos` (real), `perry-ui-ios`, `perry-ui-tvos`, `perry-ui-watchos`, `perry-ui-visionos`, `perry-ui-android`, `perry-ui-gtk4`, `perry-ui-windows` (stubs).
- **Testkit matrix** (`perry-ui-test/src/lib.rs`) — `Feature` entry so the testkit knows the symbol exists on every platform.
- **HarmonyOS** — auto-stubbed by `perry-runtime/build.rs` from the dispatch table (the same single-source-of-truth path that already covers `perry_system_open_url` et al.).

## Smoke test

Compiled `App({body: VStack([Text("hi")])}) + takeScreenshot()` against the release perry; symbol resolves end-to-end, link succeeds, binary runs.

## What's deferred (#918 follow-ups)

- **iOS / Android native impls** — the issue maps them out in detail (`UIGraphicsImageRenderer` on iOS, `PixelCopy.request` on Android).
- **`takeScreenshotAsync(cb)`** — main-thread-safe async wrapper.
- **`widgetCapture(widget, cb)`** — capture just a specific widget subtree.

The dispatch table is forward-compatible: both follow-ups add new `MethodRow` rows alongside `takeScreenshot` without breaking the sync API.

## Notes

No `Cargo.toml` version bump, no `CLAUDE.md` touch, no `CHANGELOG.md` entry — maintainer folds those in at merge time.