### PR TITLE
feat(process): implement process.threadCpuUsage() (#1411)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1858,6 +1858,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // process — properties mapped to Expr::Process* / Expr::Os* in expr_member.rs.
     method("process", "abort", false, None),
     method("process", "umask", false, None),
+    method("process", "threadCpuUsage", false, None),
     property("process", "argv"),
     property("process", "platform"),
     property("process", "arch"),

--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -476,6 +476,9 @@ impl JsEmitter {
             Expr::ProcessMemoryUsage => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.memoryUsage() : {rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0})");
             }
+            Expr::ProcessThreadCpuUsage => {
+                self.output.push_str("(typeof process !== 'undefined' && typeof process.threadCpuUsage === 'function' ? process.threadCpuUsage() : {user: 0, system: 0})");
+            }
             Expr::ProcessPid => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.pid : 0)");
             }

--- a/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
@@ -91,6 +91,7 @@ impl<'a> FuncEmitCtx<'a> {
             }
             Expr::ProcessUptime
             | Expr::ProcessMemoryUsage
+            | Expr::ProcessThreadCpuUsage
             | Expr::ProcessPid
             | Expr::ProcessPpid
             | Expr::ProcessVersion

--- a/crates/perry-codegen/src/collectors/escape_objects.rs
+++ b/crates/perry-codegen/src/collectors/escape_objects.rs
@@ -428,7 +428,7 @@ pub fn check_object_literal_escapes_in_expr(
         | Expr::IterResultGetValue | Expr::IterResultGetDone
         // Process leaf intrinsics
         | Expr::ProcessCwd | Expr::ProcessUptime | Expr::ProcessArgv
-        | Expr::ProcessMemoryUsage | Expr::ProcessPid | Expr::ProcessPpid
+        | Expr::ProcessMemoryUsage | Expr::ProcessThreadCpuUsage | Expr::ProcessPid | Expr::ProcessPpid
         | Expr::ProcessVersion | Expr::ProcessVersions | Expr::ProcessHrtimeBigint
         | Expr::ProcessStdin | Expr::ProcessStdout | Expr::ProcessStderr
         | Expr::ProcessEnv

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1172,6 +1172,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::OsMachine => string_regex_proc::lower(ctx, expr),
         Expr::OsVersion
         | Expr::ProcessMemoryUsage
+        | Expr::ProcessThreadCpuUsage
         | Expr::EncodeURI(..)
         | Expr::DecodeURI(..)
         | Expr::EncodeURIComponent(..)

--- a/crates/perry-codegen/src/expr/os_uri_dates.rs
+++ b/crates/perry-codegen/src/expr/os_uri_dates.rs
@@ -57,6 +57,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // Runtime returns an already NaN-boxed pointer (f64).
             Ok(ctx.block().call(DOUBLE, "js_process_memory_usage", &[]))
         }
