### PR TITLE
fix(security): #998 — Apple bundle-ID fallback routed through sanitizer

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -244,9 +244,10 @@ fn read_app_metadata(
             // argv. The input file stem is attacker-influenceable
             // (tooling-chosen paths), so route it through the shared
             // sanitizer before splicing into the reverse-DNS string.
+            // The helper is also used by every other Apple-platform
+            // fallback site (#998) so generated bundle IDs agree.
             let raw = input.file_stem().and_then(|s| s.to_str()).unwrap_or("app");
-            let stem = crate::commands::sanitize::sanitize_for_bundle_id_component(raw);
-            format!("com.perry.{stem}")
+            crate::commands::sanitize::default_perry_bundle_id(raw)
         });
 
     metadata
@@ -7056,7 +7057,14 @@ pub fn run_with_parse_cache(
                     None
                 })()
             })
-            .unwrap_or_else(|| format!("com.perry.{}", exe_stem));
+            .unwrap_or_else(|| {
+                // #998: shared helper so iOS bundle IDs match the macOS
+                // path (sanitized + lowercase-canonical). `exe_stem` is
+                // already transitively safe (sourced from the upstream
+                // sanitized `stem`); the helper still calls the
+                // sanitizer for the lowercase mapping.
+                crate::commands::sanitize::default_perry_bundle_id(exe_stem)
+            });
         result_bundle_id = Some(bundle_id.clone());
         result_app_dir = Some(app_dir.clone());
 
@@ -7691,7 +7699,7 @@ pub fn run_with_parse_cache(
         let bundle_id = lookup_bundle_id_from_toml(&args.input, "visionos")
             .or_else(|| lookup_bundle_id_from_toml(&args.input, "app"))
             .or_else(|| lookup_bundle_id_from_toml(&args.input, "ios"))
-            .unwrap_or_else(|| format!("com.perry.{}", exe_stem));
+            .unwrap_or_else(|| crate::commands::sanitize::default_perry_bundle_id(exe_stem));
         result_bundle_id = Some(bundle_id.clone());
         result_app_dir = Some(app_dir.clone());
 
@@ -7966,7 +7974,7 @@ pub fn run_with_parse_cache(
             .unwrap_or(stem);
         let bundle_id = lookup_bundle_id_from_toml(&args.input, "watchos")
             .or_else(|| lookup_bundle_id_from_toml(&args.input, "app"))
-            .unwrap_or_else(|| format!("com.perry.{}", exe_stem));
+            .unwrap_or_else(|| crate::commands::sanitize::default_perry_bundle_id(exe_stem));
         result_bundle_id = Some(bundle_id.clone());
         result_app_dir = Some(app_dir.clone());
 
@@ -8083,7 +8091,7 @@ pub fn run_with_parse_cache(
             .unwrap_or(stem);
         let bundle_id = lookup_bundle_id_from_toml(&args.input, "tvos")
             .or_else(|| lookup_bundle_id_from_toml(&args.input, "app"))
-            .unwrap_or_else(|| format!("com.perry.{}", exe_stem));
+            .unwrap_or_else(|| crate::commands::sanitize::default_perry_bundle_id(exe_stem));
         result_bundle_id = Some(bundle_id.clone());
         result_app_dir = Some(app_dir.clone());
 

--- a/crates/perry/src/commands/sanitize.rs
+++ b/crates/perry/src/commands/sanitize.rs
@@ -137,6 +137,17 @@ pub fn sanitize_for_bundle_id_component(raw: &str) -> String {
     out
 }
 
+/// Build the default `com.perry.<stem>` bundle ID for an executable
+/// stem when no explicit bundle ID has been configured. Shared by every
+/// Apple platform (macOS, iOS, visionOS, watchOS, tvOS) so the generated
+/// fallback agrees byte-for-byte across targets — provisioning profiles
+/// that round-trip a binary between platforms can rely on a single
+/// canonical form. #998.
+pub fn default_perry_bundle_id(exe_stem: &str) -> String {
+    let stem = sanitize_for_bundle_id_component(exe_stem);
+    format!("com.perry.{stem}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -268,6 +279,44 @@ mod tests {
     fn bundle_id_component_lowercases() {
         assert_eq!(sanitize_for_bundle_id_component("@Foo/Bar"), "foo-bar");
         assert_eq!(sanitize_for_bundle_id_component("MyApp"), "myapp");
+    }
+
+    #[test]
+    fn default_perry_bundle_id_is_sanitized_lowercase() {
+        // #998: every Apple-platform fallback (macOS/iOS/visionOS/
+        // watchOS/tvOS) must produce the same byte-for-byte form so a
+        // binary round-tripped between targets keeps a single canonical
+        // bundle ID. The shared helper enforces it.
+        assert_eq!(default_perry_bundle_id("MyApp"), "com.perry.myapp");
+        assert_eq!(default_perry_bundle_id("@scope/pkg"), "com.perry.scope-pkg");
+        assert_eq!(default_perry_bundle_id("foo bar"), "com.perry.foo_bar");
+    }
+
+    #[test]
+    fn compile_rs_uses_shared_helper_for_all_fallbacks() {
+        // #998 grep-audit: ensure no Apple-platform site builds the
+        // bundle-ID inline (which would skip the sanitizer). Every
+        // `com.perry.<stem>` derivation must go through
+        // `default_perry_bundle_id`.
+        let src = include_str!("compile.rs");
+        // The only places `com.perry.` may appear are doc/comment text;
+        // there must be no `format!("com.perry.{...", ...)` invocations
+        // (those are the unsanitized inline forms).
+        for line in src.lines() {
+            // Be conservative — skip comments outright.
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") || trimmed.starts_with("///") {
+                continue;
+            }
+            assert!(
+                !line.contains("format!(\"com.perry."),
+                "compile.rs has an inline `format!(\"com.perry.…\")` call. \
+                 Use `crate::commands::sanitize::default_perry_bundle_id` \
+                 instead so the bundle-ID fallback stays consistent across \
+                 Apple platforms (#998). Offending line:\n  {}",
+                line
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #998. Hoisted the `format!("com.perry.{stem}")` derivation into a shared `sanitize::default_perry_bundle_id` helper and routed all five Apple-platform sites (macOS + iOS + visionOS + watchOS + tvOS) through it.

Without this, the same input file `MyApp.ts` produced `com.perry.myapp` on macOS but `com.perry.MyApp` on the other Apple platforms — provisioning profiles generated for one target wouldn't match a binary built for another. Not a code-injection gap (`exe_stem` is transitively safe upstream), just a consistency bug, but a real one for anyone moving a binary across Apple targets.

## Changes

- `crates/perry/src/commands/sanitize.rs` — new `default_perry_bundle_id(exe_stem)` helper.
- `crates/perry/src/commands/compile.rs` — five `unwrap_or_else(…)` arms now call the helper.
- Two new tests in `sanitize.rs`:
  - unit test for the helper's lowercase + char-class behavior
  - grep audit that scans `compile.rs` for any inline `format!("com.perry.…")` calls (fails the suite if any reappear in future)

## Test plan

- [x] `cargo test --release -p perry --bin perry commands::sanitize` — all 15 tests pass
- [x] Audit test fails as expected if the inline pattern is reintroduced (verified locally)