### PR TITLE
fix(packaging): #872 — bundle Android cross-compile libs in WinGet zip

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -311,6 +311,49 @@ jobs:
         if: runner.os == 'Windows'
         run: cargo build --release --target ${{ matrix.target }} -p perry-ui-windows
 
+      # Closes #872: cross-compile the Android runtime libs on the Windows
+      # leg so the WinGet zip includes `libperry_runtime.a` /
+      # `libperry_stdlib.a` for `aarch64-linux-android`. Without these,
+      # `perry compile --target android` from a WinGet-installed perry
+      # bails at link time with "Could not find libperry_runtime.a".
+      # GitHub-hosted Windows runners pre-install the Android NDK at
+      # `%ANDROID_NDK_HOME%`; we point cargo at its `aarch64-linux-android-*`
+      # clang as the cross-linker.
+      - name: Install aarch64-linux-android Rust target (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: rustup target add aarch64-linux-android
+      - name: Build Android cross-compile libraries (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          # API level 24 matches every other Android leg we cross-build for
+          # elsewhere (perry-ui-android's build.rs assumes the same NDK
+          # surface).
+          ANDROID_API_LEVEL: "24"
+        run: |
+          if (-not $env:ANDROID_NDK_HOME) {
+            $env:ANDROID_NDK_HOME = $env:ANDROID_NDK_LATEST_HOME
+          }
+          if (-not $env:ANDROID_NDK_HOME) {
+            Write-Error "ANDROID_NDK_HOME not set on this Windows runner — needed for #872 android cross-build."
+            exit 1
+          }
+          $toolchain = Join-Path $env:ANDROID_NDK_HOME "toolchains/llvm/prebuilt/windows-x86_64/bin"
+          $linker = Join-Path $toolchain "aarch64-linux-android$($env:ANDROID_API_LEVEL)-clang.cmd"
+          if (-not (Test-Path $linker)) {
+            $linker = Join-Path $toolchain "aarch64-linux-android$($env:ANDROID_API_LEVEL)-clang.exe"
+          }
+          if (-not (Test-Path $linker)) {
+            Write-Error "Android NDK linker not found at $linker — NDK layout drifted; update the version-suffixed path."
+            exit 1
+          }
+          $env:CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER = $linker
+          $env:CC_aarch64_linux_android = $linker
+          $env:AR_aarch64_linux_android = Join-Path $toolchain "llvm-ar.exe"
+          cargo build --release --target aarch64-linux-android -p perry-runtime
+          cargo build --release --target aarch64-linux-android -p perry-stdlib
+
       - name: Package release archive (Unix)
         if: runner.os != 'Windows'
         run: |
@@ -407,6 +450,20 @@ jobs:
             $path = "target/${{ matrix.target }}/release/$lib"
             if (Test-Path $path) {
               Copy-Item $path staging/
+            }
+          }
+          # #872: stage the Android cross-compiled archives next to the
+          # Windows libs. perry's library_search.rs walks
+          # `<install-dir>/<triple>/release/<libname>.a` so we mirror that
+          # layout inside the zip — the `aarch64-linux-android/release/`
+          # subdir lives alongside `perry.exe`.
+          $androidLibDir = "staging/aarch64-linux-android/release"
+          New-Item -ItemType Directory -Force -Path $androidLibDir | Out-Null
+          $androidLibs = @("libperry_runtime.a", "libperry_stdlib.a")
+          foreach ($lib in $androidLibs) {
+            $src = "target/aarch64-linux-android/release/$lib"
+            if (Test-Path $src) {
+              Copy-Item $src $androidLibDir
             }
           }
           Compress-Archive -Path staging/* -DestinationPath "${{ matrix.artifact }}.zip"

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -728,6 +728,17 @@ pub(super) fn collect_library_candidates(name: &str, target: Option<&str>) -> Ve
         // Also check directories relative to the perry executable.
         if let Ok(exe) = std::env::current_exe() {
             if let Some(dir) = exe.parent() {
+                // #872: WinGet extracts the package zip into a single
+                // `PerryTS.Perry_<hash>` directory under
+                // `%LOCALAPPDATA%\Microsoft\WinGet\Packages\`. The
+                // package staging (release-packages.yml) writes Android
+                // cross-compile libs at `<root>/aarch64-linux-android/
+                // release/<name>` inside that same dir, so this lookup
+                // — `dir/<triple>/release/<name>` — must come BEFORE the
+                // sibling `dir.parent()` path below or the existing
+                // search would walk up and miss the staged libs.
+                candidates.push(dir.join(triple).join("release").join(name));
+                candidates.push(dir.join(triple).join("debug").join(name));
                 // Cross-compile targets are in ../../target/<triple>/release/ relative
                 // to the perry binary (which is in target/release/). Check this
                 // BEFORE the exe-dir bundled-install lookups below — in an


### PR DESCRIPTION
## Summary

Fixes #872. `perry compile --target android` from a WinGet-installed Perry failed with `Could not find libperry_runtime.a` because the release pipeline never cross-compiled the Android target on the Windows leg. Two parts:

### release-packages.yml (Windows leg)

After the per-host `Build UI library (Windows)` step:

1. `rustup target add aarch64-linux-android` on the Windows runner.
2. Resolve the NDK path from `ANDROID_NDK_HOME` (GitHub-hosted Windows runners pre-set this) and locate `aarch64-linux-android24-clang` inside `<ndk>/toolchains/llvm/prebuilt/windows-x86_64/bin/`. Fails the workflow with a clear error if the NDK layout drifts so future NDK rolls trip the build instead of silently shipping a broken zip.
3. `cargo build --release --target aarch64-linux-android` for `perry-runtime` and `perry-stdlib`.

The Windows packaging step now stages the produced archives at `staging/aarch64-linux-android/release/lib{perry_runtime,perry_stdlib}.a` so WinGet extracts them alongside `perry.exe` inside the package install dir.

### perry's library search

Pre-fix, `find_library_with_candidates` looked for cross-compile libs at `dir.parent()/<triple>/release/<name>` (a sibling of the install dir) but never inside the install dir itself. The WinGet zip can only write to its own package dir. Added `dir/<triple>/release/<name>` and `…/debug/…` candidates ordered BEFORE the `dir.parent()` lookups so the staged Android libs resolve cleanly.

## Test plan

- [x] `cargo build --release -p perry` — clean
- [x] `cargo test --release -p perry --bin perry commands::compile::library_search` — 10 pass
- [x] No regression of existing cross-compile candidate paths (the new lookups are additive; sibling paths remain in priority order after them)

Full validation requires a release-tag-triggered run of `Release Packages` followed by a WinGet install; not testable in PR CI.