### PR TITLE
fix(hir+runtime): Constructor.prototype method dispatch on instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.987 — fix(hir+runtime): Constructor.prototype method dispatch for computed keys + read-side introspection (ramda transducer pattern)
+
+**Symptom.** `XWrap.prototype['@@transducer/step'] = function(acc, x) { … }` — ramda's transducer scaffolding (`_xwrap.js`) plus any pre-ES6 library that attaches instance methods through a computed string-literal key — pre-fix silently fell through to a generic `PropertySet` because the assignment-side recogniser in `lower/expr_assign.rs` only matched the `MemberProp::Ident` shape (`.method = fn`). Subsequent `(new XWrap(fn))['@@transducer/step'](acc, x)` then threw `undefined is not a function` even though the dispatch hot path was perfectly capable of finding the method via `CLASS_PROTOTYPE_METHODS` — the side-table just never got populated.
+
+A second, narrower gap: even when the assignment route worked (Ident-prop form), `(Foo.prototype as any).method` reads on the function-classic shape evaluated to `undefined` because no synthetic prototype object was ever materialised. `typeof Foo.prototype.method` returned `'undefined'` despite `(new Foo()).method` reaching the registered closure correctly.
+
+**Fix — two coordinated arms:**
+
+1. **HIR assignment-side recogniser (`crates/perry-hir/src/lower/expr_assign.rs`):** extend the `<funcDecl>.prototype.<key>` matcher to handle `MemberProp::Computed(Expr::Lit::Str)` in addition to the existing `MemberProp::Ident`. The recogniser still requires a static string-literal key (computed expressions whose value isn't compile-time-resolvable still fall through to the generic dynamic PropertySet — which is fine for the rare runtime-key case). Mirrors the same key-resolution shape `lower/expr_object.rs` uses for object-literal computed keys.
+
+2. **HIR read-side recogniser (`crates/perry-hir/src/lower/expr_member.rs`) + new HIR variant `Expr::GetFunctionPrototypeMethod`:** when the AST shape `<funcDecl>.prototype.<name>` (or `<funcDecl>.prototype['<name>']`) reaches member lowering and the receiver resolves to a function-typed local or top-level `FuncRef` (skipping `class C {}` blocks, which have a real proto object, and named native imports, which are module-managed), emit a direct lookup into the side-table via the new runtime helper `js_get_function_prototype_method(func_value, name_ptr, name_len) -> f64`. Returns the registered closure (NaN-boxed) or `undefined` if no method by that name was registered against the function's synthetic class id. Mirrors `function_class_id` (read-only — does NOT allocate a new synthetic id, so reads on a function that never had any `.prototype.x = fn` write correctly return `undefined`).
+
+Together these close the round-trip: ramda's `XWrap.prototype['@@transducer/init/result/step']` triplet now both registers and reads back, and the `typeof Foo.prototype.method === 'function'` spec idiom returns `'function'` byte-for-byte against Node's output.
+
+**Validation.**
+
+`test-files/test_constructor_prototype_method.ts` (new, four assertions covering Ident-prop assign, second Ident-prop assign, prototype-method read+typeof, computed-key assign+call) now matches `node --experimental-strip-types` line-for-line:
+
+```
+5
+10
+function
+15
+```
+
+A standalone IIFE-style transducer (mirrors ramda's `_xwrap.js`) also passes:
+
+```ts
+var XWrap = (function () { function XWrap(fn) { this.f = fn; }
+  XWrap.prototype['@@transducer/step'] = function (acc, x) { return this.f(acc, x); };
+  return XWrap; })();
+// new XWrap(add)['@@transducer/step'](10, 5) === 15
+```
+
+**Known next blocker — `import * as R from 'ramda'`:** every individual ramda module imports cleanly through the direct-path shape (`import sum from 'ramda/src/sum.js'`) — verified by bisecting all 269 entries. The combined `import * as R from 'ramda'` (or a single named import like `import { sum } from 'ramda'`) still throws `TypeError: value is not a function` at module init, before any user code runs. The failure isn't surfaced by individual-module imports, so it's a cross-module init-time interaction (likely topological-sort or shared-singleton). This is unrelated to the prototype-method shape addressed here.
+
+Files: `crates/perry-hir/src/ir.rs`, `crates/perry-hir/src/lower/expr_assign.rs`, `crates/perry-hir/src/lower/expr_member.rs`, `crates/perry-hir/src/walker.rs`, `crates/perry-hir/src/stable_hash.rs`, `crates/perry-codegen/src/expr.rs`, `crates/perry-codegen/src/collectors.rs`, `crates/perry-codegen/src/runtime_decls.rs`, `crates/perry-runtime/src/object.rs`, `test-files/test_constructor_prototype_method.ts`.
+
 ## v0.5.986 — fix(runtime+codegen): Object.prototype.toString / Array.prototype.slice / hasOwnProperty / propertyIsEnumerable / fn.length for ramda init
 
 **Symptom.** `import * as R from 'ramda'` (after #970 landed `Function.prototype.apply`/`.call`) throws three different errors at module init depending on how far evaluation gets:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.986
+**Current Version:** 0.5.987
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.986"
+version = "0.5.987"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "base64",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5564,11 +5564,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.986"
+version = "0.5.987"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "itoa",
  "jni",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "block2",
  "libc",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "block2",
  "libc",
@@ -5645,11 +5645,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.986"
+version = "0.5.987"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "block2",
  "libc",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "block2",
  "libc",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "block2",
  "libc",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.986"
+version = "0.5.987"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.986"
+version = "0.5.987"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/collectors.rs
+++ b/crates/perry-codegen/src/collectors.rs
@@ -841,6 +841,9 @@ pub(crate) fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32
             walk(func, out);
             walk(value, out);
         }
+        Expr::GetFunctionPrototypeMethod { func, .. } => {
+            walk(func, out);
+        }
         Expr::MapNew | Expr::SetNew => {}
         Expr::SetNewFromArray(arr) => walk(arr, out),
         Expr::MapSet { map, key, value } => {

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -10781,6 +10781,31 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             );
             Ok(val_double)
         }
+        // Read side of #838 followup (b): `<funcDecl>.prototype.<name>`
+        // (Ident or computed-string-literal form) lowered into a direct
+        // lookup of the prototype-method side-table. Returns the closure
+        // value stored at registration time, or `undefined` if no method
+        // by that name was registered. Pre-fix this would fall through
+        // to a generic PropertyGet on a `Function.prototype` object that
+        // never materialised (so the read was always `undefined`,
+        // making `typeof Foo.prototype.method` come back `'undefined'`
+        // even though `(new Foo()).method` correctly reached the
+        // registered closure via the dispatch path).
+        Expr::GetFunctionPrototypeMethod { func, method_name } => {
+            let func_double = lower_expr(ctx, func)?;
+            let key_idx = ctx.strings.intern(method_name);
+            let key_bytes_global = format!("@{}", ctx.strings.entry(key_idx).bytes_global);
+            let key_len = ctx.strings.entry(key_idx).byte_len.to_string();
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_get_function_prototype_method",
+                &[
+                    (DOUBLE, &func_double),
+                    (PTR, &key_bytes_global),
+                    (I64, &key_len),
+                ],
+            ))
+        }
         // `static [Symbol.for("k")] = "v"` — register in the runtime's
         // class-static-symbol side table. Refs #420 (drizzle).
         Expr::ClassStaticSymbolSet {

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -756,6 +756,18 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // invokes the constructor with IMPLICIT_THIS bound to the new
     // instance. Returns the NaN-boxed new instance pointer.
     module.declare_function("js_new_function_construct", DOUBLE, &[DOUBLE, PTR, I64]);
+    // Read side of #838 followup (b): look up a previously-registered
+    // prototype method on a function value by name. Pairs with
+    // `js_register_function_prototype_method`. Returns the NaN-boxed
+    // closure value if the synthetic-class-id derived from the function
+    // has an entry under `name`, otherwise the NaN-boxed `undefined`
+    // tag. ramda's transducer pattern + `typeof Foo.prototype.method`
+    // introspection both reach this entry point.
+    module.declare_function(
+        "js_get_function_prototype_method",
+        DOUBLE,
+        &[DOUBLE, PTR, I64],
+    );
     module.declare_function("js_typeerror_new", I64, &[I64]);
     module.declare_function("js_rangeerror_new", I64, &[I64]);
     module.declare_function("js_syntaxerror_new", I64, &[I64]);

--- a/crates/perry-hir/src/ir.rs
+++ b/crates/perry-hir/src/ir.rs
@@ -1195,6 +1195,22 @@ pub enum Expr {
         value: Box<Expr>,
     },
 
+    // Read side of the JS-classic prototype-method pattern:
+    // `<funcDecl>.prototype.<name>` (or `<funcDecl>.prototype['<name>']`).
+    // Returns the closure stored in `CLASS_PROTOTYPE_METHODS` for the
+    // synthetic class id derived from the function value. Pre-fix this
+    // shape lowered to `PropertyGet(PropertyGet(funcDecl, "prototype"),
+    // name)` whose receiver evaluated to `undefined` — the user's
+    // `typeof Foo.prototype.method` came back as `'undefined'` even
+    // though `(new Foo()).method` reached the registered closure via
+    // the side-table walk. Ramda's transducer pattern only needs the
+    // assignment side, but the read side rounds out spec parity for
+    // `Constructor.prototype.method` introspection.
+    GetFunctionPrototypeMethod {
+        func: Box<Expr>,
+        method_name: String,
+    },
+
     // Static method call (e.g., Counter.increment())
     StaticMethodCall {
         class_name: String,

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -328,8 +328,24 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
                     }
                 }
             }
