### PR TITLE
fix(stdlib): implement node:cluster shape (primary-side constants + stubs)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -85,6 +85,7 @@ pub const NATIVE_MODULES: &[&str] = &[
     "readline",
     "string_decoder",
     "querystring",
+    "cluster",
     "tty",
     "process",
     "perry/tui",
@@ -1861,6 +1862,35 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // at the same address.
     method("querystring", "decode", false, None),
     method("querystring", "encode", false, None),
+    // node:cluster — shape-only surface. The fixture probes
+    // typeof properties + reads constants; we never actually fork.
+    // Methods are wired through `is_native_module_callable_export`
+    // (bound-method closure path) so `typeof cluster.fork === "function"`
+    // holds without us implementing a real fork.
+    method("cluster", "fork", false, None),
+    method("cluster", "disconnect", false, None),
+    method("cluster", "setupPrimary", false, None),
+    method("cluster", "setupMaster", false, None),
+    class("cluster", "Worker"),
+    property("cluster", "isPrimary"),
+    property("cluster", "isMaster"),
+    property("cluster", "isWorker"),
+    property("cluster", "worker"),
+    property("cluster", "workers"),
+    property("cluster", "settings"),
+    property("cluster", "schedulingPolicy"),
+    property("cluster", "SCHED_RR"),
+    property("cluster", "SCHED_NONE"),
+    // `cluster.on` / `cluster.addListener` exist as EventEmitter
+    // prototype methods on the cluster module ITSELF in Node, but
+    // `import * as cluster from "node:cluster"` reads them as named
+    // exports — and there is no `on` / `addListener` named export.
+    // Node's parity fixture prints "undefined" for both. Register them
+    // as properties so the #463 strict gate doesn't bail out at compile
+    // time; `get_native_module_constant` returns `undefined` at
+    // runtime.
+    property("cluster", "on"),
+    property("cluster", "addListener"),
     // ===========================================================
     // #513 Phase A: backfill receiver-less surface for modules that
     // previously had zero entries. Without these, `module_has_any_entries`

--- a/crates/perry-runtime/src/builtins.rs
+++ b/crates/perry-runtime/src/builtins.rs
@@ -598,7 +598,15 @@ fn format_jsvalue(value: f64, depth: usize) -> String {
                     {
                         format_object_as_json(obj_ptr, depth)
                     } else {
-                        "[object Object]".to_string()
+                        // No keys_array → either a freshly-allocated empty
+                        // object or an object whose keys are not tracked
+                        // through this slot. Node's `console.log` /
+                        // `util.inspect` prints `{}` for empty objects;
+                        // `String(obj)` / template-literal coercion print
+                        // `[object Object]` and go through
+                        // `js_jsvalue_to_string` (a separate path), so
+                        // returning `{}` here doesn't break that contract.
+                        "{}".to_string()
                     }
                 } else if gc_type == crate::gc::GC_TYPE_MAP {
                     "Map {}".to_string()

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -5132,6 +5132,16 @@ fn is_native_module_callable_export(module: &str, prop: &str) -> bool {
             | ("tty", "ReadStream")
             | ("tty", "WriteStream")
             | ("events", "EventEmitter")
+            // node:cluster — namespace property reads of these callables
+            // need to satisfy `typeof cluster.fork === "function"` etc.
+            // The fixtures only probe types, but compiled npm code that
+            // calls `cluster.fork()` would also land on the bound-method
+            // dispatch (currently a stub — see runtime entries below).
+            | ("cluster", "fork")
+            | ("cluster", "disconnect")
+            | ("cluster", "setupPrimary")
+            | ("cluster", "setupMaster")
+            | ("cluster", "Worker")
     )
 }
 
@@ -5860,6 +5870,39 @@ unsafe fn get_native_module_constant(
         // pointer) and hand it back for every read.
         "http" => match property {
             "METHODS" => Some(unsafe { http_methods_array() }),
+            _ => None,
+        },
+        // node:cluster — all property reads are static constants on the
+        // primary process. The test fixture only exercises shape, never
+        // forks a worker; the `fork` / `disconnect` / `setupPrimary` /
+        // `setupMaster` / `Worker` callables are produced separately by
+        // `is_native_module_callable_export` (bound-method closure path).
+        "cluster" => match property {
+            // Identity flags: we always identify as the primary
+            // process. A future `cluster.fork` impl would need to flip
+            // these in the spawned child.
+            "isPrimary" | "isMaster" => Some(f64::from_bits(JSValue::bool(true).bits())),
+            "isWorker" => Some(f64::from_bits(JSValue::bool(false).bits())),
+            // No active worker on the primary side.
+            "worker" => Some(f64::from_bits(JSValue::undefined().bits())),
+            // Empty registries — each read allocates a fresh empty
+            // object (the test only reads them once, so the allocation
+            // churn is irrelevant).
+            "workers" | "settings" => {
+                let obj = unsafe { js_object_alloc(0, 0) };
+                Some(f64::from_bits(JSValue::pointer(obj as *const u8).bits()))
+            }
+            // SCHED_RR is the cross-platform default (port-based on
+            // Linux/macOS, manual scheduling on Windows). `SCHED_NONE`
+            // is 1, `SCHED_RR` is 2; `schedulingPolicy` defaults to RR.
+            "schedulingPolicy" | "SCHED_RR" => Some(2.0),
+            "SCHED_NONE" => Some(1.0),
+            // EventEmitter methods on the cluster module aren't named
+            // exports — Node's namespace import reads them as
+            // `undefined`. We register them in the api-manifest so the
+            // #463 gate doesn't reject the typeof read at compile time;
+            // here we resolve them to undefined at runtime.
+            "on" | "addListener" => Some(f64::from_bits(JSValue::undefined().bits())),
             _ => None,
         },
         _ => None,

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 949 entries across 75 modules
+// Coverage: 965 entries across 76 modules
 
 declare module "@perryts/google-auth" {
   /** stdlib */
@@ -124,6 +124,41 @@ declare module "child_process" {
   export function spawn(...args: any[]): any;
   /** stdlib */
   export function spawnSync(...args: any[]): any;
+}
+
+declare module "cluster" {
+  /** stdlib */
+  export class Worker { [key: string]: any; }
+  /** stdlib */
+  export const SCHED_NONE: any;
+  /** stdlib */
+  export const SCHED_RR: any;
+  /** stdlib */
+  export const addListener: any;
+  /** stdlib */
+  export const isMaster: any;
+  /** stdlib */
+  export const isPrimary: any;
+  /** stdlib */
+  export const isWorker: any;
+  /** stdlib */
+  export const on: any;
+  /** stdlib */
+  export const schedulingPolicy: any;
+  /** stdlib */
+  export const settings: any;
+  /** stdlib */
+  export const worker: any;
+  /** stdlib */
+  export const workers: any;
+  /** stdlib */
+  export function disconnect(...args: any[]): any;
+  /** stdlib */
+  export function fork(...args: any[]): any;
+  /** stdlib */
+  export function setupMaster(...args: any[]): any;
+  /** stdlib */
+  export function setupPrimary(...args: any[]): any;
 }
 
 declare module "commander" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 949 entries across 75 modules.
+Total: 965 entries across 76 modules.
 
 ## Modules
 
@@ -17,6 +17,7 @@ Total: 949 entries across 75 modules.
 - [`buffer`](#buffer)
 - [`cheerio`](#cheerio)
 - [`child_process`](#child-process)
+- [`cluster`](#cluster)
 - [`commander`](#commander)
 - [`cron`](#cron)
 - [`crypto`](#crypto)
@@ -224,6 +225,33 @@ Total: 949 entries across 75 modules.
 - `fork` — module
 - `spawn` — module
 - `spawnSync` — module
+
+## `cluster`
+
+### Classes
+
+- `Worker`
+
+### Methods
+
+- `disconnect` — module
+- `fork` — module
+- `setupMaster` — module
+- `setupPrimary` — module
+
+### Properties
+
+- `SCHED_NONE`
+- `SCHED_RR`
+- `addListener`
+- `isMaster`
+- `isPrimary`
+- `isWorker`
+- `on`
+- `schedulingPolicy`
+- `settings`
+- `worker`
+- `workers`
 
 ## `commander`
 

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -158,12 +158,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory \u2014 `node:child_process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
-  "test_parity_cluster": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:cluster` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_parity_console": {
     "issue": "793",
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary

`node:cluster` had no bindings on main — `import * as cluster from "node:cluster"` failed at compile time. Adds the namespace surface that Node's `test_parity_cluster` exercises, all on the primary side (we never actually fork a worker yet). Flips `test_parity_cluster` to PASS and removes the stale `known_failures.json` entry.

## What's new

**Wiring only** — no new runtime crate; the surface is shape-only and reuses existing dispatch mechanisms:

- `perry-api-manifest/src/entries.rs`:
  - `cluster` added to `NATIVE_MODULES`
  - Registered: `fork` / `disconnect` / `setupPrimary` / `setupMaster` (callable exports), `Worker` (class), and the property reads (`isPrimary` / `isMaster` / `isWorker` / `worker` / `workers` / `settings` / `schedulingPolicy` / `SCHED_RR` / `SCHED_NONE` / `on` / `addListener`).
  - `on` / `addListener` are EventEmitter prototype methods on the cluster module itself in Node, but `import * as cluster from "node:cluster"` reads them as named exports — they don't exist as named exports, so Node prints `undefined` for both. Registered as properties so the #463 strict gate doesn't reject the typeof read.

- `perry-runtime/src/object/mod.rs`:
  - `get_native_module_constant`: new `"cluster"` arm returning the primary-side static values.
  - `is_native_module_callable_export`: registers the four method names + `Worker` so `typeof cluster.fork === "function"` resolves to a bound-method closure.

## Collateral: console.log empty-object printing fix

The fixture surfaced a Node parity bug Perry had been silently mis-printing for a while:

```js
console.log("prefix:", {})
// Perry (pre):  prefix: [object Object]
// Perry (post): prefix: {}
// Node:         prefix: {}
```

Node distinguishes `util.inspect({})` (`{}`) from `String({})` / `` `${ {} }` `` (`[object Object]`). Perry's `format_jsvalue` (the console.log formatter) shared the toString-side `[object Object]` fallback for objects with no `keys_array`. Switch the empty-object arm in `format_jsvalue` to `{}`; `js_jsvalue_to_string` (the String/template path) is untouched, so:

- `String({}) === "[object Object]"` ✓
- `` `${ {} }` === "[object Object]" `` ✓
- `console.log("prefix:", {}) → "prefix: {}"` ✓

## Test plan

- [x] `./run_parity_tests.sh --filter test_parity_cluster` → PASS (byte-for-byte vs `node --experimental-strip-types`)
- [x] Full `./run_parity_tests.sh` — 435/472 (92.1%), no regressions; `test_node_http_basic` flips to PASS as a collateral benefit of the empty-object inspect fix
- [x] `cargo build --release -p perry` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `./scripts/regen_api_docs.sh` ran clean — docs regenerated