### PR TITLE
fix(security): #999 — validate explicit bundle IDs at read time

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -195,10 +195,17 @@ fn package_bundle_id_from_input(input: &Path) -> Option<String> {
     loop {
         let pkg = dir.join("package.json");
         if pkg.exists() {
-            let data = fs::read_to_string(pkg).ok()?;
+            let data = fs::read_to_string(&pkg).ok()?;
             let json: serde_json::Value = serde_json::from_str(&data).ok()?;
             if let Some(bundle_id) = json.get("bundleId").and_then(|v| v.as_str()) {
-                return Some(bundle_id.to_string());
+                // #999: explicit `bundleId` was previously passed straight to
+                // codesign argv; reject obviously-hostile values at read time
+                // with a clear file-path diagnostic instead of silently letting
+                // them through.
+                let label = format!("package.json `bundleId` at {}", pkg.display());
+                return Some(crate::commands::sanitize::validate_bundle_id_or_exit(
+                    bundle_id, &label,
+                ));
             }
         }
         if !dir.pop() {
@@ -225,10 +232,14 @@ fn read_app_metadata(
     }
 
     metadata.bundle_id = cli_bundle_id
-        .map(str::to_string)
+        .map(|raw| {
+            // #999: CLI `--app-bundle-id` flag goes straight to codesign argv;
+            // validate before accepting it.
+            crate::commands::sanitize::validate_bundle_id_or_exit(raw, "CLI --app-bundle-id")
+        })
         .or_else(|| {
             let doc = perry_toml?;
-            target_bundle_section(target)
+            let raw = target_bundle_section(target)
                 .and_then(|section| toml_string(doc, section, "bundle_id"))
                 .or_else(|| toml_string(doc, "app", "bundle_id"))
                 .or_else(|| toml_string(doc, "project", "bundle_id"))
@@ -236,7 +247,15 @@ fn read_app_metadata(
                     doc.get("bundle_id")
                         .and_then(|v| v.as_str())
                         .map(str::to_string)
-                })
+                })?;
+            // #999: perry.toml is host-trusted in normal use, but the threat
+            // model in sanitize.rs explicitly lists it as attacker-influenceable
+            // (a hostile dep dropping perry.toml in a project root). Validate
+            // before letting it reach codesign.
+            Some(crate::commands::sanitize::validate_bundle_id_or_exit(
+                &raw,
+                "perry.toml `bundle_id`",
+            ))
         })
         .or_else(|| package_bundle_id_from_input(input))
         .unwrap_or_else(|| {
@@ -7017,6 +7036,13 @@ pub fn run_with_parse_cache(
         let bundle_id = args
             .app_bundle_id
             .clone()
+            .map(|raw| {
+                // #999: CLI override goes straight to codesign argv.
+                crate::commands::sanitize::validate_bundle_id_or_exit(
+                    &raw,
+                    "CLI --app-bundle-id",
+                )
+            })
             .or_else(|| {
                 (|| -> Option<String> {
                     let mut dir = args.input.canonicalize().ok()?;
@@ -7037,8 +7063,17 @@ pub fn run_with_parse_cache(
                                         .or_else(|| doc.get("bundle_id"))
                                         .and_then(|v| v.as_str())
                                         .map(|s| s.to_string());
-                                    if toml_bid.is_some() {
-                                        return toml_bid;
+                                    if let Some(raw) = toml_bid {
+                                        // #999: validate before letting toml-supplied IDs reach codesign.
+                                        let label = format!(
+                                            "perry.toml bundle_id at {}",
+                                            toml_path.display()
+                                        );
+                                        return Some(
+                                            crate::commands::sanitize::validate_bundle_id_or_exit(
+                                                &raw, &label,
+                                            ),
+                                        );
                                     }
                                 }
                             }
@@ -7046,12 +7081,22 @@ pub fn run_with_parse_cache(
                         // Then check package.json
                         let pkg = dir.join("package.json");
                         if pkg.exists() {
-                            let data = fs::read_to_string(pkg).ok()?;
+                            let data = fs::read_to_string(&pkg).ok()?;
                             let idx = data.find("\"bundleId\"")?;
                             let colon = data[idx..].find(':')?;
                             let q1 = data[idx + colon..].find('"')? + idx + colon + 1;
                             let q2 = data[q1..].find('"')? + q1;
-                            return Some(data[q1..q2].to_string());
+                            // #999: same as the toml path above — validate
+                            // before this raw byte-sliced string reaches
+                            // codesign argv.
+                            let raw = &data[q1..q2];
+                            let label = format!(
+                                "package.json `bundleId` at {}",
+                                pkg.display()
+                            );
+                            return Some(crate::commands::sanitize::validate_bundle_id_or_exit(
+                                raw, &label,
+                            ));
                         }
                     }
                     None

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -7038,10 +7038,7 @@ pub fn run_with_parse_cache(
             .clone()
             .map(|raw| {
                 // #999: CLI override goes straight to codesign argv.
-                crate::commands::sanitize::validate_bundle_id_or_exit(
-                    &raw,
-                    "CLI --app-bundle-id",
-                )
+                crate::commands::sanitize::validate_bundle_id_or_exit(&raw, "CLI --app-bundle-id")
             })
             .or_else(|| {
                 (|| -> Option<String> {
@@ -7090,10 +7087,7 @@ pub fn run_with_parse_cache(
                             // before this raw byte-sliced string reaches
                             // codesign argv.
                             let raw = &data[q1..q2];
-                            let label = format!(
-                                "package.json `bundleId` at {}",
-                                pkg.display()
-                            );
+                            let label = format!("package.json `bundleId` at {}", pkg.display());
                             return Some(crate::commands::sanitize::validate_bundle_id_or_exit(
                                 raw, &label,
                             ));

--- a/crates/perry/src/commands/compile/targets.rs
+++ b/crates/perry/src/commands/compile/targets.rs
@@ -728,8 +728,17 @@ pub(super) fn lookup_bundle_id_from_toml(input: &std::path::Path, section: &str)
                 .or_else(|| doc.get("bundle_id"))
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
-            if bid.is_some() {
-                return bid;
+            if let Some(raw) = bid {
+                // #999: validate before letting an explicit toml-supplied
+                // bundle ID reach codesign argv.
+                let label = format!(
+                    "perry.toml [{}].bundle_id at {}",
+                    section,
+                    toml_path.display()
+                );
+                return Some(crate::commands::sanitize::validate_bundle_id_or_exit(
+                    &raw, &label,
+                ));
             }
         }
     }

--- a/crates/perry/src/commands/run.rs
+++ b/crates/perry/src/commands/run.rs
@@ -1481,7 +1481,12 @@ fn read_app_metadata(project_root: &Path, input: &Path) -> (String, String) {
                 .or_else(|| t.get("bundle_id"))
         })
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+        .map(|s| {
+            // #999: this string flows into codesign argv when `perry run`
+            // re-signs the iOS bundle. Validate before letting it through.
+            let label = format!("perry.toml bundle_id at {}", toml_path.display());
+            super::sanitize::validate_bundle_id_or_exit(s, &label)
+        });
 
     // Then check package.json
     let pkg_path = project_root.join("package.json");
@@ -1502,7 +1507,12 @@ fn read_app_metadata(project_root: &Path, input: &Path) -> (String, String) {
                 .or_else(|| p.get("perry").and_then(|pp| pp.get("bundleId")))
         })
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+        .map(|s| {
+            // #999: validate before letting an explicit package.json
+            // bundle ID reach codesign argv.
+            let label = format!("package.json `bundleId` at {}", pkg_path.display());
+            super::sanitize::validate_bundle_id_or_exit(s, &label)
+        });
 
     let raw_name = toml_name.or(pkg_name).unwrap_or_else(|| {
         input

--- a/crates/perry/src/commands/sanitize.rs
+++ b/crates/perry/src/commands/sanitize.rs
@@ -426,11 +426,11 @@ mod tests {
             "",
             "foo/bar",
             "foo bar",
-            "ｐerry",         // full-width 'p' lookalike
+            "ｐerry",           // full-width 'p' lookalike
             "good\u{202E}evil", // RTL bidi override
         ] {
-            let err = validate_bundle_id(evil, "test source")
-                .unwrap_err_or_else_panic_with_label(evil);
+            let err =
+                validate_bundle_id(evil, "test source").unwrap_err_or_else_panic_with_label(evil);
             assert!(
                 err.contains("test source"),
                 "diagnostic should name the source for {evil:?}: {err}"
@@ -458,7 +458,10 @@ mod tests {
         assert!(err.contains("`;`"), "should call out `;`: {err}");
         assert!(err.contains("`|`"), "should call out `|`: {err}");
         assert!(err.contains("package.json"), "should name source: {err}");
-        assert!(err.contains("[A-Za-z0-9._-]"), "should state allowed class: {err}");
+        assert!(
+            err.contains("[A-Za-z0-9._-]"),
+            "should state allowed class: {err}"
+        );
     }
 
     #[test]

--- a/crates/perry/src/commands/sanitize.rs
+++ b/crates/perry/src/commands/sanitize.rs
@@ -148,6 +148,77 @@ pub fn default_perry_bundle_id(exe_stem: &str) -> String {
     format!("com.perry.{stem}")
 }
 
+/// Validate a user-supplied full bundle ID (`com.example.app` shape)
+/// before letting it reach `codesign --sign` or `productbuild` argv.
+///
+/// Reverse-DNS bundle IDs in practice are `[A-Za-z0-9._-]+`. We reject
+/// anything outside that class, plus the empty string and lone `.` /
+/// `..`, with a diagnostic that names the source and the offending
+/// character(s). The caller is expected to surface the error to the
+/// user — we do **not** silently rewrite explicit bundle IDs because
+/// the bundle ID is the round-trip identifier the user types into
+/// provisioning portals; mismatches between configured and built ID
+/// produce the worst kind of "why is my app installing under a
+/// different identifier" bug. #999.
+///
+/// On success returns the input string unchanged so the call-site can
+/// keep using it directly.
+pub fn validate_bundle_id(raw: &str, source_label: &str) -> Result<String, String> {
+    if raw.is_empty() {
+        return Err(format!(
+            "empty bundle ID from {source_label} — expected a reverse-DNS \
+             identifier like `com.example.app`"
+        ));
+    }
+    if raw == "." || raw == ".." {
+        return Err(format!(
+            "invalid bundle ID `{raw}` from {source_label} — `.` and `..` \
+             are reserved path components, not identifiers"
+        ));
+    }
+    // Collect every offending character (deduped, in input order) so the
+    // diagnostic surfaces the full problem set on the first build attempt
+    // instead of forcing the user to fix one char at a time.
+    let mut bad: Vec<char> = Vec::new();
+    for c in raw.chars() {
+        let ok = c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-';
+        if !ok && !bad.contains(&c) {
+            bad.push(c);
+        }
+    }
+    if !bad.is_empty() {
+        let listed = bad
+            .iter()
+            .map(|c| format!("`{}` (U+{:04X})", c, *c as u32))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(format!(
+            "invalid character(s) in bundle ID `{raw}` from {source_label}: {listed}. \
+             Allowed character set is `[A-Za-z0-9._-]`. Bundle IDs flow into \
+             `codesign --sign` and `productbuild` argv where shell metacharacters, \
+             whitespace, and path separators can flip the argument into a directive. \
+             #500/#944/#999."
+        ));
+    }
+    Ok(raw.to_string())
+}
+
+/// Convenience wrapper around [`validate_bundle_id`] for call sites
+/// that don't propagate `Result`: print the diagnostic on stderr and
+/// exit with status 1. Use this only where the surrounding signature
+/// can't carry a `Result` (e.g. `read_app_metadata` returning a
+/// tuple) — anywhere else, prefer the plain [`validate_bundle_id`]
+/// and propagate via `?`.
+pub fn validate_bundle_id_or_exit(raw: &str, source_label: &str) -> String {
+    match validate_bundle_id(raw, source_label) {
+        Ok(s) => s,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            std::process::exit(1);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,6 +388,77 @@ mod tests {
                 line
             );
         }
+    }
+
+    #[test]
+    fn validate_bundle_id_accepts_reverse_dns() {
+        // Standard reverse-DNS forms must pass — these are what real
+        // provisioning profiles look like.
+        for ok in [
+            "com.example.app",
+            "com.scope-with-dash.app_with_underscore",
+            "co.uk.example",
+            "123starts-with-digit",
+            "all-lowercase-no-dot",
+            "A.Mixed.Case.Id",
+        ] {
+            assert!(
+                validate_bundle_id(ok, "test").is_ok(),
+                "expected {ok:?} to pass validation"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_bundle_id_rejects_hostile_inputs() {
+        // #999: each of these is the kind of value a malicious
+        // `package.json`/`perry.toml` would inject to flip the argument
+        // when it lands in `codesign --sign` / `productbuild` argv.
+        for evil in [
+            "@evil/scope",
+            "a;rm -rf /",
+            "a|b",
+            "$PATH",
+            "a\nb",
+            "a\0b",
+            "..",
+            ".",
+            "",
+            "foo/bar",
+            "foo bar",
+            "ｐerry",         // full-width 'p' lookalike
+            "good\u{202E}evil", // RTL bidi override
+        ] {
+            let err = validate_bundle_id(evil, "test source")
+                .unwrap_err_or_else_panic_with_label(evil);
+            assert!(
+                err.contains("test source"),
+                "diagnostic should name the source for {evil:?}: {err}"
+            );
+        }
+    }
+
+    // Local helper — clearer panic message than plain expect_err.
+    trait UnwrapErrLabelled {
+        fn unwrap_err_or_else_panic_with_label(self, label: &str) -> String;
+    }
+    impl UnwrapErrLabelled for Result<String, String> {
+        fn unwrap_err_or_else_panic_with_label(self, label: &str) -> String {
+            match self {
+                Ok(_) => panic!("expected {label:?} to be rejected by validate_bundle_id"),
+                Err(e) => e,
+            }
+        }
+    }
+
+    #[test]
+    fn validate_bundle_id_diagnostic_lists_offending_chars() {
+        // #999 acceptance: clear diagnostic naming offending chars.
+        let err = validate_bundle_id("a;b|c", "package.json").expect_err("should fail");
+        assert!(err.contains("`;`"), "should call out `;`: {err}");
+        assert!(err.contains("`|`"), "should call out `|`: {err}");
+        assert!(err.contains("package.json"), "should name source: {err}");
+        assert!(err.contains("[A-Za-z0-9._-]"), "should state allowed class: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #999. The sanitiser landed in #944 was only applied to the fallback derivation path; explicit `bundleId`/`bundle_id` strings from `package.json`, `perry.toml`, and the `--app-bundle-id` CLI flag passed straight through to `codesign --sign` / `productbuild` argv. The threat model in `sanitize.rs` explicitly lists both file types as attacker-influenceable, so the explicit path needs the same defence.

Implements **option 2** from the issue (the reporter's preference): validate at read time, fail the build with a clear file-path + offending-char diagnostic, never silently rewrite. Silent rewrite would create the worst kind of "why is my app installing under a different identifier" bug because bundle IDs round-trip to provisioning portals.

## Changes

- `sanitize::validate_bundle_id(raw, source_label) -> Result<String, String>` — new validator. Accepts `[A-Za-z0-9._-]+`, rejects empty / `.` / `..`. Diagnostic lists every offending char (deduped, with codepoint), the source label, and the allowed character class.
- `sanitize::validate_bundle_id_or_exit` — convenience wrapper for read sites whose surrounding signature can't carry a `Result`.
- All explicit bundle-ID read sites routed through the validator:
  - `compile.rs::read_app_metadata` — CLI flag + perry.toml branches
  - `compile.rs::package_bundle_id_from_input`
  - `compile.rs` iOS inline reads (perry.toml + byte-sliced package.json)
  - `compile/targets.rs::lookup_bundle_id_from_toml` (visionOS / watchOS / tvOS)
  - `run.rs::read_app_metadata` (perry.toml + package.json)

## Test plan

- [x] `cargo test --release -p perry --bin perry commands::sanitize` — 16 pass (3 new)
- [x] `cargo test --release -p perry --bin perry commands::compile::app_metadata` — existing 3 pass (no regression on valid reverse-DNS inputs)
- [x] Acceptance: tests cover `@evil/scope`, shell metachars, control bytes, bidi marks, full-width lookalikes, `.`/`..`, empty, path separators
- [x] Acceptance: diagnostic names file path + offending chars (`validate_bundle_id_diagnostic_lists_offending_chars`)