### PR TITLE
fix(crypto): sha224/sha384, base64 digest, and Buffer hash input

### DIFF
--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -25,6 +25,7 @@ use crate::nanbox::{double_literal, POINTER_MASK_I64};
 use crate::type_analysis::{
     compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
     is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
+    static_type_of,
 };
 #[allow(unused_imports)]
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
@@ -45,6 +46,29 @@ use super::{
     unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
     I18nLowerCtx,
 };
+
+/// Whether a `createHash(...).update(e)` / `createHmac(alg, e)` argument is a
+/// Buffer / Uint8Array — either a direct buffer-producing expression or a
+/// local/field whose static type is `Buffer` / `Uint8Array`. Such inputs must
+/// not take the inline `*StringHeader` hash fast path, whose UTF-8 string
+/// unboxing reads the wrong bytes for a Buffer (#1354).
+fn hash_input_is_buffer(ctx: &FnCtx<'_>, e: &Expr) -> bool {
+    if matches!(
+        e,
+        Expr::BufferFrom { .. }
+            | Expr::BufferFromArrayBuffer { .. }
+            | Expr::BufferAlloc { .. }
+            | Expr::BufferAllocUnsafe(_)
+            | Expr::BufferConcat(_)
+            | Expr::CryptoRandomBytes(_)
+    ) {
+        return true;
+    }
+    matches!(
+        static_type_of(ctx, e),
+        Some(HirType::Named(ref n)) if n == "Buffer" || n == "Uint8Array"
+    )
+}
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
@@ -149,8 +173,38 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let want_buffer = digest_args.first().is_none()
                 || matches!(digest_args.first(), Some(Expr::Undefined));
 
