### PR TITLE
docs: recover missing CLI docs + types for recently-merged security PRs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -144,6 +144,7 @@
 - [`--emit-sandbox`](cli/emit-sandbox.md)
 - [`--lockdown`](cli/lockdown.md)
 - [Egress Allowlist (`allowedHosts`)](cli/allowed-hosts.md)
+- [Per-Package Capabilities (`perry.permissions`)](cli/capabilities.md)
 - [perry.toml Reference](cli/perry-toml.md)
 
 ---

--- a/docs/src/cli/capabilities.md
+++ b/docs/src/cli/capabilities.md
@@ -1,0 +1,113 @@
+# Per-Package Capabilities (`perry.permissions`)
+
+A compile-time HIR pass walks every imported dependency's source
+modules, derives the capability tokens its stdlib call sites would
+need, and refuses the build for any call site whose required token
+isn't in the dependency's allow-list (or the `*` default). Host code
+is always granted `*` unconditionally — gating host code is the
+`--lockdown` mode (#496), not per-package policy. (#501)
+
+**Zero runtime cost** — purely a compile-time refusal. **Cross-platform**:
+runs in the platform-agnostic `compile_command` driver before any
+backend (LLVM / WASM / ArkTS / HarmonyOS / Glance / SwiftUI / JS) is
+invoked.
+
+## Why
+
+Most npm packages will never declare their own capabilities. The
+prior art around runtime permission prompts (Deno, Bun) ships a
+prompt; that doesn't help when an install-time `bun add` lands a
+hostile dep that hides its egress until production. `perry.permissions`
+moves the gate to compile time and to the host's `package.json`, so
+the supply chain is *static* from the consumer's perspective.
+
+## Host config
+
+```json
+{
+  "perry": {
+    "permissions": {
+      "lodash": [],
+      "axios": ["net:fetch"],
+      "@scope/utils": ["crypto"],
+      "*": []
+    }
+  }
+}
+```
+
+- Keys are exact npm package names (`@scope/pkg` accepted) or the
+  universal `"*"` default.
+- Values are arrays of capability tokens (see below). Empty array
+  means "this dep is only allowed to compute — no I/O".
+- Absent map → pass is disabled and existing builds compile
+  unchanged. Set any entry to enable.
+
+## Capability tokens (MVP)
+
+| Token | Stdlib surface |
+|-------|----------------|
+| `fs:read` | `fs.readFile`, `fs.readFileSync`, `fs.stat`, `fs.readdir`, … |
+| `fs:write` | `fs.writeFile`, `fs.appendFile`, `fs.mkdir`, `fs.unlink`, `fs.rm`, … |
+| `crypto` | `crypto.*`, `crypto.subtle.*` |
+| `proc:env` | `process.env.*` reads |
+| `proc:argv` | `process.argv` reads |
+| `proc:exec` | `child_process.*` |
+| `net:fetch` | `fetch`, `Request`, `Response`, `Headers` |
+| `net:listen` | `net.createServer`, `http.createServer`, `https.createServer` |
+| `net:connect` | `net.connect`, `net.createConnection`, raw socket clients |
+| `*` | Grants every token above. Escape hatch — use sparingly. |
+
+## Diagnostic
+
+A failing build prints a combined diagnostic across every refused
+call site (capped at the first 12 entries to keep output reasonable):
+
+```text
+Error: per-package capability policy refused 3 stdlib call site(s):
+  - `axios` net:fetch at node_modules/axios/lib/http.js:42 requires `net:fetch`
+  - `axios` fs:read at node_modules/axios/lib/cookies.js:11 requires `fs:read`
+  - `mysterydep` proc:exec at node_modules/mysterydep/cli.js:7 requires `proc:exec`
+
+`perry.permissions` provides a static guarantee that each
+dependency only reaches the stdlib surfaces you've explicitly
+granted it. Refusing the build. (#501)
+```
+
+The output names the owning package, the call kind, the source span,
+and the missing token — enough to either (a) extend the allow-list,
+(b) set `"*": ["<token>"]` for a wider default, or (c) replace the
+dep with one that doesn't need the capability.
+
+## Recommended workflow
+
+1. **Start empty.** Set `"permissions": {}` to confirm your build
+   is currently passing without the pass active.
+2. **Flip the default to deny.** Add `"*": []` and rebuild. The
+   diagnostic enumerates every capability your dep tree currently
+   reaches.
+3. **Grant minimum tokens per dep.** Use the diagnostic to populate
+   `permissions` with the smallest token set each package needs.
+4. **Lock in CI.** Once the build is green with the explicit
+   permissions, leave it that way — new deps that want new tokens
+   show up as build failures, surfacing in the PR review.
+
+## Relationship to other security flags
+
+- **`--lockdown` (#496)** — gates host code itself against the
+  arbitrary-code-execution surfaces (perry-jsruntime,
+  `perry.nativeLibrary` archives, `child_process.*`). Orthogonal:
+  `perry.permissions` is per-dep, `--lockdown` is whole-binary.
+- **`allowedHosts` (#502)** — narrows `net:fetch` from "any URL" to
+  "URLs matching this allow-list." A dep with `net:fetch` permission
+  still has to clear the egress allow-list at every call site.
+- **`PERRY_SANDBOX_BUILDRS` (#505)** — sandboxes the *build-time*
+  `build.rs` scripts. `perry.permissions` controls what the
+  *runtime* binary can do.
+
+## See also
+
+- [`#501`](https://github.com/PerryTS/perry/issues/501) — design discussion.
+- [`--lockdown`](./lockdown.md)
+- [Egress Allowlist (`allowedHosts`)](./allowed-hosts.md)
+- [`PERRY_SANDBOX_BUILDRS`](./sandbox-buildrs.md)

--- a/docs/src/cli/emit-attest.md
+++ b/docs/src/cli/emit-attest.md
@@ -1,0 +1,99 @@
+# `--emit-attest` (binary attestation sidecar)
+
+`perry compile --emit-attest main.ts -o myapp` writes
+`myapp.attest.json` next to the executable. The sidecar holds the
+SHA-256 of the *post-strip / post-codesign* binary plus provenance
+metadata (perry version, git commit, build timestamp) so downstream
+consumers can verify that the artifact they downloaded matches the
+one the publisher built. (#504)
+
+## Why
+
+Publishing a Perry binary to a CDN, a release page, or an internal
+artifact registry creates a window between "publisher built it" and
+"user runs it." `--emit-attest` produces a JSON sidecar that anyone
+can recompute on the downloaded artifact and compare. A tampered or
+swapped binary fails verification with a verbose diagnostic that
+reproduces both hashes.
+
+## Emit
+
+```bash
+perry compile --emit-attest main.ts -o myapp
+# → myapp
+# → myapp.attest.json
+```
+
+Equivalent settings, last wins:
+
+1. `perry.emitAttest: true` in host `package.json`.
+2. `PERRY_EMIT_ATTEST=1` in the environment.
+3. `--emit-attest` on the CLI.
+
+`=0` / `false` explicitly disables (so a CI matrix can override a
+host-level opt-in).
+
+## Verify
+
+```bash
+perry verify --attest ./myapp
+```
+
+Streams SHA-256 of the binary on disk and compares against
+`myapp.attest.json`. Output:
+
+- **match** — prints `✓ attestation matches` plus the captured
+  provenance (perry version, commit SHA, build timestamp). Exit 0.
+- **mismatch** — prints both hashes, the sidecar's provenance, and
+  exit 1.
+- **missing sidecar** — prints actionable guidance pointing at
+  `--emit-attest`. Exit 1.
+
+The verifier runs offline (no tokio runtime, no network, no beta
+consent prompt) — distinct from the existing
+`perry verify` which goes through `verify.perryts.com` for runtime
+verification.
+
+## Manifest shape
+
+```json
+{
+  "version": 1,
+  "sha256": "abcd1234...",
+  "size": 1048576,
+  "perry_version": "0.5.999",
+  "commit_sha": "0a1b2c3...",
+  "built_at_unix": 1715990400,
+  "binary_filename": "myapp"
+}
+```
+
+`version: 1` reserves room for future top-level keys (CI signature
+blob, sigstore bundle, reproducible-builds flags log) without
+breaking existing parsers.
+
+## When the hash is captured
+
+The hash is computed *after* every post-link rewrite the platform
+applies — `strip`, `codesign`, `install_name_tool` retag, ad-hoc
+extended-attribute scrubs. That's the same byte sequence users
+download, so the recomputed hash matches when the artifact is
+intact.
+
+## Cross-platform
+
+The hook lives in the platform-agnostic `compile_command` driver,
+so every backend (LLVM, WASM, ArkTS, HarmonyOS, Glance, SwiftUI,
+JS) emits the sidecar consistently.
+
+## Follow-ups (MVP scope)
+
+The MVP captures hash + provenance. Full reproducible-builds and
+sigstore-style remote signature publication are tracked separately
+under the same issue.
+
+## See also
+
+- [`#504`](https://github.com/PerryTS/perry/issues/504) — design discussion.
+- [`#505`](./sandbox-buildrs.md) — companion build-time sandbox.
+- [`#506`](./emit-sandbox.md) — companion runtime sandbox profile.

--- a/docs/src/cli/sandbox-buildrs.md
+++ b/docs/src/cli/sandbox-buildrs.md
@@ -1,0 +1,87 @@
+# `PERRY_SANDBOX_BUILDRS`
+
+Wraps `cargo build` invocations triggered by `perry.nativeLibrary`
+resolution in macOS `sandbox-exec`, so `build.rs` scripts shipped by
+third-party crates can't reach the network or write outside the build
+output directory. Build-time only — **zero runtime cost** in the
+produced binary. (#505)
+
+## Why
+
+`perry.nativeLibrary` resolution kicks off `cargo build` for any
+source-distributed crate. A crate's `build.rs` runs with full developer
+privileges, so a typical `bun add @vendor/native-thing` silently grants
+the new dependency the ability to exfiltrate environment variables,
+read SSH keys, or modify files outside the build tree. The flag flips
+that to *opt-out* via an explicit allow-list rather than *opt-in* via
+review.
+
+## Opt-in
+
+Off by default for backwards compatibility. Enable per build via
+env var:
+
+```bash
+PERRY_SANDBOX_BUILDRS=1 perry compile main.ts -o myapp
+```
+
+CI typically sets the env var on every job; local development keeps
+the legacy flow until ready.
+
+## Profile contents
+
+The generated `sandbox-exec` profile:
+
+- `deny default` + `deny network*` — `build.rs` cannot phone home.
+- `allow file-read*` everywhere (cargo / rustc need to read system
+  libraries, source, dependency crates).
+- `allow file-write*` scoped to `target/`, `~/.cargo`, `~/.rustup`,
+  `/tmp`, and the per-build `TempDir`.
+- `allow process-fork` + `process-exec` so rustc, cc, ld, and the
+  build.rs binaries themselves can run.
+- `allow sysctl-read` / `mach-lookup` / `iokit-open` for the platform
+  queries cargo and rustc routinely issue.
+
+## Pre-fetch workflow
+
+The sandbox denies network, so cargo cannot reach `crates.io` from
+inside it. Pre-fetch once outside the sandbox before the sandboxed
+build:
+
+```bash
+cargo fetch --manifest-path node_modules/@foo/native-bar/Cargo.toml
+PERRY_SANDBOX_BUILDRS=1 perry compile main.ts -o myapp
+```
+
+CI runners typically cache `~/.cargo` across jobs, so the pre-fetch is
+free on subsequent builds.
+
+## Per-package escape hatch
+
+Some legitimate crates need network during `build.rs` (e.g. fetching
+prebuilt artifacts from a CDN). Opt them out per-package in the **host**
+`package.json`:
+
+```json
+{
+  "perry": {
+    "allowUnsandboxedBuild": ["@some-vendor/builds-with-network"]
+  }
+}
+```
+
+Host-controlled — transitive deps cannot opt themselves out. The
+exemption lives in the host repository's `package.json` and shows up
+in code review.
+
+## Cross-platform scope
+
+MVP is macOS-only (the `sandbox-exec` profile). Linux landlock
+support is tracked separately; until that lands, `PERRY_SANDBOX_BUILDRS=1`
+on Linux is a no-op (the build runs normally). Windows: out of scope.
+
+## See also
+
+- [`#505`](https://github.com/PerryTS/perry/issues/505) — design discussion.
+- [`#504`](./emit-attest.md) — companion binary attestation.
+- [`#506`](./emit-sandbox.md) — companion runtime sandbox profile.

--- a/types/perry/system/index.d.ts
+++ b/types/perry/system/index.d.ts
@@ -18,6 +18,14 @@ export function getDeviceModel(): string;
 /** Returns the BCP 47 locale tag for the device's primary language (e.g. "en-US", "fr-FR"). */
 export function getLocale(): string;
 
+/**
+ * Returns a stable, human-readable OS-version string for the current
+ * platform (e.g. `"15.2"`, `"macOS 14.5"`, `"Android 14"`). Common need
+ * for crash-report and telemetry payloads; pairs with
+ * `getDeviceModel()` / `getAppVersion()`.
+ */
+export function getOSVersion(): string;
+
 /** Returns `perry.toml :: project.version` (e.g. "1.2.6"). */
 export function getAppVersion(): string;
 
@@ -42,6 +50,51 @@ export function getAppIcon(path: string): import("perry/ui").Widget;
 
 /** Open a URL in the default browser or system handler. */
 export function openURL(url: string): void;
+
+// ---------------------------------------------------------------------------
+// System share sheet (#917)
+// ---------------------------------------------------------------------------
+
+/**
+ * Present the platform share sheet for plain text.
+ *
+ * Maps to `UIActivityViewController` on iOS, `NSSharingServicePicker`
+ * on macOS, and `Intent.ACTION_SEND` on Android. The optional `title`
+ * is the suggested subject/heading; pass `""` to omit. No-op on
+ * platforms without a system share UI.
+ */
+export function shareText(text: string, title?: string): void;
+
+/**
+ * Present the platform share sheet for a URL. Identical surface to
+ * `shareText` but the body is treated as a URL so the OS picks
+ * URL-aware activities (Mail with a link, Messages with a preview,
+ * etc.).
+ */
+export function shareUrl(url: string, title?: string): void;
+
+// ---------------------------------------------------------------------------
+// App Group / cross-process shared storage (#675)
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a value into the App Group's shared key-value store. Visible
+ * to widget extensions, share extensions, watchOS targets, and other
+ * processes belonging to the same App Group identifier. On Apple
+ * platforms backed by `UserDefaults(suiteName:)`; other platforms
+ * fall back to an in-process HashMap so the API surface is
+ * exercisable in dev/tests (not actually cross-process there).
+ */
+export function appGroupSet(key: string, value: string): void;
+
+/**
+ * Read a value previously written via `appGroupSet`. Returns the
+ * empty string when the key is absent.
+ */
+export function appGroupGet(key: string): string;
+
+/** Remove a key from the App Group store. */
+export function appGroupDelete(key: string): void;
 
 // ---------------------------------------------------------------------------
 // Keychain (secure credential storage)


### PR DESCRIPTION
Three PRs that landed via admin-bypass today reference docs files
that don't actually exist in the tree, plus three perry/system PRs
that didn't update the hand-maintained \`types/\` file. This is the
docs follow-up.

## What's missing

| PR | Issue | Surface |
|----|-------|---------|
| #981 | #505 | \`docs/src/cli/sandbox-buildrs.md\` linked from SUMMARY but never created |
| #988 | #504 | \`docs/src/cli/emit-attest.md\` linked from SUMMARY but never created |
| #969 | #501 | No docs at all — no \`capabilities.md\`, no SUMMARY entry |
| #976 | n/a | \`getOSVersion()\` added to runtime + manifest, not to \`types/perry/system/index.d.ts\` |
| #972 | #917 | \`shareText\` / \`shareUrl\` added to runtime + manifest, not to \`types/\` |
| #974 | #675 | \`appGroupSet\` / \`appGroupGet\` / \`appGroupDelete\` added to runtime + manifest, not to \`types/\` |

\`docs/src/cli/lockdown.md\` (#496) and \`docs/src/cli/emit-sandbox.md\`
(#506) did land in their respective PRs and are unaffected.

## What this PR does

- Creates the three missing \`docs/src/cli/*.md\` files with content
  derived from each PR's description (workflow, opt-in mechanisms,
  capability tokens, related-PR cross-references).
- Adds the SUMMARY.md entry for \`capabilities.md\`.
- Adds the six new \`perry/system\` signatures to
  \`types/perry/system/index.d.ts\` with the same docstring style as
  the surrounding entries.

## Why not in the original PRs

Most of these PRs were rebased + admin-merged locally during today's
loop. The docs gaps were pre-existing in the PRs themselves (the
SUMMARY entries pointed at files that were never committed); the
\`types/\` gaps are the standard "manifest entry was added but the
hand-maintained types file wasn't touched" pattern.

The auto-generated \`docs/api/perry.d.ts\` + \`docs/src/api/reference.md\`
already cover the new symbols and are up to date on main.

## Test plan

- [x] \`mdbook build docs/\` succeeds with no dead links.
- [x] Spot-check each new doc renders sanely; cross-references resolve.
- [x] Spot-check \`types/perry/system/index.d.ts\` against the runtime
  dispatch table in \`crates/perry-dispatch/src/lib.rs\` — signatures match.

Pure docs-only diff. No code changes.