### PR TITLE
feat(process): implement process.features (#1378)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -151,6 +151,16 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                             ("headersUrl".to_string(), Expr::String(String::new())),
                         ]));
                     }
+                    // #1378: process.features — object of boolean capability
+                    // flags. Consumers feature-detect on individual fields
+                    // (e.g. `process.features.openssl_is_boringssl`); a bare
+                    // read of `process.features` previously returned a 0
+                    // sentinel, so `.X` on it was always undefined. Lower
+                    // to an inline object literal matching the Node shape.
+                    // All Perry flags are `false` except `ipv6` (the
+                    // runtime's `node:dgram`/network stack handles it) —
+                    // the literal mirrors what we actually link in.
+                    "features" => return Ok(process_features_literal()),
                     _ => {}
                 }
             }
@@ -219,6 +229,7 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                             ("headersUrl".to_string(), Expr::String(String::new())),
                         ]));
                     }
+                    "features" => return Ok(process_features_literal()),
                     _ => {}
                 }
             }
@@ -1186,4 +1197,37 @@ fn is_stream_api_member(module: &str, prop: &str) -> bool {
         "transform_stream" => matches!(prop, "readable" | "writable"),
         _ => false,
     }
+}
+
+/// #1378: `process.features` literal. Boolean capability flags Node
+/// exposes so libraries can detect what the runtime links in. Perry
+/// links its own networking/TLS stack; the values here reflect what
+/// the runtime *actually* supports, not what Node would say — readers
+/// generally branch on `openssl_is_boringssl` / `quic` / `typescript`
+/// rather than rejecting any unrecognised value, so a Perry-honest
+/// shape is safer than parroting Node's.
+fn process_features_literal() -> Expr {
+    fn b(k: &str, v: bool) -> (String, Expr) {
+        (k.to_string(), Expr::Bool(v))
+    }
+    Expr::Object(vec![
+        b("inspector", false),
+        b("debug", false),
+        b("uv", false),
+        b("ipv6", true),
+        b("tls_alpn", true),
+        b("tls_sni", true),
+        b("tls_ocsp", true),
+        b("tls", true),
+        b("openssl_is_boringssl", false),
+        b("cached_builtins", false),
+        b("require_module", false),
+        b("quic", false),
+        // Perry compiles TypeScript natively (AOT) — surface as
+        // `"transform"` to distinguish from Node's `"strip"` mode.
+        (
+            "typescript".to_string(),
+            Expr::String("transform".to_string()),
+        ),
+    ])
 }

--- a/test-parity/node-suite/process/features/features.ts
+++ b/test-parity/node-suite/process/features/features.ts
@@ -1,0 +1,15 @@
+// process.features — object of boolean capability flags. Consumers
+// branch on individual fields (TLS variant, openssl/boringssl,
+// IPv6 availability). Regression cover for #1378 (Perry was
+// returning a 0 sentinel, so any field read was undefined).
+//
+// Cross-runtime parity is checked on _shape_ rather than the specific
+// flag values: Perry's TLS/IPv6/typescript story doesn't have to match
+// Node bit-for-bit, only the field types.
+const f = process.features;
+console.log("typeof:", typeof f);
+console.log("tls type:", typeof f.tls);
+console.log("ipv6 type:", typeof f.ipv6);
+console.log("openssl_is_boringssl type:", typeof f.openssl_is_boringssl);
+console.log("tls_alpn type:", typeof f.tls_alpn);
+console.log("inspector type:", typeof f.inspector);


### PR DESCRIPTION
## Summary

Node's `process.features` is an object of boolean capability flags (`tls`, `ipv6`, `inspector`, `openssl_is_boringssl`, ...) — consumers branch on individual fields to detect what the runtime links in. Perry was returning a 0 sentinel, so reading any field came back `undefined`.

Closes #1378.

## Changes

`expr_member.rs`: both the bare `process.features` and `globalThis.process.features` paths lower to an inline `Expr::Object` literal built by a new `process_features_literal()` helper.

Values reflect what Perry's runtime actually supports — `tls`/`ipv6`/`tls_alpn`/`tls_sni`/`tls_ocsp` true, `inspector`/`debug`/`uv`/`openssl_is_boringssl`/`cached_builtins`/`require_module`/`quic` false. `typescript: "transform"` distinguishes Perry's native (AOT) TS compilation from Node's `"strip"` mode.

Sits next to the `release` / `execArgv` arms shipped in #1348 / #1349.

## Test plan

- [x] `test-parity/node-suite/process/features/features.ts` asserts **shape** (typeof per field) rather than specific values, so the parity check survives any future Node version bumping individual flags.
- [x] Byte-identical to `node --experimental-strip-types` on the typeof assertions.
- [x] `cargo fmt --all -- --check` clean.