### PR TITLE
fix(fastify): non-blocking listen() + main-thread pump

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -264,6 +264,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("fastify", "setErrorHandler", true, None),
     method("fastify", "register", true, None),
     method("fastify", "listen", true, None),
+    method("fastify", "close", true, None),
     method("fastify", "method", true, None),
     method("fastify", "url", true, None),
     // Manifest-consistency catch-up (release-sweep gate).

--- a/crates/perry-codegen/src/lower_call.rs
+++ b/crates/perry-codegen/src/lower_call.rs
@@ -6499,6 +6499,24 @@ const NATIVE_MODULE_TABLE: &[NativeModSig] = &[
         args: &[NA_F64, NA_PTR],
         ret: NR_VOID,
     },
+    // `app.close()` — shut down every server bound to this
+    // FastifyApp. Pre-fix, this method had no entry in the dispatch
+    // table at all, so codegen for the `NativeMethodCall` shape fell
+    // through to the "unknown native method" arm and emitted a no-op
+    // 0.0 return. With `listen()` now non-blocking, the program
+    // doesn't exit until something marks the server as no-longer-
+    // listening — `app.close()` is how user code does that. The
+    // runtime fn walks the handle registry for matching
+    // `FastifyServerHandle` rows and clears the listening flag.
+    NativeModSig {
+        module: "fastify",
+        has_receiver: true,
+        method: "close",
+        class_filter: None,
+        runtime: "js_fastify_app_close",
+        args: &[],
+        ret: NR_VOID,
+    },
     // Fastify request methods
     NativeModSig {
         module: "fastify",

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -2503,6 +2503,11 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_fastify_get", I32, &[I64, I64, I64]);
     module.declare_function("js_fastify_head", I32, &[I64, I64, I64]);
     module.declare_function("js_fastify_listen", VOID, &[I64, DOUBLE, I64]);
+    // `app.close()` — shuts every server bound to this FastifyApp.
+    // Declared so the dispatch-table arm in lower_call.rs can emit a
+    // call site. Returns void (Rust signature returns bool, but the
+    // codegen-side caller discards the result).
+    module.declare_function("js_fastify_app_close", VOID, &[I64]);
     module.declare_function("js_fastify_options", I32, &[I64, I64, I64]);
     module.declare_function("js_fastify_patch", I32, &[I64, I64, I64]);
     module.declare_function("js_fastify_post", I32, &[I64, I64, I64]);

--- a/crates/perry-ext-fastify/src/server.rs
+++ b/crates/perry-ext-fastify/src/server.rs
@@ -11,7 +11,8 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::os::raw::c_int;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
@@ -23,8 +24,8 @@ use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot};
 
 use perry_ffi::{
-    alloc_string, get_handle, register_handle, Handle, JsClosure, JsValue, RawClosureHeader,
-    StringHeader,
+    alloc_string, get_handle, get_handle_mut, iter_handle_ids_of, register_handle, Handle,
+    JsClosure, JsValue, RawClosureHeader, StringHeader,
 };
 
 use crate::app::{ClosurePtr, FastifyApp, Route};
@@ -137,10 +138,31 @@ pub struct ErrorHeader {
 }
 
 /// Server handle returned by `js_fastify_listen`.
+///
+/// Pre-fix, `listen()` blocked the main TS thread inside an inner
+/// `event_loop` that never returned, so `await app.listen(...)` in
+/// user code never resumed and any subsequent code (an in-process
+/// `fetch` against the same process, `app.close()`, etc.) never ran —
+/// the compat-sweep fixture timed out at gtimeout(30s). The fix
+/// mirrors what perry-ext-http-server did in #604: `listen()` returns
+/// immediately after spawning the accept loop, and a new
+/// `js_fastify_process_pending` extern wired into perry-stdlib's main
+/// pump drains the per-server mpsc each tick. The receiver lives
+/// inside the handle so the pump can find it after `listen()` returns.
 pub struct FastifyServerHandle {
     pub port: u16,
     pub app_handle: Handle,
     pub shutdown_tx: Option<oneshot::Sender<()>>,
+    /// Drained by `js_fastify_process_pending` from the main TS thread
+    /// each tick. `Mutex` because the handle registry hands out `&'static`
+    /// references but the pump needs `&mut` access to `try_recv` and
+    /// we can't statically prove the pump is the only mutator.
+    pub request_rx: Mutex<Option<mpsc::Receiver<FastifyPendingRequest>>>,
+    /// True between `listen()` and `close()`. The
+    /// `js_fastify_has_active` extern returns 1 while any server has
+    /// this set, keeping the runtime's main event loop alive until the
+    /// user explicitly closes the server.
+    pub listening: AtomicBool,
 }
 
 /// Pending request waiting for the TS handler to produce a response.
@@ -256,11 +278,16 @@ pub unsafe extern "C" fn js_fastify_listen(app_handle: Handle, opts: f64, callba
         });
     });
 
-    // Register the server handle so `js_fastify_close` can find it.
+    // Register the server handle so `js_fastify_close` and the
+    // process_pending pump can find it. The receiver lives inside the
+    // handle so the pump (driven from perry-stdlib's main loop) can
+    // drain it after `listen()` returns.
     let _server_handle = register_handle(FastifyServerHandle {
         port,
         app_handle,
         shutdown_tx: Some(shutdown_tx),
+        request_rx: Mutex::new(Some(request_rx)),
+        listening: AtomicBool::new(true),
     });
 
     // Fire the user's `(err, address) => { ... }` callback — null
@@ -283,22 +310,112 @@ pub unsafe extern "C" fn js_fastify_listen(app_handle: Handle, opts: f64, callba
 
     println!("Server listening on http://0.0.0.0:{}", port);
 
-    // Enter the main event loop — drain pending requests + dispatch
-    // to user handlers until the process exits.
-    let mut request_rx = request_rx;
-    event_loop(app_handle, &mut request_rx);
+    // `listen()` is now non-blocking — the accept loop is already
+    // spawned above, and `js_fastify_process_pending` drains pending
+    // requests from the registered handle on every tick of
+    // perry-stdlib's main pump. Pre-fix this function entered the
+    // blocking `event_loop(...)` and never returned, so
+    // `await app.listen(...)` in user code never resumed — every
+    // subsequent line (the in-process `fetch` against itself,
+    // `app.close()`, etc.) was unreachable.
 }
 
