### PR TITLE
feat(process): implement process.exitCode (default undefined + set/get) (#1350)

### DIFF
--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -439,6 +439,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // #1344: process.env.X = v / delete process.env.X.
     module.declare_function("js_setenv", VOID, &[I64, DOUBLE]);
     module.declare_function("js_removeenv", VOID, &[I64]);
+    // #1350: process.exitCode get/set.
+    module.declare_function("js_process_exit_code_get", DOUBLE, &[]);
+    module.declare_function("js_process_exit_code_set", DOUBLE, &[DOUBLE]);
     module.declare_function("js_console_table", VOID, &[DOUBLE]);
     module.declare_function("js_console_table_with_properties", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_console_trace", VOID, &[DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -288,6 +288,30 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
                         }
                     }
                 }
+                // #1350: process.exitCode = v. Route directly through
+                // the runtime setter so the read side
+                // (`process.exitCode` → `js_process_exit_code_get`)
+                // sees the assigned value. The setter returns its
+                // argument so the assignment expression yields the RHS,
+                // matching JS semantics. Bypasses the generic
+                // PropertySet → js_object_set_field_by_name path which
+                // would silently drop the write — same shape as the
+                // ProcessEnv assignment fix (#1344).
+                if obj_name == "process" && ctx.lookup_local("process").is_none() {
+                    if let ast::MemberProp::Ident(prop_ident) = &member.prop {
+                        if prop_ident.sym.as_ref() == "exitCode" {
+                            return Ok(Expr::Call {
+                                callee: Box::new(Expr::ExternFuncRef {
+                                    name: "js_process_exit_code_set".to_string(),
+                                    param_types: vec![perry_types::Type::Number],
+                                    return_type: perry_types::Type::Number,
+                                }),
+                                args: vec![*value],
+                                type_args: vec![],
+                            });
+                        }
+                    }
+                }
             }
 
             // Issue #838: JS-classic prototype-method assignment.

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -240,6 +240,24 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                             index: Box::new(Expr::Number(0.0)),
                         });
                     }
+                    // #1350: process.exitCode value-read. Default is
+                    // `undefined` until something assigns to it; after a
+                    // write the previously-stored value round-trips. The
+                    // assignment side intercepts `process.exitCode = v`
+                    // in `lower_expr.rs` and routes to
+                    // `js_process_exit_code_set`. Both helpers share a
+                    // thread-local cell in `perry-runtime/src/process.rs`.
+                    "exitCode" => {
+                        return Ok(Expr::Call {
+                            callee: Box::new(Expr::ExternFuncRef {
+                                name: "js_process_exit_code_get".to_string(),
+                                param_types: vec![],
+                                return_type: Type::Number,
+                            }),
+                            args: vec![],
+                            type_args: vec![],
+                        });
+                    }
                     _ => {}
                 }
             }
@@ -330,6 +348,17 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                         return Ok(Expr::IndexGet {
                             object: Box::new(Expr::ProcessArgv),
                             index: Box::new(Expr::Number(0.0)),
+                        });
+                    }
+                    "exitCode" => {
+                        return Ok(Expr::Call {
+                            callee: Box::new(Expr::ExternFuncRef {
+                                name: "js_process_exit_code_get".to_string(),
+                                param_types: vec![],
+                                return_type: Type::Number,
+                            }),
+                            args: vec![],
+                            type_args: vec![],
                         });
                     }
                     _ => {}

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -446,6 +446,42 @@ pub extern "C" fn js_getenv_value(name_ptr: *const StringHeader) -> f64 {
     f64::from_bits(val.bits())
 }
 
+// ─── #1350: process.exitCode (default undefined + set/get) ────────────────────
+//
+// Node lets user code stash an exit code that `process.exit()` (no arg)
+// will use as the final code. Reads start `undefined`; writes coerce
+// the value to a number-like and stash it. We back this with a single
+// thread-local cell holding the NaN-boxed bits, default-initialised to
+// `JSValue::undefined()`'s bit pattern.
+
+thread_local! {
+    static PROCESS_EXIT_CODE: std::cell::Cell<u64> =
+        std::cell::Cell::new(crate::value::JSValue::undefined().bits());
+}
+
+/// `process.exitCode` value-read. Returns the last value assigned, or
+/// `undefined` if nothing has been set.
+#[no_mangle]
+pub extern "C" fn js_process_exit_code_get() -> f64 {
+    let bits = PROCESS_EXIT_CODE.with(|c| c.get());
+    f64::from_bits(bits)
+}
+
+/// `process.exitCode = v`. Stores the raw NaN-boxed bits verbatim so
+/// the read round-trips byte-for-byte — Node forwards e.g. the string
+/// `"0"` as a string and only coerces when `process.exit()` runs.
+///
+/// Returns `value` so the call site can use it as the result of the
+/// assignment expression (JS assignment evaluates to the RHS value).
+/// That keeps the codegen path uniform with other `js_*` runtime
+/// helpers that return f64 — see `lower_call/extern_func.rs:330` for
+/// the direct-call path.
+#[no_mangle]
+pub extern "C" fn js_process_exit_code_set(value: f64) -> f64 {
+    PROCESS_EXIT_CODE.with(|c| c.set(value.to_bits()));
+    value
+}
+
 /// Set an environment variable. Backs `process.env.X = v` (#1344).
 ///
 /// Reads via `js_getenv_value` already hit `std::env::var`, so writing


### PR DESCRIPTION
## Summary
- `typeof process.exitCode` was `"number"` (sentinel 0.0); Node returns `"undefined"` until something assigns.
- `process.exitCode = N` was silently dropped: the PropertySet went to an unobserved backing object while there was no read side hooked up.

This PR backs `process.exitCode` with a thread-local cell holding NaN-boxed bits (default `JSValue::undefined()`). Two helpers:

- `js_process_exit_code_get() -> f64` — returns the stored bits.
- `js_process_exit_code_set(v) -> f64` — stores `v`'s bits and returns `v`, so the assignment expression yields the RHS.

Lowering in `expr_member.rs` (reads) and `expr_assign.rs::AssignTarget::Member` (writes) routes to those via `Call { ExternFuncRef { "js_process_*" }, … }` — the `js_*` direct-call path in `lower_call/extern_func.rs` emits a direct named call without going through closure dispatch.

Closes #1350.

## Test plan
- [x] `typeof process.exitCode === "undefined"` and `process.exitCode === undefined` before any assignment
- [x] `process.exitCode = 7; process.exitCode === 7` round-trip
- [x] overwriting picks up the new value
- [x] `const r = (process.exitCode = 42); r === 42`
- [x] `process.exitCode = undefined` round-trips to `undefined`
- [x] all bullets above byte-for-byte match Node
- [x] `cargo fmt --all -- --check`