### PR TITLE
fix(ui-ios): #1178 wire appGroupSet/Get/Delete to UserDefaults(suiteName:)

### DIFF
--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -105,6 +105,23 @@ pub(super) fn compile_module_entry(
         if cross_module.needs_geisterhand && !is_dylib {
             llmod.declare_function("perry_geisterhand_start", VOID, &[I32]);
         }
+        // #1178 — bake `[ios] app_group` from perry.toml into a single
+        // `perry_app_group_init(ptr, len)` call at the top of `main`,
+        // before any user code runs (and before any `appGroupSet/Get/
+        // Delete` site could fire). Skipped entirely when the manifest
+        // doesn't configure a suite, so non-App-Group apps pay no extra
+        // bytes. Allocated up-front while `llmod` is still mutable —
+        // `main` claims the borrow below.
+        let app_group_init: Option<(String, usize)> = if is_dylib {
+            None
+        } else {
+            cross_module
+                .app_metadata
+                .app_group
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(|suite| llmod.add_string_constant(suite))
+        };
         let main = if is_dylib {
             llmod.define_function("perry_module_init", VOID, vec![])
         } else {
@@ -116,6 +133,14 @@ pub(super) fn compile_module_entry(
             blk.call_void("js_gc_init", &[]);
             if write_barriers_enabled() {
                 blk.call_void("js_gc_write_barriers_emitted", &[(I32, "1")]);
+            }
+            if let Some((const_name, byte_len)) = app_group_init.as_ref() {
+                let suite_ptr = format!("@{}", const_name);
+                let len_str = byte_len.to_string();
+                blk.call_void(
+                    "perry_app_group_init",
+                    &[(PTR, suite_ptr.as_str()), (I32, len_str.as_str())],
+                );
             }
             // Wire up stdlib HANDLE_METHOD_DISPATCH eagerly when stdlib is
             // linked. Previously this was only called from

--- a/crates/perry-codegen/src/codegen/opts.rs
+++ b/crates/perry-codegen/src/codegen/opts.rs
@@ -12,6 +12,14 @@ pub struct AppMetadata {
     pub version: String,
     pub build_number: i64,
     pub bundle_id: String,
+    /// iOS / macOS App Group suite name from `[ios] app_group` (or
+    /// `[macos] app_group`) in perry.toml. Baked into the entry module's
+    /// `main` prelude as a `perry_app_group_init(suite, len)` call so
+    /// `appGroupSet/Get/Delete` can resolve `UserDefaults(suiteName:)` at
+    /// runtime without re-reading the manifest. `None` means
+    /// `app_group_*` calls fall through to the runtime's "not configured"
+    /// stub-warn diagnostic. Refs #1178.
+    pub app_group: Option<String>,
 }
 
 impl Default for AppMetadata {
@@ -20,6 +28,7 @@ impl Default for AppMetadata {
             version: "1.0.0".to_string(),
             build_number: 1,
             bundle_id: "com.perry.app".to_string(),
+            app_group: None,
         }
     }
 }

--- a/crates/perry-codegen/src/runtime_decls/mod.rs
+++ b/crates/perry-codegen/src/runtime_decls/mod.rs
@@ -37,6 +37,14 @@ pub fn declare_phase1(module: &mut LlModule) {
     // Handle-method dispatcher wiring (issue #86). Stdlib provides the
     // real impl; when only runtime is linked, it's a no-op stub.
     module.declare_function("js_stdlib_init_dispatch", VOID, &[]);
+    // #1178 — App Group suite-name registration. The CLI bakes
+    // `[ios] app_group` from perry.toml into the entry module's `main`
+    // prelude as a single call to `perry_app_group_init(ptr, len)` so
+    // the iOS/macOS UserDefaults(suiteName:) FFI can resolve it
+    // without re-reading the manifest. Declared unconditionally because
+    // the runtime always provides the symbol; main only emits the call
+    // when `app_metadata.app_group` is `Some`.
+    module.declare_function("perry_app_group_init", VOID, &[PTR, I32]);
     // Function-name registry — populated by `main()` once per top-level
     // named function so `console.log(named)` prints `[Function: named]`
     // instead of `[Function (anonymous)]`. See #1202.

--- a/crates/perry-runtime/src/app_group.rs
+++ b/crates/perry-runtime/src/app_group.rs
@@ -1,0 +1,110 @@
+//! App Group suite-name registry (#1178).
+//!
+//! `perry/system :: appGroupSet/Get/Delete` on Apple platforms is backed by
+//! `UserDefaults(suiteName:)`. The suite name is project-level config
+//! (`[ios] app_group = "group.com.example.shared"` in `perry.toml`), not
+//! something the calling TypeScript code knows. The CLI bakes it into the
+//! entry module's `main()` prelude as a single
+//! `perry_app_group_init(ptr, len)` call so the platform FFI layer
+//! (`perry-ui-ios`, `perry-ui-macos`) can resolve it on every call without
+//! re-reading the manifest.
+//!
+//! When `[ios] app_group` is absent the codegen omits the call entirely;
+//! `configured_suite_name()` then returns `None` and the per-platform FFI
+//! falls back to its first-call stub-warn diagnostic so developers see a
+//! clear "not configured" hint instead of silent in-process storage.
+
+use std::sync::OnceLock;
+
+static SUITE_NAME: OnceLock<String> = OnceLock::new();
+
+/// Called once from `main()`'s prelude when `[ios] app_group` is set in
+/// `perry.toml`. `ptr` points into the entry module's rodata; the bytes
+/// outlive the process so we copy into an owned `String` for the
+/// `OnceLock`. Silently ignored on null/empty input — codegen only emits
+/// the call when the suite name resolves to a non-empty string.
+///
+/// # Safety
+/// Caller (perry-codegen entry module prelude) passes a `(ptr, len)` pair
+/// derived from `LlModule::add_string_constant`, so `ptr` is a valid
+/// non-null pointer to `len` UTF-8 bytes in the binary's rodata segment.
+#[no_mangle]
+pub unsafe extern "C" fn perry_app_group_init(ptr: *const u8, len: i32) {
+    if ptr.is_null() || len <= 0 {
+        return;
+    }
+    let slice = std::slice::from_raw_parts(ptr, len as usize);
+    let Ok(s) = std::str::from_utf8(slice) else {
+        return;
+    };
+    // `set` returns Err if already initialized — fine; the entry module
+    // calls this exactly once before user code runs.
+    let _ = SUITE_NAME.set(s.to_string());
+}
+
+/// Public Rust accessor for crates that already depend on
+/// `perry-runtime` (`perry-ui-ios` does). Returns the suite name baked
+/// in from `perry.toml`, or `None` when no `[ios] app_group` was
+/// configured at compile time.
+pub fn configured_suite_name() -> Option<&'static str> {
+    SUITE_NAME.get().map(String::as_str)
+}
+
+/// C-ABI accessor for FFI crates that intentionally avoid pulling
+/// `perry-runtime` in as a Cargo dep (e.g. `perry-ui-macos` —
+/// see `crates/perry-ui-macos/src/string_header.rs`'s rationale).
+/// Writes the byte length to `*out_len` and returns a pointer into
+/// the static buffer. Returns null + `*out_len = 0` when no suite is
+/// configured; the bytes are valid for the lifetime of the process
+/// and are NOT NUL-terminated — callers must use the returned length.
+///
+/// # Safety
+/// `out_len` must be a valid writable pointer to an `i32`.
+#[no_mangle]
+pub unsafe extern "C" fn perry_app_group_suite_name(out_len: *mut i32) -> *const u8 {
+    match SUITE_NAME.get() {
+        Some(s) => {
+            if !out_len.is_null() {
+                *out_len = s.len() as i32;
+            }
+            s.as_ptr()
+        }
+        None => {
+            if !out_len.is_null() {
+                *out_len = 0;
+            }
+            std::ptr::null()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // OnceLock means the suite name is process-global; the iOS/macOS
+    // FFI tests run in different processes, so a single in-process
+    // round-trip test is the most we can verify here.
+    #[test]
+    fn round_trips_a_set_suite_name() {
+        let suite = "group.com.perry.test";
+        unsafe {
+            perry_app_group_init(suite.as_ptr(), suite.len() as i32);
+        }
+        // OnceLock guarantees the first writer wins, so this matches even
+        // if a sibling test seeded a different value first.
+        let got = configured_suite_name().expect("init must store the suite");
+        assert!(
+            got == suite || got.starts_with("group."),
+            "expected a baked group.* suite, got {got:?}"
+        );
+    }
+
+    #[test]
+    fn null_ptr_is_a_no_op() {
+        unsafe {
+            perry_app_group_init(std::ptr::null(), 0);
+        }
+        // No panic, no assertion — `set` returns Err and we ignore it.
+    }
+}

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -21,6 +21,7 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+pub mod app_group;
 pub mod arena;
 pub mod array;
 pub mod async_context;

--- a/crates/perry-ui-android/src/ffi/system_api.rs
+++ b/crates/perry-ui-android/src/ffi/system_api.rs
@@ -39,23 +39,28 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
     );
 }
 
-// #675 — App Group stubs on Android. Native impl will use scoped
-// `SharedPreferences` keyed by `shared_prefs_name` from perry.toml,
-// dispatched through JNI; tracked as #675 follow-up.
+// #675 — App Group stubs on Android. The iOS side was wired to
+// `UserDefaults(suiteName:)` under #1178; the Android equivalent is
+// `context.getSharedPreferences("perry_shared", MODE_PRIVATE)` —
+// matching the read path the Glance widget bridge already uses in
+// `perry-codegen-glance/src/emit_glue.rs` (`sharedStorageGet`). The
+// JNI plumbing for the WRITE path needs a Kotlin-side helper on
+// `PerryBridge` plus a JNI call here; tracked as #1178 Android
+// follow-up (separate PR).
 #[no_mangle]
 pub extern "C" fn perry_system_app_group_set(_key_ptr: i64, _value_ptr: i64) {
     perry_runtime::stub_diag::perry_stub_warn(
         "perry_system_app_group_set",
-        "Android SharedPreferences not yet implemented (#675 follow-up)",
-        Some("#675"),
+        "Android SharedPreferences write path not yet implemented (#1178 Android follow-up). The Glance widget already reads `perry_shared` SharedPreferences; wiring the write side needs a Kotlin helper on PerryBridge.",
+        Some("#1178"),
     );
 }
 #[no_mangle]
 pub extern "C" fn perry_system_app_group_get(_key_ptr: i64) -> i64 {
     perry_runtime::stub_diag::perry_stub_warn(
         "perry_system_app_group_get",
-        "Android SharedPreferences not yet implemented (#675 follow-up)",
-        Some("#675"),
+        "Android SharedPreferences read path not yet implemented (#1178 Android follow-up).",
+        Some("#1178"),
     );
     extern "C" {
         fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
@@ -66,8 +71,8 @@ pub extern "C" fn perry_system_app_group_get(_key_ptr: i64) -> i64 {
 pub extern "C" fn perry_system_app_group_delete(_key_ptr: i64) {
     perry_runtime::stub_diag::perry_stub_warn(
         "perry_system_app_group_delete",
-        "Android SharedPreferences not yet implemented (#675 follow-up)",
-        Some("#675"),
+        "Android SharedPreferences delete path not yet implemented (#1178 Android follow-up).",
+        Some("#1178"),
     );
 }
 

--- a/crates/perry-ui-ios/src/ffi/system.rs
+++ b/crates/perry-ui-ios/src/ffi/system.rs
@@ -33,17 +33,16 @@ pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
     );
 }
 
-// #675 — App Group / cross-process shared storage on iOS. MVP uses
-// an in-process HashMap so the API is exercisable from user code;
-// the native impl (UserDefaults(suiteName:) read from
-// `application-groups` entitlement) is tracked under #675 follow-up.
-// First call per process per symbol prints a `[perry] warning` line
-// so developers know they're not getting cross-process behavior yet.
-fn app_group_store_ios() -> &'static std::sync::Mutex<std::collections::HashMap<String, String>> {
-    static STORE: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, String>>> =
-        std::sync::OnceLock::new();
-    STORE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
-}
+// #675 + #1178 — App Group / cross-process shared storage on iOS.
+//
+// Backed by `NSUserDefaults(suiteName:)`. The suite name is baked
+// into `main()`'s prelude by the CLI from `[ios] app_group` in
+// perry.toml (see `perry-runtime::app_group::perry_app_group_init`)
+// so widget extensions sharing the same App Group container can read
+// keys written here. When no suite is configured we emit a one-shot
+// stub-warn diagnostic naming the missing `[ios] app_group` key so
+// developers see why the widget can't see the value, rather than a
+// silent in-process HashMap that lies about cross-process behavior.
 fn app_group_str_from_header_ios(ptr: *const u8) -> &'static str {
     if ptr.is_null() {
         return "";
@@ -55,20 +54,51 @@ fn app_group_str_from_header_ios(ptr: *const u8) -> &'static str {
         std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
     }
 }
+
+/// Resolve the configured App Group suite, warning once per process
+/// when no `[ios] app_group` was baked in. Returns `None` so the
+/// caller can short-circuit before reaching for `UserDefaults`.
+fn app_group_suite_ios() -> Option<objc2::rc::Retained<objc2_foundation::NSString>> {
+    let suite = perry_runtime::app_group::configured_suite_name()?;
+    Some(objc2_foundation::NSString::from_str(suite))
+}
+
+fn warn_app_group_not_configured(symbol: &'static str) {
+    perry_runtime::stub_diag::perry_stub_warn(
+        symbol,
+        "App Group not configured. Add `[ios] app_group = \"group.com.example.shared\"` to perry.toml (#1178).",
+        Some("#1178"),
+    );
+}
+
+unsafe fn app_group_defaults_ios() -> *mut objc2::runtime::AnyObject {
+    let Some(suite) = app_group_suite_ios() else {
+        return std::ptr::null_mut();
+    };
+    let cls = objc2::runtime::AnyClass::get(c"NSUserDefaults").unwrap();
+    let alloc: *mut objc2::runtime::AnyObject = objc2::msg_send![cls, alloc];
+    let defaults: *mut objc2::runtime::AnyObject =
+        objc2::msg_send![alloc, initWithSuiteName: &*suite];
+    defaults
+}
+
 #[no_mangle]
 pub extern "C" fn perry_system_app_group_set(key_ptr: i64, value_ptr: i64) {
-    perry_runtime::stub_diag::perry_stub_warn(
-        "perry_system_app_group_set",
-        "iOS App Group is an in-process HashMap in this MVP (#675 follow-up: UserDefaults(suiteName:))",
-        Some("#675"),
-    );
     let key = app_group_str_from_header_ios(key_ptr as *const u8);
     let value = app_group_str_from_header_ios(value_ptr as *const u8);
     if key.is_empty() {
         return;
     }
-    if let Ok(mut g) = app_group_store_ios().lock() {
-        g.insert(key.to_string(), value.to_string());
+    unsafe {
+        let defaults = app_group_defaults_ios();
+        if defaults.is_null() {
+            warn_app_group_not_configured("perry_system_app_group_set");
+            return;
+        }
+        let ns_key = objc2_foundation::NSString::from_str(key);
+        let ns_value = objc2_foundation::NSString::from_str(value);
+        let _: () = objc2::msg_send![defaults, setObject: &*ns_value, forKey: &*ns_key];
+        let _: () = objc2::msg_send![defaults, synchronize];
     }
 }
 #[no_mangle]
@@ -76,16 +106,34 @@ pub extern "C" fn perry_system_app_group_get(key_ptr: i64) -> i64 {
     extern "C" {
         fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
     }
+    let empty = || unsafe { js_string_from_bytes(std::ptr::null(), 0) };
     let key = app_group_str_from_header_ios(key_ptr as *const u8);
     if key.is_empty() {
-        return unsafe { js_string_from_bytes(std::ptr::null(), 0) };
+        return empty();
     }
-    let value = app_group_store_ios()
-        .lock()
-        .ok()
-        .and_then(|g| g.get(key).cloned())
-        .unwrap_or_default();
-    unsafe { js_string_from_bytes(value.as_ptr(), value.len() as i32) }
+    unsafe {
+        let defaults = app_group_defaults_ios();
+        if defaults.is_null() {
+            warn_app_group_not_configured("perry_system_app_group_get");
+            return empty();
+        }
+        let ns_key = objc2_foundation::NSString::from_str(key);
+        let value: *mut objc2::runtime::AnyObject =
+            objc2::msg_send![defaults, stringForKey: &*ns_key];
+        if value.is_null() {
+            return empty();
+        }
+        let utf8_ptr: *const u8 = objc2::msg_send![value, UTF8String];
+        if utf8_ptr.is_null() {
+            return empty();
+        }
+        // NSUTF8StringEncoding = 4
+        let utf8_len: usize = objc2::msg_send![value, lengthOfBytesUsingEncoding: 4u64];
+        if utf8_len == 0 {
+            return empty();
+        }
+        js_string_from_bytes(utf8_ptr, utf8_len as i32)
+    }
 }
 #[no_mangle]
 pub extern "C" fn perry_system_app_group_delete(key_ptr: i64) {
@@ -93,8 +141,15 @@ pub extern "C" fn perry_system_app_group_delete(key_ptr: i64) {
     if key.is_empty() {
         return;
     }
-    if let Ok(mut g) = app_group_store_ios().lock() {
-        g.remove(key);
+    unsafe {
+        let defaults = app_group_defaults_ios();
+        if defaults.is_null() {
+            warn_app_group_not_configured("perry_system_app_group_delete");
+            return;
+        }
+        let ns_key = objc2_foundation::NSString::from_str(key);
+        let _: () = objc2::msg_send![defaults, removeObjectForKey: &*ns_key];
+        let _: () = objc2::msg_send![defaults, synchronize];
     }
 }
 

--- a/crates/perry-ui-macos/src/lib_ffi/system.rs
+++ b/crates/perry-ui-macos/src/lib_ffi/system.rs
@@ -104,18 +104,40 @@ unsafe fn present_sharing_picker(items: *mut objc2::runtime::AnyObject) {
     ];
 }
 
-// #675 — App Group / cross-process shared storage on macOS.
+// #675 + #1178 — App Group / cross-process shared storage on macOS.
 //
-// Backed by `NSUserDefaults(suiteName:)`. The suite name is read
-// from the `PERRY_APP_GROUP` environment variable so an app's
-// signing identity can override the default without a recompile;
-// when unset, falls back to `"group.perryapp"` which is fine for
-// the dev flow (no entitlement → the suite simply lives under
-// `~/Library/Preferences/group.perryapp.plist` instead of inside
-// the shared App Group container).
+// Backed by `NSUserDefaults(suiteName:)`. Resolution order:
+//   1. `[ios] app_group` / `[macos] app_group` baked in from
+//      `perry.toml` (the #1178 path — codegen calls
+//      `perry_app_group_init` in `main`'s prelude).
+//   2. `PERRY_APP_GROUP` environment override (predates #1178; kept
+//      for dev/CI flows that flip the suite per-run without
+//      regenerating the binary).
+//   3. `"group.perryapp"` fallback so the dev flow still works
+//      without any config — no entitlement → the suite simply lives
+//      under `~/Library/Preferences/group.perryapp.plist` instead of
+//      inside the shared App Group container.
 
 fn app_group_suite() -> objc2::rc::Retained<objc2_foundation::NSString> {
-    let suite = std::env::var("PERRY_APP_GROUP").unwrap_or_else(|_| "group.perryapp".to_string());
+    // perry-ui-macos intentionally avoids a Cargo dep on perry-runtime
+    // (see `string_header.rs`'s comment). Reach for the suite name via
+    // the C-ABI shim instead.
+    extern "C" {
+        fn perry_app_group_suite_name(out_len: *mut i32) -> *const u8;
+    }
+    let baked = unsafe {
+        let mut len: i32 = 0;
+        let ptr = perry_app_group_suite_name(&mut len as *mut i32);
+        if ptr.is_null() || len <= 0 {
+            None
+        } else {
+            let slice = std::slice::from_raw_parts(ptr, len as usize);
+            std::str::from_utf8(slice).ok().map(str::to_string)
+        }
+    };
+    let suite = baked
+        .or_else(|| std::env::var("PERRY_APP_GROUP").ok())
+        .unwrap_or_else(|| "group.perryapp".to_string());
     objc2_foundation::NSString::from_str(&suite)
 }
 

--- a/crates/perry/src/commands/compile/app_metadata.rs
+++ b/crates/perry/src/commands/compile/app_metadata.rs
@@ -87,6 +87,21 @@ pub(super) fn read_app_metadata(
         if let Some(build_number) = toml_build_number(doc) {
             metadata.build_number = build_number;
         }
+        // #1178 — App Group suite name. Resolution order: target-specific
+        // section (`[ios]` / `[macos]`) → generic `[app] app_group` →
+        // top-level `app_group`. The section preference for Apple targets
+        // mirrors how `bundle_id` is resolved above; non-Apple targets
+        // still see the value so `[android] app_group` can flow through
+        // once the SharedPreferences backend lands.
+        let target_section = target_bundle_section(target);
+        metadata.app_group = target_section
+            .and_then(|section| toml_string(doc, section, "app_group"))
+            .or_else(|| toml_string(doc, "app", "app_group"))
+            .or_else(|| {
+                doc.get("app_group")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            });
     }
 
     metadata.bundle_id = cli_bundle_id
@@ -203,6 +218,53 @@ bundle_id = "com.example.project"
         assert_eq!(metadata.version, "1.0.0");
         assert_eq!(metadata.build_number, 7);
         assert_eq!(metadata.bundle_id, "com.example.cli");
+    }
+
+    #[test]
+    fn reads_ios_app_group_from_target_section() {
+        // #1178 — `[ios] app_group` is the canonical place to declare the
+        // App Group suite name; it should win over the generic `[app]`
+        // fallback for an iOS target.
+        let dir = tempfile::tempdir().unwrap();
+        let doc = parse(
+            r#"
+[ios]
+app_group = "group.com.example.shared"
+
+[app]
+app_group = "group.com.example.fallback"
+"#,
+        );
+        let input = dir.path().join("main.ts");
+        std::fs::write(&input, "console.log('x')").unwrap();
+
+        let ios = read_app_metadata(Some(&doc), &input, Some("ios"), None);
+        assert_eq!(ios.app_group.as_deref(), Some("group.com.example.shared"));
+
+        // No-target build (host = macOS in CI) should still pick the
+        // `[macos]` or fall back to `[app]` when the target section is
+        // absent — here only `[app]` provides a value for the implicit
+        // host target.
+        let host = read_app_metadata(Some(&doc), &input, None, None);
+        // macOS host: `[macos]` is absent, so `[app]` wins.
+        if cfg!(target_os = "macos") {
+            assert_eq!(
+                host.app_group.as_deref(),
+                Some("group.com.example.fallback")
+            );
+        }
+    }
+
+    #[test]
+    fn missing_app_group_is_none() {
+        // No perry.toml at all → app_group stays None, which the codegen
+        // prelude reads as "skip the perry_app_group_init() call" and the
+        // runtime treats as "stub-warn on first appGroupSet".
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("main.ts");
+        std::fs::write(&input, "console.log('x')").unwrap();
+        let metadata = read_app_metadata(None, &input, Some("ios"), None);
+        assert!(metadata.app_group.is_none());
     }
 
     #[test]

--- a/crates/perry/src/commands/compile/apple_info_plist.rs
+++ b/crates/perry/src/commands/compile/apple_info_plist.rs
@@ -194,6 +194,66 @@ pub(super) fn inject_google_auth_info_plist(
     ))
 }
 
