### PR TITLE
feat(perf_hooks): implement clearResourceTimings + setResourceTimingBufferSize (#1339)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2155,6 +2155,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("perf_hooks", "clearMeasures", false, None),
     method("perf_hooks", "eventLoopUtilization", false, None),
     method("perf_hooks", "toJSON", false, None),
+    method("perf_hooks", "clearResourceTimings", false, None),
+    method("perf_hooks", "setResourceTimingBufferSize", false, None),
     property("perf_hooks", "timeOrigin"),
     property("perf_hooks", "performance"),
     property("perf_hooks", "constants"),

--- a/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
+++ b/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
@@ -116,6 +116,18 @@ pub(super) fn lower_perf_hooks_method(
                     .call(DOUBLE, "js_perf_event_loop_utilization", &[(DOUBLE, &a0)])
             }
             "toJSON" => ctx.block().call(DOUBLE, "js_perf_to_json", &[]),
+            "clearResourceTimings" => {
+                ctx.block()
+                    .call(DOUBLE, "js_perf_clear_resource_timings", &[])
+            }
+            "setResourceTimingBufferSize" => {
+                let a0 = lower_or_undef(ctx, 0)?;
+                ctx.block().call(
+                    DOUBLE,
+                    "js_perf_set_resource_timing_buffer_size",
+                    &[(DOUBLE, &a0)],
+                )
+            }
             _ => return Ok(None),
         };
         return Ok(Some(v));

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1080,6 +1080,8 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_perf_clear_measures", DOUBLE, &[DOUBLE]);
     module.declare_function("js_perf_event_loop_utilization", DOUBLE, &[DOUBLE]);
     module.declare_function("js_perf_to_json", DOUBLE, &[]);
