### PR TITLE
fix(geisterhand/ios): register SecureField (#1384) + include perry-stdlib in auto-build (#1383)

### DIFF
--- a/crates/perry-ui-ios/src/widgets/securefield.rs
+++ b/crates/perry-ui-ios/src/widgets/securefield.rs
@@ -100,7 +100,17 @@ pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
         std::mem::forget(target);
 
         let view: Retained<UIView> = Retained::cast_unchecked(text_field);
-        super::register_widget(view)
+        let handle = super::register_widget(view);
+        #[cfg(feature = "geisterhand")]
+        {
+            extern "C" {
+                fn perry_geisterhand_register(h: i64, wt: u8, ck: u8, cb: f64, lbl: *const u8);
+            }
+            unsafe {
+                perry_geisterhand_register(handle, 1, 1, on_change, placeholder_ptr);
+            }
+        }
+        handle
     }
 }
 

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -1197,7 +1197,17 @@ pub(super) fn build_geisterhand_libs(target: Option<&str>, format: OutputFormat)
         .arg("--features")
         .arg(format!("{}/geisterhand", ui_crate))
         .arg("-p")
-        .arg("perry-ui-geisterhand");
+        .arg("perry-ui-geisterhand")
+        // Build perry-stdlib in the same invocation so the geisterhand lib
+        // set is complete and its shared `perry-runtime` is hash-consistent
+        // with the runtime/ui libs above (a separate `cargo build -p
+        // perry-stdlib` would resolve `perry-runtime` without the geisterhand
+        // feature → a second runtime variant → undefined-symbol link errors).
+        // Without stdlib here, apps that pull native-FFI packages depending on
+        // perry-stdlib's async surface (`perry_ffi_promise_*`) had no
+        // consistent stdlib to link against under --enable-geisterhand (#1383).
+        .arg("-p")
+        .arg("perry-stdlib");
 
     // Add cross-compilation target if needed
     if let Some(triple) = rust_target_triple(target) {


### PR DESCRIPTION
Two independent geisterhand-on-iOS fixes (one commit each), found while debugging a real app on a physical device.

## #1384 — register `SecureField` with geisterhand
`SecureField` called `register_widget` but, unlike `TextField`, never called `perry_geisterhand_register`. So password fields were absent from `/widgets` and couldn't be driven via `/type` — blocking automated testing of any login/signup flow on iOS. Fix mirrors `TextField`'s registration (widget_type=1, callback_kind=1, onChange closure + placeholder), under `cfg(geisterhand)`.

## #1383 — include `perry-stdlib` in the geisterhand auto-build
`build_geisterhand_libs` built `perry-runtime` + the UI crate + `perry-ui-geisterhand`, but **not** `perry-stdlib`. The geisterhand lib set was incomplete: apps pulling native-FFI packages that depend on perry-stdlib's async surface (`perry_ffi_promise_*`) had no consistent stdlib to link against under `--enable-geisterhand`. Building `perry-stdlib` separately doesn't work either — it resolves `perry-runtime` *without* the geisterhand feature, producing a second runtime variant and undefined-symbol link errors. Fix adds `-p perry-stdlib` to the **same** cargo invocation so the shared `perry-runtime` is built once (with geisterhand) and unified across all crates.

## Verification
- Both crates `cargo check` clean (`perry-ui-ios --features geisterhand --target aarch64-apple-ios`; `perry`).
- #1384 mirrors the existing, working `TextField` registration path verbatim.
- Context: surfaced while verifying #1382 (the iOS fetch-pump fix) on a physical iPhone via geisterhand. Full on-device re-verification of the geisterhand build pipeline wasn't re-run for this PR; happy to if a maintainer wants it.