### PR TITLE
fix(stdlib): #1193 cheerio chain through any-typed intermediates

### DIFF
--- a/crates/perry-stdlib/src/cheerio.rs
+++ b/crates/perry-stdlib/src/cheerio.rs
@@ -32,7 +32,14 @@ pub struct CheerioSelectionHandle {
 
 /// cheerio.load(html) -> CheerioAPI
 ///
-/// Load HTML content for parsing.
+/// Load HTML content for parsing. Returns a raw CheerioHandle id; the
+/// callable-`$()` form (#1193) is reachable via the codegen's static
+/// dispatch table once it learns to map a value of type CheerioHandle to
+/// `js_cheerio_select` on a function-call shape. Until then user code
+/// can use the equivalent method form `load(html).select(...)` which
+/// works through both the static dispatch table and (for any-typed
+/// intermediates) the runtime fallback in
+/// `common/dispatch.rs::dispatch_cheerio`.
 #[no_mangle]
 pub unsafe extern "C" fn js_cheerio_load(html_ptr: *const StringHeader) -> Handle {
     let html = match string_from_header(html_ptr) {
@@ -441,4 +448,117 @@ pub unsafe extern "C" fn js_cheerio_selection_attrs(
     }
 
     result
+}
+
+// ============================================================================
+// #1193 — runtime fall-through dispatch for cheerio handles.
+//
+// The static NATIVE_MODULE_TABLE path resolves `cheerio.load(html).select(sel)`
+// when the receiver type survives lowering. As soon as user code lands an
+// intermediate in a `let` binding (`const sel = $.select(".x")`), the
+// codegen sees a generic `(number).method` call and routes through
+// `js_handle_method_dispatch` — which until this commit had no cheerio
+// arm, so `sel.text()` failed with `(number).text is not a function`.
+//
+// This helper accepts both `CheerioHandle` (the document) and
+// `CheerioSelectionHandle` (selection) shapes and dispatches the methods
+// the static table already exposes. Returns `None` when the handle id
+// doesn't belong to either registry so the caller falls through to the
+// next dispatcher.
+// ============================================================================
+pub(crate) unsafe fn dispatch_cheerio(handle: Handle, method: &str, args: &[f64]) -> Option<f64> {
+    use crate::common::with_handle;
+    const TAG_UNDEFINED_F64: u64 = 0x7FFC_0000_0000_0001;
+    const TAG_NULL_F64: u64 = 0x7FFC_0000_0000_0002;
+
+    let nanbox_pointer = |raw: i64| -> f64 {
+        f64::from_bits(0x7FFD_0000_0000_0000 | (raw as u64 & 0x0000_FFFF_FFFF_FFFF))
+    };
+    let nanbox_string = |ptr: *mut StringHeader| -> f64 {
+        if ptr.is_null() {
+            return f64::from_bits(TAG_NULL_F64);
+        }
+        f64::from_bits(JSValue::string_ptr(ptr).bits())
+    };
+    let arg_str_ptr = |idx: usize| -> *const StringHeader {
+        if idx >= args.len() {
+            return std::ptr::null();
+        }
+        perry_runtime::js_get_string_pointer_unified(args[idx]) as *const StringHeader
+    };
+
+    let is_selection =
+        with_handle::<CheerioSelectionHandle, bool, _>(handle, |_| true).unwrap_or(false);
+    let is_document = with_handle::<CheerioHandle, bool, _>(handle, |_| true).unwrap_or(false);
+    if !is_selection && !is_document {
+        return None;
+    }
+
+    // Document-level methods. `select` is the only thing user code reaches
+    // for the document; the rest of the table is selection-only.
+    if is_document && method == "select" {
+        let raw = js_cheerio_select(handle, arg_str_ptr(0));
+        return Some(nanbox_pointer(raw));
+    }
+    if !is_selection {
+        return None;
+    }
+
+    match method {
+        "text" => Some(nanbox_string(js_cheerio_selection_text(handle))),
+        "html" => Some(nanbox_string(js_cheerio_selection_html(handle))),
+        "attr" => Some(nanbox_string(js_cheerio_selection_attr(
+            handle,
+            arg_str_ptr(0),
+        ))),
+        "length" => Some(js_cheerio_selection_length(handle)),
+        "first" => Some(nanbox_pointer(js_cheerio_selection_first(handle))),
+        "last" => Some(nanbox_pointer(js_cheerio_selection_last(handle))),
+        "eq" => {
+            let idx = if args.is_empty() { 0.0 } else { args[0] };
+            Some(nanbox_pointer(js_cheerio_selection_eq(handle, idx)))
+        }
+        "find" => Some(nanbox_pointer(js_cheerio_selection_find(
+            handle,
+            arg_str_ptr(0),
+        ))),
+        "children" => Some(nanbox_pointer(js_cheerio_selection_children(
+            handle,
+            arg_str_ptr(0),
+        ))),
+        "parent" => Some(nanbox_pointer(js_cheerio_selection_parent(handle))),
+        "hasClass" => {
+            let r = js_cheerio_selection_has_class(handle, arg_str_ptr(0));
+            Some(f64::from_bits(JSValue::bool(r).bits()))
+        }
+        "is" => {
+            let r = js_cheerio_selection_is(handle, arg_str_ptr(0));
+            Some(f64::from_bits(JSValue::bool(r).bits()))
+        }
+        "toArray" => {
+            let arr = js_cheerio_selection_to_array(handle);
+            if arr.is_null() {
+                Some(f64::from_bits(TAG_UNDEFINED_F64))
+            } else {
+                Some(nanbox_pointer(arr as i64))
+            }
+        }
+        "texts" => {
+            let arr = js_cheerio_selection_texts(handle);
+            if arr.is_null() {
+                Some(f64::from_bits(TAG_UNDEFINED_F64))
+            } else {
+                Some(nanbox_pointer(arr as i64))
+            }
+        }
+        "attrs" => {
+            let arr = js_cheerio_selection_attrs(handle, arg_str_ptr(0));
+            if arr.is_null() {
+                Some(f64::from_bits(TAG_UNDEFINED_F64))
+            } else {
+                Some(nanbox_pointer(arr as i64))
+            }
+        }
+        _ => None,
+    }
 }

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -265,6 +265,40 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
         return crate::string_decoder::dispatch_string_decoder(handle, method_name, args);
     }
 
+    // #1193 — cheerio (bundled): both `CheerioHandle` and
+    // `CheerioSelectionHandle` lose their static type at TS-side
+    // assignment boundaries (`const sel = $.select(".x")`). The static
+    // NATIVE_MODULE_TABLE path catches direct chains like
+    // `cheerio.load(html).select(".x").text()` only when the receiver
+    // type survives lowering; the moment user code lands the
+    // intermediate in a `let`, codegen sees `(number).method` and
+    // routes here. Method-gated to disjoint sets so a colliding handle
+    // id from another registry can't fall through to a cheerio shim.
+    #[cfg(feature = "bundled-cheerio")]
+    if matches!(
+        method_name,
+        "select"
+            | "text"
+            | "html"
+            | "attr"
+            | "length"
+            | "first"
+            | "last"
+            | "eq"
+            | "find"
+            | "children"
+            | "parent"
+            | "hasClass"
+            | "is"
+            | "toArray"
+            | "texts"
+            | "attrs"
+    ) {
+        if let Some(v) = crate::cheerio::dispatch_cheerio(handle, method_name, args) {
+            return v;
+        }
+    }
+
     // Unknown handle type - return undefined
     f64::from_bits(0x7FF8_0000_0000_0001)
 }

