### PR TITLE
fix(codegen): #321 — Effect.succeed via named-import-of-namespace-reexport

### DIFF
--- a/crates/perry-codegen/src/codegen.rs
+++ b/crates/perry-codegen/src/codegen.rs
@@ -166,6 +166,21 @@ pub struct CompileOptions {
     /// Codegen uses this to know that `X.foo()` should be dispatched as
     /// a cross-module call rather than an object method call.
     pub namespace_imports: Vec<String>,
+    /// Issue #321: subset of `namespace_imports` populated by the
+    /// "named import resolves to a `export * as Foo from "./Foo"`" branch
+    /// in `compile.rs`. When the user wrote `import { Effect } from
+    /// "effect"` and effect's index.ts has `export * as Effect from
+    /// "./Effect.js"`, Effect lands in `namespace_imports` (so member
+    /// dispatch works) AND in this set (so the StaticMethodCall codegen
+    /// arm knows it's safe to route var-shape members through
+    /// `js_closure_callN`). Plain `import * as Effect from "./Effect"`
+    /// (used heavily by effect's INTERNAL modules) populates only
+    /// `namespace_imports`, NOT this set — the pre-existing direct-call
+    /// path preserves their long-standing silently-wrong-but-doesn't-throw
+    /// behavior on var-shape static calls (the right fix there is a
+    /// broader audit; doing it together with the named-import fix
+    /// surfaces init-order issues hiding behind the silent-wrong shape).
+    pub namespace_reexport_named_imports: std::collections::HashSet<String>,
     /// Imported class definitions from other native modules, keyed by
     /// the local alias (or original name when no alias). Each entry
     /// carries the class HIR, the module prefix of its origin, and an
@@ -446,6 +461,8 @@ pub struct ImportedClass {
 /// Built once in `compile_module` from `CompileOptions`.
 pub(crate) struct CrossModuleCtx {
     pub namespace_imports: std::collections::HashSet<String>,
+    /// Issue #321: see `CompileOptions::namespace_reexport_named_imports`.
+    pub namespace_reexport_named_imports: std::collections::HashSet<String>,
     /// Issue #680: per-namespace member resolution. See doc on
     /// `CompileOptions::namespace_member_prefixes`.
     pub namespace_member_prefixes: std::collections::HashMap<(String, String), String>,
@@ -1341,6 +1358,7 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
     // Build the cross-module context bundle from CompileOptions.
     let cross_module = CrossModuleCtx {
         namespace_imports: opts.namespace_imports.iter().cloned().collect(),
+        namespace_reexport_named_imports: opts.namespace_reexport_named_imports.clone(),
         namespace_member_prefixes: opts.namespace_member_prefixes,
         imported_async_funcs: opts.imported_async_funcs,
         local_async_funcs,
@@ -3764,6 +3782,7 @@ fn compile_function(
         closure_rest_params,
         local_closure_func_ids: HashMap::new(),
         namespace_imports: &cross_module.namespace_imports,
+        namespace_reexport_named_imports: &cross_module.namespace_reexport_named_imports,
         namespace_member_prefixes: &cross_module.namespace_member_prefixes,
         imported_async_funcs: &cross_module.imported_async_funcs,
         local_async_funcs: &cross_module.local_async_funcs,
@@ -4155,6 +4174,7 @@ fn compile_closure(
         closure_rest_params,
         local_closure_func_ids: HashMap::new(),
         namespace_imports: &cross_module.namespace_imports,
+        namespace_reexport_named_imports: &cross_module.namespace_reexport_named_imports,
         namespace_member_prefixes: &cross_module.namespace_member_prefixes,
         imported_async_funcs: &cross_module.imported_async_funcs,
         local_async_funcs: &cross_module.local_async_funcs,
@@ -4390,6 +4410,7 @@ fn compile_method(
         closure_rest_params,
         local_closure_func_ids: HashMap::new(),
         namespace_imports: &cross_module.namespace_imports,
+        namespace_reexport_named_imports: &cross_module.namespace_reexport_named_imports,
         namespace_member_prefixes: &cross_module.namespace_member_prefixes,
         imported_async_funcs: &cross_module.imported_async_funcs,
         local_async_funcs: &cross_module.local_async_funcs,
@@ -4870,6 +4891,7 @@ fn compile_module_entry(
             closure_rest_params: closure_rest_params,
             local_closure_func_ids: HashMap::new(),
             namespace_imports: &cross_module.namespace_imports,
+            namespace_reexport_named_imports: &cross_module.namespace_reexport_named_imports,
             namespace_member_prefixes: &cross_module.namespace_member_prefixes,
             imported_async_funcs: &cross_module.imported_async_funcs,
             local_async_funcs: &cross_module.local_async_funcs,
@@ -5251,6 +5273,7 @@ fn compile_module_entry(
             closure_rest_params: closure_rest_params,
             local_closure_func_ids: HashMap::new(),
             namespace_imports: &cross_module.namespace_imports,
+            namespace_reexport_named_imports: &cross_module.namespace_reexport_named_imports,
             namespace_member_prefixes: &cross_module.namespace_member_prefixes,
             imported_async_funcs: &cross_module.imported_async_funcs,
             local_async_funcs: &cross_module.local_async_funcs,
@@ -6093,6 +6116,7 @@ fn compile_static_method(
         closure_rest_params,
         local_closure_func_ids: HashMap::new(),
         namespace_imports: &cross_module.namespace_imports,
+        namespace_reexport_named_imports: &cross_module.namespace_reexport_named_imports,
         namespace_member_prefixes: &cross_module.namespace_member_prefixes,
         imported_async_funcs: &cross_module.imported_async_funcs,
         local_async_funcs: &cross_module.local_async_funcs,

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -617,6 +617,14 @@ pub(crate) struct FnCtx<'a> {
     /// Codegen uses this to know that `X.foo()` should be dispatched as
     /// a cross-module call rather than an object method call.
     pub namespace_imports: &'a std::collections::HashSet<String>,
+    /// Issue #321: subset of `namespace_imports` populated only by the
+    /// "named import resolves to a `export * as Foo from "./Foo"`" branch
+    /// in `compile.rs`. The StaticMethodCall arm uses this to decide
+    /// whether to route var-shape members through `js_closure_callN`
+    /// (safe for the user-import shape) vs. preserving the pre-fix
+    /// direct-call (silently-wrong-but-doesn't-throw) path used by
+    /// `import * as` namespaces in effect's internal modules.
+    pub namespace_reexport_named_imports: &'a std::collections::HashSet<String>,
     /// Issue #680: per-namespace member resolution. Keyed by
     /// `(namespace_local_name, member_name)` → `source_prefix`. Consulted
     /// by namespace member access lowering to disambiguate when the same
@@ -6759,6 +6767,56 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     let origin_suffix =
                         import_origin_suffix(ctx.import_function_origin_names, method_name);
                     let fn_name = format!("perry_fn_{}__{}", source_prefix, origin_suffix);
+                    // Issue #321: var-shaped exports (e.g. `export const succeed
+                    // = (v) => new EffectInst(v)`) emit a ZERO-ARG getter
+                    // `perry_fn_<src>__<name>()` returning the closure. The
+                    // previous code emitted a 1-arg direct call against that
+                    // 0-arg symbol — the source returned the function pointer
+                    // unchanged and the consumer saw `typeof Effect.succeed(42)
+                    // === "function"` (the closure itself, not the EffectInst).
+                    // Mirror the `lower_call.rs` var-shaped branch: fetch the
+                    // closure via the zero-arg getter, then dispatch through
+                    // `js_closure_callN` with the user args. Without this every
+                    // `Effect.succeed`/`Effect.runSync` etc. on the native
+                    // `compilePackages: ["effect"]` path returned a closure,
+                    // which `runSync` then read `._tag` off and threw
+                    // `Cannot read properties of undefined`.
+                    //
+                    // SCOPE: only fire when the class_name was registered as a
+                    // namespace via the *named-import-of-namespace-reexport*
+                    // branch (`import { Effect } from "effect"` where effect's
+                    // index.ts has `export * as Effect from "./Effect.js"`).
+                    // Plain `import * as X from "./X.js"` (used in effect's
+                    // INTERNAL modules) deliberately preserves the pre-fix
+                    // direct-call (silently-wrong-but-doesn't-throw) path —
+                    // switching them all over surfaces init-order bugs that
+                    // were hiding behind the silent shape. Those need a
+                    // separate audit.
+                    if ctx.namespace_reexport_named_imports.contains(class_name)
+                        && ctx.imported_vars.contains(method_name)
+                    {
+                        let mut lowered: Vec<String> = Vec::with_capacity(args.len());
+                        for a in args {
+                            lowered.push(lower_expr(ctx, a)?);
+                        }
+                        if lowered.len() > 16 {
+                            bail!(
+                                "perry-codegen: namespace static-method closure call with {} args (max 16)",
+                                lowered.len()
+                            );
+                        }
+                        ctx.pending_declares.push((fn_name.clone(), DOUBLE, vec![]));
+                        let closure_box = ctx.block().call(DOUBLE, &fn_name, &[]);
+                        let blk = ctx.block();
+                        let closure_handle = unbox_to_i64(blk, &closure_box);
+                        let runtime_fn = format!("js_closure_call{}", lowered.len());
+                        let mut call_args: Vec<(crate::types::LlvmType, &str)> =
+                            vec![(I64, &closure_handle)];
+                        for v in &lowered {
+                            call_args.push((DOUBLE, v.as_str()));
+                        }
+                        return Ok(blk.call(DOUBLE, &runtime_fn, &call_args));
+                    }
                     let mut lowered: Vec<String> = Vec::with_capacity(args.len());
                     for a in args {
                         lowered.push(lower_expr(ctx, a)?);

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -4389,6 +4389,14 @@ pub fn run_with_parse_cache(
             let mut namespace_member_prefixes: std::collections::HashMap<(String, String), String> =
                 std::collections::HashMap::new();
             let mut namespace_imports: Vec<String> = Vec::new();
+            // Issue #321: subset of `namespace_imports` populated only by the
+            // named-import-of-namespace-reexport branch below (`import { Effect
+            // } from "effect"` where effect's index.ts has `export * as Effect
+            // from "./Effect.js"`). The codegen's StaticMethodCall arm consults
+            // this to decide whether it can route var-shape members through
+            // `js_closure_callN`; see the field doc in codegen.rs.
+            let mut namespace_reexport_named_imports: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
             let mut imported_classes: Vec<perry_codegen::ImportedClass> = Vec::new();
             let mut imported_enums: Vec<(String, Vec<(String, perry_hir::EnumValue)>)> = Vec::new();
             let mut imported_async_set: std::collections::HashSet<String> =
@@ -4660,6 +4668,13 @@ pub fn run_with_parse_cache(
                                     break;
                                 };
                                 namespace_imports.push(local_name.clone());
+                                // Issue #321: tag this local as a "named-import-
+                                // of-namespace-reexport" so codegen's
+                                // StaticMethodCall arm knows to route var-shape
+                                // members through `js_closure_callN`. See the
+                                // expr.rs StaticMethodCall comment for why this
+                                // is scoped narrowly.
+                                namespace_reexport_named_imports.insert(local_name.clone());
                                 for (export_name, origin_path) in target_exports {
                                     let origin_prefix =
                                         compute_module_prefix(origin_path, &ctx.project_root);
@@ -4685,6 +4700,28 @@ pub fn run_with_parse_cache(
                                     }
                                     if exported_func_has_rest.get(&key).copied().unwrap_or(false) {
                                         imported_has_rest.insert(export_name.clone());
+                                    }
+                                    // Issue #321: NamespaceReExport members
+                                    // that are var-shaped exports (the
+                                    // canonical `export const succeed = (v) =>
+                                    // ...` shape in effect/Effect.ts and
+                                    // co-equivalent re-export hubs) must land
+                                    // in `imported_vars` so the codegen's
+                                    // StaticMethodCall and namespace-member
+                                    // call sites route through the zero-arg
+                                    // getter + `js_closure_callN`. Without
+                                    // this, `import { Effect } from "effect";
+                                    // Effect.succeed(42)` emitted a 1-arg
+                                    // direct call against the 0-arg getter
+                                    // — the source returned the closure
+                                    // pointer unchanged and `typeof
+                                    // Effect.succeed(42)` was `"function"`,
+                                    // and `runSync(program)` then threw
+                                    // `Cannot read properties of undefined`
+                                    // on `program._tag`. Mirrors the
+                                    // `Namespace { local }` branch above.
+                                    if exported_var_names.contains(&key) {
+                                        imported_vars.insert(export_name.clone());
                                     }
                                     if let Some(class) = exported_classes.get(&key) {
                                         imported_classes.push(perry_codegen::ImportedClass {
@@ -5809,6 +5846,7 @@ pub fn run_with_parse_cache(
                 namespace_member_prefixes,
                 emit_ir_only: bitcode_link,
                 namespace_imports,
+                namespace_reexport_named_imports,
                 imported_classes,
                 imported_enums,
                 imported_async_funcs: imported_async_set,

--- a/crates/perry/src/commands/compile/object_cache.rs
+++ b/crates/perry/src/commands/compile/object_cache.rs
@@ -256,6 +256,20 @@ pub fn compute_object_cache_key(
         );
     }
 
+    // Issue #321: namespace reexport named imports — separate subset that
+    // gates the codegen's StaticMethodCall var-shape routing. Cache must
+    // discriminate between two modules whose `namespace_imports` are
+    // identical but whose `namespace_reexport_named_imports` differ, else
+    // the wrong code-path winds up in the object file.
+    {
+        let mut v: Vec<&String> = opts.namespace_reexport_named_imports.iter().collect();
+        v.sort();
+        h.field(
+            "ns_reexport_named_imports",
+            &v.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(","),
+        );
+    }
+
     // Import function prefixes (HashMap — MUST sort).
     {
         let mut v: Vec<(&String, &String)> = opts.import_function_prefixes.iter().collect();
@@ -644,6 +658,7 @@ mod object_cache_tests {
             namespace_member_prefixes: std::collections::HashMap::new(),
             emit_ir_only: false,
             namespace_imports: Vec::new(),
+            namespace_reexport_named_imports: std::collections::HashSet::new(),
             imported_classes: Vec::new(),
             imported_enums: Vec::new(),
             imported_async_funcs: std::collections::HashSet::new(),

--- a/test-files/issue_321_named_namespace_reexport/main.ts
+++ b/test-files/issue_321_named_namespace_reexport/main.ts
@@ -1,0 +1,33 @@
+// Issue #321 — `Effect.succeed(42)` returning `undefined` on the native
+// `perry.compilePackages: ["effect"]` path.
+//
+// REPRO SHAPE: a barrel that does `export * as Effect from "./Effect.js"`
+// and a consumer that does `import { Effect } from "<pkg>"; Effect.method(...)`.
+// The consumer's `Effect.succeed(42)` lowers to
+// `StaticMethodCall { class_name: "Effect", method_name: "succeed" }`.
+//
+// PRE-FIX BUG: the StaticMethodCall arm in `crates/perry-codegen/src/expr.rs`
+// emitted a direct call `perry_fn_<src>__succeed(arg)` against a 0-arg
+// getter symbol (because `succeed = (v) => new EffectInst(v)` is var-shape:
+// the source emits a getter returning the closure, not the body). The
+// arg was silently dropped and the caller saw the closure pointer
+// itself — `typeof Effect.succeed(42) === "function"`. Effect's
+// `runSync(program)` then read `program._tag` off a closure pointer and
+// the runtime threw `Cannot read properties of undefined (reading '_tag')`.
+//
+// POST-FIX: the consumer's namespace local is tagged into a new
+// `namespace_reexport_named_imports` set so the StaticMethodCall arm
+// fetches the closure via the zero-arg getter and dispatches through
+// `js_closure_callN` with the user's args. `Effect.succeed(42)` now
+// returns the EffectInst, `_tag === "Commit"`, and `runSync` returns 42.
+//
+// This file is byte-compared against Node — see `node --experimental-strip-types`.
+// Run from the fixture directory under `test-files/fixtures/`:
+//   cd test-files/fixtures/issue_321_named_namespace_reexport
+//   perry ../../test_issue_321_named_namespace_reexport.ts -o out && ./out
+
+import { Effect } from "mini-effect";
+const p = Effect.succeed(42);
+console.log("typeof p:", typeof p);
+console.log("p?._tag:", (p as any)?._tag);
+console.log("runSync:", Effect.runSync(p));

--- a/test-files/issue_321_named_namespace_reexport/node_modules/mini-effect/package.json
+++ b/test-files/issue_321_named_namespace_reexport/node_modules/mini-effect/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "mini-effect",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./src/index.js"
+}

--- a/test-files/issue_321_named_namespace_reexport/node_modules/mini-effect/src/Effect.js
+++ b/test-files/issue_321_named_namespace_reexport/node_modules/mini-effect/src/Effect.js
@@ -1,0 +1,12 @@
+// JS version of Effect.ts for `node --experimental-strip-types` parity.
+// Perry compiles from the .ts when present (compile_packages prefers
+// `src/<name>.ts`); Node imports the .js. The user's import resolves to
+// `./Effect.js` literally, and both runtimes follow the same path.
+class EffectInst {
+  constructor(value) {
+    this._tag = "Commit";
+    this.value = value;
+  }
+}
+export const succeed = (v) => new EffectInst(v);
+export const runSync = (e) => e.value;

--- a/test-files/issue_321_named_namespace_reexport/node_modules/mini-effect/src/index.js
+++ b/test-files/issue_321_named_namespace_reexport/node_modules/mini-effect/src/index.js
@@ -1,0 +1,1 @@
+export * as Effect from "./Effect.js"

--- a/test-files/issue_321_named_namespace_reexport/package.json
+++ b/test-files/issue_321_named_namespace_reexport/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "issue-321-named-namespace-reexport",
+  "version": "0.0.0",
+  "type": "module",
+  "perry": {
+    "compilePackages": ["mini-effect"]
+  }
+}


### PR DESCRIPTION
## Summary

- Closes the basic-shape blocker for issue #321 (`Effect.succeed(42)` returning `undefined` on the `perry.compilePackages: ["effect"]` path).
- Root cause: HIR lifts `Effect.succeed(42)` to `StaticMethodCall { class_name: "Effect", method_name: "succeed" }` (uppercase-identifier rule). The codegen's StaticMethodCall arm then emitted a 1-arg direct call against `perry_fn_<Effect>__succeed`, but that symbol is a ZERO-arg getter (because `succeed` is var-shape: `export const succeed = (v) => new EffectInst(v)`). The arg was silently dropped and the call returned the closure pointer, so `typeof Effect.succeed(42) === "function"` and `_tag` was undefined.
- Fix routes var-shape namespace-reexport-named-import members through the closure-call ABI: fetch the closure via the zero-arg getter, then dispatch through `js_closure_callN`. Mirrors the existing var-shape branch in `lower_call.rs`. Scoped narrowly via a new `namespace_reexport_named_imports` set so the change only affects `import { Effect } from "effect"`-style consumers and leaves the `import * as` path (heavily used by effect's internal modules) untouched.

## What changed

| File | What |
| --- | --- |
| `crates/perry-codegen/src/codegen.rs` | New `namespace_reexport_named_imports` field on `CompileOptions` + `CrossModuleCtx`, propagated to all 6 `FnCtx` call sites. |
| `crates/perry-codegen/src/expr.rs` | New `FnCtx` ref. StaticMethodCall arm: when the class_name is in the new set AND the method_name is in `imported_vars`, fetch the closure via the zero-arg getter and call through `js_closure_callN`. |
| `crates/perry/src/commands/compile.rs` | NamespaceReExport branch now tags `local_name` into `namespace_reexport_named_imports` and tags var-shape members into `imported_vars` (mirroring the plain `Namespace { local }` branch). |
| `crates/perry/src/commands/compile/object_cache.rs` | Cache key folds in the new set so modules with identical `namespace_imports` but different `namespace_reexport_named_imports` don't share `.o` bytes. |
| `test-files/issue_321_named_namespace_reexport/` | Tiny `mini-effect` fixture reproducing the exact shape: `export * as Effect from "./Effect.js"` + var-shape `succeed`/`runSync`. Output now matches Node byte-for-byte. |

## Verification

```text
# Before:
typeof p: function
p?._tag: undefined
runSync: [Function (anonymous)]
TypeError: Cannot read properties of undefined (reading '_tag')

# After:
typeof p: object
p?._tag: Commit
runSync: 42
```

Identical to `node --experimental-strip-types main.ts`.

## Known limitation

The real `effect` package still fails before user code runs — but with a different (pre-existing) error inside one of effect's internal module init paths. That failure is **not** introduced by this PR: it reproduces on `main` without my changes too. Root cause is a separate audit (`import * as` namespace-member StaticMethodCalls in effect's internal modules use the pre-fix silently-wrong direct-call path; flipping them to closure-calls surfaces init-order bugs that need their own investigation). This PR intentionally does NOT touch that path.

## Test plan

- [ ] CI: lint, cargo-test, parity, compile-smoke, api-docs-drift, security-audit
- [x] Local: `test-files/issue_321_named_namespace_reexport/main.ts` byte-matches Node
- [x] Local: `cargo build --release -p perry-runtime -p perry-stdlib -p perry-jsruntime -p perry -p perry-transform -p perry-codegen` succeeds