### PR TITLE
fix(bcrypt): #1292 — bcrypt.hash() returns a real string, not a string-like object

### DIFF
--- a/crates/perry-stdlib/src/bcrypt.rs
+++ b/crates/perry-stdlib/src/bcrypt.rs
@@ -5,7 +5,7 @@
 
 use perry_runtime::{js_string_from_bytes, JSValue, StringHeader};
 
-use crate::common::async_bridge::{queue_promise_resolution, spawn};
+use crate::common::async_bridge::{queue_deferred_resolution, queue_promise_resolution, spawn};
 
 /// Helper to extract string from StringHeader pointer
 unsafe fn string_from_header(ptr: *const StringHeader) -> Option<String> {
@@ -33,7 +33,7 @@ pub unsafe extern "C" fn js_bcrypt_hash(
         None => {
             let err_msg = "Password is null or invalid UTF-8";
             let err_str = js_string_from_bytes(err_msg.as_ptr(), err_msg.len() as u32);
-            let err_bits = JSValue::pointer(err_str as *const u8).bits();
+            let err_bits = JSValue::string_ptr(err_str).bits();
             queue_promise_resolution(promise_ptr, false, err_bits);
             return promise;
         }
@@ -47,21 +47,34 @@ pub unsafe extern "C" fn js_bcrypt_hash(
 
         match result {
             Ok(Ok(hash)) => {
-                let hash_str = js_string_from_bytes(hash.as_ptr(), hash.len() as u32);
-                let result_bits = JSValue::pointer(hash_str as *const u8).bits();
-                queue_promise_resolution(promise_ptr, true, result_bits);
+                // #1292: build the JS string on the MAIN thread (deferred)
+                // and tag it STRING_TAG via `string_ptr`. The old path used
+                // `JSValue::pointer` (POINTER_TAG) and allocated on the tokio
+                // worker arena, so the awaited result was a string-like
+                // *object*: `typeof === "object"`, `+`/`String()` coerced to
+                // "[object Object]", and mysql2 prepared-binding serialized
+                // the object representation (>255 bytes) instead of the
+                // 60-char hash. `queue_deferred_resolution` runs the closure
+                // on the main thread so the StringHeader lands in the main
+                // arena. See common::async_bridge for the arena rationale.
+                queue_deferred_resolution(promise_ptr, true, move || {
+                    let hash_str = js_string_from_bytes(hash.as_ptr(), hash.len() as u32);
+                    JSValue::string_ptr(hash_str).bits()
+                });
             }
             Ok(Err(e)) => {
                 let err_msg = format!("Bcrypt error: {}", e);
-                let err_str = js_string_from_bytes(err_msg.as_ptr(), err_msg.len() as u32);
-                let err_bits = JSValue::pointer(err_str as *const u8).bits();
-                queue_promise_resolution(promise_ptr, false, err_bits);
+                queue_deferred_resolution(promise_ptr, false, move || {
+                    let err_str = js_string_from_bytes(err_msg.as_ptr(), err_msg.len() as u32);
+                    JSValue::string_ptr(err_str).bits()
+                });
             }
             Err(e) => {
                 let err_msg = format!("Task error: {}", e);
-                let err_str = js_string_from_bytes(err_msg.as_ptr(), err_msg.len() as u32);
-                let err_bits = JSValue::pointer(err_str as *const u8).bits();
-                queue_promise_resolution(promise_ptr, false, err_bits);
+                queue_deferred_resolution(promise_ptr, false, move || {
+                    let err_str = js_string_from_bytes(err_msg.as_ptr(), err_msg.len() as u32);
+                    JSValue::string_ptr(err_str).bits()
+                });
             }
         }
     });
@@ -84,7 +97,7 @@ pub unsafe extern "C" fn js_bcrypt_compare(
         None => {
             let err_msg = "Password is null or invalid UTF-8";
             let err_str = js_string_from_bytes(err_msg.as_ptr(), err_msg.len() as u32);
-            let err_bits = JSValue::pointer(err_str as *const u8).bits();
+            let err_bits = JSValue::string_ptr(err_str).bits();
             queue_promise_resolution(promise_ptr, false, err_bits);
             return promise;
         }
@@ -95,7 +108,7 @@ pub unsafe extern "C" fn js_bcrypt_compare(
         None => {
             let err_msg = "Hash is null or invalid UTF-8";
             let err_str = js_string_from_bytes(err_msg.as_ptr(), err_msg.len() as u32);
-            let err_bits = JSValue::pointer(err_str as *const u8).bits();
+            let err_bits = JSValue::string_ptr(err_str).bits();
             queue_promise_resolution(promise_ptr, false, err_bits);
             return promise;
         }
@@ -117,15 +130,17 @@ pub unsafe extern "C" fn js_bcrypt_compare(
             }
             Ok(Err(e)) => {
                 let err_msg = format!("Bcrypt verify error: {}", e);
-                let err_str = js_string_from_bytes(err_msg.as_ptr(), err_msg.len() as u32);
-                let err_bits = JSValue::pointer(err_str as *const u8).bits();
-                queue_promise_resolution(promise_ptr, false, err_bits);
+                queue_deferred_resolution(promise_ptr, false, move || {
+                    let err_str = js_string_from_bytes(err_msg.as_ptr(), err_msg.len() as u32);
+                    JSValue::string_ptr(err_str).bits()
+                });
             }
             Err(e) => {
                 let err_msg = format!("Task error: {}", e);
-                let err_str = js_string_from_bytes(err_msg.as_ptr(), err_msg.len() as u32);
-                let err_bits = JSValue::pointer(err_str as *const u8).bits();
-                queue_promise_resolution(promise_ptr, false, err_bits);
+                queue_deferred_resolution(promise_ptr, false, move || {
+                    let err_str = js_string_from_bytes(err_msg.as_ptr(), err_msg.len() as u32);
+                    JSValue::string_ptr(err_str).bits()
+                });
             }
         }
     });
