### PR TITLE
feat(process): implement resourceUsage() + getActiveResourcesInfo() (#1376)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1867,6 +1867,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("process", "getegid", false, None),
     method("process", "emitWarning", false, None),
     method("process", "cpuUsage", false, None),
+    method("process", "resourceUsage", false, None),
+    method("process", "getActiveResourcesInfo", false, None),
     property("process", "argv"),
     property("process", "platform"),
     property("process", "arch"),

--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -515,6 +515,12 @@ impl JsEmitter {
                 }
                 self.output.push_str(") : {user: 0, system: 0})");
             }
+            Expr::ProcessResourceUsage => {
+                self.output.push_str("(typeof process !== 'undefined' && typeof process.resourceUsage === 'function' ? process.resourceUsage() : {})");
+            }
+            Expr::ProcessActiveResourcesInfo => {
+                self.output.push_str("(typeof process !== 'undefined' && typeof process.getActiveResourcesInfo === 'function' ? process.getActiveResourcesInfo() : [])");
+            }
             Expr::ProcessPid => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.pid : 0)");
             }

--- a/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
@@ -95,6 +95,8 @@ impl<'a> FuncEmitCtx<'a> {
             | Expr::ProcessAvailableMemory
             | Expr::ProcessConstrainedMemory
             | Expr::ProcessPosixCredential(_)
+            | Expr::ProcessResourceUsage
+            | Expr::ProcessActiveResourcesInfo
             | Expr::ProcessPid
             | Expr::ProcessPpid
             | Expr::ProcessVersion

--- a/crates/perry-codegen/src/collectors/escape_objects.rs
+++ b/crates/perry-codegen/src/collectors/escape_objects.rs
@@ -432,6 +432,7 @@ pub fn check_object_literal_escapes_in_expr(
         | Expr::ProcessAvailableMemory | Expr::ProcessConstrainedMemory
         | Expr::ProcessPosixCredential(_)
         | Expr::ProcessCpuUsage(_)
+        | Expr::ProcessResourceUsage | Expr::ProcessActiveResourcesInfo
         | Expr::ProcessPid | Expr::ProcessPpid
         | Expr::ProcessVersion | Expr::ProcessVersions | Expr::ProcessHrtimeBigint
         | Expr::ProcessStdin | Expr::ProcessStdout | Expr::ProcessStderr

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1178,6 +1178,8 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ProcessPosixCredential(..)
         | Expr::ProcessEmitWarning(..)
         | Expr::ProcessCpuUsage(..)
+        | Expr::ProcessResourceUsage
+        | Expr::ProcessActiveResourcesInfo
         | Expr::EncodeURI(..)
         | Expr::DecodeURI(..)
         | Expr::EncodeURIComponent(..)

--- a/crates/perry-codegen/src/expr/os_uri_dates.rs
+++ b/crates/perry-codegen/src/expr/os_uri_dates.rs
@@ -115,6 +115,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 .block()
                 .call(DOUBLE, "js_process_cpu_usage", &[(DOUBLE, &prior_val)]))
         }
+        Expr::ProcessResourceUsage => {
+            Ok(ctx.block().call(DOUBLE, "js_process_resource_usage", &[]))
+        }
+        Expr::ProcessActiveResourcesInfo => {
+            Ok(ctx
+                .block()
+                .call(DOUBLE, "js_process_active_resources_info", &[]))
+        }
         Expr::EncodeURI(o) => {
             let v = lower_expr(ctx, o)?;
             let blk = ctx.block();

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -553,6 +553,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         | "getegid"
                         | "emitWarning"
                         | "cpuUsage"
+                        | "resourceUsage"
+                        | "getActiveResourcesInfo"
                 ) {
                     let mod_idx = ctx.strings.intern("process");
                     let mod_bytes_global = format!("@{}", ctx.strings.entry(mod_idx).bytes_global);

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -462,6 +462,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_getegid", DOUBLE, &[]);
     module.declare_function("js_process_emit_warning", VOID, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_process_cpu_usage", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_process_resource_usage", DOUBLE, &[]);
+    module.declare_function("js_process_active_resources_info", DOUBLE, &[]);
     module.declare_function("js_process_env", DOUBLE, &[]);
     module.declare_function("js_process_hrtime_bigint", DOUBLE, &[]);
     module.declare_function("js_process_chdir", VOID, &[I64]);

--- a/crates/perry-hir/src/audit.rs
+++ b/crates/perry-hir/src/audit.rs
@@ -282,6 +282,8 @@ fn specialized_stdlib_call(expr: &Expr) -> Option<(&'static str, &'static str)> 
         }
         Expr::ProcessEmitWarning(_) => ("process", "emitWarning"),
         Expr::ProcessCpuUsage(_) => ("process", "cpuUsage"),
