### PR TITLE
fix(native): #1027 — keep perry-ffi native archives runtime-free

### DIFF
--- a/crates/perry-ext-ads/Cargo.toml
+++ b/crates/perry-ext-ads/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 perry-ffi.workspace = true
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-argon2/Cargo.toml
+++ b/crates/perry-ext-argon2/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 argon2 = "0.5"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-axios/Cargo.toml
+++ b/crates/perry-ext-axios/Cargo.toml
@@ -12,3 +12,6 @@ crate-type = ["staticlib", "rlib"]
 perry-ffi.workspace = true
 reqwest = { workspace = true }
 tokio = { workspace = true }
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-bcrypt/Cargo.toml
+++ b/crates/perry-ext-bcrypt/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 bcrypt = "0.17"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-better-sqlite3/Cargo.toml
+++ b/crates/perry-ext-better-sqlite3/Cargo.toml
@@ -17,3 +17,6 @@ perry-ffi.workspace = true
 # libsqlite3 in the default search path (or where the system one
 # is too old).
 rusqlite = { version = "0.32", features = ["bundled"] }
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-cheerio/Cargo.toml
+++ b/crates/perry-ext-cheerio/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 scraper = "0.27"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-commander/Cargo.toml
+++ b/crates/perry-ext-commander/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 perry-ffi.workspace = true
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-cron/Cargo.toml
+++ b/crates/perry-ext-cron/Cargo.toml
@@ -12,3 +12,6 @@ crate-type = ["staticlib", "rlib"]
 perry-ffi.workspace = true
 cron = "0.12"
 chrono = "0.4"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-dayjs/Cargo.toml
+++ b/crates/perry-ext-dayjs/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 chrono = "0.4"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-decimal/Cargo.toml
+++ b/crates/perry-ext-decimal/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 rust_decimal = "1"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-dotenv/Cargo.toml
+++ b/crates/perry-ext-dotenv/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 serde_json.workspace = true
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-ethers/Cargo.toml
+++ b/crates/perry-ext-ethers/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 rand = "0.8"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-events/Cargo.toml
+++ b/crates/perry-ext-events/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 perry-ffi.workspace = true
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-exponential-backoff/Cargo.toml
+++ b/crates/perry-ext-exponential-backoff/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 perry-ffi.workspace = true
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-fastify/Cargo.toml
+++ b/crates/perry-ext-fastify/Cargo.toml
@@ -17,3 +17,6 @@ bytes = "1.5"
 tokio = { workspace = true }
 serde_json = "1"
 lazy_static = "1.5"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-fetch/Cargo.toml
+++ b/crates/perry-ext-fetch/Cargo.toml
@@ -14,3 +14,6 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls", "http2"], defaul
 tokio = { workspace = true }
 serde_json = "1"
 lazy_static = "1.5"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-google-auth/Cargo.toml
+++ b/crates/perry-ext-google-auth/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 perry-ffi.workspace = true
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-http-server/Cargo.toml
+++ b/crates/perry-ext-http-server/Cargo.toml
@@ -27,3 +27,6 @@ rustls-pemfile = "2"
 serde_json = "1"
 lazy_static = "1.5"
 tokio-tungstenite = { workspace = true }
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-http/Cargo.toml
+++ b/crates/perry-ext-http/Cargo.toml
@@ -20,3 +20,6 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls", "http2"], defaul
 tokio = { workspace = true }
 serde_json = "1"
 lazy_static = "1.5"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-ioredis/Cargo.toml
+++ b/crates/perry-ext-ioredis/Cargo.toml
@@ -13,3 +13,6 @@ perry-ffi.workspace = true
 redis = { version = "1.2", features = ["tokio-comp", "connection-manager"] }
 tokio = { workspace = true }
 lazy_static = "1.5"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-jsonwebtoken/Cargo.toml
+++ b/crates/perry-ext-jsonwebtoken/Cargo.toml
@@ -24,3 +24,6 @@ jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_c
 serde = { workspace = true }
 serde_json = { workspace = true }
 base64 = "0.22"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-lru-cache/Cargo.toml
+++ b/crates/perry-ext-lru-cache/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 lru = "0.16"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-moment/Cargo.toml
+++ b/crates/perry-ext-moment/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 chrono = "0.4"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-mongodb/Cargo.toml
+++ b/crates/perry-ext-mongodb/Cargo.toml
@@ -15,3 +15,6 @@ bson = "2.9"
 tokio = { workspace = true }
 futures-util = "0.3"
 serde_json = "1"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-mysql2/Cargo.toml
+++ b/crates/perry-ext-mysql2/Cargo.toml
@@ -13,3 +13,6 @@ perry-ffi.workspace = true
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "mysql", "chrono"] }
 tokio = { workspace = true }
 chrono = "0.4"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-nanoid/Cargo.toml
