### PR TITLE
feat(timers): implement node:timers/promises setTimeout/setImmediate (#1213)

### DIFF
--- a/crates/perry-runtime/src/node_submodules.rs
+++ b/crates/perry-runtime/src/node_submodules.rs
@@ -93,14 +93,27 @@ macro_rules! thunk {
     };
 }
 
-thunk!(
-    thunk_timers_setTimeout,
-    "node:timers/promises.setTimeout is not yet implemented in Perry (tracked by issue #793)."
-);
-thunk!(
-    thunk_timers_setImmediate,
-    "node:timers/promises.setImmediate is not yet implemented in Perry (tracked by issue #793)."
-);
+/// node:timers/promises.setTimeout(delay, value?) — a Promise that resolves
+/// with `value` (or undefined) after `delay` ms. Composes the existing
+/// promise-returning timer primitive; the closure dispatch pads a missing
+/// `value` arg with undefined (arity registered in `ensure_export_singleton`).
+/// Refs #1213.
+extern "C" fn timers_promises_set_timeout(
+    _closure: *const ClosureHeader,
+    delay_ms: f64,
+    value: f64,
+) -> f64 {
+    let promise = crate::timer::js_set_timeout_value(delay_ms, value);
+    crate::value::js_nanbox_pointer(promise as i64)
+}
+
+/// node:timers/promises.setImmediate(value?) — a Promise that resolves with
+/// `value` (or undefined) on a later turn. Refs #1213.
+extern "C" fn timers_promises_set_immediate(_closure: *const ClosureHeader, value: f64) -> f64 {
+    let promise = crate::timer::js_set_timeout_value(0.0, value);
+    crate::value::js_nanbox_pointer(promise as i64)
+}
+
 thunk!(
     thunk_timers_setInterval,
     "node:timers/promises.setInterval is not yet implemented in Perry (tracked by issue #793)."
@@ -1238,11 +1251,11 @@ const SUBMODULES: &[SubmoduleSpec] = &[
         exports: &[
             ExportSpec {
                 name: "setTimeout",
-                thunk: ExportThunk::Fn1(thunk_timers_setTimeout),
+                thunk: ExportThunk::Fn2(timers_promises_set_timeout),
             },
             ExportSpec {
                 name: "setImmediate",
-                thunk: ExportThunk::Fn1(thunk_timers_setImmediate),
+                thunk: ExportThunk::Fn1(timers_promises_set_immediate),
             },
             ExportSpec {
                 name: "setInterval",
@@ -1435,6 +1448,16 @@ fn ensure_export_singleton(
             "subscribe" | "unsubscribe" => 2,
             "channel" | "hasSubscribers" | "tracingChannel" => 1,
             "publish" => 2,
+            _ => 1,
+        };
+        js_register_closure_arity(thunk_ptr, arity);
+    }
+    // #1213: timers/promises.setTimeout takes (delay, value); registering the
+    // arity makes the closure dispatch pad a missing `value` with undefined.
+    if submod.key == "timers_promises" {
+        let arity = match export.name {
+            "setTimeout" => 2,
+            "setImmediate" => 1,
             _ => 1,
         };
         js_register_closure_arity(thunk_ptr, arity);

--- a/test-parity/expected/shadowed-global-fast-paths.txt
+++ b/test-parity/expected/shadowed-global-fast-paths.txt
@@ -1,2 +1,0 @@
-setTimeout error node:timers/promises.setTimeout is not yet implemented in Perry (tracked by issue #793).
-setImmediate error node:timers/promises.setImmediate is not yet implemented in Perry (tracked by issue #793).

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -380,12 +380,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory \u2014 `node:timers` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
-  "test_parity_timers_promises": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:timers/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_parity_tls": {
     "issue": "793",
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary

`node:timers/promises` `setTimeout(delay, value?)` and `setImmediate(value?)` were unimplemented stubs that threw `'… is not yet implemented'`, so `await setTimeout(ms)` / `await setTimeout(ms, value)` never resolved (part of the #1213 node:timers parity tracker / #793).

Both are now wired to the existing promise-returning timer primitive `js_set_timeout_value`, returning a Promise that resolves with `value` (or `undefined`). `setTimeout` is registered with arity 2 so the closure dispatch pads a missing `value` arg with `undefined`; `setImmediate` resolves on a later turn (0-delay). No closure synthesis needed — composes the existing tested timer→promise plumbing.

## Test

- Flips `test_parity_timers_promises` to **PASS** (removed from `known_failures.json`).
- Flips `node-suite/timers/promises/shadowed-global-fast-paths` to PASS — removed the stale `test-parity/expected/` snapshot that recorded the old stub error, so it now compares against live Node (both produce `setTimeout resolved object {"a":1}` / `setImmediate resolved object {"b":2}`).
- Verified value + no-value forms match Node:
```
await setTimeout(10)        // resolves undefined
await setTimeout(10, 'VAL') // resolves 'VAL'
await setImmediate('iv')    // resolves 'iv'
```

Remaining #1213 sub-gaps (separate follow-ups): `setInterval` async-iterator, `scheduler`/`AbortSignal` paths, numeric timer clears, and timer-callback `this` binding.

Refs #1213.