### PR TITLE
fix(ui-ios): drain stdlib pump so async fetch resolves on iOS

### DIFF
--- a/crates/perry-ui-ios/src/app.rs
+++ b/crates/perry-ui-ios/src/app.rs
@@ -625,6 +625,11 @@ define_class!(
                     js_callback_timer_tick();
                     js_interval_timer_tick();
                     js_promise_run_microtasks();
+                    // Drain deferred promise resolutions from perry-stdlib
+                    // tokio workers (async fetch/network completions). Without
+                    // this, `await fetch(...)` never resolves on iOS — the
+                    // macOS pump has always called it; iOS omitted it.
+                    js_run_stdlib_pump();
                     #[cfg(feature = "geisterhand")]
                     {
                         extern "C" { fn perry_geisterhand_pump(); }


### PR DESCRIPTION
## Problem

On a physical iOS device, **every `await fetch(...)` hangs forever** — login, password reset, dashboard data, any network call. The promise never settles, so UIs that show a spinner during a request spin indefinitely.

macOS is unaffected.

## Root cause

`perry-ui-ios`'s timer pump (`PerryPumpTarget::pump`, `crates/perry-ui-ios/src/app.rs`) drives `setTimeout`/`setInterval` and runs JS microtasks, but **never calls `js_run_stdlib_pump()`** — the call that delivers completed async results from perry-stdlib's tokio workers (fetch/network/db completions) back into the JS runtime.

`js_run_stdlib_pump` is even declared in the iOS `extern "C"` block (app.rs:600) — it just isn't invoked in the pump body. The macOS pump (`perry-ui-macos/src/app.rs`) has always called it, which is why fetch works on macOS but not iOS.

```rust
// iOS pump, before:
js_callback_timer_tick();
js_interval_timer_tick();
js_promise_run_microtasks();
// (no js_run_stdlib_pump — deferred tokio resolutions never delivered)
```

## Fix

Add `js_run_stdlib_pump()` to the iOS pump, after `js_promise_run_microtasks()` and before the geisterhand pump — matching macOS exactly. +5 lines (1 call + comment).

## Verification

Built `perry-ui-ios` with the fix, deployed a real app (GSC Master) to a physical iPhone (iOS 18), and drove its forgot-password flow — which goes through the same `await fetch(...)` path that previously hung — via geisterhand over Wi-Fi:

- **Before:** click → spinner forever, fetch promise never resolves.
- **After:** the request completes and the app renders the server's response ("If an account with that email exists, we've sent a password reset…").

## Notes

- No API/behavior change; purely wires up the already-declared pump call on iOS.
- Suggest a follow-up: a CI smoke that asserts an `await fetch()` resolves under `--target ios-simulator`, which would have caught this.