### PR TITLE
fix(runtime): #1199 honor console.dir(value, { depth }) inspect cap

### DIFF
--- a/crates/perry-codegen/src/lower_call/mod.rs
+++ b/crates/perry-codegen/src/lower_call/mod.rs
@@ -2894,16 +2894,26 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
                 return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
             }
             // console.dir(obj[, options]) — Node prints just the formatted
-            // object, ignoring the options arg (Perry doesn't honor depth /
-            // colors / showHidden yet). Without this, the multi-arg dispatch
-            // would print both the obj and the options object side by side.
+            // object. Without an options arg we hit the fast path and route
+            // through `js_console_log_dynamic` (default depth=2). With options
+            // we call `js_console_dir_with_options` so the runtime can read
+            // `options.depth` (#1199) and override INSPECT_MAX_DEPTH for the
+            // print. showHidden / colors / util.inspect.custom etc. remain
+            // best-effort (#1200–#1204).
             if property == "dir" && !args.is_empty() {
                 let v = lower_expr(ctx, &args[0])?;
-                ctx.block()
-                    .call_void("js_console_log_dynamic", &[(DOUBLE, &v)]);
-                // Lower remaining args for side effects only.
-                for a in args.iter().skip(1) {
-                    let _ = lower_expr(ctx, a)?;
+                if args.len() >= 2 {
+                    let opts = lower_expr(ctx, &args[1])?;
+                    ctx.block().call_void(
+                        "js_console_dir_with_options",
+                        &[(DOUBLE, &v), (DOUBLE, &opts)],
+                    );
+                    for a in args.iter().skip(2) {
+                        let _ = lower_expr(ctx, a)?;
+                    }
+                } else {
+                    ctx.block()
+                        .call_void("js_console_log_dynamic", &[(DOUBLE, &v)]);
                 }
                 return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
             }

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -39,6 +39,8 @@ pub fn declare_phase1(module: &mut LlModule) {
     module.declare_function("js_console_error_number", VOID, &[DOUBLE]);
     module.declare_function("js_console_warn_dynamic", VOID, &[DOUBLE]);
     module.declare_function("js_console_warn_number", VOID, &[DOUBLE]);
+    // console.dir(value, options) — honors options.depth (#1199).
+    module.declare_function("js_console_dir_with_options", VOID, &[DOUBLE, DOUBLE]);
 
     // NaN-boxing wrappers (bridge between raw handles and NaN-boxed doubles).
     module.declare_function("js_nanbox_string", DOUBLE, &[I64]);

--- a/crates/perry-runtime/src/builtins.rs
+++ b/crates/perry-runtime/src/builtins.rs
@@ -2711,8 +2711,7 @@ unsafe fn decode_dir_depth_option(options_value: f64) -> Option<usize> {
         return None;
     }
     // Confirm this is a regular object before dereferencing as ObjectHeader.
-    let gc_header =
-        (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    let gc_header = (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
     if (*gc_header).obj_type != crate::gc::GC_TYPE_OBJECT {
         return None;
     }

--- a/crates/perry-runtime/src/builtins.rs
+++ b/crates/perry-runtime/src/builtins.rs
@@ -554,8 +554,9 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                 } else if gc_type == crate::gc::GC_TYPE_ARRAY {
                     // Array — format as [ elem1, elem2, ... ] matching Node.js util.inspect.
                     // Node's default depth cap is 2: anything more than 2
-                    // levels of nesting collapses to `[Array]`. `%o` raises
-                    // the cap via INSPECT_DEPTH_LIMIT (see js_util_format).
+                    // levels of nesting collapses to `[Array]`. `%o` (`%O`'s
+                    // unbounded-depth sibling) and `console.dir(v, { depth })`
+                    // both override the cap via INSPECT_DEPTH_LIMIT.
                     if depth > inspect_depth_limit() {
                         return "[Array]".to_string();
                     }
@@ -641,7 +642,8 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                 } else if gc_type == crate::gc::GC_TYPE_OBJECT {
                     // Object — check for keys_array. Node's default depth
                     // cap is 2: anything past that collapses to `[Object]`.
-                    // `%o` raises the cap via INSPECT_DEPTH_LIMIT.
+                    // `%o` and `console.dir(v, { depth })` override via
+                    // INSPECT_DEPTH_LIMIT.
                     if depth > inspect_depth_limit() {
                         return "[Object]".to_string();
                     }
@@ -906,8 +908,9 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
 
                     if gc_type == crate::gc::GC_TYPE_ARRAY {
                         // Node's default depth cap: beyond 2 levels of
-                        // nesting, arrays collapse to `[Array]`. `%o` raises
-                        // the cap via INSPECT_DEPTH_LIMIT.
+                        // nesting, arrays collapse to `[Array]`. `%o` and
+                        // `console.dir(v, { depth })` override via
+                        // INSPECT_DEPTH_LIMIT.
                         if depth > inspect_depth_limit() {
                             return "[Array]".to_string();
                         }
@@ -934,8 +937,9 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
                         }
                     } else if gc_type == crate::gc::GC_TYPE_OBJECT {
                         // Past Node's default depth cap, nested objects
-                        // collapse to the literal token `[Object]`. `%o`
-                        // raises the cap via INSPECT_DEPTH_LIMIT.
+                        // collapse to the literal token `[Object]`. `%o` and
+                        // `console.dir(v, { depth })` override via
+                        // INSPECT_DEPTH_LIMIT.
                         if depth > inspect_depth_limit() {
                             return "[Object]".to_string();
                         }
@@ -2685,6 +2689,90 @@ pub extern "C" fn js_console_clear() {
     if std::io::stdout().is_terminal() {
         print!("\x1b[2J\x1b[H");
     }
+}
+
+/// Decode `options.depth` from a NaN-boxed `console.dir(value, options)`
+/// second arg. Mirrors Node:
+///   - missing key / non-object options → return `None` (caller defaults to 2)
+///   - `null` → `Some(usize::MAX)` (unlimited)
+///   - non-negative integer → that many levels of nesting
+///   - negative or non-finite → clamp to 0 (matches Node's coerce-to-zero)
+///
+/// # Safety
+///
+/// `options_value` must be a valid NaN-boxed JSValue.
+unsafe fn decode_dir_depth_option(options_value: f64) -> Option<usize> {
+    let jsval = JSValue::from_bits(options_value.to_bits());
+    if !jsval.is_pointer() {
+        return None;
+    }
+    let ptr: *const crate::array::ArrayHeader = jsval.as_pointer();
+    if ptr.is_null() || (ptr as usize) < 0x10000 || ((ptr as u64) >> 48) != 0 {
+        return None;
+    }
+    // Confirm this is a regular object before dereferencing as ObjectHeader.
+    let gc_header =
+        (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    if (*gc_header).obj_type != crate::gc::GC_TYPE_OBJECT {
+        return None;
+    }
+    let obj_ptr = ptr as *const crate::object::ObjectHeader;
+    let keys_array = (*obj_ptr).keys_array;
+    if keys_array.is_null() {
+        return None;
+    }
+    let key_count = crate::array::js_array_length(keys_array) as usize;
+    for i in 0..key_count {
+        let key_val = crate::array::js_array_get(keys_array, i as u32);
+        if !key_val.is_string() {
+            continue;
+        }
+        let key_ptr = key_val.as_string_ptr();
+        if key_ptr.is_null() {
+            continue;
+        }
+        let key_len = (*key_ptr).byte_len as usize;
+        let key_data = (key_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        let key_bytes = std::slice::from_raw_parts(key_data, key_len);
+        if key_bytes != b"depth" {
+            continue;
+        }
+        let raw = crate::object::js_object_get_field_f64(obj_ptr, i as u32);
+        let v = JSValue::from_bits(raw.to_bits());
+        if v.is_null() {
+            return Some(usize::MAX);
+        }
+        if v.is_int32() {
+            let n = v.as_int32();
+            return Some(if n < 0 { 0 } else { n as usize });
+        }
+        if v.is_number() {
+            let n = v.as_number();
+            if n.is_nan() {
+                return Some(0);
+            }
+            if n.is_infinite() {
+                return if n > 0.0 { Some(usize::MAX) } else { Some(0) };
+            }
+            let n_i = n as i64;
+            return Some(if n_i < 0 { 0 } else { n_i as usize });
+        }
+        return None;
+    }
+    None
+}
+
+/// `console.dir(value, options)` — formats `value` with the same surface used
+/// by `console.log`, but honors `options.depth` (Node default: 2). Issue #1199.
+///
+/// # Safety
+///
+/// Both args must be valid NaN-boxed JSValues.
+#[no_mangle]
+pub unsafe extern "C" fn js_console_dir_with_options(value: f64, options_value: f64) {
+    let max_depth = decode_dir_depth_option(options_value).unwrap_or(2);
+    let _guard = InspectDepthLimitGuard::new(max_depth);
+    println!("{}", format_jsvalue(value, 0));
 }
 
 // === console.table ===

--- a/test-parity/node-suite/console/dir/depth-options.ts
+++ b/test-parity/node-suite/console/dir/depth-options.ts
@@ -1,2 +1,24 @@
+// Issue #1199: `console.dir(value, { depth: N })` should match Node's depth
+// truncation. The default depth is 2; `depth: 0` collapses all nested objects
+// to `[Object]` / `[Array]`; finite values cap nesting at N levels.
+
 console.dir({ foo: { bar: { baz: true } } }, { depth: 0 });
 console.dir({ foo: { bar: { baz: true } } }, { depth: 1 });
+
+const deeply = {
+  a: {
+    b: {
+      c: {
+        d: 1,
+      },
+    },
+  },
+};
+
+console.dir(deeply, { depth: 0 });
+console.dir(deeply, { depth: 1 });
+console.dir(deeply, { depth: 2 });
+
+const nestedArr = [[[[1]]]];
+console.dir(nestedArr, { depth: 0 });
+console.dir(nestedArr, { depth: 1 });


### PR DESCRIPTION
## Summary
- Fixes #1199 — `console.dir(value, { depth })` now honors Node-compatible nesting limits instead of always collapsing at the hardcoded default of 2
- Adds thread-local `INSPECT_MAX_DEPTH` (default 2); `js_console_dir_with_options` decodes `options.depth` (integer → cap, `null` / `+Infinity` → unlimited, missing → default) and overrides for the duration of the print
- Codegen routes `console.dir(x, opts)` through the new runtime fn while the no-options fast path is unchanged

## Test plan
- [x] `./run_parity_tests.sh --suite node-suite --module console` — 1/1 PASS (`node-suite/console/dir/depth-options`, matches Node byte-for-byte across depth 0/1/2 on objects and depth 0/1 on nested arrays)
- [x] `./run_parity_tests.sh --suite node-suite --module util` — 24/24 PASS (no regression in shared `util.inspect` surface)
- [x] `cargo test --release -p perry-runtime --lib builtins` — 5/5 PASS
- [ ] Maintainer: bump `[workspace.package].version` + add CHANGELOG entry at merge time

## Followups (out of scope)
- `showHidden`, `colors`, `util.inspect.custom`, function-name preservation, circular-ref tracking — tracked separately by #1200 / #1201 / #1202 / #1203 / #1204. The thread-local hook makes those drop-in extensions.