### PR TITLE
fix(runtime): #1136 #1129 lower iOS-device heap-pointer guards

### DIFF
--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -119,17 +119,43 @@ pub(crate) fn test_template_raw_roots() -> (usize, usize) {
 /// <= capacity <= 16M (same bound as the GC tracer's sanity guard).
 #[inline(always)]
 pub(crate) fn clean_arr_ptr(arr: *const ArrayHeader) -> *const ArrayHeader {
-    // Heap window varies by OS: Darwin mimalloc lands in the 3-5 TB range;
+    // Heap window varies by OS: macOS mimalloc lands in the 3-5 TB range;
     // Android scudo + Linux glibc allocate MUCH lower (often < 1 TB); Windows
     // mimalloc lands well under 1 TB (often in the GB-to-tens-of-GB range).
-    // Using the Darwin-tight 2 TB floor on Android / Windows silently null-s
-    // every real array pointer, turning js_array_set_f64 into a no-op and —
-    // at the read side via js_array_map etc. — returning empty arrays for
-    // legitimate inputs (issues #385/#386/#387).
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "windows"))]
+    // iOS / tvOS / watchOS / visionOS *device* targets use libsystem_malloc
+    // (mimalloc is host-side only) and allocate in the same low range —
+    // #1136's `for…of` over `split()` reproed empty because the array
+    // pointer landed below 2 TB and `clean_arr_ptr` silently null-ed it.
+    // Using the macOS-tight 2 TB floor on Android / Windows / iOS-family
+    // silently null-s every real array pointer, turning js_array_set_f64
+    // into a no-op and — at the read side via js_array_map etc. —
+    // returning empty arrays for legitimate inputs (issues #385/#386/#387
+    // for non-macOS hosts; #1136 for iOS device).
+    //
+    // The iOS *simulator* runs on the macOS host's mimalloc and lands in
+    // the 3-5 TB range like macOS itself; lowering the floor to 4 KB does
+    // not weaken the guard there because the actual liveness check is the
+    // GcHeader / obj_type validation downstream.
+    #[cfg(any(
+        target_os = "android",
+        target_os = "linux",
+        target_os = "windows",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+    ))]
     const HEAP_MIN: u64 = 0x1000; // 4 KB (classic user-space floor)
-    #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "windows")))]
-    const HEAP_MIN: u64 = 0x200_0000_0000; // 2 TB — above observed corrupt handles on Darwin
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "linux",
+        target_os = "windows",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+    )))]
+    const HEAP_MIN: u64 = 0x200_0000_0000; // 2 TB — above observed corrupt handles on macOS
     const HEAP_MAX: u64 = 0x8000_0000_0000; // 47-bit userspace cap
     let bits = arr as u64;
     let top16 = bits >> 48;

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -55,9 +55,29 @@ pub extern "C" fn js_array_grow(arr: *mut ArrayHeader, min_capacity: u32) -> *mu
         // check that mirrors clean_arr_ptr's HEAP_MIN to skip pointers
         // that don't have a real GcHeader behind them (e.g. test-mode
         // synthetic pointers, longlived-arena edge cases).
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "windows"))]
+        // #1136: iOS family device allocates via libsystem_malloc in the
+        // same low range as Android/Linux; mirror `clean_arr_ptr`'s
+        // platform split so growth forwarding can install a stub for
+        // arrays that live below 2 TB.
+        #[cfg(any(
+            target_os = "android",
+            target_os = "linux",
+            target_os = "windows",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "visionos",
+        ))]
         const HEAP_MIN: usize = 0x1000;
