### PR TITLE
feat(parity): granular node:path suite + path runtime/codegen fixes

### DIFF
--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -9814,7 +9814,13 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let result = blk.call(I64, "js_path_normalize", &[(I64, &p_handle)]);
             Ok(nanbox_string_inline(blk, &result))
         }
-        Expr::PathResolve(p) => lower_expr(ctx, p),
+        Expr::PathResolve(p) => {
+            let p_box = lower_expr(ctx, p)?;
+            let blk = ctx.block();
+            let p_handle = unbox_to_i64(blk, &p_box);
+            let result = blk.call(I64, "js_path_resolve", &[(I64, &p_handle)]);
+            Ok(nanbox_string_inline(blk, &result))
+        }
         Expr::ObjectCreate(p) => {
             let v = lower_expr(ctx, p)?;
             Ok(ctx

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -807,6 +807,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_path_join", I64, &[I64, I64]);
     module.declare_function("js_path_win32_join", I64, &[I64, I64]);
     module.declare_function("js_path_dirname", I64, &[I64]);
+    module.declare_function("js_path_resolve", I64, &[I64]);
     module.declare_function("js_path_relative", I64, &[I64, I64]);
     module.declare_function("js_path_to_namespaced_path", I64, &[I64]);
     module.declare_function("js_path_matches_glob", I32, &[I64, I64]);

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -944,6 +944,11 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                                                     Box::new(to),
                                                 ));
                                             }
