### PR TITLE
fix(codegen): typeof of native-module methods is "function" (#1343)

### DIFF
--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -143,6 +143,30 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             n if is_global_this_builtin_function_name(n) => Some("function"),
                             _ => None,
                         }
+                    } else if let Expr::NativeModuleRef(module) = object.as_ref() {
+                        // #1343: `typeof <nativeModule>.<member>` (e.g.
+                        // `typeof crypto.randomBytes`, `typeof process.cwd`).
+                        // A method is only addressable through the call-
+                        // dispatch arms, so reading it as a plain value yields
+                        // the module's `0.0` stub and `js_value_typeof` reports
+                        // "undefined"/"number". Short-circuit only methods and
+                        // exported classes to "function". Properties fall
+                        // through (`None`): their value is materialized for
+                        // real, so the generic typeof already reports the right
+                        // primitive/object kind (`process.pid` → "number",
+                        // `os.EOL` → "string", `crypto.constants` → "object").
+                        match perry_api_manifest::module_has_symbol(module, property) {
+                            Some(e)
+                                if matches!(
+                                    e.kind,
+                                    perry_api_manifest::ApiKind::Method { .. }
+                                        | perry_api_manifest::ApiKind::Class
+                                ) =>
+                            {
+                                Some("function")
+                            }
+                            _ => None,
+                        }
                     } else {
                         // Refs #915 (gap 2 from #899): `typeof C.staticMethod`
                         // where `C` is `Expr::ClassRef` or a `LocalGet`


### PR DESCRIPTION
`typeof crypto.randomBytes` (and any native-module method read as a value, not called) returned `"undefined"`. The member is only addressable through the call-dispatch arms, so reading it as a plain value yields the module's `0.0` stub, which `js_value_typeof` classifies as `undefined`/`number`.

## Fix
Add a `NativeModuleRef` arm to the `typeof` short-circuit in `expr/literals_vars.rs`: look the member up in the API manifest (`perry_api_manifest::module_has_symbol`) and emit `"function"` for `Method`/`Class` entries. **Properties fall through** (`None`) so their materialized value types correctly — `process.pid` stays `"number"`, `os.EOL` `"string"`, `crypto.constants` `"object"`.

General fix: any manifest-registered native method now reports `"function"`. Covers `crypto.*` today; `process.*` methods benefit automatically once they're registered (currently several aren't, which is a separate gap — they hit the #463 gate before typeof).

## Validation
Byte-for-byte vs `node --experimental-strip-types`:
- `typeof` of `randomBytes` / `createHash` / `randomUUID` / `pbkdf2Sync` / `scryptSync` / `timingSafeEqual` / `getHashes` → `"function"`
- `typeof crypto.constants` → `"object"` (property, falls through)
- regression: `typeof crypto.randomUUID()` → `"string"`, `typeof crypto.randomBytes(4).toString('hex')` → `"string"`

Codegen-only; no manifest/runtime change.

Closes #1343