### PR TITLE
fix(android): honor bundle_id in APK package name (#1528)

### DIFF
--- a/crates/perry-ui-android/template/app/src/main/AndroidManifest.xml
+++ b/crates/perry-ui-android/template/app/src/main/AndroidManifest.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.perry.app">
+<!--
+  #1528: the `package` attribute on <manifest> is deprecated since AGP 7.4
+  and removed in 8.0. Leaving it here pinned the APK's package name to
+  "com.perry.app" regardless of the bundle_id substituted into
+  `applicationId`, so `aapt dump badging app-debug.apk` reported
+  com.perry.app and `adb shell am start -n <bundle_id>/…` failed.
+  Removing it lets the Gradle `applicationId` (substituted from
+  `[project].bundle_id`) be the single source of the APK package name.
+  The PerryActivity is now declared fully-qualified to its real Kotlin
+  location (com.perry.app.PerryActivity), so the implicit `.X` resolution
+  against the removed package doesn't accidentally point at a class that
+  doesn't exist under the user's bundle_id.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
@@ -34,7 +46,7 @@
             android:value="__YOUR_GOOGLE_MAPS_API_KEY__" />
 
         <activity
-            android:name=".PerryActivity"
+            android:name="com.perry.app.PerryActivity"
             android:exported="true"
             android:theme="@style/Theme.Perry.Splash"
             android:configChanges="orientation|screenSize|keyboardHidden">

--- a/crates/perry/src/commands/run/android.rs
+++ b/crates/perry/src/commands/run/android.rs
@@ -542,9 +542,14 @@ pub fn inject_android_deeplinks(
     // Locate the existing PerryActivity's <intent-filter> for
     // android.intent.action.MAIN — we insert the deep-link filters
     // immediately AFTER that block, still inside <activity>.
-    let activity_marker = "android:name=\".PerryActivity\"";
+    // #1528: the template used to declare the activity as
+    // `android:name=".PerryActivity"` but we now use the fully-
+    // qualified Kotlin path so removing the manifest `package=`
+    // doesn't break resolution. Match the trailing portion either way
+    // so older / forked templates still work.
     let activity_pos = manifest
-        .find(activity_marker)
+        .find("android:name=\"com.perry.app.PerryActivity\"")
+        .or_else(|| manifest.find("android:name=\".PerryActivity\""))
         .ok_or_else(|| anyhow!("PerryActivity tag not found in AndroidManifest.xml"))?;
 
     // Add launchMode=singleTop to the activity tag if not already present.


### PR DESCRIPTION
## Summary

`perry compile --target android` substitutes `[project].bundle_id` into the Gradle `applicationId` correctly, but the APK still shipped with `package: name='com.perry.app'` because the template's `AndroidManifest.xml` carried a hardcoded `<manifest package="com.perry.app">` attribute that overrode the install ID.

- `adb shell am start -n <bundle_id>/…` failed (wrong package name).
- `perry publish android` would have pushed the wrong applicationId to Google Play.
- App Group / FCM token registration keyed on bundle id won't match the iOS build.

Closes #1528.

## Root cause + fix

The `package` attribute on `<manifest>` is deprecated since AGP 7.4 and removed in 8.0. Perry's template is on AGP 8.8.2, so just dropping it is the modern-Android-correct path — `applicationId` becomes the single source of the APK package name.

### Two edits

1. **`AndroidManifest.xml`**: remove `package="com.perry.app"` and declare the activity as fully-qualified `android:name="com.perry.app.PerryActivity"` so the implicit `.X` resolution doesn't accidentally point at a class that doesn't exist under the user's bundle_id namespace.
2. **`run/android.rs`** deep-link injection: match either the fully-qualified or the legacy `.PerryActivity` activity-name string so the deeplink filter still lands in the right `<activity>` (forks of the template that haven't picked up the new shape keep working).

The JNI surface (`Java_com_perry_app_PerryBridge_*` symbols + the `adb shell am start -n <bundle_id>/com.perry.app.PerryActivity` launch command) is unchanged — the Kotlin classes still live at `com.perry.app.*`. Only the APK's external identity (its applicationId / package name) becomes the user's bundle_id.

## Test plan

- [x] `cargo build --release -p perry` clean.
- [x] `cargo fmt --all -- --check` clean.

Manual smoke (`aapt dump badging app-debug.apk` reports the substituted bundle_id) needs a device + JDK + Android SDK to validate; not run locally.