### PR TITLE
feat(crypto): randomInt, timingSafeEqual, getHashes/getCiphers

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1785,6 +1785,14 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("crypto", "createSecretKey", false, None),
     method("crypto", "pbkdf2Sync", false, None),
     method("crypto", "pbkdf2", false, None),
+    // crypto.randomInt([min,] max) — uniform integer in [min, max).
+    // crypto.timingSafeEqual(a, b) — constant-time byte comparison.
+    // crypto.getHashes() / getCiphers() — supported-algorithm name lists.
+    // All wired in codegen `expr/calls.rs` (direct dispatch, like createHash).
+    method("crypto", "randomInt", false, None),
+    method("crypto", "timingSafeEqual", false, None),
+    method("crypto", "getHashes", false, None),
+    method("crypto", "getCiphers", false, None),
     // Web Crypto API (issue #561) — `crypto.subtle.*`. The HIR
     // lowering at `crates/perry-hir/src/lower/expr_call.rs` recognizes
     // the `crypto.subtle.<method>(args)` chain and emits a

--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -462,6 +462,90 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_string_inline(blk, &handle))
         }
 
+        // Phase H crypto: `crypto.randomInt([min,] max)` — uniform integer
+        // in `[min, max)`. The single-arg form defaults `min` to 0. The
+        // runtime returns the value as a plain double (a JS number), so no
+        // NaN-box is needed at the call site.
+        Expr::Call { callee, args, .. }
+            if matches!(
+                callee.as_ref(),
+                Expr::PropertyGet { object, property } if property == "randomInt" && matches!(
+                    object.as_ref(),
+                    Expr::NativeModuleRef(n) if n == "crypto"
+                )
+            ) =>
+        {
+            if args.is_empty() {
+                return Ok(double_literal(0.0));
+            }
+            let (min_box, max_box) = if args.len() == 1 {
+                let max_box = lower_expr(ctx, &args[0])?;
+                (double_literal(0.0), max_box)
+            } else {
+                let min_box = lower_expr(ctx, &args[0])?;
+                let max_box = lower_expr(ctx, &args[1])?;
+                (min_box, max_box)
+            };
+            let blk = ctx.block();
+            Ok(blk.call(
+                DOUBLE,
+                "js_crypto_random_int",
+                &[(DOUBLE, &min_box), (DOUBLE, &max_box)],
+            ))
+        }
+
+        // Phase H crypto: `crypto.timingSafeEqual(a, b)` — constant-time
+        // compare of two byte sequences. Returns a NaN-boxed boolean.
+        Expr::Call { callee, args, .. }
+            if matches!(
+                callee.as_ref(),
+                Expr::PropertyGet { object, property } if property == "timingSafeEqual" && matches!(
+                    object.as_ref(),
+                    Expr::NativeModuleRef(n) if n == "crypto"
+                )
+            ) =>
+        {
+            if args.len() < 2 {
+                return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
+            }
+            let a_box = lower_expr(ctx, &args[0])?;
+            let b_box = lower_expr(ctx, &args[1])?;
+            let blk = ctx.block();
+            let a_handle = unbox_to_i64(blk, &a_box);
+            let b_handle = unbox_to_i64(blk, &b_box);
+            Ok(blk.call(
+                DOUBLE,
+                "js_crypto_timing_safe_equal",
+                &[(I64, &a_handle), (I64, &b_handle)],
+            ))
+        }
+
+        // Phase H crypto: `crypto.getHashes()` / `crypto.getCiphers()` —
+        // return a `string[]` of supported algorithm names.
+        Expr::Call { callee, .. }
+            if matches!(
+                callee.as_ref(),
+                Expr::PropertyGet { object, property }
+                    if (property == "getHashes" || property == "getCiphers") && matches!(
+                        object.as_ref(),
+                        Expr::NativeModuleRef(n) if n == "crypto"
+                    )
+            ) =>
+        {
+            let fn_name = if let Expr::PropertyGet { property, .. } = callee.as_ref() {
+                if property == "getCiphers" {
+                    "js_crypto_get_ciphers"
+                } else {
+                    "js_crypto_get_hashes"
+                }
+            } else {
+                unreachable!()
+            };
+            let blk = ctx.block();
+            let arr = blk.call(I64, fn_name, &[]);
+            Ok(nanbox_pointer_inline(blk, &arr))
+        }
+
         // `crypto.createSecretKey(key, encoding?)` — JWT signing key for
         // HS* algorithms. Native-side this returns a Uint8Array-marked
         // BufferHeader; the bridge then materializes a real v8::Uint8Array

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1068,6 +1068,15 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_crypto_pbkdf2_bytes", I64, &[I64, I64, DOUBLE, DOUBLE]);
     module.declare_function("js_crypto_random_bytes_buffer", I64, &[DOUBLE]);
     module.declare_function("js_crypto_random_uuid", I64, &[]);
