### PR TITLE
feat(process): implement process.abort() (#1374)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1856,6 +1856,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("path", "posix"),
     property("path", "win32"),
     // process — properties mapped to Expr::Process* / Expr::Os* in expr_member.rs.
+    method("process", "abort", false, None),
     property("process", "argv"),
     property("process", "platform"),
     property("process", "arch"),

--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -528,6 +528,9 @@ impl JsEmitter {
                 }
                 self.output.push_str(") : undefined)");
             }
+            Expr::ProcessAbort => {
+                self.output.push_str("(typeof process !== 'undefined' ? process.abort() : undefined)");
+            }
             Expr::ProcessStdin => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.stdin : { write: () => true })");
             }

--- a/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
@@ -118,7 +118,8 @@ impl<'a> FuncEmitCtx<'a> {
             | Expr::ProcessChdir(_)
             | Expr::ProcessOn { .. }
             | Expr::ProcessKill { .. }
-            | Expr::ProcessExit(_) => {
+            | Expr::ProcessExit(_)
+            | Expr::ProcessAbort => {
                 func.instruction(&Instruction::I64Const(TAG_UNDEFINED as i64));
             }
             Expr::EnvGet(_) | Expr::EnvGetDynamic(_) => {

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1096,6 +1096,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::RegExpFlags(..)
         | Expr::ProcessChdir(..)
         | Expr::ProcessExit(..)
+        | Expr::ProcessAbort
         | Expr::ObjectGetPrototypeOf(..)
         | Expr::ObjectDefineProperties(..)
         | Expr::ObjectSetPrototypeOf(..)

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -533,6 +533,32 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         ],
                     ));
                 }
+                // node:process — `process.abort` read as a VALUE (not called).
+                // Bare `process` lowers to the GlobalGet(0) sentinel, so the
+                // receiver name is gone here; route by the process-distinctive
+                // property name through the native-module property helper,
+                // which returns a bound-method closure (typeof "function").
+                // The call form `process.abort()` lowers separately via the
+                // dedicated HIR variant. (#1374)
+                if property.as_str() == "abort" {
+                    let mod_idx = ctx.strings.intern("process");
+                    let mod_bytes_global = format!("@{}", ctx.strings.entry(mod_idx).bytes_global);
+                    let mod_len_str = "process".len().to_string();
+                    let prop_idx = ctx.strings.intern(property);
+                    let prop_bytes_global =
+                        format!("@{}", ctx.strings.entry(prop_idx).bytes_global);
+                    let prop_len_str = property.len().to_string();
+                    return Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_native_module_property_by_name",
+                        &[
+                            (PTR, &mod_bytes_global),
+                            (I64, &mod_len_str),
+                            (PTR, &prop_bytes_global),
+                            (I64, &prop_len_str),
+                        ],
+                    ));
+                }
                 // Built-in constructors / namespaces exposed on globalThis
                 // (`Array`, `Object`, `Math`, `JSON`, ...): route the read
                 // through the singleton so `globalThis.Array` (and the

--- a/crates/perry-codegen/src/expr/string_regex_proc.rs
+++ b/crates/perry-codegen/src/expr/string_regex_proc.rs
@@ -124,6 +124,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 .call_void("js_process_exit", &[(DOUBLE, &code_val)]);
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }
+        Expr::ProcessAbort => {
+            // process.abort() — raises SIGABRT immediately. The runtime fn
+            // calls libc::abort(); we still return undefined to satisfy the
+            // expression type even though control never reaches the caller.
+            ctx.block().call_void("js_process_abort", &[]);
+            Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
+        }
         Expr::ObjectGetPrototypeOf(o) => {
             // v0.5.751: route through the runtime helper which walks
             // the class registry's parent_class_id chain for INT32-tagged

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -458,6 +458,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_chdir", VOID, &[I64]);
     module.declare_function("js_process_kill", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_process_exit", VOID, &[DOUBLE]);
+    module.declare_function("js_process_abort", VOID, &[]);
     module.declare_function("js_process_on", VOID, &[I64, I64]);
     module.declare_function("js_process_once", VOID, &[I64, I64]);
     module.declare_function("js_process_next_tick", VOID, &[I64]);

--- a/crates/perry-hir/src/audit.rs
+++ b/crates/perry-hir/src/audit.rs
@@ -267,6 +267,7 @@ fn specialized_stdlib_call(expr: &Expr) -> Option<(&'static str, &'static str)> 
         Expr::ProcessUptime => ("process", "uptime"),
         Expr::ProcessCwd => ("process", "cwd"),
         Expr::ProcessArgv => ("process", "argv"),
+        Expr::ProcessAbort => ("process", "abort"),
         Expr::ProcessStdinIsTTY => ("process", "stdin.isTTY"),
         Expr::ProcessStdoutIsTTY => ("process", "stdout.isTTY"),
         Expr::ProcessStderrIsTTY => ("process", "stderr.isTTY"),

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -458,6 +458,8 @@ pub enum Expr {
     // process.exit(code?) -> never. Bare `process.exit()` lowers as
     // `ProcessExit(None)` which the runtime treats as code 0.
     ProcessExit(Option<Box<Expr>>),
+    // process.abort() -> never. Calls SIGABRT to terminate (no clean shutdown).
+    ProcessAbort,
     // process.stdin -> stub object { write: fn }
     ProcessStdin,
     // process.stdout -> stub object { write: fn }

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -98,6 +98,11 @@ pub(super) fn try_native_module_methods(
                             };
                             return Ok(Ok(Expr::ProcessExit(code)));
                         }
+                        "abort" => {
+                            // process.abort() — raises SIGABRT, no clean
+                            // shutdown. Maps to libc::abort() at runtime.
+                            return Ok(Ok(Expr::ProcessAbort));
+                        }
                         _ => {} // Fall through to generic handling
                     }
                 }

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -279,6 +279,7 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
         Expr::EnvGet(name) => Expr::EnvGet(name.clone()),
         Expr::ProcessUptime => Expr::ProcessUptime,
         Expr::ProcessMemoryUsage => Expr::ProcessMemoryUsage,
