### PR TITLE
feat(process): implement process.loadEnvFile(path?) (#1399)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1870,6 +1870,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("process", "resourceUsage", false, None),
     method("process", "getActiveResourcesInfo", false, None),
     method("process", "hrtime", false, None),
+    method("process", "loadEnvFile", false, None),
     property("process", "argv"),
     property("process", "platform"),
     property("process", "arch"),

--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -551,6 +551,13 @@ impl JsEmitter {
                 self.emit_expr(value);
                 self.output.push_str(") : undefined)");
             }
+            Expr::ProcessLoadEnvFile(path) => {
+                self.output.push_str("(typeof process !== 'undefined' && typeof process.loadEnvFile === 'function' ? process.loadEnvFile(");
+                if let Some(p) = path {
+                    self.emit_expr(p);
+                }
+                self.output.push_str(") : undefined)");
+            }
             Expr::ProcessNextTick { callback, args } => {
                 self.output.push_str("(typeof process !== 'undefined' ? process.nextTick(");
                 self.emit_expr(callback);

--- a/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/url_process_path.rs
@@ -131,7 +131,8 @@ impl<'a> FuncEmitCtx<'a> {
             | Expr::ProcessUmask(_)
             | Expr::ProcessEmitWarning(_)
             | Expr::ProcessCpuUsage(_)
-            | Expr::ProcessSetTitle(_) => {
+            | Expr::ProcessSetTitle(_)
+            | Expr::ProcessLoadEnvFile(_) => {
                 func.instruction(&Instruction::I64Const(TAG_UNDEFINED as i64));
             }
             Expr::EnvGet(_) | Expr::EnvGetDynamic(_) => {

--- a/crates/perry-codegen/src/expr/misc_methods.rs
+++ b/crates/perry-codegen/src/expr/misc_methods.rs
@@ -138,6 +138,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(v)
         }
 
+        // -------- process.loadEnvFile(path?) (#1399) --------
+        Expr::ProcessLoadEnvFile(path) => {
+            let path_val = if let Some(e) = path {
+                lower_expr(ctx, e)?
+            } else {
+                crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            ctx.block()
+                .call_void("js_process_load_env_file", &[(DOUBLE, &path_val)]);
+            Ok(crate::nanbox::double_literal(f64::from_bits(
+                crate::nanbox::TAG_UNDEFINED,
+            )))
+        }
+
         // -------- RegExpExecIndex — reads thread-local from the last exec() call --------
         Expr::RegExpExecIndex => Ok(ctx.block().call(DOUBLE, "js_regexp_exec_get_index", &[])),
 

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1046,6 +1046,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ProcessHrtime(..)
         | Expr::ProcessTitle
         | Expr::ProcessSetTitle(..)
+        | Expr::ProcessLoadEnvFile(..)
         | Expr::RegExpExecIndex
         | Expr::CryptoRandomUUID
         | Expr::CryptoRandomBytes(..)

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -556,6 +556,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         | "resourceUsage"
                         | "getActiveResourcesInfo"
                         | "hrtime"
+                        | "loadEnvFile"
                 ) {
                     let mod_idx = ctx.strings.intern("process");
                     let mod_bytes_global = format!("@{}", ctx.strings.entry(mod_idx).bytes_global);

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -472,6 +472,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_hrtime", DOUBLE, &[DOUBLE]);
     module.declare_function("js_process_title", DOUBLE, &[]);
     module.declare_function("js_process_set_title", VOID, &[DOUBLE]);
+    module.declare_function("js_process_load_env_file", VOID, &[DOUBLE]);
     module.declare_function("js_process_chdir", VOID, &[I64]);
     module.declare_function("js_process_kill", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_process_exit", VOID, &[DOUBLE]);

--- a/crates/perry-hir/src/audit.rs
+++ b/crates/perry-hir/src/audit.rs
@@ -287,6 +287,7 @@ fn specialized_stdlib_call(expr: &Expr) -> Option<(&'static str, &'static str)> 
         Expr::ProcessHrtime(_) => ("process", "hrtime"),
         Expr::ProcessTitle => ("process", "title"),
         Expr::ProcessSetTitle(_) => ("process", "title"),
+        Expr::ProcessLoadEnvFile(_) => ("process", "loadEnvFile"),
         Expr::ProcessStdinIsTTY => ("process", "stdin.isTTY"),
         Expr::ProcessStdoutIsTTY => ("process", "stdout.isTTY"),
         Expr::ProcessStderrIsTTY => ("process", "stderr.isTTY"),

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -469,10 +469,11 @@ pub enum Expr {
     ProcessCpuUsage(Option<Box<Expr>>), // process.cpuUsage(prior?) -> { user, system } µs (diff if prior given)
     ProcessResourceUsage, // process.resourceUsage() -> {userCPUTime, maxRSS, ...} (#1376)
     ProcessActiveResourcesInfo, // process.getActiveResourcesInfo() -> string[] (#1376)
-    ProcessTitle,         // process.title getter (#1401)
-    ProcessSetTitle(Box<Expr>), // process.title = X setter (#1401)
-    ProcessStdin,         // process.stdin -> stub object { write: fn }
-    ProcessStdout,        // process.stdout -> stub object { write: fn }
+    ProcessTitle,
+    ProcessSetTitle(Box<Expr>), // process.title getter / `process.title = X` setter (#1401)
+    ProcessLoadEnvFile(Option<Box<Expr>>), // process.loadEnvFile(path?) -> undefined (#1399)
+    ProcessStdin,               // process.stdin -> stub object { write: fn }
+    ProcessStdout,              // process.stdout -> stub object { write: fn }
     // process.stderr -> stub object { write: fn }
     ProcessStderr,
     // process.stdin.setRawMode(enabled) -> stdin (#347 Phase 2)

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -267,6 +267,17 @@ pub(super) fn try_native_module_methods(
                             };
                             return Ok(Ok(Expr::ProcessHrtime(prior)));
                         }
+                        "loadEnvFile" => {
+                            // process.loadEnvFile(path?) — reads a .env file
+                            // and writes each KEY=VAL into the OS environment.
+                            // Default path is './.env'. Returns undefined.
+                            let path = if !args.is_empty() {
+                                Some(Box::new(args.into_iter().next().unwrap()))
+                            } else {
+                                None
+                            };
+                            return Ok(Ok(Expr::ProcessLoadEnvFile(path)));
+                        }
                         _ => {} // Fall through to generic handling
                     }
                 }

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -309,6 +309,10 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
         Expr::ProcessSetTitle(v) => {
             Expr::ProcessSetTitle(Box::new(substitute_expr(v, substitutions)))
         }
+        Expr::ProcessLoadEnvFile(p) => Expr::ProcessLoadEnvFile(
+            p.as_ref()
+                .map(|e| Box::new(substitute_expr(e, substitutions))),
+        ),
 
         // File system
         Expr::FsReadFileSync(path) => {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -100,6 +100,7 @@ impl SH for Expr {
             Expr::ProcessHrtime(e) => { tag(h, 11234); e.hash(h); }
             Expr::ProcessTitle => tag(h, 11235),
             Expr::ProcessSetTitle(e) => { tag(h, 11236); e.as_ref().hash(h); }
+            Expr::ProcessLoadEnvFile(e) => { tag(h, 11237); e.hash(h); }
             Expr::ProcessStdin => tag(h, 70),
             Expr::ProcessStdout => tag(h, 71),
             Expr::ProcessStderr => tag(h, 72),

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1070,6 +1070,11 @@ where
             }
         }
         Expr::ProcessSetTitle(v) => f(v),
+        Expr::ProcessLoadEnvFile(opt) => {
+            if let Some(v) = opt {
+                f(v);
+            }
+        }
 
         // ─── Child process ───────────────────────────────────────────────
         Expr::ChildProcessExecSync { command, options } => {

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1051,6 +1051,11 @@ where
             }
         }
         Expr::ProcessSetTitle(v) => f(v),
+        Expr::ProcessLoadEnvFile(opt) => {
+            if let Some(v) = opt {
+                f(v);
+            }
+        }
         Expr::ChildProcessExecSync { command, options } => {
             f(command);
             if let Some(o) = options {

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -289,6 +289,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("process", "resourceUsage")
             | ("process", "getActiveResourcesInfo")
             | ("process", "hrtime")
+            | ("process", "loadEnvFile")
             | ("tty", "isatty")
             | ("tty", "ReadStream")
             | ("tty", "WriteStream")

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -100,6 +100,60 @@ pub extern "C" fn js_process_set_title(value: f64) {
     PROCESS_TITLE.with(|c| *c.borrow_mut() = Some(s));
 }
 
+/// process.loadEnvFile(path?) -> undefined. Reads a `.env` file and sets
+/// each KEY=VALUE line via `std::env::set_var`. Default path is `./.env`
+/// (matches Node 20.12+). Lines starting with `#` are comments; matching
+/// leading/trailing single or double quotes on the value are stripped.
+/// On read failure (missing file, permission error) we silently no-op so
+/// library code can call this defensively.
+#[no_mangle]
+pub extern "C" fn js_process_load_env_file(path: f64) {
+    let undef_bits = crate::value::TAG_UNDEFINED;
+    let path_str = if path.to_bits() == undef_bits {
+        ".env".to_string()
+    } else {
+        let ptr = crate::value::js_jsvalue_to_string(path);
+        if ptr.is_null() {
+            ".env".to_string()
+        } else {
+            unsafe {
+                let header = &*ptr;
+                let len = header.byte_len as usize;
+                let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+                String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
+            }
+        }
+    };
+    let contents = match std::fs::read_to_string(&path_str) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    for raw in contents.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, raw_value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        if key.is_empty() {
+            continue;
+        }
+        let mut value = raw_value.trim().to_string();
+        // Strip leading/trailing matching quotes.
+        if value.len() >= 2 {
+            let bytes = value.as_bytes();
+            let first = bytes[0];
+            let last = bytes[value.len() - 1];
+            if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+                value = value[1..value.len() - 1].to_string();
+            }
+        }
+        std::env::set_var(key, value);
+    }
+}
+
 /// process.umask() -> number. Returns the current file-mode creation mask
 /// without modifying it. POSIX's `umask` syscall has no read-only form, so
 /// we set the mask to 0, capture the previous value, then restore it.

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1114 entries across 80 modules
+// Coverage: 1115 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1489,6 +1489,8 @@ declare module "process" {
   export function getuid(...args: any[]): any;
   /** stdlib */
   export function hrtime(...args: any[]): any;
+  /** stdlib */
+  export function loadEnvFile(...args: any[]): any;
   /** stdlib */
   export function resourceUsage(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1114 entries across 80 modules.
+Total: 1115 entries across 80 modules.
 
 ## Modules
 
@@ -1417,6 +1417,7 @@ Total: 1114 entries across 80 modules.
 - `getgid` — module
 - `getuid` — module
 - `hrtime` — module
+- `loadEnvFile` — module
 - `resourceUsage` — module
 - `threadCpuUsage` — module
 - `umask` — module

--- a/test-parity/node-suite/process/methods/load-env-file.ts
+++ b/test-parity/node-suite/process/methods/load-env-file.ts
@@ -1,2 +1,3 @@
-// process.loadEnvFile(path?) loads a .env file (Node 20.12+).
+// process.loadEnvFile is a callable (#1399). The test only probes the
+// surface — calling it would mutate process.env (host-specific path).
 console.log("is function:", typeof process.loadEnvFile === "function");


### PR DESCRIPTION
Closes #1399.

## Summary

- `process.loadEnvFile(path?)` (Node 20.12+) reads a \`.env\` file and sets each \`KEY=VALUE\` line via \`std::env::set_var\`. Default path is \`./.env\`.
- `typeof process.loadEnvFile` returns `"function"`.

## Approach

Same shape as the rest of the #793 process gap fixes:

- `Expr::ProcessLoadEnvFile(Option<Box<Expr>>)` HIR variant (optional path).
- Codegen routes to `js_process_load_env_file(path_or_undefined)`.
- Runtime helper parses non-comment / non-empty lines as `KEY=VALUE`, strips matching leading/trailing single or double quotes on the value, and writes via `std::env::set_var`. Read failures silently no-op so library code can call defensively.
- `PropertyGet` GlobalGet arm + `is_native_module_callable_export` register \`"loadEnvFile"\`.
- `api-manifest` gets the method entry.

## Test plan

- [x] `test-parity/node-suite/process/methods/load-env-file.ts` matches Node (typeof shape — calling it would mutate host state).
- [x] `cargo fmt --all -- --check` clean.
- [x] No regressions in the process node-suite.