### PR TITLE
fix(compile): #1304 link vendored optional_frameworks gated on frameworks_env

### DIFF
--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -1390,6 +1390,54 @@ pub(super) fn build_and_run_link(
                 cmd.arg("-framework").arg(framework);
             }
 
+            // Issue #1304 — vendored-SDK frameworks (e.g. GoogleSignIn
+            // for `@perryts/google-auth`). These live in a directory the
+            // app dev built/downloaded locally, named by the wrapper's
+            // `frameworks_env` env var. When that var is set and resolves
+            // to an existing directory, add it as a framework search path
+            // (`-F <dir>`) and emit one `-framework <name>` per declared
+            // `optional_frameworks` entry. When it's unset (or points at
+            // something that isn't a directory) we skip silently: the
+            // wrapper's `#if canImport(...)` Swift bridge already compiles
+            // a no-SDK fallback path, so the binary still links and
+            // returns a runtime "framework not linked" result rather than
+            // failing with undefined `GID*` symbols.
+            //
+            // Contract is static frameworks only — `-framework` links the
+            // archive directly with no `.app/Frameworks/` embed + rpath.
+            if let Some(env_name) = target_config.frameworks_env.as_deref() {
+                if !target_config.optional_frameworks.is_empty() {
+                    match std::env::var(env_name) {
+                        Ok(dir) if Path::new(&dir).is_dir() => {
+                            cmd.arg("-F").arg(&dir);
+                            for framework in &target_config.optional_frameworks {
+                                cmd.arg("-framework").arg(framework);
+                            }
+                            if let OutputFormat::Text = format {
+                                println!(
+                                    "Linking {} optional framework(s) for {} from ${} ({})",
+                                    target_config.optional_frameworks.len(),
+                                    native_lib.module,
+                                    env_name,
+                                    dir
+                                );
+                            }
+                        }
+                        Ok(dir) => {
+                            if let OutputFormat::Text = format {
+                                println!(
+                                    "Skipping optional frameworks for {}: ${} = {:?} is not a directory",
+                                    native_lib.module, env_name, dir
+                                );
+                            }
+                        }
+                        Err(_) => {
+                            // env var unset → silent skip (canImport fallback).
+                        }
+                    }
+                }
+            }
+
             // Add library search paths. MSVC link.exe takes `/LIBPATH:`;
             // every other linker we drive (clang/ld on Apple, gcc/ld on
             // Linux/Android/HarmonyOS) understands `-L`. Mirror the

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -213,6 +213,27 @@ pub(super) fn parse_native_library_manifest(
                     .collect()
             })
             .unwrap_or_default(),
