### PR TITLE
feat(widget): #1179 ts_source slot — TS widgets in main app build

### DIFF
--- a/crates/perry-codegen-glance/src/emit.rs
+++ b/crates/perry-codegen-glance/src/emit.rs
@@ -525,11 +525,51 @@ fn emit_text_content(content: &WidgetTextContent, entry_param: &str) -> String {
                     WidgetTemplatePart::Field(field) => {
                         write!(s, "${{{}.{}}}", entry_param, field).unwrap()
                     }
+                    WidgetTemplatePart::Formatted(expr) => {
+                        write!(s, "${{{}}}", emit_format_kotlin(expr, entry_param)).unwrap()
+                    }
                 }
             }
             s.push('"');
             s
         }
+        WidgetTextContent::Formatted(expr) => {
+            // Wrap the produced Kotlin expression in a string template
+            // so Text(...) consumes a String — same as the Field arm.
+            format!("\"${{{}}}\"", emit_format_kotlin(expr, entry_param))
+        }
+    }
+}
+
+/// Issue #1179 follow-up: emit a Kotlin expression for one of the
+/// whitelisted formatter calls. Result is a String-typed expression.
+fn emit_format_kotlin(expr: &WidgetFormatExpr, entry_param: &str) -> String {
+    let value = emit_format_arg_kotlin(&expr.arg, entry_param);
+    match expr.call {
+        WidgetFormatCall::StringCast | WidgetFormatCall::ToString => {
+            format!("{}.toString()", value)
+        }
+        WidgetFormatCall::NumberCast => format!("{}.toDouble()", value),
+        WidgetFormatCall::Round => format!("kotlin.math.round({}).toInt()", value),
+        WidgetFormatCall::Floor => format!("kotlin.math.floor({}).toInt()", value),
+        WidgetFormatCall::Ceil => format!("kotlin.math.ceil({}).toInt()", value),
+        WidgetFormatCall::ToFixed { digits } => {
+            format!("\"%.{}f\".format({})", digits, value)
+        }
+    }
+}
+
+fn emit_format_arg_kotlin(arg: &WidgetFormatArg, entry_param: &str) -> String {
+    match arg {
+        WidgetFormatArg::Field(field) => format!("{}.{}", entry_param, field),
+        WidgetFormatArg::Number(n) => {
+            if n.is_finite() && *n == n.floor() {
+                format!("{:.0}", n)
+            } else {
+                format!("{}", n)
+            }
+        }
+        WidgetFormatArg::String(s) => format!("\"{}\"", escape_kotlin_string(s)),
     }
 }
 
@@ -599,6 +639,8 @@ fn emit_kotlin_value(value: &WidgetTextContent) -> String {
         }
         WidgetTextContent::Field(f) => f.clone(),
         WidgetTextContent::Template(_) => "\"\"".to_string(),
+        // Conditions don't compare against formatted expressions today.
+        WidgetTextContent::Formatted(_) => "\"\"".to_string(),
     }
 }
 

--- a/crates/perry-codegen-swiftui/src/emit.rs
+++ b/crates/perry-codegen-swiftui/src/emit.rs
@@ -905,11 +905,51 @@ fn emit_text_content(content: &WidgetTextContent, entry_param: &str) -> String {
                     WidgetTemplatePart::Field(field) => {
                         write!(s, "\\({}.{})", entry_param, field).unwrap();
                     }
+                    WidgetTemplatePart::Formatted(expr) => {
+                        write!(s, "\\({})", emit_format_swift(expr, entry_param)).unwrap();
+                    }
                 }
             }
             s.push('"');
             s
         }
+        WidgetTextContent::Formatted(expr) => {
+            // Wrap the produced Swift expression in a Swift string so
+            // Text(...) consumes a String literal — same convention as
+            // the Field arm above.
+            format!("\"\\({})\"", emit_format_swift(expr, entry_param))
+        }
+    }
+}
+
+/// Emit a Swift expression for one of the whitelisted formatter calls.
+/// The result is a `String`-typed expression suitable for dropping into
+/// `Text(...)` directly or interpolating with `\(...)`.
+fn emit_format_swift(expr: &WidgetFormatExpr, entry_param: &str) -> String {
+    let value = emit_format_arg_swift(&expr.arg, entry_param);
+    match expr.call {
+        WidgetFormatCall::StringCast | WidgetFormatCall::ToString => {
+            format!("String({})", value)
+        }
+        WidgetFormatCall::NumberCast => {
+            // `Number(x)` is rarely useful in a render position; coerce
+            // through Double so callers can interpolate it.
+            format!("Double({}) ?? 0", value)
+        }
+        WidgetFormatCall::Round => format!("Int({}.rounded())", value),
+        WidgetFormatCall::Floor => format!("Int({}.rounded(.down))", value),
+        WidgetFormatCall::Ceil => format!("Int({}.rounded(.up))", value),
+        WidgetFormatCall::ToFixed { digits } => {
+            format!("String(format: \"%.{}f\", {})", digits, value)
+        }
+    }
+}
+
+fn emit_format_arg_swift(arg: &WidgetFormatArg, entry_param: &str) -> String {
+    match arg {
+        WidgetFormatArg::Field(field) => format!("{}.{}", entry_param, field),
+        WidgetFormatArg::Number(n) => format_f64(*n),
+        WidgetFormatArg::String(s) => format!("\"{}\"", escape_swift_string(s)),
     }
 }
 
@@ -950,6 +990,10 @@ fn emit_condition_value(value: &WidgetTextContent) -> String {
         }
         WidgetTextContent::Field(f) => f.clone(),
         WidgetTextContent::Template(_) => "\"\"".to_string(),
+        // Conditions compare against constants today, not formatted
+        // expressions — fall through to an empty literal so we don't
+        // emit a syntactically dubious comparison.
+        WidgetTextContent::Formatted(_) => "\"\"".to_string(),
     }
 }
 
