### PR TITLE
feat(timers): clearTimeout/clearInterval accept a numeric id (#1213)

### DIFF
--- a/crates/perry-codegen/src/lower_call/extern_func.rs
+++ b/crates/perry-codegen/src/lower_call/extern_func.rs
@@ -148,19 +148,19 @@ pub fn try_lower_extern_func_call(
             return Ok(Some(nanbox_pointer_inline(blk, &id)));
         }
         "clearTimeout" if args.len() == 1 => {
+            // Pass the raw NaN-boxed arg so the runtime accepts both the
+            // handle and its primitive numeric id (`clearTimeout(+t)`, #1213).
             let id_box = lower_expr(ctx, &args[0])?;
-            let blk = ctx.block();
-            let id_handle = unbox_to_i64(blk, &id_box);
-            blk.call_void("clearTimeout", &[(I64, &id_handle)]);
+            ctx.block()
+                .call_void("js_clear_timeout_value", &[(DOUBLE, &id_box)]);
             return Ok(Some(double_literal(f64::from_bits(
                 crate::nanbox::TAG_UNDEFINED,
             ))));
         }
         "clearInterval" if args.len() == 1 => {
             let id_box = lower_expr(ctx, &args[0])?;
-            let blk = ctx.block();
-            let id_handle = unbox_to_i64(blk, &id_box);
-            blk.call_void("clearInterval", &[(I64, &id_handle)]);
+            ctx.block()
+                .call_void("js_clear_interval_value", &[(DOUBLE, &id_box)]);
             return Ok(Some(double_literal(f64::from_bits(
                 crate::nanbox::TAG_UNDEFINED,
             ))));

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1281,6 +1281,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("setInterval", I64, &[I64, DOUBLE]);
     module.declare_function("clearTimeout", VOID, &[I64]);
     module.declare_function("clearInterval", VOID, &[I64]);
+    module.declare_function("js_clear_timeout_value", VOID, &[DOUBLE]);
+    module.declare_function("js_clear_interval_value", VOID, &[DOUBLE]);
     module.declare_function("js_buffer_from_array", I64, &[I64]);
     module.declare_function("js_buffer_from_arraybuffer_slice", I64, &[I64, I32, I32]);
     module.declare_function("js_buffer_length", I32, &[I64]);

--- a/crates/perry-runtime/src/timer.rs
+++ b/crates/perry-runtime/src/timer.rs
@@ -526,6 +526,40 @@ pub extern "C" fn clearTimeout(timer_id: i64) {
     intervals.retain(|t| !t.cleared);
 }
 
+/// Resolve a `clearTimeout`/`clearInterval` argument to a timer id. Accepts
+/// both the Timeout/Immediate handle (POINTER_TAG, lower 48 bits = id) and the
+/// primitive numeric id (`+timeout`), so `clearTimeout(+t)` works (#1213).
+/// Returns `None` for nullish/other values (a no-op clear, matching Node).
+fn arg_to_timer_id(arg: f64) -> Option<i64> {
+    let v = crate::value::JSValue::from_bits(arg.to_bits());
+    if v.is_int32() {
+        Some(v.as_int32() as i64)
+    } else if v.is_number() {
+        let n = v.as_number();
+        n.is_finite().then_some(n as i64)
+    } else if v.is_pointer() {
+        Some((arg.to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64)
+    } else {
+        None
+    }
+}
+
+/// `clearTimeout(handleOrId)` — accepts the handle or its numeric id (#1213).
+#[no_mangle]
+pub extern "C" fn js_clear_timeout_value(arg: f64) {
+    if let Some(id) = arg_to_timer_id(arg) {
+        clearTimeout(id);
+    }
+}
+
+/// `clearInterval(handleOrId)` — accepts the handle or its numeric id (#1213).
+#[no_mangle]
+pub extern "C" fn js_clear_interval_value(arg: f64) {
+    if let Some(id) = arg_to_timer_id(arg) {
+        clearInterval(id);
+    }
+}
+
 // ============================================================================
 // setInterval / clearInterval support
 // ============================================================================

--- a/test-parity/node-suite/timers/clear/numeric-id.ts
+++ b/test-parity/node-suite/timers/clear/numeric-id.ts
@@ -1,0 +1,10 @@
+import { setTimeout, clearTimeout, setInterval, clearInterval } from "node:timers";
+// clearTimeout / clearInterval accept the primitive numeric id (`+handle`),
+// not only the Timeout handle object.
+let fired = 0;
+const t = setTimeout(() => { fired++; }, 20);
+clearTimeout(+t);
+const iv = setInterval(() => { fired++; }, 5);
+clearInterval(+iv);
+await new Promise<void>((r) => setTimeout(() => r(), 50));
+console.log("cleared by numeric id:", fired === 0);


### PR DESCRIPTION
## Summary

Node lets you clear a timer by its primitive numeric id (`clearTimeout(+t)` / `clearInterval(+iv)`), not only the `Timeout` handle (part of the #1213 node:timers parity tracker). Perry's codegen `unbox_to_i64`'d the argument as a handle pointer, so a numeric argument mangled to garbage and the timer never cleared.

`clearTimeout`/`clearInterval` now pass the raw NaN-boxed argument to new runtime helpers (`js_clear_timeout_value` / `js_clear_interval_value`) that resolve it to the timer id whether it's a **number** (the primitive id, e.g. `+t === 1`) or a **handle** (POINTER_TAG, lower 48 bits = id). Nullish/other values are a no-op clear, matching Node.

## Test

New fixture `node-suite/timers/clear/numeric-id` (`clearTimeout(+t)` + `clearInterval(+iv)` → timers don't fire), matching Node. Existing `clear/` tests (handle form, cross-clear, multiple, null-and-undefined, object) still pass.

Remaining #1213 sub-gaps (separate follow-ups): timer-callback `this` binding, `node:timers` namespace/default import surface, `setInterval`/scheduler promises.

Refs #1213.