### PR TITLE
feat(crypto): wire crypto.subtle namespace + getRandomValues function (#1366)

### DIFF
--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -485,6 +485,15 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             // property must still read as a function for
             // feature-detection.
             | ("perf_hooks", "timerify")
+            // #1366: `crypto.getRandomValues` is the WebCrypto sync
+            // randomness API. Perry lowers the call form via a
+            // synthetic `$$cryptoFillRandom` method on the buffer
+            // (see `lower/expr_call/module_static.rs`), but reading
+            // it as a value (`typeof crypto.getRandomValues ===
+            // "function"`, `const f = crypto.getRandomValues`)
+            // needs the property-read form to be a bound-method
+            // closure.
+            | ("crypto", "getRandomValues")
             | ("perf_hooks", "PerformanceObserver")
             | ("perf_hooks", "PerformanceEntry")
             | ("perf_hooks", "PerformanceMark")
@@ -1352,6 +1361,15 @@ pub(crate) unsafe fn get_native_module_constant(
         },
         "crypto" => match property {
             "constants" => Some(create_sub_namespace("crypto.constants")),
+            // #1366: `crypto.subtle` is the WebCrypto SubtleCrypto
+            // instance. Resolve to a sub-namespace so `typeof
+            // crypto.subtle === "object"` matches Node and call
+            // sites that read `subtle` as a value (e.g.
+            // `const s = crypto.subtle; s.digest(...)`) get an
+            // object. The actual `subtle.<method>(...)` lowering
+            // is handled statically by HIR (see
+            // `lower/expr_call/nested_namespace.rs`).
+            "subtle" => Some(create_sub_namespace("crypto.subtle")),
             _ => None,
         },
         "crypto.constants" => crypto_const(property),

--- a/test-parity/node-suite/crypto/subtle/subtle-shape.ts
+++ b/test-parity/node-suite/crypto/subtle/subtle-shape.ts
@@ -1,0 +1,8 @@
+// crypto.subtle is the WebCrypto SubtleCrypto instance. Perry used to
+// read it as a number (the 0 sentinel), so feature-detection like
+// `if (crypto.subtle) { crypto.subtle.digest(...) }` saw `0` (falsy)
+// and the polyfill-fallback path silently took over. Regression cover
+// for #1366. Asserts shape only (typeof === "object" + truthy).
+import * as crypto from "node:crypto";
+console.log("subtle typeof:", typeof crypto.subtle);
+console.log("subtle truthy:", !!crypto.subtle);

--- a/test-parity/node-suite/crypto/webcrypto/get-random-values.ts
+++ b/test-parity/node-suite/crypto/webcrypto/get-random-values.ts
@@ -1,0 +1,22 @@
+// crypto.getRandomValues(buf) is the WebCrypto sync randomness API
+// (fills `buf` in-place with random bytes, returns it). Perry's call
+// form already worked via the buffer's $$cryptoFillRandom synthetic
+// method, but the property-read form (`typeof crypto.getRandomValues
+// === "function"`, `const f = crypto.getRandomValues`) returned
+// "number" because it wasn't on the callable-export list.
+// Regression cover for #1366.
+import * as crypto from "node:crypto";
+console.log("typeof:", typeof crypto.getRandomValues);
+const buf = new Uint8Array(8);
+const ret = crypto.getRandomValues(buf);
+console.log("length:", buf.length);
+console.log("returns same buffer:", ret === buf);
+// Walk by index to avoid the Uint8Array.some() gap.
+let anyNonZero = false;
+for (let i = 0; i < buf.length; i++) {
+  if (buf[i] !== 0) {
+    anyNonZero = true;
+    break;
+  }
+}
+console.log("filled (some byte non-zero):", anyNonZero);


### PR DESCRIPTION
## Summary

Two value-read shapes on the `node:crypto` module that Perry was returning as `0` sentinels (typeof `"number"`):

1. **`crypto.subtle`** should be the WebCrypto SubtleCrypto instance — `typeof === "object"`. Perry's `crypto.subtle.<method>()` calls already lower statically via `nested_namespace.rs`, but a bare read of `crypto.subtle` (for `if (crypto.subtle)` feature-detect or `const s = crypto.subtle`) returned `0` and falsy-branched into the polyfill.
2. **`crypto.getRandomValues`** should be a function — `typeof === "function"`. The call form already worked via the synthetic `$$cryptoFillRandom` method on the buffer, but the property-read form returned `0` because it wasn't on the callable-export list.

Closes #1366.

## Changes

- **`object/native_module.rs` `get_native_module_constant`**: adds `("crypto", "subtle")` arm that resolves to a `crypto.subtle` sub-namespace (typeof `"object"`).
- **`object/native_module.rs` `is_native_module_callable_export`**: adds `("crypto", "getRandomValues")` so the property-read produces a bound-method closure (typeof `"function"`).

## Test plan

- [x] `test-parity/node-suite/crypto/subtle/subtle-shape.ts` — byte-identical to `node --experimental-strip-types`.
- [x] `test-parity/node-suite/crypto/webcrypto/get-random-values.ts` — byte-identical. Walks the random buffer by index to avoid the separate `Uint8Array.some()` gap.
- [x] `cargo fmt --all -- --check` clean.

## Out of scope

The bare-global `crypto.X` (without `import`) is a separate webcrypto-polyfill path; this PR covers the named-import surface that the issue's repros target.