### PR TITLE
fix(ios): #1311 make --enable-geisterhand build + link for --target ios

### DIFF
--- a/.github/workflows/simctl-tests.yml
+++ b/.github/workflows/simctl-tests.yml
@@ -35,7 +35,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install iOS simulator Rust target
-        run: rustup target add aarch64-apple-ios-sim
+        run: rustup target add aarch64-apple-ios-sim aarch64-apple-ios
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -51,6 +51,21 @@ jobs:
         run: |
           cargo build --release -p perry -p perry-runtime -p perry-stdlib
           cargo build --release -p perry-ui-ios --target aarch64-apple-ios-sim
+
+      # Regression guard for #1311 — the geisterhand glue (perry-ui-ios's
+      # geisterhand_style.rs + ffi/system.rs) must compile against the iOS UI
+      # crate AND link without a runtime symbol-hash mismatch. Compile-only the
+      # device-target libs (catches the E0425 "cannot find ... in the crate
+      # root" class), then do a full `perry compile --enable-geisterhand` for
+      # the simulator (the successful link catches the app_group/stub_diag
+      # symbol-resolution class end-to-end).
+      - name: Geisterhand iOS compile smoke (#1311)
+        run: |
+          cargo build --release -p perry-ui-ios --features geisterhand --target aarch64-apple-ios
+          cargo build --release -p perry-ui-geisterhand
+          ./target/release/perry compile docs/examples/ui/testing/geisterhand_demo.ts \
+            --target ios-simulator --enable-geisterhand \
+            -o "$RUNNER_TEMP/geisterhand_demo_ios"
 
       - name: Run simctl doc-example verification
         run: ./scripts/run_simctl_tests.sh

--- a/crates/perry-runtime/src/stub_diag.rs
+++ b/crates/perry-runtime/src/stub_diag.rs
@@ -78,6 +78,51 @@ pub fn perry_stub_warn(name: &'static str, reason: &'static str, issue: Option<&
     }
 }
 
+/// C-ABI shim around [`perry_stub_warn`] for FFI crates that link
+/// perry-runtime as a Cargo dependency but must reach it through a
+/// stable, feature-set-independent symbol rather than the hash-mangled
+/// Rust path `perry_runtime::stub_diag::perry_stub_warn`.
+///
+/// `perry-ui-ios` is the motivating caller (#1311): under the
+/// `geisterhand` feature its UI staticlib is built against a
+/// perry-runtime whose Cargo feature set can differ from the runtime
+/// actually linked into the app, so the Rust-mangled symbol carries a
+/// different `-Cmetadata` hash on each side and the link fails with
+/// "Undefined symbols". A `#[no_mangle]` symbol has a fixed name on
+/// both sides and resolves regardless of feature set — the same
+/// discipline `perry_app_group_suite_name` already uses for the App
+/// Group accessor (perry-ui-macos avoids the issue entirely by not
+/// depending on perry-runtime).
+///
+/// `name`, `reason`, and (optional) `issue` are NUL-terminated C
+/// strings that MUST point into static storage (string literals): the
+/// dedup set keys on `name` as a `&'static str`.
+///
+/// # Safety
+/// `name` and `reason` are non-null pointers to NUL-terminated UTF-8
+/// living for the process lifetime; `issue` is either null or the same.
+#[no_mangle]
+pub unsafe extern "C" fn perry_stub_warn_ffi(
+    name: *const std::os::raw::c_char,
+    reason: *const std::os::raw::c_char,
+    issue: *const std::os::raw::c_char,
+) {
+    if name.is_null() || reason.is_null() {
+        return;
+    }
+    // SAFETY: callers pass `'static` C-string literals, so reborrowing
+    // the slices for `'static` is sound.
+    let as_static = |p: *const std::os::raw::c_char| -> &'static str {
+        std::ffi::CStr::from_ptr(p).to_str().unwrap_or("")
+    };
+    let issue = if issue.is_null() {
+        None
+    } else {
+        Some(as_static(issue))
+    };
+    perry_stub_warn(as_static(name), as_static(reason), issue);
+}
+
 /// One row of the auto-generated stub manifest.
 ///
 /// Populated by `build.rs` from `perry-dispatch`'s tables plus the

