### PR TITLE
feat(process): implement process.release (#1348)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -137,6 +137,20 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                     // returns a 0 sentinel and `Array.isArray(...)` /
                     // `.length` / iteration all explode.
                     "execArgv" => return Ok(Expr::Array(Vec::new())),
+                    // #1348: process.release — object describing the
+                    // current runtime release. Node returns at least
+                    // `{ name, sourceUrl, headersUrl }`. Perry binaries
+                    // are AOT and shouldn't pretend to be a Node download
+                    // tarball, but consumers feature-detect on
+                    // `process.release.name === "node"`, so we match that
+                    // shape with empty source/headers URLs.
+                    "release" => {
+                        return Ok(Expr::Object(vec![
+                            ("name".to_string(), Expr::String("node".to_string())),
+                            ("sourceUrl".to_string(), Expr::String(String::new())),
+                            ("headersUrl".to_string(), Expr::String(String::new())),
+                        ]));
+                    }
                     _ => {}
                 }
             }
@@ -198,6 +212,13 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                     "env" => return Ok(Expr::ProcessEnv),
                     "send" | "disconnect" | "connected" => return Ok(Expr::Undefined),
                     "execArgv" => return Ok(Expr::Array(Vec::new())),
+                    "release" => {
+                        return Ok(Expr::Object(vec![
+                            ("name".to_string(), Expr::String("node".to_string())),
+                            ("sourceUrl".to_string(), Expr::String(String::new())),
+                            ("headersUrl".to_string(), Expr::String(String::new())),
+                        ]));
+                    }
                     _ => {}
                 }
             }

--- a/test-parity/node-suite/process/release/release-name.ts
+++ b/test-parity/node-suite/process/release/release-name.ts
@@ -1,0 +1,8 @@
+// process.release — at minimum `{ name: "node" }`. Feature-detection
+// branches on `process.release.name === "node"`. Regression cover for
+// #1348 (Perry was returning a number sentinel, so `.name` exploded).
+const r = process.release;
+console.log("typeof:", typeof r);
+console.log("name:", r.name);
+console.log("sourceUrl typeof:", typeof r.sourceUrl);
+console.log("headersUrl typeof:", typeof r.headersUrl);


### PR DESCRIPTION
## Summary

Node's `process.release` is the object describing the current runtime release — at minimum `{ name, sourceUrl, headersUrl }`. Perry was returning a 0 sentinel, so `process.release.name === "node"` feature-detection returned `undefined` and downstream `.sourceUrl` access threw on undefined.

Closes #1348.

## Changes

`expr_member.rs`: both the bare `process.release` and the `globalThis.process.release` paths lower to an inline `Expr::Object` literal with `name: "node"` and empty `sourceUrl` / `headersUrl` strings. Perry binaries are AOT and shouldn't pretend to be a Node download tarball, so the URLs are empty rather than fabricated — feature-detection only keys off `name`.

Sits next to the `execArgv` arm shipped in #1349.

## Test plan

- [x] `test-parity/node-suite/process/release/release-name.ts` asserts `typeof`, `name`, and the URL field typeof — byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.