### PR TITLE
feat(process): implement process.umask() (#1373)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1857,6 +1857,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("path", "win32"),
     // process — properties mapped to Expr::Process* / Expr::Os* in expr_member.rs.
     method("process", "abort", false, None),
+    method("process", "umask", false, None),
     property("process", "argv"),
     property("process", "platform"),
     property("process", "arch"),

--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -535,6 +535,13 @@ impl JsEmitter {
             Expr::ProcessAbort => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.abort() : undefined)");
             }
+            Expr::ProcessUmask(mask) => {
+                self.output.push_str("(typeof process !== 'undefined' ? process.umask(");
+                if let Some(m) = mask {
+                    self.emit_expr(m);
+                }
+                self.output.push_str(") : 0)");
+            }
             Expr::ProcessStdin => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.stdin : { write: () => true })");
             }

--- a/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
@@ -119,7 +119,8 @@ impl<'a> FuncEmitCtx<'a> {
             | Expr::ProcessOn { .. }
             | Expr::ProcessKill { .. }
             | Expr::ProcessExit(_)
-            | Expr::ProcessAbort => {
+            | Expr::ProcessAbort
+            | Expr::ProcessUmask(_) => {
                 func.instruction(&Instruction::I64Const(TAG_UNDEFINED as i64));
             }
             Expr::EnvGet(_) | Expr::EnvGetDynamic(_) => {

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1097,6 +1097,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ProcessChdir(..)
         | Expr::ProcessExit(..)
         | Expr::ProcessAbort
+        | Expr::ProcessUmask(..)
         | Expr::ObjectGetPrototypeOf(..)
         | Expr::ObjectDefineProperties(..)
         | Expr::ObjectSetPrototypeOf(..)

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -533,14 +533,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         ],
                     ));
                 }
