### PR TITLE
fix(crypto): #1111 — CipherHandle property reads return bound-method closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,76 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1010 — fix(crypto): #1111 — CipherHandle property reads return bound-method closures so `c.getAuthTag?.()` doesn't short-circuit
+
+#1075 wired the runtime side of `createCipheriv("aes-256-gcm", ...)` —
+`dispatch_cipher` in `crates/perry-stdlib/src/crypto.rs` already
+handled `update` / `final` / `getAuthTag` / `setAuthTag` / `setAAD`,
+and the AES-GCM ciphertext matched Node byte-for-byte. But
+`c.getAuthTag?.()` still returned undefined and the GCM auth-tag
+round-trip didn't authenticate.
+
+Root cause: CipherHandle is a small registry id (NaN-boxed POINTER_TAG
+| handle, raw < 0x100000), and the optional-call lowering in
+`crates/perry-hir/src/lower.rs::OptChainBase::Call` evaluates the
+property as the null-check expression:
+
+```rust
+Expr::Conditional {
+    condition: Compare { op: LooseEq, left: c.getAuthTag, right: Null },
+    then_expr: Undefined,
+    else_expr: c.getAuthTag(args),
+}
+```
+
+`c.getAuthTag` (property access on a small handle) routed through
+`HANDLE_PROPERTY_DISPATCH` in `crates/perry-stdlib/src/common/dispatch.rs`,
+which had no `CipherHandle` arm and fell through to the
+`f64::from_bits(0x7FFC_0000_0000_0001)` (undefined) catch-all. The
+loose `undefined == null` check then fired and the call was skipped —
+`tag` stayed undefined, the `if (tag) d.setAuthTag(tag)` line was
+also skipped, and `d.final()` returned undefined because
+`state.auth_tag` was still `None` (GCM-decrypt requires the tag). The
+final `Buffer.concat([d.update(ct), d.final()])` then produced `""`.
+
+Ciphertext matched Node because `c.update(plain)` and `c.final()` are
+inline calls (`Expr::Call { callee: PropertyGet { ... } }`) routed
+through `js_native_call_method` → `HANDLE_METHOD_DISPATCH` →
+`dispatch_cipher`, never going through property dispatch at all.
+
+Fix mirrors the StringDecoder pattern from #848:
+
+- `crates/perry-stdlib/src/crypto.rs`: new `dispatch_cipher_property`
+  returns `js_class_method_bind(this, "<method>", len)` for the five
+  known method names. The bound closure captures the POINTER_TAG'd
+  handle as `this` and the method-name byte pointer/length (as a
+  bounded `&'static [u8]` leak of five fixed strings).
+- `crates/perry-stdlib/src/common/dispatch.rs`:
+  `js_handle_property_dispatch` gains a `#[cfg(feature = "crypto")]`
+  arm gated on (a) method-name vocabulary and (b)
+  `with_handle::<CipherHandle, ...>` to avoid handle-id collisions
+  with other registries (same disjoint-method-set discipline as the
+  existing method-dispatch arms).
+
+When the bound closure is invoked, `BOUND_METHOD_FUNC_PTR` routes
+through `js_native_call_method(this, method_name, args)`, the
+POINTER_TAG strips to a small handle, and dispatch lands at
+`dispatch_cipher` — the exact path the inline call already took.
+
+Result: `c.getAuthTag?.()`, `typeof c.getAuthTag === "function"`, and
+`const g = c.getAuthTag; g.call(c)` all work, and the full
+encrypt → getAuthTag → setAuthTag → decrypt round-trip matches Node
+byte-for-byte:
+
+```
+ct: 727b71f1caf79d78815b7a tag: c14c93ec76f514dd0c0aecfe5acccec6
+decrypted: hello world
+```
+
+Validation: 12-line repro from #1111 + three additional variants
+(direct call, optional chain, method-as-value extraction, full
+roundtrip) all match `node --experimental-strip-types`.
+
 ## v0.5.1009 — fix(object): skip misaligned non-object pointers in js_object_assign_one
 
 `js_object_assign_one` (the `Object.assign` single-source helper)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1009
