### PR TITLE
fix(ui-windows): #1061 — Picker/Combobox dropdown clipped to zero by relayout

### DIFF
--- a/crates/perry-ui-windows/src/layout.rs
+++ b/crates/perry-ui-windows/src/layout.rs
@@ -201,9 +201,30 @@ fn layout_stack(handle: i64, width: i32, height: i32, vertical: bool) {
                 } else {
                     (pos, inset_top, size, cross)
                 };
+                // Win32 COMBOBOX quirk (issue #1061): the height passed to
+                // MoveWindow bounds the *drop-down list*, not just the closed
+                // edit/selection box. The layout intrinsic for Picker /
+                // Combobox is the closed height (~28px); applying it verbatim
+                // clips the dropdown to zero, so the control renders but never
+                // opens ("static control, click does nothing — works on
+                // Linux/AppKit"). picker::create / combobox::create deliberately
+                // pass a 200px height at CreateWindowExW for exactly this
+                // reason; relayout was then destroying it. Inflate only the
+                // combobox's own window height — sibling stacking still uses
+                // the closed `size` (`pos += size` below is unchanged), so
+                // layout is unaffected and the extra height is purely the
+                // dropdown's maximum extent.
+                let move_h = if ci_info
+                    .as_ref()
+                    .is_some_and(|ci| matches!(ci.kind, WidgetKind::Picker | WidgetKind::Combobox))
+                {
+                    h.max(28) + 200
+                } else {
+                    h
+                };
                 // position child
                 unsafe {
-                    let _ = MoveWindow(child_hwnd, x, y, w, h, true);
+                    let _ = MoveWindow(child_hwnd, x, y, w, move_h, true);
                 }
                 // Apply deferred corner radius now that widget has its final size
                 widgets::apply_corner_radius(child);


### PR DESCRIPTION
Fixes #1061.

## Problem

On Windows, clicking a `Picker` does nothing — no dropdown, no options, no error. It renders as a static control. Works on Linux/macOS.

## Root cause

A Win32 `COMBOBOX`'s window height bounds its **drop-down list**, not just the closed selection box. `picker::create` (and `combobox::create`) deliberately pass a 200px height at `CreateWindowExW` for exactly this reason (`// height includes dropdown area`).

But widgets are created parented to the parking window and then repositioned by `layout::relayout`, which `MoveWindow`s every child to its layout intrinsic. For `Picker`/`Combobox` that intrinsic is the **closed** height (`28px`, `layout.rs`), applied with no compensation — so relayout destroys the create-time height and clips the dropdown to zero. The control draws but the list has nowhere to open.

This matches the platform split: AppKit's `NSPopUpButton` menu is independent of the control frame, so Linux/macOS are unaffected.

`Combobox` has the identical latent bug (same `create`-200 → `relayout`-28 pattern); this fix covers both widget kinds.

## Fix

In the stack relayout path (`crates/perry-ui-windows/src/layout.rs`), inflate **only the combobox's own `MoveWindow` height** to `h.max(28) + 200` for `Picker`/`Combobox`. Sibling stacking still advances by the closed `size` (`pos += size` is unchanged), so visual layout is unaffected — the extra height is purely the dropdown's maximum extent, restoring exactly what `create()` intended.

## Validation

- `cargo build --release -p perry-ui-windows` clean.
- Behavioral check (GUI, please confirm): `perry run` the issue's repro — clicking the Picker opens the 3-item dropdown; selecting updates "Selected index". Same for a `Combobox`.

Scoped intentionally to the stack-layout path the report hits; the ScrollView/ZStack single-child `MoveWindow` sites have the same latent quirk and can be addressed as a follow-up if needed.
