### PR TITLE
fix(web): drop perry/ui debug console.log noise (#1370)

### DIFF
--- a/crates/perry-codegen-wasm/src/wasm_runtime.js
+++ b/crates/perry-codegen-wasm/src/wasm_runtime.js
@@ -2637,12 +2637,10 @@ function uiStateSet(h, value) {
 // ---------- Widget creation functions (take JS values, return handle_id) ----------
 
 function perry_ui_app_create(titleOrOpts, width, height) {
-  console.log("app_create:", typeof titleOrOpts, JSON.stringify(titleOrOpts)?.substring(0,100));
   let title = "Perry App", bodyH, w = 800, ht = 600;
   if (typeof titleOrOpts === "object" && titleOrOpts !== null) {
     title = titleOrOpts.title || title; w = titleOrOpts.width || w; ht = titleOrOpts.height || ht;
     bodyH = titleOrOpts.body;
-    console.log("  body handle:", bodyH, "uiGet:", uiGet(bodyH));
   } else { title = titleOrOpts || title; w = width || w; ht = height || ht; }
   document.title = title;
   const root = uiGetRoot();
@@ -2685,7 +2683,6 @@ function perry_ui_text_create(text, id) {
   return h;
 }
 function perry_ui_button_create(label, callback) {
-  console.log("button_create label:", typeof label, label, "callback:", typeof callback, callback);
   const el = document.createElement("button");
   el.textContent = (typeof label === 'string') ? label : String(label ?? "");
   el._perryCallback = callback;


### PR DESCRIPTION
## Summary

The web/wasm `perry/ui` glue (`crates/perry-codegen-wasm/src/wasm_runtime.js`) logged debug traces on every UI call — `app_create:`, `  body handle:`/`uiGet:`, and `button_create label:` — which leaked into the host console and buried program output in playgrounds that relay `console.*` to an output panel (#1370).

Removed the three `console.log` debug lines from `perry_ui_app_create` and `perry_ui_button_create` (same family as the already-dropped `mem_call:`/`result:` traces). The real `console_log` / `console_log_multi` bindings that relay the program's own `console.*` are untouched.

## Test

`node --check wasm_runtime.js` passes; the file is embedded via `include_str!`. Verified the 3 debug-trace prefixes are gone and the console-relay machinery remains.

Closes #1370.