### PR TITLE
test(parity): stream — compose returns Duplex, destroyOnReturn default, read(0), read(N>buf) (1 free pass, 3 #1531/#1532)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/iterator/destroy-on-return-true-default": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: default destroyOnReturn:true — early break does not destroy stream. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/read-zero-probe": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read(0) probe — does not return null/trigger 'readable' without consuming. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/read-larger-than-buffered": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read(N>buffered) — does not return remaining buffered bytes at EOF. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/compose/returns-duplex-instance.ts
+++ b/test-parity/node-suite/stream/compose/returns-duplex-instance.ts
@@ -1,0 +1,9 @@
+import { compose, Duplex, Readable, Transform } from "node:stream";
+// compose(...) returns a Duplex — the composite stream is both Readable
+// and Writable from the outside, regardless of the inner components.
+const src = Readable.from(["a"]);
+const t = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+const composed: any = compose(src, t);
+console.log("instanceof Duplex:", composed instanceof Duplex);
+console.log("has write:", typeof composed.write === "function");
+console.log("has read:", typeof composed.read === "function");

--- a/test-parity/node-suite/stream/iterator/destroy-on-return-true-default.ts
+++ b/test-parity/node-suite/stream/iterator/destroy-on-return-true-default.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// The default for the iterator is destroyOnReturn: true — early-return
+// destroys the stream.
+const r = Readable.from(["a", "b", "c"]);
+let count = 0;
+for await (const _v of r) {
+  count++;
+  if (count === 1) break; // early return
+}
+setImmediate(() => {
+  console.log("destroyed after early break:", r.destroyed);
+});

--- a/test-parity/node-suite/stream/readable/read-larger-than-buffered.ts
+++ b/test-parity/node-suite/stream/readable/read-larger-than-buffered.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// When the requested size exceeds the buffered bytes (and end is reached),
+// read(N) returns whatever is buffered before EOF.
+const r = new Readable({ read() {} });
+r.push("hi");
+r.push(null);
+r.on("readable", () => {
+  const got = r.read(1000); // request way more than 2 bytes
+  console.log("got bytes:", got && got.length);
+  console.log("got string:", got && got.toString("utf8"));
+});

--- a/test-parity/node-suite/stream/readable/read-zero-probe.ts
+++ b/test-parity/node-suite/stream/readable/read-zero-probe.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// read(0) is a no-op probe — it does NOT consume bytes but may trigger
+// a 'readable' event when data is available.
+let readableFired = 0;
+const r = new Readable({ read() {} });
+r.on("readable", () => readableFired++);
+r.push("data");
+const r0 = r.read(0);
+console.log("read(0):", r0); // null — no consumption
+console.log("readable fired:", readableFired > 0);
+// data still available
+const remaining = r.read();
+console.log("remaining length:", remaining && remaining.length);


### PR DESCRIPTION
### Iter-46 stream tests — compose Duplex, destroyOnReturn default, read(0), read(N>buf)

| Test | Status | Tracking |
|---|---|---|
| `compose/returns-duplex-instance` | ✅ PASS | composite is Duplex instance |
| `iterator/destroy-on-return-true-default` | parity-fail | #1531 |
| `readable/read-zero-probe` | parity-fail | #1532 |
| `readable/read-larger-than-buffered` | parity-fail | #1532 |

1 free pass + 3 known_failures-tracked.
