### PR TITLE
fix(runtime): native await of V8 Promise handle in jose JWT roundtrip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,112 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1004 — fix(runtime): `js_async_step_chain` awaits V8 Promise handles instead of treating them as primitives
+
+PR #1004 landed the marshalling layer for jose JWT (HS256) sign/verify
+end-to-end through the V8 fallback, but the compat sweep fixture at
+`/tmp/perry-compat-sweep/jose/entry.ts` — the end-to-end shape, not
+just the sign half — still failed with
+
+```
+[jsruntime_pump] event loop error: JWSInvalid: Compact JWS must be a
+string or Uint8Array
+    at compactVerify (.../jose/dist/node/esm/jws/compact/verify.js:9:15)
+    at jwtVerify (.../jose/dist/node/esm/jwt/verify.js:5:28)
+```
+
+The fixture is the canonical jose roundtrip — sign then immediately
+verify with the same secret:
+
+```ts
+const secret = new TextEncoder().encode("test-secret-key-32-bytes-aaaaaaaa");
+const jwt = await new SignJWT({ sub: "alice" })
+    .setProtectedHeader({ alg: "HS256" })
+    .setExpirationTime("1h")
+    .sign(secret);
+const { payload } = await jwtVerify(jwt, secret);
+console.log("sub=" + payload.sub);
+```
+
+A diagnostic probe revealed that `typeof jwt = "object"` and
+`String(jwt) = "[object Promise]"` — the await of `.sign(secret)` was
+returning the unresolved V8 Promise handle, not the JWT string. So
+when the next statement called `jwtVerify(jwt, secret)`, jose's
+`compactVerify` was being handed the Promise object as the token —
+hence the rejection.
+
+**Root cause:** `crates/perry-runtime/src/promise.rs:js_async_step_chain`
+(the hot path that perry's async-to-generator transform emits in place
+of `Promise.resolve(<await-value>).then(step, step)` per `await`)
+short-circuits via `is_definitely_primitive(value)`:
+
+```rust
+fn is_definitely_primitive(value: f64) -> bool {
+    let tag = value.to_bits() & TAG_MASK;
+    tag != POINTER_TAG  // POINTER_TAG = 0x7FFD
+}
+```
+
+That predicate is fine for STRING_TAG (0x7FFF), INT32_TAG (0x7FFE),
+BIGINT_TAG (0x7FFA), TAG_UNDEFINED, TAG_NULL, TAG_FALSE, TAG_TRUE,
+and raw f64 numbers — none of which can be promises or thenables. But
+**JS_HANDLE_TAG (0x7FFB)** — perry-jsruntime's NaN-box tag for a V8
+handle (function, object, **including a V8 Promise**) — also fails
+`tag == POINTER_TAG`, so `is_definitely_primitive` returns `true`,
+and the step dispatch enqueues the V8 Promise handle as the
+resolution value for the next async step instead of waiting on it.
+The next step then writes the handle directly into the user
+variable — and `typeof handle` is `"object"` (per `js_handle_typeof`
+returning `false` for non-function handles), `String(handle)` is
+`"[object Promise]"`, and `jwtVerify(jwt, ...)` sees the Promise
+itself as the token argument.
+
+`js_promise_resolved` (the unfused equivalent) already had this
+covered:
+
+```rust
+pub extern "C" fn js_promise_resolved(value: f64) -> *mut Promise {
+    let value = adapt_foreign_promise_value(value);  // ← this line
+    if is_definitely_primitive(value) { ... }
+    ...
+}
+```
+
+`adapt_foreign_promise_value` calls back into the registered
+foreign-promise adapter (perry-jsruntime's `js_await_any_promise`),
+which converts a JS_HANDLE_TAG V8 Promise into a native pending
+Promise. That native Promise carries POINTER_TAG, so the post-adapt
+value naturally fails `is_definitely_primitive` and falls into the
+existing `js_value_is_promise` arm that drives the thunk path.
+
+**Fix:** call `adapt_foreign_promise_value(value)` at the entry of
+both `js_async_step_chain` and `js_async_step_done`, mirroring the
+existing pattern in `js_promise_resolved`. Both helpers are on the
+async-fn hot path:
+
+- `js_async_step_chain` handles every per-`await` lowering in an
+  async fn: `return AsyncStepChain(stepValue, __step)`.
+- `js_async_step_done` handles `return <expr>` from inside an async
+  fn body, where `<expr>` could be a V8 Promise (an `async` function
+  returning a thenable is supposed to adopt its state per spec).
+
+Once both adapt, every code path that hands a V8 Promise into perry's
+async step machinery wraps it in a native pending Promise before the
+primitive check fires; the rest of the dispatch then handles it like
+any other native promise (waits for resolution, unwraps the value,
+hands it to the next step).
+
+`test-files/test_jose_signverify_roundtrip.ts` (new) pins the
+fixture-equivalent shape. Output now prints `sub=alice` end-to-end
+through Perry's V8 fallback. The existing `test_jose_sign.ts` (just
+the sign half) still passes — it never exercised the second `await`
+because the original task only printed `typeof token`.
+
+Other npm libs that combine `async` with a Promise-returning V8
+method — anything that does `await <V8-imported-function>(...)` —
+were silently affected by the same bug; this fix lifts them all
+without per-library work. Files: `crates/perry-runtime/src/promise.rs`.
+
 ## v0.5.1003 — fix(jsruntime): jose JWT (HS256) end-to-end through the V8 fallback
 
 `await new SignJWT({ sub: 'alice' }).setProtectedHeader({ alg: 'HS256' }).sign(key)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1003
+**Current Version:** 0.5.1004
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1003"
+version = "0.5.1004"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5446,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5458,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "base64",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5570,11 +5570,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1003"
+version = "0.5.1004"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "itoa",
  "jni",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
@@ -5618,7 +5618,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "block2",
  "libc",
@@ -5633,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "block2",
  "libc",
@@ -5651,11 +5651,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1003"
+version = "0.5.1004"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "block2",
  "libc",
@@ -5670,7 +5670,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "block2",
  "libc",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "block2",
  "libc",
@@ -5698,7 +5698,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "libc",
  "perry-runtime",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1003"
+version = "0.5.1004"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1003"
+version = "0.5.1004"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/promise.rs
+++ b/crates/perry-runtime/src/promise.rs
@@ -1656,6 +1656,21 @@ pub extern "C" fn js_promise_resolved_then(
 ///     directly by the runner).
 #[no_mangle]
 pub extern "C" fn js_async_step_chain(value: f64, step_closure: ClosurePtr) -> *mut Promise {
+    // PR #1004 followup: if `value` is a JS_HANDLE_TAG handle to a V8
+    // Promise (the common case for `await <V8-fallback-call>(...)` —
+    // e.g. `await new SignJWT(...).sign(key)` in jose), convert it to
+    // a native pending Promise before any of the dispatch logic looks
+    // at it. Without this, `is_definitely_primitive(value)` returns
+    // true for the handle (only POINTER_TAG values are non-primitive),
+    // so the V8 Promise gets enqueued as the resolution value directly
+    // — the next async step then sees the unresolved Promise object
+    // as the `await` result, and code that expects the inner value
+    // (e.g. jose's `jwtVerify(jwt, key)` where `jwt` should be a
+    // string) observes `[object Promise]` instead. The other arms of
+    // this function already handle native pending Promises correctly
+    // via the `js_value_is_promise` + thunk path.
+    let value = adapt_foreign_promise_value(value);
+
     // Reuse predicate. `next` reuse is sound only when AsyncStepChain
     // is being called from the body of the SAME step closure that the
     // runner is currently dispatching. Two readers of INLINE_TRAP pose
@@ -1778,6 +1793,15 @@ pub extern "C" fn js_async_step_chain(value: f64, step_closure: ClosurePtr) -> *
 /// Fall back to `js_promise_resolved(value)`.
 #[no_mangle]
 pub extern "C" fn js_async_step_done(value: f64, step_closure: ClosurePtr) -> *mut Promise {
+    // PR #1004 followup (sibling to js_async_step_chain): adapt a
+    // JS_HANDLE_TAG V8 Promise into a native Promise before storing it
+    // as the resolution value, so `async function f() { return
+    // v8Promise; }` produces a Promise that resolves to the inner
+    // value (per ES spec for an async fn returning a thenable) instead
+    // of a Promise whose resolution value is the unresolved V8 Promise
+    // handle.
+    let value = adapt_foreign_promise_value(value);
+
     let trap = INLINE_TRAP.with(|c| c.get());
     if !trap.trap_next.is_null() && trap.current_step == step_closure as usize {
         bump(&MT_STEP_DONE_REUSE_HIT);

--- a/test-files/test_jose_signverify_roundtrip.ts
+++ b/test-files/test_jose_signverify_roundtrip.ts
@@ -1,0 +1,31 @@
+// Issue #819: end-to-end sign + verify roundtrip through the V8 fallback.
+//
+// Pre-fix: `js_async_step_chain(value, step)` checked
+// `is_definitely_primitive(value)` which only treated POINTER_TAG values
+// as non-primitive. A V8 Promise crossing the bridge comes back as a
+// JS_HANDLE_TAG (0x7FFB) value, which slipped through the primitive
+// check — the dispatch then enqueued the unresolved V8 Promise handle
+// as the resolution value for the next async step, so `jwt` in user
+// code observed `[object Promise]` instead of the signed JWT string.
+// jose's `jwtVerify(jwt, key)` then threw `JWSInvalid: Compact JWS
+// must be a string or Uint8Array`.
+//
+// The fix routes the value through `adapt_foreign_promise_value`
+// before the primitive check, which calls back into the registered
+// jsruntime adapter to wrap the V8 Promise in a native pending Promise
+// the rest of the dispatch already handles correctly.
+//
+// This mirrors `/tmp/perry-compat-sweep/jose/entry.ts` from the
+// compat sweep; expected output is `sub=alice`.
+import { SignJWT, jwtVerify } from "jose";
+
+async function main() {
+    const secret = new TextEncoder().encode("test-secret-key-32-bytes-aaaaaaaa");
+    const jwt = await new SignJWT({ sub: "alice" })
+        .setProtectedHeader({ alg: "HS256" })
+        .setExpirationTime("1h")
+        .sign(secret);
+    const { payload } = await jwtVerify(jwt, secret);
+    console.log("sub=" + payload.sub);
+}
+main();


### PR DESCRIPTION
## Summary

PR #1004 followup. The jose end-to-end sweep fixture (`/tmp/perry-compat-sweep/jose/entry.ts` — sign then immediately verify with the same secret) still failed after #1004 with `JWSInvalid: Compact JWS must be a string or Uint8Array`. A diagnostic probe revealed `typeof jwt = "object"` and `String(jwt) = "[object Promise]"` — `await new SignJWT(...).sign(secret)` was returning the unresolved V8 Promise handle to user code, so jose's `jwtVerify(jwt, secret)` received the Promise object as the token.

**Root cause:** `crates/perry-runtime/src/promise.rs:js_async_step_chain` (the hot path the async-to-generator transform emits in place of `Promise.resolve(value).then(step, step)` per `await`) short-circuits via `is_definitely_primitive(value)`, which is `tag != POINTER_TAG`. `JS_HANDLE_TAG` (0x7FFB) — the bridge tag for a V8 handle including a V8 Promise — fails that check the same way `STRING_TAG` does, so the V8 Promise gets enqueued directly as the next step's resolution value. `js_promise_resolved` (the unfused equivalent) already routes through `adapt_foreign_promise_value` to wrap a foreign Promise as a native pending Promise; the fused step-chain path was missing the same line.

**Fix:** route `value` through `adapt_foreign_promise_value` at the entry of both `js_async_step_chain` and `js_async_step_done`. The adapter calls into perry-jsruntime's `js_await_any_promise`, which wraps a V8 Promise in a native pending Promise (POINTER_TAG) the rest of the dispatch already handles via the `js_value_is_promise` arm.

Other npm libs that combine `async` with a Promise-returning V8 method — anything that does `await <V8-imported-function>(...)` — were silently affected by the same bug; this fix lifts them all without per-library work.

## Test plan

- [x] `test-files/test_jose_signverify_roundtrip.ts` (new) — pins the SignJWT → jwtVerify roundtrip; prints `sub=alice`.
- [x] Original sweep fixture at `/tmp/perry-compat-sweep/jose/entry.ts` — now prints `sub=alice`.
- [x] Existing `test_jose_sign.ts` still passes (regression check on the sign-only smoke).
- [ ] CI parity / smoke gate.

## Files

- `crates/perry-runtime/src/promise.rs` — `adapt_foreign_promise_value` at the entry of `js_async_step_chain` and `js_async_step_done`.
- `test-files/test_jose_signverify_roundtrip.ts` — new fixture.
- `Cargo.toml` / `CLAUDE.md` — `0.5.1003` → `0.5.1004`.
- `CHANGELOG.md` — full writeup under `v0.5.1004`.