### PR TITLE
test(async): #1013 — pin Promise.all + array destructure regression

### DIFF
--- a/test-files/test_issue_1013_promise_all_destructure.ts
+++ b/test-files/test_issue_1013_promise_all_destructure.ts
@@ -1,0 +1,37 @@
+// #1013: `const [a, b] = await Promise.all([fn1(), fn2()])` silently
+// produced `a === undefined` / `b === undefined` under Perry while
+// sequential awaits worked. Root cause was the HIR shape for
+// `Promise.all`: post-#973 (constructor-property) lowering routed the
+// bare `Promise` ident-as-value to `PropertyGet { GlobalGet(0),
+// "Promise" }`, so a static-method call `Promise.all(...)` became
+// `PropertyGet { PropertyGet { GlobalGet(0), "Promise" }, "all" }`
+// (two levels deep). The codegen Promise-static dispatch only matched
+// the bare-`GlobalGet` receiver, so the call fell through to
+// `js_native_call_method("all", ...)` against the Promise constructor
+// — which returned `0.0` (no such method on a function value), making
+// the awaited result a number and the destructure indexes read 0 /
+// undefined.
+//
+// #1007 collapses the member-object reroute back to `GlobalGet(0)`
+// when the original ident name matches the property (Promise.all,
+// Number.parseFloat, …) so the codegen's existing fast-path fires.
+// This test pins the byte-for-byte node match so a future regression
+// of either the HIR collapse or the codegen `is_global_constructor_expr`
+// helper fails immediately.
+
+async function fetchA(): Promise<string> {
+    return "hello-from-A";
+}
+
+async function fetchB(): Promise<{ plan: string }> {
+    return { plan: "pro" };
+}
+
+async function main() {
+    const [a, b] = await Promise.all([fetchA(), fetchB()]);
+    console.log("a:", JSON.stringify(a), "typeof:", typeof a);
+    console.log("b:", JSON.stringify(b), "typeof:", typeof b);
+    console.log("b.plan:", b?.plan);
+}
+
+main();


### PR DESCRIPTION
Closes #1013.

## Summary

The reporter's bug — `const [a, b] = await Promise.all([fn1(), fn2()])` returning `a === undefined` / `b === undefined` — is **already fixed on current main** as a side effect of two PRs that landed after the reported HEAD (`13dc587a` / v0.5.1004):

1. **#1007** (`fix(hir): #1001 — restore built-in static identity in member position`) collapses `Promise.all` from `PropertyGet { PropertyGet { GlobalGet(0), "Promise" }, "all" }` to `PropertyGet { GlobalGet(0), "all" }`.
2. **#1030** (`fix: address #945 scalar method allocation regression`) added `is_global_constructor_expr` in the codegen Promise-static dispatch, which accepts **both** the shallow (`GlobalGet(0)`) and deeper (`PropertyGet { GlobalGet(0), "Promise" }`) receiver shapes.

This PR adds a regression test (`test-files/test_issue_1013_promise_all_destructure.ts`) that pins the byte-for-byte node match. No code change.

## Root cause (pre-fix)

At `13dc587a`, the HIR for `Promise.all([fetchA(), fetchB()])` was `PropertyGet { object: PropertyGet { GlobalGet(0), "Promise" }, property: "all" }`. The codegen Promise-static dispatch only matched `matches!(object.as_ref(), Expr::GlobalGet(_))`, so this deeper shape fell through to the generic `js_native_call_method("all", …)` block — which called `"all"` against the global Promise constructor function. No such method on a function value, returned `0.0`. The awaited value was then a number, and `[a, b] = 0.0` produced `a=0, b=undefined`.

## Bisect

| Commit | Behavior |
|---|---|
| `13dc587a` (#1010, reporter HEAD) | `a: 0 typeof: number / b: undefined` |
| `42ec277c` (`#949` test harden, parent of #1007) | Still buggy |
| `f78361f1` (#1007 HIR collapse) | **Fixed** — `a: "hello-from-A" / b: {"plan":"pro"}` |
| `3856caad` (current main) | Fixed |

## Repro

```ts
async function fetchA(): Promise<string> { return "hello-from-A"; }
async function fetchB(): Promise<{ plan: string }> { return { plan: "pro" }; }
async function main() {
    const [a, b] = await Promise.all([fetchA(), fetchB()]);
    console.log("a:", JSON.stringify(a), "typeof:", typeof a);
    console.log("b:", JSON.stringify(b), "typeof:", typeof b);
    console.log("b.plan:", b?.plan);
}
main();
```

Expected (node `--experimental-strip-types`):
```
a: "hello-from-A" typeof: string
b: {"plan":"pro"} typeof: object
b.plan: pro
```

## Test plan

- [x] `test-files/test_issue_1013_promise_all_destructure.ts` matches node byte-for-byte on current main
- [x] Sanity-passed adjacent async tests (#1021/#1029/#1047 fixtures)

No version bump or changelog change.