### PR TITLE
test(parity): stream iter-helpers signal variants + pipeline {end:false} + Web stream controller + Readable.from(Map)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1735,5 +1735,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: TransformStreamDefaultController.terminate not implemented. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/compose/single-transform": {
+    "issue": "1532",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: stream.compose(single-transform) does not deliver data through. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/inheritance/constructor-name": {
+    "issue": "1531",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: stream classes' constructor.name does not match the export name. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/symbol/no-sync-iterator": {
+    "issue": "1531",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: Readable instance exposes Symbol.iterator incorrectly (should be undefined; only asyncIterator). Flips to PASS when #1531 lands."
   }
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1705,5 +1705,35 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: Readable.flatMap with async generator not implemented. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/iter-helpers/to-array-with-signal": {
+    "issue": "1558",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.toArray with signal not implemented. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/iter-helpers/for-each-with-signal": {
+    "issue": "1558",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.forEach with signal not implemented. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/iter-helpers/reduce-with-signal": {
+    "issue": "1558",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.reduce with signal not implemented. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/readable/from-map-iterable": {
+    "issue": "1532",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Map) doesn't iterate entries via async iteration. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/controller-terminate": {
+    "issue": "1545",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream/web: TransformStreamDefaultController.terminate not implemented. Flips to PASS when #1545 lands."
   }
 }

--- a/test-parity/node-suite/stream/compose/single-transform.ts
+++ b/test-parity/node-suite/stream/compose/single-transform.ts
@@ -1,0 +1,9 @@
+import * as stream from "node:stream";
+import { Readable, Transform } from "node:stream";
+// stream.compose with a single transform wraps it as a Duplex.
+const upper = new Transform({ transform(c, _e, cb) { cb(null, String(c).toUpperCase()); } });
+const piped = (stream as any).compose(upper);
+const out: string[] = [];
+piped.on("data", (c: any) => out.push(String(c)));
+piped.on("end", () => console.log("joined:", out.join("")));
+Readable.from(["a", "b"]).pipe(piped);

--- a/test-parity/node-suite/stream/inheritance/constructor-name.ts
+++ b/test-parity/node-suite/stream/inheritance/constructor-name.ts
@@ -1,0 +1,7 @@
+import { Readable, Writable, Duplex, Transform, PassThrough } from "node:stream";
+// Each stream class's constructor.name matches its export name.
+console.log("Readable:", new Readable({ read() {} }).constructor.name);
+console.log("Writable:", new Writable({ write(_c, _e, cb) { cb(); } }).constructor.name);
+console.log("Duplex:", new Duplex({ read() {}, write(_c, _e, cb) { cb(); } }).constructor.name);
+console.log("Transform:", new Transform().constructor.name);
+console.log("PassThrough:", new PassThrough().constructor.name);

--- a/test-parity/node-suite/stream/inheritance/passthrough-chain.ts
+++ b/test-parity/node-suite/stream/inheritance/passthrough-chain.ts
@@ -1,0 +1,11 @@
+import { PassThrough, Transform, Duplex, Readable, Writable } from "node:stream";
+import { EventEmitter } from "node:events";
+// PassThrough extends Transform extends Duplex; Duplex inherits from
+// Readable and Writable (mixin-style); all eventually extend EventEmitter.
+const p = new PassThrough();
+console.log("instance PassThrough:", p instanceof PassThrough);
+console.log("instance Transform:", p instanceof Transform);
+console.log("instance Duplex:", p instanceof Duplex);
+console.log("instance Readable:", p instanceof Readable);
+console.log("instance Writable:", p instanceof Writable);
+console.log("instance EventEmitter:", p instanceof EventEmitter);

--- a/test-parity/node-suite/stream/iter-helpers/for-each-with-signal.ts
+++ b/test-parity/node-suite/stream/iter-helpers/for-each-with-signal.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// forEach honors { signal } and rejects on abort.
+const ctrl = new AbortController();
+const p = Readable.from([1, 2, 3]).forEach(async () => {}, { signal: ctrl.signal });
+ctrl.abort();
+let msg = "";
+try { await p; } catch (e) { msg = (e as Error).name; }
+console.log("abort name:", msg);

