### PR TITLE
fix(crypto): #1076 createHmac/createHash silent empty on non-literal alg

### DIFF
--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -11490,20 +11490,120 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     }
                 }
                 _ => {
-                    // Unsupported — return empty string so the test
-                    // can continue (length check fails but no crash).
-                    for a in digest_args {
-                        let _ = lower_expr(ctx, a)?;
+                    // Fallback for non-literal alg (#1076) and for algorithms
+                    // we don't have a direct FFI helper for (sha1, sha512,
+                    // md5 for HMAC; sha1, sha512 for hash). Route through
+                    // the same handle protocol the standalone `createHash`
+                    // / `createHmac` arms use: allocate a Hash/Hmac handle,
+                    // chain `.update(data).digest(enc)` via runtime method
+                    // dispatch. Previously this arm returned `""` silently —
+                    // see #1076 (HMAC signature verification always failing
+                    // when `alg` was a `const`-bound or for-of-bound name).
+                    if create_args.is_empty() || update_args.is_empty() {
+                        // Mirror the legacy empty-string return for malformed
+                        // input so downstream chains keep their shape.
+                        let blk = ctx.block();
+                        let empty =
+                            blk.call(I64, "js_string_from_bytes", &[(I64, "0"), (I32, "0")]);
+                        return Ok(nanbox_string_inline(blk, &empty));
                     }
-                    for a in update_args {
-                        let _ = lower_expr(ctx, a)?;
-                    }
-                    for a in create_args {
-                        let _ = lower_expr(ctx, a)?;
-                    }
+                    // Lower all the sub-expressions before any FFI call so
+                    // their side-effects run in the source order Node sees.
+                    let alg_box = lower_expr(ctx, &create_args[0])?;
+                    let key_box_opt = if create_method == "createHmac" && create_args.len() >= 2 {
+                        Some(lower_expr(ctx, &create_args[1])?)
+                    } else {
+                        None
+                    };
+                    let data_box = lower_expr(ctx, &update_args[0])?;
+                    let enc_box_opt = if digest_args.is_empty() {
+                        None
+                    } else {
+                        Some(lower_expr(ctx, &digest_args[0])?)
+                    };
+
                     let blk = ctx.block();
-                    let empty = blk.call(I64, "js_string_from_bytes", &[(I64, "0"), (I32, "0")]);
-                    Ok(nanbox_string_inline(blk, &empty))
+                    let alg_handle = unbox_to_i64(blk, &alg_box);
+                    // Allocate the handle. Both helpers return f64 already
+                    // NaN-boxed with POINTER_TAG, suitable as the receiver
+                    // for `js_native_call_method`.
+                    let recv = if create_method == "createHmac" {
+                        let key_box = key_box_opt.expect("createHmac needs a key arg");
+                        let key_handle = unbox_to_i64(blk, &key_box);
+                        blk.call(
+                            DOUBLE,
+                            "js_crypto_create_hmac",
+                            &[(I64, &alg_handle), (I64, &key_handle)],
+                        )
+                    } else {
+                        blk.call(DOUBLE, "js_crypto_create_hash", &[(I64, &alg_handle)])
+                    };
+
+                    // Invoke `.update(data)` via the runtime's generic
+                    // handle-method dispatcher. Builds a 1-arg `double*`
+                    // arg buffer and a `js_string_from_bytes` rodata key.
+                    let update_name = emit_string_literal_global(ctx, "update");
+                    let blk = ctx.block();
+                    let update_args_buf = ctx.func.alloca_entry_array(DOUBLE, 1);
+                    {
+                        let blk = ctx.block();
+                        let slot = blk.gep(DOUBLE, &update_args_buf, &[(I64, "0")]);
+                        blk.store(DOUBLE, &data_box, &slot);
+                    }
+                    let update_args_ptr = {
+                        let blk = ctx.block();
+                        let reg = blk.next_reg();
+                        blk.emit_raw(format!(
+                            "{} = getelementptr [1 x double], ptr {}, i64 0, i64 0",
+                            reg, update_args_buf
+                        ));
+                        reg
+                    };
+                    let blk = ctx.block();
+                    let updated = blk.call(
+                        DOUBLE,
+                        "js_native_call_method",
+                        &[
+                            (DOUBLE, &recv),
+                            (PTR, &update_name),
+                            (I64, &format!("{}", "update".len())),
+                            (PTR, &update_args_ptr),
+                            (I64, "1"),
+                        ],
+                    );
+
+                    // Invoke `.digest(enc?)` — 0 or 1 args.
+                    let digest_name = emit_string_literal_global(ctx, "digest");
+                    let (digest_args_ptr, digest_argc) = if let Some(enc_box) = enc_box_opt {
+                        let buf = ctx.func.alloca_entry_array(DOUBLE, 1);
+                        {
+                            let blk = ctx.block();
+                            let slot = blk.gep(DOUBLE, &buf, &[(I64, "0")]);
+                            blk.store(DOUBLE, &enc_box, &slot);
+                        }
+                        let blk = ctx.block();
+                        let reg = blk.next_reg();
+                        blk.emit_raw(format!(
+                            "{} = getelementptr [1 x double], ptr {}, i64 0, i64 0",
+                            reg, buf
+                        ));
+                        (reg, "1".to_string())
+                    } else {
+                        ("null".to_string(), "0".to_string())
+                    };
+                    let blk = ctx.block();
+                    let result = blk.call(
+                        DOUBLE,
+                        "js_native_call_method",
+                        &[
+                            (DOUBLE, &updated),
+                            (PTR, &digest_name),
+                            (I64, &format!("{}", "digest".len())),
+                            (PTR, &digest_args_ptr),
+                            (I64, &digest_argc),
+                        ],
+                    );
+                    Ok(result)
                 }
             }
         }
