### PR TITLE
fix(wasm): #1037 — String.fromCharCode returned undefined on --target web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1008 — fix(wasm): #1037 — `String.fromCharCode` returns `undefined` on `--target web`
+
+The reduction Ralph posted on #1037 showed `s += String.fromCharCode(0)` over-appending 9 chars per iteration — but the underlying cause was not handle-ID stringification; it was simpler. The compiled `String.fromCharCode` was returning `undefined`, and `'' + undefined === 'undefined'` (which is exactly 9 chars). 16 iters × 9 = the observed 144-byte length.
+
+### Root cause
+
+`crates/perry-codegen-wasm/src/emit.rs:7702..7711` (the `Expr::StringFromCharCode` and `Expr::StringFromCodePoint` codegen arms) emitted a `mem_call` to the bridge name `string_from_char_code` (snake_case). The runtime's `__memDispatch` table in `crates/perry-codegen-wasm/src/wasm_runtime.js` only registers `string_fromCharCode` (camelCase, line 1660). With no matching dispatch entry, `mem_call` (line 1377) falls through to `__classDispatch(args[0], "string_from_char_code", [])`. `args[0]` is the decoded code argument (a plain number) — `Number.prototype["string_from_char_code"]` is undefined — `__classDispatch` returns undefined. The compiled call then NaN-boxes `undefined` and ships it back as the FFI result. JS string concat coerces that to `"undefined"`, and the editor's `buildBlockDepthString` cache grew 9× per parse, which surfaced as the apparent "hang" reported in the original issue (`object_get_dynamic` re-fetching the same end-of-buffer offset against a forever-too-small cache).
+
+### Fix
+
+Two-character edit per arm: `string_from_char_code` → `string_fromCharCode`. Both `String.fromCharCode` and `String.fromCodePoint` route through the same HIR variant in WASM today (the StringFromCodePoint arm has a `// WASM stub: same as fromCharCode for now (BMP-only)` comment from before this fix).
+
+### Verified
+
+Ralph's four-row variant matrix from the issue thread, all on `--target web` (now `--target wasm` per the harness):
+
+| Variant | Pre-fix | Post-fix |
+|---|---|---|
+| `result += 'x'` (literal) | 16 ✓ | 16 ✓ |
+| `result += String.fromCharCode(0)` | 144 | **16 ✓** |
+| `result = result + String.fromCharCode(0)` | 144 | **16 ✓** |
+| 4-iter `result += String.fromCharCode(0)` | 36 | **4 ✓** |
+| `String.fromCodePoint(65)` | undefined | **"A" ✓** |
+
+Regression test `tests/wasm/20_string_from_char_code.ts` covers all four shapes.
+
+### Harness fix bundled
+
+The wasm test runner at `tests/wasm/run_wasm_tests.sh` was failing every test with `document is not defined` because `wasm_runtime.js` injects a `<style>` element at module load (`document.head.appendChild(...)` at line 2528). Added a minimal DOM polyfill at the top of the Node eval block. Local runner only — CI uses a separate cross-compile gate that doesn't execute the wasm.
+
+Same-suite result on baseline (pre-fix, my new test removed): 12 pass, 7 fail (`05_objects_arrays`, `10_higher_order`, `11_map_set_json`, `14_regex_date`, `17_class_field_splice`, `18_module_splice`, `19_ffi_imports`). With the fix applied: identical 7 pre-existing failures + 1 new passing test (`20_string_from_char_code`). No regressions.
+
+### Related typos worth noting (not fixed in this PR — out of scope)
+
+Audit found seven other emit-side bridge names with the same snake_case/camelCase mismatch, all in the `_ => Handle instance method calls on objects` catch-all in `Expr::NativeMethodCall` (`emit.rs:5588..5840`): `string_char_at`, `string_index_of`, `string_to_lower_case`, `string_to_upper_case`, `string_starts_with`, `string_ends_with`, `string_pad_start`, `string_pad_end`. The catch-all path is unreachable for normal `str.charAt(i)` etc. — those hit `emit_method_call` at `emit.rs:4081` (camelCase, correct) — so the bugs are latent. Listing here so a future cleanup can sweep them with a separate test per name.
+
+### Files touched
+
+- `crates/perry-codegen-wasm/src/emit.rs` — two bridge-name edits in `Expr::StringFromCharCode` and `Expr::StringFromCodePoint`.
+- `tests/wasm/run_wasm_tests.sh` — DOM polyfill for the Node eval harness.
+- `tests/wasm/20_string_from_char_code.{ts,expected}` — regression test.
+- `Cargo.toml`, `CLAUDE.md` — version bump.
+
 ## v0.5.1007 — fix(wasm-runtime): #1034 Date.prototype.getDay LinkError + audit, #1035 __classDispatch optional-param arg padding
 
 Two WASM-target (`--target web`) instantiation/runtime fixes from the @honeide/editor compile sweep.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1007
