### PR TITLE
fix(process): process.env.X = v now persists to the OS environment (#1344)

### DIFF
--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -79,6 +79,28 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 );
                 return Ok(val_double);
             }
+            // #1344: `process.env.X = v` must persist to the real OS
+            // environment, not just a cached ProcessEnv object backing.
+            // Pre-fix the generic `js_object_set_field_by_name` path
+            // stored on the cached dict but `process.env.X` (`EnvGet`)
+            // reads from `std::env::var` directly, so the value never
+            // round-tripped and child processes inherited the
+            // unmodified parent env.
+            //
+            // Route the store through `js_setenv(key, value)` (writes
+            // via `std::env::set_var`, coerces non-string values to
+            // strings via `js_jsvalue_to_string`). Reads still go
+            // through `js_getenv_value`, so the round-trip works.
+            if matches!(object.as_ref(), Expr::ProcessEnv) {
+                let key_idx = ctx.strings.intern(property);
+                let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                let val_double = lower_expr(ctx, value)?;
+                let blk = ctx.block();
+                let key_box = blk.load(DOUBLE, &key_handle_global);
+                let key_handle = unbox_to_i64(blk, &key_box);
+                blk.call_void("js_setenv", &[(I64, &key_handle), (DOUBLE, &val_double)]);
+                return Ok(val_double);
+            }
             // Scalar replacement fast path: store to the field's alloca.
             if let Expr::LocalGet(id) = object.as_ref() {
                 if let Some(slot) = ctx

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -436,6 +436,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_util_types_is_boxed_primitive", DOUBLE, &[DOUBLE]);
     module.declare_function("js_getenv", I64, &[I64]);
     module.declare_function("js_getenv_value", DOUBLE, &[I64]);
+    // #1344: process.env.X = v / delete process.env.X.
+    module.declare_function("js_setenv", VOID, &[I64, DOUBLE]);
+    module.declare_function("js_removeenv", VOID, &[I64]);
     module.declare_function("js_console_table", VOID, &[DOUBLE]);
     module.declare_function("js_console_table_with_properties", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_console_trace", VOID, &[DOUBLE]);

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -446,6 +446,76 @@ pub extern "C" fn js_getenv_value(name_ptr: *const StringHeader) -> f64 {
     f64::from_bits(val.bits())
 }
 
+/// Set an environment variable. Backs `process.env.X = v` (#1344).
+///
+/// Reads via `js_getenv_value` already hit `std::env::var`, so writing
+/// through `std::env::set_var` round-trips with no caching layer to
+/// keep in sync. Non-string values are coerced via the same
+/// `js_jsvalue_to_string` Perry uses for `String(x)` / template
+/// concat — matching Node, which coerces `process.env.PORT = 8080` to
+/// `"8080"` before storing.
+///
+/// On unset (calling code routes `delete process.env.X` here too if
+/// it lowers the delete to `process.env.X = undefined` — the empty
+/// SAFE-EMPTY-STRING vs unset distinction is handled by
+/// `js_removeenv` below, which the delete path can call directly).
+#[no_mangle]
+pub extern "C" fn js_setenv(name_ptr: *const StringHeader, value: f64) {
+    use crate::value::js_jsvalue_to_string;
+    unsafe {
+        if name_ptr.is_null() || (name_ptr as usize) < 0x1000 {
+            return;
+        }
+        let len = (*name_ptr).byte_len as usize;
+        let data_ptr = (name_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        let name_bytes = std::slice::from_raw_parts(data_ptr, len);
+        let name = match std::str::from_utf8(name_bytes) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+
+        // Coerce value to string. js_jsvalue_to_string handles
+        // numbers/booleans/null/undefined and returns a *mut StringHeader.
+        let value_str_hdr = js_jsvalue_to_string(value);
+        if value_str_hdr.is_null() {
+            // Defensive: null shouldn't happen for non-undefined inputs,
+            // but if it does we silently no-op rather than crash. The
+            // `= undefined` case is intentionally rare in practice.
+            return;
+        }
+
+        // Read the string bytes back into a Rust &str directly off the
+        // StringHeader payload — same layout as `js_getenv` uses for the
+        // name above.
+        let v_len = (*value_str_hdr).byte_len as usize;
+        let v_data = (value_str_hdr as *const u8).add(std::mem::size_of::<StringHeader>());
+        let v_bytes = std::slice::from_raw_parts(v_data, v_len);
+        let v_str = match std::str::from_utf8(v_bytes) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        std::env::set_var(name, v_str);
+    }
+}
+
+/// Unset an environment variable. Backs `delete process.env.X` (#1344).
+#[no_mangle]
+pub extern "C" fn js_removeenv(name_ptr: *const StringHeader) {
+    unsafe {
+        if name_ptr.is_null() || (name_ptr as usize) < 0x1000 {
+            return;
+        }
+        let len = (*name_ptr).byte_len as usize;
+        let data_ptr = (name_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        let name_bytes = std::slice::from_raw_parts(data_ptr, len);
+        let name = match std::str::from_utf8(name_bytes) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        std::env::remove_var(name);
+    }
+}
+
 /// Get resident set size (RSS) in bytes using platform-specific APIs
 pub(crate) fn get_rss_bytes() -> u64 {
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary
- `process.env.X = v` was a no-op observable from the read side: `EnvGet` reads via `std::env::var`, but `PropertySet` only mutated a cached backing object.
- Adds a `js_setenv(name, value)` runtime helper that coerces via `js_jsvalue_to_string` and writes through `std::env::set_var`. Reads (`js_getenv_value`) now round-trip the same store.
- Adds `js_removeenv(name)` for the future `delete process.env.X` hookup.
- Routes `PropertySet { object: ProcessEnv, … }` through the new helper in `expr/property_set.rs`.

Closes #1344.

## Test plan
- [x] `process.env.MY = "hello"; process.env.MY === "hello"`
- [x] number coercion: `process.env.PORT = 8080` → `"8080"` (Node parity)
- [x] overwriting an existing var picks up the new value
- [x] regression: bare `process.env.HOME` reads still work
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p perry-runtime --lib` (538 passed)