### PR TITLE
fix(process): implement process.memoryUsage.rss() fast-path call (#1395)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -63,8 +63,8 @@ use module_class_static::try_module_class_static;
 use module_static::try_module_static_methods;
 use native_module::try_native_module_methods;
 use nested_namespace::{
-    try_path_subnamespace, try_process_hrtime_bigint, try_util_types_namespace,
-    try_web_crypto_subtle,
+    try_path_subnamespace, try_process_hrtime_bigint, try_process_memory_usage_rss,
+    try_util_types_namespace, try_web_crypto_subtle,
 };
 use post_args_dispatch::{
     try_object_has_own_call, try_object_prototype_call, try_object_static_alias_call,
@@ -211,6 +211,10 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
             // crypto.subtle.<method>(), util.types.<method>(), and
             // path.posix/win32.<method>().
             args = match try_process_hrtime_bigint(expr, args) {
+                Ok(e) => return Ok(e),
+                Err(a) => a,
+            };
+            args = match try_process_memory_usage_rss(expr, args) {
                 Ok(e) => return Ok(e),
                 Err(a) => a,
             };

--- a/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
+++ b/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
@@ -44,6 +44,40 @@ pub(super) fn try_process_hrtime_bigint(
     Err(args)
 }
 
+/// `process.memoryUsage.rss()` — Node's fast-path that returns just the
+/// RSS as a number instead of allocating the full `MemoryUsage` object
+/// (issue #1395). AST shape mirrors `process.hrtime.bigint()` above.
+///
+/// Implementation: lower to `(process.memoryUsage()).rss`. Same value
+/// Node's fast path returns; we don't have the no-allocation fast path
+/// but parity tests only care about the numeric result.
+pub(super) fn try_process_memory_usage_rss(
+    expr: &ast::Expr,
+    args: Vec<Expr>,
+) -> Result<Expr, Vec<Expr>> {
+    if let ast::Expr::Member(outer_member) = expr {
+        if let ast::Expr::Member(inner_member) = outer_member.obj.as_ref() {
+            if let ast::Expr::Ident(inner_obj) = inner_member.obj.as_ref() {
+                if inner_obj.sym.as_ref() == "process" {
+                    if let ast::MemberProp::Ident(inner_prop) = &inner_member.prop {
+                        if inner_prop.sym.as_ref() == "memoryUsage" {
+                            if let ast::MemberProp::Ident(method_ident) = &outer_member.prop {
+                                if method_ident.sym.as_ref() == "rss" {
+                                    return Ok(Expr::PropertyGet {
+                                        object: Box::new(Expr::ProcessMemoryUsage),
+                                        property: "rss".to_string(),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Err(args)
+}
+
 /// Web Crypto API — `crypto.subtle.<method>(args)` (issue #561).
 /// AST shape is the same nested-Member pattern as
 /// `process.hrtime.bigint()` above. We resolve here BEFORE the


### PR DESCRIPTION
## Summary
- Node's `process.memoryUsage.rss()` fast path was missing in Perry — calling it threw `TypeError: (number).rss is not a function` because `process.memoryUsage` read as a value gives a 0.0 sentinel.
- Adds a nested-namespace lowering arm next to the existing `process.hrtime.bigint()` one: lowers `process.memoryUsage.rss()` to `(process.memoryUsage()).rss`. Same numeric result Node's fast path returns.

Closes #1395.

## Notes
- The bare `typeof process.memoryUsage.rss` value-read still returns `"undefined"` in Perry (Node returns `"function"`). That's the same namespace-method-typeof class as the `#1320` / `#1343` work — tracked separately, not in scope here.
- Existing `process.hrtime.bigint()` and `process.memoryUsage()` paths unchanged.

## Test plan
- [x] `process.memoryUsage.rss()` returns a positive number (matches Node parity for `typeof` + `> 0`)
- [x] regression: `process.memoryUsage().rss` and `.heapUsed` still work
- [x] regression: `process.hrtime.bigint()` still works (the sibling nested-namespace arm)
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p perry-hir`