### PR TITLE
feat(perf_hooks): monitorEventLoopDelay + createHistogram stubs (#1336)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2284,26 +2284,12 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("perf_hooks", "timerify", false, None),
     // #1336: monitorEventLoopDelay() / createHistogram() return a
     // Histogram-shaped object whose method/property reads route
-    // through the `perf_histogram` namespace below. Stub — every stat
-    // reads 0 and the mutators are no-ops.
+    // through the internal `perf_histogram` namespace (not listed in
+    // NATIVE_MODULES because users never import it — they receive the
+    // object as a return value, same pattern as `perf_observer`).
+    // Stub — every stat reads 0 and the mutators are no-ops.
     method("perf_hooks", "monitorEventLoopDelay", false, None),
     method("perf_hooks", "createHistogram", false, None),
-    method("perf_histogram", "enable", false, None),
-    method("perf_histogram", "disable", false, None),
-    method("perf_histogram", "reset", false, None),
-    method("perf_histogram", "record", false, None),
-    method("perf_histogram", "recordDelta", false, None),
-    method("perf_histogram", "add", false, None),
-    method("perf_histogram", "percentile", false, None),
-    method("perf_histogram", "percentileBigInt", false, None),
-    property("perf_histogram", "mean"),
-    property("perf_histogram", "min"),
-    property("perf_histogram", "max"),
-    property("perf_histogram", "stddev"),
-    property("perf_histogram", "exceeds"),
-    property("perf_histogram", "count"),
-    property("perf_histogram", "percentiles"),
-    property("perf_histogram", "percentilesBigInt"),
     property("perf_hooks", "timeOrigin"),
     property("perf_hooks", "nodeTiming"),
     property("perf_hooks", "performance"),

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2282,6 +2282,28 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // #1335: returns `fn` unchanged today; the spec'd "wraps fn to
     // record a 'function' timeline entry" piece isn't recorded yet.
     method("perf_hooks", "timerify", false, None),
+    // #1336: monitorEventLoopDelay() / createHistogram() return a
+    // Histogram-shaped object whose method/property reads route
+    // through the `perf_histogram` namespace below. Stub — every stat
+    // reads 0 and the mutators are no-ops.
+    method("perf_hooks", "monitorEventLoopDelay", false, None),
+    method("perf_hooks", "createHistogram", false, None),
+    method("perf_histogram", "enable", false, None),
+    method("perf_histogram", "disable", false, None),
+    method("perf_histogram", "reset", false, None),
+    method("perf_histogram", "record", false, None),
+    method("perf_histogram", "recordDelta", false, None),
+    method("perf_histogram", "add", false, None),
+    method("perf_histogram", "percentile", false, None),
+    method("perf_histogram", "percentileBigInt", false, None),
+    property("perf_histogram", "mean"),
+    property("perf_histogram", "min"),
+    property("perf_histogram", "max"),
+    property("perf_histogram", "stddev"),
+    property("perf_histogram", "exceeds"),
+    property("perf_histogram", "count"),
+    property("perf_histogram", "percentiles"),
+    property("perf_histogram", "percentilesBigInt"),
     property("perf_hooks", "timeOrigin"),
     property("perf_hooks", "nodeTiming"),
     property("perf_hooks", "performance"),

--- a/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
+++ b/crates/perry-codegen/src/lower_call/native/perf_hooks.rs
@@ -148,6 +148,22 @@ pub(super) fn lower_perf_hooks_method(
             // isn't in our supported entryTypes set today, so no
             // observer would see it anyway).
             "timerify" => lower_or_undef(ctx, 0)?,
+            // #1336: perf_hooks.monitorEventLoopDelay(options?) returns
+            // an IntervalHistogram; createHistogram(options?) returns a
+            // RecordableHistogram. Both are stubs (every stat reads 0
+            // and enable/disable/reset/record are no-ops), but the
+            // returned object has the right shape for feature-detection
+            // and trivial-call paths.
+            "monitorEventLoopDelay" => {
+                let a0 = lower_or_undef(ctx, 0)?;
+                ctx.block()
+                    .call(DOUBLE, "js_perf_monitor_event_loop_delay", &[(DOUBLE, &a0)])
+            }
+            "createHistogram" => {
+                let a0 = lower_or_undef(ctx, 0)?;
+                ctx.block()
+                    .call(DOUBLE, "js_perf_create_histogram", &[(DOUBLE, &a0)])
+            }
             _ => return Ok(None),
         };
         return Ok(Some(v));

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1105,6 +1105,13 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_perf_observer_observe", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_perf_observer_disconnect", DOUBLE, &[DOUBLE]);
     module.declare_function("js_perf_observer_take_records", DOUBLE, &[DOUBLE]);