+**Current Version:** 0.5.1008
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5078,7 +5078,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "base64",
@@ -5133,14 +5133,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "log",
@@ -5153,7 +5153,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "base64",
@@ -5202,7 +5202,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "serde",
  "serde_json",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1007"
+version = "0.5.1008"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "clap",
@@ -5244,14 +5244,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5268,7 +5268,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5276,7 +5276,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5284,7 +5284,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5292,14 +5292,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "chrono",
  "cron",
@@ -5308,7 +5308,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5316,7 +5316,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5340,21 +5340,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5379,14 +5379,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-google-auth"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5417,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5446,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "bson",
  "futures-util",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5485,7 +5485,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5496,7 +5496,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5514,7 +5514,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "base64",
  "image",
@@ -5540,14 +5540,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5555,7 +5555,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5592,7 +5592,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5601,7 +5601,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "base64",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5770,11 +5770,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1007"
+version = "0.5.1008"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "base64",
  "itoa",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5800,7 +5800,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "base64",
  "block2",
@@ -5837,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "base64",
  "block2",
@@ -5856,11 +5856,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1007"
+version = "0.5.1008"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "base64",
  "block2",
@@ -5876,7 +5876,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "base64",
  "block2",
@@ -5892,7 +5892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "block2",
  "libc",
@@ -5905,7 +5905,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "base64",
  "libc",
