### PR TITLE
test(parity): stream — from(Buffer), errorMonitor, map async reject, data-listener auto-resume (#1532/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,29 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/from-buffer-direct": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Buffer) — Buffer is iterated byte-by-byte instead of emitted as single chunk. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/error-monitor-symbol": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: events.errorMonitor symbol observer not invoked on stream error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/map-async-rejection": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: readable.map(asyncFn) — rejection in fn does not abort iteration / propagate as throw. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/events/data-listener-auto-resume": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: adding 'data' listener does not flip readableFlowing to true. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/data-listener-auto-resume.ts
+++ b/test-parity/node-suite/stream/events/data-listener-auto-resume.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// Adding a 'data' listener flips the stream into flowing mode (readableFlowing becomes true).
+const r = new Readable({ read() {} });
+console.log("flowing before:", r.readableFlowing);
+r.on("data", () => {});
+console.log("flowing after 'data':", r.readableFlowing);

--- a/test-parity/node-suite/stream/events/error-monitor-symbol.ts
+++ b/test-parity/node-suite/stream/events/error-monitor-symbol.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+import { errorMonitor } from "node:events";
+// errorMonitor is a symbol that lets you observe 'error' events WITHOUT
+// consuming them. Without the symbol you can't be both observer + listener.
+const r = new Readable({ read() {} });
+let observed = false;
+let consumed = false;
+r.on(errorMonitor, () => (observed = true));
+r.on("error", () => (consumed = true));
+r.destroy(new Error("watcher-test"));
+setImmediate(() => {
+  console.log("observed:", observed);
+  console.log("consumed:", consumed);
+});

--- a/test-parity/node-suite/stream/iter-helpers/map-async-rejection.ts
+++ b/test-parity/node-suite/stream/iter-helpers/map-async-rejection.ts
@@ -1,0 +1,17 @@
+import { Readable } from "node:stream";
+// readable.map(asyncFn) — when the async fn throws, the resulting iterable
+// rejects and iteration ends.
+const r = Readable.from([1, 2, 3]);
+const mapped = r.map(async (x: number) => {
+  if (x === 2) throw new Error("map-fail");
+  return x * 10;
+});
+const out: number[] = [];
+let err: string | null = null;
+try {
+  for await (const v of mapped as any) out.push(v as number);
+} catch (e: any) {
+  err = e && e.message;
+}
+console.log("out:", out.join(","));
+console.log("err:", err);

--- a/test-parity/node-suite/stream/readable/from-buffer-direct.ts
+++ b/test-parity/node-suite/stream/readable/from-buffer-direct.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Readable.from(Buffer) — Buffer is iterable so each byte is a chunk in
+// objectMode, BUT Node short-circuits and emits whole Buffer as one chunk.
+const r = Readable.from(Buffer.from("abc"));
+const chunks: any[] = [];
+r.on("data", (c) => chunks.push(c));
+r.on("end", () => {
+  console.log("chunk count:", chunks.length);
+  console.log("first chunk is buffer:", Buffer.isBuffer(chunks[0]));
+});


### PR DESCRIPTION
### Iter-44 stream tests — from(Buffer), errorMonitor, map async reject, auto-resume

| Test | Tracking |
|---|---|
| `readable/from-buffer-direct` | #1532 — `Readable.from(Buffer)` short-circuit |
| `events/error-monitor-symbol` | #1532 — `events.errorMonitor` observer |
| `iter-helpers/map-async-rejection` | #1558 — `map(asyncFn)` rejection |
| `events/data-listener-auto-resume` | #1532 — `'data'` listener flips flowing |

All 4 parity-fail — tracked in `known_failures.json`.
