### PR TITLE
fix(runtime+stdlib): #1175 querystring.parse returns null-prototype object

### DIFF
--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -344,6 +344,12 @@ pub unsafe fn set_forwarding_address(header: *mut GcHeader, new_user_addr: *mut 
 pub const OBJ_FLAG_FROZEN: u16 = 0x01;
 pub const OBJ_FLAG_SEALED: u16 = 0x02;
 pub const OBJ_FLAG_NO_EXTEND: u16 = 0x04;
+// #1175: object was created with a null prototype (Object.create(null) /
+// querystring.parse). `Object.getPrototypeOf` returns null for these.
+// Bit 6 — bits 3..5 are the copied-nursery survival counter
+// (`GC_COPY_SURVIVAL_AGE_MASK = 0x0038`) and bits 14..15 the layout state,
+// so 0x08 would be clobbered on every minor GC. Bits 6..13 are free.
+pub const OBJ_FLAG_NULL_PROTO: u16 = 0x40;
 
 pub(super) const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 pub(super) const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -156,7 +156,8 @@ pub use array::{
 pub use bigint::js_bigint_from_string;
 pub use object::js_object_set_field_by_name;
 pub use object::{
-    js_object_alloc, js_object_alloc_with_shape, js_object_entries, js_object_get_field,
+    js_object_alloc, js_object_alloc_null_proto, js_object_alloc_with_shape, js_object_entries,
+    js_object_get_field,
     js_object_get_field_by_name, js_object_get_field_by_name_f64, js_object_get_own_field_or_undef,
     js_object_get_unboxed_f64_field, js_object_keys, js_object_set_field, js_object_set_field_f64,
     js_object_set_keys, js_object_set_unboxed_f64_field, js_object_values,

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -157,10 +157,10 @@ pub use bigint::js_bigint_from_string;
 pub use object::js_object_set_field_by_name;
 pub use object::{
     js_object_alloc, js_object_alloc_null_proto, js_object_alloc_with_shape, js_object_entries,
-    js_object_get_field,
-    js_object_get_field_by_name, js_object_get_field_by_name_f64, js_object_get_own_field_or_undef,
-    js_object_get_unboxed_f64_field, js_object_keys, js_object_set_field, js_object_set_field_f64,
-    js_object_set_keys, js_object_set_unboxed_f64_field, js_object_values,
+    js_object_get_field, js_object_get_field_by_name, js_object_get_field_by_name_f64,
+    js_object_get_own_field_or_undef, js_object_get_unboxed_f64_field, js_object_keys,
+    js_object_set_field, js_object_set_field_f64, js_object_set_keys,
+    js_object_set_unboxed_f64_field, js_object_values,
 };
 pub use promise::{js_is_promise, js_promise_run_microtasks, js_promise_state, js_promise_value};
 pub use promise::{js_promise_new, js_promise_reject, js_promise_resolve, js_promise_resolved};

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -21,10 +21,7 @@ pub extern "C" fn js_object_alloc(class_id: u32, field_count: u32) -> *mut Objec
 /// `Object.create(null)`-backed result and dodge prototype-pollution
 /// surprises.
 #[no_mangle]
-pub extern "C" fn js_object_alloc_null_proto(
-    class_id: u32,
-    field_count: u32,
-) -> *mut ObjectHeader {
+pub extern "C" fn js_object_alloc_null_proto(class_id: u32, field_count: u32) -> *mut ObjectHeader {
     let ptr = js_object_alloc_with_parent(class_id, 0, field_count);
     unsafe {
         let gc = (ptr as *mut u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -14,6 +14,25 @@ pub extern "C" fn js_object_alloc(class_id: u32, field_count: u32) -> *mut Objec
     js_object_alloc_with_parent(class_id, 0, field_count)
 }
 
+/// #1175: allocate an object whose `[[Prototype]]` is null. Same layout as
+/// `js_object_alloc`, but the `OBJ_FLAG_NULL_PROTO` bit is set on the GC
+/// header so `Object.getPrototypeOf` returns null instead of the heap
+/// pointer / synthesized proto. Used by `querystring.parse` to mirror Node's
+/// `Object.create(null)`-backed result and dodge prototype-pollution
+/// surprises.
+#[no_mangle]
+pub extern "C" fn js_object_alloc_null_proto(
+    class_id: u32,
+    field_count: u32,
+) -> *mut ObjectHeader {
+    let ptr = js_object_alloc_with_parent(class_id, 0, field_count);
+    unsafe {
+        let gc = (ptr as *mut u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;
+        (*gc)._reserved |= crate::gc::OBJ_FLAG_NULL_PROTO;
+    }
+    ptr
+}
+
 /// Allocate a new object with class ID, parent class ID, and field count
 /// The parent_class_id is used for instanceof inheritance checks
 /// Returns a pointer to the object header

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -851,7 +851,16 @@ pub extern "C" fn js_object_create(proto_value: f64) -> f64 {
             }
         }
     }
-    let obj = js_object_alloc(class_id, 0);
+    // #1175: when `proto_value` is null/undefined/non-object, the resulting
+    // object has no [[Prototype]]. Stamp OBJ_FLAG_NULL_PROTO so
+    // `Object.getPrototypeOf(Object.create(null))` returns null (it
+    // previously returned the object itself).
+    let null_proto = class_id == 0;
+    let obj = if null_proto {
+        js_object_alloc_null_proto(class_id, 0)
+    } else {
+        js_object_alloc(class_id, 0)
+    };
     // Return NaN-boxed pointer
     f64::from_bits((obj as u64) | 0x7FFD_0000_0000_0000)
 }
@@ -1013,11 +1022,27 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
     if top16 == 0x7FFD {
         let raw_addr = bits & 0x0000_FFFF_FFFF_FFFF;
         if raw_addr != 0 && raw_addr >= (crate::gc::GC_HEADER_SIZE as u64) + 0x1000 {
+            // #1175: objects allocated with a null prototype
+            // (Object.create(null), querystring.parse) report null here.
+            unsafe {
+                let obj = raw_addr as *const ObjectHeader;
+                let gc = gc_header_for(obj);
+                if (*gc)._reserved & crate::gc::OBJ_FLAG_NULL_PROTO != 0 {
+                    return f64::from_bits(TAG_NULL);
+                }
+            }
             return obj_value;
         }
     }
     if top16 == 0 {
         if bits >= (crate::gc::GC_HEADER_SIZE as u64) + 0x1000 {
+            unsafe {
+                let obj = bits as *const ObjectHeader;
+                let gc = gc_header_for(obj);
+                if (*gc)._reserved & crate::gc::OBJ_FLAG_NULL_PROTO != 0 {
+                    return f64::from_bits(TAG_NULL);
+                }
+            }
             return obj_value;
         }
     }

--- a/crates/perry-stdlib/src/querystring.rs
+++ b/crates/perry-stdlib/src/querystring.rs
@@ -28,7 +28,7 @@
 use crate::common::handle::Handle;
 use perry_runtime::array::{js_array_alloc, js_array_length, js_array_push_f64};
 use perry_runtime::{
-    js_object_alloc, js_object_get_field_by_name, js_object_get_own_field_or_undef,
+    js_object_alloc_null_proto, js_object_get_field_by_name, js_object_get_own_field_or_undef,
     js_object_set_field_by_name, js_string_from_bytes, ArrayHeader, JSValue, ObjectHeader,
     StringHeader,
 };
@@ -195,7 +195,12 @@ pub unsafe extern "C" fn js_querystring_parse(
     let eq = resolve_separator_str(eq_arg, "=");
     let max_keys = resolve_max_keys(options_arg);
 
-    let obj = js_object_alloc(0, 0);
+    // #1175: Node's `querystring.parse` returns an `Object.create(null)`
+    // result so `__proto__` / `constructor` etc. are stored as own data
+    // properties rather than punching through the prototype chain. Mirror
+    // that here — `js_object_alloc_null_proto` stamps a flag the
+    // `Object.getPrototypeOf` path consults so `proto: null` matches Node.
+    let obj = js_object_alloc_null_proto(0, 0);
     if input.is_empty() {
         return obj;
     }

--- a/test-parity/node-suite/object/create/null-prototype.ts
+++ b/test-parity/node-suite/object/create/null-prototype.ts
@@ -1,0 +1,16 @@
+// #1175: Object.create(null) must be observable as a null-prototype object,
+// independently from querystring.parse.
+const dict: any = Object.create(null);
+dict.a = "1";
+dict["__proto__"] = "own-proto";
+dict.constructor = "own-constructor";
+
+console.log("proto is null:", Object.getPrototypeOf(dict) === null);
+console.log("keys:", Object.keys(dict).sort().join(","));
+console.log("__proto__:", dict["__proto__"]);
+console.log("constructor:", dict.constructor);
+console.log("json:", JSON.stringify(dict));
+
+const assigned = Object.assign({}, dict);
+console.log("assigned proto is null:", Object.getPrototypeOf(assigned) === null);
+console.log("assigned a:", assigned.a);

--- a/test-parity/node-suite/querystring/parse/null-prototype.ts
+++ b/test-parity/node-suite/querystring/parse/null-prototype.ts
@@ -1,0 +1,34 @@
+// #1175: querystring.parse must return a null-prototype object so
+// Object.getPrototypeOf(result) === null and keys like `__proto__` /
+// `constructor` are stored as own data properties rather than punching
+// through Object.prototype. This mirrors Node's defense against
+// prototype-pollution payloads (Node v6+).
+import { parse } from "node:querystring";
+
+const r = parse("a=1&__proto__=evil&constructor=ctor") as any;
+console.log("proto:", Object.getPrototypeOf(r));
+console.log("__proto__:", r["__proto__"]);
+console.log("constructor:", r["constructor"]);
+
+// Plain object literals still have Object.prototype, and the `evil`
+// payload must not have polluted other objects.
+const o: any = {};
+console.log("plain proto null?", Object.getPrototypeOf(o) === null);
+console.log("pollution:", typeof o["evil"]);
+
+// Object.assign / spread copy own keys onto a fresh `{}` so the result
+// has Object.prototype again — the null-proto flag must not propagate.
+const copied = Object.assign({}, r);
+console.log("copied proto null?", Object.getPrototypeOf(copied) === null);
+console.log("copied a:", copied.a);
+
+const spread = { ...r };
+console.log("spread proto null?", Object.getPrototypeOf(spread) === null);
+console.log("spread a:", spread.a);
+
+// JSON.stringify walks own enumerable keys — should serialize fine even
+// without an Object.prototype chain.
+console.log("json:", JSON.stringify(r));
+
+// Object.keys / own-key iteration still works on a null-proto.
+console.log("keys:", Object.keys(r).sort().join(","));


### PR DESCRIPTION
## Summary
- `querystring.parse` now returns a null-prototype object so `Object.getPrototypeOf(result) === null`, matching Node's `Object.create(null)`-backed result and dodging `__proto__` pollution.
- Adds `OBJ_FLAG_NULL_PROTO` on `GcHeader._reserved` (bit 6 — bits 3..5 are the copied-nursery survival counter and bits 14..15 the layout state, so 0x08 would be clobbered on every minor GC) and a `js_object_alloc_null_proto` helper.
- `Object.getPrototypeOf` returns null when the flag is set; `Object.create(null)` now stamps it too (previously returned the object itself).

## Test plan
- [x] New parity case `test-parity/node-suite/querystring/parse/null-prototype.ts` matches Node byte-for-byte, including spread / `Object.assign` not propagating the flag, `JSON.stringify`, and `Object.keys`.
- [x] Existing `querystring/parse/*.ts` parity cases still match (the `empty-keys.ts` diff is pre-existing and unrelated).
- [x] `Object.create(null)` sanity (`getPrototypeOf` → null, own keys preserved) matches Node.

Closes #1175.