@@ -5920,7 +5920,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5934,7 +5934,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1007"
+version = "0.5.1008"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1007"
+version = "0.5.1008"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen-wasm/src/emit.rs
+++ b/crates/perry-codegen-wasm/src/emit.rs
@@ -7700,15 +7700,18 @@ impl<'a> FuncEmitCtx<'a> {
                 self.emit_memcall(func, "string_split", 2);
             }
             Expr::StringFromCharCode(code) => {
+                // Bridge name is the key in __memDispatch (wasm_runtime.js) — keep
+                // camelCase even though Rust prefers snake_case; no dispatch entry
+                // means mem_call silently falls through to __classDispatch.
                 self.emit_frame_begin(func, 1);
                 self.emit_store_arg(func, 0, code);
-                self.emit_memcall(func, "string_from_char_code", 1);
+                self.emit_memcall(func, "string_fromCharCode", 1);
             }
             Expr::StringFromCodePoint(code) => {
-                // WASM stub: same as fromCharCode for now (BMP-only)
+                // WASM stub: same as fromCharCode for now (BMP-only).
                 self.emit_frame_begin(func, 1);
                 self.emit_store_arg(func, 0, code);
-                self.emit_memcall(func, "string_from_char_code", 1);
+                self.emit_memcall(func, "string_fromCharCode", 1);
             }
             Expr::StringAt { string, index } => {
                 // WASM stub: alias to char_at

--- a/tests/wasm/20_string_from_char_code.expected
+++ b/tests/wasm/20_string_from_char_code.expected
@@ -1,0 +1,9 @@
+len:
+16
+A:
+A
+B:
+B
+eq-plus:
+AAAA
+4

--- a/tests/wasm/20_string_from_char_code.ts
+++ b/tests/wasm/20_string_from_char_code.ts
@@ -1,0 +1,25 @@
+// Issue #1037: String.fromCharCode / fromCodePoint via mem_call dispatch.
+// Pre-fix the WASM codegen emitted the snake_case bridge name
+// `string_from_char_code`, which had no entry in __memDispatch, so the call
+// fell through to __classDispatch(code, "string_from_char_code", []) and
+// returned undefined. That made `s += String.fromCharCode(x)` append the
+// string "undefined" (9 chars) every iteration — the 16-iter repro produced
+// length 144 instead of 16.
+
+let result = '';
+const depth = 0;
+for (let i = 0; i < 16; i++) {
+  result += String.fromCharCode(depth);
+}
+console.log('len:', result.length);
+
+// Direct call: `String.fromCharCode(65) === 'A'`.
+console.log('A:', String.fromCharCode(65));
+
+// fromCodePoint goes through the same StringFromCharCode HIR variant in WASM.
+console.log('B:', String.fromCodePoint(66));
+
+// Explicit `=` + `+` form (matrix variant from the issue thread).
+let r3 = '';
+for (let i = 0; i < 4; i++) { r3 = r3 + String.fromCharCode(65); }
+console.log('eq-plus:', r3, r3.length);

--- a/tests/wasm/run_wasm_tests.sh
+++ b/tests/wasm/run_wasm_tests.sh
@@ -39,6 +39,13 @@ run_test() {
   # Run in Node.js
   local actual
   actual=$(node -e "
+// Minimal DOM polyfill: wasm_runtime.js injects a <style> tag at module load,
+// so 'document' must exist or the require fails before any test code runs.
+globalThis.window = globalThis;
+const _stub = { id: '', appendChild: () => {}, getElementById: () => null, style: {}, textContent: '' };
+const _doc = { createElement: () => Object.assign({}, _stub), getElementById: () => null, title: '' };
+_doc.head = _stub; _doc.body = _stub;
+globalThis.document = _doc;
 const fs = require('fs');
 const html = fs.readFileSync('$html_file', 'utf8');
 const scripts = [];


### PR DESCRIPTION
## Summary

`Expr::StringFromCharCode` and `Expr::StringFromCodePoint` in the WASM emitter were calling `mem_call` with the bridge name `string_from_char_code` (snake_case). The runtime's `__memDispatch` table only has `string_fromCharCode` (camelCase). The mismatch made `mem_call` fall through to `__classDispatch(code, "string_from_char_code", [])`, which returned undefined. `s += String.fromCharCode(0)` then concatenated `"undefined"` (9 chars) per iteration — Ralph's 16-iter repro produced length 144 = 16 × 9.

(The "9× growth ratio matches handle-ID digit count" hypothesis from the issue comment was a coincidence: `'undefined'.length` is 9.)

## Fix

Two-character edit per arm — `string_from_char_code` → `string_fromCharCode`. Same bridge dispatches both `String.fromCharCode` and `String.fromCodePoint` (the StringFromCodePoint arm is currently a BMP-only stub aliased to fromCharCode).

## Variant matrix (Ralph's table, all on `--target wasm`)

| Variant | Pre-fix | Post-fix |
|---|---|---|
| `result += 'x'` (literal) | 16 ✓ | 16 ✓ |
| `result += String.fromCharCode(0)` | 144 | **16 ✓** |
| `result = result + String.fromCharCode(0)` | 144 | **16 ✓** |
| 4-iter `result += String.fromCharCode(0)` | 36 | **4 ✓** |
| `String.fromCodePoint(65)` | undefined | **"A" ✓** |

## Bundled harness fix

`tests/wasm/run_wasm_tests.sh` was failing every test with `document is not defined` — `wasm_runtime.js` injects a `<style>` element at module load (`document.head.appendChild`) since the web-UI ship. Added a minimal `document`/`window` polyfill to the Node eval block in the runner. Local-only — CI doesn't execute this script.

Same-suite results (binary built from origin/main, my new test removed):  
12 pass, 7 fail (`05_objects_arrays`, `10_higher_order`, `11_map_set_json`, `14_regex_date`, `17_class_field_splice`, `18_module_splice`, `19_ffi_imports`).  
With fix applied: identical 7 pre-existing failures + 1 new passing test (`20_string_from_char_code`). **No regressions.**

## Out of scope (worth a follow-up)

The audit found seven other bridge names with the same snake_case/camelCase mismatch, all in the `_ => Handle instance method calls on objects` catch-all in `Expr::NativeMethodCall` (`emit.rs:5588..5840`): `string_char_at`, `string_index_of`, `string_to_lower_case`, `string_to_upper_case`, `string_starts_with`, `string_ends_with`, `string_pad_start`, `string_pad_end`. They are unreachable for normal `str.charAt(i)` etc. — those hit `emit_method_call` (`emit.rs:4081`, camelCase, correct) — so the bugs are latent. Not touching them here to keep the PR focused on the user-visible bug from #1037; happy to sweep in a follow-up.

## Test plan

- [x] `cd tests/wasm && ../../target/release/perry compile 20_string_from_char_code.ts --target wasm -o /tmp/t.html` then run via the harness → `len: 16` ✓
- [x] `PERRY_ALLOW_PERRY_FEATURES=1 ./tests/wasm/run_wasm_tests.sh` → no new failures vs. origin/main baseline
- [x] `cargo build --release -p perry` succeeds, `cargo test --release -p perry-codegen-wasm` succeeds
- [ ] Verify on the original `@honeide/editor` reproducer that the keyword-tokenizer no longer hangs (this PR fixes the underlying #1037 mechanism; the editor exercises it via `buildBlockDepthString`)

Closes #1037.