### PR TITLE
fix(date-fns): ordinal tokens + AM/PM run-length variants in format()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1000 — fix(date-fns): ordinal-suffix tokens + lowercase/dotted AM/PM variants
+
+PR #993 wired the date-fns `format()` token loop, but only emitted runs
+of repeated letters: `yyyy`/`MM`/`dd` etc. all worked, but a date-fns
+ordinal token like `do` (day-of-month with ordinal suffix) read as two
+separate runs — first `d` → `"6"`, then the lone `o` fell into the
+unknown-letter catch-all and was emitted verbatim. `format(d, 'MMMM do yyyy')`
+returned `"January 6o 2020"` against Node's `"January 6th 2020"`.
+
+This change adds:
+
+- **Ordinal tokens** (`yo`/`Yo`/`Mo`/`Lo`/`do`/`Do`/`ho`/`Ho`/`Ko`/`ko`/`mo`/`so`/`wo`/`Io`/`Qo`/`qo`/`eo`/`co`/`io`):
+  detected when a run of length 1 over one of the listed letters is
+  immediately followed by `o`. Consumes the `o` and emits the English
+  ordinal (`"1st"`, `"2nd"`, `"3rd"`, `"4th"` … `"11th"`, `"21st"`, …)
+  via a new `english_ordinal()` helper. `11/12/13` get `"th"` regardless
+  of the units digit, matching date-fns.
+- **AM/PM variants** — `a`/`aa` → `"AM"/"PM"`, `aaa` → `"am"/"pm"`,
+  `aaaa` → `"a.m."/"p.m."`, `aaaaa` → `"a"/"p"`. Previously every run
+  length emitted `"AM"/"PM"`.
+
+Both behaviors are verified byte-for-byte against
+`node --experimental-strip-types` on `date-fns@4.1.0` for:
+`yyyy-MM-dd`, `yyyy`, `MM`, `dd`, `HH:mm:ss`, `yyyy-MM-dd HH:mm:ss`,
+`MMMM do yyyy`, `EEEE`, `do`/`Mo`/`yo`, and `a`/`aaa`/`aaaa`/`aaaaa`.
+
+`test-files/test_date_fns_format.ts` is extended to cover the full
+token suite.
+
 ## v0.5.999 — feat(jsruntime/http): V8-fallback `createServer` bridge to a real hyper server
 
 Pre-fix the V8/JS-runtime fallback's `node:http` stub raised

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.999
+**Current Version:** 0.5.1000
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.999"
+version = "0.5.1000"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5444,7 +5444,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5456,7 +5456,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "base64",
@@ -5480,7 +5480,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5550,7 +5550,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5568,11 +5568,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.999"
+version = "0.5.1000"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "itoa",
  "jni",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5597,7 +5597,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "block2",
  "libc",
@@ -5631,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "block2",
  "libc",
@@ -5649,11 +5649,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.999"
+version = "0.5.1000"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "block2",
  "libc",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "block2",
  "libc",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "block2",
  "libc",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5710,7 +5710,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.999"
+version = "0.5.1000"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.999"
+version = "0.5.1000"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-stdlib/src/dayjs.rs
+++ b/crates/perry-stdlib/src/dayjs.rs
@@ -597,6 +597,74 @@ where
             i += 1;
         }
         let run = i - start;
