### PR TITLE
node:buffer parity — close #1205 #1206 #1210 #1211

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2170,6 +2170,10 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("url", "format", false, None),
     method("url", "parse", false, None),
     method("url", "resolve", false, None),
+    // Issue #1211: Blob/File object-URL registry — paired with the
+    // `resolveObjectURL` export on `node:buffer`.
+    method("url", "createObjectURL", false, None),
+    method("url", "revokeObjectURL", false, None),
     // --- http (perry-ext-http surface + classes the framework spec
     //     exposes). Both http and https route through the same crate. ---
     method("http", "createServer", false, None),

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2151,6 +2151,13 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("buffer", "isUtf8", false, None),
     // Issue #1210: re-encode bytes between supported encodings.
     method("buffer", "transcode", false, None),
+    // Issue #1211: Blob / File constructors + object-URL helpers
+    // exposed from node:buffer.  Blob/File constructors are recognized
+    // by the codegen builtin path, so they only need to appear here
+    // as class exports.
+    class("buffer", "Blob"),
+    class("buffer", "File"),
+    method("buffer", "resolveObjectURL", false, None),
     property("buffer", "constants"),
     property("buffer", "kMaxLength"),
     property("buffer", "kStringMaxLength"),

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2149,6 +2149,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // Buffer module-level encoding probes added in PR #1257.
     method("buffer", "isAscii", false, None),
     method("buffer", "isUtf8", false, None),
+    // Issue #1210: re-encode bytes between supported encodings.
+    method("buffer", "transcode", false, None),
     property("buffer", "constants"),
     property("buffer", "kMaxLength"),
     property("buffer", "kStringMaxLength"),

--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -502,19 +502,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 let result_i32 = blk.zext(I8, &byte_val, I32);
                 return Ok(ctx.block().sitofp(I32, &result_i32, DOUBLE));
             }
+            // Issue #1205 slow path: route the indexed read through
+            // `js_buffer_get` so a view receiver (registered in the
+            // runtime view registry by `js_buffer_slice`) reads from
+            // the ultimate backing buffer instead of its own
+            // possibly-stale snapshot.  Fast path above stays direct
+            // since `buffer_data_slots` is only populated for
+            // `Buffer.alloc` locals, which are never views.
             let a = lower_expr(ctx, array)?;
             let blk = ctx.block();
             let handle = unbox_to_i64(blk, &a);
-            let len_i32 = blk.safe_load_i32_from_ptr(&handle);
-            let in_bounds = blk.icmp_ult(I32, &idx_i32, &len_i32);
-            blk.emit_raw(format!("call void @llvm.assume(i1 {})", in_bounds));
-            let idx_i64 = blk.zext(I32, &idx_i32, I64);
-            let data_offset = blk.add(I64, &idx_i64, "8");
-            let byte_addr = blk.add(I64, &handle, &data_offset);
-            let byte_ptr = blk.inttoptr(I64, &byte_addr);
-            let byte_val = blk.load(I8, &byte_ptr);
-            let result_i32 = blk.zext(I8, &byte_val, I32);
-            Ok(ctx.block().sitofp(I32, &result_i32, DOUBLE))
+            let byte_i32 = blk.call(I32, "js_buffer_get", &[(I64, &handle), (I32, &idx_i32)]);
+            Ok(ctx.block().sitofp(I32, &byte_i32, DOUBLE))
         }
         Expr::Uint8ArraySet {
             array,
@@ -572,18 +571,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 blk.emit_raw(format!("store i8 {}, ptr {}{}", byte_val, byte_ptr, meta));
                 return Ok(ctx.block().sitofp(I32, &val_i32, DOUBLE));
             }
+            // Issue #1205 slow path: route the indexed store through
+            // `js_buffer_set` so a view receiver propagates the write
+            // to its backing buffer (and any sister views).  Fast
+            // path above stays direct — `buffer_data_slots` only
+            // tracks `Buffer.alloc` locals, which are never views.
             let a = lower_expr(ctx, array)?;
             let blk = ctx.block();
             let handle = unbox_to_i64(blk, &a);
-            let len_i32 = blk.safe_load_i32_from_ptr(&handle);
-            let in_bounds = blk.icmp_ult(I32, &idx_i32, &len_i32);
-            blk.emit_raw(format!("call void @llvm.assume(i1 {})", in_bounds));
-            let idx_i64 = blk.zext(I32, &idx_i32, I64);
-            let data_offset = blk.add(I64, &idx_i64, "8");
-            let byte_addr = blk.add(I64, &handle, &data_offset);
-            let byte_ptr = blk.inttoptr(I64, &byte_addr);
-            let byte_val = blk.trunc(I32, &val_i32, I8);
-            blk.store(I8, &byte_val, &byte_ptr);
+            blk.call_void(
+                "js_buffer_set",
+                &[(I64, &handle), (I32, &idx_i32), (I32, &val_i32)],
+            );
             // Return the stored value as a double (for expression contexts).
             Ok(ctx.block().sitofp(I32, &val_i32, DOUBLE))
         }

--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -505,6 +505,83 @@ pub(super) fn lower_builtin_new(
             Ok(Some(handle))
         }
 
+        // Issue #1211: `new Blob(parts, opts)` / `new File(parts, name, opts)`.
+        // `parts` is a JS array of mixed string/Buffer/Blob inputs — the
+        // runtime helper (`js_blob_new` / `js_file_new`) walks the array
+        // and concatenates the bytes. Locals bound by `const b = new Blob(...)`
+        // are tagged `("blob", "Blob")` in `destructuring/var_decl.rs` so
+        // subsequent property/method access dispatches through the
+        // `module == "blob"` arm above.
+        "Blob" => {
+            let parts = if !args.is_empty() {
+                lower_expr(ctx, &args[0])?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            let mut type_str = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+            if args.len() >= 2 {
+                if let Some(props) = extract_options_fields(ctx, &args[1]) {
+                    for (k, vexpr) in &props {
+                        if k == "type" {
+                            type_str = lower_expr(ctx, vexpr)?;
+                        } else {
+                            let _ = lower_expr(ctx, vexpr)?;
+                        }
+                    }
+                } else {
+                    let _ = lower_expr(ctx, &args[1])?;
+                }
+            }
+            let handle = ctx.block().call(
+                DOUBLE,
+                "js_blob_new",
+                &[(DOUBLE, &parts), (DOUBLE, &type_str)],
+            );
+            Ok(Some(handle))
+        }
+
+        "File" => {
+            let parts = if !args.is_empty() {
+                lower_expr(ctx, &args[0])?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            let name = if args.len() >= 2 {
+                lower_expr(ctx, &args[1])?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            let mut type_str = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+            // NaN signals "use Date.now()" inside the runtime helper.
+            let mut last_modified = double_literal(f64::NAN);
+            if args.len() >= 3 {
+                if let Some(props) = extract_options_fields(ctx, &args[2]) {
+                    for (k, vexpr) in &props {
+                        match k.as_str() {
+                            "type" => type_str = lower_expr(ctx, vexpr)?,
+                            "lastModified" => last_modified = lower_expr(ctx, vexpr)?,
+                            _ => {
+                                let _ = lower_expr(ctx, vexpr)?;
+                            }
+                        }
+                    }
+                } else {
+                    let _ = lower_expr(ctx, &args[2])?;
+                }
+            }
+            let handle = ctx.block().call(
+                DOUBLE,
+                "js_file_new",
+                &[
+                    (DOUBLE, &parts),
+                    (DOUBLE, &name),
+                    (DOUBLE, &type_str),
+                    (DOUBLE, &last_modified),
+                ],
+            );
+            Ok(Some(handle))
+        }
+
         "Headers" => {
             // new Headers(init?) — init can be an object literal or another
             // Headers/array iterable. Only inline object literals are

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -781,4 +781,18 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // Issue #1210: `buffer.transcode(source, fromEnc, toEnc)`.
+    // Receiver-less Node-buffer export; arguments are NaN-boxed (source
+    // is a Buffer pointer, encodings are strings). Returns a Buffer
+    // pointer that must be NaN-boxed with POINTER_TAG by the dispatch
+    // wrapper — `NR_PTR` handles that step.
+    NativeModSig {
+        module: "buffer",
+        has_receiver: false,
+        method: "transcode",
+        class_filter: None,
+        runtime: "js_buffer_transcode",
+        args: &[NA_F64, NA_F64, NA_F64],
+        ret: NR_PTR,
+    },
 ];

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -795,4 +795,36 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[NA_F64, NA_F64, NA_F64],
         ret: NR_PTR,
     },
+    // Issue #1211: `import { resolveObjectURL } from "node:buffer"`.
+    NativeModSig {
+        module: "buffer",
+        has_receiver: false,
+        method: "resolveObjectURL",
+        class_filter: None,
+        runtime: "js_buffer_resolve_object_url",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    // Issue #1211: `URL.createObjectURL(blob)` /
+    // `URL.revokeObjectURL(url)` — modelled as receiver-less
+    // `("url", "createObjectURL"/"revokeObjectURL")` so the static
+    // method dispatch in `expr_call/module_static.rs` picks them up.
+    NativeModSig {
+        module: "url",
+        has_receiver: false,
+        method: "createObjectURL",
+        class_filter: None,
+        runtime: "js_url_create_object_url",
+        args: &[NA_F64],
+        ret: NR_STR,
+    },
+    NativeModSig {
+        module: "url",
+        has_receiver: false,
+        method: "revokeObjectURL",
+        class_filter: None,
+        runtime: "js_url_revoke_object_url",
+        args: &[NA_F64],
+        ret: NR_VOID,
+    },
 ];

--- a/crates/perry-codegen/src/lower_call/options/fetch.rs
+++ b/crates/perry-codegen/src/lower_call/options/fetch.rs
@@ -416,6 +416,22 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                     .call(DOUBLE, "js_blob_stream", &[(DOUBLE, &recv_handle)]);
                 return Ok(Some(h));
             }
+            // Issue #1211: File-specific properties.  Plain Blob handles
+            // resolve `name` to the empty string and `lastModified` to 0,
+            // which matches Node's behavior for non-File Blobs (no
+            // ambiguity from sharing the registry).
+            "name" => {
+                let str_ptr = ctx
+                    .block()
+                    .call(I64, "js_file_name", &[(DOUBLE, &recv_handle)]);
+                let blk = ctx.block();
+                return Ok(Some(nanbox_string_inline(blk, &str_ptr)));
+            }
+            "lastModified" => {
+                let blk = ctx.block();
+                let n = blk.call(DOUBLE, "js_file_last_modified", &[(DOUBLE, &recv_handle)]);
+                return Ok(Some(n));
+            }
             _ => return Ok(None),
         }
     }

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -367,6 +367,11 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_buffer_set_from", VOID, &[I64, I64, I32]);
     module.declare_function("js_buffer_slice", I64, &[I64, I32, I32]);
     module.declare_function("js_buffer_to_string", I64, &[I64, I32]);
+    // Issue #1210: `buffer.transcode(source, fromEnc, toEnc)`. Source is a
+    // NaN-boxed Buffer pointer (DOUBLE), encodings are NaN-boxed strings
+    // (DOUBLE). Returns a raw *mut BufferHeader (I64) — NR_PTR in the
+    // native dispatch table NaN-boxes the result with POINTER_TAG.
+    module.declare_function("js_buffer_transcode", I64, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_buffer_write", I32, &[I64, I64, I32, I32]);
 
     // ========== child_process ==========

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1371,6 +1371,14 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_blob_bytes", I64, &[DOUBLE]);
     module.declare_function("js_blob_text", I64, &[DOUBLE]);
     module.declare_function("js_blob_slice", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE, I64]);
+    // Issue #1211: Blob / File constructors + object-URL registry.
+    module.declare_function("js_blob_new", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_file_new", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function("js_file_name", I64, &[DOUBLE]);
+    module.declare_function("js_file_last_modified", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_url_create_object_url", I64, &[DOUBLE]);
+    module.declare_function("js_url_revoke_object_url", VOID, &[DOUBLE]);
+    module.declare_function("js_buffer_resolve_object_url", DOUBLE, &[DOUBLE]);
     // Static factories.
     module.declare_function("js_response_static_json", DOUBLE, &[DOUBLE]);
     module.declare_function("js_response_static_redirect", DOUBLE, &[I64, DOUBLE]);

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -730,6 +730,28 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                 );
                                 ctx.uses_fetch = true;
                             }
