### PR TITLE
fix(ui-macos): #1198 stateBindTextfield cursor reset on every keystroke

### DIFF
--- a/crates/perry-ui-macos/src/state.rs
+++ b/crates/perry-ui-macos/src/state.rs
@@ -1,5 +1,6 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use crate::widgets;
 
@@ -27,8 +28,14 @@ struct ToggleBinding {
     toggle_handle: i64,
 }
 
-struct TextFieldBinding {
-    textfield_handle: i64,
+pub(crate) struct TextFieldBinding {
+    pub(crate) textfield_handle: i64,
+    /// True while `state_set` is mid-flight writing this textfield, OR while the
+    /// textfield's own change observer is invoking user code that may call
+    /// `state.set`. Either way, the state→textfield write inside
+    /// `state_set` is skipped so the field's cursor / selection doesn't
+    /// reset on every keystroke. See #1198.
+    pub(crate) suppress: Cell<bool>,
 }
 
 /// A part of a multi-state text template.
@@ -61,7 +68,11 @@ thread_local! {
     /// Map from state_handle -> toggle bindings (two-way)
     static TOGGLE_BINDINGS: RefCell<HashMap<i64, Vec<ToggleBinding>>> = RefCell::new(HashMap::new());
     /// Map from state_handle -> textfield bindings (two-way)
-    static TEXTFIELD_BINDINGS: RefCell<HashMap<i64, Vec<TextFieldBinding>>> = RefCell::new(HashMap::new());
+    static TEXTFIELD_BINDINGS: RefCell<HashMap<i64, Vec<Rc<TextFieldBinding>>>> = RefCell::new(HashMap::new());
+    /// Map from textfield_handle -> binding, used by the textfield change
+    /// observer in `widgets/textfield.rs` to suppress the echo-back during
+    /// user-initiated edits (#1198).
+    pub(crate) static TEXTFIELD_TO_BINDING: RefCell<HashMap<i64, Rc<TextFieldBinding>>> = RefCell::new(HashMap::new());
     /// All multi-state text bindings
     static MULTI_TEXT_BINDINGS: RefCell<Vec<MultiTextBinding>> = const { RefCell::new(Vec::new()) };
     /// Map from state_handle -> indices into MULTI_TEXT_BINDINGS
@@ -197,11 +208,19 @@ pub fn state_set(handle: i64, value: f64) {
         }
     });
 
-    // Update textfield bindings (two-way)
+    // Update textfield bindings (two-way). Skip bindings whose
+    // suppress flag is set — that means the update originated from
+    // the textfield itself (user typing) and writing back would
+    // reset the cursor / selection. See #1198.
     TEXTFIELD_BINDINGS.with(|b| {
         if let Some(bindings) = b.borrow().get(&handle) {
             for binding in bindings {
+                if binding.suppress.get() {
+                    continue;
+                }
+                binding.suppress.set(true);
                 widgets::textfield::set_text_str(binding.textfield_handle, &formatted);
+                binding.suppress.set(false);
             }
         }
     });
@@ -338,13 +357,36 @@ pub fn bind_toggle(state_handle: i64, toggle_handle: i64) {
 }
 
 /// Bind a textfield to a state cell (two-way binding).
+///
+/// The state→textfield direction lives here: `state_set` walks
+/// `TEXTFIELD_BINDINGS` and rewrites the field. The textfield→state
+/// direction stays user-wired through the closure passed to
+/// `TextField(placeholder, onChange)` (typically
+/// `(v) => state.set(v)`). The piece this binding adds for two-way
+/// safety is the suppress flag: while the textfield's change observer
+/// is invoking that user closure, the state_set echo-back is
+/// skipped so the field's cursor / selection isn't reset. See #1198.
 pub fn bind_textfield(state_handle: i64, textfield_handle: i64) {
+    let binding = Rc::new(TextFieldBinding {
+        textfield_handle,
+        suppress: Cell::new(false),
+    });
     TEXTFIELD_BINDINGS.with(|b| {
         b.borrow_mut()
             .entry(state_handle)
             .or_default()
-            .push(TextFieldBinding { textfield_handle });
+            .push(binding.clone());
     });
+    TEXTFIELD_TO_BINDING.with(|m| {
+        m.borrow_mut().insert(textfield_handle, binding);
+    });
+
+    // Seed the textfield with the current state value (matches the
+    // GTK4 / Windows behavior so a non-empty initial state shows up
+    // in the field on first paint).
+    let value = state_get(state_handle);
+    let text = format_value(value);
+    widgets::textfield::set_text_str(textfield_handle, &text);
 }
 
 /// Bind a text widget to multiple states with a template.