+        Expr::ProcessResourceUsage => ("process", "resourceUsage"),
+        Expr::ProcessActiveResourcesInfo => ("process", "getActiveResourcesInfo"),
         Expr::ProcessStdinIsTTY => ("process", "stdin.isTTY"),
         Expr::ProcessStdoutIsTTY => ("process", "stdout.isTTY"),
         Expr::ProcessStderrIsTTY => ("process", "stderr.isTTY"),

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -452,8 +452,7 @@ pub enum Expr {
         event: Box<Expr>,
         handler: Box<Expr>,
     },
-    // process.chdir(directory) -> void
-    ProcessChdir(Box<Expr>),
+    ProcessChdir(Box<Expr>), // process.chdir(directory) -> void
     // process.kill(pid, signal?) -> void
     ProcessKill {
         pid: Box<Expr>,
@@ -468,6 +467,8 @@ pub enum Expr {
     ProcessPosixCredential(super::PosixCredentialKind), // process.{getuid,geteuid,getgid,getegid}() (#1408)
     ProcessEmitWarning(Vec<Expr>), // process.emitWarning(warning[, type, code, ctor]) -> undefined (#1375)
     ProcessCpuUsage(Option<Box<Expr>>), // process.cpuUsage(prior?) -> { user, system } µs (diff if prior given)
+    ProcessResourceUsage, // process.resourceUsage() -> {userCPUTime, maxRSS, ...} (#1376)
+    ProcessActiveResourcesInfo, // process.getActiveResourcesInfo() -> string[] (#1376)
     // process.stdin -> stub object { write: fn }
     ProcessStdin,
     // process.stdout -> stub object { write: fn }

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -195,6 +195,12 @@ pub(super) fn try_native_module_methods(
                             };
                             return Ok(Ok(Expr::ProcessCpuUsage(prior)));
                         }
+                        "resourceUsage" => {
+                            return Ok(Ok(Expr::ProcessResourceUsage));
+                        }
+                        "getActiveResourcesInfo" => {
+                            return Ok(Ok(Expr::ProcessActiveResourcesInfo));
+                        }
                         _ => {} // Fall through to generic handling
                     }
                 }

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -298,6 +298,8 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
                 .as_ref()
                 .map(|e| Box::new(substitute_expr(e, substitutions))),
         ),
