### PR TITLE
feat(perf_hooks): tag performance namespace as [object Performance] (#1479)

### DIFF
--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1399,6 +1399,21 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
                     }
                 }
             }
+            // #1479: native-module namespaces don't go through the
+            // class toStringTag hook (they share one synthetic
+            // class_id), so look them up by module name. Node tags
+            // `performance` as "Performance" — wire that up here so
+            // `Object.prototype.toString.call(performance)` matches.
+            if tag_str.is_none() && class_id == crate::object::native_module::NATIVE_MODULE_CLASS_ID
+            {
+                if let Some(module_name) =
+                    crate::object::native_module::read_native_module_name(obj_ptr)
+                {
+                    if let Some(tag) = native_module_to_string_tag(&module_name) {
+                        tag_str = Some(tag.to_string());
+                    }
+                }
+            }
         }
     }
     let formatted = match tag_str {
@@ -1408,6 +1423,20 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
     let bytes = formatted.as_bytes();
     let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
     f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK))
+}
+
+/// #1479: Map a native-module name (as stored in the namespace
+/// ObjectHeader's field 0) to its `Symbol.toStringTag` value. Only
+/// modules whose namespace is exposed as a singleton with a defined
+/// Node tag belong here — others fall back to "Object" via the
+/// caller's `None` arm.
+fn native_module_to_string_tag(module: &str) -> Option<&'static str> {
+    match module {
+        // `Object.prototype.toString.call(performance)` is
+        // "[object Performance]" in Node.
+        "perf_hooks" => Some("Performance"),
+        _ => None,
+    }
 }
 
 /// Mark a user-defined class as extending the built-in Error class.

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -72,6 +72,33 @@ pub extern "C" fn js_create_native_module_namespace(
     crate::value::js_nanbox_pointer(obj as i64)
 }
 
+/// #1479: read the module-name string stored in field 0 of a
+/// native-module-namespace ObjectHeader. Returns `None` if the field
+/// is missing, not a string, or the bytes aren't valid UTF-8. Caller
+/// must have confirmed `class_id == NATIVE_MODULE_CLASS_ID` already.
+///
+/// # Safety
+/// `obj_ptr` must point to a live `ObjectHeader` with
+/// `class_id == NATIVE_MODULE_CLASS_ID` (i.e. one produced by
+/// [`js_create_native_module_namespace`]).
+pub(crate) unsafe fn read_native_module_name(
+    obj_ptr: *const crate::object::ObjectHeader,
+) -> Option<String> {
+    const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+    let field = crate::object::js_object_get_field(obj_ptr, 0);
+    if !field.is_string() {
+        return None;
+    }
+    let str_ptr = (field.bits() & POINTER_MASK) as *const crate::string::StringHeader;
+    if str_ptr.is_null() || (str_ptr as usize) < 0x1000 {
+        return None;
+    }
+    let len = (*str_ptr).byte_len as usize;
+    let data = (str_ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+    let bytes = std::slice::from_raw_parts(data, len);
+    std::str::from_utf8(bytes).ok().map(|s| s.to_string())
+}
+
 /// Issue #649: codegen entry for `PropertyGet { NativeModuleRef(name),
 /// property }`. `NativeModuleRef` lowers to a literal `0.0` at the codegen
 /// level, so the generic PropertyGet path can't find the namespace


### PR DESCRIPTION
## Summary

Node returns `"[object Performance]"` from `Object.prototype.toString.call(performance)` — that's the spec'd host-tag for the `Performance` interface. Perry was returning the generic `"[object Object]"` because the perf_hooks namespace is a `NATIVE_MODULE_CLASS_ID`-tagged ObjectHeader: it never reaches the class-level `Symbol.toStringTag` hook (those are keyed by user-class class_id).

Closes #1479.

## Changes

- **`read_native_module_name(obj_ptr)` helper** in `object/native_module.rs`: decodes the module-name string stored in field 0 of the namespace ObjectHeader.
- **`js_object_to_string`** in `object/mod.rs`: after the class-level hook misses, if `class_id == NATIVE_MODULE_CLASS_ID` look up the module name and map it via a new `native_module_to_string_tag` table. Today the only entry is `perf_hooks → "Performance"`; future modules with a defined Node tag (`url → "URL"`, `events → "EventEmitter"`, etc.) slot in here cleanly.

## Test plan

- [x] `test-parity/node-suite/perf_hooks/shapes/to-string-tag.ts` (in the granular suite from #1331) now passes — byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.

## Out of scope

`performance[Symbol.toStringTag]` reading `"Performance"` directly remains a separate gap (Symbol-keyed property dispatch on namespace objects); the spec-compliant `Object.prototype.toString` path is now covered.