### PR TITLE
feat(jsruntime): Response/Request/Headers Web Fetch API globals in V8 fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1006 — feat(jsruntime): Response / Request / Headers Web Fetch API globals in V8 fallback
+
+The next hono blocker after the SIGSEGV fix (v0.5.1005) was:
+
+```
+file:///private/tmp/perry-compat-sweep/hono/node_modules/hono/dist/context.js:353:
+Uncaught ReferenceError: Response is not defined
+```
+
+`deno_core` (the V8 fallback embedded by `perry-jsruntime`) does not
+expose `Response`, `Request`, or `Headers` as globals. PR #950 added URL
+/ URLSearchParams polyfills in `node_polyfills.js` and a `Headers`
+polyfill nested *inside* the `if (typeof fetch === 'undefined')` block —
+fine for when `globalThis.fetch` is missing, but the V8 build *does*
+already have its own `fetch`, so the entire branch (including the
+`Headers` class) was being skipped. Result: hono's `context.js` hit
+`new Response(...)` / `new Headers()` at module-init time and threw.
+
+This commit hoists `Headers` out of the `fetch` guard, makes it
+unconditional, and adds polyfills for `Response` and `Request` that
+implement the minimal Web Fetch API surface hono and similar libraries
+need:
+
+- `new Response(body?, init?)` — `status`, `statusText`, `headers`,
+  `ok`, `body`, `bodyUsed`, `text()`, `json()`, `arrayBuffer()`,
+  `clone()`, plus the static `Response.error()`, `Response.redirect()`,
+  `Response.json()`.
+- `new Request(input, init?)` — `url`, `method`, `headers`, `body`,
+  `bodyUsed`, `text()`, `json()`, `arrayBuffer()`, `clone()`, plus
+  shape-only fields (`credentials`, `cache`, `redirect`, `mode`,
+  `signal`, ...) so hono's defensive property reads don't NPE.
+- `Headers` now lifts to be created unconditionally and supports
+  `append()`, copy-construction from another `Headers`, generator-style
+  `entries()` / `keys()` / `values()` (so `for (const [k,v] of h)` works
+  via `Symbol.iterator`), and `Symbol.toStringTag`.
+
+The existing `fetch()` polyfill now also returns a real `Response`
+instance (instead of an ad-hoc object literal) and reads request shape
+fields from a passed-in `Request` when no `init` is supplied.
+
+Validation:
+
+- `test-files/test_v8_response_request.ts` — Perry's *native* path
+  (`Response` / `Request` / `Headers` are already wired to `fetch` ops
+  in `perry-stdlib`), prints `200`, `hello`, `http://example.com/`,
+  `POST`, `text/plain`.
+- `/tmp/perry-compat-sweep/hono/entry.ts` rebuilt with
+  `--enable-js-runtime`. Previously crashed with `ReferenceError:
+  Response is not defined`. Now completes the full hono round-trip:
+  `app.get("/ping", c => c.text("pong"))` → `await app.fetch(new
+  Request("http://localhost:18933/ping"))` → `await res.text()` →
+  prints `body=pong`, matching `expected.txt`.
+
 ## v0.5.1005 — fix(jsruntime): hono `app.fetch(req)` SIGSEGV — guard small-handle pointers in `native_object_to_v8`
 
 Hono's compat-sweep fixture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1005
+**Current Version:** 0.5.1006
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "base64",
@@ -4960,14 +4960,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "log",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "base64",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "serde",
  "serde_json",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1005"
+version = "0.5.1006"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "clap",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5112,14 +5112,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "chrono",
  "cron",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5160,21 +5160,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "bson",
  "futures-util",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "base64",
  "image",
@@ -5345,14 +5345,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5446,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5458,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "base64",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5570,11 +5570,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1005"
+version = "0.5.1006"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "base64",
  "itoa",
@@ -5590,7 +5590,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "base64",
  "block2",
@@ -5636,7 +5636,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "base64",
  "block2",
@@ -5655,11 +5655,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1005"
+version = "0.5.1006"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "base64",
  "block2",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "base64",
  "block2",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "block2",
  "libc",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "base64",
  "libc",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1005"
