### PR TITLE
Expand Node parity test coverage

### DIFF
--- a/test-parity/node-suite/assert/deep/circular-objects.ts
+++ b/test-parity/node-suite/assert/deep/circular-objects.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert";
+
+const a: any = { name: "a" };
+a.self = a;
+const b: any = { name: "a" };
+b.self = b;
+const c: any = { name: "a" };
+c.self = { name: "a" };
+try { assert.deepStrictEqual(a, b); console.log("circular equal"); } catch (err: any) { console.log("circular equal err:", err?.operator); }
+try { assert.deepStrictEqual(a, c); console.log("circular mismatch no throw"); } catch (err: any) { console.log("circular mismatch:", err?.operator); }

--- a/test-parity/node-suite/assert/deep/error-causes.ts
+++ b/test-parity/node-suite/assert/deep/error-causes.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert";
+
+const a: any = new Error("outer", { cause: new TypeError("inner") });
+const b: any = new Error("outer", { cause: new TypeError("inner") });
+const c: any = new Error("outer", { cause: new RangeError("inner") });
+
+try { assert.deepStrictEqual(a, b); console.log("cause equal"); } catch (err: any) { console.log("cause equal err:", err?.operator); }
+try { assert.deepStrictEqual(a, c); console.log("cause mismatch no throw"); } catch (err: any) { console.log("cause mismatch:", err?.operator); }
+
+const agg1: any = new AggregateError([new Error("a"), "b"], "agg");
+const agg2: any = new AggregateError([new Error("a"), "b"], "agg");
+try { assert.deepStrictEqual(agg1, agg2); console.log("aggregate equal"); } catch (err: any) { console.log("aggregate err:", err?.operator); }

--- a/test-parity/node-suite/assert/deep/map-set-deep.ts
+++ b/test-parity/node-suite/assert/deep/map-set-deep.ts
@@ -1,0 +1,8 @@
+import assert from "node:assert";
+
+function show(label: string, fn: () => void): void {
+  try { fn(); console.log(label + ": pass"); } catch (err: any) { console.log(label + ":", err?.name, err?.operator || err?.code || "no-code"); }
+}
+show("map equal", () => assert.deepStrictEqual(new Map([[{ a: 1 }, new Set([1, 2])]]), new Map([[{ a: 1 }, new Set([1, 2])]])));
+show("set equal unordered", () => assert.deepStrictEqual(new Set([2, 1]), new Set([1, 2])));
+show("map mismatch", () => assert.deepStrictEqual(new Map([["a", 1]]), new Map([["a", 2]])));

--- a/test-parity/node-suite/assert/deep/partial-deep-strict-equal.ts
+++ b/test-parity/node-suite/assert/deep/partial-deep-strict-equal.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert";
+
+function show(label: string, fn: () => void): void {
+  try { fn(); console.log(label + ": pass"); } catch (err: any) { console.log(label + ":", err?.name, err?.operator || err?.code || "no-code"); }
+}
+show("object subset", () => assert.partialDeepStrictEqual({ a: 1, b: 2 }, { a: 1 }));
+show("nested subset", () => assert.partialDeepStrictEqual({ a: { b: 2, c: 3 } }, { a: { b: 2 } }));
+show("array subset", () => assert.partialDeepStrictEqual([1, 2, 3], [1, 2]));
+show("mismatch", () => assert.partialDeepStrictEqual({ a: 1 }, { a: 2 }));

--- a/test-parity/node-suite/assert/deep/promise-and-weak-collections.ts
+++ b/test-parity/node-suite/assert/deep/promise-and-weak-collections.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert";
+
+function show(label: string, fn: () => void): void {
+  try { fn(); console.log(label + ": pass"); } catch (err: any) { console.log(label + ":", err?.name, err?.operator || err?.code || "no-code"); }
+}
+show("same promise", () => { const p = Promise.resolve(1); assert.deepStrictEqual(p, p); });
+show("different promise", () => assert.deepStrictEqual(Promise.resolve(1), Promise.resolve(1)));
+show("weakmap identity", () => { const w = new WeakMap(); assert.deepStrictEqual(w, w); });
+show("weakmap different", () => assert.deepStrictEqual(new WeakMap(), new WeakMap()));

--- a/test-parity/node-suite/assert/deep/sparse-arrays.ts
+++ b/test-parity/node-suite/assert/deep/sparse-arrays.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert";
+
+function show(label: string, fn: () => void): void {
+  try { fn(); console.log(label + ": pass"); } catch (err: any) { console.log(label + ":", err?.name, err?.operator || err?.code || "no-code"); }
+}
+const sparse = Array(3); sparse[1] = "x";
+const explicit = [undefined, "x", undefined];
+const sparse2 = Array(3); sparse2[1] = "x";
+show("sparse equal", () => assert.deepStrictEqual(sparse, sparse2));
+show("sparse vs explicit", () => assert.deepStrictEqual(sparse, explicit));
+show("notDeep sparse", () => assert.notDeepStrictEqual(sparse, explicit));

--- a/test-parity/node-suite/assert/deep/symbol-properties.ts
+++ b/test-parity/node-suite/assert/deep/symbol-properties.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert";
+
+const sym = Symbol("k");
+const a: any = { x: 1 };
+a[sym] = 2;
+const b: any = { x: 1 };
+b[sym] = 2;
+const c: any = { x: 1 };
+c[sym] = 3;
+try { assert.deepStrictEqual(a, b); console.log("symbol props equal"); } catch (err: any) { console.log("symbol props equal err:", err?.operator); }
+try { assert.deepStrictEqual(a, c); console.log("symbol props mismatch no throw"); } catch (err: any) { console.log("symbol props mismatch:", err?.operator); }

--- a/test-parity/node-suite/assert/deep/typed-arrays-offsets.ts
+++ b/test-parity/node-suite/assert/deep/typed-arrays-offsets.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert";
+
+const ab1 = new ArrayBuffer(8);
+const ab2 = new ArrayBuffer(8);
+new Uint8Array(ab1).set([0, 1, 2, 3, 4, 5, 6, 7]);
+new Uint8Array(ab2).set([9, 1, 2, 3, 4, 5, 6, 9]);
+const a = new Uint8Array(ab1, 1, 6);
+const b = new Uint8Array(ab2, 1, 6);
+const c = new Int8Array(ab2, 1, 6);
+try { assert.deepStrictEqual(a, b); console.log("same bytes offset equal"); } catch (err: any) { console.log("offset equal err:", err?.operator); }
+try { assert.deepStrictEqual(a, c); console.log("different ctor no throw"); } catch (err: any) { console.log("different ctor:", err?.operator); }

--- a/test-parity/node-suite/assert/errors/match-object-regexp.ts
+++ b/test-parity/node-suite/assert/errors/match-object-regexp.ts
@@ -1,0 +1,6 @@
+import assert from "node:assert";
+
+try { assert.match("hello world", /world/); console.log("match pass"); } catch (err: any) { console.log("match pass err:", err?.operator); }
+try { assert.doesNotMatch("hello", /world/); console.log("doesNotMatch pass"); } catch (err: any) { console.log("doesNotMatch pass err:", err?.operator); }
+try { assert.match("hello", /world/); console.log("match fail no throw"); } catch (err: any) { console.log("match fail:", err?.name, err?.operator); }
+try { assert.match(123 as any, /x/); console.log("non-string no throw"); } catch (err: any) { console.log("non-string:", err?.name, err?.code || err?.operator); }

--- a/test-parity/node-suite/assert/errors/rejects-matcher-edge.ts
+++ b/test-parity/node-suite/assert/errors/rejects-matcher-edge.ts
@@ -1,0 +1,7 @@
+import assert from "node:assert";
+
+await assert.rejects(async () => { throw "plain"; }, /plain/);
+console.log("rejects string regexp");
+await assert.rejects(async () => { const e: any = new Error("boom"); e.errno = 5; throw e; }, { errno: 5 });
+console.log("rejects errno object");
+try { await assert.doesNotReject(async () => { throw new Error("nope"); }); } catch (err: any) { console.log("doesNotReject throw:", err?.name, err?.code || err?.operator); }

--- a/test-parity/node-suite/assert/errors/rejects.ts
+++ b/test-parity/node-suite/assert/errors/rejects.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert";
+
+async function main(): Promise<void> {
+  await assert.rejects(async () => { throw new TypeError("async bad"); }, TypeError);
+  console.log("rejects ctor: pass");
+  await assert.rejects(Promise.reject(Object.assign(new Error("coded"), { code: "E_CODE" })), { code: "E_CODE" });
+  console.log("rejects object: pass");
+  await assert.doesNotReject(Promise.resolve("ok"));
+  console.log("doesNotReject: pass");
+  try { await assert.rejects(Promise.resolve("nope")); } catch (err: any) { console.log("rejects resolve:", err?.name, err?.code || err?.operator); }
+}
+await main();

--- a/test-parity/node-suite/assert/errors/strict-throws-validation.ts
+++ b/test-parity/node-suite/assert/errors/strict-throws-validation.ts
@@ -4,5 +4,6 @@ function show(label: string, fn: () => void): void {
   try { fn(); console.log(label + ": pass"); } catch (err: any) { console.log(label + ":", err?.name, err?.code || err?.operator || "no-code"); }
 }
 show("strict throws regexp", () => assert.throws(() => { throw new Error("abc"); }, /abc/));
-show("strict rejects regexp", () => { throw new Error("sync marker"); });
+show("strict throws object validator", () => assert.throws(() => { const e: any = new Error("boom"); e.code = "E_X"; throw e; }, { name: "Error", code: "E_X" }));
+show("strict throws non-matching", () => assert.throws(() => { throw new Error("nope"); }, /will-not-match/));
 try { await assert.rejects(async () => { throw new Error("async abc"); }, /async/); console.log("strict rejects: pass"); } catch (err: any) { console.log("strict rejects:", err?.name, err?.code || err?.operator); }

--- a/test-parity/node-suite/assert/errors/strict-throws-validation.ts
+++ b/test-parity/node-suite/assert/errors/strict-throws-validation.ts
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict";
+
+function show(label: string, fn: () => void): void {
+  try { fn(); console.log(label + ": pass"); } catch (err: any) { console.log(label + ":", err?.name, err?.code || err?.operator || "no-code"); }
+}
+show("strict throws regexp", () => assert.throws(() => { throw new Error("abc"); }, /abc/));
+show("strict rejects regexp", () => { throw new Error("sync marker"); });
+try { await assert.rejects(async () => { throw new Error("async abc"); }, /async/); console.log("strict rejects: pass"); } catch (err: any) { console.log("strict rejects:", err?.name, err?.code || err?.operator); }

--- a/test-parity/node-suite/assert/errors/throws-matcher.ts
+++ b/test-parity/node-suite/assert/errors/throws-matcher.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert";
+
+function check(label: string, fn: () => void): void {
+  try { fn(); console.log(label + ": pass"); }
+  catch (err: any) { console.log(label + ":", err?.name, err?.code || err?.operator || "no-code"); }
+}
+
+check("throws regexp", () => assert.throws(() => { throw new TypeError("bad value"); }, /bad/));
+check("throws ctor", () => assert.throws(() => { throw new RangeError("range"); }, RangeError));
+check("throws object", () => assert.throws(() => { const e: any = new Error("boom"); e.code = "E_X"; throw e; }, { name: "Error", message: "boom", code: "E_X" }));
+check("does-not-throw", () => assert.doesNotThrow(() => 42));
+check("missing throw", () => assert.throws(() => 1, /unused/));

--- a/test-parity/node-suite/assert/errors/throws-primitive.ts
+++ b/test-parity/node-suite/assert/errors/throws-primitive.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert";
+
+function show(label: string, fn: () => void): void {
+  try { fn(); console.log(label + ": pass"); } catch (err: any) { console.log(label + ":", err?.name, err?.code || err?.operator || "no-code"); }
+}
+show("throw string exact", () => assert.throws(() => { throw "boom"; }, /^boom$/));
+show("throw number any", () => assert.throws(() => { throw 7; }));
+show("doesNotThrow primitive", () => assert.doesNotThrow(() => "ok"));
+show("doesNotThrow catches", () => assert.doesNotThrow(() => { throw "bad"; }));

--- a/test-parity/node-suite/assert/generated-message/throws-generated.ts
+++ b/test-parity/node-suite/assert/generated-message/throws-generated.ts
@@ -1,0 +1,4 @@
+import assert from "node:assert";
+
+try { assert.throws(() => 1); } catch (err: any) { console.log("missing throw:", err.generatedMessage, err.operator, typeof err.message); }
+try { assert.doesNotThrow(() => { throw new TypeError("bad"); }); } catch (err: any) { console.log("unexpected throw:", err.generatedMessage, err.operator, err.actual?.name); }

