### PR TITLE
fix(compile): PerryTS/storekit#1 — route FFI imports through manifest path

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -4496,6 +4496,23 @@ pub fn run_with_parse_cache(
                     Some(m) => sanitize_name(&m.name),
                     None => continue,
                 };
+                // PerryTS/storekit#1: when the import source is a package that
+                // declares `perry.nativeLibrary` (e.g. `@perryts/storekit`),
+                // its `.ts` source is a wrapper holding ambient `export
+                // declare function` signatures — the real implementation lives
+                // in the linked static library. There is no Perry wrapper
+                // symbol `perry_fn_<src>__<name>` for the source to emit, so
+                // registering the FFI specifier in `import_function_prefixes`
+                // would route the caller through an undefined wrapper and
+                // fail at link time. The per-specifier skip below lets
+                // `lower_call.rs` fall through to the FFI-manifest path
+                // (consults `ctx.ffi_signatures`, emits the call against the
+                // FFI symbol declared in `package.json :: perry.nativeLibrary.
+                // functions` plus a matching `declare external`).
+                let native_library_for_import = ctx
+                    .native_libraries
+                    .iter()
+                    .find(|nl| nl.module == import.source);
 
                 for spec in &import.specifiers {
                     // Handle namespace imports (import * as X)
@@ -4631,6 +4648,21 @@ pub fn run_with_parse_cache(
                         }
                         perry_hir::ImportSpecifier::Namespace { .. } => unreachable!(),
                     };
+
+                    // PerryTS/storekit#1: skip the wrapper-fn registration
+                    // when this specifier names an FFI function declared in
+                    // the source package's `perry.nativeLibrary.functions`
+                    // manifest. See the comment at `native_library_for_import`
+                    // above for the full rationale — the short version is
+                    // that the source `.ts` is ambient and has no Perry
+                    // wrapper for the linker to resolve, so we want the
+                    // FFI-manifest path in `lower_call.rs` to win.
+                    if native_library_for_import
+                        .map(|nl| nl.functions.iter().any(|f| f.name == exported_name))
+                        .unwrap_or(false)
+                    {
+                        continue;
+                    }
 
                     // Issue #310: when the source module re-exports the
                     // imported name as a namespace (`export * as Foo from


### PR DESCRIPTION
## Summary

Closes PerryTS/storekit#1. Imports from a package declaring `perry.nativeLibrary` (e.g. `@perryts/storekit`) carry ambient `export declare function` signatures only — the real implementation lives in the linked static library. The compile-side import loop was unconditionally registering every named/default specifier in `import_function_prefixes`, which made `lower_call.rs` emit a call against `perry_fn_<src>__<name>` for symbols whose source module never emits that wrapper (no body to compile). Result: link failure (`Undefined symbols: _perry_fn_..._js_storekit_start_listener`), or — on older Perry builds where the codegen path differed — an LLVM IR verifier error reporting `use of undefined value '@js_storekit_*'` because the call was emitted with no matching `declare`.

Fix: when the import source matches a `perry.nativeLibrary` package and the specifier's exported name is listed in `perry.nativeLibrary.functions`, skip the `import_function_prefixes` registration. `lower_call.rs` then falls through to the FFI-manifest path (`ctx.ffi_signatures`), which emits a direct call to the declared FFI symbol along with a matching `declare external` at the top of the caller IR. The native-library lookup is pre-computed once per import (outside the per-specifier loop) so the check is constant-time.

## Before / after

`main.ts`:
```ts
import { js_storekit_start_listener } from \"@perryts/storekit\";
js_storekit_start_listener();
```

Before:
```
Undefined symbols for architecture arm64:
  \"_perry_fn_node_modules__perryts_storekit_src_index_ts__js_storekit_start_listener\", referenced from:
      _main in main_ts.o
```

After (caller IR):
```llvm
declare void @js_storekit_start_listener()
...
call void @js_storekit_start_listener()
```

For the 6-symbol smoke test (all params/returns shapes in storekit's manifest):
```llvm
declare void @js_storekit_start_listener()
declare double @js_storekit_load_products(ptr)
declare double @js_storekit_purchase(ptr)
declare double @js_storekit_restore()
declare double @js_storekit_has_subscription()
declare double @js_storekit_get_jws()
```

All declares match the calls — types come from the FFI-manifest path in `lower_call.rs` (which is what `ffi_signatures`-driven calls were always supposed to use).

## Test plan

- [x] `cargo test --release -p perry --bin perry` → 332 passed, 0 failed
- [x] Reproduce from PerryTS/storekit#1 (`import { js_storekit_start_listener } from \"@perryts/storekit\"; js_storekit_start_listener();`) — compiles and runs (exits 0) instead of failing at link
- [x] Inspect generated IR — every FFI symbol has a matching `declare external` next to its `call`
- [ ] Smoke against an unscoped non-manifest dep (e.g. `perry-searchbird-apple-auth`) to confirm no regression on the path that already worked