+                                            "resolve" if args.is_empty() => {
+                                                return Ok(Expr::PathResolve(Box::new(
+                                                    Expr::String(String::new()),
+                                                )));
+                                            }
                                             "resolve" if !args.is_empty() => {
                                                 let mut it = args.into_iter();
                                                 let first = it.next().unwrap();
@@ -2391,6 +2396,11 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                                     }
                                 }
                                 "resolve" => {
+                                    if args.is_empty() {
+                                        return Ok(Expr::PathResolve(Box::new(Expr::String(
+                                            String::new(),
+                                        ))));
+                                    }
                                     if !args.is_empty() {
                                         // path.resolve(a, b, c): per Node, a later
                                         // absolute segment resets the accumulation —
@@ -6221,6 +6231,11 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                                 }
                             }
                             "resolve" => {
+                                if args.is_empty() {
+                                    return Ok(Expr::PathResolve(Box::new(Expr::String(
+                                        String::new(),
+                                    ))));
+                                }
                                 if !args.is_empty() {
                                     let mut iter = args.into_iter();
                                     let first = iter.next().unwrap();

--- a/crates/perry-runtime/src/path.rs
+++ b/crates/perry-runtime/src/path.rs
@@ -21,6 +21,22 @@ fn string_to_js(s: &str) -> *mut StringHeader {
     js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
 }
 
+fn resolve_posix_str(path_str: &str) -> String {
+    if path_str.is_empty() {
+        return std::env::current_dir()
+            .map(|cwd| cwd.to_string_lossy().to_string())
+            .unwrap_or_default();
+    }
+    if Path::new(path_str).is_absolute() {
+        normalize_str(path_str)
+    } else {
+        match std::env::current_dir() {
+            Ok(cwd) => normalize_str(&format!("{}/{}", cwd.to_string_lossy(), path_str)),
+            Err(_) => normalize_str(path_str),
+        }
+    }
+}
+
 /// Join two path segments. Node's `path.join` concatenates with `/` and
 /// normalizes — it does NOT reset on an absolute segment (that's
 /// `path.resolve`'s job). We can't use Rust's `Path::join` because it
@@ -154,6 +170,14 @@ pub extern "C" fn js_path_dirname(path_ptr: *const StringHeader) -> *mut StringH
         if path_str.chars().all(|c| c == '/') {
             return string_to_js("/");
         }
+        // Node preserves exactly two leading slashes for the dirname of
+        // `//foo` on POSIX.
+        if path_str.starts_with("//")
+            && !path_str.starts_with("///")
+            && !path_str[2..].contains('/')
+        {
+            return string_to_js("//");
+        }
 
         let path = Path::new(&path_str);
         match path.parent() {
@@ -232,6 +256,13 @@ pub extern "C" fn js_path_resolve(path_ptr: *const StringHeader) -> *mut StringH
             Some(s) => s,
             None => return string_to_js(""),
         };
+
+        if path_str.is_empty() {
+            return match std::env::current_dir() {
+                Ok(cwd) => string_to_js(&cwd.to_string_lossy()),
+                Err(_) => string_to_js(""),
+            };
+        }
 
         match std::fs::canonicalize(&path_str) {
             Ok(abs_path) => string_to_js(&abs_path.to_string_lossy()),
@@ -314,8 +345,8 @@ pub extern "C" fn js_path_relative(
     unsafe {
         let from = string_from_header(from_ptr).unwrap_or_default();
         let to = string_from_header(to_ptr).unwrap_or_default();
-        let from_norm = normalize_str(&from);
-        let to_norm = normalize_str(&to);
+        let from_norm = resolve_posix_str(&from);
+        let to_norm = resolve_posix_str(&to);
         let from_segs: Vec<&str> = from_norm.split('/').filter(|s| !s.is_empty()).collect();
         let to_segs: Vec<&str> = to_norm.split('/').filter(|s| !s.is_empty()).collect();
         let common = from_segs
@@ -347,7 +378,10 @@ pub extern "C" fn js_path_basename_ext(
             Some(name) => name.to_string_lossy().to_string(),
             None => return string_to_js(""),
         };
-        if !ext_str.is_empty() && base.ends_with(&ext_str) && base.len() > ext_str.len() {
+        if !ext_str.is_empty()
+            && base.ends_with(&ext_str)
+            && (base.len() > ext_str.len() || !path_str.contains('/'))
+        {
             string_to_js(&base[..base.len() - ext_str.len()])
         } else {
             string_to_js(&base)
@@ -365,9 +399,15 @@ pub extern "C" fn js_path_parse(path_ptr: *const StringHeader) -> *mut crate::ob
     let p = Path::new(&path_str);
 
     let root = if path_str.starts_with('/') { "/" } else { "" }.to_string();
-    let dir = match p.parent() {
-        Some(parent) => parent.to_string_lossy().to_string(),
-        None => String::new(),
+    let dir = if !root.is_empty() && path_str.chars().all(|c| c == '/') {
+        // Node's path.parse("/") preserves the root as the dir as well:
+        // { root: "/", dir: "/", base: "", ext: "", name: "" }.
+        root.clone()
+    } else {
+        match p.parent() {
+            Some(parent) => parent.to_string_lossy().to_string(),
+            None => String::new(),
+        }
     };
     let base = match p.file_name() {
         Some(b) => b.to_string_lossy().to_string(),
@@ -423,11 +463,22 @@ pub extern "C" fn js_path_format(obj_f64: f64) -> *mut StringHeader {
     let dir = get_str("dir");
     let root = get_str("root");
     let base = get_str("base");
+    let name = get_str("name");
+    let mut ext = get_str("ext");
+    // Node inserts the separator dot when `ext` is provided without
+    // one: path.format({ name: "file", ext: "txt" }) === "file.txt".
+    if !ext.is_empty() && !ext.starts_with('.') {
+        ext.insert(0, '.');
+    }
+    let has_tail = !base.is_empty() || !name.is_empty() || !ext.is_empty();
 
     // dir takes precedence over root; name+ext fallback when base missing
     let mut result = if !dir.is_empty() {
         let mut s = dir.clone();
-        if !s.ends_with('/') {
+        // Node always inserts a separator between dir and base, even when
+        // dir already ends with `/`. If there is no tail, keep dir as-is
+        // (path.format(path.parse("/")) === "/").
+        if has_tail {
             s.push('/');
         }
         s
@@ -444,8 +495,6 @@ pub extern "C" fn js_path_format(obj_f64: f64) -> *mut StringHeader {
     if !base.is_empty() {
         result.push_str(&base);
     } else {
-        let name = get_str("name");
-        let ext = get_str("ext");
         result.push_str(&name);
         result.push_str(&ext);
     }

--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -4,6 +4,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEST_DIR="$SCRIPT_DIR/test-files"
+NODE_SUITE_DIR="$SCRIPT_DIR/test-parity/node-suite"
 OUTPUT_DIR="$SCRIPT_DIR/test-parity/output"
 REPORT_DIR="$SCRIPT_DIR/test-parity/reports"
 
@@ -18,13 +19,32 @@ BACKEND_LABEL="LLVM"
 #   ./run_parity_tests.sh --filter parity_url
 #   ./run_parity_tests.sh --filter parity_     # all parity-inventory tests
 TEST_FILTER=""
+# Optional suite selector. The historical default (`all`) keeps running the
+# top-level test-files/*.ts corpus. The granular `node-suite` selector runs
+# curated Node-compatibility cases under test-parity/node-suite/<module>/...
+# without requiring test_parity_* names.
+TEST_SUITE="all"
+MODULE_FILTER=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --filter) TEST_FILTER="$2"; shift 2 ;;
         --filter=*) TEST_FILTER="${1#--filter=}"; shift ;;
+        --suite) TEST_SUITE="$2"; shift 2 ;;
+        --suite=*) TEST_SUITE="${1#--suite=}"; shift ;;
+        --module) MODULE_FILTER="$2"; shift 2 ;;
+        --module=*) MODULE_FILTER="${1#--module=}"; shift ;;
         *) shift ;;
     esac
 done
+
+case "$TEST_SUITE" in
+    all|parity|smoke|node-suite) ;;
+    *)
+        echo -e "\033[0;31mUnknown suite: $TEST_SUITE\033[0m"
+        echo "Known suites: all, parity, smoke, node-suite"
+        exit 1
+        ;;
+esac
 
 # Colors for output
 RED='\033[0;31m'
@@ -220,6 +240,7 @@ for raw in sys.stdin:
         sed -E '/^\(node:[0-9]+\) \[MODULE_TYPELESS_PACKAGE_JSON\]/d' | \
         sed -E '/^\(node:[0-9]+\) \[DEP[0-9]+\] DeprecationWarning:/d' | \
         sed -E '/^\(node:[0-9]+\) ExperimentalWarning: Type Stripping is an experimental feature/d' | \
+        sed -E '/^\(node:[0-9]+\) ExperimentalWarning: glob is an experimental feature/d' | \
         sed -E '/^\(Use `node --trace-deprecation/d' | \
         sed -E '/^Reparsing as ES module because module syntax was detected/d' | \
         sed -E '/^To eliminate this warning, add "type": "module"/d' | \
@@ -278,7 +299,7 @@ fi
 
 echo -e "${GREEN}Compiler and runtime built successfully${NC}"
 echo ""
-echo "Running parity tests (backend: $BACKEND_LABEL)..."
+echo "Running parity tests (backend: $BACKEND_LABEL, suite: $TEST_SUITE${MODULE_FILTER:+, module: $MODULE_FILTER})..."
 echo ""
 
 # ---------------------------------------------------------------------------
@@ -327,7 +348,12 @@ stop_echo_server() {
 
 trap stop_echo_server EXIT
 
-start_echo_server
+# The granular node-suite starts with deterministic module cases (path, url,
+# etc.) that do not need the legacy top-level net echo server. Future net
+# node-suite cases can opt into their own per-test companion lifecycle.
+if [[ "$TEST_SUITE" != "node-suite" ]]; then
+    start_echo_server
+fi
 echo ""
 
 # JSON report data
@@ -337,25 +363,67 @@ LATEST_REPORT="$REPORT_DIR/latest.json"
 # Start JSON array for test results
 TEST_RESULTS="[]"
 
+declare -a TEST_FILES=()
+case "$TEST_SUITE" in
+    all)
+        while IFS= read -r test_file; do
+            TEST_FILES+=("$test_file")
+        done < <(find "$TEST_DIR" -maxdepth 1 -type f -name '*.ts' | sort)
+        ;;
+    parity|smoke)
+        while IFS= read -r test_file; do
+            TEST_FILES+=("$test_file")
+        done < <(find "$TEST_DIR" -maxdepth 1 -type f -name 'test_parity_*.ts' | sort)
+        ;;
+    node-suite)
+        node_suite_search_root="$NODE_SUITE_DIR"
+        if [[ -n "$MODULE_FILTER" ]]; then
+            node_suite_search_root="$NODE_SUITE_DIR/$MODULE_FILTER"
+        fi
+        if [[ -d "$node_suite_search_root" ]]; then
+            while IFS= read -r test_file; do
+                TEST_FILES+=("$test_file")
+            done < <(find "$node_suite_search_root" -type f -name '*.ts' | sort)
+        fi
+        ;;
+    *)
+        echo -e "${RED}Unknown suite: $TEST_SUITE${NC}"
+        echo "Known suites: all, parity, smoke, node-suite"
+        exit 1
+        ;;
+esac
+
+if [[ ${#TEST_FILES[@]} -eq 0 ]]; then
+    echo -e "${YELLOW}No tests matched suite/filter selection${NC}"
+fi
+
 # Run each test
-for test_file in "$TEST_DIR"/*.ts; do
+for test_file in "${TEST_FILES[@]}"; do
     # Skip directories (multi/ folder)
     [[ -d "$test_file" ]] && continue
 
     test_name=$(basename "$test_file" .ts)
+    if [[ "$test_file" == "$NODE_SUITE_DIR"/* ]]; then
+        test_rel="${test_file#"$NODE_SUITE_DIR"/}"
+        test_id="node-suite/${test_rel%.ts}"
+    else
+        test_id="$test_name"
+    fi
 
-    # Optional --filter flag: only run tests whose basename contains it.
-    if [[ -n "$TEST_FILTER" ]] && [[ "$test_name" != *"$TEST_FILTER"* ]]; then
+    # Optional --filter flag: only run tests whose basename or suite id
+    # contains it.
+    if [[ -n "$TEST_FILTER" ]] && [[ "$test_name" != *"$TEST_FILTER"* ]] && [[ "$test_id" != *"$TEST_FILTER"* ]]; then
         continue
     fi
 
-    node_output_file="$OUTPUT_DIR/node/${test_name}.txt"
-    perry_output_file="$OUTPUT_DIR/perry/${test_name}.txt"
-    perry_binary="/tmp/perry_parity_$test_name"
+    safe_test_id="${test_id//\//__}"
+    node_output_file="$OUTPUT_DIR/node/${safe_test_id}.txt"
+    perry_output_file="$OUTPUT_DIR/perry/${safe_test_id}.txt"
+    perry_binary="/tmp/perry_parity_$safe_test_id"
 
     # Check if test should be skipped
     if should_skip "$test_name"; then
-        echo -e "${YELLOW}SKIP${NC}  $test_name (async/timer test)"
+        echo -e "${YELLOW}SKIP${NC}  $test_id (async/timer test)"
         ((SKIPPED++))
         continue
     fi
@@ -387,12 +455,12 @@ for test_file in "$TEST_DIR"/*.ts; do
         # to compile+run Perry and compare against the expected file.
         # Otherwise record NODE_FAIL and skip.
         if ! has_expected_output "$test_name"; then
-            echo -e "${YELLOW}SKIP${NC}  $test_name (Node.js error: exit $node_exit)"
+            echo -e "${YELLOW}SKIP${NC}  $test_id (Node.js error: exit $node_exit)"
             ((NODE_FAIL++))
             [[ -n "$local_server_pid" ]] && stop_tls_upgrade_server
             continue
         fi
-        echo -e "${YELLOW}NOTE${NC}  $test_name (Node.js error: exit $node_exit — using expected-output)"
+        echo -e "${YELLOW}NOTE${NC}  $test_id (Node.js error: exit $node_exit — using expected-output)"
     fi
 
     # Save Node.js output
@@ -402,7 +470,7 @@ for test_file in "$TEST_DIR"/*.ts; do
     # (PERRY_ALLOW_UNIMPLEMENTED=1) so unimplemented APIs surface as
     # runtime divergence (the gap signal) instead of hard compile errors.
     compile_env=""
-    if [[ "$test_name" == test_parity_* ]]; then
+    if [[ "$test_name" == test_parity_* || "$test_id" == node-suite/* ]]; then
         compile_env="PERRY_ALLOW_UNIMPLEMENTED=1"
     fi
     # #499: some parity tests transitively pull in `.js` fixtures
@@ -422,16 +490,16 @@ for test_file in "$TEST_DIR"/*.ts; do
     fi
 
     if [[ $compile_exit -ne 0 ]]; then
-        echo -e "${RED}FAIL${NC}  $test_name (compile error)"
+        echo -e "${RED}FAIL${NC}  $test_id (compile error)"
         ((COMPILE_FAIL++))
-        COMPILE_FAILURES+=("$test_name")
+        COMPILE_FAILURES+=("$test_id")
         echo "" > "$perry_output_file"
         # Persist the actual compile stderr so CI artifacts can be inspected
         # to diagnose long-tail compile failures (e.g. the macOS-14 SDK gap
         # tracked as `ci-env` in test-parity/known_failures.json). Pre-fix
         # the parity runner only logged "compile error" with no detail and
         # the macOS-14 family was diagnosed by inference, not data.
-        compile_log="$OUTPUT_DIR/${test_name}.compile_error.log"
+        compile_log="$OUTPUT_DIR/${safe_test_id}.compile_error.log"
         printf "%s\n" "$compile_output" > "$compile_log"
         [[ -n "$local_server_pid" ]] && stop_tls_upgrade_server
         continue
@@ -455,13 +523,13 @@ for test_file in "$TEST_DIR"/*.ts; do
         expected_normalized=$(normalize_output "$(cat "$EXPECTED_DIR/${test_name}.txt")")
         perry_normalized=$(normalize_output "$perry_output")
         if [[ "$perry_normalized" == "$expected_normalized" ]]; then
-            echo -e "${GREEN}PASS${NC}  $test_name (expected-output)"
+            echo -e "${GREEN}PASS${NC}  $test_id (expected-output)"
             ((PARITY_PASS++))
             status="pass"
         else
-            echo -e "${RED}FAIL${NC}  $test_name (expected-output mismatch)"
+            echo -e "${RED}FAIL${NC}  $test_id (expected-output mismatch)"
             ((PARITY_FAIL++))
-            PARITY_FAILURES+=("$test_name")
+            PARITY_FAILURES+=("$test_id")
             status="fail"
             echo "       Expected: $(cat "$EXPECTED_DIR/${test_name}.txt" | head -1)"
             echo "       Perry:    $(echo "$perry_output" | head -1)"
@@ -473,13 +541,13 @@ for test_file in "$TEST_DIR"/*.ts; do
 
         # Compare outputs
         if [[ "$node_normalized" == "$perry_normalized" ]]; then
-            echo -e "${GREEN}PASS${NC}  $test_name"
+            echo -e "${GREEN}PASS${NC}  $test_id"
             ((PARITY_PASS++))
             status="pass"
         else
-            echo -e "${RED}FAIL${NC}  $test_name (output mismatch)"
+            echo -e "${RED}FAIL${NC}  $test_id (output mismatch)"
             ((PARITY_FAIL++))
-            PARITY_FAILURES+=("$test_name")
+            PARITY_FAILURES+=("$test_id")
             status="fail"
 
             # Show diff for failures (first few lines)

--- a/test-parity/common/README.md
+++ b/test-parity/common/README.md
@@ -1,0 +1,4 @@
+# parity common helpers
+
+Shared helpers for granular parity tests. Keep helpers runnable in both Node.js
+and Perry; avoid harness-only behavior that would hide output differences.

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -8,6 +8,36 @@
       "reason": "Free-text explanation. Keep the most-actionable signal first \u2014 what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
+  "node-suite/path/win32/basename-dirname": {
+    "issue": "1162",
+    "added": "2026-05-20",
+    "category": "module-inventory",
+    "reason": "#1162: the `path.win32` sub-namespace isn't implemented. `path.win32.basename` / `path.win32.dirname` resolve to undefined; all five `node-suite/path/win32/*` fixtures flip to PASS once the win32 mirror lands."
+  },
+  "node-suite/path/win32/join-normalize": {
+    "issue": "1162",
+    "added": "2026-05-20",
+    "category": "module-inventory",
+    "reason": "#1162: the `path.win32` sub-namespace isn't implemented. `path.win32.join` happens to produce a Node-shaped string for the covered cases but `path.win32.normalize` doesn't — both rely on the missing Windows separator/drive handling. Flips to PASS with the rest of the win32 family."
+  },
+  "node-suite/path/win32/parse-format": {
+    "issue": "1162",
+    "added": "2026-05-20",
+    "category": "module-inventory",
+    "reason": "#1162: `path.win32.parse` returns undefined so the downstream property reads (`.root`, `.dir`, …) throw. Flips to PASS when the win32 mirror is wired."
+  },
+  "node-suite/path/win32/relative-resolve": {
+    "issue": "1162",
+    "added": "2026-05-20",
+    "category": "module-inventory",
+    "reason": "#1162: `path.win32.relative` / `.resolve` / `.isAbsolute` resolve to undefined. Flips to PASS when the win32 mirror is wired."
+  },
+  "node-suite/path/win32/unc-and-drive": {
+    "issue": "1162",
+    "added": "2026-05-20",
+    "category": "module-inventory",
+    "reason": "#1162: UNC paths (`\\\\\\\\server\\\\share`) and drive-relative paths (`C:foo`) need win32-specific normalize/resolve rules that Perry doesn't model on POSIX hosts. Flips to PASS when the win32 mirror is wired."
+  },
   "issue_655_repro": {
     "issue": "655",
     "added": "2026-05-15",

--- a/test-parity/node-suite/path/README.md
+++ b/test-parity/node-suite/path/README.md
@@ -1,0 +1,8 @@
+# node:path parity suite
+
+Granular Node compatibility cases for `node:path`, curated from the current broad
+`test-files/test_parity_path.ts` smoke test and intended to be expanded case by
+case from Node/Deno behavior references.
+
+Each test is intentionally small and deterministic so failures point to one API
+shape instead of the whole module.

--- a/test-parity/node-suite/path/basename/basic.ts
+++ b/test-parity/node-suite/path/basename/basic.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("basename /foo/bar/baz.txt:", path.basename("/foo/bar/baz.txt"));
+console.log("basename /foo/bar:", path.basename("/foo/bar"));
+console.log("basename relative:", path.basename("foo/bar/baz"));

--- a/test-parity/node-suite/path/basename/ext-edge-cases.ts
+++ b/test-parity/node-suite/path/basename/ext-edge-cases.ts
@@ -1,0 +1,7 @@
+import * as path from "node:path";
+
+console.log("ext empty:", path.basename("foo.txt", ""));
+console.log("ext exact whole:", path.basename("foo", "foo"));
+console.log("ext longer than base:", path.basename("foo", "foobar"));
+console.log("ext repeated suffix:", path.basename("foo.txt.txt", ".txt"));
+console.log("ext dot only:", path.basename("foo.", "."));

--- a/test-parity/node-suite/path/basename/separators.ts
+++ b/test-parity/node-suite/path/basename/separators.ts
@@ -1,0 +1,7 @@
+import * as path from "node:path";
+
+console.log("only slash:", path.basename("/"));
+console.log("double slash:", path.basename("//"));
+console.log("nested trailing slash:", path.basename("/foo/bar/baz//"));
+console.log("dot segment:", path.basename("/foo/./bar"));
+console.log("dotdot segment:", path.basename("/foo/../bar"));

--- a/test-parity/node-suite/path/basename/trailing-slash.ts
+++ b/test-parity/node-suite/path/basename/trailing-slash.ts
@@ -1,0 +1,6 @@
+import * as path from "node:path";
+
+console.log("trailing dir:", path.basename("/foo/bar/"));
+console.log("many trailing:", path.basename("/foo/bar///"));
+console.log("root:", path.basename("/"));
+console.log("empty:", path.basename(""));

--- a/test-parity/node-suite/path/basename/with-ext.ts
+++ b/test-parity/node-suite/path/basename/with-ext.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("strip .txt:", path.basename("/foo/bar/baz.txt", ".txt"));
+console.log("strip non-match:", path.basename("/foo/bar/baz.txt", ".js"));
+console.log("strip whole base:", path.basename("/foo/bar/baz", "baz"));

--- a/test-parity/node-suite/path/dirname/basic.ts
+++ b/test-parity/node-suite/path/dirname/basic.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("dirname file:", path.dirname("/foo/bar/baz.txt"));
+console.log("dirname dir:", path.dirname("/foo/bar/baz"));
+console.log("dirname relative:", path.dirname("foo/bar/baz"));

--- a/test-parity/node-suite/path/dirname/relative.ts
+++ b/test-parity/node-suite/path/dirname/relative.ts
@@ -1,0 +1,6 @@
+import * as path from "node:path";
+
+console.log("dirname one segment:", path.dirname("foo"));
+console.log("dirname dot child:", path.dirname("./foo"));
+console.log("dirname dotdot child:", path.dirname("../foo"));
+console.log("dirname nested dotdot:", path.dirname("foo/../bar"));

--- a/test-parity/node-suite/path/dirname/root.ts
+++ b/test-parity/node-suite/path/dirname/root.ts
@@ -1,0 +1,6 @@
+import * as path from "node:path";
+
+console.log("dirname root:", path.dirname("/"));
+console.log("dirname single absolute:", path.dirname("/foo"));
+console.log("dirname empty:", path.dirname(""));
+console.log("dirname dot:", path.dirname("."));

--- a/test-parity/node-suite/path/dirname/separators.ts
+++ b/test-parity/node-suite/path/dirname/separators.ts
@@ -1,0 +1,7 @@
+import * as path from "node:path";
+
+console.log("double slash:", path.dirname("//"));
+console.log("many slash:", path.dirname("////"));
+console.log("trailing file slash:", path.dirname("/foo/bar/"));
+console.log("relative trailing:", path.dirname("foo/bar/"));
+console.log("dotdot:", path.dirname("../foo/bar"));

--- a/test-parity/node-suite/path/extname/basic.ts
+++ b/test-parity/node-suite/path/extname/basic.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("ext txt:", path.extname("/foo/bar/baz.txt"));
+console.log("ext gz:", path.extname("foo.tar.gz"));
+console.log("ext trailing dot:", path.extname("foo."));

--- a/test-parity/node-suite/path/extname/dot-edge-cases.ts
+++ b/test-parity/node-suite/path/extname/dot-edge-cases.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+for (const value of [".", "..", "...", "foo..", "foo...", "foo.bar.", "foo..bar", "/foo/.bar.baz"]) {
+  console.log(value, "=>", path.extname(value));
+}

--- a/test-parity/node-suite/path/extname/dotfiles.ts
+++ b/test-parity/node-suite/path/extname/dotfiles.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("dotfile no ext:", path.extname(".gitignore"));
+console.log("dotfile with ext:", path.extname(".profile.js"));
+console.log("nested dotfile:", path.extname("/foo/.env"));

--- a/test-parity/node-suite/path/extname/no-extension.ts
+++ b/test-parity/node-suite/path/extname/no-extension.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("no ext file:", path.extname("README"));
+console.log("no ext path:", path.extname("/foo/bar/baz"));
+console.log("empty:", path.extname(""));

--- a/test-parity/node-suite/path/format/basic.ts
+++ b/test-parity/node-suite/path/format/basic.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("dir+base:", path.format({ dir: "/home/user", base: "file.txt" }));
+console.log("root+base:", path.format({ root: "/", base: "file.txt" }));
+console.log("name+ext:", path.format({ dir: "/home/user", name: "file", ext: ".txt" }));

--- a/test-parity/node-suite/path/format/empty-fields.ts
+++ b/test-parity/node-suite/path/format/empty-fields.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("empty object:", path.format({}));
+console.log("only name:", path.format({ name: "file" }));
+console.log("only ext:", path.format({ ext: ".txt" }));

--- a/test-parity/node-suite/path/format/precedence.ts
+++ b/test-parity/node-suite/path/format/precedence.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("base over name/ext:", path.format({ dir: "/tmp", base: "base.txt", name: "name", ext: ".js" }));
+console.log("dir over root:", path.format({ root: "/", dir: "/tmp", base: "file.txt" }));
+console.log("ext without dot:", path.format({ dir: "/tmp", name: "file", ext: "txt" }));

--- a/test-parity/node-suite/path/format/root-dir-base.ts
+++ b/test-parity/node-suite/path/format/root-dir-base.ts
@@ -1,0 +1,6 @@
+import * as path from "node:path";
+
+console.log("root only:", path.format({ root: "/" }));
+console.log("dir slash base:", path.format({ dir: "/", base: "file" }));
+console.log("relative dir base:", path.format({ dir: "foo", base: "bar" }));
+console.log("dir trailing slash:", path.format({ dir: "/foo/", base: "bar" }));

--- a/test-parity/node-suite/path/imports/default-import.ts
+++ b/test-parity/node-suite/path/imports/default-import.ts
@@ -1,0 +1,5 @@
+import path from "node:path";
+
+console.log("default basename:", path.basename("/foo/bar.txt"));
+console.log("default join:", path.join("/foo", "bar"));
+console.log("default sep:", path.sep);

--- a/test-parity/node-suite/path/imports/named-imports.ts
+++ b/test-parity/node-suite/path/imports/named-imports.ts
@@ -1,0 +1,8 @@
+import { basename, dirname, extname, join, normalize, resolve } from "node:path";
+
+console.log("basename:", basename("/foo/bar.txt"));
+console.log("dirname:", dirname("/foo/bar.txt"));
+console.log("extname:", extname("/foo/bar.txt"));
+console.log("join:", join("/foo", "bar"));
+console.log("normalize:", normalize("/foo//bar"));
+console.log("resolve suffix:", resolve("foo").endsWith("foo"));

--- a/test-parity/node-suite/path/isAbsolute/basic.ts
+++ b/test-parity/node-suite/path/isAbsolute/basic.ts
@@ -1,0 +1,6 @@
+import * as path from "node:path";
+
+console.log("slash:", path.isAbsolute("/"));
+console.log("absolute path:", path.isAbsolute("/foo/bar"));
+console.log("relative path:", path.isAbsolute("foo/bar"));
+console.log("empty:", path.isAbsolute(""));

--- a/test-parity/node-suite/path/isAbsolute/dot-segments.ts
+++ b/test-parity/node-suite/path/isAbsolute/dot-segments.ts
@@ -1,0 +1,6 @@
+import * as path from "node:path";
+
+console.log("dot relative:", path.isAbsolute("./foo"));
+console.log("dotdot relative:", path.isAbsolute("../foo"));
+console.log("absolute dot:", path.isAbsolute("/foo/./bar"));
+console.log("absolute dotdot:", path.isAbsolute("/foo/../bar"));

--- a/test-parity/node-suite/path/join/absolute-segments.ts
+++ b/test-parity/node-suite/path/join/absolute-segments.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("absolute second not reset:", path.join("/foo", "/bar"));
+console.log("absolute third not reset:", path.join("foo", "/bar", "/baz"));
+console.log("root plus root:", path.join("/", "/"));

--- a/test-parity/node-suite/path/join/basic.ts
+++ b/test-parity/node-suite/path/join/basic.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("join abs:", path.join("/foo", "bar", "baz"));
+console.log("join rel:", path.join("foo", "bar", "baz"));
+console.log("join single:", path.join("foo"));

--- a/test-parity/node-suite/path/join/empty-segments.ts
+++ b/test-parity/node-suite/path/join/empty-segments.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("join empty call:", path.join());
+console.log("join empty strings:", path.join("", ""));
+console.log("join skips empty:", path.join("foo", "", "bar"));

--- a/test-parity/node-suite/path/join/many-args.ts
+++ b/test-parity/node-suite/path/join/many-args.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("many args:", path.join("/foo", "bar", "baz", "qux"));
+console.log("many with empty:", path.join("", "/foo", "", "bar", ""));
+console.log("many dotdot:", path.join("/foo", "bar", "..", "baz", "."));

--- a/test-parity/node-suite/path/join/normalizes.ts
+++ b/test-parity/node-suite/path/join/normalizes.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("join double slash:", path.join("/foo//", "bar"));
+console.log("join dotdot:", path.join("/foo", "..", "bar"));
+console.log("join dot:", path.join("/foo", ".", "bar"));

--- a/test-parity/node-suite/path/matchesGlob/basic.ts
+++ b/test-parity/node-suite/path/matchesGlob/basic.ts
@@ -1,0 +1,9 @@
+import * as path from "node:path";
+
+try {
+  console.log("txt matches:", path.matchesGlob("foo.txt", "*.txt"));
+  console.log("js mismatch:", path.matchesGlob("foo.js", "*.txt"));
+  console.log("nested matches:", path.matchesGlob("src/foo.ts", "src/*.ts"));
+} catch (e) {
+  console.log("matchesGlob ERROR:", (e as Error).message);
+}

--- a/test-parity/node-suite/path/normalize/above-root.ts
+++ b/test-parity/node-suite/path/normalize/above-root.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("absolute above root:", path.normalize("/foo/../../bar"));
+console.log("relative above root:", path.normalize("foo/../../bar"));
+console.log("many dotdot relative:", path.normalize("../../foo"));

--- a/test-parity/node-suite/path/normalize/basic.ts
+++ b/test-parity/node-suite/path/normalize/basic.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("normalize repeated separators:", path.normalize("/foo/bar//baz"));
+console.log("normalize dotdot:", path.normalize("/foo/bar/../baz"));
+console.log("normalize relative:", path.normalize("foo/bar//baz"));

--- a/test-parity/node-suite/path/normalize/dot-segments.ts
+++ b/test-parity/node-suite/path/normalize/dot-segments.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("normalize dot:", path.normalize("./foo/./bar"));
+console.log("normalize leading dotdot:", path.normalize("../foo/bar"));
+console.log("normalize collapses above relative:", path.normalize("foo/../../bar"));

--- a/test-parity/node-suite/path/normalize/double-slashes.ts
+++ b/test-parity/node-suite/path/normalize/double-slashes.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("normalize leading double:", path.normalize("//foo/bar"));
+console.log("normalize trailing slash:", path.normalize("foo/bar/"));
+console.log("normalize empty:", path.normalize(""));

--- a/test-parity/node-suite/path/normalize/trailing.ts
+++ b/test-parity/node-suite/path/normalize/trailing.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("absolute trailing:", path.normalize("/foo/bar/"));
+console.log("relative trailing dot:", path.normalize("foo/bar/."));
+console.log("relative trailing dotdot slash:", path.normalize("foo/bar/../"));

--- a/test-parity/node-suite/path/parse/basic.ts
+++ b/test-parity/node-suite/path/parse/basic.ts
@@ -1,0 +1,8 @@
+import * as path from "node:path";
+
+const parsed = path.parse("/home/user/file.txt");
+console.log("root:", parsed.root);
+console.log("dir:", parsed.dir);
+console.log("base:", parsed.base);
+console.log("name:", parsed.name);
+console.log("ext:", parsed.ext);

--- a/test-parity/node-suite/path/parse/dotfiles.ts
+++ b/test-parity/node-suite/path/parse/dotfiles.ts
@@ -1,0 +1,6 @@
+import * as path from "node:path";
+
+for (const value of [".gitignore", "/home/user/.env", "/home/user/.profile.js"]) {
+  const parsed = path.parse(value);
+  console.log(value, "=>", parsed.dir, parsed.base, parsed.name, parsed.ext);
+}

--- a/test-parity/node-suite/path/parse/no-extension.ts
+++ b/test-parity/node-suite/path/parse/no-extension.ts
@@ -1,0 +1,8 @@
+import * as path from "node:path";
+
+const parsed = path.parse("/home/user/file");
+console.log("root:", parsed.root);
+console.log("dir:", parsed.dir);
+console.log("base:", parsed.base);
+console.log("name:", parsed.name);
+console.log("ext:", parsed.ext);

--- a/test-parity/node-suite/path/parse/root-and-relative.ts
+++ b/test-parity/node-suite/path/parse/root-and-relative.ts
@@ -1,0 +1,6 @@
+import * as path from "node:path";
+
+for (const value of ["/", "foo/bar.txt", "foo", ""]) {
+  const parsed = path.parse(value);
+  console.log(value || "<empty>", "=>", parsed.root, parsed.dir, parsed.base, parsed.name, parsed.ext);
+}

--- a/test-parity/node-suite/path/parse/roundtrip.ts
+++ b/test-parity/node-suite/path/parse/roundtrip.ts
@@ -1,0 +1,6 @@
+import * as path from "node:path";
+
+for (const value of ["/home/user/file.txt", "foo/bar", ".gitignore", "/"]) {
+  const parsed = path.parse(value);
+  console.log(value, "=>", path.format(parsed));
+}

--- a/test-parity/node-suite/path/parse/trailing-slash.ts
+++ b/test-parity/node-suite/path/parse/trailing-slash.ts
@@ -1,0 +1,6 @@
+import * as path from "node:path";
+
+for (const value of ["/foo/bar/", "foo/bar/", "/foo/bar//"]) {
+  const parsed = path.parse(value);
+  console.log(value, "=>", parsed.root, parsed.dir, parsed.base, parsed.ext, parsed.name);
+}

--- a/test-parity/node-suite/path/posix/basename-dirname.ts
+++ b/test-parity/node-suite/path/posix/basename-dirname.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("posix basename:", path.posix.basename("/foo/bar/baz.txt"));
+console.log("posix basename ext:", path.posix.basename("/foo/bar/baz.txt", ".txt"));
+console.log("posix dirname:", path.posix.dirname("/foo/bar/baz.txt"));

--- a/test-parity/node-suite/path/posix/edge-separators.ts
+++ b/test-parity/node-suite/path/posix/edge-separators.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("posix normalize double slash:", path.posix.normalize("//foo//bar"));
+console.log("posix dirname double slash:", path.posix.dirname("//foo"));
+console.log("posix basename trailing:", path.posix.basename("/foo/bar//"));

--- a/test-parity/node-suite/path/posix/join-normalize.ts
+++ b/test-parity/node-suite/path/posix/join-normalize.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("posix join:", path.posix.join("/foo", "bar", "baz"));
+console.log("posix join dotdot:", path.posix.join("/foo", "..", "bar"));
+console.log("posix normalize:", path.posix.normalize("/foo/bar//baz/.."));

--- a/test-parity/node-suite/path/posix/parse-format.ts
+++ b/test-parity/node-suite/path/posix/parse-format.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+const parsed = path.posix.parse("/home/user/file.txt");
+console.log("posix parse:", parsed.root, parsed.dir, parsed.base, parsed.name, parsed.ext);
+console.log("posix format:", path.posix.format({ dir: "/home/user", name: "file", ext: ".txt" }));

--- a/test-parity/node-suite/path/posix/relative-resolve.ts
+++ b/test-parity/node-suite/path/posix/relative-resolve.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("posix relative:", path.posix.relative("/foo/a", "/foo/b"));
+console.log("posix resolve:", path.posix.resolve("/foo", "bar"));
+console.log("posix isAbsolute:", path.posix.isAbsolute("/foo"));

--- a/test-parity/node-suite/path/posix/zero-length.ts
+++ b/test-parity/node-suite/path/posix/zero-length.ts
@@ -1,0 +1,7 @@
+import * as path from "node:path";
+
+console.log("posix basename empty:", path.posix.basename(""));
+console.log("posix dirname empty:", path.posix.dirname(""));
+console.log("posix normalize empty:", path.posix.normalize(""));
+console.log("posix join empty:", path.posix.join(""));
+console.log("posix resolve empty equals cwd:", path.posix.resolve("") === process.cwd());

--- a/test-parity/node-suite/path/properties/sep-delimiter.ts
+++ b/test-parity/node-suite/path/properties/sep-delimiter.ts
@@ -1,0 +1,8 @@
+import * as path from "node:path";
+
+console.log("sep:", path.sep);
+console.log("delimiter:", path.delimiter);
+console.log("posix sep:", path.posix.sep);
+console.log("posix delimiter:", path.posix.delimiter);
+console.log("win32 sep:", path.win32.sep);
+console.log("win32 delimiter:", path.win32.delimiter);

--- a/test-parity/node-suite/path/relative/absolute-relative-mix.ts
+++ b/test-parity/node-suite/path/relative/absolute-relative-mix.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("abs to rel suffix:", path.relative("/foo", "bar").endsWith("bar"));
+console.log("rel to abs suffix:", path.relative("foo", "/bar").endsWith("bar"));
+console.log("dot to child:", path.relative(".", "foo/bar"));

--- a/test-parity/node-suite/path/relative/basic.ts
+++ b/test-parity/node-suite/path/relative/basic.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("same:", path.relative("/foo", "/foo"));
+console.log("sibling:", path.relative("/foo/a", "/foo/b"));
+console.log("deeper:", path.relative("/foo", "/foo/bar/baz"));

--- a/test-parity/node-suite/path/relative/empty-and-cwd.ts
+++ b/test-parity/node-suite/path/relative/empty-and-cwd.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("empty to cwd:", path.relative("", process.cwd()));
+console.log("cwd to empty:", path.relative(process.cwd(), ""));
+console.log("empty to child:", path.relative("", "foo/bar").endsWith(path.join("foo", "bar")));

--- a/test-parity/node-suite/path/relative/relative-inputs.ts
+++ b/test-parity/node-suite/path/relative/relative-inputs.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("same relative:", path.relative("foo/bar", "foo/bar"));
+console.log("relative sibling:", path.relative("foo/a", "foo/b"));
+console.log("relative deeper:", path.relative("foo", "foo/bar/baz"));

--- a/test-parity/node-suite/path/relative/upwards.ts
+++ b/test-parity/node-suite/path/relative/upwards.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("parent:", path.relative("/foo/bar", "/foo"));
+console.log("cousin:", path.relative("/foo/bar/baz", "/foo/qux"));
+console.log("root to nested:", path.relative("/", "/foo/bar"));

--- a/test-parity/node-suite/path/resolve/absolute-wins.ts
+++ b/test-parity/node-suite/path/resolve/absolute-wins.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("resolve later abs wins:", path.resolve("/foo", "/bar", "baz"));
+console.log("resolve final abs wins:", path.resolve("foo", "/bar"));
+console.log("resolve multiple abs:", path.resolve("/a", "/b", "/c"));

--- a/test-parity/node-suite/path/resolve/basic.ts
+++ b/test-parity/node-suite/path/resolve/basic.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("resolve abs plus rel:", path.resolve("/foo", "bar"));
+console.log("resolve dot:", path.resolve("/foo", ".", "bar"));
+console.log("resolve dotdot:", path.resolve("/foo/bar", "..", "baz"));

--- a/test-parity/node-suite/path/resolve/dot-segments.ts
+++ b/test-parity/node-suite/path/resolve/dot-segments.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("dot cwd:", path.resolve(".") === process.cwd());
+console.log("dot child:", path.resolve(".", "foo").endsWith(path.join("foo")));
+console.log("dotdot suffix:", path.resolve("foo", "..").endsWith(path.basename(process.cwd())));

--- a/test-parity/node-suite/path/resolve/empty-segments.ts
+++ b/test-parity/node-suite/path/resolve/empty-segments.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("empty arg cwd:", path.resolve("") === process.cwd());
+console.log("empty then child:", path.resolve("", "foo").endsWith(path.join("foo")));
+console.log("child then empty:", path.resolve("foo", "").endsWith(path.join("foo")));

--- a/test-parity/node-suite/path/resolve/relative-cwd.ts
+++ b/test-parity/node-suite/path/resolve/relative-cwd.ts
@@ -1,0 +1,6 @@
+import * as path from "node:path";
+
+const cwd = process.cwd();
+console.log("cwd basename:", path.basename(cwd));
+console.log("resolve relative suffix:", path.resolve("foo", "bar").endsWith(path.join("foo", "bar")));
+console.log("resolve empty is cwd:", path.resolve() === cwd);

--- a/test-parity/node-suite/path/toNamespacedPath/basic.ts
+++ b/test-parity/node-suite/path/toNamespacedPath/basic.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("absolute:", path.toNamespacedPath("/foo/bar"));
+console.log("relative:", path.toNamespacedPath("foo/bar"));
+console.log("empty:", path.toNamespacedPath(""));

--- a/test-parity/node-suite/path/win32/basename-dirname.ts
+++ b/test-parity/node-suite/path/win32/basename-dirname.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("win32 basename:", path.win32.basename("C:\\foo\\bar\\baz.txt"));
+console.log("win32 basename ext:", path.win32.basename("C:\\foo\\bar\\baz.txt", ".txt"));
+console.log("win32 dirname:", path.win32.dirname("C:\\foo\\bar\\baz.txt"));

--- a/test-parity/node-suite/path/win32/join-normalize.ts
+++ b/test-parity/node-suite/path/win32/join-normalize.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("win32 join:", path.win32.join("C:\\foo", "bar", "baz"));
+console.log("win32 join dotdot:", path.win32.join("C:\\foo", "..", "bar"));
+console.log("win32 normalize:", path.win32.normalize("C:\\foo\\bar\\..\\baz"));

--- a/test-parity/node-suite/path/win32/parse-format.ts
+++ b/test-parity/node-suite/path/win32/parse-format.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+const parsed = path.win32.parse("C:\\home\\user\\file.txt");
+console.log("win32 parse:", parsed.root, parsed.dir, parsed.base, parsed.name, parsed.ext);
+console.log("win32 format:", path.win32.format({ dir: "C:\\home\\user", name: "file", ext: ".txt" }));

--- a/test-parity/node-suite/path/win32/relative-resolve.ts
+++ b/test-parity/node-suite/path/win32/relative-resolve.ts
@@ -1,0 +1,6 @@
+import * as path from "node:path";
+
+console.log("win32 relative:", path.win32.relative("C:\\foo\\a", "C:\\foo\\b"));
+console.log("win32 resolve:", path.win32.resolve("C:\\foo", "bar"));
+console.log("win32 isAbsolute drive:", path.win32.isAbsolute("C:\\foo"));
+console.log("win32 isAbsolute slash:", path.win32.isAbsolute("\\foo"));

--- a/test-parity/node-suite/path/win32/unc-and-drive.ts
+++ b/test-parity/node-suite/path/win32/unc-and-drive.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+
+console.log("win32 normalize UNC:", path.win32.normalize("\\\\server\\share\\foo\\..\\bar"));
+console.log("win32 dirname drive relative:", path.win32.dirname("C:foo\\bar"));
+console.log("win32 parse drive root:", path.win32.parse("C:\\").root);

--- a/test-parity/node-suite/path/zero-length/core-methods.ts
+++ b/test-parity/node-suite/path/zero-length/core-methods.ts
@@ -1,0 +1,10 @@
+import * as path from "node:path";
+
+console.log("basename empty:", path.basename(""));
+console.log("dirname empty:", path.dirname(""));
+console.log("extname empty:", path.extname(""));
+console.log("isAbsolute empty:", path.isAbsolute(""));
+console.log("normalize empty:", path.normalize(""));
+console.log("join empty:", path.join(""));
+console.log("resolve empty equals cwd:", path.resolve("") === process.cwd());
+console.log("relative empty empty:", path.relative("", ""));

--- a/test-parity/node-suite/path/zero-length/parse-format.ts
+++ b/test-parity/node-suite/path/zero-length/parse-format.ts
@@ -1,0 +1,6 @@
+import * as path from "node:path";
+
+const parsed = path.parse("");
+console.log("parse empty:", parsed.root, parsed.dir, parsed.base, parsed.ext, parsed.name);
+console.log("format empty parse:", path.format(parsed));
+console.log("format all empty:", path.format({ root: "", dir: "", base: "", ext: "", name: "" }));


### PR DESCRIPTION
## Summary

Splits the monolithic `test_parity_path` fixture into ~50 per-method case files under `test-parity/node-suite/path/<method>/<case>.ts`, adds a `--suite node-suite` selector to `run_parity_tests.sh`, and fixes the runtime/codegen path bugs the new fine-grained coverage surfaces. Flips `test_parity_path` from FAIL → PASS on `origin/main`.

## Runner

New flags, backwards-compatible (default `--suite all` walks `test-files/*.ts` unchanged):

```sh
./run_parity_tests.sh --suite node-suite              # all node-suite cases
./run_parity_tests.sh --suite node-suite --module path  # just path/*
```

Each `node-suite` case is reported with a `node-suite/<module>/<method>/<case>` id so failures are localizable to a single Node-spec scenario.

## Real bug fixes the granular split surfaced

`crates/perry-runtime/src/path.rs`:
- `dirname("//foo")` preserves both leading slashes (`"//"`), as Node does. Three-or-more slashes collapse.
- `path.resolve("")` returns the current working directory (was empty string).
- `path.parse("/")` returns `{root: "/", dir: "/", base: "", …}` — root is part of the dir for the bare-root case (was `dir: ""`).
- `path.format({name, ext: "txt"})` auto-inserts the separator dot (`"file.txt"`), matching Node's leading-`.`-tolerant rule.
- `path.basename(base, ext)` strips the suffix even when the input has no slashes (`basename("foo", "foo") === ""`).
- `path.relative(from, to)` resolves both sides through the cwd-aware helper, not just `normalize`.

`crates/perry-codegen/src/expr/mod.rs`:
- `Expr::PathResolve(p)` no longer no-ops back to its argument. The arm now lowers to a `js_path_resolve` runtime call — previously `path.resolve(x)` silently returned `x` unmodified in compiled code.

`crates/perry-codegen/src/runtime_decls.rs`:
- Declares `js_path_resolve` so the new codegen arm has a callable target.

`crates/perry-hir/src/lower/expr_call/mod.rs`:
- Three arms for `path.resolve()` with zero args lower to `Expr::PathResolve(Expr::String(""))` → runtime returns `process.cwd()`. The previous variadic arm only handled `!args.is_empty()`.

## `path.win32` deferred

The five `node-suite/path/win32/*` fixtures fail because Perry doesn't yet expose the `path.win32` sub-namespace — `path.win32.basename` etc. resolve to `undefined`. Skip-listed in `test-parity/known_failures.json` pointing at the tracking issue #1162 (`feat(path): implement node:path.win32 sub-namespace`).

## Test plan

- [x] `./run_parity_tests.sh --suite node-suite --module path` → 58/63 PASS (5 win32 fails, all skip-listed against #1162)
- [x] `./run_parity_tests.sh --filter test_parity_path` → PASS (was FAIL on main)
- [x] Full `./run_parity_tests.sh` → 419/484 (92.6%), no regressions vs current `origin/main` (417/484); `test_parity_path` and `test_issue_654_typed_array_dispatch` flip from FAIL to PASS
- [x] `cargo build --release -p perry` clean
- [x] `cargo fmt --all -- --check` clean