### PR TITLE
fix(perf_hooks): structured-clone mark/measure detail (#1340)

### DIFF
--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -217,7 +217,10 @@ unsafe fn option_detail_bits(options_obj: *const crate::object::ObjectHeader) ->
     if v.is_undefined() {
         JSValue::null().bits()
     } else {
-        v.bits()
+        // Node structured-clones `detail`, so the stored value deep-equals the
+        // input but is a distinct reference (mutating the original afterward
+        // doesn't affect the entry).
+        crate::builtins::js_structured_clone(f64::from_bits(v.bits())).to_bits()
     }
 }
 

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -44,18 +44,6 @@
     "category": "bug-open",
     "reason": "node:perf_hooks: performance.nodeTiming (PerformanceNodeTiming) unimplemented (not an object). Flips to PASS when #1337 lands."
   },
-  "node-suite/perf_hooks/mark/detail-structured-clone": {
-    "issue": "1340",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: mark detail is not structured-cloned (m.detail === input instead of a distinct deep-equal copy). Flips to PASS when #1340 lands."
-  },
-  "node-suite/perf_hooks/measure/detail-structured-clone": {
-    "issue": "1340",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: measure detail is not structured-cloned (same root as mark — #1340 covers both). Flips to PASS when #1340 lands."
-  },
   "node-suite/perf_hooks/entry/to-json": {
     "issue": "1387",
     "added": "2026-05-22",


### PR DESCRIPTION
## Summary

`performance.mark(name, { detail })` and `performance.measure(name, { detail })` should structured-clone `detail` (node:perf_hooks gap #1340, umbrella #793). Perry stored the same reference, so `m.detail === input` (and mutating the original mutated the stored entry).

`option_detail_bits` now routes the value through `js_structured_clone`, so the stored `detail` deep-equals the input but is a distinct reference — matching Node.

## Test

Flips both `test-parity/node-suite/perf_hooks/mark/detail-structured-clone` and `.../measure/detail-structured-clone` to PASS (one root, both removed from `known_failures.json`); the `detail-option` tests still pass.

```
deep equal: true
distinct ref: true
```

Closes #1340.