### PR TITLE
feat(crypto): implement Hash#copy() (#1369)

### DIFF
--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -129,7 +129,7 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
     // keep hash before net to avoid changing the priority of in-registry
     // matches relative to the v0.5.98/#88 ordering.
     #[cfg(feature = "crypto")]
-    if matches!(method_name, "update" | "digest")
+    if matches!(method_name, "update" | "digest" | "copy")
         && with_handle::<crate::crypto::HashHandle, bool, _>(handle, |_| true).unwrap_or(false)
     {
         return crate::crypto::dispatch_hash(handle, method_name, &args);

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -974,6 +974,38 @@ pub unsafe fn dispatch_hash(handle: i64, method: &str, args: &[f64]) -> f64 {
                 f64::from_bits(0x7FFF_0000_0000_0000u64 | ((s as u64) & 0x0000_FFFF_FFFF_FFFF))
             }
         }
+        // `hash.copy()` (#1369) — return an independent Hash whose internal
+        // state is a snapshot of this one, so the two can be `.update()`d and
+        // `.digest()`ed separately. The RustCrypto hashers are `Clone`. An
+        // already-digested hash (state taken) yields undefined, mirroring the
+        // error a caller would hit using a finalized hash. The optional
+        // `outputLength` arg only applies to XOF hashes (shake*), which Perry
+        // doesn't expose, so it is ignored.
+        "copy" => {
+            let cloned = {
+                let guard = h.state.lock().unwrap();
+                match guard.as_ref() {
+                    Some(HashState::Sha1(x)) => Some(HashState::Sha1(x.clone())),
+                    Some(HashState::Sha224(x)) => Some(HashState::Sha224(x.clone())),
+                    Some(HashState::Sha256(x)) => Some(HashState::Sha256(x.clone())),
+                    Some(HashState::Sha384(x)) => Some(HashState::Sha384(x.clone())),
+                    Some(HashState::Sha512(x)) => Some(HashState::Sha512(x.clone())),
+                    Some(HashState::Md5(x)) => Some(HashState::Md5(x.clone())),
+                    None => None,
+                }
+            };
+            match cloned {
+                Some(state) => {
+                    let new_handle: Handle = register_handle(HashHandle {
+                        state: std::sync::Mutex::new(Some(state)),
+                    });
+                    f64::from_bits(
+                        0x7FFD_0000_0000_0000u64 | ((new_handle as u64) & 0x0000_FFFF_FFFF_FFFF),
+                    )
+                }
+                None => f64::from_bits(0x7FFC_0000_0000_0001),
+            }
+        }
         _ => f64::from_bits(0x7FFC_0000_0000_0001),
     }
 }


### PR DESCRIPTION
`hash.copy()` returned a non-object, so the copied handle's `.update()` / `.digest()` threw `(number).update is not a function`.

## Fix
- Add a `copy` arm to `dispatch_hash` that clones the current `HashState` (the RustCrypto hashers are `Clone`) into a fresh `HashHandle`.
- Add `copy` to the `HashHandle` method allowlist in `common/dispatch.rs` (it only forwarded `update`/`digest`), so `.copy()` routes to `dispatch_hash` instead of falling through to the generic path.

The two hashes can then be `.update()`d and `.digest()`ed independently. An already-digested hash yields `undefined`; the optional `outputLength` arg (XOF/shake-only, not exposed by Perry) is ignored.

## Validation
Byte-for-byte vs `node --experimental-strip-types`:
- copy then diverge: `h.update('abc'); const h2 = h.copy(); h.update('def'); h2.update('xyz')` → distinct correct digests
- algorithm preserved across copy (sha512): `a.copy()` digest equals `a`'s
- plain-hash regression unchanged

Runtime-only (no codegen/manifest change — `.copy()` dispatches through the existing handle-method route).

Closes #1369

---
Also closed as already-resolved-on-`main` while working this area (verified byte-for-byte vs Node; covered by `test-files/test_crypto_cipheriv.ts`): #1356 (aes-cbc round-trip) and #1363 (aes-gcm getAuthTag/setAuthTag round-trip).