### PR TITLE
feat(perf_hooks): implement PerformanceEntry#toJSON() (#1387)

### DIFF
--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -27,12 +27,24 @@ pub(crate) fn lower_var_decl_with_destructuring(
                     ast::Expr::Object(_) => true,
                     ast::Expr::Call(call) => {
                         if let ast::Callee::Expr(callee) = &call.callee {
-                            matches!(
-                                callee.as_ref(),
-                                ast::Expr::Member(m)
-                                    if matches!(m.obj.as_ref(), ast::Expr::Ident(o) if o.sym.as_ref() == "Object")
-                                        && matches!(&m.prop, ast::MemberProp::Ident(p) if p.sym.as_ref() == "create")
-                            )
+                            if let ast::Expr::Member(m) = callee.as_ref() {
+                                let obj_is = |name: &str| matches!(m.obj.as_ref(), ast::Expr::Ident(o) if o.sym.as_ref() == name);
+                                let prop_is = |name: &str| matches!(&m.prop, ast::MemberProp::Ident(p) if p.sym.as_ref() == name);
+                                // Object.create(...) — #809.
+                                (obj_is("Object") && prop_is("create"))
+                                    // #1387: `performance.mark(...)` /
+                                    // `performance.measure(...)` return a
+                                    // PerformanceEntry — a plain shaped object,
+                                    // never a Date — so `entry.toJSON()` (and
+                                    // `.toString()`/`.valueOf()`) must skip the
+                                    // ambiguous-Date arms and fall through to
+                                    // generic dispatch (which finds the
+                                    // synthesized PerformanceEntry#toJSON).
+                                    || (obj_is("performance")
+                                        && (prop_is("mark") || prop_is("measure")))
+                            } else {
+                                false
+                            }
                         } else {
                             false
                         }

--- a/crates/perry-hir/src/lower/expr_call/static_receiver.rs
+++ b/crates/perry-hir/src/lower/expr_call/static_receiver.rs
@@ -48,6 +48,16 @@ pub(super) fn static_receiver_class(
                 {
                     return Some("Object");
                 }
+                // #1387: `performance.mark(...).toJSON()` /
+                // `performance.measure(...).toJSON()` — the entry is a plain
+                // shaped object, not a Date. Classify as "Object" so the
+                // ambiguous-Date arms are skipped and the call reaches the
+                // synthesized PerformanceEntry#toJSON.
+                if matches!(m.obj.as_ref(), ast::Expr::Ident(o) if o.sym.as_ref() == "performance")
+                    && matches!(&m.prop, ast::MemberProp::Ident(p) if p.sym.as_ref() == "mark" || p.sym.as_ref() == "measure")
+                {
+                    return Some("Object");
+                }
             }
         }
     }

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1332,6 +1332,26 @@ pub extern "C" fn js_object_get_field_by_name(
             }
         }
 
+        // #1387: `PerformanceEntry#toJSON` is a synthesized (non-enumerable)
+        // method — entry objects are plain shaped objects with no stored
+        // `toJSON` field, so a `entry.toJSON` read (e.g. `typeof entry.toJSON`)
+        // would otherwise miss the keys_array and return undefined. Return a
+        // bound-method closure; the call lands in `js_native_call_method`'s
+        // toJSON arm via `dispatch_bound_method`. Gated on the key bytes first
+        // so non-toJSON reads pay only a length+compare, not the identity
+        // check.
+        if !key.is_null() {
+            let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+            let key_len = (*key).byte_len as usize;
+            let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+            if key_bytes == b"toJSON" && crate::perf_hooks::is_perf_entry_object(obj) {
+                let this_f64 =
+                    f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+                let result = js_class_method_bind(this_f64, b"toJSON".as_ptr(), 6);
+                return JSValue::from_bits(result.to_bits());
+            }
+        }
+
         // Issue #649: native-module sub-namespace property access.
         // `fs.constants.F_OK` lowers to `PropertyGet { PropertyGet { fs,
         // "constants" }, "F_OK" }` — the inner expression's runtime value

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1683,6 +1683,20 @@ pub unsafe extern "C" fn js_native_call_method(
             return f64::from_bits(JSValue::pointer(null_obj_ptr).bits());
         }
 
