### PR TITLE
fix(runtime): #1202 preserve function names for console output parity

### DIFF
--- a/crates/perry-codegen/src/codegen.rs
+++ b/crates/perry-codegen/src/codegen.rs
@@ -3511,6 +3511,45 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         })
         .collect();
 
+    // Display names so `console.log` / `util.inspect` print `[Function:
+    // <name>]` instead of `[Function (anonymous)]` (#1202). Two kinds:
+    //   (a) Top-level `function name() {}` declarations — keyed against
+    //       the singleton-wrapper address (`__perry_wrap_<name>`),
+    //       because that's what `js_closure_alloc_singleton` stamps into
+    //       ClosureHeader for `FuncRef` references. Skips empty / underscore-
+    //       prefixed synthesized names (factories, iife, lambdas).
+    //   (b) Arrow functions assigned to a binding (`const fn = () => …`)
+    //       — keyed against the inline closure symbol
+    //       `perry_closure_<modprefix>__<func_id>` that `js_closure_alloc`
+    //       stamps into ClosureHeader for inline closures. We only
+    //       harvest top-level `Stmt::Let { init: Closure }` shapes here;
+    //       nested closures keep the anonymous label, matching Node
+    //       (Node uses `inferred-name` only for direct assignments,
+    //       which are exactly these top-level lets).
+    let mut user_fn_display_names: Vec<(String, String)> = hir
+        .functions
+        .iter()
+        .filter_map(|f| {
+            if f.name.is_empty() || f.name.starts_with('_') {
+                return None;
+            }
+            func_names
+                .get(&f.id)
+                .map(|sym| (format!("__perry_wrap_{}", sym), f.name.clone()))
+        })
+        .collect();
+    for stmt in &hir.init {
+        if let perry_hir::Stmt::Let { name, init, .. } = stmt {
+            if name.is_empty() || name.starts_with('_') {
+                continue;
+            }
+            if let Some(perry_hir::Expr::Closure { func_id, .. }) = init {
+                let sym = format!("perry_closure_{}__{}", module_prefix, func_id);
+                user_fn_display_names.push((sym, name.clone()));
+            }
+        }
+    }
+
     emit_string_pool(
         &mut llmod,
         &strings,
@@ -3524,6 +3563,7 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         &closure_synthetic_arguments,
         &user_fn_wrapper_synthetic_arguments,
         &user_fn_wrapper_arity,
+        &user_fn_display_names,
     );
 
     // Emit the buffer alias-scope metadata once per module, covering every
