### PR TITLE
fix: #927 — jwt.verify dispatches per algorithm (ES256/RS256), accepts private PEM

### DIFF
--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -8531,24 +8531,10 @@ const NATIVE_MODULE_TABLE: &[NativeModSig] = &[
         ret: NR_F64,
     },
     // ========== jsonwebtoken ==========
-    // `sign` is intentionally handled in lower_call/native.rs. It needs
-    // option-dependent runtime selection plus an already-NaN-boxed string
-    // return, so the generic table must not grow a second path for it.
-    NativeModSig {
-        module: "jsonwebtoken",
-        has_receiver: false,
-        method: "verify",
-        class_filter: None,
-        runtime: "js_jwt_verify",
-        // js_jwt_verify(token_ptr: *const StringHeader, secret_ptr: *const StringHeader)
-        // -> *mut StringHeader (JSON of claims). NR_OBJ_FROM_JSON_STR pipes
-        // the returned JSON through js_json_parse so the value visible to
-        // user code is a real object (decoded.sub works), not the JSON
-        // text. Per the jsonwebtoken README, `jwt.verify` returns the
-        // payload as an object. Issue #927.
-        args: &[NA_STR, NA_STR],
-        ret: NR_OBJ_FROM_JSON_STR,
-    },
+    // `sign` and `verify` are intentionally handled in
+    // lower_call/native.rs — both need option-dependent runtime
+    // selection (HS256 / ES256 / RS256) that the generic table can't
+    // express. `decode` stays here because it has no algorithm options.
     NativeModSig {
         module: "jsonwebtoken",
         has_receiver: false,
@@ -8556,7 +8542,9 @@ const NATIVE_MODULE_TABLE: &[NativeModSig] = &[
         class_filter: None,
         runtime: "js_jwt_decode",
         // js_jwt_decode(token_ptr) -> *mut StringHeader (JSON of payload).
-        // Mirror `verify` — returns an object to user code. Issue #927.
+        // NR_OBJ_FROM_JSON_STR pipes the returned JSON through
+        // js_json_parse_or_null so user code sees an object (mirrors
+        // `verify`'s post-#927 contract). Issue #927.
         args: &[NA_STR],
         ret: NR_OBJ_FROM_JSON_STR,
     },

--- a/crates/perry-codegen/src/lower_call/native.rs
+++ b/crates/perry-codegen/src/lower_call/native.rs
@@ -314,6 +314,93 @@ fn lower_jsonwebtoken_sign(ctx: &mut FnCtx<'_>, args: &[Expr]) -> Result<String>
     Ok(ctx.block().bitcast_i64_to_double(&raw))
 }
 
+/// Dispatch `jsonwebtoken.verify(token, secret_or_pem, options?)` to
+/// the right runtime (HS256 / ES256 / RS256) based on the
+/// `algorithms: ['…']` (or singular `algorithm: '…'`) option.
+/// Mirrors `lower_jsonwebtoken_sign`.
+///
+/// perry#927 follow-up: the generic NativeModSig table picked
+/// `js_jwt_verify` (HS256-only) for every algorithm, so ES256 / RS256
+/// tokens silently failed verification (returning `null` to user
+/// code, breaking the shop-admin auth middleware after a successful
+/// signup). Verify needs the same option-aware routing that `sign`
+/// already has.
+///
+/// Return shape matches the old `NR_OBJ_FROM_JSON_STR`: the runtime
+/// hands back a JSON-text `*mut StringHeader` (or null), which we
+/// pipe through `js_json_parse_or_null` so user code sees a real
+/// object on success and `null` on failure (no throw).
+fn lower_jsonwebtoken_verify(ctx: &mut FnCtx<'_>, args: &[Expr]) -> Result<String> {
+    if args.len() < 2 {
+        bail!(
+            "jsonwebtoken.verify(token, secret, options?) expects at least 2 args, got {}",
+            args.len()
+        );
+    }
+
+    let token_ptr = get_raw_string_ptr(ctx, &args[0])?;
+    let secret_ptr = get_raw_string_ptr(ctx, &args[1])?;
+    let mut runtime = "js_jwt_verify";
+
+    if let Some(options) = args.get(2) {
+        if let Some(props) = extract_options_fields(ctx, options) {
+            for (key, val) in &props {
+                match key.as_str() {
+                    // `algorithm: 'ES256'` (singular) — accepted for
+                    // symmetry with `sign`'s option name.
+                    "algorithm" => {
+                        if let Expr::String(algorithm) = val {
+                            runtime = match algorithm.as_str() {
+                                "ES256" => "js_jwt_verify_es256",
+                                "RS256" => "js_jwt_verify_rs256",
+                                _ => "js_jwt_verify",
+                            };
+                        } else {
+                            let _ = lower_expr(ctx, val)?;
+                        }
+                    }
+                    // `algorithms: ['ES256']` (plural array) — the
+                    // canonical Node `jsonwebtoken.verify` shape.
+                    // First entry decides routing; the underlying Rust
+                    // jsonwebtoken crate's verify is single-algorithm,
+                    // so multi-algorithm fallback isn't honored.
+                    "algorithms" => {
+                        if let Expr::Array(elems) = val {
+                            if let Some(Expr::String(algorithm)) = elems.first() {
+                                runtime = match algorithm.as_str() {
+                                    "ES256" => "js_jwt_verify_es256",
+                                    "RS256" => "js_jwt_verify_rs256",
+                                    _ => "js_jwt_verify",
+                                };
+                            }
+                        } else {
+                            let _ = lower_expr(ctx, val)?;
+                        }
+                    }
+                    _ => {
+                        let _ = lower_expr(ctx, val)?;
+                    }
+                }
+            }
+        } else {
+            let _ = lower_expr(ctx, options)?;
+        }
+    }
+
+    for extra in args.iter().skip(3) {
+        let _ = lower_expr(ctx, extra)?;
+    }
+
+    ctx.pending_declares
+        .push((runtime.to_string(), I64, vec![I64, I64]));
+    ctx.pending_declares
+        .push(("js_json_parse_or_null".to_string(), I64, vec![I64]));
+    let blk = ctx.block();
+    let raw = blk.call(I64, runtime, &[(I64, &token_ptr), (I64, &secret_ptr)]);
+    let parsed_bits = blk.call(I64, "js_json_parse_or_null", &[(I64, &raw)]);
+    Ok(blk.bitcast_i64_to_double(&parsed_bits))
+}
+
 pub(crate) fn lower_native_method_call(
     ctx: &mut FnCtx<'_>,
     module: &str,
@@ -347,6 +434,9 @@ pub(crate) fn lower_native_method_call(
 
     if module == "jsonwebtoken" && method == "sign" && object.is_none() {
         return lower_jsonwebtoken_sign(ctx, args);
+    }
+    if module == "jsonwebtoken" && method == "verify" && object.is_none() {
+        return lower_jsonwebtoken_verify(ctx, args);
     }
 
     // `perry/ui.App({ title, width, height, body, icon? })` — minimum-viable

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -1942,6 +1942,8 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_jwt_sign_es256", I64, &[I64, I64, DOUBLE, I64]);
     module.declare_function("js_jwt_sign_rs256", I64, &[I64, I64, DOUBLE, I64]);
     module.declare_function("js_jwt_verify", I64, &[I64, I64]);
+    module.declare_function("js_jwt_verify_es256", I64, &[I64, I64]);
+    module.declare_function("js_jwt_verify_rs256", I64, &[I64, I64]);
 
     // ========== axios / node-fetch ==========
     module.declare_function("js_axios_create", DOUBLE, &[I64]);

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -191,7 +191,7 @@ bundled-mongodb = ["dep:mongodb", "dep:bson", "dep:futures-util", "async-runtime
 crypto = ["dep:sha2", "dep:sha1", "dep:md-5", "dep:hex", "dep:hmac", "dep:aes", "dep:cbc", "dep:scrypt", "dep:pbkdf2", "dep:base64", "dep:x25519-dalek", "dep:ed25519-dalek", "dep:aes-gcm", "dep:aes-kw", "dep:hkdf", "async-runtime", "ids", "bundled-bcrypt", "bundled-argon2", "bundled-jsonwebtoken", "bundled-ethers"]
 bundled-bcrypt = ["dep:bcrypt", "async-runtime"]
 bundled-argon2 = ["dep:argon2", "async-runtime"]
-bundled-jsonwebtoken = ["dep:jsonwebtoken"]
+bundled-jsonwebtoken = ["dep:jsonwebtoken", "dep:p256", "dep:rsa", "dep:spki"]
 # ethers blockchain utilities — pure Rust, no extra deps. Default-on
 # through `crypto` umbrella; the well-known flip strips this and
 # routes to perry-ext-ethers when `import 'ethers'` is detected.
@@ -309,6 +309,9 @@ hex = { version = "0.4", optional = true }
 hmac = { version = "0.12", optional = true }
 bcrypt = { version = "0.17", optional = true }
 jsonwebtoken = { version = "10.4", optional = true, default-features = false, features = ["rust_crypto", "use_pem"] }
+p256 = { version = "0.13", optional = true, default-features = false, features = ["pkcs8", "pem", "ecdsa"] }
+rsa = { version = "0.9", optional = true, default-features = false, features = ["pem"] }
+spki = { version = "0.7", optional = true, default-features = false, features = ["pem", "alloc"] }
 aes = { version = "0.8", optional = true }
 cbc = { version = "0.1", optional = true }
 scrypt = { version = "0.11", optional = true }

--- a/crates/perry-stdlib/src/jsonwebtoken.rs
+++ b/crates/perry-stdlib/src/jsonwebtoken.rs
@@ -141,7 +141,29 @@ pub unsafe extern "C" fn js_jwt_sign_es256(
         Some(p) => p,
         None => return 0,
     };
-    let key = match EncodingKey::from_ec_pem(pem.as_bytes()) {
+    // jsonwebtoken's `EncodingKey::from_ec_pem` only accepts PKCS#8
+    // (`-----BEGIN PRIVATE KEY-----`). openssl's default
+    // `ecparam -genkey -name prime256v1` emits SEC1
+    // (`-----BEGIN EC PRIVATE KEY-----`), which is the form most users
+    // start with. Convert SEC1 → PKCS#8 transparently so both PEM
+    // forms work. Same ergonomic story as the verify side's
+    // `ec_pem_to_public_pem` helper.
+    let pkcs8_pem = if pem.contains("EC PRIVATE KEY") {
+        use p256::pkcs8::EncodePrivateKey;
+        match p256::SecretKey::from_sec1_pem(&pem)
+            .ok()
+            .and_then(|k| k.to_pkcs8_pem(Default::default()).ok())
+        {
+            Some(p) => p.to_string(),
+            None => {
+                eprintln!("[jwt-sign-es256] could not convert SEC1 EC PEM to PKCS#8");
+                return 0;
+            }
+        }
+    } else {
+        pem
+    };
+    let key = match EncodingKey::from_ec_pem(pkcs8_pem.as_bytes()) {
         Ok(k) => k,
         Err(e) => {
             eprintln!("[jwt-sign-es256] invalid EC PEM key: {}", e);
@@ -189,7 +211,43 @@ pub unsafe extern "C" fn js_jwt_sign_rs256(
     )
 }
 
-/// Verify and decode a JWT
+/// Shared verify path — runs the decode + returns claims as JSON, or
+/// a null pointer on any failure. `debug` mirrors the gating in
+/// `js_jwt_verify` (perry#924) so all three verify entry points emit
+/// the same `[jwt-verify]` log lines under `PERRY_DEBUG=1`.
+unsafe fn verify_decode(
+    token: &str,
+    key: &DecodingKey,
+    algorithm: Algorithm,
+    debug: bool,
+) -> *mut StringHeader {
+    let mut validation = Validation::new(algorithm);
+    // Don't require exp claim - tokens may not have expiry set
+    validation.required_spec_claims = std::collections::HashSet::new();
+    validation.validate_exp = false;
+
+    match decode::<Claims>(token, key, &validation) {
+        Ok(token_data) => {
+            let json =
+                serde_json::to_string(&token_data.claims).unwrap_or_else(|_| "{}".to_string());
+            if debug {
+                eprintln!(
+                    "[jwt-verify] success, claims={}",
+                    &json[..json.len().min(80)]
+                );
+            }
+            js_string_from_bytes(json.as_ptr(), json.len() as u32)
+        }
+        Err(e) => {
+            if debug {
+                eprintln!("[jwt-verify] error: {}", e);
+            }
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// Verify and decode an HS256 JWT
 /// jwt.verify(token, secret) -> object (payload)
 #[no_mangle]
 pub unsafe extern "C" fn js_jwt_verify(
@@ -226,31 +284,173 @@ pub unsafe extern "C" fn js_jwt_verify(
     };
 
     let key = DecodingKey::from_secret(secret.as_bytes());
-    let mut validation = Validation::new(Algorithm::HS256);
-    // Don't require exp claim - tokens may not have expiry set
-    validation.required_spec_claims = std::collections::HashSet::new();
-    validation.validate_exp = false;
+    verify_decode(&token, &key, Algorithm::HS256, debug)
+}
 
-    match decode::<Claims>(&token, &key, &validation) {
-        Ok(token_data) => {
-            // Return the claims as JSON
-            let json =
-                serde_json::to_string(&token_data.claims).unwrap_or_else(|_| "{}".to_string());
+/// Coerce an EC PEM (public *or* private, SEC1 or PKCS#8) into a
+/// PKCS#8 PUBLIC KEY PEM that `DecodingKey::from_ec_pem` accepts.
+/// Mirrors Node's `jsonwebtoken` ergonomics: the user can pass the
+/// same PEM to `sign` and `verify` without having to extract the
+/// public key separately. perry#927 follow-up — without this, ES256
+/// `verify` rejected the very PEM the matching `sign` accepted,
+/// breaking the shop-admin auth path even after the JSON-parse
+/// return-shape fix.
+fn ec_pem_to_public_pem(pem: &str) -> Option<String> {
+    use p256::pkcs8::{DecodePrivateKey, EncodePublicKey};
+
+    if pem.contains("PUBLIC KEY") {
+        return Some(pem.to_string());
+    }
+
+    // Try PKCS#8 private (`-----BEGIN PRIVATE KEY-----`) first,
+    // then SEC1 (`-----BEGIN EC PRIVATE KEY-----`).
+    let secret = p256::SecretKey::from_pkcs8_pem(pem)
+        .or_else(|_| p256::SecretKey::from_sec1_pem(pem))
+        .ok()?;
+    secret
+        .public_key()
+        .to_public_key_pem(Default::default())
+        .ok()
+}
+
+/// Verify and decode an ES256 JWT.
+/// `pem_ptr` may contain either a PUBLIC key PEM (SPKI) or the
+/// matching PRIVATE key PEM (PKCS#8 or SEC1) — the latter is
+/// auto-converted via `ec_pem_to_public_pem` so callers can reuse
+/// their signing key.
+/// jwt.verify(token, pem, { algorithms: ['ES256'] }) -> object
+#[no_mangle]
+pub unsafe extern "C" fn js_jwt_verify_es256(
+    token_ptr: *const StringHeader,
+    pem_ptr: *const StringHeader,
+) -> *mut StringHeader {
+    let debug = std::env::var_os("PERRY_DEBUG").is_some();
+
+    let token = match string_from_header(token_ptr) {
+        Some(t) => t,
+        None => {
             if debug {
-                eprintln!(
-                    "[jwt-verify] success, claims={}",
-                    &json[..json.len().min(80)]
-                );
+                eprintln!("[jwt-verify-es256] token_ptr is null or invalid");
             }
-            js_string_from_bytes(json.as_ptr(), json.len() as u32)
+            return std::ptr::null_mut();
         }
+    };
+
+    let pem = match string_from_header(pem_ptr) {
+        Some(p) => p,
+        None => {
+            if debug {
+                eprintln!("[jwt-verify-es256] pem_ptr is null or invalid");
+            }
+            return std::ptr::null_mut();
+        }
+    };
+
+    let public_pem = match ec_pem_to_public_pem(&pem) {
+        Some(p) => p,
+        None => {
+            if debug {
+                eprintln!("[jwt-verify-es256] could not derive EC public key from PEM");
+            }
+            return std::ptr::null_mut();
+        }
+    };
+
+    let key = match DecodingKey::from_ec_pem(public_pem.as_bytes()) {
+        Ok(k) => k,
         Err(e) => {
             if debug {
-                eprintln!("[jwt-verify] error: {}", e);
+                eprintln!("[jwt-verify-es256] invalid EC PEM key: {}", e);
             }
-            std::ptr::null_mut()
+            return std::ptr::null_mut();
         }
+    };
+
+    verify_decode(&token, &key, Algorithm::ES256, debug)
+}
+
+/// Coerce an RSA PEM (public *or* private, PKCS#1 or PKCS#8) into a
+/// PEM that `DecodingKey::from_rsa_pem` accepts. Matches Node's
+/// `jsonwebtoken` behavior of accepting either side of the keypair
+/// on verify.
+fn rsa_pem_to_public_pem(pem: &str) -> Option<String> {
+    use rsa::pkcs1::EncodeRsaPublicKey;
+    use rsa::pkcs8::{DecodePrivateKey, EncodePublicKey};
+
+    if pem.contains("PUBLIC KEY") {
+        // Either PKCS#1 `RSA PUBLIC KEY` or PKCS#8 `PUBLIC KEY` —
+        // both consumed directly by `DecodingKey::from_rsa_pem`.
+        return Some(pem.to_string());
     }
+
+    // Try PKCS#8 (`-----BEGIN PRIVATE KEY-----`) then PKCS#1
+    // (`-----BEGIN RSA PRIVATE KEY-----`).
+    let priv_key = rsa::RsaPrivateKey::from_pkcs8_pem(pem)
+        .or_else(|_| {
+            use rsa::pkcs1::DecodeRsaPrivateKey;
+            rsa::RsaPrivateKey::from_pkcs1_pem(pem)
+        })
+        .ok()?;
+    let pub_key = priv_key.to_public_key();
+    pub_key
+        .to_public_key_pem(Default::default())
+        .ok()
+        .or_else(|| pub_key.to_pkcs1_pem(Default::default()).ok())
+}
+
+/// Verify and decode an RS256 JWT.
+/// `pem_ptr` may contain either a PUBLIC key PEM (PKCS#1 or PKCS#8)
+/// or the matching PRIVATE key PEM (auto-converted via
+/// `rsa_pem_to_public_pem`).
+/// jwt.verify(token, pem, { algorithms: ['RS256'] }) -> object
+#[no_mangle]
+pub unsafe extern "C" fn js_jwt_verify_rs256(
+    token_ptr: *const StringHeader,
+    pem_ptr: *const StringHeader,
+) -> *mut StringHeader {
+    let debug = std::env::var_os("PERRY_DEBUG").is_some();
+
+    let token = match string_from_header(token_ptr) {
+        Some(t) => t,
+        None => {
+            if debug {
+                eprintln!("[jwt-verify-rs256] token_ptr is null or invalid");
+            }
+            return std::ptr::null_mut();
+        }
+    };
+
+    let pem = match string_from_header(pem_ptr) {
+        Some(p) => p,
+        None => {
+            if debug {
+                eprintln!("[jwt-verify-rs256] pem_ptr is null or invalid");
+            }
+            return std::ptr::null_mut();
+        }
+    };
+
+    let public_pem = match rsa_pem_to_public_pem(&pem) {
+        Some(p) => p,
+        None => {
+            if debug {
+                eprintln!("[jwt-verify-rs256] could not derive RSA public key from PEM");
+            }
+            return std::ptr::null_mut();
+        }
+    };
+
+    let key = match DecodingKey::from_rsa_pem(public_pem.as_bytes()) {
+        Ok(k) => k,
+        Err(e) => {
+            if debug {
+                eprintln!("[jwt-verify-rs256] invalid RSA PEM key: {}", e);
+            }
+            return std::ptr::null_mut();
+        }
+    };
+
+    verify_decode(&token, &key, Algorithm::RS256, debug)
 }
 
 /// Decode a JWT without verification (just parse the payload)


### PR DESCRIPTION
## Summary

The previous #927 fix (#936) made `jwt.verify` return the parsed claims object instead of the JSON text, but ES256 / RS256 tokens were still failing verification silently — the generic `NativeModSig` table routed every algorithm through `js_jwt_verify`, which was hardcoded to HS256. The token was signed correctly with ES256, then `Validation::new(Algorithm::HS256)` rejected it with `InvalidAlgorithm`, the runtime returned a null pointer, and `js_json_parse_or_null` surfaced it as `null` — breaking shop-admin's auth middleware on the very first authenticated request after a successful signup.

Fix mirrors the `sign` side's algorithm-aware dispatch:

- Add `js_jwt_verify_es256` / `js_jwt_verify_rs256` runtime functions in `perry-stdlib/src/jsonwebtoken.rs`. Both auto-derive the public key from a private PEM (PKCS#8 *or* SEC1 for EC, PKCS#8 *or* PKCS#1 for RSA) so callers can reuse the same PEM they passed to `sign` — matches Node `jsonwebtoken`'s ergonomics. Direct public-key PEMs (SPKI) also accepted unchanged.
- Replace the generic `NativeModSig` `verify` row with `lower_jsonwebtoken_verify` in `crates/perry-codegen/src/lower_call/native.rs`. Routes on the canonical `algorithms: ['…']` array option as well as the singular `algorithm: '…'`. Falls back to HS256 when the option is absent or unparseable. Return path still pipes through `js_json_parse_or_null` so user code sees an object on success and `null` on failure (same contract as before).
- Bonus: `js_jwt_sign_es256` now also accepts SEC1 (`-----BEGIN EC PRIVATE KEY-----`) PEMs, which is what `openssl ecparam -genkey -name prime256v1` emits by default. Symmetric with the new verify ergonomics.

New `perry-stdlib` deps gated on `bundled-jsonwebtoken`: `p256` (EC public-key derivation), `rsa` (RSA public-key derivation), `spki` (PEM serialization helpers).

## Test plan

- [x] Standalone repro (sign + verify a token with `algorithms: ['ES256']`) now returns the parsed claims object — `typeof decoded` is `"object"`, `decoded.sub` accessible. Previously returned `null`.
- [x] Same repro with SEC1 EC private PEM (openssl default) now signs + verifies — previously failed with `InvalidKeyFormat`.
- [x] HS256 path still works (existing perry#924 regression tests untouched).
- [ ] Full shop-admin signup → first authenticated route — re-running to confirm the perry#665 → #748 → #858 → #859 → #915 → #927 → #928 cascade is finally complete end-to-end.

## Repro

```ts
import jwt from "jsonwebtoken";
import { readFileSync } from "fs";
const PEM = readFileSync("/tmp/skelpo-jwt.pem", "utf8");
const TOK = jwt.sign({ sub: "u-001", acc: "a-001" }, PEM, { algorithm: "ES256", issuer: "z" });
const decoded = jwt.verify(TOK, PEM, { algorithms: ["ES256"], issuer: "z" }) as any;
console.log("typeof:", typeof decoded, "sub:", decoded?.sub);
```

Before this PR: `typeof: object sub: undefined` (decoded was `null`).
After: `typeof: object sub: u-001`.