### PR TITLE
fix(perry-ui-ios): #1107 partial-alpha text invisible on iOS 26

### DIFF
--- a/crates/perry-ui-ios/src/widgets/button.rs
+++ b/crates/perry-ui-ios/src/widgets/button.rs
@@ -166,6 +166,18 @@ pub fn set_bordered(handle: i64, bordered: bool) {
 }
 
 /// Set the text color of a button.
+///
+/// Issue #1107 — on iOS 26 devices a partial-alpha title color set via
+/// `setTitleColor:forState:` results in zero glyphs being painted (the
+/// reporter confirmed alpha == 1.0 is fine, AttributedText's
+/// NSAttributedString-with-NSColor path is also fine, and iOS 17
+/// simulator is unaffected). For alpha < 1.0 we additionally emit an
+/// `NSAttributedString` (NSFont + NSColor attrs) via
+/// `setAttributedTitle:forState:` mirroring the working AttributedText
+/// path. `setTitleColor:` is still issued so any state that bypasses
+/// the attributed title (custom UIButton subclasses, future
+/// `setTitle:forState:` clobbers, etc.) still has a reasonable
+/// fallback color.
 pub fn set_text_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
     if let Some(view) = super::get_widget(handle) {
         unsafe {
@@ -178,8 +190,71 @@ pub fn set_text_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
             ];
             // setTitleColor:forState: UIControlStateNormal = 0
             let _: () = msg_send![&*view, setTitleColor: &*color, forState: 0u64];
+
+            if a < 1.0 {
+                apply_button_title_color_via_attributed(&view, &color);
+            } else {
+                clear_button_attributed_title(&view);
+            }
         }
     }
+}
+
+/// Issue #1107 workaround — build an NSAttributedString with NSFont +
+/// NSColor attrs from the button's current title-for-Normal and apply
+/// it via `setAttributedTitle:forState:UIControlStateNormal`. This is
+/// the only path the reporter has shown actually renders glyphs on
+/// iOS 26 device when the foreground color carries alpha < 1.0.
+unsafe fn apply_button_title_color_via_attributed(view: &objc2_ui_kit::UIView, color: &AnyObject) {
+    use objc2::runtime::AnyClass;
+
+    // titleForState: UIControlStateNormal = 0
+    let current_title: *const NSString = msg_send![view, titleForState: 0u64];
+    if current_title.is_null() {
+        return;
+    }
+    let length: u64 = msg_send![current_title, length];
+    if length == 0 {
+        return;
+    }
+
+    let dict_cls = AnyClass::get(c"NSMutableDictionary").unwrap();
+    let attrs: Retained<AnyObject> = msg_send![dict_cls, new];
+
+    // Pull the titleLabel's current font and pin it into the attributes
+    // dict. Without an NSFont, iOS 26's text renderer skips glyphs when
+    // the color carries sub-1.0 alpha (see issue #1107).
+    let title_label: *mut AnyObject = msg_send![view, titleLabel];
+    if !title_label.is_null() {
+        let font: *mut AnyObject = msg_send![title_label, font];
+        if !font.is_null() {
+            let font_key = NSString::from_str("NSFont");
+            let _: () = msg_send![&*attrs, setObject: font, forKey: &*font_key];
+        }
+    }
+
+    let color_key = NSString::from_str("NSColor");
+    let _: () = msg_send![&*attrs, setObject: color, forKey: &*color_key];
+
+    let attr_cls = AnyClass::get(c"NSAttributedString").unwrap();
+    let alloc: *mut AnyObject = msg_send![attr_cls, alloc];
+    let attr_str: *mut AnyObject = msg_send![
+        alloc,
+        initWithString: current_title,
+        attributes: &*attrs
+    ];
+    if !attr_str.is_null() {
+        let _: () = msg_send![view, setAttributedTitle: attr_str, forState: 0u64];
+    }
+}
+
+/// alpha == 1.0 was never affected by #1107, so drop any previously
+/// applied attributed title and let `setTitleColor:`/`setTitle:` win
+/// again. Passing `nil` for the attributed title is the documented way
+/// to revert to the plain-title rendering path.
+unsafe fn clear_button_attributed_title(view: &objc2_ui_kit::UIView) {
+    let nil_attr: *const AnyObject = std::ptr::null();
+    let _: () = msg_send![view, setAttributedTitle: nil_attr, forState: 0u64];
 }
 
 /// Set the title text of a button.

