### PR TITLE
fix(structuredClone): break cycles instead of stack-overflowing (#1512)

### DIFF
--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -144,6 +144,44 @@ pub extern "C" fn js_decode_uri_component(value: f64) -> i64 {
 // structuredClone
 // ============================================================
 
+// Cycle-detection state for `js_structured_clone` (#1512). Tracks the source
+// pointers currently mid-clone on this thread. On re-entry for a pointer
+// already in the set, we return the original value rather than recursing
+// — that breaks the spec's "preserve reference identity" guarantee but
+// keeps cycles from infinite-recursing into a stack overflow, which is
+// what previously caused `performance.mark("n", { detail: o.self = o })`
+// to crash. Full reference-identity preservation would need a src→dst
+// map; deferred until a real user-facing need surfaces.
+thread_local! {
+    static STRUCTURED_CLONE_IN_PROGRESS: std::cell::RefCell<std::collections::HashSet<usize>>
+        = std::cell::RefCell::new(std::collections::HashSet::new());
+}
+
+fn structured_clone_seen(ptr: usize) -> bool {
+    STRUCTURED_CLONE_IN_PROGRESS.with(|set| set.borrow().contains(&ptr))
+}
+
+fn structured_clone_mark(ptr: usize) {
+    STRUCTURED_CLONE_IN_PROGRESS.with(|set| {
+        set.borrow_mut().insert(ptr);
+    });
+}
+
+fn structured_clone_unmark(ptr: usize) {
+    STRUCTURED_CLONE_IN_PROGRESS.with(|set| {
+        set.borrow_mut().remove(&ptr);
+    });
+}
+
+/// RAII guard that unmarks a pointer from the in-progress set when dropped,
+/// even on early returns from `js_structured_clone`'s POINTER_TAG branches.
+struct CloneCycleGuard(usize);
+impl Drop for CloneCycleGuard {
+    fn drop(&mut self) {
+        structured_clone_unmark(self.0);
+    }
+}
+
 /// structuredClone(value) -> deep-cloned value
 /// Handles numbers (pass-through), strings (copy), arrays/objects (shallow for now)
 #[no_mangle]
@@ -188,6 +226,15 @@ pub extern "C" fn js_structured_clone(value: f64) -> f64 {
             if (ptr as usize) < 0x10000 {
                 return value;
             }
+            // #1512: short-circuit on cycle so `o.self = o` doesn't infinite-
+            // recurse. The cycle edge resolves to the original value, not
+            // the clone — that breaks full reference-identity preservation
+            // but keeps cycles from stack-overflowing the runtime.
+            if structured_clone_seen(ptr as usize) {
+                return value;
+            }
+            structured_clone_mark(ptr as usize);
+            let _guard = CloneCycleGuard(ptr as usize);
             // Set is tracked in SET_REGISTRY (not GC_TYPE_SET since it has
             // no GC header). Check the registry BEFORE touching the GC
             // header bytes — they'd be garbage for raw-allocated sets.

--- a/test-parity/node-suite/perf_hooks/mark/detail-circular.ts
+++ b/test-parity/node-suite/perf_hooks/mark/detail-circular.ts
@@ -1,0 +1,13 @@
+import { performance } from "node:perf_hooks";
+// mark detail with a circular reference is accepted (structuredClone handles
+// cycles via reference preservation).
+const o: any = {};
+o.self = o;
+let ok = false;
+try {
+  performance.mark("c", { detail: o });
+  ok = true;
+} catch {
+  ok = false;
+}
+console.log("accepted:", ok);


### PR DESCRIPTION
Closes #1512.

## Summary

- `structuredClone` no longer infinite-recurses on circular references — `performance.mark("c", { detail: { o.self = o } })` now succeeds (was crashing with a stack overflow).
- The short-circuit returns the **original** pointer on cycle re-entry rather than the cloned one. That breaks the spec's reference-identity preservation inside the clone, but keeps cycles from crashing the runtime. Full identity preservation would need a src→dst map — deferred until a real need surfaces.

## Approach

Thread-local `HashSet<usize>` of source pointers currently mid-clone. POINTER_TAG branch checks the set on entry, short-circuits if seen, otherwise inserts before recursing into fields. An RAII `CloneCycleGuard` ensures the pointer is removed when the recursive frame exits, so subsequent top-level clones start fresh.

## Test plan

- [x] `test-parity/node-suite/perf_hooks/mark/detail-circular.ts` matches Node (`accepted: true`).
- [x] `cargo fmt --all -- --check` clean.