### PR TITLE
fix(codegen): Any-typed .includes()/.indexOf() dispatch dynamically (#1341)

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -255,7 +255,14 @@ pub fn try_lower_property_get_method_call(
             // variant (e.g., slice(0) is ambiguous but slice() with 0
             // args is always array.slice to copy).
             "slice" if !args.is_empty() => true,
-            "indexOf" | "includes" if args.len() == 1 => true,
+            // `indexOf` / `includes` are NOT string-forced here: an
+            // Any-typed receiver may be a runtime array (e.g. a native
+            // module property like `PerformanceObserver.supportedEntryTypes`),
+            // and forcing the string path made `arr.includes(x)` always
+            // return false (string-includes on a non-string). Falling
+            // through routes both to `js_native_call_method`, which
+            // dispatches on the runtime type and handles string + array
+            // (with content-aware element comparison). Refs #1341.
             // startsWith / endsWith only exist on String — both 1-arg
             // and 2-arg (searchString, position) forms route here.
             "startsWith" | "endsWith" if args.len() == 1 || args.len() == 2 => true,

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -56,12 +56,6 @@
     "category": "bug-open",
     "reason": "node:perf_hooks: measure detail is not structured-cloned (same root as mark — #1340 covers both). Flips to PASS when #1340 lands."
   },
-  "node-suite/perf_hooks/observer/supported-entry-types": {
-    "issue": "1341",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: PerformanceObserver.supportedEntryTypes.includes('mark'/'measure') is not usable (static array membership). Flips to PASS when #1341 lands."
-  },
   "node-suite/perf_hooks/entry/to-json": {
     "issue": "1387",
     "added": "2026-05-22",


### PR DESCRIPTION
## Summary

`PerformanceObserver.supportedEntryTypes.includes('mark')` returned `false` even though the array contains `'mark'` (node:perf_hooks gap #1341, umbrella #793).

Root cause is general, not perf_hooks-specific. In `lower_call/property_get.rs`, the "string method fallback for Any-typed receivers" force-routed 1-arg `.includes()`/`.indexOf()` to the **string** method path — contradicting the comment 4 lines above that lists `includes`/`indexOf` as array-capable methods to *exclude*. `supportedEntryTypes` is a native-module property typed `Any`, so at runtime it's an array, but `is_array_expr` is statically false → it hit the string path and ran string-`includes` on a non-string (→ always false).

Fix: drop that arm so `includes`/`indexOf` on an `Any` receiver fall through to `js_native_call_method`, which dispatches on the **runtime** type and handles string, array (content-aware `js_array_includes_jsvalue`), and buffer correctly.

## Test

Flips `test-parity/node-suite/perf_hooks/observer/supported-entry-types` to PASS:
```
is array: true
includes mark: true
includes measure: true
```

Regression sweep (all pass): Any-typed **string** `includes`/`indexOf`, 21 `*array*` + 19 `*string*` parity tests, `issue_214` SSO string-array, and buffer `includes`/`indexOf`.

Closes #1341.