### PR TITLE
fix(perry-ui-android): re-export ffi/* submodule symbols at crate root

### DIFF
--- a/crates/perry-ui-android/src/ffi/mod.rs
+++ b/crates/perry-ui-android/src/ffi/mod.rs
@@ -17,3 +17,18 @@ pub mod state_widgets;
 pub mod system_api;
 pub mod tabbar_layout;
 pub mod text_scroll;
+
+// Re-export every `pub extern "C"` symbol at the `crate::ffi` level (and
+// therefore — via `pub use ffi::*;` in lib.rs — at the crate root).
+// Without this, code that references `crate::perry_ui_*` (notably
+// `app.rs` and `geisterhand_style.rs`) fails to resolve.
+pub use basic_widgets::*;
+pub use canvas_picker::*;
+pub use embed_misc::*;
+pub use image_nav::*;
+pub use issue_553::*;
+pub use menu_dialog::*;
+pub use state_widgets::*;
+pub use system_api::*;
+pub use tabbar_layout::*;
+pub use text_scroll::*;


### PR DESCRIPTION
## Problem

\`lib.rs\` has \`pub use ffi::*;\` to publish every Android FFI export at the crate root. But \`ffi/mod.rs\` only declared the submodules with \`pub mod …;\` — it never re-exported their **contents** up to the \`ffi::\` level. So code that references \`crate::perry_ui_*\` from \`app.rs\` / \`geisterhand_style.rs\` fails to resolve, breaking \`cargo build -p perry-ui-android\` with 11× E0425 on a clean target dir.

\`\`\`
error[E0425]: cannot find value `perry_ui_state_set` in the crate root
   --> crates/perry-ui-android/src/app.rs:278:57
error[E0425]: cannot find function `perry_ui_widget_set_background_color` in the crate root
  --> crates/perry-ui-android/src/geisterhand_style.rs:31:36
error[E0425]: cannot find function `perry_ui_text_set_color` in the crate root
  --> crates/perry-ui-android/src/geisterhand_style.rs:32:25
… (etc — 11 total)
\`\`\`

Hit while trying to build the gscmaster.com mobile app for Android: the build server probably caches \`libperry_ui_android.a\` so the compile-side issue is invisible there, but a local \`cargo build -p perry-ui-android --target aarch64-linux-android\` from a clean checkout hits this immediately.

## Fix

Add \`pub use <submod>::*;\` for every \`ffi/\` submodule so the existing \`pub use ffi::*;\` chain in \`lib.rs\` actually publishes them. 15 LOC.

## Verified

\`\`\`
$ cargo check -p perry-ui-android --target aarch64-linux-android
    Finished `dev` profile [unoptimized + debuginfo]
$ cargo check -p perry-ui-android --target aarch64-linux-android --features geisterhand
    Finished `dev` profile [unoptimized + debuginfo]
\`\`\`