-            if let ast::MemberProp::Ident(prop_ident) = &member.prop {
-                let method_name = prop_ident.sym.to_string();
+            // Extract the method name from either an Ident prop
+            // (`p.method`) or a computed string-literal prop
+            // (`p['@@transducer/step']`). ramda's transducer pattern,
+            // Symbol.iterator stand-ins, and any "method with a dash or
+            // a slash" all reach assignment through the computed form;
+            // pre-fix only the Ident shape was recognised so these went
+            // to a generic PropertySet on an unobserved prototype proxy.
+            let method_name_opt: Option<String> = match &member.prop {
+                ast::MemberProp::Ident(prop_ident) => Some(prop_ident.sym.to_string()),
+                ast::MemberProp::Computed(c) => match c.expr.as_ref() {
+                    ast::Expr::Lit(ast::Lit::Str(s)) => {
+                        Some(s.value.as_str().unwrap_or("").to_string())
+                    }
+                    _ => None,
+                },
+                _ => None,
+            };
+            if let Some(method_name) = method_name_opt {
                 let obj_unwrapped = unwrap_ts(member.obj.as_ref());
                 // Issue #838 followup (b): track whether the recognised
                 // shape resolves to a `class C {}` (HIR class name) or a

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -397,6 +397,86 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
         }
     }
 
