### PR TITLE
feat(ios): #1301 add `perry setup ios --development` + on-device dev-sign path

### DIFF
--- a/crates/perry/src/commands/compile/bundle_ios.rs
+++ b/crates/perry/src/commands/compile/bundle_ios.rs
@@ -731,9 +731,39 @@ pub(super) fn build_ios_app_bundle(
                 );
             }
             println!();
-            println!("To run on iOS Simulator:");
-            println!("  xcrun simctl install booted {}", app_dir.display());
-            println!("  xcrun simctl launch booted {}", bundle_id);
+            if matches!(target, Some("ios")) {
+                // Physical-device target: dev-sign the bundle when a development
+                // profile + matching identity are already provisioned locally
+                // (via `perry setup ios --development`), then print the on-device
+                // install/launch path. A plain compile without those materials
+                // leaves the bundle unsigned and just prints instructions.
+                let config = crate::commands::publish::load_config();
+                let signed =
+                    crate::commands::run::try_sign_existing_dev_profile(&app_dir, &config, format)
+                        .unwrap_or(false);
+                if !signed {
+                    println!(
+                        "Bundle is unsigned — `perry run --target ios` dev-signs it automatically."
+                    );
+                    println!("First-time device provisioning: perry setup ios --development");
+                    println!();
+                }
+                println!("To install + launch on a connected device:");
+                println!("  perry run --target ios");
+                println!("Or manually (find <UDID> with `xcrun devicectl list devices`):");
+                println!(
+                    "  xcrun devicectl device install app --device <UDID> {}",
+                    app_dir.display()
+                );
+                println!(
+                    "  xcrun devicectl device process launch --device <UDID> {}",
+                    bundle_id
+                );
+            } else {
+                println!("To run on iOS Simulator:");
+                println!("  xcrun simctl install booted {}", app_dir.display());
+                println!("  xcrun simctl launch booted {}", bundle_id);
+            }
         }
         OutputFormat::Json => {
             let result = serde_json::json!({

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -42,8 +42,9 @@ pub use remote::{
     find_icon_source, remote_build_and_launch,
 };
 pub use resign::{
-    create_dev_profile_via_api, find_identity_for_team, find_system_dev_profile, generate_asc_jwt,
-    read_bundle_id_from_app, resign_for_development,
+    create_dev_profile_via_api, embed_profile_and_sign, find_dev_identity_for_team,
+    find_identity_for_team, find_system_dev_profile, generate_asc_jwt, read_bundle_id_from_app,
+    resign_for_development, try_sign_existing_dev_profile,
 };
 
 #[derive(Args, Debug)]

--- a/crates/perry/src/commands/run/resign.rs
+++ b/crates/perry/src/commands/run/resign.rs
@@ -16,9 +16,62 @@ pub async fn resign_for_development(
     // Read bundle ID from Info.plist
     let bundle_id = read_bundle_id_from_app(app_dir).unwrap_or_else(|| "com.perry.app".to_string());
 
-    // Find all development signing identities (we'll pick the right one after
-    // determining the provisioning profile, since the profile must contain the
-    // certificate matching the signing identity)
+    // Use team ID from saved config (NOT from the identity name — the parenthesized
+    // part in "Apple Development: Name (XXXXX)" is a personal cert ID, not the team ID)
+    let team_id = config
+        .apple
+        .as_ref()
+        .and_then(|a| a.team_id.clone())
+        .ok_or_else(|| {
+            anyhow!("No Apple team ID in ~/.perry/config.toml — run `perry setup ios` first")
+        })?;
+
+    // Pick the Apple Development identity that belongs to our team. The cert ID
+    // in the name (e.g. RY57F22743) is NOT the team ID, so this verifies the
+    // TeamIdentifier each candidate hash produces via a test codesign.
+    let (identity_hash, identity) = find_dev_identity_for_team(&team_id)?;
+
+    if let OutputFormat::Text = format {
+        println!(
+            "Re-signing for development (team {}, {})...",
+            style(&team_id).dim(),
+            style(&identity).dim()
+        );
+    }
+
+    // Step 1: Find or create a development provisioning profile
+    let profile_data = if let Some(path) = find_system_dev_profile(&bundle_id, &team_id) {
+        if let OutputFormat::Text = format {
+            println!(
+                "  Using existing dev profile: {}",
+                style(path.display()).dim()
+            );
+        }
+        std::fs::read(&path)?
+    } else {
+        // Create via App Store Connect API
+        if let OutputFormat::Text = format {
+            println!("  Creating development provisioning profile via App Store Connect...");
+        }
+        create_dev_profile_via_api(config, &bundle_id, &team_id, device_udid, format)
+            .await
+            .context(
+                "Could not create development provisioning profile.\n\
+                 Ensure your App Store Connect API key has the right permissions,\n\
+                 or use a simulator instead: perry run ios --simulator <UDID>",
+            )?
+    };
+
+    // Step 2: Embed the profile and code-sign for development.
+    embed_profile_and_sign(app_dir, &team_id, &bundle_id, &identity_hash, &profile_data)?;
+
+    Ok(())
+}
+
+/// Locate the Apple Development signing identity (hash + display name) in the
+/// Keychain that belongs to `team_id`. Returns distinct errors for "no dev
+/// identity at all" vs. "none matching this team" so callers can guide the user.
+pub fn find_dev_identity_for_team(team_id: &str) -> Result<(String, String)> {
     let output = Command::new("security")
         .args(["find-identity", "-v", "-p", "codesigning"])
         .output()
@@ -55,102 +108,79 @@ pub async fn resign_for_development(
         );
     }
 
-    // Use team ID from saved config (NOT from the identity name — the parenthesized
-    // part in "Apple Development: Name (XXXXX)" is a personal cert ID, not the team ID)
-    let team_id = config
-        .apple
-        .as_ref()
-        .and_then(|a| a.team_id.clone())
-        .ok_or_else(|| {
-            anyhow!("No Apple team ID in ~/.perry/config.toml — run `perry setup ios` first")
-        })?;
-
-    // Pick the identity that belongs to our team by checking TeamIdentifier
-    // via a test codesign. The cert ID in the name (e.g. RY57F22743) is NOT
-    // the team ID — we must verify which hash produces the right TeamIdentifier.
-    let identity_hash = find_identity_for_team(&dev_identities, &team_id).ok_or_else(|| {
+    let identity_hash = find_identity_for_team(&dev_identities, team_id).ok_or_else(|| {
         anyhow!(
             "No Apple Development certificate for team {team_id} found in Keychain.\n\
              Use Xcode to set up development signing for this team."
         )
     })?;
-    let identity = dev_identities
+    let name = dev_identities
         .iter()
         .find(|(h, _)| h == &identity_hash)
         .map(|(_, n)| n.clone())
         .unwrap_or_else(|| identity_hash.clone());
+    Ok((identity_hash, name))
+}
 
-    if let OutputFormat::Text = format {
-        println!(
-            "Re-signing for development (team {}, {})...",
-            style(&team_id).dim(),
-            style(&identity).dim()
-        );
+/// Build the entitlements plist used when code-signing a development build.
+///
+/// Reuses the compile-emitted `app.entitlements` (App Groups / associated-domains
+/// from #1178) when present — splicing the development keys
+/// (`application-identifier`, team identifier, `get-task-allow`,
+/// keychain-access-groups) in before `</dict>` — so on-device entitlements
+/// survive re-signing instead of being clobbered. When no `app.entitlements`
+/// exists, emits a standalone development plist (the prior behaviour).
+fn build_dev_entitlements_xml(app_dir: &Path, team_id: &str, bundle_id: &str) -> String {
+    let app_identifier = format!("{team_id}.{bundle_id}");
+    let dev_keys = format!(
+        "    <key>application-identifier</key>\n    <string>{app_identifier}</string>\n    \
+         <key>com.apple.developer.team-identifier</key>\n    <string>{team_id}</string>\n    \
+         <key>get-task-allow</key>\n    <true/>\n    \
+         <key>keychain-access-groups</key>\n    <array>\n        <string>{app_identifier}</string>\n    </array>\n"
+    );
+
+    match std::fs::read_to_string(app_dir.join("app.entitlements")) {
+        Ok(existing)
+            if existing.contains("</dict>") && !existing.contains("application-identifier") =>
+        {
+            existing.replacen("</dict>", &format!("{dev_keys}</dict>"), 1)
+        }
+        _ => format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+             <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+             <plist version=\"1.0\">\n<dict>\n{dev_keys}</dict>\n</plist>\n"
+        ),
     }
+}
 
-    // Step 1: Find or create a development provisioning profile
-    let profile_data = if let Some(path) = find_system_dev_profile(&bundle_id, &team_id) {
-        if let OutputFormat::Text = format {
-            println!(
-                "  Using existing dev profile: {}",
-                style(path.display()).dim()
-            );
-        }
-        std::fs::read(&path)?
-    } else {
-        // Create via App Store Connect API
-        if let OutputFormat::Text = format {
-            println!("  Creating development provisioning profile via App Store Connect...");
-        }
-        create_dev_profile_via_api(config, &bundle_id, &team_id, device_udid, format)
-            .await
-            .context(
-                "Could not create development provisioning profile.\n\
-                 Ensure your App Store Connect API key has the right permissions,\n\
-                 or use a simulator instead: perry run ios --simulator <UDID>",
-            )?
-    };
+/// Embed `profile_data` as `embedded.mobileprovision` and code-sign `app_dir`
+/// with the given development identity. The entitlements are produced by
+/// [`build_dev_entitlements_xml`], preserving any compile-emitted App Group /
+/// associated-domains entitlements.
+pub fn embed_profile_and_sign(
+    app_dir: &Path,
+    team_id: &str,
+    bundle_id: &str,
+    identity_hash: &str,
+    profile_data: &[u8],
+) -> Result<()> {
+    std::fs::write(app_dir.join("embedded.mobileprovision"), profile_data)?;
 
-    // Embed the dev profile
-    std::fs::write(app_dir.join("embedded.mobileprovision"), &profile_data)?;
-
-    // identity was already selected by team ID matching above
-
-    // Step 2: Build entitlements
     let tmp_dir = std::env::temp_dir().join("perry_run_resign");
     let _ = std::fs::remove_dir_all(&tmp_dir);
     std::fs::create_dir_all(&tmp_dir)?;
 
-    let app_identifier = format!("{team_id}.{bundle_id}");
     let entitlements = tmp_dir.join("entitlements.plist");
     std::fs::write(
         &entitlements,
-        format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>application-identifier</key>
-    <string>{app_identifier}</string>
-    <key>com.apple.developer.team-identifier</key>
-    <string>{team_id}</string>
-    <key>get-task-allow</key>
-    <true/>
-    <key>keychain-access-groups</key>
-    <array>
-        <string>{app_identifier}</string>
-    </array>
-</dict>
-</plist>
-"#,
-        ),
+        build_dev_entitlements_xml(app_dir, team_id, bundle_id),
     )?;
 
-    // Step 3: Remove old signature and re-sign
+    // Remove old signature and re-sign.
     let _ = std::fs::remove_dir_all(app_dir.join("_CodeSignature"));
 
     let status = Command::new("codesign")
-        .args(["--force", "--sign", &identity_hash, "--entitlements"])
+        .args(["--force", "--sign", identity_hash, "--entitlements"])
         .arg(&entitlements)
         .arg("--generate-entitlement-der")
         .arg(app_dir)
@@ -164,6 +194,44 @@ pub async fn resign_for_development(
     }
 
     Ok(())
+}
+
+/// Best-effort development signing for `perry compile --target ios`.
+///
+/// If a development provisioning profile (e.g. from `perry setup ios
+/// --development`) and a matching Apple Development identity are already
+/// available locally, embed + sign the bundle and return `true`. Returns
+/// `false` (without error) when the materials are missing, so a plain compile
+/// on a machine that hasn't provisioned a device still produces an unsigned
+/// bundle with install instructions instead of failing.
+pub fn try_sign_existing_dev_profile(
+    app_dir: &Path,
+    config: &super::super::publish::PerryConfig,
+    format: OutputFormat,
+) -> Result<bool> {
+    let team_id = match config.apple.as_ref().and_then(|a| a.team_id.clone()) {
+        Some(t) => t,
+        None => return Ok(false),
+    };
+    let bundle_id = read_bundle_id_from_app(app_dir).unwrap_or_else(|| "com.perry.app".to_string());
+    let profile_path = match find_system_dev_profile(&bundle_id, &team_id) {
+        Some(p) => p,
+        None => return Ok(false),
+    };
+    let (identity_hash, identity) = match find_dev_identity_for_team(&team_id) {
+        Ok(v) => v,
+        Err(_) => return Ok(false),
+    };
+    let profile_data = std::fs::read(&profile_path)?;
+    embed_profile_and_sign(app_dir, &team_id, &bundle_id, &identity_hash, &profile_data)?;
+    if let OutputFormat::Text = format {
+        println!(
+            "Signed for development (team {}, {}).",
+            style(&team_id).dim(),
+            style(&identity).dim()
+        );
+    }
+    Ok(true)
 }
 
 /// Find the signing identity hash that belongs to the given team ID.
@@ -511,5 +579,61 @@ pub fn read_bundle_id_from_app(app_dir: &Path) -> Option<String> {
         Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #1301: re-signing must not drop the App Group entitlement that
+    /// `perry compile --target ios` writes to `app.entitlements` (#1178).
+    /// The development keys are layered on top of the existing file.
+    #[test]
+    fn dev_entitlements_preserve_compile_emitted_app_group() {
+        let dir = std::env::temp_dir().join(format!("perry_resign_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("app.entitlements"),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+             <plist version=\"1.0\">\n<dict>\n    \
+             <key>com.apple.security.application-groups</key>\n    <array>\n        \
+             <string>group.com.example.shared</string>\n    </array>\n</dict>\n</plist>\n",
+        )
+        .unwrap();
+
+        let xml = build_dev_entitlements_xml(&dir, "ABCDE12345", "com.example.app");
+
+        // App Group survives.
+        assert!(xml.contains("com.apple.security.application-groups"));
+        assert!(xml.contains("group.com.example.shared"));
+        // Development keys are layered in.
+        assert!(xml.contains("<key>application-identifier</key>"));
+        assert!(xml.contains("ABCDE12345.com.example.app"));
+        assert!(xml.contains("<key>get-task-allow</key>"));
+        // Exactly one closing dict/plist (no double-wrapping).
+        assert_eq!(xml.matches("</dict>").count(), 1);
+        assert_eq!(xml.matches("</plist>").count(), 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// With no compile-emitted entitlements, a standalone development plist
+    /// is produced (the prior behaviour, kept for the no-app-group case).
+    #[test]
+    fn dev_entitlements_standalone_without_app_entitlements() {
+        let dir = std::env::temp_dir().join(format!("perry_resign_test2_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let xml = build_dev_entitlements_xml(&dir, "ABCDE12345", "com.example.app");
+
+        assert!(xml.starts_with("<?xml"));
+        assert!(xml.contains("<key>application-identifier</key>"));
+        assert!(xml.contains("ABCDE12345.com.example.app"));
+        assert!(!xml.contains("com.apple.security.application-groups"));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/perry/src/commands/setup/ios.rs
+++ b/crates/perry/src/commands/setup/ios.rs
@@ -799,3 +799,125 @@ pub fn ios_wizard(saved: &mut PerryConfig) -> Result<()> {
 
     Ok(())
 }
+
+/// `perry setup ios --development` — provision the connected device for
+/// on-device development (issue #1301).
+///
+/// Reuses the App Store Connect credentials stored by a prior `perry setup ios`
+/// to register the connected device's UDID and mint an "iOS App Development"
+/// provisioning profile for the project's bundle ID, saved next to the
+/// distribution profile at `~/.perry/<bundle>_dev.mobileprovision`. The existing
+/// `perry run --target ios` / `perry compile --target ios` paths auto-discover
+/// that profile and dev-sign the bundle, so no perry.toml distribution fields
+/// are clobbered here.
+pub fn ios_development_setup(saved: &PerryConfig) -> Result<()> {
+    println!("  {}", style("iOS Development Provisioning").bold());
+    println!("  Registers your connected device and creates an iOS App Development profile");
+    println!("  via App Store Connect (reuses the credentials from `perry setup ios`).");
+    println!();
+
+    // --- Require stored App Store Connect credentials ---
+    let apple = saved.apple.as_ref().ok_or_else(|| {
+        anyhow!(
+            "No Apple credentials found in ~/.perry/config.toml.\n\
+             Run `perry setup ios` first to store your App Store Connect API key."
+        )
+    })?;
+    let team_id = apple
+        .team_id
+        .clone()
+        .ok_or_else(|| anyhow!("Missing apple.team_id — run `perry setup ios` first."))?;
+    if apple.key_id.is_none() || apple.issuer_id.is_none() || apple.p8_key_path.is_none() {
+        bail!(
+            "Incomplete App Store Connect credentials in ~/.perry/config.toml.\n\
+             Run `perry setup ios` to (re)configure key_id, issuer_id, and the .p8 key."
+        );
+    }
+
+    // --- Resolve the project bundle ID from perry.toml ---
+    let perry_toml_path = std::env::current_dir()?.join("perry.toml");
+    let toml_bundle_id = if perry_toml_path.exists() {
+        let content = std::fs::read_to_string(&perry_toml_path)?;
+        toml::from_str::<toml::Value>(&content)
+            .ok()
+            .and_then(|parsed| {
+                parsed
+                    .get("ios")
+                    .and_then(|i| i.get("bundle_id"))
+                    .or_else(|| parsed.get("app").and_then(|a| a.get("bundle_id")))
+                    .or_else(|| parsed.get("project").and_then(|p| p.get("bundle_id")))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            })
+    } else {
+        None
+    };
+
+    let bundle_id = match toml_bundle_id {
+        Some(bid) => {
+            println!("  Bundle ID: {}", style(&bid).bold());
+            bid
+        }
+        None if is_interactive() => Input::<String>::new()
+            .with_prompt("  Bundle ID (e.g. com.company.app)")
+            .interact_text()?,
+        None => bail!(
+            "No bundle ID found in perry.toml ([ios]/[app]/[project].bundle_id).\n\
+             Add one or run this command interactively."
+        ),
+    };
+    println!();
+
+    // --- Detect / pick the connected device ---
+    let devices = crate::commands::run::detect_ios_devices()?;
+    if devices.is_empty() {
+        bail!(
+            "No connected iOS device found.\n\
+             Connect your iPhone/iPad via USB (and trust this computer), then retry.\n\
+             Verify with: xcrun devicectl list devices"
+        );
+    }
+    let udid = if devices.len() == 1 {
+        println!(
+            "  Device: {} ({})",
+            style(&devices[0].name).bold(),
+            style(&devices[0].udid).dim()
+        );
+        devices[0].udid.clone()
+    } else {
+        crate::commands::run::pick_device(&devices, "device to provision")?
+    };
+    println!();
+
+    // --- Register the device + mint the development profile via the ASC API ---
+    let rt = tokio::runtime::Runtime::new()?;
+    let profile_data = rt.block_on(crate::commands::run::create_dev_profile_via_api(
+        saved,
+        &bundle_id,
+        &team_id,
+        &udid,
+        crate::OutputFormat::Text,
+    ))?;
+
+    let save_path = dirs::home_dir().map(|h| {
+        h.join(".perry").join(format!(
+            "{}_dev.mobileprovision",
+            bundle_id.replace('.', "_")
+        ))
+    });
+
+    println!();
+    println!(
+        "  {} Development profile ready ({} bytes).",
+        style("✓").green().bold(),
+        profile_data.len()
+    );
+    if let Some(p) = &save_path {
+        println!("  Saved to {}", style(p.display()).dim());
+    }
+    println!();
+    println!("  Build, sign, install, and launch on your device with:");
+    println!("    {}", style("perry run --target ios").bold());
+
+    Ok(())
+}

--- a/crates/perry/src/commands/setup/mod.rs
+++ b/crates/perry/src/commands/setup/mod.rs
@@ -25,7 +25,7 @@ mod windows;
 // Per-platform wizards — used by `run` below.
 pub(crate) use android::android_wizard;
 pub(crate) use harmonyos::{harmonyos_wizard, prompt_password};
-pub(crate) use ios::ios_wizard;
+pub(crate) use ios::{ios_development_setup, ios_wizard};
 pub(crate) use macos::macos_wizard;
 pub(crate) use tvos::tvos_wizard;
 pub(crate) use visionos::visionos_wizard;
@@ -63,6 +63,14 @@ pub struct SetupArgs {
     /// answering "yes" at the interactive prompt; enables non-interactive / CI use.
     #[arg(long)]
     pub accept_license: bool,
+
+    /// (ios only) Provision the currently-connected device for on-device
+    /// *development* instead of App Store distribution: register the device's
+    /// UDID and mint an "iOS App Development" provisioning profile via the App
+    /// Store Connect API (saved to ~/.perry/<bundle>_dev.mobileprovision).
+    /// Requires a prior `perry setup ios` to store API credentials.
+    #[arg(long)]
+    pub development: bool,
 }
 
 pub fn run(args: SetupArgs) -> Result<()> {
@@ -97,11 +105,21 @@ pub fn run(args: SetupArgs) -> Result<()> {
         }
     };
 
+    if args.development && platform != "ios" {
+        anyhow::bail!("--development is only supported for `perry setup ios`");
+    }
+
     let mut saved = load_config();
 
     match platform.as_str() {
         "windows" => windows_wizard(args.accept_license)?,
         "android" => android_wizard(&mut saved)?,
+        "ios" if args.development => {
+            // Development-provisioning path: no global-config mutation, so
+            // return before the save_config below.
+            ios_development_setup(&saved)?;
+            return Ok(());
+        }
         "ios" => ios_wizard(&mut saved)?,
         "macos" => macos_wizard(&mut saved)?,
         "visionos" => visionos_wizard(&mut saved)?,


### PR DESCRIPTION
Fixes the development-signing half of #1301. Distribution provisioning was already automated; this adds the ahead-of-time **development**-profile + device-registration path and tightens the `compile --target ios` → install-on-device loop.

## What changed

### `perry setup ios --development` (new)
Reuses the App Store Connect credentials stored by a prior `perry setup ios` to:
1. Detect (and pick, if several) the connected iOS device via `xcrun devicectl`.
2. Register the device UDID and mint an **iOS App Development** provisioning profile for the project's `bundle_id`, saved next to the distribution one at `~/.perry/<bundle>_dev.mobileprovision`.

Non-destructive: it does **not** clobber `perry.toml` distribution fields. The existing `perry run` / `perry compile` paths already auto-discover a dev profile in `~/.perry`, so provisioning ahead of time is all that's needed.

### `perry compile --target ios` (physical device)
- Prints the **on-device** `devicectl install` / `process launch` instructions plus a pointer to `perry run --target ios` / `perry setup ios --development`, instead of simulator-only `simctl` instructions.
- **Best-effort dev-signs** the bundle when a dev profile + matching `Apple Development:` identity are already provisioned locally. A machine without those (e.g. CI) still produces an unsigned bundle — no failure, just instructions.
- `ios-simulator` keeps its existing `simctl` instructions unchanged.

### App Group entitlement no longer dropped at re-sign (bug fix)
`perry compile` writes the App Group / associated-domains entitlements to `app.entitlements` (#1178), but the re-sign step generated its own entitlements file and **dropped them**. Re-signing now layers the development keys on top of the existing `app.entitlements`, so App Groups survive `codesign` on device.

## Refactor
Extracted `find_dev_identity_for_team`, `build_dev_entitlements_xml`, and `embed_profile_and_sign` from `resign_for_development`; added `try_sign_existing_dev_profile` for the compile path. The existing `perry run --target ios` device flow (devicectl install + launch) was already wired and is unchanged.

## Tests
- New unit tests cover the entitlements-merge: App Group survives + dev keys layered in, and the standalone (no-app-group) case.
- Full `perry` crate suite green (344 tests). Manual CLI checks: `--help` surface, `--development` rejected on non-ios, clean error when ASC creds are absent.

## Out of scope / follow-up
Auto-registering the App Group **identifier** itself via the ASC API (the other "related friction" in #1301) is deferred — the public App Store Connect API does not expose App Group identifier creation, so that one step stays manual. The entitlement is no longer lost at signing time, which removes most of the friction.

> Note for maintainer: version bump + CHANGELOG entry intentionally omitted per the worktree-PR convention (folded in at merge).