### PR TITLE
node:perf_hooks — performance object, User Timing, PerformanceObserver + granular node-suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1023 — feat(ios) #1301 setup --development + fix(compile) #1304 vendored optional_frameworks
+
+Folds two PRs that merged post-v0.5.1022 without version bumps:
+
+- **#1301 / #1302** `feat(ios): perry setup ios --development + on-device
+  dev-sign path` — adds a `--development` flag to `perry setup ios` and an
+  on-device development-signing path so iOS apps can run on physical
+  devices without going through the App Store Connect provisioning flow.
+- **#1304 / #1305** `fix(compile): link vendored optional_frameworks
+  gated on frameworks_env` — `optional_frameworks` from the native
+  manifest are now only linked when the `PERRY_FRAMEWORKS` env var
+  enables them, matching the gating contract the manifest doc spells out.
+
 ## v0.5.1022 — ci(benchmark): refresh binary-size baseline after v0.5.455 → v0.5.1021 release cycle
 
 Regression Check `binary-size` job failed on v0.5.1021 against the old

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1022
+**Current Version:** 0.5.1023
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5134,7 +5134,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "base64",
@@ -5189,14 +5189,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "log",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "base64",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "serde",
  "serde_json",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1022"
+version = "0.5.1023"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "clap",
@@ -5300,14 +5300,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5340,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5348,7 +5348,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "chrono",
  "cron",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5406,14 +5406,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "bson",
  "futures-util",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "base64",
  "image",
@@ -5598,14 +5598,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5632,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "base64",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5835,11 +5835,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1022"
+version = "0.5.1023"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "base64",
  "itoa",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "base64",
  "block2",
@@ -5902,7 +5902,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "base64",
  "block2",
@@ -5921,11 +5921,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1022"
+version = "0.5.1023"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "base64",
  "block2",
@@ -5941,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "base64",
  "block2",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "block2",
  "libc",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "base64",
  "libc",
@@ -5985,7 +5985,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1022"
+version = "0.5.1023"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1022"
+version = "0.5.1023"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -91,6 +91,7 @@ pub const NATIVE_MODULES: &[&str] = &[
     "querystring",
     "cluster",
     "tty",
+    "perf_hooks",
     "process",
     "perry/tui",
     "perry/ui",
@@ -145,6 +146,7 @@ pub const RUNTIME_ONLY_MODULES: &[&str] = &[
     "perry/tui",
     "perry/background",
     "tty",
+    "perf_hooks",
 ];
 
 const fn method(
@@ -2121,6 +2123,36 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("tty", "isatty", false, None),
     class("tty", "ReadStream"),
     class("tty", "WriteStream"),
+    // --- perf_hooks (W3C User Timing on `performance` + PerformanceObserver) ---
+    method("perf_hooks", "now", false, None),
+    method("perf_hooks", "mark", false, None),
+    method("perf_hooks", "measure", false, None),
+    method("perf_hooks", "getEntries", false, None),
+    method("perf_hooks", "getEntriesByName", false, None),
+    method("perf_hooks", "getEntriesByType", false, None),
+    method("perf_hooks", "clearMarks", false, None),
+    method("perf_hooks", "clearMeasures", false, None),
+    method("perf_hooks", "eventLoopUtilization", false, None),
+    property("perf_hooks", "timeOrigin"),
+    property("perf_hooks", "performance"),
+    property("perf_hooks", "constants"),
+    class("perf_hooks", "PerformanceObserver"),
+    class("perf_hooks", "PerformanceEntry"),
+    class("perf_hooks", "PerformanceMark"),
+    class("perf_hooks", "PerformanceMeasure"),
+    method("perf_hooks", "observe", true, Some("PerformanceObserver")),
+    method(
+        "perf_hooks",
+        "disconnect",
+        true,
+        Some("PerformanceObserver"),
+    ),
+    method(
+        "perf_hooks",
+        "takeRecords",
+        true,
+        Some("PerformanceObserver"),
+    ),
     // --- buffer (module-level helpers in addition to the Buffer class
     //     already registered above) ---
     method("buffer", "alloc", false, None),

--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -153,6 +153,22 @@ pub(super) fn lower_builtin_new(
             let handle = blk.call(I64, "js_event_emitter_new", &[]);
             Ok(Some(nanbox_pointer_inline(blk, &handle)))
         }
+        // node:perf_hooks — `new PerformanceObserver(cb)` registers the
+        // observer and returns its `perf_observer` namespace object (already
+        // NaN-boxed). `cb` is passed through so the runtime can invoke it on
+        // flush; absent → undefined.
+        "PerformanceObserver" => {
+            let cb = if let Some(a) = args.first() {
+                lower_expr(ctx, a)?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            Ok(Some(ctx.block().call(
+                DOUBLE,
+                "js_perf_observer_new",
+                &[(DOUBLE, &cb)],
+            )))
+        }
         // string_decoder.StringDecoder — issue #848. `new StringDecoder("utf8")`
         // pre-fix fell through to the generic `js_object_alloc(0, 0)` placeholder,
         // so `dec.write` / `dec.end` were `undefined`. Allocate a real handle

--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -44,6 +44,7 @@ pub(super) use super::{
 
 mod box_style;
 mod jsonwebtoken;
+mod perf_hooks;
 
 use box_style::apply_box_style;
 use jsonwebtoken::{lower_jsonwebtoken_sign, lower_jsonwebtoken_verify};
@@ -112,6 +113,11 @@ pub(crate) fn lower_native_method_call(
     }
     if module == "jsonwebtoken" && method == "verify" && object.is_none() {
         return lower_jsonwebtoken_verify(ctx, args);
+    }
+
+    // node:perf_hooks → native/perf_hooks.rs (performance.* + PerformanceObserver).
+    if let Some(v) = perf_hooks::lower_perf_hooks_method(ctx, module, method, object, args)? {
+        return Ok(v);
     }
 
     // `perry/ui.App({ title, width, height, body, icon? })` — minimum-viable

--- a/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
+++ b/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
@@ -1,0 +1,124 @@
+//! node:perf_hooks codegen lowering — `performance.*` User Timing + ELU and
+//! PerformanceObserver instance methods, dispatched to the `js_perf_*` runtime
+//! helpers. Extracted from `native/mod.rs` to keep that file under the
+//! 2k-LOC gate (`scripts/check_file_size.sh`).
+
+use anyhow::Result;
+use perry_hir::Expr;
+
+use crate::expr::{lower_expr, FnCtx};
+use crate::nanbox::double_literal;
+use crate::types::DOUBLE;
+
+/// Lower a `module == "perf_hooks"` NativeMethodCall. Returns `Ok(Some(value))`
+/// when the (method, receiver) shape is handled, or `Ok(None)` to fall through
+/// to the caller's remaining dispatch.
+pub(super) fn lower_perf_hooks_method(
+    ctx: &mut FnCtx<'_>,
+    module: &str,
+    method: &str,
+    object: Option<&Expr>,
+    args: &[Expr],
+) -> Result<Option<String>> {
+    if module != "perf_hooks" {
+        return Ok(None);
+    }
+
+    // PerformanceObserver instance methods. `obs.observe()` / `.disconnect()` /
+    // `.takeRecords()` lower with `object = Some(obs)` (obs is typed as the
+    // imported class); pass the observer object value through — the runtime
+    // re-derives the registry index from it.
+    if object.is_some() && matches!(method, "observe" | "disconnect" | "takeRecords") {
+        let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+        let obs_val = lower_expr(ctx, object.unwrap())?;
+        let v = match method {
+            "observe" => {
+                let opts = match args.first() {
+                    Some(e) => lower_expr(ctx, e)?,
+                    None => undef,
+                };
+                ctx.block().call(
+                    DOUBLE,
+                    "js_perf_observer_observe",
+                    &[(DOUBLE, &obs_val), (DOUBLE, &opts)],
+                )
+            }
+            "disconnect" => {
+                ctx.block()
+                    .call(DOUBLE, "js_perf_observer_disconnect", &[(DOUBLE, &obs_val)])
+            }
+            _ => ctx.block().call(
+                DOUBLE,
+                "js_perf_observer_take_records",
+                &[(DOUBLE, &obs_val)],
+            ),
+        };
+        return Ok(Some(v));
+    }
+
+    // `performance.*` User Timing + ELU. Statically lowered (HIR
+    // module_static.rs emits the receiver-less NativeMethodCall). All args are
+    // NaN-boxed f64; absent trailing args pass `undefined`.
+    if object.is_none() {
+        let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+        let lower_or_undef = |ctx: &mut FnCtx<'_>, n: usize| -> Result<String> {
+            match args.get(n) {
+                Some(e) => lower_expr(ctx, e),
+                None => Ok(undef.clone()),
+            }
+        };
+        let v = match method {
+            "now" => ctx.block().call(DOUBLE, "js_performance_now", &[]),
+            "getEntries" => ctx.block().call(DOUBLE, "js_perf_get_entries", &[]),
+            "mark" => {
+                let name = lower_or_undef(ctx, 0)?;
+                let opts = lower_or_undef(ctx, 1)?;
+                ctx.block()
+                    .call(DOUBLE, "js_perf_mark", &[(DOUBLE, &name), (DOUBLE, &opts)])
+            }
+            "measure" => {
+                let a0 = lower_or_undef(ctx, 0)?;
+                let a1 = lower_or_undef(ctx, 1)?;
+                let a2 = lower_or_undef(ctx, 2)?;
+                ctx.block().call(
+                    DOUBLE,
+                    "js_perf_measure",
+                    &[(DOUBLE, &a0), (DOUBLE, &a1), (DOUBLE, &a2)],
+                )
+            }
+            "getEntriesByType" => {
+                let a0 = lower_or_undef(ctx, 0)?;
+                ctx.block()
+                    .call(DOUBLE, "js_perf_get_entries_by_type", &[(DOUBLE, &a0)])
+            }
+            "getEntriesByName" => {
+                let a0 = lower_or_undef(ctx, 0)?;
+                let a1 = lower_or_undef(ctx, 1)?;
+                ctx.block().call(
+                    DOUBLE,
+                    "js_perf_get_entries_by_name",
+                    &[(DOUBLE, &a0), (DOUBLE, &a1)],
+                )
+            }
+            "clearMarks" => {
+                let a0 = lower_or_undef(ctx, 0)?;
+                ctx.block()
+                    .call(DOUBLE, "js_perf_clear_marks", &[(DOUBLE, &a0)])
+            }
+            "clearMeasures" => {
+                let a0 = lower_or_undef(ctx, 0)?;
+                ctx.block()
+                    .call(DOUBLE, "js_perf_clear_measures", &[(DOUBLE, &a0)])
+            }
+            "eventLoopUtilization" => {
+                let a0 = lower_or_undef(ctx, 0)?;
+                ctx.block()
+                    .call(DOUBLE, "js_perf_event_loop_utilization", &[(DOUBLE, &a0)])
+            }
+            _ => return Ok(None),
+        };
+        return Ok(Some(v));
+    }
+
+    Ok(None)
+}

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1060,6 +1060,19 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
 
     // ========== Performance ==========
     module.declare_function("js_performance_now", DOUBLE, &[]);
+    // node:perf_hooks User Timing + ELU (perf_hooks.rs). All NaN-boxed f64.
+    module.declare_function("js_perf_mark", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_perf_measure", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function("js_perf_get_entries", DOUBLE, &[]);
+    module.declare_function("js_perf_get_entries_by_type", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_perf_get_entries_by_name", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_perf_clear_marks", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_perf_clear_measures", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_perf_event_loop_utilization", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_perf_observer_new", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_perf_observer_observe", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_perf_observer_disconnect", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_perf_observer_take_records", DOUBLE, &[DOUBLE]);
 
     // ========== Async-step iter-result scratch (perf hot path) ==========
     // See promise.rs::ITER_RESULT_VALUE / ITER_RESULT_DONE — eliminates

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -360,11 +360,37 @@ pub(super) fn try_module_static_methods(
                 }
             }
 
-            // Check for performance.now()
+            // Check for performance.now() and the W3C User Timing methods.
+            // `now()` keeps its dedicated Expr; the rest lower to a
+            // receiver-less NativeMethodCall on the perf_hooks module, which
+            // the codegen dispatches to the `js_perf_*` runtime helpers. This
+            // is purely syntactic (matches the identifier `performance`), so
+            // it fires whether `performance` is the global or the named
+            // import from node:perf_hooks.
             if obj_ident.sym.as_ref() == "performance" {
                 if let ast::MemberProp::Ident(method_ident) = &member.prop {
-                    if method_ident.sym.as_ref() == "now" {
+                    let m = method_ident.sym.as_ref();
+                    if m == "now" {
                         return Ok(Ok(Expr::PerformanceNow));
+                    }
+                    if matches!(
+                        m,
+                        "mark"
+                            | "measure"
+                            | "getEntries"
+                            | "getEntriesByName"
+                            | "getEntriesByType"
+                            | "clearMarks"
+                            | "clearMeasures"
+                            | "eventLoopUtilization"
+                    ) {
+                        return Ok(Ok(Expr::NativeMethodCall {
+                            module: "perf_hooks".to_string(),
+                            class_name: None,
+                            object: None,
+                            method: m.to_string(),
+                            args,
+                        }));
                     }
                 }
             }

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -617,6 +617,7 @@ pub fn gc_init() {
     gc_register_mutable_root_scanner(shape_cache_mutable_root_scanner);
     gc_register_mutable_root_scanner(crate::regex::scan_last_exec_groups_root_mut);
     gc_register_mutable_root_scanner(crate::array::scan_template_raw_roots_mut);
+    gc_register_mutable_root_scanner(crate::perf_hooks::scan_perf_entries_roots_mut);
     gc_register_mutable_root_scanner(transition_cache_mutable_root_scanner);
     gc_register_mutable_root_scanner(overflow_fields_mutable_root_scanner);
     gc_register_mutable_root_scanner(json_parse_mutable_root_scanner);

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -48,6 +48,7 @@ pub mod node_submodules;
 pub mod object;
 pub mod os;
 pub mod path;
+pub mod perf_hooks;
 pub mod process;
 pub mod promise;
 pub mod regex;

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -94,6 +94,17 @@ pub unsafe extern "C" fn js_native_module_property_by_name(
         property_name_len,
     ))
     .unwrap_or("");
+    // node:perf_hooks — `performance` and `constants` are object-valued
+    // exports. Resolve them to a `perf_hooks`-tagged namespace object so
+    // `typeof performance === "object"`, `performance.timeOrigin` (a
+    // constant), `performance.now` (a callable export), and
+    // `constants.NODE_PERFORMANCE_GC_*` (constants) all dispatch coherently.
+    if module_name == "perf_hooks"
+        && (property_name == "performance" || property_name == "constants")
+    {
+        return js_create_native_module_namespace(module_name.as_ptr(), module_name.len());
+    }
+
     if let Some(val) = get_native_module_constant(module_name, property_name, 0.0) {
         return val;
     }
@@ -126,6 +137,19 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
 
     if module_name == "tty" && matches!(property_name, "ReadStream" | "WriteStream") {
         attach_tty_stream_prototype(value, property_name);
+    }
+
+    // `PerformanceObserver.supportedEntryTypes` is a static array on the
+    // constructor. `PerformanceObserver` is a function value (a bound-method
+    // closure), so hang the array off it as a dynamic property — keeps
+    // `typeof PerformanceObserver === "function"` while the static read works.
+    if module_name == "perf_hooks" && property_name == "PerformanceObserver" {
+        let arr = crate::perf_hooks::js_perf_supported_entry_types();
+        crate::closure::closure_set_dynamic_prop(
+            (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize,
+            "supportedEntryTypes",
+            arr,
+        );
     }
 
     NATIVE_CALLABLE_EXPORTS.with(|c| {
@@ -299,6 +323,31 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("os", "loadavg")
             | ("os", "machine")
             | ("os", "version")
+            // node:perf_hooks — the `performance` object's methods, read as
+            // values (`typeof performance.mark === "function"`, `const m =
+            // performance.mark`). The call form is statically lowered in
+            // module_static.rs; this keeps the property-read form coherent.
+            // Also the perf_hooks class exports so `typeof PerformanceObserver
+            // === "function"` etc. hold.
+            | ("perf_hooks", "now")
+            | ("perf_hooks", "mark")
+            | ("perf_hooks", "measure")
+            | ("perf_hooks", "getEntries")
+            | ("perf_hooks", "getEntriesByName")
+            | ("perf_hooks", "getEntriesByType")
+            | ("perf_hooks", "clearMarks")
+            | ("perf_hooks", "clearMeasures")
+            | ("perf_hooks", "eventLoopUtilization")
+            | ("perf_hooks", "PerformanceObserver")
+            | ("perf_hooks", "PerformanceEntry")
+            | ("perf_hooks", "PerformanceMark")
+            | ("perf_hooks", "PerformanceMeasure")
+            | ("perf_observer", "observe")
+            | ("perf_observer", "disconnect")
+            | ("perf_observer", "takeRecords")
+            | ("perf_observer_list", "getEntries")
+            | ("perf_observer_list", "getEntriesByType")
+            | ("perf_observer_list", "getEntriesByName")
             // node:cluster — namespace property reads of these callables
             // need to satisfy `typeof cluster.fork === "function"` etc.
             // The fixtures only probe types, but compiled npm code that
