### PR TITLE
deps: bump RustCrypto digest stack to 0.11 family (#1238)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,36 @@ updates:
     groups:
       cargo-minor-and-patch:
         update-types: [minor, patch]
+    # RustCrypto stack must be bumped together (see issue #1238).
+    # Suppress the breaking 0.x -> 0.(x+1) PRs (dependabot classifies these as
+    # "minor" for pre-1.0 crates) until the whole stack — including aes-gcm 0.11
+    # and the transitive digest-0.10 holdouts (jsonwebtoken, sqlx, elliptic-curve)
+    # — is ready to move in one coordinated PR. Patch bumps still flow through.
+    ignore:
+      - dependency-name: "digest"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "sha1"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "sha2"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "sha3"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "md-5"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "hmac"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "pbkdf2"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "hkdf"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "aes"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "aes-gcm"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "aes-kw"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "cipher"
+        update-types: ["version-update:semver-minor"]
     commit-message:
       prefix: "deps"
       include: scope

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,28 +8,14 @@ updates:
     groups:
       cargo-minor-and-patch:
         update-types: [minor, patch]
-    # RustCrypto stack must be bumped together (see issue #1238).
-    # Suppress the breaking 0.x -> 0.(x+1) PRs (dependabot classifies these as
-    # "minor" for pre-1.0 crates) until the whole stack — including aes-gcm 0.11
-    # and the transitive digest-0.10 holdouts (jsonwebtoken, sqlx, elliptic-curve)
-    # — is ready to move in one coordinated PR. Patch bumps still flow through.
+    # AEAD/cipher stack must be bumped together (see issue #1238).
+    # aes-gcm 0.11 is still RC (rc.3 as of 2026-05); meanwhile aes 0.9 and
+    # aes-kw 0.3 ship a cipher 0.5 / hybrid-array API that aes-gcm 0.10
+    # doesn't understand. Suppress the breaking 0.x -> 0.(x+1) PRs
+    # (dependabot classifies these as "minor" for pre-1.0 crates) until
+    # aes-gcm 0.11 lands and the whole AEAD surface can move in one PR.
+    # Patch bumps still flow through.
     ignore:
-      - dependency-name: "digest"
-        update-types: ["version-update:semver-minor"]
-      - dependency-name: "sha1"
-        update-types: ["version-update:semver-minor"]
-      - dependency-name: "sha2"
-        update-types: ["version-update:semver-minor"]
-      - dependency-name: "sha3"
-        update-types: ["version-update:semver-minor"]
-      - dependency-name: "md-5"
-        update-types: ["version-update:semver-minor"]
-      - dependency-name: "hmac"
-        update-types: ["version-update:semver-minor"]
-      - dependency-name: "pbkdf2"
-        update-types: ["version-update:semver-minor"]
-      - dependency-name: "hkdf"
-        update-types: ["version-update:semver-minor"]
       - dependency-name: "aes"
         update-types: ["version-update:semver-minor"]
       - dependency-name: "aes-gcm"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,7 +716,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -726,6 +726,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1152,6 +1161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,6 +1483,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,7 +1500,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1821,10 +1845,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1956,7 +1992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1983,7 +2019,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2011,11 +2047,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -3145,7 +3181,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3154,7 +3199,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3822,7 +3876,7 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -3831,7 +3885,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
  "zeroize",
@@ -4081,12 +4135,12 @@ dependencies = [
  "indexmap",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "nom 8.0.0",
  "nom_locate",
  "rand 0.9.4",
  "rangemap",
- "sha2",
+ "sha2 0.10.9",
  "stringprep",
  "thiserror 2.0.18",
  "time",
@@ -4212,7 +4266,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4346,12 +4410,12 @@ dependencies = [
  "hex",
  "hickory-proto",
  "hickory-resolver",
- "hmac",
+ "hmac 0.12.1",
  "macro_magic",
- "md-5",
+ "md-5 0.10.6",
  "mongocrypt",
  "mongodb-internal-macros",
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "percent-encoding",
  "rand 0.9.4",
  "rustc_version_runtime",
@@ -4360,8 +4424,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_with",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "socket2",
  "stringprep",
  "strsim",
@@ -4907,7 +4971,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4919,7 +4983,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5029,10 +5093,18 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
- "password-hash",
- "sha2",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -5103,7 +5175,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "swc_ecma_ast",
  "tar",
  "tempfile",
@@ -5611,12 +5683,12 @@ dependencies = [
  "bytes",
  "deno_core",
  "deno_error",
- "hmac",
+ "hmac 0.13.0",
  "http-body-util",
  "hyper",
  "hyper-util",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "once_cell",
  "perry-runtime",
  "perry-stdlib",
@@ -5624,8 +5696,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha1",
- "sha2",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "thiserror 1.0.69",
  "tokio",
  "ureq",
@@ -5694,8 +5766,8 @@ dependencies = [
  "futures-util",
  "governor",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -5706,12 +5778,12 @@ dependencies = [
  "lettre",
  "libc",
  "lru",
- "md-5",
+ "md-5 0.11.0",
  "mongodb",
  "nanoid",
  "once_cell",
  "p256",
- "pbkdf2",
+ "pbkdf2 0.13.0",
  "perry-runtime",
  "perry-updater",
  "rand 0.8.6",
@@ -5728,8 +5800,8 @@ dependencies = [
  "scrypt",
  "serde",
  "serde_json",
- "sha1",
- "sha2",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "spki",
  "sqlx",
  "thiserror 1.0.69",
@@ -5922,7 +5994,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -6772,7 +6844,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -6835,7 +6907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid 0.9.6",
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -7068,9 +7140,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "password-hash",
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -7286,7 +7358,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -7303,7 +7386,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -7334,7 +7428,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -7539,7 +7633,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -7576,7 +7670,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -7599,7 +7693,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -7608,19 +7702,19 @@ dependencies = [
  "futures-util",
  "generic-array",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
  "rand 0.8.6",
  "rsa",
  "serde",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -7647,18 +7741,18 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -8549,7 +8643,7 @@ dependencies = [
  "rand 0.8.6",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "utf-8",
  "webpki-roots 0.26.11",
@@ -8569,7 +8663,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -10039,12 +10133,12 @@ dependencies = [
  "displaydoc",
  "flate2",
  "getrandom 0.3.4",
- "hmac",
+ "hmac 0.12.1",
  "indexmap",
  "lzma-rs",
  "memchr",
- "pbkdf2",
- "sha1",
+ "pbkdf2 0.12.2",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "time",
  "xz2",

--- a/crates/perry-jsruntime/Cargo.toml
+++ b/crates/perry-jsruntime/Cargo.toml
@@ -53,14 +53,14 @@ bytes = "1.5"
 # packages like `jose` can compute real HS256/HS384/HS512 signatures
 # without falling through to a no-op digest. Same crate versions as
 # `perry-stdlib`'s `crypto` feature so we don't duplicate the dep graph.
-hmac = "0.12"
-sha2 = "0.10"
+hmac = "0.13"
+sha2 = "0.11"
 # Plain hash digests for `op_perry_hash` so the V8-side
 # `crypto.createHash(...).update(...).digest('hex')` path returns real
 # hashes instead of empty strings — load-bearing for NestJS's
 # `ModuleTokenFactory` (#1021).
-sha1 = "0.10"
-md-5 = "0.10"
+sha1 = "0.11"
+md-5 = "0.11"
 
 [features]
 default = []

--- a/crates/perry-jsruntime/src/ops.rs
+++ b/crates/perry-jsruntime/src/ops.rs
@@ -577,7 +577,7 @@ fn op_perry_hash(#[string] alg: &str, #[buffer] data: &[u8]) -> Vec<u8> {
 #[op2]
 #[buffer]
 fn op_perry_hmac(#[string] alg: &str, #[buffer] key: &[u8], #[buffer] data: &[u8]) -> Vec<u8> {
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, KeyInit, Mac};
     use sha2::{Sha256, Sha384, Sha512};
 
     match alg {

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -314,11 +314,11 @@ bson = { version = "2.9", optional = true }
 rusqlite = { version = "0.32.1", features = ["bundled"], optional = true }
 
 # Crypto
-sha2 = { version = "0.10", optional = true }
-sha1 = { version = "0.10", optional = true }
-md-5 = { version = "0.10", optional = true }
+sha2 = { version = "0.11", optional = true }
+sha1 = { version = "0.11", optional = true }
+md-5 = { version = "0.11", optional = true }
 hex = { version = "0.4", optional = true }
-hmac = { version = "0.12", optional = true }
+hmac = { version = "0.13", optional = true }
 bcrypt = { version = "0.17", optional = true }
 jsonwebtoken = { version = "10.4", optional = true, default-features = false, features = ["rust_crypto", "use_pem"] }
 p256 = { version = "0.13", optional = true, default-features = false, features = ["pkcs8", "pem", "ecdsa"] }
@@ -327,7 +327,7 @@ spki = { version = "0.7", optional = true, default-features = false, features = 
 aes = { version = "0.8", optional = true }
 cbc = { version = "0.1", optional = true }
 scrypt = { version = "0.11", optional = true }
-pbkdf2 = { version = "0.12", features = ["simple"], optional = true }
+pbkdf2 = { version = "0.13", features = ["hmac"], optional = true }
 argon2 = { version = "0.5", optional = true }
 base64 = { version = "0.22", optional = true }
 x25519-dalek = { version = "2.0", features = ["static_secrets"], optional = true }
@@ -337,7 +337,7 @@ aes-gcm = { version = "0.10", optional = true }
 # when the wrap algorithm is `{ name: 'AES-KW' }`. Gated under the
 # `crypto` umbrella so it tracks the rest of the symmetric surface.
 aes-kw = { version = "0.3.0", optional = true }
-hkdf = { version = "0.12", optional = true }
+hkdf = { version = "0.13", optional = true }
 
 # Compression
 flate2 = { version = "1.0", optional = true }

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -359,7 +359,7 @@ pub unsafe extern "C" fn js_crypto_hmac_sha256(
     key_ptr: *const StringHeader,
     data_ptr: *const StringHeader,
 ) -> *mut StringHeader {
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, KeyInit, Mac};
     use sha2::Sha256;
 
     type HmacSha256 = Hmac<Sha256>;
@@ -393,7 +393,7 @@ pub unsafe extern "C" fn js_crypto_hmac_sha256_bytes(
     key_ptr: i64,
     data_ptr: i64,
 ) -> *mut perry_runtime::buffer::BufferHeader {
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, KeyInit, Mac};
     type HmacSha256 = Hmac<Sha256>;
 
     let key = bytes_from_ptr(key_ptr);
@@ -820,7 +820,7 @@ pub struct HmacHandle {
 /// algorithms return undefined.
 #[no_mangle]
 pub unsafe extern "C" fn js_crypto_create_hmac(alg_ptr: i64, key_ptr: i64) -> f64 {
-    use hmac::Mac;
+    use hmac::KeyInit;
     let alg_bytes = bytes_from_ptr(alg_ptr);
     let alg = std::str::from_utf8(&alg_bytes)
         .unwrap_or("")

--- a/crates/perry-stdlib/src/webcrypto.rs
+++ b/crates/perry-stdlib/src/webcrypto.rs
@@ -33,7 +33,7 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use once_cell::sync::Lazy;
 use sha1::Sha1;
 use sha2::{Digest as Sha2Digest, Sha256, Sha384, Sha512};

--- a/crates/perry-updater/Cargo.toml
+++ b/crates/perry-updater/Cargo.toml
@@ -13,7 +13,7 @@ perry-runtime = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 semver = "1.0"
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4"
 base64 = "0.22"
 # Ed25519 verify is provided by perry-stdlib::crypto (declared as extern in

--- a/crates/perry/Cargo.toml
+++ b/crates/perry/Cargo.toml
@@ -72,7 +72,7 @@ fslock = "0.2"
 # the CLI module. ed25519-dalek 2.1 takes any CryptoRng; we use rand 0.9
 # for the keygen seed.
 ed25519-dalek = { version = "2.1", features = ["rand_core"] }
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4"
 rand = "0.9"
 # chrono is already a transitive dep through perry-stdlib; listing it

--- a/crates/perry/src/commands/attest.rs
+++ b/crates/perry/src/commands/attest.rs
@@ -77,7 +77,7 @@ pub fn sha256_hex(path: &Path) -> Result<(String, u64)> {
         hasher.update(&buf[..n]);
         total += n as u64;
     }
-    Ok((format!("{:x}", hasher.finalize()), total))
+    Ok((hex::encode(hasher.finalize()), total))
 }
 
 /// Read `commit_sha` from the project's git tree. Best-effort:

--- a/crates/perry/src/commands/perry_lock.rs
+++ b/crates/perry/src/commands/perry_lock.rs
@@ -127,11 +127,20 @@ pub fn verify_or_write(
 }
 
 pub fn sha256_of_file(path: &Path) -> Result<String> {
+    use std::io::Read;
     let mut file = fs::File::open(path)
         .map_err(|e| anyhow!("open archive {} for hashing: {}", path.display(), e))?;
     let mut hasher = Sha256::new();
-    std::io::copy(&mut file, &mut hasher)
-        .map_err(|e| anyhow!("read archive {} for hashing: {}", path.display(), e))?;
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| anyhow!("read archive {} for hashing: {}", path.display(), e))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
     Ok(hex::encode(hasher.finalize()))
 }
 


### PR DESCRIPTION
## Summary
Holistically migrates Perry's direct deps to the RustCrypto digest 0.11 family — the action item from tracking issue #1238 that closed-via-supersede #1157. The AEAD stack (aes/aes-gcm/aes-kw/cipher) stays on the 0.10/0.8/0.3 line because aes-gcm 0.11 is still RC; dependabot ignores are narrowed accordingly.

**Bumps**
| crate  | from   | to     | where |
| ------ | ------ | ------ | ----- |
| sha1   | 0.10   | 0.11   | perry-stdlib, perry-jsruntime |
| sha2   | 0.10   | 0.11   | perry-stdlib, perry-jsruntime, perry-updater, perry |
| md-5   | 0.10   | 0.11   | perry-stdlib, perry-jsruntime |
| hmac   | 0.12   | 0.13   | perry-stdlib, perry-jsruntime |
| pbkdf2 | 0.12   | 0.13   | perry-stdlib (`simple` feature replaced by `hmac`) |
| hkdf   | 0.12   | 0.13   | perry-stdlib |

**Call-site updates for the digest 0.11 / hmac 0.13 API**
- `Hmac::<H>::new_from_slice` now sits behind the `KeyInit` trait (moved out of `Mac`). Added `use hmac::KeyInit;` in `webcrypto.rs`, `crypto.rs` (three call sites: `js_crypto_hmac_sha256`, `js_crypto_hmac_sha256_bytes`, `js_crypto_create_hmac`), and `perry-jsruntime::ops.rs::op_perry_hmac`.
- `Sha256: io::Write` was removed in sha2 0.11, so `std::io::copy(&mut file, &mut hasher)` in `perry-lock::sha256_of_file` no longer compiles. Replaced with the explicit 64 KiB read loop already used in `attest.rs::sha256_hex`.
- `Sha256::finalize()` now returns `hybrid_array::Array<u8, N>` (was `GenericArray`); `Array` doesn't implement `LowerHex`. Replaced `format!("{:x}", hasher.finalize())` in `attest.rs` with `hex::encode(hasher.finalize())` (perry already depends on `hex = "0.4"`).

**Why `cargo tree` still shows two digest versions**
Transitive consumers (jsonwebtoken, sqlx, elliptic-curve, ed25519-dalek, curve25519-dalek, p256/p384, argon2/blake2) all still pin digest 0.10 internally. They don't leak into our code, and we already coexist with two `cipher` versions the same way (0.4.4 from aes-gcm + 0.5.1). The trait-bound errors that killed #1157 came from us mixing 0.10 and 0.11 in *our* code; that's resolved.

**Dependabot config**
`.github/dependabot.yml` ignore list narrowed from "the whole digest+AEAD stack" to just `aes`/`aes-gcm`/`aes-kw`/`cipher` (still blocked on aes-gcm 0.11 stable). Patch bumps continue flowing through.

## Test plan
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry-updater -p perry-jsruntime -p perry` — clean
- [x] `cargo test --release -p perry-stdlib --lib` — 74/74 (SHA-256 vectors, AES-GCM round-trips routing through hkdf, AWS SigV4 HMAC vector, jsonwebtoken verify)
- [x] `cargo test --release -p perry-updater --lib` — 10/10 (hash + signature roundtrips)
- [x] End-to-end webcrypto smoke: `crypto.subtle.digest("SHA-256", "hello")` produces the published `2cf24dba...` vector
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI green on this PR

Refs #1238 (resolves the immediate migration; the tracking issue stays open for the AEAD-stack follow-up).