### PR TITLE
fix(webcrypto): reject with DOMException on top-level error paths (#1431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,63 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1026 — release sweep: timers epic + perf_hooks fan-out + lazy-tape fixes
+
+Rolls up 22 PRs that merged to `main` post-v0.5.1025 without version
+bumps. Full per-PR history is in `git log v0.5.1025..HEAD`.
+
+**node:timers epic (#1213, 6 PRs):**
+- **#1449** `node:timers/promises` `setTimeout` / `setImmediate` native
+  implementation.
+- **#1450** `clearTimeout` / `clearInterval` accept a numeric id (Node
+  also accepts the Timeout/Immediate handle directly, which already
+  worked).
+- **#1451** `import * as timers from 'node:timers'` namespace resolves.
+- **#1452** `typeof timeout.ref === 'function'` on Timeout / Immediate
+  handles.
+- **#1453** `Symbol.dispose` on Timeout / Immediate handles (explicit
+  resource-management proposal).
+- **#1454 / #1455** global `setImmediate` / `clearImmediate` resolve
+  + timer handle `typeof === 'function'`.
+
+**node:perf_hooks fan-out (10 PRs):**
+- **#1320 / #1445** `typeof PerformanceObserver` instance methods + inline
+  `supportedEntryTypes`.
+- **#1327 / #1443** `globalThis.performance === performance` (named-import
+  singleton identity).
+- **#1337 / #1442** `performance.nodeTiming`.
+- **#1338 / #1428** `performance.toJSON()`.
+- **#1339 / #1430** `clearResourceTimings` + `setResourceTimingBufferSize`.
+- **#1340 / #1440** `mark()` / `measure()` `detail` is structured-cloned.
+- **#1388 / #1436** `new PerformanceObserver()` without a callback throws
+  `TypeError`.
+- **#1389 / #1438** observer callback receives the observer as its 2nd arg.
+- **#1390 / #1441** `observe({ buffered: true })` delivers pre-existing
+  entries.
+- **#1403 / #1437** `measure()` with a nonexistent start/end mark throws.
+
+**node:json lazy-tape (closes #1424):**
+- **#1424 / #1447** `JSON.parse(blob, reviver)` on a lazy-tape top-level
+  array no longer SIGSEGVs (the failure I filed during the v0.5.1025
+  release-prep). `test_json_lazy_reviver` un-skip-listed.
+- **#1448 / #1456** `console.log` / `util.inspect` of a lazy-tape array
+  materialises before formatting instead of dumping internal lazy state.
+
+**Other runtime + codegen:**
+- **#1370 / #1446** drop perry/ui debug `console.log` noise from the web
+  driver.
+- **#1429** GC unsafe-zone handling for server adapters — guards the
+  unsafe-zone window when the runtime hands control to fastify/hyper
+  request handlers.
+- **#1341 / #1439** codegen: `Any`-typed `.includes()` / `.indexOf()`
+  dispatch dynamically, not as `String#includes` / `String#indexOf`
+  (was producing wrong results on arrays held in `any` shapes).
+- **#1427** deps: bump `qs` in `tests/release/packages/nestjs-hello`.
+
+`test_async_local_storage_context` (#1423) remains skip-listed —
+`.enterWith()` / `.exit()` semantics still pending (sibling slice of
+#788 / #789).
+
 ## v0.5.1025 — fix(compile): cross-target geisterhand lib lookup + parity skip-list + memory ceiling restore
 
 Unblocks the v0.5.1024 release-packages run by addressing 3 distinct

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1025
+**Current Version:** 0.5.1026
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5134,7 +5134,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "base64",
@@ -5189,14 +5189,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "log",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "base64",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "serde",
  "serde_json",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1025"
+version = "0.5.1026"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "clap",
@@ -5300,14 +5300,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5340,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5348,7 +5348,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "chrono",
  "cron",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5406,14 +5406,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "bson",
  "futures-util",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "image",
@@ -5598,14 +5598,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5632,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "flate2",
  "perry-ffi",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "perry-jsruntime"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "base64",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5835,11 +5835,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1025"
+version = "0.5.1026"
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "itoa",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "block2",
@@ -5902,7 +5902,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "block2",
@@ -5921,11 +5921,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1025"
+version = "0.5.1026"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "block2",
@@ -5941,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "block2",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "block2",
  "libc",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "libc",
@@ -5985,7 +5985,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1025"
+version = "0.5.1026"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ opt-level = "s"       # Optimize for size in stdlib
 opt-level = 3
 
 [workspace.package]
-version = "0.5.1025"
+version = "0.5.1026"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1,11 +1,11 @@
 {
   "_schema": {
-    "description": "Each entry maps a parity-suite test name to a structured record. The CI gate in .github/workflows/test.yml reads `keys[]` from this file \u2014 a test that fails AND is not a key here breaks CI. Add entries here only with full provenance (issue + added date) so we can revalidate.",
+    "description": "Each entry maps a parity-suite test name to a structured record. The CI gate in .github/workflows/test.yml reads `keys[]` from this file — a test that fails AND is not a key here breaks CI. Add entries here only with full provenance (issue + added date) so we can revalidate.",
     "fields": {
-      "issue": "Open GitHub issue number tracking this failure (e.g. \"793\"), or null when the failure is environmental / pending triage. Closed issues must be re-evaluated \u2014 flag the entry as `category: bug-stale` until a new tracking issue is filed.",
+      "issue": "Open GitHub issue number tracking this failure (e.g. \"793\"), or null when the failure is environmental / pending triage. Closed issues must be re-evaluated — flag the entry as `category: bug-stale` until a new tracking issue is filed.",
       "added": "ISO date (YYYY-MM-DD) when the test was first skip-listed. Use 2026-05-15 for entries inherited from the pre-audit format where the historical date is unknown.",
-      "category": "ci-env | module-inventory | bug-open | bug-stale | gap-categorical | gap-bisect \u2014 see test-parity/README.md for definitions.",
-      "reason": "Free-text explanation. Keep the most-actionable signal first \u2014 what changes the verdict (a fixture, a Perry fix, a Node spec change)."
+      "category": "ci-env | module-inventory | bug-open | bug-stale | gap-categorical | gap-bisect — see test-parity/README.md for definitions.",
+      "reason": "Free-text explanation. Keep the most-actionable signal first — what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
   "node-suite/perf_hooks/timerify/timerify": {
@@ -66,7 +66,7 @@
     "issue": "655",
     "added": "2026-05-15",
     "category": "bug-open",
-    "reason": "Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict \u2014 it's a deliberate failing repro."
+    "reason": "Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict — it's a deliberate failing repro."
   },
   "test_edge_regression": {
     "issue": null,
@@ -84,7 +84,7 @@
     "issue": null,
     "added": "2026-05-15",
     "category": "gap-bisect",
-    "reason": "Array method coverage probe \u2014 small divergences (flat/flatMap/finally specific edge cases). Targeted bisect needed; not a recent regression. File a tracking issue once a specific sub-case is pinned."
+    "reason": "Array method coverage probe — small divergences (flat/flatMap/finally specific edge cases). Targeted bisect needed; not a recent regression. File a tracking issue once a specific sub-case is pinned."
   },
   "test_gap_console_methods": {
     "issue": "1278",
@@ -96,13 +96,13 @@
     "issue": null,
     "added": "2026-05-17",
     "category": "gap-bisect",
-    "reason": "Advanced class features (static blocks, private brand checks, etc.) \u2014 bisect required to identify which sub-feature fails byte-for-byte vs Node."
+    "reason": "Advanced class features (static blocks, private brand checks, etc.) — bisect required to identify which sub-feature fails byte-for-byte vs Node."
   },
   "test_gap_regexp_advanced": {
     "issue": null,
     "added": "2026-05-15",
     "category": "gap-categorical",
-    "reason": "Lookbehind regex assertions \u2014 Rust's `regex` crate doesn't support `(?<=)` / `(?<!)`. Documented in CLAUDE.md as a known categorical gap. Unblocking requires swapping the regex backend or implementing a separate matcher for lookbehind."
+    "reason": "Lookbehind regex assertions — Rust's `regex` crate doesn't support `(?<=)` / `(?<!)`. Documented in CLAUDE.md as a known categorical gap. Unblocking requires swapping the regex backend or implementing a separate matcher for lookbehind."
   },
   "test_harness_async_context": {
     "issue": "788",
@@ -114,31 +114,31 @@
     "issue": "806",
     "added": "2026-05-16",
     "category": "bug-stale",
-    "reason": "#806 harness for `class X extends Fn(...)<...>` patterns. Two sub-cases surface real Perry gaps today: (1) bare-factory subclass loses the base's field initializer (`bare.kind: undefined` vs Node's `bare.kind: bare`); (2) chained mixin `WithA(WithB(WithC(Base)))` throws `TypeError: value is not a function` at construction. Captured-factory + Effect double-call shapes pass post-#740 \u2014 the harness verifies that survives. Linked to #321 umbrella; will flip to PASS as each sub-case lands."
+    "reason": "#806 harness for `class X extends Fn(...)<...>` patterns. Two sub-cases surface real Perry gaps today: (1) bare-factory subclass loses the base's field initializer (`bare.kind: undefined` vs Node's `bare.kind: bare`); (2) chained mixin `WithA(WithB(WithC(Base)))` throws `TypeError: value is not a function` at construction. Captured-factory + Effect double-call shapes pass post-#740 — the harness verifies that survives. Linked to #321 umbrella; will flip to PASS as each sub-case lands."
   },
   "test_issue_233_async_array_param_push": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "bug-stale",
-    "reason": "#233 (16-element cap on async array-param push) closed on macOS. Linux CI still surfaces a divergence \u2014 bisect needed to pin the Linux-only sub-case before filing a new tracking issue. Rolled under the parity roadmap (#793) in the meantime."
+    "reason": "#233 (16-element cap on async array-param push) closed on macOS. Linux CI still surfaces a divergence — bisect needed to pin the Linux-only sub-case before filing a new tracking issue. Rolled under the parity roadmap (#793) in the meantime."
   },
   "test_issue_422_socket_connect": {
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "#422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental \u2014 needs a CI-side fixture, not a Perry fix."
+    "reason": "#422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental — needs a CI-side fixture, not a Perry fix."
   },
   "test_issue_462_nullish_property_access": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "bug-stale",
-    "reason": "Behavior is correct (TypeError thrown, UNREACHABLE never prints). Only stack-trace format diverges from Node \u2014 #616 closed with framing improvements but byte-for-byte parity requires source-text retention through the runtime. Track under the parity roadmap; file a dedicated stack-format issue if/when it becomes a real blocker."
+    "reason": "Behavior is correct (TypeError thrown, UNREACHABLE never prints). Only stack-trace format diverges from Node — #616 closed with framing improvements but byte-for-byte parity requires source-text retention through the runtime. Track under the parity roadmap; file a dedicated stack-format issue if/when it becomes a real blocker."
   },
   "test_issue_510_primitive_method_typeerror": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "bug-stale",
-    "reason": "Same root cause as test_issue_462 \u2014 see #616 (closed). Behavior correct; framing differs. Regression vector: v0.5.702 (#596) routed throw helpers through js_throw which exposed the format gap. Track under the parity roadmap until a stack-format issue is filed."
+    "reason": "Same root cause as test_issue_462 — see #616 (closed). Behavior correct; framing differs. Regression vector: v0.5.702 (#596) routed throw helpers through js_throw which exposed the format gap. Track under the parity roadmap until a stack-format issue is filed."
   },
   "test_issue_561_sigv4_chain": {
     "issue": "793",
@@ -162,7 +162,7 @@
     "issue": "922",
     "added": "2026-05-17",
     "category": "bug-open",
-    "reason": "Regression test from #922 (P0 production /api crash). Deliberate failing repro until the underlying codegen bug is fixed; #934 added a circuit breaker that converts the runaway loop into [PERRY ABORT] (so test fails by design \u2014 the abort message diverges from Node's success output)."
+    "reason": "Regression test from #922 (P0 production /api crash). Deliberate failing repro until the underlying codegen bug is fixed; #934 added a circuit breaker that converts the runaway loop into [PERRY ABORT] (so test fails by design — the abort message diverges from Node's success output)."
   },
   "test_issue_express_map_undefined": {
     "issue": "912",
@@ -186,229 +186,229 @@
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 needs a CI-side fixture, not a Perry fix."
+    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
   },
   "test_net_socket": {
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 needs a CI-side fixture, not a Perry fix."
+    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
   },
   "test_net_upgrade_tls": {
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test needs a TLS-capable echo server fixture; not available on CI. Environmental \u2014 needs a CI-side fixture."
+    "reason": "Net test needs a TLS-capable echo server fixture; not available on CI. Environmental — needs a CI-side fixture."
   },
   "test_parity_assert": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:assert` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:assert` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_async_hooks": {
     "issue": "789",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:async_hooks` createHook lifecycle + asyncId tracking missing. Tracked in #789. Flips to PASS once createHook fires."
+    "reason": "Node.js module inventory — `node:async_hooks` createHook lifecycle + asyncId tracking missing. Tracked in #789. Flips to PASS once createHook fires."
   },
   "test_parity_buffer": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:buffer` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:buffer` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_child_process": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:child_process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:child_process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_crypto": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:crypto` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:crypto` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_dgram": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:dgram` (UDP) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:dgram` (UDP) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_diagnostics_channel": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:diagnostics_channel` not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:diagnostics_channel` not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_dns": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:dns` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:dns` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_dns_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:dns/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:dns/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_fs": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:fs` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:fs` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_fs_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:fs/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:fs/promises` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_http": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:http` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:http` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_http2": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:http2` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:http2` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_https": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:https` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:https` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_module": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:module` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:module` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_net": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:net` socket-layer surface not implemented (Server/Socket classes, BlockList, SocketAddress). Classification helpers landed via #811. Tracker for surface coverage; flips to PASS as each API lands."
+    "reason": "Node.js module inventory — `node:net` socket-layer surface not implemented (Server/Socket classes, BlockList, SocketAddress). Classification helpers landed via #811. Tracker for surface coverage; flips to PASS as each API lands."
   },
   "test_parity_os": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:os` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:os` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_path": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:path` surface. Per-method gaps closed via #741 and #810 (path.posix/win32 sub-namespace). This test now PASSes byte-for-byte; entry retained until the next sweep confirms it can be removed."
+    "reason": "Node.js module inventory — `node:path` surface. Per-method gaps closed via #741 and #810 (path.posix/win32 sub-namespace). This test now PASSes byte-for-byte; entry retained until the next sweep confirms it can be removed."
   },
   "test_parity_perf_hooks": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:perf_hooks` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:perf_hooks` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_process": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:process` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_readline": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:readline` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:readline` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_readline_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:readline/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:readline/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_sqlite": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:sqlite` (Node 22.5+ built-in) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:sqlite` (Node 22.5+ built-in) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:stream` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:stream` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream_consumers": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:stream/consumers` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:stream/consumers` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream_promises": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:stream/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:stream/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream_web": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:stream/web` (WHATWG streams) surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:stream/web` (WHATWG streams) surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_sys": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:sys` (legacy alias for util) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:sys` (legacy alias for util) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_test": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:test` (built-in test runner) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:test` (built-in test runner) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_tls": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:tls` surface not fully implemented (Socket-level TLS upgrade works via net.upgradeToTLS; the higher-level tls.connect/Server is partial). Tracker for surface coverage."
+    "reason": "Node.js module inventory — `node:tls` surface not fully implemented (Socket-level TLS upgrade works via net.upgradeToTLS; the higher-level tls.connect/Server is partial). Tracker for surface coverage."
   },
   "test_parity_url": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:url` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:url` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_util": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:util` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:util` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_worker_threads": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:worker_threads` surface not implemented (perry/thread provides a Perry-native alternative). Tracker for surface coverage; flips to PASS as each API lands."
+    "reason": "Node.js module inventory — `node:worker_threads` surface not implemented (perry/thread provides a Perry-native alternative). Tracker for surface coverage; flips to PASS as each API lands."
   },
   "test_parity_zlib": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:zlib` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+    "reason": "Node.js module inventory — `node:zlib` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_sock_write_map": {
     "issue": null,
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 issue #91 dispatch fix landed in v0.5.581 and is no longer the cause; needs a CI-side fixture."
+    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — issue #91 dispatch fix landed in v0.5.581 and is no longer the cause; needs a CI-side fixture."
   },
   "test_decorators_nest_js_common_canary": {
     "issue": null,
@@ -420,18 +420,18 @@
     "issue": null,
     "added": "2026-05-18",
     "category": "ci-env",
-    "reason": "Ramda npm-package fixture failure on Linux CI; observed on #1038's CI run pre-merge. Companion to the existing test_ramda_user_import skip in the compile-smoke list \u2014 the parity harness can't npm-install ramda. File a CI-side fixture issue if/when this matters for sweep coverage."
+    "reason": "Ramda npm-package fixture failure on Linux CI; observed on #1038's CI run pre-merge. Companion to the existing test_ramda_user_import skip in the compile-smoke list — the parity harness can't npm-install ramda. File a CI-side fixture issue if/when this matters for sweep coverage."
   },
   "test_stream_on": {
     "issue": null,
     "added": "2026-05-18",
     "category": "ci-env",
-    "reason": "node:stream emitter wiring still incomplete (cf. existing test_parity_stream module-inventory entry). Same failure observed on #1038 pre-merge \u2014 not a regression."
+    "reason": "node:stream emitter wiring still incomplete (cf. existing test_parity_stream module-inventory entry). Same failure observed on #1038 pre-merge — not a regression."
   },
   "test_zlib_brotli_decompress": {
     "issue": null,
     "added": "2026-05-18",
     "category": "ci-env",
-    "reason": "Brotli decompression path under node:zlib not yet implemented (cf. existing test_parity_zlib module-inventory entry). Same failure observed on #1038 pre-merge \u2014 not a regression."
+    "reason": "Brotli decompression path under node:zlib not yet implemented (cf. existing test_parity_zlib module-inventory entry). Same failure observed on #1038 pre-merge — not a regression."
   }
 }


