### PR TITLE
feat(system): takeScreenshot() returns base64 PNG of key window (#918)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5576,6 +5576,7 @@ version = "0.5.1004"
 name = "perry-ui-android"
 version = "0.5.1004"
 dependencies = [
+ "base64",
  "itoa",
  "jni",
  "libc",
@@ -5601,6 +5602,7 @@ dependencies = [
 name = "perry-ui-gtk4"
 version = "0.5.1004"
 dependencies = [
+ "base64",
  "cairo-rs",
  "dirs 5.0.1",
  "gstreamer",
@@ -5620,6 +5622,7 @@ dependencies = [
 name = "perry-ui-ios"
 version = "0.5.1004"
 dependencies = [
+ "base64",
  "block2",
  "libc",
  "objc2",
@@ -5635,6 +5638,7 @@ dependencies = [
 name = "perry-ui-macos"
 version = "0.5.1004"
 dependencies = [
+ "base64",
  "block2",
  "libc",
  "objc2",
@@ -5657,6 +5661,7 @@ version = "0.5.1004"
 name = "perry-ui-tvos"
 version = "0.5.1004"
 dependencies = [
+ "base64",
  "block2",
  "libc",
  "objc2",
@@ -5672,6 +5677,7 @@ dependencies = [
 name = "perry-ui-visionos"
 version = "0.5.1004"
 dependencies = [
+ "base64",
  "block2",
  "libc",
  "objc2",
@@ -5700,6 +5706,7 @@ dependencies = [
 name = "perry-ui-windows"
 version = "0.5.1004"
 dependencies = [
+ "base64",
  "libc",
  "perry-runtime",
  "perry-ui",

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2123,6 +2123,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("perry/system", "geolocationStopWatch", false, None),
     method("perry/system", "geolocationRequestPermission", false, None),
     method("perry/system", "imagePickerPick", false, None),
+    // --- perry/system in-app screen capture (issue #918). ---
+    method("perry/system", "takeScreenshot", false, None),
     // --- perry/system network reachability (issue #582). ---
     method("perry/system", "networkGetStatus", false, None),
     method("perry/system", "networkOnChange", false, None),

--- a/crates/perry-dispatch/src/lib.rs
+++ b/crates/perry-dispatch/src/lib.rs
@@ -2284,6 +2284,13 @@ pub static PERRY_SYSTEM_TABLE: &[MethodRow] = &[
         args: &[ArgKind::F64, ArgKind::F64, ArgKind::Closure],
         ret: ReturnKind::Void,
     },
+    // ---- In-app screen capture (issue #918) ----
+    MethodRow {
+        method: "takeScreenshot",
+        runtime: "perry_system_take_screenshot",
+        args: &[],
+        ret: ReturnKind::Str,
+    },
     // ---- Network reachability (issue #582) ----
     MethodRow {
         method: "networkGetStatus",

--- a/crates/perry-ui-android/Cargo.toml
+++ b/crates/perry-ui-android/Cargo.toml
@@ -19,6 +19,7 @@ perry-runtime = { path = "../perry-runtime", default-features = false }
 # surface (`image` crate + perry-ffi only). Force-linked via `extern crate` in
 # lib.rs so libperry_ui_android.a bundles the symbols.
 perry-ext-sharp = { path = "../perry-ext-sharp" }
+base64 = "0.22"
 libc = "0.2"
 jni = "0.21"
 serde_json = "1"

--- a/crates/perry-ui-android/src/lib.rs
+++ b/crates/perry-ui-android/src/lib.rs
@@ -2722,3 +2722,26 @@ pub extern "C" fn perry_ui_attributed_text_clear(h: i64) {
         widgets::attributed_text::clear(h)
     })
 }
+
+// ---- In-app screen capture (issue #918) ----
+/// Capture the root View as a PNG and return a base64-encoded string.
+/// Returns an empty string if capture is unavailable (e.g. the geisterhand
+/// feature is OFF, the Activity is not attached, or the JNI call fails).
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    }
+    use base64::Engine as _;
+    unsafe {
+        let mut len: usize = 0;
+        let ptr = crate::screenshot::perry_ui_screenshot_capture(&mut len as *mut usize);
+        if ptr.is_null() || len == 0 {
+            return js_string_from_bytes(std::ptr::null(), 0) as i64;
+        }
+        let bytes = std::slice::from_raw_parts(ptr, len);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        libc::free(ptr as *mut libc::c_void);
+        js_string_from_bytes(encoded.as_ptr(), encoded.len() as i64) as i64
+    }
+}

--- a/crates/perry-ui-gtk4/Cargo.toml
+++ b/crates/perry-ui-gtk4/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["rlib", "staticlib"]
 perry-ui = { path = "../perry-ui" }
 perry-ui-testkit = { workspace = true }
 perry-runtime = { path = "../perry-runtime" }
+base64 = "0.22"
 libc = "0.2"
 gtk4 = { version = "0.9", features = ["v4_6"] }
 cairo-rs = "0.20"

--- a/crates/perry-ui-gtk4/src/lib.rs
+++ b/crates/perry-ui-gtk4/src/lib.rs
@@ -2422,3 +2422,25 @@ pub extern "C" fn perry_ui_attributed_text_append(
 pub extern "C" fn perry_ui_attributed_text_clear(h: i64) {
     widgets::attributed_text::clear(h);
 }
+
+// ---- In-app screen capture (issue #918) ----
+/// Capture the active window as a PNG and return a base64-encoded string.
+/// Returns an empty string if no window is available or capture fails.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    }
+    use base64::Engine as _;
+    unsafe {
+        let mut len: usize = 0;
+        let ptr = crate::screenshot::perry_ui_screenshot_capture(&mut len as *mut usize);
+        if ptr.is_null() || len == 0 {
+            return js_string_from_bytes(std::ptr::null(), 0) as i64;
+        }
+        let bytes = std::slice::from_raw_parts(ptr, len);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        libc::free(ptr as *mut libc::c_void);
+        js_string_from_bytes(encoded.as_ptr(), encoded.len() as i64) as i64
+    }
+}

--- a/crates/perry-ui-ios/Cargo.toml
+++ b/crates/perry-ui-ios/Cargo.toml
@@ -15,6 +15,7 @@ geisterhand = []
 perry-ui = { path = "../perry-ui" }
 perry-ui-testkit = { workspace = true }
 perry-runtime = { path = "../perry-runtime", default-features = false }
+base64 = "0.22"
 block2 = "0.6"
 libc = "0.2"
 objc2 = "0.6"

--- a/crates/perry-ui-ios/src/lib.rs
+++ b/crates/perry-ui-ios/src/lib.rs
@@ -1430,6 +1430,29 @@ pub extern "C" fn perry_system_image_picker_pick(
     image_picker::pick(max_count, allow_multiple, callback);
 }
 
+// ---- In-app screen capture (issue #918) ----
+/// Capture the key window as a PNG and return a base64-encoded string.
+/// Returns an empty string if no key window is available (e.g. before the
+/// scene is attached, in tests, or in CLI builds) or capture fails.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: u32) -> *mut u8;
+    }
+    use base64::Engine as _;
+    unsafe {
+        let mut len: usize = 0;
+        let ptr = crate::screenshot::perry_ui_screenshot_capture(&mut len as *mut usize);
+        if ptr.is_null() || len == 0 {
+            return js_string_from_bytes(std::ptr::null(), 0) as i64;
+        }
+        let bytes = std::slice::from_raw_parts(ptr, len);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        libc::free(ptr as *mut libc::c_void);
+        js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32) as i64
+    }
+}
+
 // ---- Network reachability (issue #582) ----
 #[no_mangle]
 pub extern "C" fn perry_system_network_get_status(callback: f64) {

--- a/crates/perry-ui-macos/Cargo.toml
+++ b/crates/perry-ui-macos/Cargo.toml
@@ -14,6 +14,7 @@ geisterhand = []
 [dependencies]
 perry-ui = { path = "../perry-ui" }
 perry-ui-testkit = { workspace = true }
+base64 = "0.22"
 block2 = "0.6"
 libc = "0.2"
 objc2 = "0.6"

--- a/crates/perry-ui-macos/src/lib.rs
+++ b/crates/perry-ui-macos/src/lib.rs
@@ -2038,6 +2038,30 @@ pub extern "C" fn perry_system_image_picker_pick(
     image_picker::pick(max_count, allow_multiple, callback);
 }
 
+// ---- In-app screen capture (issue #918) ----
+/// Capture the key window as a PNG and return a base64-encoded string.
+/// Returns an empty string (interned via `js_string_from_bytes`) if no key
+/// window is available (e.g. headless CLI builds) or capture fails.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    use base64::Engine as _;
+    unsafe {
+        let mut len: usize = 0;
+        let ptr = crate::screenshot::perry_ui_screenshot_capture(&mut len as *mut usize);
+        if ptr.is_null() || len == 0 {
+            return js_string_from_bytes(std::ptr::null(), 0);
+        }
+        let bytes = std::slice::from_raw_parts(ptr, len);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        // perry_ui_screenshot_capture allocates with libc::malloc; release it.
+        libc::free(ptr as *mut libc::c_void);
+        js_string_from_bytes(encoded.as_ptr(), encoded.len() as i32)
+    }
+}
+
 // ---- Network reachability (issue #582) ----
 #[no_mangle]
 pub extern "C" fn perry_system_network_get_status(callback: f64) {

--- a/crates/perry-ui-tvos/Cargo.toml
+++ b/crates/perry-ui-tvos/Cargo.toml
@@ -15,6 +15,7 @@ geisterhand = []
 perry-ui = { path = "../perry-ui" }
 perry-ui-testkit = { workspace = true }
 perry-runtime = { path = "../perry-runtime", default-features = false }
+base64 = "0.22"
 block2 = "0.6"
 libc = "0.2"
 objc2 = "0.6"

--- a/crates/perry-ui-tvos/src/lib.rs
+++ b/crates/perry-ui-tvos/src/lib.rs
@@ -2576,3 +2576,25 @@ pub extern "C" fn perry_ui_attributed_text_append(
 pub extern "C" fn perry_ui_attributed_text_clear(h: i64) {
     widgets::attributed_text::clear(h);
 }
+
+// ---- In-app screen capture (issue #918) ----
+/// Capture the key window as a PNG and return a base64-encoded string.
+/// Returns an empty string if no key window is available or capture fails.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    }
+    use base64::Engine as _;
+    unsafe {
+        let mut len: usize = 0;
+        let ptr = crate::screenshot::perry_ui_screenshot_capture(&mut len as *mut usize);
+        if ptr.is_null() || len == 0 {
+            return js_string_from_bytes(std::ptr::null(), 0) as i64;
+        }
+        let bytes = std::slice::from_raw_parts(ptr, len);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        libc::free(ptr as *mut libc::c_void);
+        js_string_from_bytes(encoded.as_ptr(), encoded.len() as i64) as i64
+    }
+}

--- a/crates/perry-ui-visionos/Cargo.toml
+++ b/crates/perry-ui-visionos/Cargo.toml
@@ -15,6 +15,7 @@ geisterhand = []
 perry-ui = { path = "../perry-ui" }
 perry-ui-testkit = { workspace = true }
 perry-runtime = { path = "../perry-runtime", default-features = false }
+base64 = "0.22"
 block2 = "0.6"
 libc = "0.2"
 objc2 = "0.6"

--- a/crates/perry-ui-visionos/src/lib.rs
+++ b/crates/perry-ui-visionos/src/lib.rs
@@ -2675,3 +2675,25 @@ pub extern "C" fn perry_ui_attributed_text_append(
 pub extern "C" fn perry_ui_attributed_text_clear(h: i64) {
     widgets::attributed_text::clear(h);
 }
+
+// ---- In-app screen capture (issue #918) ----
+/// Capture the key window as a PNG and return a base64-encoded string.
+/// Returns an empty string if no key window is available or capture fails.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    }
+    use base64::Engine as _;
+    unsafe {
+        let mut len: usize = 0;
+        let ptr = crate::screenshot::perry_ui_screenshot_capture(&mut len as *mut usize);
+        if ptr.is_null() || len == 0 {
+            return js_string_from_bytes(std::ptr::null(), 0) as i64;
+        }
+        let bytes = std::slice::from_raw_parts(ptr, len);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        libc::free(ptr as *mut libc::c_void);
+        js_string_from_bytes(encoded.as_ptr(), encoded.len() as i64) as i64
+    }
+}

--- a/crates/perry-ui-watchos/src/lib.rs
+++ b/crates/perry-ui-watchos/src/lib.rs
@@ -1639,3 +1639,14 @@ pub extern "C" fn perry_ui_attributed_text_clear(h: i64) {
         node.attributed_runs.clear();
     });
 }
+
+// ---- In-app screen capture (issue #918) ----
+/// watchOS has no screenshot-capable runtime today (no `screenshot.rs` in
+/// this crate). Returns an empty string so callers can branch on length.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+}

--- a/crates/perry-ui-windows/Cargo.toml
+++ b/crates/perry-ui-windows/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["rlib", "staticlib"]
 perry-ui = { path = "../perry-ui" }
 perry-ui-testkit = { workspace = true }
 perry-runtime = { path = "../perry-runtime", default-features = false, features = ["stdlib"] }
+base64 = "0.22"
 libc = "0.2"
 # Proper PNG encoder (deflate). The old inline encoder wrote stored blocks
 # → 2.7 MB baseline for a 900×788 window. With real compression: ~50 KB.

--- a/crates/perry-ui-windows/src/lib.rs
+++ b/crates/perry-ui-windows/src/lib.rs
@@ -2516,3 +2516,25 @@ pub extern "C" fn perry_ui_attributed_text_append(
 pub extern "C" fn perry_ui_attributed_text_clear(h: i64) {
     widgets::attributed_text::clear(h);
 }
+
+// ---- In-app screen capture (issue #918) ----
+/// Capture the active window as a PNG and return a base64-encoded string.
+/// Returns an empty string if no window is available or capture fails.
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    }
+    use base64::Engine as _;
+    unsafe {
+        let mut len: usize = 0;
+        let ptr = crate::screenshot::perry_ui_screenshot_capture(&mut len as *mut usize);
+        if ptr.is_null() || len == 0 {
+            return js_string_from_bytes(std::ptr::null(), 0) as i64;
+        }
+        let bytes = std::slice::from_raw_parts(ptr, len);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        libc::free(ptr as *mut libc::c_void);
+        js_string_from_bytes(encoded.as_ptr(), encoded.len() as i64) as i64
+    }
+}

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -615,6 +615,7 @@ pub(super) fn collect_modules(
                             | "geolocationStopWatch"
                             | "geolocationRequestPermission"
                             | "imagePickerPick"
+                            | "takeScreenshot"
                             | "networkGetStatus"
                             | "networkOnChange"
                             | "networkStopOnChange"

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 898 entries across 71 modules
+// Coverage: 900 entries across 71 modules
 
 declare module "argon2" {
   /** stdlib */
@@ -125,6 +125,8 @@ declare module "crypto" {
   export function createHash(...args: any[]): any;
   /** stdlib */
   export function createHmac(...args: any[]): any;
+  /** stdlib */
+  export function createSecretKey(...args: any[]): any;
   /** stdlib */
   export function getRandomValues(...args: any[]): any;
   /** stdlib */
@@ -767,6 +769,8 @@ declare module "perry/system" {
   export function preferencesGet(...args: any[]): any;
   /** stdlib */
   export function preferencesSet(...args: any[]): any;
+  /** stdlib */
+  export function takeScreenshot(...args: any[]): any;
 }
 
 declare module "perry/thread" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 898 entries across 71 modules.
+Total: 900 entries across 71 modules.
 
 ## Modules
 
@@ -230,6 +230,7 @@ Total: 898 entries across 71 modules.
 
 - `createHash` — module
 - `createHmac` — module
+- `createSecretKey` — module
 - `getRandomValues` — module
 - `md5` — module
 - `pbkdf2` — module
@@ -938,6 +939,7 @@ Total: 898 entries across 71 modules.
 - `openURL` — module
 - `preferencesGet` — module
 - `preferencesSet` — module
+- `takeScreenshot` — module
 
 ## `perry/thread`
 

--- a/test-files/test_take_screenshot.ts
+++ b/test-files/test_take_screenshot.ts
@@ -1,0 +1,18 @@
+// Smoke test for perry/system takeScreenshot() (issue #918).
+//
+// In CLI builds with no UI host attached, takeScreenshot() returns an
+// empty string. This test just confirms the function:
+//   - is callable from TypeScript (i.e. compiles and links),
+//   - returns a string (so typeof === "string"),
+//   - does not crash the runtime.
+//
+// On a UI-hosted build (macOS/iOS/tvOS/visionOS/GTK4/Windows/Android) the
+// returned string would be a base64-encoded PNG of the key window contents;
+// validating that requires a UI host so it's not exercised here.
+
+import { takeScreenshot } from "perry/system";
+
+const png = takeScreenshot();
+console.log("typeof:", typeof png);
+console.log("length:", png.length);
+console.log("ok");

--- a/types/perry/system/index.d.ts
+++ b/types/perry/system/index.d.ts
@@ -301,6 +301,37 @@ export function imagePickerPick(
 ): void;
 
 // -----------------------------------------------------------------------------
+// In-app screen capture (issue #918)
+//
+// Capture the contents of the key window as a PNG and return a base64-encoded
+// string. The returned value is the raw base64 payload (no `data:image/png;base64,`
+// prefix) so callers can prepend their own scheme or write the decoded bytes
+// to disk via `Buffer.from(s, "base64")` + `fs.writeFileSync`.
+//
+// Platform support:
+//   - macOS:   CGWindowListCreateImage on the key NSWindow.
+//   - iOS:     UIGraphics + drawViewHierarchyInRect on the key UIWindow.
+//   - tvOS:    UIGraphics on the key UIWindow (same as iOS).
+//   - visionOS: UIGraphics on the key UIWindow (same as iOS).
+//   - GTK4:    GtkWidget snapshot of the active GtkWindow.
+//   - Windows: GDI BitBlt of the active HWND, encoded with the `png` crate.
+//   - Android: Canvas-backed Bitmap of the root View, JNI-driven (geisterhand
+//              feature only — returns "" in plain builds).
+//   - watchOS: not supported — returns "".
+//   - CLI / headless builds with no UI host: returns "".
+//
+// The call is synchronous and runs on the calling thread. On macOS / iOS /
+// tvOS / visionOS it must run on the main thread (the AppKit/UIKit thread
+// the app was started on); calling from a background thread is undefined.
+// -----------------------------------------------------------------------------
+
+/**
+ * Capture the key window as a PNG and return a base64-encoded string.
+ * Returns `""` if no UI host is attached or capture fails on the platform.
+ */
+export function takeScreenshot(): string;
+
+// -----------------------------------------------------------------------------
 // Network reachability (issue #582)
 //
 // `networkGetStatus` invokes `cb` synchronously with the current connection


### PR DESCRIPTION
## Summary

Adds `takeScreenshot(): string` to `perry/system` — returns a base64-encoded PNG of the key window contents (no `data:image/png;base64,` prefix), or `""` if no UI host is attached (CLI builds) or capture fails on the platform.

## What's already there

Every platform UI crate already exposes `perry_ui_screenshot_capture(*mut usize) -> *mut u8` (returns malloc'd PNG bytes). It's the existing source of pixels for the geisterhand dev-server `/screenshot` endpoint and is registered via `perry_geisterhand_register_screenshot_capture` from each crate's `app.rs`. Implementations:

- macOS — `CGWindowListCreateImage` on the key `NSWindow`.
- iOS / tvOS / visionOS — UIKit `drawViewHierarchyInRect:afterScreenUpdates:` + `UIImagePNGRepresentation`.
- GTK4 — GtkWidget snapshot + cairo PNG.
- Windows — GDI `BitBlt` of the HWND + `png` crate encode.
- Android — Canvas-backed Bitmap of the root View via JNI (gated behind `geisterhand` feature).
- watchOS — no screenshot runtime exists.

## What's new

A thin `perry_system_take_screenshot()` wrapper per crate that calls the existing capturer, base64-encodes the PNG bytes, releases the malloc'd buffer with `libc::free`, and returns the result via `js_string_from_bytes`. Mirrors the `imagePickerPick` (#552) wiring exactly:

- **Runtime FFI** per crate (macos, ios, tvos, visionos, gtk4, windows, android): real impl. **watchOS**: empty-string stub (matches the existing pattern for unsupported platforms).
- **`crates/perry-dispatch/src/lib.rs`** — new `MethodRow` (`takeScreenshot` -> `perry_system_take_screenshot`, no args, `ReturnKind::Str`).
- **`crates/perry-api-manifest/src/entries.rs`** — new entry under `perry/system`.
- **`crates/perry/src/commands/compile/collect_modules.rs`** — add `takeScreenshot` to the UI-lib-trigger match arm so importing it auto-links the platform UI crate.
- **`types/perry/system/index.d.ts`** — typed `takeScreenshot(): string` with a JSDoc block listing per-platform support.
- **`docs/api/perry.d.ts`** + **`docs/src/api/reference.md`** — regenerated via `./scripts/regen_api_docs.sh` to keep `api-docs-drift` green.
- **`test-files/test_take_screenshot.ts`** — smoke test that confirms callability + non-crash in headless CLI builds (returns `""`).

`base64 = "0.22"` added to each platform UI crate's `Cargo.toml` (already a workspace dep, used in several other crates the same way).

## Scope (intentionally minimal)

- `takeScreenshotAsync(cb)` and `widgetCapture(widget, cb)` from the issue are **deferred to follow-up PRs** to keep this change tight.
- macOS window-server-side capture from #998/#999 (different security context) is also out of scope.

## Test plan

- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` — green.
- [x] `cargo build --release -p perry-ui-macos -p perry-dispatch -p perry-api-manifest` — green.
- [x] `cargo check --release -p perry-ui-ios -p perry-ui-tvos -p perry-ui-visionos -p perry-ui-watchos` — green on host (cross-platform target installs not available locally but the new code is straight cookie-cutter).
- [x] `cargo test --release -p perry-dispatch -p perry-api-manifest` — all 5 dispatch-drift tests pass (new row resolves through the central lookup).
- [x] `./scripts/regen_api_docs.sh` ran clean — `docs/api/perry.d.ts` + `docs/src/api/reference.md` regenerated and committed (no drift).
- [x] Smoke test compiles + runs without crashing on macOS CLI (no UI host): prints `typeof: string`, `length: 0`, `ok`.
- [ ] CI to verify `compile-smoke`, `parity`, `lint`, `cargo-test`, `api-docs-drift`, `security-audit`.

Closes #918