### PR TITLE
feat(perf_hooks): implement performance.markResourceTiming as no-op (#1478)

### DIFF
--- a/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
+++ b/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
@@ -128,6 +128,15 @@ pub(super) fn lower_perf_hooks_method(
                     &[(DOUBLE, &a0)],
                 )
             }
+            // #1478: performance.markResourceTiming(info) appends a
+            // PerformanceResourceTiming entry built from a
+            // PerformanceTimingInfo-shaped object. Perry doesn't track
+            // the resource-timing buffer yet — return undefined as a
+            // no-op so feature-detect-and-call (`typeof X === "function"`
+            // + invocation) doesn't crash. The accompanying read of
+            // performance.getEntriesByType("resource") still returns
+            // an empty array.
+            "markResourceTiming" => undef.clone(),
             _ => return Ok(None),
         };
         return Ok(Some(v));

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -386,6 +386,7 @@ pub(super) fn try_module_static_methods(
                             | "toJSON"
                             | "clearResourceTimings"
                             | "setResourceTimingBufferSize"
+                            | "markResourceTiming"
                     ) {
                         return Ok(Ok(Expr::NativeMethodCall {
                             module: "perf_hooks".to_string(),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -358,6 +358,11 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("perf_hooks", "toJSON")
             | ("perf_hooks", "clearResourceTimings")
             | ("perf_hooks", "setResourceTimingBufferSize")
+            // #1478: performance.markResourceTiming(info) records a
+            // PerformanceResourceTiming. Perry's runtime no-ops it but
+            // the property must still read as a function for
+            // feature-detection (`typeof X === "function"`) wrappers.
+            | ("perf_hooks", "markResourceTiming")
             | ("perf_hooks", "PerformanceObserver")
             | ("perf_hooks", "PerformanceEntry")
             | ("perf_hooks", "PerformanceMark")


### PR DESCRIPTION
## Summary

Node's `performance.markResourceTiming(info, ...)` records a `PerformanceResourceTiming` entry built from a `PerformanceTimingInfo`-shaped object (paired with `clearResourceTimings` / `setResourceTimingBufferSize`). Perry was reading the property as undefined — `typeof performance.markResourceTiming === "function"` returned false and any call crashed.

Perry doesn't track the resource-timing buffer yet, so the call is a no-op returning undefined. The accompanying read of `performance.getEntriesByType("resource")` still returns an empty array, matching the no-recorded-entries shape.

Closes #1478.

## Changes

- **HIR dispatch** (`module_static.rs`): adds `markResourceTiming` to the perf_hooks NativeMethodCall list.
- **Codegen** (`perf_hooks.rs`): folds the call to undefined, sitting next to the `clearResourceTimings` / `setResourceTimingBufferSize` arms.
- **Property-read typeof** (`object/native_module.rs`): adds `("perf_hooks", "markResourceTiming")` to the callable-export list so `typeof performance.markResourceTiming === "function"` matches Node and `const f = performance.markResourceTiming` is a callable bound-method closure.

## Test plan

- [x] `test-parity/node-suite/perf_hooks/resource-timing/mark-resource-timing.ts` (in the granular suite from #1331) now passes — byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.