### PR TITLE
chore(parity): drop known_failures entries unblocked by #1336

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -8,18 +8,6 @@
       "reason": "Free-text explanation. Keep the most-actionable signal first — what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
-  "node-suite/perf_hooks/histogram/monitor-event-loop-delay": {
-    "issue": "1336",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: monitorEventLoopDelay() unimplemented (not a function). Flips to PASS when #1336 lands."
-  },
-  "node-suite/perf_hooks/histogram/create-histogram": {
-    "issue": "1336",
-    "added": "2026-05-22",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: createHistogram() unimplemented (not a function). Flips to PASS when #1336 lands."
-  },
   "node-suite/perf_hooks/shapes/to-string-tag": {
     "issue": "1479",
     "added": "2026-05-23",


### PR DESCRIPTION
Housekeeping follow-up to #1555.

Both \`node-suite/perf_hooks/histogram/monitor-event-loop-delay\` and \`node-suite/perf_hooks/histogram/create-histogram\` now PASS — the histogram stubs from #1336 / #1555 satisfy the type-shape assertions the tests do.

## Verified locally
- \`monitor-event-loop-delay.ts\` → \`enable: true / disable: true / mean: true\` (matches Node).
- \`create-histogram.ts\` → \`record: true / count: true\` (matches Node).

No behavior change — purely a parity-dashboard cleanup so the surface coverage trend reflects reality.