### PR TITLE
feat(perf_hooks): observe({ buffered: true }) delivers pre-existing entries (#1390)

### DIFF
--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -644,6 +644,7 @@ pub extern "C" fn js_perf_observer_observe(obs_val: f64, opts: f64) -> f64 {
     unsafe {
         let id = observer_id_from_value(obs_val);
         let mut types: Vec<u8> = Vec::new();
+        let mut buffered = false;
         if let Some(opts_obj) = as_object_ptr(opts) {
             // entryTypes: string[]
             let key = b"entryTypes";
@@ -670,13 +671,40 @@ pub extern "C" fn js_perf_observer_observe(obs_val: f64, opts: f64) -> f64 {
                     types.push(code);
                 }
             }
+            // buffered: boolean — also deliver entries already on the timeline.
+            let bkey = b"buffered";
+            let bkp = crate::string::js_string_from_bytes(bkey.as_ptr(), bkey.len() as u32);
+            let b_v = js_object_get_field_by_name(opts_obj, bkp);
+            buffered = crate::value::js_is_truthy(f64::from_bits(b_v.bits())) != 0;
         }
+        let observed = types.clone();
         OBSERVERS.with(|o| {
             if let Some(obs) = o.borrow_mut().get_mut(id) {
                 obs.entry_types = types;
                 obs.active = true;
             }
         });
+        // `buffered: true` delivers entries created before observe() was
+        // called. Queue the matching timeline entries and arm the async flush
+        // so the callback fires on a later turn (Node's buffered semantics).
+        if buffered {
+            let pre: Vec<PerfEntry> = PERF_ENTRIES.with(|store| {
+                store
+                    .borrow()
+                    .iter()
+                    .filter(|e| observed.contains(&e.entry_type))
+                    .cloned()
+                    .collect()
+            });
+            if !pre.is_empty() {
+                OBSERVERS.with(|o| {
+                    if let Some(obs) = o.borrow_mut().get_mut(id) {
+                        obs.pending.extend(pre);
+                    }
+                });
+                schedule_flush();
+            }
+        }
         f64::from_bits(JSValue::undefined().bits())
     }
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -50,12 +50,6 @@
     "category": "bug-open",
     "reason": "node:perf_hooks: PerformanceEntry#toJSON() is not a function. Flips to PASS when #1387 lands."
   },
-  "node-suite/perf_hooks/observer/buffered": {
-    "issue": "1390",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: observe({ buffered: true }) does not deliver pre-existing entries (callback never fires). Flips to PASS when #1390 lands."
-  },
   "node-suite/console/dir/depth-options": {
     "issue": "1199",
     "added": "2026-05-20",


### PR DESCRIPTION
## Summary

`PerformanceObserver.observe({ type, buffered: true })` should deliver entries created **before** `observe()` was called (node:perf_hooks gap #1390, umbrella #793). Perry never delivered them — the callback didn't fire.

`js_perf_observer_observe` now parses the `buffered` flag; when set, it copies the timeline entries matching the observed type(s) into the observer's pending buffer and arms the async flush, so the callback fires on a later turn with the pre-existing entries. Non-buffered `observe()` is unchanged.

## Test

Flips `test-parity/node-suite/perf_hooks/observer/buffered` to PASS (`buffered count: 2`); all other observer tests (observe-marks/measures, multiple-observers, take-records, …) still pass.

Closes #1390.