### PR TITLE
release: v0.5.1025 — fix(compile) cross-target geisterhand lookup + parity skip-list + bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1025 — fix(compile): cross-target geisterhand lib lookup + parity skip-list + memory ceiling restore
+
+Unblocks the v0.5.1024 release-packages run by addressing 3 distinct
+gate failures observed on run #26298996134 / #26298996081:
+
+**simctl iOS (`--target ios-simulator --enable-geisterhand`)**
+
+`crates/perry/src/commands/compile/library_search.rs::find_geisterhand_lib`
+fell back to the host `target/release/` directory when the
+cross-target `target/<triple>/release/` directory was missing the
+requested `.a` — so on the iOS-simulator workflow the function returned
+the host macOS `libperry_runtime.a` for an iOS-simulator link, producing
+
+    ld: building for 'iOS-simulator', but linking in object file
+    (target/release/libperry_runtime.a[2]…) built for 'macOS'
+    clang: error: linker command failed with exit code 1
+
+The same fallback also masked the auto-build trigger in
+`link/mod.rs` — `find_geisterhand_runtime(Some("ios-simulator"))`
+returned a path (host `.a`), `gh_missing` stayed `false`, and
+`build_geisterhand_libs(<cross-target>)` never ran. Fix: when a
+cross-compile target is specified, search ONLY the matching triple's
+release directories and `continue` instead of falling through to host
+paths. Host build (target = None) behaviour unchanged.
+
+**Parity gate (2 new failures triaged)**
+
+Both surfaced as NEW (not-in-known_failures.json) on the v0.5.1024
+parity job (442 pass / 38 fail / 2 NEW). Filed granular issues per
+`feedback_granular_gap_issues.md` and added skip-list entries:
+
+- **#1423** `test_async_local_storage_context` — `AsyncLocalStorage`
+  `.enterWith()` / `.exit()` aren't implemented end-to-end. The test
+  prints 10 of 17 expected lines and exits silently. Sibling slice of
+  #788 #789.
+- **#1424** `test_json_lazy_reviver` — `JSON.parse(blob, reviver)` on a
+  lazy-tape top-level array produces zero output (the reviver dispatch
+  on the materialised lazy array crashes / exits before any of the 4
+  `console.log` lines fire). Likely fallout from the GC checkpoint +
+  copied-minor work under #1090 / #1146 / #1235 / #1324.
+
+**compile-smoke memory ceiling**
+
+`scripts/run_memory_stability_tests.sh` `test_memory_json_churn` 290 /
+315 MB ceiling — already merged as PR #1422 / dec43e27 (this changelog
+entry calls it out as part of the v0.5.1024-failure-recovery story for
+completeness).
+
 ## v0.5.1024 — release sweep: crypto + perf_hooks + ios + wasm timers
 
 Rolls up 26 PRs that merged to `main` post-v0.5.1023 without version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1024
+**Current Version:** 0.5.1025
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5134,7 +5134,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "base64",
@@ -5189,14 +5189,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "log",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "base64",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "serde",
  "serde_json",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1024"
+version = "0.5.1025"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "clap",
@@ -5300,14 +5300,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5340,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5348,7 +5348,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "chrono",
  "cron",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5406,14 +5406,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "bson",
  "futures-util",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "base64",
  "image",
@@ -5598,14 +5598,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5632,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "base64",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5835,11 +5835,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1024"
+version = "0.5.1025"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "base64",
  "itoa",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "base64",
  "block2",
@@ -5902,7 +5902,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "base64",
  "block2",
@@ -5921,11 +5921,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1024"
+version = "0.5.1025"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "base64",
  "block2",
@@ -5941,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "base64",
  "block2",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "block2",
  "libc",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "base64",
  "libc",
@@ -5985,7 +5985,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1024"
+version = "0.5.1025"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1024"
+version = "0.5.1025"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -1077,9 +1077,21 @@ pub(super) fn find_geisterhand_lib(name: &str, target: Option<&str>) -> Option<P
         }
         roots
     };
