### PR TITLE
feat(timers): resolve 'import * as timers from node:timers' namespace (#1213)

### DIFF
--- a/crates/perry-runtime/src/node_submodules.rs
+++ b/crates/perry-runtime/src/node_submodules.rs
@@ -114,6 +114,44 @@ extern "C" fn timers_promises_set_immediate(_closure: *const ClosureHeader, valu
     crate::value::js_nanbox_pointer(promise as i64)
 }
 
+// ── node:timers namespace (`import * as timers from "node:timers"`) ──────────
+// Route to the SAME global timer runtime fns the bare globals use, so
+// `timers.setTimeout(...)` matches `setTimeout(...)`. NOTE: named imports
+// (`import { setTimeout } from "node:timers"`) deliberately bypass this and
+// keep the codegen global fast-path (which handles `setTimeout(fn, delay,
+// ...args)` varargs) — compile.rs skips registering node:timers named imports
+// as submodule exports. Refs #1213.
+fn callback_arg_to_i64(v: f64) -> i64 {
+    (v.to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64
+}
+extern "C" fn timers_ns_set_timeout(_c: *const ClosureHeader, cb: f64, ms: f64) -> f64 {
+    crate::value::js_nanbox_pointer(crate::timer::js_set_timeout_callback(
+        callback_arg_to_i64(cb),
+        ms,
+    ))
+}
+extern "C" fn timers_ns_set_interval(_c: *const ClosureHeader, cb: f64, ms: f64) -> f64 {
+    crate::value::js_nanbox_pointer(crate::timer::setInterval(callback_arg_to_i64(cb), ms))
+}
+extern "C" fn timers_ns_set_immediate(_c: *const ClosureHeader, cb: f64) -> f64 {
+    crate::value::js_nanbox_pointer(crate::timer::js_set_immediate_callback(
+        callback_arg_to_i64(cb),
+    ))
+}
+extern "C" fn timers_ns_clear_timeout(_c: *const ClosureHeader, arg: f64) -> f64 {
+    crate::timer::js_clear_timeout_value(arg);
+    f64::from_bits(TAG_UNDEFINED)
+}
+extern "C" fn timers_ns_clear_interval(_c: *const ClosureHeader, arg: f64) -> f64 {
+    crate::timer::js_clear_interval_value(arg);
+    f64::from_bits(TAG_UNDEFINED)
+}
+// Immediates live in the shared timer pool; clearTimeout retains-out both pools.
+extern "C" fn timers_ns_clear_immediate(_c: *const ClosureHeader, arg: f64) -> f64 {
+    crate::timer::js_clear_timeout_value(arg);
+    f64::from_bits(TAG_UNDEFINED)
+}
+
 thunk!(
     thunk_timers_setInterval,
     "node:timers/promises.setInterval is not yet implemented in Perry (tracked by issue #793)."
@@ -1247,6 +1285,37 @@ fn ensure_diag_noop_closure() -> *mut ClosureHeader {
 
 const SUBMODULES: &[SubmoduleSpec] = &[
     SubmoduleSpec {
+        // node:timers namespace object (`import * as timers`). Named imports
+        // bypass this (compile.rs) to keep the global fast-path. (#1213)
+        key: "timers",
+        exports: &[
+            ExportSpec {
+                name: "setTimeout",
+                thunk: ExportThunk::Fn2(timers_ns_set_timeout),
+            },
+            ExportSpec {
+                name: "setInterval",
+                thunk: ExportThunk::Fn2(timers_ns_set_interval),
+            },
+            ExportSpec {
+                name: "setImmediate",
+                thunk: ExportThunk::Fn1(timers_ns_set_immediate),
+            },
+            ExportSpec {
+                name: "clearTimeout",
+                thunk: ExportThunk::Fn1(timers_ns_clear_timeout),
+            },
+            ExportSpec {
+                name: "clearInterval",
+                thunk: ExportThunk::Fn1(timers_ns_clear_interval),
+            },
+            ExportSpec {
+                name: "clearImmediate",
+                thunk: ExportThunk::Fn1(timers_ns_clear_immediate),
+            },
+        ],
+    },
+    SubmoduleSpec {
         key: "timers_promises",
         exports: &[
             ExportSpec {
@@ -1458,6 +1527,14 @@ fn ensure_export_singleton(
         let arity = match export.name {
             "setTimeout" => 2,
             "setImmediate" => 1,
+            _ => 1,
+        };
+        js_register_closure_arity(thunk_ptr, arity);
+    }
+    // #1213: node:timers namespace — setTimeout/setInterval take (cb, delay).
+    if submod.key == "timers" {
+        let arity = match export.name {
+            "setTimeout" | "setInterval" => 2,
             _ => 1,
         };
         js_register_closure_arity(thunk_ptr, arity);

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -2771,15 +2771,24 @@ pub fn run_with_parse_cache(
                 for spec in &import.specifiers {
                     match spec {
                         perry_hir::ImportSpecifier::Named { imported, local } => {
-                            import_function_node_submodule.insert(
-                                local.clone(),
-                                (submod_key.clone(), imported.clone()),
-                            );
-                            if local != imported {
+                            // #1213: node:timers named imports (`import {
+                            // setTimeout } from "node:timers"`) keep the global
+                            // timer codegen fast-path (which handles the
+                            // `setTimeout(fn, delay, ...args)` varargs form).
+                            // Routing them through the submodule thunk here
+                            // would drop varargs — only the `import * as`
+                            // namespace shape uses the submodule.
+                            if submod_key != "timers" {
                                 import_function_node_submodule.insert(
-                                    imported.clone(),
+                                    local.clone(),
                                     (submod_key.clone(), imported.clone()),
                                 );
+                                if local != imported {
+                                    import_function_node_submodule.insert(
+                                        imported.clone(),
+                                        (submod_key.clone(), imported.clone()),
+                                    );
+                                }
                             }
                         }
                         perry_hir::ImportSpecifier::Default { local } => {
@@ -2797,7 +2806,11 @@ pub fn run_with_parse_cache(
                             // submodules (`timers/promises` etc.) keep the
                             // function-singleton routing because no real
                             // code reads them as namespace objects.
-                            if submod_key == "diagnostics_channel" {
+                            if submod_key == "diagnostics_channel" || submod_key == "timers" {
+                                // Default import of node:timers is the module
+                                // object — route to the namespace so
+                                // `import timers from "node:timers"` works
+                                // like `import * as timers` (#1213).
                                 namespace_node_submodules
                                     .insert(local.clone(), submod_key.clone());
                                 if !namespace_imports.contains(local) {

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -131,6 +131,10 @@ pub(super) fn collect_js_module_imports(file_path: &std::path::Path, source: &st
 pub(super) fn known_node_submodule_key(source: &str) -> Option<&'static str> {
     let normalized = source.strip_prefix("node:").unwrap_or(source);
     match normalized {
+        // node:timers — only the `import * as timers` namespace shape routes
+        // through the submodule namespace; named imports keep the global
+        // fast-path (gated in compile.rs). (#1213)
+        "timers" => Some("timers"),
         "timers/promises" => Some("timers_promises"),
         "readline/promises" => Some("readline_promises"),
         "stream/promises" => Some("stream_promises"),

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -378,7 +378,7 @@
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:timers` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "node:timers \u2014 `import * as timers` namespace now resolves (#1213, the namespace + setTimeout/setInterval/setImmediate/clear* surface passes). Remaining gap: the Timeout/Immediate handle's instance methods (ref/unref/hasRef/refresh/close) are not implemented (typeof reports undefined vs Node's function), so this full-surface test still fails. Flips to PASS when those land. Not a regression."
   },
   "test_parity_tls": {
     "issue": "793",

--- a/test-parity/node-suite/timers/namespace/import-surface.ts
+++ b/test-parity/node-suite/timers/namespace/import-surface.ts
@@ -1,0 +1,16 @@
+import * as timers from "node:timers";
+// `import * as timers from "node:timers"` resolves to a namespace whose timer
+// functions route to the same global implementations.
+console.log("setTimeout:", typeof timers.setTimeout);
+console.log("setInterval:", typeof timers.setInterval);
+console.log("setImmediate:", typeof timers.setImmediate);
+console.log("clearTimeout:", typeof timers.clearTimeout);
+console.log("clearInterval:", typeof timers.clearInterval);
+console.log("clearImmediate:", typeof timers.clearImmediate);
+let fired = 0;
+const t = timers.setTimeout(() => { fired++; }, 0);
+timers.clearTimeout(t);
+const i = timers.setInterval(() => { fired++; }, 0);
+timers.clearInterval(i);
+await new Promise<void>((r) => timers.setTimeout(() => r(), 20));
+console.log("cleared via namespace:", fired === 0);


### PR DESCRIPTION
## Summary

`import * as timers from "node:timers"` hard-errored at module collection (`Could not resolve namespace import`) — node:timers had no namespace object (its named functions are globals). Part of the #1213 node:timers parity tracker.

Adds a `node:timers` submodule namespace whose `setTimeout`/`setInterval`/`setImmediate`/`clearTimeout`/`clearInterval`/`clearImmediate` exports route to the **same** global timer runtime fns the bare globals use, so `timers.setTimeout(...)` matches `setTimeout(...)`.

### Avoiding the named-import regression
node:timers **named** imports (`import { setTimeout } from "node:timers"`) are deliberately **gated out** of the submodule path in `compile.rs` — they keep the global codegen fast-path that handles the `setTimeout(fn, delay, ...args)` **varargs** form. Routing them through the fixed-arity submodule thunk would have dropped varargs. **Verified no regression**: `setTimeout(fn, 0, "hi", 42)` via named import still forwards args (matches Node). Default import (`import timers from "node:timers"`) routes to the namespace.

## Test

- New fixture `node-suite/timers/namespace/import-surface` (typeof + setTimeout/clearTimeout/setInterval/clearInterval via the namespace) — matches Node.
- Named-import varargs regression check passes.
- `test_parity_timers` now **compiles** (namespace resolves); its remaining failure is the `Timeout`/`Immediate` handle instance methods (`ref`/`unref`/`hasRef`/`refresh`/`close`) — a separate sub-gap, `known_failures` reason updated.

Refs #1213.