### PR TITLE
fix(runtime): force-keep js_dyn_index_get/set under LTO (#1561)

### DIFF
--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -221,3 +221,29 @@ pub extern "C" fn js_is_undefined_or_bare_nan(value: f64) -> i32 {
     }
     0
 }
+
+// --- #1561: force-keep the dynamic-index FFI exports under LTO ---
+//
+// `js_dyn_index_get` / `js_dyn_index_set` / `js_is_undefined_or_bare_nan`
+// are `#[no_mangle] pub extern "C"`, but they have **zero internal Rust
+// callers** — they are only ever invoked from generated LLVM IR (codegen
+// emits the calls in `perry-codegen/src/expr/index_get.rs` and
+// `expr/instance_misc1.rs`). The default `.a` staticlib keeps them via
+// staticlib-export semantics, but any build mode that round-trips the
+// runtime through whole-program LLVM bitcode — the `PERRY_LLVM_BITCODE_LINK`
+// path in `optimized_libs.rs`, cross-compile `-Zbuild-std` builds, or a
+// future switch to fat LTO — is free to *internalize* an unreferenced
+// `#[no_mangle]` symbol and dead-strip it, leaving the codegen-emitted call
+// dangling: `Undefined symbols: _js_dyn_index_get` at final link.
+//
+// The `#[used]` statics below take the address of each export, creating a
+// retained reference edge that LTO and the linker's `-dead_strip` must
+// honor (the entries land in `@llvm.used` / a `no_dead_strip` section). This
+// guarantees the symbols survive auto-optimize regardless of feature set or
+// link mode. Function-pointer types are `Sync`, so no wrapper is needed.
+#[used]
+static KEEP_JS_DYN_INDEX_GET: extern "C" fn(f64, f64) -> f64 = js_dyn_index_get;
+#[used]
+static KEEP_JS_DYN_INDEX_SET: extern "C" fn(f64, f64, f64) -> f64 = js_dyn_index_set;
+#[used]
+static KEEP_JS_IS_UNDEFINED_OR_BARE_NAN: extern "C" fn(f64) -> i32 = js_is_undefined_or_bare_nan;


### PR DESCRIPTION
## Summary

Closes #1561.

`js_dyn_index_get`, `js_dyn_index_set` and `js_is_undefined_or_bare_nan` (the dynamic `obj[idx]` helpers, issue #514) are `#[no_mangle] pub extern "C"` but have **zero internal Rust callers** — they are invoked only from generated LLVM IR (`perry-codegen/src/expr/index_get.rs` + `expr/instance_misc1.rs`, emitted whenever a numeric index hits an `any`/`unknown`-typed receiver).

The default `.a` staticlib keeps them via staticlib-export semantics, but any build mode that round-trips the runtime through whole-program LLVM bitcode — the `PERRY_LLVM_BITCODE_LINK` path in `optimized_libs.rs`, cross-compile `-Zbuild-std` builds, or a future switch to fat LTO — is free to *internalize* an unreferenced `#[no_mangle]` symbol and dead-strip it, leaving the codegen-emitted call dangling:

```
Undefined symbols for architecture arm64:
  "_js_dyn_index_get", referenced from:
      _main in test_gap_error_extensions_ts.o
```

## Fix

Add three `#[used]` statics that take the address of each export. `#[used]` lands them in `@llvm.used` / a `no_dead_strip` section, creating a retained reference edge LTO and the linker's `-dead_strip` must honor — so the symbols survive auto-optimize regardless of feature set or link mode. The "always-include path" requested in the issue, with no `cfg` gating. Function-pointer types are `Sync`, so no wrapper is needed.

## Verification

- `cargo build --release -p perry-runtime` — clean.
- `cargo fmt --all -- --check` — clean.
- Compiled a dynamic-index program (`const x: any = [10,20,30]; x[1]`) under default auto-optimize → links + runs (`20`, `10`).
- `test-files/test_gap_error_extensions.ts` under auto-optimize → links and is **byte-for-byte identical** to `node --experimental-strip-types` (25/25 lines).

Part of #793.