--- a/crates/perry-ui-ios/src/widgets/text.rs
+++ b/crates/perry-ui-ios/src/widgets/text.rs
@@ -64,6 +64,21 @@ pub fn set_string(handle: i64, text_ptr: *const u8) {
 ///                 Button that don't respond to `setTextColor:` and
 ///                 would raise `unrecognized selector` → non-unwinding
 ///                 panic across the FFI boundary → process abort)
+///
+/// Issue #1107 — on iOS 26 devices a partial-alpha UIColor passed to
+/// `setTextColor:` causes UILabel to render zero glyphs (alpha == 1.0
+/// works; iOS 17 simulator works; iOS 26 device fails). The
+/// `AttributedText` widget's path (UIColor as the `NSColor`/
+/// `NSForegroundColorAttributeName` value inside an
+/// `NSAttributedString`'s attributes dict, applied via
+/// `setAttributedText:`) is the one path the reporter confirmed renders
+/// correctly with sub-1.0 alpha. So for the alpha < 1.0 case we mirror
+/// that path: read the label's current `text` + `font`, build an
+/// `NSAttributedString` with `NSFont` + `NSColor` attrs, and call
+/// `setAttributedText:`. `textColor` is still set as well so future
+/// `setText:` calls (which clobber the attributed buffer) still pick up
+/// at least the solid-color approximation rather than reverting to
+/// system default.
 pub fn set_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
     let Some(view) = super::get_widget(handle) else {
         return;
@@ -91,7 +106,76 @@ pub fn set_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
             alpha: a as objc2_core_foundation::CGFloat
         ];
         let _: () = msg_send![&*view, setTextColor: &*color];
+
+        // iOS 26 partial-alpha workaround (issue #1107).
+        // alpha == 1.0 is unaffected by the bug, keep the simple
+        // setTextColor: path so we don't disturb intrinsic-content sizing.
+        if a < 1.0 {
+            apply_label_color_via_attributed(&view, &color);
+        } else {
+            // Clear any prior attributedText we may have set so the plain
+            // textColor path takes effect again.
+            clear_label_attributed_text(&view);
+        }
     }
+}
+
+/// Issue #1107 workaround — mirror `AttributedText::append`'s code
+/// path so a partial-alpha NSColor actually paints glyphs on iOS 26.
+/// Pulls the current `text` + `font` off the label and re-applies them
+/// via `setAttributedText:` with `NSFont` + `NSColor` attrs.
+unsafe fn apply_label_color_via_attributed(view: &UIView, color: &objc2::runtime::AnyObject) {
+    use objc2::runtime::AnyObject;
+
+    let current_text: *const objc2_foundation::NSString = msg_send![view, text];
+    if current_text.is_null() {
+        return;
+    }
+    let length: u64 = msg_send![current_text, length];
+    if length == 0 {
+        return;
+    }
+
+    let dict_cls = AnyClass::get(c"NSMutableDictionary").unwrap();
+    let attrs: Retained<AnyObject> = msg_send![dict_cls, new];
+
+    // Always emit NSFont — without it, iOS 26's Liquid Glass text
+    // renderer appears to skip glyph emission for sub-1.0 alpha.
+    let font: *mut AnyObject = msg_send![view, font];
+    if !font.is_null() {
+        let font_key = NSString::from_str("NSFont");
+        let _: () = msg_send![&*attrs, setObject: font, forKey: &*font_key];
+    }
+
+    let color_key = NSString::from_str("NSColor");
+    let _: () = msg_send![&*attrs, setObject: color, forKey: &*color_key];
+
+    let attr_cls = AnyClass::get(c"NSAttributedString").unwrap();
+    let alloc: *mut AnyObject = msg_send![attr_cls, alloc];
+    let attr_str: *mut AnyObject = msg_send![
+        alloc,
+        initWithString: current_text,
+        attributes: &*attrs
+    ];
+    if !attr_str.is_null() {
+        let _: () = msg_send![view, setAttributedText: attr_str];
+    }
+}
+
+/// Counterpart to `apply_label_color_via_attributed` — for alpha == 1.0
+/// (or color cleared) we want plain `textColor` rendering to win again,
+/// so explicitly drop the attributedText we may have set earlier by
+/// rebuilding it from the current plain string with no attributes.
+unsafe fn clear_label_attributed_text(view: &UIView) {
+    use objc2::runtime::AnyObject;
+    let current_text: *const objc2_foundation::NSString = msg_send![view, text];
+    if current_text.is_null() {
+        return;
+    }
+    // Re-issuing setText: with the same string forces UILabel to
+    // discard any internal attributedText state. This is cheaper than
+    // building a no-op NSAttributedString.
+    let _: () = msg_send![view, setText: current_text as *const AnyObject];
 }
 
 /// Determine the correct target for font/text operations.


