### PR TITLE
fix(jsruntime): jose JWT (HS256) end-to-end through V8 fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,133 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1003 — fix(jsruntime): jose JWT (HS256) end-to-end through the V8 fallback
+
+`await new SignJWT({ sub: 'alice' }).setProtectedHeader({ alg: 'HS256' }).sign(key)`
+through `jose` was returning a malformed token and `jwtVerify` was
+rejecting it. The original failure surfaced as
+`JWSInvalid: Compact JWS must be a string or Uint8Array` and later as
+`TypeError: util.types.isKeyObject is not a function` / `Key for the
+HS256 algorithm must be one of type KeyObject, Uint8Array, or JSON
+Web Key. Received an instance of Array`. Root cause was six-layered:
+
+**1. Native to V8 Uint8Array marshalling lost the typed-array kind.**
+`crates/perry-jsruntime/src/bridge.rs:native_object_to_v8` dispatched
+`TypedArrayHeader`s and `BufferHeader`s through the generic
+`v8::Array::new` branch, so a perry-side `Uint8Array` (or
+`TextEncoder().encode(...)` Buffer) crossed the boundary as a plain
+`v8::Array`. Libraries that branch on `value instanceof Uint8Array`
+(jose, jsonwebtoken, every JWS impl) failed the type check and either
+threw or fell through to JWK handling on a non-JWK input.
+
+Fix: detect the typed-array / buffer registries (`lookup_typed_array_kind`
+and `is_registered_buffer` / `is_uint8array_buffer` in `perry-runtime`)
+before the generic-object arm. For each hit, allocate a V8 `ArrayBuffer`,
+copy the bytes (the source pointer is GC-owned by perry — a copy keeps
+V8's backing store independent), and wrap with the matching
+TypedArray constructor (`Uint8Array`, `Int16Array`, ...). Round-trips
+into V8 fallback modules now preserve the JS-level type.
+
+**2. `node:crypto.createHmac().update().digest()` returned an empty digest.**
+The V8 stub in `crates/perry-jsruntime/src/modules.rs` had a no-op
+`createHmac` that returned `''` from `.digest()`. jose's
+`runtime/sign.js` calls `crypto.createHmac(hmacDigest(alg), k)` then
+`.digest()` for HS*; the empty result produced a token whose signature
+section was the empty string.
+
+Fix: new `op_perry_hmac(alg, key, data)` deno op
+(`crates/perry-jsruntime/src/ops.rs`) using `hmac` + `sha2` (same
+crate versions as `perry-stdlib`'s `crypto` feature). The V8 stub's
+`createHmac` now buffers `.update(...)` chunks, concats them on
+`.digest(encoding?)`, calls the op, and returns either a `Buffer`
+(default), hex, base64, or base64url string per Node's
+`Hmac.prototype.digest` API. The HMAC output is a real Buffer so
+downstream `instanceof Uint8Array` checks succeed and
+`.toString('base64url')` works without going through the
+broken Array path.
+
+**3. `Buffer.toString('base64url')` / `Buffer.from(_, 'base64url')` were unimplemented.**
+`crates/perry-jsruntime/src/node_polyfills.js`'s `Buffer.toString`
+fell through to the utf8 branch on `base64url`, so jose's
+`base64url(signature)` (which is `Buffer.from(sig).toString('base64url')`)
+returned a binary blob smashed into a JS string. JWS tokens looked like
+`{header}.{payload}.{garbage}` and were unparseable.
+
+Fix: `Buffer.toString('base64url')` now base64-encodes, strips trailing
+`=`, and substitutes `+` to `-` / `/` to `_`. `Buffer.from(str, 'base64url')`
+normalizes back (`-` to `+`, `_` to `/`, re-add padding to a multiple of 4)
+before calling `atob`. Also added pure-JS `globalThis.btoa` / `atob`
+globals (V8 standalone does not expose them; Node has them since
+v16, and jose / jwt-decode / jsonwebtoken assume they exist).
+
+**4. `atob` decoded `'='` as `__b64chars.indexOf('=') === -1` and emitted `0xff` bytes.**
+After the base64url normalize re-added the `=` padding for a
+44-char input, the polyfill's atob treated the trailing `=` as `-1`
+and OR'd it into the last byte. Result: every base64url-decoded
+`Uint8Array` had a spurious `0xff` byte at the tail, so jose's
+`crypto.timingSafeEqual(actual, expected)` saw length 33 vs 32 and
+returned false — `jwtVerify` failed with
+`JWSSignatureVerificationFailed` even though sign produced the
+correct digest.
+
+Fix: `atob` now treats `''` and `'='` as the padding index (64) so
+the byte-emit branches skip the trailing partial group cleanly.
+
+**5. `node:crypto.createSecretKey` was a V8-only no-op.**
+Calling `createSecretKey('secret', 'utf8')` from compiled TypeScript
+returned `undefined` because the symbol existed only in the V8
+fallback stub (`crates/perry-jsruntime/src/modules.rs`) — there was
+no native dispatcher. jose's `getSignVerifyKey` then saw `undefined`
+and threw before even reaching the HMAC path.
+
+Fix: new `js_crypto_create_secret_key` in
+`crates/perry-stdlib/src/crypto.rs` returns a `BufferHeader` of the
+key bytes (utf8 string or Buffer input), marked via
+`mark_as_uint8array` so it passes `instanceof Uint8Array` everywhere.
+HS* in jose accepts Uint8Array directly per
+`getSignVerifyKey`; full KeyObject identity is not required. Wired
+through `crates/perry-codegen/src/expr.rs` (PropertyGet shape:
+`crypto.createSecretKey(...)`) and `crates/perry-hir/src/lower/expr_call.rs`
+(named-import shape: `createSecretKey(...)` after
+`import { createSecretKey } from 'node:crypto'`).
+
+**6. `util.types.isKeyObject` / `isCryptoKey` were absent and `node:crypto.KeyObject` was an empty class.**
+jose's `is_key_object.js` calls `util.types.isKeyObject(obj)` to
+distinguish KeyObject from Uint8Array on the key-input path; without
+the helper it threw `is not a function` before ever reaching the
+signing flow. Separately, the V8 stub's `KeyObject` had no body to
+match against `key instanceof KeyObject`, so `getSignVerifyKey` fell
+into the "Received undefined" branch.
+
+Fix: `crates/perry-jsruntime/src/modules.rs` now ships
+`util.types.isKeyObject` and `isCryptoKey` duck-typed against the
+KeyObject / CryptoKey shape (the V8 stub doesn't expose Node's
+internal `internalBinding('util')`, so brand checks aren't available).
+The V8 stub `KeyObject` became a real class with `type`,
+`_material` (Uint8Array of key bytes), `symmetricKeySize`, and
+`export(format?)` returning a `Buffer.from(this._material)` so
+HMAC-side `instanceof KeyObject` + `key.export()` both succeed.
+
+**Test:** `test-files/test_jose_sign.ts` runs the full
+`import { SignJWT } from 'jose'; import { createSecretKey } from 'node:crypto';`
+HS256 sign smoke. Expected output is `string` + `3` (typeof token,
+parts after split). The original task repro (with
+`await jwtVerify(token, key)` then `console.log('sub=' + payload.sub)`)
+now prints `sub=alice`.
+
+**Files touched:**
+- `crates/perry-jsruntime/Cargo.toml` — added `hmac = "0.12"`, `sha2 = "0.10"` (same versions as `perry-stdlib`).
+- `crates/perry-jsruntime/src/ops.rs` — new `op_perry_hmac` deno op, registered in `extension!(perry_ops, ops = [..., op_perry_hmac])`.
+- `crates/perry-jsruntime/src/bridge.rs` — typed-array / buffer detection in `native_object_to_v8` before the generic-object arm.
+- `crates/perry-jsruntime/src/modules.rs` — real `createHmac`, `createSecretKey`, `KeyObject`, `webcrypto`, `sign`/`verify` stubs in the `node:crypto` V8 stub. `util.types.isKeyObject` / `isCryptoKey` in the `node:util` stub.
+- `crates/perry-jsruntime/src/node_polyfills.js` — `btoa`/`atob` globals (atob `=` padding fix), `Buffer.toString('base64url')`, `Buffer.from(_, 'base64url')`.
+- `crates/perry-stdlib/src/crypto.rs` — new `js_crypto_create_secret_key` Uint8Array-marked Buffer allocator.
+- `crates/perry-codegen/src/expr.rs` — codegen dispatch for `crypto.createSecretKey(...)`.
+- `crates/perry-codegen/src/runtime_decls.rs` — extern decl for `js_crypto_create_secret_key`.
+- `crates/perry-hir/src/lower/expr_call.rs` — named-import lowering for `createSecretKey(...)` from `node:crypto`.
+- `crates/perry-api-manifest/src/entries.rs` — manifest entry for `crypto.createSecretKey` (strict-API gate).
+- `test-files/test_jose_sign.ts` — new HS256 sign smoke.
+
 ## v0.5.1002 — fix(jsruntime): Effect.pipe(map) chain composition
 
 `Effect.runSync(Effect.succeed(42).pipe(Effect.map(x => x + 1)))` returned
@@ -83,7 +210,6 @@ runs, `fn called with: 42` prints, result is `43`. Gap suite unchanged
 fixtures pass.
 
 Fixture: `test-files/test_effect_pipe_map.ts` (chain repro).
-
 ## v0.5.1001 — fix(jsruntime/http): V8 listen keepalive + express handler smoke
 
 Post-#994 the V8-fallback `http.createServer().listen(port, cb)` smoke

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1002
+**Current Version:** 0.5.1003
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1002"
+version = "0.5.1003"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,12 +5420,13 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "bytes",
  "deno_core",
  "deno_error",
+ "hmac",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -5437,6 +5438,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 1.0.69",
  "tokio",
  "ureq",
@@ -5444,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5456,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "base64",
@@ -5480,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5550,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5560,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5568,11 +5570,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1002"
+version = "0.5.1003"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "itoa",
  "jni",
@@ -5587,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5597,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5616,7 +5618,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "block2",
  "libc",
@@ -5631,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "block2",
  "libc",
@@ -5649,11 +5651,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1002"
+version = "0.5.1003"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "block2",
  "libc",
@@ -5668,7 +5670,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "block2",
  "libc",
@@ -5683,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "block2",
  "libc",
@@ -5696,7 +5698,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5710,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5724,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1002"
+version = "0.5.1003"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1002"
+version = "0.5.1003"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1701,6 +1701,12 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("crypto", "randomFillSync", false, None),
     method("crypto", "createHash", false, None),
     method("crypto", "createHmac", false, None),
+    // `crypto.createSecretKey(key, encoding?)` — required by jose for the
+    // JWT signing path; returns a Uint8Array-marked Buffer of the key
+    // bytes that `instanceof Uint8Array` accepts on both sides of the
+    // V8 boundary. Wired through codegen in `expr.rs` (no NATIVE_MODULE_TABLE
+    // entry — direct dispatch matches the createHash/createHmac pattern).
+    method("crypto", "createSecretKey", false, None),
     method("crypto", "pbkdf2Sync", false, None),
     method("crypto", "pbkdf2", false, None),
     // Web Crypto API (issue #561) — `crypto.subtle.*`. The HIR

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -11564,6 +11564,34 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_string_inline(blk, &handle))
         }
 
+        // `crypto.createSecretKey(key, encoding?)` — JWT signing key for
+        // HS* algorithms. Native-side this returns a Uint8Array-marked
+        // BufferHeader; the bridge then materializes a real v8::Uint8Array
+        // when the value crosses into a V8-fallback module (jose). See
+        // `js_crypto_create_secret_key` for the encoding handling.
+        Expr::Call { callee, args, .. }
+            if matches!(
+                callee.as_ref(),
+                Expr::PropertyGet { object, property } if property == "createSecretKey" && matches!(
+                    object.as_ref(),
+                    Expr::NativeModuleRef(n) if n == "crypto"
+                )
+            ) =>
+        {
+            if args.is_empty() {
+                return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
+            }
+            let key_box = lower_expr(ctx, &args[0])?;
+            // Ignore the encoding arg if present — we only honor utf8.
+            if args.len() >= 2 {
+                let _ = lower_expr(ctx, &args[1])?;
+            }
+            let blk = ctx.block();
+            let key_handle = unbox_to_i64(blk, &key_box);
+            let buf_handle = blk.call(I64, "js_crypto_create_secret_key", &[(I64, &key_handle)]);
+            Ok(nanbox_pointer_inline(blk, &buf_handle))
+        }
+
         // crypto.pbkdf2Sync(password, salt, iterations, keylen, algorithm) -> Buffer.
         // Only SHA-256 is wired through right now — that's what SCRAM needs.
         // The `algorithm` arg is validated at runtime but ignored by codegen;

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -1070,6 +1070,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_crypto_pbkdf2_bytes", I64, &[I64, I64, DOUBLE, DOUBLE]);
     module.declare_function("js_crypto_random_bytes_buffer", I64, &[DOUBLE]);
     module.declare_function("js_crypto_random_uuid", I64, &[]);
+    // `crypto.createSecretKey(key, encoding?)` — returns Uint8Array-marked
+    // BufferHeader of the key bytes (jose accepts Uint8Array for HS*).
+    module.declare_function("js_crypto_create_secret_key", I64, &[I64]);
     // Web Crypto (issue #561): crypto.subtle.{digest,importKey,sign,verify}.
     // Each takes NaN-boxed JS values as f64 and returns a *mut Promise.
     module.declare_function("js_webcrypto_digest", I64, &[DOUBLE, DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_call.rs
+++ b/crates/perry-hir/src/lower/expr_call.rs
@@ -6494,6 +6494,36 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                                     )));
                                 }
                             }
