### PR TITLE
fix(stdlib): #1176 honor querystring parse/stringify codec overrides

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/node_misc.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_misc.rs
@@ -47,7 +47,7 @@ pub(super) const NODE_MISC_ROWS: &[NativeModSig] = &[
         method: "stringify",
         class_filter: None,
         runtime: "js_querystring_stringify",
-        args: &[NA_F64, NA_F64, NA_F64],
+        args: &[NA_F64, NA_F64, NA_F64, NA_F64],
         ret: NR_F64,
     },
     NativeModSig {
@@ -56,7 +56,7 @@ pub(super) const NODE_MISC_ROWS: &[NativeModSig] = &[
         method: "encode",
         class_filter: None,
         runtime: "js_querystring_stringify",
-        args: &[NA_F64, NA_F64, NA_F64],
+        args: &[NA_F64, NA_F64, NA_F64, NA_F64],
         ret: NR_F64,
     },
     // ========== LRU Cache ==========

--- a/crates/perry-codegen/src/runtime_decls.rs
+++ b/crates/perry-codegen/src/runtime_decls.rs
@@ -2630,7 +2630,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function(
         "js_querystring_stringify",
         DOUBLE,
-        &[DOUBLE, DOUBLE, DOUBLE],
+        &[DOUBLE, DOUBLE, DOUBLE, DOUBLE],
     );
 
     // ========== Fastify ==========

--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -26,6 +26,8 @@
 //! symbol.
 
 use crate::common::handle::Handle;
+use std::borrow::Cow;
+
 use perry_runtime::array::{js_array_alloc, js_array_length, js_array_push_f64};
 use perry_runtime::closure::{is_closure_ptr, js_closure_call1, ClosureHeader};
 use perry_runtime::{
@@ -226,11 +228,17 @@ pub unsafe extern "C" fn js_querystring_parse(
             }
         };
         let key = match decode {
-            Some(cb) => apply_codec(cb, key_raw),
+            Some(cb) => {
+                let normalized = normalize_decode_component_input(key_raw);
+                apply_codec(cb, normalized.as_ref())
+            }
             None => percent_decode(key_raw, true),
         };
         let value = match decode {
-            Some(cb) => apply_codec(cb, val_raw),
+            Some(cb) => {
+                let normalized = normalize_decode_component_input(val_raw);
+                apply_codec(cb, normalized.as_ref())
+            }
             None => percent_decode(val_raw, true),
         };
         push_parsed_pair(obj, &key, &value);
@@ -261,6 +269,17 @@ unsafe fn resolve_codec_option(options: f64, name: &str) -> Option<*const Closur
         return None;
     }
     Some(ptr as *const ClosureHeader)
+}
+
+/// Node's querystring parser rewrites `+` to `%20` before invoking a custom
+/// decoder. The decoder is expected to receive percent-encoded input; passing
+/// raw `+` would make identity/custom decoders diverge from Node.
+fn normalize_decode_component_input(input: &str) -> Cow<'_, str> {
+    if input.as_bytes().contains(&b'+') {
+        Cow::Owned(input.replace('+', "%20"))
+    } else {
+        Cow::Borrowed(input)
+    }
 }
 
 /// Call a user-supplied codec closure with `raw` and decode the return.

--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -27,6 +27,7 @@
 
 use crate::common::handle::Handle;
 use perry_runtime::array::{js_array_alloc, js_array_length, js_array_push_f64};