+    // When a cross-compile target is specified, ONLY look in that triple's
+    // release directories. Falling through to host `target/release/` returns
+    // a wrong-architecture `.a` that the linker then refuses with
+    //
+    //   ld: building for 'iOS-simulator', but linking in object file
+    //   (target/release/libperry_runtime.a[2]…) built for 'macOS'
+    //
+    // Pre-fix the host fallback also masked the "auto-build geisterhand for
+    // this target" check in `link/mod.rs` — `find_geisterhand_runtime`
+    // returned the host `.a`, `gh_missing` stayed `false`, and
+    // `build_geisterhand_libs(<cross-target>)` never fired. Surfaced on the
+    // v0.5.1024 simctl-tests workflow run.
+    let triple = rust_target_triple(target);
     for root in &search_roots {
-        // Cross-compilation target dir first
-        if let Some(triple) = rust_target_triple(target) {
+        if let Some(triple) = triple {
             // Separate geisterhand build dir
             let path = root.join(format!("target/geisterhand/{}/release/{}", triple, name));
             if path.exists() {
@@ -1090,8 +1102,11 @@ pub(super) fn find_geisterhand_lib(name: &str, target: Option<&str>) -> Option<P
             if path.exists() {
                 return Some(path);
             }
+            // No host fallback for cross-compile targets — see comment above.
+            continue;
         }
-        // Host build dir
+        // Host build (target is None / matches host triple) — search both
+        // geisterhand-specific and shared release directories.
         let path = root.join(format!("target/geisterhand/release/{}", name));
         if path.exists() {
             return Some(path);

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -242,6 +242,18 @@
     "category": "bug-open",
     "reason": "Regression test from #911 (express map undefined / http.METHODS). The METHODS property is now in the manifest (PR adding it alongside this entry); the test may still diverge from Node in the exact METHODS list shape. Re-evaluate once express compiles cleanly."
   },
+  "test_async_local_storage_context": {
+    "issue": "1423",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "AsyncLocalStorage `.enterWith()` / `.exit()` aren't implemented end-to-end — the test prints the first 10 lines (await/then/catch/nextTick/timer/immediate/interval contexts + nested outer) and then exits silently when `enterWith()` is invoked, missing the last 7 lines covering enterWith semantics + exit/restore mechanics. Sibling slice of #788 #789 (real AsyncLocalStorage tracking across await/microtasks/timers + real `async_hooks.createHook` lifecycle). Surfaced as a NEW failure on v0.5.1024 release-packages parity. Flips to PASS when `.enterWith` / `.exit` land."
+  },
+  "test_json_lazy_reviver": {
+    "issue": "1424",
+    "added": "2026-05-22",
+    "category": "bug-open",
+    "reason": "`JSON.parse(blob, reviver)` with a lazy-tape top-level array (PERRY_JSON_TAPE=1 path) produces zero output — the reviver dispatch on the materialised lazy array crashes / exits before any of the 4 `console.log` lines fire. Likely fallout from the GC checkpoint + copied-minor work under #1090 / #1146 / #1235 / #1324. Surfaced as a NEW failure on v0.5.1024 release-packages parity. Flips to PASS when the lazy-tape reviver dispatch is fixed."
+  },
   "test_jsruntime_mixed_async_ordering_matrix": {
     "issue": null,
     "added": "2026-05-17",


### PR DESCRIPTION
## Summary

Bundles 3 fixes that together unblock the v0.5.1024 release-packages gate failure:

1. **simctl iOS link bug** in `find_geisterhand_lib` — when a cross-compile target was specified, the function fell back to the host `target/release/<lib>.a` if the cross-target lib was missing. The linker then refused to use the macOS `.a` for an iOS-sim binary, AND the same fallback masked the geisterhand auto-build trigger so the cross-target lib was never produced. Fix: with a target triple, search only that triple's directories.
2. **Parity gate**: 2 NEW failures triaged. Filed granular issues per `feedback_granular_gap_issues.md`:
   - **#1423** `test_async_local_storage_context` (`.enterWith` / `.exit` not implemented)
   - **#1424** `test_json_lazy_reviver` (JSON.parse(reviver) on lazy-tape top-level array exits early)
3. **CHANGELOG entry** also calls out PR #1422 (memory ceiling restore) for completeness — already on main as `dec43e27`.

## Surfaced by

- Release Packages run #26299008495 → await-tests failure cascaded all build/publish jobs to skipped
- Tests run #26298996134 → parity (2 NEW), compile-smoke (memory ceiling)
- Simctl Tests (iOS) run #26298996081 → linker arch mismatch

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check -p perry` clean
- [ ] PR CI: lint + cargo-test + api-docs-drift + security-audit + harmonyos-smoke pass
- [ ] After merge: tag v0.5.1025 → release-packages.yml all-green

Refs #1311 #1383 #1384 #1422 #1423 #1424.