+        // #1387: synthesized `PerformanceEntry#toJSON()`. Entry objects are
+        // plain shaped objects with no stored `toJSON` field, so the
+        // field-scan dispatch below would miss it. A bound-method read (from
+        // the property-get intercept) routes here via `dispatch_bound_method`,
+        // and a direct `entry.toJSON()` call lands here too — both serialize
+        // the entry's fields into a plain object. Safe to read the header:
+        // `obj` is a validated heap object (gc_type read above).
+        if method_name == "toJSON"
+            && gc_type == crate::gc::GC_TYPE_OBJECT
+            && crate::perf_hooks::is_perf_entry_object(obj)
+        {
+            return crate::perf_hooks::perf_entry_to_json(object);
+        }
+
         if gc_type != crate::gc::GC_TYPE_OBJECT {
             // Only accept object_type == 1 (OBJECT_TYPE_REGULAR)
             let object_type = (*obj).object_type;

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -17,7 +17,10 @@
 //! hold an arbitrary heap JSValue, so the store is registered as a GC root
 //! scanner (`scan_perf_entries_roots_mut`).
 
-use crate::object::{js_object_alloc_with_shape, js_object_get_field_by_name, js_object_set_field};
+use crate::object::{
+    js_object_alloc_with_shape, js_object_get_field, js_object_get_field_by_name,
+    js_object_set_field,
+};
 use crate::string::StringHeader;
 use crate::value::JSValue;
 use std::cell::{Cell, RefCell};
@@ -31,6 +34,13 @@ const ENTRY_TYPE_MEASURE: u8 = 1;
 /// returned by mark/measure and the getEntries* arrays.
 const PERF_ENTRY_SHAPE: u32 = 0x7FFF_FF40;
 const PERF_ENTRY_KEYS: &[u8] = b"name\0entryType\0startTime\0duration\0detail\0";
+
+/// Distinct shape for the plain object returned by `PerformanceEntry#toJSON()`
+/// (#1387). Same field names as the entry, but a different shape id so its
+/// `keys_array` allocation differs from the entry's — `is_perf_entry_object`
+/// then reports `false` for the toJSON result, matching Node where the
+/// serialized object is a plain object with no `toJSON` method of its own.
+const PERF_ENTRY_JSON_SHAPE: u32 = 0x7FFF_FF42;
 
 /// Shape id for the `{ idle, active, utilization }` eventLoopUtilization object.
 const ELU_SHAPE: u32 = 0x7FFF_FF41;
@@ -60,6 +70,54 @@ thread_local! {
     /// Singleton so the named import and `globalThis.performance` are the same
     /// object (Node identity). GC-rooted in `scan_perf_entries_roots_mut`.
     static PERFORMANCE_NS: Cell<u64> = const { Cell::new(0) };
+
+    /// The `keys_array` pointer shared by every entry object on this thread.
+    /// `js_object_alloc_with_shape` caches one `keys_array` per shape id, so
+    /// all `PERF_ENTRY_SHAPE` objects share the same allocation — recording it
+    /// once lets `is_perf_entry_object` recognize an entry with a single
+    /// pointer compare (no per-key string matching, no GC-tracked registry of
+    /// movable entry pointers). Set on the first `entry_to_object` call.
+    static PERF_ENTRY_KEYS_ARRAY: Cell<usize> = const { Cell::new(0) };
+}
+
+/// True when `obj` is a mark/measure entry object produced by
+/// `entry_to_object` — i.e. its `keys_array` is the recorded shared
+/// `PERF_ENTRY_SHAPE` allocation. The toJSON-result object uses a different
+/// shape, so it deliberately does not match. (#1387)
+pub(crate) unsafe fn is_perf_entry_object(obj: *const crate::object::ObjectHeader) -> bool {
+    if obj.is_null() {
+        return false;
+    }
+    let recorded = PERF_ENTRY_KEYS_ARRAY.with(|c| c.get());
+    recorded != 0 && (*obj).keys_array as usize == recorded
+}
+
+/// Build the plain object returned by `PerformanceEntry#toJSON()` — a copy of
+/// the entry's `{ name, entryType, startTime, duration, detail }` fields under
+/// a distinct shape so the result is itself a plain object (no synthesized
+/// `toJSON`). Mirrors Node's serialization. (#1387)
+pub(crate) unsafe fn perf_entry_to_json(this: f64) -> f64 {
+    let jv = JSValue::from_bits(this.to_bits());
+    if !jv.is_pointer() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let src = jv.as_pointer::<crate::object::ObjectHeader>();
+    if src.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    // Snapshot the 5 fields BEFORE allocating `out` — the alloc can trigger a
+    // GC that relocates `src`, invalidating this raw pointer.
+    let fields: [JSValue; 5] = std::array::from_fn(|i| js_object_get_field(src, i as u32));
+    let out = js_object_alloc_with_shape(
+        PERF_ENTRY_JSON_SHAPE,
+        5,
+        PERF_ENTRY_KEYS.as_ptr(),
+        PERF_ENTRY_KEYS.len() as u32,
+    );
+    for (i, v) in fields.iter().enumerate() {
+        js_object_set_field(out, i as u32, *v);
+    }
+    crate::value::js_nanbox_pointer(out as i64)
 }
 
 /// The per-thread singleton `performance` namespace object (perf_hooks-tagged).
@@ -147,6 +205,15 @@ unsafe fn entry_to_object(e: &PerfEntry) -> f64 {
         PERF_ENTRY_KEYS.as_ptr(),
         PERF_ENTRY_KEYS.len() as u32,
     );
+    // Record the shared keys_array so `is_perf_entry_object` can recognize
+    // entries by pointer identity (see PERF_ENTRY_KEYS_ARRAY). All entries on
+    // this thread share it, so a single store on the first call suffices.
+    let keys_ptr = (*obj).keys_array as usize;
+    PERF_ENTRY_KEYS_ARRAY.with(|c| {
+        if c.get() == 0 {
+            c.set(keys_ptr);
+        }
+    });
     let type_str = if e.entry_type == ENTRY_TYPE_MEASURE {
         "measure"
     } else {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -26,12 +26,6 @@
     "category": "bug-open",
     "reason": "node:perf_hooks: createHistogram() unimplemented (not a function). Flips to PASS when #1336 lands."
   },
-  "node-suite/perf_hooks/entry/to-json": {
-    "issue": "1387",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: PerformanceEntry#toJSON() is not a function. Flips to PASS when #1387 lands."
-  },
   "node-suite/console/dir/depth-options": {
     "issue": "1199",
     "added": "2026-05-20",


### PR DESCRIPTION
## Summary

`mark`/`measure` entries are plain shaped objects, so `PerformanceEntry#toJSON` did not exist: `typeof entry.toJSON` was `"undefined"`, and `entry.toJSON()` was mis-lowered to the Date `toJSON` intrinsic (the receiver isn't statically a non-Date class), reading the entry pointer's bits as a timestamp and returning `null` (#1387).

## Fix

**Runtime (perry-runtime):**
- Recognize an entry object by **keys_array pointer identity** — all entries on a thread share one cached `keys_array` for `PERF_ENTRY_SHAPE`, so detection is a single pointer compare (no per-key string matching, no GC-tracked registry of movable entry pointers).
- `js_object_get_field_by_name`: synthesize a non-enumerable `toJSON` bound-method closure for entry receivers, so `typeof entry.toJSON === "function"` without polluting `Object.keys` / spread / `console.log`.
- `js_native_call_method`: a `toJSON` arm that serializes `{ name, entryType, startTime, duration, detail }` into a plain object under a distinct shape (so the result has no `toJSON` of its own), matching Node.

**HIR (perry-hir):**
- Classify `performance.mark(...)` / `performance.measure(...)` results (both as a local initializer and as a direct-call receiver) as plain objects, so the ambiguous-Date method arms (`toJSON`/`toString`/`valueOf`/…) are skipped and the call reaches the synthesized `toJSON`. Reuses the existing #809 `plain_object_locals` mechanism (whose sole consumer is the Date-method gate).

## Test

- `node-suite/perf_hooks/entry/to-json` flips to **PASS**; removed its `known_failures.json` entry.
- Verified mark + measure entries, the direct-call shape `performance.mark(...).toJSON()`, and Date/URL `toJSON` regression (incl. invalid-date → `null`) — all match Node.
- `cargo test -p perry-hir -p perry-runtime`: 536/0. perf_hooks node-suite 58 pass / 3 fail (the deferred `timerify` #1335 + `histogram` #1336 infra, still skip-listed).

Closes #1387.