### PR TITLE
fix(runtime): string.match() honors fancy-regex fallback (date-fns format)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.985 — fix(runtime): `string.match(regex)` honors fancy-regex fallback for backreferenced patterns (date-fns format() unblocked)
+
+**Symptom.** With v0.5.984's `Date.prototype.constructor` fix in place, date-fns 4.x `format(new Date(2024, 0, 15), 'yyyy-MM-dd')` got past `constructFrom` but then crashed:
+
+```
+[NULL_PTR_METHOD_CALL] js_native_call_method: null pointer object for method 'map'
+TypeError: Cannot read properties of undefined (reading 'map')
+```
+
+**Root cause.** date-fns' `format.js` tokenizes the format string via:
+
+```js
+const formattingTokensRegExp =
+  /[yYQqMLwIdDecihHKkms]o|(\w)\1*|''|'(''|[^'])+('|$)|./g;
+
+let parts = formatStr.match(longFormattingTokensRegExp)
+  .map(...)
+  .join("")
+  .match(formattingTokensRegExp)
+  .map(...);
+```
+
+The `(\w)\1*` backreference is fine in V8 but the Rust `regex` crate rejects it. Perry's `get_or_compile_regex` already had a fancy-regex fallback path: when the standard regex crate fails to compile a pattern, it stashes the compiled fancy-regex into `FANCY_CACHE` and substitutes a never-match `[^\s\S]` placeholder in the primary slot. The placeholder kept `js_regexp_test` / `js_regexp_exec` callers from crashing, and `js_regexp_exec` itself had explicit fancy-fallback wiring (`fancy_captures = FANCY_CACHE.with(...)` before the standard `regex.captures(...)` call).
+
+But `js_string_match` (the `String.prototype.match` entry point) never consulted `FANCY_CACHE`. It just dispatched to the never-match placeholder and returned `null`. The chained `.map(...)` then crashed with the NULL_PTR_METHOD_CALL above. `js_string_match_all` and `js_string_search_regex` had the same gap, but the failing date-fns path goes through `js_string_match` so this fix targets that entry point.
+
+**Fix.** Added `lookup_fancy_regex(re)` helper next to `js_string_match` in `crates/perry-runtime/src/regex.rs` that returns `Some(Arc<fancy_regex::Regex>)` whenever the header's `(pattern, flags)` is registered in `FANCY_CACHE`. `js_string_match` now checks the cache before falling through to the standard `regex` crate:
+
+- **Global flag**: collects all matches via `fre.find_iter(str_data)` and builds the same NaN-boxed-string array shape as the standard path.
+- **Non-global**: returns the full match plus capture groups via `fre.captures(str_data)`. (Named-capture `groups` is left null for the fancy path — none of the date-fns format regexes use named captures, and the existing standard-regex path already handles named captures via the same `LAST_EXEC_GROUPS` thread-local that gets cleared here.)
+
+**Validation.**
+
+- `format(new Date(2024, 0, 15), 'yyyy-MM-dd')` → `2024-01-15` (matches Node).
+- Additional date-fns format strings tested against Node: `'HH:mm:ss'`, `'yyyy-MM-dd HH:mm:ss'`, `'MMM yyyy'`, `'EEEE, MMMM do yyyy'` — all byte-for-byte parity.
+- New `test-files/test_date_fns_format.ts` exercises the underlying `(\w)\1*` pattern shape (global + non-global) and the no-match-returns-null case without importing date-fns directly.
+
+**Follow-ups.** `js_string_match_all`, `js_regexp_test`, and `js_string_search_regex` still consult only the placeholder regex when the pattern needed fancy-regex. None are on date-fns' `format()` hot path so they're deferred to a separate issue; the same `lookup_fancy_regex` helper can wire them in when needed.
+
 ## v0.5.984 — feat(runtime): `.constructor` on Date / Array / Object instances + `new <inst.constructor>(...)` dispatch
 
 **Symptom.** date-fns 4.x throws `RangeError: Invalid time value` on the very first call to `format(new Date(2024, 0, 15), 'yyyy-MM-dd')`. Root cause is `constructFrom(date, value)` — the helper every other date-fns export funnels through:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.984
