### PR TITLE
docs: regenerate API reference + .d.ts to match manifest

### DIFF
--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 870 entries across 71 modules
+// Coverage: 898 entries across 71 modules
 
 declare module "argon2" {
   /** stdlib */
@@ -399,9 +399,25 @@ declare module "lodash" {
   /** stdlib */
   export function head(p0: any): any;
   /** stdlib */
+  export function inRange(p0: any, p1: any, p2: any): boolean;
+  /** stdlib */
   export function kebabCase(p0: string): string;
   /** stdlib */
   export function last(p0: any): any;
+  /** stdlib */
+  export function max(p0: any): any;
+  /** stdlib */
+  export function maxBy(p0: any, p1: any): any;
+  /** stdlib */
+  export function mean(p0: any): number;
+  /** stdlib */
+  export function meanBy(p0: any, p1: any): number;
+  /** stdlib */
+  export function min(p0: any): any;
+  /** stdlib */
+  export function minBy(p0: any, p1: any): any;
+  /** stdlib */
+  export function random(p0: any, p1: any): number;
   /** stdlib */
   export function range(p0: any, p1: any, p2: any): any;
   /** stdlib */
@@ -410,6 +426,12 @@ declare module "lodash" {
   export function size(p0: any): any;
   /** stdlib */
   export function snakeCase(p0: string): string;
+  /** stdlib */
+  export function sum(p0: any): number;
+  /** stdlib */
+  export function sumBy(p0: any, p1: any): number;
+  /** stdlib */
+  export function tail(p0: any): any;
   /** stdlib */
   export function take(p0: any, p1: any): any;
   /** stdlib */
@@ -1172,6 +1194,8 @@ declare module "stream" {
   export class Transform { [key: string]: any; }
   /** stdlib */
   export class Writable { [key: string]: any; }
+  /** stdlib */
+  export const prototype: any;
   /** stdlib */
   export function finished(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 870 entries across 71 modules.
+Total: 898 entries across 71 modules.
 
 ## Modules
 
@@ -614,17 +614,29 @@ Total: 870 entries across 71 modules.
 - `camelCase` — module
 - `chunk` — module
 - `clamp` — module
+- `clamp` — module
 - `compact` — module
 - `drop` — module
 - `first` — module
 - `flatten` — module
 - `head` — module
+- `inRange` — module
 - `kebabCase` — module
 - `last` — module
+- `max` — module
+- `maxBy` — module
+- `mean` — module
+- `meanBy` — module
+- `min` — module
+- `minBy` — module
+- `random` — module
 - `range` — module
 - `reverse` — module
 - `size` — module
 - `snakeCase` — module
+- `sum` — module
+- `sumBy` — module
+- `tail` — module
 - `take` — module
 - `times` — module
 - `uniq` — module
@@ -1228,9 +1240,28 @@ Total: 870 entries across 71 modules.
 
 ### Methods
 
+- `addListener` — instance
+- `emit` — instance
+- `eventNames` — instance
 - `finished` — module
 - `from` — module
+- `getMaxListeners` — instance
+- `listenerCount` — instance
+- `listeners` — instance
+- `off` — instance
+- `on` — instance
+- `once` — instance
 - `pipeline` — module
+- `prependListener` — instance
+- `prependOnceListener` — instance
+- `rawListeners` — instance
+- `removeAllListeners` — instance
+- `removeListener` — instance
+- `setMaxListeners` — instance
+
+### Properties
+
+- `prototype`
 
 ## `streams`
 


### PR DESCRIPTION
## Summary

PRs #966, #967, #982, and #984 added entries to
`perry-api-manifest::API_MANIFEST` (stream EventEmitter instance
methods, `stream.prototype`, lodash
`inRange`/`max`/`maxBy`/`mean`/`meanBy`/`min`/`minBy`/`random`/`sum`/`sumBy`/`tail`)
but didn't rerun `./scripts/regen_api_docs.sh`. The `api-docs-drift`
gate has been red on every PR that lands on top — including #947, which
doesn't touch the manifest at all. This is the same shape of stale-on-main
blocker that #958 cleared for `cargo-test` earlier.

Mechanical regen, no manifest edits.

- Coverage: 870 → 898 entries across 71 modules.
- Files: `docs/api/perry.d.ts`, `docs/src/api/reference.md`.

## Test plan

- [x] `./scripts/regen_api_docs.sh` is idempotent: re-running on this branch produces no further diff.
- [x] Diff matches what the `api-docs-drift` job on #947 reported (`26 +`, `33 +`, `2 -`).