### PR TITLE
fix(perf_hooks): measure() with a nonexistent start/end mark throws (#1403)

### DIFF
--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -170,6 +170,24 @@ unsafe fn resolve_endpoint_value(v: JSValue) -> f64 {
     }
 }
 
+/// Resolve a positional `measure(name, startMark, endMark?)` endpoint. A number
+/// passes through; a string must name an existing mark — Node throws when it
+/// doesn't (the silent-0 fallback used by the options form isn't valid for
+/// positional start/end marks).
+unsafe fn resolve_positional_endpoint(v: JSValue) -> f64 {
+    if let Some(n) = num_of(v) {
+        n
+    } else if v.is_string() {
+        let name = header_to_string(v.as_string_ptr());
+        match lookup_mark_start(&name) {
+            Some(t) => t,
+            None => throw_type_error(&format!("The \"{name}\" performance mark has not been set")),
+        }
+    } else {
+        0.0
+    }
+}
+
 /// Most-recent mark startTime for `name`, if any.
 fn lookup_mark_start(name: &str) -> Option<f64> {
     PERF_ENTRIES.with(|store| {
@@ -293,10 +311,10 @@ pub extern "C" fn js_perf_measure(name_val: f64, arg2: f64, arg3: f64) -> f64 {
             return finish_measure(name, start_time, duration, detail_bits);
         } else if arg2_jv.is_string() {
             // Positional form: measure(name, startMark, endMark?)
-            let start = resolve_endpoint_value(arg2_jv);
+            let start = resolve_positional_endpoint(arg2_jv);
             let arg3_jv = JSValue::from_bits(arg3.to_bits());
             let end = if arg3_jv.is_string() || arg3_jv.is_number() {
-                resolve_endpoint_value(arg3_jv)
+                resolve_positional_endpoint(arg3_jv)
             } else {
                 perf_now()
             };

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -80,12 +80,6 @@
     "category": "bug-open",
     "reason": "node:perf_hooks: observe({ buffered: true }) does not deliver pre-existing entries (callback never fires). Flips to PASS when #1390 lands."
   },
-  "node-suite/perf_hooks/errors/measure-nonexistent-mark": {
-    "issue": "1403",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: measure(name, startMark) with a nonexistent mark should throw; Perry does not throw. Flips to PASS when #1403 lands."
-  },
   "node-suite/console/dir/depth-options": {
     "issue": "1199",
     "added": "2026-05-20",


### PR DESCRIPTION
## Summary

`performance.measure(name, startMark)` referencing a mark that doesn't exist should throw (node:perf_hooks gap #1403, umbrella #793). Perry silently resolved the missing mark to startTime 0.

The positional form now uses `resolve_positional_endpoint`, which throws a TypeError (`instanceof Error`) when a string endpoint names a mark that hasn't been set. The options form (`{ start, end }`) keeps its existing lenient resolution, so no other measure case changes.

## Test

Flips `test-parity/node-suite/perf_hooks/errors/measure-nonexistent-mark` to PASS; the positional `from-marks` / `numeric-start-end` tests (which reference existing marks) still pass.

```
threw: true
```

Closes #1403.