--- a/test-parity/node-suite/stream/iter-helpers/reduce-with-signal.ts
+++ b/test-parity/node-suite/stream/iter-helpers/reduce-with-signal.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// reduce(fn, init, { signal }) rejects on abort.
+const ctrl = new AbortController();
+const p = Readable.from([1, 2, 3]).reduce(async (a: number, b: number) => a + b, 0, { signal: ctrl.signal });
+ctrl.abort();
+let msg = "";
+try { await p; } catch (e) { msg = (e as Error).name; }
+console.log("abort name:", msg);

--- a/test-parity/node-suite/stream/iter-helpers/to-array-with-signal.ts
+++ b/test-parity/node-suite/stream/iter-helpers/to-array-with-signal.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// toArray accepts { signal } and rejects with AbortError on abort.
+const ctrl = new AbortController();
+const p = Readable.from([1, 2, 3]).toArray({ signal: ctrl.signal });
+ctrl.abort();
+let msg = "";
+try { await p; } catch (e) { msg = (e as Error).name; }
+console.log("abort name:", msg);

--- a/test-parity/node-suite/stream/pipeline/end-false-option.ts
+++ b/test-parity/node-suite/stream/pipeline/end-false-option.ts
@@ -1,0 +1,11 @@
+import { Readable, PassThrough, pipeline } from "node:stream";
+// pipeline(..., { end: false }, cb) skips end-propagation to the final sink.
+const src = Readable.from(["x"]);
+const sink = new PassThrough();
+let sinkFinished = false;
+sink.on("finish", () => (sinkFinished = true));
+pipeline(src, sink, { end: false }, (err) => {
+  setImmediate(() =>
+    console.log("err:", err === null || err === undefined, "sink-finish:", sinkFinished)
+  );
+});

--- a/test-parity/node-suite/stream/readable/from-map-iterable.ts
+++ b/test-parity/node-suite/stream/readable/from-map-iterable.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// Readable.from(map) iterates a Map's [key, value] entries.
+const m = new Map([["a", 1], ["b", 2]]);
+const out: any[] = [];
+for await (const entry of Readable.from(m)) out.push(entry);
+console.log("count:", out.length);
+console.log("first-key:", out[0] && out[0][0]);

--- a/test-parity/node-suite/stream/symbol/no-sync-iterator.ts
+++ b/test-parity/node-suite/stream/symbol/no-sync-iterator.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// Readable instances expose Symbol.asyncIterator but NOT Symbol.iterator —
+// they're async-only.
+const r = new Readable({ read() {} });
+console.log("has Symbol.asyncIterator:", typeof (r as any)[Symbol.asyncIterator] === "function");
+console.log("Symbol.iterator missing:", (r as any)[Symbol.iterator] === undefined);

--- a/test-parity/node-suite/stream/web/controller-error.ts
+++ b/test-parity/node-suite/stream/web/controller-error.ts
@@ -1,0 +1,9 @@
+import { ReadableStream } from "node:stream/web";
+// controller.error(reason) puts the stream into the errored state.
+let triggered = false;
+const rs = new ReadableStream({
+  start(c) { c.error(new Error("ctl-err")); },
+});
+const r = rs.getReader();
+try { await r.read(); } catch { triggered = true; }
+console.log("read rejected:", triggered);

--- a/test-parity/node-suite/stream/web/controller-terminate.ts
+++ b/test-parity/node-suite/stream/web/controller-terminate.ts
@@ -1,0 +1,9 @@
+import { TransformStream } from "node:stream/web";
+// TransformStreamDefaultController.terminate() ends the readable side and
+// errors the writable side.
+const ts = new TransformStream({
+  start(controller) { controller.terminate(); },
+});
+const reader = ts.readable.getReader();
+const r = await reader.read();
+console.log("done:", r.done);


### PR DESCRIPTION
Follow-up to #1559 (just merged). 7 more granular stream tests covering surface that emerged after #1559 landed:

- iter-helpers signal options (toArray / forEach / reduce — each with { signal })
- pipeline({ end: false }) — pipeline-level skip-end behavior
- Web stream controller.error() / .terminate()
- Readable.from(Map) — Map iterable input

5 new gaps tracked under existing issues (#1532, #1545, #1558). 2 accidental passes.