### PR TITLE
feat(crypto): implement crypto.hkdfSync (#1362)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1793,6 +1793,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // crypto.scryptSync(password, salt, keylen, options?) -> Buffer. Wired in
     // codegen `expr/calls.rs`; HIR types the result as Uint8Array.
     method("crypto", "scryptSync", false, None),
+    // crypto.hkdfSync(digest, ikm, salt, info, keylen) -> ArrayBuffer.
+    method("crypto", "hkdfSync", false, None),
     // crypto.randomInt([min,] max) — uniform integer in [min, max).
     // crypto.timingSafeEqual(a, b) — constant-time byte comparison.
     // crypto.getHashes() / getCiphers() — supported-algorithm name lists.

--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -758,6 +758,45 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &buf_handle))
         }
 
+        // crypto.hkdfSync(digest, ikm, salt, info, keylen) -> ArrayBuffer.
+        // The runtime returns an array-buffer-marked Buffer; callers wrap it
+        // with `Buffer.from(...)` / `new Uint8Array(...)`.
+        Expr::Call { callee, args, .. }
+            if matches!(
+                callee.as_ref(),
+                Expr::PropertyGet { object, property } if property == "hkdfSync" && matches!(
+                    object.as_ref(),
+                    Expr::NativeModuleRef(n) if n == "crypto"
+                )
+            ) =>
+        {
+            if args.len() < 5 {
+                return Ok(double_literal(0.0));
+            }
+            let digest_box = lower_expr(ctx, &args[0])?;
+            let ikm_box = lower_expr(ctx, &args[1])?;
+            let salt_box = lower_expr(ctx, &args[2])?;
+            let info_box = lower_expr(ctx, &args[3])?;
+            let keylen_box = lower_expr(ctx, &args[4])?;
+            let blk = ctx.block();
+            let digest_handle = unbox_to_i64(blk, &digest_box);
+            let ikm_handle = unbox_to_i64(blk, &ikm_box);
+            let salt_handle = unbox_to_i64(blk, &salt_box);
+            let info_handle = unbox_to_i64(blk, &info_box);
+            let buf_handle = blk.call(
+                I64,
+                "js_crypto_hkdf_sync",
+                &[
+                    (I64, &digest_handle),
+                    (I64, &ikm_handle),
+                    (I64, &salt_handle),
+                    (I64, &info_handle),
+                    (DOUBLE, &keylen_box),
+                ],
+            );
+            Ok(nanbox_pointer_inline(blk, &buf_handle))
+        }
+
         // Phase H fs: `fs.promises.METHOD(args...)` — HIR shape is a
         // nested PropertyGet { PropertyGet { NativeModuleRef("fs"),
         // "promises" }, method }. We route these to their sync

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -557,6 +557,8 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_crypto_create_sign", DOUBLE, &[I64]);
     module.declare_function("js_crypto_create_verify", DOUBLE, &[I64]);
     module.declare_function("js_crypto_hkdf_sha256", I64, &[I64, I64, I64, DOUBLE]);
+    // crypto.hkdfSync(digest, ikm, salt, info, keylen) -> ArrayBuffer.
+    module.declare_function("js_crypto_hkdf_sync", I64, &[I64, I64, I64, I64, DOUBLE]);
     module.declare_function("js_crypto_pbkdf2", I64, &[I64, I64, DOUBLE, DOUBLE]);
     module.declare_function("js_crypto_random_bytes_hex", I64, &[DOUBLE]);
     module.declare_function("js_crypto_random_nonce", I64, &[]);

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -862,6 +862,67 @@ pub unsafe extern "C" fn js_crypto_scrypt_bytes(
     alloc_buffer_from_slice(&out)
 }
 
