### PR TITLE
feat(process): implement process.finalization control surface (#1482)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -180,6 +180,23 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                     // .includes(name)) now does the right thing instead
                     // of crashing on the 0.0 sentinel.
                     "moduleLoadList" => return Ok(Expr::Array(vec![])),
+                    // #1482: process.finalization — control surface added
+                    // in Node 22 for FinalizationRegistry-like lifecycle
+                    // hooks (register / registerBeforeExit / unregister).
+                    // Perry doesn't have the runtime support yet, but
+                    // shape-only consumers feature-detect on
+                    // `typeof process.finalization === "object"` first;
+                    // returning an Object with the three documented
+                    // method names (currently undefined) closes that
+                    // gap. Real implementations of register / unregister
+                    // are tracked separately.
+                    "finalization" => {
+                        return Ok(Expr::Object(vec![
+                            ("register".to_string(), Expr::Undefined),
+                            ("registerBeforeExit".to_string(), Expr::Undefined),
+                            ("unregister".to_string(), Expr::Undefined),
+                        ]));
+                    }
                     _ => {}
                 }
             }
@@ -251,6 +268,13 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                     "features" => return Ok(process_features_literal()),
                     "sourceMapsEnabled" => return Ok(Expr::Bool(false)),
                     "moduleLoadList" => return Ok(Expr::Array(vec![])),
+                    "finalization" => {
+                        return Ok(Expr::Object(vec![
+                            ("register".to_string(), Expr::Undefined),
+                            ("registerBeforeExit".to_string(), Expr::Undefined),
+                            ("unregister".to_string(), Expr::Undefined),
+                        ]));
+                    }
                     _ => {}
                 }
             }


### PR DESCRIPTION
## Summary
- `typeof process.finalization` was `"number"` (sentinel 0.0); Node 22 returns an `"object"` with `register`/`registerBeforeExit`/`unregister`.
- Lowers bare `process.finalization` and `globalThis.process.finalization` to an inline object literal with those three method names (values are `undefined`).
- Closes the shape-only gap (`typeof`, `Object.keys`). Wiring the registry to Perry's GC is a separate follow-up.

Closes #1482.

## Test plan
- [x] `typeof process.finalization === "object"`
- [x] `Object.keys(process.finalization).sort().join(",") === "register,registerBeforeExit,unregister"`
- [x] `globalThis.process.finalization` matches
- [x] not null
- [x] regression: argv / features unchanged
- [x] `cargo fmt --all -- --check`