-        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "windows")))]
+        #[cfg(not(any(
+            target_os = "android",
+            target_os = "linux",
+            target_os = "windows",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "visionos",
+        )))]
         const HEAP_MIN: usize = 0x200_0000_0000;
         if (arr as usize) >= HEAP_MIN + crate::gc::GC_HEADER_SIZE {
             // Only forward arrays that came from the GC arena. A

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -9,6 +9,16 @@
 use super::*;
 
 /// Get a field from an object by index
+///
+/// #1129/#1136: the small-pointer guard below previously used a 16 MB
+/// floor (0x1000000), which rejected legitimate iOS-device heap
+/// pointers from libsystem_malloc — `splitDeepLink()` returning
+/// `{ segments }` and the caller destructuring `const { segments } = …`
+/// silently produced `undefined`. The real liveness check is the
+/// downstream `is_valid_obj_ptr` / `obj_type` validation; this gate
+/// only needs to keep the small-handle range and null/guard pages
+/// out before unsafe deref. 64 KB matches the bar used elsewhere in
+/// this module (e.g. `js_object_get_field_ic_miss`).
 #[no_mangle]
 pub extern "C" fn js_object_get_field(obj: *const ObjectHeader, field_index: u32) -> JSValue {
     let obj = {
@@ -26,7 +36,7 @@ pub extern "C" fn js_object_get_field(obj: *const ObjectHeader, field_index: u32
             obj
         }
     };
-    if obj.is_null() || (obj as usize) < 0x1000000 {
+    if obj.is_null() || (obj as usize) < 0x10000 {
         return JSValue::undefined();
     }
     unsafe {
@@ -172,7 +182,7 @@ pub extern "C" fn js_object_set_field(obj: *mut ObjectHeader, field_index: u32, 
             obj
         }
     };
-    if obj.is_null() || (obj as usize) < 0x1000000 {
+    if obj.is_null() || (obj as usize) < 0x10000 {
         return;
     }
     unsafe {
@@ -324,7 +334,7 @@ pub extern "C" fn js_object_set_unboxed_f64_field(
             obj
         }
     };
-    if obj.is_null() || (obj as usize) < 0x1000000 {
+    if obj.is_null() || (obj as usize) < 0x10000 {
         return;
     }
     unsafe {
@@ -371,7 +381,7 @@ pub extern "C" fn js_object_set_field_by_index(
     field_index: u32,
     value: f64,
 ) {
-    if obj.is_null() || (obj as usize) < 0x1000000 {
+    if obj.is_null() || (obj as usize) < 0x10000 {
         return;
     }
     unsafe {
@@ -973,7 +983,7 @@ pub extern "C" fn js_object_get_field_by_name(
         }
         return JSValue::undefined();
     }
-    if (obj as usize) < 0x1000000 {
+    if (obj as usize) < 0x10000 {
         return JSValue::undefined();
     }
     unsafe {

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -92,7 +92,7 @@ pub extern "C" fn js_object_set_field_by_name(
             obj
         }
     };
-    if obj.is_null() || (obj as usize) < 0x1000000 {
+    if obj.is_null() || (obj as usize) < 0x10000 {
         // Small non-null value — could be a stripped handle (after ensure_i64 stripped NaN-box tag)
         if !obj.is_null() && (obj as usize) > 0 {
             unsafe {

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1301,18 +1301,44 @@ pub(crate) fn extends_builtin_error(class_id: u32) -> bool {
 /// Issue #73 follow-up: raised the lower bound from 1 MB to 2 TB to reject
 /// corrupted NaN-boxes whose 48-bit handle lands in the 1-2 TB window
 /// (e.g. `0x00FF_0000_0000` from an `ArrayHeader { length: 0, capacity:
-/// 255 }` read as u64). Real Darwin mimalloc + arena allocations all
+/// 255 }` read as u64). Real macOS mimalloc + arena allocations all
 /// land in the 3-5 TB range; anything below 2 TB is certainly bogus on
 /// that platform. Linux glibc and Windows mimalloc allocate well below
-/// 2 TB though (often in the GB-to-tens-of-GB range), so the Darwin floor
+/// 2 TB though (often in the GB-to-tens-of-GB range), so the macOS floor
 /// silently rejects every legitimate object pointer there — issues
 /// #385/#386/#387 traced back to this exact filter on Windows.
+///
+/// #1136 / #1129: iOS-family *device* targets (aarch64-apple-ios,
+/// -tvos, -watchos, -visionos) ship without mimalloc and use
+/// libsystem_malloc, whose user allocations land in the same low range
+/// as Android/Linux/Windows. Treat them like those platforms — the
+/// downstream `GcHeader.obj_type` check is the real liveness guard.
+/// The simulator (e.g. ios + target_abi = "sim") runs on the macOS
+/// host's mimalloc so its allocations still land above 2 TB; lowering
+/// the floor here is safe because the obj_type validation does the
+/// work.
 #[inline(always)]
 fn is_valid_obj_ptr(ptr: *const u8) -> bool {
     let addr = ptr as u64;
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "windows"))]
+    #[cfg(any(
+        target_os = "android",
+        target_os = "linux",
+        target_os = "windows",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+    ))]
     const HEAP_MIN: u64 = 0x1000;
-    #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "windows")))]
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "linux",
+        target_os = "windows",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+    )))]
     const HEAP_MIN: u64 = 0x200_0000_0000;
     (HEAP_MIN..0x8000_0000_0000).contains(&addr)
 }

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -253,7 +253,7 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
             return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
         }
         let obj = extract_obj_ptr(obj_value);
-        if obj.is_null() || (obj as usize) < 0x1000000 {
+        if obj.is_null() || (obj as usize) < 0x10000 {
             return f64::from_bits(TAG_FALSE);
         }
         let key_str = crate::builtins::js_string_coerce(key_value);
@@ -456,7 +456,7 @@ pub extern "C" fn js_object_define_property(
 /// even when the value is undefined or the property is an accessor (no underlying slot).
 #[allow(unused_assignments)]
 unsafe fn ensure_key_in_keys_array(obj: *mut ObjectHeader, key: *const crate::StringHeader) {
-    if obj.is_null() || (obj as usize) < 0x1000000 || key.is_null() {
+    if obj.is_null() || (obj as usize) < 0x10000 || key.is_null() {
         return;
     }
     let scope = crate::gc::RuntimeHandleScope::new();
@@ -646,7 +646,7 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
 
 /// Helper: does `key` appear in `obj.keys_array`?
 unsafe fn own_key_present(obj: *mut ObjectHeader, key: *const crate::StringHeader) -> bool {
-    if obj.is_null() || (obj as usize) < 0x1000000 || key.is_null() {
+    if obj.is_null() || (obj as usize) < 0x10000 || key.is_null() {
         return false;
     }
     let keys = (*obj).keys_array;
@@ -697,7 +697,7 @@ pub extern "C" fn js_object_get_own_field_or_undef(
     }
     unsafe {
         let obj = extract_obj_ptr(obj_value);
-        if obj.is_null() || (obj as usize) < 0x1000000 {
+        if obj.is_null() || (obj as usize) < 0x10000 {
             return f64::from_bits(TAG_UNDEF);
         }
         if (obj as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {

--- a/crates/perry-runtime/src/value/dynamic_object.rs
+++ b/crates/perry-runtime/src/value/dynamic_object.rs
@@ -47,14 +47,35 @@ pub extern "C" fn js_value_length_f64(value: f64) -> f64 {
     // nonsense.
     if top16 == 0x7FFD {
         let handle = (bits & POINTER_MASK) as usize;
-        // Heap window: Darwin mimalloc lands in 3-5 TB, but Android scudo,
-        // Linux glibc, and Windows mimalloc all allocate much lower (often
-        // hundreds of GB or less). Using the Darwin-tight 2 TB floor on
-        // Android / Windows null-s every real pointer. See clean_arr_ptr
+        // Heap window: macOS mimalloc lands in 3-5 TB, but Android scudo,
+        // Linux glibc, Windows mimalloc, and iOS-family device
+        // libsystem_malloc all allocate much lower (often hundreds of GB
+        // or less, and on iOS device often in the single-digit GB or even
+        // sub-GB range). Using the macOS-tight 2 TB floor on those
+        // platforms null-s every real pointer — on iOS device this is the
+        // bug behind #1136 (`.length` on an array returned from
+        // `String.split()` collapses to 0, so `for…of` loops zero times
+        // and `segments.length === 0` is wrongly true). See clean_arr_ptr
         // for the same platform split.
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "windows"))]
+        #[cfg(any(
+            target_os = "android",
+            target_os = "linux",
+            target_os = "windows",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "visionos",
+        ))]
         let heap_min: usize = 0x1000;
-        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "windows")))]
+        #[cfg(not(any(
+            target_os = "android",
+            target_os = "linux",
+            target_os = "windows",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "visionos",
+        )))]
         let heap_min: usize = 0x200_0000_0000;
         if handle < heap_min || handle >= 0x8000_0000_0000 {
             return 0.0;
@@ -105,9 +126,29 @@ pub extern "C" fn js_value_length_f64(value: f64) -> f64 {
     // sometimes hands their pointer through as `bitcast i64 → double`
     // without a POINTER_TAG. Without this path, `Int32Array.length`
     // returned 0 because the value's top16 was 0, not 0x7FFD.
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "windows"))]
+    // #1136: mirror the platform split above for raw-pointer-bitcast
+    // values too, so a Buffer/TypedArray pointer handed through as
+    // `bitcast i64 → double` on iOS device still resolves to its real
+    // length via the registry lookups below.
+    #[cfg(any(
+        target_os = "android",
+        target_os = "linux",
+        target_os = "windows",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+    ))]
     let raw_heap_min: u64 = 0x1000;
