### PR TITLE
fix(security): #996 — ignore @perry-allow-dynamic inside node_modules

### DIFF
--- a/crates/perry-hir/src/ir.rs
+++ b/crates/perry-hir/src/ir.rs
@@ -79,11 +79,15 @@ thread_local! {
     /// #503: when true, HIR lowering refuses compile-time `obj[expr]()` /
     /// `obj[expr]` on known stdlib namespace receivers (`process`, `fs`,
     /// `crypto`, `child_process`, `net`, `os`, `path`, `http`, `https`,
-    /// `stream`, `url`, `util`, `buffer`, `events`, `dns`, `tls`,
-    /// `querystring`, `zlib`) unless the index is a string literal or
-    /// compile-time-foldable string. Catches the dispatch-by-string class
-    /// of supply-chain evasion. Set to false by `perry.allowDynamicStdlibDispatch: true`
-    /// or `PERRY_ALLOW_DYNAMIC_STDLIB=1`.
+    /// `http2`, `stream`, `url`, `util`, `events`, `dns`, `tls`,
+    /// `querystring`, `zlib`, `async_hooks`, `readline`, `string_decoder`,
+    /// `tty`, `worker_threads`) unless the index is a string literal or
+    /// compile-time-foldable string. (`buffer` is intentionally excluded —
+    /// `Buffer` is a constructor, not a namespace object.) Catches the
+    /// dispatch-by-string class of supply-chain evasion. The canonical
+    /// list lives in `lower/expr_member.rs::STDLIB_NAMESPACE_NAMES`. Set
+    /// to false by `perry.allowDynamicStdlibDispatch: true` or
+    /// `PERRY_ALLOW_DYNAMIC_STDLIB=1`.
     static REFUSE_DYNAMIC_STDLIB_DISPATCH: std::cell::Cell<bool> = const { std::cell::Cell::new(true) };
 
     /// #503: per-thread set of npm package names that opted out of the

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -833,8 +833,14 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                         let pkg_allowed = pkg
                             .map(crate::ir::dynamic_stdlib_allowed_for_package)
                             .unwrap_or(false);
-                        let site_allowed =
-                            crate::ir::current_module_has_allow_dynamic_at(member.span.lo.0);
+                        // #996: `// @perry-allow-dynamic` is host-code only.
+                        // A malicious npm package can write the annotation next
+                        // to its own call to defeat the refusal — closing the
+                        // hole means dependencies must be opted in by the host
+                        // via `perry.allowDynamicStdlibDispatch` (the
+                        // `pkg_allowed` branch above), never by themselves.
+                        let site_allowed = pkg.is_none()
+                            && crate::ir::current_module_has_allow_dynamic_at(member.span.lo.0);
                         if !pkg_allowed && !site_allowed {
                             let pkg_label = pkg
                                 .map(|p| format!(" (in package `{}`)", p))

--- a/crates/perry-hir/tests/dynamic_stdlib_dispatch.rs
+++ b/crates/perry-hir/tests/dynamic_stdlib_dispatch.rs
@@ -167,6 +167,30 @@ fn global_disable_opts_out() {
 }
 
 #[test]
+fn site_annotation_ignored_inside_node_modules() {
+    // #996 — a malicious dependency must not be able to grant itself
+    // dynamic-dispatch permission by sitting a `// @perry-allow-dynamic`
+    // next to its own call. Only the host (paths outside `node_modules/`)
+    // may use the annotation; deps opt in via the host's
+    // `perry.allowDynamicStdlibDispatch` list (or the global flag).
+    let src = r#"
+        const k: string = "exit";
+        // @perry-allow-dynamic
+        // @ts-ignore
+        (process as any)[k](0);
+    "#;
+    let err = try_lower(src, "/repo/node_modules/evil/index.ts")
+        .expect_err("annotation in node_modules must not opt out");
+    assert!(
+        err.contains("dynamic dispatch on stdlib namespace `process`"),
+        "unexpected error: {err}"
+    );
+    // Host-code regression guard — same annotation in a host file must still pass.
+    let host_outcome = try_lower(src, "/repo/src/main.ts");
+    host_outcome.expect("annotation in host code must still opt out");
+}
+
+#[test]
 fn package_name_extraction() {
     use perry_hir::package_name_for_source_path;
     assert_eq!(

--- a/docs/src/cli/dynamic-dispatch.md
+++ b/docs/src/cli/dynamic-dispatch.md
@@ -52,10 +52,10 @@ process.exit(0);                // ✓
 fs.readFileSync("/tmp/x");       // ✓
 ```
 
-### 2. `// @perry-allow-dynamic` annotation
+### 2. `// @perry-allow-dynamic` annotation (host code only)
 
-For legitimate one-off dispatch, drop a line comment on or immediately
-above the offending site:
+For legitimate one-off dispatch in your own code, drop a line comment
+on or immediately above the offending site:
 
 ```typescript,no-test
 const k = pickHandler();
@@ -65,6 +65,13 @@ const k = pickHandler();
 
 Contiguous comment lines above the call also count, so the annotation
 can sit alongside an `// @ts-ignore` or similar.
+
+The annotation is honored **only in host source files** (anything not
+under `node_modules/`). A dependency cannot grant itself the opt-out by
+writing `// @perry-allow-dynamic` next to its own call — that would
+defeat the supply-chain defense the check exists for. Dependencies opt
+in via the host's per-package allow list (below) or the global flag.
+Tracked in [#996](https://github.com/PerryTS/perry/issues/996).
 
 ### 3. Per-package allow list in `package.json`
 


### PR DESCRIPTION
## Summary

Fixes #996. The `// @perry-allow-dynamic` site annotation was honored regardless of source path, so a malicious dep could grant itself the opt-out by writing the annotation next to its own call — defeating the supply-chain defense from #503/#941.

Now: the annotation is honored **only in host source files** (paths where `package_name_for_source_path` returns `None`). Dependencies opt in via the host's per-package allow-list (`perry.allowDynamicStdlibDispatch`) or the global flag — both host-controlled.

## Changes

- `crates/perry-hir/src/lower/expr_member.rs` — gate `site_allowed` on `pkg.is_none()`.
- `crates/perry-hir/tests/dynamic_stdlib_dispatch.rs` — new `site_annotation_ignored_inside_node_modules` test with host-code counter-assertion.
- `crates/perry-hir/src/ir.rs` — fix doc drift in `REFUSE_DYNAMIC_STDLIB_DISPATCH` docstring (added `http2`, `async_hooks`, `readline`, `string_decoder`, `tty`, `worker_threads`; removed `buffer`; point at canonical list in `STDLIB_NAMESPACE_NAMES`).
- `docs/src/cli/dynamic-dispatch.md` — annotation section now states the opt-out is host-code only.

## Test plan

- [x] `cargo test --release -p perry-hir --test dynamic_stdlib_dispatch` — all 12 tests pass (including the new one)
- [x] Acceptance: annotation in node_modules file → fails compilation
- [x] Acceptance: same annotation in host code → still passes (regression guard)