--- a/test-files/run_test_issue_1193.sh
+++ b/test-files/run_test_issue_1193.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Wire-level regression for issue #1193 — cheerio chain through any-typed
+# intermediates. See test_issue_1193_cheerio_chain.ts for the writeup.
+#
+# Usage:
+#   PERRY_BIN=./target/release/perry ./test-files/run_test_issue_1193.sh
+#
+# Assertions:
+#   * Bound-then-method chain through CheerioSelectionHandle works:
+#     `.text()` returns "helloworld".
+#   * Bound document, then `.select(...).text()`: same result via the
+#     document-level arm of dispatch_cheerio.
+#
+# Pre-fix the runtime threw `(number).<method> is not a function` on the
+# `.text()` step the moment the SelectionHandle landed in a `let` binding.
+
+set -euo pipefail
+
+PERRY_BIN="${PERRY_BIN:-./target/release/perry}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_SRC="$SCRIPT_DIR/test_issue_1193_cheerio_chain.ts"
+EXE="${TMPDIR:-/tmp}/test_issue_1193_cheerio_chain"
+
+cd "$WORKSPACE_ROOT"
+
+if [[ ! -x "$PERRY_BIN" ]]; then
+    echo "FAIL: perry binary not found at $PERRY_BIN — build first via cargo build --release -p perry" >&2
+    exit 1
+fi
+
+echo "[1193] compiling fixture..."
+PERRY_ALLOW_PERRY_FEATURES=1 "$PERRY_BIN" "$TEST_SRC" -o "$EXE" >/dev/null
+
+echo "[1193] running fixture..."
+OUTPUT="$("$EXE" 2>&1)"
+echo "$OUTPUT" | sed 's/^/    /'
+
+fail=0
+if [[ "$OUTPUT" != *"text: helloworld"* ]]; then
+    echo "[1193] FAIL -- selection text() regressed (expected 'helloworld')"
+    fail=1
+fi
+if [[ "$OUTPUT" != *"text2: helloworld"* ]]; then
+    echo "[1193] FAIL -- doc.select(...).text() through bound doc regressed"
+    fail=1
+fi
+if [[ "$OUTPUT" == *"is not a function"* ]]; then
+    echo "[1193] FAIL -- dispatch fell through to the not-callable path"
+    fail=1
+fi
+
+if [[ $fail -eq 0 ]]; then
+    echo "[1193] PASS"
+    exit 0
+else
+    exit 1
+fi

