### PR TITLE
fix(runtime): #1187 implement Date.prototype local-time setters

### DIFF
--- a/crates/perry-codegen-js/src/emit.rs
+++ b/crates/perry-codegen-js/src/emit.rs
@@ -2200,6 +2200,14 @@ impl JsEmitter {
             Expr::DateSetUtcMinutes { date, value } => { self.emit_expr(date); self.output.push_str(".setUTCMinutes("); self.emit_expr(value); self.output.push(')'); }
             Expr::DateSetUtcSeconds { date, value } => { self.emit_expr(date); self.output.push_str(".setUTCSeconds("); self.emit_expr(value); self.output.push(')'); }
             Expr::DateSetUtcMilliseconds { date, value } => { self.emit_expr(date); self.output.push_str(".setUTCMilliseconds("); self.emit_expr(value); self.output.push(')'); }
+            Expr::DateSetFullYear { date, value } => { self.emit_expr(date); self.output.push_str(".setFullYear("); self.emit_expr(value); self.output.push(')'); }
+            Expr::DateSetMonth { date, value } => { self.emit_expr(date); self.output.push_str(".setMonth("); self.emit_expr(value); self.output.push(')'); }
+            Expr::DateSetDate { date, value } => { self.emit_expr(date); self.output.push_str(".setDate("); self.emit_expr(value); self.output.push(')'); }
+            Expr::DateSetHours { date, value } => { self.emit_expr(date); self.output.push_str(".setHours("); self.emit_expr(value); self.output.push(')'); }
+            Expr::DateSetMinutes { date, value } => { self.emit_expr(date); self.output.push_str(".setMinutes("); self.emit_expr(value); self.output.push(')'); }
+            Expr::DateSetSeconds { date, value } => { self.emit_expr(date); self.output.push_str(".setSeconds("); self.emit_expr(value); self.output.push(')'); }
+            Expr::DateSetMilliseconds { date, value } => { self.emit_expr(date); self.output.push_str(".setMilliseconds("); self.emit_expr(value); self.output.push(')'); }
+            Expr::DateSetTime { date, value } => { self.emit_expr(date); self.output.push_str(".setTime("); self.emit_expr(value); self.output.push(')'); }
             Expr::DateValueOf(d) => { self.emit_expr(d); self.output.push_str(".valueOf()"); }
             Expr::DateToDateString(d) => { self.emit_expr(d); self.output.push_str(".toDateString()"); }
             Expr::DateToTimeString(d) => { self.emit_expr(d); self.output.push_str(".toTimeString()"); }

--- a/crates/perry-codegen-wasm/src/emit/expr.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr.rs
@@ -3307,6 +3307,54 @@ impl<'a> FuncEmitCtx<'a> {
                 self.emit_store_arg(func, 1, value);
                 self.emit_memcall(func, "date_set_utc_milliseconds", 2);
             }
+            Expr::DateSetFullYear { date, value } => {
+                self.emit_frame_begin(func, 2);
+                self.emit_store_arg(func, 0, date);
+                self.emit_store_arg(func, 1, value);
+                self.emit_memcall(func, "date_set_full_year", 2);
+            }
+            Expr::DateSetMonth { date, value } => {
+                self.emit_frame_begin(func, 2);
+                self.emit_store_arg(func, 0, date);
+                self.emit_store_arg(func, 1, value);
+                self.emit_memcall(func, "date_set_month", 2);
+            }
+            Expr::DateSetDate { date, value } => {
+                self.emit_frame_begin(func, 2);
+                self.emit_store_arg(func, 0, date);
+                self.emit_store_arg(func, 1, value);
+                self.emit_memcall(func, "date_set_date", 2);
+            }
+            Expr::DateSetHours { date, value } => {
+                self.emit_frame_begin(func, 2);
+                self.emit_store_arg(func, 0, date);
+                self.emit_store_arg(func, 1, value);
+                self.emit_memcall(func, "date_set_hours", 2);
+            }
+            Expr::DateSetMinutes { date, value } => {
+                self.emit_frame_begin(func, 2);
+                self.emit_store_arg(func, 0, date);
+                self.emit_store_arg(func, 1, value);
+                self.emit_memcall(func, "date_set_minutes", 2);
+            }
+            Expr::DateSetSeconds { date, value } => {
+                self.emit_frame_begin(func, 2);
+                self.emit_store_arg(func, 0, date);
+                self.emit_store_arg(func, 1, value);
+                self.emit_memcall(func, "date_set_seconds", 2);
+            }
+            Expr::DateSetMilliseconds { date, value } => {
+                self.emit_frame_begin(func, 2);
+                self.emit_store_arg(func, 0, date);
+                self.emit_store_arg(func, 1, value);
+                self.emit_memcall(func, "date_set_milliseconds", 2);
+            }
+            Expr::DateSetTime { date, value } => {
+                self.emit_frame_begin(func, 2);
+                self.emit_store_arg(func, 0, date);
+                self.emit_store_arg(func, 1, value);
+                self.emit_memcall(func, "date_set_time", 2);
+            }
 
             // --- Error ---
             Expr::ErrorNew(msg) => {

--- a/crates/perry-codegen-wasm/src/emit/string_collection.rs
+++ b/crates/perry-codegen-wasm/src/emit/string_collection.rs
@@ -833,7 +833,15 @@ impl WasmModuleEmitter {
             | Expr::DateSetUtcHours { date, value }
             | Expr::DateSetUtcMinutes { date, value }
             | Expr::DateSetUtcSeconds { date, value }
-            | Expr::DateSetUtcMilliseconds { date, value } => {
+            | Expr::DateSetUtcMilliseconds { date, value }
+            | Expr::DateSetFullYear { date, value }
+            | Expr::DateSetMonth { date, value }
+            | Expr::DateSetDate { date, value }
+            | Expr::DateSetHours { date, value }
+            | Expr::DateSetMinutes { date, value }
+            | Expr::DateSetSeconds { date, value }
+            | Expr::DateSetMilliseconds { date, value }
+            | Expr::DateSetTime { date, value } => {
                 self.collect_strings_in_expr(date);
                 self.collect_strings_in_expr(value);
             }

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -9780,6 +9780,81 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 &[(DOUBLE, &d), (DOUBLE, &v)],
             ))
         }
+        // Local-time Date setters (#1187). The runtime functions all share
+        // the same `(timestamp, value) -> new_timestamp` shape, so the
+        // lowering is the same modulo the C symbol name.
+        Expr::DateSetFullYear { date, value } => {
+            let d = lower_expr(ctx, date)?;
+            let v = lower_expr(ctx, value)?;
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_date_set_full_year",
+                &[(DOUBLE, &d), (DOUBLE, &v)],
+            ))
+        }
+        Expr::DateSetMonth { date, value } => {
+            let d = lower_expr(ctx, date)?;
+            let v = lower_expr(ctx, value)?;
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_date_set_month",
+                &[(DOUBLE, &d), (DOUBLE, &v)],
+            ))
+        }
+        Expr::DateSetDate { date, value } => {
+            let d = lower_expr(ctx, date)?;
+            let v = lower_expr(ctx, value)?;
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_date_set_date",
+                &[(DOUBLE, &d), (DOUBLE, &v)],
+            ))
+        }
+        Expr::DateSetHours { date, value } => {
+            let d = lower_expr(ctx, date)?;
+            let v = lower_expr(ctx, value)?;
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_date_set_hours",
+                &[(DOUBLE, &d), (DOUBLE, &v)],
+            ))
+        }
+        Expr::DateSetMinutes { date, value } => {
+            let d = lower_expr(ctx, date)?;
+            let v = lower_expr(ctx, value)?;
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_date_set_minutes",
+                &[(DOUBLE, &d), (DOUBLE, &v)],
+            ))
+        }
+        Expr::DateSetSeconds { date, value } => {
+            let d = lower_expr(ctx, date)?;
+            let v = lower_expr(ctx, value)?;
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_date_set_seconds",
+                &[(DOUBLE, &d), (DOUBLE, &v)],
+            ))
+        }
+        Expr::DateSetMilliseconds { date, value } => {
+            let d = lower_expr(ctx, date)?;
+            let v = lower_expr(ctx, value)?;
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_date_set_milliseconds",
+                &[(DOUBLE, &d), (DOUBLE, &v)],
+            ))
+        }
+        Expr::DateSetTime { date, value } => {
+            let d = lower_expr(ctx, date)?;
+            let v = lower_expr(ctx, value)?;
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_date_set_time",
+                &[(DOUBLE, &d), (DOUBLE, &v)],
+            ))
+        }
         Expr::ArrayIsArray(o) => {
             // Fast path: static type is definitively array → emit
             // TAG_TRUE at compile time. Slow path: indeterminate

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -9795,47 +9795,37 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::DateSetMonth { date, value } => {
             let d = lower_expr(ctx, date)?;
             let v = lower_expr(ctx, value)?;
-            Ok(ctx.block().call(
-                DOUBLE,
-                "js_date_set_month",
-                &[(DOUBLE, &d), (DOUBLE, &v)],
-            ))
+            Ok(ctx
+                .block()
+                .call(DOUBLE, "js_date_set_month", &[(DOUBLE, &d), (DOUBLE, &v)]))
         }
         Expr::DateSetDate { date, value } => {
             let d = lower_expr(ctx, date)?;
             let v = lower_expr(ctx, value)?;
-            Ok(ctx.block().call(
-                DOUBLE,
-                "js_date_set_date",
-                &[(DOUBLE, &d), (DOUBLE, &v)],
-            ))
+            Ok(ctx
+                .block()
+                .call(DOUBLE, "js_date_set_date", &[(DOUBLE, &d), (DOUBLE, &v)]))
         }
         Expr::DateSetHours { date, value } => {
             let d = lower_expr(ctx, date)?;
             let v = lower_expr(ctx, value)?;
-            Ok(ctx.block().call(
-                DOUBLE,
-                "js_date_set_hours",
-                &[(DOUBLE, &d), (DOUBLE, &v)],
-            ))
+            Ok(ctx
+                .block()
+                .call(DOUBLE, "js_date_set_hours", &[(DOUBLE, &d), (DOUBLE, &v)]))
         }
         Expr::DateSetMinutes { date, value } => {
             let d = lower_expr(ctx, date)?;
             let v = lower_expr(ctx, value)?;
-            Ok(ctx.block().call(
-                DOUBLE,
-                "js_date_set_minutes",
-                &[(DOUBLE, &d), (DOUBLE, &v)],
-            ))
+            Ok(ctx
+                .block()
+                .call(DOUBLE, "js_date_set_minutes", &[(DOUBLE, &d), (DOUBLE, &v)]))
         }
         Expr::DateSetSeconds { date, value } => {
             let d = lower_expr(ctx, date)?;
             let v = lower_expr(ctx, value)?;
-            Ok(ctx.block().call(
-                DOUBLE,
-                "js_date_set_seconds",
-                &[(DOUBLE, &d), (DOUBLE, &v)],
-            ))
+            Ok(ctx
+                .block()
+                .call(DOUBLE, "js_date_set_seconds", &[(DOUBLE, &d), (DOUBLE, &v)]))
         }
         Expr::DateSetMilliseconds { date, value } => {
             let d = lower_expr(ctx, date)?;
@@ -9849,11 +9839,9 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::DateSetTime { date, value } => {
             let d = lower_expr(ctx, date)?;
             let v = lower_expr(ctx, value)?;
-            Ok(ctx.block().call(
-                DOUBLE,
-                "js_date_set_time",
-                &[(DOUBLE, &d), (DOUBLE, &v)],
-            ))
+            Ok(ctx
+                .block()
+                .call(DOUBLE, "js_date_set_time", &[(DOUBLE, &d), (DOUBLE, &v)]))
         }
         Expr::ArrayIsArray(o) => {
             // Fast path: static type is definitively array → emit

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -872,6 +872,15 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_date_set_utc_minutes", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_date_set_utc_seconds", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_date_set_utc_milliseconds", DOUBLE, &[DOUBLE, DOUBLE]);
+    // Local-time setters (#1187).
+    module.declare_function("js_date_set_full_year", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_date_set_month", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_date_set_date", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_date_set_hours", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_date_set_minutes", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_date_set_seconds", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_date_set_milliseconds", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_date_set_time", DOUBLE, &[DOUBLE, DOUBLE]);
     // Math extras (stubs in expr.rs had fallen through to no-op/passthrough).
     module.declare_function("js_math_clz32", DOUBLE, &[DOUBLE]);
     module.declare_function("js_math_cbrt", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/ir.rs
+++ b/crates/perry-hir/src/ir.rs
@@ -2308,6 +2308,40 @@ pub enum Expr {
         value: Box<Expr>,
     },
 
+    // Date setters (local-time variants) — return the new timestamp (#1187)
+    DateSetFullYear {
+        date: Box<Expr>,
+        value: Box<Expr>,
+    },
+    DateSetMonth {
+        date: Box<Expr>,
+        value: Box<Expr>,
+    },
+    DateSetDate {
+        date: Box<Expr>,
+        value: Box<Expr>,
+    },
+    DateSetHours {
+        date: Box<Expr>,
+        value: Box<Expr>,
+    },
+    DateSetMinutes {
+        date: Box<Expr>,
+        value: Box<Expr>,
+    },
+    DateSetSeconds {
+        date: Box<Expr>,
+        value: Box<Expr>,
+    },
+    DateSetMilliseconds {
+        date: Box<Expr>,
+        value: Box<Expr>,
+    },
+    DateSetTime {
+        date: Box<Expr>,
+        value: Box<Expr>,
+    },
+
     // Date misc
     DateValueOf(Box<Expr>),      // date.valueOf() -> number (same as getTime)
     DateToDateString(Box<Expr>), // date.toDateString() -> string

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -3605,9 +3605,16 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                                 let date_expr = lower_expr(ctx, &member.obj)?;
                                 return Ok(Expr::DateToJSON(Box::new(date_expr)));
                             }
-                            // UTC setters — mutate the local variable in place
+                            // UTC setters — mutate the local variable in place.
+                            // Local-time setters (#1187) live in the same arm —
+                            // pre-fix `setHours` / `setDate` / etc. fell through
+                            // and surfaced as `(number).setHours is not a
+                            // function` at runtime because Date is stored as a
+                            // raw f64 with no method table.
                             "setUTCFullYear" | "setUTCMonth" | "setUTCDate" | "setUTCHours"
-                            | "setUTCMinutes" | "setUTCSeconds" | "setUTCMilliseconds" => {
+                            | "setUTCMinutes" | "setUTCSeconds" | "setUTCMilliseconds"
+                            | "setFullYear" | "setMonth" | "setDate" | "setHours"
+                            | "setMinutes" | "setSeconds" | "setMilliseconds" | "setTime" => {
                                 if !args.is_empty() {
                                     let value_expr = args.into_iter().next().unwrap();
                                     let date_expr = lower_expr(ctx, &member.obj)?;
@@ -3637,6 +3644,38 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                                             value: Box::new(value_expr),
                                         },
                                         "setUTCMilliseconds" => Expr::DateSetUtcMilliseconds {
+                                            date: Box::new(date_expr.clone()),
+                                            value: Box::new(value_expr),
+                                        },
+                                        "setFullYear" => Expr::DateSetFullYear {
+                                            date: Box::new(date_expr.clone()),
+                                            value: Box::new(value_expr),
+                                        },
+                                        "setMonth" => Expr::DateSetMonth {
+                                            date: Box::new(date_expr.clone()),
+                                            value: Box::new(value_expr),
+                                        },
+                                        "setDate" => Expr::DateSetDate {
+                                            date: Box::new(date_expr.clone()),
+                                            value: Box::new(value_expr),
+                                        },
+                                        "setHours" => Expr::DateSetHours {
+                                            date: Box::new(date_expr.clone()),
+                                            value: Box::new(value_expr),
+                                        },
+                                        "setMinutes" => Expr::DateSetMinutes {
+                                            date: Box::new(date_expr.clone()),
+                                            value: Box::new(value_expr),
+                                        },
+                                        "setSeconds" => Expr::DateSetSeconds {
+                                            date: Box::new(date_expr.clone()),
+                                            value: Box::new(value_expr),
+                                        },
+                                        "setMilliseconds" => Expr::DateSetMilliseconds {
+                                            date: Box::new(date_expr.clone()),
+                                            value: Box::new(value_expr),
+                                        },
+                                        "setTime" => Expr::DateSetTime {
                                             date: Box::new(date_expr.clone()),
                                             value: Box::new(value_expr),
                                         },

--- a/crates/perry-hir/src/stable_hash.rs
+++ b/crates/perry-hir/src/stable_hash.rs
@@ -2999,6 +2999,46 @@ impl SH for Expr {
                 date.as_ref().hash(h);
                 value.as_ref().hash(h);
             }
+            Expr::DateSetFullYear { date, value } => {
+                tag(h, 478);
+                date.as_ref().hash(h);
+                value.as_ref().hash(h);
+            }
+            Expr::DateSetMonth { date, value } => {
+                tag(h, 479);
+                date.as_ref().hash(h);
+                value.as_ref().hash(h);
+            }
+            Expr::DateSetDate { date, value } => {
+                tag(h, 480);
+                date.as_ref().hash(h);
+                value.as_ref().hash(h);
+            }
+            Expr::DateSetHours { date, value } => {
+                tag(h, 481);
+                date.as_ref().hash(h);
+                value.as_ref().hash(h);
+            }
+            Expr::DateSetMinutes { date, value } => {
+                tag(h, 482);
+                date.as_ref().hash(h);
+                value.as_ref().hash(h);
+            }
+            Expr::DateSetSeconds { date, value } => {
+                tag(h, 483);
+                date.as_ref().hash(h);
+                value.as_ref().hash(h);
+            }
+            Expr::DateSetMilliseconds { date, value } => {
+                tag(h, 484);
+                date.as_ref().hash(h);
+                value.as_ref().hash(h);
+            }
+            Expr::DateSetTime { date, value } => {
+                tag(h, 485);
+                date.as_ref().hash(h);
+                value.as_ref().hash(h);
+            }
             Expr::DateValueOf(e) => {
                 tag(h, 338);
                 e.as_ref().hash(h);

--- a/crates/perry-hir/src/walker.rs
+++ b/crates/perry-hir/src/walker.rs
@@ -754,7 +754,15 @@ where
         | Expr::DateSetUtcHours { date, value }
         | Expr::DateSetUtcMinutes { date, value }
         | Expr::DateSetUtcSeconds { date, value }
-        | Expr::DateSetUtcMilliseconds { date, value } => {
+        | Expr::DateSetUtcMilliseconds { date, value }
+        | Expr::DateSetFullYear { date, value }
+        | Expr::DateSetMonth { date, value }
+        | Expr::DateSetDate { date, value }
+        | Expr::DateSetHours { date, value }
+        | Expr::DateSetMinutes { date, value }
+        | Expr::DateSetSeconds { date, value }
+        | Expr::DateSetMilliseconds { date, value }
+        | Expr::DateSetTime { date, value } => {
             f(date);
             f(value);
         }
@@ -2100,7 +2108,15 @@ where
         | Expr::DateSetUtcHours { date, value }
         | Expr::DateSetUtcMinutes { date, value }
         | Expr::DateSetUtcSeconds { date, value }
-        | Expr::DateSetUtcMilliseconds { date, value } => {
+        | Expr::DateSetUtcMilliseconds { date, value }
+        | Expr::DateSetFullYear { date, value }
+        | Expr::DateSetMonth { date, value }
+        | Expr::DateSetDate { date, value }
+        | Expr::DateSetHours { date, value }
+        | Expr::DateSetMinutes { date, value }
+        | Expr::DateSetSeconds { date, value }
+        | Expr::DateSetMilliseconds { date, value }
+        | Expr::DateSetTime { date, value } => {
             f(date);
             f(value);
         }

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -875,6 +875,164 @@ pub extern "C" fn js_date_set_utc_milliseconds(timestamp: f64, value: f64) -> f6
     )
 }
 
+// --- Local-time setters (#1187) ---
+//
+// `setHours` / `setDate` / `setMonth` / `setFullYear` / etc. interpret their
+// argument in the running process's *local* timezone, so the rebuild has to
+// round-trip through `timestamp_to_local_components`. The local-clock
+// components get reassembled with the requested component swapped, then we
+// subtract the tz offset at that instant to land back at a true UTC epoch.
+// Mirrors the conversion in `js_date_new_local_components`. NaN passes
+// through untouched so an Invalid Date stays an Invalid Date.
+
+fn rebuild_local_with(
+    timestamp: f64,
+    year: Option<i32>,
+    month: Option<u32>,
+    day: Option<u32>,
+    hour: Option<u32>,
+    minute: Option<u32>,
+    second: Option<u32>,
+    millisecond: Option<i64>,
+) -> f64 {
+    if timestamp.is_nan() {
+        return timestamp;
+    }
+    let ts_ms = timestamp as i64;
+    let secs = ts_ms.div_euclid(1000);
+    let cur_ms = ts_ms.rem_euclid(1000);
+    let (cy, cm, cd, ch, cmi, cs, _) = timestamp_to_local_components(secs);
+    let new_year = year.unwrap_or(cy);
+    let new_month = month.unwrap_or(cm);
+    let new_day = day.unwrap_or(cd);
+    let new_hour = hour.unwrap_or(ch);
+    let new_minute = minute.unwrap_or(cmi);
+    let new_second = second.unwrap_or(cs);
+    let new_ms = millisecond.unwrap_or(cur_ms);
+    let local_secs = components_to_timestamp(
+        new_year, new_month, new_day, new_hour, new_minute, new_second,
+    );
+    let (_, _, _, _, _, _, tz_offset) = timestamp_to_local_components(local_secs);
+    let utc_secs = local_secs - tz_offset;
+    let result = (utc_secs * 1000 + new_ms) as f64;
+    let result = date_or_invalid(result);
+    if !result.is_nan() {
+        register_date_bits(result.to_bits());
+    }
+    result
+}
+
+#[no_mangle]
+pub extern "C" fn js_date_set_full_year(timestamp: f64, value: f64) -> f64 {
+    rebuild_local_with(
+        timestamp,
+        Some(value as i32),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn js_date_set_month(timestamp: f64, value: f64) -> f64 {
+    // JS months are 0-based; components_to_timestamp wants 1-based.
+    rebuild_local_with(
+        timestamp,
+        None,
+        Some(value as u32 + 1),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn js_date_set_date(timestamp: f64, value: f64) -> f64 {
+    rebuild_local_with(
+        timestamp,
+        None,
+        None,
+        Some(value as u32),
+        None,
+        None,
+        None,
+        None,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn js_date_set_hours(timestamp: f64, value: f64) -> f64 {
+    rebuild_local_with(
+        timestamp,
+        None,
+        None,
+        None,
+        Some(value as u32),
+        None,
+        None,
+        None,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn js_date_set_minutes(timestamp: f64, value: f64) -> f64 {
+    rebuild_local_with(
+        timestamp,
+        None,
+        None,
+        None,
+        None,
+        Some(value as u32),
+        None,
+        None,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn js_date_set_seconds(timestamp: f64, value: f64) -> f64 {
+    rebuild_local_with(
+        timestamp,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(value as u32),
+        None,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn js_date_set_milliseconds(timestamp: f64, value: f64) -> f64 {
+    rebuild_local_with(
+        timestamp,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(value as i64),
+    )
+}
+
+/// `date.setTime(ms)` — replace the entire time value. NaN in produces an
+/// Invalid Date; otherwise the new ms timestamp is registered so future
+/// `instanceof Date` checks succeed.
+#[no_mangle]
+pub extern "C" fn js_date_set_time(_timestamp: f64, value: f64) -> f64 {
+    let result = date_or_invalid(value);
+    if !result.is_nan() {
+        register_date_bits(result.to_bits());
+    }
+    result
+}
+
 // --- String-returning Date methods ---
 
 const WEEKDAY_NAMES: [&str; 7] = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];

--- a/test-files/test_issue_1187_date_setters.ts
+++ b/test-files/test_issue_1187_date_setters.ts
@@ -1,0 +1,32 @@
+// Issue #1187 — Date.prototype local-time setters
+// Pre-fix: `d.setHours(...)` threw `TypeError: (number).setHours is not a function`
+// because the HIR lowering only dispatched `setUTC*` methods.
+
+function getExpiry(): Date {
+  const expiry = new Date(2024, 0, 15, 10, 0, 0, 0);
+  expiry.setHours(expiry.getHours() + 1);
+  return expiry;
+}
+
+const e = getExpiry();
+console.log(e.getHours());
+
+const d = new Date(2024, 0, 15, 10, 0, 0, 0);
+d.setDate(20);
+console.log(d.getDate());
+d.setMonth(5);
+console.log(d.getMonth());
+d.setFullYear(2025);
+console.log(d.getFullYear());
+d.setMinutes(30);
+console.log(d.getMinutes());
+d.setSeconds(45);
+console.log(d.getSeconds());
+d.setMilliseconds(500);
+console.log(d.getMilliseconds());
+d.setTime(0);
+console.log(d.getTime());
+
+const d2 = new Date(2024, 0, 15, 10, 0, 0, 0);
+console.log(d2.setHours(15));
+console.log(d2.getHours());


### PR DESCRIPTION
## Summary

- Closes #1187. `d.setHours(d.getHours() + 1)` aborted with `TypeError: (number).setHours is not a function` because the HIR lowering only routed `setUTC*` — the local-time setters fell through to a generic property lookup, and since Date is stored as a raw f64 timestamp the receiver became `(number)`.
- Adds the local-time setters end-to-end: 8 new `js_date_set_*` runtime functions (`setFullYear`/`setMonth`/`setDate`/`setHours`/`setMinutes`/`setSeconds`/`setMilliseconds`/`setTime`), 8 matching `DateSet*` HIR variants (walker / stable_hash / lowering), and lowering arms in the LLVM, JS, and WASM backends. Mirrors the existing `DateSetUtc*` plumbing.
- Mutation semantics match JS: when the receiver is a local (e.g. `let d = new Date(); d.setHours(15)`), the HIR wraps the setter result in `LocalSet` so `d` is updated in place and the expression still evaluates to the new ms timestamp.
- Component setters round-trip through `timestamp_to_local_components`, swap the requested field, and subtract the tz offset at that instant to land back at UTC — same conversion as `js_date_new_local_components`. NaN passes through (Invalid Date stays Invalid Date); finite results re-register in `DATE_REGISTRY` so `instanceof Date` still holds after mutation.

## Test plan

- [x] `test-files/test_issue_1187_date_setters.ts` (new) compiles + matches `node --experimental-strip-types` byte-for-byte
- [x] Exact repro from the issue (`new Date(); expiry.setHours(expiry.getHours()+1); return expiry; ... .toISOString()`) compiles and prints a valid ISO string ~1 hour from now
- [x] `test-files/test_gap_date_methods.ts` still parity-matches Node
- [x] `cargo test -p perry-runtime -p perry-hir -p perry-codegen` green
- [ ] CI: lint, cargo-test, parity, compile-smoke, api-docs-drift, security-audit

Version bump + `CHANGELOG.md` entry intentionally omitted — Ralph folds those in at merge time.