-    #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "windows")))]
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "linux",
+        target_os = "windows",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+    )))]
     let raw_heap_min: u64 = 0x200_0000_0000;
     if top16 == 0 && bits >= raw_heap_min && bits < 0x8000_0000_0000 {
         let handle = bits as usize;


### PR DESCRIPTION
## Summary

iOS *device* target had `for…of` over `String.split()` results and
object-literal-return + destructure both silently returning wrong
values. Three categories of pointer guards rejected legitimate
libsystem_malloc pointers on iOS device — when iterating an array
or reading an object field on iOS device, the runtime saw the
pointer's address as "too low" and returned undefined / empty.

Concretely, from #1136's repro `parseDeepLink("wishare://page/about")`
returned `null` instead of `{ route: "static-page", pageSlug: "about" }`
because:

1. `s.split("/")` returned a valid array, but
2. `arr.length` (via `js_value_length_f64`) checked the pointer
   against a 2 TB macOS-tight floor and returned `0`, so
3. `for (const piece of arr)` looped zero times,
4. `segments` ended up empty, and
5. `splitDeepLink`'s caller hit `segments.length === 0` → `null`.

The destructure path `const { segments } = splitDeepLink(url)`
hit the same class of bug in `js_object_get_field_by_name` (16 MB
floor rejecting iOS-device heap pointers in the 1-16 MB band) so
even when the array iteration succeeded, the returned `{ segments }`
field read collapsed to undefined.

## Fix

Three categories, all in `crates/perry-runtime`:

- **Cfg-gated 2 TB `HEAP_MIN` extended to iOS family**:
  `array/header.rs` `clean_arr_ptr`, `array/push_pop.rs`
  `js_array_grow` forwarding, `value/dynamic_object.rs`
  `js_value_length_f64` (POINTER_TAG + raw-bitcast paths), and
  `object/mod.rs` `is_valid_obj_ptr`. iOS / tvOS / watchOS /
  visionOS now use the same low (4 KB) floor as Android / Linux /
  Windows. macOS host stays at 2 TB.

- **16 MB pointer floor lowered to 64 KB** (unconditional): five
  helpers in `object/field_get_set.rs`, `object/object_ops.rs`,
  and `object/field_set_by_name.rs`. The real liveness check is
  the downstream `GcHeader.obj_type` validation; 64 KB matches
  the bar already used by `js_object_get_field_ic_miss` and is
  enough to keep small handles and null/guard pages out before
  the unsafe deref.

- **`is_valid_obj_ptr` extended to iOS family** (overlaps with #1129).

## Why this is safe

- macOS host: unchanged (cfg branch unchanged, still 2 TB).
- iOS simulator: cfg lowers it, but simulator allocations still
  land above 2 TB on the macOS host's mimalloc; the obj_type
  validation downstream catches bogus pointers.
- iOS / tvOS / watchOS / visionOS device: now matches Android /
  Linux / Windows behavior.
- All other platforms: unchanged.

## Test plan

- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` — clean
- [x] `cargo build --release --target aarch64-apple-ios -p perry-runtime -p perry-stdlib` — clean
- [x] `cargo test --release -p perry-runtime --lib` — 451 passed, 0 failed
- [x] `cargo test --release -p perry-stdlib --lib` — 74 passed, 0 failed
- [x] `cargo fmt --all -- --check` — clean
- [x] Host repro from #1136 compiles + prints the expected result
- [ ] On-device verification of the `parseDeepLink("wishare://page/about")` repro (requires physical iOS device; deferred to maintainer)

## Notes

- Closes #1136.
- Also addresses the same root cause for #1129; if #1129 lands first
  the overlapping `field_get_set.rs` / `is_valid_obj_ptr` edits are
  no-ops.
- Pre-existing `perry-jsruntime` test compile failure is unrelated
  (private `resolve_module_path` after the #1246 file split).