### PR TITLE
fix(net,ws,http): #1114 — per-tick scratch-Vec in net/ws/http pumps

### DIFF
--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -1565,15 +1565,32 @@ pub unsafe extern "C" fn js_net_socket_upgrade_tls(
 /// happens HERE on the main thread, never in the tokio read task.
 ///
 /// Returns the number of events fired in this pass.
+///
+/// #1114 followup (mysql wedge): this pump runs on EVERY iteration of
+/// the generated event loop AND every iteration of every inline `await`
+/// poll loop. `@perryts/mysql` (pure-TS driver) drives all its bytes
+/// through `net.Socket`, so under a `setInterval` + async-query JobLoop
+/// this function is the dominant per-tick path. The original
+/// `Vec::drain(..).collect()` allocated a fresh Vec every call
+/// (mirroring the fastify wedge that e538caa7 fixed) → GC `madvise`
+/// page-churn. Reuse a per-thread scratch buffer (moved out across
+/// dispatch so a re-entrant pump from inside a user callback is safe;
+/// capacity retained → zero steady-state allocation).
 #[no_mangle]
 pub unsafe extern "C" fn js_net_process_pending() -> i32 {
-    let events: Vec<PendingNetEvent> = {
+    thread_local! {
+        static SCRATCH: std::cell::RefCell<Vec<PendingNetEvent>> =
+            const { std::cell::RefCell::new(Vec::new()) };
+    }
+    let mut events = SCRATCH.with(|s| std::mem::take(&mut *s.borrow_mut()));
+    events.clear();
+    {
         let mut g = statics::pending_events().lock().unwrap();
-        g.drain(..).collect()
-    };
+        events.append(&mut *g);
+    }
     let count = events.len() as i32;
 
-    for ev in events {
+    for ev in events.drain(..) {
         match ev {
             PendingNetEvent::Connect(id) => {
                 for cb in listeners_for(id, "connect") {
@@ -1715,6 +1732,16 @@ pub unsafe extern "C" fn js_net_process_pending() -> i32 {
             }
         }
     }
+
+    // Restore the (capacity-retaining) buffer to the thread-local so the
+    // next tick reuses it. A re-entrant pump call during dispatch may
+    // have left a grown buffer in the slot — keep whichever is larger.
+    SCRATCH.with(|s| {
+        let mut slot = s.borrow_mut();
+        if events.capacity() >= slot.capacity() {
+            *slot = events;
+        }
+    });
 
     count
 }

--- a/crates/perry-stdlib/src/http.rs
+++ b/crates/perry-stdlib/src/http.rs
@@ -758,16 +758,28 @@ pub unsafe extern "C" fn js_http_response_headers(handle: Handle) -> f64 {
 /// Process pending HTTP events on the main thread.
 /// Called from js_stdlib_process_pending().
 /// Returns number of events processed.
+///
+/// #1114 followup: same per-tick scratch-Vec discipline as the fastify
+/// (e538caa7), net, and ws pumps. Called every event-loop iteration +
+/// every inline `await` poll iteration; the original
+/// `Vec::drain(..).collect()` was a per-call heap alloc that contributed
+/// to the GC `madvise` churn under sustained HTTP client traffic.
 #[no_mangle]
 pub unsafe extern "C" fn js_http_process_pending() -> i32 {
-    let events: Vec<PendingHttpEvent> = {
+    thread_local! {
+        static SCRATCH: std::cell::RefCell<Vec<PendingHttpEvent>> =
+            const { std::cell::RefCell::new(Vec::new()) };
+    }
+    let mut events = SCRATCH.with(|s| std::mem::take(&mut *s.borrow_mut()));
+    events.clear();
+    {
         let mut guard = HTTP_PENDING_EVENTS.lock().unwrap();
-        guard.drain(..).collect()
-    };
+        events.append(&mut *guard);
+    }
 
     let count = events.len() as i32;
 
-    for event in events {
+    for event in events.drain(..) {
         match event {
             PendingHttpEvent::Response {
                 request_handle,
@@ -887,6 +899,16 @@ pub unsafe extern "C" fn js_http_process_pending() -> i32 {
             }
         }
     }
+
+    // Restore the (capacity-retaining) buffer to the thread-local so the
+    // next tick reuses it. A re-entrant pump call during dispatch may
+    // have left a grown buffer in the slot — keep whichever is larger.
+    SCRATCH.with(|s| {
+        let mut slot = s.borrow_mut();
+        if events.capacity() >= slot.capacity() {
+            *slot = events;
+        }
+    });
 
     count
 }

--- a/crates/perry-stdlib/src/net/mod.rs
+++ b/crates/perry-stdlib/src/net/mod.rs
@@ -960,15 +960,32 @@ pub unsafe extern "C" fn js_net_socket_upgrade_tls(
 ///
 /// Per the arena-safety rule: JSValue construction (Buffer, error string)
 /// happens HERE on the main thread, never in the tokio read task.
+///
+/// #1114 followup (mysql wedge): this pump runs on EVERY iteration of the
+/// generated event loop AND every iteration of every inline `await` poll
+/// loop. `@perryts/mysql` (pure-TS driver) drives all its bytes through
+/// `net.Socket`, so under a `setInterval` + async-query JobLoop this
+/// function is the dominant per-tick path. The original `Vec::drain(..)
+/// .collect()` allocated a fresh Vec every call (mirroring the fastify
+/// wedge that e538caa7 fixed) → GC `madvise` page-churn. Reuse a
+/// per-thread scratch buffer (moved out across dispatch so a re-entrant
+/// pump from inside a user callback is safe; capacity retained → zero
+/// steady-state allocation).
 #[no_mangle]
 pub unsafe extern "C" fn js_net_process_pending() -> i32 {
-    let events: Vec<PendingNetEvent> = {
+    thread_local! {
+        static SCRATCH: std::cell::RefCell<Vec<PendingNetEvent>> =
+            const { std::cell::RefCell::new(Vec::new()) };
+    }
+    let mut events = SCRATCH.with(|s| std::mem::take(&mut *s.borrow_mut()));
+    events.clear();
+    {
         let mut g = NET_PENDING_EVENTS.lock().unwrap();
-        g.drain(..).collect()
-    };
+        events.append(&mut *g);
+    }
     let count = events.len() as i32;
 
-    for ev in events {
+    for ev in events.drain(..) {
         match ev {
             PendingNetEvent::Connect(id) => {
                 for cb in listeners_for(id, "connect") {
@@ -1025,6 +1042,16 @@ pub unsafe extern "C" fn js_net_process_pending() -> i32 {
             }
         }
     }
+
+    // Restore the (capacity-retaining) buffer to the thread-local so the
+    // next tick reuses it. A re-entrant pump call during dispatch may
+    // have left a grown buffer in the slot — keep whichever is larger.
+    SCRATCH.with(|s| {
+        let mut slot = s.borrow_mut();
+        if events.capacity() >= slot.capacity() {
+            *slot = events;
+        }
+    });
 
     count
 }

--- a/crates/perry-stdlib/src/ws.rs
+++ b/crates/perry-stdlib/src/ws.rs
@@ -1139,17 +1139,32 @@ pub fn js_ws_has_active_handles() -> i32 {
 /// Process pending WebSocket events (called from js_stdlib_process_pending)
 /// Drains the event queue and invokes closures on the main thread.
 /// Returns number of events processed.
+///
+/// #1114 followup: same per-tick scratch-Vec discipline as the fastify
+/// (e538caa7) and net (this PR) pumps. Called every event-loop iteration
+/// + every inline `await` poll iteration; the original
+/// `Vec::drain(..).collect()` was a per-call heap alloc that contributed
+/// to the GC `madvise` churn observed under shop-admin's realtime WS
+/// broker + JobLoop combo. Reuse a per-thread scratch buffer (moved out
+/// across dispatch so a re-entrant pump from inside a user callback is
+/// safe).
 #[cfg(not(target_os = "ios"))]
 #[no_mangle]
 pub unsafe extern "C" fn js_ws_process_pending() -> i32 {
-    let events: Vec<PendingWsEvent> = {
+    thread_local! {
+        static SCRATCH: std::cell::RefCell<Vec<PendingWsEvent>> =
+            const { std::cell::RefCell::new(Vec::new()) };
+    }
+    let mut events = SCRATCH.with(|s| std::mem::take(&mut *s.borrow_mut()));
+    events.clear();
+    {
         let mut guard = WS_PENDING_EVENTS.lock().unwrap();
-        guard.drain(..).collect()
-    };
+        events.append(&mut *guard);
+    }
 
     let count = events.len() as i32;
 
-    for event in events {
+    for event in events.drain(..) {
         match event {
             PendingWsEvent::Connection(server_handle, client_ws_id) => {
                 // Get 'connection' listeners from server
@@ -1316,6 +1331,16 @@ pub unsafe extern "C" fn js_ws_process_pending() -> i32 {
             }
         }
     }
+
+    // Restore the (capacity-retaining) buffer to the thread-local so the
+    // next tick reuses it. A re-entrant pump call during dispatch may
+    // have left a grown buffer in the slot — keep whichever is larger.
+    SCRATCH.with(|s| {
+        let mut slot = s.borrow_mut();
+        if events.capacity() >= slot.capacity() {
+            *slot = events;
+        }
+    });
 
     count
 }


### PR DESCRIPTION
## Summary

- e538caa7 (#1144) fixed the fastify half of #1114, but `@perryts/mysql` is a pure-TS driver whose bytes ride `net.Socket` — not fastify. The JobLoop's `setInterval` + async-MySQL tick still wedges on v0.5.1014.
- `js_net_process_pending` had the *exact* `Vec::drain(..).collect()` shape that the fastify pump had pre-e538caa7: a fresh `Vec<PendingNetEvent>` heap alloc on every event-loop iteration AND every inline `await`-poll iteration. Same pattern unfixed in `js_ws_process_pending` and `js_http_process_pending`.
- Mirror the e538caa7 thread-local scratch-Vec discipline in all four pumps. `mem::take` makes a re-entrant pump (user callback that inline-awaits back into the loop) safe; `Vec::append` moves queue contents in-place where `drain+collect` always allocates the collect target.

## Files

- `crates/perry-stdlib/src/net/mod.rs` — bundled-net path
- `crates/perry-ext-net/src/lib.rs` — well-known-flip net path
- `crates/perry-stdlib/src/ws.rs` — bundled-ws
- `crates/perry-stdlib/src/http.rs` — bundled HTTP client

## Test plan

- [x] `cargo test --release -p perry-stdlib --lib` — 63/63 green
- [x] `cargo test --release -p perry-ext-net` — 3/3 green
- [x] `cargo test --release -p perry-runtime --lib event_pump` — 4/4 green (incl. e538caa7's `sustained_budget_zero_spin_is_throttled`)
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` — clean
- [x] `cargo fmt --check` — clean
- [ ] **Shop-admin smoke** — re-enable `new JobLoop().start()` in `server/main.ts` against this branch, confirm `/healthz` stays responsive + CPU stays low under the `setInterval` + `@perryts/mysql claimJobs` tick. Synthetic `/tmp/repro1114_real` didn't trigger the wedge even with real MySQL (scale-bound trigger documented in v0.5.1013's CHANGELOG), so final verification needs the actual ~68-file unit.

Per CLAUDE.md's "External contributor PRs" convention, this PR does **not** touch `Cargo.toml` `[workspace.package] version`, the `**Current Version:**` line in `CLAUDE.md`, or `CHANGELOG.md` — leaving those for the maintainer at merge time.

Refs #1114.