### PR TITLE
feat(process): implement process.emitWarning() (#1375)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1865,6 +1865,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("process", "geteuid", false, None),
     method("process", "getgid", false, None),
     method("process", "getegid", false, None),
+    method("process", "emitWarning", false, None),
     property("process", "argv"),
     property("process", "platform"),
     property("process", "arch"),

--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -498,6 +498,16 @@ impl JsEmitter {
                     m = method
                 );
             }
+            Expr::ProcessEmitWarning(args) => {
+                self.output.push_str("(typeof process !== 'undefined' && typeof process.emitWarning === 'function' ? process.emitWarning(");
+                for (i, a) in args.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(", ");
+                    }
+                    self.emit_expr(a);
+                }
+                self.output.push_str(") : undefined)");
+            }
             Expr::ProcessPid => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.pid : 0)");
             }

--- a/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
@@ -124,7 +124,8 @@ impl<'a> FuncEmitCtx<'a> {
             | Expr::ProcessKill { .. }
             | Expr::ProcessExit(_)
             | Expr::ProcessAbort
-            | Expr::ProcessUmask(_) => {
+            | Expr::ProcessUmask(_)
+            | Expr::ProcessEmitWarning(_) => {
                 func.instruction(&Instruction::I64Const(TAG_UNDEFINED as i64));
             }
             Expr::EnvGet(_) | Expr::EnvGetDynamic(_) => {

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1176,6 +1176,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ProcessAvailableMemory
         | Expr::ProcessConstrainedMemory
         | Expr::ProcessPosixCredential(..)
+        | Expr::ProcessEmitWarning(..)
         | Expr::EncodeURI(..)
         | Expr::DecodeURI(..)
         | Expr::EncodeURIComponent(..)

--- a/crates/perry-codegen/src/expr/os_uri_dates.rs
+++ b/crates/perry-codegen/src/expr/os_uri_dates.rs
@@ -79,6 +79,32 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             };
             Ok(ctx.block().call(DOUBLE, fn_name, &[]))
         }
+        Expr::ProcessEmitWarning(args) => {
+            // First three positional args (warning, type, code). Missing
+            // slots are passed as TAG_UNDEFINED so the runtime can detect
+            // and skip them.
+            let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+            let warning = if let Some(e) = args.first() {
+                lower_expr(ctx, e)?
+            } else {
+                undef.clone()
+            };
+            let type_v = if let Some(e) = args.get(1) {
+                lower_expr(ctx, e)?
+            } else {
+                undef.clone()
+            };
+            let code_v = if let Some(e) = args.get(2) {
+                lower_expr(ctx, e)?
+            } else {
+                undef.clone()
+            };
+            ctx.block().call_void(
+                "js_process_emit_warning",
+                &[(DOUBLE, &warning), (DOUBLE, &type_v), (DOUBLE, &code_v)],
+            );
+            Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
+        }
         Expr::EncodeURI(o) => {
             let v = lower_expr(ctx, o)?;
             let blk = ctx.block();

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -551,6 +551,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         | "geteuid"
                         | "getgid"
                         | "getegid"
+                        | "emitWarning"
                 ) {
                     let mod_idx = ctx.strings.intern("process");
                     let mod_bytes_global = format!("@{}", ctx.strings.entry(mod_idx).bytes_global);

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -460,6 +460,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_geteuid", DOUBLE, &[]);
     module.declare_function("js_process_getgid", DOUBLE, &[]);
     module.declare_function("js_process_getegid", DOUBLE, &[]);
+    module.declare_function("js_process_emit_warning", VOID, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_process_env", DOUBLE, &[]);
     module.declare_function("js_process_hrtime_bigint", DOUBLE, &[]);
     module.declare_function("js_process_chdir", VOID, &[I64]);

--- a/crates/perry-hir/src/audit.rs
+++ b/crates/perry-hir/src/audit.rs
@@ -280,6 +280,7 @@ fn specialized_stdlib_call(expr: &Expr) -> Option<(&'static str, &'static str)> 
         Expr::ProcessPosixCredential(crate::ir::PosixCredentialKind::Egid) => {
             ("process", "getegid")
         }
+        Expr::ProcessEmitWarning(_) => ("process", "emitWarning"),
         Expr::ProcessStdinIsTTY => ("process", "stdin.isTTY"),
         Expr::ProcessStdoutIsTTY => ("process", "stdout.isTTY"),
         Expr::ProcessStderrIsTTY => ("process", "stderr.isTTY"),

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -459,16 +459,14 @@ pub enum Expr {
         pid: Box<Expr>,
         signal: Option<Box<Expr>>,
     },
-    // process.exit(code?) -> never. Bare `process.exit()` lowers as
-    // `ProcessExit(None)` which the runtime treats as code 0.
-    ProcessExit(Option<Box<Expr>>),
-    // process.abort() -> never. Calls SIGABRT to terminate (no clean shutdown).
-    ProcessAbort,
+    ProcessExit(Option<Box<Expr>>), // process.exit(code?) -> never; None means code 0
+    ProcessAbort,                   // process.abort() -> never; raises SIGABRT
     ProcessUmask(Option<Box<Expr>>), // process.umask(mask?) -> number; no-arg reads, arg sets and returns previous
-    ProcessThreadCpuUsage, // process.threadCpuUsage() -> { user, system } microseconds (current thread)
-    ProcessAvailableMemory, // process.availableMemory() -> number (free memory bytes)
+    ProcessThreadCpuUsage,           // process.threadCpuUsage() -> { user, system } microseconds
+    ProcessAvailableMemory,          // process.availableMemory() -> number (free memory bytes)
     ProcessConstrainedMemory, // process.constrainedMemory() -> number (OS limit, 0 if unconstrained)
     ProcessPosixCredential(super::PosixCredentialKind), // process.{getuid,geteuid,getgid,getegid}() (#1408)
+    ProcessEmitWarning(Vec<Expr>), // process.emitWarning(warning[, type, code, ctor]) -> undefined (#1375)
     // process.stdin -> stub object { write: fn }
     ProcessStdin,
     // process.stdout -> stub object { write: fn }

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -177,6 +177,13 @@ pub(super) fn try_native_module_methods(
                                 crate::ir::PosixCredentialKind::Egid,
                             )));
                         }
