### PR TITLE
feat(stream): static helpers Readable.isDisturbed + isErrored (#1534)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2197,6 +2197,14 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // through the `Readable.foo` -> `stream.foo` route in
     // `lower_call.rs`, so the gate keys off `stream.from`.
     method("stream", "from", false, None),
+    // #1534: static introspection helpers — `Readable.isDisturbed(s)`
+    // and `Readable.isErrored(s)`. Stub returns `false` (Perry's
+    // stream stubs don't track state yet) — correct for a fresh,
+    // untouched stream. Directional helpers `isReadable`/`isWritable`
+    // are deferred (their answer depends on stream direction which
+    // Perry's stub doesn't carry at runtime yet).
+    method("stream", "isDisturbed", false, None),
+    method("stream", "isErrored", false, None),
     // EventEmitter methods on stream instances. node:stream extends
     // EventEmitter — every Readable/Writable/Duplex/Transform/PassThrough
     // exposes the full `.on('data'|'end'|'error'|'close'|...)` /

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -387,6 +387,39 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // #1534: static introspection helpers `isDisturbed` and
+    // `isErrored`. Node exposes them on every stream class (Readable /
+    // Writable / Duplex inherit from Stream). For a freshly-constructed
+    // stream both return `false`, which matches Perry's stub state
+    // (we don't track disturbed/errored bits yet). Consumers that
+    // branch on `if (Readable.isErrored(s)) cleanup()` typecheck,
+    // don't throw, and skip the error-cleanup arm — which is the
+    // honest answer for a stream we never let actually transfer data.
+    //
+    // The directional helpers `isReadable` / `isWritable` are NOT here:
+    // Node's answer depends on the stream type (Readable returns
+    // `true` for isReadable + `null` for isWritable; Writable swaps;
+    // Duplex says `true` for both). Perry's stub doesn't carry that
+    // information at runtime, so a uniform return would lie for at
+    // least one case — kept as a follow-up under #1534.
+    NativeModSig {
+        module: "stream",
+        has_receiver: false,
+        method: "isDisturbed",
+        class_filter: None,
+        runtime: "js_node_stream_is_disturbed",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: false,
+        method: "isErrored",
+        class_filter: None,
+        runtime: "js_node_stream_is_errored",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     // ========== Events ==========
     NativeModSig {
         module: "events",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -807,6 +807,9 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_transform_new", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_passthrough_new", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_readable_from", DOUBLE, &[DOUBLE]);
+    // #1534: static introspection helpers — always return false today.
+    module.declare_function("js_node_stream_is_disturbed", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_node_stream_is_errored", DOUBLE, &[DOUBLE]);
 
     // ========== Event emitter ==========
     module.declare_function("js_event_emitter_emit", DOUBLE, &[I64, I64, I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -278,3 +278,26 @@ pub extern "C" fn js_node_stream_passthrough_new(_opts: f64) -> f64 {
 pub extern "C" fn js_node_stream_readable_from(_iterable: f64) -> f64 {
     js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED))
 }
+
+// ─────────────────────────────────────────────────────────────────
+// #1534: static introspection helpers `Readable.isDisturbed(s)` and
+// `Readable.isErrored(s)`. Node returns booleans reflecting the
+// stream's internal state machine; Perry's stream stubs don't track
+// any of that state yet, so both return `false` — which is the
+// correct answer for a freshly-constructed, untouched stream. The
+// directional helpers `isReadable` / `isWritable` aren't here
+// because Node's answer depends on the stream's actual direction
+// (Readable returns `true` for isReadable + `null` for isWritable
+// and so on); a uniform stub would lie for at least one case, so
+// they're deferred until Perry's stream stub tracks direction.
+// ─────────────────────────────────────────────────────────────────
+
+#[no_mangle]
+pub extern "C" fn js_node_stream_is_disturbed(_stream: f64) -> f64 {
+    f64::from_bits(TAG_FALSE)
+}
+
+#[no_mangle]
+pub extern "C" fn js_node_stream_is_errored(_stream: f64) -> f64 {
+    f64::from_bits(TAG_FALSE)
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1196 entries across 80 modules
+// Coverage: 1198 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1718,6 +1718,10 @@ declare module "stream" {
   export function finished(...args: any[]): any;
   /** stdlib */
   export function from(...args: any[]): any;
+  /** stdlib */
+  export function isDisturbed(...args: any[]): any;
+  /** stdlib */
+  export function isErrored(...args: any[]): any;
   /** stdlib */
   export function pipeline(...args: any[]): any;
 }

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1196 entries across 80 modules.
+Total: 1198 entries across 80 modules.
 
 ## Modules
 
@@ -1603,6 +1603,8 @@ Total: 1196 entries across 80 modules.
 - `finished` — module
 - `from` — module
 - `getMaxListeners` — instance
+- `isDisturbed` — module
+- `isErrored` — module
 - `listenerCount` — instance
 - `listeners` — instance
 - `off` — instance

--- a/test-parity/node-suite/stream/static/readable-is-disturbed.ts
+++ b/test-parity/node-suite/stream/static/readable-is-disturbed.ts
@@ -1,0 +1,15 @@
+// Stream static introspection helpers `Readable.isDisturbed(s)` /
+// `Readable.isErrored(s)`. For a freshly-constructed, untouched
+// stream both return `false`. Perry's stream stubs don't track
+// state, so the stub also returns `false` — which is the correct
+// answer for this shape of usage. Regression cover for #1534.
+//
+// Directional helpers `isReadable` / `isWritable` deliberately not
+// asserted: Node's answer depends on direction (Readable returns
+// `true` for isReadable + `null` for isWritable) and Perry's stub
+// doesn't carry direction at runtime yet — they're tracked as a
+// follow-up in #1534.
+import { Readable } from "node:stream";
+const r = new Readable({ read() {} });
+console.log("isDisturbed:", Readable.isDisturbed(r));
+console.log("isErrored:", Readable.isErrored(r));


### PR DESCRIPTION
## Summary

Node exposes static introspection helpers on every stream class (Readable / Writable / Duplex inherit from Stream). For a freshly-constructed, untouched stream `Readable.isDisturbed(s)` and `Readable.isErrored(s)` both return `false`. Perry previously refused the call entirely via the #463 unimplemented-API gate (`Error: stream.isDisturbed is not implemented in Perry`) — even the typeof probe couldn't reach the function.

Stubbed to return `false` uniformly, which is the correct answer for a freshly-constructed stream and matches what Perry's stream stubs actually represent (we don't track disturbed/errored bits yet).

Closes #1534 (partial).

## Changes

- **HIR dispatch table** (`lower_call/native_table/net_events.rs`): adds the two methods alongside `Readable.from`, routing through the `Readable.foo` -> `stream.foo` rewrite (so the entry keys off `stream.isDisturbed` / `stream.isErrored`).
- **Runtime stubs** (`runtime/src/node_stream.rs`): `js_node_stream_is_disturbed` / `js_node_stream_is_errored` return TAG_FALSE.
- **Runtime decl** (`codegen/runtime_decls/stdlib_ffi.rs`).
- **API manifest** (`perry-api-manifest`): declares both methods as supported, with the documented limitation.

## Out of scope

The directional helpers `isReadable` / `isWritable` are deferred: Node's answer depends on the stream's actual direction (Readable returns `true` for isReadable + `null` for isWritable; Writable swaps), and Perry's stub doesn't carry that information at runtime yet. A uniform return would lie for at least one case — keeping the issue open for those.

## Test plan

- [x] `test-parity/node-suite/stream/static/readable-is-disturbed.ts` is byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.
- [x] `./scripts/regen_api_docs.sh` re-run; docs/api/perry.d.ts + docs/src/api/reference.md updated.