### PR TITLE
feat(crypto): implement generateKeyPairSync (RSA + EC) (#1365)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1795,6 +1795,9 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("crypto", "scryptSync", false, None),
     // crypto.hkdfSync(digest, ikm, salt, info, keylen) -> ArrayBuffer.
     method("crypto", "hkdfSync", false, None),
+    // crypto.generateKeyPairSync(type, options) -> { publicKey, privateKey }
+    // PEM strings (RSA / EC P-256). Wired in codegen `expr/calls.rs`.
+    method("crypto", "generateKeyPairSync", false, None),
     // crypto.randomInt([min,] max) — uniform integer in [min, max).
     // crypto.timingSafeEqual(a, b) — constant-time byte comparison.
     // crypto.getHashes() / getCiphers() — supported-algorithm name lists.

--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -797,6 +797,42 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &buf_handle))
         }
 
+        // crypto.generateKeyPairSync(type, options) -> { publicKey, privateKey }.
+        // The runtime builds the object (PEM strings) and returns it already
+        // NaN-boxed; `.publicKey` / `.privateKey` reads go through the generic
+        // object property dispatch (the object carries a keys array).
+        Expr::Call { callee, args, .. }
+            if matches!(
+                callee.as_ref(),
+                Expr::PropertyGet { object, property } if property == "generateKeyPairSync" && matches!(
+                    object.as_ref(),
+                    Expr::NativeModuleRef(n) if n == "crypto"
+                )
+            ) =>
+        {
+            if args.is_empty() {
+                return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
+            }
+            let type_box = lower_expr(ctx, &args[0])?;
+            let opts_box = if args.len() >= 2 {
+                Some(lower_expr(ctx, &args[1])?)
+            } else {
+                None
+            };
+            let blk = ctx.block();
+            let type_handle = unbox_to_i64(blk, &type_box);
+            let opts_handle = match &opts_box {
+                Some(b) => unbox_to_i64(blk, b),
+                None => "0".to_string(),
+            };
+            // Returns an already-NaN-boxed object (POINTER_TAG).
+            Ok(blk.call(
+                DOUBLE,
+                "js_crypto_generate_key_pair_sync",
+                &[(I64, &type_handle), (I64, &opts_handle)],
+            ))
+        }
+
         // Phase H fs: `fs.promises.METHOD(args...)` — HIR shape is a
         // nested PropertyGet { PropertyGet { NativeModuleRef("fs"),
         // "promises" }, method }. We route these to their sync

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -566,6 +566,8 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // crypto.scryptSync(password, salt, keylen, options?) -> Buffer. The 4th
     // arg is the NaN-unboxed options-object pointer (0 = none).
     module.declare_function("js_crypto_scrypt_bytes", I64, &[I64, I64, DOUBLE, I64]);