--- a/crates/perry-ui-ios/src/ffi/system.rs
+++ b/crates/perry-ui-ios/src/ffi/system.rs
@@ -3,10 +3,32 @@
 //! Extracted from `lib.rs` for file-size hygiene. No behavior changes.
 
 use crate::*;
+use core::ffi::{c_char, CStr};
 
 // =============================================================================
 // System APIs (perry/system module)
 // =============================================================================
+
+// Emit a first-call no-op-stub diagnostic through perry-runtime's stable
+// C-ABI shim (`perry_stub_warn_ffi`) rather than the hash-mangled Rust path
+// `perry_runtime::stub_diag::perry_stub_warn`. Under the `geisterhand`
+// feature this UI lib and the linked runtime can be built with different
+// Cargo feature sets, which makes Rust-mangled symbols unresolvable at link
+// time (#1311); a `#[no_mangle]` symbol resolves regardless. Mirrors how
+// perry-ui-macos reaches `perry_app_group_suite_name`. `name`/`reason`/`issue`
+// are `'static` C-string literals.
+fn stub_warn(name: &CStr, reason: &CStr, issue: Option<&CStr>) {
+    extern "C" {
+        fn perry_stub_warn_ffi(name: *const c_char, reason: *const c_char, issue: *const c_char);
+    }
+    unsafe {
+        perry_stub_warn_ffi(
+            name.as_ptr(),
+            reason.as_ptr(),
+            issue.map_or(std::ptr::null(), CStr::as_ptr),
+        );
+    }
+}
 
 /// #917 — system share sheet (text). MVP stub on iOS: emits a
 /// first-call warning. The native implementation (issue follow-up)
