### PR TITLE
fix(perf_hooks): globalThis.performance === the named import (#1327)

### DIFF
--- a/crates/perry-codegen/src/expr/helpers.rs
+++ b/crates/perry-codegen/src/expr/helpers.rs
@@ -287,6 +287,7 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
             | "Math"
             | "JSON"
             | "Reflect"
+            | "performance"
     )
 }
 
@@ -296,7 +297,11 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
 /// namespaces — they keep `typeof === "object"` via the existing match
 /// arms.
 pub(crate) fn is_global_this_builtin_function_name(name: &str) -> bool {
-    is_global_this_builtin_name(name) && !matches!(name, "console" | "Math" | "JSON" | "Reflect")
+    is_global_this_builtin_name(name)
+        && !matches!(
+            name,
+            "console" | "Math" | "JSON" | "Reflect" | "performance"
+        )
 }
 
 /// SSO-safe variant of `unbox_to_i64` for NaN-boxed string operands.

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -359,6 +359,15 @@ fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         };
         js_object_set_field_by_name(singleton, name_key, ns_value);
     }
+    // node:perf_hooks `performance` global — bind it to the same singleton the
+    // named import resolves to, so `globalThis.performance ===
+    // require("perf_hooks").performance` (#1327). typeof stays "object".
+    {
+        let pname = b"performance";
+        let pkey = crate::string::js_string_from_bytes(pname.as_ptr(), pname.len() as u32);
+        let pval = crate::perf_hooks::performance_namespace();
+        js_object_set_field_by_name(singleton, pkey, pval);
+    }
 }
 
 /// Populate well-known method properties on a builtin constructor's

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -99,9 +99,12 @@ pub unsafe extern "C" fn js_native_module_property_by_name(
     // `typeof performance === "object"`, `performance.timeOrigin` (a
     // constant), `performance.now` (a callable export), and
     // `constants.NODE_PERFORMANCE_GC_*` (constants) all dispatch coherently.
-    if module_name == "perf_hooks"
-        && (property_name == "performance" || property_name == "constants")
-    {
+    if module_name == "perf_hooks" && property_name == "performance" {
+        // Singleton so `require("perf_hooks").performance` and the global
+        // `performance` are the same object (Node identity guarantee, #1327).
+        return crate::perf_hooks::performance_namespace();
+    }
+    if module_name == "perf_hooks" && property_name == "constants" {
         return js_create_native_module_namespace(module_name.as_ptr(), module_name.len());
     }
 

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -56,6 +56,26 @@ struct PerfEntry {
 
 thread_local! {
     static PERF_ENTRIES: RefCell<Vec<PerfEntry>> = const { RefCell::new(Vec::new()) };
+    /// Cached `performance` namespace object (NaN-boxed bits, 0 = uninit).
+    /// Singleton so the named import and `globalThis.performance` are the same
+    /// object (Node identity). GC-rooted in `scan_perf_entries_roots_mut`.
+    static PERFORMANCE_NS: Cell<u64> = const { Cell::new(0) };
+}
+
+/// The per-thread singleton `performance` namespace object (perf_hooks-tagged).
+/// Both the `node:perf_hooks` named import and `globalThis.performance` resolve
+/// through here so `globalThis.performance === require("perf_hooks").performance`
+/// holds, matching Node.
+pub fn performance_namespace() -> f64 {
+    let cached = PERFORMANCE_NS.with(|c| c.get());
+    if cached != 0 {
+        return f64::from_bits(cached);
+    }
+    let module = b"perf_hooks";
+    let ns =
+        unsafe { crate::object::js_create_native_module_namespace(module.as_ptr(), module.len()) };
+    PERFORMANCE_NS.with(|c| c.set(ns.to_bits()));
+    ns
 }
 
 /// `performance.timeOrigin` — ms since the Unix epoch captured at first read.
@@ -909,6 +929,15 @@ pub fn scan_perf_entries_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
     CURRENT_LIST.with(|c| {
         for e in c.borrow_mut().iter_mut() {
             visitor.visit_nanbox_u64_slot(&mut e.detail_bits);
+        }
+    });
+    // Keep the cached `performance` namespace alive + forwarded so the
+    // singleton identity (named import === globalThis.performance) survives GC.
+    PERFORMANCE_NS.with(|c| {
+        let mut bits = c.get();
+        if bits != 0 {
+            visitor.visit_nanbox_u64_slot(&mut bits);
+            c.set(bits);
         }
     });
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -14,12 +14,6 @@
     "category": "bug-open",
     "reason": "node:perf_hooks granular parity: typeof obs.observe/disconnect/takeRecords reports the wrong type because member reads on a native-class instance lower as a method call (not a PropertyGet). The call forms work (observe-marks PASSES). Flips to PASS when #1320 lands."
   },
-  "node-suite/perf_hooks/global/performance-identity": {
-    "issue": "1327",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks granular parity: globalThis.performance !== the node:perf_hooks named import. The import resolves to a fresh namespace object per read and the global is a separate path; neither is a cached singleton. Flips to PASS when #1327 lands."
-  },
   "node-suite/perf_hooks/timerify/timerify": {
     "issue": "1335",
     "added": "2026-05-22",


### PR DESCRIPTION
## Summary

Node guarantees `globalThis.performance === require('perf_hooks').performance` (node:perf_hooks gap #1327, umbrella #793). In Perry the named import resolved to a **fresh** perf_hooks namespace per read, and `globalThis.performance` was a separate (unpopulated) path — so identity never held and `globalThis.performance.now` was `undefined`.

Fix introduces a single source of truth:
- **runtime** (`perf_hooks.rs`): a per-thread cached `performance` namespace singleton (`performance_namespace()`), GC-rooted in `scan_perf_entries_roots_mut` so identity survives evacuation.
- **named import** (`native_module.rs`): `perf_hooks.performance` returns the singleton (`constants` stays a fresh namespace).
- **global** (`global_this.rs`): `populate_global_this_builtins` binds `globalThis.performance` to the same singleton.
- **codegen** (`helpers.rs`): `performance` joins `is_global_this_builtin_name` so `globalThis.performance` value-reads route to the global field, and the function-name exclusion keeps `typeof === "object"`.

## Test

Flips `test-parity/node-suite/perf_hooks/global/performance-identity` to PASS:
```
same object: true
global now is fn: function
```

Regression sweep (all clean / pre-existing-only): perf_hooks node-suite (56 pass), `global` filter (3 pass), `test_gap` cross-section (36 pass; the 1 fail is the pre-existing tracked `test_gap_class_advanced` static-block gap). Every parity test prints via the global `console`, exercising global init.

Closes #1327.