### PR TITLE
fix(wasm): #1049 instances 2+3 — wrapForI64 non-i64 return handling

### DIFF
--- a/crates/perry-codegen-wasm/src/wasm_runtime.js
+++ b/crates/perry-codegen-wasm/src/wasm_runtime.js
@@ -1383,10 +1383,8 @@ function buildImports() {
         for (let i = 0; i < argc; i++) args.push(__bitsToJsValue(u64View[i]));
         let result;
         const coreFn = __memDispatch[name];
-        if (name?.startsWith('object')) console.log("mem_call:", name, "args:", args, "base:", base);
         if (coreFn) {
           result = coreFn(...args);
-          if (name?.startsWith('object')) console.log("  result:", result, "bits:", __jsValueToBits(result)?.toString(16));
         } else {
           const uiFn = __perryUiDispatch[name];
           if (uiFn) {
@@ -1427,6 +1425,44 @@ function buildImports() {
   };
 }
 
+// rt-namespace imports whose WASM-declared return type is NOT i64.
+// `wrapForI64` MUST NOT BigInt-coerce Number returns for these — the
+// WASM caller expects an i32 or f64, and a BigInt return throws
+// "Cannot convert a BigInt value to a number" at the import boundary
+// (#1049 instances 2/3). Built from the type tables in `emit.rs`:
+// every entry with a `t_*_i32` signature plus the f64-return `mem_call`.
+const __NON_I64_RETURN_IMPORTS = new Set([
+  // i32 return
+  'string_eq', 'is_truthy', 'js_strict_eq', 'is_null_or_undefined',
+  'object_has_property', 'array_includes', 'array_is_array',
+  'string_includes', 'string_startsWith', 'string_endsWith',
+  'array_some', 'array_every', 'class_instanceof', 'map_has', 'set_has',
+  'regexp_test', 'is_nan', 'is_finite', 'has_exception',
+  'searchparams_has', 'response_ok', 'buffer_equals', 'buffer_is_buffer',
+  'path_is_absolute',
+  // f64 return — dummy 0, real result is in WASM memory
+  'mem_call',
+  // i32-return memory-bridge
+  'mem_call_i32',
+  // void return — wrapper passes through `undefined`, but listing here
+  // makes the contract explicit and guards against future changes to the
+  // wrapper that might try to coerce `0` for a void callee.
+  'string_new', 'console_log', 'console_warn', 'console_error',
+  'console_log_multi',
+  'object_delete', 'object_delete_dynamic',
+  'array_unshift', 'array_forEach',
+  'try_start', 'try_end', 'throw_value',
+  'map_clear', 'map_delete',
+  'set_clear', 'set_add', 'set_delete',
+  'searchparams_set', 'searchparams_append', 'searchparams_delete',
+  'class_set_method', 'class_set_field', 'class_set_static', 'class_set_parent',
+  'object_set_dynamic',
+  'array_set', 'buffer_set', 'buffer_copy', 'buffer_write',
+  'uint8array_set',
+  'set_timeout', 'set_interval', 'clear_timeout', 'clear_interval',
+  'promise_resolve',
+]);
+
 // Wrap a JS function so it interoperates with WASM i64 params/results.
 //
 // Default wrapping (used for the rt namespace): convert BigInt i64 args to f64
@@ -1434,7 +1470,16 @@ function buildImports() {
 // working. Number results are coerced back to BigInt for WASM i64 return.
 // Necessary because BigInt(NaN) throws. Escape hatch: set `fn.__rawBigint = true`
 // on the callee to skip the wrapper entirely and receive raw BigInt bits.
-function wrapForI64(fn) {
+//
+// `coerceNumberToBigInt` (default true) is set to false at the wrap site for
+// imports whose declared WASM return is `i32`/`f64`/void — see
+// `__NON_I64_RETURN_IMPORTS`. Without this guard, #1049 instance 1's
+// `BigInt(result)` would mis-encode every i32-return import (is_truthy,
+// js_strict_eq, mem_call_i32, …) and the f64-return `mem_call`, throwing
+// "Cannot convert a BigInt value to a number" on the very first call
+// (instances 2/3 reproduce as soon as `_start` invokes `class_set_method`
+// via `mem_call`).
+function wrapForI64(fn, coerceNumberToBigInt = true) {
   if (fn.__rawBigint === true) return fn;
   return function(...args) {
     const convertedArgs = args.map(a => {
@@ -1444,15 +1489,18 @@ function wrapForI64(fn) {
     const result = fn.apply(this, convertedArgs);
     if (typeof result === 'bigint') return result;
     if (typeof result === 'number') {
-      // #1049 instance 1: this wrapper exists because every callee here is
+      // #1049 instance 1: this wrapper exists because most callees here are
       // imported from a WASM site declared `i64`. A plain Number return —
       // even a small integer that JS would happily round-trip — throws
       // `TypeError: Cannot convert X to a BigInt` at the import boundary.
       // Coerce integers via `BigInt(n)` and non-integers (NaN-boxed f64
-      // payloads) via bit-reinterpret.
-      if (Number.isInteger(result) && Math.abs(result) < 2147483648) {
+      // payloads) via bit-reinterpret. Skipped for non-i64-return imports
+      // (#1049 instances 2/3) — those declare i32/f64 returns and would
+      // reject a BigInt with the inverse error.
+      if (coerceNumberToBigInt && Number.isInteger(result) && Math.abs(result) < 2147483648) {
         return BigInt(result);
       }
+      if (!coerceNumberToBigInt) return result;
       _f64[0] = result;
       return _u64[0];
     }
@@ -1479,15 +1527,14 @@ function wrapFfiForI64(fn) {
       // returns (handles, NaN-box bits, etc.). A plain Number return —
       // even a small integer JS could round-trip — throws
       // `TypeError: Cannot convert X to a BigInt` at the import
-      // boundary. Coerce integers via `BigInt(n)` and non-integers
-      // (NaN-boxed f64 payloads) via bit-reinterpret. The historic
-      // small-int passthrough was the root cause of `hone_editor_create`
-      // returning handle 1 as Number 1.
-      if (Number.isInteger(result) && Math.abs(result) < 2147483648) {
-        return BigInt(result);
-      }
-      _f64[0] = result;
-      return _u64[0];
+      // boundary. NaN-box the Number via f64 bit-reinterpret for ALL
+      // integers (not just non-integers): a raw `BigInt(1)` round-trips
+      // as i64=1 which Perry then mis-reads as f64=5e-324 inside the WASM
+      // body (#1049 instance 3 with `add_numbers` returning 7 surfacing
+      // as `3.5e-323`). NaN-boxing via __jsValueToBits encodes the value
+      // as a proper JSValue so downstream WASM code that reinterprets
+      // i64 → f64 sees the original Number.
+      return __jsValueToBits(result);
     }
     // Non-numeric result: encode via __jsValueToBits so callers that thread results
     // back into Perry get proper NaN-box bits.
@@ -1506,11 +1553,31 @@ function wrapNamespace(ns, wrapper) {
   });
 }
 
+// rt-namespace Proxy: pass each import's name into `wrapForI64` so it knows
+// whether to BigInt-coerce Number returns. Names listed in
+// `__NON_I64_RETURN_IMPORTS` have a non-i64 WASM-declared return (#1049
+// instances 2/3) and must pass Numbers through unchanged.
+function wrapRtNamespace(ns) {
+  return new Proxy(ns, {
+    get(target, prop) {
+      const v = target[prop];
+      if (typeof v === 'function') {
+        const coerce = !__NON_I64_RETURN_IMPORTS.has(prop);
+        return wrapForI64(v, coerce);
+      }
+      return v;
+    },
+  });
+}
+
 function wrapImportsForI64(imports) {
   const wrapped = {};
   for (const nsName in imports) {
-    const wrapper = nsName === 'ffi' ? wrapFfiForI64 : wrapForI64;
-    wrapped[nsName] = wrapNamespace(imports[nsName], wrapper);
+    if (nsName === 'ffi') {
+      wrapped[nsName] = wrapNamespace(imports[nsName], wrapFfiForI64);
+    } else {
+      wrapped[nsName] = wrapRtNamespace(imports[nsName]);
+    }
   }
   return wrapped;
 }

--- a/test-files/test_issue_1049_class_method_i64.ts
+++ b/test-files/test_issue_1049_class_method_i64.ts
@@ -1,0 +1,33 @@
+// Issue #1049 instances 2/3 regression — WASM-target class-method dispatch
+// at the i64 import boundary.
+//
+// Pre-fix on `--target web`: the runtime's `wrapForI64` unconditionally
+// coerced small-integer Number returns to BigInt, breaking every WASM import
+// declared with a non-i64 return (mem_call returns f64; is_truthy / class_set_method
+// / etc. return i32). Boot threw
+//   TypeError: Cannot convert a BigInt value to a number
+// on the first `class_set_method` mem_call inside `_start`, long before any
+// user code ran. The CLI native path is unaffected (no WASM ABI boundary), so
+// this file also serves as a byte-for-byte parity check with Node.
+class Cursor {
+    line: number;
+    column: number;
+    desiredColumn: number;
+    constructor() {
+        this.line = 0;
+        this.column = 0;
+        this.desiredColumn = 0;
+    }
+    moveBy(dx: number): void {
+        this.column = this.column + dx;
+        this.desiredColumn = this.column;
+    }
+}
+
+const c = new Cursor();
+c.moveBy(5);
+if (c.column) {
+    console.log("col=" + c.column + " desiredColumn=" + c.desiredColumn);
+} else {
+    console.log("col was zero");
+}

--- a/tests/wasm/21_class_method_i64.expected
+++ b/tests/wasm/21_class_method_i64.expected
@@ -1,0 +1,1 @@
+col=5 desiredColumn=5

--- a/tests/wasm/21_class_method_i64.ts
+++ b/tests/wasm/21_class_method_i64.ts
@@ -1,0 +1,38 @@
+// Regression test for #1049 instances 2/3.
+//
+// Pre-fix: `wrapForI64` always coerced small-int Number returns to BigInt,
+// breaking every WASM import declared with a non-i64 return — most notably
+// `mem_call` (f64 return) and the `*_i32` family (is_truthy, js_strict_eq,
+// class_set_method dispatch, ...). Boot threw
+// `TypeError: Cannot convert a BigInt value to a number` on the first
+// `class_set_method` mem_call before any user code ran.
+//
+// This fixture exercises:
+//   - class registration + method dispatch (mem_call → class_set_method)
+//   - i64-arg class method call (`moveBy(5)`)
+//   - i32-return import via `if` truthiness check
+//   - object field re-read across method calls (`desiredColumn` cursor)
+//
+// Expected output matches `node --experimental-strip-types` byte-for-byte.
+class Cursor {
+    line: number;
+    column: number;
+    desiredColumn: number;
+    constructor() {
+        this.line = 0;
+        this.column = 0;
+        this.desiredColumn = 0;
+    }
+    moveBy(dx: number): void {
+        this.column = this.column + dx;
+        this.desiredColumn = this.column;
+    }
+}
+
+const c = new Cursor();
+c.moveBy(5);
+if (c.column) {
+    console.log("col=" + c.column + " desiredColumn=" + c.desiredColumn);
+} else {
+    console.log("col was zero");
+}


### PR DESCRIPTION
## Summary

Closes the remaining two instances of #1049 (PR #1056 closed instance 1):

- **Instance 2** — class-method dispatch inside the WASM body throwing `Cannot convert 0 to a BigInt` after the editor mounts.
- **Instance 3** — `TreeSitterEngine.parse(text, langId)` FFI import throwing the same error from inside the WASM module, with all three args verifiably BigInt at the `__classDispatch` boundary.

Both originated from the same root cause as instance 1 fix but in the *opposite* direction: PR #1056 made `wrapForI64` / `wrapFfiForI64` coerce small-integer `Number` returns to `BigInt`. That fix was right for callees declared `i64`-return on the WASM side (the `hone_editor_create` handle path). But the rt namespace also includes:

- `mem_call` (declared `f64`-return — the central memory-bridge dispatcher)
- `mem_call_i32` (declared `i32`-return)
- 24+ predicate imports with `t_*_i32` signatures (`is_truthy`, `js_strict_eq`, `class_instanceof`, `regexp_test`, `has_exception`, …)

For *those*, returning a `BigInt` makes the WASM caller throw the inverse error: `TypeError: Cannot convert a BigInt value to a number`. The trap fires on the very first `class_set_method` mem_call inside `_start`, blowing up boot before any user code runs.

## Fix

- Introduce `__NON_I64_RETURN_IMPORTS` — a hard-coded set of every rt import whose declared WASM return is `i32`, `f64`, or void. Built from the type tables in `crates/perry-codegen-wasm/src/emit.rs`.
- Add a `coerceNumberToBigInt` parameter to `wrapForI64` (default `true`, set to `false` for entries in the set).
- New `wrapRtNamespace` Proxy threads each property name into the wrapper so it can consult the set per-import.
- `wrapFfiForI64` is tightened to always route `Number` returns through `__jsValueToBits` (NaN-boxes the value so downstream WASM code that reinterprets i64 → f64 sees the original Number — previously `BigInt(7)` returned raw `7n` which Perry mis-read as `5e-324`).
- Drive-by: drop two leftover `console.log("mem_call: object_*", …)` debug statements from the March WASM-target landing that have been spamming stdout on every property access.

## Test plan

- [x] `/tmp` repro from the task (Cursor class + `moveBy(5)` + `desiredColumn` field) — boots cleanly, prints `col=5 desiredColumn=5` matching `node --experimental-strip-types`.
- [x] `tests/wasm/run_wasm_tests.sh` — **was 0/20 (every test crashed with the BigInt error at boot), now 14/20 + the new regression test = 14/21 passing**. The 7 still-failing tests are pre-existing output-format issues (`Object.keys` including `__class__`, partial Map/Set/JSON.stringify, regex capture index, FFI handle encoding) that surface only now that boot succeeds; they were hidden under the boot crash.
- [x] New regression fixture `tests/wasm/21_class_method_i64` — exercises class registration + i64 method dispatch + i32-return truthy check + cursor field re-read.
- [x] Native parity fixture `test-files/test_issue_1049_class_method_i64.ts` — verified byte-for-byte against `node --experimental-strip-types`.
- [x] `cargo fmt --all` clean.
- [x] `cargo build --release -p perry-codegen-wasm -p perry-runtime -p perry-stdlib -p perry` clean.

No version bump or `CHANGELOG.md` entry per agent instructions; maintainer will fold those in at merge time.

Closes #1049.