+/// #1178 — write (or augment) `app.entitlements` with the
+/// `com.apple.security.application-groups` array when
+/// `[ios] app_group` is configured in perry.toml.
+///
+/// Idempotent with `inject_ios_deeplinks`: if the deeplinks pass
+/// already wrote an entitlements file (e.g. associated-domains for
+/// `applinks:`), we splice our `<key>...</key><array>...</array>`
+/// before the closing `</dict>` instead of clobbering it. Otherwise
+/// we emit the full plist wrapper. Either way the user's signing
+/// pipeline picks up a single `app.entitlements` file at codesign
+/// time.
+pub(super) fn inject_ios_app_group_entitlement(
+    app_dir: &std::path::Path,
+    app_group: Option<&str>,
+    format: OutputFormat,
+) -> Option<()> {
+    let app_group = app_group.filter(|s| !s.is_empty())?;
+    let entitlements_path = app_dir.join("app.entitlements");
+
+    let key_block = format!(
+        "    <key>com.apple.security.application-groups</key>\n    <array>\n        <string>{}</string>\n    </array>\n",
+        app_group
+    );
+
+    let new_contents = match fs::read_to_string(&entitlements_path) {
+        Ok(existing) => {
+            // Already declared? leave the user's hand-written or
+            // deeplinks-injected entry alone.
+            if existing.contains("com.apple.security.application-groups") {
+                return Some(());
+            }
+            existing.replace(
+                "</dict>\n</plist>",
+                &format!("{}</dict>\n</plist>", key_block),
+            )
+        }
+        Err(_) => {
+            format!(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n{}</dict>\n</plist>\n",
+                key_block
+            )
+        }
+    };
+
+    fs::write(&entitlements_path, new_contents).ok()?;
+
+    if let OutputFormat::Text = format {
+        println!(
+            "  App Group: {} → {} (#1178)",
+            app_group,
+            entitlements_path.display()
+        );
+        println!(
+            "  Sign with: codesign --entitlements {} ...",
+            entitlements_path.display()
+        );
+    }
+    Some(())
+}
+
 /// Cheap CFBundleIdentifier extraction from an in-memory Info.plist string.
 /// We need it for the CFBundleURLName field (Apple's convention is
 /// `<bundle-id>.<scheme>`). Falls back to `perry.deeplink` when the

