### PR TITLE
test(crypto): pin AES-GCM short-tag encrypt parity (#1433 — partial)

### DIFF
--- a/test-parity/node-suite/crypto/cipher/aes-gcm-short-tag-bytes.ts
+++ b/test-parity/node-suite/crypto/cipher/aes-gcm-short-tag-bytes.ts
@@ -1,0 +1,38 @@
+// Verify AES-GCM produces byte-identical auth tags to Node for the
+// non-standard short tag lengths {4, 8}. The original concern in #1433
+// was that Perry's RustCrypto Aes*Gcm backend returned wrong bytes for
+// these (the issue text speculated GHASH-with-shorter-tag-len would
+// differ from full-tag truncation). In practice Node's OpenSSL backend
+// just truncates the 16-byte tag, and Perry's `aes-gcm` crate likewise
+// truncates after computing the full 16-byte tag, so the bytes match.
+//
+// This test pins the invariant on the **encrypt** side; the matching
+// **decrypt** path with sub-12-byte tags is a separate bug — the
+// `aes-gcm` crate's `SealedTagSize` trait is `private` and only
+// permits U12..=U16, so we can't instantiate `AesGcm<.., U4>` for
+// decryption. Tracked as a follow-up.
+import * as crypto from "node:crypto";
+import { Buffer } from "node:buffer";
+
+const key = Buffer.alloc(32, 1);
+const iv = Buffer.alloc(12, 2);
+const data = Buffer.from("hello world");
+
+for (const tagLen of [4, 8, 12, 16]) {
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv, { authTagLength: tagLen });
+  const ct = Buffer.concat([cipher.update(data), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  console.log(`tagLen=${tagLen} ct=${ct.toString("hex")} tag=${tag.toString("hex")}`);
+}
+
+// Round-trip with the supported {12, 16} tag lengths confirms the
+// decrypt path is byte-correct in the supported range.
+for (const tagLen of [12, 16]) {
+  const c = crypto.createCipheriv("aes-256-gcm", key, iv, { authTagLength: tagLen });
+  const ct = Buffer.concat([c.update(data), c.final()]);
+  const tag = c.getAuthTag();
+  const d = crypto.createDecipheriv("aes-256-gcm", key, iv, { authTagLength: tagLen });
+  d.setAuthTag(tag);
+  const pt = Buffer.concat([d.update(ct), d.final()]);
+  console.log(`roundtrip-${tagLen}:`, pt.toString());
+}


### PR DESCRIPTION
Partial close on #1433 (AES-GCM authTagLength 4/8).

## Summary
#1433 claimed Perry's RustCrypto \`Aes*Gcm\` path produced different tag bytes from Node for \`authTagLength\` 4 and 8. After implementing what the issue suggested (instantiate \`AesGcm<.., U4>\` and \`AesGcm<.., U8>\` for decrypt and slot in matching encrypt arms), I discovered:

1. **The encrypt-side bytes already match Node byte-for-byte.** Node's OpenSSL backend just truncates the 16-byte GCM tag, and Perry's \`aes-gcm\` crate likewise truncates after the full computation. The issue's premise about encrypt-side divergence was wrong.

2. **The decrypt path is the actual bug.** \`aes-gcm\` 0.10 seals \`SealedTagSize\` to \`U12..=U16\`, so \`AesGcm<.., U4>\` and \`AesGcm<.., U8>\` can't be instantiated for either encrypt OR decrypt — and the current decrypt dispatch (\`decrypt_gcm{128,192,256}_with_tag_len\` in \`crypto.rs\`) silently returns \`None\` for tag lengths < 12 via the \`_ => None\` arm. The user gets empty plaintext instead of a loud failure.

## What this PR ships
A parity test (\`test-parity/node-suite/crypto/cipher/aes-gcm-short-tag-bytes.ts\`) that:
- Pins the encrypt-side byte invariant for \`{4, 8, 12, 16}\` — passes (matches Node).
- Round-trips encrypt + decrypt for \`{12, 16}\` — passes (the supported decrypt range).

## What's left for #1433
The decrypt path for tag lengths < 12 needs either:
- A different AES-GCM backend that doesn't seal tag size, or
- Manual GCM composition over \`aes::Aes*\` + the \`ghash\` crate (which is already a transitive dep via \`aes-gcm\`).

Both options are ~50-100 LOC and need careful test coverage; tracked as a follow-up.

## Test plan
- [x] New \`aes-gcm-short-tag-bytes.ts\` parity output \`diff\`s clean against Node.
- [x] Existing \`aes-gcm-auth-tag-length.ts\` and \`aes-gcm-variable-tags.ts\` parity tests unchanged.
- [x] \`cargo fmt --all -- --check\` clean.