### PR TITLE
fix(json): JSON.parse reviver on a lazy-tape array no longer SIGSEGVs (#1424)

### DIFF
--- a/crates/perry-runtime/src/json/reviver.rs
+++ b/crates/perry-runtime/src/json/reviver.rs
@@ -6,6 +6,37 @@ use crate::{js_string_from_bytes, JSValue, StringHeader};
 
 // ─── JSON.parse with reviver ────────────────────────────────────────────────
 
+/// Force-materialize a lazy-tape array (`PERRY_JSON_TAPE`) into a real
+/// `ArrayHeader` tree and return a JSValue pointing at it. The reviver walk
+/// below reads `length`/`capacity`/element f64s directly off the pointer — a
+/// `LazyArrayHeader` has a different layout, so without this the walk reads
+/// garbage and SIGSEGVs. Unlike `redirect_lazy_to_materialized` (stringify),
+/// this forces materialization even when nothing has indexed the array yet.
+/// No-op for non-lazy values. Refs #1424.
+unsafe fn force_materialize_if_lazy(value: JSValue) -> JSValue {
+    let bits = value.bits();
+    if (bits >> 48) != 0x7FFD {
+        return value;
+    }
+    let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const u8;
+    if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return value;
+    }
+    let gc_header = ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    if (*gc_header).obj_type != crate::gc::GC_TYPE_LAZY_ARRAY {
+        return value;
+    }
+    let lazy = ptr as *mut crate::json_tape::LazyArrayHeader;
+    if (*lazy).magic != crate::json_tape::LAZY_ARRAY_MAGIC {
+        return value;
+    }
+    let materialized = crate::json_tape::force_materialize_lazy(lazy);
+    if materialized.is_null() {
+        return value;
+    }
+    JSValue::object_ptr(materialized as *mut u8)
+}
+
 /// Apply reviver to a parsed JSON value. The reviver is called as reviver(key, value).
 /// For objects, it's called for each property; for the root, key is "".
 pub(crate) unsafe fn apply_reviver(
@@ -13,6 +44,9 @@ pub(crate) unsafe fn apply_reviver(
     key_f64: f64,
     reviver: *const crate::closure::ClosureHeader,
 ) -> JSValue {
+    // A lazy-tape array must be materialized before the in-place element walk
+    // (its header layout differs from ArrayHeader). #1424.
+    let value = force_materialize_if_lazy(value);
     let bits = value.bits();
 
     // If value is an object, recurse into its properties first

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -176,12 +176,6 @@
     "category": "bug-open",
     "reason": "AsyncLocalStorage `.enterWith()` / `.exit()` aren't implemented end-to-end — the test prints the first 10 lines (await/then/catch/nextTick/timer/immediate/interval contexts + nested outer) and then exits silently when `enterWith()` is invoked, missing the last 7 lines covering enterWith semantics + exit/restore mechanics. Sibling slice of #788 #789 (real AsyncLocalStorage tracking across await/microtasks/timers + real `async_hooks.createHook` lifecycle). Surfaced as a NEW failure on v0.5.1024 release-packages parity. Flips to PASS when `.enterWith` / `.exit` land."
   },
-  "test_json_lazy_reviver": {
-    "issue": "1424",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "`JSON.parse(blob, reviver)` with a lazy-tape top-level array (PERRY_JSON_TAPE=1 path) produces zero output — the reviver dispatch on the materialised lazy array crashes / exits before any of the 4 `console.log` lines fire. Likely fallout from the GC checkpoint + copied-minor work under #1090 / #1146 / #1235 / #1324. Surfaced as a NEW failure on v0.5.1024 release-packages parity. Flips to PASS when the lazy-tape reviver dispatch is fixed."
-  },
   "test_jsruntime_mixed_async_ordering_matrix": {
     "issue": null,
     "added": "2026-05-17",


### PR DESCRIPTION
## Summary

`JSON.parse(blob, reviver)` on a large top-level array crashed with SIGSEGV (exit 139, zero output) under the lazy-tape path (`PERRY_JSON_TAPE=1`, and the default for this shape), and the reviver was never invoked on the elements (#1424).

`apply_reviver` walks the parsed value as an `ArrayHeader`, reading `length`/`capacity`/element f64s directly off the pointer. A `LazyArrayHeader` has a different layout, so those reads returned garbage → out-of-bounds element access → crash. Fix: materialize a lazy array via `force_materialize_lazy` at the top of `apply_reviver` (mirroring the stringify path's `redirect_lazy_to_materialized`, but forcing materialization since nothing has indexed the array yet), so the in-place element walk + write-backs operate on a real `ArrayHeader` and the caller receives the materialized array.

## Test

Flips `test_json_lazy_reviver` to PASS in **both** default and `PERRY_JSON_TAPE=1` modes:
```
len 300
first 1
last 300
calls 301
```
JSON parity sweep clean in the default (CI) config: 18 pass, 0 fail.

> Note: a *separate*, pre-existing tape-only bug remains — `console.log()` of a non-revived lazy string array prints `[object Object]` (`test_json_sso_strings` under `PERRY_JSON_TAPE=1`); unrelated to the reviver path. Filing separately.

Closes #1424.