### PR TITLE
fix(fastify): #1293 route `(request as any).json()`/`.body` through external-fastify handle dispatch

### DIFF
--- a/crates/perry-ext-fastify/src/context.rs
+++ b/crates/perry-ext-fastify/src/context.rs
@@ -365,6 +365,29 @@ pub unsafe extern "C" fn js_fastify_req_set_user_data(ctx_handle: Handle, data: 
     }
 }
 
+/// #1293 — membership probe for the well-known-flipped generic
+/// dispatch path. Returns 1 iff `handle` is a live `FastifyContext`
+/// in *this crate's* perry-ffi registry, 0 otherwise.
+///
+/// When the well-known flip routes `fastify` to perry-ext-fastify,
+/// perry-stdlib's `js_handle_method_dispatch` / `js_handle_property_dispatch`
+/// can no longer see the request/reply handle — it lives in perry-ffi's
+/// registry, not perry-stdlib's. So `(request as any).json()` /
+/// `(request as any).body` (where the `as any` cast erased the static
+/// type and codegen emitted a generic dynamic dispatch rather than a
+/// `NativeMethodCall`) silently returned NaN / undefined. perry-stdlib's
+/// external-fastify dispatch arms call this to confirm the handle is ours
+/// before forwarding to the `js_fastify_req_*` / `js_fastify_ctx_*`
+/// exports. Mirrors `js_ext_net_is_socket_handle` (perry-ext-net).
+#[no_mangle]
+pub unsafe extern "C" fn js_ext_fastify_is_context_handle(ctx_handle: Handle) -> i32 {
+    if get_handle::<FastifyContext>(ctx_handle).is_some() {
+        1
+    } else {
+        0
+    }
+}
+
 // ============================================================================
 // FFI: Reply methods (Fastify style — `reply.status(...).send(...)`)
 // ============================================================================

--- a/crates/perry-ext-fastify/src/lib.rs
+++ b/crates/perry-ext-fastify/src/lib.rs
@@ -285,6 +285,38 @@ mod tests {
     }
 
     #[test]
+    fn ext_fastify_is_context_handle_membership() {
+        // #1293 — the membership probe perry-stdlib's external-fastify
+        // dispatch arms consult before forwarding `(request as any).json()`
+        // / `(request as any).body` to our `js_fastify_*` exports.
+        let ctx = FastifyContext::new(
+            0,
+            "POST".to_string(),
+            "/x".to_string(),
+            HashMap::new(),
+            Some(b"{}".to_vec()),
+            HashMap::new(),
+        );
+        let ctx_handle = register_handle(ctx);
+        // A non-existent handle id is never ours.
+        assert_eq!(unsafe { js_ext_fastify_is_context_handle(0) }, 0);
+        assert_eq!(
+            unsafe { js_ext_fastify_is_context_handle(ctx_handle + 9_999) },
+            0
+        );
+        // A live FastifyContext handle is ours.
+        assert_eq!(unsafe { js_ext_fastify_is_context_handle(ctx_handle) }, 1);
+        // A FastifyApp handle is NOT a context (type-discriminated downcast).
+        let app_handle = register_handle(FastifyApp::new());
+        assert_eq!(unsafe { js_ext_fastify_is_context_handle(app_handle) }, 0);
+
+        drop_handle(ctx_handle);
+        drop_handle(app_handle);
+        // After the context is dropped the probe reports it gone.
+        assert_eq!(unsafe { js_ext_fastify_is_context_handle(ctx_handle) }, 0);
+    }
+
+    #[test]
     fn port_extraction_safe_defaults() {
         // Object literal pattern verified through the wider unit
         // tests; here we exercise the bare-number pattern + the

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -99,6 +99,38 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
         return dispatch_fastify_context(handle, method_name, args);
     }
 