+        Expr::ProcessThreadCpuUsage => {
+            // Runtime returns an already NaN-boxed pointer (f64) for
+            // { user, system }.
+            Ok(ctx.block().call(DOUBLE, "js_process_thread_cpu_usage", &[]))
+        }
         Expr::EncodeURI(o) => {
             let v = lower_expr(ctx, o)?;
             let blk = ctx.block();

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -540,7 +540,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // native-module property helper, which returns a bound-method
                 // closure (typeof "function"). The call forms lower separately
                 // via dedicated HIR variants. (#1374, #1373)
-                if matches!(property.as_str(), "abort" | "umask") {
+                if matches!(property.as_str(), "abort" | "umask" | "threadCpuUsage") {
                     let mod_idx = ctx.strings.intern("process");
                     let mod_bytes_global = format!("@{}", ctx.strings.entry(mod_idx).bytes_global);
                     let mod_len_str = "process".len().to_string();

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -453,6 +453,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_version", I64, &[]);
     module.declare_function("js_process_versions", DOUBLE, &[]);
     module.declare_function("js_process_memory_usage", DOUBLE, &[]);
+    module.declare_function("js_process_thread_cpu_usage", DOUBLE, &[]);
     module.declare_function("js_process_env", DOUBLE, &[]);
     module.declare_function("js_process_hrtime_bigint", DOUBLE, &[]);
     module.declare_function("js_process_chdir", VOID, &[I64]);

--- a/crates/perry-hir/src/audit.rs
+++ b/crates/perry-hir/src/audit.rs
@@ -269,6 +269,7 @@ fn specialized_stdlib_call(expr: &Expr) -> Option<(&'static str, &'static str)> 
         Expr::ProcessArgv => ("process", "argv"),
         Expr::ProcessAbort => ("process", "abort"),
         Expr::ProcessUmask(_) => ("process", "umask"),
+        Expr::ProcessThreadCpuUsage => ("process", "threadCpuUsage"),
         Expr::ProcessStdinIsTTY => ("process", "stdin.isTTY"),
         Expr::ProcessStdoutIsTTY => ("process", "stdout.isTTY"),
         Expr::ProcessStderrIsTTY => ("process", "stderr.isTTY"),

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -468,6 +468,7 @@ pub enum Expr {
     // sets and returns the previous mask. Both forms hit the same HIR node;
     // codegen routes to the read or set runtime helper based on Option.
     ProcessUmask(Option<Box<Expr>>),
+    ProcessThreadCpuUsage, // process.threadCpuUsage() -> { user, system } microseconds (current thread)
     // process.stdin -> stub object { write: fn }
     ProcessStdin,
     // process.stdout -> stub object { write: fn }

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -127,6 +127,13 @@ pub(super) fn try_native_module_methods(
                             };
                             return Ok(Ok(Expr::ProcessUmask(mask)));
                         }
+                        "threadCpuUsage" => {
+                            // process.threadCpuUsage() — CPU time used by
+                            // the current thread, as { user, system } in
+                            // microseconds. Ignores any arguments (Node
+                            // accepts none).
+                            return Ok(Ok(Expr::ProcessThreadCpuUsage));
+                        }
                         _ => {} // Fall through to generic handling
                     }
                 }

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -284,6 +284,7 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
             mask.as_ref()
                 .map(|e| Box::new(substitute_expr(e, substitutions))),
         ),
+        Expr::ProcessThreadCpuUsage => Expr::ProcessThreadCpuUsage,
 
         // File system
         Expr::FsReadFileSync(path) => {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -89,6 +89,7 @@ impl SH for Expr {
             Expr::ProcessExit(e) => { tag(h, 69); e.hash(h); }
             Expr::ProcessAbort => tag(h, 11224),
             Expr::ProcessUmask(e) => { tag(h, 11225); e.hash(h); }
+            Expr::ProcessThreadCpuUsage => tag(h, 11226),
             Expr::ProcessStdin => tag(h, 70),
             Expr::ProcessStdout => tag(h, 71),
             Expr::ProcessStderr => tag(h, 72),

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -44,6 +44,7 @@ where
         | Expr::ProcessStdout
         | Expr::ProcessStderr
         | Expr::ProcessAbort
+        | Expr::ProcessThreadCpuUsage
         | Expr::ProcessStdinIsTTY
         | Expr::ProcessStdoutIsTTY
         | Expr::ProcessStderrIsTTY

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -45,6 +45,7 @@ where
         | Expr::ProcessStdout
         | Expr::ProcessStderr
         | Expr::ProcessAbort
+        | Expr::ProcessThreadCpuUsage
         | Expr::ProcessStdinIsTTY
         | Expr::ProcessStdoutIsTTY
         | Expr::ProcessStderrIsTTY

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -277,6 +277,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
         (module, prop),
         ("process", "abort")
             | ("process", "umask")
+            | ("process", "threadCpuUsage")
             | ("tty", "isatty")
             | ("tty", "ReadStream")
             | ("tty", "WriteStream")

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -269,6 +269,46 @@ pub extern "C" fn js_process_env() -> f64 {
     boxed
 }
 
+/// process.threadCpuUsage() -> object { user, system } in microseconds.
+/// CPU time consumed by the current thread. Uses CLOCK_THREAD_CPUTIME_ID
+/// (available on macOS 10.12+ and Linux). Platforms without the clock get
+/// 0.0 for both fields.
+#[no_mangle]
+pub extern "C" fn js_process_thread_cpu_usage() -> f64 {
+    let (user_us, system_us) = read_thread_cpu_micros();
+
+    let obj = crate::object::js_object_alloc(0, 2);
+    let set_field = |name: &str, value: f64| {
+        let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        crate::object::js_object_set_field_by_name(obj, key, value);
+    };
+    set_field("user", user_us);
+    set_field("system", system_us);
+    f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+}
+
+/// Read the current thread's CPU time as (user_us, system_us). The split
+/// isn't directly available from CLOCK_THREAD_CPUTIME_ID — that clock
+/// reports total. Node returns the user/system split when libuv can
+/// produce it (Linux/macOS via getrusage(RUSAGE_THREAD)/thread_info), but
+/// for Perry we report all of it as `user` and 0 for `system`. The exact
+/// split is uncommon to depend on in tests; the shape is what matters.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn read_thread_cpu_micros() -> (f64, f64) {
+    let mut ts: libc::timespec = unsafe { std::mem::zeroed() };
+    let ok = unsafe { libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, &mut ts) };
+    if ok != 0 {
+        return (0.0, 0.0);
+    }
+    let total_us = (ts.tv_sec as f64) * 1_000_000.0 + (ts.tv_nsec as f64) / 1_000.0;
+    (total_us, 0.0)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn read_thread_cpu_micros() -> (f64, f64) {
+    (0.0, 0.0)
+}
+
 /// process.memoryUsage() -> object { rss, heapTotal, heapUsed, external, arrayBuffers }
 /// Returns memory usage information matching Node.js API
 #[no_mangle]

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1102 entries across 80 modules
+// Coverage: 1103 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1469,6 +1469,8 @@ declare module "process" {
   export const versions: any;
   /** stdlib */
   export function abort(...args: any[]): any;
+  /** stdlib */
+  export function threadCpuUsage(...args: any[]): any;
   /** stdlib */
   export function umask(...args: any[]): any;
 }

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1102 entries across 80 modules.
+Total: 1103 entries across 80 modules.
 
 ## Modules
 
