### PR TITLE
fix(process): process.send / process.disconnect undefined without IPC (#1407)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -120,6 +120,14 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                     "stdout" => return Ok(Expr::ProcessStdout),
                     "stderr" => return Ok(Expr::ProcessStderr),
                     "env" => return Ok(Expr::ProcessEnv),
+                    // #1407: IPC-only members. When the process wasn't
+                    // spawned with an IPC channel (the default), Node
+                    // leaves these as `undefined` rather than exposing a
+                    // dummy method. Reads here must short-circuit to
+                    // Undefined so `typeof process.send === "undefined"`
+                    // matches Node and downstream `if (process.send)`
+                    // guards do the right thing.
+                    "send" | "disconnect" => return Ok(Expr::Undefined),
                     _ => {}
                 }
             }
@@ -179,6 +187,7 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                     "version" => return Ok(Expr::ProcessVersion),
                     "versions" => return Ok(Expr::ProcessVersions),
                     "env" => return Ok(Expr::ProcessEnv),
+                    "send" | "disconnect" => return Ok(Expr::Undefined),
                     _ => {}
                 }
             }


### PR DESCRIPTION
## Summary
- `typeof process.send` was `"number"` (sentinel 0.0) instead of `"undefined"` — Node returns `undefined` when the process wasn't spawned with an IPC channel.
- Same fix for `process.disconnect`.
- Short-circuits the property read to `Expr::Undefined` in HIR lowering (bare `process.X` and `globalThis.process.X` paths), so the typical `if (process.send) { ... }` guard now matches Node and `process.send(...)` throws `TypeError` instead of `0(...)` errors.

Closes #1407.

## Test plan
- [x] `typeof process.send === "undefined"` and `process.send === undefined`
- [x] same for `process.disconnect`
- [x] `globalThis.process.send`, `(globalThis as any).process.send` paths
- [x] bare `process.send!("x")` still throws (matches Node)
- [x] regression: `process.argv`, `process.env`, `process.pid`, `process.platform` still work
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p perry-hir`