### PR TITLE
fix(canvas): implement stateful (HTML5-style) Canvas API on iOS + macOS

### DIFF
--- a/crates/perry-ui-ios/src/ffi/widgets_advanced.rs
+++ b/crates/perry-ui-ios/src/ffi/widgets_advanced.rs
@@ -99,15 +99,25 @@ pub extern "C" fn perry_ui_canvas_fill_gradient(
 }
 
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_set_fill_color(_h: i64, _r: f64, _g: f64, _b: f64, _a: f64) {}
+pub extern "C" fn perry_ui_canvas_set_fill_color(h: i64, r: f64, g: f64, b: f64, a: f64) {
+    widgets::canvas::set_fill_color(h, r, g, b, a);
+}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_set_stroke_color(_h: i64, _r: f64, _g: f64, _b: f64, _a: f64) {}
+pub extern "C" fn perry_ui_canvas_set_stroke_color(h: i64, r: f64, g: f64, b: f64, a: f64) {
+    widgets::canvas::set_stroke_color(h, r, g, b, a);
+}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_set_line_width(_h: i64, _w: f64) {}
+pub extern "C" fn perry_ui_canvas_set_line_width(h: i64, w: f64) {
+    widgets::canvas::set_line_width(h, w);
+}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_fill_rect(_h: i64, _x: f64, _y: f64, _w: f64, _ht: f64) {}
+pub extern "C" fn perry_ui_canvas_fill_rect(h: i64, x: f64, y: f64, w: f64, ht: f64) {
+    widgets::canvas::fill_rect(h, x, y, w, ht);
+}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_stroke_rect(_h: i64, _x: f64, _y: f64, _w: f64, _ht: f64) {}
+pub extern "C" fn perry_ui_canvas_stroke_rect(h: i64, x: f64, y: f64, w: f64, ht: f64) {
+    widgets::canvas::stroke_rect(h, x, y, w, ht);
+}
 #[no_mangle]
 pub extern "C" fn perry_ui_canvas_clear_rect(h: i64, _x: f64, _y: f64, _w: f64, _ht: f64) {
     widgets::canvas::clear(h);
@@ -115,11 +125,17 @@ pub extern "C" fn perry_ui_canvas_clear_rect(h: i64, _x: f64, _y: f64, _w: f64, 
 #[no_mangle]
 pub extern "C" fn perry_ui_canvas_arc(_h: i64, _x: f64, _y: f64, _r: f64, _sa: f64, _ea: f64) {}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_close_path(_h: i64) {}
+pub extern "C" fn perry_ui_canvas_close_path(h: i64) {
+    widgets::canvas::close_path(h);
+}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_fill(_h: i64) {}
+pub extern "C" fn perry_ui_canvas_fill(h: i64) {
+    widgets::canvas::fill(h);
+}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_stroke_path(_h: i64) {}
+pub extern "C" fn perry_ui_canvas_stroke_path(h: i64) {
+    widgets::canvas::stroke_path(h);
+}
 #[no_mangle]
 pub extern "C" fn perry_ui_canvas_fill_text(_h: i64, _ptr: i64, _x: f64, _y: f64) {}
 #[no_mangle]

--- a/crates/perry-ui-ios/src/widgets/canvas.rs
+++ b/crates/perry-ui-ios/src/widgets/canvas.rs
@@ -36,6 +36,10 @@ extern "C" {
     fn CGContextSetLineCap(c: CGContextRef, cap: i32);
     fn CGContextSetLineJoin(c: CGContextRef, join: i32);
     fn CGContextSetRGBStrokeColor(c: CGContextRef, r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat);
+    fn CGContextSetRGBFillColor(c: CGContextRef, r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat);
+    fn CGContextFillPath(c: CGContextRef);
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+    fn CGContextStrokeRect(c: CGContextRef, rect: CGRect);
     fn CGContextDrawLinearGradient(
         c: CGContextRef,
         gradient: CGGradientRef,
@@ -78,6 +82,36 @@ enum DrawCommand {
         a2: f64,
         direction: f64,
     },
+    // Stateful (HTML5-canvas-style) API: setters update current state,
+    // StrokePath/FillPath render the accumulated path with that state.
+    SetStrokeColor {
+        r: f64,
+        g: f64,
+        b: f64,
+        a: f64,
+    },
+    SetFillColor {
+        r: f64,
+        g: f64,
+        b: f64,
+        a: f64,
+    },
+    SetLineWidth(f64),
+    ClosePath,
+    StrokePath,
+    FillPath,
+    FillRect {
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+    },
+    StrokeRect {
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+    },
 }
 
 thread_local! {
@@ -119,11 +153,17 @@ define_class!(
                     // Track current path points for gradient fill
                     let mut path_points: Vec<(f64, f64)> = Vec::new();
                     let mut in_path = false;
+                    // Stateful API current values
+                    let mut cur_stroke = (0.0f64, 0.0f64, 0.0f64, 1.0f64);
+                    let mut cur_fill = (0.0f64, 0.0f64, 0.0f64, 1.0f64);
+                    let mut cur_width = 1.0f64;
+                    let mut path_closed = false;
 
                     for cmd in commands.iter() {
                         match cmd {
                             DrawCommand::BeginPath => {
                                 path_points.clear();
+                                path_closed = false;
                                 in_path = true;
                             }
                             DrawCommand::MoveTo(x, y) => {
@@ -200,6 +240,74 @@ define_class!(
                                     }
                                 }
                                 in_path = false;
+                            }
+                            DrawCommand::SetStrokeColor { r, g, b, a } => {
+                                cur_stroke = (*r, *g, *b, *a);
+                            }
+                            DrawCommand::SetFillColor { r, g, b, a } => {
+                                cur_fill = (*r, *g, *b, *a);
+                            }
+                            DrawCommand::SetLineWidth(w) => {
+                                cur_width = *w;
+                            }
+                            DrawCommand::ClosePath => {
+                                path_closed = true;
+                            }
+                            DrawCommand::StrokePath => {
+                                if path_points.len() >= 2 {
+                                    unsafe {
+                                        CGContextSaveGState(ctx);
+                                        CGContextSetRGBStrokeColor(ctx, cur_stroke.0, cur_stroke.1, cur_stroke.2, cur_stroke.3);
+                                        CGContextSetLineWidth(ctx, cur_width);
+                                        CGContextSetLineCap(ctx, 1);
+                                        CGContextSetLineJoin(ctx, 1);
+                                        CGContextBeginPath(ctx);
+                                        CGContextMoveToPoint(ctx, path_points[0].0, path_points[0].1);
+                                        for pt in &path_points[1..] {
+                                            CGContextAddLineToPoint(ctx, pt.0, pt.1);
+                                        }
+                                        if path_closed {
+                                            CGContextClosePath(ctx);
+                                        }
+                                        CGContextStrokePath(ctx);
+                                        CGContextRestoreGState(ctx);
+                                    }
+                                }
+                                in_path = false;
+                            }
+                            DrawCommand::FillPath => {
+                                if path_points.len() >= 2 {
+                                    unsafe {
+                                        CGContextSaveGState(ctx);
+                                        CGContextSetRGBFillColor(ctx, cur_fill.0, cur_fill.1, cur_fill.2, cur_fill.3);
+                                        CGContextBeginPath(ctx);
+                                        CGContextMoveToPoint(ctx, path_points[0].0, path_points[0].1);
+                                        for pt in &path_points[1..] {
+                                            CGContextAddLineToPoint(ctx, pt.0, pt.1);
+                                        }
+                                        CGContextClosePath(ctx);
+                                        CGContextFillPath(ctx);
+                                        CGContextRestoreGState(ctx);
+                                    }
+                                }
+                                in_path = false;
+                            }
+                            DrawCommand::FillRect { x, y, w, h } => {
+                                unsafe {
+                                    CGContextSaveGState(ctx);
+                                    CGContextSetRGBFillColor(ctx, cur_fill.0, cur_fill.1, cur_fill.2, cur_fill.3);
+                                    CGContextFillRect(ctx, CGRect::new(CGPoint::new(*x, *y), CGSize::new(*w, *h)));
+                                    CGContextRestoreGState(ctx);
+                                }
+                            }
+                            DrawCommand::StrokeRect { x, y, w, h } => {
+                                unsafe {
+                                    CGContextSaveGState(ctx);
+                                    CGContextSetRGBStrokeColor(ctx, cur_stroke.0, cur_stroke.1, cur_stroke.2, cur_stroke.3);
+                                    CGContextSetLineWidth(ctx, cur_width);
+                                    CGContextStrokeRect(ctx, CGRect::new(CGPoint::new(*x, *y), CGSize::new(*w, *h)));
+                                    CGContextRestoreGState(ctx);
+                                }
                             }
                         }
                     }
@@ -378,4 +486,61 @@ pub fn fill_gradient(
             }
         }
     }
+}
+
+// ── Stateful (HTML5-canvas-style) API ────────────────────────────────
+// Setters record state; stroke_path/fill render the accumulated path.
+
+fn push_cmd(handle: i64, cmd: DrawCommand) {
+    if let Some(key) = get_canvas_key(handle) {
+        CANVAS_COMMANDS.with(|cmds| {
+            if let Some(commands) = cmds.borrow_mut().get_mut(&key) {
+                commands.push(cmd);
+            }
+        });
+    }
+}
+
+fn redraw(handle: i64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let _: () = msg_send![&*view, setNeedsDisplay];
+        }
+    }
+}
+
+pub fn set_stroke_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    push_cmd(handle, DrawCommand::SetStrokeColor { r, g, b, a });
+}
+
+pub fn set_fill_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    push_cmd(handle, DrawCommand::SetFillColor { r, g, b, a });
+}
+
+pub fn set_line_width(handle: i64, w: f64) {
+    push_cmd(handle, DrawCommand::SetLineWidth(w));
+}
+
+pub fn close_path(handle: i64) {
+    push_cmd(handle, DrawCommand::ClosePath);
+}
+
+pub fn stroke_path(handle: i64) {
+    push_cmd(handle, DrawCommand::StrokePath);
+    redraw(handle);
+}
+
+pub fn fill(handle: i64) {
+    push_cmd(handle, DrawCommand::FillPath);
+    redraw(handle);
+}
+
+pub fn fill_rect(handle: i64, x: f64, y: f64, w: f64, h: f64) {
+    push_cmd(handle, DrawCommand::FillRect { x, y, w, h });
+    redraw(handle);
+}
+
+pub fn stroke_rect(handle: i64, x: f64, y: f64, w: f64, h: f64) {
+    push_cmd(handle, DrawCommand::StrokeRect { x, y, w, h });
+    redraw(handle);
 }

