### PR TITLE
feat(jsruntime/http): V8-fallback createServer bridge to native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,82 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.999 — feat(jsruntime/http): V8-fallback `createServer` bridge to a real hyper server
+
+Pre-fix the V8/JS-runtime fallback's `node:http` stub raised
+`Error: http.createServer not supported in this environment` whenever an
+interpreted module (express, fastify, nestjs, …) called
+`http.createServer((req, res) => …)`. Express's `app.listen(...)` goes
+through `http.createServer(app)` internally, so any V8-resolved express
+app crashed at boot.
+
+This change wires the stub to a real hyper-based HTTP/1.1 server via
+four new deno_core ops:
+
+- `op_perry_http_listen(port, host)` — async; binds a `tokio::net::TcpListener`
+  on Perry's shared multi-thread tokio runtime, spawns a hyper accept
+  loop that pushes `PendingHttpRequest`s through an mpsc channel.
+- `op_perry_http_accept(serverId)` — async; pops the next pending
+  request, stashes the response `oneshot::Sender` keyed by request id,
+  returns `{id, method, url, headers, rawHeaders, body}` to JS.
+- `op_perry_http_respond(reqId, status, headersJson, body)` — sync;
+  resolves the stashed oneshot with a `HttpResponseShape` so hyper's
+  service fn can write the response.
+- `op_perry_http_close(serverId)` — sync; drops the accept-loop shutdown
+  oneshot so the listener exits cleanly.
+
+`crates/perry-jsruntime/src/modules.rs` `node:http` stub now exports a
+real `Server` class with `.listen()`, `.close()`, `.on()`, plus
+`IncomingMessage` and `ServerResponse` that implement the minimum
+surface express needs: `req.method`/`req.url`/`req.headers`,
+`res.writeHead`/`res.setHeader`/`res.write`/`res.end`/`res.statusCode`.
+Response bodies are utf-8 strings (no streaming); request bodies are
+synthesized as a single `'data'` event followed by `'end'` on next tick
+so `req.on('data', cb).on('end', cb)` consumers work.
+
+Two adjacent fixes were required so the async-op pipeline could touch
+tokio at all:
+
+1. `JsRuntime::new()` captures `tokio::runtime::Handle::try_current()`
+   for its async-op executor. `ensure_runtime_initialized` previously
+   called it without any tokio context, so the captured handle pointed
+   at nothing and any subsequent `TcpListener::bind` / `tokio::spawn`
+   from inside an async op panicked with "there is no reactor running".
+   `ensure_runtime_initialized` now enters Perry's shared
+   `TOKIO_RUNTIME` via `tokio::runtime::Runtime::enter` before
+   constructing the runtime.
+2. The same enter() guard now wraps every `with_runtime(...)` call.
+   Without this the JS event loop pump (`poll_event_loop`) would poll
+   async ops in a thread-local context that lacked a reactor. Mirror
+   logic added to `jsruntime_process_pending`.
+
+`jsruntime_has_active_handles` now keeps the program alive while any
+V8-fallback http server is bound; without this, the outer event loop
+would exit before the accept loop saw its first connection.
+
+Validation:
+
+- `test-files/test_http_createserver_v8.ts` (TS file, goes through the
+  *native* `node:http` path on perry-ext-http-server) still prints
+  `200 hello` — unchanged, no regression.
+- Express smoke from the issue prompt (`/tmp/perry-express-http/test.ts`
+  with `import express from 'express'` + `app.listen(19000, cb)`) now
+  prints `listening on 19000` (pre-fix: thrown error at module init).
+- A middleware-only express variant (`app.use((req, res) => res.end(...))`)
+  serves a real HTTP response: external `fetch('http://127.0.0.1:.../')`
+  returns `status=200 body=hi-from-middleware`.
+
+Deferred — explicitly out of scope for this initial bridge:
+
+- Streaming request/response bodies (everything buffers as a string).
+- HTTPS + HTTP/2 (`createSecureServer` still throws — applications that
+  need TLS termination should compile through the native path).
+- `req.socket`/`req.connection` surface.
+- `'upgrade'` events / WebSocket handshakes inside V8 (those live in
+  perry-ext-http-server via `js_node_http_server_on`).
+- A full `Server` `EventEmitter` (the shim implements on/off/emit but
+  isn't an `events.EventEmitter` instance).
+
 ## v0.5.998 — fix(date-fns): format() returns a formatted string instead of undefined
 
 **Symptom.** `import { format } from 'date-fns'; format(new Date(2020, 0, 6), 'yyyy-MM-dd')` compiled cleanly and ran without error, but the console printed `undefined` instead of `2020-01-06`. Same shape for every other free function date-fns exports (`parseISO`, `addDays`, `isAfter`, …).
@@ -30,7 +106,6 @@ console.log(format(d, 'MM'));            // 01
 console.log(format(d, 'dd'));            // 06
 console.log(typeof format(d, 'yyyy'));   // string
 ```
-
 ## v0.5.997 — feat(jsruntime): V8 named-import static-method dispatch for Effect.succeed
 
 **Symptom.** `import { Effect } from 'effect'; Effect.succeed(42)` returned the literal number `0` instead of an Effect class instance. `typeof e === 'number'`, `e.pipe` was `undefined`, `e._tag` was `undefined`. Same shape blocked any `import { X } from 'v8-fallback-pkg'; X.method(args)` pattern where the V8 module's top-level export `X` is itself a sub-namespace object holding the actual functions — the Effect/jose/many-internal-tools pattern.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.998
+**Current Version:** 0.5.999
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.998"
+version = "0.5.999"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,11 +5420,15 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
+ "bytes",
  "deno_core",
  "deno_error",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "log",
  "once_cell",
  "perry-runtime",
@@ -5440,7 +5444,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5452,7 +5456,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "base64",
@@ -5476,7 +5480,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5546,7 +5550,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5556,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5564,11 +5568,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.998"
+version = "0.5.999"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "itoa",
  "jni",
@@ -5583,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5593,7 +5597,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5612,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "block2",
  "libc",
@@ -5627,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "block2",
  "libc",
@@ -5645,11 +5649,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.998"
+version = "0.5.999"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "block2",
  "libc",
@@ -5664,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "block2",
  "libc",
@@ -5679,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "block2",
  "libc",
@@ -5692,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5706,7 +5710,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5720,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.998"
+version = "0.5.999"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.998"
+version = "0.5.999"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-jsruntime/Cargo.toml
+++ b/crates/perry-jsruntime/Cargo.toml
@@ -41,5 +41,13 @@ regex = "1"
 # HTTP client for fetch() polyfill (blocking, no Tokio dependency)
 ureq = "2"
 
+# HTTP server stack for `http.createServer` shim used by the V8 fallback
+# path (express/fastify smoke tests). Same crate versions as perry-ext-http-server
+# so we don't duplicate the dep graph.
+hyper = { version = "1.4", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["server", "tokio"] }
+http-body-util = "0.1"
+bytes = "1.5"
+
 [features]
 default = []

--- a/crates/perry-jsruntime/src/interop.rs
+++ b/crates/perry-jsruntime/src/interop.rs
@@ -435,6 +435,13 @@ fn poll_pending_module_evaluations(state: &mut JsRuntimeState) -> i32 {
 extern "C" fn jsruntime_process_pending() -> i32 {
     jsruntime_profile_register();
     bump_jsruntime(&JSRUNTIME_PUMP_TICKS);
+    // Enter the shared tokio runtime so async ops (e.g. the V8-fallback
+    // `op_perry_http_*` listener) that touch `tokio::net` / `tokio::spawn`
+    // can run inside a reactor context. Without this guard, polling an
+    // async op that does `TcpListener::bind(...)` panics with "there is
+    // no reactor running".
+    let tokio_rt = crate::get_tokio_runtime();
+    let _enter = tokio_rt.enter();
     with_runtime(|state| {
         let mut ran = poll_v8_event_loop_once(state);
         let resolved_ticks = resolve_pending_jsruntime_ticks(state);
@@ -457,7 +464,12 @@ extern "C" fn jsruntime_has_active_handles() -> i32 {
             .as_ref()
             .is_some_and(|state| !state.pending_module_evaluations.is_empty())
     });
-    if has_foreign_adapters || has_pending_ticks || has_module_evaluations {
+    // Keep the program alive while any V8-fallback `http.createServer`
+    // is still listening — without this the outer event loop exits
+    // immediately after `server.listen(...)` resolves and the accept
+    // loop's tokio task is dropped before serving any requests.
+    let has_http_servers = crate::ops::perry_http_active_count() > 0;
+    if has_foreign_adapters || has_pending_ticks || has_module_evaluations || has_http_servers {
         1
     } else {
         0

--- a/crates/perry-jsruntime/src/lib.rs
+++ b/crates/perry-jsruntime/src/lib.rs
@@ -199,6 +199,15 @@ pub fn ensure_runtime_initialized() {
     if REENTRY_PTR.with(|p| !p.get().is_null()) {
         return;
     }
+    // `JsRuntime::new()` captures `tokio::runtime::Handle::try_current()`
+    // for its async-op executor. Without entering Perry's shared tokio
+    // runtime here, async ops that touch `tokio::net` / `tokio::spawn`
+    // would later panic with "no reactor running" because the captured
+    // handle would be empty / point at a defunct runtime. Mirror this
+    // enter() in `with_runtime` below so every poll of the JS event loop
+    // sees the same reactor context.
+    let tokio_rt = get_tokio_runtime();
+    let _enter = tokio_rt.enter();
     JS_RUNTIME.with(|cell| {
         let mut opt = cell.borrow_mut();
         if opt.is_none() {
@@ -236,6 +245,11 @@ where
     }
 
     ensure_runtime_initialized();
+    // Enter the shared tokio runtime context so V8 async ops touching
+    // `tokio::net` / `tokio::spawn` (e.g. the V8-fallback http server
+    // ops) can run inside a reactor. See `ensure_runtime_initialized`.
+    let tokio_rt = get_tokio_runtime();
+    let _enter = tokio_rt.enter();
     JS_RUNTIME.with(|cell| {
         let mut opt = cell.borrow_mut();
         let state = opt.as_mut().expect("Runtime should be initialized");

--- a/crates/perry-jsruntime/src/modules.rs
+++ b/crates/perry-jsruntime/src/modules.rs
@@ -1108,14 +1108,305 @@ export default { TLSSocket, connect, createSecureContext };
 "#.to_string(),
         "http" | "https" | "http2" => r#"
 // Stub implementation for Node.js http/https/http2 module
-export class IncomingMessage {}
-export class ServerResponse {}
+//
+// `createServer(handler)` bridges to the V8-fallback HTTP server via
+// the `op_perry_http_*` ops (see crates/perry-jsruntime/src/ops.rs).
+// This is the minimum viable shape — enough for express.listen() to
+// receive real requests and respond. NOT a full Node `http.Server`
+// (no streams, no trailers, no upgrade events). Apps that need richer
+// HTTP server semantics should compile through the native path
+// (perry-ext-http-server).
+const __perry_core = (typeof Deno !== 'undefined' && Deno.core) ? Deno.core : null;
+const __perry_ops = __perry_core && __perry_core.ops ? __perry_core.ops : null;
+
+export class IncomingMessage {
+    constructor(opaque) {
+        this.method = opaque.method;
+        this.url = opaque.url;
+        this.headers = opaque.headers || {};
+        this.rawHeaders = opaque.rawHeaders || [];
+        this.httpVersion = '1.1';
+        this.httpVersionMajor = 1;
+        this.httpVersionMinor = 1;
+        this.complete = true;
+        this._body = opaque.body || '';
+        this._listeners = Object.create(null);
+        // Minimal stream-ish events: synthesize 'data' + 'end' on next tick
+        // so handlers that wire `.on('data', ...).on('end', ...)` work.
+        Promise.resolve().then(() => {
+            const dataCbs = this._listeners['data'] || [];
+            if (dataCbs.length > 0 && this._body) {
+                for (const cb of dataCbs) cb(this._body);
+            }
+            const endCbs = this._listeners['end'] || [];
+            for (const cb of endCbs) cb();
+        });
+    }
+    on(event, listener) {
+        (this._listeners[event] = this._listeners[event] || []).push(listener);
+        return this;
+    }
+    once(event, listener) {
+        const wrapped = (...args) => { this.off(event, wrapped); listener(...args); };
+        return this.on(event, wrapped);
+    }
+    off(event, listener) {
+        const arr = this._listeners[event];
+        if (arr) { const i = arr.indexOf(listener); if (i >= 0) arr.splice(i, 1); }
+        return this;
+    }
+    removeListener(event, listener) { return this.off(event, listener); }
+    emit(event, ...args) {
+        const arr = this._listeners[event];
+        if (arr) arr.slice().forEach(fn => fn.apply(this, args));
+        return !!arr;
+    }
+    setEncoding() { return this; }
+    pause() { return this; }
+    resume() { return this; }
+}
+
+export class ServerResponse {
+    constructor(reqId) {
+        this._reqId = reqId;
+        this._status = 200;
+        this._headers = []; // array of [name, value] preserving order
+        this._headerMap = Object.create(null); // lowercase -> last value
+        this._body = '';
+        this._ended = false;
+        this.headersSent = false;
+        this.finished = false;
+        this.statusCode = 200;
+        this.statusMessage = '';
+        this._listeners = Object.create(null);
+    }
+    setHeader(name, value) {
+        const lower = String(name).toLowerCase();
+        // Replace any previous entry for the same header.
+        this._headers = this._headers.filter(p => p[0].toLowerCase() !== lower);
+        this._headers.push([String(name), String(value)]);
+        this._headerMap[lower] = String(value);
+        return this;
+    }
+    getHeader(name) { return this._headerMap[String(name).toLowerCase()]; }
+    getHeaders() {
+        const out = {};
+        for (const [k, v] of this._headers) out[k.toLowerCase()] = v;
+        return out;
+    }
+    getHeaderNames() { return Object.keys(this._headerMap); }
+    hasHeader(name) { return String(name).toLowerCase() in this._headerMap; }
+    removeHeader(name) {
+        const lower = String(name).toLowerCase();
+        this._headers = this._headers.filter(p => p[0].toLowerCase() !== lower);
+        delete this._headerMap[lower];
+        return this;
+    }
+    writeHead(status, statusMessageOrHeaders, headers) {
+        this._status = status;
+        this.statusCode = status;
+        let h = headers;
+        if (statusMessageOrHeaders && typeof statusMessageOrHeaders !== 'string') {
+            h = statusMessageOrHeaders;
+        } else if (typeof statusMessageOrHeaders === 'string') {
+            this.statusMessage = statusMessageOrHeaders;
+        }
+        if (h) {
+            if (Array.isArray(h)) {
+                // [name1, val1, name2, val2, ...]
+                for (let i = 0; i + 1 < h.length; i += 2) this.setHeader(h[i], h[i + 1]);
+            } else {
+                for (const k of Object.keys(h)) this.setHeader(k, h[k]);
+            }
+        }
+        return this;
+    }
+    write(chunk) {
+        if (this._ended) return false;
+        if (chunk == null) return true;
+        if (typeof chunk === 'string') {
+            this._body += chunk;
+        } else if (chunk instanceof Uint8Array) {
+            this._body += new TextDecoder().decode(chunk);
+        } else if (chunk && chunk.buffer instanceof ArrayBuffer) {
+            this._body += new TextDecoder().decode(new Uint8Array(chunk.buffer));
+        } else {
+            this._body += String(chunk);
+        }
+        return true;
+    }
+    end(chunk, encoding, cb) {
+        if (this._ended) return this;
+        if (typeof chunk === 'function') { cb = chunk; chunk = undefined; }
+        else if (typeof encoding === 'function') { cb = encoding; encoding = undefined; }
+        if (chunk != null) this.write(chunk);
+        this._ended = true;
+        this.finished = true;
+        this.headersSent = true;
+        // Default Content-Length when caller hasn't set Transfer-Encoding.
+        const lower = this._headerMap;
+        if (!lower['content-length'] && !lower['transfer-encoding']) {
+            const len = (typeof TextEncoder !== 'undefined')
+                ? new TextEncoder().encode(this._body).length
+                : this._body.length;
+            this.setHeader('Content-Length', String(len));
+        }
+        if (__perry_ops && __perry_ops.op_perry_http_respond) {
+            try {
+                __perry_ops.op_perry_http_respond(
+                    this._reqId, this._status, JSON.stringify(this._headers), this._body);
+            } catch (_) {}
+        }
+        const finishCbs = this._listeners['finish'] || [];
+        for (const f of finishCbs) { try { f(); } catch (_) {} }
+        const closeCbs = this._listeners['close'] || [];
+        for (const f of closeCbs) { try { f(); } catch (_) {} }
+        if (typeof cb === 'function') { try { cb(); } catch (_) {} }
+        return this;
+    }
+    on(event, listener) {
+        (this._listeners[event] = this._listeners[event] || []).push(listener);
+        return this;
+    }
+    once(event, listener) {
+        const wrapped = (...args) => { this.off(event, wrapped); listener(...args); };
+        return this.on(event, wrapped);
+    }
+    off(event, listener) {
+        const arr = this._listeners[event];
+        if (arr) { const i = arr.indexOf(listener); if (i >= 0) arr.splice(i, 1); }
+        return this;
+    }
+    removeListener(event, listener) { return this.off(event, listener); }
+    emit(event, ...args) {
+        const arr = this._listeners[event];
+        if (arr) arr.slice().forEach(fn => fn.apply(this, args));
+        return !!arr;
+    }
+    flushHeaders() { this.headersSent = true; }
+}
+
 export class Agent {}
+
+class Server {
+    constructor(handler) {
+        this._handler = handler || (() => {});
+        this._serverId = 0;
+        this._listening = false;
+        this._listeners = Object.create(null);
+        this._listenAddress = null;
+    }
+    _emit(event, ...args) {
+        const arr = this._listeners[event];
+        if (arr) arr.slice().forEach(fn => { try { fn.apply(this, args); } catch (_) {} });
+    }
+    on(event, listener) {
+        if (event === 'request' && typeof listener === 'function') {
+            // Mirror Node: 'request' listeners run in addition to the
+            // constructor handler. Stash them in _listeners and dispatch
+            // alongside the main handler in the accept loop.
+        }
+        (this._listeners[event] = this._listeners[event] || []).push(listener);
+        return this;
+    }
+    once(event, listener) {
+        const wrapped = (...args) => { this.off(event, wrapped); listener(...args); };
+        return this.on(event, wrapped);
+    }
+    off(event, listener) {
+        const arr = this._listeners[event];
+        if (arr) { const i = arr.indexOf(listener); if (i >= 0) arr.splice(i, 1); }
+        return this;
+    }
+    removeListener(event, listener) { return this.off(event, listener); }
+    addListener(event, listener) { return this.on(event, listener); }
+    emit(event, ...args) { this._emit(event, ...args); return true; }
+    setTimeout() { return this; }
+    address() {
+        if (!this._listenAddress) return null;
+        return { port: this._listenAddress.port, address: this._listenAddress.host, family: 'IPv4' };
+    }
+    listen(...args) {
+        // express calls listen(port, cb); also support (port, host, cb) and ({port, host}, cb).
+        let port = 3000;
+        let host = '0.0.0.0';
+        let cb = null;
+        for (const a of args) {
+            if (typeof a === 'number') port = a;
+            else if (typeof a === 'string') {
+                const n = parseInt(a, 10);
+                if (!isNaN(n)) port = n;
+            } else if (typeof a === 'function') cb = a;
+            else if (a && typeof a === 'object') {
+                if (typeof a.port === 'number') port = a.port;
+                if (typeof a.host === 'string') host = a.host;
+            }
+        }
+        if (!__perry_ops || !__perry_ops.op_perry_http_listen) {
+            throw new Error('http.createServer: Perry V8-fallback HTTP ops unavailable');
+        }
+        const self = this;
+        // Kick off the bind + accept loop. Once bound, fire 'listening'
+        // + the user callback and begin dispatching to the handler.
+        (async () => {
+            try {
+                const sid = await __perry_ops.op_perry_http_listen(port, host);
+                self._serverId = sid;
+                self._listening = true;
+                self._listenAddress = { port, host };
+                self._emit('listening');
+                if (typeof cb === 'function') { try { cb(); } catch (_) {} }
+                // Accept loop
+                while (self._listening && self._serverId !== 0) {
+                    let r;
+                    try { r = await __perry_ops.op_perry_http_accept(sid); }
+                    catch (_) { break; }
+                    if (!r || r.id === 0) break;
+                    const req = new IncomingMessage(r);
+                    const res = new ServerResponse(r.id);
+                    // Fire 'request' listeners + the constructor handler.
+                    const reqListeners = self._listeners['request'] || [];
+                    for (const fn of reqListeners) {
+                        try { fn.call(self, req, res); } catch (e) { /* swallow */ }
+                    }
+                    try {
+                        const ret = self._handler(req, res);
+                        if (ret && typeof ret.then === 'function') {
+                            ret.catch(() => {});
+                        }
+                    } catch (e) {
+                        if (!res._ended) {
+                            try {
+                                res.statusCode = 500;
+                                res.end('Internal Server Error');
+                            } catch (_) {}
+                        }
+                    }
+                }
+            } catch (err) {
+                self._emit('error', err);
+                if (typeof cb === 'function') { try { cb(err); } catch (_) {} }
+            }
+        })();
+        return this;
+    }
+    close(cb) {
+        if (this._serverId && __perry_ops && __perry_ops.op_perry_http_close) {
+            try { __perry_ops.op_perry_http_close(this._serverId); } catch (_) {}
+        }
+        this._listening = false;
+        this._serverId = 0;
+        this._emit('close');
+        if (typeof cb === 'function') { try { cb(); } catch (_) {} }
+        return this;
+    }
+    closeAllConnections() {}
+    closeIdleConnections() {}
+    get listening() { return this._listening; }
+}
+
 // Issue #912 (#909 follow-up): express/router read `const { METHODS } =
 // require('node:http')` at module init and immediately call `METHODS.map(...)`.
-// Pre-fix METHODS was undefined and threw `TypeError: Cannot read properties
-// of undefined (reading 'map')`. Mirrors `http_methods_array` in
-// perry-runtime/src/object.rs (Node 22 snapshot).
 export const METHODS = [
     'ACL', 'BIND', 'CHECKOUT', 'CONNECT', 'COPY', 'DELETE', 'GET', 'HEAD',
     'LINK', 'LOCK', 'M-SEARCH', 'MERGE', 'MKACTIVITY', 'MKCALENDAR', 'MKCOL',
@@ -1123,9 +1414,6 @@ export const METHODS = [
     'PURGE', 'PUT', 'QUERY', 'REBIND', 'REPORT', 'SEARCH', 'SOURCE',
     'SUBSCRIBE', 'TRACE', 'UNBIND', 'UNLINK', 'UNLOCK', 'UNSUBSCRIBE'
 ];
-// Node also exposes a `STATUS_CODES` map keyed by integer code. Expose a
-// minimal subset so consumers that read `STATUS_CODES[500]` at module init
-// don't crash with the same "undefined" pattern.
 export const STATUS_CODES = {
     100: 'Continue', 101: 'Switching Protocols', 200: 'OK', 201: 'Created',
     202: 'Accepted', 204: 'No Content', 301: 'Moved Permanently',
@@ -1138,9 +1426,10 @@ export const STATUS_CODES = {
 };
 export function request() { throw new Error('http.request not supported in this environment'); }
 export function get() { throw new Error('http.get not supported in this environment'); }
-export function createServer() { throw new Error('http.createServer not supported in this environment'); }
+export function createServer(handler) { return new Server(handler); }
 export function createSecureServer() { throw new Error('http2.createSecureServer not supported in this environment'); }
-export default { IncomingMessage, ServerResponse, Agent, METHODS, STATUS_CODES, request, get, createServer, createSecureServer };
+export { Server };
+export default { IncomingMessage, ServerResponse, Server, Agent, METHODS, STATUS_CODES, request, get, createServer, createSecureServer };
 "#.to_string(),
         "crypto" => r#"
 // Stub implementation for Node.js 'crypto' module

--- a/crates/perry-jsruntime/src/ops.rs
+++ b/crates/perry-jsruntime/src/ops.rs
@@ -6,6 +6,18 @@ use deno_core::{extension, op2};
 use deno_error::JsErrorBox;
 use std::collections::HashMap;
 use std::io::{self, Write};
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{body::Incoming, Request, Response};
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpListener;
+use tokio::sync::{mpsc, oneshot};
 
 #[op2]
 #[string]
@@ -96,6 +108,373 @@ fn op_perry_fetch(
     }
 }
 
+// ============================================================================
+// node:http createServer support for the V8 fallback path (issue follow-up
+// to #678 — express/fastify need a real HTTP server inside the V8 sandbox).
+//
+// Architecture:
+//
+//   JS side (modules.rs `node:http` stub)                  Rust side (ops)
+//   ┌─────────────────────────────────┐                   ┌────────────────┐
+//   │ const s = http.createServer(h)  │                   │                │
+//   │ s.listen(port, cb)              │ op_perry_http_    │ tokio TcpListener
+//   │   ↳ accept loop:                │    listen(port)   │   + hyper http1│
+//   │     async loop {                │ ────────────────► │   spawned on    │
+//   │       const r = await           │                   │   shared tokio  │
+//   │         op_accept(serverId)     │ op_perry_http_    │   runtime       │
+//   │       run user handler(r,res)   │    accept(id)     │                │
+//   │       op_respond(reqId, status, │ ◄──────────────── │ pushes pending  │
+//   │                  headers, body) │                   │ via mpsc        │
+//   │     }                           │                   │                │
+//   └─────────────────────────────────┘                   └────────────────┘
+//
+// Goal: enough HTTP server semantics that express's `.listen(port, cb)`
+// + a single `(req, res)` handler that calls `res.writeHead` + `res.end`
+// can be smoke-tested. Bodies are passed as strings (utf-8 lossy);
+// streaming bodies are NOT supported here. For richer needs, the native
+// HTTP server in perry-ext-http-server is the path.
+// ============================================================================
+
+static NEXT_SERVER_ID: AtomicI32 = AtomicI32::new(1);
+static NEXT_REQUEST_ID: AtomicI32 = AtomicI32::new(1);
+static ACTIVE_SERVERS: AtomicI32 = AtomicI32::new(0);
+
+struct PerryHttpServer {
+    /// Pending incoming requests pushed by the hyper service fn.
+    /// tokio::sync::Mutex so we can hold the lock across an `.await`.
+    request_rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<PendingHttpRequest>>,
+    /// Drops cause the accept loop to exit.
+    shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+    /// Set true once `op_perry_http_close` runs (clears the active counter).
+    closed: Mutex<bool>,
+}
+
+struct PendingHttpRequest {
+    id: i32,
+    method: String,
+    url: String,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+    /// Oneshot the hyper service fn waits on for the response.
+    response_tx: oneshot::Sender<HttpResponseShape>,
+}
+
+#[derive(Default)]
+struct HttpResponseShape {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+}
+
+fn server_registry() -> &'static Mutex<HashMap<i32, Arc<PerryHttpServer>>> {
+    static REG: OnceLock<Mutex<HashMap<i32, Arc<PerryHttpServer>>>> = OnceLock::new();
+    REG.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn pending_response_registry() -> &'static Mutex<HashMap<i32, oneshot::Sender<HttpResponseShape>>> {
+    static REG: OnceLock<Mutex<HashMap<i32, oneshot::Sender<HttpResponseShape>>>> = OnceLock::new();
+    REG.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Returns >0 while any V8-fallback http.Server is bound and not yet
+/// closed. Lets the outer pump keep the program alive while a server
+/// is listening even if no other async work is pending.
+pub(crate) fn perry_http_active_count() -> i32 {
+    ACTIVE_SERVERS.load(Ordering::SeqCst)
+}
+
+async fn handle_request_for_perry_http(
+    server_id: i32,
+    req: Request<Incoming>,
+) -> Result<Response<Full<Bytes>>, hyper::Error> {
+    let method = req.method().to_string();
+    let uri = req.uri();
+    let url = match uri.query() {
+        Some(q) => format!("{}?{}", uri.path(), q),
+        None => uri.path().to_string(),
+    };
+    let mut headers: Vec<(String, String)> = Vec::new();
+    for (name, value) in req.headers().iter() {
+        if let Ok(v) = value.to_str() {
+            headers.push((name.as_str().to_string(), v.to_string()));
+        }
+    }
+    let body_bytes: Vec<u8> = match req.collect().await {
+        Ok(c) => c.to_bytes().to_vec(),
+        Err(_) => Vec::new(),
+    };
+
+    let (response_tx, response_rx) = oneshot::channel::<HttpResponseShape>();
+    let req_id = NEXT_REQUEST_ID.fetch_add(1, Ordering::SeqCst);
+
+    // Lookup server, push pending request.
+    let server = {
+        let reg = server_registry().lock().unwrap();
+        reg.get(&server_id).cloned()
+    };
+    let Some(server) = server else {
+        return Ok(Response::builder()
+            .status(503)
+            .body(Full::new(Bytes::from("Server not registered")))
+            .unwrap());
+    };
+
+    let pending = PendingHttpRequest {
+        id: req_id,
+        method,
+        url,
+        headers,
+        body: body_bytes,
+        response_tx,
+    };
+
+    // Push to the request mpsc; the JS-side accept loop polls.
+    let push_result = {
+        let reg = server_senders().lock().unwrap();
+        if let Some(tx) = reg.get(&server_id) {
+            tx.send(pending).map_err(|_| ())
+        } else {
+            Err(())
+        }
+    };
+    if push_result.is_err() {
+        return Ok(Response::builder()
+            .status(503)
+            .body(Full::new(Bytes::from("Server closed")))
+            .unwrap());
+    }
+    let _ = server; // keep server Arc alive for the body length of this fn
+
+    match response_rx.await {
+        Ok(shape) => {
+            let mut builder = Response::builder().status(shape.status);
+            for (k, v) in &shape.headers {
+                builder = builder.header(k, v);
+            }
+            Ok(builder.body(Full::new(Bytes::from(shape.body))).unwrap())
+        }
+        Err(_) => Ok(Response::builder()
+            .status(500)
+            .body(Full::new(Bytes::from("Handler error")))
+            .unwrap()),
+    }
+}
+
+// Separate map for senders so PerryHttpServer can own the receiver mutably
+// inside the JS-side accept op.
+fn server_senders() -> &'static Mutex<HashMap<i32, mpsc::UnboundedSender<PendingHttpRequest>>> {
+    static REG: OnceLock<Mutex<HashMap<i32, mpsc::UnboundedSender<PendingHttpRequest>>>> =
+        OnceLock::new();
+    REG.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// `op_perry_http_listen(port, host)` — bind a TCP listener, spawn a
+/// hyper http1 acceptor, register a new server id. Returns the server
+/// id on success. Async to allow tokio bind to run on the shared runtime.
+///
+/// Important: deno_core's executor doesn't run inside Perry's shared
+/// `TOKIO_RUNTIME`, so naked `TcpListener::bind` / `tokio::spawn` calls
+/// here would panic with "no reactor running". Every tokio-touching
+/// future is wrapped in the runtime handle via `_enter` or
+/// `tokio_rt.spawn(...)`. See `crate::get_tokio_runtime`.
+#[op2]
+#[smi]
+async fn op_perry_http_listen(port: i32, #[string] host: String) -> Result<i32, JsErrorBox> {
+    let bind_host = if host.is_empty() {
+        "0.0.0.0".to_string()
+    } else {
+        host
+    };
+    let bind_str = format!("{}:{}", bind_host, port);
+    let addr: SocketAddr = bind_str
+        .parse()
+        .map_err(|e| JsErrorBox::generic(format!("invalid bind address {}: {}", bind_str, e)))?;
+
+    let tokio_rt = crate::get_tokio_runtime();
+    // Bind on the shared runtime so the listener is registered with its reactor.
+    let listener = tokio_rt
+        .spawn(async move { TcpListener::bind(addr).await })
+        .await
+        .map_err(|e| JsErrorBox::generic(format!("spawn bind task failed: {}", e)))?
+        .map_err(|e| JsErrorBox::generic(format!("bind {} failed: {}", bind_str, e)))?;
+
+    let (request_tx, request_rx) = mpsc::unbounded_channel::<PendingHttpRequest>();
+    let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
+
+    let server_id = NEXT_SERVER_ID.fetch_add(1, Ordering::SeqCst);
+    let server = Arc::new(PerryHttpServer {
+        request_rx: tokio::sync::Mutex::new(request_rx),
+        shutdown_tx: Mutex::new(Some(shutdown_tx)),
+        closed: Mutex::new(false),
+    });
+    server_registry()
+        .lock()
+        .unwrap()
+        .insert(server_id, server.clone());
+    server_senders()
+        .lock()
+        .unwrap()
+        .insert(server_id, request_tx);
+
+    ACTIVE_SERVERS.fetch_add(1, Ordering::SeqCst);
+
+    tokio_rt.spawn(async move {
+        let tokio_rt = crate::get_tokio_runtime();
+        loop {
+            tokio::select! {
+                accepted = listener.accept() => {
+                    match accepted {
+                        Ok((stream, _peer)) => {
+                            let io = TokioIo::new(stream);
+                            tokio_rt.spawn(async move {
+                                let service = service_fn(move |req: Request<Incoming>| async move {
+                                    handle_request_for_perry_http(server_id, req).await
+                                });
+                                if let Err(e) = http1::Builder::new()
+                                    .serve_connection(io, service)
+                                    .await
+                                {
+                                    let _ = e; // client disconnects etc — silenced
+                                }
+                            });
+                        }
+                        Err(e) => {
+                            eprintln!("[perry-http] accept error: {}", e);
+                            break;
+                        }
+                    }
+                }
+                _ = &mut shutdown_rx => {
+                    break;
+                }
+            }
+        }
+        // Accept loop exit — drop senders so accept op resolves null.
+        server_senders().lock().unwrap().remove(&server_id);
+    });
+
+    Ok(server_id)
+}
+
+/// `op_perry_http_accept(serverId)` — async, resolves with the next
+/// pending request, or with `{ id: 0 }` when the server is closed.
+#[op2]
+#[serde]
+async fn op_perry_http_accept(#[smi] server_id: i32) -> serde_json::Value {
+    let server = {
+        let reg = server_registry().lock().unwrap();
+        reg.get(&server_id).cloned()
+    };
+    let Some(server) = server else {
+        return serde_json::json!({ "id": 0 });
+    };
+
+    let pending_opt: Option<PendingHttpRequest> = {
+        // tokio::sync::Mutex lets us hold the lock across `.await`.
+        let mut rx_guard = server.request_rx.lock().await;
+        rx_guard.recv().await
+    };
+
+    let Some(pending) = pending_opt else {
+        // Server shut down.
+        return serde_json::json!({ "id": 0 });
+    };
+
+    // Stash the response oneshot keyed by request id so op_respond can
+    // resolve it.
+    pending_response_registry()
+        .lock()
+        .unwrap()
+        .insert(pending.id, pending.response_tx);
+
+    let body_str = String::from_utf8_lossy(&pending.body).to_string();
+    let headers_obj = serde_json::Value::Object(
+        pending
+            .headers
+            .iter()
+            .map(|(k, v)| (k.to_lowercase(), serde_json::Value::String(v.clone())))
+            .collect(),
+    );
+    let raw_headers = serde_json::Value::Array(
+        pending
+            .headers
+            .iter()
+            .flat_map(|(k, v)| {
+                vec![
+                    serde_json::Value::String(k.clone()),
+                    serde_json::Value::String(v.clone()),
+                ]
+            })
+            .collect(),
+    );
+
+    serde_json::json!({
+        "id": pending.id,
+        "method": pending.method,
+        "url": pending.url,
+        "headers": headers_obj,
+        "rawHeaders": raw_headers,
+        "body": body_str,
+    })
+}
+
+/// `op_perry_http_respond(reqId, status, headersJson, body)` — sync.
+/// `headersJson` is a JSON-encoded array of [name, value] pairs (preserves
+/// duplicates / order — needed for Set-Cookie etc).
+#[op2(fast)]
+fn op_perry_http_respond(
+    #[smi] req_id: i32,
+    #[smi] status: i32,
+    #[string] headers_json: &str,
+    #[string] body: &str,
+) {
+    let headers: Vec<(String, String)> =
+        match serde_json::from_str::<Vec<(String, String)>>(headers_json) {
+            Ok(v) => v,
+            Err(_) => Vec::new(),
+        };
+    let tx = pending_response_registry().lock().unwrap().remove(&req_id);
+    if let Some(tx) = tx {
+        let shape = HttpResponseShape {
+            status: status as u16,
+            headers,
+            body: body.as_bytes().to_vec(),
+        };
+        let _ = tx.send(shape);
+    }
+}
+
+/// `op_perry_http_close(serverId)` — drop the shutdown channel; the
+/// accept loop notices and exits. Future accept ops resolve `{id:0}`.
+#[op2(fast)]
+fn op_perry_http_close(#[smi] server_id: i32) {
+    let server = {
+        let reg = server_registry().lock().unwrap();
+        reg.get(&server_id).cloned()
+    };
+    if let Some(server) = server {
+        let already_closed = {
+            let mut closed = server.closed.lock().unwrap();
+            let was = *closed;
+            *closed = true;
+            was
+        };
+        // Fire shutdown.
+        if let Some(tx) = server.shutdown_tx.lock().unwrap().take() {
+            let _ = tx.send(());
+        }
+        // Drop the sender so accept resolves null after draining.
+        server_senders().lock().unwrap().remove(&server_id);
+        if !already_closed {
+            ACTIVE_SERVERS.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+    // Remove from registry — pending response oneshots for this server
+    // will simply never fire; their hyper service fns receive Err and
+    // return 500. Acceptable for shutdown.
+    server_registry().lock().unwrap().remove(&server_id);
+}
+
 extension!(
     perry_ops,
     ops = [
@@ -103,5 +482,9 @@ extension!(
         op_perry_call_native,
         op_perry_print,
         op_perry_fetch,
+        op_perry_http_listen,
+        op_perry_http_accept,
+        op_perry_http_respond,
+        op_perry_http_close,
     ],
 );

--- a/test-files/test_http_createserver_v8.ts
+++ b/test-files/test_http_createserver_v8.ts
@@ -1,0 +1,16 @@
+import http from 'node:http';
+import { setTimeout as wait } from 'node:timers/promises';
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('hello\n');
+});
+
+const port = 18999;
+await new Promise<void>(resolve => server.listen(port, () => resolve()));
+
+const result = await fetch(`http://127.0.0.1:${port}/`);
+const body = await result.text();
+console.log(result.status, body.trim());  // 200 hello
+
+server.close();


### PR DESCRIPTION
## Summary

- Bridges `node:http`'s `createServer` from the V8/JS-runtime fallback path
  to a real hyper-based HTTP/1.1 server. Pre-fix the stub threw
  `http.createServer not supported in this environment`, which crashed
  express (and would crash fastify/nestjs the same way) at module init.
- Adds four deno_core ops — `op_perry_http_listen` (async, binds a
  `tokio::net::TcpListener` + spawns a hyper accept loop on Perry's
  shared multi-thread tokio runtime), `op_perry_http_accept` (async,
  pops the next pending request), `op_perry_http_respond` (sync,
  resolves the response oneshot), `op_perry_http_close` (sync, drops
  the accept-loop shutdown channel).
- Replaces the `node:http` JS stub in `crates/perry-jsruntime/src/modules.rs`
  with a real `Server` class + minimal `IncomingMessage`/`ServerResponse`
  surface (`req.method`/`url`/`headers`, `res.writeHead`/`setHeader`/
  `write`/`end`/`statusCode`).
- Fixes a latent "no reactor running" panic by entering Perry's shared
  `TOKIO_RUNTIME` inside `ensure_runtime_initialized` and `with_runtime`
  (and `jsruntime_process_pending`). Without this, `JsRuntime::new`'s
  captured tokio handle was empty and any subsequent async op that
  touched `tokio::net` / `tokio::spawn` panicked.
- Keeps the program alive while any V8-fallback server is listening via
  a new active-server counter wired into `jsruntime_has_active_handles`.

Goal: enough HTTP server semantics that the prompt-cited express smoke
(`app.listen(port, cb)` + a single handler that calls `res.end`) works
end-to-end through the V8 path. Streaming bodies, HTTPS / HTTP/2,
WebSocket upgrades, and `req.socket`/`req.connection` are explicitly
out of scope — applications that need them should keep using the
native compile path through `perry-ext-http-server`. See the CHANGELOG
entry for the full deferred list.

## Test plan

- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry-jsruntime -p perry`
- [x] `test-files/test_http_createserver_v8.ts` (native `node:http` path) prints `200 hello` — unchanged.
- [x] Express prompt smoke: `import express from 'express'; app.get(...); app.listen(19000, cb); server.close()` prints `listening on 19000` and exits 0 (pre-fix: thrown error at module init).
- [x] Middleware-only express variant served a real HTTP response: external `fetch` returned `status=200 body=hi-from-middleware` and the handler logged `middleware called GET /`.
- [x] Byte-for-byte match with `node --experimental-strip-types test-files/test_http_createserver_v8.ts` (`200 hello`).