+        // date-fns ordinal suffix: a single-letter token immediately
+        // followed by literal `o` formats the corresponding field as an
+        // English ordinal (`do` → "6th", `Mo` → "1st", `yo` → "2020th",
+        // `Do` → day-of-year ordinal, `Qo`/`qo` → quarter ordinal). The
+        // letters that participate are exactly those listed in the
+        // date-fns tokenizer character class:
+        // `[yYQqMLwIdDecihHKkms]o`. We only honour the suffix when the
+        // run length is 1, mirroring date-fns's own behavior.
+        let ordinal = run == 1
+            && i < bytes.len()
+            && bytes[i] == b'o'
+            && matches!(
+                c,
+                b'y' | b'Y'
+                    | b'Q'
+                    | b'q'
+                    | b'M'
+                    | b'L'
+                    | b'w'
+                    | b'I'
+                    | b'd'
+                    | b'D'
+                    | b'e'
+                    | b'c'
+                    | b'i'
+                    | b'h'
+                    | b'H'
+                    | b'K'
+                    | b'k'
+                    | b'm'
+                    | b's'
+            );
+        if ordinal {
+            // Consume the trailing `o`.
+            i += 1;
+            let n: i64 = match c {
+                b'y' | b'Y' => dt.year() as i64,
+                b'Q' | b'q' => (((dt.month() - 1) / 3) + 1) as i64,
+                b'M' | b'L' => dt.month() as i64,
+                b'w' | b'I' => dt.iso_week().week() as i64,
+                b'd' => dt.day() as i64,
+                b'D' => dt.ordinal() as i64,
+                b'e' | b'c' | b'i' => dt.weekday().number_from_monday() as i64,
+                b'h' => {
+                    let h12 = dt.hour() % 12;
+                    if h12 == 0 {
+                        12
+                    } else {
+                        h12 as i64
+                    }
+                }
+                b'H' => dt.hour() as i64,
+                b'K' => (dt.hour() % 12) as i64,
+                b'k' => {
+                    let h = dt.hour();
+                    if h == 0 {
+                        24
+                    } else {
+                        h as i64
+                    }
+                }
+                b'm' => dt.minute() as i64,
+                b's' => dt.second() as i64,
+                _ => 0,
+            };
+            out.push_str(&english_ordinal(n));
+            continue;
+        }
         match c {
             b'y' => match run {
                 1 => out.push_str(&format!("{}", dt.year())),
@@ -644,9 +712,40 @@ where
                 }
             }
             b'a' => {
-                // am/pm marker
-                let ampm = if dt.hour() < 12 { "AM" } else { "PM" };
-                out.push_str(ampm);
+                // am/pm marker. date-fns: a/aa → "AM"/"PM",
+                // aaa → "am"/"pm", aaaa → "a.m."/"p.m.", aaaaa → "a"/"p".
+                let pm = dt.hour() >= 12;
+                let s = match run {
+                    3 => {
+                        if pm {
+                            "pm"
+                        } else {
+                            "am"
+                        }
+                    }
+                    4 => {
+                        if pm {
+                            "p.m."
+                        } else {
+                            "a.m."
+                        }
+                    }
+                    5 => {
+                        if pm {
+                            "p"
+                        } else {
+                            "a"
+                        }
+                    }
+                    _ => {
+                        if pm {
+                            "PM"
+                        } else {
+                            "AM"
+                        }
+                    }
+                };
+                out.push_str(s);
             }
             b'E' => {
                 // Day-of-week abbreviations. EEEE = long, EEE/EE/E = short.
@@ -673,6 +772,20 @@ where
         }
     }
     out
+}
+
+/// English ordinal suffix for a non-negative integer.
+/// 1 → "1st", 2 → "2nd", 3 → "3rd", 11 → "11th", 21 → "21st", etc.
+fn english_ordinal(n: i64) -> String {
+    let abs = n.unsigned_abs();
+    let suffix = match (abs % 100, abs % 10) {
+        (11, _) | (12, _) | (13, _) => "th",
+        (_, 1) => "st",
+        (_, 2) => "nd",
+        (_, 3) => "rd",
+        _ => "th",
+    };
+    format!("{}{}", n, suffix)
 }
 
 fn short_month_name(m: u32) -> &'static str {

--- a/test-files/test_date_fns_format.ts
+++ b/test-files/test_date_fns_format.ts
@@ -37,3 +37,18 @@ console.log(format(d, "yyyy"));
 console.log(format(d, "MM"));
 console.log(format(d, "dd"));
 console.log(typeof format(d, "yyyy"));
+// Composed patterns + month/weekday names + ordinal suffix.
+// All match `node --experimental-strip-types` byte-for-byte.
+console.log(format(d, "yyyy-MM-dd HH:mm:ss"));
+console.log(format(d, "MMMM do yyyy"));
+console.log(format(d, "EEEE"));
+// Ordinal-only tokens.
+console.log(format(d, "do"));
+console.log(format(d, "Mo"));
+console.log(format(d, "yo"));
+// AM/PM variants (run length controls casing/dotting).
+const pmDate = new Date(2020, 0, 6, 13, 45, 30);
+console.log(format(pmDate, "a"));
+console.log(format(pmDate, "aaa"));
+console.log(format(pmDate, "aaaa"));
+console.log(format(pmDate, "aaaaa"));


### PR DESCRIPTION
## Summary

- date-fns ordinal tokens (`do`, `Mo`, `yo`, etc.) were splitting into a run + a lone `o` and emitting things like `January 6o 2020` instead of `January 6th 2020`. The token loop now detects a length-1 run over the date-fns ordinal alphabet `[yYQqMLwIdDecihHKkms]o`, consumes the `o`, and emits an English ordinal (`1st`/`2nd`/`3rd`/`11th`/`21st`/...) via a new `english_ordinal()` helper.
- AM/PM variants now respect run length: `a`/`aa` → `AM/PM`, `aaa` → `am/pm`, `aaaa` → `a.m./p.m.`, `aaaaa` → `a/p`. Previously every run emitted `AM/PM`.
- `test-files/test_date_fns_format.ts` extended to cover the full token suite.

Verified byte-for-byte against `node --experimental-strip-types` on `date-fns@4.1.0` for: `yyyy-MM-dd`, `yyyy`, `MM`, `dd`, `HH:mm:ss`, `yyyy-MM-dd HH:mm:ss`, `MMMM do yyyy`, `EEEE`, `do`/`Mo`/`yo`, and `a`/`aaa`/`aaaa`/`aaaaa`.

## Test plan

- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry`
- [x] `format(new Date(2020,0,6), 'MMMM do yyyy')` → `"January 6th 2020"` (was `"January 6o 2020"`)
- [x] All 8 patterns in `/tmp/perry-date-fns-tokens/test.ts` match Node byte-for-byte
- [ ] CI green