+    // crypto.randomInt([min,] max) -> number; codegen passes min=0 for the
+    // single-arg form. Returns the integer as a plain double.
+    module.declare_function("js_crypto_random_int", DOUBLE, &[DOUBLE, DOUBLE]);
+    // crypto.timingSafeEqual(a, b) -> boolean (NaN-boxed). Args are unboxed
+    // to raw i64 pointers (Buffer / TypedArray / string).
+    module.declare_function("js_crypto_timing_safe_equal", DOUBLE, &[I64, I64]);
+    // crypto.getHashes() / getCiphers() -> string[]; returns *mut ArrayHeader.
+    module.declare_function("js_crypto_get_hashes", I64, &[]);
+    module.declare_function("js_crypto_get_ciphers", I64, &[]);
     // `crypto.createSecretKey(key, encoding?)` — returns Uint8Array-marked
     // BufferHeader of the key bytes (jose accepts Uint8Array for HS*).
     module.declare_function("js_crypto_create_secret_key", I64, &[I64]);

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -710,6 +710,17 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                                 Type::Named("Uint8Array".to_string())
                             }
                             "randomUUID" => Type::String,
+                            // `crypto.randomInt(...)` is an integer; typing it
+                            // as Number lets arithmetic / comparisons take the
+                            // numeric fast path.
+                            "randomInt" => Type::Number,
+                            // `crypto.getHashes()` / `getCiphers()` return
+                            // `string[]`. Typing the result as an array routes
+                            // `.includes` / `.indexOf` through the content-
+                            // comparison path (otherwise an `any`-typed result
+                            // uses pointer-identity comparison and never
+                            // matches a freshly-allocated needle string).
+                            "getHashes" | "getCiphers" => Type::Array(Box::new(Type::String)),
                             _ => Type::Any,
                         };
                     }

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -352,6 +352,100 @@ fn resolve_range(total: usize, offset: Option<usize>, size: Option<usize>) -> (u
     (start, end)
 }
 
+/// Decode a NaN-boxed numeric `f64` to a plain `f64`. Number literals
+/// reach the FFI as raw doubles, but a value that flowed through an
+/// integer-typed path may arrive INT32-tagged (`0x7FFE` top16). Handle
+/// both so `randomInt` works regardless of which representation codegen
+/// picked for `min` / `max`.
+fn nanboxed_to_f64_num(bits: f64) -> f64 {
+    let raw = bits.to_bits();
+    let top16 = (raw >> 48) as u16;
+    if top16 == 0x7FFE {
+        return ((raw & 0xFFFF_FFFF) as u32 as i32) as f64;
+    }
+    bits
+}
+
+/// `crypto.randomInt([min, ]max)` — uniform random integer in `[min, max)`.
+/// Codegen passes `min = 0` for the single-argument form. Uses rejection
+/// sampling so the distribution is unbiased (matching Node's guarantee).
+/// Returns the integer as a plain `f64`. A degenerate range (`max <= min`)
+/// returns `min` rather than crashing.
+#[no_mangle]
+pub extern "C" fn js_crypto_random_int(min_bits: f64, max_bits: f64) -> f64 {
+    let min = nanboxed_to_f64_num(min_bits) as i64;
+    let max = nanboxed_to_f64_num(max_bits) as i64;
+    if max <= min {
+        return min as f64;
+    }
+    let range = (max - min) as u64;
+    // Rejection sampling: discard values in the unfair tail so every
+    // outcome in `[0, range)` is equally likely.
+    let limit = u64::MAX - (u64::MAX % range);
+    let mut rng = rand::thread_rng();
+    let mut r = rng.next_u64();
+    while r >= limit {
+        r = rng.next_u64();
+    }
+    (min + (r % range) as i64) as f64
+}
+
+/// `crypto.timingSafeEqual(a, b)` — constant-time comparison of two
+/// equal-length byte sequences (Buffer / TypedArray / string). Returns a
+/// NaN-boxed boolean. Node throws `RangeError` when the lengths differ; the
+/// no-exception FFI path returns `false` instead so a length mismatch
+/// degrades gracefully rather than crashing.
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_timing_safe_equal(a_ptr: i64, b_ptr: i64) -> f64 {
+    const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
+    const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+    let a = bytes_from_ptr(a_ptr);
+    let b = bytes_from_ptr(b_ptr);
+    if a.len() != b.len() {
+        return f64::from_bits(TAG_FALSE);
+    }
+    let mut diff: u8 = 0;
+    for i in 0..a.len() {
+        diff |= a[i] ^ b[i];
+    }
+    f64::from_bits(if diff == 0 { TAG_TRUE } else { TAG_FALSE })
+}
+
+/// `crypto.getHashes()` — the digest algorithms Perry can construct via
+/// `createHash` / `createHmac`. Returns a JS `string[]`.
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_get_hashes() -> *mut perry_runtime::ArrayHeader {
+    use perry_runtime::{js_array_alloc, js_array_push, JSValue};
+    const NAMES: [&str; 6] = ["md5", "sha1", "sha224", "sha256", "sha384", "sha512"];
+    let arr = js_array_alloc(0);
+    for n in NAMES {
+        let ptr = js_string_from_bytes(n.as_ptr(), n.len() as u32);
+        js_array_push(arr, JSValue::string_ptr(ptr));
+    }
+    arr
+}
+
+/// `crypto.getCiphers()` — the symmetric ciphers Perry supports
+/// (`createCipheriv` / WebCrypto AES-GCM). Returns a JS `string[]`.
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_get_ciphers() -> *mut perry_runtime::ArrayHeader {
+    use perry_runtime::{js_array_alloc, js_array_push, JSValue};
+    const NAMES: [&str; 6] = [
+        "aes-128-cbc",
+        "aes-192-cbc",
+        "aes-256-cbc",
+        "aes-128-gcm",
+        "aes-192-gcm",
+        "aes-256-gcm",
+    ];
+    let arr = js_array_alloc(0);
+    for n in NAMES {
+        let ptr = js_string_from_bytes(n.as_ptr(), n.len() as u32);
+        js_array_push(arr, JSValue::string_ptr(ptr));
+    }
+    arr
+}
+
 /// Create HMAC-SHA256
 /// crypto.createHmac('sha256', key).update(data).digest('hex') -> string
 #[no_mangle]

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1086 entries across 80 modules
+// Coverage: 1090 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -325,6 +325,10 @@ declare module "crypto" {
   /** stdlib */
   export function createSecretKey(...args: any[]): any;
   /** stdlib */
