### PR TITLE
feat(perf_hooks): implement performance.timerify(fn) as identity wrapper (#1335)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2231,6 +2231,11 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("perf_hooks", "toJSON", false, None),
     method("perf_hooks", "clearResourceTimings", false, None),
     method("perf_hooks", "setResourceTimingBufferSize", false, None),
+    // #1478: stub — records the entry (no-op today, see codegen).
+    method("perf_hooks", "markResourceTiming", false, None),
+    // #1335: returns `fn` unchanged today; the spec'd "wraps fn to
+    // record a 'function' timeline entry" piece isn't recorded yet.
+    method("perf_hooks", "timerify", false, None),
     property("perf_hooks", "timeOrigin"),
     property("perf_hooks", "nodeTiming"),
     property("perf_hooks", "performance"),

--- a/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
+++ b/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
@@ -137,6 +137,17 @@ pub(super) fn lower_perf_hooks_method(
             // performance.getEntriesByType("resource") still returns
             // an empty array.
             "markResourceTiming" => undef.clone(),
+            // #1335: performance.timerify(fn) wraps `fn` so each call
+            // records a 'function' timeline entry; the wrapper still
+            // returns fn's result. Perry doesn't track function
+            // timings, so the simplest spec-compatible behavior is to
+            // return `fn` itself — `typeof timerified === "function"`
+            // still holds, calling it produces the original result,
+            // and the only missing side effect is pushing an entry
+            // into the PerformanceObserver "function" type (which
+            // isn't in our supported entryTypes set today, so no
+            // observer would see it anyway).
+            "timerify" => lower_or_undef(ctx, 0)?,
             _ => return Ok(None),
         };
         return Ok(Some(v));

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -376,6 +376,7 @@ pub(super) fn try_module_static_methods(
                             | "clearResourceTimings"
                             | "setResourceTimingBufferSize"
                             | "markResourceTiming"
+                            | "timerify"
                     ) {
                         return Ok(Ok(Expr::NativeMethodCall {
                             module: "perf_hooks".to_string(),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -479,6 +479,12 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             // the property must still read as a function for
             // feature-detection (`typeof X === "function"`) wrappers.
             | ("perf_hooks", "markResourceTiming")
+            // #1335: performance.timerify(fn) wraps `fn` to record a
+            // 'function' timeline entry per call. Perry currently
+            // returns `fn` unchanged (no entry recorded), but the
+            // property must still read as a function for
+            // feature-detection.
+            | ("perf_hooks", "timerify")
             | ("perf_hooks", "PerformanceObserver")
             | ("perf_hooks", "PerformanceEntry")
             | ("perf_hooks", "PerformanceMark")

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1174 entries across 80 modules
+// Coverage: 1176 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -997,11 +997,15 @@ declare module "perf_hooks" {
   /** stdlib */
   export function mark(...args: any[]): any;
   /** stdlib */
+  export function markResourceTiming(...args: any[]): any;
+  /** stdlib */
   export function measure(...args: any[]): any;
   /** stdlib */
   export function now(...args: any[]): any;
   /** stdlib */
   export function setResourceTimingBufferSize(...args: any[]): any;
+  /** stdlib */
+  export function timerify(...args: any[]): any;
   /** stdlib */
   export function toJSON(...args: any[]): any;
 }

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1174 entries across 80 modules.
+Total: 1176 entries across 80 modules.
 
 ## Modules
 
@@ -1103,11 +1103,13 @@ Total: 1174 entries across 80 modules.
 - `getEntriesByName` — module
 - `getEntriesByType` — module
 - `mark` — module
+- `markResourceTiming` — module
 - `measure` — module
 - `now` — module
 - `observe` — instance *(class: `PerformanceObserver`)*
 - `setResourceTimingBufferSize` — module
 - `takeRecords` — instance *(class: `PerformanceObserver`)*
+- `timerify` — module
 - `toJSON` — module
 
 ### Properties

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -8,12 +8,6 @@
       "reason": "Free-text explanation. Keep the most-actionable signal first — what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
-  "node-suite/perf_hooks/timerify/timerify": {
-    "issue": "1335",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: performance.timerify(fn) unimplemented (not a function). Flips to PASS when #1335 lands."
-  },
   "node-suite/perf_hooks/histogram/monitor-event-loop-delay": {
     "issue": "1336",
     "added": "2026-05-22",


### PR DESCRIPTION
## Summary

Node's `performance.timerify(fn)` returns a wrapper that records a `'function'`-type timeline entry per call and forwards through to `fn`'s result. Perry was reading the property as undefined — feature-detect returned false and calling it crashed.

Spec-compatible minimum: return `fn` itself. The wrapper still satisfies `typeof === "function"` and produces the original result; only the side-effect of pushing a `'function'` entry into the PerformanceObserver buffer is missing. That entry type isn't in our supported entryTypes set today, so no observer would have seen it anyway.

Closes #1335.

## Changes

- **HIR dispatch** (`module_static.rs`): adds `timerify` to the perf_hooks NativeMethodCall list.
- **Codegen** (`perf_hooks.rs`): folds the call to its first arg via `lower_or_undef(ctx, 0)`, sitting next to the `markResourceTiming` arm shipped in #1478.
- **Property-read typeof** (`object/native_module.rs`): adds `("perf_hooks", "timerify")` to the callable-export list so `typeof performance.timerify === "function"` matches Node.
- **API manifest** (`perry-api-manifest`): declares `markResourceTiming` and `timerify` as supported so the "not implemented" gate doesn't reject calls.
- **Known failures**: removes the `perf_hooks/timerify/timerify` skip-list entry — the suite now expects PASS.

## Test plan

- [x] `test-parity/node-suite/perf_hooks/timerify/timerify.ts` is byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.