### PR TITLE
gc: add telemetry and dirty-page remembered scanning

### DIFF
--- a/crates/perry-codegen/src/codegen.rs
+++ b/crates/perry-codegen/src/codegen.rs
@@ -3570,10 +3570,9 @@ fn shadow_stack_enabled() -> bool {
 /// Gen-GC Phase C2 emission gate. PERRY_WRITE_BARRIERS=1 / on /
 /// true → emit `js_write_barrier(parent_bits, child_bits)` after
 /// every heap-store site. Default OFF — barriers cost a function
-/// call per store and the runtime entry's old-vs-young range scan
-/// is O(blocks). C3 will replace the range scan with a single
-/// GC_FLAG_YOUNG bit-test, at which point flipping the default
-/// becomes attractive.
+/// call per store. The runtime entry uses arena page side metadata
+/// for old-vs-young classification; flipping the default remains a
+/// later policy decision after barriered workloads are measured.
 pub(crate) fn write_barriers_enabled() -> bool {
     use std::sync::OnceLock;
     static CACHED: OnceLock<bool> = OnceLock::new();

--- a/crates/perry-codegen/src/expr.rs
+++ b/crates/perry-codegen/src/expr.rs
@@ -1051,22 +1051,32 @@ impl<'a> FnCtx<'a> {
 
 /// Lower an expression to a raw LLVM `double` value. Returns the string form
 /// of the value (either a `%rN` register or a literal like `42.0`).
-/// Gen-GC Phase C2 helper: emit `js_write_barrier(parent_bits,
-/// child_bits)` after a heap-store site when `PERRY_WRITE_BARRIERS=1`.
-/// `parent_bits` and `child_bits` are SSA names already bitcast to
-/// i64. No-op when the gate is off — branchless at codegen time
-/// because the env var is read once, OnceLock-cached.
-///
-/// Called from every emit site that writes a child value into a
-/// heap-allocated parent: PropertySet, IndexSet (array element +
-/// object key), class field set fast path, closure capture set
-/// (boxed + non-boxed), array push, etc.
+/// Gen-GC Phase C2 helper: emit a write barrier after heap-store sites
+/// when `PERRY_WRITE_BARRIERS=1`. Sites with a precise field/element
+/// address use `js_write_barrier_slot`; opaque helper stores keep using
+/// the compatibility wrapper, which conservatively marks the parent span.
+/// The env gate is read once and OnceLock-cached at codegen time.
 fn emit_write_barrier(ctx: &mut FnCtx<'_>, parent_bits: &str, child_bits: &str) {
     if !crate::codegen::write_barriers_enabled() {
         return;
     }
     ctx.block()
         .call_void("js_write_barrier", &[(I64, parent_bits), (I64, child_bits)]);
+}
+
+fn emit_write_barrier_slot_on_block(
+    blk: &mut LlBlock,
+    parent_bits: &str,
+    slot_addr: &str,
+    child_bits: &str,
+) {
+    if !crate::codegen::write_barriers_enabled() {
+        return;
+    }
+    blk.call_void(
+        "js_write_barrier_slot",
+        &[(I64, parent_bits), (I64, slot_addr), (I64, child_bits)],
+    );
 }
 
 /// Issue #562 — `super({ ... })` for `class X extends ReadableStream`,
@@ -3301,6 +3311,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             if is_array_expr(ctx, object) && is_string_expr(ctx, index) {
                 let arr_box = lower_expr(ctx, object)?;
                 let key_box = lower_expr(ctx, index)?;
+                let value_needs_barrier = !is_numeric_expr(ctx, value);
                 let val_double = lower_expr(ctx, value)?;
                 let blk = ctx.block();
                 let arr_handle = unbox_to_i64(blk, &arr_box);
@@ -3314,9 +3325,11 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         (DOUBLE, &val_double),
                     ],
                 );
-                let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
-                let arr_bits = ctx.block().bitcast_double_to_i64(&arr_box);
-                emit_write_barrier(ctx, &arr_bits, &val_bits);
+                if value_needs_barrier {
+                    let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
+                    let arr_bits = ctx.block().bitcast_double_to_i64(&arr_box);
+                    emit_write_barrier(ctx, &arr_bits, &val_bits);
+                }
                 return Ok(val_double);
             }
             // Issue #637 followup: `arr[k] = X` where receiver is array
@@ -3333,6 +3346,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             if is_array_expr(ctx, object) && !is_numeric_expr(ctx, index) {
                 let arr_box = lower_expr(ctx, object)?;
                 let idx_double = lower_expr(ctx, index)?;
+                let value_needs_barrier = !is_numeric_expr(ctx, value);
                 let val_double = lower_expr(ctx, value)?;
                 let blk = ctx.block();
                 let arr_handle = unbox_to_i64(blk, &arr_box);
@@ -3345,9 +3359,11 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         (DOUBLE, &val_double),
                     ],
                 );
-                let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
-                let arr_bits = ctx.block().bitcast_double_to_i64(&arr_box);
-                emit_write_barrier(ctx, &arr_bits, &val_bits);
+                if value_needs_barrier {
+                    let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
+                    let arr_bits = ctx.block().bitcast_double_to_i64(&arr_box);
+                    emit_write_barrier(ctx, &arr_bits, &val_bits);
+                }
                 return Ok(val_double);
             }
             // Same dispatch tree as IndexGet: known array → fast inline,
@@ -3387,6 +3403,13 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let element_addr = blk.add(I64, &arr_handle, &with_header);
                         let element_ptr = blk.inttoptr(I64, &element_addr);
                         blk.store(DOUBLE, &val_double, &element_ptr);
+                        let val_bits = blk.bitcast_double_to_i64(&val_double);
+                        emit_write_barrier_slot_on_block(
+                            blk,
+                            &arr_handle,
+                            &element_addr,
+                            &val_bits,
+                        );
                         return Ok(val_double);
                     }
                 }
@@ -3501,9 +3524,6 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     "js_object_set_field_by_name",
                     &[(I64, &obj_handle), (I64, &key_raw), (DOUBLE, &val_double)],
                 );
-                // Gen-GC Phase C2: write barrier on object key store.
-                let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
-                emit_write_barrier(ctx, &obj_bits, &val_bits);
                 return Ok(val_double);
             }
             if is_string_expr(ctx, index) {
@@ -3523,9 +3543,6 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         (DOUBLE, &val_double),
                     ],
                 );
-                // Gen-GC Phase C2: write barrier on string-keyed obj write.
-                let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
-                emit_write_barrier(ctx, &obj_bits, &val_bits);
                 return Ok(val_double);
             }
             // Fallback with runtime STRING_TAG check, matching IndexGet.
@@ -3743,6 +3760,9 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     let idx_str = field_index.to_string();
                     let field_ptr = blk.gep(DOUBLE, &fields_base, &[(I64, &idx_str)]);
                     blk.store(DOUBLE, &val_double, &field_ptr);
+                    let field_addr = blk.ptrtoint(&field_ptr, I64);
+                    let val_bits = blk.bitcast_double_to_i64(&val_double);
+                    emit_write_barrier_slot_on_block(blk, &obj_bits, &field_addr, &val_bits);
                     return Ok(val_double);
                 }
             }
@@ -3769,10 +3789,6 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 "js_object_set_field_by_name",
                 &[(I64, &obj_bits), (I64, &key_raw), (DOUBLE, &val_double)],
             );
-            // Gen-GC Phase C2 (per docs/generational-gc-plan.md §C):
-            // see emit_write_barrier — gated PERRY_WRITE_BARRIERS=1.
-            let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
-            emit_write_barrier(ctx, &obj_bits, &val_bits);
             Ok(val_double)
         }
 
@@ -14442,6 +14458,8 @@ fn lower_index_set_fast(
         );
         let new_box = nanbox_pointer_inline(blk, &new_handle);
         blk.store(DOUBLE, &new_box, &slot);
+        let val_bits = blk.bitcast_double_to_i64(val_double);
+        emit_write_barrier_slot_on_block(blk, &arr_handle, "0", &val_bits);
         blk.br(&merge_label);
     }
 
