### PR TITLE
fix(hir): #1070 — instanceof narrowing breaks property read in fastify error handler

### DIFF
--- a/crates/perry-hir/src/lower_patterns.rs
+++ b/crates/perry-hir/src/lower_patterns.rs
@@ -285,10 +285,24 @@ pub(crate) fn pre_scan_fastify_handler_params(
         ast::Expr::Fn(_) => return None, // fn expressions handled separately
         _ => return None,
     };
-    let req_name = arrow.params.first().and_then(pat_ident_name)?;
+    // Issue #1070: `setErrorHandler(async (err, req, reply) => …)` —
+    // the first arrow param is the THROWN VALUE, not a fastify Request.
+    // Registering `err` as `("fastify", "Request")` causes `err.problem`
+    // (or any user-field access on a thrown class instance) to lower to
+    // a NativeMethodCall whose method name isn't in the fastify Request
+    // dispatch table → the lower_native_method_call fall-through emits
+    // `double_literal(0.0)`, so the access prints as `0`. Skip the first
+    // arrow param for setErrorHandler so only params[1] / params[2]
+    // (the real Request / Reply) get the native-instance tags.
+    let (req_param_idx, reply_param_idx) = if method_name == "setErrorHandler" {
+        (1, 2)
+    } else {
+        (0, 1)
+    };
+    let req_name = arrow.params.get(req_param_idx).and_then(pat_ident_name)?;
     let reply_name = arrow
         .params
-        .get(1)
+        .get(reply_param_idx)
         .and_then(pat_ident_name)
         .unwrap_or_default();
     Some((req_name, reply_name))

--- a/scripts/run_fastify_tests.sh
+++ b/scripts/run_fastify_tests.sh
@@ -154,6 +154,18 @@ check "GET /throw-async body" \
 actual="$(curl -s --max-time 5 "http://127.0.0.1:$PORT/hello" || true)"
 check "GET /hello after throw" '{"hello":"world"}' "$actual"
 
+# Issue #1070: `setErrorHandler(async (err, req, reply) => …)` —
+# `err instanceof MyError` narrowing must let `err.<field>` reads
+# return the actual class-instance field instead of the `0` zero-
+# sentinel that the misregistered ("fastify","Request") tag produced.
+code_and_body="$(curl -s --max-time 5 -o "$TMP_DIR/throw_problem_body" -w '%{http_code}' \
+    "http://127.0.0.1:$PORT/throw-problem" || true)"
+throw_problem_body="$(cat "$TMP_DIR/throw_problem_body" 2>/dev/null || true)"
+check "GET /throw-problem status (#1070)" "400" "$code_and_body"
+check "GET /throw-problem body (#1070)" \
+    '{"title":"Bad Request","status":400}' \
+    "$throw_problem_body"
+
 echo
 echo "fastify-tests: $pass passed, $fail failed"
 

--- a/test-files/test_fastify_integration.ts
+++ b/test-files/test_fastify_integration.ts
@@ -30,6 +30,35 @@ app.get("/throw-async", async (_request, _reply) => {
   throw new Error("async route boom");
 });
 
+// Issue #1070: `instanceof`-narrowed property access on the error value
+// inside a `setErrorHandler(async (err, req, reply) => …)` callback
+// previously printed `0`. Pre-fix the first arrow param (`err`) was tagged
+// as a fastify Request native instance, so `err.<field>` lowered to a
+// NativeMethodCall whose unknown-method fall-through emits `0.0`.
+class ProblemError extends Error {
+  constructor(public readonly problem: { title: string; status: number }) {
+    super(problem.title);
+  }
+}
+app.setErrorHandler(async (err, _req, reply) => {
+  if (err instanceof ProblemError) {
+    void reply.code(err.problem.status).send(err.problem);
+    return;
+  }
+  // Defer to the default fastify envelope shape for everything else, so
+  // the pre-existing /throw-sync and /throw-async parity assertions keep
+  // their `{"statusCode":500,"error":"Internal Server Error","message":…}`
+  // bodies after this test added a user handler to the app.
+  void reply.code(500).send({
+    statusCode: 500,
+    error: "Internal Server Error",
+    message: err.message,
+  });
+});
+app.get("/throw-problem", async (_request, _reply) => {
+  throw new ProblemError({ title: "Bad Request", status: 400 });
+});
+
 app.listen({ port: port }, () => {
   // Sentinel line the harness waits for before starting curl assertions.
   console.log("ready port=" + port);


### PR DESCRIPTION
Closes #1070.

## Root cause

`pre_scan_fastify_handler_params` (in `crates/perry-hir/src/lower_patterns.rs`) registered the **first** arrow param of every recognized fastify handler call as a `("fastify", "Request")` native instance — including `app.setErrorHandler(async (err, req, reply) => …)`, whose first param is the thrown value, not a Request.

With `err` tagged as Request, any user-field read like `err.problem` lowered to a `NativeMethodCall { module: "fastify", method: "problem", … }`. `problem` isn't in the Request method dispatch table, so the `lower_native_method_call` fall-through (`crates/perry-codegen/src/lower_call/native.rs:2297`) returned `double_literal(0.0)` — the access printed as `0`.

`(err as MyError).problem` worked because `expr_member.rs`'s native-instance shape check only matches `member.obj == Expr::Ident`; a `TsAs` cast bypassed it and went through generic property dispatch — which is why the bug report's outside-the-if access printed the full object but the inside-the-narrow bare `err.problem` access printed `0`.

## Fix

Skip the err param for `setErrorHandler` so only `params[1]=request` and `params[2]=reply` get the native-instance tags. `err.<field>` then falls through to the generic property dispatch that reads the actual class-instance field at runtime.

## Verification

Reproducer from the issue:

```
[A] outside if — problem: {"title":"Bad Request","status":400}
[A] inside if — problem: {"title":"Bad Request","status":400}   ← pre-fix: 0
[A] const p: {"title":"Bad Request","status":400}                ← pre-fix: 0
[B] no-narrow as-cast — problem: {"title":"Bad Request","status":400}
```

Regression coverage added in `test_fastify_integration.ts` + `run_fastify_tests.sh`:
- `POST /throw-problem` throws a `ProblemError` instance from a route
- `setErrorHandler` narrows via `instanceof` and reads `err.problem.{status,title}`
- HTTP 400 with `{"title":"Bad Request","status":400}` body

All 12 fastify integration tests pass (10 pre-existing + 2 new for #1070).

No version bump or changelog change — maintainer handles that at merge time.

## Test plan
- [x] Reproduced the bug locally with the issue's exact repro
- [x] Verified the fix restores correct field reads
- [x] All `cargo test -p perry-hir` and `cargo test -p perry-codegen` pass
- [x] `scripts/run_fastify_tests.sh`: 12/12 pass (was 10/10 pre-fix + 2 new for #1070)