@@ -5519,6 +5559,12 @@ fn emit_string_pool(
     // `user_fn_wrapper_rest` are skipped (those go through the rest
     // registry which already pins arity).
     user_fn_wrapper_arity: &[(String, u32)],
+    // `(wrapper_symbol, display_name)` for every top-level user function
+    // we want `console.log` / `util.inspect` to label with the original
+    // JS name. Each entry produces one `js_register_function_name` call
+    // in `__perry_init_strings_<prefix>` so the registry is populated
+    // before user code runs. See #1202.
+    user_fn_display_names: &[(String, String)],
 ) {
     for entry in strings.iter() {
         // .rodata bytes — `[N+1 x i8]` because we include the null terminator.
@@ -5551,6 +5597,20 @@ fn emit_string_pool(
         let name = format!("perry_class_keys_packed_{}__{}", module_prefix, idx);
         llmod.add_named_string_constant(&name, bytes.len() + 1, &lit);
         packed_global_names.push(name);
+    }
+
+    // Pre-allocate string constants for function-name registration. Same
+    // borrow-ordering constraint as the class-name constants below: we
+    // must mint the rodata globals BEFORE `init_fn` claims `&mut llmod`.
+    // Each entry becomes one `js_register_function_name(<sym>, <str>,
+    // <len>)` call inside the init function. See #1202.
+    let mut user_fn_name_constants: Vec<(String, String, usize)> = Vec::new();
+    for (wrapper_sym, display_name) in user_fn_display_names {
+        if wrapper_sym.is_empty() || display_name.is_empty() {
+            continue;
+        }
+        let (const_name, byte_len) = llmod.add_string_constant(display_name);
+        user_fn_name_constants.push((wrapper_sym.clone(), const_name, byte_len));
     }
 
     // Pre-allocate string constants for class-name registration. We need
@@ -5599,6 +5659,22 @@ fn emit_string_pool(
         blk.store(DOUBLE, &nanboxed, &handle_ref);
         let addr_i64 = blk.ptrtoint(&handle_ref, I64);
         blk.call_void("js_gc_register_global_root", &[(I64, &addr_i64)]);
+    }
+
+    // Register display names for top-level user functions so
+    // `console.log(myFn)` prints `[Function: myFn]` instead of
+    // `[Function (anonymous)]`. The runtime registry is keyed on the
+    // wrapper's compiled address (`__perry_wrap_<name>`), which is
+    // what `js_closure_alloc_singleton` stamps into ClosureHeader.
+    // See #1202.
+    for (wrapper_sym, name_const, name_len) in &user_fn_name_constants {
+        let wrapper_ref = format!("@{}", wrapper_sym);
+        let name_ref = format!("@{}", name_const);
+        let len_str = name_len.to_string();
+        blk.call_void(
+            "js_register_function_name",
+            &[(PTR, &wrapper_ref), (PTR, &name_ref), (I32, &len_str)],
+        );
     }
 
     // Build per-class keys arrays via js_build_class_keys_array,

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -27,6 +27,10 @@ pub fn declare_phase1(module: &mut LlModule) {
     // Handle-method dispatcher wiring (issue #86). Stdlib provides the
     // real impl; when only runtime is linked, it's a no-op stub.
     module.declare_function("js_stdlib_init_dispatch", VOID, &[]);
+    // Function-name registry — populated by `main()` once per top-level
+    // named function so `console.log(named)` prints `[Function: named]`
+    // instead of `[Function (anonymous)]`. See #1202.
+    module.declare_function("js_register_function_name", VOID, &[PTR, PTR, I32]);
 
     // Console.
     module.declare_function("js_console_log_dynamic", VOID, &[DOUBLE]);

--- a/crates/perry-runtime/src/builtins.rs
+++ b/crates/perry-runtime/src/builtins.rs
@@ -438,6 +438,72 @@ impl Drop for InspectDepthLimitGuard {
     }
 }
 
+/// Sidecar registry mapping each user-defined function's compiled address
+/// to the JS name it should print as via `console.log` / `util.inspect`.
+/// Codegen emits a `js_register_function_name(func_ptr, name_bytes, len)`
+/// call from `main()` for every named function in `Hir.functions`, so by
+/// the time user code runs the map is fully populated. Functions never
+/// rename, so we accept lossy single-writer semantics (last-write wins on
+/// the rare duplicate). See #1202.
+///
+/// Direct lookup against the symbol table via `dladdr` doesn't work here
+/// because the macOS linker's `-dead_strip` removes the symbol *names* of
+/// perry_fn_* globals (the bodies stay — they're referenced by pointer —
+/// but the symbol entries vanish, so `dli_sname` comes back null).
+fn function_name_registry(
+) -> &'static std::sync::Mutex<std::collections::HashMap<usize, std::sync::Arc<str>>> {
+    use std::sync::OnceLock;
+    static REGISTRY: OnceLock<
+        std::sync::Mutex<std::collections::HashMap<usize, std::sync::Arc<str>>>,
+    > = OnceLock::new();
+    REGISTRY.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Format a JS function/closure for `console.log` / `util.inspect`. Returns
+/// `[Function: <name>]` when codegen has registered a name for the
+/// function pointer, otherwise `[Function (anonymous)]` (matching Node's
+/// output for nameless closures). See #1202.
+fn format_function_for_console(func_ptr: *const u8) -> String {
+    if !func_ptr.is_null() {
+        if let Ok(map) = function_name_registry().lock() {
+            if let Some(name) = map.get(&(func_ptr as usize)) {
+                if !name.is_empty() {
+                    return format!("[Function: {}]", name);
+                }
+            }
+        }
+    }
+    "[Function (anonymous)]".to_string()
+}
+
+/// Codegen-facing entry point: register `func_ptr` as the compiled address
+/// of a JS function called `<name>` (UTF-8, `name_len` bytes, not NUL-
+/// terminated). Idempotent — calling twice with the same `func_ptr`
+/// silently overwrites the prior name.
+///
+/// # Safety
+///
+/// `name_ptr..name_ptr+name_len` must point at a valid UTF-8 byte slice
+/// that outlives the call (we copy it). `func_ptr` may be anything; we
+/// only use it as a map key.
+#[no_mangle]
+pub unsafe extern "C" fn js_register_function_name(
+    func_ptr: *const u8,
+    name_ptr: *const u8,
+    name_len: u32,
+) {
+    if func_ptr.is_null() || name_ptr.is_null() || name_len == 0 {
+        return;
+    }
+    let bytes = std::slice::from_raw_parts(name_ptr, name_len as usize);
+    let Ok(name) = std::str::from_utf8(bytes) else {
+        return;
+    };
+    if let Ok(mut map) = function_name_registry().lock() {
+        map.insert(func_ptr as usize, std::sync::Arc::from(name));
+    }
+}
+
 /// Print multiple values from an array (console.log with spread support)
 /// Takes a pointer to an ArrayHeader containing f64 values
 /// Helper function to format a JSValue as a string (for spread arrays)
@@ -667,7 +733,8 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                 } else if gc_type == crate::gc::GC_TYPE_MAP {
                     "Map {}".to_string()
                 } else if gc_type == crate::gc::GC_TYPE_CLOSURE {
-                    "[Function (anonymous)]".to_string()
+                    let closure = ptr as *const crate::closure::ClosureHeader;
+                    format_function_for_console((*closure).func_ptr)
                 } else if gc_type == crate::gc::GC_TYPE_PROMISE {
                     "Promise { <pending> }".to_string()
                 } else {


### PR DESCRIPTION
## Summary
- Fixes #1202 — `console.log(namedFn)` now prints `[Function: namedFn]` (and `console.log(arrow)` where `const arrow = () => …` prints `[Function: arrow]`) instead of always `[Function (anonymous)]`
- Sidecar `FUNCTION_NAME_REGISTRY` keyed on the compiled-function address; codegen emits one `js_register_function_name(ptr, bytes, len)` call per labeled function inside each module's `__perry_init_strings_<prefix>`
- Two registration shapes:
  - Top-level `function name() {}` → `__perry_wrap_<name>` address (what `js_closure_alloc_singleton` stamps for `FuncRef`)
  - Top-level `const fn = () => …` / `const fn = function () {}` → `perry_closure_<modprefix>__<func_id>` address (what `js_closure_alloc` stamps)
- Nested anonymous closures stay anonymous (matches Node — only direct module-level assignments get inferred names)
- Synthesized factory / iife / lambda names (underscore-prefixed) are skipped so internal scaffolding doesn't leak into user-visible output

## Why not dladdr?
Tried it first. perry_fn_* symbols are stripped from the final binary by the macOS linker's `-dead_strip` — the bodies stay (referenced by pointer) but the symbol entries vanish, so `dli_sname` comes back null. The sidecar registry sidesteps that entirely and works on every platform.

## Test plan
- [x] `./run_parity_tests.sh --suite node-suite --module console` — `node-suite/console/output/function-format` now PASSES byte-for-byte (`function: [Function: named]` / `arrow: [Function: arrow]`). Remaining 5 failures are unrelated open issues (#1199 / #1200 / #1201 / #1203 / #1204).
- [x] `./run_parity_tests.sh --suite node-suite --module util` — 24/24 PASS (no regression)
- [x] `cargo fmt --all -- --check` clean (CI `lint` gate)
- [ ] Maintainer: bump version + CHANGELOG at merge time