@@ -16,20 +38,20 @@ use crate::*;
 /// platform — apps can compile-test against the API.
 #[no_mangle]
 pub extern "C" fn perry_system_share_text(_text_ptr: i64, _title_ptr: i64) {
-    perry_runtime::stub_diag::perry_stub_warn(
-        "perry_system_share_text",
-        "iOS UIActivityViewController not yet implemented (#917 follow-up)",
-        Some("#917"),
+    stub_warn(
+        c"perry_system_share_text",
+        c"iOS UIActivityViewController not yet implemented (#917 follow-up)",
+        Some(c"#917"),
     );
 }
 
 /// #917 — system share sheet (URL). MVP stub on iOS.
 #[no_mangle]
 pub extern "C" fn perry_system_share_url(_url_ptr: i64, _title_ptr: i64) {
-    perry_runtime::stub_diag::perry_stub_warn(
-        "perry_system_share_url",
-        "iOS UIActivityViewController not yet implemented (#917 follow-up)",
-        Some("#917"),
+    stub_warn(
+        c"perry_system_share_url",
+        c"iOS UIActivityViewController not yet implemented (#917 follow-up)",
+        Some(c"#917"),
     );
 }
 
@@ -59,15 +81,30 @@ fn app_group_str_from_header_ios(ptr: *const u8) -> &'static str {
 /// when no `[ios] app_group` was baked in. Returns `None` so the
 /// caller can short-circuit before reaching for `UserDefaults`.
 fn app_group_suite_ios() -> Option<objc2::rc::Retained<objc2_foundation::NSString>> {
-    let suite = perry_runtime::app_group::configured_suite_name()?;
-    Some(objc2_foundation::NSString::from_str(suite))
+    // Reach the baked-in suite name through perry-runtime's stable C-ABI
+    // accessor instead of the hash-mangled Rust `configured_suite_name()`, so
+    // the symbol resolves even when this UI lib and the linked runtime were
+    // built with different Cargo feature sets (#1311). Mirrors perry-ui-macos.
+    extern "C" {
+        fn perry_app_group_suite_name(out_len: *mut i32) -> *const u8;
+    }
+    unsafe {
+        let mut len: i32 = 0;
+        let ptr = perry_app_group_suite_name(&mut len as *mut i32);
+        if ptr.is_null() || len <= 0 {
+            return None;
+        }
+        let slice = std::slice::from_raw_parts(ptr, len as usize);
+        let suite = std::str::from_utf8(slice).ok()?;
+        Some(objc2_foundation::NSString::from_str(suite))
+    }
 }
 
-fn warn_app_group_not_configured(symbol: &'static str) {
-    perry_runtime::stub_diag::perry_stub_warn(
+fn warn_app_group_not_configured(symbol: &CStr) {
+    stub_warn(
         symbol,
-        "App Group not configured. Add `[ios] app_group = \"group.com.example.shared\"` to perry.toml (#1178).",
-        Some("#1178"),
+        c"App Group not configured. Add `[ios] app_group = \"group.com.example.shared\"` to perry.toml (#1178).",
+        Some(c"#1178"),
     );
 }
 
@@ -92,7 +129,7 @@ pub extern "C" fn perry_system_app_group_set(key_ptr: i64, value_ptr: i64) {
     unsafe {
         let defaults = app_group_defaults_ios();
         if defaults.is_null() {
-            warn_app_group_not_configured("perry_system_app_group_set");
+            warn_app_group_not_configured(c"perry_system_app_group_set");
             return;
         }
         let ns_key = objc2_foundation::NSString::from_str(key);
@@ -114,7 +151,7 @@ pub extern "C" fn perry_system_app_group_get(key_ptr: i64) -> i64 {
     unsafe {
         let defaults = app_group_defaults_ios();
         if defaults.is_null() {
-            warn_app_group_not_configured("perry_system_app_group_get");
+            warn_app_group_not_configured(c"perry_system_app_group_get");
             return empty();
         }
         let ns_key = objc2_foundation::NSString::from_str(key);
@@ -144,7 +181,7 @@ pub extern "C" fn perry_system_app_group_delete(key_ptr: i64) {
     unsafe {
         let defaults = app_group_defaults_ios();
         if defaults.is_null() {
-            warn_app_group_not_configured("perry_system_app_group_delete");
+            warn_app_group_not_configured(c"perry_system_app_group_delete");
             return;
         }
         let ns_key = objc2_foundation::NSString::from_str(key);
@@ -328,10 +365,10 @@ pub extern "C" fn perry_system_get_device_model() -> i64 {
 /// iOS; native impl will use `[[UIDevice currentDevice] systemVersion]`.
 #[no_mangle]
 pub extern "C" fn perry_system_get_os_version() -> i64 {
-    perry_runtime::stub_diag::perry_stub_warn(
-        "perry_system_get_os_version",
-        "iOS getOSVersion not yet implemented (UIDevice.systemVersion follow-up)",
-        Some("#918"),
+    stub_warn(
+        c"perry_system_get_os_version",
+        c"iOS getOSVersion not yet implemented (UIDevice.systemVersion follow-up)",
+        Some(c"#918"),
     );
     extern "C" {
         fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;

--- a/crates/perry-ui-ios/src/lib.rs
+++ b/crates/perry-ui-ios/src/lib.rs
@@ -25,6 +25,21 @@ pub mod geisterhand_style;
 // sub-modules for file-size hygiene (originally inline here, ~2,900 LOC).
 mod ffi;
 
+// Re-export the FFI entry points at the crate root so intra-crate callers that
+// reference `crate::perry_ui_*` paths resolve — mirroring perry-ui-macos. The
+// geisterhand glue (`app.rs` registration + `geisterhand_style.rs` dispatch)
+// relies on this; without it the `geisterhand` feature build fails with E0425
+// "cannot find ... in the crate root" (issue #1311). Linker-visible
+// `#[no_mangle]` symbols are unaffected; this is purely Rust path resolution.
+pub use ffi::camera::*;
+pub use ffi::comms::*;
+pub use ffi::dialogs_lifecycle::*;
+pub use ffi::misc::*;
+pub use ffi::security_notifications::*;
+pub use ffi::system::*;
+pub use ffi::widgets_advanced::*;
+pub use ffi::widgets_basic::*;
+
 /// Debug logging macro that writes to a file (NSLog/eprintln don't work reliably on iOS)
 #[macro_export]
 macro_rules! ws_log {

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -4455,10 +4455,26 @@ pub fn run_with_parse_cache(
     // prebuilt one. Auto-mode never enables panic=abort when geisterhand
     // is on, so the geisterhand path always uses the prebuilt variant.
     let runtime_lib = if ctx.needs_geisterhand {
-        if let Some(gh_rt) = find_geisterhand_runtime(target.as_deref()) {
-            gh_rt
-        } else {
-            find_runtime_library(target.as_deref())?
+        // The geisterhand-enabled runtime/UI/registry libs live in
+        // target/geisterhand and are auto-built on first use. On a cold
+        // build they don't exist yet at this point — the link step builds
+        // any missing ones, but that runs *after* runtime_lib is resolved.
+        // Build them now, before selecting the runtime, so we don't fall
+        // through to find_runtime_library() and pick the *host* runtime
+        // (wrong target + wrong feature set). That fallback is what makes a
+        // cold `--target ios --enable-geisterhand` fail with "building for
+        // 'iOS-simulator', but linking in object file built for 'macOS'"
+        // (#1311 Ask #2). This mirrors the missing-libs check in the link
+        // step and is idempotent — that check then finds them present.
+        let gh_missing = find_geisterhand_runtime(target.as_deref()).is_none()
+            || find_geisterhand_library(target.as_deref()).is_none()
+            || (ctx.needs_ui && find_geisterhand_ui(target.as_deref()).is_none());
+        if gh_missing {
+            build_geisterhand_libs(target.as_deref(), format)?;
+        }
+        match find_geisterhand_runtime(target.as_deref()) {
+            Some(gh_rt) => gh_rt,
+            None => find_runtime_library(target.as_deref())?,
         }
     } else if let Some(auto_rt) = optimized_libs.runtime.clone() {
         auto_rt


### PR DESCRIPTION
Closes #1311.

Geisterhand was unusable on iOS — both compile and link failed — while macOS worked. **Root cause:** `perry-ui-macos` has no `perry-runtime` Cargo dependency and reaches the runtime only through `#[no_mangle]` C-ABI symbols, so it's immune to feature-set hash drift. `perry-ui-ios` *does* depend on `perry-runtime` and was reaching into it via Rust paths.

## Failure 1 — compile errors (E0425)
`perry-ui-ios`'s `ffi` submodule functions weren't re-exported at crate root, so `geisterhand_style.rs` + `app.rs`'s `crate::perry_ui_*` paths didn't resolve. Added `pub use ffi::<sub>::*;` re-exports — the same pattern `perry-ui-macos` uses via `lib_ffi`.

## Failure 2 — link symbol-hash mismatch
iOS called two *plain Rust* runtime functions by path — `app_group::configured_suite_name` and `stub_diag::perry_stub_warn` — whose hash-mangled symbols differed between the `--features geisterhand` UI lib and the auto-optimized runtime it links against → "Undefined symbols". Routed both through stable `#[no_mangle]` C-ABI: reused the existing `perry_app_group_suite_name`, added a new `perry_stub_warn_ffi` shim. Verified at the symbol level that perry-ui-ios's own objects now have **zero** hash-mangled `perry_runtime` references.

## Cold-build ordering bug (issue Ask #2)
`runtime_lib` was resolved via `find_geisterhand_runtime` *before* the link step auto-builds the geisterhand libs, so a cold build fell back to the **host** runtime → `building for 'iOS-simulator', but linking object built for 'macOS'`. Now the geisterhand libs are built before runtime resolution (idempotent missing-check).

## CI smoke (issue Ask #3)
Added a geisterhand iOS compile-smoke to `simctl-tests.yml` (tag-push only): device-target libs + a full `perry compile --target ios-simulator --enable-geisterhand` on the geisterhand demo.

## Validation
- Compiles for `aarch64-apple-ios` and `aarch64-apple-ios-sim`, with and without geisterhand.
- **Cold** `perry compile --target ios-simulator --enable-geisterhand` → valid arm64 iOS-sim `.app` bundle with all `perry_geisterhand_*` symbols linked.
- No regression: host macOS geisterhand compile works; `cargo fmt --all --check` clean; `stub_diag` tests pass.

Per contributor convention this PR does not bump the version or touch `CHANGELOG.md`.