@@ -1370,5 +1414,105 @@ mod tests {
         assert!(view.contains(".frame(maxWidth: .infinity)"));
         assert!(view.contains(".widgetURL(URL(string: \"myapp://home\")!)"));
         assert!(view.contains(".containerBackground(Color.blue.gradient, for: .widget)"));
+    }
+
+    #[test]
+    fn format_to_fixed_emits_string_format() {
+        let s = emit_format_swift(
+            &WidgetFormatExpr {
+                call: WidgetFormatCall::ToFixed { digits: 2 },
+                arg: WidgetFormatArg::Field("totalClicks".to_string()),
+            },
+            "entry",
+        );
+        assert_eq!(s, "String(format: \"%.2f\", entry.totalClicks)");
+    }
+
+    #[test]
+    fn format_math_round_emits_rounded_int() {
+        let s = emit_format_swift(
+            &WidgetFormatExpr {
+                call: WidgetFormatCall::Round,
+                arg: WidgetFormatArg::Field("totalClicks".to_string()),
+            },
+            "entry",
+        );
+        assert_eq!(s, "Int(entry.totalClicks.rounded())");
+    }
+
+    #[test]
+    fn format_math_floor_and_ceil_emit_directed_rounding() {
+        let floor = emit_format_swift(
+            &WidgetFormatExpr {
+                call: WidgetFormatCall::Floor,
+                arg: WidgetFormatArg::Field("totalClicks".to_string()),
+            },
+            "entry",
+        );
+        assert_eq!(floor, "Int(entry.totalClicks.rounded(.down))");
+        let ceil = emit_format_swift(
+            &WidgetFormatExpr {
+                call: WidgetFormatCall::Ceil,
+                arg: WidgetFormatArg::Field("totalClicks".to_string()),
+            },
+            "entry",
+        );
+        assert_eq!(ceil, "Int(entry.totalClicks.rounded(.up))");
+    }
+
+    #[test]
+    fn format_string_cast_wraps_in_string_init() {
+        let s = emit_format_swift(
+            &WidgetFormatExpr {
+                call: WidgetFormatCall::StringCast,
+                arg: WidgetFormatArg::Field("totalClicks".to_string()),
+            },
+            "entry",
+        );
+        assert_eq!(s, "String(entry.totalClicks)");
+    }
+
+    #[test]
+    fn text_formatted_render_replaces_empty_string_bug() {
+        // Issue #1179 follow-up: rendering `Text(Math.round(entry.totalClicks))`
+        // used to emit `Text("")`. The new path produces a proper Swift
+        // string interpolation through the whitelisted format helper.
+        let widget = make_widget(
+            "com.test.Formatted",
+            vec![("totalClicks".to_string(), WidgetFieldType::Number)],
+            vec![WidgetNode::Text {
+                content: WidgetTextContent::Formatted(WidgetFormatExpr {
+                    call: WidgetFormatCall::Round,
+                    arg: WidgetFormatArg::Field("totalClicks".to_string()),
+                }),
+                modifiers: vec![],
+            }],
+        );
+        let view = emit_view(&widget, "Formatted");
+        assert!(view.contains("Text(\"\\(Int(entry.totalClicks.rounded()))\")"));
+        // And it must not collapse to the empty-string bug.
+        assert!(!view.contains("Text(\"\")"));
+    }
+
+    #[test]
+    fn template_with_formatted_hole_interpolates_through_helper() {
+        // ``Total: ${entry.totalClicks.toFixed(2)}`` should land as
+        // `Text("Total: \(String(format: "%.2f", entry.totalClicks))")`.
+        let widget = make_widget(
+            "com.test.Template",
+            vec![("totalClicks".to_string(), WidgetFieldType::Number)],
+            vec![WidgetNode::Text {
+                content: WidgetTextContent::Template(vec![
+                    WidgetTemplatePart::Literal("Total: ".to_string()),
+                    WidgetTemplatePart::Formatted(WidgetFormatExpr {
+                        call: WidgetFormatCall::ToFixed { digits: 2 },
+                        arg: WidgetFormatArg::Field("totalClicks".to_string()),
+                    }),
+                ]),
+                modifiers: vec![],
+            }],
+        );
+        let view = emit_view(&widget, "Template");
+        assert!(view.contains("Text(\"Total: \\(String(format: \"%.2f\", entry.totalClicks))\")"));
     }
 }

--- a/crates/perry-codegen-wear-tiles/src/emit.rs
+++ b/crates/perry-codegen-wear-tiles/src/emit.rs
@@ -354,11 +354,49 @@ fn emit_text_content(content: &WidgetTextContent, entry_param: &str) -> String {
                     WidgetTemplatePart::Field(field) => {
                         write!(s, "${{{}.{}}}", entry_param, field).unwrap()
                     }
+                    WidgetTemplatePart::Formatted(expr) => {
+                        write!(s, "${{{}}}", emit_format_kotlin(expr, entry_param)).unwrap()
+                    }
                 }
             }
             s.push('"');
             s
         }
+        WidgetTextContent::Formatted(expr) => {
+            format!("\"${{{}}}\"", emit_format_kotlin(expr, entry_param))
+        }
+    }
+}
+
+/// Issue #1179 follow-up: emit a Kotlin expression for one of the
+/// whitelisted formatter calls. Result is a String-typed expression.
+fn emit_format_kotlin(expr: &WidgetFormatExpr, entry_param: &str) -> String {
+    let value = emit_format_arg_kotlin(&expr.arg, entry_param);
+    match expr.call {
+        WidgetFormatCall::StringCast | WidgetFormatCall::ToString => {
+            format!("{}.toString()", value)
+        }
+        WidgetFormatCall::NumberCast => format!("{}.toDouble()", value),
+        WidgetFormatCall::Round => format!("kotlin.math.round({}).toInt()", value),
+        WidgetFormatCall::Floor => format!("kotlin.math.floor({}).toInt()", value),
+        WidgetFormatCall::Ceil => format!("kotlin.math.ceil({}).toInt()", value),
+        WidgetFormatCall::ToFixed { digits } => {
+            format!("\"%.{}f\".format({})", digits, value)
+        }
+    }
+}
+
+fn emit_format_arg_kotlin(arg: &WidgetFormatArg, entry_param: &str) -> String {
+    match arg {
+        WidgetFormatArg::Field(field) => format!("{}.{}", entry_param, field),
+        WidgetFormatArg::Number(n) => {
+            if n.is_finite() && *n == n.floor() {
+                format!("{:.0}", n)
+            } else {
+                format!("{}", n)
+            }
+        }
+        WidgetFormatArg::String(s) => format!("\"{}\"", escape_kotlin_string(s)),
     }
 }
 
@@ -393,6 +431,8 @@ fn emit_kotlin_value(value: &WidgetTextContent) -> String {
         }
         WidgetTextContent::Field(f) => f.clone(),
         WidgetTextContent::Template(_) => "\"\"".to_string(),
+        // Conditions don't compare against formatted expressions today.
+        WidgetTextContent::Formatted(_) => "\"\"".to_string(),
     }
 }
 

--- a/crates/perry-hir/src/ir/mod.rs
+++ b/crates/perry-hir/src/ir/mod.rs
@@ -37,8 +37,9 @@ pub use module::Module;
 // ---- widget.rs ----
 pub use widget::{
     GaugeStyle, WidgetConditionOp, WidgetConfigParam, WidgetConfigParamType, WidgetDecl,
-    WidgetFieldType, WidgetFont, WidgetModifier, WidgetNode, WidgetPlaceholderValue,
-    WidgetStackKind, WidgetTemplatePart, WidgetTextContent,
+    WidgetFieldType, WidgetFont, WidgetFormatArg, WidgetFormatCall, WidgetFormatExpr,
+    WidgetModifier, WidgetNode, WidgetPlaceholderValue, WidgetStackKind, WidgetTemplatePart,
+    WidgetTextContent,
 };
 
 // ---- decl.rs ----

