### PR TITLE
feat(stream): implement compose + duplexPair as fresh-Duplex stubs (#1539)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2210,6 +2210,11 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // ignores the signal and returns the stream verbatim so chain
     // patterns (`r = addAbortSignal(s, r)`) keep working.
     method("stream", "addAbortSignal", false, None),
+    // #1539: `stream.compose(...streams)` chains streams into a
+    // composite Duplex; `stream.duplexPair([opts])` returns a paired
+    // `[Duplex, Duplex]`. Both return fresh Duplex stubs today.
+    method("stream", "compose", false, None),
+    method("stream", "duplexPair", false, None),
     // EventEmitter methods on stream instances. node:stream extends
     // EventEmitter — every Readable/Writable/Duplex/Transform/PassThrough
     // exposes the full `.on('data'|'end'|'error'|'close'|...)` /

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -436,6 +436,31 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         args: &[NA_F64, NA_F64],
         ret: NR_F64,
     },
+    // #1539: `stream.compose(...streams)` chains streams into a
+    // composite Duplex; `stream.duplexPair([opts])` returns a paired
+    // `[Duplex, Duplex]`. Both return fresh Duplex stubs today
+    // (real composition/pairing isn't propagated yet) so consumers
+    // that branch on `instanceof Duplex` / typeof get the right
+    // shape and don't crash. Variadic args list for `compose` is
+    // accepted and ignored.
+    NativeModSig {
+        module: "stream",
+        has_receiver: false,
+        method: "compose",
+        class_filter: None,
+        runtime: "js_node_stream_compose",
+        args: &[NA_VARARGS],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: false,
+        method: "duplexPair",
+        class_filter: None,
+        runtime: "js_node_stream_duplex_pair",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     // ========== Events ==========
     NativeModSig {
         module: "events",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -812,6 +812,9 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_is_errored", DOUBLE, &[DOUBLE]);
     // #1541: addAbortSignal(signal, stream) — identity-returns the stream.
     module.declare_function("js_node_stream_add_abort_signal", DOUBLE, &[DOUBLE, DOUBLE]);
+    // #1539: compose(...streams) -> new Duplex; duplexPair(opts) -> [Duplex, Duplex].
+    module.declare_function("js_node_stream_compose", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_node_stream_duplex_pair", DOUBLE, &[DOUBLE]);
 
     // ========== Event emitter ==========
     module.declare_function("js_event_emitter_emit", DOUBLE, &[I64, I64, I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -313,3 +313,32 @@ pub extern "C" fn js_node_stream_is_errored(_stream: f64) -> f64 {
 pub extern "C" fn js_node_stream_add_abort_signal(_signal: f64, stream: f64) -> f64 {
     stream
 }
+
+/// #1539: `stream.compose(...streams)` chains a sequence of streams
+/// into one composite Duplex (data flows through them in order).
+/// Perry's stream stubs don't propagate data through chains, so the
+/// helper returns a fresh Duplex — the typeof / instanceof checks
+/// callers do (`compose(a, b) instanceof Duplex`) hold, and the
+/// reads/writes are stubbed at the Duplex layer same as a bare
+/// `new Duplex()`. The variadic `...streams` arg list is ignored;
+/// real composition is tracked separately.
+#[no_mangle]
+pub extern "C" fn js_node_stream_compose(_streams_array: f64) -> f64 {
+    js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
+}
+
+/// #1539: `stream.duplexPair([options])` returns a two-element array
+/// `[Duplex, Duplex]` where writes to one show up as reads on the
+/// other and vice versa. Perry's stubs return a pair of unrelated
+/// Duplex stubs so the shape (`const [a, b] = duplexPair()`,
+/// `a instanceof Duplex`) matches; cross-stream piping is the real
+/// missing piece, tracked separately.
+#[no_mangle]
+pub extern "C" fn js_node_stream_duplex_pair(_opts: f64) -> f64 {
+    let a = js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED));
+    let b = js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED));
+    let arr = crate::array::js_array_alloc(2);
+    crate::array::js_array_push(arr, JSValue::from_bits(a.to_bits()));
+    crate::array::js_array_push(arr, JSValue::from_bits(b.to_bits()));
+    f64::from_bits(JSValue::pointer(arr as *const u8).bits())
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1199 entries across 80 modules
+// Coverage: 1201 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1716,6 +1716,10 @@ declare module "stream" {
   export const prototype: any;
   /** stdlib */
   export function addAbortSignal(...args: any[]): any;
+  /** stdlib */
+  export function compose(...args: any[]): any;
+  /** stdlib */
+  export function duplexPair(...args: any[]): any;
   /** stdlib */
   export function finished(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1199 entries across 80 modules.
+Total: 1201 entries across 80 modules.
 
 ## Modules
 
@@ -1599,6 +1599,8 @@ Total: 1199 entries across 80 modules.
 
 - `addAbortSignal` — module
 - `addListener` — instance
+- `compose` — module
+- `duplexPair` — module
 - `emit` — instance
 - `eventNames` — instance
 - `finished` — module

--- a/test-parity/node-suite/stream/static/compose-helper.ts
+++ b/test-parity/node-suite/stream/static/compose-helper.ts
@@ -1,0 +1,12 @@
+// `stream.compose(...streams)` chains a sequence of streams into a
+// composite Duplex (data flows through them in order). Perry's stream
+// stubs don't propagate data through chains yet, but the typeof
+// result (composite is an object) needs to match so consumers that
+// branch on `typeof compose(...) === "object"` don't fall through.
+// Regression cover for #1539. Real composition is tracked separately.
+import { compose, Readable, Writable } from "node:stream";
+const out = compose(
+  new Readable({ read() {} }),
+  new Writable({ write(_a, _b, c) { c(); } }),
+);
+console.log("typeof:", typeof out);

--- a/test-parity/node-suite/stream/static/duplex-pair.ts
+++ b/test-parity/node-suite/stream/static/duplex-pair.ts
@@ -1,0 +1,10 @@
+// `stream.duplexPair([opts])` returns a two-element array of paired
+// Duplex streams. Perry's stubs return a pair of fresh Duplex stubs
+// (cross-stream piping isn't propagated yet); the test only asserts
+// shape (length 2 + both entries are objects). Regression cover for
+// #1539.
+import { duplexPair } from "node:stream";
+const pair = duplexPair();
+console.log("length:", pair.length);
+console.log("[0] typeof:", typeof pair[0]);
+console.log("[1] typeof:", typeof pair[1]);


### PR DESCRIPTION
## Summary

Node exposes two newer stream factories:
- `stream.compose(...streams)` chains a sequence of streams into one composite Duplex (data flows through them in order).
- `stream.duplexPair([opts])` returns a paired `[Duplex, Duplex]` where writes to one show up as reads on the other.

Perry was refusing both calls via the #463 unimplemented-API gate.

Stubbed: `compose` returns a fresh Duplex (composition isn't propagated); `duplexPair` returns a two-element array of two unrelated Duplex stubs (cross-stream piping isn't propagated). Consumers that branch on `compose(a, b) instanceof Duplex` or destructure `const [a, b] = duplexPair()` get the right shape and don't crash.

Closes #1539 (partial — see Out of scope).

## Changes

- **HIR dispatch table** (`lower_call/native_table/net_events.rs`): two new arms sitting next to the `addAbortSignal` / `isErrored` / `isDisturbed` arms shipped in #1541 / #1534.
- **Runtime stubs** (`runtime/src/node_stream.rs`): `js_node_stream_compose` delegates to `js_node_stream_duplex_new`; `js_node_stream_duplex_pair` builds a 2-element array of fresh Duplex stubs.
- **Runtime decls** (`codegen/runtime_decls/stdlib_ffi.rs`).
- **API manifest** (`perry-api-manifest`).

## Out of scope

Real composition (chained data flow) and pairing (cross-stream piping) are tracked separately — Perry's stream stubs don't propagate data through chains yet. This PR closes the typeof/call-doesn't-crash gap.

## Test plan

- [x] `test-parity/node-suite/stream/static/compose-helper.ts` and `duplex-pair.ts` assert shape (typeof + array length + element typeof). Byte-identical to `node --experimental-strip-types`.
- [x] `cargo fmt --all -- --check` clean.
- [x] `./scripts/regen_api_docs.sh` re-run.