### PR TITLE
feat(process): #1330 wire method values, env writes, hrtime(), argv0/execPath/title

### DIFF
--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -498,6 +498,12 @@ impl JsEmitter {
                 self.emit_expr(cb);
                 self.output.push_str("))");
             }
+            Expr::ProcessHrtime(prev) => {
+                self.output
+                    .push_str("(typeof process !== 'undefined' ? process.hrtime(");
+                self.emit_expr(prev);
+                self.output.push_str(") : [0, 0])");
+            }
             Expr::ProcessOn { event, handler } => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.on(");
                 self.emit_expr(event);

--- a/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
@@ -115,6 +115,7 @@ impl<'a> FuncEmitCtx<'a> {
                 func.instruction(&Instruction::I64Const(TAG_UNDEFINED as i64));
             }
             Expr::ProcessNextTick(_)
+            | Expr::ProcessHrtime(_)
             | Expr::ProcessChdir(_)
             | Expr::ProcessOn { .. }
             | Expr::ProcessKill { .. }

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -364,6 +364,7 @@ pub fn check_escapes_in_expr(
         | Expr::StructuredClone(operand)
         | Expr::QueueMicrotask(operand)
         | Expr::ProcessNextTick(operand)
+        | Expr::ProcessHrtime(operand)
         | Expr::ArrayIsArray(operand) => {
             check_escapes_in_expr(operand, candidates, classes, escaped);
         }

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -253,6 +253,7 @@ fn collect_used_new_fields_in_expr(
         | Expr::StructuredClone(operand)
         | Expr::QueueMicrotask(operand)
         | Expr::ProcessNextTick(operand)
+        | Expr::ProcessHrtime(operand)
         | Expr::ArrayIsArray(operand)
         | Expr::ObjectRest {
             object: operand, ..

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -968,6 +968,7 @@ pub fn collect_localset_ids_in_expr_filtered(
         | Expr::StructuredClone(operand)
         | Expr::QueueMicrotask(operand)
         | Expr::ProcessNextTick(operand)
+        | Expr::ProcessHrtime(operand)
         | Expr::FsExistsSync(operand)
         | Expr::FsReadFileSync(operand)
         | Expr::FsReadFileBinary(operand)

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -218,6 +218,7 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         | Expr::StructuredClone(operand)
         | Expr::QueueMicrotask(operand)
         | Expr::ProcessNextTick(operand)
+        | Expr::ProcessHrtime(operand)
         | Expr::FsExistsSync(operand)
         | Expr::FsReadFileSync(operand)
         | Expr::FsReadFileBinary(operand)

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -201,6 +201,24 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     );
                     Ok(blk.bitcast_i64_to_double(&tagged))
                 }
+                // delete process.env.KEY — remove the variable from the real
+                // process environment (the store EnvGet reads), so the next
+                // read is undefined. `delete` evaluates to true. (#1330)
+                Expr::EnvGet(name) => {
+                    let key_idx = ctx.strings.intern(name);
+                    let key_handle_global =
+                        format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                    let blk = ctx.block();
+                    let key_box = blk.load(DOUBLE, &key_handle_global);
+                    let key_handle = unbox_to_i64(blk, &key_box);
+                    Ok(blk.call(DOUBLE, "js_removeenv", &[(I64, &key_handle)]))
+                }
+                Expr::EnvGetDynamic(name_expr) => {
+                    let key_box = lower_expr(ctx, name_expr)?;
+                    let blk = ctx.block();
+                    let key_handle = unbox_str_handle(blk, &key_box);
+                    Ok(blk.call(DOUBLE, "js_removeenv", &[(I64, &key_handle)]))
+                }
                 _ => {
                     let _ = lower_expr(ctx, operand)?;
                     Ok(double_literal(1.0))
@@ -430,6 +448,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             };
             blk.call_void(runtime, &[(I64, &cb_handle)]);
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
+        }
+
+        // process.hrtime([prev]) -> [seconds, nanoseconds]. The operand is
+        // the optional previous tuple (Undefined for the no-arg form); the
+        // runtime returns an already-NaN-boxed array pointer. (#1330)
+        Expr::ProcessHrtime(prev) => {
+            let prev_box = lower_expr(ctx, prev)?;
+            let blk = ctx.block();
+            Ok(blk.call(DOUBLE, "js_process_hrtime", &[(DOUBLE, &prev_box)]))
         }
 
         // -------- RegExpTest --------

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -957,6 +957,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::PathWin32 { .. }
         | Expr::QueueMicrotask(..)
         | Expr::ProcessNextTick(..)
+        | Expr::ProcessHrtime(..)
         | Expr::RegExpTest { .. }
         | Expr::RegExpExec { .. }
         | Expr::GlobalGet(..)

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -533,6 +533,50 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         ],
                     ));
                 }
