### PR TITLE
feat(stream): implement stream.addAbortSignal(signal, stream) (#1541)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2205,6 +2205,11 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // Perry's stub doesn't carry at runtime yet).
     method("stream", "isDisturbed", false, None),
     method("stream", "isErrored", false, None),
+    // #1541: `stream.addAbortSignal(signal, stream)` — Node wires
+    // the AbortSignal so aborting it destroys the stream. Stub
+    // ignores the signal and returns the stream verbatim so chain
+    // patterns (`r = addAbortSignal(s, r)`) keep working.
+    method("stream", "addAbortSignal", false, None),
     // EventEmitter methods on stream instances. node:stream extends
     // EventEmitter — every Readable/Writable/Duplex/Transform/PassThrough
     // exposes the full `.on('data'|'end'|'error'|'close'|...)` /

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -420,6 +420,22 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // #1541: `stream.addAbortSignal(signal, stream)` wires the
+    // AbortSignal so that aborting it destroys the stream — and
+    // returns the stream for chaining. Perry's stream stubs don't
+    // implement destroy/abort propagation yet, but the identity
+    // return shape (`r = addAbortSignal(s, r)`) needs to work so
+    // feature-detect-and-call sites don't crash. The signal is
+    // accepted and ignored; the stream is returned verbatim.
+    NativeModSig {
+        module: "stream",
+        has_receiver: false,
+        method: "addAbortSignal",
+        class_filter: None,
+        runtime: "js_node_stream_add_abort_signal",
+        args: &[NA_F64, NA_F64],
+        ret: NR_F64,
+    },
     // ========== Events ==========
     NativeModSig {
         module: "events",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -810,6 +810,8 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // #1534: static introspection helpers — always return false today.
     module.declare_function("js_node_stream_is_disturbed", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_is_errored", DOUBLE, &[DOUBLE]);
+    // #1541: addAbortSignal(signal, stream) — identity-returns the stream.
+    module.declare_function("js_node_stream_add_abort_signal", DOUBLE, &[DOUBLE, DOUBLE]);
 
     // ========== Event emitter ==========
     module.declare_function("js_event_emitter_emit", DOUBLE, &[I64, I64, I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -301,3 +301,15 @@ pub extern "C" fn js_node_stream_is_disturbed(_stream: f64) -> f64 {
 pub extern "C" fn js_node_stream_is_errored(_stream: f64) -> f64 {
     f64::from_bits(TAG_FALSE)
 }
+
+/// #1541: `stream.addAbortSignal(signal, stream)` — Node wires the
+/// AbortSignal so aborting it destroys the stream, and returns the
+/// stream for chaining. Perry's stream stubs don't implement the
+/// destroy / abort propagation yet, so the helper just returns the
+/// stream verbatim and ignores the signal. Caller chains
+/// (`r = addAbortSignal(s, r)`) keep working with the same stream
+/// reference they passed in.
+#[no_mangle]
+pub extern "C" fn js_node_stream_add_abort_signal(_signal: f64, stream: f64) -> f64 {
+    stream
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1198 entries across 80 modules
+// Coverage: 1199 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1714,6 +1714,8 @@ declare module "stream" {
   export class Writable { [key: string]: any; }
   /** stdlib */
   export const prototype: any;
+  /** stdlib */
+  export function addAbortSignal(...args: any[]): any;
   /** stdlib */
   export function finished(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1198 entries across 80 modules.
+Total: 1199 entries across 80 modules.
 
 ## Modules
 
@@ -1597,6 +1597,7 @@ Total: 1198 entries across 80 modules.
 
 ### Methods
 
+- `addAbortSignal` — module
 - `addListener` — instance
 - `emit` — instance
 - `eventNames` — instance

--- a/test-parity/node-suite/stream/abort/add-abort-signal.ts
+++ b/test-parity/node-suite/stream/abort/add-abort-signal.ts
@@ -1,0 +1,10 @@
+// `addAbortSignal(signal, stream)` wires the AbortSignal so aborting
+// it destroys the stream — and returns the stream for chaining.
+// Perry's stream stubs don't track destroy/abort yet, so the stub
+// only matches Node on the identity-return shape (the common
+// `r = addAbortSignal(c.signal, r)` chain pattern). Regression
+// cover for #1541. Real abort-propagation is tracked separately.
+import { addAbortSignal, Readable } from "node:stream";
+const c = new AbortController();
+const r = new Readable({ read() {} });
+console.log("returns same:", addAbortSignal(c.signal, r) === r);


### PR DESCRIPTION
## Summary

Node's `stream.addAbortSignal(signal, stream)` wires the AbortSignal so aborting it destroys the stream — and returns the stream for chaining, which is the load-bearing piece of the typical `r = addAbortSignal(c.signal, r)` pattern. Perry refused the call via the #463 unimplemented-API gate.

Stubbed: the signal arg is accepted and ignored, the stream arg is returned verbatim. The identity-return shape that callers actually depend on works now.

Closes #1541 (partial — see Out of scope).

## Changes

- **HIR dispatch table** (`lower_call/native_table/net_events.rs`): adds the method routing to a runtime helper, sitting next to the `isDisturbed`/`isErrored` arms shipped in #1534.
- **Runtime stub** (`runtime/src/node_stream.rs`): `js_node_stream_add_abort_signal(_signal, stream) -> stream`.
- **Runtime decl** (`codegen/runtime_decls/stdlib_ffi.rs`).
- **API manifest** (`perry-api-manifest`): declares the method as supported with the documented limitation.

## Out of scope

Real abort-propagation (`controller.abort()` → `stream.destroy(err)`) is tracked separately — Perry's stream stubs don't implement destroy yet. This PR closes the typeof/call-doesn't-crash gap; the destroy-on-abort behavior gap remains.

## Test plan

- [x] `test-parity/node-suite/stream/abort/add-abort-signal.ts` is byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.
- [x] `./scripts/regen_api_docs.sh` re-run.