### PR TITLE
fix(android): cross-compile works on Windows hosts (#1508)

### DIFF
--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -1007,6 +1007,66 @@ pub(super) fn find_harmonyos_sdk() -> Option<PathBuf> {
     None
 }
 
+/// Build the `CC_*` / `CXX_*` / `CARGO_TARGET_*_LINKER` env vars that
+/// point cc-rs and rustc at the Android NDK toolchain. Issue #1508 —
+/// without these, `cargo build --target aarch64-linux-android` falls
+/// back to the host `cc`, which fails outright on Windows (`clang.exe
+/// not found`) and produces architecturally-mismatched objects on Unix.
+///
+/// Mirrors `harmonyos_cross_env` below. The NDK API level is fixed at
+/// 24 (Android 7.0) — matches the existing `platform_cmd.rs` /
+/// `link/mod.rs` JNI stub compile invocations.
+pub(super) fn android_cross_env(ndk_home: &Path, target: Option<&str>) -> Vec<(String, String)> {
+    let (triple, clang_target) = match target {
+        Some("android-x86_64") => ("x86_64-linux-android", "x86_64-linux-android24"),
+        // `android` (default) is the arm64 device target.
+        _ => ("aarch64-linux-android", "aarch64-linux-android24"),
+    };
+
+    // NDK ships per-host prebuilt toolchains. Tag must match the build
+    // machine, NOT the target — Windows-host builds were falling through
+    // to `linux-x86_64` and erroring out before this fix landed.
+    let host_tag = if cfg!(target_os = "macos") {
+        "darwin-x86_64"
+    } else if cfg!(target_os = "windows") {
+        "windows-x86_64"
+    } else {
+        "linux-x86_64"
+    };
+
+    let bin = ndk_home
+        .join("toolchains")
+        .join("llvm")
+        .join("prebuilt")
+        .join(host_tag)
+        .join("bin");
+    // On Windows the NDK's wrapper scripts are `.cmd` files.
+    let ext = if cfg!(target_os = "windows") {
+        ".cmd"
+    } else {
+        ""
+    };
+    let clang = bin.join(format!("{}-clang{}", clang_target, ext));
+    let clangpp = bin.join(format!("{}-clang++{}", clang_target, ext));
+
+    let triple_upper = triple.to_uppercase().replace('-', "_");
+    let triple_under = triple.replace('-', "_");
+
+    vec![
+        (format!("CC_{}", triple), clang.display().to_string()),
+        (format!("CC_{}", triple_under), clang.display().to_string()),
+        (format!("CXX_{}", triple), clangpp.display().to_string()),
+        (
+            format!("CXX_{}", triple_under),
+            clangpp.display().to_string(),
+        ),
+        (
+            format!("CARGO_TARGET_{}_LINKER", triple_upper),
+            clang.display().to_string(),
+        ),
+    ]
+}
+
 /// Cross-compile env vars to pass to `cargo build` so `cc-rs` picks up the
 /// OHOS SDK's clang + musl sysroot for any C source in dependency build.rs
 /// scripts (notably `libmimalloc-sys`, which needs `pthread.h`).

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -698,8 +698,11 @@ pub(super) fn build_and_run_link(
         )
         .ok();
         let ndk_home = std::env::var("ANDROID_NDK_HOME").unwrap_or_default();
+        // #1508: see platform_cmd.rs — same host-tag bug.
         let host_tag = if cfg!(target_os = "macos") {
             "darwin-x86_64"
+        } else if cfg!(target_os = "windows") {
+            "windows-x86_64"
         } else {
             "linux-x86_64"
         };
@@ -1311,6 +1314,22 @@ pub(super) fn build_and_run_link(
                     if is_harmonyos {
                         if let Some(sdk) = super::library_search::find_harmonyos_sdk() {
                             for (k, v) in super::library_search::harmonyos_cross_env(&sdk, target) {
+                                cargo_cmd.env(k, v);
+                            }
+                        }
+                    }
+                    // #1508: For Android, do the same with the NDK so cc-rs can
+                    // compile native C deps (libsqlite3-sys / libmimalloc-sys
+                    // / etc.) using the NDK clang. Without this, cc-rs falls
+                    // back to the host `cc` and fails with
+                    // `failed to find tool "clang.exe"` on Windows (and
+                    // architecturally-mismatched objects on Unix).
+                    if is_android {
+                        if let Some(ndk) = std::env::var_os("ANDROID_NDK_HOME") {
+                            for (k, v) in super::library_search::android_cross_env(
+                                std::path::Path::new(&ndk),
+                                target,
+                            ) {
                                 cargo_cmd.env(k, v);
                             }
                         }

--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -425,10 +425,21 @@ pub fn select_linker_command(
     } else if is_android {
         // Use Android NDK clang to produce a shared library (.so)
         let ndk_home = std::env::var("ANDROID_NDK_HOME").map_err(|_| {
-            anyhow!("ANDROID_NDK_HOME not set. Set it to your NDK path, e.g. $HOME/Library/Android/sdk/ndk/28.0.12433566")
+            anyhow!(
+                "ANDROID_NDK_HOME not set. Set it to your NDK path, e.g. \
+                 $HOME/Library/Android/sdk/ndk/28.0.12433566 (macOS), \
+                 $HOME/Android/Sdk/ndk/28.0.12433566 (Linux), or \
+                 %LOCALAPPDATA%\\Android\\Sdk\\ndk\\28.0.12433566 (Windows)"
+            )
         })?;
+        // #1508: Windows host falls through to "linux-x86_64" and points at
+        // a path that doesn't exist on the NDK. The NDK ships per-host
+        // prebuilt toolchains under `toolchains/llvm/prebuilt/<host>/`;
+        // the host tag must match the build machine, not the target.
         let host_tag = if cfg!(target_os = "macos") {
             "darwin-x86_64"
+        } else if cfg!(target_os = "windows") {
+            "windows-x86_64"
         } else {
             "linux-x86_64"
         };

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -577,6 +577,18 @@ pub(super) fn build_optimized_libs(
             }
         }
     }
+    // #1508: same shape for Android — cc-rs can't find the NDK clang
+    // otherwise (silent on Unix where `clang` happens to exist, hard fail
+    // on Windows with `clang.exe not found`).
+    if matches!(target, Some("android") | Some("android-x86_64")) {
+        if let Some(ndk) = std::env::var_os("ANDROID_NDK_HOME") {
+            for (k, v) in
+                super::library_search::android_cross_env(std::path::Path::new(&ndk), target)
+            {
+                cargo_cmd.env(k, v);
+            }
+        }
+    }
     if panic_abort_safe {
         // Override the workspace profile's `panic = "unwind"` for the
         // duration of this invocation. RUSTFLAGS is the only path that


### PR DESCRIPTION
## Summary
Two independent bugs blocked `perry compile --target android` on Windows hosts.

### Bug 1 — wrong NDK host tag
`link/platform_cmd.rs:430` and `link/mod.rs:701` both have a two-branch `cfg!` that fell through to `linux-x86_64` on Windows. The NDK ships per-host prebuilt toolchains under `toolchains/llvm/prebuilt/<host>/`, so the path didn't exist and the linker failed with `Android NDK clang not found at: …/prebuilt/linux-x86_64/…`. JNI stub compilation silently fell back via `unwrap_or(false)` and produced a broken binary.

Add explicit `cfg!(target_os = "windows") → "windows-x86_64"` branches in both files.

### Bug 2 — missing `android_cross_env`
Unlike HarmonyOS (which calls `harmonyos_cross_env` at `optimized_libs.rs:565` + `link/mod.rs:1316`), Android had no equivalent. cc-rs had nothing to point at when compiling native C deps (libsqlite3-sys / libmimalloc-sys) and bailed with `failed to find tool "clang.exe"` on Windows.

Add `android_cross_env(ndk_home, target)` in `library_search.rs` mirroring `harmonyos_cross_env`. Sets `CC_*` / `CXX_*` / `CARGO_TARGET_*_LINKER` to the NDK clang for the chosen target, using the host-aware tag from fix (1). On Windows the NDK uses `.cmd` wrapper scripts — append `.cmd` to the clang/clang++ names.

### Bonus
Error message updated to include Windows-style path next to existing macOS/Linux examples.

Closes #1508.

## Test plan
- [x] `cargo build --release -p perry` clean
- [x] `cargo test --release -p perry --bin perry` (348 passed)
- [x] `cargo fmt --all -- --check`
- [ ] manual Windows / Linux / macOS cross-compile validation requires a Windows host — not covered in this PR (deferring to user-side verification)