@@ -11533,6 +11633,44 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let alg_handle = unbox_to_i64(blk, &alg_box);
             // Returns an already-NaN-boxed f64 (POINTER_TAG + handle id).
             Ok(blk.call(DOUBLE, "js_crypto_create_hash", &[(I64, &alg_handle)]))
+        }
+
+        // Standalone `crypto.createHmac(alg, key)` — same shape as
+        // `createHash` above. Closes #1076 for the `const h = createHmac(...)`
+        // / for-of patterns where the chain-collapse can't match because
+        // `.update()` / `.digest()` happen on subsequent statements (or
+        // because the alg isn't a literal the fast path recognizes).
+        // `js_crypto_create_hmac` returns a NaN-boxed handle; dispatch_hmac
+        // (registered in `perry-stdlib/src/common/dispatch.rs`) handles the
+        // method routing.
+        Expr::Call { callee, args, .. }
+            if matches!(
+                callee.as_ref(),
+                Expr::PropertyGet { object, property } if property == "createHmac" && matches!(
+                    object.as_ref(),
+                    Expr::NativeModuleRef(n) if n == "crypto"
+                )
+            ) =>
+        {
+            if args.len() < 2 {
+                // Lower whatever's there to honor side effects, then
+                // return undefined — Node throws here, but our other
+                // crypto arms degrade gracefully rather than panic.
+                for a in args {
+                    let _ = lower_expr(ctx, a)?;
+                }
+                return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
+            }
+            let alg_box = lower_expr(ctx, &args[0])?;
+            let key_box = lower_expr(ctx, &args[1])?;
+            let blk = ctx.block();
+            let alg_handle = unbox_to_i64(blk, &alg_box);
+            let key_handle = unbox_to_i64(blk, &key_box);
+            Ok(blk.call(
+                DOUBLE,
+                "js_crypto_create_hmac",
+                &[(I64, &alg_handle), (I64, &key_handle)],
+            ))
         }
 
         // Phase H crypto: `crypto.randomBytes(n)` as a Buffer.

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -1130,6 +1130,12 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // h.update(x); h.digest()`. Returns a NaN-boxed POINTER_TAG handle id;
     // subsequent method dispatch flows through HANDLE_METHOD_DISPATCH.
     module.declare_function("js_crypto_create_hash", DOUBLE, &[I64]);