--- a/test-files/test_issue_1193_cheerio_chain.ts
+++ b/test-files/test_issue_1193_cheerio_chain.ts
@@ -1,0 +1,33 @@
+// Issue #1193 — cheerio chain through any-typed intermediates.
+//
+// Pre-fix, `load(html).select(".x").text()` worked for direct chains but
+// any user-side intermediate landed a SelectionHandle in a typed-as-number
+// `let` binding, and the follow-up `.text()` then fell through codegen's
+// static cheerio dispatch and surfaced as
+// `(number).text is not a function`. Same shape for `(load(html) as any)`
+// or anywhere TS-side type info evaporated.
+//
+// Fix (perry-stdlib/src/cheerio.rs + common/dispatch.rs): added a
+// runtime-side `dispatch_cheerio` arm to `js_handle_method_dispatch` that
+// routes both `CheerioHandle` and `CheerioSelectionHandle` methods to
+// their corresponding FFI calls. Now the chain reassembles via the
+// runtime fallback whenever the codegen lost the static cheerio type.
+//
+// The user-facing `$(sel)` callable form (the original repro shape) is a
+// separate codegen-level fix tracked in the same issue — runtime dispatch
+// alone can't make a non-closure handle callable. This regression covers
+// the achievable slice: the documented `.select(sel)` method form must
+// survive any-typed bindings.
+import { load } from "cheerio";
+
+const $ = load("<html><body><p class='x'>hello</p><p class='x'>world</p></body></html>");
+
+// The any-typed intermediate is what regressed before the dispatch fix.
+const sel = $.select(".x");
+console.log("text:", sel.text());
+
+// Same shape from a doc bound through a `let` — the document-level
+// `.select()` arm of dispatch_cheerio is what closes this one.
+const doc = $;
+const sel2 = doc.select(".x");
+console.log("text2:", sel2.text());


### PR DESCRIPTION
## Summary

`cheerio.load(html).select(".x").text()` worked as a direct chain because the codegen's static `NATIVE_MODULE_TABLE` dispatch preserved the cheerio receiver tag end-to-end. The moment user code landed an intermediate in a `let` binding (`const sel = $.select(".x")`), the SelectionHandle came back NaN-boxed as a generic pointer and the follow-up `.text()` saw a number-typed receiver — static dispatch declined and the call fell through to `js_handle_method_dispatch`, which had no cheerio arm. Result: `(number).<method> is not a function` on every selection-level method.

This PR adds a runtime-side `dispatch_cheerio` arm and wires it into `js_handle_method_dispatch` (gated on a disjoint method set so colliding handle ids from other registries can't accidentally fall through to a cheerio shim). Routes both `CheerioHandle` (document `.select(...)`) and `CheerioSelectionHandle` (`text` / `html` / `attr` / `length` / `first` / `last` / `eq` / `find` / `children` / `parent` / `hasClass` / `is` / `toArray` / `texts` / `attrs`) to their existing FFI calls.

## Test plan

- [x] `./test-files/run_test_issue_1193.sh` — covers both regression shapes:
  - Bound selection: `const sel = $.select(".x"); sel.text()` → `"helloworld"`.
  - Bound document: `const doc = $; doc.select(".x").text()` → same.
- [x] `cargo build --release -p perry-stdlib` clean.
- [x] `cargo fmt --all -- --check` clean.
- [ ] CI: `lint` / `cargo-test` / `api-docs-drift` / `security-audit`.

## Not in this PR

The user's original `$(".x")` **callable** form still throws `value is not a function`. Making it work needs the codegen to recognise a Call expression whose callee resolves to a value of type CheerioHandle and either rewrite it to `.select(sel)` at HIR-lower time or route the function-call shape directly to `js_cheerio_select`.

I tried a runtime-side closure wrap on `js_cheerio_load` (wrap the handle in a Perry closure that dispatches to `js_cheerio_select`, and add an unwrap helper inside `js_cheerio_select`). It makes `$()` work, but breaks the static `$.select(...)` path: the codegen sees the closure-wrapped receiver as a function value and stops dispatching through the cheerio `NATIVE_MODULE_TABLE` rows. The clean fix is at the codegen layer; tracking as a follow-up on #1193.

## Notes

- The `.first()` arm of `dispatch_cheerio` reaches an existing semantic bug in `js_cheerio_selection_first` (re-parses the first element's html as a full document, then matches `"*"` against html/body/p — `.first().text()` returns the same text repeated). Out of scope for this PR; flagged here for the next cheerio pass.