### PR TITLE
fix(jsruntime/http): V8 listen keepalive + express handler smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,132 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1001 — fix(jsruntime/http): V8 listen keepalive + express handler smoke
+
+Post-#994 the V8-fallback `http.createServer().listen(port, cb)` smoke
+was hanging end-to-end in three different ways. This release ships
+fixes for the first two; the third (express + native `await fetch`
+self-call inside the listen callback) is documented below as a known
+limitation gated on real native async lowering.
+
+**1. `app.listen()` returned before bind completed → "listening" never printed**
+
+`op_perry_http_listen` is an async deno op: its body spawns
+`TcpListener::bind(addr)` on the shared multi-thread runtime and awaits
+the `JoinHandle`. The codegen-emitted outer event loop calls
+`js_run_jsruntime_pump` once before the header check, which polls
+`state.runtime.poll_event_loop(...)` exactly once. That single poll
+suspends on the bind future and returns `Poll::Pending` — but
+`jsruntime_has_active_handles` only inspected resolved-state counters
+(`ACTIVE_SERVERS`, foreign-promise adapters, pending ticks, module
+evaluations). With all four at zero, the header check returned 0 and
+the program exited before bind ever resolved.
+
+Fix: `poll_v8_event_loop_once` now records the most recent
+`Poll::Pending` / `Poll::Ready` result in a new
+`JsRuntimeState::last_poll_was_pending` flag, and the
+active-handles check returns 1 whenever the last poll left
+deno_core with refed ops in flight. `crates/perry-jsruntime/src/lib.rs`
+(state field + ctor), `crates/perry-jsruntime/src/interop.rs` (set
+the flag in `poll_v8_event_loop_once`, read it from
+`jsruntime_has_active_handles`). New regression test:
+`test-files/test_issue_997_v8_listen_keepalive.ts` (synchronous
+listen-cb that closes immediately — pre-fix hangs forever under
+`timeout`, post-fix prints "listening" and exits 0).
+
+**2. Express request handlers threw `ReferenceError: setImmediate is not defined` and `TypeError: Buffer.isBuffer is not a function`**
+
+External curl to a Perry-compiled express server (`app.listen(port,
+() => {...})`) was reaching the JS-side accept loop, dispatching to
+express's router, then throwing two missing-polyfill errors. Both
+turn into our V8 shim's catch-all 500 response, so callers saw
+`Internal Server Error` instead of the route's body.
+
+Fixes in `crates/perry-jsruntime/src/node_polyfills.js`:
+
+- Added `globalThis.setImmediate` / `globalThis.clearImmediate`
+  polyfills (microtask-based, mirroring the existing setTimeout
+  polyfill). Express's router uses `setImmediate` to break recursion
+  in middleware chains.
+- Added `Buffer.allocUnsafeSlow` static method. `safe-buffer`
+  (used by express, body-parser, etc.) detects whether our
+  global Buffer is "complete enough" by checking for all four of
+  `from` / `alloc` / `allocUnsafe` / `allocUnsafeSlow`. With
+  `allocUnsafeSlow` missing, safe-buffer falls through to a
+  `copyProps(Buffer, SafeBuffer)` fallback that uses `for...in` —
+  which silently skips ES class static methods because those are
+  non-enumerable in V8. The resulting SafeBuffer was missing
+  `isBuffer` / `byteLength` / etc., and every `Buffer.isBuffer(chunk)`
+  in `express/lib/response.js` threw TypeError. Providing
+  `allocUnsafeSlow` keeps safe-buffer on the happy path (just
+  re-exports our Buffer).
+
+Validated: `curl http://127.0.0.1:port/ping` against a
+Perry-compiled `app.get('/ping', (_req, res) => res.send('pong'))`
+now returns `pong` with HTTP 200.
+
+**3. Server.listen cb ordering + `op_perry_fetch` made async**
+
+Smaller refactors in the same code path:
+
+- `Server.listen` in the `node:http` shim now schedules the
+  user-supplied listening callback as `Promise.resolve().then(() =>
+  cb())` so the JS-side accept loop registers its first
+  `op_perry_http_accept(sid)` op BEFORE the trampoline-driven
+  callback runs. Pre-fix the synchronous `cb()` call could block
+  the V8 thread (when cb's native body contained an `await`) before
+  any accept op was queued, leaving hyper's `service_fn` stuck on
+  an mpsc with no consumer. Strictly logical-ordering improvement
+  for the express+self-fetch case (#4 below) — covers the no-await
+  callback shape today.
+- `op_perry_fetch` is now `async` (PR #994 deliberately chose sync
+  ureq to dodge a nested-block-on issue in the legacy blocking-await
+  path). The blocking ureq is wrapped in
+  `tokio::task::spawn_blocking` so the V8 thread can yield via
+  `await` while ureq runs on a tokio blocking-pool worker. The
+  polyfill's `const result = core.ops.op_perry_fetch(...)` is now
+  `const result = await core.ops.op_perry_fetch(...)` to preserve
+  the same callsite shape.
+
+**4. Self-fetch from inside an `async` listen callback (deferred)**
+
+The original repro was `app.listen(port, async () => { const r =
+await fetch('http://127.0.0.1:port/...') })`. Even with everything
+above, this still deadlocks. Root cause is structural: Perry's
+TS→native compilation lowers user `async () => …` arrows into a
+busy-wait loop (`crates/perry-codegen/src/expr.rs:10687`) rather
+than a true Future-style state machine, so a native callback
+invoked from the V8 trampoline (`native_callback_trampoline` in
+`crates/perry-jsruntime/src/interop.rs`) blocks the V8 thread for
+the entire duration of the callback body. Inside the busy-wait the
+re-entrant `js_run_jsruntime_pump` call DOES poll V8 — but
+`op_perry_http_accept`'s `rx.recv().await` future, scheduled on
+deno_core's executor, never resolves while the outer V8 stack
+frame holds an active scope from the trampoline. Net effect: the
+native fetch establishes a TCP connection to the hyper accept
+loop, hyper pushes the request through the mpsc, but the accept
+op never fires its V8 continuation — so the handler chain never
+runs and the request hangs.
+
+Workarounds that DO work today:
+
+- Use the `new Promise<void>(resolve => server.listen(port, () =>
+  resolve()))` pattern instead of an async-arrow callback, then
+  do the fetch in top-level code outside the callback. This is
+  what `test-files/test_http_createserver_v8.ts` exercises; it
+  still passes against this build (`200 hello` + exit 0).
+- External clients (curl, another process, etc.) hit the server
+  cleanly — the deadlock only manifests on same-process self-fetch
+  inside the listen-cb itself.
+- Fastify still works end-to-end (it routes through perry-stdlib's
+  bundled fastify path, not the V8-fallback hyper bridge, so the
+  trampoline doesn't sit on the V8 stack while the handler is
+  awaited).
+
+Deferring the self-fetch case to a future issue covering Perry's
+async lowering. The trampoline ↔ busy-wait interaction is too
+broad to safely patch in the V8-fallback http shim alone.
+
 ## v0.5.1000 — fix(date-fns): ordinal-suffix tokens + lowercase/dotted AM/PM variants
 
 PR #993 wired the date-fns `format()` token loop, but only emitted runs
@@ -30,7 +156,6 @@ Both behaviors are verified byte-for-byte against
 
 `test-files/test_date_fns_format.ts` is extended to cover the full
 token suite.
-
 ## v0.5.999 — feat(jsruntime/http): V8-fallback `createServer` bridge to a real hyper server
 
 Pre-fix the V8/JS-runtime fallback's `node:http` stub raised

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1000
+**Current Version:** 0.5.1001
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1000"
+version = "0.5.1001"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5444,7 +5444,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5456,7 +5456,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "base64",
@@ -5480,7 +5480,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5550,7 +5550,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5568,11 +5568,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1000"
+version = "0.5.1001"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "itoa",
  "jni",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5597,7 +5597,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "block2",
  "libc",
@@ -5631,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "block2",
  "libc",
@@ -5649,11 +5649,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1000"
+version = "0.5.1001"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "block2",
  "libc",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "block2",
  "libc",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "block2",
  "libc",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5710,7 +5710,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1000"
+version = "0.5.1001"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1000"
+version = "0.5.1001"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-jsruntime/src/interop.rs
+++ b/crates/perry-jsruntime/src/interop.rs
@@ -361,12 +361,25 @@ fn poll_v8_event_loop_once(state: &mut JsRuntimeState) -> i32 {
     let waker = notifying_waker();
     let mut cx = TaskContext::from_waker(&waker);
     match state.runtime.poll_event_loop(&mut cx, Default::default()) {
-        Poll::Ready(Ok(())) => 0,
+        Poll::Ready(Ok(())) => {
+            // V8 event loop drained — clear the pending flag so the outer
+            // loop can exit (assuming no other source — timers, stdlib,
+            // http servers — still keeps it alive).
+            state.last_poll_was_pending = false;
+            0
+        }
         Poll::Ready(Err(e)) => {
+            state.last_poll_was_pending = false;
             eprintln!("[jsruntime_pump] event loop error: {}", e);
             1
         }
-        Poll::Pending => 0,
+        Poll::Pending => {
+            // Refed async op / dyn import / microtask / promise event
+            // outstanding. `jsruntime_has_active_handles` reads this flag
+            // to keep the outer event loop alive until the op resolves.
+            state.last_poll_was_pending = true;
+            0
+        }
     }
 }
 
@@ -464,12 +477,31 @@ extern "C" fn jsruntime_has_active_handles() -> i32 {
             .as_ref()
             .is_some_and(|state| !state.pending_module_evaluations.is_empty())
     });
+    // `last_poll_was_pending` is set by `poll_v8_event_loop_once` whenever
+    // deno_core returns `Poll::Pending` — i.e. a refed async op / dyn
+    // import / microtask / promise event is still in flight. Without this
+    // gate, a top-level `await op_perry_http_listen(port)` (or any other
+    // async op invoked from module init) returns to the codegen-emitted
+    // outer event loop while its body is still suspended on a tokio
+    // worker; the header check then sees no other active source and
+    // exits before the op resolves and the listening callback can fire.
+    // Pairs with the express smoke at #997.
+    let has_pending_v8 = JS_RUNTIME.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .is_some_and(|state| state.last_poll_was_pending)
+    });
     // Keep the program alive while any V8-fallback `http.createServer`
     // is still listening — without this the outer event loop exits
     // immediately after `server.listen(...)` resolves and the accept
     // loop's tokio task is dropped before serving any requests.
     let has_http_servers = crate::ops::perry_http_active_count() > 0;