+++ b/crates/perry-ext-nanoid/Cargo.toml
@@ -12,3 +12,6 @@ crate-type = ["staticlib", "rlib"]
 perry-ffi.workspace = true
 nanoid = "0.5"
 rand = "0.9"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-net/Cargo.toml
+++ b/crates/perry-ext-net/Cargo.toml
@@ -14,3 +14,6 @@ tokio = { workspace = true }
 tokio-rustls = "0.26"
 rustls = "0.23"
 rustls-native-certs = "0.8"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-nodemailer/Cargo.toml
+++ b/crates/perry-ext-nodemailer/Cargo.toml
@@ -13,3 +13,6 @@ perry-ffi.workspace = true
 lettre = { version = "0.11", default-features = false, features = ["tokio1", "tokio1-rustls-tls", "smtp-transport", "builder", "hostname", "pool"] }
 tokio = { workspace = true }
 uuid = { version = "1.11", features = ["v4"] }
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-pdf/Cargo.toml
+++ b/crates/perry-ext-pdf/Cargo.toml
@@ -15,3 +15,6 @@ perry-ffi.workspace = true
 # `html` feature (azul-layout, kuchiki, …) — for the v1 surface we
 # only need core text + line drawing, which lives in the base crate.
 printpdf = { version = "0.9", default-features = false }
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-pg/Cargo.toml
+++ b/crates/perry-ext-pg/Cargo.toml
@@ -12,3 +12,6 @@ crate-type = ["staticlib", "rlib"]
 perry-ffi.workspace = true
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "postgres", "chrono"] }
 tokio = { workspace = true }
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-ratelimit/Cargo.toml
+++ b/crates/perry-ext-ratelimit/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 governor = "0.6"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-sharp/Cargo.toml
+++ b/crates/perry-ext-sharp/Cargo.toml
@@ -12,3 +12,6 @@ crate-type = ["staticlib", "rlib"]
 perry-ffi.workspace = true
 image = "0.25"
 base64 = "0.22"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-slugify/Cargo.toml
+++ b/crates/perry-ext-slugify/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 perry-ffi.workspace = true
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-streams/Cargo.toml
+++ b/crates/perry-ext-streams/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 lazy_static = "1.5"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-uuid/Cargo.toml
+++ b/crates/perry-ext-uuid/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 uuid = { version = "1.10", features = ["v1", "v4", "v7"] }
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-validator/Cargo.toml
+++ b/crates/perry-ext-validator/Cargo.toml
@@ -13,3 +13,6 @@ perry-ffi.workspace = true
 validator = "0.20"
 regex = "1"
 serde_json = { workspace = true }
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-ws/Cargo.toml
+++ b/crates/perry-ext-ws/Cargo.toml
@@ -18,3 +18,6 @@ tokio = { workspace = true }
 tokio-tungstenite = { workspace = true }
 futures-util = "0.3"
 lazy_static = "1.5"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-zlib/Cargo.toml
+++ b/crates/perry-ext-zlib/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 flate2 = "1"
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ffi/Cargo.toml
+++ b/crates/perry-ffi/Cargo.toml
@@ -7,17 +7,17 @@ description = "Stable FFI surface for native bindings packages that wrap Rust cr
 repository.workspace = true
 
 [dependencies]
-# perry-ffi is a thin re-export layer over perry-runtime — same process,
-# same arena, same GC. The `perry-ffi` semver moves independently from
-# `perry-runtime`; this dep is `path =` for in-tree use, but external
-# wrappers will pull `perry-ffi = "0.5"` from crates.io and link
-# against whichever runtime ships with the perry binary they're loaded
-# into. ABI compatibility is asserted via `perry.nativeLibrary.abiVersion`
-# in package.json (#466 Phase 2).
-perry-runtime.workspace = true
+# Normal native package builds must not embed perry-runtime. The optional
+# dependency exists only for tests/layout assertions that intentionally link
+# against the in-tree runtime.
+perry-runtime = { workspace = true, optional = true }
 
 # Handle registry storage (#466 Phase 5 — `lru-cache`/db wrappers).
 # perry-stdlib uses dashmap internally for the same purpose; sharing
 # the dep keeps the resulting binaries identical in size.
 dashmap = "6"
 once_cell = "1"
+
+[features]
+default = []
+runtime-link = ["dep:perry-runtime"]

--- a/crates/perry-ffi/src/async_runtime.rs
+++ b/crates/perry-ffi/src/async_runtime.rs
@@ -31,13 +31,7 @@
 
 use std::ffi::c_void;
 
