### PR TITLE
feat(timers): Symbol.dispose on Timeout/Immediate handles (#1213)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1757,6 +1757,9 @@ fn is_timer_handle_method_key(key: &[u8]) -> bool {
             | b"refresh"
             | b"close"
             | b"__perry_dispose__"
+            // `using t = setTimeout(...)` / `t[Symbol.dispose]` — the
+            // well-known dispose symbol lowers to this key. (#1213)
+            | b"@@__perry_wk_dispose"
             | b"@@__perry_wk_toPrimitive"
     )
 }

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -250,7 +250,10 @@ pub unsafe extern "C" fn js_native_call_method(
                         crate::timer::clearInterval(id);
                         return object;
                     }
-                    "__perry_dispose__" => {
+                    // `__perry_dispose__` is the class-member form; the
+                    // well-known `Symbol.dispose` computed form lowers to
+                    // `@@__perry_wk_dispose`. Both clear the timer (#1213).
+                    "__perry_dispose__" | "@@__perry_wk_dispose" => {
                         crate::timer::clearTimeout(id);
                         crate::timer::clearInterval(id);
                         return f64::from_bits(JSValue::undefined().bits());

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -648,6 +648,28 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
         }
         return f64::from_bits(TAG_UNDEFINED);
     }
+    // #1213: Timeout/Immediate handles expose `Symbol.dispose` so
+    // `using t = setTimeout(...)` and `t[Symbol.dispose]()` clear the timer.
+    // The handle is a small id NaN-boxed as POINTER; the symbol-keyed read
+    // otherwise misses the side table and returns undefined.
+    if (bits >> 48) == 0x7FFD {
+        let id = (bits & 0x0000_FFFF_FFFF_FFFF) as i64;
+        if id > 0 && id < 0x100000 && crate::timer::is_known_timer_id(id) {
+            let dispose = well_known_symbol("dispose");
+            if !dispose.is_null() {
+                let dispose_f64 =
+                    f64::from_bits(crate::value::JSValue::pointer(dispose as *const u8).bits());
+                if sym_key_from_f64(sym_f64) == sym_key_from_f64(dispose_f64) {
+                    let mname = b"@@__perry_wk_dispose";
+                    return crate::object::js_class_method_bind(
+                        obj_f64,
+                        mname.as_ptr(),
+                        mname.len(),
+                    );
+                }
+            }
+        }
+    }
     let obj_key = obj_key_from_f64(obj_f64);
     let sym_key = sym_key_from_f64(sym_f64);
     if obj_key == 0 || sym_key == 0 {

--- a/test-parity/node-suite/timers/object/dispose-timeout.ts
+++ b/test-parity/node-suite/timers/object/dispose-timeout.ts
@@ -1,0 +1,8 @@
+// A Timeout handle exposes Symbol.dispose; disposing it clears the timer
+// (the explicit-resource-management `using` form relies on this).
+const events: string[] = [];
+const t = setTimeout(() => events.push("fired"), 5) as any;
+console.log("dispose typeof:", typeof t[Symbol.dispose]);
+t[Symbol.dispose]();
+await new Promise<void>((resolve) => setTimeout(() => resolve(), 25));
+console.log("events after dispose:", events.join(",") || "none");


### PR DESCRIPTION
## Summary

A `Timeout`/`Immediate` handle now exposes `Symbol.dispose`: reading `t[Symbol.dispose]` returns a bound method (`typeof === "function"`) and calling it clears the timer — the runtime side of the explicit-resource-management `using t = setTimeout(...)` form (part of #1213).

`Symbol.dispose` lowers to a symbol-keyed `IndexGet` (`@@__perry_wk_dispose`), which reads through `js_object_get_symbol_property` — **not** the string-property path — so the existing timer-handle-method block was bypassed. This adds a tightly-gated case there (small-pointer receiver + `is_known_timer_id` + the dispose well-known symbol) returning the bound method via `js_class_method_bind`, plus wires `@@__perry_wk_dispose` into the method-call timer block (clears the timer) and `is_timer_handle_method_key`.

## Test

New fixture `node-suite/timers/object/dispose-timeout` — matches Node:
```
dispose typeof: function
events after dispose: none   (timer cleared by t[Symbol.dispose]())
```
No regression in the timers node-suite.

> Note: the broader `object/dispose` fixture also exercises `setImmediate(...)`, which is a **separate** pre-existing gap (the global `setImmediate`/`setTimeout` identifiers read as `typeof "object"`/"boolean" rather than "function"), so it still fails on that line.

Refs #1213.