-    if has_foreign_adapters || has_pending_ticks || has_module_evaluations || has_http_servers {
+    if has_foreign_adapters
+        || has_pending_ticks
+        || has_module_evaluations
+        || has_http_servers
+        || has_pending_v8
+    {
         1
     } else {
         0

--- a/crates/perry-jsruntime/src/lib.rs
+++ b/crates/perry-jsruntime/src/lib.rs
@@ -83,6 +83,15 @@ pub struct JsRuntimeState {
     pub pending_module_evaluations: HashMap<deno_core::ModuleId, PendingModuleEvaluation>,
     /// Whether the runtime has been initialized
     pub initialized: bool,
+    /// True if the last call to `poll_event_loop` returned `Poll::Pending`,
+    /// meaning deno_core still has refed ops in flight (async ops,
+    /// dyn imports, microtask backlog, etc.). Used by
+    /// `jsruntime_has_active_handles` to keep the codegen-emitted outer
+    /// event loop ticking while any V8-side async work is outstanding —
+    /// without it, a top-level `await op_perry_http_listen(...)` returns
+    /// to the caller while its bind future is still on the multi-thread
+    /// runtime, and the outer loop exits before the bind completes.
+    pub last_poll_was_pending: bool,
 }
 
 pub struct PendingModuleEvaluation {
@@ -122,6 +131,7 @@ impl JsRuntimeState {
             loaded_modules: HashMap::new(),
             pending_module_evaluations: HashMap::new(),
             initialized: true,
+            last_poll_was_pending: false,
         }
     }
 }

--- a/crates/perry-jsruntime/src/modules.rs
+++ b/crates/perry-jsruntime/src/modules.rs
@@ -1348,6 +1348,26 @@ class Server {
         const self = this;
         // Kick off the bind + accept loop. Once bound, fire 'listening'
         // + the user callback and begin dispatching to the handler.
+        //
+        // Critical ordering for the express + native-fetch self-call
+        // pattern (#997): the listening callback is invoked AFTER the
+        // accept loop has registered its first `op_perry_http_accept`
+        // op. This matters because user callbacks compiled from Perry
+        // TypeScript come in as native trampolines — the V8 thread is
+        // blocked synchronously while the callback's native body runs,
+        // and any `await` inside the body busy-waits on the V8 thread
+        // (pumping `js_run_jsruntime_pump` inside the wait so microtasks
+        // still progress). If we called `cb()` BEFORE the accept loop
+        // queued its op, an `await fetch('http://127.0.0.1:port/...')`
+        // inside cb would block waiting for the server to respond, but
+        // the server can't dispatch because the accept loop hasn't
+        // started — three-way deadlock against the synchronous trampoline.
+        //
+        // Scheduling cb on Promise.resolve().then() defers it past the
+        // first `await op_perry_http_accept(...)`, so by the time the
+        // trampoline starts blocking the V8 thread there's already a
+        // pending accept op the inner pump can drive to resolution
+        // when hyper hands a request through the mpsc.
         (async () => {
             try {
                 const sid = await __perry_ops.op_perry_http_listen(port, host);
@@ -1355,7 +1375,11 @@ class Server {
                 self._listening = true;
                 self._listenAddress = { port, host };
                 self._emit('listening');
-                if (typeof cb === 'function') { try { cb(); } catch (_) {} }
+                if (typeof cb === 'function') {
+                    // Defer to a microtask so the accept loop below
+                    // registers `op_perry_http_accept` first.
+                    Promise.resolve().then(() => { try { cb(); } catch (_) {} });
+                }
                 // Accept loop
                 while (self._listening && self._serverId !== 0) {
                     let r;

--- a/crates/perry-jsruntime/src/node_polyfills.js
+++ b/crates/perry-jsruntime/src/node_polyfills.js
@@ -25,6 +25,21 @@
             return new Buffer(size);
         }
 
+        // safe-buffer (used by express, body-parser, etc.) detects whether
+        // our Buffer is "complete enough" by checking for all four of
+        // .from / .alloc / .allocUnsafe / .allocUnsafeSlow. If any are
+        // missing it copies static props onto a SafeBuffer shim using a
+        // for-in loop, which silently skips ES class static methods
+        // because those are non-enumerable. The resulting SafeBuffer is
+        // then missing isBuffer / byteLength / etc. and every
+        // `Buffer.isBuffer(chunk)` in express/response.js throws
+        // TypeError. Providing allocUnsafeSlow keeps safe-buffer on the
+        // happy path (just re-exports our Buffer), avoiding the lossy
+        // for-in copy entirely.
+        static allocUnsafeSlow(size) {
+            return new Buffer(size);
+        }
+
         static from(data, encodingOrOffset, length) {
             if (typeof data === 'string') {
                 const encoding = encodingOrOffset || 'utf8';
@@ -261,6 +276,19 @@
         globalThis.setInterval = function(fn, delay) { return __timerId++; };
         globalThis.clearInterval = function(id) {};
     }
+    // setImmediate / clearImmediate - Node-specific. express's router uses
+    // setImmediate to break recursion in middleware chains. Without this
+    // polyfill, every request handler throws ReferenceError and our http
+    // shim returns 500. Microtask-based fallback matches the behavior of
+    // setTimeout above; same caveat applies (no real event loop ordering).
+    if (typeof globalThis.setImmediate === 'undefined') {
+        globalThis.setImmediate = function(fn, ...args) {
+            const id = __timerId++;
+            Promise.resolve().then(() => { try { fn(...args); } catch (_) {} });
+            return id;
+        };
+        globalThis.clearImmediate = function(id) {};
+    }
 
     // fetch() polyfill using op_perry_fetch Deno op
     if (typeof globalThis.fetch === 'undefined') {
@@ -286,7 +314,13 @@
                     Object.assign(headers, init.headers);
                 }
             }
-            const result = core.ops.op_perry_fetch(url, method, body, headers);
+            // op_perry_fetch is async (returns a Promise). Awaiting here
+            // yields back to the V8 event loop, which is required for
+            // self-fetch patterns like app.listen(port, async () => {
+            // await fetch("http://127.0.0.1:port/...") }) - without
+            // the yield the JS-side accept loop never starts polling
+            // op_perry_http_accept and the request deadlocks.
+            const result = await core.ops.op_perry_fetch(url, method, body, headers);
             return {
                 ok: result.status >= 200 && result.status < 300,
                 status: result.status,

--- a/crates/perry-jsruntime/src/ops.rs
+++ b/crates/perry-jsruntime/src/ops.rs
@@ -44,16 +44,59 @@ fn op_perry_print(#[string] message: String) {
     let _ = stdout.flush();
 }
 
-/// Synchronous HTTP fetch op for V8's fetch() polyfill.
-/// Uses ureq (blocking) to avoid Tokio runtime conflicts when called
-/// from within js_await_js_promise's block_on context.
+/// Async HTTP fetch op for V8's fetch() polyfill.
+///
+/// History: this op was initially synchronous (#994) because the legacy
+/// blocking-await path (`PERRY_JSRUNTIME_ENABLE_LEGACY_BLOCKING_AWAIT`)
+/// already runs inside `tokio_rt.block_on(...)` and a naive `tokio::spawn`
+/// inside that block was hitting a current-thread runtime nested-block-on
+/// deadlock. The downside was that any `await fetch(...)` from a JS
+/// program ran ureq on the V8 thread synchronously — fine for "fetch
+/// before listening" workloads, but it deadlocks the express smoke
+/// (`app.listen(port, async cb => { await fetch(...) })`) because the
+/// V8 thread is the same one that drives the JS-side accept loop:
+///
+///   1. listen-cb fires. cb body runs to first `await` → ureq blocks
+///      the V8 thread waiting on `127.0.0.1:port`.
+///   2. The hyper accept loop on the shared tokio runtime accepts the
+///      connection and pushes a `PendingHttpRequest` into the mpsc.
+///   3. Nobody is calling `op_perry_http_accept`: the JS-side accept
+///      loop only starts after cb returns, but cb is awaiting fetch,
+///      which is blocked waiting for the server, which is waiting for
+///      the accept loop. Three-way deadlock.
+///
+/// Fix: make the op async and run the blocking ureq call on
+/// `tokio::task::spawn_blocking`. The await in JS then suspends the
+/// awaiting frame, V8 returns to the event loop, the JS-side accept
+/// loop starts polling `op_perry_http_accept`, and the spawn_blocking
+/// worker eventually returns the response to V8.
+///
+/// `spawn_blocking` uses tokio's blocking thread pool, which is distinct
+/// from the main worker pool — so ureq's blocking I/O doesn't tie up a
+/// runtime worker. We use the shared `TOKIO_RUNTIME` so behavior matches
+/// the rest of the V8 ops.
 #[op2]
 #[serde]
-fn op_perry_fetch(
+async fn op_perry_fetch(
     #[string] url: String,
     #[string] method: String,
     #[string] body: String,
     #[serde] headers: HashMap<String, String>,
+) -> Result<serde_json::Value, JsErrorBox> {
+    let tokio_rt = crate::get_tokio_runtime();
+    tokio_rt
+        .spawn_blocking(move || run_ureq_fetch(url, method, body, headers))
+        .await
+        .map_err(|e| JsErrorBox::generic(format!("fetch task join error: {}", e)))?
+}
+
+/// Blocking ureq dispatch. Runs on a tokio blocking-pool worker via
+/// `op_perry_fetch`; keep it pure so the async wrapper stays trivial.
+fn run_ureq_fetch(
+    url: String,
+    method: String,
+    body: String,
+    headers: HashMap<String, String>,
 ) -> Result<serde_json::Value, JsErrorBox> {
     let agent = ureq::agent();
     let method_upper = method.to_uppercase();

--- a/test-files/test_issue_997_v8_listen_keepalive.ts
+++ b/test-files/test_issue_997_v8_listen_keepalive.ts
@@ -1,0 +1,37 @@
+// Regression test for issue #997 — V8-fallback `http.createServer().listen()`
+// must keep the outer event loop alive while the bind future is in flight on
+// a tokio worker, even when no other source (timers, stdlib pumps, http
+// active count) has been registered yet.
+//
+// Pre-fix, `app.listen(port, callback)` returned to the codegen-emitted
+// outer event loop while `op_perry_http_listen`'s `TcpListener::bind`
+// future was still suspended on the multi-thread runtime. The header
+// `js_jsruntime_has_active_handles` only inspected resolved-state
+// counters (ACTIVE_SERVERS / pending tick / module eval), saw zero,
+// and exited the program before bind completed. User-visible symptom:
+// "listening" never prints and the server isn't reachable.
+//
+// Fix: `poll_v8_event_loop_once` now records `last_poll_was_pending`,
+// and `jsruntime_has_active_handles` returns 1 whenever the last
+// poll left deno_core with refed ops in flight. This keeps the
+// outer loop ticking until the bind resolves and ACTIVE_SERVERS
+// increments. See crates/perry-jsruntime/src/{lib,interop}.rs.
+//
+// Smoke shape mirrors test_http_createserver_v8.ts but with a
+// synchronous listen callback and an immediate server.close(), so
+// the test exits deterministically once the callback fires. The
+// success criterion is that "listening" prints at all — pre-fix this
+// hung indefinitely (rc=124 under `timeout`).
+
+import http from "node:http";
+
+const server = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("ok");
+});
+
+const port = 18997;
+server.listen(port, () => {
+    console.log("listening");
+    server.close();
+});


### PR DESCRIPTION
## Summary

Three bug fixes that unblock the express end-to-end smoke against the V8-fallback `http.createServer` bridge from #994:

- **V8 bind keepalive**: `JsRuntimeState::last_poll_was_pending` is set by `poll_v8_event_loop_once` whenever deno_core reports refed ops in flight, and `jsruntime_has_active_handles` returns 1 while it's set. Pre-fix, `app.listen(port, cb)` returned to the codegen-emitted outer event loop while `op_perry_http_listen`'s `TcpListener::bind` future was still suspended on the multi-thread runtime, the outer loop saw no active source, and the program exited before bind ever resolved.
- **Express handler polyfills**: added `setImmediate` / `clearImmediate` globals (express's router uses them to break middleware recursion) and `Buffer.allocUnsafeSlow` (so `safe-buffer`, used by `express/lib/response.js`, doesn't fall through to a `for...in` copyProps that silently drops non-enumerable static methods like `Buffer.isBuffer`). Without these, every `(_req, res) => res.send('pong')` threw and the http shim returned 500.
- **Cb ordering + async `op_perry_fetch`**: `Server.listen` now schedules the listening callback via `Promise.resolve().then(() => cb())` so the JS accept loop registers its first `op_perry_http_accept(sid)` op before the trampoline-driven callback gets a chance to block the V8 thread. `op_perry_fetch` is now an async op wrapping the blocking ureq call in `tokio::task::spawn_blocking`, with the polyfill updated to `await core.ops.op_perry_fetch(...)`.

External clients (`curl http://127.0.0.1:port/...`) hit a Perry-compiled express server and get the route body. The self-fetch case (`async () => { await fetch('http://127.0.0.1:port/...') }` inside the listen-cb) still deadlocks because Perry's native async lowering busy-waits on the V8 thread inside trampolines, blocking the IIFE's accept loop continuation — documented in CHANGELOG as a deferred issue gated on real Future-style state-machine lowering.

## Verification

- New regression `test-files/test_issue_997_v8_listen_keepalive.ts`: synchronous listen-cb that closes the server immediately. Pre-fix hangs forever under `timeout`; post-fix prints `listening` and exits 0.
- Existing `test-files/test_http_createserver_v8.ts` still passes (`200 hello` + exit 0).
- Express smoke (`app.get('/ping', (_req, res) => res.send('pong'))`) returns `pong` via external curl. Confirmed locally.
- Fastify end-to-end smoke (`{"msg":"pong"}`) still works through perry-stdlib's bundled fastify path.

## Test plan

- [ ] CI lint passes
- [ ] CI cargo-test passes
- [ ] CI parity passes
- [ ] CI compile-smoke passes
- [ ] Local: `target/release/perry test-files/test_issue_997_v8_listen_keepalive.ts -o /tmp/t && timeout 5 /tmp/t` prints `listening` and exits 0
- [ ] Local: `target/release/perry test-files/test_http_createserver_v8.ts -o /tmp/t2 && timeout 10 /tmp/t2` prints `200 hello`