### PR TITLE
refactor(hir): extract shared crypto.<method> lowering helper (#1434)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/crypto.rs
+++ b/crates/perry-hir/src/lower/expr_call/crypto.rs
@@ -1,0 +1,62 @@
+//! Shared `crypto.<method>` lowering helpers.
+//!
+//! #1434: both the named-import path (`import { randomBytes } from
+//! "node:crypto"; randomBytes(16)`, lowered in `globals.rs`) and the
+//! dotted path (`crypto.randomBytes(16)`, lowered in `module_static.rs`)
+//! used to inline the same `Expr::CryptoRandom*` constructions side-by-
+//! side, requiring parallel edits every time a new method joined the
+//! group. Extracting the shared piece into one helper makes the
+//! "named-import + dotted form share a codegen path" invariant the
+//! type-checker enforces.
+//!
+//! Only methods whose lowering shape is **identical between the two
+//! sites** live here. Methods that diverge — e.g. dotted-only
+//! `getRandomValues` (rewrites into an instance method on the buffer)
+//! and dotted-only `sha256`/`md5` (dedicated `Expr::CryptoSha256` /
+//! `Expr::CryptoMd5` shortcuts) — stay at their call site.
+
+use crate::ir::Expr;
+
+/// Cheap pre-check so the caller can avoid moving `args` into the
+/// helper when the method isn't ours. Must stay in sync with the
+/// `match` in [`lower_crypto_passthrough`].
+pub(super) fn is_passthrough_method(method: &str) -> bool {
+    matches!(method, "randomFillSync" | "randomUUID" | "randomBytes")
+}
+
+/// Lower one of the shared `crypto.<method>(...)` shapes. Returns
+/// `Some(expr)` when `method` is in the set this helper covers,
+/// `None` otherwise.
+///
+/// Today's set:
+/// - `randomFillSync(buffer, offset?, size?)` → `Expr::CryptoRandomFillSync`.
+/// - `randomUUID()` → `Expr::CryptoRandomUUID`.
+/// - `randomBytes(size)` → `Expr::CryptoRandomBytes`.
+pub(super) fn lower_crypto_passthrough(method: &str, args: Vec<Expr>) -> Option<Expr> {
+    match method {
+        "randomFillSync" => {
+            if args.is_empty() {
+                return None;
+            }
+            let mut iter = args.into_iter();
+            let buffer = iter.next().unwrap();
+            let offset = iter.next().unwrap_or(Expr::Undefined);
+            let size = iter.next().unwrap_or(Expr::Undefined);
+            Some(Expr::CryptoRandomFillSync {
+                buffer: Box::new(buffer),
+                offset: Box::new(offset),
+                size: Box::new(size),
+            })
+        }
+        "randomUUID" => Some(Expr::CryptoRandomUUID),
+        "randomBytes" => {
+            if args.is_empty() {
+                return None;
+            }
+            Some(Expr::CryptoRandomBytes(Box::new(
+                args.into_iter().next().unwrap(),
+            )))
+        }
+        _ => None,
+    }
+}

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -668,30 +668,15 @@ pub(super) fn try_global_builtins(
             // arm above (line ~3060) uses, so both call shapes
             // share one codegen path.
             if module_name == "crypto" {
+                if super::crypto::is_passthrough_method(func_name) {
+                    if let Some(expr) = super::crypto::lower_crypto_passthrough(
+                        func_name,
+                        std::mem::take(&mut args),
+                    ) {
+                        return Ok(Ok(expr));
+                    }
+                }
                 match func_name {
-                    "randomFillSync" => {
-                        if !args.is_empty() {
-                            let mut iter = args.into_iter();
-                            let buffer = iter.next().unwrap();
-                            let offset = iter.next().unwrap_or(Expr::Undefined);
-                            let size = iter.next().unwrap_or(Expr::Undefined);
-                            return Ok(Ok(Expr::CryptoRandomFillSync {
-                                buffer: Box::new(buffer),
-                                offset: Box::new(offset),
-                                size: Box::new(size),
-                            }));
-                        }
-                    }
-                    "randomUUID" => {
-                        return Ok(Ok(Expr::CryptoRandomUUID));
-                    }
-                    "randomBytes" => {
-                        if !args.is_empty() {
-                            return Ok(Ok(Expr::CryptoRandomBytes(Box::new(
-                                args.into_iter().next().unwrap(),
-                            ))));
-                        }
-                    }
                     // `createSecretKey(key, encoding?)` from a named
                     // import. Without this arm the call lowered to a
                     // generic NativeMethodCall with no dispatcher for

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -28,6 +28,7 @@ use super::{
 };
 
 mod array_only_methods;
+mod crypto;
 mod globals;
 mod imported_array_methods;
 mod inline_array_methods;

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -863,17 +863,18 @@ pub(super) fn try_module_static_methods(
             if is_crypto_module {
                 if let ast::MemberProp::Ident(method_ident) = &member.prop {
                     let method_name = method_ident.sym.as_ref();
+                    // #1434: keep the named-import + dotted form on one
+                    // shared lowering path for the methods whose shape
+                    // matches between sites.
+                    if super::crypto::is_passthrough_method(method_name) {
+                        if let Some(expr) = super::crypto::lower_crypto_passthrough(
+                            method_name,
+                            std::mem::take(&mut args),
+                        ) {
+                            return Ok(Ok(expr));
+                        }
+                    }
                     match method_name {
-                        "randomBytes" => {
-                            if !args.is_empty() {
-                                return Ok(Ok(Expr::CryptoRandomBytes(Box::new(
-                                    args.into_iter().next().unwrap(),
-                                ))));
-                            }
-                        }
-                        "randomUUID" => {
-                            return Ok(Ok(Expr::CryptoRandomUUID));
-                        }
                         "sha256" => {
                             if !args.is_empty() {
                                 return Ok(Ok(Expr::CryptoSha256(Box::new(
@@ -907,27 +908,10 @@ pub(super) fn try_module_static_methods(
                                 }));
                             }
                         }
-                        // `crypto.randomFillSync(buf, offset?, size?)`
-                        // — fills `buf` in-place with random bytes
-                        // and returns it. Handles BufferHeader and
-                        // TypedArrayHeader (Uint8Array, Uint32Array,
-                        // etc — axios uses Uint32Array). The
-                        // offset/size args are optional; absent
-                        // values lower as Undefined and the runtime
-                        // treats them as 0 / full-length.
-                        "randomFillSync" => {
-                            if !args.is_empty() {
-                                let mut iter = args.into_iter();
-                                let buffer = iter.next().unwrap();
-                                let offset = iter.next().unwrap_or(Expr::Undefined);
-                                let size = iter.next().unwrap_or(Expr::Undefined);
-                                return Ok(Ok(Expr::CryptoRandomFillSync {
-                                    buffer: Box::new(buffer),
-                                    offset: Box::new(offset),
-                                    size: Box::new(size),
-                                }));
-                            }
-                        }
+                        // `crypto.randomBytes` / `randomUUID` /
+                        // `randomFillSync` are handled by the shared
+                        // `crypto::lower_crypto_passthrough` above —
+                        // see #1434.
                         _ => {} // Fall through to generic handling
                     }
                 }


### PR DESCRIPTION
## Summary

The named-import path (`import { randomBytes } from "node:crypto"; randomBytes(16)`, lowered in `globals.rs`) and the dotted path (`crypto.randomBytes(16)`, lowered in `module_static.rs`) used to inline the same `Expr::CryptoRandom*` constructions side-by-side. Each new crypto method required parallel edits at both sites, and #1419 had to keep the two lists manually in sync.

Closes #1434.

## Changes

New `expr_call/crypto.rs` submodule with:
- `lower_crypto_passthrough(method, args) -> Option<Expr>` — the shared lowering.
- `is_passthrough_method(method) -> bool` — cheap pre-check so the caller doesn't move `args` into the helper when the method isn't ours.

Both call sites delegate to it. Today's covered set: `randomBytes`, `randomUUID`, `randomFillSync`.

Methods whose lowering shape **diverges** between sites stay at their call site:
- Dotted-only `sha256` / `md5` (dedicated `Expr::CryptoSha256` / `Expr::CryptoMd5` shortcuts).
- Dotted-only `getRandomValues` (rewrites into an instance method on the buffer).
- Named-import-only `createSecretKey` (synthetic `PropertyGet` through `NativeModuleRef`).

The shared helper grows naturally when a method's shape lines up across both sites.

## Test plan

- [x] Smoke-tested both shapes: `randomBytes(n)` / `randomUUID()` / `randomFillSync(buf)` produce identical output through named-import and dotted forms.
- [x] `cargo fmt --all -- --check` clean.

Pure refactor — behavior identical.