### PR TITLE
fix(codegen): node:timers/promises segfault when shadowing global setTimeout (#1317)

### DIFF
--- a/crates/perry-codegen/src/lower_call/extern_func.rs
+++ b/crates/perry-codegen/src/lower_call/extern_func.rs
@@ -38,6 +38,23 @@ pub fn try_lower_extern_func_call(
     else {
         return Ok(None);
     };
+    // Issue #1317: when `name` is bound to a named import from a Node
+    // submodule Perry recognizes but doesn't yet back with a real impl
+    // (`node:timers/promises`, `node:readline/promises`,
+    // `node:stream/promises`, `node:stream/consumers`, `node:sys`), the
+    // shadowing import collides with global names like `setTimeout`/
+    // `setInterval`/`setImmediate`. Without this guard, e.g.
+    // `import { setTimeout } from "node:timers/promises";
+    //  await setTimeout(1, { a: 1 }, { ref: false })`
+    // would lower to the global `setTimeout(fn, delay, ...args)` fast
+    // path below — handing `1` to `js_set_timeout_callback_args` as if
+    // it were a callback handle and segfaulting on the next dispatch.
+    // Skip the fast-path table so the call falls through to the regular
+    // closure-dispatch lowering, which invokes the named-import
+    // singleton's thunk (raising the "not yet implemented" error).
+    if ctx.import_function_node_submodule.contains_key(name) {
+        return Ok(None);
+    }
     match name.as_str() {
         "setTimeout" if args.len() == 2 => {
             let cb_box = lower_expr(ctx, &args[0])?;

--- a/test-parity/expected/shadowed-global-fast-paths.txt
+++ b/test-parity/expected/shadowed-global-fast-paths.txt
@@ -1,0 +1,2 @@
+setTimeout error node:timers/promises.setTimeout is not yet implemented in Perry (tracked by issue #793).
+setImmediate error node:timers/promises.setImmediate is not yet implemented in Perry (tracked by issue #793).

--- a/test-parity/node-suite/timers/promises/shadowed-global-fast-paths.ts
+++ b/test-parity/node-suite/timers/promises/shadowed-global-fast-paths.ts
@@ -1,0 +1,16 @@
+import { setImmediate, setTimeout } from "node:timers/promises";
+
+async function report(label: string, fn: () => Promise<unknown>) {
+  try {
+    const value = await fn();
+    console.log(label + " resolved", typeof value, JSON.stringify(value));
+  } catch (err: any) {
+    console.log(label + " error", err?.message || String(err));
+  }
+}
+
+// Regression for #1317: these named imports intentionally shadow the global
+// timer functions. Perry must route them through the node:timers/promises
+// import thunk, not the global timer callback fast paths.
+await report("setTimeout", () => setTimeout(1, { a: 1 }, { ref: true }));
+await report("setImmediate", () => setImmediate({ b: 2 }, { ref: true }));


### PR DESCRIPTION
## Summary
- Fix `node:timers/promises` segfault when the imported `setTimeout`/`setInterval`/`setImmediate` shadowed the global builtin in `lower_call/extern_func.rs`.
- When the call name is bound to a named import from a recognized Node submodule (`import_function_node_submodule`), skip the global fast-path table and fall through to the closure-dispatch path, so the import singleton's thunk runs.
- Resolves #1317.

## Root cause
`crates/perry-codegen/src/lower_call/extern_func.rs` has fast-path lowering for global names `setTimeout` / `setInterval` / `setImmediate` / `clearTimeout` / `clearInterval`, matched by bare string. When `import { setTimeout } from "node:timers/promises"` shadowed the global, a call like `setTimeout(1, { a: 1 }, { ref: false })` still matched the global `setTimeout(fn, delay, ...args)` 3-arg branch and called `js_set_timeout_callback_args(1, {a:1}, ...)` — handing `1` to the dispatcher as a callback handle and segfaulting.

## Test plan
- [x] `target/release/perry test-parity/node-suite/timers/promises/timeout-value-and-ref.ts` now exits 1 with the expected `Error: node:timers/promises.setTimeout is not yet implemented in Perry (tracked by issue #793).` (was SIGSEGV / exit 139).
- [x] `./run_parity_tests.sh --suite=node-suite --module=timers` completes with no compile failures or segfaults.
- [x] Other `timers/promises/*` tests still resolve to either the stub thrower or their previous outputs — no regression in segfault count.