@@ -165,20 +180,26 @@ pub unsafe extern "C" fn js_bcrypt_gen_salt(rounds: f64) -> *mut perry_runtime::
 
         match result {
             Ok(Ok(salt)) => {
-                let salt_str = js_string_from_bytes(salt.as_ptr(), salt.len() as u32);
-                let result_bits = JSValue::pointer(salt_str as *const u8).bits();
-                queue_promise_resolution(promise_ptr, true, result_bits);
+                // #1292: same as `js_bcrypt_hash` — defer string creation to
+                // the main thread and tag STRING_TAG so the salt awaits as a
+                // real JS string, not a string-like object.
+                queue_deferred_resolution(promise_ptr, true, move || {
+                    let salt_str = js_string_from_bytes(salt.as_ptr(), salt.len() as u32);
+                    JSValue::string_ptr(salt_str).bits()
+                });
             }
             Ok(Err(e)) => {
-                let err_str = js_string_from_bytes(e.as_ptr(), e.len() as u32);
-                let err_bits = JSValue::pointer(err_str as *const u8).bits();
-                queue_promise_resolution(promise_ptr, false, err_bits);
+                queue_deferred_resolution(promise_ptr, false, move || {
+                    let err_str = js_string_from_bytes(e.as_ptr(), e.len() as u32);
+                    JSValue::string_ptr(err_str).bits()
+                });
             }
             Err(e) => {
                 let err_msg = format!("Task error: {}", e);
-                let err_str = js_string_from_bytes(err_msg.as_ptr(), err_msg.len() as u32);
-                let err_bits = JSValue::pointer(err_str as *const u8).bits();
-                queue_promise_resolution(promise_ptr, false, err_bits);
+                queue_deferred_resolution(promise_ptr, false, move || {
+                    let err_str = js_string_from_bytes(err_msg.as_ptr(), err_msg.len() as u32);
+                    JSValue::string_ptr(err_str).bits()
+                });
             }
         }
     });


### PR DESCRIPTION
## Summary

Fixes #1292. `bcrypt.hash(password, rounds)` was returning a value that
coerced to `"[object Object]"` via `+` and `String()`, reported
`typeof === "object"`, and made mysql2 prepared-statement binding send
the object representation (>255 bytes → MySQL error 1406 "Data too long
for column") instead of the 60-char hash.

## Root cause

The async resolution path in `crates/perry-stdlib/src/bcrypt.rs` did two
things wrong:

1. **Wrong NaN-box tag.** It boxed the result `StringHeader` with
   `JSValue::pointer` (`POINTER_TAG` → `typeof "object"`) instead of
   `JSValue::string_ptr` (`STRING_TAG` → `typeof "string"`). That alone
   explains every coercion symptom — `+`/`String()` → `"[object Object]"`,
   and mysql2 serializing the object instead of the string.
2. **Wrong thread.** It allocated the string on the tokio worker arena,
   which `common::async_bridge` explicitly documents as unsafe (per-thread
   arenas).

`.length` reading 60 and `JSON.stringify` producing the right string were
coincidences of the `StringHeader` layout and JSON's own pointer handling,
which is why the issue's only reliable workaround was a
`JSON.parse(JSON.stringify(raw))` round-trip.

The sync `hashSync` path already pre-boxed with `STRING_TAG`; only the
async paths were missed. The external `perry-ext-bcrypt` crate was already
correct (it uses `nanbox_string_bits`/`STRING_TAG` via perry-ffi); the
default `import 'bcrypt'` routes to the bundled perry-stdlib module, which
is the one the issue hit.

## Fix

Route the hash/salt/error resolutions through `queue_deferred_resolution`
so the `StringHeader` is built on the **main thread** (correct arena) and
tag it with `JSValue::string_ptr` (`STRING_TAG`). This matches the pattern
`spawn_for_promise` already uses for its error strings. Applied to
`js_bcrypt_hash`, `js_bcrypt_gen_salt`, and the error strings of
`js_bcrypt_compare` (its boolean-success path is unchanged).

## Verification

Compiled and ran the issue's repro:

```
typeof          : string          (was "object")
.length         : 60
"" + raw        : $2b$12$GAI/EJt.zUrZ1wE1.CH5iO8Q7czYAxMzT6zXBFG07a48vTaHVPXy6
String(raw)     : $2b$12$GAI/EJt.zUrZ1wE1.CH5iO8Q7czYAxMzT6zXBFG07a48vTaHVPXy6
startsWith $2    : true
substring(0,7)  : $2b$12$
JSON.stringify  : "$2b$12$..."     (still correct)
compare match   : 1
compare mismatch: 0
```

`typeof` is now `"string"`, `+`/`String()` return the real 60-char hash,
string methods work, and `compare()` round-trips against the freshly
produced hash. mysql2 prepared binding now sends the 60-byte string.

Note: the issue also observed `!!(raw as any).substring === false`. That
is a pre-existing, general Perry behavior — dynamic property access of
built-in string methods returns falsy for *any* string literal too (the
direct method call works). It was a consequence of the value being an
object here, not a separate bcrypt bug, and is out of scope for this fix.