+version = "0.5.1006"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1005"
+version = "0.5.1006"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-jsruntime/src/node_polyfills.js
+++ b/crates/perry-jsruntime/src/node_polyfills.js
@@ -364,13 +364,181 @@
         globalThis.clearImmediate = function(id) {};
     }
 
+    // Headers polyfill -- needed independently of fetch by libraries like hono
+    // that reference `new Headers()` / `instanceof Headers` at module-init time.
+    // deno_core does not provide these as globals; without this `import "hono"`
+    // crashes with `ReferenceError: Headers is not defined`.
+    if (typeof globalThis.Headers === 'undefined') {
+        globalThis.Headers = class Headers {
+            constructor(init) {
+                this._map = {};
+                if (init === undefined || init === null) return;
+                if (init instanceof Headers) {
+                    init.forEach((v, k) => { this._map[k.toLowerCase()] = String(v); });
+                } else if (Array.isArray(init)) {
+                    for (const [k, v] of init) {
+                        this._map[k.toLowerCase()] = String(v);
+                    }
+                } else if (typeof init === 'object') {
+                    for (const [k, v] of Object.entries(init)) {
+                        this._map[k.toLowerCase()] = String(v);
+                    }
+                }
+            }
+            get(name) { return this._map[name.toLowerCase()] ?? null; }
+            set(name, value) { this._map[name.toLowerCase()] = String(value); }
+            has(name) { return name.toLowerCase() in this._map; }
+            delete(name) { delete this._map[name.toLowerCase()]; }
+            append(name, value) {
+                const k = name.toLowerCase();
+                if (k in this._map) {
+                    this._map[k] = this._map[k] + ', ' + String(value);
+                } else {
+                    this._map[k] = String(value);
+                }
+            }
+            forEach(cb, thisArg) {
+                for (const [k, v] of Object.entries(this._map)) cb.call(thisArg, v, k, this);
+            }
+            *entries() { for (const e of Object.entries(this._map)) yield e; }
+            *keys() { for (const k of Object.keys(this._map)) yield k; }
+            *values() { for (const v of Object.values(this._map)) yield v; }
+            [Symbol.iterator]() { return this.entries(); }
+            get [Symbol.toStringTag]() { return 'Headers'; }
+        };
+    }
+
+    // Response polyfill -- needed by hono and other Web-Fetch-API libraries that
+    // construct Response objects at module-init time. Minimal Web Fetch API shape.
+    if (typeof globalThis.Response === 'undefined') {
+        globalThis.Response = class Response {
+            constructor(body, init) {
+                this._body = body == null ? '' : body;
+                init = init || {};
+                this.status = init.status != null ? init.status : 200;
+                this.statusText = init.statusText != null ? String(init.statusText) : '';
+                this.headers = init.headers instanceof globalThis.Headers
+                    ? init.headers
+                    : new globalThis.Headers(init.headers);
+                this.ok = this.status >= 200 && this.status < 300;
+                this.redirected = false;
+                this.type = 'default';
+                this.url = '';
+                this.bodyUsed = false;
+            }
+            get body() { return this._body; }
+            async text() {
+                this.bodyUsed = true;
+                const b = this._body;
+                if (b == null) return '';
+                if (typeof b === 'string') return b;
+                if (b instanceof Uint8Array) return new TextDecoder().decode(b);
+                if (b instanceof ArrayBuffer) return new TextDecoder().decode(new Uint8Array(b));
+                return String(b);
+            }
+            async json() { return JSON.parse(await this.text()); }
+            async arrayBuffer() {
+                this.bodyUsed = true;
+                const b = this._body;
+                if (b instanceof ArrayBuffer) return b;
+                if (b instanceof Uint8Array) return b.buffer;
+                return new TextEncoder().encode(typeof b === 'string' ? b : String(b ?? '')).buffer;
+            }
+            async blob() { return { size: 0, type: '' }; }
+            clone() {
+                const r = new Response(this._body, { status: this.status, statusText: this.statusText, headers: this.headers });
+                r.url = this.url;
+                return r;
+            }
+            static error() {
+                const r = new Response(null, { status: 0 });
+                r.type = 'error';
+                return r;
+            }
+            static redirect(url, status) {
+                const r = new Response(null, { status: status || 302 });
+                r.headers.set('location', String(url));
+                return r;
+            }
+            static json(data, init) {
+                const headers = new globalThis.Headers((init && init.headers) || {});
+                if (!headers.has('content-type')) headers.set('content-type', 'application/json');
+                return new Response(JSON.stringify(data), {
+                    status: init && init.status != null ? init.status : 200,
+                    statusText: init && init.statusText,
+                    headers,
+                });
+            }
+            get [Symbol.toStringTag]() { return 'Response'; }
+        };
+    }
+
+    // Request polyfill -- needed by hono's app.fetch(req) entry point and any
+    // server library accepting a Request object.
+    if (typeof globalThis.Request === 'undefined') {
+        globalThis.Request = class Request {
+            constructor(input, init) {
+                init = init || {};
+                if (input instanceof Request) {
+                    this.url = input.url;
+                    this.method = init.method != null ? String(init.method).toUpperCase() : input.method;
+                    this.headers = init.headers ? new globalThis.Headers(init.headers) : new globalThis.Headers(input.headers);
+                    this._body = init.body != null ? init.body : input._body;
+                } else {
+                    this.url = String(input);
+                    this.method = init.method != null ? String(init.method).toUpperCase() : 'GET';
+                    this.headers = init.headers instanceof globalThis.Headers
+                        ? init.headers
+                        : new globalThis.Headers(init.headers);
+                    this._body = init.body != null ? init.body : null;
+                }
+                this.credentials = init.credentials || 'same-origin';
+                this.cache = init.cache || 'default';
+                this.redirect = init.redirect || 'follow';
+                this.referrer = init.referrer || '';
+                this.integrity = init.integrity || '';
+                this.signal = init.signal || null;
+                this.bodyUsed = false;
+                this.mode = init.mode || 'cors';
+            }
+            get body() { return this._body; }
+            async text() {
+                this.bodyUsed = true;
+                const b = this._body;
+                if (b == null) return '';
+                if (typeof b === 'string') return b;
+                if (b instanceof Uint8Array) return new TextDecoder().decode(b);
+                if (b instanceof ArrayBuffer) return new TextDecoder().decode(new Uint8Array(b));
+                return String(b);
+            }
+            async json() { return JSON.parse(await this.text()); }
+            async arrayBuffer() {
+                this.bodyUsed = true;
+                const b = this._body;
+                if (b instanceof ArrayBuffer) return b;
+                if (b instanceof Uint8Array) return b.buffer;
+                return new TextEncoder().encode(typeof b === 'string' ? b : String(b ?? '')).buffer;
+            }
+            async formData() { return new globalThis.URLSearchParams(await this.text()); }
+            async blob() { return { size: 0, type: '' }; }
+            clone() {
+                return new Request(this.url, {
+                    method: this.method,
+                    headers: this.headers,
+                    body: this._body,
+                });
+            }
+            get [Symbol.toStringTag]() { return 'Request'; }
+        };
+    }
+
     // fetch() polyfill using op_perry_fetch Deno op
     if (typeof globalThis.fetch === 'undefined') {
         const core = Deno.core;
         globalThis.fetch = async function(input, init) {
             const url = typeof input === 'string' ? input : input.url;
-            const method = (init && init.method) || 'GET';
-            let body = (init && init.body) || '';
+            const method = (init && init.method) || (input && input.method) || 'GET';
+            let body = (init && init.body) || (input && input._body) || '';
             // Convert Uint8Array/ArrayBuffer body to string (ethers.js sends Uint8Array)
             if (body && typeof body !== 'string') {
                 if (body instanceof Uint8Array || body instanceof ArrayBuffer) {
@@ -382,11 +550,13 @@
             }
             const headers = {};
             if (init && init.headers) {
-                if (init.headers instanceof Headers) {
+                if (init.headers instanceof globalThis.Headers) {
                     init.headers.forEach((v, k) => { headers[k] = v; });
                 } else if (typeof init.headers === 'object') {
                     Object.assign(headers, init.headers);
                 }
+            } else if (input && input.headers instanceof globalThis.Headers) {
+                input.headers.forEach((v, k) => { headers[k] = v; });
             }
             // op_perry_fetch is async (returns a Promise). Awaiting here
             // yields back to the V8 event loop, which is required for
@@ -395,41 +565,12 @@
             // the yield the JS-side accept loop never starts polling
             // op_perry_http_accept and the request deadlocks.
             const result = await core.ops.op_perry_fetch(url, method, body, headers);
-            return {
-                ok: result.status >= 200 && result.status < 300,
+            return new globalThis.Response(result.body, {
                 status: result.status,
                 statusText: result.statusText,
-                headers: new Headers(result.headers),
-                text: async () => result.body,
-                json: async () => JSON.parse(result.body),
-                arrayBuffer: async () => new TextEncoder().encode(result.body).buffer,
-            };
+                headers: result.headers,
+            });
         };
-        // Headers polyfill if needed
-        if (typeof globalThis.Headers === 'undefined') {
-            globalThis.Headers = class Headers {
-                constructor(init) {
-                    this._map = {};
-                    if (Array.isArray(init)) {
-                        for (const [k, v] of init) {
-                            this._map[k.toLowerCase()] = String(v);
-                        }
-                    } else if (init && typeof init === 'object') {
-                        for (const [k, v] of Object.entries(init)) {
-                            this._map[k.toLowerCase()] = String(v);
-                        }
-                    }
-                }
-                get(name) { return this._map[name.toLowerCase()] || null; }
-                set(name, value) { this._map[name.toLowerCase()] = value; }
-                has(name) { return name.toLowerCase() in this._map; }
-                delete(name) { delete this._map[name.toLowerCase()]; }
-                forEach(cb) { for (const [k, v] of Object.entries(this._map)) cb(v, k, this); }
-                entries() { return Object.entries(this._map)[Symbol.iterator](); }
-                keys() { return Object.keys(this._map)[Symbol.iterator](); }
-                values() { return Object.values(this._map)[Symbol.iterator](); }
-            };
-        }
     }
 
     // AbortController polyfill

--- a/test-files/test_v8_response_request.ts
+++ b/test-files/test_v8_response_request.ts
@@ -1,0 +1,17 @@
+// Test that Response, Request, Headers globals are available in the V8 fallback.
+// Build: cargo run --release -- test-files/test_v8_response_request.ts -o /tmp/t_v8_rr --enable-js-runtime
+// Run:   /tmp/t_v8_rr
+
+async function main() {
+    const res = new Response("hello", { status: 200 });
+    console.log(res.status);          // 200
+    console.log(await res.text());    // hello
+
+    const req = new Request("http://example.com/", { method: "POST", body: "data" });
+    console.log(req.url);             // http://example.com/
+    console.log(req.method);          // POST
+
+    const h = new Headers({ "content-type": "text/plain" });
+    console.log(h.get("content-type")); // text/plain
+}
+main();


### PR DESCRIPTION
## Summary
- Hoists `Headers` polyfill out of the `if (typeof fetch === 'undefined')` guard so it is created unconditionally — deno_core has its own `fetch` but does not expose `Headers`, leaving hono's `new Headers()` calls in `context.js` to throw `ReferenceError`.
- Adds `Response` and `Request` polyfills implementing the minimal Web Fetch API surface (status/statusText/headers/ok/body, `text()`/`json()`/`arrayBuffer()`/`clone()`, static `Response.error/redirect/json`, full `Request` shape fields). `Headers` gains `append()`, copy-construction, generator-style iteration, and `Symbol.toStringTag`.
- Rewires the existing `fetch()` polyfill to return a real `Response` instance instead of an ad-hoc object literal, and to accept a passed-in `Request` as `input`.

## Test plan
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry-jsruntime -p perry`
- [x] `test-files/test_v8_response_request.ts` (native path through `perry-stdlib::fetch`) prints `200 / hello / http://example.com/ / POST / text/plain`
- [x] `/tmp/perry-compat-sweep/hono/entry.ts` rebuilt with `--enable-js-runtime`: previously threw `ReferenceError: Response is not defined`, now completes `app.fetch(new Request(...))` round-trip and prints `body=pong` matching `expected.txt`