### PR TITLE
feat(process): implement process.cpuUsage() (#1347)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1866,6 +1866,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("process", "getgid", false, None),
     method("process", "getegid", false, None),
     method("process", "emitWarning", false, None),
+    method("process", "cpuUsage", false, None),
     property("process", "argv"),
     property("process", "platform"),
     property("process", "arch"),

--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -508,6 +508,13 @@ impl JsEmitter {
                 }
                 self.output.push_str(") : undefined)");
             }
+            Expr::ProcessCpuUsage(prior) => {
+                self.output.push_str("(typeof process !== 'undefined' && typeof process.cpuUsage === 'function' ? process.cpuUsage(");
+                if let Some(p) = prior {
+                    self.emit_expr(p);
+                }
+                self.output.push_str(") : {user: 0, system: 0})");
+            }
             Expr::ProcessPid => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.pid : 0)");
             }

--- a/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
@@ -125,7 +125,8 @@ impl<'a> FuncEmitCtx<'a> {
             | Expr::ProcessExit(_)
             | Expr::ProcessAbort
             | Expr::ProcessUmask(_)
-            | Expr::ProcessEmitWarning(_) => {
+            | Expr::ProcessEmitWarning(_)
+            | Expr::ProcessCpuUsage(_) => {
                 func.instruction(&Instruction::I64Const(TAG_UNDEFINED as i64));
             }
             Expr::EnvGet(_) | Expr::EnvGetDynamic(_) => {

--- a/crates/perry-codegen/src/collectors/escape_objects.rs
+++ b/crates/perry-codegen/src/collectors/escape_objects.rs
@@ -431,6 +431,7 @@ pub fn check_object_literal_escapes_in_expr(
         | Expr::ProcessMemoryUsage | Expr::ProcessThreadCpuUsage
         | Expr::ProcessAvailableMemory | Expr::ProcessConstrainedMemory
         | Expr::ProcessPosixCredential(_)
+        | Expr::ProcessCpuUsage(_)
         | Expr::ProcessPid | Expr::ProcessPpid
         | Expr::ProcessVersion | Expr::ProcessVersions | Expr::ProcessHrtimeBigint
         | Expr::ProcessStdin | Expr::ProcessStdout | Expr::ProcessStderr

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1177,6 +1177,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ProcessConstrainedMemory
         | Expr::ProcessPosixCredential(..)
         | Expr::ProcessEmitWarning(..)
+        | Expr::ProcessCpuUsage(..)
         | Expr::EncodeURI(..)
         | Expr::DecodeURI(..)
         | Expr::EncodeURIComponent(..)

--- a/crates/perry-codegen/src/expr/os_uri_dates.rs
+++ b/crates/perry-codegen/src/expr/os_uri_dates.rs
@@ -105,6 +105,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             );
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }
+        Expr::ProcessCpuUsage(prior) => {
+            let prior_val = if let Some(e) = prior {
+                lower_expr(ctx, e)?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            Ok(ctx
+                .block()
+                .call(DOUBLE, "js_process_cpu_usage", &[(DOUBLE, &prior_val)]))
+        }
         Expr::EncodeURI(o) => {
             let v = lower_expr(ctx, o)?;
             let blk = ctx.block();

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -552,6 +552,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         | "getgid"
                         | "getegid"
                         | "emitWarning"
+                        | "cpuUsage"
                 ) {
                     let mod_idx = ctx.strings.intern("process");
                     let mod_bytes_global = format!("@{}", ctx.strings.entry(mod_idx).bytes_global);

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -461,6 +461,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_getgid", DOUBLE, &[]);
     module.declare_function("js_process_getegid", DOUBLE, &[]);
     module.declare_function("js_process_emit_warning", VOID, &[DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function("js_process_cpu_usage", DOUBLE, &[DOUBLE]);
     module.declare_function("js_process_env", DOUBLE, &[]);
     module.declare_function("js_process_hrtime_bigint", DOUBLE, &[]);
     module.declare_function("js_process_chdir", VOID, &[I64]);

--- a/crates/perry-hir/src/audit.rs
+++ b/crates/perry-hir/src/audit.rs
@@ -281,6 +281,7 @@ fn specialized_stdlib_call(expr: &Expr) -> Option<(&'static str, &'static str)> 
             ("process", "getegid")
         }
         Expr::ProcessEmitWarning(_) => ("process", "emitWarning"),
+        Expr::ProcessCpuUsage(_) => ("process", "cpuUsage"),
         Expr::ProcessStdinIsTTY => ("process", "stdin.isTTY"),
         Expr::ProcessStdoutIsTTY => ("process", "stdout.isTTY"),
         Expr::ProcessStderrIsTTY => ("process", "stderr.isTTY"),

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -467,6 +467,7 @@ pub enum Expr {
     ProcessConstrainedMemory, // process.constrainedMemory() -> number (OS limit, 0 if unconstrained)
     ProcessPosixCredential(super::PosixCredentialKind), // process.{getuid,geteuid,getgid,getegid}() (#1408)
     ProcessEmitWarning(Vec<Expr>), // process.emitWarning(warning[, type, code, ctor]) -> undefined (#1375)
+    ProcessCpuUsage(Option<Box<Expr>>), // process.cpuUsage(prior?) -> { user, system } µs (diff if prior given)
     // process.stdin -> stub object { write: fn }
     ProcessStdin,
     // process.stdout -> stub object { write: fn }

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -184,6 +184,17 @@ pub(super) fn try_native_module_methods(
                             // and lets the runtime do the formatting.
                             return Ok(Ok(Expr::ProcessEmitWarning(args)));
                         }
+                        "cpuUsage" => {
+                            // process.cpuUsage(prior?) — { user, system } in
+                            // microseconds. If prior is given, returns the
+                            // diff (clamped to >= 0).
+                            let prior = if !args.is_empty() {
+                                Some(Box::new(args.into_iter().next().unwrap()))
+                            } else {
+                                None
+                            };
+                            return Ok(Ok(Expr::ProcessCpuUsage(prior)));
+                        }
                         _ => {} // Fall through to generic handling
                     }
                 }

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -293,6 +293,11 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
                 .map(|a| substitute_expr(a, substitutions))
                 .collect(),
         ),
+        Expr::ProcessCpuUsage(prior) => Expr::ProcessCpuUsage(
+            prior
+                .as_ref()
+                .map(|e| Box::new(substitute_expr(e, substitutions))),
+        ),
 
         // File system
         Expr::FsReadFileSync(path) => {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -94,6 +94,7 @@ impl SH for Expr {
             Expr::ProcessConstrainedMemory => tag(h, 11228),
             Expr::ProcessPosixCredential(k) => { tag(h, 11229); (*k as u8).hash(h); }
             Expr::ProcessEmitWarning(args) => { tag(h, 11230); for a in args { a.hash(h); } }
+            Expr::ProcessCpuUsage(e) => { tag(h, 11231); e.hash(h); }
             Expr::ProcessStdin => tag(h, 70),
             Expr::ProcessStdout => tag(h, 71),
             Expr::ProcessStderr => tag(h, 72),

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1056,6 +1056,11 @@ where
                 f(a);
             }
         }
+        Expr::ProcessCpuUsage(opt) => {
+            if let Some(v) = opt {
+                f(v);
+            }
+        }
 
         // ─── Child process ───────────────────────────────────────────────
         Expr::ChildProcessExecSync { command, options } => {

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1037,6 +1037,11 @@ where
                 f(a);
             }
         }
+        Expr::ProcessCpuUsage(opt) => {
+            if let Some(v) = opt {
+                f(v);
+            }
+        }
         Expr::ChildProcessExecSync { command, options } => {
             f(command);
             if let Some(o) = options {

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -285,6 +285,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("process", "getgid")
             | ("process", "getegid")
             | ("process", "emitWarning")
+            | ("process", "cpuUsage")
             | ("tty", "isatty")
             | ("tty", "ReadStream")
             | ("tty", "WriteStream")

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -130,6 +130,69 @@ pub extern "C" fn js_process_getegid() -> f64 {
     }
 }
 
+/// process.cpuUsage(prior?) -> { user, system } µs.
+/// Reads CPU time consumed by the process via getrusage(RUSAGE_SELF) on
+/// unix. With a `prior` object, returns the diff (clamped to >= 0).
+/// Non-unix targets return `{ user: 0, system: 0 }`.
+#[no_mangle]
+pub extern "C" fn js_process_cpu_usage(prior: f64) -> f64 {
+    let (mut user_us, mut system_us) = read_process_cpu_micros();
+    let undef_bits = crate::value::TAG_UNDEFINED;
+    if prior.to_bits() != undef_bits {
+        let (prev_user, prev_system) = extract_cpu_pair(prior);
+        user_us = (user_us - prev_user).max(0.0);
+        system_us = (system_us - prev_system).max(0.0);
+    }
+    let obj = crate::object::js_object_alloc(0, 2);
+    let set_field = |name: &str, value: f64| {
+        let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        crate::object::js_object_set_field_by_name(obj, key, value);
+    };
+    set_field("user", user_us);
+    set_field("system", system_us);
+    f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+}
+
+#[cfg(unix)]
+fn read_process_cpu_micros() -> (f64, f64) {
+    let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) } != 0 {
+        return (0.0, 0.0);
+    }
+    let user = (usage.ru_utime.tv_sec as f64) * 1_000_000.0 + usage.ru_utime.tv_usec as f64;
+    let system = (usage.ru_stime.tv_sec as f64) * 1_000_000.0 + usage.ru_stime.tv_usec as f64;
+    (user, system)
+}
+
+#[cfg(not(unix))]
+fn read_process_cpu_micros() -> (f64, f64) {
+    (0.0, 0.0)
+}
+
+/// Read `.user` and `.system` (numbers, microseconds) from a JS object
+/// — used by `js_process_cpu_usage` to compute diffs. Missing fields
+/// or non-numeric values count as 0.
+fn extract_cpu_pair(value: f64) -> (f64, f64) {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return (0.0, 0.0);
+    }
+    let obj_ptr = jv.as_pointer::<u8>() as *mut crate::object::ObjectHeader;
+    if obj_ptr.is_null() {
+        return (0.0, 0.0);
+    }
+    let get_num = |name: &str| -> f64 {
+        let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let v = crate::object::js_object_get_field_by_name_f64(obj_ptr, key);
+        if v.is_nan() {
+            0.0
+        } else {
+            v
+        }
+    };
+    (get_num("user"), get_num("system"))
+}
+
 /// process.emitWarning(warning[, type, code, ctor]) -> undefined.
 /// Writes a formatted warning to stderr matching Node's shape:
 /// `(node:<pid>) <Type> [CODE]: <message>`. Anything that can't be

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1110 entries across 80 modules
+// Coverage: 1111 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1473,6 +1473,8 @@ declare module "process" {
   export function availableMemory(...args: any[]): any;
   /** stdlib */
   export function constrainedMemory(...args: any[]): any;