+                            // `createSecretKey(key, encoding?)` from a named
+                            // import. Without this arm the call lowered to a
+                            // generic NativeMethodCall with no dispatcher for
+                            // `crypto.createSecretKey`, so the call returned
+                            // undefined and `jose.sign(undefined)` threw
+                            // "Received undefined". Reuse the same PropertyGet
+                            // shape that the `crypto.createSecretKey(...)`
+                            // call-site form already exercises (handled in
+                            // `expr.rs` near the createHash/createHmac block)
+                            // so both shapes share one codegen path.
+                            "createSecretKey" => {
+                                if !args.is_empty() {
+                                    let mut iter = args.into_iter();
+                                    let key_arg = iter.next().unwrap();
+                                    let mut new_args = vec![key_arg];
+                                    if let Some(enc) = iter.next() {
+                                        new_args.push(enc);
+                                    }
+                                    return Ok(Expr::Call {
+                                        callee: Box::new(Expr::PropertyGet {
+                                            object: Box::new(Expr::NativeModuleRef(
+                                                "crypto".to_string(),
+                                            )),
+                                            property: "createSecretKey".to_string(),
+                                        }),
+                                        args: new_args,
+                                        type_args: vec![],
+                                    });
+                                }
+                            }
                             _ => {} // Fall through
                         }
                     }

