### PR TITLE
fix(timers): typeof timeout.ref === 'function' on Timeout/Immediate handles (#1213)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1805,6 +1805,23 @@ pub extern "C" fn js_object_get_field_ic_miss(
     // dispatch to the per-module accessor instead of silently
     // returning undefined.
     if (obj as usize) > 0 && (obj as usize) < 0x100000 {
+        // #1213: Timeout/Immediate handle methods (ref/unref/hasRef/refresh/
+        // close) read as bound-method function values so `typeof t.ref ===
+        // "function"` holds (the call form already works via
+        // js_native_call_method). The IC fast path funnels small handles here,
+        // bypassing the identical block in `js_object_get_field_by_name`, so it
+        // must be mirrored.
+        unsafe {
+            let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+            let key_len = (*key).byte_len as usize;
+            let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+            if is_timer_handle_method_key(key_bytes) && crate::timer::is_known_timer_id(obj as i64)
+            {
+                let this_f64 =
+                    f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+                return super::js_class_method_bind(this_f64, key_ptr, key_len);
+            }
+        }
         // Drizzle-sqlite blocker: synth `data.constructor` for small-handle
         // receivers — IC-miss path mirror of the constructor intercept in
         // `js_object_get_field_by_name`. Refs #645 deeper followup.

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -374,12 +374,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory \u2014 `node:test` (built-in test runner) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
-  "test_parity_timers": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "node:timers \u2014 `import * as timers` namespace now resolves (#1213, the namespace + setTimeout/setInterval/setImmediate/clear* surface passes). Remaining gap: the Timeout/Immediate handle's instance methods (ref/unref/hasRef/refresh/close) are not implemented (typeof reports undefined vs Node's function), so this full-surface test still fails. Flips to PASS when those land. Not a regression."
-  },
   "test_parity_tls": {
     "issue": "793",
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary

Reading a `Timeout`/`Immediate` handle method (`ref`/`unref`/`hasRef`/`refresh`/`close`) returned `undefined`, so `typeof timeout.ref === "undefined"` (Node: `"function"`) — even though **calling** them already worked (`js_native_call_method`). Part of #1213.

Root cause: the codegen property-read inline cache funnels small-handle receivers through `js_object_get_field_ic_miss`, whose small-handle block had a `constructor` synth + `HANDLE_PROPERTY_DISPATCH` fallback but was **missing the timer-handle-method check** that `js_object_get_field_by_name` has. So the read fell through to `HANDLE_PROPERTY_DISPATCH` (which has no timer entry) and returned `undefined`. Fix mirrors the `is_timer_handle_method_key` + `js_class_method_bind` block into the IC-miss path.

## Test

- **Flips `test_parity_timers` to PASS** (full surface now matches Node byte-for-byte; removed from `known_failures.json`).
- node-suite `timers/object/*` method tests pass (ref-unref, refresh, close, hasref-after-clear, timeout-methods, chained-ref-refresh, refresh-and-close).
- `object/dispose` still fails on a **separate pre-existing** gap (`timeout[Symbol.dispose]` — a well-known-symbol key, not a string method).

Refs #1213.