### PR TITLE
fix(runtime): #1225 Buffer.from(buf) shares .buffer identity with source

### DIFF
--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -117,6 +117,22 @@ pub extern "C" fn js_buffer_from_value(value: i64, encoding: i32) -> *mut Buffer
             let buf = buffer_alloc(len);
             (*buf).length = len;
             std::ptr::copy_nonoverlapping(buffer_data(src), buffer_data_mut(buf), len as usize);
+            // Issue #1225: Node's `Buffer.from(src)` carves the copy out of the
+            // shared 8 KiB pool slab so `src.buffer === cp.buffer`.  Perry has
+            // no pool, but we still need that `===` identity to hold for
+            // userland code that compares `.buffer` references.  Propagate
+            // src's resolved alias onto the copy; chained copies collapse to
+            // the same root so `Buffer.from(Buffer.from(src)).buffer ===
+            // src.buffer` also holds.
+            //
+            // Skip when src is a plain `Uint8Array` — Node's
+            // `Buffer.from(uint8Array)` allocates a fresh ArrayBuffer for the
+            // copy and never shares with the source.  Only honest Buffers go
+            // through the pool.
+            if !is_uint8array_buffer(ptr) {
+                let alias = resolve_buffer_ab_alias(ptr);
+                set_buffer_ab_alias(buf as usize, alias);
+            }
             buf
         }
     } else {

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -34,7 +34,7 @@ fn buffer_gc_total_size(capacity: usize) -> usize {
 /// Thread-local registry of buffer pointers for instanceof checks.
 /// Since BufferHeader has the same layout as ArrayHeader (no type_id field),
 /// we track buffer pointers separately to distinguish them from arrays.
-use crate::fast_hash::{new_ptr_hash_set, PtrHashSet};
+use crate::fast_hash::{new_ptr_hash_map, new_ptr_hash_set, PtrHashMap, PtrHashSet};
 use std::cell::RefCell;
 
 thread_local! {
@@ -49,6 +49,19 @@ thread_local! {
     /// would make the second `js_uint8array_new` call mistake the source
     /// for a Uint8Array and fall into the spec-mandated COPY branch).
     static ARRAY_BUFFER_REGISTRY: RefCell<PtrHashSet<usize>> = RefCell::new(new_ptr_hash_set());
+    /// Issue #1225: ArrayBuffer-identity alias map for Buffers produced by
+    /// copy paths like `Buffer.from(buf)`.  Node-compatible semantics: the
+    /// new Buffer's `.buffer` returns the same ArrayBuffer object as the
+    /// source's `.buffer` because both views live inside the shared 8 KiB
+    /// pool slab.  Perry allocates fresh inline storage per Buffer, so the
+    /// `.buffer` getter would otherwise return the new BufferHeader pointer
+    /// and `src.buffer === cp.buffer` would be false.  Storing the source's
+    /// resolved alias here lets the getter return a stable identity token.
+    /// Limitation: the bytes are not actually inside the aliased buffer, so
+    /// reads/writes through `.buffer` won't observe the view's data — only
+    /// the `===` identity check matches Node.
+    static BUFFER_AB_ALIAS: RefCell<PtrHashMap<usize, usize>> =
+        RefCell::new(new_ptr_hash_map());
 }
 
 pub fn mark_as_array_buffer(addr: usize) {
@@ -178,6 +191,30 @@ pub fn mark_as_uint8array(addr: usize) {
 
 pub fn is_uint8array_buffer(addr: usize) -> bool {
     UINT8ARRAY_FROM_CTOR.with(|r| r.borrow().contains(&addr))
+}
+
+/// Record that `buf`'s `.buffer` property should resolve to `alias` instead of
+/// `buf` itself.  Used by copy paths (`Buffer.from(src)`) to propagate the
+/// source's ArrayBuffer identity onto the new buffer — see #1225.
+pub fn set_buffer_ab_alias(buf: usize, alias: usize) {
+    BUFFER_AB_ALIAS.with(|m| {
+        m.borrow_mut().insert(buf, alias);
+    });
+}
+
+/// Look up the ArrayBuffer-identity alias for a Buffer.  Returns `None` for
+/// buffers that haven't been involved in a copy chain (their `.buffer` just
+/// returns themselves, as before).
+pub fn buffer_ab_alias(buf: usize) -> Option<usize> {
+    BUFFER_AB_ALIAS.with(|m| m.borrow().get(&buf).copied())
+}
+
+/// Collapse an alias chain to its root: if `buf` already aliases something,
+/// return that; otherwise return `buf` itself.  Callers use this to seed the
+/// alias on a fresh copy so chained `Buffer.from(Buffer.from(src))` keeps
+/// `===` identity with the original source.
+pub fn resolve_buffer_ab_alias(buf: usize) -> usize {
+    buffer_ab_alias(buf).unwrap_or(buf)
 }
 
 /// Allocate a buffer with the given capacity

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -24,8 +24,9 @@ pub use header::{BufferHeader, BUFFER_TYPE_ID, SMALL_BUF_THRESHOLD};
 
 // ---- Re-exports: allocation / registry helpers ----
 pub use header::{
-    buffer_alloc, buffer_data, buffer_data_mut, is_array_buffer, is_registered_buffer,
-    is_uint8array_buffer, mark_as_array_buffer, mark_as_uint8array, register_buffer,
+    buffer_ab_alias, buffer_alloc, buffer_data, buffer_data_mut, is_array_buffer,
+    is_registered_buffer, is_uint8array_buffer, mark_as_array_buffer, mark_as_uint8array,
+    register_buffer, resolve_buffer_ab_alias, set_buffer_ab_alias,
 };
 
 // ---- Re-exports: Buffer.from / alloc / concat (FFI) ----

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -993,8 +993,13 @@ pub extern "C" fn js_object_get_field_by_name(
                     return JSValue::number(crate::buffer::js_buffer_length(b) as f64);
                 }
                 if key_bytes == b"buffer" {
+                    // Issue #1225: a copied Buffer aliases its source's
+                    // ArrayBuffer identity so `Buffer.from(src).buffer ===
+                    // src.buffer` matches Node's pool-slab sharing.  Fresh
+                    // buffers without an entry fall back to their own pointer.
+                    let alias = crate::buffer::resolve_buffer_ab_alias(obj as usize);
                     return JSValue::from_bits(
-                        crate::value::js_nanbox_pointer(obj as i64).to_bits(),
+                        crate::value::js_nanbox_pointer(alias as i64).to_bits(),
                     );
                 }
                 // Issue #639 followup: method-as-value reads on a Buffer

--- a/crates/perry-runtime/src/value/dynamic_object.rs
+++ b/crates/perry-runtime/src/value/dynamic_object.rs
@@ -221,8 +221,16 @@ pub unsafe extern "C" fn js_dynamic_object_get_property(
                 return 0.0;
             }
             "buffer" => {
-                // Return the buffer itself (Perry doesn't separate ArrayBuffer)
-                return obj_value;
+                // Issue #1225: return the ArrayBuffer-identity alias when the
+                // buffer is a copy (so `src.buffer === Buffer.from(src).buffer`);
+                // otherwise return the buffer itself, matching the
+                // pre-aliasing behavior where Perry didn't separate
+                // ArrayBuffer from BufferHeader.
+                let alias = crate::buffer::resolve_buffer_ab_alias(ptr as usize);
+                if alias == ptr as usize {
+                    return obj_value;
+                }
+                return f64::from_bits(crate::value::js_nanbox_pointer(alias as i64).to_bits());
             }
             _ => {
                 return f64::from_bits(TAG_UNDEFINED);

--- a/test-files/test_gap_buffer_pool_identity.ts
+++ b/test-files/test_gap_buffer_pool_identity.ts
@@ -1,0 +1,35 @@
+// Gap test: #1225 Buffer.from(buf) shares .buffer identity with src.
+// Node carves Buffer.from(buf) out of a shared 8 KiB pool slab so
+// src.buffer === cp.buffer.  Perry models the case the issue calls
+// out — copy-from-Buffer — by propagating the source's
+// ArrayBuffer-alias onto the new buffer.  Bytes are still a real
+// copy; only the `.buffer` identity is shared.
+
+import { Buffer } from "node:buffer";
+
+const src = Buffer.from("abc");
+const cp = Buffer.from(src);
+console.log("src.buffer === cp.buffer:", src.buffer === cp.buffer);
+
+// Identity must be transitive across chained copies.
+const cp2 = Buffer.from(cp);
+console.log("cp2.buffer === src.buffer:", cp2.buffer === src.buffer);
+console.log("cp2.buffer === cp.buffer:", cp2.buffer === cp.buffer);
+
+// Mutating the copy must NOT touch the source bytes.
+const src2 = Buffer.from("xyz");
+const cp3 = Buffer.from(src2);
+cp3[0] = 0xff;
+console.log("src2[0] after cp3 write:", src2[0]);
+console.log("cp3[0] after cp3 write:", cp3[0]);
+
+// Length is preserved on the copy.
+console.log("cp.length:", cp.length);
+console.log("cp.byteLength:", cp.byteLength);
+
+// Uint8Array source must NOT share identity (Node spec-allocates a fresh
+// ArrayBuffer for `Buffer.from(uint8Array)`).  Guard against over-aliasing.
+const u8 = new Uint8Array([1, 2, 3]);
+const fromU8 = Buffer.from(u8);
+console.log("Buffer.from(uint8Array) shares with src:",
+    fromU8.buffer === u8.buffer);


### PR DESCRIPTION
## Summary

- `Buffer.from(src)` now preserves `src.buffer === cp.buffer` (Node behavior), even though the bytes are still copied — fixes #1225.
- Adds a thread-local ArrayBuffer-identity alias map; the `.buffer` getter resolves through it. Uint8Array sources are skipped (Node spec-allocates a fresh ArrayBuffer there).
- New gap test `test-files/test_gap_buffer_pool_identity.ts` covers the reported case, transitive identity across chained copies, mutation isolation, and the Uint8Array negative path.

## What is *not* fixed

This is the minimal `Buffer.from(buf)` slice of #1225. The broader pool model (two unrelated `Buffer.from(string)` calls sharing `.buffer` until 8 KiB is exhausted) needs a real pool implementation and is left for a follow-up.

`.buffer.byteLength` still reflects the source buffer's data length rather than 8192 — the alias is the source itself, not a synthetic 8 KiB slab. Mutation through `.buffer` writes to the source. Callers introspecting the slab via `.buffer`/`.byteOffset`/`.byteLength` will still differ from Node; only the `===` identity check the issue calls out is fixed.

## Test plan

- [x] `node --experimental-strip-types test-files/test_gap_buffer_pool_identity.ts` ↔ `./target/release/perry ... && /tmp/test_1225` produce identical output (byte-for-byte diff clean).
- [x] `cargo test --release -p perry-runtime --lib` — 451/451 pass.
- [x] `cargo fmt --all -- --check` clean.
- [x] `test_gap_buffer_ops.ts` still passes parity (regression check).