+    // #1336: histogram stubs for perf_hooks.monitorEventLoopDelay() /
+    // .createHistogram(). Histogram methods route via the perf_histogram
+    // namespace through native_module_dispatch.
+    module.declare_function("js_perf_monitor_event_loop_delay", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_perf_create_histogram", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_perf_histogram_noop", DOUBLE, &[]);
+    module.declare_function("js_perf_histogram_percentile", DOUBLE, &[DOUBLE]);
 
     // ========== Async-step iter-result scratch (perf hot path) ==========
     // See promise.rs::ITER_RESULT_VALUE / ITER_RESULT_DONE — eliminates

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -504,6 +504,19 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("perf_observer_list", "getEntries")
             | ("perf_observer_list", "getEntriesByType")
             | ("perf_observer_list", "getEntriesByName")
+            // #1336: monitorEventLoopDelay() / createHistogram() return
+            // a `perf_histogram`-tagged namespace object. Property reads
+            // of method names need to satisfy `typeof h.enable === "function"`.
+            | ("perf_hooks", "monitorEventLoopDelay")
+            | ("perf_hooks", "createHistogram")
+            | ("perf_histogram", "enable")
+            | ("perf_histogram", "disable")
+            | ("perf_histogram", "reset")
+            | ("perf_histogram", "record")
+            | ("perf_histogram", "recordDelta")
+            | ("perf_histogram", "add")
+            | ("perf_histogram", "percentile")
+            | ("perf_histogram", "percentileBigInt")
             // node:cluster — namespace property reads of these callables
             // need to satisfy `typeof cluster.fork === "function"` etc.
             // The fixtures only probe types, but compiled npm code that
@@ -1493,6 +1506,19 @@ pub(crate) unsafe fn get_native_module_constant(
             // #463 gate doesn't reject the typeof read at compile time;
             // here we resolve them to undefined at runtime.
             "on" | "addListener" => Some(f64::from_bits(JSValue::undefined().bits())),
+            _ => None,
+        },
+        // #1336: Histograms returned by perf_hooks.monitorEventLoopDelay /
+        // .createHistogram expose numeric stats via property read. Perry's
+        // stub doesn't record samples so every accessor reads 0; `exceeds`
+        // and `count` matter for code that branches on counts before
+        // computing averages.
+        "perf_histogram" => match property {
+            "mean" | "min" | "max" | "stddev" | "exceeds" | "count" => Some(0.0),
+            "percentiles" | "percentilesBigInt" => {
+                let obj = unsafe { js_object_alloc(0, 0) };
+                Some(f64::from_bits(JSValue::pointer(obj as *const u8).bits()))
+            }
             _ => None,
         },
         _ => None,

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -225,6 +225,20 @@ pub(crate) unsafe fn dispatch_native_module_method(
             crate::perf_hooks::current_list_get_by_name(arg(0))
         }
 
