### PR TITLE
test(parity): stream — removeAllListeners no-arg, map closure, AbortSignal.timeout, defaultEncoding (1 free pass, 3 #1532/#1539/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/remove-all-listeners-no-arg": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: removeAllListeners() with no arg — does not clear every event's listeners. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/map-with-thisarg": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: iter-helper closure capture — outer-var reference in arrow fn yields wrong values. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/options/default-encoding": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Writable defaultEncoding option — encoding arg seen by _write differs from 'hex'. Flips to PASS when #1539 lands."
   }
 }

--- a/test-parity/node-suite/stream/abort/signal-timeout.ts
+++ b/test-parity/node-suite/stream/abort/signal-timeout.ts
@@ -1,0 +1,11 @@
+import { Readable, pipeline } from "node:stream";
+// AbortSignal.timeout(ms) aborts after ms milliseconds; pipeline gets
+// the abort as an err.
+const signal = (AbortSignal as any).timeout(20);
+const src = new Readable({ read() {} }); // never pushes
+pipeline(src, async function* (s: AsyncIterable<any>) {
+  for await (const c of s) yield c;
+}, { signal }, (err: any) => {
+  console.log("err present:", !!err);
+  console.log("err name:", err && err.name);
+});

--- a/test-parity/node-suite/stream/events/remove-all-listeners-no-arg.ts
+++ b/test-parity/node-suite/stream/events/remove-all-listeners-no-arg.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// removeAllListeners() without an event name clears EVERY listener for
+// every event on the emitter.
+const r = new Readable({ read() {} });
+r.on("data", () => {});
+r.on("end", () => {});
+r.on("error", () => {});
+r.removeAllListeners();
+console.log("event names left:", r.eventNames().length);

--- a/test-parity/node-suite/stream/iter-helpers/map-with-thisarg.ts
+++ b/test-parity/node-suite/stream/iter-helpers/map-with-thisarg.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Iterator helpers accept { signal, concurrency } options but do NOT have
+// a thisArg in the options bag — fn binds normally. Confirm: arrow fn
+// referencing outer var works.
+const r = Readable.from([1, 2, 3]);
+const multiplier = 10;
+const mapped = r.map((x: any) => (x as number) * multiplier);
+const out: number[] = [];
+for await (const v of mapped as any) out.push(v);
+console.log("mapped:", out.join(","));

--- a/test-parity/node-suite/stream/options/default-encoding.ts
+++ b/test-parity/node-suite/stream/options/default-encoding.ts
@@ -1,0 +1,14 @@
+import { Writable } from "node:stream";
+// Writable's defaultEncoding option controls the encoding used when
+// write(chunk) is called without an explicit encoding arg.
+let seenEnc: any = null;
+const w = new Writable({
+  defaultEncoding: "hex",
+  write(_c, enc, cb) {
+    if (!seenEnc) seenEnc = enc;
+    cb();
+  },
+});
+w.write("abcdef");
+w.end();
+w.on("finish", () => console.log("default encoding:", seenEnc));


### PR DESCRIPTION
### Iter-51 stream tests — removeAllListeners no-arg, map closure, AbortSignal.timeout, defaultEncoding

| Test | Status | Tracking |
|---|---|---|
| `events/remove-all-listeners-no-arg` | parity-fail | #1532 |
| `iter-helpers/map-with-thisarg` | parity-fail | #1558 |
| `abort/signal-timeout` | ✅ PASS | `AbortSignal.timeout(ms)` aborts pipeline |
| `options/default-encoding` | parity-fail | #1539 |

1 free pass + 3 known_failures-tracked.