+**Current Version:** 0.5.985
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.984"
+version = "0.5.985"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "base64",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5564,11 +5564,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.984"
+version = "0.5.985"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "itoa",
  "jni",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "block2",
  "libc",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "block2",
  "libc",
@@ -5645,11 +5645,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.984"
+version = "0.5.985"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "block2",
  "libc",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "block2",
  "libc",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "block2",
  "libc",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.984"
+version = "0.5.985"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.984"
+version = "0.5.985"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -298,6 +298,21 @@ pub extern "C" fn js_regexp_test(re: *const RegExpHeader, s: *const StringHeader
     }
 }
 
+/// Look up a fancy-regex fallback for the given header, if one was
+/// registered at compile-time because the `regex` crate rejected the
+/// pattern (backreferences, lookbehind, etc.).
+fn lookup_fancy_regex(re: *const RegExpHeader) -> Option<Arc<fancy_regex::Regex>> {
+    unsafe {
+        let pat = string_as_str((*re).pattern_ptr);
+        let flags_str = string_as_str((*re).flags_ptr);
+        FANCY_CACHE.with(|fc| {
+            fc.borrow()
+                .get(&(pat.to_string(), flags_str.to_string()))
+                .cloned()
+        })
+    }
+}
+
 /// Find matches in a string
 /// string.match(regex) -> string[] | null (returns array pointer, null if no match)
 #[no_mangle]
