### PR TITLE
test(parity): add node:crypto granular suite

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1,11 +1,11 @@
 {
   "_schema": {
-    "description": "Each entry maps a parity-suite test name to a structured record. The CI gate in .github/workflows/test.yml reads `keys[]` from this file \u2014 a test that fails AND is not a key here breaks CI. Add entries here only with full provenance (issue + added date) so we can revalidate.",
+    "description": "Each entry maps a parity-suite test name to a structured record. The CI gate in .github/workflows/test.yml reads `keys[]` from this file — a test that fails AND is not a key here breaks CI. Add entries here only with full provenance (issue + added date) so we can revalidate.",
     "fields": {
-      "issue": "Open GitHub issue number tracking this failure (e.g. \"793\"), or null when the failure is environmental / pending triage. Closed issues must be re-evaluated \u2014 flag the entry as `category: bug-stale` until a new tracking issue is filed.",
+      "issue": "Open GitHub issue number tracking this failure (e.g. \"793\"), or null when the failure is environmental / pending triage. Closed issues must be re-evaluated — flag the entry as `category: bug-stale` until a new tracking issue is filed.",
       "added": "ISO date (YYYY-MM-DD) when the test was first skip-listed. Use 2026-05-15 for entries inherited from the pre-audit format where the historical date is unknown.",
-      "category": "ci-env | module-inventory | bug-open | bug-stale | gap-categorical | gap-bisect \u2014 see test-parity/README.md for definitions.",
-      "reason": "Free-text explanation. Keep the most-actionable signal first \u2014 what changes the verdict (a fixture, a Perry fix, a Node spec change)."
+      "category": "ci-env | module-inventory | bug-open | bug-stale | gap-categorical | gap-bisect — see test-parity/README.md for definitions.",
+      "reason": "Free-text explanation. Keep the most-actionable signal first — what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
   "node-suite/perf_hooks/observer/entry-types": {
@@ -19,6 +19,144 @@
     "added": "2026-05-22",
     "category": "bug-open",
     "reason": "node:perf_hooks granular parity: globalThis.performance !== the node:perf_hooks named import. The import resolves to a fresh namespace object per read and the global is a separate path; neither is a cached singleton. Flips to PASS when #1327 lands."
+  },
+  "node-suite/crypto/hash/digest-base64": {
+    "issue": "1352",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto granular parity: createHash(...).digest('base64'|'base64url') ignores the encoding and returns hex. The digest codegen chain handles hex + no-arg Buffer but not base64. Flips to PASS when #1352 lands."
+  },
+  "node-suite/crypto/hash/digest-buffer-hex": {
+    "issue": "1353",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto granular parity: the no-arg digest() Buffer doesn't round-trip through Buffer#toString('hex') (yields raw bytes, not hex). digest-buffer-shape (isBuffer + length) PASSES. Flips to PASS when #1353 lands."
+  },
+  "node-suite/crypto/hash/buffer-input": {
+    "issue": "1354",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto granular parity: createHash().update(Buffer.from(s)) produces a different digest than update(s) — Buffer input is hashed by the wrong representation. Flips to PASS when #1354 lands."
+  },
+  "node-suite/crypto/pbkdf2/sha512-sync": {
+    "issue": "1355",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto granular parity: pbkdf2Sync ignores the digest argument for non-sha256 (sha512 returns a wrong result); sha256 is correct. Flips to PASS when #1355 lands."
+  },
+  "node-suite/crypto/cipher/aes-256-cbc-roundtrip": {
+    "issue": "1356",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto granular parity: createCipheriv/createDecipheriv round-trip yields NaN instead of the plaintext. Flips to PASS when #1356 lands."
+  },
+  "node-suite/crypto/hash/sha384-hex": {
+    "issue": "1357",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: createHash('sha384') is unimplemented (returns undefined); only sha256/md5/sha1/sha512 are wired. Flips to PASS when #1357 lands."
+  },
+  "node-suite/crypto/hash/sha224-hex": {
+    "issue": "1357",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: createHash('sha224') is unimplemented (returns undefined). Flips to PASS when #1357 lands."
+  },
+  "node-suite/crypto/introspection/get-hashes": {
+    "issue": "1358",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: crypto.getHashes() is not a function (unimplemented). Flips to PASS when #1358 lands."
+  },
+  "node-suite/crypto/introspection/get-ciphers": {
+    "issue": "1358",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: crypto.getCiphers() is not a function (unimplemented). Flips to PASS when #1358 lands."
+  },
+  "node-suite/crypto/random/random-int": {
+    "issue": "1359",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: crypto.randomInt(min, max) is not a function (unimplemented). Flips to PASS when #1359 lands."
+  },
+  "node-suite/crypto/misc/timing-safe-equal": {
+    "issue": "1360",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: crypto.timingSafeEqual(a, b) is not a function (unimplemented). Flips to PASS when #1360 lands."
+  },
+  "node-suite/crypto/scrypt/scrypt-sync": {
+    "issue": "1361",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: crypto.scryptSync(...) is not a function (unimplemented). Flips to PASS when #1361 lands."
+  },
+  "node-suite/crypto/hkdf/hkdf-sync": {
+    "issue": "1362",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: crypto.hkdfSync(...) is not a function (unimplemented). Flips to PASS when #1362 lands."
+  },
+  "node-suite/crypto/cipher/aes-256-gcm": {
+    "issue": "1363",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: AES-GCM is incomplete — getAuthTag() returns a 16-byte tag but the encrypt/decrypt round-trip with setAuthTag does not recover the plaintext. Flips to PASS when #1363 lands."
+  },
+  "node-suite/crypto/cipher/aes-128-cbc-roundtrip": {
+    "issue": "1356",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: aes-128-cbc createCipheriv/Decipheriv round-trip yields NaN (same cipher gap as aes-256-cbc). Flips to PASS when #1356 lands."
+  },
+  "node-suite/crypto/shapes/method-types": {
+    "issue": "1343",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: typeof crypto.createHash/createHmac/randomBytes/pbkdf2Sync is not 'function' — the call forms work (special-cased), but reading the method as a value reports the wrong type (member-read reflection gap). Flips to PASS when #1343 lands."
+  },
+  "node-suite/crypto/sign/create-sign-verify": {
+    "issue": "1364",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: createSign / createVerify are unimplemented (not functions). Flips to PASS when #1364 lands."
+  },
+  "node-suite/crypto/keys/generate-key-pair-sync": {
+    "issue": "1365",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: generateKeyPairSync / generateKeySync are unimplemented (not functions). Flips to PASS when #1365 lands."
+  },
+  "node-suite/crypto/subtle/subtle-shape": {
+    "issue": "1366",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: crypto.subtle (WebCrypto SubtleCrypto) is unimplemented — not an object with digest/importKey. Flips to PASS when #1366 lands."
+  },
+  "node-suite/crypto/webcrypto/get-random-values": {
+    "issue": "1366",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: crypto.getRandomValues (WebCrypto) read as a value is not a function. Flips to PASS when #1366 lands."
+  },
+  "node-suite/crypto/x509/x509-certificate": {
+    "issue": "1367",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: X509Certificate is unimplemented (not a constructor). Flips to PASS when #1367 lands."
+  },
+  "node-suite/crypto/dh/diffie-hellman": {
+    "issue": "1368",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: createDiffieHellman / createECDH are unimplemented (not functions). Flips to PASS when #1368 lands."
+  },
+  "node-suite/crypto/hash/copy": {
+    "issue": "1369",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:crypto: Hash#copy() is unimplemented (not a function on the hash object). Flips to PASS when #1369 lands."
   },
   "node-suite/console/dir/depth-options": {
     "issue": "1199",
@@ -54,7 +192,7 @@
     "issue": "655",
     "added": "2026-05-15",
     "category": "bug-open",
-    "reason": "Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict \u2014 it's a deliberate failing repro."
+    "reason": "Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict — it's a deliberate failing repro."
   },
   "test_edge_regression": {
     "issue": null,
@@ -72,7 +210,7 @@
     "issue": null,
     "added": "2026-05-15",
     "category": "gap-bisect",
-    "reason": "Array method coverage probe \u2014 small divergences (flat/flatMap/finally specific edge cases). Targeted bisect needed; not a recent regression. File a tracking issue once a specific sub-case is pinned."
+    "reason": "Array method coverage probe — small divergences (flat/flatMap/finally specific edge cases). Targeted bisect needed; not a recent regression. File a tracking issue once a specific sub-case is pinned."
   },
   "test_gap_console_methods": {
     "issue": "1278",
@@ -84,13 +222,13 @@
     "issue": null,
     "added": "2026-05-17",
     "category": "gap-bisect",
-    "reason": "Advanced class features (static blocks, private brand checks, etc.) \u2014 bisect required to identify which sub-feature fails byte-for-byte vs Node."
+    "reason": "Advanced class features (static blocks, private brand checks, etc.) — bisect required to identify which sub-feature fails byte-for-byte vs Node."
   },
   "test_gap_regexp_advanced": {
     "issue": null,
     "added": "2026-05-15",
     "category": "gap-categorical",
-    "reason": "Lookbehind regex assertions \u2014 Rust's `regex` crate doesn't support `(?<=)` / `(?<!)`. Documented in CLAUDE.md as a known categorical gap. Unblocking requires swapping the regex backend or implementing a separate matcher for lookbehind."
+    "reason": "Lookbehind regex assertions — Rust's `regex` crate doesn't support `(?<=)` / `(?<!)`. Documented in CLAUDE.md as a known categorical gap. Unblocking requires swapping the regex backend or implementing a separate matcher for lookbehind."
   },
   "test_harness_async_context": {
     "issue": "788",
@@ -102,31 +240,31 @@
     "issue": "806",
     "added": "2026-05-16",
     "category": "bug-stale",
-    "reason": "#806 harness for `class X extends Fn(...)<...>` patterns. Two sub-cases surface real Perry gaps today: (1) bare-factory subclass loses the base's field initializer (`bare.kind: undefined` vs Node's `bare.kind: bare`); (2) chained mixin `WithA(WithB(WithC(Base)))` throws `TypeError: value is not a function` at construction. Captured-factory + Effect double-call shapes pass post-#740 \u2014 the harness verifies that survives. Linked to #321 umbrella; will flip to PASS as each sub-case lands."
+    "reason": "#806 harness for `class X extends Fn(...)<...>` patterns. Two sub-cases surface real Perry gaps today: (1) bare-factory subclass loses the base's field initializer (`bare.kind: undefined` vs Node's `bare.kind: bare`); (2) chained mixin `WithA(WithB(WithC(Base)))` throws `TypeError: value is not a function` at construction. Captured-factory + Effect double-call shapes pass post-#740 — the harness verifies that survives. Linked to #321 umbrella; will flip to PASS as each sub-case lands."
   },
   "test_issue_233_async_array_param_push": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "bug-stale",
-    "reason": "#233 (16-element cap on async array-param push) closed on macOS. Linux CI still surfaces a divergence \u2014 bisect needed to pin the Linux-only sub-case before filing a new tracking issue. Rolled under the parity roadmap (#793) in the meantime."
+    "reason": "#233 (16-element cap on async array-param push) closed on macOS. Linux CI still surfaces a divergence — bisect needed to pin the Linux-only sub-case before filing a new tracking issue. Rolled under the parity roadmap (#793) in the meantime."
   },
   "test_issue_422_socket_connect": {
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "#422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental \u2014 needs a CI-side fixture, not a Perry fix."
+    "reason": "#422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental — needs a CI-side fixture, not a Perry fix."
   },
   "test_issue_462_nullish_property_access": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "bug-stale",
-    "reason": "Behavior is correct (TypeError thrown, UNREACHABLE never prints). Only stack-trace format diverges from Node \u2014 #616 closed with framing improvements but byte-for-byte parity requires source-text retention through the runtime. Track under the parity roadmap; file a dedicated stack-format issue if/when it becomes a real blocker."
+    "reason": "Behavior is correct (TypeError thrown, UNREACHABLE never prints). Only stack-trace format diverges from Node — #616 closed with framing improvements but byte-for-byte parity requires source-text retention through the runtime. Track under the parity roadmap; file a dedicated stack-format issue if/when it becomes a real blocker."
   },
   "test_issue_510_primitive_method_typeerror": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "bug-stale",
-    "reason": "Same root cause as test_issue_462 \u2014 see #616 (closed). Behavior correct; framing differs. Regression vector: v0.5.702 (#596) routed throw helpers through js_throw which exposed the format gap. Track under the parity roadmap until a stack-format issue is filed."
+    "reason": "Same root cause as test_issue_462 — see #616 (closed). Behavior correct; framing differs. Regression vector: v0.5.702 (#596) routed throw helpers through js_throw which exposed the format gap. Track under the parity roadmap until a stack-format issue is filed."
   },
   "test_issue_561_sigv4_chain": {
     "issue": "793",
@@ -150,7 +288,7 @@
     "issue": "922",
     "added": "2026-05-17",
     "category": "bug-open",
-    "reason": "Regression test from #922 (P0 production /api crash). Deliberate failing repro until the underlying codegen bug is fixed; #934 added a circuit breaker that converts the runaway loop into [PERRY ABORT] (so test fails by design \u2014 the abort message diverges from Node's success output)."
+    "reason": "Regression test from #922 (P0 production /api crash). Deliberate failing repro until the underlying codegen bug is fixed; #934 added a circuit breaker that converts the runaway loop into [PERRY ABORT] (so test fails by design — the abort message diverges from Node's success output)."
   },
   "test_issue_express_map_undefined": {
     "issue": "912",
@@ -168,241 +306,241 @@
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 needs a CI-side fixture, not a Perry fix."
+    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
   },
   "test_net_socket": {
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 needs a CI-side fixture, not a Perry fix."
+    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
   },
   "test_net_upgrade_tls": {
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test needs a TLS-capable echo server fixture; not available on CI. Environmental \u2014 needs a CI-side fixture."
+    "reason": "Net test needs a TLS-capable echo server fixture; not available on CI. Environmental — needs a CI-side fixture."
   },
   "test_parity_assert": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:assert` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:assert` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_async_hooks": {
     "issue": "789",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:async_hooks` createHook lifecycle + asyncId tracking missing. Tracked in #789. Flips to PASS once createHook fires."
+    "reason": "Node.js module inventory — `node:async_hooks` createHook lifecycle + asyncId tracking missing. Tracked in #789. Flips to PASS once createHook fires."
   },
   "test_parity_buffer": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:buffer` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:buffer` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_child_process": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:child_process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:child_process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_crypto": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:crypto` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:crypto` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_dgram": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:dgram` (UDP) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:dgram` (UDP) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_diagnostics_channel": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:diagnostics_channel` not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:diagnostics_channel` not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_dns": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:dns` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:dns` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_dns_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:dns/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:dns/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_fs": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:fs` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:fs` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_fs_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:fs/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:fs/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_http": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:http` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:http` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_http2": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:http2` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:http2` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_https": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:https` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:https` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_module": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:module` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:module` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_net": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:net` socket-layer surface not implemented (Server/Socket classes, BlockList, SocketAddress). Classification helpers landed via #811. Tracker for surface coverage; flips to PASS as each API lands."
