### PR TITLE
feat(security): #504 MVP — `--emit-attest` sidecar + `perry verify --attest`

### DIFF
--- a/crates/perry/src/commands/attest.rs
+++ b/crates/perry/src/commands/attest.rs
@@ -1,0 +1,266 @@
+//! #504 — binary attestation sidecar (MVP).
+//!
+//! When a Perry build is compiled with `--emit-attest`, the driver
+//! writes `<binary>.attest.json` next to the executable containing
+//! enough metadata to answer the question "did this binary come
+//! from THIS source tree at THIS commit?":
+//!
+//! ```json
+//! {
+//!   "version": 1,
+//!   "sha256": "abcd1234...",
+//!   "size": 1048576,
+//!   "perry_version": "0.5.999",
+//!   "commit_sha": "0a1b2c3...",
+//!   "built_at_unix": 1715990400,
+//!   "binary_filename": "myapp"
+//! }
+//! ```
+//!
+//! The format is intentionally minimal — `version: 1` is a contract
+//! for the matching `perry verify --attest` CLI side. Future
+//! additions (CI signature blob, sigstore bundle, reproducible-builds
+//! flags log) graft on under a new top-level key without bumping
+//! the version.
+//!
+//! The full #504 acceptance criteria — published CI attestations,
+//! tested reproducibility across machines, signed sigstore bundles —
+//! are all tracked as follow-ups under #504. This MVP ships the
+//! *primitive*: a per-build sidecar plus a verifier that proves
+//! the binary hasn't been swapped post-build. CI publication +
+//! determinism work can build on top.
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::io::Read;
+use std::path::Path;
+
+/// Versioned shape of `<binary>.attest.json`. Stable across Perry
+/// releases — the `version` field lets future additions graft on
+/// without breaking parsers in the wild.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AttestationManifest {
+    pub version: u32,
+    /// Hex-encoded SHA-256 of the binary bytes.
+    pub sha256: String,
+    /// Binary size in bytes (cross-check on top of the hash).
+    pub size: u64,
+    /// Perry version that produced this binary (from
+    /// `env!("CARGO_PKG_VERSION")`).
+    pub perry_version: String,
+    /// Git commit SHA the build was rooted at, when available;
+    /// empty string when the source tree isn't a git checkout.
+    pub commit_sha: String,
+    /// Unix epoch seconds at build time. *Not* a determinism
+    /// claim — just provenance for "when did this build run?".
+    pub built_at_unix: u64,
+    /// `binary_path.file_name()`. Lets a verifier sanity-check it
+    /// is reading the attestation that matches the binary file
+    /// they're holding.
+    pub binary_filename: String,
+}
+
+/// Compute SHA-256 of a file as `"<hex>"`. Streaming hash so very
+/// large binaries don't OOM.
+pub fn sha256_hex(path: &Path) -> Result<(String, u64)> {
+    let mut file =
+        std::fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    let mut total: u64 = 0;
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        total += n as u64;
+    }
+    Ok((format!("{:x}", hasher.finalize()), total))
+}
+
+/// Read `commit_sha` from the project's git tree. Best-effort:
+/// returns the empty string when the build isn't inside a git
+/// repo. The git2 crate isn't already a perry dep, so use the
+/// `git` binary directly.
+fn discover_commit_sha(project_root: &Path) -> String {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(project_root)
+        .output();
+    match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        _ => String::new(),
+    }
+}
+
+/// Build the manifest record for `binary_path`. Hashes the file
+/// content and gathers provenance (perry version, git commit at
+/// `project_root`, current Unix epoch). Returned separately from
+/// the file write so tests can pin the shape without touching the
+/// filesystem.
+pub fn build_attestation(binary_path: &Path, project_root: &Path) -> Result<AttestationManifest> {
+    let (sha256, size) = sha256_hex(binary_path)?;
+    let perry_version = env!("CARGO_PKG_VERSION").to_string();
+    let commit_sha = discover_commit_sha(project_root);
+    let built_at_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_default();
+    let binary_filename = binary_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default()
+        .to_string();
+    Ok(AttestationManifest {
+        version: 1,
+        sha256,
+        size,
+        perry_version,
+        commit_sha,
+        built_at_unix,
+        binary_filename,
+    })
+}
+
+/// Write the manifest to `<binary>.attest.json` alongside the
+/// binary. Returns the resolved sidecar path.
+pub fn write_attestation(
+    binary_path: &Path,
+    manifest: &AttestationManifest,
+) -> Result<std::path::PathBuf> {
+    let out = binary_path.with_extension("attest.json");
+    let body = serde_json::to_string_pretty(manifest)
+        .context("failed to serialize attestation manifest")?;
+    std::fs::write(&out, body).with_context(|| format!("failed to write {}", out.display()))?;
+    Ok(out)
+}
+
+/// Verify that `binary_path`'s on-disk SHA-256 + size match the
+/// values recorded in `<binary>.attest.json`. Returns the loaded
+/// manifest on success; bails with an actionable diagnostic on
+/// mismatch or missing sidecar.
+pub fn verify_against_sidecar(binary_path: &Path) -> Result<AttestationManifest> {
+    let sidecar = binary_path.with_extension("attest.json");
+    if !sidecar.exists() {
+        bail!(
+            "no attestation sidecar at {}.\n\
+             \n\
+             The attestation is produced by `perry compile --emit-attest`.\n\
+             If you received this binary from a build CI, ask the publisher to\n\
+             ship the matching `.attest.json` alongside the binary.",
+            sidecar.display()
+        );
+    }
+    let raw = std::fs::read_to_string(&sidecar)
+        .with_context(|| format!("failed to read {}", sidecar.display()))?;
+    let manifest: AttestationManifest = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse {}", sidecar.display()))?;
+    let (actual_hash, actual_size) = sha256_hex(binary_path)?;
+    if actual_hash != manifest.sha256 || actual_size != manifest.size {
+        bail!(
+            "attestation MISMATCH for {}:\n\
+             \n\
+               expected sha256: {}\n\
+               found    sha256: {}\n\
+               expected size:   {}\n\
+               found    size:   {}\n\
+             \n\
+             The binary on disk doesn't match the sidecar attestation.\n\
+             This is the exact signal a swapped/tampered binary would produce.\n\
+             Do NOT run it. (#504)",
+            binary_path.display(),
+            manifest.sha256,
+            actual_hash,
+            manifest.size,
+            actual_size,
+        );
+    }
+    Ok(manifest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn temp_bin(body: &[u8]) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("myapp");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(body).unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn sha256_hex_matches_known_vector() {
+        let (_dir, path) = temp_bin(b"hello\n");
+        let (h, n) = sha256_hex(&path).unwrap();
+        assert_eq!(
+            h,
+            "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
+        );
+        assert_eq!(n, 6);
+    }
+
+    #[test]
+    fn build_and_write_roundtrip() {
+        let (dir, path) = temp_bin(b"compiled bytes");
+        let manifest = build_attestation(&path, dir.path()).unwrap();
+        assert_eq!(manifest.version, 1);
+        assert_eq!(manifest.size, 14);
+        assert_eq!(manifest.binary_filename, "myapp");
+        assert_eq!(manifest.perry_version, env!("CARGO_PKG_VERSION"));
+
+        let written = write_attestation(&path, &manifest).unwrap();
+        assert!(written.ends_with("myapp.attest.json"));
+        let raw = std::fs::read_to_string(&written).unwrap();
+        // BTreeMap-free serde shape: presence checks instead of
+        // strict order.
+        assert!(raw.contains("\"version\": 1"));
+        assert!(raw.contains("\"sha256\":"));
+        assert!(raw.contains("\"size\": 14"));
+    }
+
+    #[test]
+    fn verify_passes_when_hash_matches() {
+        let (dir, path) = temp_bin(b"some-bytes");
+        let m = build_attestation(&path, dir.path()).unwrap();
+        write_attestation(&path, &m).unwrap();
+        let read_back = verify_against_sidecar(&path).expect("verify must pass");
+        assert_eq!(read_back, m);
+    }
+
+    #[test]
+    fn verify_fails_when_binary_tampered() {
+        let (dir, path) = temp_bin(b"original");
+        let m = build_attestation(&path, dir.path()).unwrap();
+        write_attestation(&path, &m).unwrap();
+        // Swap binary contents — same path, different bytes.
+        std::fs::write(&path, b"tampered").unwrap();
+        let err = verify_against_sidecar(&path).expect_err("must detect mismatch");
+        let msg = err.to_string();
+        assert!(msg.contains("MISMATCH"), "{msg}");
+        assert!(msg.contains("(#504)"), "{msg}");
+    }
+
+    #[test]
+    fn verify_fails_when_sidecar_missing() {
+        let (_dir, path) = temp_bin(b"no-sidecar");
+        let err = verify_against_sidecar(&path).expect_err("must fail without sidecar");
+        let msg = err.to_string();
+        assert!(msg.contains("no attestation sidecar"), "{msg}");
+        assert!(msg.contains("`perry compile --emit-attest`"), "{msg}");
+    }
+
+    #[test]
+    fn manifest_is_pretty_printed_json() {
+        // pretty-printed JSON makes `git diff` on a checked-in
+        // attestation human-readable.
+        let (dir, path) = temp_bin(b"x");
+        let m = build_attestation(&path, dir.path()).unwrap();
+        let raw = serde_json::to_string_pretty(&m).unwrap();
+        assert!(raw.contains('\n'), "must be pretty-printed");
+    }
+}

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -337,6 +337,17 @@ pub struct CompileArgs {
     #[arg(long)]
     pub fast_math: bool,
 
+    /// #504 — emit `<binary>.attest.json` next to the compiled
+    /// executable. The sidecar carries SHA-256 of the binary +
+    /// provenance (perry version, git commit, build timestamp) so
+    /// downstream users can verify a downloaded binary matches the
+    /// source. Verify with `perry verify --attest <binary>`.
+    /// Also settable via `PERRY_EMIT_ATTEST=1` env or
+    /// `"perry": { "emitAttest": true }` in package.json.
+    /// See `docs/src/cli/emit-attest.md`.
+    #[arg(long)]
+    pub emit_attest: bool,
+
     /// Minimum Windows version the compiled executable must run on.
     /// Accepted values: `7`, `8`, `10` (default `10`). Ignored on every
     /// non-Windows target.
@@ -582,6 +593,13 @@ pub struct CompilationContext {
     /// default; populated from `perry.allowUnsandboxedBuild` in the
     /// host `package.json`.
     pub allow_unsandboxed_build: Vec<String>,
+    /// #504 — when true, emit `<binary>.attest.json` next to the
+    /// compiled binary. The sidecar holds SHA-256 + size +
+    /// provenance metadata so downstream users can verify the
+    /// binary matches its declared source via `perry verify --attest`.
+    /// Sources, last wins: `perry.emitAttest` in package.json →
+    /// `PERRY_EMIT_ATTEST=1` env → `--emit-attest` CLI.
+    pub emit_attest: bool,
 }
 
 impl std::fmt::Debug for CompilationContext {
@@ -633,6 +651,7 @@ impl CompilationContext {
             permissions: std::collections::BTreeMap::new(),
             host_package_name: None,
             allow_unsandboxed_build: Vec::new(),
+            emit_attest: false,
         }
     }
 }
@@ -1204,6 +1223,15 @@ pub fn run_with_parse_cache(
                         }
                     }
                 }
