### PR TITLE
test(parity): stream iter-24 — await using, push(undefined), async-iter compose, promises pipeline return

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,29 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/dispose/await-using-disposes": {
+    "issue": "1531",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: await using does not trigger Symbol.asyncDispose on the stream. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/push/push-undefined": {
+    "issue": "1532",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: push(undefined) crashes instead of being treated as end-of-stream. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/from-async-iterable": {
+    "issue": "1539",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: stream.compose with async-iterable source does not propagate data. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/promises/pipeline-returns-undefined": {
+    "issue": "1533",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream/promises: pipeline resolves with the wrong value. Flips to PASS when #1533 lands."
   }
 }

--- a/test-parity/node-suite/stream/compose/from-async-iterable.ts
+++ b/test-parity/node-suite/stream/compose/from-async-iterable.ts
@@ -1,0 +1,10 @@
+import * as stream from "node:stream";
+// stream.compose accepts an async iterable as the first (source) argument.
+async function* src() {
+  yield "x";
+  yield "y";
+}
+const piped = (stream as any).compose(src());
+const out: string[] = [];
+piped.on("data", (c: any) => out.push(String(c)));
+piped.on("end", () => console.log("joined:", out.join("")));

--- a/test-parity/node-suite/stream/dispose/await-using-disposes.ts
+++ b/test-parity/node-suite/stream/dispose/await-using-disposes.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// `await using` triggers Symbol.asyncDispose at the end of the scope —
+// the stream is destroyed after the block.
+let r: Readable;
+{
+  await using inner = Readable.from(["a", "b"]) as any;
+  r = inner;
+  for await (const _ of inner) {
+    /* consume to keep the stream live */
+  }
+}
+console.log("destroyed after scope:", r!.destroyed);

--- a/test-parity/node-suite/stream/promises/pipeline-returns-undefined.ts
+++ b/test-parity/node-suite/stream/promises/pipeline-returns-undefined.ts
@@ -1,0 +1,5 @@
+import { Readable, PassThrough } from "node:stream";
+import { pipeline } from "node:stream/promises";
+// stream/promises.pipeline resolves with undefined on clean completion.
+const ret = await pipeline(Readable.from(["a"]), new PassThrough());
+console.log("ret:", ret);

--- a/test-parity/node-suite/stream/push/push-undefined.ts
+++ b/test-parity/node-suite/stream/push/push-undefined.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// push(undefined) coerces to a string in non-objectMode (or signals end);
+// it should NOT crash.
+const r = new Readable({ read() {} });
+let errored = false;
+r.on("error", () => (errored = true));
+try { r.push(undefined as any); } catch { errored = true; }
+console.log("pushed without crash:", !errored);
+r.push(null);


### PR DESCRIPTION
4 more niche stream tests. All map to existing issues #1531/#1532/#1533/#1539.