### PR TITLE
fix(crypto): pbkdf2Sync honors the digest argument (#1355)

### DIFF
--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -574,11 +574,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &buf_handle))
         }
 
-        // crypto.pbkdf2Sync(password, salt, iterations, keylen, algorithm) -> Buffer.
-        // Only SHA-256 is wired through right now — that's what SCRAM needs.
-        // The `algorithm` arg is validated at runtime but ignored by codegen;
-        // callers that need non-SHA256 fall through to the generic path and
-        // get an empty Buffer back.
+        // crypto.pbkdf2Sync(password, salt, iterations, keylen, digest) -> Buffer.
+        // The digest algorithm (sha256/sha512/sha224/sha384/sha1) is passed
+        // through to the runtime so non-SHA256 keys derive correctly (#1355).
+        // An absent digest arg passes a null pointer; the runtime defaults to
+        // SHA-256 (what SCRAM relies on).
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
@@ -595,13 +595,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let salt_box = lower_expr(ctx, &args[1])?;
             let iter_box = lower_expr(ctx, &args[2])?;
             let keylen_box = lower_expr(ctx, &args[3])?;
-            // Ignore the digest algorithm arg for now — the FFI is SHA-256 only.
-            if args.len() >= 5 {
-                let _ = lower_expr(ctx, &args[4])?;
-            }
+            let digest_box = if args.len() >= 5 {
+                Some(lower_expr(ctx, &args[4])?)
+            } else {
+                None
+            };
             let blk = ctx.block();
             let pwd_handle = unbox_to_i64(blk, &pwd_box);
             let salt_handle = unbox_to_i64(blk, &salt_box);
+            let digest_handle = match &digest_box {
+                Some(b) => unbox_to_i64(blk, b),
+                None => "0".to_string(),
+            };
             let buf_handle = blk.call(
                 I64,
                 "js_crypto_pbkdf2_bytes",
@@ -610,6 +615,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     (I64, &salt_handle),
                     (DOUBLE, &iter_box),
                     (DOUBLE, &keylen_box),
+                    (I64, &digest_handle),
                 ],
             );
             Ok(nanbox_pointer_inline(blk, &buf_handle))

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1065,7 +1065,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_crypto_md5", I64, &[I64]);
     module.declare_function("js_crypto_hmac_sha256", I64, &[I64, I64]);
     module.declare_function("js_crypto_hmac_sha256_bytes", I64, &[I64, I64]);
-    module.declare_function("js_crypto_pbkdf2_bytes", I64, &[I64, I64, DOUBLE, DOUBLE]);
+    module.declare_function(
+        "js_crypto_pbkdf2_bytes",
+        I64,
+        &[I64, I64, DOUBLE, DOUBLE, I64],
+    );
     module.declare_function("js_crypto_random_bytes_buffer", I64, &[DOUBLE]);
     module.declare_function("js_crypto_random_uuid", I64, &[]);
     // crypto.randomInt([min,] max) -> number; codegen passes min=0 for the

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -501,23 +501,47 @@ pub unsafe extern "C" fn js_crypto_hmac_sha256_bytes(
     alloc_buffer_from_slice(&digest)
 }
 
-/// PBKDF2-HMAC-SHA-256 returning a Buffer. Counterpart of
-/// `crypto.pbkdf2Sync(password, salt, iterations, keylen, 'sha256')`.
+/// PBKDF2-HMAC returning a Buffer. Counterpart of
+/// `crypto.pbkdf2Sync(password, salt, iterations, keylen, digest)`.
 /// Accepts string or Buffer for both password and salt.
+///
+/// `digest_ptr` is the NaN-unboxed pointer to the digest-algorithm string
+/// (`'sha256'`, `'sha512'`, …). A null/empty/unknown digest defaults to
+/// SHA-256 — the algorithm SCRAM and the previous callers relied on. The
+/// digest was silently ignored before, so `pbkdf2Sync(..., 'sha512')`
+/// produced a SHA-256 key (#1355).
 #[no_mangle]
 pub unsafe extern "C" fn js_crypto_pbkdf2_bytes(
     password_ptr: i64,
     salt_ptr: i64,
     iterations: f64,
     keylen: f64,
+    digest_ptr: i64,
 ) -> *mut perry_runtime::buffer::BufferHeader {
     use pbkdf2::pbkdf2_hmac;
+    use sha2::{Sha224, Sha384};
     let password = bytes_from_ptr(password_ptr);
     let salt = bytes_from_ptr(salt_ptr);
     let iter = iterations as u32;
     let klen = keylen as usize;
     let mut out = vec![0u8; klen];
-    pbkdf2_hmac::<Sha256>(&password, &salt, iter, &mut out);
+    // Resolve the digest algorithm. `digest_ptr` may be a null/sentinel
+    // pointer (no arg passed) — fall back to SHA-256 in that case.
+    let digest = if (digest_ptr as usize) < 0x1000 {
+        String::new()
+    } else {
+        String::from_utf8_lossy(&bytes_from_ptr(digest_ptr))
+            .to_ascii_lowercase()
+            .replace('-', "")
+    };
+    match digest.as_str() {
+        "sha1" => pbkdf2_hmac::<Sha1>(&password, &salt, iter, &mut out),
+        "sha224" => pbkdf2_hmac::<Sha224>(&password, &salt, iter, &mut out),
+        "sha384" => pbkdf2_hmac::<Sha384>(&password, &salt, iter, &mut out),
+        "sha512" => pbkdf2_hmac::<Sha512>(&password, &salt, iter, &mut out),
+        // "sha256" and the empty/unknown default.
+        _ => pbkdf2_hmac::<Sha256>(&password, &salt, iter, &mut out),
+    }
     alloc_buffer_from_slice(&out)
 }
 


### PR DESCRIPTION
`js_crypto_pbkdf2_bytes` hardcoded HMAC-SHA256 and the codegen `pbkdf2Sync` arm dropped the digest argument, so `crypto.pbkdf2Sync(pw, salt, iter, len, 'sha512')` silently derived a **SHA-256** key.

## Fix
- Plumb the digest string through to the runtime (new 5th FFI arg).
- The runtime now dispatches `pbkdf2_hmac` over **sha1 / sha224 / sha256 / sha384 / sha512**.
- A null / empty / unknown digest defaults to **SHA-256** — the algorithm SCRAM and the previous 4-arg callers relied on, so existing call sites are unaffected.

## Validation
Byte-for-byte against `node --experimental-strip-types` (`password`/`salt`, 1000 iterations):

| digest | matches Node |
|--------|--------------|
| sha256 | ✓ |
| sha512 | ✓ |
| sha1   | ✓ |
| sha224 | ✓ |
| sha384 | ✓ |

Closes #1355