+    // External Fastify path (#1293): when the well-known flip routes
+    // `fastify` to perry-ext-fastify, the request/reply handle lives in
+    // perry-ffi's registry — invisible to the `with_handle::<FastifyContext>`
+    // probe above (separate DashMap, separate type). `(request as any).json()`
+    // / `(request as any).body()` (where the `as any` cast made codegen emit
+    // a generic dynamic dispatch instead of a `NativeMethodCall`) used to
+    // fall through and return NaN. Same dispatch contract as the bundled arm,
+    // but membership + the `js_fastify_*` exports resolve to perry-ext-fastify
+    // at link time. Mirrors the `external-net-pump` arm below.
+    #[cfg(all(not(feature = "http-server"), feature = "external-fastify-pump"))]
+    if matches!(
+        method_name,
+        "send"
+            | "status"
+            | "code"
+            | "header"
+            | "type"
+            | "method"
+            | "url"
+            | "body"
+            | "json"
+            | "params"
+            | "headers"
+    ) {
+        extern "C" {
+            fn js_ext_fastify_is_context_handle(handle: i64) -> i32;
+        }
+        if unsafe { js_ext_fastify_is_context_handle(handle) } != 0 {
+            return dispatch_external_fastify_context(handle, method_name, args);
+        }
+    }
+
     // ioredis client.
     #[cfg(feature = "database-redis")]
     if matches!(
@@ -560,6 +592,76 @@ unsafe fn dispatch_fastify_context(handle: i64, method: &str, args: &[f64]) -> f
     }
 }
 
+/// Dispatch a method call on a perry-ext-fastify request/reply handle via
+/// `extern "C"` symbols (#1293). Same dispatch contract as
+/// `dispatch_fastify_context` above, but the per-method `js_fastify_*`
+/// functions resolve to perry-ext-fastify's archive at link time, not
+/// perry-stdlib's `crate::fastify::*` (which is compiled out when the
+/// well-known flip strips `http-server`). Caller gates on
+/// `js_ext_fastify_is_context_handle` + the same method vocabulary.
+#[cfg(all(not(feature = "http-server"), feature = "external-fastify-pump"))]
+unsafe fn dispatch_external_fastify_context(handle: i64, method: &str, args: &[f64]) -> f64 {
+    use perry_runtime::JSValue;
+
+    extern "C" {
+        fn js_fastify_reply_send(handle: i64, data: f64) -> bool;
+        fn js_fastify_reply_status(handle: i64, code: f64) -> i64;
+        fn js_fastify_reply_header(handle: i64, name: i64, value: i64) -> i64;
+        fn js_fastify_reply_type(handle: i64, value: i64) -> i64;
+        fn js_fastify_req_method(handle: i64) -> *mut perry_runtime::StringHeader;
+        fn js_fastify_req_url(handle: i64) -> *mut perry_runtime::StringHeader;
+        fn js_fastify_req_json(handle: i64) -> f64;
+        fn js_fastify_req_params_object(handle: i64) -> f64;
+        fn js_fastify_req_headers(handle: i64) -> i64;
+    }
+
+    match method {
+        // Reply methods
+        "send" if !args.is_empty() => {
+            if js_fastify_reply_send(handle, args[0]) {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        "status" | "code" if !args.is_empty() => {
+            let result = js_fastify_reply_status(handle, args[0]);
+            // NaN-box the handle as a pointer so `reply.status(200).send(...)`
+            // chains (the next dispatch sees a small-handle pointer again).
+            f64::from_bits(0x7FFD_0000_0000_0000 | (result as u64 & 0x0000_FFFF_FFFF_FFFF))
+        }
+        "header" if args.len() >= 2 => {
+            let name = args[0].to_bits() as i64;
+            let value = args[1].to_bits() as i64;
+            let result = js_fastify_reply_header(handle, name, value);
+            f64::from_bits(0x7FFD_0000_0000_0000 | (result as u64 & 0x0000_FFFF_FFFF_FFFF))
+        }
+        "type" if !args.is_empty() => {
+            let value = args[0].to_bits() as i64;
+            let result = js_fastify_reply_type(handle, value);
+            f64::from_bits(0x7FFD_0000_0000_0000 | (result as u64 & 0x0000_FFFF_FFFF_FFFF))
+        }
+        // Request methods
+        "method" => {
+            let ptr = js_fastify_req_method(handle);
+            f64::from_bits(JSValue::string_ptr(ptr).bits())
+        }
+        "url" => {
+            let ptr = js_fastify_req_url(handle);
+            f64::from_bits(JSValue::string_ptr(ptr).bits())
+        }
+        // Both `request.body` and `request.json()` surface the parsed body;
+        // `js_fastify_req_json` returns NaN-boxed undefined when there is none.
+        "body" | "json" => js_fastify_req_json(handle),
+        "params" => js_fastify_req_params_object(handle),
+        "headers" => {
+            let bits = js_fastify_req_headers(handle);
+            f64::from_bits(bits as u64)
+        }
+        _ => f64::from_bits(0x7FFC_0000_0000_0001), // undefined
+    }
+}
+
 /// Dispatch method calls on net.Socket handles when codegen couldn't tag
 /// the receiver type. Mirrors the static NATIVE_MODULE_TABLE entries for
 /// the same methods (write/end/destroy/on/upgradeToTLS).
@@ -781,6 +883,68 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
             }
             _ => f64::from_bits(0x7FFC_0000_0000_0001), // undefined
         };