--- a/crates/perry-ui-macos/src/widgets/textfield.rs
+++ b/crates/perry-ui-macos/src/widgets/textfield.rs
@@ -9,8 +9,8 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 
 thread_local! {
-    /// Map from observer object address to (closure_f64, textfield_view_ptr)
-    static TEXTFIELD_CALLBACKS: RefCell<HashMap<usize, (f64, *const AnyObject)>> = RefCell::new(HashMap::new());
+    /// Map from observer object address to (closure_f64, textfield_view_ptr, textfield_handle)
+    static TEXTFIELD_CALLBACKS: RefCell<HashMap<usize, (f64, *const AnyObject, i64)>> = RefCell::new(HashMap::new());
     /// Map from observer address to (submit_closure_f64, textfield_view_ptr)
     static TEXTFIELD_SUBMIT_CALLBACKS: RefCell<HashMap<usize, (f64, *const AnyObject)>> = RefCell::new(HashMap::new());
     /// Map from observer address to (focus_closure_f64, textfield_view_ptr)
@@ -41,7 +41,7 @@ define_class!(
             let key = self.ivars().callback_key.get();
             crate::catch_callback_panic("textfield callback", std::panic::AssertUnwindSafe(|| {
                 TEXTFIELD_CALLBACKS.with(|cbs| {
-                    if let Some(&(closure_f64, tf_ptr)) = cbs.borrow().get(&key) {
+                    if let Some(&(closure_f64, tf_ptr, tf_handle)) = cbs.borrow().get(&key) {
                         if tf_ptr.is_null() {
                             return;
                         }
@@ -65,8 +65,22 @@ define_class!(
                         let nanboxed = unsafe { js_nanbox_string(str_ptr as i64) };
 
                         let closure_ptr = unsafe { js_nanbox_get_pointer(closure_f64) };
+
+                        // If this textfield is bound to a state cell via
+                        // `stateBindTextfield`, set the binding's suppress flag
+                        // around the user closure so any `state.set` inside it
+                        // doesn't echo back to setStringValue and reset the
+                        // user's cursor / selection. See #1198.
+                        let binding = crate::state::TEXTFIELD_TO_BINDING
+                            .with(|m| m.borrow().get(&tf_handle).cloned());
+                        if let Some(ref b) = binding {
+                            b.suppress.set(true);
+                        }
                         unsafe {
                             js_closure_call1(closure_ptr as *const u8, nanboxed);
+                        }
+                        if let Some(b) = binding {
+                            b.suppress.set(false);
                         }
                     }
                 });
@@ -187,7 +201,8 @@ pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
         observer.ivars().callback_key.set(observer_addr);
 
         TEXTFIELD_CALLBACKS.with(|cbs| {
-            cbs.borrow_mut().insert(observer_addr, (on_change, tf_raw));
+            cbs.borrow_mut()
+                .insert(observer_addr, (on_change, tf_raw, handle));
         });
 
         #[cfg(feature = "geisterhand")]


### PR DESCRIPTION
## Summary

Closes #1198.

The macOS `bind_textfield` had no suppress flag — every `state.set()` invoked inside the user's onChange ran the `TEXTFIELD_BINDINGS` loop and re-wrote the field via `setStringValue`, resetting the cursor / selection on each keystroke. Windows (since v0.5.778) and GTK4 already use the per-binding `Cell<bool>` suppress pattern; this brings macOS in line.

- `TextFieldBinding` is now `Rc`-shared and holds a `suppress: Cell<bool>`.
- New `TEXTFIELD_TO_BINDING` map lets the textfield change observer in `widgets/textfield.rs` find the binding for the textfield it fired on and toggle suppress around the user closure call.
- `state_set`'s `TEXTFIELD_BINDINGS` loop skips suppressed bindings and wraps the `setStringValue` call in `suppress=true` so nested `state_set` re-entries also short-circuit.
- `bind_textfield` now seeds the field with the current state value on registration (matches GTK4 / Windows behavior).

The reporter is on Windows v0.5.511, predating the matching Windows fix in v0.5.778 — so that platform's been good on `main` for a while. macOS was the remaining gap.

## Test plan

- [x] `cargo build --release -p perry-ui-macos -p perry-runtime -p perry-stdlib -p perry`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --release -p perry-ui-macos`
- [x] Compile + launch `test-files/test_issue_763_reactive_textfield.ts` (same scenario as the #1198 repro) — GUI window starts cleanly, no crashes
- [ ] Manual: type mid-string in the field, confirm cursor stays put (requires human at the keyboard — can't script through NSWindow input from CI)
- [ ] Manual: press "set hello world" Button, confirm field text updates to `Hello, World!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)