### PR TITLE
test(ramda): pin #985 V8-namespace fix with user-import fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,74 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.995 — test(ramda): user-import fixture pinning the #985 V8-namespace fix
+
+**Symptom (apparent regression in v0.5.993/.994 compat sweep).** `/tmp/perry-compat-sweep` reported ramda failing at v0.5.993 and v0.5.994:
+
+```
+sum=0
+head=0
+```
+
+instead of the expected `sum=15 / head=1`. The fixture in question is the canonical user-import form:
+
+```ts
+import * as R from "ramda";
+const arr = [1, 2, 3, 4, 5];
+console.log("sum=" + R.sum(arr));
+console.log("head=" + R.head(arr));
+```
+
+PR #985 (committed at `a7cd054a`, 2026-05-18 05:48) had specifically claimed this case was fixed by adding `CompileOptions::namespace_v8_specifiers` and routing `R.<member>(args)` through `js_call_v8_export` from both `expr.rs:6588` (StaticMethodCall arm) and `lower_call.rs:549` (namespace-member-call arm).
+
+**Root cause — stale sweep binary, not a regression.** The sweep at `/tmp/perry-compat-sweep/run.sh` defaults `PERRY_BIN` to `/Users/amlug/projects/perry/perry/target/release/perry`, and that binary on disk was built at 05:25 — 23 minutes *before* #985's commit landed. Rebuilding the compiler (`cargo build --release -p perry-runtime -p perry-stdlib -p perry-jsruntime -p perry`) and rerunning the sweep against the freshly-built binary turns the ramda fixture green immediately:
+
+```
+package       status  phase    error_excerpt
+ramda         PASS    -        -
+```
+
+No code change is required — #985's namespace_v8_specifiers route covers the user-import / bare-V8-fallback path as designed.
+
+**What this release adds — a pinning fixture that would have caught the false alarm.** `test-files/test_ramda_user_import.ts` exercises the exact `import * as R from 'ramda'` user-import shape against five direct calls (number return path):
+
+| call | expected |
+|---|---|
+| `R.sum([1,2,3,4,5])` | 15 |
+| `R.head([1,2,3])` | 1 |
+| `R.add(2, 3)` | 5 |
+| `R.identity(42)` | 42 |
+| `R.multiply(3, 4)` | 12 |
+
+`node --experimental-strip-types test_ramda_user_import.ts` produces `15 / 1 / 5 / 42 / 12`, and the v0.5.995 perry binary matches byte-for-byte. Curried higher-order returns (`const inc = R.add(1); inc(5)`) are intentionally **not** in this fixture — #985 deferred them because the V8 bridge still returns closures as opaque handles the native callsite can't dispatch.
+
+**Validation.**
+
+```
+mkdir -p /tmp/perry-ramda-99 && cd /tmp/perry-ramda-99
+cp <worktree>/test-files/test_ramda_user_import.ts test_user.ts
+cat > package.json <<'EOF'
+{ "name": "test", "type": "module", "dependencies": { "ramda": "0.30.1" } }
+EOF
+npm install --silent --no-audit --no-fund
+<worktree>/target/release/perry test_user.ts -o out_user && ./out_user
+# → 15 / 1 / 5 / 42 / 12 (matches `node --experimental-strip-types`)
+```
+
+Compat sweep with the v0.5.995 worktree binary:
+```
+PERRY_BIN=<worktree>/target/release/perry bash /tmp/perry-compat-sweep/run.sh
+# → ramda PASS
+```
+
+**Files touched.**
+
+- `test-files/test_ramda_user_import.ts` — new fixture.
+- `Cargo.toml`, `CLAUDE.md` — version bump to 0.5.995.
+- `CHANGELOG.md` — this entry.
+
+No source code changes — this release is documentation + a regression-pinning test for the #985 fix.
+
 ## v0.5.994 — feat(jsruntime): V8 ModuleLoader reads from embedded module map (self-contained binaries)
 
 **Symptom.** v0.5.993 closed half of #818: the `__perry_js_bundle.js` artifact now contains every transitive sibling a pure-ESM npm package re-exports, so the bundle's *content* matches reality. The other half (called out in that release's own "Known next blocker") was still open — `NodeModuleLoader::load` in `crates/perry-jsruntime/src/modules.rs` reads source via `std::fs::read_to_string(&path)`, never consults `globalThis.__COMPILETS_MODULES`, and walks the real `node_modules/` tree at runtime. Move a Perry-compiled binary that uses hono / express / any other V8-fallback package into a directory that doesn't have `node_modules/` and V8 throws `Cannot resolve module` (or in the cross-thread `app.fetch(req)` shape, segfaults rc=139) for every missing file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.994
