### PR TITLE
fix(hir+codegen): chained Buffer.concat(x).slice(...) → real Buffer.slice (#1177)

### DIFF
--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -9876,6 +9876,44 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &buf_handle))
         }
 
+        // #1177: `buf.slice(start?, end?)` on a statically buffer-producing
+        // receiver — emitted by the HIR fold at `expr_call/mod.rs:5396` when
+        // `.slice` is called on `BufferConcat` / `BufferFrom` / a chained
+        // `BufferSlice`. Pre-fix the chained `Buffer.concat(c).slice(0,8)`
+        // shape fell through to generic dynamic dispatch which routed
+        // `.slice` through String.slice semantics on the NaN-boxed Buffer
+        // pointer — producing a "string" with length=8 and all bytes empty.
+        // Folding to `Expr::BufferSlice` here calls `js_buffer_slice` (which
+        // ALWAYS copies bytes via `ptr::copy_nonoverlapping` into a freshly
+        // allocated Buffer registered in BUFFER_REGISTRY) so the result has
+        // its own backing storage independent of the parent's lifetime.
+        Expr::BufferSlice { buffer, start, end } => {
+            let buf_box = lower_expr(ctx, buffer)?;
+            let blk = ctx.block();
+            let buf_handle = unbox_to_i64(blk, &buf_box);
+            // Default start=0, end=buf.length. `js_buffer_slice` itself
+            // handles end-clamping via `.min(len)`, so we can pass i32::MAX
+            // when end is omitted to mean "to the end" — matches how the
+            // Node API treats `buf.slice(start)` (no end → to the end).
+            let start_box = match start {
+                Some(e) => lower_expr(ctx, e)?,
+                None => double_literal(0.0),
+            };
+            let end_box = match end {
+                Some(e) => lower_expr(ctx, e)?,
+                None => double_literal(i32::MAX as f64),
+            };
+            let blk = ctx.block();
+            let start_i32 = blk.fptosi(DOUBLE, &start_box, I32);
+            let end_i32 = blk.fptosi(DOUBLE, &end_box, I32);
+            let result = blk.call(
+                I64,
+                "js_buffer_slice",
+                &[(I64, &buf_handle), (I32, &start_i32), (I32, &end_i32)],
+            );
+            Ok(nanbox_pointer_inline(blk, &result))
+        }
+
         // -------- BufferIsBuffer --------
         // `Buffer.isBuffer(x)`. Runtime returns i32 (0/1); wrap as NaN-boxed
         // boolean. `js_buffer_is_buffer` already strips NaN-box tags and

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -5395,6 +5395,32 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                             // returns false and JSON.stringify segfaults.
                             "slice" if !args.is_empty() => {
                                 let array_expr = lower_expr(ctx, &member.obj)?;
+                                // #1177: when the receiver is statically Buffer-producing
+                                // (`Buffer.concat(...).slice(0,8)`, `Buffer.from(...).slice(...)`,
+                                // or a chained `.slice(...).slice(...)`), the receiver type isn't
+                                // an `Ident` so the buffer-method block above can't see it. The
+                                // generic Call fallthrough then routes `.slice` through
+                                // `js_native_call_method` which picks String.slice semantics on
+                                // the NaN-boxed Buffer pointer — producing a "string" of length
+                                // 8 with all bytes as spaces/undefined. Fold to `Expr::BufferSlice`
+                                // here so codegen calls `js_buffer_slice` directly. Must come
+                                // BEFORE the Array shapes below so a `BufferConcat`/`BufferFrom`/
+                                // `BufferSlice` receiver is never misrouted to `Expr::ArraySlice`.
+                                if matches!(
+                                    &array_expr,
+                                    Expr::BufferConcat(_)
+                                        | Expr::BufferFrom { .. }
+                                        | Expr::BufferSlice { .. }
+                                ) {
+                                    let mut args_iter = args.into_iter();
+                                    let start = args_iter.next().unwrap();
+                                    let end = args_iter.next();
+                                    return Ok(Expr::BufferSlice {
+                                        buffer: Box::new(array_expr),
+                                        start: Some(Box::new(start)),
+                                        end: end.map(Box::new),
+                                    });
+                                }
                                 if matches!(
                                     &array_expr,
                                     Expr::ArrayMap { .. } | Expr::ArrayFilter { .. } | Expr::ArraySort { .. } |


### PR DESCRIPTION
## Summary

Fixes #1177. `Buffer.concat(chunks).slice(0, 8)` written inline (no intermediate `const`) returned a "string" of length 8 whose bytes were all empty/undefined. Storing the concat result in a local first made `.slice` work — which is why the bug went unnoticed: every example in real code happened to use the local-bound form, until someone wrote the natural one-liner during the #1132 verification detour.

## Root cause

The buffer-method dispatch block at `crates/perry-hir/src/lower/expr_call/mod.rs:3809` is guarded by `if let ast::Expr::Ident(arr_ident) = member.obj.as_ref()` — it only fires when the `.slice` receiver is a bare identifier. For chained `Buffer.concat(chunks).slice(0,8)` the receiver is itself a `CallExpr`, so the buffer-aware path is skipped.

The `.slice` arm at `:5396` folded receivers like `ArrayMap`, `ArraySort`, `Array(_)`, etc. to `Expr::ArraySlice`, but `BufferConcat` / `BufferFrom` / `BufferSlice` weren't in the list. Generic Call fallthrough routed `.slice` through `js_native_call_method` which picked **String.slice** semantics on the NaN-boxed Buffer pointer — producing `typeof === "string"`, `isBuffer === false`, `length=8`, all bytes empty.

## Fix

1. **HIR fold** (`expr_call/mod.rs:5396`): before the existing ArraySlice fold, recognize `BufferConcat` / `BufferFrom` / `BufferSlice` receivers and emit `Expr::BufferSlice { buffer, start, end }`. Must come **before** the Array shapes so a Buffer receiver isn't misrouted to `ArraySlice` (which would call `js_array_slice` on a Buffer pointer).
2. **Codegen** (`expr/mod.rs`): `Expr::BufferSlice` had a HIR variant declared and walked but no codegen lowering. Added an arm that lowers start/end to i32 (default `0` and `i32::MAX` for the "no end" case — `js_buffer_slice` clamps end to length) and calls `js_buffer_slice` directly. `js_buffer_slice` already `ptr::copy_nonoverlapping`'s bytes into a newly allocated Buffer registered in BUFFER_REGISTRY, so the result has its own backing storage independent of the parent's lifetime.

## Test plan

- [x] Issue-body repro `Array.from(Buffer.concat(chunks).slice(0, 8)).join(",")` → `137,80,78,71,13,10,26,10` (was `, , , , , , , `)
- [x] `typeof Buffer.concat(c).slice(0,8) === "object"` (was `"string"`)
- [x] `Buffer.isBuffer(Buffer.concat(c).slice(0,8)) === true` (was `false`)
- [x] Chain of slices `Buffer.concat(c).slice(0,8).slice(2,4)` → `78,71`
- [x] `Buffer.from([1,2,3,4,5]).slice(1,4)` → `2,3,4`
- [x] Default-end `Buffer.concat(c).slice(2)` → `78,71,13,10,26,10`
- [x] Pre-existing stored-then-slice form `const b = Buffer.concat(c); b.slice(0,8)` still works (regression check)
- [x] Existing #1132 verification (`http.createServer` → `http.get` → `chunks` → `slice`) unchanged
- [x] `cargo test --release -p perry-hir -p perry-codegen` clean