### PR TITLE
fix(http): #1121 honor listen(0) request for OS-assigned ephemeral port

### DIFF
--- a/crates/perry-ext-http-server/src/types.rs
+++ b/crates/perry-ext-http-server/src/types.rs
@@ -34,6 +34,11 @@ pub struct Promise {
 
 /// Extract a port from `{ port }` object, bare number, or fall back.
 /// `default_port` is used when neither shape yields a usable value.
+///
+/// Node treats `0` as a request for an OS-assigned ephemeral port — it's
+/// *not* the "missing value" sentinel. Pre-fix #1121, `extract_port`
+/// returned `default_port` for `listen(0)` so user code that asked for
+/// ephemeral binding ended up clashing on the default 3000 / 8080.
 pub unsafe fn extract_port(opts: f64, default_port: u16) -> u16 {
     let v = JsValue::from_bits(opts.to_bits());
     if v.is_pointer() {
@@ -52,7 +57,7 @@ pub unsafe fn extract_port(opts: f64, default_port: u16) -> u16 {
     }
     if v.is_number() {
         let n = v.to_number();
-        if n > 0.0 {
+        if n.is_finite() && n >= 0.0 && n <= u16::MAX as f64 {
             return n as u16;
         }
     }
@@ -227,4 +232,44 @@ pub(crate) fn read_string_header_bytes(ptr: *mut StringHeader) -> Option<Vec<u8>
 #[allow(dead_code)]
 pub(crate) unsafe fn _force_promise_reason_link(p: *mut Promise) -> f64 {
     js_promise_reason(p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn port_zero_is_kept_for_ephemeral_binding() {
+        // Node semantic: `listen(0)` asks the OS to pick a free port. The
+        // pre-#1121 check (`n > 0.0`) treated 0 as "missing" and fell back
+        // to default_port — so user code that asked for ephemeral binding
+        // collided on the default 3000 / 8080 instead.
+        let port = unsafe { extract_port(0.0_f64, 8080) };
+        assert_eq!(
+            port, 0,
+            "extract_port(0.0) should return 0, not the fallback"
+        );
+    }
+
+    #[test]
+    fn finite_positive_port_is_kept() {
+        let port = unsafe { extract_port(4242.0_f64, 8080) };
+        assert_eq!(port, 4242);
+    }
+
+    #[test]
+    fn negative_or_nan_or_inf_falls_back_to_default() {
+        assert_eq!(unsafe { extract_port(-1.0_f64, 8080) }, 8080);
+        assert_eq!(unsafe { extract_port(f64::NAN, 8080) }, 8080);
+        assert_eq!(unsafe { extract_port(f64::INFINITY, 8080) }, 8080);
+    }
+
+    #[test]
+    fn out_of_range_port_falls_back_to_default() {
+        // Anything above 65535 isn't a valid TCP port — fall back rather
+        // than wrap on the `as u16` cast (which would silently bind on
+        // a wrong, low-numbered port).
+        let port = unsafe { extract_port(70000.0_f64, 8080) };
+        assert_eq!(port, 8080);
+    }
 }


### PR DESCRIPTION
## Summary
Closes #1121. The original link errors (`_js_node_http_create_server`, `_js_node_http_res_end`, `_js_node_http_server_listen`) reported on v0.5.1010 are already fixed by intervening well-known-binding work — `import { createServer } from 'http'` now resolves through `libperry_ext_http.a` / `libperry_ext_http_server.a` and the binary links cleanly without an explicit `perry.compilePackages` entry.

The user's exact repro from the issue body still mis-bound, though: `s.listen(0)` collided on port 3000. `extract_port`'s `n > 0.0` check rejected the legitimate Node-spec "let the OS pick" value of 0 and fell back to `default_port`. This PR fixes the bare-number arm to accept any finite non-negative value in `[0, u16::MAX]`, so `listen(0)` returns 0 and `TcpListener::bind("0.0.0.0:0")` does the right thing. While there, hardens against NaN / ±Infinity / negative / overflow inputs that would previously have wrapped on the `as u16` cast.

## Test plan
- [x] User's exact repro from #1121 now links + binds + serves (no more `bind 0.0.0.0:3000 failed: Address already in use`)
- [x] `cargo test --release -p perry-ext-http-server --lib types::tests` — 4/4 PASS (port-0 / positive / NaN+Inf / overflow)
- [x] `cargo fmt --all -- --check` clean
- [ ] Maintainer: bump version + CHANGELOG at merge time

## Followups (out of scope)
- `server.address().port` doesn't reflect the OS-assigned port back to user code yet. With this fix the bind succeeds, but a user who wants to know which port they got still has to use a fixed port.