### PR TITLE
fix(node): implement stream consumers

### DIFF
--- a/crates/perry-codegen/src/expr/helpers.rs
+++ b/crates/perry-codegen/src/expr/helpers.rs
@@ -278,6 +278,7 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
             | "AbortController"
             | "AbortSignal"
             | "FormData"
+            | "Blob"
             | "Headers"
             | "Request"
             | "Response"

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -93,6 +93,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 "Set" => 0xFFFF0023u32,
                 // `Array` — runtime detects via GC_TYPE_ARRAY at obj-8.
                 "Array" => 0xFFFF0024u32,
+                // `ArrayBuffer` — runtime detects BufferHeader storage marked
+                // with Perry's ArrayBuffer side registry.
+                "ArrayBuffer" => 0xFFFF0025u32,
+                // `Blob` — stream consumers allocate a scoped Blob-shaped
+                // ObjectHeader tagged with this reserved class id.
+                "Blob" => 0xFFFF0026u32,
                 // `Object` — every non-primitive matches per ECMAScript;
                 // reserved id mapped in the runtime. Pre-#585 this fell
                 // into the `cid = 0` fallback and matched accidentally

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -250,11 +250,11 @@ pub fn try_lower_property_get_method_call(
             // js_native_call_method fallback handles it correctly via
             // js_string_replace_string.
             "replace" if args.len() == 2 && matches!(&args[1], Expr::Closure { .. }) => true,
-            // slice/indexOf/includes exist on both strings and arrays.
-            // Route to string path only when args rule out the array
-            // variant (e.g., slice(0) is ambiguous but slice() with 0
-            // args is always array.slice to copy).
-            "slice" if !args.is_empty() => true,
+            // `slice` exists on strings, arrays, buffers, and Blob-like
+            // objects. Let the runtime dispatcher choose by receiver shape;
+            // forcing the string path here turns Blob slices into string
+            // slices for Any-typed native-module results.
+            "slice" => false,
             // `indexOf` / `includes` are NOT string-forced here: an
             // Any-typed receiver may be a runtime array (e.g. a native
             // module property like `PerformanceObserver.supportedEntryTypes`),

--- a/crates/perry-jsruntime/src/modules/builtin_stubs.rs
+++ b/crates/perry-jsruntime/src/modules/builtin_stubs.rs
@@ -796,20 +796,46 @@ export default { platform, arch, cpus, homedir, tmpdir, hostname, type, release,
 // So we make `Stream` a real class, attach the sub-classes as static
 // properties, and export the *class itself* as default.
 class Stream {
-    constructor() {}
+    constructor() { this._perryError = undefined; }
     pipe(dest) { return dest; }
     on() { return this; }
     once() { return this; }
-    emit() { return false; }
+    emit(event, arg) {
+        if (event === "error") {
+            this._perryError = arg;
+            return true;
+        }
+        return false;
+    }
     off() { return this; }
     addListener() { return this; }
     removeListener() { return this; }
     removeAllListeners() { return this; }
 }
 export class Readable extends Stream {
-    constructor() { super(); }
-    read() { return null; }
+    constructor(options = undefined) {
+        super();
+        if (options && typeof options.read === "function") this._perryRead = options.read;
+        this._perryReadInvoked = false;
+    }
+    static from(iterable) {
+        const readable = new Readable();
+        if (iterable == null) readable._perryChunks = [];
+        else if (Array.isArray(iterable)) readable._perryChunks = iterable.slice();
+        else if (typeof iterable === "string" || iterable instanceof ArrayBuffer || ArrayBuffer.isView(iterable)) readable._perryChunks = [iterable];
+        else if (typeof iterable[Symbol.iterator] === "function") readable._perryChunks = Array.from(iterable);
+        else readable._perryChunks = [iterable];
+        return readable;
+    }
+    read() {
+        if (this._perryChunks && this._perryChunks.length > 0) return this._perryChunks.shift();
+        return null;
+    }
     pipe(dest) { return dest; }
+    async *[Symbol.asyncIterator]() {
+        const chunks = this._perryChunks || [];
+        for (const chunk of chunks) yield chunk;
+    }
 }
 export class Writable extends Stream {
     constructor() { super(); }
@@ -1309,13 +1335,113 @@ export async function finished() { throw new Error('stream.promises.finished not
 export default { pipeline, finished };
 "#.to_string(),
         "stream/consumers" => r#"
-// Stub implementation for Node.js 'stream/consumers' module
-export async function arrayBuffer() { throw new Error('stream.consumers.arrayBuffer not supported'); }
-export async function blob() { throw new Error('stream.consumers.blob not supported'); }
-export async function buffer() { throw new Error('stream.consumers.buffer not supported'); }
-export async function json() { throw new Error('stream.consumers.json not supported'); }
-export async function text() { throw new Error('stream.consumers.text not supported'); }
-export default { arrayBuffer, blob, buffer, json, text };
+// Lightweight implementation for Node.js 'stream/consumers' module.
+class __PerryBuffer extends Uint8Array {
+    static from(input, encoding) {
+        if (typeof input === "string") return new __PerryBuffer(new TextEncoder().encode(input));
+        if (input instanceof ArrayBuffer) return new __PerryBuffer(input.slice(0));
+        if (ArrayBuffer.isView(input)) return new __PerryBuffer(input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength));
+        if (Array.isArray(input)) return new __PerryBuffer(input);
+        return new __PerryBuffer(0);
+    }
+    toString(encoding = "utf8") {
+        if (encoding === "hex") return Array.from(this, (b) => b.toString(16).padStart(2, "0")).join("");
+        return new TextDecoder().decode(this);
+    }
+}
+
+const __PerryBufferCtor = globalThis.Buffer || __PerryBuffer;
+
+function __perryChunkToBytes(chunk) {
+    if (typeof chunk === "string") return new TextEncoder().encode(chunk);
+    if (chunk instanceof ArrayBuffer) return new Uint8Array(chunk);
+    if (ArrayBuffer.isView(chunk)) return new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+    if (typeof chunk === "number") return new Uint8Array([chunk & 255]);
+    return new Uint8Array(0);
+}
+
+async function __perryCollectChunks(stream) {
+    if (stream == null) return [];
+    if (stream._perryError !== undefined) throw stream._perryError;
+    if (typeof stream._perryRead === "function" && !stream._perryReadInvoked) {
+        stream._perryReadInvoked = true;
+        stream._perryRead.call(stream);
+    }
+    if (stream._perryError !== undefined) throw stream._perryError;
+    if (Array.isArray(stream._perryChunks)) return stream._perryChunks.slice();
+    if (typeof stream[Symbol.asyncIterator] === "function") {
+        const chunks = [];
+        for await (const chunk of stream) chunks.push(chunk);
+        if (stream._perryError !== undefined) throw stream._perryError;
+        return chunks;
+    }
+    if (typeof stream[Symbol.iterator] === "function") return Array.from(stream);
+    return [stream];
+}
+
+async function __perryCollectBytes(stream) {
+    const chunks = await __perryCollectChunks(stream);
+    const arrays = chunks.map(__perryChunkToBytes);
+    const total = arrays.reduce((n, arr) => n + arr.byteLength, 0);
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const arr of arrays) {
+        out.set(arr, offset);
+        offset += arr.byteLength;
+    }
+    return out;
+}
+
+export async function arrayBuffer(stream) {
+    const data = await __perryCollectBytes(stream);
+    return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+}
+export async function blob(stream) {
+    const data = await __perryCollectBytes(stream);
+    if (typeof Blob !== "undefined") {
+        const value = new Blob([data]);
+        if (typeof value.bytes !== "function") value.bytes = async () => new Uint8Array(await value.arrayBuffer());
+        return value;
+    }
+    return {
+        size: data.byteLength,
+        type: "",
+        async text() { return new TextDecoder().decode(data); },
+        async arrayBuffer() { return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength); },
+        async bytes() { return new Uint8Array(data); },
+        slice(start = 0, end = data.byteLength, type = "") {
+            const normalize = (value, fallback) => {
+                if (value === undefined) return fallback;
+                const n = Number(value);
+                return n < 0 ? Math.max(data.byteLength + n, 0) : Math.min(n, data.byteLength);
+            };
+            const lo = normalize(start, 0);
+            const hi = Math.max(normalize(end, data.byteLength), lo);
+            const sliced = data.slice(lo, hi);
+            return {
+                size: sliced.byteLength,
+                type: String(type || ""),
+                async text() { return new TextDecoder().decode(sliced); },
+                async arrayBuffer() { return sliced.buffer.slice(sliced.byteOffset, sliced.byteOffset + sliced.byteLength); },
+                async bytes() { return new Uint8Array(sliced); },
+            };
+        },
+        stream() { return { _perryChunks: [data] }; },
+    };
+}
+export async function buffer(stream) {
+    return __PerryBufferCtor.from(await arrayBuffer(stream));
+}
+export async function bytes(stream) {
+    return new Uint8Array(await arrayBuffer(stream));
+}
+export async function text(stream) {
+    return new TextDecoder().decode(await bytes(stream));
+}
+export async function json(stream) {
+    return JSON.parse(await text(stream));
+}
+export default { arrayBuffer, blob, buffer, bytes, json, text };
 "#.to_string(),
         "stream/web" => r#"
 // Stub implementation for Node.js 'stream/web' module

--- a/crates/perry-jsruntime/src/modules/loader.rs
+++ b/crates/perry-jsruntime/src/modules/loader.rs
@@ -54,7 +54,7 @@ impl NodeModuleLoader {
     }
 
     /// Resolve a module specifier to an absolute path
-    fn resolve_module_path(&self, specifier: &str, referrer: &Path) -> Result<PathBuf> {
+    pub(super) fn resolve_module_path(&self, specifier: &str, referrer: &Path) -> Result<PathBuf> {
         // Issue #818 follow-up: prefer embedded-bundle lookups over disk
         // probes. For bare specifiers ("hono", "@scope/x") an alias map
         // gives us the canonical build-time path directly; for relative

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -23,7 +23,10 @@
 //! runtime rewrite.
 
 use crate::closure::{js_closure_alloc, js_closure_get_capture_ptr, ClosureHeader};
-use crate::object::{js_object_alloc_with_shape, js_object_set_field, ObjectHeader};
+use crate::object::{
+    js_object_alloc_with_shape, js_object_get_field_by_name_f64, js_object_set_field,
+    js_object_set_field_by_name, ObjectHeader,
+};
 use crate::value::JSValue;
 
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
@@ -37,6 +40,10 @@ const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
 const READABLE_SHAPE_ID: u32 = 0x7FFF_FE60;
 const WRITABLE_SHAPE_ID: u32 = 0x7FFF_FE70;
 const DUPLEX_SHAPE_ID: u32 = 0x7FFF_FE80;
+const READABLE_CHUNKS_KEY: &[u8] = b"__perryReadableChunks";
+const READABLE_ERROR_KEY: &[u8] = b"__perryReadableError";
+const READABLE_READ_KEY: &[u8] = b"__perryReadableRead";
+const READABLE_READ_INVOKED_KEY: &[u8] = b"__perryReadableReadInvoked";
 
 // ─────────────────────────────────────────────────────────────────
 // Stub method bodies. Each receives the closure pointer (slot 0
@@ -67,7 +74,11 @@ extern "C" fn ns_chain3(closure: *const ClosureHeader, _a: f64, _b: f64, _c: f64
     this_value(closure)
 }
 
-extern "C" fn ns_emit2(_closure: *const ClosureHeader, _e: f64, _a: f64) -> f64 {
+extern "C" fn ns_emit2(closure: *const ClosureHeader, event: f64, arg: f64) -> f64 {
+    if string_value_eq(event, b"error") {
+        set_hidden_value(this_value(closure), hidden_error_key(), arg);
+        return f64::from_bits(TAG_TRUE);
+    }
     f64::from_bits(TAG_FALSE)
 }
 extern "C" fn ns_read1(_closure: *const ClosureHeader, _n: f64) -> f64 {
@@ -142,6 +153,281 @@ fn build_object(methods: &[(&str, StubFn)], shape_id: u32) -> *mut ObjectHeader 
         js_object_set_field(obj, i as u32, val);
     }
     obj
+}
+
+#[inline]
+fn box_pointer(ptr: *const u8) -> f64 {
+    f64::from_bits(JSValue::pointer(ptr).bits())
+}
+
+#[inline]
+#[cfg(test)]
+fn box_string(ptr: *mut crate::string::StringHeader) -> f64 {
+    f64::from_bits(JSValue::string_ptr(ptr).bits())
+}
+
+#[inline]
+fn raw_ptr_from_value(value: f64) -> usize {
+    let bits = value.to_bits();
+    let jsval = JSValue::from_bits(bits);
+    if jsval.is_pointer() || jsval.is_string() || jsval.is_bigint() {
+        return (bits & crate::value::POINTER_MASK) as usize;
+    }
+    if bits != 0 && bits < 0x0001_0000_0000_0000 {
+        return bits as usize;
+    }
+    0
+}
+
+#[inline]
+unsafe fn gc_type_for_ptr(raw: usize) -> Option<u8> {
+    if raw < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return None;
+    }
+    let header = (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    let gc_type = (*header).obj_type;
+    if gc_type <= crate::gc::GC_TYPE_MAX {
+        Some(gc_type)
+    } else {
+        None
+    }
+}
+
+#[inline]
+fn hidden_chunks_key() -> *mut crate::string::StringHeader {
+    hidden_key(READABLE_CHUNKS_KEY)
+}
+
+#[inline]
+fn hidden_error_key() -> *mut crate::string::StringHeader {
+    hidden_key(READABLE_ERROR_KEY)
+}
+
+#[inline]
+fn hidden_read_key() -> *mut crate::string::StringHeader {
+    hidden_key(READABLE_READ_KEY)
+}
+
+#[inline]
+fn hidden_read_invoked_key() -> *mut crate::string::StringHeader {
+    hidden_key(READABLE_READ_INVOKED_KEY)
+}
+
+fn hidden_key(bytes: &[u8]) -> *mut crate::string::StringHeader {
+    crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
+}
+
+fn string_value_eq(value: f64, expected: &[u8]) -> bool {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if !jsval.is_any_string() {
+        return false;
+    }
+    let ptr = crate::value::js_get_string_pointer_unified(value) as *const crate::StringHeader;
+    if ptr.is_null() || (ptr as usize) < 0x10000 {
+        return false;
+    }
+    unsafe {
+        let len = (*ptr).byte_len as usize;
+        if len != expected.len() {
+            return false;
+        }
+        let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        std::slice::from_raw_parts(data, len) == expected
+    }
+}
+
+fn object_ptr_from_value(value: f64) -> Option<*mut ObjectHeader> {
+    let raw = raw_ptr_from_value(value);
+    if raw < 0x10000 || crate::buffer::is_registered_buffer(raw) {
+        return None;
+    }
+    unsafe {
+        if gc_type_for_ptr(raw) != Some(crate::gc::GC_TYPE_OBJECT) {
+            return None;
+        }
+    }
+    Some(raw as *mut ObjectHeader)
+}
+
+fn get_hidden_value(value: f64, key: *mut crate::string::StringHeader) -> Option<f64> {
+    let obj = object_ptr_from_value(value)?;
+    let value = js_object_get_field_by_name_f64(obj as *const ObjectHeader, key);
+    if value.to_bits() == TAG_UNDEFINED {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn set_hidden_value(value: f64, key: *mut crate::string::StringHeader, field_value: f64) {
+    if let Some(obj) = object_ptr_from_value(value) {
+        js_object_set_field_by_name(obj, key, field_value);
+    }
+}
+
+fn is_array_like_value(value: f64) -> bool {
+    let raw = raw_ptr_from_value(value);
+    if raw < 0x10000 || crate::buffer::is_registered_buffer(raw) {
+        return false;
+    }
+    unsafe {
+        matches!(
+            gc_type_for_ptr(raw),
+            Some(crate::gc::GC_TYPE_ARRAY | crate::gc::GC_TYPE_LAZY_ARRAY)
+        )
+    }
+}
+
+fn readable_hidden_chunks(value: f64) -> Option<f64> {
+    get_hidden_value(value, hidden_chunks_key())
+}
+
+fn readable_hidden_error(value: f64) -> Option<f64> {
+    get_hidden_value(value, hidden_error_key())
+}
+
+fn read_callback_from_options(opts: f64) -> Option<f64> {
+    get_hidden_value(opts, hidden_key(b"read"))
+}
+
+fn invoke_read_once(stream: f64) {
+    let Some(read) = get_hidden_value(stream, hidden_read_key()) else {
+        return;
+    };
+    if get_hidden_value(stream, hidden_read_invoked_key()).is_some() {
+        return;
+    }
+    set_hidden_value(stream, hidden_read_invoked_key(), f64::from_bits(TAG_TRUE));
+    let prev_this = crate::object::js_implicit_this_set(stream);
+    unsafe {
+        let _ = crate::closure::js_native_call_value(read, std::ptr::null(), 0);
+    }
+    crate::object::js_implicit_this_set(prev_this);
+}
+
+fn is_single_chunk_value(value: f64) -> bool {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if jsval.is_any_string() {
+        return true;
+    }
+    let raw = raw_ptr_from_value(value);
+    raw >= 0x10000 && crate::buffer::is_registered_buffer(raw)
+}
+
+fn normalize_readable_from_input(iterable: f64) -> f64 {
+    if let Some(chunks) = readable_hidden_chunks(iterable) {
+        return chunks;
+    }
+    if is_array_like_value(iterable) {
+        return iterable;
+    }
+
+    let arr = crate::array::js_array_alloc(1);
+    if is_single_chunk_value(iterable) {
+        let arr = crate::array::js_array_push_f64(arr, iterable);
+        return box_pointer(arr as *const u8);
+    }
+    box_pointer(arr as *const u8)
+}
+
+fn append_string_bytes(value: f64, out: &mut Vec<u8>) {
+    let ptr = crate::value::js_get_string_pointer_unified(value) as *const crate::StringHeader;
+    append_string_ptr_bytes(ptr, out);
+}
+
+fn append_string_ptr_bytes(ptr: *const crate::StringHeader, out: &mut Vec<u8>) {
+    if ptr.is_null() || (ptr as usize) < 0x10000 {
+        return;
+    }
+    unsafe {
+        let len = (*ptr).byte_len as usize;
+        let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        out.extend_from_slice(std::slice::from_raw_parts(data, len));
+    }
+}
+
+fn append_buffer_bytes(raw: usize, out: &mut Vec<u8>) {
+    if raw < 0x10000 || !crate::buffer::is_registered_buffer(raw) {
+        return;
+    }
+    unsafe {
+        let buf = raw as *const crate::buffer::BufferHeader;
+        let len = (*buf).length as usize;
+        let data = crate::buffer::buffer_data(buf);
+        out.extend_from_slice(std::slice::from_raw_parts(data, len));
+    }
+}
+
+fn append_array_chunks(raw: usize, out: &mut Vec<u8>, depth: u8) {
+    if raw < 0x10000 {
+        return;
+    }
+    let arr = raw as *const crate::array::ArrayHeader;
+    let len = crate::array::js_array_length(arr);
+    for i in 0..len {
+        let chunk = crate::array::js_array_get_f64(arr, i);
+        append_chunk_bytes(chunk, out, depth + 1);
+    }
+}
+
+fn append_chunk_bytes(value: f64, out: &mut Vec<u8>, depth: u8) {
+    if depth > 8 {
+        return;
+    }
+    let jsval = JSValue::from_bits(value.to_bits());
+    if jsval.is_any_string() {
+        append_string_bytes(value, out);
+        return;
+    }
+
+    let raw = raw_ptr_from_value(value);
+    if raw < 0x10000 {
+        return;
+    }
+    if crate::buffer::is_registered_buffer(raw) {
+        append_buffer_bytes(raw, out);
+        return;
+    }
+
+    unsafe {
+        match gc_type_for_ptr(raw) {
+            Some(crate::gc::GC_TYPE_ARRAY | crate::gc::GC_TYPE_LAZY_ARRAY) => {
+                append_array_chunks(raw, out, depth);
+            }
+            Some(crate::gc::GC_TYPE_OBJECT) => {
+                if let Some(chunks) = readable_hidden_chunks(value) {
+                    append_chunk_bytes(chunks, out, depth + 1);
+                }
+            }
+            Some(crate::gc::GC_TYPE_STRING) => {
+                append_string_ptr_bytes(raw as *const crate::StringHeader, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Drain the chunk storage Perry attaches in `Readable.from(iterable)`.
+///
+/// This intentionally handles only the current stream stub's concrete shapes:
+/// arrays of strings/Buffers/Uint8Arrays/ArrayBuffers plus direct single
+/// string/binary chunks. It gives `node:stream/consumers` useful data without
+/// pretending Perry has a full Node stream pump yet.
+pub fn js_node_stream_collect_bytes(stream: f64) -> Vec<u8> {
+    js_node_stream_collect_bytes_result(stream).unwrap_or_default()
+}
+
+pub fn js_node_stream_collect_bytes_result(stream: f64) -> Result<Vec<u8>, f64> {
+    invoke_read_once(stream);
+    if let Some(err) = readable_hidden_error(stream) {
+        return Err(err);
+    }
+    let mut out = Vec::new();
+    append_chunk_bytes(stream, &mut out, 0);
+    if let Some(err) = readable_hidden_error(stream) {
+        return Err(err);
+    }
+    Ok(out)
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -238,10 +524,17 @@ fn duplex_methods() -> [(&'static str, StubFn); 22] {
 // ─────────────────────────────────────────────────────────────────
 
 #[no_mangle]
-pub extern "C" fn js_node_stream_readable_new(_opts: f64) -> f64 {
+pub extern "C" fn js_node_stream_readable_new(opts: f64) -> f64 {
     let methods = readable_methods();
     let obj = build_object(&methods, READABLE_SHAPE_ID + methods.len() as u32);
-    f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+    let readable = f64::from_bits(JSValue::pointer(obj as *const u8).bits());
+    if let Some(read) = read_callback_from_options(opts) {
+        js_object_set_field_by_name(obj, hidden_read_key(), read);
+        let emit_key = hidden_key(b"emit");
+        let emit = js_object_get_field_by_name_f64(obj as *const ObjectHeader, emit_key);
+        set_hidden_value(opts, emit_key, emit);
+    }
+    readable
 }
 
 #[no_mangle]
@@ -271,12 +564,17 @@ pub extern "C" fn js_node_stream_passthrough_new(_opts: f64) -> f64 {
 }
 
 /// `Readable.from(iterable)` — Node's static factory. Returns a
-/// Readable object that would, in a real implementation, stream
-/// chunks from the iterable. For the stub it's identical to
-/// `new Readable()` — the iterable arg is accepted and discarded.
+/// Readable object and retains simple iterable chunks so
+/// `node:stream/consumers` can drain the current stub stream surface.
 #[no_mangle]
-pub extern "C" fn js_node_stream_readable_from(_iterable: f64) -> f64 {
-    js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED))
+pub extern "C" fn js_node_stream_readable_from(iterable: f64) -> f64 {
+    let readable = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
+    let raw = raw_ptr_from_value(readable);
+    if raw >= 0x10000 {
+        let chunks = normalize_readable_from_input(iterable);
+        js_object_set_field_by_name(raw as *mut ObjectHeader, hidden_chunks_key(), chunks);
+    }
+    readable
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -298,8 +596,12 @@ pub extern "C" fn js_node_stream_is_disturbed(_stream: f64) -> f64 {
 }
 
 #[no_mangle]
-pub extern "C" fn js_node_stream_is_errored(_stream: f64) -> f64 {
-    f64::from_bits(TAG_FALSE)
+pub extern "C" fn js_node_stream_is_errored(stream: f64) -> f64 {
+    if readable_hidden_error(stream).is_some() {
+        f64::from_bits(TAG_TRUE)
+    } else {
+        f64::from_bits(TAG_FALSE)
+    }
 }
 
 /// #1541: `stream.addAbortSignal(signal, stream)` — Node wires the
@@ -375,4 +677,49 @@ pub extern "C" fn js_node_stream_to_web(_node_stream: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_node_stream_from_web(_web_stream: f64) -> f64 {
     js_node_stream_duplex_new(f64::from_bits(TAG_UNDEFINED))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn string_value(s: &str) -> f64 {
+        let ptr = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+        box_string(ptr)
+    }
+
+    fn buffer_value(bytes: &[u8]) -> f64 {
+        let buf = crate::buffer::buffer_alloc(bytes.len() as u32);
+        unsafe {
+            (*buf).length = bytes.len() as u32;
+            std::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                crate::buffer::buffer_data_mut(buf),
+                bytes.len(),
+            );
+        }
+        box_pointer(buf as *const u8)
+    }
+
+    #[test]
+    fn readable_from_retains_string_chunks_for_consumers() {
+        let mut arr = crate::array::js_array_alloc(2);
+        arr = crate::array::js_array_push_f64(arr, string_value("he"));
+        arr = crate::array::js_array_push_f64(arr, string_value("llo"));
+
+        let readable = js_node_stream_readable_from(box_pointer(arr as *const u8));
+
+        assert_eq!(js_node_stream_collect_bytes(readable), b"hello");
+    }
+
+    #[test]
+    fn readable_from_retains_buffer_chunks_for_consumers() {
+        let mut arr = crate::array::js_array_alloc(2);
+        arr = crate::array::js_array_push_f64(arr, buffer_value(b"ab"));
+        arr = crate::array::js_array_push_f64(arr, buffer_value(b"cd"));
+
+        let readable = js_node_stream_readable_from(box_pointer(arr as *const u8));
+
+        assert_eq!(js_node_stream_collect_bytes(readable), b"abcd");
+    }
 }

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -15,16 +15,12 @@
 //! is `"function"`, plus per-submodule namespace stubs whose properties point
 //! at the same singletons.
 //!
-//! The thunks are deliberately minimal — they throw `Error("<api> is not yet
-//! implemented in Perry")` when invoked. Full functional implementations of
-//! these APIs are tracked separately under the #793 Node compatibility
-//! roadmap. The fix here is strictly about restoring the import surface so
-//! consuming code can at least introspect the bindings (typeof checks,
-//! `=== util.format` comparisons, dynamic-shape introspection) without
-//! tripping over `true`-as-a-function downstream errors.
+//! Most thunks are deliberately minimal — they throw `Error("<api> is not yet
+//! implemented in Perry")` when invoked. `node:stream/consumers` is the first
+//! submodule here with concrete behavior, so consuming code can import and use
+//! its helpers while the broader #793 Node compatibility roadmap continues.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::os::raw::c_int;
 use std::sync::atomic::{AtomicI64, Ordering};
 
@@ -174,7 +170,13 @@ thunk!(
 );
 
 fn promise_value(value: f64) -> f64 {
-    let promise = crate::promise::js_promise_resolved(value);
+    let promise = crate::promise::js_promise_new();
+    crate::promise::js_promise_resolve(promise, value);
+    f64::from_bits(JSValue::pointer(promise as *const u8).bits())
+}
+
+fn promise_rejected(reason: f64) -> f64 {
+    let promise = crate::promise::js_promise_rejected(reason);
     f64::from_bits(JSValue::pointer(promise as *const u8).bits())
 }
 
@@ -458,30 +460,233 @@ thunk!(
     "node:stream/promises.finished is not yet implemented in Perry (tracked by issue #793)."
 );
 
-thunk!(
-    thunk_consumers_text,
-    "node:stream/consumers.text is not yet implemented in Perry (tracked by issue #793)."
-);
-thunk!(
-    thunk_consumers_json,
-    "node:stream/consumers.json is not yet implemented in Perry (tracked by issue #793)."
-);
-thunk!(
-    thunk_consumers_buffer,
-    "node:stream/consumers.buffer is not yet implemented in Perry (tracked by issue #793)."
-);
-thunk!(
-    thunk_consumers_arrayBuffer,
-    "node:stream/consumers.arrayBuffer is not yet implemented in Perry (tracked by issue #793)."
-);
-thunk!(
-    thunk_consumers_bytes,
-    "node:stream/consumers.bytes is not yet implemented in Perry (tracked by issue #793)."
-);
-thunk!(
-    thunk_consumers_blob,
-    "node:stream/consumers.blob is not yet implemented in Perry (tracked by issue #793)."
-);
+fn buffer_from_bytes(
+    bytes: &[u8],
+    mark_array_buffer: bool,
+    mark_uint8_array: bool,
+) -> *mut crate::buffer::BufferHeader {
+    let buf = crate::buffer::buffer_alloc(bytes.len() as u32);
+    unsafe {
+        (*buf).length = bytes.len() as u32;
+        if !bytes.is_empty() {
+            std::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                crate::buffer::buffer_data_mut(buf),
+                bytes.len(),
+            );
+        }
+    }
+    if mark_array_buffer {
+        crate::buffer::mark_as_array_buffer(buf as usize);
+    }
+    if mark_uint8_array {
+        crate::buffer::mark_as_uint8array(buf as usize);
+    }
+    buf
+}
+
+fn bytes_to_buffer_value(bytes: &[u8]) -> f64 {
+    let buf = buffer_from_bytes(bytes, false, false);
+    f64::from_bits(JSValue::pointer(buf as *const u8).bits())
+}
+
+fn bytes_to_array_buffer_value(bytes: &[u8]) -> f64 {
+    let buf = buffer_from_bytes(bytes, true, false);
+    f64::from_bits(JSValue::pointer(buf as *const u8).bits())
+}
+
+fn bytes_to_uint8_array_value(bytes: &[u8]) -> f64 {
+    let buf = buffer_from_bytes(bytes, false, true);
+    f64::from_bits(JSValue::pointer(buf as *const u8).bits())
+}
+
+fn bytes_to_text_value(bytes: &[u8]) -> f64 {
+    let cow = String::from_utf8_lossy(bytes);
+    let ptr = js_string_from_bytes(cow.as_bytes().as_ptr(), cow.len() as u32);
+    f64::from_bits(JSValue::string_ptr(ptr).bits())
+}
+
+fn stream_consumer_bytes(stream: f64) -> Result<Vec<u8>, f64> {
+    crate::node_stream::js_node_stream_collect_bytes_result(stream)
+}
+
+const CLASS_ID_BLOB: u32 = 0xFFFF0026;
+
+extern "C" fn blob_text_method(closure: *const ClosureHeader) -> f64 {
+    let bytes = captured_blob_bytes(closure);
+    promise_value(bytes_to_text_value(&bytes))
+}
+
+extern "C" fn blob_array_buffer_method(closure: *const ClosureHeader) -> f64 {
+    let bytes = captured_blob_bytes(closure);
+    promise_value(bytes_to_array_buffer_value(&bytes))
+}
+
+extern "C" fn blob_bytes_method(closure: *const ClosureHeader) -> f64 {
+    let bytes = captured_blob_bytes(closure);
+    promise_value(bytes_to_uint8_array_value(&bytes))
+}
+
+extern "C" fn blob_slice_method(
+    closure: *const ClosureHeader,
+    start: f64,
+    end: f64,
+    content_type: f64,
+) -> f64 {
+    let bytes = captured_blob_bytes(closure);
+    let len = bytes.len() as i64;
+    let normalize = |value: f64, default: i64| -> i64 {
+        if value.is_nan() || value.to_bits() == crate::value::TAG_UNDEFINED {
+            return default;
+        }
+        let n = value as i64;
+        if n < 0 {
+            (len + n).max(0)
+        } else {
+            n.min(len)
+        }
+    };
+    let lo = normalize(start, 0);
+    let hi = normalize(end, len);
+    let (lo, hi) = if hi < lo { (lo, lo) } else { (lo, hi) };
+    let content_type = string_from_value(content_type).unwrap_or_default();
+    blob_value_from_bytes_and_type(&bytes[lo as usize..hi as usize], &content_type)
+}
+
+extern "C" fn blob_stream_method(closure: *const ClosureHeader) -> f64 {
+    let bytes = captured_blob_bytes(closure);
+    crate::node_stream::js_node_stream_readable_from(bytes_to_uint8_array_value(&bytes))
+}
+
+fn captured_blob_bytes(closure: *const ClosureHeader) -> Vec<u8> {
+    let raw = js_closure_get_capture_ptr(closure, 0) as usize;
+    if raw < 0x10000 || !crate::buffer::is_registered_buffer(raw) {
+        return Vec::new();
+    }
+    unsafe {
+        let buf = raw as *const crate::buffer::BufferHeader;
+        let len = (*buf).length as usize;
+        let data = crate::buffer::buffer_data(buf);
+        std::slice::from_raw_parts(data, len).to_vec()
+    }
+}
+
+fn set_named_value(obj: *mut ObjectHeader, name: &[u8], value: f64) {
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_set_field_by_name(obj, key, value);
+}
+
+#[allow(clippy::missing_transmute_annotations)]
+fn blob_method_value(
+    func: *const u8,
+    arity: u32,
+    backing: *mut crate::buffer::BufferHeader,
+) -> f64 {
+    js_register_closure_arity(func, arity);
+    let closure = js_closure_alloc(func, 1);
+    js_closure_set_capture_ptr(closure, 0, backing as i64);
+    f64::from_bits(JSValue::pointer(closure as *const u8).bits())
+}
+
+fn blob_value_from_bytes(bytes: &[u8]) -> f64 {
+    blob_value_from_bytes_and_type(bytes, "")
+}
+
+fn blob_value_from_bytes_and_type(bytes: &[u8], content_type: &str) -> f64 {
+    let backing = buffer_from_bytes(bytes, false, false);
+    let obj = js_object_alloc(CLASS_ID_BLOB, 7);
+    set_named_value(obj, b"size", bytes.len() as f64);
+    set_named_value(obj, b"type", bytes_to_text_value(content_type.as_bytes()));
+    set_named_value(
+        obj,
+        b"text",
+        blob_method_value(blob_text_method as *const u8, 0, backing),
+    );
+    set_named_value(
+        obj,
+        b"arrayBuffer",
+        blob_method_value(blob_array_buffer_method as *const u8, 0, backing),
+    );
+    set_named_value(
+        obj,
+        b"bytes",
+        blob_method_value(blob_bytes_method as *const u8, 0, backing),
+    );
+    set_named_value(
+        obj,
+        b"slice",
+        blob_method_value(blob_slice_method as *const u8, 3, backing),
+    );
+    set_named_value(
+        obj,
+        b"stream",
+        blob_method_value(blob_stream_method as *const u8, 0, backing),
+    );
+    f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+}
+
+fn string_from_value(value: f64) -> Option<String> {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if !jsval.is_any_string() {
+        return None;
+    }
+    let ptr = crate::value::js_get_string_pointer_unified(value) as *const StringHeader;
+    if ptr.is_null() || (ptr as usize) < 0x10000 {
+        return None;
+    }
+    unsafe {
+        let len = (*ptr).byte_len as usize;
+        let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        Some(String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned())
+    }
+}
+
+extern "C" fn thunk_consumers_text(_closure: *const ClosureHeader, stream: f64) -> f64 {
+    match stream_consumer_bytes(stream) {
+        Ok(bytes) => promise_value(bytes_to_text_value(&bytes)),
+        Err(err) => promise_rejected(err),
+    }
+}
+
+extern "C" fn thunk_consumers_json(_closure: *const ClosureHeader, stream: f64) -> f64 {
+    match stream_consumer_bytes(stream) {
+        Ok(bytes) => {
+            let text = bytes_to_text_value(&bytes);
+            let text_ptr = crate::value::js_get_string_pointer_unified(text) as *const StringHeader;
+            let parsed = unsafe { crate::json::js_json_parse(text_ptr) };
+            promise_value(f64::from_bits(parsed.bits()))
+        }
+        Err(err) => promise_rejected(err),
+    }
+}
+
+extern "C" fn thunk_consumers_buffer(_closure: *const ClosureHeader, stream: f64) -> f64 {
+    match stream_consumer_bytes(stream) {
+        Ok(bytes) => promise_value(bytes_to_buffer_value(&bytes)),
+        Err(err) => promise_rejected(err),
+    }
+}
+
+extern "C" fn thunk_consumers_arrayBuffer(_closure: *const ClosureHeader, stream: f64) -> f64 {
+    match stream_consumer_bytes(stream) {
+        Ok(bytes) => promise_value(bytes_to_array_buffer_value(&bytes)),
+        Err(err) => promise_rejected(err),
+    }
+}
+
+extern "C" fn thunk_consumers_bytes(_closure: *const ClosureHeader, stream: f64) -> f64 {
+    match stream_consumer_bytes(stream) {
+        Ok(bytes) => promise_value(bytes_to_uint8_array_value(&bytes)),
+        Err(err) => promise_rejected(err),
+    }
+}
+
+extern "C" fn thunk_consumers_blob(_closure: *const ClosureHeader, stream: f64) -> f64 {
+    match stream_consumer_bytes(stream) {
+        Ok(bytes) => promise_value(blob_value_from_bytes(&bytes)),
+        Err(err) => promise_rejected(err),
+    }
+}
 
 // node:sys is a deprecated alias for node:util — point each export at
 // the same thunks until util's named-export surface is wired up. The

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -139,6 +139,7 @@ pub(crate) const GLOBAL_THIS_BUILTIN_CONSTRUCTORS: &[&str] = &[
     "AbortController",
     "AbortSignal",
     "FormData",
+    "Blob",
     "Headers",
     "Request",
     "Response",

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -84,6 +84,30 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
         return false_val;
     }
 
+    // ArrayBuffer — Perry models ArrayBuffer storage with BufferHeader values
+    // marked in a side registry. They can arrive either NaN-boxed or as raw
+    // buffer pointers, matching the Buffer/Uint8Array path above.
+    const CLASS_ID_ARRAY_BUFFER: u32 = 0xFFFF0025;
+    if class_id == CLASS_ID_ARRAY_BUFFER {
+        let addr = if jsval.is_pointer() {
+            (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+        } else {
+            let top16 = (bits >> 48) as u16;
+            if top16 == 0 && bits >= 0x1000 {
+                bits as usize
+            } else {
+                0
+            }
+        };
+        if addr != 0
+            && crate::buffer::is_registered_buffer(addr)
+            && crate::buffer::is_array_buffer(addr)
+        {
+            return true_val;
+        }
+        return false_val;
+    }
+
     // Built-in JS types Map / Set / RegExp / Date — Perry doesn't define
     // user classes for these, so we use reserved class IDs and detect via
     // the per-type registries (MAP_REGISTRY / SET_REGISTRY / REGEX_POINTERS)

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -326,12 +326,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory — `node:stream` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
-  "test_parity_stream_consumers": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:stream/consumers` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_parity_stream_promises": {
     "issue": "793",
     "added": "2026-05-15",
@@ -1046,30 +1040,6 @@
     "category": "bug-open",
     "reason": "node:stream: transform() callback with Error doesn't propagate as `error` event. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/consumers/buffer": {
-    "issue": "1544",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/consumers.buffer(stream) not implemented. Flips to PASS when #1544 lands."
-  },
-  "node-suite/stream/consumers/text": {
-    "issue": "1544",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/consumers.text(stream) not implemented. Flips to PASS when #1544 lands."
-  },
-  "node-suite/stream/consumers/json": {
-    "issue": "1544",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/consumers.json(stream) not implemented. Flips to PASS when #1544 lands."
-  },
-  "node-suite/stream/consumers/array-buffer": {
-    "issue": "1544",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/consumers.arrayBuffer(stream) not implemented. Flips to PASS when #1544 lands."
-  },
   "node-suite/stream/web/imports": {
     "issue": "1545",
     "added": "2026-05-23",
@@ -1159,12 +1129,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: stream.compose(t1, t2) chain doesn't propagate through transforms. Flips to PASS when #1539 lands."
-  },
-  "node-suite/stream/consumers/blob": {
-    "issue": "1544",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/consumers.blob(stream) not implemented. Flips to PASS when #1544 lands."
   },
   "node-suite/stream/pipeline/already-ended": {
     "issue": "1532",
@@ -1573,12 +1537,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: stream.Stream legacy constructor not exposed as the default export. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/consumers/with-errored-stream": {
-    "issue": "1544",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/consumers: text(stream) does not reject when the stream errors. Flips to PASS when #1544 lands."
   },
   "node-suite/stream/destroy/destroy-string": {
     "issue": "1532",

--- a/test-parity/node-suite/stream/consumers/array-buffer.ts
+++ b/test-parity/node-suite/stream/consumers/array-buffer.ts
@@ -1,7 +1,15 @@
+import { Buffer } from "node:buffer";
 import { Readable } from "node:stream";
 import { arrayBuffer } from "node:stream/consumers";
-// stream/consumers.arrayBuffer(stream) resolves to an ArrayBuffer.
-const r = Readable.from([Buffer.from([1, 2, 3])]);
-const ab = await arrayBuffer(r);
-console.log("isArrayBuffer:", ab instanceof ArrayBuffer);
-console.log("byteLength:", ab.byteLength);
+
+const directArrayBuffer = new Uint8Array([122, 33]).buffer;
+const value = await arrayBuffer(
+  Readable.from([Buffer.from("xy"), directArrayBuffer]),
+);
+const bytes = new Uint8Array(value);
+console.log("isArrayBuffer:", value instanceof ArrayBuffer);
+console.log("byteLength:", value.byteLength);
+console.log("first:", bytes[0]);
+console.log("second:", bytes[1]);
+console.log("third:", bytes[2]);
+console.log("fourth:", bytes[3]);

--- a/test-parity/node-suite/stream/consumers/blob.ts
+++ b/test-parity/node-suite/stream/consumers/blob.ts
@@ -1,7 +1,15 @@
+import { Buffer } from "node:buffer";
 import { Readable } from "node:stream";
 import { blob } from "node:stream/consumers";
-// stream/consumers.blob(stream) resolves to a Blob with the concatenated content.
-const r = Readable.from(["hello"]);
-const b = await blob(r);
-console.log("is Blob:", b instanceof Blob);
-console.log("size:", b.size);
+
+const value = await blob(Readable.from([Buffer.from("bl"), Buffer.from("ob")]));
+console.log("is Blob:", value instanceof Blob);
+console.log("size:", value.size);
+console.log("type:", value.type);
+console.log("text:", await value.text());
+console.log("arrayBuffer byteLength:", (await value.arrayBuffer()).byteLength);
+console.log("bytes length:", (await value.bytes()).length);
+console.log("slice is Blob:", value.slice(1, 3) instanceof Blob);
+console.log("slice size:", value.slice(1, 3).size);
+console.log("slice text:", await value.slice(1, 3).text());
+console.log("stream function:", typeof value.stream);

--- a/test-parity/node-suite/stream/consumers/buffer.ts
+++ b/test-parity/node-suite/stream/consumers/buffer.ts
@@ -1,8 +1,7 @@
+import { Buffer } from "node:buffer";
 import { Readable } from "node:stream";
 import { buffer } from "node:stream/consumers";
-// stream/consumers.buffer(stream) consumes a Readable and resolves with a
-// single concatenated Buffer.
-const r = Readable.from([Buffer.from("ab"), Buffer.from("cd")]);
-const buf = await buffer(r);
-console.log("length:", buf.length);
-console.log("content:", buf.toString());
+
+const value = await buffer(Readable.from([Buffer.from("ab"), Buffer.from("cd")]));
+console.log("buffer hex:", value.toString("hex"));
+console.log("buffer length:", value.length);

--- a/test-parity/node-suite/stream/consumers/bytes.ts
+++ b/test-parity/node-suite/stream/consumers/bytes.ts
@@ -1,0 +1,10 @@
+import { Buffer } from "node:buffer";
+import { Readable } from "node:stream";
+import { bytes } from "node:stream/consumers";
+
+const value = await bytes(
+  Readable.from([Buffer.from("uv"), new Uint8Array([119, 120])]),
+);
+console.log("bytes length:", value.length);
+console.log("bytes first:", value[0]);
+console.log("bytes last:", value[3]);

--- a/test-parity/node-suite/stream/consumers/json.ts
+++ b/test-parity/node-suite/stream/consumers/json.ts
@@ -1,7 +1,6 @@
 import { Readable } from "node:stream";
 import { json } from "node:stream/consumers";
-// stream/consumers.json(stream) consumes a JSON-encoded stream and resolves
-// to the parsed value.
-const r = Readable.from(['{"x":', "1}"]);
-const obj = await json(r);
-console.log("x:", (obj as any).x);
+
+const value = await json(Readable.from(['{"a":', "1", ',"b":"ok"}']));
+console.log("json a:", (value as { a: number }).a);
+console.log("json b:", (value as { b: string }).b);

--- a/test-parity/node-suite/stream/consumers/text.ts
+++ b/test-parity/node-suite/stream/consumers/text.ts
@@ -1,5 +1,4 @@
 import { Readable } from "node:stream";
 import { text } from "node:stream/consumers";
-// stream/consumers.text(stream) resolves to a UTF-8 decoded string.
-const r = Readable.from(["hello ", "world"]);
-console.log("got:", await text(r));
+
+console.log("text:", await text(Readable.from(["he", "llo"])));


### PR DESCRIPTION
## Summary
- implement `node:stream/consumers` helpers: `arrayBuffer`, `blob`, `buffer`, `bytes`, `text`, and `json`
- retain/drain simple `Readable.from(...)` chunk inputs, including ArrayBuffer chunks
- add Blob/ArrayBuffer identity support and reject consumers when a stream emits `error`
- remove passing #1544 stream-consumer known failures and add granular parity coverage

Closes #1544.

## Test Plan
- `cargo test -p perry-runtime node_stream`
- `cargo test -p perry-jsruntime modules`
- `cargo check -p perry-codegen`
- `./run_parity_tests.sh --filter test_parity_stream_consumers`
- `./run_parity_tests.sh --suite node-suite --module stream/consumers`