+    }
+
+    // External Fastify property path (#1293): the well-known-flipped twin of
+    // the `http-server` arm above. `(request as any).body` / `.headers` /
+    // `.params` / ... on a perry-ext-fastify handle (its `as any` cast erased
+    // the type, so codegen routed through `js_object_get_field_by_name` →
+    // here instead of a `NativeMethodCall`). Membership + the `js_fastify_*`
+    // symbols resolve to perry-ext-fastify at link time.
+    #[cfg(all(not(feature = "http-server"), feature = "external-fastify-pump"))]
+    if matches!(
+        property_name,
+        "query" | "params" | "body" | "rawBody" | "text" | "headers" | "method" | "url" | "user"
+    ) {
+        extern "C" {
+            fn js_ext_fastify_is_context_handle(handle: i64) -> i32;
+            fn js_fastify_req_query_object(handle: i64) -> f64;
+            fn js_fastify_req_params_object(handle: i64) -> f64;
+            fn js_fastify_req_json(handle: i64) -> f64;
+            fn js_fastify_req_body(handle: i64) -> *mut perry_runtime::StringHeader;
+            fn js_fastify_req_headers(handle: i64) -> i64;
+            fn js_fastify_req_method(handle: i64) -> *mut perry_runtime::StringHeader;
+            fn js_fastify_req_url(handle: i64) -> *mut perry_runtime::StringHeader;
+            fn js_fastify_req_get_user_data(handle: i64) -> f64;
+        }
+        if unsafe { js_ext_fastify_is_context_handle(handle) } != 0 {
+            use perry_runtime::JSValue;
+            return match property_name {
+                "query" => unsafe { js_fastify_req_query_object(handle) },
+                "params" => unsafe { js_fastify_req_params_object(handle) },
+                "body" => unsafe { js_fastify_req_json(handle) },
+                "rawBody" | "text" => {
+                    let ptr = unsafe { js_fastify_req_body(handle) };
+                    if ptr.is_null() {
+                        f64::from_bits(0x7FFC_0000_0000_0001)
+                    } else {
+                        f64::from_bits(JSValue::string_ptr(ptr).bits())
+                    }
+                }
+                "headers" => {
+                    let bits = unsafe { js_fastify_req_headers(handle) };
+                    f64::from_bits(bits as u64)
+                }
+                "method" => {
+                    let ptr = unsafe { js_fastify_req_method(handle) };
+                    if ptr.is_null() {
+                        f64::from_bits(0x7FFC_0000_0000_0001)
+                    } else {
+                        f64::from_bits(JSValue::string_ptr(ptr).bits())
+                    }
+                }
+                "url" => {
+                    let ptr = unsafe { js_fastify_req_url(handle) };
+                    if ptr.is_null() {
+                        f64::from_bits(0x7FFC_0000_0000_0001)
+                    } else {
+                        f64::from_bits(JSValue::string_ptr(ptr).bits())
+                    }
+                }
+                "user" => unsafe { js_fastify_req_get_user_data(handle) },
+                _ => f64::from_bits(0x7FFC_0000_0000_0001),
+            };
+        }
     }
 
     // Issue #340: axios response — dispatch `r.status` / `r.data` /

