### PR TITLE
ci(memory): restore 290/315 MB json_churn ceiling reverted by #1324

### DIFF
--- a/scripts/run_memory_stability_tests.sh
+++ b/scripts/run_memory_stability_tests.sh
@@ -1732,14 +1732,17 @@ echo "=== Memory-leak regression tests (RSS plateau under sustained alloc) ==="
 # Limits ~50-70% above measured baseline on macOS arm64. CI runners
 # may differ slightly; loosen a limit here rather than in the .ts.
 run_test test-files/test_memory_long_lived_loop.ts 100 "done, lastId=199999"
-# JSON churn stays at 250 MB for default/mark-sweep/gen-gc. On macOS
-# arm64, force-evac+verify has a stable tape+verifier high-water after
-# tape scratch/key-cache cleanup: default/gen-gc 240 MB, mark-sweep 90 MB,
-# force-evac+verify 262 MB, verifier direct parse (PERRY_JSON_TAPE=0)
-# 189 MB, forced tape 261 MB. Trace stayed in copied-minor mode with
-# fallback_reason=none, conservative pins=0, copy-only roots/bytes=0, and
-# old-page allocated/live/reusable/returned bytes=0.
-run_test test-files/test_memory_json_churn.ts      250 "done, checksum=637747500" 275
+# JSON churn — widened to 290 / 315 MB for the GC rework window under
+# #1090. Observed Ubuntu CI on the v0.5.1024 release-packages run:
+# default 268 MB, gen-gc 268 MB, force-evac+verify 288 MB — the same
+# Linux glibc + RSS-accounting gap that prompted Ralph's prior 200→250
+# bump in v0.5.842 (f95ef059). 290/315 was already set in v0.5.1022
+# (#1286 / 4fcfddb9) but PR #1324 ("Port GC checkpoint runtime work for
+# #1090", e933b893) reverted the ceiling back to 250/275 while writing
+# new comments referencing macOS arm64 baselines that don't apply on
+# Ubuntu CI. Restore the wider ceiling here; revisit + tighten when
+# #1090 closes.
+run_test test-files/test_memory_json_churn.ts      290 "done, checksum=637747500" 315
 run_test test-files/test_memory_string_churn.ts    100 "done, total=9577780"
 run_test test-files/test_memory_closure_churn.ts    50 "done, sum=15004649874"
 


### PR DESCRIPTION
## Summary

- PR #1324 (e933b893) reverted the 290/315 MB ceiling from v0.5.1022 (#1286) back to 250/275 while rewriting the surrounding comments.
- The v0.5.1024 release-packages compile-smoke job hit the same Ubuntu overrun we fixed once: default 268 / gen-gc 268 / force-evac+verify 288 MB.
- Restores 290/315 + rewrites the comment to reference the rebump + revert history so the next contributor doesn't undo it again.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [ ] CI: memory-stability sub-step of compile-smoke passes on the PR run

Refs #1090 #1286 #1324.