### PR TITLE
feat(process): implement process.allowedNodeEnvironmentFlags (#1380)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -210,6 +210,15 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                             ("target_defaults".to_string(), Expr::Object(Vec::new())),
                         ]));
                     }
+                    // #1380: process.allowedNodeEnvironmentFlags — the
+                    // set of NODE_OPTIONS / V8 flags Node will accept
+                    // from the environment. Perry binaries are AOT and
+                    // don't honour NODE_OPTIONS-style runtime flags, so
+                    // the empty Set is the spec-compatible shape.
+                    // Without this, the bare read returned a 0 sentinel
+                    // and `.has(...)` / `.size` / `for...of` iteration
+                    // all exploded.
+                    "allowedNodeEnvironmentFlags" => return Ok(Expr::SetNew),
                     _ => {}
                 }
             }
@@ -294,6 +303,7 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                             ("target_defaults".to_string(), Expr::Object(Vec::new())),
                         ]));
                     }
+                    "allowedNodeEnvironmentFlags" => return Ok(Expr::SetNew),
                     _ => {}
                 }
             }

--- a/test-parity/node-suite/process/env/allowed-flags.ts
+++ b/test-parity/node-suite/process/env/allowed-flags.ts
@@ -1,0 +1,9 @@
+// process.allowedNodeEnvironmentFlags — Set of NODE_OPTIONS / V8 flags
+// the runtime will honour from the environment. Perry binaries are AOT
+// and don't honour runtime flags, so the empty Set is the spec
+// shape. Regression cover for #1380 (Perry was returning a 0 sentinel
+// so `.has` / `.size` / iteration all threw).
+const f = process.allowedNodeEnvironmentFlags;
+console.log("instanceof Set:", f instanceof Set);
+console.log("size typeof:", typeof f.size);
+console.log("has(--bogus):", f.has("--bogus"));


### PR DESCRIPTION
## Summary

Node's `process.allowedNodeEnvironmentFlags` is the `Set<string>` of NODE_OPTIONS / V8 flags the runtime will honour from the environment. Perry was returning a 0 sentinel, so `.has(...)` / `.size` / `for...of` iteration all crashed with "value is not a function".

Perry binaries are AOT and don't honour runtime CLI flags from the environment — the empty Set is the spec-compatible shape.

Closes #1380.

## Changes

`expr_member.rs`: both bare `process.allowedNodeEnvironmentFlags` and `globalThis.process.allowedNodeEnvironmentFlags` paths lower to `Expr::SetNew`, sitting next to the `config` / `release` / `features` arms shipped in #1379 / #1348 / #1378.

## Test plan

- [x] `test-parity/node-suite/process/env/allowed-flags.ts` asserts `instanceof Set`, `.size` typeof, and `.has(...)` behavior — byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.

The `typeof set.has === "function"` shape is the broader #1320-class method-as-value typeof gap and intentionally not asserted here.