### PR TITLE
fix(jsruntime): #1195 default-import member name → "default"

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -2705,6 +2705,21 @@ pub fn run_with_parse_cache(
                                 .insert(local.clone(), synthetic_prefix.clone());
                             import_function_v8_specifiers
                                 .insert(local.clone(), specifier.clone());
+                            // #1195 — `import YAML from "yaml"` lands here.
+                            // When the local name is used as a static-method
+                            // receiver (`YAML.parse(...)`), the StaticMethodCall
+                            // arm in expr/static_method.rs looks up
+                            // `import_function_origin_names[class_name]` to
+                            // pick the namespace property name, falling back
+                            // to the local name. Without this insert, the
+                            // bridge would ask V8 for `ns.YAML` (which doesn't
+                            // exist on the proxy module's namespace; it
+                            // re-exports the default under the literal
+                            // "default" key). Record the local→"default"
+                            // override so the bridge resolves the right
+                            // namespace property.
+                            import_function_origin_names
+                                .insert(local.clone(), "default".to_string());
                         }
                         perry_hir::ImportSpecifier::Namespace { local } => {
                             // Namespace bindings (`import * as X from "ink"`)


### PR DESCRIPTION
## Summary

`import YAML from "yaml"` (a default import of a V8-fallback module) bound the local alias only into `import_function_v8_specifiers`. The companion `import_function_origin_names` map was left untouched, so `YAML.parse(...)` resolved the namespace property as `ns.YAML` (the local alias) instead of `ns.default`.

This PR adds the missing `local → "default"` insert in the `ImportSpecifier::Default` arm of `compile.rs`, mirroring the equivalent registration that already exists in the aliased-Named arm. With this change the proxy module's actual default-key export is reachable from the bridge.

Closes #1195 (primary `YAML.parse() returns undefined` symptom)

## Test plan

- [x] Repro from issue (`import YAML from "yaml"; YAML.parse("a: 1\\nb:\\n  - x\\n  - y\\n")`):
  - Before: `typeof obj === "undefined"`, throws on `obj.a`.
  - After:  `typeof obj === "object"`, `obj.a === 1`.
- [ ] CI: `cargo-test` / `lint` / `api-docs-drift` / `security-audit`.

## Follow-up not in this PR

V8-handle arrays don't support `[i]` indexing from compiled native code yet. After this PR, `obj.b.length` works (V8 dispatch), but `obj.b[0]` still returns `undefined`. That needs a separate dispatch-table entry routing `arr[i]` to `js_handle_array_get` when `arr` carries a V8 handle. Worth a follow-up issue once #1195's primary symptom is closed.