### PR TITLE
fix(jwt): #1074 — algorithm const ref + sign/verify dispatch

### DIFF
--- a/crates/perry-codegen/src/lower_call/native.rs
+++ b/crates/perry-codegen/src/lower_call/native.rs
@@ -261,6 +261,13 @@ fn lower_jsonwebtoken_sign(ctx: &mut FnCtx<'_>, args: &[Expr]) -> Result<String>
     let payload_ptr = lower_jsonwebtoken_payload_ptr(ctx, &args[0])?;
     let secret_ptr = get_raw_string_ptr(ctx, &args[1])?;
     let mut runtime = "js_jwt_sign";
+    // #1074: when the user writes `{ algorithm: ALG }` (i.e. `algorithm`
+    // is a non-literal expression), the inline-literal fast path can't
+    // pick a typed runtime helper. We track that as a fallback to
+    // `js_jwt_sign_dyn`, which takes the alg string as a runtime argument
+    // and dispatches there. Pre-#1074 this fell through to the HS256
+    // path silently — a real cryptographic downgrade.
+    let mut alg_ptr_dyn: Option<String> = None;
     let mut expires_in = double_literal(0.0);
     let mut kid_ptr = "0".to_string();
 
@@ -276,7 +283,11 @@ fn lower_jsonwebtoken_sign(ctx: &mut FnCtx<'_>, args: &[Expr]) -> Result<String>
                                 _ => "js_jwt_sign",
                             };
                         } else {
-                            let _ = lower_expr(ctx, val)?;
+                            // Non-literal alg (#1074): lower to a string
+                            // pointer and let `js_jwt_sign_dyn` pick the
+                            // right backend at runtime.
+                            alg_ptr_dyn = Some(get_raw_string_ptr(ctx, val)?);
+                            runtime = "js_jwt_sign_dyn";
                         }
                     }
                     "expiresIn" => {
@@ -291,7 +302,26 @@ fn lower_jsonwebtoken_sign(ctx: &mut FnCtx<'_>, args: &[Expr]) -> Result<String>
                 }
             }
         } else {
-            let _ = lower_expr(ctx, options)?;
+            // #1074 case C: the options expression is not an inline
+            // object literal (e.g. `const opts = { algorithm: "ES256" };
+            // jwt.sign(p, k, opts)`). Lower options as a NaN-boxed
+            // JSValue and route to `js_jwt_sign_dyn_opts`, which
+            // extracts algorithm/expiresIn/keyid at runtime.
+            let opts_val = lower_expr(ctx, options)?;
+            for extra in args.iter().skip(3) {
+                let _ = lower_expr(ctx, extra)?;
+            }
+            ctx.pending_declares.push((
+                "js_jwt_sign_dyn_opts".to_string(),
+                I64,
+                vec![I64, I64, DOUBLE],
+            ));
+            let raw = ctx.block().call(
+                I64,
+                "js_jwt_sign_dyn_opts",
+                &[(I64, &payload_ptr), (I64, &secret_ptr), (DOUBLE, &opts_val)],
+            );
+            return Ok(ctx.block().bitcast_i64_to_double(&raw));
         }
     }
 
@@ -299,18 +329,40 @@ fn lower_jsonwebtoken_sign(ctx: &mut FnCtx<'_>, args: &[Expr]) -> Result<String>
         let _ = lower_expr(ctx, extra)?;
     }
 
-    ctx.pending_declares
-        .push((runtime.to_string(), I64, vec![I64, I64, DOUBLE, I64]));
-    let raw = ctx.block().call(
-        I64,
-        runtime,
-        &[
-            (I64, &payload_ptr),
-            (I64, &secret_ptr),
-            (DOUBLE, &expires_in),
-            (I64, &kid_ptr),
-        ],
-    );
+    // Build the call. The five-arg dyn path takes the alg string first;
+    // the four-arg typed-helper path doesn't (the algorithm is implied
+    // by the symbol name).
+    let raw = if let Some(alg_ptr) = alg_ptr_dyn {
+        ctx.pending_declares.push((
+            "js_jwt_sign_dyn".to_string(),
+            I64,
+            vec![I64, I64, I64, DOUBLE, I64],
+        ));
+        ctx.block().call(
+            I64,
+            "js_jwt_sign_dyn",
+            &[
+                (I64, &alg_ptr),
+                (I64, &payload_ptr),
+                (I64, &secret_ptr),
+                (DOUBLE, &expires_in),
+                (I64, &kid_ptr),
+            ],
+        )
+    } else {
+        ctx.pending_declares
+            .push((runtime.to_string(), I64, vec![I64, I64, DOUBLE, I64]));
+        ctx.block().call(
+            I64,
+            runtime,
+            &[
+                (I64, &payload_ptr),
+                (I64, &secret_ptr),
+                (DOUBLE, &expires_in),
+                (I64, &kid_ptr),
+            ],
+        )
+    };
     Ok(ctx.block().bitcast_i64_to_double(&raw))
 }
 
