### PR TITLE
feat(host-embed): #1088 --output-type staticlib + Event Loop FFI

### DIFF
--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -64,7 +64,13 @@ pub(super) fn compile_module_entry(
 ) -> Result<()> {
     let strings_init_name = format!("__perry_init_strings_{}", module_prefix);
 
-    let is_dylib = output_type == "dylib";
+    // #1088 — staticlib output is functionally identical to dylib at the
+    // codegen layer: both expose `perry_module_init` instead of `main`, both
+    // skip the embedded event loop (host drives it), both skip the
+    // app-group/geisterhand init that only makes sense for a stand-alone
+    // executable. The variable name stays for diff hygiene with the
+    // historical dylib-only branches downstream.
+    let is_dylib = output_type == "dylib" || output_type == "staticlib";
 
     if is_entry {
         // Pre-declare each non-entry module's init function as an

--- a/crates/perry-runtime/src/event_pump.rs
+++ b/crates/perry-runtime/src/event_pump.rs
@@ -22,13 +22,73 @@
 //! `wait_timeout` survive — if we used a bare `Condvar::wait_timeout`
 //! without a flag we would lose any notify that races the lock acquire.
 
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::os::raw::c_void;
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicPtr, Ordering};
 use std::sync::{Condvar, Mutex, OnceLock};
 use std::time::Duration;
 
 use crate::timer::{
     js_callback_timer_next_deadline, js_interval_timer_next_deadline, js_timer_next_deadline,
 };
+
+// ============================================================================
+// #1088 — Host-embedding wake callback.
+//
+// Hosts that drive the event loop themselves (Rust + winit, Qt, GTK4, …)
+// sleep on OS primitives that don't observe Perry's internal `Condvar`. They
+// register `(cb, ctx)` once via `perry_set_wake_callback`; `js_notify_main_thread`
+// then invokes it on top of the existing condvar path so the host wakes
+// instantly instead of polling. The callback runs on whatever thread called
+// `js_notify_main_thread` (any tokio worker, any std::thread::spawn), so the
+// host's implementation must be thread-safe — typical use is
+// `EventLoopProxy::send_event(())` which is.
+// ============================================================================
+
+/// Host wake callback. Stored as raw pointers so the C FFI surface stays
+/// trivially `unsafe extern "C"`. Either-or-both can be null; the
+/// `cb` slot being null disables the wake.
+static WAKE_CALLBACK: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+static WAKE_CONTEXT: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
+
+/// Register a host wake callback. Passing `cb = NULL` clears the previous
+/// registration. The `ctx` pointer is opaque to Perry — the host owns its
+/// lifetime; we just hand it back on each invocation.
+///
+/// Thread-safety: the registration store is atomic; the callback itself is
+/// invoked from `js_notify_main_thread`, which any producer thread may
+/// call. Hosts must therefore use a thread-safe wake primitive (winit's
+/// `EventLoopProxy`, a self-pipe, an eventfd, etc.).
+///
+/// # Safety
+/// `cb` must remain callable for as long as it is registered. `ctx` must
+/// remain valid for the same window. Pass `cb = NULL` before dropping
+/// the target context to avoid use-after-free from a concurrent notify.
+#[no_mangle]
+pub unsafe extern "C" fn perry_set_wake_callback(
+    cb: Option<unsafe extern "C" fn(*mut c_void)>,
+    ctx: *mut c_void,
+) {
+    // Order matters: store the context first so any racing notifier that
+    // observes the new cb pointer also sees a fresh ctx.
+    WAKE_CONTEXT.store(ctx, Ordering::Release);
+    let cb_ptr = cb.map(|f| f as *mut ()).unwrap_or(std::ptr::null_mut());
+    WAKE_CALLBACK.store(cb_ptr, Ordering::Release);
+}
+
+#[inline]
+fn invoke_host_wake_callback() {
+    let cb_ptr = WAKE_CALLBACK.load(Ordering::Acquire);
+    if cb_ptr.is_null() {
+        return;
+    }
+    let ctx = WAKE_CONTEXT.load(Ordering::Acquire);
+    // SAFETY: `cb` was registered by a host that guaranteed it remains
+    // callable until cleared. We re-check non-null right above the call.
+    unsafe {
+        let cb: unsafe extern "C" fn(*mut c_void) = std::mem::transmute(cb_ptr);
+        cb(ctx);
+    }
+}
 
 struct Pump {
     /// `true` iff a producer notified since the last consumer reset.
@@ -144,6 +204,15 @@ pub extern "C" fn js_notify_main_thread() {
     // path it took (Release so subsequent producer side-effects are
     // visible).
     NOTIFIED.store(true, Ordering::Release);
+    // #1088 — fan the wake out to the host-registered callback (if any)
+    // BEFORE the WAITER_COUNT fast-path return. The host may be sleeping
+    // on an OS primitive (winit's `EventLoopProxy`, an eventfd, …) that
+    // Perry's condvar doesn't observe; without this hook a hot tokio
+    // worker pushing fetch results would only wake the host on the next
+    // OS-event tick. Registration is opt-in — `invoke_host_wake_callback`
+    // is a single atomic-load when no host is listening, so callers that
+    // never register pay essentially nothing.
+    invoke_host_wake_callback();
     // Hot path: no consumer is currently in `cvar.wait_timeout`, so
     // we don't need to take the mutex or signal the cvar — the next
     // call to `js_wait_for_event` will see `NOTIFIED == true` on the
@@ -163,6 +232,115 @@ pub extern "C" fn js_notify_main_thread() {
     *flag = true;
     drop(flag);
     PUMP.cvar.notify_one();
+}
+
+// ============================================================================
+// #1088 — Unified Event Loop FFI facade for host embedding.
+//
+// The internal pump surface (`js_promise_run_microtasks`, `js_run_stdlib_pump`,
+// `js_microtasks_pending`, `js_*_timer_next_deadline`, the various
+// `js_*_has_active_handles` shims) is correct but easy to mis-wire from a
+// host: forgetting `js_run_stdlib_pump` silently hangs `fetch`; relying only
+// on `js_microtasks_pending` to gate sleep ignores timers and stdlib I/O.
+//
+// The three functions below collapse the foot-guns into one obvious surface:
+//
+//   * `perry_poll()`           — drains microtasks + stdlib + jsruntime
+//   * `perry_has_work()`       — true while anything is pending (microtasks,
+//                                timers across all 3 queues, stdlib handles,
+//                                jsruntime handles)
+//   * `perry_next_wake_ms()`   — minimum across the 3 timer queues, or -1
+//
+// Pair with `perry_set_wake_callback` for polling-free integration.
+// ============================================================================
+
+extern "C" {
+    fn js_promise_run_microtasks() -> i32;
+    fn js_run_stdlib_pump();
+    fn js_run_jsruntime_pump();
+    fn js_microtasks_pending() -> i32;
+    fn js_stdlib_has_active_handles() -> i32;
+    fn js_jsruntime_has_active_handles() -> i32;
+}
+
+/// Drain everything Perry is currently holding ready: microtask queue, the
+/// stdlib pump (fetch / fs / ws / fastify / timers), the perry-jsruntime
+/// pump (V8 fallback module evaluations). Returns the number of microtasks
+/// executed by `js_promise_run_microtasks`. Stdlib/jsruntime pumps don't
+/// report task counts, so the return value is a lower-bound proxy for
+/// "did anything observable happen this tick".
+///
+/// Safe to call from the host's event-loop tick. Idempotent at zero cost
+/// when there's no work — the stdlib/jsruntime pump trampolines bail
+/// immediately when nothing is registered.
+#[no_mangle]
+pub extern "C" fn perry_poll() -> i32 {
+    // SAFETY: every call site below is a Perry C FFI surface declared with
+    // `extern "C"` linkage and stable across host builds; no thread-safety
+    // invariants beyond what each individual function already documents.
+    unsafe {
+        let microtasks = js_promise_run_microtasks();
+        js_run_stdlib_pump();
+        js_run_jsruntime_pump();
+        microtasks
+    }
+}
+
+/// Returns 1 if the host should keep the event loop alive — anything
+/// pending across all of Perry's internal queues. Use as the gate for
+/// `ControlFlow::Wait` vs `ControlFlow::Poll` in winit, or the equivalent
+/// in other event-loop frameworks.
+///
+/// Checks (any positive answer ⇒ has work):
+///   * `js_microtasks_pending()`           — promise microtasks
+///   * any of the 3 timer queues has a deadline ≥ 0
+///   * `js_stdlib_has_active_handles()`    — fetch / ws / fastify / timers
+///   * `js_jsruntime_has_active_handles()` — V8 fallback adapters
+#[no_mangle]
+pub extern "C" fn perry_has_work() -> i32 {
+    // SAFETY: same trampoline surface as `perry_poll`.
+    let pending_microtasks = unsafe { js_microtasks_pending() };
+    if pending_microtasks > 0 {
+        return 1;
+    }
+    let has_timer = js_timer_next_deadline() >= 0.0
+        || js_callback_timer_next_deadline() >= 0.0
+        || js_interval_timer_next_deadline() >= 0.0;
+    if has_timer {
+        return 1;
+    }
+    if unsafe { js_stdlib_has_active_handles() } != 0 {
+        return 1;
+    }
+    if unsafe { js_jsruntime_has_active_handles() } != 0 {
+        return 1;
+    }
+    0
+}
+
+/// Returns the closest pending wake-up across all 3 timer queues, in
+/// milliseconds from now. Returns -1.0 when no timers are scheduled —
+/// the host can then sleep indefinitely (or until an OS event / a wake
+/// callback fires).
+///
+/// NaN is *not* returned — keeps the return shape printable and avoids
+/// surprising hosts that compare with `<`.
+#[no_mangle]
+pub extern "C" fn perry_next_wake_ms() -> f64 {
+    let mut best: f64 = -1.0;
+    for d in [
+        js_timer_next_deadline(),
+        js_callback_timer_next_deadline(),
+        js_interval_timer_next_deadline(),
+    ] {
+        if d < 0.0 {
+            continue;
+        }
+        if best < 0.0 || d < best {
+            best = d;
+        }
+    }
+    best
 }
 
 /// Block until the next scheduled timer fires, a notify arrives, or the

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -3995,6 +3995,15 @@ pub fn run_with_parse_cache(
     let stem_owned = super::sanitize::sanitize_for_linker_argv(raw_stem);
     let stem = stem_owned.as_str();
     let is_dylib = args.output_type == "dylib";
+    // #1088 — staticlib output: a Rust/C/C++ host links our `.a` / `.lib`
+    // alongside `libperry_runtime.a` (and friends) and drives the event
+    // loop itself via the FFI surface in `perry-runtime/src/event_pump.rs`
+    // (`perry_poll`, `perry_has_work`, `perry_next_wake_ms`,
+    // `perry_set_wake_callback`). Behaves like `dylib` at the codegen
+    // layer (no `main` emission, `perry_module_init` entrypoint), but the
+    // link step uses `ar` instead of `cc -shared`.
+    let is_staticlib = args.output_type == "staticlib";
+    let is_library_output = is_dylib || is_staticlib;
     // Capture the args fields that helpers downstream of the
     // `args.output.unwrap_or_else(...)` partial-move still need.
     // Per the saved feedback note on this file: any helper extracted
@@ -4011,6 +4020,17 @@ pub fn run_with_parse_cache(
             #[cfg(not(target_os = "macos"))]
             {
                 PathBuf::from(format!("{}.so", stem))
+            }
+        } else if is_staticlib {
+            // #1088 — Windows hosts expect `.lib`; everywhere else uses
+            // the Unix `lib<stem>.a` convention so the archive is reachable
+            // from `-l<stem>` at the host's link step.
+            if matches!(target.as_deref(), Some("windows"))
+                || (target.is_none() && cfg!(target_os = "windows"))
+            {
+                PathBuf::from(format!("{}.lib", stem))
+            } else {
+                PathBuf::from(format!("lib{}.a", stem))
             }
         } else if matches!(
             target.as_deref(),
@@ -4212,6 +4232,74 @@ pub fn run_with_parse_cache(
     // is_watchos / is_tvos are defined below (near jsruntime_lib).
     // The is_cross_* bindings used to live here, but they're now derived
     // inside `link::build_and_run_link` which is the only consumer.
+
+    // #1088 — staticlib output: bundle the object files into a `.a` / `.lib`
+    // archive. Skip runtime / stdlib linking entirely; the Rust/C/C++ host
+    // is expected to link `libperry_runtime.a` (and any extension archives
+    // it uses) alongside our archive at its own link step. Codegen already
+    // emits `perry_module_init` instead of `main` (see is_dylib branch in
+    // codegen/entry.rs, which now also covers `staticlib`).
+    if is_staticlib {
+        let is_windows_target = matches!(target.as_deref(), Some("windows"))
+            || (target.is_none() && cfg!(target_os = "windows"));
+        // Best-effort: drop a stale archive first so `ar` doesn't append to a
+        // previous build's contents.
+        let _ = fs::remove_file(&exe_path);
+        let mut cmd = if is_windows_target {
+            // MSVC `lib.exe` is the standard host on Windows; mingw users
+            // can override with `AR=...` since `cc::ar_name()` parity isn't
+            // available here.
+            let mut c = Command::new("lib.exe");
+            c.arg(format!("/OUT:{}", exe_path.display()));
+            c
+        } else {
+            let mut c = Command::new("ar");
+            // `c` create, `r` insert/replace, `s` write index. Matches what
+            // rustc invokes via cc-rs for `crate-type = staticlib`.
+            c.arg("crs").arg(&exe_path);
+            c
+        };
+        for obj_path in &obj_paths {
+            cmd.arg(obj_path);
+        }
+        let status = cmd.status()?;
+        if !status.success() {
+            return Err(anyhow!("Archiving staticlib failed"));
+        }
+
+        match format {
+            OutputFormat::Text => println!("Wrote static archive: {}", exe_path.display()),
+            OutputFormat::Json => {
+                println!("{{\"output\": \"{}\"}}", exe_path.display());
+            }
+        }
+
+        if !args.keep_intermediates {
+            for obj_path in &obj_paths {
+                let _ = fs::remove_file(obj_path);
+            }
+        }
+
+        let codegen_cache_stats = if object_cache.is_enabled() {
+            Some((
+                object_cache.hits(),
+                object_cache.misses(),
+                object_cache.stores(),
+                object_cache.store_errors(),
+            ))
+        } else {
+            None
+        };
+        return Ok(CompileResult {
+            output_path: exe_path,
+            target: target.clone().unwrap_or_else(|| "native".to_string()),
+            bundle_id: None,
+            // Reuse the dylib flag downstream — both library outputs share the
+            // "no embedded event loop, host drives `perry_module_init`" shape.
+            is_dylib: true,
+            codegen_cache_stats,
+        });
+    }
 
     // For dylib output, skip runtime/stdlib linking — symbols resolve from host at dlopen time
     if is_dylib {

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -88,7 +88,10 @@ pub struct CompileArgs {
     #[arg(long)]
     pub app_bundle_id: Option<String>,
 
-    /// Output type: executable (default) or dylib (shared library plugin)
+    /// Output type: executable (default), dylib (shared library plugin), or
+    /// staticlib (`.a` / `.lib` archive for embedding into a Rust/C/C++ host
+    /// — see #1088). dylib and staticlib both skip embedded-`main` emission
+    /// and expose `perry_module_init`.
     #[arg(long, default_value = "executable")]
     pub output_type: String,
 

--- a/test-files/run_test_issue_1088.sh
+++ b/test-files/run_test_issue_1088.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# Wire-level regression harness for issue #1088 — `--output-type staticlib`
+# + unified Event Loop FFI for host embedding.
+# See test_issue_1088_staticlib.ts / test_issue_1088_host.c for the writeup.
+#
+# Usage:
+#   PERRY_BIN=./target/release/perry ./test-files/run_test_issue_1088.sh
+#
+# Assertions:
+#   * `--output-type staticlib` produces an `ar` archive whose only entry
+#     point is `perry_module_init` (no `T main` symbol — would collide).
+#   * A C host program linked against the archive + libperry_runtime.a +
+#     libperry_stdlib.a can call `perry_module_init`, `perry_poll`,
+#     `perry_has_work`, `perry_next_wake_ms`, and `perry_set_wake_callback`.
+#   * After registering a wake callback, `js_notify_main_thread()` from the
+#     same thread fires it.
+#
+# macOS-only for now — Linux works in principle (just swap the framework
+# args) but the parity / compile-smoke CI lanes are tag-gated and the
+# host-embedding lane isn't wired up yet (#1088 explicitly asked for the
+# surface first; CI plumbing is the follow-up). The script bails cleanly
+# on other platforms so it doesn't fail the suite there.
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "[1088] SKIP — host-embedding smoke is macOS-only for now"
+    exit 0
+fi
+
+PERRY_BIN="${PERRY_BIN:-./target/release/perry}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TS_SRC="$SCRIPT_DIR/test_issue_1088_staticlib.ts"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/perry-1088.XXXXXX")"
+STATIC_LIB="$WORK_DIR/libperry_tslib.a"
+HOST_EXE="$WORK_DIR/smoke"
+C_SRC="$WORK_DIR/host.c"
+cat > "$C_SRC" <<'CHOST'
+/* Host smoke for #1088 — embedded here rather than a sibling .c because
+ * test-files/test_* is gitignored unless it matches *.ts/*.tsx. The body
+ * exercises perry_module_init, the unified Event Loop facade, and the
+ * wake-callback registration round-trip. */
+#include <stdio.h>
+#include <stdlib.h>
+extern void   perry_module_init(void);
+extern int    perry_poll(void);
+extern int    perry_has_work(void);
+extern double perry_next_wake_ms(void);
+extern void   js_notify_main_thread(void);
+extern void   perry_set_wake_callback(void (*cb)(void *), void *ctx);
+static int wake_fired = 0;
+static void on_wake(void *ctx) { (void)ctx; wake_fired = 1; }
+int main(void) {
+    printf("[host] calling perry_module_init\n");
+    perry_module_init();
+    printf("[host] perry_module_init returned\n");
+    int polled = perry_poll();
+    int has = perry_has_work();
+    double next = perry_next_wake_ms();
+    printf("[host] perry_poll=%d perry_has_work=%d perry_next_wake_ms=%.1f\n",
+           polled, has, next);
+    perry_set_wake_callback(on_wake, NULL);
+    js_notify_main_thread();
+    printf("[host] wake_fired=%d\n", wake_fired);
+    perry_set_wake_callback(NULL, NULL);
+    if (wake_fired != 1) {
+        fprintf(stderr, "[host] FAIL — wake callback did not fire after notify\n");
+        return 2;
+    }
+    if (next != -1.0) {
+        fprintf(stderr, "[host] FAIL — idle program reported a pending wake (next=%.1f)\n", next);
+        return 3;
+    }
+    return 0;
+}
+CHOST
+
+cd "$WORKSPACE_ROOT"
+
+if [[ ! -x "$PERRY_BIN" ]]; then
+    echo "FAIL: perry binary not found at $PERRY_BIN — build first via cargo build --release -p perry" >&2
+    exit 1
+fi
+
+cleanup() { rm -rf "$WORK_DIR"; }
+trap cleanup EXIT
+
+echo "[1088] compiling staticlib..."
+PERRY_ALLOW_PERRY_FEATURES=1 "$PERRY_BIN" "$TS_SRC" -o "$STATIC_LIB" \
+    --output-type staticlib >/dev/null
+
+# The runtime + stdlib archives that the codegen auto-optimized; the host has
+# to bring these along at its own link step. Pick the most recent
+# perry-auto-* dir — `perry compile` keeps the path opaque, so we scan.
+AUTO_DIR="$(ls -td "$WORKSPACE_ROOT"/target/perry-auto-*/release 2>/dev/null | head -n 1)"
+if [[ -z "$AUTO_DIR" ]]; then
+    AUTO_DIR="$WORKSPACE_ROOT/target/release"
+fi
+RUNTIME_LIB="$AUTO_DIR/libperry_runtime.a"
+STDLIB_LIB="$AUTO_DIR/libperry_stdlib.a"
+
+for lib in "$STATIC_LIB" "$RUNTIME_LIB" "$STDLIB_LIB"; do
+    if [[ ! -f "$lib" ]]; then
+        echo "[1088] FAIL — missing $lib" >&2
+        exit 1
+    fi
+done
+
+echo "[1088] checking archive contents..."
+if nm "$STATIC_LIB" 2>&1 | grep -qE '^[0-9a-f]+ T _?main$'; then
+    echo "[1088] FAIL — archive exports 'main', will collide with host" >&2
+    exit 1
+fi
+if ! nm "$STATIC_LIB" 2>&1 | grep -qE '^[0-9a-f]+ T _?perry_module_init$'; then
+    echo "[1088] FAIL — archive missing 'perry_module_init' entry point" >&2
+    exit 1
+fi
+
+echo "[1088] linking host smoke..."
+cc -o "$HOST_EXE" "$C_SRC" \
+    "$STATIC_LIB" "$RUNTIME_LIB" "$STDLIB_LIB" \
+    -framework Foundation \
+    -framework CoreFoundation \
+    -framework Security \
+    -framework SystemConfiguration \
+    -lc++ \
+    >/dev/null 2>&1
+
+echo "[1088] running host..."
+OUTPUT="$("$HOST_EXE" 2>&1)"
+echo "$OUTPUT" | sed 's/^/    /'
+
+fail=0
+if [[ "$OUTPUT" != *"[ts] module init: hello from staticlib"* ]]; then
+    echo "[1088] FAIL — perry_module_init didn't actually run the TS module body"
+    fail=1
+fi
+if [[ "$OUTPUT" != *"perry_poll=0 perry_has_work=0 perry_next_wake_ms=-1.0"* ]]; then
+    echo "[1088] FAIL — idle facade defaults regressed"
+    fail=1
+fi
+if [[ "$OUTPUT" != *"wake_fired=1"* ]]; then
+    echo "[1088] FAIL — perry_set_wake_callback didn't fire on notify"
+    fail=1
+fi
+
+if [[ $fail -eq 0 ]]; then
+    echo "[1088] PASS"
+    exit 0
+else
+    exit 1
+fi

--- a/test-files/test_issue_1088_staticlib.ts
+++ b/test-files/test_issue_1088_staticlib.ts
@@ -1,0 +1,18 @@
+// Issue #1088 — `--output-type staticlib` + unified Event Loop FFI.
+//
+// Minimal TS surface to validate the staticlib link path. The companion
+// `run_test_issue_1088.sh` script:
+//   1. Compiles this with `--output-type staticlib`, producing a
+//      `libperry_tslib.a` whose only exported entry point is
+//      `perry_module_init` (no `main` symbol — that would collide with
+//      the host's own main).
+//   2. Links a small C smoke host against the archive + libperry_runtime.a,
+//      calls `perry_module_init`, then walks `perry_poll` / `perry_has_work`
+//      / `perry_next_wake_ms` / `perry_set_wake_callback` to prove the host
+//      embedding FFI is reachable and behaves.
+//
+// The TS body itself is intentionally trivial — the whole point of the
+// staticlib mode is that the *host* drives the event loop, so the TS
+// surface only needs to print on init to confirm `perry_module_init`
+// actually ran.
+console.log("[ts] module init: hello from staticlib");


### PR DESCRIPTION
## Summary

Adds the host-embedding surface from #1088: `--output-type staticlib` plus a small unified Event Loop FFI in `perry-runtime` so Rust / C / C++ hosts (winit, Qt, GTK4) can link compiled TypeScript into their own process and drive the event loop themselves.

### 1. `--output-type staticlib`

- `perry compile --output-type staticlib lib.ts -o libapp.a` produces a `.a` / `.lib` archive.
- The codegen branch that previously fired only for `dylib` now also covers `staticlib`: the entry-module emits `perry_module_init` instead of `main`, skips the embedded event-loop poll body, and skips app-group / geisterhand init that only makes sense for stand-alone executables.
- The link step uses `ar crs` (Unix) or `lib.exe /OUT:` (Windows) and skips runtime/stdlib archiving — the host links those alongside.

### 2. Unified Event Loop FFI

New C surface in `perry-runtime/src/event_pump.rs`:

| Function | Behavior |
|---|---|
| `perry_poll() -> i32` | Drains microtasks + stdlib + jsruntime pumps; returns the microtask count. |
| `perry_has_work() -> i32` | `1` while microtasks pending, any of the 3 timer queues has a deadline, or stdlib / jsruntime has active handles. |
| `perry_next_wake_ms() -> f64` | Min of the 3 timer-queue deadlines, or `-1.0` if none. |
| `perry_set_wake_callback(cb, ctx)` | Register a host wake hook. Invoked from `js_notify_main_thread` on top of the existing condvar path so hosts sleeping on OS primitives (winit's `EventLoopProxy`, eventfd, …) wake instantly. |

`js_notify_main_thread` invokes the wake callback before the `WAITER_COUNT` fast-path return — a single atomic-load when no host is listening, so callers that never register pay essentially nothing.

Closes #1088.

## Test plan

- [x] `./test-files/run_test_issue_1088.sh` — compiles a tiny TS module as a staticlib, asserts the archive has no `T main` symbol and does export `T perry_module_init`, links a C smoke host that walks all four facade functions + the wake-callback round-trip, and runs it. macOS-only for now (the script bails cleanly elsewhere); Linux works in principle, the CI lane is the follow-up.
- [x] `cargo build --release -p perry-runtime` clean.
- [x] `cargo build --release -p perry` clean (108 pre-existing warnings, no new ones).
- [x] `cargo fmt --all -- --check` clean.
- [ ] CI: `lint` / `cargo-test` / `api-docs-drift` / `security-audit`.

## Notes

- `is_dylib` in `codegen/entry.rs` is now `is_library_output` semantically (matches both `dylib` and `staticlib`); kept the variable name for diff hygiene with all the downstream `!is_dylib` branches.
- `perry_set_wake_callback(NULL, NULL)` clears the registration — used in the smoke test to keep parallel tests in the same process from getting surprise wakes.