### PR TITLE
fix(android): unblock build path — bionic libc + Kotlin 2.0 (refs #1160)

### DIFF
--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -387,7 +387,7 @@ pub extern "C" fn js_os_loadavg() -> *mut ArrayHeader {
     use crate::array::{js_array_alloc, js_array_push_f64};
 
     let arr = js_array_alloc(3);
-    #[cfg(unix)]
+    #[cfg(all(unix, not(target_os = "android")))]
     {
         let mut loads = [0.0_f64; 3];
         unsafe {
@@ -401,8 +401,10 @@ pub extern "C" fn js_os_loadavg() -> *mut ArrayHeader {
         }
         result
     }
-    #[cfg(not(unix))]
+    #[cfg(not(all(unix, not(target_os = "android"))))]
     {
+        // Android's bionic libc does not provide getloadavg(3); Node's
+        // os.loadavg() returns [0, 0, 0] there too, so match that.
         let mut result = arr;
         for _ in 0..3 {
             result = js_array_push_f64(result, 0.0);

--- a/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryBridge.kt
+++ b/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryBridge.kt
@@ -585,10 +585,11 @@ object PerryBridge {
             uiHandler.post { requestGeolocationPermission(callbackKey) }
             return
         }
-        val granted = ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
-                == PackageManager.PERMISSION_GRANTED ||
-            ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_COARSE_LOCATION)
-                == PackageManager.PERMISSION_GRANTED
+        val granted =
+            ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION) ==
+                PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+                PackageManager.PERMISSION_GRANTED
         if (granted) {
             nativeInvokeCallbackWithString(callbackKey, "granted")
         } else {
@@ -1760,8 +1761,8 @@ object PerryBridge {
 
     private inline fun <reified T : android.text.style.CharacterStyle> richTextToggleSpan(
         et: EditText,
-        factory: () -> T,
-        matches: (T) -> Boolean
+        crossinline factory: () -> T,
+        crossinline matches: (T) -> Boolean,
     ) {
         uiHandler.post {
             val editable = et.text ?: return@post


### PR DESCRIPTION
## Summary

Two unrelated build-time errors prevent `cargo build --target aarch64-linux-android` and `./gradlew assembleDebug` from succeeding on a clean tree. Both surfaced while trying to reproduce #1160 — without them the repro can't reach `nativeMain`.

- **perry-runtime: `libc::getloadavg` missing on bionic** — `js_os_loadavg` calls `libc::getloadavg`, which Android's bionic libc does not provide. Gate the unix branch with `not(target_os = "android")` and route Android through the zero-fallback that already existed for non-unix targets. Matches Node's `os.loadavg()` (returns `[0,0,0]` on Android).
- **perry-ui-android template `PerryBridge.kt` Kotlin 2.0 errors**:
  - `requestGeolocationPermission`: multi-line `||` expression with `==` at the start of the continuation line — Kotlin 2.0 terminates the statement at the `)` of the first line, so the rest parses as a fresh expression and `if (granted)` sees an `Int`. Restructured so each line ends with the dangling operator.
  - `richTextToggleSpan` inline fun passes `factory` and `matches` lambdas into a `uiHandler.post { ... }` block — Kotlin 2.0 requires `crossinline` on lambdas that may be invoked from a different scope. Added.

## Scope

**Does NOT fix #1160 itself.** The HWUI destroyed-mutex SIGABRT is downstream of these and needs the actual repro path open before it can be debugged. Filing this as a `refs #1160` PR rather than `fixes #1160`.

After these two changes:
- `cargo build --release -p perry-runtime --target aarch64-linux-android` succeeds.
- `./gradlew assembleDebug` succeeds.
- APK installs and the Activity launches on a Pixel API 35 emulator.

(There is still a third blocker hit in my environment — `dlopen failed: TLS symbol "(null)" using IE access model` — that's distinct from both this PR and #1160; it appears to be a toolchain/NDK setup difference and is not addressed here.)

## Test plan

- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry-ui-android --target aarch64-linux-android`
- [x] `cargo fmt --all -- --check`
- [x] `perry main.ts --target android -o main_android` produces an `.so`
- [x] `./gradlew assembleDebug` in the generated `android-build/` succeeds and produces `app-debug.apk`
- [x] `adb install` + `am start` reach `PerryActivity.startNative()`
- [ ] **#1160 destroyed-mutex repro still occurs after this PR** — needs a reviewer in an environment where the dlopen succeeds.