### PR TITLE
feat(stream): typeof default Stream import is 'function' (#1535)

### DIFF
--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -590,6 +590,23 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                     {
                         return Ok(Expr::String("function".to_string()));
                     }
+                    // #1535: `import Stream from "node:stream"` should make
+                    // `typeof Stream === "function"` (legacy Stream
+                    // constructor with class statics hung off it). Perry
+                    // resolves the default import to a native-module
+                    // namespace today, so the read defaulted to typeof
+                    // "object". Fold when the local ident is bound as the
+                    // default import of a node module whose default export
+                    // Node exposes as a constructor function. (Other
+                    // modules whose default is a non-callable namespace —
+                    // `node:os`, `node:path` — stay typeof "object".)
+                    if ctx.lookup_local(n).is_none() {
+                        if let Some((module_name, None)) = ctx.lookup_native_module(n) {
+                            if matches!(module_name, "stream" | "node:stream") {
+                                return Ok(Expr::String("function".to_string()));
+                            }
+                        }
+                    }
                 }
                 if let ast::Expr::Member(member) = unary.arg.as_ref() {
                     if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {

--- a/test-parity/node-suite/stream/imports/default-is-stream.ts
+++ b/test-parity/node-suite/stream/imports/default-is-stream.ts
@@ -1,0 +1,9 @@
+// `import Stream from "node:stream"` should bind the local to the legacy
+// Stream constructor — typeof "function", with the Readable/Writable/...
+// classes hung off it as statics. Perry was resolving the default import
+// to a namespace object (typeof "object"), so feature-detect like
+// `typeof Stream === "function"` returned false. Regression cover for
+// #1535. Asserts only the typeof — the class-statics surface is tracked
+// separately under #1531.
+import Stream from "node:stream";
+console.log("typeof:", typeof Stream);


### PR DESCRIPTION
## Summary

Node's `import Stream from "node:stream"` binds the local to the legacy Stream constructor — `typeof === "function"`, with the Readable/Writable/PassThrough/Transform/Duplex classes hung off it as statics. Perry was resolving the default import to a namespace object (typeof `"object"`), so feature-detect like `typeof Stream === "function"` returned false.

Closes #1535.

## Changes

Folded in `lower_expr.rs` typeof handler: when the local ident is the default import of `node:stream` (lookup returns `(module_name, None)`), return the literal `"function"`. Other modules whose default is a non-callable namespace (`node:os`, `node:path`) stay typeof `"object"`.

## Test plan

- [x] `test-parity/node-suite/stream/imports/default-is-stream.ts` — byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.

## Out of scope

The class-statics surface (`Stream.Readable`, `Stream.Writable`, ...) is tracked separately under #1531. This PR only closes the typeof gap.