### PR TITLE
test(parity): stream — find no-match, every/some empty, getDefaultHighWaterMark types (3 free pass, 1 #1532)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,11 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/static/get-default-hwm-types": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: getDefaultHighWaterMark(false|true) — return type or value mismatches Node (not Number or 0). Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/iter-helpers/every-empty-true.ts
+++ b/test-parity/node-suite/stream/iter-helpers/every-empty-true.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// every(fn) on an empty stream returns true (vacuously).
+const r = Readable.from([]);
+const result = await (r as any).every((_x: any) => false);
+console.log("every(empty) returns:", result);

--- a/test-parity/node-suite/stream/iter-helpers/find-no-match.ts
+++ b/test-parity/node-suite/stream/iter-helpers/find-no-match.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// find(fn) returns undefined when no item matches the predicate.
+const r = Readable.from([1, 2, 3, 4]);
+const result = await (r as any).find((x: number) => x > 10);
+console.log("found:", result);
+console.log("is undefined:", result === undefined);

--- a/test-parity/node-suite/stream/iter-helpers/some-empty-false.ts
+++ b/test-parity/node-suite/stream/iter-helpers/some-empty-false.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// some(fn) on an empty stream returns false (no item to match).
+const r = Readable.from([]);
+const result = await (r as any).some((_x: any) => true);
+console.log("some(empty) returns:", result);

--- a/test-parity/node-suite/stream/static/get-default-hwm-types.ts
+++ b/test-parity/node-suite/stream/static/get-default-hwm-types.ts
@@ -1,0 +1,9 @@
+import { getDefaultHighWaterMark } from "node:stream";
+// getDefaultHighWaterMark returns a number for both modes; check both
+// arities explicitly (boolean indicates objectMode).
+const std = getDefaultHighWaterMark(false);
+const obj = getDefaultHighWaterMark(true);
+console.log("std is number:", typeof std === "number");
+console.log("obj is number:", typeof obj === "number");
+console.log("std > 0:", std > 0);
+console.log("obj > 0:", obj > 0);


### PR DESCRIPTION
### Iter-47 stream tests — vacuous iter-helpers + getDefaultHighWaterMark

| Test | Status | Tracking |
|---|---|---|
| `iter-helpers/find-no-match` | ✅ PASS | returns `undefined` correctly |
| `iter-helpers/every-empty-true` | ✅ PASS | vacuously true on empty stream |
| `iter-helpers/some-empty-false` | ✅ PASS | vacuously false on empty stream |
| `static/get-default-hwm-types` | parity-fail | #1532 — return type/value |

**3 free passes** — Perry's iter-helpers handle vacuous edge cases correctly.
