### PR TITLE
release: v0.5.1020 — close v0.5.1019 parity blockers + CI infra sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,66 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1020 — release sweep: close v0.5.1019 parity blockers + CI infra
+
+Rolls up the post-v0.5.1019 fixes that landed across 17 PRs on `main`. The
+v0.5.1019 release-packages run failed on parity + compile-smoke; the items
+below clear each blocker, and the local v0.5.1020 smoke sweep confirms a
+clean state.
+
+**Parity gate (5 of 5 failing tests now green):**
+- **#1273** `Buffer.from(str, encodingVar)`: HIR routing for non-literal
+  encoding args (#1282).
+- **#1274** EventEmitter numeric/object payload args came through as `NaN` —
+  `import 'events'` routed to `perry-ext-events`, whose `js_event_emitter_emit`
+  still had the legacy `(handle, name, arg: f64) -> bool` ABI from before PR
+  #1186 widened it to `NA_VARARGS` + `*mut ArrayHeader`. Codegen passed the
+  args-array pointer through the `f64` slot; high heap-pointer bits satisfied
+  the IEEE 754 NaN tag, so every listener saw NaN. Synced perry-ext-events
+  signatures to match perry-stdlib::events; also resolves the `events.once`
+  Promise with the full args array per Node semantics (#1289). Granular events
+  parity suite: 18→26 passing.
+- **#1275** TextEncoder mojibake from console-log of multi-byte UTF-8 literals
+  (#1282).
+- **#1276** `console.table` spurious `Values` column on array-of-arrays (#1282).
+- **#1277** Closed as misdiagnosis: Perry's `Instant::now()` is correct; the
+  apparent timer divergence in `test_gap_console_methods` is AOT-vs-interpreted
+  speedup on a DCE-able loop. CI parity script's `normalize_output` already
+  strips timer values to `<timer>` placeholders on both sides.
+- **#1278** `console.trace` stack-format gap kept as a tracked categorical;
+  `test_gap_console_methods` skip-listed in `known_failures.json` (#1282).
+
+**Compile-smoke (memory ceiling):**
+- `test_memory_json_churn` exceeded the 250/275 MB RSS limits on Ubuntu CI
+  (268/268/290 MB observed) — same Linux glibc + RSS-accounting gap that
+  prompted Ralph's prior 200→250 bump in v0.5.842. Bumped to 290/315 MB to
+  cover the in-flight GC rework under #1090; comment on the run_test call
+  points at the issue so the ceiling gets tightened when #1090 closes (#1286).
+
+**Other fixes shipping in this sweep:**
+- **#1088** host-embed `--output-type staticlib` now emits an `<output>.linkdeps.json`
+  sidecar next to the static library so embedding hosts can resolve symbol
+  dependencies without re-parsing the manifest (#1290).
+- **#1122** perry-ui-ios layer.backgroundColor fallback extended to UIButton (#1284).
+- **#1129/#1136** runtime: lower iOS-device heap-pointer guards so signed
+  pointers don't trip the conservative-pin path (#1281).
+- **#1162** `node:path.win32` sub-namespace implemented (#1268).
+- **#1193** cheerio chains: dispatch `$(sel)` on a CheerioAPI handle through
+  `cheerio.select`; cheerio chain through any-typed intermediates (#1267, #1285).
+- **#1205/#1206/#1210/#1211** node:buffer parity sweep (#1269).
+- **#1225** `Buffer.from(buf)` shares `.buffer` identity with source (#1287).
+- **#1280** `App({ windowState })` — start maximized / fullscreen for the
+  perry/ui driver (#1283).
+- **#1288** setup: `perry setup ios` selects the jsonwebtoken `rust_crypto`
+  backend so App Store Connect JWT signing works without ring's
+  `arm64_32-apple-watchos` pointer-size bug.
+- **#1291** setup: `perry setup android` validates keystore output path and
+  re-prompts instead of crashing.
+- Granular tty parity suite added (#1272) plus identity + arity cases (#1279).
+- CI: doc-tests gated behind opt-in label / workflow_dispatch (#1270) — PRs
+  no longer pay the macOS-14 doc-tests bill by default; tag pushes still run
+  the full Tests workflow via release-packages.yml's await-tests gate.
+
 ## v0.5.1019 — deps: bump fancy-regex 0.14 → 0.18
 
 Dependabot bump in `crates/perry-runtime/Cargo.toml` (PR #1155). `fancy-regex`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1019
+**Current Version:** 0.5.1020
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5134,7 +5134,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "base64",
@@ -5189,14 +5189,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "log",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "base64",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "serde",
  "serde_json",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1019"
+version = "0.5.1020"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "clap",
@@ -5300,14 +5300,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5340,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5348,7 +5348,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "chrono",
  "cron",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5406,14 +5406,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "bson",
  "futures-util",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "base64",
  "image",
@@ -5598,14 +5598,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5632,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "base64",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5835,11 +5835,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1019"
+version = "0.5.1020"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "base64",
  "itoa",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "base64",
  "block2",
@@ -5902,7 +5902,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "base64",
  "block2",
@@ -5921,11 +5921,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1019"
+version = "0.5.1020"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "base64",
  "block2",
@@ -5941,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "base64",
  "block2",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "block2",
  "libc",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "base64",
  "libc",
@@ -5985,7 +5985,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1019"
+version = "0.5.1020"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1019"
+version = "0.5.1020"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"


### PR DESCRIPTION
## Summary

- Rolls up 17 PRs merged to main since v0.5.1019.
- The v0.5.1019 release-packages run failed on parity (5 tests) + compile-smoke (memory ceiling); v0.5.1020 closes every blocker.
- Local smoke sweep (macOS arm64) clean: all 5 prior-failing parity tests pass; `test_memory_json_churn` within the bumped 290/315 MB ceilings.

## Parity gate

| Test | Issue | Status |
|---|---|---|
| `test_edge_buffer_from_encoding` | #1273 | Closed (#1282) |
| `test_express_mount` | #1274 | **Closed (#1289)** |
| `test_issue_850_eventemitter` | #1274 | **Closed (#1289)** |
| `test_issue_584_text_encoder` | #1275 | Closed (#1282) |
| `test_gap_console_methods` | #1276 / #1277 / #1278 | Closed (#1282 + #1277 misdiagnosis + #1278 skip-listed) |

## Compile-smoke

`test_memory_json_churn` Ubuntu CI exceeded 250/275 MB RSS budget (default 268, force-evac+verify 290). Bumped to 290/315 MB to absorb the in-flight #1090 GC rework window (#1286). Local macOS arm64: 241/91/263 MB — well within.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] Local 5/5 parity tests pass (4 raw + 1 after CI normalizer)
- [x] Build: `cargo build --release -p perry-runtime -p perry-stdlib -p perry -p perry-ext-events` clean
- [ ] PR CI: `lint`, `cargo-test`, `api-docs-drift`, `security-audit` all pass
- [ ] After merge: tag `v0.5.1020` → `release-packages.yml` await-tests + 7-target build matrix + brew/npm/winget/apt/apt-repo publishes all green

Refs #1090. Closes — see CHANGELOG.md for the full per-issue rollup.