@@ -341,6 +393,10 @@ fn lower_jsonwebtoken_verify(ctx: &mut FnCtx<'_>, args: &[Expr]) -> Result<Strin
     let token_ptr = get_raw_string_ptr(ctx, &args[0])?;
     let secret_ptr = get_raw_string_ptr(ctx, &args[1])?;
     let mut runtime = "js_jwt_verify";
+    // #1074: when `algorithm` (or the first entry of `algorithms`) is a
+    // non-literal expression, lower it as a string and route through
+    // `js_jwt_verify_dyn` instead of silently picking HS256.
+    let mut alg_ptr_dyn: Option<String> = None;
 
     if let Some(options) = args.get(2) {
         if let Some(props) = extract_options_fields(ctx, options) {
@@ -356,7 +412,8 @@ fn lower_jsonwebtoken_verify(ctx: &mut FnCtx<'_>, args: &[Expr]) -> Result<Strin
                                 _ => "js_jwt_verify",
                             };
                         } else {
-                            let _ = lower_expr(ctx, val)?;
+                            alg_ptr_dyn = Some(get_raw_string_ptr(ctx, val)?);
+                            runtime = "js_jwt_verify_dyn";
                         }
                     }
                     // `algorithms: ['ES256']` (plural array) — the
@@ -366,14 +423,33 @@ fn lower_jsonwebtoken_verify(ctx: &mut FnCtx<'_>, args: &[Expr]) -> Result<Strin
                     // so multi-algorithm fallback isn't honored.
                     "algorithms" => {
                         if let Expr::Array(elems) = val {
-                            if let Some(Expr::String(algorithm)) = elems.first() {
-                                runtime = match algorithm.as_str() {
-                                    "ES256" => "js_jwt_verify_es256",
-                                    "RS256" => "js_jwt_verify_rs256",
-                                    _ => "js_jwt_verify",
-                                };
+                            match elems.first() {
+                                Some(Expr::String(algorithm)) => {
+                                    runtime = match algorithm.as_str() {
+                                        "ES256" => "js_jwt_verify_es256",
+                                        "RS256" => "js_jwt_verify_rs256",
+                                        _ => "js_jwt_verify",
+                                    };
+                                }
+                                // #1074: first element is a non-literal
+                                // (e.g. `algorithms: [ALG]` where ALG is
+                                // a const-bound name). Lower it as a
+                                // string and route through the dyn path.
+                                Some(other) => {
+                                    alg_ptr_dyn = Some(get_raw_string_ptr(ctx, other)?);
+                                    runtime = "js_jwt_verify_dyn";
+                                }
+                                None => {}
                             }
                         } else {
+                            // `algorithms` is a non-array expression
+                            // (e.g. a const-bound array reference). We
+                            // could try harder, but the runtime opts
+                            // path below already handles this when the
+                            // whole options object is non-extractable.
+                            // Lower the side effect and let the
+                            // following HS256 fallback fire — same as
+                            // pre-#1074 (rare in practice).
                             let _ = lower_expr(ctx, val)?;
                         }
                     }
@@ -383,7 +459,28 @@ fn lower_jsonwebtoken_verify(ctx: &mut FnCtx<'_>, args: &[Expr]) -> Result<Strin
                 }
             }
         } else {
-            let _ = lower_expr(ctx, options)?;
+            // #1074 case C: options is not an inline object literal —
+            // defer extraction to `js_jwt_verify_dyn_opts`, which reads
+            // `algorithm` / `algorithms[0]` at runtime.
+            let opts_val = lower_expr(ctx, options)?;
+            for extra in args.iter().skip(3) {
+                let _ = lower_expr(ctx, extra)?;
+            }
+            ctx.pending_declares.push((
+                "js_jwt_verify_dyn_opts".to_string(),
+                I64,
+                vec![I64, I64, DOUBLE],
+            ));
+            ctx.pending_declares
+                .push(("js_json_parse_or_null".to_string(), I64, vec![I64]));
+            let blk = ctx.block();
+            let raw = blk.call(
+                I64,
+                "js_jwt_verify_dyn_opts",
+                &[(I64, &token_ptr), (I64, &secret_ptr), (DOUBLE, &opts_val)],
+            );
+            let parsed_bits = blk.call(I64, "js_json_parse_or_null", &[(I64, &raw)]);
+            return Ok(blk.bitcast_i64_to_double(&parsed_bits));
         }
     }
 
