### PR TITLE
build(deps): #1236 bump aws-lc-sys 0.40.0 → 0.41.0 (Linux poly_Rq_mul fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary

aws-lc-sys 0.40.0 shipped without `crypto/hrss/asm/poly_rq_mul.S` in its Linux x86_64 build configuration, so any binary that linked `libperry_stdlib.a` on Linux x86_64 failed to link with:

```
ld: error: undefined symbol: aws_lc_0_40_0_poly_Rq_mul
>>> referenced by hrss.c
>>>               5da2666a73fb65eb-hrss.o:(poly_mul) in archive libperry_stdlib.a
```

aws-lc-rs 1.17.0 / aws-lc-sys 0.41.0 include the missing assembly file. The bump goes through `aws-lc-rs` because it pins `aws-lc-sys` with a caret range (`^0.40`), so the only path is to step `aws-lc-rs` forward.

Closes #1236

## Test plan

- [x] `cargo build --release -p perry-stdlib` clean on macOS aarch64 (local).
- [ ] CI Linux x86_64 link path (the actual regression — re-verified by CI).
- [ ] `cargo-test` / `lint` / `api-docs-drift` / `security-audit` (CI).

## Notes

Lockfile-only change; no source edits required. Both crates are transitive deps via `rustls 0.23 → aws-lc-rs` (default crypto provider).