### PR TITLE
fix(json): console.log/inspect of a lazy-tape array (#1448)

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -454,7 +454,27 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                 // The GC header is located GC_HEADER_SIZE bytes before the user pointer.
                 let gc_header =
                     (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-                let gc_type = (*gc_header).obj_type;
+                let mut gc_type = (*gc_header).obj_type;
+                // #1448: a lazy-tape array (PERRY_JSON_TAPE) has obj_type
+                // GC_TYPE_LAZY_ARRAY, which misses the array branch below and
+                // prints `[object Object]`. Materialize it to a real array so
+                // it inspects like one (mirrors the stringify redirect).
+                let ptr: *const crate::array::ArrayHeader =
+                    if gc_type == crate::gc::GC_TYPE_LAZY_ARRAY {
+                        let m = crate::json_tape::force_materialize_lazy(
+                            ptr as *mut crate::json_tape::LazyArrayHeader,
+                        );
+                        if m.is_null() {
+                            ptr
+                        } else {
+                            gc_type = (*((m as *const u8).sub(crate::gc::GC_HEADER_SIZE)
+                                as *const crate::gc::GcHeader))
+                                .obj_type;
+                            m as *const crate::array::ArrayHeader
+                        }
+                    } else {
+                        ptr
+                    };
 
                 if gc_type == crate::gc::GC_TYPE_ERROR {
                     // Error object
@@ -1026,7 +1046,26 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
                     // misinterpret arrays as objects or vice versa.
                     let gc_header = (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE)
                         as *const crate::gc::GcHeader;
-                    let gc_type = (*gc_header).obj_type;
+                    let mut gc_type = (*gc_header).obj_type;
+                    // #1448: materialize a nested lazy-tape array so it inspects
+                    // as a real array. Reading its LazyArrayHeader as an
+                    // ArrayHeader below would otherwise read garbage and SIGSEGV.
+                    let ptr: *const crate::array::ArrayHeader =
+                        if gc_type == crate::gc::GC_TYPE_LAZY_ARRAY {
+                            let m = crate::json_tape::force_materialize_lazy(
+                                ptr as *mut crate::json_tape::LazyArrayHeader,
+                            );
+                            if m.is_null() {
+                                ptr
+                            } else {
+                                gc_type = (*((m as *const u8).sub(crate::gc::GC_HEADER_SIZE)
+                                    as *const crate::gc::GcHeader))
+                                    .obj_type;
+                                m as *const crate::array::ArrayHeader
+                            }
+                        } else {
+                            ptr
+                        };
 
                     if gc_type == crate::gc::GC_TYPE_ARRAY {
                         // Cycle check FIRST so back-edges always print as


### PR DESCRIPTION
## Summary

Under `PERRY_JSON_TAPE=1`, `console.log(JSON.parse('["a","bb","ccc"]'))` printed `[object Object]` instead of the array (#1448). The inspect formatter's array branch checks `obj_type == GC_TYPE_ARRAY`, but a non-materialized lazy-tape array has `GC_TYPE_LAZY_ARRAY`, so it fell through to the object catch-all.

Both `gc_type` sites in the inspect formatter now `force_materialize_lazy` the value when it's a lazy array (mirroring the stringify `redirect_lazy_to_materialized`), so it formats as a real array.

## Test

- `console.log(JSON.parse('["a","bb","ccc"]'))` and `[1,2,3]` now match Node (`[ 'a', 'bb', 'ccc' ]` / `[ 1, 2, 3 ]`).
- Flips `test_json_sso_strings` under `PERRY_JSON_TAPE=1`.
- Regression-checked: tape-off (CI default) json parity sweep unchanged (18 pass, 0 fail); fmt + file-size gates pass.

> Note: a nested lazy array *inside an object* (`console.log({ items: JSON.parse('[...]') })`) still SIGSEGVs through a separate object-field formatting path (`format_object_as_json`) — pre-existing, filing as a follow-up.

Closes #1448.