### PR TITLE
fix(hir): process.<method> value reads report typeof 'function' (#1343)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -265,6 +265,30 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                     }
                     _ => {}
                 }
+                // #1343: a `process.<method>` read used as a VALUE. The
+                // call form (`process.cwd()`) is intercepted in expr_call
+                // and lowered to its dedicated `ProcessCwd`/etc. variant
+                // before reaching here, so this only fires for bare reads
+                // (`typeof process.cwd`, `const f = process.cwd`). The arms
+                // above cover process *properties* (argv/env/pid/…); anything
+                // the API manifest classifies as a process *method* is a
+                // callable function value in Node. Lower it to a
+                // `NativeModuleRef("process")` property read so the codegen
+                // typeof short-circuit (which consults `module_has_symbol`)
+                // reports "function" — exactly the already-working
+                // `crypto.<method>` namespace path. Without this, `process`
+                // lowers to a `GlobalGet` and `typeof process.cwd` read
+                // "undefined" even though `process.cwd()` works.
+                let prop = prop_ident.sym.as_ref();
+                if matches!(
+                    perry_api_manifest::module_has_symbol("process", prop).map(|e| &e.kind),
+                    Some(perry_api_manifest::ApiKind::Method { .. })
+                ) {
+                    return Ok(Expr::PropertyGet {
+                        object: Box::new(Expr::NativeModuleRef("process".to_string())),
+                        property: prop.to_string(),
+                    });
+                }
             }
         }
         // `globalThis.process` returns an object whose `.env`/`.argv`/


### PR DESCRIPTION
## Summary

Closes #1343.

`typeof process.cwd` (and `nextTick`/`hrtime`/`exit`/`on`/`uptime`/`memoryUsage`/`cpuUsage`) returned `"undefined"` even though the call forms work and Node reports `"function"`:

```ts
console.log(typeof process.cwd);   // perry: "undefined"  node: "function"
console.log(typeof process.cwd()); // both: "string" (call works)
```

## Root cause

A bare `process.<method>` read lowered to a generic `PropertyGet` on the `process` global (`GlobalGet`), which has no such field → `undefined`.

`crypto.<method>` already works because `crypto.createHash` lowers to a `PropertyGet` on a `NativeModuleRef("crypto")`, and codegen's existing #1343 typeof short-circuit (`literals_vars.rs`) reports `"function"` for any `NativeModuleRef` member the API manifest classifies as a `Method`/`Class`. The process methods are **already in the manifest** — they just weren't routed through `NativeModuleRef`.

## Fix

In `lower/expr_member.rs`, lower a value-position `process.<method>` (where `module_has_symbol("process", prop)` is a `Method`) to `PropertyGet { NativeModuleRef("process"), method }`, so it hits the same short-circuit as crypto. 24-line, single-file change.

- The **call** form is untouched: `process.cwd()` is intercepted in `expr_call` and lowered to its dedicated `ProcessCwd` variant before reaching this code.
- Dedicated process **properties** (`argv`/`env`/`pid`/`stdout`/…) still return their own variants from the match above; only manifest-`Method` names are rerouted.

## Verification

- `process/shapes/method-types.ts` and `process/nexttick/is-function.ts` — **byte-identical to `node --experimental-strip-types`** (all 8 method typeofs now `"function"`).
- Regression check (`typeof process.cwd()`, `process.argv`, `process.env`, `process.pid`, `process.nextTick(...)`) — identical to Node.
- `cargo test -p perry-hir` — all green; `cargo fmt --all -- --check` — clean.

## Not in scope (follow-up)

Capturing a method into a variable (`const f = process.cwd; typeof f`) still reads `"undefined"` — the value-capture path returns the runtime stub rather than a callable closure. This affects `crypto.*` identically today and is a separate first-class-method-value gap; filed as a follow-up. The two `#1343` repros only exercise direct `typeof`, which this fixes.

Part of #793.
