### PR TITLE
test(parity): stream — eventNames, getMaxListeners default, Readable no-read-fn, instanceof EE (1 free pass, 3 #1531/#1532)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/event-names-returns-array": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: eventNames() — returns wrong shape or missing event names. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/get-max-listeners-default": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: getMaxListeners() default — not 10, or EventEmitter.defaultMaxListeners differs. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/classes/readable-no-read-fn": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: new Readable({}) without read fn — push-based usage produces wrong output. Flips to PASS when #1531 lands."
   }
 }

--- a/test-parity/node-suite/stream/classes/readable-no-read-fn.ts
+++ b/test-parity/node-suite/stream/classes/readable-no-read-fn.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// new Readable({}) — no read fn — works for purely push-based usage.
+// (Calling read() emits 'error' with ERR_METHOD_NOT_IMPLEMENTED only in
+// pull mode; here we push, so no error.)
+const r = new Readable({});
+const out: string[] = [];
+r.on("data", (c) => out.push(String(c)));
+r.on("end", () => console.log("out:", out.join(",")));
+r.on("error", () => {});
+r.push("a");
+r.push("b");
+r.push(null);

--- a/test-parity/node-suite/stream/events/event-names-returns-array.ts
+++ b/test-parity/node-suite/stream/events/event-names-returns-array.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// eventNames() returns the array of event names currently with at least
+// one listener (string + symbol entries).
+const r = new Readable({ read() {} });
+r.on("data", () => {});
+r.on("end", () => {});
+const names = r.eventNames();
+console.log("is array:", Array.isArray(names));
+console.log("count:", names.length);
+console.log("has data:", names.includes("data"));
+console.log("has end:", names.includes("end"));

--- a/test-parity/node-suite/stream/events/get-max-listeners-default.ts
+++ b/test-parity/node-suite/stream/events/get-max-listeners-default.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { EventEmitter } from "node:events";
+// getMaxListeners() returns Number; default is EventEmitter.defaultMaxListeners (10).
+const r = new Readable({ read() {} });
+console.log("default:", r.getMaxListeners());
+console.log("is number:", typeof r.getMaxListeners() === "number");
+console.log("EE default:", EventEmitter.defaultMaxListeners);

--- a/test-parity/node-suite/stream/meta/instanceof-eventemitter.ts
+++ b/test-parity/node-suite/stream/meta/instanceof-eventemitter.ts
@@ -1,0 +1,13 @@
+import { Readable, Writable, Duplex, Transform, PassThrough } from "node:stream";
+import { EventEmitter } from "node:events";
+// All Node stream classes inherit from EventEmitter.
+const r = new Readable({ read() {} });
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+const d = new Duplex({ read() {}, write(_c, _e, cb) { cb(); } });
+const t = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+const p = new PassThrough();
+console.log("R:", r instanceof EventEmitter);
+console.log("W:", w instanceof EventEmitter);
+console.log("D:", d instanceof EventEmitter);
+console.log("T:", t instanceof EventEmitter);
+console.log("P:", p instanceof EventEmitter);


### PR DESCRIPTION
### Iter-52 stream tests — eventNames, getMaxListeners, Readable no-read-fn, instanceof EE

| Test | Status | Tracking |
|---|---|---|
| `events/event-names-returns-array` | parity-fail | #1532 |
| `events/get-max-listeners-default` | parity-fail | #1532 |
| `classes/readable-no-read-fn` | parity-fail | #1531 |
| `meta/instanceof-eventemitter` | ✅ PASS | 5 stream classes inherit EventEmitter |

1 free pass + 3 known_failures-tracked.