--- a/crates/perry-jsruntime/Cargo.toml
+++ b/crates/perry-jsruntime/Cargo.toml
@@ -49,5 +49,12 @@ hyper-util = { version = "0.1", features = ["server", "tokio"] }
 http-body-util = "0.1"
 bytes = "1.5"
 
+# HMAC + SHA2 for `node:crypto.createHmac` in the V8 fallback path so
+# packages like `jose` can compute real HS256/HS384/HS512 signatures
+# without falling through to a no-op digest. Same crate versions as
+# `perry-stdlib`'s `crypto` feature so we don't duplicate the dep graph.
+hmac = "0.12"
+sha2 = "0.10"
+
 [features]
 default = []

--- a/crates/perry-jsruntime/src/bridge.rs
+++ b/crates/perry-jsruntime/src/bridge.rs
@@ -907,6 +907,106 @@ fn native_object_to_v8<'s>(
         return v8::null(scope).into();
     }
 
+    // Issue (jose JWT blocker): Uint8Array / TypedArray pointers crossing
+    // into V8 used to fall through to the generic `v8::Array` branch,
+    // which turned a perry Uint8Array into a v8 Array. Libraries running
+    // in the V8 fallback (jose, jsonwebtoken) check `instanceof Uint8Array`
+    // on signing inputs/outputs and fail with "Received an instance of
+    // Array". Detect typed-array pointers via the runtime's registry and
+    // materialize a real v8 `Uint8Array` (or matching TypedArray) with a
+    // copy of the underlying bytes so V8 owns the backing store.
+    //
+    // Two perry representations cross the boundary here:
+    //   - `TypedArrayHeader` — `new Uint8Array([..])` and TypedArray ops.
+    //   - `BufferHeader` marked via `mark_as_uint8array` — what
+    //     `TextEncoder().encode(...)` and `Buffer.from(...)` return.
+    //     Layout is identical (`length: u32, capacity: u32`) but the
+    //     "kind" is implicit (always uint8) and tracked in a separate
+    //     registry. Handle both before the generic-object branch.
+    {
+        let buf_addr = ptr as usize;
+        // BufferHeader path: registered Uint8Array buffer with the
+        // packed-u8 layout. Must materialize as v8 Uint8Array so jose's
+        // `instanceof Uint8Array` checks pass.
+        let is_buf = perry_runtime::buffer::is_registered_buffer(buf_addr);
+        let is_marked_u8 = perry_runtime::buffer::is_uint8array_buffer(buf_addr);
+        if is_buf || is_marked_u8 {
+            let buf = ptr as *const perry_runtime::buffer::BufferHeader;
+            let length = unsafe { (*buf).length } as usize;
+            let data_ptr = unsafe {
+                (ptr as *const u8).add(std::mem::size_of::<perry_runtime::buffer::BufferHeader>())
+            };
+            let ab = v8::ArrayBuffer::new(scope, length);
+            if length > 0 {
+                let bs = ab.get_backing_store();
+                let dst = bs.data().map(|nn| nn.as_ptr() as *mut u8);
+                if let Some(dst) = dst {
+                    unsafe { std::ptr::copy_nonoverlapping(data_ptr, dst, length) };
+                }
+            }
+            if let Some(ta) = v8::Uint8Array::new(scope, ab, 0, length) {
+                return ta.into();
+            }
+        }
+        if let Some(kind) = perry_runtime::typedarray::lookup_typed_array_kind(buf_addr) {
+            let ta = ptr as *const perry_runtime::typedarray::TypedArrayHeader;
+            let length = unsafe { (*ta).length } as usize;
+            let elem_size = perry_runtime::typedarray::elem_size_for_kind(kind);
+            let byte_len = length.saturating_mul(elem_size);
+            let data_ptr = unsafe {
+                (ptr as *const u8).add(std::mem::size_of::<
+                    perry_runtime::typedarray::TypedArrayHeader,
+                >())
+            };
+            // Build an ArrayBuffer owned by V8 and copy the perry bytes into it.
+            // Using a copy (not a backing-store wrapper) keeps lifetimes simple:
+            // perry's GC can reclaim the source without confusing V8.
+            let ab = v8::ArrayBuffer::new(scope, byte_len);
+            if byte_len > 0 {
+                let bs = ab.get_backing_store();
+                let dst = bs.data().map(|nn| nn.as_ptr() as *mut u8);
+                if let Some(dst) = dst {
+                    unsafe { std::ptr::copy_nonoverlapping(data_ptr, dst, byte_len) };
+                }
+            }
+            // Element kind → V8 TypedArray constructor.
+            use perry_runtime::typedarray as ta_mod;
+            let ta_value: v8::Local<v8::Value> = match kind {
+                ta_mod::KIND_INT8 => v8::Int8Array::new(scope, ab, 0, length)
+                    .map(|v| v.into())
+                    .unwrap_or_else(|| v8::Array::new(scope, 0).into()),
+                ta_mod::KIND_UINT8 | ta_mod::KIND_UINT8_CLAMPED => {
+                    // V8 has Uint8ClampedArray as a separate type, but jose
+                    // / jsonwebtoken only branch on `Uint8Array`. Use the
+                    // plain Uint8Array unless we explicitly need clamped.
+                    v8::Uint8Array::new(scope, ab, 0, length)
+                        .map(|v| v.into())
+                        .unwrap_or_else(|| v8::Array::new(scope, 0).into())
+                }
+                ta_mod::KIND_INT16 => v8::Int16Array::new(scope, ab, 0, length)
+                    .map(|v| v.into())
+                    .unwrap_or_else(|| v8::Array::new(scope, 0).into()),
+                ta_mod::KIND_UINT16 => v8::Uint16Array::new(scope, ab, 0, length)
+                    .map(|v| v.into())
+                    .unwrap_or_else(|| v8::Array::new(scope, 0).into()),
+                ta_mod::KIND_INT32 => v8::Int32Array::new(scope, ab, 0, length)
+                    .map(|v| v.into())
+                    .unwrap_or_else(|| v8::Array::new(scope, 0).into()),
+                ta_mod::KIND_UINT32 => v8::Uint32Array::new(scope, ab, 0, length)
+                    .map(|v| v.into())
+                    .unwrap_or_else(|| v8::Array::new(scope, 0).into()),
+                ta_mod::KIND_FLOAT32 => v8::Float32Array::new(scope, ab, 0, length)
+                    .map(|v| v.into())
+                    .unwrap_or_else(|| v8::Array::new(scope, 0).into()),
+                ta_mod::KIND_FLOAT64 => v8::Float64Array::new(scope, ab, 0, length)
+                    .map(|v| v.into())
+                    .unwrap_or_else(|| v8::Array::new(scope, 0).into()),
+                _ => v8::Array::new(scope, 0).into(),
+            };
+            return ta_value;
+        }
+    }
+
     // Use GcHeader (8 bytes before user pointer) to reliably determine type.
     // All Perry arrays and objects are arena-allocated with GcHeader via arena_alloc_gc.
     let gc_header_ptr = (ptr as usize).wrapping_sub(perry_runtime::gc::GC_HEADER_SIZE);