+    "reason": "Node.js module inventory — `node:net` socket-layer surface not implemented (Server/Socket classes, BlockList, SocketAddress). Classification helpers landed via #811. Tracker for surface coverage; flips to PASS as each API lands."
   },
   "test_parity_os": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:os` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:os` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_path": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:path` surface. Per-method gaps closed via #741 and #810 (path.posix/win32 sub-namespace). This test now PASSes byte-for-byte; entry retained until the next sweep confirms it can be removed."
+    "reason": "Node.js module inventory — `node:path` surface. Per-method gaps closed via #741 and #810 (path.posix/win32 sub-namespace). This test now PASSes byte-for-byte; entry retained until the next sweep confirms it can be removed."
   },
   "test_parity_perf_hooks": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:perf_hooks` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:perf_hooks` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_process": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_readline": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:readline` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:readline` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_readline_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:readline/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:readline/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_sqlite": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:sqlite` (Node 22.5+ built-in) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:sqlite` (Node 22.5+ built-in) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:stream` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:stream` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream_consumers": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:stream/consumers` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:stream/consumers` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:stream/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:stream/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream_web": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:stream/web` (WHATWG streams) surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:stream/web` (WHATWG streams) surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_sys": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:sys` (legacy alias for util) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:sys` (legacy alias for util) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_test": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:test` (built-in test runner) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:test` (built-in test runner) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_timers": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:timers` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:timers` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_timers_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:timers/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:timers/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_tls": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:tls` surface not fully implemented (Socket-level TLS upgrade works via net.upgradeToTLS; the higher-level tls.connect/Server is partial). Tracker for surface coverage."
