### PR TITLE
release: v0.5.1026 — timers epic + perf_hooks fan-out + lazy-tape fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,63 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1026 — release sweep: timers epic + perf_hooks fan-out + lazy-tape fixes
+
+Rolls up 22 PRs that merged to `main` post-v0.5.1025 without version
+bumps. Full per-PR history is in `git log v0.5.1025..HEAD`.
+
+**node:timers epic (#1213, 6 PRs):**
+- **#1449** `node:timers/promises` `setTimeout` / `setImmediate` native
+  implementation.
+- **#1450** `clearTimeout` / `clearInterval` accept a numeric id (Node
+  also accepts the Timeout/Immediate handle directly, which already
+  worked).
+- **#1451** `import * as timers from 'node:timers'` namespace resolves.
+- **#1452** `typeof timeout.ref === 'function'` on Timeout / Immediate
+  handles.
+- **#1453** `Symbol.dispose` on Timeout / Immediate handles (explicit
+  resource-management proposal).
+- **#1454 / #1455** global `setImmediate` / `clearImmediate` resolve
+  + timer handle `typeof === 'function'`.
+
+**node:perf_hooks fan-out (10 PRs):**
+- **#1320 / #1445** `typeof PerformanceObserver` instance methods + inline
+  `supportedEntryTypes`.
+- **#1327 / #1443** `globalThis.performance === performance` (named-import
+  singleton identity).
+- **#1337 / #1442** `performance.nodeTiming`.
+- **#1338 / #1428** `performance.toJSON()`.
+- **#1339 / #1430** `clearResourceTimings` + `setResourceTimingBufferSize`.
+- **#1340 / #1440** `mark()` / `measure()` `detail` is structured-cloned.
+- **#1388 / #1436** `new PerformanceObserver()` without a callback throws
+  `TypeError`.
+- **#1389 / #1438** observer callback receives the observer as its 2nd arg.
+- **#1390 / #1441** `observe({ buffered: true })` delivers pre-existing
+  entries.
+- **#1403 / #1437** `measure()` with a nonexistent start/end mark throws.
+
+**node:json lazy-tape (closes #1424):**
+- **#1424 / #1447** `JSON.parse(blob, reviver)` on a lazy-tape top-level
+  array no longer SIGSEGVs (the failure I filed during the v0.5.1025
+  release-prep). `test_json_lazy_reviver` un-skip-listed.
+- **#1448 / #1456** `console.log` / `util.inspect` of a lazy-tape array
+  materialises before formatting instead of dumping internal lazy state.
+
+**Other runtime + codegen:**
+- **#1370 / #1446** drop perry/ui debug `console.log` noise from the web
+  driver.
+- **#1429** GC unsafe-zone handling for server adapters — guards the
+  unsafe-zone window when the runtime hands control to fastify/hyper
+  request handlers.
+- **#1341 / #1439** codegen: `Any`-typed `.includes()` / `.indexOf()`
+  dispatch dynamically, not as `String#includes` / `String#indexOf`
+  (was producing wrong results on arrays held in `any` shapes).
+- **#1427** deps: bump `qs` in `tests/release/packages/nestjs-hello`.
+
+`test_async_local_storage_context` (#1423) remains skip-listed —
+`.enterWith()` / `.exit()` semantics still pending (sibling slice of
+#788 / #789).
+
 ## v0.5.1025 — fix(compile): cross-target geisterhand lib lookup + parity skip-list + memory ceiling restore
 
 Unblocks the v0.5.1024 release-packages run by addressing 3 distinct

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1025
+**Current Version:** 0.5.1026
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5134,7 +5134,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "base64",
@@ -5189,14 +5189,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "log",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "base64",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "serde",
  "serde_json",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1025"
+version = "0.5.1026"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "clap",
@@ -5300,14 +5300,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5340,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5348,7 +5348,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "chrono",
  "cron",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5406,14 +5406,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "bson",
  "futures-util",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "image",
@@ -5598,14 +5598,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5632,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "base64",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5835,11 +5835,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1025"
+version = "0.5.1026"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "itoa",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "block2",
@@ -5902,7 +5902,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "block2",
@@ -5921,11 +5921,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1025"
+version = "0.5.1026"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "block2",
@@ -5941,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "block2",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "block2",
  "libc",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "libc",
@@ -5985,7 +5985,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1025"
+version = "0.5.1026"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"


### PR DESCRIPTION
## Summary

Rolls up 22 PRs that merged to `main` post-v0.5.1025 without per-PR version bumps. Full per-PR rollup in CHANGELOG.md.

**Headlines:**
- **node:timers epic** (#1213, 6 PRs #1449-#1455)
- **node:perf_hooks fan-out** (10 PRs across #1320 #1327 #1337-#1340 #1388-#1390 #1403)
- **#1424 lazy-tape reviver SIGSEGV fixed** (test un-skip-listed)
- **#1448 console.log/inspect on lazy-tape arrays**
- **#1429 GC unsafe-zone guards for fastify/hyper handlers**
- **#1341 codegen: Any-typed `.includes()` / `.indexOf()` dynamic dispatch**
- **#1370 ui debug log noise removed**

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check -p perry` clean
- [ ] PR CI: lint + cargo-test + api-docs-drift + security-audit + harmonyos-smoke pass
- [ ] After merge: tag v0.5.1026 → release-packages.yml all-green