### PR TITLE
fix(runtime+hir): #1248 #1249 inspect.custom on classes + nested multi-line break

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -266,6 +266,16 @@ pub fn lower_class_decl(
                     ast::PropName::Computed(computed) => {
                         if is_symbol_iterator_key(&computed.expr) {
                             "@@iterator".to_string()
+                        } else if is_inspect_custom_key(ctx, &computed.expr)
+                            && !method.is_static
+                            && matches!(method.kind, ast::MethodKind::Method)
+                        {
+                            // `[util.inspect.custom]() {}` on a class — rename
+                            // to a stable string key so `js_register_class_method`
+                            // picks it up. `format_object_as_json` looks up
+                            // this name on the object's vtable when there is no
+                            // per-instance entry. Refs #1248.
+                            "__perry_inspect_custom__".to_string()
                         } else if let Some(wk) = symbol_well_known_key(&computed.expr) {
                             // hasInstance (static method): lift the method
                             // body to a top-level function named
@@ -927,6 +937,14 @@ pub fn lower_class_from_ast(
                 let prop_name = match &method.key {
                     ast::PropName::Ident(ident) => ident.sym.to_string(),
                     ast::PropName::Str(s) => s.value.as_str().unwrap_or("").to_string(),
+                    ast::PropName::Computed(computed)
+                        if is_inspect_custom_key(ctx, &computed.expr)
+                            && !method.is_static
+                            && matches!(method.kind, ast::MethodKind::Method) =>
+                    {
+                        // Refs #1248: see class_decl.rs Method handling above.
+                        "__perry_inspect_custom__".to_string()
+                    }
                     _ => continue,
                 };
                 match method.kind {

--- a/crates/perry-hir/src/lower_decl/class_members.rs
+++ b/crates/perry-hir/src/lower_decl/class_members.rs
@@ -372,6 +372,15 @@ pub fn lower_class_method(
         ast::PropName::Computed(computed) if is_symbol_iterator_key(&computed.expr) => {
             "@@iterator".to_string()
         }
+        ast::PropName::Computed(computed)
+            if is_inspect_custom_key(ctx, &computed.expr)
+                && !method.is_static
+                && matches!(method.kind, ast::MethodKind::Method) =>
+        {
+            // Refs #1248: `[util.inspect.custom]() {}` on a class — rename to
+            // a stable string key so the runtime's vtable picks it up.
+            "__perry_inspect_custom__".to_string()
+        }
         ast::PropName::Computed(computed) => {
             // Well-known symbols (hasInstance, toStringTag, toPrimitive,
             // asyncIterator) get a synthetic `@@<short>` name. The caller

--- a/crates/perry-hir/src/lower_decl/helpers.rs
+++ b/crates/perry-hir/src/lower_decl/helpers.rs
@@ -166,6 +166,50 @@ pub fn is_symbol_iterator_key(expr: &ast::Expr) -> bool {
     false
 }
 
+/// Detect the computed key `[util.inspect.custom]` / `[inspect.custom]` in a
+/// class method / object literal. Mirrors the AST pattern recognised by
+/// `lower_member_expression` in `expr_member.rs` so the same `inspect.custom`
+/// pattern that becomes `Symbol.for("nodejs.util.inspect.custom")` as a value
+/// is detected as a method key too. Refs #1248.
+pub fn is_inspect_custom_key(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    let member = match expr {
+        ast::Expr::Member(m) => m,
+        _ => return false,
+    };
+    let prop_ident = match &member.prop {
+        ast::MemberProp::Ident(p) => p,
+        _ => return false,
+    };
+    if prop_ident.sym.as_ref() != "custom" {
+        return false;
+    }
+    // Case A: `inspect.custom` where `inspect` is a named import from
+    // `node:util`.
+    if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
+        if let Some((module_name, Some(method_name))) =
+            ctx.lookup_native_module(obj_ident.sym.as_ref())
+        {
+            if (module_name == "util" || module_name == "node:util") && method_name == "inspect" {
+                return true;
+            }
+        }
+    }
+    // Case B: `util.inspect.custom` where `util` is a whole-module alias.
+    if let ast::Expr::Member(inner) = member.obj.as_ref() {
+        if let (ast::Expr::Ident(obj_ident), ast::MemberProp::Ident(inner_prop)) =
+            (inner.obj.as_ref(), &inner.prop)
+        {
+            let obj_name = obj_ident.sym.to_string();
+            let is_util_module =
+                obj_name == "util" || ctx.lookup_builtin_module_alias(&obj_name) == Some("util");
+            if is_util_module && inner_prop.sym.as_ref() == "inspect" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Detect the computed key `[Symbol.<well-known>]` in a class method (static
 /// method, getter, regular method). Returns the short well-known name
 /// ("toPrimitive", "hasInstance", "toStringTag", "iterator", "asyncIterator",

--- a/crates/perry-hir/src/lower_decl/mod.rs
+++ b/crates/perry-hir/src/lower_decl/mod.rs
@@ -42,8 +42,8 @@ pub(crate) use enum_decl::lower_enum_decl;
 pub(crate) use fn_decl::lower_fn_decl;
 pub(crate) use helpers::{
     append_synthetic_arguments_param, body_uses_arguments, build_default_param_stmts,
-    collect_let_decls_in_stmt, init_is_webassembly_instantiate, is_symbol_iterator_key,
-    symbol_well_known_key,
+    collect_let_decls_in_stmt, init_is_webassembly_instantiate, is_inspect_custom_key,
+    is_symbol_iterator_key, symbol_well_known_key,
 };
 pub(crate) use interface_decl::lower_interface_decl;
 pub(crate) use private_members::{

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -784,6 +784,37 @@ unsafe fn format_object_as_json(
                 return format_jsvalue(ret, depth);
             }
         }
+
+        // #1248: class-method `[util.inspect.custom]() {}` is not stored in
+        // the per-instance symbol side table — HIR renames it to
+        // `__perry_inspect_custom__` and registers it on the class vtable
+        // (see crates/perry-hir/src/lower_decl/class_decl.rs). Walk the
+        // object's class chain when the instance lookup misses.
+        let class_id = (*obj_ptr).class_id;
+        if class_id != 0 {
+            if let Some((func_ptr, param_count)) =
+                crate::object::lookup_class_method_in_chain(class_id, "__perry_inspect_custom__")
+            {
+                let _guard = InspectCustomInspectGuard::new(false);
+                let remaining = inspect_depth_limit().saturating_sub(depth) as f64;
+                let options_obj = crate::object::js_object_alloc(0, 0);
+                let options_arg = crate::value::js_nanbox_pointer(options_obj as i64);
+                let undef_arg = f64::from_bits(crate::value::TAG_UNDEFINED);
+                let args = [remaining, options_arg, undef_arg];
+                let ret = crate::object::call_vtable_method(
+                    func_ptr,
+                    obj_ptr as i64,
+                    args.as_ptr(),
+                    args.len(),
+                    param_count,
+                );
+                let ret_jv = crate::value::JSValue::from_bits(ret.to_bits());
+                if ret_jv.is_any_string() {
+                    return jsvalue_string_content(ret).unwrap_or_default();
+                }
+                return format_jsvalue(ret, depth);
+            }
+        }
     }
 
     let keys_array = (*obj_ptr).keys_array;
@@ -885,13 +916,20 @@ unsafe fn format_object_as_json(
     // outer callers (arrays, nested objects) may prepend indentation that
     // pushes the final width past 80. Empty / short bodies stay on one line
     // so `console.dir({ foo: 1 })` keeps printing `{ foo: 1 }`. Refs #1201.
-    if single_line.len() <= 72 {
+    //
+    // #1249: if any rendered child already contains a newline (its own
+    // nested formatter chose multi-line), the outer MUST also break — keeping
+    // it single-line would re-emit the child's continuation lines without our
+    // indent prefix, producing a left-aligned inner body inside an indented
+    // outer body.
+    let any_child_multiline = parts.iter().any(|p| p.contains('\n'));
+    if !any_child_multiline && single_line.len() <= 72 {
         return single_line;
     }
     let indent = "  ";
     let body = parts
         .iter()
-        .map(|p| format!("{}{}", indent, p))
+        .map(|p| format!("{}{}", indent, p.replace('\n', "\n  ")))
         .collect::<Vec<_>>()
         .join(",\n");
     format!("{{\n{}\n}}", body)

--- a/test-parity/node-suite/util/inspect/custom-hook-class.ts
+++ b/test-parity/node-suite/util/inspect/custom-hook-class.ts
@@ -1,0 +1,45 @@
+import { inspect } from "node:util";
+
+// #1248: `[util.inspect.custom]` declared on a class prototype is invoked
+// when the formatter encounters an instance. Pre-fix the hook resolution
+// only consulted the per-instance symbol side table — class methods route
+// through prototype/class-static dispatch and never registered an entry
+// for the instance.
+class Foo {
+  [inspect.custom]() {
+    return "Foo<custom>";
+  }
+}
+console.log(new Foo());
+
+// Non-string returns recurse with the regular depth cap.
+class Bar {
+  [inspect.custom]() {
+    return { kind: "bar" };
+  }
+}
+console.log(new Bar());
+
+// Inheritance: a hook on the base class fires for a subclass instance.
+class Base {
+  [inspect.custom]() {
+    return "Base<custom>";
+  }
+}
+class Sub extends Base {}
+console.log(new Sub());
+
+// #1249: nested multi-line objects force the outer to break too, and the
+// nested body's continuation lines are re-indented to sit under the outer.
+console.log({
+  outer: {
+    aaaa: 1,
+    bbbb: 2,
+    cccc: 3,
+    dddd: 4,
+    eeee: 5,
+    ffff: 6,
+    gggg: 7,
+    hhhh: 8,
+  },
+});


### PR DESCRIPTION
## Summary
- **#1248**: `[util.inspect.custom]() {}` declared as a class method is now invoked when an instance is logged. HIR detects the `inspect.custom` / `util.inspect.custom` computed key (same AST pattern `expr_member.rs` already recognises for the value form) and renames the method to a stable string key `__perry_inspect_custom__` — the same trick the dispose family uses. `format_object_as_json` falls back to a class-vtable lookup of that name (walking the parent chain) when no per-instance symbol entry is found, and invokes it with the same `(depth, options, inspect)` args the side-table path already uses.
- **#1249**: an object whose child rendering already went multi-line now forces the parent to break too, and each child's continuation lines are re-indented under the outer's body. Pre-fix the outer measured only its single-line body width and stayed on one line — the inner's continuation lines appeared left-aligned inside an indented outer.

## Test plan
- [x] `./run_parity_tests.sh --suite node-suite --module util` — 29/29 pass, including a new `node-suite/util/inspect/custom-hook-class` case covering class hook (string return), non-string return, inheritance, and the nested-break repro.
- [x] `cargo test --release -p perry-runtime -p perry-hir --lib` — 451 + 100 pass.
- [x] Manual byte-for-byte parity against `node --experimental-strip-types` on the issue repros.

Refs #1201.