### PR TITLE
feat(perry/system): #675 — App Group / cross-process shared storage

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2104,6 +2104,16 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // shapes: plain text + URL.
     method("perry/system", "shareText", false, None),
     method("perry/system", "shareUrl", false, None),
+    // #675 — App Group / cross-process shared storage. Widget
+    // extensions, share extensions, watchOS targets, etc. all need
+    // a way to share key/value data with the host app. macOS/iOS:
+    // `UserDefaults(suiteName:)`. Android: scoped SharedPreferences
+    // (follow-up). Every other platform: an in-process HashMap
+    // fallback so the API surface is exercisable in dev/tests; not
+    // actually cross-process there. Follow-up tracker: #675.
+    method("perry/system", "appGroupSet", false, None),
+    method("perry/system", "appGroupGet", false, None),
+    method("perry/system", "appGroupDelete", false, None),
     method("perry/system", "keychainSave", false, None),
     method("perry/system", "keychainGet", false, None),
     method("perry/system", "keychainDelete", false, None),

--- a/crates/perry-dispatch/src/lib.rs
+++ b/crates/perry-dispatch/src/lib.rs
@@ -2119,6 +2119,28 @@ pub static PERRY_SYSTEM_TABLE: &[MethodRow] = &[
         args: &[ArgKind::Str, ArgKind::Str],
         ret: ReturnKind::Void,
     },
+    // #675 — App Group / cross-process shared storage. set/get/delete
+    // map to the platform's native shared-storage suite on Apple
+    // platforms (`UserDefaults(suiteName:)`); other platforms get an
+    // in-process HashMap fallback for API parity.
+    MethodRow {
+        method: "appGroupSet",
+        runtime: "perry_system_app_group_set",
+        args: &[ArgKind::Str, ArgKind::Str],
+        ret: ReturnKind::Void,
+    },
+    MethodRow {
+        method: "appGroupGet",
+        runtime: "perry_system_app_group_get",
+        args: &[ArgKind::Str],
+        ret: ReturnKind::Str,
+    },
+    MethodRow {
+        method: "appGroupDelete",
+        runtime: "perry_system_app_group_delete",
+        args: &[ArgKind::Str],
+        ret: ReturnKind::Void,
+    },
     MethodRow {
         method: "keychainSave",
         runtime: "perry_system_keychain_save",

--- a/crates/perry-ui-android/src/lib.rs
+++ b/crates/perry-ui-android/src/lib.rs
@@ -1432,6 +1432,35 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "perry_system_share_url",
         "Android Intent.ACTION_SEND not yet implemented (#917 follow-up)",
         Some("#917"),
+// #675 — App Group stubs on Android. Native impl will use scoped
+// `SharedPreferences` keyed by `shared_prefs_name` from perry.toml,
+// dispatched through JNI; tracked as #675 follow-up.
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_set(_key_ptr: i64, _value_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_set",
+        "Android SharedPreferences not yet implemented (#675 follow-up)",
+        Some("#675"),
+    );
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_get(_key_ptr: i64) -> i64 {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_get",
+        "Android SharedPreferences not yet implemented (#675 follow-up)",
+        Some("#675"),
+    );
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_delete(_key_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_delete",
+        "Android SharedPreferences not yet implemented (#675 follow-up)",
+        Some("#675"),
     );
 }
 

--- a/crates/perry-ui-gtk4/src/lib.rs
+++ b/crates/perry-ui-gtk4/src/lib.rs
@@ -1730,6 +1730,36 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "perry_system_share_url",
         "GTK4/Linux XDG share portal not yet wired (#917 follow-up)",
         Some("#917"),
+// #675 — App Group stubs on GTK4 / Linux. Native impl will use a
+// per-user XDG path (`$XDG_DATA_HOME/<bundle_id>/shared/`) for the
+// blob shape and a small JSON-backed kv store; tracked as #675
+// follow-up.
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_set(_key_ptr: i64, _value_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_set",
+        "GTK4/Linux XDG-backed App Group not implemented (#675 follow-up)",
+        Some("#675"),
+    );
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_get(_key_ptr: i64) -> i64 {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_get",
+        "GTK4/Linux XDG-backed App Group not implemented (#675 follow-up)",
+        Some("#675"),
+    );
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_delete(_key_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_delete",
+        "GTK4/Linux XDG-backed App Group not implemented (#675 follow-up)",
+        Some("#675"),
     );
 }
 