-                // node:process — `process.abort` read as a VALUE (not called).
-                // Bare `process` lowers to the GlobalGet(0) sentinel, so the
-                // receiver name is gone here; route by the process-distinctive
-                // property name through the native-module property helper,
-                // which returns a bound-method closure (typeof "function").
-                // The call form `process.abort()` lowers separately via the
-                // dedicated HIR variant. (#1374)
-                if property.as_str() == "abort" {
+                // node:process — `process.abort` / `process.umask` etc. read
+                // as VALUES (not called). Bare `process` lowers to the
+                // GlobalGet(0) sentinel, so the receiver name is gone here;
+                // route by the process-distinctive property name through the
+                // native-module property helper, which returns a bound-method
+                // closure (typeof "function"). The call forms lower separately
+                // via dedicated HIR variants. (#1374, #1373)
+                if matches!(property.as_str(), "abort" | "umask") {
                     let mod_idx = ctx.strings.intern("process");
                     let mod_bytes_global = format!("@{}", ctx.strings.entry(mod_idx).bytes_global);
                     let mod_len_str = "process".len().to_string();

--- a/crates/perry-codegen/src/expr/string_regex_proc.rs
+++ b/crates/perry-codegen/src/expr/string_regex_proc.rs
@@ -131,6 +131,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             ctx.block().call_void("js_process_abort", &[]);
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }
+        Expr::ProcessUmask(mask) => {
+            // process.umask(mask?) — returns the current file-mode creation
+            // mask as a number. The arg form sets the mask first and returns
+            // the previous value. The no-arg form reads-and-restores so the
+            // mask isn't disturbed.
+            if let Some(e) = mask {
+                let v = lower_expr(ctx, e)?;
+                Ok(ctx
+                    .block()
+                    .call(DOUBLE, "js_process_umask_set", &[(DOUBLE, &v)]))
+            } else {
+                Ok(ctx.block().call(DOUBLE, "js_process_umask", &[]))
+            }
+        }
         Expr::ObjectGetPrototypeOf(o) => {
             // v0.5.751: route through the runtime helper which walks
             // the class registry's parent_class_id chain for INT32-tagged

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -459,6 +459,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_kill", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_process_exit", VOID, &[DOUBLE]);
     module.declare_function("js_process_abort", VOID, &[]);
+    module.declare_function("js_process_umask", DOUBLE, &[]);
+    module.declare_function("js_process_umask_set", DOUBLE, &[DOUBLE]);
     module.declare_function("js_process_on", VOID, &[I64, I64]);
     module.declare_function("js_process_once", VOID, &[I64, I64]);
     module.declare_function("js_process_next_tick", VOID, &[I64]);

--- a/crates/perry-hir/src/audit.rs
+++ b/crates/perry-hir/src/audit.rs
@@ -268,6 +268,7 @@ fn specialized_stdlib_call(expr: &Expr) -> Option<(&'static str, &'static str)> 
         Expr::ProcessCwd => ("process", "cwd"),
         Expr::ProcessArgv => ("process", "argv"),
         Expr::ProcessAbort => ("process", "abort"),
+        Expr::ProcessUmask(_) => ("process", "umask"),
         Expr::ProcessStdinIsTTY => ("process", "stdin.isTTY"),
         Expr::ProcessStdoutIsTTY => ("process", "stdout.isTTY"),
         Expr::ProcessStderrIsTTY => ("process", "stderr.isTTY"),

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -464,6 +464,10 @@ pub enum Expr {
     ProcessExit(Option<Box<Expr>>),
     // process.abort() -> never. Calls SIGABRT to terminate (no clean shutdown).
     ProcessAbort,
+    // process.umask(mask?) -> number. No-arg reads current mask; with-arg
+    // sets and returns the previous mask. Both forms hit the same HIR node;
+    // codegen routes to the read or set runtime helper based on Option.
+    ProcessUmask(Option<Box<Expr>>),
     // process.stdin -> stub object { write: fn }
     ProcessStdin,
     // process.stdout -> stub object { write: fn }

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -116,6 +116,17 @@ pub(super) fn try_native_module_methods(
                             // shutdown. Maps to libc::abort() at runtime.
                             return Ok(Ok(Expr::ProcessAbort));
                         }
+                        "umask" => {
+                            // process.umask(mask?) — returns the current
+                            // file-mode creation mask, optionally setting
+                            // a new one first and returning the previous.
+                            let mask = if !args.is_empty() {
+                                Some(Box::new(args.into_iter().next().unwrap()))
+                            } else {
+                                None
+                            };
+                            return Ok(Ok(Expr::ProcessUmask(mask)));
+                        }
                         _ => {} // Fall through to generic handling
                     }
                 }

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -280,6 +280,10 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
         Expr::ProcessUptime => Expr::ProcessUptime,
         Expr::ProcessMemoryUsage => Expr::ProcessMemoryUsage,
         Expr::ProcessAbort => Expr::ProcessAbort,
+        Expr::ProcessUmask(mask) => Expr::ProcessUmask(
+            mask.as_ref()
+                .map(|e| Box::new(substitute_expr(e, substitutions))),
+        ),
 
         // File system
         Expr::FsReadFileSync(path) => {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -88,6 +88,7 @@ impl SH for Expr {
             Expr::ProcessKill { pid, signal } => { tag(h, 68); pid.as_ref().hash(h); signal.hash(h); }
             Expr::ProcessExit(e) => { tag(h, 69); e.hash(h); }
             Expr::ProcessAbort => tag(h, 11224),
+            Expr::ProcessUmask(e) => { tag(h, 11225); e.hash(h); }
             Expr::ProcessStdin => tag(h, 70),
             Expr::ProcessStdout => tag(h, 71),
             Expr::ProcessStderr => tag(h, 72),

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1042,6 +1042,11 @@ where
                 f(v);
             }
         }
+        Expr::ProcessUmask(opt) => {
+            if let Some(v) = opt {
+                f(v);
+            }
+        }
 
         // ─── Child process ───────────────────────────────────────────────
         Expr::ChildProcessExecSync { command, options } => {

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1023,6 +1023,11 @@ where
                 f(v);
             }
         }
