### PR TITLE
feat(crypto): implement crypto.scryptSync (#1361)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1785,6 +1785,9 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("crypto", "createSecretKey", false, None),
     method("crypto", "pbkdf2Sync", false, None),
     method("crypto", "pbkdf2", false, None),
+    // crypto.scryptSync(password, salt, keylen, options?) -> Buffer. Wired in
+    // codegen `expr/calls.rs`; HIR types the result as Uint8Array.
+    method("crypto", "scryptSync", false, None),
     // crypto.randomInt([min,] max) — uniform integer in [min, max).
     // crypto.timingSafeEqual(a, b) — constant-time byte comparison.
     // crypto.getHashes() / getCiphers() — supported-algorithm name lists.

--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -615,6 +615,51 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &buf_handle))
         }
 
+        // crypto.scryptSync(password, salt, keylen, options?) -> Buffer.
+        // The runtime returns a Buffer (HIR types scryptSync as Uint8Array)
+        // and reads optional `{ N, r, p }` cost params from the options
+        // object pointer; an absent options arg passes a null pointer and the
+        // runtime uses Node's defaults (N=16384, r=8, p=1).
+        Expr::Call { callee, args, .. }
+            if matches!(
+                callee.as_ref(),
+                Expr::PropertyGet { object, property } if property == "scryptSync" && matches!(
+                    object.as_ref(),
+                    Expr::NativeModuleRef(n) if n == "crypto"
+                )
+            ) =>
+        {
+            if args.len() < 3 {
+                return Ok(double_literal(0.0));
+            }
+            let pwd_box = lower_expr(ctx, &args[0])?;
+            let salt_box = lower_expr(ctx, &args[1])?;
+            let keylen_box = lower_expr(ctx, &args[2])?;
+            let opts_box = if args.len() >= 4 {
+                Some(lower_expr(ctx, &args[3])?)
+            } else {
+                None
+            };
+            let blk = ctx.block();
+            let pwd_handle = unbox_to_i64(blk, &pwd_box);
+            let salt_handle = unbox_to_i64(blk, &salt_box);
+            let opts_handle = match &opts_box {
+                Some(b) => unbox_to_i64(blk, b),
+                None => "0".to_string(),
+            };
+            let buf_handle = blk.call(
+                I64,
+                "js_crypto_scrypt_bytes",
+                &[
+                    (I64, &pwd_handle),
+                    (I64, &salt_handle),
+                    (DOUBLE, &keylen_box),
+                    (I64, &opts_handle),
+                ],
+            );
+            Ok(nanbox_pointer_inline(blk, &buf_handle))
+        }
+
         // Phase H fs: `fs.promises.METHOD(args...)` — HIR shape is a
         // nested PropertyGet { PropertyGet { NativeModuleRef("fs"),
         // "promises" }, method }. We route these to their sync

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -558,6 +558,9 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_crypto_random_bytes_hex", I64, &[DOUBLE]);
     module.declare_function("js_crypto_random_nonce", I64, &[]);
     module.declare_function("js_crypto_scrypt", I64, &[I64, I64, DOUBLE]);
