### PR TITLE
fix(perf_hooks): new PerformanceObserver() without a callback throws TypeError (#1388)

### DIFF
--- a/crates/perry-codegen/src/expr/new_dynamic.rs
+++ b/crates/perry-codegen/src/expr/new_dynamic.rs
@@ -156,6 +156,35 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 }
             }
 
+            // `new (PerformanceObserver as any)(cb?)` — the `as any` cast
+            // (used because no-arg construction is a TS type error) strips the
+            // bare identifier, so the constructor arrives as
+            // `NewDynamic { callee: PropertyGet { NativeModuleRef("perf_hooks"),
+            // "PerformanceObserver" } }` instead of the special-cased `New`
+            // handled in lower_call/builtin.rs. Route to the same runtime
+            // registrar so the no-callback TypeError (and normal construction)
+            // fire. Refs #1388.
+            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+                if property == "PerformanceObserver" {
+                    if let Expr::NativeModuleRef(mod_name) = object.as_ref() {
+                        if mod_name == "perf_hooks" {
+                            let cb = if args.is_empty() {
+                                crate::nanbox::double_literal(f64::from_bits(
+                                    crate::nanbox::TAG_UNDEFINED,
+                                ))
+                            } else {
+                                lower_expr(ctx, &args[0])?
+                            };
+                            return Ok(ctx.block().call(
+                                DOUBLE,
+                                "js_perf_observer_new",
+                                &[(DOUBLE, &cb)],
+                            ));
+                        }
+                    }
+                }
+            }
+
             // Refs #740: `new O.Inner(args)` where `O` is an object
             // literal whose `Inner` field was initialized from a class
             // expression. The Stmt::Let lowering populates

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -554,11 +554,23 @@ unsafe fn make_observer_object(id: usize) -> f64 {
     crate::value::js_nanbox_pointer(obj as i64)
 }
 
+/// True if `v` is callable (matches `typeof v === "function"`) — covers
+/// closures, V8 handles, and class refs uniformly.
+unsafe fn is_function_value(v: f64) -> bool {
+    let p = crate::builtins::js_value_typeof(v) as *const StringHeader;
+    header_to_string(p) == "function"
+}
+
 /// `new PerformanceObserver(callback)` — register the observer and return its
-/// namespace object.
+/// namespace object. Throws a TypeError when `callback` is not a function
+/// (Node: ERR_INVALID_ARG_TYPE), including the no-argument
+/// `new PerformanceObserver()` form.
 #[no_mangle]
 pub extern "C" fn js_perf_observer_new(cb: f64) -> f64 {
     unsafe {
+        if !is_function_value(cb) {
+            throw_type_error("The \"callback\" argument must be of type function");
+        }
         let id = OBSERVERS.with(|o| {
             let mut o = o.borrow_mut();
             o.push(Observer {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -68,12 +68,6 @@
     "category": "bug-open",
     "reason": "node:perf_hooks: PerformanceEntry#toJSON() is not a function. Flips to PASS when #1387 lands."
   },
-  "node-suite/perf_hooks/observer/no-callback-throws": {
-    "issue": "1388",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: new PerformanceObserver() without a callback should throw TypeError; Perry does not throw. Flips to PASS when #1388 lands."
-  },
   "node-suite/perf_hooks/observer/callback-observer-arg": {
     "issue": "1389",
     "added": "2026-05-22",


### PR DESCRIPTION
## Summary

`new PerformanceObserver()` without a callback should throw a TypeError (node:perf_hooks gap #1388, umbrella #793). Perry didn't throw.

Two parts:
- **runtime** (`perf_hooks.rs`): `js_perf_observer_new` now throws a TypeError (Node `ERR_INVALID_ARG_TYPE`) when the callback isn't a function — using a `typeof === "function"` check so existing observers built with real closures are unaffected.
- **codegen** (`new_dynamic.rs`): the test constructs via `new (PerformanceObserver as any)()` because no-arg construction is otherwise a TS type error. The `as any` cast strips the bare identifier, so the constructor lowers to `NewDynamic { callee: PropertyGet { NativeModuleRef("perf_hooks"), "PerformanceObserver" } }` rather than the special-cased `New` in `lower_call/builtin.rs`, which returned a placeholder object and never called the registrar. Route that `NewDynamic` shape to `js_perf_observer_new` (mirroring the existing `assert.AssertionError` case) so both forms share one path.

## Test

Flips `test-parity/node-suite/perf_hooks/observer/no-callback-throws` to PASS; all other observer tests (built with real callbacks) still pass.

```
threw: true
```

Closes #1388.