@@ -1040,6 +1089,25 @@ pub(crate) unsafe fn get_native_module_constant(
     };
 
     match module_name {
+        // node:perf_hooks — `performance.timeOrigin` (ms since epoch at start)
+        // and the `constants.NODE_PERFORMANCE_GC_*` numeric table. Both the
+        // `performance` and `constants` objects are tagged "perf_hooks", so
+        // they share this arm (distinct property names, no collision).
+        "perf_hooks" => match property {
+            "timeOrigin" => Some(crate::perf_hooks::time_origin_ms()),
+            "NODE_PERFORMANCE_GC_MAJOR" => Some(4.0),
+            "NODE_PERFORMANCE_GC_MINOR" => Some(1.0),
+            "NODE_PERFORMANCE_GC_INCREMENTAL" => Some(8.0),
+            "NODE_PERFORMANCE_GC_WEAKCB" => Some(16.0),
+            "NODE_PERFORMANCE_GC_FLAGS_NO" => Some(0.0),
+            "NODE_PERFORMANCE_GC_FLAGS_CONSTRUCT_RETAINED" => Some(2.0),
+            "NODE_PERFORMANCE_GC_FLAGS_FORCED" => Some(4.0),
+            "NODE_PERFORMANCE_GC_FLAGS_SYNCHRONOUS_PHANTOM_PROCESSING" => Some(8.0),
+            "NODE_PERFORMANCE_GC_FLAGS_ALL_AVAILABLE_GARBAGE" => Some(16.0),
+            "NODE_PERFORMANCE_GC_FLAGS_ALL_EXTERNAL_MEMORY" => Some(32.0),
+            "NODE_PERFORMANCE_GC_FLAGS_SCHEDULE_IDLE" => Some(64.0),
+            _ => None,
+        },
         "path" => match property {
             "sep" => {
                 if cfg!(windows) {

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -112,6 +112,50 @@ pub(crate) unsafe fn dispatch_native_module_method(
         // ── tty module ──
         ("tty", "isatty") => crate::tty::js_tty_isatty(arg(0)),
 
+        // ── perf_hooks module (performance.*) ──
+        // Statically lowered at call sites (module_static.rs); these arms
+        // also serve the generic namespace-object method-dispatch path.
+        ("perf_hooks", "now") => crate::date::js_performance_now(),
+        ("perf_hooks", "mark") => crate::perf_hooks::js_perf_mark(arg(0), arg(1)),
+        ("perf_hooks", "measure") => crate::perf_hooks::js_perf_measure(arg(0), arg(1), arg(2)),
+        ("perf_hooks", "getEntries") => crate::perf_hooks::js_perf_get_entries(),
+        ("perf_hooks", "getEntriesByType") => {
+            crate::perf_hooks::js_perf_get_entries_by_type(arg(0))
+        }
+        ("perf_hooks", "getEntriesByName") => {
+            crate::perf_hooks::js_perf_get_entries_by_name(arg(0), arg(1))
+        }
+        ("perf_hooks", "clearMarks") => crate::perf_hooks::js_perf_clear_marks(arg(0)),
+        ("perf_hooks", "clearMeasures") => crate::perf_hooks::js_perf_clear_measures(arg(0)),
+        ("perf_hooks", "eventLoopUtilization") => {
+            crate::perf_hooks::js_perf_event_loop_utilization(arg(0))
+        }
+
+        // ── PerformanceObserver instance (perf_observer) ──
+        // The registry index lives in field[1] of the namespace object; the
+        // runtime fns re-derive it from the object value.
+        ("perf_observer", "observe") => {
+            let obs_val = crate::value::js_nanbox_pointer(obj as i64);
+            crate::perf_hooks::js_perf_observer_observe(obs_val, arg(0))
+        }
+        ("perf_observer", "disconnect") => {
+            let obs_val = crate::value::js_nanbox_pointer(obj as i64);
+            crate::perf_hooks::js_perf_observer_disconnect(obs_val)
+        }
+        ("perf_observer", "takeRecords") => {
+            let obs_val = crate::value::js_nanbox_pointer(obj as i64);
+            crate::perf_hooks::js_perf_observer_take_records(obs_val)
+        }
+
+        // ── PerformanceObserverEntryList (the callback `list` arg) ──
+        ("perf_observer_list", "getEntries") => crate::perf_hooks::current_list_get_entries(),
+        ("perf_observer_list", "getEntriesByType") => {
+            crate::perf_hooks::current_list_get_by_type(arg(0))
+        }
+        ("perf_observer_list", "getEntriesByName") => {
+            crate::perf_hooks::current_list_get_by_name(arg(0))
+        }
+
         // ── timers module ──
         ("timers", "setTimeout") if args_len >= 2 => {
             let cb = arg(0);

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -1,0 +1,730 @@
+//! node:perf_hooks runtime support — W3C User Timing (`performance.mark` /
+//! `performance.measure` + the timeline query/clear methods),
+//! `performance.timeOrigin`, and `performance.eventLoopUtilization`.
+//!
+//! `performance` is bound (in HIR lowering) to a native-module namespace
+//! object tagged `"perf_hooks"`, so:
+//!   * `typeof performance` → "object"
+//!   * `performance.mark(...)` / `.measure(...)` / `.getEntries*` / `.clear*`
+//!     dispatch here via `dispatch_native_module_method`
+//!   * `performance.now` / `.mark` / … read as values resolve to bound-method
+//!     closures (`is_native_module_callable_export`)
+//!   * `performance.timeOrigin` resolves via `get_native_module_constant`
+//!
+//! The timeline is a per-thread `Vec<PerfEntry>`. Mark/Measure result objects
+//! are plain shaped objects with the Node fields
+//! `{ name, entryType, startTime, duration, detail }`. The `detail` slot can
+//! hold an arbitrary heap JSValue, so the store is registered as a GC root
+//! scanner (`scan_perf_entries_roots_mut`).
+
+use crate::object::{js_object_alloc_with_shape, js_object_get_field_by_name, js_object_set_field};
+use crate::string::StringHeader;
+use crate::value::JSValue;
+use std::cell::{Cell, RefCell};
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const ENTRY_TYPE_MARK: u8 = 0;
+const ENTRY_TYPE_MEASURE: u8 = 1;
+
+/// Shape id for the `{ name, entryType, startTime, duration, detail }` object
+/// returned by mark/measure and the getEntries* arrays.
+const PERF_ENTRY_SHAPE: u32 = 0x7FFF_FF40;
+const PERF_ENTRY_KEYS: &[u8] = b"name\0entryType\0startTime\0duration\0detail\0";
+
+/// Shape id for the `{ idle, active, utilization }` eventLoopUtilization object.
+const ELU_SHAPE: u32 = 0x7FFF_FF41;
+const ELU_KEYS: &[u8] = b"idle\0active\0utilization\0";
+
+#[derive(Clone)]
+struct PerfEntry {
+    name: String,
+    entry_type: u8,
+    start_time: f64,
+    duration: f64,
+    /// NaN-boxed JSValue bits of the entry's `detail` (defaults to `null`).
+    detail_bits: u64,
+}
+
+thread_local! {
+    static PERF_ENTRIES: RefCell<Vec<PerfEntry>> = const { RefCell::new(Vec::new()) };
+}
+
+/// `performance.timeOrigin` — ms since the Unix epoch captured at first read.
+/// Node fixes this at process start; capturing it lazily (process-global via
+/// `OnceLock`) is close enough and is always a positive number.
+static TIME_ORIGIN_MS: OnceLock<f64> = OnceLock::new();
+
+pub(crate) fn time_origin_ms() -> f64 {
+    *TIME_ORIGIN_MS.get_or_init(|| {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs_f64() * 1000.0)
+            .unwrap_or(0.0)
+    })
+}
+
+/// Read a `*StringHeader` into an owned `String`.
+unsafe fn header_to_string(p: *const StringHeader) -> String {
+    if p.is_null() {
+        return String::new();
+    }
+    let len = (*p).byte_len as usize;
+    let data = (p as *const u8).add(std::mem::size_of::<StringHeader>());
+    std::str::from_utf8(std::slice::from_raw_parts(data, len))
+        .unwrap_or("")
+        .to_string()
+}
+
+/// JS string-coerce an arg (`${value}`) into an owned `String`.
+unsafe fn coerce_to_string(value: f64) -> String {
+    let ptr = crate::builtins::js_string_coerce(value);
+    header_to_string(ptr)
+}
+
+/// Read a JS value as an f64 if it is numeric, accepting both the int32 and
+/// double NaN-box representations (`is_number()` alone misses int32 since
+/// INT32_TAG falls inside the tagged range). Returns `None` otherwise.
+fn num_of(v: JSValue) -> Option<f64> {
+    if v.is_int32() {
+        Some(v.as_int32() as f64)
+    } else if v.is_number() {
+        Some(v.as_number())
+    } else {
+        None
+    }
+}
+
+/// Build a NaN-boxed string value from a Rust `&str`.
+fn str_value(s: &str) -> JSValue {
+    let ptr = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+    JSValue::string_ptr(ptr)
+}
+
+/// Materialize a `PerfEntry` into a `{ name, entryType, startTime, duration,
+/// detail }` JS object and return its NaN-boxed pointer bits.
+unsafe fn entry_to_object(e: &PerfEntry) -> f64 {
+    let obj = js_object_alloc_with_shape(
+        PERF_ENTRY_SHAPE,
+        5,
+        PERF_ENTRY_KEYS.as_ptr(),
+        PERF_ENTRY_KEYS.len() as u32,
+    );
+    let type_str = if e.entry_type == ENTRY_TYPE_MEASURE {
+        "measure"
+    } else {
+        "mark"
+    };
+    js_object_set_field(obj, 0, str_value(&e.name));
+    js_object_set_field(obj, 1, str_value(type_str));
+    js_object_set_field(obj, 2, JSValue::number(e.start_time));
+    js_object_set_field(obj, 3, JSValue::number(e.duration));
+    js_object_set_field(obj, 4, JSValue::from_bits(e.detail_bits));
+    crate::value::js_nanbox_pointer(obj as i64)
+}
+
+/// `performance.now()` reading used for default mark startTimes / measure
+/// endpoints. Mirrors `js_performance_now` (ms since epoch); the absolute
+/// origin is irrelevant to User Timing arithmetic since marks share it.
+fn perf_now() -> f64 {
+    crate::date::js_performance_now()
+}
+
+/// Read an option field that may be a number or a mark-name string and
+/// resolve it to a timeline value. Returns `None` when the field is absent
+/// (undefined). Strings resolve to the most-recent same-named mark's
+/// startTime (0 if not found, matching nothing-thrown lenient behavior).
+unsafe fn resolve_option_endpoint(
+    options_obj: *const crate::object::ObjectHeader,
+    key: &str,
+) -> Option<f64> {
+    let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+    let v = js_object_get_field_by_name(options_obj, key_ptr);
+    if v.is_undefined() {
+        return None;
+    }
+    Some(resolve_endpoint_value(v))
+}
+
+unsafe fn resolve_endpoint_value(v: JSValue) -> f64 {
+    if let Some(n) = num_of(v) {
+        n
+    } else if v.is_string() {
+        let name = header_to_string(v.as_string_ptr());
+        lookup_mark_start(&name).unwrap_or(0.0)
+    } else {
+        0.0
+    }
+}
+
+/// Most-recent mark startTime for `name`, if any.
+fn lookup_mark_start(name: &str) -> Option<f64> {
+    PERF_ENTRIES.with(|store| {
+        store
+            .borrow()
+            .iter()
+            .rev()
+            .find(|e| e.entry_type == ENTRY_TYPE_MARK && e.name == name)
+            .map(|e| e.start_time)
+    })
+}
+
+unsafe fn option_number(options_obj: *const crate::object::ObjectHeader, key: &str) -> Option<f64> {
+    let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+    num_of(js_object_get_field_by_name(options_obj, key_ptr))
+}
+
+unsafe fn option_present(options_obj: *const crate::object::ObjectHeader, key: &str) -> bool {
+    let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+    !js_object_get_field_by_name(options_obj, key_ptr).is_undefined()
+}
+
+unsafe fn option_detail_bits(options_obj: *const crate::object::ObjectHeader) -> u64 {
+    let key = b"detail";
+    let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+    let v = js_object_get_field_by_name(options_obj, key_ptr);
+    if v.is_undefined() {
+        JSValue::null().bits()
+    } else {
+        v.bits()
+    }
+}
+
+fn as_object_ptr(v: f64) -> Option<*const crate::object::ObjectHeader> {
+    let jv = JSValue::from_bits(v.to_bits());
+    if jv.is_pointer() {
+        Some(jv.as_pointer::<crate::object::ObjectHeader>() as *const _)
+    } else {
+        None
+    }
+}
+
+// ── performance.mark(name, options?) ─────────────────────────────────────────
+/// Returns a PerformanceMark object and appends it to the timeline.
+#[no_mangle]
+pub extern "C" fn js_perf_mark(name_val: f64, options_val: f64) -> f64 {
+    unsafe {
+        let name = coerce_to_string(name_val);
+        let mut start_time = perf_now();
+        let mut detail_bits = JSValue::null().bits();
+        if let Some(opts) = as_object_ptr(options_val) {
+            if let Some(st) = option_number(opts, "startTime") {
+                start_time = st;
+            }
+            detail_bits = option_detail_bits(opts);
+        }
+        let entry = PerfEntry {
+            name,
+            entry_type: ENTRY_TYPE_MARK,
+            start_time,
+            duration: 0.0,
+            detail_bits,
+        };
+        let obj = entry_to_object(&entry);
+        notify_observers(&entry);
+        PERF_ENTRIES.with(|store| store.borrow_mut().push(entry));
+        obj
+    }
+}
+
+// ── performance.measure(name, startOrOptions?, end?) ─────────────────────────
+/// Computes startTime/duration from positional marks or an options object,
+/// appends a PerformanceMeasure to the timeline, and returns it.
+#[no_mangle]
+pub extern "C" fn js_perf_measure(name_val: f64, arg2: f64, arg3: f64) -> f64 {
+    unsafe {
+        let name = coerce_to_string(name_val);
+        let arg2_jv = JSValue::from_bits(arg2.to_bits());
+
+        let (start_time, duration);
+        if let Some(opts) = as_object_ptr(arg2) {
+            // Options form: { start?, end?, duration?, detail? }
+            let start_present = option_present(opts, "start");
+            let end_present = option_present(opts, "end");
+            let dur = option_number(opts, "duration");
+
+            let start_resolved = resolve_option_endpoint(opts, "start");
+            let end_resolved = resolve_option_endpoint(opts, "end");
+
+            let end = if end_present {
+                end_resolved.unwrap_or(0.0)
+            } else if let (Some(d), Some(s)) = (dur, start_resolved) {
+                s + d
+            } else {
+                perf_now()
+            };
+            let start = if start_present {
+                start_resolved.unwrap_or(0.0)
+            } else if let Some(d) = dur {
+                if end_present {
+                    end - d
+                } else {
+                    0.0
+                }
+            } else {
+                0.0
+            };
+            start_time = start;
+            duration = dur.unwrap_or(end - start);
+
+            let detail_bits = option_detail_bits(opts);
+            return finish_measure(name, start_time, duration, detail_bits);
+        } else if arg2_jv.is_string() {
+            // Positional form: measure(name, startMark, endMark?)
+            let start = resolve_endpoint_value(arg2_jv);
+            let arg3_jv = JSValue::from_bits(arg3.to_bits());
+            let end = if arg3_jv.is_string() || arg3_jv.is_number() {
+                resolve_endpoint_value(arg3_jv)
+            } else {
+                perf_now()
+            };
+            start_time = start;
+            duration = end - start;
+        } else {
+            // measure(name) — from time origin (0) to now.
+            start_time = 0.0;
+            duration = perf_now();
+        }
+
+        finish_measure(name, start_time, duration, JSValue::null().bits())
+    }
+}
+
+unsafe fn finish_measure(name: String, start_time: f64, duration: f64, detail_bits: u64) -> f64 {
+    let entry = PerfEntry {
+        name,
+        entry_type: ENTRY_TYPE_MEASURE,
+        start_time,
+        duration,
+        detail_bits,
+    };
+    let obj = entry_to_object(&entry);
+    notify_observers(&entry);
+    PERF_ENTRIES.with(|store| store.borrow_mut().push(entry));
+    obj
+}
+
+// ── getEntries / getEntriesByType / getEntriesByName ─────────────────────────
+unsafe fn entries_to_array(filter: impl Fn(&PerfEntry) -> bool) -> f64 {
+    let snapshot: Vec<PerfEntry> = PERF_ENTRIES.with(|store| {
+        store
+            .borrow()
+            .iter()
+            .filter(|e| filter(e))
+            .cloned()
+            .collect()
+    });
+    let mut arr = crate::array::js_array_alloc(snapshot.len() as u32);
+    for e in &snapshot {
+        let obj = entry_to_object(e);
+        arr = crate::array::js_array_push(arr, JSValue::from_bits(obj.to_bits()));
+    }
+    crate::value::js_nanbox_pointer(arr as i64)
+}
+
+#[no_mangle]
+pub extern "C" fn js_perf_get_entries() -> f64 {
+    unsafe { entries_to_array(|_| true) }
+}
+
+#[no_mangle]
+pub extern "C" fn js_perf_get_entries_by_type(type_val: f64) -> f64 {
+    unsafe {
+        let want = coerce_to_string(type_val);
+        let want_type = if want == "measure" {
+            ENTRY_TYPE_MEASURE
+        } else {
+            ENTRY_TYPE_MARK
+        };
+        // Only "mark"/"measure" are tracked; an unknown type yields [].
+        if want != "mark" && want != "measure" {
+            return entries_to_array(|_| false);
+        }
+        entries_to_array(move |e| e.entry_type == want_type)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_perf_get_entries_by_name(name_val: f64, type_val: f64) -> f64 {
+    unsafe {
+        let want_name = coerce_to_string(name_val);
+        let type_jv = JSValue::from_bits(type_val.to_bits());
+        let want_type: Option<u8> = if type_jv.is_string() {
+            match header_to_string(type_jv.as_string_ptr()).as_str() {
+                "mark" => Some(ENTRY_TYPE_MARK),
+                "measure" => Some(ENTRY_TYPE_MEASURE),
+                _ => Some(255),
+            }
+        } else {
+            None
+        };
+        entries_to_array(move |e| {
+            e.name == want_name && want_type.map(|t| t == e.entry_type).unwrap_or(true)
+        })
+    }
+}
+
+// ── clearMarks / clearMeasures ───────────────────────────────────────────────
+// `clearMarks()` / `clearMarks(undefined)` clear all marks; `clearMarks(name)`
+// clears only same-named marks (Node parity). Return `undefined`.
+unsafe fn clear_entries(entry_type: u8, name_val: f64) -> f64 {
+    let name = if JSValue::from_bits(name_val.to_bits()).is_undefined() {
+        None
+    } else {
+        Some(coerce_to_string(name_val))
+    };
+    PERF_ENTRIES.with(|store| {
+        store.borrow_mut().retain(|e| {
+            if e.entry_type != entry_type {
+                return true;
+            }
+            match &name {
+                Some(n) => &e.name != n,
+                None => false,
+            }
+        });
+    });
+    f64::from_bits(JSValue::undefined().bits())
+}
+
+#[no_mangle]
+pub extern "C" fn js_perf_clear_marks(name_val: f64) -> f64 {
+    unsafe { clear_entries(ENTRY_TYPE_MARK, name_val) }
+}
+
+#[no_mangle]
+pub extern "C" fn js_perf_clear_measures(name_val: f64) -> f64 {
+    unsafe { clear_entries(ENTRY_TYPE_MEASURE, name_val) }
+}
+
+// ── eventLoopUtilization ─────────────────────────────────────────────────────
+// Perry has no libuv event loop to instrument, so report a stable cumulative
+// idle/active split anchored to wall-clock since timeOrigin. The result keeps
+// Node's object shape and the diff form's utilization in [0, 1].
+fn cumulative_idle_active() -> (f64, f64) {
+    let elapsed = (perf_now() - time_origin_ms()).max(0.0);
+    let active = elapsed * 0.05;
+    let idle = elapsed - active;
+    (idle, active)
+}
+
+unsafe fn make_elu_object(idle: f64, active: f64) -> f64 {
+    let util = if idle + active > 0.0 {
+        active / (idle + active)
+    } else {
+        0.0
+    };
+    let obj = js_object_alloc_with_shape(ELU_SHAPE, 3, ELU_KEYS.as_ptr(), ELU_KEYS.len() as u32);
+    js_object_set_field(obj, 0, JSValue::number(idle));
+    js_object_set_field(obj, 1, JSValue::number(active));
+    js_object_set_field(obj, 2, JSValue::number(util));
+    crate::value::js_nanbox_pointer(obj as i64)
+}
+
+#[no_mangle]
+pub extern "C" fn js_perf_event_loop_utilization(prev: f64) -> f64 {
+    unsafe {
+        let (idle, active) = cumulative_idle_active();
+        if !JSValue::from_bits(prev.to_bits()).is_undefined() {
+            if let Some(prev_obj) = as_object_ptr(prev) {
+                let pk = |k: &[u8]| -> f64 {
+                    let kp = crate::string::js_string_from_bytes(k.as_ptr(), k.len() as u32);
+                    num_of(js_object_get_field_by_name(prev_obj, kp)).unwrap_or(0.0)
+                };
+                let pidle = pk(b"idle");
+                let pactive = pk(b"active");
+                return make_elu_object((idle - pidle).max(0.0), (active - pactive).max(0.0));
+            }
+        }
+        make_elu_object(idle, active)
+    }
+}
+
+// ── PerformanceObserver ──────────────────────────────────────────────────────
+// Observers are stored in a per-thread registry; the JS-visible observer
+// object is a `perf_observer`-tagged native-module namespace object whose
+// field[1] holds the registry index (so `obs.observe(...)` /
+// `obs.disconnect()` / `obs.takeRecords()` route through
+// `dispatch_native_module_method` like any namespace method). Buffered
+// entries are delivered to the callback asynchronously: a single
+// `setTimeout(flush, 0)` is scheduled the first time any observer buffers an
+// entry, and the flush builds a `perf_observer_list`-tagged list object and
+// invokes each callback with it. This matches Node's "queued, delivered on a
+// later turn" semantics closely enough for User Timing.
+
+struct Observer {
+    cb_bits: u64,
+    entry_types: Vec<u8>,
+    pending: Vec<PerfEntry>,
+    active: bool,
+}
+
+thread_local! {
+    static OBSERVERS: RefCell<Vec<Observer>> = const { RefCell::new(Vec::new()) };
+    static FLUSH_SCHEDULED: Cell<bool> = const { Cell::new(false) };
+    /// Entries exposed to the observer callback's `list` arg during a flush.
+    static CURRENT_LIST: RefCell<Vec<PerfEntry>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Build the `perf_observer` namespace object carrying the registry index.
+unsafe fn make_observer_object(id: usize) -> f64 {
+    let obj = crate::object::js_object_alloc(crate::object::NATIVE_MODULE_CLASS_ID, 2);
+    let module = b"perf_observer";
+    let mname = crate::string::js_string_from_bytes(module.as_ptr(), module.len() as u32);
+    js_object_set_field(obj, 0, JSValue::string_ptr(mname));
+    js_object_set_field(obj, 1, JSValue::number(id as f64));
+    let mut keys = crate::array::js_array_alloc(2);
+    for k in [b"__module__".as_slice(), b"__observer_id__".as_slice()] {
+        let kp = crate::string::js_string_from_bytes(k.as_ptr(), k.len() as u32);
+        keys = crate::array::js_array_push(keys, JSValue::string_ptr(kp));
+    }
+    crate::object::js_object_set_keys(obj, keys);
+    crate::value::js_nanbox_pointer(obj as i64)
+}
+
+/// `new PerformanceObserver(callback)` — register the observer and return its
+/// namespace object.
+#[no_mangle]
+pub extern "C" fn js_perf_observer_new(cb: f64) -> f64 {
+    unsafe {
+        let id = OBSERVERS.with(|o| {
+            let mut o = o.borrow_mut();
+            o.push(Observer {
+                cb_bits: cb.to_bits(),
+                entry_types: Vec::new(),
+                pending: Vec::new(),
+                active: false,
+            });
+            o.len() - 1
+        });
+        make_observer_object(id)
+    }
+}
+
+fn entry_type_code(name: &str) -> Option<u8> {
+    match name {
+        "mark" => Some(ENTRY_TYPE_MARK),
+        "measure" => Some(ENTRY_TYPE_MEASURE),
+        _ => None,
+    }
+}
+
+/// Read the registry index out of a `perf_observer` namespace object value's
+/// field[1].
+pub fn observer_id_from_value(obs_val: f64) -> usize {
+    unsafe {
+        match as_object_ptr(obs_val) {
+            Some(obj) => {
+                observer_id_from_field(crate::object::js_object_get_field(obj as *mut _, 1))
+            }
+            None => 0,
+        }
+    }
+}
+
+/// `observer.observe({ entryTypes: [...] } | { type: "..." })`. `obs_val` is the
+/// `perf_observer` namespace object.
+#[no_mangle]
+pub extern "C" fn js_perf_observer_observe(obs_val: f64, opts: f64) -> f64 {
+    unsafe {
+        let id = observer_id_from_value(obs_val);
+        let mut types: Vec<u8> = Vec::new();
+        if let Some(opts_obj) = as_object_ptr(opts) {
+            // entryTypes: string[]
+            let key = b"entryTypes";
+            let kp = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+            let arr_v = js_object_get_field_by_name(opts_obj, kp);
+            if arr_v.is_pointer() {
+                let arr = arr_v.as_pointer::<crate::array::ArrayHeader>();
+                let len = crate::array::js_array_length(arr);
+                for i in 0..len {
+                    let el = crate::array::js_array_get(arr, i);
+                    if el.is_string() {
+                        if let Some(code) = entry_type_code(&header_to_string(el.as_string_ptr())) {
+                            types.push(code);
+                        }
+                    }
+                }
+            }
+            // type: string (single-type form)
+            let tkey = b"type";
+            let tkp = crate::string::js_string_from_bytes(tkey.as_ptr(), tkey.len() as u32);
+            let t_v = js_object_get_field_by_name(opts_obj, tkp);
+            if t_v.is_string() {
+                if let Some(code) = entry_type_code(&header_to_string(t_v.as_string_ptr())) {
+                    types.push(code);
+                }
+            }
+        }
+        OBSERVERS.with(|o| {
+            if let Some(obs) = o.borrow_mut().get_mut(id) {
+                obs.entry_types = types;
+                obs.active = true;
+            }
+        });
+        f64::from_bits(JSValue::undefined().bits())
+    }
+}
+
+/// `observer.disconnect()`.
+#[no_mangle]
+pub extern "C" fn js_perf_observer_disconnect(obs_val: f64) -> f64 {
+    let id = observer_id_from_value(obs_val);
+    OBSERVERS.with(|o| {
+        if let Some(obs) = o.borrow_mut().get_mut(id) {
+            obs.active = false;
+            obs.pending.clear();
+        }
+    });
+    f64::from_bits(JSValue::undefined().bits())
+}
+
+/// `observer.takeRecords()` — drain + return the observer's buffered entries.
+#[no_mangle]
+pub extern "C" fn js_perf_observer_take_records(obs_val: f64) -> f64 {
+    unsafe {
+        let id = observer_id_from_value(obs_val);
+        let entries: Vec<PerfEntry> = OBSERVERS.with(|o| {
+            o.borrow_mut()
+                .get_mut(id)
+                .map(|obs| std::mem::take(&mut obs.pending))
+                .unwrap_or_default()
+        });
+        let mut arr = crate::array::js_array_alloc(entries.len() as u32);
+        for e in &entries {
+            let obj = entry_to_object(e);
+            arr = crate::array::js_array_push(arr, JSValue::from_bits(obj.to_bits()));
+        }
+        crate::value::js_nanbox_pointer(arr as i64)
+    }
+}
+
+/// Read the registry index out of a `perf_observer` namespace object's field[1].
+pub fn observer_id_from_field(v: JSValue) -> usize {
+    num_of(v).map(|n| n as usize).unwrap_or(0)
+}
+
+/// Buffer an entry into every active observer that subscribes to its type and
+/// arm a single async flush.
+fn notify_observers(entry: &PerfEntry) {
+    let mut any = false;
+    OBSERVERS.with(|o| {
+        for obs in o.borrow_mut().iter_mut() {
+            if obs.active && obs.entry_types.contains(&entry.entry_type) {
+                obs.pending.push(entry.clone());
+                any = true;
+            }
+        }
+    });
+    if any {
+        schedule_flush();
+    }
+}
+
+fn schedule_flush() {
+    if FLUSH_SCHEDULED.with(|f| f.get()) {
+        return;
+    }
+    FLUSH_SCHEDULED.with(|f| f.set(true));
+    unsafe {
+        let closure =
+            crate::closure::js_closure_alloc_singleton(js_perf_observer_flush_all as *const u8);
+        crate::timer::js_set_timeout_callback(closure as i64, 0.0);
+    }
+}
+
+/// Timer callback: deliver each observer's buffered entries via its callback.
+#[no_mangle]
+pub extern "C" fn js_perf_observer_flush_all(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    FLUSH_SCHEDULED.with(|f| f.set(false));
+    let work: Vec<(u64, Vec<PerfEntry>)> = OBSERVERS.with(|o| {
+        o.borrow_mut()
+            .iter_mut()
+            .filter(|obs| obs.active && !obs.pending.is_empty())
+            .map(|obs| (obs.cb_bits, std::mem::take(&mut obs.pending)))
+            .collect()
+    });
+    for (cb_bits, entries) in work {
+        unsafe {
+            CURRENT_LIST.with(|c| *c.borrow_mut() = entries);
+            let module = b"perf_observer_list";
+            let list =
+                crate::object::js_create_native_module_namespace(module.as_ptr(), module.len());
+            let cb_jv = JSValue::from_bits(cb_bits);
+            if cb_jv.is_pointer() {
+                let cb_closure = cb_jv.as_pointer::<crate::closure::ClosureHeader>();
+                crate::closure::js_closure_call1(cb_closure, list);
+            }
+            CURRENT_LIST.with(|c| c.borrow_mut().clear());
+        }
+    }
+    f64::from_bits(JSValue::undefined().bits())
+}
+
+/// Build an array from the in-flight observer `list` entries (for the
+/// `perf_observer_list` namespace methods).
+pub unsafe fn current_list_to_array(filter: impl Fn(&PerfEntry) -> bool) -> f64 {
+    let snapshot: Vec<PerfEntry> =
+        CURRENT_LIST.with(|c| c.borrow().iter().filter(|e| filter(e)).cloned().collect());
+    let mut arr = crate::array::js_array_alloc(snapshot.len() as u32);
+    for e in &snapshot {
+        let obj = entry_to_object(e);
+        arr = crate::array::js_array_push(arr, JSValue::from_bits(obj.to_bits()));
+    }
+    crate::value::js_nanbox_pointer(arr as i64)
+}
+
+pub unsafe fn current_list_get_entries() -> f64 {
+    current_list_to_array(|_| true)
+}
+
+pub unsafe fn current_list_get_by_type(type_val: f64) -> f64 {
+    let want = coerce_to_string(type_val);
+    match entry_type_code(&want) {
+        Some(code) => current_list_to_array(move |e| e.entry_type == code),
+        None => current_list_to_array(|_| false),
+    }
+}
+
+pub unsafe fn current_list_get_by_name(name_val: f64) -> f64 {
+    let want = coerce_to_string(name_val);
+    current_list_to_array(move |e| e.name == want)
+}
+
+/// Build the `PerformanceObserver.supportedEntryTypes` array.
+#[no_mangle]
+pub extern "C" fn js_perf_supported_entry_types() -> f64 {
+    unsafe {
+        let mut arr = crate::array::js_array_alloc(2);
+        for t in ["mark", "measure"] {
+            arr = crate::array::js_array_push(arr, str_value(t));
+        }
+        crate::value::js_nanbox_pointer(arr as i64)
+    }
+}
+
+// ── GC root scanner ──────────────────────────────────────────────────────────
+/// Keep `detail` JSValues stored in the timeline + observer buffers, and the
+/// observer callbacks, alive across GC.
+pub fn scan_perf_entries_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    PERF_ENTRIES.with(|store| {
+        for e in store.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_u64_slot(&mut e.detail_bits);
+        }
+    });
+    OBSERVERS.with(|o| {
+        for obs in o.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_u64_slot(&mut obs.cb_bits);
+            for e in obs.pending.iter_mut() {
+                visitor.visit_nanbox_u64_slot(&mut e.detail_bits);
+            }
+        }
+    });
+    CURRENT_LIST.with(|c| {
+        for e in c.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_u64_slot(&mut e.detail_bits);
+        }
+    });
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1067 entries across 79 modules
+// Coverage: 1086 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -821,6 +821,41 @@ declare module "path" {
   export function resolve(...args: any[]): any;
   /** stdlib */
   export function toNamespacedPath(...args: any[]): any;
+}
+
+declare module "perf_hooks" {
+  /** stdlib */
+  export class PerformanceEntry { [key: string]: any; }
+  /** stdlib */
+  export class PerformanceMark { [key: string]: any; }
+  /** stdlib */
+  export class PerformanceMeasure { [key: string]: any; }
+  /** stdlib */
+  export class PerformanceObserver { [key: string]: any; }
+  /** stdlib */
+  export const constants: any;
+  /** stdlib */
+  export const performance: any;
+  /** stdlib */
+  export const timeOrigin: any;
+  /** stdlib */
+  export function clearMarks(...args: any[]): any;
+  /** stdlib */
+  export function clearMeasures(...args: any[]): any;
+  /** stdlib */
+  export function eventLoopUtilization(...args: any[]): any;
+  /** stdlib */
+  export function getEntries(...args: any[]): any;
+  /** stdlib */
+  export function getEntriesByName(...args: any[]): any;
+  /** stdlib */
+  export function getEntriesByType(...args: any[]): any;
+  /** stdlib */
+  export function mark(...args: any[]): any;
+  /** stdlib */
+  export function measure(...args: any[]): any;
+  /** stdlib */
+  export function now(...args: any[]): any;
 }
 
 declare module "perry/ads" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1067 entries across 79 modules.
+Total: 1086 entries across 80 modules.
 
 ## Modules
 
@@ -52,6 +52,7 @@ Total: 1067 entries across 79 modules.
 - [`nodemailer`](#nodemailer)
 - [`os`](#os)
 - [`path`](#path)
+- [`perf_hooks`](#perf-hooks)
 - [`perry/ads`](#perry-ads)
 - [`perry/background`](#perry-background)
 - [`perry/i18n`](#perry-i18n)
@@ -1012,6 +1013,36 @@ Total: 1067 entries across 79 modules.
 - `posix`
 - `sep`
 - `win32`
+
+## `perf_hooks`
+
+### Classes
+
+- `PerformanceEntry`
+- `PerformanceMark`
+- `PerformanceMeasure`
+- `PerformanceObserver`
+
+### Methods
+
+- `clearMarks` — module
+- `clearMeasures` — module
+- `disconnect` — instance *(class: `PerformanceObserver`)*
+- `eventLoopUtilization` — module
+- `getEntries` — module
+- `getEntriesByName` — module
+- `getEntriesByType` — module
+- `mark` — module
+- `measure` — module
+- `now` — module
+- `observe` — instance *(class: `PerformanceObserver`)*
+- `takeRecords` — instance *(class: `PerformanceObserver`)*
+
+### Properties
+
+- `constants`
+- `performance`
+- `timeOrigin`
 
 ## `perry/ads`
 

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -8,6 +8,12 @@
       "reason": "Free-text explanation. Keep the most-actionable signal first \u2014 what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
+  "node-suite/perf_hooks/observer/entry-types": {
+    "issue": "1320",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:perf_hooks granular parity: typeof obs.observe/disconnect/takeRecords reports the wrong type because member reads on a native-class instance lower as a method call (not a PropertyGet). The call forms work (observe-marks PASSES). Flips to PASS when #1320 lands."
+  },
   "node-suite/console/dir/depth-options": {
     "issue": "1199",
     "added": "2026-05-20",

--- a/test-parity/node-suite/perf_hooks/clear/clear-marks.ts
+++ b/test-parity/node-suite/perf_hooks/clear/clear-marks.ts
@@ -1,0 +1,9 @@
+import { performance } from "node:perf_hooks";
+// clearMarks() removes mark entries; clearMarks(name) removes just that mark.
+performance.mark("a");
+performance.mark("b");
+console.log("before:", performance.getEntriesByType("mark").length);
+performance.clearMarks("a");
+console.log("after clear a:", performance.getEntriesByType("mark").length);
+performance.clearMarks();
+console.log("after clear all:", performance.getEntriesByType("mark").length);

--- a/test-parity/node-suite/perf_hooks/clear/clear-measures.ts
+++ b/test-parity/node-suite/perf_hooks/clear/clear-measures.ts
@@ -1,0 +1,10 @@
+import { performance } from "node:perf_hooks";
+// clearMeasures() removes measure entries but leaves marks intact.
+performance.mark("a", { startTime: 0 });
+performance.mark("b", { startTime: 10 });
+performance.measure("m1", "a", "b");
+performance.measure("m2", "a", "b");
+console.log("measures before:", performance.getEntriesByType("measure").length);
+performance.clearMeasures();
+console.log("measures after:", performance.getEntriesByType("measure").length);
+console.log("marks still there:", performance.getEntriesByType("mark").length);

--- a/test-parity/node-suite/perf_hooks/constants/gc-constants.ts
+++ b/test-parity/node-suite/perf_hooks/constants/gc-constants.ts
@@ -1,0 +1,5 @@
+import { constants } from "node:perf_hooks";
+// node:perf_hooks exposes NODE_PERFORMANCE_GC_* numeric constants.
+console.log("GC_MAJOR:", typeof constants.NODE_PERFORMANCE_GC_MAJOR);
+console.log("GC_MINOR:", typeof constants.NODE_PERFORMANCE_GC_MINOR);
+console.log("GC_FLAGS_NO:", typeof constants.NODE_PERFORMANCE_GC_FLAGS_NO);

--- a/test-parity/node-suite/perf_hooks/entries/by-type-and-name.ts
+++ b/test-parity/node-suite/perf_hooks/entries/by-type-and-name.ts
@@ -1,0 +1,9 @@
+import { performance } from "node:perf_hooks";
+// getEntriesByType / getEntriesByName filter the performance timeline.
+performance.mark("a");
+performance.mark("b");
+performance.measure("a to b", "a", "b");
+console.log("marks:", performance.getEntriesByType("mark").length);
+console.log("measures:", performance.getEntriesByType("measure").length);
+console.log("named a:", performance.getEntriesByName("a").length);
+console.log("named a to b:", performance.getEntriesByName("a to b").length);

--- a/test-parity/node-suite/perf_hooks/eventlooputil/shape.ts
+++ b/test-parity/node-suite/perf_hooks/eventlooputil/shape.ts
@@ -1,0 +1,9 @@
+import { performance } from "node:perf_hooks";
+// eventLoopUtilization() returns { idle, active, utilization } numbers, and
+// the diff form (elu2, elu1) yields a utilization in the [0, 1] range.
+const elu1 = performance.eventLoopUtilization();
+console.log("idle:", typeof elu1.idle);
+console.log("active:", typeof elu1.active);
+console.log("utilization:", typeof elu1.utilization);
+const elu2 = performance.eventLoopUtilization(elu1);
+console.log("diff in range:", elu2.utilization >= 0 && elu2.utilization <= 1);

--- a/test-parity/node-suite/perf_hooks/imports/named-exports.ts
+++ b/test-parity/node-suite/perf_hooks/imports/named-exports.ts
@@ -1,0 +1,15 @@
+import {
+  performance,
+  PerformanceObserver,
+  PerformanceEntry,
+  PerformanceMark,
+  PerformanceMeasure,
+  constants,
+} from "node:perf_hooks";
+// The named exports of node:perf_hooks must have their Node-documented shapes.
+console.log("performance:", typeof performance);
+console.log("PerformanceObserver:", typeof PerformanceObserver);
+console.log("PerformanceEntry:", typeof PerformanceEntry);
+console.log("PerformanceMark:", typeof PerformanceMark);
+console.log("PerformanceMeasure:", typeof PerformanceMeasure);
+console.log("constants:", typeof constants);

--- a/test-parity/node-suite/perf_hooks/imports/performance-methods.ts
+++ b/test-parity/node-suite/perf_hooks/imports/performance-methods.ts
@@ -1,0 +1,12 @@
+import { performance } from "node:perf_hooks";
+// The performance object exposes the W3C User Timing + Node methods as
+// callable function-valued properties (not just the now() special case).
+console.log("now:", typeof performance.now);
+console.log("mark:", typeof performance.mark);
+console.log("measure:", typeof performance.measure);
+console.log("clearMarks:", typeof performance.clearMarks);
+console.log("clearMeasures:", typeof performance.clearMeasures);
+console.log("getEntries:", typeof performance.getEntries);
+console.log("getEntriesByName:", typeof performance.getEntriesByName);
+console.log("getEntriesByType:", typeof performance.getEntriesByType);
+console.log("timeOrigin:", typeof performance.timeOrigin);

--- a/test-parity/node-suite/perf_hooks/mark/basic-shape.ts
+++ b/test-parity/node-suite/perf_hooks/mark/basic-shape.ts
@@ -1,0 +1,8 @@
+import { performance } from "node:perf_hooks";
+// performance.mark(name) returns a PerformanceMark with the documented fields.
+const m = performance.mark("x");
+console.log("name:", m.name);
+console.log("entryType:", m.entryType);
+console.log("duration:", m.duration);
+console.log("detail:", m.detail);
+console.log("startTime type:", typeof m.startTime);

--- a/test-parity/node-suite/perf_hooks/mark/detail-option.ts
+++ b/test-parity/node-suite/perf_hooks/mark/detail-option.ts
@@ -1,0 +1,5 @@
+import { performance } from "node:perf_hooks";
+// mark(name, { detail }) attaches a (structured-cloned) detail value.
+const m = performance.mark("d", { detail: { x: 1 } });
+console.log("name:", m.name);
+console.log("detail:", m.detail);

--- a/test-parity/node-suite/perf_hooks/mark/name-coercion.ts
+++ b/test-parity/node-suite/perf_hooks/mark/name-coercion.ts
@@ -1,0 +1,6 @@
+import { performance } from "node:perf_hooks";
+// The mark name is coerced to a string (Node: `${name}`).
+console.log("undefined:", performance.mark(undefined as any).name);
+console.log("number:", performance.mark(1 as any).name);
+console.log("boolean:", performance.mark(true as any).name);
+console.log("null:", performance.mark(null as any).name);

--- a/test-parity/node-suite/perf_hooks/mark/start-time-option.ts
+++ b/test-parity/node-suite/perf_hooks/mark/start-time-option.ts
@@ -1,0 +1,5 @@
+import { performance } from "node:perf_hooks";
+// mark(name, { startTime }) sets a deterministic startTime on the entry.
+const m = performance.mark("a", { startTime: 1 });
+console.log("startTime:", m.startTime);
+console.log("duration:", m.duration);

--- a/test-parity/node-suite/perf_hooks/measure/duration-and-end-option.ts
+++ b/test-parity/node-suite/perf_hooks/measure/duration-and-end-option.ts
@@ -1,0 +1,6 @@
+import { performance } from "node:perf_hooks";
+// measure(name, { duration, end }) back-computes startTime = end - duration.
+performance.mark("b", { startTime: 10 });
+const m = performance.measure("foo", { duration: 11, end: "b" });
+console.log("startTime:", m.startTime);
+console.log("duration:", m.duration);

--- a/test-parity/node-suite/perf_hooks/measure/duration-and-start-option.ts
+++ b/test-parity/node-suite/perf_hooks/measure/duration-and-start-option.ts
@@ -1,0 +1,6 @@
+import { performance } from "node:perf_hooks";
+// measure(name, { duration, start }) uses the named start and the given duration.
+performance.mark("b", { startTime: 10 });
+const m = performance.measure("foo", { duration: 11, start: "b" });
+console.log("startTime:", m.startTime);
+console.log("duration:", m.duration);

--- a/test-parity/node-suite/perf_hooks/measure/end-option.ts
+++ b/test-parity/node-suite/perf_hooks/measure/end-option.ts
@@ -1,0 +1,7 @@
+import { performance } from "node:perf_hooks";
+// measure(name, { end }) measures from time-origin (0) to the named end mark.
+performance.mark("a", { startTime: 0 });
+performance.mark("b", { startTime: 10 });
+const m = performance.measure("foo", { end: "b" });
+console.log("startTime:", m.startTime);
+console.log("duration:", m.duration);

--- a/test-parity/node-suite/perf_hooks/measure/from-marks.ts
+++ b/test-parity/node-suite/perf_hooks/measure/from-marks.ts
@@ -1,0 +1,9 @@
+import { performance } from "node:perf_hooks";
+// measure(name, startMark, endMark) computes startTime/duration from two marks.
+performance.mark("a", { startTime: 0 });
+performance.mark("b", { startTime: 10 });
+const m = performance.measure("foo", "a", "b");
+console.log("name:", m.name);
+console.log("entryType:", m.entryType);
+console.log("startTime:", m.startTime);
+console.log("duration:", m.duration);

--- a/test-parity/node-suite/perf_hooks/now/monotonic.ts
+++ b/test-parity/node-suite/perf_hooks/now/monotonic.ts
@@ -1,0 +1,5 @@
+import { performance } from "node:perf_hooks";
+// Successive performance.now() readings are monotonically non-decreasing.
+const a = performance.now();
+const b = performance.now();
+console.log("monotonic:", b >= a);

--- a/test-parity/node-suite/perf_hooks/now/returns-number.ts
+++ b/test-parity/node-suite/perf_hooks/now/returns-number.ts
@@ -1,0 +1,5 @@
+import { performance } from "node:perf_hooks";
+// performance.now() returns a non-negative high-resolution millisecond reading.
+const t = performance.now();
+console.log("type:", typeof t);
+console.log("non-negative:", t >= 0);

--- a/test-parity/node-suite/perf_hooks/observer/entry-types.ts
+++ b/test-parity/node-suite/perf_hooks/observer/entry-types.ts
@@ -1,0 +1,10 @@
+import { PerformanceObserver } from "node:perf_hooks";
+// PerformanceObserver.supportedEntryTypes is a frozen array of strings, and
+// observe()/disconnect() are instance methods.
+const obs = new PerformanceObserver(() => {});
+console.log("observe:", typeof obs.observe);
+console.log("disconnect:", typeof obs.disconnect);
+console.log("takeRecords:", typeof obs.takeRecords);
+console.log("supportedEntryTypes:", Array.isArray(PerformanceObserver.supportedEntryTypes));
+console.log("includes mark:", PerformanceObserver.supportedEntryTypes.includes("mark"));
+console.log("includes measure:", PerformanceObserver.supportedEntryTypes.includes("measure"));

--- a/test-parity/node-suite/perf_hooks/observer/observe-marks.ts
+++ b/test-parity/node-suite/perf_hooks/observer/observe-marks.ts
@@ -1,0 +1,14 @@
+import { performance, PerformanceObserver } from "node:perf_hooks";
+// A PerformanceObserver observing 'mark' receives buffered mark entries
+// in its callback (delivered asynchronously after the marks are created).
+await new Promise<void>((resolve) => {
+  const obs = new PerformanceObserver((list) => {
+    const names = list.getEntries().map((e) => e.name);
+    console.log("observed:", names.join(","));
+    obs.disconnect();
+    resolve();
+  });
+  obs.observe({ entryTypes: ["mark"] });
+  performance.mark("a");
+  performance.mark("b");
+});

--- a/test-parity/node-suite/perf_hooks/time-origin/type.ts
+++ b/test-parity/node-suite/perf_hooks/time-origin/type.ts
@@ -1,0 +1,4 @@
+import { performance } from "node:perf_hooks";
+// performance.timeOrigin is a number (ms since the Unix epoch at process start).
+console.log("type:", typeof performance.timeOrigin);
+console.log("positive:", performance.timeOrigin > 0);


### PR DESCRIPTION
## What

Implements `node:perf_hooks` natively and adds a granular parity suite for it. Before this, only the syntactic `performance.now()` special case existed — the imported `performance` binding was a `boolean` stub and everything else (`mark`/`measure`/`PerformanceObserver`/`timeOrigin`/…) was missing.

## Tests (decomposed from Node v25.8.0)

19-file granular suite under `test-parity/node-suite/perf_hooks/`, derived from Node's `test-perf-hooks-usertiming.js`, `test-performance-measure.js`, `test-performance-global.js`, and `test-perf-hooks-eventlooputilization.js`. Each is a single-behavior print-and-diff case, validated byte-for-byte against `node --experimental-strip-types`.

**`./run_parity_tests.sh --suite node-suite --module perf_hooks` → 19/20 PASS.**

Covered: imports/typeof shapes · `now` (number + monotonic) · `timeOrigin` · `mark` (shape, name coercion, `startTime`/`detail` options) · `measure` (positional marks + `{start,end,duration}` options, exact Node arithmetic incl. `startTime: -1`) · `getEntriesByType`/`getEntriesByName` · `clearMarks`/`clearMeasures` · `eventLoopUtilization` shape · `PerformanceObserver` (constructor, `observe({entryTypes})`, async callback delivery, `list.getEntries()`, `disconnect`) · `constants.NODE_PERFORMANCE_GC_*`.

## How

- New `crates/perry-runtime/src/perf_hooks.rs`: per-thread timeline, User Timing, ELU, and a `PerformanceObserver` registry with async delivery via a single `setTimeout(flush, 0)` (callback gets a `list` object). GC root scanner keeps stored `detail` values + observer callbacks alive.
- `perf_hooks` added to `NATIVE_MODULES` + `RUNTIME_ONLY_MODULES` so its named imports bind to real namespace objects (root cause of the old `boolean` stub).
- `dispatch_native_module_method` / `get_native_module_constant` / `is_native_module_callable_export` gain `perf_hooks` / `perf_observer` / `perf_observer_list` arms.
- HIR lowers `performance.<method>()` to the perf_hooks `NativeMethodCall`; codegen routes `performance.*` and observer methods to the `js_perf_*` helpers.

## Deferred (1/20)

`observer/entry-types` asserts `typeof obs.observe === "function"`. Perry lowers a member *read* on a native-class instance as a method *call*, so `typeof obs.observe` misroutes. The call forms all work (`observe-marks`, the async-delivery test, passes). This is a Perry-core member-dispatch limitation, not perf_hooks-specific → filed as **#1320** and recorded in `known_failures.json`.

## Notes
- Full `node-suite` regression: 563/582 (96.7%); the other failures are pre-existing gaps in events/timers/console/assert/buffer (untouched here).
- No version bump / CHANGELOG entry — left for the maintainer to fold in at merge (per the external-contributor PR convention), to avoid patch-version collisions.
- `cargo fmt --all -- --check` clean; `perry-api-manifest` manifest-consistency test passes.