### PR TITLE
test(parity): stream — asyncIter.next direct, end 3-arg, reduce no-initial, cancel-no-reader (1 free pass, 3 #1531/#1539/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/async-iter/iterator-next-direct": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: r[Symbol.asyncIterator]().next() — direct call doesn't yield correct {value, done} shape. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/writable/end-three-arg": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: end(chunk, encoding, callback) 3-arg form — cb does not fire after finish. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/iter-helpers/reduce-no-initial": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: reduce(fn) without initial — first item not used as accumulator. Flips to PASS when #1558 lands."
   }
 }

--- a/test-parity/node-suite/stream/async-iter/iterator-next-direct.ts
+++ b/test-parity/node-suite/stream/async-iter/iterator-next-direct.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// r[Symbol.asyncIterator]() returns an async iterator whose next() yields
+// {value, done} Promises.
+const r = Readable.from(["a", "b"]);
+const it = (r as any)[Symbol.asyncIterator]();
+const a = await it.next();
+const b = await it.next();
+const c = await it.next();
+console.log("a:", a.value, a.done);
+console.log("b:", b.value, b.done);
+console.log("c done:", c.done);

--- a/test-parity/node-suite/stream/iter-helpers/reduce-no-initial.ts
+++ b/test-parity/node-suite/stream/iter-helpers/reduce-no-initial.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// reduce(fn) without an initial value uses the first stream item as the
+// accumulator, then folds the rest.
+const r = Readable.from([1, 2, 3, 4]);
+const sum = await (r as any).reduce((acc: number, x: number) => acc + x);
+console.log("sum:", sum);

--- a/test-parity/node-suite/stream/web/cancel-no-reader.ts
+++ b/test-parity/node-suite/stream/web/cancel-no-reader.ts
@@ -1,0 +1,11 @@
+import { ReadableStream } from "node:stream/web";
+// rs.cancel() works directly without first calling getReader() — it
+// cancels the stream and rejects future reads.
+let cancelled = false;
+const rs = new ReadableStream({
+  start(c) { c.enqueue("x"); },
+  cancel() { cancelled = true; },
+});
+await rs.cancel("done");
+console.log("cancelled hook fired:", cancelled);
+console.log("locked after cancel:", rs.locked);

--- a/test-parity/node-suite/stream/writable/end-three-arg.ts
+++ b/test-parity/node-suite/stream/writable/end-three-arg.ts
@@ -1,0 +1,9 @@
+import { Writable } from "node:stream";
+// end(chunk, encoding, callback) — full 3-arg form: writes chunk with
+// encoding, then calls cb after finish.
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+let cbFired = false;
+w.end("done", "utf8", () => (cbFired = true));
+w.on("finish", () => {
+  setImmediate(() => console.log("end-cb fired:", cbFired));
+});


### PR DESCRIPTION
### Iter-45 stream tests — asyncIter.next direct, end 3-arg, reduce no-initial, cancel-no-reader

| Test | Status | Tracking |
|---|---|---|
| `async-iter/iterator-next-direct` | parity-fail | #1531 |
| `writable/end-three-arg` | parity-fail | #1539 |
| `iter-helpers/reduce-no-initial` | parity-fail | #1558 |
| `web/cancel-no-reader` | ✅ PASS | `rs.cancel()` without `getReader()` |

1 free pass + 3 known_failures-tracked.
