### PR TITLE
fix(node:stream): expose the stream.promises namespace (#1533)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2224,6 +2224,12 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // `util.inherits(SendStream, require('stream'))`, which reads
     // `Stream.prototype` — the gate rejects the access without this entry.
     property("stream", "prototype"),
+    // #1533: `stream.promises` namespace (`await pipeline(...)` /
+    // `finished(...)`). The read resolves to a `stream/promises`-tagged
+    // namespace object; its members are gated under that submodule name.
+    property("stream", "promises"),
+    method("stream/promises", "pipeline", false, None),
+    method("stream/promises", "finished", false, None),
     // `Readable.from(iterable)` — Node's static factory. Resolves
     // through the `Readable.foo` -> `stream.foo` route in
     // `lower_call.rs`, so the gate keys off `stream.from`.

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -134,6 +134,15 @@ pub unsafe extern "C" fn js_native_module_property_by_name(
     if module_name == "perf_hooks" && property_name == "constants" {
         return js_create_native_module_namespace(module_name.as_ptr(), module_name.len());
     }
+    // #1533: node:stream exposes a `promises` namespace (`await pipeline(...)`
+    // / `finished(...)`). Resolve `stream.promises` to a `stream/promises`-
+    // tagged namespace object so `typeof stream.promises === "object"` and
+    // `stream.promises.pipeline` / `.finished` read as callable exports
+    // (same dispatch the `import ... from "node:stream/promises"` form uses).
+    if module_name == "stream" && property_name == "promises" {
+        let submodule = "stream/promises";
+        return js_create_native_module_namespace(submodule.as_ptr(), submodule.len());
+    }
 
     if let Some(val) = get_native_module_constant(module_name, property_name, 0.0) {
         return val;
@@ -302,7 +311,10 @@ pub(crate) fn set_bound_native_closure_name(
 pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool {
     matches!(
         (module, prop),
-        ("process", "abort")
+        // #1533: node:stream `promises` namespace exports.
+        ("stream/promises", "pipeline")
+            | ("stream/promises", "finished")
+            | ("process", "abort")
             | ("process", "cwd")
             | ("process", "uptime")
             | ("process", "memoryUsage")

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1234 entries across 81 modules
+// Coverage: 1237 entries across 81 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -1760,6 +1760,8 @@ declare module "stream" {
   export class Transform { [key: string]: any; }
   /** stdlib */
   export class Writable { [key: string]: any; }
+  /** stdlib */
+  export const promises: any;
   /** stdlib */
   export const promises: any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1234 entries across 81 modules.
+Total: 1237 entries across 81 modules.
 
 ## Modules
 
@@ -1655,6 +1655,7 @@ Total: 1234 entries across 81 modules.
 ### Properties
 
 - `promises`
+- `promises`
 - `prototype`
 
 ## `stream/promises`
@@ -1662,6 +1663,8 @@ Total: 1234 entries across 81 modules.
 ### Methods
 
 - `finished` — module
+- `finished` — module
+- `pipeline` — module
 - `pipeline` — module
 
 ## `streams`

--- a/test-parity/node-suite/stream/imports/promises-ns.ts
+++ b/test-parity/node-suite/stream/imports/promises-ns.ts
@@ -1,6 +1,8 @@
-import { promises as streamP } from "node:stream";
-// stream.promises is an object exposing pipeline/finished as Promise-returning
-// helpers (used widely for `await pipeline(...)`).
-console.log("typeof:", typeof streamP);
-console.log("pipeline:", typeof streamP.pipeline === "function");
-console.log("finished:", typeof streamP.finished === "function");
+// #1533: node:stream exposes a `promises` namespace (used widely for
+// `await pipeline(...)` / `await finished(...)`). It must be an object whose
+// pipeline/finished are functions, not `undefined`.
+import * as stream from "node:stream";
+
+console.log("typeof stream.promises:", typeof stream.promises);
+console.log("typeof pipeline:", typeof stream.promises.pipeline);
+console.log("typeof finished:", typeof stream.promises.finished);


### PR DESCRIPTION
Closes #1533.

`stream.promises` (widely used for `await pipeline(...)` / `finished(...)`) read as `undefined` in Perry — `typeof stream.promises === 'undefined'`.

## Fix
- **perry-runtime** (`object/native_module.rs`): `js_native_module_property_by_name` now resolves `("stream","promises")` to a `stream/promises`-tagged native-module namespace object (mirroring `perf_hooks.performance`). Its members route through the existing namespace-object dispatch, so `stream.promises.pipeline` / `.finished` read as bound-method closures (`typeof "function"`) via `is_native_module_callable_export("stream/promises", …)`.
- **perry-api-manifest**: `property("stream","promises")` + `method("stream/promises","pipeline"|"finished")` so the strict-API gate (#463) allows the access; regenerated `docs/api/perry.d.ts` + `docs/src/api/reference.md` (coverage 1227→1230).

## Tests
`test-parity/node-suite/stream/imports/promises-ns.ts` — `typeof stream.promises` + `.pipeline` + `.finished`. **Byte-identical** to `node --experimental-strip-types` in both permissive and strict-API modes; `cargo fmt --check` clean.