### PR TITLE
feat(runtime+jsruntime): Object.prototype methods on Buffer + require() namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.989 — feat(runtime+jsruntime): expose Object.prototype methods on Buffer instances + plain-object require() namespace
+
+**Symptom.** `import express from 'express'` (and any transitive consumer of `safer-buffer`) threw `TypeError: buffer.hasOwnProperty is not a function` at module-init time. safer-buffer's `safer.js` opens with `for (key in buffer) { if (!buffer.hasOwnProperty(key)) continue; ... }` where `buffer` is the value returned by `require('buffer')`. Two distinct gaps converged on the same error message:
+
+1. **Buffer instances** had no `Object.prototype.*` fallbacks. PR #978 wired `hasOwnProperty` / `propertyIsEnumerable` on generic `ObjectHeader` instances inside `js_native_call_method`, but Buffer dispatch routes through the dedicated `dispatch_buffer_method` arm (because BufferHeader is a raw `alloc()` without a GcHeader and is detected via `BUFFER_REGISTRY` before the GcHeader inspection runs). That arm matched on the buffer-specific method names and returned `undefined` for everything else — so `buf.hasOwnProperty` was undefined and `typeof buf.hasOwnProperty` was `'undefined'`.
+
+2. **`require('builtin')` returned a raw ESM-namespace object** with a null prototype (per QuickJS / ES spec for module namespaces). Even though our `'buffer'` stub exported `Buffer`, `constants`, `kMaxLength`, etc. correctly, the namespace itself had no `Object.prototype` in its chain — so `nsObj.hasOwnProperty(...)` threw before any Buffer instance was even involved. This is what actually crashed safer-buffer (the call site `buffer.hasOwnProperty(key)` is on the **module**, not on a Buffer instance).
+
+**Fix — two coordinated changes:**
+
+1. **`crates/perry-runtime/src/object.rs::dispatch_buffer_method`:** add explicit arms for `hasOwnProperty`, `propertyIsEnumerable`, `valueOf`, `toLocaleString`, `isPrototypeOf` before the `_ => undefined` fallback. `hasOwnProperty(idx)` / `propertyIsEnumerable(idx)` check numeric-string and int32 keys against `(*buf_ptr).length` (Node spec: indexed bytes are own enumerable properties on a Buffer, `length` is inherited from the prototype). `valueOf` round-trips the buffer pointer, `toLocaleString` delegates to `toString()` with the utf8 encoding tag, and `isPrototypeOf` returns false. `is_buffer_method_name` is extended with the same names so a method-as-value read (`typeof buf.hasOwnProperty === "function"`) materializes a bound-method closure via `js_class_method_bind` and the subsequent call routes back through the new arms.
+
+2. **`crates/perry-jsruntime/src/modules.rs::__perry_require_namespace`:** when the value returned from `require()` is an ESM module-namespace object (`Object.getPrototypeOf(ns) === null`), copy its enumerable own properties into a plain object so it inherits from `Object.prototype`. References to inner classes/functions are preserved (the copy is shallow and uses `=`, so static members and `.prototype` on copied function/class values survive). This unblocks every legacy CJS module that probes its imports with `hasOwnProperty` (safer-buffer being the highest-profile example).
+
+**Validation.**
+- `test-files/test_buffer_prototype_methods.ts` — byte-for-byte match with `node --experimental-strip-types` (`false`, `false`, `function`, `hello`, `function`, `false`).
+- `/tmp/perry-express` smoke test: pre-fix crashed with `buffer.hasOwnProperty is not a function` at `safer-buffer/safer.js:36:15`. Post-fix the safer-buffer crash is gone; downstream `send` then hits a separate unrelated issue (`util.inherits` on a stub-default-export Stream that lacks `.prototype`), tracked separately.
+
 ## v0.5.988 — feat(lodash): add max/min/maxBy/minBy/clamp/inRange/random to manifest
 
 Direct follow-up to PR #966 (sum/mean/sumBy/meanBy/head/last/tail). After #966 unblocked `lodash.sum`, the next bare-lodash sweep tripped on `_.max` — the runtime helpers for `clamp`/`inRange`/`random` already existed (and `clamp` had a `NativeModSig`), but no manifest entry, and the four extrema (`max`/`min`/`maxBy`/`minBy`) didn't exist at all. This PR fills the gap end-to-end.
