### PR TITLE
fix(perf_hooks): throw on mark detail with a Function (#1513)

### DIFF
--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -308,6 +308,17 @@ unsafe fn option_detail_bits(options_obj: *const crate::object::ObjectHeader) ->
     if v.is_undefined() {
         JSValue::null().bits()
     } else {
+        // #1513: Functions are not structured-cloneable — Node throws
+        // DataCloneError. Perry's structuredClone passes closures through
+        // silently, so detect the case up-front and throw a TypeError
+        // (Perry doesn't implement DOMException; the test only checks
+        // that *something* throws).
+        if v.is_pointer() {
+            let ptr = (v.bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+            if crate::closure::is_closure_ptr(ptr) {
+                throw_type_error("could not be cloned: a Function is not structured-cloneable");
+            }
+        }
         // Node structured-clones `detail`, so the stored value deep-equals the
         // input but is a distinct reference (mutating the original afterward
         // doesn't affect the entry).

--- a/test-parity/node-suite/perf_hooks/mark/detail-function-throws.ts
+++ b/test-parity/node-suite/perf_hooks/mark/detail-function-throws.ts
@@ -1,0 +1,10 @@
+import { performance } from "node:perf_hooks";
+// mark detail with a Function value is not structured-cloneable and throws
+// DataCloneError.
+let threw = false;
+try {
+  performance.mark("fn", { detail: () => {} });
+} catch {
+  threw = true;
+}
+console.log("threw:", threw);


### PR DESCRIPTION
Closes #1513.

## Summary

- `performance.mark(name, { detail: fn })` now throws (was silently accepted in Perry; Node throws DataCloneError).
- The throw is a TypeError rather than a DOMException-typed DataCloneError because Perry doesn't implement DOMException — the parity test just checks that something throws, not the error class.

## Approach

`option_detail_bits` (the shared helper consumed by `js_perf_mark` and `js_perf_measure`) detects the closure case up-front via `is_closure_ptr` and throws a TypeError before `js_structured_clone` (which otherwise passes closures through). Covers both call sites with one check.

## Test plan

- [x] `test-parity/node-suite/perf_hooks/mark/detail-function-throws.ts` matches Node (`threw: true`).
- [x] `cargo fmt --all -- --check` clean.