### PR TITLE
fix(wasm): #1049 instance 1 — wrapForI64 / wrapFfiForI64 must return BigInt

### DIFF
--- a/crates/perry-codegen-wasm/src/wasm_runtime.js
+++ b/crates/perry-codegen-wasm/src/wasm_runtime.js
@@ -1444,7 +1444,15 @@ function wrapForI64(fn) {
     const result = fn.apply(this, convertedArgs);
     if (typeof result === 'bigint') return result;
     if (typeof result === 'number') {
-      if (Number.isInteger(result) && Math.abs(result) < 2147483648) return result;
+      // #1049 instance 1: this wrapper exists because every callee here is
+      // imported from a WASM site declared `i64`. A plain Number return —
+      // even a small integer that JS would happily round-trip — throws
+      // `TypeError: Cannot convert X to a BigInt` at the import boundary.
+      // Coerce integers via `BigInt(n)` and non-integers (NaN-boxed f64
+      // payloads) via bit-reinterpret.
+      if (Number.isInteger(result) && Math.abs(result) < 2147483648) {
+        return BigInt(result);
+      }
       _f64[0] = result;
       return _u64[0];
     }
@@ -1467,7 +1475,17 @@ function wrapFfiForI64(fn) {
     const result = fn.apply(this, convertedArgs);
     if (typeof result === 'bigint') return result;
     if (typeof result === 'number') {
-      if (Number.isInteger(result) && Math.abs(result) < 2147483648) return result;
+      // #1049 instance 1: the WASM import side declares these as `i64`
+      // returns (handles, NaN-box bits, etc.). A plain Number return —
+      // even a small integer JS could round-trip — throws
+      // `TypeError: Cannot convert X to a BigInt` at the import
+      // boundary. Coerce integers via `BigInt(n)` and non-integers
+      // (NaN-boxed f64 payloads) via bit-reinterpret. The historic
+      // small-int passthrough was the root cause of `hone_editor_create`
+      // returning handle 1 as Number 1.
+      if (Number.isInteger(result) && Math.abs(result) < 2147483648) {
+        return BigInt(result);
+      }
       _f64[0] = result;
       return _u64[0];
     }


### PR DESCRIPTION
## Summary

Closes the first known instance from the #1049 tracking issue. Both `wrapForI64` and `wrapFfiForI64` special-cased small integer Number results and returned them unchanged. The wrappers exist precisely to bridge WASM `i64` imports, where modern engines reject a plain Number with `TypeError: Cannot convert X to a BigInt`.

User-visible symptom in @honeide/editor: `hone_editor_create` returned handle `1` as Number; the WASM caller threw on the i64 boundary and the editor never mounted. Workaround was `return BigInt(h) as any` at every FFI consumer.

Fix: coerce integer Numbers via `BigInt(n)` in both wrappers. Non-integer Numbers (NaN-boxed f64 payloads) still bit-reinterpret to BigInt via the existing `_u64[0]` round-trip. The block comment on `wrapForI64` already promised this behavior ("Number results are coerced back to BigInt for WASM i64 return") — code now agrees.

## Test plan

- [x] `cargo build --release -p perry-codegen-wasm` — clean
- [x] `cargo test --release -p perry-codegen-wasm` — no regressions (no JS-side tests exist for the runtime; verified by static review and tracking-issue's described symptom)

Instances 2 and 3 from #1049 (internal class-method dispatch + TreeSitter parse arg shuffle) are separate codegen sites and remain open.