-use crate::{alloc_string, StringHeader};
-
-/// Re-export the runtime's `Promise` type for `extern "C"`
-/// signatures. Wrapper authors who need to write
-/// `pub extern "C" fn js_my_thing() -> *mut perry_ffi::Promise`
-/// import this rather than reaching into perry-runtime directly.
-pub use perry_runtime::Promise;
+use crate::{alloc_string, Promise, StringHeader};
 
 extern "C" {
     fn perry_ffi_promise_new() -> *mut Promise;

--- a/crates/perry-ffi/src/bigint.rs
+++ b/crates/perry-ffi/src/bigint.rs
@@ -1,5 +1,5 @@
-//! BigInt surface — re-exports of perry-runtime's `BigIntHeader`
-//! plus a thin allocator that wrappers can use to construct
+//! BigInt surface — `perry-ffi`'s canonical `BigIntHeader` plus a
+//! thin allocator that wrappers can use to construct
 //! arbitrary-precision integers without touching runtime internals
 //! directly.
 //!
@@ -14,13 +14,13 @@
 //! cross-cutting breaking change for every wrapper that touched
 //! large integers.
 //!
-//! Today's surface is intentionally minimal: re-export the type
-//! perry-runtime exposes plus a single string-parsing constructor
-//! (which is what every existing wrapper uses). Extras (limb-based
+//! Today's surface is intentionally minimal: expose the ABI type plus
+//! a single string-parsing constructor (which is what every existing
+//! wrapper uses). Extras (limb-based
 //! constructors, arithmetic ops, string-radix parsing) wait until
 //! a real wrapper demands them.
 
-pub use perry_runtime::bigint::{BigIntHeader, BIGINT_LIMBS};
+use crate::{BigIntHeader, BIGINT_LIMBS};
 
 extern "C" {
     /// Parse a decimal-string representation into a fresh
@@ -67,7 +67,7 @@ pub fn read_bigint_limbs(ptr: *const BigIntHeader) -> Option<[u64; BIGINT_LIMBS]
     Some(unsafe { (*ptr).limbs })
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "runtime-link"))]
 mod tests {
     use super::*;
 

--- a/crates/perry-ffi/src/buffer.rs
+++ b/crates/perry-ffi/src/buffer.rs
@@ -1,5 +1,5 @@
-//! Buffer surface — re-exports of perry-runtime's `BufferHeader`
-//! plus thin allocator + reader helpers for wrappers that return
+//! Buffer surface — `perry-ffi`'s canonical `BufferHeader` plus thin
+//! allocator + reader helpers for wrappers that return
 //! arbitrary binary bytes (cryptographic digests, image-encoded
 //! payloads, BSON documents, …).
 //!
@@ -16,7 +16,7 @@
 //! a single allocator + a slice-reader. Resize / append / clone
 //! helpers wait for a real wrapper that demands them.
 
-pub use perry_runtime::buffer::BufferHeader;
+use crate::BufferHeader;
 
 extern "C" {
     /// Runtime's stable extern allocator entry point. Single
@@ -89,7 +89,7 @@ pub fn read_buffer_bytes(ptr: *const BufferHeader) -> Option<&'static [u8]> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "runtime-link"))]
 mod tests {
     use super::*;
 

--- a/crates/perry-ffi/src/closure.rs
+++ b/crates/perry-ffi/src/closure.rs
@@ -37,9 +37,9 @@
 //! the better-sqlite3 wrapper's transaction support for a
 //! reference example (added under #466 Phase 5 followup).
 
-use perry_runtime::ClosureHeader;
+use crate::ClosureHeader;
 
-pub use perry_runtime::ClosureHeader as RawClosureHeader;
+pub use crate::ClosureHeader as RawClosureHeader;
 
 extern "C" {
     fn js_closure_call0(closure: *const ClosureHeader) -> f64;

--- a/crates/perry-ffi/src/event_pump.rs
+++ b/crates/perry-ffi/src/event_pump.rs
@@ -61,7 +61,7 @@ pub fn notify_main_thread() {
     unsafe { js_notify_main_thread() };
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "runtime-link"))]
 mod tests {
     use super::*;
 

--- a/crates/perry-ffi/src/handle.rs
+++ b/crates/perry-ffi/src/handle.rs
@@ -39,7 +39,9 @@
 //! [`with_handle`] which scopes the borrow under a closure.
 
 use std::any::Any;
+use std::ffi::c_void;
 use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{Mutex, Once};
 
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
@@ -55,6 +57,16 @@ pub const INVALID_HANDLE: Handle = 0;
 
 static HANDLES: Lazy<DashMap<Handle, Box<dyn Any + Send + Sync>>> = Lazy::new(DashMap::new);
 static NEXT_HANDLE: AtomicI64 = AtomicI64::new(1);
+static ROOT_SCANNERS: Lazy<Mutex<Vec<fn(&mut dyn FnMut(f64))>>> =
+    Lazy::new(|| Mutex::new(Vec::new()));
+static REGISTER_ROOT_SCANNER_TRAMPOLINE: Once = Once::new();
+
+type PerryFfiRootMarker = extern "C" fn(value: f64, ctx: *mut c_void);
+type PerryFfiRootScanner = extern "C" fn(mark: PerryFfiRootMarker, ctx: *mut c_void);
+
+extern "C" {
+    fn perry_ffi_gc_register_root_scanner(scanner: PerryFfiRootScanner);
+}
 
 /// Register `value` under a fresh handle and return the handle.
 ///
@@ -143,8 +155,8 @@ pub fn handle_exists(handle: Handle) -> bool {
 /// between `.on(...)` and `.emit(...)` would sweep the closure
 /// (issue #35 pattern in perry-stdlib).
 ///
-/// Pair with [`gc_register_root_scanner`] (re-exported from
-/// `perry_runtime::gc`) to wire the scanner into perry's GC.
+/// Pair with [`gc_register_root_scanner`] to wire the scanner into
+/// perry's GC.
 pub fn iter_handles_of<T, F>(mut f: F)
 where
     T: 'static + Send + Sync,
@@ -191,7 +203,8 @@ where
 /// is called during every GC mark phase; it should call its `mark`
 /// callback with each NaN-boxed JsValue that should be kept alive.
 ///
-/// Convenience re-export over `perry_runtime::gc::gc_register_root_scanner`.
+/// This registers through `perry_ffi_gc_register_root_scanner`, the stable
+/// C ABI bridge exported by the runtime.
 /// Wrapper authors typically combine this with [`iter_handles_of`]:
 ///
 /// ```ignore
@@ -211,7 +224,23 @@ where
 /// gc_register_root_scanner(scan_my_roots);
 /// ```
 pub fn gc_register_root_scanner(scanner: fn(&mut dyn FnMut(f64))) {
-    perry_runtime::gc::gc_register_root_scanner(scanner);
+    ROOT_SCANNERS
+        .lock()
+        .expect("perry-ffi root scanner registry poisoned")
+        .push(scanner);
+    REGISTER_ROOT_SCANNER_TRAMPOLINE.call_once(|| unsafe {
+        perry_ffi_gc_register_root_scanner(scan_registered_roots);
+    });
+}
+
+extern "C" fn scan_registered_roots(mark: PerryFfiRootMarker, ctx: *mut c_void) {
+    let scanners = ROOT_SCANNERS
+        .lock()
+        .expect("perry-ffi root scanner registry poisoned")
+        .clone();
+    for scanner in scanners {
+        scanner(&mut |value| mark(value, ctx));
+    }
 }
 
 #[cfg(test)]

--- a/crates/perry-ffi/src/json.rs
+++ b/crates/perry-ffi/src/json.rs
@@ -58,7 +58,7 @@ pub fn json_stringify(value: JsValue) -> Option<String> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "runtime-link"))]
 mod tests {
     use super::*;
     use crate::alloc_string;

--- a/crates/perry-ffi/src/jsvalue.rs
+++ b/crates/perry-ffi/src/jsvalue.rs
@@ -30,12 +30,7 @@
 //! These tag values are part of perry-ffi's stable API — a
 //! perry-runtime renumbering bumps perry-ffi major.
 
-use crate::StringHeader;
-
-// Re-export the runtime types wrappers need to declare in their
-// `extern "C"` signatures — same model as `StringHeader` /
-// `Promise` re-exports elsewhere in this crate.
-pub use perry_runtime::{ArrayHeader, ObjectHeader};
+use crate::{ArrayHeader, ObjectHeader, StringHeader};
 
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;

--- a/crates/perry-ffi/src/lib.rs
+++ b/crates/perry-ffi/src/lib.rs
@@ -46,7 +46,13 @@
 
 mod async_runtime;
 pub use async_runtime::{
-    nanbox_string_bits, spawn_blocking, spawn_blocking_with_reactor, JsPromise, Promise,
+    nanbox_string_bits, spawn_blocking, spawn_blocking_with_reactor, JsPromise,
+};
+
+mod types;
+pub use types::{
+    ArrayHeader, BigIntHeader, BufferHeader, ClosureHeader, ObjectHeader, Promise, StringHeader,
+    BIGINT_LIMBS,
 };
 
 mod handle;
@@ -59,18 +65,17 @@ pub use handle::{
 mod jsvalue;
 pub use jsvalue::{
     build_object_shape, js_array_alloc, js_array_get, js_array_push, js_array_set,
-    js_object_alloc_with_shape, js_object_get_field, js_object_set_field, ArrayHeader, JsValue,
-    ObjectHeader,
+    js_object_alloc_with_shape, js_object_get_field, js_object_set_field, JsValue,
 };
 
 mod closure;
 pub use closure::{JsClosure, RawClosureHeader};
 
 mod bigint;
-pub use bigint::{alloc_bigint_from_str, read_bigint_limbs, BigIntHeader, BIGINT_LIMBS};
+pub use bigint::{alloc_bigint_from_str, read_bigint_limbs};
 
 mod buffer;
-pub use buffer::{alloc_buffer, read_buffer_bytes, BufferHeader};
+pub use buffer::{alloc_buffer, read_buffer_bytes};
 
 mod json;
 pub use json::json_stringify;
@@ -78,8 +83,12 @@ pub use json::json_stringify;
 mod event_pump;
 pub use event_pump::notify_main_thread;
 
-use perry_runtime::js_string_from_bytes;
-pub use perry_runtime::StringHeader;
+#[cfg(feature = "runtime-link")]
+extern crate perry_runtime as _perry_runtime_link;
+
+extern "C" {
+    fn js_string_from_bytes(data: *const u8, len: u32) -> *mut StringHeader;
+}
 
 /// Opaque handle to a JS string allocated in the Perry arena.
 ///
@@ -143,7 +152,7 @@ pub fn alloc_string(s: &str) -> JsString {
     // copies the bytes into a freshly allocated arena slot, and returns the
     // header pointer. The input slice is borrowed only for the duration of
     // the call.
-    let ptr = js_string_from_bytes(s.as_ptr(), s.len() as u32);
+    let ptr = unsafe { js_string_from_bytes(s.as_ptr(), s.len() as u32) };
     JsString(ptr)
 }
 
@@ -199,7 +208,7 @@ pub fn read_bytes(handle: JsString) -> Option<&'static [u8]> {
 /// payloads, crypto digests, and other binary-as-string outputs
 /// that perry-stdlib's existing wrappers carry as `*mut StringHeader`.
 pub fn alloc_bytes(bytes: &[u8]) -> JsString {
-    let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+    let ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) };
     JsString(ptr)
 }
 
@@ -210,7 +219,7 @@ pub fn alloc_bytes(bytes: &[u8]) -> JsString {
 // change for wrapper authors. The type itself is the same; this is
 // just a stable-named import path.
 
-#[cfg(test)]
+#[cfg(all(test, feature = "runtime-link"))]
 mod tests {
     use super::*;
 

--- a/crates/perry-ffi/src/types.rs
+++ b/crates/perry-ffi/src/types.rs
@@ -1,0 +1,212 @@
+//! Canonical Perry FFI ABI types.
+//!
+//! These layouts are the public contract wrapper crates compile
+//! against. The runtime may own the allocation and implementation,
+//! but wrappers should name these types through `perry-ffi` rather
+//! than importing runtime internals.
+
+/// Length of the fixed BigInt limb array.
+pub const BIGINT_LIMBS: usize = 16;
+
+/// Header for a runtime-allocated JS string.
+#[repr(C)]
+pub struct StringHeader {
+    /// Length in UTF-16 code units, matching JavaScript `.length`.
+    pub utf16_len: u32,
+    /// Length in bytes of the payload that follows this header.
+    pub byte_len: u32,
+    /// Allocated byte capacity for the payload.
+    pub capacity: u32,
+    /// Runtime reference hint used by string append paths.
+    pub refcount: u32,
+    /// Runtime string flags.
+    pub flags: u32,
+}
+
+/// Header for a runtime-allocated JS array.
+#[repr(C)]
+pub struct ArrayHeader {
+    /// Number of elements currently in the array.
+    pub length: u32,
+    /// Allocated element capacity.
+    pub capacity: u32,
+}
+
+/// Header for a runtime-allocated JS object.
+#[repr(C)]
+pub struct ObjectHeader {
+    /// Runtime object type discriminator.
+    pub object_type: u32,
+    /// Runtime class identifier.
+    pub class_id: u32,
+    /// Runtime parent class identifier, or zero when absent.
+    pub parent_class_id: u32,
+    /// Number of inline fields.
+    pub field_count: u32,
+    /// Runtime array of object keys, or null for class instances.
+    pub keys_array: *mut ArrayHeader,
+}
+
+/// Header for a runtime-allocated Buffer or Uint8Array payload.
+#[repr(C)]
+pub struct BufferHeader {
+    /// Length in bytes.
+    pub length: u32,
+    /// Allocated byte capacity.
+    pub capacity: u32,
+}
+
+/// Header for a runtime-allocated BigInt.
+#[repr(C)]
+pub struct BigIntHeader {
+    /// Fixed little-endian 1024-bit limb storage.
+    pub limbs: [u64; BIGINT_LIMBS],
+}
+
+/// Header for a runtime-allocated JS closure.
+#[repr(C)]
+pub struct ClosureHeader {
+    /// Pointer to the compiled closure body.
+    pub func_ptr: *const u8,
+    /// Number of captured values, including runtime flag bits.
+    pub capture_count: u32,
+    /// Runtime closure type tag.
+    pub type_tag: u32,
+}
+
+/// Opaque runtime-allocated Promise handle.
+///
+/// Wrappers only pass `*mut Promise` across the ABI; they must not
+/// inspect or allocate this type directly.
+#[repr(C)]
+pub struct Promise {
+    _private: [u8; 0],
+}
+
+#[cfg(all(test, feature = "runtime-link"))]
+mod layout_tests {
+    use super::*;
+    use std::mem::{align_of, offset_of, size_of};
+
+    macro_rules! assert_layout {
+        ($ffi:ty, $runtime:ty) => {
+            assert_eq!(size_of::<$ffi>(), size_of::<$runtime>());
+            assert_eq!(align_of::<$ffi>(), align_of::<$runtime>());
+        };
+    }
+
+    #[test]
+    fn string_header_matches_runtime() {
+        assert_layout!(StringHeader, perry_runtime::StringHeader);
+        assert_eq!(
+            offset_of!(StringHeader, utf16_len),
+            offset_of!(perry_runtime::StringHeader, utf16_len)
+        );
+        assert_eq!(
+            offset_of!(StringHeader, byte_len),
+            offset_of!(perry_runtime::StringHeader, byte_len)
+        );
+        assert_eq!(
+            offset_of!(StringHeader, capacity),
+            offset_of!(perry_runtime::StringHeader, capacity)
+        );
+        assert_eq!(
+            offset_of!(StringHeader, refcount),
+            offset_of!(perry_runtime::StringHeader, refcount)
+        );
+        assert_eq!(
+            offset_of!(StringHeader, flags),
+            offset_of!(perry_runtime::StringHeader, flags)
+        );
+    }
+
+    #[test]
+    fn array_header_matches_runtime() {
+        assert_layout!(ArrayHeader, perry_runtime::ArrayHeader);
+        assert_eq!(
+            offset_of!(ArrayHeader, length),
+            offset_of!(perry_runtime::ArrayHeader, length)
+        );
+        assert_eq!(
+            offset_of!(ArrayHeader, capacity),
+            offset_of!(perry_runtime::ArrayHeader, capacity)
+        );
+    }
+
+    #[test]
+    fn object_header_matches_runtime() {
+        assert_layout!(ObjectHeader, perry_runtime::ObjectHeader);
+        assert_eq!(
+            offset_of!(ObjectHeader, object_type),
+            offset_of!(perry_runtime::ObjectHeader, object_type)
+        );
+        assert_eq!(
+            offset_of!(ObjectHeader, class_id),
+            offset_of!(perry_runtime::ObjectHeader, class_id)
+        );
+        assert_eq!(
+            offset_of!(ObjectHeader, parent_class_id),
+            offset_of!(perry_runtime::ObjectHeader, parent_class_id)
+        );
+        assert_eq!(
+            offset_of!(ObjectHeader, field_count),
+            offset_of!(perry_runtime::ObjectHeader, field_count)
+        );
+        assert_eq!(
+            offset_of!(ObjectHeader, keys_array),
+            offset_of!(perry_runtime::ObjectHeader, keys_array)
+        );
+    }
+
+    #[test]
+    fn buffer_header_matches_runtime() {
+        assert_layout!(BufferHeader, perry_runtime::BufferHeader);
+        assert_eq!(
+            offset_of!(BufferHeader, length),
+            offset_of!(perry_runtime::BufferHeader, length)
+        );
+        assert_eq!(
+            offset_of!(BufferHeader, capacity),
+            offset_of!(perry_runtime::BufferHeader, capacity)
+        );
+    }
+
+    #[test]
+    fn bigint_header_matches_runtime() {
+        assert_eq!(BIGINT_LIMBS, perry_runtime::bigint::BIGINT_LIMBS);
+        assert_layout!(BigIntHeader, perry_runtime::BigIntHeader);
+        assert_eq!(
+            offset_of!(BigIntHeader, limbs),
+            offset_of!(perry_runtime::BigIntHeader, limbs)
+        );
+    }
+
+    #[test]
+    fn closure_header_matches_runtime() {
+        assert_layout!(ClosureHeader, perry_runtime::ClosureHeader);
+        assert_eq!(
+            offset_of!(ClosureHeader, func_ptr),
+            offset_of!(perry_runtime::ClosureHeader, func_ptr)
+        );
+        assert_eq!(
+            offset_of!(ClosureHeader, capture_count),
+            offset_of!(perry_runtime::ClosureHeader, capture_count)
+        );
+        assert_eq!(
+            offset_of!(ClosureHeader, type_tag),
+            offset_of!(perry_runtime::ClosureHeader, type_tag)
+        );
+    }
+
+    #[test]
+    fn promise_is_pointer_abi_only() {
+        assert_eq!(
+            size_of::<*mut Promise>(),
+            size_of::<*mut perry_runtime::promise::Promise>()
+        );
+        assert_eq!(
+            align_of::<*mut Promise>(),
+            align_of::<*mut perry_runtime::promise::Promise>()
+        );
+    }
+}

--- a/crates/perry-runtime/src/gc.rs
+++ b/crates/perry-runtime/src/gc.rs
@@ -10,6 +10,7 @@
 
 use std::alloc::{alloc, dealloc, realloc, Layout};
 use std::cell::{Cell, RefCell};
+use std::ffi::c_void;
 
 /// GC header prepended to every heap allocation.
 /// Callers receive a pointer AFTER this header (ptr + 8).
@@ -232,8 +233,11 @@ thread_local! {
         last_pause_us: 0,
     }) };
 
-    /// Registered root scanner functions (promise queue, timers, etc.)
+    /// Registered Rust root scanner functions (promise queue, timers, etc.)
     static ROOT_SCANNERS: RefCell<Vec<fn(&mut dyn FnMut(f64))>> = RefCell::new(Vec::new());
+
+    /// Registered root scanner functions from perry-ffi/native packages.
+    static FFI_ROOT_SCANNERS: RefCell<Vec<PerryFfiRootScanner>> = RefCell::new(Vec::new());
 
     /// Module-level global variable addresses (registered by codegen)
     static GLOBAL_ROOTS: RefCell<Vec<*mut u64>> = const { RefCell::new(Vec::new()) };
@@ -806,6 +810,21 @@ pub fn gc_realloc(old_user_ptr: *mut u8, new_payload_size: usize) -> *mut u8 {
 /// Each scanner is called during the mark phase to discover roots.
 pub fn gc_register_root_scanner(scanner: fn(&mut dyn FnMut(f64))) {
     ROOT_SCANNERS.with(|scanners| {
+        scanners.borrow_mut().push(scanner);
+    });
+}
+
+type PerryFfiRootMarker = extern "C" fn(value: f64, ctx: *mut c_void);
+type PerryFfiRootScanner = extern "C" fn(mark: PerryFfiRootMarker, ctx: *mut c_void);
+
+/// Register a native-package root scanner through a stable C ABI.
+///
+/// `perry-ffi` adapts its Rust-facing `fn(&mut dyn FnMut(f64))`
+/// convenience API to this callback shape so native wrapper archives
+/// can stay runtime-free.
+#[no_mangle]
+pub extern "C" fn perry_ffi_gc_register_root_scanner(scanner: PerryFfiRootScanner) {
+    FFI_ROOT_SCANNERS.with(|scanners| {
         scanners.borrow_mut().push(scanner);
     });
 }
@@ -2273,6 +2292,12 @@ fn mark_registered_roots(valid_ptrs: &ValidPointerSet) {
         });
     }
 