+    // crypto.scryptSync(password, salt, keylen, options?) -> Buffer. The 4th
+    // arg is the NaN-unboxed options-object pointer (0 = none).
+    module.declare_function("js_crypto_scrypt_bytes", I64, &[I64, I64, DOUBLE, I64]);
     module.declare_function(
         "js_crypto_scrypt_custom",
         I64,

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -768,6 +768,76 @@ pub unsafe extern "C" fn js_crypto_scrypt_custom(
     js_string_from_bytes(hex_str.as_ptr(), hex_str.len() as u32)
 }
 
+/// `crypto.scryptSync(password, salt, keylen[, options])` → Buffer.
+///
+/// Unlike `js_crypto_scrypt` (which returns a hex string), this returns a
+/// Buffer to match Node's `scryptSync`, and reads password/salt via
+/// `bytes_from_ptr` so Buffer inputs hash correctly. Optional cost
+/// parameters are read from `options_ptr` (a NaN-unboxed object pointer, or
+/// a null/sentinel for none): `N`/`cost`, `r`/`blockSize`, `p`/
+/// `parallelization`. Defaults match Node: N=16384, r=8, p=1.
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_scrypt_bytes(
+    password_ptr: i64,
+    salt_ptr: i64,
+    key_length: f64,
+    options_ptr: i64,
+) -> *mut perry_runtime::buffer::BufferHeader {
+    use perry_runtime::{js_object_get_field_by_name, ObjectHeader};
+    let password = bytes_from_ptr(password_ptr);
+    let salt = bytes_from_ptr(salt_ptr);
+    let klen = key_length as usize;
+    if klen == 0 || klen > 1024 {
+        return alloc_buffer_from_slice(&[]);
+    }
+    // Node defaults: N=16384 (cost), r=8 (blockSize), p=1 (parallelization).
+    let (mut n, mut r, mut p) = (16384u64, 8u32, 1u32);
+    if (options_ptr as usize) >= 0x1000 {
+        let obj = options_ptr as *const ObjectHeader;
+        // Read a numeric option by primary or alias name; None if absent.
+        let mut read = |primary: &str, alias: &str| -> Option<f64> {
+            let pk = js_string_from_bytes(primary.as_ptr(), primary.len() as u32);
+            let v = js_object_get_field_by_name(obj, pk);
+            if !v.is_undefined() {
+                return Some(v.to_number());
+            }
+            let ak = js_string_from_bytes(alias.as_ptr(), alias.len() as u32);
+            let v = js_object_get_field_by_name(obj, ak);
+            if v.is_undefined() {
+                None
+            } else {
+                Some(v.to_number())
+            }
+        };
+        if let Some(x) = read("N", "cost") {
+            if x >= 1.0 {
+                n = x as u64;
+            }
+        }
+        if let Some(x) = read("r", "blockSize") {
+            if x >= 1.0 {
+                r = x as u32;
+            }
+        }
+        if let Some(x) = read("p", "parallelization") {
+            if x >= 1.0 {
+                p = x as u32;
+            }
+        }
+    }
+    // `scrypt::Params` takes log2(N); Node requires N to be a power of two,
+    // so trailing_zeros gives the exact exponent. A non-power-of-two or an
+    // otherwise-invalid combo falls back to the Node defaults.
+    let log_n = n.trailing_zeros() as u8;
+    let params = scrypt::Params::new(log_n, r, p, klen)
+        .unwrap_or_else(|_| scrypt::Params::new(14, 8, 1, klen).unwrap());
+    let mut out = vec![0u8; klen];
+    if scrypt::scrypt(&password, &salt, &params, &mut out).is_err() {
+        return alloc_buffer_from_slice(&[]);
+    }
+    alloc_buffer_from_slice(&out)
+}
+
 // ---------------------------------------------------------------------------
 // Hash handle — powers `const h = crypto.createHash('sha1'); h.update(x);
 // h.digest()` (issue #86). The runtime-resident chain-collapse in

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1090 entries across 80 modules
+// Coverage: 1091 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -344,6 +344,8 @@ declare module "crypto" {
   export function randomInt(...args: any[]): any;
   /** stdlib */
   export function randomUUID(...args: any[]): any;
+  /** stdlib */
+  export function scryptSync(...args: any[]): any;
   /** stdlib */
   export function sha256(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1090 entries across 80 modules.
+Total: 1091 entries across 80 modules.
 
 ## Modules
 
@@ -392,6 +392,7 @@ Total: 1090 entries across 80 modules.
 - `randomFillSync` — module
 - `randomInt` — module
 - `randomUUID` — module
+- `scryptSync` — module
 - `sha256` — module
 - `timingSafeEqual` — module
 


### PR DESCRIPTION
`crypto.scryptSync` was rejected by the strict-API gate (#463): the existing `js_crypto_scrypt` returned a **hex string** and was never wired to the `crypto` namespace.

## Implementation
- New `js_crypto_scrypt_bytes` returns a **Buffer** (matching Node) and reads inputs via `bytes_from_ptr`, so string **and** Buffer password/salt both work.
- Optional cost params are read from the options object in the runtime: `N`/`cost`, `r`/`blockSize`, `p`/`parallelization`, defaulting to Node's **N=16384, r=8, p=1**.
- HIR already types `scryptSync` as `Uint8Array`, so `scryptSync(...).toString('hex')` and `[i]` indexing take the buffer path.
- Wired through codegen (`expr/calls.rs`), the FFI decls, and the API manifest (+ regenerated docs).

## Validation
Byte-for-byte vs `node --experimental-strip-types`:
- default 32-byte and 64-byte keys
- `.length` and byte indexing (`buf[0]`)
- custom `{ N: 1024, r: 8, p: 1 }` options
- `Buffer` password/salt inputs

## Note
This implements the synchronous form. The callback-style async `crypto.scrypt(pw, salt, keylen, cb)` is not included — Perry has no native→JS callback path for KDFs today (the existing "async" `pbkdf2` is likewise sync-returning), so it's a separate follow-up.

Closes #1361