### PR TITLE
feat(perf_hooks): implement performance.toJSON() (#1338)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2154,6 +2154,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("perf_hooks", "clearMarks", false, None),
     method("perf_hooks", "clearMeasures", false, None),
     method("perf_hooks", "eventLoopUtilization", false, None),
+    method("perf_hooks", "toJSON", false, None),
     property("perf_hooks", "timeOrigin"),
     property("perf_hooks", "performance"),
     property("perf_hooks", "constants"),

--- a/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
+++ b/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
@@ -115,6 +115,7 @@ pub(super) fn lower_perf_hooks_method(
                 ctx.block()
                     .call(DOUBLE, "js_perf_event_loop_utilization", &[(DOUBLE, &a0)])
             }
+            "toJSON" => ctx.block().call(DOUBLE, "js_perf_to_json", &[]),
             _ => return Ok(None),
         };
         return Ok(Some(v));

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1079,6 +1079,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_perf_clear_marks", DOUBLE, &[DOUBLE]);
     module.declare_function("js_perf_clear_measures", DOUBLE, &[DOUBLE]);
     module.declare_function("js_perf_event_loop_utilization", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_perf_to_json", DOUBLE, &[]);
     module.declare_function("js_perf_observer_new", DOUBLE, &[DOUBLE]);
     module.declare_function("js_perf_observer_observe", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_perf_observer_disconnect", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -383,6 +383,7 @@ pub(super) fn try_module_static_methods(
                             | "clearMarks"
                             | "clearMeasures"
                             | "eventLoopUtilization"
+                            | "toJSON"
                     ) {
                         return Ok(Ok(Expr::NativeMethodCall {
                             module: "perf_hooks".to_string(),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -338,6 +338,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("perf_hooks", "clearMarks")
             | ("perf_hooks", "clearMeasures")
             | ("perf_hooks", "eventLoopUtilization")
+            | ("perf_hooks", "toJSON")
             | ("perf_hooks", "PerformanceObserver")
             | ("perf_hooks", "PerformanceEntry")
             | ("perf_hooks", "PerformanceMark")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -130,6 +130,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("perf_hooks", "eventLoopUtilization") => {
             crate::perf_hooks::js_perf_event_loop_utilization(arg(0))
         }
+        ("perf_hooks", "toJSON") => crate::perf_hooks::js_perf_to_json(),
 
         // ── PerformanceObserver instance (perf_observer) ──
         // The registry index lives in field[1] of the namespace object; the

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -36,6 +36,10 @@ const PERF_ENTRY_KEYS: &[u8] = b"name\0entryType\0startTime\0duration\0detail\0"
 const ELU_SHAPE: u32 = 0x7FFF_FF41;
 const ELU_KEYS: &[u8] = b"idle\0active\0utilization\0";
 
+/// Shape id for the `{ timeOrigin }` snapshot returned by `performance.toJSON()`.
+const TOJSON_SHAPE: u32 = 0x7FFF_FF42;
+const TOJSON_KEYS: &[u8] = b"timeOrigin\0";
+
 #[derive(Clone)]
 struct PerfEntry {
     name: String,
@@ -471,6 +475,25 @@ pub extern "C" fn js_perf_event_loop_utilization(prev: f64) -> f64 {
             }
         }
         make_elu_object(idle, active)
+    }
+}
+
+// ── performance.toJSON() ─────────────────────────────────────────────────────
+/// A JSON snapshot of the performance object. Node returns
+/// `{ nodeTiming, timeOrigin, ... }`; Perry currently surfaces `timeOrigin`
+/// (a positive ms value), which is the field user code reads when serializing
+/// `performance`. Forward-compatible with adding `nodeTiming` later (#1337).
+#[no_mangle]
+pub extern "C" fn js_perf_to_json() -> f64 {
+    unsafe {
+        let obj = js_object_alloc_with_shape(
+            TOJSON_SHAPE,
+            1,
+            TOJSON_KEYS.as_ptr(),
+            TOJSON_KEYS.len() as u32,
+        );
+        js_object_set_field(obj, 0, JSValue::number(time_origin_ms()));
+        crate::value::js_nanbox_pointer(obj as i64)
     }
 }
 

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1095 entries across 80 modules
+// Coverage: 1096 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -874,6 +874,8 @@ declare module "perf_hooks" {
   export function measure(...args: any[]): any;
   /** stdlib */
   export function now(...args: any[]): any;
+  /** stdlib */
+  export function toJSON(...args: any[]): any;
 }
 
 declare module "perry/ads" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1095 entries across 80 modules.
+Total: 1096 entries across 80 modules.
 
 ## Modules
 
@@ -1046,6 +1046,7 @@ Total: 1095 entries across 80 modules.
 - `now` — module
 - `observe` — instance *(class: `PerformanceObserver`)*
 - `takeRecords` — instance *(class: `PerformanceObserver`)*
+- `toJSON` — module
 
 ### Properties
 

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -44,12 +44,6 @@
     "category": "bug-open",
     "reason": "node:perf_hooks: performance.nodeTiming (PerformanceNodeTiming) unimplemented (not an object). Flips to PASS when #1337 lands."
   },
-  "node-suite/perf_hooks/to-json/to-json": {
-    "issue": "1338",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: performance.toJSON() unimplemented (not a function). Flips to PASS when #1338 lands."
-  },
   "node-suite/perf_hooks/resource-timing/clear-and-buffer-size": {
     "issue": "1339",
     "added": "2026-05-22",


### PR DESCRIPTION
## Summary

Implements `performance.toJSON()` (node:perf_hooks gap #1338, umbrella #793).

Node's `performance.toJSON()` returns a snapshot object including `timeOrigin`. Perry previously reported `typeof performance.toJSON === 'undefined'` and the call failed to compile (manifest rejection). This wires the method end-to-end:

- **runtime** (`perf_hooks.rs`): new `js_perf_to_json()` returning `{ timeOrigin }` (a positive ms value); forward-compatible with adding `nodeTiming` later (#1337).
- **HIR** (`module_static.rs`): `performance.toJSON()` lowers to a `perf_hooks` NativeMethodCall.
- **codegen** (`native/perf_hooks.rs` + `runtime_decls/stdlib_ffi.rs`): emit the call + declare the extern.
- **runtime dispatch** (`native_module_dispatch.rs`) and the **typeof-read** path (`native_module.rs`) so `typeof performance.toJSON === 'function'`.
- **API manifest** (`entries.rs`) + regenerated `docs/`.

## Test

Flips `test-parity/node-suite/perf_hooks/to-json/to-json` to PASS (removed from `known_failures.json`). Verified byte-for-byte against `node --experimental-strip-types`:

```
is object: true
timeOrigin number: true
```

Closes #1338.