+use perry_runtime::closure::{is_closure_ptr, js_closure_call1, ClosureHeader};
 use perry_runtime::{
     js_object_alloc, js_object_get_field_by_name, js_object_get_own_field_or_undef,
     js_object_set_field_by_name, js_string_from_bytes, ArrayHeader, JSValue, ObjectHeader,
@@ -194,6 +195,7 @@ pub unsafe extern "C" fn js_querystring_parse(
     let sep = resolve_separator_str(sep_arg, "&");
     let eq = resolve_separator_str(eq_arg, "=");
     let max_keys = resolve_max_keys(options_arg);
+    let decode = resolve_codec_option(options_arg, "decodeURIComponent");
 
     let obj = js_object_alloc(0, 0);
     if input.is_empty() {
@@ -223,12 +225,52 @@ pub unsafe extern "C" fn js_querystring_parse(
                 None => (pair, ""),
             }
         };
-        let key = percent_decode(key_raw, true);
-        let value = percent_decode(val_raw, true);
+        let key = match decode {
+            Some(cb) => apply_codec(cb, key_raw),
+            None => percent_decode(key_raw, true),
+        };
+        let value = match decode {
+            Some(cb) => apply_codec(cb, val_raw),
+            None => percent_decode(val_raw, true),
+        };
         push_parsed_pair(obj, &key, &value);
         parsed += 1;
     }
     obj
+}
+
+/// Look up a callable option (`decodeURIComponent` / `encodeURIComponent`).
+/// Returns `Some(closure)` only when the slot holds a real ClosureHeader —
+/// non-callable values (or absent options) fall back to the built-in codec.
+unsafe fn resolve_codec_option(options: f64, name: &str) -> Option<*const ClosureHeader> {
+    let value = JSValue::from_bits(options.to_bits());
+    if !value.is_pointer() {
+        return None;
+    }
+    let obj = value.as_pointer::<ObjectHeader>() as *mut ObjectHeader;
+    if obj.is_null() {
+        return None;
+    }
+    let key = intern_string(name);
+    let slot = js_object_get_field_by_name(obj, key);
+    if slot.is_undefined() || slot.is_null() || !slot.is_pointer() {
+        return None;
+    }
+    let ptr = slot.as_pointer::<u8>() as usize;
+    if !is_closure_ptr(ptr) {
+        return None;
+    }
+    Some(ptr as *const ClosureHeader)
+}
+
+/// Call a user-supplied codec closure with `raw` and decode the return.
+/// Returns the empty string if the callback yielded a non-string — Node
+/// would coerce via `String(ret)`, but the only realistic failure mode here
+/// is a buggy callback, and an empty string is observably distinct.
+unsafe fn apply_codec(callback: *const ClosureHeader, raw: &str) -> String {
+    let arg = nanbox_string(intern_string(raw));
+    let ret = js_closure_call1(callback, arg);
+    nanboxed_to_string(ret).unwrap_or_default()
 }
 
 fn resolve_max_keys(options: f64) -> Option<usize> {
@@ -330,13 +372,19 @@ unsafe fn push_parsed_pair(obj: *mut ObjectHeader, key: &str, value: &str) {
     js_object_set_field_by_name(obj, key_hdr, f64::from_bits(arr_boxed.bits()));
 }
 
-/// `querystring.stringify(obj, sep?, eq?)` → string.
+/// `querystring.stringify(obj, sep?, eq?, options?)` → string.
 #[no_mangle]
-pub unsafe extern "C" fn js_querystring_stringify(obj_arg: f64, sep_arg: f64, eq_arg: f64) -> f64 {
+pub unsafe extern "C" fn js_querystring_stringify(
+    obj_arg: f64,
+    sep_arg: f64,
+    eq_arg: f64,
+    options_arg: f64,
+) -> f64 {
     // Default separators are the bytes Node uses; we read into UTF-8
     // strings instead of bytes since the chars are always ASCII.
     let sep = resolve_separator_str(sep_arg, "&");
     let eq = resolve_separator_str(eq_arg, "=");
+    let encode = resolve_codec_option(options_arg, "encodeURIComponent");
 
     let bits = obj_arg.to_bits();
     let top16 = bits >> 48;
@@ -366,7 +414,7 @@ pub unsafe extern "C" fn js_querystring_stringify(obj_arg: f64, sep_arg: f64, eq
         };
         let key_hdr = intern_string(&key);
         let value_bits = js_object_get_field_by_name(obj, key_hdr).bits();
-        append_stringify_value(&mut out, &key, value_bits, &sep, &eq);
+        append_stringify_value(&mut out, &key, value_bits, &sep, &eq, encode);
     }
     nanbox_string(intern_string(&out))
 }
@@ -389,7 +437,14 @@ unsafe fn append_stringify_value(
     value_bits: u64,
     sep: &str,
     eq: &str,
+    encode: Option<*const ClosureHeader>,
 ) {
+    let encode_with = |s: &str| -> String {
+        match encode {
+            Some(cb) => apply_codec(cb, s),
+            None => percent_encode(s),
+        }
+    };
     let top16 = value_bits >> 48;
     let value_f64 = f64::from_bits(value_bits);
 
@@ -411,9 +466,9 @@ unsafe fn append_stringify_value(
                     if !out.is_empty() {
                         out.push_str(sep);
                     }
-                    out.push_str(&percent_encode(key));
+                    out.push_str(&encode_with(key));
                     out.push_str(eq);
-                    out.push_str(&percent_encode(&elem_str));
+                    out.push_str(&encode_with(&elem_str));
                 }
                 return;
             }
@@ -424,9 +479,9 @@ unsafe fn append_stringify_value(
     if !out.is_empty() {
         out.push_str(sep);
     }
-    out.push_str(&percent_encode(key));
+    out.push_str(&encode_with(key));
     out.push_str(eq);
-    out.push_str(&percent_encode(&value_str));
+    out.push_str(&encode_with(&value_str));
 }
 
 fn querystring_scalar_to_string(value_bits: u64) -> String {

--- a/test-parity/node-suite/querystring/options/parse-decode-non-function.ts
+++ b/test-parity/node-suite/querystring/options/parse-decode-non-function.ts
@@ -1,0 +1,9 @@
+import { parse } from "node:querystring";
+
+// Non-callable `decodeURIComponent` slots must fall back to the built-in
+// percent decoder. Node coerces silently; Perry's runtime path skips the
+// closure call when `is_closure_ptr` returns false.
+console.log(JSON.stringify(parse("a=hi%20there", undefined, undefined, { decodeURIComponent: "not-a-fn" as unknown as (s: string) => string })));
+console.log(JSON.stringify(parse("a=hi%20there", undefined, undefined, { decodeURIComponent: null as unknown as (s: string) => string })));
+console.log(JSON.stringify(parse("a=hi%20there", undefined, undefined, { decodeURIComponent: undefined })));
+console.log(JSON.stringify(parse("a=hi%20there", undefined, undefined, {})));

--- a/test-parity/node-suite/querystring/options/parse-decode-plus.ts
+++ b/test-parity/node-suite/querystring/options/parse-decode-plus.ts
@@ -1,0 +1,8 @@
+import { parse } from "node:querystring";
+
+// With a custom decoder, Node rewrites `+` to `%20` before invoking the
+// callback. Identity/custom decoders therefore see percent-encoded spaces,
+// not raw plus signs.
+const tag = (s: string): string => `<${s}>`;
+console.log(JSON.stringify(parse("a+b=c+d", undefined, undefined, { decodeURIComponent: tag })));
+console.log(JSON.stringify(parse("a+b=c+d&a%20b=c%20d", undefined, undefined, { decodeURIComponent: tag })));

--- a/test-parity/node-suite/querystring/options/parse-decode-uri-component.ts
+++ b/test-parity/node-suite/querystring/options/parse-decode-uri-component.ts
@@ -1,0 +1,7 @@
+import { parse } from "node:querystring";
+
+const upper = (s: string): string => s.toUpperCase();
+console.log(JSON.stringify(parse("a=hello&b=world", undefined, undefined, { decodeURIComponent: upper })));
+
+const tag = (s: string): string => `<${s}>`;
+console.log(JSON.stringify(parse("x=1&y=2&x=3", undefined, undefined, { decodeURIComponent: tag })));

--- a/test-parity/node-suite/querystring/options/parse-options-combined.ts
+++ b/test-parity/node-suite/querystring/options/parse-options-combined.ts
@@ -1,0 +1,11 @@
+import { parse } from "node:querystring";
+
+// `maxKeys` and `decodeURIComponent` must coexist on the same options
+// object. The limit applies BEFORE decoding — Node counts pairs, not
+// decoded keys.
+const tag = (s: string): string => `<${s}>`;
+console.log(JSON.stringify(parse("a=1&b=2&c=3&d=4", undefined, undefined, { maxKeys: 2, decodeURIComponent: tag })));
+console.log(JSON.stringify(parse("a=1&b=2&c=3", undefined, undefined, { maxKeys: 0, decodeURIComponent: tag })));
+
+// Custom separators + custom decoder.
+console.log(JSON.stringify(parse("a:1;b:2", ";", ":", { decodeURIComponent: tag })));

--- a/test-parity/node-suite/querystring/options/stringify-encode-non-function.ts
+++ b/test-parity/node-suite/querystring/options/stringify-encode-non-function.ts
@@ -1,0 +1,8 @@
+import { stringify } from "node:querystring";
+
+// Mirror of parse-decode-non-function.ts: non-callable `encodeURIComponent`
+// slots fall back to Node's percent encoder.
+console.log(stringify({ a: "hi there" }, undefined, undefined, { encodeURIComponent: "not-a-fn" as unknown as (s: string) => string }));
+console.log(stringify({ a: "hi there" }, undefined, undefined, { encodeURIComponent: null as unknown as (s: string) => string }));
+console.log(stringify({ a: "hi there" }, undefined, undefined, { encodeURIComponent: undefined }));
+console.log(stringify({ a: "hi there" }, undefined, undefined, {}));

--- a/test-parity/node-suite/querystring/options/stringify-encode-uri-component.ts
+++ b/test-parity/node-suite/querystring/options/stringify-encode-uri-component.ts
@@ -1,0 +1,7 @@
+import { stringify } from "node:querystring";
+
+const upper = (s: string): string => s.toUpperCase();
+console.log(stringify({ a: "hello", b: "world" }, undefined, undefined, { encodeURIComponent: upper }));
+
+const tag = (s: string): string => `<${s}>`;
+console.log(stringify({ x: "1", y: ["2", "3"] }, undefined, undefined, { encodeURIComponent: tag }));

--- a/test-parity/node-suite/querystring/options/stringify-options-combined.ts
+++ b/test-parity/node-suite/querystring/options/stringify-options-combined.ts
@@ -1,0 +1,12 @@
+import { stringify } from "node:querystring";
+
+// Custom separators + custom encoder on the same call. Encoder must be
+// applied to keys and values (including array elements), while `sep`/`eq`
+// stay literal.
+const tag = (s: string): string => `<${s}>`;
+console.log(stringify({ a: "1", b: "2" }, ";", ":", { encodeURIComponent: tag }));
+console.log(stringify({ x: "1", y: ["2", "3"] }, ";", ":", { encodeURIComponent: tag }));
+
+// Encoder receives the raw key/value verbatim — verify it sees space, not `+`.
+const reveal = (s: string): string => `[${s.length}:${s}]`;
+console.log(stringify({ "a b": "c d" }, undefined, undefined, { encodeURIComponent: reveal }));


### PR DESCRIPTION
## Summary
- Read `decodeURIComponent` / `encodeURIComponent` from the options object via `js_object_get_field_by_name` and route key/value through the user closure (`js_closure_call1`) instead of the built-in percent codec.
- `js_querystring_stringify` gains a 4th `options_arg` parameter (already present on `parse`); `runtime_decls` and the native-dispatch table updated to match.
- Adds parity cases for the codec-options path: the two staged in the issue plus four edge cases (non-callable codec fallback, `maxKeys`+decoder combo, custom sep/eq + encoder, raw-value probe).

Closes #1176.

## Test plan
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry`
- [x] All six new parity cases under `test-parity/node-suite/querystring/options/` match Node byte-for-byte
- [x] `parse-max-keys.ts` still passes (regression check)