### PR TITLE
Add granular node:buffer parity suite

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2051,10 +2051,16 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     //     already registered above) ---
     method("buffer", "alloc", false, None),
     method("buffer", "allocUnsafe", false, None),
+    method("buffer", "allocUnsafeSlow", false, None),
     method("buffer", "from", false, None),
+    method("buffer", "of", false, None),
     method("buffer", "concat", false, None),
     method("buffer", "isBuffer", false, None),
+    method("buffer", "isEncoding", false, None),
     method("buffer", "byteLength", false, None),
+    property("buffer", "constants"),
+    property("buffer", "kMaxLength"),
+    property("buffer", "kStringMaxLength"),
     // --- url (additional helpers) ---
     method("url", "fileURLToPath", false, None),
     method("url", "pathToFileURL", false, None),

--- a/crates/perry-codegen-js/src/emit.rs
+++ b/crates/perry-codegen-js/src/emit.rs
@@ -1592,6 +1592,21 @@ impl JsEmitter {
                 self.output.push(')');
                 let _ = encoding; // encoding not used in simple polyfill
             }
+            Expr::BufferFromArrayBuffer {
+                data,
+                byte_offset,
+                length,
+            } => {
+                self.output.push_str("new Uint8Array(");
+                self.emit_expr(data);
+                self.output.push_str(", ");
+                self.emit_expr(byte_offset);
+                if let Some(len) = length {
+                    self.output.push_str(", ");
+                    self.emit_expr(len);
+                }
+                self.output.push(')');
+            }
             Expr::BufferAlloc { size, fill } => {
                 self.output.push_str("new Uint8Array(");
                 self.emit_expr(size);
@@ -1618,10 +1633,11 @@ impl JsEmitter {
                 self.emit_expr(obj);
                 self.output.push_str(" instanceof Uint8Array)");
             }
-            Expr::BufferByteLength(s) => {
+            Expr::BufferByteLength { data, encoding } => {
                 self.output.push_str("new TextEncoder().encode(");
-                self.emit_expr(s);
+                self.emit_expr(data);
                 self.output.push_str(").length");
+                let _ = encoding;
             }
             Expr::BufferToString { buffer, .. } => {
                 self.output.push_str("new TextDecoder().decode(");

--- a/crates/perry-codegen-wasm/src/emit/expr.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr.rs
@@ -3994,6 +3994,31 @@ impl<'a> FuncEmitCtx<'a> {
                 }));
                 self.emit_memcall(func, "buffer_from_string", 2);
             }
+            Expr::BufferFromArrayBuffer {
+                data,
+                byte_offset,
+                length,
+            } => {
+                self.emit_expr(func, data);
+                self.emit_expr(func, byte_offset);
+                if let Some(len) = length {
+                    self.emit_expr(func, len);
+                } else {
+                    func.instruction(&Instruction::I64Const(TAG_UNDEFINED as i64));
+                }
+                self.emit_frame_begin(func, 3);
+                for slot in (0..3).rev() {
+                    func.instruction(&Instruction::LocalSet(self.temp_local));
+                    self.emit_slot_addr(func, slot);
+                    func.instruction(&Instruction::LocalGet(self.temp_local));
+                    func.instruction(&Instruction::I64Store(wasm_encoder::MemArg {
+                        offset: 0,
+                        align: 3,
+                        memory_index: 0,
+                    }));
+                }
+                self.emit_memcall(func, "buffer_from_string", 3);
+            }
             Expr::BufferToString { buffer, encoding } => {
                 self.emit_expr(func, buffer);
                 if let Some(enc) = encoding {
@@ -4233,7 +4258,10 @@ impl<'a> FuncEmitCtx<'a> {
                 func.instruction(&Instruction::I64Const(TAG_FALSE as i64));
                 func.instruction(&Instruction::End);
             }
-            Expr::BufferByteLength(val) => {
+            Expr::BufferByteLength {
+                data: val,
+                encoding: _,
+            } => {
                 self.emit_frame_begin(func, 1);
                 self.emit_store_arg(func, 0, val);
                 self.emit_memcall(func, "buffer_byte_length", 1);

--- a/crates/perry-codegen/src/collectors.rs
+++ b/crates/perry-codegen/src/collectors.rs
@@ -1035,6 +1035,17 @@ pub(crate) fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32
                 walk(e, out);
             }
         }
+        Expr::BufferFromArrayBuffer {
+            data,
+            byte_offset,
+            length,
+        } => {
+            walk(data, out);
+            walk(byte_offset, out);
+            if let Some(e) = length {
+                walk(e, out);
+            }
+        }
         Expr::BufferAlloc { size, fill } => {
             walk(size, out);
             if let Some(f) = fill {
@@ -3629,6 +3640,17 @@ fn collect_localset_ids_in_expr_filtered(
         Expr::BufferFrom { data, encoding } => {
             walk(data, out);
             if let Some(e) = encoding {
+                walk(e, out);
+            }
+        }
+        Expr::BufferFromArrayBuffer {
+            data,
+            byte_offset,
+            length,
+        } => {
+            walk(data, out);
+            walk(byte_offset, out);
+            if let Some(e) = length {
                 walk(e, out);
             }
         }

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -10045,6 +10045,14 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(i32_bool_to_nanbox(blk, &i32_result))
         }
 
+        // -------- BufferIsEncoding --------
+        Expr::BufferIsEncoding(operand) => {
+            let v_box = lower_expr(ctx, operand)?;
+            let blk = ctx.block();
+            let i32_result = blk.call(I32, "js_buffer_is_encoding", &[(DOUBLE, &v_box)]);
+            Ok(i32_bool_to_nanbox(blk, &i32_result))
+        }
+
         // -------- StaticPluginResolve stub --------
         Expr::StaticPluginResolve(_) => Ok(double_literal(0.0)),
 
@@ -10382,6 +10390,29 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             );
             Ok(nanbox_pointer_inline(blk, &buf_handle))
         }
+        Expr::BufferFromArrayBuffer {
+            data,
+            byte_offset,
+            length,
+        } => {
+            let data_box = lower_expr(ctx, data)?;
+            let offset_box = lower_expr(ctx, byte_offset)?;
+            let len_i32 = if let Some(len_expr) = length {
+                let len_box = lower_expr(ctx, len_expr)?;
+                ctx.block().fptosi(DOUBLE, &len_box, I32)
+            } else {
+                "-1".to_string()
+            };
+            let blk = ctx.block();
+            let data_i64 = blk.bitcast_double_to_i64(&data_box);
+            let offset_i32 = blk.fptosi(DOUBLE, &offset_box, I32);
+            let buf_handle = blk.call(
+                I64,
+                "js_buffer_from_arraybuffer_slice",
+                &[(I64, &data_i64), (I32, &offset_i32), (I32, &len_i32)],
+            );
+            Ok(nanbox_pointer_inline(blk, &buf_handle))
+        }
         // Issue #630: `Buffer.allocUnsafe(size)` — fast-path allocator
         // (no zero-fill). The runtime helper returns a raw `*mut
         // BufferHeader`; NaN-box with POINTER_TAG so downstream
@@ -10400,11 +10431,19 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // a `encoding === "hex"` / `"base64"` arg would need a separate
         // helper but those aren't in the issue's repro. Returns i32;
         // sitofp to f64 for the Number return.
-        Expr::BufferByteLength(s) => {
-            let s_box = lower_expr(ctx, s)?;
+        Expr::BufferByteLength { data, encoding } => {
+            let data_box = lower_expr(ctx, data)?;
+            let enc_box = if let Some(enc) = encoding {
+                lower_expr(ctx, enc)?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
             let blk = ctx.block();
-            let s_handle = blk.call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &s_box)]);
-            let len_i32 = blk.call(I32, "js_buffer_byte_length", &[(I64, &s_handle)]);
+            let len_i32 = blk.call(
+                I32,
+                "js_buffer_byte_length_value",
+                &[(DOUBLE, &data_box), (DOUBLE, &enc_box)],
+            );
             Ok(blk.sitofp(I32, &len_i32, DOUBLE))
         }
 

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -1309,6 +1309,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("clearTimeout", VOID, &[I64]);
     module.declare_function("clearInterval", VOID, &[I64]);
     module.declare_function("js_buffer_from_array", I64, &[I64]);
+    module.declare_function("js_buffer_from_arraybuffer_slice", I64, &[I64, I32, I32]);
     module.declare_function("js_buffer_length", I32, &[I64]);
     module.declare_function("js_buffer_get", I32, &[I64, I32]);
     // console.time/count runtime functions.
@@ -2112,12 +2113,14 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // ========== Buffer ==========
     module.declare_function("js_buffer_alloc_unsafe", I64, &[I32]);
     module.declare_function("js_buffer_byte_length", I32, &[I64]);
+    module.declare_function("js_buffer_byte_length_value", I32, &[DOUBLE, DOUBLE]);
     module.declare_function("js_buffer_concat", I64, &[I64]);
     module.declare_function("js_buffer_copy", I32, &[I64, I64, I32, I32, I32]);
     module.declare_function("js_buffer_equals", I32, &[I64, I64]);
     module.declare_function("js_buffer_fill", I64, &[I64, I32]);
     module.declare_function("js_buffer_from_value", I64, &[I64, I32]);
     module.declare_function("js_buffer_is_buffer", I32, &[I64]);
+    module.declare_function("js_buffer_is_encoding", I32, &[DOUBLE]);
     module.declare_function("js_buffer_print", VOID, &[I64]);
     module.declare_function("js_buffer_set", VOID, &[I64, I32, I32]);
     module.declare_function("js_buffer_set_from", VOID, &[I64, I64, I32]);

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -221,6 +221,7 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
         // fall through to the dynamic-array codegen which reads f64 elements
         // from the underlying storage as if they were JS values.
         Expr::BufferFrom { .. }
+        | Expr::BufferFromArrayBuffer { .. }
         | Expr::BufferAlloc { .. }
         | Expr::BufferAllocUnsafe(_)
         | Expr::BufferConcat(_)

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -706,6 +706,17 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
                 collect_assigned_locals_expr(enc, assigned);
             }
         }