-/// Close the server by dropping the registered handle.
+/// Close one specific server by its `FastifyServerHandle` id. Marks
+/// the server as no-longer-listening (so `js_fastify_has_active`
+/// stops reporting it as active), drops the request receiver, and
+/// fires the shutdown oneshot so the accept loop exits. Idempotent —
+/// safe to call multiple times.
 #[no_mangle]
 pub unsafe extern "C" fn js_fastify_close(server_handle: Handle) -> bool {
-    if let Some(_server) = get_handle::<FastifyServerHandle>(server_handle) {
-        // Shutdown sender drops when the handle is dropped — the
-        // accept loop's `tokio::select!` picks up the channel close
-        // and terminates. Simpler than threading the sender out.
+    if let Some(server) = get_handle_mut::<FastifyServerHandle>(server_handle) {
+        server.listening.store(false, Ordering::Release);
+        *server.request_rx.lock().unwrap() = None;
+        if let Some(tx) = server.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
         return true;
     }
     false
+}
+
+/// `app.close()` — close every server bound to `app_handle`. Walks the
+/// handle registry for matching `FastifyServerHandle` rows and marks
+/// each as no-longer listening so `js_fastify_has_active` lets the
+/// runtime's event loop exit. Returns void — TS-side dispatch arm
+/// just discards the result.
+#[no_mangle]
+pub unsafe extern "C" fn js_fastify_app_close(app_handle: Handle) {
+    let mut server_ids: Vec<Handle> = Vec::new();
+    iter_handle_ids_of::<FastifyServerHandle, _>(|id| {
+        if let Some(s) = get_handle::<FastifyServerHandle>(id) {
+            if s.app_handle == app_handle {
+                server_ids.push(id);
+            }
+        }
+    });
+    for id in server_ids {
+        let _ = js_fastify_close(id);
+    }
+}
+
+/// Pump entrypoint — drain pending requests from every registered
+/// `FastifyServerHandle` and dispatch each on the main TS thread.
+/// Wired into perry-stdlib's `js_stdlib_process_pending` via the
+/// `external-fastify-pump` feature so the runtime's outer event loop
+/// drives us each tick.
+///
+/// Returns the number of requests processed (matches the convention
+/// other pump arms follow — `js_ws_process_pending`,
+/// `js_node_http_server_process_pending`, etc.).
+#[no_mangle]
+pub extern "C" fn js_fastify_process_pending() -> i32 {
+    let mut server_handles: Vec<Handle> = Vec::new();
+    iter_handle_ids_of::<FastifyServerHandle, _>(|id| {
+        server_handles.push(id);
+    });
+    let mut count = 0i32;
+    for h in server_handles {
+        let app_handle = match get_handle::<FastifyServerHandle>(h) {
+            Some(s) => s.app_handle,
+            None => continue,
+        };
+        loop {
+            let pending = match get_handle::<FastifyServerHandle>(h) {
+                Some(s) => {
+                    let mut guard = s.request_rx.lock().unwrap();
+                    match guard.as_mut() {
+                        Some(rx) => rx.try_recv().ok(),
+                        None => None,
+                    }
+                }
+                None => None,
+            };
+            let pending = match pending {
+                Some(p) => p,
+                None => break,
+            };
+            process_request(app_handle, pending);
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Reports whether any registered fastify server is currently in the
+/// "listening" state. Wired into perry-stdlib's
+/// `js_stdlib_has_active_handles` so the runtime's main event loop
+/// keeps running until the user explicitly closes every server.
+#[no_mangle]
+pub extern "C" fn js_fastify_has_active() -> i32 {
+    let mut active = 0i32;
+    iter_handle_ids_of::<FastifyServerHandle, _>(|id| {
+        if let Some(s) = get_handle::<FastifyServerHandle>(id) {
+            if s.listening.load(Ordering::Acquire) {
+                active = 1;
+            }
+        }
+    });
+    active
 }
 
 // ============================================================================
@@ -392,60 +509,6 @@ async fn handle_request(
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body(Full::new(Bytes::from("Handler error")))
             .unwrap()),
-    }
-}
-
-/// Main thread event loop — drains pending requests and runs user
-/// handlers (and lifecycle hooks) synchronously.
-fn event_loop(app_handle: Handle, request_rx: &mut mpsc::Receiver<FastifyPendingRequest>) {
-    loop {
-        // Pump stdlib so perry-ext-{ws,net,http,fetch} events that
-        // accumulated on tokio workers get dispatched on the JS main
-        // thread. Without this, listeners registered before
-        // `app.listen()` (e.g. `wss.on('connection', ...)` against a
-        // separate WebSocketServer) never see incoming traffic. See
-        // #747 — and #746, whose symptom is the same in any program
-        // that combines `fastify` with `ws` / `net` / `http`.
-        unsafe {
-            js_run_stdlib_pump();
-        }
-
-        // Drain microtasks queued by previous handler runs.
-        unsafe {
-            js_promise_run_microtasks();
-        }
-
-        // Try to receive a request with a 10ms timeout. Keeps the
-        // event loop responsive without busy-spinning.
-        let result = match try_recv_with_timeout(request_rx) {
-            Some(p) => p,
-            None => continue,
-        };
-
-        process_request(app_handle, result);
-    }
-}
-
-/// Receive a pending request, blocking up to 10ms. We can't easily
-/// re-enter perry-stdlib's tokio runtime from this thread (we're
-/// outside any tokio context here), so we use `try_recv` in a tight
-/// loop with a small `thread::sleep`.
-fn try_recv_with_timeout(
-    request_rx: &mut mpsc::Receiver<FastifyPendingRequest>,
-) -> Option<FastifyPendingRequest> {
-    use std::time::{Duration, Instant};
-    let deadline = Instant::now() + Duration::from_millis(10);
-    loop {
-        match request_rx.try_recv() {
-            Ok(p) => return Some(p),
-            Err(mpsc::error::TryRecvError::Disconnected) => return None,
-            Err(mpsc::error::TryRecvError::Empty) => {
-                if Instant::now() >= deadline {
-                    return None;
-                }
-                std::thread::sleep(Duration::from_micros(200));
-            }
-        }
     }
 }
 

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -154,6 +154,18 @@ external-http-server-pump = ["async-runtime"]
 # the program exits before any callback fires. Issue #769.
 external-http-client-pump = ["async-runtime"]
 
+# Activated by `optimized_libs::build_optimized_libs` when the well-known
+# flip routes `import 'fastify'` to perry-ext-fastify (which is the
+# default path for the bundled-fastify feature). Tells perry-stdlib's
+# `js_stdlib_process_pending` / `js_stdlib_has_active_handles` to call
+# into perry-ext-fastify's `js_fastify_process_pending` /
+# `js_fastify_has_active` externs each tick. Without this, the
+# (now non-blocking) `listen()` returns but no main-thread code ever
+# drains pending requests — programs that combine fastify with an
+# in-process `fetch` against itself, lifecycle hooks, or async route
+# handlers hang. Mirrors `external-http-server-pump`.
+external-fastify-pump = ["async-runtime"]
+
 # TLS — direct `tls.connect()` and `socket.upgradeToTLS()` (Postgres SSLRequest flow).
 # Uses rustls (not native-tls) to avoid OpenSSL on every platform and keep Android
 # cross-compile unblocked; matches reqwest/tokio-tungstenite/mongodb feature flags.

--- a/crates/perry-stdlib/src/common/async_bridge.rs
+++ b/crates/perry-stdlib/src/common/async_bridge.rs
@@ -432,6 +432,34 @@ pub extern "C" fn js_stdlib_process_pending() -> i32 {
     // reader's queue and dispatches to question/line/close callbacks.
     count += crate::readline::js_readline_process_pending();
 
+    // Process pending fastify requests. With the bundled-fastify
+    // adapter, `app.listen()` used to block the main TS thread inside
+    // its own inner event loop forever, so an `await app.listen(...)`
+    // never returned and no subsequent user code (in-process `fetch`,
+    // `app.close()`, etc.) ever ran. The pump now mirrors how
+    // perry-ext-http-server handles dispatch (#604): `listen()` returns
+    // immediately and the per-server mpsc is drained here on each tick.
+    //
+    // Two activation paths:
+    //   * `http-server` — the bundled adapter (`perry-stdlib::fastify`)
+    //     is compiled in. Call its pump directly.
+    //   * `external-fastify-pump` — the well-known flip routed
+    //     `import 'fastify'` to perry-ext-fastify and stripped
+    //     `bundled-fastify`. The symbol is provided by the external
+    //     crate; declare and call it via extern. Mirrors how
+    //     `external-net-pump` and `external-ws-pump` work.
+    #[cfg(feature = "http-server")]
+    {
+        count += crate::fastify::js_fastify_process_pending();
+    }
+    #[cfg(all(feature = "external-fastify-pump", not(feature = "http-server")))]
+    {
+        extern "C" {
+            fn js_fastify_process_pending() -> i32;
+        }
+        count += unsafe { js_fastify_process_pending() };
+    }
+
     count
 }
 
@@ -563,6 +591,31 @@ pub extern "C" fn js_stdlib_has_active_handles() -> i32 {
     // / `rl.question()` programs don't exit before the user types.
     if crate::readline::js_readline_has_active() != 0 {
         return 1;
+    }
+    // Bundled-fastify — keep the loop alive while any FastifyServerHandle
+    // is in the "listening" state. Paired with
+    // `js_fastify_process_pending` in `js_stdlib_process_pending` above
+    // (closes the compat-sweep timeout for `await app.listen(...)` +
+    // in-process `fetch`).
+    #[cfg(feature = "http-server")]
+    {
+        if crate::fastify::js_fastify_has_active_handles() != 0 {
+            return 1;
+        }
+    }
+    // External fastify (perry-ext-fastify) — when the well-known flip
+    // routes `import 'fastify'` to perry-ext-fastify and strips
+    // `bundled-fastify`, the symbol below is provided by the external
+    // crate at link time. Mirrors the `external-{net,ws,http-server}-pump`
+    // arms above.
+    #[cfg(all(feature = "external-fastify-pump", not(feature = "http-server")))]
+    {
+        extern "C" {
+            fn js_fastify_has_active() -> i32;
+        }
+        if unsafe { js_fastify_has_active() } != 0 {
+            return 1;
+        }
     }
     0
 }

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -68,6 +68,7 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
             | "setErrorHandler"
             | "register"
             | "listen"
+            | "close"
     ) && with_handle::<crate::fastify::FastifyApp, bool, _>(handle, |_| true).unwrap_or(false)
     {
         return dispatch_fastify_app(handle, method_name, args);
@@ -397,6 +398,17 @@ unsafe fn dispatch_fastify_app(handle: i64, method: &str, args: &[f64]) -> f64 {
                 0
             };
             crate::fastify::js_fastify_listen(handle, args[0], callback);
+            f64::from_bits(0x7FF8_0000_0000_0001) // undefined (void)
+        }
+        "close" => {
+            // `app.close()` — shut down every server bound to this
+            // FastifyApp. Walks the handle registry for matching
+            // `FastifyServerHandle` rows and marks each as no-longer
+            // listening so `js_fastify_has_active_handles` lets the
+            // runtime's event loop exit. Pre-fix `close` was not
+            // routed here — fell through to "unknown method" and was a
+            // no-op, so the server kept the loop alive forever.
+            crate::fastify::js_fastify_app_close(handle);
             f64::from_bits(0x7FF8_0000_0000_0001) // undefined (void)
         }
         _ => {

--- a/crates/perry-stdlib/src/common/handle.rs
+++ b/crates/perry-stdlib/src/common/handle.rs
@@ -106,6 +106,25 @@ where
     }
 }
 
