### PR TITLE
test(parity): expand node:perf_hooks coverage (timerify/histogram/nodeTiming/toJSON/resource-timing)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -20,6 +20,54 @@
     "category": "bug-open",
     "reason": "node:perf_hooks granular parity: globalThis.performance !== the node:perf_hooks named import. The import resolves to a fresh namespace object per read and the global is a separate path; neither is a cached singleton. Flips to PASS when #1327 lands."
   },
+  "node-suite/perf_hooks/timerify/timerify": {
+    "issue": "1335",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:perf_hooks: performance.timerify(fn) unimplemented (not a function). Flips to PASS when #1335 lands."
+  },
+  "node-suite/perf_hooks/histogram/monitor-event-loop-delay": {
+    "issue": "1336",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:perf_hooks: monitorEventLoopDelay() unimplemented (not a function). Flips to PASS when #1336 lands."
+  },
+  "node-suite/perf_hooks/histogram/create-histogram": {
+    "issue": "1336",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:perf_hooks: createHistogram() unimplemented (not a function). Flips to PASS when #1336 lands."
+  },
+  "node-suite/perf_hooks/node-timing/node-timing": {
+    "issue": "1337",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:perf_hooks: performance.nodeTiming (PerformanceNodeTiming) unimplemented (not an object). Flips to PASS when #1337 lands."
+  },
+  "node-suite/perf_hooks/to-json/to-json": {
+    "issue": "1338",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:perf_hooks: performance.toJSON() unimplemented (not a function). Flips to PASS when #1338 lands."
+  },
+  "node-suite/perf_hooks/resource-timing/clear-and-buffer-size": {
+    "issue": "1339",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:perf_hooks: clearResourceTimings() / setResourceTimingBufferSize() unimplemented. Flips to PASS when #1339 lands."
+  },
+  "node-suite/perf_hooks/mark/detail-structured-clone": {
+    "issue": "1340",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:perf_hooks: mark detail is not structured-cloned (m.detail === input instead of a distinct deep-equal copy). Flips to PASS when #1340 lands."
+  },
+  "node-suite/perf_hooks/observer/supported-entry-types": {
+    "issue": "1341",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:perf_hooks: PerformanceObserver.supportedEntryTypes.includes('mark'/'measure') is not usable (static array membership). Flips to PASS when #1341 lands."
+  },
   "node-suite/console/dir/depth-options": {
     "issue": "1199",
     "added": "2026-05-20",

--- a/test-parity/node-suite/perf_hooks/entries/by-name-with-type.ts
+++ b/test-parity/node-suite/perf_hooks/entries/by-name-with-type.ts
@@ -1,0 +1,7 @@
+import { performance } from "node:perf_hooks";
+// getEntriesByName(name, type) filters by both name and entryType.
+performance.mark("dup");
+performance.mark("dup", { startTime: 1 });
+console.log("by name only:", performance.getEntriesByName("dup").length);
+console.log("by name+mark:", performance.getEntriesByName("dup", "mark").length);
+console.log("by name+measure:", performance.getEntriesByName("dup", "measure").length);

--- a/test-parity/node-suite/perf_hooks/eventlooputil/diff-two-arg.ts
+++ b/test-parity/node-suite/perf_hooks/eventlooputil/diff-two-arg.ts
@@ -1,0 +1,8 @@
+import { performance } from "node:perf_hooks";
+// eventLoopUtilization(utilSince1, utilSince2) computes the delta between two
+// prior readings; utilization stays in [0, 1].
+const a = performance.eventLoopUtilization();
+const b = performance.eventLoopUtilization();
+const d = performance.eventLoopUtilization(b, a);
+console.log("utilization type:", typeof d.utilization);
+console.log("in range:", d.utilization >= 0 && d.utilization <= 1);

--- a/test-parity/node-suite/perf_hooks/histogram/create-histogram.ts
+++ b/test-parity/node-suite/perf_hooks/histogram/create-histogram.ts
@@ -1,0 +1,6 @@
+import { createHistogram } from "node:perf_hooks";
+// createHistogram() returns a RecordableHistogram supporting record()/min/max.
+const h = createHistogram();
+console.log("record:", typeof h.record === "function");
+h.record(5);
+console.log("count:", typeof h.count === "number");

--- a/test-parity/node-suite/perf_hooks/histogram/monitor-event-loop-delay.ts
+++ b/test-parity/node-suite/perf_hooks/histogram/monitor-event-loop-delay.ts
@@ -1,0 +1,7 @@
+import { monitorEventLoopDelay } from "node:perf_hooks";
+// monitorEventLoopDelay() returns an IntervalHistogram with enable/disable +
+// stats accessors.
+const h = monitorEventLoopDelay();
+console.log("enable:", typeof h.enable === "function");
+console.log("disable:", typeof h.disable === "function");
+console.log("mean:", typeof h.mean === "number");

--- a/test-parity/node-suite/perf_hooks/mark/detail-structured-clone.ts
+++ b/test-parity/node-suite/perf_hooks/mark/detail-structured-clone.ts
@@ -1,0 +1,7 @@
+import { performance } from "node:perf_hooks";
+// mark(name, { detail }) structured-clones detail: the stored value deep-equals
+// the input but is a distinct object reference.
+const d = { x: 1 };
+const m = performance.mark("c", { detail: d });
+console.log("deep equal:", JSON.stringify(m.detail) === JSON.stringify(d));
+console.log("distinct ref:", m.detail !== d);

--- a/test-parity/node-suite/perf_hooks/node-timing/node-timing.ts
+++ b/test-parity/node-suite/perf_hooks/node-timing/node-timing.ts
@@ -1,0 +1,7 @@
+import { performance } from "node:perf_hooks";
+// performance.nodeTiming is a PerformanceNodeTiming entry with bootstrap
+// milestones.
+const nt = performance.nodeTiming;
+console.log("is object:", typeof nt === "object" && nt !== null);
+console.log("nodeStart number:", typeof nt.nodeStart === "number");
+console.log("entryType:", nt.entryType);

--- a/test-parity/node-suite/perf_hooks/observer/observe-single-type.ts
+++ b/test-parity/node-suite/perf_hooks/observer/observe-single-type.ts
@@ -1,0 +1,12 @@
+import { performance, PerformanceObserver } from "node:perf_hooks";
+// observe({ type }) is the single-entry-type form of observe().
+await new Promise<void>((resolve) => {
+  const obs = new PerformanceObserver((list) => {
+    console.log("observed:", list.getEntries().map((e) => e.name).join(","));
+    obs.disconnect();
+    resolve();
+  });
+  obs.observe({ type: "mark" });
+  performance.mark("a");
+  performance.mark("b");
+});

--- a/test-parity/node-suite/perf_hooks/observer/supported-entry-types.ts
+++ b/test-parity/node-suite/perf_hooks/observer/supported-entry-types.ts
@@ -1,0 +1,7 @@
+import { PerformanceObserver } from "node:perf_hooks";
+// PerformanceObserver.supportedEntryTypes is a static array including the
+// user-timing types.
+const t = PerformanceObserver.supportedEntryTypes;
+console.log("is array:", Array.isArray(t));
+console.log("includes mark:", t.includes("mark"));
+console.log("includes measure:", t.includes("measure"));

--- a/test-parity/node-suite/perf_hooks/resource-timing/clear-and-buffer-size.ts
+++ b/test-parity/node-suite/perf_hooks/resource-timing/clear-and-buffer-size.ts
@@ -1,0 +1,4 @@
+import { performance } from "node:perf_hooks";
+// The resource-timing buffer management methods exist on performance.
+console.log("clearResourceTimings:", typeof performance.clearResourceTimings === "function");
+console.log("setResourceTimingBufferSize:", typeof performance.setResourceTimingBufferSize === "function");

--- a/test-parity/node-suite/perf_hooks/timerify/timerify.ts
+++ b/test-parity/node-suite/perf_hooks/timerify/timerify.ts
@@ -1,0 +1,6 @@
+import { performance } from "node:perf_hooks";
+// performance.timerify(fn) wraps fn so each call records a 'function' timeline
+// entry; the wrapper still returns fn's result.
+const wrapped = performance.timerify((a: number, b: number) => a + b);
+console.log("is function:", typeof wrapped === "function");
+console.log("result:", wrapped(2, 3));

--- a/test-parity/node-suite/perf_hooks/to-json/to-json.ts
+++ b/test-parity/node-suite/perf_hooks/to-json/to-json.ts
@@ -1,0 +1,5 @@
+import { performance } from "node:perf_hooks";
+// performance.toJSON() returns a snapshot object including timeOrigin.
+const j = performance.toJSON();
+console.log("is object:", typeof j === "object" && j !== null);
+console.log("timeOrigin number:", typeof j.timeOrigin === "number");


### PR DESCRIPTION
Follow-up to #1321/#1328 (perf_hooks, merged). Audited the suite for missing coverage and added 11 granular cases for the rest of the `node:perf_hooks` surface.

## New passing
- `observer/observe-single-type` — `observe({ type })` single-entry-type form
- `eventlooputil/diff-two-arg` — `eventLoopUtilization(b, a)` delta form
- `entries/by-name-with-type` — `getEntriesByName(name, type)`

## New gaps — each with its own granular issue
- `timerify` → #1335
- `monitorEventLoopDelay` / `createHistogram` → #1336
- `nodeTiming` → #1337
- `toJSON` → #1338
- `clearResourceTimings` / `setResourceTimingBufferSize` → #1339
- `mark` detail structured-clone → #1340
- `PerformanceObserver.supportedEntryTypes.includes` → #1341

All recorded in `known_failures.json` pointing at the specific issue. No version bump / CHANGELOG.