### PR TITLE
fix(node:crypto): ECDH.setPublicKey.name is "deprecated" (#1368)

### DIFF
--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -2487,7 +2487,8 @@ pub unsafe fn dispatch_ecdh(handle: i64, method: &str, args: &[f64]) -> f64 {
                 Err(_) => f64::from_bits(0x7FFC_0000_0000_0001),
             }
         }
-        "setPublicKey" => f64::from_bits(JSValue::undefined().bits()),
+        // "deprecated" is the bound-method alias for setPublicKey (#1368).
+        "setPublicKey" | "deprecated" => f64::from_bits(JSValue::undefined().bits()),
         "computeSecret" | "dhComputeSecret" if !args.is_empty() => {
             let guard = h.private_key.lock().unwrap();
             let key = match guard.as_ref() {
@@ -2517,7 +2518,12 @@ pub unsafe fn dispatch_ecdh_property(handle: i64, property: &str) -> f64 {
         "getPublicKey" => b"getPublicKey",
         "getPrivateKey" => b"dhGetPrivateKey",
         "setPrivateKey" => b"setPrivateKey",
-        "setPublicKey" => b"setPublicKey",
+        // #1368: Node deprecated ECDH.setPublicKey (DEP0031) and exposes it
+        // via a `deprecate()` wrapper, so its `.name` is "deprecated".
+        // `dispatch_ecdh` accepts "deprecated" as a setPublicKey alias so a
+        // captured-then-called `const f = ecdh.setPublicKey; f(...)` still
+        // dispatches. (DH's setPublicKey is NOT deprecated — keeps its name.)
+        "setPublicKey" => b"deprecated",
         "computeSecret" => b"dhComputeSecret",
         _ => return nanbox_undefined(),
     };


### PR DESCRIPTION
Closes #1368.

`createDiffieHellman` / `createDiffieHellmanGroup` / `getDiffieHellman` / `createECDH` (+ MODP groups, x25519 stateless `diffieHellman`, ECDH key exchange) already work on `main` — **17/18** of the node-suite `crypto/{dh,ec,ecdh}` repros pass byte-for-byte (the issue text "Not functions" was stale).

The lone gap was `ecdh.setPublicKey.name`: Node deprecated `ECDH.setPublicKey` (DEP0031) and exposes it via a `deprecate()` wrapper whose `.name` is `"deprecated"`; Perry reported `"setPublicKey"`.

## Fix (perry-stdlib/src/crypto.rs)
- `dispatch_ecdh_property` binds ECDH's `setPublicKey` display-name to `"deprecated"` — matching how its `computeSecret`/`getPrivateKey` already mirror Node's internal `dhComputeSecret`/`dhGetPrivateKey` names.
- `dispatch_ecdh` accepts `"deprecated"` as a `setPublicKey` dispatch alias, so a captured-then-called `const f = ecdh.setPublicKey; f(...)` still routes correctly.
- DH's `setPublicKey` is **not** deprecated and keeps its `"setPublicKey"` name (verified `dh/method-properties` still passes).

## Tests
All node-suite `crypto/{dh,ec,ecdh}` repros (18/18, incl. `ecdh/method-properties`) are byte-identical to `node --experimental-strip-types`. Regression-checked `dh/method-properties` + `ecdh/set-private-key`. `cargo fmt --check` clean; runtime-only (no codegen/manifest/docs change).