### PR TITLE
feat(telemetry): #849 — opt-in compatibility reports for unsupported TS/Node features

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,78 @@ perry/
 
 ---
 
+## Privacy & Telemetry
+
+Perry ships **two independent opt-in channels** for sending data home —
+nothing leaves your machine without an explicit `enabled = true` or `on` in
+`~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and `CI=true`.
+
+### 1. Generic usage analytics — `telemetry.enabled`
+
+Counts `perry compile`, `perry init`, `perry publish` invocations on a
+background HTTP POST. Sends: command name, platform (`darwin`/`linux`/...),
+Perry version, success/error status, and an anonymous client UUID.
+
+### 2. Compatibility reports — `telemetry.compatibility_reports` (#849)
+
+Separate opt-in for "I hit an unsupported TS/Node feature and bailed." Sends
+a structured report when the compiler emits one of these diagnostic codes:
+`UnsupportedBinaryOp`, `UnsupportedExpression`, `UnsupportedStatement`,
+`DynamicPropertyAccess`, `ImplicitCoercion`, `UnresolvedImport`, `NoOpStub`.
+
+Three modes:
+
+- `off` — never send. Sink isn't even installed; zero overhead.
+- `ask` (default) — when a qualifying diagnostic fires, prompt once per
+  session: `[y] just this once / [a] always / [n] not this time / [N] never`.
+- `on` — always send (after dedup + redaction). No prompt.
+
+**What's sent (the entire payload schema):**
+
+```json
+{
+  "perry_version": "0.5.x",
+  "client_id": "uuid",
+  "code": "UnsupportedExpression",
+  "category": "gap-categorical",
+  "stage": "hir-lower",
+  "snippet_hash": "sha256:...",
+  "snippet_redacted": "let <id1> = await <id2>();",
+  "ts_feature": "decorator",
+  "node_api": "node:async_hooks.createHook",
+  "os": "darwin-arm64",
+  "node_target": "20"
+}
+```
+
+**What's NEVER sent:** raw source, file paths, project names, env vars, your
+program's stdout/stderr, dependency tree, or anything tied to identity
+beyond the existing anonymous `client_id`. Snippets are redacted before
+hashing — string literals → `"<str>"`, numbers → `<num>`, identifiers
+(except built-ins like `console`, `Math`, `Promise`) → `<id1>`, `<id2>`,
+capped at 200 chars, with a hard reject if any invariant fails.
+
+A local 30-day dedup cache at `~/.perry/.report-cache` prevents resending
+the same `snippet_hash` on every reload.
+
+### Inspecting & managing
+
+```bash
+perry doctor                          # shows current mode, sent/queued counts
+perry doctor --show-pending-reports   # print redacted payloads queued this run
+perry doctor --clear-report-cache     # wipe the 30-day dedup cache
+```
+
+To opt out at the file level, edit `~/.perry/config.toml`:
+
+```toml
+[telemetry]
+enabled = false                  # generic analytics off
+compatibility_reports = "off"    # #849 compat reports off
+```
+
+---
+
 ## Development
 
 ```bash

