### PR TITLE
fix(ui): dispatch Canvas method calls on widget-typed params (#1483)

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -51,6 +51,7 @@ impl LoweringContext {
             builtin_module_aliases: Vec::new(),
             type_param_scopes: Vec::new(),
             native_instances: Vec::new(),
+            ui_widget_type_aliases: HashMap::new(),
             current_class: None,
             extern_func_types: Vec::new(),
             source_file_path: source_file_path.into(),
@@ -917,6 +918,25 @@ impl LoweringContext {
             .push((local_name, module_name, class_name));
     }
 
+    /// #1483: resolve a parameter's declared type name to a perry/ui widget
+    /// class that uses handle-based instance dispatch (Canvas, State, ...).
+    /// Returns the canonical widget name (e.g. "Canvas") when `type_name`
+    /// refers to a perry/ui widget — whether via its value-import name
+    /// (`canvas: Canvas`) or a type-only import alias (`type Canvas as
+    /// CanvasType` → `canvas: CanvasType`). Returns `None` otherwise, so a
+    /// user class that merely shares a name with a widget isn't mis-tagged
+    /// (resolution requires an actual perry/ui import).
+    pub(crate) fn resolve_perry_ui_widget_type(&self, type_name: &str) -> Option<String> {
+        // Value import: `import { Canvas } from "perry/ui"`.
+        if let Some(("perry/ui", Some(widget))) = self.lookup_native_module(type_name) {
+            if perry_ui_handle_widget(widget) {
+                return Some(widget.to_string());
+            }
+        }
+        // Type-only import, possibly aliased: `import { type Canvas as CanvasType }`.
+        self.ui_widget_type_aliases.get(type_name).cloned()
+    }
+
     pub(crate) fn lookup_native_instance(&self, name: &str) -> Option<(&str, &str)> {
         // Issue #1132 — walk the scoped instances back-to-front so a
         // later (inner-scope) registration shadows an earlier
@@ -1100,4 +1120,24 @@ impl LoweringContext {
         }
         self.functions.truncate(functions_mark);
     }
+}
+
+/// perry/ui named imports that return an opaque widget handle and dispatch
+/// instance methods through `NativeMethodCall` (handle-based dispatch). The
+/// set mirrors the local-init registration in `module_decl.rs`; keep the two
+/// in sync. Used to tag widget-typed function parameters (#1483).
+pub(crate) fn perry_ui_handle_widget(name: &str) -> bool {
+    matches!(
+        name,
+        "Canvas"
+            | "State"
+            | "Sheet"
+            | "Toolbar"
+            | "Window"
+            | "LazyVStack"
+            | "NavigationStack"
+            | "Picker"
+            | "Table"
+            | "TabBar"
+    )
 }

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -108,6 +108,19 @@ pub(super) fn lower_arrow(ctx: &mut LoweringContext, arrow: &ast::ArrowExpr) -> 
         }
     }
 
+    // #1483: perry/ui widget arrow-params (`(canvas: Canvas) => ...` or, via a
+    // type-only import alias, `(canvas: CanvasType) => ...`) dispatch instance
+    // methods through perry/ui `NativeMethodCall` like a local `const canvas =
+    // Canvas(...)`. Mirrors the fn-decl registration; resolution requires a
+    // real perry/ui import so user classes sharing a widget name aren't tagged.
+    for param in &params {
+        if let Type::Named(type_name) = &param.ty {
+            if let Some(widget) = ctx.resolve_perry_ui_widget_type(type_name) {
+                ctx.register_native_instance(param.name.clone(), "perry/ui".to_string(), widget);
+            }
+        }
+    }
+
     // Generate Let statements for destructuring patterns BEFORE lowering body
     // This ensures the destructured variable names are defined when the body references them
     let mut destructuring_stmts = Vec::new();

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -117,6 +117,13 @@ pub struct LoweringContext {
     /// Native class instances: local_name -> (module_name, class_name)
     /// Tracks variables that hold instances of native module classes (e.g., EventEmitter)
     pub(crate) native_instances: Vec<(String, String, String)>,
+    /// #1483: type-only perry/ui widget import aliases — local_name ->
+    /// canonical widget name. `import { type Canvas as CanvasType }` records
+    /// `CanvasType -> Canvas` so a `canvas: CanvasType` parameter can be
+    /// tagged as a perry/ui native instance (handle-based method dispatch),
+    /// exactly like a `canvas: Canvas` param or a `const canvas = Canvas(...)`
+    /// local. Type-only native specifiers are otherwise dropped at import.
+    pub(crate) ui_widget_type_aliases: HashMap<String, String>,
     /// Current class being lowered (for arrow function `this` capture)
     pub(crate) current_class: Option<String>,
     /// Extern function types: name -> (param_types, return_type)

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -78,6 +78,28 @@ pub(crate) fn lower_module_decl(
                         // returned undefined. ECS demo-simple repro.
                         let spec_type_only = named.is_type_only || whole_decl_type_only;
                         if spec_type_only && is_native {
+                            // #1483: a type-only perry/ui widget import — e.g.
+                            // `import { type Canvas as CanvasType }` — carries no
+                            // value binding and is otherwise dropped here, but a
+                            // `canvas: CanvasType` parameter still needs handle
+                            // method dispatch. Record alias → canonical widget so
+                            // fn_decl's param registration can resolve it.
+                            if source == "perry/ui" {
+                                let local = named.local.sym.to_string();
+                                let imported = named
+                                    .imported
+                                    .as_ref()
+                                    .map(|i| match i {
+                                        ast::ModuleExportName::Ident(id) => id.sym.to_string(),
+                                        ast::ModuleExportName::Str(s) => {
+                                            s.value.as_str().unwrap_or("").to_string()
+                                        }
+                                    })
+                                    .unwrap_or_else(|| local.clone());
+                                if super::context::perry_ui_handle_widget(&imported) {
+                                    ctx.ui_widget_type_aliases.insert(local, imported);
+                                }
+                            }
                             continue;
                         }
                         let local = named.local.sym.to_string();

--- a/crates/perry-hir/src/lower_decl/fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/fn_decl.rs
@@ -136,6 +136,21 @@ pub fn lower_fn_decl(ctx: &mut LoweringContext, fn_decl: &ast::FnDecl) -> Result
         }
     }
 