--- a/test-parity/node-suite/buffer/allocation/alloc-fill-typedarray.ts
+++ b/test-parity/node-suite/buffer/allocation/alloc-fill-typedarray.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const fill = new Uint8Array([65, 66]);
+console.log("typed fill:", Buffer.alloc(5, fill).toString());
+console.log("zero len fill:", Buffer.alloc(0, fill).length);
+try { console.log("negative size:", Buffer.alloc(-1 as any).length); } catch (err: any) { console.log("negative size:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/buffer/byte-length/edge-encodings.ts
+++ b/test-parity/node-suite/buffer/byte-length/edge-encodings.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+for (const enc of ["utf8", "utf16le", "latin1", "base64", "base64url", "hex"] as BufferEncoding[]) {
+  try { console.log(enc + ":", Buffer.byteLength("hé==", enc)); } catch (err: any) { console.log(enc + ":", err?.name); }
+}
+console.log("lone high surrogate:", Buffer.byteLength("\ud800", "utf8"));
+console.log("invalid encoding accepted:", Buffer.byteLength("abc", "madeup" as any));

--- a/test-parity/node-suite/buffer/compare/bounds-errors.ts
+++ b/test-parity/node-suite/buffer/compare/bounds-errors.ts
@@ -1,0 +1,12 @@
+import { Buffer } from "node:buffer";
+
+const a = Buffer.from("abcdef");
+const b = Buffer.from("abcxyz");
+function show(label: string, fn: () => unknown): void {
+  try { console.log(label + ":", fn()); } catch (err: any) { console.log(label + ":", err?.name, err?.code || "no-code"); }
+}
+show("range equal", () => a.compare(b, 0, 3, 0, 3));
+show("range diff", () => a.compare(b, 3, 6, 3, 6));
+show("targetStart negative", () => a.compare(b, -1));
+show("sourceEnd large", () => a.compare(b, 0, 3, 0, 99));
+show("uint8 target", () => a.compare(new Uint8Array([97, 98, 99]) as any));

--- a/test-parity/node-suite/buffer/concat/edge-lengths.ts
+++ b/test-parity/node-suite/buffer/concat/edge-lengths.ts
@@ -1,0 +1,9 @@
+import { Buffer } from "node:buffer";
+
+const a = Buffer.from("ab");
+const b = Buffer.from("cd");
+console.log("empty:", Buffer.concat([]).length);
+console.log("short:", Buffer.concat([a, b], 3).toString());
+console.log("long hex:", Buffer.concat([a, b], 6).toString("hex"));
+console.log("uint8:", Buffer.concat([a, new Uint8Array([101, 102]) as any]).toString());
+try { Buffer.concat(["x" as any]); console.log("bad no throw"); } catch (err: any) { console.log("bad:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/buffer/copy-slice/copy-overlap.ts
+++ b/test-parity/node-suite/buffer/copy-slice/copy-overlap.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("abcdef");
+console.log("copy ret:", b.copy(b, 2, 0, 4));
+console.log("overlap:", b.toString());
+const c = Buffer.from("abcdef");
+console.log("copy empty:", c.copy(c, 0, 2, 2), c.toString());

--- a/test-parity/node-suite/buffer/encoding/base64-edge-extra.ts
+++ b/test-parity/node-suite/buffer/encoding/base64-edge-extra.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+for (const input of ["aGk", "aGk=", "a G\nk=", "!!!!", "-_8"]) {
+  try { console.log("base64:", JSON.stringify(input), Buffer.from(input, "base64").toString("hex")); } catch (err: any) { console.log("base64 err:", err?.name, err?.code || "no-code"); }
+  try { console.log("base64url:", JSON.stringify(input), Buffer.from(input, "base64url").toString("hex")); } catch (err: any) { console.log("base64url err:", err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/buffer/encoding/latin1-ascii-roundtrip-extra.ts
+++ b/test-parity/node-suite/buffer/encoding/latin1-ascii-roundtrip-extra.ts
@@ -1,0 +1,6 @@
+import { Buffer } from "node:buffer";
+
+const bytes = Buffer.from([0x41, 0x80, 0xff]);
+console.log("latin1:", bytes.toString("latin1").split("").map(c => c.charCodeAt(0)).join(","));
+console.log("ascii:", bytes.toString("ascii").split("").map(c => c.charCodeAt(0)).join(","));
+console.log("latin1 from:", Buffer.from("A\u0080\u00ff", "latin1").toString("hex"));

--- a/test-parity/node-suite/buffer/fill-write/fill-coercions-extra.ts
+++ b/test-parity/node-suite/buffer/fill-write/fill-coercions-extra.ts
@@ -1,0 +1,10 @@
+import { Buffer } from "node:buffer";
+
+function show(label: string, fn: () => unknown): void {
+  const b = Buffer.alloc(5, ".");
+  try { console.log(label + ":", fn.call(null, b), b.toString("hex")); } catch (err: any) { console.log(label + ":", err?.name, err?.code || "no-code"); }
+}
+show("fill number", (b: Buffer) => b.fill(257));
+show("fill bool", (b: Buffer) => b.fill(true as any));
+show("fill empty string", (b: Buffer) => b.fill(""));
+show("fill uint8", (b: Buffer) => b.fill(new Uint8Array([65, 66]) as any));

--- a/test-parity/node-suite/buffer/fill-write/write-coercions.ts
+++ b/test-parity/node-suite/buffer/fill-write/write-coercions.ts
@@ -1,0 +1,10 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(6, ".");
+function show(label: string, fn: () => unknown): void {
+  try { console.log(label + ":", fn(), b.toString()); } catch (err: any) { console.log(label + ":", err?.name, err?.code || "no-code"); }
+}
+show("write bool", () => b.write("abc", true as any));
+show("write null len", () => b.write("XYZ", 2, null as any));
+show("write bad enc", () => b.write("x", 0, 1, "bad" as any));
+show("fill bad range", () => b.fill("z", 5, 2));

--- a/test-parity/node-suite/buffer/from/arraylike-coercions.ts
+++ b/test-parity/node-suite/buffer/from/arraylike-coercions.ts
@@ -1,0 +1,5 @@
+import { Buffer } from "node:buffer";
+
+for (const value of [{ length: "3", 0: 65, 1: 66, 2: 67 }, { length: -1, 0: 65 }, { length: 2.8, 0: 65, 1: 66, 2: 67 }]) {
+  try { console.log("arraylike:", Buffer.from(value as any).toJSON().data.join(",")); } catch (err: any) { console.log("arraylike err:", err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/buffer/from/primitive-errors.ts
+++ b/test-parity/node-suite/buffer/from/primitive-errors.ts
@@ -1,0 +1,5 @@
+import { Buffer } from "node:buffer";
+
+for (const value of [null, undefined, 123, true, Symbol("s"), 10n] as any[]) {
+  try { console.log("from", String(value) + ":", Buffer.from(value).length); } catch (err: any) { console.log("from", String(value) + ":", err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/buffer/from/shared-array-buffer.ts
+++ b/test-parity/node-suite/buffer/from/shared-array-buffer.ts
@@ -1,0 +1,9 @@
+import { Buffer } from "node:buffer";
+
+const sab = new SharedArrayBuffer(4);
+const u8 = new Uint8Array(sab);
+u8.set([1, 2, 3, 4]);
+const b = Buffer.from(sab as any);
+console.log("initial:", b.toJSON().data.join(","));
+u8[1] = 9;
+console.log("shared:", b.toJSON().data.join(","));

--- a/test-parity/node-suite/buffer/from/valueof-symbol-to-primitive.ts
+++ b/test-parity/node-suite/buffer/from/valueof-symbol-to-primitive.ts
@@ -1,0 +1,10 @@
+import { Buffer } from "node:buffer";
+
+const valueOfObj = { valueOf() { return "6869"; } };
+try { console.log("valueOf hex:", Buffer.from(valueOfObj as any, "hex").toString()); } catch (err: any) { console.log("valueOf err:", err?.name, err?.code || "no-code"); }
+
+const primitiveObj = { [Symbol.toPrimitive]() { return "ok"; } };
+try { console.log("toPrimitive:", Buffer.from(primitiveObj as any).toString()); } catch (err: any) { console.log("toPrimitive err:", err?.name, err?.code || "no-code"); }
+
+const arrayLike: any = { 0: 65, 2: 67, length: 4 };
+console.log("arrayLike sparse:", Buffer.from(arrayLike).toJSON().data.join(","));

--- a/test-parity/node-suite/buffer/json-inspect/inspect-limits.ts
+++ b/test-parity/node-suite/buffer/json-inspect/inspect-limits.ts
@@ -1,0 +1,5 @@
+import { Buffer, INSPECT_MAX_BYTES } from "node:buffer";
+
+console.log("inspect max type:", typeof INSPECT_MAX_BYTES, INSPECT_MAX_BYTES > 0);
+console.log("small inspect:", Buffer.from([1, 2, 3]).inspect());
+console.log("toString tag:", Object.prototype.toString.call(Buffer.from([])));

--- a/test-parity/node-suite/buffer/properties/is-utf8-ascii-invalid.ts
+++ b/test-parity/node-suite/buffer/properties/is-utf8-ascii-invalid.ts
@@ -1,0 +1,10 @@
+import { Buffer, isAscii, isUtf8 } from "node:buffer";
+
+const valid = Buffer.from("hello");
+const utf8 = Buffer.from("hé");
+const invalid = Buffer.from([0xc3, 0x28]);
+const empty = Buffer.alloc(0);
+console.log("ascii valid:", isAscii(valid), isUtf8(valid));
+console.log("utf8 non-ascii:", isAscii(utf8), isUtf8(utf8));
+console.log("invalid:", isAscii(invalid), isUtf8(invalid));
+console.log("empty:", isAscii(empty), isUtf8(empty));

--- a/test-parity/node-suite/buffer/properties/subclass-species.ts
+++ b/test-parity/node-suite/buffer/properties/subclass-species.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+class MyBuffer extends Buffer {}
+const b: any = MyBuffer.from("abc");
+console.log("instance my:", b instanceof MyBuffer);
+console.log("instance buffer:", b instanceof Buffer);
+console.log("slice ctor:", b.slice(0, 1).constructor.name);

--- a/test-parity/node-suite/buffer/read-write-float/special-values.ts
+++ b/test-parity/node-suite/buffer/read-write-float/special-values.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+for (const value of [NaN, Infinity, -Infinity, -0, 1.5]) {
+  const b = Buffer.alloc(8);
+  b.writeDoubleLE(value, 0);
+  const read = b.readDoubleLE(0);
+  console.log("double:", String(value), Number.isNaN(read) ? "NaN" : Object.is(read, -0) ? "-0" : String(read));
+}

--- a/test-parity/node-suite/buffer/read-write-int/range-errors-extra.ts
+++ b/test-parity/node-suite/buffer/read-write-int/range-errors-extra.ts
@@ -1,0 +1,10 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.alloc(4);
+function show(label: string, fn: () => unknown): void {
+  try { console.log(label + ":", fn()); } catch (err: any) { console.log(label + ":", err?.name, err?.code || "no-code"); }
+}
+show("writeUInt8 256", () => b.writeUInt8(256, 0));
+show("writeInt8 -129", () => b.writeInt8(-129, 0));
+show("readUInt32BE oob", () => b.readUInt32BE(1));
+show("readInt16LE neg offset", () => b.readInt16LE(-1 as any));

--- a/test-parity/node-suite/buffer/search/ucs2-and-buffer-needle.ts
+++ b/test-parity/node-suite/buffer/search/ucs2-and-buffer-needle.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+const b = Buffer.from("a😀b😀c");
+console.log("index string:", b.indexOf("😀"));
+console.log("last string:", b.lastIndexOf("😀"));
+console.log("includes buffer:", b.includes(Buffer.from("b")));
+console.log("ucs2:", Buffer.from("ab", "utf16le").indexOf("b", 0, "utf16le"));
+console.log("nan offset:", b.indexOf("a", NaN as any));

--- a/test-parity/node-suite/buffer/swap/mutation-and-return.ts
+++ b/test-parity/node-suite/buffer/swap/mutation-and-return.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "node:buffer";
+
+const b16 = Buffer.from([0, 1, 2, 3]);
+console.log("swap16 same:", b16.swap16() === b16, b16.toString("hex"));
+const b32 = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7]);
+console.log("swap32 same:", b32.swap32() === b32, b32.toString("hex"));
+const b64 = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7]);
+console.log("swap64 same:", b64.swap64() === b64, b64.toString("hex"));

--- a/test-parity/node-suite/console/console-class/group-and-count-instance.ts
+++ b/test-parity/node-suite/console/console-class/group-and-count-instance.ts
@@ -1,0 +1,14 @@
+import { Console } from "node:console";
+import { Writable } from "node:stream";
+
+let out = "";
+const sink = new Writable({ write(chunk, _enc, cb) { out += chunk.toString(); cb(); } });
+const c = new Console({ stdout: sink, stderr: sink });
+c.count("x");
+c.group("g");
+c.log("inside");
+c.groupEnd();
+c.countReset("x");
+c.count("x");
+await new Promise(resolve => setImmediate(resolve));
+console.log("captured:", JSON.stringify(out.trim().split(/\n/)));

--- a/test-parity/node-suite/console/console-class/stream-errors.ts
+++ b/test-parity/node-suite/console/console-class/stream-errors.ts
@@ -1,0 +1,17 @@
+import { Console } from "node:console";
+import { Writable } from "node:stream";
+
+class Boom extends Writable {
+  _write(_chunk: any, _enc: string, cb: Function) { cb(new Error("boom")); }
+}
+const stdout = new Boom();
+const stderr = new Boom();
+stdout.on("error", (err: any) => console.log("stdout error:", err.message));
+stderr.on("error", (err: any) => console.log("stderr error:", err.message));
+const c1 = new Console({ stdout, stderr, ignoreErrors: true });
+console.log("ignore start");
+c1.log("hidden");
+c1.error("hidden err");
+await new Promise(resolve => setImmediate(resolve));
+console.log("ignore end");
+try { new Console({ stdout: undefined as any, stderr }); console.log("invalid stream no throw"); } catch (err: any) { console.log("invalid stream:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/console/count/object-labels.ts
+++ b/test-parity/node-suite/console/count/object-labels.ts
@@ -1,0 +1,6 @@
+const obj = { toString() { return "obj-label"; } };
+console.count(obj as any);
+console.count(obj as any);
+console.countReset(obj as any);
+console.count(obj as any);
+try { console.count(Symbol("s") as any); } catch (err: any) { console.log("symbol count:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/console/dir/sorted-and-getters.ts
+++ b/test-parity/node-suite/console/dir/sorted-and-getters.ts
@@ -1,0 +1,4 @@
+const obj: any = { b: 2, a: 1 };
+Object.defineProperty(obj, "g", { get() { return 3; }, enumerable: true });
+console.dir(obj, { sorted: true });
+console.dir(obj, { getters: true });

--- a/test-parity/node-suite/console/group/nested-empty-labels.ts
+++ b/test-parity/node-suite/console/group/nested-empty-labels.ts
@@ -1,0 +1,8 @@
+console.group();
+console.log("inside1");
+console.group("");
+console.log("inside2");
+console.groupEnd();
+console.groupEnd();
+console.groupEnd();
+console.log("after");

--- a/test-parity/node-suite/console/output/class-and-private-fields.ts
+++ b/test-parity/node-suite/console/output/class-and-private-fields.ts
@@ -1,0 +1,7 @@
+class Foo {
+  #secret = 1;
+  publicValue = 2;
+  method() { return this.#secret; }
+}
+console.log("class instance:", new Foo());
+console.dir(new Foo(), { showHidden: true });

--- a/test-parity/node-suite/console/output/error-cause.ts
+++ b/test-parity/node-suite/console/output/error-cause.ts
@@ -1,0 +1,4 @@
+const err: any = new Error("outer", { cause: new TypeError("inner") });
+err.code = "E_OUTER";
+console.log("error cause:", err);
+console.error("error stderr:", err.name, err.message, err.code);

--- a/test-parity/node-suite/console/output/format-circular-and-bigint.ts
+++ b/test-parity/node-suite/console/output/format-circular-and-bigint.ts
@@ -1,0 +1,6 @@
+const circular: any = { name: "root" };
+circular.self = circular;
+console.log("json circular:%j", circular);
+console.log("number bigint:%d", 12n);
+console.log("integer bigint:%i", 12n);
+console.log("float bigint:%f", 12n);

--- a/test-parity/node-suite/console/output/format-edge-values.ts
+++ b/test-parity/node-suite/console/output/format-edge-values.ts
@@ -1,0 +1,4 @@
+console.log("nan:%d inf:%d negzero:%d", NaN, Infinity, -0);
+console.log("bigint as object:%o", 10n);
+console.log("symbol as string:%s", Symbol.for("x"));
+console.log("undefined extra", undefined, null);

--- a/test-parity/node-suite/console/output/proxy-getters.ts
+++ b/test-parity/node-suite/console/output/proxy-getters.ts
@@ -1,0 +1,5 @@
+const obj: any = {};
+Object.defineProperty(obj, "secret", { get() { return 42; }, enumerable: true });
+console.log("getter object:", obj);
+const prox = new Proxy({ a: 1 }, { get(target, prop, receiver) { return Reflect.get(target, prop, receiver); } });
+console.log("proxy:", prox);

--- a/test-parity/node-suite/console/table/column-order-extra.ts
+++ b/test-parity/node-suite/console/table/column-order-extra.ts
@@ -1,0 +1,2 @@
+console.table([{ b: 2, a: 1 }, { c: 3, a: 4 }]);
+console.table([{ b: 2, a: 1 }, { c: 3, a: 4 }], ["a", "b", "c"]);

--- a/test-parity/node-suite/console/table/nested-and-nullish.ts
+++ b/test-parity/node-suite/console/table/nested-and-nullish.ts
@@ -1,0 +1,2 @@
+console.table([{ a: null, b: undefined, c: { d: 1 } }, { a: 2, b: 3, c: [1, 2] }]);
+console.table({ left: null, right: undefined, nested: { x: 1 } });

--- a/test-parity/node-suite/console/table/symbol-and-missing-columns.ts
+++ b/test-parity/node-suite/console/table/symbol-and-missing-columns.ts
@@ -1,0 +1,5 @@
+const sym = Symbol("s");
+const row: any = { a: 1, b: 2 };
+row[sym] = 3;
+console.table([row], ["a", "missing"]);
+console.table(new Map([["x", { a: 1 }], ["y", { a: 2, b: 3 }]]));

--- a/test-parity/node-suite/console/time/object-labels-extra.ts
+++ b/test-parity/node-suite/console/time/object-labels-extra.ts
@@ -1,0 +1,5 @@
+const label = { toString() { return "timer-object"; } };
+console.time(label as any);
+console.timeLog(label as any, "mid");
+console.timeEnd(label as any);
+try { console.time(Symbol("t") as any); } catch (err: any) { console.log("symbol time:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/diagnostics_channel/channel/channel-name-types.ts
+++ b/test-parity/node-suite/diagnostics_channel/channel/channel-name-types.ts
@@ -1,0 +1,6 @@
+import { channel } from "node:diagnostics_channel";
+
+for (const name of ["", "0", Symbol.for("dc-name")] as any[]) {
+  try { const ch = channel(name); console.log("name:", String(name), String(ch.name), ch === channel(name)); } catch (err: any) { console.log("name err:", String(name), err?.name, err?.code || "no-code"); }
+}
+try { channel({} as any); console.log("object name no throw"); } catch (err: any) { console.log("object name:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/diagnostics_channel/channel/publish-return-values.ts
+++ b/test-parity/node-suite/diagnostics_channel/channel/publish-return-values.ts
@@ -1,0 +1,9 @@
+import { channel } from "node:diagnostics_channel";
+
+const ch = channel("dc-publish-return-values");
+console.log("publish no subs:", ch.publish({ a: 1 }));
+function sub(msg: any) { console.log("sub msg:", msg.a); }
+ch.subscribe(sub);
+console.log("publish one sub:", ch.publish({ a: 2 }));
+ch.unsubscribe(sub);
+console.log("publish after unsub:", ch.publish({ a: 3 }));

--- a/test-parity/node-suite/diagnostics_channel/channel/reentrant-publish.ts
+++ b/test-parity/node-suite/diagnostics_channel/channel/reentrant-publish.ts
@@ -1,0 +1,8 @@
+import { channel } from "node:diagnostics_channel";
+
+const ch = channel("dc-reentrant-publish-extra");
+const events: string[] = [];
+let depth = 0;
+ch.subscribe(() => { events.push("sub" + depth); if (depth++ === 0) ch.publish({ nested: true }); depth--; });
+ch.publish({});
+console.log("events:", events.join(","));

--- a/test-parity/node-suite/diagnostics_channel/channel/subscribe-validation-extra.ts
+++ b/test-parity/node-suite/diagnostics_channel/channel/subscribe-validation-extra.ts
@@ -1,0 +1,10 @@
+import { channel, hasSubscribers } from "node:diagnostics_channel";
+
+function show(label: string, fn: () => unknown): void {
+  try { console.log(label + ":", fn()); } catch (err: any) { console.log(label + ":", err?.name, err?.code || "no-code"); }
+}
+show("has numeric", () => hasSubscribers(123 as any));
+show("channel symbol", () => channel(Symbol.for("dc-symbol-extra") as any).name.toString());
+const ch = channel("dc-validation-extra");
+show("subscribe null", () => ch.subscribe(null as any));
+show("unsubscribe null", () => ch.unsubscribe(null as any));

--- a/test-parity/node-suite/diagnostics_channel/channel/subscriber-throws-order.ts
+++ b/test-parity/node-suite/diagnostics_channel/channel/subscriber-throws-order.ts
@@ -1,0 +1,10 @@
+import { channel } from "node:diagnostics_channel";
+
+const ch = channel("dc-subscriber-throws-order-extra");
+const events: string[] = [];
+process.once("uncaughtException", (err: any) => { events.push("uncaught:" + err.message); });
+ch.subscribe(() => { events.push("first"); throw new Error("boom"); });
+ch.subscribe(() => { events.push("second"); });
+try { ch.publish({}); console.log("publish no throw"); } catch (err: any) { console.log("caught:", err.message); }
+await new Promise(resolve => setImmediate(resolve));
+console.log("events:", events.join(","));

--- a/test-parity/node-suite/diagnostics_channel/channel/unsubscribe-during-publish.ts
+++ b/test-parity/node-suite/diagnostics_channel/channel/unsubscribe-during-publish.ts
@@ -1,0 +1,11 @@
+import { channel } from "node:diagnostics_channel";
+
+const ch = channel("dc-unsubscribe-during-publish");
+const events: string[] = [];
+function first() { events.push("first"); ch.unsubscribe(second); }
+function second() { events.push("second"); }
+ch.subscribe(first);
+ch.subscribe(second);
+ch.publish({});
+ch.publish({});
+console.log("events:", events.join(","));

--- a/test-parity/node-suite/diagnostics_channel/imports/default-and-namespace-identity.ts
+++ b/test-parity/node-suite/diagnostics_channel/imports/default-and-namespace-identity.ts
@@ -1,0 +1,5 @@
+import dcDefault, * as dc from "node:diagnostics_channel";
+
+console.log("default channel:", typeof (dcDefault as any).channel);
+console.log("same channel fn:", (dcDefault as any).channel === dc.channel);
+console.log("same object channel:", dc.channel("identity") === (dcDefault as any).channel("identity"));

--- a/test-parity/node-suite/diagnostics_channel/stores/nested-bind-store.ts
+++ b/test-parity/node-suite/diagnostics_channel/stores/nested-bind-store.ts
@@ -1,0 +1,12 @@
+import { channel } from "node:diagnostics_channel";
+
+const ch: any = channel("dc-nested-bind-store");
+if (typeof ch.bindStore !== "function") {
+  console.log("bindStore type:", typeof ch.bindStore);
+} else {
+  const store = { value: 1 };
+  ch.bindStore(store);
+  console.log("has after bind:", ch.hasSubscribers);
+  ch.unbindStore(store);
+  console.log("has after unbind:", ch.hasSubscribers);
+}

--- a/test-parity/node-suite/diagnostics_channel/tracing/trace-callback-error-first.ts
+++ b/test-parity/node-suite/diagnostics_channel/tracing/trace-callback-error-first.ts
@@ -1,0 +1,12 @@
+import { tracingChannel } from "node:diagnostics_channel";
+
+const ch = tracingChannel("dc-callback-error-first-extra");
+const events: string[] = [];
+ch.subscribe({
+  start: () => events.push("start"),
+  asyncStart: (ctx: any) => events.push("asyncStart:" + (ctx.error?.message || ctx.result)),
+  asyncEnd: (ctx: any) => events.push("asyncEnd:" + (ctx.error?.message || ctx.result)),
+  error: (ctx: any) => events.push("error:" + ctx.error.message),
+});
+ch.traceCallback((cb: Function) => cb(new Error("cbfail")), 0, {}, undefined, (err: any) => console.log("cb err:", err.message));
+console.log("events:", events.join("|"));

--- a/test-parity/node-suite/diagnostics_channel/tracing/trace-promise-resolution.ts
+++ b/test-parity/node-suite/diagnostics_channel/tracing/trace-promise-resolution.ts
@@ -1,0 +1,13 @@
+import { tracingChannel } from "node:diagnostics_channel";
+
+const ch = tracingChannel("dc-trace-promise-resolution-extra");
+const events: string[] = [];
+ch.subscribe({
+  start: () => events.push("start"),
+  asyncStart: (ctx: any) => events.push("asyncStart:" + ctx.result),
+  asyncEnd: (ctx: any) => events.push("asyncEnd:" + ctx.result),
+  end: () => events.push("end"),
+});
+const result = await ch.tracePromise(async () => "ok", {});
+console.log("result:", result);
+console.log("events:", events.join("|"));

--- a/test-parity/node-suite/diagnostics_channel/tracing/trace-sync-error-order.ts
+++ b/test-parity/node-suite/diagnostics_channel/tracing/trace-sync-error-order.ts
@@ -1,0 +1,11 @@
+import { tracingChannel } from "node:diagnostics_channel";
+
+const ch = tracingChannel("dc-trace-sync-error-order");
+const events: string[] = [];
+ch.subscribe({
+  start: () => events.push("start"),
+  error: (ctx: any) => events.push("error:" + ctx.error.message),
+  end: () => events.push("end"),
+});
+try { ch.traceSync(() => { events.push("fn"); throw new Error("boom"); }, {}); } catch (err: any) { console.log("caught:", err.message); }
+console.log("events:", events.join("|"));

--- a/test-parity/node-suite/events/emitter/capture-rejections.ts
+++ b/test-parity/node-suite/events/emitter/capture-rejections.ts
@@ -1,0 +1,9 @@
+import { EventEmitter } from "node:events";
+
+const ee = new EventEmitter({ captureRejections: true });
+const events: string[] = [];
+ee.on("x", async () => { throw new Error("async bad"); });
+ee.on("error", (err: any) => events.push("error:" + err.message));
+ee.emit("x");
+await new Promise(resolve => setImmediate(resolve));
+console.log("events:", events.join(","));

--- a/test-parity/node-suite/events/emitter/event-names-symbols.ts
+++ b/test-parity/node-suite/events/emitter/event-names-symbols.ts
@@ -1,0 +1,10 @@
+import { EventEmitter } from "node:events";
+
+const ee = new EventEmitter();
+const sym = Symbol("evt");
+ee.on("a", () => {});
+ee.on(sym, () => {});
+console.log("names:", ee.eventNames().map(String).sort().join(","));
+console.log("count sym:", ee.listenerCount(sym));
+ee.removeAllListeners("a");
+console.log("names after:", ee.eventNames().map(String).join(","));

--- a/test-parity/node-suite/events/emitter/mutation-during-emit.ts
+++ b/test-parity/node-suite/events/emitter/mutation-during-emit.ts
@@ -1,0 +1,12 @@
+import { EventEmitter } from "node:events";
+
+const ee = new EventEmitter();
+const events: string[] = [];
+function a() { events.push("a"); ee.off("x", b); ee.on("x", c); }
+function b() { events.push("b"); }
+function c() { events.push("c"); }
+ee.on("x", a);
+ee.on("x", b);
+ee.emit("x");
+ee.emit("x");
+console.log("events:", events.join(","));

--- a/test-parity/node-suite/events/emitter/once-prepend-order.ts
+++ b/test-parity/node-suite/events/emitter/once-prepend-order.ts
@@ -1,0 +1,10 @@
+import { EventEmitter } from "node:events";
+
+const ee = new EventEmitter();
+const events: string[] = [];
+ee.once("x", () => events.push("once"));
+ee.prependOnceListener("x", () => events.push("prependOnce"));
+ee.prependListener("x", () => events.push("prepend"));
+ee.emit("x");
+ee.emit("x");
+console.log("events:", events.join(","));

--- a/test-parity/node-suite/events/emitter/prepend-and-raw-listeners.ts
+++ b/test-parity/node-suite/events/emitter/prepend-and-raw-listeners.ts
@@ -1,0 +1,13 @@
+import { EventEmitter } from "node:events";
+
+const ee = new EventEmitter();
+const events: string[] = [];
+function a() { events.push("a"); }
+function b() { events.push("b"); }
+ee.on("x", a);
+ee.prependListener("x", b);
+ee.once("x", () => events.push("once"));
+console.log("listeners:", ee.listeners("x").length, ee.rawListeners("x").length);
+ee.emit("x");
+ee.emit("x");
+console.log("events:", events.join(","));

--- a/test-parity/node-suite/events/errors/error-monitor.ts
+++ b/test-parity/node-suite/events/errors/error-monitor.ts
@@ -1,0 +1,7 @@
+import { EventEmitter, errorMonitor } from "node:events";
+
+const ee = new EventEmitter();
+const seen: string[] = [];
+ee.on(errorMonitor, (err: any) => seen.push("monitor:" + err.message));
+try { ee.emit("error", new Error("boom")); } catch (err: any) { seen.push("caught:" + err.message); }
+console.log("seen:", seen.join(","));

--- a/test-parity/node-suite/events/errors/error-with-no-listener-return.ts
+++ b/test-parity/node-suite/events/errors/error-with-no-listener-return.ts
@@ -1,0 +1,6 @@
+import { EventEmitter } from "node:events";
+
+const ee = new EventEmitter();
+try { console.log("emit error ret:", ee.emit("error", new Error("boom"))); } catch (err: any) { console.log("emit error threw:", err.name, err.message); }
+ee.on("error", () => {});
+console.log("emit error handled:", ee.emit("error", new Error("ok")));

--- a/test-parity/node-suite/events/listeners/add-abort-listener.ts
+++ b/test-parity/node-suite/events/listeners/add-abort-listener.ts
@@ -1,0 +1,14 @@
+import { addAbortListener } from "node:events";
+
+const ac = new AbortController();
+let count = 0;
+const disposable: any = addAbortListener(ac.signal, () => { count++; });
+console.log("dispose type:", typeof disposable?.[Symbol.dispose]);
+ac.abort();
+ac.abort();
+console.log("count:", count);
+const ac2 = new AbortController();
+const d2: any = addAbortListener(ac2.signal, () => { count += 10; });
+d2?.[Symbol.dispose]?.();
+ac2.abort();
+console.log("count after dispose:", count);

--- a/test-parity/node-suite/events/listeners/remove-listener-event.ts
+++ b/test-parity/node-suite/events/listeners/remove-listener-event.ts
@@ -1,9 +1,10 @@
 import { EventEmitter } from "node:events";
 
-const em = new EventEmitter();
-const seen: string[] = [];
-em.on("removeListener", (name: string) => seen.push(name));
-const h = () => {};
-em.on("hello", h);
-em.removeListener("hello", h);
-console.log("seen:", seen);
+const ee = new EventEmitter();
+const events: string[] = [];
+function fn() {}
+ee.on("removeListener", (name, listener) => events.push(String(name) + ":" + (listener === fn)));
+ee.on("x", fn);
+ee.off("x", fn);
+ee.removeAllListeners("removeListener");
+console.log("events:", events.join(","));

--- a/test-parity/node-suite/events/listeners/static-event-target.ts
+++ b/test-parity/node-suite/events/listeners/static-event-target.ts
@@ -1,0 +1,11 @@
+import { getEventListeners, getMaxListeners, setMaxListeners } from "node:events";
+
+const target = new EventTarget();
+function listener() {}
+target.addEventListener("x", listener);
+console.log("listeners:", getEventListeners(target, "x").length);
+console.log("max before:", getMaxListeners(target));
+setMaxListeners(7, target);
+console.log("max after:", getMaxListeners(target));
+target.removeEventListener("x", listener);
+console.log("listeners after:", getEventListeners(target, "x").length);

--- a/test-parity/node-suite/events/max-listeners/static-multiple-targets.ts
+++ b/test-parity/node-suite/events/max-listeners/static-multiple-targets.ts
@@ -1,0 +1,8 @@
+import { EventEmitter, getMaxListeners, setMaxListeners } from "node:events";
+
+const a = new EventEmitter();
+const b = new EventEmitter();
+console.log("before:", getMaxListeners(a), getMaxListeners(b));
+setMaxListeners(3, a, b);
+console.log("after:", getMaxListeners(a), getMaxListeners(b));
+try { setMaxListeners(-1, a); console.log("negative no throw"); } catch (err: any) { console.log("negative:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/events/on/async-iterator-abort.ts
+++ b/test-parity/node-suite/events/on/async-iterator-abort.ts
@@ -1,0 +1,15 @@
+import { EventEmitter, on } from "node:events";
+
+const ee = new EventEmitter();
+const ac = new AbortController();
+const seen: string[] = [];
+try {
+  const iter = on(ee, "data", { signal: ac.signal });
+  ee.emit("data", "a");
+  ee.emit("data", "b");
+  for await (const args of iter) {
+    seen.push(args.join("/"));
+    if (seen.length === 2) ac.abort();
+  }
+} catch (err: any) { console.log("abort:", err?.name, err?.code || "no-code"); }
+console.log("seen:", seen.join(","));

--- a/test-parity/node-suite/events/on/high-watermark-options.ts
+++ b/test-parity/node-suite/events/on/high-watermark-options.ts
@@ -1,0 +1,12 @@
+import { EventEmitter, on } from "node:events";
+
+const ee = new EventEmitter();
+const iter = on(ee, "data", { highWaterMark: 2, lowWaterMark: 1 } as any);
+ee.emit("data", "a");
+ee.emit("data", "b");
+ee.emit("end");
+let count = 0;
+for await (const args of iter) {
+  console.log("item:", args.join(","));
+  if (++count === 2) break;
+}

--- a/test-parity/node-suite/events/once/abort-and-error.ts
+++ b/test-parity/node-suite/events/once/abort-and-error.ts
@@ -1,0 +1,12 @@
+import { EventEmitter, once } from "node:events";
+
+const ee = new EventEmitter();
+const ac = new AbortController();
+const p = once(ee, "ready", { signal: ac.signal }).then(() => "resolved", (err: any) => err.name + ":" + (err.code || "no-code"));
+ac.abort();
+console.log("abort once:", await p);
+
+const ee2 = new EventEmitter();
+const p2 = once(ee2, "ready").then(() => "resolved", (err: any) => err.message);
+ee2.emit("error", new Error("bad"));
+console.log("error once:", await p2);

--- a/test-parity/node-suite/events/once/multiple-args.ts
+++ b/test-parity/node-suite/events/once/multiple-args.ts
@@ -1,0 +1,7 @@
+import { EventEmitter, once } from "node:events";
+
+const ee = new EventEmitter();
+const p = once(ee, "data");
+ee.emit("data", "a", 2, true);
+const args = await p;
+console.log("args:", args.map(String).join(","));

--- a/test-parity/node-suite/os/collections/network-interfaces-shape.ts
+++ b/test-parity/node-suite/os/collections/network-interfaces-shape.ts
@@ -1,0 +1,11 @@
+import os from "node:os";
+
+const nets = os.networkInterfaces();
+const names = Object.keys(nets).sort();
+console.log("names type:", Array.isArray(names), names.length >= 0);
+for (const name of names.slice(0, 2)) {
+  const list = nets[name] || [];
+  console.log("iface:", typeof name, Array.isArray(list), list.length >= 0);
+  const first: any = list[0];
+  if (first) console.log("addr shape:", typeof first.address, typeof first.family, typeof first.internal);
+}

--- a/test-parity/node-suite/os/constants/errno-selected-extra.ts
+++ b/test-parity/node-suite/os/constants/errno-selected-extra.ts
@@ -1,0 +1,6 @@
+import os from "node:os";
+
+for (const key of ["EEXIST", "ENOENT", "EINVAL", "ECONNRESET", "ETIMEDOUT"]) {
+  const value = (os.constants.errno as any)[key];
+  console.log(key + ":", typeof value, value !== 0);
+}

--- a/test-parity/node-suite/os/constants/priority-and-signals.ts
+++ b/test-parity/node-suite/os/constants/priority-and-signals.ts
@@ -1,0 +1,6 @@
+import os from "node:os";
+
+console.log("SIGINT:", typeof os.constants.signals.SIGINT, os.constants.signals.SIGINT > 0);
+console.log("EACCES:", typeof os.constants.errno.EACCES, os.constants.errno.EACCES !== 0);
+console.log("priority low:", typeof os.constants.priority.PRIORITY_LOW);
+console.log("priority high:", typeof os.constants.priority.PRIORITY_HIGH);

--- a/test-parity/node-suite/os/methods/freemem-totalmem-relationship.ts
+++ b/test-parity/node-suite/os/methods/freemem-totalmem-relationship.ts
@@ -1,0 +1,7 @@
+import os from "node:os";
+
+const free = os.freemem();
+const total = os.totalmem();
+console.log("types:", typeof free, typeof total);
+console.log("nonnegative:", free >= 0, total >= 0);
+console.log("free<=total:", free <= total);

--- a/test-parity/node-suite/os/methods/modern-methods.ts
+++ b/test-parity/node-suite/os/methods/modern-methods.ts
@@ -1,0 +1,8 @@
+import os from "node:os";
+
+for (const name of ["availableParallelism", "machine", "version", "endianness"] as const) {
+  try {
+    const value = (os as any)[name]();
+    console.log(name + ":", typeof value, String(value).length > 0);
+  } catch (err: any) { console.log(name + ":", err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/os/methods/priority.ts
+++ b/test-parity/node-suite/os/methods/priority.ts
@@ -1,0 +1,5 @@
+import os from "node:os";
+
+try { console.log("getPriority self:", typeof os.getPriority()); } catch (err: any) { console.log("getPriority self:", err?.name, err?.code || "no-code"); }
+try { os.getPriority(-999999); console.log("getPriority bad no throw"); } catch (err: any) { console.log("getPriority bad:", err?.name, err?.code || "no-code"); }
+try { os.setPriority(999999 as any); console.log("setPriority one arg ok"); } catch (err: any) { console.log("setPriority one arg:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/os/paths/tmpdir-env-extra.ts
+++ b/test-parity/node-suite/os/paths/tmpdir-env-extra.ts
@@ -1,0 +1,5 @@
+import os from "node:os";
+
+console.log("tmpdir type:", typeof os.tmpdir(), os.tmpdir().length > 0);
+console.log("homedir type:", typeof os.homedir());
+console.log("devNull:", os.devNull.includes("null") || os.devNull.includes("NUL"));

--- a/test-parity/node-suite/os/platform/loadavg-and-cpus-shape.ts
+++ b/test-parity/node-suite/os/platform/loadavg-and-cpus-shape.ts
@@ -1,0 +1,8 @@
+import os from "node:os";
+
+const load = os.loadavg();
+console.log("load shape:", Array.isArray(load), load.length, load.every(n => typeof n === "number"));
+const cpus = os.cpus();
+console.log("cpus shape:", Array.isArray(cpus), cpus.length >= 0);
+const cpu: any = cpus[0];
+if (cpu) console.log("cpu fields:", typeof cpu.model, typeof cpu.speed, typeof cpu.times?.user);

--- a/test-parity/node-suite/os/platform/release-type-arch.ts
+++ b/test-parity/node-suite/os/platform/release-type-arch.ts
@@ -1,0 +1,6 @@
+import os from "node:os";
+
+console.log("type:", typeof os.type(), os.type().length > 0);
+console.log("release:", typeof os.release(), os.release().length > 0);
+console.log("platform:", typeof os.platform(), os.platform().length > 0);
+console.log("arch:", typeof os.arch(), os.arch().length > 0);

--- a/test-parity/node-suite/os/properties/eol-and-constants-identity.ts
+++ b/test-parity/node-suite/os/properties/eol-and-constants-identity.ts
@@ -1,0 +1,5 @@
+import os from "node:os";
+
+console.log("EOL len:", os.EOL.length > 0);
+console.log("constants identity:", os.constants === os.constants);
+console.log("signals identity:", os.constants.signals === os.constants.signals);

--- a/test-parity/node-suite/os/userinfo/encoding-buffer.ts
+++ b/test-parity/node-suite/os/userinfo/encoding-buffer.ts
@@ -1,0 +1,8 @@
+import os from "node:os";
+
+try {
+  const info: any = os.userInfo({ encoding: "buffer" as any });
+  console.log("username buffer:", Buffer.isBuffer(info.username));
+  console.log("homedir buffer:", Buffer.isBuffer(info.homedir));
+  console.log("uid type:", typeof info.uid);
+} catch (err: any) { console.log("userinfo buffer:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/os/userinfo/invalid-options.ts
+++ b/test-parity/node-suite/os/userinfo/invalid-options.ts
@@ -1,0 +1,5 @@
+import os from "node:os";
+
+for (const options of [null, { encoding: "madeup" }, { encoding: 123 }] as any[]) {
+  try { console.log("userinfo:", JSON.stringify(options), typeof os.userInfo(options).username); } catch (err: any) { console.log("userinfo:", JSON.stringify(options), err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/path/basename/suffix-edge-cases.ts
+++ b/test-parity/node-suite/path/basename/suffix-edge-cases.ts
@@ -1,0 +1,5 @@
+import path from "node:path";
+
+for (const [p, suffix] of [["/a/b.txt", ".txt"], ["/a/b.txt", "txt"], ["/a/b.txt", ".md"], ["/a/.bashrc", ".bashrc"], ["/a/b/", ""]] as any[]) {
+  console.log("base:", p, suffix, "=>", path.basename(p, suffix));
+}

--- a/test-parity/node-suite/path/extname/edge-cases-extra.ts
+++ b/test-parity/node-suite/path/extname/edge-cases-extra.ts
@@ -1,0 +1,5 @@
+import path from "node:path";
+
+for (const p of ["", ".", "..", ".bashrc", "file.", "file..", "a.b/c", "a/b.c.d", "a/."]) {
+  console.log("ext:", JSON.stringify(p), "=>", JSON.stringify(path.extname(p)));
+}

--- a/test-parity/node-suite/path/format/priority-rules.ts
+++ b/test-parity/node-suite/path/format/priority-rules.ts
@@ -1,0 +1,6 @@
+import path from "node:path";
+
+console.log("base wins:", path.format({ dir: "/tmp", name: "name", ext: ".txt", base: "base.md" }));
+console.log("root used:", path.format({ root: "/", name: "x", ext: ".js" }));
+console.log("dot ext:", path.format({ dir: "/a", name: "b", ext: "txt" }));
+console.log("win base wins:", path.win32.format({ dir: "C:\\x", name: "a", ext: ".b", base: "c.d" }));

--- a/test-parity/node-suite/path/join/type-errors-extra.ts
+++ b/test-parity/node-suite/path/join/type-errors-extra.ts
@@ -1,0 +1,5 @@
+import path from "node:path";
+
+for (const args of [["a", 1], ["a", null], ["a", {}], ["a", []]] as any[]) {
+  try { console.log("join:", path.join(...args)); } catch (err: any) { console.log("join err:", err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/path/matchesGlob/edge-cases.ts
+++ b/test-parity/node-suite/path/matchesGlob/edge-cases.ts
@@ -1,0 +1,10 @@
+import path from "node:path";
+
+function show(p: string, pattern: string): void {
+  try { console.log(p + " ~ " + pattern + ":", path.matchesGlob(p, pattern)); } catch (err: any) { console.log(p + " ~ " + pattern + ":", err?.name, err?.code || "no-code"); }
+}
+show("src/app.ts", "src/*.ts");
+show("src/nested/app.ts", "src/*.ts");
+show("src/nested/app.ts", "src/**/*.ts");
+show("README.md", "*.{md,txt}");
+show("a/b", "a/**");

--- a/test-parity/node-suite/path/normalize/trailing-separators-extra.ts
+++ b/test-parity/node-suite/path/normalize/trailing-separators-extra.ts
@@ -1,0 +1,8 @@
+import path from "node:path";
+
+for (const p of ["/foo/bar//", "/foo/./bar/", "/foo/bar/..", "//server//share//"]) {
+  console.log("posix:", p, "=>", path.posix.normalize(p));
+}
+for (const p of ["C:\\foo\\bar\\\\", "C:\\foo\\.\\bar\\", "C:\\foo\\bar\\..", "\\\\server\\share\\\\"]) {
+  console.log("win32:", p, "=>", path.win32.normalize(p));
+}

--- a/test-parity/node-suite/path/parse/dotfiles-and-roots.ts
+++ b/test-parity/node-suite/path/parse/dotfiles-and-roots.ts
@@ -1,0 +1,6 @@
+import path from "node:path";
+
+for (const p of ["/.bashrc", "/", "/tmp/.", "/tmp/..", "C:\\foo\\bar.txt", "\\\\server\\share\\file"]) {
+  const parsed = p.includes("\\") ? path.win32.parse(p) : path.parse(p);
+  console.log("parse:", p, "=>", JSON.stringify(parsed));
+}

--- a/test-parity/node-suite/path/posix/windows-looking-paths.ts
+++ b/test-parity/node-suite/path/posix/windows-looking-paths.ts
@@ -1,0 +1,6 @@
+import path from "node:path";
+
+for (const p of ["C:\\foo\\bar", "C:/foo/bar", "\\\\server\\share", "a\\b\\c"]) {
+  console.log("posix basename:", p, "=>", path.posix.basename(p));
+  console.log("posix dirname:", p, "=>", path.posix.dirname(p));
+}

--- a/test-parity/node-suite/path/relative/edge-cases-extra.ts
+++ b/test-parity/node-suite/path/relative/edge-cases-extra.ts
@@ -1,0 +1,6 @@
+import path from "node:path";
+
+console.log("same:", JSON.stringify(path.relative("/a/b", "/a/b")));
+console.log("parent:", path.relative("/a/b/c", "/a/d"));
+console.log("win same drive:", path.win32.relative("C:\\a\\b", "C:\\a\\c"));
+console.log("win unc:", path.win32.relative("\\\\s\\share\\a", "\\\\s\\share\\b"));

--- a/test-parity/node-suite/path/resolve/type-errors-extra.ts
+++ b/test-parity/node-suite/path/resolve/type-errors-extra.ts
@@ -1,0 +1,5 @@
+import path from "node:path";
+
+for (const value of [null, undefined, 1, {}, []] as any[]) {
+  try { console.log("resolve:", path.resolve("/tmp", value)); } catch (err: any) { console.log("resolve err:", err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/path/toNamespacedPath/edge-cases.ts
+++ b/test-parity/node-suite/path/toNamespacedPath/edge-cases.ts
@@ -1,0 +1,6 @@
+import path from "node:path";
+
+for (const p of ["", "foo", "/tmp/x", "C:\\foo", "\\\\server\\share\\file", "\\\\?\\C:\\already"]) {
+  console.log("ns:", JSON.stringify(p), "=>", path.win32.toNamespacedPath(p));
+}
+console.log("posix:", path.posix.toNamespacedPath("/tmp/x"));

--- a/test-parity/node-suite/path/win32/posix-looking-paths.ts
+++ b/test-parity/node-suite/path/win32/posix-looking-paths.ts
@@ -1,0 +1,6 @@
+import path from "node:path";
+
+for (const p of ["/foo/bar", "/foo/bar/", "foo/bar/baz", "//server/share"]) {
+  console.log("win basename:", p, "=>", path.win32.basename(p));
+  console.log("win dirname:", p, "=>", path.win32.dirname(p));
+}

--- a/test-parity/node-suite/path/win32/unc-and-drive-relative.ts
+++ b/test-parity/node-suite/path/win32/unc-and-drive-relative.ts
@@ -1,0 +1,8 @@
+import path from "node:path";
+
+const w = path.win32;
+for (const p of ["C:foo", "C:\\foo\\..\\bar", "\\\\server\\share\\dir\\..\\file", "//server/share/a/b"]) {
+  console.log("normalize:", p, "=>", w.normalize(p));
+}
+console.log("resolve drive relative:", w.resolve("C:foo"));
+console.log("relative drives:", w.relative("C:\\a\\b", "D:\\a\\b"));

--- a/test-parity/node-suite/path/zero-length/type-errors-extra.ts
+++ b/test-parity/node-suite/path/zero-length/type-errors-extra.ts
@@ -1,0 +1,5 @@
+import path from "node:path";
+
+for (const value of [null, undefined, 1, {}, []] as any[]) {
+  try { console.log("basename", String(value) + ":", path.basename(value)); } catch (err: any) { console.log("basename", String(value) + ":", err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/querystring/escape/unicode-and-plus.ts
+++ b/test-parity/node-suite/querystring/escape/unicode-and-plus.ts
@@ -1,0 +1,6 @@
+import querystring from "node:querystring";
+
+for (const value of ["a b", "a+b", "é", "😀", "!*'()"] ) {
+  const escaped = querystring.escape(value);
+  console.log("escape:", value, "=>", escaped, "=>", querystring.unescape(escaped));
+}

--- a/test-parity/node-suite/querystring/options/custom-encoder.ts
+++ b/test-parity/node-suite/querystring/options/custom-encoder.ts
@@ -1,0 +1,5 @@
+import querystring from "node:querystring";
+
+const out = querystring.stringify({ a: "x y", b: "z" }, "&", "=", { encodeURIComponent(v: string) { return "[" + v + "]"; } });
+console.log("custom encoder:", out);
+try { querystring.stringify({ a: "x" }, undefined, undefined, { encodeURIComponent() { throw new Error("encode boom"); } }); console.log("throw encoder no throw"); } catch (err: any) { console.log("throw encoder:", err?.name, err?.message); }

--- a/test-parity/node-suite/querystring/options/maxkeys-edge.ts
+++ b/test-parity/node-suite/querystring/options/maxkeys-edge.ts
@@ -1,0 +1,7 @@
+import querystring from "node:querystring";
+
+const input = "a=1&b=2&c=3";
+for (const maxKeys of [0, 1, 2, -1, Infinity, NaN] as any[]) {
+  const out = querystring.parse(input, undefined, undefined, { maxKeys });
+  console.log("maxKeys", String(maxKeys) + ":", Object.keys(out).join(","));
+}

--- a/test-parity/node-suite/querystring/parse/custom-decoder-errors.ts
+++ b/test-parity/node-suite/querystring/parse/custom-decoder-errors.ts
@@ -1,0 +1,8 @@
+import querystring from "node:querystring";
+
+try {
+  querystring.parse("a=1", undefined, undefined, { decodeURIComponent() { throw new Error("decode boom"); } });
+  console.log("throwing decoder: no throw");
+} catch (err: any) { console.log("throwing decoder:", err?.name, err?.message); }
+const out = querystring.parse("a=1%202&b=x+y", undefined, undefined, { decodeURIComponent(v: string) { return "[" + v + "]"; } });
+console.log("custom decoder:", JSON.stringify(out));

--- a/test-parity/node-suite/querystring/parse/empty-and-missing-values.ts
+++ b/test-parity/node-suite/querystring/parse/empty-and-missing-values.ts
@@ -1,0 +1,5 @@
+import querystring from "node:querystring";
+
+for (const input of ["", "a", "a=", "=b", "&&a=1&&", "a=1&a=2"]) {
+  console.log("parse:", JSON.stringify(input), JSON.stringify(querystring.parse(input)));
+}

--- a/test-parity/node-suite/querystring/parse/plus-and-percent.ts
+++ b/test-parity/node-suite/querystring/parse/plus-and-percent.ts
@@ -1,0 +1,5 @@
+import querystring from "node:querystring";
+
+for (const input of ["a+b=c+d", "a%2Bb=c%2Bd", "a=%E0%A4%A", "a=%F0%9F%98%80"]) {
+  console.log("parse:", input, JSON.stringify(querystring.parse(input)));
+}

--- a/test-parity/node-suite/querystring/parse/prototype-keys.ts
+++ b/test-parity/node-suite/querystring/parse/prototype-keys.ts
@@ -1,0 +1,7 @@
+import querystring from "node:querystring";
+
+const out: any = querystring.parse("__proto__=x&constructor=y&prototype=z&toString=q");
+console.log("keys:", Object.keys(out).sort().join(","));
+console.log("proto value:", out.__proto__);
+console.log("constructor value:", out.constructor);
+console.log("plain polluted:", ({} as any).polluted === true);

--- a/test-parity/node-suite/querystring/parse/semicolon-custom-sep.ts
+++ b/test-parity/node-suite/querystring/parse/semicolon-custom-sep.ts
@@ -1,0 +1,5 @@
+import querystring from "node:querystring";
+
+const input = "a=1;b=2;c=3%204";
+console.log("default:", JSON.stringify(querystring.parse(input)));
+console.log("semicolon:", JSON.stringify(querystring.parse(input, ";", "=")));

--- a/test-parity/node-suite/querystring/roundtrip/multichar-separators.ts
+++ b/test-parity/node-suite/querystring/roundtrip/multichar-separators.ts
@@ -1,0 +1,6 @@
+import querystring from "node:querystring";
+
+const s = querystring.stringify({ a: 1, b: 2 }, "&&", "=>");
+console.log("string:", s);
+const parsed = querystring.parse(s, "&&", "=>");
+console.log("parsed:", JSON.stringify(parsed));

--- a/test-parity/node-suite/querystring/stringify/arrays-and-nullish.ts
+++ b/test-parity/node-suite/querystring/stringify/arrays-and-nullish.ts
@@ -1,0 +1,6 @@
+import querystring from "node:querystring";
+
+console.log("array:", querystring.stringify({ a: ["x", "y"], b: 1 }));
+console.log("nullish:", querystring.stringify({ a: null as any, b: undefined as any, c: false }));
+console.log("object value:", querystring.stringify({ a: { x: 1 } as any }));
+console.log("custom sep:", querystring.stringify({ a: 1, b: 2 }, ";", ":"));

--- a/test-parity/node-suite/querystring/stringify/primitives-extra.ts
+++ b/test-parity/node-suite/querystring/stringify/primitives-extra.ts
@@ -1,0 +1,5 @@
+import querystring from "node:querystring";
+
+console.log("number bool:", querystring.stringify({ a: 1, b: true, c: false }));
+console.log("bigint symbol:", querystring.stringify({ a: 1n as any, b: Symbol("s") as any }));
+console.log("date regexp:", querystring.stringify({ d: new Date(0) as any, r: /x/ as any }));

--- a/test-parity/node-suite/querystring/stringify/symbol-keys-extra.ts
+++ b/test-parity/node-suite/querystring/stringify/symbol-keys-extra.ts
@@ -1,0 +1,8 @@
+import querystring from "node:querystring";
+
+const sym = Symbol("s");
+const obj: any = { a: 1 };
+obj[sym] = 2;
+Object.defineProperty(obj, "hidden", { value: 3, enumerable: false });
+console.log("stringify:", querystring.stringify(obj));
+console.log("keys:", Object.keys(obj).join(","));

--- a/test-parity/node-suite/querystring/unescape/malformed-percent.ts
+++ b/test-parity/node-suite/querystring/unescape/malformed-percent.ts
@@ -1,0 +1,5 @@
+import querystring from "node:querystring";
+
+for (const input of ["%", "%2", "%zz", "%E0%A4%A", "a+b", "a%20b"]) {
+  try { console.log("unescape:", input, "=>", querystring.unescape(input)); } catch (err: any) { console.log("unescape:", input, err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/string_decoder/base64/chunk-padding.ts
+++ b/test-parity/node-suite/string_decoder/base64/chunk-padding.ts
@@ -1,0 +1,8 @@
+import { StringDecoder } from "node:string_decoder";
+
+const bytes = Buffer.from("hello world").toString("base64");
+for (let split = 0; split <= bytes.length; split += 3) {
+  const d = new StringDecoder("base64");
+  const out = d.write(Buffer.from(bytes.slice(0, split))) + d.write(Buffer.from(bytes.slice(split))) + d.end();
+  console.log("split", split + ":", out);
+}

--- a/test-parity/node-suite/string_decoder/base64/invalid-bytes.ts
+++ b/test-parity/node-suite/string_decoder/base64/invalid-bytes.ts
@@ -1,0 +1,6 @@
+import { StringDecoder } from "node:string_decoder";
+
+const d = new StringDecoder("base64");
+console.log("invalid bytes:", d.write(Buffer.from([255, 254, 253])) + d.end());
+const d2 = new StringDecoder("base64");
+console.log("split one byte:", d2.write(Buffer.from([1])) + "|" + d2.end());

--- a/test-parity/node-suite/string_decoder/constructor/normalization-extra.ts
+++ b/test-parity/node-suite/string_decoder/constructor/normalization-extra.ts
@@ -1,0 +1,5 @@
+import { StringDecoder } from "node:string_decoder";
+
+for (const enc of [undefined, "", "UTF-8", "Utf16LE", "BASE64"] as any[]) {
+  try { const d = new StringDecoder(enc); console.log("enc:", String(enc), "=>", d.encoding); } catch (err: any) { console.log("enc:", String(enc), err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/string_decoder/encodings/aliases-extra.ts
+++ b/test-parity/node-suite/string_decoder/encodings/aliases-extra.ts
@@ -1,0 +1,5 @@
+import { StringDecoder } from "node:string_decoder";
+
+for (const enc of ["utf8", "utf-8", "ucs2", "ucs-2", "utf16le", "latin1", "binary", "base64", "hex"] as any[]) {
+  try { const d = new StringDecoder(enc); console.log(enc + ":", d.encoding, d.write(Buffer.from("6869", "hex"))); } catch (err: any) { console.log(enc + ":", err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/string_decoder/end/repeated-end.ts
+++ b/test-parity/node-suite/string_decoder/end/repeated-end.ts
@@ -1,0 +1,6 @@
+import { StringDecoder } from "node:string_decoder";
+
+const d = new StringDecoder("utf8");
+console.log("partial:", JSON.stringify(d.write(Buffer.from([0xe2, 0x82]))));
+console.log("end1:", JSON.stringify(d.end()));
+console.log("end2:", JSON.stringify(d.end()));

--- a/test-parity/node-suite/string_decoder/hex/odd-boundaries.ts
+++ b/test-parity/node-suite/string_decoder/hex/odd-boundaries.ts
@@ -1,0 +1,6 @@
+import { StringDecoder } from "node:string_decoder";
+
+const d = new StringDecoder("hex");
+console.log("one:", d.write(Buffer.from([0x0a])));
+console.log("two:", d.write(Buffer.from([0xbc, 0xde])));
+console.log("end:", d.end());

--- a/test-parity/node-suite/string_decoder/inputs/typedarray-dataview.ts
+++ b/test-parity/node-suite/string_decoder/inputs/typedarray-dataview.ts
@@ -1,0 +1,7 @@
+import { StringDecoder } from "node:string_decoder";
+
+const d = new StringDecoder("utf8");
+const u8 = new Uint8Array([104, 105]);
+console.log("u8:", d.write(u8));
+try { console.log("dataview:", d.write(new DataView(u8.buffer) as any)); } catch (err: any) { console.log("dataview:", err?.name, err?.code || "no-code"); }
+try { console.log("string:", d.write("x" as any)); } catch (err: any) { console.log("string:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/string_decoder/state/multiple-writes.ts
+++ b/test-parity/node-suite/string_decoder/state/multiple-writes.ts
@@ -1,0 +1,7 @@
+import { StringDecoder } from "node:string_decoder";
+
+const d = new StringDecoder("utf8");
+console.log("w1:", JSON.stringify(d.write(Buffer.from([0xe2]))));
+console.log("w2:", JSON.stringify(d.write(Buffer.from([0x82]))));
+console.log("w3:", JSON.stringify(d.write(Buffer.from([0xac]))));
+console.log("end:", JSON.stringify(d.end()));

--- a/test-parity/node-suite/string_decoder/utf16le/surrogate-boundaries.ts
+++ b/test-parity/node-suite/string_decoder/utf16le/surrogate-boundaries.ts
@@ -1,0 +1,8 @@
+import { StringDecoder } from "node:string_decoder";
+
+const bytes = Buffer.from("a😀b", "utf16le");
+for (let split = 0; split <= bytes.length; split++) {
+  const d = new StringDecoder("utf16le");
+  const out = d.write(bytes.subarray(0, split)) + d.write(bytes.subarray(split)) + d.end();
+  console.log("split", split + ":", out);
+}

--- a/test-parity/node-suite/string_decoder/utf8/invalid-sequences-extra.ts
+++ b/test-parity/node-suite/string_decoder/utf8/invalid-sequences-extra.ts
@@ -1,0 +1,6 @@
+import { StringDecoder } from "node:string_decoder";
+
+for (const bytes of [[0x80], [0xc0, 0xaf], [0xe2, 0x28, 0xa1], [0xf0, 0x28, 0x8c, 0xbc]]) {
+  const d = new StringDecoder("utf8");
+  console.log("invalid:", Buffer.from(bytes).toString("hex"), JSON.stringify(d.write(Buffer.from(bytes)) + d.end()));
+}

--- a/test-parity/node-suite/string_decoder/utf8/split-boundaries.ts
+++ b/test-parity/node-suite/string_decoder/utf8/split-boundaries.ts
@@ -1,0 +1,8 @@
+import { StringDecoder } from "node:string_decoder";
+
+const bytes = Buffer.from("a€𐍈b");
+for (let split = 0; split <= bytes.length; split++) {
+  const d = new StringDecoder("utf8");
+  const out = d.write(bytes.subarray(0, split)) + d.write(bytes.subarray(split)) + d.end();
+  console.log("split", split + ":", out);
+}

--- a/test-parity/node-suite/timers/clear/cross-clear.ts
+++ b/test-parity/node-suite/timers/clear/cross-clear.ts
@@ -1,0 +1,9 @@
+const events: string[] = [];
+const t = setTimeout(() => events.push("timeout"), 5);
+clearInterval(t as any);
+const i = setInterval(() => events.push("interval"), 5);
+clearTimeout(i as any);
+clearTimeout(null as any);
+clearInterval(undefined as any);
+await new Promise(resolve => setTimeout(resolve, 20));
+console.log("events:", events.join(",") || "none");

--- a/test-parity/node-suite/timers/immediate/args-and-errors.ts
+++ b/test-parity/node-suite/timers/immediate/args-and-errors.ts
@@ -1,0 +1,7 @@
+const events: string[] = [];
+process.once("uncaughtException", (err: any) => { events.push("caught:" + err.message); });
+setImmediate((a: string, b: string) => events.push(a + b), "a", "b");
+setImmediate(() => { throw new Error("boom"); });
+setImmediate(() => events.push("after"));
+await new Promise(resolve => setTimeout(resolve, 20));
+console.log("events:", events.join("|"));

--- a/test-parity/node-suite/timers/immediate/clear-before-run.ts
+++ b/test-parity/node-suite/timers/immediate/clear-before-run.ts
@@ -1,0 +1,7 @@
+const events: string[] = [];
+const im = setImmediate(() => events.push("immediate"));
+clearImmediate(im);
+clearImmediate(null as any);
+setImmediate(() => events.push("after"));
+await new Promise(resolve => setTimeout(resolve, 20));
+console.log("events:", events.join(","));

--- a/test-parity/node-suite/timers/interval/args-and-clear-inside.ts
+++ b/test-parity/node-suite/timers/interval/args-and-clear-inside.ts
@@ -1,0 +1,7 @@
+const events: string[] = [];
+const id = setInterval((a: string) => {
+  events.push(a);
+  if (events.length === 2) clearInterval(id);
+}, 1, "tick");
+await new Promise(resolve => setTimeout(resolve, 20));
+console.log("events:", events.join(","));

--- a/test-parity/node-suite/timers/object/dispose.ts
+++ b/test-parity/node-suite/timers/object/dispose.ts
@@ -1,0 +1,9 @@
+const events: string[] = [];
+const timeout: any = setTimeout(() => events.push("timeout"), 5);
+console.log("timeout dispose type:", typeof timeout[Symbol.dispose]);
+timeout[Symbol.dispose]?.();
+const immediate: any = setImmediate(() => events.push("immediate"));
+console.log("immediate dispose type:", typeof immediate[Symbol.dispose]);
+immediate[Symbol.dispose]?.();
+await new Promise(resolve => setTimeout(resolve, 20));
+console.log("events:", events.join(",") || "none");

--- a/test-parity/node-suite/timers/object/refresh-and-close.ts
+++ b/test-parity/node-suite/timers/object/refresh-and-close.ts
@@ -1,0 +1,8 @@
+const events: string[] = [];
+const t: any = setTimeout(() => events.push("timeout"), 5);
+console.log("refresh type:", typeof t.refresh);
+console.log("close type:", typeof t.close);
+t.refresh?.();
+t.close?.();
+await new Promise(resolve => setTimeout(resolve, 20));
+console.log("events:", events.join(",") || "none");

--- a/test-parity/node-suite/timers/object/to-primitive-extra.ts
+++ b/test-parity/node-suite/timers/object/to-primitive-extra.ts
@@ -1,0 +1,6 @@
+const t: any = setTimeout(() => {}, 1000);
+console.log("primitive type:", typeof +t);
+console.log("primitive positive:", +t > 0);
+clearTimeout(+t as any);
+await new Promise(resolve => setTimeout(resolve, 10));
+console.log("cleared by primitive");

--- a/test-parity/node-suite/timers/ordering/immediate-vs-timeout-main.ts
+++ b/test-parity/node-suite/timers/ordering/immediate-vs-timeout-main.ts
@@ -1,0 +1,5 @@
+const events: string[] = [];
+setImmediate(() => events.push("immediate"));
+setTimeout(() => events.push("timeout"), 0);
+await new Promise(resolve => setTimeout(resolve, 30));
+console.log("events:", events.join(","));

--- a/test-parity/node-suite/timers/ordering/nested-order-extra.ts
+++ b/test-parity/node-suite/timers/ordering/nested-order-extra.ts
@@ -1,0 +1,9 @@
+const events: string[] = [];
+setTimeout(() => {
+  events.push("timeout1");
+  queueMicrotask(() => events.push("micro-in-timeout"));
+  setTimeout(() => events.push("timeout2"), 0);
+}, 0);
+Promise.resolve().then(() => events.push("promise"));
+await new Promise(resolve => setTimeout(resolve, 30));
+console.log("events:", events.join("|"));

--- a/test-parity/node-suite/timers/promises/abort-signal.ts
+++ b/test-parity/node-suite/timers/promises/abort-signal.ts
@@ -1,0 +1,7 @@
+import { setTimeout as delay, setImmediate as immediate } from "node:timers/promises";
+
+const ac = new AbortController();
+const p = delay(50, "late", { signal: ac.signal }).then(v => "resolved:" + v, (err: any) => err.name + ":" + (err.code || "no-code"));
+ac.abort();
+console.log("timeout abort:", await p);
+console.log("immediate value:", await immediate("ok"));

--- a/test-parity/node-suite/timers/promises/interval-async-iterator.ts
+++ b/test-parity/node-suite/timers/promises/interval-async-iterator.ts
@@ -1,0 +1,11 @@
+import { setInterval } from "node:timers/promises";
+
+const ac = new AbortController();
+const values: string[] = [];
+try {
+  for await (const value of setInterval(1, "tick", { signal: ac.signal })) {
+    values.push(String(value));
+    if (values.length === 3) ac.abort();
+  }
+} catch (err: any) { console.log("interval abort:", err?.name, err?.code || "no-code"); }
+console.log("values:", values.join(","));

--- a/test-parity/node-suite/timers/promises/scheduler-wait-abort.ts
+++ b/test-parity/node-suite/timers/promises/scheduler-wait-abort.ts
@@ -1,0 +1,7 @@
+import { scheduler } from "node:timers/promises";
+
+const ac = new AbortController();
+const p = scheduler.wait(50, { signal: ac.signal }).then(() => "resolved", (err: any) => err.name + ":" + (err.code || "no-code"));
+ac.abort();
+console.log("wait abort:", await p);
+console.log("yield value:", await scheduler.yield());

--- a/test-parity/node-suite/timers/promises/timeout-value-and-ref.ts
+++ b/test-parity/node-suite/timers/promises/timeout-value-and-ref.ts
@@ -1,0 +1,4 @@
+import { setTimeout } from "node:timers/promises";
+
+console.log("value object:", JSON.stringify(await setTimeout(1, { a: 1 }, { ref: false })));
+console.log("value undefined:", await setTimeout(1));

--- a/test-parity/node-suite/timers/timeout/args-and-this.ts
+++ b/test-parity/node-suite/timers/timeout/args-and-this.ts
@@ -1,0 +1,4 @@
+const events: string[] = [];
+setTimeout(function(this: any, a: string, b: string) { events.push(String(this && typeof this) + ":" + a + b); }, 1, "a", "b");
+await new Promise(resolve => setTimeout(resolve, 20));
+console.log("events:", events.join(","));

--- a/test-parity/node-suite/timers/timeout/large-delay-warning-shape.ts
+++ b/test-parity/node-suite/timers/timeout/large-delay-warning-shape.ts
@@ -1,0 +1,6 @@
+const events: string[] = [];
+const t = setTimeout(() => events.push("large"), 2 ** 31);
+clearTimeout(t);
+setTimeout(() => events.push("small"), 1);
+await new Promise(resolve => setTimeout(resolve, 20));
+console.log("events:", events.join(","));

--- a/test-parity/node-suite/timers/timeout/zero-negative-delay.ts
+++ b/test-parity/node-suite/timers/timeout/zero-negative-delay.ts
@@ -1,0 +1,6 @@
+const events: string[] = [];
+setTimeout(() => events.push("neg"), -1);
+setTimeout(() => events.push("nan"), NaN as any);
+setTimeout(() => events.push("zero"), 0);
+await new Promise(resolve => setTimeout(resolve, 20));
+console.log("events:", events.sort().join(","));

--- a/test-parity/node-suite/tty/classes/color-depth-env.ts
+++ b/test-parity/node-suite/tty/classes/color-depth-env.ts
@@ -1,0 +1,10 @@
+import tty from "node:tty";
+
+const out: any = process.stdout;
+console.log("write stream:", out instanceof tty.WriteStream || typeof out.getColorDepth === "function");
+if (typeof out.getColorDepth === "function") {
+  console.log("color depth default:", typeof out.getColorDepth());
+  console.log("has colors 2:", typeof out.hasColors(2));
+}
+const input: any = process.stdin;
+console.log("read stream raw type:", typeof input.isRaw);

--- a/test-parity/node-suite/tty/classes/has-colors-env-objects.ts
+++ b/test-parity/node-suite/tty/classes/has-colors-env-objects.ts
@@ -1,0 +1,7 @@
+const out: any = process.stdout;
+if (typeof out.hasColors === "function") {
+  console.log("hasColors object:", out.hasColors({ colors: 16 }));
+  console.log("depth object:", out.getColorDepth({ TMUX: "1" }));
+} else {
+  console.log("hasColors type:", typeof out.hasColors);
+}

--- a/test-parity/node-suite/tty/classes/readstream-constructor-errors.ts
+++ b/test-parity/node-suite/tty/classes/readstream-constructor-errors.ts
@@ -1,0 +1,5 @@
+import tty from "node:tty";
+
+try { const rs: any = new tty.ReadStream(0); console.log("readstream:", typeof rs.isRaw, typeof rs.setRawMode); } catch (err: any) { console.log("readstream:", err?.name, err?.code || "no-code"); }
+try { const ws: any = new tty.WriteStream(1); console.log("writestream:", typeof ws.columns, typeof ws.rows, typeof ws.getColorDepth); } catch (err: any) { console.log("writestream:", err?.name, err?.code || "no-code"); }
+try { new tty.ReadStream("0" as any); console.log("bad readstream no throw"); } catch (err: any) { console.log("bad readstream:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/tty/classes/write-stream-method-shape.ts
+++ b/test-parity/node-suite/tty/classes/write-stream-method-shape.ts
@@ -1,0 +1,4 @@
+const out: any = process.stdout;
+for (const name of ["clearLine", "clearScreenDown", "cursorTo", "moveCursor", "getWindowSize"]) {
+  console.log(name + ":", typeof out[name]);
+}

--- a/test-parity/node-suite/tty/isatty/fd-coercion-extra.ts
+++ b/test-parity/node-suite/tty/isatty/fd-coercion-extra.ts
@@ -1,0 +1,5 @@
+import tty from "node:tty";
+
+for (const fd of [NaN, Infinity, 1.5, true, null] as any[]) {
+  try { console.log("fd", String(fd) + ":", tty.isatty(fd)); } catch (err: any) { console.log("fd", String(fd) + ":", err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/tty/isatty/invalid-fds.ts
+++ b/test-parity/node-suite/tty/isatty/invalid-fds.ts
@@ -1,0 +1,6 @@
+import tty from "node:tty";
+
+for (const fd of [-1, 0, 1, 2, 999999] as any[]) {
+  try { console.log("isatty", fd + ":", tty.isatty(fd)); } catch (err: any) { console.log("isatty", fd + ":", err?.name, err?.code || "no-code"); }
+}
+try { console.log("isatty string:", tty.isatty("1" as any)); } catch (err: any) { console.log("isatty string:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/tty/isatty/object-coercion.ts
+++ b/test-parity/node-suite/tty/isatty/object-coercion.ts
@@ -1,0 +1,5 @@
+import tty from "node:tty";
+
+const obj = { valueOf() { return 1; } };
+try { console.log("object:", tty.isatty(obj as any)); } catch (err: any) { console.log("object:", err?.name, err?.code || "no-code"); }
+try { console.log("bigint:", tty.isatty(1n as any)); } catch (err: any) { console.log("bigint:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/tty/process/stdout-stderr-shape.ts
+++ b/test-parity/node-suite/tty/process/stdout-stderr-shape.ts
@@ -1,0 +1,4 @@
+console.log("stdout fd:", typeof (process.stdout as any).fd);
+console.log("stderr fd:", typeof (process.stderr as any).fd);
+console.log("stdout isTTY:", typeof (process.stdout as any).isTTY);
+console.log("stderr isTTY:", typeof (process.stderr as any).isTTY);

--- a/test-parity/node-suite/url/legacy/format-auth-and-query.ts
+++ b/test-parity/node-suite/url/legacy/format-auth-and-query.ts
@@ -1,0 +1,5 @@
+import url from "node:url";
+
+console.log("format object:", url.format({ protocol: "http", slashes: true, auth: "u:p", hostname: "example.com", pathname: "/a b", query: { x: "1 2" } } as any));
+console.log("format url:", url.format(new URL("https://example.com/a?b=c")));
+try { console.log("format bad:", url.format(123 as any)); } catch (err: any) { console.log("format bad:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/url/legacy/parse-ipv6-and-invalid.ts
+++ b/test-parity/node-suite/url/legacy/parse-ipv6-and-invalid.ts
@@ -1,0 +1,8 @@
+import url from "node:url";
+
+for (const input of ["http://[::1]:8080/a?b=c", "http://user:pass@example.com/a", "//example.com/path", "http://%zz/"]) {
+  try {
+    const u = url.parse(input, true, true);
+    console.log("parse:", input, "=>", u.protocol, u.host, u.pathname, typeof u.query);
+  } catch (err: any) { console.log("parse:", input, "=>", err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/url/module/domain-conversion-extra.ts
+++ b/test-parity/node-suite/url/module/domain-conversion-extra.ts
@@ -1,0 +1,6 @@
+import { domainToASCII, domainToUnicode } from "node:url";
+
+for (const d of ["mañana.com", "☃.net", "xn--maana-pta.com", "bad domain", ""] ) {
+  console.log("ascii:", JSON.stringify(d), "=>", domainToASCII(d));
+  console.log("unicode:", JSON.stringify(d), "=>", domainToUnicode(d));
+}

--- a/test-parity/node-suite/url/module/file-url-options-extra.ts
+++ b/test-parity/node-suite/url/module/file-url-options-extra.ts
@@ -1,0 +1,6 @@
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const u = pathToFileURL("/tmp/a#b?c");
+console.log("escaped path:", u.href);
+console.log("roundtrip:", fileURLToPath(u));
+try { fileURLToPath("https://example.com/"); console.log("https no throw"); } catch (err: any) { console.log("https:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/url/module/file-url-windows-and-encoded.ts
+++ b/test-parity/node-suite/url/module/file-url-windows-and-encoded.ts
@@ -1,0 +1,8 @@
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+for (const u of ["file:///tmp/a%20b", "file:///tmp/%E2%82%AC", "file://host/share/file", "file:///tmp/a%2Fb"]) {
+  try { console.log("fileURLToPath:", u, "=>", fileURLToPath(u)); } catch (err: any) { console.log("fileURLToPath:", u, "=>", err?.name, err?.code || "no-code"); }
+}
+for (const p of ["/tmp/a b", "/tmp/€", "relative/path"]) {
+  try { console.log("pathToFileURL:", p, "=>", pathToFileURL(p).href); } catch (err: any) { console.log("pathToFileURL:", p, "=>", err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/url/module/url-canparse-parse-edge.ts
+++ b/test-parity/node-suite/url/module/url-canparse-parse-edge.ts
@@ -1,0 +1,6 @@
+import { URL } from "node:url";
+
+for (const [input, base] of [["/x", "https://example.com"], ["http://[::1]", undefined], ["http://%zz", undefined], ["x", "bad base"]] as any[]) {
+  try { console.log("canParse:", input, base, URL.canParse(input, base)); } catch (err: any) { console.log("canParse err:", err?.name, err?.code || "no-code"); }
+  try { const u: any = (URL as any).parse(input, base); console.log("parse:", u && u.href); } catch (err: any) { console.log("parse err:", err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/url/module/url-tojson-origin.ts
+++ b/test-parity/node-suite/url/module/url-tojson-origin.ts
@@ -1,0 +1,4 @@
+const urls = [new URL("https://example.com/a?b=c#d"), new URL("file:///tmp/a"), new URL("data:text/plain,hi")];
+for (const u of urls) {
+  console.log("url:", u.toJSON(), u.origin);
+}

--- a/test-parity/node-suite/url/search-params/constructor-inputs-extra.ts
+++ b/test-parity/node-suite/url/search-params/constructor-inputs-extra.ts
@@ -1,0 +1,4 @@
+for (const input of [{ a: "1", b: "2" }, [["a", "1"], ["a", "2"]], new URLSearchParams("x=1")] as any[]) {
+  try { const p = new URLSearchParams(input); console.log("params:", p.toString()); } catch (err: any) { console.log("params err:", err?.name, err?.code || "no-code"); }
+}
+try { new URLSearchParams([["a"]] as any); console.log("bad tuple no throw"); } catch (err: any) { console.log("bad tuple:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/url/search-params/delete-has-value.ts
+++ b/test-parity/node-suite/url/search-params/delete-has-value.ts
@@ -1,0 +1,5 @@
+const p = new URLSearchParams("a=1&a=2&a=1&b=1");
+console.log("has value:", p.has("a", "2"));
+p.delete("a", "1");
+console.log("after delete value:", p.toString());
+console.log("getAll:", p.getAll("a").join(","));

--- a/test-parity/node-suite/url/search-params/forEach-thisarg.ts
+++ b/test-parity/node-suite/url/search-params/forEach-thisarg.ts
@@ -1,0 +1,5 @@
+const p = new URLSearchParams("a=1&b=2");
+const ctx = { prefix: "ctx" };
+const out: string[] = [];
+p.forEach(function(this: any, value, key, obj) { out.push(this.prefix + ":" + key + "=" + value + ":" + (obj === p)); }, ctx);
+console.log("out:", out.join(","));

--- a/test-parity/node-suite/url/search-params/sort-and-size.ts
+++ b/test-parity/node-suite/url/search-params/sort-and-size.ts
@@ -1,0 +1,5 @@
+const p = new URLSearchParams("b=2&a=1&b=3");
+console.log("size before:", (p as any).size);
+p.sort();
+console.log("sorted:", p.toString());
+console.log("entries:", Array.from(p.entries()).map(x => x.join(":" )).join(","));

--- a/test-parity/node-suite/url/url/base-and-relative.ts
+++ b/test-parity/node-suite/url/url/base-and-relative.ts
@@ -1,0 +1,4 @@
+for (const [input, base] of [["../x", "https://example.com/a/b/c"], ["?q=1", "https://example.com/a"], ["#h", "https://example.com/a?b=c"], ["//other/path", "https://example.com/a"]]) {
+  const u = new URL(input, base);
+  console.log("url:", input, "=>", u.href);
+}

--- a/test-parity/node-suite/url/url/invalid-setters.ts
+++ b/test-parity/node-suite/url/url/invalid-setters.ts
@@ -1,0 +1,4 @@
+const u = new URL("https://example.com/a");
+for (const [prop, value] of [["protocol", "1"], ["port", "99999"], ["hostname", "bad host"], ["href", "not a url"]] as any[]) {
+  try { (u as any)[prop] = value; console.log("set:", prop, "=>", u.href); } catch (err: any) { console.log("set:", prop, err?.name, err?.code || "no-code"); }
+}

--- a/test-parity/node-suite/url/url/mutation-properties.ts
+++ b/test-parity/node-suite/url/url/mutation-properties.ts
@@ -1,0 +1,10 @@
+const u = new URL("https://user:pass@example.com:8080/a/b?x=1#h");
+u.username = "u s";
+u.password = "p@";
+u.hostname = "mañana.com";
+u.pathname = "/c d";
+u.searchParams.set("x", "2 3");
+u.hash = "frag ment";
+console.log("href:", u.href);
+console.log("origin:", u.origin);
+console.log("auth:", u.username, u.password);

--- a/test-parity/node-suite/util/callbackify/rejection-reasons.ts
+++ b/test-parity/node-suite/util/callbackify/rejection-reasons.ts
@@ -1,0 +1,14 @@
+import { callbackify } from "node:util";
+
+function run(label: string, fn: Function): Promise<void> {
+  return new Promise(resolve => {
+    callbackify(fn)((err: any, value: any) => {
+      console.log(label + ":", err ? err.name + ":" + (err.reason === undefined ? "undefined" : String(err.reason)) : "ok:" + value);
+      resolve();
+    });
+  });
+}
+await run("resolve", async () => "ok");
+await run("reject null", async () => { throw null; });
+await run("reject undefined", async () => { throw undefined; });
+await run("reject error", async () => { throw new Error("bad"); });

--- a/test-parity/node-suite/util/deprecate/basic-warning.ts
+++ b/test-parity/node-suite/util/deprecate/basic-warning.ts
@@ -1,0 +1,6 @@
+import { deprecate } from "node:util";
+
+const fn = deprecate((x: number) => x + 1, "deprecated fn", "DEP_PERRY_TEST");
+console.log("call1:", fn(1));
+console.log("call2:", fn(2));
+try { deprecate(() => 1, "msg", "bad code with spaces"); console.log("bad code no throw"); } catch (err: any) { console.log("bad code:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/util/format/inspect-options-interaction.ts
+++ b/test-parity/node-suite/util/format/inspect-options-interaction.ts
@@ -1,0 +1,4 @@
+import { formatWithOptions } from "node:util";
+
+console.log(formatWithOptions({ colors: false, depth: 1 }, "value:%O", { a: { b: { c: 1 } } }));
+console.log(formatWithOptions({ compact: false }, "%o", { a: 1, b: 2 }));

--- a/test-parity/node-suite/util/format/missing-extra-specifiers.ts
+++ b/test-parity/node-suite/util/format/missing-extra-specifiers.ts
@@ -1,0 +1,5 @@
+import { format } from "node:util";
+
+console.log(format("missing:%s:%d:%j"));
+console.log(format("extra", "a", 1, { b: 2 }));
+console.log(format("unknown:%q", "x"));

--- a/test-parity/node-suite/util/format/specifier-edge-cases.ts
+++ b/test-parity/node-suite/util/format/specifier-edge-cases.ts
@@ -1,0 +1,10 @@
+import { format } from "node:util";
+
+const circular: any = { name: "c" };
+circular.self = circular;
+console.log(format("s:%s d:%d i:%i f:%f", "x", "12.5", "12.5", "12.5"));
+console.log(format("j:%j", circular));
+console.log(format("o:%o", { a: 1 }));
+console.log(format("O:%O", { a: { b: { c: 1 } } }));
+console.log(format("percent:%% extra", "x", 1));
+console.log(format("big:%d", 10n));

--- a/test-parity/node-suite/util/formatWithOptions/colors-depth.ts
+++ b/test-parity/node-suite/util/formatWithOptions/colors-depth.ts
@@ -1,0 +1,5 @@
+import { formatWithOptions } from "node:util";
+
+console.log(formatWithOptions({ colors: true }, "%s", "x").includes("x"));
+console.log(formatWithOptions({ depth: 0 }, "%O", { a: { b: 1 } }));
+console.log(formatWithOptions({ sorted: true }, "%O", { b: 2, a: 1 }));

--- a/test-parity/node-suite/util/formatWithOptions/getters-and-custominspect.ts
+++ b/test-parity/node-suite/util/formatWithOptions/getters-and-custominspect.ts
@@ -1,0 +1,7 @@
+import { formatWithOptions, inspect } from "node:util";
+
+const obj: any = {};
+Object.defineProperty(obj, "x", { get() { return 7; }, enumerable: true });
+obj[inspect.custom] = () => "CUSTOM";
+console.log(formatWithOptions({ getters: true }, "%O", obj));
+console.log(formatWithOptions({ customInspect: false }, "%O", obj));

--- a/test-parity/node-suite/util/inspect/boxed-and-symbols.ts
+++ b/test-parity/node-suite/util/inspect/boxed-and-symbols.ts
@@ -1,0 +1,8 @@
+import { inspect } from "node:util";
+
+const sym = Symbol("k");
+const obj: any = { [sym]: 1, normal: 2 };
+console.log("symbols:", inspect(obj));
+console.log("boxed string:", inspect(new String("x")));
+console.log("boxed number:", inspect(new Number(3)));
+console.log("boxed bool:", inspect(new Boolean(false)));

--- a/test-parity/node-suite/util/inspect/collections-extra.ts
+++ b/test-parity/node-suite/util/inspect/collections-extra.ts
@@ -1,0 +1,6 @@
+import { inspect } from "node:util";
+
+console.log("map:", inspect(new Map([[{ a: 1 }, new Set([1, 2])]]), { depth: 3 }));
+console.log("set:", inspect(new Set(["a", "b"])));
+console.log("date:", inspect(new Date("2020-01-02T03:04:05.000Z")));
+console.log("regexp:", inspect(/a+/gi));

--- a/test-parity/node-suite/util/inspect/error-cause-and-aggregate.ts
+++ b/test-parity/node-suite/util/inspect/error-cause-and-aggregate.ts
@@ -1,0 +1,4 @@
+import { inspect } from "node:util";
+
+console.log("cause:", inspect(new Error("outer", { cause: new Error("inner") })));
+console.log("aggregate:", inspect(new AggregateError([new Error("a"), "b"], "agg")));

--- a/test-parity/node-suite/util/inspect/promise-weakrefs.ts
+++ b/test-parity/node-suite/util/inspect/promise-weakrefs.ts
@@ -1,0 +1,5 @@
+import { inspect } from "node:util";
+
+console.log("promise pending:", inspect(new Promise(() => {})));
+console.log("weakref:", inspect(new WeakRef({ a: 1 })));
+console.log("finalization registry:", inspect(new FinalizationRegistry(() => {})));

--- a/test-parity/node-suite/util/inspect/proxy-getters-weak.ts
+++ b/test-parity/node-suite/util/inspect/proxy-getters-weak.ts
@@ -1,0 +1,10 @@
+import { inspect } from "node:util";
+
+const obj: any = {};
+Object.defineProperty(obj, "value", { get() { return 42; }, enumerable: true });
+console.log("getter false:", inspect(obj));
+console.log("getter true:", inspect(obj, { getters: true }));
+const proxy = new Proxy({ a: 1 }, {});
+console.log("proxy default:", inspect(proxy));
+console.log("proxy shown:", inspect(proxy, { showProxy: true }));
+console.log("weakmap:", inspect(new WeakMap([[{}, 1]]), { showHidden: true }));

--- a/test-parity/node-suite/util/inspect/typed-arrays-arraybuffer.ts
+++ b/test-parity/node-suite/util/inspect/typed-arrays-arraybuffer.ts
@@ -1,0 +1,7 @@
+import { inspect } from "node:util";
+
+const ab = new ArrayBuffer(4);
+new Uint8Array(ab).set([1, 2, 3, 4]);
+console.log("arraybuffer:", inspect(ab));
+console.log("uint8:", inspect(new Uint8Array(ab, 1, 2)));
+console.log("dataview:", inspect(new DataView(ab)));

--- a/test-parity/node-suite/util/parse-args/basic.ts
+++ b/test-parity/node-suite/util/parse-args/basic.ts
@@ -1,0 +1,5 @@
+import { parseArgs } from "node:util";
+
+const result = parseArgs({ args: ["--flag", "--name", "perry", "pos"], options: { flag: { type: "boolean" }, name: { type: "string" } }, allowPositionals: true });
+console.log("values:", JSON.stringify(result.values));
+console.log("positionals:", result.positionals.join(","));

--- a/test-parity/node-suite/util/parse-args/negative-options.ts
+++ b/test-parity/node-suite/util/parse-args/negative-options.ts
@@ -1,0 +1,7 @@
+import { parseArgs } from "node:util";
+
+try {
+  const result = parseArgs({ args: ["--no-color", "--count=-1"], options: { color: { type: "boolean" }, count: { type: "string" } } });
+  console.log("values:", JSON.stringify(result.values));
+} catch (err: any) { console.log("no-color:", err?.name, err?.code || "no-code"); }
+try { parseArgs({ args: ["--flag=value"], options: { flag: { type: "boolean" } } }); console.log("bool value no throw"); } catch (err: any) { console.log("bool value:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/util/parse-args/tokens-and-strict.ts
+++ b/test-parity/node-suite/util/parse-args/tokens-and-strict.ts
@@ -1,0 +1,6 @@
+import { parseArgs } from "node:util";
+
+const result = parseArgs({ args: ["-a", "1", "--", "tail"], options: { a: { type: "string", short: "a" } }, tokens: true, allowPositionals: true });
+console.log("values:", JSON.stringify(result.values));
+console.log("tokens:", result.tokens?.map(t => t.kind + ":" + (t.name || t.value || "")).join(","));
+try { parseArgs({ args: ["--unknown"], options: {}, strict: true }); console.log("strict no throw"); } catch (err: any) { console.log("strict:", err?.name, err?.code || "no-code"); }

--- a/test-parity/node-suite/util/promisify/custom-and-this.ts
+++ b/test-parity/node-suite/util/promisify/custom-and-this.ts
@@ -1,0 +1,12 @@
+import { promisify } from "node:util";
+
+const obj = {
+  value: 5,
+  add(x: number, cb: Function) { cb(null, this.value + x); },
+};
+console.log("bound:", await promisify(obj.add).call(obj, 7));
+function multi(cb: Function) { cb(null, "a", "b"); }
+console.log("multi:", await promisify(multi)());
+function custom(cb: Function) { cb(null, "unused"); }
+(custom as any)[promisify.custom] = () => Promise.resolve("custom-result");
+console.log("custom:", await promisify(custom)());

--- a/test-parity/node-suite/util/promisify/error-and-sync-throw.ts
+++ b/test-parity/node-suite/util/promisify/error-and-sync-throw.ts
@@ -1,0 +1,6 @@
+import { promisify } from "node:util";
+
+function errback(cb: Function) { cb(new Error("bad")); }
+function syncThrow(cb: Function) { throw new Error("sync"); }
+try { await promisify(errback)(); console.log("errback no reject"); } catch (err: any) { console.log("errback:", err.message); }
+try { await promisify(syncThrow)(); console.log("sync no throw"); } catch (err: any) { console.log("sync:", err.message); }

--- a/test-parity/node-suite/util/types/arraybuffer-sharedarraybuffer.ts
+++ b/test-parity/node-suite/util/types/arraybuffer-sharedarraybuffer.ts
@@ -1,0 +1,6 @@
+import { types } from "node:util";
+
+console.log("arraybuffer:", types.isArrayBuffer(new ArrayBuffer(1)));
+console.log("sharedarraybuffer:", types.isSharedArrayBuffer(new SharedArrayBuffer(1)));
+console.log("anyarraybuffer ab:", types.isAnyArrayBuffer(new ArrayBuffer(1)));
+console.log("anyarraybuffer sab:", types.isAnyArrayBuffer(new SharedArrayBuffer(1)));

--- a/test-parity/node-suite/util/types/boxed-and-typedarrays-extra.ts
+++ b/test-parity/node-suite/util/types/boxed-and-typedarrays-extra.ts
@@ -1,0 +1,7 @@
+import { types } from "node:util";
+
+console.log("boxed number:", types.isBoxedPrimitive(new Number(1)));
+console.log("uint8:", types.isUint8Array(new Uint8Array(1)));
+console.log("int16:", types.isInt16Array(new Int16Array(1)));
+console.log("float64:", types.isFloat64Array(new Float64Array(1)));
+console.log("bigint64:", types.isBigInt64Array(new BigInt64Array(1)));

--- a/test-parity/node-suite/util/types/more-builtins.ts
+++ b/test-parity/node-suite/util/types/more-builtins.ts
@@ -1,0 +1,10 @@
+import { types } from "node:util";
+
+async function af() {}
+function* gf() {}
+console.log("async fn:", types.isAsyncFunction(af));
+console.log("generator fn:", types.isGeneratorFunction(gf));
+console.log("generator object:", types.isGeneratorObject(gf()));
+console.log("native error:", types.isNativeError(new Error("x")));
+console.log("date:", types.isDate(new Date()));
+console.log("regexp:", types.isRegExp(/x/));

--- a/test-parity/node-suite/util/types/proxy-and-promises.ts
+++ b/test-parity/node-suite/util/types/proxy-and-promises.ts
@@ -1,0 +1,9 @@
+import { types } from "node:util";
+
+const proxy = new Proxy({}, {});
+console.log("proxy:", types.isProxy(proxy));
+console.log("promise:", types.isPromise(Promise.resolve(1)));
+console.log("map iterator:", types.isMapIterator(new Map().keys()));
+console.log("set iterator:", types.isSetIterator(new Set().values()));
+console.log("arraybuffer view:", types.isArrayBufferView(new DataView(new ArrayBuffer(1))));
+console.log("boxed string:", types.isBoxedPrimitive(new String("x")));


### PR DESCRIPTION
## Summary

Expands the curated `test-parity/node-suite` coverage for the modules that were already under test, without introducing new modules and without expanding `object`.

This PR adds **184 new Node parity tests** across existing module directories:

- `assert`
- `buffer`
- `console`
- `diagnostics_channel`
- `events`
- `os`
- `path`
- `querystring`
- `string_decoder`
- `timers`
- `tty`
- `url`
- `util`

The suite grows from **611** to **795** tests.

## What changed

Added focused edge-case coverage for:

- assertion matching, rejection/throw validation, deep equality, sparse arrays, Map/Set, typed arrays, circular references, symbols, and error causes
- Buffer coercion, allocation, encodings, concat bounds, fill/write behavior, SharedArrayBuffer, inspection, ranges, swaps, and numeric edge cases
- console formatting, `Console` instances, object labels, grouping, tables, getters, proxy-like shapes, private fields, error causes, and circular/BigInt formatters
- diagnostics channel subscriber behavior, tracing, reentrant publish, import identity, and store shape
- events abort/error handling, capture rejections, listener mutation, symbols, `once`/`on`, static listener helpers, and max listener behavior
- OS constants, user info, network interface shape, platform/cpu/load/memory methods, and path-like values
- path POSIX/win32 edge cases, type validation, parsing/formatting, namespaces, glob matching, and normalization
- querystring parsing/stringifying, malformed escapes, custom encoders/decoders, legacy separators, prototype-like keys, and primitive values
- string decoder chunk boundaries, invalid sequences, encoding aliases, stateful writes, and utf16/base64/hex boundaries
- timers promises, abort behavior, object handles, ordering, disposal/refresh/close, clear behavior, and callback arguments
- tty stream/class/isatty shape and coercion cases
- URL, URLSearchParams, file URL helpers, mutation, static parse/canParse, legacy formatting, and encoding behavior
- util formatting, inspect, parseArgs, promisify/callbackify/deprecate, and util.types predicates

## Validation performed

New tests were validated against Node 22.15.0 with:

```bash
node --experimental-strip-types <new-test-file>
```

Repository checks run locally:

```bash
git diff --check
cargo check -p perry-api-manifest -p perry-hir -p perry-stdlib
cargo build --release -p perry -p perry-runtime -p perry-stdlib
```

Full node-suite parity run against Perry:

```bash
./run_parity_tests.sh --suite=node-suite
```

Result:

```txt
Parity Pass:   679
Parity Fail:   113
Compile Fail:  3
Skipped:       0
Parity Rate:   85.7%
```

## Gaps surfaced by the expanded suite

The expanded suite identifies **116 total parity gaps**:

- 113 output/behavior mismatches
- 3 compile failures

By module:

| Module | Total tests | Pass | Failures | Rate |
|---|---:|---:|---:|---:|
| `util` | 51 | 30 | 21 | 58.8% |
| `buffer` | 114 | 98 | 16 | 86.0% |
| `timers` | 58 | 45 | 13 | 77.6% |
| `console` | 117 | 106 | 11 | 90.6% |
| `url` | 48 | 37 | 11 | 77.1% |
| `events` | 51 | 41 | 10 | 80.4% |
| `assert` | 63 | 54 | 9 | 85.7% |
| `path` | 77 | 68 | 9 | 88.3% |
| `os` | 38 | 31 | 7 | 81.6% |
| `querystring` | 55 | 52 | 3 | 94.5% |
| `diagnostics_channel` | 57 | 55 | 2 | 96.5% |
| `string_decoder` | 34 | 32 | 2 | 94.1% |
| `tty` | 31 | 29 | 2 | 93.5% |
| `object` | 1 | 1 | 0 | 100% |

Main behavior buckets found:

- `util`: inspect rendering, util.types predicates, parseArgs, promisify/callbackify/deprecate, format/formatWithOptions options
- `buffer`: Buffer.from coercion, ArrayBuffer offsets, SharedArrayBuffer, encodings, concat length handling, fill/write validation, inspect constants
- `timers`: timers/promises abort behavior, interval async iterator, scheduler aborts, timer object methods/disposal, callback `this`, ordering, one segfault in a promises timeout case
- `console`: custom Console streams, object label coercion, getter/sorted inspect, class private field output, circular/BigInt formatting
- `url`: URL mutation/escaping, URLSearchParams constructors and thisArg, file URL Unicode/errors, legacy format/parse edge cases
- `events`: abort/error behavior, captureRejections, errorMonitor, addAbortListener, symbol/eventNames, once/on semantics
- `assert`: deep equality for Error cause, Map/Set, partial deep equality, typed arrays, throws/rejects failure behavior
- `path`: win32/UNC behavior, type validation, normalization, parse, toNamespacedPath, matchesGlob
- `os`: priority methods, networkInterfaces/loadavg/cpus/userInfo/devNull shapes, dynamic namespace dispatch compile guard
- `querystring`: custom decoder, missing values, symbol/non-enumerable keys
- `diagnostics_channel`: subscriber error ordering and traceCallback error-first behavior
- `string_decoder`: encoding normalization and utf16le compile path
- `tty`: TTY constructor and color/class shape

Compile failures surfaced:

```txt
node-suite/buffer/search/ucs2-and-buffer-needle
node-suite/os/methods/modern-methods
node-suite/string_decoder/utf16le/surrogate-boundaries
```

Known root causes from local run:

- `buffer/search/ucs2-and-buffer-needle`: `utf16le` is not recognized in that Buffer encoding lowering path.
- `string_decoder/utf16le/surrogate-boundaries`: same `utf16le` encoding path issue.
- `os/methods/modern-methods`: dynamic stdlib namespace dispatch (`os[name]()`) is intentionally blocked by Perry's safety guard.

## Suggested follow-up work

This PR intentionally keeps the scope to test coverage. Follow-up implementation work can be split by root cause/module:

1. Quick wins:
   - static-call rewrite or explicit allow comment for `os/methods/modern-methods`
   - `URLSearchParams.forEach(thisArg)`
   - console object label coercion
   - Buffer allocation/write/concat validation edge cases
2. High-impact modules:
   - `util`
   - `buffer`
   - `timers`
3. Medium-impact modules:
   - `url`
   - `events`
   - `console`
   - `assert`
   - `path`
   - `os`

## Notes

This is opened as a draft because the expanded `node-suite` intentionally exposes current Perry parity gaps. The PR is intended as a coverage/visibility step before implementation-focused PRs.