@@ -391,12 +488,23 @@ fn lower_jsonwebtoken_verify(ctx: &mut FnCtx<'_>, args: &[Expr]) -> Result<Strin
         let _ = lower_expr(ctx, extra)?;
     }
 
-    ctx.pending_declares
-        .push((runtime.to_string(), I64, vec![I64, I64]));
+    let raw = if let Some(alg_ptr) = alg_ptr_dyn {
+        ctx.pending_declares
+            .push(("js_jwt_verify_dyn".to_string(), I64, vec![I64, I64, I64]));
+        ctx.block().call(
+            I64,
+            "js_jwt_verify_dyn",
+            &[(I64, &alg_ptr), (I64, &token_ptr), (I64, &secret_ptr)],
+        )
+    } else {
+        ctx.pending_declares
+            .push((runtime.to_string(), I64, vec![I64, I64]));
+        ctx.block()
+            .call(I64, runtime, &[(I64, &token_ptr), (I64, &secret_ptr)])
+    };
     ctx.pending_declares
         .push(("js_json_parse_or_null".to_string(), I64, vec![I64]));
     let blk = ctx.block();
-    let raw = blk.call(I64, runtime, &[(I64, &token_ptr), (I64, &secret_ptr)]);
     let parsed_bits = blk.call(I64, "js_json_parse_or_null", &[(I64, &raw)]);
     Ok(blk.bitcast_i64_to_double(&parsed_bits))
 }

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -1965,6 +1965,18 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_jwt_verify", I64, &[I64, I64]);
     module.declare_function("js_jwt_verify_es256", I64, &[I64, I64]);
     module.declare_function("js_jwt_verify_rs256", I64, &[I64, I64]);
+    // #1074: runtime-algorithm dispatchers. The codegen `lower_jsonwebtoken_*`
+    // fast paths still hard-route literal `algorithm: "ES256"` to the typed
+    // helpers above; non-literal shapes (const-bound ident, spread, ternary)
+    // are routed here with the alg name lowered as a string at runtime.
+    module.declare_function("js_jwt_sign_dyn", I64, &[I64, I64, I64, DOUBLE, I64]);
+    module.declare_function("js_jwt_verify_dyn", I64, &[I64, I64, I64]);
+    // #1074 case C: options is a whole non-extractable expression
+    // (`const opts = { algorithm: "ES256" }; jwt.sign(p, k, opts)`). We
+    // pass `opts` as a NaN-boxed JSValue and the runtime helper extracts
+    // `algorithm` / `expiresIn` / `keyid` via `js_object_get_field_by_name`.
+    module.declare_function("js_jwt_sign_dyn_opts", I64, &[I64, I64, DOUBLE]);
+    module.declare_function("js_jwt_verify_dyn_opts", I64, &[I64, I64, DOUBLE]);
 
     // ========== axios / node-fetch ==========
     module.declare_function("js_axios_create", DOUBLE, &[I64]);