@@ -14453,20 +14471,28 @@ fn lower_index_set_fast(
         .cond_br(&in_bounds, &inbounds_label, &check_cap_label);
 
     // Helper: compute element_ptr = arr_ptr + 8 + idx*8 and emit a store.
-    fn store_element(blk: &mut LlBlock, arr_handle: &str, idx_i32: &str, val_double: &str) {
+    fn store_element(
+        blk: &mut LlBlock,
+        arr_handle: &str,
+        idx_i32: &str,
+        val_double: &str,
+    ) -> String {
         let idx_i64 = blk.zext(I32, idx_i32, I64);
         let byte_offset = blk.shl(I64, &idx_i64, "3"); // *8
         let with_header = blk.add(I64, &byte_offset, "8"); // +8 for header
         let element_addr = blk.add(I64, arr_handle, &with_header);
         let element_ptr = blk.inttoptr(I64, &element_addr);
         blk.store(DOUBLE, val_double, &element_ptr);
+        element_addr
     }
 
     // FASTEST: in-bounds path. Store directly, jump to merge.
     ctx.current_block = inbounds_idx;
     {
         let blk = ctx.block();
-        store_element(blk, &arr_handle, &idx_i32, val_double);
+        let element_addr = store_element(blk, &arr_handle, &idx_i32, val_double);
+        let val_bits = blk.bitcast_double_to_i64(val_double);
+        emit_write_barrier_slot_on_block(blk, &arr_handle, &element_addr, &val_bits);
         blk.br(&merge_label);
     }
 
@@ -14487,11 +14513,13 @@ fn lower_index_set_fast(
     ctx.current_block = extend_inline_idx;
     {
         let blk = ctx.block();
-        store_element(blk, &arr_handle, &idx_i32, val_double);
+        let element_addr = store_element(blk, &arr_handle, &idx_i32, val_double);
         // Bump length: store idx+1 to arr_ptr+0.
         let new_len = blk.add(I32, &idx_i32, "1");
         let len_ptr = blk.inttoptr(I64, &arr_handle); // length is at offset 0
         blk.store(I32, &new_len, &len_ptr);
+        let val_bits = blk.bitcast_double_to_i64(val_double);
+        emit_write_barrier_slot_on_block(blk, &arr_handle, &element_addr, &val_bits);
         blk.br(&merge_label);
     }
 
@@ -14506,20 +14534,12 @@ fn lower_index_set_fast(
         );
         let new_box = nanbox_pointer_inline(blk, &new_handle);
         blk.store(DOUBLE, &new_box, &slot);
+        let val_bits = blk.bitcast_double_to_i64(val_double);
+        emit_write_barrier_slot_on_block(blk, &arr_handle, "0", &val_bits);
         blk.br(&merge_label);
     }
 
     ctx.current_block = merge_idx;
-    // Gen-GC Phase C2: write barrier on the array element store.
-    // Both fast and slow paths funnel here. We use `arr_handle`
-    // (already in scope) as the parent. Note: post-realloc, the
-    // local slot has been updated with the new pointer; the
-    // barrier sees the OLD `arr_handle` which is fine for Phase C
-    // — the new pointer points into the same arena, same gen-flag
-    // status, and the parent is what we record (not the new
-    // location).
-    let val_bits = ctx.block().bitcast_double_to_i64(val_double);
-    emit_write_barrier(ctx, &arr_handle, &val_bits);
     Ok(())
 }
 

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -1560,7 +1560,9 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // pointer stores in the per-thread remembered set so minor
     // GC can scan precise roots + RS instead of the full old-gen.
     //   js_write_barrier(parent_bits: u64, child_bits: u64)
+    //   js_write_barrier_slot(parent_bits: u64, slot_addr: u64, child_bits: u64)
     module.declare_function("js_write_barrier", VOID, &[I64, I64]);
+    module.declare_function("js_write_barrier_slot", VOID, &[I64, I64, I64]);
 
     // Array methods (Phase B.12).
     // - js_array_pop_f64(arr) -> f64    (last element, NaN if empty)

--- a/crates/perry-runtime/src/arena.rs
+++ b/crates/perry-runtime/src/arena.rs
@@ -5,7 +5,7 @@
 //! can be reset at once (e.g., at end of program or during GC).
 
 use std::alloc::{alloc, Layout};
-use std::cell::UnsafeCell;
+use std::cell::{Cell, RefCell, UnsafeCell};
 
 /// Size of each arena block (1 MB — issue #179 tier 1 #1).
 ///
@@ -47,6 +47,208 @@ use std::cell::UnsafeCell;
 ///   iteration as it did with 16 × 8 MB blocks — the adaptive step
 ///   shrinks appropriately on the first productive collection.
 const BLOCK_SIZE: usize = 1024 * 1024;
+const GENERATION_PAGE_SHIFT: usize = 12;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HeapGeneration {
+    Unknown,
+    Nursery,
+    Longlived,
+    Old,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PageGenerationRange {
+    base: usize,
+    end: usize,
+    generation: HeapGeneration,
+}
+
+impl PageGenerationRange {
+    #[inline]
+    fn contains(self, addr: usize) -> bool {
+        addr >= self.base && addr < self.end
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PageGenerationCache {
+    page: usize,
+    range: PageGenerationRange,
+    valid: bool,
+}
+
+impl PageGenerationCache {
+    const fn empty() -> Self {
+        Self {
+            page: 0,
+            range: PageGenerationRange {
+                base: 0,
+                end: 0,
+                generation: HeapGeneration::Unknown,
+            },
+            valid: false,
+        }
+    }
+}
+
+type OldGenPageObjectMap = crate::fast_hash::PtrHashMap<usize, Vec<usize>>;
+
+thread_local! {
+    static GENERATION_RANGES: RefCell<Vec<PageGenerationRange>> =
+        const { RefCell::new(Vec::new()) };
+
+    static PAGE_GENERATION_CACHE: Cell<PageGenerationCache> =
+        const { Cell::new(PageGenerationCache::empty()) };
+
+    static OLD_GEN_PAGE_OBJECTS: RefCell<OldGenPageObjectMap> =
+        RefCell::new(crate::fast_hash::new_ptr_hash_map());
+}
+
+#[inline]
+pub(crate) fn generation_page_for_addr(addr: usize) -> usize {
+    addr >> GENERATION_PAGE_SHIFT
+}
+
+#[inline]
+fn invalidate_generation_cache() {
+    PAGE_GENERATION_CACHE.with(|cache| cache.set(PageGenerationCache::empty()));
+}
+
+#[inline]
+fn find_generation_range(
+    ranges: &[PageGenerationRange],
+    addr: usize,
+) -> Option<PageGenerationRange> {
+    let idx = ranges.partition_point(|range| range.base <= addr);
+    if idx == 0 {
+        return None;
+    }
+    let range = ranges[idx - 1];
+    range.contains(addr).then_some(range)
+}
+
+fn register_block_generation(base: usize, size: usize, generation: HeapGeneration) {
+    if base == 0 || size == 0 || matches!(generation, HeapGeneration::Unknown) {
+        return;
+    }
+    let end = base + size;
+    let range = PageGenerationRange {
+        base,
+        end,
+        generation,
+    };
+    GENERATION_RANGES.with(|ranges| {
+        let mut ranges = ranges.borrow_mut();
+        if let Some(existing) = ranges
+            .iter_mut()
+            .find(|existing| existing.base == base && existing.end == end)
+        {
+            *existing = range;
+            return;
+        }
+        let idx = ranges.partition_point(|existing| existing.base < base);
+        ranges.insert(idx, range);
+    });
+    invalidate_generation_cache();
+}
+
+fn unregister_block_generation(base: usize, size: usize) {
+    if base == 0 || size == 0 {
+        return;
+    }
+    let end = base + size;
+    GENERATION_RANGES.with(|ranges| {
+        ranges
+            .borrow_mut()
+            .retain(|range| !(range.base == base && range.end == end));
+    });
+    invalidate_generation_cache();
+}
+
+#[inline]
+pub(crate) fn classify_heap_generation(addr: usize) -> HeapGeneration {
+    if addr == 0 {
+        return HeapGeneration::Unknown;
+    }
+    let page = generation_page_for_addr(addr);
+    if let Some(generation) = PAGE_GENERATION_CACHE.with(|cache| {
+        let cached = cache.get();
+        (cached.valid && cached.page == page && cached.range.contains(addr))
+            .then_some(cached.range.generation)
+    }) {
+        return generation;
+    }
+
+    let found = GENERATION_RANGES.with(|ranges| {
+        let ranges = ranges.borrow();
+        find_generation_range(&ranges, addr)
+    });
+    if let Some(range) = found {
+        PAGE_GENERATION_CACHE.with(|cache| {
+            cache.set(PageGenerationCache {
+                page,
+                range,
+                valid: true,
+            });
+        });
+        range.generation
+    } else {
+        HeapGeneration::Unknown
+    }
+}
+
+fn register_old_object_pages(header_addr: usize, total_size: usize) {
+    if header_addr == 0 || total_size == 0 {
+        return;
+    }
+    let first_page = generation_page_for_addr(header_addr);
+    let last_page = generation_page_for_addr(header_addr + total_size - 1);
+    OLD_GEN_PAGE_OBJECTS.with(|index| {
+        let mut index = index.borrow_mut();
+        for page in first_page..=last_page {
+            let headers = index.entry(page).or_insert_with(Vec::new);
+            if !headers.contains(&header_addr) {
+                headers.push(header_addr);
+            }
+        }
+    });
+}
+
+pub(crate) fn old_arena_walk_objects_on_pages(
+    pages: &crate::fast_hash::PtrHashSet<usize>,
+    mut callback: impl FnMut(*mut u8),
+) -> usize {
+    if pages.is_empty() {
+        return 0;
+    }
+
+    let mut headers = Vec::new();
+    let mut seen = crate::fast_hash::new_ptr_hash_set();
+    OLD_GEN_PAGE_OBJECTS.with(|index| {
+        let index = index.borrow();
+        for page in pages {
+            if let Some(page_headers) = index.get(page) {
+                for &header_addr in page_headers {
+                    if seen.insert(header_addr) {
+                        headers.push(header_addr);
+                    }
+                }
+            }
+        }
+    });
+
+    let count = headers.len();
+    for header_addr in headers {
+        callback(header_addr as *mut u8);
+    }
+    count
+}
+
+#[cfg(test)]
+pub(crate) fn old_arena_page_index_clear_for_tests() {
+    OLD_GEN_PAGE_OBJECTS.with(|index| index.borrow_mut().clear());
+}
 
 /// Create a block of at least the given size (for oversized allocations)
 fn alloc_block(min_size: usize) -> ArenaBlock {
@@ -128,6 +330,7 @@ impl ArenaBlock {
 struct Arena {
     blocks: Vec<ArenaBlock>,
     current: usize,
+    generation: HeapGeneration,
 }
 
 impl Drop for Arena {
@@ -150,12 +353,14 @@ impl Drop for Arena {
 }
 
 impl Arena {
-    fn new() -> Self {
+    fn new(generation: HeapGeneration) -> Self {
         let initial = ArenaBlock::new();
+        register_block_generation(initial.data as usize, initial.size, generation);
         ARENA_TOTAL_BYTES.with(|t| t.set(t.get() + initial.size));
         Arena {
             blocks: vec![initial],
             current: 0,
+            generation,
         }
     }
 
@@ -211,6 +416,8 @@ impl Arena {
         // through nursery blocks.
         let fresh = alloc_block(size);
         let fresh_size = fresh.size;
+        let fresh_base = fresh.data as usize;
+        register_block_generation(fresh_base, fresh_size, self.generation);
         let mut tomb_idx: Option<usize> = None;
         for i in 0..self.blocks.len() {
             if self.blocks[i].data.is_null() {
@@ -250,7 +457,7 @@ thread_local! {
     /// `arena_reset_empty_blocks`).
     static ARENA_TOTAL_BYTES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 
-    static ARENA: UnsafeCell<Arena> = UnsafeCell::new(Arena::new());
+    static ARENA: UnsafeCell<Arena> = UnsafeCell::new(Arena::new(HeapGeneration::Nursery));
 
     /// Segregated long-lived arena (issue #179). Holds objects that are
     /// intentionally pinned for the lifetime of the program by explicit
@@ -269,7 +476,8 @@ thread_local! {
     /// still traverse them so mark/trace reach cached objects; root
     /// scanners (`scan_parse_roots`, `scan_shape_cache_roots`,
     /// `scan_transition_cache_roots`) keep them marked.
-    static LONGLIVED_ARENA: UnsafeCell<Arena> = UnsafeCell::new(Arena::new());
+    static LONGLIVED_ARENA: UnsafeCell<Arena> =
+        UnsafeCell::new(Arena::new(HeapGeneration::Longlived));
 
     /// Generational-GC old-generation arena (gen-GC Phase B per
     /// `docs/generational-gc-plan.md`). Holds objects PROMOTED from
@@ -286,7 +494,7 @@ thread_local! {
     /// the inline bump allocator. Major GC will eventually mark-
     /// sweep them in Phase C+; today they accumulate forever
     /// because nothing allocates into them.
-    static OLD_ARENA: UnsafeCell<Arena> = UnsafeCell::new(Arena::new());
+    static OLD_ARENA: UnsafeCell<Arena> = UnsafeCell::new(Arena::new(HeapGeneration::Old));
 
     /// Inline allocator state — a cache of the current arena block's
     /// `(data, offset, size)` triple, exposed via a stable pointer so
@@ -477,7 +685,6 @@ pub fn arena_alloc_gc_longlived(size: usize, align: usize, obj_type: u8) -> *mut
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
-
     unsafe { raw.add(GC_HEADER_SIZE) }
 }
 
@@ -517,6 +724,7 @@ pub fn arena_alloc_gc_old(size: usize, align: usize, obj_type: u8) -> *mut u8 {
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
+    register_old_object_pages(raw as usize, total);
 
     unsafe { raw.add(GC_HEADER_SIZE) }
 }
@@ -664,6 +872,62 @@ pub fn arena_in_use_bytes() -> usize {
     used
 }
 
+#[derive(Clone, Copy, Default)]
+pub(crate) struct ArenaRegionTelemetry {
+    pub(crate) in_use_bytes: usize,
+    pub(crate) reserved_bytes: usize,
+    pub(crate) block_count: usize,
+}
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct ArenaTelemetrySnapshot {
+    pub(crate) arena: ArenaRegionTelemetry,
+    pub(crate) longlived: ArenaRegionTelemetry,
+    pub(crate) old: ArenaRegionTelemetry,
+    pub(crate) total_in_use_bytes: usize,
+    pub(crate) total_reserved_bytes: usize,
+    pub(crate) total_block_count: usize,
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct ArenaResetStats {
+    pub reset_blocks: usize,
+    pub deallocated_blocks: usize,
+    pub deallocated_bytes: usize,
+}
+
+fn arena_region_telemetry(arena: &Arena) -> ArenaRegionTelemetry {
+    ArenaRegionTelemetry {
+        in_use_bytes: arena.blocks.iter().map(|b| b.offset).sum(),
+        reserved_bytes: arena.blocks.iter().map(|b| b.size).sum(),
+        block_count: arena.blocks.iter().filter(|b| !b.data.is_null()).count(),
+    }
+}
+
+pub(crate) fn arena_telemetry_snapshot() -> ArenaTelemetrySnapshot {
+    sync_inline_arena_state();
+    let arena = ARENA.with(|arena| {
+        let arena = unsafe { &*arena.get() };
+        arena_region_telemetry(arena)
+    });
+    let longlived = LONGLIVED_ARENA.with(|arena| {
+        let arena = unsafe { &*arena.get() };
+        arena_region_telemetry(arena)
+    });
+    let old = OLD_ARENA.with(|arena| {
+        let arena = unsafe { &*arena.get() };
+        arena_region_telemetry(arena)
+    });
+    ArenaTelemetrySnapshot {
+        arena,
+        longlived,
+        old,
+        total_in_use_bytes: arena.in_use_bytes + longlived.in_use_bytes + old.in_use_bytes,
+        total_reserved_bytes: arena.reserved_bytes + longlived.reserved_bytes + old.reserved_bytes,
+        total_block_count: arena.block_count + longlived.block_count + old.block_count,
+    }
+}
+
 /// Walk all GcHeader objects in arena blocks linearly (general arena +
 /// longlived arena, in that order — block indices are global with
 /// general blocks occupying `0..general_block_count()`).
@@ -782,6 +1046,43 @@ pub fn arena_walk_objects(mut callback: impl FnMut(*mut u8)) {
     OLD_ARENA.with(|arena| {
         let arena = unsafe { &*arena.get() };
         walk_region(&arena.blocks);
+    });
+}
+
+/// Walk only objects physically allocated in the old-generation arena.
+/// Dirty-page remembered scanning uses this to process old-gen modbuf
+/// pages without touching nursery or longlived blocks.
+pub fn old_arena_walk_objects(mut callback: impl FnMut(*mut u8)) {
+    use crate::gc::GcHeader;
+
+    OLD_ARENA.with(|arena| {
+        let arena = unsafe { &*arena.get() };
+        for block in &arena.blocks {
+            let mut offset = 0usize;
+            while offset < block.offset {
+                let aligned = (offset + 7) & !7;
+                if aligned >= block.offset {
+                    break;
+                }
+
+                let header_ptr = unsafe { block.data.add(aligned) };
+                let header = header_ptr as *const GcHeader;
+
+                unsafe {
+                    let total_size = (*header).size as usize;
+                    if total_size == 0 || total_size > block.size {
+                        break;
+                    }
+
+                    let obj_type = (*header).obj_type;
+                    if (1..=9).contains(&obj_type) {
+                        callback(header_ptr);
+                    }
+
+                    offset = aligned + total_size;
+                }
+            }
+        }
     });
 }
 
@@ -996,7 +1297,7 @@ pub fn arena_reset_all_blocks_to_zero() {
 /// the working set crosses ~64MB; with it, GC reclaims empty blocks
 /// in place and the inline allocator keeps reusing the same ~8MB
 /// arena block forever.
-pub fn arena_reset_empty_blocks(block_has_live: &[bool]) {
+pub fn arena_reset_empty_blocks(block_has_live: &[bool]) -> ArenaResetStats {
     let n_live = block_has_live.iter().filter(|&&b| b).count();
     let n_total = block_has_live.len();
     // Issue #179: only reset general-arena blocks. Longlived-arena blocks
@@ -1141,8 +1442,11 @@ pub fn arena_reset_empty_blocks(block_has_live: &[bool]) {
             }
             block.dead_cycles += 1;
             if block.dead_cycles >= DEALLOC_DEAD_CYCLES {
+                let base = block.data as usize;
+                let size = block.size;
                 let layout = Layout::from_size_align(block.size, 16).unwrap();
-                deallocated_ranges.push((block.data as usize, block.size));
+                unregister_block_generation(base, size);
+                deallocated_ranges.push((base, size));
                 std::alloc::dealloc(block.data, layout);
                 ARENA_TOTAL_BYTES.with(|t| t.set(t.get().saturating_sub(block.size)));
                 block.data = std::ptr::null_mut();
@@ -1151,6 +1455,15 @@ pub fn arena_reset_empty_blocks(block_has_live: &[bool]) {
                 block.dead_cycles = 0;
             }
         }
+        let reset_blocks = reset_block_ranges.len();
+        let deallocated_blocks = deallocated_ranges.len();
+        let deallocated_bytes: usize = deallocated_ranges.iter().map(|&(_, s)| s).sum();
+        let stats = ArenaResetStats {
+            reset_blocks,
+            deallocated_blocks,
+            deallocated_bytes,
+        };
+
         if !deallocated_ranges.is_empty() {
             // Drop free-list entries pointing into deallocated
             // blocks — same reasoning as the reset path, but the
@@ -1168,54 +1481,54 @@ pub fn arena_reset_empty_blocks(block_has_live: &[bool]) {
                 }
             });
             if std::env::var_os("PERRY_GC_DIAG").is_some() {
-                let total: usize = deallocated_ranges.iter().map(|&(_, s)| s).sum();
                 eprintln!(
                     "[gc-dealloc] freed {} blocks ({} bytes) back to OS",
                     deallocated_ranges.len(),
-                    total
+                    deallocated_bytes
                 );
             }
         }
 
         if reset_block_ranges.is_empty() && deallocated_ranges.is_empty() {
-            return;
-        }
-
-        // Walk back the `current` index to the first reset block —
-        // i.e., one with `offset == 0`. Skip tombstones (data.is_null())
-        // — the inline allocator can't bump from a deallocated slot.
-        // If we just picked the first block with any free space we'd
-        // land on the live block that still has 80 bytes left at the
-        // end (not enough for a 96-byte class instance), and the next
-        // alloc would push a fresh block. The reset blocks are the
-        // whole point of this routine — make sure we actually use one.
-        let mut new_current = arena.current;
-        for (i, block) in arena.blocks.iter().enumerate() {
-            if !block.data.is_null() && block.offset == 0 {
-                new_current = i;
-                break;
-            }
-        }
-        // If `new_current` ended up pointing at a tombstone (the only
-        // remaining offset==0 entries are deallocated slots), keep
-        // `arena.current` where it was — the next `Arena::alloc` slow
-        // path will tombstone-reuse a slot and update `current` then.
-        if !arena.blocks[new_current].data.is_null() {
-            arena.current = new_current;
-        }
-        let _ = (n_live, n_total);
-        INLINE_STATE.with(|s| {
-            let inline = &mut *s.get();
-            if !inline.data.is_null() {
-                let block = &arena.blocks[arena.current];
-                if !block.data.is_null() {
-                    inline.data = block.data;
-                    inline.offset = block.offset;
-                    inline.size = block.size;
+            stats
+        } else {
+            // Walk back the `current` index to the first reset block —
+            // i.e., one with `offset == 0`. Skip tombstones (data.is_null())
+            // — the inline allocator can't bump from a deallocated slot.
+            // If we just picked the first block with any free space we'd
+            // land on the live block that still has 80 bytes left at the
+            // end (not enough for a 96-byte class instance), and the next
+            // alloc would push a fresh block. The reset blocks are the
+            // whole point of this routine — make sure we actually use one.
+            let mut new_current = arena.current;
+            for (i, block) in arena.blocks.iter().enumerate() {
+                if !block.data.is_null() && block.offset == 0 {
+                    new_current = i;
+                    break;
                 }
             }
-        });
-    });
+            // If `new_current` ended up pointing at a tombstone (the only
+            // remaining offset==0 entries are deallocated slots), keep
+            // `arena.current` where it was — the next `Arena::alloc` slow
+            // path will tombstone-reuse a slot and update `current` then.
+            if !arena.blocks[new_current].data.is_null() {
+                arena.current = new_current;
+            }
+            let _ = (n_live, n_total);
+            INLINE_STATE.with(|s| {
+                let inline = &mut *s.get();
+                if !inline.data.is_null() {
+                    let block = &arena.blocks[arena.current];
+                    if !block.data.is_null() {
+                        inline.data = block.data;
+                        inline.offset = block.offset;
+                        inline.size = block.size;
+                    }
+                }
+            });
+            stats
+        }
+    })
 }
 
 /// Get arena memory statistics: (heap_used, heap_total)
@@ -1271,41 +1584,20 @@ pub fn old_gen_in_use_bytes() -> usize {
 
 /// Gen-GC Phase C: is `addr` inside any nursery (= general
 /// `ARENA`) block? Hot-path predicate for the write barrier —
-/// "is the child of this store a young-gen pointer?". Linear
-/// scan over nursery blocks; typically 5-30 blocks per thread,
-/// each compare is one branch + one less-than. Will be replaced
-/// by a single bit-test on the GcHeader's GC_FLAG_YOUNG once the
-/// nursery alloc path sets that flag (sub-phase C3).
+/// "is the child of this store a young-gen pointer?". Backed by
+/// page side metadata so the runtime barrier does not scan every
+/// arena block on each heap store.
 #[inline]
 pub fn pointer_in_nursery(addr: usize) -> bool {
-    ARENA.with(|a| unsafe {
-        let arena = &*a.get();
-        for block in &arena.blocks {
-            let base = block.data as usize;
-            if addr >= base && addr < base + block.size {
-                return true;
-            }
-        }
-        false
-    })
+    matches!(classify_heap_generation(addr), HeapGeneration::Nursery)
 }
 
 /// Gen-GC Phase C: is `addr` inside any old-gen arena block?
-/// Mirror of `pointer_in_nursery`. Empty in Phase B (returns
-/// false), populated in Phase C+ as promotion lands objects in
-/// the old region.
+/// Mirror of `pointer_in_nursery`, also backed by page side
+/// metadata.
 #[inline]
 pub fn pointer_in_old_gen(addr: usize) -> bool {
-    OLD_ARENA.with(|a| unsafe {
-        let arena = &*a.get();
-        for block in &arena.blocks {
-            let base = block.data as usize;
-            if addr >= base && addr < base + block.size {
-                return true;
-            }
-        }
-        false
-    })
+    matches!(classify_heap_generation(addr), HeapGeneration::Old)
 }
 
 #[cfg(test)]
@@ -1331,6 +1623,131 @@ mod tests {
     fn general_block_offset(idx: usize) -> usize {
         sync_inline_arena_state();
         ARENA.with(|a| unsafe { (&*a.get()).blocks[idx].offset })
+    }
+
+    fn run_with_fresh_arenas(test: impl FnOnce() + Send + 'static) {
+        std::thread::spawn(test)
+            .join()
+            .expect("arena test panicked");
+    }
+
+    fn reset_old_nursery_block(dead_cycles_before: u32) -> (usize, usize, usize, ArenaResetStats) {
+        let full_block_payload = BLOCK_SIZE - GC_HEADER_SIZE;
+        let mut blocks = Vec::new();
+        for _ in 0..7 {
+            let ptr = arena_alloc_gc(full_block_payload, 8, GC_TYPE_STRING) as usize;
+            let idx = general_block_index_for(ptr).expect("allocation should be in nursery");
+            blocks.push(idx);
+        }
+        blocks.sort_unstable();
+        blocks.dedup();
+        assert!(
+            blocks.len() >= 7,
+            "test setup should force seven distinct nursery blocks"
+        );
+
+        let current = ARENA.with(|a| unsafe { (&*a.get()).current });
+        let keep_low = current.saturating_sub(4);
+        let candidate = blocks
+            .into_iter()
+            .find(|&idx| idx < keep_low)
+            .expect("test setup should leave a nursery block outside the keep window");
+
+        let (base, size) = ARENA.with(|a| unsafe {
+            let arena = &mut *a.get();
+            let block = &mut arena.blocks[candidate];
+            assert!(!block.data.is_null());
+            assert!(block.offset > 0);
+            block.dead_cycles = dead_cycles_before;
+            (block.data as usize, block.size)
+        });
+
+        let mut block_has_live = vec![false; arena_block_count()];
+        block_has_live[current] = true;
+        let stats = arena_reset_empty_blocks(&block_has_live);
+        (candidate, base, size, stats)
+    }
+
+    #[test]
+    fn generation_metadata_classifies_arena_regions() {
+        run_with_fresh_arenas(|| {
+            let nursery = arena_alloc_gc(32, 8, GC_TYPE_STRING) as usize;
+            let longlived = arena_alloc_gc_longlived(32, 8, GC_TYPE_STRING) as usize;
+            let old = arena_alloc_gc_old(32, 8, GC_TYPE_STRING) as usize;
+
+            assert_eq!(classify_heap_generation(nursery), HeapGeneration::Nursery);
+            assert_eq!(
+                classify_heap_generation(longlived),
+                HeapGeneration::Longlived
+            );
+            assert_eq!(classify_heap_generation(old), HeapGeneration::Old);
+            assert!(pointer_in_nursery(nursery));
+            assert!(!pointer_in_nursery(longlived));
+            assert!(!pointer_in_old_gen(longlived));
+            assert!(pointer_in_old_gen(old));
+        });
+    }
+
+    #[test]
+    fn generation_metadata_survives_nursery_block_reset() {
+        run_with_fresh_arenas(|| {
+            let (idx, base, size, stats) = reset_old_nursery_block(0);
+            assert!(
+                stats.reset_blocks >= 1,
+                "test setup should reset at least one nursery block"
+            );
+            ARENA.with(|a| unsafe {
+                let arena = &*a.get();
+                assert!(!arena.blocks[idx].data.is_null());
+                assert_eq!(arena.blocks[idx].offset, 0);
+            });
+            assert_eq!(classify_heap_generation(base), HeapGeneration::Nursery);
+            assert_eq!(
+                classify_heap_generation(base + size - 1),
+                HeapGeneration::Nursery
+            );
+        });
+    }
+
+    #[test]
+    fn generation_metadata_removed_on_nursery_block_deallocation() {
+        run_with_fresh_arenas(|| {
+            let (idx, base, _size, stats) = reset_old_nursery_block(1);
+            assert!(
+                stats.deallocated_blocks >= 1,
+                "test setup should deallocate at least one nursery block"
+            );
+            ARENA.with(|a| unsafe {
+                let arena = &*a.get();
+                assert!(arena.blocks[idx].data.is_null());
+                assert_eq!(arena.blocks[idx].size, 0);
+            });
+            assert_eq!(classify_heap_generation(base), HeapGeneration::Unknown);
+            assert!(!pointer_in_nursery(base));
+        });
+    }
+
+    #[test]
+    fn generation_metadata_registered_on_tombstone_reuse() {
+        run_with_fresh_arenas(|| {
+            let (idx, _base, _size, stats) = reset_old_nursery_block(1);
+            assert!(
+                stats.deallocated_blocks >= 1,
+                "test setup should create a nursery tombstone"
+            );
+
+            let oversized = arena_alloc_gc(BLOCK_SIZE + 64, 8, GC_TYPE_STRING) as usize;
+            ARENA.with(|a| unsafe {
+                let arena = &*a.get();
+                assert!(!arena.blocks[idx].data.is_null());
+                assert!(
+                    arena.blocks[idx].size > BLOCK_SIZE,
+                    "oversized allocation should replace the tombstone with a fresh block"
+                );
+            });
+            assert_eq!(general_block_index_for(oversized), Some(idx));
+            assert_eq!(classify_heap_generation(oversized), HeapGeneration::Nursery);
+        });
     }
 
     /// Issue #179: a longlived-arena allocation must not land inside any

--- a/crates/perry-runtime/src/gc.rs
+++ b/crates/perry-runtime/src/gc.rs
@@ -10,7 +10,10 @@
 
 use std::alloc::{alloc, dealloc, realloc, Layout};
 use std::cell::{Cell, RefCell};
+use std::collections::BTreeMap;
 use std::ffi::c_void;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 
 /// GC header prepended to every heap allocation.
 /// Callers receive a pointer AFTER this header (ptr + 8).
@@ -415,6 +418,385 @@ thread_local! {
     /// behaviour: doubles when mostly-garbage, halves when mostly-live.
     static GC_MALLOC_COUNT_STEP: std::cell::Cell<usize> =
         const { std::cell::Cell::new(GC_MALLOC_COUNT_STEP_INITIAL) };
+}
+
+#[inline]
+fn gc_trace_enabled() -> bool {
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        matches!(
+            std::env::var("PERRY_GC_TRACE").as_deref(),
+            Ok("1") | Ok("on") | Ok("true")
+        )
+    })
+}
+
+#[derive(Clone, Copy)]
+enum GcCollectionKind {
+    Minor,
+    Full,
+}
+
+impl GcCollectionKind {
+    #[inline]
+    fn as_str(self) -> &'static str {
+        match self {
+            GcCollectionKind::Minor => "minor",
+            GcCollectionKind::Full => "full",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum GcTriggerKind {
+    ArenaBytes,
+    MallocCount,
+    Manual,
+    Direct,
+}
+
+impl GcTriggerKind {
+    #[inline]
+    fn as_str(self) -> &'static str {
+        match self {
+            GcTriggerKind::ArenaBytes => "arena_bytes",
+            GcTriggerKind::MallocCount => "malloc_count",
+            GcTriggerKind::Manual => "manual",
+            GcTriggerKind::Direct => "direct",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct GcStepSnapshot {
+    arena_step_bytes: usize,
+    next_arena_trigger_bytes: usize,
+    malloc_step: usize,
+    next_malloc_trigger: usize,
+    trigger_bumped: bool,
+}
+
+impl GcStepSnapshot {
+    #[inline]
+    fn current() -> Self {
+        Self {
+            arena_step_bytes: GC_STEP_BYTES.with(|c| c.get()),
+            next_arena_trigger_bytes: GC_NEXT_TRIGGER_BYTES.with(|c| c.get()),
+            malloc_step: GC_MALLOC_COUNT_STEP.with(|c| c.get()),
+            next_malloc_trigger: GC_NEXT_MALLOC_TRIGGER.with(|c| c.get()),
+            trigger_bumped: GC_TRIGGER_BUMPED.with(|c| c.get()),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct GcTriggerSnapshot {
+    kind: GcTriggerKind,
+    steps_before: Option<GcStepSnapshot>,
+}
+
+impl GcTriggerSnapshot {
+    #[inline]
+    fn capture(kind: GcTriggerKind) -> Self {
+        Self {
+            kind,
+            steps_before: gc_trace_enabled().then(GcStepSnapshot::current),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct RememberedSetTraceStats {
+    entries_scanned: usize,
+    valid_roots: usize,
+    newly_marked: usize,
+    dirty_pages_before: usize,
+    dirty_pages_after: usize,
+    dirty_pages_scanned: usize,
+    old_objects_considered: usize,
+    dirty_objects_scanned: usize,
+    dirty_slot_pages_considered: usize,
+    dirty_slot_ranges_scanned: usize,
+    dirty_slots_scanned: usize,
+}
+
+#[derive(Clone, Copy, Default)]
+struct BlockPersistTraceStats {
+    iterations: usize,
+    candidate_blocks: usize,
+    live_blocks: usize,
+    marked_objects: usize,
+}
+
+#[derive(Clone, Copy, Default)]
+struct EvacuationTraceStats {
+    objects: usize,
+    bytes: usize,
+}
+
+#[derive(Clone, Copy, Default)]
+struct SweepTraceStats {
+    freed_bytes: u64,
+    reset_blocks: usize,
+    deallocated_blocks: usize,
+    deallocated_bytes: usize,
+}
+
+#[derive(Clone, Copy, Default)]
+struct BarrierTraceCounters {
+    calls: u64,
+    non_pointer_parent_skips: u64,
+    non_pointer_child_skips: u64,
+    parent_not_old_skips: u64,
+    child_not_young_skips: u64,
+    remembered_set_insert_attempts: u64,
+    new_inserts: u64,
+    dirty_page_mark_attempts: u64,
+    new_dirty_pages: u64,
+    conservative_parent_span_marks: u64,
+}
+
+impl BarrierTraceCounters {
+    const fn zero() -> Self {
+        Self {
+            calls: 0,
+            non_pointer_parent_skips: 0,
+            non_pointer_child_skips: 0,
+            parent_not_old_skips: 0,
+            child_not_young_skips: 0,
+            remembered_set_insert_attempts: 0,
+            new_inserts: 0,
+            dirty_page_mark_attempts: 0,
+            new_dirty_pages: 0,
+            conservative_parent_span_marks: 0,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum BarrierTraceCounter {
+    Calls,
+    NonPointerParentSkips,
+    NonPointerChildSkips,
+    ParentNotOldSkips,
+    ChildNotYoungSkips,
+    RememberedSetInsertAttempts,
+    NewInserts,
+    DirtyPageMarkAttempts,
+    NewDirtyPages,
+    ConservativeParentSpanMarks,
+}
+
+struct GcCycleTrace {
+    collection_kind: GcCollectionKind,
+    trigger_kind: GcTriggerKind,
+    steps_before: GcStepSnapshot,
+    pause_us: u64,
+    phase_us: BTreeMap<&'static str, u64>,
+    arena_before: crate::arena::ArenaTelemetrySnapshot,
+    malloc_before: usize,
+    remembered_set_before: usize,
+    remembered_set: RememberedSetTraceStats,
+    conservative_pinned: usize,
+    evacuation: EvacuationTraceStats,
+    block_persist: BlockPersistTraceStats,
+    sweep: SweepTraceStats,
+    write_barrier: BarrierTraceCounters,
+}
+
+impl GcCycleTrace {
+    fn new(collection_kind: GcCollectionKind, trigger: GcTriggerSnapshot) -> Option<Self> {
+        let steps_before = trigger.steps_before?;
+        let mut phase_us = BTreeMap::new();
+        for name in [
+            "build_valid_pointer_set",
+            "root_marking",
+            "remembered_set_marking",
+            "trace_worklist",
+            "block_persistence",
+            "evacuation",
+            "reference_rewrite",
+            "sweep",
+            "remembered_set_clear",
+            "conservative_pin_clear",
+            "malloc_trim",
+        ] {
+            phase_us.insert(name, 0);
+        }
+        Some(Self {
+            collection_kind,
+            trigger_kind: trigger.kind,
+            steps_before,
+            pause_us: 0,
+            phase_us,
+            arena_before: crate::arena::arena_telemetry_snapshot(),
+            malloc_before: malloc_object_count(),
+            remembered_set_before: remembered_set_size(),
+            remembered_set: RememberedSetTraceStats::default(),
+            conservative_pinned: 0,
+            evacuation: EvacuationTraceStats::default(),
+            block_persist: BlockPersistTraceStats::default(),
+            sweep: SweepTraceStats::default(),
+            write_barrier: take_write_barrier_trace_counters(),
+        })
+    }
+
+    #[inline]
+    fn record_phase(&mut self, name: &'static str, elapsed: Duration) {
+        *self.phase_us.entry(name).or_insert(0) += elapsed.as_micros() as u64;
+    }
+
+    fn emit(self, steps_after: GcStepSnapshot) {
+        let arena_after = crate::arena::arena_telemetry_snapshot();
+        let malloc_after = malloc_object_count();
+        let remembered_set_after = remembered_set_size();
+        let event = serde_json::json!({
+            "event": "gc_cycle",
+            "collection_kind": self.collection_kind.as_str(),
+            "pause_us": self.pause_us,
+            "phase_us": self.phase_us,
+            "arena_bytes": {
+                "before": arena_snapshot_json(self.arena_before),
+                "after": arena_snapshot_json(arena_after),
+            },
+            "malloc_objects": {
+                "before": self.malloc_before,
+                "after": malloc_after,
+            },
+            "remembered_set": {
+                "before": self.remembered_set_before,
+                "after": remembered_set_after,
+                "entries_scanned": self.remembered_set.entries_scanned,
+                "valid_roots": self.remembered_set.valid_roots,
+                "newly_marked": self.remembered_set.newly_marked,
+                "dirty_pages_before": self.remembered_set.dirty_pages_before,
+                "dirty_pages_after": remembered_dirty_page_count(),
+                "dirty_pages_scanned": self.remembered_set.dirty_pages_scanned,
+                "old_objects_considered": self.remembered_set.old_objects_considered,
+                "dirty_objects_scanned": self.remembered_set.dirty_objects_scanned,
+                "dirty_slot_pages_considered": self.remembered_set.dirty_slot_pages_considered,
+                "dirty_slot_ranges_scanned": self.remembered_set.dirty_slot_ranges_scanned,
+                "dirty_slots_scanned": self.remembered_set.dirty_slots_scanned,
+            },
+            "conservative_pinned": self.conservative_pinned,
+            "evacuation": {
+                "objects": self.evacuation.objects,
+                "bytes": self.evacuation.bytes,
+            },
+            "block_persist": {
+                "iterations": self.block_persist.iterations,
+                "candidate_blocks": self.block_persist.candidate_blocks,
+                "live_blocks": self.block_persist.live_blocks,
+                "marked_objects": self.block_persist.marked_objects,
+            },
+            "sweep": {
+                "freed_bytes": self.sweep.freed_bytes,
+                "reset_blocks": self.sweep.reset_blocks,
+                "deallocated_blocks": self.sweep.deallocated_blocks,
+                "deallocated_bytes": self.sweep.deallocated_bytes,
+            },
+            "write_barrier": {
+                "calls": self.write_barrier.calls,
+                "non_pointer_parent_skips": self.write_barrier.non_pointer_parent_skips,
+                "non_pointer_child_skips": self.write_barrier.non_pointer_child_skips,
+                "parent_not_old_skips": self.write_barrier.parent_not_old_skips,
+                "child_not_young_skips": self.write_barrier.child_not_young_skips,
+                "remembered_set_insert_attempts": self.write_barrier.remembered_set_insert_attempts,
+                "new_inserts": self.write_barrier.new_inserts,
+                "dirty_page_mark_attempts": self.write_barrier.dirty_page_mark_attempts,
+                "new_dirty_pages": self.write_barrier.new_dirty_pages,
+                "conservative_parent_span_marks": self.write_barrier.conservative_parent_span_marks,
+            },
+            "trigger": {
+                "kind": self.trigger_kind.as_str(),
+            },
+            "steps": steps_json(self.steps_before, steps_after),
+        });
+        if let Ok(line) = serde_json::to_string(&event) {
+            eprintln!("{line}");
+        }
+    }
+}
+
+struct GcCollectOutcome {
+    freed_bytes: u64,
+    trace: Option<GcCycleTrace>,
+}
+
+impl GcCollectOutcome {
+    #[inline]
+    fn emit_after_current(self) -> u64 {
+        let Self { freed_bytes, trace } = self;
+        if let Some(trace) = trace {
+            trace.emit(GcStepSnapshot::current());
+        }
+        freed_bytes
+    }
+}
+
+#[inline]
+fn trace_phase_start(trace: &Option<GcCycleTrace>) -> Option<Instant> {
+    trace.as_ref().map(|_| Instant::now())
+}
+
+#[inline]
+fn trace_phase_record(
+    trace: &mut Option<GcCycleTrace>,
+    name: &'static str,
+    start: Option<Instant>,
+) {
+    if let (Some(trace), Some(start)) = (trace.as_mut(), start) {
+        trace.record_phase(name, start.elapsed());
+    }
+}
+
+#[inline]
+fn malloc_object_count() -> usize {
+    MALLOC_STATE.with(|s| s.borrow().objects.len())
+}
+
+fn arena_region_json(region: crate::arena::ArenaRegionTelemetry) -> serde_json::Value {
+    serde_json::json!({
+        "in_use_bytes": region.in_use_bytes,
+        "reserved_bytes": region.reserved_bytes,
+        "block_count": region.block_count,
+    })
+}
+
+fn arena_snapshot_json(snapshot: crate::arena::ArenaTelemetrySnapshot) -> serde_json::Value {
+    serde_json::json!({
+        "arena": arena_region_json(snapshot.arena),
+        "longlived": arena_region_json(snapshot.longlived),
+        "old": arena_region_json(snapshot.old),
+        "total_in_use_bytes": snapshot.total_in_use_bytes,
+        "total_reserved_bytes": snapshot.total_reserved_bytes,
+        "total_block_count": snapshot.total_block_count,
+    })
+}
+
+fn steps_json(before: GcStepSnapshot, after: GcStepSnapshot) -> serde_json::Value {
+    serde_json::json!({
+        "arena_step_bytes": {
+            "before": before.arena_step_bytes,
+            "after": after.arena_step_bytes,
+        },
+        "next_arena_trigger_bytes": {
+            "before": before.next_arena_trigger_bytes,
+            "after": after.next_arena_trigger_bytes,
+        },
+        "malloc_step": {
+            "before": before.malloc_step,
+            "after": after.malloc_step,
+        },
+        "next_malloc_trigger": {
+            "before": before.next_malloc_trigger,
+            "after": after.next_malloc_trigger,
+        },
+        "trigger_bumped": {
+            "before": before.trigger_bumped,
+            "after": after.trigger_bumped,
+        },
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -955,7 +1337,9 @@ pub fn gc_check_trigger() {
         // surfaces the dead working set, rather than deferring until
         // after the grace completes.
         let pre_in_use = crate::arena::arena_in_use_bytes();
-        let sweep_freed_bytes = gc_collect_inner();
+        let outcome =
+            gc_collect_inner_with_trigger(GcTriggerSnapshot::capture(GcTriggerKind::ArenaBytes));
+        let sweep_freed_bytes = outcome.freed_bytes;
         let post_in_use = crate::arena::arena_in_use_bytes();
 
         // Adaptive step:
@@ -1069,6 +1453,7 @@ pub fn gc_check_trigger() {
         let survivors = MALLOC_STATE.with(|s| s.borrow().objects.len());
         let mstep = GC_MALLOC_COUNT_STEP.with(|c| c.get());
         GC_NEXT_MALLOC_TRIGGER.with(|c| c.set(survivors + mstep));
+        outcome.emit_after_current();
         return;
     }
     // Also trigger on malloc object count to bound memory growth for
@@ -1088,7 +1473,8 @@ pub fn gc_check_trigger() {
     let next_malloc_trigger = GC_NEXT_MALLOC_TRIGGER.with(|c| c.get());
     if malloc_count >= next_malloc_trigger {
         let pre_count = malloc_count;
-        gc_collect_inner();
+        let outcome =
+            gc_collect_inner_with_trigger(GcTriggerSnapshot::capture(GcTriggerKind::MallocCount));
         let survivors = MALLOC_STATE.with(|s| s.borrow().objects.len());
         // Adapt the malloc-count step based on collection effectiveness.
         //
@@ -1119,6 +1505,7 @@ pub fn gc_check_trigger() {
             GC_MALLOC_COUNT_STEP.with(|c| c.set(mstep));
         }
         GC_NEXT_MALLOC_TRIGGER.with(|c| c.set(survivors + mstep));
+        outcome.emit_after_current();
     }
 }
 
@@ -1155,7 +1542,8 @@ pub extern "C" fn js_gc_collect() {
         }
         return;
     }
-    gc_collect_inner();
+    gc_collect_inner_with_trigger(GcTriggerSnapshot::capture(GcTriggerKind::Manual))
+        .emit_after_current();
 }
 
 /// Increment GC_UNSAFE_ZONES. Called by stdlib when spawning tokio tasks
@@ -1209,6 +1597,11 @@ pub extern "C" fn gc_check_trigger_export() {
 /// (RSS ≤70 MB direct path) lands and proves out across the gap +
 /// parity test corpus.
 pub fn gc_collect_minor() -> u64 {
+    gc_collect_minor_with_trigger(GcTriggerSnapshot::capture(GcTriggerKind::Direct))
+        .emit_after_current()
+}
+
+fn gc_collect_minor_with_trigger(trigger: GcTriggerSnapshot) -> GcCollectOutcome {
     // Phase C4b-γ-3: re-entrancy guard. Without this, the evacuation
     // pass's `arena_alloc_gc_old` can trigger `gc_check_trigger` (via
     // `arena.alloc`'s slow-path block-fill) DURING the outer collection
@@ -1236,11 +1629,14 @@ pub fn gc_collect_minor() -> u64 {
         f.set(prev | GC_FLAG_IN_ALLOC);
         prev & GC_FLAG_IN_ALLOC
     });
-    let start = std::time::Instant::now();
+    let mut trace = GcCycleTrace::new(GcCollectionKind::Minor, trigger);
+    let start = Instant::now();
     // MARK_SEEDS persists across GC cycles. Clear before any try_mark
     // call so trace sees only this cycle's freshly-marked headers.
     clear_mark_seeds();
+    let phase_start = trace_phase_start(&trace);
     let valid_ptrs = build_valid_pointer_set();
+    trace_phase_record(&mut trace, "build_valid_pointer_set", phase_start);
 
     // === MARK PHASE (minor) ===
     // Order matters for the C4b pinning policy. We pin from every
@@ -1271,6 +1667,7 @@ pub fn gc_collect_minor() -> u64 {
     // root-direct discoveries, not transitive heap reachability —
     // transitively-discovered objects came via heap fields that
     // C4b-γ-2 will walk to rewrite.
+    let phase_start = trace_phase_start(&trace);
     mark_stack_roots(&valid_ptrs);
     // CONS_PINNED is only consumed by `evacuate_tenured_nursery_objects`,
     // which is gated on `gen_gc_evacuate_enabled()`. When evacuation is
@@ -1291,9 +1688,22 @@ pub fn gc_collect_minor() -> u64 {
     if evac {
         pin_currently_marked_as_conservative();
     }
-    mark_remembered_set_roots(&valid_ptrs);
+    trace_phase_record(&mut trace, "root_marking", phase_start);
+    let phase_start = trace_phase_start(&trace);
+    let remembered_set = mark_remembered_set_roots(&valid_ptrs);
+    trace_phase_record(&mut trace, "remembered_set_marking", phase_start);
+    if let Some(trace) = trace.as_mut() {
+        trace.remembered_set = remembered_set;
+    }
+    let phase_start = trace_phase_start(&trace);
     trace_marked_objects_minor(&valid_ptrs);
-    mark_block_persisting_arena_objects(&valid_ptrs);
+    trace_phase_record(&mut trace, "trace_worklist", phase_start);
+    let phase_start = trace_phase_start(&trace);
+    let block_persist = mark_block_persisting_arena_objects(&valid_ptrs);
+    trace_phase_record(&mut trace, "block_persistence", phase_start);
+    if let Some(trace) = trace.as_mut() {
+        trace.block_persist = block_persist;
+    }
     // Phase C4b-γ-2 makes evacuation correctness-safe: the
     // post-evac `rewrite_forwarded_references` walk visits every
     // reference site we own (shadow stack + module globals + every
@@ -1336,32 +1746,56 @@ pub fn gc_collect_minor() -> u64 {
     // referenced objects are not evacuated — we never rewrite
     // C-stack words.
     if gen_gc_evacuate_enabled() {
-        let n_evac = evacuate_tenured_nursery_objects();
+        let phase_start = trace_phase_start(&trace);
+        let evacuation = evacuate_tenured_nursery_objects();
+        trace_phase_record(&mut trace, "evacuation", phase_start);
+        if let Some(trace) = trace.as_mut() {
+            trace.evacuation = evacuation;
+            trace.conservative_pinned = cons_pinned_count();
+        }
+        let phase_start = trace_phase_start(&trace);
         rewrite_forwarded_references(&valid_ptrs);
+        trace_phase_record(&mut trace, "reference_rewrite", phase_start);
         if std::env::var_os("PERRY_GC_DIAG").is_some() {
             eprintln!(
                 "[gc-evac] evacuated={} cons_pinned={}",
-                n_evac,
+                evacuation.objects,
                 cons_pinned_count()
             );
         }
+    } else if let Some(trace) = trace.as_mut() {
+        trace.conservative_pinned = cons_pinned_count();
     }
 
     // === SWEEP PHASE ===
     // `do_age_bump = true` folds the per-object HAS_SURVIVED / TENURED
     // update into this same walk (see comment block above the removed
     // dedicated age-bump pass).
-    let freed_bytes = sweep_with_age_bump(true);
+    let phase_start = trace_phase_start(&trace);
+    let sweep = sweep_with_age_bump(true);
+    trace_phase_record(&mut trace, "sweep", phase_start);
+    let freed_bytes = sweep.freed_bytes;
+    if let Some(trace) = trace.as_mut() {
+        trace.sweep = sweep;
+    }
 
     // RS clear — see gc_collect_inner for the rationale.
-    REMEMBERED_SET.with(|s| s.borrow_mut().clear());
+    let phase_start = trace_phase_start(&trace);
+    remembered_set_clear();
+    trace_phase_record(&mut trace, "remembered_set_clear", phase_start);
     // Conservative-pinning is per-cycle; clear so next cycle
     // re-discovers fresh.
+    let phase_start = trace_phase_start(&trace);
     CONS_PINNED.with(|s| s.borrow_mut().clear());
+    trace_phase_record(&mut trace, "conservative_pin_clear", phase_start);
 
     #[cfg(target_env = "gnu")]
-    unsafe {
-        libc::malloc_trim(0);
+    {
+        let phase_start = trace_phase_start(&trace);
+        unsafe {
+            libc::malloc_trim(0);
+        }
+        trace_phase_record(&mut trace, "malloc_trim", phase_start);
     }
 
     let elapsed_us = start.elapsed().as_micros() as u64;
@@ -1384,7 +1818,10 @@ pub fn gc_collect_minor() -> u64 {
             f.set(cur & !GC_FLAG_IN_ALLOC);
         }
     });
-    freed_bytes
+    if let Some(trace) = trace.as_mut() {
+        trace.pause_us = elapsed_us;
+    }
+    GcCollectOutcome { freed_bytes, trace }
 }
 
 /// Generational GC (minor collection on every trigger) is now the
@@ -1435,26 +1872,36 @@ pub fn gen_gc_evacuate_enabled() -> bool {
     })
 }
 
+#[cfg(test)]
 fn gc_collect_inner() -> u64 {
+    gc_collect_inner_with_trigger(GcTriggerSnapshot::capture(GcTriggerKind::Direct))
+        .emit_after_current()
+}
+
+fn gc_collect_inner_with_trigger(trigger: GcTriggerSnapshot) -> GcCollectOutcome {
     // Issue #745: clear the per-cycle bytes-bump flag so the next
     // gc-suppressed parse can rebaseline the trigger again. Done at
     // the top so all entry points — full GC, minor GC, manual
     // `gc()`, the malloc-count trigger path — keep the flag in sync.
     GC_TRIGGER_BUMPED.with(|c| c.set(false));
     if gen_gc_enabled() {
-        return gc_collect_minor();
+        return gc_collect_minor_with_trigger(trigger);
     }
-    let start = std::time::Instant::now();
+    let mut trace = GcCycleTrace::new(GcCollectionKind::Full, trigger);
+    let start = Instant::now();
 
     // MARK_SEEDS persists across GC cycles. Clear before any try_mark
     // call so trace sees only this cycle's freshly-marked headers.
     clear_mark_seeds();
     // Build set of valid heap pointers for conservative stack scan validation
+    let phase_start = trace_phase_start(&trace);
     let valid_ptrs = build_valid_pointer_set();
+    trace_phase_record(&mut trace, "build_valid_pointer_set", phase_start);
 
     // === MARK PHASE ===
 
     // 1. Conservative stack scan
+    let phase_start = trace_phase_start(&trace);
     mark_stack_roots(&valid_ptrs);
 
     // 2. Scan registered global roots (module-level variables)
@@ -1462,6 +1909,7 @@ fn gc_collect_inner() -> u64 {
 
     // 3. Run registered root scanners (promise queues, timers, etc.)
     mark_registered_roots(&valid_ptrs);
+    trace_phase_record(&mut trace, "root_marking", phase_start);
 
     // 3b. Gen-GC Phase C3: scan remembered set as additional roots.
     //     Old-gen objects that wrote young-gen pointers since the
@@ -1471,21 +1919,39 @@ fn gc_collect_inner() -> u64 {
     //     but it's cheap and keeps the dispatch path uniform with
     //     the eventual minor-GC entry. RS is cleared at the end of
     //     collection so the next cycle starts coherent.
-    mark_remembered_set_roots(&valid_ptrs);
+    let phase_start = trace_phase_start(&trace);
+    let remembered_set = mark_remembered_set_roots(&valid_ptrs);
+    trace_phase_record(&mut trace, "remembered_set_marking", phase_start);
+    if let Some(trace) = trace.as_mut() {
+        trace.remembered_set = remembered_set;
+    }
 
     // 4. Trace from marked roots (iterative worklist)
+    let phase_start = trace_phase_start(&trace);
     trace_marked_objects(&valid_ptrs);
+    trace_phase_record(&mut trace, "trace_worklist", phase_start);
 
     // 5. Block-persistence pass: arena blocks survive whole or not at all, so
     //    arena objects sharing a block with a root-reachable object persist
     //    even when not themselves reachable. Their malloc children must stay
     //    alive too (issues #43 / #44).
-    mark_block_persisting_arena_objects(&valid_ptrs);
+    let phase_start = trace_phase_start(&trace);
+    let block_persist = mark_block_persisting_arena_objects(&valid_ptrs);
+    trace_phase_record(&mut trace, "block_persistence", phase_start);
+    if let Some(trace) = trace.as_mut() {
+        trace.block_persist = block_persist;
+    }
 
     // === SWEEP PHASE ===
-    // sweep() now clears mark bits on surviving objects inline,
+    // The sweep walk clears mark bits on surviving objects inline,
     // eliminating 2 redundant heap walks (arena + malloc).
-    let freed_bytes = sweep();
+    let phase_start = trace_phase_start(&trace);
+    let sweep = sweep_with_age_bump(false);
+    trace_phase_record(&mut trace, "sweep", phase_start);
+    let freed_bytes = sweep.freed_bytes;
+    if let Some(trace) = trace.as_mut() {
+        trace.sweep = sweep;
+    }
 
     // Gen-GC Phase C3: clear the remembered set after sweep. The
     // RS records old→young writes since the previous collection;
@@ -1495,7 +1961,9 @@ fn gc_collect_inner() -> u64 {
     // swept. Either way the parent's RS entry is no longer
     // load-bearing — the next allocation cycle's barrier emissions
     // will repopulate it as needed.
-    REMEMBERED_SET.with(|s| s.borrow_mut().clear());
+    let phase_start = trace_phase_start(&trace);
+    remembered_set_clear();
+    trace_phase_record(&mut trace, "remembered_set_clear", phase_start);
 
     // Return released glibc heap pages to the kernel. Without this, glibc
     // keeps freed memory in its arena for reuse but never shrinks RSS, so
@@ -1504,8 +1972,12 @@ fn gc_collect_inner() -> u64 {
     // Perry GC successfully frees the underlying objects.
     // No-op on non-glibc platforms (macOS, musl).
     #[cfg(target_env = "gnu")]
-    unsafe {
-        libc::malloc_trim(0);
+    {
+        let phase_start = trace_phase_start(&trace);
+        unsafe {
+            libc::malloc_trim(0);
+        }
+        trace_phase_record(&mut trace, "malloc_trim", phase_start);
     }
 
     let elapsed_us = start.elapsed().as_micros() as u64;
@@ -1516,7 +1988,10 @@ fn gc_collect_inner() -> u64 {
         stats.total_freed_bytes += freed_bytes;
         stats.last_pause_us = elapsed_us;
     });
-    freed_bytes
+    if let Some(trace) = trace.as_mut() {
+        trace.pause_us = elapsed_us;
+    }
+    GcCollectOutcome { freed_bytes, trace }
 }
 
 /// A sorted-`Vec`-backed set of valid user-space heap pointers,
@@ -2102,12 +2577,12 @@ unsafe fn mark_field_into_worklist(
     val_bits: u64,
     valid_ptrs: &ValidPointerSet,
     worklist: &mut Vec<*mut GcHeader>,
-) {
+) -> bool {
     let tag = val_bits & TAG_MASK;
     let ptr_val: usize = if tag == POINTER_TAG || tag == STRING_TAG || tag == BIGINT_TAG {
         let p = (val_bits & POINTER_MASK) as usize;
         if p == 0 {
-            return;
+            return false;
         }
         p
     } else {
@@ -2117,7 +2592,7 @@ unsafe fn mark_field_into_worklist(
         // which puts them well above 0x0000_FFFF_FFFF_FFFF — they're
         // rejected here.
         if !(0x1000..=0x0000_FFFF_FFFF_FFFF).contains(&val_bits) {
-            return;
+            return false;
         }
         val_bits as usize
     };
@@ -2127,13 +2602,13 @@ unsafe fn mark_field_into_worklist(
     // starts, not interior pointers (those only arise in conservative
     // stack scanning, which uses `try_mark_value_or_raw`).
     if !valid_ptrs.contains(&ptr_val) {
-        return;
+        return false;
     }
 
     let header = header_from_user_ptr(ptr_val as *const u8);
     let flags = (*header).gc_flags;
     if flags & (GC_FLAG_MARKED | GC_FLAG_PINNED) != 0 {
-        return;
+        return false;
     }
     (*header).gc_flags = flags | GC_FLAG_MARKED;
     // Push directly onto the caller's worklist. No MARK_SEEDS push —
@@ -2142,6 +2617,7 @@ unsafe fn mark_field_into_worklist(
     // mark_remembered_set_roots, mark_stack_roots). The trace drain
     // already owns and consumes this worklist.
     worklist.push(header);
+    true
 }
 
 /// Get the bottom (highest address) of the current thread's stack.
@@ -2326,34 +2802,415 @@ extern "C" fn perry_ffi_mark_root(value: f64, ctx: *mut c_void) {
 }
 
 /// Gen-GC Phase C3: mark the remembered set as roots. Old-gen
-/// objects in the RS may hold pointers to young-gen objects that
-/// would otherwise be missed by a minor GC. Today the full GC
-/// also calls this so the RS stays coherent (nothing gets stuck
-/// pointing at swept young objects), and so that the RS clear at
-/// the end has clear "consumed" semantics. The actual minor-GC
-/// time win lands in C3b when trace-from-RS short-circuits at
-/// old-gen boundaries instead of recursing through them.
-fn mark_remembered_set_roots(valid_ptrs: &ValidPointerSet) {
-    // Snapshot the RS so we can iterate without holding the borrow
-    // across `try_mark_value` (which may trigger user-code paths
-    // that touch other RefCells).
-    let snapshot: Vec<usize> = REMEMBERED_SET.with(|s| s.borrow().iter().copied().collect());
-    for header_addr in snapshot {
+/// dirty pages may hold pointers to young-gen objects that would
+/// otherwise be missed by a minor GC. This is Perry's compact
+/// equivalent of MMTk's modbuf / ProcessModBuf: barriers log old
+/// pages, this phase scans those bounded regions, and the clear at
+/// collection end gives the log consumed semantics.
+fn mark_remembered_set_roots(valid_ptrs: &ValidPointerSet) -> RememberedSetTraceStats {
+    let dirty_old_pages: crate::fast_hash::PtrHashSet<usize> =
+        DIRTY_OLD_PAGES.with(|s| s.borrow().iter().copied().collect());
+    let external_dirty_entries: Vec<(usize, usize)> = EXTERNAL_DIRTY_SLOT_PAGES.with(|s| {
+        s.borrow()
+            .iter()
+            .flat_map(|(&page, headers)| headers.iter().copied().map(move |header| (page, header)))
+            .collect()
+    });
+    let mut dirty_pages = dirty_old_pages.clone();
+    for (page, _) in &external_dirty_entries {
+        dirty_pages.insert(*page);
+    }
+    let fallback_snapshot: Vec<usize> =
+        REMEMBERED_SET.with(|s| s.borrow().iter().copied().collect());
+    let mut stats = RememberedSetTraceStats {
+        entries_scanned: dirty_old_pages.len()
+            + external_dirty_entries.len()
+            + fallback_snapshot.len(),
+        dirty_pages_before: dirty_pages.len(),
+        dirty_pages_scanned: dirty_pages.len(),
+        ..RememberedSetTraceStats::default()
+    };
+
+    if !dirty_old_pages.is_empty() || !external_dirty_entries.is_empty() {
+        let mut seen_headers = crate::fast_hash::new_ptr_hash_set();
+        if !dirty_old_pages.is_empty() {
+            crate::arena::old_arena_walk_objects_on_pages(&dirty_old_pages, |header_ptr| unsafe {
+                let header = header_ptr as *mut GcHeader;
+                if !seen_headers.insert(header as usize) {
+                    return;
+                }
+                scan_dirty_header_once(header, &dirty_pages, valid_ptrs, &mut stats);
+            });
+        }
+        for (_, header_addr) in external_dirty_entries {
+            if !seen_headers.insert(header_addr) {
+                continue;
+            }
+            unsafe {
+                scan_dirty_header_once(
+                    header_addr as *mut GcHeader,
+                    &dirty_pages,
+                    valid_ptrs,
+                    &mut stats,
+                );
+            }
+        }
+    }
+
+    // Test-only fallback path. Production barriers no longer insert
+    // object headers here, but keeping the scan lets tests compare the
+    // old object-set behavior against the dirty-page path.
+    for header_addr in fallback_snapshot {
         // Header sits at GcHeader; user pointer is +GC_HEADER_SIZE.
-        // Mark the OLD-gen object itself live (Phase C3b will scan
-        // its fields for young pointers without recursing into the
-        // old-gen subtree). For this commit we use the existing
-        // `try_mark_value` machinery which traces transitively —
-        // correct but not yet generationally optimal.
         let user_ptr = header_addr + GC_HEADER_SIZE;
         if !valid_ptrs.contains(&user_ptr) {
             continue;
         }
-        // Treat as a NaN-boxed POINTER value; try_mark_value
-        // dispatches through the standard mark + worklist path.
+        stats.valid_roots += 1;
         let nanbox = POINTER_TAG | (user_ptr as u64);
-        try_mark_value(nanbox, valid_ptrs);
+        if try_mark_value(nanbox, valid_ptrs) {
+            stats.newly_marked += 1;
+        }
     }
+    stats.dirty_pages_after = remembered_dirty_page_count();
+    stats
+}
+
+unsafe fn scan_dirty_header_once(
+    header: *mut GcHeader,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    let total_size = (*header).size as usize;
+    if total_size == 0 {
+        return;
+    }
+    let user_ptr = (header as *mut u8).add(GC_HEADER_SIZE);
+    if !valid_ptrs.contains(&(user_ptr as usize)) {
+        return;
+    }
+    stats.old_objects_considered += 1;
+    stats.valid_roots += 1;
+    stats.dirty_objects_scanned += 1;
+    scan_dirty_object_slots(header, dirty_pages, valid_ptrs, stats);
+}
+
+#[inline]
+fn dirty_pages_contains_addr(
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    addr: usize,
+) -> bool {
+    dirty_pages.contains(&crate::arena::generation_page_for_addr(addr))
+}
+
+unsafe fn scan_dirty_slot(
+    slot: *const u64,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    if !dirty_pages_contains_addr(dirty_pages, slot as usize) {
+        return;
+    }
+    stats.dirty_slots_scanned += 1;
+    if try_mark_young_value_as_seed(*slot, valid_ptrs) {
+        stats.newly_marked += 1;
+    }
+}
+
+unsafe fn scan_dirty_raw_ptr_slot<T>(
+    slot: *const *mut T,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    scan_dirty_raw_ptr_value_slot(
+        slot as usize,
+        *slot as usize,
+        dirty_pages,
+        valid_ptrs,
+        stats,
+    );
+}
+
+unsafe fn scan_dirty_const_raw_ptr_slot<T>(
+    slot: *const *const T,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    scan_dirty_raw_ptr_value_slot(
+        slot as usize,
+        *slot as usize,
+        dirty_pages,
+        valid_ptrs,
+        stats,
+    );
+}
+
+fn scan_dirty_raw_ptr_value_slot(
+    slot_addr: usize,
+    ptr: usize,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    if !dirty_pages_contains_addr(dirty_pages, slot_addr) {
+        return;
+    }
+    stats.dirty_slots_scanned += 1;
+    if try_mark_young_user_ptr_as_seed(ptr, valid_ptrs) {
+        stats.newly_marked += 1;
+    }
+}
+
+unsafe fn scan_dirty_slot_range(
+    slots: *const u64,
+    slot_count: usize,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    if slots.is_null() || slot_count == 0 || dirty_pages.is_empty() {
+        return;
+    }
+    const PAGE_SHIFT: usize = 12;
+    const PAGE_SIZE: usize = 1 << PAGE_SHIFT;
+
+    let slots_start = slots as usize;
+    let Some(slots_bytes) = slot_count.checked_mul(std::mem::size_of::<u64>()) else {
+        return;
+    };
+    let Some(slots_end) = slots_start.checked_add(slots_bytes) else {
+        return;
+    };
+    let mut ranges = Vec::<(usize, usize)>::new();
+
+    for &page in dirty_pages {
+        let page_start = page << PAGE_SHIFT;
+        let page_end = page_start + PAGE_SIZE;
+        if page_end <= slots_start || page_start >= slots_end {
+            continue;
+        }
+        stats.dirty_slot_pages_considered += 1;
+        let start_addr = page_start.max(slots_start);
+        let end_addr = page_end.min(slots_end);
+        let start_idx = (start_addr - slots_start + 7) / 8;
+        let end_idx = (end_addr - slots_start + 7) / 8;
+        if start_idx < end_idx && start_idx < slot_count {
+            ranges.push((start_idx, end_idx.min(slot_count)));
+        }
+    }
+
+    if ranges.is_empty() {
+        return;
+    }
+    ranges.sort_unstable();
+    let mut merged = Vec::<(usize, usize)>::with_capacity(ranges.len());
+    for (start, end) in ranges {
+        if let Some((_, last_end)) = merged.last_mut() {
+            if start <= *last_end {
+                *last_end = (*last_end).max(end);
+                continue;
+            }
+        }
+        merged.push((start, end));
+    }
+
+    for (start, end) in merged {
+        stats.dirty_slot_ranges_scanned += 1;
+        for i in start..end {
+            stats.dirty_slots_scanned += 1;
+            if try_mark_young_value_as_seed(*slots.add(i), valid_ptrs) {
+                stats.newly_marked += 1;
+            }
+        }
+    }
+}
+
+unsafe fn scan_dirty_object_slots(
+    header: *mut GcHeader,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    let user_ptr = (header as *mut u8).add(GC_HEADER_SIZE);
+    match (*header).obj_type {
+        GC_TYPE_ARRAY => scan_dirty_array_slots(user_ptr, dirty_pages, valid_ptrs, stats),
+        GC_TYPE_OBJECT => scan_dirty_object_field_slots(user_ptr, dirty_pages, valid_ptrs, stats),
+        GC_TYPE_CLOSURE => scan_dirty_closure_slots(user_ptr, dirty_pages, valid_ptrs, stats),
+        GC_TYPE_PROMISE => scan_dirty_promise_slots(user_ptr, dirty_pages, valid_ptrs, stats),
+        GC_TYPE_ERROR => scan_dirty_error_slots(user_ptr, dirty_pages, valid_ptrs, stats),
+        GC_TYPE_MAP => scan_dirty_map_slots(user_ptr, dirty_pages, valid_ptrs, stats),
+        GC_TYPE_LAZY_ARRAY => scan_dirty_lazy_array_slots(user_ptr, dirty_pages, valid_ptrs, stats),
+        GC_TYPE_STRING | GC_TYPE_BIGINT => {}
+        _ => {}
+    }
+}
+
+unsafe fn scan_dirty_array_slots(
+    user_ptr: *mut u8,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    let header = (user_ptr as *const u8).sub(GC_HEADER_SIZE) as *const GcHeader;
+    if (*header).gc_flags & GC_FLAG_FORWARDED != 0 {
+        return;
+    }
+    let arr = user_ptr as *const crate::array::ArrayHeader;
+    let length = (*arr).length;
+    let capacity = (*arr).capacity;
+    if length > capacity || length > 16_000_000 {
+        return;
+    }
+    let elements =
+        (user_ptr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const u64;
+    scan_dirty_slot_range(elements, length as usize, dirty_pages, valid_ptrs, stats);
+}
+
+unsafe fn scan_dirty_object_field_slots(
+    user_ptr: *mut u8,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    let obj = user_ptr as *const crate::object::ObjectHeader;
+    let field_count = (*obj).field_count;
+    if field_count > 1_000_000 {
+        return;
+    }
+    scan_dirty_raw_ptr_slot(&(*obj).keys_array, dirty_pages, valid_ptrs, stats);
+    let fields = (user_ptr as *const u8).add(std::mem::size_of::<crate::object::ObjectHeader>())
+        as *const u64;
+    scan_dirty_slot_range(fields, field_count as usize, dirty_pages, valid_ptrs, stats);
+}
+
+unsafe fn scan_dirty_closure_slots(
+    user_ptr: *mut u8,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    let closure = user_ptr as *const crate::closure::ClosureHeader;
+    let capture_count = crate::closure::real_capture_count((*closure).capture_count);
+    let captures = (user_ptr as *const u8).add(std::mem::size_of::<crate::closure::ClosureHeader>())
+        as *const u64;
+    scan_dirty_slot_range(
+        captures,
+        capture_count as usize,
+        dirty_pages,
+        valid_ptrs,
+        stats,
+    );
+}
+
+unsafe fn scan_dirty_promise_slots(
+    user_ptr: *mut u8,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    let promise = user_ptr as *const crate::promise::Promise;
+    scan_dirty_slot(
+        &(*promise).value as *const f64 as *const u64,
+        dirty_pages,
+        valid_ptrs,
+        stats,
+    );
+    scan_dirty_slot(
+        &(*promise).reason as *const f64 as *const u64,
+        dirty_pages,
+        valid_ptrs,
+        stats,
+    );
+    scan_dirty_const_raw_ptr_slot(&(*promise).on_fulfilled, dirty_pages, valid_ptrs, stats);
+    scan_dirty_const_raw_ptr_slot(&(*promise).on_rejected, dirty_pages, valid_ptrs, stats);
+    scan_dirty_raw_ptr_slot(&(*promise).next, dirty_pages, valid_ptrs, stats);
+}
+
+unsafe fn scan_dirty_error_slots(
+    user_ptr: *mut u8,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    let error = user_ptr as *const crate::error::ErrorHeader;
+    scan_dirty_raw_ptr_slot(&(*error).message, dirty_pages, valid_ptrs, stats);
+    scan_dirty_raw_ptr_slot(&(*error).name, dirty_pages, valid_ptrs, stats);
+    scan_dirty_raw_ptr_slot(&(*error).stack, dirty_pages, valid_ptrs, stats);
+    scan_dirty_slot(
+        &(*error).cause as *const f64 as *const u64,
+        dirty_pages,
+        valid_ptrs,
+        stats,
+    );
+    scan_dirty_raw_ptr_slot(&(*error).errors, dirty_pages, valid_ptrs, stats);
+}
+
+unsafe fn scan_dirty_map_slots(
+    user_ptr: *mut u8,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    let map = user_ptr as *const crate::map::MapHeader;
+    let size = (*map).size;
+    let capacity = (*map).capacity;
+    if size > capacity || size > 100_000 || (*map).entries.is_null() {
+        return;
+    }
+    let entries = (*map).entries as *const u64;
+    scan_dirty_slot_range(entries, size as usize * 2, dirty_pages, valid_ptrs, stats);
+}
+
+unsafe fn scan_dirty_lazy_array_slots(
+    user_ptr: *mut u8,
+    dirty_pages: &crate::fast_hash::PtrHashSet<usize>,
+    valid_ptrs: &ValidPointerSet,
+    stats: &mut RememberedSetTraceStats,
+) {
+    let lazy = user_ptr as *const crate::json_tape::LazyArrayHeader;
+    if (*lazy).magic != crate::json_tape::LAZY_ARRAY_MAGIC {
+        return;
+    }
+    scan_dirty_const_raw_ptr_slot(&(*lazy).blob_str, dirty_pages, valid_ptrs, stats);
+    scan_dirty_raw_ptr_slot(&(*lazy).materialized, dirty_pages, valid_ptrs, stats);
+    scan_dirty_raw_ptr_slot(
+        &(*lazy).materialized_elements,
+        dirty_pages,
+        valid_ptrs,
+        stats,
+    );
+    scan_dirty_raw_ptr_slot(&(*lazy).materialized_bitmap, dirty_pages, valid_ptrs, stats);
+}
+
+fn try_mark_young_value_as_seed(value_bits: u64, valid_ptrs: &ValidPointerSet) -> bool {
+    let ptr = decode_heap_addr(value_bits);
+    try_mark_young_user_ptr_as_seed(ptr, valid_ptrs)
+}
+
+fn try_mark_young_user_ptr_as_seed(ptr_val: usize, valid_ptrs: &ValidPointerSet) -> bool {
+    if ptr_val == 0 || !valid_ptrs.contains(&ptr_val) {
+        return false;
+    }
+    if !matches!(
+        crate::arena::classify_heap_generation(ptr_val),
+        crate::arena::HeapGeneration::Nursery
+    ) {
+        return false;
+    }
+    unsafe {
+        let header = header_from_user_ptr(ptr_val as *const u8);
+        let flags = (*header).gc_flags;
+        if flags & (GC_FLAG_MARKED | GC_FLAG_PINNED) != 0 {
+            return false;
+        }
+        (*header).gc_flags = flags | GC_FLAG_MARKED;
+        push_mark_seed(header);
+    }
+    true
 }
 
 /// Process a worklist of already-marked headers: follow references iteratively,
@@ -2497,9 +3354,11 @@ fn trace_marked_objects_minor(valid_ptrs: &ValidPointerSet) {
 /// old-block neighbors as new block-persist candidates.
 const BLOCK_PERSIST_WINDOW: usize = 5;
 
-fn mark_block_persisting_arena_objects(valid_ptrs: &ValidPointerSet) {
+fn mark_block_persisting_arena_objects(valid_ptrs: &ValidPointerSet) -> BlockPersistTraceStats {
     let mut worklist: Vec<*mut GcHeader> = Vec::new();
+    let mut stats = BlockPersistTraceStats::default();
     loop {
+        stats.iterations += 1;
         let n_blocks = crate::arena::arena_block_count();
         let general_n = crate::arena::general_block_count();
         // Recent-window lower bound: same formula as the reset policy's
@@ -2530,6 +3389,12 @@ fn mark_block_persisting_arena_objects(valid_ptrs: &ValidPointerSet) {
                 }
             },
         );
+        let live_blocks_this = block_has_live.iter().filter(|&&live| live).count();
+        let candidate_blocks_this = (persist_low..general_n)
+            .filter(|&block_idx| block_has_live.get(block_idx).copied().unwrap_or(false))
+            .count();
+        stats.live_blocks += live_blocks_this;
+        stats.candidate_blocks += candidate_blocks_this;
 
         // Pass 2: mark any unmarked arena object in a live block and enqueue.
         // Block-level pre-filter skips the object loop for dead blocks —
@@ -2561,6 +3426,7 @@ fn mark_block_persisting_arena_objects(valid_ptrs: &ValidPointerSet) {
                 }
             },
         );
+        stats.marked_objects += newly_marked;
 
         if newly_marked == 0 {
             break;
@@ -2572,6 +3438,7 @@ fn mark_block_persisting_arena_objects(valid_ptrs: &ValidPointerSet) {
         // the block-persist pump).
         drain_trace_worklist(&mut worklist, valid_ptrs);
     }
+    stats
 }
 
 /// Trace Map entries — scan all key-value pairs in the Map's entries array.
@@ -2960,8 +3827,9 @@ unsafe fn trace_error(
 
 /// Sweep: free unmarked malloc objects; add unmarked arena objects to free list.
 /// Returns total bytes freed.
+#[cfg(test)]
 fn sweep() -> u64 {
-    sweep_with_age_bump(false)
+    sweep_with_age_bump(false).freed_bytes
 }
 
 /// Sweep variant that folds the minor-GC age-bump pass into the same arena walk.
@@ -2978,7 +3846,7 @@ fn sweep() -> u64 {
 /// general-arena (nursery) objects age — longlived and old-gen are skipped, as
 /// in the original standalone age-bump pass (which used `pointer_in_old_gen`
 /// for the same gate).
-fn sweep_with_age_bump(do_age_bump: bool) -> u64 {
+fn sweep_with_age_bump(do_age_bump: bool) -> SweepTraceStats {
     let mut freed_bytes: u64 = 0;
 
     // Sweep malloc objects.
@@ -3233,9 +4101,14 @@ fn sweep_with_age_bump(do_age_bump: bool) -> u64 {
             freed_bytes
         );
     }
-    crate::arena::arena_reset_empty_blocks(&block_has_live);
+    let reset = crate::arena::arena_reset_empty_blocks(&block_has_live);
 
-    freed_bytes
+    SweepTraceStats {
+        freed_bytes,
+        reset_blocks: reset.reset_blocks,
+        deallocated_blocks: reset.deallocated_blocks,
+        deallocated_bytes: reset.deallocated_bytes,
+    }
 }
 
 /// Clear mark bits on all surviving objects
@@ -3320,32 +4193,39 @@ pub fn json_parse_root_scanner(mark: &mut dyn FnMut(f64)) {
 // (docs/generational-gc-plan.md §Phase C)
 // ---------------------------------------------------------------------------
 //
-// Generational GC needs to know which old-gen objects hold
+// Generational GC needs to know which old-gen regions hold
 // references to young-gen objects, so a minor GC can scan just
-// those (the "remembered set") instead of the entire old-gen.
+// those dirty pages instead of the entire old-gen.
 //
 // The write barrier fires on every heap store. Semantics:
-//   if parent is OLD and child points to YOUNG, add parent to
-//   the remembered set.
+//   if parent is OLD and child points to YOUNG, dirty the page
+//   containing the written slot.
 //
-// Sub-phase C1 (this commit): runtime infrastructure — barrier
-// function + remembered set storage + unit tests. No codegen
-// emission yet (sub-phase C2). No minor GC consuming the set
-// yet (sub-phase C3).
-//
-// Bounded false-positive policy: the remembered set is a HashSet
-// of GcHeader pointers (NOT card-marks). False positives are
-// safe (extra scan during minor GC, no correctness impact); false
-// negatives would skip a live young-gen object and break
-// correctness. The current implementation uses HashSet<usize>
-// because pointer-tagged f64 NaN-boxing means the same heap
-// pointer can appear via different tag bytes; storing the
-// canonicalized GcHeader address dedups across tag variants.
+// Bounded false-positive policy: dirty pages are allowed to scan
+// extra slots on the same 4 KiB page; false negatives would skip a
+// live young-gen object and break correctness. `REMEMBERED_SET` is
+// retained only as a test fallback for the previous object-level
+// HashSet behavior.
 
 thread_local! {
-    /// Set of OLD-gen GcHeader addresses that have been written to
-    /// with a YOUNG-gen pointer since the last minor GC. Cleared
-    /// by minor GC after the remembered-set scan (Phase C3).
+    /// Dirty old-generation pages that have received a YOUNG-gen
+    /// pointer since the last collection. This is Perry's compact
+    /// modbuf: barriers log bounded page regions, and minor GC scans
+    /// old objects intersecting those pages.
+    pub(crate) static DIRTY_OLD_PAGES: std::cell::RefCell<crate::fast_hash::PtrHashSet<usize>> =
+        std::cell::RefCell::new(crate::fast_hash::new_ptr_hash_set());
+
+    /// Dirty non-arena slot pages owned by old-generation parents.
+    /// `Map.entries` lives in a malloc buffer behind an old MapHeader,
+    /// so its slot page cannot be discovered from the old-arena page
+    /// index. Key by external page and retain the owning old headers.
+    pub(crate) static EXTERNAL_DIRTY_SLOT_PAGES: std::cell::RefCell<crate::fast_hash::PtrHashMap<usize, Vec<usize>>> =
+        std::cell::RefCell::new(crate::fast_hash::new_ptr_hash_map());
+
+    /// Test-only object-level fallback remembered set. Production
+    /// barriers use `DIRTY_OLD_PAGES`; tests keep this path available
+    /// for parity checks and rollback coverage without a user-facing
+    /// runtime mode.
     pub(crate) static REMEMBERED_SET: std::cell::RefCell<std::collections::HashSet<usize>> =
         std::cell::RefCell::new(std::collections::HashSet::new());
 
@@ -3363,6 +4243,55 @@ thread_local! {
     /// the end of every collection so the next cycle starts fresh.
     pub(crate) static CONS_PINNED: std::cell::RefCell<std::collections::HashSet<usize>> =
         std::cell::RefCell::new(std::collections::HashSet::new());
+
+    static WRITE_BARRIER_TRACE_COUNTERS: Cell<BarrierTraceCounters> =
+        const { Cell::new(BarrierTraceCounters::zero()) };
+}
+
+pub(crate) fn write_barriers_enabled() -> bool {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        matches!(
+            std::env::var("PERRY_WRITE_BARRIERS").as_deref(),
+            Ok("1") | Ok("on") | Ok("true")
+        )
+    })
+}
+
+#[inline]
+fn bump_write_barrier_trace_counter(counter: BarrierTraceCounter) {
+    if !gc_trace_enabled() {
+        return;
+    }
+    WRITE_BARRIER_TRACE_COUNTERS.with(|cell| {
+        let mut counters = cell.get();
+        match counter {
+            BarrierTraceCounter::Calls => counters.calls += 1,
+            BarrierTraceCounter::NonPointerParentSkips => counters.non_pointer_parent_skips += 1,
+            BarrierTraceCounter::NonPointerChildSkips => counters.non_pointer_child_skips += 1,
+            BarrierTraceCounter::ParentNotOldSkips => counters.parent_not_old_skips += 1,
+            BarrierTraceCounter::ChildNotYoungSkips => counters.child_not_young_skips += 1,
+            BarrierTraceCounter::RememberedSetInsertAttempts => {
+                counters.remembered_set_insert_attempts += 1;
+            }
+            BarrierTraceCounter::NewInserts => counters.new_inserts += 1,
+            BarrierTraceCounter::DirtyPageMarkAttempts => counters.dirty_page_mark_attempts += 1,
+            BarrierTraceCounter::NewDirtyPages => counters.new_dirty_pages += 1,
+            BarrierTraceCounter::ConservativeParentSpanMarks => {
+                counters.conservative_parent_span_marks += 1;
+            }
+        }
+        cell.set(counters);
+    });
+}
+
+fn take_write_barrier_trace_counters() -> BarrierTraceCounters {
+    WRITE_BARRIER_TRACE_COUNTERS.with(|cell| {
+        let counters = cell.get();
+        cell.set(BarrierTraceCounters::zero());
+        counters
+    })
 }
 
 /// Gen-GC Phase C4b: walk the current arena+malloc marked set and
@@ -3403,7 +4332,7 @@ fn pin_currently_marked_as_conservative() {
 /// Gen-GC Phase C4b-β: walk arena nursery objects and copy
 /// non-pinned tenured ones into OLD_ARENA. Install a forwarding
 /// pointer at the original nursery slot's user-payload start.
-/// Returns the count of evacuated objects (diagnostic only).
+/// Returns evacuated object and byte counts (diagnostic only).
 ///
 /// Candidate filter: the object must be
 /// - in the nursery arena (not OLD, not LONGLIVED)
@@ -3422,8 +4351,8 @@ fn pin_currently_marked_as_conservative() {
 /// dead and the nursery block can reset; the new copy is marked
 /// MARKED so the rewrite walk picks up its (copied) fields and so
 /// sweep keeps it alive.
-fn evacuate_tenured_nursery_objects() -> usize {
-    let mut evacuated = 0usize;
+fn evacuate_tenured_nursery_objects() -> EvacuationTraceStats {
+    let mut evacuated = EvacuationTraceStats::default();
     crate::arena::arena_walk_objects(|header_ptr| {
         let header = header_ptr as *mut GcHeader;
         unsafe {
@@ -3477,7 +4406,8 @@ fn evacuate_tenured_nursery_objects() -> usize {
             // age-bump pass on the next cycle would treat it as
             // a fresh young object.
             (*new_header).gc_flags |= GC_FLAG_TENURED;
-            evacuated += 1;
+            evacuated.objects += 1;
+            evacuated.bytes += total;
         }
     });
     evacuated
@@ -3789,47 +4719,73 @@ pub fn cons_pinned_count() -> usize {
     CONS_PINNED.with(|s| s.borrow().len())
 }
 
-/// Gen-GC Phase C1: the write barrier. Called by codegen-emitted
-/// store sites (after sub-phase C2 wires the emission).
+/// Gen-GC Phase C1: compatibility write barrier. Test callers and
+/// older bitcode still call this two-argument form; it conservatively
+/// dirties the parent object's occupied pages.
+#[no_mangle]
+pub extern "C" fn js_write_barrier(parent: u64, child: u64) {
+    js_write_barrier_slot(parent, 0, child);
+}
+
+/// Gen-GC Phase C1: slot-aware write barrier. Called by
+/// codegen-emitted store sites when `PERRY_WRITE_BARRIERS=1`.
 ///
 /// Decode the parent + child as raw addresses. If parent's
 /// GcHeader sits in the old-gen arena AND child's NaN-boxed
 /// pointer (any of POINTER / STRING / BIGINT / SHORT_STRING)
-/// resolves to a heap address inside the nursery, record the
-/// parent's GcHeader in the remembered set.
+/// resolves to a heap address inside the nursery, dirty the page
+/// containing the written slot. A zero slot address falls back to
+/// dirtying every occupied page in the parent object.
 ///
 /// Hot-path constraints: this fires on EVERY heap store in
-/// compiled code once C2 lands. Must be cheap. The current
-/// O(blocks) range checks via `pointer_in_*` will be optimized
-/// to a single bit-test on `GcHeader::gc_flags & GC_FLAG_YOUNG`
-/// in sub-phase C3 — this commit's predicate is the simple
-/// correct-but-slower form so the C2 codegen wiring can land
-/// without a perf cliff (gated behind PERRY_WRITE_BARRIERS=1).
+/// compiled code when `PERRY_WRITE_BARRIERS=1`. Must be cheap:
+/// generation checks use arena page side metadata rather than
+/// scanning every arena block.
 #[no_mangle]
-pub extern "C" fn js_write_barrier(parent: u64, child: u64) {
-    // Decode the parent — must be a NaN-boxed pointer (POINTER /
-    // STRING / BIGINT / SHORT_STRING) or a raw heap address.
-    let parent_addr = decode_heap_addr(parent);
-    if parent_addr == 0 {
-        return;
-    }
-    // Decode child similarly.
+pub extern "C" fn js_write_barrier_slot(parent: u64, slot_addr: u64, child: u64) {
+    write_barrier_slot_inner(parent, slot_addr as usize, child, false);
+}
+
+fn write_barrier_slot_inner(parent: u64, slot_addr: usize, child: u64, external_slot: bool) {
+    bump_write_barrier_trace_counter(BarrierTraceCounter::Calls);
+
+    // Decode child first: primitive stores are the most common skip.
     let child_addr = decode_heap_addr(child);
     if child_addr == 0 {
+        bump_write_barrier_trace_counter(BarrierTraceCounter::NonPointerChildSkips);
+        return;
+    }
+    // Decode the parent — must be a NaN-boxed heap pointer.
+    let parent_addr = decode_heap_addr(parent);
+    if parent_addr == 0 {
+        bump_write_barrier_trace_counter(BarrierTraceCounter::NonPointerParentSkips);
         return;
     }
     // Old → young check.
-    if !crate::arena::pointer_in_old_gen(parent_addr) {
+    if !matches!(
+        crate::arena::classify_heap_generation(parent_addr),
+        crate::arena::HeapGeneration::Old
+    ) {
+        bump_write_barrier_trace_counter(BarrierTraceCounter::ParentNotOldSkips);
         return;
     }
-    if !crate::arena::pointer_in_nursery(child_addr) {
+    if !matches!(
+        crate::arena::classify_heap_generation(child_addr),
+        crate::arena::HeapGeneration::Nursery
+    ) {
+        bump_write_barrier_trace_counter(BarrierTraceCounter::ChildNotYoungSkips);
         return;
     }
-    // Parent's GcHeader sits at parent_addr - GC_HEADER_SIZE.
-    let header = parent_addr.saturating_sub(GC_HEADER_SIZE);
-    REMEMBERED_SET.with(|s| {
-        s.borrow_mut().insert(header);
-    });
+
+    bump_write_barrier_trace_counter(BarrierTraceCounter::RememberedSetInsertAttempts);
+    let inserted = if external_slot {
+        remember_old_to_young_external_slot(parent_addr, slot_addr)
+    } else {
+        remember_old_to_young_slot(parent_addr, slot_addr)
+    };
+    if inserted {
+        bump_write_barrier_trace_counter(BarrierTraceCounter::NewInserts);
+    }
 }
 
 /// Decode a NaN-boxed value into a heap address. Returns 0 for
@@ -3843,11 +4799,18 @@ fn decode_heap_addr(bits: u64) -> usize {
     if tag == POINTER_TAG || tag == STRING_TAG || tag == BIGINT_TAG {
         (bits & POINTER_MASK) as usize
     } else if tag < 0x7FF8_0000_0000_0000 {
-        // Plain double — could be a raw bitcast pointer (rare).
-        // Treat as non-pointer in the barrier; minor GC's precise
-        // root scan still catches anything reachable via the
-        // shadow stack.
-        0
+        // Possible raw pointer. Accept only if the arena side metadata
+        // recognizes it as a heap address; ordinary f64 payload bits
+        // miss the metadata table and remain non-pointers.
+        let addr = bits as usize;
+        if matches!(
+            crate::arena::classify_heap_generation(addr),
+            crate::arena::HeapGeneration::Unknown
+        ) {
+            0
+        } else {
+            addr
+        }
     } else {
         // SHORT_STRING_TAG (0x7FF9), INT32_TAG (0x7FFE),
         // primitive (0x7FFC), JS_HANDLE (0x7FFB) — none are
@@ -3856,18 +4819,167 @@ fn decode_heap_addr(bits: u64) -> usize {
     }
 }
 
+fn remember_old_to_young_slot(parent_addr: usize, slot_addr: usize) -> bool {
+    if slot_addr != 0
+        && matches!(
+            crate::arena::classify_heap_generation(slot_addr),
+            crate::arena::HeapGeneration::Old
+        )
+    {
+        return mark_dirty_old_page(crate::arena::generation_page_for_addr(slot_addr));
+    }
+    bump_write_barrier_trace_counter(BarrierTraceCounter::ConservativeParentSpanMarks);
+    mark_dirty_parent_span(parent_addr)
+}
+
+fn mark_dirty_parent_span(parent_addr: usize) -> bool {
+    if parent_addr < GC_HEADER_SIZE {
+        return false;
+    }
+    let header_addr = parent_addr - GC_HEADER_SIZE;
+    let header = header_addr as *const GcHeader;
+    let total_size = unsafe { (*header).size as usize };
+    if total_size == 0 {
+        return false;
+    }
+    let first_page = crate::arena::generation_page_for_addr(header_addr);
+    let last_page = crate::arena::generation_page_for_addr(header_addr + total_size - 1);
+    let mut inserted_any = false;
+    for page in first_page..=last_page {
+        inserted_any |= mark_dirty_old_page(page);
+    }
+    inserted_any
+}
+
+fn remember_old_to_young_external_slot(parent_addr: usize, slot_addr: usize) -> bool {
+    if slot_addr == 0 || parent_addr < GC_HEADER_SIZE {
+        return false;
+    }
+    let header_addr = parent_addr - GC_HEADER_SIZE;
+    mark_dirty_external_slot_page(
+        header_addr,
+        crate::arena::generation_page_for_addr(slot_addr),
+    )
+}
+
+fn mark_dirty_old_page(page: usize) -> bool {
+    bump_write_barrier_trace_counter(BarrierTraceCounter::DirtyPageMarkAttempts);
+    DIRTY_OLD_PAGES.with(|s| {
+        let inserted = s.borrow_mut().insert(page);
+        if inserted {
+            bump_write_barrier_trace_counter(BarrierTraceCounter::NewDirtyPages);
+        }
+        inserted
+    })
+}
+
+fn mark_dirty_external_slot_page(header_addr: usize, page: usize) -> bool {
+    bump_write_barrier_trace_counter(BarrierTraceCounter::DirtyPageMarkAttempts);
+    EXTERNAL_DIRTY_SLOT_PAGES.with(|s| {
+        let mut pages = s.borrow_mut();
+        let page_was_new = !pages.contains_key(&page);
+        let headers = pages.entry(page).or_insert_with(Vec::new);
+        let header_was_new = if headers.contains(&header_addr) {
+            false
+        } else {
+            headers.push(header_addr);
+            true
+        };
+        if page_was_new {
+            bump_write_barrier_trace_counter(BarrierTraceCounter::NewDirtyPages);
+        }
+        header_was_new
+    })
+}
+
+pub(crate) fn runtime_write_barrier_slot(parent_addr: usize, slot_addr: usize, child_bits: u64) {
+    if !write_barriers_enabled() {
+        return;
+    }
+    js_write_barrier_slot(parent_addr as u64, slot_addr as u64, child_bits);
+}
+
+pub(crate) fn runtime_write_barrier_external_slot(
+    parent_addr: usize,
+    slot_addr: usize,
+    child_bits: u64,
+) {
+    if !write_barriers_enabled() {
+        return;
+    }
+    write_barrier_slot_inner(parent_addr as u64, slot_addr, child_bits, true);
+}
+
+pub(crate) fn runtime_dirty_external_slot_span(
+    parent_addr: usize,
+    first_slot_addr: usize,
+    slot_count: usize,
+) {
+    if !write_barriers_enabled() {
+        return;
+    }
+    dirty_external_slot_span(parent_addr, first_slot_addr, slot_count);
+}
+
+fn dirty_external_slot_span(parent_addr: usize, first_slot_addr: usize, slot_count: usize) {
+    if parent_addr < GC_HEADER_SIZE || first_slot_addr == 0 || slot_count == 0 {
+        return;
+    }
+    if !matches!(
+        crate::arena::classify_heap_generation(parent_addr),
+        crate::arena::HeapGeneration::Old
+    ) {
+        return;
+    }
+    let Some(bytes) = slot_count.checked_mul(std::mem::size_of::<u64>()) else {
+        return;
+    };
+    let Some(last_byte) = first_slot_addr.checked_add(bytes.saturating_sub(1)) else {
+        return;
+    };
+    bump_write_barrier_trace_counter(BarrierTraceCounter::ConservativeParentSpanMarks);
+    let header_addr = parent_addr - GC_HEADER_SIZE;
+    let first_page = crate::arena::generation_page_for_addr(first_slot_addr);
+    let last_page = crate::arena::generation_page_for_addr(last_byte);
+    for page in first_page..=last_page {
+        mark_dirty_external_slot_page(header_addr, page);
+    }
+}
+
+fn remembered_dirty_page_count() -> usize {
+    DIRTY_OLD_PAGES.with(|old| {
+        let old = old.borrow();
+        EXTERNAL_DIRTY_SLOT_PAGES.with(|external| {
+            let external = external.borrow();
+            if external.is_empty() {
+                return old.len();
+            }
+            let mut pages = crate::fast_hash::new_ptr_hash_set();
+            for &page in old.iter() {
+                pages.insert(page);
+            }
+            for &page in external.keys() {
+                pages.insert(page);
+            }
+            pages.len()
+        })
+    })
+}
+
 /// Gen-GC Phase C: read the current remembered set size — used
 /// by tests and `PERRY_GC_DIAG=1` output to confirm barrier
 /// activity. Returns 0 in Phase C1 since no codegen-emitted
 /// barrier has fired yet.
 pub fn remembered_set_size() -> usize {
-    REMEMBERED_SET.with(|s| s.borrow().len())
+    remembered_dirty_page_count() + REMEMBERED_SET.with(|s| s.borrow().len())
 }
 
 /// Gen-GC Phase C: clear the remembered set. Will be called by
 /// minor GC after the rs-scan completes (Phase C3). Test-only
 /// for now to enable test isolation.
 pub fn remembered_set_clear() {
+    DIRTY_OLD_PAGES.with(|s| s.borrow_mut().clear());
+    EXTERNAL_DIRTY_SLOT_PAGES.with(|s| s.borrow_mut().clear());
     REMEMBERED_SET.with(|s| s.borrow_mut().clear());
 }
 
@@ -4041,6 +5153,7 @@ mod tests {
         let bigint_ptr = gc_malloc(16, GC_TYPE_BIGINT);
 
         unsafe {
+            init_test_closure(closure_ptr);
             assert_eq!((*header_from_user_ptr(string_ptr)).obj_type, GC_TYPE_STRING);
             assert_eq!(
                 (*header_from_user_ptr(closure_ptr)).obj_type,
@@ -4299,6 +5412,9 @@ mod tests {
         // Allocate some objects
         let ptr1 = gc_malloc(32, GC_TYPE_STRING);
         let ptr2 = gc_malloc(64, GC_TYPE_CLOSURE);
+        unsafe {
+            init_test_closure(ptr2);
+        }
 
         let valid_set = build_valid_pointer_set();
 
@@ -4498,7 +5614,106 @@ mod tests {
     /// Helper for write-barrier tests: clear the remembered set
     /// to a known-empty state.
     fn reset_remembered_set() {
+        DIRTY_OLD_PAGES.with(|s| s.borrow_mut().clear());
+        EXTERNAL_DIRTY_SLOT_PAGES.with(|s| s.borrow_mut().clear());
         REMEMBERED_SET.with(|s| s.borrow_mut().clear());
+        crate::arena::old_arena_page_index_clear_for_tests();
+    }
+
+    unsafe fn init_test_closure(ptr: *mut u8) {
+        let closure = ptr as *mut crate::closure::ClosureHeader;
+        (*closure).func_ptr = std::ptr::null();
+        (*closure).capture_count = 0;
+        (*closure).type_tag = crate::closure::CLOSURE_MAGIC;
+    }
+
+    unsafe fn alloc_old_test_object(
+        field_count: u32,
+    ) -> (*mut crate::object::ObjectHeader, *mut u64) {
+        let payload = std::mem::size_of::<crate::object::ObjectHeader>() + field_count as usize * 8;
+        let obj = crate::arena::arena_alloc_gc_old(payload, 8, GC_TYPE_OBJECT)
+            as *mut crate::object::ObjectHeader;
+        (*obj).object_type = 1;
+        (*obj).class_id = 0;
+        (*obj).parent_class_id = 0;
+        (*obj).field_count = field_count;
+        (*obj).keys_array = std::ptr::null_mut();
+        let fields =
+            (obj as *mut u8).add(std::mem::size_of::<crate::object::ObjectHeader>()) as *mut u64;
+        for i in 0..field_count as usize {
+            *fields.add(i) = 0;
+        }
+        (obj, fields)
+    }
+
+    unsafe fn alloc_old_test_array(length: u32) -> (*mut crate::array::ArrayHeader, *mut u64) {
+        let payload = std::mem::size_of::<crate::array::ArrayHeader>() + length as usize * 8;
+        let arr = crate::arena::arena_alloc_gc_old(payload, 8, GC_TYPE_ARRAY)
+            as *mut crate::array::ArrayHeader;
+        (*arr).length = length;
+        (*arr).capacity = length;
+        let elements =
+            (arr as *mut u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *mut u64;
+        for i in 0..length as usize {
+            *elements.add(i) = 0;
+        }
+        (arr, elements)
+    }
+
+    unsafe fn alloc_old_test_map(
+        capacity: u32,
+    ) -> (*mut crate::map::MapHeader, *mut u64, std::alloc::Layout) {
+        let map = crate::arena::arena_alloc_gc_old(
+            std::mem::size_of::<crate::map::MapHeader>(),
+            8,
+            GC_TYPE_MAP,
+        ) as *mut crate::map::MapHeader;
+        let layout = std::alloc::Layout::from_size_align((capacity as usize * 16).max(8), 8)
+            .expect("valid map entries layout");
+        let entries = std::alloc::alloc_zeroed(layout) as *mut u64;
+        assert!(!entries.is_null());
+        (*map).size = 0;
+        (*map).capacity = capacity;
+        (*map).entries = entries as *mut f64;
+        (map, entries, layout)
+    }
+
+    unsafe fn retire_old_test_map(
+        map: *mut crate::map::MapHeader,
+        entries: *mut u64,
+        layout: std::alloc::Layout,
+    ) {
+        (*map).size = 0;
+        (*map).capacity = 0;
+        (*map).entries = std::ptr::null_mut();
+        std::alloc::dealloc(entries as *mut u8, layout);
+    }
+
+    unsafe fn field_index_not_on_last_page(fields: *mut u64, field_count: u32) -> usize {
+        assert!(field_count > 1);
+        let last_page =
+            crate::arena::generation_page_for_addr(fields.add(field_count as usize - 1) as usize);
+        for i in 0..field_count as usize {
+            if crate::arena::generation_page_for_addr(fields.add(i) as usize) != last_page {
+                return i;
+            }
+        }
+        panic!("test object did not span multiple field pages");
+    }
+
+    unsafe fn field_indices_on_distinct_pages(
+        fields: *mut u64,
+        field_count: u32,
+    ) -> (usize, usize) {
+        assert!(field_count > 1);
+        let first = field_index_not_on_last_page(fields, field_count);
+        let first_page = crate::arena::generation_page_for_addr(fields.add(first) as usize);
+        for i in 0..field_count as usize {
+            if crate::arena::generation_page_for_addr(fields.add(i) as usize) != first_page {
+                return (first, i);
+            }
+        }
+        panic!("test object did not span two field pages");
     }
 
     #[test]
@@ -4513,14 +5728,40 @@ mod tests {
         assert_eq!(
             remembered_set_size(),
             1,
-            "old→young write must record parent"
+            "old→young write must dirty the remembered page"
         );
-        // Same write again should NOT double-count (HashSet dedups).
+        // Same write again should NOT double-count (dirty pages dedup).
         js_write_barrier(parent_nanbox, child_nanbox);
         assert_eq!(
             remembered_set_size(),
             1,
-            "duplicate barrier call must dedup"
+            "duplicate barrier call must dedup the dirty page"
+        );
+    }
+
+    #[test]
+    fn test_write_barrier_slot_marks_dirty_page_and_dedups() {
+        reset_remembered_set();
+        let young = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let (old_obj, fields) = unsafe { alloc_old_test_object(1) };
+        unsafe {
+            *fields = POINTER_TAG | young as u64;
+        }
+        js_write_barrier_slot(
+            POINTER_TAG | old_obj as u64,
+            fields as u64,
+            POINTER_TAG | young as u64,
+        );
+        assert_eq!(remembered_dirty_page_count(), 1);
+        js_write_barrier_slot(
+            POINTER_TAG | old_obj as u64,
+            fields as u64,
+            POINTER_TAG | young as u64,
+        );
+        assert_eq!(
+            remembered_dirty_page_count(),
+            1,
+            "same dirty page should be logged once"
         );
     }
 
@@ -4590,6 +5831,18 @@ mod tests {
     }
 
     #[test]
+    fn test_write_barrier_non_pointer_parent_skipped() {
+        reset_remembered_set();
+        let young = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        js_write_barrier_slot(0x7FFE_0000_0000_002A_u64, 0, POINTER_TAG | young as u64);
+        assert_eq!(
+            remembered_set_size(),
+            0,
+            "non-pointer parent must not dirty remembered pages"
+        );
+    }
+
+    #[test]
     fn test_write_barrier_remembered_set_clear() {
         reset_remembered_set();
         let young = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
@@ -4601,11 +5854,34 @@ mod tests {
     }
 
     #[test]
+    fn test_write_barrier_slot_clear() {
+        reset_remembered_set();
+        let young = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let (old_obj, fields) = unsafe { alloc_old_test_object(1) };
+        js_write_barrier_slot(
+            POINTER_TAG | old_obj as u64,
+            fields as u64,
+            POINTER_TAG | young as u64,
+        );
+        assert_eq!(remembered_dirty_page_count(), 1);
+        remembered_set_clear();
+        assert_eq!(remembered_dirty_page_count(), 0);
+        assert_eq!(remembered_set_size(), 0);
+    }
+
+    #[test]
     fn test_gc_collect_minor_clears_rs() {
         reset_remembered_set();
         let young = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
-        let old = crate::arena::arena_alloc_gc_old(40, 8, GC_TYPE_OBJECT) as usize;
-        js_write_barrier(POINTER_TAG | (old as u64), POINTER_TAG | (young as u64));
+        let (old, fields) = unsafe { alloc_old_test_object(1) };
+        unsafe {
+            *fields = POINTER_TAG | young as u64;
+        }
+        js_write_barrier_slot(
+            POINTER_TAG | old as u64,
+            fields as u64,
+            POINTER_TAG | young as u64,
+        );
         assert_eq!(remembered_set_size(), 1);
         let _freed = gc_collect_minor();
         assert_eq!(
@@ -4613,6 +5889,334 @@ mod tests {
             0,
             "minor GC must clear RS just like full GC does"
         );
+    }
+
+    #[test]
+    fn test_dirty_page_scan_marks_young_child() {
+        reset_remembered_set();
+        clear_marks();
+        let young = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let (old_obj, fields) = unsafe { alloc_old_test_object(1) };
+        unsafe {
+            *fields = POINTER_TAG | young as u64;
+        }
+        js_write_barrier_slot(
+            POINTER_TAG | old_obj as u64,
+            fields as u64,
+            POINTER_TAG | young as u64,
+        );
+        let valid_ptrs = build_valid_pointer_set();
+        let stats = mark_remembered_set_roots(&valid_ptrs);
+        assert_eq!(stats.dirty_pages_scanned, 1);
+        assert_eq!(stats.old_objects_considered, 1);
+        assert_eq!(stats.dirty_objects_scanned, 1);
+        assert!(
+            stats.dirty_slots_scanned >= 1,
+            "dirty page should scan at least the written field slot"
+        );
+        assert_eq!(stats.newly_marked, 1);
+        unsafe {
+            let child_header = header_from_user_ptr(young as *const u8);
+            assert_ne!((*child_header).gc_flags & GC_FLAG_MARKED, 0);
+        }
+        clear_marks();
+        remembered_set_clear();
+    }
+
+    #[test]
+    fn test_dirty_page_array_scan_is_slot_range_bounded() {
+        reset_remembered_set();
+        clear_marks();
+        let dirty_child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let clean_child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let (old_arr, elements) = unsafe { alloc_old_test_array(2048) };
+        let (dirty_idx, clean_idx) = unsafe { field_indices_on_distinct_pages(elements, 2048) };
+        let dirty_slot = unsafe { elements.add(dirty_idx) };
+        unsafe {
+            *dirty_slot = POINTER_TAG | dirty_child as u64;
+            *elements.add(clean_idx) = POINTER_TAG | clean_child as u64;
+        }
+        js_write_barrier_slot(
+            POINTER_TAG | old_arr as u64,
+            dirty_slot as u64,
+            POINTER_TAG | dirty_child as u64,
+        );
+
+        let valid_ptrs = build_valid_pointer_set();
+        let stats = mark_remembered_set_roots(&valid_ptrs);
+        assert_eq!(stats.old_objects_considered, 1);
+        assert_eq!(stats.dirty_objects_scanned, 1);
+        assert_eq!(stats.dirty_slot_ranges_scanned, 1);
+        assert!(
+            stats.dirty_slots_scanned <= 512,
+            "one dirty page should scan at most one 4 KiB page of u64 slots"
+        );
+        unsafe {
+            let dirty_header = header_from_user_ptr(dirty_child as *const u8);
+            let clean_header = header_from_user_ptr(clean_child as *const u8);
+            assert_ne!((*dirty_header).gc_flags & GC_FLAG_MARKED, 0);
+            assert_eq!((*clean_header).gc_flags & GC_FLAG_MARKED, 0);
+        }
+        clear_marks();
+        remembered_set_clear();
+    }
+
+    #[test]
+    fn test_dirty_page_scan_ignores_clean_old_pages() {
+        reset_remembered_set();
+        clear_marks();
+        let dirty_child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let clean_child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let (dirty_obj, dirty_fields) = unsafe { alloc_old_test_object(2048) };
+        let dirty_idx = unsafe { field_index_not_on_last_page(dirty_fields, 2048) };
+        let dirty_slot = unsafe { dirty_fields.add(dirty_idx) };
+        unsafe {
+            *dirty_slot = POINTER_TAG | dirty_child as u64;
+        }
+        let (_clean_obj, clean_fields) = unsafe { alloc_old_test_object(2048) };
+        let clean_idx = unsafe { field_index_not_on_last_page(clean_fields, 2048) };
+        unsafe {
+            *clean_fields.add(clean_idx) = POINTER_TAG | clean_child as u64;
+        }
+
+        js_write_barrier_slot(
+            POINTER_TAG | dirty_obj as u64,
+            dirty_slot as u64,
+            POINTER_TAG | dirty_child as u64,
+        );
+
+        let valid_ptrs = build_valid_pointer_set();
+        let stats = mark_remembered_set_roots(&valid_ptrs);
+        assert_eq!(stats.dirty_pages_scanned, 1);
+        assert_eq!(
+            stats.old_objects_considered, 1,
+            "clean old pages must not feed objects into the dirty scan"
+        );
+        assert_eq!(stats.dirty_objects_scanned, 1);
+        assert_eq!(stats.dirty_slot_ranges_scanned, 1);
+        assert!(
+            stats.dirty_slots_scanned <= 512,
+            "one dirty field page should not scan the whole old object"
+        );
+        unsafe {
+            let dirty_header = header_from_user_ptr(dirty_child as *const u8);
+            let clean_header = header_from_user_ptr(clean_child as *const u8);
+            assert_ne!((*dirty_header).gc_flags & GC_FLAG_MARKED, 0);
+            assert_eq!(
+                (*clean_header).gc_flags & GC_FLAG_MARKED,
+                0,
+                "young child stored only on a clean old page should not be marked"
+            );
+        }
+        clear_marks();
+        remembered_set_clear();
+    }
+
+    #[test]
+    fn test_dirty_page_scan_dedupes_object_spanning_dirty_pages() {
+        reset_remembered_set();
+        clear_marks();
+        let young_a = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let young_b = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let (old_obj, fields) = unsafe { alloc_old_test_object(2048) };
+        let (idx_a, idx_b) = unsafe { field_indices_on_distinct_pages(fields, 2048) };
+        let slot_a = unsafe { fields.add(idx_a) };
+        let slot_b = unsafe { fields.add(idx_b) };
+        unsafe {
+            *slot_a = POINTER_TAG | young_a as u64;
+            *slot_b = POINTER_TAG | young_b as u64;
+        }
+
+        js_write_barrier_slot(
+            POINTER_TAG | old_obj as u64,
+            slot_a as u64,
+            POINTER_TAG | young_a as u64,
+        );
+        js_write_barrier_slot(
+            POINTER_TAG | old_obj as u64,
+            slot_b as u64,
+            POINTER_TAG | young_b as u64,
+        );
+
+        let valid_ptrs = build_valid_pointer_set();
+        let stats = mark_remembered_set_roots(&valid_ptrs);
+        assert_eq!(stats.dirty_pages_scanned, 2);
+        assert_eq!(
+            stats.old_objects_considered, 1,
+            "one object spanning two dirty pages should be considered once"
+        );
+        assert_eq!(stats.dirty_objects_scanned, 1);
+        assert_eq!(stats.dirty_slot_pages_considered, 2);
+        assert!(stats.dirty_slot_ranges_scanned <= 2);
+        assert!(
+            stats.dirty_slots_scanned <= 1024,
+            "two dirty field pages should bound scanning to two pages"
+        );
+        assert_eq!(stats.newly_marked, 2);
+        unsafe {
+            let header_a = header_from_user_ptr(young_a as *const u8);
+            let header_b = header_from_user_ptr(young_b as *const u8);
+            assert_ne!((*header_a).gc_flags & GC_FLAG_MARKED, 0);
+            assert_ne!((*header_b).gc_flags & GC_FLAG_MARKED, 0);
+        }
+        clear_marks();
+        remembered_set_clear();
+    }
+
+    #[test]
+    fn test_dirty_page_map_entry_scan_is_external_range_bounded() {
+        reset_remembered_set();
+        clear_marks();
+        let dirty_child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let clean_child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let (map, entries, layout) = unsafe { alloc_old_test_map(2048) };
+        unsafe {
+            (*map).size = 2048;
+        }
+        let (dirty_idx, clean_idx) = unsafe { field_indices_on_distinct_pages(entries, 4096) };
+        let dirty_slot = unsafe { entries.add(dirty_idx) };
+        unsafe {
+            *dirty_slot = POINTER_TAG | dirty_child as u64;
+            *entries.add(clean_idx) = POINTER_TAG | clean_child as u64;
+        }
+        write_barrier_slot_inner(
+            POINTER_TAG | map as u64,
+            dirty_slot as usize,
+            POINTER_TAG | dirty_child as u64,
+            true,
+        );
+
+        let valid_ptrs = build_valid_pointer_set();
+        let stats = mark_remembered_set_roots(&valid_ptrs);
+        assert_eq!(stats.dirty_pages_scanned, 1);
+        assert_eq!(stats.old_objects_considered, 1);
+        assert_eq!(stats.dirty_objects_scanned, 1);
+        assert_eq!(stats.dirty_slot_ranges_scanned, 1);
+        assert!(
+            stats.dirty_slots_scanned <= 512,
+            "one dirty map entries page should not scan the whole map"
+        );
+        unsafe {
+            let dirty_header = header_from_user_ptr(dirty_child as *const u8);
+            let clean_header = header_from_user_ptr(clean_child as *const u8);
+            assert_ne!((*dirty_header).gc_flags & GC_FLAG_MARKED, 0);
+            assert_eq!((*clean_header).gc_flags & GC_FLAG_MARKED, 0);
+            retire_old_test_map(map, entries, layout);
+        }
+        clear_marks();
+        remembered_set_clear();
+    }
+
+    #[test]
+    fn test_dirty_page_map_external_dedupes_and_clears() {
+        reset_remembered_set();
+        let young = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let (map, entries, layout) = unsafe { alloc_old_test_map(16) };
+        unsafe {
+            (*map).size = 16;
+            *entries.add(1) = POINTER_TAG | young as u64;
+        }
+        let slot = unsafe { entries.add(1) };
+        write_barrier_slot_inner(
+            POINTER_TAG | map as u64,
+            slot as usize,
+            POINTER_TAG | young as u64,
+            true,
+        );
+        write_barrier_slot_inner(
+            POINTER_TAG | map as u64,
+            slot as usize,
+            POINTER_TAG | young as u64,
+            true,
+        );
+        assert_eq!(remembered_set_size(), 1);
+        remembered_set_clear();
+        assert_eq!(remembered_set_size(), 0);
+        unsafe {
+            retire_old_test_map(map, entries, layout);
+        }
+    }
+
+    #[test]
+    fn test_dirty_page_map_realloc_span_marks_new_entries_pages() {
+        reset_remembered_set();
+        clear_marks();
+        let young = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let (map, entries, layout) = unsafe { alloc_old_test_map(1024) };
+        unsafe {
+            (*map).size = 1024;
+            *entries.add(1023) = POINTER_TAG | young as u64;
+        }
+        let new_layout = std::alloc::Layout::from_size_align(2048 * 16, 8).unwrap();
+        let new_entries = unsafe { std::alloc::alloc_zeroed(new_layout) as *mut u64 };
+        assert!(!new_entries.is_null());
+        unsafe {
+            std::ptr::copy_nonoverlapping(entries, new_entries, 2048);
+            (*map).entries = new_entries as *mut f64;
+            (*map).capacity = 2048;
+        }
+        dirty_external_slot_span(map as usize, new_entries as usize, 2048);
+
+        let valid_ptrs = build_valid_pointer_set();
+        let stats = mark_remembered_set_roots(&valid_ptrs);
+        assert!(stats.dirty_pages_scanned >= 1);
+        assert_eq!(stats.old_objects_considered, 1);
+        assert_eq!(stats.newly_marked, 1);
+        unsafe {
+            let header = header_from_user_ptr(young as *const u8);
+            assert_ne!((*header).gc_flags & GC_FLAG_MARKED, 0);
+            retire_old_test_map(map, new_entries, new_layout);
+            std::alloc::dealloc(entries as *mut u8, layout);
+        }
+        clear_marks();
+        remembered_set_clear();
+    }
+
+    #[test]
+    fn test_object_hashset_fallback_still_scans() {
+        reset_remembered_set();
+        clear_marks();
+        let (old_obj, _fields) = unsafe { alloc_old_test_object(1) };
+        let old_header = old_obj as usize - GC_HEADER_SIZE;
+        REMEMBERED_SET.with(|s| {
+            s.borrow_mut().insert(old_header);
+        });
+        let valid_ptrs = build_valid_pointer_set();
+        let stats = mark_remembered_set_roots(&valid_ptrs);
+        assert_eq!(stats.entries_scanned, 1);
+        assert_eq!(stats.valid_roots, 1);
+        assert_eq!(stats.newly_marked, 1);
+        unsafe {
+            let header = header_from_user_ptr(old_obj as *const u8);
+            assert_ne!((*header).gc_flags & GC_FLAG_MARKED, 0);
+        }
+        clear_marks();
+        remembered_set_clear();
+    }
+
+    #[test]
+    fn test_gc_collect_minor_keeps_dirty_page_child_alive() {
+        reset_remembered_set();
+        let young = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
+        let (old_obj, fields) = unsafe { alloc_old_test_object(1) };
+        unsafe {
+            *fields = POINTER_TAG | young as u64;
+        }
+        js_write_barrier_slot(
+            POINTER_TAG | old_obj as u64,
+            fields as u64,
+            POINTER_TAG | young as u64,
+        );
+        let _ = gc_collect_minor();
+        unsafe {
+            let child_header = header_from_user_ptr(young as *const u8);
+            assert_ne!(
+                (*child_header).gc_flags & GC_FLAG_HAS_SURVIVED,
+                0,
+                "dirty-page remembered scan should keep the young child alive through minor GC"
+            );
+        }
+        remembered_set_clear();
     }
 
     #[test]
@@ -4797,7 +6401,7 @@ mod tests {
         // Pin it.
         CONS_PINNED.with(|s| s.borrow_mut().insert(header as usize));
         let n = evacuate_tenured_nursery_objects();
-        assert_eq!(n, 0, "pinned tenured object must not be evacuated");
+        assert_eq!(n.objects, 0, "pinned tenured object must not be evacuated");
         unsafe {
             assert_eq!(
                 (*header).gc_flags & GC_FLAG_FORWARDED,
@@ -4853,7 +6457,10 @@ mod tests {
             (*header).gc_flags |= GC_FLAG_MARKED | GC_FLAG_TENURED;
         }
         let n = evacuate_tenured_nursery_objects();
-        assert_eq!(n, 1, "tenured non-pinned marked object must evacuate");
+        assert_eq!(
+            n.objects, 1,
+            "tenured non-pinned marked object must evacuate"
+        );
         unsafe {
             assert_ne!((*header).gc_flags & GC_FLAG_FORWARDED, 0);
             let new_user = forwarding_address(header);
@@ -4902,8 +6509,15 @@ mod tests {
         reset_remembered_set();
         // Set up an old→young edge to populate the RS.
         let young = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
-        let old = crate::arena::arena_alloc_gc_old(40, 8, GC_TYPE_OBJECT) as usize;
-        js_write_barrier(POINTER_TAG | (old as u64), POINTER_TAG | (young as u64));
+        let (old, fields) = unsafe { alloc_old_test_object(1) };
+        unsafe {
+            *fields = POINTER_TAG | young as u64;
+        }
+        js_write_barrier_slot(
+            POINTER_TAG | old as u64,
+            fields as u64,
+            POINTER_TAG | young as u64,
+        );
         assert_eq!(remembered_set_size(), 1);
         // Run a full collection.
         let _freed = gc_collect_inner();
@@ -4922,6 +6536,7 @@ mod tests {
         let ptr2 = gc_malloc(64, GC_TYPE_CLOSURE);
 
         unsafe {
+            init_test_closure(ptr2);
             (*header_from_user_ptr(ptr1)).gc_flags |= GC_FLAG_MARKED;
             (*header_from_user_ptr(ptr2)).gc_flags |= GC_FLAG_MARKED;
         }
@@ -4964,8 +6579,11 @@ mod tests {
         // pointers to consider; the test is about the setjmp not
         // crashing, not about a specific mark outcome.
         let _ptr1 = gc_malloc(32, GC_TYPE_STRING);
-        let _ptr2 = gc_malloc(48, GC_TYPE_CLOSURE);
+        let ptr2 = gc_malloc(48, GC_TYPE_CLOSURE);
         let _ptr3 = gc_malloc(16, GC_TYPE_BIGINT);
+        unsafe {
+            init_test_closure(ptr2);
+        }
 
         // Should complete cleanly. If the shared `_setjmp` extern is
         // mis-sized, libc will scribble past the 256-byte buffer in

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -544,12 +544,12 @@ unsafe fn find_key_index(map: *const MapHeader, key: f64) -> i32 {
 }
 
 /// Grow the entries array if needed (header stays at same address)
-unsafe fn ensure_capacity(map: *mut MapHeader) {
+unsafe fn ensure_capacity(map: *mut MapHeader) -> bool {
     let size = (*map).size;
     let capacity = (*map).capacity;
 
     if size < capacity {
-        return;
+        return false;
     }
 
     // Double the capacity
@@ -564,6 +564,7 @@ unsafe fn ensure_capacity(map: *mut MapHeader) {
 
     (*map).entries = new_entries;
     (*map).capacity = new_capacity;
+    true
 }
 
 /// Set a key-value pair in the map
@@ -582,17 +583,42 @@ pub extern "C" fn js_map_set(map: *mut MapHeader, key: f64, value: f64) -> *mut 
         if idx >= 0 {
             // Update existing value (key position unchanged → no index update)
             let entries = entries_ptr_mut(map);
-            ptr::write(entries.add((idx as usize) * 2 + 1), value);
+            let value_slot = entries.add((idx as usize) * 2 + 1);
+            ptr::write(value_slot, value);
+            crate::gc::runtime_write_barrier_external_slot(
+                map as usize,
+                value_slot as usize,
+                value.to_bits(),
+            );
             return map;
         }
 
         // Key doesn't exist, append a new entry
-        ensure_capacity(map);
+        let grew = ensure_capacity(map);
         let size = (*map).size;
         let entries = entries_ptr_mut(map);
+        if grew && size > 0 {
+            crate::gc::runtime_dirty_external_slot_span(
+                map as usize,
+                entries as usize,
+                size as usize * 2,
+            );
+        }
 
-        ptr::write(entries.add((size as usize) * 2), key);
-        ptr::write(entries.add((size as usize) * 2 + 1), value);
+        let key_slot = entries.add((size as usize) * 2);
+        let value_slot = entries.add((size as usize) * 2 + 1);
+        ptr::write(key_slot, key);
+        ptr::write(value_slot, value);
+        crate::gc::runtime_write_barrier_external_slot(
+            map as usize,
+            key_slot as usize,
+            key.to_bits(),
+        );
+        crate::gc::runtime_write_barrier_external_slot(
+            map as usize,
+            value_slot as usize,
+            value.to_bits(),
+        );
 
         (*map).size = size + 1;
 
@@ -691,8 +717,20 @@ pub extern "C" fn js_map_delete(map: *mut MapHeader, key: f64) -> i32 {
         if (idx as u32) < size - 1 {
             let last_key = ptr::read(entries.add(((size - 1) as usize) * 2));
             let last_value = ptr::read(entries.add(((size - 1) as usize) * 2 + 1));
-            ptr::write(entries.add((idx as usize) * 2), last_key);
-            ptr::write(entries.add((idx as usize) * 2 + 1), last_value);
+            let key_slot = entries.add((idx as usize) * 2);
+            let value_slot = entries.add((idx as usize) * 2 + 1);
+            ptr::write(key_slot, last_key);
+            ptr::write(value_slot, last_value);
+            crate::gc::runtime_write_barrier_external_slot(
+                map as usize,
+                key_slot as usize,
+                last_key.to_bits(),
+            );
+            crate::gc::runtime_write_barrier_external_slot(
+                map as usize,
+                value_slot as usize,
+                last_value.to_bits(),
+            );
             swapped_key = Some(last_key);
         }
 

--- a/crates/perry-runtime/src/object.rs
+++ b/crates/perry-runtime/src/object.rs
@@ -2401,6 +2401,16 @@ pub struct ObjectHeader {
     pub keys_array: *mut ArrayHeader,
 }
 
+#[inline]
+unsafe fn set_object_keys_array(obj: *mut ObjectHeader, keys_array: *mut ArrayHeader) {
+    (*obj).keys_array = keys_array;
+    crate::gc::runtime_write_barrier_slot(
+        obj as usize,
+        &(*obj).keys_array as *const _ as usize,
+        keys_array as u64,
+    );
+}
+
 /// Allocate a new object with the given class ID and field count
 /// Returns a pointer to the object header
 #[no_mangle]
@@ -3228,7 +3238,9 @@ pub extern "C" fn js_object_set_field(obj: *mut ObjectHeader, field_index: u32, 
             value
         };
         let fields_ptr = (obj as *mut u8).add(std::mem::size_of::<ObjectHeader>()) as *mut JSValue;
-        ptr::write(fields_ptr.add(field_index as usize), value);
+        let slot = fields_ptr.add(field_index as usize);
+        ptr::write(slot, value);
+        crate::gc::runtime_write_barrier_slot(obj as usize, slot as usize, value.bits());
     }
 }
 
@@ -3373,7 +3385,7 @@ pub extern "C" fn js_object_set_field_by_index(
 #[no_mangle]
 pub extern "C" fn js_object_set_keys(obj: *mut ObjectHeader, keys_array: *mut ArrayHeader) {
     unsafe {
-        (*obj).keys_array = keys_array;
+        set_object_keys_array(obj, keys_array);
     }
 }
 
@@ -5167,7 +5179,7 @@ pub extern "C" fn js_object_set_field_by_name(
                 } else {
                     vbits
                 };
-                (*obj).keys_array = next_keys as *mut ArrayHeader;
+                set_object_keys_array(obj, next_keys as *mut ArrayHeader);
                 let alloc_limit = std::cmp::max((*obj).field_count, 8) as usize;
                 if (slot_idx as usize) < alloc_limit {
                     // Inline the field write — `obj` has already been
@@ -5177,7 +5189,9 @@ pub extern "C" fn js_object_set_field_by_name(
                     // point re-doing it in `js_object_set_field`.
                     let fields_ptr =
                         (obj as *mut u8).add(std::mem::size_of::<ObjectHeader>()) as *mut JSValue;
-                    ptr::write(fields_ptr.add(slot_idx as usize), JSValue::from_bits(vbits));
+                    let slot = fields_ptr.add(slot_idx as usize);
+                    ptr::write(slot, JSValue::from_bits(vbits));
+                    crate::gc::runtime_write_barrier_slot(obj as usize, slot as usize, vbits);
                     // Bump field_count only for inline slots — leaving
                     // it at the physical capacity is what steers
                     // `js_object_get_field_by_name`'s reads to the
@@ -5212,7 +5226,7 @@ pub extern "C" fn js_object_set_field_by_name(
             let new_keys = crate::array::js_array_alloc(4);
             let new_keys =
                 crate::array::js_array_push(new_keys, JSValue::string_ptr(key as *mut _));
-            (*obj).keys_array = new_keys;
+            set_object_keys_array(obj, new_keys);
 
             // Reallocate fields to hold at least one value
             // Note: We assume the object has enough field slots pre-allocated
@@ -5316,7 +5330,7 @@ pub extern "C" fn js_object_set_field_by_name(
                     *dst_data.add(i) = *src_data.add(i);
                 }
                 (*cloned).length = key_count as u32;
-                (*obj).keys_array = cloned;
+                set_object_keys_array(obj, cloned);
                 cloned
             } else {
                 keys
@@ -5331,7 +5345,7 @@ pub extern "C" fn js_object_set_field_by_name(
                 };
                 let new_keys =
                     crate::array::js_array_push(owned_keys, JSValue::string_ptr(key as *mut _));
-                (*obj).keys_array = new_keys;
+                set_object_keys_array(obj, new_keys);
                 overflow_set(obj as usize, new_index, vbits);
                 transition_cache_insert(
                     prev_keys_usize,
@@ -5349,7 +5363,7 @@ pub extern "C" fn js_object_set_field_by_name(
             }
             let new_keys =
                 crate::array::js_array_push(owned_keys, JSValue::string_ptr(key as *mut _));
-            (*obj).keys_array = new_keys;
+            set_object_keys_array(obj, new_keys);
             js_object_set_field(obj, new_index as u32, JSValue::from_bits(value.to_bits()));
             if new_index as u32 >= (*obj).field_count {
                 (*obj).field_count = new_index as u32 + 1;
@@ -5470,7 +5484,7 @@ pub extern "C" fn js_object_set_field_by_name(
                 *dst_data.add(i) = *src_data.add(i);
             }
             (*cloned).length = key_count as u32;
-            (*obj).keys_array = cloned;
+            set_object_keys_array(obj, cloned);
             cloned
         } else {
             keys
@@ -5492,7 +5506,7 @@ pub extern "C" fn js_object_set_field_by_name(
             };
             let new_keys =
                 crate::array::js_array_push(owned_keys, JSValue::string_ptr(key as *mut _));
-            (*obj).keys_array = new_keys;
+            set_object_keys_array(obj, new_keys);
             overflow_set(obj as usize, new_index, vbits);
             // Record the shape transition so the next object sharing
             // `prev_keys` that adds the same key hits the fast path.
@@ -5510,7 +5524,7 @@ pub extern "C" fn js_object_set_field_by_name(
         // First, add the key to the keys array (may reallocate)
         let new_keys = crate::array::js_array_push(owned_keys, JSValue::string_ptr(key as *mut _));
         // Update the object's keys_array pointer in case js_array_push reallocated
-        (*obj).keys_array = new_keys;
+        set_object_keys_array(obj, new_keys);
 
         // Set the field at the new index and update logical field_count
         js_object_set_field(obj, new_index as u32, JSValue::from_bits(value.to_bits()));
@@ -5592,7 +5606,7 @@ pub extern "C" fn js_object_delete_field(
             *dst_elements.add(j) = *src_elements.add(j + 1);
         }
         (*keys_cloned).length = new_count as u32;
-        (*obj).keys_array = keys_cloned;
+        set_object_keys_array(obj, keys_cloned);
 
         // 1) Shift values down: for slot j in i..new_count, copy slot j+1
         //    into slot j. Inline reads/writes for j < alloc_limit;
@@ -10067,7 +10081,7 @@ unsafe fn ensure_key_in_keys_array(obj: *mut ObjectHeader, key: *const crate::St
     if keys.is_null() {
         let new_keys = crate::array::js_array_alloc(4);
         let new_keys = crate::array::js_array_push(new_keys, JSValue::string_ptr(key as *mut _));
-        (*obj).keys_array = new_keys;
+        set_object_keys_array(obj, new_keys);
         if (*obj).field_count == 0 {
             (*obj).field_count = 1;
         }
@@ -10098,13 +10112,13 @@ unsafe fn ensure_key_in_keys_array(obj: *mut ObjectHeader, key: *const crate::St
             *dst_data.add(i) = *src_data.add(i);
         }
         (*cloned).length = key_count as u32;
-        (*obj).keys_array = cloned;
+        set_object_keys_array(obj, cloned);
         cloned
     } else {
         keys
     };
     let new_keys = crate::array::js_array_push(owned_keys, JSValue::string_ptr(key as *mut _));
-    (*obj).keys_array = new_keys;
+    set_object_keys_array(obj, new_keys);
     let new_index = key_count as u32;
     if new_index >= (*obj).field_count {
         (*obj).field_count = new_index + 1;


### PR DESCRIPTION
## Summary

- add `PERRY_GC_TRACE` JSONL telemetry for completed GC cycles, including phase timings, arena/malloc stats, remembered-set shape, write-barrier counters, evacuation, block persistence, and sweep/reset stats
- add arena range side metadata for fast nursery/old/longlived generation classification and use it in write barriers without per-page classifier-table RSS growth
- add slot-aware and external-slot dirty-page remembered tracking, old-page -> old-object indexing, and range-bounded dirty slot scanning for large arrays/objects/maps/closures
- wire runtime object/map helper stores through the barrier path and add tests for metadata lifecycle, dirty-page scanning, external map pages, slot-range bounds, old-map test fixture cleanup, and initialized raw closure fixtures used by conservative-stack tests

## Verification

- `cargo fmt --check`
- `cargo test -p perry-runtime` -> 280 passed
- `cargo test --release -p perry-runtime` -> 280 passed
- `for i in 1 2 3 4 5; do cargo test -p perry-runtime gc::tests; done` -> all 5 passed
- `scripts/run_memory_stability_tests.sh` -> 18 pass, 0 fail; `test_memory_json_churn.ts` was 232 MB / 250 MB locally after compacting generation metadata
- `cargo check -p perry-codegen`
- `cargo build --release -p perry`
- `git diff --check HEAD`
- `PERRY_WRITE_BARRIERS=1 PERRY_GC_TRACE=1 ./bench_json_roundtrip` emitted 2 JSONL GC lines; `jq -s -e` confirmed telemetry field types
- no-trace `./bench_json_roundtrip` produced 0 bytes on stderr