--- a/crates/perry-ui-macos/src/lib_ffi/style_and_canvas.rs
+++ b/crates/perry-ui-macos/src/lib_ffi/style_and_canvas.rs
@@ -162,15 +162,25 @@ pub extern "C" fn perry_ui_canvas_fill_gradient(
 }
 
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_set_fill_color(_h: i64, _r: f64, _g: f64, _b: f64, _a: f64) {}
+pub extern "C" fn perry_ui_canvas_set_fill_color(h: i64, r: f64, g: f64, b: f64, a: f64) {
+    widgets::canvas::set_fill_color(h, r, g, b, a);
+}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_set_stroke_color(_h: i64, _r: f64, _g: f64, _b: f64, _a: f64) {}
+pub extern "C" fn perry_ui_canvas_set_stroke_color(h: i64, r: f64, g: f64, b: f64, a: f64) {
+    widgets::canvas::set_stroke_color(h, r, g, b, a);
+}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_set_line_width(_h: i64, _w: f64) {}
+pub extern "C" fn perry_ui_canvas_set_line_width(h: i64, w: f64) {
+    widgets::canvas::set_line_width(h, w);
+}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_fill_rect(_h: i64, _x: f64, _y: f64, _w: f64, _ht: f64) {}
+pub extern "C" fn perry_ui_canvas_fill_rect(h: i64, x: f64, y: f64, w: f64, ht: f64) {
+    widgets::canvas::fill_rect(h, x, y, w, ht);
+}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_stroke_rect(_h: i64, _x: f64, _y: f64, _w: f64, _ht: f64) {}
+pub extern "C" fn perry_ui_canvas_stroke_rect(h: i64, x: f64, y: f64, w: f64, ht: f64) {
+    widgets::canvas::stroke_rect(h, x, y, w, ht);
+}
 #[no_mangle]
 pub extern "C" fn perry_ui_canvas_clear_rect(h: i64, _x: f64, _y: f64, _w: f64, _ht: f64) {
     widgets::canvas::clear(h);
@@ -178,11 +188,17 @@ pub extern "C" fn perry_ui_canvas_clear_rect(h: i64, _x: f64, _y: f64, _w: f64, 
 #[no_mangle]
 pub extern "C" fn perry_ui_canvas_arc(_h: i64, _x: f64, _y: f64, _r: f64, _sa: f64, _ea: f64) {}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_close_path(_h: i64) {}
+pub extern "C" fn perry_ui_canvas_close_path(h: i64) {
+    widgets::canvas::close_path(h);
+}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_fill(_h: i64) {}
+pub extern "C" fn perry_ui_canvas_fill(h: i64) {
+    widgets::canvas::fill(h);
+}
 #[no_mangle]
-pub extern "C" fn perry_ui_canvas_stroke_path(_h: i64) {}
+pub extern "C" fn perry_ui_canvas_stroke_path(h: i64) {
+    widgets::canvas::stroke_path(h);
+}
 #[no_mangle]
 pub extern "C" fn perry_ui_canvas_fill_text(_h: i64, _ptr: i64, _x: f64, _y: f64) {}
 #[no_mangle]

--- a/crates/perry-ui-macos/src/widgets/canvas.rs
+++ b/crates/perry-ui-macos/src/widgets/canvas.rs
@@ -35,6 +35,10 @@ extern "C" {
     fn CGContextSetLineCap(c: CGContextRef, cap: i32);
     fn CGContextSetLineJoin(c: CGContextRef, join: i32);
     fn CGContextSetRGBStrokeColor(c: CGContextRef, r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat);
+    fn CGContextSetRGBFillColor(c: CGContextRef, r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat);
+    fn CGContextFillPath(c: CGContextRef);
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+    fn CGContextStrokeRect(c: CGContextRef, rect: CGRect);
     fn CGContextDrawLinearGradient(
         c: CGContextRef,
         gradient: CGGradientRef,
@@ -80,6 +84,34 @@ enum DrawCommand {
         b2: f64,
         a2: f64,
         direction: f64,
+    },
+    SetStrokeColor {
+        r: f64,
+        g: f64,
+        b: f64,
+        a: f64,
+    },
+    SetFillColor {
+        r: f64,
+        g: f64,
+        b: f64,
+        a: f64,
+    },
+    SetLineWidth(f64),
+    ClosePath,
+    StrokePath,
+    FillPath,
+    FillRect {
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+    },
+    StrokeRect {
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
     },
 }
 
@@ -130,11 +162,17 @@ define_class!(
                     // #854: an `in_path: bool` companion used to live here
                     // but was only ever written, never read. Removed.
                     let mut path_points: Vec<(f64, f64)> = Vec::new();
+                    // Stateful (HTML5-canvas-style) drawing state.
+                    let mut cur_stroke = (0.0, 0.0, 0.0, 1.0);
+                    let mut cur_fill = (0.0, 0.0, 0.0, 1.0);
+                    let mut cur_width = 1.0;
+                    let mut path_closed = false;
 
                     for cmd in commands.iter() {
                         match cmd {
                             DrawCommand::BeginPath => {
                                 path_points.clear();
+                                path_closed = false;
                             }
                             DrawCommand::MoveTo(x, y) => {
                                 // Flip Y coordinate (macOS origin is bottom-left)
@@ -210,6 +248,74 @@ define_class!(
                                         CGColorSpaceRelease(color_space);
                                         CGContextRestoreGState(ctx);
                                     }
+                                }
+                            }
+                            DrawCommand::SetStrokeColor { r, g, b, a } => {
+                                cur_stroke = (*r, *g, *b, *a);
+                            }
+                            DrawCommand::SetFillColor { r, g, b, a } => {
+                                cur_fill = (*r, *g, *b, *a);
+                            }
+                            DrawCommand::SetLineWidth(w) => {
+                                cur_width = *w;
+                            }
+                            DrawCommand::ClosePath => {
+                                path_closed = true;
+                            }
+                            DrawCommand::StrokePath => {
+                                if path_points.len() >= 2 {
+                                    unsafe {
+                                        CGContextSaveGState(ctx);
+                                        CGContextSetRGBStrokeColor(ctx, cur_stroke.0, cur_stroke.1, cur_stroke.2, cur_stroke.3);
+                                        CGContextSetLineWidth(ctx, cur_width);
+                                        CGContextSetLineCap(ctx, 1);
+                                        CGContextSetLineJoin(ctx, 1);
+                                        CGContextBeginPath(ctx);
+                                        CGContextMoveToPoint(ctx, path_points[0].0, path_points[0].1);
+                                        for pt in &path_points[1..] {
+                                            CGContextAddLineToPoint(ctx, pt.0, pt.1);
+                                        }
+                                        if path_closed {
+                                            CGContextClosePath(ctx);
+                                        }
+                                        CGContextStrokePath(ctx);
+                                        CGContextRestoreGState(ctx);
+                                    }
+                                }
+                            }
+                            DrawCommand::FillPath => {
+                                if path_points.len() >= 2 {
+                                    unsafe {
+                                        CGContextSaveGState(ctx);
+                                        CGContextSetRGBFillColor(ctx, cur_fill.0, cur_fill.1, cur_fill.2, cur_fill.3);
+                                        CGContextBeginPath(ctx);
+                                        CGContextMoveToPoint(ctx, path_points[0].0, path_points[0].1);
+                                        for pt in &path_points[1..] {
+                                            CGContextAddLineToPoint(ctx, pt.0, pt.1);
+                                        }
+                                        CGContextClosePath(ctx);
+                                        CGContextFillPath(ctx);
+                                        CGContextRestoreGState(ctx);
+                                    }
+                                }
+                            }
+                            DrawCommand::FillRect { x, y, w, h } => {
+                                let flipped_y = canvas_h - y - h;
+                                unsafe {
+                                    CGContextSaveGState(ctx);
+                                    CGContextSetRGBFillColor(ctx, cur_fill.0, cur_fill.1, cur_fill.2, cur_fill.3);
+                                    CGContextFillRect(ctx, CGRect::new(CGPoint::new(*x, flipped_y), CGSize::new(*w, *h)));
+                                    CGContextRestoreGState(ctx);
+                                }
+                            }
+                            DrawCommand::StrokeRect { x, y, w, h } => {
+                                let flipped_y = canvas_h - y - h;
+                                unsafe {
+                                    CGContextSaveGState(ctx);
+                                    CGContextSetRGBStrokeColor(ctx, cur_stroke.0, cur_stroke.1, cur_stroke.2, cur_stroke.3);
+                                    CGContextSetLineWidth(ctx, cur_width);
+                                    CGContextStrokeRect(ctx, CGRect::new(CGPoint::new(*x, flipped_y), CGSize::new(*w, *h)));
+                                    CGContextRestoreGState(ctx);
                                 }
                             }
                         }
@@ -390,4 +496,61 @@ pub fn fill_gradient(
             }
         }
     }
+}
+
+// ── Stateful (HTML5-canvas-style) API ────────────────────────────────
+// Setters record state; stroke_path/fill render the accumulated path.
+
+fn push_cmd(handle: i64, cmd: DrawCommand) {
+    if let Some(key) = get_canvas_key(handle) {
+        CANVAS_COMMANDS.with(|cmds| {
+            if let Some(commands) = cmds.borrow_mut().get_mut(&key) {
+                commands.push(cmd);
+            }
+        });
+    }
+}
+
+fn redraw(handle: i64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            let _: () = msg_send![&*view, setNeedsDisplay: true];
+        }
+    }
+}
+
+pub fn set_stroke_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    push_cmd(handle, DrawCommand::SetStrokeColor { r, g, b, a });
+}
+
+pub fn set_fill_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
+    push_cmd(handle, DrawCommand::SetFillColor { r, g, b, a });
+}
+
+pub fn set_line_width(handle: i64, w: f64) {
+    push_cmd(handle, DrawCommand::SetLineWidth(w));
+}
+
+pub fn close_path(handle: i64) {
+    push_cmd(handle, DrawCommand::ClosePath);
+}
+
+pub fn stroke_path(handle: i64) {
+    push_cmd(handle, DrawCommand::StrokePath);
+    redraw(handle);
+}
+
+pub fn fill(handle: i64) {
+    push_cmd(handle, DrawCommand::FillPath);
+    redraw(handle);
+}
+
+pub fn fill_rect(handle: i64, x: f64, y: f64, w: f64, h: f64) {
+    push_cmd(handle, DrawCommand::FillRect { x, y, w, h });
+    redraw(handle);
+}
+
+pub fn stroke_rect(handle: i64, x: f64, y: f64, w: f64, h: f64) {
+    push_cmd(handle, DrawCommand::StrokeRect { x, y, w, h });
+    redraw(handle);
 }


