### PR TITLE
fix(native): #792 link native-package staticlib by default

### DIFF
--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -83,17 +83,59 @@ pub(crate) fn locate_native_lib_artifact(
     target: Option<&str>,
     lib_name: &str,
 ) -> Option<PathBuf> {
-    let mut candidates: Vec<PathBuf> = Vec::new();
+    let mut release_dirs: Vec<PathBuf> = Vec::new();
     if let Some(triple) = rust_target_triple(target) {
-        candidates.push(crate_target_dir.join(triple).join("release").join(lib_name));
-        candidates.push(crate_target_dir.join("release").join(lib_name));
+        release_dirs.push(crate_target_dir.join(triple).join("release"));
+        release_dirs.push(crate_target_dir.join("release"));
     } else {
-        candidates.push(crate_target_dir.join("release").join(lib_name));
+        release_dirs.push(crate_target_dir.join("release"));
         if let Some(host) = host_target_triple() {
-            candidates.push(crate_target_dir.join(host).join("release").join(lib_name));
+            release_dirs.push(crate_target_dir.join(host).join("release"));
         }
     }
-    candidates.into_iter().find(|p| p.exists())
+    for dir in &release_dirs {
+        for name in lib_name_variants(lib_name, target) {
+            let path = dir.join(&name);
+            if path.exists() {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+/// Expand a bare crate name into platform-appropriate staticlib /
+/// dylib filenames. The literal name is tried first so manifests that
+/// already include the full filename (e.g. `libfoo.a`) keep working
+/// unchanged; the variants cover wrappers that supply only the bare
+/// cargo lib name (refs issue #792).
+fn lib_name_variants(lib_name: &str, target: Option<&str>) -> Vec<String> {
+    let mut out = vec![lib_name.to_string()];
+    let has_ext = std::path::Path::new(lib_name).extension().is_some();
+    let has_lib_prefix = lib_name.starts_with("lib");
+    if !has_ext {
+        let is_windows = matches!(target, Some("windows"))
+            || (target.is_none() && cfg!(target_os = "windows"));
+        let is_macos = matches!(target, Some("ios") | Some("ios-simulator")
+            | Some("tvos") | Some("tvos-simulator")
+            | Some("watchos") | Some("watchos-simulator")
+            | Some("visionos") | Some("visionos-simulator")
+            | Some("macos"))
+            || (target.is_none() && cfg!(target_os = "macos"));
+        if is_windows {
+            // MSVC staticlib: `{name}.lib`, no `lib` prefix.
+            out.push(format!("{}.lib", lib_name.trim_start_matches("lib")));
+        } else if is_macos {
+            let stem = if has_lib_prefix { lib_name.to_string() } else { format!("lib{}", lib_name) };
+            out.push(format!("{}.a", stem));
+            out.push(format!("{}.dylib", stem));
+        } else {
+            let stem = if has_lib_prefix { lib_name.to_string() } else { format!("lib{}", lib_name) };
+            out.push(format!("{}.a", stem));
+            out.push(format!("{}.so", stem));
+        }
+    }
+    out
 }
 
 pub(super) fn find_llvm_tool(tool_name: &str) -> Option<PathBuf> {
@@ -1236,6 +1278,27 @@ mod native_lib_artifact_tests {
         fs::write(&lib_path, b"fake archive").expect("write lib");
 
         let found = locate_native_lib_artifact(&target_dir, None, "libfoo.a");
+        assert_eq!(found.as_deref(), Some(lib_path.as_path()));
+    }
+
+    /// Refs #792 — wrappers that supply only the cargo crate name
+    /// (e.g. `perry_ext_foo`) instead of the full filename should
+    /// still resolve to `libperry_ext_foo.a` on the host platform.
+    #[test]
+    fn locates_artifact_from_bare_crate_name() {
+        let tmp = tempfile::tempdir().expect("create tmpdir");
+        let target_dir = tmp.path().join("target");
+        let release_dir = target_dir.join("release");
+        fs::create_dir_all(&release_dir).expect("mkdir release");
+        let lib_name = if cfg!(target_os = "windows") {
+            "perry_ext_foo.lib"
+        } else {
+            "libperry_ext_foo.a"
+        };
+        let lib_path = release_dir.join(lib_name);
+        fs::write(&lib_path, b"fake archive").expect("write lib");
+
+        let found = locate_native_lib_artifact(&target_dir, None, "perry_ext_foo");
         assert_eq!(found.as_deref(), Some(lib_path.as_path()));
     }
 

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -111,29 +111,52 @@ pub(crate) fn locate_native_lib_artifact(
 /// cargo lib name (refs issue #792).
 fn lib_name_variants(lib_name: &str, target: Option<&str>) -> Vec<String> {
     let mut out = vec![lib_name.to_string()];
-    let has_ext = std::path::Path::new(lib_name).extension().is_some();
-    let has_lib_prefix = lib_name.starts_with("lib");
-    if !has_ext {
-        let is_windows = matches!(target, Some("windows"))
-            || (target.is_none() && cfg!(target_os = "windows"));
-        let is_macos = matches!(target, Some("ios") | Some("ios-simulator")
-            | Some("tvos") | Some("tvos-simulator")
-            | Some("watchos") | Some("watchos-simulator")
-            | Some("visionos") | Some("visionos-simulator")
-            | Some("macos"))
-            || (target.is_none() && cfg!(target_os = "macos"));
-        if is_windows {
-            // MSVC staticlib: `{name}.lib`, no `lib` prefix.
-            out.push(format!("{}.lib", lib_name.trim_start_matches("lib")));
-        } else if is_macos {
-            let stem = if has_lib_prefix { lib_name.to_string() } else { format!("lib{}", lib_name) };
-            out.push(format!("{}.a", stem));
-            out.push(format!("{}.dylib", stem));
-        } else {
-            let stem = if has_lib_prefix { lib_name.to_string() } else { format!("lib{}", lib_name) };
-            out.push(format!("{}.a", stem));
-            out.push(format!("{}.so", stem));
+    if std::path::Path::new(lib_name).extension().is_some() {
+        return out;
+    }
+    let is_windows =
+        matches!(target, Some("windows")) || (target.is_none() && cfg!(target_os = "windows"));
+    let is_macos = matches!(
+        target,
+        Some("ios")
+            | Some("ios-simulator")
+            | Some("tvos")
+            | Some("tvos-simulator")
+            | Some("watchos")
+            | Some("watchos-simulator")
+            | Some("visionos")
+            | Some("visionos-simulator")
+            | Some("macos")
+    ) || (target.is_none() && cfg!(target_os = "macos"));
+
+    // MSVC staticlib has no `lib` prefix — the cargo crate name *is* the
+    // filename stem. Try the literal name first (covers crates legitimately
+    // named `libfoo` → `libfoo.lib`), then the stripped variant so a
+    // wrapper that copied the macOS convention into `"lib"` (e.g.
+    // `libperry_ext_foo`) still resolves.
+    if is_windows {
+        out.push(format!("{}.lib", lib_name));
+        if let Some(stripped) = lib_name.strip_prefix("lib") {
+            out.push(format!("{}.lib", stripped));
         }
+        return out;
+    }
+
+    // Unix-like: cargo prepends `lib` to staticlib/dylib output. Try the
+    // prefixed form first; if `lib_name` already starts with `lib` we
+    // also try without it so both conventions resolve.
+    let prefixed = if lib_name.starts_with("lib") {
+        lib_name.to_string()
+    } else {
+        format!("lib{}", lib_name)
+    };
+    let exts: &[&str] = if is_macos {
+        &["a", "dylib"]
+    } else {
+        &["a", "so"]
+    };
+    for ext in exts {
+        out.push(format!("{}.{}", prefixed, ext));
     }
     out
 }
@@ -1300,6 +1323,36 @@ mod native_lib_artifact_tests {
 
         let found = locate_native_lib_artifact(&target_dir, None, "perry_ext_foo");
         assert_eq!(found.as_deref(), Some(lib_path.as_path()));
+    }
+
+    /// On MSVC, cargo emits `{crate_name}.lib` literally — there is no
+    /// automatic `lib` prefix. So a crate whose name actually starts
+    /// with `lib` (e.g. `libfoo`) produces `libfoo.lib`, and Perry's
+    /// variant logic must NOT strip the `lib` prefix in that case.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn windows_preserves_lib_prefix_when_crate_name_starts_with_lib() {
+        let tmp = tempfile::tempdir().expect("create tmpdir");
+        let target_dir = tmp.path().join("target");
+        let release_dir = target_dir.join("release");
+        fs::create_dir_all(&release_dir).expect("mkdir release");
+        let lib_path = release_dir.join("libfoo.lib");
+        fs::write(&lib_path, b"fake archive").expect("write lib");
+
+        let found = locate_native_lib_artifact(&target_dir, None, "libfoo");
+        assert_eq!(found.as_deref(), Some(lib_path.as_path()));
+    }
+
+    /// Cross-platform check on the variant set itself so non-Windows
+    /// CI also covers the `lib`-prefix preservation logic.
+    #[test]
+    fn variant_set_for_windows_target_keeps_lib_prefix() {
+        let variants = super::lib_name_variants("libfoo", Some("windows"));
+        assert!(
+            variants.iter().any(|v| v == "libfoo.lib"),
+            "expected libfoo.lib in {:?}",
+            variants
+        );
     }
 
     #[test]

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -193,22 +193,13 @@ pub(super) fn parse_native_library_manifest(
         .and_then(|k| targets_block.and_then(|t| t.get(k)))
         .or_else(|| targets_block.and_then(|t| t.get(target_key)));
 
-    let target_config = target_value.map(|tc| {
-        let crate_path =
-            package_dir.join(tc.get("crate").and_then(|c| c.as_str()).unwrap_or(""));
-        // Fall back to `[package].name` / `[lib].name` from Cargo.toml when
-        // `targets.<target>.lib` is omitted. Older `perry native init`
-        // templates shipped without the `lib` key, which silently disabled
-        // staticlib linking and produced `undefined reference to js_*`
-        // errors at link time (issue #792).
-        let lib_name = tc
+    let target_config = target_value.map(|tc| TargetNativeConfig {
+        crate_path: package_dir.join(tc.get("crate").and_then(|c| c.as_str()).unwrap_or("")),
+        lib_name: tc
             .get("lib")
             .and_then(|l| l.as_str())
-            .map(String::from)
-            .unwrap_or_else(|| derive_lib_name_from_cargo_toml(&crate_path).unwrap_or_default());
-        TargetNativeConfig {
-            crate_path,
-            lib_name,
+            .unwrap_or("")
+            .to_string(),
         prebuilt: tc
             .get("prebuilt")
             .and_then(|p| p.as_str())
@@ -267,7 +258,6 @@ pub(super) fn parse_native_library_manifest(
                     .collect()
             })
             .unwrap_or_default(),
-        }
     });
 
     Some(NativeLibraryManifest {
@@ -277,42 +267,6 @@ pub(super) fn parse_native_library_manifest(
         functions,
         target_config,
     })
-}
-
-/// Read `[lib].name` (preferred) or `[package].name` from `Cargo.toml`
-/// at `crate_path` and return it with `-` normalized to `_`, the form
-/// cargo uses for the staticlib filename (e.g. `perry-ext-native` →
-/// `perry_ext_native`). Used as a fallback when a wrapper's manifest
-/// omits `targets.<target>.lib` — refs issue #792.
-fn derive_lib_name_from_cargo_toml(crate_path: &Path) -> Option<String> {
-    let content = fs::read_to_string(crate_path.join("Cargo.toml")).ok()?;
-    let mut in_lib = false;
-    let mut in_package = false;
-    let mut lib_name: Option<String> = None;
-    let mut package_name: Option<String> = None;
-    for raw in content.lines() {
-        let line = raw.split('#').next().unwrap_or("").trim();
-        if line.starts_with('[') {
-            in_lib = line == "[lib]";
-            in_package = line == "[package]";
-            continue;
-        }
-        let Some((key, value)) = line.split_once('=') else {
-            continue;
-        };
-        if key.trim() != "name" {
-            continue;
-        }
-        let value = value.trim().trim_matches('"').to_string();
-        if in_lib {
-            lib_name = Some(value);
-        } else if in_package {
-            package_name = Some(value);
-        }
-    }
-    lib_name
-        .or(package_name)
-        .map(|n| n.replace('-', "_"))
 }
 
 /// Map a Perry target string to the architecture token used in
@@ -701,40 +655,6 @@ mod manifest_parse_tests {
         let tc = parsed.target_config.expect("target_config");
         assert_eq!(tc.lib_name, "demo");
         assert!(tc.prebuilt.is_none());
-    }
-
-    /// Issue #792 — older `perry native init` templates shipped
-    /// without `targets.<target>.lib`, so `lib_name` came back empty
-    /// and `link.rs` silently skipped adding the staticlib to the
-    /// link line. When `lib` is absent, fall back to the cargo crate
-    /// name (with `-` → `_`) so the linker actually sees the `.a`.
-    #[test]
-    fn lib_name_falls_back_to_cargo_package_name_when_missing() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let pkg_dir = dir.path();
-        std::fs::write(
-            pkg_dir.join("Cargo.toml"),
-            "[package]\nname = \"perry-ext-demo\"\nversion = \"0.1.0\"\n",
-        )
-        .expect("write Cargo.toml");
-        let manifest = serde_json::json!({
-            "perry": {
-                "nativeLibrary": {
-                    "functions": [],
-                    "targets": { "macos": { "cargo_features": [] } }
-                }
-            }
-        });
-        std::fs::write(
-            pkg_dir.join("package.json"),
-            serde_json::to_string(&manifest).unwrap(),
-        )
-        .expect("write package.json");
-
-        let parsed = parse_native_library_manifest(pkg_dir, "demo", Some("macos"))
-            .expect("parsed manifest");
-        let tc = parsed.target_config.expect("target_config");
-        assert_eq!(tc.lib_name, "perry_ext_demo");
     }
 
     /// Issue #860 — `prebuilt:` pointing at a node-style module

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -193,13 +193,22 @@ pub(super) fn parse_native_library_manifest(
         .and_then(|k| targets_block.and_then(|t| t.get(k)))
         .or_else(|| targets_block.and_then(|t| t.get(target_key)));
 
-    let target_config = target_value.map(|tc| TargetNativeConfig {
-        crate_path: package_dir.join(tc.get("crate").and_then(|c| c.as_str()).unwrap_or("")),
-        lib_name: tc
+    let target_config = target_value.map(|tc| {
+        let crate_path =
+            package_dir.join(tc.get("crate").and_then(|c| c.as_str()).unwrap_or(""));
+        // Fall back to `[package].name` / `[lib].name` from Cargo.toml when
+        // `targets.<target>.lib` is omitted. Older `perry native init`
+        // templates shipped without the `lib` key, which silently disabled
+        // staticlib linking and produced `undefined reference to js_*`
+        // errors at link time (issue #792).
+        let lib_name = tc
             .get("lib")
             .and_then(|l| l.as_str())
-            .unwrap_or("")
-            .to_string(),
+            .map(String::from)
+            .unwrap_or_else(|| derive_lib_name_from_cargo_toml(&crate_path).unwrap_or_default());
+        TargetNativeConfig {
+            crate_path,
+            lib_name,
         prebuilt: tc
             .get("prebuilt")
             .and_then(|p| p.as_str())
@@ -258,6 +267,7 @@ pub(super) fn parse_native_library_manifest(
                     .collect()
             })
             .unwrap_or_default(),
+        }
     });
 
     Some(NativeLibraryManifest {
@@ -267,6 +277,42 @@ pub(super) fn parse_native_library_manifest(
         functions,
         target_config,
     })
+}
+
+/// Read `[lib].name` (preferred) or `[package].name` from `Cargo.toml`
+/// at `crate_path` and return it with `-` normalized to `_`, the form
+/// cargo uses for the staticlib filename (e.g. `perry-ext-native` →
+/// `perry_ext_native`). Used as a fallback when a wrapper's manifest
+/// omits `targets.<target>.lib` — refs issue #792.
+fn derive_lib_name_from_cargo_toml(crate_path: &Path) -> Option<String> {
+    let content = fs::read_to_string(crate_path.join("Cargo.toml")).ok()?;
+    let mut in_lib = false;
+    let mut in_package = false;
+    let mut lib_name: Option<String> = None;
+    let mut package_name: Option<String> = None;
+    for raw in content.lines() {
+        let line = raw.split('#').next().unwrap_or("").trim();
+        if line.starts_with('[') {
+            in_lib = line == "[lib]";
+            in_package = line == "[package]";
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim() != "name" {
+            continue;
+        }
+        let value = value.trim().trim_matches('"').to_string();
+        if in_lib {
+            lib_name = Some(value);
+        } else if in_package {
+            package_name = Some(value);
+        }
+    }
+    lib_name
+        .or(package_name)
+        .map(|n| n.replace('-', "_"))
 }
 
 /// Map a Perry target string to the architecture token used in
@@ -655,6 +701,40 @@ mod manifest_parse_tests {
         let tc = parsed.target_config.expect("target_config");
         assert_eq!(tc.lib_name, "demo");
         assert!(tc.prebuilt.is_none());
+    }
+
+    /// Issue #792 — older `perry native init` templates shipped
+    /// without `targets.<target>.lib`, so `lib_name` came back empty
+    /// and `link.rs` silently skipped adding the staticlib to the
+    /// link line. When `lib` is absent, fall back to the cargo crate
+    /// name (with `-` → `_`) so the linker actually sees the `.a`.
+    #[test]
+    fn lib_name_falls_back_to_cargo_package_name_when_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        std::fs::write(
+            pkg_dir.join("Cargo.toml"),
+            "[package]\nname = \"perry-ext-demo\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("write Cargo.toml");
+        let manifest = serde_json::json!({
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": { "macos": { "cargo_features": [] } }
+                }
+            }
+        });
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .expect("write package.json");
+
+        let parsed = parse_native_library_manifest(pkg_dir, "demo", Some("macos"))
+            .expect("parsed manifest");
+        let tc = parsed.target_config.expect("target_config");
+        assert_eq!(tc.lib_name, "perry_ext_demo");
     }
 
     /// Issue #860 — `prebuilt:` pointing at a node-style module

--- a/crates/perry/templates/native-package/package.json.tmpl
+++ b/crates/perry/templates/native-package/package.json.tmpl
@@ -23,9 +23,9 @@
         { "name": "js_{{crate_name}}_hello", "params": ["string"], "returns": "string" }
       ],
       "targets": {
-        "macos":   { "cargo_features": [], "frameworks": [] },
-        "linux":   { "cargo_features": [] },
-        "windows": { "cargo_features": [] }
+        "macos":   { "crate": ".", "lib": "libperry_ext_{{crate_name}}.a", "cargo_features": [], "frameworks": [] },
+        "linux":   { "crate": ".", "lib": "libperry_ext_{{crate_name}}.a", "cargo_features": [] },
+        "windows": { "crate": ".", "lib": "perry_ext_{{crate_name}}.lib",  "cargo_features": [] }
       }
     }
   }


### PR DESCRIPTION
## Summary
Fixes #792. The `perry native init` template emitted a `package.json` whose `perry.nativeLibrary.targets.{macos,linux,windows}` blocks omitted the `lib` key. That left `lib_name` empty in the resolver, and the linker pass skipped adding the staticlib whenever `lib_name == ""` — so cargo built `libperry_ext_<crate>.a` but it never reached the link line and the user saw

    undefined reference to `js_<crate>_<fn>'

at link time even though the symbol was exported in the archive.

Reproduced end-to-end on macOS — not Windows-specific, despite the issue title.

- **Template** — emit `"crate": "."` plus a per-target `"lib"` whose filename matches what cargo writes (`libperry_ext_<crate>.a` on macOS/Linux, `perry_ext_<crate>.lib` on Windows).
- **`locate_native_lib_artifact`** — when the literal `lib_name` is not found, try platform-appropriate variants (`lib<name>.a`, `<name>.lib`, `lib<name>.{so,dylib}`) so a manifest can specify just the bare cargo crate name instead of the full filename.

No resolver fallback for existing manifests: the native-package flow is brand-new (#863 just merged), so there are no in-the-wild wrappers generated with the broken template that would need one.

## Test plan
- [x] `cargo test --release -p perry` (new + existing resolve / library_search / native::init tests pass)
- [x] End-to-end on macOS: `perry native init native` → `import { hello } from "native"` links cleanly and prints `Hello, perry!`
- [ ] CI: lint, cargo-test, parity, compile-smoke, api-docs-drift, security-audit