+        // ── Histogram instance methods (#1336) ──
+        // Every method is a no-op on the stub — `enable`/`disable`/`reset`
+        // don't sample anything, `record`/`recordDelta`/`add` discard input.
+        // `percentile(p)` returns 0 (no samples => no rank).
+        ("perf_histogram", "enable")
+        | ("perf_histogram", "disable")
+        | ("perf_histogram", "reset")
+        | ("perf_histogram", "record")
+        | ("perf_histogram", "recordDelta")
+        | ("perf_histogram", "add") => crate::perf_hooks::js_perf_histogram_noop(),
+        ("perf_histogram", "percentile") | ("perf_histogram", "percentileBigInt") => {
+            crate::perf_hooks::js_perf_histogram_percentile(arg(0))
+        }
+
         // ── timers module ──
         ("timers", "setTimeout") if args_len >= 2 => {
             let cb = arg(0);

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -1019,3 +1019,58 @@ pub fn scan_perf_entries_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
         }
     });
 }
+
+// ── Histograms (perf_histogram namespace) ────────────────────────────────────
+// `monitorEventLoopDelay()` returns an IntervalHistogram and
+// `createHistogram()` returns a RecordableHistogram. Perry doesn't actually
+// sample event-loop delay or record user-supplied values yet — every stat
+// reads as 0, and enable/disable/reset/record/recordDelta/add are no-ops.
+// The shape is enough to satisfy feature-detection (`typeof h.record ===
+// "function"`, `typeof h.mean === "number"`) and the trivial-call paths
+// that user code drives through these histograms. Issue #1336.
+
+/// Build a `perf_histogram`-tagged namespace object. Distinguishing
+/// IntervalHistogram vs RecordableHistogram is unnecessary for the stub
+/// surface — every method/property is shared and trivial — so the same
+/// shape covers both. The receiver-less property reads route through
+/// `is_native_module_callable_export` (methods) and
+/// `get_native_module_constant` (numeric accessors).
+unsafe fn make_histogram_object() -> f64 {
+    let obj = crate::object::js_object_alloc(crate::object::NATIVE_MODULE_CLASS_ID, 1);
+    let module = b"perf_histogram";
+    let mname = crate::string::js_string_from_bytes(module.as_ptr(), module.len() as u32);
+    js_object_set_field(obj, 0, JSValue::string_ptr(mname));
+    let mut keys = crate::array::js_array_alloc(1);
+    let kp = crate::string::js_string_from_bytes(b"__module__".as_ptr(), 10);
+    keys = crate::array::js_array_push(keys, JSValue::string_ptr(kp));
+    crate::object::js_object_set_keys(obj, keys);
+    crate::value::js_nanbox_pointer(obj as i64)
+}
+
+/// `perf_hooks.monitorEventLoopDelay(options?)` — returns an IntervalHistogram.
+#[no_mangle]
+pub extern "C" fn js_perf_monitor_event_loop_delay(_options: f64) -> f64 {
+    unsafe { make_histogram_object() }
+}
+
+/// `perf_hooks.createHistogram(options?)` — returns a RecordableHistogram.
+#[no_mangle]
+pub extern "C" fn js_perf_create_histogram(_options: f64) -> f64 {
+    unsafe { make_histogram_object() }
+}
+
+/// `histogram.enable()` / `.disable()` / `.reset()` / `.record(n)` /
+/// `.recordDelta()` / `.add(other)` — no-ops on the stub. Returns
+/// `undefined` per Node's signature for the void-returning methods;
+/// `.enable()` actually returns `true` in Node (was it running before?),
+/// but `undefined` is what the unobserved-stub case warrants.
+#[no_mangle]
+pub extern "C" fn js_perf_histogram_noop() -> f64 {
+    f64::from_bits(JSValue::undefined().bits())
+}
+
+/// `histogram.percentile(p)` — returns 0 (no recorded samples).
+#[no_mangle]
+pub extern "C" fn js_perf_histogram_percentile(_p: f64) -> f64 {
+    0.0
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1221 entries across 81 modules
+// Coverage: 1205 entries across 80 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -991,41 +991,6 @@ declare module "path" {
   export function resolve(...args: any[]): any;
   /** stdlib */
   export function toNamespacedPath(...args: any[]): any;
-}
-
-declare module "perf_histogram" {
-  /** stdlib */
-  export const count: any;
-  /** stdlib */
-  export const exceeds: any;
-  /** stdlib */
-  export const max: any;
-  /** stdlib */
-  export const mean: any;
-  /** stdlib */
-  export const min: any;
-  /** stdlib */
-  export const percentiles: any;
-  /** stdlib */
-  export const percentilesBigInt: any;
-  /** stdlib */
-  export const stddev: any;
-  /** stdlib */
-  export function add(...args: any[]): any;
-  /** stdlib */
-  export function disable(...args: any[]): any;
-  /** stdlib */
-  export function enable(...args: any[]): any;
-  /** stdlib */
-  export function percentile(...args: any[]): any;
-  /** stdlib */
-  export function percentileBigInt(...args: any[]): any;
-  /** stdlib */
-  export function record(...args: any[]): any;
-  /** stdlib */
-  export function recordDelta(...args: any[]): any;
-  /** stdlib */
-  export function reset(...args: any[]): any;
 }
 
 declare module "perf_hooks" {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1203 entries across 80 modules
+// Coverage: 1221 entries across 81 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -993,6 +993,41 @@ declare module "path" {
   export function toNamespacedPath(...args: any[]): any;
 }
 