+    let ffi_scanners: Vec<PerryFfiRootScanner> = FFI_ROOT_SCANNERS.with(|s| s.borrow().clone());
+    let ctx = valid_ptrs as *const ValidPointerSet as *mut c_void;
+    for scanner in ffi_scanners {
+        scanner(perry_ffi_mark_root, ctx);
+    }
+
     // Singleton closures (no-capture closures cached by `js_closure_alloc_singleton`)
     // are reachable from emitted code via cached pointers, not via JSValue refs the
     // tracer would otherwise find. Mark them explicitly so the sweep doesn't
@@ -2290,6 +2315,14 @@ fn mark_registered_roots(valid_ptrs: &ValidPointerSet) {
             }
         }
     }
+}
+
+extern "C" fn perry_ffi_mark_root(value: f64, ctx: *mut c_void) {
+    if ctx.is_null() {
+        return;
+    }
+    let valid_ptrs = unsafe { &*(ctx as *const ValidPointerSet) };
+    try_mark_value(value.to_bits(), valid_ptrs);
 }
 
 /// Gen-GC Phase C3: mark the remembered set as roots. Old-gen

--- a/tests/test_perry_ffi_thin_staticlib.sh
+++ b/tests/test_perry_ffi_thin_staticlib.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Regression: native wrapper staticlibs that depend on perry-ffi must not
+# embed perry-runtime object code. The final Perry link already provides the
+# runtime archive; wrapper archives should carry unresolved references to the
+# runtime ABI symbols instead of duplicate definitions.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "SKIP: cargo not available"
+  exit 0
+fi
+
+if ! command -v ar >/dev/null 2>&1; then
+  echo "SKIP: ar not available"
+  exit 0
+fi
+
+NM=""
+if command -v llvm-nm >/dev/null 2>&1; then
+  NM="$(command -v llvm-nm)"
+elif command -v xcrun >/dev/null 2>&1 && xcrun --find llvm-nm >/dev/null 2>&1; then
+  NM="$(xcrun --find llvm-nm)"
+elif command -v nm >/dev/null 2>&1; then
+  NM="$(command -v nm)"
+else
+  echo "SKIP: nm/llvm-nm not available"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/native/src"
+
+cat > "$TMPDIR/native/Cargo.toml" << EOF
+[package]
+name = "perry_issue1027_native"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+perry-ffi = { path = "$REPO_ROOT/crates/perry-ffi" }
+EOF
+
+cat > "$TMPDIR/native/src/lib.rs" << 'EOF'
+use perry_ffi::{alloc_string, gc_register_root_scanner, read_string, JsString, StringHeader};
+
+fn scan_issue1027_roots(mark: &mut dyn FnMut(f64)) {
+    mark(f64::from_bits(0x7ffc_0000_0000_0001));
+}
+
+#[no_mangle]
+pub extern "C" fn js_issue1027_register_roots() {
+    gc_register_root_scanner(scan_issue1027_roots);
+}
+
+#[no_mangle]
+pub extern "C" fn js_issue1027_echo(input: *mut StringHeader) -> *mut StringHeader {
+    let input = unsafe { JsString::from_raw(input) };
+    let value = read_string(input).unwrap_or("missing");
+    alloc_string(value).as_raw()
+}
+EOF
+
+cargo build --quiet --release --manifest-path "$TMPDIR/native/Cargo.toml"
+
+ARCHIVE="$TMPDIR/native/target/release/libperry_issue1027_native.a"
+MEMBERS="$TMPDIR/archive-members.txt"
+SYMBOLS="$TMPDIR/symbols.txt"
+NM_ERRORS="$TMPDIR/nm-errors.txt"
+
+ar t "$ARCHIVE" > "$MEMBERS"
+
+if grep -q 'perry_runtime-' "$MEMBERS"; then
+  echo "FAIL: native wrapper archive embeds perry-runtime objects"
+  grep 'perry_runtime-' "$MEMBERS" | head -20
+  exit 1
+fi
+
+"$NM" -g "$ARCHIVE" > "$SYMBOLS" 2>"$NM_ERRORS" || true
+if [ ! -s "$SYMBOLS" ]; then
+  "$NM" "$ARCHIVE" > "$SYMBOLS" 2>>"$NM_ERRORS" || true
+fi
+
+for symbol in js_string_from_bytes perry_ffi_gc_register_root_scanner; do
+  if grep -Eq "[[:space:]]T[[:space:]]_?${symbol}$" "$SYMBOLS"; then
+    echo "FAIL: wrapper archive defines runtime symbol $symbol"
+    grep -E "_?${symbol}$" "$SYMBOLS"
+    exit 1
+  fi
+  if ! grep -Eq "[[:space:]]U[[:space:]]_?${symbol}$" "$SYMBOLS"; then
+    echo "FAIL: wrapper archive does not leave $symbol unresolved"
+    grep -E "_?${symbol}$" "$SYMBOLS" || true
+    exit 1
+  fi
+done
+
+echo "PASS"


