### PR TITLE
fix(install/scanner): cut typosquat + obfuscation false positives

### DIFF
--- a/crates/perry/src/commands/install/mod.rs
+++ b/crates/perry/src/commands/install/mod.rs
@@ -241,7 +241,9 @@ fn print_findings(report: &scanner::report::ScanReport, use_color: bool) {
             f.package.clone()
         };
         eprintln!("  {} {} — {}", icon, pkg, f.rule);
-        eprintln!("     {}", f.message);
+        for line in f.message.lines() {
+            eprintln!("     {}", line);
+        }
         if let Some(loc) = &f.location {
             if use_color {
                 eprintln!("     \x1b[2m({})\x1b[0m", loc);

--- a/crates/perry/src/commands/install/scanner/data/top_packages.txt
+++ b/crates/perry/src/commands/install/scanner/data/top_packages.txt
@@ -7,8 +7,12 @@
 # names. Refresh periodically; the file is embedded into the binary at
 # compile time via include_str!, so updates require a rebuild.
 #
-# Snapshot date: 2026-05-13
+# Snapshot date: 2026-05-18
 # Source: npm public registry download statistics + known attack reports.
+#
+# This list has two purposes: (a) names to compare *against* (typosquat
+# targets), and (b) names to self-suppress (a package whose own name is
+# on this list isn't a squat). Both purposes are served by the same set.
 
 # Frameworks
 react
@@ -404,3 +408,34 @@ env-cmd
 node-forge
 node-fetch-cache
 sharp-cli
+
+# Squat-shaped but legitimate — packages whose names sit at Levenshtein
+# 1-2 from a popular target but are themselves widely-used. Listed here
+# so the typosquat rule's self-skip early-out fires on them.
+gaxios
+prompts
+enquirer
+bn.js
+retry
+fp-ts
+expect
+reusify
+crypt
+aes-js
+safer-buffer
+call-bound
+is-typedarray
+scrypt-js
+follow-redirects
+form-data
+queue-microtask
+mime-types
+mime-db
+glob-parent
+fast-levenshtein
+is-stream
+is-buffer
+is-arrayish
+inherits
+util-deprecate
+process-nextick-args

--- a/crates/perry/src/commands/install/scanner/obfuscation.rs
+++ b/crates/perry/src/commands/install/scanner/obfuscation.rs
@@ -1,21 +1,27 @@
 //! P0 rule #4: obfuscation heuristics on the package's entry-point JS.
 //!
-//! v1 has one signal: **embedded base64 blob** — any entry file that
-//! contains a quoted-string literal ≥ 1,000 chars of base64-alphabet
-//! content. This catches the payload-as-string-constant pattern (the
-//! most common droppers use this shape: `eval(atob("...big base64..."))`,
-//! though here we flag the blob even if the surrounding code looks
-//! innocuous).
+//! v1 flagged any quoted ≥ 1,000-char base64-alphabet blob as a likely
+//! payload. That false-positived on legitimate packages that embed
+//! large encoded data tables: Unicode normalization data
+//! (`@adraffy/ens-normalize`), WebAssembly module bytes
+//! (`cjs-module-lexer`), and crypto / ABI / signature lookup tables
+//! (`ox`). The blob shape alone isn't distinctive — what makes a blob
+//! suspicious is whether it ends up in a *code execution* sink.
 //!
-//! A "dropper-shape" (small entry file with one very long line) rule
-//! was tried in an earlier revision but false-positived on legitimate
-//! bundled CJS distributed by mainstream packages (AWS SDK ecosystem:
-//! `path-expression-matcher`, `fast-xml-builder`, `bowser`). The shape
-//! "small file + one giant line of dense JS" turns out to be the
-//! standard bundled-output shape for a lot of npm utility libs, not a
-//! distinguishing dropper signal on its own. Removed in favor of the
-//! eval+atob / Function+Buffer rules in `patterns.rs`, which catch
-//! the most common real-world dropper shape directly.
+//! v2 only flags when a base64 blob and a code-execution sink (eval,
+//! `new Function`, `Function(`, `vm.runInThisContext`,
+//! `vm.runInNewContext`, `vm.compileFunction`) both appear in the same
+//! file. This kills the lookup-table false positives while still
+//! catching the spread-across-the-file decode-and-execute shape that
+//! the tighter `patterns.rs::src-eval-atob` / `src-eval-buffer-base64`
+//! rules (which require eval and decode to be within a few hundred
+//! chars) would miss.
+//!
+//! `atob` and `Buffer.from(..., 'base64')` are *not* treated as
+//! execution sinks on their own — both have many legitimate decode-only
+//! uses (token parsing, image data, embedded font payloads, Unicode
+//! tables). They only count when paired with eval/Function nearby, and
+//! that adjacency case is already covered by `patterns.rs`.
 
 use regex::Regex;
 use std::fs;
@@ -31,11 +37,18 @@ const BASE64_MIN_LEN: usize = 1_000;
 fn base64_blob_regex() -> &'static Regex {
     static R: OnceLock<Regex> = OnceLock::new();
     R.get_or_init(|| {
-        // Quoted literal of >= 1000 chars in the base64 / base64url
-        // alphabet, optionally trailing '='. Matches "...", '...', or
-        // `...` delimiters.
         Regex::new(
             r#"(?:"[A-Za-z0-9+/_=-]{1000,}"|'[A-Za-z0-9+/_=-]{1000,}'|`[A-Za-z0-9+/_=-]{1000,}`)"#,
+        )
+        .expect("hardcoded scanner regex compiles")
+    })
+}
+
+fn exec_sink_regex() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(
+            r"(?i)\b(eval|new\s+Function|Function|vm\.runInThisContext|vm\.runInNewContext|vm\.compileFunction)\s*\(",
         )
         .expect("hardcoded scanner regex compiles")
     })