### PR DESCRIPTION
Closes a partial slice of #1431 (WebCrypto `subtle.*` rejection-vs-resolve-undefined regression).

## Summary
- Adds `reject_with_dom_exception(name, message)` helper in `crates/perry-stdlib/src/webcrypto.rs` that constructs a `{ name, message, stack: "" }` object and returns a rejected Promise carrying it — the shape `.catch(e => e.name === "...")` consumers (jose, aws4fetch, oidc-client-ts, web-push) match on.
- Converts the most user-visible top-level error paths across `digest`, `importKey`, `exportKey`, `sign`, `verify`, `encrypt`, `decrypt`, `generateKey`, `deriveKey`, `wrapKey`, `unwrapKey` from `resolve_undefined()` to `reject_with_dom_exception(...)`. These are the cases where the algorithm name itself is unrecognized, the key isn't a registered CryptoKey, the format string is unsupported, or the key bytes are empty — i.e. the cases where the call should never have been issued.
- Inner failures (algorithm/key-kind mismatches, RSA DER parse errors, decrypt MAC failures) remain `resolve_undefined()` for now — they need per-site classification (`OperationError` vs `DataError` vs `InvalidAccessError`) and will follow up in further passes against #1431.
- Re-exports `js_promise_rejected` from `perry_runtime` root so stdlib callers don't have to reach into the `promise` submodule.

## Test plan
Three new parity tests under `test-parity/node-suite/crypto/webcrypto/errors/`:
- [x] `digest-unknown-alg.ts` — `subtle.digest(\"BOGUS-256\", data)` now rejects; matches Node `rejected: true / name-type: string` byte-for-byte.
- [x] `import-key-bad-format.ts` — `subtle.importKey(\"bogus\", ...)` now rejects; matches Node.
- [x] `sign-missing-key.ts` — `subtle.sign(\"HMAC\", new Uint8Array(32), data)` now rejects; matches Node.
- [x] Happy paths unchanged: ran `crypto/webcrypto/digest.ts` and `crypto/webcrypto/hmac-sign-verify.ts` — Perry output `diff`s clean against Node.
- [x] `cargo fmt --all -- --check` clean.

Tests focus on the no-silent-resolve invariant (`rejected: true`, `typeof e.name === \"string\"`) rather than asserting specific WebCrypto error-name strings — Node's full name taxonomy spans `TypeError` / `DOMException(\"NotSupportedError\" | \"InvalidAccessError\" | \"DataError\" | \"OperationError\")` and a per-site Perry match would require deeper classification (the follow-up work tracked in #1431).