### PR TITLE
fix(stdlib+ext-fastify): #1120 — fastify Buffer/Uint8Array bodies + auto-HEAD-for-GET (v0.5.1017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1017 — fix(stdlib+ext-fastify): #1120 — fastify reply Buffer / Uint8Array bodies + auto-HEAD-for-GET
+
+Closes #1120 end-to-end. Three coordinated behaviors:
+
+### 1. Buffer / Uint8Array bodies ship raw bytes (not Buffer.toJSON)
+
+Returning a `Buffer` (or `Uint8Array`) from a fastify route handler used to be JSON-serialized via `Buffer.toJSON()` — wire payload `{"type":"Buffer","data":[137,80,...]}` — and any `reply.type(...)` the handler had set was overwritten with `application/json`. A 1.3 MB WASM asset served via `reply.type('application/wasm'); return readFileSync('/path/x.wasm');` came out as a multi-megabyte JSON string of decimal byte digits.
+
+Root cause: both perry-ext-fastify and the bundled perry-stdlib fastify funnelled non-string handler returns through `js_json_stringify`, which correctly emits `Buffer.toJSON()` for `Buffer` pointers. The fastify response builder never probed `BUFFER_REGISTRY` to short-circuit binary payloads onto the raw-bytes path that perry-ext-http-server already uses for `res.end(buf)` (closed in #1124).
+
+Fix mirrors #1124's shape across four sites:
+
+- `crates/perry-ext-fastify/src/context.rs` — new `BodyKind` enum (Binary / TextOrJson) + `extract_buffer_bytes(value: f64) -> Option<Vec<u8>>` helper. `jsvalue_to_response_body` returns `(Vec<u8>, BodyKind)`, probing `js_buffer_is_buffer` before the JSON fallback. `js_fastify_reply_send` defaults `content-type` to `application/octet-stream` when the payload is binary and no content-type was pinned via `reply.type(...)`.
+- `crates/perry-ext-fastify/src/server.rs` — `build_response_body` returns `(Vec<u8>, BodyKind)`. `process_request` (the canonical post-handler path) picks the default content-type based on `BodyKind` instead of unconditionally pushing `application/json`. The hook-chain fallback in `handle_error_response` does the same.
+- `crates/perry-stdlib/src/fastify/context.rs` + `server.rs` — same pair of edits for the bundled fastify path. With the v0.5.572 well-known flip, `import 'fastify'` routes to perry-ext-fastify and bundled-fastify is stripped, but the bundled path still ships for callers that don't trigger the flip (e.g. transitive http-server usage).
+
+### 2. Uint8Array constructor-from-array-literal works through the same path
+
+`new Uint8Array([1, 2, 3, 4, 5])` was suspected to bypass `BUFFER_REGISTRY` because the codegen routes it through `js_uint8array_new` → `js_uint8array_from_array` → `buffer_alloc`. Verified empirically: the small-buffer slab path (`<8KB`) is covered by `is_registered_buffer`'s fast slab-range check, so `js_buffer_is_buffer` returns 1 and the new probe lights up correctly. No code change needed beyond the BUFFER_REGISTRY probe in part 1; the regression harness now pins this case.
+
+### 3. Auto-handle HEAD against any registered GET (Node fastify shadowing)
+
+Pre-fix `HEAD /path` against a route registered only as `app.get(...)` returned the default 404 JSON because the route matcher only accepted exact-method matches. Node fastify auto-handles this via `app.head` shadowing — run the GET handler, drop the body, keep `Content-Length`.
+
+Fix in `crates/perry-ext-fastify/src/server.rs::handle_request` and `crates/perry-stdlib/src/fastify/server.rs::handle_request`:
+- Two-pass route match. First pass: exact method. Second pass (only when method is `HEAD`): fall back to a `GET` route on the same path.
+- When the fallback matches, rewrite the dispatch method to `GET` so the handler runs as if Node-style shadowing fired.
+- Strip the body from the hyper response and emit `Content-Length` reflecting the would-have-been body size, so clients (curl `-I`, browsers, monitoring tools) see what `GET` would produce.
+
+### Regression test
+
+`test-files/test_issue_1120_fastify_buffer.ts` + `test-files/run_test_issue_1120.sh` — three assertions per server-fixture boot:
+
+1. `GET /buf` → 8-byte PNG magic body + `application/octet-stream` (Buffer raw bytes, part 1). Pre-fix: Buffer.toJSON + `application/json`.
+2. `GET /u8` → `01 02 03 04 05` body + `application/octet-stream` (Uint8Array raw bytes, part 2). Pre-fix: `{"0":1,"1":2,...}` + `application/json`.
+3. `HEAD /buf` → status 200, empty body, `Content-Length: 8` (part 3). Pre-fix: 404 `{"error":"Not Found"}`.
+
+Validated: harness passes all 3; pre-existing `run_test_issue_1124.sh` (server-side http Buffer body) and `test_issue_1123_listen.ts` (net.createServer accept loop) still pass; `cargo test --release -p perry-ext-fastify -p perry-stdlib` green.
+
 ## v0.5.1016 — docs(cli): list every real `--target` in `perry compile --help` (#1119)
 
 The clap doc-comment on `CompileArgs.target` listed only `ios-simulator, ios, android, ios-widget, ios-widget-simulator` — omitting `web`, `wasm`, `visionos[-simulator]`, `watchos-widget[-simulator]`, `android-widget`, `wearos-tile`, `windows`, and `linux`, even though `docs/src/cli/flags.md` already documents the full set and `--target web` is the official path for browser-runnable WASM. People scaffolding new web projects against Perry hit `perry compile --help` first, found no `web` target, and assumed it wasn't supported.
@@ -18,7 +57,6 @@ Lands [TheHypnoo](https://github.com/TheHypnoo)'s `node:querystring` implementat
 2. **Loose small-handle guard.** The heap-pointer fallback rejected `addr < 0x1000`, admitting any small-handle id in `0x1000..0x10000` and then dereferencing it as a `*const StringHeader`. Bumped to `< 0x10000` to match the rest of the runtime's pointer-vs-handle ceiling (`object.rs`'s small-handle dispatch path uses the same threshold).
 
 Attribution: code authored by TheHypnoo (PR #1151). The SSO/guard fixes are review fixes applied at merge time. PR #1151 itself can be closed; the squash-merge wasn't possible because the contributor's fork doesn't allow maintainer pushes.
-
 ## v0.5.1014 — fix(codegen): restore `IncomingMessage` `__get_statusCode` / `__get_statusMessage` / `__get_headers` rows lost in #1099 squash
 
 The v0.5.1012 fix added three `NativeModSig` rows to `lower_call.rs` so `res.statusCode` on a client-side `IncomingMessage` routes to perry-ext-http's `js_http_status_code` (instead of falling through to the zero-sentinel). #1150 (chore(codegen) #1099 — split `lower_call.rs` into `lower_call/*` submodules) was authored against pre-fix `main`, and its squash-merge resolved the modify/delete conflict by taking the PR's deletion of the file — losing the three rows that had moved into `native_table.rs` via the resolution commit on the PR branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1016
+**Current Version:** 0.5.1017
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5084,7 +5084,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "base64",
@@ -5139,14 +5139,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "log",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5168,7 +5168,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "base64",
@@ -5208,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "serde",
  "serde_json",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1016"
+version = "0.5.1017"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "clap",
@@ -5250,14 +5250,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5298,14 +5298,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "chrono",
  "cron",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5322,7 +5322,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5338,7 +5338,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5346,21 +5346,21 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5399,7 +5399,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5455,7 +5455,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "bson",
  "futures-util",
@@ -5467,7 +5467,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5477,7 +5477,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5486,7 +5486,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
  "rustls",
@@ -5497,7 +5497,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5515,7 +5515,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5524,7 +5524,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5532,7 +5532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "base64",
  "image",
@@ -5541,14 +5541,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5574,7 +5574,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5585,7 +5585,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5602,7 +5602,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5618,7 +5618,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5646,7 +5646,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "base64",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5756,7 +5756,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5774,11 +5774,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1016"
+version = "0.5.1017"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "base64",
  "itoa",
@@ -5794,7 +5794,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "base64",
  "block2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "base64",
  "block2",
@@ -5860,11 +5860,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1016"
+version = "0.5.1017"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "base64",
  "block2",
@@ -5880,7 +5880,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "base64",
  "block2",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "block2",
  "libc",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "base64",
  "libc",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5938,7 +5938,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1016"
+version = "0.5.1017"
 dependencies = [
  "wasmi",
 ]
@@ -8059,9 +8059,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.46"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1016"
+version = "0.5.1017"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-ext-fastify/src/context.rs
+++ b/crates/perry-ext-fastify/src/context.rs
@@ -34,6 +34,36 @@ extern "C" {
     /// JSON.stringify with type hint. Same as
     /// `perry_ffi::json_stringify` modulo the type-hint argument.
     fn js_json_stringify(value: f64, type_hint: u32) -> *mut StringHeader;
+
+    /// True if `ptr` (raw POINTER_TAG-masked address) points at a
+    /// `BufferHeader` registered with the runtime's BUFFER_REGISTRY.
+    /// Used to distinguish `Buffer` / `Uint8Array` payloads from
+    /// `StringHeader`-shaped objects when building response bodies.
+    /// Same C-exposed extern perry-ext-http-server uses (see
+    /// `crates/perry-runtime/src/buffer.rs:601`).
+    fn js_buffer_is_buffer(ptr: i64) -> i32;
+}
+
+/// `BufferHeader` mirror — must match `crates/perry-runtime/src/buffer.rs`'s
+/// layout (`{ length: u32, capacity: u32 }`, data immediately after the
+/// 8-byte header). Distinct from `StringHeader` (20-byte header), so a
+/// Buffer must NEVER be read through the string-shaped path.
+#[repr(C)]
+struct BufferHeader {
+    length: u32,
+    capacity: u32,
+}
+
+/// Body type returned by `build_response_body` / `jsvalue_to_response_body`
+/// when the caller needs to pick a sensible default `content-type`.
+/// `Binary` is set when the handler returned a `Buffer` / `Uint8Array`;
+/// the caller defaults its content-type to `application/octet-stream`
+/// instead of `application/json` so binary assets (PNG, WASM, …) ship
+/// untouched (#1120).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BodyKind {
+    Binary,
+    TextOrJson,
 }
 
 static CONTEXT_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -386,13 +416,29 @@ pub unsafe extern "C" fn js_fastify_reply_type(ctx_handle: Handle, value: i64) -
 
 /// `reply.send(payload)` — finalize the response. Returns true if the
 /// response was newly sent, false if `ctx.sent` was already true.
+///
+/// When the payload is a `Buffer` / `Uint8Array` and the handler
+/// hasn't pinned a `content-type` yet (`reply.type(...)`), the
+/// response defaults to `application/octet-stream` so binary assets
+/// don't ship as JSON.toString'd bytes (#1120).
 #[no_mangle]
 pub unsafe extern "C" fn js_fastify_reply_send(ctx_handle: Handle, data: f64) -> bool {
     if let Some(ctx) = get_handle_mut::<FastifyContext>(ctx_handle) {
         if ctx.sent {
             return false;
         }
-        let body = jsvalue_to_response_body(data);
+        let (body, kind) = jsvalue_to_response_body(data);
+        if kind == BodyKind::Binary
+            && !ctx
+                .response_headers
+                .iter()
+                .any(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+        {
+            ctx.response_headers.push((
+                "content-type".to_string(),
+                "application/octet-stream".to_string(),
+            ));
+        }
         ctx.response_body = Some(body);
         ctx.sent = true;
         return true;
@@ -476,15 +522,51 @@ pub unsafe extern "C" fn js_fastify_ctx_redirect(ctx_handle: Handle, url: i64, s
 // ============================================================================
 
 /// Convert a NaN-boxed JsValue to response bytes. Strings pass through
-/// as-is; everything else gets JSON-stringified.
-pub(crate) unsafe fn jsvalue_to_response_body(value: f64) -> Vec<u8> {
+/// as-is; `Buffer` / `Uint8Array` ships its raw bytes (no UTF-8
+/// round-trip); everything else gets JSON-stringified. The caller
+/// inspects the returned `BodyKind` to pick a default content-type
+/// when the handler didn't set one.
+///
+/// Issue #1120: pre-fix, every non-string value funnelled through
+/// `js_json_stringify`. A returned Buffer surfaced as Buffer.toJSON's
+/// `{"type":"Buffer","data":[...]}` payload (~6× bloat) and the
+/// caller still pushed `application/json` for the content-type.
+pub(crate) unsafe fn jsvalue_to_response_body(value: f64) -> (Vec<u8>, BodyKind) {
     let jsv = JsValue::from_bits(value.to_bits());
     if jsv.is_string() {
         if let Some(s) = extract_jsvalue_string(value) {
-            return s.into_bytes();
+            return (s.into_bytes(), BodyKind::TextOrJson);
         }
     }
-    jsvalue_to_json_string(value).into_bytes()
+    if let Some(bytes) = extract_buffer_bytes(value) {
+        return (bytes, BodyKind::Binary);
+    }
+    (
+        jsvalue_to_json_string(value).into_bytes(),
+        BodyKind::TextOrJson,
+    )
+}
+
+/// Probe BUFFER_REGISTRY for a POINTER_TAG'd value. Returns the raw
+/// bytes of the underlying `BufferHeader` payload if `value` is a
+/// `Buffer` / `Uint8Array`; `None` otherwise. Shared with `server.rs`'s
+/// `build_response_body` (#1120).
+pub(crate) unsafe fn extract_buffer_bytes(value: f64) -> Option<Vec<u8>> {
+    let v = JsValue::from_bits(value.to_bits());
+    if !v.is_pointer() {
+        return None;
+    }
+    let raw = (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64;
+    if js_buffer_is_buffer(raw) == 0 {
+        return None;
+    }
+    let buf = raw as *const BufferHeader;
+    if buf.is_null() {
+        return None;
+    }
+    let len = (*buf).length as usize;
+    let data = (buf as *const u8).add(std::mem::size_of::<BufferHeader>());
+    Some(std::slice::from_raw_parts(data, len).to_vec())
 }
 
 /// Serialize a NaN-boxed JsValue as a JSON string.

--- a/crates/perry-ext-fastify/src/server.rs
+++ b/crates/perry-ext-fastify/src/server.rs
@@ -29,7 +29,7 @@ use perry_ffi::{
 };
 
 use crate::app::{ClosurePtr, FastifyApp, Route};
-use crate::context::{jsvalue_to_response_body, FastifyContext};
+use crate::context::{extract_buffer_bytes, jsvalue_to_response_body, BodyKind, FastifyContext};
 
 const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 const PTR_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
@@ -568,15 +568,34 @@ async fn handle_request(
         Err(_) => None,
     };
 
-    // Match
+    // Match: first try the exact method, then — for HEAD — fall back to
+    // a GET route with the same path. Node fastify auto-handles HEAD
+    // against any registered GET (via `app.head` shadowing) by running
+    // the GET handler and dropping the body before sending. We do the
+    // same: rewrite the method to GET so the handler sees a vanilla
+    // request, then strip the body on the way out (see `head_for_get`
+    // below). #1120 part 2.
     let mut matched_params = HashMap::new();
     let mut found_route = false;
+    let mut head_for_get = false;
     for route in routes.iter() {
         if route.method == method {
             if let Some(params) = route.pattern.match_path(&path) {
                 matched_params = params;
                 found_route = true;
                 break;
+            }
+        }
+    }
+    if !found_route && method == "HEAD" {
+        for route in routes.iter() {
+            if route.method == "GET" {
+                if let Some(params) = route.pattern.match_path(&path) {
+                    matched_params = params;
+                    found_route = true;
+                    head_for_get = true;
+                    break;
+                }
             }
         }
     }
@@ -590,8 +609,17 @@ async fn handle_request(
     }
 
     let (response_tx, response_rx) = oneshot::channel::<FastifyResponse>();
+    // When fronting a GET handler for an inbound HEAD, surface the
+    // method as `GET` to the handler — Node fastify's shadowing
+    // semantics. The body-drop happens below in the hyper response
+    // assembly.
+    let dispatch_method = if head_for_get {
+        "GET".to_string()
+    } else {
+        method.clone()
+    };
     let pending = FastifyPendingRequest {
-        method,
+        method: dispatch_method,
         path,
         headers,
         body,
@@ -611,12 +639,29 @@ async fn handle_request(
 
     match response_rx.await {
         Ok(fr) => {
+            let body_len = fr.body.len();
             let mut builder = Response::builder()
                 .status(StatusCode::from_u16(fr.status).unwrap_or(StatusCode::OK));
+            let mut had_content_length = false;
             for (name, value) in fr.headers {
+                if name.eq_ignore_ascii_case("content-length") {
+                    had_content_length = true;
+                }
                 builder = builder.header(name, value);
             }
-            Ok(builder.body(Full::new(Bytes::from(fr.body))).unwrap())
+            let body_bytes = if head_for_get {
+                // HEAD response: no body on the wire, but expose the
+                // would-have-been size via Content-Length so clients
+                // (curl -I, browsers, monitoring) see what GET would
+                // produce. Mirror of Node fastify's HEAD-on-GET path.
+                if !had_content_length {
+                    builder = builder.header("content-length", body_len.to_string());
+                }
+                Bytes::new()
+            } else {
+                Bytes::from(fr.body)
+            };
+            Ok(builder.body(Full::new(body_bytes)).unwrap())
         }
         Err(_) => Ok(Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -827,22 +872,35 @@ fn process_request(app_handle: Handle, pending: FastifyPendingRequest) {
 
     // Build + send the response.
     if let Some(ctx) = get_handle::<FastifyContext>(ctx_handle) {
+        // Track whether the body came back as binary (Buffer / Uint8Array)
+        // so the default content-type below picks octet-stream over JSON
+        // when the handler didn't pin one via `reply.type(...)` (#1120).
+        let (body, body_kind) = if let Some(b) = ctx.response_body.clone() {
+            // The body was set explicitly by `reply.send(...)`, which
+            // already pushed an `application/octet-stream` default if
+            // the payload was binary and no content-type was pinned.
+            // Treat it as text/json here so we don't override.
+            (b, BodyKind::TextOrJson)
+        } else {
+            unsafe { build_response_body(final_result) }
+        };
         let mut response = FastifyResponse {
             status: ctx.status_code,
             headers: ctx.response_headers.clone(),
-            body: ctx
-                .response_body
-                .clone()
-                .unwrap_or_else(|| unsafe { build_response_body(final_result) }),
+            body,
         };
         if !response
             .headers
             .iter()
-            .any(|(k, _)| k.to_lowercase() == "content-type")
+            .any(|(k, _)| k.eq_ignore_ascii_case("content-type"))
         {
+            let ct = match body_kind {
+                BodyKind::Binary => "application/octet-stream",
+                BodyKind::TextOrJson => "application/json",
+            };
             response
                 .headers
-                .push(("content-type".to_string(), "application/json".to_string()));
+                .push(("content-type".to_string(), ct.to_string()));
         }
         let _ = pending.response_tx.send(response);
     }
@@ -984,7 +1042,23 @@ fn handle_error_response(
             if fallback_reason.is_none() {
                 if let Some(ctx) = perry_ffi::get_handle_mut::<FastifyContext>(ctx_handle) {
                     if ctx.response_body.is_none() {
-                        ctx.response_body = Some(unsafe { build_response_body(final_result) });
+                        let (bytes, kind) = unsafe { build_response_body(final_result) };
+                        // #1120: when the hook chain returned a Buffer /
+                        // Uint8Array and no content-type was pinned, default
+                        // to octet-stream so the request finalization step
+                        // doesn't paint over it with `application/json`.
+                        if kind == BodyKind::Binary
+                            && !ctx
+                                .response_headers
+                                .iter()
+                                .any(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+                        {
+                            ctx.response_headers.push((
+                                "content-type".to_string(),
+                                "application/octet-stream".to_string(),
+                            ));
+                        }
+                        ctx.response_body = Some(bytes);
                     }
                 }
                 return;
@@ -1084,7 +1158,7 @@ unsafe fn render_rejection_body(reason: f64) -> Vec<u8> {
     // Strings: wrap the user's message verbatim.
     let jsv = JsValue::from_bits(reason.to_bits());
     if jsv.is_string() {
-        let s = jsvalue_to_response_body(reason);
+        let (s, _) = jsvalue_to_response_body(reason);
         // s is the raw string bytes; embed as a JSON string literal.
         let mut out = b"{\"error\":".to_vec();
         out.push(b'"');
@@ -1116,7 +1190,7 @@ unsafe fn render_rejection_body(reason: f64) -> Vec<u8> {
         }
     }
     // Numbers/bools/null/undefined: best-effort stringification.
-    let body = jsvalue_to_response_body(reason);
+    let (body, _) = jsvalue_to_response_body(reason);
     let mut out = b"{\"error\":".to_vec();
     if body.is_empty() {
         out.extend_from_slice(b"null");
@@ -1181,22 +1255,35 @@ fn push_json_string(out: &mut Vec<u8>, bytes: &[u8]) {
 }
 
 /// Render the handler return value as response bytes. Handlers can
-/// return strings (used as-is), objects/arrays (JSON-stringified),
-/// numbers/bools (toString), or `undefined` (empty `{}`).
-unsafe fn build_response_body(value: f64) -> Vec<u8> {
+/// return strings (used as-is), `Buffer` / `Uint8Array` (raw bytes,
+/// see #1120), objects/arrays (JSON-stringified), numbers/bools
+/// (toString), or `undefined` (empty `{}`). The returned `BodyKind`
+/// signals whether the caller should default `content-type` to
+/// `application/octet-stream` (binary) instead of `application/json`.
+unsafe fn build_response_body(value: f64) -> (Vec<u8>, BodyKind) {
     let jsv = JsValue::from_bits(value.to_bits());
     if jsv.is_undefined() || jsv.is_null() {
-        return b"{}".to_vec();
+        return (b"{}".to_vec(), BodyKind::TextOrJson);
     }
     if jsv.is_string() {
         return jsvalue_to_response_body(value);
+    }
+    // Issue #1120 — Buffer / Uint8Array must ship their raw bytes,
+    // not the Buffer.toJSON `{"type":"Buffer","data":[...]}` form
+    // that `js_json_stringify` produces. Probe BUFFER_REGISTRY
+    // first; only fall through to JSON for non-buffer pointers.
+    if let Some(bytes) = extract_buffer_bytes(value) {
+        return (bytes, BodyKind::Binary);
     }
     if jsv.is_pointer() {
         let str_ptr = js_json_stringify(value, 0);
         if !str_ptr.is_null() {
             let len = (*str_ptr).byte_len as usize;
             let data_ptr = (str_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-            return std::slice::from_raw_parts(data_ptr, len).to_vec();
+            return (
+                std::slice::from_raw_parts(data_ptr, len).to_vec(),
+                BodyKind::TextOrJson,
+            );
         }
     }
     // Fallback through the unified path.

--- a/crates/perry-stdlib/src/fastify/context.rs
+++ b/crates/perry-stdlib/src/fastify/context.rs
@@ -5,7 +5,46 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use perry_runtime::{js_string_from_bytes, JSValue, StringHeader};
+use perry_runtime::{js_string_from_bytes, BufferHeader, JSValue, StringHeader};
+
+extern "C" {
+    /// Probe the runtime's BUFFER_REGISTRY for a NaN-boxed POINTER_TAG
+    /// pointer. Returns 1 for `Buffer` / `Uint8Array`, 0 otherwise.
+    /// Used to distinguish binary payloads from `StringHeader`-shaped
+    /// objects when building response bodies (#1120).
+    fn js_buffer_is_buffer(ptr: i64) -> i32;
+}
+
+/// Body type used by `build_response_body` / `jsvalue_to_response_body`
+/// so the caller can default `content-type` to `application/octet-stream`
+/// when the handler returned a Buffer and didn't pin a type via
+/// `reply.type(...)` (#1120).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BodyKind {
+    Binary,
+    TextOrJson,
+}
+
+/// Probe BUFFER_REGISTRY for a POINTER_TAG'd value; returns the raw
+/// payload bytes if it's a `Buffer` / `Uint8Array`. Shared with
+/// `server.rs::build_response_body` (#1120).
+pub(crate) unsafe fn extract_buffer_bytes(value: f64) -> Option<Vec<u8>> {
+    let v = JSValue::from_bits(value.to_bits());
+    if !v.is_pointer() {
+        return None;
+    }
+    let raw = (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64;
+    if js_buffer_is_buffer(raw) == 0 {
+        return None;
+    }
+    let buf = raw as *const BufferHeader;
+    if buf.is_null() {
+        return None;
+    }
+    let len = (*buf).length as usize;
+    let data = (buf as *const u8).add(std::mem::size_of::<BufferHeader>());
+    Some(std::slice::from_raw_parts(data, len).to_vec())
+}
 
 use crate::common::{get_handle, get_handle_mut, Handle};
 
@@ -457,8 +496,11 @@ pub unsafe extern "C" fn js_fastify_reply_type(ctx_handle: Handle, value: i64) -
     ctx_handle
 }
 
-/// Send response (Fastify style)
-/// Returns true if sent, false otherwise
+/// Send response (Fastify style). Returns true if newly sent.
+///
+/// `Buffer` / `Uint8Array` payloads default `content-type` to
+/// `application/octet-stream` when the handler hasn't pinned one
+/// via `reply.type(...)` so binary assets don't ship as JSON (#1120).
 #[no_mangle]
 pub unsafe extern "C" fn js_fastify_reply_send(ctx_handle: Handle, data: f64) -> bool {
     if let Some(ctx) = get_handle_mut::<FastifyContext>(ctx_handle) {
@@ -466,8 +508,18 @@ pub unsafe extern "C" fn js_fastify_reply_send(ctx_handle: Handle, data: f64) ->
             return false;
         }
 
-        // Convert data to response body
-        let body = jsvalue_to_response_body(data);
+        let (body, kind) = jsvalue_to_response_body(data);
+        if kind == BodyKind::Binary
+            && !ctx
+                .response_headers
+                .iter()
+                .any(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+        {
+            ctx.response_headers.push((
+                "content-type".to_string(),
+                "application/octet-stream".to_string(),
+            ));
+        }
         ctx.response_body = Some(body);
         ctx.sent = true;
         return true;
@@ -565,19 +617,29 @@ pub unsafe extern "C" fn js_fastify_ctx_redirect(ctx_handle: Handle, url: i64, s
 // Helper functions
 // ============================================================================
 
-/// Convert a JSValue to a response body (bytes)
-unsafe fn jsvalue_to_response_body(value: f64) -> Vec<u8> {
+/// Convert a JSValue to a response body. Strings pass through as
+/// raw UTF-8; `Buffer` / `Uint8Array` ships the raw payload (no
+/// UTF-8 round-trip — pre-fix the bytes went through Buffer.toJSON
+/// per #1120); everything else gets JSON-stringified. The returned
+/// `BodyKind` tells the caller whether to default `content-type` to
+/// `application/octet-stream` (binary) or `application/json`.
+pub(crate) unsafe fn jsvalue_to_response_body(value: f64) -> (Vec<u8>, BodyKind) {
     let jsv = JSValue::from_bits(value.to_bits());
 
-    // Check if it's a string
     if jsv.is_string() {
         if let Some(s) = extract_jsvalue_string(value) {
-            return s.into_bytes();
+            return (s.into_bytes(), BodyKind::TextOrJson);
         }
     }
 
-    // Otherwise serialize as JSON
-    jsvalue_to_json_string(value).into_bytes()
+    if let Some(bytes) = extract_buffer_bytes(value) {
+        return (bytes, BodyKind::Binary);
+    }
+
+    (
+        jsvalue_to_json_string(value).into_bytes(),
+        BodyKind::TextOrJson,
+    )
 }
 
 /// Convert a JSValue to a JSON string

--- a/crates/perry-stdlib/src/fastify/server.rs
+++ b/crates/perry-stdlib/src/fastify/server.rs
@@ -18,6 +18,7 @@ use tokio::sync::mpsc;
 
 use perry_runtime::{js_string_from_bytes, JSValue, StringHeader};
 
+use super::context::{extract_buffer_bytes, BodyKind};
 use super::{ClosurePtr, FastifyApp, FastifyContext};
 use crate::common::{for_each_handle_of, get_handle, register_handle, Handle, RUNTIME};
 
@@ -316,9 +317,14 @@ async fn handle_request(
         Err(_) => None,
     };
 
-    // Match route
+    // Match route: first exact-method, then — for HEAD requests — fall
+    // back to a GET route on the same path. Node fastify auto-handles
+    // HEAD against any registered GET (via `app.head` shadowing). We
+    // rewrite the method to GET so the handler runs normally, then
+    // strip the body on the way out via `head_for_get` below (#1120).
     let mut matched_params = HashMap::new();
     let mut found_route = false;
+    let mut head_for_get = false;
 
     for route in routes.iter() {
         if route.method == method {
@@ -326,6 +332,18 @@ async fn handle_request(
                 matched_params = params;
                 found_route = true;
                 break;
+            }
+        }
+    }
+    if !found_route && method == "HEAD" {
+        for route in routes.iter() {
+            if route.method == "GET" {
+                if let Some(params) = route.pattern.match_path(&path) {
+                    matched_params = params;
+                    found_route = true;
+                    head_for_get = true;
+                    break;
+                }
             }
         }
     }
@@ -342,9 +360,17 @@ async fn handle_request(
     // Create oneshot channel for response
     let (response_tx, response_rx) = tokio::sync::oneshot::channel::<FastifyResponse>();
 
-    // Send request to TypeScript handler
+    // Send request to TypeScript handler. When fronting a GET handler
+    // for an inbound HEAD, surface the method as `GET` to the handler —
+    // matches Node fastify's shadowing semantics. The body-drop happens
+    // below in the hyper response assembly.
+    let dispatch_method = if head_for_get {
+        "GET".to_string()
+    } else {
+        method.clone()
+    };
     let pending = FastifyPendingRequest {
-        method,
+        method: dispatch_method,
         path,
         headers,
         body,
@@ -362,16 +388,33 @@ async fn handle_request(
     // Wait for response
     match response_rx.await {
         Ok(fastify_response) => {
+            let body_len = fastify_response.body.len();
             let mut response = Response::builder()
                 .status(StatusCode::from_u16(fastify_response.status).unwrap_or(StatusCode::OK));
 
+            let mut had_content_length = false;
             for (name, value) in fastify_response.headers {
+                if name.eq_ignore_ascii_case("content-length") {
+                    had_content_length = true;
+                }
                 response = response.header(name, value);
             }
 
-            Ok(response
-                .body(Full::new(Bytes::from(fastify_response.body)))
-                .unwrap())
+            let body_bytes = if head_for_get {
+                // HEAD response: no body on the wire, but expose the
+                // would-have-been size via Content-Length so clients
+                // (curl -I, browsers, monitoring) see what GET would
+                // produce. Mirror of Node fastify's HEAD-on-GET path
+                // (#1120).
+                if !had_content_length {
+                    response = response.header("content-length", body_len.to_string());
+                }
+                Bytes::new()
+            } else {
+                Bytes::from(fastify_response.body)
+            };
+
+            Ok(response.body(Full::new(body_bytes)).unwrap())
         }
         Err(_) => Ok(Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -632,25 +675,35 @@ fn process_fastify_request_with_app(app: &FastifyApp, pending: FastifyPendingReq
 
         // Always send a response (from hook or route handler)
         if let Some(ctx) = get_handle::<FastifyContext>(ctx_handle) {
+            // If the handler called `reply.send(...)`, the body and
+            // content-type are already pinned on `ctx`. Otherwise the
+            // body comes from the handler's return value, and we use
+            // its `BodyKind` to default the content-type (#1120 —
+            // Buffer / Uint8Array → octet-stream, everything else
+            // → json).
+            let (body, body_kind) = match ctx.response_body.clone() {
+                Some(b) => (b, BodyKind::TextOrJson),
+                None => build_response_body(final_result),
+            };
             let response = FastifyResponse {
                 status: ctx.status_code,
                 headers: ctx.response_headers.clone(),
-                body: ctx.response_body.clone().unwrap_or_else(|| {
-                    // If no explicit body, use handler return value
-                    build_response_body(final_result)
-                }),
+                body,
             };
 
-            // Ensure content-type is set
             let mut final_response = response;
             if !final_response
                 .headers
                 .iter()
-                .any(|(k, _)| k.to_lowercase() == "content-type")
+                .any(|(k, _)| k.eq_ignore_ascii_case("content-type"))
             {
+                let ct = match body_kind {
+                    BodyKind::Binary => "application/octet-stream",
+                    BodyKind::TextOrJson => "application/json",
+                };
                 final_response
                     .headers
-                    .push(("content-type".to_string(), "application/json".to_string()));
+                    .push(("content-type".to_string(), ct.to_string()));
             }
 
             let _ = pending.response_tx.send(final_response);
@@ -790,7 +843,23 @@ fn handle_error_response(
             if fallback_reason.is_none() {
                 if let Some(ctx) = crate::common::get_handle_mut::<FastifyContext>(ctx_handle) {
                     if ctx.response_body.is_none() {
-                        ctx.response_body = Some(build_response_body(final_result));
+                        let (bytes, kind) = build_response_body(final_result);
+                        // #1120 — when the body came back binary and no
+                        // content-type was pinned, default to octet-stream
+                        // so the request finalization step doesn't paint
+                        // over it with `application/json`.
+                        if kind == BodyKind::Binary
+                            && !ctx
+                                .response_headers
+                                .iter()
+                                .any(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+                        {
+                            ctx.response_headers.push((
+                                "content-type".to_string(),
+                                "application/octet-stream".to_string(),
+                            ));
+                        }
+                        ctx.response_body = Some(bytes);
                     }
                 }
                 return;
@@ -883,7 +952,7 @@ fn render_rejection_body(reason: f64) -> Vec<u8> {
 
     let jsv = JSValue::from_bits(reason.to_bits());
     if jsv.is_string() {
-        let s = build_response_body(reason);
+        let (s, _) = build_response_body(reason);
         let mut out = b"{\"error\":".to_vec();
         out.push(b'"');
         for b in s {
@@ -918,7 +987,7 @@ fn render_rejection_body(reason: f64) -> Vec<u8> {
             }
         }
     }
-    let body = build_response_body(reason);
+    let (body, _) = build_response_body(reason);
     let mut out = b"{\"error\":".to_vec();
     if body.is_empty() {
         out.extend_from_slice(b"null");
@@ -983,16 +1052,17 @@ fn push_json_string(out: &mut Vec<u8>, bytes: &[u8]) {
     out.push(b'"');
 }
 
-/// Build response body from handler return value
-fn build_response_body(value: f64) -> Vec<u8> {
+/// Build response body from handler return value. Returns the raw
+/// bytes plus a `BodyKind` so the caller can default `content-type`
+/// to `application/octet-stream` for binary payloads (Buffer /
+/// Uint8Array) instead of `application/json` (#1120).
+fn build_response_body(value: f64) -> (Vec<u8>, BodyKind) {
     let jsv = JSValue::from_bits(value.to_bits());
 
-    // If undefined/null, return empty object
     if jsv.is_undefined() || jsv.is_null() {
-        return b"{}".to_vec();
+        return (b"{}".to_vec(), BodyKind::TextOrJson);
     }
 
-    // If string, return as-is
     if jsv.is_string() {
         unsafe {
             let ptr = perry_runtime::js_get_string_pointer_unified(value);
@@ -1001,12 +1071,17 @@ fn build_response_body(value: f64) -> Vec<u8> {
                 let len = (*header).byte_len as usize;
                 let data_ptr = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
                 let bytes = std::slice::from_raw_parts(data_ptr, len);
-                return bytes.to_vec();
+                return (bytes.to_vec(), BodyKind::TextOrJson);
             }
         }
     }
 
-    // For objects/arrays (pointers), use js_json_stringify for proper JSON serialization
+    // #1120 — Buffer / Uint8Array ships its raw payload (no
+    // Buffer.toJSON detour through `js_json_stringify`).
+    if let Some(bytes) = unsafe { extract_buffer_bytes(value) } {
+        return (bytes, BodyKind::Binary);
+    }
+
     if jsv.is_pointer() {
         extern "C" {
             fn js_json_stringify(value: f64, type_hint: u32) -> *mut StringHeader;
@@ -1017,23 +1092,22 @@ fn build_response_body(value: f64) -> Vec<u8> {
                 let len = (*str_ptr).byte_len as usize;
                 let data_ptr = (str_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
                 let bytes = std::slice::from_raw_parts(data_ptr, len);
-                return bytes.to_vec();
+                return (bytes.to_vec(), BodyKind::TextOrJson);
             }
         }
     }
 
-    // Fallback: convert to string
     unsafe {
         let json_ptr = perry_runtime::js_jsvalue_to_string(value);
         if !json_ptr.is_null() {
             let len = (*json_ptr).byte_len as usize;
             let data_ptr = (json_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
             let bytes = std::slice::from_raw_parts(data_ptr, len);
-            return bytes.to_vec();
+            return (bytes.to_vec(), BodyKind::TextOrJson);
         }
     }
 
-    b"{}".to_vec()
+    (b"{}".to_vec(), BodyKind::TextOrJson)
 }
 
 /// Close one specific server by its `FastifyServerHandle` id. Marks
@@ -1148,13 +1222,13 @@ mod tests {
     /// Test building response body from different value types
     #[test]
     fn test_build_response_body() {
-        // Test undefined
-        let body = build_response_body(f64::from_bits(JSValue::undefined().bits()));
+        let (body, kind) = build_response_body(f64::from_bits(JSValue::undefined().bits()));
         assert_eq!(body, b"{}");
+        assert_eq!(kind, BodyKind::TextOrJson);
 
-        // Test null
-        let body = build_response_body(f64::from_bits(JSValue::null().bits()));
+        let (body, kind) = build_response_body(f64::from_bits(JSValue::null().bits()));
         assert_eq!(body, b"{}");
+        assert_eq!(kind, BodyKind::TextOrJson);
 
         // Test number (these get converted via js_jsvalue_to_string, which returns "{}" for numbers without proper string conversion)
         // In practice, handler return values would be objects that get JSON serialized

--- a/test-files/run_test_issue_1120.sh
+++ b/test-files/run_test_issue_1120.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Wire-level regression harness for issue #1120 — fastify Buffer /
+# Uint8Array response body integrity + auto-HEAD-for-GET.
+# See test_issue_1120_fastify_buffer.ts for the bug writeup.
+#
+# Usage:
+#   PERRY_BIN=./target/release/perry ./test-files/run_test_issue_1120.sh
+#
+# Three assertions:
+#   1. GET /buf  →  body is 8-byte PNG magic + content-type is
+#      `application/octet-stream` (handler set via `reply.type(...)`).
+#      Pre-fix this came back as Buffer.toJSON + `application/json`.
+#   2. GET /u8   →  body is `01 02 03 04 05` + content-type defaults
+#      to `application/octet-stream` (Uint8Array, no reply.type).
+#      Pre-fix: `{"0":1,...}` + `application/json`.
+#   3. HEAD /buf →  status 200, empty body, Content-Length: 8.
+#      Pre-fix: 404 (HEAD not matched against registered GET).
+#
+# Always tears the server down, even on failure paths.
+
+set -euo pipefail
+
+PERRY_BIN="${PERRY_BIN:-./target/release/perry}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_SRC="$SCRIPT_DIR/test_issue_1120_fastify_buffer.ts"
+PORT=18996
+EXE="${TMPDIR:-/tmp}/test_issue_1120_fastify_buffer"
+EXPECTED_BUF_BODY="89504e470d0a1a0a"
+EXPECTED_U8_BODY="0102030405"
+EXPECTED_CT="application/octet-stream"
+EXPECTED_HEAD_CL="8"
+
+cd "$WORKSPACE_ROOT"
+
+if [[ ! -x "$PERRY_BIN" ]]; then
+    echo "FAIL: perry binary not found at $PERRY_BIN — build first via cargo build --release -p perry" >&2
+    exit 1
+fi
+
+echo "[1120] compiling fixture..."
+PERRY_ALLOW_PERRY_FEATURES=1 "$PERRY_BIN" "$TEST_SRC" -o "$EXE" >/dev/null 2>&1
+
+echo "[1120] starting server on :$PORT..."
+"$EXE" >/dev/null 2>&1 &
+SERVER_PID=$!
+trap 'kill $SERVER_PID 2>/dev/null; wait $SERVER_PID 2>/dev/null || true' EXIT
+
+# Wait for bind.
+for i in 1 2 3 4 5 6 7 8; do
+    if curl -sS -o /dev/null --max-time 1 "http://127.0.0.1:$PORT/buf" 2>/dev/null; then
+        break
+    fi
+    sleep 0.1
+done
+
+fail=0
+
+# Assertion 1: GET /buf
+TMP_OUT="$(mktemp)"
+ACTUAL_BUF_CT="$(curl -sS --max-time 2 -o "$TMP_OUT" -w "%{content_type}" "http://127.0.0.1:$PORT/buf" | tr -d '\r\n')"
+ACTUAL_BUF_BODY="$(xxd -p "$TMP_OUT" | tr -d '\n')"
+rm -f "$TMP_OUT"
+echo "[1120] GET /buf body=$ACTUAL_BUF_BODY ct=$ACTUAL_BUF_CT"
+if [[ "$ACTUAL_BUF_BODY" != "$EXPECTED_BUF_BODY" ]]; then
+    echo "[1120] FAIL — Buffer body mismatch (pre-fix: Buffer.toJSON form)"
+    fail=1
+fi
+if [[ "$ACTUAL_BUF_CT" != "$EXPECTED_CT"* ]]; then
+    echo "[1120] FAIL — Buffer content-type mismatch (pre-fix: application/json overwrite)"
+    fail=1
+fi
+
+# Assertion 2: GET /u8
+TMP_OUT="$(mktemp)"
+ACTUAL_U8_CT="$(curl -sS --max-time 2 -o "$TMP_OUT" -w "%{content_type}" "http://127.0.0.1:$PORT/u8" | tr -d '\r\n')"
+ACTUAL_U8_BODY="$(xxd -p "$TMP_OUT" | tr -d '\n')"
+rm -f "$TMP_OUT"
+echo "[1120] GET /u8  body=$ACTUAL_U8_BODY  ct=$ACTUAL_U8_CT"
+if [[ "$ACTUAL_U8_BODY" != "$EXPECTED_U8_BODY" ]]; then
+    echo "[1120] FAIL — Uint8Array body mismatch (pre-fix: {\"0\":1,...} object form)"
+    fail=1
+fi
+if [[ "$ACTUAL_U8_CT" != "$EXPECTED_CT"* ]]; then
+    echo "[1120] FAIL — Uint8Array content-type default mismatch"
+    fail=1
+fi
+
+# Assertion 3: HEAD /buf (auto-HEAD-for-GET)
+HEAD_RESULT="$(curl -sS --max-time 2 -I "http://127.0.0.1:$PORT/buf" || true)"
+HEAD_STATUS="$(printf '%s\n' "$HEAD_RESULT" | head -n 1 | awk '{print $2}')"
+HEAD_CL="$(printf '%s\n' "$HEAD_RESULT" \
+    | awk -F': ' 'tolower($1)=="content-length"{print $2}' \
+    | tr -d '\r\n' | head -c 200)"
+echo "[1120] HEAD /buf status=$HEAD_STATUS content-length=$HEAD_CL"
+if [[ "$HEAD_STATUS" != "200" ]]; then
+    echo "[1120] FAIL — HEAD on registered GET returned $HEAD_STATUS (pre-fix: 404)"
+    fail=1
+fi
+if [[ "$HEAD_CL" != "$EXPECTED_HEAD_CL" ]]; then
+    echo "[1120] FAIL — HEAD Content-Length=$HEAD_CL, expected $EXPECTED_HEAD_CL"
+    fail=1
+fi
+
+if [[ $fail -eq 0 ]]; then
+    echo "[1120] PASS"
+    exit 0
+else
+    exit 1
+fi

--- a/test-files/test_issue_1120_fastify_buffer.ts
+++ b/test-files/test_issue_1120_fastify_buffer.ts
@@ -1,0 +1,69 @@
+// Issue #1120 — fastify reply Buffer / Uint8Array integrity + auto-HEAD.
+//
+// Part 1 (body): returning a `Buffer` / `Uint8Array` from a handler
+// used to be JSON-serialized via `Buffer.toJSON()` /
+// numeric-key-object stringification, producing wire payloads like
+// `{"type":"Buffer","data":[137,80,...]}` or `{"0":1,"1":2,...}` and
+// overwriting any `reply.type(...)` the handler had set. A 1.3 MB
+// binary asset would balloon ~6× and ship as `application/json`.
+//
+// Root cause: both perry-ext-fastify and the bundled perry-stdlib
+// fastify funnelled non-string handler returns through
+// `js_json_stringify`. Fix: probe `js_buffer_is_buffer(ptr)` first
+// in `crates/perry-ext-fastify/src/{context,server}.rs` and
+// `crates/perry-stdlib/src/fastify/{context,server}.rs`, ship raw
+// bytes, default `content-type` to `application/octet-stream` when
+// the handler didn't pin one via `reply.type(...)`.
+//
+// Part 2 (HEAD): Node fastify auto-handles HEAD against any
+// registered GET (via `app.head` shadowing). Pre-fix Perry's
+// fastify returned a 404 JSON for `HEAD /buf` because the route
+// matcher only accepted exact-method matches. Fix: when no exact
+// HEAD route matches, fall back to a GET route on the same path,
+// rewrite the dispatch method to GET, then drop the body on the
+// wire while preserving Content-Length so clients see the size
+// they'd get from GET.
+//
+// The wire-byte assertions happen in `run_test_issue_1120.sh`:
+//   - GET /buf  →  body is the 8-byte PNG magic, content-type is
+//     `application/octet-stream`. Validates part 1 (Buffer path).
+//   - GET /u8   →  body is `01 02 03 04 05`, content-type is
+//     `application/octet-stream`. Validates Uint8Array path.
+//   - HEAD /buf →  body is empty, Content-Length is 8, status 200.
+//     Validates part 2 (auto-HEAD).
+
+import fastify from "fastify";
+import { Buffer } from "node:buffer";
+
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const PORT = 18996;
+
+const app = fastify();
+
+app.get("/buf", async (_req: any, reply: any) => {
+    reply.type("application/octet-stream");
+    return Buffer.from(PNG_MAGIC);
+});
+
+app.get("/u8", async (_req: any, _reply: any) => {
+    // No `reply.type(...)` here — the dispatcher should default to
+    // `application/octet-stream` because the returned payload is a
+    // `Uint8Array` (binary). Pre-fix this came back as `application/json`
+    // with a `{"0":1,"1":2,...}` body.
+    return new Uint8Array([1, 2, 3, 4, 5]);
+});
+
+app.listen({ port: PORT, host: "127.0.0.1" }, (err: any) => {
+    if (err) {
+        console.log("ERR " + err);
+        return;
+    }
+    console.log("LISTENING");
+    // Self-close so the parity runner sees deterministic stdout and
+    // exits within its 30s budget. 1500ms gives the harness room to
+    // issue 3 sequential curls.
+    setTimeout(() => {
+        app.close();
+        console.log("CLOSED");
+    }, 1500);
+});


### PR DESCRIPTION
## Summary

Closes #1120 end-to-end. Three coordinated behaviors land together in both `perry-ext-fastify` and the bundled `perry-stdlib` fastify (so the well-known-flip path and the fallback path both behave identically):

1. **Body integrity** — `return Buffer.from(...)` / `return new Uint8Array([...])` now ship raw bytes instead of `Buffer.toJSON()` / numeric-key-object stringification. `reply.type(...)` is no longer painted over with `application/json`. Probes `js_buffer_is_buffer` first in `jsvalue_to_response_body` + `build_response_body`; defaults content-type to `application/octet-stream` when the payload is binary and no `reply.type(...)` was set.

2. **Uint8Array array-literal coverage** — `new Uint8Array([1, 2, 3])` already lands in `BUFFER_REGISTRY` via the small-buffer slab fast-path (`is_registered_buffer`'s slab-range check), so the part-1 probe handles it transparently. No runtime change beyond the probe; the regression harness now pins this case.

3. **Auto-HEAD-for-GET** — Node fastify auto-handles `HEAD /path` against any registered `app.get(...)` via `app.head` shadowing. Pre-fix Perry returned the default 404 JSON. Fix: two-pass route match — first exact-method, then HEAD→GET fallback. When falling back, rewrite the dispatch method to `GET` so the handler runs normally, strip the body from the hyper response, emit `Content-Length` reflecting the would-have-been body size.

Mirror of the same shape #1124 used for `res.end(buf)` server-side body integrity. Detailed root-cause + per-file diffs in `CHANGELOG.md`.

## Test plan

- [x] `PERRY_BIN=./target/release/perry ./test-files/run_test_issue_1120.sh` — new wire-byte harness, three assertions per fixture boot:
  - `GET /buf` → 8-byte PNG magic + `application/octet-stream`
  - `GET /u8` → `01 02 03 04 05` + `application/octet-stream`
  - `HEAD /buf` → status 200, empty body, `Content-Length: 8`
- [x] `PERRY_BIN=./target/release/perry ./test-files/run_test_issue_1124.sh` — pre-existing http server-side Buffer body harness, no regression.
- [x] `./target/release/perry test-files/test_issue_1123_listen.ts && /tmp/test_1123_listen` — `net.createServer` accept-loop lifecycle, no regression.
- [x] `cargo test --release -p perry-ext-fastify -p perry-stdlib` — green (10 + 63 tests).
- [ ] CI: `lint`, `cargo-test`, `parity`, `compile-smoke`, `api-docs-drift`, `security-audit`.

## Context

Originated from a client report:
> Verified on perry 0.5.1014: net.createServer returns a handle but the accept loop is explicitly deferred (commit 8411fd3d note). http.createServer still doesn't link. fastify works but JSON-serializes Buffer/Uint8Array (#1120 unfixed). The only working server is fastify-with-text-only-responses.

Of the three claims:

1. `net.createServer` accept loop — **already wired up** in the same squashed PR #1133 the client cited. The client read only the first sub-commit's note in the squash; the second sub-commit (`feat(net): #1123 followup — Server.listen + 'connection' accept loop`) fully wires the accept loop. `test_issue_1123_listen.ts` runs the full lifecycle clean.
2. `http.createServer` linking — **already works.** Compiled, linked, listened, responded.
3. fastify Buffer/Uint8Array — **real bug, fixed here.**

Out-of-scope of `#1120` (not affected by this PR): the issue body's second half — overriding `app.head()` registrations explicitly — is still served by the standard route match before the auto-HEAD fallback fires, so user-defined HEAD handlers continue to win.