--- a/test-files/run_test_issue_1293.sh
+++ b/test-files/run_test_issue_1293.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Wire-level regression harness for issue #1293 — fastify
+# `(request as any).json()` / `(request as any).body` returned NaN /
+# undefined (silent 400) under the well-known-flipped perry-ext-fastify
+# backend. See test_issue_1293_fastify_request_json_as_any.ts for the writeup.
+#
+# Usage:
+#   PERRY_BIN=./target/release/perry ./test-files/run_test_issue_1293.sh
+#
+# Assertion: POST `{"hello":"world"}` to /typed, /any-json and /any-body each
+# returns a JSON body containing `"hello":"world"` and `"typeofBody":"object"`.
+# Pre-fix /any-json returned `"body":"falsy"` (json() was a bare NaN) and
+# /any-body returned `"body":"falsy"` (.body was undefined).
+
+set -euo pipefail
+
+PERRY_BIN="${PERRY_BIN:-./target/release/perry}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_SRC="$SCRIPT_DIR/test_issue_1293_fastify_request_json_as_any.ts"
+PORT=18993
+EXE="${TMPDIR:-/tmp}/test_issue_1293_fastify_request_json_as_any"
+
+cd "$WORKSPACE_ROOT"
+
+if [[ ! -x "$PERRY_BIN" ]]; then
+    echo "FAIL: perry binary not found at $PERRY_BIN — build first via cargo build --release -p perry" >&2
+    exit 1
+fi
+
+echo "[1293] compiling fixture..."
+PERRY_ALLOW_PERRY_FEATURES=1 "$PERRY_BIN" "$TEST_SRC" -o "$EXE" >/dev/null 2>&1
+
+echo "[1293] starting server on :$PORT..."
+"$EXE" >/dev/null 2>&1 &
+SERVER_PID=$!
+trap 'kill $SERVER_PID 2>/dev/null; wait $SERVER_PID 2>/dev/null || true' EXIT
+
+# Wait for bind.
+for i in 1 2 3 4 5 6 7 8; do
+    if curl -sS -o /dev/null --max-time 1 -X POST "http://127.0.0.1:$PORT/typed" \
+        -H 'Content-Type: application/json' -d '{"_":0}' 2>/dev/null; then
+        break
+    fi
+    sleep 0.1
+done
+
+fail=0
+for ROUTE in typed any-json any-body; do
+    RESPONSE="$(curl -sS --max-time 2 -X POST "http://127.0.0.1:$PORT/$ROUTE" \
+        -H 'Content-Type: application/json' -d '{"hello":"world"}')"
+    echo "[1293] $ROUTE response=$RESPONSE"
+
+    if [[ "$RESPONSE" == *'"body":"falsy"'* ]]; then
+        echo "[1293] FAIL ($ROUTE) — handler took the if(!body) 400 path (body lost)"
+        fail=1
+    fi
+    if [[ "$RESPONSE" != *'"hello":"world"'* ]]; then
+        echo "[1293] FAIL ($ROUTE) — parsed body lost the 'hello' key"
+        fail=1
+    fi
+    if [[ "$RESPONSE" != *'"typeofBody":"object"'* ]]; then
+        echo "[1293] FAIL ($ROUTE) — body was not an object (pre-fix: number/undefined)"
+        fail=1
+    fi
+done
+
+if [[ $fail -eq 0 ]]; then
+    echo "[1293] PASS"
+    exit 0
+else
+    exit 1
+fi

--- a/test-files/test_issue_1293_fastify_request_json_as_any.ts
+++ b/test-files/test_issue_1293_fastify_request_json_as_any.ts
@@ -1,0 +1,58 @@
+// Issue #1293 — fastify `(request as any).json()` / `(request as any).body`
+// returned NaN / undefined (silent 400) under the well-known-flipped
+// perry-ext-fastify backend.
+//
+// #1240 fixed `request.json()` on the *typed* receiver — that lowers to a
+// `NativeMethodCall { module: "fastify" }` and dispatches through the static
+// NATIVE_MODULE_TABLE → `js_fastify_ctx_json` (with its zero-arg detection).
+//
+// But the standard Fastify body-parse pattern in the wild casts the receiver:
+// `const body = (request as any).json(); if (!body) return reply.status(400)…`.
+// The `as any` cast erases the static type, so codegen emits a *generic*
+// dynamic dispatch (`Call { callee: PropertyGet }` / `PropertyGet`) instead of
+// a `NativeMethodCall`. At runtime that lands in perry-stdlib's
+// `js_handle_method_dispatch` / `js_handle_property_dispatch` — which probed
+// only perry-stdlib's *own* handle registry. Under the well-known flip the
+// FastifyContext lives in perry-ffi's registry instead, so the probe missed,
+// the call fell through, and `json()` came back as a bare NaN (`typeof
+// "number"`) while `.body` came back `undefined`.
+//
+// Fix: perry-ext-fastify exports `js_ext_fastify_is_context_handle`, and
+// perry-stdlib's dispatch grows `external-fastify-pump` arms (mirroring the
+// `external-net-pump` arms) that consult it and forward to the linked
+// `js_fastify_*` exports.
+//
+// Wire-level assertion: every shape — typed json(), `(as any).json()`,
+// `(as any).body`, and json() consumed only by `if(!body)` — returns the
+// parsed object intact.
+
+import Fastify from "fastify";
+
+const PORT = 18993;
+const app = Fastify({ logger: false });
+
+// Typed receiver — the #1240 path (NativeMethodCall). Must keep working.
+app.post("/typed", async (request, reply) => {
+    const body = request.json() as { hello?: string };
+    if (!body) return reply.status(400).send({ where: "typed", body: "falsy" });
+    return { where: "typed", typeofBody: typeof body, hello: body.hello ?? null };
+});
+
+// `(request as any).json()` consumed only by `if (!body)` — the exact #1293
+// repro. Pre-fix this 400'd because json() returned NaN.
+app.post("/any-json", async (request, reply) => {
+    const body = (request as any).json() as any;
+    if (!body) return reply.status(400).send({ where: "any-json", body: "falsy" });
+    return { where: "any-json", typeofBody: typeof body, hello: body.hello ?? null };
+});
+
+// `(request as any).body` — the property-access shape (the workaround the
+// issue author shipped). Goes through `js_handle_property_dispatch`.
+app.post("/any-body", async (request, reply) => {
+    const body = (request as any).body as any;
+    if (!body) return reply.status(400).send({ where: "any-body", body: "falsy" });
+    return { where: "any-body", typeofBody: typeof body, hello: body.hello ?? null };
+});
+
+await app.listen({ port: PORT, host: "127.0.0.1" });
+console.log(`listening on :${PORT}`);


