### PR TITLE
Add exact-head GC evidence packet for #1090

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ tests/test-*
 !tests/test_*.sh
 !tests/test-*.sh
 !tests/test_copied_minor_fallback_report.py
+!tests/test_gc_1090_evidence_report.py
 !tests/*/
 bench_*
 !bench_*.ts

--- a/scripts/gc_1090_evidence_packet.sh
+++ b/scripts/gc_1090_evidence_packet.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# Build an exact-head #1090 GC evidence packet from clean detached worktrees.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BASE_REF="origin/main"
+HEAD_REF="HEAD"
+RUNS=5
+OUT=""
+SKIP_PERF_COMPREHENSIVE=0
+KEEP_WORKTREES=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/gc_1090_evidence_packet.sh [options]
+
+Options:
+  --base-ref REF                 Comparison base (default: origin/main)
+  --head-ref REF                 Head/PR ref (default: HEAD)
+  --runs N                       Benchmark samples per benchmark (default: 5)
+  --out PATH                     Output root (default: tmp/gc-1090-evidence-<utc>)
+  --skip-perf-comprehensive      Skip optional perf-comprehensive probe
+  --keep-worktrees               Keep detached worktrees after the run
+  -h, --help                     Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-ref) BASE_REF="$2"; shift 2 ;;
+    --head-ref) HEAD_REF="$2"; shift 2 ;;
+    --runs) RUNS="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --skip-perf-comprehensive) SKIP_PERF_COMPREHENSIVE=1; shift ;;
+    --keep-worktrees) KEEP_WORKTREES=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if ! [[ "$RUNS" =~ ^[0-9]+$ ]] || [[ "$RUNS" -lt 1 ]]; then
+  echo "--runs must be a positive integer" >&2
+  exit 2
+fi
+
+if [[ -z "$OUT" ]]; then
+  OUT="tmp/gc-1090-evidence-$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+
+cd "$ROOT"
+
+BASE_SHA="$(git rev-parse --verify "$BASE_REF^{commit}")"
+HEAD_SHA="$(git rev-parse --verify "$HEAD_REF^{commit}")"
+OUT_ABS="$(python3 - "$ROOT" "$OUT" <<'PY'
+import os
+import sys
+root, out = sys.argv[1], sys.argv[2]
+if not os.path.isabs(out):
+    out = os.path.join(root, out)
+print(os.path.abspath(out))
+PY
+)"
+OUT_REL="$(python3 - "$ROOT" "$OUT_ABS" <<'PY'
+import os
+import sys
+root, out = map(os.path.abspath, sys.argv[1:3])
+try:
+    rel = os.path.relpath(out, root)
+except ValueError:
+    raise SystemExit(1)
+if rel.startswith(".."):
+    raise SystemExit(1)
+print(rel)
+PY
+)" || {
+  echo "output path must be inside the repository: $OUT_ABS" >&2
+  exit 2
+}
+
+if ! git check-ignore -q -- "$OUT_REL"; then
+  echo "output path must be ignored by git: $OUT_REL" >&2
+  exit 2
+fi
+
+if [[ -n "$(git ls-files -- "$OUT_REL" "$OUT_REL/**")" ]]; then
+  echo "output path contains tracked files; choose a fresh ignored path: $OUT_REL" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_ABS"
+
+BASE_WT="$OUT_ABS/worktrees/base"
+HEAD_WT="$OUT_ABS/worktrees/head"
+METADATA="$OUT_ABS/metadata.json"
+
+cleanup() {
+  if [[ "$KEEP_WORKTREES" -eq 0 ]]; then
+    git worktree remove --force "$BASE_WT" >/dev/null 2>&1 || true
+    git worktree remove --force "$HEAD_WT" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+write_metadata() {
+  python3 - "$METADATA" "$BASE_REF" "$HEAD_REF" "$BASE_SHA" "$HEAD_SHA" "$RUNS" "$SKIP_PERF_COMPREHENSIVE" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+path = Path(sys.argv[1])
+existing = {}
+if path.exists():
+    existing = json.loads(path.read_text(encoding="utf-8"))
+existing.update({
+    "schema_version": 1,
+    "generated_at": existing.get("generated_at") or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "base_ref": sys.argv[2],
+    "head_ref": sys.argv[3],
+    "base_sha": sys.argv[4],
+    "head_sha": sys.argv[5],
+    "runs": int(sys.argv[6]),
+    "skip_perf_comprehensive": sys.argv[7] == "1",
+    "commands": existing.get("commands", {}),
+})
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+}
+
+record_command() {
+  local label="$1"
+  local name="$2"
+  local status="$3"
+  local exit_code="$4"
+  local log_path="${5:-}"
+  local reason="${6:-}"
+  python3 - "$METADATA" "$label" "$name" "$status" "$exit_code" "$log_path" "$reason" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+path = Path(sys.argv[1])
+label, name, status, exit_code, log_path, reason = sys.argv[2:8]
+data = json.loads(path.read_text(encoding="utf-8"))
+commands = data.setdefault("commands", {})
+label_commands = commands.setdefault(label, {})
+entry = {
+    "status": status,
+    "exit_code": int(exit_code),
+    "finished_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+}
+if log_path:
+    entry["log"] = log_path
+if reason:
+    entry["reason"] = reason
+label_commands[name] = entry
+path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+}
+
+write_metadata
+
+echo "=== #1090 exact-head GC evidence packet ==="
+echo "base: $BASE_REF -> $BASE_SHA"
+echo "head: $HEAD_REF -> $HEAD_SHA"
+echo "out:  $OUT_ABS"
+
+mkdir -p "$OUT_ABS/worktrees"
+git worktree add --detach "$BASE_WT" "$BASE_SHA"
+git worktree add --detach "$HEAD_WT" "$HEAD_SHA"
+
+run_logged() {
+  local label="$1"
+  local name="$2"
+  local worktree="$3"
+  local log="$4"
+  shift 4
+  mkdir -p "$(dirname "$log")"
+  echo "=== $label: $name ==="
+  set +e
+  (
+    cd "$worktree"
+    "$@"
+  ) >"$log" 2>&1
+  local code=$?
+  set -e
+  local status="pass"
+  if [[ "$code" -ne 0 ]]; then
+    status="fail"
+  fi
+  record_command "$label" "$name" "$status" "$code" "$log" ""
+  echo "  $status (exit=$code, log=$log)"
+  return 0
+}
+
+run_for_label() {
+  local label="$1"
+  local worktree="$2"
+  local label_out="$OUT_ABS/$label"
+  mkdir -p "$label_out/logs" "$label_out/benchmarks"
+
+  run_logged "$label" "build" "$worktree" "$label_out/logs/build.log" \
+    cargo build --release -p perry
+
+  if [[ "$(command_status "$label" build)" == "fail" ]]; then
+    record_command "$label" "memory_stability" "skipped" 0 "" "build failed"
+    record_command "$label" "benchmarks" "skipped" 0 "" "build failed"
+    return
+  fi
+
+  run_logged "$label" "memory_stability" "$worktree" "$label_out/logs/memory-stability.command.log" \
+    env "PERRY_GC_EVIDENCE_DIR=$label_out/memory" scripts/run_memory_stability_tests.sh
+
+  run_logged "$label" "benchmarks" "$worktree" "$label_out/logs/benchmarks-full-runs${RUNS}.log" \
+    benchmarks/compare.sh --full --runs "$RUNS" --json-out "$label_out/benchmarks/full.json"
+
+  run_perf_comprehensive "$label" "$worktree" "$label_out"
+}
+
+command_status() {
+  local label="$1"
+  local name="$2"
+  python3 - "$METADATA" "$label" "$name" <<'PY'
+import json
+import sys
+data = json.load(open(sys.argv[1]))
+print(data.get("commands", {}).get(sys.argv[2], {}).get(sys.argv[3], {}).get("status", "missing"))
+PY
+}
+
+discover_perf_command() {
+  local worktree="$1"
+  if [[ -x "$worktree/scripts/run_perf_comprehensive.sh" ]]; then
+    printf '%s\n' "scripts/run_perf_comprehensive.sh"
+    return 0
+  fi
+  if [[ -x "$worktree/scripts/perf-comprehensive.sh" ]]; then
+    printf '%s\n' "scripts/perf-comprehensive.sh"
+    return 0
+  fi
+  return 1
+}
+
+run_perf_comprehensive() {
+  local label="$1"
+  local worktree="$2"
+  local label_out="$3"
+  local log="$label_out/logs/perf-comprehensive.log"
+
+  if [[ "$SKIP_PERF_COMPREHENSIVE" -eq 1 ]]; then
+    record_command "$label" "perf_comprehensive" "skipped" 0 "" "skipped by --skip-perf-comprehensive"
+    return
+  fi
+
+  local cmd
+  if ! cmd="$(discover_perf_command "$worktree")"; then
+    record_command "$label" "perf_comprehensive" "skipped" 0 "" "command not found"
+    return
+  fi
+
+  run_logged "$label" "perf_comprehensive" "$worktree" "$log" "$cmd"
+}
+
+run_for_label "base" "$BASE_WT"
+run_for_label "head" "$HEAD_WT"
+
+set +e
+python3 "$ROOT/scripts/gc_1090_evidence_report.py" \
+  --root "$OUT_ABS" \
+  --json-out "$OUT_ABS/gc-1090-packet.json" \
+  --md-out "$OUT_ABS/gc-1090-packet.md"
+REPORT_EXIT=$?
+set -e
+
+echo ""
+echo "packet markdown: $OUT_ABS/gc-1090-packet.md"
+echo "packet json:     $OUT_ABS/gc-1090-packet.json"
+exit "$REPORT_EXIT"

--- a/scripts/gc_1090_evidence_report.py
+++ b/scripts/gc_1090_evidence_report.py
@@ -1,0 +1,569 @@
+#!/usr/bin/env python3
+"""Build a PR-ready #1090 GC evidence packet from exact-head artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REQUIRED_BENCHMARKS = (
+    "bench_json_roundtrip",
+    "bench_gc_pressure",
+    "07_object_create",
+    "12_binary_trees",
+)
+
+STRICT_COPIED_MINOR_WORKLOADS = (
+    "json_roundtrip",
+    "string_churn",
+    "object_property_churn",
+    "mixed_request_shaping",
+    "map_set_churn",
+    "promise_churn",
+)
+
+FALLBACK_REASONS = (
+    "none",
+    "copy_only_roots",
+    "barriers_inactive",
+    "conservative_stack",
+    "malloc_registry_unavailable",
+    "pinned_young_root",
+    "pinned_young_dirty_slot",
+    "pinned_young_transitive",
+    "not_attempted",
+)
+
+SPEED_THRESHOLD_PCT = 15.0
+MEMORY_THRESHOLD_PCT = 25.0
+MIN_SPEED_DELTA_MS = 20
+MIN_MEMORY_DELTA_KB = 2048
+
+
+def load_json(path: Path, default: Any = None) -> Any:
+    if not path.exists():
+        return default
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def nested(obj: Any, *path: str, default: Any = None) -> Any:
+    cur = obj
+    for key in path:
+        if not isinstance(cur, dict):
+            return default
+        cur = cur.get(key, default)
+    return cur
+
+
+def int_value(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    return 0
+
+
+def pct_delta(base: int | None, head: int | None) -> float | None:
+    if base is None or head is None or base <= 0:
+        return None
+    return ((head - base) / base) * 100.0
+
+
+def ratio_delta(base: int | None, head: int | None) -> dict[str, Any]:
+    pct = pct_delta(base, head)
+    return {
+        "base": base,
+        "head": head,
+        "delta": None if base is None or head is None else head - base,
+        "delta_pct": None if pct is None else round(pct, 1),
+    }
+
+
+def command_exit(metadata: dict[str, Any], label: str, command: str) -> int | None:
+    exit_code = nested(metadata, "commands", label, command, "exit_code")
+    return exit_code if isinstance(exit_code, int) else None
+
+
+def command_status(metadata: dict[str, Any], label: str, command: str) -> str:
+    status = nested(metadata, "commands", label, command, "status")
+    if isinstance(status, str):
+        return status
+    exit_code = command_exit(metadata, label, command)
+    if exit_code is None:
+        return "missing"
+    return "pass" if exit_code == 0 else "fail"
+
+
+def label_paths(root: Path, label: str) -> dict[str, Path]:
+    base = root / label
+    return {
+        "benchmarks": base / "benchmarks" / "full.json",
+        "memory_summary": base / "memory" / "reports" / "memory_stability_summary.json",
+        "copied_minor": base / "memory" / "reports" / "copied_minor_fallback_report.json",
+        "target_collector": base / "memory" / "reports" / "target_collector_gates_report.json",
+    }
+
+
+def memory_summary(root: Path, label: str) -> dict[str, Any]:
+    summary = load_json(label_paths(root, label)["memory_summary"], {})
+    return {
+        "passed": int_value(summary.get("passed")) if isinstance(summary, dict) else 0,
+        "failed": int_value(summary.get("failed")) if isinstance(summary, dict) else 0,
+        "skipped": int_value(summary.get("skipped")) if isinstance(summary, dict) else 0,
+        "path": str(label_paths(root, label)["memory_summary"]),
+        "present": bool(summary),
+    }
+
+
+def benchmark_entry(benchmarks: dict[str, Any], name: str) -> dict[str, Any]:
+    entry = nested(benchmarks, "benchmarks", name, default={})
+    return entry if isinstance(entry, dict) else {}
+
+
+def benchmark_matrix(
+    root: Path,
+    base_label: str,
+    head_label: str,
+    errors: list[str],
+    warnings: list[str],
+) -> dict[str, Any]:
+    base = load_json(label_paths(root, base_label)["benchmarks"], {})
+    head = load_json(label_paths(root, head_label)["benchmarks"], {})
+    matrix: dict[str, Any] = {}
+
+    for report_label, report in ((base_label, base), (head_label, head)):
+        if not report:
+            errors.append(f"{report_label}: benchmark JSON is missing")
+            continue
+        for name, entry in nested(report, "benchmarks", default={}).items():
+            correctness = entry.get("correctness", {})
+            status = correctness.get("status")
+            if status == "fail":
+                errors.append(
+                    f"{report_label}:{name}: correctness failed: "
+                    f"{correctness.get('reason', 'semantic output mismatch')}"
+                )
+            elif status == "unchecked":
+                warnings.append(f"{report_label}:{name}: correctness unchecked")
+
+    for name in REQUIRED_BENCHMARKS:
+        base_entry = benchmark_entry(base, name)
+        head_entry = benchmark_entry(head, name)
+        if not base_entry:
+            errors.append(f"{base_label}:{name}: required benchmark missing")
+        if not head_entry:
+            errors.append(f"{head_label}:{name}: required benchmark missing")
+
+        base_ms = base_entry.get("perry_ms")
+        head_ms = head_entry.get("perry_ms")
+        base_rss = base_entry.get("perry_rss_kb")
+        head_rss = head_entry.get("perry_rss_kb")
+        time = ratio_delta(base_ms, head_ms)
+        rss = ratio_delta(base_rss, head_rss)
+
+        time_regression = (
+            time["delta_pct"] is not None
+            and time["delta_pct"] > SPEED_THRESHOLD_PCT
+            and abs(time["delta"] or 0) >= MIN_SPEED_DELTA_MS
+        )
+        rss_regression = (
+            rss["delta_pct"] is not None
+            and rss["delta_pct"] > MEMORY_THRESHOLD_PCT
+            and abs(rss["delta"] or 0) >= MIN_MEMORY_DELTA_KB
+        )
+        if time_regression:
+            errors.append(
+                f"{name}: time regression {base_ms}ms -> {head_ms}ms "
+                f"({time['delta_pct']:+.1f}%)"
+            )
+        if rss_regression:
+            errors.append(
+                f"{name}: RSS regression {base_rss}KB -> {head_rss}KB "
+                f"({rss['delta_pct']:+.1f}%)"
+            )
+
+        matrix[name] = {
+            "time_ms": time,
+            "rss_kb": rss,
+            "base_correctness": nested(base_entry, "correctness", "status", default="missing"),
+            "head_correctness": nested(head_entry, "correctness", "status", default="missing"),
+            "gate": "fail" if time_regression or rss_regression else "pass",
+        }
+
+    return matrix
+
+
+def normalize_reason_counts(counts: Any) -> dict[str, int]:
+    result = {reason: 0 for reason in FALLBACK_REASONS}
+    if isinstance(counts, dict):
+        for key, value in counts.items():
+            if isinstance(key, str):
+                result[key] = int_value(value)
+    return result
+
+
+def copied_report_summary(root: Path, label: str) -> dict[str, Any]:
+    report = load_json(label_paths(root, label)["copied_minor"], {})
+    summary = report.get("summary", {}) if isinstance(report, dict) else {}
+    workloads = report.get("workloads", {}) if isinstance(report, dict) else {}
+    return {
+        "present": bool(report),
+        "path": str(label_paths(root, label)["copied_minor"]),
+        "summary": {
+            "cycles": int_value(summary.get("cycles")) if isinstance(summary, dict) else 0,
+            "fallback_reason_counts": normalize_reason_counts(
+                summary.get("fallback_reason_counts") if isinstance(summary, dict) else {}
+            ),
+            "conservative_pinned_bytes": int_value(
+                summary.get("conservative_pinned_bytes") if isinstance(summary, dict) else 0
+            ),
+            "legacy_copy_only_scanner_pinned_bytes": int_value(
+                nested(summary, "legacy_copy_only_scanner_pinned", "bytes", default=0)
+            ),
+            "copied_objects": int_value(nested(summary, "copying_nursery", "copied_objects", default=0)),
+            "copied_bytes": int_value(nested(summary, "copying_nursery", "copied_bytes", default=0)),
+            "promoted_objects": int_value(nested(summary, "copying_nursery", "promoted_objects", default=0)),
+            "promoted_bytes": int_value(nested(summary, "copying_nursery", "promoted_bytes", default=0)),
+            "malloc_registry_rebuilds": int_value(
+                nested(summary, "copying_nursery", "malloc_registry_rebuilds", default=0)
+            ),
+        },
+        "workloads": workloads if isinstance(workloads, dict) else {},
+    }
+
+
+def target_collector_summary(root: Path, label: str) -> dict[str, Any]:
+    report = load_json(label_paths(root, label)["target_collector"], {})
+    summary = report.get("summary", {}) if isinstance(report, dict) else {}
+    return {
+        "present": bool(report),
+        "path": str(label_paths(root, label)["target_collector"]),
+        "cycles": int_value(summary.get("cycles")) if isinstance(summary, dict) else 0,
+        "fallback_reason_counts": normalize_reason_counts(
+            summary.get("fallback_reason_counts") if isinstance(summary, dict) else {}
+        ),
+        "copied_objects": int_value(nested(summary, "copying_nursery", "copied_objects", default=0)),
+        "copied_bytes": int_value(nested(summary, "copying_nursery", "copied_bytes", default=0)),
+        "promoted_objects": int_value(nested(summary, "copying_nursery", "promoted_objects", default=0)),
+        "promoted_bytes": int_value(nested(summary, "copying_nursery", "promoted_bytes", default=0)),
+        "malloc_registry_rebuilds": int_value(
+            nested(summary, "copying_nursery", "malloc_registry_rebuilds", default=0)
+        ),
+        "old_page_accounting": summary.get("old_page_accounting", {})
+        if isinstance(summary, dict)
+        else {},
+    }
+
+
+def workload_counts(workload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "fallback_reason_counts": normalize_reason_counts(
+            workload.get("fallback_reason_counts", {})
+        ),
+        "conservative_pinned_bytes": int_value(workload.get("conservative_pinned_bytes")),
+        "legacy_copy_only_scanner_pinned_bytes": int_value(
+            nested(workload, "legacy_copy_only_scanner_pinned", "bytes", default=0)
+        ),
+        "malloc_registry_rebuilds": int_value(
+            nested(workload, "copying_nursery", "malloc_registry_rebuilds", default=0)
+        ),
+        "copied_objects": int_value(
+            nested(workload, "copying_nursery", "copied_objects", default=0)
+        ),
+        "promoted_objects": int_value(
+            nested(workload, "copying_nursery", "promoted_objects", default=0)
+        ),
+    }
+
+
+def gate_copied_minor(
+    head_copied: dict[str, Any],
+    errors: list[str],
+    warnings: list[str],
+) -> dict[str, Any]:
+    if not head_copied["present"]:
+        errors.append("head: copied-minor fallback report is missing")
+        return {}
+
+    workload_results: dict[str, Any] = {}
+    workloads = head_copied["workloads"]
+    for name in STRICT_COPIED_MINOR_WORKLOADS:
+        workload = workloads.get(name)
+        if not isinstance(workload, dict):
+            warnings.append(f"head:{name}: strict copied-minor workload missing")
+            continue
+        counts = workload_counts(workload)
+        workload_results[name] = counts
+        non_none = {
+            reason: count
+            for reason, count in counts["fallback_reason_counts"].items()
+            if reason != "none" and count > 0
+        }
+        if name == "json_roundtrip" and non_none:
+            errors.append(f"head:{name}: fallback reasons other than none: {non_none}")
+        if counts["conservative_pinned_bytes"] != 0:
+            errors.append(
+                f"head:{name}: conservative_pinned_bytes="
+                f"{counts['conservative_pinned_bytes']}, want 0"
+            )
+        if counts["legacy_copy_only_scanner_pinned_bytes"] != 0:
+            errors.append(
+                f"head:{name}: legacy_copy_only_scanner_pinned.bytes="
+                f"{counts['legacy_copy_only_scanner_pinned_bytes']}, want 0"
+            )
+        if counts["malloc_registry_rebuilds"] != 0:
+            errors.append(
+                f"head:{name}: malloc_registry_rebuilds="
+                f"{counts['malloc_registry_rebuilds']}, want 0"
+            )
+
+    return workload_results
+
+
+def perf_summary(metadata: dict[str, Any], base_label: str, head_label: str) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for label in (base_label, head_label):
+        entry = nested(metadata, "commands", label, "perf_comprehensive", default={})
+        if not isinstance(entry, dict):
+            entry = {}
+        entry = dict(entry)
+        log = entry.get("log")
+        outlier_lines: list[str] = []
+        if isinstance(log, str) and log:
+            log_path = Path(log)
+            if log_path.exists():
+                for line in log_path.read_text(
+                    encoding="utf-8", errors="replace"
+                ).splitlines():
+                    lowered = line.lower()
+                    if "gc" in lowered or "outlier" in lowered:
+                        outlier_lines.append(line)
+                    if len(outlier_lines) >= 20:
+                        break
+        entry["outlier_lines"] = outlier_lines
+        result[label] = entry
+    return result
+
+
+def collect_report(root: Path, base_label: str, head_label: str) -> dict[str, Any]:
+    metadata = load_json(root / "metadata.json", {})
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    for label in (base_label, head_label):
+        if command_exit(metadata, label, "build") not in (0, None):
+            errors.append(f"{label}: release build failed")
+        memory_exit = command_exit(metadata, label, "memory_stability")
+        if memory_exit not in (0, None):
+            errors.append(f"{label}: memory stability command failed with {memory_exit}")
+        bench_exit = command_exit(metadata, label, "benchmarks")
+        if bench_exit not in (0, None):
+            warnings.append(
+                f"{label}: benchmark command exited {bench_exit}; "
+                "required benchmark gates are evaluated from JSON"
+            )
+
+    memory = {
+        base_label: memory_summary(root, base_label),
+        head_label: memory_summary(root, head_label),
+    }
+    for label, summary in memory.items():
+        if not summary["present"]:
+            errors.append(f"{label}: memory stability summary missing")
+        if summary["failed"] != 0:
+            errors.append(f"{label}: memory stability failed={summary['failed']}")
+
+    benchmarks = benchmark_matrix(root, base_label, head_label, errors, warnings)
+    copied_minor = {
+        base_label: copied_report_summary(root, base_label),
+        head_label: copied_report_summary(root, head_label),
+    }
+    target_collector = {
+        base_label: target_collector_summary(root, base_label),
+        head_label: target_collector_summary(root, head_label),
+    }
+    strict_workloads = gate_copied_minor(copied_minor[head_label], errors, warnings)
+
+    perf = perf_summary(metadata, base_label, head_label)
+
+    packet = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "status": "fail" if errors else "pass",
+        "errors": errors,
+        "warnings": warnings,
+        "refs": {
+            "base": {
+                "label": base_label,
+                "ref": metadata.get("base_ref"),
+                "sha": metadata.get("base_sha"),
+            },
+            "head": {
+                "label": head_label,
+                "ref": metadata.get("head_ref"),
+                "sha": metadata.get("head_sha"),
+            },
+        },
+        "commands": metadata.get("commands", {}),
+        "memory_stability": memory,
+        "benchmarks": benchmarks,
+        "copied_minor": copied_minor,
+        "strict_head_workloads": strict_workloads,
+        "target_collector": target_collector,
+        "perf_comprehensive": perf,
+    }
+    return packet
+
+
+def fmt_delta(entry: dict[str, Any], unit: str) -> str:
+    base = entry.get("base")
+    head = entry.get("head")
+    delta = entry.get("delta")
+    pct = entry.get("delta_pct")
+    if base is None or head is None or delta is None or pct is None:
+        return "missing"
+    sign = "+" if delta >= 0 else ""
+    return f"{base}{unit} -> {head}{unit} ({sign}{delta}{unit}, {pct:+.1f}%)"
+
+
+def reason_summary(counts: dict[str, int]) -> str:
+    nonzero = {key: value for key, value in counts.items() if value}
+    if not nonzero:
+        return "none"
+    return ", ".join(f"{key}={value}" for key, value in sorted(nonzero.items()))
+
+
+def render_markdown(packet: dict[str, Any]) -> str:
+    status = packet["status"].upper()
+    base_sha = nested(packet, "refs", "base", "sha", default="?")
+    head_sha = nested(packet, "refs", "head", "sha", default="?")
+    lines = [
+        f"# #1090 GC Evidence Packet: {status}",
+        "",
+        f"- Base: `{base_sha}`",
+        f"- Head: `{head_sha}`",
+        f"- Generated: `{packet['generated_at']}`",
+        "",
+        "## Gate Summary",
+    ]
+    if packet["errors"]:
+        lines.extend(f"- FAIL: {error}" for error in packet["errors"])
+    else:
+        lines.append("- PASS: all hard gates passed")
+    if packet["warnings"]:
+        lines.extend(f"- WARN: {warning}" for warning in packet["warnings"])
+
+    lines.extend(
+        [
+            "",
+            "## Required Benchmarks",
+            "",
+            "| Benchmark | Correct | Time | RSS | Gate |",
+            "|---|---|---:|---:|---|",
+        ]
+    )
+    for name in REQUIRED_BENCHMARKS:
+        entry = packet["benchmarks"].get(name, {})
+        correct = f"{entry.get('base_correctness', '?')} -> {entry.get('head_correctness', '?')}"
+        lines.append(
+            f"| `{name}` | {correct} | {fmt_delta(entry.get('time_ms', {}), 'ms')} "
+            f"| {fmt_delta(entry.get('rss_kb', {}), 'KB')} | {entry.get('gate', 'missing')} |"
+        )
+
+    lines.extend(["", "## Memory Stability", "", "| Ref | Passed | Failed | Skipped |"])
+    lines.append("|---|---:|---:|---:|")
+    for label, summary in packet["memory_stability"].items():
+        lines.append(
+            f"| `{label}` | {summary['passed']} | {summary['failed']} | {summary['skipped']} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Copied-Minor Evidence",
+            "",
+            "| Ref | Fallback Reasons | Conservative Pinned Bytes | Copy-Only Pinned Bytes | Copied/Promoted Objects | Copied/Promoted Bytes | Malloc Registry Rebuilds |",
+            "|---|---|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for label, report in packet["copied_minor"].items():
+        summary = report["summary"]
+        copied_promoted = summary["copied_objects"] + summary["promoted_objects"]
+        copied_promoted_bytes = summary["copied_bytes"] + summary["promoted_bytes"]
+        lines.append(
+            f"| `{label}` | {reason_summary(summary['fallback_reason_counts'])} "
+            f"| {summary['conservative_pinned_bytes']} "
+            f"| {summary['legacy_copy_only_scanner_pinned_bytes']} "
+            f"| {copied_promoted} "
+            f"| {copied_promoted_bytes} "
+            f"| {summary['malloc_registry_rebuilds']} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Target Collector Gates",
+            "",
+            "| Ref | Present | Fallback Reasons | Copied Objects | Copied Bytes | Promoted Objects | Promoted Bytes | Malloc Registry Rebuilds |",
+            "|---|---|---|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for label, report in packet["target_collector"].items():
+        lines.append(
+            f"| `{label}` | {report['present']} "
+            f"| {reason_summary(report['fallback_reason_counts'])} "
+            f"| {report['copied_objects']} | {report['copied_bytes']} "
+            f"| {report['promoted_objects']} | {report['promoted_bytes']} "
+            f"| {report['malloc_registry_rebuilds']} |"
+        )
+
+    lines.extend(["", "## Perf-Comprehensive Outlier Check", ""])
+    for label, perf in packet["perf_comprehensive"].items():
+        status = perf.get("status", "missing") if isinstance(perf, dict) else "missing"
+        reason = perf.get("reason", "") if isinstance(perf, dict) else ""
+        log = perf.get("log", "") if isinstance(perf, dict) else ""
+        suffix = f" ({reason})" if reason else ""
+        log_part = f" log: `{log}`" if log else ""
+        lines.append(f"- `{label}`: {status}{suffix}{log_part}")
+        for outlier in perf.get("outlier_lines", []) if isinstance(perf, dict) else []:
+            lines.append(f"  - `{outlier}`")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", required=True, help="Evidence output root")
+    parser.add_argument("--base-label", default="base")
+    parser.add_argument("--head-label", default="head")
+    parser.add_argument("--json-out", help="Packet JSON path")
+    parser.add_argument("--md-out", help="Packet Markdown path")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root)
+    packet = collect_report(root, args.base_label, args.head_label)
+
+    json_out = Path(args.json_out) if args.json_out else root / "gc-1090-packet.json"
+    md_out = Path(args.md_out) if args.md_out else root / "gc-1090-packet.md"
+    write_json(json_out, packet)
+    md_out.parent.mkdir(parents=True, exist_ok=True)
+    md_out.write_text(render_markdown(packet), encoding="utf-8")
+
+    return 1 if packet["status"] == "fail" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gc_1090_evidence_packet_smoke.sh
+++ b/tests/test_gc_1090_evidence_packet_smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="${1:-$ROOT/tmp/gc-1090-evidence-smoke-$(date -u +%Y%m%dT%H%M%SZ)}"
+
+"$ROOT/scripts/gc_1090_evidence_packet.sh" \
+  --base-ref HEAD \
+  --head-ref HEAD \
+  --runs 1 \
+  --out "$OUT" \
+  --skip-perf-comprehensive
+
+python3 - "$OUT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+metadata = json.loads((root / "metadata.json").read_text(encoding="utf-8"))
+packet = json.loads((root / "gc-1090-packet.json").read_text(encoding="utf-8"))
+
+assert metadata["base_sha"] == metadata["head_sha"], metadata
+assert (root / "gc-1090-packet.md").exists()
+assert (root / "gc-1090-packet.json").exists()
+
+for name in ("bench_json_roundtrip", "bench_gc_pressure", "07_object_create", "12_binary_trees"):
+    assert name in packet["benchmarks"], packet["benchmarks"].keys()
+
+head = packet["copied_minor"]["head"]["summary"]
+assert "fallback_reason_counts" in head
+assert "conservative_pinned_bytes" in head
+PY

--- a/tests/test_gc_1090_evidence_report.py
+++ b/tests/test_gc_1090_evidence_report.py
@@ -1,0 +1,215 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "gc_1090_evidence_report.py"
+
+SPEC = importlib.util.spec_from_file_location("gc_1090_evidence_report", SCRIPT_PATH)
+assert SPEC is not None
+REPORT = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(REPORT)
+
+
+REQUIRED_BENCHMARKS = (
+    "bench_json_roundtrip",
+    "bench_gc_pressure",
+    "07_object_create",
+    "12_binary_trees",
+)
+
+
+def write_json(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def copied_workload(
+    *,
+    fallback_reason="none",
+    conservative_pinned_bytes=0,
+    copy_only_pinned_bytes=0,
+    malloc_registry_rebuilds=0,
+):
+    counts = {reason: 0 for reason in REPORT.FALLBACK_REASONS}
+    counts[fallback_reason] = 1
+    return {
+        "fallback_reason_counts": counts,
+        "conservative_pinned_bytes": conservative_pinned_bytes,
+        "legacy_copy_only_scanner_pinned": {"bytes": copy_only_pinned_bytes},
+        "copying_nursery": {
+            "copied_objects": 1,
+            "copied_bytes": 16,
+            "promoted_objects": 0,
+            "promoted_bytes": 0,
+            "malloc_registry_rebuilds": malloc_registry_rebuilds,
+        },
+    }
+
+
+def copied_report(**overrides):
+    workloads = {
+        name: copied_workload()
+        for name in REPORT.STRICT_COPIED_MINOR_WORKLOADS
+    }
+    workloads.update(overrides)
+    return {
+        "summary": {
+            "cycles": len(workloads),
+            "fallback_reason_counts": {"none": len(workloads)},
+            "conservative_pinned_bytes": 0,
+            "legacy_copy_only_scanner_pinned": {"bytes": 0},
+            "copying_nursery": {
+                "copied_objects": len(workloads),
+                "copied_bytes": len(workloads) * 16,
+                "promoted_objects": 0,
+                "promoted_bytes": 0,
+                "malloc_registry_rebuilds": 0,
+            },
+        },
+        "workloads": workloads,
+    }
+
+
+def target_report():
+    return {
+        "summary": {
+            "cycles": 1,
+            "fallback_reason_counts": {"none": 1},
+            "copying_nursery": {
+                "copied_objects": 1,
+                "copied_bytes": 16,
+                "promoted_objects": 0,
+                "promoted_bytes": 0,
+                "malloc_registry_rebuilds": 0,
+            },
+            "old_page_accounting": {},
+        }
+    }
+
+
+def benchmark_report(multiplier=1, correctness="pass"):
+    benchmarks = {}
+    for name in REQUIRED_BENCHMARKS:
+        benchmarks[name] = {
+            "perry_ms": 100 * multiplier,
+            "perry_rss_kb": 100_000 * multiplier,
+            "correctness": {
+                "status": correctness,
+                "reason": "matched",
+                "actual_lines": ["checksum:1"],
+                "expected_lines": ["checksum:1"],
+            },
+        }
+    return {"commit": "abc", "benchmarks": benchmarks}
+
+
+class Gc1090EvidenceReportTests(unittest.TestCase):
+    def make_root(self, *, head_copied=None, head_benchmarks=None, head_memory_failed=0):
+        temp = tempfile.TemporaryDirectory()
+        root = Path(temp.name)
+        metadata = {
+            "base_ref": "origin/main",
+            "head_ref": "HEAD",
+            "base_sha": "a" * 40,
+            "head_sha": "b" * 40,
+            "commands": {
+                "base": {
+                    "build": {"status": "pass", "exit_code": 0},
+                    "memory_stability": {"status": "pass", "exit_code": 0},
+                    "benchmarks": {"status": "pass", "exit_code": 0},
+                },
+                "head": {
+                    "build": {"status": "pass", "exit_code": 0},
+                    "memory_stability": {"status": "pass", "exit_code": 0},
+                    "benchmarks": {"status": "pass", "exit_code": 0},
+                },
+            },
+        }
+        write_json(root / "metadata.json", metadata)
+        for label in ("base", "head"):
+            write_json(
+                root / label / "memory" / "reports" / "memory_stability_summary.json",
+                {
+                    "script": "run_memory_stability_tests.sh",
+                    "passed": 58,
+                    "failed": head_memory_failed if label == "head" else 0,
+                    "skipped": 0,
+                },
+            )
+            write_json(
+                root / label / "memory" / "reports" / "copied_minor_fallback_report.json",
+                head_copied if label == "head" and head_copied is not None else copied_report(),
+            )
+            write_json(
+                root / label / "memory" / "reports" / "target_collector_gates_report.json",
+                target_report(),
+            )
+            write_json(
+                root / label / "benchmarks" / "full.json",
+                head_benchmarks
+                if label == "head" and head_benchmarks is not None
+                else benchmark_report(),
+            )
+        return temp, root
+
+    def collect(self, **kwargs):
+        temp, root = self.make_root(**kwargs)
+        self.addCleanup(temp.cleanup)
+        return REPORT.collect_report(root, "base", "head")
+
+    def test_pass_case(self):
+        packet = self.collect()
+        self.assertEqual(packet["status"], "pass")
+        self.assertEqual(packet["errors"], [])
+
+    def test_main_writes_packet_files(self):
+        temp, root = self.make_root()
+        self.addCleanup(temp.cleanup)
+        exit_code = REPORT.main(["--root", str(root)])
+        self.assertEqual(exit_code, 0)
+        self.assertTrue((root / "gc-1090-packet.json").exists())
+        self.assertTrue((root / "gc-1090-packet.md").exists())
+        packet = json.loads((root / "gc-1090-packet.json").read_text(encoding="utf-8"))
+        self.assertEqual(packet["status"], "pass")
+        self.assertIn("# #1090 GC Evidence Packet: PASS", (root / "gc-1090-packet.md").read_text(encoding="utf-8"))
+
+    def test_fails_conservative_stack(self):
+        packet = self.collect(
+            head_copied=copied_report(
+                json_roundtrip=copied_workload(fallback_reason="conservative_stack")
+            )
+        )
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(
+            any("fallback reasons other than none" in error for error in packet["errors"])
+        )
+
+    def test_fails_conservative_pinned_bytes(self):
+        packet = self.collect(
+            head_copied=copied_report(
+                json_roundtrip=copied_workload(conservative_pinned_bytes=8)
+            )
+        )
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(
+            any("conservative_pinned_bytes=8" in error for error in packet["errors"])
+        )
+
+    def test_fails_benchmark_correctness(self):
+        packet = self.collect(head_benchmarks=benchmark_report(correctness="fail"))
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(any("correctness failed" in error for error in packet["errors"]))
+
+    def test_fails_memory_stability(self):
+        packet = self.collect(head_memory_failed=1)
+        self.assertEqual(packet["status"], "fail")
+        self.assertTrue(any("memory stability failed=1" in error for error in packet["errors"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a one-command #1090 evidence packet that compares an exact head commit against `origin/main` from clean detached worktrees.

This does not close #1090. It makes #1090 measurable.

Refs #1090.

## What changed

- Added `scripts/gc_1090_evidence_packet.sh`
- Added `scripts/gc_1090_evidence_report.py`
- Added parser/gate unit tests
- Added a shell smoke harness

## Why

#1090's target invariant needs exact-head proof:

```text
minor GC cost = live young objects + dirty old pages/cards + mutable roots
```

The packet reports:

- exact base/head SHAs
- benchmark time/RSS deltas
- checksum/correctness status
- memory stability pass/fail counts
- copied-minor fallback reasons
- conservative pinned bytes
- copy-only pinned bytes
- copied/promoted objects/bytes
- malloc registry rebuilds
- target collector gate summary

## Verification

- `python3 -m unittest tests/test_gc_1090_evidence_report.py`
- `python3 -m py_compile scripts/gc_1090_evidence_report.py tests/test_gc_1090_evidence_report.py`
- `bash -n scripts/gc_1090_evidence_packet.sh tests/test_gc_1090_evidence_packet_smoke.sh`
- `git diff --check`

## Manual packet command

```bash
scripts/gc_1090_evidence_packet.sh \
  --base-ref origin/main \
  --head-ref HEAD \
  --runs 5 \
  --out tmp/gc-1090-evidence
```