+    "reason": "Node.js module inventory — `node:tls` surface not fully implemented (Socket-level TLS upgrade works via net.upgradeToTLS; the higher-level tls.connect/Server is partial). Tracker for surface coverage."
   },
   "test_parity_url": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:url` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:url` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_util": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:util` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:util` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_worker_threads": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:worker_threads` surface not implemented (perry/thread provides a Perry-native alternative). Tracker for surface coverage; flips to PASS as each API lands."
+    "reason": "Node.js module inventory — `node:worker_threads` surface not implemented (perry/thread provides a Perry-native alternative). Tracker for surface coverage; flips to PASS as each API lands."
   },
   "test_parity_zlib": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:zlib` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:zlib` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_sock_write_map": {
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 issue #91 dispatch fix landed in v0.5.581 and is no longer the cause; needs a CI-side fixture."
+    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — issue #91 dispatch fix landed in v0.5.581 and is no longer the cause; needs a CI-side fixture."
   },
   "test_decorators_nest_js_common_canary": {
     "issue": null,
@@ -414,18 +552,18 @@
     "issue": null,
     "added": "2026-05-18",
     "category": "ci-env",
-    "reason": "Ramda npm-package fixture failure on Linux CI; observed on #1038's CI run pre-merge. Companion to the existing test_ramda_user_import skip in the compile-smoke list \u2014 the parity harness can't npm-install ramda. File a CI-side fixture issue if/when this matters for sweep coverage."
+    "reason": "Ramda npm-package fixture failure on Linux CI; observed on #1038's CI run pre-merge. Companion to the existing test_ramda_user_import skip in the compile-smoke list — the parity harness can't npm-install ramda. File a CI-side fixture issue if/when this matters for sweep coverage."
   },
   "test_stream_on": {
     "issue": null,
     "added": "2026-05-18",
     "category": "ci-env",
-    "reason": "node:stream emitter wiring still incomplete (cf. existing test_parity_stream module-inventory entry). Same failure observed on #1038 pre-merge \u2014 not a regression."
+    "reason": "node:stream emitter wiring still incomplete (cf. existing test_parity_stream module-inventory entry). Same failure observed on #1038 pre-merge — not a regression."
   },
   "test_zlib_brotli_decompress": {
     "issue": null,
     "added": "2026-05-18",
     "category": "ci-env",
-    "reason": "Brotli decompression path under node:zlib not yet implemented (cf. existing test_parity_zlib module-inventory entry). Same failure observed on #1038 pre-merge \u2014 not a regression."
+    "reason": "Brotli decompression path under node:zlib not yet implemented (cf. existing test_parity_zlib module-inventory entry). Same failure observed on #1038 pre-merge — not a regression."
   }
 }

--- a/test-parity/node-suite/crypto/cipher/aes-128-cbc-roundtrip.ts
+++ b/test-parity/node-suite/crypto/cipher/aes-128-cbc-roundtrip.ts
@@ -1,0 +1,11 @@
+import crypto from "node:crypto";
+// AES-128-CBC round-trip (16-byte key) recovers the plaintext.
+const key = Buffer.alloc(16, 5);
+const iv = Buffer.alloc(16, 9);
+const c = crypto.createCipheriv("aes-128-cbc", key, iv);
+let enc = c.update("hi", "utf8", "hex");
+enc += c.final("hex");
+const d = crypto.createDecipheriv("aes-128-cbc", key, iv);
+let dec = d.update(enc, "hex", "utf8");
+dec += d.final("utf8");
+console.log("round-trip:", dec);

--- a/test-parity/node-suite/crypto/cipher/aes-256-cbc-roundtrip.ts
+++ b/test-parity/node-suite/crypto/cipher/aes-256-cbc-roundtrip.ts
@@ -1,0 +1,12 @@
+import crypto from "node:crypto";
+// createCipheriv / createDecipheriv round-trip: decrypting the ciphertext with
+// the same key+iv recovers the plaintext.
+const key = Buffer.alloc(32, 7);
+const iv = Buffer.alloc(16, 3);
+const c = crypto.createCipheriv("aes-256-cbc", key, iv);
+let enc = c.update("secret", "utf8", "hex");
+enc += c.final("hex");
+const d = crypto.createDecipheriv("aes-256-cbc", key, iv);
+let dec = d.update(enc, "hex", "utf8");
+dec += d.final("utf8");
+console.log("round-trip:", dec);

--- a/test-parity/node-suite/crypto/cipher/aes-256-gcm.ts
+++ b/test-parity/node-suite/crypto/cipher/aes-256-gcm.ts
@@ -1,0 +1,15 @@
+import crypto from "node:crypto";
+// AES-256-GCM produces ciphertext + a 16-byte auth tag; decrypting with the
+// tag recovers the plaintext.
+const key = Buffer.alloc(32, 1);
+const iv = Buffer.alloc(12, 2);
+const c = crypto.createCipheriv("aes-256-gcm", key, iv);
+let enc = c.update("secret", "utf8", "hex");
+enc += c.final("hex");
+const tag = c.getAuthTag();
+const d = crypto.createDecipheriv("aes-256-gcm", key, iv);
+d.setAuthTag(tag);
+let dec = d.update(enc, "hex", "utf8");
+dec += d.final("utf8");
+console.log("tag length:", tag.length);
+console.log("round-trip:", dec);

--- a/test-parity/node-suite/crypto/constants/rsa-padding.ts
+++ b/test-parity/node-suite/crypto/constants/rsa-padding.ts
@@ -1,0 +1,4 @@
+import crypto from "node:crypto";
+// crypto.constants exposes the OpenSSL-defined numeric padding/SSL constants.
+console.log("RSA_PKCS1_PADDING:", typeof crypto.constants.RSA_PKCS1_PADDING);
+console.log("RSA_PKCS1_OAEP_PADDING:", typeof crypto.constants.RSA_PKCS1_OAEP_PADDING);

--- a/test-parity/node-suite/crypto/dh/diffie-hellman.ts
+++ b/test-parity/node-suite/crypto/dh/diffie-hellman.ts
@@ -1,0 +1,4 @@
+import crypto from "node:crypto";
+// Diffie-Hellman / ECDH factory functions.
+console.log("createDiffieHellman:", typeof crypto.createDiffieHellman === "function");
+console.log("createECDH:", typeof crypto.createECDH === "function");

--- a/test-parity/node-suite/crypto/hash/buffer-input.ts
+++ b/test-parity/node-suite/crypto/hash/buffer-input.ts
@@ -1,0 +1,7 @@
+import crypto from "node:crypto";
+// Hashing a Buffer hashes its bytes — same digest as hashing the equivalent
+// string.
+const fromBuf = crypto.createHash("sha256").update(Buffer.from("hello")).digest("hex");
+const fromStr = crypto.createHash("sha256").update("hello").digest("hex");
+console.log("equal:", fromBuf === fromStr);
+console.log(fromBuf);

--- a/test-parity/node-suite/crypto/hash/copy.ts
+++ b/test-parity/node-suite/crypto/hash/copy.ts
@@ -1,0 +1,8 @@
+import crypto from "node:crypto";
+// Hash#copy() clones the in-progress hash state so the two finish independently.
+const h = crypto.createHash("sha256");
+h.update("hello");
+const h2 = h.copy();
+h.update("!");
+console.log("base:", h.digest("hex"));
+console.log("copy:", h2.digest("hex"));

--- a/test-parity/node-suite/crypto/hash/digest-base64.ts
+++ b/test-parity/node-suite/crypto/hash/digest-base64.ts
@@ -1,0 +1,4 @@
+import crypto from "node:crypto";
+// digest("base64") / digest("base64url") encode the digest bytes, not hex.
+console.log("base64:", crypto.createHash("sha256").update("hello").digest("base64"));
+console.log("base64url:", crypto.createHash("sha256").update("hello").digest("base64url"));

--- a/test-parity/node-suite/crypto/hash/digest-buffer-hex.ts
+++ b/test-parity/node-suite/crypto/hash/digest-buffer-hex.ts
@@ -1,0 +1,5 @@
+import crypto from "node:crypto";
+// The no-encoding digest Buffer round-trips through Buffer#toString("hex") to
+// the same hex string as digest("hex").
+const buf = crypto.createHash("sha256").update("hello").digest();
+console.log("hex:", buf.toString("hex"));

--- a/test-parity/node-suite/crypto/hash/digest-buffer-shape.ts
+++ b/test-parity/node-suite/crypto/hash/digest-buffer-shape.ts
@@ -1,0 +1,5 @@
+import crypto from "node:crypto";
+// digest() with no encoding returns a 32-byte Buffer for SHA-256.
+const buf = crypto.createHash("sha256").update("hello").digest();
+console.log("isBuffer:", Buffer.isBuffer(buf));
+console.log("length:", buf.length);

--- a/test-parity/node-suite/crypto/hash/empty-input.ts
+++ b/test-parity/node-suite/crypto/hash/empty-input.ts
@@ -1,0 +1,3 @@
+import crypto from "node:crypto";
+// SHA-256 of the empty string (the canonical e3b0c442... constant).
+console.log(crypto.createHash("sha256").update("").digest("hex"));

--- a/test-parity/node-suite/crypto/hash/incremental-update.ts
+++ b/test-parity/node-suite/crypto/hash/incremental-update.ts
@@ -1,0 +1,7 @@
+import crypto from "node:crypto";
+// Multiple update() calls accumulate; the digest equals hashing the
+// concatenation.
+const a = crypto.createHash("sha256").update("hel").update("lo").digest("hex");
+const b = crypto.createHash("sha256").update("hello").digest("hex");
+console.log("equal:", a === b);
+console.log(a);

--- a/test-parity/node-suite/crypto/hash/md5-hex.ts
+++ b/test-parity/node-suite/crypto/hash/md5-hex.ts
@@ -1,0 +1,2 @@
+import crypto from "node:crypto";
+console.log(crypto.createHash("md5").update("hello").digest("hex"));

--- a/test-parity/node-suite/crypto/hash/sha1-hex.ts
+++ b/test-parity/node-suite/crypto/hash/sha1-hex.ts
@@ -1,0 +1,2 @@
+import crypto from "node:crypto";
+console.log(crypto.createHash("sha1").update("hello").digest("hex"));

--- a/test-parity/node-suite/crypto/hash/sha224-hex.ts
+++ b/test-parity/node-suite/crypto/hash/sha224-hex.ts
@@ -1,0 +1,2 @@
+import crypto from "node:crypto";
+console.log(crypto.createHash("sha224").update("hello").digest("hex"));

--- a/test-parity/node-suite/crypto/hash/sha256-hex.ts
+++ b/test-parity/node-suite/crypto/hash/sha256-hex.ts
@@ -1,0 +1,3 @@
+import crypto from "node:crypto";
+// SHA-256 hex digest of a known string is a fixed value.
+console.log(crypto.createHash("sha256").update("hello").digest("hex"));

--- a/test-parity/node-suite/crypto/hash/sha384-hex.ts
+++ b/test-parity/node-suite/crypto/hash/sha384-hex.ts
@@ -1,0 +1,2 @@
+import crypto from "node:crypto";
+console.log(crypto.createHash("sha384").update("hello").digest("hex"));

--- a/test-parity/node-suite/crypto/hash/sha512-hex.ts
+++ b/test-parity/node-suite/crypto/hash/sha512-hex.ts
@@ -1,0 +1,2 @@
+import crypto from "node:crypto";
+console.log(crypto.createHash("sha512").update("hello").digest("hex"));

--- a/test-parity/node-suite/crypto/hkdf/hkdf-sync.ts
+++ b/test-parity/node-suite/crypto/hkdf/hkdf-sync.ts
@@ -1,0 +1,4 @@
+import crypto from "node:crypto";
+// hkdfSync derives a key deterministically; it returns an ArrayBuffer.
+const out = crypto.hkdfSync("sha256", "key", "salt", "info", 16);
+console.log(Buffer.from(out).toString("hex"));

--- a/test-parity/node-suite/crypto/hmac/incremental-update.ts
+++ b/test-parity/node-suite/crypto/hmac/incremental-update.ts
@@ -1,0 +1,6 @@
+import crypto from "node:crypto";
+// Chained HMAC update() accumulates; equals hashing the concatenation.
+const a = crypto.createHmac("sha256", "key").update("he").update("llo").digest("hex");
+const b = crypto.createHmac("sha256", "key").update("hello").digest("hex");
+console.log("equal:", a === b);
+console.log(a);

--- a/test-parity/node-suite/crypto/hmac/sha1-hex.ts
+++ b/test-parity/node-suite/crypto/hmac/sha1-hex.ts
@@ -1,0 +1,2 @@
+import crypto from "node:crypto";
+console.log(crypto.createHmac("sha1", "key").update("hello").digest("hex"));

--- a/test-parity/node-suite/crypto/hmac/sha256-hex.ts
+++ b/test-parity/node-suite/crypto/hmac/sha256-hex.ts
@@ -1,0 +1,3 @@
+import crypto from "node:crypto";
+// HMAC-SHA256 hex digest of a known (key, message) pair is fixed.
+console.log(crypto.createHmac("sha256", "key").update("hello").digest("hex"));

--- a/test-parity/node-suite/crypto/hmac/sha512-hex.ts
+++ b/test-parity/node-suite/crypto/hmac/sha512-hex.ts
@@ -1,0 +1,2 @@
+import crypto from "node:crypto";
+console.log(crypto.createHmac("sha512", "key").update("hello").digest("hex"));

--- a/test-parity/node-suite/crypto/introspection/get-ciphers.ts
+++ b/test-parity/node-suite/crypto/introspection/get-ciphers.ts
@@ -1,0 +1,5 @@
+import crypto from "node:crypto";
+// crypto.getCiphers() lists supported cipher algorithms.
+const c = crypto.getCiphers();
+console.log("is array:", Array.isArray(c));
+console.log("includes aes-256-cbc:", c.includes("aes-256-cbc"));

--- a/test-parity/node-suite/crypto/introspection/get-hashes.ts
+++ b/test-parity/node-suite/crypto/introspection/get-hashes.ts
@@ -1,0 +1,5 @@
+import crypto from "node:crypto";
+// crypto.getHashes() lists supported hash algorithms.
+const h = crypto.getHashes();
+console.log("is array:", Array.isArray(h));
+console.log("includes sha256:", h.includes("sha256"));

--- a/test-parity/node-suite/crypto/keys/create-secret-key.ts
+++ b/test-parity/node-suite/crypto/keys/create-secret-key.ts
@@ -1,0 +1,4 @@
+import crypto from "node:crypto";
+// createSecretKey(buffer) returns a KeyObject (an object).
+const k = crypto.createSecretKey(Buffer.from("secret-key-bytes"));
+console.log("typeof:", typeof k);

--- a/test-parity/node-suite/crypto/keys/generate-key-pair-sync.ts
+++ b/test-parity/node-suite/crypto/keys/generate-key-pair-sync.ts
@@ -1,0 +1,4 @@
+import crypto from "node:crypto";
+// generateKeyPairSync is a function (used to produce {publicKey, privateKey}).
+console.log("generateKeyPairSync:", typeof crypto.generateKeyPairSync === "function");
+console.log("generateKeySync:", typeof crypto.generateKeySync === "function");

--- a/test-parity/node-suite/crypto/misc/timing-safe-equal.ts
+++ b/test-parity/node-suite/crypto/misc/timing-safe-equal.ts
@@ -1,0 +1,4 @@
+import crypto from "node:crypto";
+// timingSafeEqual compares two equal-length buffers in constant time.
+console.log("equal:", crypto.timingSafeEqual(Buffer.from("abc"), Buffer.from("abc")));
+console.log("not equal:", crypto.timingSafeEqual(Buffer.from("abc"), Buffer.from("abd")));

--- a/test-parity/node-suite/crypto/pbkdf2/sha256-sync.ts
+++ b/test-parity/node-suite/crypto/pbkdf2/sha256-sync.ts
@@ -1,0 +1,3 @@
+import crypto from "node:crypto";
+// pbkdf2Sync with SHA-256 is deterministic for fixed inputs.
+console.log(crypto.pbkdf2Sync("pw", "salt", 100, 16, "sha256").toString("hex"));

--- a/test-parity/node-suite/crypto/pbkdf2/sha512-sync.ts
+++ b/test-parity/node-suite/crypto/pbkdf2/sha512-sync.ts
@@ -1,0 +1,4 @@
+import crypto from "node:crypto";
+// pbkdf2Sync honors the digest argument — sha512 produces a different (and
+// specific) result than sha256.
+console.log(crypto.pbkdf2Sync("pw", "salt", 50, 16, "sha512").toString("hex"));

--- a/test-parity/node-suite/crypto/random/random-bytes-length.ts
+++ b/test-parity/node-suite/crypto/random/random-bytes-length.ts
@@ -1,0 +1,6 @@
+import crypto from "node:crypto";
+// randomBytes(n) returns an n-byte Buffer (value is non-deterministic).
+const b = crypto.randomBytes(16);
+console.log("isBuffer:", Buffer.isBuffer(b));
+console.log("length:", b.length);
+console.log("zero length:", crypto.randomBytes(0).length);

--- a/test-parity/node-suite/crypto/random/random-fill-sync.ts
+++ b/test-parity/node-suite/crypto/random/random-fill-sync.ts
@@ -1,0 +1,7 @@
+import crypto from "node:crypto";
+// randomFillSync fills the given buffer in place and returns it (value is
+// non-deterministic; length/identity are fixed).
+const buf = Buffer.alloc(8);
+const ret = crypto.randomFillSync(buf);
+console.log("length:", buf.length);
+console.log("returns same buffer:", ret === buf);

--- a/test-parity/node-suite/crypto/random/random-int.ts
+++ b/test-parity/node-suite/crypto/random/random-int.ts
@@ -1,0 +1,5 @@
+import crypto from "node:crypto";
+// randomInt(min, max) returns an integer in [min, max).
+const n = crypto.randomInt(0, 10);
+console.log("in range:", n >= 0 && n < 10);
+console.log("integer:", Number.isInteger(n));

--- a/test-parity/node-suite/crypto/random/uuid-format.ts
+++ b/test-parity/node-suite/crypto/random/uuid-format.ts
@@ -1,0 +1,9 @@
+import crypto from "node:crypto";
+// randomUUID() is non-deterministic, but its shape is fixed: 36 chars, 4
+// dashes, version nibble '4', and a valid RFC-4122 variant nibble.
+const u = crypto.randomUUID();
+console.log("length:", u.length);
+console.log("dashes:", (u.match(/-/g) || []).length);
+console.log("version:", u[14]);
+console.log("variant:", ["8", "9", "a", "b"].includes(u[19].toLowerCase()));
+console.log("hex-and-dashes:", /^[0-9a-f-]+$/.test(u));

--- a/test-parity/node-suite/crypto/scrypt/scrypt-sync.ts
+++ b/test-parity/node-suite/crypto/scrypt/scrypt-sync.ts
@@ -1,0 +1,3 @@
+import crypto from "node:crypto";
+// scryptSync is deterministic for fixed inputs.
+console.log(crypto.scryptSync("pw", "salt", 16).toString("hex"));

--- a/test-parity/node-suite/crypto/shapes/method-types.ts
+++ b/test-parity/node-suite/crypto/shapes/method-types.ts
@@ -1,0 +1,7 @@
+import crypto from "node:crypto";
+// The crypto methods are callable function values (the call forms work, but
+// reading them as values must also report "function").
+console.log("createHash:", typeof crypto.createHash === "function");
+console.log("createHmac:", typeof crypto.createHmac === "function");
+console.log("randomBytes:", typeof crypto.randomBytes === "function");
+console.log("pbkdf2Sync:", typeof crypto.pbkdf2Sync === "function");

--- a/test-parity/node-suite/crypto/sign/create-sign-verify.ts
+++ b/test-parity/node-suite/crypto/sign/create-sign-verify.ts
@@ -1,0 +1,4 @@
+import crypto from "node:crypto";
+// createSign / createVerify are factory functions for signature streams.
+console.log("createSign:", typeof crypto.createSign === "function");
+console.log("createVerify:", typeof crypto.createVerify === "function");

--- a/test-parity/node-suite/crypto/subtle/subtle-shape.ts
+++ b/test-parity/node-suite/crypto/subtle/subtle-shape.ts
@@ -1,0 +1,5 @@
+import crypto from "node:crypto";
+// crypto.subtle is the WebCrypto SubtleCrypto object with async primitives.
+console.log("subtle object:", typeof crypto.subtle === "object" && crypto.subtle !== null);
+console.log("digest:", typeof crypto.subtle.digest === "function");
+console.log("importKey:", typeof crypto.subtle.importKey === "function");

--- a/test-parity/node-suite/crypto/webcrypto/get-random-values.ts
+++ b/test-parity/node-suite/crypto/webcrypto/get-random-values.ts
@@ -1,0 +1,7 @@
+import crypto from "node:crypto";
+// crypto.getRandomValues (WebCrypto) fills a typed array in place.
+console.log("is function:", typeof crypto.getRandomValues === "function");
+const a = new Uint8Array(8);
+const ret = crypto.getRandomValues(a);
+console.log("returns same:", ret === a);
+console.log("length:", a.length);

--- a/test-parity/node-suite/crypto/x509/x509-certificate.ts
+++ b/test-parity/node-suite/crypto/x509/x509-certificate.ts
@@ -1,0 +1,3 @@
+import crypto from "node:crypto";
+// X509Certificate is exposed as a constructor.
+console.log("X509Certificate:", typeof crypto.X509Certificate === "function");


### PR DESCRIPTION
First `node-suite` coverage for `node:crypto` (there was none before). **40 granular** cases covering the full module surface, validated against `node --experimental-strip-types`. Tests use the namespace form (`import crypto from "node:crypto"`), which Perry special-cases; the named-import form returns `undefined` (folded into #1332).

## Passing (17/40) — the deterministic hashing/HMAC core
hash `sha256`/`md5`/`sha1`/`sha512` hex · empty-input · incremental `update()` · `digest()` Buffer shape · HMAC `sha256`/`sha512`/`sha1` (+incremental) · `pbkdf2Sync(sha256)` · `randomUUID` format · `randomBytes` length · `randomFillSync` · `createSecretKey` · `crypto.constants`.

## Gaps (23/40) — all recorded in `known_failures.json`
**Bugs in existing features → #1332:** `digest('base64'|'base64url')` encoding · `digest()` Buffer `toString('hex')` · Buffer input hashing · `pbkdf2` non-sha256 digest · aes-128/256-cbc round-trip → `NaN`.

**Unimplemented algorithms/APIs → #1334:** `sha224`/`sha384` · `getHashes`/`getCiphers` · `randomInt` · `timingSafeEqual` · `scryptSync` · `hkdfSync` · AES-GCM round-trip · `createSign`/`createVerify` · `generateKeyPairSync` · `crypto.subtle` (WebCrypto) · `getRandomValues` · `X509Certificate` · `createDiffieHellman`/`createECDH` · `Hash#copy` · method-value `typeof` reflection.

This is the full deterministic + shape surface of `node:crypto`; every gap is a reproducible test that flips green when the API lands. No version bump / CHANGELOG (maintainer folds in at merge).