### PR DESCRIPTION
Fixes #1293.

## Root cause

The canonical Fastify body-parse pattern casts the receiver:

```ts
const body = (request as any).json();
if (!body) return reply.status(400).send({ error: "Invalid body" });
```

The `as any` cast **erases the static type**, so codegen lowers `.json()` to a *generic* dynamic dispatch (`Call { callee: PropertyGet }`) instead of a `NativeMethodCall { module: "fastify" }` — confirmed via `--print-hir`. At runtime that lands in perry-stdlib's `js_handle_method_dispatch` / `js_handle_property_dispatch`.

Those dispatchers probe only **perry-stdlib's own** handle registry (`with_handle::<crate::fastify::FastifyContext>`). But the well-known flip routes `fastify` → **perry-ext-fastify**, whose `FastifyContext` lives in **perry-ffi's separate registry** (the two are documented as disjoint integer spaces). The probe missed, the call fell through, and:

- `(request as any).json()` returned a bare `NaN` (`typeof "number"`, `String(j)` = `"NaN"`)
- `(request as any).body` returned `undefined`

…silently 400-ing every POST that used the Fetch-style accessor. The `if(!body)`-vs-`typeof` distinction in the report was incidental — the value was wrong in **all** cases on current `main`; the typed `request.json()` (no cast) path from #1240 was the only one that worked.

## Fix

Mirrors the established `external-net-pump` pattern:

- **perry-ext-fastify** exports `js_ext_fastify_is_context_handle` — a membership probe over its own perry-ffi registry.
- **perry-stdlib** dispatch grows `external-fastify-pump` arms (gated `not(http-server)`) for both method and property dispatch that consult the probe and forward to the linked `js_fastify_*` exports — full parity with the bundled `http-server` arms (json, body, method, url, params, headers, send, status, code, header, type / query, rawBody, text, user).

## Validation

Exact issue repro now matches the "Expected" output — all three routes return `200` with the parsed body:

```
=== no-anchor ===   {"where":"no-anchor","body":{"hello":"world"}}
=== with-anchor === {"where":"with-anchor","body":{"hello":"world"}}
=== use-body ===    {"where":"use-body","body":{"hello":"world"}}
```

- New wire-level harness `test-files/run_test_issue_1293.sh` (typed json(), `(as any).json()`, `(as any).body`) — **PASS**
- Existing `run_test_issue_1240.sh` (typed path) — **PASS** (no regression)
- New perry-ext-fastify unit test for the membership probe — **PASS**
- `cargo test -p perry-ext-fastify` (12) + `cargo test -p perry-stdlib` (74) — **PASS**
- `cargo fmt --all -- --check` — clean

> Note for merge: version bump + CHANGELOG entry intentionally omitted (folded in at merge per repo convention).