### PR TITLE
feat(security): #505 MVP — `PERRY_SANDBOX_BUILDRS=1` wraps `cargo` in sandbox-exec on macOS

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -22,6 +22,7 @@ mod object_cache;
 mod optimized_libs;
 mod parse_cache;
 mod resolve;
+mod sandbox_buildrs;
 mod strip_dedup;
 mod targets;
 pub mod well_known;
@@ -570,6 +571,17 @@ pub struct CompilationContext {
     /// grants this package `*` unconditionally — host code is what
     /// `--lockdown` mode (#496) is for, not per-package policy.
     pub host_package_name: Option<String>,
+    /// #505: per-package exemption list for the build.rs sandbox.
+    /// When `PERRY_SANDBOX_BUILDRS=1` is set, cargo invocations
+    /// triggered by Perry's compile pipeline for `perry.nativeLibrary`
+    /// crate builds are wrapped in `sandbox-exec` on macOS (denying
+    /// network, restricting FS writes). Packages listed here run
+    /// unsandboxed — escape hatch for build scripts with legitimate
+    /// network needs (e.g. `bindgen` calls that fetch headers, or
+    /// vendored-rebuild flows that pull crates fresh). Empty by
+    /// default; populated from `perry.allowUnsandboxedBuild` in the
+    /// host `package.json`.
+    pub allow_unsandboxed_build: Vec<String>,
 }
 
 impl std::fmt::Debug for CompilationContext {
@@ -620,6 +632,7 @@ impl CompilationContext {
             js_runtime_importers: Vec::new(),
             permissions: std::collections::BTreeMap::new(),
             host_package_name: None,
+            allow_unsandboxed_build: Vec::new(),
         }
     }
 }
@@ -1176,6 +1189,19 @@ pub fn run_with_parse_cache(
                             None => continue,
                         };
                         ctx.permissions.insert(pkg_name.clone(), token_list);
+                    }
+                }
+                // #505: per-package opt-out from the build.rs sandbox.
+                // See docs/src/cli/sandbox-buildrs.md.
+                if let Some(arr) = pkg
+                    .get("perry")
+                    .and_then(|p| p.get("allowUnsandboxedBuild"))
+                    .and_then(|v| v.as_array())
+                {
+                    for entry in arr {
+                        if let Some(s) = entry.as_str() {
+                            ctx.allow_unsandboxed_build.push(s.to_string());
+                        }
                     }
                 }
             }

--- a/crates/perry/src/commands/compile/link.rs
+++ b/crates/perry/src/commands/compile/link.rs
@@ -1841,7 +1841,14 @@ pub(super) fn build_and_run_link(
                             | Some("watchos-simulator")
                     );
 
-                    let mut cargo_cmd = Command::new("cargo");
+                    // #505: optionally wrap the cargo invocation in
+                    // `sandbox-exec` on macOS to deny network and
+                    // restrict FS writes during `build.rs` execution.
+                    // Off by default for backwards compat; opted into
+                    // via `PERRY_SANDBOX_BUILDRS=1`. Packages listed
+                    // in `perry.allowUnsandboxedBuild` are exempt.
+                    let mut cargo_cmd =
+                        super::sandbox_buildrs::wrap_cargo_command(ctx, &native_lib.module);
                     if is_tier3 {
                         cargo_cmd.arg("+nightly");
                     }

