### PR TITLE
test(parity): stream — pipeline async sink, newListener event, pipeTo locks, unshift after end (#1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,29 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipeline/async-fn-sink": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline(src, async fn) — fn-as-sink form not yet wired (cb not called, collected is empty). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/new-listener-meta-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'newListener' meta-event not emitted when a listener is added. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/pipe-to-locks-and-releases": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: pipeTo() does not flip rs/ws.locked true during, false after. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/unshift-after-end": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: unshift() after end — does not emit 'error' / ERR_STREAM_PUSH_AFTER_EOF. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/new-listener-meta-event.ts
+++ b/test-parity/node-suite/stream/events/new-listener-meta-event.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// 'newListener' is fired when a listener is added, BEFORE it joins the
+// listener list. Useful for hooking into setup.
+const r = new Readable({ read() {} });
+const seenEvents: string[] = [];
+r.on("newListener", (event) => seenEvents.push(event));
+r.on("data", () => {});
+r.on("end", () => {});
+console.log("newListener fired for:", seenEvents.join(","));

--- a/test-parity/node-suite/stream/pipeline/async-fn-sink.ts
+++ b/test-parity/node-suite/stream/pipeline/async-fn-sink.ts
@@ -1,0 +1,15 @@
+import { Readable, pipeline } from "node:stream";
+// pipeline(src, async fn) — fn receives the async-iterable source and
+// can collect or process it; pipeline calls the cb when fn resolves.
+const src = Readable.from(["a", "b", "c"]);
+const collected: string[] = [];
+pipeline(
+  src,
+  async function (source: AsyncIterable<any>) {
+    for await (const v of source) collected.push(String(v));
+  },
+  (err: any) => {
+    console.log("err:", err);
+    console.log("collected:", collected.join(","));
+  },
+);

--- a/test-parity/node-suite/stream/readable/unshift-after-end.ts
+++ b/test-parity/node-suite/stream/readable/unshift-after-end.ts
@@ -1,0 +1,17 @@
+import { Readable } from "node:stream";
+// unshift() after the stream has ended is documented as a no-op /
+// recoverable; in practice Node emits 'error' (ERR_STREAM_PUSH_AFTER_EOF).
+const r = new Readable({ read() {} });
+r.push("a");
+r.push(null);
+let errMsg: string | null = null;
+r.on("error", (err) => (errMsg = err && err.message));
+r.on("data", () => {});
+r.on("end", () => {
+  try {
+    r.unshift("late");
+  } catch (e: any) {
+    errMsg = e.message;
+  }
+  setImmediate(() => console.log("err:", errMsg));
+});

--- a/test-parity/node-suite/stream/web/pipe-to-locks-and-releases.ts
+++ b/test-parity/node-suite/stream/web/pipe-to-locks-and-releases.ts
@@ -1,0 +1,11 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// pipeTo() takes an internal reader/writer, so during the call rs.locked
+// and ws.locked are true; after completion the lock should release.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const ws = new WritableStream({ write() {} });
+const p = rs.pipeTo(ws);
+console.log("rs.locked during:", rs.locked);
+console.log("ws.locked during:", ws.locked);
+await p;
+console.log("rs.locked after:", rs.locked);
+console.log("ws.locked after:", ws.locked);


### PR DESCRIPTION
### Iter-48 stream tests — pipeline async sink, newListener event, pipeTo locks, unshift after end

| Test | Tracking |
|---|---|
| `pipeline/async-fn-sink` | #1532 |
| `events/new-listener-meta-event` | #1532 |
| `web/pipe-to-locks-and-releases` | #1545 |
| `readable/unshift-after-end` | #1532 |

All 4 parity-fail — tracked in `known_failures.json`.