@@ -38,7 +56,6 @@ false
 PR #966's `test-files/test_lodash_sum.ts` still passes unchanged (`10 / 2.5 / 3 / 1 / 3`) — no regression on the previously-landed aggregators.
 
 **Known follow-up — `compilePackages: ["lodash"]` path.** With `compilePackages` set to compile lodash from `node_modules` instead of routing through native, the test crashes at runtime with `TypeError: Cannot read properties of undefined (reading 'call')` — same V8-fallback-style issue that's blocking other compile-as-package smokes (#678 territory). The bare-import path (which is what the manifest + native dispatch is actually for) works correctly.
-
 ## v0.5.987 — fix(hir+runtime): Constructor.prototype method dispatch for computed keys + read-side introspection (ramda transducer pattern)
 
 **Symptom.** `XWrap.prototype['@@transducer/step'] = function(acc, x) { … }` — ramda's transducer scaffolding (`_xwrap.js`) plus any pre-ES6 library that attaches instance methods through a computed string-literal key — pre-fix silently fell through to a generic `PropertySet` because the assignment-side recogniser in `lower/expr_assign.rs` only matched the `MemberProp::Ident` shape (`.method = fn`). Subsequent `(new XWrap(fn))['@@transducer/step'](acc, x)` then threw `undefined is not a function` even though the dispatch hot path was perfectly capable of finding the method via `CLASS_PROTOTYPE_METHODS` — the side-table just never got populated.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.988
+**Current Version:** 0.5.989
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.988"
+version = "0.5.989"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "base64",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5564,11 +5564,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.988"
+version = "0.5.989"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "itoa",
  "jni",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "block2",
  "libc",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "block2",
  "libc",
@@ -5645,11 +5645,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.988"
+version = "0.5.989"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "block2",
  "libc",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "block2",
  "libc",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "block2",
  "libc",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.988"