+        Expr::ProcessUmask(opt) => {
+            if let Some(v) = opt {
+                f(v);
+            }
+        }
         Expr::ChildProcessExecSync { command, options } => {
             f(command);
             if let Some(o) = options {

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -276,6 +276,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
     matches!(
         (module, prop),
         ("process", "abort")
+            | ("process", "umask")
             | ("tty", "isatty")
             | ("tty", "ReadStream")
             | ("tty", "WriteStream")

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -47,6 +47,43 @@ pub extern "C" fn js_process_abort() {
     std::process::abort();
 }
 
+/// process.umask() -> number. Returns the current file-mode creation mask
+/// without modifying it. POSIX's `umask` syscall has no read-only form, so
+/// we set the mask to 0, capture the previous value, then restore it.
+#[no_mangle]
+pub extern "C" fn js_process_umask() -> f64 {
+    #[cfg(unix)]
+    unsafe {
+        let prev = libc::umask(0);
+        libc::umask(prev);
+        prev as f64
+    }
+    #[cfg(not(unix))]
+    {
+        0.0
+    }
+}
+
+/// process.umask(mask) -> number. Sets the file-mode creation mask to
+/// `mask` (coerced to integer) and returns the previous value.
+#[no_mangle]
+pub extern "C" fn js_process_umask_set(mask: f64) -> f64 {
+    #[cfg(unix)]
+    unsafe {
+        let m = if mask.is_nan() || mask.is_infinite() {
+            0
+        } else {
+            mask as libc::mode_t
+        };
+        libc::umask(m) as f64
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = mask;
+        0.0
+    }
+}
+
 /// Get an environment variable by name (takes JS string pointer)
 /// Returns a string pointer, or null (0) if not found
 #[no_mangle]

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1101 entries across 80 modules
+// Coverage: 1102 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1469,6 +1469,8 @@ declare module "process" {
   export const versions: any;
   /** stdlib */
   export function abort(...args: any[]): any;
+  /** stdlib */
+  export function umask(...args: any[]): any;
 }
 
 declare module "querystring" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1101 entries across 80 modules.
+Total: 1102 entries across 80 modules.
 
 ## Modules
 
@@ -1407,6 +1407,7 @@ Total: 1101 entries across 80 modules.
 ### Methods
 
 - `abort` — module
+- `umask` — module
 
 ### Properties
 

--- a/test-parity/node-suite/process/methods/umask.ts
+++ b/test-parity/node-suite/process/methods/umask.ts
@@ -1,0 +1,2 @@
+// process.umask() reads the process file-mode creation mask (a number).
+console.log("is number:", typeof process.umask() === "number");


### PR DESCRIPTION
Closes #1373.

## Summary

- `typeof process.umask` now returns `"function"` (was `"undefined"`).
- `process.umask()` returns the current file-mode creation mask (a number); `process.umask(newMask)` sets it and returns the previous value — matches Node.

## Approach

Same shape as #1374:

- `Expr::ProcessUmask(Option<Box<Expr>>)` HIR variant; the call form lowers there. Codegen routes the no-arg form to `js_process_umask` (read-and-restore via `libc::umask(0)` + `libc::umask(prev)`) and the arg form to `js_process_umask_set(mask)`.
- For the value-read form, `PropertyGet` extends the GlobalGet→`js_native_module_property_by_name` arm (previously `"abort"` only) to also handle `"umask"`, and `is_native_module_callable_export` returns true so the bound-method closure has `typeof "function"`.
- `api-manifest` gets `method("process", "umask", ...)` for the typeof short-circuit, SBOM audit, and .d.ts.
- docs/api regenerated.

## Test plan

- [x] `test-parity/node-suite/process/methods/umask.ts` — `typeof process.umask() === "number"` matches Node.
- [x] `cargo fmt --all -- --check` clean.
- [x] All 4 `process` node-suite tests pass (abort, umask, with-args, ref-unref).