### PR TITLE
test(parity): stream — listenerCount, rawListeners-once, start-throw, emit multi-args (1 free pass, 3 #1532)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/listener-count-by-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: listenerCount(event) — returns wrong count per event name. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/raw-listeners-once-wrapped": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: rawListeners() — once-wrapper does not expose .listener pointing at original fn. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/emit-multiple-args-stream": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: emit(event, a, b, c) — listeners receive wrong number of args (variadic args lost). Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/emit-multiple-args-stream.ts
+++ b/test-parity/node-suite/stream/events/emit-multiple-args-stream.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// emit(event, a, b, c, ...) passes all args to each listener.
+const r = new Readable({ read() {} });
+let received: any[] = [];
+r.on("custom", (a: any, b: any, c: any) => {
+  received = [a, b, c];
+});
+r.emit("custom", 1, "two", { three: 3 });
+console.log("args:", JSON.stringify(received));

--- a/test-parity/node-suite/stream/events/listener-count-by-event.ts
+++ b/test-parity/node-suite/stream/events/listener-count-by-event.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// listenerCount(eventName) returns the number of registered listeners
+// for the given event (excludes future once()-removed wrappers count).
+const r = new Readable({ read() {} });
+r.on("data", () => {});
+r.on("data", () => {});
+r.once("end", () => {});
+console.log("data count:", r.listenerCount("data"));
+console.log("end count:", r.listenerCount("end"));
+console.log("error count:", r.listenerCount("error"));

--- a/test-parity/node-suite/stream/events/raw-listeners-once-wrapped.ts
+++ b/test-parity/node-suite/stream/events/raw-listeners-once-wrapped.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// rawListeners() returns the listener array INCLUDING the once-wrapper
+// for once() listeners (.listener points to the original fn).
+const r = new Readable({ read() {} });
+const fn = () => {};
+r.once("end", fn);
+const raw = r.rawListeners("end");
+console.log("raw length:", raw.length);
+console.log("raw[0] is wrapper:", (raw[0] as any).listener === fn);

--- a/test-parity/node-suite/stream/web/start-throw-rejects.ts
+++ b/test-parity/node-suite/stream/web/start-throw-rejects.ts
@@ -1,0 +1,16 @@
+import { ReadableStream } from "node:stream/web";
+// If the underlying source's start() throws (or returns a rejected
+// Promise), the stream errors and reads/cancel reject.
+const rs = new ReadableStream({
+  start() {
+    throw new Error("start-fail");
+  },
+});
+const reader = rs.getReader();
+let errMsg: string | null = null;
+try {
+  await reader.read();
+} catch (e: any) {
+  errMsg = e && e.message;
+}
+console.log("read rejected:", errMsg);


### PR DESCRIPTION
### Iter-49 stream tests — listenerCount, rawListeners-once, start-throw, emit multi-args

| Test | Status | Tracking |
|---|---|---|
| `events/listener-count-by-event` | parity-fail | #1532 |
| `events/raw-listeners-once-wrapped` | parity-fail | #1532 |
| `web/start-throw-rejects` | ✅ PASS | sink `start()` throw → read() rejects |
| `events/emit-multiple-args-stream` | parity-fail | #1532 |

1 free pass + 3 known_failures-tracked.
