### PR TITLE
fix(perry-ui-ios): #1122 extend layer.backgroundColor fallback to UIButton

### DIFF
--- a/crates/perry-ui-ios/src/widgets/mod.rs
+++ b/crates/perry-ui-ios/src/widgets/mod.rs
@@ -312,16 +312,27 @@ pub unsafe fn create_cg_color(r: f64, g: f64, b: f64, a: f64) -> *mut c_void {
 
 /// Set a solid background color on any widget.
 ///
-/// Issue #1122 — UIStackView's documented iOS 14+ `backgroundColor`
-/// support paints reliably when the stack view is the screen root but
-/// fails to draw on **nested** stack views on iOS 26 device (the inner
-/// "card" VStack rendered transparent over the outer pink screen even
-/// though `setBackgroundColor:` returned). For UIStackView we fall back
-/// to the pre-iOS-14 pattern of inserting a plain UIView pinned to the
-/// stack's bounds as `subview` index 0 (NOT `arrangedSubview`, so it
-/// stays out of the layout). The plain `setBackgroundColor:` is still
-/// issued so non-buggy paths (the root stack, iOS 17 sim) keep their
-/// existing rendering.
+/// Issue #1122 — on iOS 26 device, certain UIKit views silently drop
+/// `setBackgroundColor:` even though the call returns normally. Two
+/// confirmed cases so far:
+///
+/// 1. **Nested `UIStackView`** — the outer/root stack paints, but inner
+///    stacks render transparent. UIStackView's iOS 14+ backgroundColor
+///    routes through a hidden backing layer that the iOS 26 compositor
+///    sometimes skips for non-root stacks.
+/// 2. **`UIButton`** — the reported "no red rectangle at all" symptom
+///    on the Wishare button. PR #1127 worked around it by switching to
+///    `UIButtonTypeCustom` (avoiding the Liquid Glass tint override),
+///    and we keep a `layer.backgroundColor` belt-and-suspenders here in
+///    case a future iOS UIKit version intercepts `setBackgroundColor:`
+///    on UIButton again.
+///
+/// For both we write `setBackgroundColor:` (so non-buggy paths and iOS
+/// 17 simulator keep working unchanged) **and** push the same color
+/// down to `layer.backgroundColor` as a CGColor. CALayer's own
+/// `backgroundColor` paints reliably on iOS 26 regardless of UIKit-side
+/// interception. For ordinary UIViews `setBackgroundColor:` already
+/// routes to `layer.backgroundColor`, so this is a no-op there.
 pub fn set_background_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
     if let Some(view) = get_widget(handle) {
         unsafe {
@@ -334,21 +345,31 @@ pub fn set_background_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
             ];
             let _: () = objc2::msg_send![&*view, setBackgroundColor: &*ui_color];
 
-            // Stack-view fallback for nested-bg painting (#1122).
-            // Nested UIStackView's `backgroundColor` property doesn't
-            // paint on iOS 26 device. The CALayer underneath always
-            // paints its own `backgroundColor` though, so we hand the
-            // color down to the layer directly (using CGColor) as a
-            // belt-and-suspenders fix.
-            if let Some(stack_cls) = AnyClass::get(c"UIStackView") {
-                let is_stack: bool = objc2::msg_send![&*view, isKindOfClass: stack_cls];
-                if is_stack {
-                    let layer: *mut AnyObject = objc2::msg_send![&*view, layer];
-                    if !layer.is_null() {
-                        let cg_color: *const std::ffi::c_void =
-                            objc2::msg_send![&*ui_color, CGColor];
-                        let _: () = objc2::msg_send![layer, setBackgroundColor: cg_color];
-                    }
+            // Layer-level fallback for views known to drop or override
+            // `setBackgroundColor:` on iOS 26 device (#1122):
+            //   * UIStackView — nested stacks paint transparent
+            //   * UIButton    — Liquid Glass renderer may override
+            // Set CALayer.backgroundColor with CGColor directly so the
+            // pixels paint regardless of UIKit-side interception. For
+            // ordinary UIViews this is a no-op (setBackgroundColor:
+            // already updates layer.backgroundColor).
+            let is_stack = AnyClass::get(c"UIStackView")
+                .map(|cls| {
+                    let r: bool = objc2::msg_send![&*view, isKindOfClass: cls];
+                    r
+                })
+                .unwrap_or(false);
+            let is_button = AnyClass::get(c"UIButton")
+                .map(|cls| {
+                    let r: bool = objc2::msg_send![&*view, isKindOfClass: cls];
+                    r
+                })
+                .unwrap_or(false);
+            if is_stack || is_button {
+                let layer: *mut AnyObject = objc2::msg_send![&*view, layer];
+                if !layer.is_null() {
+                    let cg_color: *const std::ffi::c_void = objc2::msg_send![&*ui_color, CGColor];
+                    let _: () = objc2::msg_send![layer, setBackgroundColor: cg_color];
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Extends the `layer.backgroundColor` CGColor fallback that #1127 added for `UIStackView` to also cover `UIButton`. Same class of iOS 26 bug — `setBackgroundColor:` can be silently overridden by the Liquid Glass renderer even after #1127's `UIButtonTypeCustom` switch. Setting `layer.backgroundColor` directly bypasses any UIKit-side interception. No behavior change for ordinary UIViews (their `setBackgroundColor:` already maps to `layer.backgroundColor`).
- Rewrites `set_background_color`'s doc comment — it previously described an "inserting a UIView pinned to stack bounds" fallback that the actual implementation never did (it always set `layer.backgroundColor` with CGColor). New comment documents both currently-known iOS 26 cases and the rationale.

## Context

#1122 has been blocked by two layers of bugs that both had to land before on-device behavior could be re-verified:

1. **Native side** — #1109 (partial-alpha label fix) → #1127 (UIButton type-Custom + UIStackView layer fallback) → **this PR** (UIButton layer fallback).
2. **TS compiler** — #1129, where imported color object literals returned `undefined` on `--target ios`, was silently producing NaN colors at every `widgetSetBackgroundColor` / `textSetColor` call site that used `BRAND_RED` / `TEXT_PRIMARY` etc. from `theme.ts`. That's now closed by #1281 (`baaeb448`).

With this PR + everything in main, the Wishare Onboarding repro from #1122 should now render. Asking the reporter to rebuild against `main` and retest before closing.

## Test plan

- [x] `cargo check -p perry-ui-ios --target aarch64-apple-ios` — no new warnings, only the pre-existing `js_string_from_bytes` signature-mismatch warnings.
- [x] `cargo build --release -p perry-ui-ios --target aarch64-apple-ios` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [ ] On-device retest on iOS 26.5 of #1122's Wishare Onboarding screen — owner: reporter.