### PR TITLE
v0.5.1016: docs(cli) — list every real --target in `perry compile --help` (#1119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1016 — docs(cli): list every real `--target` in `perry compile --help` (#1119)
+
+The clap doc-comment on `CompileArgs.target` listed only `ios-simulator, ios, android, ios-widget, ios-widget-simulator` — omitting `web`, `wasm`, `visionos[-simulator]`, `watchos-widget[-simulator]`, `android-widget`, `wearos-tile`, `windows`, and `linux`, even though `docs/src/cli/flags.md` already documents the full set and `--target web` is the official path for browser-runnable WASM. People scaffolding new web projects against Perry hit `perry compile --help` first, found no `web` target, and assumed it wasn't supported.
+
+Fix is doc-comment-only at `crates/perry/src/commands/compile.rs:327` — list every target the docs already cover, point at `docs/src/cli/flags.md` for the full table. No behavior change.
+
 ## v0.5.1015 — feat(stdlib): implement `node:querystring` (#1151) + fix latent SSO bugs
 
 Lands [TheHypnoo](https://github.com/TheHypnoo)'s `node:querystring` implementation as a direct cherry-pick onto main (PR #1151 went DIRTY against post-#1146 main and the contributor's fork has no "Allow edits by maintainers"). Greenfield: `escape` / `unescape` / `parse` / `stringify` + `decode` / `encode` aliases, six matching `NativeModSig` rows, API-manifest entries, and removal of `test_parity_querystring` from `known_failures.json`. Parity goes byte-for-byte against `node --experimental-strip-types`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1015
+**Current Version:** 0.5.1016
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5084,7 +5084,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "base64",
@@ -5139,14 +5139,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "log",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5168,7 +5168,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "base64",
@@ -5208,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "serde",
  "serde_json",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1015"
+version = "0.5.1016"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "clap",
@@ -5250,14 +5250,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5298,14 +5298,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "chrono",
  "cron",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5322,7 +5322,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5338,7 +5338,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5346,21 +5346,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5387,14 +5387,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-google-auth"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5425,7 +5425,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5446,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5462,7 +5462,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "bson",
  "futures-util",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5514,7 +5514,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5522,7 +5522,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "base64",
  "image",
@@ -5548,14 +5548,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5592,7 +5592,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "dashmap 6.1.0",
  "once_cell",
@@ -5609,7 +5609,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5665,7 +5665,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "base64",
@@ -5690,7 +5690,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5763,7 +5763,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5781,11 +5781,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1015"
+version = "0.5.1016"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "base64",
  "itoa",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5811,7 +5811,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "base64",
  "block2",
@@ -5848,7 +5848,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "base64",
  "block2",
@@ -5867,11 +5867,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1015"
+version = "0.5.1016"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "base64",
  "block2",
@@ -5887,7 +5887,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "base64",
  "block2",
@@ -5903,7 +5903,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "block2",
  "libc",
@@ -5916,7 +5916,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "base64",
  "libc",
@@ -5931,7 +5931,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5945,7 +5945,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1015"
+version = "0.5.1016"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1015"
+version = "0.5.1016"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -324,7 +324,11 @@ pub struct CompileArgs {
     #[arg(long)]
     pub enable_wasm_runtime: bool,
 
-    /// Target platform: ios-simulator, ios, android, ios-widget, ios-widget-simulator (default: native host)
+    /// Target platform: ios-simulator, ios, visionos-simulator, visionos,
+    /// android, ios-widget, ios-widget-simulator, watchos-widget,
+    /// watchos-widget-simulator, android-widget, wearos-tile, web, wasm,
+    /// windows, linux (default: native host). See docs/src/cli/flags.md
+    /// for the full target table.
     #[arg(long)]
     pub target: Option<String>,
 


### PR DESCRIPTION
## Summary

Fixes #1119. The `--target` doc-comment in `crates/perry/src/commands/compile.rs:327` listed only:

> ios-simulator, ios, android, ios-widget, ios-widget-simulator (default: native host)

but `docs/src/cli/flags.md` already documents a much larger set including `web`, `wasm`, `visionos[-simulator]`, `watchos-widget[-simulator]`, `android-widget`, `wearos-tile`, `windows`, and `linux`. `--target web` is the official path for browser-runnable WASM (downstream packages like `@honeide/editor` document it), and the help string drove people scaffolding new web projects to assume the target wasn't supported.

## Change

Doc-comment-only. New help text lists every target the docs table already covers and points readers at `docs/src/cli/flags.md` for the full table. No behavior change.

```
--target <TARGET>
    Target platform: ios-simulator, ios, visionos-simulator, visionos,
    android, ios-widget, ios-widget-simulator, watchos-widget,
    watchos-widget-simulator, android-widget, wearos-tile, web, wasm,
    windows, linux (default: native host). See docs/src/cli/flags.md
    for the full target table
```

## Test plan

- [x] `cargo build --release -p perry --bin perry` — clean
- [x] `./target/release/perry compile --help | grep -A1 'target <TARGET>'` — shows `web` and `wasm` in the listed targets