--- a/crates/perry-stdlib/src/jsonwebtoken.rs
+++ b/crates/perry-stdlib/src/jsonwebtoken.rs
@@ -4,7 +4,9 @@
 //! Provides JWT sign, verify, and decode functionality.
 
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
-use perry_runtime::{js_string_from_bytes, StringHeader};
+use perry_runtime::{
+    js_object_get_field_by_name, js_string_from_bytes, ObjectHeader, StringHeader,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -209,6 +211,135 @@ pub unsafe extern "C" fn js_jwt_sign_rs256(
         &key,
         kid_ptr,
     )
+}
+
+/// Dynamic-algorithm `jwt.sign` dispatcher (#1074).
+///
+/// The codegen fast path in `lower_jsonwebtoken_sign` routes inline-literal
+/// `{ algorithm: "ES256" }` to `js_jwt_sign_es256` / `…_rs256` at compile
+/// time. When `algorithm` is anything else — a const-bound identifier
+/// (`const ALG = "ES256"; jwt.sign(p, k, { algorithm: ALG })`), a property
+/// spread, a ternary, etc. — the fast path falls through and previously
+/// silently signed with HS256 keyed by the user's PEM (cryptographic
+/// downgrade: the token is HMAC-signed with the PEM bytes, on-wire
+/// `header.alg` reads `"HS256"`, so any verifier that accepts either
+/// HMAC OR EC/RSA quietly accepted the downgrade).
+///
+/// This entry point reads the algorithm name from `alg_ptr` at runtime and
+/// dispatches to the same `sign_common` paths the typed helpers use. The
+/// inline-literal fast path remains for the common case; everything else
+/// goes through here.
+#[no_mangle]
+pub unsafe extern "C" fn js_jwt_sign_dyn(
+    alg_ptr: *const StringHeader,
+    payload_ptr: *const StringHeader,
+    secret_ptr: *const StringHeader,
+    expires_in_secs: f64,
+    kid_ptr: *const StringHeader,
+) -> i64 {
+    let alg_name = string_from_header(alg_ptr).unwrap_or_else(|| "HS256".to_string());
+    match alg_name.as_str() {
+        "ES256" => js_jwt_sign_es256(payload_ptr, secret_ptr, expires_in_secs, kid_ptr),
+        "RS256" => js_jwt_sign_rs256(payload_ptr, secret_ptr, expires_in_secs, kid_ptr),
+        "HS256" | "" => js_jwt_sign(payload_ptr, secret_ptr, expires_in_secs, kid_ptr),
+        other => {
+            // Unknown alg — treat as HS256 fallback (matches the legacy
+            // non-literal behavior) but log under PERRY_DEBUG so callers
+            // can diagnose. The header.alg will still say HS256, so the
+            // user's verifier rejects it properly — this is a safer
+            // failure mode than the pre-#1074 silent downgrade.
+            if std::env::var_os("PERRY_DEBUG").is_some() {
+                eprintln!(
+                    "[jwt-sign-dyn] unknown algorithm `{}`; falling back to HS256",
+                    other
+                );
+            }
+            js_jwt_sign(payload_ptr, secret_ptr, expires_in_secs, kid_ptr)
+        }
+    }
+}
+
+/// Coerce a NaN-boxed JSValue (`f64`) into a raw `*const ObjectHeader`
+/// pointer. Mirrors the upper-bits sniff used in `perry-stdlib/src/http.rs`.
+/// Returns null when the value isn't pointer-shaped.
+unsafe fn jsvalue_to_object_ptr(obj_f64: f64) -> *const ObjectHeader {
+    let obj_bits = obj_f64.to_bits();
+    let upper = obj_bits >> 48;
+    if upper >= 0x7FF8 {
+        (obj_bits & 0x0000_FFFF_FFFF_FFFF) as *const ObjectHeader
+    } else if upper == 0 && obj_bits >= 0x10000 {
+        obj_bits as *const ObjectHeader
+    } else {
+        std::ptr::null()
+    }
+}
+
+/// Read a named property off a NaN-boxed object value, returning its
+/// string-typed result as a `*const StringHeader` (or null when missing/
+/// not-a-string). The field name is materialized as a transient
+/// `*const StringHeader` because that's `js_object_get_field_by_name`'s
+/// signature.
+unsafe fn opts_get_string_field(obj_f64: f64, field: &str) -> *const StringHeader {
+    let obj_ptr = jsvalue_to_object_ptr(obj_f64);
+    if obj_ptr.is_null() {
+        return std::ptr::null();
+    }
+    let key = js_string_from_bytes(field.as_ptr(), field.len() as u32);
+    let val = js_object_get_field_by_name(obj_ptr, key);
+    if val.is_undefined() || val.is_null() {
+        return std::ptr::null();
+    }
+    if val.is_string() {
+        return val.as_string_ptr();
+    }
+    std::ptr::null()
+}
+
+/// Read a named property as f64. Returns 0.0 when missing/non-numeric
+/// (matches `lower_jsonwebtoken_sign`'s `expires_in = double_literal(0.0)`
+/// default).
+unsafe fn opts_get_number_field(obj_f64: f64, field: &str) -> f64 {
+    let obj_ptr = jsvalue_to_object_ptr(obj_f64);
+    if obj_ptr.is_null() {
+        return 0.0;
+    }
+    let key = js_string_from_bytes(field.as_ptr(), field.len() as u32);
+    let val = js_object_get_field_by_name(obj_ptr, key);
+    if val.is_undefined() || val.is_null() {
+        return 0.0;
+    }
+    if val.is_number() {
+        return val.as_number();
+    }
+    0.0
+}
+
+/// `jwt.sign(payload, secret, options)` where `options` is a non-extractable
+/// expression (e.g. `const opts = { algorithm: "ES256", ... }; jwt.sign(p, k, opts)`)
+/// — #1074 case C. The codegen lowers `opts` as a NaN-boxed JSValue and we
+/// extract `algorithm` / `expiresIn` / `keyid` at runtime, then defer to
+/// `js_jwt_sign_dyn`. Reads each option via `js_object_get_field_by_name`
+/// (which works for ordinary `Expr::Object` literals → `__AnonShape_*` class
+/// instances).
+#[no_mangle]
+pub unsafe extern "C" fn js_jwt_sign_dyn_opts(
+    payload_ptr: *const StringHeader,
+    secret_ptr: *const StringHeader,
+    options_value: f64,
+) -> i64 {
+    let alg_ptr = opts_get_string_field(options_value, "algorithm");
+    // `keyid` is the spec-correct field name; `kid` is accepted as an alias
+    // (matches the inline-literal codegen path which special-cases both).
+    let kid_ptr = {
+        let p = opts_get_string_field(options_value, "keyid");
+        if p.is_null() {
+            opts_get_string_field(options_value, "kid")
+        } else {
+            p
+        }
+    };
+    let expires_in = opts_get_number_field(options_value, "expiresIn");
+    js_jwt_sign_dyn(alg_ptr, payload_ptr, secret_ptr, expires_in, kid_ptr)
 }
 
 /// Shared verify path — runs the decode + returns claims as JSON, or