+                // node:process — `process.cwd` / `process.nextTick` / … read
+                // as VALUES (not called), plus the string props argv0 /
+                // execPath / title. Bare `process` lowers to the GlobalGet(0)
+                // sentinel, so the receiver name is gone here; we route by the
+                // process-distinctive property name through the native-module
+                // property helper, which returns a bound-method closure
+                // (typeof "function") for the methods and a string for the
+                // props. The call forms (`process.cwd()`) lower separately to
+                // dedicated HIR variants and never reach here. (#1330)
+                if matches!(
+                    property.as_str(),
+                    "cwd"
+                        | "nextTick"
+                        | "hrtime"
+                        | "exit"
+                        | "on"
+                        | "once"
+                        | "uptime"
+                        | "memoryUsage"
+                        | "cpuUsage"
+                        | "kill"
+                        | "chdir"
+                        | "argv0"
+                        | "execPath"
+                        | "title"
+                ) {
+                    let mod_idx = ctx.strings.intern("process");
+                    let mod_bytes_global = format!("@{}", ctx.strings.entry(mod_idx).bytes_global);
+                    let mod_len_str = "process".len().to_string();
+                    let prop_idx = ctx.strings.intern(property);
+                    let prop_bytes_global =
+                        format!("@{}", ctx.strings.entry(prop_idx).bytes_global);
+                    let prop_len_str = property.len().to_string();
+                    return Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_native_module_property_by_name",
+                        &[
+                            (PTR, &mod_bytes_global),
+                            (I64, &mod_len_str),
+                            (PTR, &prop_bytes_global),
+                            (I64, &prop_len_str),
+                        ],
+                    ));
+                }
                 // Built-in constructors / namespaces exposed on globalThis
                 // (`Array`, `Object`, `Math`, `JSON`, ...): route the read
                 // through the singleton so `globalThis.Array` (and the

