### PR TITLE
feat(parity): querystring BigInt support + edge-case test coverage

### DIFF
--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -407,6 +407,17 @@ fn querystring_scalar_to_string(value_bits: u64) -> String {
     if value.is_int32() {
         return value.as_int32().to_string();
     }
+    if value.is_bigint() {
+        let ptr = value.as_bigint_ptr();
+        if ptr.is_null() {
+            return String::new();
+        }
+        let hdr = unsafe { perry_runtime::bigint::js_bigint_to_string(ptr) };
+        if hdr.is_null() {
+            return String::new();
+        }
+        return unsafe { nanboxed_to_string(nanbox_string(hdr)) }.unwrap_or_default();
+    }
     if value.is_number() {
         let n = value.as_number();
         if !n.is_finite() {

--- a/test-parity/node-suite/querystring/parse/empty-keys.ts
+++ b/test-parity/node-suite/querystring/parse/empty-keys.ts
@@ -1,0 +1,6 @@
+import { parse } from "node:querystring";
+
+console.log("=value:", JSON.stringify(parse("=value")));
+console.log("=:", JSON.stringify(parse("=")));
+console.log("===:", JSON.stringify(parse("===")));
+console.log("=a&=b:", JSON.stringify(parse("=a&=b")));

--- a/test-parity/node-suite/querystring/parse/invalid-percent.ts
+++ b/test-parity/node-suite/querystring/parse/invalid-percent.ts
@@ -1,0 +1,7 @@
+import { parse } from "node:querystring";
+
+console.log("%G1:", JSON.stringify(parse("a=%G1")));
+console.log("trailing %:", JSON.stringify(parse("a=%")));
+console.log("short %2:", JSON.stringify(parse("a=%2")));
+console.log("%ZZ:", JSON.stringify(parse("a=%ZZ")));
+console.log("mixed:", JSON.stringify(parse("a=%41%G1%42")));

--- a/test-parity/node-suite/querystring/stringify/bigint.ts
+++ b/test-parity/node-suite/querystring/stringify/bigint.ts
@@ -1,0 +1,6 @@
+import { stringify } from "node:querystring";
+
+console.log("small:", stringify({ a: 1n as unknown as string }));
+console.log("large:", stringify({ a: 9007199254740993n as unknown as string }));
+console.log("negative:", stringify({ a: (-42n) as unknown as string }));
+console.log("array:", stringify({ a: [1n, 2n, 3n] as unknown as string[] }));

--- a/test-parity/node-suite/querystring/stringify/empty-object.ts
+++ b/test-parity/node-suite/querystring/stringify/empty-object.ts
@@ -1,0 +1,5 @@
+import { stringify } from "node:querystring";
+
+console.log("empty:", JSON.stringify(stringify({})));
+console.log("empty array val:", JSON.stringify(stringify({ a: [] })));
+console.log("nested empty:", JSON.stringify(stringify({ a: {} as unknown as string })));

--- a/test-parity/node-suite/querystring/stringify/non-object-input.ts
+++ b/test-parity/node-suite/querystring/stringify/non-object-input.ts
@@ -1,0 +1,7 @@
+import { stringify } from "node:querystring";
+
+console.log("null:", JSON.stringify(stringify(null as unknown as Record<string, unknown>)));
+console.log("undefined:", JSON.stringify(stringify(undefined as unknown as Record<string, unknown>)));
+console.log("string:", JSON.stringify(stringify("a=1" as unknown as Record<string, unknown>)));
+console.log("number:", JSON.stringify(stringify(42 as unknown as Record<string, unknown>)));
+console.log("bool:", JSON.stringify(stringify(true as unknown as Record<string, unknown>)));

--- a/test-parity/node-suite/querystring/stringify/space-encoding.ts
+++ b/test-parity/node-suite/querystring/stringify/space-encoding.ts
@@ -1,0 +1,6 @@
+import { stringify } from "node:querystring";
+
+console.log("single space:", stringify({ a: "hello world" }));
+console.log("multi spaces:", stringify({ key: "a  b   c" }));
+console.log("plus literal:", stringify({ a: "a+b" }));
+console.log("mix:", stringify({ a: "a b+c d" }));


### PR DESCRIPTION
## Summary

Follow-up to #1169. Adds six new parity cases under `test-parity/node-suite/querystring/` and fixes one stringify gap surfaced by them.

- **BigInt in `stringify`**: `{ a: 1n }` now serializes as `a=1`. Previously it produced `a=` — `JSValue::is_number()` returns true for BIGINT_TAG (0x7FFA) because that tag sits outside the 0x7FFC..=0x7FFF tagged range the predicate checks, so BigInts hit the number branch and `is_finite()`/`fract()` turned them into empty strings. Reordering `querystring_scalar_to_string` to check `is_bigint()` before `is_number()` routes them through `js_bigint_to_string` for a correct decimal `toString()`.
- New PASS cases (all green against `node --experimental-strip-types`):
  - `parse/empty-keys` — `=value`, `=`, `===`, `=a&=b`
  - `parse/invalid-percent` — `%G1`, trailing `%`, short `%2`, `%ZZ`, mixed
  - `stringify/bigint` — small / large / negative / array of BigInt
  - `stringify/empty-object` — `{}`, `{ a: [] }`, nested empty object
  - `stringify/non-object-input` — null / undefined / string / number / bool inputs
  - `stringify/space-encoding` — spaces encode as `%20` (not `+`), `+` literal preserved

Querystring suite now: **33/33 PASS (100%)**.

## Out of scope (follow-ups)

While writing these cases I also drafted four more that surfaced real gaps. Filed separately so this PR stays cohesive — see issues linked below.

## Test plan

- [ ] `cargo build --release -p perry-runtime -p perry-stdlib -p perry`
- [ ] `./run_parity_tests.sh --suite node-suite --module querystring` — 33/33 PASS
- [ ] `./run_parity_tests.sh` full sweep — no regressions
- [ ] `cargo test --release --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-visionos --exclude perry-ui-android --exclude perry-ui-windows --exclude perry-ui-gtk4`

## Notes

- No version bump or CHANGELOG entry (maintainer folds in at merge time).
- No ABI change vs main (the 4-arg `js_querystring_parse` widening already landed in #1169).