+**Current Version:** 0.5.1010
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5084,7 +5084,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "base64",
@@ -5139,14 +5139,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "log",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5168,7 +5168,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "base64",
@@ -5208,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "serde",
  "serde_json",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1009"
+version = "0.5.1010"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "clap",
@@ -5250,14 +5250,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5298,14 +5298,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "chrono",
  "cron",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5322,7 +5322,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5338,7 +5338,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5346,21 +5346,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5385,14 +5385,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-google-auth"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5404,7 +5404,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5444,7 +5444,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "bson",
  "futures-util",
@@ -5472,7 +5472,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5502,7 +5502,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "base64",
  "image",
@@ -5546,14 +5546,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5569,7 +5569,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5590,7 +5590,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5598,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5607,7 +5607,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5623,7 +5623,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5649,7 +5649,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "base64",
@@ -5686,7 +5686,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5759,7 +5759,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5777,11 +5777,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1009"
+version = "0.5.1010"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "base64",
  "itoa",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5807,7 +5807,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5828,7 +5828,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "base64",
  "block2",
@@ -5844,7 +5844,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "base64",
  "block2",
@@ -5863,11 +5863,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1009"
+version = "0.5.1010"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "base64",
  "block2",
@@ -5883,7 +5883,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "base64",
  "block2",
@@ -5899,7 +5899,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "block2",
  "libc",
@@ -5912,7 +5912,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "base64",
  "libc",
@@ -5927,7 +5927,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5941,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1009"
+version = "0.5.1010"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1009"
+version = "0.5.1010"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -812,6 +812,20 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
         return crate::string_decoder::dispatch_string_decoder_property(handle, property_name);
     }
 
+    // Issue #1111: CipherHandle method-as-value reads. Returns a
+    // bound-method closure for `update` / `final` / `getAuthTag` /
+    // `setAuthTag` / `setAAD` so `c.getAuthTag?.()` doesn't short-circuit
+    // on the optional-chain `c.getAuthTag == null` check. Same disjoint
+    // method-name gate as the method-dispatch arm above.
+    #[cfg(feature = "crypto")]
+    if matches!(
+        property_name,
+        "update" | "final" | "getAuthTag" | "setAuthTag" | "setAAD"
+    ) && with_handle::<crate::crypto::CipherHandle, bool, _>(handle, |_| true).unwrap_or(false)
+    {
+        return crate::crypto::dispatch_cipher_property(handle, property_name);
+    }
+
     // Unknown handle type - return undefined
     f64::from_bits(0x7FFC_0000_0000_0001)
 }

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -1273,3 +1273,37 @@ pub unsafe fn dispatch_cipher(handle: i64, method: &str, args: &[f64]) -> f64 {
         _ => nanbox_undefined(),
     }
 }
+
+/// Property reads on a CipherHandle — `c.getAuthTag` / `c.setAuthTag` /
+/// `c.update` / `c.final` / `c.setAAD`. Issue #1111: without this,
+/// `c.getAuthTag?.()` short-circuited because the property access
+/// returned undefined (small handles have no field storage), so the
+/// `?.` lowering's `c.getAuthTag == null` check fired and the call
+/// never happened.
+///
+/// Each known method name returns a bound-method closure (via
+/// `js_class_method_bind`) whose `this` is the POINTER_TAG-NaN-boxed
+/// handle. When invoked the closure routes through
+/// `js_native_call_method` → `HANDLE_METHOD_DISPATCH` → `dispatch_cipher`,
+/// the exact path `c.method(args)` takes when called inline. So
+/// `typeof c.getAuthTag === "function"` and `const g = c.getAuthTag; g()`
+/// both work, mirroring Node's `Cipher` shape.
+pub unsafe fn dispatch_cipher_property(handle: i64, property: &str) -> f64 {
+    let name_bytes: &'static [u8] = match property {
+        "update" => b"update",
+        "final" => b"final",
+        "getAuthTag" => b"getAuthTag",
+        "setAuthTag" => b"setAuthTag",
+        "setAAD" => b"setAAD",
+        _ => return nanbox_undefined(),
+    };
+    let this_f64 = nanbox_pointer_f64(handle as usize);
+    extern "C" {
+        fn js_class_method_bind(
+            instance: f64,
+            method_name_ptr: *const u8,
+            method_name_len: usize,
+        ) -> f64;
+    }
+    js_class_method_bind(this_f64, name_bytes.as_ptr(), name_bytes.len())
+}

