### PR TITLE
test(parity): stream — reader Symbol.dispose, async compose handler, flow chunk separation, BYOB throws (1 free pass, 3 #1531/#1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/compose/async-handler-promise": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(src, asyncGenWithAwait) — async-await handler not iterated correctly. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/flow/multi-data-event-no-concat": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: flowing-mode push() yields concatenated chunk instead of separate 'data' events. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/byob-reader-getReader": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: getReader({mode:'byob'}) on non-byte stream does not throw TypeError. Flips to PASS when #1545 lands."
   }
 }

--- a/test-parity/node-suite/stream/compose/async-handler-promise.ts
+++ b/test-parity/node-suite/stream/compose/async-handler-promise.ts
@@ -1,0 +1,13 @@
+import { compose, Readable } from "node:stream";
+// compose() accepts an async-generator handler that awaits between yields.
+const src = Readable.from(["a", "b", "c"]);
+async function* slow(source: AsyncIterable<any>) {
+  for await (const c of source) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    yield String(c).toUpperCase();
+  }
+}
+const composed: any = compose(src, slow);
+const out: string[] = [];
+composed.on("data", (c: any) => out.push(String(c)));
+composed.on("end", () => console.log("composed-async:", out.join(",")));

--- a/test-parity/node-suite/stream/flow/multi-data-event-no-concat.ts
+++ b/test-parity/node-suite/stream/flow/multi-data-event-no-concat.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+// In flowing mode, each push() generally produces its own 'data' event
+// (chunks not concatenated unless buffered before listener attaches).
+const r = new Readable({ read() {} });
+const events: string[] = [];
+r.on("data", (c) => events.push(String(c)));
+r.on("end", () => {
+  console.log("event count:", events.length);
+  console.log("each event:", events.join(","));
+});
+r.push("a");
+r.push("b");
+r.push("c");
+r.push(null);

--- a/test-parity/node-suite/stream/web/byob-reader-getReader.ts
+++ b/test-parity/node-suite/stream/web/byob-reader-getReader.ts
@@ -1,0 +1,11 @@
+import { ReadableStream } from "node:stream/web";
+// getReader({ mode: "byob" }) returns a BYOB reader on byte streams.
+// Without type:'bytes', it should throw TypeError.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+let caught: string | null = null;
+try {
+  rs.getReader({ mode: "byob" } as any);
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("byob on non-byte stream throws:", caught);

--- a/test-parity/node-suite/stream/web/reader-symbol-dispose.ts
+++ b/test-parity/node-suite/stream/web/reader-symbol-dispose.ts
@@ -1,0 +1,6 @@
+import { ReadableStream } from "node:stream/web";
+// Web ReadableStreamDefaultReader exposes Symbol.dispose (Node 22+) so it
+// can be used with `using` declarations to auto-release the lock.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const reader = rs.getReader();
+console.log("has Symbol.dispose:", typeof (reader as any)[Symbol.dispose]);


### PR DESCRIPTION
### Iter-50 stream tests — reader Symbol.dispose, async compose, flow chunks, BYOB

| Test | Status | Tracking |
|---|---|---|
| `web/reader-symbol-dispose` | ✅ PASS | `Symbol.dispose` on Web reader (Node 22+) |
| `compose/async-handler-promise` | parity-fail | #1531 |
| `flow/multi-data-event-no-concat` | parity-fail | #1532 |
| `web/byob-reader-getReader` | parity-fail | #1545 |

1 free pass + 3 known_failures-tracked.

**Milestone**: this is the 20th PR in the iter-31..50 loop run; 80 new stream tests have been added, of which ~25% PASS against Node out of the box.