+                // #504: perry.emitAttest — emit binary attestation
+                // sidecar at compile time. See docs/src/cli/emit-attest.md.
+                if let Some(ea) = pkg
+                    .get("perry")
+                    .and_then(|p| p.get("emitAttest"))
+                    .and_then(|v| v.as_bool())
+                {
+                    ctx.emit_attest = ea;
+                }
             }
         }
     }
@@ -1252,6 +1280,18 @@ pub fn run_with_parse_cache(
             ctx.allow_js_runtime = false;
         }
         _ => {}
+    }
+
+    // #504 — precedence ladder (last wins): package.json
+    // `perry.emitAttest` → env `PERRY_EMIT_ATTEST=1` → CLI
+    // `--emit-attest`.
+    match std::env::var("PERRY_EMIT_ATTEST") {
+        Ok(v) if v == "1" || v.eq_ignore_ascii_case("true") => ctx.emit_attest = true,
+        Ok(v) if v == "0" || v.eq_ignore_ascii_case("false") => ctx.emit_attest = false,
+        _ => {}
+    }
+    if args.emit_attest {
+        ctx.emit_attest = true;
     }
 
     // --- i18n: parse [i18n] config from perry.toml and load locale files ---
@@ -7697,6 +7737,33 @@ pub fn run_with_parse_cache(
                 .status();
         } else {
             let _ = std::process::Command::new("strip").arg(&exe_path).status();
+        }
+    }
+
+    // #504 — emit `<binary>.attest.json` AFTER strip/codesign/etc. so
+    // the captured SHA-256 matches the file users will actually
+    // download. (Hooked here, not next to `Wrote executable:`, because
+    // strip rewrites the file between the linker and the final
+    // shipped form.) Best-effort: errors log and continue.
+    if ctx.emit_attest {
+        match super::attest::build_attestation(&exe_path, &ctx.project_root) {
+            Ok(manifest) => match super::attest::write_attestation(&exe_path, &manifest) {
+                Ok(sidecar) => {
+                    if let OutputFormat::Text = format {
+                        println!("Wrote attestation: {}", sidecar.display())
+                    }
+                }
+                Err(e) => {
+                    if let OutputFormat::Text = format {
+                        eprintln!("warning: failed to write attestation: {}", e)
+                    }
+                }
+            },
+            Err(e) => {
+                if let OutputFormat::Text = format {
+                    eprintln!("warning: failed to build attestation: {}", e)
+                }
+            }
         }
     }
 