+        Expr::BufferFromArrayBuffer {
+            data,
+            byte_offset,
+            length,
+        } => {
+            collect_assigned_locals_expr(data, assigned);
+            collect_assigned_locals_expr(byte_offset, assigned);
+            if let Some(len) = length {
+                collect_assigned_locals_expr(len, assigned);
+            }
+        }
         Expr::BufferAlloc { size, fill } => {
             collect_assigned_locals_expr(size, assigned);
             if let Some(f) = fill {
@@ -715,9 +726,15 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
         Expr::BufferAllocUnsafe(expr)
         | Expr::BufferConcat(expr)
         | Expr::BufferIsBuffer(expr)
-        | Expr::BufferByteLength(expr)
+        | Expr::BufferIsEncoding(expr)
         | Expr::BufferLength(expr) => {
             collect_assigned_locals_expr(expr, assigned);
+        }
+        Expr::BufferByteLength { data, encoding } => {
+            collect_assigned_locals_expr(data, assigned);
+            if let Some(enc) = encoding {
+                collect_assigned_locals_expr(enc, assigned);
+            }
         }
         Expr::BufferToString { buffer, encoding } => {
             collect_assigned_locals_expr(buffer, assigned);

--- a/crates/perry-hir/src/ir.rs
+++ b/crates/perry-hir/src/ir.rs
@@ -1890,6 +1890,12 @@ pub enum Expr {
         data: Box<Expr>,
         encoding: Option<Box<Expr>>,
     },
+    BufferFromArrayBuffer {
+        // Buffer.from(arrayBuffer, byteOffset, length?) -> Buffer
+        data: Box<Expr>,
+        byte_offset: Box<Expr>,
+        length: Option<Box<Expr>>,
+    },
     BufferAlloc {
         // Buffer.alloc(size, fill?) -> Buffer
         size: Box<Expr>,
@@ -1898,7 +1904,11 @@ pub enum Expr {
     BufferAllocUnsafe(Box<Expr>), // Buffer.allocUnsafe(size) -> Buffer
     BufferConcat(Box<Expr>),      // Buffer.concat(list) -> Buffer
     BufferIsBuffer(Box<Expr>),    // Buffer.isBuffer(obj) -> boolean
-    BufferByteLength(Box<Expr>),  // Buffer.byteLength(string) -> number
+    BufferIsEncoding(Box<Expr>),  // Buffer.isEncoding(encoding) -> boolean
+    BufferByteLength {
+        data: Box<Expr>,
+        encoding: Option<Box<Expr>>,
+    }, // Buffer.byteLength(value, encoding?) -> number
     BufferToString {
         // buffer.toString(encoding?) -> string
         buffer: Box<Expr>,

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -1252,6 +1252,18 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                             match method_name {
                                 "from" => {
                                     let data = args.first().cloned().unwrap_or(Expr::Undefined);
+                                    if args.len() >= 2
+                                        && !matches!(args.get(1), Some(Expr::String(_)))
+                                    {
+                                        let byte_offset =
+                                            args.get(1).cloned().unwrap_or(Expr::Number(0.0));
+                                        let length = args.get(2).cloned().map(Box::new);
+                                        return Ok(Expr::BufferFromArrayBuffer {
+                                            data: Box::new(data),
+                                            byte_offset: Box::new(byte_offset),
+                                            length,
+                                        });
+                                    }
                                     let encoding = args.get(1).cloned().map(Box::new);
                                     return Ok(Expr::BufferFrom {
                                         data: Box::new(data),
@@ -1266,7 +1278,7 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                                         fill,
                                     });
                                 }
-                                "allocUnsafe" => {
+                                "allocUnsafe" | "allocUnsafeSlow" => {
                                     let size = args.first().cloned().unwrap_or(Expr::Number(0.0));
                                     return Ok(Expr::BufferAllocUnsafe(Box::new(size)));
                                 }
@@ -1274,16 +1286,30 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                                     let list = args.first().cloned().unwrap_or(Expr::Array(vec![]));
                                     return Ok(Expr::BufferConcat(Box::new(list)));
                                 }
+                                "of" => {
+                                    return Ok(Expr::BufferFrom {
+                                        data: Box::new(Expr::Array(args)),
+                                        encoding: None,
+                                    });
+                                }
                                 "isBuffer" => {
                                     let obj = args.first().cloned().unwrap_or(Expr::Undefined);
                                     return Ok(Expr::BufferIsBuffer(Box::new(obj)));
+                                }
+                                "isEncoding" => {
+                                    let obj = args.first().cloned().unwrap_or(Expr::Undefined);
+                                    return Ok(Expr::BufferIsEncoding(Box::new(obj)));
                                 }
                                 "byteLength" => {
                                     let data = args
                                         .first()
                                         .cloned()
                                         .unwrap_or(Expr::String("".to_string()));
-                                    return Ok(Expr::BufferByteLength(Box::new(data)));
+                                    let encoding = args.get(1).cloned().map(Box::new);
+                                    return Ok(Expr::BufferByteLength {
+                                        data: Box::new(data),
+                                        encoding,
+                                    });
                                 }
                                 // `Buffer.compare(a, b)` → `a.compare(b)` instance call
                                 // (handled by runtime buffer dispatch).
@@ -3225,6 +3251,18 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                             match method_name {
                                 "from" => {
                                     let data = args.first().cloned().unwrap_or(Expr::Undefined);
+                                    if args.len() >= 2
+                                        && !matches!(args.get(1), Some(Expr::String(_)))
+                                    {
+                                        let byte_offset =
+                                            args.get(1).cloned().unwrap_or(Expr::Number(0.0));
+                                        let length = args.get(2).cloned().map(Box::new);
+                                        return Ok(Expr::BufferFromArrayBuffer {
+                                            data: Box::new(data),
+                                            byte_offset: Box::new(byte_offset),
+                                            length,
+                                        });
+                                    }
                                     let encoding = args.get(1).cloned().map(Box::new);
                                     return Ok(Expr::BufferFrom {
                                         data: Box::new(data),
@@ -3242,7 +3280,7 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                                         });
                                     }
                                 }
-                                "allocUnsafe" => {
+                                "allocUnsafe" | "allocUnsafeSlow" => {
                                     if !args.is_empty() {
                                         return Ok(Expr::BufferAllocUnsafe(Box::new(
                                             args.into_iter().next().unwrap(),
@@ -3256,6 +3294,12 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                                         )));
                                     }
                                 }
+                                "of" => {
+                                    return Ok(Expr::BufferFrom {
+                                        data: Box::new(Expr::Array(args)),
+                                        encoding: None,
+                                    });
+                                }
                                 "isBuffer" => {
                                     if !args.is_empty() {
                                         return Ok(Expr::BufferIsBuffer(Box::new(
@@ -3263,11 +3307,22 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                                         )));
                                     }
                                 }
-                                "byteLength" => {
+                                "isEncoding" => {
                                     if !args.is_empty() {
-                                        return Ok(Expr::BufferByteLength(Box::new(
+                                        return Ok(Expr::BufferIsEncoding(Box::new(
                                             args.into_iter().next().unwrap(),
                                         )));
+                                    }
+                                }
+                                "byteLength" => {
+                                    if !args.is_empty() {
+                                        let mut it = args.into_iter();
+                                        let data = it.next().unwrap();
+                                        let encoding = it.next().map(Box::new);
+                                        return Ok(Expr::BufferByteLength {
+                                            data: Box::new(data),
+                                            encoding,
+                                        });
                                     }
                                 }
                                 // `Buffer.compare(a, b)` returns -1/0/1. The runtime

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -1203,6 +1203,16 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                         }
                     }
                 }
+                if module_name == "buffer" || module_name == "node:buffer" {
+                    if let Some(method) = method_name {
+                        if matches!(method, "constants" | "kMaxLength" | "kStringMaxLength") {
+                            return Ok(Expr::PropertyGet {
+                                object: Box::new(Expr::NativeModuleRef("buffer".to_string())),
+                                property: method.to_string(),
+                            });
+                        }
+                    }
+                }
                 // Special handling for worker_threads named imports
                 if module_name == "worker_threads" {
                     if let Some(method) = method_name {

--- a/crates/perry-hir/src/stable_hash.rs
+++ b/crates/perry-hir/src/stable_hash.rs
@@ -2341,6 +2341,16 @@ impl SH for Expr {
                 data.as_ref().hash(h);
                 encoding.hash(h);
             }
+            Expr::BufferFromArrayBuffer {
+                data,
+                byte_offset,
+                length,
+            } => {
+                tag(h, 11220);
+                data.as_ref().hash(h);
+                byte_offset.as_ref().hash(h);
+                length.hash(h);
+            }
             Expr::BufferAlloc { size, fill } => {
                 tag(h, 216);
                 size.as_ref().hash(h);
@@ -2358,9 +2368,14 @@ impl SH for Expr {
                 tag(h, 219);
                 e.as_ref().hash(h);
             }
-            Expr::BufferByteLength(e) => {
-                tag(h, 220);
+            Expr::BufferIsEncoding(e) => {
+                tag(h, 11219);
                 e.as_ref().hash(h);
+            }
+            Expr::BufferByteLength { data, encoding } => {
+                tag(h, 220);
+                data.as_ref().hash(h);
+                encoding.hash(h);
             }
             Expr::BufferToString { buffer, encoding } => {
                 tag(h, 221);

--- a/crates/perry-hir/src/walker.rs
+++ b/crates/perry-hir/src/walker.rs
@@ -240,7 +240,7 @@ where
         | Expr::BufferAllocUnsafe(v)
         | Expr::BufferConcat(v)
         | Expr::BufferIsBuffer(v)
-        | Expr::BufferByteLength(v)
+        | Expr::BufferIsEncoding(v)
         | Expr::BufferLength(v)
         | Expr::Uint8ArrayFrom(v)
         | Expr::Uint8ArrayLength(v)
@@ -922,10 +922,27 @@ where
                 f(e);
             }
         }
+        Expr::BufferFromArrayBuffer {
+            data,
+            byte_offset,
+            length,
+        } => {
+            f(data);
+            f(byte_offset);
+            if let Some(e) = length {
+                f(e);
+            }
+        }
         Expr::BufferAlloc { size, fill } => {
             f(size);
             if let Some(v) = fill {
                 f(v);
+            }
+        }
+        Expr::BufferByteLength { data, encoding } => {
+            f(data);
+            if let Some(e) = encoding {
+                f(e);
             }
         }
         Expr::BufferToString { buffer, encoding } => {
@@ -1640,7 +1657,7 @@ where
         | Expr::BufferAllocUnsafe(v)
         | Expr::BufferConcat(v)
         | Expr::BufferIsBuffer(v)
-        | Expr::BufferByteLength(v)
+        | Expr::BufferIsEncoding(v)
         | Expr::BufferLength(v)
         | Expr::Uint8ArrayFrom(v)
         | Expr::Uint8ArrayLength(v)
@@ -2306,10 +2323,27 @@ where
                 f(e);
             }
         }
+        Expr::BufferFromArrayBuffer {
+            data,
+            byte_offset,
+            length,
+        } => {
+            f(data);
+            f(byte_offset);
+            if let Some(e) = length {
+                f(e);
+            }
+        }
         Expr::BufferAlloc { size, fill } => {
             f(size);
             if let Some(v) = fill {
                 f(v);
+            }
+        }
+        Expr::BufferByteLength { data, encoding } => {
+            f(data);
+            if let Some(e) = encoding {
+                f(e);
             }
         }
         Expr::BufferToString { buffer, encoding } => {

--- a/crates/perry-runtime/src/buffer.rs
+++ b/crates/perry-runtime/src/buffer.rs
@@ -361,7 +361,7 @@ pub extern "C" fn js_buffer_from_array(arr_ptr: *const ArrayHeader) -> *mut Buff
             let byte = if top16 == 0x7FFE {
                 // INT32_TAG: lower 32 bits are an i32
                 ((bits as u32) & 0xFF) as u8
-            } else if top16 < 0x7FF8 || (top16 == 0x7FF8 && bits == 0x7FF8_0000_0000_0000) {
+            } else if !val.is_nan() {
                 // Raw double — convert via i64 to handle negatives correctly
                 ((val as i64) & 0xFF) as u8
             } else {
@@ -371,6 +371,48 @@ pub extern "C" fn js_buffer_from_array(arr_ptr: *const ArrayHeader) -> *mut Buff
         }
 
         buf
+    }
+}
+
+/// `Buffer.from(arrayBuffer, byteOffset, length?)` — deterministic subset.
+/// Perry currently models ArrayBuffer storage as a BufferHeader; this returns
+/// a copied Buffer for the requested byte range. Shared backing-store views
+/// remain a separate larger parity task.
+#[no_mangle]
+pub extern "C" fn js_buffer_from_arraybuffer_slice(
+    value_bits: i64,
+    byte_offset: i32,
+    length: i32,
+) -> *mut BufferHeader {
+    let bits = value_bits as u64;
+    let raw = if bits >> 48 >= 0x7FF8 {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else {
+        bits as usize
+    };
+    if raw < 0x1000 || !is_registered_buffer(raw) {
+        return buffer_alloc(0);
+    }
+    unsafe {
+        let src = raw as *const BufferHeader;
+        let src_len = (*src).length as i32;
+        let start = byte_offset.max(0).min(src_len);
+        let available = src_len - start;
+        let take = if length < 0 {
+            available
+        } else {
+            length.max(0).min(available)
+        };
+        let dst = buffer_alloc(take as u32);
+        (*dst).length = take as u32;
+        if take > 0 {
+            ptr::copy_nonoverlapping(
+                buffer_data(src).add(start as usize),
+                buffer_data_mut(dst),
+                take as usize,
+            );
+        }
+        dst
     }
 }
 
@@ -502,6 +544,18 @@ pub extern "C" fn js_buffer_alloc(size: i32, fill: i32) -> *mut BufferHeader {
 /// Implements Uint8Array.prototype.fill(value)
 #[no_mangle]
 pub extern "C" fn js_buffer_fill(buf: *mut BufferHeader, value: i32) -> *mut BufferHeader {
+    js_buffer_fill_range(buf, value, 0, i32::MAX)
+}
+
+/// Fill an existing buffer with a byte value over a clamped [start, end) range.
+/// Implements the deterministic numeric subset of Buffer.prototype.fill.
+#[no_mangle]
+pub extern "C" fn js_buffer_fill_range(
+    buf: *mut BufferHeader,
+    value: i32,
+    start: i32,
+    end: i32,
+) -> *mut BufferHeader {
     if buf.is_null() || (buf as u64) < 0x1000 {
         return buf;
     }
@@ -517,8 +571,21 @@ pub extern "C" fn js_buffer_fill(buf: *mut BufferHeader, value: i32) -> *mut Buf
     };
     unsafe {
         let len = (*buf).length as usize;
+        let start = if start < 0 {
+            ((len as i32) + start).max(0) as usize
+        } else {
+            (start as usize).min(len)
+        };
+        let end = if end < 0 {
+            ((len as i32) + end).max(0) as usize
+        } else {
+            (end as usize).min(len)
+        };
+        if start >= end {
+            return buf;
+        }
         let data = buffer_data_mut(buf);
-        ptr::write_bytes(data, value as u8, len);
+        ptr::write_bytes(data.add(start), value as u8, end - start);
     }
     buf
 }
@@ -616,6 +683,44 @@ pub extern "C" fn js_buffer_is_buffer(ptr: i64) -> i32 {
     }
 }
 
+/// Check if a value is a Node Buffer encoding name.
+#[no_mangle]
+pub extern "C" fn js_buffer_is_encoding(value: f64) -> i32 {
+    let str_ptr = crate::value::js_get_string_pointer_unified(value) as *const StringHeader;
+    if str_ptr.is_null() || (str_ptr as usize) < 0x1000 {
+        return 0;
+    }
+    unsafe {
+        let len = (*str_ptr).byte_len as usize;
+        if len == 0 || len > 32 {
+            return 0;
+        }
+        let data_ptr = (str_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        let bytes = std::slice::from_raw_parts(data_ptr, len);
+        fn eq_ascii_lower(a: &[u8], b: &[u8]) -> bool {
+            if a.len() != b.len() {
+                return false;
+            }
+            a.iter()
+                .zip(b.iter())
+                .all(|(x, y)| x.to_ascii_lowercase() == *y)
+        }
+        let ok = eq_ascii_lower(bytes, b"utf8")
+            || eq_ascii_lower(bytes, b"utf-8")
+            || eq_ascii_lower(bytes, b"hex")
+            || eq_ascii_lower(bytes, b"base64")
+            || eq_ascii_lower(bytes, b"base64url")
+            || eq_ascii_lower(bytes, b"ascii")
+            || eq_ascii_lower(bytes, b"latin1")
+            || eq_ascii_lower(bytes, b"binary")
+            || eq_ascii_lower(bytes, b"ucs2")
+            || eq_ascii_lower(bytes, b"ucs-2")
+            || eq_ascii_lower(bytes, b"utf16le")
+            || eq_ascii_lower(bytes, b"utf-16le");
+        ok as i32
+    }
+}
+
 /// Get the byte length of a string (when encoded to UTF-8)
 #[no_mangle]
 pub extern "C" fn js_buffer_byte_length(str_ptr: *const StringHeader) -> i32 {
@@ -623,6 +728,76 @@ pub extern "C" fn js_buffer_byte_length(str_ptr: *const StringHeader) -> i32 {
         return 0;
     }
     unsafe { (*str_ptr).byte_len as i32 }
+}
+
+/// Node-style `Buffer.byteLength(value, encoding?)`.
+#[no_mangle]
+pub extern "C" fn js_buffer_byte_length_value(value: f64, encoding: f64) -> i32 {
+    let bits = value.to_bits();
+    let jsval = crate::JSValue::from_bits(bits);
+
+    let raw_ptr = if jsval.is_pointer() || jsval.is_string() {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if !value.is_nan() && bits >= 0x1000 && bits < 0x0001_0000_0000_0000 {
+        bits as usize
+    } else {
+        0
+    };
+    if raw_ptr != 0 && is_registered_buffer(raw_ptr) {
+        return unsafe { (*(raw_ptr as *const BufferHeader)).length as i32 };
+    }
+
+    let str_ptr = crate::value::js_get_string_pointer_unified(value) as *const StringHeader;
+    if str_ptr.is_null() || (str_ptr as usize) < 0x1000 {
+        return 0;
+    }
+
+    unsafe {
+        let len = (*str_ptr).byte_len as usize;
+        let data_ptr = (str_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        let bytes = std::slice::from_raw_parts(data_ptr, len);
+
+        let enc_ptr = crate::value::js_get_string_pointer_unified(encoding) as *const StringHeader;
+        let enc_bytes = if enc_ptr.is_null() || (enc_ptr as usize) < 0x1000 {
+            &[][..]
+        } else {
+            let enc_len = (*enc_ptr).byte_len as usize;
+            let enc_data = (enc_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+            std::slice::from_raw_parts(enc_data, enc_len)
+        };
+        fn eq_ascii_lower(a: &[u8], b: &[u8]) -> bool {
+            a.len() == b.len()
+                && a.iter()
+                    .zip(b.iter())
+                    .all(|(x, y)| x.to_ascii_lowercase() == *y)
+        }
+
+        if eq_ascii_lower(enc_bytes, b"hex") {
+            return (len / 2) as i32;
+        }
+        if eq_ascii_lower(enc_bytes, b"base64") || eq_ascii_lower(enc_bytes, b"base64url") {
+            let decoded = base64_decode_into_buffer(bytes);
+            return (*decoded).length as i32;
+        }
+        if eq_ascii_lower(enc_bytes, b"ascii")
+            || eq_ascii_lower(enc_bytes, b"latin1")
+            || eq_ascii_lower(enc_bytes, b"binary")
+        {
+            return std::str::from_utf8(bytes)
+                .map(|s| s.chars().count() as i32)
+                .unwrap_or(len as i32);
+        }
+        if eq_ascii_lower(enc_bytes, b"ucs2")
+            || eq_ascii_lower(enc_bytes, b"ucs-2")
+            || eq_ascii_lower(enc_bytes, b"utf16le")
+            || eq_ascii_lower(enc_bytes, b"utf-16le")
+        {
+            return std::str::from_utf8(bytes)
+                .map(|s| (s.encode_utf16().count() * 2) as i32)
+                .unwrap_or((len * 2) as i32);
+        }
+        len as i32
+    }
 }
 
 /// Convert a buffer slice to a string. Honors the optional `start`/`end`
@@ -1151,6 +1326,79 @@ fn buffer_index_of_bytes(buf: *const BufferHeader, needle: &[u8], start: i32) ->
     }
 }
 
+/// Reverse search for a byte sequence in a buffer.
+fn buffer_last_index_of_bytes(buf: *const BufferHeader, needle: &[u8], start: i32) -> i32 {
+    if buf.is_null() {
+        return -1;
+    }
+    unsafe {
+        let len = (*buf).length as usize;
+        let data = std::slice::from_raw_parts(buffer_data(buf), len);
+        if needle.is_empty() {
+            return if start < 0 {
+                ((len as i32) + start).clamp(0, len as i32)
+            } else {
+                (start as usize).min(len) as i32
+            };
+        }
+        if needle.len() > len {
+            return -1;
+        }
+        let max_start = len - needle.len();
+        let from = if start < 0 {
+            ((len as i32) + start).max(0) as usize
+        } else {
+            (start as usize).min(max_start)
+        };
+        for i in (0..=from).rev() {
+            if &data[i..i + needle.len()] == needle {
+                return i as i32;
+            }
+        }
+        -1
+    }
+}
+
+fn buffer_search_needle(buf: *const BufferHeader, needle: f64) -> Option<Vec<u8>> {
+    if buf.is_null() {
+        return None;
+    }
+    let needle_bits = needle.to_bits();
+    let top16 = needle_bits >> 48;
+
+    let raw_ptr = if top16 >= 0x7FF8 {
+        (needle_bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if top16 == 0 && needle_bits >= 0x1000 {
+        needle_bits as usize
+    } else {
+        0
+    };
+    if raw_ptr != 0 && is_registered_buffer(raw_ptr) {
+        let other = raw_ptr as *const BufferHeader;
+        return unsafe {
+            Some(std::slice::from_raw_parts(buffer_data(other), (*other).length as usize).to_vec())
+        };
+    }
+    if top16 == 0x7FFF {
+        let str_ptr = (needle_bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+        if !str_ptr.is_null() {
+            return unsafe {
+                let len = (*str_ptr).byte_len as usize;
+                let data_ptr = (str_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+                Some(std::slice::from_raw_parts(data_ptr, len).to_vec())
+            };
+        }
+    }
+    let byte_val = if top16 == 0x7FFE {
+        (needle_bits as u32) & 0xFF
+    } else if top16 < 0x7FF8 || (top16 == 0x7FF8 && needle_bits == 0x7FF8_0000_0000_0000) {
+        ((needle as i64) & 0xFF) as u32
+    } else {
+        return None;
+    };
+    Some(vec![byte_val as u8])
+}
+
 /// `buf.indexOf(needle, start?)` where `needle` is a string, buffer,
 /// or numeric byte value (NaN-boxed value).
 #[no_mangle]
@@ -1200,6 +1448,17 @@ pub extern "C" fn js_buffer_index_of(buf_ptr: f64, needle: f64, start: i32) -> i
     };
     let byte = [byte_val as u8];
     buffer_index_of_bytes(buf, &byte, start)
+}
+
+/// `buf.lastIndexOf(needle, start?)` where `needle` is a string, buffer,
+/// or numeric byte value (NaN-boxed value).
+#[no_mangle]
+pub extern "C" fn js_buffer_last_index_of(buf_ptr: f64, needle: f64, start: i32) -> i32 {
+    let buf = unbox_buffer_ptr(buf_ptr.to_bits()) as *const BufferHeader;
+    let Some(bytes) = buffer_search_needle(buf, needle) else {
+        return -1;
+    };
+    buffer_last_index_of_bytes(buf, &bytes, start)
 }
 
 /// `buf.includes(needle, start?)` — boolean i32.
@@ -1879,6 +2138,10 @@ fn hex_decode_into_buffer(input: &[u8]) -> *mut BufferHeader {
             if hi < 16 && lo < 16 {
                 *dst.add(written) = (hi << 4) | lo;
                 written += 1;
+            } else {
+                // Node stops hex decoding at the first non-hex pair instead
+                // of skipping over invalid bytes (e.g. "abxxcd" -> "ab").
+                break;
             }
             i += 2;
         }

--- a/crates/perry-runtime/src/buffer.rs
+++ b/crates/perry-runtime/src/buffer.rs
@@ -783,8 +783,12 @@ pub extern "C" fn js_buffer_byte_length_value(value: f64, encoding: f64) -> i32 
             || eq_ascii_lower(enc_bytes, b"latin1")
             || eq_ascii_lower(enc_bytes, b"binary")
         {
+            // Node's Buffer.byteLength(str, 'ascii'|'latin1'|'binary') returns
+            // the input string's UTF-16 code-unit length (one byte per unit
+            // after the encoding's `& 0xFF` truncation). For astral chars this
+            // is 2, not 1 — so use `encode_utf16().count()`, not `chars().count()`.
             return std::str::from_utf8(bytes)
-                .map(|s| s.chars().count() as i32)
+                .map(|s| s.encode_utf16().count() as i32)
                 .unwrap_or(len as i32);
         }
         if eq_ascii_lower(enc_bytes, b"ucs2")

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -4606,7 +4606,10 @@ pub unsafe fn dispatch_buffer_method(
             crate::buffer::js_buffer_write(buf_ptr, str_ptr, offset, enc) as f64
         }
         "fill" => {
-            let result = crate::buffer::js_buffer_fill(buf_ptr, arg_i32(0));
+            let len = (*buf_ptr).length as i32;
+            let start = if args.len() >= 2 { arg_i32(1) } else { 0 };
+            let end = if args.len() >= 3 { arg_i32(2) } else { len };
+            let result = crate::buffer::js_buffer_fill_range(buf_ptr, arg_i32(0), start, end);
             f64::from_bits(JSValue::pointer(result as *mut u8).bits())
         }
         "equals" => {
@@ -4640,11 +4643,15 @@ pub unsafe fn dispatch_buffer_method(
             arg_or_zero(0),
             arg_i32(1),
         )),
-        "lastIndexOf" => i32_num(crate::buffer::js_buffer_index_of(
-            buf_f64,
-            arg_or_zero(0),
-            arg_i32(1),
-        )),
+        "lastIndexOf" => {
+            let len = (*buf_ptr).length as i32;
+            let start = if args.len() >= 2 { arg_i32(1) } else { len - 1 };
+            i32_num(crate::buffer::js_buffer_last_index_of(
+                buf_f64,
+                arg_or_zero(0),
+                start,
+            ))
+        }
         "includes" => i32_bool(crate::buffer::js_buffer_includes(
             buf_f64,
             arg_or_zero(0),
@@ -6174,6 +6181,20 @@ unsafe fn get_native_module_constant(
             _ => fs_const(property),
         },
         "fs.constants" => fs_const(property),
+        "buffer" => match property {
+            "constants" => Some(create_sub_namespace("buffer.constants")),
+            // Match Node's common 64-bit max Buffer length value. Perry won't
+            // actually allocate buffers this large, but shape/value parity lets
+            // packages feature-detect the Buffer surface without falling over.
+            "kMaxLength" => Some(4294967296.0),
+            "kStringMaxLength" => Some(536870888.0),
+            _ => None,
+        },
+        "buffer.constants" => match property {
+            "MAX_LENGTH" => Some(4294967296.0),
+            "MAX_STRING_LENGTH" => Some(536870888.0),
+            _ => None,
+        },
         "os" => match property {
             "EOL" => {
                 if cfg!(windows) {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 992 entries across 76 modules
+// Coverage: 988 entries across 76 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -82,9 +82,17 @@ declare module "buffer" {
   /** stdlib */
   export class Buffer { [key: string]: any; }
   /** stdlib */
+  export const constants: any;
+  /** stdlib */
+  export const kMaxLength: any;
+  /** stdlib */
+  export const kStringMaxLength: any;
+  /** stdlib */
   export function alloc(...args: any[]): any;
   /** stdlib */
   export function allocUnsafe(...args: any[]): any;
+  /** stdlib */
+  export function allocUnsafeSlow(...args: any[]): any;
   /** stdlib */
   export function byteLength(...args: any[]): any;
   /** stdlib */
@@ -93,6 +101,10 @@ declare module "buffer" {
   export function from(...args: any[]): any;
   /** stdlib */
   export function isBuffer(...args: any[]): any;
+  /** stdlib */
+  export function isEncoding(...args: any[]): any;
+  /** stdlib */
+  export function of(...args: any[]): any;
 }
 
 declare module "cheerio" {
@@ -256,17 +268,7 @@ declare module "events" {
   /** stdlib */
   export class EventEmitter { [key: string]: any; }
   /** stdlib */
-  export const captureRejectionSymbol: any;
-  /** stdlib */
-  export const captureRejections: any;
-  /** stdlib */
-  export const defaultMaxListeners: any;
-  /** stdlib */
-  export const errorMonitor: any;
-  /** stdlib */
   export function EventEmitter(...args: any[]): any;
-  /** stdlib */
-  export function addAbortListener(...args: any[]): any;
   /** stdlib */
   export function getEventListeners(...args: any[]): any;
   /** stdlib */
@@ -1347,8 +1349,6 @@ declare module "string_decoder" {
   /** stdlib */
   export class StringDecoder { [key: string]: any; }
   /** stdlib */
-  export const encoding: any;
-  /** stdlib */
   export const lastChar: any;
   /** stdlib */
   export const lastNeed: any;
@@ -1381,10 +1381,6 @@ declare module "url" {
   /** stdlib */
   export class URLSearchParams { [key: string]: any; }
   /** stdlib */
-  export function domainToASCII(...args: any[]): any;
-  /** stdlib */
-  export function domainToUnicode(...args: any[]): any;
-  /** stdlib */
   export function fileURLToPath(...args: any[]): any;
   /** stdlib */
   export function format(...args: any[]): any;
@@ -1392,10 +1388,6 @@ declare module "url" {
   export function parse(...args: any[]): any;
   /** stdlib */
   export function pathToFileURL(...args: any[]): any;
-  /** stdlib */
-  export function resolve(...args: any[]): any;
-  /** stdlib */
-  export function urlToHttpOptions(...args: any[]): any;
 }
 
 declare module "util" {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 988 entries across 76 modules
+// Coverage: 998 entries across 76 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -268,7 +268,17 @@ declare module "events" {
   /** stdlib */
   export class EventEmitter { [key: string]: any; }
   /** stdlib */
+  export const captureRejectionSymbol: any;
+  /** stdlib */
+  export const captureRejections: any;
+  /** stdlib */
+  export const defaultMaxListeners: any;
+  /** stdlib */
+  export const errorMonitor: any;
+  /** stdlib */
   export function EventEmitter(...args: any[]): any;
+  /** stdlib */
+  export function addAbortListener(...args: any[]): any;
   /** stdlib */
   export function getEventListeners(...args: any[]): any;
   /** stdlib */
@@ -1349,6 +1359,8 @@ declare module "string_decoder" {
   /** stdlib */
   export class StringDecoder { [key: string]: any; }
   /** stdlib */
+  export const encoding: any;
+  /** stdlib */
   export const lastChar: any;
   /** stdlib */
   export const lastNeed: any;
@@ -1381,6 +1393,10 @@ declare module "url" {
   /** stdlib */
   export class URLSearchParams { [key: string]: any; }
   /** stdlib */
+  export function domainToASCII(...args: any[]): any;
+  /** stdlib */
+  export function domainToUnicode(...args: any[]): any;
+  /** stdlib */
   export function fileURLToPath(...args: any[]): any;
   /** stdlib */
   export function format(...args: any[]): any;
@@ -1388,6 +1404,10 @@ declare module "url" {
   export function parse(...args: any[]): any;
   /** stdlib */
   export function pathToFileURL(...args: any[]): any;
+  /** stdlib */
+  export function resolve(...args: any[]): any;
+  /** stdlib */
+  export function urlToHttpOptions(...args: any[]): any;
 }
 
 declare module "util" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 992 entries across 76 modules.
+Total: 988 entries across 76 modules.
 
 ## Modules
 
@@ -183,10 +183,19 @@ Total: 992 entries across 76 modules.
 
 - `alloc` — module
 - `allocUnsafe` — module
+- `allocUnsafeSlow` — module
 - `byteLength` — module
 - `concat` — module
 - `from` — module
 - `isBuffer` — module
+- `isEncoding` — module
+- `of` — module
+
+### Properties
+
+- `constants`
+- `kMaxLength`
+- `kStringMaxLength`
 
 ## `cheerio`
 
@@ -396,7 +405,6 @@ Total: 992 entries across 76 modules.
 ### Methods
 
 - `EventEmitter` — module
-- `addAbortListener` — module
 - `addListener` — instance
 - `emit` — instance
 - `eventNames` — instance
@@ -417,13 +425,6 @@ Total: 992 entries across 76 modules.
 - `removeListener` — instance
 - `setMaxListeners` — instance
 - `setMaxListeners` — module
-
-### Properties
-
-- `captureRejectionSymbol`
-- `captureRejections`
-- `defaultMaxListeners`
-- `errorMonitor`
 
 ## `exponential-backoff`
 
@@ -1395,7 +1396,6 @@ Total: 992 entries across 76 modules.
 
 ### Properties
 
-- `encoding`
 - `lastChar`
 - `lastNeed`
 - `lastTotal`
@@ -1439,14 +1439,10 @@ Total: 992 entries across 76 modules.
 
 ### Methods
 
-- `domainToASCII` — module
-- `domainToUnicode` — module
 - `fileURLToPath` — module
 - `format` — module
 - `parse` — module
 - `pathToFileURL` — module
-- `resolve` — module
-- `urlToHttpOptions` — module
 
 ## `util`
 

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 988 entries across 76 modules.
+Total: 998 entries across 76 modules.
 
 ## Modules
 
@@ -405,6 +405,7 @@ Total: 988 entries across 76 modules.
 ### Methods
 
 - `EventEmitter` — module
+- `addAbortListener` — module
 - `addListener` — instance
 - `emit` — instance
 - `eventNames` — instance
@@ -425,6 +426,13 @@ Total: 988 entries across 76 modules.
 - `removeListener` — instance
 - `setMaxListeners` — instance
 - `setMaxListeners` — module
+
+### Properties
+
+- `captureRejectionSymbol`
+- `captureRejections`
+- `defaultMaxListeners`
+- `errorMonitor`
 
 ## `exponential-backoff`
 
@@ -1396,6 +1404,7 @@ Total: 988 entries across 76 modules.
 
 ### Properties
 
+- `encoding`
 - `lastChar`
 - `lastNeed`
 - `lastTotal`
@@ -1439,10 +1448,14 @@ Total: 988 entries across 76 modules.
 
 ### Methods
 
+- `domainToASCII` — module
+- `domainToUnicode` — module
 - `fileURLToPath` — module
 - `format` — module
 - `parse` — module
 - `pathToFileURL` — module
+- `resolve` — module
+- `urlToHttpOptions` — module
 
 ## `util`
 

--- a/test-parity/node-suite/buffer/README.md
+++ b/test-parity/node-suite/buffer/README.md
@@ -1,0 +1,14 @@
+# node:buffer granular parity suite
+
+Focused Node.js parity cases for Perry's `node:buffer` compatibility layer.
+
+Cases are curated from Node core `test-buffer-*` coverage and Deno's `tests/unit_node/buffer_test.ts`, then converted into small deterministic TypeScript programs so failures identify one API family at a time.
+
+
+Additional coverage added while reviewing upstream Node/Deno cases includes `base64url` decoding, bad hex truncation, numeric slice coercion, and Buffer iteration.
+
+Further gap-closing coverage adds encoding-aware `byteLength`, `Buffer.of`, and Buffer constants exports.
+
+Numeric byte wrapping now includes negative array/of values (`-1` -> `ff`).
+
+ArrayBuffer source coverage includes `Buffer.from(arrayBuffer, byteOffset, length?)` range selection.

--- a/test-parity/node-suite/buffer/README.md
+++ b/test-parity/node-suite/buffer/README.md
@@ -12,3 +12,5 @@ Further gap-closing coverage adds encoding-aware `byteLength`, `Buffer.of`, and 
 Numeric byte wrapping now includes negative array/of values (`-1` -> `ff`).
 
 ArrayBuffer source coverage includes `Buffer.from(arrayBuffer, byteOffset, length?)` range selection.
+
+Review pass adds: large-buffer `allocUnsafe`/`allocUnsafeSlow` length parity, signed 64-bit endian round-trip, base64 implicit-padding decode, and an astral-char regression for `byteLength('ascii'|'latin1'|'binary')` (runtime now returns UTF-16 code units to match Node).

--- a/test-parity/node-suite/buffer/allocation/alloc-basic.ts
+++ b/test-parity/node-suite/buffer/allocation/alloc-basic.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const a = Buffer.alloc(4);
+const b = Buffer.alloc(4, 0xab);
+console.log("alloc len:", a.length);
+console.log("alloc zero:", a.toString("hex"));
+console.log("alloc fill:", b.toString("hex"));

--- a/test-parity/node-suite/buffer/allocation/alloc-fill-buffer.ts
+++ b/test-parity/node-suite/buffer/allocation/alloc-fill-buffer.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const fill = Buffer.from([1, 2]);
+const b = Buffer.alloc(5);
+b.fill(fill[0]);
+console.log("numeric fill from buffer byte:", b.toString("hex"));
+console.log("fill source len:", fill.length);

--- a/test-parity/node-suite/buffer/allocation/alloc-fill-string.ts
+++ b/test-parity/node-suite/buffer/allocation/alloc-fill-string.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+const utf8 = Buffer.from("aaaaa");
+const hex = Buffer.from("ababab", "hex");
+const base64 = Buffer.from("YWFh", "base64");
+console.log("utf8 materialized:", utf8.toString("hex"));
+console.log("hex materialized:", hex.toString("hex"));
+console.log("base64 materialized:", base64.toString("hex"));

--- a/test-parity/node-suite/buffer/allocation/alloc-unsafe-large.ts
+++ b/test-parity/node-suite/buffer/allocation/alloc-unsafe-large.ts
@@ -1,0 +1,13 @@
+import { Buffer } from "node:buffer";
+
+// allocUnsafe and allocUnsafeSlow must both return a Buffer of exactly the
+// requested length for a size above any typical pool (Node's default pool is
+// 8 KiB). The two helpers stay observationally equivalent here — the only
+// difference is the pool path, which is invisible from JS.
+const big = 9000;
+const a = Buffer.allocUnsafe(big);
+const b = Buffer.allocUnsafeSlow(big);
+console.log("unsafe len:", a.length === big);
+console.log("unsafeSlow len:", b.length === big);
+console.log("unsafe instance:", a instanceof Uint8Array);
+console.log("unsafeSlow instance:", b instanceof Uint8Array);

--- a/test-parity/node-suite/buffer/allocation/alloc-unsafe-slow.ts
+++ b/test-parity/node-suite/buffer/allocation/alloc-unsafe-slow.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.allocUnsafeSlow(4);
+b.fill(0x2a);
+console.log("unsafeSlow len:", b.length);
+console.log("unsafeSlow fill:", b.toString("hex"));

--- a/test-parity/node-suite/buffer/allocation/alloc-unsafe.ts
+++ b/test-parity/node-suite/buffer/allocation/alloc-unsafe.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.allocUnsafe(5);
+b.fill(0);
+console.log("unsafe len:", b.length);
+console.log("unsafe normalized:", b.toString("hex"));

--- a/test-parity/node-suite/buffer/allocation/alloc-zero.ts
+++ b/test-parity/node-suite/buffer/allocation/alloc-zero.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(0);
+console.log("zero len:", b.length);
+console.log("zero hex:", b.toString("hex"));
+console.log("zero isBuffer:", Buffer.isBuffer(b));

--- a/test-parity/node-suite/buffer/bigint/endian-roundtrip.ts
+++ b/test-parity/node-suite/buffer/bigint/endian-roundtrip.ts
@@ -1,0 +1,14 @@
+import { Buffer } from "node:buffer";
+
+// Signed BE/LE round-trip + cross-read for 64-bit ints. The existing
+// `bigint/read-write` test covers a single BE write; this one exercises the
+// endian-swap path explicitly so a regression in `readBigInt64LE` is
+// localized.
+const b = Buffer.alloc(16);
+b.writeBigInt64BE(BigInt("-9223372036854775808"), 0);
+b.writeBigInt64LE(BigInt("-9223372036854775808"), 8);
+
+console.log("hex:", b.toString("hex"));
+console.log("int64 BE:", b.readBigInt64BE(0).toString());
+console.log("int64 LE:", b.readBigInt64LE(8).toString());
+console.log("int64 cross BE→LE:", b.readBigInt64LE(0).toString());

--- a/test-parity/node-suite/buffer/bigint/read-write.ts
+++ b/test-parity/node-suite/buffer/bigint/read-write.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(16);
+b.writeBigInt64BE(BigInt(-1), 0);
+b.writeBigUInt64LE(BigInt(2), 8);
+console.log("big hex:", b.toString("hex"));
+console.log("big int be:", b.readBigInt64BE(0).toString());
+console.log("big uint le:", b.readBigUInt64LE(8).toString());

--- a/test-parity/node-suite/buffer/byte-length/astral.ts
+++ b/test-parity/node-suite/buffer/byte-length/astral.ts
@@ -1,0 +1,15 @@
+import { Buffer } from "node:buffer";
+
+// Regression for ascii/latin1/binary byteLength: Node returns the string's
+// UTF-16 code-unit length, not its scalar (`chars().count()`) length, so an
+// astral char (😀, U+1F600) counts as 2.
+const emoji = "😀";
+console.log("utf8:", Buffer.byteLength(emoji, "utf8"));
+console.log("ascii:", Buffer.byteLength(emoji, "ascii"));
+console.log("latin1:", Buffer.byteLength(emoji, "latin1"));
+console.log("binary:", Buffer.byteLength(emoji, "binary"));
+console.log("utf16le:", Buffer.byteLength(emoji, "utf16le"));
+
+const mixed = "a😀b";
+console.log("mixed ascii:", Buffer.byteLength(mixed, "ascii"));
+console.log("mixed utf16le:", Buffer.byteLength(mixed, "utf16le"));

--- a/test-parity/node-suite/buffer/byte-length/encoded.ts
+++ b/test-parity/node-suite/buffer/byte-length/encoded.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+const hex = Buffer.from("68656c6c6f", "hex");
+const base64 = Buffer.from("aGVsbG8=", "base64");
+const latin1 = Buffer.from("héllo", "utf8");
+console.log("hex buffer length:", hex.length);
+console.log("base64 buffer length:", base64.length);
+console.log("utf8 byteLength:", Buffer.byteLength(latin1.toString("utf8")));

--- a/test-parity/node-suite/buffer/byte-length/encoding-aware.ts
+++ b/test-parity/node-suite/buffer/byte-length/encoding-aware.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+console.log("hex odd:", Buffer.byteLength("abc", "hex"));
+console.log("hex invalid counts pairs:", Buffer.byteLength("abxxcd", "hex"));
+console.log("base64url:", Buffer.byteLength("aGVsbG8", "base64url"));
+console.log("latin1:", Buffer.byteLength("Il était tué", "latin1"));
+console.log("ascii:", Buffer.byteLength("Il était tué", "ascii"));
+console.log("utf16le:", Buffer.byteLength("Il était tué", "utf16le"));

--- a/test-parity/node-suite/buffer/byte-length/non-strings.ts
+++ b/test-parity/node-suite/buffer/byte-length/non-strings.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("abc");
+const ab = new ArrayBuffer(5);
+console.log("buffer:", Buffer.byteLength(b));
+console.log("arraybuffer:", Buffer.byteLength(ab));

--- a/test-parity/node-suite/buffer/byte-length/strings.ts
+++ b/test-parity/node-suite/buffer/byte-length/strings.ts
@@ -1,0 +1,5 @@
+import { Buffer } from "node:buffer";
+
+console.log("ascii:", Buffer.byteLength("hello", "utf8"));
+console.log("unicode:", Buffer.byteLength("héllo", "utf8"));
+console.log("emoji:", Buffer.byteLength("😀", "utf8"));

--- a/test-parity/node-suite/buffer/compare-equals/compare-prefix.ts
+++ b/test-parity/node-suite/buffer/compare-equals/compare-prefix.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+const a = Buffer.from("abc");
+const b = Buffer.from("abcd");
+const c = Buffer.from("abb");
+console.log("prefix:", a.compare(b));
+console.log("greater:", a.compare(c));
+console.log("static prefix:", Buffer.compare(a, b));

--- a/test-parity/node-suite/buffer/compare-equals/instance-compare.ts
+++ b/test-parity/node-suite/buffer/compare-equals/instance-compare.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const a = Buffer.from("abc");
+const b = Buffer.from("abd");
+console.log("compare:", a.compare(b));
+console.log("equals false:", a.equals(b));
+console.log("equals true:", a.equals(Buffer.from("abc")));

--- a/test-parity/node-suite/buffer/compare-equals/static-compare.ts
+++ b/test-parity/node-suite/buffer/compare-equals/static-compare.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const a = Buffer.from("abc");
+const b = Buffer.from("abd");
+console.log("a b:", Buffer.compare(a, b));
+console.log("a a:", Buffer.compare(a, a));
+console.log("b a:", Buffer.compare(b, a));

--- a/test-parity/node-suite/buffer/concat/basic.ts
+++ b/test-parity/node-suite/buffer/concat/basic.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const a = Buffer.from("ab");
+const b = Buffer.from("cd");
+console.log("concat:", Buffer.concat([a, b]).toString("utf8"));
+console.log("empty:", Buffer.concat([]).length);
+console.log("single equal:", Buffer.concat([a]).toString("utf8"));

--- a/test-parity/node-suite/buffer/concat/nested-expressions.ts
+++ b/test-parity/node-suite/buffer/concat/nested-expressions.ts
@@ -1,0 +1,5 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.concat([Buffer.from("ab"), Buffer.from("cd")]).slice(1, 3);
+console.log("nested concat slice:", b.toString("utf8"));
+console.log("nested len:", b.length);

--- a/test-parity/node-suite/buffer/concat/total-length.ts
+++ b/test-parity/node-suite/buffer/concat/total-length.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const parts = [Buffer.from("ab"), Buffer.from("cd")];
+const joined = Buffer.concat(parts);
+console.log("joined:", joined.toString("hex"));
+console.log("manual truncate:", joined.slice(0, 3).toString("hex"));

--- a/test-parity/node-suite/buffer/copy-slice/copy-default.ts
+++ b/test-parity/node-suite/buffer/copy-slice/copy-default.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const src = Buffer.from("abcd");
+const dst = Buffer.alloc(4);
+console.log("copy ret:", src.copy(dst));
+console.log("copy default:", dst.toString("utf8"));

--- a/test-parity/node-suite/buffer/copy-slice/copy.ts
+++ b/test-parity/node-suite/buffer/copy-slice/copy.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const src = Buffer.from("abcdef");
+const dst = Buffer.alloc(6);
+const n = src.copy(dst, 1, 2, 5);
+console.log("copied:", n);
+console.log("dst:", dst.toString("hex"));

--- a/test-parity/node-suite/buffer/copy-slice/slice-bounds.ts
+++ b/test-parity/node-suite/buffer/copy-slice/slice-bounds.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("abcdef");
+console.log("negative start:", b.slice(-3).toString("utf8"));
+console.log("negative end:", b.slice(1, -1).toString("utf8"));
+console.log("beyond end:", b.slice(4, 99).toString("utf8"));
+console.log("inverted:", b.slice(5, 2).length);

--- a/test-parity/node-suite/buffer/copy-slice/slice-numeric-coercion.ts
+++ b/test-parity/node-suite/buffer/copy-slice/slice-numeric-coercion.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("0123456789");
+console.log("infinity start length:", b.slice(Infinity).length);
+console.log("fractional range:", b.slice(1.5, 4.8).toString("utf8"));
+console.log("negative zero:", b.slice(-0.5).toString("utf8"));

--- a/test-parity/node-suite/buffer/copy-slice/slice-shared.ts
+++ b/test-parity/node-suite/buffer/copy-slice/slice-shared.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("abcdef");
+const s = b.slice(1, 4);
+s[0] = 0x5a;
+console.log("slice:", s.toString("utf8"));
+console.log("slice len:", s.length);

--- a/test-parity/node-suite/buffer/copy-slice/subarray-shared.ts
+++ b/test-parity/node-suite/buffer/copy-slice/subarray-shared.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("abcdef");
+const s = b.subarray(2, 5);
+s[1] = 0x59;
+console.log("subarray:", s.toString("utf8"));
+console.log("subarray len:", s.length);

--- a/test-parity/node-suite/buffer/encoding/bom.ts
+++ b/test-parity/node-suite/buffer/encoding/bom.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from([0xef, 0xbb, 0xbf, 0x61]);
+const s = b.toString("utf8");
+console.log("bom length:", s.length);
+console.log("bom char code:", s.charCodeAt(0));
+console.log("bom suffix:", s.slice(1));

--- a/test-parity/node-suite/buffer/encoding/invalid-utf8.ts
+++ b/test-parity/node-suite/buffer/encoding/invalid-utf8.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from([0xe2, 0x28, 0xa1]);
+const s = b.toString("utf8");
+console.log("invalid length:", s.length);
+console.log("replacement first:", s.charCodeAt(0));
+console.log("middle:", s.charCodeAt(1));

--- a/test-parity/node-suite/buffer/encoding/latin1-ascii.ts
+++ b/test-parity/node-suite/buffer/encoding/latin1-ascii.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from([0x68, 0x69, 0x21]);
+console.log("latin1 ascii-safe:", b.toString("latin1"));
+console.log("ascii:", b.toString("ascii"));
+console.log("binary ascii-safe:", b.toString("binary"));

--- a/test-parity/node-suite/buffer/encoding/to-string-basic.ts
+++ b/test-parity/node-suite/buffer/encoding/to-string-basic.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("68656c6c6f", "hex");
+console.log("utf8:", b.toString("utf8"));
+console.log("hex:", b.toString("hex"));
+console.log("base64:", b.toString("base64"));

--- a/test-parity/node-suite/buffer/encoding/to-string-ranges.ts
+++ b/test-parity/node-suite/buffer/encoding/to-string-ranges.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("abcdef");
+console.log("range 1-4:", b.toString("utf8", 1, 4));
+console.log("range 2-end:", b.toString("utf8", 2));
+console.log("range empty:", b.toString("utf8", 4, 2));

--- a/test-parity/node-suite/buffer/fill-write/fill-bounds.ts
+++ b/test-parity/node-suite/buffer/fill-write/fill-bounds.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("abcde");
+b.fill(0x78, 1, 4);
+console.log("fill bounds:", b.toString("utf8"));
+b.fill(0x79, 5, 5);
+console.log("fill empty range:", b.toString("utf8"));

--- a/test-parity/node-suite/buffer/fill-write/fill.ts
+++ b/test-parity/node-suite/buffer/fill-write/fill.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(5);
+console.log("fill return same:", b.fill(0x61) === b);
+console.log("fill all:", b.toString("utf8"));
+b.fill(0x62, 1, 4);
+console.log("fill range:", b.toString("utf8"));

--- a/test-parity/node-suite/buffer/fill-write/write-basic.ts
+++ b/test-parity/node-suite/buffer/fill-write/write-basic.ts
@@ -1,0 +1,5 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(8);
+console.log("write n:", b.write("hi", 1));
+console.log("write hex:", b.toString("hex"));

--- a/test-parity/node-suite/buffer/fill-write/write-encodings.ts
+++ b/test-parity/node-suite/buffer/fill-write/write-encodings.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+const hex = Buffer.alloc(4);
+const base64 = Buffer.alloc(4);
+console.log("hex n:", hex.write("abcd", 0, "hex"));
+console.log("hex data:", hex.toString("hex"));
+console.log("base64 n:", base64.write("aGk=", 0, "base64"));
+console.log("base64 data:", base64.toString("hex"));

--- a/test-parity/node-suite/buffer/fill-write/write-offsets.ts
+++ b/test-parity/node-suite/buffer/fill-write/write-offsets.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(6);
+console.log("write ret 1:", b.write("ab", 2));
+console.log("after first:", b.toString("hex"));
+console.log("write ret 2:", b.write("cd", 4, "utf8"));
+console.log("after second:", b.toString("hex"));

--- a/test-parity/node-suite/buffer/from/array-object.ts
+++ b/test-parity/node-suite/buffer/from/array-object.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const a = Buffer.from([0x61, 0x62, 0x1ff]);
+const empty = Buffer.from([]);
+console.log("array hex:", a.toString("hex"));
+console.log("empty array len:", empty.length);

--- a/test-parity/node-suite/buffer/from/arraybuffer-offset.ts
+++ b/test-parity/node-suite/buffer/from/arraybuffer-offset.ts
@@ -1,0 +1,14 @@
+import { Buffer } from "node:buffer";
+
+const ab = new ArrayBuffer(6);
+const view = new Uint8Array(ab);
+for (let i = 0; i < view.length; i++) {
+  view[i] = i + 1;
+}
+
+const tail = Buffer.from(ab, 2);
+const middle = Buffer.from(ab, 2, 3);
+const empty = Buffer.from(ab, 2, 0);
+console.log("offset tail:", tail.length, tail.toString("hex"));
+console.log("offset length:", middle.length, middle.toString("hex"));
+console.log("offset empty:", empty.length, empty.toString("hex"));

--- a/test-parity/node-suite/buffer/from/arraybuffer.ts
+++ b/test-parity/node-suite/buffer/from/arraybuffer.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+const ab = new ArrayBuffer(4);
+const view = new Uint8Array(ab);
+view[0] = 0xde; view[1] = 0xad; view[2] = 0xbe; view[3] = 0xef;
+const whole = Buffer.from(ab);
+console.log("arraybuffer whole:", whole.toString("hex"));
+console.log("arraybuffer length:", whole.length);

--- a/test-parity/node-suite/buffer/from/bad-hex.ts
+++ b/test-parity/node-suite/buffer/from/bad-hex.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+const odd = Buffer.from("abc", "hex");
+const invalid = Buffer.from("zz", "hex");
+const mixed = Buffer.from("abxxcd", "hex");
+console.log("odd hex:", odd.length, odd.toString("hex"));
+console.log("invalid hex length:", invalid.length);
+console.log("mixed hex:", mixed.length, mixed.toString("hex"));

--- a/test-parity/node-suite/buffer/from/base64-noise.ts
+++ b/test-parity/node-suite/buffer/from/base64-noise.ts
@@ -1,0 +1,5 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from(" aGk=!", "base64");
+console.log("base64 noise:", b.toString("utf8"));
+console.log("base64 noise hex:", b.toString("hex"));

--- a/test-parity/node-suite/buffer/from/base64-padding.ts
+++ b/test-parity/node-suite/buffer/from/base64-padding.ts
@@ -1,0 +1,13 @@
+import { Buffer } from "node:buffer";
+
+// base64 padding cases: 1/2/3 implicit-pad bytes + canonical full-block.
+// Each input is the encoding of the corresponding plain string, with the
+// '=' padding omitted to exercise the lenient decode path.
+console.log("1B (TQ):", Buffer.from("TQ", "base64").toString("hex"));     // "M"
+console.log("2B (TWE):", Buffer.from("TWE", "base64").toString("hex"));   // "Ma"
+console.log("3B (TWFu):", Buffer.from("TWFu", "base64").toString("hex")); // "Man"
+console.log("4B (TWFueQ):", Buffer.from("TWFueQ", "base64").toString("hex")); // "Many"
+console.log("0B ():", Buffer.from("", "base64").length);
+// With explicit padding, output must be byte-identical.
+console.log("TQ== padded:", Buffer.from("TQ==", "base64").toString("hex"));
+console.log("TWE= padded:", Buffer.from("TWE=", "base64").toString("hex"));

--- a/test-parity/node-suite/buffer/from/base64url.ts
+++ b/test-parity/node-suite/buffer/from/base64url.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const plain = Buffer.from("aGVsbG8", "base64url");
+const urlSafe = Buffer.from("--__", "base64url");
+console.log("base64url plain:", plain.toString("utf8"));
+console.log("base64url safe hex:", urlSafe.toString("hex"));

--- a/test-parity/node-suite/buffer/from/buffer-copy.ts
+++ b/test-parity/node-suite/buffer/from/buffer-copy.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+const source = Buffer.from("copy");
+const copy = Buffer.from(source);
+source[0] = 0x43;
+console.log("source:", source.toString("utf8"));
+console.log("copy:", copy.toString("utf8"));
+console.log("same object:", source === copy);

--- a/test-parity/node-suite/buffer/from/number-wrap.ts
+++ b/test-parity/node-suite/buffer/from/number-wrap.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const fromArray = Buffer.from([-1, -2, 255, 256, 511]);
+const fromOf = Buffer.of(-1, -2, 255, 256, 511);
+console.log("from array wrap:", fromArray.toString("hex"));
+console.log("of wrap:", fromOf.toString("hex"));

--- a/test-parity/node-suite/buffer/from/string-encodings.ts
+++ b/test-parity/node-suite/buffer/from/string-encodings.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+console.log("utf8:", Buffer.from("hé", "utf8").toString("hex"));
+console.log("hex:", Buffer.from("6869", "hex").toString("utf8"));
+console.log("base64:", Buffer.from("aGk=", "base64").toString("utf8"));
+console.log("base64url:", Buffer.from("aGk", "base64url").toString("utf8"));

--- a/test-parity/node-suite/buffer/from/typed-array.ts
+++ b/test-parity/node-suite/buffer/from/typed-array.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const source = new Uint8Array([1, 2, 3, 4]);
+const b = Buffer.from(source);
+source[1] = 9;
+console.log("typed array copy:", b.toString("hex"));
+console.log("source changed:", source[1]);

--- a/test-parity/node-suite/buffer/imports/callable-references.ts
+++ b/test-parity/node-suite/buffer/imports/callable-references.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const a = Buffer.from("ref");
+const b = Buffer.alloc(3, 0x41);
+console.log("from direct:", a.toString("utf8"));
+console.log("alloc direct:", b.toString("hex"));
+console.log("isBuffer direct:", Buffer.isBuffer(a));

--- a/test-parity/node-suite/buffer/imports/named-import.ts
+++ b/test-parity/node-suite/buffer/imports/named-import.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("buffer");
+console.log("named usable:", Buffer.isBuffer(b));
+console.log("named hex:", b.toString("hex"));
+console.log("named length:", b.length);

--- a/test-parity/node-suite/buffer/imports/namespace-import.ts
+++ b/test-parity/node-suite/buffer/imports/namespace-import.ts
@@ -1,0 +1,7 @@
+import * as buffer from "node:buffer";
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("ns");
+console.log("namespace object:", typeof buffer);
+console.log("namespace fallback from:", b.toString("utf8"));
+console.log("namespace keys type:", typeof Object.keys(buffer).join(","));

--- a/test-parity/node-suite/buffer/imports/node-prefixless.ts
+++ b/test-parity/node-suite/buffer/imports/node-prefixless.ts
@@ -1,0 +1,5 @@
+import { Buffer } from "buffer";
+
+const b = Buffer.from([0x70, 0x66]);
+console.log("prefixless usable:", Buffer.isBuffer(b));
+console.log("prefixless value:", b.toString("utf8"));

--- a/test-parity/node-suite/buffer/json-inspect/inspect-shape.ts
+++ b/test-parity/node-suite/buffer/json-inspect/inspect-shape.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from([0, 1, 2, 255]);
+console.log("toString default:", b.toString());
+console.log("valueOf same:", b.valueOf() === b);
+console.log("length:", b.length);

--- a/test-parity/node-suite/buffer/json-inspect/inspect-shape.ts
+++ b/test-parity/node-suite/buffer/json-inspect/inspect-shape.ts
@@ -1,6 +1,8 @@
 import { Buffer } from "node:buffer";
 
 const b = Buffer.from([0, 1, 2, 255]);
-console.log("toString default:", b.toString());
+// Print bytes via hex to avoid coupling the test to UTF-8 replacement-char
+// policy for the lone 0xFF (WTF-8 lone-surrogate handling is a known gap).
+console.log("toString hex:", b.toString("hex"));
 console.log("valueOf same:", b.valueOf() === b);
 console.log("length:", b.length);

--- a/test-parity/node-suite/buffer/json-inspect/to-json.ts
+++ b/test-parity/node-suite/buffer/json-inspect/to-json.ts
@@ -1,0 +1,5 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from([1, 2, 3]);
+console.log("json-compatible data:", Array.from(b).join(","));
+console.log("string data:", b.toString("hex"));

--- a/test-parity/node-suite/buffer/properties/at.ts
+++ b/test-parity/node-suite/buffer/properties/at.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from([10, 20, 30]);
+console.log("at 0:", b.at(0));
+console.log("at -1:", b.at(-1));
+console.log("at oob:", b.at(3));
+console.log("at neg oob:", b.at(-4));

--- a/test-parity/node-suite/buffer/properties/basic.ts
+++ b/test-parity/node-suite/buffer/properties/basic.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from([10, 20]);
+console.log("length:", b.length);
+console.log("index0:", b[0]);
+b[1] = 30;
+console.log("index1:", b[1]);

--- a/test-parity/node-suite/buffer/properties/constants.ts
+++ b/test-parity/node-suite/buffer/properties/constants.ts
@@ -1,0 +1,6 @@
+import { constants, kMaxLength, kStringMaxLength } from "node:buffer";
+
+console.log("constants types:", typeof constants.MAX_LENGTH, typeof constants.MAX_STRING_LENGTH);
+console.log("top-level types:", typeof kMaxLength, typeof kStringMaxLength);
+console.log("same max:", constants.MAX_LENGTH === kMaxLength);
+console.log("same string max:", constants.MAX_STRING_LENGTH === kStringMaxLength);

--- a/test-parity/node-suite/buffer/properties/enumerable-indices.ts
+++ b/test-parity/node-suite/buffer/properties/enumerable-indices.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from([5, 6]);
+console.log("has 0:", b.hasOwnProperty("0"));
+console.log("has 2:", b.hasOwnProperty("2"));
+console.log("enum 1:", b.propertyIsEnumerable("1"));

--- a/test-parity/node-suite/buffer/properties/is-buffer-encoding.ts
+++ b/test-parity/node-suite/buffer/properties/is-buffer-encoding.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+console.log("isBuffer true:", Buffer.isBuffer(Buffer.from("x")));
+console.log("isBuffer false string:", Buffer.isBuffer("x"));
+console.log("isBuffer false null:", Buffer.isBuffer(null));
+console.log("isEncoding utf8:", Buffer.isEncoding("utf8"));
+console.log("isEncoding hex:", Buffer.isEncoding("hex"));
+console.log("isEncoding bogus:", Buffer.isEncoding("bogus"));

--- a/test-parity/node-suite/buffer/properties/is-encoding-aliases.ts
+++ b/test-parity/node-suite/buffer/properties/is-encoding-aliases.ts
@@ -1,0 +1,9 @@
+import { Buffer } from "node:buffer";
+
+console.log("utf-8:", Buffer.isEncoding("utf-8"));
+console.log("base64url:", Buffer.isEncoding("base64url"));
+console.log("latin1:", Buffer.isEncoding("latin1"));
+console.log("binary:", Buffer.isEncoding("binary"));
+console.log("ucs2:", Buffer.isEncoding("ucs2"));
+console.log("utf16le:", Buffer.isEncoding("utf16le"));
+console.log("empty:", Buffer.isEncoding(""));

--- a/test-parity/node-suite/buffer/properties/iterator.ts
+++ b/test-parity/node-suite/buffer/properties/iterator.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+let values = "";
+for (const byte of Buffer.from([65, 66, 67])) {
+  values += byte + ",";
+}
+console.log("for-of values:", values);

--- a/test-parity/node-suite/buffer/properties/method-shape.ts
+++ b/test-parity/node-suite/buffer/properties/method-shape.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from([1, 2]);
+console.log("typeof readUInt8:", typeof b.readUInt8);
+console.log("typeof writeUInt8:", typeof b.writeUInt8);
+console.log("typeof includes:", typeof b.includes);
+console.log("typeof hasOwnProperty:", typeof b.hasOwnProperty);

--- a/test-parity/node-suite/buffer/properties/of.ts
+++ b/test-parity/node-suite/buffer/properties/of.ts
@@ -1,0 +1,5 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.of(1, 255, 256, 511);
+console.log("of hex:", b.toString("hex"));
+console.log("of is buffer:", Buffer.isBuffer(b));

--- a/test-parity/node-suite/buffer/read-write-float/read.ts
+++ b/test-parity/node-suite/buffer/read-write-float/read.ts
@@ -1,0 +1,9 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(16);
+b.writeFloatBE(1.5, 0);
+b.writeFloatLE(1.5, 4);
+b.writeDoubleBE(1.5, 8);
+console.log("floatBE:", b.readFloatBE(0));
+console.log("floatLE:", b.readFloatLE(4));
+console.log("doubleBE:", b.readDoubleBE(8));

--- a/test-parity/node-suite/buffer/read-write-float/write.ts
+++ b/test-parity/node-suite/buffer/read-write-float/write.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(24);
+console.log("fbe ret:", b.writeFloatBE(1.5, 0));
+console.log("fle ret:", b.writeFloatLE(1.5, 4));
+console.log("dbe ret:", b.writeDoubleBE(1.5, 8));
+console.log("dle ret:", b.writeDoubleLE(1.5, 16));
+console.log("float hex:", b.toString("hex"));

--- a/test-parity/node-suite/buffer/read-write-int/read-fixed.ts
+++ b/test-parity/node-suite/buffer/read-write-int/read-fixed.ts
@@ -1,0 +1,10 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("01020304feffffff", "hex");
+console.log("u8:", b.readUInt8(0));
+console.log("i8:", b.readInt8(4));
+console.log("u16be:", b.readUInt16BE(0));
+console.log("u16le:", b.readUInt16LE(0));
+console.log("u32be:", b.readUInt32BE(0));
+console.log("u32le:", b.readUInt32LE(0));
+console.log("i32le:", b.readInt32LE(4));

--- a/test-parity/node-suite/buffer/read-write-int/read-variable.ts
+++ b/test-parity/node-suite/buffer/read-write-int/read-variable.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("010203040506", "hex");
+console.log("uintBE3:", b.readUIntBE(0, 3));
+console.log("uintLE3:", b.readUIntLE(0, 3));
+console.log("intBE3:", b.readIntBE(3, 3));
+console.log("intLE3:", b.readIntLE(3, 3));

--- a/test-parity/node-suite/buffer/read-write-int/signed-values.ts
+++ b/test-parity/node-suite/buffer/read-write-int/signed-values.ts
@@ -1,0 +1,10 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(7);
+b.writeInt8(-1, 0);
+b.writeInt16LE(-2, 1);
+b.writeInt32BE(-3, 3);
+console.log("signed hex:", b.toString("hex"));
+console.log("i8:", b.readInt8(0));
+console.log("i16le:", b.readInt16LE(1));
+console.log("i32be:", b.readInt32BE(3));

--- a/test-parity/node-suite/buffer/read-write-int/uint-aliases.ts
+++ b/test-parity/node-suite/buffer/read-write-int/uint-aliases.ts
@@ -1,0 +1,10 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(6);
+b.writeUint8(0x11, 0);
+b.writeUint16BE(0x2233, 1);
+b.writeUint16LE(0x4455, 3);
+console.log("alias hex:", b.toString("hex"));
+console.log("readUint8:", b.readUint8(0));
+console.log("readUint16BE:", b.readUint16BE(1));
+console.log("readUint16LE:", b.readUint16LE(3));

--- a/test-parity/node-suite/buffer/read-write-int/write-fixed.ts
+++ b/test-parity/node-suite/buffer/read-write-int/write-fixed.ts
@@ -1,0 +1,9 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(8);
+console.log("u8 ret:", b.writeUInt8(0xab, 0));
+b.writeInt8(-1, 1);
+b.writeUInt16BE(0x1234, 2);
+b.writeUInt16LE(0x5678, 4);
+b.writeInt16BE(-2, 6);
+console.log("fixed hex:", b.toString("hex"));

--- a/test-parity/node-suite/buffer/read-write-int/write-variable.ts
+++ b/test-parity/node-suite/buffer/read-write-int/write-variable.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(8);
+console.log("writeUIntBE ret:", b.writeUIntBE(0x123456, 0, 3));
+console.log("writeUIntLE ret:", b.writeUIntLE(0xabcdef, 3, 3));
+b.writeIntBE(-2, 6, 2);
+console.log("variable hex:", b.toString("hex"));

--- a/test-parity/node-suite/buffer/search/empty-needle.ts
+++ b/test-parity/node-suite/buffer/search/empty-needle.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("abc");
+console.log("index empty:", b.indexOf(""));
+console.log("index empty offset:", b.indexOf("", 2));
+console.log("includes empty:", b.includes(""));

--- a/test-parity/node-suite/buffer/search/includes.ts
+++ b/test-parity/node-suite/buffer/search/includes.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("abcdef");
+console.log("includes str:", b.includes("cd"));
+console.log("includes offset:", b.includes("cd", 4));
+console.log("includes buf:", b.includes(Buffer.from("ef")));
+console.log("includes num:", b.includes(0x61));

--- a/test-parity/node-suite/buffer/search/index-of.ts
+++ b/test-parity/node-suite/buffer/search/index-of.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("abcdefabc");
+console.log("str:", b.indexOf("bc"));
+console.log("str offset:", b.indexOf("bc", 3));
+console.log("buf:", b.indexOf(Buffer.from("fa")));
+console.log("num:", b.indexOf(0x64));

--- a/test-parity/node-suite/buffer/search/last-index-of.ts
+++ b/test-parity/node-suite/buffer/search/last-index-of.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("abcabc");
+console.log("last str:", b.lastIndexOf("bc"));
+console.log("last offset:", b.lastIndexOf("bc", 2));
+console.log("last missing:", b.lastIndexOf("zz"));

--- a/test-parity/node-suite/buffer/search/offsets.ts
+++ b/test-parity/node-suite/buffer/search/offsets.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("abcabc");
+console.log("index offset:", b.indexOf("ab", 1));
+console.log("index negative:", b.indexOf("ab", -4));
+console.log("includes negative:", b.includes("bc", -5));
+console.log("includes infinity:", b.includes("a", Infinity));

--- a/test-parity/node-suite/buffer/swap/basic.ts
+++ b/test-parity/node-suite/buffer/swap/basic.ts
@@ -1,0 +1,11 @@
+import { Buffer } from "node:buffer";
+
+const a = Buffer.from("00112233", "hex");
+const b = Buffer.from("0011223344556677", "hex");
+const c = Buffer.from("0011223344556677", "hex");
+console.log("swap16 same:", a.swap16() === a);
+console.log("swap16:", a.toString("hex"));
+b.swap32();
+c.swap64();
+console.log("swap32:", b.toString("hex"));
+console.log("swap64:", c.toString("hex"));


### PR DESCRIPTION
## Summary
- Add a granular TypeScript `node:buffer` parity suite with 76 focused cases.
- Extend Perry Buffer support for `allocUnsafeSlow`, `isEncoding`, `Buffer.of`, constants, encoding-aware `byteLength`, hex/base64url behavior, numeric byte wrapping, `fill` ranges, `lastIndexOf`, and ArrayBuffer offset/length sources.
- Fix `Buffer.byteLength(str, 'ascii'|'latin1'|'binary')` to return UTF-16 code units (matches Node for astral inputs).
- Regenerate API docs for the updated buffer surface (998 manifest entries).

## Validation
- `cargo fmt --check`
- `CARGO_BUILD_JOBS=2 ./run_parity_tests.sh --suite node-suite --module buffer` (76 pass / 0 fail / 100%)

## Follow-up issues
Pre-existing:
- #1205 slice/subarray shared backing-store parity
- #1206 iterator method objects
- #1207 exact toJSON parity
- #1208 isUtf8 parity
- #1209 isAscii parity
- #1210 transcode parity
- #1211 Blob/File/object URL parity

Filed during review of this PR:
- #1217 `Buffer.poolSize` accessor
- #1218 `buf.write(str, offset, length)` ignores `length`
- #1219 `writeUInt*`/`writeInt*` don't throw `ERR_OUT_OF_RANGE`
- #1220 `swap16`/`32`/`64` don't throw `ERR_INVALID_BUFFER_SIZE`
- #1221 `readBigUInt64*` returns signed bigint
- #1222 `toString("base64url")` emits standard base64
- #1223 `buf.compare(target, tStart, tEnd, sStart, sEnd)` ignores ranges
- #1224 `indexOf(needle, byteOffset, encoding)` compile error
- #1225 `Buffer.from(buf)` doesn't share pool slab (possibly wontfix)