+                            // Issue #1211: `new Blob([...])` / `new File([...], name)`.
+                            // File shares the Blob runtime registry — the codegen
+                            // `module == "blob"` arm dispatches `.name` /
+                            // `.lastModified` regardless of class tag, so File
+                            // tracks as a Blob instance with the class tag
+                            // available for future File-only property checks.
+                            "Blob" => {
+                                ctx.register_native_instance(
+                                    name.clone(),
+                                    "blob".to_string(),
+                                    "Blob".to_string(),
+                                );
+                                ctx.uses_fetch = true;
+                            }
+                            "File" => {
+                                ctx.register_native_instance(
+                                    name.clone(),
+                                    "blob".to_string(),
+                                    "File".to_string(),
+                                );
+                                ctx.uses_fetch = true;
+                            }
                             // Issue #237: Web Streams API constructors.
                             "ReadableStream" => {
                                 ctx.register_native_instance(

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -1254,6 +1254,29 @@ pub(super) fn try_module_static_methods(
                             args.into_iter().next().unwrap(),
                         ))));
                     }
+                    // Issue #1211: `URL.createObjectURL(blob)` /
+                    // `URL.revokeObjectURL(url)` route to the
+                    // Blob-registry helpers. Modelled as receiver-less
+                    // `NativeMethodCall { module: "url" }` so the
+                    // native dispatch table picks them up.
+                    if method_name == "createObjectURL" {
+                        return Ok(Ok(Expr::NativeMethodCall {
+                            module: "url".to_string(),
+                            class_name: None,
+                            object: None,
+                            method: "createObjectURL".to_string(),
+                            args,
+                        }));
+                    }
+                    if method_name == "revokeObjectURL" {
+                        return Ok(Ok(Expr::NativeMethodCall {
+                            module: "url".to_string(),
+                            class_name: None,
+                            object: None,
+                            method: "revokeObjectURL".to_string(),
+                            args,
+                        }));
+                    }
                 }
             }
         }

--- a/crates/perry-runtime/src/buffer/access.rs
+++ b/crates/perry-runtime/src/buffer/access.rs
@@ -10,6 +10,19 @@ pub extern "C" fn js_buffer_get(buf_ptr: *const BufferHeader, index: i32) -> i32
         if index as u32 >= (*buf_ptr).length {
             return 0;
         }
+        // Issue #1205: if the receiver is a registered view, read from
+        // the ultimate backing buffer — otherwise the view's local
+        // snapshot can lag any direct-fast-path write made to the
+        // backing through codegen.
+        let buf_addr = buf_ptr as usize;
+        if let Some(info) = super::view::lookup(buf_addr) {
+            let back_off = info.offset + index as u32;
+            let backing_ptr = info.backing as *const BufferHeader;
+            if !backing_ptr.is_null() && back_off < (*backing_ptr).length {
+                let back_data = buffer_data(backing_ptr);
+                return *back_data.add(back_off as usize) as i32;
+            }
+        }
         let data = buffer_data(buf_ptr);
         *data.add(index as usize) as i32
     }
@@ -25,8 +38,28 @@ pub extern "C" fn js_buffer_set(buf_ptr: *mut BufferHeader, index: i32, value: i
         if index as u32 >= (*buf_ptr).length {
             return;
         }
+        let byte = (value & 0xFF) as u8;
+        // Write the byte to the receiver's own data area first so a
+        // direct codegen fast-path read of this buffer still sees the
+        // update.
         let data = buffer_data_mut(buf_ptr);
-        *data.add(index as usize) = (value & 0xFF) as u8;
+        *data.add(index as usize) = byte;
+        // Issue #1205: propagate through the view registry.  If the
+        // receiver is itself a slice, mirror the write into the
+        // ultimate backing buffer; in either direction, sister views
+        // covering the same backing byte must observe the new value.
+        let buf_addr = buf_ptr as usize;
+        if let Some(info) = super::view::lookup(buf_addr) {
+            let back_off = info.offset + index as u32;
+            let backing_ptr = info.backing as *mut BufferHeader;
+            if !backing_ptr.is_null() && back_off < (*backing_ptr).length {
+                let back_data = buffer_data_mut(backing_ptr);
+                *back_data.add(back_off as usize) = byte;
+                super::view::propagate_byte_to_views(info.backing, back_off, byte, buf_addr);
+            }
+        } else {
+            super::view::propagate_byte_to_views(buf_addr, index as u32, byte, buf_addr);
+        }
     }
 }
 
@@ -74,7 +107,10 @@ pub extern "C" fn js_buffer_set_from(
     }
 }
 
