### PR TITLE
feat(ui): Image({ systemName }) SF-symbol object form (#1495)

### DIFF
--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -1094,15 +1094,24 @@ pub(crate) fn lower_native_method_call(
         if let Some(props) = extract_options_fields(ctx, &args[0]) {
             let mut url_arg: Option<Expr> = None;
             let mut alt_arg: Option<Expr> = None;
+            let mut system_name_arg: Option<Expr> = None;
             for (key, val) in &props {
                 match key.as_str() {
                     "url" => url_arg = Some(val.clone()),
                     "alt" => alt_arg = Some(val.clone()),
+                    // #1495: Image({ systemName }) -> SF-symbol image,
+                    // routed to the same runtime as ImageSymbol(name).
+                    "systemName" => system_name_arg = Some(val.clone()),
                     _ => {
                         // Lower for side effects so any nested closures
                         // are still collected.
                         let _ = lower_expr(ctx, val)?;
                     }
+                }
+            }
+            if let Some(name) = system_name_arg {
+                if let Some(sig) = perry_ui_table_lookup("ImageSymbol") {
+                    return lower_perry_ui_table_call(ctx, sig, &[name]);
                 }
             }
             if let Some(u) = url_arg {

--- a/test-files/test_issue_1495_image_systemname.ts
+++ b/test-files/test_issue_1495_image_systemname.ts
@@ -1,0 +1,24 @@
+// Issue #1495 — Image({ systemName }) SF-symbol object form.
+//
+// The SF-symbol image widget already exists as ImageSymbol(name); this
+// wires the more ergonomic object-literal form Image({ systemName }) to
+// the same runtime (perry_ui_image_create_symbol), matching the existing
+// Image({ url, alt }) overload.
+//
+// Compile-smoke only (perry/ui renders a native window). Verified via the
+// emitted LLVM IR: Image({ systemName }) lowers to perry_ui_image_create_symbol,
+// identical to ImageSymbol(name); Image({ url }) still lowers to
+// perry_ui_image_create_url.
+import { App, VStack, Image, ImageSymbol } from "perry/ui";
+
+App({
+  title: "Symbol Test",
+  width: 300,
+  height: 200,
+  body: VStack([
+    Image({ systemName: "gear" }),
+    Image({ systemName: "star.fill" }),
+    ImageSymbol("bell"),
+    Image({ url: "https://example.com/a.png", alt: "A" }),
+  ]),
+});

--- a/types/perry/ui/index.d.ts
+++ b/types/perry/ui/index.d.ts
@@ -514,14 +514,18 @@ export function ImageSymbol(name: string): Widget;
  * ```ts
  * Image("https://example.com/avatar.png");
  * Image({ url: "https://example.com/avatar.png", alt: "Avatar" });
+ * Image({ systemName: "gear" }); // SF Symbol, same as ImageSymbol("gear")
  * ```
  *
- * (#635)
+ * (#635, #1495)
  */
 export function Image(url: string, alt?: string): Widget;
 export function Image(options: {
     url: string;
     alt?: string;
+}): Widget;
+export function Image(options: {
+    systemName: string;
 }): Widget;
 
 /**


### PR DESCRIPTION
Closes #1495.

## Summary

The SF-symbol image widget already exists as `ImageSymbol(name)` (types + dispatch row + `perry_ui_image_create_symbol` runtime). #1495 asked for the more ergonomic surface — an SF-symbol image via the same object-literal form used elsewhere. This wires `Image({ systemName })` to the existing symbol runtime, mirroring the existing `Image({ url, alt })` overload.

## Changes

- **`crates/perry-codegen/src/lower_call/native/mod.rs`** — the `Image({...})` object-literal destructure now recognizes a `systemName` field and routes to the `ImageSymbol` `UiSig` row (`perry_ui_image_create_symbol`), exactly the path `ImageSymbol(name)` takes.
- **`types/perry/ui/index.d.ts`** — add the `Image({ systemName })` overload.
- **`test-files/test_issue_1495_image_systemname.ts`** — compile-smoke repro.

No manifest/runtime changes — reuses the existing `ImageSymbol` row and `perry_ui_image_create_symbol` (so no api-docs regen needed).

## Verification

Emitted LLVM IR for the repro (2× `Image({ systemName })` + 1× `ImageSymbol(name)` + 1× `Image({ url })`):

```
   4 image_create_symbol   # 3 call sites + 1 declare
   2 image_create_url      # 1 call site  + 1 declare
```

`Image({ systemName })` and `ImageSymbol(name)` both lower to `perry_ui_image_create_symbol`; `Image({ url })` still lowers to `perry_ui_image_create_url`. The app compiles and links cleanly against `libperry_ui_macos.a`.