### PR TITLE
fix(process): #1312 unset process.env.X is undefined (nullish), so `??` applies

### DIFF
--- a/crates/perry-codegen/src/expr/array_methods.rs
+++ b/crates/perry-codegen/src/expr/array_methods.rs
@@ -302,10 +302,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let blk = ctx.block();
             let key_box = blk.load(DOUBLE, &key_handle_global);
             let key_handle = unbox_to_i64(blk, &key_box);
-            let result = blk.call(I64, "js_getenv", &[(I64, &key_handle)]);
-            // Returns null pointer if env var doesn't exist; nanbox as
-            // string (or null) and let downstream handle it.
-            Ok(nanbox_string_inline(blk, &result))
+            // js_getenv_value returns `undefined` (nullish) for an unset
+            // var, not a STRING_TAG'd null pointer — so `?? default`
+            // applies and typeof/JSON.stringify agree (#1312).
+            Ok(blk.call(DOUBLE, "js_getenv_value", &[(I64, &key_handle)]))
         }
         Expr::EnvGetDynamic(name_expr) => {
             let key_box = lower_expr(ctx, name_expr)?;
@@ -314,8 +314,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // `process.env[shortName]`); `js_getenv` dereferences it as
             // `*StringHeader`. #214 SSO bug class.
             let key_handle = unbox_str_handle(blk, &key_box);
-            let result = blk.call(I64, "js_getenv", &[(I64, &key_handle)]);
-            Ok(nanbox_string_inline(blk, &result))
+            // `undefined` for unset vars — see EnvGet above (#1312).
+            Ok(blk.call(DOUBLE, "js_getenv_value", &[(I64, &key_handle)]))
         }
         Expr::ProcessEnv => {
             // `process.env` (or `globalThis.process.env`) as a value.

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -435,6 +435,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_util_types_is_boolean_object", DOUBLE, &[DOUBLE]);
     module.declare_function("js_util_types_is_boxed_primitive", DOUBLE, &[DOUBLE]);
     module.declare_function("js_getenv", I64, &[I64]);
+    module.declare_function("js_getenv_value", DOUBLE, &[I64]);
     module.declare_function("js_console_table", VOID, &[DOUBLE]);
     module.declare_function("js_console_table_with_properties", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_console_trace", VOID, &[DOUBLE]);

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -65,6 +65,31 @@ pub extern "C" fn js_getenv(name_ptr: *const StringHeader) -> *mut StringHeader 
     }
 }
 
+/// Get an environment variable, returning a fully NaN-boxed JS value.
+///
+/// Unlike `js_getenv` (which returns a raw `*mut StringHeader`, 0 when
+/// unset), this returns an f64 NaN-boxed value the call site can use
+/// directly. An unset var yields `undefined` — matching Node, where
+/// `process.env.UNSET` is `undefined` — so `process.env.X ?? default`
+/// applies the default. Tagging the null pointer as a STRING_TAG value
+/// instead (the old fast-path behavior) produced a value that read as
+/// `typeof "string"` yet stringified to `null` and was non-nullish, so
+/// `??` silently swallowed the fallback (#1312).
+///
+/// A var that IS set to the empty string still returns `""` (a valid,
+/// non-null string), which is falsy but not nullish — also matching
+/// Node, so `??` won't clobber a legitimately empty value.
+#[no_mangle]
+pub extern "C" fn js_getenv_value(name_ptr: *const StringHeader) -> f64 {
+    let ptr = js_getenv(name_ptr);
+    let val = if ptr.is_null() {
+        JSValue::undefined()
+    } else {
+        JSValue::string_ptr(ptr)
+    };
+    f64::from_bits(val.bits())
+}
+
 /// Get resident set size (RSS) in bytes using platform-specific APIs
 pub(crate) fn get_rss_bytes() -> u64 {
     #[cfg(target_os = "macos")]

--- a/test-files/test_issue_1312_env_nullish.ts
+++ b/test-files/test_issue_1312_env_nullish.ts
@@ -1,0 +1,22 @@
+// #1312 — process.env.<UNSET> must be nullish (undefined), so `?? default` applies.
+const v = process.env.DEFINITELY_UNSET_VAR_XYZ;
+console.log('typeof:', typeof v); // expect: undefined
+console.log('value:', JSON.stringify(v)); // expect: undefined (JSON.stringify(undefined) prints "undefined")
+console.log('?? :', JSON.stringify(v ?? 'FALLBACK')); // expect: "FALLBACK"
+console.log('|| :', JSON.stringify(v || 'FALLBACK')); // expect: "FALLBACK"
+
+// A SET var should be returned verbatim (and ?? must NOT clobber it).
+const set = process.env.PERRY_1312_SET ?? 'FALLBACK';
+console.log('set ??:', set); // expect: hello (when PERRY_1312_SET=hello)
+
+// A var SET to empty string is falsy but NOT nullish: ?? keeps "", || swaps.
+const empty = process.env.PERRY_1312_EMPTY;
+console.log('empty typeof:', typeof empty); // expect: string
+console.log('empty ?? :', JSON.stringify(empty ?? 'FALLBACK')); // expect: "" (kept)
+console.log('empty || :', JSON.stringify(empty || 'FALLBACK')); // expect: "FALLBACK"
+
+// Dynamic access path (EnvGetDynamic) should behave identically.
+const key = 'DEFINITELY_UNSET_VAR_XYZ';
+const dyn = process.env[key];
+console.log('dyn typeof:', typeof dyn); // expect: undefined
+console.log('dyn ?? :', JSON.stringify(dyn ?? 'FALLBACK')); // expect: "FALLBACK"


### PR DESCRIPTION
## Summary

Fixes #1312. Reading an unset env var via `process.env.X` (or `process.env[key]`) returned a value that was **falsy but not nullish**, so the idiomatic `process.env.X ?? default` silently kept the bogus value instead of applying the fallback.

### Root cause

The `process.env.X` / `process.env[key]` fast paths (`EnvGet` / `EnvGetDynamic` in codegen) called `js_getenv`, which returns a null `*StringHeader` when the var is unset, then unconditionally tagged the result with `STRING_TAG`. A null pointer OR'd with `STRING_TAG` is a malformed value:

| Operation | Result | Correct? |
|-----------|--------|----------|
| `typeof` | `"string"` | ✗ (Node: `"undefined"`) |
| `JSON.stringify` | `null` | ✗ (Node: `undefined`) |
| `?? default` | non-nullish → no fallback | ✗ |
| `\|\| default` | falsy → fallback | ✓ (the documented workaround) |

### Fix

Add `js_getenv_value(name) -> f64` in `perry-runtime/src/process.rs` that returns NaN-boxed `undefined` for an unset var — matching Node, where `process.env.UNSET` is `undefined` — and the string otherwise. A var set to the empty string still returns `""` (falsy but not nullish), so `??` won't clobber a legitimately empty value. Both the static (`EnvGet`) and dynamic (`EnvGetDynamic`) codegen paths now call it. `js_getenv` is left intact.

### Validation

- New regression test `test-files/test_issue_1312_env_nullish.ts` covers unset / set / empty-string / dynamic-access cases. Perry output is **byte-for-byte identical** to `node --experimental-strip-types`.
- `test_process_env.ts` parity still matches.
- `cargo test -p perry-runtime -p perry-codegen`: 456 passed, 0 failed.
- `cargo fmt --all -- --check`: clean.

Per repo convention this PR omits the version bump / CHANGELOG entry — the maintainer folds those in at merge.