### PR TITLE
fix(fastify): #1240 request.json() returns parsed body

### DIFF
--- a/crates/perry-ext-fastify/src/context.rs
+++ b/crates/perry-ext-fastify/src/context.rs
@@ -453,6 +453,16 @@ pub unsafe extern "C" fn js_fastify_reply_send(ctx_handle: Handle, data: f64) ->
 /// `c.json(data, status?)`.
 #[no_mangle]
 pub unsafe extern "C" fn js_fastify_ctx_json(ctx_handle: Handle, data: f64, status: f64) -> f64 {
+    // #1240 — `request.json()` (Fetch API) shares the dispatch slot with
+    // `reply.json(data)` / `c.json(data, status)` because both receivers are
+    // backed by the same FastifyContext handle. A zero-arg call from user code
+    // arrives here with `data` padded to NaN-boxed undefined; in that case route
+    // to `js_fastify_req_json` so existing Fetch-style codebases keep working
+    // without touching `request.body`.
+    if data.to_bits() == TAG_UNDEFINED {
+        return js_fastify_req_json(ctx_handle);
+    }
+
     if let Some(ctx) = get_handle_mut::<FastifyContext>(ctx_handle) {
         if status > 0.0 {
             ctx.status_code = status as u16;

--- a/crates/perry-stdlib/src/fastify/context.rs
+++ b/crates/perry-stdlib/src/fastify/context.rs
@@ -535,6 +535,16 @@ pub unsafe extern "C" fn js_fastify_reply_send(ctx_handle: Handle, data: f64) ->
 /// Returns a response marker value
 #[no_mangle]
 pub unsafe extern "C" fn js_fastify_ctx_json(ctx_handle: Handle, data: f64, status: f64) -> f64 {
+    // #1240 — `request.json()` (Fetch API) shares the dispatch slot with
+    // `reply.json(data)` / `c.json(data, status)` because both receivers are
+    // backed by the same FastifyContext handle. A zero-arg call from user code
+    // arrives here with `data` padded to NaN-boxed undefined; in that case route
+    // to `js_fastify_req_json` so existing Fetch-style codebases keep working
+    // without touching `request.body`.
+    if data.to_bits() == JSValue::undefined().bits() {
+        return js_fastify_req_json(ctx_handle);
+    }
+
     if let Some(ctx) = get_handle_mut::<FastifyContext>(ctx_handle) {
         if status > 0.0 {
             ctx.status_code = status as u16;

--- a/test-files/run_test_issue_1240.sh
+++ b/test-files/run_test_issue_1240.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Wire-level regression harness for issue #1240 — fastify request.json()
+# returns parsed body instead of undefined.
+# See test_issue_1240_fastify_request_json.ts for the bug writeup.
+#
+# Usage:
+#   PERRY_BIN=./target/release/perry ./test-files/run_test_issue_1240.sh
+#
+# Assertion: POST /json-test with `{"hello":"world"}` returns a JSON body
+# containing `"hasHelloKey":true` and `"hello":"world"`. Pre-fix the
+# response was `{"parsedIsUndefined":true,...}` (and the body was actually
+# the literal string `"undefined"` because the c.json shim was running by
+# mistake — the test server here would still 200 because the handler
+# returns its diagnostic object instead of routing through reply.send).
+
+set -euo pipefail
+
+PERRY_BIN="${PERRY_BIN:-./target/release/perry}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_SRC="$SCRIPT_DIR/test_issue_1240_fastify_request_json.ts"
+PORT=18997
+EXE="${TMPDIR:-/tmp}/test_issue_1240_fastify_request_json"
+
+cd "$WORKSPACE_ROOT"
+
+if [[ ! -x "$PERRY_BIN" ]]; then
+    echo "FAIL: perry binary not found at $PERRY_BIN — build first via cargo build --release -p perry" >&2
+    exit 1
+fi
+
+echo "[1240] compiling fixture..."
+PERRY_ALLOW_PERRY_FEATURES=1 "$PERRY_BIN" "$TEST_SRC" -o "$EXE" >/dev/null 2>&1
+
+echo "[1240] starting server on :$PORT..."
+"$EXE" >/dev/null 2>&1 &
+SERVER_PID=$!
+trap 'kill $SERVER_PID 2>/dev/null; wait $SERVER_PID 2>/dev/null || true' EXIT
+
+# Wait for bind.
+for i in 1 2 3 4 5 6 7 8; do
+    if curl -sS -o /dev/null --max-time 1 -X POST "http://127.0.0.1:$PORT/json-test" \
+        -H 'Content-Type: application/json' -d '{"_":0}' 2>/dev/null; then
+        break
+    fi
+    sleep 0.1
+done
+
+fail=0
+RESPONSE="$(curl -sS --max-time 2 -X POST "http://127.0.0.1:$PORT/json-test" \
+    -H 'Content-Type: application/json' -d '{"hello":"world"}')"
+
+echo "[1240] response=$RESPONSE"
+
+if [[ "$RESPONSE" != *'"hasHelloKey":true'* ]]; then
+    echo "[1240] FAIL — request.json() did not parse body (pre-fix: undefined)"
+    fail=1
+fi
+if [[ "$RESPONSE" != *'"hello":"world"'* ]]; then
+    echo "[1240] FAIL — parsed body lost the 'hello' key"
+    fail=1
+fi
+if [[ "$RESPONSE" == *'"parsedIsUndefined":true'* ]]; then
+    echo "[1240] FAIL — request.json() returned undefined (regression of #1240)"
+    fail=1
+fi
+
+if [[ $fail -eq 0 ]]; then
+    echo "[1240] PASS"
+    exit 0
+else
+    exit 1
+fi

--- a/test-files/test_issue_1240_fastify_request_json.ts
+++ b/test-files/test_issue_1240_fastify_request_json.ts
@@ -1,0 +1,39 @@
+// Issue #1240 — fastify `request.json()` returns `undefined` (silent 400).
+//
+// Before the fix, the native dispatch table routed the `json` method to
+// `js_fastify_ctx_json` (the Hono-style `c.json(data, status?)` reply
+// helper). When user code wrote `request.json()` with no args, the codegen
+// padded the missing `data` slot with NaN-boxed `undefined` and the runtime
+// shim happily serialized `"undefined"` as the response body AND set
+// `ctx.sent = true`, silently 400-ing every POST endpoint.
+//
+// Fix (perry-stdlib + perry-ext-fastify): `js_fastify_ctx_json` now detects
+// the zero-arg shape (`data == NaN-boxed undefined`) and routes to
+// `js_fastify_req_json`, matching the Fetch API `Request.json()` semantics
+// the user's codebase relies on.
+//
+// Wire-level assertion: POST a JSON payload, return the parsed object, and
+// verify the round-trip arrived intact. Pre-fix the response was
+// `{"viaJsonUndefined":true}`; post-fix it has the parsed key.
+
+import Fastify from "fastify";
+
+const PORT = 18997;
+const app = Fastify({ logger: false });
+
+app.post("/json-test", async (request, _reply) => {
+    const parsed = request.json();
+    return {
+        typeofParsed: typeof parsed,
+        parsedIsUndefined: parsed === undefined,
+        hasHelloKey:
+            parsed !== null &&
+            parsed !== undefined &&
+            typeof parsed === "object" &&
+            "hello" in (parsed as Record<string, unknown>),
+        hello: (parsed as { hello?: string })?.hello ?? null,
+    };
+});
+
+await app.listen({ port: PORT, host: "127.0.0.1" });
+console.log(`listening on :${PORT}`);


### PR DESCRIPTION
## Summary

- `request.json()` (Fetch API) now returns the parsed JSON body instead of `undefined`. Previously every POST handler that used the Fetch-style accessor silently 400-ed because the same native dispatch slot drove both `request.json()` and `reply.json(data, status?)` and the zero-arg call landed in the reply shim.
- Disambiguation moves to runtime (zero-arg ⇒ `data == NaN-boxed undefined` ⇒ route to `js_fastify_req_json`). The native dispatch table can't distinguish request from reply because both receivers are backed by the same `FastifyContext` handle.
- Applied symmetrically in `crates/perry-stdlib/src/fastify/context.rs` and `crates/perry-ext-fastify/src/context.rs` (duplicate shims).

Closes #1240

## Root cause

The native_table entry for `json` is `js_fastify_ctx_json(handle, data, status)`. When user code wrote `request.json()` with no args, codegen padded the two missing slots with NaN-boxed `undefined`. The shim still ran the reply path: it serialized the string `"undefined"` as the response body and set `ctx.sent = true`, which is why downstream `reply.status(400).send(...)` chains came back with literal `null` bodies — the response had already been "sent" by the bogus serializer.

## Test plan

- [x] `./test-files/run_test_issue_1240.sh` (new) — wire-level POST to a route that returns `request.json()`, asserts the parsed `hello:world` key round-trips.
- [x] Local repro from issue: typed `request.json()` returns `{typeof: "object", hello: "world"}`.
- [ ] CI: lint / cargo-test / api-docs-drift / security-audit (pending).

## Known follow-up (not in this PR)

The issue's repro uses `(request as any).json()`. With `as any` the codegen drops the Fastify type tag, so the call doesn't reach the native dispatch table at all — it routes through the dynamic `js_handle_method_dispatch` path instead. That path already maps `json` → `js_fastify_req_json` but the receiver shape coming through `any` doesn't currently let the handle id round-trip cleanly. Fixing that needs a separate change in the `any`-typed property/method-call lowering. This PR closes the typed-receiver hole, which is the dominant one in real codebases that use `@types/fastify`.