--- a/crates/perry/src/commands/compile/bundle_ios.rs
+++ b/crates/perry/src/commands/compile/bundle_ios.rs
@@ -16,7 +16,9 @@ use anyhow::Result;
 
 use crate::OutputFormat;
 
-use super::apple_info_plist::{inject_google_auth_info_plist, inject_ios_deeplinks};
+use super::apple_info_plist::{
+    inject_google_auth_info_plist, inject_ios_app_group_entitlement, inject_ios_deeplinks,
+};
 use super::targets::compile_metallib_for_bundle;
 use super::widget_build;
 use super::CompilationContext;
@@ -454,6 +456,14 @@ pub(super) fn build_ios_app_bundle(
     // automatically when present alongside the .app bundle.
     let info_plist =
         inject_ios_deeplinks(&info_plist, &input, &app_dir, format).unwrap_or(info_plist);
+
+    // #1178 — augment `app.entitlements` with the
+    // `com.apple.security.application-groups` array when
+    // `[ios] app_group` is set in perry.toml. Idempotent with the
+    // deeplinks pass above — it only adds our key, leaving any
+    // existing entitlements (associated-domains, hand-written
+    // entries) intact.
+    inject_ios_app_group_entitlement(&app_dir, ctx.app_metadata.app_group.as_deref(), format);
 
     // #1138 — `[google_auth]` block in perry.toml feeds the
     // GoogleSignIn SDK via Info.plist keys the Swift bridge in


### PR DESCRIPTION
## Summary

Closes #1178. Replaces the iOS in-process HashMap stub for `appGroupSet/Get/Delete` with real `UserDefaults(suiteName:)` calls so widget extensions sharing the App Group container can read values the host writes.

- New `[ios] app_group` / `[macos] app_group` key in `perry.toml` is baked into `main`'s prelude as `perry_app_group_init(ptr, len)` (skipped when the manifest doesn't set it — no overhead).
- New `perry-runtime::app_group` module stores the suite in a process-global `OnceLock` and exposes a C-ABI shim so `perry-ui-macos` (which intentionally has no perry-runtime Cargo dep) can read it.
- iOS path emits a clearer "App Group not configured. Add `[ios] app_group = ...` to perry.toml (#1178)" stub-warn when the suite is missing, instead of silently lying via the HashMap.
- macOS resolution order is now: baked suite → `PERRY_APP_GROUP` env override → `group.perryapp` fallback. Existing dev/CI knobs keep working.
- `bundle_ios.rs` auto-writes (or augments) `app.entitlements` with `com.apple.security.application-groups` so codesign picks it up without manual editing. Idempotent with the existing deeplinks-injected entitlements file.
- Android stubs updated to point at a `#1178` follow-up — the JNI write path needs a Kotlin helper; deferred to a separate PR. The Glance widget already reads `perry_shared` `SharedPreferences` so the read side is wired.

## Test plan

- [x] `cargo test --release -p perry-runtime --lib app_group` — 2 new tests pass (round-trip + null-ptr no-op).
- [x] `cargo test --release -p perry --bin perry app_metadata` — 2 new tests pass (`reads_ios_app_group_from_target_section`, `missing_app_group_is_none`) alongside the 3 existing ones.
- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry-codegen -p perry-ui-macos -p perry` — clean.
- [x] `cargo check -p perry-ui-ios --target aarch64-apple-ios-sim` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] End-to-end on macOS: compile a program that calls `appGroupSet("k", "v")` with `[ios] app_group = "group.com.perry.test1178"` in perry.toml → `defaults read group.com.perry.test1178` returns the value from a separate process (the cross-process visibility the issue was blocked on).