+    // #1483: perry/ui widget parameters (e.g. `canvas: Canvas` or, via a
+    // type-only import alias, `canvas: CanvasType`) must dispatch instance
+    // methods through perry/ui `NativeMethodCall` exactly like a local
+    // `const canvas = Canvas(...)`. The match above only covers non-UI
+    // native types; resolve the (possibly import-aliased) widget type here.
+    // Resolution requires an actual perry/ui import, so a user class that
+    // happens to be named `Canvas`/`Table`/`Picker` is not mis-tagged.
+    for param in &params {
+        if let Type::Named(type_name) = &param.ty {
+            if let Some(widget) = ctx.resolve_perry_ui_widget_type(type_name) {
+                ctx.register_native_instance(param.name.clone(), "perry/ui".to_string(), widget);
+            }
+        }
+    }
+
     // Extract return type from function's type annotation (with context).
     // Body-based inference for unannotated functions is filled in after body
     // lowering below, once parameters and body locals are visible to


### PR DESCRIPTION
## Summary

Closes #1483.

A `perry/ui` widget method call silently no-op'd when the receiver was a **function parameter** instead of a local binding:

```ts
function drawLine(canvas: Canvas, x1: number, y1: number) {
  canvas.moveTo(x1, y1)   // ❌ silently dropped
  canvas.stroke()
}

const canvas = Canvas(300, 100)
canvas.moveTo(10, 10)     // ✅ works
```

## Root cause

perry/ui instance dispatch (`expr_call/static_and_instance.rs`) lowers `canvas.moveTo(...)` to a `NativeMethodCall` only when the receiver name is a **registered native instance**. A local `const canvas = Canvas(...)` gets registered from its creation call; a parameter carries only a type annotation, so it was never registered and the method calls fell through to the generic `Call` + `PropertyGet` path — a no-op against an opaque widget handle.

`fn_decl.rs` / `expr_function.rs` already register a fixed set of native param types (`Request`, `WebSocket`, `FastifyReply`, …) but omitted perry/ui widgets.

## Fix

Register widget-typed params as perry/ui native instances, resolving:
- the **direct** type name — `canvas: Canvas`;
- the **type-only import alias** — `import { type Canvas as CanvasType }` → `canvas: CanvasType` (these specifiers were otherwise dropped at import, so a small alias map is recorded for perry/ui widget type imports).

Resolution requires an actual perry/ui import, so a **user class** named `Canvas`/`Table`/`Picker` is **not** mis-tagged.

Files: `lower/lowering_context.rs` (+field), `lower/context.rs` (resolver + widget set), `lower/module_decl.rs` (record type-only alias), `lower_decl/fn_decl.rs` + `lower/expr_function.rs` (param registration). +97 lines, all additive.

## Verification

Via `--print-hir`, param-typed Canvas method calls now emit the same `NativeMethodCall { module: "perry/ui", class_name: Some("Canvas"), object: Some(LocalGet(0)) }` as the inline local case:
- aliased `canvas: CanvasType` ✓
- direct `canvas: Canvas` ✓
- arrow `(canvas: Canvas) => ...` path covered ✓
- **negative**: a user class `Table` with no perry/ui import stays a plain `Call` (no false positive) ✓

`cargo test -p perry-hir` green, `cargo fmt --all -- --check` clean, and the full repro compiles to an executable.

Part of #793.