--- a/crates/perry-jsruntime/src/modules.rs
+++ b/crates/perry-jsruntime/src/modules.rs
@@ -1497,10 +1497,99 @@ export function createHash(algorithm) {
         digest(encoding) { return ''; }
     };
 }
+// `crypto.createHmac(algorithm, key)` — real HMAC for HS256/384/512 via
+// `op_perry_hmac`. The op takes a normalized algorithm name plus
+// zero-copy Uint8Array buffers for the key/data. We accumulate update()
+// inputs into a single Uint8Array on .digest() to match Node's API
+// shape (Node's createHmac returns a Hmac that supports chained
+// update().update().digest()). Without this, libraries like `jose`
+// fall through to an empty signature and produce malformed JWS tokens.
+const __perry_hmac_normalize_alg = (algorithm) => {
+    if (typeof algorithm !== 'string') return null;
+    const a = algorithm.toLowerCase();
+    if (a === 'sha256' || a === 'sha-256') return 'sha256';
+    if (a === 'sha384' || a === 'sha-384') return 'sha384';
+    if (a === 'sha512' || a === 'sha-512') return 'sha512';
+    return null;
+};
+const __perry_hmac_to_bytes = (input) => {
+    if (input == null) return new Uint8Array(0);
+    if (input instanceof Uint8Array) return input;
+    if (input instanceof ArrayBuffer) return new Uint8Array(input);
+    if (ArrayBuffer.isView(input)) {
+        return new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+    }
+    if (typeof input === 'string') {
+        return new TextEncoder().encode(input);
+    }
+    // KeyObject / shim with .export(), ._material, or ._key — best-effort
+    // unwrap. Check _material first so we don't recurse through the Buffer
+    // returned from export() (which would already be a Uint8Array hit).
+    if (input._material instanceof Uint8Array) return input._material;
+    if (typeof input.export === 'function') {
+        try { return __perry_hmac_to_bytes(input.export()); } catch (_) {}
+    }
+    if (input._key != null) return __perry_hmac_to_bytes(input._key);
+    return new Uint8Array(0);
+};
+const __perry_hmac_concat = (chunks) => {
+    let total = 0;
+    for (const c of chunks) total += c.length;
+    const out = new Uint8Array(total);
+    let off = 0;
+    for (const c of chunks) { out.set(c, off); off += c.length; }
+    return out;
+};
+const __perry_hmac_to_hex = (bytes) => {
+    let s = '';
+    for (let i = 0; i < bytes.length; i++) {
+        s += (bytes[i] + 0x100).toString(16).slice(1);
+    }
+    return s;
+};
+const __perry_hmac_to_base64 = (bytes) => {
+    if (typeof Buffer !== 'undefined' && Buffer.from) {
+        return Buffer.from(bytes).toString('base64');
+    }
+    // Fallback (no Buffer): manual base64.
+    let bin = '';
+    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+    if (typeof btoa === 'function') return btoa(bin);
+    return bin;
+};
 export function createHmac(algorithm, key) {
+    const alg = __perry_hmac_normalize_alg(algorithm);
+    const keyBytes = __perry_hmac_to_bytes(key);
+    const chunks = [];
+    const ops = (typeof Deno !== 'undefined' && Deno.core && Deno.core.ops) ? Deno.core.ops : null;
     return {
-        update(data) { return this; },
-        digest(encoding) { return ''; }
+        update(data, _inputEncoding) {
+            chunks.push(__perry_hmac_to_bytes(data));
+            return this;
+        },
+        digest(encoding) {
+            const dataBytes = __perry_hmac_concat(chunks);
+            let out;
+            if (alg && ops && typeof ops.op_perry_hmac === 'function') {
+                out = ops.op_perry_hmac(alg, keyBytes, dataBytes);
+                if (!(out instanceof Uint8Array)) out = new Uint8Array(out || []);
+            } else {
+                out = new Uint8Array(0);
+            }
+            if (encoding === 'hex') return __perry_hmac_to_hex(out);
+            if (encoding === 'base64') return __perry_hmac_to_base64(out);
+            if (encoding === 'base64url') {
+                return __perry_hmac_to_base64(out).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+            }
+            // No encoding → Buffer/Uint8Array. Prefer Node-style Buffer
+            // (jose calls `.toString('base64url')` on the result). Buffer
+            // extends Uint8Array, so `instanceof Uint8Array` checks still
+            // pass on the returned value.
+            if (typeof Buffer !== 'undefined' && Buffer.from) {
+                return Buffer.from(out);
+            }
+            return out;
+        }
     };
 }
 export function pbkdf2Sync() { return new Uint8Array(32); }
