### PR TITLE
feat(process): implement uncaught-exception capture API (#1406)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -134,6 +134,22 @@ pub(super) fn try_native_module_methods(
                             // being undefined downstream.
                             return Ok(Ok(Expr::Undefined));
                         }
+                        "hasUncaughtExceptionCaptureCallback" => {
+                            // #1406: returns a boolean indicating whether
+                            // a capture callback has been installed via
+                            // setUncaughtExceptionCaptureCallback. Perry
+                            // doesn't expose that hook, so the answer is
+                            // always `false`.
+                            return Ok(Ok(Expr::Bool(false)));
+                        }
+                        "setUncaughtExceptionCaptureCallback" => {
+                            // #1406: installs a single callback that
+                            // intercepts uncaught exceptions before they
+                            // reach the `uncaughtException` event. Perry
+                            // doesn't have the hook to install — the call
+                            // is a no-op returning undefined.
+                            return Ok(Ok(Expr::Undefined));
+                        }
                         "exit" => {
                             // process.exit() / process.exit(code) — never
                             // returns, terminates the process. Until now this

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -619,6 +619,8 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                                         | "setSourceMapsEnabled"
                                         | "getBuiltinModule"
                                         | "dlopen"
+                                        | "hasUncaughtExceptionCaptureCallback"
+                                        | "setUncaughtExceptionCaptureCallback"
                                 )
                                 && ctx.lookup_local("process").is_none()
                             {


### PR DESCRIPTION
## Summary

Node exposes `process.hasUncaughtExceptionCaptureCallback()` (boolean getter) + `process.setUncaughtExceptionCaptureCallback(fn|null)` (installs/clears a single capture callback that intercepts uncaught exceptions before the `uncaughtException` event fires). Perry was reading both as bare numbers — `typeof` lied with `"number"` and any call crashed with "value is not a function".

Perry doesn't expose the underlying capture hook, so both behave as no-ops:

- `hasUncaughtExceptionCaptureCallback()` → `Expr::Bool(false)`.
- `setUncaughtExceptionCaptureCallback(fn|null)` → `Expr::Undefined`.

Closes #1406.

## Changes

- **Call lowering** (`native_module.rs`): two new arms sitting next to the `ref` / `unref` / `setSourceMapsEnabled` / `getBuiltinModule` / `dlopen` stubs.
- **Typeof fold** (`lower_expr.rs`): both method names added to the same process-method-as-function list so `typeof process.X === "function"` returns true for feature detection.

## Test plan

- [x] `test-parity/node-suite/process/exception/uncaught-capture.ts` (in the granular suite from #1331) now passes — byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.