### PR TITLE
test(parity): static dispatch for os/methods/modern-methods (#1318)

### DIFF
--- a/test-parity/node-suite/os/methods/modern-methods.ts
+++ b/test-parity/node-suite/os/methods/modern-methods.ts
@@ -1,8 +1,21 @@
 import os from "node:os";
 
-for (const name of ["availableParallelism", "machine", "version", "endianness"] as const) {
-  try {
-    const value = (os as any)[name]();
-    console.log(name + ":", typeof value, String(value).length > 0);
-  } catch (err: any) { console.log(name + ":", err?.name, err?.code || "no-code"); }
-}
+try {
+  const value = os.availableParallelism();
+  console.log("availableParallelism:", typeof value, String(value).length > 0);
+} catch (err: any) { console.log("availableParallelism:", err?.name, err?.code || "no-code"); }
+
+try {
+  const value = os.machine();
+  console.log("machine:", typeof value, String(value).length > 0);
+} catch (err: any) { console.log("machine:", err?.name, err?.code || "no-code"); }
+
+try {
+  const value = os.version();
+  console.log("version:", typeof value, String(value).length > 0);
+} catch (err: any) { console.log("version:", err?.name, err?.code || "no-code"); }
+
+try {
+  const value = os.endianness();
+  console.log("endianness:", typeof value, String(value).length > 0);
+} catch (err: any) { console.log("endianness:", err?.name, err?.code || "no-code"); }


### PR DESCRIPTION
## Summary

Closes #1318. Rewrites `test-parity/node-suite/os/methods/modern-methods.ts` to use explicit static `os.<method>()` calls instead of the dynamic `os[name]()` shape, which Perry's stdlib namespace-dispatch safety guard intentionally rejects at compile time.

Same four methods covered (`availableParallelism`, `machine`, `version`, `endianness`) with the same `typeof` + non-empty-string assertions and the same try/catch reporting shape. The dynamic dispatch wasn't the property under test.

## Test plan
- [x] `node --experimental-strip-types test-parity/node-suite/os/methods/modern-methods.ts`
- [x] `./target/release/perry test-parity/node-suite/os/methods/modern-methods.ts -o /tmp/mm && /tmp/mm`
- [x] `diff` of both outputs — byte-for-byte parity.