--- a/crates/perry-ui-ios/src/lib.rs
+++ b/crates/perry-ui-ios/src/lib.rs
@@ -1393,6 +1393,69 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "iOS UIActivityViewController not yet implemented (#917 follow-up)",
         Some("#917"),
     );
+// #675 — App Group / cross-process shared storage on iOS. MVP uses
+// an in-process HashMap so the API is exercisable from user code;
+// the native impl (UserDefaults(suiteName:) read from
+// `application-groups` entitlement) is tracked under #675 follow-up.
+// First call per process per symbol prints a `[perry] warning` line
+// so developers know they're not getting cross-process behavior yet.
+fn app_group_store_ios() -> &'static std::sync::Mutex<std::collections::HashMap<String, String>> {
+    static STORE: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, String>>> =
+        std::sync::OnceLock::new();
+    STORE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+fn app_group_str_from_header_ios(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_set(key_ptr: i64, value_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_set",
+        "iOS App Group is an in-process HashMap in this MVP (#675 follow-up: UserDefaults(suiteName:))",
+        Some("#675"),
+    );
+    let key = app_group_str_from_header_ios(key_ptr as *const u8);
+    let value = app_group_str_from_header_ios(value_ptr as *const u8);
+    if key.is_empty() {
+        return;
+    }
+    if let Ok(mut g) = app_group_store_ios().lock() {
+        g.insert(key.to_string(), value.to_string());
+    }
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_get(key_ptr: i64) -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    let key = app_group_str_from_header_ios(key_ptr as *const u8);
+    if key.is_empty() {
+        return unsafe { js_string_from_bytes(std::ptr::null(), 0) };
+    }
+    let value = app_group_store_ios()
+        .lock()
+        .ok()
+        .and_then(|g| g.get(key).cloned())
+        .unwrap_or_default();
+    unsafe { js_string_from_bytes(value.as_ptr(), value.len() as i32) }
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_delete(key_ptr: i64) {
+    let key = app_group_str_from_header_ios(key_ptr as *const u8);
+    if key.is_empty() {
+        return;
+    }
+    if let Ok(mut g) = app_group_store_ios().lock() {
+        g.remove(key);
+    }
 }
 
 /// Open a URL in the default browser/app.

--- a/crates/perry-ui-macos/src/lib.rs
+++ b/crates/perry-ui-macos/src/lib.rs
@@ -1644,6 +1644,117 @@ unsafe fn present_sharing_picker(items: *mut objc2::runtime::AnyObject) {
     ];
 }
 