+/// Like `for_each_handle_of`, but yields handle ids instead of refs.
+/// Callers need the id so they can later mutate the entry (`get_handle_mut`)
+/// or call `take_handle`/`drop_handle` — neither of which is possible
+/// while holding the iterator's read lock on the DashMap. The fastify
+/// pump uses this to drain per-server `request_rx` channels without
+/// keeping the registry locked across the dispatch (which may itself
+/// register/drop handles).
+pub fn iter_handle_ids_of<T, F>(mut f: F)
+where
+    T: 'static + Send + Sync,
+    F: FnMut(Handle),
+{
+    for entry in HANDLES.iter() {
+        if entry.value().downcast_ref::<T>().is_some() {
+            f(*entry.key());
+        }
+    }
+}
+
 /// Clone a handle's value if it implements Clone
 pub fn clone_handle<T: 'static + Send + Sync + Clone>(handle: Handle) -> Option<Handle> {
     HANDLES.get(&handle).and_then(|entry| {

--- a/crates/perry-stdlib/src/fastify/server.rs
+++ b/crates/perry-stdlib/src/fastify/server.rs
@@ -11,14 +11,15 @@ use hyper_util::rt::TokioIo;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::os::raw::c_int;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 
 use perry_runtime::{js_string_from_bytes, JSValue, StringHeader};
 
 use super::{ClosurePtr, FastifyApp, FastifyContext};
-use crate::common::{get_handle, register_handle, Handle, RUNTIME};
+use crate::common::{for_each_handle_of, get_handle, register_handle, Handle, RUNTIME};
 
 struct ClosureCallResult {
     value: f64,
@@ -31,11 +32,32 @@ enum HookOutcome {
     Error(f64),
 }
 
-/// Server handle for managing the running server
+/// Server handle for managing the running server.
+///
+/// Closes the in-process fastify timeout from the compat sweep: pre-fix
+/// `js_fastify_listen` entered a blocking `event_loop` and never
+/// returned, so the user's `await app.listen(...)` never resumed and
+/// subsequent code (an in-process `fetch` against itself, `app.close`,
+/// etc.) never ran. The fix mirrors what perry-ext-http-server did in
+/// #604: `listen()` returns immediately after spawning the accept loop,
+/// and a new `js_fastify_process_pending` extern wired into
+/// perry-stdlib's main pump drains the per-server mpsc each tick. To
+/// support that, the receiver lives inside the handle instead of as a
+/// local stack variable of `event_loop`.
 pub struct FastifyServerHandle {
     pub port: u16,
     pub app_handle: Handle,
     pub shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    /// Drained by `js_fastify_process_pending` from the main TS thread
+    /// each tick. `Mutex` because the handle registry hands out `&'static`
+    /// references but the pump needs `&mut` access to `try_recv` and we
+    /// can't statically prove the pump is the only mutator.
+    pub request_rx: Mutex<Option<mpsc::Receiver<FastifyPendingRequest>>>,
+    /// True between `listen()` and `close()`. The
+    /// `js_fastify_has_active` extern returns 1 while any server has
+    /// this set, keeping the runtime's main event loop alive until
+    /// the user explicitly closes the server.
+    pub listening: AtomicBool,
 }
 
 /// Pending request waiting for TypeScript handler
@@ -78,7 +100,7 @@ pub unsafe extern "C" fn js_fastify_listen(app_handle: Handle, opts: f64, callba
         }
     };
 
-    let (request_tx, mut request_rx) = mpsc::channel::<FastifyPendingRequest>(1024);
+    let (request_tx, request_rx) = mpsc::channel::<FastifyPendingRequest>(1024);
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
     let request_tx = Arc::new(request_tx);
@@ -159,12 +181,23 @@ pub unsafe extern "C" fn js_fastify_listen(app_handle: Handle, opts: f64, callba
         }
     });
 
