### PR TITLE
codegen: refine crypto factory/KDF return types to Buffer (#1432)

### DIFF
--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -322,6 +322,33 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
                         _ => {}
                     }
                 }
+                // #1432: crypto factories / KDFs that return a NaN-boxed
+                // BufferHeader. Without this refinement they're typed
+                // `Any`, so the HMAC fast-path's `key_is_buffer` check
+                // can't identify a `SecretKey` / `pbkdf2Sync` result as
+                // a Buffer — the call falls through to handle-dispatch
+                // (~3 mutex locks) instead of the inline-FFI literal-key
+                // fast path. The runtime values are real Buffers, so
+                // tagging them `Named("Buffer")` is correct.
+                //
+                // Mirrors the existing `Expr::CryptoRandomBytes(_) →
+                // Uint8Array` arm in `static_type_of`; we use `"Buffer"`
+                // rather than `"Uint8Array"` here because the HMAC
+                // fast-path key check specifically matches the
+                // `Named("Buffer")` name (see `is_buffer_expr`).
+                if matches!(object.as_ref(), Expr::NativeModuleRef(m) if m == "crypto") {
+                    match property.as_str() {
+                        "createSecretKey"
+                        | "generateKeySync"
+                        | "scryptSync"
+                        | "pbkdf2Sync"
+                        | "hkdfSync"
+                        | "randomBytes" => {
+                            return Some(HirType::Named("Buffer".into()));
+                        }
+                        _ => {}
+                    }
+                }
             }
             // `crypto.createHash(alg).update(data).digest(enc)` chain.
             // The expr.rs handler collapses this into a runtime call. With an


### PR DESCRIPTION
## Summary
- `crypto.createSecretKey` / `generateKeySync` / `scryptSync` / `pbkdf2Sync` / `hkdfSync` / `randomBytes` all return Buffers at runtime but were typed `Any` in `static_type_of`.
- Adds a `(NativeModuleRef("crypto"), method)` arm next to the existing fs arm, refining to `Named("Buffer")`.
- Lets the HMAC inline-FFI fast path's `key_is_buffer` gate correctly identify SecretKey / KDF results as Buffers — literal-data-string call sites now take the single-FFI fast path instead of falling through to ~3-mutex handle-dispatch.
- `"Buffer"` (not `"Uint8Array"`) is the right tag here — `is_buffer_expr` matches that exact `Named` name.

Closes #1432.

## Test plan
- [x] `crypto.randomBytes(16)` / `crypto.scryptSync("pw","salt",16)` runtime values still `Buffer.isBuffer === true`, `.length` correct
- [x] HMAC with literal key still works: `createHmac("sha256","k").update("data").digest("hex")` matches Node
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p perry-codegen`