### PR TITLE
feat(process): implement process.dlopen as no-op stub (#1409)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -119,6 +119,21 @@ pub(super) fn try_native_module_methods(
                             // already handle).
                             return Ok(Ok(Expr::Undefined));
                         }
+                        "dlopen" => {
+                            // #1409: process.dlopen(module, filename, flags?)
+                            // is Node's native-addon (.node) loader. Perry
+                            // statically links every dependency at compile
+                            // time — there's no dynamic loader to call.
+                            // Returning undefined is the closest no-op:
+                            // call sites that probe for the function before
+                            // attempting to load an addon (a common pattern
+                            // in optional-dep wrappers) see typeof "function"
+                            // and a "loaded" non-error, then fall back to
+                            // their pure-JS path. Real addon-loading
+                            // attempts will surface as the addon's exports
+                            // being undefined downstream.
+                            return Ok(Ok(Expr::Undefined));
+                        }
                         "exit" => {
                             // process.exit() / process.exit(code) — never
                             // returns, terminates the process. Until now this

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -601,19 +601,24 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                             {
                                 return Ok(Expr::String("function".to_string()));
                             }
-                            // #1410 / #1400 / #1398: `typeof process.ref` /
-                            // `typeof process.unref` /
+                            // #1410 / #1400 / #1398 / #1409: `typeof
+                            // process.ref` / `typeof process.unref` /
                             // `typeof process.setSourceMapsEnabled` /
-                            // `typeof process.getBuiltinModule`. These
-                            // methods lower to `Expr::Undefined` / no-ops
-                            // when called; a bare member read still falls
+                            // `typeof process.getBuiltinModule` /
+                            // `typeof process.dlopen`. These methods
+                            // lower to `Expr::Undefined` / no-ops when
+                            // called; a bare member read still falls
                             // through to the generic process member path
                             // (returns 0 / "number" typeof), so fold to
                             // "function" here to match Node.
                             if obj_name == "process"
                                 && matches!(
                                     prop_name,
-                                    "ref" | "unref" | "setSourceMapsEnabled" | "getBuiltinModule"
+                                    "ref"
+                                        | "unref"
+                                        | "setSourceMapsEnabled"
+                                        | "getBuiltinModule"
+                                        | "dlopen"
                                 )
                                 && ctx.lookup_local("process").is_none()
                             {


### PR DESCRIPTION
## Summary

Node's `process.dlopen(module, filename, flags?)` is the native-addon (`.node`) loader. Perry was reading it as a bare number, so `typeof process.dlopen === "function"` returned false and call sites crashed with "value is not a function".

Perry statically links every dependency at compile time — there's no dynamic loader to wire up. The closest no-op is to return undefined: optional-dep wrappers that feature-detect on `typeof process.dlopen === "function"` first see a "loaded" non-error and fall back to their pure-JS path; real addon-loading attempts surface as undefined exports downstream.

Closes #1409.

## Changes

- **Call lowering** (`native_module.rs`): folds to `Expr::Undefined`, sitting next to the `ref` / `unref` / `setSourceMapsEnabled` / `getBuiltinModule` arms.
- **Typeof fold** (`lower_expr.rs`): adds `dlopen` to the same process-method-as-function list.

## Test plan

- [x] `test-parity/node-suite/process/methods/dlopen.ts` (already in the granular suite from #1331) now passes — byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.