### PR TITLE
fix(timers): global setImmediate/clearImmediate calls + timer typeof === 'function' (#1454)

### DIFF
--- a/crates/perry-codegen/src/lower_call/extern_func.rs
+++ b/crates/perry-codegen/src/lower_call/extern_func.rs
@@ -165,6 +165,16 @@ pub fn try_lower_extern_func_call(
                 crate::nanbox::TAG_UNDEFINED,
             ))));
         }
+        // #1454: clearImmediate(handle) — immediates live in the shared timer
+        // pool, so the timeout-clear helper retains-out the immediate too.
+        "clearImmediate" if args.len() == 1 => {
+            let id_box = lower_expr(ctx, &args[0])?;
+            ctx.block()
+                .call_void("js_clear_timeout_value", &[(DOUBLE, &id_box)]);
+            return Ok(Some(double_literal(f64::from_bits(
+                crate::nanbox::TAG_UNDEFINED,
+            ))));
+        }
         "gc" => {
             ctx.block().call_void("js_gc_collect", &[]);
             return Ok(Some(double_literal(f64::from_bits(

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -1364,11 +1364,20 @@ pub(crate) fn closure_uses_this(body: &[Stmt]) -> bool {
     body.iter().any(uses_this_stmt)
 }
 
-/// Check if a name is a built-in global function provided by the runtime
+/// Check if a name is a built-in global function provided by the runtime.
+/// #1454: setImmediate/clearImmediate recognized too, so bare calls lower to
+/// ExternFuncRef (codegen fast path), not a not-a-function GlobalGet.
 pub(crate) fn is_builtin_function(name: &str) -> bool {
     matches!(
         name,
-        "setTimeout" | "setInterval" | "clearTimeout" | "clearInterval" | "fetch" | "gc"
+        "setTimeout"
+            | "setInterval"
+            | "setImmediate"
+            | "clearTimeout"
+            | "clearInterval"
+            | "clearImmediate"
+            | "fetch"
+            | "gc"
     )
 }
 

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -572,6 +572,24 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                     if id.sym.as_ref() == "Function" && ctx.lookup_local("Function").is_none() {
                         return Ok(Expr::String("function".to_string()));
                     }
+                    // #1454: global timer builtins (+ fetch) are functions, but
+                    // a bare read lowers to an ExternFuncRef whose typeof reads
+                    // "boolean". Fold to "function" (gc is excluded — it's
+                    // undefined in Node without --expose-gc).
+                    let n = id.sym.as_ref();
+                    if matches!(
+                        n,
+                        "setTimeout"
+                            | "setInterval"
+                            | "setImmediate"
+                            | "clearTimeout"
+                            | "clearInterval"
+                            | "clearImmediate"
+                            | "fetch"
+                    ) && ctx.lookup_local(n).is_none()
+                    {
+                        return Ok(Expr::String("function".to_string()));
+                    }
                 }
                 if let ast::Expr::Member(member) = unary.arg.as_ref() {
                     if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {

--- a/test-parity/node-suite/timers/global-functions.ts
+++ b/test-parity/node-suite/timers/global-functions.ts
@@ -1,0 +1,12 @@
+// Global timer functions are callable and report typeof "function".
+console.log("setTimeout:", typeof setTimeout);
+console.log("setInterval:", typeof setInterval);
+console.log("setImmediate:", typeof setImmediate);
+console.log("clearTimeout:", typeof clearTimeout);
+console.log("clearInterval:", typeof clearInterval);
+console.log("clearImmediate:", typeof clearImmediate);
+let fired = 0;
+const im = setImmediate(() => { fired++; });
+clearImmediate(im);
+await new Promise<void>((r) => setTimeout(() => r(), 15));
+console.log("cleared immediate:", fired === 0);


### PR DESCRIPTION
## Summary

Two related global-timer gaps (#1454):

1. **`setImmediate`/`clearImmediate` bare calls threw `value is not a function`** — they weren't in `is_builtin_function`, so they lowered to a `GlobalGet` call instead of an `ExternFuncRef` (which hits the codegen fast path). Added both; `setImmediate` already had a codegen call arm, added a `clearImmediate` arm routing to `js_clear_timeout_value` (immediates share the timer pool).
2. **`typeof setTimeout` (etc.) read `"boolean"`** — bare timer builtins lower to an `ExternFuncRef` whose `typeof` is wrong. Fold `typeof` of `setTimeout`/`setInterval`/`setImmediate`/`clearTimeout`/`clearInterval`/`clearImmediate` (+ `fetch`) to `"function"`. `gc` is excluded (it's `undefined` in Node without `--expose-gc`).

## Test

- Flips `node-suite/timers/object/dispose` to PASS (the `setImmediate` half, on top of #1453's `Symbol.dispose`).
- New fixture `node-suite/timers/global-functions` — `typeof` of all six + `setImmediate`/`clearImmediate` call/clear — matches Node.
- Regression-checked: `typeof fetch === "function"`, `setTimeout(...)` calls, and `test_parity_timers`/`test_parity_timers_promises` all still pass.

Closes #1454.