### PR TITLE
chore(cli): #1105 PR 2 — extract per-target bundle writers from run_with_parse_cache

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -1489,6 +1489,525 @@ fn summarize_codegen_cache_stats(
     ))
 }
 
+/// Walk up from `start` looking for a project anchor (`package.json`
+/// or, for the watchOS case, `perry.toml`). Bounded to 5 levels so a
+/// runaway walk can't traverse the filesystem. Returns the deepest
+/// directory that holds an anchor; if none found within the bound,
+/// returns the starting input unchanged.
+fn find_project_root_for_resources(start: &Path, watch_for_perry_toml: bool) -> PathBuf {
+    let mut project_root = start.to_path_buf();
+    for _ in 0..5 {
+        if project_root.join("package.json").exists() {
+            break;
+        }
+        if watch_for_perry_toml && project_root.join("perry.toml").exists() {
+            break;
+        }
+        if let Some(parent) = project_root.parent() {
+            project_root = parent.to_path_buf();
+        } else {
+            break;
+        }
+    }
+    project_root
+}
+
+/// Recursive copy used by the per-target bundle writers. Mirrors the
+/// inline `copy_dir_recursive_standalone` / `copy_dir_recursive`
+/// helpers that existed in each bundle branch.
+fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        let dest_path = dst.join(entry.file_name());
+        if ty.is_dir() {
+            copy_dir_recursive(&entry.path(), &dest_path)?;
+        } else {
+            fs::copy(entry.path(), &dest_path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Copy the `logo` / `assets` / `resources` / `images` directories
+/// from `project_root` into `dest_dir`. Used by the bundle writers
+/// so `[[NSBundle mainBundle] resourcePath]` / `resolve_asset_path`
+/// can find assets at runtime.
+fn copy_bundle_resource_dirs(project_root: &Path, dest_dir: &Path) {
+    for dir_name in &["logo", "assets", "resources", "images"] {
+        let resource_dir = project_root.join(dir_name);
+        if resource_dir.is_dir() {
+            let dest = dest_dir.join(dir_name);
+            let _ = copy_dir_recursive(&resource_dir, &dest);
+        }
+    }
+}
+
+/// Create a watchOS `.app` bundle: copy the linked binary into the
+/// bundle, write `Info.plist` (CFBundleExecutable / CFBundleIdentifier
+/// / WKApplication), copy project asset directories, then run the
+/// shared metallib compile for any `.metal` sources.
+///
+/// Returns `(app_dir, bundle_id)` so the caller can wire them into
+/// the final `CompileResult` (`result_app_dir`, `result_bundle_id`).
+fn bundle_for_watchos(
+    exe_path: &Path,
+    stem: &str,
+    target: Option<&str>,
+    input: &Path,
+    ctx: &CompilationContext,
+    format: OutputFormat,
+) -> Result<(PathBuf, String)> {
+    let app_dir = exe_path.with_extension("app");
+    let _ = fs::create_dir_all(&app_dir);
+    let bundle_exe = app_dir.join(exe_path.file_name().unwrap_or_default());
+    fs::copy(exe_path, &bundle_exe)?;
+    let _ = fs::remove_file(exe_path);
+
+    let exe_stem = exe_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(stem);
+    let bundle_id = lookup_bundle_id_from_toml(input, "watchos")
+        .or_else(|| lookup_bundle_id_from_toml(input, "app"))
+        .unwrap_or_else(|| crate::commands::sanitize::default_perry_bundle_id(exe_stem));
+
+    let info_plist = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>{exe_stem}</string>
+    <key>CFBundleIdentifier</key>
+    <string>{bundle_id}</string>
+    <key>CFBundleName</key>
+    <string>{exe_stem}</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>MinimumOSVersion</key>
+    <string>10.0</string>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>4</integer>
+    </array>
+    <key>WKApplication</key>
+    <true/>
+    <key>WKWatchOnly</key>
+    <true/>
+</dict>
+</plist>"#
+    );
+    fs::write(app_dir.join("Info.plist"), info_plist)?;
+
+    // Copy project resource directories into the bundle so
+    // bloom_load_texture / load_sound / read_file can resolve relative
+    // asset paths via [[NSBundle mainBundle] resourcePath].
+    if let Some(src_dir) = input
+        .canonicalize()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+    {
+        let project_root = find_project_root_for_resources(&src_dir, true);
+        copy_bundle_resource_dirs(&project_root, &app_dir);
+    }
+
+    compile_metallib_for_bundle(ctx, target, &app_dir, format)?;
+
+    match format {
+        OutputFormat::Text => {
+            println!("Wrote watchOS app bundle: {}", app_dir.display());
+            println!();
+            println!("To run on Apple Watch Simulator:");
+            println!("  xcrun simctl install booted {}", app_dir.display());
+            println!("  xcrun simctl launch booted {}", bundle_id);
+        }
+        OutputFormat::Json => {
+            let result = serde_json::json!({
+                "success": true,
+                "output": app_dir.to_string_lossy(),
+                "bundle_id": bundle_id,
+                "native_modules": ctx.native_modules.len(),
+                "js_modules": ctx.js_modules.len(),
+            });
+            println!("{}", serde_json::to_string(&result)?);
+        }
+    }
+
+    Ok((app_dir, bundle_id))
+}
+
+/// Walk up from the input file looking for `perry.toml` and harvest
+/// visionOS-relevant metadata: project version + build number, the
+/// `[visionos] deployment_target` (falling back to `minimum_version`,
+/// or `"1.0"`), the optional `encryption_exempt` flag, and any
+/// `[visionos.info_plist]` key/value pairs serialized into a plist
+/// fragment ready to splice into the dict.
+///
+/// Returns sensible defaults when no `perry.toml` is found.
+fn read_visionos_app_metadata(input: &Path) -> (String, String, String, Option<bool>, String) {
+    let walk = (|| -> Option<(String, String, String, Option<bool>, String)> {
+        let mut dir = input.canonicalize().ok()?;
+        for _ in 0..5 {
+            dir = dir.parent()?.to_path_buf();
+            let toml_path = dir.join("perry.toml");
+            if !toml_path.exists() {
+                continue;
+            }
+            let data = fs::read_to_string(&toml_path).ok()?;
+            let doc: toml::Table = data.parse().ok()?;
+            let project = doc.get("project").and_then(|v| v.as_table());
+            let visionos = doc.get("visionos").and_then(|v| v.as_table());
+            let version = project
+                .and_then(|p| p.get("version"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("1.0.0")
+                .to_string();
+            let build_number = project
+                .and_then(|p| p.get("build_number"))
+                .and_then(|v| {
+                    v.as_integer()
+                        .map(|n| n.to_string())
+                        .or_else(|| v.as_str().map(|s| s.to_string()))
+                })
+                .unwrap_or_else(|| "1".to_string());
+            let deployment_target = visionos
+                .and_then(|v| {
+                    v.get("deployment_target")
+                        .or_else(|| v.get("minimum_version"))
+                })
+                .and_then(|v| v.as_str())
+                .unwrap_or("1.0")
+                .to_string();
+            let encryption_exempt = visionos
+                .and_then(|v| v.get("encryption_exempt"))
+                .and_then(|v| v.as_bool());
+            let mut entries = String::new();
+            if let Some(info_plist) = visionos
+                .and_then(|v| v.get("info_plist"))
+                .and_then(|v| v.as_table())
+            {
+                for (key, value) in info_plist {
+                    if let Some(s) = value.as_str() {
+                        entries.push_str(&format!(
+                            "    <key>{}</key>\n    <string>{}</string>\n",
+                            key, s
+                        ));
+                    } else if let Some(b) = value.as_bool() {
+                        entries.push_str(&format!(
+                            "    <key>{}</key>\n    <{}/>\n",
+                            key,
+                            if b { "true" } else { "false" }
+                        ));
+                    } else if let Some(i) = value.as_integer() {
+                        entries.push_str(&format!(
+                            "    <key>{}</key>\n    <integer>{}</integer>\n",
+                            key, i
+                        ));
+                    }
+                }
+            }
+            return Some((
+                version,
+                build_number,
+                deployment_target,
+                encryption_exempt,
+                entries,
+            ));
+        }
+        Some((
+            "1.0.0".to_string(),
+            "1".to_string(),
+            "1.0".to_string(),
+            None,
+            String::new(),
+        ))
+    })();
+    walk.unwrap_or_else(|| {
+        (
+            "1.0.0".to_string(),
+            "1".to_string(),
+            "1.0".to_string(),
+            None,
+            String::new(),
+        )
+    })
+}
+
+/// Write `<bundle>/<locale>.lproj/Localizable.strings` for every
+/// configured locale. Used by the iOS / macOS / visionOS bundle
+/// writers — Foundation `NSLocalizedString(key)` resolves from these
+/// files when the user's preferred language matches the directory.
+fn write_lproj_localized_strings(
+    app_dir: &Path,
+    i18n_table: Option<&perry_transform::i18n::I18nStringTable>,
+    i18n_config: Option<&perry_transform::i18n::I18nConfig>,
+) {
+    let (table, config) = match (i18n_table, i18n_config) {
+        (Some(t), Some(c)) if !t.keys.is_empty() => (t, c),
+        _ => return,
+    };
+    for (locale_idx, locale) in config.locales.iter().enumerate() {
+        let lproj_dir = app_dir.join(format!("{}.lproj", locale));
+        let _ = fs::create_dir_all(&lproj_dir);
+        let mut strings_content = String::new();
+        for (key_idx, key) in table.keys.iter().enumerate() {
+            let flat_idx = locale_idx * table.keys.len() + key_idx;
+            let value = table
+                .translations
+                .get(flat_idx)
+                .cloned()
+                .unwrap_or_else(|| key.clone());
+            let escaped_key = key.replace('\\', "\\\\").replace('"', "\\\"");
+            let escaped_val = value.replace('\\', "\\\\").replace('"', "\\\"");
+            strings_content
+                .push_str(&format!("\"{}\" = \"{}\";\n", escaped_key, escaped_val));
+        }
+        let _ = fs::write(lproj_dir.join("Localizable.strings"), &strings_content);
+    }
+}
+
+/// Create a visionOS `.app` bundle. Reads `perry.toml` for version +
+/// build number + deployment target + encryption-exemption + custom
+/// Info.plist entries, copies the linked binary, writes Info.plist
+/// (with XRSimulator / XROS platform tag), copies project asset
+/// directories, and writes per-locale `.lproj/Localizable.strings`
+/// from the i18n table. Returns `(app_dir, bundle_id)`.
+fn bundle_for_visionos(
+    exe_path: &Path,
+    stem: &str,
+    target: Option<&str>,
+    input: &Path,
+    ctx: &CompilationContext,
+    i18n_table: Option<&perry_transform::i18n::I18nStringTable>,
+    i18n_config: Option<&perry_transform::i18n::I18nConfig>,
+    format: OutputFormat,
+) -> Result<(PathBuf, String)> {
+    let app_dir = exe_path.with_extension("app");
+    let _ = fs::create_dir_all(&app_dir);
+    let bundle_exe = app_dir.join(exe_path.file_name().unwrap_or_default());
+    fs::copy(exe_path, &bundle_exe)?;
+    let _ = fs::remove_file(exe_path);
+
+    let exe_stem = exe_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(stem);
+    let bundle_id = lookup_bundle_id_from_toml(input, "visionos")
+        .or_else(|| lookup_bundle_id_from_toml(input, "app"))
+        .or_else(|| lookup_bundle_id_from_toml(input, "ios"))
+        .unwrap_or_else(|| crate::commands::sanitize::default_perry_bundle_id(exe_stem));
+
+    let (app_version, app_build_number, deployment_target, encryption_exempt, custom_plist_entries) =
+        read_visionos_app_metadata(input);
+
+    let platform_name = if target == Some("visionos-simulator") {
+        "XRSimulator"
+    } else {
+        "XROS"
+    };
+
+    let mut info_plist = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>{exe_stem}</string>
+    <key>CFBundleIdentifier</key>
+    <string>{bundle_id}</string>
+    <key>CFBundleName</key>
+    <string>{exe_stem}</string>
+    <key>CFBundleVersion</key>
+    <string>{app_build_number}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>{app_version}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>MinimumOSVersion</key>
+    <string>{deployment_target}</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>{platform_name}</string>
+    </array>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>arm64</string>
+    </array>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>7</integer>
+    </array>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <true/>
+        <key>UIApplicationPreferredDefaultSceneSessionRole</key>
+        <string>UIWindowSceneSessionRoleApplication</string>
+        <key>UISceneConfigurations</key>
+        <dict/>
+    </dict>
+</dict>
+</plist>"#
+    );
+
+    let usage_descriptions = concat!(
+        "    <key>NSCameraUsageDescription</key>\n",
+        "    <string>This app uses the camera to identify colors.</string>\n",
+        "    <key>NSMicrophoneUsageDescription</key>\n",
+        "    <string>This app uses the microphone to measure sound levels.</string>\n",
+    );
+    info_plist = info_plist.replace(
+        "</dict>\n</plist>",
+        &format!("{}</dict>\n</plist>", usage_descriptions),
+    );
+
+    if let Some(exempt) = encryption_exempt {
+        let encryption_entry = format!(
+            "    <key>ITSAppUsesNonExemptEncryption</key>\n    <{}/>\n",
+            if exempt { "false" } else { "true" }
+        );
+        info_plist = info_plist.replace(
+            "</dict>\n</plist>",
+            &format!("{}</dict>\n</plist>", encryption_entry),
+        );
+    }
+
+    if !custom_plist_entries.is_empty() {
+        info_plist = info_plist.replace(
+            "</dict>\n</plist>",
+            &format!("{}</dict>\n</plist>", custom_plist_entries),
+        );
+    }
+
+    fs::write(app_dir.join("Info.plist"), info_plist)?;
+
+    if let Some(src_dir) = input
+        .canonicalize()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+    {
+        let project_root = find_project_root_for_resources(&src_dir, true);
+        copy_bundle_resource_dirs(&project_root, &app_dir);
+    }
+
+    write_lproj_localized_strings(&app_dir, i18n_table, i18n_config);
+
+    match format {
+        OutputFormat::Text => {
+            println!("Wrote visionOS app bundle: {}", app_dir.display());
+            println!();
+            println!("To run on Apple Vision Pro Simulator:");
+            println!("  xcrun simctl install booted {}", app_dir.display());
+            println!("  xcrun simctl launch booted {}", bundle_id);
+        }
+        OutputFormat::Json => {
+            let result = serde_json::json!({
+                "success": true,
+                "output": app_dir.to_string_lossy(),
+                "bundle_id": bundle_id,
+                "native_modules": ctx.native_modules.len(),
+                "js_modules": ctx.js_modules.len(),
+            });
+            println!("{}", serde_json::to_string(&result)?);
+        }
+    }
+
+    Ok((app_dir, bundle_id))
+}
+
+/// Create a tvOS `.app` bundle. Same shape as `bundle_for_watchos`
+/// but with the Apple TV `UIDeviceFamily` (3), `MinimumOSVersion`
+/// 17.0, and a UI-thread principal class of `BloomApplication` (the
+/// runtime's UIApplication subclass on tvOS). No project-resource
+/// copy in this path — tvOS apps consume assets via the metallib /
+/// embedded JS bundle.
+fn bundle_for_tvos(
+    exe_path: &Path,
+    stem: &str,
+    target: Option<&str>,
+    input: &Path,
+    ctx: &CompilationContext,
+    format: OutputFormat,
+) -> Result<(PathBuf, String)> {
+    let app_dir = exe_path.with_extension("app");
+    let _ = fs::create_dir_all(&app_dir);
+    let bundle_exe = app_dir.join(exe_path.file_name().unwrap_or_default());
+    fs::copy(exe_path, &bundle_exe)?;
+    let _ = fs::remove_file(exe_path);
+
+    let exe_stem = exe_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(stem);
+    let bundle_id = lookup_bundle_id_from_toml(input, "tvos")
+        .or_else(|| lookup_bundle_id_from_toml(input, "app"))
+        .unwrap_or_else(|| crate::commands::sanitize::default_perry_bundle_id(exe_stem));
+
+    let info_plist = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>{exe_stem}</string>
+    <key>CFBundleIdentifier</key>
+    <string>{bundle_id}</string>
+    <key>CFBundleName</key>
+    <string>{exe_stem}</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>MinimumOSVersion</key>
+    <string>17.0</string>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>3</integer>
+    </array>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIRequiresFullScreen</key>
+    <true/>
+    <key>NSPrincipalClass</key>
+    <string>BloomApplication</string>
+</dict>
+</plist>"#
+    );
+    fs::write(app_dir.join("Info.plist"), info_plist)?;
+
+    compile_metallib_for_bundle(ctx, target, &app_dir, format)?;
+
+    match format {
+        OutputFormat::Text => {
+            println!("Wrote tvOS app bundle: {}", app_dir.display());
+            println!();
+            println!("To run on Apple TV Simulator:");
+            println!("  xcrun simctl install booted {}", app_dir.display());
+            println!("  xcrun simctl launch booted {}", bundle_id);
+        }
+        OutputFormat::Json => {
+            let result = serde_json::json!({
+                "success": true,
+                "output": app_dir.to_string_lossy(),
+                "bundle_id": bundle_id,
+                "native_modules": ctx.native_modules.len(),
+                "js_modules": ctx.js_modules.len(),
+            });
+            println!("{}", serde_json::to_string(&result)?);
+        }
+    }
+
+    Ok((app_dir, bundle_id))
+}
+
 /// i18n: emit `res/values-<locale>/strings.xml` next to the Android
 /// `.so` for every configured locale. Best-effort; failures don't
 /// abort the build. Keys are sanitized to `[A-Za-z0-9_]+` (Android
@@ -8089,468 +8608,28 @@ pub fn run_with_parse_cache(
             }
         }
     } else if is_visionos {
-        let app_dir = exe_path.with_extension("app");
-        let _ = fs::create_dir_all(&app_dir);
-        let bundle_exe = app_dir.join(exe_path.file_name().unwrap_or_default());
-        fs::copy(&exe_path, &bundle_exe)?;
-        let _ = fs::remove_file(&exe_path);
-
-        let exe_stem = exe_path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or(stem);
-        let bundle_id = lookup_bundle_id_from_toml(&args.input, "visionos")
-            .or_else(|| lookup_bundle_id_from_toml(&args.input, "app"))
-            .or_else(|| lookup_bundle_id_from_toml(&args.input, "ios"))
-            .unwrap_or_else(|| crate::commands::sanitize::default_perry_bundle_id(exe_stem));
-        result_bundle_id = Some(bundle_id.clone());
-        result_app_dir = Some(app_dir.clone());
-
-        let (
-            app_version,
-            app_build_number,
-            deployment_target,
-            encryption_exempt,
-            custom_plist_entries,
-        ) = (|| -> Option<(String, String, String, Option<bool>, String)> {
-            let mut dir = args.input.canonicalize().ok()?;
-            for _ in 0..5 {
-                dir = dir.parent()?.to_path_buf();
-                let toml_path = dir.join("perry.toml");
-                if !toml_path.exists() {
-                    continue;
-                }
-                let data = fs::read_to_string(&toml_path).ok()?;
-                let doc: toml::Table = data.parse().ok()?;
-                let project = doc.get("project").and_then(|v| v.as_table());
-                let visionos = doc.get("visionos").and_then(|v| v.as_table());
-                let version = project
-                    .and_then(|p| p.get("version"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("1.0.0")
-                    .to_string();
-                let build_number = project
-                    .and_then(|p| p.get("build_number"))
-                    .and_then(|v| {
-                        v.as_integer()
-                            .map(|n| n.to_string())
-                            .or_else(|| v.as_str().map(|s| s.to_string()))
-                    })
-                    .unwrap_or_else(|| "1".to_string());
-                let deployment_target = visionos
-                    .and_then(|v| {
-                        v.get("deployment_target")
-                            .or_else(|| v.get("minimum_version"))
-                    })
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("1.0")
-                    .to_string();
-                let encryption_exempt = visionos
-                    .and_then(|v| v.get("encryption_exempt"))
-                    .and_then(|v| v.as_bool());
-                let mut entries = String::new();
-                if let Some(info_plist) = visionos
-                    .and_then(|v| v.get("info_plist"))
-                    .and_then(|v| v.as_table())
-                {
-                    for (key, value) in info_plist {
-                        if let Some(s) = value.as_str() {
-                            entries.push_str(&format!(
-                                "    <key>{}</key>\n    <string>{}</string>\n",
-                                key, s
-                            ));
-                        } else if let Some(b) = value.as_bool() {
-                            entries.push_str(&format!(
-                                "    <key>{}</key>\n    <{}/>\n",
-                                key,
-                                if b { "true" } else { "false" }
-                            ));
-                        } else if let Some(i) = value.as_integer() {
-                            entries.push_str(&format!(
-                                "    <key>{}</key>\n    <integer>{}</integer>\n",
-                                key, i
-                            ));
-                        }
-                    }
-                }
-                return Some((
-                    version,
-                    build_number,
-                    deployment_target,
-                    encryption_exempt,
-                    entries,
-                ));
-            }
-            Some((
-                "1.0.0".to_string(),
-                "1".to_string(),
-                "1.0".to_string(),
-                None,
-                String::new(),
-            ))
-        })()
-        .unwrap();
-
-        let platform_name = if target.as_deref() == Some("visionos-simulator") {
-            "XRSimulator"
-        } else {
-            "XROS"
-        };
-
-        let mut info_plist = format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>CFBundleExecutable</key>
-    <string>{exe_stem}</string>
-    <key>CFBundleIdentifier</key>
-    <string>{bundle_id}</string>
-    <key>CFBundleName</key>
-    <string>{exe_stem}</string>
-    <key>CFBundleVersion</key>
-    <string>{app_build_number}</string>
-    <key>CFBundleShortVersionString</key>
-    <string>{app_version}</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-    <key>CFBundleInfoDictionaryVersion</key>
-    <string>6.0</string>
-    <key>MinimumOSVersion</key>
-    <string>{deployment_target}</string>
-    <key>CFBundleSupportedPlatforms</key>
-    <array>
-        <string>{platform_name}</string>
-    </array>
-    <key>UIRequiredDeviceCapabilities</key>
-    <array>
-        <string>arm64</string>
-    </array>
-    <key>UIDeviceFamily</key>
-    <array>
-        <integer>7</integer>
-    </array>
-    <key>UILaunchScreen</key>
-    <dict/>
-    <key>UIApplicationSceneManifest</key>
-    <dict>
-        <key>UIApplicationSupportsMultipleScenes</key>
-        <true/>
-        <key>UIApplicationPreferredDefaultSceneSessionRole</key>
-        <string>UIWindowSceneSessionRoleApplication</string>
-        <key>UISceneConfigurations</key>
-        <dict/>
-    </dict>
-</dict>
-</plist>"#
-        );
-
-        let usage_descriptions = concat!(
-            "    <key>NSCameraUsageDescription</key>\n",
-            "    <string>This app uses the camera to identify colors.</string>\n",
-            "    <key>NSMicrophoneUsageDescription</key>\n",
-            "    <string>This app uses the microphone to measure sound levels.</string>\n",
-        );
-        info_plist = info_plist.replace(
-            "</dict>\n</plist>",
-            &format!("{}</dict>\n</plist>", usage_descriptions),
-        );
-
-        if let Some(exempt) = encryption_exempt {
-            let encryption_entry = format!(
-                "    <key>ITSAppUsesNonExemptEncryption</key>\n    <{}/>\n",
-                if exempt { "false" } else { "true" }
-            );
-            info_plist = info_plist.replace(
-                "</dict>\n</plist>",
-                &format!("{}</dict>\n</plist>", encryption_entry),
-            );
-        }
-
-        if !custom_plist_entries.is_empty() {
-            info_plist = info_plist.replace(
-                "</dict>\n</plist>",
-                &format!("{}</dict>\n</plist>", custom_plist_entries),
-            );
-        }
-
-        fs::write(app_dir.join("Info.plist"), info_plist)?;
-
-        let source_dir = args
-            .input
-            .canonicalize()
-            .ok()
-            .and_then(|p| p.parent().map(|d| d.to_path_buf()));
-        if let Some(src_dir) = &source_dir {
-            let mut project_root = src_dir.clone();
-            for _ in 0..5 {
-                if project_root.join("package.json").exists()
-                    || project_root.join("perry.toml").exists()
-                {
-                    break;
-                }
-                if let Some(parent) = project_root.parent() {
-                    project_root = parent.to_path_buf();
-                } else {
-                    break;
-                }
-            }
-            fn copy_dir_recursive(
-                src: &std::path::Path,
-                dst: &std::path::Path,
-            ) -> std::io::Result<()> {
-                fs::create_dir_all(dst)?;
-                for entry in fs::read_dir(src)? {
-                    let entry = entry?;
-                    let ty = entry.file_type()?;
-                    let dest_path = dst.join(entry.file_name());
-                    if ty.is_dir() {
-                        copy_dir_recursive(&entry.path(), &dest_path)?;
-                    } else {
-                        fs::copy(entry.path(), &dest_path)?;
-                    }
-                }
-                Ok(())
-            }
-            for dir_name in &["logo", "assets", "resources", "images"] {
-                let resource_dir = project_root.join(dir_name);
-                if resource_dir.is_dir() {
-                    let dest = app_dir.join(dir_name);
-                    let _ = copy_dir_recursive(&resource_dir, &dest);
-                }
-            }
-        }
-
-        if let (Some(ref table), Some(ref config)) = (&i18n_table, &i18n_config) {
-            if !table.keys.is_empty() {
-                for (locale_idx, locale) in config.locales.iter().enumerate() {
-                    let lproj_dir = app_dir.join(format!("{}.lproj", locale));
-                    let _ = fs::create_dir_all(&lproj_dir);
-                    let mut strings_content = String::new();
-                    for (key_idx, key) in table.keys.iter().enumerate() {
-                        let flat_idx = locale_idx * table.keys.len() + key_idx;
-                        let value = table
-                            .translations
-                            .get(flat_idx)
-                            .cloned()
-                            .unwrap_or_else(|| key.clone());
-                        let escaped_key = key.replace('\\', "\\\\").replace('"', "\\\"");
-                        let escaped_val = value.replace('\\', "\\\\").replace('"', "\\\"");
-                        strings_content
-                            .push_str(&format!("\"{}\" = \"{}\";\n", escaped_key, escaped_val));
-                    }
-                    let _ = fs::write(lproj_dir.join("Localizable.strings"), &strings_content);
-                }
-            }
-        }
-
-        match format {
-            OutputFormat::Text => {
-                println!("Wrote visionOS app bundle: {}", app_dir.display());
-                println!();
-                println!("To run on Apple Vision Pro Simulator:");
-                println!("  xcrun simctl install booted {}", app_dir.display());
-                println!("  xcrun simctl launch booted {}", bundle_id);
-            }
-            OutputFormat::Json => {
-                let result = serde_json::json!({
-                    "success": true,
-                    "output": app_dir.to_string_lossy(),
-                    "bundle_id": bundle_id,
-                    "native_modules": ctx.native_modules.len(),
-                    "js_modules": ctx.js_modules.len(),
-                });
-                println!("{}", serde_json::to_string(&result)?);
-            }
-        }
+        let (app_dir, bundle_id) = bundle_for_visionos(
+            &exe_path,
+            stem,
+            target.as_deref(),
+            &args.input,
+            &ctx,
+            i18n_table.as_ref(),
+            i18n_config.as_ref(),
+            format,
+        )?;
+        result_bundle_id = Some(bundle_id);
+        result_app_dir = Some(app_dir);
     } else if is_watchos {
-        // Create watchOS .app bundle
-        let app_dir = exe_path.with_extension("app");
-        let _ = fs::create_dir_all(&app_dir);
-        let bundle_exe = app_dir.join(exe_path.file_name().unwrap_or_default());
-        fs::copy(&exe_path, &bundle_exe)?;
-        let _ = fs::remove_file(&exe_path);
-
-        let exe_stem = exe_path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or(stem);
-        let bundle_id = lookup_bundle_id_from_toml(&args.input, "watchos")
-            .or_else(|| lookup_bundle_id_from_toml(&args.input, "app"))
-            .unwrap_or_else(|| crate::commands::sanitize::default_perry_bundle_id(exe_stem));
-        result_bundle_id = Some(bundle_id.clone());
-        result_app_dir = Some(app_dir.clone());
-
-        let info_plist = format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>CFBundleExecutable</key>
-    <string>{exe_stem}</string>
-    <key>CFBundleIdentifier</key>
-    <string>{bundle_id}</string>
-    <key>CFBundleName</key>
-    <string>{exe_stem}</string>
-    <key>CFBundleVersion</key>
-    <string>1.0</string>
-    <key>CFBundleShortVersionString</key>
-    <string>1.0</string>
-    <key>MinimumOSVersion</key>
-    <string>10.0</string>
-    <key>UIDeviceFamily</key>
-    <array>
-        <integer>4</integer>
-    </array>
-    <key>WKApplication</key>
-    <true/>
-    <key>WKWatchOnly</key>
-    <true/>
-</dict>
-</plist>"#
-        );
-        fs::write(app_dir.join("Info.plist"), info_plist)?;
-
-        // Copy project resource directories into the bundle so
-        // bloom_load_texture / load_sound / read_file can resolve relative
-        // asset paths via [[NSBundle mainBundle] resourcePath].
-        let source_dir = args
-            .input
-            .canonicalize()
-            .ok()
-            .and_then(|p| p.parent().map(|d| d.to_path_buf()));
-        if let Some(src_dir) = &source_dir {
-            let mut project_root = src_dir.clone();
-            for _ in 0..5 {
-                if project_root.join("package.json").exists()
-                    || project_root.join("perry.toml").exists()
-                {
-                    break;
-                }
-                if let Some(parent) = project_root.parent() {
-                    project_root = parent.to_path_buf();
-                } else {
-                    break;
-                }
-            }
-            fn copy_dir_recursive(
-                src: &std::path::Path,
-                dst: &std::path::Path,
-            ) -> std::io::Result<()> {
-                fs::create_dir_all(dst)?;
-                for entry in fs::read_dir(src)? {
-                    let entry = entry?;
-                    let ty = entry.file_type()?;
-                    let dest_path = dst.join(entry.file_name());
-                    if ty.is_dir() {
-                        copy_dir_recursive(&entry.path(), &dest_path)?;
-                    } else {
-                        fs::copy(entry.path(), &dest_path)?;
-                    }
-                }
-                Ok(())
-            }
-            for dir_name in &["logo", "assets", "resources", "images"] {
-                let resource_dir = project_root.join(dir_name);
-                if resource_dir.is_dir() {
-                    let dest = app_dir.join(dir_name);
-                    let _ = copy_dir_recursive(&resource_dir, &dest);
-                }
-            }
-        }
-
-        compile_metallib_for_bundle(&ctx, target.as_deref(), &app_dir, format)?;
-
-        match format {
-            OutputFormat::Text => {
-                println!("Wrote watchOS app bundle: {}", app_dir.display());
-                println!();
-                println!("To run on Apple Watch Simulator:");
-                println!("  xcrun simctl install booted {}", app_dir.display());
-                println!("  xcrun simctl launch booted {}", bundle_id);
-            }
-            OutputFormat::Json => {
-                let result = serde_json::json!({
-                    "success": true,
-                    "output": app_dir.to_string_lossy(),
-                    "bundle_id": bundle_id,
-                    "native_modules": ctx.native_modules.len(),
-                    "js_modules": ctx.js_modules.len(),
-                });
-                println!("{}", serde_json::to_string(&result)?);
-            }
-        }
+        let (app_dir, bundle_id) =
+            bundle_for_watchos(&exe_path, stem, target.as_deref(), &args.input, &ctx, format)?;
+        result_bundle_id = Some(bundle_id);
+        result_app_dir = Some(app_dir);
     } else if is_tvos {
-        // Create tvOS .app bundle
-        let app_dir = exe_path.with_extension("app");
-        let _ = fs::create_dir_all(&app_dir);
-        let bundle_exe = app_dir.join(exe_path.file_name().unwrap_or_default());
-        fs::copy(&exe_path, &bundle_exe)?;
-        let _ = fs::remove_file(&exe_path);
-
-        let exe_stem = exe_path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or(stem);
-        let bundle_id = lookup_bundle_id_from_toml(&args.input, "tvos")
-            .or_else(|| lookup_bundle_id_from_toml(&args.input, "app"))
-            .unwrap_or_else(|| crate::commands::sanitize::default_perry_bundle_id(exe_stem));
-        result_bundle_id = Some(bundle_id.clone());
-        result_app_dir = Some(app_dir.clone());
-
-        let info_plist = format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>CFBundleExecutable</key>
-    <string>{exe_stem}</string>
-    <key>CFBundleIdentifier</key>
-    <string>{bundle_id}</string>
-    <key>CFBundleName</key>
-    <string>{exe_stem}</string>
-    <key>CFBundleVersion</key>
-    <string>1.0</string>
-    <key>CFBundleShortVersionString</key>
-    <string>1.0</string>
-    <key>MinimumOSVersion</key>
-    <string>17.0</string>
-    <key>UIDeviceFamily</key>
-    <array>
-        <integer>3</integer>
-    </array>
-    <key>UILaunchScreen</key>
-    <dict/>
-    <key>UIRequiresFullScreen</key>
-    <true/>
-    <key>NSPrincipalClass</key>
-    <string>BloomApplication</string>
-</dict>
-</plist>"#
-        );
-        fs::write(app_dir.join("Info.plist"), info_plist)?;
-
-        compile_metallib_for_bundle(&ctx, target.as_deref(), &app_dir, format)?;
-
-        match format {
-            OutputFormat::Text => {
-                println!("Wrote tvOS app bundle: {}", app_dir.display());
-                println!();
-                println!("To run on Apple TV Simulator:");
-                println!("  xcrun simctl install booted {}", app_dir.display());
-                println!("  xcrun simctl launch booted {}", bundle_id);
-            }
-            OutputFormat::Json => {
-                let result = serde_json::json!({
-                    "success": true,
-                    "output": app_dir.to_string_lossy(),
-                    "bundle_id": bundle_id,
-                    "native_modules": ctx.native_modules.len(),
-                    "js_modules": ctx.js_modules.len(),
-                });
-                println!("{}", serde_json::to_string(&result)?);
-            }
-        }
+        let (app_dir, bundle_id) =
+            bundle_for_tvos(&exe_path, stem, target.as_deref(), &args.input, &ctx, format)?;
+        result_bundle_id = Some(bundle_id);
+        result_app_dir = Some(app_dir);
     } else {
         // For Windows/Linux (non-bundle targets), copy asset directories next to the exe
         // so that resolve_asset_path can find them relative to the executable.


### PR DESCRIPTION
## Summary

Part of #1105. Stacked on top of #1128 (PR 1).

**Re-plan note**: the original PR 2 spec called for introducing `CompilePipeline` + converting each phase to `impl` methods. That requires data-flow analysis across the 7400-line stack frame and risks subtle regression in a hot CLI path. This PR instead continues PR 1's pattern with larger named phase functions, so the orchestrator's per-platform bundle dispatch is visible in the file outline. `CompilePipeline` can land in a follow-up once the phases are already named functions.

Per-target `.app` bundle writers extracted:

| Helper | Purpose |
|---|---|
| `bundle_for_watchos` | copy binary + Info.plist (`WKApplication`/`UIDeviceFamily=4`) + asset dirs + metallib |
| `bundle_for_tvos` | same shape, tvOS-specific Info.plist (`UIDeviceFamily=3`, `MinimumOSVersion=17.0`, `BloomApplication` principal class) |
| `bundle_for_visionos` | `perry.toml [visionos]` harvest, XRSimulator/XROS platform tag, asset copy, per-locale `.lproj/Localizable.strings` |

Shared helpers introduced (reusable by the remaining iOS / macOS branches in a follow-up):

- `find_project_root_for_resources` — bounded walk-up to anchor an asset copy
- `copy_dir_recursive` — replaces three inlined inner functions with the same body
- `copy_bundle_resource_dirs` — copy `logo`/`assets`/`resources`/`images`
- `read_visionos_app_metadata` — `perry.toml [visionos]` read
- `write_lproj_localized_strings` — per-locale `Localizable.strings` emit

`run_with_parse_cache` shrinks by ~460 lines (now ~6940). New helpers add ~540 lines of signatures + doc + lifted bodies, so net file growth is ~80 lines — same trade-off as PR 1.

## Test plan

- [x] `cargo build --release -p perry` clean
- [x] `cargo test --release -p perry` — 332 tests pass
- [x] Host smoke test produces byte-identical output to baseline
- [x] `--target ios-simulator` produces same `.app` bundle (matched JSON emit)
- [ ] CI parity sweep (will run on push)