--- a/crates/perry-hir/src/ir/widget.rs
+++ b/crates/perry-hir/src/ir/widget.rs
@@ -157,12 +157,61 @@ pub enum WidgetTextContent {
     Field(String),
     /// Template literal with parts: `Score: ${entry.score}`
     Template(Vec<WidgetTemplatePart>),
+    /// Issue #1179 follow-up: a whitelisted formatting/coercion call
+    /// (`String(x)`, `Number(x)`, `x.toFixed(n)`, `x.toString()`,
+    /// `Math.round/floor/ceil(x)`) applied to a single argument.
+    /// Anything outside this whitelist still degrades to
+    /// `Literal(String::new())` so older codepaths don't observe a new
+    /// variant they can't interpret; new code MUST handle this variant.
+    Formatted(WidgetFormatExpr),
 }
 
 #[derive(Debug, Clone)]
 pub enum WidgetTemplatePart {
     Literal(String),
     Field(String),
+    /// Issue #1179 follow-up: a whitelisted formatting call inside a
+    /// template literal hole (e.g., `${Math.round(entry.x)}`).
+    Formatted(WidgetFormatExpr),
+}
+
+/// Issue #1179 follow-up: whitelisted formatter or coercion that we
+/// know how to transpile into each platform's render-text expression
+/// (SwiftUI / Kotlin Glance / Wear Tiles). The whitelist is deliberately
+/// small — anything richer is the user's job to compute in the provider
+/// and pass through as a pre-formatted string field.
+#[derive(Debug, Clone)]
+pub enum WidgetFormatCall {
+    /// `String(x)` — coerce to a display string
+    StringCast,
+    /// `Number(x)` — coerce to a numeric value
+    NumberCast,
+    /// `Math.round(x)` — round to the nearest integer
+    Round,
+    /// `Math.floor(x)`
+    Floor,
+    /// `Math.ceil(x)`
+    Ceil,
+    /// `x.toFixed(n)` — fixed-point string with `n` digits after the dot
+    ToFixed { digits: u32 },
+    /// `x.toString()` — explicit string coercion
+    ToString,
+}
+
+#[derive(Debug, Clone)]
+pub enum WidgetFormatArg {
+    /// `entry.<field>` — references a named entry field
+    Field(String),
+    /// Numeric literal argument (e.g., `Math.round(3.14)`)
+    Number(f64),
+    /// String literal argument
+    String(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct WidgetFormatExpr {
+    pub call: WidgetFormatCall,
+    pub arg: WidgetFormatArg,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/perry-hir/src/lower/widget_decl.rs
+++ b/crates/perry-hir/src/lower/widget_decl.rs
@@ -435,22 +435,20 @@ pub(crate) fn try_lower_widget_decl(
                 }
             }
             "entryFields" => {
-                // Allow explicit entry field declarations
+                // Allow explicit entry field declarations. Issue #1179
+                // follow-up: parse_entry_field_value_spec recurses through
+                // array literals (`[X]` → `Array<X>`) and object literals
+                // (`{k: 'string'}` → `Object`), so users can describe
+                // nested shapes without falling into the catch-all that
+                // used to collapse everything to `String` and break
+                // SwiftUI `ForEach` over arrays of objects.
                 if let ast::Expr::Object(obj) = kv.value.as_ref() {
                     for field_prop in &obj.props {
                         if let ast::PropOrSpread::Prop(p) = field_prop {
                             if let ast::Prop::KeyValue(field_kv) = p.as_ref() {
                                 let field_name = prop_name_to_string(&field_kv.key);
-                                let field_type = match field_kv.value.as_ref() {
-                                    ast::Expr::Lit(ast::Lit::Str(s)) => {
-                                        match s.value.as_str().unwrap_or("") {
-                                            "number" => WidgetFieldType::Number,
-                                            "boolean" => WidgetFieldType::Boolean,
-                                            _ => WidgetFieldType::String,
-                                        }
-                                    }
-                                    _ => WidgetFieldType::String,
-                                };
+                                let field_type =
+                                    parse_entry_field_value_spec(field_kv.value.as_ref());
                                 entry_fields.push((field_name, field_type));
                             }
                         }
@@ -558,6 +556,70 @@ fn extract_entry_fields_from_param(pat: &ast::Pat, fields: &mut Vec<(String, Wid
                 }
             }
         }
+    }
+}
+
+/// Issue #1179 follow-up: parse an `entryFields` value-position spec
+/// into a `WidgetFieldType`. Recognized forms:
+///
+/// - `'string' | 'number' | 'boolean'` (plus `'string?' | 'number?' | 'boolean?'`,
+///   `'string[]' | 'number[]' | 'boolean[]'`) — primitive specs;
+/// - `[X]` — array literal with a single element, resolves to `Array<X>`;
+/// - `{ k: <spec>, ... }` — object literal, resolves to `Object([(k, X), ...])`.
+///
+/// Anything else falls back to `String` for backwards compatibility with
+/// existing widget configs.
+fn parse_entry_field_value_spec(expr: &ast::Expr) -> WidgetFieldType {
+    match expr {
+        ast::Expr::Lit(ast::Lit::Str(s)) => {
+            parse_entry_field_primitive_spec(s.value.as_str().unwrap_or(""))
+        }
+        ast::Expr::Array(arr) => {
+            // Take the first non-empty element as the array's element
+            // type; widgets declaring `sites: [{...}]` use a single
+            // exemplar object to describe the array shape.
+            let inner = arr
+                .elems
+                .iter()
+                .flatten()
+                .next()
+                .map(|e| parse_entry_field_value_spec(e.expr.as_ref()))
+                .unwrap_or(WidgetFieldType::String);
+            WidgetFieldType::Array(Box::new(inner))
+        }
+        ast::Expr::Object(obj) => {
+            let mut obj_fields = Vec::new();
+            for prop in &obj.props {
+                if let ast::PropOrSpread::Prop(p) = prop {
+                    if let ast::Prop::KeyValue(kv) = p.as_ref() {
+                        let field_name = prop_name_to_string(&kv.key);
+                        let field_type = parse_entry_field_value_spec(kv.value.as_ref());
+                        obj_fields.push((field_name, field_type));
+                    }
+                }
+            }
+            WidgetFieldType::Object(obj_fields)
+        }
+        _ => WidgetFieldType::String,
+    }
+}
+
+/// Helper for `parse_entry_field_value_spec`: turn a primitive string
+/// spec into a `WidgetFieldType`. Supports `?` (optional) and `[]`
+/// (array) suffixes on the recognized base types.
+fn parse_entry_field_primitive_spec(spec: &str) -> WidgetFieldType {
+    let trimmed = spec.trim();
+    if let Some(base) = trimmed.strip_suffix('?') {
+        return WidgetFieldType::Optional(Box::new(parse_entry_field_primitive_spec(base)));
+    }
+    if let Some(base) = trimmed.strip_suffix("[]") {
+        return WidgetFieldType::Array(Box::new(parse_entry_field_primitive_spec(base)));
+    }
+    match trimmed {
+        "number" => WidgetFieldType::Number,
+        "boolean" => WidgetFieldType::Boolean,
+        "string" => WidgetFieldType::String,
+        _ => WidgetFieldType::String,
     }
 }
 
@@ -692,8 +754,20 @@ fn parse_text_content(expr: &ast::Expr) -> WidgetTextContent {
                 WidgetTextContent::Literal(String::new())
             }
         }
+        ast::Expr::Call(_) => {
+            // Issue #1179 follow-up: try the whitelist of known formatters
+            // (`String(x)`, `Number(x)`, `x.toFixed(n)`, `x.toString()`,
+            // `Math.round/floor/ceil(x)`). Anything outside the whitelist
+            // degrades to an empty literal — same behavior as before, but
+            // a follow-up could surface this as a diagnostic.
+            match try_parse_widget_format_expr(expr) {
+                Some(fmt) => WidgetTextContent::Formatted(fmt),
+                None => WidgetTextContent::Literal(String::new()),
+            }
+        }
         ast::Expr::Tpl(tpl) => {
-            // Template literal: `Score: ${entry.score}`
+            // Template literal: `Score: ${entry.score}` or
+            // `Score: ${Math.round(entry.score)}`.
             let mut parts = Vec::new();
             for (i, quasi) in tpl.quasis.iter().enumerate() {
                 let raw = quasi.raw.as_ref().to_string();
@@ -701,16 +775,132 @@ fn parse_text_content(expr: &ast::Expr) -> WidgetTextContent {
                     parts.push(WidgetTemplatePart::Literal(raw));
                 }
                 if i < tpl.exprs.len() {
-                    if let ast::Expr::Member(member) = tpl.exprs[i].as_ref() {
-                        if let ast::MemberProp::Ident(prop) = &member.prop {
-                            parts.push(WidgetTemplatePart::Field(prop.sym.to_string()));
+                    match tpl.exprs[i].as_ref() {
+                        ast::Expr::Member(member) => {
+                            if let ast::MemberProp::Ident(prop) = &member.prop {
+                                parts.push(WidgetTemplatePart::Field(prop.sym.to_string()));
+                            }
                         }
+                        call @ ast::Expr::Call(_) => {
+                            if let Some(fmt) = try_parse_widget_format_expr(call) {
+                                parts.push(WidgetTemplatePart::Formatted(fmt));
+                            }
+                        }
+                        _ => {}
                     }
                 }
             }
             WidgetTextContent::Template(parts)
         }
         _ => WidgetTextContent::Literal(String::new()),
+    }
+}
+
+/// Issue #1179 follow-up: recognize one of the whitelisted formatting
+/// calls inside a render text position. Returns `None` for any shape
+/// the codegen path can't transpile (callers fall back to an empty
+/// literal in that case).
+fn try_parse_widget_format_expr(expr: &ast::Expr) -> Option<WidgetFormatExpr> {
+    let call = match expr {
+        ast::Expr::Call(c) => c,
+        _ => return None,
+    };
+    let callee = match &call.callee {
+        ast::Callee::Expr(e) => e.as_ref(),
+        _ => return None,
+    };
+
+    match callee {
+        // `String(x)` / `Number(x)` — global coercion functions.
+        ast::Expr::Ident(ident) => {
+            let arg = call.args.first().and_then(|a| parse_format_arg(&a.expr))?;
+            match ident.sym.as_ref() {
+                "String" => Some(WidgetFormatExpr {
+                    call: WidgetFormatCall::StringCast,
+                    arg,
+                }),
+                "Number" => Some(WidgetFormatExpr {
+                    call: WidgetFormatCall::NumberCast,
+                    arg,
+                }),
+                _ => None,
+            }
+        }
+        // `Math.round(x)` / `Math.floor(x)` / `Math.ceil(x)` and
+        // `x.toFixed(n)` / `x.toString()` member calls.
+        ast::Expr::Member(member) => {
+            let prop_name = match &member.prop {
+                ast::MemberProp::Ident(p) => p.sym.as_ref(),
+                _ => return None,
+            };
+            // Math.*
+            if let ast::Expr::Ident(obj) = member.obj.as_ref() {
+                if obj.sym.as_ref() == "Math" {
+                    let arg = call.args.first().and_then(|a| parse_format_arg(&a.expr))?;
+                    let call_kind = match prop_name {
+                        "round" => WidgetFormatCall::Round,
+                        "floor" => WidgetFormatCall::Floor,
+                        "ceil" => WidgetFormatCall::Ceil,
+                        _ => return None,
+                    };
+                    return Some(WidgetFormatExpr {
+                        call: call_kind,
+                        arg,
+                    });
+                }
+            }
+            // x.toFixed(n) / x.toString() — `x` must be a member access
+            // (entry field) for us to handle it.
+            let arg = match member.obj.as_ref() {
+                ast::Expr::Member(inner) => match &inner.prop {
+                    ast::MemberProp::Ident(p) => WidgetFormatArg::Field(p.sym.to_string()),
+                    _ => return None,
+                },
+                _ => return None,
+            };
+            match prop_name {
+                "toString" if call.args.is_empty() => Some(WidgetFormatExpr {
+                    call: WidgetFormatCall::ToString,
+                    arg,
+                }),
+                "toFixed" => {
+                    let digits = call
+                        .args
+                        .first()
+                        .and_then(|a| match a.expr.as_ref() {
+                            ast::Expr::Lit(ast::Lit::Num(n)) => Some(n.value),
+                            _ => None,
+                        })
+                        .filter(|n| n.is_finite() && *n >= 0.0)
+                        .map(|n| n as u32)
+                        .unwrap_or(0);
+                    Some(WidgetFormatExpr {
+                        call: WidgetFormatCall::ToFixed { digits },
+                        arg,
+                    })
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Parse an argument expression into a `WidgetFormatArg`. Recognized
+/// shapes are `entry.<field>` (member access), numeric literal, and
+/// string literal. Anything else returns `None` and bubbles up to a
+/// non-recognized format call.
+fn parse_format_arg(expr: &ast::Expr) -> Option<WidgetFormatArg> {
+    match expr {
+        ast::Expr::Member(member) => match &member.prop {
+            ast::MemberProp::Ident(p) => Some(WidgetFormatArg::Field(p.sym.to_string())),
+            _ => None,
+        },
+        ast::Expr::Lit(ast::Lit::Num(n)) => Some(WidgetFormatArg::Number(n.value)),
+        ast::Expr::Lit(ast::Lit::Str(s)) => Some(WidgetFormatArg::String(
+            s.value.as_str().unwrap_or("").to_string(),
+        )),
+        _ => None,
     }
 }
 
@@ -1498,5 +1688,301 @@ fn parse_placeholder_value(expr: &ast::Expr) -> WidgetPlaceholderValue {
             WidgetPlaceholderValue::Object(fields)
         }
         _ => WidgetPlaceholderValue::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use swc_common::DUMMY_SP;
+    use swc_ecma_ast as ast;
+
+    fn str_lit(value: &str) -> ast::Expr {
+        ast::Expr::Lit(ast::Lit::Str(ast::Str {
+            span: DUMMY_SP,
+            value: value.into(),
+            raw: None,
+        }))
+    }
+
+    fn key_value(key: &str, value: ast::Expr) -> ast::PropOrSpread {
+        ast::PropOrSpread::Prop(Box::new(ast::Prop::KeyValue(ast::KeyValueProp {
+            key: ast::PropName::Ident(ast::IdentName {
+                span: DUMMY_SP,
+                sym: key.into(),
+            }),
+            value: Box::new(value),
+        })))
+    }
+
+    fn array_lit(elems: Vec<ast::Expr>) -> ast::Expr {
+        ast::Expr::Array(ast::ArrayLit {
+            span: DUMMY_SP,
+            elems: elems
+                .into_iter()
+                .map(|e| {
+                    Some(ast::ExprOrSpread {
+                        spread: None,
+                        expr: Box::new(e),
+                    })
+                })
+                .collect(),
+        })
+    }
+
+    fn object_lit(props: Vec<ast::PropOrSpread>) -> ast::Expr {
+        ast::Expr::Object(ast::ObjectLit {
+            span: DUMMY_SP,
+            props,
+        })
+    }
+
+    #[test]
+    fn primitive_spec_recognized_scalars() {
+        assert!(matches!(
+            parse_entry_field_primitive_spec("number"),
+            WidgetFieldType::Number
+        ));
+        assert!(matches!(
+            parse_entry_field_primitive_spec("boolean"),
+            WidgetFieldType::Boolean
+        ));
+        assert!(matches!(
+            parse_entry_field_primitive_spec("string"),
+            WidgetFieldType::String
+        ));
+    }
+
+    #[test]
+    fn primitive_spec_unknown_falls_back_to_string() {
+        assert!(matches!(
+            parse_entry_field_primitive_spec("Date"),
+            WidgetFieldType::String
+        ));
+        assert!(matches!(
+            parse_entry_field_primitive_spec(""),
+            WidgetFieldType::String
+        ));
+    }
+
+    #[test]
+    fn primitive_spec_optional_and_array_suffixes() {
+        assert!(matches!(
+            parse_entry_field_primitive_spec("number?"),
+            WidgetFieldType::Optional(inner) if matches!(*inner, WidgetFieldType::Number)
+        ));
+        assert!(matches!(
+            parse_entry_field_primitive_spec("string[]"),
+            WidgetFieldType::Array(inner) if matches!(*inner, WidgetFieldType::String)
+        ));
+        // `'boolean[]?'` — array suffix is parsed first, then optional.
+        let nested = parse_entry_field_primitive_spec("boolean[]?");
+        let WidgetFieldType::Optional(o) = nested else {
+            panic!("expected Optional, got {:?}", nested);
+        };
+        let WidgetFieldType::Array(a) = *o else {
+            panic!("expected Optional<Array>, got Optional<other>");
+        };
+        assert!(matches!(*a, WidgetFieldType::Boolean));
+    }
+
+    #[test]
+    fn entry_field_value_spec_object_literal_becomes_object() {
+        // Inline `{ url: 'string', clicks: 'number' }`.
+        let expr = object_lit(vec![
+            key_value("url", str_lit("string")),
+            key_value("clicks", str_lit("number")),
+        ]);
+        let ty = parse_entry_field_value_spec(&expr);
+        let WidgetFieldType::Object(fields) = ty else {
+            panic!("expected Object, got {:?}", ty);
+        };
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].0, "url");
+        assert!(matches!(fields[0].1, WidgetFieldType::String));
+        assert_eq!(fields[1].0, "clicks");
+        assert!(matches!(fields[1].1, WidgetFieldType::Number));
+    }
+
+    #[test]
+    fn entry_field_value_spec_array_of_objects_does_not_collapse_to_string() {
+        // Inline `[{ url: 'string', clicks: 'number' }]`. This is the
+        // exact shape that used to collapse to `String` in the old
+        // parser, breaking SwiftUI `ForEach` over the field.
+        let inner = object_lit(vec![
+            key_value("url", str_lit("string")),
+            key_value("clicks", str_lit("number")),
+        ]);
+        let expr = array_lit(vec![inner]);
+        let ty = parse_entry_field_value_spec(&expr);
+        let WidgetFieldType::Array(elem) = ty else {
+            panic!("expected Array, got {:?}", ty);
+        };
+        let WidgetFieldType::Object(fields) = *elem else {
+            panic!("expected Array<Object>, got Array<other>");
+        };
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].0, "url");
+        assert_eq!(fields[1].0, "clicks");
+    }
+
+    fn ident_expr(name: &str) -> ast::Expr {
+        ast::Expr::Ident(ast::Ident {
+            span: DUMMY_SP,
+            ctxt: Default::default(),
+            sym: name.into(),
+            optional: false,
+        })
+    }
+
+    fn member_expr(obj: ast::Expr, prop: &str) -> ast::Expr {
+        ast::Expr::Member(ast::MemberExpr {
+            span: DUMMY_SP,
+            obj: Box::new(obj),
+            prop: ast::MemberProp::Ident(ast::IdentName {
+                span: DUMMY_SP,
+                sym: prop.into(),
+            }),
+        })
+    }
+
+    fn call_expr(callee: ast::Expr, args: Vec<ast::Expr>) -> ast::Expr {
+        ast::Expr::Call(ast::CallExpr {
+            span: DUMMY_SP,
+            ctxt: Default::default(),
+            callee: ast::Callee::Expr(Box::new(callee)),
+            args: args
+                .into_iter()
+                .map(|e| ast::ExprOrSpread {
+                    spread: None,
+                    expr: Box::new(e),
+                })
+                .collect(),
+            type_args: None,
+        })
+    }
+
+    fn num_lit(n: f64) -> ast::Expr {
+        ast::Expr::Lit(ast::Lit::Num(ast::Number {
+            span: DUMMY_SP,
+            value: n,
+            raw: None,
+        }))
+    }
+
+    #[test]
+    fn format_expr_recognizes_string_cast() {
+        // `String(entry.totalClicks)`
+        let expr = call_expr(
+            ident_expr("String"),
+            vec![member_expr(ident_expr("entry"), "totalClicks")],
+        );
+        let fmt = try_parse_widget_format_expr(&expr).expect("expected Formatted match");
+        assert!(matches!(fmt.call, WidgetFormatCall::StringCast));
+        assert!(matches!(
+            fmt.arg,
+            WidgetFormatArg::Field(ref f) if f == "totalClicks"
+        ));
+    }
+
+    #[test]
+    fn format_expr_recognizes_math_round_floor_ceil() {
+        for (method, expected) in [
+            ("round", WidgetFormatCall::Round),
+            ("floor", WidgetFormatCall::Floor),
+            ("ceil", WidgetFormatCall::Ceil),
+        ] {
+            let callee = member_expr(ident_expr("Math"), method);
+            let expr = call_expr(
+                callee,
+                vec![member_expr(ident_expr("entry"), "totalClicks")],
+            );
+            let fmt =
+                try_parse_widget_format_expr(&expr).expect("expected Math.* to match whitelist");
+            assert!(
+                std::mem::discriminant(&fmt.call) == std::mem::discriminant(&expected),
+                "method `{}` produced {:?}, want {:?}",
+                method,
+                fmt.call,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn format_expr_recognizes_to_fixed_with_digits_literal() {
+        // `entry.totalClicks.toFixed(2)`
+        let target = member_expr(ident_expr("entry"), "totalClicks");
+        let callee = member_expr(target, "toFixed");
+        let expr = call_expr(callee, vec![num_lit(2.0)]);
+        let fmt = try_parse_widget_format_expr(&expr).expect("expected toFixed match");
+        assert!(matches!(fmt.call, WidgetFormatCall::ToFixed { digits: 2 }));
+        assert!(matches!(
+            fmt.arg,
+            WidgetFormatArg::Field(ref f) if f == "totalClicks"
+        ));
+    }
+
+    #[test]
+    fn format_expr_rejects_unknown_call_shape() {
+        // `fmt(entry.totalClicks)` — user-defined function, not in
+        // the whitelist; must return None (caller falls back to an
+        // empty literal rather than producing broken output).
+        let expr = call_expr(
+            ident_expr("fmt"),
+            vec![member_expr(ident_expr("entry"), "totalClicks")],
+        );
+        assert!(try_parse_widget_format_expr(&expr).is_none());
+    }
+
+    #[test]
+    fn parse_text_content_call_path_collapses_for_unknown() {
+        // Same as above but exercising the public entrypoint — verifies
+        // that the call falls through to Literal("") rather than
+        // silently dropping into Field("").
+        let expr = call_expr(
+            ident_expr("fmt"),
+            vec![member_expr(ident_expr("entry"), "totalClicks")],
+        );
+        match parse_text_content(&expr) {
+            WidgetTextContent::Literal(ref s) if s.is_empty() => {}
+            other => panic!("expected Literal(\"\"), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_text_content_call_path_recognized_call_becomes_formatted() {
+        // `Math.round(entry.totalClicks)` — the user's actual bug
+        // shape. Must produce Formatted, not the catch-all empty
+        // literal that lost the call body.
+        let expr = call_expr(
+            member_expr(ident_expr("Math"), "round"),
+            vec![member_expr(ident_expr("entry"), "totalClicks")],
+        );
+        match parse_text_content(&expr) {
+            WidgetTextContent::Formatted(fmt) => {
+                assert!(matches!(fmt.call, WidgetFormatCall::Round));
+                assert!(matches!(
+                    fmt.arg,
+                    WidgetFormatArg::Field(ref f) if f == "totalClicks"
+                ));
+            }
+            other => panic!("expected Formatted, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn entry_field_value_spec_array_with_string_suffix_spec() {
+        // `'string[]'` and `['string']` both resolve to `Array<String>`.
+        let by_suffix = parse_entry_field_value_spec(&str_lit("string[]"));
+        let by_literal = parse_entry_field_value_spec(&array_lit(vec![str_lit("string")]));
+        assert!(matches!(
+            by_suffix,
+            WidgetFieldType::Array(inner) if matches!(*inner, WidgetFieldType::String)
+        ));
+        assert!(matches!(
+            by_literal,
+            WidgetFieldType::Array(inner) if matches!(*inner, WidgetFieldType::String)
+        ));
     }
 }

--- a/crates/perry-hir/src/stable_hash/widgets.rs
+++ b/crates/perry-hir/src/stable_hash/widgets.rs
@@ -232,6 +232,10 @@ impl SH for WidgetTextContent {
                 tag(h, 2);
                 parts.hash(h);
             }
+            WidgetTextContent::Formatted(expr) => {
+                tag(h, 3);
+                expr.hash(h);
+            }
         }
     }
 }
@@ -245,6 +249,53 @@ impl SH for WidgetTemplatePart {
             }
             WidgetTemplatePart::Field(s) => {
                 tag(h, 1);
+                s.hash(h);
+            }
+            WidgetTemplatePart::Formatted(expr) => {
+                tag(h, 2);
+                expr.hash(h);
+            }
+        }
+    }
+}
+
+impl SH for WidgetFormatExpr {
+    fn hash<H: StableHasher>(&self, h: &mut H) {
+        self.call.hash(h);
+        self.arg.hash(h);
+    }
+}
+
+impl SH for WidgetFormatCall {
+    fn hash<H: StableHasher>(&self, h: &mut H) {
+        match self {
+            WidgetFormatCall::StringCast => tag(h, 0),
+            WidgetFormatCall::NumberCast => tag(h, 1),
+            WidgetFormatCall::Round => tag(h, 2),
+            WidgetFormatCall::Floor => tag(h, 3),
+            WidgetFormatCall::Ceil => tag(h, 4),
+            WidgetFormatCall::ToFixed { digits } => {
+                tag(h, 5);
+                digits.hash(h);
+            }
+            WidgetFormatCall::ToString => tag(h, 6),
+        }
+    }
+}
+
+impl SH for WidgetFormatArg {
+    fn hash<H: StableHasher>(&self, h: &mut H) {
+        match self {
+            WidgetFormatArg::Field(s) => {
+                tag(h, 0);
+                s.hash(h);
+            }
+            WidgetFormatArg::Number(n) => {
+                tag(h, 1);
+                n.hash(h);
+            }
+            WidgetFormatArg::String(s) => {
+                tag(h, 2);
                 s.hash(h);
             }
         }

--- a/crates/perry/src/commands/compile/widget_build.rs
+++ b/crates/perry/src/commands/compile/widget_build.rs
@@ -39,6 +39,14 @@ pub struct WidgetEntry {
     pub watchos_source: Option<String>,
     /// Optional Android Glance variant. Not wired up in v1.
     pub glance_source: Option<String>,
+    /// Issue #1179: TS entry point (relative to the perry.toml project
+    /// root, or absolute) that declares one or more `Widget({...})` calls.
+    /// When set, `perry compile --target ios` / `--target android`
+    /// invokes the existing `--target ios-widget` / `--target android-widget`
+    /// codegen internally and uses the produced sources in place of
+    /// `swift_source` / `glance_source`. Lets apps keep a single source
+    /// of truth (`widgets/index.ts`) without checking in generated code.
+    pub ts_source: Option<String>,
     /// Display name shown in the widget gallery. Defaults to `name`.
     pub display_name: Option<String>,
     /// One-line description. Defaults to "{display_name} widget".
@@ -148,11 +156,17 @@ pub(super) fn build_declared_widgets_ios(
 
     let mut built = 0usize;
     for entry in &entries {
+        let has_ts = entry.ts_source.is_some();
+
         // watchOS / Android variants: emit a warning and skip. We don't
         // hard-fail because a single `[[widget]]` entry can legitimately
         // declare multiple platform sources — the iOS half should still
         // build even if the Android half hasn't been wired yet.
-        if entry.swift_source.is_none() && entry.watchos_source.is_some() {
+        //
+        // When `ts_source` is set we always produce SwiftUI from it for
+        // the iOS path, so the "watchOS-only" / "Android-only" skips
+        // don't apply.
+        if entry.swift_source.is_none() && !has_ts && entry.watchos_source.is_some() {
             warn_skip(
                 format,
                 &entry.name,
@@ -161,7 +175,7 @@ pub(super) fn build_declared_widgets_ios(
             );
             continue;
         }
-        if entry.glance_source.is_some() && entry.swift_source.is_none() {
+        if entry.glance_source.is_some() && entry.swift_source.is_none() && !has_ts {
             // Pure-Android widget: skipped here, picked up by
             // `build_declared_widgets_android` when the target is android.
             continue;
@@ -179,39 +193,45 @@ pub(super) fn build_declared_widgets_ios(
         // the Android slice is handled by build_declared_widgets_android
         // on android targets, the iOS .appex is built here.
 
-        let Some(swift_source) = entry.swift_source.as_deref() else {
-            // No iOS source and no skip-warned non-iOS source above means a
-            // bogus entry — surface it but don't kill the build.
+        // Issue #1179: resolve the SwiftUI source directory. Precedence
+        // is explicit `swift_source` (hand-edited override) > `ts_source`
+        // (cross-compiled from TS). When neither is present we surface
+        // the bogus entry as a warning and skip.
+        let (abs_swift_source, swift_source_display) = if let Some(swift_source) =
+            entry.swift_source.as_deref()
+        {
+            let abs = resolve_against_project_root(project_root.as_deref(), swift_source);
+            if !abs.exists() {
+                return Err(anyhow!(
+                    "[[widget]] `{}`: swift_source `{}` does not exist (looked at `{}`)",
+                    entry.name,
+                    swift_source,
+                    abs.display()
+                ));
+            }
+            (abs, swift_source.to_string())
+        } else if let Some(ts_source) = entry.ts_source.as_deref() {
+            let abs_ts = resolve_against_project_root(project_root.as_deref(), ts_source);
+            if !abs_ts.exists() {
+                return Err(anyhow!(
+                    "[[widget]] `{}`: ts_source `{}` does not exist (looked at `{}`)",
+                    entry.name,
+                    ts_source,
+                    abs_ts.display()
+                ));
+            }
+            let dir = compile_ts_widget_to_swift(&abs_ts, &entry.name, app_bundle_id, format)?;
+            (dir, ts_source.to_string())
+        } else {
             match format {
                 OutputFormat::Text => eprintln!(
-                    "Warning: [[widget]] `{}` has neither swift_source nor a recognized non-iOS source — skipping.",
+                    "Warning: [[widget]] `{}` has neither swift_source, ts_source, nor a recognized non-iOS source — skipping.",
                     entry.name
                 ),
                 OutputFormat::Json => {}
             }
             continue;
         };
-
-        let abs_swift_source = match project_root.as_deref() {
-            Some(root) => {
-                let candidate = root.join(swift_source);
-                if candidate.exists() {
-                    candidate
-                } else {
-                    PathBuf::from(swift_source)
-                }
-            }
-            None => PathBuf::from(swift_source),
-        };
-
-        if !abs_swift_source.exists() {
-            return Err(anyhow!(
-                "[[widget]] `{}`: swift_source `{}` does not exist (looked at `{}`)",
-                entry.name,
-                swift_source,
-                abs_swift_source.display()
-            ));
-        }
 
         let display_name = entry
             .display_name
@@ -222,9 +242,9 @@ pub(super) fn build_declared_widgets_ios(
         let swift_files = collect_swift_files(&abs_swift_source)?;
         if swift_files.is_empty() {
             return Err(anyhow!(
-                "[[widget]] `{}`: swift_source `{}` contained no `.swift` files",
+                "[[widget]] `{}`: source `{}` contained no `.swift` files",
                 entry.name,
-                abs_swift_source.display()
+                swift_source_display
             ));
         }
 
@@ -322,6 +342,166 @@ fn warn_skip(format: OutputFormat, widget: &str, platform: &str, message: &str) 
     if let OutputFormat::Text = format {
         eprintln!("Warning: widget `{}` ({}): {}", widget, platform, message);
     }
+}
+
+/// Resolve a `[[widget]]`-relative path against the project root that owns
+/// `perry.toml`. Falls back to the raw path if no project root is known
+/// or the joined candidate doesn't exist on disk.
+fn resolve_against_project_root(project_root: Option<&Path>, source: &str) -> PathBuf {
+    match project_root {
+        Some(root) => {
+            let candidate = root.join(source);
+            if candidate.exists() {
+                candidate
+            } else {
+                PathBuf::from(source)
+            }
+        }
+        None => PathBuf::from(source),
+    }
+}
+
+/// Issue #1179: cross-compile a `[[widget]] ts_source` to SwiftUI by
+/// re-invoking the running `perry` binary with `--target ios-widget
+/// --skip-swift-build`. Returns the directory of emitted `.swift` files,
+/// which the iOS build path then feeds into `swiftc` as if it were the
+/// user's `swift_source`. Side-effect-free at the filesystem level apart
+/// from writing into a fresh temp directory under `std::env::temp_dir()`.
+fn compile_ts_widget_to_swift(
+    ts_source: &Path,
+    widget_name: &str,
+    app_bundle_id: &str,
+    format: OutputFormat,
+) -> Result<PathBuf> {
+    let perry = std::env::current_exe()
+        .map_err(|e| anyhow!("Failed to locate the running perry binary: {}", e))?;
+
+    let tmp_dir = std::env::temp_dir().join(format!(
+        "perry-ts-widget-ios-{}-{}-{}",
+        widget_name,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    fs::create_dir_all(&tmp_dir)
+        .with_context(|| format!("Failed to create temp dir `{}`", tmp_dir.display()))?;
+
+    if let OutputFormat::Text = format {
+        println!(
+            "  Cross-compiling TS widget `{}` ({}) → {}",
+            widget_name,
+            ts_source.display(),
+            tmp_dir.display()
+        );
+    }
+
+    let mut cmd = Command::new(&perry);
+    // Pass `--format` as a global flag so it propagates to the nested
+    // `compile` subcommand. Inherit the parent's format so json-mode
+    // builds don't get text chatter mixed into stdout.
+    match format {
+        OutputFormat::Text => {}
+        OutputFormat::Json => {
+            cmd.args(["--format", "json"]);
+        }
+    }
+    cmd.arg("compile")
+        .arg(ts_source)
+        .args(["--target", "ios-widget"])
+        .args(["--app-bundle-id", app_bundle_id])
+        .arg("--skip-swift-build")
+        .arg("-o")
+        .arg(&tmp_dir);
+
+    let status = cmd.status().map_err(|e| {
+        anyhow!(
+            "Failed to invoke nested `perry compile --target ios-widget` for widget `{}`: {}",
+            widget_name,
+            e
+        )
+    })?;
+    if !status.success() {
+        return Err(anyhow!(
+            "Nested `perry compile --target ios-widget` failed for widget `{}` \
+             (input `{}`, exit {}).",
+            widget_name,
+            ts_source.display(),
+            status.code().unwrap_or(-1),
+        ));
+    }
+
+    Ok(tmp_dir)
+}
+
+/// Issue #1179: cross-compile a `[[widget]] ts_source` to Kotlin Glance
+/// sources by re-invoking the running `perry` binary with
+/// `--target android-widget`. Returns the directory of emitted `.kt`
+/// files, which the Android build path then copies into the Gradle
+/// project as if it were the user's `glance_source`.
+fn compile_ts_widget_to_glance(
+    ts_source: &Path,
+    widget_name: &str,
+    app_package: &str,
+    format: OutputFormat,
+) -> Result<PathBuf> {
+    let perry = std::env::current_exe()
+        .map_err(|e| anyhow!("Failed to locate the running perry binary: {}", e))?;
+
+    let tmp_dir = std::env::temp_dir().join(format!(
+        "perry-ts-widget-android-{}-{}-{}",
+        widget_name,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    fs::create_dir_all(&tmp_dir)
+        .with_context(|| format!("Failed to create temp dir `{}`", tmp_dir.display()))?;
+
+    if let OutputFormat::Text = format {
+        println!(
+            "  Cross-compiling TS widget `{}` ({}) → {}",
+            widget_name,
+            ts_source.display(),
+            tmp_dir.display()
+        );
+    }
+
+    let mut cmd = Command::new(&perry);
+    match format {
+        OutputFormat::Text => {}
+        OutputFormat::Json => {
+            cmd.args(["--format", "json"]);
+        }
+    }
+    cmd.arg("compile")
+        .arg(ts_source)
+        .args(["--target", "android-widget"])
+        .args(["--app-bundle-id", app_package])
+        .arg("-o")
+        .arg(&tmp_dir);
+
+    let status = cmd.status().map_err(|e| {
+        anyhow!(
+            "Failed to invoke nested `perry compile --target android-widget` for widget `{}`: {}",
+            widget_name,
+            e
+        )
+    })?;
+    if !status.success() {
+        return Err(anyhow!(
+            "Nested `perry compile --target android-widget` failed for widget `{}` \
+             (input `{}`, exit {}).",
+            widget_name,
+            ts_source.display(),
+            status.code().unwrap_or(-1),
+        ));
+    }
+
+    Ok(tmp_dir)
 }
 
 fn resolve_sdk_path(sdk: &str) -> Result<String> {
@@ -451,29 +631,37 @@ pub(crate) fn build_declared_widgets_android(
     let mut receiver_blocks: Vec<String> = Vec::new();
 
     for entry in &entries {
-        let Some(glance_source) = entry.glance_source.as_deref() else {
-            continue;
-        };
-
-        let abs_source = match project_root.as_deref() {
-            Some(root) => {
-                let candidate = root.join(glance_source);
-                if candidate.exists() {
-                    candidate
-                } else {
-                    PathBuf::from(glance_source)
+        // Issue #1179: resolve the Kotlin/Glance source directory.
+        // Precedence is explicit `glance_source` (hand-edited override)
+        // > `ts_source` (cross-compiled from TS). Entries with neither
+        // skip silently on the Android path — they may be iOS-only.
+        let (abs_source, source_display) =
+            if let Some(glance_source) = entry.glance_source.as_deref() {
+                let abs = resolve_against_project_root(project_root.as_deref(), glance_source);
+                if !abs.exists() {
+                    return Err(anyhow!(
+                        "[[widget]] `{}`: glance_source `{}` does not exist (looked at `{}`)",
+                        entry.name,
+                        glance_source,
+                        abs.display()
+                    ));
                 }
-            }
-            None => PathBuf::from(glance_source),
-        };
-        if !abs_source.exists() {
-            return Err(anyhow!(
-                "[[widget]] `{}`: glance_source `{}` does not exist (looked at `{}`)",
-                entry.name,
-                glance_source,
-                abs_source.display()
-            ));
-        }
+                (abs, glance_source.to_string())
+            } else if let Some(ts_source) = entry.ts_source.as_deref() {
+                let abs_ts = resolve_against_project_root(project_root.as_deref(), ts_source);
+                if !abs_ts.exists() {
+                    return Err(anyhow!(
+                        "[[widget]] `{}`: ts_source `{}` does not exist (looked at `{}`)",
+                        entry.name,
+                        ts_source,
+                        abs_ts.display()
+                    ));
+                }
+                let dir = compile_ts_widget_to_glance(&abs_ts, &entry.name, app_package, format)?;
+                (dir, ts_source.to_string())
+            } else {
+                continue;
+            };
 
         // Lay each widget under `<app_package>.widgets.<name>` so apps
         // shipping several widgets don't collide in one flat package.
@@ -489,8 +677,9 @@ pub(crate) fn build_declared_widgets_android(
         let kt_files = collect_kotlin_files(&abs_source)?;
         if kt_files.is_empty() {
             return Err(anyhow!(
-                "[[widget]] `{}`: glance_source `{}` contained no `.kt` files",
+                "[[widget]] `{}`: source `{}` contained no `.kt` files (resolved to `{}`)",
                 entry.name,
+                source_display,
                 abs_source.display()
             ));
         }
@@ -700,6 +889,49 @@ intents = ["DailyIntent", "RefreshIntent"]
         assert_eq!(w.display_name.as_deref(), Some("Daily change"));
         assert_eq!(w.intents, vec!["DailyIntent", "RefreshIntent"]);
         assert!(w.glance_source.is_some());
+    }
+
+    #[test]
+    fn manifest_parses_ts_source_widget_entry() {
+        let toml_text = r#"
+[[widget]]
+name = "Widgets"
+ts_source = "widgets/index.ts"
+"#;
+        let m: WidgetManifest = toml::from_str(toml_text).unwrap();
+        assert_eq!(m.widget.len(), 1);
+        let w = &m.widget[0];
+        assert_eq!(w.name, "Widgets");
+        assert_eq!(w.ts_source.as_deref(), Some("widgets/index.ts"));
+        assert!(w.swift_source.is_none());
+        assert!(w.glance_source.is_none());
+    }
+
+    #[test]
+    fn resolve_against_project_root_joins_when_candidate_exists() {
+        let tmp = std::env::temp_dir().join(format!(
+            "perry-resolve-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let sub = tmp.join("widgets");
+        fs::create_dir_all(&sub).unwrap();
+        let resolved = resolve_against_project_root(Some(&tmp), "widgets");
+        assert_eq!(resolved, sub);
+        fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn resolve_against_project_root_falls_back_to_raw() {
+        // Non-existent candidate under root → fall back to raw path.
+        let resolved = resolve_against_project_root(
+            Some(Path::new("/nonexistent/perry/root")),
+            "/absolute/widgets/dir",
+        );
+        assert_eq!(resolved, PathBuf::from("/absolute/widgets/dir"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `ts_source` to the `[[widget]]` schema. When `perry compile --target ios` / `--target android` sees a widget with `ts_source` (and no `swift_source` / `glance_source`), it re-invokes the running `perry` binary with `--target ios-widget` / `--target android-widget` to emit SwiftUI / Kotlin Glance into a temp directory, then continues through the existing swiftc + `.appex` embed (iOS) or Gradle copy + `<receiver>` injection (Android) pipeline.
- Net effect: one source of truth (`widgets/index.ts`), no checked-in generated SwiftUI/Kotlin, and the main `--target ios` / `--target android` build picks the TS widget bundle up automatically.
- Precedence is explicit `swift_source` / `glance_source` > `ts_source` so a user mid-port can still pin the platform output if needed.
- Also fixes the two small SwiftUI/Glance codegen gaps the issue noted in passing (see below).

Closes #1179.

## Example

```toml
[[widget]]
name = "Widgets"
ts_source = "widgets/index.ts"
```

Then `perry compile --target ios --app-bundle-id com.example.app` (or `--target android`) bundles every `Widget({...})` declared in `widgets/index.ts` into the produced `.app` (or Gradle project) without any other manifest changes.

## Codegen gap fixes

1. **`entryFields` arrays-of-objects no longer collapse to `String`.** The old parser only recognized string-literal values (`'number'`, `'boolean'`, otherwise `String`), so any nested shape was lost and SwiftUI `ForEach` over the field was broken. New `parse_entry_field_value_spec` recursively handles primitive-with-suffix specs (`'string?'`, `'number[]'`), array literals (`[X]` → `Array<X>`), and object literals (`{ k: <spec>, ... }` → `Object`).

2. **Whitelisted formatter calls inside `render` no longer emit `Text("")`.** A new `WidgetTextContent::Formatted` variant carries one of `String(x)`, `Number(x)`, `x.toString()`, `x.toFixed(n)`, `Math.round/floor/ceil(x)`. The three widget codegen crates (SwiftUI, Glance, Wear Tiles) transpile each to its native equivalent. Calls outside the whitelist still fall back to an empty literal — same as before — so users get a clear "switch to a supported formatter or pre-format in the provider" path. User-defined `fmt(...)` is intentionally out of scope.

## Test plan
- [x] `cargo build -p perry` — clean
- [x] `cargo test -p perry widget_build::` — 12/12
- [x] `cargo test -p perry-hir lower::widget_decl` — 12/12 (10 new: entryFields recursive shapes, format-call whitelist recognition, fallback for unrecognized calls)
- [x] `cargo test -p perry-codegen-swiftui` — 15/15 (5 new: each formatter emits the right Swift, end-to-end `Text(Math.round(entry.x))` no longer collapses to `Text("")`)
- [x] `cargo test -p perry-codegen-glance` — clean
- [x] `cargo test -p perry-codegen-wear-tiles` — clean
- [x] `cargo test -p perry-hir` — 169/169
- [x] `cargo fmt --all -- --check` — clean
- [ ] End-to-end: GSC Master TopSites/QuickStats/DailyChange widgets via `widgets/index.ts` (issue reporter to validate downstream)