### PR TITLE
feat(process): expose argv0 / execPath / title as string properties (#1346)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -220,6 +220,26 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                     // all exploded.
                     "allowedNodeEnvironmentFlags" => return Ok(Expr::SetNew),
                     "report" => return Ok(process_report_literal()),
+                    // #1346: process.argv0 / execPath / title — Node
+                    // documents these as strings (program-invocation
+                    // name / resolved-binary path / OS-displayed
+                    // title). Perry was hitting the 0.0 sentinel and
+                    // `typeof process.argv0 === "string"` failed; any
+                    // `.length` / `.endsWith(...)` then crashed.
+                    //
+                    // Lower all three to `process.argv[0]` — Perry's
+                    // own argv[0] is already the binary path / name
+                    // we'd want for argv0 and execPath, and is a
+                    // reasonable default for `title` (Node defaults
+                    // to argv[0] too until something assigns `.title`).
+                    // Settable `process.title` is tracked separately
+                    // (#1401); the shape-only read is what closes #1346.
+                    "argv0" | "execPath" | "title" => {
+                        return Ok(Expr::IndexGet {
+                            object: Box::new(Expr::ProcessArgv),
+                            index: Box::new(Expr::Number(0.0)),
+                        });
+                    }
                     _ => {}
                 }
             }
@@ -306,6 +326,12 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                     }
                     "allowedNodeEnvironmentFlags" => return Ok(Expr::SetNew),
                     "report" => return Ok(process_report_literal()),
+                    "argv0" | "execPath" | "title" => {
+                        return Ok(Expr::IndexGet {
+                            object: Box::new(Expr::ProcessArgv),
+                            index: Box::new(Expr::Number(0.0)),
+                        });
+                    }
                     _ => {}
                 }
             }


### PR DESCRIPTION
## Summary
- `typeof process.argv0` / `process.execPath` / `process.title` was `"number"` (sentinel 0.0); Node returns strings.
- Lowers all three to `process.argv[0]`. Perry's argv[0] is already the binary path/name; Node also defaults `title` to argv[0] until something assigns it.
- Same handling in bare `process.X` and `globalThis.process.X` arms.
- Settable `process.title` is tracked separately (#1401) — read-only shape is what closes #1346.

Closes #1346.

## Test plan
- [x] all three return `string`, non-empty length
- [x] `globalThis.process.argv0`/`.execPath`/`.title` mirror bare access
- [x] regression: other process props unchanged
- [x] `cargo fmt --all -- --check`