@@ -451,6 +582,82 @@ pub unsafe extern "C" fn js_jwt_verify_rs256(
     };
 
     verify_decode(&token, &key, Algorithm::RS256, debug)
+}
+
+/// Dynamic-algorithm `jwt.verify` dispatcher (#1074).
+///
+/// Mirrors `js_jwt_sign_dyn`. The codegen fast path resolves
+/// `algorithms: ["ES256"]` to `js_jwt_verify_es256` at compile time;
+/// const-ref or computed shapes fell through to `js_jwt_verify` (HS256)
+/// and silently rejected ES/RS tokens. This entry point reads the
+/// algorithm name from `alg_ptr` at runtime and dispatches.
+#[no_mangle]
+pub unsafe extern "C" fn js_jwt_verify_dyn(
+    alg_ptr: *const StringHeader,
+    token_ptr: *const StringHeader,
+    secret_ptr: *const StringHeader,
+) -> *mut StringHeader {
+    let alg_name = string_from_header(alg_ptr).unwrap_or_else(|| "HS256".to_string());
+    match alg_name.as_str() {
+        "ES256" => js_jwt_verify_es256(token_ptr, secret_ptr),
+        "RS256" => js_jwt_verify_rs256(token_ptr, secret_ptr),
+        "HS256" | "" => js_jwt_verify(token_ptr, secret_ptr),
+        other => {
+            if std::env::var_os("PERRY_DEBUG").is_some() {
+                eprintln!(
+                    "[jwt-verify-dyn] unknown algorithm `{}`; falling back to HS256",
+                    other
+                );
+            }
+            js_jwt_verify(token_ptr, secret_ptr)
+        }
+    }
+}
+
+/// `jwt.verify(token, secret, options)` where `options` is a non-extractable
+/// expression (case C, #1074). Extract `algorithm` (singular) or the first
+/// entry of `algorithms` (plural array) at runtime and defer to
+/// `js_jwt_verify_dyn`. The plural-array first-entry rule mirrors the
+/// compile-time fast path in `lower_jsonwebtoken_verify` — the underlying
+/// `jsonwebtoken` crate verifies against one algorithm at a time, so we
+/// pick the first.
+#[no_mangle]
+pub unsafe extern "C" fn js_jwt_verify_dyn_opts(
+    token_ptr: *const StringHeader,
+    secret_ptr: *const StringHeader,
+    options_value: f64,
+) -> *mut StringHeader {
+    // Try singular `algorithm: "..."` first.
+    let mut alg_ptr = opts_get_string_field(options_value, "algorithm");
+    // Then plural `algorithms: ["..."]`. Read the field, then index [0]
+    // through `js_array_get_f64` to mirror the compile-time fast path.
+    if alg_ptr.is_null() {
+        let obj_ptr = jsvalue_to_object_ptr(options_value);
+        if !obj_ptr.is_null() {
+            let key = js_string_from_bytes("algorithms".as_ptr(), "algorithms".len() as u32);
+            let arr_val = js_object_get_field_by_name(obj_ptr, key);
+            // Array is pointer-tagged in NaN-boxing; extract pointer if
+            // present. We reuse the existing array_get_f64 entry point
+            // because it's the most-tested path for array.[i] reads.
+            if !arr_val.is_undefined() && !arr_val.is_null() {
+                // The array NaN-box is POINTER_TAG-shaped just like an
+                // object — strip the upper bits to recover the raw
+                // ArrayHeader*. `js_array_get_f64` does its own tag
+                // strip too, but we already have an authoritative
+                // pointer here so just pass it through.
+                let arr_bits = arr_val.bits();
+                let arr_ptr =
+                    (arr_bits & 0x0000_FFFF_FFFF_FFFF) as *const perry_runtime::ArrayHeader;
+                if !arr_ptr.is_null() {
+                    let first_jsval = perry_runtime::js_array_get(arr_ptr, 0);
+                    if first_jsval.is_string() {
+                        alg_ptr = first_jsval.as_string_ptr();
+                    }
+                }
+            }
+        }
+    }
+    js_jwt_verify_dyn(alg_ptr, token_ptr, secret_ptr)
 }
 
 /// Decode a JWT without verification (just parse the payload)

