### PR TITLE
test(parity): stream — from(Map), from(Set), PassThrough hierarchy, WritableStream no-args (1 free pass, 3 #1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/from-map-entries": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Map) — entry tuples not yielded correctly. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-set-values": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Set) — values not iterated in insertion order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/writable-stream-no-args": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: new WritableStream() (no sink) — constructor or write() misbehaves. Flips to PASS when #1545 lands."
   }
 }

--- a/test-parity/node-suite/stream/classes/passthrough-extends-transform.ts
+++ b/test-parity/node-suite/stream/classes/passthrough-extends-transform.ts
@@ -1,0 +1,8 @@
+import { PassThrough, Transform, Duplex, Readable, Writable } from "node:stream";
+// PassThrough extends Transform → Duplex → Readable + Writable.
+const p = new PassThrough();
+console.log("instanceof PassThrough:", p instanceof PassThrough);
+console.log("instanceof Transform:", p instanceof Transform);
+console.log("instanceof Duplex:", p instanceof Duplex);
+console.log("instanceof Readable:", p instanceof Readable);
+console.log("instanceof Writable:", p instanceof Writable);

--- a/test-parity/node-suite/stream/readable/from-map-entries.ts
+++ b/test-parity/node-suite/stream/readable/from-map-entries.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// Readable.from(Map) iterates entries (since Map is iterable yielding [k, v]).
+const m = new Map<string, number>([
+  ["a", 1],
+  ["b", 2],
+]);
+const r = Readable.from(m);
+const out: string[] = [];
+for await (const v of r) {
+  out.push(JSON.stringify(v));
+}
+console.log("entries:", out.join("|"));

--- a/test-parity/node-suite/stream/readable/from-set-values.ts
+++ b/test-parity/node-suite/stream/readable/from-set-values.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Readable.from(Set) iterates the set values in insertion order.
+const s = new Set([10, 20, 30]);
+const r = Readable.from(s);
+const out: number[] = [];
+for await (const v of r) {
+  out.push(v as number);
+}
+console.log("values:", out.join(","));

--- a/test-parity/node-suite/stream/web/writable-stream-no-args.ts
+++ b/test-parity/node-suite/stream/web/writable-stream-no-args.ts
@@ -1,0 +1,9 @@
+import { WritableStream } from "node:stream/web";
+// `new WritableStream()` with no underlying sink should still construct
+// — writes are silently dropped (the default sink swallows everything).
+const ws = new WritableStream();
+const w = ws.getWriter();
+await w.write("x");
+await w.close();
+console.log("locked:", ws.locked);
+console.log("constructed:", ws instanceof WritableStream);


### PR DESCRIPTION
### Iter-53 stream tests — from(Map/Set), PassThrough hierarchy, WritableStream no-args

| Test | Status | Tracking |
|---|---|---|
| `readable/from-map-entries` | parity-fail | #1532 |
| `readable/from-set-values` | parity-fail | #1532 |
| `classes/passthrough-extends-transform` | ✅ PASS | Full class chain inheritance |
| `web/writable-stream-no-args` | parity-fail | #1545 |

1 free pass + 3 known_failures-tracked.
