### PR TITLE
fix(wasm): #1323 dispatch timer builtins through mem_call bridge

### DIFF
--- a/crates/perry-codegen-wasm/src/emit/expr/calls.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/calls.rs
@@ -60,6 +60,53 @@ impl<'a> FuncEmitCtx<'a> {
                     }
                 }
 
+                // Built-in timer globals (setTimeout/setInterval/clearTimeout/
+                // clearInterval). These resolve to `Expr::ExternFuncRef` with no
+                // entry in `func_name_map`, so without this intercept they fall
+                // through to the ExternFuncRef arm below, which drops the args and
+                // pushes `undefined` — the timer is never scheduled and the
+                // callback never fires (#1323). Route them through the mem_call
+                // bridge to `__memDispatch.set_timeout` / `set_interval` /
+                // `clear_timeout` / `clear_interval` in wasm_runtime.js, mirroring
+                // how fetch/closure_call dispatch. The set_* bridges take
+                // (closure, delay) and return the timer id; the clear_* bridges
+                // take (id). Trailing setTimeout(fn, delay, ...args) extras are
+                // dropped (Node passes them to the callback — out of scope here).
+                if let Expr::ExternFuncRef { name, .. } = callee.as_ref() {
+                    let timer = match name.as_str() {
+                        "setTimeout" => Some(("set_timeout", 2u32)),
+                        "setInterval" => Some(("set_interval", 2u32)),
+                        "clearTimeout" => Some(("clear_timeout", 1u32)),
+                        "clearInterval" => Some(("clear_interval", 1u32)),
+                        _ => None,
+                    };
+                    if let Some((bridge, arity)) = timer {
+                        self.emit_frame_begin(func, arity);
+                        for slot in 0..arity {
+                            match args.get(slot as usize) {
+                                Some(arg) => self.emit_store_arg(func, slot, arg),
+                                None => {
+                                    // Pad missing arg (e.g. setTimeout(fn)) with undefined.
+                                    self.emit_slot_addr(func, slot);
+                                    func.instruction(&Instruction::I64Const(TAG_UNDEFINED as i64));
+                                    func.instruction(&Instruction::I64Store(
+                                        wasm_encoder::MemArg {
+                                            offset: 0,
+                                            align: 3,
+                                            memory_index: 0,
+                                        },
+                                    ));
+                                }
+                            }
+                        }
+                        // emit_memcall leaves the i64 result (timer id for set_*,
+                        // NaN-boxed undefined for clear_*) on the stack, satisfying
+                        // the call expression's value requirement.
+                        self.emit_memcall(func, bridge, arity);
+                        return true;
+                    }
+                }
+
                 // Evaluate arguments first
                 for arg in args {
                     self.emit_expr(func, arg);

--- a/tests/wasm/23_timers.expected
+++ b/tests/wasm/23_timers.expected
@@ -1,0 +1,3 @@
+top
+tick
+done

--- a/tests/wasm/23_timers.ts
+++ b/tests/wasm/23_timers.ts
@@ -1,0 +1,17 @@
+// Timer callbacks on the web/wasm target (#1323).
+// setTimeout / setInterval callbacks must actually fire, and
+// clearInterval must stop a repeating timer. Without the emit-side
+// bridge dispatch, these calls were silent no-ops: top-level code ran
+// but no deferred callback ever executed.
+console.log("top");
+
+// setInterval fires, then clears itself via the captured timer id.
+const id = setInterval(() => {
+  console.log("tick");
+  clearInterval(id);
+}, 5);
+
+// setTimeout fires after the interval has ticked once and cleared.
+setTimeout(() => {
+  console.log("done");
+}, 40);


### PR DESCRIPTION
## Summary

Fixes #1323 — on `--target web`/`--target wasm`, `setTimeout`/`setInterval` callbacks never fired. Top-level code ran, but every deferred callback was silently dropped.

## Root cause

The timer builtins lower to `Expr::ExternFuncRef { name: "setTimeout" }` (via `is_builtin_function` in `perry-hir`), but the WASM emitter had **no call-site handler** for them. The generic `ExternFuncRef` arm in `emit/expr/calls.rs` looks the name up in `func_name_map`, doesn't find it (timers aren't user/FFI functions), and falls through to its else branch — which **drops the args and pushes `undefined`**. The timer was never scheduled.

The `__memDispatch.set_timeout` / `set_interval` / `clear_timeout` / `clear_interval` bridges in `wasm_runtime.js` already existed and were correct, and the names were already interned in `string_collection.rs` — only the emitter wiring was missing. (The `rt.set_timeout` direct-import variant is declared but never called.)

## Fix

Intercept the four timer builtins in `calls.rs` before the generic `ExternFuncRef` arm and route them through the existing `mem_call` bridge, mirroring how `fetch`/`closure_call` dispatch:

- `setTimeout`/`setInterval` → `set_timeout`/`set_interval` with `(closure, delay)`, returning the timer id.
- `clearTimeout`/`clearInterval` → `clear_timeout`/`clear_interval` with `(id)`.

Missing args (e.g. `setTimeout(fn)`) are padded with `undefined`. Trailing `setTimeout(fn, delay, ...args)` extras are dropped for now (Node forwards them to the callback — out of scope here).

## Test

Adds `tests/wasm/23_timers.{ts,expected}`: a self-clearing `setInterval` plus a `setTimeout` that prints `top` / `tick` / `done`.

Verified through the Node harness (`tests/wasm/run_wasm_tests.sh`, which evals the generated `<script>`s under real Node timers):

- **With the fix:** prints `top`, `tick`, `done` (interval fires once, clears itself, timeout fires) and Node exits cleanly.
- **Without the fix** (codegen change reverted): prints only `top` — reproducing the issue exactly.

The other 7 pre-existing wasm-suite failures (objects/arrays, higher-order, map/set, regex/date, class-field-splice, module-splice, ffi-imports) are unchanged by this PR; confirmed by running the suite with and without the codegen change.