+                        "emitWarning" => {
+                            // process.emitWarning(warning[, type, code, ctor])
+                            // — writes a formatted warning to stderr. Perry
+                            // collapses the overloads into a positional Vec
+                            // and lets the runtime do the formatting.
+                            return Ok(Ok(Expr::ProcessEmitWarning(args)));
+                        }
                         _ => {} // Fall through to generic handling
                     }
                 }

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -288,6 +288,11 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
         Expr::ProcessAvailableMemory => Expr::ProcessAvailableMemory,
         Expr::ProcessConstrainedMemory => Expr::ProcessConstrainedMemory,
         Expr::ProcessPosixCredential(k) => Expr::ProcessPosixCredential(*k),
+        Expr::ProcessEmitWarning(args) => Expr::ProcessEmitWarning(
+            args.iter()
+                .map(|a| substitute_expr(a, substitutions))
+                .collect(),
+        ),
 
         // File system
         Expr::FsReadFileSync(path) => {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -93,6 +93,7 @@ impl SH for Expr {
             Expr::ProcessAvailableMemory => tag(h, 11227),
             Expr::ProcessConstrainedMemory => tag(h, 11228),
             Expr::ProcessPosixCredential(k) => { tag(h, 11229); (*k as u8).hash(h); }
+            Expr::ProcessEmitWarning(args) => { tag(h, 11230); for a in args { a.hash(h); } }
             Expr::ProcessStdin => tag(h, 70),
             Expr::ProcessStdout => tag(h, 71),
             Expr::ProcessStderr => tag(h, 72),

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1051,6 +1051,11 @@ where
                 f(v);
             }
         }
+        Expr::ProcessEmitWarning(args) => {
+            for a in args {
+                f(a);
+            }
+        }
 
         // ─── Child process ───────────────────────────────────────────────
         Expr::ChildProcessExecSync { command, options } => {

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1032,6 +1032,11 @@ where
                 f(v);
             }
         }