+  /** stdlib */
+  export function cpuUsage(...args: any[]): any;
   /** stdlib */
   export function emitWarning(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1110 entries across 80 modules.
+Total: 1111 entries across 80 modules.
 
 ## Modules
 
@@ -1409,6 +1409,7 @@ Total: 1110 entries across 80 modules.
 - `abort` — module
 - `availableMemory` — module
 - `constrainedMemory` — module
+- `cpuUsage` — module
 - `emitWarning` — module
 - `getegid` — module
 - `geteuid` — module

--- a/test-parity/node-suite/process/cpu/cpu-usage-shape.ts
+++ b/test-parity/node-suite/process/cpu/cpu-usage-shape.ts
@@ -1,4 +1,3 @@
-// process.cpuUsage() returns { user, system } microsecond counters.
-const c = process.cpuUsage();
-console.log("user:", typeof c.user === "number");
-console.log("system:", typeof c.system === "number");
+// process.cpuUsage() returns { user, system } in microseconds.
+const u = process.cpuUsage();
+console.log("ok:", typeof u === "object" && typeof u.user === "number" && typeof u.system === "number");


### PR DESCRIPTION
Closes #1347.

## Summary

- `typeof process.cpuUsage` returns `"function"` (was `"undefined"`).
- `process.cpuUsage()` returns `{ user, system }` microsecond counters.
- `process.cpuUsage(prior)` returns the diff against a previous reading (clamped to >= 0).

## Approach

Same shape as #1374 / #1373 / #1411 / #1377 / #1408 / #1375:

- `Expr::ProcessCpuUsage(Option<Box<Expr>>)` HIR variant (optional prior).
- Codegen routes to `js_process_cpu_usage`, which reads `getrusage(RUSAGE_SELF)` on unix and packs `ru_utime` / `ru_stime` into a JS object. With a prior `{ user, system }` object it subtracts and clamps each field. Non-unix returns zeros.
- `PropertyGet` GlobalGet arm + `is_native_module_callable_export` register `"cpuUsage"`.
- `api-manifest` gets `method("process", "cpuUsage", ...)`.

## Test plan

- [x] `test-parity/node-suite/process/cpu/cpu-usage-shape.ts` matches Node (object with numeric `user` / `system`).
- [x] All 14 process node-suite tests pass.
- [x] `cargo fmt --all -- --check` clean.