### PR TITLE
test(parity): perf_hooks audit-5 — markResourceTiming, toStringTag, disconnect-idempotent

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -26,6 +26,18 @@
     "category": "bug-open",
     "reason": "node:perf_hooks: createHistogram() unimplemented (not a function). Flips to PASS when #1336 lands."
   },
+  "node-suite/perf_hooks/resource-timing/mark-resource-timing": {
+    "issue": "1478",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:perf_hooks: performance.markResourceTiming is unimplemented (not a function). Flips to PASS when #1478 lands."
+  },
+  "node-suite/perf_hooks/shapes/to-string-tag": {
+    "issue": "1479",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:perf_hooks: Object.prototype.toString.call(performance) yields the generic object tag instead of '[object Performance]'. Flips to PASS when #1479 lands."
+  },
   "node-suite/console/dir/depth-options": {
     "issue": "1199",
     "added": "2026-05-20",

--- a/test-parity/node-suite/perf_hooks/observer/disconnect-idempotent.ts
+++ b/test-parity/node-suite/perf_hooks/observer/disconnect-idempotent.ts
@@ -1,0 +1,13 @@
+import { PerformanceObserver } from "node:perf_hooks";
+// PerformanceObserver#disconnect() is idempotent — calling it again after
+// the observer is already disconnected is a no-op (does not throw).
+const obs = new PerformanceObserver(() => {});
+obs.observe({ entryTypes: ["mark"] });
+obs.disconnect();
+let threw = false;
+try {
+  obs.disconnect();
+} catch {
+  threw = true;
+}
+console.log("double-disconnect threw:", threw);

--- a/test-parity/node-suite/perf_hooks/resource-timing/mark-resource-timing.ts
+++ b/test-parity/node-suite/perf_hooks/resource-timing/mark-resource-timing.ts
@@ -1,0 +1,4 @@
+import { performance } from "node:perf_hooks";
+// performance.markResourceTiming(info) records a resource-timing entry
+// (paired with clearResourceTimings / setResourceTimingBufferSize).
+console.log("is function:", typeof performance.markResourceTiming === "function");

--- a/test-parity/node-suite/perf_hooks/shapes/to-string-tag.ts
+++ b/test-parity/node-suite/perf_hooks/shapes/to-string-tag.ts
@@ -1,0 +1,4 @@
+import { performance } from "node:perf_hooks";
+// Performance has a Symbol.toStringTag of "Performance", so
+// Object.prototype.toString returns "[object Performance]".
+console.log("tag:", Object.prototype.toString.call(performance));


### PR DESCRIPTION
Fifth-pass audit on `node:perf_hooks` after #1391 merged. 3 new granular cases for the remaining surface against Node, validated in a worktree off current main.

## New passing
- `observer/disconnect-idempotent` — `PerformanceObserver#disconnect()` is idempotent (double-disconnect doesn't throw)

## New gaps — each its own granular issue
- `performance.markResourceTiming` (function) → **#1478**
- `Object.prototype.toString.call(performance) === "[object Performance]"` (`Symbol.toStringTag`) → **#1479**

Recorded in `known_failures.json`. No version bump / CHANGELOG.