+        Expr::ProcessEmitWarning(args) => {
+            for a in args {
+                f(a);
+            }
+        }
         Expr::ChildProcessExecSync { command, options } => {
             f(command);
             if let Some(o) = options {

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -284,6 +284,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("process", "geteuid")
             | ("process", "getgid")
             | ("process", "getegid")
+            | ("process", "emitWarning")
             | ("tty", "isatty")
             | ("tty", "ReadStream")
             | ("tty", "WriteStream")

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -130,6 +130,51 @@ pub extern "C" fn js_process_getegid() -> f64 {
     }
 }
 
+/// process.emitWarning(warning[, type, code, ctor]) -> undefined.
+/// Writes a formatted warning to stderr matching Node's shape:
+/// `(node:<pid>) <Type> [CODE]: <message>`. Anything that can't be
+/// coerced to a string is rendered via `js_jsvalue_to_string`. The 4th
+/// `ctor` arg (Node's trace anchor) is accepted but ignored — Perry
+/// doesn't capture stack traces here.
+#[no_mangle]
+pub extern "C" fn js_process_emit_warning(warning: f64, type_name: f64, code: f64) {
+    use std::io::Write;
+    let undef_bits = crate::value::TAG_UNDEFINED;
+    let value_to_string = |v: f64| -> String {
+        if v.to_bits() == undef_bits {
+            return String::new();
+        }
+        let ptr = crate::value::js_jsvalue_to_string(v);
+        if ptr.is_null() {
+            return String::new();
+        }
+        unsafe {
+            let header = &*ptr;
+            let len = header.byte_len as usize;
+            let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+            String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
+        }
+    };
+
+    let msg = value_to_string(warning);
+    let raw_type = value_to_string(type_name);
+    let raw_code = value_to_string(code);
+    let label = if raw_type.is_empty() {
+        "Warning".to_string()
+    } else {
+        raw_type
+    };
+    let code_part = if raw_code.is_empty() {
+        String::new()
+    } else {
+        format!(" [{}]", raw_code)
+    };
+    let pid = std::process::id();
+    let line = format!("(node:{}) {}{}: {}\n", pid, label, code_part, msg);
+    let mut stderr = std::io::stderr().lock();
+    let _ = stderr.write_all(line.as_bytes());
+}
+
 /// process.availableMemory() -> number. Free system memory available to
 /// the process in bytes. Delegates to `js_os_freemem`'s host-statistics
 /// path on macOS/iOS, sysinfo on Linux, GlobalMemoryStatusEx on Windows.

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1109 entries across 80 modules
+// Coverage: 1110 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1473,6 +1473,8 @@ declare module "process" {
   export function availableMemory(...args: any[]): any;
   /** stdlib */
   export function constrainedMemory(...args: any[]): any;
+  /** stdlib */
+  export function emitWarning(...args: any[]): any;
   /** stdlib */
   export function getegid(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1109 entries across 80 modules.
+Total: 1110 entries across 80 modules.
 
 ## Modules
 
@@ -1409,6 +1409,7 @@ Total: 1109 entries across 80 modules.
 - `abort` — module
 - `availableMemory` — module
 - `constrainedMemory` — module
+- `emitWarning` — module
 - `getegid` — module
 - `geteuid` — module
 - `getgid` — module

--- a/test-parity/node-suite/process/methods/emit-warning.ts
+++ b/test-parity/node-suite/process/methods/emit-warning.ts
@@ -1,0 +1,4 @@
+// process.emitWarning is a callable function. Calling it would write to
+// stderr (ordering of stdout vs stderr + Node's trace-warnings hint differ
+// across runtimes), so the test only probes the surface.
+console.log("is function:", typeof process.emitWarning === "function");


### PR DESCRIPTION
Closes #1375.

## Summary

- `typeof process.emitWarning` returns `"function"` (was `"undefined"`).
- `process.emitWarning(msg[, type, code, ctor])` writes a formatted warning to stderr matching Node's shape: `(node:<pid>) <Type> [<CODE>]: <message>`.

## Approach

Same shape as #1374 / #1373 / #1411 / #1377 / #1408:

- `Expr::ProcessEmitWarning(Vec<Expr>)` HIR variant; native_module.rs lowers the call.
- Codegen passes the first three args (warning / type / code) plus `TAG_UNDEFINED` slots for missing ones to `js_process_emit_warning`, which coerces each via `js_jsvalue_to_string` and writes to stderr. The 4th `ctor` arg (Node's trace anchor) is accepted but ignored — Perry doesn't capture stack traces here.
- `PropertyGet` GlobalGet arm + `is_native_module_callable_export` register `"emitWarning"` so the value-read form has `typeof "function"`.
- `api-manifest` gets `method("process", "emitWarning", ...)`.

## Test plan

- [x] `test-parity/node-suite/process/methods/emit-warning.ts` matches Node (typeof shape only — Node and Perry differ on the relative ordering of stdout vs stderr and on the `(Use --trace-warnings ...)` hint, so the test doesn't actually invoke it).
- [x] All 12 process node-suite tests pass.
- [x] `cargo fmt --all -- --check` clean.