+    // Issue #838 followup (b) — read side: `<funcDecl>.prototype.<name>`
+    // (and the computed-string-literal form
+    // `<funcDecl>.prototype['<name>']`). The assignment side routes
+    // through `Expr::RegisterFunctionPrototypeMethod` which stores the
+    // method in `CLASS_PROTOTYPE_METHODS[synthetic_cid]`; pre-fix the
+    // matching read fell through to `PropertyGet(PropertyGet(funcDecl,
+    // "prototype"), name)` whose receiver evaluated to `undefined`, so
+    // `typeof Foo.prototype.method` came back `'undefined'` even with a
+    // working dispatch. Look up the side-table directly here. Same
+    // unwrap helper as the assignment-side recogniser so TS casts
+    // (`(Foo.prototype as any).method`) don't defeat the match.
+    {
+        fn unwrap_ts_local(e: &ast::Expr) -> &ast::Expr {
+            let mut cur = e;
+            loop {
+                match cur {
+                    ast::Expr::TsAs(x) => cur = &x.expr,
+                    ast::Expr::TsNonNull(x) => cur = &x.expr,
+                    ast::Expr::TsSatisfies(x) => cur = &x.expr,
+                    ast::Expr::TsTypeAssertion(x) => cur = &x.expr,
+                    ast::Expr::TsConstAssertion(x) => cur = &x.expr,
+                    ast::Expr::Paren(x) => cur = &x.expr,
+                    _ => return cur,
+                }
+            }
+        }
+        let method_name_opt: Option<String> = match &member.prop {
+            ast::MemberProp::Ident(p) => Some(p.sym.to_string()),
+            ast::MemberProp::Computed(c) => match c.expr.as_ref() {
+                ast::Expr::Lit(ast::Lit::Str(s)) => {
+                    Some(s.value.as_str().unwrap_or("").to_string())
+                }
+                _ => None,
+            },
+            _ => None,
+        };
+        if let Some(method_name) = method_name_opt {
+            let obj_unwrapped = unwrap_ts_local(member.obj.as_ref());
+            if let ast::Expr::Member(inner) = obj_unwrapped {
+                let prop_is_prototype = matches!(
+                    &inner.prop,
+                    ast::MemberProp::Ident(p) if p.sym.as_ref() == "prototype"
+                );
+                if prop_is_prototype {
+                    let inner_obj = unwrap_ts_local(inner.obj.as_ref());
+                    if let ast::Expr::Ident(fn_ident) = inner_obj {
+                        let fn_name = fn_ident.sym.to_string();
+                        // Mirror the assignment-side resolution order:
+                        // function-typed local > top-level FuncRef. Skip
+                        // classes — `class C` already has a real proto
+                        // object exposed elsewhere and the side-table
+                        // walk wouldn't help here. Skip native imports
+                        // since their `.prototype` is module-managed.
+                        if ctx.lookup_class(&fn_name).is_none()
+                            && !matches!(ctx.lookup_native_module(&fn_name), Some((_, Some(_))))
+                        {
+                            let func_expr = if let Some(local_id) = ctx.lookup_local(&fn_name) {
+                                if ctx.function_valued_locals.contains(&local_id) {
+                                    Some(Expr::LocalGet(local_id))
+                                } else {
+                                    None
+                                }
+                            } else if let Some(func_id) = ctx.lookup_func(&fn_name) {
+                                Some(Expr::FuncRef(func_id))
+                            } else {
+                                None
+                            };
+                            if let Some(func_expr) = func_expr {
+                                return Ok(Expr::GetFunctionPrototypeMethod {
+                                    func: Box::new(func_expr),
+                                    method_name,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // Check for native instance property access (e.g., response.status, response.ok)
     if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
         let obj_name = obj_ident.sym.to_string();

--- a/crates/perry-hir/src/stable_hash.rs
+++ b/crates/perry-hir/src/stable_hash.rs
@@ -3691,6 +3691,11 @@ impl SH for Expr {
                 method_name.hash(h);
                 value.as_ref().hash(h);
             }
+            Expr::GetFunctionPrototypeMethod { func, method_name } => {
+                tag(h, 1465);
+                func.as_ref().hash(h);
+                method_name.hash(h);
+            }
             Expr::WebAssemblyValidate(bytes) => {
                 tag(h, 449);
                 bytes.as_ref().hash(h);

--- a/crates/perry-hir/src/walker.rs
+++ b/crates/perry-hir/src/walker.rs
@@ -486,6 +486,9 @@ where
             f(func);
             f(value);
         }
+        Expr::GetFunctionPrototypeMethod { func, .. } => {
+            f(func);
+        }
         Expr::IndexGet { object, index } => {
             f(object);
             f(index);
@@ -1836,6 +1839,9 @@ where
         Expr::RegisterFunctionPrototypeMethod { func, value, .. } => {
             f(func);
             f(value);
+        }
+        Expr::GetFunctionPrototypeMethod { func, .. } => {
+            f(func);
         }
         Expr::IndexGet { object, index } => {
             f(object);

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -1488,6 +1488,47 @@ pub unsafe extern "C" fn js_register_prototype_method(
 /// `Expr::FuncRef` lowers to via `js_closure_alloc_singleton`). Anything
 /// else is a no-op — preserves the pre-fix baseline where non-callable
 /// `.prototype.m = fn` writes were silent property sets.
+/// Issue #838 followup (b) — read side: look up a method previously
+/// registered via `js_register_function_prototype_method` against the
+/// synthetic class id derived from `func_value`. Pre-fix the AST shape
+/// `<funcDecl>.prototype.<name>` lowered to a generic PropertyGet on a
+/// `Function.prototype` object that never materialised, so the read
+/// was always `undefined` — `typeof Foo.prototype.method` came back
+/// `'undefined'` even when the method was correctly dispatched through
+/// `(new Foo()).method` via the side-table walk. Pairs with the new
+/// `Expr::GetFunctionPrototypeMethod` HIR variant.
+///
+/// Returns the NaN-boxed `undefined` tag if the function value isn't a
+/// registered closure, or no method by that name was registered.
+#[no_mangle]
+pub unsafe extern "C" fn js_get_function_prototype_method(
+    func_value: f64,
+    name_ptr: *const u8,
+    name_len: usize,
+) -> f64 {
+    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    if name_ptr.is_null() || name_len == 0 {
+        return undef;
+    }
+    let name = match std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)) {
+        Ok(s) => s,
+        Err(_) => return undef,
+    };
+    // Look up the (already-allocated) synthetic class id for this
+    // function value. Don't allocate one here — reads on a function
+    // that never had any `.prototype.x = fn` assignment should
+    // return `undefined`, matching the spec'd behavior of reading a
+    // missing property on the `Function.prototype` object.
+    let cid = function_class_id(func_value);
+    if cid == 0 {
+        return undef;
+    }
+    match lookup_prototype_method(cid, name) {
+        Some(v) => v,
+        None => undef,
+    }
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn js_register_function_prototype_method(
     func_value: f64,

--- a/test-files/test_constructor_prototype_method.ts
+++ b/test-files/test_constructor_prototype_method.ts
@@ -1,0 +1,20 @@
+function Box(this: any, value: number) {
+  this.value = value;
+}
+(Box.prototype as any).getValue = function () {
+  return this.value;
+};
+(Box.prototype as any).doubled = function () {
+  return this.value * 2;
+};
+
+const b = new (Box as any)(5);
+console.log(b.getValue()); // expect 5
+console.log(b.doubled()); // expect 10
+console.log(typeof (Box.prototype as any).getValue); // expect 'function'
+
+// With computed property name
+(Box.prototype as any)["triple"] = function () {
+  return this.value * 3;
+};
+console.log(b.triple()); // expect 15


### PR DESCRIPTION
## Summary

- HIR assignment recogniser now accepts computed string-literal keys (`Foo.prototype['method'] = fn`), not just `Foo.prototype.method = fn`. Lights up ramda's transducer pattern (`XWrap.prototype['@@transducer/step'] = fn`) and any pre-ES6 lib that uses keys with dashes/slashes/special chars.
- Adds read-side support via new HIR variant `Expr::GetFunctionPrototypeMethod` and runtime helper `js_get_function_prototype_method`. `(Foo.prototype as any).method` reads on the function-classic shape now resolve to the registered closure, so the spec idiom `typeof Foo.prototype.method === 'function'` returns `'function'`.
- Test `test-files/test_constructor_prototype_method.ts` matches Node byte-for-byte (5/10/function/15).

## Background

Perry's existing `CLASS_PROTOTYPE_METHODS` side-table already powers instance-method dispatch (`(new Foo()).method()` reaches the registered closure with `this` bound to the receiver — issue #838 + followups). Two narrow gaps remained:

1. **Assignment side missed computed string-literal keys.** The recogniser in `lower/expr_assign.rs` only matched `MemberProp::Ident`. ramda's `_xwrap.js` (and any TypeScript-subset code that uses keys like `@@transducer/step`) routes through `MemberProp::Computed`, so the assignment fell through to a generic PropertySet on an unobserved proxy and the instance dispatch found nothing. Fix mirrors the same key-resolution shape `lower/expr_object.rs` already uses for object-literal computed keys.

2. **Read side was always `undefined`.** Even after a successful Ident-prop registration, `(Foo.prototype as any).method` evaluated to `undefined` because no synthetic prototype object was ever materialised. `typeof Foo.prototype.method` came back `'undefined'` despite instances dispatching correctly. New recogniser in `lower/expr_member.rs` emits `Expr::GetFunctionPrototypeMethod`, which codegen lowers to a direct lookup into the side-table via the new runtime helper. Skips `class C {}` blocks (those have a real proto object) and named native imports (module-managed).

## Known next blocker

`import * as R from 'ramda'` (or any named import of a ramda export) still throws `TypeError: value is not a function` at module init, before any user code runs. Every individual ramda module (`import sum from 'ramda/src/sum.js'`) compiles and runs cleanly — verified by bisecting all 269 entries. So the failure is a cross-module init-time interaction, separate from the prototype-method shape addressed here.

## Test plan

- [x] `test-files/test_constructor_prototype_method.ts` matches Node line-for-line: `5 / 10 / function / 15`
- [x] Standalone IIFE XWrap mirror returns 15 from `new XWrap(add)['@@transducer/step'](10, 5)`
- [x] Direct module path `import sum from 'ramda/src/sum.js'; sum([1,2,3,4,5])` returns 15
- [ ] Full `import * as R from 'ramda'` — known follow-up, unrelated init-time issue