### PR TITLE
fix(object): skip misaligned non-object pointers in js_object_assign_one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1009 — fix(object): skip misaligned non-object pointers in js_object_assign_one
+
+`js_object_assign_one` (the `Object.assign` single-source helper)
+decodes target/source permissively and is documented to skip
+non-object sources (`Object.assign(t, 5)` / `null`). The existing
+guards only rejected NaN-boxed specials and values `< 0x10000`; an
+untagged, unaligned bit pattern passed through and was dereferenced as
+`*ObjectHeader` at `(*src).keys_array`.
+
+A real `ObjectHeader` is heap-allocated `#[repr(C)]` with `u64` /
+pointer fields, so a valid object pointer is always 8-byte aligned.
+Observed on a Windows release build of a large Perry app: a non-pointer
+value (`0x1d81ff6950a`) reached `source`, and `(*src).keys_array` is a
+misaligned read — a hard abort under debug pointer-alignment checks,
+and in release silent memory corruption that surfaced downstream as a
+GC out-of-bounds panic (a NaN-boxed value used as a shadow-stack
+index). Adds an `% 8 != 0` alignment guard to both the target and
+source decode paths, treating a misaligned value as a non-object and
+skipping it — exactly the documented `Object.assign(t, <non-object>)`
+behaviour.
+
 ## v0.5.1008 — fix(wasm): #1037 — `String.fromCharCode` returns `undefined` on `--target web`
 
 The reduction Ralph posted on #1037 showed `s += String.fromCharCode(0)` over-appending 9 chars per iteration — but the underlying cause was not handle-ID stringification; it was simpler. The compiled `String.fromCharCode` was returning `undefined`, and `'' + undefined === 'undefined'` (which is exactly 9 chars). 16 iters × 9 = the observed 144-byte length.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1008
+**Current Version:** 0.5.1009
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5084,7 +5084,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "base64",
@@ -5139,14 +5139,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "log",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5168,7 +5168,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "base64",
@@ -5208,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "serde",
  "serde_json",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1008"
+version = "0.5.1009"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "clap",
@@ -5250,14 +5250,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5298,14 +5298,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "chrono",
  "cron",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5322,7 +5322,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5338,7 +5338,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5346,21 +5346,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5385,14 +5385,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-google-auth"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5404,7 +5404,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5444,7 +5444,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "bson",
  "futures-util",
@@ -5472,7 +5472,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5502,7 +5502,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "base64",
  "image",
@@ -5546,14 +5546,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5569,7 +5569,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5590,7 +5590,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5598,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5607,7 +5607,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5623,7 +5623,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5649,7 +5649,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "base64",
@@ -5686,7 +5686,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5759,7 +5759,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5777,11 +5777,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1008"
+version = "0.5.1009"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "base64",
  "itoa",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5807,7 +5807,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5828,7 +5828,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "base64",
  "block2",
@@ -5844,7 +5844,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "base64",
  "block2",
@@ -5863,11 +5863,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1008"
+version = "0.5.1009"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "base64",
  "block2",
@@ -5883,7 +5883,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "base64",
  "block2",
@@ -5899,7 +5899,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "block2",
  "libc",
@@ -5912,7 +5912,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "base64",
  "libc",
@@ -5927,7 +5927,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5941,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1008"
+version = "0.5.1009"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1008"
+version = "0.5.1009"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -2968,7 +2968,16 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
     } else {
         tgt_bits as usize
     };
-    if tgt_raw < 0x10000 {
+    // A real `ObjectHeader` is heap-allocated and #[repr(C)] with u64 /
+    // pointer fields, so a valid object pointer is always 8-byte aligned.
+    // The tag / `< 0x10000` checks let an untagged, unaligned bit pattern
+    // through (observed on Windows: a non-pointer value reaches here as
+    // `source`, e.g. 0x1d81ff6950a). Dereferencing it as `*ObjectHeader`
+    // is a misaligned read — a hard abort under debug pointer-alignment
+    // checks, silent memory corruption (→ later GC out-of-bounds) in
+    // release. Treat a misaligned value as a non-object and skip, exactly
+    // the documented behaviour for `Object.assign(t, <non-object>)`.
+    if tgt_raw < 0x10000 || tgt_raw % 8 != 0 {
         return target_f64;
     }
 
@@ -2983,7 +2992,10 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
     } else {
         src_bits as usize
     };
-    if src_raw < 0x10000 || src_raw == tgt_raw {
+    // Same alignment guard as the target above — `src` is dereferenced at
+    // `(*src).keys_array` just below; an unaligned non-object source must
+    // be skipped, not dereferenced.
+    if src_raw < 0x10000 || src_raw % 8 != 0 || src_raw == tgt_raw {
         return target_f64;
     }
 


### PR DESCRIPTION
## Problem

`js_object_assign_one` (the `Object.assign` single-source helper) decodes target/source permissively and is documented to skip non-object sources (`Object.assign(t, 5)` / `null`). The existing guards only rejected NaN-boxed specials and values `< 0x10000`; an **untagged, unaligned bit pattern passed through** and was dereferenced as `*ObjectHeader` at `(*src).keys_array`.

A real `ObjectHeader` is heap-allocated `#[repr(C)]` with `u64`/pointer fields, so a valid object pointer is always 8-byte aligned.

Observed on a Windows release build of a large Perry app: a non-pointer value (`0x1d81ff6950a`) reached `source`; `(*src).keys_array` is a misaligned read — a **hard abort** under debug pointer-alignment checks, and in release **silent memory corruption** that surfaced downstream as a GC out-of-bounds panic (a NaN-boxed value used as a shadow-stack index).

## Fix

Add an `% 8 != 0` alignment guard to both the target and source decode paths in `js_object_assign_one`. A misaligned value is treated as a non-object and skipped — exactly the documented `Object.assign(t, <non-object>)` behaviour. 14-line, surgical, no behavior change for valid objects.

## Notes

- Original commit authored by @proggeramlug; reached `feat/windows-crash-backtrace` after PR #916 (the ACCESS_VIOLATION backtrace) was already merged, so it never had its own PR. Cherry-picked clean onto current `main`.
- Verified: clean `cargo build --release -p perry-runtime -p perry-stdlib -p perry`.
