### PR TITLE
feat(node:crypto): implement X509Certificate (#1367)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,8 +1757,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2311,6 +2324,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -5826,6 +5845,7 @@ dependencies = [
  "validator",
  "windows-sys 0.61.2",
  "x25519-dalek",
+ "x509-cert",
 ]
 
 [[package]]
@@ -9927,6 +9947,17 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
 ]
 
 [[package]]

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1780,6 +1780,9 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("crypto", "createSign", false, None),
     method("crypto", "createVerify", false, None),
     class("crypto", "ECDH"),
+    // #1367: X509Certificate — `new X509Certificate(pem|der)` + read-only
+    // subject/issuer/validFrom/validTo/serialNumber/fingerprint/ca props.
+    class("crypto", "X509Certificate"),
     method("crypto", "createECDH", false, None),
     method("crypto", "createDiffieHellman", false, None),
     method("crypto", "createDiffieHellmanGroup", false, None),

--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -355,6 +355,25 @@ pub(super) fn lower_builtin_new(
             let handle = blk.call(I64, "js_async_local_storage_new", &[]);
             Ok(Some(nanbox_pointer_inline(blk, &handle)))
         }
+        // #1367: `new crypto.X509Certificate(pem | der)` — parse the cert
+        // into a handle exposing subject/issuer/validFrom/validTo/
+        // serialNumber/fingerprint/fingerprint256/ca/raw. The arg is a PEM
+        // string or DER Buffer; unbox to its raw pointer for the runtime
+        // parser (`js_crypto_x509_new` returns an already-NaN-boxed handle).
+        "X509Certificate" => {
+            let input = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            let blk = ctx.block();
+            let input_handle = unbox_to_i64(blk, &input);
+            Ok(Some(blk.call(
+                DOUBLE,
+                "js_crypto_x509_new",
+                &[(I64, &input_handle)],
+            )))
+        }
         "AsyncResource" => {
             let type_value = if let Some(arg) = args.first() {
                 lower_expr(ctx, arg)?

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1344,6 +1344,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // subsequent method dispatch flows through HANDLE_METHOD_DISPATCH.
     module.declare_function("js_crypto_create_hash", DOUBLE, &[I64]);
     module.declare_function("js_crypto_create_hash_options", DOUBLE, &[I64, DOUBLE]);
+    // #1367: `new X509Certificate(pem|der)` — parses to a NaN-boxed handle.
+    module.declare_function("js_crypto_x509_new", DOUBLE, &[I64]);
     module.declare_function("js_crypto_create_sign", DOUBLE, &[I64]);
     module.declare_function("js_crypto_create_verify", DOUBLE, &[I64]);
     module.declare_function("js_crypto_create_ecdh", DOUBLE, &[I64]);

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -237,6 +237,13 @@ pub(crate) fn infer_type_from_expr(expr: &ast::Expr, ctx: &LoweringContext) -> T
                         base: name,
                         type_args: Vec::new(),
                     },
+                    // #1367: `new X509Certificate(...)` returns a runtime
+                    // crypto HANDLE (like `createECDH()`), not a user class.
+                    // Typing it `Named` sends property reads down the broken
+                    // class-field path (returns 0); leave it `Any` so reads
+                    // route through HANDLE_PROPERTY_DISPATCH to the X509
+                    // property dispatch (matching how ECDH handles work).
+                    "X509Certificate" => Type::Any,
                     _ => Type::Named(name),
                 }
             } else {

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -200,7 +200,7 @@ bundled-mongodb = ["dep:mongodb", "dep:bson", "dep:futures-util", "async-runtime
 # bindings so the well-known flip (#466 Phase 4 step 2) can route them
 # to perry-ext-bcrypt / perry-ext-argon2 without taking the rest of
 # the crypto surface offline.
-crypto = ["dep:sha2", "dep:sha1", "dep:sha3", "dep:rsa-sha1", "dep:md-5", "dep:hex", "dep:hmac", "dep:aes", "dep:cbc", "dep:ecb", "dep:scrypt", "dep:pbkdf2", "dep:base64", "dep:x25519-dalek", "dep:ed25519-dalek", "dep:aes-gcm", "dep:aes-kw", "dep:hkdf", "dep:p256", "async-runtime", "ids", "bundled-bcrypt", "bundled-argon2", "bundled-jsonwebtoken", "bundled-ethers"]
+crypto = ["dep:sha2", "dep:sha1", "dep:sha3", "dep:rsa-sha1", "dep:md-5", "dep:hex", "dep:hmac", "dep:aes", "dep:cbc", "dep:ecb", "dep:scrypt", "dep:pbkdf2", "dep:base64", "dep:x25519-dalek", "dep:ed25519-dalek", "dep:aes-gcm", "dep:aes-kw", "dep:hkdf", "dep:p256", "dep:x509-cert", "async-runtime", "ids", "bundled-bcrypt", "bundled-argon2", "bundled-jsonwebtoken", "bundled-ethers"]
 bundled-bcrypt = ["dep:bcrypt", "async-runtime"]
 bundled-argon2 = ["dep:argon2", "async-runtime"]
 bundled-jsonwebtoken = ["dep:jsonwebtoken", "dep:p256", "dep:rsa", "dep:spki"]
@@ -325,6 +325,9 @@ bcrypt = { version = "0.17", optional = true }
 jsonwebtoken = { workspace = true, optional = true }
 p256 = { version = "0.13", optional = true, default-features = false, features = ["pkcs8", "pem", "ecdsa", "ecdh"] }
 rsa = { version = "0.9", optional = true, default-features = false, features = ["pem", "sha2"] }
+# #1367 node:crypto X509Certificate — DER/PEM cert parsing (RustCrypto, reuses
+# the der/spki/const-oid already in the lock).
+x509-cert = { version = "0.2", optional = true, default-features = false, features = ["pem"] }
 spki = { version = "0.7", optional = true, default-features = false, features = ["pem", "alloc"] }
 aes = { version = "0.8", optional = true }
 cbc = { version = "0.1", optional = true }

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -991,6 +991,25 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
         return crate::crypto::dispatch_diffie_hellman_property(handle, property_name);
     }
 
+    // #1367: X509Certificate read-only properties (data values, not
+    // bound-method closures).
+    #[cfg(feature = "crypto")]
+    if matches!(
+        property_name,
+        "subject"
+            | "issuer"
+            | "validFrom"
+            | "validTo"
+            | "serialNumber"
+            | "fingerprint"
+            | "fingerprint256"
+            | "ca"
+            | "raw"
+    ) && with_handle::<crate::crypto::X509Handle, bool, _>(handle, |_| true).unwrap_or(false)
+    {
+        return crate::crypto::dispatch_x509_property(handle, property_name);
+    }
+
     // Issue #1111: CipherHandle method-as-value reads. Returns a
     // bound-method closure for `update` / `final` / `getAuthTag` /
     // `setAuthTag` / `setAAD` / `setAutoPadding` so `c.getAuthTag?.()` doesn't short-circuit

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -2092,6 +2092,210 @@ pub struct DiffieHellmanHandle {
     public_key: std::sync::Mutex<Option<Vec<u8>>>,
 }
 
+// ───────────────────────────────────────────────────────────────────
+// #1367: node:crypto X509Certificate. `new X509Certificate(pem|der)`
+// parses the cert and exposes Node's read-only properties. Parsing uses
+// RustCrypto's `x509-cert` (the der/spki/const-oid already in the lock).
+// ───────────────────────────────────────────────────────────────────
+
+pub struct X509Handle {
+    der: Vec<u8>,
+    cert: x509_cert::Certificate,
+}
+
+/// Short attribute name for an X.500 DN OID, matching Node's subject /
+/// issuer formatting (`CN`, `O`, `C`, …); falls back to the dotted OID.
+fn x509_attr_short_name(oid: &str) -> String {
+    match oid {
+        "2.5.4.3" => "CN",
+        "2.5.4.6" => "C",
+        "2.5.4.7" => "L",
+        "2.5.4.8" => "ST",
+        "2.5.4.10" => "O",
+        "2.5.4.11" => "OU",
+        "2.5.4.4" => "SN",
+        "2.5.4.42" => "GN",
+        "2.5.4.5" => "serialNumber",
+        "2.5.4.9" => "STREET",
+        "0.9.2342.19200300.100.1.25" => "DC",
+        "1.2.840.113549.1.9.1" => "emailAddress",
+        other => return other.to_string(),
+    }
+    .to_string()
+}
+
+/// Format an X.500 `Name` the way Node's `cert.subject` / `cert.issuer`
+/// do: one `TYPE=value` per line, newline-joined, in encoding order.
+fn x509_format_name(name: &x509_cert::name::Name) -> String {
+    use x509_cert::der::Encode;
+    let mut lines: Vec<String> = Vec::new();
+    for rdn in name.0.iter() {
+        for atv in rdn.0.iter() {
+            let oid = atv.oid.to_string();
+            // The value is an AttributeValue (ASN.1 Any); decode common
+            // string forms. Fall back to its UTF-8 lossy DER tail.
+            let value = atv
+                .value
+                .decode_as::<x509_cert::der::asn1::Utf8StringRef>()
+                .map(|s| s.as_str().to_string())
+                .or_else(|_| {
+                    atv.value
+                        .decode_as::<x509_cert::der::asn1::PrintableStringRef>()
+                        .map(|s| s.as_str().to_string())
+                })
+                .or_else(|_| {
+                    atv.value
+                        .decode_as::<x509_cert::der::asn1::Ia5StringRef>()
+                        .map(|s| s.as_str().to_string())
+                })
+                .unwrap_or_else(|_| {
+                    let bytes = atv.value.to_der().unwrap_or_default();
+                    // Skip the 2-byte tag+len header when present.
+                    let tail = if bytes.len() > 2 {
+                        &bytes[2..]
+                    } else {
+                        &bytes[..]
+                    };
+                    String::from_utf8_lossy(tail).to_string()
+                });
+            lines.push(format!("{}={}", x509_attr_short_name(&oid), value));
+        }
+    }
+    lines.join("\n")
+}
+
+/// Format an X.509 validity `Time` as Node does — `MMM D HH:MM:SS YYYY GMT`
+/// with a space-padded day (e.g. `Jan  1 00:00:00 2020 GMT`).
+fn x509_format_time(time: &x509_cert::time::Time) -> String {
+    const MONTHS: [&str; 12] = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+    let dt = time.to_date_time();
+    let month = MONTHS
+        .get((dt.month() as usize).saturating_sub(1))
+        .copied()
+        .unwrap_or("Jan");
+    format!(
+        "{} {:>2} {:02}:{:02}:{:02} {} GMT",
+        month,
+        dt.day(),
+        dt.hour(),
+        dt.minutes(),
+        dt.seconds(),
+        dt.year(),
+    )
+}
+
+/// Uppercase colon-separated hex of a digest, matching Node's
+/// `cert.fingerprint` / `.fingerprint256`.
+fn x509_colon_hex(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|b| format!("{:02X}", b))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+/// `new crypto.X509Certificate(pem | der)` — parse and register a handle.
+/// Accepts a PEM string or a DER Buffer/Uint8Array. Returns `undefined`
+/// on a parse failure (Node throws; the stub degrades to undefined).
+///
+/// # Safety
+/// `input_ptr` must be a valid string/buffer pointer (the codegen-unboxed
+/// constructor argument).
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_x509_new(input_ptr: i64) -> f64 {
+    use x509_cert::der::{Decode, DecodePem, Encode};
+    let bytes = bytes_from_ptr(input_ptr);
+    let cert = if bytes.starts_with(b"-----BEGIN") {
+        match x509_cert::Certificate::from_pem(&bytes) {
+            Ok(c) => c,
+            Err(_) => return nanbox_undefined(),
+        }
+    } else {
+        match x509_cert::Certificate::from_der(&bytes) {
+            Ok(c) => c,
+            Err(_) => return nanbox_undefined(),
+        }
+    };
+    let der = match cert.to_der() {
+        Ok(d) => d,
+        Err(_) => return nanbox_undefined(),
+    };
+    let handle: Handle = register_handle(X509Handle { der, cert });
+    f64::from_bits(0x7FFD_0000_0000_0000u64 | ((handle as u64) & 0x0000_FFFF_FFFF_FFFF))
+}
+
+/// Read-only property dispatch for an X509Certificate handle.
+pub unsafe fn dispatch_x509_property(handle: i64, property: &str) -> f64 {
+    use sha1::Sha1;
+    use sha2::{Digest, Sha256};
+    let h = match get_handle_mut::<X509Handle>(handle) {
+        Some(h) => h,
+        None => return nanbox_undefined(),
+    };
+    let string_f64 = |s: &str| -> f64 {
+        let ptr = js_string_from_bytes(s.as_ptr(), s.len() as u32);
+        f64::from_bits(JSValue::string_ptr(ptr).bits())
+    };
+    let tbs = &h.cert.tbs_certificate;
+    match property {
+        "subject" => string_f64(&x509_format_name(&tbs.subject)),
+        "issuer" => string_f64(&x509_format_name(&tbs.issuer)),
+        "validFrom" => string_f64(&x509_format_time(&tbs.validity.not_before)),
+        "validTo" => string_f64(&x509_format_time(&tbs.validity.not_after)),
+        "serialNumber" => {
+            let hex_str: String = tbs
+                .serial_number
+                .as_bytes()
+                .iter()
+                .map(|b| format!("{:02X}", b))
+                .collect();
+            string_f64(&hex_str)
+        }
+        "fingerprint" => {
+            let digest = Sha1::digest(&h.der);
+            string_f64(&x509_colon_hex(&digest))
+        }
+        "fingerprint256" => {
+            let digest = Sha256::digest(&h.der);
+            string_f64(&x509_colon_hex(&digest))
+        }
+        "ca" => {
+            // BasicConstraints (id-ce 2.5.29.19) cA flag.
+            let is_ca = x509_basic_constraints_ca(&h.cert);
+            f64::from_bits(if is_ca {
+                0x7FFC_0000_0000_0004
+            } else {
+                0x7FFC_0000_0000_0003
+            })
+        }
+        "raw" => {
+            let buf = alloc_buffer_from_slice(&h.der);
+            f64::from_bits(0x7FFD_0000_0000_0000u64 | ((buf as u64) & 0x0000_FFFF_FFFF_FFFF))
+        }
+        _ => nanbox_undefined(),
+    }
+}
+
+/// Extract the BasicConstraints `cA` flag (default false when absent).
+fn x509_basic_constraints_ca(cert: &x509_cert::Certificate) -> bool {
+    use x509_cert::der::Decode;
+    let Some(exts) = cert.tbs_certificate.extensions.as_ref() else {
+        return false;
+    };
+    for ext in exts.iter() {
+        if ext.extn_id.to_string() == "2.5.29.19" {
+            if let Ok(bc) =
+                x509_cert::ext::pkix::BasicConstraints::from_der(ext.extn_value.as_bytes())
+            {
+                return bc.ca;
+            }
+        }
+    }
+    false
+}
+
 const DH_DEFAULT_PRIME_HEX: &str = concat!(
     "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1",
     "29024E088A67CC74020BBEA63B139B22514A08798E3404DD",

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1237 entries across 81 modules
+// Coverage: 1238 entries across 81 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -312,6 +312,8 @@ declare module "cron" {
 declare module "crypto" {
   /** stdlib */
   export class ECDH { [key: string]: any; }
+  /** stdlib */
+  export class X509Certificate { [key: string]: any; }
   /** stdlib */
   export const constants: any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1237 entries across 81 modules.
+Total: 1238 entries across 81 modules.
 
 ## Modules
 
@@ -379,6 +379,7 @@ Total: 1237 entries across 81 modules.
 ### Classes
 
 - `ECDH`
+- `X509Certificate`
 
 ### Methods
 

--- a/test-parity/node-suite/crypto/x509/x509-certificate.ts
+++ b/test-parity/node-suite/crypto/x509/x509-certificate.ts
@@ -1,0 +1,43 @@
+// #1367: new X509Certificate(pem) parses a certificate and exposes Node's
+// read-only properties. The cert is embedded so validFrom/validTo are
+// deterministic (both Perry and Node parse the same bytes).
+//
+// NOTE: properties are read via bracket access (`cert["subject"]`). The
+// implementation is correct for dot access too, but `cert.subject` (a
+// value-read dot on a handle local) currently returns 0 via the codegen
+// PropertyGet fast path — a pre-existing bug tracked in #1583, not an X509
+// gap. This repro flips to dot once #1583 lands.
+import { X509Certificate } from "node:crypto";
+
+const pem = `-----BEGIN CERTIFICATE-----
+MIIDXzCCAkegAwIBAgIUICGaY01t7nWGtQ+QsMAicwoeRLUwDQYJKoZIhvcNAQEL
+BQAwPzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMQ4wDAYDVQQKDAVQZXJyeTET
+MBEGA1UEAwwKcGVycnkudGVzdDAeFw0yNjA1MjMyMjM3NDZaFw0yNzA1MjMyMjM3
+NDZaMD8xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEOMAwGA1UECgwFUGVycnkx
+EzARBgNVBAMMCnBlcnJ5LnRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDSofrefQLAkx4k9mHYD/VrTLCkiPH7DP3RTmTD8UotAG+kv2+JQVIRWJOP
+/mJWC+ZnIVK7dCs8fqvsHS3HuU5BAYPQ4U7IyFyA48/ZBdsHECY6wuqhNW9yD5Pj
+x066iEFMckKKCNBP7gLX3rsrp4R5uWmvmK6lNqMgO4Xx8c3ae9xyxupUaS13fNzA
+inw5NNp7axLJm62llWMBOP+w2ZgQL4UmJDdxe5GI0q94ChHTU7uIr3DMOGAGWuoY
+zXLk8LeSwncgWn3CZZ4WpUxibNvhVG1pmZAbgeWB5GZboUMXd2a0Uyjq3EB2kYfx
+hPQYOp3obhEy1JtodmJHAlqYqG8vAgMBAAGjUzBRMB0GA1UdDgQWBBRB2mlHlpxU
+LohkBQ2NH8rRhV9hQDAfBgNVHSMEGDAWgBRB2mlHlpxULohkBQ2NH8rRhV9hQDAP
+BgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCvghtILxg/BdFTS9ZA
+VarJrhSrEHSlJ2Bqp6v8BJmMpouU9heVhT24RdAx9nM46jZPem6Mt55ZQ+eyR7vK
+iC5T5yPWreaKEWnbS7YhxSTcLZOhMMZ4eah02f1lhYtiDF6u7p6zfY1HjZlJrbE4
+WNdOEcttJh8BTciSV2wuxD7iZNejN5L1wH+PATHTnuEuryksRhky4tOb7UiY7qkj
+M11jjUSojXBNqw754Na4vTz5hhjJo17NeB3hZw6N+r9flCGdTQZ4k02hx9+LbxcJ
+uVylGMusIXcohDauuPEBi/NXk0owHqF6uafjjW5lHK2CnsHKL8U0qHRdcKFJZ4Jx
+/gTV
+-----END CERTIFICATE-----`;
+const cert = new X509Certificate(pem);
+console.log("typeof X509Certificate:", typeof X509Certificate);
+console.log("subject:", JSON.stringify(cert["subject"]));
+console.log("issuer:", JSON.stringify(cert["issuer"]));
+console.log("validFrom:", cert["validFrom"]);
+console.log("validTo:", cert["validTo"]);
+console.log("serialNumber:", cert["serialNumber"]);
+console.log("fingerprint:", cert["fingerprint"]);
+console.log("fingerprint256:", cert["fingerprint256"]);
+console.log("ca:", cert["ca"]);
+console.log("raw length:", cert["raw"].length);


### PR DESCRIPTION
Closes #1367.

`crypto.X509Certificate` was "not a constructor". Now `new crypto.X509Certificate(pem | der)` parses a certificate (RustCrypto `x509-cert`, reusing the `der`/`spki`/`const-oid` already in the lock) and exposes Node's read-only properties **byte-identical** to `node --experimental-strip-types`:

`subject`, `issuer`, `validFrom`, `validTo`, `serialNumber`, `fingerprint` (sha1), `fingerprint256` (sha256), `ca` (BasicConstraints), `raw`.

## Implementation
- **perry-stdlib** (`crypto.rs`): `X509Handle` + `js_crypto_x509_new` (PEM/DER parse) + `dispatch_x509_property`, with Node-matching DN formatting (OID short-names, newline-joined), validity formatting (`MMM D HH:MM:SS YYYY GMT`, space-padded day), and uppercase colon-hex fingerprints. Routed through `js_handle_property_dispatch`.
- **perry-codegen**: `new X509Certificate(...)` arm in `lower_builtin_new` + runtime decl; HIR types the result `Any` (a runtime handle like ECDH, not a user class) so reads route via HANDLE_PROPERTY_DISPATCH.
- **perry-api-manifest**: `class("crypto","X509Certificate")` + regenerated `docs/api/perry.d.ts` + `docs/src/api/reference.md`.

## Tests
`test-parity/node-suite/crypto/x509/x509-certificate.ts` — byte-identical to Node in **both permissive and strict-API modes**. `cargo fmt --check` clean.

The repro reads properties via bracket access (`cert["subject"]`). The implementation is correct for dot access too, but `cert.subject` (a value-read dot on a handle local) currently returns 0 through the codegen PropertyGet fast path — the pre-existing **#1583** bug (which also gates #1537), not an X509 gap. The repro flips to dot once #1583 lands.

Follow-ups for the rest of the X509 surface (`publicKey` KeyObject, `verify`/`checkHost`/`subjectAltName`/`keyUsage`) can build on this handle.