### PR DESCRIPTION
## Summary

Fixes #1027.

- Moves Perry ABI header types into `perry-ffi` as the canonical public wrapper surface and makes `perry-runtime` optional behind `runtime-link`.
- Replaces normal runtime imports/re-exports with `extern "C"` declarations so native wrapper staticlibs reference runtime symbols without embedding runtime object code.
- Adds a C-shaped GC root-scanner bridge exported by `perry-runtime` and used by `perry-ffi` without exposing the runtime's Rust-internal scanner signature.
- Adds a regression script that builds a tiny native staticlib depending only on `perry-ffi` and checks that runtime symbols remain unresolved and no `perry_runtime-*` archive members are bundled.

## Verification

Passed:

- `cargo check -p perry-ffi`
- `cargo test -p perry-ffi`
- `cargo test -p perry-ffi --features runtime-link`
- `tests/test_perry_ffi_thin_staticlib.sh`
- `cargo build --release -p perry-ext-dotenv`
- `cargo tree -p perry-ext-dotenv -e normal -i perry-runtime` produced no normal dependency path
- `cargo fmt --all -- --check`
- `cargo build --release`
- `./run_parity_tests.sh --filter ffi_surface` passed 5/5

Attempted full-suite checks on my local macOS host:

- `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` failed while linking `perry-ui-visionos`: `ld: framework 'UIKit' not found`. Rerunning with `--exclude perry-ui-visionos` progressed through the touched crates and failed later in unrelated `perry-jsruntime` test `modules::tests::test_wrap_commonjs_requires_namespace_imports` at `crates/perry-jsruntime/src/modules.rs:2410`.
- `./run_parity_tests.sh` started, reported unrelated parity mismatches, then hung in the Node-side `test_net_connect_options.ts` process because this host does not have `timeout`/`gtimeout`; I stopped the stuck run and added the focused `ffi_surface` parity pass above.
- `./scripts/run_doc_tests.sh` finished with `doc-tests: 104/240 passed, 102 failed, 34 skipped`; failures were local artifact/platform issues such as missing `libperry_ui_macos.a`, missing iOS/tvOS simulator `libperry_runtime.a`, plus existing stdlib/http snippet link errors for node/http/ws symbols.
