### PR TITLE
fix(runtime): close #1247 #1250 #1251 util.inspect.custom hook gaps

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -596,22 +596,15 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                     let obj_ptr = ptr as *const crate::object::ObjectHeader;
                     let keys_array = (*obj_ptr).keys_array;
 
-                    let body_str = if !keys_array.is_null()
-                        && (keys_array as usize) > 0x10000
-                        && ((keys_array as u64) >> 48) == 0
-                    {
-                        format_object_as_json(obj_ptr, depth)
-                    } else {
-                        // No keys_array → either a freshly-allocated empty
-                        // object or an object whose keys are not tracked
-                        // through this slot. Node's `console.log` /
-                        // `util.inspect` prints `{}` for empty objects;
-                        // `String(obj)` / template-literal coercion print
-                        // `[object Object]` and go through
-                        // `js_jsvalue_to_string` (a separate path), so
-                        // returning `{}` here doesn't break that contract.
-                        "{}".to_string()
-                    };
+                    // Always route through `format_object_as_json` so the
+                    // `[util.inspect.custom]` hook lookup runs even for
+                    // objects with no string-keyed fields (#1247 / #1252):
+                    // an object whose only own key is the inspect symbol
+                    // has `keys_array == null` and the prior fast-path
+                    // skipped the hook entirely, printing `{}`. The
+                    // formatter itself short-circuits to `{}` when no
+                    // hook fires and the keys_array is empty.
+                    let body_str = format_object_as_json(obj_ptr, depth);
                     inspect_finish_circular(ptr as usize, body_str)
                 } else if gc_type == crate::gc::GC_TYPE_MAP {
                     "Map {}".to_string()
@@ -761,11 +754,33 @@ unsafe fn format_object_as_json(
                 }
                 let closure_ptr = val_ptr as *const crate::closure::ClosureHeader;
                 let _guard = InspectCustomInspectGuard::new(false);
-                let ret = crate::closure::js_closure_call0(closure_ptr);
+                // Node invokes the hook as `hook.call(this, depth, options, inspect)`
+                // — see #1247. `depth` is the REMAINING recursion budget (counts
+                // down from `util.inspect`'s `depth` option, default 2). Perry's
+                // internal `depth` counts UP from 0 so we invert it. `options`
+                // is a placeholder object — populating its fields properly is
+                // its own follow-up. `inspect` is undefined since we don't yet
+                // expose a JS-callable equivalent.
+                let remaining = inspect_depth_limit().saturating_sub(depth) as f64;
+                let options_obj = crate::object::js_object_alloc(0, 0);
+                let options_arg = crate::value::js_nanbox_pointer(options_obj as i64);
+                let undef_arg = f64::from_bits(crate::value::TAG_UNDEFINED);
+                let ret = crate::closure::js_closure_call3(
+                    closure_ptr,
+                    remaining,
+                    options_arg,
+                    undef_arg,
+                );
                 let ret_jv = crate::value::JSValue::from_bits(ret.to_bits());
                 if ret_jv.is_any_string() {
                     return jsvalue_string_content(ret).unwrap_or_default();
                 }
+                // #1251: non-string return values count as one nesting
+                // level — but the hook itself was reached from the
+                // formatter at `depth`, so the return value's nested
+                // structure starts at `depth` (NOT `depth + 1`). Node
+                // ends up truncating `[Object]` at the same boundary
+                // because both formatters increment by 1 per descent.
                 return format_jsvalue(ret, depth);
             }
         }

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -306,6 +306,38 @@ pub extern "C" fn js_object_define_property(
         if obj.is_null() {
             return obj_value;
         }
+        // #1250: when the key is a Symbol, route into the symbol side
+        // table (`SYMBOL_PROPERTIES`) the same way `obj[sym] = value`
+        // does. Without this, `Object.defineProperty(obj, sym, ...)`
+        // would drop the symbol and try to coerce it to a string,
+        // which is exactly the failure mode reported for
+        // `Object.defineProperty(obj, inspect.custom, …)`.
+        let key_bits = key_value.to_bits();
+        let key_tag = key_bits & 0xFFFF_0000_0000_0000;
+        if key_tag == 0x7FFD_0000_0000_0000 {
+            let raw_ptr = (key_bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::symbol::SymbolHeader;
+            if !raw_ptr.is_null()
+                && (raw_ptr as usize) >= 0x1000
+                && (*raw_ptr).magic == crate::symbol::SYMBOL_MAGIC
+            {
+                let desc_ptr = extract_obj_ptr(descriptor_value);
+                if !desc_ptr.is_null() {
+                    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+                    let value_field = js_object_get_field_by_name(
+                        desc_ptr as *const ObjectHeader,
+                        value_key,
+                    );
+                    if !value_field.is_undefined() {
+                        crate::symbol::js_object_set_symbol_property(
+                            obj_value,
+                            key_value,
+                            f64::from_bits(value_field.bits()),
+                        );
+                    }
+                }
+                return obj_value;
+            }
+        }
         // Extract key string
         let key_str = crate::builtins::js_string_coerce(key_value);
         if key_str.is_null() {

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -323,10 +323,8 @@ pub extern "C" fn js_object_define_property(
                 let desc_ptr = extract_obj_ptr(descriptor_value);
                 if !desc_ptr.is_null() {
                     let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
-                    let value_field = js_object_get_field_by_name(
-                        desc_ptr as *const ObjectHeader,
-                        value_key,
-                    );
+                    let value_field =
+                        js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);
                     if !value_field.is_undefined() {
                         crate::symbol::js_object_set_symbol_property(
                             obj_value,

--- a/test-parity/node-suite/util/inspect/custom-hook-args.ts
+++ b/test-parity/node-suite/util/inspect/custom-hook-args.ts
@@ -1,0 +1,30 @@
+import { inspect } from "node:util";
+
+// #1247: hook receives (depth, options, inspect). depth is the remaining
+// budget (default 2 at top level).
+const depthHook: any = {
+  [inspect.custom](depth: number) {
+    return depth === null ? "<no-depth>" : "depth=" + depth;
+  },
+};
+console.log(depthHook);
+
+// String-return hook flows verbatim.
+const strHook: any = { [inspect.custom]: () => "<plain-string>" };
+console.log(strHook);
+
+// #1251: non-string hook return recurses with the standard depth cap so
+// `[Object]` truncation matches Node.
+const nestedHook: any = {
+  [inspect.custom]: () => ({ x: { y: { z: { w: 1 } } } }),
+};
+console.log(nestedHook);
+
+// #1250: Object.defineProperty with a symbol key routes into the
+// symbol side-table.
+const defined: any = { name: "x" };
+Object.defineProperty(defined, inspect.custom, {
+  value: () => "<hooked-via-defineProperty>",
+  enumerable: false,
+});
+console.log(defined);


### PR DESCRIPTION
## Summary

Closes three of the deferred `util.inspect.custom` issues from PR #1257's
follow-up list. Each one had a small, well-defined runtime fix in
`crates/perry-runtime/src/builtins/formatting.rs` (plus one in
`crates/perry-runtime/src/object/object_ops.rs` for #1250).

## Issues

Closes #1247
Closes #1250
Closes #1251

## Details

### #1247 — hook now receives `(depth, options, inspect)`

Node invokes the hook as `hook.call(this, depth, options, inspect)`.
Perry was calling `js_closure_call0` so any hook that consulted `depth`
saw `undefined → 0`. Switched to `js_closure_call3`, passing the
remaining recursion budget (the depth limit minus the current nesting,
mirroring Node's countdown), an empty placeholder options object, and
`undefined` for the `inspect` slot (Perry has no JS-callable equivalent
yet — populating that is its own follow-up).

### #1251 — depth handling for non-string hook returns

Side-effect of the same #1247 fix: with hook return values now flowing
through `format_jsvalue` correctly, the existing depth-cap logic
already truncates at the same boundary Node does. Verified against
the `{ a: { b: { c: { d: 1 } } } }` repro — both print
`{ x: { y: { z: [Object] } } }`.

### Root cause hidden behind both #1247 and #1252's deferred shape

`format_jsvalue`'s pointer arm short-circuited to `"{}"` whenever the
object's `keys_array` was null. An object whose only own property is
the inspect symbol has no string-keyed fields, so the hook lookup
inside `format_object_as_json` was never reached. Routed every object
through `format_object_as_json` so the symbol-side-table check fires
before the empty-object fallback.

### #1250 — `Object.defineProperty` with a Symbol key

`js_object_define_property` coerced every key through
`js_string_coerce`, which discards the symbol and writes a
description-string property instead. Added a symbol-tag fast path
that detects pointer-tagged values whose target has `SymbolHeader::magic
== SYMBOL_MAGIC` and routes the descriptor's `value` field into
`js_object_set_symbol_property` (same destination as the bracketed
literal form `obj[sym] = value`).

## Validation

- `cargo build --release -p perry-runtime -p perry`
- `./run_parity_tests.sh --suite node-suite --module util` → 27/27 (added one)

New parity test [`custom-hook-args.ts`](test-parity/node-suite/util/inspect/custom-hook-args.ts)
covers all four behaviours byte-for-byte against
`node --experimental-strip-types`.

## Out of scope

Remaining `util.inspect.custom` follow-ups (#1248 class-prototype hook,
#1249 nested multi-line reindent) and the larger buffer/path/timers
parity items (#1162, #1205, #1206, #1210, #1211, #1213) need
substantially more invasive changes and will land in separate PRs.