+        Expr::ProcessResourceUsage => Expr::ProcessResourceUsage,
+        Expr::ProcessActiveResourcesInfo => Expr::ProcessActiveResourcesInfo,
 
         // File system
         Expr::FsReadFileSync(path) => {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -95,6 +95,8 @@ impl SH for Expr {
             Expr::ProcessPosixCredential(k) => { tag(h, 11229); (*k as u8).hash(h); }
             Expr::ProcessEmitWarning(args) => { tag(h, 11230); for a in args { a.hash(h); } }
             Expr::ProcessCpuUsage(e) => { tag(h, 11231); e.hash(h); }
+            Expr::ProcessResourceUsage => tag(h, 11232),
+            Expr::ProcessActiveResourcesInfo => tag(h, 11233),
             Expr::ProcessStdin => tag(h, 70),
             Expr::ProcessStdout => tag(h, 71),
             Expr::ProcessStderr => tag(h, 72),

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -48,6 +48,8 @@ where
         | Expr::ProcessAvailableMemory
         | Expr::ProcessConstrainedMemory
         | Expr::ProcessPosixCredential(_)
+        | Expr::ProcessResourceUsage
+        | Expr::ProcessActiveResourcesInfo
         | Expr::ProcessStdinIsTTY
         | Expr::ProcessStdoutIsTTY
         | Expr::ProcessStderrIsTTY

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -49,6 +49,8 @@ where
         | Expr::ProcessAvailableMemory
         | Expr::ProcessConstrainedMemory
         | Expr::ProcessPosixCredential(_)
+        | Expr::ProcessResourceUsage
+        | Expr::ProcessActiveResourcesInfo
         | Expr::ProcessStdinIsTTY
         | Expr::ProcessStdoutIsTTY
         | Expr::ProcessStderrIsTTY

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -286,6 +286,8 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("process", "getegid")
             | ("process", "emitWarning")
             | ("process", "cpuUsage")
+            | ("process", "resourceUsage")
+            | ("process", "getActiveResourcesInfo")
             | ("tty", "isatty")
             | ("tty", "ReadStream")
             | ("tty", "WriteStream")

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -130,6 +130,111 @@ pub extern "C" fn js_process_getegid() -> f64 {
     }
 }
 
+/// process.resourceUsage() -> object with getrusage(RUSAGE_SELF)
+/// counters matching Node's shape (#1376). Linux's `ru_maxrss` is in
+/// kilobytes; macOS/BSD's is in bytes — Node normalizes Linux to bytes,
+/// so we do too. Non-unix targets return zeroed fields.
+#[no_mangle]
+pub extern "C" fn js_process_resource_usage() -> f64 {
+    #[allow(unused_mut)]
+    let mut user_cpu: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut system_cpu: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut max_rss: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut shared_mem: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut unshared_data: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut unshared_stack: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut minor_faults: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut major_faults: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut swapped_out: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut fs_read: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut fs_write: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut ipc_sent: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut ipc_recv: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut signals: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut vcsw: f64 = 0.0;
+    #[allow(unused_mut)]
+    let mut ivcsw: f64 = 0.0;
+
+    #[cfg(unix)]
+    {
+        let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+        if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) } == 0 {
+            user_cpu = (usage.ru_utime.tv_sec as f64) * 1_000_000.0 + usage.ru_utime.tv_usec as f64;
+            system_cpu =
+                (usage.ru_stime.tv_sec as f64) * 1_000_000.0 + usage.ru_stime.tv_usec as f64;
+            #[cfg(target_os = "linux")]
+            {
+                max_rss = (usage.ru_maxrss as f64) * 1024.0;
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                max_rss = usage.ru_maxrss as f64;
+            }
+            shared_mem = usage.ru_ixrss as f64;
+            unshared_data = usage.ru_idrss as f64;
+            unshared_stack = usage.ru_isrss as f64;
+            minor_faults = usage.ru_minflt as f64;
+            major_faults = usage.ru_majflt as f64;
+            swapped_out = usage.ru_nswap as f64;
+            fs_read = usage.ru_inblock as f64;
+            fs_write = usage.ru_oublock as f64;
+            ipc_sent = usage.ru_msgsnd as f64;
+            ipc_recv = usage.ru_msgrcv as f64;
+            signals = usage.ru_nsignals as f64;
+            vcsw = usage.ru_nvcsw as f64;
+            ivcsw = usage.ru_nivcsw as f64;
+        }
+    }
+
+    let obj = crate::object::js_object_alloc(0, 16);
+    let set_field = |name: &str, value: f64| {
+        let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        crate::object::js_object_set_field_by_name(obj, key, value);
+    };
+    set_field("userCPUTime", user_cpu);
+    set_field("systemCPUTime", system_cpu);
+    set_field("maxRSS", max_rss);
+    set_field("sharedMemorySize", shared_mem);
+    set_field("unsharedDataSize", unshared_data);
+    set_field("unsharedStackSize", unshared_stack);
+    set_field("minorPageFault", minor_faults);
+    set_field("majorPageFault", major_faults);
+    set_field("swappedOut", swapped_out);
+    set_field("fsRead", fs_read);
+    set_field("fsWrite", fs_write);
+    set_field("ipcSent", ipc_sent);
+    set_field("ipcReceived", ipc_recv);
+    set_field("signalsCount", signals);
+    set_field("voluntaryContextSwitches", vcsw);
+    set_field("involuntaryContextSwitches", ivcsw);
+    f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+}
+
+/// process.getActiveResourcesInfo() -> string[]. Node returns names of
+/// libuv handles currently keeping the loop alive (TLSWrap, Timeout,
+/// TCPSERVERWRAP, ...). Perry doesn't surface that introspection yet —
+/// return an empty array. The surface is callable so
+/// `typeof process.getActiveResourcesInfo === "function"` holds.
+#[no_mangle]
+pub extern "C" fn js_process_active_resources_info() -> f64 {
+    let arr = crate::array::js_array_alloc(0);
+    f64::from_bits(JSValue::pointer(arr as *const u8).bits())
+}
+
 /// process.cpuUsage(prior?) -> { user, system } µs.
 /// Reads CPU time consumed by the process via getrusage(RUSAGE_SELF) on
 /// unix. With a `prior` object, returns the diff (clamped to >= 0).

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1111 entries across 80 modules
+// Coverage: 1113 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1478,6 +1478,8 @@ declare module "process" {
   /** stdlib */
   export function emitWarning(...args: any[]): any;
   /** stdlib */
