### PR TITLE
test(async): extend #1013 coverage to cross-module property-return shape

### DIFF
--- a/test-files/fixtures/issue_1013/user_lookup.ts
+++ b/test-files/fixtures/issue_1013/user_lookup.ts
@@ -1,0 +1,34 @@
+// #1013 coverage fixture: cross-module async helpers that await an
+// inner lookup and return a property read off the resolved value.
+// This is the exact shape the reporter saw fail in gscmaster-api —
+// same-file fixtures don't exercise it because the importer-side
+// closure resolution lives in the same module as the helpers.
+
+type User = { id: string; accessToken: string; plan: string };
+
+async function lookupUser(userId: string): Promise<User | null> {
+    // A trivial inner await to keep the helper async-shaped; the
+    // outer `await Promise.all([getAccessToken(...), getUserPlan(...)])`
+    // is what the regression targets.
+    const users: Record<string, User> = {
+        u1: { id: "u1", accessToken: "tok-256-chars-aaaaaaaaaaaaa", plan: "pro" },
+    };
+    await Promise.resolve(null);
+    return users[userId] ?? null;
+}
+
+export async function getAccessToken(userId: string): Promise<string | null> {
+    const user = await lookupUser(userId);
+    if (!user) return null;
+    // Property-read return — the original repro's smoking gun. The
+    // returned value crosses an async-step frame boundary; before #1007
+    // the property read landed in a stale NaN-boxed slot at the
+    // destructure site.
+    return user.accessToken;
+}
+
+export async function getUserPlan(userId: string): Promise<{ plan: string } | null> {
+    const user = await lookupUser(userId);
+    if (!user) return null;
+    return { plan: user.plan };
+}

--- a/test-files/test_issue_1013_promise_all_destructure.ts
+++ b/test-files/test_issue_1013_promise_all_destructure.ts
@@ -19,6 +19,8 @@
 // of either the HIR collapse or the codegen `is_global_constructor_expr`
 // helper fails immediately.
 
+import { getAccessToken, getUserPlan } from "./fixtures/issue_1013/user_lookup.ts";
+
 async function fetchA(): Promise<string> {
     return "hello-from-A";
 }
@@ -28,10 +30,23 @@ async function fetchB(): Promise<{ plan: string }> {
 }
 
 async function main() {
+    // Same-file literal-return shape — covers the dispatch bug.
     const [a, b] = await Promise.all([fetchA(), fetchB()]);
     console.log("a:", JSON.stringify(a), "typeof:", typeof a);
     console.log("b:", JSON.stringify(b), "typeof:", typeof b);
     console.log("b.plan:", b?.plan);
+
+    // Cross-module async helpers returning property reads off the
+    // resolved value — the exact shape from the original gscmaster-api
+    // repro. Covers the full #1013 surface, not just the dispatch
+    // path. (See PR #1064 review feedback.)
+    const [accessToken, userPlan] = await Promise.all([
+        getAccessToken("u1"),
+        getUserPlan("u1"),
+    ]);
+    console.log("accessToken:", JSON.stringify(accessToken), "typeof:", typeof accessToken);
+    console.log("userPlan:", JSON.stringify(userPlan), "typeof:", typeof userPlan);
+    console.log("userPlan.plan:", userPlan?.plan);
 }
 
 main();


### PR DESCRIPTION
Follow-up to PR #1064 per @andrewtdiz's review feedback ([comment](https://github.com/PerryTS/perry/pull/1064#issuecomment-4484882844)).

PR #1064 pinned the same-file literal-return shape — covers the dispatch bug. The original gscmaster-api repro from #1013 used **cross-module imported async helpers** that awaited an inner lookup and returned **a property read** off the resolved value (`return user.accessToken`). That shape isn't exercised by the previous test.

This PR adds `test-files/fixtures/issue_1013/user_lookup.ts` exporting `getAccessToken` / `getUserPlan` against an inner `await lookupUser(id)`, each returning a property read. The test now destructures **both shapes** from `Promise.all`:

```ts
// same-file literal — covers dispatch
const [a, b] = await Promise.all([fetchA(), fetchB()]);

// cross-module property-return — original #1013 surface
const [accessToken, userPlan] = await Promise.all([
    getAccessToken("u1"),
    getUserPlan("u1"),
]);
```

Verified byte-for-byte against `node --experimental-strip-types`.

No version bump or changelog change.