--- a/test-files/test_jwt_sign_dynamic_alg.ts
+++ b/test-files/test_jwt_sign_dynamic_alg.ts
@@ -1,0 +1,50 @@
+// Issue #1074: `jwt.sign(payload, key, { algorithm: X, ... })` silently
+// fell back to HS256 — using the user's PEM as an HMAC secret — when
+// `algorithm` was anything other than an inline string literal. Mirror
+// bug on `jwt.verify`'s `algorithms: [...]` option.
+//
+// Cases:
+//   (A) inline literal — already worked.
+//   (B) const-bound identifier — pre-fix: HS256 downgrade.
+//   (C) entire options object is a const ref — pre-fix: HS256 downgrade.
+//   (D) verify with const-bound algorithm — pre-fix: HS256 verifier
+//       rejected the ES256 token.
+//
+// We use fixed PEMs (not `crypto.generateKeyPairSync`, which isn't
+// implemented at runtime in Perry) so the test runs identically under
+// `node --experimental-strip-types` and the compiled binary.
+
+import jwt from "jsonwebtoken";
+
+const PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgDs+eWRRv9eNsy9jl
+OtgmyVnBsC3sPnHSS9CFY50PaYqhRANCAATwulSHHEW9sy6mtXYotgUxQXF/8i3d
+lveYC6TEbgW+DDWNCbo5l39ck+0YBA0X3LzLYB8y9DzBii0xLisYIBNP
+-----END PRIVATE KEY-----`;
+
+const PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8LpUhxxFvbMuprV2KLYFMUFxf/It
+3Zb3mAukxG4Fvgw1jQm6OZd/XJPtGAQNF9y8y2AfMvQ8wYotMS4rGCATTw==
+-----END PUBLIC KEY-----`;
+
+const ALG = "ES256";
+
+// (A) inline literal — was the only working path.
+const tokA = jwt.sign({ sub: "a" }, PRIVATE_KEY, { algorithm: "ES256", issuer: "z" });
+const headA = JSON.parse(Buffer.from(tokA.split(".")[0]!, "base64url").toString("utf8"));
+console.log("(A)", headA.alg);
+
+// (B) const ref — was falling back to HS256.
+const tokB = jwt.sign({ sub: "b" }, PRIVATE_KEY, { algorithm: ALG, issuer: "z" });
+const headB = JSON.parse(Buffer.from(tokB.split(".")[0]!, "base64url").toString("utf8"));
+console.log("(B)", headB.alg);
+
+// (C) const opts — was falling back to HS256.
+const opts = { algorithm: "ES256" as const, issuer: "z" };
+const tokC = jwt.sign({ sub: "c" }, PRIVATE_KEY, opts);
+const headC = JSON.parse(Buffer.from(tokC.split(".")[0]!, "base64url").toString("utf8"));
+console.log("(C)", headC.alg);
+
+// (D) verify with const-ref algorithm.
+const decoded = jwt.verify(tokA, PUBLIC_KEY, { algorithms: [ALG] }) as any;
+console.log("(D)", decoded.sub);


