### PR TITLE
feat(stream): web-stream interop stubs (#1540)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2215,6 +2215,11 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // `[Duplex, Duplex]`. Both return fresh Duplex stubs today.
     method("stream", "compose", false, None),
     method("stream", "duplexPair", false, None),
+    // #1540: Web-stream interop helpers — Readable/Writable .toWeb /
+    // .fromWeb. Stubs return a fresh Duplex (data isn't propagated
+    // between Node and WHATWG universes yet).
+    method("stream", "toWeb", false, None),
+    method("stream", "fromWeb", false, None),
     // EventEmitter methods on stream instances. node:stream extends
     // EventEmitter — every Readable/Writable/Duplex/Transform/PassThrough
     // exposes the full `.on('data'|'end'|'error'|'close'|...)` /

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -461,6 +461,32 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // #1540: Web-stream interop. Node exposes static helpers on
+    // both Readable and Writable for converting to/from WHATWG
+    // streams (Readable.toWeb / Readable.fromWeb /
+    // Writable.toWeb / Writable.fromWeb). Perry returns a fresh
+    // Duplex stub for either direction (data isn't propagated
+    // between Node and WHATWG universes yet); typeof + truthy +
+    // method-existence checks pass. Real adapters are tracked
+    // separately.
+    NativeModSig {
+        module: "stream",
+        has_receiver: false,
+        method: "toWeb",
+        class_filter: None,
+        runtime: "js_node_stream_to_web",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: false,
+        method: "fromWeb",
+        class_filter: None,
+        runtime: "js_node_stream_from_web",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     // ========== Events ==========
     NativeModSig {
         module: "events",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -815,6 +815,9 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // #1539: compose(...streams) -> new Duplex; duplexPair(opts) -> [Duplex, Duplex].
     module.declare_function("js_node_stream_compose", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_duplex_pair", DOUBLE, &[DOUBLE]);
+    // #1540: Readable/Writable .toWeb / .fromWeb — return fresh Duplex stubs.
+    module.declare_function("js_node_stream_to_web", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_node_stream_from_web", DOUBLE, &[DOUBLE]);
 
     // ========== Event emitter ==========
     module.declare_function("js_event_emitter_emit", DOUBLE, &[I64, I64, I64]);

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -342,3 +342,37 @@ pub extern "C" fn js_node_stream_duplex_pair(_opts: f64) -> f64 {
     crate::array::js_array_push(arr, JSValue::from_bits(b.to_bits()));
     f64::from_bits(JSValue::pointer(arr as *const u8).bits())
 }
+
+// ─────────────────────────────────────────────────────────────────
+// #1540: Web-stream interop. Node exposes static helpers on the
+// stream classes for converting between Node streams and WHATWG
+// streams:
+//   - `Readable.toWeb(nodeReadable)` → WHATWG ReadableStream
+//   - `Readable.fromWeb(webStream)` → Node Readable
+//   - `Writable.toWeb(nodeWritable)` → WHATWG WritableStream
+//   - `Writable.fromWeb(webStream)` → Node Writable
+//
+// Perry's stubs return a Node stream of the appropriate direction
+// for all four (data isn't actually forwarded between the two
+// universes yet). That's the closest shape match: consumers that
+// branch on `typeof toWeb(s) === "object"` or destructure with
+// `const w = Readable.fromWeb(...)` get a non-null object back and
+// don't crash. Real bidirectional adapters are tracked separately.
+// ─────────────────────────────────────────────────────────────────
+
+/// `Readable.toWeb` / `Writable.toWeb` — Perry returns a fresh
+/// Duplex stub for either direction. It's not a real WHATWG
+/// ReadableStream / WritableStream, but typeof / truthy / method
+/// existence checks (`.pipeTo`, etc. via duplex_methods) pass.
+#[no_mangle]
+pub extern "C" fn js_node_stream_to_web(_node_stream: f64) -> f64 {
+    js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
+}
+
+/// `Readable.fromWeb` / `Writable.fromWeb` — Perry returns a fresh
+/// Duplex stub for either direction. Real bidirectional adapters
+/// are tracked separately.
+#[no_mangle]
+pub extern "C" fn js_node_stream_from_web(_web_stream: f64) -> f64 {
+    js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1201 entries across 80 modules
+// Coverage: 1203 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1725,11 +1725,15 @@ declare module "stream" {
   /** stdlib */
   export function from(...args: any[]): any;
   /** stdlib */
+  export function fromWeb(...args: any[]): any;
+  /** stdlib */
   export function isDisturbed(...args: any[]): any;
   /** stdlib */
   export function isErrored(...args: any[]): any;
   /** stdlib */
   export function pipeline(...args: any[]): any;
+  /** stdlib */
+  export function toWeb(...args: any[]): any;
 }
 
 declare module "streams" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1201 entries across 80 modules.
+Total: 1203 entries across 80 modules.
 
 ## Modules
 
@@ -1605,6 +1605,7 @@ Total: 1201 entries across 80 modules.
 - `eventNames` — instance
 - `finished` — module
 - `from` — module
+- `fromWeb` — module
 - `getMaxListeners` — instance
 - `isDisturbed` — module
 - `isErrored` — module
@@ -1620,6 +1621,7 @@ Total: 1201 entries across 80 modules.
 - `removeAllListeners` — instance
 - `removeListener` — instance
 - `setMaxListeners` — instance
+- `toWeb` — module
 
 ### Properties
 

--- a/test-parity/node-suite/stream/webstream/readable-from-web.ts
+++ b/test-parity/node-suite/stream/webstream/readable-from-web.ts
@@ -1,0 +1,10 @@
+// `Readable.fromWeb(webStream)` should return a Node Readable
+// wrapping the WHATWG ReadableStream. Perry's stub returns a fresh
+// Duplex stand-in (the WHATWG-side data isn't pulled through yet);
+// the test asserts shape only — `typeof === "object"`. Regression
+// cover for #1540.
+import { Readable } from "node:stream";
+const web = new ReadableStream();
+const r = Readable.fromWeb(web);
+console.log("typeof:", typeof r);
+console.log("truthy:", !!r);

--- a/test-parity/node-suite/stream/webstream/readable-to-web.ts
+++ b/test-parity/node-suite/stream/webstream/readable-to-web.ts
@@ -1,0 +1,9 @@
+// `Readable.toWeb(nodeReadable)` should return a WHATWG ReadableStream.
+// Perry's stub returns a fresh Duplex stand-in (data isn't propagated
+// between Node and WHATWG universes yet), so the test asserts shape
+// only — `typeof === "object"`. Regression cover for #1540.
+import { Readable } from "node:stream";
+const r = new Readable({ read() {} });
+const w = Readable.toWeb(r);
+console.log("typeof:", typeof w);
+console.log("truthy:", !!w);


### PR DESCRIPTION
## Summary

Node exposes four static helpers for converting between Node streams and WHATWG streams:

- `Readable.toWeb(nodeReadable)` → WHATWG ReadableStream
- `Readable.fromWeb(webStream)` → Node Readable
- `Writable.toWeb(nodeWritable)` → WHATWG WritableStream
- `Writable.fromWeb(webStream)` → Node Writable

Perry was refusing all four via the #463 unimplemented-API gate (`Error: stream.toWeb is not implemented`).

Stubbed: both `toWeb` and `fromWeb` return a fresh Duplex stand-in for either direction. Data isn't propagated between Node and WHATWG universes yet, but typeof / truthy / method-existence checks pass and `const w = Readable.fromWeb(webStream)` doesn't crash.

Closes #1540 (partial — see Out of scope).

## Changes

Single pair of runtime functions (`js_node_stream_to_web` / `js_node_stream_from_web`) handles both Readable.X and Writable.X via the `class_filter: None` route — the typeof shape callers actually check is the same regardless of direction.

- HIR dispatch table (`lower_call/native_table/net_events.rs`).
- Runtime stubs (`runtime/src/node_stream.rs`).
- Runtime decls (`codegen/runtime_decls/stdlib_ffi.rs`).
- API manifest (`perry-api-manifest`).

## Out of scope

Real bidirectional adapters (data actually flowing between Node and WHATWG universes) are tracked separately. This PR closes the typeof/call-doesn't-crash gap.

## Test plan

- [x] `test-parity/node-suite/stream/webstream/readable-to-web.ts` and `readable-from-web.ts` byte-identical to `node --experimental-strip-types` on the typeof/truthy assertions.
- [x] `cargo fmt --all -- --check` clean.
- [x] `./scripts/regen_api_docs.sh` re-run.