### PR TITLE
feat(process): implement process.config (#1379)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -197,6 +197,19 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                             ("unregister".to_string(), Expr::Undefined),
                         ]));
                     }
+                    // #1379: process.config — object describing build-time
+                    // config (`{ variables, target_defaults }` in Node).
+                    // Perry has no `node-gyp`-style build to surface, but
+                    // consumers feature-detect on `process.config.variables`
+                    // existing (or specific fields like `target_arch`), so
+                    // return the shape with empty sub-objects rather than
+                    // letting the bare read fall through to the 0 sentinel.
+                    "config" => {
+                        return Ok(Expr::Object(vec![
+                            ("variables".to_string(), Expr::Object(Vec::new())),
+                            ("target_defaults".to_string(), Expr::Object(Vec::new())),
+                        ]));
+                    }
                     _ => {}
                 }
             }
@@ -273,6 +286,12 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                             ("register".to_string(), Expr::Undefined),
                             ("registerBeforeExit".to_string(), Expr::Undefined),
                             ("unregister".to_string(), Expr::Undefined),
+                        ]));
+                    }
+                    "config" => {
+                        return Ok(Expr::Object(vec![
+                            ("variables".to_string(), Expr::Object(Vec::new())),
+                            ("target_defaults".to_string(), Expr::Object(Vec::new())),
                         ]));
                     }
                     _ => {}

--- a/test-parity/node-suite/process/config/config.ts
+++ b/test-parity/node-suite/process/config/config.ts
@@ -1,0 +1,10 @@
+// process.config — build-time config object. Node exposes
+// `{ variables, target_defaults }` populated from node-gyp's GYP file.
+// Perry compiles AOT with no gyp file to surface, so the sub-objects
+// are empty but the shape (typeof) is preserved. Regression cover for
+// #1379. Asserts shape only since exact contents are Node-version /
+// build-tooling specific.
+const c = process.config;
+console.log("typeof:", typeof c);
+console.log("variables typeof:", typeof c.variables);
+console.log("target_defaults typeof:", typeof c.target_defaults);


### PR DESCRIPTION
## Summary

Node's `process.config` is the build-time config object — `{ variables, target_defaults }` populated by node-gyp at build time. Perry was returning a 0 sentinel, so `process.config.variables` threw on undefined and `Object.keys(process.config)` crashed.

Perry has no gyp file to surface, so the sub-objects are empty — the shape preserves consumer feature-detection paths (`process.config?.variables?.target_arch`, etc.).

Closes #1379.

## Changes

`expr_member.rs`: both bare `process.config` and the `globalThis.process.config` paths lower to an inline `Expr::Object` literal sitting next to the `release` / `features` arms shipped in #1348 / #1378.

Test fixture is force-added to skirt the root `.gitignore`'s top-level `config` rule (which targets binary outputs); the parity path is fixed by the issue's repro.

## Test plan

- [x] `test-parity/node-suite/process/config/config.ts` asserts shape (typeof top-level + sub-objects) — byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.