+            // The inline `js_crypto_sha256` / `js_crypto_md5` fast path only
+            // produces a hex string (or, for the no-arg form, a raw-byte
+            // Buffer). Any other digest encoding (`'base64'`, `'base64url'`,
+            // …) must fall through to the runtime handle dispatch, whose
+            // `dispatch_hash` honors the encoding (#1352). A non-literal
+            // encoding arg also can't be folded inline.
+            let enc_fast_ok = match digest_args.first() {
+                None | Some(Expr::Undefined) => true,
+                Some(Expr::String(s)) => s.eq_ignore_ascii_case("hex"),
+                _ => false,
+            };
+            // The inline path unboxes the data/key as a `*StringHeader` and
+            // hashes the UTF-8 string bytes. A Buffer / Uint8Array input has a
+            // different header layout, so hashing it through the string path
+            // reads the wrong bytes (#1354). Route Buffer-typed inputs to the
+            // handle dispatch, whose `bytes_from_ptr` reads either layout.
+            // Detect both inline buffer-producing expressions (`Buffer.from(…)`,
+            // `crypto.randomBytes(…)`, …) and locals/fields whose static type
+            // is Buffer / Uint8Array (see `hash_input_is_buffer`). Each borrow
+            // of `ctx` is scoped to the `is_some_and` call so it does not
+            // collide with the `&mut ctx` borrows in the arm bodies.
+            let data_is_buffer = update_args
+                .first()
+                .is_some_and(|e| hash_input_is_buffer(ctx, e));
+            let key_is_buffer = create_args
+                .get(1)
+                .is_some_and(|e| hash_input_is_buffer(ctx, e));
+            let fast_ok = enc_fast_ok && !data_is_buffer;
+            let hmac_fast_ok = fast_ok && !key_is_buffer;
+
             match (create_method, alg) {
-                ("createHash", "sha256") if !update_args.is_empty() => {
+                ("createHash", "sha256") if fast_ok && !update_args.is_empty() => {
                     let data_box = lower_expr(ctx, &update_args[0])?;
                     let blk = ctx.block();
                     // SSO-safe data unbox — both `js_crypto_sha256` and the
@@ -165,7 +219,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         Ok(nanbox_string_inline(blk, &result))
                     }
                 }
-                ("createHash", "md5") if !update_args.is_empty() => {
+                ("createHash", "md5") if fast_ok && !update_args.is_empty() => {
                     let data_box = lower_expr(ctx, &update_args[0])?;
                     let blk = ctx.block();
                     // SSO-safe — see sha256 arm above.
@@ -173,7 +227,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     let result = blk.call(I64, "js_crypto_md5", &[(I64, &data_handle)]);
                     Ok(nanbox_string_inline(blk, &result))
                 }
-                ("createHmac", "sha256") if create_args.len() >= 2 && !update_args.is_empty() => {
+                ("createHmac", "sha256")
+                    if hmac_fast_ok && create_args.len() >= 2 && !update_args.is_empty() =>
+                {
                     let key_box = lower_expr(ctx, &create_args[1])?;
                     let data_box = lower_expr(ctx, &update_args[0])?;
                     let blk = ctx.block();

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -15,7 +15,7 @@ use md5::{Digest as Md5Digest, Md5};
 use perry_runtime::{js_string_from_bytes, StringHeader};
 use rand::RngCore;
 use sha1::Sha1;
-use sha2::{Digest as Sha256Digest, Sha256, Sha512};
+use sha2::{Digest as Sha256Digest, Sha224, Sha256, Sha384, Sha512};
 
 /// Helper to extract string from StringHeader pointer
 unsafe fn string_from_header(ptr: *const StringHeader) -> Option<Vec<u8>> {
@@ -688,7 +688,9 @@ pub unsafe extern "C" fn js_crypto_scrypt_custom(
 
 pub enum HashState {
     Sha1(Sha1),
+    Sha224(Sha224),
     Sha256(Sha256),
+    Sha384(Sha384),
     Sha512(Sha512),
     Md5(Md5),
 }
@@ -713,7 +715,9 @@ pub unsafe extern "C" fn js_crypto_create_hash(alg_ptr: i64) -> f64 {
         .to_ascii_lowercase();
     let state = match alg.as_str() {
         "sha1" | "sha-1" => HashState::Sha1(Sha1::new()),
+        "sha224" | "sha-224" => HashState::Sha224(Sha224::new()),
         "sha256" | "sha-256" => HashState::Sha256(Sha256::new()),
+        "sha384" | "sha-384" => HashState::Sha384(Sha384::new()),
         "sha512" | "sha-512" => HashState::Sha512(Sha512::new()),
         "md5" => HashState::Md5(Md5::new()),
         _ => return f64::from_bits(0x7FFC_0000_0000_0001),
@@ -739,7 +743,9 @@ pub unsafe fn dispatch_hash(handle: i64, method: &str, args: &[f64]) -> f64 {
             if let Some(state) = guard.as_mut() {
                 match state {
                     HashState::Sha1(x) => Sha256Digest::update(x, &bytes),
+                    HashState::Sha224(x) => Sha256Digest::update(x, &bytes),
                     HashState::Sha256(x) => Sha256Digest::update(x, &bytes),
+                    HashState::Sha384(x) => Sha256Digest::update(x, &bytes),
                     HashState::Sha512(x) => Sha256Digest::update(x, &bytes),
                     HashState::Md5(x) => Md5Digest::update(x, &bytes),
                 }
@@ -753,7 +759,9 @@ pub unsafe fn dispatch_hash(handle: i64, method: &str, args: &[f64]) -> f64 {
             };
             let digest: Vec<u8> = match state {
                 Some(HashState::Sha1(x)) => x.finalize().to_vec(),
+                Some(HashState::Sha224(x)) => x.finalize().to_vec(),
                 Some(HashState::Sha256(x)) => x.finalize().to_vec(),
+                Some(HashState::Sha384(x)) => x.finalize().to_vec(),
                 Some(HashState::Sha512(x)) => x.finalize().to_vec(),
                 Some(HashState::Md5(x)) => x.finalize().to_vec(),
                 None => return f64::from_bits(0x7FFC_0000_0000_0001),


### PR DESCRIPTION
Three fixes in the `createHash` / `createHmac` digest path. The hex + string-input inline fast path (SCRAM / #214 / #1076) is left **unchanged**; the fixes either add runtime algorithms or route the previously-mishandled cases to the runtime handle dispatch (`dispatch_hash`), which was already correct for them.

## Fixes
- **sha224 / sha384** (#1357) — added to the runtime `HashState` enum, `js_crypto_create_hash`, and `dispatch_hash`. `createHash('sha224'|'sha384')` previously returned `undefined`, so the chained `.update()` threw `Cannot read properties of undefined`.
- **`digest('base64'|'base64url')`** (#1352) — the inline `sha256`/`md5`/`hmac-sha256` fast path only emits hex (or a raw-byte Buffer for the no-arg form), so it silently returned **hex** for any other encoding. The fast path is now narrowed to hex / no-arg only; every other encoding falls through to `dispatch_hash`, which honors base64/base64url.
- **`update(Buffer)` / `createHmac(_, Buffer)`** (#1354) — the fast path unboxed inputs as `*StringHeader` and hashed the UTF-8 string bytes, reading the wrong bytes for a Buffer/Uint8Array (different header layout). Buffer-typed inputs — inline `Buffer.from(...)` / `crypto.randomBytes(...)` **and** `Buffer`/`Uint8Array`-typed locals/fields — now route to the handle dispatch, whose `bytes_from_ptr` reads either layout.

## Validation
Byte-for-byte parity against `node --experimental-strip-types`:
- `digest('base64')` / `digest('base64url')` for hash + hmac
- `update(Buffer)` (local var) and `createHmac(_, Buffer.from(...))` (inline)
- `sha224` / `sha384` hex + base64
- **Regression unchanged**: `sha256`/`md5`/`hmac` hex, no-arg Buffer digest length, standalone `const h = createHash(...)` form, dynamic (`const alg`) hash/hmac, incremental `.update().update()`.

## Not included
`digest()` (no-arg) Buffer `.toString('hex')` / numeric indexing (#1353) is a separate type-inference issue — the no-arg `digest()` result isn't statically typed as a Buffer, so `.toString('hex')` and `buf[0]` mis-dispatch. It affects the runtime handle path too and is unchanged by this PR; it'll be addressed separately.

Closes #1352
Closes #1354
Closes #1357