--- a/test-files/test_issue_1111_gcm_auth_tag_optchain.ts
+++ b/test-files/test_issue_1111_gcm_auth_tag_optchain.ts
@@ -1,0 +1,23 @@
+import * as crypto from "node:crypto";
+
+const key = Buffer.alloc(32, 0x42);
+const iv  = Buffer.alloc(12, 0x33);
+const plain = Buffer.from("hello world", "utf8");
+
+// Issue #1111 repro: optional-call on a CipherHandle's method.
+// Pre-fix, c.getAuthTag (property access on a small handle) returned
+// undefined, so the `?.` short-circuit fired and tag was undefined.
+const c = crypto.createCipheriv("aes-256-gcm", key, iv);
+const ct  = Buffer.concat([c.update(plain), c.final()]);
+const tag = (c as any).getAuthTag?.();
+console.log("ct:", ct.toString("hex"));
+console.log("tag:", tag?.toString?.("hex") ?? "(none)");
+
+// Method-as-value: the bound closure should report as `function`.
+console.log("typeof getAuthTag:", typeof (c as any).getAuthTag);
+
+// Full roundtrip via decipher.setAuthTag.
+const d = crypto.createDecipheriv("aes-256-gcm", key, iv);
+if (tag) (d as any).setAuthTag(tag);
+const out = Buffer.concat([d.update(ct), d.final()]);
+console.log("decrypted:", out.toString("utf8"));


### PR DESCRIPTION
## Summary

- Fixes #1111: `cipher.getAuthTag?.()` returned undefined and `decipher.setAuthTag(tag)` no-op'd because the optional-chain check short-circuited on `c.getAuthTag == null`.
- Root cause: `HANDLE_PROPERTY_DISPATCH` had no CipherHandle arm — property access on a small-handle CipherHandle returned undefined, so the OptChainBase::Call lowering's null-check fired and the call never happened. Inline calls (`c.update(plain)`, `c.final()`) worked because they route through `js_native_call_method` -> `dispatch_cipher` and never touch property dispatch.
- Mirrors the StringDecoder #848 pattern: returns a bound-method closure (via `js_class_method_bind`) for `update`/`final`/`getAuthTag`/`setAuthTag`/`setAAD`. Closure captures the POINTER_TAG'd handle as `this`; invoking it routes through `HANDLE_METHOD_DISPATCH` -> `dispatch_cipher` — same path as inline calls.

After the fix, all four variants match `node --experimental-strip-types` byte-for-byte:

```
ct: 727b71f1caf79d78815b7a tag: c14c93ec76f514dd0c0aecfe5acccec6
decrypted: hello world
```

Also: `typeof c.getAuthTag === "function"` returns true, and `const g = c.getAuthTag; g.call(c)` produces the same tag.

## Test plan

- [x] 12-line repro from issue #1111 — perry output matches Node byte-for-byte
- [x] Variants: direct call / optional chain / `typeof` / method-as-value extraction / full encrypt+decrypt roundtrip
- [x] Existing `test-files/test_crypto_cipheriv.ts` (CBC + GCM direct-call roundtrip) — non-regression
- [x] New `test-files/test_issue_1111_gcm_auth_tag_optchain.ts` covers the OptChain case
- [x] `cargo test --release -p perry-stdlib -- crypto` — 9 passed (AES-GCM round-trip 128/256, etc.)
- [x] Full `cargo build --release` — green

Bumps to 0.5.1010.