### PR TITLE
test(parity): stream — Symbol.asyncDispose, getEventListeners, asyncIterator.return, Web writer concurrency (#1531/#1545)

### DIFF
--- a/parity_status.sh
+++ b/parity_status.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# parity_status.sh — print Perry's overall parity rate against
+# `node --experimental-strip-types` across every node-suite module.
+#
+# Discovers all directories under test-parity/node-suite/ and runs the
+# parity harness per module (via run_module_parity.sh which is itself a
+# thin wrapper over run_parity_tests.sh). Prints a per-module breakdown
+# plus a grand total + percentage.
+#
+# Usage:
+#   ./parity_status.sh             # all node-suite modules
+#   ./parity_status.sh os url      # arbitrary list (override discovery)
+#
+# A clean run is the source of truth for "how close is Perry to Node
+# parity?" — every failing test is a known issue (the harness's own gate
+# breaks CI on untracked failures, so the failure count reflects real
+# remaining gaps).
+
+set -uo pipefail
+cd "$(dirname "$0")"
+
+modules=("$@")
+if (( ${#modules[@]} == 0 )); then
+    while IFS= read -r d; do
+        [ -d "$d" ] || continue
+        m=$(basename "$d")
+        # Only directories that actually contain .ts cases.
+        if compgen -G "$d"'**/*.ts' > /dev/null 2>&1 || compgen -G "$d"'*.ts' > /dev/null 2>&1; then
+            modules+=("$m")
+        fi
+    done < <(printf '%s\n' test-parity/node-suite/*/)
+fi
+
+if (( ${#modules[@]} == 0 )); then
+    echo "No node-suite modules with tests found under test-parity/node-suite/." >&2
+    exit 1
+fi
+
+# Defer to run_module_parity.sh which already prints a per-module +
+# total table; it's the canonical front-end for batching the harness
+# across modules.
+exec ./run_module_parity.sh "${modules[@]}"

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1657,5 +1657,35 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: Readable instance exposes Symbol.iterator incorrectly (should be undefined; only asyncIterator). Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/dispose/async-dispose": {
+    "issue": "1531",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: Symbol.asyncDispose (Node 21+ explicit disposal protocol) not implemented on stream instances. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/ee/get-event-listeners": {
+    "issue": "1531",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:events.getEventListeners(stream, name) does not return the listener array. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/iterator/return-method": {
+    "issue": "1531",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: async iterator's return() does not resolve { value: undefined, done: true }. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/web/writable-multiple-writers-fails": {
+    "issue": "1545",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream/web: second getWriter() on a locked WritableStream should throw. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/web/writer-close-returns-promise": {
+    "issue": "1545",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
   }
 }

--- a/test-parity/node-suite/stream/dispose/async-dispose.ts
+++ b/test-parity/node-suite/stream/dispose/async-dispose.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// Stream instances expose Symbol.asyncDispose (Node 21+) so they can be
+// used with `await using`.
+const r = new Readable({ read() {} });
+console.log("has asyncDispose:", typeof (r as any)[Symbol.asyncDispose] === "function");

--- a/test-parity/node-suite/stream/ee/get-event-listeners.ts
+++ b/test-parity/node-suite/stream/ee/get-event-listeners.ts
@@ -1,0 +1,10 @@
+import { PassThrough } from "node:stream";
+import { getEventListeners } from "node:events";
+// events.getEventListeners(emitter, event) (Node 19+) returns the listener
+// array, including for streams (which extend EventEmitter).
+const p = new PassThrough();
+const fn = () => {};
+p.on("data", fn);
+const listeners = getEventListeners(p, "data");
+console.log("is array:", Array.isArray(listeners));
+console.log("length:", listeners.length);

--- a/test-parity/node-suite/stream/iterator/return-method.ts
+++ b/test-parity/node-suite/stream/iterator/return-method.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// The async iterator's .return() ends iteration early and resolves with
+// { value: undefined, done: true }.
+const r = Readable.from(["a", "b", "c"]);
+const it = (r as any)[Symbol.asyncIterator]();
+await it.next();
+const ret = await it.return();
+console.log("done:", ret.done);
+console.log("value:", ret.value);

--- a/test-parity/node-suite/stream/web/writable-multiple-writers-fails.ts
+++ b/test-parity/node-suite/stream/web/writable-multiple-writers-fails.ts
@@ -1,0 +1,12 @@
+import { WritableStream } from "node:stream/web";
+// A WritableStream can only have one writer locked at a time; getWriter()
+// throws if already locked.
+const ws = new WritableStream({ write() {} });
+ws.getWriter(); // lock
+let threw = false;
+try {
+  ws.getWriter();
+} catch {
+  threw = true;
+}
+console.log("second getWriter threw:", threw);

--- a/test-parity/node-suite/stream/web/writer-close-returns-promise.ts
+++ b/test-parity/node-suite/stream/web/writer-close-returns-promise.ts
@@ -1,0 +1,8 @@
+import { WritableStream } from "node:stream/web";
+// writer.close() returns a Promise that resolves once the stream is fully closed.
+const ws = new WritableStream({ write() {} });
+const w = ws.getWriter();
+const p = w.close();
+console.log("is promise:", typeof (p as any).then === "function");
+await p;
+console.log("closed");


### PR DESCRIPTION
Follow-up to #1563. 5 niche-but-documented stream tests covering surface that emerged after #1563 landed:

- Symbol.asyncDispose on stream instances (Node 21+ `await using`)
- events.getEventListeners(stream, name) (Node 19+)
- async iterator's .return() method
- WritableStream double-getWriter throws when locked
- WritableStream writer.close() returns a Promise

All 5 fall under existing issues #1531 (instance shape, EE inheritance) and #1545 (stream/web).