### PR TITLE
fix: avoid reusing mutable async closure state

### DIFF
--- a/crates/perry-codegen/src/boxed_vars.rs
+++ b/crates/perry-codegen/src/boxed_vars.rs
@@ -1022,7 +1022,7 @@ fn collect_outer_writes_in_expr(expr: &perry_hir::Expr, out: &mut HashSet<u32>) 
 /// the given statements, INCLUDING inside nested closures. Used to
 /// detect whether a local is ever mutated — the "is this captured +
 /// mutated" gate for boxing.
-fn collect_write_ids_in_stmts(stmts: &[perry_hir::Stmt], out: &mut HashSet<u32>) {
+pub(crate) fn collect_write_ids_in_stmts(stmts: &[perry_hir::Stmt], out: &mut HashSet<u32>) {
     for s in stmts {
         collect_write_ids_in_stmt(s, out);
     }
@@ -1099,6 +1099,7 @@ fn collect_write_ids_in_stmt(stmt: &perry_hir::Stmt, out: &mut HashSet<u32>) {
                 collect_write_ids_in_stmts(&case.body, out);
             }
         }
+        Stmt::Labeled { body, .. } => collect_write_ids_in_stmt(body, out),
         _ => {}
     }
 }

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -5063,8 +5063,9 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // ClosureHeader and skips gc_malloc + gc_check_trigger.
             //
             // We skip the captured-singleton path for closures whose
-            // body mutates a capture: those want fresh per-site identity
-            // because each call site might want its own writable slot.
+            // body mutates an unboxed capture: those want fresh
+            // per-call identity because the captured slot itself holds
+            // mutable state for that invocation.
             //
             // Closures that capture `this` are still routable through
             // the captured-singleton path — we include the `this` value
@@ -5096,9 +5097,13 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // work even though the box pointers are stable across
             // call sites. The relaxed gate plus the multi-slot LRU
             // backing reclaims that overhead.
-            let _ = mutable_captures;
             let no_capture_singleton = total_caps == 0;
-            let captured_singleton = !no_capture_singleton;
+            let mut write_ids = std::collections::HashSet::new();
+            crate::boxed_vars::collect_write_ids_in_stmts(body, &mut write_ids);
+            let writes_unboxed_capture = auto_captures
+                .iter()
+                .any(|cap_id| !ctx.boxed_vars.contains(cap_id) && write_ids.contains(cap_id));
+            let captured_singleton = !no_capture_singleton && !writes_unboxed_capture;
 
             // For captures_this, the cache buffer needs an extra slot
             // for the `this` value so the cache key distinguishes

--- a/test-files/test_issue_1029_async_reentry.ts
+++ b/test-files/test_issue_1029_async_reentry.ts
@@ -1,0 +1,21 @@
+let runs = 0;
+
+async function f(): Promise<string> {
+    runs++;
+    await Promise.resolve();
+    return "hello";
+}
+
+const one = await f();
+const two = await f();
+const three = await f();
+
+if (one !== "hello" || two !== "hello" || three !== "hello") {
+    throw new Error("async reentry returned " + one + "," + two + "," + three);
+}
+
+if (runs !== 3) {
+    throw new Error("async body ran " + runs + " times");
+}
+
+console.log("issue-1029 ok");


### PR DESCRIPTION
Fixes #1029

## Summary
- Avoid captured-closure singleton reuse when a closure body writes an unboxed captured local, so per-call async state slots are not shared across repeated invocations.
- Reuse the existing write-id collector from codegen and make it traverse labeled statements, which catches async state-machine writes such as `__gen_state` / `__gen_done`.
- Add a regression fixture that awaits the same async function three times and verifies the body runs three times.

## Root Cause
The async state-machine step closure captured unboxed mutable state. The captured-closure singleton cache reused the same closure object on later calls, so the first call's completed state leaked into subsequent calls and the async body did not run again.

Boxed captures still use the cache path because the closure stores a stable box pointer and reads the current box contents dynamically.

## Verification
Local focused checks:
- PASS `cargo build --quiet --bin perry`
- PASS `target/debug/perry compile test-files/test_issue_1029_async_reentry.ts --no-cache -o /tmp/perry_issue_1029 && /tmp/perry_issue_1029` (`issue-1029 ok`)
- PASS `PERRY_BIN=./target/debug/perry scripts/run_native_no_fallback_tests.sh test-files/test_issue_1029_async_reentry.ts test-files/test_async.ts test-files/test_async_chain.ts test-files/test_edge_promises.ts` (`4 passed, 0 failed`)
- PASS `cargo fmt --all -- --check`
- PASS `cargo build --release`

GitHub CI:
- PASS `lint`
- PASS `cargo-test`
- PASS `parity`
- PASS `doc-tests`
- PASS `compile-smoke`
- PASS `api-docs-drift`
- PASS `harmonyos-smoke`
- PASS `security-audit`