+        // Issue #1304 — vendored-SDK frameworks gated on an env var.
+        // Accept both camelCase (`optionalFrameworks`/`frameworksEnv`,
+        // matching `libDirs`/`pkgConfig`) and snake_case
+        // (`optional_frameworks`/`frameworks_env`, matching
+        // `swift_sources`/`metal_sources`) so package authors don't get
+        // tripped up by the manifest's mixed casing convention.
+        optional_frameworks: tc
+            .get("optionalFrameworks")
+            .or_else(|| tc.get("optional_frameworks"))
+            .and_then(|f| f.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        frameworks_env: tc
+            .get("frameworksEnv")
+            .or_else(|| tc.get("frameworks_env"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
         libs: tc
             .get("libs")
             .and_then(|l| l.as_array())
@@ -757,6 +778,108 @@ mod manifest_parse_tests {
         let tc = parsed.target_config.expect("target_config");
         let prebuilt = tc.prebuilt.expect("prebuilt path");
         assert_eq!(prebuilt, pkg_dir.join("./vendor/libfoo.a"));
+    }
+
+    /// Issue #1304 — vendored-SDK frameworks parse from the snake_case
+    /// manifest keys (`optional_frameworks` / `frameworks_env`), matching
+    /// the `swift_sources` / `metal_sources` convention. These are the
+    /// shape `@perryts/google-auth` uses for the real GoogleSignIn SDK.
+    #[test]
+    fn optional_frameworks_parse_snake_case() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        let manifest = serde_json::json!({
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": {
+                        "ios": {
+                            "crate": "crate-ios",
+                            "lib": "perry_google_auth",
+                            "optional_frameworks": ["GoogleSignIn"],
+                            "frameworks_env": "PERRY_GOOGLE_SIGN_IN_FRAMEWORK_DIR"
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .expect("write package.json");
+
+        let parsed =
+            parse_native_library_manifest(pkg_dir, "demo", Some("ios")).expect("parsed manifest");
+        let tc = parsed.target_config.expect("target_config");
+        assert_eq!(tc.optional_frameworks, vec!["GoogleSignIn"]);
+        assert_eq!(
+            tc.frameworks_env.as_deref(),
+            Some("PERRY_GOOGLE_SIGN_IN_FRAMEWORK_DIR")
+        );
+    }
+
+    /// The camelCase spelling (`optionalFrameworks` / `frameworksEnv`,
+    /// matching `libDirs` / `pkgConfig`) is accepted too — the manifest's
+    /// casing convention is mixed, so we don't want a silent no-op when an
+    /// author picks the camelCase form.
+    #[test]
+    fn optional_frameworks_parse_camel_case() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        let manifest = serde_json::json!({
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": {
+                        "ios": {
+                            "crate": "crate-ios",
+                            "lib": "demo",
+                            "optionalFrameworks": ["GoogleSignIn", "AppAuth"],
+                            "frameworksEnv": "VENDOR_FW_DIR"
+                        }
+                    }
+                }
+            }
+        });
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .expect("write package.json");
+
+        let parsed =
+            parse_native_library_manifest(pkg_dir, "demo", Some("ios")).expect("parsed manifest");
+        let tc = parsed.target_config.expect("target_config");
+        assert_eq!(tc.optional_frameworks, vec!["GoogleSignIn", "AppAuth"]);
+        assert_eq!(tc.frameworks_env.as_deref(), Some("VENDOR_FW_DIR"));
+    }
+
+    /// Omitting both fields must default to an empty list / `None`, not
+    /// error — every existing wrapper lacks them.
+    #[test]
+    fn optional_frameworks_default_when_absent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        let manifest = serde_json::json!({
+            "perry": {
+                "nativeLibrary": {
+                    "functions": [],
+                    "targets": { "ios": { "crate": "rust", "lib": "demo" } }
+                }
+            }
+        });
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .expect("write package.json");
+
+        let parsed =
+            parse_native_library_manifest(pkg_dir, "demo", Some("ios")).expect("parsed manifest");
+        let tc = parsed.target_config.expect("target_config");
+        assert!(tc.optional_frameworks.is_empty());
+        assert!(tc.frameworks_env.is_none());
     }
 }
 

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -621,6 +621,31 @@ pub struct TargetNativeConfig {
     /// distribution pattern).
     pub prebuilt: Option<PathBuf>,
     pub frameworks: Vec<String>,
+    /// Vendored Apple frameworks linked *only* when an opt-in env var
+    /// resolves to a directory holding them (issue #1304). Unlike
+    /// `frameworks` (system frameworks, always linked from the SDK's
+    /// `System/Library/Frameworks`), these come from a third-party SDK
+    /// the app dev builds/downloads locally — e.g. GoogleSignIn for
+    /// `@perryts/google-auth`. Each entry is passed as `-framework
+    /// <name>`, gated on `frameworks_env`.
+    ///
+    /// Contract is **static frameworks only**: `-framework` links the
+    /// archive directly with no `.app/Frameworks/` embed or rpath, so
+    /// the vendored `.framework` must contain a static Mach-O. Dynamic
+    /// frameworks (CocoaPods-built GoogleSignIn) would also need
+    /// embedding + an `@executable_path/Frameworks` rpath, which is not
+    /// yet implemented (see #1304's open question).
+    pub optional_frameworks: Vec<String>,
+    /// Name of the environment variable that points at the directory
+    /// holding the `optional_frameworks` (issue #1304). When set and the
+    /// referenced path is an existing directory, the link line gains
+    /// `-F <dir>` plus one `-framework` per `optional_frameworks` entry.
+    /// When unset (or the path is missing), the optional frameworks are
+    /// skipped silently — the wrapper's Swift bridge `#if
+    /// canImport(...)` fallback already compiles a no-SDK code path, so
+    /// the build still links and returns a runtime "framework not
+    /// linked" result instead of failing.
+    pub frameworks_env: Option<String>,
     pub libs: Vec<String>,
     /// Extra `-L`/`/LIBPATH:` search paths to hand the linker before the
     /// `libs` entries are resolved. Anchored to the manifest's

--- a/docs/src/native-libraries/manifest-v1.md
+++ b/docs/src/native-libraries/manifest-v1.md
@@ -152,7 +152,9 @@ as their device counterpart (`ios` covers both `ios-simulator` and
 |-----------------|------------------|----------|-------|
 | `crate`         | path string      | yes\*    | Path (relative to package.json) to the Cargo crate that produces the staticlib. Required when `prebuilt` is absent. |
 | `lib`           | string           | yes\*    | Library name (without the `lib` prefix or `.a` extension). Required when `prebuilt` is absent. |
-| `frameworks`    | array of string  | no       | Apple-only — frameworks to pass to `clang -framework`. |
+| `frameworks`    | array of string  | no       | Apple-only — system frameworks to pass to `clang -framework` (resolved from the SDK's `System/Library/Frameworks`). |
+| `optionalFrameworks` | array of string | no  | Apple-only — vendored third-party frameworks linked **only** when `frameworksEnv` resolves to a directory containing them. `-framework <name>` per entry. Static frameworks only (see below). Snake_case `optional_frameworks` also accepted. |
+| `frameworksEnv` | string           | no       | Name of an env var that points at the directory holding `optionalFrameworks`. When set + the path is a directory, `-F <dir>` is added to the link line; when unset, the optional frameworks are skipped silently. Snake_case `frameworks_env` also accepted. |
 | `libs`          | array of string  | no       | System libraries to pass to the linker (`-lcurl`, etc.). |
 | `libDirs`       | array of paths   | no       | Extra linker search paths. Emitted before `libs` as `-L<dir>` (or `/LIBPATH:<dir>` on Windows MSVC). Relative entries resolve against `package.json`. |
 | `pkgConfig`     | array of string  | no       | pkg-config package names. The compiler runs `pkg-config --libs` and forwards the output. |
@@ -163,6 +165,48 @@ as their device counterpart (`ios` covers both `ios-simulator` and
 When both `prebuilt` and `crate`/`lib` are absent for the user's
 compile target, the wrapper is silently skipped on that target —
 useful for platform-specific bindings that only exist on macOS, etc.
+
+### Vendored frameworks (`optionalFrameworks` + `frameworksEnv`)
+
+Some Apple SDKs can't be redistributed through npm (licensing) or
+are too large to vendor — GoogleSignIn is the canonical example. For
+these, the wrapper declares the SDK's framework name(s) in
+`optionalFrameworks` and the name of an environment variable in
+`frameworksEnv`. The app developer builds/downloads the framework
+locally, points the env var at the directory holding it, and Perry's
+linker adds `-F <dir>` plus `-framework <name>` for each entry.
+
+```json
+"targets": {
+  "ios": {
+    "crate": "crate-ios",
+    "lib": "perry_google_auth",
+    "optionalFrameworks": ["GoogleSignIn"],
+    "frameworksEnv": "PERRY_GOOGLE_SIGN_IN_FRAMEWORK_DIR"
+  }
+}
+```
+
+```bash
+PERRY_GOOGLE_SIGN_IN_FRAMEWORK_DIR=/path/to/Frameworks \
+  perry compile app.ts --target ios
+```
+
+When the env var is **unset** (or points at a non-directory), the
+optional frameworks are skipped silently. This pairs with a Swift
+bridge guarded by `#if canImport(GoogleSignIn)`: the no-SDK fallback
+compiles and the binary still links, returning a runtime
+"framework not linked" result instead of failing with undefined
+symbols. The same `build.rs` opt-in (`-F $DIR` to `swiftc`) must
+gate the bridge's compile so both halves agree.
+
+**Contract — static frameworks only.** `-framework` links the
+archive directly; Perry does **not** embed the `.framework` into
+`<app>.app/Frameworks/` or add an `@executable_path/Frameworks`
+rpath. A dynamic framework would link but fail to load at runtime.
+Vendor a statically-linked `.framework` (or a `.xcframework` slice
+containing a static Mach-O). Embedding dynamic frameworks +
+resource bundles is tracked as future work (#1304).
 
 ## Resolution
 


### PR DESCRIPTION
Closes #1304.

## Problem

`@perryts/google-auth` documents a two-part opt-in for the real GoogleSignIn SDK. Only the **first** part (`build.rs` passing `-F $DIR` to `swiftc` so the bridge compiles the real code path) was implemented. The **second** part — getting Perry's final linker to actually link the framework — never ran, because `build.rs` emits `cargo:rustc-link-*` directives and Perry doesn't link through cargo. Perry's link line only added system frameworks, never the manifest's vendored frameworks, so the real-SDK build failed with:

```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_GIDConfiguration", ...
  "_OBJC_CLASS_$_GIDSignIn", ...
  "_kGIDSignInErrorDomain", ...
ld: symbol(s) not found for architecture arm64
```

There was no `--link-arg` / `-F` passthrough either, so an app dev couldn't inject the flags themselves — the only unblock was patching the compiler.

## Fix

Implements parts 1 & 2 of the issue's proposal:

1. **Parse** `optional_frameworks: Vec<String>` and `frameworks_env: Option<String>` from the `targets.<plat>` manifest block (`resolve.rs` + `types.rs`). Both camelCase (`optionalFrameworks`/`frameworksEnv`) and snake_case spellings are accepted, since the manifest schema already mixes the two conventions (`libDirs`/`pkgConfig` vs `swift_sources`/`metal_sources`).
2. **Link** (`link/mod.rs`): right after the existing system-`frameworks` loop, if `frameworks_env` is set and resolves to an existing directory, add `-F <dir>` to the link line plus `-framework <name>` for each `optional_frameworks` entry. If the env var is unset (or points at a non-directory), skip silently — the wrapper's `#if canImport(...)` Swift bridge already compiles a no-SDK fallback, so the binary still links and returns a runtime "framework not linked" result. Current env-unset behavior is preserved.

### Scope / contract

**Static frameworks only.** `-framework` links the archive directly with no `<app>.app/Frameworks/` embed or `@executable_path/Frameworks` rpath. A dynamic framework (CocoaPods-built GoogleSignIn) would link but fail to load at runtime. This matches the issue's "open question" recommendation; embedding dynamic frameworks + resource bundles is left as future work (still tracked under #1304). The static-only contract and the GoogleSignIn opt-in example are documented in `docs/src/native-libraries/manifest-v1.md`.

## Tests

- New `manifest_parse_tests`: snake_case parse, camelCase parse, and absent-defaults (empty vec / `None`).
- All 9 tests in the module pass; `cargo fmt --all -- --check` is clean.

> Note for merge: per the worktree-PR convention, this branch intentionally does **not** bump `Cargo.toml`/`CLAUDE.md` version or add a `CHANGELOG.md` entry — those get folded in at merge time.