-    // Store server handle
+    // Store server handle — includes the request receiver so the
+    // main-thread pump (`js_fastify_process_pending`) can drain it.
     let _server_handle = register_handle(FastifyServerHandle {
         port,
         app_handle,
         shutdown_tx: Some(shutdown_tx),
+        request_rx: Mutex::new(Some(request_rx)),
+        listening: AtomicBool::new(true),
     });
+
+    // Make sure the perry-stdlib pump is registered with the runtime
+    // so the main event loop calls `js_stdlib_process_pending` /
+    // `js_stdlib_has_active_handles` each tick. Programs that never
+    // touched another async stdlib feature before `listen()` (the
+    // compat-sweep fixture is exactly this shape) would otherwise sit
+    // idle with the pump unregistered.
+    crate::common::ensure_pump_registered();
 
     // Call callback with (null, address)
     if callback != 0 {
@@ -183,8 +216,13 @@ pub unsafe extern "C" fn js_fastify_listen(app_handle: Handle, opts: f64, callba
 
     println!("Server listening on http://0.0.0.0:{}", port);
 
-    // Enter the main event loop
-    event_loop(app_handle, &mut request_rx);
+    // `listen()` is now non-blocking — the accept loop is already
+    // spawned above, and `js_fastify_process_pending` drains pending
+    // requests from the registered handle on every tick of the main
+    // event loop. Pre-fix this function called `event_loop(...)` and
+    // never returned, so `await app.listen(...)` in user code never
+    // resumed — every subsequent line (the in-process `fetch` against
+    // itself, `app.close()`, etc.) was unreachable.
 }
 
 /// Handle incoming HTTP request - match route and forward to TypeScript
@@ -286,51 +324,143 @@ async fn handle_request(
     }
 }
 
