### PR TITLE
test(parity): stream — removeListener event, web strategies, pipe returns destination, objectMode read (#1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,29 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/remove-listener-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'removeListener' meta-event not emitted when removeListener() is called. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/strategies-imported": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: CountQueuingStrategy / ByteLengthQueuingStrategy not exported from node:stream/web. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/returns-destination": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: r.pipe(dst) does not return dst — pipe-chain broken. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/object-mode-read-returns-object": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: objectMode Readable.read() does not return single object per call. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/remove-listener-event.ts
+++ b/test-parity/node-suite/stream/events/remove-listener-event.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+// 'removeListener' is emitted when a listener is removed via removeListener().
+const r = new Readable({ read() {} });
+let fired = false;
+let firedEvent: string | null = null;
+r.on("removeListener", (event) => {
+  fired = true;
+  firedEvent = event;
+});
+const fn = () => {};
+r.on("data", fn);
+r.removeListener("data", fn);
+console.log("removeListener event fired:", fired);
+console.log("event name:", firedEvent);

--- a/test-parity/node-suite/stream/pipe/returns-destination.ts
+++ b/test-parity/node-suite/stream/pipe/returns-destination.ts
@@ -1,0 +1,12 @@
+import { Readable, PassThrough } from "node:stream";
+// readable.pipe(dst) returns dst (so you can chain `.pipe(next)`).
+const r = Readable.from(["x"]);
+const middle = new PassThrough();
+const sink = new PassThrough();
+const returned = r.pipe(middle);
+console.log("returned is middle:", returned === middle);
+// Chain pipe
+const chained = middle.pipe(sink);
+console.log("chained is sink:", chained === sink);
+sink.on("data", () => {});
+sink.on("end", () => console.log("done"));

--- a/test-parity/node-suite/stream/readable/object-mode-read-returns-object.ts
+++ b/test-parity/node-suite/stream/readable/object-mode-read-returns-object.ts
@@ -1,0 +1,16 @@
+import { Readable } from "node:stream";
+// In objectMode, read() returns ONE object at a time (not concatenated).
+const r = new Readable({
+  objectMode: true,
+  read() {
+    this.push({ a: 1 });
+    this.push({ b: 2 });
+    this.push(null);
+  },
+});
+r.on("readable", () => {
+  const first = r.read();
+  const second = r.read();
+  console.log("first:", JSON.stringify(first));
+  console.log("second:", JSON.stringify(second));
+});

--- a/test-parity/node-suite/stream/web/strategies-imported.ts
+++ b/test-parity/node-suite/stream/web/strategies-imported.ts
@@ -1,0 +1,13 @@
+import {
+  ReadableStream,
+  CountQueuingStrategy,
+  ByteLengthQueuingStrategy,
+} from "node:stream/web";
+// Both queuing strategy classes are exported from node:stream/web and
+// can be passed to ReadableStream constructor's 2nd arg.
+const c = new CountQueuingStrategy({ highWaterMark: 5 });
+const b = new ByteLengthQueuingStrategy({ highWaterMark: 1024 });
+console.log("count hwm:", c.highWaterMark);
+console.log("byte hwm:", b.highWaterMark);
+const rs = new ReadableStream({ start(c) { c.close(); } }, c);
+console.log("rs constructed:", rs instanceof ReadableStream);


### PR DESCRIPTION
### Iter-43 stream tests — removeListener event, web strategies, pipe returns destination, objectMode read

| Test | Tracking |
|---|---|
| `events/remove-listener-event` | #1532 — `'removeListener'` meta-event |
| `web/strategies-imported` | #1545 — Both `QueuingStrategy` classes from `node:stream/web` |
| `pipe/returns-destination` | #1532 — `r.pipe(dst)` returns dst |
| `readable/object-mode-read-returns-object` | #1532 — objectMode read() |

All 4 parity-fail — tracked in `known_failures.json`.