+**Current Version:** 0.5.995
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.994"
+version = "0.5.995"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "base64",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5564,11 +5564,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.994"
+version = "0.5.995"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "itoa",
  "jni",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "block2",
  "libc",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "block2",
  "libc",
@@ -5645,11 +5645,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.994"
+version = "0.5.995"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "block2",
  "libc",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "block2",
  "libc",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "block2",
  "libc",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.994"
+version = "0.5.995"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.994"
+version = "0.5.995"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/test-files/test_ramda_user_import.ts
+++ b/test-files/test_ramda_user_import.ts
@@ -1,0 +1,34 @@
+// Issue followup to #985: V8 namespace-import member calls — user-import form.
+//
+// `import * as R from "ramda"; R.sum([1,2,3,4,5])` returned `0` instead of
+// `15` for every wildcard-namespace member call on a V8-fallback module
+// (ramda, date-fns, jose, effect). #985 added
+// `CompileOptions::namespace_v8_specifiers` and routes the call through
+// `js_call_v8_export(specifier, member, args, argc)` from both the codegen
+// StaticMethodCall arm (`expr.rs`) and the namespace-member-call arm
+// (`lower_call.rs`).
+//
+// This fixture nails the regression bar by exercising the exact pattern
+// the v0.5.993 compat sweep tripped on (`"sum=" + R.sum(arr)` — result
+// flows through string concat, no companion Named import). The sweep
+// originally showed `0` because it consumed a binary built before #985
+// landed; with the post-#985 binary the same fixture produces the
+// expected Node output below.
+//
+// Covers number return (sum/head/add/identity/multiply) — the higher-order
+// `R.add(1)` curried-call form is intentionally NOT tested here because
+// the V8 bridge still returns closures as opaque handles that the native
+// callsite can't dispatch (out of scope per #985).
+//
+// Expected output (matches `node --experimental-strip-types`):
+//   15
+//   1
+//   5
+//   42
+//   12
+import * as R from 'ramda';
+console.log(R.sum([1, 2, 3, 4, 5]));
+console.log(R.head([1, 2, 3]));
+console.log(R.add(2, 3));
+console.log(R.identity(42));
+console.log(R.multiply(3, 4));


### PR DESCRIPTION
## Summary

- v0.5.993/.994 compat sweep reported `R.sum([1,2,3,4,5]) === 0` (and `R.head([1,2,3]) === 0`) for the ramda fixture, but a fresh build of the post-#985 compiler returns 15 / 1 correctly. Root cause: the sweep's default `PERRY_BIN` (`/Users/amlug/projects/perry/perry/target/release/perry`) was built at 05:25 on 2026-05-18, 23 minutes before #985 (`a7cd054a`) landed at 05:48. No code regression.
- Adds `test-files/test_ramda_user_import.ts` exercising the user-import shape (`import * as R from 'ramda'`) across `sum`/`head`/`add`/`identity`/`multiply` so the exact pattern that tripped the sweep is pinned. Output matches `node --experimental-strip-types` byte-for-byte: `15 / 1 / 5 / 42 / 12`.
- Documents the false-alarm + the v0.5.995 release in CHANGELOG.md. No source changes — #985's `namespace_v8_specifiers` route in `expr.rs` / `lower_call.rs` already covers the bare-V8-fallback path.

## Test plan

- [x] `mkdir -p /tmp/perry-ramda-99 && cd /tmp/perry-ramda-99 && cp <worktree>/test-files/test_ramda_user_import.ts test_user.ts && npm i ramda@0.30.1 && <worktree>/target/release/perry test_user.ts -o out && ./out` → `15 / 1 / 5 / 42 / 12`
- [x] `node --experimental-strip-types test_user.ts` → same byte-for-byte
- [x] `PERRY_BIN=<worktree>/target/release/perry bash /tmp/perry-compat-sweep/run.sh` → ramda PASS (was FAIL with stale main-tree binary)
- [x] `cargo fmt --all` clean
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry-jsruntime -p perry` clean