### PR TITLE
fix(stdlib+runtime): #1182 preserve UTF-16LE lone surrogates from StringDecoder

### DIFF
--- a/crates/perry-runtime/src/json.rs
+++ b/crates/perry-runtime/src/json.rs
@@ -4277,8 +4277,7 @@ mod tests {
         // escape Node's JSON.stringify produces, not the raw invalid-UTF-8
         // bytes.
         let bytes: [u8; 3] = [0xED, 0xA0, 0xBD];
-        let input =
-            crate::string::js_string_from_wtf8_bytes(bytes.as_ptr(), bytes.len() as u32);
+        let input = crate::string::js_string_from_wtf8_bytes(bytes.as_ptr(), bytes.len() as u32);
         let value = f64::from_bits(crate::value::JSValue::string_ptr(input).bits());
         let output = unsafe { js_json_stringify(value, TYPE_UNKNOWN) };
 
@@ -4293,8 +4292,7 @@ mod tests {
         // V8's JSON.stringify pairs them and emits the astral codepoint's
         // UTF-8; Perry must match. 👍 = U+1F44D = F0 9F 91 8D.
         let bytes: [u8; 6] = [0xED, 0xA0, 0xBD, 0xED, 0xB1, 0x8D];
-        let input =
-            crate::string::js_string_from_wtf8_bytes(bytes.as_ptr(), bytes.len() as u32);
+        let input = crate::string::js_string_from_wtf8_bytes(bytes.as_ptr(), bytes.len() as u32);
         let value = f64::from_bits(crate::value::JSValue::string_ptr(input).bits());
         let output = unsafe { js_json_stringify(value, TYPE_UNKNOWN) };
 
@@ -4307,8 +4305,7 @@ mod tests {
         // be re-encoded — only valid adjacent (high, low) pairs collapse.
         // Input is 0xED A0 BD ('a' = 0x61), expected `"\ud83da"`.
         let bytes: [u8; 4] = [0xED, 0xA0, 0xBD, b'a'];
-        let input =
-            crate::string::js_string_from_wtf8_bytes(bytes.as_ptr(), bytes.len() as u32);
+        let input = crate::string::js_string_from_wtf8_bytes(bytes.as_ptr(), bytes.len() as u32);
         let value = f64::from_bits(crate::value::JSValue::string_ptr(input).bits());
         let output = unsafe { js_json_stringify(value, TYPE_UNKNOWN) };
 

--- a/crates/perry-runtime/src/json.rs
+++ b/crates/perry-runtime/src/json.rs
@@ -1745,7 +1745,13 @@ unsafe fn write_escaped_string(buf: &mut String, s: &str) {
     // a straight-line SIMD-friendly scan + one `push_str` beats the
     // scalar per-byte escape loop. Needs_escape fires for `"`, `\`, or
     // any control byte (< 0x20).
-    let needs_escape = bytes.iter().any(|&b| b < 0x20 || b == b'"' || b == b'\\');
+    // Also trip the slow path for WTF-8 lone surrogate sequences
+    // (issue #1182): a lead byte of 0xED followed by 0xA0..=0xBF means
+    // we have a 3-byte encoding of U+D800..=U+DFFF and need to emit a
+    // `\uXXXX` escape rather than the raw (invalid-UTF-8) bytes.
+    let needs_escape = bytes
+        .iter()
+        .any(|&b| b < 0x20 || b == b'"' || b == b'\\' || b == 0xED);
     if !needs_escape {
         buf.reserve(bytes.len() + 2);
         buf.push('"');
@@ -1772,7 +1778,64 @@ unsafe fn write_escaped_string(buf: &mut String, s: &str) {
     // codebase treats stringify output as a byte stream — and an
     // ill-formed result is strictly preferable to a SIGABRT.
     let buf_vec = buf.as_mut_vec();
-    for (i, &b) in bytes.iter().enumerate() {
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        // WTF-8 surrogate handling (issue #1182). A 0xED 0xA0..=0xBF
+        // 0x80..=0xBF triple encodes a code unit in U+D800..=U+DFFF.
+        // Two cases mirror Node's JSON.stringify:
+        //
+        //   * A high surrogate (0xA0..=0xAF mid byte) immediately
+        //     followed by a low surrogate (0xB0..=0xBF mid byte) is
+        //     a *valid* UTF-16 pair — re-encode it as the 4-byte
+        //     UTF-8 of the astral codepoint, no escape. This is the
+        //     only way `'\uD83D' + '\uDC4D'` round-trips through
+        //     `dec.end()` + concat as 👍 instead of two escapes.
+        //
+        //   * Any remaining (lone) surrogate triple emits the
+        //     `\uXXXX` escape.
+        if b == 0xED
+            && i + 2 < bytes.len()
+            && (0xA0..=0xBF).contains(&bytes[i + 1])
+            && (0x80..=0xBF).contains(&bytes[i + 2])
+        {
+            let high_cu: u32 = (((b & 0x0F) as u32) << 12)
+                | (((bytes[i + 1] & 0x3F) as u32) << 6)
+                | ((bytes[i + 2] & 0x3F) as u32);
+            // Valid pair? Need the next 3 bytes to be a low surrogate
+            // (0xED 0xB0..=0xBF 0x80..=0xBF) directly adjacent.
+            let pair_low = if (0xD800..=0xDBFF).contains(&high_cu)
+                && i + 5 < bytes.len()
+                && bytes[i + 3] == 0xED
+                && (0xB0..=0xBF).contains(&bytes[i + 4])
+                && (0x80..=0xBF).contains(&bytes[i + 5])
+            {
+                let low_cu: u32 = (((bytes[i + 3] & 0x0F) as u32) << 12)
+                    | (((bytes[i + 4] & 0x3F) as u32) << 6)
+                    | ((bytes[i + 5] & 0x3F) as u32);
+                Some(low_cu)
+            } else {
+                None
+            };
+            if start < i {
+                buf_vec.extend_from_slice(&bytes[start..i]);
+            }
+            if let Some(low_cu) = pair_low {
+                let cp = 0x10000 + ((high_cu - 0xD800) << 10) + (low_cu - 0xDC00);
+                if let Some(c) = char::from_u32(cp) {
+                    let mut tmp = [0u8; 4];
+                    let s = c.encode_utf8(&mut tmp);
+                    buf_vec.extend_from_slice(s.as_bytes());
+                    i += 6;
+                    start = i;
+                    continue;
+                }
+            }
+            buf_vec.extend_from_slice(format!("\\u{:04x}", high_cu).as_bytes());
+            i += 3;
+            start = i;
+            continue;
+        }
         let escape = match b {
             b'"' => Some("\\\""),
             b'\\' => Some("\\\\"),
@@ -1785,6 +1848,7 @@ unsafe fn write_escaped_string(buf: &mut String, s: &str) {
                 }
                 buf_vec.extend_from_slice(format!("\\u{:04x}", b).as_bytes());
                 start = i + 1;
+                i += 1;
                 continue;
             }
             _ => None,
@@ -1796,6 +1860,7 @@ unsafe fn write_escaped_string(buf: &mut String, s: &str) {
             buf_vec.extend_from_slice(esc.as_bytes());
             start = i + 1;
         }
+        i += 1;
     }
     if start < bytes.len() {
         buf_vec.extend_from_slice(&bytes[start..]);
@@ -4203,5 +4268,67 @@ mod tests {
         assert_eq!(unsafe { (*output).byte_len }, 4);
         assert_eq!(unsafe { (*output).utf16_len }, 3);
         assert_eq!(unsafe { (*output).flags }, 0);
+    }
+
+    #[test]
+    fn stringify_wtf8_lone_surrogate_emits_unicode_escape() {
+        // Issue #1182: a string containing a WTF-8 lone high surrogate
+        // (U+D83D as bytes 0xED 0xA0 0xBD) must stringify to the `\ud83d`
+        // escape Node's JSON.stringify produces, not the raw invalid-UTF-8
+        // bytes.
+        let bytes: [u8; 3] = [0xED, 0xA0, 0xBD];
+        let input =
+            crate::string::js_string_from_wtf8_bytes(bytes.as_ptr(), bytes.len() as u32);
+        let value = f64::from_bits(crate::value::JSValue::string_ptr(input).bits());
+        let output = unsafe { js_json_stringify(value, TYPE_UNKNOWN) };
+
+        assert_eq!(unsafe { str_from_header(output).unwrap() }, "\"\\ud83d\"");
+    }
+
+    #[test]
+    fn stringify_pairs_adjacent_wtf8_surrogates_as_astral_utf8() {
+        // Issue #1182 follow-up: when a StringDecoder('utf16le') stream is
+        // flushed mid-pair via .end(), the two halves end up as 6 WTF-8
+        // bytes (high triple + low triple) in the concatenated result.
+        // V8's JSON.stringify pairs them and emits the astral codepoint's
+        // UTF-8; Perry must match. 👍 = U+1F44D = F0 9F 91 8D.
+        let bytes: [u8; 6] = [0xED, 0xA0, 0xBD, 0xED, 0xB1, 0x8D];
+        let input =
+            crate::string::js_string_from_wtf8_bytes(bytes.as_ptr(), bytes.len() as u32);
+        let value = f64::from_bits(crate::value::JSValue::string_ptr(input).bits());
+        let output = unsafe { js_json_stringify(value, TYPE_UNKNOWN) };
+
+        assert_eq!(unsafe { str_from_header(output).unwrap() }, "\"\u{1F44D}\"");
+    }
+
+    #[test]
+    fn stringify_high_surrogate_then_bmp_still_escapes_high() {
+        // Sanity: a high surrogate followed by a non-surrogate must NOT
+        // be re-encoded — only valid adjacent (high, low) pairs collapse.
+        // Input is 0xED A0 BD ('a' = 0x61), expected `"\ud83da"`.
+        let bytes: [u8; 4] = [0xED, 0xA0, 0xBD, b'a'];
+        let input =
+            crate::string::js_string_from_wtf8_bytes(bytes.as_ptr(), bytes.len() as u32);
+        let value = f64::from_bits(crate::value::JSValue::string_ptr(input).bits());
+        let output = unsafe { js_json_stringify(value, TYPE_UNKNOWN) };
+
+        assert_eq!(unsafe { str_from_header(output).unwrap() }, "\"\\ud83da\"");
+    }
+
+    #[test]
+    fn stringify_3byte_utf8_below_surrogate_block_is_unchanged() {
+        // U+D7FF is the codepoint immediately before the surrogate block.
+        // It also starts with 0xED (0xED 0x9F 0xBF) so it exercises the
+        // boundary in the WTF-8 detector — must NOT escape, must pass
+        // through as raw UTF-8 bytes.
+        let s = "\u{D7FF}";
+        let input = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+        let value = f64::from_bits(crate::value::JSValue::string_ptr(input).bits());
+        let output = unsafe { js_json_stringify(value, TYPE_UNKNOWN) };
+
+        let mut expected = String::from("\"");
+        expected.push_str(s);
+        expected.push('"');
+        assert_eq!(unsafe { str_from_header(output).unwrap() }, expected);
     }
 }

--- a/crates/perry-stdlib/src/string_decoder.rs
+++ b/crates/perry-stdlib/src/string_decoder.rs
@@ -26,6 +26,7 @@
 
 use crate::common::handle::{get_handle_mut, register_handle, with_handle};
 use perry_runtime::buffer::{is_registered_buffer, BufferHeader};
+use perry_runtime::string::js_string_from_wtf8_bytes;
 use perry_runtime::{js_string_from_bytes, JSValue, StringHeader};
 
 /// Which textual encoding the StringDecoder was constructed with.
@@ -337,7 +338,34 @@ fn end_utf8(state: &mut StringDecoderHandle, bytes: Option<&[u8]>) -> String {
 
 /// UTF-16LE write: pair bytes as little-endian u16 code units. The last
 /// odd byte (if any) is buffered into `utf16_partial`.
-fn write_utf16le(state: &mut StringDecoderHandle, bytes: &[u8]) -> String {
+/// Encode a UTF-16 surrogate code unit (U+D800..=U+DFFF) as 3 WTF-8 bytes.
+/// This is the same 3-byte form regular UTF-8 would use for a BMP codepoint
+/// in that range — invalid as strict UTF-8, valid as WTF-8. Perry's runtime
+/// understands the encoding (`STRING_FLAG_HAS_LONE_SURROGATES`,
+/// `isWellFormed`/`toWellFormed`, JSON.stringify escape).
+fn push_wtf8_surrogate(out: &mut Vec<u8>, unit: u16) {
+    let cp = unit as u32;
+    out.push(0xE0 | ((cp >> 12) as u8 & 0x0F));
+    out.push(0x80 | ((cp >> 6) as u8 & 0x3F));
+    out.push(0x80 | (cp as u8 & 0x3F));
+}
+
+/// Encode any BMP code unit (or astral codepoint via surrogate pair input
+/// path) into UTF-8 / WTF-8. For surrogates routes to `push_wtf8_surrogate`.
+fn push_unit_wtf8(out: &mut Vec<u8>, unit: u16) {
+    match unit {
+        0xD800..=0xDFFF => push_wtf8_surrogate(out, unit),
+        _ => {
+            // Safe: non-surrogate BMP always has a char form.
+            let c = unsafe { char::from_u32_unchecked(unit as u32) };
+            let mut buf = [0u8; 4];
+            let s = c.encode_utf8(&mut buf);
+            out.extend_from_slice(s.as_bytes());
+        }
+    }
+}
+
+fn write_utf16le(state: &mut StringDecoderHandle, bytes: &[u8]) -> Vec<u8> {
     let mut combined: Vec<u8> =
         Vec::with_capacity(bytes.len() + if state.utf16_partial.is_some() { 1 } else { 0 });
     if let Some(b) = state.utf16_partial.take() {
@@ -351,7 +379,7 @@ fn write_utf16le(state: &mut StringDecoderHandle, bytes: &[u8]) -> String {
         state.utf16_partial = Some(combined[take]);
     }
     let head = &combined[..take];
-    let mut out = String::with_capacity(take / 2);
+    let mut out: Vec<u8> = Vec::with_capacity(take);
     let mut iter = head.chunks_exact(2);
     for pair in iter.by_ref() {
         let unit = u16::from_le_bytes([pair[0], pair[1]]);
@@ -360,13 +388,17 @@ fn write_utf16le(state: &mut StringDecoderHandle, bytes: &[u8]) -> String {
             if (0xDC00..=0xDFFF).contains(&unit) {
                 let cp = 0x10000 + (((h - 0xD800) as u32) << 10) + ((unit - 0xDC00) as u32);
                 if let Some(c) = char::from_u32(cp) {
-                    out.push(c);
+                    let mut buf = [0u8; 4];
+                    let s = c.encode_utf8(&mut buf);
+                    out.extend_from_slice(s.as_bytes());
                 } else {
-                    out.push('\u{FFFD}');
+                    push_unit_wtf8(&mut out, 0xFFFD);
                 }
             } else {
-                // Lone high → replacement, then reprocess this unit.
-                out.push('\u{FFFD}');
+                // Lone high → emit the buffered high as WTF-8, then reprocess
+                // this unit (which may itself be a high surrogate, BMP char,
+                // or another lone low surrogate).
+                push_wtf8_surrogate(&mut out, h);
                 process_utf16_unit(&mut out, &mut state.utf16_high_surrogate, unit);
             }
         } else {
@@ -376,29 +408,58 @@ fn write_utf16le(state: &mut StringDecoderHandle, bytes: &[u8]) -> String {
     out
 }
 
-fn process_utf16_unit(out: &mut String, high: &mut Option<u16>, unit: u16) {
+fn process_utf16_unit(out: &mut Vec<u8>, high: &mut Option<u16>, unit: u16) {
     match unit {
         0xD800..=0xDBFF => *high = Some(unit),
-        0xDC00..=0xDFFF => out.push('\u{FFFD}'),
-        _ => out.push(char::from_u32(unit as u32).unwrap_or('\u{FFFD}')),
+        0xDC00..=0xDFFF => push_wtf8_surrogate(out, unit),
+        _ => push_unit_wtf8(out, unit),
     }
 }
 
-fn end_utf16le(state: &mut StringDecoderHandle, bytes: Option<&[u8]>) -> String {
+fn end_utf16le(state: &mut StringDecoderHandle, bytes: Option<&[u8]>) -> Vec<u8> {
     let mut out = match bytes {
         Some(b) => write_utf16le(state, b),
-        None => String::new(),
+        None => Vec::new(),
     };
     // Any leftover lone byte at end is dropped (matches Node — the trailing
     // odd byte produces no character).
     state.utf16_partial = None;
-    // Node can return a JS string containing a lone high surrogate here.
-    // Perry's runtime string is UTF-8, so use U+FFFD for the unpaired scalar
-    // until runtime strings can preserve raw UTF-16 code units.
-    if state.utf16_high_surrogate.take().is_some() {
-        out.push('\u{FFFD}');
+    // Node returns a JS string containing the lone high surrogate code unit
+    // here (e.g. `"\ud83d"` when only the first half of a surrogate pair was
+    // ever fed in). Issue #1182: preserve it as WTF-8 so consumers like
+    // JSON.stringify can re-emit the `\uXXXX` escape Node produces.
+    if let Some(h) = state.utf16_high_surrogate.take() {
+        push_wtf8_surrogate(&mut out, h);
     }
     out
+}
+
+/// Build a StringHeader from utf16le-decoded bytes, picking the WTF-8
+/// constructor (which sets `STRING_FLAG_HAS_LONE_SURROGATES`) only when the
+/// payload actually contains a lone surrogate triple. Strings with no
+/// surrogates stay strictly UTF-8 so `isWellFormed()` keeps reporting true.
+unsafe fn string_from_wtf8_bytes_if_needed(bytes: &[u8]) -> *mut StringHeader {
+    if contains_wtf8_surrogate(bytes) {
+        js_string_from_wtf8_bytes(bytes.as_ptr(), bytes.len() as u32)
+    } else {
+        js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
+    }
+}
+
+/// Returns true if `bytes` contains at least one WTF-8 lone-surrogate
+/// 3-byte sequence (0xED, 0xA0..=0xBF, 0x80..=0xBF).
+fn contains_wtf8_surrogate(bytes: &[u8]) -> bool {
+    let mut i = 0;
+    while i + 2 < bytes.len() {
+        if bytes[i] == 0xED
+            && (0xA0..=0xBF).contains(&bytes[i + 1])
+            && (0x80..=0xBF).contains(&bytes[i + 2])
+        {
+            return true;
+        }
+        i += 1;
+    }
+    false
 }
 
 /// Base64 alphabet for `STANDARD` (RFC 4648), matching Node's
@@ -629,15 +690,25 @@ pub unsafe fn dispatch_string_decoder(handle: i64, method: &str, args: &[f64]) -
             } else {
                 bytes_from_write_arg(args[0])
             };
-            let s = match h.mode {
-                DecodingMode::Utf8 => write_utf8(h, &bytes),
-                DecodingMode::Utf16Le => write_utf16le(h, &bytes),
-                DecodingMode::Base64 | DecodingMode::Base64Url => write_base64(h, &bytes),
-                DecodingMode::Hex => write_hex(h, &bytes),
-                DecodingMode::Latin1 => write_latin1(h, &bytes),
-                DecodingMode::Ascii => write_ascii(h, &bytes),
+            let sh = match h.mode {
+                DecodingMode::Utf16Le => {
+                    let v = write_utf16le(h, &bytes);
+                    string_from_wtf8_bytes_if_needed(&v)
+                }
+                _ => {
+                    let s = match h.mode {
+                        DecodingMode::Utf8 => write_utf8(h, &bytes),
+                        DecodingMode::Base64 | DecodingMode::Base64Url => {
+                            write_base64(h, &bytes)
+                        }
+                        DecodingMode::Hex => write_hex(h, &bytes),
+                        DecodingMode::Latin1 => write_latin1(h, &bytes),
+                        DecodingMode::Ascii => write_ascii(h, &bytes),
+                        DecodingMode::Utf16Le => unreachable!(),
+                    };
+                    js_string_from_bytes(s.as_ptr(), s.len() as u32)
+                }
             };
-            let sh = js_string_from_bytes(s.as_ptr(), s.len() as u32);
             f64::from_bits(0x7FFF_0000_0000_0000u64 | ((sh as u64) & 0x0000_FFFF_FFFF_FFFF))
         }
         "end" => {
@@ -653,27 +724,35 @@ pub unsafe fn dispatch_string_decoder(handle: i64, method: &str, args: &[f64]) -
                 }
             };
             let bytes_ref = bytes_opt.as_deref();
-            let s = match h.mode {
-                DecodingMode::Utf8 => end_utf8(h, bytes_ref),
-                DecodingMode::Utf16Le => end_utf16le(h, bytes_ref),
-                DecodingMode::Base64 => end_base64(h, bytes_ref, true),
-                DecodingMode::Base64Url => end_base64(h, bytes_ref, false),
-                // Hex / Latin1 / Ascii have no carry-over state — `end`
-                // is just a `write` with no trailing flush.
-                DecodingMode::Hex => match bytes_ref {
-                    Some(b) => write_hex(h, b),
-                    None => String::new(),
-                },
-                DecodingMode::Latin1 => match bytes_ref {
-                    Some(b) => write_latin1(h, b),
-                    None => String::new(),
-                },
-                DecodingMode::Ascii => match bytes_ref {
-                    Some(b) => write_ascii(h, b),
-                    None => String::new(),
-                },
+            let sh = match h.mode {
+                DecodingMode::Utf16Le => {
+                    let v = end_utf16le(h, bytes_ref);
+                    string_from_wtf8_bytes_if_needed(&v)
+                }
+                _ => {
+                    let s = match h.mode {
+                        DecodingMode::Utf8 => end_utf8(h, bytes_ref),
+                        DecodingMode::Base64 => end_base64(h, bytes_ref, true),
+                        DecodingMode::Base64Url => end_base64(h, bytes_ref, false),
+                        // Hex / Latin1 / Ascii have no carry-over state — `end`
+                        // is just a `write` with no trailing flush.
+                        DecodingMode::Hex => match bytes_ref {
+                            Some(b) => write_hex(h, b),
+                            None => String::new(),
+                        },
+                        DecodingMode::Latin1 => match bytes_ref {
+                            Some(b) => write_latin1(h, b),
+                            None => String::new(),
+                        },
+                        DecodingMode::Ascii => match bytes_ref {
+                            Some(b) => write_ascii(h, b),
+                            None => String::new(),
+                        },
+                        DecodingMode::Utf16Le => unreachable!(),
+                    };
+                    js_string_from_bytes(s.as_ptr(), s.len() as u32)
+                }
             };
-            let sh = js_string_from_bytes(s.as_ptr(), s.len() as u32);
             f64::from_bits(0x7FFF_0000_0000_0000u64 | ((sh as u64) & 0x0000_FFFF_FFFF_FFFF))
         }
         _ => f64::from_bits(JSValue::undefined().bits()),
@@ -788,5 +867,40 @@ mod tests {
         let mut s = StringDecoderHandle::new();
         assert_eq!(write_utf8(&mut s, "hello".as_bytes()), "hello");
         assert_eq!(s.last_need, 0);
+    }
+
+    #[test]
+    fn utf16le_end_emits_lone_high_surrogate_as_wtf8() {
+        // Issue #1182: a high surrogate fed in with no matching low must be
+        // returned verbatim by .end() — Node yields a JS string whose single
+        // code unit is 0xD83D. We carry it across in WTF-8 (0xED 0xA0 0xBD).
+        let mut s = StringDecoderHandle::with_mode(DecodingMode::Utf16Le);
+        assert!(write_utf16le(&mut s, &[0x3D, 0xD8]).is_empty());
+        assert_eq!(s.utf16_high_surrogate, Some(0xD83D));
+        let tail = end_utf16le(&mut s, None);
+        assert_eq!(tail, vec![0xED, 0xA0, 0xBD]);
+        assert!(contains_wtf8_surrogate(&tail));
+    }
+
+    #[test]
+    fn utf16le_lone_high_then_bmp_emits_wtf8_then_char() {
+        // Buffered high surrogate followed by a non-low unit: Node emits the
+        // lone high *and* the trailing BMP char (it does not collapse to
+        // U+FFFD as the pre-#1182 behaviour did).
+        let mut s = StringDecoderHandle::with_mode(DecodingMode::Utf16Le);
+        // 0x3DD8 (high surrogate) + 0x6100 ('a' in UTF-16LE).
+        let out = write_utf16le(&mut s, &[0x3D, 0xD8, 0x61, 0x00]);
+        assert_eq!(out, vec![0xED, 0xA0, 0xBD, b'a']);
+    }
+
+    #[test]
+    fn utf16le_valid_pair_still_decodes_to_astral() {
+        // The fix must NOT regress the well-formed split-surrogate case.
+        // 0x3DD8 0x4DDC is the UTF-16LE encoding of U+1F44D 👍.
+        let mut s = StringDecoderHandle::with_mode(DecodingMode::Utf16Le);
+        assert!(write_utf16le(&mut s, &[0x3D, 0xD8]).is_empty());
+        let out = write_utf16le(&mut s, &[0x4D, 0xDC]);
+        assert_eq!(out, "\u{1F44D}".as_bytes());
+        assert!(!contains_wtf8_surrogate(&out));
     }
 }

--- a/crates/perry-stdlib/src/string_decoder.rs
+++ b/crates/perry-stdlib/src/string_decoder.rs
@@ -698,9 +698,7 @@ pub unsafe fn dispatch_string_decoder(handle: i64, method: &str, args: &[f64]) -
                 _ => {
                     let s = match h.mode {
                         DecodingMode::Utf8 => write_utf8(h, &bytes),
-                        DecodingMode::Base64 | DecodingMode::Base64Url => {
-                            write_base64(h, &bytes)
-                        }
+                        DecodingMode::Base64 | DecodingMode::Base64Url => write_base64(h, &bytes),
                         DecodingMode::Hex => write_hex(h, &bytes),
                         DecodingMode::Latin1 => write_latin1(h, &bytes),
                         DecodingMode::Ascii => write_ascii(h, &bytes),

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -452,12 +452,6 @@
     "category": "ci-env",
     "reason": "Brotli decompression path under node:zlib not yet implemented (cf. existing test_parity_zlib module-inventory entry). Same failure observed on #1038 pre-merge \u2014 not a regression."
   },
-  "node-suite/string_decoder/utf16le/end-cases": {
-    "issue": "1182",
-    "added": "2026-05-20",
-    "category": "module-inventory",
-    "reason": "#1182: Perry decodes split valid UTF-16LE surrogate pairs, but runtime strings are UTF-8 and cannot preserve Node's lone surrogate code units returned by end(). Flips to PASS when raw UTF-16 lone-surrogate semantics are modeled or normalized."
-  },
   "node-suite/events/on/async-iterator-basic": {
     "issue": "1183",
     "added": "2026-05-20",

--- a/test-parity/node-suite/string_decoder/utf16le/end-cases.ts
+++ b/test-parity/node-suite/string_decoder/utf16le/end-cases.ts
@@ -1,6 +1,20 @@
 import { StringDecoder } from "node:string_decoder";
 
-for (const [first, next] of [["3D", "6100"], ["3DD8", ""], ["3DD8", "6100"], ["3DD84D", "DC"]]) {
+// Mirrors Node's test/parallel/test-string-decoder-end.js utf16le table —
+// covers odd-byte carry, lone surrogates, mid-pair end() flushes, and the
+// full astral round-trip. Issue #1182.
+const cases: [string, string][] = [
+  ["3D", "6100"],
+  ["3D", "D84DDC"],
+  ["3DD8", ""],
+  ["3DD8", "6100"],
+  ["3DD8", "4DDC"],
+  ["3DD84D", ""],
+  ["3DD84D", "6100"],
+  ["3DD84D", "DC"],
+  ["3DD84DDC", "6100"],
+];
+for (const [first, next] of cases) {
   const dec = new StringDecoder("utf16le");
   const output = dec.write(Buffer.from(first, "hex")) + dec.end() + dec.write(Buffer.from(next, "hex")) + dec.end();
   console.log(first + "/" + next + ":", JSON.stringify(output));


### PR DESCRIPTION
Closes #1182.

## Summary

`StringDecoder('utf16le').end()` was emitting `U+FFFD` whenever a lone high
surrogate was buffered across writes, because Perry's runtime string was
strictly UTF-8. Node returns the raw surrogate code unit, so
`JSON.stringify(dec.write(...) + dec.end())` diverged.

Perry's `StringHeader` already has a `STRING_FLAG_HAS_LONE_SURROGATES` bit
and a `js_string_from_wtf8_bytes` constructor (used by `isWellFormed` /
`toWellFormed`). This PR wires the utf16le decoder into that path and
teaches `JSON.stringify` to honour it.

## Changes

- `crates/perry-stdlib/src/string_decoder.rs`
  - `write_utf16le` / `end_utf16le` now produce `Vec<u8>` and emit lone
    surrogates as 3-byte WTF-8 (`0xED 0xA0..BF 0x80..BF`).
  - Dispatch routes the result through `js_string_from_wtf8_bytes` only
    when surrogates are actually present, so well-formed utf16le strings
    keep `isWellFormed() === true`.
- `crates/perry-runtime/src/json.rs`
  - `write_escaped_string` now detects WTF-8 surrogate triples. Lone
    surrogates emit `\uXXXX` (matching V8). Valid adjacent (high, low)
    pairs are re-encoded as the astral codepoint's UTF-8 so
    `'\uD83D' + '\uDC4D'` round-trips to `"👍"` rather than two escapes.
- `test-parity/node-suite/string_decoder/utf16le/end-cases.ts`
  - Expanded from 4 cases to the full 9-case table from Node's
    `test/parallel/test-string-decoder-end.js` utf16le block.
- `test-parity/known_failures.json`
  - Removed the `#1182` entry now that the case is PASS.

## Tests

- `cargo test -p perry-runtime --lib json::tests` — 7 pass (3 new):
  lone-surrogate escape, adjacent-pair → astral, `U+D7FF` boundary,
  high-then-BMP still escapes high.
- `cargo test -p perry-stdlib --lib string_decoder` — 7 pass (3 new):
  end emits lone high as WTF-8, lone high then BMP, valid pair still
  decodes to astral.
- Parity diff vs Node for the 9-case end-cases.ts and basic-and-split.ts
  is byte-identical.
- Spot-checked Node's utf8 invalid-byte cases (incl. `EDA0B5EDB08D`
  fed to a utf8 decoder) — still byte-identical to Node; the utf8 path
  is untouched.

## Test plan

- [x] \`cargo build --release -p perry-runtime -p perry-stdlib -p perry\`
- [x] \`cargo test -p perry-runtime --lib json::tests\`
- [x] \`cargo test -p perry-stdlib --lib string_decoder\`
- [x] \`diff <(node --experimental-strip-types end-cases.ts) <(./perry end-cases.ts && ./out)\` → identical
- [ ] CI green