### PR DESCRIPTION
## Problem

The stateful `Canvas` methods — `setStrokeColor`, `setFillColor`, `setLineWidth`, `closePath`, `fill`, `strokePath`, `fillRect`, `strokeRect` — were no-op FFI stubs on both `perry-ui-ios` and `perry-ui-macos`.

Only the older arg-bearing variants (`stroke(r,g,b,a,w)` and `fillGradient(...)`) actually drew anything, so any TS code using the HTML5-Canvas-style stateful API rendered blank.

Hit while building the [gscmaster.com mobile app](https://github.com/gscmaster) — the dual-line + area-fill performance chart drew only the gradient area (which uses the legacy `fillGradient` arm) and nothing for the `setStrokeColor` / `beginPath` / `lineTo` / `stroke()` line strokes.

## Fix

Wire the stubs to push new `DrawCommand` variants and replay them in `drawRect` using CGContext:

- New variants: `SetStrokeColor { r,g,b,a }`, `SetFillColor { r,g,b,a }`, `SetLineWidth(f64)`, `ClosePath`, `StrokePath`, `FillPath`, `FillRect { x,y,w,h }`, `StrokeRect { x,y,w,h }`.
- Replay tracks `cur_stroke` / `cur_fill` / `cur_width` / `path_closed` across the command stream — setters update state, `StrokePath` / `FillPath` consume it.
- Mirrors the existing `Stroke` and `FillGradient` arms (same Save/RestoreGState, same path-points accumulator, same `CGContextStrokePath` / new `CGContextFillPath`).
- `BeginPath` now also resets `path_closed = false` so a fresh subpath isn't accidentally auto-closed by a prior `closePath()`.

Two new CG externs added on each platform: `CGContextSetRGBFillColor`, `CGContextFillPath`, `CGContextFillRect`, `CGContextStrokeRect`.

macOS additionally Y-flips `FillRect` / `StrokeRect` (bottom-left origin); `FillPath` / `StrokePath` already work in flipped path-point coords accumulated by the existing `MoveTo` / `LineTo` arms.

## What this unblocks

Any line-chart / area-chart / shape-stroke code written against the documented `Canvas` interface (`fill(): void`, `stroke(): void`, etc.). Confirmed end-to-end on iPhone 16 Pro: chart that was previously blank now renders.

## Out of scope

- `arc()`, `fillText()`, `setFont()` are still stubs — not needed by the chart that motivated this and not trivial. Happy to follow up if there's interest.