### PR TITLE
feat(process): implement process.loadEnvFile as no-op stub (#1399)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -150,6 +150,17 @@ pub(super) fn try_native_module_methods(
                             // is a no-op returning undefined.
                             return Ok(Ok(Expr::Undefined));
                         }
+                        "loadEnvFile" => {
+                            // #1399: process.loadEnvFile(path?) (Node 20.12+)
+                            // reads a `.env` file from disk and adds its
+                            // KEY=value entries to process.env. Perry today
+                            // doesn't persist `process.env.X = v` writes
+                            // (#1344) so eagerly loading would be moot;
+                            // returning undefined is the closest no-op for
+                            // call sites that probe-and-call. Real `.env`
+                            // loading is tracked separately.
+                            return Ok(Ok(Expr::Undefined));
+                        }
                         "exit" => {
                             // process.exit() / process.exit(code) — never
                             // returns, terminates the process. Until now this

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -621,6 +621,7 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                                         | "dlopen"
                                         | "hasUncaughtExceptionCaptureCallback"
                                         | "setUncaughtExceptionCaptureCallback"
+                                        | "loadEnvFile"
                                 )
                                 && ctx.lookup_local("process").is_none()
                             {


### PR DESCRIPTION
## Summary

Node 20.12+ exposes `process.loadEnvFile(path?)` to read a `.env` file from disk and add its KEY=value entries to `process.env`. Perry was reading it as a bare number — `typeof process.loadEnvFile === "function"` returned false and call sites crashed with "value is not a function".

Perry today doesn't persist `process.env.X = v` writes (tracked in #1344), so eagerly loading a `.env` would be moot. Returning undefined is the closest no-op for the probe-and-call pattern. Real `.env` loading is tracked separately — this PR closes the typeof / call-doesn't-crash gap.

Closes #1399.

## Changes

- **Call lowering** (`native_module.rs`): folds to `Expr::Undefined`, sitting next to the `ref` / `unref` / `setSourceMapsEnabled` / `getBuiltinModule` / `dlopen` / `hasUncaughtExceptionCaptureCallback` / `setUncaughtExceptionCaptureCallback` arms.
- **Typeof fold** (`lower_expr.rs`): adds `loadEnvFile` to the same process-method-as-function list.

## Test plan

- [x] `test-parity/node-suite/process/methods/load-env-file.ts` (in the granular suite from #1331) now passes — byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.