### PR TITLE
feat(tui): JSX intrinsic rewriter for <Box>/<Text> (#689)

### DIFF
--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -402,6 +402,235 @@ fn emit_own_method_override_check(
     )
 }
 
+/// Sentinel prefix the HIR's `lower_jsx_element_name` stamps onto an
+/// `ExternFuncRef` when a JSX element name (e.g. `<Box>`) resolves to a
+/// function imported from a native Perry module. Format:
+/// `__perry_jsx_intrinsic::<module>::<method>__`.
+///
+/// Mirrors the producer in `crates/perry-hir/src/jsx.rs`. See
+/// `try_rewrite_perry_tui_jsx_intrinsic` for the codegen consumer.
+const JSX_INTRINSIC_SENTINEL_PREFIX: &str = "__perry_jsx_intrinsic::";
+const JSX_INTRINSIC_SENTINEL_SUFFIX: &str = "__";
+
+/// Decode an ExternFuncRef name into `(module, method)` if it carries
+/// the JSX-intrinsic sentinel. Returns `None` for anything else — that's
+/// the signal to fall back to the generic `js_jsx` runtime adapter.
+fn decode_jsx_intrinsic_sentinel(name: &str) -> Option<(&str, &str)> {
+    let inner = name
+        .strip_prefix(JSX_INTRINSIC_SENTINEL_PREFIX)?
+        .strip_suffix(JSX_INTRINSIC_SENTINEL_SUFFIX)?;
+    let (module, method) = inner.rsplit_once("::")?;
+    Some((module, method))
+}
+
+/// Pop the `"children"` field out of a JSX props object literal,
+/// returning the remaining props and the children expression (if any).
+/// JSX props arrive as `Expr::Object(fields)` from
+/// `crates/perry-hir/src/jsx.rs`; non-Object shapes (e.g. `Expr::Null`
+/// when an element has no attrs and no children) yield empty fields and
+/// a None children expression.
+fn split_children_from_props(props: &Expr) -> (Vec<(String, Expr)>, Option<Expr>) {
+    let fields: Vec<(String, Expr)> = match props {
+        Expr::Object(fields) => fields.clone(),
+        _ => Vec::new(),
+    };
+    let mut other: Vec<(String, Expr)> = Vec::with_capacity(fields.len());
+    let mut children: Option<Expr> = None;
+    for (k, v) in fields.into_iter() {
+        if k == "children" {
+            children = Some(v);
+        } else {
+            other.push((k, v));
+        }
+    }
+    (other, children)
+}
+
+/// JSX intrinsic rewriter for `perry/tui` built-in widgets (issue #689).
+///
+/// The HIR's JSX lowering (`crates/perry-hir/src/jsx.rs`) emits
+/// `Call { callee: ExternFuncRef("jsx"|"jsxs"), args: [type, props] }`
+/// for every JSX element. When the JSX name (`<Box>` / `<Text>`)
+/// resolves to a native-module-imported intrinsic, the HIR stamps the
+/// type ExternFuncRef with a sentinel name encoding the source module
+/// + exported method — see `JSX_INTRINSIC_SENTINEL_PREFIX`.
+///
+/// This function decodes the sentinel and, for `perry/tui::Box` and
+/// `perry/tui::Text` specifically, rewrites the JSX-shaped call into a
+/// direct `NativeMethodCall` that goes through
+/// `lower_native_method_call` — i.e. the exact same lowering as the
+/// function-call form `Box(opts, children)` / `Text(content, opts)`.
+/// The user-component path (`<App />` where `App` is a closure) is
+/// unaffected because that lowers as `ExternFuncRef("App")` /
+/// `LocalGet(...)`, neither of which carries the intrinsic sentinel.
+///
+/// Returns `Ok(Some(call_value))` if a rewrite happened, `Ok(None)` to
+/// fall through to the generic `js_jsx` adapter.
+///
+/// Coverage today (v1):
+/// - `perry/tui::Box` — pops `children` out of props, packs remaining
+///   props into a style options object, wraps a single child in a
+///   one-element array, dispatches `Box(opts, children)`.
+/// - `perry/tui::Text` — pops `children` out of props as the content
+///   string, dispatches `Text(content, opts)` for the styled form or
+///   `Text(content)` for the bare form.
+///
+/// Follow-up scope (#689): Spacer, Input, Spinner, List, Select,
+/// ProgressBar, Table, Tabs, TextArea. All currently fall through to
+/// `js_jsx` and return TAG_UNDEFINED until the rewriter is extended.
+fn try_rewrite_perry_tui_jsx_intrinsic(
+    ctx: &mut FnCtx<'_>,
+    _is_jsxs: bool,
+    args: &[Expr],
+) -> Result<Option<String>> {
+    // `jsx(type, props)` always arrives with exactly two args. Anything
+    // else is unexpected — let it fall through to the runtime adapter
+    // so the user sees the diagnostic from the failure-mode path
+    // instead of a silent rewrite.
+    let (type_arg, props_arg) = match args {
+        [t, p] => (t, p),
+        _ => return Ok(None),
+    };
+
+    let Expr::ExternFuncRef { name: type_name, .. } = type_arg else {
+        return Ok(None);
+    };
+    let Some((module, method)) = decode_jsx_intrinsic_sentinel(type_name) else {
+        return Ok(None);
+    };
+
+    // V1: only `perry/tui::Box` and `perry/tui::Text` are rewritten.
+    // Other native modules / other perry/tui intrinsics fall through.
+    if module != "perry/tui" {
+        return Ok(None);
+    }
+
+    match method {
+        "Box" => Some(rewrite_jsx_box(ctx, props_arg)).transpose(),
+        "Text" => Some(rewrite_jsx_text(ctx, props_arg)).transpose(),
+        _ => Ok(None),
+    }
+}
+
+/// Rewrite `jsx(Box, { …props…, children })` into the `Box(opts, children_array)`
+/// function-call form, then dispatch through `lower_native_method_call`.
+/// `<Box>` with no children lowers to `Box(opts)` (1-arg shape, which
+/// the dispatch table handles).
+fn rewrite_jsx_box(ctx: &mut FnCtx<'_>, props_arg: &Expr) -> Result<String> {
+    let (other_props, children_opt) = split_children_from_props(props_arg);
+
+    // Build the children-array arg.
+    //
+    // JSX's single-child path emits `children: <expr>` directly (NOT
+    // wrapped in an array); the multi-child path emits
+    // `children: Expr::Array([...])`. Three children shapes to
+    // distinguish:
+    //
+    // 1. `Expr::Array([...])` — multi-child JSX. Pass through; the
+    //    Box dispatch iterates the elements at compile time.
+    // 2. `Expr::Call { callee: ExternFuncRef("jsx"|"jsxs") }` — single
+    //    JSX widget child (e.g. `<Box><Text>hi</Text></Box>`). Wrap
+    //    in `Array([child])` so the Box dispatch sees one widget at
+    //    compile time. Without the wrap, Box would route this through
+    //    `js_perry_tui_box_add_children_array` and crash trying to
+    //    read array headers from a widget handle.
+    // 3. Anything else — a runtime expression that evaluates to a
+    //    widget *array* (e.g. `<Box>{labels.map(l => <Text>{l}</Text>)}</Box>`).
+    //    Pass through so Box uses its runtime
+    //    `js_perry_tui_box_add_children_array` iterator. This matches
+    //    React/ink semantics: `{arr}` as a single child is flattened.
+    //    A `LocalGet` holding a single widget value is the one shape
+    //    this heuristic gets wrong; users with that pattern should
+    //    wrap explicitly: `<Box>{[w]}</Box>`.
+    let children_array_opt: Option<Expr> = children_opt.map(|c| match &c {
+        Expr::Array(_) => c,
+        Expr::Call { callee, .. } if is_jsx_call_callee(callee) => Expr::Array(vec![c]),
+        _ => c,
+    });
+
+    let opts_expr = Expr::Object(other_props);
+
+    let synth_args: Vec<Expr> = match children_array_opt {
+        Some(children) => vec![opts_expr, children],
+        None => vec![opts_expr],
+    };
+
+    lower_native_method_call(ctx, "perry/tui", None, "Box", None, &synth_args)
+}
+
+/// True if `callee` is the HIR's marker for a JSX call (either the
+/// generic `jsx`/`jsxs` adapter, or one of the intrinsic-sentinel
+/// `ExternFuncRef`s the HIR stamps onto perry/tui widget tags). Used
+/// by `rewrite_jsx_box` to recognise single-widget children that need
+/// to be wrapped in a one-element array before reaching the Box
+/// dispatch.
+fn is_jsx_call_callee(callee: &Expr) -> bool {
+    matches!(
+        callee,
+        Expr::ExternFuncRef { name, .. }
+            if name == "jsx"
+                || name == "jsxs"
+                || name.starts_with(JSX_INTRINSIC_SENTINEL_PREFIX)
+    )
+}
+
+/// Rewrite `jsx(Text, { …style…, children })` into the `Text(content, opts)`
+/// function-call form, then dispatch through `lower_native_method_call`.
+/// Single-child `<Text>{x}</Text>` passes the child as the content.
+/// Multi-child `<Text>count: {n}</Text>` concatenates the children with
+/// `+` so the runtime gets a single string content — ink behaves the
+/// same way (children are folded into one rendered string).
+fn rewrite_jsx_text(ctx: &mut FnCtx<'_>, props_arg: &Expr) -> Result<String> {
+    let (other_props, children_opt) = split_children_from_props(props_arg);
+
+    // Pick the content expression.
+    // - `None` (no children) → empty string. Matches `<Text></Text>`
+    //   behaviour in ink (renders an empty line).
+    // - `Some(Array([...]))` from `jsxs` (>1 child) → fold the elements
+    //   together with binary `+`. Perry's runtime promotes both sides
+    //   to strings when either operand is a string, so `"count: " + n`
+    //   yields the same value the function-call form
+    //   `Text("count: " + n)` would.
+    // - `Some(_)` otherwise → use the value directly.
+    let content_expr: Expr = match children_opt {
+        Some(Expr::Array(elems)) => fold_string_concat(elems),
+        Some(other) => other,
+        None => Expr::String(String::new()),
+    };
+
+    // If there are style props, dispatch the 2-arg styled form;
+    // otherwise drop into the 1-arg bare form so the dispatch table
+    // routes straight to `js_perry_tui_text`.
+    let synth_args: Vec<Expr> = if other_props.is_empty() {
+        vec![content_expr]
+    } else {
+        vec![content_expr, Expr::Object(other_props)]
+    };
+
+    lower_native_method_call(ctx, "perry/tui", None, "Text", None, &synth_args)
+}
+
+/// Left-fold a list of expressions into `a + b + c + …`. Used by
+/// `rewrite_jsx_text` to flatten multi-child `<Text>foo {x} bar</Text>`
+/// into a single content string before handing off to the perry/tui
+/// Text dispatch. Empty input returns the empty string literal so the
+/// runtime renders an empty line (parity with ink).
+fn fold_string_concat(mut elems: Vec<Expr>) -> Expr {
+    if elems.is_empty() {
+        return Expr::String(String::new());
+    }
+    let mut iter = elems.drain(..);
+    let mut acc = iter.next().unwrap();
+    for next in iter {
+        acc = Expr::Binary {
+            op: perry_hir::BinaryOp::Add,
+            left: Box::new(acc),
+            right: Box::new(next),
+        };
+    }
+    acc
+}
+
 /// Lower a `Call` expression. Two shapes are supported:
 /// 1. `FuncRef(id)(args...)` — direct call to a user function by HIR id.
 /// 2. `console.log(expr)` where `expr` lowers to a double — emits a
