### PR TITLE
refactor: #855 — Rust 2024 forward-compat (static_mut_refs + mach2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4153,6 +4153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
+
+[[package]]
 name = "macro_magic"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5665,6 +5671,7 @@ dependencies = [
  "itoa",
  "lazy_static",
  "libc",
+ "mach2",
  "mimalloc",
  "perry-dispatch",
  "rand 0.8.6",

--- a/crates/perry-runtime/Cargo.toml
+++ b/crates/perry-runtime/Cargo.toml
@@ -74,6 +74,13 @@ windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
 ] }
 
+# #855: libc::mach_host_self is deprecated; the mach2 crate is the
+# upstream-recommended replacement. Pulled in only where we actually
+# call host_statistics64 (`js_os_freemem` on macOS / iOS). Need 0.6+
+# because earlier mach2 releases didn't surface mach_host_self.
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+mach2 = "0.6"
+
 # build.rs auto-generates no-op `perry_ui_*` FFI stubs for the harmonyos
 # build (cfg(feature = "ohos-napi")) by reading the dispatch tables here.
 # See `build.rs` and issue #395 for the rationale.

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -791,9 +791,16 @@ fn transition_cache_insert(
 /// `scan_shape_cache_roots` — without this the mark phase would free
 /// cached target arrays that no live object currently holds directly,
 /// and the next cache-hit store would dereference freed memory.
+///
+/// #855: walk the static via `&raw const` + raw pointer indexing to
+/// avoid the `static_mut_refs` lint (hard error in Rust 2024). The
+/// cache is thread-local-by-discipline (perry user code is single-
+/// threaded), so the unsafe deref is sound.
 pub fn scan_transition_cache_roots(mark: &mut dyn FnMut(f64)) {
+    let base: *const TransitionEntry = (&raw const TRANSITION_CACHE_GLOBAL).cast();
     unsafe {
-        for entry in TRANSITION_CACHE_GLOBAL.iter() {
+        for i in 0..TRANSITION_CACHE_SIZE {
+            let entry = &*base.add(i);
             if entry.next_keys != 0 {
                 let jsval = JSValue::pointer(entry.next_keys as *const u8);
                 mark(f64::from_bits(jsval.bits()));

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -206,12 +206,17 @@ pub extern "C" fn js_os_totalmem() -> f64 {
 pub extern "C" fn js_os_freemem() -> f64 {
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     {
+        // #855: libc::mach_host_self is deprecated upstream — call
+        // `mach2::mach_init::mach_host_self()` instead. The rest of
+        // the host-statistics surface (host_statistics64,
+        // vm_statistics64, HOST_VM_INFO64) is still libc-provided
+        // because mach2 hasn't surfaced it yet (as of mach2 0.6).
         unsafe {
             let mut vm_info: libc::vm_statistics64 = std::mem::zeroed();
             let mut count = (std::mem::size_of::<libc::vm_statistics64>()
                 / std::mem::size_of::<libc::integer_t>()) as u32;
             let ret = libc::host_statistics64(
-                libc::mach_host_self(),
+                mach2::mach_init::mach_host_self(),
                 libc::HOST_VM_INFO64,
                 &mut vm_info as *mut _ as *mut _,
                 &mut count,

--- a/crates/perry-runtime/src/string.rs
+++ b/crates/perry-runtime/src/string.rs
@@ -2821,9 +2821,16 @@ unsafe fn concat_content_matches(
 }
 
 /// GC root scanner for the intern table.
+///
+/// #855: walk via `&raw const` + raw pointer indexing to avoid the
+/// `static_mut_refs` lint (hard error in Rust 2024). The intern table
+/// is thread-local-by-discipline (perry user code is single-threaded),
+/// so the unsafe deref is sound.
 pub fn scan_intern_table_roots(mark: &mut dyn FnMut(f64)) {
+    let base: *const InternEntry = (&raw const INTERN_TABLE).cast();
     unsafe {
-        for entry in INTERN_TABLE.iter() {
+        for i in 0..INTERN_TABLE_SIZE {
+            let entry = &*base.add(i);
             if entry.string_ptr != 0 {
                 let nanboxed =
                     0x7FFF_0000_0000_0000u64 | (entry.string_ptr as u64 & 0x0000_FFFF_FFFF_FFFFu64);


### PR DESCRIPTION
## Summary

Fixes #855. Three warnings that become hard errors in Rust 2024 or after upstream deprecation removal.

### `static_mut_refs` (2 sites)
`scan_transition_cache_roots` and `scan_intern_table_roots` previously iterated `STATIC_MUT.iter()` — exactly the `&[T]`-from-static-mut construct the lint targets. Followed the reporter's recommended option (b): `&raw const STATIC` cast to `*const EntryT` + bounded raw-pointer indexing through the table size constant. No locking on the hot path, no intermediate reference.

### `libc::mach_host_self` (1 site)
libc 0.2 marks `mach_host_self` deprecated and points at the mach2 crate. Added target-gated `mach2 = "0.6"` (only macOS/iOS; mach2 `compile_error!`s elsewhere) and switched the single call. The rest of the surface (`host_statistics64`, `vm_statistics64`, `HOST_VM_INFO64`) stays on libc — mach2 0.6 hasn't surfaced those yet.

## Test plan

- [x] `cargo build --release -p perry-runtime` — clean, no `static_mut_refs` / `mach_host_self` warnings
- [x] `cargo test --release -p perry-runtime --lib` — 264 pass