+    module.declare_function("js_perf_clear_resource_timings", DOUBLE, &[]);
+    module.declare_function("js_perf_set_resource_timing_buffer_size", DOUBLE, &[DOUBLE]);
     module.declare_function("js_perf_observer_new", DOUBLE, &[DOUBLE]);
     module.declare_function("js_perf_observer_observe", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_perf_observer_disconnect", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -384,6 +384,8 @@ pub(super) fn try_module_static_methods(
                             | "clearMeasures"
                             | "eventLoopUtilization"
                             | "toJSON"
+                            | "clearResourceTimings"
+                            | "setResourceTimingBufferSize"
                     ) {
                         return Ok(Ok(Expr::NativeMethodCall {
                             module: "perf_hooks".to_string(),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -339,6 +339,8 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("perf_hooks", "clearMeasures")
             | ("perf_hooks", "eventLoopUtilization")
             | ("perf_hooks", "toJSON")
+            | ("perf_hooks", "clearResourceTimings")
+            | ("perf_hooks", "setResourceTimingBufferSize")
             | ("perf_hooks", "PerformanceObserver")
             | ("perf_hooks", "PerformanceEntry")
             | ("perf_hooks", "PerformanceMark")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -131,6 +131,12 @@ pub(crate) unsafe fn dispatch_native_module_method(
             crate::perf_hooks::js_perf_event_loop_utilization(arg(0))
         }
         ("perf_hooks", "toJSON") => crate::perf_hooks::js_perf_to_json(),
+        ("perf_hooks", "clearResourceTimings") => {
+            crate::perf_hooks::js_perf_clear_resource_timings()
+        }
+        ("perf_hooks", "setResourceTimingBufferSize") => {
+            crate::perf_hooks::js_perf_set_resource_timing_buffer_size(arg(0))
+        }
 
         // ── PerformanceObserver instance (perf_observer) ──
         // The registry index lives in field[1] of the namespace object; the

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -497,6 +497,21 @@ pub extern "C" fn js_perf_to_json() -> f64 {
     }
 }
 
+// ── clearResourceTimings() / setResourceTimingBufferSize(n) ──────────────────
+// Perry has no Resource Timing buffer (no PerformanceResourceTiming entries are
+// ever recorded), so these are no-ops matching Node's signatures — both return
+// `undefined`. They exist so user code that manages the resource-timing buffer
+// runs unchanged.
+#[no_mangle]
+pub extern "C" fn js_perf_clear_resource_timings() -> f64 {
+    f64::from_bits(JSValue::undefined().bits())
+}
+
+#[no_mangle]
+pub extern "C" fn js_perf_set_resource_timing_buffer_size(_n: f64) -> f64 {
+    f64::from_bits(JSValue::undefined().bits())
+}
+
 // ── PerformanceObserver ──────────────────────────────────────────────────────
 // Observers are stored in a per-thread registry; the JS-visible observer
 // object is a `perf_observer`-tagged native-module namespace object whose

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1096 entries across 80 modules
+// Coverage: 1098 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -861,6 +861,8 @@ declare module "perf_hooks" {
   /** stdlib */
   export function clearMeasures(...args: any[]): any;
   /** stdlib */
+  export function clearResourceTimings(...args: any[]): any;
+  /** stdlib */
   export function eventLoopUtilization(...args: any[]): any;
   /** stdlib */
   export function getEntries(...args: any[]): any;
@@ -874,6 +876,8 @@ declare module "perf_hooks" {
   export function measure(...args: any[]): any;
   /** stdlib */
   export function now(...args: any[]): any;
+  /** stdlib */
+  export function setResourceTimingBufferSize(...args: any[]): any;
   /** stdlib */
   export function toJSON(...args: any[]): any;
 }

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1096 entries across 80 modules.
+Total: 1098 entries across 80 modules.
 
 ## Modules
 
@@ -1036,6 +1036,7 @@ Total: 1096 entries across 80 modules.
 
 - `clearMarks` — module
 - `clearMeasures` — module
+- `clearResourceTimings` — module
 - `disconnect` — instance *(class: `PerformanceObserver`)*
 - `eventLoopUtilization` — module
 - `getEntries` — module
@@ -1045,6 +1046,7 @@ Total: 1096 entries across 80 modules.
 - `measure` — module
 - `now` — module
 - `observe` — instance *(class: `PerformanceObserver`)*
+- `setResourceTimingBufferSize` — module
 - `takeRecords` — instance *(class: `PerformanceObserver`)*
 - `toJSON` — module
 

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -44,12 +44,6 @@
     "category": "bug-open",
     "reason": "node:perf_hooks: performance.nodeTiming (PerformanceNodeTiming) unimplemented (not an object). Flips to PASS when #1337 lands."
   },
-  "node-suite/perf_hooks/resource-timing/clear-and-buffer-size": {
-    "issue": "1339",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: clearResourceTimings() / setResourceTimingBufferSize() unimplemented. Flips to PASS when #1339 lands."
-  },
   "node-suite/perf_hooks/mark/detail-structured-clone": {
     "issue": "1340",
     "added": "2026-05-22",


### PR DESCRIPTION
## Summary

Implements `performance.clearResourceTimings()` and `performance.setResourceTimingBufferSize(n)` (node:perf_hooks gap #1339, umbrella #793).

Perry records no `PerformanceResourceTiming` entries (no network resource timeline), so both are no-ops that match Node's signatures and return `undefined`. They exist so user code that manages the resource-timing buffer runs unchanged, and `typeof performance.clearResourceTimings === 'function'` holds.

Wired end-to-end: runtime helpers (`perf_hooks.rs`), HIR static lowering (`module_static.rs`), codegen + extern decls (`native/perf_hooks.rs`, `runtime_decls/stdlib_ffi.rs`), runtime namespace dispatch (`native_module_dispatch.rs`), the typeof-read path (`native_module.rs`), and the API manifest (`entries.rs` + regenerated `docs/`).

## Test

Flips `test-parity/node-suite/perf_hooks/resource-timing/clear-and-buffer-size` to PASS (removed from `known_failures.json`):

```
clearResourceTimings: true
setResourceTimingBufferSize: true
```

Closes #1339.