+declare module "perf_histogram" {
+  /** stdlib */
+  export const count: any;
+  /** stdlib */
+  export const exceeds: any;
+  /** stdlib */
+  export const max: any;
+  /** stdlib */
+  export const mean: any;
+  /** stdlib */
+  export const min: any;
+  /** stdlib */
+  export const percentiles: any;
+  /** stdlib */
+  export const percentilesBigInt: any;
+  /** stdlib */
+  export const stddev: any;
+  /** stdlib */
+  export function add(...args: any[]): any;
+  /** stdlib */
+  export function disable(...args: any[]): any;
+  /** stdlib */
+  export function enable(...args: any[]): any;
+  /** stdlib */
+  export function percentile(...args: any[]): any;
+  /** stdlib */
+  export function percentileBigInt(...args: any[]): any;
+  /** stdlib */
+  export function record(...args: any[]): any;
+  /** stdlib */
+  export function recordDelta(...args: any[]): any;
+  /** stdlib */
+  export function reset(...args: any[]): any;
+}
+
 declare module "perf_hooks" {
   /** stdlib */
   export class PerformanceEntry { [key: string]: any; }
@@ -1019,6 +1054,8 @@ declare module "perf_hooks" {
   /** stdlib */
   export function clearResourceTimings(...args: any[]): any;
   /** stdlib */
+  export function createHistogram(...args: any[]): any;
+  /** stdlib */
   export function eventLoopUtilization(...args: any[]): any;
   /** stdlib */
   export function getEntries(...args: any[]): any;
@@ -1032,6 +1069,8 @@ declare module "perf_hooks" {
   export function markResourceTiming(...args: any[]): any;
   /** stdlib */
   export function measure(...args: any[]): any;
+  /** stdlib */
+  export function monitorEventLoopDelay(...args: any[]): any;
   /** stdlib */
   export function now(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1221 entries across 81 modules.
+Total: 1205 entries across 80 modules.
 
 ## Modules
 
@@ -52,7 +52,6 @@ Total: 1221 entries across 81 modules.
 - [`nodemailer`](#nodemailer)
 - [`os`](#os)
 - [`path`](#path)
-- [`perf_histogram`](#perf-histogram)
 - [`perf_hooks`](#perf-hooks)
 - [`perry/ads`](#perry-ads)
 - [`perry/background`](#perry-background)
@@ -1106,30 +1105,6 @@ Total: 1221 entries across 81 modules.
 - `posix`
 - `sep`
 - `win32`
-
-## `perf_histogram`
-
-### Methods
-
-- `add` — module
-- `disable` — module
-- `enable` — module
-- `percentile` — module
-- `percentileBigInt` — module
-- `record` — module
-- `recordDelta` — module
-- `reset` — module
-
-### Properties
-
-- `count`
-- `exceeds`
-- `max`
-- `mean`
-- `min`
-- `percentiles`
-- `percentilesBigInt`
-- `stddev`
 
 ## `perf_hooks`
 

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1203 entries across 80 modules.
+Total: 1221 entries across 81 modules.
 
 ## Modules
 
@@ -52,6 +52,7 @@ Total: 1203 entries across 80 modules.
 - [`nodemailer`](#nodemailer)
 - [`os`](#os)
 - [`path`](#path)
+- [`perf_histogram`](#perf-histogram)
 - [`perf_hooks`](#perf-hooks)
 - [`perry/ads`](#perry-ads)
 - [`perry/background`](#perry-background)
@@ -1106,6 +1107,30 @@ Total: 1203 entries across 80 modules.
 - `sep`
 - `win32`
 
+## `perf_histogram`
+
+### Methods
+
+- `add` — module
+- `disable` — module
+- `enable` — module
+- `percentile` — module
+- `percentileBigInt` — module
+- `record` — module
+- `recordDelta` — module
+- `reset` — module
+
+### Properties
+
+- `count`
+- `exceeds`
+- `max`
+- `mean`
+- `min`
+- `percentiles`
+- `percentilesBigInt`
+- `stddev`
+
 ## `perf_hooks`
 
 ### Classes
@@ -1120,6 +1145,7 @@ Total: 1203 entries across 80 modules.
 - `clearMarks` — module
 - `clearMeasures` — module
 - `clearResourceTimings` — module
+- `createHistogram` — module
 - `disconnect` — instance *(class: `PerformanceObserver`)*
 - `eventLoopUtilization` — module
 - `getEntries` — module
@@ -1128,6 +1154,7 @@ Total: 1203 entries across 80 modules.
 - `mark` — module
 - `markResourceTiming` — module
 - `measure` — module
+- `monitorEventLoopDelay` — module
 - `now` — module
 - `observe` — instance *(class: `PerformanceObserver`)*
 - `setResourceTimingBufferSize` — module


### PR DESCRIPTION
Closes #1336.

## Summary
Adds runtime stubs for \`perf_hooks.monitorEventLoopDelay()\` and \`perf_hooks.createHistogram()\`. Both return a Histogram-shaped object whose method/property reads route through a new \`perf_histogram\` native-module namespace.

The stub doesn't actually sample event-loop delay or record user-supplied values — every stat (\`mean\` / \`min\` / \`max\` / \`stddev\` / \`exceeds\` / \`count\`) reads as 0 and the mutators (\`enable\` / \`disable\` / \`reset\` / \`record\` / \`recordDelta\` / \`add\`) are no-ops. \`percentile(p)\` returns 0; \`percentiles\` / \`percentilesBigInt\` return an empty plain object so iteration doesn't crash.

The shape is enough to satisfy feature-detection (\`typeof h.enable === \"function\"\`, \`typeof h.mean === \"number\"\`) and the trivial-call paths that user code drives through these histograms.

## Wiring
- Runtime stubs in \`crates/perry-runtime/src/perf_hooks.rs\`.
- Codegen lowering in \`crates/perry-codegen/src/lower_call/native/perf_hooks.rs\`.
- Extern decls in \`crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs\`.
- Namespace callable-exports, numeric constants, method dispatch in \`crates/perry-runtime/src/object/native_module.rs\` + \`native_module_dispatch.rs\`.
- Manifest entries in \`crates/perry-api-manifest/src/entries.rs\` (with regenerated \`docs/api/perry.d.ts\` + \`docs/src/api/reference.md\`).

## Test plan
- [x] \`test-parity/node-suite/perf_hooks/histogram/monitor-event-loop-delay.ts\` — Perry output \`diff\`s clean against Node (\`enable: true / disable: true / mean: true\`).
- [x] \`test-parity/node-suite/perf_hooks/histogram/create-histogram.ts\` — Perry output \`diff\`s clean against Node (\`record: true / count: true\`).
- [x] \`cargo fmt --all -- --check\` clean.