### PR TITLE
fix(hir): #1069 — synthetic-arguments callees: don't pad missing args + bounds-check OOB

### DIFF
--- a/crates/perry-hir/src/lower.rs
+++ b/crates/perry-hir/src/lower.rs
@@ -66,8 +66,7 @@ pub struct LoweringContext {
     /// runtime `arguments` array. Padding inflates `arguments.length` to
     /// the declared fixed-param count regardless of how many args the
     /// caller actually passed (issue #1069).
-    pub(crate) func_defaults:
-        Vec<(FuncId, Vec<Option<Expr>>, Vec<LocalId>, Option<usize>, bool)>,
+    pub(crate) func_defaults: Vec<(FuncId, Vec<Option<Expr>>, Vec<LocalId>, Option<usize>, bool)>,
     /// Classes: name -> id
     pub(crate) classes: Vec<(String, ClassId)>,
     /// Static members of classes: class_name -> (static_field_names, static_method_names)
@@ -4501,8 +4500,13 @@ fn lower_module_decl(
                         .params
                         .last()
                         .is_some_and(|p| p.is_rest && p.name == "arguments");
-                    ctx.func_defaults
-                        .push((func.id, defaults, param_ids, rest_idx, has_synth_args));
+                    ctx.func_defaults.push((
+                        func.id,
+                        defaults,
+                        param_ids,
+                        rest_idx,
+                        has_synth_args,
+                    ));
                     module.functions.push(func);
                     // Track in exports
                     module.exports.push(Export::Named {
@@ -5516,8 +5520,13 @@ fn lower_module_decl(
                                 .params
                                 .last()
                                 .is_some_and(|p| p.is_rest && p.name == "arguments");
-                            ctx.func_defaults
-                                .push((func.id, defaults, param_ids, rest_idx, has_synth_args));
+                            ctx.func_defaults.push((
+                                func.id,
+                                defaults,
+                                param_ids,
+                                rest_idx,
+                                has_synth_args,
+                            ));
                             module.functions.push(func);
                             // Register under both names: callable locally as
                             // `<ident>` (some modules also `export { foo }`
@@ -5590,8 +5599,13 @@ fn lower_module_decl(
                             .params
                             .last()
                             .is_some_and(|p| p.is_rest && p.name == "arguments");
-                        ctx.func_defaults
-                            .push((func.id, defaults, param_ids, rest_idx, has_synth_args));
+                        ctx.func_defaults.push((
+                            func.id,
+                            defaults,
+                            param_ids,
+                            rest_idx,
+                            has_synth_args,
+                        ));
                         module.functions.push(func);
                         // Both the named export entry (so the importer's
                         // namespace populator sees `default`) and the
@@ -6165,8 +6179,13 @@ fn lower_stmt(ctx: &mut LoweringContext, module: &mut Module, stmt: &ast::Stmt) 
                         .params
                         .last()
                         .is_some_and(|p| p.is_rest && p.name == "arguments");
-                    ctx.func_defaults
-                        .push((func.id, defaults, param_ids, rest_idx, has_synth_args));
+                    ctx.func_defaults.push((
+                        func.id,
+                        defaults,
+                        param_ids,
+                        rest_idx,
+                        has_synth_args,
+                    ));
                     module.functions.push(func);
                 }
                 ast::Decl::Var(var_decl) => {

--- a/crates/perry-hir/src/lower.rs
+++ b/crates/perry-hir/src/lower.rs
@@ -54,11 +54,20 @@ pub struct LoweringContext {
     pub(crate) functions: Vec<(String, FuncId)>,
     /// Function parameter defaults: func_id -> (defaults, param_local_ids)
     /// Per-function param-default info used by the call-site fill pass:
-    /// `(func_id, [Option<default> per param], [LocalId per param], Option<rest_param_index>)`.
+    /// `(func_id, [Option<default> per param], [LocalId per param], Option<rest_param_index>, has_synthetic_arguments)`.
     /// The rest-param index (if any) is the position of `...rest`; the fill
     /// loop must stop before it because rest params get bundled at runtime
     /// from trailing positional args, not filled with `undefined`.
-    pub(crate) func_defaults: Vec<(FuncId, Vec<Option<Expr>>, Vec<LocalId>, Option<usize>)>,
+    /// `has_synthetic_arguments` is true when the trailing rest param was
+    /// inserted by `append_synthetic_arguments_param` because the body
+    /// references the magic `arguments` identifier — in that case the call
+    /// site must NOT pad missing fixed-param slots with `undefined`, because
+    /// the codegen synth-args bundle path uses `args.len()` to size the
+    /// runtime `arguments` array. Padding inflates `arguments.length` to
+    /// the declared fixed-param count regardless of how many args the
+    /// caller actually passed (issue #1069).
+    pub(crate) func_defaults:
+        Vec<(FuncId, Vec<Option<Expr>>, Vec<LocalId>, Option<usize>, bool)>,
     /// Classes: name -> id
     pub(crate) classes: Vec<(String, ClassId)>,
     /// Static members of classes: class_name -> (static_field_names, static_method_names)
@@ -1171,12 +1180,17 @@ impl LoweringContext {
     pub(crate) fn lookup_func_defaults(
         &self,
         func_id: FuncId,
-    ) -> Option<(&[Option<Expr>], &[LocalId], Option<usize>)> {
+    ) -> Option<(&[Option<Expr>], &[LocalId], Option<usize>, bool)> {
         self.func_defaults
             .iter()
-            .find(|(id, _, _, _)| *id == func_id)
-            .map(|(_, defaults, param_ids, rest_idx)| {
-                (defaults.as_slice(), param_ids.as_slice(), *rest_idx)
+            .find(|(id, _, _, _, _)| *id == func_id)
+            .map(|(_, defaults, param_ids, rest_idx, has_synth_args)| {
+                (
+                    defaults.as_slice(),
+                    param_ids.as_slice(),
+                    *rest_idx,
+                    *has_synth_args,
+                )
             })
     }
 
@@ -4483,8 +4497,12 @@ fn lower_module_decl(
                         func.params.iter().map(|p| p.default.clone()).collect();
                     let param_ids: Vec<LocalId> = func.params.iter().map(|p| p.id).collect();
                     let rest_idx = func.params.iter().position(|p| p.is_rest);
+                    let has_synth_args = func
+                        .params
+                        .last()
+                        .is_some_and(|p| p.is_rest && p.name == "arguments");
                     ctx.func_defaults
-                        .push((func.id, defaults, param_ids, rest_idx));
+                        .push((func.id, defaults, param_ids, rest_idx, has_synth_args));
                     module.functions.push(func);
                     // Track in exports
                     module.exports.push(Export::Named {
@@ -5494,8 +5512,12 @@ fn lower_module_decl(
                             let param_ids: Vec<LocalId> =
                                 func.params.iter().map(|p| p.id).collect();
                             let rest_idx = func.params.iter().position(|p| p.is_rest);
+                            let has_synth_args = func
+                                .params
+                                .last()
+                                .is_some_and(|p| p.is_rest && p.name == "arguments");
                             ctx.func_defaults
-                                .push((func.id, defaults, param_ids, rest_idx));
+                                .push((func.id, defaults, param_ids, rest_idx, has_synth_args));
                             module.functions.push(func);
                             // Register under both names: callable locally as
                             // `<ident>` (some modules also `export { foo }`
@@ -5564,8 +5586,12 @@ fn lower_module_decl(
                             func.params.iter().map(|p| p.default.clone()).collect();
                         let param_ids: Vec<LocalId> = func.params.iter().map(|p| p.id).collect();
                         let rest_idx = func.params.iter().position(|p| p.is_rest);
+                        let has_synth_args = func
+                            .params
+                            .last()
+                            .is_some_and(|p| p.is_rest && p.name == "arguments");
                         ctx.func_defaults
-                            .push((func.id, defaults, param_ids, rest_idx));
+                            .push((func.id, defaults, param_ids, rest_idx, has_synth_args));
                         module.functions.push(func);
                         // Both the named export entry (so the importer's
                         // namespace populator sees `default`) and the
@@ -6135,8 +6161,12 @@ fn lower_stmt(ctx: &mut LoweringContext, module: &mut Module, stmt: &ast::Stmt) 
                         func.params.iter().map(|p| p.default.clone()).collect();
                     let param_ids: Vec<LocalId> = func.params.iter().map(|p| p.id).collect();
                     let rest_idx = func.params.iter().position(|p| p.is_rest);
+                    let has_synth_args = func
+                        .params
+                        .last()
+                        .is_some_and(|p| p.is_rest && p.name == "arguments");
                     ctx.func_defaults
-                        .push((func.id, defaults, param_ids, rest_idx));
+                        .push((func.id, defaults, param_ids, rest_idx, has_synth_args));
                     module.functions.push(func);
                 }
                 ast::Decl::Var(var_decl) => {

--- a/crates/perry-hir/src/lower/expr_call.rs
+++ b/crates/perry-hir/src/lower/expr_call.rs
@@ -6579,49 +6579,49 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                         // fixed-param padding and the body's default-fill
                         // statements substitute user defaults.
                     } else {
-                    let defaults = defaults.to_vec();
-                    let param_ids = param_ids.to_vec();
-                    let num_provided = args.len();
-                    let fill_end = match rest_idx {
-                        Some(i) => i,
-                        None => defaults.len(),
-                    };
-                    // Build substitution map: callee param LocalId -> actual arg expression
-                    // For provided args, map to the caller's arg expression
-                    // For defaulted args, map to the expanded default (built incrementally)
-                    let mut param_map: Vec<(LocalId, Expr)> = Vec::new();
-                    for i in 0..param_ids.len().min(num_provided) {
-                        param_map.push((param_ids[i], args[i].clone()));
-                    }
-                    // Fill in missing arguments with their defaults, substituting
-                    // any parameter references to use the caller's scope.
-                    //
-                    // Refs #645 deeper followup / #488 drizzle-sqlite: push
-                    // something for EVERY slot from num_provided..defaults.len(),
-                    // even when defaults[i] is None — otherwise a later Some
-                    // default lands at the wrong positional slot. Drizzle's
-                    // tableBase(name, columns, extraConfig, schema?, baseName=name)
-                    // is the load-bearing repro: 3-arg call, slot 3 (schema)
-                    // has None default and slot 4 (baseName) has Some(name).
-                    // The pre-fix loop skipped slot 3 and pushed baseName's
-                    // default into slot 3 — so schema got the table name and
-                    // rendered SQL became `"users"."users"` instead of `"users"`.
-                    for i in num_provided..fill_end {
-                        let substituted = if let Some(default_expr) = &defaults[i] {
-                            LoweringContext::substitute_param_refs_in_default(
-                                default_expr,
-                                &param_map,
-                            )
-                        } else {
-                            Expr::Undefined
+                        let defaults = defaults.to_vec();
+                        let param_ids = param_ids.to_vec();
+                        let num_provided = args.len();
+                        let fill_end = match rest_idx {
+                            Some(i) => i,
+                            None => defaults.len(),
                         };
-                        // Add this expanded default to the map so later defaults
-                        // can reference it (e.g., c = b where b was also defaulted)
-                        if i < param_ids.len() {
-                            param_map.push((param_ids[i], substituted.clone()));
+                        // Build substitution map: callee param LocalId -> actual arg expression
+                        // For provided args, map to the caller's arg expression
+                        // For defaulted args, map to the expanded default (built incrementally)
+                        let mut param_map: Vec<(LocalId, Expr)> = Vec::new();
+                        for i in 0..param_ids.len().min(num_provided) {
+                            param_map.push((param_ids[i], args[i].clone()));
                         }
-                        args.push(substituted);
-                    }
+                        // Fill in missing arguments with their defaults, substituting
+                        // any parameter references to use the caller's scope.
+                        //
+                        // Refs #645 deeper followup / #488 drizzle-sqlite: push
+                        // something for EVERY slot from num_provided..defaults.len(),
+                        // even when defaults[i] is None — otherwise a later Some
+                        // default lands at the wrong positional slot. Drizzle's
+                        // tableBase(name, columns, extraConfig, schema?, baseName=name)
+                        // is the load-bearing repro: 3-arg call, slot 3 (schema)
+                        // has None default and slot 4 (baseName) has Some(name).
+                        // The pre-fix loop skipped slot 3 and pushed baseName's
+                        // default into slot 3 — so schema got the table name and
+                        // rendered SQL became `"users"."users"` instead of `"users"`.
+                        for i in num_provided..fill_end {
+                            let substituted = if let Some(default_expr) = &defaults[i] {
+                                LoweringContext::substitute_param_refs_in_default(
+                                    default_expr,
+                                    &param_map,
+                                )
+                            } else {
+                                Expr::Undefined
+                            };
+                            // Add this expanded default to the map so later defaults
+                            // can reference it (e.g., c = b where b was also defaulted)
+                            if i < param_ids.len() {
+                                param_map.push((param_ids[i], substituted.clone()));
+                            }
+                            args.push(substituted);
+                        }
                     } // end of !has_synth_args branch
                 }
             }

--- a/crates/perry-hir/src/lower/expr_call.rs
+++ b/crates/perry-hir/src/lower/expr_call.rs
@@ -6546,10 +6546,9 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
             // Fill in default arguments if callee is a known function
             let mut args = args;
             if let Expr::FuncRef(func_id) = &callee_expr {
-                if let Some((defaults, param_ids, rest_idx)) = ctx.lookup_func_defaults(*func_id) {
-                    let defaults = defaults.to_vec();
-                    let param_ids = param_ids.to_vec();
-                    let num_provided = args.len();
+                if let Some((defaults, param_ids, rest_idx, has_synth_args)) =
+                    ctx.lookup_func_defaults(*func_id)
+                {
                     // Refs #653 followup to v0.5.789's #645 fix: stop the
                     // default-fill loop BEFORE the rest param's slot. Pushing
                     // `Expr::Undefined` for a rest param turns
@@ -6558,6 +6557,31 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                     // `args[0] = undefined`. Real semantics: trailing positional
                     // args get bundled into the rest array at runtime; missing
                     // ones produce an empty array, NOT a single-undefined array.
+                    //
+                    // Issue #1069: synthetic-`arguments` rest param. For
+                    // `function f(a, b) { arguments }`, the HIR appends a
+                    // hidden `arguments`-named rest param so the body can
+                    // reference it. The codegen call-site synth-args path
+                    // (`crates/perry-codegen/src/lower_call.rs:974`) uses
+                    // `args.len()` to size the runtime `arguments` array
+                    // AND pads missing fixed-param slots with `undefined`
+                    // itself, so the body's `if (param === undefined) {
+                    // param = default; }` prefix applies user defaults
+                    // there. If we let the loop below push Undefined into
+                    // the fixed-param slots, `args.len()` inflates to the
+                    // declared fixed-param count and `arguments.length`
+                    // reads as the declared count regardless of the
+                    // caller's actual arg count — `f()` reports
+                    // `arguments.length === 2` instead of `0`. Skip the
+                    // fill loop entirely for synth-args callees.
+                    if has_synth_args {
+                        // Skip the default-fill loop. Codegen handles the
+                        // fixed-param padding and the body's default-fill
+                        // statements substitute user defaults.
+                    } else {
+                    let defaults = defaults.to_vec();
+                    let param_ids = param_ids.to_vec();
+                    let num_provided = args.len();
                     let fill_end = match rest_idx {
                         Some(i) => i,
                         None => defaults.len(),
@@ -6598,6 +6622,7 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
                         }
                         args.push(substituted);
                     }
+                    } // end of !has_synth_args branch
                 }
             }
 

--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -194,8 +194,11 @@ fn lower_method_prop(
         let defaults: Vec<Option<Expr>> = params.iter().map(|p| p.default.clone()).collect();
         let param_ids: Vec<LocalId> = params.iter().map(|p| p.id).collect();
         let rest_idx = params.iter().position(|p| p.is_rest);
+        let has_synth_args = params
+            .last()
+            .is_some_and(|p| p.is_rest && p.name == "arguments");
         ctx.func_defaults
-            .push((func_id, defaults, param_ids, rest_idx));
+            .push((func_id, defaults, param_ids, rest_idx, has_synth_args));
         ctx.pending_functions.push(Function {
             id: func_id,
             name: func_name,

--- a/crates/perry-runtime/src/value.rs
+++ b/crates/perry-runtime/src/value.rs
@@ -1154,6 +1154,23 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
             let arr = raw_ptr as *const crate::array::ArrayHeader;
             return crate::array::js_array_get_f64(arr, idx_i32 as u32);
         }
+        // Issue #1069: bounds-check regular arrays so out-of-range reads
+        // return TAG_UNDEFINED instead of whatever's in the slot. Without
+        // this, an empty (or short) array — most visibly the synthetic
+        // `arguments` array bundled by the call-site for caller arity 0 —
+        // returns the raw 0.0 slot value because `js_array_alloc` rounds
+        // capacity up to MIN_ARRAY_CAPACITY and the unchecked load reads
+        // past `length` into zeroed-but-allocated storage. `arguments[0]`
+        // on `function f() { arguments[0] }; f()` printed `0` instead of
+        // `undefined`. The narrow gate (GC_TYPE_ARRAY) keeps object
+        // numeric-key fast path unchanged.
+        if obj_type == crate::gc::GC_TYPE_ARRAY {
+            let arr = raw_ptr as *const crate::array::ArrayHeader;
+            let length = unsafe { (*arr).length };
+            if (idx_i32 as u32) >= length {
+                return f64::from_bits(TAG_UNDEFINED);
+            }
+        }
     }
     let elem_addr = raw_ptr.wrapping_add(8 + (idx_i32 as usize) * 8);
     let v = unsafe { *(elem_addr as *const f64) };

--- a/test-files/issue_1069/main.ts
+++ b/test-files/issue_1069/main.ts
@@ -1,0 +1,26 @@
+// Issue #1069: cross-module `arguments` bundling for Effect's `dual()` pattern.
+//
+// `duallib` exports `hasProperty = dual(2, body)` — a closure stored as a
+// const, whose body reads `arguments.length` to discriminate data-first vs
+// curried. The previous PR series (#915 / gap 1) made the LOCAL call site bundle
+// ALL args for synthetic-`arguments` rest params. But the CROSS-MODULE call
+// site in `lower_call.rs` (the `ExternFuncRef` path that emits
+// `perry_fn_<src>__<name>(...)`) still only bundles TRAILING args beyond
+// fixed_count — matching ordinary user `...rest`, not the synthetic-arguments
+// case. So `hasProperty({}, "x")` cross-module reaches its body with
+// `arguments.length === 0` (only zero trailing args) instead of `2`.
+import { hasProperty, getArity } from "duallib";
+
+// Data-first: 2 args → boolean
+console.log("hasProperty 2-arg:", hasProperty({ x: 1 }, "x"));  // expect: true
+console.log("hasProperty 2-arg miss:", hasProperty({ x: 1 }, "y"));  // expect: false
+
+// Curried: 1 arg → function
+const isX = hasProperty("x") as any;
+console.log("hasProperty curried typeof:", typeof isX);  // expect: function
+console.log("hasProperty curried apply:", isX({ x: 1 }));  // expect: true
+
+// Plain arity probe (not dual, just an exported `function` reading arguments).
+console.log("getArity 0:", getArity());        // expect: 0
+console.log("getArity 1:", getArity("a"));     // expect: 1
+console.log("getArity 3:", getArity(1, 2, 3)); // expect: 3

--- a/test-files/issue_1069/node_modules/duallib/index.ts
+++ b/test-files/issue_1069/node_modules/duallib/index.ts
@@ -1,0 +1,35 @@
+// Effect-style `dual()` helper: returns a function whose body reads
+// `arguments.length` to dispatch data-first vs curried.
+function dual(arity: number, body: any): any {
+  return function () {
+    if (arguments.length >= arity) {
+      // Data-first path: forward all args to the body. We use a plain
+      // call shape so the body still sees `arguments.length` correctly
+      // through its own synthetic-arguments slot.
+      const a = arguments;
+      if (a.length === 2) return body(a[0], a[1]);
+      if (a.length === 1) return body(a[0]);
+      if (a.length === 3) return body(a[0], a[1], a[2]);
+      return body();
+    }
+    // Curried path: capture the first arg and return a function that
+    // takes the rest. Body is `(self, x) => ...`, curried form is
+    // `(x) => (self) => body(self, x)`.
+    const first = arguments[0];
+    return function (self: any) {
+      return body(self, first);
+    };
+  };
+}
+
+// Public API mirrors Effect's `Predicate.hasProperty`.
+export const hasProperty = dual(2, (self: any, property: any) => {
+  return typeof self === "object" && self !== null && property in self;
+});
+
+// Sanity: plain exported function that reads `arguments.length` directly.
+// Tests the simpler "function decl with synthetic arguments" cross-module
+// path — no dual wrapper.
+export function getArity(): number {
+  return arguments.length;
+}

--- a/test-files/issue_1069/node_modules/duallib/package.json
+++ b/test-files/issue_1069/node_modules/duallib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "duallib",
+  "version": "0.0.1",
+  "main": "index.ts",
+  "types": "index.ts"
+}

--- a/test-files/issue_1069/package.json
+++ b/test-files/issue_1069/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "issue-1069-probe",
+  "version": "0.0.1",
+  "perry": {
+    "compilePackages": ["duallib"],
+    "allow": { "compilePackages": ["duallib"] }
+  }
+}

--- a/test-files/test_issue_1069_arguments_coverage.ts
+++ b/test-files/test_issue_1069_arguments_coverage.ts
@@ -1,0 +1,91 @@
+// Coverage probe for issue #1069's "arguments magic object" sub-target.
+// Walks through every pattern Effect's `dual()` plus general Node idioms
+// rely on. Each block prints something Node prints byte-for-byte, so we
+// can diff against `node --experimental-strip-types`.
+
+// 1. Basic arguments.length and indexed access.
+function args1(a: any, b: any) {
+  return [arguments.length, arguments[0], arguments[1], arguments[2]];
+}
+console.log("1a:", JSON.stringify(args1()));                  // [0,undefined,undefined,undefined]
+console.log("1b:", JSON.stringify(args1(10)));                // [1,10,undefined,undefined]
+console.log("1c:", JSON.stringify(args1(10, 20)));            // [2,10,20,undefined]
+console.log("1d:", JSON.stringify(args1(10, 20, 30, 40)));    // [4,10,20,30]
+
+// 2. Spread of arguments into another call.
+function args2() {
+  return Math.max(...arguments as any);
+}
+console.log("2:", args2(3, 1, 4, 1, 5, 9, 2, 6));             // 9
+
+// 3. Array.from(arguments).
+function args3() {
+  return Array.from(arguments).join("-");
+}
+console.log("3:", args3(1, 2, 3, "x"));                       // 1-2-3-x
+
+// 4. arguments forwarded into .apply(this, arguments).
+function inner4(this: any, x: number, y: number, z: number) {
+  return x * 100 + y * 10 + z;
+}
+function outer4() {
+  return (inner4 as any).apply(null, arguments);
+}
+console.log("4:", outer4(1, 2, 3));                           // 123
+
+// 5. for-loop over arguments by index.
+function args5() {
+  let s = "";
+  for (let i = 0; i < arguments.length; i++) s += arguments[i];
+  return s;
+}
+console.log("5:", args5("a", "b", "c", "d"));                 // abcd
+
+// 6. arguments inside a nested arrow inherits the enclosing function's.
+function args6() {
+  const inner = () => arguments[0];
+  return inner();
+}
+console.log("6:", args6("captured"));                         // captured
+
+// 7. arguments.length in a returned FnExpr (the gap-1 pattern).
+function make7() {
+  return function (a: any, b: any) {
+    return arguments.length;
+  };
+}
+const f7 = make7();
+console.log("7a:", f7());                                     // 0
+console.log("7b:", f7(1, 2, 3));                              // 3
+
+// 8. Effect-style dual() dispatcher.
+function dual8(arity: number, body: any): any {
+  return function () {
+    if (arguments.length >= arity) {
+      if (arguments.length === 2) return body(arguments[0], arguments[1]);
+      if (arguments.length === 3) return body(arguments[0], arguments[1], arguments[2]);
+      return body();
+    }
+    const first = arguments[0];
+    return function (self: any) { return body(self, first); };
+  };
+}
+const hasProperty8 = dual8(2, (self: any, prop: any) =>
+  typeof self === "object" && self !== null && prop in self);
+console.log("8a:", hasProperty8({ k: 1 }, "k"));              // true
+console.log("8b:", hasProperty8({ k: 1 }, "x"));              // false
+console.log("8c:", typeof hasProperty8("k"));                 // function
+console.log("8d:", (hasProperty8("k") as any)({ k: 1 }));     // true
+
+// 9. Class method reading arguments.
+class C9 {
+  m() {
+    return arguments.length;
+  }
+  static s() {
+    return arguments.length;
+  }
+}
+const c9 = new C9();
+console.log("9a:", c9.m(1, 2, 3));                            // 3
+console.log("9b:", C9.s("a", "b", "c", "d", "e"));            // 5


### PR DESCRIPTION
## Summary

Sub-target of #1069's "`arguments` magic object" unlock. For `function f(a, b) { arguments.length }` called as `f()`, Perry reported `arguments.length === 2` instead of `0`, and `arguments[i]` on an empty rest array returned `0.0` instead of `undefined`.

Two layered bugs:

1. **HIR default-fill at call site** (`lower/expr_call.rs::lower_call`): for synth-`arguments` callees, the call-site fill loop padded missing fixed-param slots with `Expr::Undefined`, which inflated `args.len()` — and the codegen synth-args bundle path uses `args.len()` to size the runtime `arguments` array. So `f()` saw `arguments.length === 2`. Fix: thread a `has_synth_args` flag through `func_defaults` (5 push sites + the `lookup_func_defaults` consumer) and skip the fill loop entirely for synth-args callees. Codegen already pads missing fixed-param slots itself in that branch, and the body's `if (param === undefined) { param = default; }` prefix still applies user defaults.

2. **`js_dyn_index_get` OOB** (`runtime/src/value.rs`): the `Type::Any` IndexGet fast path (issue #514) routes numeric reads through `js_dyn_index_get`. For `LAZY_ARRAY`/`FORWARDED` it delegates to `js_array_get_f64` which bounds-checks, but for regular `GC_TYPE_ARRAY` it does raw `arr + 8 + idx*8` with no `length` guard. `js_array_alloc(0)` rounds capacity up to `MIN_ARRAY_CAPACITY` so `arguments[0]` on an empty rest array read zeroed-but-allocated storage. Fix: one-line `idx >= length` check on the `GC_TYPE_ARRAY` branch.

## Test plan

- [x] New: `test-files/test_issue_1069_arguments_coverage.ts` — 9 patterns Effect's `dual()` and general Node code rely on (length, indexed access, spread, `Array.from`, `.apply(this, arguments)`, arrow capture, class instance + static methods).
- [x] New: `test-files/issue_1069/` cross-module — `dual()`-returned closure imported from a `node_modules/duallib/` fixture, exercises the ExternFuncRef boundary.
- [x] Both match `node --experimental-strip-types` byte-for-byte.
- [x] Regression check: pre-existing tests `test_issue_effect_arguments_length_returned_fn`, `test_issue_effect_tag_deeper`, `test_issue_effect_tag_undefined`, `test_issue_effect_factory_static_dispatch`, `test_default_params`, `test_rest_params` still pass.
- [x] Gap suite baseline unchanged: 35/36 (the lone fail `test_gap_class_advanced` is pre-existing — static block initialization, unrelated to `arguments`).

Per CLAUDE.md's external-contributor guidance, leaving the version bump + CHANGELOG entry for the maintainer to fold in at merge time.