### PR TITLE
feat(parity): granular node:querystring suite + querystring runtime fixes

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table.rs
+++ b/crates/perry-codegen/src/lower_call/native_table.rs
@@ -1840,7 +1840,7 @@ pub(super) const NATIVE_MODULE_TABLE: &[NativeModSig] = &[
         method: "parse",
         class_filter: None,
         runtime: "js_querystring_parse",
-        args: &[NA_F64, NA_F64, NA_F64],
+        args: &[NA_F64, NA_F64, NA_F64, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -1849,7 +1849,7 @@ pub(super) const NATIVE_MODULE_TABLE: &[NativeModSig] = &[
         method: "decode",
         class_filter: None,
         runtime: "js_querystring_parse",
-        args: &[NA_F64, NA_F64, NA_F64],
+        args: &[NA_F64, NA_F64, NA_F64, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -2542,7 +2542,11 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // STRING_TAG value directly.
     module.declare_function("js_querystring_escape", DOUBLE, &[DOUBLE]);
     module.declare_function("js_querystring_unescape", DOUBLE, &[DOUBLE]);
-    module.declare_function("js_querystring_parse", I64, &[DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function(
+        "js_querystring_parse",
+        I64,
+        &[DOUBLE, DOUBLE, DOUBLE, DOUBLE],
+    );
     module.declare_function(
         "js_querystring_stringify",
         DOUBLE,

--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -116,7 +116,7 @@ fn percent_encode(input: &str) -> String {
     out
 }
 
-fn percent_decode(input: &str) -> String {
+fn percent_decode(input: &str, plus_as_space: bool) -> String {
     let bytes = input.as_bytes();
     let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
     let mut i = 0;
@@ -141,9 +141,7 @@ fn percent_decode(input: &str) -> String {
                 }
             }
         }
-        // Node's `unescape` also turns `+` into space, matching the
-        // historical `application/x-www-form-urlencoded` rule.
-        if b == b'+' {
+        if plus_as_space && b == b'+' {
             out.push(b' ');
         } else {
             out.push(b);
@@ -179,54 +177,85 @@ pub unsafe extern "C" fn js_querystring_unescape(str_arg: f64) -> f64 {
         Some(s) => s,
         None => return f64::from_bits(JSValue::undefined().bits()),
     };
-    nanbox_string(intern_string(&percent_decode(&s)))
+    nanbox_string(intern_string(&percent_decode(&s, false)))
 }
 
-/// Default separators if the caller didn't pass one. Node uses `&` and
-/// `=`; passing `undefined` for either falls back to the default.
-fn resolve_separator(value: f64, default_byte: u8) -> u8 {
-    let bits = value.to_bits();
-    if bits == JSValue::undefined().bits() || bits == JSValue::null().bits() {
-        return default_byte;
-    }
-    match unsafe { nanboxed_to_string(value) } {
-        Some(s) if !s.is_empty() => s.as_bytes()[0],
-        _ => default_byte,
-    }
-}
-
-/// `querystring.parse(str, sep?, eq?)` → object. Repeated keys produce
+/// `querystring.parse(str, sep?, eq?, options?)` → object. Repeated keys produce
 /// array values. Empty input returns an empty object.
 #[no_mangle]
 pub unsafe extern "C" fn js_querystring_parse(
     str_arg: f64,
     sep_arg: f64,
     eq_arg: f64,
+    options_arg: f64,
 ) -> *mut ObjectHeader {
     let input = nanboxed_to_string(str_arg).unwrap_or_default();
-    let sep = resolve_separator(sep_arg, b'&');
-    let eq = resolve_separator(eq_arg, b'=');
+    let sep = resolve_separator_str(sep_arg, "&");
+    let eq = resolve_separator_str(eq_arg, "=");
+    let max_keys = resolve_max_keys(options_arg);
 
     let obj = js_object_alloc(0, 0);
     if input.is_empty() {
         return obj;
     }
 
-    for pair in input.as_bytes().split(|&c| c == sep) {
+    let pairs: Box<dyn Iterator<Item = &str>> = if sep.is_empty() {
+        Box::new(std::iter::once(input.as_str()))
+    } else {
+        Box::new(input.split(sep.as_str()))
+    };
+    let mut parsed = 0usize;
+    for pair in pairs {
+        if let Some(limit) = max_keys {
+            if parsed >= limit {
+                break;
+            }
+        }
         if pair.is_empty() {
             continue;
         }
-        let (key_bytes, val_bytes) = match pair.iter().position(|&c| c == eq) {
-            Some(p) => (&pair[..p], &pair[p + 1..]),
-            None => (pair, &b""[..]),
+        let (key_raw, val_raw) = if eq.is_empty() {
+            (pair, "")
+        } else {
+            match pair.find(eq.as_str()) {
+                Some(p) => (&pair[..p], &pair[p + eq.len()..]),
+                None => (pair, ""),
+            }
         };
-        let key_raw = std::str::from_utf8(key_bytes).unwrap_or("");
-        let val_raw = std::str::from_utf8(val_bytes).unwrap_or("");
-        let key = percent_decode(key_raw);
-        let value = percent_decode(val_raw);
+        let key = percent_decode(key_raw, true);
+        let value = percent_decode(val_raw, true);
         push_parsed_pair(obj, &key, &value);
+        parsed += 1;
     }
     obj
+}
+
+fn resolve_max_keys(options: f64) -> Option<usize> {
+    let value = JSValue::from_bits(options.to_bits());
+    if !value.is_pointer() {
+        return Some(1000);
+    }
+    let obj = value.as_pointer::<ObjectHeader>();
+    if obj.is_null() {
+        return Some(1000);
+    }
+    let key = intern_string("maxKeys");
+    let max_keys = unsafe { js_object_get_field_by_name(obj, key) };
+    if max_keys.is_undefined() || max_keys.is_null() {
+        return Some(1000);
+    }
+    let n = if max_keys.is_int32() {
+        max_keys.as_int32() as f64
+    } else if max_keys.is_number() {
+        max_keys.as_number()
+    } else {
+        return Some(1000);
+    };
+    if n <= 0.0 || !n.is_finite() {
+        None
+    } else {
+        Some(n.floor() as usize)
+    }
 }
 
 /// Insert `(key, value)` into the parse result, promoting to an array
@@ -317,9 +346,7 @@ fn resolve_separator_str(value: f64, default: &'static str) -> String {
     }
 }
 
-/// Append `key=value` (or `key=v1&key=v2` for arrays) to `out`. Skips
-/// non-stringifiable values to match Node's filter (functions, symbols
-/// get dropped silently).
+/// Append `key=value` (or `key=v1&key=v2` for arrays) to `out`.
 unsafe fn append_stringify_value(
     out: &mut String,
     key: &str,
@@ -344,10 +371,7 @@ unsafe fn append_stringify_value(
                 let n = js_array_length(arr);
                 for i in 0..n {
                     let elem = perry_runtime::array::js_array_get_f64(arr, i);
-                    let elem_str = match nanboxed_to_string(elem) {
-                        Some(s) => s,
-                        None => continue,
-                    };
+                    let elem_str = querystring_scalar_to_string(elem.to_bits());
                     if !out.is_empty() {
                         out.push_str(sep);
                     }
@@ -360,14 +384,41 @@ unsafe fn append_stringify_value(
         }
     }
 
-    let value_str = match nanboxed_to_string(value_f64) {
-        Some(s) => s,
-        None => return,
-    };
+    let value_str = querystring_scalar_to_string(value_f64.to_bits());
     if !out.is_empty() {
         out.push_str(sep);
     }
     out.push_str(&percent_encode(key));
     out.push_str(eq);
     out.push_str(&percent_encode(&value_str));
+}
+
+fn querystring_scalar_to_string(value_bits: u64) -> String {
+    let value = JSValue::from_bits(value_bits);
+    if value.is_undefined() || value.is_null() {
+        return String::new();
+    }
+    if perry_runtime::date::is_registered_date_bits(value_bits) {
+        return String::new();
+    }
+    if value.is_bool() {
+        return value.as_bool().to_string();
+    }
+    if value.is_int32() {
+        return value.as_int32().to_string();
+    }
+    if value.is_number() {
+        let n = value.as_number();
+        if !n.is_finite() {
+            return String::new();
+        }
+        if n.fract() == 0.0 {
+            return (n as i64).to_string();
+        }
+        return n.to_string();
+    }
+    if value.is_any_string() {
+        return unsafe { nanboxed_to_string(f64::from_bits(value_bits)) }.unwrap_or_default();
+    }
+    String::new()
 }

--- a/test-parity/node-suite/querystring/README.md
+++ b/test-parity/node-suite/querystring/README.md
@@ -1,0 +1,5 @@
+# node:querystring parity suite
+
+Granular Node compatibility cases for the legacy `node:querystring` module.
+Cases are curated from Node behavior and kept small so parse/stringify/escaping
+failures point to one API shape.

--- a/test-parity/node-suite/querystring/aliases/decode-encode.ts
+++ b/test-parity/node-suite/querystring/aliases/decode-encode.ts
@@ -1,0 +1,6 @@
+import * as querystring from "node:querystring";
+
+console.log("decode parse same:", querystring.decode === querystring.parse);
+console.log("encode stringify same:", querystring.encode === querystring.stringify);
+console.log("decode:", JSON.stringify(querystring.decode("x=1")));
+console.log("encode:", querystring.encode({ x: "1" }));

--- a/test-parity/node-suite/querystring/escape/basic.ts
+++ b/test-parity/node-suite/querystring/escape/basic.ts
@@ -1,0 +1,6 @@
+import { escape } from "node:querystring";
+
+console.log("ascii:", escape("hello"));
+console.log("space:", escape("hello world"));
+console.log("reserved:", escape("a&b=c"));
+console.log("symbols:", escape("!*'()~"));

--- a/test-parity/node-suite/querystring/escape/utf8.ts
+++ b/test-parity/node-suite/querystring/escape/utf8.ts
@@ -1,0 +1,5 @@
+import { escape } from "node:querystring";
+
+console.log("latin1:", escape("café"));
+console.log("emoji:", escape("🙂"));
+console.log("mixed:", escape("a b/café"));

--- a/test-parity/node-suite/querystring/imports/namespace-import.ts
+++ b/test-parity/node-suite/querystring/imports/namespace-import.ts
@@ -1,0 +1,5 @@
+import * as querystring from "node:querystring";
+
+console.log("escape:", querystring.escape("hello world"));
+console.log("parse:", JSON.stringify(querystring.parse("a=1")));
+console.log("stringify:", querystring.stringify({ a: "1" }));

--- a/test-parity/node-suite/querystring/imports/node-prefixless.ts
+++ b/test-parity/node-suite/querystring/imports/node-prefixless.ts
@@ -1,0 +1,4 @@
+import { parse, stringify } from "querystring";
+
+console.log("parse:", JSON.stringify(parse("a=1&b=2")));
+console.log("stringify:", stringify({ a: "1", b: "2" }));

--- a/test-parity/node-suite/querystring/options/parse-max-keys.ts
+++ b/test-parity/node-suite/querystring/options/parse-max-keys.ts
@@ -1,0 +1,7 @@
+import { parse } from "node:querystring";
+
+console.log("max 2:", JSON.stringify(parse("a=1&b=2&c=3", undefined, undefined, { maxKeys: 2 })));
+console.log("max 0:", JSON.stringify(parse("a=1&b=2&c=3", undefined, undefined, { maxKeys: 0 })));
+console.log("max negative:", JSON.stringify(parse("a=1&b=2&c=3", undefined, undefined, { maxKeys: -1 })));
+console.log("max infinity:", JSON.stringify(parse("a=1&b=2&c=3", undefined, undefined, { maxKeys: Infinity })));
+console.log("max nan:", JSON.stringify(parse("a=1&b=2&c=3", undefined, undefined, { maxKeys: NaN })));

--- a/test-parity/node-suite/querystring/parse/basic.ts
+++ b/test-parity/node-suite/querystring/parse/basic.ts
@@ -1,0 +1,6 @@
+import { parse } from "node:querystring";
+
+const parsed = parse("a=1&b=2");
+console.log("a:", parsed.a);
+console.log("b:", parsed.b);
+console.log("keys:", Object.keys(parsed).join(","));

--- a/test-parity/node-suite/querystring/parse/custom-separators.ts
+++ b/test-parity/node-suite/querystring/parse/custom-separators.ts
@@ -1,0 +1,6 @@
+import { parse } from "node:querystring";
+
+const parsed = parse("a:1;b:2;a:3", ";", ":");
+console.log("a array:", Array.isArray(parsed.a));
+console.log("a:", (parsed.a as string[]).join(","));
+console.log("b:", parsed.b);

--- a/test-parity/node-suite/querystring/parse/empty-and-separators.ts
+++ b/test-parity/node-suite/querystring/parse/empty-and-separators.ts
@@ -1,0 +1,9 @@
+import { parse } from "node:querystring";
+
+function keyCount(value: object): number {
+  return Object.keys(value).length;
+}
+
+console.log("empty keys:", keyCount(parse("")));
+console.log("only separators keys:", keyCount(parse("&&&")));
+console.log("extra separators:", JSON.stringify(parse("&&a=1&&b=2&")));

--- a/test-parity/node-suite/querystring/parse/encoded-delimiters.ts
+++ b/test-parity/node-suite/querystring/parse/encoded-delimiters.ts
@@ -1,0 +1,5 @@
+import { parse } from "node:querystring";
+
+const parsed = parse("a%3Db=c%26d&x%26y=1%3D2");
+console.log("a=b:", parsed["a=b"]);
+console.log("x&y:", parsed["x&y"]);

--- a/test-parity/node-suite/querystring/parse/encoded.ts
+++ b/test-parity/node-suite/querystring/parse/encoded.ts
@@ -1,0 +1,6 @@
+import { parse } from "node:querystring";
+
+const parsed = parse("a%20b=c%20d&caf%C3%A9=ol%C3%A9&plus=a+b");
+console.log("space key:", parsed["a b"]);
+console.log("utf8 key:", parsed["café"]);
+console.log("plus:", parsed.plus);

--- a/test-parity/node-suite/querystring/parse/equals-in-value.ts
+++ b/test-parity/node-suite/querystring/parse/equals-in-value.ts
@@ -1,0 +1,6 @@
+import { parse } from "node:querystring";
+
+const parsed = parse("a=b=c&d=e&x==y");
+console.log("a:", parsed.a);
+console.log("d:", parsed.d);
+console.log("x:", parsed.x);

--- a/test-parity/node-suite/querystring/parse/missing-values.ts
+++ b/test-parity/node-suite/querystring/parse/missing-values.ts
@@ -1,0 +1,7 @@
+import { parse } from "node:querystring";
+
+const parsed = parse("a&b=&=emptykey&c=3");
+console.log("a:", JSON.stringify(parsed.a));
+console.log("b:", JSON.stringify(parsed.b));
+console.log("empty key:", JSON.stringify(parsed[""]));
+console.log("c:", parsed.c);

--- a/test-parity/node-suite/querystring/parse/multi-char-separators.ts
+++ b/test-parity/node-suite/querystring/parse/multi-char-separators.ts
@@ -1,0 +1,6 @@
+import { parse } from "node:querystring";
+
+const parsed = parse("a::1;;b::2;;a::3", ";;", "::");
+console.log("a array:", Array.isArray(parsed.a));
+console.log("a:", (parsed.a as string[]).join(","));
+console.log("b:", parsed.b);

--- a/test-parity/node-suite/querystring/parse/no-eq-repeated.ts
+++ b/test-parity/node-suite/querystring/parse/no-eq-repeated.ts
@@ -1,0 +1,6 @@
+import { parse } from "node:querystring";
+
+const parsed = parse("a&a=2&b");
+console.log("a array:", Array.isArray(parsed.a));
+console.log("a:", (parsed.a as string[]).join(","));
+console.log("b:", JSON.stringify(parsed.b));

--- a/test-parity/node-suite/querystring/parse/repeated-keys.ts
+++ b/test-parity/node-suite/querystring/parse/repeated-keys.ts
@@ -1,0 +1,5 @@
+import { parse } from "node:querystring";
+
+const parsed = parse("a=1&a=2&a=3");
+console.log("is array:", Array.isArray(parsed.a));
+console.log("joined:", (parsed.a as string[]).join(","));

--- a/test-parity/node-suite/querystring/roundtrip/basic.ts
+++ b/test-parity/node-suite/querystring/roundtrip/basic.ts
@@ -1,0 +1,9 @@
+import { parse, stringify } from "node:querystring";
+
+const input = { a: "1", b: "hello world", café: "olé" };
+const encoded = stringify(input);
+const parsed = parse(encoded);
+console.log("encoded:", encoded);
+console.log("a:", parsed.a);
+console.log("b:", parsed.b);
+console.log("café:", parsed.café);

--- a/test-parity/node-suite/querystring/roundtrip/repeated.ts
+++ b/test-parity/node-suite/querystring/roundtrip/repeated.ts
@@ -1,0 +1,8 @@
+import { parse, stringify } from "node:querystring";
+
+const encoded = stringify({ a: ["1", "2"], b: "x" });
+const parsed = parse(encoded);
+console.log("encoded:", encoded);
+console.log("a array:", Array.isArray(parsed.a));
+console.log("a:", (parsed.a as string[]).join(","));
+console.log("b:", parsed.b);

--- a/test-parity/node-suite/querystring/stringify/arrays.ts
+++ b/test-parity/node-suite/querystring/stringify/arrays.ts
@@ -1,0 +1,4 @@
+import { stringify } from "node:querystring";
+
+console.log("array:", stringify({ a: ["1", "2", "3"] }));
+console.log("mixed:", stringify({ a: ["1", "2"], b: "x" }));

--- a/test-parity/node-suite/querystring/stringify/basic.ts
+++ b/test-parity/node-suite/querystring/stringify/basic.ts
@@ -1,0 +1,5 @@
+import { stringify } from "node:querystring";
+
+console.log("basic:", stringify({ a: "1", b: "2" }));
+console.log("number bool:", stringify({ n: 42, ok: true }));
+console.log("empty obj:", stringify({}));

--- a/test-parity/node-suite/querystring/stringify/custom-separators.ts
+++ b/test-parity/node-suite/querystring/stringify/custom-separators.ts
@@ -1,0 +1,4 @@
+import { stringify } from "node:querystring";
+
+console.log("custom:", stringify({ a: "1", b: "2" }, ";", ":"));
+console.log("custom array:", stringify({ a: ["1", "2"] }, ";", ":"));

--- a/test-parity/node-suite/querystring/stringify/encoded.ts
+++ b/test-parity/node-suite/querystring/stringify/encoded.ts
@@ -1,0 +1,5 @@
+import { stringify } from "node:querystring";
+
+console.log("space:", stringify({ "a b": "c d" }));
+console.log("utf8:", stringify({ café: "olé" }));
+console.log("reserved:", stringify({ "a&b": "c=d" }));

--- a/test-parity/node-suite/querystring/stringify/multi-char-separators.ts
+++ b/test-parity/node-suite/querystring/stringify/multi-char-separators.ts
@@ -1,0 +1,4 @@
+import { stringify } from "node:querystring";
+
+console.log("multi:", stringify({ a: "1", b: "2" }, ";;", "::"));
+console.log("multi array:", stringify({ a: ["1", "2"], b: "3" }, ";;", "::"));

--- a/test-parity/node-suite/querystring/stringify/non-string-primitives.ts
+++ b/test-parity/node-suite/querystring/stringify/non-string-primitives.ts
@@ -1,0 +1,5 @@
+import { stringify } from "node:querystring";
+
+console.log("number bool:", stringify({ n: 42, ok: true, no: false }));
+console.log("nan inf:", stringify({ nan: NaN, inf: Infinity, negInf: -Infinity }));
+console.log("object date:", stringify({ o: { x: 1 }, d: new Date(0) }));

--- a/test-parity/node-suite/querystring/stringify/null-undefined.ts
+++ b/test-parity/node-suite/querystring/stringify/null-undefined.ts
@@ -1,0 +1,4 @@
+import { stringify } from "node:querystring";
+
+console.log("null undefined empty:", stringify({ a: null, b: undefined, c: "" }));
+console.log("array null undefined:", stringify({ a: [null, undefined, "", "x"] }));

--- a/test-parity/node-suite/querystring/unescape/basic.ts
+++ b/test-parity/node-suite/querystring/unescape/basic.ts
@@ -1,0 +1,6 @@
+import { unescape } from "node:querystring";
+
+console.log("space:", unescape("hello%20world"));
+console.log("reserved:", unescape("a%26b%3Dc"));
+console.log("plus:", unescape("a+b+c"));
+console.log("invalid percent:", unescape("abc%zzdef"));

--- a/test-parity/node-suite/querystring/unescape/utf8.ts
+++ b/test-parity/node-suite/querystring/unescape/utf8.ts
@@ -1,0 +1,5 @@
+import { unescape } from "node:querystring";
+
+console.log("latin1:", unescape("caf%C3%A9"));
+console.log("emoji:", unescape("%F0%9F%99%82"));
+console.log("mixed:", unescape("a%20b%2Fcaf%C3%A9"));


### PR DESCRIPTION
## Summary

- Splits node:querystring parity into per-method case files under `test-parity/node-suite/querystring/<method>/<case>.ts`, mirroring the node:path layout from #1163. Picks up `--suite node-suite` without touching `run_parity_tests.sh`.
- Fixes three behavioral divergences surfaced by the new cases: `unescape` no longer turns `+` into space; `parse` accepts the `options.maxKeys` argument (default 1000, 0/negative/NaN/Infinity disable the limit); multi-character `sep`/`eq` are honored.
- Tightens `stringify` value coercion via `querystring_scalar_to_string` (NaN/±Infinity, Date, and non-primitive objects → empty string), so the filter matches Node.

## Test plan

- [ ] `cargo build --release -p perry-runtime -p perry-stdlib -p perry`
- [ ] `./run_parity_tests.sh --suite node-suite --module querystring` — all cases PASS against `node --experimental-strip-types`
- [ ] `./run_parity_tests.sh` full sweep — no regressions
- [ ] `cargo test --release --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-visionos --exclude perry-ui-android --exclude perry-ui-windows --exclude perry-ui-gtk4`

## Notes

- No version bump or CHANGELOG entry (maintainer folds in at merge time).
- Native ABI widened: `js_querystring_parse` now takes 4 f64 args; updated in `native_table.rs` and `runtime_decls.rs`.