### PR TITLE
feat(process): implement availableMemory() + constrainedMemory() (#1377)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1859,6 +1859,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("process", "abort", false, None),
     method("process", "umask", false, None),
     method("process", "threadCpuUsage", false, None),
+    method("process", "availableMemory", false, None),
+    method("process", "constrainedMemory", false, None),
     property("process", "argv"),
     property("process", "platform"),
     property("process", "arch"),

--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -479,6 +479,12 @@ impl JsEmitter {
             Expr::ProcessThreadCpuUsage => {
                 self.output.push_str("(typeof process !== 'undefined' && typeof process.threadCpuUsage === 'function' ? process.threadCpuUsage() : {user: 0, system: 0})");
             }
+            Expr::ProcessAvailableMemory => {
+                self.output.push_str("(typeof process !== 'undefined' && typeof process.availableMemory === 'function' ? process.availableMemory() : 0)");
+            }
+            Expr::ProcessConstrainedMemory => {
+                self.output.push_str("(typeof process !== 'undefined' && typeof process.constrainedMemory === 'function' ? process.constrainedMemory() : 0)");
+            }
             Expr::ProcessPid => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.pid : 0)");
             }

--- a/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
@@ -92,6 +92,8 @@ impl<'a> FuncEmitCtx<'a> {
             Expr::ProcessUptime
             | Expr::ProcessMemoryUsage
             | Expr::ProcessThreadCpuUsage
+            | Expr::ProcessAvailableMemory
+            | Expr::ProcessConstrainedMemory
             | Expr::ProcessPid
             | Expr::ProcessPpid
             | Expr::ProcessVersion

--- a/crates/perry-codegen/src/collectors/escape_objects.rs
+++ b/crates/perry-codegen/src/collectors/escape_objects.rs
@@ -428,7 +428,9 @@ pub fn check_object_literal_escapes_in_expr(
         | Expr::IterResultGetValue | Expr::IterResultGetDone
         // Process leaf intrinsics
         | Expr::ProcessCwd | Expr::ProcessUptime | Expr::ProcessArgv
-        | Expr::ProcessMemoryUsage | Expr::ProcessThreadCpuUsage | Expr::ProcessPid | Expr::ProcessPpid
+        | Expr::ProcessMemoryUsage | Expr::ProcessThreadCpuUsage
+        | Expr::ProcessAvailableMemory | Expr::ProcessConstrainedMemory
+        | Expr::ProcessPid | Expr::ProcessPpid
         | Expr::ProcessVersion | Expr::ProcessVersions | Expr::ProcessHrtimeBigint
         | Expr::ProcessStdin | Expr::ProcessStdout | Expr::ProcessStderr
         | Expr::ProcessEnv

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1173,6 +1173,8 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::OsVersion
         | Expr::ProcessMemoryUsage
         | Expr::ProcessThreadCpuUsage
+        | Expr::ProcessAvailableMemory
+        | Expr::ProcessConstrainedMemory
         | Expr::EncodeURI(..)
         | Expr::DecodeURI(..)
         | Expr::EncodeURIComponent(..)

--- a/crates/perry-codegen/src/expr/os_uri_dates.rs
+++ b/crates/perry-codegen/src/expr/os_uri_dates.rs
@@ -62,6 +62,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // { user, system }.
             Ok(ctx.block().call(DOUBLE, "js_process_thread_cpu_usage", &[]))
         }
+        Expr::ProcessAvailableMemory => {
+            Ok(ctx.block().call(DOUBLE, "js_process_available_memory", &[]))
+        }
+        Expr::ProcessConstrainedMemory => {
+            Ok(ctx
+                .block()
+                .call(DOUBLE, "js_process_constrained_memory", &[]))
+        }
         Expr::EncodeURI(o) => {
             let v = lower_expr(ctx, o)?;
             let blk = ctx.block();

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -540,7 +540,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // native-module property helper, which returns a bound-method
                 // closure (typeof "function"). The call forms lower separately
                 // via dedicated HIR variants. (#1374, #1373)
-                if matches!(property.as_str(), "abort" | "umask" | "threadCpuUsage") {
+                if matches!(
+                    property.as_str(),
+                    "abort" | "umask" | "threadCpuUsage" | "availableMemory" | "constrainedMemory"
+                ) {
                     let mod_idx = ctx.strings.intern("process");
                     let mod_bytes_global = format!("@{}", ctx.strings.entry(mod_idx).bytes_global);
                     let mod_len_str = "process".len().to_string();

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -454,6 +454,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_versions", DOUBLE, &[]);
     module.declare_function("js_process_memory_usage", DOUBLE, &[]);
     module.declare_function("js_process_thread_cpu_usage", DOUBLE, &[]);
+    module.declare_function("js_process_available_memory", DOUBLE, &[]);
+    module.declare_function("js_process_constrained_memory", DOUBLE, &[]);
     module.declare_function("js_process_env", DOUBLE, &[]);
     module.declare_function("js_process_hrtime_bigint", DOUBLE, &[]);
     module.declare_function("js_process_chdir", VOID, &[I64]);

--- a/crates/perry-hir/src/audit.rs
+++ b/crates/perry-hir/src/audit.rs
@@ -270,6 +270,8 @@ fn specialized_stdlib_call(expr: &Expr) -> Option<(&'static str, &'static str)> 
         Expr::ProcessAbort => ("process", "abort"),
         Expr::ProcessUmask(_) => ("process", "umask"),
         Expr::ProcessThreadCpuUsage => ("process", "threadCpuUsage"),
+        Expr::ProcessAvailableMemory => ("process", "availableMemory"),
+        Expr::ProcessConstrainedMemory => ("process", "constrainedMemory"),
         Expr::ProcessStdinIsTTY => ("process", "stdin.isTTY"),
         Expr::ProcessStdoutIsTTY => ("process", "stdout.isTTY"),
         Expr::ProcessStderrIsTTY => ("process", "stderr.isTTY"),

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -464,11 +464,10 @@ pub enum Expr {
     ProcessExit(Option<Box<Expr>>),
     // process.abort() -> never. Calls SIGABRT to terminate (no clean shutdown).
     ProcessAbort,
-    // process.umask(mask?) -> number. No-arg reads current mask; with-arg
-    // sets and returns the previous mask. Both forms hit the same HIR node;
-    // codegen routes to the read or set runtime helper based on Option.
-    ProcessUmask(Option<Box<Expr>>),
+    ProcessUmask(Option<Box<Expr>>), // process.umask(mask?) -> number; no-arg reads, arg sets and returns previous
     ProcessThreadCpuUsage, // process.threadCpuUsage() -> { user, system } microseconds (current thread)
+    ProcessAvailableMemory, // process.availableMemory() -> number (free memory bytes)
+    ProcessConstrainedMemory, // process.constrainedMemory() -> number (OS limit, 0 if unconstrained)
     // process.stdin -> stub object { write: fn }
     ProcessStdin,
     // process.stdout -> stub object { write: fn }

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -144,6 +144,17 @@ pub(super) fn try_native_module_methods(
                             // accepts none).
                             return Ok(Ok(Expr::ProcessThreadCpuUsage));
                         }
+                        "availableMemory" => {
+                            // process.availableMemory() — free system memory
+                            // available to the process, in bytes.
+                            return Ok(Ok(Expr::ProcessAvailableMemory));
+                        }
+                        "constrainedMemory" => {
+                            // process.constrainedMemory() — OS-imposed memory
+                            // limit (cgroups/container), in bytes. 0 when no
+                            // limit applies.
+                            return Ok(Ok(Expr::ProcessConstrainedMemory));
+                        }
                         _ => {} // Fall through to generic handling
                     }
                 }

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -285,6 +285,8 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
                 .map(|e| Box::new(substitute_expr(e, substitutions))),
         ),
         Expr::ProcessThreadCpuUsage => Expr::ProcessThreadCpuUsage,
+        Expr::ProcessAvailableMemory => Expr::ProcessAvailableMemory,
+        Expr::ProcessConstrainedMemory => Expr::ProcessConstrainedMemory,
 
         // File system
         Expr::FsReadFileSync(path) => {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -90,6 +90,8 @@ impl SH for Expr {
             Expr::ProcessAbort => tag(h, 11224),
             Expr::ProcessUmask(e) => { tag(h, 11225); e.hash(h); }
             Expr::ProcessThreadCpuUsage => tag(h, 11226),
+            Expr::ProcessAvailableMemory => tag(h, 11227),
+            Expr::ProcessConstrainedMemory => tag(h, 11228),
             Expr::ProcessStdin => tag(h, 70),
             Expr::ProcessStdout => tag(h, 71),
             Expr::ProcessStderr => tag(h, 72),

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -45,6 +45,8 @@ where
         | Expr::ProcessStderr
         | Expr::ProcessAbort
         | Expr::ProcessThreadCpuUsage
+        | Expr::ProcessAvailableMemory
+        | Expr::ProcessConstrainedMemory
         | Expr::ProcessStdinIsTTY
         | Expr::ProcessStdoutIsTTY
         | Expr::ProcessStderrIsTTY

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -46,6 +46,8 @@ where
         | Expr::ProcessStderr
         | Expr::ProcessAbort
         | Expr::ProcessThreadCpuUsage
+        | Expr::ProcessAvailableMemory
+        | Expr::ProcessConstrainedMemory
         | Expr::ProcessStdinIsTTY
         | Expr::ProcessStdoutIsTTY
         | Expr::ProcessStderrIsTTY

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -278,6 +278,8 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
         ("process", "abort")
             | ("process", "umask")
             | ("process", "threadCpuUsage")
+            | ("process", "availableMemory")
+            | ("process", "constrainedMemory")
             | ("tty", "isatty")
             | ("tty", "ReadStream")
             | ("tty", "WriteStream")

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -84,6 +84,54 @@ pub extern "C" fn js_process_umask_set(mask: f64) -> f64 {
     }
 }
 
+/// process.availableMemory() -> number. Free system memory available to
+/// the process in bytes. Delegates to `js_os_freemem`'s host-statistics
+/// path on macOS/iOS, sysinfo on Linux, GlobalMemoryStatusEx on Windows.
+#[no_mangle]
+pub extern "C" fn js_process_available_memory() -> f64 {
+    crate::os::js_os_freemem()
+}
+
+/// process.constrainedMemory() -> number. The memory limit imposed by the
+/// OS (cgroups v2 on Linux containers), in bytes. Returns 0 when no
+/// effective limit applies — Node also returns 0 in that case. macOS and
+/// Windows have no per-process equivalent we read here, so they always
+/// return 0.
+#[no_mangle]
+pub extern "C" fn js_process_constrained_memory() -> f64 {
+    #[cfg(target_os = "linux")]
+    {
+        // cgroups v2 reports the memory limit as a decimal number in
+        // bytes, or the literal string "max" for "no limit". Older
+        // cgroups v1 expose memory.limit_in_bytes — we try both.
+        for path in [
+            "/sys/fs/cgroup/memory.max",
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+        ] {
+            if let Ok(s) = std::fs::read_to_string(path) {
+                let s = s.trim();
+                if s == "max" {
+                    return 0.0;
+                }
+                if let Ok(v) = s.parse::<u64>() {
+                    // Kernel returns u64::MAX (or close to it) to mean
+                    // "unlimited" in cgroups v1; treat anything near that
+                    // ceiling as unconstrained.
+                    if v < (u64::MAX / 2) {
+                        return v as f64;
+                    }
+                    return 0.0;
+                }
+            }
+        }
+        0.0
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        0.0
+    }
+}
+
 /// Get an environment variable by name (takes JS string pointer)
 /// Returns a string pointer, or null (0) if not found
 #[no_mangle]

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1103 entries across 80 modules
+// Coverage: 1105 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1469,6 +1469,10 @@ declare module "process" {
   export const versions: any;
   /** stdlib */
   export function abort(...args: any[]): any;
+  /** stdlib */
+  export function availableMemory(...args: any[]): any;
+  /** stdlib */
+  export function constrainedMemory(...args: any[]): any;
   /** stdlib */
   export function threadCpuUsage(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1103 entries across 80 modules.
+Total: 1105 entries across 80 modules.
 
 ## Modules
 
@@ -1407,6 +1407,8 @@ Total: 1103 entries across 80 modules.
 ### Methods
 
 - `abort` — module
+- `availableMemory` — module
+- `constrainedMemory` — module
 - `threadCpuUsage` — module
 - `umask` — module
 

--- a/test-parity/node-suite/process/memory/available-memory.ts
+++ b/test-parity/node-suite/process/memory/available-memory.ts
@@ -1,0 +1,3 @@
+// process.availableMemory() and process.constrainedMemory() return numbers.
+console.log("available is number:", typeof process.availableMemory() === "number");
+console.log("constrained is number:", typeof process.constrainedMemory() === "number");


### PR DESCRIPTION
Closes #1377.

## Summary

- `process.availableMemory()` returns the free system memory in bytes (delegates to `js_os_freemem`).
- `process.constrainedMemory()` returns the cgroups v2 / v1 memory limit on Linux containers; 0 elsewhere or when unconstrained — matches Node.

## Approach

Same shape as #1374 / #1373 / #1411:

- Two no-args HIR variants (`Expr::ProcessAvailableMemory`, `Expr::ProcessConstrainedMemory`); native_module.rs lowers the calls.
- Codegen routes to `js_process_available_memory` / `js_process_constrained_memory` (return `f64`).
- `PropertyGet` extends the GlobalGet routing arm; `is_native_module_callable_export` registers the pairs so `typeof process.availableMemory === "function"` holds.
- `api-manifest` gets `method` entries for the typeof short-circuit, SBOM, and .d.ts.
- docs/api regenerated.

## Test plan

- [x] `test-parity/node-suite/process/memory/available-memory.ts` matches Node (`available is number: true`, `constrained is number: true`).
- [x] `cargo fmt --all -- --check` clean.
- [x] Process node-suite passes locally.