### PR TITLE
feat(jsruntime): V8 named-import static-method dispatch for Effect.succeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.997 — feat(jsruntime): V8 named-import static-method dispatch for Effect.succeed
+
+**Symptom.** `import { Effect } from 'effect'; Effect.succeed(42)` returned the literal number `0` instead of an Effect class instance. `typeof e === 'number'`, `e.pipe` was `undefined`, `e._tag` was `undefined`. Same shape blocked any `import { X } from 'v8-fallback-pkg'; X.method(args)` pattern where the V8 module's top-level export `X` is itself a sub-namespace object holding the actual functions — the Effect/jose/many-internal-tools pattern.
+
+**Root cause — StaticMethodCall on a Named V8 import had no dispatch path.** Perry's HIR-lower lifts `Effect.succeed(42)` to `StaticMethodCall { class_name: "Effect", method_name: "succeed" }` because `Effect` is uppercase + imported (a workaround for missing cross-module class metadata at HIR-lower time). The codegen's StaticMethodCall arm in `crates/perry-codegen/src/expr.rs` then probes, in order:
+
+1. `methods.get(("Effect", "succeed"))` — misses (Effect isn't a perry class)
+2. `namespace_imports.contains("Effect")` — false (it's a Named, not `import * as Effect`)
+3. … fall through to `double_literal(0.0)` stub.
+
+The #985 ramda fix added the same dispatch for the namespace branch (`import * as R from 'ramda'; R.sum(...)`) by routing through `js_call_v8_export(specifier, member, args)`. The Effect shape needed a different bridge call: the V8 module's `Effect` export is itself an object, not a function — `effect.succeed(...)` at the module root doesn't exist; the actual function lives at `effect.Effect.succeed`.
+
+**Fix — new `js_call_v8_member_method` bridge + codegen probe.** Two parts:
+
+1. **Runtime bridge** (`crates/perry-jsruntime/src/interop.rs`). New `js_call_v8_member_method(spec, member, method, args)` FFI entry that:
+   - Loads the module via `js_load_module(spec)`.
+   - Reads `member` off the module namespace (must be an object, not a primitive — Effect/jose/etc all match this shape).
+   - Reads `method` off the member object, asserts it's callable.
+   - Invokes with `this` bound to the member object (matches the JS call semantics — `Effect.succeed(42)` runs with `this === Effect`).
+   - Marshals args + return through the existing `native_to_v8` / `v8_to_native` pair. Object returns come back as JS handles so the receiver-side property/method dispatch reaches V8 again with the prototype intact.
+
+2. **Codegen probe** (`crates/perry-codegen/src/expr.rs`). New `emit_v8_member_method_call(spec, member, method, args)` helper (same shape as #985's `emit_v8_export_call`) materializes three rodata constants + stack-allocates the args buffer + emits the FFI call. The StaticMethodCall arm now probes `ctx.import_function_v8_specifiers.get(class_name)` after the existing namespace branch; on a hit, route through the new helper using the imported (origin) name as the member key.
+
+3. **Aliased-import support** (`crates/perry/src/commands/compile.rs`). When `local != imported` for a Named V8 import, record `local → imported` in `import_function_origin_names` so `import { Effect as Eff } from 'effect'; Eff.succeed(42)` correctly looks up `Effect` on the namespace instead of `Eff`. Without this the alias would silently look up a missing property and fall to undefined.
+
+4. **PropertyGet routing for V8 handles** (`crates/perry-runtime/src/object.rs`). `js_object_get_field_by_name` now detects JS_HANDLE_TAG (top16 == 0x7FFB) at the top of the function and routes through the registered `JS_HANDLE_OBJECT_GET_PROPERTY` callback (perry-jsruntime's `js_handle_object_get_property`). Mirror of the existing `js_call_method` JS_HANDLE_CALL_METHOD dispatch. Without this, `e.value` / `e._tag` on a JS-handle-shaped Effect instance fell through to the small-handle dispatch (which only knows about Fastify/axios/sqlite, not generic V8 handles) and returned undefined. Method calls were already routed correctly — only property reads needed the equivalent fix.
+
+**Validation.**
+
+- `import { Effect } from 'effect'; const e = Effect.succeed(42); console.log(typeof e, typeof e.pipe, e._tag)` now prints `object function Success` — matches `node --experimental-strip-types` byte-for-byte. Pre-fix: `number undefined undefined`.
+- `Effect.runSync(Effect.succeed(42))` returns `42`.
+- `e.pipe(Effect.map(x => x + 1))` chains correctly (the pipe result is also a JS-handle-shaped Effect instance).
+- New in-repo regression test `test-files/test_v8_class_instance_return.ts` + `test-files/fixtures/v8_class_instance_pkg/v8_helper.mjs` pin the synthetic `import { Thing } from "<v8-module>"; Thing.make(42).{value,_tag,doubled(),pipe}` shape that isolates the bug from Effect's full code path. Six lines of output; matches Node.
+- Existing `test-files/test_v8_namespace_call.ts` (#985 wildcard-namespace test) and the #678 V8 fallback tests still pass — the new probe in `StaticMethodCall` runs after the existing namespace branch, so wildcard-namespace dispatch is unchanged.
+- Ramda's `import * as R from 'ramda'; R.sum([1,2,3])` still returns `6` (no regression in the namespace path).
+
+**Out of scope / deferred.**
+
+- Aliased named imports (`import { Effect as Eff }`) are wired but not exercised by Effect's own code — there's no regression test for them yet.
+- Effect's deeper code paths (Schema.ts ~310th-init, HashRing) still hit #684/#809 (object-literal computed-keys, cross-module spread) — those are separate trackers under the umbrella #321.
+- The Effect/jose/etc pattern is the most common shape but not the only one; if a V8 module exports a function (rather than an object) at the named-import slot, `js_call_v8_member_method`'s `is_object` check returns undefined and we'd need a fallback to call the export directly. Not seen in the current package matrix.
+
+**Files changed.**
+
+- `crates/perry-jsruntime/src/interop.rs` — `js_call_v8_member_method` FFI + `c_str_to_utf8` helper.
+- `crates/perry-codegen/src/expr.rs` — `emit_v8_member_method_call` helper + StaticMethodCall probe.
+- `crates/perry/src/commands/compile.rs` — alias→imported registration for V8 named imports.
+- `crates/perry-runtime/src/object.rs` — JS_HANDLE_TAG fast path at the top of `js_object_get_field_by_name`.
+- `crates/perry-runtime/src/value.rs` — expose `JS_HANDLE_OBJECT_GET_PROPERTY` as `pub(crate)` so object.rs can read it.
+- `test-files/test_v8_class_instance_return.ts` + `test-files/fixtures/v8_class_instance_pkg/v8_helper.mjs` — synthetic regression test.
+
 ## v0.5.996 — test(express): lock in the post-#986 `app.on('mount', ...)` smoke
 
 **Context.** The #986 (v0.5.992) fix made the V8-fallback `events` shim lazy-init `_events` on every method touch, which closed the express `app.init()` → `this.on('mount', ...)` crash. The follow-up task expected a *deeper* `Cannot read properties of undefined (reading 'mount')` crash to surface after that fix (`events.js:5` in the V8 stack), but reproducing the express smoke at v0.5.994 — `npm install express@4.21.0` + `import express from 'express'; const app = express(); console.log(typeof app, typeof app.get)` — already prints

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.996
+**Current Version:** 0.5.997
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.996"
+version = "0.5.997"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "base64",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5564,11 +5564,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.996"
+version = "0.5.997"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "itoa",
  "jni",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "block2",
  "libc",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "block2",
  "libc",
@@ -5645,11 +5645,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.996"
+version = "0.5.997"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "block2",
  "libc",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "block2",
  "libc",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "block2",
  "libc",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.996"
+version = "0.5.997"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.996"
+version = "0.5.997"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -196,6 +196,110 @@ pub(crate) fn emit_v8_export_call(
     )
 }
 
+/// Issue #818 (Effect.succeed pattern): emit a
+/// `js_call_v8_member_method(spec, member, method, args)` bridge call for a
+/// named V8 import used as a static-method receiver — `Effect.succeed(42)`
+/// where `Effect` is `import { Effect } from 'effect'`. The V8 module's
+/// top-level export `Effect` is itself a namespace-shaped object whose
+/// `.succeed` is the actual function; the existing `emit_v8_export_call`
+/// would mistakenly try to invoke `effect.succeed(...)` at the module root.
+pub(crate) fn emit_v8_member_method_call(
+    ctx: &mut FnCtx<'_>,
+    specifier: &str,
+    member: &str,
+    method: &str,
+    lowered_args: &[String],
+) -> String {
+    let idx = ctx.typed_parse_counter;
+    ctx.typed_parse_counter += 1;
+    let spec_global = format!("perry_v8_mspec_{}", idx);
+    let member_global = format!("perry_v8_mmember_{}", idx);
+    let method_global = format!("perry_v8_mmethod_{}", idx);
+    let escape = |s: &str| -> String {
+        let bytes = s.as_bytes();
+        let mut lit = String::with_capacity(bytes.len() + 4);
+        lit.push('c');
+        lit.push('"');
+        for &b in bytes {
+            if (32..127).contains(&b) && b != b'"' && b != b'\\' {
+                lit.push(b as char);
+            } else {
+                lit.push('\\');
+                lit.push_str(&format!("{:02X}", b));
+            }
+        }
+        lit.push_str("\\00\"");
+        lit
+    };
+    let spec_bytes = specifier.as_bytes().len();
+    let member_bytes = member.as_bytes().len();
+    let method_bytes = method.as_bytes().len();
+    ctx.typed_parse_rodata.push(format!(
+        "@{} = private unnamed_addr constant [{} x i8] {}",
+        spec_global,
+        spec_bytes + 1,
+        escape(specifier)
+    ));
+    ctx.typed_parse_rodata.push(format!(
+        "@{} = private unnamed_addr constant [{} x i8] {}",
+        member_global,
+        member_bytes + 1,
+        escape(member)
+    ));
+    ctx.typed_parse_rodata.push(format!(
+        "@{} = private unnamed_addr constant [{} x i8] {}",
+        method_global,
+        method_bytes + 1,
+        escape(method)
+    ));
+
+    let argc = lowered_args.len();
+    let alloca_count = if argc == 0 { 1 } else { argc };
+    let blk = ctx.block();
+    let argc_lit = format!("{}", argc);
+    let spec_ptr = format!("@{}", spec_global);
+    let member_ptr = format!("@{}", member_global);
+    let method_ptr = format!("@{}", method_global);
+    let spec_len_lit = format!("{}", spec_bytes);
+    let member_len_lit = format!("{}", member_bytes);
+    let method_len_lit = format!("{}", method_bytes);
+
+    let args_slot = blk.fresh_reg();
+    blk.emit_raw(format!(
+        "{} = alloca [{} x double], align 8",
+        args_slot, alloca_count
+    ));
+    for (i, v) in lowered_args.iter().enumerate() {
+        let slot = blk.fresh_reg();
+        blk.emit_raw(format!(
+            "{} = getelementptr inbounds [{} x double], ptr {}, i64 0, i64 {}",
+            slot, alloca_count, args_slot, i
+        ));
+        blk.emit_raw(format!("store double {}, ptr {}, align 8", v, slot));
+    }
+
+    ctx.pending_declares.push((
+        "js_call_v8_member_method".to_string(),
+        DOUBLE,
+        vec![PTR, I64, PTR, I64, PTR, I64, PTR, I64],
+    ));
+    let blk = ctx.block();
+    blk.call(
+        DOUBLE,
+        "js_call_v8_member_method",
+        &[
+            (PTR, &spec_ptr),
+            (I64, &spec_len_lit),
+            (PTR, &member_ptr),
+            (I64, &member_len_lit),
+            (PTR, &method_ptr),
+            (I64, &method_len_lit),
+            (PTR, &args_slot),
+            (I64, &argc_lit),
+        ],
+    )
+}
+
 /// If `callee` is a `new`-target whose class name is statically
 /// known, return that name. Used by the `Expr::NewDynamic` lowering
 /// to reroute statically-resolvable shapes to the regular `lower_new`
@@ -6654,6 +6758,42 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         lowered.iter().map(|s| (DOUBLE, s.as_str())).collect();
                     return Ok(ctx.block().call(DOUBLE, &fn_name, &arg_slices));
                 }
+            }
+            // Issue #818 (Effect.succeed pattern): the receiver is a NAMED
+            // import (`import { Effect } from 'effect'`), not a namespace
+            // alias. The HIR's "uppercase Ident looks like a class" rule
+            // lifts `Effect.succeed(args)` to StaticMethodCall, but `Effect`
+            // isn't a perry class and isn't in `namespace_imports`. When the
+            // class_name resolves to a V8-fallback specifier, route through
+            // the bridge: load the module, get the named member as an
+            // object, then call .method on it. Without this the call fell
+            // to the `double_literal(0.0)` stub below — Effect's
+            // `Effect.succeed(42)` returned the literal `0` instead of the
+            // tagged Effect instance.
+            if let Some(specifier) = ctx.import_function_v8_specifiers.get(class_name).cloned() {
+                let mut lowered: Vec<String> = Vec::with_capacity(args.len());
+                for a in args {
+                    lowered.push(lower_expr(ctx, a)?);
+                }
+                // The V8 module's top-level export uses the *imported* name
+                // (the name in the source module). If the local alias differs
+                // from the imported name, fall back to the local name — the
+                // specifier-registration code in compile.rs registers both
+                // when local != imported, so for a Named import the lookup
+                // key here is the consumer-visible alias which equals the
+                // remote name when no `as` rename is present.
+                let member = ctx
+                    .import_function_origin_names
+                    .get(class_name)
+                    .cloned()
+                    .unwrap_or_else(|| class_name.clone());
+                return Ok(emit_v8_member_method_call(
+                    ctx,
+                    &specifier,
+                    &member,
+                    method_name,
+                    &lowered,
+                ));
             }
             for a in args {
                 let _ = lower_expr(ctx, a)?;

--- a/crates/perry-jsruntime/src/interop.rs
+++ b/crates/perry-jsruntime/src/interop.rs
@@ -1195,6 +1195,168 @@ pub unsafe extern "C" fn js_call_v8_export(
     )
 }
 
+/// Issue #818 (Effect.succeed pattern): invoke a method on a NAMED member of a
+/// V8-fallback module — `Effect.succeed(42)` where `Effect` is imported by name
+/// (`import { Effect } from 'effect'`) and the export is itself a sub-namespace
+/// object that holds the actual `succeed` function.
+///
+/// Without this entry, `StaticMethodCall { class_name: "Effect", method_name:
+/// "succeed" }` fell through to `double_literal(0.0)` because:
+///   - `methods.get(("Effect","succeed"))` misses (Effect isn't a perry class)
+///   - `namespace_imports.contains("Effect")` is false (it's a Named, not a
+///     `import * as Effect`)
+///   - The existing `js_call_v8_export` would call `effect.succeed(...)` at
+///     the top level of the module, but the actual function lives at
+///     `effect.Effect.succeed`.
+///
+/// Bundles `js_load_module` + namespace-property-get + method-call so the
+/// codegen can drop in a single FFI call wherever a named V8 import is invoked
+/// as a static method. Argument and return marshalling follows the same
+/// conventions as `js_call_v8_export` — args already NaN-boxed, result
+/// NaN-boxed (objects come back as JS handles so subsequent `.value` /
+/// `.pipe()` accesses route through the existing HANDLE_PROPERTY / METHOD
+/// dispatch and reach V8 again with the prototype intact).
+#[no_mangle]
+pub unsafe extern "C" fn js_call_v8_member_method(
+    specifier_ptr: *const i8,
+    specifier_len: usize,
+    member_name_ptr: *const i8,
+    member_name_len: usize,
+    method_name_ptr: *const i8,
+    method_name_len: usize,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    bump_v8_entry(V8EntryKind::V8ExportCall);
+    let module_handle = js_load_module(specifier_ptr, specifier_len);
+    if module_handle == 0 {
+        return f64::from_bits(0x7FFC_0000_0000_0001);
+    }
+    let member_name = match c_str_to_utf8(member_name_ptr, member_name_len) {
+        Some(s) => s,
+        None => return f64::from_bits(0x7FFC_0000_0000_0001),
+    };
+    let method_name = match c_str_to_utf8(method_name_ptr, method_name_len) {
+        Some(s) => s,
+        None => return f64::from_bits(0x7FFC_0000_0000_0001),
+    };
+    let args = if args_ptr.is_null() || args_len == 0 {
+        Vec::new()
+    } else {
+        std::slice::from_raw_parts(args_ptr, args_len).to_vec()
+    };
+
+    with_runtime(|state| {
+        let module_id = module_handle as deno_core::ModuleId;
+        let namespace = match state.runtime.get_module_namespace(module_id) {
+            Ok(ns) => ns,
+            Err(e) => {
+                log::error!("Failed to get module namespace: {}", e);
+                return f64::from_bits(0x7FFC_0000_0000_0001);
+            }
+        };
+
+        deno_core::scope!(scope, &mut state.runtime);
+        let namespace = v8::Local::new(scope, namespace);
+        v8::tc_scope!(tc_scope, scope);
+
+        // Walk the member chain (single hop here — caller passes `Effect`
+        // for `Effect.succeed(args)`). Result must be a callable host.
+        let member_key = match v8::String::new(tc_scope, &member_name) {
+            Some(k) => k,
+            None => return f64::from_bits(0x7FFC_0000_0000_0001),
+        };
+        let member_val = match namespace.get(tc_scope, member_key.into()) {
+            Some(v) => v,
+            None => {
+                eprintln!(
+                    "[JS-INTEROP] V8 member '{}' not found on module namespace",
+                    member_name
+                );
+                return f64::from_bits(0x7FFC_0000_0000_0001);
+            }
+        };
+        if !member_val.is_object() {
+            eprintln!(
+                "[JS-INTEROP] V8 member '{}' is not an object (got typeof {})",
+                member_name,
+                if member_val.is_function() {
+                    "function"
+                } else {
+                    "primitive"
+                }
+            );
+            return f64::from_bits(0x7FFC_0000_0000_0001);
+        }
+        let member_obj = match member_val.to_object(tc_scope) {
+            Some(o) => o,
+            None => return f64::from_bits(0x7FFC_0000_0000_0001),
+        };
+
+        let method_key = match v8::String::new(tc_scope, &method_name) {
+            Some(k) => k,
+            None => return f64::from_bits(0x7FFC_0000_0000_0001),
+        };
+        let method_val = match member_obj.get(tc_scope, method_key.into()) {
+            Some(v) => v,
+            None => {
+                eprintln!(
+                    "[JS-INTEROP] V8 method '{}.{}' not found",
+                    member_name, method_name
+                );
+                return f64::from_bits(0x7FFC_0000_0000_0001);
+            }
+        };
+        if !method_val.is_function() {
+            eprintln!(
+                "[JS-INTEROP] V8 '{}.{}' is not a function",
+                member_name, method_name
+            );
+            return f64::from_bits(0x7FFC_0000_0000_0001);
+        }
+        let method = v8::Local::<v8::Function>::try_from(method_val).unwrap();
+
+        let v8_args: Vec<v8::Local<v8::Value>> = args
+            .iter()
+            .map(|&a| native_to_v8(tc_scope, fixup_native_for_v8(a)))
+            .collect();
+
+        // Bind `this` to the member object so methods that use `this`
+        // (most class-style static methods) see the right receiver.
+        let result = match method.call(tc_scope, member_obj.into(), &v8_args) {
+            Some(r) => r,
+            None => {
+                if tc_scope.has_caught() {
+                    if let Some(exception) = tc_scope.exception() {
+                        let msg = exception.to_rust_string_lossy(tc_scope);
+                        eprintln!(
+                            "[JS-INTEROP] '{}.{}' threw: {}",
+                            member_name, method_name, msg
+                        );
+                    }
+                }
+                return f64::from_bits(0x7FFC_0000_0000_0001);
+            }
+        };
+
+        v8_to_native(tc_scope, result)
+    })
+}
+
+fn c_str_to_utf8(ptr: *const i8, len: usize) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    let bytes = unsafe {
+        if len > 0 {
+            std::slice::from_raw_parts(ptr as *const u8, len)
+        } else {
+            CStr::from_ptr(ptr as *const c_char).to_bytes()
+        }
+    };
+    std::str::from_utf8(bytes).ok().map(|s| s.to_string())
+}
+
 fn call_function_impl(
     state: &mut JsRuntimeState,
     namespace: v8::Global<v8::Object>,

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -3710,6 +3710,37 @@ pub extern "C" fn js_object_get_field_by_name(
     obj: *const ObjectHeader,
     key: *const crate::StringHeader,
 ) -> JSValue {
+    // Issue #818 (Effect class-instance pattern): a V8 handle (JS_HANDLE_TAG
+    // = 0x7FFB) reaches here when codegen routes a generic `PropertyGet`
+    // through this slow path — e.g. `Effect.succeed(42).value` where the
+    // call return was a JS handle but the HIR `js_transform` pass didn't
+    // rewrite the consumer-side `.value` into `JsGetProperty` (because the
+    // call lowered as a `StaticMethodCall`, not as a `JsCallMethod`). The
+    // method-call counterpart in `js_call_method` already routes
+    // JS_HANDLE_TAG values to V8 via JS_HANDLE_CALL_METHOD; do the same
+    // here via JS_HANDLE_OBJECT_GET_PROPERTY so subsequent property reads
+    // on a returned class instance reach the live V8 object instead of
+    // falling to the small-handle dispatch (which only knows about
+    // Fastify/axios/sqlite, not generic V8 handles).
+    {
+        let bits = obj as u64;
+        if (bits >> 48) == 0x7FFB && !key.is_null() {
+            let func_ptr = crate::value::JS_HANDLE_OBJECT_GET_PROPERTY
+                .load(std::sync::atomic::Ordering::SeqCst);
+            if !func_ptr.is_null() {
+                let func: unsafe extern "C" fn(f64, *const i8, usize) -> f64 =
+                    unsafe { std::mem::transmute(func_ptr) };
+                unsafe {
+                    let key_ptr =
+                        (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                    let key_len = (*key).byte_len as usize;
+                    let result = func(f64::from_bits(bits), key_ptr as *const i8, key_len);
+                    return JSValue::from_bits(result.to_bits());
+                }
+            }
+            return JSValue::undefined();
+        }
+    }
     // Issue #618-followup: read INT32-tagged class ref's dynamic property
     // from the side-table (mirror of the set-side intercept). For drizzle's
     // `SQL.Aliased` lookup pattern.

--- a/crates/perry-runtime/src/value.rs
+++ b/crates/perry-runtime/src/value.rs
@@ -121,7 +121,8 @@ type JsHandleTypeofFn = unsafe extern "C" fn(f64) -> i32;
 
 static JS_HANDLE_ARRAY_GET: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 static JS_HANDLE_ARRAY_LENGTH: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
-static JS_HANDLE_OBJECT_GET_PROPERTY: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+pub(crate) static JS_HANDLE_OBJECT_GET_PROPERTY: AtomicPtr<()> =
+    AtomicPtr::new(std::ptr::null_mut());
 static JS_HANDLE_TO_STRING: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 pub static JS_HANDLE_CALL_METHOD: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 pub static JS_NATIVE_MODULE_JS_LOADER: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -4271,6 +4271,21 @@ pub fn run_with_parse_cache(
                                     .insert(imported.clone(), synthetic_prefix.clone());
                                 import_function_v8_specifiers
                                     .insert(imported.clone(), specifier.clone());
+                                // Issue #818 (Effect.succeed pattern) follow-up:
+                                // when an aliased named-import (`import { Foo
+                                // as Bar }`) of a V8 module is used as a
+                                // static-method receiver (`Bar.method(...)`),
+                                // the codegen's StaticMethodCall arm sees
+                                // class_name = "Bar" — but the V8 namespace
+                                // exposes the property under "Foo". Record the
+                                // local→imported mapping in
+                                // `import_function_origin_names` so the bridge
+                                // call reaches the right namespace property.
+                                // Without this, aliased Effect-shaped imports
+                                // would look up a missing property and fall to
+                                // undefined.
+                                import_function_origin_names
+                                    .insert(local.clone(), imported.clone());
                             }
                         }
                         perry_hir::ImportSpecifier::Default { local } => {

--- a/test-files/fixtures/v8_class_instance_pkg/v8_helper.mjs
+++ b/test-files/fixtures/v8_class_instance_pkg/v8_helper.mjs
@@ -1,0 +1,15 @@
+// V8-fallback helper used by `test_v8_class_instance_return.ts`. Mirrors
+// the Effect/jose shape: a named export `Thing` that is itself an object
+// (not a class function) whose `.make(v)` returns a class-instance with
+// `.value` and `.doubled()`. The bug pre-#818 had `Thing.make(42)` fall
+// to the `double_literal(0.0)` codegen stub.
+class Box {
+  constructor(v) { this.value = v; this._tag = 'Boxed'; }
+  doubled() { return this.value * 2; }
+  pipe(fn) { return fn(this); }
+}
+
+export const Thing = {
+  make(v) { return new Box(v); },
+  greet(name) { return 'hello ' + name; }
+};

--- a/test-files/test_v8_class_instance_return.ts
+++ b/test-files/test_v8_class_instance_return.ts
@@ -1,0 +1,34 @@
+// Issue #818 — V8-fallback class-instance return marshalling for
+// `Effect.succeed(42)`-shaped patterns.
+//
+// `import { Thing } from "<v8-module>"; Thing.make(42)` hit the HIR's
+// "uppercase Ident looks like a class" rule and lowered to
+// `StaticMethodCall { class_name: "Thing", method_name: "make" }`. Pre-#818
+// the codegen had no path for a Named V8 import used as a static-method
+// receiver: methods.get miss, namespace_imports.contains miss, fall to
+// `double_literal(0.0)` stub. Effect's `Effect.succeed(42)` produced the
+// literal number 0 instead of a tagged Effect instance.
+//
+// Fix: when class_name is in `import_function_v8_specifiers`, route through
+// the new `js_call_v8_member_method(spec, member, method, args)` runtime
+// bridge. The bridge loads the module, gets `Thing` from its namespace,
+// calls `.make(args)` on it, and the object return crosses back as a JS
+// handle (so `inst.value` / `inst.doubled()` route through the existing
+// HANDLE_PROPERTY / HANDLE_METHOD dispatch).
+//
+// Expected output matches `node --experimental-strip-types`:
+//   object
+//   42
+//   Boxed
+//   84
+//   function
+//   hello world
+import { Thing } from './fixtures/v8_class_instance_pkg/v8_helper.mjs';
+
+const inst = Thing.make(42);
+console.log(typeof inst);
+console.log((inst as any).value);
+console.log((inst as any)._tag);
+console.log((inst as any).doubled());
+console.log(typeof (inst as any).pipe);
+console.log(Thing.greet('world'));


### PR DESCRIPTION
## Summary

- `import { Effect } from 'effect'; Effect.succeed(42)` returned the literal number `0` instead of an Effect class instance — `typeof e === 'number'`, `.pipe` undefined, `._tag` undefined. After this PR: `object / function / Success`, matching Node byte-for-byte.
- Same shape blocked any `import { X } from 'v8-fallback-pkg'; X.method(args)` pattern where the V8 module's top-level export `X` is itself a sub-namespace object holding the actual functions (Effect / jose / other internal-tool packages).
- Companion to #985 (which wired up `import * as R from 'ramda'; R.sum(...)` — the wildcard-namespace branch). This PR wires up the **named-import** branch via a new `js_call_v8_member_method` bridge and a JS_HANDLE_TAG fast path in `js_object_get_field_by_name`.

## Root cause

HIR-lower lifts `Effect.succeed(42)` to `StaticMethodCall { class_name: "Effect", method_name: "succeed" }` because `Effect` is uppercase + imported (a workaround for missing cross-module class metadata at HIR-lower time). The codegen StaticMethodCall arm probes `methods.get` (miss), `namespace_imports.contains("Effect")` (false — it's Named, not `import * as`), falls to `double_literal(0.0)`. The #985 ramda fix patched the namespace branch but couldn't reach this one because `Effect` is itself an object on the `effect` module (not a function), so `effect.succeed(...)` at the root doesn't exist — the actual function lives at `effect.Effect.succeed`. A different bridge call was needed.

Additionally, even with the call fixed, `e.value` / `e._tag` on the returned JS-handle-shaped class instance fell through to the small-handle dispatch (which only knows about Fastify/axios/sqlite), so property reads returned undefined. Method calls were already routed correctly through `js_call_method`'s JS_HANDLE_CALL_METHOD dispatch — only property reads needed the equivalent fix.

## What this ships

1. **New `js_call_v8_member_method` runtime FFI** (`crates/perry-jsruntime/src/interop.rs`). Loads the module, reads the named member as an object, asserts the method is callable, invokes with `this` bound to the member, marshals args + return through the existing `native_to_v8`/`v8_to_native` pair.

2. **New `emit_v8_member_method_call` codegen helper** (`crates/perry-codegen/src/expr.rs`). Materializes three rodata constants + stack-allocates the args buffer + emits the FFI call. The StaticMethodCall arm probes `ctx.import_function_v8_specifiers.get(class_name)` after the existing namespace branch.

3. **Aliased-import support** (`crates/perry/src/commands/compile.rs`). Records `local → imported` in `import_function_origin_names` when `local != imported` so `import { Effect as Eff }` correctly looks up `Effect` on the namespace.

4. **JS_HANDLE_TAG fast path** (`crates/perry-runtime/src/object.rs`). `js_object_get_field_by_name` now detects top16 == 0x7FFB at entry and routes through the registered `JS_HANDLE_OBJECT_GET_PROPERTY` callback. Mirror of the existing `js_call_method` JS_HANDLE_CALL_METHOD routing.

5. **Regression test**. `test-files/test_v8_class_instance_return.ts` + `test-files/fixtures/v8_class_instance_pkg/v8_helper.mjs` pin a synthetic `import { Thing } from "<v8-module>"; Thing.make(42)` shape (Effect/jose distilled, six lines of output, matches Node).

Out of scope: alias-import is wired but not regression-tested. Effect's deeper code paths (Schema.ts ~310th-init, HashRing) still hit #684/#809 under the #321 umbrella.

## Test plan

- [x] `import { Effect } from 'effect'; Effect.succeed(42)` → matches Node `object / function / Success`
- [x] `Effect.runSync(Effect.succeed(42))` → 42
- [x] `e.pipe(Effect.map(x => x + 1))` chains correctly (`object / function`)
- [x] `test-files/test_v8_class_instance_return.ts` — six lines, matches Node
- [x] `test-files/test_v8_namespace_call.ts` (#985 regression) — still passes
- [x] `test-files/test_issue_678_v8_fallback{,_symbols}.ts` — still pass
- [x] `test-files/test_gap_*.ts` — same six diffs as main (pre-existing, unrelated)
- [x] `import * as L from 'lodash'; L.sum([1,2,3])` — still 6