### PR TITLE
feat(perf_hooks): implement performance.nodeTiming (#1337)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2158,6 +2158,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("perf_hooks", "clearResourceTimings", false, None),
     method("perf_hooks", "setResourceTimingBufferSize", false, None),
     property("perf_hooks", "timeOrigin"),
+    property("perf_hooks", "nodeTiming"),
     property("perf_hooks", "performance"),
     property("perf_hooks", "constants"),
     class("perf_hooks", "PerformanceObserver"),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1098,6 +1098,7 @@ pub(crate) unsafe fn get_native_module_constant(
         // they share this arm (distinct property names, no collision).
         "perf_hooks" => match property {
             "timeOrigin" => Some(crate::perf_hooks::time_origin_ms()),
+            "nodeTiming" => Some(crate::perf_hooks::js_perf_node_timing()),
             "NODE_PERFORMANCE_GC_MAJOR" => Some(4.0),
             "NODE_PERFORMANCE_GC_MINOR" => Some(1.0),
             "NODE_PERFORMANCE_GC_INCREMENTAL" => Some(8.0),

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -40,6 +40,10 @@ const ELU_KEYS: &[u8] = b"idle\0active\0utilization\0";
 const TOJSON_SHAPE: u32 = 0x7FFF_FF42;
 const TOJSON_KEYS: &[u8] = b"timeOrigin\0";
 
+/// Shape id + keys for `performance.nodeTiming` (PerformanceNodeTiming entry).
+const NODE_TIMING_SHAPE: u32 = 0x7FFF_FF43;
+const NODE_TIMING_KEYS: &[u8] = b"name\0entryType\0startTime\0duration\0nodeStart\0v8Start\0bootstrapComplete\0environment\0loopStart\0loopExit\0idleTime\0";
+
 #[derive(Clone)]
 struct PerfEntry {
     name: String,
@@ -514,6 +518,40 @@ pub extern "C" fn js_perf_to_json() -> f64 {
             TOJSON_KEYS.len() as u32,
         );
         js_object_set_field(obj, 0, JSValue::number(time_origin_ms()));
+        crate::value::js_nanbox_pointer(obj as i64)
+    }
+}
+
+// ── performance.nodeTiming (PerformanceNodeTiming) ───────────────────────────
+/// A PerformanceNodeTiming entry (entryType "node") exposing the Node bootstrap
+/// milestones. Perry has no libuv bootstrap to instrument, so the milestones
+/// are 0 relative to timeOrigin (loopStart reflects time since origin, loopExit
+/// is -1 while the loop is running); every field is numeric, matching Node's
+/// shape.
+#[no_mangle]
+pub extern "C" fn js_perf_node_timing() -> f64 {
+    unsafe {
+        let obj = js_object_alloc_with_shape(
+            NODE_TIMING_SHAPE,
+            11,
+            NODE_TIMING_KEYS.as_ptr(),
+            NODE_TIMING_KEYS.len() as u32,
+        );
+        js_object_set_field(obj, 0, str_value("node")); // name
+        js_object_set_field(obj, 1, str_value("node")); // entryType
+        js_object_set_field(obj, 2, JSValue::number(0.0)); // startTime
+        js_object_set_field(obj, 3, JSValue::number(0.0)); // duration
+        js_object_set_field(obj, 4, JSValue::number(0.0)); // nodeStart
+        js_object_set_field(obj, 5, JSValue::number(0.0)); // v8Start
+        js_object_set_field(obj, 6, JSValue::number(0.0)); // bootstrapComplete
+        js_object_set_field(obj, 7, JSValue::number(0.0)); // environment
+        js_object_set_field(
+            obj,
+            8,
+            JSValue::number((perf_now() - time_origin_ms()).max(0.0)),
+        ); // loopStart
+        js_object_set_field(obj, 9, JSValue::number(-1.0)); // loopExit (loop running)
+        js_object_set_field(obj, 10, JSValue::number(0.0)); // idleTime
         crate::value::js_nanbox_pointer(obj as i64)
     }
 }

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1098 entries across 80 modules
+// Coverage: 1099 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -852,6 +852,8 @@ declare module "perf_hooks" {
   export class PerformanceObserver { [key: string]: any; }
   /** stdlib */
   export const constants: any;
+  /** stdlib */
+  export const nodeTiming: any;
   /** stdlib */
   export const performance: any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1098 entries across 80 modules.
+Total: 1099 entries across 80 modules.
 
 ## Modules
 
@@ -1053,6 +1053,7 @@ Total: 1098 entries across 80 modules.
 ### Properties
 
 - `constants`
+- `nodeTiming`
 - `performance`
 - `timeOrigin`
 

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -38,12 +38,6 @@
     "category": "bug-open",
     "reason": "node:perf_hooks: createHistogram() unimplemented (not a function). Flips to PASS when #1336 lands."
   },
-  "node-suite/perf_hooks/node-timing/node-timing": {
-    "issue": "1337",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: performance.nodeTiming (PerformanceNodeTiming) unimplemented (not an object). Flips to PASS when #1337 lands."
-  },
   "node-suite/perf_hooks/entry/to-json": {
     "issue": "1387",
     "added": "2026-05-22",


### PR DESCRIPTION
## Summary

`performance.nodeTiming` should be a `PerformanceNodeTiming` entry (entryType `'node'`) with numeric bootstrap milestones (node:perf_hooks gap #1337, umbrella #793). Perry returned a non-object.

Adds `js_perf_node_timing()` returning a shaped object with the Node fields (`name`, `entryType: 'node'`, `startTime`, `duration`, `nodeStart`, `v8Start`, `bootstrapComplete`, `environment`, `loopStart`, `loopExit`, `idleTime`). Perry has no libuv bootstrap to instrument, so the milestones are 0 relative to `timeOrigin` (`loopStart` = time since origin, `loopExit` = -1 while the loop runs) — every field is numeric, matching Node's shape. Wired as a `perf_hooks` namespace property via `get_native_module_constant`, plus the API manifest + regenerated docs.

## Test

Flips `test-parity/node-suite/perf_hooks/node-timing/node-timing` to PASS:
```
is object: true
nodeStart number: true
entryType: node
```

Closes #1337.