@@ -314,6 +329,66 @@ pub extern "C" fn js_string_match(
     unsafe {
         let regex = &*(*re).regex_ptr;
         let global = (*re).global;
+
+        // If this regex couldn't be compiled by the `regex` crate (e.g.
+        // backreferences like `(\w)\1*`, used by date-fns' format token
+        // regex), `get_or_compile_regex` substituted a never-match
+        // `[^\s\S]` placeholder and stashed the real pattern in
+        // `FANCY_CACHE`. Route through fancy-regex so `.match()` returns
+        // real results instead of always-null.
+        if let Some(fre) = lookup_fancy_regex(re) {
+            if global {
+                // Collect all non-overlapping matches via fancy-regex's
+                // find_iter. Mirrors the `regex` crate global path below.
+                let mut matches: Vec<String> = Vec::new();
+                let mut iter = fre.find_iter(str_data);
+                while let Some(Ok(m)) = iter.next() {
+                    matches.push(m.as_str().to_string());
+                }
+                if matches.is_empty() {
+                    return ptr::null_mut();
+                }
+                let arr = crate::array::js_array_alloc(matches.len() as u32);
+                (*arr).length = matches.len() as u32;
+                let elements_ptr =
+                    (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+                for (i, m) in matches.iter().enumerate() {
+                    let str_ptr = js_string_from_str(m);
+                    let nanboxed = js_nanbox_string(str_ptr as i64);
+                    std::ptr::write(elements_ptr.add(i), nanboxed);
+                }
+                return arr;
+            } else {
+                // Non-global: first match + capture groups (parallels the
+                // standard-regex non-global branch below).
+                match fre.captures(str_data) {
+                    Ok(Some(caps)) => {
+                        let arr = crate::array::js_array_alloc(caps.len() as u32);
+                        (*arr).length = caps.len() as u32;
+                        let elements_ptr =
+                            (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+                        for i in 0..caps.len() {
+                            if let Some(m) = caps.get(i) {
+                                let str_ptr = js_string_from_str(m.as_str());
+                                let nanboxed = js_nanbox_string(str_ptr as i64);
+                                std::ptr::write(elements_ptr.add(i), nanboxed);
+                            } else {
+                                std::ptr::write(
+                                    elements_ptr.add(i),
+                                    f64::from_bits(0x7FFC_0000_0000_0001),
+                                );
+                            }
+                        }
+                        LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
+                        return arr;
+                    }
+                    _ => {
+                        LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
+                        return ptr::null_mut();
+                    }
+                }
+            }
+        }
 
         if global {
             // Global flag: return all matches

--- a/test-files/test_date_fns_format.ts
+++ b/test-files/test_date_fns_format.ts
@@ -1,0 +1,29 @@
+// Regression: date-fns format() needs `string.match()` to honor
+// fancy-regex fallback for patterns with backreferences (`(\w)\1*`).
+// Before this fix, `formatStr.match(formattingTokensRegExp)` returned
+// null because the regex crate rejected the pattern and the fancy
+// fallback was only wired into `RegExp.prototype.exec()`. The downstream
+// `.map(...)` then crashed with NULL_PTR_METHOD_CALL.
+//
+// We don't import date-fns here (it's a compilePackages dep, not a test
+// dep). Instead, exercise the underlying regex shape that drives format().
+
+const formattingTokensRegExp =
+  /[yYQqMLwIdDecihHKkms]o|(\w)\1*|''|'(''|[^'])+('|$)|./g;
+
+const tokens = "yyyy-MM-dd HH:mm:ss".match(formattingTokensRegExp);
+console.log(tokens);
+
+const tokens2 = "EEEE, MMMM do yyyy".match(formattingTokensRegExp);
+console.log(tokens2);
+
+// Backreference + non-global (returns first match w/ captures)
+const simple = /(\w)\1*/;
+console.log("abcaaab".match(simple));
+
+// Backreference + global
+const g = /(\w)\1*/g;
+console.log("aabbbccdd".match(g));
+
+// No-match returns null
+console.log("xyz".match(/(\w)\1+/));


### PR DESCRIPTION
## Summary

- `date-fns` 4.x `format()` got past `constructFrom` (PR #973) but immediately tripped on `formatStr.match(/[yYQqMLwIdDecihHKkms]o|(\w)\1*|''|'(''|[^'])+('|$)|./g).map(...)` because the regex contains a `(\w)\1*` backreference. The Rust `regex` crate rejects backreferences, so `get_or_compile_regex` substituted a never-match `[^\s\S]` placeholder and stashed the real pattern in `FANCY_CACHE` for fancy-regex to handle.
- `RegExp.prototype.exec` already wired up the fancy fallback (lookup before falling through), but `String.prototype.match` didn't. `formatStr.match(...)` therefore returned `null`, and the chained `.map(...)` blew up with `NULL_PTR_METHOD_CALL`.
- Add `lookup_fancy_regex(re)` helper, have `js_string_match` consult `FANCY_CACHE` first. Global flag walks `fre.find_iter`; non-global returns the full match + capture groups via `fre.captures`. Pattern + flags + array shape match the standard-regex path exactly.

Validation:
- `format(new Date(2024, 0, 15), 'yyyy-MM-dd')` → `2024-01-15` (matches Node).
- Also exercised `'HH:mm:ss'`, `'yyyy-MM-dd HH:mm:ss'`, `'MMM yyyy'`, `'EEEE, MMMM do yyyy'` — byte-for-byte parity.
- `test-files/test_date_fns_format.ts` covers the underlying regex shape (global + non-global + no-match) without importing date-fns directly.

Follow-ups (not in this PR): `js_string_match_all`, `js_regexp_test`, and `js_string_search_regex` still consult only the placeholder for fancy patterns. None are on date-fns' `format()` hot path; the same `lookup_fancy_regex` helper can be wired in when needed.

## Test plan
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry`
- [x] `format(new Date(2024, 0, 15), 'yyyy-MM-dd')` returns `2024-01-15` via `compilePackages: ["date-fns"]`
- [x] Multi-format parity check vs `node --experimental-strip-types`
- [x] `test-files/test_date_fns_format.ts` matches Node for `(\w)\1*` global + non-global + no-match
- [ ] CI: `lint`, `cargo-test`, `parity`, `compile-smoke`, `api-docs-drift`, `security-audit`