### PR TITLE
fix(codegen): declare cross-module method wrappers in consumer TU (#1126)

### DIFF
--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -6568,7 +6568,24 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // so callers can invoke via the closure-call ABI. The
             // `__perry_wrap_<fn>` symbol is emitted by compile_module
             // for every user function.
+            //
+            // #1126: when the resolved parent method lives in a DIFFERENT
+            // module (typical with cross-module class inheritance —
+            // rxjs's `OperatorSubscriber extends Subscriber` where
+            // `super.complete` / `super._complete` refer to Subscriber.ts's
+            // methods), the wrapper's `define` lives in the source TU but
+            // is referenced from this consumer TU. LLVM per-TU IR
+            // validation rejects the reference unless we forward-declare
+            // the symbol. Push into `pending_declares` — `declare_function`
+            // dedupes against any later same-TU `define` (`module.rs:67-69`
+            // comment) so this is safe for the same-module case too. The
+            // signature is informational only (runtime dispatches via
+            // ClosureHeader's func_ptr); use the same `(i64)` + 0 doubles
+            // shape the imported-function-ref site at `expr/mod.rs:12331`
+            // uses for unknown-arity imports.
             let wrap_name = format!("__perry_wrap_{}", fn_name);
+            ctx.pending_declares
+                .push((wrap_name.clone(), DOUBLE, vec![I64]));
             let blk = ctx.block();
             let wrap_ptr = format!("@{}", wrap_name);
             let closure_handle = blk.call(I64, "js_closure_alloc_singleton", &[(PTR, &wrap_ptr)]);


### PR DESCRIPTION
## Summary

Fixes #1126. `Expr::SuperPropertyGet` (value form `const f = super.foo`) emits `js_closure_alloc_singleton(@__perry_wrap_<fn>)` against the resolved parent method's wrapper. When the parent class lives in a *different* module — the common npm-package pattern where a derived class overrides hook methods on an imported parent (rxjs's `OperatorSubscriber extends Subscriber`, delegating \`_next\` / \`_error\` / \`_complete\` to \`super\`) — the wrapper's \`define\` is in the source class's LLVM TU, but the consumer TU never forward-declared the symbol. clang failed per-TU IR validation with:

```
error: use of undefined value '@__perry_wrap_perry_method_..._Subscriber___complete'
```

That cascaded: `OperatorSubscriber.ts` couldn't compile → the empty-stub fallback only emits the `__init` symbol (not class methods/constructors) → every downstream rxjs operator that referenced `OperatorSubscriber::unsubscribe` or its constructor failed to link (`LNK2019` on MSVC, `Undefined symbol` on macOS ld). 226 modules succeeded, 1 failure, link death. The repro is the canonical 5-line rxjs Subject test from the issue body — every rxjs user hits this.

## Fix

`crates/perry-codegen/src/expr/mod.rs` `Expr::SuperPropertyGet`: push `(__perry_wrap_<fn>, double, [i64])` into `pending_declares` before emitting the singleton call.

`LlModule::declare_function` (`module.rs:67`) is dedupe-by-name and the comment explicitly notes:
> If a function with the same name is later *defined* in this module, the declaration is dropped at `to_ir` time so LLVM doesn't see both.

So this is safe for the same-module case (the declaration is dropped, no duplicate symbol) and unblocks the cross-module case. Signature is informational per the existing pattern at `expr/mod.rs:12331`:
> The signature is for LLVM-IR well-formedness only — the runtime closure-call machinery casts the func_ptr to its own ABI at dispatch time

## Test plan

- [x] Issue-body 5-line rxjs repro (`import { Subject } from 'rxjs'; new Subject().subscribe(v => console.log(v)); .next(1)`): pre-fix dies with `Error compiling module 'OperatorSubscriber.ts'` + 28 downstream `LNK2019` undefined-symbol errors. Post-fix all 227 modules compile, link succeeds, the 2.0 MB binary prints `1`.
- [x] Same-module value-form `super.foo` smoke test (`class B { greet(n){...} } class D extends B { f(n){ const g = super.greet; return g(n) } }`) still prints `Hello, world` (the declare drops at to_ir time, no LLVM duplicate-symbol).
- [x] `cargo test --release -p perry-codegen` clean
- [x] `cargo test --release --workspace --exclude perry-ui-...` clean

The cascading link-error path from #1126's body (when ANY module fails to compile, the empty-stub fallback doesn't synthesize method/constructor symbols for downstream modules) is not separately fixed in this PR — but no longer fires because there's no failed-module to stub.