### PR TITLE
fix(android): unblock build + JNI bridge for the default Android target

### DIFF
--- a/android-build/app/src/main/java/com/perry/app/PerryActivity.kt
+++ b/android-build/app/src/main/java/com/perry/app/PerryActivity.kt
@@ -27,6 +27,13 @@ class PerryActivity : Activity() {
         private const val PERMISSION_REQUEST_CODE = 100
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        intent.data?.toString()?.takeIf { it.isNotEmpty() }?.let {
+            PerryBridge.deliverDeepLinkUrl(it, "warm")
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -51,6 +58,13 @@ class PerryActivity : Activity() {
 
         // Initialize the bridge with this Activity
         PerryBridge.init(this, rootLayout)
+
+        // Capture the cold-start deep-link URL (if any). The JS handler
+        // hasn't been registered yet — PerryBridge.appOnOpenUrl() will
+        // replay this through nativeInvokeDeepLinkCallback once it is.
+        intent?.data?.toString()?.takeIf { it.isNotEmpty() }?.let {
+            PerryBridge.deliverDeepLinkUrl(it, "cold-start")
+        }
 
         // Request any dangerous runtime permissions declared in the manifest
         // before starting native code, so they're available when needed.

--- a/android-build/app/src/main/java/com/perry/app/PerryBridge.kt
+++ b/android-build/app/src/main/java/com/perry/app/PerryBridge.kt
@@ -126,6 +126,55 @@ object PerryBridge {
     @JvmStatic
     fun getActivity(): Activity = activity
 
+    // --- Deep links (issue #583) ---
+    //
+    // The Rust side (perry-ui-android/src/deeplinks.rs) registers the JS
+    // handler via `PerryBridge.appOnOpenUrl(key)` and reads the cold-start
+    // URL via `appGetLaunchUrl()`. The Kotlin side owns the Activity-level
+    // intent.data capture (set from PerryActivity.onCreate / onNewIntent)
+    // and dispatches URLs into JS through `nativeInvokeDeepLinkCallback`.
+    //
+    // Without these methods, the JNI `call_static_method("appOnOpenUrl",
+    // "(J)V")` in set_handler() throws NoSuchMethodError → pending JNI
+    // exception → the next JNI op (e.g. NavStack create) aborts the app.
+
+    private var deepLinkCallbackKey: Long = 0L
+    private var pendingLaunchUrl: String = ""
+
+    @JvmStatic
+    fun appOnOpenUrl(callbackKey: Long) {
+        deepLinkCallbackKey = callbackKey
+        // Cold-start replay: if a URL arrived before the handler was
+        // registered, fire it now through the native invoker.
+        val pending = pendingLaunchUrl
+        if (pending.isNotEmpty()) {
+            pendingLaunchUrl = ""
+            try { nativeInvokeDeepLinkCallback(callbackKey, pending, "cold-start") }
+            catch (_: UnsatisfiedLinkError) { /* native lib unloaded — drop */ }
+        }
+    }
+
+    @JvmStatic
+    fun appGetLaunchUrl(): String = pendingLaunchUrl
+
+    /**
+     * Called from PerryActivity for cold-start (onCreate) and warm
+     * (onNewIntent) intents. If the JS handler is already registered
+     * the URL is dispatched immediately; otherwise it's queued for the
+     * cold-start replay path above.
+     */
+    @JvmStatic
+    fun deliverDeepLinkUrl(url: String, source: String) {
+        if (url.isEmpty()) return
+        val key = deepLinkCallbackKey
+        if (key == 0L) {
+            pendingLaunchUrl = url
+            return
+        }
+        try { nativeInvokeDeepLinkCallback(key, url, source) }
+        catch (_: UnsatisfiedLinkError) { /* native lib unloaded — drop */ }
+    }
+
     // --- Content view ---
 
     @JvmStatic
@@ -579,10 +628,8 @@ object PerryBridge {
             uiHandler.post { requestGeolocationPermission(callbackKey) }
             return
         }
-        val granted = ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
-                == PackageManager.PERMISSION_GRANTED ||
-            ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_COARSE_LOCATION)
-                == PackageManager.PERMISSION_GRANTED
+        val granted = ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
         if (granted) {
             nativeInvokeCallbackWithString(callbackKey, "granted")
         } else {
@@ -1398,8 +1445,8 @@ object PerryBridge {
 
     private inline fun <reified T : android.text.style.CharacterStyle> richTextToggleSpan(
         et: EditText,
-        factory: () -> T,
-        matches: (T) -> Boolean
+        crossinline factory: () -> T,
+        crossinline matches: (T) -> Boolean
     ) {
         uiHandler.post {
             val editable = et.text ?: return@post
@@ -1783,4 +1830,26 @@ object PerryBridge {
 
     @JvmStatic
     external fun nativeMenuItemSelected(menuHandle: Long, index: Int)
+
+    // Push/local notification JNI bridge. Implemented in
+    // perry-ui-android `system.rs` as
+    // `Java_com_perry_app_PerryBridge_nativeNotification*`; declared here so
+    // PerryFirebaseMessagingService / PerryNotificationReceiver can invoke
+    // them (decls were missing, breaking the Android Kotlin build).
+    @JvmStatic
+    external fun nativeNotificationTap(id: String)
+
+    @JvmStatic
+    external fun nativeNotificationToken(token: String)
+
+    @JvmStatic
+    external fun nativeNotificationReceive(payloadJson: String)
+
+    @JvmStatic
+    external fun nativeNotificationBackgroundReceive(payloadJson: String)
+
+    // Implemented in perry-ui-android `callback.rs` as
+    // `Java_com_perry_app_PerryBridge_nativeInvokeDeepLinkCallback`.
+    @JvmStatic
+    external fun nativeInvokeDeepLinkCallback(key: Long, url: String, source: String)
 }

--- a/crates/perry-ui-android/src/lib.rs
+++ b/crates/perry-ui-android/src/lib.rs
@@ -2617,6 +2617,13 @@ pub extern "C" fn perry_ui_bottom_nav_set_unselected_tint_color(
 pub extern "C" fn perry_ui_lazyvstack_set_refresh_control(_handle: i64, _callback: f64) {}
 #[no_mangle]
 pub extern "C" fn perry_ui_lazyvstack_end_refreshing(_handle: i64) {}
+// Matches the iOS stub (perry-ui-ios/src/lib.rs). Without this export, the
+// Android UI lib is missing a symbol that the TS `lazyvstackSetRowHeight`
+// API lowers to, and `dlopen(libperry_app.so)` fails at launch with an
+// UnsatisfiedLinkError. No-op is fine: LinearLayout sizes children by their
+// own measurement; per-row height isn't applied on Android today.
+#[no_mangle]
+pub extern "C" fn perry_ui_lazyvstack_set_row_height(_handle: i64, _height: f64) {}
 #[no_mangle]
 pub extern "C" fn perry_ui_lazyvstack_set_scroll_end_callback(
     _handle: i64,
@@ -2796,6 +2803,7 @@ pub extern "C" fn perry_ui_attributed_text_clear(h: i64) {
 /// Capture the root View as a PNG and return a base64-encoded string.
 /// Returns an empty string if capture is unavailable (e.g. the geisterhand
 /// feature is OFF, the Activity is not attached, or the JNI call fails).
+#[cfg(feature = "geisterhand")]
 #[no_mangle]
 pub extern "C" fn perry_system_take_screenshot() -> i64 {
     extern "C" {
@@ -2813,4 +2821,17 @@ pub extern "C" fn perry_system_take_screenshot() -> i64 {
         libc::free(ptr as *mut libc::c_void);
         js_string_from_bytes(encoded.as_ptr(), encoded.len() as i64) as i64
     }
+}
+
+// Screenshot capture lives in the geisterhand renderer. Under the default
+// Android Views (JNI) backend that module is configured out, so honor the
+// documented contract and return an empty string instead of referencing
+// the absent `crate::screenshot` (which broke the default Android build).
+#[cfg(not(feature = "geisterhand"))]
+#[no_mangle]
+pub extern "C" fn perry_system_take_screenshot() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) as i64 }
 }

--- a/crates/perry-ui-android/src/widgets/securefield.rs
+++ b/crates/perry-ui-android/src/widgets/securefield.rs
@@ -45,9 +45,13 @@ pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
         let bridge_class =
             jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
         let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+        // Use the same JNI bridge entrypoint as textfield/textarea —
+        // PerryBridge.setTextChangedCallback. The stale `setTextWatcher`
+        // name didn't exist on the Kotlin side and aborted with
+        // NoSuchMethodError whenever a SecureField was constructed.
         let _ = env.call_static_method(
             bridge_cls,
-            "setTextWatcher",
+            "setTextChangedCallback",
             "(Landroid/widget/EditText;J)V",
             &[JValue::Object(&edit_text), JValue::Long(cb_key)],
         );


### PR DESCRIPTION
## Summary

Bringing up a Perry-targeted app on the Android emulator from current
`main` surfaced a chain of breakages — the Android target wasn't
compilable, dlopenable, or runnable end-to-end. None of these changes
are Android-specific behavior tweaks; each one repairs a contract that
other platforms already honor.

Verified on a Pixel_8 emulator (API 35, arm64-v8a, NDK 30): app now
compiles cleanly, links cleanly, passes `dlopen`, runs `Java_…_nativeMain`
through to `App.run()`/`setContentView`, and starts the 8 ms timer pump.

## Compile / link fixes

| File | Fix |
|---|---|
| `crates/perry-ui-android/src/lib.rs` (`perry_system_take_screenshot`) | Function referenced `crate::screenshot::…` unconditionally but `pub mod screenshot;` is `#[cfg(feature = \"geisterhand\")]`. Default builds failed with E0433. Cfg-gate the function; non-geisterhand returns an empty base64 string, matching the documented contract. |
| `crates/perry-ui-android/src/lib.rs` | Added no-op `perry_ui_lazyvstack_set_row_height` (matches the iOS stub). Without it, every app that calls `lazyvstackSetRowHeight(list, …)` failed `dlopen(libperry_app.so)` with `cannot locate symbol`. |
| `crates/perry-runtime/src/gc.rs` | Added no-op `js_gc_note_slot_layout` / `js_gc_write_barriers_emitted`. The codegen emits unconditional refs; no crate provided them, so `dlopen` died on the first. No-op honors the contract (the GC functions fine without per-slot layout notes). |
| `android-build/.../PerryBridge.kt` (`granted` expression) | Kotlin syntax error: `==` / `\|\|` at line *start*. Moved operators to line ends. |
| `android-build/.../PerryBridge.kt` (`richTextToggleSpan`) | Kotlin 2.0.21 rejects `inline fun` lambdas called from inside `uiHandler.post { … }` without `crossinline`. Added on `factory` and `matches`. |
| `android-build/.../PerryBridge.kt` (`nativeNotification{Tap,Token,Receive,BackgroundReceive}`) | Added the four `@JvmStatic external fun` declarations. `PerryFirebaseMessagingService` / `PerryNotificationReceiver` referenced them; the Rust side already exports the matching JNI symbols in `perry-ui-android/src/system.rs`. |

## JNI-bridge fixes

| Area | Fix |
|---|---|
| `crates/perry-ui-android/src/widgets/securefield.rs` | Called `PerryBridge.setTextWatcher` but the actual entrypoint is `setTextChangedCallback` (textfield.rs / textarea.rs use it). Mismatch aborted with `JNI DETECTED ERROR … NoSuchMethodError` the moment a SecureField was constructed. Renamed the JNI call to match. |
| `android-build/.../PerryBridge.kt` (deep links) | The Kotlin side had **no** deep-link implementation. `perry-ui-android/src/deeplinks.rs` documents the contract: register a handler key via `PerryBridge.appOnOpenUrl(J)V`, read the cold-start URL via `appGetLaunchUrl()Ljava/lang/String;`, dispatch URLs back into JS through `nativeInvokeDeepLinkCallback(key, url, source)`. None existed. `set_handler()` discards the JNI result, so the `NoSuchMethodError` exception stayed pending and the next JNI op (NewLocalRef from NavStack `get_activity`) tripped CheckJNI → app abort. Added: `appOnOpenUrl` / `appGetLaunchUrl` / `deliverDeepLinkUrl` `@JvmStatic` methods + the `external fun nativeInvokeDeepLinkCallback` declaration on `PerryBridge`. |
| `android-build/.../PerryActivity.kt` | Captures `intent?.data` in `onCreate` (cold start) and overrides `onNewIntent` (warm), routing both through `PerryBridge.deliverDeepLinkUrl(url, source)`. |

## Known follow-up — *not* in this PR

After all of the above the app passes `dlopen`, `nativeMain` runs to
completion, the NavStack tree is built, root view is attached, and the
8 ms timer pump starts. ~140 ms later the first JS-side callback fires
and the HWUI worker aborts with:

```
F libc    : FORTIFY: pthread_mutex_lock called on a destroyed mutex (0x...)
F libc    : Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid N (hwuiTask1)
```

No tombstone is produced (FORTIFY aborts skip the standard debuggerd
dump path), no Java exception, no JNI message. Likely a render-side
use-after-free of a sync primitive — needs lldb / ASAN to localize.
Filing as a separate issue.

## Test plan

- [x] `cargo build --release -p perry-ui-android -p perry-runtime --target aarch64-linux-android` (NDK 30, with the cc-rs unversioned-clang shim documented in the issue tracker) — clean build
- [x] `perry compile src/main.ts --target android -o libperry_app.so` — links, no missing symbols
- [x] `cd android-build && ./gradlew assembleDebug` — `BUILD SUCCESSFUL`, APK produced
- [x] `adb install` + `am start` — no `UnsatisfiedLinkError`, no JNI `NoSuchMethodError`, no perry-native-thread tombstone; reaches `attach_root_to_activity: setContentView called` + `start_timer_pump`
- [ ] Visual audit on emulator — blocked by the HWUI mutex abort (separate issue)