### PR TITLE
fix(node:crypto): dispatch captured-then-called crypto methods (#1577)

### DIFF
--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -178,7 +178,7 @@ pub use value::{
 pub use value::{
     js_set_handle_array_get, js_set_handle_array_length, js_set_handle_call_method,
     js_set_handle_object_get_property, js_set_handle_to_string, js_set_handle_typeof,
-    js_set_native_module_js_loader, js_set_new_from_handle_v8,
+    js_set_native_crypto_dispatch, js_set_native_module_js_loader, js_set_new_from_handle_v8,
 };
 
 // Extension pump registration — allows extensions to register pump functions

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -812,6 +812,24 @@ pub(crate) unsafe fn dispatch_native_module_method(
             f64::from_bits(JSValue::undefined().bits())
         }
 
+        // #1577: captured-then-called crypto methods (`const f =
+        // crypto.createHash; f(...)`). The impls live in perry-stdlib (which
+        // depends on this crate), so route through the dispatcher stdlib
+        // registers at startup via `js_set_native_crypto_dispatch`. Null when
+        // stdlib isn't linked (e.g. runtime-only tests) → undefined. The
+        // `randomFillSync` arm above is handled inline and never reaches here.
+        ("crypto", _) => {
+            let ptr =
+                crate::value::JS_NATIVE_CRYPTO_DISPATCH.load(std::sync::atomic::Ordering::SeqCst);
+            if ptr.is_null() {
+                f64::from_bits(JSValue::undefined().bits())
+            } else {
+                let dispatch: unsafe extern "C" fn(*const u8, usize, *const f64, usize) -> f64 =
+                    std::mem::transmute(ptr);
+                dispatch(method_name.as_ptr(), method_name.len(), args_ptr, args_len)
+            }
+        }
+
         _ => {
             // Method not found on native module — return undefined
             f64::from_bits(JSValue::undefined().bits())

--- a/crates/perry-runtime/src/value/handle.rs
+++ b/crates/perry-runtime/src/value/handle.rs
@@ -38,6 +38,16 @@ pub extern "C" fn js_set_handle_call_method(func: JsHandleCallMethodFn) {
     JS_HANDLE_CALL_METHOD.store(func as *mut (), Ordering::SeqCst);
 }
 
+/// Set the node:crypto module-method dispatcher (called by perry-stdlib's
+/// `js_stdlib_init_dispatch` at program startup). Lets a captured-then-called
+/// crypto method (`const f = crypto.createHash; f(...)`) reach the stdlib
+/// crypto impls — this crate can't call them directly since perry-stdlib
+/// depends on it. Stays null when stdlib isn't linked. (#1577)
+#[no_mangle]
+pub extern "C" fn js_set_native_crypto_dispatch(func: JsNativeCryptoDispatchFn) {
+    JS_NATIVE_CRYPTO_DISPATCH.store(func as *mut (), Ordering::SeqCst);
+}
+
 /// Set the native module JS property loader (called by perry-jsruntime)
 /// This callback loads a native module via V8 and gets a property from it.
 #[no_mangle]

--- a/crates/perry-runtime/src/value/mod.rs
+++ b/crates/perry-runtime/src/value/mod.rs
@@ -57,17 +57,17 @@ pub(crate) use tags::{
     STRING_TAG, TAG_FALSE, TAG_HOLE, TAG_MASK, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
 };
 pub use tags::{
-    JS_HANDLE_CALL_METHOD, JS_HANDLE_TYPEOF, JS_NATIVE_MODULE_JS_LOADER, JS_NEW_FROM_HANDLE_V8,
-    SHORT_STRING_MAX_LEN,
+    JS_HANDLE_CALL_METHOD, JS_HANDLE_TYPEOF, JS_NATIVE_CRYPTO_DISPATCH, JS_NATIVE_MODULE_JS_LOADER,
+    JS_NEW_FROM_HANDLE_V8, SHORT_STRING_MAX_LEN,
 };
 
 // Crate-internal handle dispatch atomics + callback type aliases (read by
 // every dispatcher that needs to call back into perry-jsruntime).
 pub(crate) use tags::{
     JsHandleArrayGetFn, JsHandleArrayLengthFn, JsHandleCallMethodFn, JsHandleObjectGetPropertyFn,
-    JsHandleToStringFn, JsHandleTypeofFn, JsNativeModuleJsLoaderFn, JsNewFromHandleV8Fn,
-    JS_HANDLE_ARRAY_GET, JS_HANDLE_ARRAY_LENGTH, JS_HANDLE_OBJECT_GET_PROPERTY,
-    JS_HANDLE_TO_STRING,
+    JsHandleToStringFn, JsHandleTypeofFn, JsNativeCryptoDispatchFn, JsNativeModuleJsLoaderFn,
+    JsNewFromHandleV8Fn, JS_HANDLE_ARRAY_GET, JS_HANDLE_ARRAY_LENGTH,
+    JS_HANDLE_OBJECT_GET_PROPERTY, JS_HANDLE_TO_STRING,
 };
 
 // ----- JSValue type + impls -----
@@ -78,8 +78,8 @@ pub(crate) use handle::js_handle_is_function;
 pub use handle::{
     is_js_handle, js_handle_array_get, js_handle_array_length, js_set_handle_array_get,
     js_set_handle_array_length, js_set_handle_call_method, js_set_handle_object_get_property,
-    js_set_handle_to_string, js_set_handle_typeof, js_set_native_module_js_loader,
-    js_set_new_from_handle_v8, native_module_try_js_property,
+    js_set_handle_to_string, js_set_handle_typeof, js_set_native_crypto_dispatch,
+    js_set_native_module_js_loader, js_set_new_from_handle_v8, native_module_try_js_property,
 };
 
 // ----- Basic NaN-box pack / unpack FFI -----

--- a/crates/perry-runtime/src/value/tags.rs
+++ b/crates/perry-runtime/src/value/tags.rs
@@ -108,6 +108,12 @@ pub(crate) type JsNewFromHandleV8Fn = unsafe extern "C" fn(f64, *const f64, usiz
 /// 1 = "function" (V8 callable), 0 = "object" (everything else — including arrays).
 /// Negative values reserved for future use ("symbol" = 2 if V8 ever exposes it that way).
 pub(crate) type JsHandleTypeofFn = unsafe extern "C" fn(f64) -> i32;
+/// node:crypto module-method dispatcher (registered by perry-stdlib). Takes
+/// `(method_name_ptr, method_name_len, args_ptr, args_len)` and returns the
+/// NaN-boxed result. Lets a captured-then-called crypto method reach the
+/// stdlib crypto impls, which this crate can't call directly. (#1577)
+pub(crate) type JsNativeCryptoDispatchFn =
+    unsafe extern "C" fn(*const u8, usize, *const f64, usize) -> f64;
 
 // ----- JS handle dispatch atomics (shared between handle.rs and consumers) -----
 
@@ -120,3 +126,4 @@ pub static JS_HANDLE_CALL_METHOD: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_
 pub static JS_NATIVE_MODULE_JS_LOADER: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 pub static JS_NEW_FROM_HANDLE_V8: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 pub static JS_HANDLE_TYPEOF: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+pub static JS_NATIVE_CRYPTO_DISPATCH: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -1309,4 +1309,7 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
     js_register_handle_method_dispatch(js_handle_method_dispatch);
     js_register_handle_property_dispatch(js_handle_property_dispatch);
     js_register_handle_property_set_dispatch(js_handle_property_set_dispatch);
+    // #1577: route captured-then-called `crypto.*` methods (which reach the
+    // runtime's native-module dispatch) back to the stdlib crypto impls.
+    perry_runtime::js_set_native_crypto_dispatch(crate::crypto::js_crypto_native_dispatch);
 }

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -1087,6 +1087,63 @@ pub extern "C" fn js_crypto_random_int(min_bits: f64, max_bits: f64) -> f64 {
     rand::thread_rng().gen_range(min..max) as f64
 }
 
+/// #1577: dispatcher for captured-then-called `crypto.*` methods
+/// (`const f = crypto.createHash; f("sha256")`). The runtime's native-module
+/// dispatch (`dispatch_native_module_method`) routes `("crypto", method)`
+/// here once it's registered in `js_stdlib_init_dispatch` — the runtime can't
+/// call these stdlib impls directly (perry-stdlib depends on perry-runtime).
+/// Args arrive as NaN-boxed f64s; string args are unboxed SSO-safely the same
+/// way the direct-call lowering does. Unhandled methods return undefined.
+///
+/// # Safety
+/// `method_ptr`/`args_ptr` must be valid for their stated lengths (the runtime
+/// passes the live method name and call-arg buffer).
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_native_dispatch(
+    method_ptr: *const u8,
+    method_len: usize,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    let undefined = f64::from_bits(JSValue::undefined().bits());
+    let method = if method_ptr.is_null() || method_len == 0 {
+        ""
+    } else {
+        std::str::from_utf8(std::slice::from_raw_parts(method_ptr, method_len)).unwrap_or("")
+    };
+    let arg = |n: usize| -> f64 {
+        if n < args_len && !args_ptr.is_null() {
+            *args_ptr.add(n)
+        } else {
+            undefined
+        }
+    };
+    // SSO-safe StringHeader pointer (matches `unbox_to_i64` on the direct path).
+    let str_ptr = |n: usize| -> i64 { perry_runtime::js_get_string_pointer_unified(arg(n)) as i64 };
+    // A buffer-or-string arg's raw pointer (bytes_from_ptr handles both).
+    let bytes_ptr = |n: usize| -> i64 {
+        let v = arg(n);
+        if JSValue::from_bits(v.to_bits()).is_any_string() {
+            perry_runtime::js_get_string_pointer_unified(v) as i64
+        } else {
+            perry_runtime::js_nanbox_get_pointer(v)
+        }
+    };
+    match method {
+        "createHash" => js_crypto_create_hash(str_ptr(0)),
+        "createHmac" => js_crypto_create_hmac(str_ptr(0), bytes_ptr(1)),
+        "randomUUID" => f64::from_bits(JSValue::string_ptr(js_crypto_random_uuid()).bits()),
+        "randomBytes" => {
+            let buf = js_crypto_random_bytes_buffer(arg(0));
+            f64::from_bits(JSValue::pointer(buf as *const u8).bits())
+        }
+        // Node: randomInt(max) → [0,max); randomInt(min,max) → [min,max).
+        "randomInt" if args_len >= 2 => js_crypto_random_int(arg(0), arg(1)),
+        "randomInt" => js_crypto_random_int(0.0, arg(0)),
+        _ => undefined,
+    }
+}
+
 /// `crypto.randomInt(min, max, callback)` callback form. The random value is
 /// generated through the synchronous helper and delivered as `(err, n)`.
 #[no_mangle]

--- a/test-parity/node-suite/crypto/imports/captured-method-calls.ts
+++ b/test-parity/node-suite/crypto/imports/captured-method-calls.ts
@@ -1,0 +1,19 @@
+// #1577: a crypto method captured into a variable must stay callable, not
+// just report typeof "function". A bound-method call routes through the
+// runtime's native-module dispatch, which (post-fix) forwards crypto methods
+// to the perry-stdlib impls via a registered dispatcher.
+import * as crypto from "node:crypto";
+
+const createHash = crypto.createHash;
+const createHmac = crypto.createHmac;
+const randomUUID = crypto.randomUUID;
+const randomBytes = crypto.randomBytes;
+const randomInt = crypto.randomInt;
+
+console.log("hash:", createHash("sha256").update("abc").digest("hex"));
+console.log("hmac:", createHmac("sha256", "key").update("abc").digest("hex"));
+console.log("uuid len:", randomUUID().length);
+console.log("uuid parts:", randomUUID().split("-").length);
+console.log("bytes len:", randomBytes(16).length);
+console.log("randomInt(5,6):", randomInt(5, 6));
+console.log("randomInt(1):", randomInt(1));


### PR DESCRIPTION
Closes #1577.

A captured `crypto` method (`const f = crypto.createHash; f("sha256")...`) reported `typeof "function"` but returned **undefined** when called. A bound-method call routes through the runtime's `dispatch_native_module_method`, which had the `process.*` arms but only `crypto.randomFillSync` — all other crypto methods fell through to undefined. (Direct `crypto.createHash(...)` calls are unaffected; codegen lowers them via a special Phase-H chain-collapse that bypasses this dispatch.)

The blocker: crypto impls live in **perry-stdlib**, which depends on perry-runtime, so the runtime dispatch can't call them directly.

## Fix — a stdlib→runtime registration hook (mirrors `JS_HANDLE_CALL_METHOD`)

- **perry-runtime**: `JS_NATIVE_CRYPTO_DISPATCH` AtomicPtr + `js_set_native_crypto_dispatch` setter. The `("crypto", _)` arm of `dispatch_native_module_method` forwards `(method, args)` to the registered dispatcher. Stays null when stdlib isn't linked → undefined fallback, so runtime-only builds and `cargo test -p perry-runtime` link cleanly (verified).
- **perry-stdlib**: `js_crypto_native_dispatch` maps captured crypto methods → their impls (`createHash`/`createHmac`/`randomUUID`/`randomBytes`/`randomInt`), unboxing string args SSO-safely via `js_get_string_pointer_unified` (matching the direct-call lowering). Registered in `js_stdlib_init_dispatch` at program startup.

The hook is reusable for wiring further crypto methods (or other stdlib modules) into the captured-call path.

## Tests

`test-parity/node-suite/crypto/imports/captured-method-calls.ts` — captured `createHash`/`createHmac` chains, `randomUUID`, `randomBytes`, `randomInt`. **Byte-identical** to `node --experimental-strip-types`. `perry-runtime --lib` builds standalone; `cargo fmt --check` clean. No codegen/HIR change.