@@ -939,7 +1168,26 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
             // stubs that return TAG_UNDEFINED; real JSX rendering should be
             // implemented by importing a JSX runtime package (e.g. react or
             // preact) via the `perry.compilePackages` mechanism.
+            //
+            // perry/tui JSX intrinsic rewriter (#689). When the first arg
+            // is `ExternFuncRef { name: "__perry_jsx_intrinsic::<mod>::<method>__" }`
+            // (the HIR's marker for `<Box>` / `<Text>` resolved against a
+            // native module — see `crates/perry-hir/src/jsx.rs`), bypass
+            // the runtime `js_jsx` adapter entirely and route the call
+            // through `lower_native_method_call` so the JSX form lowers
+            // to the same widget builder the function-call form would.
+            // Today this covers Box + Text from `perry/tui`; other
+            // intrinsics (Spacer / Input / Spinner / List / Select /
+            // ProgressBar / Table / Tabs / TextArea) are listed as
+            // follow-up scope in #689 and continue to fall through to
+            // `js_jsx` (returns TAG_UNDEFINED until the rewriter is
+            // extended).
             "jsx" | "jsxs" => {
+                if let Some(call) =
+                    try_rewrite_perry_tui_jsx_intrinsic(ctx, name == "jsxs", args)?
+                {
+                    return Ok(call);
+                }
                 let runtime_fn = if name == "jsx" { "js_jsx" } else { "js_jsxs" };
                 let mut lowered: Vec<String> = Vec::with_capacity(args.len());
                 for a in args {

--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -492,7 +492,10 @@ fn try_rewrite_perry_tui_jsx_intrinsic(
         _ => return Ok(None),
     };
 
-    let Expr::ExternFuncRef { name: type_name, .. } = type_arg else {
+    let Expr::ExternFuncRef {
+        name: type_name, ..
+    } = type_arg
+    else {
         return Ok(None);
     };
     let Some((module, method)) = decode_jsx_intrinsic_sentinel(type_name) else {
@@ -1183,8 +1186,7 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
             // `js_jsx` (returns TAG_UNDEFINED until the rewriter is
             // extended).
             "jsx" | "jsxs" => {
-                if let Some(call) =
-                    try_rewrite_perry_tui_jsx_intrinsic(ctx, name == "jsxs", args)?
+                if let Some(call) = try_rewrite_perry_tui_jsx_intrinsic(ctx, name == "jsxs", args)?
                 {
                     return Ok(call);
                 }

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -1041,9 +1041,7 @@ pub(crate) fn is_promise_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
                     return true;
                 }
                 // `Array.fromAsync(...)` returns a Promise<Array>.
-                if property == "fromAsync"
-                    && is_global_builtin_named(object.as_ref(), "Array")
-                {
+                if property == "fromAsync" && is_global_builtin_named(object.as_ref(), "Array") {
                     return true;
                 }
                 // `.then(cb)` / `.catch(cb)` / `.finally(cb)` on a promise

--- a/crates/perry-hir/src/jsx.rs
+++ b/crates/perry-hir/src/jsx.rs
@@ -143,6 +143,27 @@ pub(crate) fn lower_jsx_element_name(
                     Ok(Expr::LocalGet(id))
                 } else if let Some(id) = ctx.lookup_func(&n) {
                     Ok(Expr::FuncRef(id))
+                } else if let Some((module_name, method_name)) = ctx.lookup_native_module(&n) {
+                    // Native-module-imported JSX intrinsic (e.g. `<Box>` /
+                    // `<Text>` from `perry/tui`). Tag the ExternFuncRef
+                    // with a sentinel name
+                    // `__perry_jsx_intrinsic::<module>::<method>__` so the
+                    // codegen's `jsx`/`jsxs` arm can recognise it as a
+                    // built-in intrinsic and rewrite the runtime `js_jsx`
+                    // call into a direct widget-builder call. Including
+                    // the module name in the sentinel ensures the
+                    // rewriter only triggers when the JSX-named
+                    // identifier resolves to a known native module —
+                    // never a user-defined `Box` from elsewhere
+                    // (issue #689).
+                    let module = module_name.to_string();
+                    let method = method_name.unwrap_or(&n).to_string();
+                    let sentinel = format!("__perry_jsx_intrinsic::{module}::{method}__");
+                    Ok(Expr::ExternFuncRef {
+                        name: sentinel,
+                        param_types: Vec::new(),
+                        return_type: Type::Any,
+                    })
                 } else if let Some(orig) = ctx.lookup_imported_func(&n) {
                     Ok(Expr::ExternFuncRef {
                         name: orig.to_string(),

--- a/test-files/test_issue_679_perry_tui_jsx_audit.tsx
+++ b/test-files/test_issue_679_perry_tui_jsx_audit.tsx
@@ -7,17 +7,17 @@
 //     as a closure pointer and invokes it.
 //  2. JSX-as-call-expression: `const w = <Comp x={1} />` is just an
 //     expression returning whatever Comp returns.
+//  3. Built-in widget intrinsics (#689): `<Box>` / `<Text>` lower
+//     through the codegen rewriter in `crates/perry-codegen/src/lower_call.rs`
+//     so the JSX form is interchangeable with the function-call form
+//     `Box([...])` / `Text("…")`. Acceptance below covers single-child,
+//     multi-child, and styled variants.
 //
-// What does NOT yet lower cleanly through JSX (deferred follow-up):
-//
-//  3. Built-in widget intrinsics: `<Box flexDirection="row">...</Box>`
-//     and `<Text color="red">...</Text>` lower to `jsx(Box, props)` and
-//     today fall through to TAG_UNDEFINED. The function-call form
-//     `Box({ flexDirection: "row" }, [Text("…", { fg: "red" })])` still
-//     works as documented in #358 Phase 3+.
-//
-// Workaround: stay on function-call form for Box/Text intrinsics until
-// the Box/Text JSX compile-time rewriter lands.
+// Follow-up scope (not covered here):
+//  - JSX form for Spacer / Input / Spinner / List / Select / ProgressBar
+//    / Table / Tabs / TextArea — the rewriter today only handles
+//    Box + Text (#689 v1). Those intrinsics still need the function-call
+//    form and continue to fall through to TAG_UNDEFINED in JSX form.
 
 import { Box, Text, render } from "perry/tui";
 
@@ -38,8 +38,44 @@ const t = <Tag />;
 render(Box([t]));
 console.log("\n--- no-props JSX ok ---");
 
+// 3a. JSX form: bare Box wrapping a bare Text — the simplest shape that
+//     used to fall through to TAG_UNDEFINED before #689. The rewriter
+//     turns `jsx(Box, { children: jsx(Text, { children: "hello" }) })`
+//     into `Box([Text("hello")])` at compile time.
+const bareBoxText = <Box><Text>hello</Text></Box>;
+render(bareBoxText);
+console.log("\n--- jsx Box+Text ok ---");
+
+// 3b. JSX form: Box with style props + multi-child Text array. Mirrors
+//     ink's typical row layout. The rewriter pops `children` out of the
+//     props object before forwarding the remaining keys as the style
+//     opts arg, and packs the child array as the second positional arg.
+const styledRow = (
+    <Box flexDirection="row" gap={2}>
+        <Text color="red">red</Text>
+        <Text color="green">green</Text>
+        <Text color="blue">blue</Text>
+    </Box>
+);
+render(styledRow);
+console.log("\n--- jsx styled row ok ---");
+
+// 3c. JSX form: Text-only call with style options on Text itself. The
+//     rewriter routes through the 2-arg `Text(content, opts)` dispatch
+//     so `bold` / `color` etc. land on `js_perry_tui_text_styled`.
+const styledText = <Text color="yellow" bold={true}>bold yellow</Text>;
+render(Box([styledText]));
+console.log("\n--- jsx styled Text ok ---");
+
 /*
 @covers
 crates/perry-runtime/src/jsx.rs:
+  - js_jsx
   - js_jsxs
+crates/perry-codegen/src/lower_call.rs:
+  - try_rewrite_perry_tui_jsx_intrinsic
+  - rewrite_jsx_box
+  - rewrite_jsx_text
+crates/perry-hir/src/jsx.rs:
+  - lower_jsx_element_name (native-module sentinel branch)
 */

--- a/test-files/test_perry_tui_inkcompat_counter_jsx.tsx
+++ b/test-files/test_perry_tui_inkcompat_counter_jsx.tsx
@@ -1,0 +1,45 @@
+// #689 — JSX-form variant of the inkcompat counter test.
+//
+// Mirrors `test_perry_tui_inkcompat_counter.ts` but uses the JSX form
+// `<Box><Text>{...}</Text></Box>` instead of the function-call form
+// `Box([Text(...)])`. Exercises the codegen JSX intrinsic rewriter
+// (`crates/perry-codegen/src/lower_call.rs::try_rewrite_perry_tui_jsx_intrinsic`)
+// end-to-end through the same useState / useInput / run / exit
+// pipeline as the original test.
+//
+// Acceptance: prints `FINAL=N` matching whatever the stdin transcript
+// drove. Compared against the function-call counter test to confirm
+// JSX-form == function-call-form semantics for Box + Text.
+
+import { Box, Text, useState, useInput, run, exit } from "perry/tui";
+
+let finalValue = 0;
+
+run(() => {
+    const [n, setN] = useState(0);
+    finalValue = n;
+    useInput((s: string) => {
+        if (s === "+") {
+            setN(finalValue + 1);
+            finalValue = finalValue + 1;
+        }
+        if (s === "-") {
+            setN(finalValue - 1);
+            finalValue = finalValue - 1;
+        }
+        if (s === "q") exit();
+    });
+    // Note: JSX text whitespace is trimmed by `normalize_jsx_text`, so
+    // we use string concat for the label to match the function-call
+    // form's `Text("count: " + n)` output exactly. The JSX `{...}`
+    // expression slot still exercises the rewriter — both single-child
+    // and multi-child paths are tested in
+    // `test_issue_679_perry_tui_jsx_audit.tsx`.
+    return (
+        <Box>
+            <Text>{"count: " + n}</Text>
+        </Box>
+    );
+});
+
+console.log("FINAL=" + finalValue);


### PR DESCRIPTION
## Summary

- **What it does:** Adds a compile-time rewriter so `<Box>` / `<Text>` JSX intrinsics from `perry/tui` lower to the same widget builders as their function-call equivalents (`Box(opts, children)` / `Text(content, opts)`), instead of bottoming out in the runtime `js_jsx`/`js_jsxs` adapter that returns `TAG_UNDEFINED`. Pre-fix `<Box><Text>hi</Text></Box>` rendered nothing; post-fix it renders identically to `Box([Text("hi")])`.
- **How it works:** Two-piece compile-time pipeline.
  - HIR (`crates/perry-hir/src/jsx.rs::lower_jsx_element_name`): when a JSX name resolves to a native-module-imported function (`Box` / `Text` from `perry/tui`), tag the `ExternFuncRef` with a sentinel name `__perry_jsx_intrinsic::<module>::<method>__`. Encodes the source module so a user-defined `Box` from a different module is NEVER rewritten.
  - Codegen (`crates/perry-codegen/src/lower_call.rs`): in the existing `"jsx" | "jsxs"` arm, decode the sentinel and route through `lower_native_method_call` with synthesised args. `rewrite_jsx_box` pops `children` out of props and wraps single JSX-call children in a one-element array (multi-child / runtime-array children pass through unchanged so the `js_perry_tui_box_add_children_array` runtime iterator still works for `<Box>{arr.map(...)}</Box>`). `rewrite_jsx_text` folds multi-child Text contents with `+` and routes through the bare or styled Text dispatch depending on whether non-`children` props are present.
- **Intrinsics covered (v1):** `Box` + `Text` only — the 90% of ink-style code per the issue. Spacer / Input / Spinner / List / Select / ProgressBar / Table / Tabs / TextArea continue to fall through to `js_jsx` and return `TAG_UNDEFINED`; extending the rewriter for those is listed as follow-up scope in #689.
- **User-component path unchanged:** `<App />` (where `App` is a closure or user-defined function) still lowers via the existing `js_jsx` dispatcher because those callees lower as `LocalGet` / `FuncRef` / `ExternFuncRef(<orig>)`, none of which carries the intrinsic sentinel.
- **`js_jsx` / `js_jsxs` runtime unchanged:** the fix is purely compile-time; runtime adapters stay byte-for-byte identical.

## Test plan

- [x] `test-files/test_issue_679_perry_tui_jsx_audit.tsx` expanded with three new sections: bare `<Box><Text>hello</Text></Box>`, multi-child styled row, and styled `<Text color="yellow" bold>`. All render identically to the function-call equivalents.
- [x] New `test-files/test_perry_tui_inkcompat_counter_jsx.tsx` mirrors the existing inkcompat counter test in JSX form; `echo "++q" | bin` yields the same `FINAL=2` snapshot as the function-call counter.
- [x] User-defined `Box` from a non-native module (`import { Box } from "./my_box"`) is NOT rewritten — verified the call still flows through the user-function path and returns the custom result.
- [x] Mapped-children JSX `<Box>{labels.map(l => <Text>{l}</Text>)}</Box>` falls through to `js_perry_tui_box_add_children_array` and iterates correctly at runtime.
- [x] All 10 existing perry/tui tests + all 7 inkcompat tests still compile + run.
- [x] `cargo test --release -p perry-hir -p perry-codegen` passes.

Closes #689.