+  export function getCiphers(...args: any[]): any;
+  /** stdlib */
+  export function getHashes(...args: any[]): any;
+  /** stdlib */
   export function getRandomValues(...args: any[]): any;
   /** stdlib */
   export function md5(...args: any[]): any;
@@ -337,9 +341,13 @@ declare module "crypto" {
   /** stdlib */
   export function randomFillSync(...args: any[]): any;
   /** stdlib */
+  export function randomInt(...args: any[]): any;
+  /** stdlib */
   export function randomUUID(...args: any[]): any;
   /** stdlib */
   export function sha256(...args: any[]): any;
+  /** stdlib */
+  export function timingSafeEqual(...args: any[]): any;
 }
 
 declare module "date-fns" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1086 entries across 80 modules.
+Total: 1090 entries across 80 modules.
 
 ## Modules
 
@@ -382,14 +382,18 @@ Total: 1086 entries across 80 modules.
 - `createHash` — module
 - `createHmac` — module
 - `createSecretKey` — module
+- `getCiphers` — module
+- `getHashes` — module
 - `getRandomValues` — module
 - `md5` — module
 - `pbkdf2` — module
 - `pbkdf2Sync` — module
 - `randomBytes` — module
 - `randomFillSync` — module
+- `randomInt` — module
 - `randomUUID` — module
 - `sha256` — module
+- `timingSafeEqual` — module
 
 ### Properties
 


### PR DESCRIPTION
Three additive `node:crypto` utility surfaces. None touch the existing sha256/md5 digest fast-path (SCRAM / #1076 / #214), so regression risk is contained to brand-new property names.

## What's added
- **`crypto.randomInt([min,] max)`** (#1359) — uniform integer in `[min, max)` via rejection sampling (unbiased, matching Node). Single-arg form defaults `min` to 0. HIR types the result as `number`.
- **`crypto.timingSafeEqual(a, b)`** (#1360) — constant-time byte comparison of Buffer / TypedArray / string inputs, returns a boolean. A length mismatch returns `false` (the no-exception FFI path) rather than throwing a `RangeError`.
- **`crypto.getHashes()` / `crypto.getCiphers()`** (#1358) — `string[]` of supported digest / cipher names. Typed as `Array<String>` in HIR lowering so `.includes` / `.indexOf` use content comparison rather than pointer identity (an `any`-typed array result otherwise never matches a freshly-allocated needle string).

## Layers touched
- `perry-stdlib/src/crypto.rs` — 4 new FFI functions
- `perry-codegen/src/expr/calls.rs` — 4 dispatch arms (`NativeModuleRef("crypto")`)
- `perry-codegen/src/runtime_decls/strings.rs` — FFI declarations
- `perry-hir/src/lower_types.rs` — return-type inference for the new methods
- `perry-api-manifest/src/entries.rs` + regenerated `docs/`

## Validation
Byte-for-byte parity against `node --experimental-strip-types` for randomInt range (1000 draws, both arg forms), timingSafeEqual equal/unequal, and getHashes/getCiphers membership. Existing createHash/createHmac/randomBytes/randomUUID output unchanged. `cargo fmt --all -- --check` clean; API docs regenerated (no drift).

Closes #1358
Closes #1359
Closes #1360