### PR DESCRIPTION
Closes #1074.

`jwt.sign(payload, key, { algorithm: X, ... })` silently fell back to HS256 (using the user's PEM as an HMAC secret) when `algorithm` was anything other than an inline string literal — const-bound identifier, ternary, spread, or a const-bound options object. Mirror bug on `jwt.verify`'s `algorithm` / `algorithms: [...]`. Real cryptographic downgrade: tokens were HMAC-signed with the PEM bytes while `header.alg` claimed HS256, so any verifier accepting either family quietly accepted the downgrade.

## Approach (mirrors #1076 / PR #1080 for `crypto.createHmac`)

- **Const resolution only:** no
- **Runtime dispatch fallback:** yes (`js_jwt_sign_dyn`, `js_jwt_verify_dyn`)
- **Both:** the inline-literal fast path is unchanged; everything else routes through runtime dispatch

The fast path (`{ algorithm: \"ES256\" }` inline literal) still picks the typed `js_jwt_sign_es256` / `_rs256` symbol at compile time. Non-literal shapes lower the alg value as `*const StringHeader` and call new `js_jwt_sign_dyn(alg, payload, secret, exp, kid)`, which dispatches to the same `sign_common` paths at runtime.

For case C (whole options is a non-extractable expression), there's a second variant `js_jwt_sign_dyn_opts(payload, secret, opts_jsvalue)` that extracts `algorithm` / `expiresIn` / `keyid` from the NaN-boxed object at runtime via `js_object_get_field_by_name` before deferring to `_dyn`. Same shape for verify, including `algorithms: [...]` plural via `js_array_get`.

## Verify side (`algorithms: [...]`)

Yes — `lower_jsonwebtoken_verify` was updated to cover all the shapes:
- `algorithm: \"ES256\"` (literal) — fast path
- `algorithm: ALG` (const ref) — runtime dispatch via `js_jwt_verify_dyn`
- `algorithms: [\"ES256\"]` (array of literal) — fast path
- `algorithms: [ALG]` (array of non-literal) — runtime dispatch
- whole options non-extractable — `js_jwt_verify_dyn_opts` reads `algorithm` first, then falls back to `algorithms[0]`

## Deferred

- Multi-algorithm fallback in `algorithms: [\"ES256\", \"RS256\"]` — only the first entry is honored (matches pre-fix behavior; underlying Rust `jsonwebtoken` crate's verify is single-algorithm anyway).
- Non-array `algorithms` (e.g. a const-bound array reference at the field-level) inside an otherwise-inline options object — falls through to the previous HS256 fallback. Rare in practice; case C handles the more common spread shape.

## Test plan

- [x] `test-files/test_jwt_sign_dynamic_alg.ts` — covers cases A (inline literal), B (const-bound ident), C (const-bound options object), D (verify with const-bound algorithm). Output matches `node --experimental-strip-types` byte-for-byte: `(A) ES256 / (B) ES256 / (C) ES256 / (D) a`.
- [x] Existing `test_issue_915_jwt_sign.ts` and `test_issue_927_jwt_verify_returns_object.ts` still pass.
- [x] `cargo test --release -p perry-codegen --test manifest_consistency` — 4 passed.
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` — clean.

No version bump / changelog change — maintainer handles at merge time.