+version = "0.5.989"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.988"
+version = "0.5.989"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-jsruntime/src/modules.rs
+++ b/crates/perry-jsruntime/src/modules.rs
@@ -752,6 +752,22 @@ const _cjs = (function() {{
             if (ns.__perry_commonjs === true && ns.default !== undefined) return ns.default;
         }} catch (_) {{
         }}
+        // ESM module-namespace objects (from `import * as ns`) have a null
+        // prototype, so `ns.hasOwnProperty(...)` throws "is not a function".
+        // safer-buffer's `for (key in buffer) if (!buffer.hasOwnProperty(key))`
+        // probe (loaded indirectly by express via body-parser) and similar
+        // legacy CommonJS code expects the value returned from `require()` to
+        // inherit from Object.prototype. Copy enumerable own props into a
+        // plain object so Object.prototype.* (hasOwnProperty,
+        // propertyIsEnumerable, toString, valueOf) is reachable.
+        try {{
+            if (ns && typeof ns === 'object' && Object.getPrototypeOf(ns) === null) {{
+                var __o = {{}};
+                for (var __k in ns) __o[__k] = ns[__k];
+                return __o;
+            }}
+        }} catch (_) {{
+        }}
         return ns;
     }}
     function require(specifier) {{

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -7834,6 +7834,18 @@ pub fn is_buffer_method_name(name: &str) -> bool {
             | "swap16"
             | "swap32"
             | "swap64"
+            // Object.prototype methods exposed on Buffer instances so
+            // safer-buffer's `if (buffer.hasOwnProperty(...))` probe (and
+            // similar duck-type tests in express / body-parser dependents)
+            // resolve to a callable, not undefined. Without these,
+            // `typeof buf.hasOwnProperty` is `"undefined"` and the
+            // subsequent invocation throws "buffer.hasOwnProperty is not
+            // a function" at express startup.
+            | "hasOwnProperty"
+            | "propertyIsEnumerable"
+            | "valueOf"
+            | "isPrototypeOf"
+            | "toLocaleString"
             | "readUInt8"
             | "readUint8"
             | "readInt8"
@@ -8197,6 +8209,127 @@ pub unsafe fn dispatch_buffer_method(
             crate::buffer::js_buffer_write_int_le(buf_f64, arg_or_zero(0), arg_i32(1), arg_i32(2));
             (arg_i32(1) + arg_i32(2)) as f64
         }
+        // ── Object.prototype fallbacks on Buffer instances ──
+        // safer-buffer (loaded by express) probes Buffer instances with
+        // `if (buffer.hasOwnProperty(...))`. Pre-fix every non-buffer-specific
+        // method read returned undefined, so the call threw
+        // "buffer.hasOwnProperty is not a function". Mirror the generic
+        // ObjectHeader behaviour wired up in PR #978: hasOwnProperty checks
+        // numeric indices against the buffer length (Node spec — indexed
+        // bytes are own properties, `length` is on the prototype), and
+        // the remaining Object.prototype methods get spec-shaped stubs.
+        "hasOwnProperty" => {
+            let key_is_own = if args.is_empty() {
+                false
+            } else {
+                let key_bits = args[0].to_bits();
+                if (key_bits >> 48) == 0x7FFF {
+                    // string key
+                    let sptr =
+                        (key_bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::string::StringHeader;
+                    if sptr.is_null() {
+                        false
+                    } else {
+                        let slen = (*sptr).byte_len as usize;
+                        let sdata =
+                            (sptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                        let bytes = std::slice::from_raw_parts(sdata, slen);
+                        if let Ok(s) = std::str::from_utf8(bytes) {
+                            // Only numeric-string indices that are in bounds
+                            // count as own properties for Buffer/Uint8Array.
+                            if let Ok(idx) = s.parse::<u32>() {
+                                let buf_len = (*buf_ptr).length as u32;
+                                idx < buf_len
+                            } else {
+                                false
+                            }
+                        } else {
+                            false
+                        }
+                    }
+                } else if (key_bits >> 48) == 0x7FFE {
+                    // int32 key
+                    let idx = (key_bits & 0xFFFF_FFFF) as i32;
+                    let buf_len = (*buf_ptr).length as i32;
+                    idx >= 0 && idx < buf_len
+                } else if !(0x7FF8..=0x7FFF).contains(&(key_bits >> 48)) {
+                    // raw f64 numeric key (NaN-boxing tags occupy 0x7FF8..=0x7FFF)
+                    let n = args[0];
+                    if n.is_finite() && n.fract() == 0.0 && n >= 0.0 {
+                        let idx = n as u32;
+                        let buf_len = (*buf_ptr).length as u32;
+                        idx < buf_len
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            };
+            i32_bool(key_is_own as i32)
+        }
+        "propertyIsEnumerable" => {
+            // Same key→own check as hasOwnProperty; indexed bytes on a
+            // Buffer are enumerable own data properties.
+            let key_is_own = if args.is_empty() {
+                false
+            } else {
+                let key_bits = args[0].to_bits();
+                if (key_bits >> 48) == 0x7FFF {
+                    let sptr =
+                        (key_bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::string::StringHeader;
+                    if sptr.is_null() {
+                        false
+                    } else {
+                        let slen = (*sptr).byte_len as usize;
+                        let sdata =
+                            (sptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                        let bytes = std::slice::from_raw_parts(sdata, slen);
+                        if let Ok(s) = std::str::from_utf8(bytes) {
+                            if let Ok(idx) = s.parse::<u32>() {
+                                let buf_len = (*buf_ptr).length as u32;
+                                idx < buf_len
+                            } else {
+                                false
+                            }
+                        } else {
+                            false
+                        }
+                    }
+                } else if (key_bits >> 48) == 0x7FFE {
+                    let idx = (key_bits & 0xFFFF_FFFF) as i32;
+                    let buf_len = (*buf_ptr).length as i32;
+                    idx >= 0 && idx < buf_len
+                } else if !args[0].is_nan() {
+                    let n = args[0];
+                    if n.is_finite() && n.fract() == 0.0 && n >= 0.0 {
+                        let idx = n as u32;
+                        let buf_len = (*buf_ptr).length as u32;
+                        idx < buf_len
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            };
+            i32_bool(key_is_own as i32)
+        }
+        // `buf.valueOf()` returns the Buffer itself in Node (Uint8Array
+        // inherits the no-op valueOf from Object.prototype, but for the
+        // duck-test usage in safer-buffer/express-graph the receiver
+        // round-trip is what matters).
+        "valueOf" => f64::from_bits(JSValue::pointer(addr as *mut u8).bits()),
+        // `buf.toLocaleString()` — Node delegates to toString() with no
+        // args, which yields the utf8 decode. Match that.
+        "toLocaleString" => {
+            let str_ptr = crate::buffer::js_buffer_to_string(buf_ptr, 0);
+            f64::from_bits(JSValue::string_ptr(str_ptr).bits())
+        }
+        // `buf.isPrototypeOf(other)` — buffers aren't prototype objects in
+        // user code, so this is always false (matches Node when `buf` is
+        // a Buffer instance rather than `Buffer.prototype`).
+        "isPrototypeOf" => i32_bool(0),
         _ => f64::from_bits(crate::value::TAG_UNDEFINED),
     }
 }

--- a/test-files/test_buffer_prototype_methods.ts
+++ b/test-files/test_buffer_prototype_methods.ts
@@ -1,0 +1,11 @@
+// Issue follow-up to #978: expose Object.prototype methods on Buffer instances.
+// safer-buffer (used by express) does `if (buffer.hasOwnProperty(...))` to
+// probe Buffer instances. Pre-fix this crashed with
+// "buffer.hasOwnProperty is not a function".
+const b = Buffer.from('hello', 'utf8');
+console.log(b.hasOwnProperty('length'));       // false (length is on prototype)
+console.log(b.hasOwnProperty('nonexistent'));  // false
+console.log(typeof b.toString);                // 'function'
+console.log(b.toString('utf8'));               // 'hello'
+console.log(typeof b.valueOf);                 // 'function'
+console.log(b.propertyIsEnumerable('length')); // false


### PR DESCRIPTION
## Summary

- Add `hasOwnProperty` / `propertyIsEnumerable` / `valueOf` / `toLocaleString` / `isPrototypeOf` arms to `dispatch_buffer_method` so safer-buffer's `for (key in buf) { if (!buf.hasOwnProperty(key)) ... }` probe resolves on Buffer instances.
- Plain-object-copy ESM module namespaces returned via `__perry_require_namespace` so `require('buffer').hasOwnProperty(...)` works (the actual safer-buffer crash site — the receiver is the module, not a Buffer instance).
- Extend `is_buffer_method_name` so method-as-value reads (`typeof buf.hasOwnProperty === 'function'`) return a bound-method closure that dispatches back through the new arms.

Index-key probes for `hasOwnProperty(idx)` / `propertyIsEnumerable(idx)` check the numeric / int32 / numeric-string key against `(*buf_ptr).length`, matching Node (indexed bytes are own enumerable; `length` is on the prototype).

Direct follow-up to PR #973 (Date/Array/Object .constructor) and PR #978 (ramda prototype methods).

## Test plan

- [x] `test-files/test_buffer_prototype_methods.ts` byte-for-byte matches `node --experimental-strip-types`:
  ```
  false
  false
  function
  hello
  function
  false
  ```
- [x] `/tmp/perry-express` smoke (`import express from 'express'`) — pre-fix crashed at `safer-buffer/safer.js:36:15` with `buffer.hasOwnProperty is not a function`; post-fix safer-buffer load succeeds (downstream `send` hits an unrelated `util.inherits` stub gap, tracked separately).
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry -p perry-jsruntime` clean.