### PR TITLE
feat(perry/system): #917 — shareText/shareUrl system share sheet

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2098,6 +2098,12 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("perry/system", "getBundleId", false, None),
     method("perry/system", "getAppIcon", false, None),
     method("perry/system", "openURL", false, None),
+    // #917 — system share sheet (UIActivityViewController on iOS,
+    // NSSharingServicePicker on macOS, Intent.ACTION_SEND on
+    // Android). Two convenience entry points cover the common
+    // shapes: plain text + URL.
+    method("perry/system", "shareText", false, None),
+    method("perry/system", "shareUrl", false, None),
     method("perry/system", "keychainSave", false, None),
     method("perry/system", "keychainGet", false, None),
     method("perry/system", "keychainDelete", false, None),

--- a/crates/perry-dispatch/src/lib.rs
+++ b/crates/perry-dispatch/src/lib.rs
@@ -2102,6 +2102,23 @@ pub static PERRY_SYSTEM_TABLE: &[MethodRow] = &[
         args: &[ArgKind::Str],
         ret: ReturnKind::Void,
     },
+    // #917 — system share sheet. Both entry points take a body
+    // string + an optional title (empty = no title); the platform
+    // implementation maps to the native share API
+    // (UIActivityViewController / NSSharingServicePicker /
+    // Intent.ACTION_SEND).
+    MethodRow {
+        method: "shareText",
+        runtime: "perry_system_share_text",
+        args: &[ArgKind::Str, ArgKind::Str],
+        ret: ReturnKind::Void,
+    },
+    MethodRow {
+        method: "shareUrl",
+        runtime: "perry_system_share_url",
+        args: &[ArgKind::Str, ArgKind::Str],
+        ret: ReturnKind::Void,
+    },
     MethodRow {
         method: "keychainSave",
         runtime: "perry_system_keychain_save",

--- a/crates/perry-ui-android/src/lib.rs
+++ b/crates/perry-ui-android/src/lib.rs
@@ -1414,6 +1414,27 @@ pub extern "C" fn perry_system_open_url(url_ptr: i64) {
     system::open_url(url_ptr as *const u8);
 }
 
+/// #917 — system share sheet stub on Android. Native impl will use
+/// `Intent.ACTION_SEND` with `Intent.EXTRA_TEXT` + `Intent.EXTRA_TITLE`
+/// wrapped via `Intent.createChooser`, dispatched through JNI. MVP
+/// stub + first-call warning.
+#[no_mangle]
+pub extern "C" fn perry_system_share_text(_text_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_text",
+        "Android Intent.ACTION_SEND not yet implemented (#917 follow-up)",
+        Some("#917"),
+    );
+}
+#[no_mangle]
+pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_url",
+        "Android Intent.ACTION_SEND not yet implemented (#917 follow-up)",
+        Some("#917"),
+    );
+}
+
 #[no_mangle]
 pub extern "C" fn perry_system_is_dark_mode() -> i64 {
     system::is_dark_mode()

--- a/crates/perry-ui-gtk4/src/lib.rs
+++ b/crates/perry-ui-gtk4/src/lib.rs
@@ -1711,6 +1711,28 @@ pub extern "C" fn perry_system_open_url(url_ptr: i64) {
     system::open_url(url_ptr as *const u8);
 }
 
+/// #917 — system share sheet stub on GTK4 / Linux. A real
+/// implementation would launch the XDG desktop portal's
+/// "Open URI" / "Send" flow via `org.freedesktop.portal.Email` /
+/// `Sharing`; landed as a #917 follow-up. MVP stub + first-call
+/// warning.
+#[no_mangle]
+pub extern "C" fn perry_system_share_text(_text_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_text",
+        "GTK4/Linux XDG share portal not yet wired (#917 follow-up)",
+        Some("#917"),
+    );
+}
+#[no_mangle]
+pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_url",
+        "GTK4/Linux XDG share portal not yet wired (#917 follow-up)",
+        Some("#917"),
+    );
+}
+
 /// Check if dark mode is enabled.
 #[no_mangle]
 pub extern "C" fn perry_system_is_dark_mode() -> i64 {

--- a/crates/perry-ui-ios/src/lib.rs
+++ b/crates/perry-ui-ios/src/lib.rs
@@ -1370,6 +1370,31 @@ pub extern "C" fn perry_ui_state_on_change(state_handle: i64, callback: f64) {
 // System APIs (perry/system module)
 // =============================================================================
 
+/// #917 — system share sheet (text). MVP stub on iOS: emits a
+/// first-call warning. The native implementation (issue follow-up)
+/// will wrap `UIActivityViewController` with the text in
+/// `activityItems`, anchored to the key window's root view
+/// controller. Kept stub-shaped so the symbol exists on every
+/// platform — apps can compile-test against the API.
+#[no_mangle]
+pub extern "C" fn perry_system_share_text(_text_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_text",
+        "iOS UIActivityViewController not yet implemented (#917 follow-up)",
+        Some("#917"),
+    );
+}
+
+/// #917 — system share sheet (URL). MVP stub on iOS.
+#[no_mangle]
+pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_url",
+        "iOS UIActivityViewController not yet implemented (#917 follow-up)",
+        Some("#917"),
+    );
+}
+
 /// Open a URL in the default browser/app.
 #[no_mangle]
 pub extern "C" fn perry_system_open_url(url_ptr: i64) {

--- a/crates/perry-ui-macos/src/lib.rs
+++ b/crates/perry-ui-macos/src/lib.rs
@@ -1544,6 +1544,106 @@ pub extern "C" fn perry_ui_state_on_change(state_handle: i64, callback: f64) {
 // System APIs (perry/system module)
 // =============================================================================
 
+/// #917 — system share sheet (text). Wraps `NSSharingServicePicker`
+/// anchored to the key window's content view. `title` is currently
+/// dropped on macOS (Cocoa's picker derives its label from the
+/// item type); kept in the signature for cross-platform symmetry
+/// with iOS/Android. Both args are Perry string pointers.
+#[no_mangle]
+pub extern "C" fn perry_system_share_text(text_ptr: i64, _title_ptr: i64) {
+    fn str_from_header(ptr: *const u8) -> &'static str {
+        if ptr.is_null() {
+            return "";
+        }
+        unsafe {
+            let header = ptr as *const crate::string_header::StringHeader;
+            let len = (*header).byte_len as usize;
+            let data = ptr.add(std::mem::size_of::<crate::string_header::StringHeader>());
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+        }
+    }
+    let text = str_from_header(text_ptr as *const u8);
+    if text.is_empty() {
+        return;
+    }
+    unsafe {
+        let ns_text = objc2_foundation::NSString::from_str(text);
+        let arr_cls = objc2::runtime::AnyClass::get(c"NSArray").unwrap();
+        let items: *mut objc2::runtime::AnyObject =
+            objc2::msg_send![arr_cls, arrayWithObject: &*ns_text];
+        present_sharing_picker(items);
+    }
+}
+
+/// #917 — system share sheet (URL). Same shape as `shareText` but
+/// wraps the value as `NSURL` so the picker offers
+/// Safari / Reading List / Add to Bookmarks alongside Messages / Mail.
+#[no_mangle]
+pub extern "C" fn perry_system_share_url(url_ptr: i64, _title_ptr: i64) {
+    fn str_from_header(ptr: *const u8) -> &'static str {
+        if ptr.is_null() {
+            return "";
+        }
+        unsafe {
+            let header = ptr as *const crate::string_header::StringHeader;
+            let len = (*header).byte_len as usize;
+            let data = ptr.add(std::mem::size_of::<crate::string_header::StringHeader>());
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+        }
+    }
+    let url_str = str_from_header(url_ptr as *const u8);
+    if url_str.is_empty() {
+        return;
+    }
+    unsafe {
+        let ns_str = objc2_foundation::NSString::from_str(url_str);
+        let url_cls = objc2::runtime::AnyClass::get(c"NSURL").unwrap();
+        let url: *mut objc2::runtime::AnyObject =
+            objc2::msg_send![url_cls, URLWithString: &*ns_str];
+        let arr_cls = objc2::runtime::AnyClass::get(c"NSArray").unwrap();
+        let items: *mut objc2::runtime::AnyObject = if url.is_null() {
+            // Malformed URL → fall back to sharing as plain text.
+            objc2::msg_send![arr_cls, arrayWithObject: &*ns_str]
+        } else {
+            objc2::msg_send![arr_cls, arrayWithObject: url]
+        };
+        present_sharing_picker(items);
+    }
+}
+
+/// Build an `NSSharingServicePicker` for `items` and present it
+/// anchored to the key window's content-view bounds. Common helper
+/// so `shareText` and `shareUrl` share the presentation logic.
+unsafe fn present_sharing_picker(items: *mut objc2::runtime::AnyObject) {
+    let picker_cls = objc2::runtime::AnyClass::get(c"NSSharingServicePicker").unwrap();
+    let alloc: *mut objc2::runtime::AnyObject = objc2::msg_send![picker_cls, alloc];
+    let picker: *mut objc2::runtime::AnyObject = objc2::msg_send![alloc, initWithItems: items];
+    if picker.is_null() {
+        return;
+    }
+    let app_cls = objc2::runtime::AnyClass::get(c"NSApplication").unwrap();
+    let app: *mut objc2::runtime::AnyObject = objc2::msg_send![app_cls, sharedApplication];
+    let key_window: *mut objc2::runtime::AnyObject = objc2::msg_send![app, keyWindow];
+    if key_window.is_null() {
+        return;
+    }
+    let content_view: *mut objc2::runtime::AnyObject = objc2::msg_send![key_window, contentView];
+    if content_view.is_null() {
+        return;
+    }
+    let bounds: objc2_foundation::NSRect = objc2::msg_send![content_view, bounds];
+    // showRelativeToRect:ofView:preferredEdge: — anchor to the
+    // content view's bounds, preferred edge = NSRectEdgeMinY (1)
+    // so the popover renders above the view.
+    const NS_RECT_EDGE_MIN_Y: u64 = 1;
+    let _: () = objc2::msg_send![
+        picker,
+        showRelativeToRect: bounds,
+        ofView: content_view,
+        preferredEdge: NS_RECT_EDGE_MIN_Y
+    ];
+}
+
 /// Open a URL in the default browser/app.
 #[no_mangle]
 pub extern "C" fn perry_system_open_url(url_ptr: i64) {

--- a/crates/perry-ui-test/src/lib.rs
+++ b/crates/perry-ui-test/src/lib.rs
@@ -1452,6 +1452,31 @@ pub const FEATURES: &[Feature] = &[
         web: S,
         web_name: None,
     },
+    // #917: system share sheet. macOS has the real NSSharingServicePicker
+    // implementation; every other platform is a no-op stub today
+    // (per-platform native impls land as #917 follow-ups).
+    Feature {
+        name: "perry_system_share_text",
+        category: SystemApi,
+        macos: S,
+        ios: S,
+        android: S,
+        gtk4: S,
+        windows: S,
+        web: S,
+        web_name: None,
+    },
+    Feature {
+        name: "perry_system_share_url",
+        category: SystemApi,
+        macos: S,
+        ios: S,
+        android: S,
+        gtk4: S,
+        windows: S,
+        web: S,
+        web_name: None,
+    },
     Feature {
         name: "perry_system_is_dark_mode",
         category: SystemApi,

--- a/crates/perry-ui-tvos/src/lib.rs
+++ b/crates/perry-ui-tvos/src/lib.rs
@@ -1260,6 +1260,29 @@ pub extern "C" fn perry_ui_state_on_change(state_handle: i64, callback: f64) {
 // System APIs (perry/system module)
 // =============================================================================
 
+/// #917 — system share sheet stub on tvOS. Apple's tvOS doesn't
+/// expose UIActivityViewController; the typical tvOS share flow uses
+/// AirDrop only and isn't programmatically invokable. Stub + first-
+/// call warning.
+#[no_mangle]
+pub extern "C" fn perry_system_share_text(_text_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_text",
+        "tvOS does not expose a programmatic share sheet (#917)",
+        Some("#917"),
+    );
+}
+
+/// #917 — system share sheet stub on tvOS.
+#[no_mangle]
+pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_url",
+        "tvOS does not expose a programmatic share sheet (#917)",
+        Some("#917"),
+    );
+}
+
 /// Open a URL in the default browser/app.
 #[no_mangle]
 pub extern "C" fn perry_system_open_url(url_ptr: i64) {

--- a/crates/perry-ui-visionos/src/lib.rs
+++ b/crates/perry-ui-visionos/src/lib.rs
@@ -1381,6 +1381,27 @@ pub extern "C" fn perry_ui_state_on_change(state_handle: i64, callback: f64) {
 // System APIs (perry/system module)
 // =============================================================================
 
+/// #917 — system share sheet stub on visionOS. UIActivityViewController
+/// is available but its presentation model on visionOS is different
+/// (window-anchored rather than view-anchored). Stub + first-call
+/// warning; the visionOS native impl is tracked under #917 follow-up.
+#[no_mangle]
+pub extern "C" fn perry_system_share_text(_text_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_text",
+        "visionOS share sheet not yet implemented (#917 follow-up)",
+        Some("#917"),
+    );
+}
+#[no_mangle]
+pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_url",
+        "visionOS share sheet not yet implemented (#917 follow-up)",
+        Some("#917"),
+    );
+}
+
 /// Open a URL in the default browser/app.
 #[no_mangle]
 pub extern "C" fn perry_system_open_url(url_ptr: i64) {

--- a/crates/perry-ui-watchos/src/lib.rs
+++ b/crates/perry-ui-watchos/src/lib.rs
@@ -1174,6 +1174,25 @@ pub extern "C" fn perry_ui_table_get_selected_row(_h: i64) -> i64 {
 
 #[no_mangle]
 pub extern "C" fn perry_system_open_url(_url: i64) {}
+/// #917 — system share sheet stub on watchOS. WatchKit doesn't
+/// expose a public share API; AirDrop / Messages share flows are
+/// system-driven. Stub + first-call warning.
+#[no_mangle]
+pub extern "C" fn perry_system_share_text(_text_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_text",
+        "watchOS does not expose a programmatic share sheet (#917)",
+        Some("#917"),
+    );
+}
+#[no_mangle]
+pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_url",
+        "watchOS does not expose a programmatic share sheet (#917)",
+        Some("#917"),
+    );
+}
 #[no_mangle]
 pub extern "C" fn perry_system_request_location(_cb: f64) {}
 #[no_mangle]