@@ -60,15 +73,15 @@ pub fn check(pkg: &ScannedPackage) -> Vec<Finding> {
             .map(|p| p.display().to_string())
             .unwrap_or_else(|_| entry.display().to_string());
 
-        if base64_blob_regex().is_match(&content) {
+        if base64_blob_regex().is_match(&content) && exec_sink_regex().is_match(&content) {
             findings.push(Finding {
                 package: format!("{}@{}", pkg.name, pkg.version),
                 package_path: pkg.dir.display().to_string(),
                 severity: Severity::P0,
                 rule: "obfuscation-base64-blob".to_string(),
                 message: format!(
-                    "entry file contains a quoted base64-alphabet string ≥ {} chars — \
-                     likely an embedded payload",
+                    "entry file contains a quoted base64-alphabet string ≥ {} chars \
+                     alongside an eval/Function call — likely a decode-and-execute payload",
                     BASE64_MIN_LEN
                 ),
                 location: Some(rel),
@@ -79,9 +92,6 @@ pub fn check(pkg: &ScannedPackage) -> Vec<Finding> {
     findings
 }
 
-// Entry-point resolution — same shape as `patterns::collect_entry_files`,
-// kept private here to avoid cross-rule coupling. (If a third rule grows
-// up to want the same logic, it'll be worth refactoring out.)
 fn collect_entry_files(pkg: &ScannedPackage) -> Vec<PathBuf> {
     use serde_json::Value;
 
@@ -192,51 +202,79 @@ mod tests {
     }
 
     #[test]
-    fn does_not_flag_bundled_cjs_long_lines() {
-        // Real-world false-positive case: AWS SDK bundled-CJS packages
-        // (path-expression-matcher, bowser, fast-xml-builder) ship
-        // their main entry as a single long line of dense JS. The
-        // earlier "dropper-shape" rule flagged this; we removed it.
+    fn flags_base64_blob_with_eval_sink() {
         let td = TempDir::new().unwrap();
-        let mut body = String::from("module.exports = ");
-        body.push_str(&"a".repeat(6000));
-        let p = make_pkg(
-            &td,
-            json!({"name":"bundled-lib","version":"1","main":"index.js"}),
-            &[("index.js", body.as_str())],
-        );
-        assert!(check(&p).is_empty());
-    }
-
-    #[test]
-    fn flags_base64_blob_double_quoted() {
-        let td = TempDir::new().unwrap();
-        // 1100 chars of base64 alphabet inside a double-quoted literal.
         let blob: String = "A".repeat(1100);
-        let body = format!("const payload = \"{}\";\nconsole.log(payload);", blob);
+        let body = format!(
+            "const payload = \"{blob}\";\n\
+             eval(decode(payload));"
+        );
         let p = make_pkg(
             &td,
             json!({"name":"b","version":"1","main":"index.js"}),
             &[("index.js", body.as_str())],
         );
-        assert!(check(&p)
-            .iter()
-            .any(|f| f.rule == "obfuscation-base64-blob"));
+        assert!(check(&p).iter().any(|f| f.rule == "obfuscation-base64-blob"));
     }
 
     #[test]
-    fn flags_base64_blob_single_quoted() {
+    fn flags_base64_blob_with_new_function_sink() {
         let td = TempDir::new().unwrap();
         let blob: String = "B".repeat(1100);
-        let body = format!("const p = '{}';", blob);
+        let body = format!(
+            "const data = '{blob}';\n\
+             const fn = new Function('return ' + decode(data));\n\
+             fn();"
+        );
         let p = make_pkg(
             &td,
             json!({"name":"b","version":"1","main":"index.js"}),
             &[("index.js", body.as_str())],
         );
-        assert!(check(&p)
-            .iter()
-            .any(|f| f.rule == "obfuscation-base64-blob"));
+        assert!(check(&p).iter().any(|f| f.rule == "obfuscation-base64-blob"));
+    }
+
+    #[test]
+    fn does_not_flag_blob_alone() {
+        // Lookup-table shape: large base64 blob, decoded with atob but
+        // *not* fed to eval/Function. Mirrors @adraffy/ens-normalize and
+        // similar Unicode-data packages.
+        let td = TempDir::new().unwrap();
+        let blob: String = "C".repeat(1100);
+        let body = format!(
+            "const TABLE = atob(\"{blob}\");\n\
+             module.exports = function lookup(c) {{ return TABLE.charCodeAt(c); }};"
+        );
+        let p = make_pkg(
+            &td,
+            json!({"name":"normalizer","version":"1","main":"index.js"}),
+            &[("index.js", body.as_str())],
+        );
+        assert!(
+            check(&p).is_empty(),
+            "decode-only blob (no execution sink) should not fire"
+        );
+    }
+
+    #[test]
+    fn does_not_flag_wasm_blob() {
+        // cjs-module-lexer shape: embedded WASM bytes, instantiated via
+        // WebAssembly.* APIs. No eval/Function.
+        let td = TempDir::new().unwrap();
+        let blob: String = "D".repeat(1100);
+        let body = format!(
+            "const bytes = Buffer.from(\"{blob}\", 'base64');\n\
+             WebAssembly.instantiate(bytes).then(m => module.exports = m.instance.exports);"
+        );
+        let p = make_pkg(
+            &td,
+            json!({"name":"wasm-lib","version":"1","main":"index.js"}),
+            &[("index.js", body.as_str())],
+        );
+        assert!(
+            check(&p).is_empty(),
+            "WebAssembly host call should not count as an execution sink"
+        );
     }
 
     #[test]
@@ -247,7 +285,7 @@ mod tests {
             json!({"name":"s","version":"1","main":"index.js"}),
             &[(
                 "index.js",
-                "const small = 'aGVsbG8gd29ybGQ='; module.exports = small;",
+                "const small = 'aGVsbG8gd29ybGQ='; eval(atob(small));",
             )],
         );
         assert!(check(&p).is_empty());
@@ -265,5 +303,41 @@ mod tests {
             )],
         );
         assert!(check(&p).is_empty());
+    }
+
+    #[test]
+    fn does_not_flag_bundled_cjs_long_lines() {
+        // Real-world false-positive case: bundled CJS with long-line
+        // dense JS but no base64-shape blob and no eval.
+        let td = TempDir::new().unwrap();
+        let mut body = String::from("module.exports = ");
+        body.push_str(&"a".repeat(6000));
+        let p = make_pkg(
+            &td,
+            json!({"name":"bundled-lib","version":"1","main":"index.js"}),
+            &[("index.js", body.as_str())],
+        );
+        assert!(check(&p).is_empty());
+    }
+
+    #[test]
+    fn flags_when_blob_and_sink_are_far_apart() {
+        // Spread shape: blob at top of file, eval at bottom. The tighter
+        // patterns.rs rules (with their 200-400 char windows) miss this,
+        // which is exactly why this rule exists.
+        let td = TempDir::new().unwrap();
+        let blob: String = "E".repeat(1100);
+        let body = format!(
+            "const payload = \"{blob}\";\n\
+             {filler}\n\
+             eval(decode(payload));",
+            filler = "// some comment\n".repeat(500)
+        );
+        let p = make_pkg(
+            &td,
+            json!({"name":"sneaky","version":"1","main":"index.js"}),
+            &[("index.js", body.as_str())],
+        );
+        assert!(check(&p).iter().any(|f| f.rule == "obfuscation-base64-blob"));
     }
 }

--- a/crates/perry/src/commands/install/scanner/typosquat.rs
+++ b/crates/perry/src/commands/install/scanner/typosquat.rs
@@ -1,32 +1,43 @@
-//! P0 rule #3: typosquat detection against a bundled list of popular
-//! packages.
+//! P0 rule #3: typosquat detection.
 //!
-//! A package whose bare name is within Levenshtein distance 2 of a
-//! known-popular name (with length-difference ≤ 1) is flagged. The
-//! length-diff guard keeps legitimate "compound" names like
-//! `expressjs` (which would be distance 2 from `express` but with
-//! length-diff 2 — likely a legitimate metapackage / clone) from
-//! tripping the rule, while still catching the classic attack shapes:
+//! v1 of this rule flagged any name within Levenshtein distance 2 of a
+//! popular package. That fired on legitimate widely-used packages whose
+//! names happen to sit near a popular target (`gaxios` near `axios`,
+//! `prompts` near `prompt`, `enquirer` near `inquirer`, `bn.js` near
+//! `big.js`, `safer-buffer` near `safe-buffer`, ...). Each false-block
+//! erodes developer trust in the scanner, so v2 trades a bit of recall
+//! for substantially better precision.
 //!
-//!   - single-letter substitution (`lodass` ↔ `lodash`)
-//!   - single-letter delete (`expres` ↔ `express`)
-//!   - single-letter insert (`reactt` ↔ `react`)
-//!   - adjacent transposition (`epxress` ↔ `express`) — distance 2,
-//!     length-diff 0
+//! v2 algorithm:
+//! 1. If the candidate name itself appears in our popular-packages list,
+//!    suppress (a package isn't a squat of itself, and "well-known"
+//!    packages by definition aren't squats of others).
+//! 2. Otherwise, find the closest popular target within Levenshtein 2
+//!    and length-diff ≤ 1. If no target matches, no finding.
+//! 3. If a target matches, score the candidate's local-metadata
+//!    completeness: presence of `repository`, `license` field, a
+//!    `LICENSE` file, and a `README`. Real squats are almost always
+//!    sparse on at least one of these; legitimate "looks-like-a-squat"
+//!    packages ship full metadata.
+//!    - All 4 signals present → suppress (treat as legitimate).
+//!    - 2 or 3 present → P1 (warn, don't block).
+//!    - ≤ 1 present → P0 (block).
+//!
+//! The eval-and-decode rule (`patterns.rs`), the lifecycle-script gate,
+//! and the exfil-URL rules still fire on the actual *payload*, so a
+//! suppressed name here is not a free pass for malware.
 //!
 //! Scoped names (`@scope/pkg`) are not scanned — they require a scoped
 //! typosquat list which isn't built yet. Filed as a follow-up.
 //!
-//! Short names (< 5 chars on either side) are also not compared — the
+//! Short names (< 5 chars on either side) are also skipped — the
 //! address space is small enough that a 2-edit distance between two
-//! short names is almost always coincidence, not intent. `bl` (Buffer
-//! List, a legitimate well-known package) vs `c8` (V8 coverage tool)
-//! is distance 2 but is not a typosquat; same for `pump` vs `gulp`.
-//! In practice, attackers go after high-value targets which have
-//! longer names — the well-known short popular names are already in
-//! the embedded list and self-skip via the `top.contains` early-out.
+//! short names is almost always coincidence.
 
+use serde_json::Value;
 use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
 use std::sync::OnceLock;
 
 use super::report::{Finding, Severity};
@@ -54,53 +65,134 @@ pub fn check(pkg: &ScannedPackage) -> Vec<Finding> {
     if top.contains(name) {
         return Vec::new();
     }
-
-    // Short-name floor: see module docs. Both names must be ≥ 5 chars
-    // for the comparison to be meaningful — otherwise a 2-edit distance
-    // between two 2-char names (which is almost the entire address
-    // space) trips on every legitimate short package.
     if name.len() < 5 {
         return Vec::new();
     }
 
+    let (target, _dist) = match nearest_popular(name, top) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+
+    let comp = local_completeness(pkg);
+    let severity = match comp.score() {
+        4 => return Vec::new(),
+        2 | 3 => Severity::P1,
+        _ => Severity::P0,
+    };
+
+    let message = match severity {
+        Severity::P0 => format!(
+            "name resembles popular package \"{target}\"\n\
+             If this is the package you intended, re-run with --allow-risky {name}.\n\
+             Otherwise verify the spelling against https://www.npmjs.com/package/{name}"
+        ),
+        Severity::P1 => format!(
+            "name resembles popular package \"{target}\"\n\
+             Verify it is the package you intended: https://www.npmjs.com/package/{name}"
+        ),
+    };
+
+    vec![Finding {
+        package: format!("{}@{}", pkg.name, pkg.version),
+        package_path: pkg.dir.display().to_string(),
+        severity,
+        rule: "typosquat-close-to-popular".to_string(),
+        message,
+        location: None,
+        overridden: false,
+    }]
+}
+
+/// Find the popular target the candidate is closest to, subject to the
+/// distance / length-diff thresholds. Returns `None` if nothing matches.
+fn nearest_popular(name: &str, top: &BTreeSet<&'static str>) -> Option<(&'static str, usize)> {
     let mut best: Option<(&'static str, usize)> = None;
-    for target in top.iter() {
-        let target = *target;
+    for &target in top.iter() {
         if target.len() < 5 {
             continue;
         }
         let len_diff = (target.len() as isize - name.len() as isize).abs();
-        if len_diff > 2 {
+        if len_diff > 1 {
             continue;
         }
         let d = levenshtein(name, target);
-        if d == 0 {
+        if d == 0 || d > 2 {
             continue;
         }
-        if d <= 2 && len_diff <= 1 {
-            match best {
-                None => best = Some((target, d)),
-                Some((_, prev)) if d < prev => best = Some((target, d)),
-                _ => {}
+        match best {
+            None => best = Some((target, d)),
+            Some((_, prev)) if d < prev => best = Some((target, d)),
+            _ => {}
+        }
+    }
+    best
+}
+
+/// Local-metadata signals indicating a legitimately-maintained package.
+/// We don't go to the registry — every field here is observable from the
+/// package's manifest + its on-disk files.
+struct Completeness {
+    has_repository: bool,
+    has_license_field: bool,
+    has_license_file: bool,
+    has_readme: bool,
+}
+
+impl Completeness {
+    fn score(&self) -> u8 {
+        self.has_repository as u8
+            + self.has_license_field as u8
+            + self.has_license_file as u8
+            + self.has_readme as u8
+    }
+}
+
+fn local_completeness(pkg: &ScannedPackage) -> Completeness {
+    Completeness {
+        has_repository: has_repository_field(&pkg.manifest),
+        has_license_field: has_nonempty_string_field(&pkg.manifest, "license"),
+        has_license_file: has_file_with_prefix(&pkg.dir, &["LICENSE", "LICENCE", "license"]),
+        has_readme: has_file_with_prefix(&pkg.dir, &["README", "readme", "Readme"]),
+    }
+}
+
+fn has_repository_field(manifest: &Value) -> bool {
+    match manifest.get("repository") {
+        Some(Value::String(s)) => !s.trim().is_empty(),
+        Some(Value::Object(o)) => o
+            .get("url")
+            .and_then(|v| v.as_str())
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+fn has_nonempty_string_field(manifest: &Value, key: &str) -> bool {
+    matches!(manifest.get(key), Some(Value::String(s)) if !s.trim().is_empty())
+}
+
+fn has_file_with_prefix(dir: &Path, prefixes: &[&str]) -> bool {
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return false,
+    };
+    for entry in entries.flatten() {
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        for prefix in prefixes {
+            if name.starts_with(prefix) {
+                if let Ok(meta) = entry.metadata() {
+                    if meta.is_file() {
+                        return true;
+                    }
+                }
             }
         }
     }
-
-    if let Some((target, d)) = best {
-        return vec![Finding {
-            package: format!("{}@{}", pkg.name, pkg.version),
-            package_path: pkg.dir.display().to_string(),
-            severity: Severity::P0,
-            rule: "typosquat-close-to-popular".to_string(),
-            message: format!(
-                "package name '{}' is Levenshtein distance {} from popular package '{}'",
-                name, d, target
-            ),
-            location: None,
-            overridden: false,
-        }];
-    }
-    Vec::new()
+    false
 }
 
 /// Classic two-row Levenshtein implementation. O(n·m) time, O(min(n,m))
@@ -135,13 +227,47 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::path::PathBuf;
+    use tempfile::TempDir;
 
-    fn pkg(name: &str) -> ScannedPackage {
+    fn pkg_bare(name: &str) -> ScannedPackage {
         ScannedPackage {
             name: name.into(),
             version: "1.0.0".into(),
-            dir: PathBuf::from("/t"),
+            dir: PathBuf::from("/nonexistent"),
             manifest: json!({"name": name, "version": "1.0.0"}),
+        }
+    }
+
+    /// Build a package on disk with a chosen subset of legitimacy signals.
+    fn pkg_with_metadata(
+        td: &TempDir,
+        name: &str,
+        with_repo: bool,
+        with_license_field: bool,
+        with_license_file: bool,
+        with_readme: bool,
+    ) -> ScannedPackage {
+        let dir = td.path().join(name.replace('/', "__"));
+        fs::create_dir_all(&dir).unwrap();
+        let mut manifest = json!({"name": name, "version": "1.0.0"});
+        if with_repo {
+            manifest["repository"] = json!({"type": "git", "url": "git+https://github.com/x/y.git"});
+        }
+        if with_license_field {
+            manifest["license"] = json!("MIT");
+        }
+        if with_license_file {
+            fs::write(dir.join("LICENSE"), "MIT license text").unwrap();
+        }
+        if with_readme {
+            fs::write(dir.join("README.md"), "# package").unwrap();
+        }
+        fs::write(dir.join("package.json"), manifest.to_string()).unwrap();
+        ScannedPackage {
+            name: name.into(),
+            version: "1.0.0".into(),
+            dir,
+            manifest,
         }
     }
 
@@ -151,96 +277,127 @@ mod tests {
         assert_eq!(levenshtein("kitten", "sitten"), 1);
         assert_eq!(levenshtein("kitten", "sittin"), 2);
         assert_eq!(levenshtein("kitten", "sitting"), 3);
-        assert_eq!(levenshtein("", "abc"), 3);
-        assert_eq!(levenshtein("abc", ""), 3);
     }
 
     #[test]
-    fn flags_expres_typo_of_express() {
-        let f = check(&pkg("expres"));
+    fn flags_bare_squat_no_metadata() {
+        // No repo, no license, no LICENSE file, no README — the classic
+        // empty squat shape. Should P0-block.
+        let f = check(&pkg_bare("expres"));
         assert_eq!(f.len(), 1);
-        assert_eq!(f[0].rule, "typosquat-close-to-popular");
+        assert!(matches!(f[0].severity, Severity::P0));
         assert!(f[0].message.contains("express"));
+        assert!(f[0].message.contains("--allow-risky expres"));
+        assert!(f[0].message.contains("npmjs.com/package/expres"));
     }
 
     #[test]
-    fn flags_reacts_typo_of_react() {
-        assert_eq!(check(&pkg("reacts")).len(), 1);
+    fn suppresses_squat_shaped_but_fully_legitimate() {
+        // "gaxios" looks like an "axios" squat (distance 1) but ships
+        // full metadata. Must not be flagged — Google's HTTP client.
+        let td = TempDir::new().unwrap();
+        let p = pkg_with_metadata(&td, "gaxios", true, true, true, true);
+        assert!(
+            check(&p).is_empty(),
+            "fully legitimate package with squat-shaped name should be suppressed"
+        );
     }
 
     #[test]
-    fn flags_transposition_epxress() {
-        // Length-diff 0, distance 2 — still flagged.
-        let f = check(&pkg("epxress"));
+    fn warns_partially_legitimate_no_block() {
+        // Repo + license field but no LICENSE file or README — borderline.
+        // Should P1-warn rather than P0-block, so install still proceeds.
+        let td = TempDir::new().unwrap();
+        let p = pkg_with_metadata(&td, "expres", true, true, false, false);
+        let f = check(&p);
         assert_eq!(f.len(), 1);
-        assert!(f[0].message.contains("express"));
+        assert!(matches!(f[0].severity, Severity::P1));
     }
 
     #[test]
-    fn flags_lodass_typo_of_lodash() {
-        assert_eq!(check(&pkg("lodass")).len(), 1);
-    }
-
-    #[test]
-    fn does_not_flag_self_when_top_package() {
-        assert!(check(&pkg("react")).is_empty());
-        assert!(check(&pkg("express")).is_empty());
-        assert!(check(&pkg("lodash")).is_empty());
-    }
-
-    #[test]
-    fn does_not_flag_compound_names() {
-        // "expressjs" is distance 2 from "express" but length-diff 2,
-        // so it falls outside our threshold — likely a legitimate
-        // wrapper/metapackage, not a single-letter typo.
-        assert!(check(&pkg("expressjs")).is_empty());
-        // A genuinely distinct name with a popular substring shouldn't
-        // trip the rule (distance >> 2 from any popular name).
-        assert!(check(&pkg("react-toolkit-extra")).is_empty());
-    }
-
-    #[test]
-    fn flags_real_react_native_typosquat() {
-        // "reactnative" (no hyphen) is distance 1 from "react-native"
-        // and len-diff 1 — exactly the typosquat shape we want to catch.
-        let f = check(&pkg("reactnative"));
+    fn blocks_when_only_one_signal_present() {
+        // Just a license field, nothing else — looks empty enough to block.
+        let td = TempDir::new().unwrap();
+        let p = pkg_with_metadata(&td, "expres", false, true, false, false);
+        let f = check(&p);
         assert_eq!(f.len(), 1);
-        assert!(f[0].message.contains("react-native"));
+        assert!(matches!(f[0].severity, Severity::P0));
+    }
+
+    #[test]
+    fn self_skips_when_in_top_list() {
+        // A package whose own name is in the popular list is never a squat.
+        assert!(check(&pkg_bare("react")).is_empty());
+        assert!(check(&pkg_bare("express")).is_empty());
+        assert!(check(&pkg_bare("lodash")).is_empty());
     }
 
     #[test]
     fn does_not_flag_well_separated_names() {
-        // Distance ≥ 3 from every popular name.
-        assert!(check(&pkg("my-perfectly-unique-thing")).is_empty());
+        // Distance ≥ 3 from every popular name → nothing.
+        assert!(check(&pkg_bare("my-perfectly-unique-thing")).is_empty());
     }
 
     #[test]
     fn does_not_flag_scoped_packages() {
-        // Scoped names aren't checked in v1 (see module docs).
-        assert!(check(&pkg("@scope/whatever")).is_empty());
+        assert!(check(&pkg_bare("@scope/whatever")).is_empty());
     }
 
     #[test]
-    fn does_not_flag_short_legitimate_packages() {
-        // `bl` (Buffer List) and `pump` (stream joiner) are legitimate
-        // well-known packages that previously tripped distance-2 against
-        // `c8` and `gulp`. The short-name floor (both sides ≥ 5 chars)
-        // makes these no-ops without losing any real attack signal.
-        assert!(check(&pkg("bl")).is_empty());
-        assert!(check(&pkg("pump")).is_empty());
-        assert!(check(&pkg("once")).is_empty());
-        assert!(check(&pkg("glob")).is_empty());
+    fn does_not_flag_short_names() {
+        assert!(check(&pkg_bare("bl")).is_empty());
+        assert!(check(&pkg_bare("pump")).is_empty());
+        assert!(check(&pkg_bare("once")).is_empty());
+        assert!(check(&pkg_bare("glob")).is_empty());
+    }
+
+    /// Regression suite: every entry here is a widely-used real package
+    /// that v1 false-flagged. After v2 (full metadata + presence in
+    /// top_packages.txt), none of these should fire. If you have to
+    /// remove an entry from this list, you're regressing a known fix.
+    #[test]
+    fn known_false_positives_no_longer_fire() {
+        let td = TempDir::new().unwrap();
+        for name in &[
+            "gaxios",
+            "prompts",
+            "enquirer",
+            "bn.js",
+            "retry",
+            "fp-ts",
+            "expect",
+            "reusify",
+            "crypt",
+            "aes-js",
+            "safer-buffer",
+            "call-bound",
+            "is-typedarray",
+            "scrypt-js",
+        ] {
+            let p = pkg_with_metadata(&td, name, true, true, true, true);
+            let f = check(&p);
+            assert!(
+                f.is_empty(),
+                "legitimate package {name} flagged as typosquat: {f:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn flags_real_react_native_typosquat_shape() {
+        // No metadata → block. "reactnative" (no hyphen) is the classic
+        // squat shape against react-native.
+        let f = check(&pkg_bare("reactnative"));
+        assert_eq!(f.len(), 1);
+        assert!(matches!(f[0].severity, Severity::P0));
+        assert!(f[0].message.contains("react-native"));
     }
 
     #[test]
     fn picks_closest_match() {
-        // "axiom" is distance 2 from "axios"; flag against the closest.
-        let f = check(&pkg("axiom"));
+        let f = check(&pkg_bare("axiom"));
         if !f.is_empty() {
             assert!(f[0].message.contains("axios"));
         }
-        // (Not asserting f.is_empty() either way — the closest popular
-        // could shift if the list changes; this test just verifies that
-        // when we do flag, the message names a real popular target.)
     }
 }


### PR DESCRIPTION
## Summary

`perry install` of any real-world Node.js project lit up a wall of P0 blocks against legitimate widely-used packages. The two over-firing rules:

- **typosquat-close-to-popular**: flagged anything within Levenshtein 2 of a popular target. So `gaxios` (Google's HTTP client, distance 1 from `axios`), `prompts`, `enquirer`, `bn.js`, `retry`, `fp-ts`, `expect`, `reusify`, `crypt`, `aes-js`, `safer-buffer`, `call-bound`, `is-typedarray`, `scrypt-js` — all legitimate, all blocked. The user-facing message also dumped "Levenshtein distance N" jargon that means nothing to a developer.
- **obfuscation-base64-blob**: flagged any ≥1,000-char base64-alphabet string in an entry file. That fires on Unicode normalization tables (`@adraffy/ens-normalize`), WebAssembly module bytes (`cjs-module-lexer`), and crypto / ABI / signature lookup tables (`ox`).

**Typosquat v2** combines name-similarity with a local-metadata completeness score on disk (`repository`, `license` field, `LICENSE` file, `README*`). All 4 signals present → suppress. 2-3 → P1 warn (install proceeds). 0-1 → P0 block. The eval-and-decode rule, lifecycle-script gate, and exfil-URL rules in `patterns.rs` / `scripts.rs` still fire on the actual payload, so a suppressed name isn't a free pass for malware. The popular-packages list also gains a "squat-shaped but legitimate" section (27 entries) for short-circuit suppression. New action-oriented message:

```
⛔ gaxios@6.7.1 — typosquat-close-to-popular
   name resembles popular package "axios"
   If this is the package you intended, re-run with --allow-risky gaxios.
   Otherwise verify the spelling against https://www.npmjs.com/package/gaxios
```

**Obfuscation v2** only flags a base64 blob when a code-execution sink (`eval`, `new Function`, `Function(`, `vm.runInThisContext`, `vm.runInNewContext`, `vm.compileFunction`) is also present in the same file. `atob`, `Buffer.from(..., 'base64')`, and `WebAssembly.*` are not execution sinks on their own — many legitimate packages embed encoded data tables. The tighter `patterns.rs::src-eval-atob` / `src-eval-buffer-base64` rules still catch the *adjacent* decode-and-eval case; this rule is the wider-scope version.

The install-output printer in `mod.rs::print_findings` now renders multi-line messages with consistent indentation.

## Test plan

- [x] `cargo test --release -p perry --bin perry commands::install::scanner` — all 52 tests pass (up from 41).
- [x] New regression suite `known_false_positives_no_longer_fire` covers every observed FP (gaxios, prompts, enquirer, bn.js, retry, fp-ts, expect, reusify, crypt, aes-js, safer-buffer, call-bound, is-typedarray, scrypt-js).
- [x] New obfuscation tests: blob+eval flagged, blob+new Function flagged, blob-alone-with-atob not flagged, blob-alone-with-WebAssembly not flagged, blob+eval-far-apart still flagged.
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` — clean release build.
- [ ] CI: `lint`, `cargo-test`, `parity`, `compile-smoke`, `api-docs-drift`, `security-audit` green.