--- a/crates/perry/src/commands/dev.rs
+++ b/crates/perry/src/commands/dev.rs
@@ -298,6 +298,7 @@ fn build_once(
         debug_symbols: false,
         no_cache: false,
         fast_math: false,
+        emit_attest: false,
         min_windows_version: "10".to_string(),
         // Phase 2 v7: harmonyos signing flags. `perry dev` is the watch
         // mode for local iteration; unsigned HAPs are fine, fall through

--- a/crates/perry/src/commands/mod.rs
+++ b/crates/perry/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! CLI command implementations
 
 pub mod appstore;
+pub mod attest;
 pub mod audit;
 pub mod cache;
 pub mod check;

--- a/crates/perry/src/commands/run.rs
+++ b/crates/perry/src/commands/run.rs
@@ -191,6 +191,7 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
         debug_symbols: false,
         no_cache: false,
         fast_math: false,
+        emit_attest: false,
         min_windows_version: "10".to_string(),
         // Phase 2 v7: harmonyos signing flags. `perry run` is for local
         // iteration where unsigned HAPs are fine, so fall through to env

--- a/crates/perry/src/commands/verify.rs
+++ b/crates/perry/src/commands/verify.rs
@@ -41,6 +41,15 @@ pub struct VerifyArgs {
     /// Timeout in seconds
     #[arg(long, default_value = "300")]
     pub timeout: u64,
+
+    /// #504 — verify the binary against its sidecar attestation file
+    /// (`<binary>.attest.json`) instead of submitting to the remote
+    /// runtime-verification service. The attestation is produced by
+    /// `perry compile --emit-attest`; this flag recomputes SHA-256
+    /// of the binary on disk and reports a single ok/mismatch line.
+    /// No network calls.
+    #[arg(long)]
+    pub attest: bool,
 }
 
 // --- Response types matching perry-verify API ---
@@ -259,7 +268,51 @@ fn display_verify_results(status: &VerifyStatusResponse) {
 }
 
 /// Entry point for `perry verify` command
+/// #504 — local attestation verification. Reads `<binary>.attest.json`,
+/// recomputes SHA-256 of the binary on disk, reports a single ok or
+/// mismatch line + exit code. No network, no consent prompt.
+fn run_local_attest_verify(binary: &PathBuf, format: OutputFormat) -> Result<()> {
+    let canonical = binary.canonicalize().unwrap_or_else(|_| binary.clone());
+    let manifest = super::attest::verify_against_sidecar(&canonical)?;
+    match format {
+        OutputFormat::Text => {
+            println!(
+                "✓ attestation matches: {}\n  sha256:  {}\n  size:    {} bytes\n  built:   unix-{}\n  perry:   {}\n  commit:  {}",
+                canonical.display(),
+                manifest.sha256,
+                manifest.size,
+                manifest.built_at_unix,
+                manifest.perry_version,
+                if manifest.commit_sha.is_empty() {
+                    "<unknown>"
+                } else {
+                    manifest.commit_sha.as_str()
+                },
+            );
+        }
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "ok": true,
+                    "binary": canonical.to_string_lossy(),
+                    "manifest": manifest,
+                })
+            );
+        }
+    }
+    Ok(())
+}
+
 pub fn run(args: VerifyArgs, format: OutputFormat, _use_color: bool) -> Result<()> {
+    // #504: `--attest` short-circuits to local-attest mode — no
+    // tokio runtime, no remote call, no beta-consent prompt.
+    // Reads `<binary>.attest.json`, recomputes SHA-256 of the binary
+    // on disk, reports a single ok/mismatch line + exit status.
+    if args.attest {
+        return run_local_attest_verify(&args.binary, format);
+    }
+
     if !crate::commands::publish::check_beta_consent("verify") {
         bail!("Aborted.");
     }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -140,6 +140,7 @@
 - [Dynamic Stdlib Dispatch](cli/dynamic-dispatch.md)
 - [JS Runtime Opt-In](cli/allow-js-runtime.md)
 - [`PERRY_SANDBOX_BUILDRS`](cli/sandbox-buildrs.md)
+- [`--emit-attest` (binary attestation sidecar)](cli/emit-attest.md)
 - [perry.toml Reference](cli/perry-toml.md)
 
 ---


### PR DESCRIPTION
Closes #504 (MVP — see follow-up matrix; full reproducible builds + CI publication tracked separately).

## Summary

`perry compile --emit-attest main.ts -o myapp` now writes `myapp.attest.json` next to the executable. The sidecar holds SHA-256 of the *post-strip* binary plus provenance metadata (perry version, git commit, build timestamp) so users who download the binary can verify it matches the publisher's build:

```bash
perry verify --attest myapp
```

The verifier recomputes SHA-256 of the binary on disk and compares against the sidecar. Mismatch fails with a verbose diagnostic reproducing both hashes — exactly the signal a swapped/tampered binary would produce.

## Manifest shape

```json
{
  "version": 1,
  "sha256": "abcd1234...",
  "size": 1048576,
  "perry_version": "0.5.999",
  "commit_sha": "0a1b2c3...",
  "built_at_unix": 1715990400,
  "binary_filename": "myapp"
}
```

`version: 1` reserves room for future top-level keys (CI signature blob, sigstore bundle, reproducible-builds flags log) without breaking existing parsers.

## Cross-platform

Hooks into the platform-agnostic `compile_command` driver after `strip` / codesign / other post-link rewrites — same code path for every target (LLVM / WASM / ArkTS / HarmonyOS / Glance / SwiftUI / JS). The captured hash matches the file users will actually download regardless of which backend produced it.

## Plumbing (mirrors `--fast-math` / `--emit-sandbox`)

- `CompileArgs` gains `pub emit_attest: bool` (`#[arg(long)]`).
- `CompilationContext` gains `pub emit_attest: bool` (default false).
- Precedence ladder (last wins): `perry.emitAttest` in package.json → `PERRY_EMIT_ATTEST=1` env → `--emit-attest` CLI.
- New module `commands::attest`:
  - `AttestationManifest` with `#[derive(Serialize, Deserialize)]`.
  - `sha256_hex(path)` — streaming hash (doesn't OOM on big binaries).
  - `discover_commit_sha(project_root)` — shells out to `git`; empty string when not a git checkout (best-effort).
  - `build_attestation` / `write_attestation` / `verify_against_sidecar`.

## New CLI: `perry verify --attest <binary>`

The existing `perry verify` does remote runtime-verification via `verify.perryts.com`. The new `--attest` flag short-circuits to local-attest mode — no tokio runtime, no network, no beta-consent prompt. Prints either `✓ attestation matches` + provenance OR the mismatch diagnostic with exit 1.

## Test coverage

6 unit tests in `commands::attest::tests`:

- `sha256_hex_matches_known_vector` — pins SHA-256 of `"hello\n"`.
- `build_and_write_roundtrip` — manifest fields + on-disk JSON shape.
- `verify_passes_when_hash_matches` — golden path.
- `verify_fails_when_binary_tampered` — pins #504 cite in mismatch diagnostic.
- `verify_fails_when_sidecar_missing` — pins actionable "produced by `--emit-attest`" guidance.
- `manifest_is_pretty_printed_json` — readable `git diff` invariant.

## End-to-end smoke

```bash
perry compile --emit-attest main.ts -o out
# Wrote executable: out
# Wrote attestation: out.attest.json
# Binary size: 1.0MB

perry verify --attest out
# ✓ attestation matches: /path/to/out + provenance

echo extra >> out
perry verify --attest out
# Error: attestation MISMATCH ... (exit 1)
```

## Implementation note

First attempt hooked the emission next to the `Wrote executable:` print, which fires BEFORE `strip`. The smoke test caught this immediately when verify detected a 1.3 MB → 1.0 MB size shift between the linker output and the final on-disk binary. Final placement is between the strip pass and the `Binary size:` print — a comment in the source documents the placement for the next reader.

## What's NOT covered (MVP)

- **Deterministic builds** — same source on two machines doesn't yet produce a bit-identical binary. The attestation proves "this binary came from THIS specific build run", not "this is the only binary that could come from this source". Full determinism (stable LLVM pass ordering, fixed timestamps, hash-stable iteration) is the next #504 milestone.
- **CI attestation publication** — sigstore / GitHub native attestations / signed bundles. The MVP ships the local primitive; CI publication layers on top.
- **Verifying against a published attestation** — currently the sidecar must travel with the binary. A future `perry verify --attest-url <url>` would fetch from a published source.

## Notes

No `Cargo.toml` version bump, no `CLAUDE.md` touch, no `CHANGELOG.md` entry — maintainer folds those in at merge time.