--- a/crates/perry-diagnostics/Cargo.toml
+++ b/crates/perry-diagnostics/Cargo.toml
@@ -8,3 +8,6 @@ description = "Diagnostic infrastructure for the Perry TypeScript compiler"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/crates/perry-diagnostics/src/compat_report.rs
+++ b/crates/perry-diagnostics/src/compat_report.rs
@@ -1,0 +1,828 @@
+//! Opt-in compatibility reports (#849).
+//!
+//! When the compiler emits a diagnostic whose `DiagnosticCode` is one of the
+//! "compatibility-gap" variants (`UnsupportedBinaryOp`, `UnsupportedExpression`,
+//! `UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`,
+//! `UnresolvedImport`, `NoOpStub`), we may want to record an anonymous report
+//! that points back at the unsupported feature so the maintainers can
+//! prioritize fixes.
+//!
+//! This module is **the privacy boundary**:
+//!
+//! - We never construct a payload that contains raw source text — only a
+//!   redacted snippet (identifiers anonymized to `<id1>`, `<id2>`; literals
+//!   replaced by `<str>`/`<num>`; capped at 200 chars).
+//! - We never send anything over the network from this crate. The actual
+//!   upload is delegated to the CLI (`crates/perry/src/telemetry.rs`) via a
+//!   `ReportSink` registered at process startup.
+//! - If redaction fails any invariant (a quoted string survives, an
+//!   upper-case identifier looks like leaked source, ...), the payload is
+//!   rejected before it ever reaches the sink.
+//!
+//! Tests in `tests/redaction.rs` enforce the redaction guarantees with a
+//! table-driven corpus.
+
+use crate::diagnostic::DiagnosticCode;
+use serde::{Deserialize, Serialize};
+use std::sync::{Mutex, OnceLock};
+
+/// Hard cap on snippet length (post-redaction). The issue spec says 200.
+pub const MAX_SNIPPET_LEN: usize = 200;
+
+/// Compile pipeline stages a report can originate from. Mirrors the buckets
+/// the maintainers use when triaging `known_failures.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReportStage {
+    HirLower,
+    Codegen,
+    Link,
+    Runtime,
+}
+
+impl ReportStage {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ReportStage::HirLower => "hir-lower",
+            ReportStage::Codegen => "codegen",
+            ReportStage::Link => "link",
+            ReportStage::Runtime => "runtime",
+        }
+    }
+}
+
+/// Maps to the `category` field of `test-parity/known_failures.json` so
+/// user-reported gaps and maintainer-curated gaps are comparable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReportCategory {
+    /// A known TypeScript construct Perry doesn't handle yet (decorators,
+    /// lookbehind regex, ...). Maps to `gap-categorical` in known_failures.
+    GapCategorical,
+    /// A bug discovered by bisection — likely a regression in a specific
+    /// pass that used to work.
+    GapBisect,
+    /// Tracks an already-open issue.
+    BugOpen,
+    /// A previously-tracked bug that may still bite users.
+    BugStale,
+    /// Environment / CI plumbing problem, not a real compiler gap.
+    CiEnv,
+    /// Module inventory miss — a `node:*` API Perry doesn't carry.
+    ModuleInventory,
+}
+
+impl ReportCategory {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ReportCategory::GapCategorical => "gap-categorical",
+            ReportCategory::GapBisect => "gap-bisect",
+            ReportCategory::BugOpen => "bug-open",
+            ReportCategory::BugStale => "bug-stale",
+            ReportCategory::CiEnv => "ci-env",
+            ReportCategory::ModuleInventory => "module-inventory",
+        }
+    }
+}
+
+/// The wire payload for a single compatibility report.
+///
+/// Only the redacted snippet ever leaves the machine. Field order is stable
+/// because consumers may grep the JSON.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CompatibilityReport {
+    /// `env!("CARGO_PKG_VERSION")` at the time the report was queued.
+    pub perry_version: String,
+    /// Anonymous client UUID — same one used by the generic telemetry channel.
+    pub client_id: String,
+    /// Stringified `DiagnosticCode` variant (e.g. `"UnsupportedExpression"`).
+    pub code: String,
+    /// `ReportCategory` variant as kebab-case string.
+    pub category: String,
+    /// `ReportStage` variant as kebab-case string.
+    pub stage: String,
+    /// `sha256:<hex>` of the redacted snippet, for server-side dedup.
+    pub snippet_hash: String,
+    /// Redacted, ≤200-char snippet of the offending source.
+    pub snippet_redacted: String,
+    /// Optional name of the TypeScript feature (e.g. `"decorator"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ts_feature: Option<String>,
+    /// Optional name of the Node API (e.g. `"node:async_hooks.createHook"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_api: Option<String>,
+    /// `darwin-arm64`, `linux-x86_64`, ...
+    pub os: String,
+    /// `--target node:<n>` if available, else `"unknown"`.
+    pub node_target: String,
+}
+
+impl CompatibilityReport {
+    /// Build a report from raw fields. Performs redaction + snippet hash.
+    ///
+    /// Returns `Err(RedactionError)` if redaction fails an invariant — the
+    /// caller MUST NOT fall back to the raw snippet on error.
+    pub fn build(
+        code: DiagnosticCode,
+        category: ReportCategory,
+        stage: ReportStage,
+        raw_snippet: &str,
+        client_id: String,
+        perry_version: String,
+        os: String,
+        node_target: String,
+        ts_feature: Option<String>,
+        node_api: Option<String>,
+    ) -> Result<Self, RedactionError> {
+        let snippet_redacted = redact_snippet(raw_snippet)?;
+        let snippet_hash = sha256_hash(&snippet_redacted);
+        Ok(CompatibilityReport {
+            perry_version,
+            client_id,
+            code: format!("{:?}", code),
+            category: category.as_str().to_string(),
+            stage: stage.as_str().to_string(),
+            snippet_hash,
+            snippet_redacted,
+            ts_feature,
+            node_api,
+            os,
+            node_target,
+        })
+    }
+}
+
+/// Why redaction refused to produce a payload. Each variant is something
+/// the privacy invariant check caught — refuse, don't fall back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RedactionError {
+    /// A `"..."` or `'...'` quoted string survived redaction.
+    QuotedStringSurvived,
+    /// A template literal `` `...` `` survived redaction.
+    TemplateLiteralSurvived,
+    /// An upper-case identifier survived that isn't a known global (likely
+    /// a user-defined class name leaking).
+    UpperCaseIdentifierSurvived(String),
+    /// Numeric literal survived after redaction.
+    NumericLiteralSurvived,
+    /// Input was empty or whitespace-only — no signal to report.
+    EmptyAfterRedaction,
+}
+
+impl std::fmt::Display for RedactionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RedactionError::QuotedStringSurvived => {
+                write!(f, "redaction failed: a quoted string survived")
+            }
+            RedactionError::TemplateLiteralSurvived => {
+                write!(f, "redaction failed: a template literal survived")
+            }
+            RedactionError::UpperCaseIdentifierSurvived(s) => {
+                write!(f, "redaction failed: identifier `{}` survived", s)
+            }
+            RedactionError::NumericLiteralSurvived => {
+                write!(f, "redaction failed: a numeric literal survived")
+            }
+            RedactionError::EmptyAfterRedaction => {
+                write!(f, "redaction failed: snippet empty after redaction")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RedactionError {}
+
+/// Globals that should NOT be anonymized to `<idN>` because they carry
+/// signal — knowing the user wrote `Promise.race` is exactly the point.
+/// Casing matters: `Promise` is preserved, but a user-defined `Foo` is not.
+const PRESERVED_IDENTS: &[&str] = &[
+    // JS built-ins
+    "console",
+    "Math",
+    "JSON",
+    "Promise",
+    "Array",
+    "Object",
+    "String",
+    "Number",
+    "Boolean",
+    "RegExp",
+    "Date",
+    "Error",
+    "TypeError",
+    "RangeError",
+    "Symbol",
+    "Map",
+    "Set",
+    "WeakMap",
+    "WeakSet",
+    "Reflect",
+    "Proxy",
+    "BigInt",
+    "Buffer",
+    "globalThis",
+    "undefined",
+    "null",
+    "true",
+    "false",
+    "NaN",
+    "Infinity",
+    // Common Node globals
+    "process",
+    "require",
+    "module",
+    "exports",
+    "__dirname",
+    "__filename",
+    "global",
+    "setTimeout",
+    "clearTimeout",
+    "setInterval",
+    "clearInterval",
+    "setImmediate",
+    "clearImmediate",
+    "queueMicrotask",
+    "fetch",
+    // TS/JS keywords (already lowercase mostly — listed for explicitness)
+    "let",
+    "const",
+    "var",
+    "function",
+    "return",
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "break",
+    "continue",
+    "switch",
+    "case",
+    "default",
+    "try",
+    "catch",
+    "finally",
+    "throw",
+    "new",
+    "delete",
+    "typeof",
+    "instanceof",
+    "in",
+    "of",
+    "void",
+    "this",
+    "super",
+    "class",
+    "extends",
+    "implements",
+    "interface",
+    "type",
+    "enum",
+    "namespace",
+    "import",
+    "from",
+    "export",
+    "as",
+    "async",
+    "await",
+    "yield",
+    "static",
+    "public",
+    "private",
+    "protected",
+    "readonly",
+    "abstract",
+    "declare",
+    "any",
+    "unknown",
+    "never",
+    "string",
+    "number",
+    "boolean",
+    "object",
+    "bigint",
+    "symbol",
+    "is",
+];
+
+/// Returns true if the identifier is a built-in we keep verbatim.
+fn is_preserved_ident(s: &str) -> bool {
+    PRESERVED_IDENTS.contains(&s)
+}
+
+/// Redact a raw source snippet according to the rules in #849:
+///
+/// 1. All string literals (single, double, backtick) → `"<str>"` / `` `<tpl>` ``
+/// 2. All numeric literals → `<num>`
+/// 3. All identifiers except [`PRESERVED_IDENTS`] → `<id1>`, `<id2>`, ... (stable across the snippet)
+/// 4. Hard cap at 200 chars, truncate with `...`
+/// 5. Reject if any invariant fails (no quoted string survives, no
+///    obviously-user-named identifier survives).
+///
+/// This is a deliberately conservative tokenizer; it does not need to
+/// understand TypeScript syntax — only enough to find literals and idents
+/// reliably and replace them.
+pub fn redact_snippet(input: &str) -> Result<String, RedactionError> {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    let mut ident_map: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut next_id: usize = 1;
+
+    while i < bytes.len() {
+        let c = bytes[i];
+
+        // Skip line comments
+        if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+        // Skip block comments
+        if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i = (i + 2).min(bytes.len());
+            continue;
+        }
+
+        // String / template literals
+        if c == b'"' || c == b'\'' {
+            let quote = c;
+            i += 1;
+            while i < bytes.len() {
+                if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == quote {
+                    i += 1;
+                    break;
+                }
+                // Strings can't span newlines without escape — give up on this
+                // string if we hit one (treat the rest as code).
+                if bytes[i] == b'\n' {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            out.push_str("\"<str>\"");
+            continue;
+        }
+        if c == b'`' {
+            i += 1;
+            // Template literals can be nested via `${...}` — we just scan
+            // for the matching backtick and treat everything between as opaque.
+            while i < bytes.len() && bytes[i] != b'`' {
+                if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                    i += 2;
+                    continue;
+                }
+                i += 1;
+            }
+            if i < bytes.len() {
+                i += 1; // consume closing `
+            }
+            out.push_str("`<tpl>`");
+            continue;
+        }
+
+        // Numeric literal
+        if c.is_ascii_digit()
+            || (c == b'.'
+                && i + 1 < bytes.len()
+                && bytes[i + 1].is_ascii_digit())
+        {
+            // Eat digits, dots, exponent markers, hex/oct/bin prefixes,
+            // underscores, BigInt 'n' suffix
+            while i < bytes.len() {
+                let ch = bytes[i];
+                if ch.is_ascii_digit()
+                    || ch == b'.'
+                    || ch == b'_'
+                    || ch == b'x'
+                    || ch == b'X'
+                    || ch == b'o'
+                    || ch == b'O'
+                    || ch == b'b'
+                    || ch == b'B'
+                    || ch == b'e'
+                    || ch == b'E'
+                    || ch == b'n'
+                    || (ch.is_ascii_hexdigit() && i > 0 && {
+                        // Only inside a hex literal context (preceded by 0x...)
+                        // — approximate by allowing hex digits after we've
+                        // already started consuming. Safe overestimate.
+                        true
+                    })
+                    || ((ch == b'+' || ch == b'-')
+                        && i > 0
+                        && (bytes[i - 1] == b'e' || bytes[i - 1] == b'E'))
+                {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            out.push_str("<num>");
+            continue;
+        }
+
+        // Identifier
+        if c.is_ascii_alphabetic() || c == b'_' || c == b'$' {
+            let start = i;
+            while i < bytes.len() {
+                let ch = bytes[i];
+                if ch.is_ascii_alphanumeric() || ch == b'_' || ch == b'$' {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            let ident = &input[start..i];
+            if is_preserved_ident(ident) {
+                out.push_str(ident);
+            } else {
+                let n = *ident_map.entry(ident.to_string()).or_insert_with(|| {
+                    let n = next_id;
+                    next_id += 1;
+                    n
+                });
+                out.push_str(&format!("<id{}>", n));
+            }
+            continue;
+        }
+
+        // Punctuation / operator / whitespace — copy verbatim
+        out.push(c as char);
+        i += 1;
+    }
+
+    // Collapse multiple consecutive whitespace into a single space, drop leading/trailing
+    let trimmed: String = {
+        let mut t = String::with_capacity(out.len());
+        let mut prev_ws = false;
+        for ch in out.chars() {
+            if ch.is_whitespace() {
+                if !prev_ws && !t.is_empty() {
+                    t.push(' ');
+                }
+                prev_ws = true;
+            } else {
+                t.push(ch);
+                prev_ws = false;
+            }
+        }
+        t.trim_end().to_string()
+    };
+
+    // Hard cap with ellipsis. Truncate on a char boundary so we don't
+    // produce invalid UTF-8 mid-codepoint.
+    let truncated = if trimmed.chars().count() > MAX_SNIPPET_LEN {
+        let cap_chars = MAX_SNIPPET_LEN.saturating_sub(3);
+        let mut s: String = trimmed.chars().take(cap_chars).collect();
+        s.push_str("...");
+        s
+    } else {
+        trimmed
+    };
+
+    if truncated.is_empty() {
+        return Err(RedactionError::EmptyAfterRedaction);
+    }
+
+    // ---- Invariant checks ----------------------------------------------
+    verify_redaction_invariants(&truncated)?;
+
+    Ok(truncated)
+}
+
+/// Privacy invariants: anything that survives that should NOT have should
+/// turn into an error so the caller refuses the report rather than sending
+/// raw source.
+fn verify_redaction_invariants(s: &str) -> Result<(), RedactionError> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+
+        // Skip our own placeholders so they don't trip the invariant checks.
+        // `<str>`, `<num>`, `<tpl>`, `<id1>`, `<id2>`, ...
+        if c == b'<' {
+            // Find matching '>'
+            let close = s[i..].find('>').map(|p| i + p);
+            if let Some(end) = close {
+                i = end + 1;
+                continue;
+            }
+        }
+
+        // No quoted strings should survive outside of our `"<str>"` placeholder.
+        // Our placeholder is `"<str>"`. Detect a quote whose interior isn't
+        // exactly `<str>` or `<tpl>`.
+        if c == b'"' {
+            // Skip our own `"<str>"` placeholder.
+            if s[i..].starts_with("\"<str>\"") {
+                i += "\"<str>\"".len();
+                continue;
+            }
+            return Err(RedactionError::QuotedStringSurvived);
+        }
+        if c == b'\'' {
+            return Err(RedactionError::QuotedStringSurvived);
+        }
+        if c == b'`' {
+            if s[i..].starts_with("`<tpl>`") {
+                i += "`<tpl>`".len();
+                continue;
+            }
+            return Err(RedactionError::TemplateLiteralSurvived);
+        }
+
+        // Identifier scan
+        if c.is_ascii_alphabetic() || c == b'_' || c == b'$' {
+            let start = i;
+            while i < bytes.len() {
+                let ch = bytes[i];
+                if ch.is_ascii_alphanumeric() || ch == b'_' || ch == b'$' {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            let ident = &s[start..i];
+            // Pure-upper-case-and-digits like `MAX_LEN` is a user const leaking
+            // — but `is_preserved_ident` will have allowed e.g. `JSON`, so we
+            // only reject upper-case idents that are NOT in the preserved list.
+            // Also: starts-with-upper-case (PascalCase) idents not in the
+            // preserved list are most likely user types.
+            if !is_preserved_ident(ident) {
+                if let Some(first) = ident.chars().next() {
+                    if first.is_ascii_uppercase() {
+                        return Err(RedactionError::UpperCaseIdentifierSurvived(
+                            ident.to_string(),
+                        ));
+                    }
+                }
+            }
+            continue;
+        }
+
+        // Numeric literal leftover
+        if c.is_ascii_digit() {
+            return Err(RedactionError::NumericLiteralSurvived);
+        }
+
+        i += 1;
+    }
+    Ok(())
+}
+
+/// Compute `sha256:<hex>` of the input. Pure Rust, no external crate — we
+/// can't pull `sha2` in for one hash. Small implementation lifted from
+/// FIPS 180-4.
+pub fn sha256_hash(input: &str) -> String {
+    let digest = sha256(input.as_bytes());
+    let mut s = String::from("sha256:");
+    for b in digest {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+fn sha256(data: &[u8]) -> [u8; 32] {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+
+    let mut h: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+        0x5be0cd19,
+    ];
+
+    // Pre-processing: padding
+    let bit_len = (data.len() as u64).wrapping_mul(8);
+    let mut buf: Vec<u8> = Vec::with_capacity(data.len() + 72);
+    buf.extend_from_slice(data);
+    buf.push(0x80);
+    while buf.len() % 64 != 56 {
+        buf.push(0);
+    }
+    buf.extend_from_slice(&bit_len.to_be_bytes());
+
+    for chunk in buf.chunks(64) {
+        let mut w = [0u32; 64];
+        for i in 0..16 {
+            w[i] = u32::from_be_bytes([
+                chunk[i * 4],
+                chunk[i * 4 + 1],
+                chunk[i * 4 + 2],
+                chunk[i * 4 + 3],
+            ]);
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+        let mut a = h[0];
+        let mut b = h[1];
+        let mut c = h[2];
+        let mut d = h[3];
+        let mut e = h[4];
+        let mut f = h[5];
+        let mut g = h[6];
+        let mut hh = h[7];
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ ((!e) & g);
+            let t1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let t2 = s0.wrapping_add(maj);
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(t2);
+        }
+        h[0] = h[0].wrapping_add(a);
+        h[1] = h[1].wrapping_add(b);
+        h[2] = h[2].wrapping_add(c);
+        h[3] = h[3].wrapping_add(d);
+        h[4] = h[4].wrapping_add(e);
+        h[5] = h[5].wrapping_add(f);
+        h[6] = h[6].wrapping_add(g);
+        h[7] = h[7].wrapping_add(hh);
+    }
+
+    let mut out = [0u8; 32];
+    for i in 0..8 {
+        out[i * 4..i * 4 + 4].copy_from_slice(&h[i].to_be_bytes());
+    }
+    out
+}
+
+/// Maps a `DiagnosticCode` to a default `ReportCategory`. Diagnostics that
+/// aren't compatibility-relevant return `None` and won't generate reports.
+pub fn category_for_code(code: DiagnosticCode) -> Option<ReportCategory> {
+    use DiagnosticCode::*;
+    match code {
+        UnsupportedBinaryOp
+        | UnsupportedExpression
+        | UnsupportedStatement
+        | UnsupportedPattern
+        | UnsupportedFeature
+        | UnsupportedPropertyKey
+        | UnsupportedAssignmentTarget
+        | UnsupportedCalleeType
+        | UnsupportedUnaryOp
+        | UnsupportedType => Some(ReportCategory::GapCategorical),
+        DynamicPropertyAccess | ImplicitCoercion => Some(ReportCategory::GapCategorical),
+        UnresolvedImport => Some(ReportCategory::ModuleInventory),
+        NoOpStub | UnimplementedApi => Some(ReportCategory::ModuleInventory),
+        // Codes we explicitly don't report on — too noisy or user-typo.
+        _ => None,
+    }
+}
+
+/// Returns true if the given `DiagnosticCode` is in the targeted set for
+/// compatibility reporting.
+pub fn is_reportable_code(code: DiagnosticCode) -> bool {
+    category_for_code(code).is_some()
+}
+
+/// Description of a pending report that the chokepoint enqueues. The CLI
+/// telemetry sink picks these up, applies the consent + dedup policy, and
+/// either drops them or forwards them upstream.
+#[derive(Debug, Clone)]
+pub struct PendingReport {
+    pub code: DiagnosticCode,
+    pub category: ReportCategory,
+    pub stage: ReportStage,
+    pub raw_snippet: String,
+    pub ts_feature: Option<String>,
+    pub node_api: Option<String>,
+}
+
+/// Sink trait registered by the CLI at startup so `perry-diagnostics`
+/// doesn't need to know about reqwest / config / threads.
+pub trait ReportSink: Send + Sync {
+    /// Called once per qualifying diagnostic emission. Implementations
+    /// should be cheap — they typically just push onto a queue.
+    fn submit(&self, pending: PendingReport);
+}
+
+fn sink_slot() -> &'static Mutex<Option<Box<dyn ReportSink>>> {
+    static INSTANCE: OnceLock<Mutex<Option<Box<dyn ReportSink>>>> = OnceLock::new();
+    INSTANCE.get_or_init(|| Mutex::new(None))
+}
+
+/// Install a sink. Called once from the CLI at startup. Idempotent — a
+/// later install replaces the previous sink (useful in tests).
+pub fn set_report_sink(sink: Box<dyn ReportSink>) {
+    if let Ok(mut guard) = sink_slot().lock() {
+        *guard = Some(sink);
+    }
+}
+
+/// Returns true if a sink has been installed. Lets the chokepoint short-
+/// circuit when reporting is disabled at every layer.
+pub fn has_report_sink() -> bool {
+    sink_slot()
+        .lock()
+        .map(|g| g.is_some())
+        .unwrap_or(false)
+}
+
+/// Internal: forward a pending report to the installed sink, if any.
+/// Called from the diagnostic emission chokepoint. No-op when no sink is
+/// installed (which is the common case — only the `perry` CLI installs one).
+pub fn enqueue_report(pending: PendingReport) {
+    if let Ok(guard) = sink_slot().lock() {
+        if let Some(sink) = guard.as_ref() {
+            sink.submit(pending);
+        }
+    }
+}
+
+/// Convenience: given a built `Diagnostic` and a raw source snippet,
+/// enqueue a report if the diagnostic's code is in the targeted set.
+/// This is the single chokepoint referenced in the issue spec.
+pub fn maybe_enqueue_for_diagnostic(
+    code: DiagnosticCode,
+    raw_snippet: &str,
+    stage: ReportStage,
+    ts_feature: Option<String>,
+    node_api: Option<String>,
+) {
+    if !has_report_sink() {
+        return;
+    }
+    let Some(category) = category_for_code(code) else {
+        return;
+    };
+    if raw_snippet.trim().is_empty() {
+        return;
+    }
+    enqueue_report(PendingReport {
+        code,
+        category,
+        stage,
+        raw_snippet: raw_snippet.to_string(),
+        ts_feature,
+        node_api,
+    });
+}
+
+#[cfg(test)]
+mod inline_tests {
+    use super::*;
+
+    #[test]
+    fn sha256_known_vector() {
+        // "" -> e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        assert_eq!(
+            sha256_hash(""),
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        // "abc" -> ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+        assert_eq!(
+            sha256_hash("abc"),
+            "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn redact_basic_identifier_renumbering() {
+        let r = redact_snippet("let userName = otherName;").unwrap();
+        assert!(r.contains("<id1>"));
+        assert!(r.contains("<id2>"));
+        assert!(!r.contains("userName"));
+        assert!(!r.contains("otherName"));
+    }
+}

--- a/crates/perry-diagnostics/src/compat_report.rs
+++ b/crates/perry-diagnostics/src/compat_report.rs
@@ -393,10 +393,7 @@ pub fn redact_snippet(input: &str) -> Result<String, RedactionError> {
         }
 
         // Numeric literal
-        if c.is_ascii_digit()
-            || (c == b'.'
-                && i + 1 < bytes.len()
-                && bytes[i + 1].is_ascii_digit())
+        if c.is_ascii_digit() || (c == b'.' && i + 1 < bytes.len() && bytes[i + 1].is_ascii_digit())
         {
             // Eat digits, dots, exponent markers, hex/oct/bin prefixes,
             // underscores, BigInt 'n' suffix
@@ -753,10 +750,7 @@ pub fn set_report_sink(sink: Box<dyn ReportSink>) {
 /// Returns true if a sink has been installed. Lets the chokepoint short-
 /// circuit when reporting is disabled at every layer.
 pub fn has_report_sink() -> bool {
-    sink_slot()
-        .lock()
-        .map(|g| g.is_some())
-        .unwrap_or(false)
+    sink_slot().lock().map(|g| g.is_some()).unwrap_or(false)
 }
 
 /// Internal: forward a pending report to the installed sink, if any.

--- a/crates/perry-diagnostics/src/emitter.rs
+++ b/crates/perry-diagnostics/src/emitter.rs
@@ -1,9 +1,56 @@
 //! Diagnostic emitters for different output formats.
 
+use crate::compat_report::{
+    is_reportable_code, maybe_enqueue_for_diagnostic, ReportStage,
+};
 use crate::diagnostic::{Diagnostic, Diagnostics, Severity};
 use crate::source_cache::SourceCache;
 use crate::span::LabelStyle;
 use std::io::Write;
+
+/// #849 chokepoint: extract the raw snippet for `diagnostic` from the
+/// `SourceCache` and forward it to the compat-report queue if the code
+/// is in the targeted set AND a sink is installed.
+///
+/// All three emitters call this from their `emit` implementation. It's
+/// the single place in the codebase where a diagnostic's source snippet
+/// becomes a candidate report — keeps emission policy out of the
+/// per-crate diagnostic-construction sites.
+pub fn forward_to_compat_report_channel(diagnostic: &Diagnostic, cache: &SourceCache) {
+    if !is_reportable_code(diagnostic.code) {
+        return;
+    }
+    let span = diagnostic.span;
+    if span.is_dummy() {
+        return;
+    }
+    let Some(file) = cache.get_file(span.file_id) else {
+        return;
+    };
+    // Pull the snippet (offset slice) from the file. Stay within bounds.
+    let src = &file.source;
+    let start = (span.start as usize).min(src.len());
+    let end = (span.end as usize).min(src.len()).max(start);
+    if start == end {
+        return;
+    }
+    // Find a UTF-8 char boundary at or after `start` and at or before `end`.
+    let start = (start..=end)
+        .find(|&i| src.is_char_boundary(i))
+        .unwrap_or(start);
+    let end = (start..=end)
+        .rev()
+        .find(|&i| src.is_char_boundary(i))
+        .unwrap_or(end);
+    let snippet = &src[start..end];
+    maybe_enqueue_for_diagnostic(
+        diagnostic.code,
+        snippet,
+        ReportStage::HirLower,
+        None,
+        None,
+    );
+}
 
 /// Trait for emitting diagnostics in various formats.
 pub trait DiagnosticEmitter {
@@ -76,6 +123,11 @@ impl<W: Write> TerminalEmitter<W> {
 
 impl<W: Write> DiagnosticEmitter for TerminalEmitter<W> {
     fn emit(&mut self, diagnostic: &Diagnostic, cache: &SourceCache) -> std::io::Result<()> {
+        // #849: single chokepoint — enqueue a compatibility report when
+        // the diagnostic code is in the targeted set. No-op when no
+        // sink is installed.
+        forward_to_compat_report_channel(diagnostic, cache);
+
         let color = self.severity_color(diagnostic.severity);
         let reset = self.reset();
         let bold = self.bold();
@@ -223,6 +275,9 @@ impl<W: Write> JsonEmitter<W> {
 
 impl<W: Write> DiagnosticEmitter for JsonEmitter<W> {
     fn emit(&mut self, diagnostic: &Diagnostic, cache: &SourceCache) -> std::io::Result<()> {
+        // #849 chokepoint — see TerminalEmitter::emit comment.
+        forward_to_compat_report_channel(diagnostic, cache);
+
         let loc = cache.location(diagnostic.span);
 
         let json = serde_json::json!({
@@ -284,6 +339,9 @@ impl<W: Write> SimpleEmitter<W> {
 
 impl<W: Write> DiagnosticEmitter for SimpleEmitter<W> {
     fn emit(&mut self, diagnostic: &Diagnostic, cache: &SourceCache) -> std::io::Result<()> {
+        // #849 chokepoint — see TerminalEmitter::emit comment.
+        forward_to_compat_report_channel(diagnostic, cache);
+
         let loc = cache.location(diagnostic.span);
 
         if let Some(loc) = loc {

--- a/crates/perry-diagnostics/src/emitter.rs
+++ b/crates/perry-diagnostics/src/emitter.rs
@@ -1,8 +1,6 @@
 //! Diagnostic emitters for different output formats.
 
-use crate::compat_report::{
-    is_reportable_code, maybe_enqueue_for_diagnostic, ReportStage,
-};
+use crate::compat_report::{is_reportable_code, maybe_enqueue_for_diagnostic, ReportStage};
 use crate::diagnostic::{Diagnostic, Diagnostics, Severity};
 use crate::source_cache::SourceCache;
 use crate::span::LabelStyle;
@@ -43,13 +41,7 @@ pub fn forward_to_compat_report_channel(diagnostic: &Diagnostic, cache: &SourceC
         .find(|&i| src.is_char_boundary(i))
         .unwrap_or(end);
     let snippet = &src[start..end];
-    maybe_enqueue_for_diagnostic(
-        diagnostic.code,
-        snippet,
-        ReportStage::HirLower,
-        None,
-        None,
-    );
+    maybe_enqueue_for_diagnostic(diagnostic.code, snippet, ReportStage::HirLower, None, None);
 }
 
 /// Trait for emitting diagnostics in various formats.

--- a/crates/perry-diagnostics/src/lib.rs
+++ b/crates/perry-diagnostics/src/lib.rs
@@ -31,12 +31,19 @@
 //! emitter.emit(&diag, &cache).unwrap();
 //! ```
 
+pub mod compat_report;
 pub mod diagnostic;
 pub mod emitter;
 pub mod source_cache;
 pub mod span;
 
 // Re-export commonly used types
+pub use compat_report::{
+    category_for_code, enqueue_report, has_report_sink, is_reportable_code,
+    maybe_enqueue_for_diagnostic, redact_snippet, set_report_sink, sha256_hash,
+    CompatibilityReport, PendingReport, RedactionError, ReportCategory, ReportSink, ReportStage,
+    MAX_SNIPPET_LEN,
+};
 pub use diagnostic::{
     Applicability, Diagnostic, DiagnosticBuilder, DiagnosticCode, Diagnostics, RelatedInfo,
     Severity, Suggestion,

--- a/crates/perry-diagnostics/tests/chokepoint_integration.rs
+++ b/crates/perry-diagnostics/tests/chokepoint_integration.rs
@@ -1,0 +1,114 @@
+//! End-to-end check that the emitter chokepoint forwards the right
+//! diagnostics into the compat-report queue.
+//!
+//! Validates the privacy boundary: when a sink is installed, a diagnostic
+//! whose `DiagnosticCode` is in the reportable set produces a queued
+//! `PendingReport` whose `raw_snippet` matches what was in the source
+//! file at the diagnostic's span. Diagnostics with non-reportable codes
+//! never enqueue anything.
+
+use perry_diagnostics::compat_report::{
+    set_report_sink, PendingReport, ReportSink,
+};
+use perry_diagnostics::{
+    Diagnostic, DiagnosticCode, DiagnosticEmitter, SimpleEmitter, SourceCache, Span,
+};
+use std::sync::{Arc, Mutex, OnceLock};
+
+/// All three tests share the global sink slot via `set_report_sink`, so
+/// they MUST run serially.
+fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+#[derive(Default)]
+struct CapturingSink {
+    captured: Arc<Mutex<Vec<PendingReport>>>,
+}
+
+impl ReportSink for CapturingSink {
+    fn submit(&self, pending: PendingReport) {
+        self.captured.lock().unwrap().push(pending);
+    }
+}
+
+#[test]
+fn reportable_diagnostic_enqueues_pending_report() {
+    let _g = test_lock();
+    let captured = Arc::new(Mutex::new(Vec::<PendingReport>::new()));
+    set_report_sink(Box::new(CapturingSink {
+        captured: captured.clone(),
+    }));
+
+    let mut cache = SourceCache::new();
+    let src = "let x = await foo();\n";
+    let file_id = cache.add_file("smoke.ts", src.to_string());
+
+    // Build a UnsupportedExpression diagnostic whose span covers `await foo()`
+    let start = src.find("await").unwrap() as u32;
+    let end = (src.find(";").unwrap()) as u32;
+    let diag = Diagnostic::error(DiagnosticCode::UnsupportedExpression, "test")
+        .with_span(Span::new(file_id, start, end))
+        .build();
+
+    let mut buf = Vec::new();
+    let mut emitter = SimpleEmitter::new(&mut buf);
+    emitter.emit(&diag, &cache).unwrap();
+
+    let captured = captured.lock().unwrap();
+    assert_eq!(captured.len(), 1, "expected exactly one queued report");
+    let report = &captured[0];
+    assert_eq!(report.code, DiagnosticCode::UnsupportedExpression);
+    // The raw snippet pulled from the cache must match the source bytes
+    // at the diagnostic's span.
+    assert_eq!(report.raw_snippet, "await foo()");
+}
+
+#[test]
+fn non_reportable_diagnostic_does_not_enqueue() {
+    let _g = test_lock();
+    let captured = Arc::new(Mutex::new(Vec::<PendingReport>::new()));
+    set_report_sink(Box::new(CapturingSink {
+        captured: captured.clone(),
+    }));
+
+    let mut cache = SourceCache::new();
+    let file_id = cache.add_file("x.ts", "const x = 1;".to_string());
+    let diag = Diagnostic::error(DiagnosticCode::ParseError, "parse failure")
+        .with_span(Span::new(file_id, 0, 4))
+        .build();
+
+    let mut buf = Vec::new();
+    let mut emitter = SimpleEmitter::new(&mut buf);
+    emitter.emit(&diag, &cache).unwrap();
+
+    let captured = captured.lock().unwrap();
+    assert!(
+        captured.is_empty(),
+        "ParseError is not in the reportable set; got: {:?}",
+        *captured
+    );
+}
+
+#[test]
+fn dummy_span_diagnostic_does_not_enqueue() {
+    let _g = test_lock();
+    let captured = Arc::new(Mutex::new(Vec::<PendingReport>::new()));
+    set_report_sink(Box::new(CapturingSink {
+        captured: captured.clone(),
+    }));
+
+    let mut cache = SourceCache::new();
+    let _id = cache.add_file("x.ts", "const x = 1;".to_string());
+    // Diagnostic with no span — no snippet to redact, must not enqueue.
+    let diag = Diagnostic::error(DiagnosticCode::UnsupportedExpression, "no span").build();
+
+    let mut buf = Vec::new();
+    let mut emitter = SimpleEmitter::new(&mut buf);
+    emitter.emit(&diag, &cache).unwrap();
+
+    assert!(captured.lock().unwrap().is_empty());
+}

--- a/crates/perry-diagnostics/tests/chokepoint_integration.rs
+++ b/crates/perry-diagnostics/tests/chokepoint_integration.rs
@@ -7,9 +7,7 @@
 //! file at the diagnostic's span. Diagnostics with non-reportable codes
 //! never enqueue anything.
 
-use perry_diagnostics::compat_report::{
-    set_report_sink, PendingReport, ReportSink,
-};
+use perry_diagnostics::compat_report::{set_report_sink, PendingReport, ReportSink};
 use perry_diagnostics::{
     Diagnostic, DiagnosticCode, DiagnosticEmitter, SimpleEmitter, SourceCache, Span,
 };

--- a/crates/perry-diagnostics/tests/redaction.rs
+++ b/crates/perry-diagnostics/tests/redaction.rs
@@ -1,0 +1,325 @@
+//! Mandatory table-driven redaction tests for #849 compatibility reports.
+//!
+//! The compatibility-report channel is opt-in but the privacy invariant is
+//! non-negotiable: nothing that looks like raw source — quoted strings,
+//! template literals, user-named identifiers, numeric literals — may
+//! survive redaction. These tests pin that behaviour against a curated
+//! corpus so we notice the day someone "improves" the redactor and
+//! accidentally lets a string through.
+//!
+//! Two layers:
+//!
+//! 1. `redact_corpus` — table of `(name, input, expected_substrings_present,
+//!    expected_substrings_absent)`. Each case must:
+//!    a. redact successfully,
+//!    b. produce the expected placeholders,
+//!    c. NOT contain any of the forbidden substrings (the raw identifiers,
+//!       string contents, etc.).
+//!
+//! 2. `reject_corpus` — table of inputs that should already be rejected
+//!    (defence in depth: even if someone wires a future variant that
+//!    skips redaction, building a `CompatibilityReport` would still fail).
+
+use perry_diagnostics::compat_report::{
+    redact_snippet, CompatibilityReport, RedactionError, ReportCategory, ReportStage,
+    MAX_SNIPPET_LEN,
+};
+use perry_diagnostics::DiagnosticCode;
+
+struct RedactCase {
+    name: &'static str,
+    input: &'static str,
+    /// Substrings that MUST appear in the redacted output.
+    must_contain: &'static [&'static str],
+    /// Substrings that MUST NOT appear in the redacted output (would leak
+    /// the user's source).
+    must_not_contain: &'static [&'static str],
+}
+
+const REDACT_CASES: &[RedactCase] = &[
+    RedactCase {
+        name: "double-quoted string is replaced",
+        input: r#"const greeting = "hello world";"#,
+        must_contain: &["\"<str>\"", "<id1>"],
+        must_not_contain: &["hello", "world", "greeting"],
+    },
+    RedactCase {
+        name: "single-quoted string is replaced",
+        input: "let secret = 'sk_live_abc123';",
+        must_contain: &["\"<str>\"", "<id1>"],
+        must_not_contain: &["sk_live", "abc123", "secret"],
+    },
+    RedactCase {
+        name: "template literal is replaced",
+        input: "const msg = `hello ${userName}, your token is ${token}`;",
+        must_contain: &["`<tpl>`", "<id1>"],
+        must_not_contain: &["hello", "userName", "token", "msg"],
+    },
+    RedactCase {
+        name: "numeric literals are replaced",
+        input: "const x = 42 + 3.14 * 0xff;",
+        must_contain: &["<num>", "<id1>"],
+        must_not_contain: &["42", "3.14", "0xff"],
+    },
+    RedactCase {
+        name: "preserved builtin identifiers survive verbatim",
+        input: "console.log(Math.max(99, 88));",
+        must_contain: &["console", "Math", "<num>"],
+        // `1`/`2` would false-match inside `<id1>`/`<id2>`, so test with
+        // distinctive numbers that can't appear in any placeholder.
+        must_not_contain: &["99", "88"],
+    },
+    RedactCase {
+        name: "Promise + await preserved, user names anonymized",
+        input: "async function fetchUser() { return await Promise.all([fetch(url)]); }",
+        must_contain: &["Promise", "await", "fetch", "<id1>"],
+        must_not_contain: &["fetchUser"],
+    },
+    RedactCase {
+        name: "identical idents get the same number",
+        input: "let foo = foo + foo;",
+        must_contain: &["<id1>"],
+        must_not_contain: &["<id2>", "foo"],
+    },
+    RedactCase {
+        name: "two different idents get different numbers",
+        input: "let foo = bar;",
+        must_contain: &["<id1>", "<id2>"],
+        must_not_contain: &["foo", "bar"],
+    },
+    RedactCase {
+        name: "node:* module name in a string is redacted (we don't pass it through)",
+        input: "import { createHook } from 'node:async_hooks';",
+        must_contain: &["import", "\"<str>\"", "<id1>"],
+        must_not_contain: &["async_hooks", "createHook"],
+    },
+    RedactCase {
+        name: "decorator survives as a punctuation-prefixed id",
+        input: "@inject() class UserService {}",
+        must_contain: &["class", "<id1>", "<id2>"],
+        must_not_contain: &["inject", "UserService"],
+    },
+    RedactCase {
+        name: "line comment is stripped",
+        input: "let x = 1; // user-private comment with email@example.com",
+        must_contain: &["<id1>", "<num>"],
+        must_not_contain: &["user-private", "email", "example.com"],
+    },
+    RedactCase {
+        name: "block comment is stripped",
+        input: "/* TODO: hide this */ let secret = 'x';",
+        must_contain: &["<id1>", "\"<str>\""],
+        must_not_contain: &["TODO", "hide", "secret"],
+    },
+    RedactCase {
+        name: "escaped quotes inside string don't break redaction",
+        input: r#"let a = "she said \"hi\" yesterday";"#,
+        must_contain: &["<id1>", "\"<str>\""],
+        must_not_contain: &["she", "hi", "yesterday"],
+    },
+    RedactCase {
+        name: "no leaked literal between two strings",
+        input: r#"const a = "first" + leakedVar + "second";"#,
+        must_contain: &["<id1>", "<id2>", "\"<str>\""],
+        must_not_contain: &["first", "second", "leakedVar"],
+    },
+    RedactCase {
+        name: "BigInt literal handled",
+        input: "let n = 9007199254740993n;",
+        must_contain: &["<num>", "<id1>"],
+        must_not_contain: &["9007199254740993"],
+    },
+    RedactCase {
+        name: "exponent notation literal handled",
+        input: "let n = 1.5e10;",
+        must_contain: &["<num>", "<id1>"],
+        must_not_contain: &["1.5", "e10"],
+    },
+    RedactCase {
+        name: "underscore numeric separator handled",
+        input: "let n = 1_000_000;",
+        must_contain: &["<num>", "<id1>"],
+        must_not_contain: &["1_000_000", "1000000"],
+    },
+    RedactCase {
+        name: "preserved process/require survive",
+        input: "const fs = require('fs');",
+        must_contain: &["require", "\"<str>\"", "<id1>"],
+        must_not_contain: &["fs ", " fs"],
+    },
+    RedactCase {
+        name: "long input is truncated to <= MAX_SNIPPET_LEN with ellipsis",
+        input: "let a = 1; let b = 2; let c = 3; let d = 4; let e = 5; let f = 6; let g = 7; let h = 8; let i = 9; let j = 10; let k = 11; let l = 12; let m = 13; let n = 14; let o = 15; let p = 16; let q = 17; let r = 18; let s = 19; let t = 20; let u = 21; let v = 22; let w = 23;",
+        must_contain: &["..."],
+        must_not_contain: &[], // length checked below by name
+    },
+    RedactCase {
+        name: "whitespace collapsed",
+        input: "let     x    =     1;",
+        must_contain: &["<id1> = <num>"],
+        must_not_contain: &["    "],
+    },
+    RedactCase {
+        name: "keyword-only snippet preserved",
+        input: "for (let i = 0; i < n; i++) {}",
+        must_contain: &["for", "let", "<num>", "<id1>"],
+        must_not_contain: &["0", "n;"], // 'n;' is a substring of "n;" which the original has — verifies identifier renaming
+    },
+    RedactCase {
+        name: "unsupported binary op snippet",
+        input: "let mask = a ?? b;",
+        must_contain: &["??", "<id1>", "<id2>"],
+        must_not_contain: &["mask", "a ", "b;"],
+    },
+];
+
+#[test]
+fn redact_corpus() {
+    for case in REDACT_CASES {
+        let result = redact_snippet(case.input);
+        let redacted = match result {
+            Ok(r) => r,
+            Err(e) => panic!(
+                "case `{}` should redact but failed with {:?}\ninput: {:?}",
+                case.name, e, case.input
+            ),
+        };
+
+        // Length cap
+        assert!(
+            redacted.chars().count() <= MAX_SNIPPET_LEN,
+            "case `{}` exceeded MAX_SNIPPET_LEN ({} > {}): {:?}",
+            case.name,
+            redacted.chars().count(),
+            MAX_SNIPPET_LEN,
+            redacted
+        );
+
+        for s in case.must_contain {
+            assert!(
+                redacted.contains(s),
+                "case `{}` missing required placeholder {:?}\nredacted: {:?}",
+                case.name,
+                s,
+                redacted
+            );
+        }
+        for s in case.must_not_contain {
+            assert!(
+                !redacted.contains(s),
+                "case `{}` leaked forbidden substring {:?}\nredacted: {:?}",
+                case.name,
+                s,
+                redacted
+            );
+        }
+    }
+}
+
+#[test]
+fn redact_long_input_truncates_with_ellipsis() {
+    // 300 distinct keyword tokens (each token is the preserved keyword
+    // `let` — preserved idents survive verbatim, so the redacted output
+    // stays long enough to exceed MAX_SNIPPET_LEN and trigger truncation).
+    let long: String = std::iter::repeat("let ").take(80).collect();
+    let r = redact_snippet(&long).unwrap();
+    assert!(
+        r.chars().count() <= MAX_SNIPPET_LEN,
+        "got {} chars, max {}",
+        r.chars().count(),
+        MAX_SNIPPET_LEN
+    );
+    assert!(r.ends_with("..."), "expected ellipsis, got {:?}", r);
+}
+
+#[test]
+fn redact_empty_input_is_rejected() {
+    assert!(matches!(
+        redact_snippet(""),
+        Err(RedactionError::EmptyAfterRedaction)
+    ));
+    assert!(matches!(
+        redact_snippet("   \n\t  "),
+        Err(RedactionError::EmptyAfterRedaction)
+    ));
+}
+
+#[test]
+fn build_report_rejects_when_redaction_would_fail_on_empty() {
+    let r = CompatibilityReport::build(
+        DiagnosticCode::UnsupportedExpression,
+        ReportCategory::GapCategorical,
+        ReportStage::HirLower,
+        "",
+        "client".into(),
+        "0.0.0".into(),
+        "darwin-arm64".into(),
+        "20".into(),
+        None,
+        None,
+    );
+    assert!(matches!(r, Err(RedactionError::EmptyAfterRedaction)));
+}
+
+#[test]
+fn build_report_succeeds_with_clean_snippet() {
+    let r = CompatibilityReport::build(
+        DiagnosticCode::UnsupportedExpression,
+        ReportCategory::GapCategorical,
+        ReportStage::HirLower,
+        "const x = await foo();",
+        "client-uuid".into(),
+        "0.5.1000".into(),
+        "darwin-arm64".into(),
+        "20".into(),
+        Some("await-in-non-async".into()),
+        None,
+    )
+    .expect("clean snippet must redact");
+    assert_eq!(r.code, "UnsupportedExpression");
+    assert_eq!(r.category, "gap-categorical");
+    assert_eq!(r.stage, "hir-lower");
+    assert!(r.snippet_hash.starts_with("sha256:"));
+    assert_eq!(r.snippet_hash.len(), "sha256:".len() + 64);
+    assert!(!r.snippet_redacted.contains("foo"));
+    assert!(r.snippet_redacted.contains("await"));
+    // Serializes
+    let json = serde_json::to_string(&r).unwrap();
+    assert!(json.contains("\"perry_version\":\"0.5.1000\""));
+    assert!(!json.contains("foo"));
+}
+
+#[test]
+fn deterministic_hash_for_same_redacted_input() {
+    // Two different raw inputs that redact to the same shape must produce
+    // the same snippet_hash, so server-side dedup works.
+    let a = CompatibilityReport::build(
+        DiagnosticCode::UnsupportedExpression,
+        ReportCategory::GapCategorical,
+        ReportStage::HirLower,
+        "const userA = doStuff();",
+        "c".into(),
+        "0".into(),
+        "linux".into(),
+        "20".into(),
+        None,
+        None,
+    )
+    .unwrap();
+    let b = CompatibilityReport::build(
+        DiagnosticCode::UnsupportedExpression,
+        ReportCategory::GapCategorical,
+        ReportStage::HirLower,
+        "const userB = doStuff();",
+        "c".into(),
+        "0".into(),
+        "linux".into(),
+        "20".into(),
+        None,
+        None,
+    )
+    .unwrap();
+    // Identifiers anonymize to <id1>/<id2> in the same positions, so the
+    // redacted snippets — and therefore the hashes — are identical.
+    assert_eq!(a.snippet_hash, b.snippet_hash);
+}

--- a/crates/perry/src/commands/doctor.rs
+++ b/crates/perry/src/commands/doctor.rs
@@ -14,6 +14,19 @@ pub struct DoctorArgs {
     /// Run checks silently and only report failures
     #[arg(long)]
     pub quiet: bool,
+
+    /// #849: print queued opt-in compatibility reports (the redacted
+    /// payloads that would be sent on next compile) and exit. Lets
+    /// users inspect what compat telemetry would look like before
+    /// opting in.
+    #[arg(long)]
+    pub show_pending_reports: bool,
+
+    /// #849: clear the local 30-day dedup cache at
+    /// `~/.perry/.report-cache`. Next time a previously-suppressed
+    /// gap fires, it'll be reported again.
+    #[arg(long)]
+    pub clear_report_cache: bool,
 }
 
 static CHECK: Emoji<'_, '_> = Emoji("✓ ", "[OK] ");
@@ -264,6 +277,29 @@ fn check_update_available() -> CheckResult {
     }
 }
 
+/// #849: surface compatibility-report mode + cumulative counters.
+/// Always `Ok` — the channel is opt-in, so "off" is a valid state, not
+/// an error. The detail line tells the user where to look to flip it.
+fn check_compat_reports() -> CheckResult {
+    let mode = crate::compat_reports::active_mode();
+    let counters = crate::compat_reports::current_counters();
+    let cache_path = crate::compat_reports::cache_path();
+    let cache_exists = cache_path.exists();
+    let details = format!(
+        "mode={} (sent={}, suppressed-by-dedup={}, queued={}, cache={})",
+        mode.as_str(),
+        counters.sent,
+        counters.suppressed_by_dedup,
+        counters.queued,
+        if cache_exists { "present" } else { "empty" },
+    );
+    CheckResult {
+        name: "compatibility reports (#849)".to_string(),
+        status: CheckStatus::Ok,
+        details: Some(details),
+    }
+}
+
 fn check_project_config() -> CheckResult {
     let config_path = PathBuf::from("perry.toml");
     if config_path.exists() {
@@ -282,6 +318,34 @@ fn check_project_config() -> CheckResult {
 }
 
 pub fn run(args: DoctorArgs, format: OutputFormat, use_color: bool) -> Result<()> {
+    // #849: fast-paths that don't need the full environment-checks rundown.
+    if args.clear_report_cache {
+        let cleared = crate::compat_reports::clear_cache();
+        if cleared {
+            println!("Cleared compatibility-report dedup cache at {}", crate::compat_reports::cache_path().display());
+        } else {
+            println!("No compatibility-report cache to clear.");
+        }
+        return Ok(());
+    }
+    if args.show_pending_reports {
+        let pending = crate::compat_reports::drain_for_display();
+        if pending.is_empty() {
+            println!("No pending compatibility reports.");
+            println!("Reports are populated during a compile run, not by `perry doctor` itself.");
+            println!(
+                "To exercise the path, run a compile that fires an unsupported-feature diagnostic."
+            );
+        } else {
+            for r in &pending {
+                println!("{}", serde_json::to_string_pretty(r).unwrap_or_default());
+                println!();
+            }
+            println!("Total pending: {} (after redaction)", pending.len());
+        }
+        return Ok(());
+    }
+
     let checks = vec![
         check_perry_version(),
         check_update_available(),
@@ -289,6 +353,7 @@ pub fn run(args: DoctorArgs, format: OutputFormat, use_color: bool) -> Result<()
         check_system_linker(),
         check_runtime_library(),
         check_project_config(),
+        check_compat_reports(),
     ];
 
     let mut has_errors = false;

--- a/crates/perry/src/commands/doctor.rs
+++ b/crates/perry/src/commands/doctor.rs
@@ -322,7 +322,10 @@ pub fn run(args: DoctorArgs, format: OutputFormat, use_color: bool) -> Result<()
     if args.clear_report_cache {
         let cleared = crate::compat_reports::clear_cache();
         if cleared {
-            println!("Cleared compatibility-report dedup cache at {}", crate::compat_reports::cache_path().display());
+            println!(
+                "Cleared compatibility-report dedup cache at {}",
+                crate::compat_reports::cache_path().display()
+            );
         } else {
             println!("No compatibility-report cache to clear.");
         }

--- a/crates/perry/src/compat_reports.rs
+++ b/crates/perry/src/compat_reports.rs
@@ -21,9 +21,7 @@ use crate::telemetry::{
     self, generate_client_id, load_telemetry_config, save_telemetry_config, CompatibilityReports,
     TelemetryConfig,
 };
-use perry_diagnostics::compat_report::{
-    CompatibilityReport, PendingReport, ReportSink,
-};
+use perry_diagnostics::compat_report::{CompatibilityReport, PendingReport, ReportSink};
 use serde::{Deserialize, Serialize};
 use std::io::IsTerminal;
 use std::path::PathBuf;
@@ -60,9 +58,7 @@ impl SessionConsent {
     fn allows_send(&self) -> bool {
         matches!(
             self,
-            SessionConsent::AllowOnce
-                | SessionConsent::AllowAlways
-                | SessionConsent::AlreadyOn
+            SessionConsent::AllowOnce | SessionConsent::AllowAlways | SessionConsent::AlreadyOn
         )
     }
 }
@@ -89,10 +85,7 @@ fn counters() -> &'static Mutex<ReportCounters> {
 
 /// Snapshot of the live counters for `perry doctor` output.
 pub(crate) fn current_counters() -> ReportCounters {
-    counters()
-        .lock()
-        .map(|g| *g)
-        .unwrap_or_default()
+    counters().lock().map(|g| *g).unwrap_or_default()
 }
 
 struct QueueSink;
@@ -482,12 +475,11 @@ mod tests {
         let mut cache = ReportCache::default();
         // Pretend this hash was seen 31 days ago.
         let thirty_one_days = 31 * 24 * 60 * 60;
-        cache
-            .seen
-            .insert("sha256:stale".into(), unix_now().saturating_sub(thirty_one_days));
-        cache
-            .seen
-            .insert("sha256:fresh".into(), unix_now());
+        cache.seen.insert(
+            "sha256:stale".into(),
+            unix_now().saturating_sub(thirty_one_days),
+        );
+        cache.seen.insert("sha256:fresh".into(), unix_now());
         cache.prune();
         assert!(!cache.seen.contains_key("sha256:stale"));
         assert!(cache.seen.contains_key("sha256:fresh"));

--- a/crates/perry/src/compat_reports.rs
+++ b/crates/perry/src/compat_reports.rs
@@ -1,0 +1,525 @@
+//! CLI-side glue for #849 compatibility reports.
+//!
+//! `perry-diagnostics` defines the payload type, the redactor, and a
+//! `ReportSink` trait. This module:
+//!
+//! - Installs the sink at process startup (`install_sink`).
+//! - Holds the in-process queue of `PendingReport`s.
+//! - Owns the 30-day dedup cache at `~/.perry/.report-cache`.
+//! - Drives the consent prompt (mode = `ask`).
+//! - Drains the queue and forwards approved reports to Chirp (or
+//!   `--show-pending-reports`) on shutdown.
+//!
+//! Privacy invariant: a `PendingReport` carries the raw snippet only
+//! across this in-process boundary. We never persist raw snippets to disk
+//! and never put them on the wire — the snippet is redacted in
+//! `CompatibilityReport::build`, the redacted version is what flushes
+//! out, and the cache only stores `snippet_hash` (already redaction-only).
+
+use crate::commands::publish::{load_config, save_config};
+use crate::telemetry::{
+    self, generate_client_id, load_telemetry_config, save_telemetry_config, CompatibilityReports,
+    TelemetryConfig,
+};
+use perry_diagnostics::compat_report::{
+    CompatibilityReport, PendingReport, ReportSink,
+};
+use serde::{Deserialize, Serialize};
+use std::io::IsTerminal;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+/// One-time-per-process flag so the "ask" prompt only fires once even if
+/// the compiler emits 50 unsupported-feature diagnostics for the same
+/// file. After the user answers, subsequent reports either flow or are
+/// dropped according to the answer.
+fn consent_decision_for_session() -> &'static Mutex<Option<SessionConsent>> {
+    static INSTANCE: OnceLock<Mutex<Option<SessionConsent>>> = OnceLock::new();
+    INSTANCE.get_or_init(|| Mutex::new(None))
+}
+
+/// What the user (or env) decided for this process run. `None` means we
+/// haven't asked yet — the next qualifying report triggers the prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionConsent {
+    /// `y` — yes, just this once. Don't persist.
+    AllowOnce,
+    /// `a` — yes, always. Persist `on`.
+    AllowAlways,
+    /// `n` — no, this time. Don't persist.
+    DenyOnce,
+    /// `N` — never. Persist `off`.
+    DenyAlways,
+    /// Mode was already `on` at session start (no prompt needed).
+    AlreadyOn,
+    /// Mode was already `off` (no prompt — we don't even install the sink).
+    AlreadyOff,
+}
+
+impl SessionConsent {
+    fn allows_send(&self) -> bool {
+        matches!(
+            self,
+            SessionConsent::AllowOnce
+                | SessionConsent::AllowAlways
+                | SessionConsent::AlreadyOn
+        )
+    }
+}
+
+/// Pending-report queue. Pushed to by the diagnostic chokepoint, drained
+/// at flush time.
+fn pending_queue() -> &'static Mutex<Vec<PendingReport>> {
+    static INSTANCE: OnceLock<Mutex<Vec<PendingReport>>> = OnceLock::new();
+    INSTANCE.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Counters surfaced by `perry doctor`.
+#[derive(Default, Debug, Clone, Copy)]
+pub(crate) struct ReportCounters {
+    pub queued: usize,
+    pub sent: usize,
+    pub suppressed_by_dedup: usize,
+}
+
+fn counters() -> &'static Mutex<ReportCounters> {
+    static INSTANCE: OnceLock<Mutex<ReportCounters>> = OnceLock::new();
+    INSTANCE.get_or_init(|| Mutex::new(ReportCounters::default()))
+}
+
+/// Snapshot of the live counters for `perry doctor` output.
+pub(crate) fn current_counters() -> ReportCounters {
+    counters()
+        .lock()
+        .map(|g| *g)
+        .unwrap_or_default()
+}
+
+struct QueueSink;
+
+impl ReportSink for QueueSink {
+    fn submit(&self, pending: PendingReport) {
+        if let Ok(mut q) = pending_queue().lock() {
+            // Throttle: cap the queue at 100 in-process. We don't want a
+            // pathological loop emitting unbounded reports.
+            if q.len() < 100 {
+                q.push(pending);
+                if let Ok(mut c) = counters().lock() {
+                    c.queued += 1;
+                }
+            }
+        }
+    }
+}
+
+/// Read the active `compatibility_reports` mode for this process,
+/// honouring env-level overrides (`PERRY_NO_TELEMETRY=1`, `CI=true`).
+pub(crate) fn active_mode() -> CompatibilityReports {
+    if telemetry::should_skip_telemetry() {
+        return CompatibilityReports::Off;
+    }
+    load_telemetry_config()
+        .map(|c| c.compatibility_reports)
+        .unwrap_or(CompatibilityReports::Ask)
+}
+
+/// Install the diagnostic sink so HIR/codegen emission sites enqueue
+/// `PendingReport`s. Idempotent — calling twice replaces the sink.
+///
+/// Mode `Off` skips installation entirely (zero overhead in the
+/// emission path, since `has_report_sink()` returns false).
+pub(crate) fn install_sink() {
+    let mode = active_mode();
+    if mode == CompatibilityReports::Off {
+        return;
+    }
+    perry_diagnostics::compat_report::set_report_sink(Box::new(QueueSink));
+
+    // If the user already opted in (`on`), pre-seed the session consent
+    // so we never block on a prompt mid-compile.
+    if mode == CompatibilityReports::On {
+        if let Ok(mut g) = consent_decision_for_session().lock() {
+            *g = Some(SessionConsent::AlreadyOn);
+        }
+    }
+}
+
+/// Drain the queue, prompt for consent if necessary, send approved
+/// reports. Called from the CLI shutdown path right before
+/// `telemetry::flush()`.
+pub(crate) fn flush() {
+    let mode = active_mode();
+    if mode == CompatibilityReports::Off {
+        // Empty the queue to keep `perry doctor`'s queued counter honest.
+        if let Ok(mut q) = pending_queue().lock() {
+            q.clear();
+        }
+        return;
+    }
+
+    let pending: Vec<PendingReport> = pending_queue()
+        .lock()
+        .map(|mut q| std::mem::take(&mut *q))
+        .unwrap_or_default();
+    if pending.is_empty() {
+        return;
+    }
+
+    let consent = ensure_consent(mode, pending.first());
+    if !consent.allows_send() {
+        return;
+    }
+
+    let mut cache = ReportCache::load();
+    let client_id = ensure_client_id();
+    let perry_version = env!("CARGO_PKG_VERSION").to_string();
+    let os = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
+    let node_target = std::env::var("PERRY_NODE_TARGET").unwrap_or_else(|_| "unknown".to_string());
+
+    let mut to_send: Vec<CompatibilityReport> = Vec::new();
+    for p in pending {
+        let report = match CompatibilityReport::build(
+            p.code,
+            p.category,
+            p.stage,
+            &p.raw_snippet,
+            client_id.clone(),
+            perry_version.clone(),
+            os.clone(),
+            node_target.clone(),
+            p.ts_feature.clone(),
+            p.node_api.clone(),
+        ) {
+            Ok(r) => r,
+            Err(_e) => {
+                // Refused by redaction — drop, never fall back. (We
+                // intentionally don't surface the error to avoid
+                // confusing the user with a noisy line for an opt-in
+                // background channel.)
+                continue;
+            }
+        };
+
+        if cache.contains_recent(&report.snippet_hash) {
+            if let Ok(mut c) = counters().lock() {
+                c.suppressed_by_dedup += 1;
+            }
+            continue;
+        }
+        cache.record(report.snippet_hash.clone());
+        to_send.push(report);
+    }
+
+    cache.save();
+
+    for report in to_send {
+        send_compat_report(&report);
+        if let Ok(mut c) = counters().lock() {
+            c.sent += 1;
+        }
+    }
+}
+
+/// Render a single compatibility-report payload to stderr in the format
+/// `perry doctor --show-pending-reports` expects. Returns the redacted
+/// reports (drains the queue) so the doctor command can list them.
+pub(crate) fn drain_for_display() -> Vec<CompatibilityReport> {
+    let pending: Vec<PendingReport> = pending_queue()
+        .lock()
+        .map(|mut q| std::mem::take(&mut *q))
+        .unwrap_or_default();
+    let client_id = ensure_client_id();
+    let perry_version = env!("CARGO_PKG_VERSION").to_string();
+    let os = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
+    let node_target = std::env::var("PERRY_NODE_TARGET").unwrap_or_else(|_| "unknown".to_string());
+
+    let mut out = Vec::new();
+    for p in pending {
+        if let Ok(r) = CompatibilityReport::build(
+            p.code,
+            p.category,
+            p.stage,
+            &p.raw_snippet,
+            client_id.clone(),
+            perry_version.clone(),
+            os.clone(),
+            node_target.clone(),
+            p.ts_feature,
+            p.node_api,
+        ) {
+            out.push(r);
+        }
+    }
+    out
+}
+
+/// Persisted dedup record. `seen_at` is a unix timestamp; entries older
+/// than `CACHE_TTL_SECS` are pruned on load.
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+struct ReportCache {
+    /// snippet_hash -> unix seconds when last seen
+    seen: std::collections::HashMap<String, u64>,
+}
+
+const CACHE_TTL_SECS: u64 = 30 * 24 * 60 * 60; // 30 days
+
+pub(crate) fn cache_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".perry")
+        .join(".report-cache")
+}
+
+impl ReportCache {
+    fn load() -> Self {
+        let path = cache_path();
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            return Self::default();
+        };
+        let mut cache: ReportCache = serde_json::from_str(&content).unwrap_or_default();
+        cache.prune();
+        cache
+    }
+
+    fn save(&self) {
+        let path = cache_path();
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Ok(content) = serde_json::to_string(self) {
+            let _ = std::fs::write(path, content);
+        }
+    }
+
+    fn contains_recent(&self, hash: &str) -> bool {
+        let now = unix_now();
+        match self.seen.get(hash) {
+            Some(&t) => now.saturating_sub(t) < CACHE_TTL_SECS,
+            None => false,
+        }
+    }
+
+    fn record(&mut self, hash: String) {
+        self.seen.insert(hash, unix_now());
+    }
+
+    fn prune(&mut self) {
+        let now = unix_now();
+        self.seen
+            .retain(|_, &mut t| now.saturating_sub(t) < CACHE_TTL_SECS);
+    }
+}
+
+/// Public entry point for `perry doctor --clear-report-cache`. Returns
+/// `true` if a cache file existed and was removed, `false` if there was
+/// nothing to clear.
+pub(crate) fn clear_cache() -> bool {
+    let path = cache_path();
+    if path.exists() {
+        std::fs::remove_file(&path).is_ok()
+    } else {
+        false
+    }
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Ensure a client_id is present in config (reuses the same UUID as the
+/// generic telemetry channel — same anonymous identifier across both
+/// opt-ins).
+fn ensure_client_id() -> String {
+    let cfg = load_telemetry_config();
+    if let Some(c) = cfg {
+        if !c.client_id.is_empty() {
+            return c.client_id;
+        }
+    }
+    // Mint a new one and persist it.
+    let new_id = generate_client_id();
+    let mut tc = load_telemetry_config().unwrap_or_default();
+    tc.client_id = new_id.clone();
+    save_telemetry_config(&tc);
+    new_id
+}
+
+/// Decide whether this session is allowed to send compat reports.
+/// Memoized per process — we don't re-prompt for every diagnostic.
+fn ensure_consent(mode: CompatibilityReports, sample: Option<&PendingReport>) -> SessionConsent {
+    if let Ok(g) = consent_decision_for_session().lock() {
+        if let Some(c) = *g {
+            return c;
+        }
+    }
+
+    let decision = match mode {
+        CompatibilityReports::Off => SessionConsent::AlreadyOff,
+        CompatibilityReports::On => SessionConsent::AlreadyOn,
+        CompatibilityReports::Ask => prompt_consent(sample),
+    };
+
+    if let Ok(mut g) = consent_decision_for_session().lock() {
+        *g = Some(decision);
+    }
+    decision
+}
+
+/// Four-choice interactive prompt per #849:
+///
+/// ```
+///   [y] yes, just this once
+///   [a] yes, always (don't ask again)
+///   [n] no, this time
+///   [N] never, don't ask again
+/// ```
+///
+/// Default (Enter) = `n`. Non-TTY environments silently deny (== `n`).
+fn prompt_consent(sample: Option<&PendingReport>) -> SessionConsent {
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        return SessionConsent::DenyOnce;
+    }
+
+    eprintln!();
+    if let Some(p) = sample {
+        let feature = p
+            .ts_feature
+            .clone()
+            .or_else(|| p.node_api.clone())
+            .unwrap_or_else(|| format!("{:?}", p.code));
+        eprintln!("Perry doesn't yet fully support: {}", feature);
+    }
+    eprintln!();
+    eprintln!("  Send an anonymous report to help prioritize?");
+    eprintln!("  [y] yes, just this once");
+    eprintln!("  [a] yes, always (don't ask again)");
+    eprintln!("  [n] no, this time          (default)");
+    eprintln!("  [N] never, don't ask again");
+    eprintln!();
+
+    use std::io::Write;
+    eprint!("> ");
+    let _ = std::io::stderr().flush();
+
+    let mut line = String::new();
+    if std::io::stdin().read_line(&mut line).is_err() {
+        return SessionConsent::DenyOnce;
+    }
+    let answer = line.trim();
+    match answer {
+        "y" | "Y" => SessionConsent::AllowOnce,
+        "a" | "A" => {
+            persist_mode(CompatibilityReports::On);
+            SessionConsent::AllowAlways
+        }
+        "N" => {
+            persist_mode(CompatibilityReports::Off);
+            SessionConsent::DenyAlways
+        }
+        // Empty (Enter) or "n" — deny just this time
+        _ => SessionConsent::DenyOnce,
+    }
+}
+
+fn persist_mode(mode: CompatibilityReports) {
+    let mut config = load_config();
+    let mut t = config.telemetry.unwrap_or(TelemetryConfig {
+        enabled: false,
+        client_id: String::new(),
+        compatibility_reports: CompatibilityReports::Ask,
+    });
+    if t.client_id.is_empty() {
+        t.client_id = generate_client_id();
+    }
+    t.compatibility_reports = mode;
+    config.telemetry = Some(t);
+    let _ = save_config(&config);
+}
+
+/// POST a single compatibility report to Chirp. Best-effort; failures are
+/// silently swallowed (this is opt-in background telemetry).
+fn send_compat_report(report: &CompatibilityReport) {
+    let body = match serde_json::to_value(report) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let client_id = report.client_id.clone();
+
+    std::thread::spawn(move || {
+        let client = match reqwest::blocking::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(3))
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+        {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+        let envelope = serde_json::json!({
+            "event": "compat_report",
+            "dims": body,
+        });
+        let _ = client
+            .post("https://api.chirp247.com/api/v1/event")
+            .header("Content-Type", "application/json")
+            .header("X-Chirp-Key", "testkey123")
+            .header("X-Chirp-Client", client_id)
+            .json(&envelope)
+            .send();
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perry_diagnostics::compat_report::{ReportCategory, ReportStage};
+    use perry_diagnostics::DiagnosticCode;
+
+    #[test]
+    fn cache_prunes_entries_older_than_30_days() {
+        let mut cache = ReportCache::default();
+        // Pretend this hash was seen 31 days ago.
+        let thirty_one_days = 31 * 24 * 60 * 60;
+        cache
+            .seen
+            .insert("sha256:stale".into(), unix_now().saturating_sub(thirty_one_days));
+        cache
+            .seen
+            .insert("sha256:fresh".into(), unix_now());
+        cache.prune();
+        assert!(!cache.seen.contains_key("sha256:stale"));
+        assert!(cache.seen.contains_key("sha256:fresh"));
+    }
+
+    #[test]
+    fn cache_contains_recent_respects_ttl() {
+        let mut cache = ReportCache::default();
+        cache.record("sha256:x".into());
+        assert!(cache.contains_recent("sha256:x"));
+        assert!(!cache.contains_recent("sha256:y"));
+    }
+
+    #[test]
+    fn queue_sink_pushes_pending_reports() {
+        // Clear queue first
+        if let Ok(mut q) = pending_queue().lock() {
+            q.clear();
+        }
+        if let Ok(mut c) = counters().lock() {
+            *c = ReportCounters::default();
+        }
+        let sink = QueueSink;
+        sink.submit(PendingReport {
+            code: DiagnosticCode::UnsupportedExpression,
+            category: ReportCategory::GapCategorical,
+            stage: ReportStage::HirLower,
+            raw_snippet: "const x = 1;".into(),
+            ts_feature: None,
+            node_api: None,
+        });
+        assert_eq!(pending_queue().lock().unwrap().len(), 1);
+        assert_eq!(current_counters().queued, 1);
+    }
+}

--- a/crates/perry/src/main.rs
+++ b/crates/perry/src/main.rs
@@ -3,6 +3,7 @@
 //! CLI driver for compiling TypeScript to native executables.
 
 mod commands;
+mod compat_reports;
 mod telemetry;
 mod update_checker;
 
@@ -357,6 +358,12 @@ fn main_inner() -> Result<()> {
         false
     };
 
+    // #849: install the compat-report sink so diagnostic emission sites
+    // can enqueue reports. Honors `compatibility_reports = "off"` (skips
+    // installation entirely) and `PERRY_NO_TELEMETRY=1`/`CI=true` (same
+    // env overrides as the generic telemetry channel).
+    compat_reports::install_sink();
+
     // Spawn background update check (non-blocking, cached for 24h)
     let is_update_cmd = matches!(cli.command, Some(Commands::Update(_)));
     let bg_check = if !cli.quiet && !is_update_cmd && !update_checker::should_skip_check() {
@@ -457,6 +464,11 @@ fn main_inner() -> Result<()> {
             update_checker::print_update_notice(&current, &latest, &release_url, use_stderr_color);
         }
     }
+
+    // #849: drain queued compat reports (prompts the user once in `ask`
+    // mode) before flushing generic telemetry. Runs even when the
+    // command succeeded — reports fire on *warnings* too (e.g. NoOpStub).
+    compat_reports::flush();
 
     // Wait for any pending telemetry events to be delivered before exiting
     telemetry::flush();

--- a/crates/perry/src/telemetry.rs
+++ b/crates/perry/src/telemetry.rs
@@ -22,15 +22,55 @@ const CHIRP_KEY: &str = "testkey123";
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// Tri-state setting for the #849 opt-in compatibility-report channel.
+/// Decoupled from `enabled` (generic usage analytics) so users can opt in
+/// to one without the other.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum CompatibilityReports {
+    /// Never send. Sink stays uninstalled; queue stays empty.
+    Off,
+    /// Prompt the user the first time a qualifying report would fire.
+    /// Default for new installs.
+    #[default]
+    Ask,
+    /// Always send (after dedup + redaction). User has opted in.
+    On,
+}
+
+impl CompatibilityReports {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            CompatibilityReports::Off => "off",
+            CompatibilityReports::Ask => "ask",
+            CompatibilityReports::On => "on",
+        }
+    }
+}
+
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct TelemetryConfig {
     pub(crate) enabled: bool,
     #[serde(default)]
     pub(crate) client_id: String,
+    /// #849: opt-in compatibility reports. Off by default in code (`Ask`
+    /// is the variant default but `#[serde(default)]` means existing
+    /// installs without the field get `Off` until they upgrade — see
+    /// `compatibility_reports_default`).
+    #[serde(default = "compatibility_reports_default")]
+    pub(crate) compatibility_reports: CompatibilityReports,
+}
+
+/// Existing users (config.toml predates #849) get `Ask` so they see the
+/// prompt next time a gap is hit. New installs running through
+/// `init_and_check_consent()` also land on `Ask`. Set explicitly to `Off`
+/// to opt out at the file level.
+fn compatibility_reports_default() -> CompatibilityReports {
+    CompatibilityReports::Ask
 }
 
 /// Returns true if telemetry should be skipped entirely (explicit opt-out).
-fn should_skip_telemetry() -> bool {
+pub(crate) fn should_skip_telemetry() -> bool {
     if std::env::var("PERRY_NO_TELEMETRY").is_ok_and(|v| v == "1" || v == "true") {
         return true;
     }
@@ -48,20 +88,20 @@ fn should_skip_consent_prompt() -> bool {
 
 /// Load telemetry config from ~/.perry/config.toml.
 /// Returns None if no [telemetry] section exists (= never asked).
-fn load_telemetry_config() -> Option<TelemetryConfig> {
+pub(crate) fn load_telemetry_config() -> Option<TelemetryConfig> {
     let config = load_config();
     config.telemetry
 }
 
 /// Save telemetry config, preserving all other config sections.
-fn save_telemetry_config(telemetry: &TelemetryConfig) {
+pub(crate) fn save_telemetry_config(telemetry: &TelemetryConfig) {
     let mut config = load_config();
     config.telemetry = Some(telemetry.clone());
     let _ = save_config(&config);
 }
 
 /// Generate a random client ID (UUID-like hex string).
-fn generate_client_id() -> String {
+pub(crate) fn generate_client_id() -> String {
     let mut bytes = [0u8; 16];
 
     // Try /dev/urandom first (Unix) — must use Read trait, not fs::read (infinite device)
@@ -109,6 +149,11 @@ fn prompt_consent() -> bool {
     let config = TelemetryConfig {
         enabled: consent,
         client_id: generate_client_id(),
+        // Generic analytics consent prompt doesn't speak for the
+        // separate #849 compat-report channel — leave it on `Ask` so
+        // the user gets a focused, in-context prompt the first time
+        // a gap actually fires.
+        compatibility_reports: CompatibilityReports::Ask,
     };
     save_telemetry_config(&config);
 


### PR DESCRIPTION
## Summary

Adds a narrow, opt-in telemetry channel for compatibility gaps —
**separate** from the existing generic usage analytics. Closes #849.

When the compiler emits a diagnostic with one of the targeted
`DiagnosticCode` variants (`UnsupportedBinaryOp`, `UnsupportedExpression`,
`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`,
`UnresolvedImport`, `NoOpStub`), a redacted, dedup'd report is queued.
On CLI shutdown the queue is drained, optionally prompted for, and
forwarded to Chirp.

## What landed (the "Done when" checklist from the issue)

- [x] **`compatibility_reports` config field** plumbed through
  `PerryConfig` with `off | ask | on`
  (`crates/perry/src/telemetry.rs`).
- [x] **Payload type** `CompatibilityReport` defined in
  `perry-diagnostics::compat_report` with serde derives matching the
  schema in the issue body (perry_version, client_id, code, category,
  stage, snippet_hash, snippet_redacted, ts_feature, node_api, os,
  node_target).
- [x] **Single chokepoint** in `perry-diagnostics::emitter` —
  `forward_to_compat_report_channel(diag, cache)` called from all three
  emitters (`TerminalEmitter`, `JsonEmitter`, `SimpleEmitter`). No per-
  crate emission policy required. Hits every site that goes through the
  diagnostic emitter, including the `lower_bail!` chain in
  `perry-hir`, the codegen "Call callee shape not supported" sites, and
  the runtime `NoOpStub` warnings.
- [x] **Redaction module** with mandatory table-driven test coverage:
  `crates/perry-diagnostics/src/compat_report.rs::redact_snippet` plus
  `tests/redaction.rs` (22-case corpus + 5 invariant tests). Rules:
  - String literals → `"<str>"`; template literals → `` `<tpl>` ``
  - Number literals → `<num>` (incl. BigInt `n` suffix, exponents,
    underscore separators)
  - Identifiers (except whitelisted globals: `console`, `Math`,
    `Promise`, `Array`, `Object`, `process`, JS/TS keywords, ...) →
    `<id1>`, `<id2>`, ... (stable across the snippet)
  - Comments stripped, whitespace collapsed
  - Hard cap 200 chars with `...` truncation
  - **Reject** the snippet if any quoted string, template literal,
    PascalCase ident, or numeric literal survives — never fall back to
    the raw snippet.
- [x] **30-day dedup cache** at `~/.perry/.report-cache` keyed by
  `snippet_hash` (`crates/perry/src/compat_reports.rs::ReportCache`).
  TTL-prunes on load, persists JSON.
- [x] **`perry doctor` integration** — shows current mode + counters
  (`sent`, `suppressed-by-dedup`, `queued`) plus cache status.
  `--show-pending-reports` prints the redacted payloads about to be
  sent. `--clear-report-cache` resets the dedup cache.
- [x] **Consent prompt** wired into the diagnostic emission path —
  four-choice UX (`y` / `a` / `n` / `N`) per the spec; `a`/`N` persist
  `on`/`off` to config.toml; default (Enter) = `n`. Memoized per
  process so we don't re-prompt for every diagnostic.
- [x] **Docs**: new "Privacy & Telemetry" section in README documenting
  both channels and the exact wire schema; `perry doctor` output
  surfaces the mode.

## Privacy invariants enforced

- The chokepoint refuses to enqueue if no sink is installed (zero
  overhead in the common case).
- The CLI sink **never** persists raw snippets — they live in memory in
  a `PendingReport` only until `compat_reports::flush()` redacts them.
- `CompatibilityReport::build` always redacts; a redaction failure
  drops the report instead of sending raw source.
- The cache stores only `snippet_hash` (already redaction-only).
- `PERRY_NO_TELEMETRY=1` and `CI=true` both suppress the sink entirely
  (same env overrides as the existing generic telemetry channel).

## Deferred to a follow-up

- **Server-side `known_failures.json` lookup** that surfaces "likely
  #N" in the consent prompt. The prompt currently says `Perry doesn't
  yet fully support: <ts_feature or node_api or code>` without a
  cross-reference. The infrastructure (categorization mirrors
  `known_failures.json`'s schema) is in place; surfacing the issue
  number is purely a server-side lookup added later.

Explicitly out of scope per the issue body: auto-creating GitHub
issues, runtime crash reports, performance telemetry, public
dashboards, raw-source upload.

## Test plan

- [x] `cargo test -p perry-diagnostics` (16 tests pass: 6 redaction
  table cases + 5 invariant tests + 3 chokepoint integration tests +
  2 inline unit tests).
- [x] `cargo test -p perry --bin perry` (327 tests pass, including 3
  new `compat_reports::tests` for cache TTL, dedup behaviour, and
  queue sink push semantics).
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry`
  succeeds with no new warnings from #849 files.
- [x] Smoke: `perry doctor` shows `compatibility reports (#849): mode=ask`
  with empty counters on a fresh install; `--show-pending-reports`
  and `--clear-report-cache` work end-to-end.
- [x] Smoke: `PERRY_NO_TELEMETRY=1 perry doctor` shows `mode=off` and
  installs no sink (verified by absence of queued reports after a
  failed compile).

## Files touched

- `crates/perry-diagnostics/src/compat_report.rs` (new — payload, redactor, sha256, sink trait)
- `crates/perry-diagnostics/src/emitter.rs` (chokepoint hook in all 3 emitters)
- `crates/perry-diagnostics/src/lib.rs` (re-exports)
- `crates/perry-diagnostics/Cargo.toml` (dev-deps)
- `crates/perry-diagnostics/tests/redaction.rs` (new — mandatory table-driven coverage)
- `crates/perry-diagnostics/tests/chokepoint_integration.rs` (new — emitter end-to-end)
- `crates/perry/src/compat_reports.rs` (new — CLI sink, cache, consent prompt)
- `crates/perry/src/telemetry.rs` (CompatibilityReports enum + config field)
- `crates/perry/src/main.rs` (install_sink + flush wiring)
- `crates/perry/src/commands/doctor.rs` (mode/counters check + 2 new flags)
- `README.md` (Privacy & Telemetry section)