+        Expr::ProcessAbort => Expr::ProcessAbort,
 
         // File system
         Expr::FsReadFileSync(path) => {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -87,6 +87,7 @@ impl SH for Expr {
             Expr::ProcessChdir(e) => { tag(h, 67); e.as_ref().hash(h); }
             Expr::ProcessKill { pid, signal } => { tag(h, 68); pid.as_ref().hash(h); signal.hash(h); }
             Expr::ProcessExit(e) => { tag(h, 69); e.hash(h); }
+            Expr::ProcessAbort => tag(h, 11224),
             Expr::ProcessStdin => tag(h, 70),
             Expr::ProcessStdout => tag(h, 71),
             Expr::ProcessStderr => tag(h, 72),

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -43,6 +43,7 @@ where
         | Expr::ProcessStdin
         | Expr::ProcessStdout
         | Expr::ProcessStderr
+        | Expr::ProcessAbort
         | Expr::ProcessStdinIsTTY
         | Expr::ProcessStdoutIsTTY
         | Expr::ProcessStderrIsTTY

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -44,6 +44,7 @@ where
         | Expr::ProcessStdin
         | Expr::ProcessStdout
         | Expr::ProcessStderr
+        | Expr::ProcessAbort
         | Expr::ProcessStdinIsTTY
         | Expr::ProcessStdoutIsTTY
         | Expr::ProcessStderrIsTTY

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -275,7 +275,8 @@ pub(crate) fn set_bound_native_closure_name(
 pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool {
     matches!(
         (module, prop),
-        ("tty", "isatty")
+        ("process", "abort")
+            | ("tty", "isatty")
             | ("tty", "ReadStream")
             | ("tty", "WriteStream")
             | ("events", "EventEmitter")

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -35,6 +35,18 @@ pub extern "C" fn js_process_exit(code: f64) {
     std::process::exit(exit_code);
 }
 
+/// process.abort() -> never. Raises SIGABRT (no clean shutdown). Matches
+/// Node's behavior — atexit handlers and other shutdown logic are skipped.
+#[no_mangle]
+pub extern "C" fn js_process_abort() {
+    #[cfg(unix)]
+    unsafe {
+        libc::abort();
+    }
+    #[cfg(not(unix))]
+    std::process::abort();
+}
+
 /// Get an environment variable by name (takes JS string pointer)
 /// Returns a string pointer, or null (0) if not found
 #[no_mangle]

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1100 entries across 80 modules
+// Coverage: 1101 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1467,6 +1467,8 @@ declare module "process" {
   export const version: any;
   /** stdlib */
   export const versions: any;
+  /** stdlib */
+  export function abort(...args: any[]): any;
 }
 
 declare module "querystring" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1100 entries across 80 modules.
+Total: 1101 entries across 80 modules.
 
 ## Modules
 
@@ -1403,6 +1403,10 @@ Total: 1100 entries across 80 modules.
 - `query` — instance
 
 ## `process`
+
+### Methods
+
+- `abort` — module
 
 ### Properties
 

--- a/test-parity/node-suite/process/methods/abort.ts
+++ b/test-parity/node-suite/process/methods/abort.ts
@@ -1,0 +1,3 @@
+// process.abort is a callable function (not invoked here — it would kill the
+// process).
+console.log("is function:", typeof process.abort === "function");


### PR DESCRIPTION
Closes #1374.

## Summary

- `typeof process.abort` now returns `"function"` (was `"undefined"`).
- `process.abort()` raises SIGABRT via the runtime, no clean shutdown — matches Node.

## Approach

Same shape as #1371 used for `cwd` / `nextTick` / `exit` / `kill` etc. on the `feat/process-node-suite` branch:

- `Expr::ProcessAbort` HIR variant; the call form lowers there and codegen emits a void call to `js_process_abort` (`libc::abort()` on unix, `std::process::abort()` elsewhere).
- For the value-read form (`typeof process.abort`, `const f = process.abort`), bare `process` lowers to the `GlobalGet(0)` sentinel so the receiver name is gone — `PropertyGet` routes the `"abort"` property through `js_native_module_property_by_name("process", "abort")`, and `is_native_module_callable_export` returns true so the helper hands back a bound-method closure (typeof `"function"`).
- `api-manifest` gets a `method("process", "abort", ...)` entry so the compile-time typeof short-circuit and SBOM audit see the surface.

## Test plan

- [x] `test-parity/node-suite/process/methods/abort.ts` — verifies `typeof process.abort === "function"` (matches Node).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo build --release -p perry-runtime -p perry-codegen -p perry` clean.