### PR TITLE
feat(process): implement sourceMapsEnabled + setSourceMapsEnabled (#1400)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -96,6 +96,16 @@ pub(super) fn try_native_module_methods(
                             // "value is not a function".
                             return Ok(Ok(Expr::Undefined));
                         }
+                        "setSourceMapsEnabled" => {
+                            // #1400: process.setSourceMapsEnabled(bool) —
+                            // toggles runtime source-map resolution in Node.
+                            // Perry compiles AOT and has no resolver to
+                            // toggle, so the call is a no-op returning
+                            // undefined. Without this, framework startup
+                            // code that conditionally enables maps crashes
+                            // on "value is not a function".
+                            return Ok(Ok(Expr::Undefined));
+                        }
                         "exit" => {
                             // process.exit() / process.exit(code) — never
                             // returns, terminates the process. Until now this

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -161,6 +161,15 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                     // runtime's `node:dgram`/network stack handles it) —
                     // the literal mirrors what we actually link in.
                     "features" => return Ok(process_features_literal()),
+                    // #1400: process.sourceMapsEnabled — boolean indicating
+                    // whether the runtime's source-map support is on. Perry
+                    // compiles AOT and doesn't ship a source-map resolver,
+                    // so the value is always false. Without this arm the
+                    // bare read returned a 0 sentinel — falsy in a boolean
+                    // context but `typeof` was `"number"`, so libraries
+                    // doing `typeof process.sourceMapsEnabled === "boolean"`
+                    // bailed out (e.g. some Vitest stack-trace formatters).
+                    "sourceMapsEnabled" => return Ok(Expr::Bool(false)),
                     _ => {}
                 }
             }
@@ -230,6 +239,7 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                         ]));
                     }
                     "features" => return Ok(process_features_literal()),
+                    "sourceMapsEnabled" => return Ok(Expr::Bool(false)),
                     _ => {}
                 }
             }

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -601,14 +601,15 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                             {
                                 return Ok(Expr::String("function".to_string()));
                             }
-                            // #1410: `typeof process.ref` / `typeof process.unref`.
-                            // The methods are pure no-op stubs that lower to
-                            // `Expr::Undefined` when called; a bare member
-                            // read still falls through to the generic process
-                            // member path (returns 0 / "number" typeof), so
-                            // fold to "function" here to match Node.
+                            // #1410 / #1400: `typeof process.ref` / `typeof
+                            // process.unref` / `typeof process.setSourceMapsEnabled`.
+                            // These methods lower to `Expr::Undefined` /
+                            // no-ops when called; a bare member read still
+                            // falls through to the generic process member
+                            // path (returns 0 / "number" typeof), so fold
+                            // to "function" here to match Node.
                             if obj_name == "process"
-                                && matches!(prop_name, "ref" | "unref")
+                                && matches!(prop_name, "ref" | "unref" | "setSourceMapsEnabled")
                                 && ctx.lookup_local("process").is_none()
                             {
                                 return Ok(Expr::String("function".to_string()));

--- a/test-parity/node-suite/process/methods/source-maps-enabled.ts
+++ b/test-parity/node-suite/process/methods/source-maps-enabled.ts
@@ -1,0 +1,9 @@
+// process.sourceMapsEnabled (boolean getter) + process.setSourceMapsEnabled
+// (function). Perry is AOT and doesn't ship a source-map resolver, so the
+// getter always reads false and the setter is a no-op. Tests on shape only
+// since Node's exact toggle behavior depends on --enable-source-maps.
+// Regression cover for #1400.
+console.log("sourceMapsEnabled typeof:", typeof process.sourceMapsEnabled);
+console.log("setSourceMapsEnabled typeof:", typeof process.setSourceMapsEnabled);
+console.log("setSourceMapsEnabled returns:", process.setSourceMapsEnabled(true));
+console.log("setSourceMapsEnabled false ok:", process.setSourceMapsEnabled(false));


### PR DESCRIPTION
## Summary

- `process.sourceMapsEnabled` (boolean getter exposing the runtime's source-map state) → lowers to `Expr::Bool(false)`. Perry compiles AOT and ships no source-map resolver.
- `process.setSourceMapsEnabled(bool)` (no-op for Perry) → lowers to `Expr::Undefined` in `native_module.rs`.
- `typeof process.setSourceMapsEnabled` → folds to `"function"` in `lower_expr.rs`, joining the existing `ref`/`unref` arm from #1410.

Closes #1400.

Before this, `typeof process.sourceMapsEnabled` returned `"number"` (the 0 sentinel), and calling `process.setSourceMapsEnabled(...)` threw "value is not a function".

## Test plan

- [x] `test-parity/node-suite/process/methods/source-maps-enabled.ts` asserts shape (typeof + setter return) — byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.