### PR TITLE
fix(fastify): #1048 — reply.type/.header chained + missing stdlib FFI

### DIFF
--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -6620,6 +6620,11 @@ const NATIVE_MODULE_TABLE: &[NativeModSig] = &[
     // function existed in `runtime_decls.rs` but no NativeModSig routed
     // user code at it. CORS hooks, Cache-Control, and content-type
     // overrides all evaporated.
+    //
+    // `ret: NR_PTR` is critical — the Rust impl returns `Handle` (i64).
+    // Previously `NR_F64` caused chained `.header(...).send(...)` to read
+    // an uninitialized XMM0/D0 register as the receiver, producing
+    // `(number).send is not a function` errors (#1048).
     NativeModSig {
         module: "fastify",
         has_receiver: true,
@@ -6627,10 +6632,11 @@ const NATIVE_MODULE_TABLE: &[NativeModSig] = &[
         class_filter: None,
         runtime: "js_fastify_reply_header",
         args: &[NA_JSV, NA_JSV],
-        ret: NR_F64,
+        ret: NR_PTR,
     },
     // `reply.type(value)` — Fastify alias for setting `content-type`.
     // Routes to `js_fastify_reply_type` (thin wrapper over reply_header).
+    // `ret: NR_PTR` for the same reason as `reply.header` above (#1048).
     NativeModSig {
         module: "fastify",
         has_receiver: true,
@@ -6638,7 +6644,7 @@ const NATIVE_MODULE_TABLE: &[NativeModSig] = &[
         class_filter: None,
         runtime: "js_fastify_reply_type",
         args: &[NA_JSV],
-        ret: NR_F64,
+        ret: NR_PTR,
     },
     // Fastify context methods (Hono-style)
     NativeModSig {

--- a/crates/perry-hir/src/lower/expr_call.rs
+++ b/crates/perry-hir/src/lower/expr_call.rs
@@ -2201,8 +2201,8 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                         // untagged NaN that the next chain step read as a number
                         // ("(number).send is not a function"). Static NATIVE_MODULE_TABLE
                         // dispatch covers it correctly.
-                        let is_fastify_reply = module.as_str() == "fastify"
-                            && class_name.as_deref() == Some("Reply");
+                        let is_fastify_reply =
+                            module.as_str() == "fastify" && class_name.as_deref() == Some("Reply");
                         let is_fastify_reply_chain_method = matches!(
                             method_name.as_str(),
                             "code" | "status" | "header" | "type" | "send"

--- a/crates/perry-hir/src/lower/expr_call.rs
+++ b/crates/perry-hir/src/lower/expr_call.rs
@@ -2189,7 +2189,27 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                                 | "parse"
                                 | "opts"
                         );
-                        if (is_math_lib && is_math_method) || (is_commander && is_commander_method)
+                        // #1048 — fastify Reply chainable methods. `reply.code(201)
+                        // .type("application/json").send(payload)` ships every method
+                        // returning the same reply handle for chaining; without this
+                        // branch only the inner `.code(...)` resolved as a
+                        // NativeMethodCall and the rest of the chain fell through to
+                        // the generic Call+PropertyGet path. That path routes through
+                        // `js_native_call_method` → HANDLE_METHOD_DISPATCH, which has
+                        // no fastify arm when the well-known flip strips
+                        // `bundled-fastify` from stdlib — so `.type(...)` returned an
+                        // untagged NaN that the next chain step read as a number
+                        // ("(number).send is not a function"). Static NATIVE_MODULE_TABLE
+                        // dispatch covers it correctly.
+                        let is_fastify_reply = module.as_str() == "fastify"
+                            && class_name.as_deref() == Some("Reply");
+                        let is_fastify_reply_chain_method = matches!(
+                            method_name.as_str(),
+                            "code" | "status" | "header" | "type" | "send"
+                        );
+                        if (is_math_lib && is_math_method)
+                            || (is_commander && is_commander_method)
+                            || (is_fastify_reply && is_fastify_reply_chain_method)
                         {
                             return Ok(Expr::NativeMethodCall {
                                 module: module.clone(),

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -81,6 +81,7 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
             | "status"
             | "code"
             | "header"
+            | "type"
             | "method"
             | "url"
             | "body"
@@ -430,6 +431,17 @@ unsafe fn dispatch_fastify_context(handle: i64, method: &str, args: &[f64]) -> f
             let value = args[1].to_bits() as i64;
             let result = crate::fastify::js_fastify_reply_header(handle, name, value);
             // Return the handle for chaining
+            f64::from_bits(0x7FFD_0000_0000_0000 | (result as u64 & 0x0000_FFFF_FFFF_FFFF))
+        }
+        // `reply.type(value)` — chainable alias for setting content-type.
+        // Without this arm, chained `.code().type().send()` returned
+        // TAG_UNDEFINED for `.type()` and the next chain step failed with
+        // `(number).send is not a function` (#1048). The chain takes this
+        // path (rather than NATIVE_MODULE_TABLE static dispatch) because
+        // the HIR loses the static type after the first call in the chain.
+        "type" if !args.is_empty() => {
+            let value = args[0].to_bits() as i64;
+            let result = crate::fastify::js_fastify_reply_type(handle, value);
             f64::from_bits(0x7FFD_0000_0000_0000 | (result as u64 & 0x0000_FFFF_FFFF_FFFF))
         }
         // Request methods

--- a/crates/perry-stdlib/src/fastify/context.rs
+++ b/crates/perry-stdlib/src/fastify/context.rs
@@ -436,6 +436,27 @@ pub unsafe extern "C" fn js_fastify_reply_header(
     ctx_handle
 }
 
+/// `reply.type(value)` — Fastify alias for `reply.header("content-type", value)`.
+/// Chainable: returns the reply handle so `.type(...).send(...)` works.
+///
+/// Previously missing from the stdlib copy of fastify (#1048): user code using
+/// the bundled-fastify path failed at link time with
+/// `Undefined symbols: _js_fastify_reply_type` because only perry-ext-fastify
+/// shipped this symbol.
+#[no_mangle]
+pub unsafe extern "C" fn js_fastify_reply_type(ctx_handle: Handle, value: i64) -> Handle {
+    let value = match string_from_nanboxed(value) {
+        Some(v) => v,
+        None => return ctx_handle,
+    };
+
+    if let Some(ctx) = get_handle_mut::<FastifyContext>(ctx_handle) {
+        ctx.response_headers
+            .push(("content-type".to_string(), value));
+    }
+    ctx_handle
+}
+
 /// Send response (Fastify style)
 /// Returns true if sent, false otherwise
 #[no_mangle]


### PR DESCRIPTION
## Summary

Fixes #1048. Closes four interlocking root causes that together broke `reply.code().type().send()` chains and the standalone `reply.type(...)` link path.

1. **Missing stdlib FFI**: `js_fastify_reply_type` existed only in `perry-ext-fastify` — when the bundled-fastify stdlib path linked (no well-known flip), the binary errored with `Undefined symbols: _js_fastify_reply_type`. Added the symbol to `perry-stdlib/src/fastify/context.rs`.
2. **NATIVE_MODULE_TABLE return-type mismatch**: `reply.type` and `reply.header` were tagged `NR_F64` but the Rust impls return `Handle` (i64). The ABI mismatch made chained `.type(...).send(...)` read an uninitialized XMM0/D0 register as the receiver. Fixed to `NR_PTR`.
3. **HIR fluent-chain gap**: the chain detection at `lower/expr_call.rs` covered `big.js`/`decimal.js`/`commander` but not fastify Reply. So only the inner `.code(...)` lowered as a NativeMethodCall; `.type(...)`/`.send(...)` fell through to generic Call+PropertyGet → `js_native_call_method` → HANDLE_METHOD_DISPATCH, which has no fastify arm when the well-known flip strips `bundled-fastify`. Added Reply chainable methods so the full chain emits nested NativeMethodCalls.
4. **Handle-dispatch vocabulary**: for the no-flip path, `dispatch_fastify_context` already handled `send`/`status`/`code`/`header` but not `type`. Added the `"type"` arm + matching method-name gate.

## Test plan

- [x] Issue repro (chained) returns `{"ok":true}` 201 `application/json`
- [x] Issue repro (stepwise) returns `{"ok":true}` 201 `application/json`
- [x] `.code().send()` chain (incidentally fixed) returns the right body
- [x] `cargo test --release -p perry-hir -p perry-codegen -p perry-stdlib` — all pass