### PR TITLE
fix(perry-ui-gtk4): #1246 follow-up — restore image.rs resolve_asset_path access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1021 — fix(perry-ui-gtk4): #1246 follow-up, restore image.rs resolve_asset_path access
+
+PR #1246 ("Drop all files to <2k LOC + tighten size gate") split
+`crates/perry-ui-gtk4/src/lib.rs` and moved `resolve_asset_path` into
+`ffi::layout`, leaving the function private. `widgets/image.rs:33` still
+called `crate::resolve_asset_path(path)` (root path), so the gtk4 build
+on the `linux-aarch64-gnu` release target broke with:
+
+    error[E0425]: cannot find function `resolve_asset_path` in the crate root
+      --> crates/perry-ui-gtk4/src/widgets/image.rs:33:27
+
+Local macOS workspace builds didn't hit it because perry-ui-gtk4 is
+excluded from the macOS cargo-test set (per CLAUDE.md). v0.5.1020's
+release-packages run (#26249481496) surfaced it on the
+`linux-aarch64-gnu` matrix entry, which then fail-fast-cancelled four
+other matrix builds and skipped every publish job (winget / homebrew /
+npm / apt / apt-repo).
+
+Two-line fix:
+
+- `ffi::layout::resolve_asset_path`: `fn` → `pub(crate) fn` so sibling
+  widget modules can reach it through `crate::ffi::layout::…`.
+- `widgets::image::create_file`: `crate::resolve_asset_path(path)` →
+  `crate::ffi::layout::resolve_asset_path(path)`.
+
 ## v0.5.1020 — release sweep: close v0.5.1019 parity blockers + CI infra
 
 Rolls up the post-v0.5.1019 fixes that landed across 17 PRs on `main`. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1020
+**Current Version:** 0.5.1021
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5134,7 +5134,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "base64",
@@ -5189,14 +5189,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "log",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "base64",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "serde",
  "serde_json",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1020"
+version = "0.5.1021"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "clap",
@@ -5300,14 +5300,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5340,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5348,7 +5348,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "chrono",
  "cron",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5406,14 +5406,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "bson",
  "futures-util",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "base64",
  "image",
@@ -5598,14 +5598,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5632,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "base64",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5835,11 +5835,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1020"
+version = "0.5.1021"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "base64",
  "itoa",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "base64",
  "block2",
@@ -5902,7 +5902,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "base64",
  "block2",
@@ -5921,11 +5921,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1020"
+version = "0.5.1021"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "base64",
  "block2",
@@ -5941,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "base64",
  "block2",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "block2",
  "libc",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "base64",
  "libc",
@@ -5985,7 +5985,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1020"
+version = "0.5.1021"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1020"
+version = "0.5.1021"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-ui-gtk4/src/ffi/layout.rs
+++ b/crates/perry-ui-gtk4/src/ffi/layout.rs
@@ -131,7 +131,16 @@ pub extern "C" fn perry_ui_app_set_icon(path_ptr: i64) {
 }
 
 /// Resolve an asset path relative to the executable directory.
-fn resolve_asset_path(path: &str) -> std::path::PathBuf {
+///
+/// `pub(crate)` so `widgets::image` (and any other widget module that
+/// loads files bundled next to the executable) can reuse this exact
+/// resolution rule without duplicating it. Pre-#1246 the function lived
+/// at crate root and was reachable as `crate::resolve_asset_path`;
+/// after the file split it moved here and stayed private, so
+/// `widgets/image.rs`'s `crate::resolve_asset_path(path)` call broke at
+/// link-target time on linux-aarch64-gnu (E0425, surfaced on the
+/// v0.5.1020 release-packages run 26249481496).
+pub(crate) fn resolve_asset_path(path: &str) -> std::path::PathBuf {
     let p = std::path::Path::new(path);
     if p.is_absolute() && p.exists() {
         return p.to_path_buf();

--- a/crates/perry-ui-gtk4/src/widgets/image.rs
+++ b/crates/perry-ui-gtk4/src/widgets/image.rs
@@ -30,7 +30,7 @@ pub fn create_file(path_ptr: *const u8) -> i64 {
     let raw = str_from_header(path_ptr);
     let path = raw.split('\0').next().unwrap_or(raw);
     // Resolve path relative to executable directory (handles bundled assets)
-    let resolved = crate::resolve_asset_path(path);
+    let resolved = crate::ffi::layout::resolve_asset_path(path);
     let picture = gtk4::Picture::for_filename(&resolved);
     picture.set_can_shrink(true);
     let handle = super::register_widget(picture.clone().upcast());


### PR DESCRIPTION
## Summary

- PR #1246 split `crates/perry-ui-gtk4/src/lib.rs` and moved `resolve_asset_path` into `ffi::layout`, leaving the function private — `widgets/image.rs:33` still called `crate::resolve_asset_path(path)` (root path), so the gtk4 build broke on linux-aarch64-gnu in the v0.5.1020 release-packages run.
- Made `ffi::layout::resolve_asset_path` `pub(crate)` and updated the image.rs call site to use the correct module path.
- Local macOS workspace builds didn't catch this because perry-ui-gtk4 is excluded from macOS cargo-test (per CLAUDE.md).

## Surfaced by

[release-packages run #26249481496](https://github.com/PerryTS/perry/actions/runs/26249481496), `build (ubuntu-24.04-arm, aarch64-unknown-linux-gnu, perry-linux-aarch64)`. Fail-fast cascaded into 4 other matrix entries getting cancelled and all publish jobs (winget / homebrew / npm / apt / apt-repo) being skipped.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check -p perry-ui-gtk4` clean locally
- [ ] PR CI: lint + cargo-test + api-docs-drift + security-audit + harmonyos-smoke pass
- [ ] After merge: re-tag v0.5.1021 → release-packages run goes all-green