### PR TITLE
hotfix(ui): repair share_url stubs + Feature list (unblocks every PR's lint gate)

### DIFF
--- a/crates/perry-ui-android/src/lib.rs
+++ b/crates/perry-ui-android/src/lib.rs
@@ -1432,6 +1432,9 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "perry_system_share_url",
         "Android Intent.ACTION_SEND not yet implemented (#917 follow-up)",
         Some("#917"),
+    );
+}
+
 // #675 — App Group stubs on Android. Native impl will use scoped
 // `SharedPreferences` keyed by `shared_prefs_name` from perry.toml,
 // dispatched through JNI; tracked as #675 follow-up.

--- a/crates/perry-ui-gtk4/src/lib.rs
+++ b/crates/perry-ui-gtk4/src/lib.rs
@@ -1730,6 +1730,9 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "perry_system_share_url",
         "GTK4/Linux XDG share portal not yet wired (#917 follow-up)",
         Some("#917"),
+    );
+}
+
 // #675 — App Group stubs on GTK4 / Linux. Native impl will use a
 // per-user XDG path (`$XDG_DATA_HOME/<bundle_id>/shared/`) for the
 // blob shape and a small JSON-backed kv store; tracked as #675

--- a/crates/perry-ui-ios/src/lib.rs
+++ b/crates/perry-ui-ios/src/lib.rs
@@ -1393,6 +1393,8 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "iOS UIActivityViewController not yet implemented (#917 follow-up)",
         Some("#917"),
     );
+}
+
 // #675 — App Group / cross-process shared storage on iOS. MVP uses
 // an in-process HashMap so the API is exercisable from user code;
 // the native impl (UserDefaults(suiteName:) read from

--- a/crates/perry-ui-test/src/lib.rs
+++ b/crates/perry-ui-test/src/lib.rs
@@ -1457,6 +1457,26 @@ pub const FEATURES: &[Feature] = &[
     // (per-platform native impls land as #917 follow-ups).
     Feature {
         name: "perry_system_share_text",
+        category: SystemApi,
+        macos: S,
+        ios: S,
+        android: S,
+        gtk4: S,
+        windows: S,
+        web: S,
+        web_name: None,
+    },
+    Feature {
+        name: "perry_system_share_url",
+        category: SystemApi,
+        macos: S,
+        ios: S,
+        android: S,
+        gtk4: S,
+        windows: S,
+        web: S,
+        web_name: None,
+    },
     // #675: App Group / cross-process shared storage. macOS has the
     // real NSUserDefaults(suiteName:) impl; iOS has the in-process
     // HashMap MVP; every other platform is a first-call-warning stub.
@@ -1472,7 +1492,6 @@ pub const FEATURES: &[Feature] = &[
         web_name: None,
     },
     Feature {
-        name: "perry_system_share_url",
         name: "perry_system_app_group_get",
         category: SystemApi,
         macos: S,

--- a/crates/perry-ui-tvos/src/lib.rs
+++ b/crates/perry-ui-tvos/src/lib.rs
@@ -1280,6 +1280,9 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "perry_system_share_url",
         "tvOS does not expose a programmatic share sheet (#917)",
         Some("#917"),
+    );
+}
+
 // #675 — App Group / cross-process shared storage. MVP stubs on
 // tvOS; tvOS user apps don't typically share data cross-process,
 // and the matching real impl (UserDefaults(suiteName:)) isn't

--- a/crates/perry-ui-visionos/src/lib.rs
+++ b/crates/perry-ui-visionos/src/lib.rs
@@ -1399,6 +1399,9 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "perry_system_share_url",
         "visionOS share sheet not yet implemented (#917 follow-up)",
         Some("#917"),
+    );
+}
+
 // #675 — App Group stubs on visionOS. Same UserDefaults(suiteName:)
 // path as iOS will work; tracked as #675 follow-up.
 #[no_mangle]

--- a/crates/perry-ui-watchos/src/lib.rs
+++ b/crates/perry-ui-watchos/src/lib.rs
@@ -1191,6 +1191,9 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "perry_system_share_url",
         "watchOS does not expose a programmatic share sheet (#917)",
         Some("#917"),
+    );
+}
+
 // #675 — App Group stubs on watchOS. WatchKit *does* support
 // `UserDefaults(suiteName:)` against the same App Group entitlement
 // as the iOS host, but the wiring is more complex; tracked as

--- a/crates/perry-ui-windows/src/lib.rs
+++ b/crates/perry-ui-windows/src/lib.rs
@@ -1573,6 +1573,9 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
         "perry_system_share_url",
         "Windows DataTransferManager not yet wired (#917 follow-up)",
         Some("#917"),
+    );
+}
+
 // #675 — App Group stubs on Windows. Native impl will use
 // `%LOCALAPPDATA%\<bundle_id>\shared\` for the blob shape and a
 // JSON-backed kv store; tracked as #675 follow-up.


### PR DESCRIPTION
## What this fixes

The merge of #974 (#675 app-group) into main left several files with **unclosed delimiters** — every PR opened since then fails the `lint` gate because `cargo fmt --check --all` can't even parse the affected files.

Concretely:
- Every platform-stub crate (`perry-ui-android/gtk4/ios/tvos/visionos/watchos/windows`)'s `perry_system_share_url` function body was truncated mid-statement — missing the closing `);}` before the next item.
- `perry-ui-test/src/lib.rs` `FEATURES` list had two `Feature` entries collapsed together (`perry_system_share_text` merged into `perry_system_app_group_set`, and `perry_system_share_url` merged into `perry_system_app_group_get`), leaving the file unparseable.

## Repro on current main

```bash
cargo fmt --check --all
# error: this file contains an unclosed delimiter
#     --> crates/perry-ui-android/src/lib.rs:2811:3
# (also gtk4, tvos, watchos, visionos, windows, ui-test)
```

## Why standalone hotfix

This is blocking #1014 (#689 TUI rewriter), #1018 (#676 widgets), and any future PR's lint gate. Landing this as a tiny standalone PR lets every open PR be rebased cleanly afterwards. The fix is also already included in #1018, but pulling it forward isolates the risk to 8 files and 40 lines.

## Verification

- `cargo fmt --check --all` — green
- `cargo check -p perry-ui-test --release` — green
- `cargo check -p perry-ui-{ios,tvos,visionos,watchos} --release` — green (Apple stub crates compile)

No behavioral changes — only delimiter restorations and FEATURE-list reconstruction.