### PR TITLE
feat(perry/ui): wire showToast for --target web (#1546)

### DIFF
--- a/crates/perry-codegen-wasm/src/emit/ui_method_map.rs
+++ b/crates/perry-codegen-wasm/src/emit/ui_method_map.rs
@@ -74,6 +74,11 @@ pub(super) fn map_ui_method(method: &str, class_name: Option<&str>) -> &'static 
         "textfieldSetFontSize" => "perry_ui_set_font_size",
         "textfieldSetBorderless" => "perry_ui_textfield_set_borderless",
         "stackSetAlignment" => "perry_ui_stack_set_alignment",
+        // #1546: showToast(msg) renders a bottom-of-page toast on web —
+        // previously was a no-op (only HarmonyOS routed
+        // `promptAction.showToast` through the runtime drain queue).
+        // Now wires to a JS-side fade-in/out div in wasm_runtime.js.
+        "showToast" => "perry_ui_show_toast",
         // Text decoration (issue #185 Phase B). 0=none, 1=underline,
         // 2=strikethrough on the canonical FFI; CSS-side translates.
         "textSetDecoration" | "text_set_decoration" => "perry_ui_text_set_decoration",

--- a/crates/perry-codegen-wasm/src/wasm_runtime.js
+++ b/crates/perry-codegen-wasm/src/wasm_runtime.js
@@ -2636,6 +2636,43 @@ function uiStateSet(h, value) {
 
 // ---------- Widget creation functions (take JS values, return handle_id) ----------
 
+// #1546: showToast(msg) — bottom-center fade-in/out toast for --target web.
+// HarmonyOS routes through `promptAction.showToast` via a runtime drain queue;
+// on web the previous behavior was a documented no-op. The implementation here
+// stays minimal: one host-managed div, queued messages, default 3s visible.
+function perry_ui_show_toast(message) {
+  if (typeof document === "undefined") return;
+  const msg = (message === null || message === undefined) ? "" : String(message);
+  if (!perry_ui_show_toast._q) perry_ui_show_toast._q = [];
+  perry_ui_show_toast._q.push(msg);
+  if (perry_ui_show_toast._busy) return;
+  perry_ui_show_toast._busy = true;
+  const drain = () => {
+    const next = perry_ui_show_toast._q.shift();
+    if (next === undefined) { perry_ui_show_toast._busy = false; return; }
+    let el = perry_ui_show_toast._el;
+    if (!el) {
+      el = document.createElement("div");
+      el.setAttribute("data-perry-toast", "");
+      el.style.cssText =
+        "position:fixed;left:50%;bottom:32px;transform:translateX(-50%);" +
+        "background:rgba(28,28,30,0.92);color:#fff;padding:10px 18px;" +
+        "border-radius:18px;font:14px -apple-system,system-ui,Segoe UI,Roboto,sans-serif;" +
+        "max-width:80vw;box-shadow:0 6px 24px rgba(0,0,0,0.25);" +
+        "opacity:0;transition:opacity .18s ease;pointer-events:none;z-index:2147483647;";
+      document.body.appendChild(el);
+      perry_ui_show_toast._el = el;
+    }
+    el.textContent = next;
+    requestAnimationFrame(() => { el.style.opacity = "1"; });
+    setTimeout(() => {
+      el.style.opacity = "0";
+      setTimeout(drain, 200);
+    }, 3000);
+  };
+  drain();
+}
+
 function perry_ui_app_create(titleOrOpts, width, height) {
   let title = "Perry App", bodyH, w = 800, ht = 600;
   if (typeof titleOrOpts === "object" && titleOrOpts !== null) {
@@ -3810,6 +3847,8 @@ const __perryUiDispatch = {
   perry_ui_widget_set_context_menu,
   // Animations
   perry_ui_animate_opacity, perry_ui_animate_position,
+  // #1546: showToast on web
+  perry_ui_show_toast,
   // Events
   perry_ui_set_on_click, perry_ui_set_on_hover, perry_ui_set_on_double_click,
   // State


### PR DESCRIPTION
Closes #1546 for the web target. Other platforms (macOS, iOS, Android, GTK) remain no-ops.

## Summary
\`showToast(message)\` from \`perry/ui\` was a documented no-op on every platform except HarmonyOS. The playground at playground.perryts.com — which compiles with \`--target web\` — silently swallowed toast calls. This PR wires the web backend:

- Maps \`showToast\` → \`perry_ui_show_toast\` in \`perry-codegen-wasm/src/emit/ui_method_map.rs\` so the wasm dispatch routes calls to the JS bridge instead of the no-bridge fallback.
- Adds \`perry_ui_show_toast(message)\` in \`perry-codegen-wasm/src/wasm_runtime.js\`. Single host-managed \`<div data-perry-toast>\` reused across calls, 3-second visible window, fades in/out via CSS transition, queues overlapping calls so two rapid \`showToast(...)\` invocations show sequentially instead of overwriting.
- Registers the bridge in the \`__perryUiDispatch\` table so the wasm \`emit_memcall\` finds it.

## Test plan
- [x] Compile the issue's repro program with \`--target web\`: produces a 208.8 KB HTML bundle that includes the \`perry_ui_show_toast\` function definition (10 references in the generated file, including the dispatch-table entry).
- [x] \`cargo fmt --all -- --check\` clean.
- [ ] **Manual:** open the generated HTML in a browser, click the button, observe a black rounded toast fading in at the bottom of the viewport, lingering for 3 seconds, then fading out.

Out of scope: macOS/iOS/Android/GTK backends. Those follow-ups can route to \`NSAlert\`/\`UIAlertController\`/\`Toast.makeText\`/\`GtkPopover\` respectively — same per-platform pattern as the rest of \`perry/ui\`.