-/// Main event loop - process incoming requests
-fn event_loop(app_handle: Handle, request_rx: &mut mpsc::Receiver<FastifyPendingRequest>) {
+/// Pump entrypoint — drain pending requests from every registered
+/// `FastifyServerHandle` and dispatch each to the user's route handler
+/// + hooks on the main TS thread. Wired into perry-stdlib's
+/// `js_stdlib_process_pending` so the runtime's outer event loop drives
+/// us each tick.
+///
+/// Returns the number of requests processed (matches the convention
+/// other pump arms follow — `js_ws_process_pending`,
+/// `js_node_http_server_process_pending`, etc.).
+pub fn js_fastify_process_pending() -> i32 {
+    // Snapshot handle ids so we don't hold a DashMap iterator across
+    // the dispatch — handler calls may register/drop other handles.
+    let mut server_handles: Vec<Handle> = Vec::new();
+    crate::common::iter_handle_ids_of::<FastifyServerHandle, _>(|id| {
+        server_handles.push(id);
+    });
+
+    let mut count = 0i32;
+    for h in server_handles {
+        // Snapshot the app handle inside the borrow scope.
+        let app_handle = match get_handle::<FastifyServerHandle>(h) {
+            Some(s) => s.app_handle,
+            None => continue,
+        };
+        loop {
+            // try_recv against the per-server channel. Holds the
+            // mutex only briefly so concurrent close() (which the
+            // handler chain may invoke) can still take the rx out.
+            let pending = match get_handle::<FastifyServerHandle>(h) {
+                Some(s) => {
+                    let mut guard = s.request_rx.lock().unwrap();
+                    match guard.as_mut() {
+                        Some(rx) => match rx.try_recv() {
+                            Ok(p) => Some(p),
+                            Err(_) => None,
+                        },
+                        None => None,
+                    }
+                }
+                None => None,
+            };
+            let pending = match pending {
+                Some(p) => p,
+                None => break,
+            };
+            process_fastify_request(app_handle, pending);
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Reports whether any registered fastify server is currently in the
+/// "listening" state. Wired into perry-stdlib's
+/// `js_stdlib_has_active_handles` so the runtime's main event loop
+/// keeps running until the user explicitly closes every server. Without
+/// this, the runtime would see no active sources after the user's
+/// `main()` returns control to the loop and exit immediately — the
+/// accept task would be torn down before the first request could be
+/// dispatched.
+pub fn js_fastify_has_active_handles() -> i32 {
+    let mut active = 0i32;
+    for_each_handle_of::<FastifyServerHandle, _>(|s| {
+        if s.listening.load(Ordering::Acquire) {
+            active = 1;
+        }
+    });
+    active
+}
+
+/// Shared dispatch path used by both the (now removed) blocking
+/// event loop and the new pump entrypoint. Extracted into a free
+/// function so the pump can call it without re-binding to a specific
+/// `FastifyServerHandle` row in the registry.
+fn process_fastify_request(app_handle: Handle, pending: FastifyPendingRequest) {
     let app = match get_handle::<FastifyApp>(app_handle) {
         Some(a) => a,
         None => return,
     };
+    process_fastify_request_with_app(app, pending);
+}
 
-    loop {
-        // Process any pending stdlib operations (promises, etc.)
-        crate::common::js_stdlib_process_pending();
+/// Per-request dispatch — kept as a closure-style block matching the
+/// previous `if let Ok(Some(pending)) = result { ... }` body, with
+/// only the `loop {}` wrapper removed.
+fn process_fastify_request_with_app(app: &FastifyApp, pending: FastifyPendingRequest) {
+    // Process any pending microtasks before dispatching.
+    perry_runtime::js_promise_run_microtasks();
 
-        // Process any pending microtasks
-        perry_runtime::js_promise_run_microtasks();
+    {
+        // Create context
+        let ctx = FastifyContext::new(
+            0, // request_id
+            pending.method.clone(),
+            pending.path.clone(),
+            pending.headers.clone(),
+            pending.body.clone(),
+            pending.params.clone(),
+        );
+        let ctx_handle = register_handle(ctx);
 
-        // Try to receive a request (non-blocking with small timeout)
-        let result = RUNTIME.block_on(async {
-            tokio::time::timeout(std::time::Duration::from_millis(10), request_rx.recv()).await
-        });
+        // Find matching route and call handler
+        let error_handler = app.error_handler;
+        let mut response_sent = false;
 
-        if let Ok(Some(pending)) = result {
-            // Create context
-            let ctx = FastifyContext::new(
-                0, // request_id
-                pending.method.clone(),
-                pending.path.clone(),
-                pending.headers.clone(),
-                pending.body.clone(),
-                pending.params.clone(),
-            );
-            let ctx_handle = register_handle(ctx);
+        // NaN-box the context handle with POINTER_TAG for hook calls
+        let nanboxed_ctx_for_hooks =
+            f64::from_bits(0x7FFD_0000_0000_0000 | (ctx_handle as u64 & 0x0000_FFFF_FFFF_FFFF));
 
-            // Find matching route and call handler
-            let error_handler = app.error_handler;
-            let mut response_sent = false;
+        // Collect hook ptrs (copy i64 values to avoid holding borrow on app during hook execution)
+        let on_request_hooks: Vec<ClosurePtr> = app.hooks.on_request.to_vec();
+        let pre_handler_hooks: Vec<ClosurePtr> = app.hooks.pre_handler.to_vec();
 
-            // NaN-box the context handle with POINTER_TAG for hook calls
-            let nanboxed_ctx_for_hooks =
-                f64::from_bits(0x7FFD_0000_0000_0000 | (ctx_handle as u64 & 0x0000_FFFF_FFFF_FFFF));
+        // Run onRequest hooks (e.g., auth middleware, rate limiting, CORS)
+        for hook in &on_request_hooks {
+            match unsafe { call_hook_awaiting(*hook, nanboxed_ctx_for_hooks, ctx_handle) } {
+                HookOutcome::Continue => {}
+                HookOutcome::Sent => {
+                    response_sent = true;
+                    break;
+                }
+                HookOutcome::Error(reason) => {
+                    handle_error_response(
+                        error_handler,
+                        nanboxed_ctx_for_hooks,
+                        ctx_handle,
+                        reason,
+                    );
+                    response_sent = true;
+                    break;
+                }
+            }
+        }
 
-            // Collect hook ptrs (copy i64 values to avoid holding borrow on app during hook execution)
-            let on_request_hooks: Vec<ClosurePtr> = app.hooks.on_request.to_vec();
-            let pre_handler_hooks: Vec<ClosurePtr> = app.hooks.pre_handler.to_vec();
-
-            // Run onRequest hooks (e.g., auth middleware, rate limiting, CORS)
-            for hook in &on_request_hooks {
+        // Run preHandler hooks (if no response sent yet)
+        if !response_sent {
+            for hook in &pre_handler_hooks {
                 match unsafe { call_hook_awaiting(*hook, nanboxed_ctx_for_hooks, ctx_handle) } {
                     HookOutcome::Continue => {}
                     HookOutcome::Sent => {
@@ -349,133 +479,101 @@ fn event_loop(app_handle: Handle, request_rx: &mut mpsc::Receiver<FastifyPending
                     }
                 }
             }
-
-            // Run preHandler hooks (if no response sent yet)
-            if !response_sent {
-                for hook in &pre_handler_hooks {
-                    match unsafe { call_hook_awaiting(*hook, nanboxed_ctx_for_hooks, ctx_handle) } {
-                        HookOutcome::Continue => {}
-                        HookOutcome::Sent => {
-                            response_sent = true;
-                            break;
-                        }
-                        HookOutcome::Error(reason) => {
-                            handle_error_response(
-                                error_handler,
-                                nanboxed_ctx_for_hooks,
-                                ctx_handle,
-                                reason,
-                            );
-                            response_sent = true;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // Call route handler (if no hook sent a response)
-            // undefined NaN-box value: tag 0x7FFC, payload 1
-            let undefined_bits: u64 = 0x7FFC_0000_0000_0001;
-            let mut final_result: f64 = f64::from_bits(undefined_bits);
-
-            if !response_sent {
-                if let Some((route, _)) = app.match_route(&pending.method, &pending.path) {
-                    let handler = route.handler;
-
-                    // NaN-box the context handle with POINTER_TAG so it can be dispatched
-                    // by js_native_call_method when the handler calls request/reply methods
-                    let nanboxed_ctx = nanboxed_ctx_for_hooks; // same value, different name for clarity
-
-                    // Call handler(request, reply) - both are the context handle
-                    let call = {
-                        let closure_ptr = handler as *const perry_runtime::ClosureHeader;
-                        unsafe { call_closure2_catching(closure_ptr, nanboxed_ctx, nanboxed_ctx) }
-                    };
-                    if let Some(reason) = call.thrown {
-                        handle_error_response(error_handler, nanboxed_ctx, ctx_handle, reason);
-                        response_sent = true;
-                    }
-
-                    // Process any async operations
-                    crate::common::js_stdlib_process_pending();
-                    perry_runtime::js_promise_run_microtasks();
-
-                    // Check if handler returned a promise (NaN-boxed pointer to a Promise)
-                    if !response_sent {
-                        final_result = call.value;
-                    }
-                    let jsv = JSValue::from_bits(call.value.to_bits());
-                    if !response_sent && jsv.is_pointer() {
-                        let ptr = jsv.as_pointer::<perry_runtime::Promise>();
-                        // Try to treat it as a promise and wait for it
-                        if { perry_runtime::js_is_promise(ptr as *mut perry_runtime::Promise) } != 0
-                        {
-                            wait_for_promise(ptr as *mut perry_runtime::Promise);
-                            // Read state AFTER the wait — `js_promise_value`
-                            // returns `(*promise).value` unconditionally and
-                            // that field stays at `0.0` for rejected and
-                            // pending promises (rejection writes `reason`,
-                            // not `value`). Without this branch, an
-                            // unhandled rejection inside a route handler
-                            // would serialize the literal byte `0` as the
-                            // response body — issue #748.
-                            let st = {
-                                perry_runtime::js_promise_state(ptr as *mut perry_runtime::Promise)
-                            };
-                            if st == 2 {
-                                let reason = {
-                                    perry_runtime::promise::js_promise_reason(
-                                        ptr as *mut perry_runtime::Promise,
-                                    )
-                                };
-                                handle_error_response(
-                                    error_handler,
-                                    nanboxed_ctx,
-                                    ctx_handle,
-                                    reason,
-                                );
-                                final_result = f64::from_bits(0x7FFC_0000_0000_0001);
-                            } else {
-                                final_result = {
-                                    perry_runtime::js_promise_value(
-                                        ptr as *mut perry_runtime::Promise,
-                                    )
-                                };
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Always send a response (from hook or route handler)
-            if let Some(ctx) = get_handle::<FastifyContext>(ctx_handle) {
-                let response = FastifyResponse {
-                    status: ctx.status_code,
-                    headers: ctx.response_headers.clone(),
-                    body: ctx.response_body.clone().unwrap_or_else(|| {
-                        // If no explicit body, use handler return value
-                        build_response_body(final_result)
-                    }),
-                };
-
-                // Ensure content-type is set
-                let mut final_response = response;
-                if !final_response
-                    .headers
-                    .iter()
-                    .any(|(k, _)| k.to_lowercase() == "content-type")
-                {
-                    final_response
-                        .headers
-                        .push(("content-type".to_string(), "application/json".to_string()));
-                }
-
-                let _ = pending.response_tx.send(final_response);
-                response_sent = true;
-            }
-
-            let _ = response_sent; // suppress unused warning
         }
+
+        // Call route handler (if no hook sent a response)
+        // undefined NaN-box value: tag 0x7FFC, payload 1
+        let undefined_bits: u64 = 0x7FFC_0000_0000_0001;
+        let mut final_result: f64 = f64::from_bits(undefined_bits);
+
+        if !response_sent {
+            if let Some((route, _)) = app.match_route(&pending.method, &pending.path) {
+                let handler = route.handler;
+
+                // NaN-box the context handle with POINTER_TAG so it can be dispatched
+                // by js_native_call_method when the handler calls request/reply methods
+                let nanboxed_ctx = nanboxed_ctx_for_hooks; // same value, different name for clarity
+
+                // Call handler(request, reply) - both are the context handle
+                let call = {
+                    let closure_ptr = handler as *const perry_runtime::ClosureHeader;
+                    unsafe { call_closure2_catching(closure_ptr, nanboxed_ctx, nanboxed_ctx) }
+                };
+                if let Some(reason) = call.thrown {
+                    handle_error_response(error_handler, nanboxed_ctx, ctx_handle, reason);
+                    response_sent = true;
+                }
+
+                // Process any async operations
+                crate::common::js_stdlib_process_pending();
+                perry_runtime::js_promise_run_microtasks();
+
+                // Check if handler returned a promise (NaN-boxed pointer to a Promise)
+                if !response_sent {
+                    final_result = call.value;
+                }
+                let jsv = JSValue::from_bits(call.value.to_bits());
+                if !response_sent && jsv.is_pointer() {
+                    let ptr = jsv.as_pointer::<perry_runtime::Promise>();
+                    // Try to treat it as a promise and wait for it
+                    if { perry_runtime::js_is_promise(ptr as *mut perry_runtime::Promise) } != 0 {
+                        wait_for_promise(ptr as *mut perry_runtime::Promise);
+                        // Read state AFTER the wait — `js_promise_value`
+                        // returns `(*promise).value` unconditionally and
+                        // that field stays at `0.0` for rejected and
+                        // pending promises (rejection writes `reason`,
+                        // not `value`). Without this branch, an
+                        // unhandled rejection inside a route handler
+                        // would serialize the literal byte `0` as the
+                        // response body — issue #748.
+                        let st =
+                            { perry_runtime::js_promise_state(ptr as *mut perry_runtime::Promise) };
+                        if st == 2 {
+                            let reason = {
+                                perry_runtime::promise::js_promise_reason(
+                                    ptr as *mut perry_runtime::Promise,
+                                )
+                            };
+                            handle_error_response(error_handler, nanboxed_ctx, ctx_handle, reason);
+                            final_result = f64::from_bits(0x7FFC_0000_0000_0001);
+                        } else {
+                            final_result = {
+                                perry_runtime::js_promise_value(ptr as *mut perry_runtime::Promise)
+                            };
+                        }
+                    }
+                }
+            }
+        }
+
+        // Always send a response (from hook or route handler)
+        if let Some(ctx) = get_handle::<FastifyContext>(ctx_handle) {
+            let response = FastifyResponse {
+                status: ctx.status_code,
+                headers: ctx.response_headers.clone(),
+                body: ctx.response_body.clone().unwrap_or_else(|| {
+                    // If no explicit body, use handler return value
+                    build_response_body(final_result)
+                }),
+            };
+
+            // Ensure content-type is set
+            let mut final_response = response;
+            if !final_response
+                .headers
+                .iter()
+                .any(|(k, _)| k.to_lowercase() == "content-type")
+            {
+                final_response
+                    .headers
+                    .push(("content-type".to_string(), "application/json".to_string()));
+            }
+
+            let _ = pending.response_tx.send(final_response);
+            response_sent = true;
+        }
+
+        let _ = response_sent; // suppress unused warning
     }
 }
 
@@ -854,14 +952,47 @@ fn build_response_body(value: f64) -> Vec<u8> {
     b"{}".to_vec()
 }
 
-/// Close the server
+/// Close one specific server by its `FastifyServerHandle` id. Marks
+/// the server as no-longer-listening (so `js_fastify_has_active_handles`
+/// stops reporting it as active), drops the request receiver, and
+/// fires the shutdown oneshot so the accept loop exits. Idempotent —
+/// safe to call multiple times.
 #[no_mangle]
 pub unsafe extern "C" fn js_fastify_close(server_handle: Handle) -> bool {
-    if let Some(_server) = get_handle::<FastifyServerHandle>(server_handle) {
-        // Shutdown will be triggered when the handle is dropped
+    if let Some(server) = crate::common::get_handle_mut::<FastifyServerHandle>(server_handle) {
+        server.listening.store(false, Ordering::Release);
+        // Drop the receiver so `has_active` stops claiming pending
+        // requests as a reason to keep the loop alive.
+        *server.request_rx.lock().unwrap() = None;
+        // Trigger the accept loop's shutdown branch.
+        if let Some(tx) = server.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        // Re-balance the `js_gc_enter_unsafe_zone` from listen().
+        perry_runtime::gc::js_gc_exit_unsafe_zone();
         return true;
     }
     false
+}
+
+/// Mark every server bound to `app_handle` as closed. Used by the
+/// `app.close()` dispatch arm — the user gets a single handle (the
+/// FastifyApp) and shouldn't have to track per-server handles to shut
+/// the listener down. Returns void — the codegen-side caller discards
+/// the result.
+#[no_mangle]
+pub unsafe extern "C" fn js_fastify_app_close(app_handle: Handle) {
+    let mut server_ids: Vec<Handle> = Vec::new();
+    crate::common::iter_handle_ids_of::<FastifyServerHandle, _>(|id| {
+        if let Some(s) = get_handle::<FastifyServerHandle>(id) {
+            if s.app_handle == app_handle {
+                server_ids.push(id);
+            }
+        }
+    });
+    for id in server_ids {
+        let _ = js_fastify_close(id);
+    }
 }
 
 #[cfg(test)]

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -343,6 +343,20 @@ pub(super) fn build_optimized_libs(
             if original_features.contains(&"bundled-ws") {
                 features.insert("external-ws-pump");
             }
+            // Same shape for fastify. The compat-sweep fastify fixture
+            // hit a hang at `await app.listen(...)` because
+            // perry-ext-fastify's `js_fastify_listen` entered a blocking
+            // event loop that never returned. With `listen()` now non-
+            // blocking, the per-server mpsc receiver lives inside the
+            // FastifyServerHandle and is drained by
+            // `js_fastify_process_pending`. Activating this feature
+            // wires that pump call into perry-stdlib's
+            // `js_stdlib_process_pending` / `_has_active_handles` so
+            // requests flow on the main TS thread once the flip routes
+            // `import 'fastify'` to perry-ext-fastify.
+            if original_features.contains(&"bundled-fastify") {
+                features.insert("external-fastify-pump");
+            }
             // Closes #604 — when the well-known flip routes `node:http` /
             // `node:https` / `node:http2` to perry-ext-http (which bundles
             // perry-ext-http-server), activate `external-http-server-pump`

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 927 entries across 74 modules
+// Coverage: 928 entries across 74 modules
 
 declare module "@perryts/google-auth" {
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 927 entries across 74 modules.
+Total: 928 entries across 74 modules.
 
 ## Modules
 
@@ -407,6 +407,7 @@ Total: 927 entries across 74 modules.
 - `addHook` — instance
 - `all` — instance
 - `body` — instance
+- `close` — instance
 - `code` — instance
 - `default` — module
 - `delete` — instance

--- a/test-files/test_fastify_in_process.ts
+++ b/test-files/test_fastify_in_process.ts
@@ -1,0 +1,29 @@
+// In-process fastify smoke test mirroring the
+// /tmp/perry-compat-sweep/fastify/entry.ts fixture.
+//
+// Pre-fix `js_fastify_listen` (in both perry-stdlib's bundled adapter
+// AND perry-ext-fastify) entered a blocking inner event loop and never
+// returned, so `await app.listen(...)` never resumed — the in-process
+// `fetch` against the same process never even started and the program
+// timed out at gtimeout(30s) with rc=124.
+//
+// After the fix, `listen()` returns immediately and the per-server
+// mpsc receiver is drained from perry-stdlib's main pump on every
+// tick. The handler runs on the main TS thread, the response flows
+// back through hyper, the in-process fetch resolves, and `app.close()`
+// flips the listening flag so `js_stdlib_has_active_handles` lets the
+// runtime exit.
+import Fastify from "fastify";
+
+const app = Fastify();
+app.get("/ping", async () => ({ ok: true }));
+
+async function main() {
+  await app.listen({ port: 18933 });
+  const r = await fetch("http://127.0.0.1:18933/ping");
+  const j = (await r.json()) as { ok: boolean };
+  console.log("ok=" + j.ok);
+  await app.close();
+}
+
+main();


### PR DESCRIPTION
## Summary

Closes the in-process fastify timeout from the compat sweep. `/tmp/perry-compat-sweep/fastify/entry.ts` was hanging at `Server listening on http://0.0.0.0:18932` until `gtimeout 30s` killed it (rc=124). Now exits cleanly with `ok=true`.

## Root cause

`js_fastify_listen` (in BOTH perry-stdlib's bundled adapter `crates/perry-stdlib/src/fastify/server.rs` AND perry-ext-fastify `crates/perry-ext-fastify/src/server.rs`) entered a blocking inner `event_loop(...)` that never returned, so:

```ts
await app.listen({ port: 18932 });   // never resumed
const r = await fetch("http://127.0.0.1:18932/ping");  // unreachable
const j = await r.json();             // unreachable
console.log("ok=" + j.ok);            // unreachable
await app.close();                    // unreachable
```

This is the same shape of bug that #604 fixed for `node:http` in `perry-ext-http-server`. Apply that pattern to fastify.

## Fix

- `listen()` returns immediately after spawning the accept loop.
- Per-server mpsc receiver moved from the `event_loop` stack into `FastifyServerHandle` (Mutex<Option<...>>) so the main pump can find it.
- New `js_fastify_process_pending` drains pending requests from every registered handle each tick. Wired into perry-stdlib's `js_stdlib_process_pending`.
- New `js_fastify_has_active` keeps the runtime's main event loop alive while any server is in the "listening" state. Wired into perry-stdlib's `js_stdlib_has_active_handles`.
- `app.close()` previously fell through to "unknown native method" and silently no-op'd. Added an entry to the codegen `NATIVE_MODULE_TABLE` routing to a new `js_fastify_app_close` that walks the handle registry for matching servers, flips their listening flag, drops their rx, and fires shutdown — so the runtime exits naturally after the user calls close.
- New `external-fastify-pump` feature, activated by the well-known flip when `bundled-fastify` is stripped (`import 'fastify'` → perry-ext-fastify). Mirrors `external-{net,ws,http-server}-pump`.

## Files touched

- `crates/perry-stdlib/src/fastify/server.rs` — non-blocking listen, new process_pending/has_active, app_close
- `crates/perry-ext-fastify/src/server.rs` — same shape for the external crate
- `crates/perry-stdlib/Cargo.toml` — new `external-fastify-pump` feature
- `crates/perry-stdlib/src/common/async_bridge.rs` — wire the new pump and has-active gate
- `crates/perry-stdlib/src/common/dispatch.rs` — route `app.close()` runtime dispatch
- `crates/perry-stdlib/src/common/handle.rs` — new `iter_handle_ids_of` helper
- `crates/perry-codegen/src/lower_call.rs` — new fastify `close` entry in NATIVE_MODULE_TABLE
- `crates/perry-codegen/src/runtime_decls.rs` — declare `js_fastify_app_close`
- `crates/perry/src/commands/compile/optimized_libs.rs` — activate `external-fastify-pump` on the flip
- `test-files/test_fastify_in_process.ts` — new smoke test mirroring the compat-sweep fixture

## Test plan

- [x] Compat-sweep fastify fixture now passes (rc=0, prints `ok=true`).
- [x] Output matches Node: `ok=true`.
- [x] `scripts/run_fastify_tests.sh` end-to-end suite passes (10/10 routes).
- [x] `cargo test --release -p perry-stdlib --lib fastify` — 22/22 fastify unit tests pass.
- [x] `test-files/test_fastify_in_process.ts` (new) compiles and runs to `ok=true` rc=0.

No version bump or changelog change (maintainer folds those in at merge time).