### PR TITLE
test(tty): extend parity suite with identity + arity cases

### DIFF
--- a/test-parity/node-suite/tty/classes/has-colors-with-count.ts
+++ b/test-parity/node-suite/tty/classes/has-colors-with-count.ts
@@ -1,0 +1,10 @@
+import tty from "node:tty";
+
+// Node's WriteStream.prototype.hasColors accepts an optional color count.
+// hasColors() / hasColors(count) / hasColors(count, env) must each return a boolean
+// without throwing for the documented arities.
+console.log("hasColors() boolean:", typeof tty.WriteStream.prototype.hasColors() === "boolean");
+console.log("hasColors(2) boolean:", typeof tty.WriteStream.prototype.hasColors(2) === "boolean");
+console.log("hasColors(16) boolean:", typeof tty.WriteStream.prototype.hasColors(16) === "boolean");
+console.log("hasColors(256) boolean:", typeof tty.WriteStream.prototype.hasColors(256) === "boolean");
+console.log("hasColors(16777216) boolean:", typeof tty.WriteStream.prototype.hasColors(16777216) === "boolean");

--- a/test-parity/node-suite/tty/classes/prototype-method-identity.ts
+++ b/test-parity/node-suite/tty/classes/prototype-method-identity.ts
@@ -1,0 +1,13 @@
+import * as tty from "node:tty";
+
+// Prototype methods must be stable references across reads — Node caches them
+// on the prototype object, so two accesses produce the same function value.
+const hasColorsA = tty.WriteStream.prototype.hasColors;
+const hasColorsB = tty.WriteStream.prototype.hasColors;
+const getDepthA = tty.WriteStream.prototype.getColorDepth;
+const getDepthB = tty.WriteStream.prototype.getColorDepth;
+
+console.log("hasColors identity:", hasColorsA === hasColorsB);
+console.log("getColorDepth identity:", getDepthA === getDepthB);
+console.log("hasColors is function:", typeof hasColorsA === "function");
+console.log("getColorDepth is function:", typeof getDepthA === "function");

--- a/test-parity/node-suite/tty/imports/named-namespace-identity.ts
+++ b/test-parity/node-suite/tty/imports/named-namespace-identity.ts
@@ -1,0 +1,12 @@
+import * as ttyNs from "node:tty";
+import { isatty as namedIsatty } from "node:tty";
+import tty from "node:tty";
+
+// The named, namespace, and default import bindings must all reach the same
+// underlying function reference — Node consolidates them via the module
+// namespace object.
+console.log("named === namespace:", namedIsatty === ttyNs.isatty);
+console.log("default === namespace:", tty.isatty === ttyNs.isatty);
+console.log("named === default:", namedIsatty === tty.isatty);
+console.log("ReadStream namespace === default:", ttyNs.ReadStream === tty.ReadStream);
+console.log("WriteStream namespace === default:", ttyNs.WriteStream === tty.WriteStream);

--- a/test-parity/node-suite/tty/isatty/repeat-call-stability.ts
+++ b/test-parity/node-suite/tty/isatty/repeat-call-stability.ts
@@ -1,0 +1,17 @@
+import * as tty from "node:tty";
+
+// isatty must be deterministic for a given fd within a single process — the
+// answer doesn't change call-to-call, and the function itself remains the same
+// reference across reads.
+const ref1 = tty.isatty;
+const ref2 = tty.isatty;
+console.log("isatty self-identity:", ref1 === ref2);
+
+const a = tty.isatty(1);
+const b = tty.isatty(1);
+const c = tty.isatty(1);
+console.log("fd1 stable:", a === b && b === c);
+
+const x = tty.isatty(99);
+const y = tty.isatty(99);
+console.log("fd99 stable false:", x === false && y === false);


### PR DESCRIPTION
## Summary

Follow-up to #1272 — extends the new `node:tty` parity suite with four
additional CI-safe cases that exercise surface the suite didn't yet cover.

- `classes/has-colors-with-count.ts` — `WriteStream.prototype.hasColors(count)` arity coverage across 1/4/8/24-bit ranges
- `classes/prototype-method-identity.ts` — `hasColors`/`getColorDepth` return the same reference across repeated reads (smoke test for the bound-callable cache landed in #1272)
- `isatty/repeat-call-stability.ts` — `tty.isatty` self-identity and call-to-call determinism for fd 1 and 99
- `imports/named-namespace-identity.ts` — named, namespace, and default import bindings converge on the same function/constructor references

## Validation

- `./run_parity_tests.sh --suite node-suite --module tty` → 23/23 PASS (100%)