### PR TITLE
fix(process): wire process.ref / process.unref as no-op functions (#1410)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -87,6 +87,15 @@ pub(super) fn try_native_module_methods(
                                 }));
                             }
                         }
+                        "ref" | "unref" => {
+                            // #1410: process.ref() / process.unref() — no-ops
+                            // in Node (process always keeps the loop alive,
+                            // so there's nothing to ref/unref). Return
+                            // undefined so callers that probe and invoke them
+                            // (e.g. graceful-shutdown helpers) don't crash on
+                            // "value is not a function".
+                            return Ok(Ok(Expr::Undefined));
+                        }
                         "exit" => {
                             // process.exit() / process.exit(code) — never
                             // returns, terminates the process. Until now this

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -601,6 +601,18 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                             {
                                 return Ok(Expr::String("function".to_string()));
                             }
+                            // #1410: `typeof process.ref` / `typeof process.unref`.
+                            // The methods are pure no-op stubs that lower to
+                            // `Expr::Undefined` when called; a bare member
+                            // read still falls through to the generic process
+                            // member path (returns 0 / "number" typeof), so
+                            // fold to "function" here to match Node.
+                            if obj_name == "process"
+                                && matches!(prop_name, "ref" | "unref")
+                                && ctx.lookup_local("process").is_none()
+                            {
+                                return Ok(Expr::String("function".to_string()));
+                            }
                             if matches!(
                                 ctx.lookup_native_instance(obj_name),
                                 Some(("async_hooks", "AsyncHook"))

--- a/test-parity/node-suite/process/methods/ref-unref.ts
+++ b/test-parity/node-suite/process/methods/ref-unref.ts
@@ -1,0 +1,9 @@
+// process.ref() / process.unref() — no-ops in Node, but they MUST exist as
+// functions returning undefined. Regression cover for #1410 (Perry was
+// reading them as numbers, so `typeof` lied and any invocation threw
+// "value is not a function").
+console.log("ref typeof:", typeof process.ref);
+console.log("unref typeof:", typeof process.unref);
+console.log("ref result:", process.ref());
+console.log("unref result:", process.unref());
+console.log("done");


### PR DESCRIPTION
## Summary

Both `process.ref()` and `process.unref()` exist on Node's `process` and are pure no-ops returning `undefined`. Perry was reading them as bare numbers, so:

- `typeof process.ref === "function"` returned `false` (broke feature detection in graceful-shutdown helpers).
- Actually calling them threw `value is not a function`.

Closes #1410.

## Changes

- **HIR call lowering** (`native_module.rs`): `process.ref()` / `process.unref()` fold to `Expr::Undefined`.
- **Typeof fold** (`lower_expr.rs`): `typeof process.ref` / `typeof process.unref` returns the literal `"function"` string, matching the perf_hooks pattern already used there for `observe`/`disconnect`. The narrow rule only fires when `process` is unshadowed.

## Test plan

- [x] `test-parity/node-suite/process/methods/ref-unref.ts` covers both `typeof` and call shapes; byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.
- [x] Doesn't touch the broader `process.<method>` typeof refactor that #1330 is addressing — narrow per-method arm, easy to subsume later.