--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -53,6 +53,26 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             property,
             value,
         } => {
+            // process.env.KEY = v — write the real process environment (the
+            // store EnvGet/js_getenv reads), coercing the value to a string
+            // like Node. Pre-fix this lowered to a generic field-set on the
+            // cached js_process_env() object, which EnvGet never consults, so
+            // the write never round-tripped (#1330). The assignment evaluates
+            // to the RHS, so we return the original value double.
+            if matches!(object.as_ref(), Expr::ProcessEnv) {
+                let key_idx = ctx.strings.intern(property);
+                let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                let val_double = lower_expr(ctx, value)?;
+                let blk = ctx.block();
+                let key_box = blk.load(DOUBLE, &key_handle_global);
+                let key_handle = unbox_to_i64(blk, &key_box);
+                blk.call(
+                    DOUBLE,
+                    "js_setenv",
+                    &[(I64, &key_handle), (DOUBLE, &val_double)],
+                );
+                return Ok(val_double);
+            }
             // Closes #304: `arr.length = N` must mutate the ArrayHeader, not
             // set a "length" field in the object dispatch. Pre-fix the generic
             // `js_object_set_field_by_name(arr, "length", N)` path silently

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -455,6 +455,13 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_memory_usage", DOUBLE, &[]);
     module.declare_function("js_process_env", DOUBLE, &[]);
     module.declare_function("js_process_hrtime_bigint", DOUBLE, &[]);
+    // process.hrtime([prev]) -> [s, ns] tuple; prev (or undefined) is a
+    // NaN-boxed f64, result is an already-NaN-boxed array pointer (#1330).
+    module.declare_function("js_process_hrtime", DOUBLE, &[DOUBLE]);
+    // process.env.KEY = v / delete process.env.KEY — write/remove the real
+    // OS environment. Name is a StringHeader* passed as I64 (#1330).
+    module.declare_function("js_setenv", DOUBLE, &[I64, DOUBLE]);
+    module.declare_function("js_removeenv", DOUBLE, &[I64]);
     module.declare_function("js_process_chdir", VOID, &[I64]);
     module.declare_function("js_process_kill", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_process_exit", VOID, &[DOUBLE]);

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -436,6 +436,11 @@ pub enum Expr {
     ProcessVersions,
     // process.hrtime.bigint() -> bigint (nanoseconds since arbitrary point)
     ProcessHrtimeBigint,
+    // process.hrtime([prev]) -> [seconds, nanoseconds] integer tuple.
+    // The operand is the optional previous tuple for the diff form; a
+    // no-arg call carries `Expr::Undefined` so the variant always holds a
+    // child (keeps it in the existing single-operand walker groups).
+    ProcessHrtime(Box<Expr>),
     // process.nextTick(callback) -> void
     ProcessNextTick(Box<Expr>),
     // process.on(event, handler) -> void (registers an event listener)

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -36,6 +36,15 @@ pub(super) fn try_native_module_methods(
                         "uptime" => return Ok(Ok(Expr::ProcessUptime)),
                         "cwd" => return Ok(Ok(Expr::ProcessCwd)),
                         "memoryUsage" => return Ok(Ok(Expr::ProcessMemoryUsage)),
+                        // process.hrtime() / process.hrtime(prevTuple). The
+                        // `process.hrtime.bigint()` form is intercepted earlier
+                        // by try_process_hrtime_bigint (nested_namespace.rs), so
+                        // only the direct call reaches here. Carry the optional
+                        // prev arg, defaulting to Undefined for the no-arg form.
+                        "hrtime" => {
+                            let arg = args.into_iter().next().unwrap_or(Expr::Undefined);
+                            return Ok(Ok(Expr::ProcessHrtime(Box::new(arg))));
+                        }
                         "nextTick" => {
                             if !args.is_empty() {
                                 return Ok(Ok(Expr::ProcessNextTick(Box::new(

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -81,6 +81,7 @@ impl SH for Expr {
             Expr::ProcessVersion => tag(h, 62),
             Expr::ProcessVersions => tag(h, 63),
             Expr::ProcessHrtimeBigint => tag(h, 64),
+            Expr::ProcessHrtime(e) => { tag(h, 11224); e.as_ref().hash(h); }
             Expr::ProcessNextTick(e) => { tag(h, 65); e.as_ref().hash(h); }
             Expr::ProcessOn { event, handler } => { tag(h, 66); event.as_ref().hash(h); handler.as_ref().hash(h); }
             Expr::ProcessOnce { event, handler } => { tag(h, 11223); event.as_ref().hash(h); handler.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -101,6 +101,7 @@ where
         | Expr::StaticFieldSet { value: v, .. }
         | Expr::EnvGetDynamic(v)
         | Expr::ProcessNextTick(v)
+        | Expr::ProcessHrtime(v)
         | Expr::ProcessChdir(v)
         | Expr::ProcessStdinSetRawMode(v)
         | Expr::TtyIsAtty(v)

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -102,6 +102,7 @@ where
         | Expr::StaticFieldSet { value: v, .. }
         | Expr::EnvGetDynamic(v)
         | Expr::ProcessNextTick(v)
+        | Expr::ProcessHrtime(v)
         | Expr::ProcessChdir(v)
         | Expr::ProcessStdinSetRawMode(v)
         | Expr::TtyIsAtty(v)

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -443,6 +443,23 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("console", "profile")
             | ("console", "profileEnd")
             | ("console", "timeStamp")
+            // node:process — methods read as VALUES (`typeof process.cwd ===
+            // "function"`, `const f = process.nextTick`). The call forms are
+            // lowered to dedicated HIR variants (ProcessCwd/ProcessHrtime/…)
+            // and never reach here; this just keeps the property-read form a
+            // callable closure so `typeof` matches Node (#1330). cpuUsage has
+            // no call lowering yet — the read still reports "function".
+            | ("process", "cwd")
+            | ("process", "nextTick")
+            | ("process", "hrtime")
+            | ("process", "exit")
+            | ("process", "on")
+            | ("process", "once")
+            | ("process", "uptime")
+            | ("process", "memoryUsage")
+            | ("process", "cpuUsage")
+            | ("process", "kill")
+            | ("process", "chdir")
     )
 }
 
@@ -1106,6 +1123,39 @@ pub(crate) unsafe fn get_native_module_constant(
             "NODE_PERFORMANCE_GC_FLAGS_ALL_AVAILABLE_GARBAGE" => Some(16.0),
             "NODE_PERFORMANCE_GC_FLAGS_ALL_EXTERNAL_MEMORY" => Some(32.0),
             "NODE_PERFORMANCE_GC_FLAGS_SCHEDULE_IDLE" => Some(64.0),
+            _ => None,
+        },
+        // node:process — string-valued properties read off the bare global
+        // `process` (lowered to a `GlobalGet` PropertyGet that routes here).
+        // Values differ per runtime; Node guarantees only that they're
+        // strings (#1330).
+        "process" => match property {
+            "argv0" => {
+                let v = std::env::args()
+                    .next()
+                    .unwrap_or_else(|| "perry".to_string());
+                Some(str_val(&v))
+            }
+            "execPath" => {
+                let v = std::env::current_exe()
+                    .ok()
+                    .and_then(|p| p.to_str().map(|s| s.to_string()))
+                    .or_else(|| std::env::args().next())
+                    .unwrap_or_else(|| "perry".to_string());
+                Some(str_val(&v))
+            }
+            "title" => {
+                let v = std::env::current_exe()
+                    .ok()
+                    .and_then(|p| {
+                        p.file_name()
+                            .and_then(|n| n.to_str())
+                            .map(|s| s.to_string())
+                    })
+                    .or_else(|| std::env::args().next())
+                    .unwrap_or_else(|| "perry".to_string());
+                Some(str_val(&v))
+            }
             _ => None,
         },
         "path" => match property {

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -557,6 +557,44 @@ pub extern "C" fn js_process_hrtime_bigint() -> f64 {
     js_nanbox_bigint(bi as i64)
 }
 
+/// process.hrtime([prev]) -> [seconds, nanoseconds]
+///
+/// Returns a 2-element integer tuple of the high-resolution real time
+/// relative to an arbitrary, monotonic process-start baseline (the same
+/// baseline `process.hrtime.bigint()` uses). When `prev` is a previous
+/// `[s, ns]` tuple, returns the non-negative diff `now - prev`, matching
+/// Node; an undefined/non-array `prev` yields the absolute reading.
+/// Returns a NaN-boxed POINTER_TAG f64 so codegen can use it directly.
+#[no_mangle]
+pub extern "C" fn js_process_hrtime(prev: f64) -> f64 {
+    use crate::array::{js_array_alloc, js_array_get_element, js_array_push_f64};
+    use crate::value::JSValue;
+
+    let mut total_ns: u128 = get_hrtime_start().elapsed().as_nanos();
+
+    // Diff form: `process.hrtime(prevTuple)` subtracts the supplied
+    // `[seconds, nanoseconds]` reading. Monotonic baseline guarantees
+    // `now >= prev`, so the saturating subtraction never wraps.
+    let pv = JSValue::from_bits(prev.to_bits());
+    if pv.is_pointer() {
+        let arr_i64 = pv.as_pointer::<ArrayHeader>() as i64;
+        let prev_s = js_array_get_element(arr_i64, 0);
+        let prev_ns = js_array_get_element(arr_i64, 1);
+        if prev_s.is_finite() && prev_ns.is_finite() {
+            let prev_total = (prev_s.max(0.0) as u128) * 1_000_000_000 + (prev_ns.max(0.0) as u128);
+            total_ns = total_ns.saturating_sub(prev_total);
+        }
+    }
+
+    let secs = (total_ns / 1_000_000_000) as f64;
+    let nsec = (total_ns % 1_000_000_000) as f64;
+
+    let arr = js_array_alloc(2);
+    let arr = js_array_push_f64(arr, secs);
+    let arr = js_array_push_f64(arr, nsec);
+    f64::from_bits(JSValue::pointer(arr as *const u8).bits())
+}
+
 // process.on/once handlers, partitioned by event name. Today only
 // 'uncaughtException' actually fires from the runtime (during the diag
 // uncaught-drain hook); 'exit' and any other event names are stored so

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -90,6 +90,58 @@ pub extern "C" fn js_getenv_value(name_ptr: *const StringHeader) -> f64 {
     f64::from_bits(val.bits())
 }
 
+/// Read a `*StringHeader` into an owned `String` (mirrors `js_getenv`'s
+/// inline decode). Returns `None` for a null/low-tagged pointer or
+/// non-UTF-8 bytes.
+unsafe fn header_to_string(ptr: *const StringHeader) -> Option<String> {
+    if ptr.is_null() || (ptr as usize) < 0x1000 {
+        return None;
+    }
+    let len = (*ptr).byte_len as usize;
+    let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+    let bytes = std::slice::from_raw_parts(data, len);
+    std::str::from_utf8(bytes).ok().map(|s| s.to_string())
+}
+
+/// `process.env.KEY = value` — write the real process environment.
+///
+/// `process.env` is backed by the OS environment (the same store
+/// `js_getenv`/`Expr::EnvGet` reads), so writing here makes a subsequent
+/// `process.env.KEY` read round-trip. Node coerces assigned values to
+/// strings (`process.env.N = 42` stores `"42"`); we mirror that via
+/// `js_jsvalue_to_string`. Returns the original RHS so the assignment
+/// expression evaluates to it, matching JS.
+///
+/// Pre-fix, `process.env.KEY = v` lowered to a generic `PropertySet` on
+/// the cached `js_process_env()` object, which `EnvGet` never consults —
+/// so the write silently never round-tripped (#1330).
+#[no_mangle]
+pub extern "C" fn js_setenv(name_ptr: *const StringHeader, value: f64) -> f64 {
+    unsafe {
+        let name = match header_to_string(name_ptr) {
+            Some(s) => s,
+            None => return value,
+        };
+        let val_ptr = crate::value::js_jsvalue_to_string(value);
+        let val = header_to_string(val_ptr).unwrap_or_default();
+        std::env::set_var(&name, &val);
+    }
+    value
+}
+
+/// `delete process.env.KEY` — remove the variable from the real
+/// environment so the subsequent read is `undefined` (matching Node).
+/// Returns `true` like the `delete` operator.
+#[no_mangle]
+pub extern "C" fn js_removeenv(name_ptr: *const StringHeader) -> f64 {
+    unsafe {
+        if let Some(name) = header_to_string(name_ptr) {
+            std::env::remove_var(&name);
+        }
+    }
+    f64::from_bits(JSValue::bool(true).bits())
+}
+
 /// Get resident set size (RSS) in bytes using platform-specific APIs
 pub(crate) fn get_rss_bytes() -> u64 {
     #[cfg(target_os = "macos")]

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -20,36 +20,6 @@
     "category": "bug-open",
     "reason": "node:perf_hooks granular parity: globalThis.performance !== the node:perf_hooks named import. The import resolves to a fresh namespace object per read and the global is a separate path; neither is a cached singleton. Flips to PASS when #1327 lands."
   },
-  "node-suite/process/shapes/method-types": {
-    "issue": "1330",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:process granular parity: typeof process.cwd/nextTick/hrtime/exit/on/uptime/memoryUsage/cpuUsage is not 'function' — method values on the process global read as a small handle/number (the call forms work). Flips to PASS when #1330 lands."
-  },
-  "node-suite/process/nexttick/is-function": {
-    "issue": "1330",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:process granular parity: typeof process.nextTick is not 'function' even though process.nextTick(cb) ordering works (nexttick/ordering PASSES). Member-read-as-value gap. Flips to PASS when #1330 lands."
-  },
-  "node-suite/process/env/write": {
-    "issue": "1330",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:process granular parity: process.env.X = v does not persist (read returns undefined). js_process_env() caches the object correctly, so the gap is the assignment lowering not setting a field on it. Flips to PASS when #1330 lands."
-  },
-  "node-suite/process/hrtime/tuple": {
-    "issue": "1330",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:process granular parity: process.hrtime() (direct call) throws 'value is not a function' — only process.hrtime.bigint() is wired. Should return a [seconds, nanoseconds] tuple. Flips to PASS when #1330 lands."
-  },
-  "node-suite/process/props/string-props": {
-    "issue": "1330",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:process granular parity: process.argv0/execPath/title read as a number instead of a string (not exposed as properties). Flips to PASS when #1330 lands."
-  },
   "node-suite/console/dir/depth-options": {
     "issue": "1199",
     "added": "2026-05-20",

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -20,6 +20,36 @@
     "category": "bug-open",
     "reason": "node:perf_hooks granular parity: globalThis.performance !== the node:perf_hooks named import. The import resolves to a fresh namespace object per read and the global is a separate path; neither is a cached singleton. Flips to PASS when #1327 lands."
   },
+  "node-suite/process/shapes/method-types": {
+    "issue": "1330",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:process granular parity: typeof process.cwd/nextTick/hrtime/exit/on/uptime/memoryUsage/cpuUsage is not 'function' — method values on the process global read as a small handle/number (the call forms work). Flips to PASS when #1330 lands."
+  },
+  "node-suite/process/nexttick/is-function": {
+    "issue": "1330",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:process granular parity: typeof process.nextTick is not 'function' even though process.nextTick(cb) ordering works (nexttick/ordering PASSES). Member-read-as-value gap. Flips to PASS when #1330 lands."
+  },
+  "node-suite/process/env/write": {
+    "issue": "1330",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:process granular parity: process.env.X = v does not persist (read returns undefined). js_process_env() caches the object correctly, so the gap is the assignment lowering not setting a field on it. Flips to PASS when #1330 lands."
+  },
+  "node-suite/process/hrtime/tuple": {
+    "issue": "1330",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:process granular parity: process.hrtime() (direct call) throws 'value is not a function' — only process.hrtime.bigint() is wired. Should return a [seconds, nanoseconds] tuple. Flips to PASS when #1330 lands."
+  },
+  "node-suite/process/props/string-props": {
+    "issue": "1330",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "node:process granular parity: process.argv0/execPath/title read as a number instead of a string (not exposed as properties). Flips to PASS when #1330 lands."
+  },
   "node-suite/console/dir/depth-options": {
     "issue": "1199",
     "added": "2026-05-20",

--- a/test-parity/node-suite/process/argv/shape.ts
+++ b/test-parity/node-suite/process/argv/shape.ts
@@ -1,0 +1,7 @@
+// process.argv is a non-empty array of strings (argv[0] is the executable;
+// its value differs between `node` and the compiled binary, so only the
+// shape is asserted).
+console.log("is array:", Array.isArray(process.argv));
+console.log("non-empty:", process.argv.length >= 1);
+console.log("argv0 is string:", typeof process.argv[0] === "string");
+console.log("all strings:", process.argv.every((a) => typeof a === "string"));

--- a/test-parity/node-suite/process/cwd/returns-string.ts
+++ b/test-parity/node-suite/process/cwd/returns-string.ts
@@ -1,0 +1,5 @@
+// process.cwd() returns the current working directory as an absolute string.
+const cwd = process.cwd();
+console.log("is string:", typeof cwd === "string");
+console.log("non-empty:", cwd.length > 0);
+console.log("absolute:", cwd.startsWith("/") || /^[A-Za-z]:\\/.test(cwd));

--- a/test-parity/node-suite/process/env/access.ts
+++ b/test-parity/node-suite/process/env/access.ts
@@ -1,0 +1,5 @@
+// process.env is a string→string map; reads of a present var are strings and
+// reads of an absent var are undefined.
+console.log("env object:", typeof process.env === "object");
+console.log("PATH is string:", typeof process.env.PATH === "string");
+console.log("absent is undefined:", process.env.PERRY_DEFINITELY_UNSET_VAR === undefined);

--- a/test-parity/node-suite/process/env/write.ts
+++ b/test-parity/node-suite/process/env/write.ts
@@ -1,0 +1,8 @@
+// Writing to process.env coerces to a string and round-trips; deleting it
+// makes the read undefined again.
+process.env.PERRY_RT = "hello";
+console.log("after set:", process.env.PERRY_RT);
+process.env.PERRY_NUM = 42 as any;
+console.log("coerced:", process.env.PERRY_NUM, typeof process.env.PERRY_NUM);
+delete process.env.PERRY_RT;
+console.log("after delete:", process.env.PERRY_RT);

--- a/test-parity/node-suite/process/hrtime/tuple.ts
+++ b/test-parity/node-suite/process/hrtime/tuple.ts
@@ -1,0 +1,8 @@
+// process.hrtime() returns a [seconds, nanoseconds] integer tuple; the diff
+// form is non-negative.
+const t = process.hrtime();
+console.log("is array:", Array.isArray(t));
+console.log("length 2:", t.length === 2);
+console.log("ints:", Number.isInteger(t[0]) && Number.isInteger(t[1]));
+const d = process.hrtime(t);
+console.log("diff non-negative:", d[0] >= 0);

--- a/test-parity/node-suite/process/nexttick/is-function.ts
+++ b/test-parity/node-suite/process/nexttick/is-function.ts
@@ -1,0 +1,2 @@
+// process.nextTick is a callable function value.
+console.log("nextTick is function:", typeof process.nextTick === "function");

--- a/test-parity/node-suite/process/nexttick/ordering.ts
+++ b/test-parity/node-suite/process/nexttick/ordering.ts
@@ -1,0 +1,8 @@
+// process.nextTick(cb) defers cb until after the current synchronous run.
+let log: string[] = [];
+process.nextTick(() => log.push("tick"));
+log.push("sync");
+process.nextTick(() => {
+  log.push("tick2");
+  console.log("order:", log.join(","));
+});

--- a/test-parity/node-suite/process/platform/platform-arch.ts
+++ b/test-parity/node-suite/process/platform/platform-arch.ts
@@ -1,0 +1,8 @@
+// process.platform / process.arch report the host (same machine for Node and
+// Perry, so the values match) and are drawn from the known enums.
+const platforms = ["aix", "darwin", "freebsd", "linux", "openbsd", "sunos", "win32"];
+const arches = ["arm", "arm64", "ia32", "loong64", "mips", "mipsel", "ppc64", "riscv64", "s390x", "x64"];
+console.log("platform:", process.platform);
+console.log("arch:", process.arch);
+console.log("platform known:", platforms.includes(process.platform));
+console.log("arch known:", arches.includes(process.arch));

--- a/test-parity/node-suite/process/props/string-props.ts
+++ b/test-parity/node-suite/process/props/string-props.ts
@@ -1,0 +1,5 @@
+// argv0 / execPath / title are string properties (values differ between
+// runtimes, so only the type is asserted).
+console.log("argv0 is string:", typeof process.argv0 === "string");
+console.log("execPath is string:", typeof process.execPath === "string");
+console.log("title is string:", typeof process.title === "string");

--- a/test-parity/node-suite/process/shapes/method-types.ts
+++ b/test-parity/node-suite/process/shapes/method-types.ts
@@ -1,0 +1,9 @@
+// The process methods are callable function values.
+console.log("cwd:", typeof process.cwd === "function");
+console.log("nextTick:", typeof process.nextTick === "function");
+console.log("hrtime:", typeof process.hrtime === "function");
+console.log("exit:", typeof process.exit === "function");
+console.log("on:", typeof process.on === "function");
+console.log("uptime:", typeof process.uptime === "function");
+console.log("memoryUsage:", typeof process.memoryUsage === "function");
+console.log("cpuUsage:", typeof process.cpuUsage === "function");

--- a/test-parity/node-suite/process/shapes/process-object.ts
+++ b/test-parity/node-suite/process/shapes/process-object.ts
@@ -1,0 +1,7 @@
+// The `process` global is an object with the documented top-level shapes.
+console.log("typeof process:", typeof process);
+console.log("env is object:", typeof process.env === "object");
+console.log("argv is array:", Array.isArray(process.argv));
+console.log("versions is object:", typeof process.versions === "object");
+console.log("pid is number:", typeof process.pid === "number");
+console.log("pid positive:", process.pid > 0);

--- a/test-parity/node-suite/process/version/version-format.ts
+++ b/test-parity/node-suite/process/version/version-format.ts
@@ -1,0 +1,4 @@
+// process.version is a "v"-prefixed string; process.versions is an object.
+console.log("version is string:", typeof process.version === "string");
+console.log("version starts v:", process.version.startsWith("v"));
+console.log("versions is object:", typeof process.versions === "object");


### PR DESCRIPTION
Closes #1330. Stacked on #1331 (the granular `node:process` suite) — base will auto-retarget to `main` when #1331 merges.

Implements the five `node:process` gaps the suite pinned. The process module is now **12/12** in `node-suite/process`; the five `known_failures.json` entries are removed (they flip to PASS).

## Gaps fixed

1. **Method values read as functions.** `typeof process.cwd` / `nextTick` / `hrtime` / `exit` / `on` / `uptime` / `memoryUsage` / `cpuUsage` is now `"function"`. Bare `process` lowers to the `GlobalGet(0)` sentinel, so `process.<method>` reads (not calls) are routed through `js_native_module_property_by_name("process", …)` — the same machinery `os`/`tty`/`perf_hooks`/`console` use — with the pairs added to `is_native_module_callable_export`. The closure is a real function value (also fixes `const f = process.cwd`). The **call** forms still lower to their dedicated HIR variants and never reach this path.

2. **`process.env` writes/deletes persist.** `process.env.X = v` now lowers to `js_setenv`, which writes the real OS environment (the store `EnvGet`/`js_getenv` reads) and coerces the value to a string like Node (`process.env.N = 42` → `"42"`). `delete process.env.X` lowers to `js_removeenv`. Pre-fix the write hit a field on the cached `js_process_env()` object that `EnvGet` never consults, so it silently never round-tripped.

3. **`process.hrtime()` direct call.** New `Expr::ProcessHrtime(Box<Expr>)` + `js_process_hrtime`, returning a `[seconds, nanoseconds]` integer tuple off the existing monotonic baseline. The diff form `process.hrtime(prev)` is non-negative. `process.hrtime.bigint()` is still intercepted earlier (nested-namespace dispatch).

4. **`argv0` / `execPath` / `title`** are exposed as string properties via `get_native_module_constant("process", …)`.

## Validation

- `./run_parity_tests.sh --suite node-suite --module process` → **12/12 PASS**, byte-identical to `node --experimental-strip-types`.
- `env/write` and `hrtime/tuple` outputs verified equal to Node.
- Regression spot-check: `perf_hooks` stays at its known baseline (31 pass / 2 known fail: #1320, #1327) — the suite that shares `native_module.rs` most heavily — confirming the additive `"process"` arms don't disturb other modules. Remaining `os`/`console` node-suite failures are pre-existing (namespace-identity semantics and console error/`[cause]` formatting), unrelated to this change.
- `cargo fmt --all --check` clean; `cargo build --release -p perry-runtime -p perry-stdlib -p perry` green.

## Notes

- `cpuUsage` has no call lowering yet — the read still correctly reports `"function"`; calling the captured value is a separate (pre-existing) limitation.
- Per the contributor convention, no version bump / CHANGELOG entry — folded in at merge.