-/// Create a slice of a buffer (returns a new buffer)
+/// Create a slice of a buffer.  Issue #1205: the returned buffer is
+/// a *view* over the source — registered in the view registry so that
+/// subsequent reads/writes via the runtime helpers propagate between
+/// the slice and the original.
 #[no_mangle]
 pub extern "C" fn js_buffer_slice(
     buf_ptr: *const BufferHeader,
@@ -111,6 +147,10 @@ pub extern "C" fn js_buffer_slice(
         let src_data = buffer_data(buf_ptr).add(start as usize);
         let dst_data = buffer_data_mut(result);
         ptr::copy_nonoverlapping(src_data, dst_data, slice_len as usize);
+
+        // Register the alias.  `register` flattens slices-of-slices
+        // so the recorded backing is always the original allocation.
+        super::view::register(result as usize, buf_ptr as usize, start as u32, slice_len);
 
         result
     }

--- a/crates/perry-runtime/src/buffer/iter.rs
+++ b/crates/perry-runtime/src/buffer/iter.rs
@@ -1,0 +1,184 @@
+//! Issue #1206: Node's `Buffer` exposes real iterator-protocol objects
+//! from `buf.values()`, `buf.keys()`, `buf.entries()`, and
+//! `buf[Symbol.iterator]()`.  Each returned value must support `.next()`
+//! returning `{ value, done }`.
+//!
+//! Perry's `for...of` over a Buffer already works via the indexed
+//! length/[i] path, but exposing the explicit iterator surface lets
+//! ecosystem code call `it.next().value` (the shape the parity fixture
+//! and Node's docs document).
+//!
+//! Representation: a regular `ObjectHeader` with a dedicated
+//! `BUFFER_ITERATOR_CLASS_ID`. Three fields hold the backing buffer,
+//! the current cursor index, and the iterator kind (0 = values,
+//! 1 = keys, 2 = entries). Dispatch lives in
+//! `object/native_call_method.rs` — see the class-id check that routes
+//! to `dispatch_buffer_iterator_method`.
+
+use super::*;
+
+use crate::object::{js_object_alloc, js_object_get_field, js_object_set_field, ObjectHeader};
+use crate::value::{js_nanbox_get_pointer, js_nanbox_pointer, JSValue, TAG_UNDEFINED};
+
+/// Class id reserved for Buffer iterators. Sits adjacent to
+/// `BUFFER_TYPE_ID` (0xFFFF0004) in the 0xFFFF prefix reserved for
+/// runtime-defined classes.
+pub const BUFFER_ITERATOR_CLASS_ID: u32 = 0xFFFF_0005;
+
+/// Iterator kind tags — matches the i32 stored in field 2 of every
+/// BufferIterator object.
+const KIND_VALUES: i32 = 0;
+const KIND_KEYS: i32 = 1;
+const KIND_ENTRIES: i32 = 2;
+
+fn unbox_buffer_ptr(value: f64) -> *mut BufferHeader {
+    let bits = value.to_bits();
+    let addr = if bits >> 48 >= 0x7FF8 {
+        bits & 0x0000_FFFF_FFFF_FFFF
+    } else {
+        bits
+    };
+    if addr < 0x1000 {
+        return std::ptr::null_mut();
+    }
+    addr as *mut BufferHeader
+}
+
+unsafe fn alloc_iterator(buf_ptr: *mut BufferHeader, kind: i32) -> f64 {
+    let obj = js_object_alloc(BUFFER_ITERATOR_CLASS_ID, 3);
+    // Field 0: backing buffer (NaN-boxed pointer).
+    let buf_nan = js_nanbox_pointer(buf_ptr as i64);
+    js_object_set_field(obj, 0, JSValue::from_bits(buf_nan.to_bits()));
+    // Field 1: cursor index, starts at 0.
+    js_object_set_field(obj, 1, JSValue::number(0.0));
+    // Field 2: iterator kind.
+    js_object_set_field(obj, 2, JSValue::number(kind as f64));
+    js_nanbox_pointer(obj as i64)
+}
+
+/// `buf.values()` — iterator yielding each byte value.
+#[no_mangle]
+pub extern "C" fn js_buffer_values(buf_f64: f64) -> f64 {
+    let buf_ptr = unbox_buffer_ptr(buf_f64);
+    if buf_ptr.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    unsafe { alloc_iterator(buf_ptr, KIND_VALUES) }
+}
+
+/// `buf.keys()` — iterator yielding each index `0..length`.
+#[no_mangle]
+pub extern "C" fn js_buffer_keys(buf_f64: f64) -> f64 {
+    let buf_ptr = unbox_buffer_ptr(buf_f64);
+    if buf_ptr.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    unsafe { alloc_iterator(buf_ptr, KIND_KEYS) }
+}
+
+/// `buf.entries()` — iterator yielding `[index, value]` pairs.
+#[no_mangle]
+pub extern "C" fn js_buffer_entries(buf_f64: f64) -> f64 {
+    let buf_ptr = unbox_buffer_ptr(buf_f64);
+    if buf_ptr.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    unsafe { alloc_iterator(buf_ptr, KIND_ENTRIES) }
+}
+
+/// Build the `{ value, done }` iterator-result object.  `value`
+/// arrives as a NaN-boxed JSValue; `done` is a JS boolean.
+unsafe fn make_iter_result(value: JSValue, done: bool) -> f64 {
+    let obj = js_object_alloc(0, 2);
+
+    // keys array so destructuring + for-of can find named slots.
+    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+    let done_key = crate::string::js_string_from_bytes(b"done".as_ptr(), 4);
+    let keys = crate::array::js_array_alloc(2);
+    crate::array::js_array_push(keys, JSValue::string_ptr(value_key));
+    crate::array::js_array_push(keys, JSValue::string_ptr(done_key));
+    crate::object::js_object_set_keys(obj, keys);
+
+    js_object_set_field(obj, 0, value);
+    js_object_set_field(obj, 1, JSValue::bool(done));
+    js_nanbox_pointer(obj as i64)
+}
+
+unsafe fn make_pair_array(idx: u32, byte: u8) -> f64 {
+    let pair = crate::array::js_array_alloc(2);
+    (*pair).length = 2;
+    let elems = (pair as *mut u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *mut f64;
+    *elems.add(0) = idx as f64;
+    *elems.add(1) = byte as f64;
+    crate::array::note_array_slot(pair, 0, (idx as f64).to_bits());
+    crate::array::note_array_slot(pair, 1, (byte as f64).to_bits());
+    js_nanbox_pointer(pair as i64)
+}
+
+/// Dispatch `.next()` / `[Symbol.iterator]()` on a Buffer iterator
+/// object. Routed from `js_native_call_method`'s class-id check.
+pub unsafe fn dispatch_buffer_iterator_method(
+    iter_obj: *mut ObjectHeader,
+    method_name: &str,
+) -> f64 {
+    match method_name {
+        "next" => {
+            // Field 0: backing buffer pointer (NaN-boxed).
+            let backing_field = js_object_get_field(iter_obj, 0);
+            let backing_f64 = f64::from_bits(backing_field.bits());
+            let buf_ptr = js_nanbox_get_pointer(backing_f64) as *mut BufferHeader;
+            // Field 1: current index.
+            let idx_field = js_object_get_field(iter_obj, 1);
+            let idx_f64 = f64::from_bits(idx_field.bits());
+            let idx = idx_f64 as u32;
+            // Field 2: iterator kind.
+            let kind_field = js_object_get_field(iter_obj, 2);
+            let kind = f64::from_bits(kind_field.bits()) as i32;
+
+            let len = if buf_ptr.is_null() {
+                0u32
+            } else {
+                (*buf_ptr).length
+            };
+
+            if idx >= len {
+                return make_iter_result(JSValue::undefined(), true);
+            }
+
+            // Advance the stored cursor before computing the value so
+            // a subsequent `.next()` call sees the bumped index.
+            js_object_set_field(iter_obj, 1, JSValue::number((idx + 1) as f64));
+
+            let byte = if buf_ptr.is_null() {
+                0u8
+            } else {
+                let data = buffer_data(buf_ptr);
+                *data.add(idx as usize)
+            };
+
+            let value = match kind {
+                KIND_VALUES => JSValue::number(byte as f64),
+                KIND_KEYS => JSValue::number(idx as f64),
+                KIND_ENTRIES => {
+                    let pair = make_pair_array(idx, byte);
+                    JSValue::from_bits(pair.to_bits())
+                }
+                _ => JSValue::undefined(),
+            };
+            make_iter_result(value, false)
+        }
+        // Iterators are themselves iterable — calling `[Symbol.iterator]()`
+        // on one returns the same iterator. This is what Node does and
+        // lets `for (const v of buf.values())` re-enter without an extra
+        // wrapper. Without it the for-of fallback path would attempt to
+        // index the iterator as an array and get nonsense.
+        "Symbol.iterator" | "@@iterator" => js_nanbox_pointer(iter_obj as i64),
+        // `return`/`throw` are part of the iterator spec but most
+        // for-of paths don't need them; Node's BufferIterator inherits
+        // them from %IteratorPrototype%. We return a `{ value: undefined,
+        // done: true }` shape — enough for early-exit code that checks
+        // `it.return?.()` semantics.
+        "return" | "throw" => make_iter_result(JSValue::undefined(), true),
+        _ => f64::from_bits(TAG_UNDEFINED),
+    }
+}

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -20,6 +20,7 @@ mod mutate;
 mod numeric;
 mod query;
 mod transcode;
+mod view;
 
 // ---- Re-exports: types & constants ----
 pub use header::{BufferHeader, BUFFER_TYPE_ID, SMALL_BUF_THRESHOLD};

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -15,9 +15,11 @@ mod copy_write;
 mod encode;
 mod from;
 mod header;
+mod iter;
 mod mutate;
 mod numeric;
 mod query;
+mod transcode;
 
 // ---- Re-exports: types & constants ----
 pub use header::{BufferHeader, BUFFER_TYPE_ID, SMALL_BUF_THRESHOLD};
@@ -87,6 +89,15 @@ pub use numeric::{
 pub use coding::{
     base64_decode_into_buffer, base64_encode_into_string, base64url_encode_into_string,
     decode_base64, decode_hex, hex_decode_into_buffer, hex_encode_into_string,
+};
+
+// ---- Re-exports: transcode (FFI) ----
+pub use transcode::js_buffer_transcode;
+
+// ---- Re-exports: iterator surface (FFI + dispatch hook) ----
+pub use iter::{
+    dispatch_buffer_iterator_method, js_buffer_entries, js_buffer_keys, js_buffer_values,
+    BUFFER_ITERATOR_CLASS_ID,
 };
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/buffer/transcode.rs
+++ b/crates/perry-runtime/src/buffer/transcode.rs
@@ -1,0 +1,213 @@
+//! Issue #1210: `buffer.transcode(source, fromEnc, toEnc)`.
+//!
+//! Node's `node:buffer` module exports a `transcode` helper that
+//! re-encodes the bytes of a Buffer from one supported encoding into
+//! another. The Node implementation accepts a wide encoding matrix
+//! (icu-backed); we land a deterministic subset that covers the
+//! published Deno node-compat fixtures and the common JS-string-bridge
+//! use cases without taking an icu dependency:
+//!
+//!   - `utf16le` / `ucs2` / `ucs-2` / `utf-16le` → `utf8` / `utf-8`
+//!   - `utf8` / `utf-8` / `ascii` / `latin1` / `binary` → `utf16le` / `ucs2`
+//!
+//! Unsupported encoding pairs return an empty Buffer (matching the
+//! "decode failed → empty bytes" surface seen on most icu fallback
+//! paths) rather than throwing — Perry doesn't surface JS-side errors
+//! from receiver-less native module helpers today, so an empty result
+//! is the closest non-crashing parity behaviour.
+
+use super::*;
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum TranscodeEnc {
+    Utf8,
+    Utf16Le,
+    Latin1,
+    Other,
+}
+
+fn classify_encoding(value: f64) -> TranscodeEnc {
+    let str_ptr = crate::value::js_get_string_pointer_unified(value) as *const StringHeader;
+    if str_ptr.is_null() || (str_ptr as usize) < 0x1000 {
+        return TranscodeEnc::Other;
+    }
+    unsafe {
+        let len = (*str_ptr).byte_len as usize;
+        if len == 0 || len > 16 {
+            return TranscodeEnc::Other;
+        }
+        let data = (str_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        let bytes = std::slice::from_raw_parts(data, len);
+        let mut lower = [0u8; 16];
+        for (i, b) in bytes.iter().enumerate() {
+            lower[i] = b.to_ascii_lowercase();
+        }
+        let lower = &lower[..len];
+        match lower {
+            b"utf8" | b"utf-8" => TranscodeEnc::Utf8,
+            b"utf16le" | b"utf-16le" | b"ucs2" | b"ucs-2" => TranscodeEnc::Utf16Le,
+            b"latin1" | b"binary" | b"ascii" => TranscodeEnc::Latin1,
+            _ => TranscodeEnc::Other,
+        }
+    }
+}
+
+fn buffer_bytes<'a>(buf_ptr: *const BufferHeader) -> &'a [u8] {
+    if buf_ptr.is_null() || (buf_ptr as usize) < 0x1000 {
+        return &[];
+    }
+    unsafe {
+        let len = (*buf_ptr).length as usize;
+        let data = buffer_data(buf_ptr);
+        std::slice::from_raw_parts(data, len)
+    }
+}
+
+fn buffer_from_bytes(out: &[u8]) -> *mut BufferHeader {
+    let buf = buffer_alloc(out.len() as u32);
+    unsafe {
+        (*buf).length = out.len() as u32;
+        if !out.is_empty() {
+            std::ptr::copy_nonoverlapping(out.as_ptr(), buffer_data_mut(buf), out.len());
+        }
+    }
+    buf
+}
+
+fn utf16le_to_utf8(bytes: &[u8]) -> Vec<u8> {
+    // Walk u16 code units, lossy-decode (unpaired surrogates → U+FFFD)
+    // to mirror Node/ICU's "lossy" default for the buffer.transcode
+    // path. Odd-length input drops the trailing byte, matching Node.
+    let chunks = bytes.chunks_exact(2);
+    let u16_iter = chunks.map(|c| u16::from_le_bytes([c[0], c[1]]));
+    let decoded: String = char::decode_utf16(u16_iter)
+        .map(|r| r.unwrap_or('\u{FFFD}'))
+        .collect();
+    decoded.into_bytes()
+}
+
+fn utf8_to_utf16le(bytes: &[u8]) -> Vec<u8> {
+    let cow = String::from_utf8_lossy(bytes);
+    let mut out = Vec::with_capacity(cow.len() * 2);
+    for unit in cow.encode_utf16() {
+        out.extend_from_slice(&unit.to_le_bytes());
+    }
+    out
+}
+
+fn latin1_to_utf16le(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.extend_from_slice(&(b as u16).to_le_bytes());
+    }
+    out
+}
+
+fn latin1_to_utf8(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(bytes.len());
+    for &b in bytes {
+        if b < 0x80 {
+            out.push(b);
+        } else {
+            // Latin-1 maps 0x80..0xFF → U+0080..U+00FF, which is a
+            // 2-byte UTF-8 sequence.
+            out.push(0xC0 | (b >> 6));
+            out.push(0x80 | (b & 0x3F));
+        }
+    }
+    out
+}
+
+/// `buffer.transcode(source, fromEnc, toEnc)` — re-encode Buffer bytes.
+///
+/// `source_f64` is a NaN-boxed Buffer pointer; `from_enc_f64`/`to_enc_f64`
+/// are NaN-boxed encoding-name strings.  Returns a freshly-allocated
+/// Buffer holding the re-encoded bytes.  Unsupported encoding pairs
+/// return an empty Buffer.
+#[no_mangle]
+pub extern "C" fn js_buffer_transcode(
+    source_f64: f64,
+    from_enc_f64: f64,
+    to_enc_f64: f64,
+) -> *mut BufferHeader {
+    let bits = source_f64.to_bits();
+    let addr = if bits >> 48 >= 0x7FF8 {
+        bits & 0x0000_FFFF_FFFF_FFFF
+    } else {
+        bits
+    };
+    if addr < 0x1000 {
+        return buffer_alloc(0);
+    }
+    let buf_ptr = addr as *const BufferHeader;
+    let src_bytes = buffer_bytes(buf_ptr);
+    let from = classify_encoding(from_enc_f64);
+    let to = classify_encoding(to_enc_f64);
+
+    if from == to {
+        return buffer_from_bytes(src_bytes);
+    }
+
+    let out: Vec<u8> = match (from, to) {
+        (TranscodeEnc::Utf16Le, TranscodeEnc::Utf8) => utf16le_to_utf8(src_bytes),
+        (TranscodeEnc::Utf8, TranscodeEnc::Utf16Le) => utf8_to_utf16le(src_bytes),
+        (TranscodeEnc::Latin1, TranscodeEnc::Utf16Le) => latin1_to_utf16le(src_bytes),
+        (TranscodeEnc::Latin1, TranscodeEnc::Utf8) => latin1_to_utf8(src_bytes),
+        // utf8/utf16le → latin1: lossy narrow per Node — only the low byte
+        // of each code unit is kept; code points > 0xFF emit '?'.
+        (TranscodeEnc::Utf16Le, TranscodeEnc::Latin1) => {
+            let chunks = src_bytes.chunks_exact(2);
+            let mut out = Vec::with_capacity(chunks.len());
+            for c in chunks {
+                let unit = u16::from_le_bytes([c[0], c[1]]);
+                out.push(if unit > 0xFF { b'?' } else { unit as u8 });
+            }
+            out
+        }
+        (TranscodeEnc::Utf8, TranscodeEnc::Latin1) => {
+            let cow = String::from_utf8_lossy(src_bytes);
+            let mut out = Vec::with_capacity(cow.len());
+            for ch in cow.chars() {
+                let cp = ch as u32;
+                out.push(if cp > 0xFF { b'?' } else { cp as u8 });
+            }
+            out
+        }
+        _ => Vec::new(),
+    };
+
+    buffer_from_bytes(&out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn utf16le_to_utf8_basic() {
+        // "Hi" as UTF-16LE: H=0x48 0x00, i=0x69 0x00
+        let bytes = [0x48u8, 0x00, 0x69, 0x00];
+        let out = utf16le_to_utf8(&bytes);
+        assert_eq!(out, b"Hi");
+    }
+
+    #[test]
+    fn utf16le_to_utf8_odd_length_drops_trailing() {
+        let bytes = [0x48u8, 0x00, 0x69];
+        let out = utf16le_to_utf8(&bytes);
+        assert_eq!(out, b"H");
+    }
+
+    #[test]
+    fn utf8_to_utf16le_basic() {
+        let out = utf8_to_utf16le(b"Hi");
+        assert_eq!(out, [0x48, 0x00, 0x69, 0x00]);
+    }
+
+    #[test]
+    fn latin1_to_utf8_high_byte() {
+        // 0xE9 = 'é' in Latin-1 → 0xC3 0xA9 in UTF-8.
+        let out = latin1_to_utf8(&[0xE9]);
+        assert_eq!(out, [0xC3, 0xA9]);
+    }
+}

--- a/crates/perry-runtime/src/buffer/view.rs
+++ b/crates/perry-runtime/src/buffer/view.rs
@@ -1,0 +1,187 @@
+//! Issue #1205: shared backing-store semantics for
+//! `Buffer.prototype.slice` / `subarray`.
+//!
+//! Node's `Buffer.slice` / `subarray` return a *view* over the source
+//! buffer's memory: mutating the view is visible through the original
+//! and vice-versa.  Perry historically returned a freshly-allocated
+//! buffer with a copy of the slice bytes.
+//!
+//! Implementation strategy:
+//!
+//! 1.  `js_buffer_slice` still allocates a fresh `BufferHeader` and
+//!     copies the bytes.  The fresh allocation lets the LLVM codegen's
+//!     direct `gep+load/store` against the buffer pointer keep working
+//!     unchanged — `view_ptr + 8 + idx` is always valid memory.
+//! 2.  The view registry below remembers the alias relationship
+//!     between the new view and its ultimate backing buffer plus a
+//!     reverse map from the backing buffer to every live view.
+//! 3.  The runtime byte mutators (`js_buffer_set`, `js_buffer_write`,
+//!     `js_buffer_fill_range`, `js_buffer_copy`) consult the registry
+//!     and propagate writes to every aliased buffer.  Together with
+//!     the codegen slow-path indexed-write change in
+//!     `Uint8ArraySet`/`Uint8ArrayGet` (`crates/perry-codegen/src/
+//!     expr/arrays_finds.rs`), this lets `s[0] = 0x5a; buf[1]`-style
+//!     round-trips observe the mutation through both sides.
+//!
+//! Limitations that remain (tracked under follow-up subtasks of
+//! #1205):
+//! - Codegen `Uint8ArrayGet`/`Uint8ArraySet` *fast paths* (statically
+//!   typed `Buffer` locals fed by `Buffer.alloc`) skip the runtime
+//!   helper and access memory directly.  Slices of `Buffer.alloc`
+//!   buffers therefore lose the back-propagation when the alloc'd
+//!   side is the one being mutated by tight-loop code that hits the
+//!   fast path.  In practice the gap-suite shapes go through the
+//!   slow path (slice receivers and `Buffer.from(...)` initializers
+//!   aren't tracked in `buffer_data_slots`).
+
+use super::*;
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+/// Each live slice/subarray records its ultimate backing buffer plus
+/// the [offset, offset + length) range within that backing.  The
+/// offset is in bytes; `length` matches the view's own `length`
+/// field.  Slices-of-slices flatten on insert — we always resolve
+/// to the *ultimate* backing so writes don't have to walk a chain.
+#[derive(Copy, Clone)]
+pub(crate) struct ViewInfo {
+    pub backing: usize,
+    pub offset: u32,
+    pub length: u32,
+}
+
+thread_local! {
+    /// `view_ptr → ViewInfo`.  Lookups during writes are O(1).
+    static VIEW_REGISTRY: RefCell<HashMap<usize, ViewInfo>> =
+        RefCell::new(HashMap::with_capacity(64));
+    /// `backing_ptr → Vec<view_ptr>`.  Backing-side writes walk this
+    /// list to mirror bytes into every aliased view.  Vector entries
+    /// are tombstoned (set to 0) on view drop rather than removed so
+    /// hot-path iteration stays branch-light.
+    static BACKING_TO_VIEWS: RefCell<HashMap<usize, Vec<usize>>> =
+        RefCell::new(HashMap::with_capacity(64));
+}
+
+#[inline]
+pub(crate) fn lookup(view_ptr: usize) -> Option<ViewInfo> {
+    VIEW_REGISTRY.with(|r| r.borrow().get(&view_ptr).copied())
+}
+
+#[inline]
+pub(crate) fn backing_of(buf_ptr: usize) -> usize {
+    lookup(buf_ptr).map(|v| v.backing).unwrap_or(buf_ptr)
+}
+
+#[inline]
+pub(crate) fn for_each_view<F: FnMut(usize, ViewInfo)>(backing_ptr: usize, mut f: F) {
+    BACKING_TO_VIEWS.with(|m| {
+        if let Some(views) = m.borrow().get(&backing_ptr) {
+            for &view in views.iter() {
+                if view != 0 {
+                    if let Some(info) = lookup(view) {
+                        f(view, info);
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Register a freshly-allocated `view_ptr` as a view over `backing_ptr`
+/// at byte range `[offset, offset+length)`.  Resolves slices-of-slices
+/// to the ultimate backing so reads/writes never walk a chain.
+pub(crate) fn register(
+    view_ptr: usize,
+    backing_ptr_raw: usize,
+    offset_raw: u32,
+    length: u32,
+) -> ViewInfo {
+    // Walk through the chain so `slice.slice()` ends up pointing at
+    // the original `Buffer.from(...)` allocation, not the intermediate
+    // slice.  This keeps every mutation a single registry hop.
+    let (backing, offset) = if let Some(parent) = lookup(backing_ptr_raw) {
+        (parent.backing, parent.offset + offset_raw)
+    } else {
+        (backing_ptr_raw, offset_raw)
+    };
+    let info = ViewInfo {
+        backing,
+        offset,
+        length,
+    };
+    VIEW_REGISTRY.with(|r| {
+        r.borrow_mut().insert(view_ptr, info);
+    });
+    BACKING_TO_VIEWS.with(|m| {
+        m.borrow_mut().entry(backing).or_default().push(view_ptr);
+    });
+    info
+}
+
+/// Write a single byte into every live view of `backing_ptr` whose
+/// range covers `back_offset`.  Skips the originating `skip_view`
+/// pointer so a view-originated write isn't double-applied to itself.
+///
+/// SAFETY: callers must guarantee that every recorded view pointer in
+/// `BACKING_TO_VIEWS` still references a live `BufferHeader` allocation.
+/// Slab/large buffers in Perry today live for the thread's lifetime
+/// (see `buffer_alloc_small` and the malloc path), so that invariant
+/// holds.
+pub(crate) unsafe fn propagate_byte_to_views(
+    backing_ptr: usize,
+    back_offset: u32,
+    value: u8,
+    skip_view: usize,
+) {
+    for_each_view(backing_ptr, |view_ptr, info| {
+        if view_ptr == skip_view {
+            return;
+        }
+        if back_offset < info.offset {
+            return;
+        }
+        let local = back_offset - info.offset;
+        if local >= info.length {
+            return;
+        }
+        let view_data = buffer_data_mut(view_ptr as *mut BufferHeader);
+        *view_data.add(local as usize) = value;
+    });
+}
+
+/// Write a range of bytes from `src` into every live view of
+/// `backing_ptr` whose window overlaps `[back_offset, back_offset+len)`.
+/// Used by `js_buffer_write`, `js_buffer_fill_range`, and the copy
+/// helper so per-byte loops in user code don't have to call into the
+/// registry for every store.
+pub(crate) unsafe fn propagate_range_to_views(
+    backing_ptr: usize,
+    back_offset: u32,
+    src: *const u8,
+    len: u32,
+    skip_view: usize,
+) {
+    if len == 0 || src.is_null() {
+        return;
+    }
+    for_each_view(backing_ptr, |view_ptr, info| {
+        if view_ptr == skip_view {
+            return;
+        }
+        let view_start = info.offset;
+        let view_end = info.offset + info.length;
+        let back_start = back_offset;
+        let back_end = back_offset + len;
+        let lo = view_start.max(back_start);
+        let hi = view_end.min(back_end);
+        if lo >= hi {
+            return;
+        }
+        let view_data = buffer_data_mut(view_ptr as *mut BufferHeader);
+        let src_off = (lo - back_start) as usize;
+        let view_off = (lo - view_start) as usize;
+        let bytes = (hi - lo) as usize;
+        std::ptr::copy_nonoverlapping(src.add(src_off), view_data.add(view_off), bytes);
+    });
+}

--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -36,6 +36,10 @@ pub fn is_buffer_method_name(name: &str) -> bool {
             | "swap16"
             | "swap32"
             | "swap64"
+            // Issue #1206: explicit iterator-protocol surface.
+            | "values"
+            | "keys"
+            | "entries"
             // Object.prototype methods exposed on Buffer instances so
             // safer-buffer's `if (buffer.hasOwnProperty(...))` probe (and
             // similar duck-type tests in express / body-parser dependents)
@@ -168,6 +172,12 @@ pub unsafe fn dispatch_buffer_method(
             let result = crate::buffer::js_buffer_slice(buf_ptr, start, end);
             f64::from_bits(JSValue::pointer(result as *mut u8).bits())
         }
+        // Issue #1206: explicit iterator-protocol surface. Each helper
+        // returns a Buffer-iterator object whose `.next()` is dispatched
+        // through `dispatch_buffer_iterator_method` in `iter.rs`.
+        "values" => crate::buffer::js_buffer_values(buf_f64),
+        "keys" => crate::buffer::js_buffer_keys(buf_f64),
+        "entries" => crate::buffer::js_buffer_entries(buf_f64),
         // `src.copy(dst, targetStart?, sourceStart?, sourceEnd?)` — mirrors
         // Node's Buffer.prototype.copy. Returns the number of bytes copied.
         "copy" if !args.is_empty() => {

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1003,6 +1003,16 @@ pub unsafe extern "C" fn js_native_call_method(
                 // unconditionally. Removed.
                 return dispatch_native_module_method(obj, method_name, args_ptr, args_len);
             }
+            // Issue #1206: Buffer iterators returned from `buf.values()` etc.
+            // have a dedicated class id so `.next()` lands here and dispatches
+            // to the iterator-protocol helper without paying the generic
+            // closure-field scan below.
+            if (*obj).class_id == crate::buffer::BUFFER_ITERATOR_CLASS_ID {
+                return crate::buffer::dispatch_buffer_iterator_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                );
+            }
 
             // Scan object fields for a callable property (closure stored via IndexSet)
             let keys = (*obj).keys_array;
@@ -1303,6 +1313,15 @@ pub unsafe extern "C" fn js_native_call_method(
             if (*obj).class_id == NATIVE_MODULE_CLASS_ID {
                 // #853: same dead-after-return as the first arm above.
                 return dispatch_native_module_method(obj, method_name, args_ptr, args_len);
+            }
+            // Issue #1206: same class-id check as the NaN-boxed path above
+            // so a raw-pointer iterator value (uncommon, but possible after
+            // a bitcast) still routes through the iterator dispatcher.
+            if (*obj).class_id == crate::buffer::BUFFER_ITERATOR_CLASS_ID {
+                return crate::buffer::dispatch_buffer_iterator_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                );
             }
 
             // Field name scan on this object

--- a/crates/perry-stdlib/src/fetch.rs
+++ b/crates/perry-stdlib/src/fetch.rs
@@ -972,6 +972,21 @@ lazy_static::lazy_static! {
 struct BlobData {
     body: Vec<u8>,
     content_type: String,
+    // Issue #1211: when the handle was created via `new File(parts, name, opts)`
+    // these mirror the spec File interface — Blobs leave both at None.
+    file_name: Option<String>,
+    last_modified_ms: Option<f64>,
+}
+
+impl BlobData {
+    fn blob(body: Vec<u8>, content_type: String) -> Self {
+        BlobData {
+            body,
+            content_type,
+            file_name: None,
+            last_modified_ms: None,
+        }
+    }
 }
 
 fn alloc_blob(data: BlobData) -> usize {
@@ -981,6 +996,16 @@ fn alloc_blob(data: BlobData) -> usize {
     drop(id_guard);
     BLOB_REGISTRY.lock().unwrap().insert(id, data);
     id
+}
+
+// Issue #1211 Object URLs: `URL.createObjectURL(blob)` returns a
+// `blob:nodedata:<id>` URL and `URL.revokeObjectURL(url)` removes it.
+// `resolveObjectURL(url)` returns the same blob handle (or undefined
+// after revoke).  The registry is process-global; entries live until
+// `revokeObjectURL` clears them.
+lazy_static::lazy_static! {
+    static ref OBJECT_URL_REGISTRY: Mutex<HashMap<String, usize>> = Mutex::new(HashMap::new());
+    static ref NEXT_OBJECT_URL_ID: Mutex<u64> = Mutex::new(1);
 }
 
 fn alloc_headers(store: HeadersStore) -> usize {
@@ -1317,15 +1342,9 @@ pub unsafe extern "C" fn js_response_blob(handle: f64) -> *mut perry_runtime::Pr
                     .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
                     .map(|(_, v)| v.clone())
                     .unwrap_or_default();
-                BlobData {
-                    body: resp.body.clone(),
-                    content_type: ct,
-                }
+                BlobData::blob(resp.body.clone(), ct)
             }
-            None => BlobData {
-                body: Vec::new(),
-                content_type: String::new(),
-            },
+            None => BlobData::blob(Vec::new(), String::new()),
         }
     };
     let blob_id = alloc_blob(data);
@@ -1467,10 +1486,228 @@ pub unsafe extern "C" fn js_blob_slice(
     } else {
         string_from_header(type_ptr).unwrap_or_default()
     };
-    handle_to_f64(alloc_blob(BlobData {
-        body: slice,
-        content_type: new_type,
-    }))
+    handle_to_f64(alloc_blob(BlobData::blob(slice, new_type)))
+}
+
+// ----------------- Issue #1211 Blob/File constructor + object URL FFI -----------------
+
+/// Walk a JS value passed as the `parts` argument of
+/// `new Blob([...])` / `new File([...], name)` and append its bytes
+/// to `out`. Supported part shapes:
+///   - String (NaN-boxed STRING_TAG): UTF-8 encode the characters.
+///   - Buffer / Uint8Array (NaN-boxed POINTER_TAG → BufferHeader):
+///     copy the raw bytes.
+///   - Blob handle (NaN-boxed POINTER_TAG → small int id):
+///     fetch the registered body bytes.
+///   - Array (NaN-boxed POINTER_TAG → ArrayHeader): recurse so
+///     `[["a", "b"], "c"]` flattens like Node's behavior.
+/// Anything else is silently dropped; matches Node's relaxed
+/// behavior for stringifying non-recognized inputs to "".
+unsafe fn append_blob_part_bytes(part: f64, out: &mut Vec<u8>) {
+    let bits = part.to_bits();
+    let top16 = bits >> 48;
+    // STRING_TAG ─ NaN-box a *mut StringHeader.
+    if top16 == 0x7FFF {
+        let str_ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+        if let Some(s) = string_from_header(str_ptr) {
+            out.extend_from_slice(s.as_bytes());
+        }
+        return;
+    }
+    // POINTER_TAG ─ either a buffer, an array (recurse), or a small-id Blob.
+    if top16 == 0x7FFD {
+        let addr = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+        // Small id → registered Blob handle. The Blob FFI carries
+        // ids well below page-size so the cutoff is safe.
+        if addr != 0 && addr < 0x10000 {
+            if let Some(body) = blob_bytes_clone(addr) {
+                out.extend_from_slice(&body);
+                return;
+            }
+        }
+        // BufferHeader?
+        if addr >= 0x1000 && perry_runtime::buffer::is_registered_buffer(addr) {
+            let buf = addr as *const perry_runtime::buffer::BufferHeader;
+            let len = (*buf).length as usize;
+            let data = perry_runtime::buffer::buffer_data(buf);
+            out.extend_from_slice(std::slice::from_raw_parts(data, len));
+            return;
+        }
+        // Array? Walk elements and recurse.
+        let arr_ptr = addr as *const perry_runtime::array::ArrayHeader;
+        if !arr_ptr.is_null() && addr >= 0x1000 {
+            let gc_header = (arr_ptr as *const u8).sub(perry_runtime::gc::GC_HEADER_SIZE)
+                as *const perry_runtime::gc::GcHeader;
+            let obj_type = (*gc_header).obj_type;
+            if obj_type == perry_runtime::gc::GC_TYPE_ARRAY
+                || obj_type == perry_runtime::gc::GC_TYPE_LAZY_ARRAY
+            {
+                let len = perry_runtime::array::js_array_length(arr_ptr);
+                for i in 0..len {
+                    let elem = perry_runtime::array::js_array_get(arr_ptr, i);
+                    append_blob_part_bytes(f64::from_bits(elem.bits()), out);
+                }
+            }
+        }
+    }
+}
+
+/// `new Blob(parts, { type })` — allocate a Blob handle from the
+/// flattened bytes of `parts`.  Returns a NaN-boxed POINTER_TAG
+/// handle identical to the one `response.blob()` produces, so all
+/// subsequent `blob.size` / `blob.type` / `blob.text()` /
+/// `blob.arrayBuffer()` / `blob.slice()` dispatch flows through the
+/// existing `module == "blob"` arm in codegen.
+#[no_mangle]
+pub unsafe extern "C" fn js_blob_new(parts: f64, content_type: f64) -> f64 {
+    let mut body: Vec<u8> = Vec::new();
+    append_blob_part_bytes(parts, &mut body);
+    let type_str = {
+        let bits = content_type.to_bits();
+        if (bits >> 48) == 0x7FFF {
+            let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+            string_from_header(p).unwrap_or_default()
+        } else {
+            String::new()
+        }
+    };
+    handle_to_f64(alloc_blob(BlobData::blob(body, type_str)))
+}
+
+/// `new File(parts, name, { type, lastModified })` — same registry as
+/// Blob, with `name` / `last_modified_ms` populated so
+/// `js_file_name` / `js_file_last_modified` can read them back. The
+/// returned handle is `instanceof Blob` (same registry); dispatch
+/// routes File-specific property reads via `module == "blob",
+/// class_name == "File"` in codegen.
+#[no_mangle]
+pub unsafe extern "C" fn js_file_new(
+    parts: f64,
+    name: f64,
+    content_type: f64,
+    last_modified: f64,
+) -> f64 {
+    let mut body: Vec<u8> = Vec::new();
+    append_blob_part_bytes(parts, &mut body);
+    let name_str = {
+        let bits = name.to_bits();
+        if (bits >> 48) == 0x7FFF {
+            let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+            string_from_header(p).unwrap_or_default()
+        } else {
+            String::new()
+        }
+    };
+    let type_str = {
+        let bits = content_type.to_bits();
+        if (bits >> 48) == 0x7FFF {
+            let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+            string_from_header(p).unwrap_or_default()
+        } else {
+            String::new()
+        }
+    };
+    // `last_modified` is a plain numeric f64 argument (callers pass
+    // NaN to signal "use Date.now()" — match Node's default).
+    let lm = if last_modified.is_nan() {
+        // Cheap stamp: wall clock in ms.  Same source the codegen
+        // uses for `Date.now()` so two consecutive `new File()` calls
+        // produce a monotonic-ish sequence.
+        use std::time::{SystemTime, UNIX_EPOCH};
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as f64)
+            .unwrap_or(0.0)
+    } else {
+        last_modified
+    };
+    let data = BlobData {
+        body,
+        content_type: type_str,
+        file_name: Some(name_str),
+        last_modified_ms: Some(lm),
+    };
+    handle_to_f64(alloc_blob(data))
+}
+
+/// `file.name` — empty string for plain Blob handles.
+#[no_mangle]
+pub unsafe extern "C" fn js_file_name(handle: f64) -> *mut StringHeader {
+    let id = handle_id(handle);
+    let name = BLOB_REGISTRY
+        .lock()
+        .unwrap()
+        .get(&id)
+        .and_then(|b| b.file_name.clone())
+        .unwrap_or_default();
+    js_string_from_bytes(name.as_ptr(), name.len() as u32)
+}
+
+/// `file.lastModified` — Date-now-style timestamp; 0 for plain Blobs.
+#[no_mangle]
+pub extern "C" fn js_file_last_modified(handle: f64) -> f64 {
+    let id = handle_id(handle);
+    BLOB_REGISTRY
+        .lock()
+        .unwrap()
+        .get(&id)
+        .and_then(|b| b.last_modified_ms)
+        .unwrap_or(0.0)
+}
+
+/// `URL.createObjectURL(blob)` — register the Blob handle under a
+/// fresh `blob:nodedata:<n>` URL and return the URL string.
+#[no_mangle]
+pub unsafe extern "C" fn js_url_create_object_url(blob_handle: f64) -> *mut StringHeader {
+    let id = handle_id(blob_handle);
+    if id == 0 {
+        return js_string_from_bytes(b"".as_ptr(), 0);
+    }
+    let url = {
+        let mut counter = NEXT_OBJECT_URL_ID.lock().unwrap();
+        let n = *counter;
+        *counter += 1;
+        // Node's published shape: `blob:nodedata:<uuid>`. We use a
+        // monotonic counter — the actual identity bytes don't matter
+        // to `resolveObjectURL` so long as they round-trip.
+        format!("blob:nodedata:{:032x}", n)
+    };
+    OBJECT_URL_REGISTRY.lock().unwrap().insert(url.clone(), id);
+    js_string_from_bytes(url.as_ptr(), url.len() as u32)
+}
+
+/// `URL.revokeObjectURL(url)` — drop the registry entry, if any.
+#[no_mangle]
+pub unsafe extern "C" fn js_url_revoke_object_url(url: f64) {
+    let bits = url.to_bits();
+    if (bits >> 48) != 0x7FFF {
+        return;
+    }
+    let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+    let s = match string_from_header(p) {
+        Some(s) => s,
+        None => return,
+    };
+    OBJECT_URL_REGISTRY.lock().unwrap().remove(&s);
+}
+
+/// `import { resolveObjectURL } from "node:buffer"` — return the
+/// registered Blob handle for `url`, or `undefined` after revoke.
+#[no_mangle]
+pub unsafe extern "C" fn js_buffer_resolve_object_url(url: f64) -> f64 {
+    let bits = url.to_bits();
+    if (bits >> 48) != 0x7FFF {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+    let s = match string_from_header(p) {
+        Some(s) => s,
+        None => return f64::from_bits(TAG_UNDEFINED),
+    };
+    match OBJECT_URL_REGISTRY.lock().unwrap().get(&s).copied() {
+        Some(id) => handle_to_f64(id),
+        None => f64::from_bits(TAG_UNDEFINED),
+    }
 }
 
 // ----------------- Web Streams bridge helpers (issue #237) -----------------

--- a/crates/perry-stdlib/src/fetch.rs
+++ b/crates/perry-stdlib/src/fetch.rs
@@ -77,7 +77,7 @@ struct FetchResponse {
 /// net / DB) still use the legacy form until Phase 2 of the unification migrates
 /// them to NaN-boxed too.
 #[inline]
-fn handle_id(value: f64) -> usize {
+pub(crate) fn handle_id(value: f64) -> usize {
     let bits = value.to_bits();
     let top16 = bits >> 48;
     if top16 >= 0x7FF8 {
@@ -95,12 +95,12 @@ fn handle_id(value: f64) -> usize {
 /// NaN-box a Web Fetch handle id (registry index) into a POINTER_TAG f64
 /// for return across the FFI boundary. Pairs with `handle_id` on accessor entry.
 #[inline]
-fn handle_to_f64(id: usize) -> f64 {
+pub(crate) fn handle_to_f64(id: usize) -> f64 {
     perry_runtime::value::js_nanbox_pointer(id as i64)
 }
 
 /// Helper to extract string from StringHeader pointer
-unsafe fn string_from_header(ptr: *const StringHeader) -> Option<String> {
+pub(crate) unsafe fn string_from_header(ptr: *const StringHeader) -> Option<String> {
     // NaN-boxed TAG_UNDEFINED (0x7FFC_0000_0000_0001) unboxes to 0x1
     // after POINTER_MASK. Treat any pointer below page size as invalid.
     if ptr.is_null() || (ptr as usize) < 0x1000 {
@@ -904,7 +904,7 @@ pub extern "C" fn js_fetch_stream_close(handle: f64) -> f64 {
 // Web Fetch API: Headers, Request, Response constructors and methods
 // ========================================================================
 
-const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+pub(crate) const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
 const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
 const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
@@ -964,22 +964,22 @@ lazy_static::lazy_static! {
     static ref NEXT_HEADERS_ID: Mutex<usize> = Mutex::new(1);
     static ref REQUEST_REGISTRY: Mutex<HashMap<usize, RequestRecord>> = Mutex::new(HashMap::new());
     static ref NEXT_REQUEST_ID: Mutex<usize> = Mutex::new(1);
-    static ref BLOB_REGISTRY: Mutex<HashMap<usize, BlobData>> = Mutex::new(HashMap::new());
+    pub(crate) static ref BLOB_REGISTRY: Mutex<HashMap<usize, BlobData>> = Mutex::new(HashMap::new());
     static ref NEXT_BLOB_ID: Mutex<usize> = Mutex::new(1);
 }
 
 #[derive(Clone)]
-struct BlobData {
-    body: Vec<u8>,
-    content_type: String,
+pub(crate) struct BlobData {
+    pub(crate) body: Vec<u8>,
+    pub(crate) content_type: String,
     // Issue #1211: when the handle was created via `new File(parts, name, opts)`
     // these mirror the spec File interface — Blobs leave both at None.
-    file_name: Option<String>,
-    last_modified_ms: Option<f64>,
+    pub(crate) file_name: Option<String>,
+    pub(crate) last_modified_ms: Option<f64>,
 }
 
 impl BlobData {
-    fn blob(body: Vec<u8>, content_type: String) -> Self {
+    pub(crate) fn blob(body: Vec<u8>, content_type: String) -> Self {
         BlobData {
             body,
             content_type,
@@ -989,23 +989,13 @@ impl BlobData {
     }
 }
 
-fn alloc_blob(data: BlobData) -> usize {
+pub(crate) fn alloc_blob(data: BlobData) -> usize {
     let mut id_guard = NEXT_BLOB_ID.lock().unwrap();
     let id = *id_guard;
     *id_guard += 1;
     drop(id_guard);
     BLOB_REGISTRY.lock().unwrap().insert(id, data);
     id
-}
-
-// Issue #1211 Object URLs: `URL.createObjectURL(blob)` returns a
-// `blob:nodedata:<id>` URL and `URL.revokeObjectURL(url)` removes it.
-// `resolveObjectURL(url)` returns the same blob handle (or undefined
-// after revoke).  The registry is process-global; entries live until
-// `revokeObjectURL` clears them.
-lazy_static::lazy_static! {
-    static ref OBJECT_URL_REGISTRY: Mutex<HashMap<String, usize>> = Mutex::new(HashMap::new());
-    static ref NEXT_OBJECT_URL_ID: Mutex<u64> = Mutex::new(1);
 }
 
 fn alloc_headers(store: HeadersStore) -> usize {
@@ -1489,226 +1479,9 @@ pub unsafe extern "C" fn js_blob_slice(
     handle_to_f64(alloc_blob(BlobData::blob(slice, new_type)))
 }
 
-// ----------------- Issue #1211 Blob/File constructor + object URL FFI -----------------
-
-/// Walk a JS value passed as the `parts` argument of
-/// `new Blob([...])` / `new File([...], name)` and append its bytes
-/// to `out`. Supported part shapes:
-///   - String (NaN-boxed STRING_TAG): UTF-8 encode the characters.
-///   - Buffer / Uint8Array (NaN-boxed POINTER_TAG → BufferHeader):
-///     copy the raw bytes.
-///   - Blob handle (NaN-boxed POINTER_TAG → small int id):
-///     fetch the registered body bytes.
-///   - Array (NaN-boxed POINTER_TAG → ArrayHeader): recurse so
-///     `[["a", "b"], "c"]` flattens like Node's behavior.
-/// Anything else is silently dropped; matches Node's relaxed
-/// behavior for stringifying non-recognized inputs to "".
-unsafe fn append_blob_part_bytes(part: f64, out: &mut Vec<u8>) {
-    let bits = part.to_bits();
-    let top16 = bits >> 48;
-    // STRING_TAG ─ NaN-box a *mut StringHeader.
-    if top16 == 0x7FFF {
-        let str_ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
-        if let Some(s) = string_from_header(str_ptr) {
-            out.extend_from_slice(s.as_bytes());
-        }
-        return;
-    }
-    // POINTER_TAG ─ either a buffer, an array (recurse), or a small-id Blob.
-    if top16 == 0x7FFD {
-        let addr = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
-        // Small id → registered Blob handle. The Blob FFI carries
-        // ids well below page-size so the cutoff is safe.
-        if addr != 0 && addr < 0x10000 {
-            if let Some(body) = blob_bytes_clone(addr) {
-                out.extend_from_slice(&body);
-                return;
-            }
-        }
-        // BufferHeader?
-        if addr >= 0x1000 && perry_runtime::buffer::is_registered_buffer(addr) {
-            let buf = addr as *const perry_runtime::buffer::BufferHeader;
-            let len = (*buf).length as usize;
-            let data = perry_runtime::buffer::buffer_data(buf);
-            out.extend_from_slice(std::slice::from_raw_parts(data, len));
-            return;
-        }
-        // Array? Walk elements and recurse.
-        let arr_ptr = addr as *const perry_runtime::array::ArrayHeader;
-        if !arr_ptr.is_null() && addr >= 0x1000 {
-            let gc_header = (arr_ptr as *const u8).sub(perry_runtime::gc::GC_HEADER_SIZE)
-                as *const perry_runtime::gc::GcHeader;
-            let obj_type = (*gc_header).obj_type;
-            if obj_type == perry_runtime::gc::GC_TYPE_ARRAY
-                || obj_type == perry_runtime::gc::GC_TYPE_LAZY_ARRAY
-            {
-                let len = perry_runtime::array::js_array_length(arr_ptr);
-                for i in 0..len {
-                    let elem = perry_runtime::array::js_array_get(arr_ptr, i);
-                    append_blob_part_bytes(f64::from_bits(elem.bits()), out);
-                }
-            }
-        }
-    }
-}
-
-/// `new Blob(parts, { type })` — allocate a Blob handle from the
-/// flattened bytes of `parts`.  Returns a NaN-boxed POINTER_TAG
-/// handle identical to the one `response.blob()` produces, so all
-/// subsequent `blob.size` / `blob.type` / `blob.text()` /
-/// `blob.arrayBuffer()` / `blob.slice()` dispatch flows through the
-/// existing `module == "blob"` arm in codegen.
-#[no_mangle]
-pub unsafe extern "C" fn js_blob_new(parts: f64, content_type: f64) -> f64 {
-    let mut body: Vec<u8> = Vec::new();
-    append_blob_part_bytes(parts, &mut body);
-    let type_str = {
-        let bits = content_type.to_bits();
-        if (bits >> 48) == 0x7FFF {
-            let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
-            string_from_header(p).unwrap_or_default()
-        } else {
-            String::new()
-        }
-    };
-    handle_to_f64(alloc_blob(BlobData::blob(body, type_str)))
-}
-
-/// `new File(parts, name, { type, lastModified })` — same registry as
-/// Blob, with `name` / `last_modified_ms` populated so
-/// `js_file_name` / `js_file_last_modified` can read them back. The
-/// returned handle is `instanceof Blob` (same registry); dispatch
-/// routes File-specific property reads via `module == "blob",
-/// class_name == "File"` in codegen.
-#[no_mangle]
-pub unsafe extern "C" fn js_file_new(
-    parts: f64,
-    name: f64,
-    content_type: f64,
-    last_modified: f64,
-) -> f64 {
-    let mut body: Vec<u8> = Vec::new();
-    append_blob_part_bytes(parts, &mut body);
-    let name_str = {
-        let bits = name.to_bits();
-        if (bits >> 48) == 0x7FFF {
-            let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
-            string_from_header(p).unwrap_or_default()
-        } else {
-            String::new()
-        }
-    };
-    let type_str = {
-        let bits = content_type.to_bits();
-        if (bits >> 48) == 0x7FFF {
-            let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
-            string_from_header(p).unwrap_or_default()
-        } else {
-            String::new()
-        }
-    };
-    // `last_modified` is a plain numeric f64 argument (callers pass
-    // NaN to signal "use Date.now()" — match Node's default).
-    let lm = if last_modified.is_nan() {
-        // Cheap stamp: wall clock in ms.  Same source the codegen
-        // uses for `Date.now()` so two consecutive `new File()` calls
-        // produce a monotonic-ish sequence.
-        use std::time::{SystemTime, UNIX_EPOCH};
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_millis() as f64)
-            .unwrap_or(0.0)
-    } else {
-        last_modified
-    };
-    let data = BlobData {
-        body,
-        content_type: type_str,
-        file_name: Some(name_str),
-        last_modified_ms: Some(lm),
-    };
-    handle_to_f64(alloc_blob(data))
-}
-
-/// `file.name` — empty string for plain Blob handles.
-#[no_mangle]
-pub unsafe extern "C" fn js_file_name(handle: f64) -> *mut StringHeader {
-    let id = handle_id(handle);
-    let name = BLOB_REGISTRY
-        .lock()
-        .unwrap()
-        .get(&id)
-        .and_then(|b| b.file_name.clone())
-        .unwrap_or_default();
-    js_string_from_bytes(name.as_ptr(), name.len() as u32)
-}
-
-/// `file.lastModified` — Date-now-style timestamp; 0 for plain Blobs.
-#[no_mangle]
-pub extern "C" fn js_file_last_modified(handle: f64) -> f64 {
-    let id = handle_id(handle);
-    BLOB_REGISTRY
-        .lock()
-        .unwrap()
-        .get(&id)
-        .and_then(|b| b.last_modified_ms)
-        .unwrap_or(0.0)
-}
-
-/// `URL.createObjectURL(blob)` — register the Blob handle under a
-/// fresh `blob:nodedata:<n>` URL and return the URL string.
-#[no_mangle]
-pub unsafe extern "C" fn js_url_create_object_url(blob_handle: f64) -> *mut StringHeader {
-    let id = handle_id(blob_handle);
-    if id == 0 {
-        return js_string_from_bytes(b"".as_ptr(), 0);
-    }
-    let url = {
-        let mut counter = NEXT_OBJECT_URL_ID.lock().unwrap();
-        let n = *counter;
-        *counter += 1;
-        // Node's published shape: `blob:nodedata:<uuid>`. We use a
-        // monotonic counter — the actual identity bytes don't matter
-        // to `resolveObjectURL` so long as they round-trip.
-        format!("blob:nodedata:{:032x}", n)
-    };
-    OBJECT_URL_REGISTRY.lock().unwrap().insert(url.clone(), id);
-    js_string_from_bytes(url.as_ptr(), url.len() as u32)
-}
-
-/// `URL.revokeObjectURL(url)` — drop the registry entry, if any.
-#[no_mangle]
-pub unsafe extern "C" fn js_url_revoke_object_url(url: f64) {
-    let bits = url.to_bits();
-    if (bits >> 48) != 0x7FFF {
-        return;
-    }
-    let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
-    let s = match string_from_header(p) {
-        Some(s) => s,
-        None => return,
-    };
-    OBJECT_URL_REGISTRY.lock().unwrap().remove(&s);
-}
-
-/// `import { resolveObjectURL } from "node:buffer"` — return the
-/// registered Blob handle for `url`, or `undefined` after revoke.
-#[no_mangle]
-pub unsafe extern "C" fn js_buffer_resolve_object_url(url: f64) -> f64 {
-    let bits = url.to_bits();
-    if (bits >> 48) != 0x7FFF {
-        return f64::from_bits(TAG_UNDEFINED);
-    }
-    let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
-    let s = match string_from_header(p) {
-        Some(s) => s,
-        None => return f64::from_bits(TAG_UNDEFINED),
-    };
-    match OBJECT_URL_REGISTRY.lock().unwrap().get(&s).copied() {
-        Some(id) => handle_to_f64(id),
-        None => f64::from_bits(TAG_UNDEFINED),
-    }
-}
+// Issue #1211: Blob / File constructors + object-URL registry now
+// live in sibling `fetch_blob.rs` to keep this file under the
+// 2,000-line size gate.  See that module for the FFI entry points.
 
 // ----------------- Web Streams bridge helpers (issue #237) -----------------
 //

--- a/crates/perry-stdlib/src/fetch_blob.rs
+++ b/crates/perry-stdlib/src/fetch_blob.rs
@@ -1,0 +1,250 @@
+//! Issue #1211: `node:buffer` Blob/File constructors + object-URL
+//! registry.  Split out of `fetch.rs` to keep that file under the
+//! 2,000-line lint gate.
+//!
+//! Hand-offs into `fetch.rs`:
+//!   - `BLOB_REGISTRY`/`alloc_blob`/`BlobData` (storage + record shape)
+//!   - `handle_id` / `handle_to_f64` (handle <-> NaN-boxed f64)
+//!   - `string_from_header` (`*StringHeader` → `Option<String>`)
+//!   - `TAG_UNDEFINED` constant
+//! All exposed as `pub(crate)` in fetch.rs so this module can build on
+//! the same registry without re-implementing the ABI.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use perry_runtime::string::{js_string_from_bytes, StringHeader};
+
+use crate::fetch::{
+    alloc_blob, blob_bytes_clone, handle_id, handle_to_f64, string_from_header, BlobData,
+    BLOB_REGISTRY, TAG_UNDEFINED,
+};
+
+// Object URLs: `URL.createObjectURL(blob)` returns a
+// `blob:nodedata:<id>` URL and `URL.revokeObjectURL(url)` removes it.
+// `resolveObjectURL(url)` returns the same blob handle (or undefined
+// after revoke).  The registry is process-global; entries live until
+// `revokeObjectURL` clears them.
+lazy_static::lazy_static! {
+    static ref OBJECT_URL_REGISTRY: Mutex<HashMap<String, usize>> = Mutex::new(HashMap::new());
+    static ref NEXT_OBJECT_URL_ID: Mutex<u64> = Mutex::new(1);
+}
+
+/// Walk a JS value passed as the `parts` argument of
+/// `new Blob([...])` / `new File([...], name)` and append its bytes
+/// to `out`. Supported part shapes:
+///   - String (NaN-boxed STRING_TAG): UTF-8 encode the characters.
+///   - Buffer / Uint8Array (NaN-boxed POINTER_TAG → BufferHeader):
+///     copy the raw bytes.
+///   - Blob handle (NaN-boxed POINTER_TAG → small int id):
+///     fetch the registered body bytes.
+///   - Array (NaN-boxed POINTER_TAG → ArrayHeader): recurse so
+///     `[["a", "b"], "c"]` flattens like Node's behavior.
+/// Anything else is silently dropped; matches Node's relaxed
+/// behavior for stringifying non-recognized inputs to "".
+unsafe fn append_blob_part_bytes(part: f64, out: &mut Vec<u8>) {
+    let bits = part.to_bits();
+    let top16 = bits >> 48;
+    // STRING_TAG ─ NaN-box a *mut StringHeader.
+    if top16 == 0x7FFF {
+        let str_ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+        if let Some(s) = string_from_header(str_ptr) {
+            out.extend_from_slice(s.as_bytes());
+        }
+        return;
+    }
+    // POINTER_TAG ─ either a buffer, an array (recurse), or a small-id Blob.
+    if top16 == 0x7FFD {
+        let addr = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+        // Small id → registered Blob handle. The Blob FFI carries
+        // ids well below page-size so the cutoff is safe.
+        if addr != 0 && addr < 0x10000 {
+            if let Some(body) = blob_bytes_clone(addr) {
+                out.extend_from_slice(&body);
+                return;
+            }
+        }
+        // BufferHeader?
+        if addr >= 0x1000 && perry_runtime::buffer::is_registered_buffer(addr) {
+            let buf = addr as *const perry_runtime::buffer::BufferHeader;
+            let len = (*buf).length as usize;
+            let data = perry_runtime::buffer::buffer_data(buf);
+            out.extend_from_slice(std::slice::from_raw_parts(data, len));
+            return;
+        }
+        // Array? Walk elements and recurse.
+        let arr_ptr = addr as *const perry_runtime::array::ArrayHeader;
+        if !arr_ptr.is_null() && addr >= 0x1000 {
+            let gc_header = (arr_ptr as *const u8).sub(perry_runtime::gc::GC_HEADER_SIZE)
+                as *const perry_runtime::gc::GcHeader;
+            let obj_type = (*gc_header).obj_type;
+            if obj_type == perry_runtime::gc::GC_TYPE_ARRAY
+                || obj_type == perry_runtime::gc::GC_TYPE_LAZY_ARRAY
+            {
+                let len = perry_runtime::array::js_array_length(arr_ptr);
+                for i in 0..len {
+                    let elem = perry_runtime::array::js_array_get(arr_ptr, i);
+                    append_blob_part_bytes(f64::from_bits(elem.bits()), out);
+                }
+            }
+        }
+    }
+}
+
+/// `new Blob(parts, { type })` — allocate a Blob handle from the
+/// flattened bytes of `parts`.  Returns a NaN-boxed POINTER_TAG
+/// handle identical to the one `response.blob()` produces, so all
+/// subsequent `blob.size` / `blob.type` / `blob.text()` /
+/// `blob.arrayBuffer()` / `blob.slice()` dispatch flows through the
+/// existing `module == "blob"` arm in codegen.
+#[no_mangle]
+pub unsafe extern "C" fn js_blob_new(parts: f64, content_type: f64) -> f64 {
+    let mut body: Vec<u8> = Vec::new();
+    append_blob_part_bytes(parts, &mut body);
+    let type_str = {
+        let bits = content_type.to_bits();
+        if (bits >> 48) == 0x7FFF {
+            let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+            string_from_header(p).unwrap_or_default()
+        } else {
+            String::new()
+        }
+    };
+    handle_to_f64(alloc_blob(BlobData::blob(body, type_str)))
+}
+
+/// `new File(parts, name, { type, lastModified })` — same registry as
+/// Blob, with `name` / `last_modified_ms` populated so
+/// `js_file_name` / `js_file_last_modified` can read them back. The
+/// returned handle is `instanceof Blob` (same registry); dispatch
+/// routes File-specific property reads via `module == "blob",
+/// class_name == "File"` in codegen.
+#[no_mangle]
+pub unsafe extern "C" fn js_file_new(
+    parts: f64,
+    name: f64,
+    content_type: f64,
+    last_modified: f64,
+) -> f64 {
+    let mut body: Vec<u8> = Vec::new();
+    append_blob_part_bytes(parts, &mut body);
+    let name_str = {
+        let bits = name.to_bits();
+        if (bits >> 48) == 0x7FFF {
+            let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+            string_from_header(p).unwrap_or_default()
+        } else {
+            String::new()
+        }
+    };
+    let type_str = {
+        let bits = content_type.to_bits();
+        if (bits >> 48) == 0x7FFF {
+            let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+            string_from_header(p).unwrap_or_default()
+        } else {
+            String::new()
+        }
+    };
+    // `last_modified` is a plain numeric f64 argument (callers pass
+    // NaN to signal "use Date.now()" — match Node's default).
+    let lm = if last_modified.is_nan() {
+        // Cheap stamp: wall clock in ms.  Same source the codegen
+        // uses for `Date.now()` so two consecutive `new File()` calls
+        // produce a monotonic-ish sequence.
+        use std::time::{SystemTime, UNIX_EPOCH};
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as f64)
+            .unwrap_or(0.0)
+    } else {
+        last_modified
+    };
+    let data = BlobData {
+        body,
+        content_type: type_str,
+        file_name: Some(name_str),
+        last_modified_ms: Some(lm),
+    };
+    handle_to_f64(alloc_blob(data))
+}
+
+/// `file.name` — empty string for plain Blob handles.
+#[no_mangle]
+pub unsafe extern "C" fn js_file_name(handle: f64) -> *mut StringHeader {
+    let id = handle_id(handle);
+    let name = BLOB_REGISTRY
+        .lock()
+        .unwrap()
+        .get(&id)
+        .and_then(|b| b.file_name.clone())
+        .unwrap_or_default();
+    js_string_from_bytes(name.as_ptr(), name.len() as u32)
+}
+
+/// `file.lastModified` — Date-now-style timestamp; 0 for plain Blobs.
+#[no_mangle]
+pub extern "C" fn js_file_last_modified(handle: f64) -> f64 {
+    let id = handle_id(handle);
+    BLOB_REGISTRY
+        .lock()
+        .unwrap()
+        .get(&id)
+        .and_then(|b| b.last_modified_ms)
+        .unwrap_or(0.0)
+}
+
+/// `URL.createObjectURL(blob)` — register the Blob handle under a
+/// fresh `blob:nodedata:<n>` URL and return the URL string.
+#[no_mangle]
+pub unsafe extern "C" fn js_url_create_object_url(blob_handle: f64) -> *mut StringHeader {
+    let id = handle_id(blob_handle);
+    if id == 0 {
+        return js_string_from_bytes(b"".as_ptr(), 0);
+    }
+    let url = {
+        let mut counter = NEXT_OBJECT_URL_ID.lock().unwrap();
+        let n = *counter;
+        *counter += 1;
+        // Node's published shape: `blob:nodedata:<uuid>`. We use a
+        // monotonic counter — the actual identity bytes don't matter
+        // to `resolveObjectURL` so long as they round-trip.
+        format!("blob:nodedata:{:032x}", n)
+    };
+    OBJECT_URL_REGISTRY.lock().unwrap().insert(url.clone(), id);
+    js_string_from_bytes(url.as_ptr(), url.len() as u32)
+}
+
+/// `URL.revokeObjectURL(url)` — drop the registry entry, if any.
+#[no_mangle]
+pub unsafe extern "C" fn js_url_revoke_object_url(url: f64) {
+    let bits = url.to_bits();
+    if (bits >> 48) != 0x7FFF {
+        return;
+    }
+    let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+    let s = match string_from_header(p) {
+        Some(s) => s,
+        None => return,
+    };
+    OBJECT_URL_REGISTRY.lock().unwrap().remove(&s);
+}
+
+/// `import { resolveObjectURL } from "node:buffer"` — return the
+/// registered Blob handle for `url`, or `undefined` after revoke.
+#[no_mangle]
+pub unsafe extern "C" fn js_buffer_resolve_object_url(url: f64) -> f64 {
+    let bits = url.to_bits();
+    if (bits >> 48) != 0x7FFF {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let p = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+    let s = match string_from_header(p) {
+        Some(s) => s,
+        None => return f64::from_bits(TAG_UNDEFINED),
+    };
+    match OBJECT_URL_REGISTRY.lock().unwrap().get(&s).copied() {
+        Some(id) => handle_to_f64(id),
+        None => f64::from_bits(TAG_UNDEFINED),
+    }
+}

--- a/crates/perry-stdlib/src/lib.rs
+++ b/crates/perry-stdlib/src/lib.rs
@@ -134,6 +134,12 @@ pub use fastify::*;
 pub mod fetch;
 #[cfg(feature = "http-client")]
 pub use fetch::*;
+// Issue #1211: Blob/File constructors + object-URL helpers split out
+// of fetch.rs to keep that file under the 2,000-line lint gate.
+#[cfg(feature = "http-client")]
+pub mod fetch_blob;
+#[cfg(feature = "http-client")]
+pub use fetch_blob::*;
 
 #[cfg(feature = "http-client")]
 pub mod http;

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1061 entries across 79 modules
+// Coverage: 1067 entries across 79 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -152,7 +152,11 @@ declare module "bignumber.js" {
 
 declare module "buffer" {
   /** stdlib */
+  export class Blob { [key: string]: any; }
+  /** stdlib */
   export class Buffer { [key: string]: any; }
+  /** stdlib */
+  export class File { [key: string]: any; }
   /** stdlib */
   export const constants: any;
   /** stdlib */
@@ -181,6 +185,10 @@ declare module "buffer" {
   export function isUtf8(...args: any[]): any;
   /** stdlib */
   export function of(...args: any[]): any;
+  /** stdlib */
+  export function resolveObjectURL(...args: any[]): any;
+  /** stdlib */
+  export function transcode(...args: any[]): any;
 }
 
 declare module "cheerio" {
@@ -1520,6 +1528,8 @@ declare module "url" {
   /** stdlib */
   export class URLSearchParams { [key: string]: any; }
   /** stdlib */
+  export function createObjectURL(...args: any[]): any;
+  /** stdlib */
   export function domainToASCII(...args: any[]): any;
   /** stdlib */
   export function domainToUnicode(...args: any[]): any;
@@ -1533,6 +1543,8 @@ declare module "url" {
   export function pathToFileURL(...args: any[]): any;
   /** stdlib */
   export function resolve(...args: any[]): any;
+  /** stdlib */
+  export function revokeObjectURL(...args: any[]): any;
   /** stdlib */
   export function urlToHttpOptions(...args: any[]): any;
 }

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1061 entries across 79 modules.
+Total: 1067 entries across 79 modules.
 
 ## Modules
 
@@ -232,7 +232,9 @@ Total: 1061 entries across 79 modules.
 
 ### Classes
 
+- `Blob`
 - `Buffer`
+- `File`
 
 ### Methods
 
@@ -247,6 +249,8 @@ Total: 1061 entries across 79 modules.
 - `isEncoding` — module
 - `isUtf8` — module
 - `of` — module
+- `resolveObjectURL` — module
+- `transcode` — module
 
 ### Properties
 
@@ -1537,6 +1541,7 @@ Total: 1061 entries across 79 modules.
 
 ### Methods
 
+- `createObjectURL` — module
 - `domainToASCII` — module
 - `domainToUnicode` — module
 - `fileURLToPath` — module
@@ -1544,6 +1549,7 @@ Total: 1061 entries across 79 modules.
 - `parse` — module
 - `pathToFileURL` — module
 - `resolve` — module
+- `revokeObjectURL` — module
 - `urlToHttpOptions` — module
 
 ## `util`

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -8,6 +8,36 @@
       "reason": "Free-text explanation. Keep the most-actionable signal first \u2014 what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
+  "node-suite/buffer/blob-file/blob-basic": {
+    "issue": "1211",
+    "added": "2026-05-21",
+    "category": "module-inventory",
+    "reason": "#1211: `import { Blob } from 'node:buffer'` isn't a recognized named export. Perry has partial Blob support via the global constructor + perry-stdlib fetch registry, but the node:buffer surface (size/type/text()/arrayBuffer()) isn't wired up. Flips to PASS when the buffer-module Blob export lands."
+  },
+  "node-suite/buffer/blob-file/file-basic": {
+    "issue": "1211",
+    "added": "2026-05-21",
+    "category": "module-inventory",
+    "reason": "#1211: `File` extends Blob with name/lastModified. Same module-inventory gap as blob-basic — needs File class modeling on top of Blob exposure from node:buffer."
+  },
+  "node-suite/buffer/blob-file/object-url": {
+    "issue": "1211",
+    "added": "2026-05-21",
+    "category": "module-inventory",
+    "reason": "#1211: `resolveObjectURL` (paired with `URL.createObjectURL` / `URL.revokeObjectURL`) needs an object-URL registry. The Blob/File surface from #1211 lands first; this fixture cross-checks the registry round-trip."
+  },
+  "node-suite/buffer/copy-slice/slice-shared-mutation": {
+    "issue": "1205",
+    "added": "2026-05-21",
+    "category": "bug-open",
+    "reason": "#1205: Buffer.slice currently allocates a fresh BufferHeader with copied bytes rather than a view over the backing store. Codegen Uint8ArrayGet/Set emits direct gep+load/store against the buffer pointer (handle+8+idx), so a view-aware runtime helper can't intercept the byte access without a fast-path refactor. Flips to PASS when the codegen byte access learns about view headers."
+  },
+  "node-suite/buffer/copy-slice/subarray-shared-mutation": {
+    "issue": "1205",
+    "added": "2026-05-21",
+    "category": "bug-open",
+    "reason": "#1205: Buffer.subarray shares the slice/copy implementation — see slice-shared-mutation for the underlying gap."
+  },
   "node-suite/console/dir/depth-options": {
     "issue": "1199",
     "added": "2026-05-20",

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -8,36 +8,6 @@
       "reason": "Free-text explanation. Keep the most-actionable signal first \u2014 what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
-  "node-suite/buffer/blob-file/blob-basic": {
-    "issue": "1211",
-    "added": "2026-05-21",
-    "category": "module-inventory",
-    "reason": "#1211: `import { Blob } from 'node:buffer'` isn't a recognized named export. Perry has partial Blob support via the global constructor + perry-stdlib fetch registry, but the node:buffer surface (size/type/text()/arrayBuffer()) isn't wired up. Flips to PASS when the buffer-module Blob export lands."
-  },
-  "node-suite/buffer/blob-file/file-basic": {
-    "issue": "1211",
-    "added": "2026-05-21",
-    "category": "module-inventory",
-    "reason": "#1211: `File` extends Blob with name/lastModified. Same module-inventory gap as blob-basic — needs File class modeling on top of Blob exposure from node:buffer."
-  },
-  "node-suite/buffer/blob-file/object-url": {
-    "issue": "1211",
-    "added": "2026-05-21",
-    "category": "module-inventory",
-    "reason": "#1211: `resolveObjectURL` (paired with `URL.createObjectURL` / `URL.revokeObjectURL`) needs an object-URL registry. The Blob/File surface from #1211 lands first; this fixture cross-checks the registry round-trip."
-  },
-  "node-suite/buffer/copy-slice/slice-shared-mutation": {
-    "issue": "1205",
-    "added": "2026-05-21",
-    "category": "bug-open",
-    "reason": "#1205: Buffer.slice currently allocates a fresh BufferHeader with copied bytes rather than a view over the backing store. Codegen Uint8ArrayGet/Set emits direct gep+load/store against the buffer pointer (handle+8+idx), so a view-aware runtime helper can't intercept the byte access without a fast-path refactor. Flips to PASS when the codegen byte access learns about view headers."
-  },
-  "node-suite/buffer/copy-slice/subarray-shared-mutation": {
-    "issue": "1205",
-    "added": "2026-05-21",
-    "category": "bug-open",
-    "reason": "#1205: Buffer.subarray shares the slice/copy implementation — see slice-shared-mutation for the underlying gap."
-  },
   "node-suite/console/dir/depth-options": {
     "issue": "1199",
     "added": "2026-05-20",

--- a/test-parity/node-suite/buffer/blob-file/blob-basic.ts
+++ b/test-parity/node-suite/buffer/blob-file/blob-basic.ts
@@ -1,0 +1,11 @@
+import { Blob } from "node:buffer";
+
+const b = new Blob(["hi"], { type: "text/plain" });
+console.log("size:", b.size);
+console.log("type:", b.type);
+
+const text = await b.text();
+console.log("text:", text);
+
+const ab = await b.arrayBuffer();
+console.log("arrayBuffer.byteLength:", ab.byteLength);

--- a/test-parity/node-suite/buffer/blob-file/file-basic.ts
+++ b/test-parity/node-suite/buffer/blob-file/file-basic.ts
@@ -1,0 +1,10 @@
+import { File } from "node:buffer";
+
+const f = new File(["data"], "hello.txt", { type: "text/plain", lastModified: 1700000000000 });
+console.log("name:", f.name);
+console.log("size:", f.size);
+console.log("type:", f.type);
+console.log("lastModified:", f.lastModified);
+
+const text = await f.text();
+console.log("text:", text);

--- a/test-parity/node-suite/buffer/blob-file/object-url.ts
+++ b/test-parity/node-suite/buffer/blob-file/object-url.ts
@@ -1,0 +1,15 @@
+import { Blob, resolveObjectURL } from "node:buffer";
+
+// `node:buffer` doesn't expose `URL.createObjectURL` directly — pull
+// it off the global URL constructor (it's the same registry).
+const b = new Blob(["payload"], { type: "text/plain" });
+const url = URL.createObjectURL(b);
+console.log("url-prefix:", url.startsWith("blob:"));
+
+const resolved = resolveObjectURL(url);
+console.log("resolved-size:", resolved.size);
+console.log("resolved-type:", resolved.type);
+
+URL.revokeObjectURL(url);
+const after = resolveObjectURL(url);
+console.log("after-revoke:", after);

--- a/test-parity/node-suite/buffer/copy-slice/slice-shared-mutation.ts
+++ b/test-parity/node-suite/buffer/copy-slice/slice-shared-mutation.ts
@@ -1,0 +1,14 @@
+import { Buffer } from "node:buffer";
+
+const buf = Buffer.from([0x61, 0x62, 0x63, 0x64, 0x65, 0x66]);
+const s = buf.slice(1, 4);
+
+// Mutating the slice should be visible through the original buffer.
+s[0] = 0x5a;
+console.log("buf[1]:", buf[1].toString(16));
+console.log("s[0]:", s[0].toString(16));
+
+// Mutating the original buffer should be visible through the slice.
+buf[2] = 0x5b;
+console.log("buf[2]:", buf[2].toString(16));
+console.log("s[1]:", s[1].toString(16));

--- a/test-parity/node-suite/buffer/copy-slice/subarray-shared-mutation.ts
+++ b/test-parity/node-suite/buffer/copy-slice/subarray-shared-mutation.ts
@@ -1,0 +1,14 @@
+import { Buffer } from "node:buffer";
+
+const buf = Buffer.from([0x61, 0x62, 0x63, 0x64, 0x65, 0x66]);
+const v = buf.subarray(1, 4);
+
+// Mutating the original buffer must be visible through the view.
+buf[1] = 0x62;
+console.log("buf[1]:", buf[1].toString(16));
+console.log("v[0]:", v[0].toString(16));
+
+// Mutating the view must be visible through the original buffer.
+v[1] = 0x59;
+console.log("buf[2]:", buf[2].toString(16));
+console.log("v[1]:", v[1].toString(16));

--- a/test-parity/node-suite/buffer/encoding/transcode-utf16le.ts
+++ b/test-parity/node-suite/buffer/encoding/transcode-utf16le.ts
@@ -1,0 +1,14 @@
+import { transcode, Buffer } from "node:buffer";
+
+// Canonical Deno node-compat case: "Hi" as UTF-16LE → UTF-8.
+const hi = transcode(Buffer.from("48006900", "hex"), "utf16le", "utf8");
+console.log("hi:", hi.toString());
+console.log("hi len:", hi.length);
+
+// Round-trip the other way: UTF-8 → UTF-16LE → UTF-8.
+const back = transcode(transcode(Buffer.from("Hi"), "utf8", "utf16le"), "utf16le", "utf8");
+console.log("round-trip:", back.toString());
+
+// ucs2 alias maps to the same UTF-16LE pair semantics as Node.
+const ucs2 = transcode(Buffer.from("48006900", "hex"), "ucs2", "utf8");
+console.log("ucs2:", ucs2.toString());

--- a/test-parity/node-suite/buffer/properties/iterator-methods.ts
+++ b/test-parity/node-suite/buffer/properties/iterator-methods.ts
@@ -1,0 +1,23 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from([9, 8, 7]);
+
+// .values(): yields each byte.
+const vi = b.values();
+console.log("values.next.value:", vi.next().value);
+console.log("values.next.value:", vi.next().value);
+console.log("values.next.value:", vi.next().value);
+const done = vi.next();
+console.log("values.done:", done.done, "value:", done.value);
+
+// .keys(): yields each index.
+const ki = b.keys();
+console.log("keys.next.value:", ki.next().value);
+console.log("keys.next.value:", ki.next().value);
+
+// .entries(): yields [index, value] pairs.
+const ei = b.entries();
+const e0 = ei.next();
+console.log("entries.next.value[0]:", e0.value[0], "value[1]:", e0.value[1]);
+const e1 = ei.next();
+console.log("entries.next.value[0]:", e1.value[0], "value[1]:", e1.value[1]);


### PR DESCRIPTION
## Summary
All four node:buffer parity gaps land in this PR.

- **#1210 `buffer.transcode`** — utf16le/ucs2/utf8/latin1 matrix. Runtime helper, native-table row, FFI decl, api-manifest entry.
- **#1206 buffer iterator methods** — `buf.values()` / `keys()` / `entries()` return real iterator-protocol objects via a new `BUFFER_ITERATOR_CLASS_ID`; `.next()` dispatches through a class-id check in `js_native_call_method`.
- **#1205 slice/subarray shared backing-store** — `Buffer.slice` / `subarray` register the result in a thread-local view registry; the runtime byte mutators (`js_buffer_set`) propagate writes bi-directionally between the view, the ultimate backing buffer, and every sister view whose range overlaps the touched bytes. The codegen `Uint8ArrayGet` / `Uint8ArraySet` slow path routes through `js_buffer_get` / `js_buffer_set` so `s[0] = 0x5a; buf[1]` round-trips correctly; the fast path stays direct because `buffer_data_slots` only tags `Buffer.alloc` locals (never views).
- **#1211 Blob / File / resolveObjectURL** — `new Blob([parts], opts)` and `new File([parts], name, opts)` land via `lower_builtin_new`. `URL.createObjectURL` / `URL.revokeObjectURL` / `resolveObjectURL` round-trip through a process-global object-URL registry. File-specific `name` / `lastModified` reuse the existing `module == "blob"` arm; the existing `BLOB_REGISTRY` carries optional File metadata to avoid a second registry.

`./run_parity_tests.sh --suite node-suite --module buffer` now reports **94/94 PASS** (up from 89/94 with five known-failure entries on the initial commit).

## Test plan
- [ ] CI `cargo-test` workflow passes (perry-runtime unit tests + manifest drift gate)
- [ ] `./run_parity_tests.sh --suite node-suite --module buffer` → 94/94 PASS
- [ ] No new entries in `test-parity/known_failures.json`