### PR TITLE
feat(geisterhand): register widgetSetOnClick taps for /click coverage (iOS)

### DIFF
--- a/crates/perry-ui-ios/src/widgets/button.rs
+++ b/crates/perry-ui-ios/src/widgets/button.rs
@@ -424,5 +424,18 @@ pub fn set_on_tap(handle: i64, callback: f64) {
 
             std::mem::forget(target);
         }
+        // Register with geisterhand so e2e harnesses can drive list rows
+        // and any other VStack/HStack/Text that uses widgetSetOnClick.
+        // Widget-type 9 = "clickable region", callback_kind 0 = CB_ON_CLICK
+        // so POST /click/<handle> dispatches this callback.
+        #[cfg(feature = "geisterhand")]
+        {
+            extern "C" {
+                fn perry_geisterhand_register(h: i64, wt: u8, ck: u8, cb: f64, lbl: *const u8);
+            }
+            unsafe {
+                perry_geisterhand_register(handle, 9, 0, callback, std::ptr::null());
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #1486.

## Problem

Geisterhand only registers widgets that have a dedicated clickable widget-type — Button, Picker, Slider, Toggle, TextField, SecureField. Any widget that becomes tappable via \`widgetSetOnClick(handle, cb)\` (list rows built on \`VStackWithInsets\`, "link"-style \`Text\`, custom row composites) is invisible to \`GET /widgets\` and \`POST /click/<handle>\` returns \`no onClick callback for this handle\`.

This breaks any test that needs to drive list-cell navigation. Hit while auditing the gscmaster.com mobile app: the dashboard's site rows are tap targets but couldn't be reached from geisterhand at all.

## Change

\`set_on_tap\` in \`crates/perry-ui-ios/src/widgets/button.rs\` (which backs every \`widgetSetOnClick\` call via \`mod.rs::set_on_click\`) now also calls \`perry_geisterhand_register\` under \`cfg(feature = "geisterhand")\`:

- \`widget_type\` = 9 — picked as a generic "clickable region" code, distinct from Button(0), TextField(1), Slider(2), Toggle(3), Picker(4)
- \`callback_kind\` = 0 = \`CB_ON_CLICK\`, so \`POST /click/<handle>\` dispatches it via the existing path
- \`label\` = null pointer — the row caller hasn't given us a label, and accessibility labels aren't standardized on these views yet

13 LOC, no behavior change off-feature.

## Verified

End-to-end on a real iPhone:
- \`GET /widgets\` now lists ~37 type-9 entries on the dashboard (one per site row).
- \`POST /click/<row-handle>\` opens site detail, same as a physical tap.
- Auth screens / profile screen also work — all their \`widgetSetOnClick\` rows show up.

## Follow-ups (not in this PR)

- \`perry-ui-macos\` likely wants the same treatment — happy to mirror in a follow-up.
- Wiring \`label\` through to something useful (e.g. the row's first Text child) would make \`/widgets?label=…\` work for these; that's a bigger ergonomic question about how \`widgetSetOnClick\` should expose a name.