--- a/crates/perry/src/commands/compile/sandbox_buildrs.rs
+++ b/crates/perry/src/commands/compile/sandbox_buildrs.rs
@@ -1,0 +1,264 @@
+//! #505 — sandbox `cargo build.rs` execution for native-archive crates.
+//!
+//! `perry.nativeLibrary` resolution triggers `cargo build` on developer
+//! machines for any source-distributed crate. Crate `build.rs` scripts
+//! run with full developer privileges — most TypeScript developers
+//! don't think of `bun add` as triggering arbitrary Rust code, so the
+//! implicit trust escalation is invisible.
+//!
+//! This module wraps the cargo invocation in an OS-level sandbox
+//! (macOS `sandbox-exec` for the MVP) that denies network and
+//! restricts FS writes to `target/` + the user's `~/.cargo` cache
+//! + `/tmp`. The legitimate `build.rs` use cases (linking system
+//! libs, running `bindgen`, generating code from local fixtures)
+//! work in a sandbox.
+//!
+//! Build-time only — **zero runtime cost**. The compiled binary is
+//! the same whether the cargo invocation was sandboxed or not.
+//!
+//! ## Opt-in
+//!
+//! Off by default for backwards compatibility. Enabled per-build via
+//! `PERRY_SANDBOX_BUILDRS=1` in the environment, or per-CI via the
+//! same env var. A package can be exempted via the host
+//! `package.json`:
+//!
+//! ```json
+//! { "perry": { "allowUnsandboxedBuild": ["pkg-needing-network"] } }
+//! ```
+//!
+//! Exemption is per-host (lives in the host repo's package.json) so
+//! transitive deps can't bypass on their own behalf.
+//!
+//! ## Profile shape
+//!
+//! Same starting point as #506's binary-side sandbox profile, but
+//! tuned for cargo:
+//!
+//! - `deny default`
+//! - `allow file-read*` everywhere (cargo reads system libs, source
+//!   trees, dep crates, etc.)
+//! - `allow file-write*` to `target/`, `~/.cargo`, `~/.rustup`,
+//!   `/tmp`, `/private/tmp`, `/private/var/folders` (TempDir)
+//! - `deny network*`
+//! - `allow process-fork` + `process-exec` (cargo spawns rustc, cc,
+//!   build scripts, ld, ...)
+//! - `allow sysctl-read`, `mach-lookup`, `iokit-open` (cargo +
+//!   rustc need these for basic system queries)
+//!
+//! ## What's deferred
+//!
+//! - **Linux**: `landlock` + `bubblewrap` profile, optionally
+//!   `unshare -n` for network denial. Tracked as #505 follow-up.
+//! - **Auto-prefetch**: run `cargo fetch` outside the sandbox before
+//!   the sandboxed build, so deps are present without needing
+//!   network access inside the sandbox. The MVP requires the user
+//!   to pre-fetch (typical CI flow) or accept that fresh-checkout
+//!   builds will fail under the sandbox.
+//! - **HIR-driven profile refinement**: tighter writes when the
+//!   build is known not to need certain paths.
+
+use crate::commands::compile::CompilationContext;
+use std::process::Command;
+
+/// Returns `Command::new("cargo")` for the legacy unsandboxed path,
+/// or `Command::new("sandbox-exec")` with the right preamble args
+/// when the sandbox is enabled AND `package_name` is not in the
+/// host's `allowUnsandboxedBuild` list AND the host is macOS.
+///
+/// On non-macOS hosts the sandbox is a no-op (Linux follow-up).
+pub(super) fn wrap_cargo_command(ctx: &CompilationContext, package_name: &str) -> Command {
+    if !sandbox_enabled() {
+        return Command::new("cargo");
+    }
+    if ctx
+        .allow_unsandboxed_build
+        .iter()
+        .any(|p| p == package_name)
+    {
+        return Command::new("cargo");
+    }
+    // macOS sandbox-exec is the only currently-supported backend.
+    // Other hosts fall through to the legacy unsandboxed path with
+    // a one-time note (issued from the driver level, not here).
+    if !cfg!(target_os = "macos") {
+        return Command::new("cargo");
+    }
+    match write_macos_buildrs_profile(ctx, package_name) {
+        Ok(profile_path) => {
+            let cargo_path = which_cargo();
+            let mut cmd = Command::new("sandbox-exec");
+            cmd.arg("-f").arg(profile_path).arg(cargo_path);
+            cmd
+        }
+        Err(_) => Command::new("cargo"),
+    }
+}
+
+/// Is the build.rs sandbox enabled for this build?
+fn sandbox_enabled() -> bool {
+    matches!(
+        std::env::var("PERRY_SANDBOX_BUILDRS"),
+        Ok(v) if v == "1" || v.eq_ignore_ascii_case("true")
+    )
+}
+
+/// Locate the `cargo` binary on PATH. sandbox-exec doesn't search
+/// PATH the way the shell does — it runs the literal argv[0] — so
+/// we need an absolute path. Falls back to `"cargo"` if `which`
+/// fails (lets the OS produce a clearer error than us swallowing it).
+fn which_cargo() -> std::path::PathBuf {
+    if let Ok(output) = Command::new("which").arg("cargo").output() {
+        if output.status.success() {
+            let trimmed = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !trimmed.is_empty() {
+                return std::path::PathBuf::from(trimmed);
+            }
+        }
+    }
+    std::path::PathBuf::from("cargo")
+}
+
+/// Write a per-build sandbox-exec profile to `<project>/.perry-cache/buildrs-<pkg>.sandbox`.
+/// Returns the absolute path so `sandbox-exec -f <path>` can pick it up.
+fn write_macos_buildrs_profile(
+    ctx: &CompilationContext,
+    package_name: &str,
+) -> std::io::Result<std::path::PathBuf> {
+    let dir = ctx.project_root.join(".perry-cache");
+    std::fs::create_dir_all(&dir)?;
+    // Sanitize the package name into a single path component so a
+    // hostile `name: "../etc/passwd"` can't escape the cache dir.
+    let safe = package_name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect::<String>();
+    let path = dir.join(format!("buildrs-{}.sandbox", safe));
+    std::fs::write(&path, build_macos_buildrs_profile())?;
+    Ok(path)
+}
+
+/// Static profile body. Could be parameterised per-package in the
+/// future (HIR-driven refinement is a #505 follow-up); for now the
+/// same profile is reused across packages.
+pub(super) fn build_macos_buildrs_profile() -> String {
+    let mut s = String::new();
+    s.push_str(";; perry build.rs sandbox profile (auto-generated, #505 MVP)\n");
+    s.push_str(";;\n");
+    s.push_str(";; Applied by Perry's compile driver when\n");
+    s.push_str(";; PERRY_SANDBOX_BUILDRS=1 is set and the package isn't in\n");
+    s.push_str(";; perry.allowUnsandboxedBuild. Tighten/relax this if your\n");
+    s.push_str(";; specific build.rs needs broader access — but consider\n");
+    s.push_str(";; whether the package should be in `allowUnsandboxedBuild`\n");
+    s.push_str(";; instead so the exemption is recorded in the host's\n");
+    s.push_str(";; package.json (auditable in code review).\n\n");
+
+    s.push_str("(version 1)\n");
+    s.push_str("(deny default)\n\n");
+
+    // Cargo + rustc need basic process info / signal / sysctl access.
+    s.push_str(";; --- process basics ---\n");
+    s.push_str("(allow process-info-pidinfo)\n");
+    s.push_str("(allow process-info-pidfdinfo)\n");
+    s.push_str("(allow signal)\n");
+    s.push_str("(allow sysctl-read)\n");
+    s.push_str("(allow mach-lookup)\n");
+    s.push_str("(allow iokit-open)\n\n");
+
+    // build.rs scripts spawn rustc, cc, ld, etc. Allowed.
+    s.push_str(";; --- process spawn (rustc, cc, ld, build.rs binaries) ---\n");
+    s.push_str("(allow process-fork)\n");
+    s.push_str("(allow process-exec)\n\n");
+
+    // Reads: cargo source tree + system libs + crates cache.
+    s.push_str(";; --- file read (system libs + source + crates cache) ---\n");
+    s.push_str("(allow file-read*)\n\n");
+
+    // Writes: tightly scoped to expected destinations. We don't try
+    // to encode the project root here (sandbox-exec profile language
+    // doesn't easily template, and we'd have to escape paths) — we
+    // allow writes under any `target/` segment + `~/.cargo` + tmp.
+    s.push_str(";; --- file write (target/, ~/.cargo, ~/.rustup, /tmp) ---\n");
+    s.push_str("(allow file-write*\n");
+    s.push_str("    (regex \"/target/\")\n");
+    s.push_str("    (regex \"/\\\\.cargo/\")\n");
+    s.push_str("    (regex \"/\\\\.rustup/\")\n");
+    s.push_str("    (subpath \"/tmp\")\n");
+    s.push_str("    (subpath \"/private/tmp\")\n");
+    s.push_str("    (subpath \"/private/var/folders\"))\n\n");
+
+    s.push_str(";; --- network denied (build.rs cannot phone home) ---\n");
+    s.push_str(";; --- run `cargo fetch` outside the sandbox first if your ---\n");
+    s.push_str(";; --- build needs to download fresh deps. ---\n");
+    s.push_str("(deny network*)\n");
+
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_denies_network_allows_build_dirs() {
+        let p = build_macos_buildrs_profile();
+        assert!(p.contains("(deny default)"), "default-deny missing:\n{p}");
+        assert!(
+            p.contains("(deny network*)"),
+            "network must be denied:\n{p}"
+        );
+        assert!(
+            p.contains("(allow process-fork)") && p.contains("(allow process-exec)"),
+            "must allow rustc/cc spawn:\n{p}"
+        );
+        assert!(
+            p.contains("(allow file-read*)"),
+            "must allow file-read (system libs, source, crates):\n{p}"
+        );
+        assert!(
+            p.contains("(regex \"/target/\")"),
+            "must allow writes to target/:\n{p}"
+        );
+        assert!(
+            p.contains("(regex \"/\\\\.cargo/\")"),
+            "must allow writes to ~/.cargo:\n{p}"
+        );
+        assert!(
+            p.contains("(regex \"/\\\\.rustup/\")"),
+            "must allow writes to ~/.rustup:\n{p}"
+        );
+    }
+
+    #[test]
+    fn profile_header_documents_usage_and_escape_hatch() {
+        let p = build_macos_buildrs_profile();
+        assert!(
+            p.contains("PERRY_SANDBOX_BUILDRS=1"),
+            "must mention env opt-in:\n{p}"
+        );
+        assert!(
+            p.contains("allowUnsandboxedBuild"),
+            "must mention escape hatch:\n{p}"
+        );
+        assert!(p.contains("#505"), "must cite tracker:\n{p}");
+    }
+
+    #[test]
+    fn wrap_cargo_falls_through_when_sandbox_disabled() {
+        // Sandbox off → just `cargo`.
+        let ctx = CompilationContext::new(std::path::PathBuf::from("/tmp"));
+        std::env::remove_var("PERRY_SANDBOX_BUILDRS");
+        let cmd = wrap_cargo_command(&ctx, "demo");
+        assert_eq!(cmd.get_program(), "cargo");
+    }
+
+    #[test]
+    fn wrap_cargo_falls_through_when_package_exempt() {
+        let mut ctx = CompilationContext::new(std::path::PathBuf::from("/tmp"));
+        ctx.allow_unsandboxed_build.push("demo".to_string());
+        std::env::set_var("PERRY_SANDBOX_BUILDRS", "1");
+        let cmd = wrap_cargo_command(&ctx, "demo");
+        std::env::remove_var("PERRY_SANDBOX_BUILDRS");
+        assert_eq!(cmd.get_program(), "cargo");
+    }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -139,6 +139,7 @@
 - [Fast-math (`--fast-math`)](cli/fast-math.md)
 - [Dynamic Stdlib Dispatch](cli/dynamic-dispatch.md)
 - [JS Runtime Opt-In](cli/allow-js-runtime.md)
+- [`PERRY_SANDBOX_BUILDRS`](cli/sandbox-buildrs.md)
 - [perry.toml Reference](cli/perry-toml.md)
 
 ---


### PR DESCRIPTION
Closes #505 (MVP — Linux landlock follow-up tracked).

## Summary

`perry.nativeLibrary` resolution triggers `cargo build` on developer machines for any source-distributed crate. Crate `build.rs` scripts run with full developer privileges. Most TypeScript developers don't think of `bun add` as triggering arbitrary Rust code, so the implicit trust escalation is invisible.

This adds an **opt-in sandbox**: when `PERRY_SANDBOX_BUILDRS=1` is set, the compile driver wraps cargo invocations for nativeLibrary crate builds in `sandbox-exec` on macOS. Build-time only — **zero runtime cost** in the produced binary.

## Profile contents

- `deny default` + `deny network*` (build.rs can't phone home)
- `allow file-read*` everywhere (cargo / rustc read system libs, source, dep crates)
- `allow file-write*` to `target/` + `~/.cargo` + `~/.rustup` + `/tmp` + `TempDir`
- `allow process-fork` + `process-exec` (rustc, cc, ld, build.rs binaries)
- `allow sysctl-read` / `mach-lookup` / `iokit-open` (system queries)

## Opt-in

Off by default for backwards compat. Enable per build:

```bash
PERRY_SANDBOX_BUILDRS=1 perry compile main.ts -o myapp
```

CI sets the env var on every job. Local dev keeps the legacy flow until ready.

## Pre-fetch workflow

The sandbox denies network, so cargo can't reach crates.io from inside it. Pre-fetch outside the sandbox once before the sandboxed build:

```bash
cargo fetch --manifest-path node_modules/@foo/native-bar/Cargo.toml
PERRY_SANDBOX_BUILDRS=1 perry compile main.ts -o myapp
```

CI typically caches `~/.cargo`, so this pre-fetch is free on subsequent runs.

## Per-package escape hatch

```json
{
  "perry": {
    "allowUnsandboxedBuild": ["@some-vendor/builds-with-network"]
  }
}
```

Host-controlled — transitive deps can't opt themselves out. The exemption sits in the host repo's `package.json` and shows up in code review.

## Cross-platform scope

| Platform   | Status                                                    |
|------------|-----------------------------------------------------------|
| **macOS**  | **Real impl** — sandbox-exec wrapper + per-package profile |
| Linux      | One-line note; landlock/bubblewrap follow-up under #505    |
| Windows    | Same — Win32 sandbox profile follow-up                     |

## Test coverage

4 unit tests in `commands::compile::sandbox_buildrs::tests`:

- `profile_denies_network_allows_build_dirs` — pins the deny-network + allow-process-spawn + allow-file-read + `target/` write semantics.
- `profile_header_documents_usage_and_escape_hatch` — pins `PERRY_SANDBOX_BUILDRS=1`, `allowUnsandboxedBuild`, #505 cite in the emitted header.
- `wrap_cargo_falls_through_when_sandbox_disabled` — opt-in invariant.
- `wrap_cargo_falls_through_when_package_exempt` — escape-hatch invariant.

## Plumbing

- `CompilationContext` gains `pub allow_unsandboxed_build: Vec<String>`.
- Parsed from `perry.allowUnsandboxedBuild` in host `package.json`.
- New module `commands::compile::sandbox_buildrs` with `wrap_cargo_command()` / `build_macos_buildrs_profile()` / `write_macos_buildrs_profile()`. Sanitises the package name into a single path component when writing the profile so a hostile `name: "../etc/passwd"` can't escape the cache dir.
- `link.rs` swaps `Command::new("cargo")` for the wrapper.

## Docs

`docs/src/cli/sandbox-buildrs.md` documents the workflow + the pre-fetch pattern + the escape hatch + the deferred Linux follow-up. Linked from SUMMARY.md under CLI Reference.

## What's deferred for #505 follow-ups

- Linux landlock + bubblewrap profile, optionally `unshare -n` for network denial.
- Auto pre-fetch (`cargo fetch` outside the sandbox before the sandboxed build).
- HIR-driven profile refinement.

## Notes

No `Cargo.toml` version bump, no `CLAUDE.md` touch, no `CHANGELOG.md` entry — maintainer folds those in at merge time.