### PR TITLE
chore: cargo fmt --all on #1009 / #1011 leftovers

### DIFF
--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -1041,9 +1041,7 @@ pub(crate) fn is_promise_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
                     return true;
                 }
                 // `Array.fromAsync(...)` returns a Promise<Array>.
-                if property == "fromAsync"
-                    && is_global_builtin_named(object.as_ref(), "Array")
-                {
+                if property == "fromAsync" && is_global_builtin_named(object.as_ref(), "Array") {
                     return true;
                 }
                 // `.then(cb)` / `.catch(cb)` / `.finally(cb)` on a promise

--- a/crates/perry-runtime/src/builtins.rs
+++ b/crates/perry-runtime/src/builtins.rs
@@ -1009,8 +1009,7 @@ pub extern "C" fn js_util_format(arr_ptr: *const crate::array::ArrayHeader) -> f
             return String::new();
         }
         let len = (*s_ptr).byte_len as usize;
-        let data =
-            (s_ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+        let data = (s_ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
         let bs = std::slice::from_raw_parts(data, len);
         std::str::from_utf8(bs).unwrap_or("").to_string()
     }
@@ -1019,8 +1018,7 @@ pub extern "C" fn js_util_format(arr_ptr: *const crate::array::ArrayHeader) -> f
     }
     unsafe {
         let length = (*arr_ptr).length as usize;
-        let data_ptr = (arr_ptr as *const u8)
-            .add(std::mem::size_of::<crate::array::ArrayHeader>())
+        let data_ptr = (arr_ptr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>())
             as *const f64;
 
         // No format string → empty result. Node returns "" for


### PR DESCRIPTION
Both #1009 and #1011 were admin-merged with lint red. cargo fmt's only complaint is two trivial line-break collapses in the code those PRs touched. Landing the cleanup so subsequent PRs don't inherit a red lint on top of their own diffs.

Mechanical `cargo fmt --all` output — no semantic change.