### PR TITLE
fix(setup): validate keystore output path in perry setup android

### DIFF
--- a/crates/perry/src/commands/setup/android.rs
+++ b/crates/perry/src/commands/setup/android.rs
@@ -56,10 +56,7 @@ pub fn android_wizard(saved: &mut PerryConfig) -> Result<()> {
         println!("  Generating a new Android release keystore...");
         println!();
 
-        let path = Input::<String>::new()
-            .with_prompt("  Output path (e.g. ~/release-key.keystore)")
-            .interact_text()?;
-        let path = expand_tilde(&path);
+        let path = prompt_output_path("  Output path (e.g. ~/release-key.keystore)")?;
         let alias = Input::<String>::new()
             .with_prompt("  Key alias")
             .default("key0".to_string())

--- a/crates/perry/src/commands/setup/helpers.rs
+++ b/crates/perry/src/commands/setup/helpers.rs
@@ -27,6 +27,69 @@ pub fn expand_tilde(path: &str) -> String {
     }
 }
 
+/// Prompt for a writable *output* file path (file doesn't have to exist
+/// yet, but its parent directory must exist and be writable by the
+/// current user). Re-prompts on failure instead of bailing — typo-tolerant
+/// for interactive flows like `perry setup android` where a slipped
+/// `~/../foo` would otherwise crash the whole command after the user has
+/// already entered an alias + password.
+pub fn prompt_output_path(prompt: &str) -> Result<String> {
+    loop {
+        let raw = Input::<String>::new().with_prompt(prompt).interact_text()?;
+        let expanded = expand_tilde(&raw);
+        match check_writable_output(&expanded) {
+            Ok(()) => return Ok(expanded),
+            Err(msg) => {
+                println!();
+                println!("  {} {msg}", style("✗").red());
+                println!("    Try a path inside your home directory, e.g. ~/release-key.keystore");
+                println!();
+            }
+        }
+    }
+}
+
+/// Probe whether the given output path is writable by the current user:
+/// resolves the parent directory (canonicalizing through any `..`
+/// components so the error message names the *real* directory the OS
+/// will refuse), then attempts to create-and-delete a tiny probe file.
+/// Returns a human-readable message on failure rather than a typed error,
+/// because the only consumer formats it straight back to the prompt.
+fn check_writable_output(path: &str) -> std::result::Result<(), String> {
+    if path.trim().is_empty() {
+        return Err("Path cannot be empty".to_string());
+    }
+    let p = std::path::Path::new(path);
+    let parent = p
+        .parent()
+        .filter(|pp| !pp.as_os_str().is_empty())
+        .unwrap_or_else(|| std::path::Path::new("."));
+    let canonical_parent = parent.canonicalize().map_err(|e| {
+        format!(
+            "Parent directory {} is not reachable: {e}",
+            parent.display()
+        )
+    })?;
+    if !canonical_parent.is_dir() {
+        return Err(format!(
+            "Parent path {} is not a directory",
+            canonical_parent.display()
+        ));
+    }
+    let probe = canonical_parent.join(format!(".perry-write-test-{}", std::process::id()));
+    match std::fs::File::create(&probe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&probe);
+            Ok(())
+        }
+        Err(e) => Err(format!(
+            "Cannot write to {} ({})",
+            canonical_parent.display(),
+            e.kind()
+        )),
+    }
+}
+
 /// Prompt for a file path, validate it exists and has the expected extension.
 pub fn prompt_file_path(prompt: &str, expected_ext: &str) -> Result<String> {
     let path = Input::<String>::new().with_prompt(prompt).interact_text()?;

--- a/crates/perry/src/commands/setup/mod.rs
+++ b/crates/perry/src/commands/setup/mod.rs
@@ -35,9 +35,9 @@ pub(crate) use windows::windows_wizard;
 // Cross-platform helpers shared across wizards.
 pub(crate) use common_apple::{generate_asc_jwt, prompt_api_credentials};
 pub(crate) use helpers::{
-    expand_tilde, press_enter_to_continue, prompt_file_path, update_perry_toml_android,
-    update_perry_toml_encryption_exempt, update_perry_toml_ios, update_perry_toml_macos,
-    update_perry_toml_section_bool,
+    expand_tilde, press_enter_to_continue, prompt_file_path, prompt_output_path,
+    update_perry_toml_android, update_perry_toml_encryption_exempt, update_perry_toml_ios,
+    update_perry_toml_macos, update_perry_toml_section_bool,
 };
 
 // Cert utilities used by macos (re-exported in case any other module wants them).


### PR DESCRIPTION
## Summary

- `perry setup android` crashes the whole wizard when the user mistypes the keystore path. Concrete repro: typing `~/../release-key.keystore` expands to `/Users/<you>/../release-key.keystore` = `/Users/release-key.keystore`, which `keytool` can't write to. The wizard `bail!`s after the user has already entered an alias + password.
- Add a `prompt_output_path` helper that expands `~/`, canonicalizes the parent through any `..`, probes write-access by creating + deleting a tiny `.perry-write-test-<pid>` file (because `permissions().readonly()` doesn't honor effective-uid on Unix), and re-prompts on failure instead of bailing.
- Wire it into the keystore-generation branch of `android.rs` — alias + password prompts now only run once the path is known good.

## Why a probe instead of a permission check

On Unix, `metadata.permissions().readonly()` only reflects whether the owner-write bit is set on the *file*, not whether the *current process* can actually create entries in that directory. Trying to create a probe file is the only check that matches what `keytool` (or any subsequent open(O_CREAT) call) will hit.

## Test plan

- [x] `cargo build --release -p perry` — green
- [x] `cargo fmt --all -- --check` — clean
- [x] Manually re-run `perry setup android` with `~/../release-key.keystore`: now prints `✗ Cannot write to /Users (permission denied)` and re-prompts instead of crashing. Typing `~/release-key.keystore` succeeds and proceeds to alias/password.
- [ ] CI: `lint`, `cargo-test`, `api-docs-drift`, `security-audit`

## Out of scope

The same helper would also fit `tvos.rs` / `visionos.rs` / `watchos.rs` / `macos.rs` "save this generated cert" prompts, but I kept the change scoped to the path that actually broke. Happy to roll those into a follow-up if it's worth it.