### PR TITLE
release: v0.5.1024 — crypto + perf_hooks + ios + wasm timers release sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1024 — release sweep: crypto + perf_hooks + ios + wasm timers
+
+Rolls up 26 PRs that merged to `main` post-v0.5.1023 without version
+bumps. Highlights below; full per-PR history is in `git log
+v0.5.1023..HEAD`.
+
+**node:crypto gap-fixes (8 PRs):**
+- **#1352 #1353 #1355 #1361** addressed across **#1386 #1393 #1394 #1402
+  #1405**: `crypto.randomInt`, `crypto.timingSafeEqual`,
+  `crypto.getHashes` / `crypto.getCiphers`, `sha224` / `sha384`, base64
+  digest, Buffer hash input, no-arg `digest()` typed as Buffer,
+  `pbkdf2Sync` honors the digest argument, `crypto.scryptSync`. See
+  project_crypto_1332 (memory) for what's still open under #1332.
+
+**node:perf_hooks (#1321 + coverage):**
+- **#1321** Native `performance` + User Timing API (`mark`/`measure`) +
+  `PerformanceObserver`, plus a granular node-suite covering the surface.
+- **#1328 #1342 (PR-side) + observer-typeof under #1320**: coverage
+  expansions — `timerify`, histogram, `nodeTiming`, `toJSON`,
+  resource-timing, single-type observe, empty-clear, negative duration,
+  multiple observers, `measure(bad-mark)`. See project_perf_hooks_1321.
+
+**Other runtime + codegen:**
+- **#1090** Port GC checkpoint runtime work (#1324).
+- **#1311 / #1316 #1384 #1385** geisterhand on iOS — `--target ios`
+  builds + links the geisterhand inspector + registers SecureField in
+  perry-ui-ios + auto-includes perry-stdlib. See project_geisterhand_ios_1311.
+- **#1312 / #1314** `process.env.X` (unset) is undefined (nullish), so
+  `??` applies as in Node.
+- **#1319** Runtime thread-safety hardening for cross-thread statics.
+- **#1322** Exact-head GC evidence packet (diagnostics tooling).
+- **#1323 / #1329** wasm: dispatch timer builtins through the mem_call
+  bridge. See project_wasm_timers_1323.
+- **#1317 / #1326** Codegen: `node:timers/promises` segfault when a user
+  module shadows global `setTimeout`.
+- **#1330 → #1331** node:process suite (7 of 12 cases).
+- **#1292 / #1307** `bcrypt.hash()` returns a real String (not a
+  string-like object).
+- **#1293 / #1308** fastify: route `(request as any).json()` / `.body`
+  through the external-fastify handle dispatch.
+- **#1296** Performance gaps in common app patterns.
+- **#1297** `diagnostics_channel` parity support.
+- **#1301 / #1313** iOS App Groups capability (best-effort enable +
+  manual-step guidance).
+- **#1318 / #1325** Parity: `os/methods/modern-methods` rewritten on
+  static dispatch.
+- **#1315 #1342** Expanded Node parity test coverage.
+- **#1382** ui-ios: drain stdlib pump so async `fetch` resolves on iOS.
+- **#1392 / #1404** ui-wasm: reactive state + setText on web/wasm target.
+
 ## v0.5.1023 — feat(ios) #1301 setup --development + fix(compile) #1304 vendored optional_frameworks
 
 Folds two PRs that merged post-v0.5.1022 without version bumps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1023
+**Current Version:** 0.5.1024
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5134,7 +5134,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "base64",
@@ -5189,14 +5189,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "log",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "base64",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "serde",
  "serde_json",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1023"
+version = "0.5.1024"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "clap",
@@ -5300,14 +5300,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5340,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5348,7 +5348,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "chrono",
  "cron",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5406,14 +5406,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "bson",
  "futures-util",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "base64",
  "image",
@@ -5598,14 +5598,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5632,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "base64",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5835,11 +5835,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1023"
+version = "0.5.1024"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "base64",
  "itoa",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "base64",
  "block2",
@@ -5902,7 +5902,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "base64",
  "block2",
@@ -5921,11 +5921,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1023"
+version = "0.5.1024"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "base64",
  "block2",
@@ -5941,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "base64",
  "block2",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "block2",
  "libc",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "base64",
  "libc",
@@ -5985,7 +5985,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1023"
+version = "0.5.1024"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1023"
+version = "0.5.1024"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"


### PR DESCRIPTION
## Summary

Rolls up 26 PRs that merged to `main` post-v0.5.1023 without per-PR version bumps. Full per-PR detail in CHANGELOG.md.

**Headlines:**
- **node:crypto gap-fixes** (#1352 #1353 #1355 #1361 across #1386 #1393 #1394 #1402 #1405)
- **node:perf_hooks** (#1321 + #1328 #1342 coverage) — `performance` + User Timing + PerformanceObserver native impl
- **#1090 GC checkpoint runtime work** (#1324)
- **#1311 geisterhand on iOS** (#1316 #1383 #1384 #1385)
- **#1323 wasm timer dispatch** (#1329)
- **#1317 node:timers/promises shadow-segfault** (#1326)
- ...

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] Cargo.lock regenerated for version bump
- [ ] PR CI: lint + cargo-test + api-docs-drift + security-audit + harmonyos-smoke pass
- [ ] After merge: tag v0.5.1024 → release-packages.yml all-green