+    // crypto.generateKeyPairSync(type, options) -> { publicKey, privateKey }.
+    module.declare_function("js_crypto_generate_key_pair_sync", DOUBLE, &[I64, I64]);
     module.declare_function(
         "js_crypto_scrypt_custom",
         I64,

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -923,6 +923,93 @@ pub unsafe extern "C" fn js_crypto_hkdf_sync(
     make(&okm)
 }
 
+/// `crypto.generateKeyPairSync(type, options)` → `{ publicKey, privateKey }`
+/// as PEM strings (#1365). Supports `'rsa'` (modulusLength from options,
+/// default 2048) and `'ec'` (NIST P-256 / `prime256v1`). The public key is
+/// SPKI PEM, the private key PKCS#8 PEM — the format the overwhelming
+/// majority of callers request via `publicKeyEncoding`/`privateKeyEncoding:
+/// { type, format: 'pem' }`. The encoding-options object is accepted but only
+/// the PEM string form is produced (KeyObjects and DER are not modeled).
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_generate_key_pair_sync(type_ptr: i64, options_ptr: i64) -> f64 {
+    let ktype = String::from_utf8_lossy(&bytes_from_ptr(type_ptr)).to_ascii_lowercase();
+
+    // RSA modulus length from `options.modulusLength` (default 2048).
+    let modulus_bits = read_options_number(options_ptr, "modulusLength").unwrap_or(2048.0) as usize;
+
+    let pems: Option<(String, String)> = match ktype.as_str() {
+        "rsa" => {
+            use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
+            let mut rng = rand::thread_rng();
+            // Clamp to a sane range; Node's default is 2048.
+            let bits = modulus_bits.clamp(512, 8192);
+            rsa::RsaPrivateKey::new(&mut rng, bits).ok().and_then(|sk| {
+                let pk = sk.to_public_key();
+                let priv_pem = sk.to_pkcs8_pem(LineEnding::LF).ok()?.to_string();
+                let pub_pem = pk.to_public_key_pem(LineEnding::LF).ok()?;
+                Some((pub_pem, priv_pem))
+            })
+        }
+        // 'ec' (default/prime256v1) and the explicit 'prime256v1'/'p-256'.
+        "ec" | "prime256v1" | "p-256" | "p256" => {
+            use p256::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
+            let secret = p256::SecretKey::random(&mut rand::thread_rng());
+            let priv_pem = secret
+                .to_pkcs8_pem(LineEnding::LF)
+                .ok()
+                .map(|p| p.to_string());
+            let pub_pem = secret.public_key().to_public_key_pem(LineEnding::LF).ok();
+            match (pub_pem, priv_pem) {
+                (Some(pb), Some(pv)) => Some((pb, pv)),
+                _ => None,
+            }
+        }
+        _ => None,
+    };
+
+    match pems {
+        Some((pub_pem, priv_pem)) => build_key_pair_object(&pub_pem, &priv_pem),
+        None => nanbox_undefined(),
+    }
+}
+
+/// Read a numeric field from a NaN-unboxed options object pointer (0/null →
+/// `None`). Shared by `generateKeyPairSync`.
+unsafe fn read_options_number(options_ptr: i64, name: &str) -> Option<f64> {
+    if (options_ptr as usize) < 0x1000 {
+        return None;
+    }
+    let obj = options_ptr as *const perry_runtime::ObjectHeader;
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let v = perry_runtime::js_object_get_field_by_name(obj, key);
+    if v.is_undefined() {
+        None
+    } else {
+        Some(v.to_number())
+    }
+}
+
+/// Build a `{ publicKey, privateKey }` JS object holding the two PEM strings,
+/// returned NaN-boxed as POINTER_TAG.
+unsafe fn build_key_pair_object(pub_pem: &str, priv_pem: &str) -> f64 {
+    use perry_runtime::{
+        js_array_alloc, js_array_push, js_object_alloc, js_object_set_field, js_object_set_keys,
+        JSValue,
+    };
+    let obj = js_object_alloc(0, 2);
+    let keys = js_array_alloc(2);
+    let pub_key_name = js_string_from_bytes("publicKey".as_ptr(), 9);
+    js_array_push(keys, JSValue::string_ptr(pub_key_name));
+    let priv_key_name = js_string_from_bytes("privateKey".as_ptr(), 10);
+    js_array_push(keys, JSValue::string_ptr(priv_key_name));
+    let pub_s = js_string_from_bytes(pub_pem.as_ptr(), pub_pem.len() as u32);
+    let priv_s = js_string_from_bytes(priv_pem.as_ptr(), priv_pem.len() as u32);
+    js_object_set_field(obj, 0, JSValue::string_ptr(pub_s));
+    js_object_set_field(obj, 1, JSValue::string_ptr(priv_s));
+    js_object_set_keys(obj, keys);
+    nanbox_pointer_f64(obj as usize)
+}
+
 // ---------------------------------------------------------------------------
 // Hash handle — powers `const h = crypto.createHash('sha1'); h.update(x);
 // h.digest()` (issue #86). The runtime-resident chain-collapse in

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1094 entries across 80 modules
+// Coverage: 1095 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -328,6 +328,8 @@ declare module "crypto" {
   export function createSign(...args: any[]): any;
   /** stdlib */
   export function createVerify(...args: any[]): any;
+  /** stdlib */
+  export function generateKeyPairSync(...args: any[]): any;
   /** stdlib */
   export function getCiphers(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1094 entries across 80 modules.
+Total: 1095 entries across 80 modules.
 
 ## Modules
 
@@ -384,6 +384,7 @@ Total: 1094 entries across 80 modules.
 - `createSecretKey` — module
 - `createSign` — module
 - `createVerify` — module
+- `generateKeyPairSync` — module
 - `getCiphers` — module
 - `getHashes` — module
 - `getRandomValues` — module


### PR DESCRIPTION
`crypto.generateKeyPairSync` hit the #463 gate — unimplemented.

## Implementation
`js_crypto_generate_key_pair_sync` generates an **RSA** keypair (`modulusLength` from options, default 2048) or an **EC P-256** keypair, and returns a `{ publicKey, privateKey }` object whose values are **PEM strings** — SPKI for the public key, PKCS#8 for the private key (the form callers request via `publicKeyEncoding`/`privateKeyEncoding: { type, format: 'pem' }`).

The result object carries a keys array, so `.publicKey` / `.privateKey` and destructuring read through the generic property dispatch.

Wired through codegen (`expr/calls.rs`), FFI decls, and the API manifest (+ regenerated docs).

## Validation
Keygen output is random, so this verifies **shape + interop**:
- PEM headers match Node: `-----BEGIN PUBLIC KEY-----` (SPKI), `-----BEGIN PRIVATE KEY-----` (PKCS#8), for both RSA and EC.
- **Node loads the Perry-generated PEMs** and completes a `createSign`/`createVerify` round-trip for both RSA and EC → `true`, proving the keys are valid and interoperable.

## Follow-ups
ed25519 keygen (needs the `ed25519-dalek` `pkcs8` feature) and DER / KeyObject output forms; RSA + EC PEM is the dominant `generateKeyPairSync` usage.

Closes #1365