### PR TITLE
feat(process): implement process.execArgv (#1349)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -129,6 +129,14 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                     // and downstream `if (process.send)` /
                     // `if (process.connected)` guards do the right thing.
                     "send" | "disconnect" | "connected" => return Ok(Expr::Undefined),
+                    // #1349: process.execArgv is the array of runtime CLI
+                    // flags the interpreter was started with (`["--inspect",
+                    // ...]` for Node). Perry binaries are AOT — there's no
+                    // runtime flag list to forward — so the empty array is
+                    // the correct shape. Without this, the bare read
+                    // returns a 0 sentinel and `Array.isArray(...)` /
+                    // `.length` / iteration all explode.
+                    "execArgv" => return Ok(Expr::Array(Vec::new())),
                     _ => {}
                 }
             }
@@ -189,6 +197,7 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                     "versions" => return Ok(Expr::ProcessVersions),
                     "env" => return Ok(Expr::ProcessEnv),
                     "send" | "disconnect" | "connected" => return Ok(Expr::Undefined),
+                    "execArgv" => return Ok(Expr::Array(Vec::new())),
                     _ => {}
                 }
             }

--- a/test-parity/node-suite/process/exec-argv/exec-argv.ts
+++ b/test-parity/node-suite/process/exec-argv/exec-argv.ts
@@ -1,0 +1,9 @@
+// process.execArgv — runtime CLI flags. Perry binaries are AOT so the
+// list is always empty, and the strip-types invocation Node uses here
+// would otherwise put `--experimental-strip-types` in it. The shape
+// assertions (Array.isArray + every-string) are what callers actually
+// branch on. Regression cover for #1349.
+const argv = process.execArgv;
+console.log("is array:", Array.isArray(argv));
+console.log("all strings:", argv.every((v) => typeof v === "string"));
+console.log("length type:", typeof argv.length);


### PR DESCRIPTION
## Summary

Node's `process.execArgv` is the array of CLI flags the interpreter was started with. Perry was returning the property as a 0 sentinel, so:
- `Array.isArray(process.execArgv)` returned `false`
- `.length` / iteration crashed with type errors

Perry binaries are AOT — there's no runtime flag list to forward — so the empty array is the correct shape. Closes #1349.

## Changes

`expr_member.rs`: both the bare `process.execArgv` and the `globalThis.process.execArgv` paths now lower to `Expr::Array(Vec::new())`, sitting next to the existing `argv` / `versions` / IPC-undefined arms.

## Test plan

- [x] `test-parity/node-suite/process/exec-argv/exec-argv.ts` asserts shape (`Array.isArray` + every-string + `length` type) so it stays parity-clean regardless of which flags Node was invoked with.
- [x] Byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.