### PR DESCRIPTION
Closes #1107.

## Root cause

On iOS 26 device, `UILabel.setTextColor:` and `UIButton.setTitleColor:forState:` with a `UIColor` whose alpha < 1.0 render **zero glyphs**. Reporter confirmed:

- alpha == 1.0 paints fine (same code path)
- iOS 17 simulator is unaffected (only iOS 26 device fails)
- `AttributedText` widget's path — UIColor under `NSColor` / `NSForegroundColorAttributeName` inside an NSAttributedString applied via `setAttributedText:` — renders correctly with sub-1.0 alpha

Looks like an iOS 26 / Liquid Glass text renderer regression: the plain `textColor` / `titleColor` paths are silently dropped (or rasterised invisibly) when the color isn't fully opaque, while the attributed-text path goes through a different renderer that still honors partial alpha.

## Fix

In `crates/perry-ui-ios/src/widgets/text.rs::set_color` (UILabel) and `crates/perry-ui-ios/src/widgets/button.rs::set_text_color` (UIButton): for `alpha < 1.0`, mirror `AttributedText::append`'s known-working code path on the plain widget by also setting `attributedText` / `attributedTitle:forState:`:

1. Read the current `text` / `titleForState:UIControlStateNormal`
2. Read the current `font` (from the label or `button.titleLabel.font`)
3. Build an `NSAttributedString` with `NSFont` + `NSColor` attrs (matching `attributed_text.rs` line-for-line on the keys)
4. Apply via `setAttributedText:` / `setAttributedTitle:forState:UIControlStateNormal`

`setTextColor:` / `setTitleColor:` is still issued first, so any later `setText:` / `setTitle:` clobber (which discards the attributed buffer) retains a reasonable solid-color fallback. For `alpha == 1.0` we explicitly clear any prior attributedText/attributedTitle so the plain path takes over, avoiding disturbing intrinsic-content sizing on the unaffected iOS 17 path.

Critically, the NSFont attr is always emitted — the reporter's "Routing `set_color` through `setAttributedText:` with NSColor in attributes dict … Zero-glyph" bisection-step likely didn't include NSFont, and on iOS 26 it appears NSFont is required for sub-1.0 alpha to render.

## Files touched

- `crates/perry-ui-ios/src/widgets/text.rs`
- `crates/perry-ui-ios/src/widgets/button.rs`

No TS / HIR / codegen / shim changes.

## Test plan

The agent doesn't have iOS 26.5 device access. Reporter should validate:

- [ ] On iOS 26.5 device, run the issue reproducer:
  ```ts
  import { Text, VStack, textSetFontSize, textSetColor } from "perry/ui";
  const TEXT_PRIMARY = { r: 0, g: 0, b: 0, a: 0.87 };
  const slogan = Text("Erlebe eine Welt, in der Teilen Freude schenkt");
  textSetFontSize(slogan, 24);
  textSetColor(slogan, TEXT_PRIMARY.r, TEXT_PRIMARY.g, TEXT_PRIMARY.b, TEXT_PRIMARY.a);
  ```
  expect: 87%-black glyphs visible.
- [ ] Same on a `Button(...)` title with `textSetColor(btn, 0, 0, 0, 0.87)` — expect 87%-black glyphs.
- [ ] iOS 17 simulator regression check: `Text` + `textSetColor` with both alpha == 1.0 and alpha == 0.87 still render.
- [ ] Existing `AttributedText` widget still works (untouched code path; smoke test only).

If the alpha < 1.0 cases still come out blank on device, the next hypothesis is that NSColor (the iOS legacy key) needs to be `NSForegroundColorAttributeName` literal (`@"NSColor"` resolves to the same symbol but if Apple changed it on iOS 26, we'd want to look up `kCTForegroundColorAttributeName` from CoreText instead). Easy follow-up if validation fails.

No version bump or changelog change — maintainer will fold those in at merge.