### PR TITLE
fix(process): forward trailing args from process.nextTick (#1351)

### DIFF
--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -491,11 +491,15 @@ impl JsEmitter {
             Expr::ProcessHrtimeBigint => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.hrtime.bigint() : BigInt(Date.now()) * 1000000n)");
             }
-            Expr::ProcessNextTick(cb) => {
+            Expr::ProcessNextTick { callback, args } => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.nextTick(");
-                self.emit_expr(cb);
+                self.emit_expr(callback);
+                for a in args {
+                    self.output.push_str(", ");
+                    self.emit_expr(a);
+                }
                 self.output.push_str(") : queueMicrotask(");
-                self.emit_expr(cb);
+                self.emit_expr(callback);
                 self.output.push_str("))");
             }
             Expr::ProcessOn { event, handler } => {

--- a/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
@@ -114,7 +114,7 @@ impl<'a> FuncEmitCtx<'a> {
             | Expr::OsEOL => {
                 func.instruction(&Instruction::I64Const(TAG_UNDEFINED as i64));
             }
-            Expr::ProcessNextTick(_)
+            Expr::ProcessNextTick { .. }
             | Expr::ProcessChdir(_)
             | Expr::ProcessOn { .. }
             | Expr::ProcessKill { .. }

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -363,12 +363,17 @@ pub fn check_escapes_in_expr(
         | Expr::FinalizationRegistryNew(operand)
         | Expr::StructuredClone(operand)
         | Expr::QueueMicrotask(operand)
-        | Expr::ProcessNextTick(operand)
         | Expr::ArrayIsArray(operand) => {
             check_escapes_in_expr(operand, candidates, classes, escaped);
         }
         Expr::JsonParseTyped { text, .. } => {
             check_escapes_in_expr(text, candidates, classes, escaped);
+        }
+        Expr::ProcessNextTick { callback, args } => {
+            check_escapes_in_expr(callback, candidates, classes, escaped);
+            for a in args {
+                check_escapes_in_expr(a, candidates, classes, escaped);
+            }
         }
         Expr::Conditional {
             condition,

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -252,7 +252,6 @@ fn collect_used_new_fields_in_expr(
         | Expr::FinalizationRegistryNew(operand)
         | Expr::StructuredClone(operand)
         | Expr::QueueMicrotask(operand)
-        | Expr::ProcessNextTick(operand)
         | Expr::ArrayIsArray(operand)
         | Expr::ObjectRest {
             object: operand, ..
@@ -262,6 +261,12 @@ fn collect_used_new_fields_in_expr(
         | Expr::Btoa(operand) => collect_used_new_fields_in_expr(operand, non_escaping_news, used),
         Expr::JsonParseTyped { text, .. } => {
             collect_used_new_fields_in_expr(text, non_escaping_news, used)
+        }
+        Expr::ProcessNextTick { callback, args } => {
+            collect_used_new_fields_in_expr(callback, non_escaping_news, used);
+            for a in args {
+                collect_used_new_fields_in_expr(a, non_escaping_news, used);
+            }
         }
         Expr::Conditional {
             condition,

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -967,7 +967,6 @@ pub fn collect_localset_ids_in_expr_filtered(
         | Expr::WeakRefDeref(operand)
         | Expr::StructuredClone(operand)
         | Expr::QueueMicrotask(operand)
-        | Expr::ProcessNextTick(operand)
         | Expr::FsExistsSync(operand)
         | Expr::FsReadFileSync(operand)
         | Expr::FsReadFileBinary(operand)
@@ -1004,6 +1003,12 @@ pub fn collect_localset_ids_in_expr_filtered(
             walk(operand, out);
         }
         Expr::JsonParseTyped { text, .. } => walk(text, out),
+        Expr::ProcessNextTick { callback, args } => {
+            walk(callback, out);
+            for a in args {
+                walk(a, out);
+            }
+        }
         Expr::Call { callee, args, .. } => {
             walk(callee, out);
             for a in args {

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -217,7 +217,6 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         | Expr::WeakRefDeref(operand)
         | Expr::StructuredClone(operand)
         | Expr::QueueMicrotask(operand)
-        | Expr::ProcessNextTick(operand)
         | Expr::FsExistsSync(operand)
         | Expr::FsReadFileSync(operand)
         | Expr::FsReadFileBinary(operand)
@@ -254,6 +253,12 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
             walk(operand, out);
         }
         Expr::JsonParseTyped { text, .. } => walk(text, out),
+        Expr::ProcessNextTick { callback, args } => {
+            walk(callback, out);
+            for a in args {
+                walk(a, out);
+            }
+        }
         Expr::Call { callee, args, .. } => {
             walk(callee, out);
             for a in args {

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -414,21 +414,47 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             }
         }
 
-        // -------- queueMicrotask(fn) / process.nextTick(fn) stubs --------
-        // Real microtask scheduling needs the runtime's queue. For
-        // now we lower the callback for side effects (it might be a
-        // closure expression that needs to register slots) and
-        // return undefined.
-        Expr::QueueMicrotask(cb) | Expr::ProcessNextTick(cb) => {
+        // -------- queueMicrotask(fn) stub --------
+        Expr::QueueMicrotask(cb) => {
             let cb_box = lower_expr(ctx, cb)?;
             let blk = ctx.block();
             let cb_handle = unbox_to_i64(blk, &cb_box);
-            let runtime = match expr {
-                Expr::QueueMicrotask(_) => "js_queue_microtask",
-                Expr::ProcessNextTick(_) => "js_queue_next_tick",
-                _ => unreachable!(),
-            };
-            blk.call_void(runtime, &[(I64, &cb_handle)]);
+            blk.call_void("js_queue_microtask", &[(I64, &cb_handle)]);
+            Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
+        }
+
+        // -------- process.nextTick(fn, ...args) --------
+        // Trailing args are forwarded to the callback when the tick fires
+        // (#1351). Pack them into a stack buffer of doubles and hand off to
+        // the varargs runtime entry; the no-args form goes through the
+        // simpler `js_queue_next_tick` to avoid the alloca cost.
+        Expr::ProcessNextTick { callback, args } => {
+            let cb_box = lower_expr(ctx, callback)?;
+            if args.is_empty() {
+                let blk = ctx.block();
+                let cb_handle = unbox_to_i64(blk, &cb_box);
+                blk.call_void("js_queue_next_tick", &[(I64, &cb_handle)]);
+                return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
+            }
+            let n = args.len();
+            let buf = ctx.func.alloca_entry_array(DOUBLE, n);
+            for (i, a) in args.iter().enumerate() {
+                let v = lower_expr(ctx, a)?;
+                let blk = ctx.block();
+                let slot = blk.gep(DOUBLE, &buf, &[(I64, &format!("{}", i))]);
+                blk.store(DOUBLE, &v, &slot);
+            }
+            let ptr_reg = ctx.block().next_reg();
+            ctx.block().emit_raw(format!(
+                "{} = getelementptr [{} x double], ptr {}, i64 0, i64 0",
+                ptr_reg, n, buf
+            ));
+            let blk = ctx.block();
+            let cb_handle = unbox_to_i64(blk, &cb_box);
+            blk.call_void(
+                "js_queue_next_tick_args",
+                &[(I64, &cb_handle), (PTR, &ptr_reg), (I32, &n.to_string())],
+            );
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }
 

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -970,7 +970,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::PathWin32Join(..)
         | Expr::PathWin32 { .. }
         | Expr::QueueMicrotask(..)
-        | Expr::ProcessNextTick(..)
+        | Expr::ProcessNextTick { .. }
         | Expr::RegExpTest { .. }
         | Expr::RegExpExec { .. }
         | Expr::GlobalGet(..)

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -892,6 +892,13 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // Microtask queue (queueMicrotask / process.nextTick).
     module.declare_function("js_queue_microtask", VOID, &[I64]);
     module.declare_function("js_queue_next_tick", VOID, &[I64]);
+    // #1351: process.nextTick(cb, ...args) — trailing args packed into a
+    // stack buffer of doubles, forwarded when the tick fires.
+    module.declare_function(
+        "js_queue_next_tick_args",
+        VOID,
+        &[I64, crate::types::PTR, I32],
+    );
     module.declare_function("js_drain_queued_microtasks", VOID, &[]);
     // Uint8Array constructor wrapper that flags the resulting buffer so the
     // formatter prints `Uint8Array(N) [ ... ]` instead of `<Buffer ...>`.

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -436,8 +436,12 @@ pub enum Expr {
     ProcessVersions,
     // process.hrtime.bigint() -> bigint (nanoseconds since arbitrary point)
     ProcessHrtimeBigint,
-    // process.nextTick(callback) -> void
-    ProcessNextTick(Box<Expr>),
+    // process.nextTick(callback, ...args) -> void.
+    // Trailing args are forwarded to the callback when it fires (#1351).
+    ProcessNextTick {
+        callback: Box<Expr>,
+        args: Vec<Expr>,
+    },
     // process.on(event, handler) -> void (registers an event listener)
     ProcessOn {
         event: Box<Expr>,

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -38,9 +38,13 @@ pub(super) fn try_native_module_methods(
                         "memoryUsage" => return Ok(Ok(Expr::ProcessMemoryUsage)),
                         "nextTick" => {
                             if !args.is_empty() {
-                                return Ok(Ok(Expr::ProcessNextTick(Box::new(
-                                    args.into_iter().next().unwrap(),
-                                ))));
+                                let mut iter = args.into_iter();
+                                let callback = iter.next().unwrap();
+                                let trailing: Vec<Expr> = iter.collect();
+                                return Ok(Ok(Expr::ProcessNextTick {
+                                    callback: Box::new(callback),
+                                    args: trailing,
+                                }));
                             }
                         }
                         "on" => {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -81,7 +81,7 @@ impl SH for Expr {
             Expr::ProcessVersion => tag(h, 62),
             Expr::ProcessVersions => tag(h, 63),
             Expr::ProcessHrtimeBigint => tag(h, 64),
-            Expr::ProcessNextTick(e) => { tag(h, 65); e.as_ref().hash(h); }
+            Expr::ProcessNextTick { callback, args } => { tag(h, 65); callback.as_ref().hash(h); for a in args { a.hash(h); } }
             Expr::ProcessOn { event, handler } => { tag(h, 66); event.as_ref().hash(h); handler.as_ref().hash(h); }
             Expr::ProcessOnce { event, handler } => { tag(h, 11223); event.as_ref().hash(h); handler.as_ref().hash(h); }
             Expr::ProcessChdir(e) => { tag(h, 67); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -100,7 +100,6 @@ where
         | Expr::PropertyUpdate { object: v, .. }
         | Expr::StaticFieldSet { value: v, .. }
         | Expr::EnvGetDynamic(v)
-        | Expr::ProcessNextTick(v)
         | Expr::ProcessChdir(v)
         | Expr::ProcessStdinSetRawMode(v)
         | Expr::TtyIsAtty(v)
@@ -1029,6 +1028,12 @@ where
             f(pid);
             if let Some(s) = signal {
                 f(s);
+            }
+        }
+        Expr::ProcessNextTick { callback, args } => {
+            f(callback);
+            for a in args {
+                f(a);
             }
         }
         Expr::ProcessExit(opt) => {

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -101,7 +101,6 @@ where
         | Expr::PropertyUpdate { object: v, .. }
         | Expr::StaticFieldSet { value: v, .. }
         | Expr::EnvGetDynamic(v)
-        | Expr::ProcessNextTick(v)
         | Expr::ProcessChdir(v)
         | Expr::ProcessStdinSetRawMode(v)
         | Expr::TtyIsAtty(v)
@@ -1010,6 +1009,12 @@ where
             f(pid);
             if let Some(s) = signal {
                 f(s);
+            }
+        }
+        Expr::ProcessNextTick { callback, args } => {
+            f(callback);
+            for a in args {
+                f(a);
             }
         }
         Expr::ProcessExit(opt) => {

--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -339,15 +339,33 @@ pub extern "C" fn js_structured_clone(value: f64) -> f64 {
 /// should print "sync" then "micro", not "micro" then "sync".
 #[no_mangle]
 pub extern "C" fn js_queue_microtask(callback: i64) {
-    queue_microtask_with_type(callback, "Microtask");
+    queue_microtask_with_type(callback, "Microtask", Vec::new());
 }
 
 #[no_mangle]
 pub extern "C" fn js_queue_next_tick(callback: i64) {
-    queue_microtask_with_type(callback, "TickObject");
+    queue_microtask_with_type(callback, "TickObject", Vec::new());
 }
 
-fn queue_microtask_with_type(callback: i64, type_name: &str) {
+/// process.nextTick(cb, ...args) — forwards trailing args to `cb` when the
+/// tick fires (#1351). `args_ptr`/`n_args` describe a NaN-boxed-f64 buffer
+/// allocated on the caller's stack; we copy the slice eagerly because the
+/// drain runs after the caller returns.
+///
+/// # Safety
+/// `args_ptr` must point to `n_args` valid `f64` values, or be null if
+/// `n_args == 0`.
+#[no_mangle]
+pub unsafe extern "C" fn js_queue_next_tick_args(callback: i64, args_ptr: *const f64, n_args: i32) {
+    let args: Vec<f64> = if args_ptr.is_null() || n_args <= 0 {
+        Vec::new()
+    } else {
+        std::slice::from_raw_parts(args_ptr, n_args as usize).to_vec()
+    };
+    queue_microtask_with_type(callback, "TickObject", args);
+}
+
+fn queue_microtask_with_type(callback: i64, type_name: &str, args: Vec<f64>) {
     let context = crate::async_context::capture_context();
     let ids = crate::async_hooks::init_resource(
         type_name,
@@ -355,13 +373,26 @@ fn queue_microtask_with_type(callback: i64, type_name: &str) {
         false,
     );
     QUEUED_MICROTASKS.with(|q| {
-        q.borrow_mut()
-            .push((callback, context, ids.async_id, ids.trigger_async_id));
+        q.borrow_mut().push(QueuedMicrotask {
+            callback,
+            context,
+            async_id: ids.async_id,
+            trigger_async_id: ids.trigger_async_id,
+            args,
+        });
     });
 }
 
+pub(crate) struct QueuedMicrotask {
+    pub callback: i64,
+    pub context: crate::async_context::AsyncContextSnapshot,
+    pub async_id: u64,
+    pub trigger_async_id: u64,
+    pub args: Vec<f64>,
+}
+
 thread_local! {
-    static QUEUED_MICROTASKS: std::cell::RefCell<Vec<(i64, crate::async_context::AsyncContextSnapshot, u64, u64)>> = const { std::cell::RefCell::new(Vec::new()) };
+    static QUEUED_MICROTASKS: std::cell::RefCell<Vec<QueuedMicrotask>> = const { std::cell::RefCell::new(Vec::new()) };
     static QUEUED_MICROTASK_PREV_CONTEXTS: std::cell::RefCell<Vec<crate::async_context::AsyncContextSnapshot>> = const { std::cell::RefCell::new(Vec::new()) };
 }
 
@@ -377,7 +408,10 @@ pub fn restore_queued_microtask_contexts() {
 /// Drain queued microtasks. Called by `js_promise_run_microtasks`.
 #[no_mangle]
 pub extern "C" fn js_drain_queued_microtasks() {
-    use crate::closure::js_closure_call0;
+    use crate::closure::{
+        js_closure_call0, js_closure_call1, js_closure_call2, js_closure_call3, js_closure_call4,
+        js_closure_call5, js_closure_call6, js_closure_call7, js_closure_call8, js_closure_call9,
+    };
     loop {
         let task = QUEUED_MICROTASKS.with(|q| {
             let mut queue = q.borrow_mut();
@@ -388,16 +422,61 @@ pub extern "C" fn js_drain_queued_microtasks() {
             }
         });
         match task {
-            Some((cb, context, async_id, trigger_async_id)) => {
+            Some(QueuedMicrotask {
+                callback: cb,
+                context,
+                async_id,
+                trigger_async_id,
+                args,
+            }) => {
                 let scope = crate::gc::RuntimeHandleScope::new();
                 let callback_handle =
                     scope.root_raw_const_ptr(cb as *const crate::closure::ClosureHeader);
+                let arg_handles = scope.root_nanbox_f64_slice(&args);
                 let previous = crate::async_context::enter_context(&context);
                 QUEUED_MICROTASK_PREV_CONTEXTS.with(|stack| {
                     stack.borrow_mut().push(previous);
                 });
                 crate::async_hooks::before(async_id, trigger_async_id);
-                js_closure_call0(callback_handle.get_raw_const_ptr());
+                let a = crate::gc::RuntimeHandleScope::refreshed_nanbox_f64_slice(&arg_handles);
+                let cb_ptr = callback_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>();
+                match a.len() {
+                    0 => {
+                        js_closure_call0(cb_ptr);
+                    }
+                    1 => {
+                        js_closure_call1(cb_ptr, a[0]);
+                    }
+                    2 => {
+                        js_closure_call2(cb_ptr, a[0], a[1]);
+                    }
+                    3 => {
+                        js_closure_call3(cb_ptr, a[0], a[1], a[2]);
+                    }
+                    4 => {
+                        js_closure_call4(cb_ptr, a[0], a[1], a[2], a[3]);
+                    }
+                    5 => {
+                        js_closure_call5(cb_ptr, a[0], a[1], a[2], a[3], a[4]);
+                    }
+                    6 => {
+                        js_closure_call6(cb_ptr, a[0], a[1], a[2], a[3], a[4], a[5]);
+                    }
+                    7 => {
+                        js_closure_call7(cb_ptr, a[0], a[1], a[2], a[3], a[4], a[5], a[6]);
+                    }
+                    8 => {
+                        js_closure_call8(cb_ptr, a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]);
+                    }
+                    _ => {
+                        // >= 9 args: clamp to 9. Mirrors the setTimeout
+                        // dispatch fallback; real-world nextTick rarely
+                        // exceeds 1-2 trailing args.
+                        js_closure_call9(
+                            cb_ptr, a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8],
+                        );
+                    }
+                }
                 crate::async_hooks::after(async_id);
                 crate::async_hooks::destroy(async_id);
                 QUEUED_MICROTASK_PREV_CONTEXTS.with(|stack| {
@@ -418,9 +497,14 @@ pub fn scan_queued_microtask_roots(mark: &mut dyn FnMut(f64)) {
 
 pub fn scan_queued_microtask_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     QUEUED_MICROTASKS.with(|q| {
-        for (callback, context, _, _) in q.borrow_mut().iter_mut() {
-            visitor.visit_i64_slot(callback);
-            crate::async_context::scan_snapshot_roots_mut(context, visitor);
+        for task in q.borrow_mut().iter_mut() {
+            visitor.visit_i64_slot(&mut task.callback);
+            crate::async_context::scan_snapshot_roots_mut(&mut task.context, visitor);
+            // #1351: trailing nextTick args may be heap pointers — keep
+            // them rooted alongside the callback closure.
+            for arg in task.args.iter_mut() {
+                visitor.visit_nanbox_f64_slot(arg);
+            }
         }
     });
     QUEUED_MICROTASK_PREV_CONTEXTS.with(|stack| {
@@ -436,7 +520,13 @@ pub(crate) fn test_seed_queued_microtask(callback: i64, context_store: f64) {
     QUEUED_MICROTASKS.with(|q| {
         let mut q = q.borrow_mut();
         q.clear();
-        q.push((callback, context, 0, 0));
+        q.push(QueuedMicrotask {
+            callback,
+            context,
+            async_id: 0,
+            trigger_async_id: 0,
+            args: Vec::new(),
+        });
     });
     QUEUED_MICROTASK_PREV_CONTEXTS.with(|stack| stack.borrow_mut().clear());
 }
@@ -457,10 +547,10 @@ pub(crate) fn test_queued_microtask_snapshot() -> (usize, u64, u64) {
         let q = q.borrow();
         let (callback, store_bits) = q
             .first()
-            .map(|(callback, context, _, _)| {
+            .map(|task| {
                 (
-                    *callback as usize,
-                    crate::async_context::test_snapshot_first_store(context)
+                    task.callback as usize,
+                    crate::async_context::test_snapshot_first_store(&task.context)
                         .map(f64::to_bits)
                         .unwrap_or(0),
                 )

--- a/test-parity/node-suite/process/nexttick/with-args.ts
+++ b/test-parity/node-suite/process/nexttick/with-args.ts
@@ -1,0 +1,26 @@
+// process.nextTick(cb, ...args) — JS spec forwards the trailing args to
+// the callback when the tick fires. Regression cover for #1351 (Perry was
+// silently dropping them).
+await new Promise<void>((resolve) => {
+  process.nextTick(
+    (a: string, b: number, c: boolean) => {
+      console.log("args:", a, b, c);
+      resolve();
+    },
+    "x",
+    2,
+    true,
+  );
+});
+await new Promise<void>((resolve) => {
+  process.nextTick((v: string) => {
+    console.log("single:", v);
+    resolve();
+  }, "hello");
+});
+await new Promise<void>((resolve) => {
+  process.nextTick(() => {
+    console.log("no args ok");
+    resolve();
+  });
+});


### PR DESCRIPTION
## Summary

`process.nextTick(cb, a, b)` now invokes `cb(a, b)` — previously Perry silently dropped the trailing args (no-arg form already worked). Closes #1351.

Implementation mirrors the `setTimeout(fn, delay, ...args)` path from #665:

- HIR `ProcessNextTick` variant switches to a struct with `callback` + `args`.
- Codegen emits `js_queue_next_tick_args(cb, ptr, n)` when args are present, packing them into a stack buffer of NaN-boxed doubles. The no-arg form stays on the simpler `js_queue_next_tick`.
- Runtime queue entry grows a `Vec<f64>`; the drain dispatches via `js_closure_call0..9` based on arg count.
- GC scan walks the trailing args alongside the callback closure so heap pointers survive a collection between schedule and drain.

## Test plan

- [x] `test-parity/node-suite/process/nexttick/with-args.ts` is byte-identical to `node --experimental-strip-types`.
- [x] Existing `test-files/test_gap_node_process.ts` (no-args nextTick) still passes.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo test --release -p perry-runtime --lib microtask` passes (3/3).