@@ -1521,7 +1610,50 @@ export function timingSafeEqual(a, b) {
 }
 export function createCipheriv() { throw new Error('crypto.createCipheriv not supported in V8 fallback'); }
 export function createDecipheriv() { throw new Error('crypto.createDecipheriv not supported in V8 fallback'); }
-export function createSecretKey(key) { return { _key: key, type: 'secret', asymmetricKeyType: undefined, symmetricKeySize: (key && key.length) || 0, export() { return key; } }; }
+// `KeyObject` (V8 fallback shim) — must be a real class so that
+// `key instanceof KeyObject` checks in libraries like `jose` succeed.
+// `createSecretKey(key, encoding)` returns a KeyObject; for utf8 input
+// we encode via TextEncoder so the underlying bytes match what HMAC
+// expects (Node's `createSecretKey('secret', 'utf8')` byte-aligns
+// with Buffer.from('secret', 'utf8')).
+export class KeyObject {
+    constructor(opts) {
+        opts = opts || {};
+        this.type = opts.type || 'secret';
+        this.asymmetricKeyType = opts.asymmetricKeyType;
+        this.asymmetricKeyDetails = opts.asymmetricKeyDetails;
+        this._material = opts._material || new Uint8Array(0);
+        this.symmetricKeySize = this._material.length;
+    }
+    export(options) {
+        // Node returns a Buffer for secret keys when no format is given.
+        if (typeof Buffer !== 'undefined' && Buffer.from) {
+            return Buffer.from(this._material);
+        }
+        return this._material;
+    }
+    static from(cryptoKey) {
+        return new KeyObject({ type: 'secret', _material: new Uint8Array(0) });
+    }
+}
+export function createSecretKey(key, encoding) {
+    let bytes;
+    if (key instanceof Uint8Array) {
+        bytes = key;
+    } else if (typeof key === 'string') {
+        // Node accepts a string + encoding; only utf8 is common.
+        if (encoding && encoding !== 'utf8' && encoding !== 'utf-8') {
+            // Best-effort: hex / base64 decoders are not free here. Fall
+            // back to utf8 bytes so the caller still gets a valid key.
+        }
+        bytes = new TextEncoder().encode(key);
+    } else if (key && key.buffer instanceof ArrayBuffer) {
+        bytes = new Uint8Array(key.buffer, key.byteOffset || 0, key.byteLength);
+    } else {
+        bytes = new Uint8Array(0);
+    }
+    return new KeyObject({ type: 'secret', _material: bytes });
+}
 export function createPrivateKey() { throw new Error('crypto.createPrivateKey not supported in V8 fallback'); }
 export function createPublicKey() { throw new Error('crypto.createPublicKey not supported in V8 fallback'); }
 export function generateKeyPair() { throw new Error('crypto.generateKeyPair not supported in V8 fallback'); }