+// #675 — App Group / cross-process shared storage on macOS.
+//
+// Backed by `NSUserDefaults(suiteName:)`. The suite name is read
+// from the `PERRY_APP_GROUP` environment variable so an app's
+// signing identity can override the default without a recompile;
+// when unset, falls back to `"group.perryapp"` which is fine for
+// the dev flow (no entitlement → the suite simply lives under
+// `~/Library/Preferences/group.perryapp.plist` instead of inside
+// the shared App Group container).
+
+fn app_group_suite() -> objc2::rc::Retained<objc2_foundation::NSString> {
+    let suite = std::env::var("PERRY_APP_GROUP").unwrap_or_else(|_| "group.perryapp".to_string());
+    objc2_foundation::NSString::from_str(&suite)
+}
+
+unsafe fn app_group_defaults() -> *mut objc2::runtime::AnyObject {
+    let cls = objc2::runtime::AnyClass::get(c"NSUserDefaults").unwrap();
+    let alloc: *mut objc2::runtime::AnyObject = objc2::msg_send![cls, alloc];
+    let suite = app_group_suite();
+    let defaults: *mut objc2::runtime::AnyObject =
+        objc2::msg_send![alloc, initWithSuiteName: &*suite];
+    defaults
+}
+
+fn appgroup_str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const crate::string_header::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<crate::string_header::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// #675 — set a key in the App Group's `NSUserDefaults` suite.
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_set(key_ptr: i64, value_ptr: i64) {
+    let key = appgroup_str_from_header(key_ptr as *const u8);
+    let value = appgroup_str_from_header(value_ptr as *const u8);
+    if key.is_empty() {
+        return;
+    }
+    unsafe {
+        let defaults = app_group_defaults();
+        if defaults.is_null() {
+            return;
+        }
+        let ns_key = objc2_foundation::NSString::from_str(key);
+        let ns_value = objc2_foundation::NSString::from_str(value);
+        let _: () = objc2::msg_send![defaults, setObject: &*ns_value, forKey: &*ns_key];
+        let _: () = objc2::msg_send![defaults, synchronize];
+    }
+}
+
+/// #675 — read a key from the App Group suite. Returns the empty
+/// string when the key is absent (matches the contract documented in
+/// the issue: "" if absent).
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_get(key_ptr: i64) -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    let empty = || unsafe { js_string_from_bytes(std::ptr::null(), 0) };
+    let key = appgroup_str_from_header(key_ptr as *const u8);
+    if key.is_empty() {
+        return empty();
+    }
+    unsafe {
+        let defaults = app_group_defaults();
+        if defaults.is_null() {
+            return empty();
+        }
+        let ns_key = objc2_foundation::NSString::from_str(key);
+        let value: *mut objc2::runtime::AnyObject =
+            objc2::msg_send![defaults, stringForKey: &*ns_key];
+        if value.is_null() {
+            return empty();
+        }
+        // Convert NSString -> UTF-8 bytes.
+        let utf8_ptr: *const u8 = objc2::msg_send![value, UTF8String];
+        if utf8_ptr.is_null() {
+            return empty();
+        }
+        let utf8_len: usize = objc2::msg_send![value, lengthOfBytesUsingEncoding: 4u64]; // NSUTF8StringEncoding = 4
+        if utf8_len == 0 {
+            return empty();
+        }
+        js_string_from_bytes(utf8_ptr, utf8_len as i32)
+    }
+}
+
+/// #675 — remove a key from the App Group suite.
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_delete(key_ptr: i64) {
+    let key = appgroup_str_from_header(key_ptr as *const u8);
+    if key.is_empty() {
+        return;
+    }
+    unsafe {
+        let defaults = app_group_defaults();
+        if defaults.is_null() {
+            return;
+        }
+        let ns_key = objc2_foundation::NSString::from_str(key);
+        let _: () = objc2::msg_send![defaults, removeObjectForKey: &*ns_key];
+        let _: () = objc2::msg_send![defaults, synchronize];
+    }
+}
+
 /// Open a URL in the default browser/app.
 #[no_mangle]
 pub extern "C" fn perry_system_open_url(url_ptr: i64) {

--- a/crates/perry-ui-test/src/lib.rs
+++ b/crates/perry-ui-test/src/lib.rs
@@ -1457,6 +1457,11 @@ pub const FEATURES: &[Feature] = &[
     // (per-platform native impls land as #917 follow-ups).
     Feature {
         name: "perry_system_share_text",
+    // #675: App Group / cross-process shared storage. macOS has the
+    // real NSUserDefaults(suiteName:) impl; iOS has the in-process
+    // HashMap MVP; every other platform is a first-call-warning stub.
+    Feature {
+        name: "perry_system_app_group_set",
         category: SystemApi,
         macos: S,
         ios: S,
@@ -1468,6 +1473,18 @@ pub const FEATURES: &[Feature] = &[
     },
     Feature {
         name: "perry_system_share_url",
+        name: "perry_system_app_group_get",
+        category: SystemApi,
+        macos: S,
+        ios: S,
+        android: S,
+        gtk4: S,
+        windows: S,
+        web: S,
+        web_name: None,
+    },
+    Feature {
+        name: "perry_system_app_group_delete",
         category: SystemApi,
         macos: S,
         ios: S,

--- a/crates/perry-ui-tvos/src/lib.rs
+++ b/crates/perry-ui-tvos/src/lib.rs
@@ -1280,6 +1280,36 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "perry_system_share_url",
         "tvOS does not expose a programmatic share sheet (#917)",
         Some("#917"),
+// #675 — App Group / cross-process shared storage. MVP stubs on
+// tvOS; tvOS user apps don't typically share data cross-process,
+// and the matching real impl (UserDefaults(suiteName:)) isn't
+// commonly used here. Stub + first-call warning so callers know.
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_set(_key_ptr: i64, _value_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_set",
+        "tvOS App Group not implemented (#675 follow-up)",
+        Some("#675"),
+    );
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_get(_key_ptr: i64) -> i64 {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_get",
+        "tvOS App Group not implemented (#675 follow-up)",
+        Some("#675"),
+    );
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_delete(_key_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_delete",
+        "tvOS App Group not implemented (#675 follow-up)",
+        Some("#675"),
     );
 }
 

--- a/crates/perry-ui-visionos/src/lib.rs
+++ b/crates/perry-ui-visionos/src/lib.rs
@@ -1399,6 +1399,34 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "perry_system_share_url",
         "visionOS share sheet not yet implemented (#917 follow-up)",
         Some("#917"),
+// #675 — App Group stubs on visionOS. Same UserDefaults(suiteName:)
+// path as iOS will work; tracked as #675 follow-up.
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_set(_key_ptr: i64, _value_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_set",
+        "visionOS App Group not implemented (#675 follow-up)",
+        Some("#675"),
+    );
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_get(_key_ptr: i64) -> i64 {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_get",
+        "visionOS App Group not implemented (#675 follow-up)",
+        Some("#675"),
+    );
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_delete(_key_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_delete",
+        "visionOS App Group not implemented (#675 follow-up)",
+        Some("#675"),
     );
 }
 

--- a/crates/perry-ui-watchos/src/lib.rs
+++ b/crates/perry-ui-watchos/src/lib.rs
@@ -1191,6 +1191,36 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "perry_system_share_url",
         "watchOS does not expose a programmatic share sheet (#917)",
         Some("#917"),
+// #675 — App Group stubs on watchOS. WatchKit *does* support
+// `UserDefaults(suiteName:)` against the same App Group entitlement
+// as the iOS host, but the wiring is more complex; tracked as
+// #675 follow-up.
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_set(_key_ptr: i64, _value_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_set",
+        "watchOS App Group not implemented (#675 follow-up)",
+        Some("#675"),
+    );
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_get(_key_ptr: i64) -> i64 {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_get",
+        "watchOS App Group not implemented (#675 follow-up)",
+        Some("#675"),
+    );
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_delete(_key_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_delete",
+        "watchOS App Group not implemented (#675 follow-up)",
+        Some("#675"),
     );
 }
 #[no_mangle]

--- a/crates/perry-ui-windows/src/lib.rs
+++ b/crates/perry-ui-windows/src/lib.rs
@@ -1573,6 +1573,35 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "perry_system_share_url",
         "Windows DataTransferManager not yet wired (#917 follow-up)",
         Some("#917"),
+// #675 — App Group stubs on Windows. Native impl will use
+// `%LOCALAPPDATA%\<bundle_id>\shared\` for the blob shape and a
+// JSON-backed kv store; tracked as #675 follow-up.
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_set(_key_ptr: i64, _value_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_set",
+        "Windows %LOCALAPPDATA%-backed App Group not implemented (#675 follow-up)",
+        Some("#675"),
+    );
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_get(_key_ptr: i64) -> i64 {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_get",
+        "Windows %LOCALAPPDATA%-backed App Group not implemented (#675 follow-up)",
+        Some("#675"),
+    );
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}
+#[no_mangle]
+pub extern "C" fn perry_system_app_group_delete(_key_ptr: i64) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        "perry_system_app_group_delete",
+        "Windows %LOCALAPPDATA%-backed App Group not implemented (#675 follow-up)",
+        Some("#675"),
     );
 }
 

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 903 entries across 71 modules
+// Coverage: 906 entries across 71 modules
 
 declare module "argon2" {
   /** stdlib */
@@ -695,6 +695,12 @@ declare module "perry/plugin" {
 declare module "perry/system" {
   /** stdlib */
   export function appGetLaunchUrl(...args: any[]): any;
+  /** stdlib */
+  export function appGroupDelete(...args: any[]): any;
+  /** stdlib */
+  export function appGroupGet(...args: any[]): any;
+  /** stdlib */
+  export function appGroupSet(...args: any[]): any;
   /** stdlib */
   export function appOnOpenUrl(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 903 entries across 71 modules.
+Total: 906 entries across 71 modules.
 
 ## Modules
 
@@ -902,6 +902,9 @@ Total: 903 entries across 71 modules.
 ### Methods
 
 - `appGetLaunchUrl` — module
+- `appGroupDelete` — module
+- `appGroupGet` — module
+- `appGroupSet` — module
 - `appOnOpenUrl` — module
 - `audioGetLevel` — module
 - `audioGetPeak` — module


### PR DESCRIPTION
Closes #675 (MVP — see follow-up matrix).

## Summary

Three new `perry/system` entry points so widgets, share extensions, watchOS targets, etc. can share key/value data with the host app:

```typescript,no-test
import { appGroupSet, appGroupGet, appGroupDelete } from "perry/system";

appGroupSet("sessionToken", "abc123");
const t = appGroupGet("sessionToken");  // "abc123" — "" if absent
appGroupDelete("sessionToken");
```

Without this, the only official way to wire a Perry app to a Perry-built widget extension was to hand-write a Rust+Swift bridge per project. The issue calls this out as a steep onboarding cliff that creates a forest of subtly-different forks across the ecosystem.

## Cross-platform coverage

| Platform   | Status                                                       |
|------------|--------------------------------------------------------------|
| **macOS**  | **Real impl** — `NSUserDefaults(suiteName:)`, default suite name `"group.perryapp"` overridable via `PERRY_APP_GROUP` env var |
| **iOS**    | In-process HashMap MVP (API exercisable in dev/tests) + #675 follow-up warning |
| tvOS       | Stub (tvOS user apps rarely share data cross-process)        |
| watchOS    | Stub + #675 follow-up                                        |
| visionOS   | Stub + #675 follow-up                                        |
| Android    | Stub + #675 follow-up (`SharedPreferences` via JNI)        |
| Windows    | Stub + #675 follow-up (`%LOCALAPPDATA%`-backed kv)         |
| Linux/GTK4 | Stub + #675 follow-up (XDG-backed kv)                        |
| WASM       | Stub via dispatch table fallback                             |
| HarmonyOS  | Stub auto-generated by `perry-runtime/build.rs`            |

Every stub funnels through `perry_runtime::stub_diag::perry_stub_warn` so first call per process per symbol prints a `[perry] warning` line naming the platform and the #675 tracker.

## macOS implementation detail

`NSUserDefaults initWithSuiteName:` → `setObject:forKey:` / `stringForKey:` / `removeObjectForKey:` → `synchronize`. The suite name is read from the `PERRY_APP_GROUP` environment variable; defaults to `"group.perryapp"`.

For dev builds without the `application-groups` entitlement, the suite still works — it just stores under `~/Library/Preferences/group.perryapp.plist` instead of inside the shared App Group container. That makes the API usable in local iteration without setting up code-signing.

`appGroupGet` returns the empty string when the key is absent (per the issue's contract). NSString → UTF-8 bytes via `UTF8String` + `lengthOfBytesUsingEncoding:NSUTF8StringEncoding` (= 4).

## Plumbing (mirrors #918 / #917 pattern)

- `perry-api-manifest/src/entries.rs` — three method rows.
- `perry-dispatch/src/lib.rs` — three `MethodRow` rows (set: `[Str, Str] → Void`, get: `[Str] → Str`, delete: `[Str] → Void`). WASM falls through to `ui_method_to_runtime()` — symbol mapping for free.
- Per-platform exports across all UI crates.
- `perry-ui-test/src/lib.rs` — three `Feature` rows.
- HarmonyOS auto-stubbed via `perry-runtime/build.rs`.

## Smoke test

`App({body}) + appGroupSet + appGroupGet + appGroupDelete` against release perry compiles + links cleanly; symbol resolution verified end-to-end.

## What's deferred (#675 follow-ups)

- `writeBlob`/`readBlob` — file-backed shared data the issue calls out (`FileManager.containerURL` on iOS, XDG on Linux, etc.).
- Real iOS / Android / Windows / Linux / visionOS impls.
- `perry.toml` `[ios].app_group` + `[android].shared_prefs_name` configuration plumbing — currently hardcoded to the `PERRY_APP_GROUP` env var on macOS.
- Entitlement merge into Perry's signing pipeline for App Group capability.

## Notes

No `Cargo.toml` version bump, no `CLAUDE.md` touch, no `CHANGELOG.md` entry — maintainer folds those in at merge time.