--- a/crates/perry-ui-windows/src/lib.rs
+++ b/crates/perry-ui-windows/src/lib.rs
@@ -1556,6 +1556,26 @@ pub extern "C" fn perry_system_open_url(url_ptr: i64) {
     system::open_url(url_ptr as *const u8);
 }
 
+/// #917 — system share sheet stub on Windows. A real impl will use
+/// the WinRT `DataTransferManager` (`ShowShareUI`) flow; landed
+/// as a #917 follow-up. MVP stub + first-call warning.
+#[no_mangle]
+pub extern "C" fn perry_system_share_text(_text_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_text",
+        "Windows DataTransferManager not yet wired (#917 follow-up)",
+        Some("#917"),
+    );
+}
+#[no_mangle]
+pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_share_url",
+        "Windows DataTransferManager not yet wired (#917 follow-up)",
+        Some("#917"),
+    );
+}
+
 /// Check if dark mode is enabled.
 #[no_mangle]
 pub extern "C" fn perry_system_is_dark_mode() -> i64 {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 901 entries across 71 modules
+// Coverage: 903 entries across 71 modules
 
 declare module "argon2" {
   /** stdlib */
@@ -771,6 +771,10 @@ declare module "perry/system" {
   export function preferencesGet(...args: any[]): any;
   /** stdlib */
   export function preferencesSet(...args: any[]): any;
+  /** stdlib */
+  export function shareText(...args: any[]): any;
+  /** stdlib */
+  export function shareUrl(...args: any[]): any;
   /** stdlib */
   export function takeScreenshot(...args: any[]): any;
 }

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 901 entries across 71 modules.
+Total: 903 entries across 71 modules.
 
 ## Modules
 
@@ -940,6 +940,8 @@ Total: 901 entries across 71 modules.
 - `openURL` — module
 - `preferencesGet` — module
 - `preferencesSet` — module
+- `shareText` — module
+- `shareUrl` — module
 - `takeScreenshot` — module
 
 ## `perry/thread`


### PR DESCRIPTION
Closes #917 (MVP — see follow-up matrix).

## Summary

Two perry/system entry points wrapping the native share picker:

```typescript,no-test
import { shareText, shareUrl } from "perry/system";
shareText("hello world");
shareUrl("https://example.com", "My link");
```

Use case: "share my invitation code" / "share this listing" flows where the OS share sheet hands the value to Messages / Mail / WhatsApp / etc. Wishare's invite-friends screen had to fall back to `clipboardWrite` + manual paste; native apps already expose this surface.

## Cross-platform coverage

| Platform   | Status                                                    |
|------------|-----------------------------------------------------------|
| **macOS**  | **Real impl** — `NSSharingServicePicker` anchored to key window |
| iOS        | Stub + #917 follow-up warning (`UIActivityViewController`)        |
| tvOS       | Stub (tvOS doesn't expose a programmatic share sheet)              |
| watchOS    | Stub (WatchKit doesn't expose a public API)                        |
| visionOS   | Stub + #917 follow-up (window-anchored `UIActivityViewController`) |
| Android    | Stub + #917 follow-up (`Intent.ACTION_SEND` chooser)              |
| Windows    | Stub + #917 follow-up (`DataTransferManager.ShowShareUI`)         |
| Linux/GTK4 | Stub + #917 follow-up (XDG share portal)                           |
| WASM       | Stub via dispatch table fallback                                   |
| HarmonyOS  | Stub auto-generated by `perry-runtime/build.rs`                  |

Every stub funnels through `perry_runtime::stub_diag::perry_stub_warn`, so first call per process per symbol prints a `[perry] warning` line naming the platform and the #917 tracker.

## macOS implementation detail

`NSSharingServicePicker initWithItems` → `showRelativeToRect:ofView:preferredEdge:` anchored to the key window's content-view bounds (`NSRectEdgeMinY` so the popover renders above the view). `shareText` wraps the value as `NSString`; `shareUrl` wraps as `NSURL` so the picker offers Safari / Reading List / Bookmarks alongside Messages / Mail / Notes. Malformed URLs fall back to plain-text sharing.

The `title` argument is currently dropped on macOS (Cocoa's picker derives its label from the item type); kept in the signature for cross-platform symmetry with iOS/Android where title is meaningful.

## Plumbing (mirrors #918's takeScreenshot pattern)

- API manifest, dispatch table, every per-platform UI crate, testkit feature matrix, HarmonyOS auto-stub via `build.rs`. WASM falls through to `ui_method_to_runtime()` so no parallel edit there.

## Smoke test

Compiled `App({body}) + shareText() + shareUrl()` against release perry; symbols resolve end-to-end, link succeeds, binary writes cleanly.

## What's deferred (#917 follow-ups)

- **iOS / Android / Windows / Linux / visionOS native impls** — issue maps each native API.
- **`shareItems({text?, url?, title?})`** structured variant — dispatch is forward-compatible; a new `MethodRow` will land it without changing the two convenience entry points.

## Notes

No `Cargo.toml` version bump, no `CLAUDE.md` touch, no `CHANGELOG.md` entry — maintainer folds those in at merge time.