+/// `crypto.hkdfSync(digest, ikm, salt, info, keylen)` → ArrayBuffer.
+///
+/// HKDF (RFC 5869) extract-and-expand. `ikm`/`salt`/`info` are read as raw
+/// bytes (string or Buffer); `digest` selects the HMAC hash (sha256 default,
+/// plus sha1/sha224/sha384/sha512). Returns the derived key in a real
+/// ArrayBuffer to match Node, so `Buffer.from(result)` / `new
+/// Uint8Array(result)` work. An empty salt means "no salt" per the spec.
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_hkdf_sync(
+    digest_ptr: i64,
+    ikm_ptr: i64,
+    salt_ptr: i64,
+    info_ptr: i64,
+    keylen: f64,
+) -> *mut perry_runtime::buffer::BufferHeader {
+    use hkdf::Hkdf;
+    let digest = String::from_utf8_lossy(&bytes_from_ptr(digest_ptr))
+        .to_ascii_lowercase()
+        .replace('-', "");
+    let ikm = bytes_from_ptr(ikm_ptr);
+    let salt = bytes_from_ptr(salt_ptr);
+    let info = bytes_from_ptr(info_ptr);
+    let out_len = keylen as usize;
+    // Cap at the largest HKDF output across supported digests (255*64 for
+    // sha512); per-digest over-length is rejected by `expand` below.
+    let make = |bytes: &[u8]| -> *mut perry_runtime::buffer::BufferHeader {
+        let buf = alloc_buffer_from_slice(bytes);
+        if !buf.is_null() {
+            perry_runtime::buffer::mark_as_array_buffer(buf as usize);
+        }
+        buf
+    };
+    if out_len == 0 || out_len > 255 * 64 {
+        return make(&[]);
+    }
+    let salt_ref: Option<&[u8]> = if salt.is_empty() { None } else { Some(&salt) };
+    let mut okm = vec![0u8; out_len];
+    let ok = match digest.as_str() {
+        "sha1" => Hkdf::<Sha1>::new(salt_ref, &ikm)
+            .expand(&info, &mut okm)
+            .is_ok(),
+        "sha224" => Hkdf::<Sha224>::new(salt_ref, &ikm)
+            .expand(&info, &mut okm)
+            .is_ok(),
+        "sha384" => Hkdf::<Sha384>::new(salt_ref, &ikm)
+            .expand(&info, &mut okm)
+            .is_ok(),
+        "sha512" => Hkdf::<Sha512>::new(salt_ref, &ikm)
+            .expand(&info, &mut okm)
+            .is_ok(),
+        // "sha256" and the empty/unknown default.
+        _ => Hkdf::<Sha256>::new(salt_ref, &ikm)
+            .expand(&info, &mut okm)
+            .is_ok(),
+    };
+    if !ok {
+        return make(&[]);
+    }
+    make(&okm)
+}
+
 // ---------------------------------------------------------------------------
 // Hash handle — powers `const h = crypto.createHash('sha1'); h.update(x);
 // h.digest()` (issue #86). The runtime-resident chain-collapse in

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1093 entries across 80 modules
+// Coverage: 1094 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -334,6 +334,8 @@ declare module "crypto" {
   export function getHashes(...args: any[]): any;
   /** stdlib */
   export function getRandomValues(...args: any[]): any;
+  /** stdlib */
+  export function hkdfSync(...args: any[]): any;
   /** stdlib */
   export function md5(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1093 entries across 80 modules.
+Total: 1094 entries across 80 modules.
 
 ## Modules
 
@@ -387,6 +387,7 @@ Total: 1093 entries across 80 modules.
 - `getCiphers` — module
 - `getHashes` — module
 - `getRandomValues` — module
+- `hkdfSync` — module
 - `md5` — module
 - `pbkdf2` — module
 - `pbkdf2Sync` — module


### PR DESCRIPTION
`crypto.hkdfSync` wasn't wired to the `crypto` namespace (hit the #463 gate). The existing `js_crypto_hkdf_sha256` was sha256-only, used hex-string I/O, and had the wrong arg shape, so it couldn't back Node's `hkdfSync(digest, ikm, salt, info, keylen)`.

## Implementation
- New `js_crypto_hkdf_sync`: reads `ikm`/`salt`/`info` as **raw bytes** (string or Buffer), dispatches HKDF (RFC 5869) over **sha1 / sha224 / sha256 / sha384 / sha512**, and returns the derived key in a **real ArrayBuffer** (`mark_as_array_buffer`) to match Node — so `Buffer.from(result)`, `new Uint8Array(result)`, and `.byteLength` all work. Empty `salt` means "no salt".
- Wired through codegen (`expr/calls.rs`), FFI decls, and the API manifest (+ regenerated docs).

## Validation
Byte-for-byte vs `node --experimental-strip-types`:
- sha256 / sha512 / sha1 derivations
- no-salt (`''`)
- `Buffer` inputs for ikm/salt/info
- ArrayBuffer interop: `Buffer.from(r).toString('hex')`, `new Uint8Array(r)[0]`, `r.byteLength`

Closes #1362