### PR TITLE
fix(runtime): thread-safety hardening for cross-thread runtime statics

### DIFF
--- a/crates/perry-runtime/src/arena/block.rs
+++ b/crates/perry-runtime/src/arena/block.rs
@@ -103,14 +103,20 @@ impl ArenaBlock {
         // swept; the freed entries buffer was reused for a new alloc;
         // the first f64 key drifted to a denormal (~1.086e-311).
         let pad = align.max(8);
-        let aligned_offset = (self.offset + pad - 1) & !(pad - 1);
-        if aligned_offset + size > self.size {
+        // Check arithmetic on the bump path explicitly. `allocation_start`
+        // already uses checked_add for the excluded-pages slow path; this
+        // mirrors that on the fast path so a hostile `size`/`align` pair
+        // can never wrap and hand back an in-bounds pointer for an
+        // out-of-bounds region.
+        let aligned_offset = self.offset.checked_add(pad - 1)? & !(pad - 1);
+        let bumped = aligned_offset.checked_add(size)?;
+        if bumped > self.size {
             return None;
         }
 
         let ptr = unsafe { self.data.add(aligned_offset) };
-        let bumped = aligned_offset + size;
-        self.offset = (bumped + pad - 1) & !(pad - 1);
+        let next = bumped.checked_add(pad - 1)? & !(pad - 1);
+        self.offset = next;
         Some(ptr)
     }
 

--- a/crates/perry-runtime/src/closure/alloc.rs
+++ b/crates/perry-runtime/src/closure/alloc.rs
@@ -79,6 +79,11 @@ pub unsafe fn note_closure_capture_slot(
     index: usize,
     value_bits: u64,
 ) {
+    // Standard generational-GC discipline: callers store `value_bits` into the
+    // slot *before* calling here; we then record the layout bit and fire the
+    // post-store write barrier. The captured value remains rooted on the
+    // caller's Rust stack between the store and this call, so a minor GC
+    // triggered in that window cannot drop it.
     crate::gc::layout_note_slot(closure as usize, index, value_bits);
     let slot = closure_capture_slots_mut(closure).add(index);
     crate::gc::runtime_write_barrier_slot(closure as usize, slot as usize, value_bits);

--- a/crates/perry-runtime/src/exception.rs
+++ b/crates/perry-runtime/src/exception.rs
@@ -38,100 +38,135 @@ extern "C" {
 // Maximum nesting depth for try blocks
 const MAX_TRY_DEPTH: usize = 128;
 
-// Static storage for exception handling
-static mut JUMP_BUFFERS: [JmpBuf; MAX_TRY_DEPTH] = [JmpBuf::new(); MAX_TRY_DEPTH];
-static mut TRY_DEPTH: usize = 0;
-static mut CURRENT_EXCEPTION: f64 = 0.0;
-static mut HAS_EXCEPTION: bool = false;
-static mut IN_FINALLY: bool = false;
+/// Per-thread exception state. Exception handling uses setjmp/longjmp,
+/// and a jmp_buf captured by setjmp on thread A is meaningless on thread
+/// B (its stack frame doesn't exist there) — so the buffers, the depth
+/// counter, the current exception, and the finally-flag all have to
+/// live in TLS once `perry/thread` workers can run user code that
+/// throws. Previously all five were process-wide `static mut`s and would
+/// corrupt under any concurrent throw.
+struct ExceptionState {
+    jump_buffers: [JmpBuf; MAX_TRY_DEPTH],
+    try_depth: usize,
+    current_exception: f64,
+    has_exception: bool,
+    in_finally: bool,
+}
+
+impl ExceptionState {
+    const fn new() -> Self {
+        ExceptionState {
+            jump_buffers: [JmpBuf::new(); MAX_TRY_DEPTH],
+            try_depth: 0,
+            current_exception: 0.0,
+            has_exception: false,
+            in_finally: false,
+        }
+    }
+}
+
+thread_local! {
+    static EXCEPTION_STATE: std::cell::UnsafeCell<ExceptionState> =
+        const { std::cell::UnsafeCell::new(ExceptionState::new()) };
+}
+
+#[inline]
+fn with_exception_state<R>(f: impl FnOnce(*mut ExceptionState) -> R) -> R {
+    EXCEPTION_STATE.with(|c| f(c.get()))
+}
 
 /// Push a new try block and return a pointer to its jmp_buf.
 /// The generated code must call setjmp() directly with this pointer.
 #[no_mangle]
 pub extern "C" fn js_try_push() -> *mut i32 {
-    unsafe {
-        if TRY_DEPTH >= MAX_TRY_DEPTH {
+    with_exception_state(|s| unsafe {
+        if (*s).try_depth >= MAX_TRY_DEPTH {
             panic!("Try block nesting too deep");
         }
-        let depth = TRY_DEPTH;
-        TRY_DEPTH += 1;
-        JUMP_BUFFERS[depth].as_mut_ptr()
-    }
+        let depth = (*s).try_depth;
+        (*s).try_depth += 1;
+        (*s).jump_buffers[depth].as_mut_ptr()
+    })
 }
 
 /// End a try block (just decrements depth, does NOT clear exception)
 /// The exception is cleared explicitly by js_clear_exception() in catch blocks
 #[no_mangle]
 pub extern "C" fn js_try_end() {
-    unsafe {
-        TRY_DEPTH = TRY_DEPTH.saturating_sub(1);
-    }
+    with_exception_state(|s| unsafe {
+        (*s).try_depth = (*s).try_depth.saturating_sub(1);
+    });
 }
 
 /// Throw an exception with the given value
 #[no_mangle]
 pub extern "C" fn js_throw(value: f64) -> ! {
-    unsafe {
-        CURRENT_EXCEPTION = value;
-        HAS_EXCEPTION = true;
+    // Pull the jmp_buf pointer out under the TLS borrow, then drop the
+    // borrow before calling longjmp (longjmp doesn't return, so leaving
+    // the TLS access "open" would leave the cell permanently borrowed
+    // on this thread; in practice UnsafeCell tolerates it but the
+    // shorter scope keeps things tidy).
+    let jb_ptr: *mut i32 = with_exception_state(|s| unsafe {
+        (*s).current_exception = value;
+        (*s).has_exception = true;
 
-        if IN_FINALLY {
+        if (*s).in_finally {
             eprintln!("Cannot throw during finally block");
             std::process::abort();
         }
 
-        if TRY_DEPTH == 0 {
+        if (*s).try_depth == 0 {
             print_uncaught(value);
             std::process::exit(1);
         }
 
-        // Jump to the most recent try block
-        let depth = TRY_DEPTH - 1;
-        longjmp(JUMP_BUFFERS[depth].as_mut_ptr(), 1)
-    }
+        let depth = (*s).try_depth - 1;
+        (*s).jump_buffers[depth].as_mut_ptr()
+    });
+    unsafe { longjmp(jb_ptr, 1) }
 }
 
 /// Get the current exception value
 #[no_mangle]
 pub extern "C" fn js_get_exception() -> f64 {
-    unsafe { CURRENT_EXCEPTION }
+    with_exception_state(|s| unsafe { (*s).current_exception })
 }
 
 /// Check if there's an active exception
 #[no_mangle]
 pub extern "C" fn js_has_exception() -> i32 {
-    unsafe {
-        if HAS_EXCEPTION {
+    with_exception_state(|s| unsafe {
+        if (*s).has_exception {
             1
         } else {
             0
         }
-    }
+    })
 }
 
 /// Clear the current exception
 #[no_mangle]
 pub extern "C" fn js_clear_exception() {
-    unsafe {
-        HAS_EXCEPTION = false;
-        CURRENT_EXCEPTION = 0.0;
-    }
+    with_exception_state(|s| unsafe {
+        (*s).has_exception = false;
+        (*s).current_exception = 0.0;
+    });
 }
 
 /// Mark entering a finally block
 #[no_mangle]
 pub extern "C" fn js_enter_finally() {
-    unsafe {
-        IN_FINALLY = true;
-    }
+    with_exception_state(|s| unsafe {
+        (*s).in_finally = true;
+    });
 }
 
 /// Mark leaving a finally block
 #[no_mangle]
 pub extern "C" fn js_leave_finally() {
-    unsafe {
-        IN_FINALLY = false;
-    }
+    with_exception_state(|s| unsafe {
+        (*s).in_finally = false;
+    });
 }
 
 /// Read a StringHeader into an owned Rust String (empty on null/garbage).
@@ -249,17 +284,17 @@ pub fn scan_exception_roots(mark: &mut dyn FnMut(f64)) {
 }
 
 pub fn scan_exception_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
-    unsafe {
-        if HAS_EXCEPTION {
-            visitor.visit_nanbox_f64_raw_slot(&raw mut CURRENT_EXCEPTION);
+    with_exception_state(|s| unsafe {
+        if (*s).has_exception {
+            visitor.visit_nanbox_f64_raw_slot(&raw mut (*s).current_exception);
         }
-    }
+    });
 }
 
 #[cfg(test)]
 pub(crate) fn test_set_exception(value: f64) {
-    unsafe {
-        CURRENT_EXCEPTION = value;
-        HAS_EXCEPTION = true;
-    }
+    with_exception_state(|s| unsafe {
+        (*s).current_exception = value;
+        (*s).has_exception = true;
+    });
 }

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -775,7 +775,7 @@ pub fn is_class_id_registered(class_id: u32) -> bool {
 /// Function pointer type for dispatching method calls on handle-based objects.
 /// Handle-based objects use small integer IDs (1, 2, 3...) instead of real heap pointers.
 /// This is registered by perry-stdlib to dispatch to Fastify, ioredis, etc.
-type HandleMethodDispatchFn = unsafe extern "C" fn(
+pub type HandleMethodDispatchFn = unsafe extern "C" fn(
     handle: i64,
     method_name_ptr: *const u8,
     method_name_len: usize,
@@ -783,43 +783,79 @@ type HandleMethodDispatchFn = unsafe extern "C" fn(
     args_len: usize,
 ) -> f64;
 
-pub(crate) static mut HANDLE_METHOD_DISPATCH: Option<HandleMethodDispatchFn> = None;
-
 /// Function pointer type for dispatching property access on handle-based objects.
-type HandlePropertyDispatchFn = unsafe extern "C" fn(
+pub type HandlePropertyDispatchFn = unsafe extern "C" fn(
     handle: i64,
     property_name_ptr: *const u8,
     property_name_len: usize,
 ) -> f64;
 
-pub static mut HANDLE_PROPERTY_DISPATCH: Option<HandlePropertyDispatchFn> = None;
-
 /// Function pointer type for dispatching property set on handle-based objects.
-type HandlePropertySetDispatchFn = unsafe extern "C" fn(
+pub type HandlePropertySetDispatchFn = unsafe extern "C" fn(
     handle: i64,
     property_name_ptr: *const u8,
     property_name_len: usize,
     value: f64,
 );
 
-pub static mut HANDLE_PROPERTY_SET_DISPATCH: Option<HandlePropertySetDispatchFn> = None;
+// Dispatch tables are written once at startup (by `js_register_handle_*_dispatch`)
+// and read from many threads thereafter (perry/thread workers run user code that
+// hits these). Stored as AtomicPtr to make reads/writes data-race-free; the
+// underlying value is still a single function pointer with Option semantics
+// (null = unset).
+static HANDLE_METHOD_DISPATCH_PTR: std::sync::atomic::AtomicPtr<()> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+static HANDLE_PROPERTY_DISPATCH_PTR: std::sync::atomic::AtomicPtr<()> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+static HANDLE_PROPERTY_SET_DISPATCH_PTR: std::sync::atomic::AtomicPtr<()> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+
+#[inline]
+pub fn handle_method_dispatch() -> Option<HandleMethodDispatchFn> {
+    let p = HANDLE_METHOD_DISPATCH_PTR.load(std::sync::atomic::Ordering::Acquire);
+    if p.is_null() {
+        None
+    } else {
+        Some(unsafe { std::mem::transmute::<*mut (), HandleMethodDispatchFn>(p) })
+    }
+}
+
+#[inline]
+pub fn handle_property_dispatch() -> Option<HandlePropertyDispatchFn> {
+    let p = HANDLE_PROPERTY_DISPATCH_PTR.load(std::sync::atomic::Ordering::Acquire);
+    if p.is_null() {
+        None
+    } else {
+        Some(unsafe { std::mem::transmute::<*mut (), HandlePropertyDispatchFn>(p) })
+    }
+}
+
+#[inline]
+pub fn handle_property_set_dispatch() -> Option<HandlePropertySetDispatchFn> {
+    let p = HANDLE_PROPERTY_SET_DISPATCH_PTR.load(std::sync::atomic::Ordering::Acquire);
+    if p.is_null() {
+        None
+    } else {
+        Some(unsafe { std::mem::transmute::<*mut (), HandlePropertySetDispatchFn>(p) })
+    }
+}
 
 /// Register a function to handle method calls on handle-based objects
 #[no_mangle]
 pub unsafe extern "C" fn js_register_handle_method_dispatch(f: HandleMethodDispatchFn) {
-    HANDLE_METHOD_DISPATCH = Some(f);
+    HANDLE_METHOD_DISPATCH_PTR.store(f as *mut (), std::sync::atomic::Ordering::Release);
 }
 
 /// Register a function to handle property access on handle-based objects
 #[no_mangle]
 pub unsafe extern "C" fn js_register_handle_property_dispatch(f: HandlePropertyDispatchFn) {
-    HANDLE_PROPERTY_DISPATCH = Some(f);
+    HANDLE_PROPERTY_DISPATCH_PTR.store(f as *mut (), std::sync::atomic::Ordering::Release);
 }
 
 /// Register a function to handle property set on handle-based objects
 #[no_mangle]
 pub unsafe extern "C" fn js_register_handle_property_set_dispatch(f: HandlePropertySetDispatchFn) {
-    HANDLE_PROPERTY_SET_DISPATCH = Some(f);
+    HANDLE_PROPERTY_SET_DISPATCH_PTR.store(f as *mut (), std::sync::atomic::Ordering::Release);
 }
 
 /// Register a class method in the vtable registry.

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -932,8 +932,7 @@ pub extern "C" fn js_object_get_field_by_name(
                             return JSValue::from_bits(JSValue::pointer(null_obj_ptr).bits());
                         }
                     }
-                    let dispatch = unsafe { HANDLE_PROPERTY_DISPATCH };
-                    if let Some(dispatch) = dispatch {
+                    if let Some(dispatch) = handle_property_dispatch() {
                         unsafe {
                             let key_ptr =
                                 (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
@@ -970,8 +969,7 @@ pub extern "C" fn js_object_get_field_by_name(
                     return JSValue::from_bits(result.to_bits());
                 }
             }
-            let dispatch = unsafe { HANDLE_PROPERTY_DISPATCH };
-            if let Some(dispatch) = dispatch {
+            if let Some(dispatch) = handle_property_dispatch() {
                 unsafe {
                     let key_ptr =
                         (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
@@ -1795,8 +1793,7 @@ pub extern "C" fn js_object_get_field_ic_miss(
                 return f64::from_bits(JSValue::pointer(null_obj_ptr).bits());
             }
         }
-        let dispatch = unsafe { HANDLE_PROPERTY_DISPATCH };
-        if let Some(dispatch) = dispatch {
+        if let Some(dispatch) = handle_property_dispatch() {
             unsafe {
                 let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                 let key_len = (*key).byte_len as usize;

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -75,9 +75,9 @@ pub extern "C" fn js_object_set_field_by_name(
             }
             if (raw as usize) < 0x10000 {
                 // Small handle — dispatch to handle property set if registered
-                unsafe {
-                    if let Some(dispatch) = HANDLE_PROPERTY_SET_DISPATCH {
-                        if !key.is_null() {
+                if let Some(dispatch) = handle_property_set_dispatch() {
+                    if !key.is_null() {
+                        unsafe {
                             let name_ptr =
                                 (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                             let name_len = (*key).byte_len as usize;
@@ -95,9 +95,9 @@ pub extern "C" fn js_object_set_field_by_name(
     if obj.is_null() || (obj as usize) < 0x10000 {
         // Small non-null value — could be a stripped handle (after ensure_i64 stripped NaN-box tag)
         if !obj.is_null() && (obj as usize) > 0 {
-            unsafe {
-                if let Some(dispatch) = HANDLE_PROPERTY_SET_DISPATCH {
-                    if !key.is_null() {
+            if let Some(dispatch) = handle_property_set_dispatch() {
+                if !key.is_null() {
+                    unsafe {
                         let name_ptr =
                             (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                         let name_len = (*key).byte_len as usize;

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -729,18 +729,30 @@ const TRANSITION_CACHE_SIZE: usize = 16384;
 #[allow(dead_code)]
 const TRANSITION_CACHE_MASK: usize = TRANSITION_CACHE_SIZE - 1;
 
-/// Main-thread transition cache — bypasses TLS overhead (user code is
-/// single-threaded). `#[no_mangle]` so the LLVM codegen can emit inline
-/// lookups against this symbol (write PIC).
-#[no_mangle]
-static mut TRANSITION_CACHE_GLOBAL: [TransitionEntry; TRANSITION_CACHE_SIZE] = [TransitionEntry {
-    prev_keys: 0,
-    key_ptr: 0,
-    next_keys: 0,
-    slot_idx: 0,
-    target_len: 0,
-};
-    TRANSITION_CACHE_SIZE];
+/// Per-thread transition cache. Was a process-wide `static mut`, but with
+/// `perry/thread` user code allocating objects on worker threads each
+/// thread has its own arena — cached `next_keys` / `key_ptr` pointers
+/// from another thread are use-after-free in our address space. The
+/// previous `#[no_mangle]` exposed the symbol for inline LLVM lookups
+/// but a grep across crates/perry-codegen confirms no codegen path ever
+/// resolved against it, so the export was dead.
+thread_local! {
+    static TRANSITION_CACHE_GLOBAL: std::cell::UnsafeCell<[TransitionEntry; TRANSITION_CACHE_SIZE]> =
+        const { std::cell::UnsafeCell::new([TransitionEntry {
+            prev_keys: 0,
+            key_ptr: 0,
+            next_keys: 0,
+            slot_idx: 0,
+            target_len: 0,
+        }; TRANSITION_CACHE_SIZE]) };
+}
+
+#[inline]
+fn with_transition_cache<R>(
+    f: impl FnOnce(*mut [TransitionEntry; TRANSITION_CACHE_SIZE]) -> R,
+) -> R {
+    TRANSITION_CACHE_GLOBAL.with(|c| f(c.get()))
+}
 
 /// FNV-1a content hash for a property-name string.
 /// Exported as `perry_key_content_hash` for the codegen write-PIC to
@@ -792,7 +804,7 @@ fn transition_cache_lookup(
 ) -> Option<(usize, u32)> {
     let kp = interned_key as usize;
     let slot = transition_cache_slot(prev_keys, kp);
-    let entry = unsafe { TRANSITION_CACHE_GLOBAL[slot] };
+    let entry = with_transition_cache(|t| unsafe { (*t)[slot] });
     if entry.next_keys != 0 && entry.prev_keys == prev_keys && entry.key_ptr == kp {
         let expected_len = entry.slot_idx.checked_add(1)?;
         if entry.target_len == expected_len {
@@ -856,14 +868,16 @@ fn transition_cache_insert(
                 target_len = expected_len;
             }
         }
-        TRANSITION_CACHE_GLOBAL[slot] = TransitionEntry {
+    }
+    with_transition_cache(|t| unsafe {
+        (*t)[slot] = TransitionEntry {
             prev_keys,
             key_ptr: kp,
             next_keys,
             slot_idx,
             target_len,
         };
-    }
+    });
     // Small dynamic shapes are stabilized eagerly because otherwise
     // the original builder can grow the cached target in place and
     // force future lookups to reject it. Large one-off dictionaries
@@ -885,10 +899,9 @@ pub fn scan_transition_cache_roots(mark: &mut dyn FnMut(f64)) {
 }
 
 pub fn scan_transition_cache_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
-    let base: *mut TransitionEntry = (&raw mut TRANSITION_CACHE_GLOBAL).cast();
-    unsafe {
+    with_transition_cache(|table| unsafe {
         for i in 0..TRANSITION_CACHE_SIZE {
-            let entry = &mut *base.add(i);
+            let entry = &mut (*table)[i];
             if entry.next_keys != 0 {
                 let mut invalidate = false;
                 invalidate |= visitor.visit_metadata_usize_slot(&mut entry.prev_keys);
@@ -905,7 +918,7 @@ pub fn scan_transition_cache_roots_mut(visitor: &mut crate::gc::RuntimeRootVisit
                 }
             }
         }
-    }
+    });
 }
 
 /// GC root scanner: mark all cached shape keys arrays so they're not freed.
@@ -1012,33 +1025,33 @@ pub(crate) fn test_shape_cache_root(shape_id: u32) -> (usize, usize) {
 
 #[cfg(test)]
 pub(crate) fn test_seed_transition_cache_root(next_keys: usize) {
-    unsafe {
-        TRANSITION_CACHE_GLOBAL[0] = TransitionEntry {
+    with_transition_cache(|t| unsafe {
+        (*t)[0] = TransitionEntry {
             prev_keys: 0,
             key_ptr: 0,
             next_keys,
             slot_idx: 0,
             target_len: 0,
         };
-    }
+    });
 }
 
 #[cfg(test)]
 pub(crate) fn test_transition_cache_root() -> usize {
-    unsafe { TRANSITION_CACHE_GLOBAL[0].next_keys }
+    with_transition_cache(|t| unsafe { (*t)[0].next_keys })
 }
 
 #[cfg(test)]
 pub(crate) fn test_clear_transition_cache_root() {
-    unsafe {
-        TRANSITION_CACHE_GLOBAL[0] = TransitionEntry {
+    with_transition_cache(|t| unsafe {
+        (*t)[0] = TransitionEntry {
             prev_keys: 0,
             key_ptr: 0,
             next_keys: 0,
             slot_idx: 0,
             target_len: 0,
         };
-    }
+    });
 }
 
 #[cfg(test)]
@@ -1503,14 +1516,14 @@ mod tests {
         );
 
         let slot = transition_cache_slot(0, key as usize);
-        unsafe {
-            TRANSITION_CACHE_GLOBAL[slot] = TransitionEntry {
+        with_transition_cache(|t| unsafe {
+            (*t)[slot] = TransitionEntry {
                 prev_keys: 0,
                 key_ptr: 0,
                 next_keys: 0,
                 slot_idx: 0,
                 target_len: 0,
             };
-        }
+        });
     }
 }

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -293,7 +293,7 @@ pub unsafe extern "C" fn js_native_call_method(
     // with no tag are raw handle IDs from Perry's integer-typed handle parameters.
     let raw_bits = object.to_bits();
     if raw_bits > 0 && raw_bits < 0x100000 {
-        if let Some(dispatch) = HANDLE_METHOD_DISPATCH {
+        if let Some(dispatch) = handle_method_dispatch() {
             return dispatch(
                 raw_bits as i64,
                 method_name.as_ptr(),
@@ -706,7 +706,7 @@ pub unsafe extern "C" fn js_native_call_method(
         let raw_ptr = jsval.as_pointer::<u8>() as usize;
         if raw_ptr > 0 && raw_ptr < 0x100000 {
             // This is a handle, not a real memory pointer - dispatch to stdlib
-            if let Some(dispatch) = HANDLE_METHOD_DISPATCH {
+            if let Some(dispatch) = handle_method_dispatch() {
                 return dispatch(
                     raw_ptr as i64,
                     method_name.as_ptr(),

--- a/crates/perry-runtime/src/string/concat.rs
+++ b/crates/perry-runtime/src/string/concat.rs
@@ -1,7 +1,7 @@
 //! String concatenation: pairwise, fused with NaN-boxed value, and n-way chain.
 
 use super::intern::{
-    concat_content_matches, fnv1a_concat, INTERN_MAX_BYTE_LEN, INTERN_TABLE, INTERN_TABLE_MASK,
+    concat_content_matches, fnv1a_concat, with_intern_table, INTERN_MAX_BYTE_LEN, INTERN_TABLE_MASK,
 };
 use super::*;
 
@@ -130,15 +130,21 @@ pub extern "C" fn js_string_concat(
         unsafe {
             let hash = fnv1a_concat(a, blen_a, b, blen_b);
             let slot = (hash as usize) & INTERN_TABLE_MASK;
-            let entry = &INTERN_TABLE[slot];
-            if entry.string_ptr != 0 && entry.hash == hash {
-                let existing = entry.string_ptr as *const StringHeader;
-                if is_valid_string_ptr(existing)
-                    && (*existing).byte_len == total_blen
-                    && concat_content_matches(a, blen_a, b, blen_b, existing)
-                {
-                    return existing as *mut StringHeader;
+            let hit = with_intern_table(|table| {
+                let entry = &(*table)[slot];
+                if entry.string_ptr != 0 && entry.hash == hash {
+                    let existing = entry.string_ptr as *const StringHeader;
+                    if is_valid_string_ptr(existing)
+                        && (*existing).byte_len == total_blen
+                        && concat_content_matches(a, blen_a, b, blen_b, existing)
+                    {
+                        return Some(existing);
+                    }
                 }
+                None
+            });
+            if let Some(existing) = hit {
+                return existing as *mut StringHeader;
             }
         }
     }

--- a/crates/perry-runtime/src/string/format.rs
+++ b/crates/perry-runtime/src/string/format.rs
@@ -6,9 +6,16 @@ use super::*;
 /// Cached small-integer string table (0..=255). Initialized lazily on
 /// first access. Avoids gc_malloc + format! for commonly repeated
 /// number-to-string conversions (loop counters, property name suffixes).
+///
+/// Thread-local: each thread (perry/thread workers and the main thread)
+/// has its own arena, so cached pointers MUST be per-thread — sharing
+/// across threads would hand back arena pointers that are invalid in
+/// the caller's address space (use-after-free / cross-arena UB).
 const SMALL_INT_CACHE_SIZE: usize = 256;
-static mut SMALL_INT_CACHE: [*mut StringHeader; SMALL_INT_CACHE_SIZE] =
-    [std::ptr::null_mut(); SMALL_INT_CACHE_SIZE];
+thread_local! {
+    static SMALL_INT_CACHE: std::cell::UnsafeCell<[*mut StringHeader; SMALL_INT_CACHE_SIZE]> =
+        const { std::cell::UnsafeCell::new([std::ptr::null_mut(); SMALL_INT_CACHE_SIZE]) };
+}
 
 /// Convert a number (f64) to a string
 /// Returns a new string representing the number
@@ -17,11 +24,9 @@ pub extern "C" fn js_number_to_string(value: f64) -> *mut StringHeader {
     // Fast path: small non-negative integers use a cached string table.
     if value.fract() == 0.0 && value >= 0.0 && value < SMALL_INT_CACHE_SIZE as f64 {
         let idx = value as usize;
-        unsafe {
-            let cached = SMALL_INT_CACHE[idx];
-            if !cached.is_null() {
-                return cached;
-            }
+        let cached = SMALL_INT_CACHE.with(|c| unsafe { (*c.get())[idx] });
+        if !cached.is_null() {
+            return cached;
         }
         // Allocate and cache
         let s = format!("{}", value as u64);
@@ -29,12 +34,13 @@ pub extern "C" fn js_number_to_string(value: f64) -> *mut StringHeader {
         unsafe {
             // Mark as shared so it's never mutated in-place
             (*ptr).refcount = 0;
-            SMALL_INT_CACHE[idx] = ptr;
-            // Mark as interned so GC roots it via the intern scanner
+            // Mark as pinned so GC keeps it live for the lifetime of this
+            // thread's arena.
             let gc_header =
                 (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;
             (*gc_header).gc_flags |= crate::gc::GC_FLAG_PINNED;
         }
+        SMALL_INT_CACHE.with(|c| unsafe { (*c.get())[idx] = ptr });
         return ptr;
     }
 

--- a/crates/perry-runtime/src/string/intern.rs
+++ b/crates/perry-runtime/src/string/intern.rs
@@ -17,11 +17,25 @@ pub(crate) const INTERN_TABLE_MASK: usize = INTERN_TABLE_SIZE - 1;
 /// Maximum byte length for strings eligible for interning.
 pub(crate) const INTERN_MAX_BYTE_LEN: u32 = 64;
 
-#[no_mangle]
-pub(crate) static mut INTERN_TABLE: [InternEntry; INTERN_TABLE_SIZE] = [InternEntry {
-    hash: 0,
-    string_ptr: 0,
-}; INTERN_TABLE_SIZE];
+/// Per-thread intern table.
+///
+/// Each thread (main + every `perry/thread` worker) has its own arena, so
+/// cached `StringHeader*` pointers MUST be per-thread — a string interned
+/// from worker A's arena is a use-after-free / cross-arena pointer when
+/// read from worker B. The previous design used a single process-wide
+/// `static mut`, which both raced under concurrent allocation and risked
+/// handing back foreign-arena pointers.
+thread_local! {
+    pub(crate) static INTERN_TABLE: std::cell::UnsafeCell<[InternEntry; INTERN_TABLE_SIZE]> =
+        const { std::cell::UnsafeCell::new([InternEntry { hash: 0, string_ptr: 0 }; INTERN_TABLE_SIZE]) };
+}
+
+#[inline]
+pub(crate) fn with_intern_table<R>(
+    f: impl FnOnce(*mut [InternEntry; INTERN_TABLE_SIZE]) -> R,
+) -> R {
+    INTERN_TABLE.with(|c| f(c.get()))
+}
 
 /// Intern a property-name string. Returns the canonical pointer for
 /// the given content. `hash` is the pre-computed FNV-1a hash.
@@ -37,21 +51,30 @@ pub extern "C" fn js_string_intern(key: *const StringHeader, hash: u64) -> *cons
         }
 
         let slot = (hash as usize) & INTERN_TABLE_MASK;
-        let entry = &mut INTERN_TABLE[slot];
-
-        if entry.string_ptr != 0 && entry.hash == hash {
-            let existing = entry.string_ptr as *const StringHeader;
-            if is_valid_string_ptr(existing)
-                && (*existing).byte_len == byte_len
-                && intern_content_equals(key, existing, byte_len)
-            {
-                return existing;
+        let hit = with_intern_table(|table| {
+            let entry = &(*table)[slot];
+            if entry.string_ptr != 0 && entry.hash == hash {
+                let existing = entry.string_ptr as *const StringHeader;
+                if is_valid_string_ptr(existing)
+                    && (*existing).byte_len == byte_len
+                    && intern_content_equals(key, existing, byte_len)
+                {
+                    return Some(existing);
+                }
             }
+            None
+        });
+        if let Some(existing) = hit {
+            return existing;
         }
 
         // Miss or collision — insert (evict on collision)
-        entry.hash = hash;
-        entry.string_ptr = key as usize;
+        with_intern_table(|table| {
+            (*table)[slot] = InternEntry {
+                hash,
+                string_ptr: key as usize,
+            };
+        });
 
         // Mark as interned in GcHeader
         let gc_header =
@@ -138,46 +161,46 @@ pub(crate) unsafe fn concat_content_matches(
 
 /// GC root scanner for the intern table.
 ///
-/// #855: walk via `&raw const` + raw pointer indexing to avoid the
-/// `static_mut_refs` lint (hard error in Rust 2024). The intern table
-/// is thread-local-by-discipline (perry user code is single-threaded),
-/// so the unsafe deref is sound.
+/// The intern table is `thread_local!` (issue: runtime thread-safety
+/// hardening), so this scans the *current* thread's table. Each thread's
+/// GC pass calls this from its own scanner registration, which is the
+/// correct partitioning — a thread's GC only walks its own arena, and
+/// only its own intern entries point into that arena.
 pub fn scan_intern_table_roots(mark: &mut dyn FnMut(f64)) {
     let mut visitor = crate::gc::RuntimeRootVisitor::for_copy(mark);
     scan_intern_table_roots_mut(&mut visitor);
 }
 
 pub fn scan_intern_table_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
-    let base: *mut InternEntry = (&raw mut INTERN_TABLE).cast();
-    unsafe {
+    with_intern_table(|table| unsafe {
         for i in 0..INTERN_TABLE_SIZE {
-            let entry = &mut *base.add(i);
+            let entry = &mut (*table)[i];
             visitor.visit_tagged_usize_slot(&mut entry.string_ptr, crate::value::STRING_TAG);
         }
-    }
+    });
 }
 
 #[cfg(test)]
 pub(crate) fn test_seed_intern_table_root(string_ptr: usize) {
-    unsafe {
-        INTERN_TABLE[0] = InternEntry {
+    with_intern_table(|table| unsafe {
+        (*table)[0] = InternEntry {
             hash: 0xC0DEC0DE,
             string_ptr,
         };
-    }
+    });
 }
 
 #[cfg(test)]
 pub(crate) fn test_intern_table_root() -> usize {
-    unsafe { INTERN_TABLE[0].string_ptr }
+    with_intern_table(|table| unsafe { (*table)[0].string_ptr })
 }
 
 #[cfg(test)]
 pub(crate) fn test_clear_intern_table_root() {
-    unsafe {
-        INTERN_TABLE[0] = InternEntry {
+    with_intern_table(|table| unsafe {
+        (*table)[0] = InternEntry {
             hash: 0,
             string_ptr: 0,
         };
-    }
+    });
 }

--- a/crates/perry-runtime/src/string/tests.rs
+++ b/crates/perry-runtime/src/string/tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Moved verbatim from the pre-split monolithic `string.rs`.
 
-use super::intern::{InternEntry, INTERN_TABLE, INTERN_TABLE_MASK};
+use super::intern::{with_intern_table, InternEntry, INTERN_TABLE_MASK};
 use super::*;
 
 fn malloc_object_count_for_test() -> usize {
@@ -98,7 +98,7 @@ fn interned_strings_remain_scannable_and_content_equal() {
     let key = b"gc-managed-intern-key";
     let hash = fnv1a_for_test(key);
     let slot = (hash as usize) & INTERN_TABLE_MASK;
-    let old_entry = unsafe { INTERN_TABLE[slot] };
+    let old_entry = with_intern_table(|t| unsafe { (*t)[slot] });
 
     let first = js_string_from_bytes(key.as_ptr(), key.len() as u32);
     let canonical = js_string_intern(first, hash);
@@ -123,8 +123,10 @@ fn interned_strings_remain_scannable_and_content_equal() {
     unsafe {
         let header = gc_header_for_string(canonical);
         assert_ne!((*header).gc_flags & crate::gc::GC_FLAG_INTERNED, 0);
-        INTERN_TABLE[slot] = old_entry;
     }
+    with_intern_table(|t| unsafe {
+        (*t)[slot] = old_entry;
+    });
 }
 
 #[test]

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -127,10 +127,17 @@ pub fn well_known_symbol(short_name: &str) -> *mut SymbolHeader {
         id: next_id(),
     });
     let sym_ptr = Box::into_raw(boxed);
-    cache.insert(short_name.to_string(), sym_ptr as usize);
-    drop(guard);
+    // Fully initialize the symbol's side tables BEFORE publishing it in
+    // the cache. A concurrent reader that observes the pointer via the
+    // cache must already see a complete view (description present,
+    // is_registered_symbol true) — otherwise `Symbol.description` /
+    // `Symbol.toString()` / `is_symbol` can transiently return wrong
+    // results. Lock order matches `js_symbol_for` below: cache → side
+    // tables, never the reverse.
     record_registered_symbol_description(sym_ptr as usize, short_name);
     register_symbol_pointer(sym_ptr as usize);
+    cache.insert(short_name.to_string(), sym_ptr as usize);
+    drop(guard);
     sym_ptr
 }
 
@@ -326,10 +333,17 @@ pub unsafe extern "C" fn js_symbol_for(key_f64: f64) -> f64 {
         id: next_id(),
     });
     let sym_ptr = Box::into_raw(boxed);
-    registry.insert(key.clone(), sym_ptr as usize);
-    drop(guard);
+    // Fully initialize the side tables BEFORE publishing the pointer in
+    // the registry. Otherwise a concurrent `Symbol.for("same_key")` on
+    // another thread can see the pointer via the registry but get None
+    // from registered_symbol_description, returning a transiently bogus
+    // sym.description / sym.toString() / Symbol.keyFor(). Lock order is
+    // SYMBOL_REGISTRY → SYMBOL_POINTERS → REGISTERED_SYMBOL_DESCRIPTIONS;
+    // no reader takes them in the reverse order.
     record_registered_symbol_description(sym_ptr as usize, &key);
     register_symbol_pointer(sym_ptr as usize);
+    registry.insert(key.clone(), sym_ptr as usize);
+    drop(guard);
     f64::from_bits(POINTER_TAG | (sym_ptr as u64 & POINTER_MASK))
 }
 

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -61,6 +61,34 @@ static SYMBOL_REGISTRY: Mutex<Option<HashMap<String, usize>>> = Mutex::new(None)
 // GcHeader byte.
 static SYMBOL_POINTERS: Mutex<Option<HashSet<usize>>> = Mutex::new(None);
 
+/// Process-lifetime descriptions for registered (`Symbol.for`) and well-known
+/// symbols. These symbols are Box-leaked so they outlive every GC cycle, but
+/// the description StringHeader they used to point at was allocated in the
+/// calling thread's arena — which gets freed when a `perry/thread` worker
+/// exits, leaving the symbol with a dangling description pointer. Storing
+/// the description text here (Rust-owned, process-lifetime) lets readers
+/// materialize a fresh StringHeader in the *caller's* arena on demand, which
+/// is the only thread-safe contract: the symbol identity is global, but
+/// every StringHeader belongs to exactly one thread's arena.
+static REGISTERED_SYMBOL_DESCRIPTIONS: Mutex<Option<HashMap<usize, std::sync::Arc<str>>>> =
+    Mutex::new(None);
+
+pub(crate) fn registered_symbol_description(sym_ptr: usize) -> Option<std::sync::Arc<str>> {
+    let guard = REGISTERED_SYMBOL_DESCRIPTIONS.lock().unwrap();
+    guard.as_ref().and_then(|m| m.get(&sym_ptr).cloned())
+}
+
+fn record_registered_symbol_description(sym_ptr: usize, description: &str) {
+    let mut guard = REGISTERED_SYMBOL_DESCRIPTIONS.lock().unwrap();
+    if guard.is_none() {
+        *guard = Some(HashMap::new());
+    }
+    guard
+        .as_mut()
+        .unwrap()
+        .insert(sym_ptr, std::sync::Arc::from(description));
+}
+
 // Pre-allocated well-known symbols (Symbol.toPrimitive, Symbol.hasInstance,
 // Symbol.toStringTag, Symbol.iterator, Symbol.asyncIterator). Allocated once
 // on first access and cached forever. These are distinct from the
@@ -86,20 +114,22 @@ pub fn well_known_symbol(short_name: &str) -> *mut SymbolHeader {
     if let Some(&ptr_usize) = cache.get(short_name) {
         return ptr_usize as *mut SymbolHeader;
     }
-    // First use: allocate a persistent (leaked) SymbolHeader with the short
-    // name as its description. `registered = 0` so `Symbol.keyFor` returns
-    // undefined.
-    let desc_bytes = short_name.as_bytes();
-    let desc_ptr = js_string_from_bytes(desc_bytes.as_ptr(), desc_bytes.len() as u32);
+    // First use: allocate a persistent (leaked) SymbolHeader. Description is
+    // null-on-the-header — the actual text lives in REGISTERED_SYMBOL_DESCRIPTIONS,
+    // and readers materialize a StringHeader in their own arena on demand. We
+    // can't store a real StringHeader pointer here because this allocation may
+    // be made on a worker thread whose arena will later be torn down, while
+    // the SymbolHeader itself is Box-leaked and outlives that arena.
     let boxed = Box::new(SymbolHeader {
         magic: SYMBOL_MAGIC,
         registered: 0,
-        description: desc_ptr,
+        description: std::ptr::null_mut(),
         id: next_id(),
     });
     let sym_ptr = Box::into_raw(boxed);
     cache.insert(short_name.to_string(), sym_ptr as usize);
     drop(guard);
+    record_registered_symbol_description(sym_ptr as usize, short_name);
     register_symbol_pointer(sym_ptr as usize);
     sym_ptr
 }
@@ -282,20 +312,23 @@ pub unsafe extern "C" fn js_symbol_for(key_f64: f64) -> f64 {
     }
 
     // Not found — allocate a persistent SymbolHeader. We use Box::leak so the
-    // pointer outlives any GC cycle (the registry holds it as a root).
-    // Also leak a persistent StringHeader for the description.
-    let desc_ptr = js_string_from_bytes(key.as_ptr(), key.len() as u32);
-
-    // Create a Box-allocated SymbolHeader (not via gc_malloc) so it survives
-    // forever. Registered symbols must be strong roots.
+    // pointer outlives any GC cycle (the registry holds it as a root). The
+    // description text is stored in REGISTERED_SYMBOL_DESCRIPTIONS as a
+    // process-lifetime Arc<str>; the header's `description` pointer stays
+    // null. Readers (`sym.description`, `sym.toString()`, key_for) consult
+    // the side table and materialize a StringHeader in *their own* arena on
+    // demand, so cross-thread reads are safe even when the originating
+    // worker's arena was torn down.
     let boxed = Box::new(SymbolHeader {
         magic: SYMBOL_MAGIC,
         registered: 1,
-        description: desc_ptr,
+        description: std::ptr::null_mut(),
         id: next_id(),
     });
     let sym_ptr = Box::into_raw(boxed);
-    registry.insert(key, sym_ptr as usize);
+    registry.insert(key.clone(), sym_ptr as usize);
+    drop(guard);
+    record_registered_symbol_description(sym_ptr as usize, &key);
     register_symbol_pointer(sym_ptr as usize);
     f64::from_bits(POINTER_TAG | (sym_ptr as u64 & POINTER_MASK))
 }
@@ -324,6 +357,12 @@ pub unsafe extern "C" fn js_symbol_key_for(sym_f64: f64) -> f64 {
     if (*sym_ptr).registered == 0 {
         return f64::from_bits(TAG_UNDEFINED);
     }
+    // Registered symbols carry the description as Arc<str> in the side
+    // table; materialize a fresh StringHeader in this thread's arena.
+    if let Some(s) = registered_symbol_description(sym_ptr as usize) {
+        let header = js_string_from_bytes(s.as_bytes().as_ptr(), s.as_bytes().len() as u32);
+        return f64::from_bits(STRING_TAG | (header as u64 & POINTER_MASK));
+    }
     let desc = (*sym_ptr).description;
     if desc.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
@@ -347,6 +386,10 @@ pub unsafe extern "C" fn js_symbol_description(sym_f64: f64) -> f64 {
     if (*sym_ptr).magic != SYMBOL_MAGIC {
         return f64::from_bits(TAG_UNDEFINED);
     }
+    if let Some(s) = registered_symbol_description(sym_ptr as usize) {
+        let header = js_string_from_bytes(s.as_bytes().as_ptr(), s.as_bytes().len() as u32);
+        return f64::from_bits(STRING_TAG | (header as u64 & POINTER_MASK));
+    }
     let desc = (*sym_ptr).description;
     if desc.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
@@ -369,7 +412,11 @@ pub unsafe extern "C" fn js_symbol_to_string(sym_f64: f64) -> i64 {
         let s = b"Symbol()";
         return js_string_from_bytes(s.as_ptr(), s.len() as u32) as i64;
     }
-    let desc_str = str_from_header((*sym_ptr).description).unwrap_or_default();
+    let desc_str = if let Some(s) = registered_symbol_description(sym_ptr as usize) {
+        s.as_ref().to_string()
+    } else {
+        str_from_header((*sym_ptr).description).unwrap_or_default()
+    };
     let rendered = format!("Symbol({})", desc_str);
     js_string_from_bytes(rendered.as_ptr(), rendered.len() as u32) as i64
 }
@@ -481,7 +528,11 @@ pub unsafe extern "C" fn js_object_set_symbol_property(
                 let func_ptr = (*closure_ptr).func_ptr;
                 if !func_ptr.is_null() {
                     let sym_ptr = sym_key as *const SymbolHeader;
-                    let desc = str_from_header((*sym_ptr).description).unwrap_or_default();
+                    let desc = registered_symbol_description(sym_ptr as usize)
+                        .map(|s| s.as_ref().to_string())
+                        .unwrap_or_else(|| {
+                            str_from_header((*sym_ptr).description).unwrap_or_default()
+                        });
                     let inferred = format!("[{}]", desc);
                     crate::builtins::register_function_name_if_absent(func_ptr as usize, &inferred);
                 }

--- a/crates/perry-runtime/src/value/dynamic_object.rs
+++ b/crates/perry-runtime/src/value/dynamic_object.rs
@@ -220,7 +220,7 @@ pub unsafe extern "C" fn js_dynamic_object_get_property(
 
     // Check if this is a handle-based object (small integer, not a real heap pointer)
     if ptr < 0x100000 {
-        if let Some(dispatch) = crate::object::HANDLE_PROPERTY_DISPATCH {
+        if let Some(dispatch) = crate::object::handle_property_dispatch() {
             return dispatch(ptr, property_name_ptr as *const u8, property_name_len);
         }
         return f64::from_bits(TAG_UNDEFINED);


### PR DESCRIPTION
## Summary

`perry/thread` workers run user JS code on background OS threads. The runtime exposed several process-wide `static mut`s touched on every allocation, throw, and dispatch — concurrent worker code raced on shared mutable state, and stored arena-local pointers that became use-after-free when the originating thread exited.

This PR partitions the offending state per-thread (or per-process where pointer-identity must be global), with no codegen changes — every `static mut` removed was grep-confirmed unreferenced from `crates/perry-codegen`.

## Before / After

| # | Issue | Before | After |
|---|---|---|---|
| 1 | `INTERN_TABLE` (8K entries) | `static mut`, racy `&mut INTERN_TABLE[slot]` on every property-name allocation; cross-thread reads returned foreign-arena pointers | `thread_local!` UnsafeCell; per-thread GC scanner sees only its own table |
| 2 | `TRANSITION_CACHE_GLOBAL` (16K entries) | Same — raced under concurrent object construction; comment claimed codegen inlined against the `#[no_mangle]` symbol but grep showed zero codegen refs | `thread_local!`; dead `#[no_mangle]` export removed |
| 3 | Exception state (`JUMP_BUFFERS[128]`, `TRY_DEPTH`, `CURRENT_EXCEPTION`, `HAS_EXCEPTION`, `IN_FINALLY`) | 5 process-wide `static mut`s; concurrent `throw`s raced on the depth counter and `longjmp`'d into stack frames that belonged to other threads | Single `ExceptionState` struct in TLS; `js_throw` releases the TLS borrow before `longjmp`; per-thread GC scanner roots `current_exception` |
| 4 | `SMALL_INT_CACHE` (Number→string) | `static mut` of arena pointers; cache populated on thread A handed back invalid pointers on thread B | `thread_local!`; pinned `StringHeader`s per thread |
| 5 | `HANDLE_METHOD_DISPATCH` / `HANDLE_PROPERTY_DISPATCH` / `HANDLE_PROPERTY_SET_DISPATCH` | `static mut Option<fn>` written once at startup, read from many threads without synchronization | `AtomicPtr<()>` with Acquire/Release; safe accessors `handle_method_dispatch()` etc. |
| 6 | `Symbol.for` / well-known symbol descriptions | `Box::leak`'d `SymbolHeader` carried a `*mut StringHeader` allocated in the calling thread's arena; freed when that worker exited, leaving a dangling pointer in the process-lifetime symbol | New `REGISTERED_SYMBOL_DESCRIPTIONS` side table (`HashMap<sym_ptr, Arc<str>>`); readers materialize a fresh `StringHeader` in the caller's arena on demand |
| 7 | `arena::ArenaBlock::alloc` bump arithmetic | Wrapping `+` for `aligned_offset + size`; a hostile `size`/`align` pair could wrap and return an in-bounds pointer for an out-of-bounds region | All bump arithmetic via `checked_add`, matching the slow path that already did this |
| 8 | Closure capture write-barrier ordering | Flagged by the audit; on review, callers store-then-barrier with the value rooted on the Rust stack between the two — the existing pattern is correct | No code change; added a SAFETY comment so future maintainers don't try to "fix" it |

## Test plan

- [x] `cargo build --release -p perry-runtime -p perry-stdlib -p perry` — clean
- [x] `cargo test --release -p perry-runtime --lib` — 450 pass; 5 pre-existing flakes in `event_pump::tests` (timing-sensitive `sustained_budget_zero_spin_is_throttled` poisons the shared `SERIAL` mutex; commit ea6d467a already loosened this test once; grep confirms `event_pump` does not touch any state changed here)
- [x] `./run_parity_tests.sh --filter test_gap_` — 36/37 pass (97.2%); the lone failure is `test_gap_class_advanced`, a known failure listed in `test-parity/known_failures.json` for static-class-block lowering, unrelated to runtime statics

## Notes

- No `Cargo.toml` / `CLAUDE.md` / `CHANGELOG.md` edits — maintainer handles version + changelog at merge.
- No codegen changes; every removed `static mut` was grep-confirmed unreferenced from `crates/perry-codegen`.