### PR TITLE
fix(transform): #1196 rewrite user returns in StateExit::Goto state bodies

### DIFF
--- a/crates/perry-transform/src/generator.rs
+++ b/crates/perry-transform/src/generator.rs
@@ -1011,6 +1011,24 @@ fn transform_generator_function_with_extra_captures(
                 case_body.push(Stmt::Return(Some(make_iter_result(value.clone(), false))));
             }
             StateExit::Goto(next_state) => {
+                // #1196: a user `return X` inside this state body — at any
+                // depth — must terminate the whole async function, not just
+                // fall through to `next_state`. Mirrors the Yield/Done arms
+                // above. Without the rewrite, `rewrite_returns_to_labeled_break`
+                // later strips the return to `[Expr(X), LabeledBreak]`
+                // (value discarded, IterResult never set). The post-step
+                // code then sees the IterResult left over from the previous
+                // yield (done=false) and re-chains the step closure onto
+                // it via AsyncStepChain — re-entering this same state,
+                // taking the same early-return, and looping forever.
+                // Symptom: ~123 MB arena growth per outer call, GC every
+                // ~250 ms, 90%+ CPU. Triggered when the state body fans
+                // into a Goto (e.g. an `if (...) return X;` immediately
+                // before a `for` loop with `await` inside).
+                if body_contains_return(&case_body) {
+                    prepend_done_before_returns(&mut case_body, done_id);
+                    rewrite_returns_as_done(&mut case_body);
+                }
                 case_body.push(Stmt::Expr(Expr::LocalSet(
                     state_id,
                     Box::new(Expr::Number(*next_state as f64)),

--- a/test-files/test_issue_1196_async_goto_early_return.ts
+++ b/test-files/test_issue_1196_async_goto_early_return.ts
@@ -1,0 +1,30 @@
+// #1196: async fn with an early `return X` inside an `if`, immediately
+// followed by an unreached `for ... await ...` loop wedged the runtime —
+// the state body holding the early-return exited via StateExit::Goto
+// (to the loop's condition state), and the Goto arm of the state-machine
+// case builder didn't apply `rewrite_returns_as_done` /
+// `prepend_done_before_returns`. The early-return became
+// `[Expr(value), LabeledBreak]` with IterResult never set, so the
+// post-step code re-chained the step closure onto the previous yield's
+// resolved value and looped forever, allocating ~5 MB of arena per call.
+//
+// Companion to test_issue_1047 (which fixed the StateExit::Yield arm).
+
+async function withCallback<T>(fn: () => Promise<T>): Promise<T> {
+    return fn();
+}
+
+async function inner(): Promise<number[]> {
+    return withCallback(async () => {
+        const rows = await new Promise<number[]>((r) => r([]));
+        if (rows.length === 0) return [];
+        for (const id of rows) {
+            await new Promise<void>((r) => r());
+            void id;
+        }
+        return rows;
+    });
+}
+
+const result = await inner();
+console.log("result length:", result.length, " is array:", Array.isArray(result));


### PR DESCRIPTION
## Summary
- Closes #1196. The async-lowering state-machine builder applied `rewrite_returns_as_done` + `prepend_done_before_returns` to state bodies exiting via `Yield` (#1047) and `Done` (#594), but not `Goto`.
- A user-level `return X` inside a state body that exits via `Goto` (e.g. `if (...) return X` immediately before a `for ... await ...` loop) fell through to `rewrite_returns_to_labeled_break`, which stripped it to `[Expr(X), LabeledBreak]` — value discarded, IterResult never set.
- Post-step code then read stale IterResult (done=false) from the previous yield and dispatched `AsyncStepChain`, re-invoking the step closure on the same state — an infinite loop allocating ~5 MB of arena per outer call (~123 MB per call peak, GC every ~250 ms, 90%+ CPU). Applied the same conditional rewrite the other two arms already do.

## Repro / numbers
Issue's 18-line repro:
- Before: 22 GC cycles in 5 s, arena climbs to 130 MB, 0 ticks logged (await never resolves).
- After:  0 GC cycles in 5 s, arena flat, 8 ticks logged (10/20/.../80) — function actually completes.

## Test plan
- [x] `cargo test --release -p perry-hir -p perry-transform -p perry-codegen`
- [x] All 12 async/generator test_*.ts files in test-files/ exit 0
- [x] `run_parity_tests.sh --filter async` — 21/21 pass (incl. new `test_issue_1196_async_goto_early_return`)
- [x] #1047 regression test still passes (`test_issue_1047_async_early_return_unreached_await`)
- [x] Both bisect variants from the issue (no-early-return / no-inner-await) still run with 0 GC cycles