+    // Hmac-handle form (issue #1076): `crypto.createHmac(alg, key).update(d).
+    // digest(enc)` when `alg` isn't a literal string the chain-collapse
+    // recognizes (`const alg = "sha256"`, for-of bindings, ternaries, etc.).
+    // Same handle protocol as `js_crypto_create_hash` — POINTER_TAG box, then
+    // HANDLE_METHOD_DISPATCH routes `.update` / `.digest` to `dispatch_hmac`.
+    module.declare_function("js_crypto_create_hmac", DOUBLE, &[I64, I64]);
     module.declare_function("js_string_from_bytes", I64, &[I64, I32]);
     module.declare_function("js_string_from_wtf8_bytes", I64, &[I64, I32]);
     // Buffer.alloc(size, fill) — returns raw *mut BufferHeader.

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -126,6 +126,16 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
         return crate::crypto::dispatch_hash(handle, method_name, args);
     }
 
+    // crypto Hmac handle: createHmac(alg, key).update(...).digest(). Routes
+    // the runtime path the codegen falls back to whenever `alg` isn't a
+    // literal `"sha256"`. See #1076 for the silent-empty bug this closes.
+    #[cfg(feature = "crypto")]
+    if matches!(method_name, "update" | "digest")
+        && with_handle::<crate::crypto::HmacHandle, bool, _>(handle, |_| true).unwrap_or(false)
+    {
+        return crate::crypto::dispatch_hmac(handle, method_name, args);
+    }
+
     // SQLite Statement handle: stmt.raw() / .all() / .get() / .run() —
     // routes the dynamic-receiver path used by drizzle's
     // `this.stmt.raw().all(...params)` chain (where `this.stmt` is

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -786,3 +786,129 @@ pub unsafe fn dispatch_hash(handle: i64, method: &str, args: &[f64]) -> f64 {
 fn is_undefined_f64(v: f64) -> bool {
     v.to_bits() == 0x7FFC_0000_0000_0001
 }
+
+// ---------------------------------------------------------------------------
+// HMAC handle — covers the same #1076 silent-empty bug shape that the hash
+// handle covers for `createHash`. The chain-collapse in
+// `perry-codegen/src/expr.rs` only emits the literal-`"sha256"` fast path
+// for `crypto.createHmac(alg, key).update(data).digest(enc)`. When `alg`
+// is a `const`-bound identifier, a for-of binding, a ternary, or anything
+// else that isn't an inline `Expr::String`, the codegen falls back to
+// `js_crypto_create_hmac` which returns a handle. Subsequent `.update(...)`
+// and `.digest(...)` calls dispatch through `HANDLE_METHOD_DISPATCH` →
+// `dispatch_hmac` below. Supports sha1, sha256, sha512, and md5 — Node's
+// commonly-used HMAC algorithms. Unknown algorithms return undefined so
+// the symptom (silent empty hex) becomes a real `undefined.update is not
+// a function` at the call site instead of a wrong answer.
+// ---------------------------------------------------------------------------
+
+pub enum HmacState {
+    Sha1(hmac::Hmac<Sha1>),
+    Sha256(hmac::Hmac<Sha256>),
+    Sha512(hmac::Hmac<Sha512>),
+    Md5(hmac::Hmac<Md5>),
+}
+
+pub struct HmacHandle {
+    /// `Option` so `digest()` can `take()` ownership of the MAC
+    /// (`finalize()` consumes `self`).
+    state: std::sync::Mutex<Option<HmacState>>,
+}
+
+/// Allocate a new HMAC handle for `(alg, key)`. Mirrors `js_crypto_create_hash`
+/// in shape: returns the handle id NaN-boxed with `POINTER_TAG`. Unknown
+/// algorithms return undefined.
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_create_hmac(alg_ptr: i64, key_ptr: i64) -> f64 {
+    use hmac::Mac;
+    let alg_bytes = bytes_from_ptr(alg_ptr);
+    let alg = std::str::from_utf8(&alg_bytes)
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let key = bytes_from_ptr(key_ptr);
+    let state = match alg.as_str() {
+        "sha1" | "sha-1" => match hmac::Hmac::<Sha1>::new_from_slice(&key) {
+            Ok(m) => HmacState::Sha1(m),
+            Err(_) => return f64::from_bits(0x7FFC_0000_0000_0001),
+        },
+        "sha256" | "sha-256" => match hmac::Hmac::<Sha256>::new_from_slice(&key) {
+            Ok(m) => HmacState::Sha256(m),
+            Err(_) => return f64::from_bits(0x7FFC_0000_0000_0001),
+        },
+        "sha512" | "sha-512" => match hmac::Hmac::<Sha512>::new_from_slice(&key) {
+            Ok(m) => HmacState::Sha512(m),
+            Err(_) => return f64::from_bits(0x7FFC_0000_0000_0001),
+        },
+        "md5" => match hmac::Hmac::<Md5>::new_from_slice(&key) {
+            Ok(m) => HmacState::Md5(m),
+            Err(_) => return f64::from_bits(0x7FFC_0000_0000_0001),
+        },
+        _ => return f64::from_bits(0x7FFC_0000_0000_0001),
+    };
+    let handle: Handle = register_handle(HmacHandle {
+        state: std::sync::Mutex::new(Some(state)),
+    });
+    f64::from_bits(0x7FFD_0000_0000_0000u64 | ((handle as u64) & 0x0000_FFFF_FFFF_FFFF))
+}
+
+/// Dispatch `update` / `digest` on an HmacHandle. Called from
+/// `common/dispatch.rs::js_handle_method_dispatch`.
+pub unsafe fn dispatch_hmac(handle: i64, method: &str, args: &[f64]) -> f64 {
+    use hmac::Mac;
+    let h = match get_handle_mut::<HmacHandle>(handle) {
+        Some(h) => h,
+        None => return f64::from_bits(0x7FFC_0000_0000_0001),
+    };
+    match method {
+        "update" if !args.is_empty() => {
+            let ptr = (args[0].to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64;
+            let bytes = bytes_from_ptr(ptr);
+            let mut guard = h.state.lock().unwrap();
+            if let Some(state) = guard.as_mut() {
+                match state {
+                    HmacState::Sha1(x) => Mac::update(x, &bytes),
+                    HmacState::Sha256(x) => Mac::update(x, &bytes),
+                    HmacState::Sha512(x) => Mac::update(x, &bytes),
+                    HmacState::Md5(x) => Mac::update(x, &bytes),
+                }
+            }
+            // Return the same handle (NaN-boxed) so the chain
+            // `hmac.update(data).digest(enc)` continues against the same
+            // state. Mirrors Node's behavior (`update` returns `this`).
+            f64::from_bits(0x7FFD_0000_0000_0000u64 | ((handle as u64) & 0x0000_FFFF_FFFF_FFFF))
+        }
+        "digest" => {
+            let state = {
+                let mut guard = h.state.lock().unwrap();
+                guard.take()
+            };
+            let digest: Vec<u8> = match state {
+                Some(HmacState::Sha1(x)) => x.finalize().into_bytes().to_vec(),
+                Some(HmacState::Sha256(x)) => x.finalize().into_bytes().to_vec(),
+                Some(HmacState::Sha512(x)) => x.finalize().into_bytes().to_vec(),
+                Some(HmacState::Md5(x)) => x.finalize().into_bytes().to_vec(),
+                None => return f64::from_bits(0x7FFC_0000_0000_0001),
+            };
+            if args.is_empty() || is_undefined_f64(args[0]) {
+                let buf = alloc_buffer_from_slice(&digest);
+                f64::from_bits(0x7FFD_0000_0000_0000u64 | ((buf as u64) & 0x0000_FFFF_FFFF_FFFF))
+            } else {
+                let enc_ptr = (args[0].to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64;
+                let enc_bytes = bytes_from_ptr(enc_ptr);
+                let enc = std::str::from_utf8(&enc_bytes)
+                    .unwrap_or("hex")
+                    .to_ascii_lowercase();
+                let encoded = match enc.as_str() {
+                    "hex" => hex::encode(&digest),
+                    "base64" => base64::engine::general_purpose::STANDARD.encode(&digest),
+                    "base64url" => base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&digest),
+                    "binary" | "latin1" => String::from_utf8_lossy(&digest).into_owned(),
+                    _ => hex::encode(&digest),
+                };
+                let s = js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32);
+                f64::from_bits(0x7FFF_0000_0000_0000u64 | ((s as u64) & 0x0000_FFFF_FFFF_FFFF))
+            }
+        }
+        _ => f64::from_bits(0x7FFC_0000_0000_0001),
+    }
+}

--- a/test-files/test_crypto_hmac_dynamic_alg.ts
+++ b/test-files/test_crypto_hmac_dynamic_alg.ts
@@ -1,0 +1,38 @@
+// Issue #1076 — crypto.createHmac(alg, key) silently returned "" when
+// `alg` wasn't an inline string literal (const-bound, for-of-bound,
+// ternary). All four cases below must print the same 64-char hex digest
+// for the sha256/HMAC-SHA256 of "payload" under key "secret".
+//
+// Reference (Node):
+//   sha256("payload", "secret") =>
+//     b82fcb791acec57859b989b430a826488ce2e479fdf92326bd0a2e8375a42ba4
+
+import * as crypto from "node:crypto";
+
+const key = "secret";
+const data = "payload";
+
+// (1) inline literal — was the only working path
+console.log("(1)", crypto.createHmac("sha256", key).update(data).digest("hex"));
+
+// (2) for-of bound — was returning ""
+for (const alg of ["sha256", "sha1"]) {
+    console.log("(2)", alg, crypto.createHmac(alg, key).update(data).digest("hex"));
+}
+
+// (3) const reference — was returning ""
+const alg = "sha256";
+console.log("(3)", crypto.createHmac(alg, key).update(data).digest("hex"));
+
+// (4) ternary
+const useStrong = true;
+console.log("(4)", crypto.createHmac(useStrong ? "sha256" : "sha1", key).update(data).digest("hex"));
+
+// (5) bound-then-used (createHmac result stored in a local first, then chained)
+const h = crypto.createHmac("sha256", key);
+h.update(data);
+console.log("(5)", h.digest("hex"));
+
+// (6) ditto for createHash to exercise the same handle-runtime fallback
+const alg2 = "sha256";
+console.log("(6)", crypto.createHash(alg2).update(data).digest("hex"));


### PR DESCRIPTION
Closes #1076.

## Summary
- `crypto.createHmac(alg, key).update(data).digest(enc)` silently returned `""` whenever `alg` wasn't an inline `Expr::String` literal — const-bound names, for-of bindings, ternaries, etc. HMAC webhook verification, TOTP, and any code that picked the algorithm dynamically silently produced wrong answers instead of failing.
- Replace the chain-collapse catch-all empty-string return with a runtime handle path: allocate an Hmac/Hash handle and invoke `.update(data).digest(enc)` via `js_native_call_method`. Covers all non-literal alg cases plus the algorithms the fast path doesn't have direct FFI helpers for (sha1, sha512, md5 for HMAC; sha1, sha512 for hash).
- Add `HmacHandle` + `js_crypto_create_hmac` + `dispatch_hmac` in `perry-stdlib` mirroring the existing `HashHandle` shape. Supports sha1/sha256/sha512/md5 + hex/base64/base64url/binary digest encodings.
- Add a standalone codegen arm for `crypto.createHmac(alg, key)` mirroring the existing standalone `createHash` arm — covers `const h = createHmac(...); h.update().digest()` split across statements.

## Approach
Option C (per the task brief): runtime dispatch fallback for non-literal alg, plus a standalone handle-based codegen path for the bound-then-used pattern. The literal-`"sha256"` fast path (createHash sha256/md5, createHmac sha256) stays unchanged for the common case.

## Test plan
- [x] `cargo test --release -p perry-codegen --test manifest_consistency` — 4/4 pass
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry`
- [x] `test-files/test_crypto_hmac_dynamic_alg.ts` covers inline-literal, for-of, const-ref, ternary, bound-then-used, and createHash const-ref. Byte-for-byte match with `node --experimental-strip-types`.
- [x] `test-files/test_gap_node_crypto_buffer.ts` still passes (literal-alg fast path unchanged).

## Sibling APIs
- `createHmac` (algorithms: sha1, sha256, sha512, md5) — fixed via handle path.
- `createHash` (algorithms: sha1, sha256, sha512, md5) — non-literal alg now flows through the same handle path that the standalone arm already used; previously the chain-collapse caught it and returned `""`.
- `createCipheriv`, `createDecipheriv`, `createSign`, `createVerify` — out of scope for this PR. The const-binding aspect described in the issue would affect them similarly, but they're tracked elsewhere (#1075 is the active issue for `createCipheriv` AES-GCM wiring; signed APIs would need fresh handle types and FFI). Worth a follow-up sweep but not bundled here to keep this PR focused on the reported failure.

No version bump or changelog change (per worktree rules — maintainer applies at merge time).