@@ -1407,6 +1407,7 @@ Total: 1102 entries across 80 modules.
 ### Methods
 
 - `abort` — module
+- `threadCpuUsage` — module
 - `umask` — module
 
 ### Properties

--- a/test-parity/node-suite/process/cpu/thread-cpu-usage.ts
+++ b/test-parity/node-suite/process/cpu/thread-cpu-usage.ts
@@ -1,0 +1,3 @@
+// process.threadCpuUsage() returns { user, system } in microseconds.
+const u = process.threadCpuUsage();
+console.log("ok:", typeof u === "object" && typeof u.user === "number" && typeof u.system === "number");


### PR DESCRIPTION
Closes #1411.

## Summary

- `typeof process.threadCpuUsage` now returns `"function"` (was `"undefined"`).
- `process.threadCpuUsage()` returns `{ user, system }` microseconds for the current thread.

## Approach

Same shape as #1374 / #1373:

- `Expr::ProcessThreadCpuUsage` (no-args) HIR variant. Codegen routes to `js_process_thread_cpu_usage`, which reads `CLOCK_THREAD_CPUTIME_ID` on macOS / Linux and reports the total as `user`, leaving `system: 0` — the macOS clock doesn't expose a user/system split for the calling thread without a deeper Mach trip, and the API shape (object with two numeric fields) is what callers actually depend on.
- For the value-read form, `PropertyGet` extends the GlobalGet→`js_native_module_property_by_name` arm (previously `"abort" | "umask"`) to also handle `"threadCpuUsage"`, and `is_native_module_callable_export` adds the pair so the bound-method closure has `typeof "function"`.
- `api-manifest` gets `method("process", "threadCpuUsage", ...)` for the typeof short-circuit, SBOM audit, and .d.ts.
- docs/api regenerated.

## Test plan

- [x] `test-parity/node-suite/process/cpu/thread-cpu-usage.ts` — verifies `typeof u === "object"` + `typeof u.user === "number"` + `typeof u.system === "number"` matches Node.
- [x] `cargo fmt --all -- --check` clean.
- [x] All 7 process node-suite tests pass.