@@ -1529,10 +1661,6 @@ export function diffieHellman() { throw new Error('crypto.diffieHellman not supp
 export function publicEncrypt() { throw new Error('crypto.publicEncrypt not supported in V8 fallback'); }
 export function privateDecrypt() { throw new Error('crypto.privateDecrypt not supported in V8 fallback'); }
 export function getCiphers() { return []; }
-export class KeyObject {
-    constructor() { this.type = 'secret'; this.asymmetricKeyType = undefined; this.symmetricKeySize = 0; }
-    export() { return new Uint8Array(0); }
-}
 export const constants = {
     RSA_PKCS1_PADDING: 1,
     RSA_PKCS1_OAEP_PADDING: 4,
@@ -1540,7 +1668,29 @@ export const constants = {
     RSA_PSS_SALTLEN_MAX_SIGN: -2,
     RSA_PSS_SALTLEN_AUTO: -2,
 };
-export default { randomBytes, randomFillSync, randomUUID, createHash, createHmac, pbkdf2Sync, pbkdf2, timingSafeEqual, createCipheriv, createDecipheriv, createSecretKey, createPrivateKey, createPublicKey, generateKeyPair, diffieHellman, publicEncrypt, privateDecrypt, getCiphers, KeyObject, constants };
+// `crypto.webcrypto` — Node exposes the Web Crypto API namespace here.
+// jose's `webcrypto.js` reads `crypto.webcrypto.CryptoKey`; returning a
+// minimal object with the same surface lets ESM linking succeed and
+// makes `crypto.webcrypto?.CryptoKey` resolve to `undefined` rather
+// than crash with a TypeError.
+export const webcrypto = (typeof globalThis !== 'undefined' && globalThis.crypto)
+    ? globalThis.crypto
+    : { subtle: {}, getRandomValues(arr) { return arr; } };
+// `crypto.sign(algorithm, data, key, callback)` — Node's one-shot
+// signer. jose's `runtime/sign.js` does `promisify(crypto.sign)` and
+// only calls the resulting Promise variant for non-HS algorithms.
+// Throwing here keeps the V8 stub deterministic: HS* never touches
+// `crypto.sign`, and asymmetric signing is unsupported on this path.
+export function sign(algorithm, data, key, callback) {
+    const err = new Error('crypto.sign (asymmetric) not supported in V8 fallback');
+    if (typeof callback === 'function') {
+        callback(err);
+        return;
+    }
+    throw err;
+}
+export function verify() { throw new Error('crypto.verify (asymmetric) not supported in V8 fallback'); }
+export default { randomBytes, randomFillSync, randomUUID, createHash, createHmac, pbkdf2Sync, pbkdf2, timingSafeEqual, createCipheriv, createDecipheriv, createSecretKey, createPrivateKey, createPublicKey, generateKeyPair, diffieHellman, publicEncrypt, privateDecrypt, getCiphers, KeyObject, constants, webcrypto, sign, verify };
 "#.to_string(),
         "fs" => r#"
 // Stub implementation for Node.js 'fs' module
@@ -1757,6 +1907,25 @@ export const TextDecoder = globalThis.TextDecoder;
 // `false` for an unknown shape is the conservative answer (the caller
 // then falls through to its own duck-typing path).
 const _isPromiseLike = (v) => v != null && (typeof v === "object" || typeof v === "function") && typeof v.then === "function";
+// `_isKeyObjectShape` — duck-types the `node:crypto` `KeyObject` shim
+// without importing it (avoids a circular module dependency between
+// node:util and node:crypto). Real Node uses an internal class brand;
+// for our V8 fallback path the shape check is sufficient because
+// libraries (jose) only ever produce KeyObjects via `createSecretKey`
+// or `KeyObject.from`, both of which set `type: 'secret' | ...`
+// alongside a typed-array `_material` field.
+const _isKeyObjectShape = (v) => (
+    v != null && typeof v === 'object'
+    && typeof v.type === 'string'
+    && (v._material instanceof Uint8Array || v._key != null
+        || typeof v.export === 'function')
+);
+const _isCryptoKeyShape = (v) => (
+    v != null && typeof v === 'object'
+    && typeof v.algorithm === 'object'
+    && typeof v.type === 'string'
+    && typeof v.extractable === 'boolean'
+);
 export const types = {
     isPromise: (v) => _isPromiseLike(v),
     isAsyncFunction: (v) => typeof v === "function" && v.constructor && v.constructor.name === "AsyncFunction",
@@ -1777,6 +1946,13 @@ export const types = {
     isBoxedPrimitive: () => false,
     isAnyArrayBuffer: (v) => v instanceof ArrayBuffer,
     isModuleNamespaceObject: () => false,
+    // `util.types.isKeyObject` / `isCryptoKey` are required by `jose`
+    // (and other JWT/JOSE libs) to discriminate between Uint8Array,
+    // CryptoKey, and Node's KeyObject before signing/verifying. The
+    // V8 fallback path doesn't expose a real `internalBinding('util')`
+    // so we duck-type against the shape produced by our crypto shim.
+    isKeyObject: (v) => _isKeyObjectShape(v),
+    isCryptoKey: (v) => _isCryptoKeyShape(v),
 };
 export default { promisify, callbackify, inspect, format, formatWithOptions, debuglog, deprecate, inherits, TextEncoder, TextDecoder, types };
 "#.to_string(),

--- a/crates/perry-jsruntime/src/node_polyfills.js
+++ b/crates/perry-jsruntime/src/node_polyfills.js
@@ -5,6 +5,64 @@
 (function() {
     if (typeof globalThis.Buffer !== 'undefined') return;
 
+    // btoa/atob - browser globals not present in V8 standalone runtime. Node
+    // exposes them since v16; libraries that target both browser and node
+    // (jose, jwt-decode, jsonwebtoken) assume they exist. Pure-JS impls
+    // mirror the WHATWG spec: btoa takes a binary string and emits base64,
+    // atob takes base64 and emits a binary string. Buffer.toString('base64')
+    // and Buffer.from(str, 'base64') below funnel through these.
+    if (typeof globalThis.btoa === 'undefined') {
+        const __b64chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+        globalThis.btoa = function(input) {
+            const s = String(input);
+            let out = '';
+            for (let i = 0; i < s.length; ) {
+                const a = s.charCodeAt(i++) & 0xff;
+                const b = i < s.length ? s.charCodeAt(i++) & 0xff : NaN;
+                const c = i < s.length ? s.charCodeAt(i++) & 0xff : NaN;
+                const e1 = a >> 2;
+                const e2 = ((a & 3) << 4) | (isNaN(b) ? 0 : (b >> 4));
+                const e3 = isNaN(b) ? 64 : (((b & 15) << 2) | (isNaN(c) ? 0 : (c >> 6)));
+                const e4 = isNaN(c) ? 64 : (c & 63);
+                out += __b64chars.charAt(e1) + __b64chars.charAt(e2)
+                    + (e3 === 64 ? '=' : __b64chars.charAt(e3))
+                    + (e4 === 64 ? '=' : __b64chars.charAt(e4));
+            }
+            return out;
+        };
+        globalThis.atob = function(input) {
+            // Treat '=' and missing trailing chars as the b64 padding index
+            // (64) so the byte-emit branches below skip the trailing partial
+            // group. Without this, `indexOf('=')` returned -1 and we emitted
+            // bogus 0xFF bytes for inputs that had stripped padding (the
+            // jose base64url path normalizes `_` to `/`, re-adds `=`, then
+            // calls atob - that final `=` was decoded as -1 to 0xff and
+            // corrupted JWS signatures by one extra byte at the tail).
+            const idx = (ch) => {
+                if (ch === '' || ch === '=') return 64;
+                const i = __b64chars.indexOf(ch);
+                return i < 0 ? 64 : i;
+            };
+            const s = String(input).replace(/[^A-Za-z0-9+/=]/g, '');
+            let out = '';
+            for (let i = 0; i < s.length; ) {
+                const e1 = idx(s.charAt(i++));
+                const e2 = idx(s.charAt(i++));
+                const e3 = idx(s.charAt(i++));
+                const e4 = idx(s.charAt(i++));
+                if (e1 === 64 || e2 === 64) break;
+                out += String.fromCharCode((e1 << 2) | (e2 >> 4));
+                if (e3 !== 64) {
+                    out += String.fromCharCode(((e2 & 15) << 4) | (e3 >> 2));
+                    if (e4 !== 64) {
+                        out += String.fromCharCode(((e3 & 3) << 6) | e4);
+                    }
+                }
+            }
+            return out;
+        };
+    }
+
     class Buffer extends Uint8Array {
         static alloc(size, fill, encoding) {
             const buf = new Buffer(size);
@@ -50,8 +108,17 @@
                     }
                     return new Buffer(bytes.buffer);
                 }
-                if (encoding === 'base64') {
-                    const binary = atob(data);
+                if (encoding === 'base64' || encoding === 'base64url') {
+                    // Normalize base64url -> base64 before atob: re-add padding
+                    // and undo the URL-safe alphabet substitution. Required by
+                    // jose `decodeBase64`, jwt-decode, and most JWT libs.
+                    let normalized = data;
+                    if (encoding === 'base64url') {
+                        normalized = data.replace(/-/g, '+').replace(/_/g, '/');
+                        const padLen = (4 - (normalized.length % 4)) % 4;
+                        if (padLen > 0) normalized = normalized + '='.repeat(padLen);
+                    }
+                    const binary = atob(normalized);
                     const bytes = new Uint8Array(binary.length);
                     for (let i = 0; i < binary.length; i++) {
                         bytes[i] = binary.charCodeAt(i);
@@ -127,12 +194,19 @@
                 }
                 return hex;
             }
-            if (encoding === 'base64') {
+            if (encoding === 'base64' || encoding === 'base64url') {
                 let binary = '';
                 for (let i = 0; i < slice.length; i++) {
                     binary += String.fromCharCode(slice[i]);
                 }
-                return btoa(binary);
+                const b64 = btoa(binary);
+                // base64url - required by jose / jsonwebtoken for JWS signatures
+                // and JWT payloads. Differs from base64 by replacing `+`/`/` with
+                // URL-safe `-`/`_` and stripping trailing `=` padding.
+                if (encoding === 'base64url') {
+                    return b64.replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+                }
+                return b64;
             }
             // utf8 / utf-8 / ascii / latin1
             return new TextDecoder().decode(slice);

--- a/crates/perry-jsruntime/src/ops.rs
+++ b/crates/perry-jsruntime/src/ops.rs
@@ -518,6 +518,52 @@ fn op_perry_http_close(#[smi] server_id: i32) {
     server_registry().lock().unwrap().remove(&server_id);
 }
 
+/// `op_perry_hmac(alg, key, data)` — sync HMAC compute. `alg` is one of
+/// `"sha256" | "sha384" | "sha512"`. `key` and `data` are zero-copy
+/// `#[buffer]` views into V8 ArrayBuffers (typically Uint8Arrays). The
+/// return is a freshly-allocated Vec<u8> (the digest) which deno_core
+/// converts back into a Uint8Array on the JS side.
+///
+/// Used by the `node:crypto` V8 stub's `createHmac().update().digest()`
+/// path so that libraries running through the V8 fallback (jose, etc.)
+/// can compute real HS256/HS384/HS512 signatures instead of returning
+/// an empty digest. Unsupported algorithms fall back to an empty Vec
+/// so the JS caller sees a zero-length digest rather than crashing.
+#[op2]
+#[buffer]
+fn op_perry_hmac(#[string] alg: &str, #[buffer] key: &[u8], #[buffer] data: &[u8]) -> Vec<u8> {
+    use hmac::{Hmac, Mac};
+    use sha2::{Sha256, Sha384, Sha512};
+
+    match alg {
+        "sha256" | "SHA-256" | "SHA256" => {
+            let mut mac = match Hmac::<Sha256>::new_from_slice(key) {
+                Ok(m) => m,
+                Err(_) => return Vec::new(),
+            };
+            mac.update(data);
+            mac.finalize().into_bytes().to_vec()
+        }
+        "sha384" | "SHA-384" | "SHA384" => {
+            let mut mac = match Hmac::<Sha384>::new_from_slice(key) {
+                Ok(m) => m,
+                Err(_) => return Vec::new(),
+            };
+            mac.update(data);
+            mac.finalize().into_bytes().to_vec()
+        }
+        "sha512" | "SHA-512" | "SHA512" => {
+            let mut mac = match Hmac::<Sha512>::new_from_slice(key) {
+                Ok(m) => m,
+                Err(_) => return Vec::new(),
+            };
+            mac.update(data);
+            mac.finalize().into_bytes().to_vec()
+        }
+        _ => Vec::new(),
+    }
+}
+
 extension!(
     perry_ops,
     ops = [
@@ -529,5 +575,6 @@ extension!(
         op_perry_http_accept,
         op_perry_http_respond,
         op_perry_http_close,
+        op_perry_hmac,
     ],
 );

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -160,6 +160,38 @@ pub unsafe extern "C" fn js_crypto_md5(data_ptr: *const StringHeader) -> *mut St
     js_string_from_bytes(hex_str.as_ptr(), hex_str.len() as u32)
 }
 
+/// `crypto.createSecretKey(key, encoding?)` — produce a key Buffer
+/// that jose / jsonwebtoken / etc. can use as an HS* signing key.
+///
+/// In Node's surface this returns a `KeyObject`, but for the V8-fallback
+/// JWT path that's where Perry's JS shim lives. From native Perry the
+/// shortest correct value is a `BufferHeader` of the raw key bytes,
+/// marked as a `Uint8Array` so that:
+///   - jose's `key instanceof Uint8Array` check passes after the native
+///     -> V8 marshal turns the BufferHeader into a real `v8::Uint8Array`
+///     (`bridge.rs:native_object_to_v8`),
+///   - `instanceof KeyObject` is not required for HS* algorithms (jose
+///     accepts Uint8Array directly per `getSignVerifyKey`).
+///
+/// `key_ptr` may point at a Buffer (already bytes) or a StringHeader
+/// (utf8 string literal). The `encoding` arg is accepted for API parity
+/// but only utf8/utf-8 is honored today; anything else is treated as
+/// utf8 (so `'secret'` and `'secret', 'utf8'` produce identical bytes).
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_create_secret_key(
+    key_ptr: i64,
+) -> *mut perry_runtime::buffer::BufferHeader {
+    let bytes = bytes_from_ptr(key_ptr);
+    let buf = alloc_buffer_from_slice(&bytes);
+    if !buf.is_null() {
+        // Mark as Uint8Array so `instanceof Uint8Array` works, both in
+        // perry-native code and after the bridge materializes a v8
+        // Uint8Array on the V8 side.
+        perry_runtime::buffer::mark_as_uint8array(buf as usize);
+    }
+    buf
+}
+
 /// Generate random bytes and return as a Buffer
 /// crypto.randomBytes(size) -> Buffer
 #[no_mangle]

--- a/test-files/test_jose_sign.ts
+++ b/test-files/test_jose_sign.ts
@@ -1,0 +1,12 @@
+// jose JWT compile-as-package smoke. Uses the original task spec - native
+// createSecretKey now wires through to a Uint8Array-marked BufferHeader
+// that the bridge materializes as a real v8::Uint8Array when handed to
+// jose inside the V8 fallback. See CHANGELOG entry for the full fix.
+import { SignJWT } from 'jose';
+import { createSecretKey } from 'node:crypto';
+const key = createSecretKey('secret', 'utf8');
+const token = await new SignJWT({ a: 1 })
+    .setProtectedHeader({ alg: 'HS256' })
+    .sign(key);
+console.log(typeof token);             // 'string'
+console.log(token.split('.').length);  // 3


### PR DESCRIPTION
## Summary

Six-layered fix so `await new SignJWT(...).sign(createSecretKey(...))` through `jose` produces a valid token and `jwtVerify` succeeds end-to-end through Perry's V8 fallback.

The original task description framed this as "string return from V8 Promise await". The actual root cause turned out to be deeper: a perry-side `Uint8Array` was marshalling into V8 as a plain `v8::Array`, so jose's `instanceof Uint8Array` checks failed before any await happened. Six layers needed fixing:

1. **Native to V8 Uint8Array/TypedArray/BufferHeader marshalling** — `bridge.rs:native_object_to_v8` now materializes real `v8::Uint8Array` (and matching `Int8Array`/`Int16Array`/...) by consulting `lookup_typed_array_kind` and `is_registered_buffer` before the generic-object arm. Libraries that branch on `value instanceof Uint8Array` (jose, jsonwebtoken, every JWS impl) now type-check correctly.
2. **`node:crypto.createHmac` was a no-op** — V8 stub returned `''` from `.digest()`. Now backed by a new `op_perry_hmac(alg, key, data)` deno op using `hmac` + `sha2` (same versions as `perry-stdlib`'s `crypto` feature). Supports SHA256/384/512.
3. **`Buffer.toString('base64url')` / `Buffer.from(_, 'base64url')` were unimplemented** — fell through to utf8 and produced binary garbage in JWS tokens. Now encode/decode the URL-safe alphabet correctly and handle padding.
4. **`globalThis.btoa` / `atob` were absent** (V8 standalone, unlike Node v16+, doesn't expose them). Added pure-JS WHATWG-spec impls. Crucially, `atob` now treats `'='` as the b64 padding index (was returning -1 from `__b64chars.indexOf('=')` and OR'ing 0xff into the last byte — every base64url-decoded `Uint8Array` had a spurious trailing byte, which made `crypto.timingSafeEqual` see length 33 vs 32 and reject every otherwise-correct JWT).
5. **`node:crypto.createSecretKey` was V8-stub-only** — native compile returned `undefined`. New `js_crypto_create_secret_key` in `perry-stdlib` returns a Uint8Array-marked `BufferHeader`; wired through codegen (PropertyGet shape via `expr.rs`) and HIR lowering (named-import shape via `lower/expr_call.rs`). HS* in jose accepts Uint8Array directly.
6. **`util.types.isKeyObject` / `isCryptoKey` and a real `KeyObject` class** in the V8 stubs — jose's `is_key_object.js` calls `util.types.isKeyObject(obj)`, and `getSignVerifyKey` does `instanceof KeyObject`. Both are now wired.

See `CHANGELOG.md` (v0.5.1002 block) for the full per-bug writeup.

## Test plan

- [x] `test-files/test_jose_sign.ts` (new) — `import { SignJWT, createSecretKey };` HS256 sign smoke. Prints `string` + `3` (typeof token, parts after `.split`).
- [x] Original task repro at `/tmp/perry-jose-2/test.ts` (with `await jwtVerify(token, key)` then `console.log('sub=' + payload.sub)`) — prints `token type: string`, `sub=alice`.
- [x] HMAC byte-for-byte match against `node -e "crypto.createHmac('sha256','secret').update(...)"`.
- [ ] CI parity / smoke gate.

## Files touched

- `crates/perry-jsruntime/Cargo.toml` — `hmac = "0.12"`, `sha2 = "0.10"`.
- `crates/perry-jsruntime/src/ops.rs` — new `op_perry_hmac`.
- `crates/perry-jsruntime/src/bridge.rs` — typed-array / buffer marshalling.
- `crates/perry-jsruntime/src/modules.rs` — real `createHmac`/`createSecretKey`/`KeyObject`/`webcrypto`/`sign`/`verify` in the `node:crypto` V8 stub; `util.types.isKeyObject` / `isCryptoKey` in the `node:util` stub.
- `crates/perry-jsruntime/src/node_polyfills.js` — `btoa`/`atob` globals (with `=` padding fix); `Buffer.toString('base64url')`; `Buffer.from(_, 'base64url')`.
- `crates/perry-stdlib/src/crypto.rs` — `js_crypto_create_secret_key`.
- `crates/perry-codegen/src/expr.rs` — `crypto.createSecretKey(...)` dispatch.
- `crates/perry-codegen/src/runtime_decls.rs` — extern decl.
- `crates/perry-hir/src/lower/expr_call.rs` — named-import lowering for `createSecretKey(...)`.
- `crates/perry-api-manifest/src/entries.rs` — strict-API manifest entry.
- `test-files/test_jose_sign.ts` — new HS256 smoke.