### PR TITLE
fix(perf_hooks): typeof PerformanceObserver instance methods + inline supportedEntryTypes (#1320)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2162,6 +2162,10 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("perf_hooks", "performance"),
     property("perf_hooks", "constants"),
     class("perf_hooks", "PerformanceObserver"),
+    // PerformanceObserver.supportedEntryTypes — static array of entry-type
+    // names. Read inline (`PerformanceObserver.supportedEntryTypes.includes(...)`)
+    // it resolves as a perf_hooks property; declare it so the read isn't gated.
+    property("perf_hooks", "supportedEntryTypes"),
     class("perf_hooks", "PerformanceEntry"),
     class("perf_hooks", "PerformanceMark"),
     class("perf_hooks", "PerformanceMeasure"),

--- a/crates/perry-hir/src/lower/expr_call/module_class_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_class_static.rs
@@ -49,6 +49,13 @@ pub(super) fn try_module_class_static(
                                 | ("fs", "constants")
                                 | ("path", "posix")
                                 | ("path", "win32")
+                                // #1320: `PerformanceObserver.supportedEntryTypes`
+                                // is a static *array value*, not a class — so
+                                // `…supportedEntryTypes.includes(x)` is a value
+                                // method, not a class static. Fall through to
+                                // value-method dispatch instead of building a
+                                // bogus NativeMethodCall(class="supportedEntryTypes").
+                                | ("perf_hooks", "supportedEntryTypes")
                         );
                         // Unimplemented-API gate (#463) for the chained
                         // `mod.X.Y()` case. The lower_member gate fires

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -603,6 +603,20 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                             ) {
                                 return Ok(Expr::String("function".to_string()));
                             }
+                            // #1320: `typeof obs.observe` on a PerformanceObserver
+                            // instance. A bare member read on a native-class
+                            // instance lowers to a 0-arg NativeMethodCall (getter
+                            // semantics), so `typeof` evaluated `observe()` and
+                            // reported "undefined". These are methods, not
+                            // getters — fold to "function" (the call form
+                            // `obs.observe(...)` is unaffected).
+                            if matches!(
+                                ctx.lookup_native_instance(obj_name),
+                                Some(("perf_hooks", _))
+                            ) && matches!(prop_name, "observe" | "disconnect" | "takeRecords")
+                            {
+                                return Ok(Expr::String("function".to_string()));
+                            }
                             // #677: `typeof Function.prototype` → "object".
                             // `Function.prototype` is the (immutable) prototype
                             // chain root for all functions; in Node typeof is

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1099 entries across 80 modules
+// Coverage: 1100 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -856,6 +856,8 @@ declare module "perf_hooks" {
   export const nodeTiming: any;
   /** stdlib */
   export const performance: any;
+  /** stdlib */
+  export const supportedEntryTypes: any;
   /** stdlib */
   export const timeOrigin: any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1099 entries across 80 modules.
+Total: 1100 entries across 80 modules.
 
 ## Modules
 
@@ -1055,6 +1055,7 @@ Total: 1099 entries across 80 modules.
 - `constants`
 - `nodeTiming`
 - `performance`
+- `supportedEntryTypes`
 - `timeOrigin`
 
 ## `perry/ads`

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -8,12 +8,6 @@
       "reason": "Free-text explanation. Keep the most-actionable signal first \u2014 what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
-  "node-suite/perf_hooks/observer/entry-types": {
-    "issue": "1320",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks granular parity: typeof obs.observe/disconnect/takeRecords reports the wrong type because member reads on a native-class instance lower as a method call (not a PropertyGet). The call forms work (observe-marks PASSES). Flips to PASS when #1320 lands."
-  },
   "node-suite/perf_hooks/timerify/timerify": {
     "issue": "1335",
     "added": "2026-05-22",


### PR DESCRIPTION
## Summary

`typeof obs.observe` (etc.) on a `PerformanceObserver` instance reported `"undefined"` instead of `"function"` (node:perf_hooks gap #1320, umbrella #793). Fixing the repro test (`observer/entry-types`) surfaced a second, related HIR-lowering bug, so this PR has two parts:

1. **typeof of native-class instance methods** (`lower_expr.rs`): a bare member read on a native-class instance lowers to a 0-arg `NativeMethodCall` (getter semantics), so `typeof` evaluated `observe()` and reported the result's type. `observe`/`disconnect`/`takeRecords` are *methods* — fold `typeof` to `"function"`, mirroring the existing `async_hooks` `AsyncHook`/`AsyncResource` arms. The call form `obs.observe(...)` is unaffected.

2. **inline `PerformanceObserver.supportedEntryTypes.includes(x)`** (`module_class_static.rs`): the `module.Class.staticMethod()` handler treated the static array property `supportedEntryTypes` as a *class* and `includes` as a static method, building a bogus `NativeMethodCall(class="supportedEntryTypes")` that returned `undefined`. Added `(perf_hooks, supportedEntryTypes)` to the `is_sub_namespace` fall-through list so `.includes()` dispatches on the array value (via the #1341 dynamic path), and declared `supportedEntryTypes` in the API manifest.

## Test

Flips `test-parity/node-suite/perf_hooks/observer/entry-types` to PASS (all 6 lines match Node). Regression-swept: perf_hooks node-suite (57 pass), `async_hooks` (same lowering patterns, pass), `test_gap`/`test_compat` (only the pre-existing tracked `test_gap_class_advanced` + `test_compat_buffers_typed` fail, both unrelated).

Closes #1320.