+  export function getActiveResourcesInfo(...args: any[]): any;
+  /** stdlib */
   export function getegid(...args: any[]): any;
   /** stdlib */
   export function geteuid(...args: any[]): any;
@@ -1485,6 +1487,8 @@ declare module "process" {
   export function getgid(...args: any[]): any;
   /** stdlib */
   export function getuid(...args: any[]): any;
+  /** stdlib */
+  export function resourceUsage(...args: any[]): any;
   /** stdlib */
   export function threadCpuUsage(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1111 entries across 80 modules.
+Total: 1113 entries across 80 modules.
 
 ## Modules
 
@@ -1411,10 +1411,12 @@ Total: 1111 entries across 80 modules.
 - `constrainedMemory` — module
 - `cpuUsage` — module
 - `emitWarning` — module
+- `getActiveResourcesInfo` — module
 - `getegid` — module
 - `geteuid` — module
 - `getgid` — module
 - `getuid` — module
+- `resourceUsage` — module
 - `threadCpuUsage` — module
 - `umask` — module
 

--- a/test-parity/node-suite/process/resource/active-resources.ts
+++ b/test-parity/node-suite/process/resource/active-resources.ts
@@ -1,2 +1,4 @@
-// process.getActiveResourcesInfo() returns an array of active-resource names.
+// process.getActiveResourcesInfo() returns a string[] of names of libuv
+// handles keeping the loop alive. Perry returns an empty array (no
+// introspection yet). The test verifies the shape, not the contents.
 console.log("is array:", Array.isArray(process.getActiveResourcesInfo()));

--- a/test-parity/node-suite/process/resource/resource-usage.ts
+++ b/test-parity/node-suite/process/resource/resource-usage.ts
@@ -1,4 +1,5 @@
-// process.resourceUsage() returns a struct of numeric usage counters.
+// process.resourceUsage() returns a struct of getrusage(RUSAGE_SELF) counters.
 const r = process.resourceUsage();
-console.log("maxRSS:", typeof r.maxRSS === "number");
-console.log("userCPUTime:", typeof r.userCPUTime === "number");
+console.log("is object:", typeof r === "object");
+console.log("userCPUTime is number:", typeof r.userCPUTime === "number");
+console.log("maxRSS is number:", typeof r.maxRSS === "number");


### PR DESCRIPTION
Closes #1376.

## Summary

- `process.resourceUsage()` returns the full Node-compatible 16-field `getrusage(RUSAGE_SELF)` struct (`userCPUTime`, `maxRSS`, ...).
- `process.getActiveResourcesInfo()` returns `string[]` — empty for now (Perry doesn't expose libuv handle introspection yet), but callable so library code probing it doesn't crash.
- Both `typeof` checks return `"function"`.

## Approach

Same shape as #1374 / #1373 / #1411 / #1377 / #1408 / #1375 / #1347:

- Two no-args HIR variants. Codegen routes to `js_process_resource_usage` / `js_process_active_resources_info`.
- `js_process_resource_usage` reads `getrusage(RUSAGE_SELF)` on unix and packs all 16 fields. Linux's `ru_maxrss` is normalized from kilobytes to bytes (Node does the same). Non-unix returns zeros.
- `js_process_active_resources_info` allocates an empty array.
- `PropertyGet` GlobalGet arm + `is_native_module_callable_export` register both names.
- `api-manifest` gets `method` entries.

## Test plan

- [x] `test-parity/node-suite/process/resource/resource-usage.ts` — `typeof r === "object"` + numeric `userCPUTime` + numeric `maxRSS`.
- [x] `test-parity/node-suite/process/resource/active-resources.ts` — `Array.isArray(...)`.
- [x] Both match Node.
- [x] `cargo fmt --all -- --check` clean.
- [x] No regressions in the process node-suite (pre-existing gaps remain pre-existing).