### PR TITLE
test(parity): stream — multi-pipe, on() chain, pause-resume cycle, cork return (#1532/#1539)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,29 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/pipe-multiple-destinations": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe to multiple destinations — data delivered to only one or wrong counts. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/on-returns-this-chained": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: on() chained — return value not the emitter, breaking chained registration. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/flow/pause-resume-cycle": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: readableFlowing — does not track pause→flow→pause transitions correctly. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/cork-returns-undefined": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: cork()/uncork() return values differ from undefined. Flips to PASS when #1539 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/on-returns-this-chained.ts
+++ b/test-parity/node-suite/stream/events/on-returns-this-chained.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// on() returns the emitter itself, enabling chained registrations.
+const r = new Readable({ read() {} });
+const chained = r.on("data", () => {}).on("end", () => {});
+console.log("chained is r:", chained === r);
+console.log("data listeners:", r.listenerCount("data"));
+console.log("end listeners:", r.listenerCount("end"));

--- a/test-parity/node-suite/stream/flow/pause-resume-cycle.ts
+++ b/test-parity/node-suite/stream/flow/pause-resume-cycle.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// A stream can cycle through paused → flowing → paused. The
+// readableFlowing getter reflects each state.
+const r = new Readable({ read() {} });
+console.log("initial:", r.readableFlowing);
+r.on("data", () => {});
+console.log("after data:", r.readableFlowing);
+r.pause();
+console.log("after pause:", r.readableFlowing);
+r.resume();
+console.log("after resume:", r.readableFlowing);

--- a/test-parity/node-suite/stream/pipe/pipe-multiple-destinations.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-multiple-destinations.ts
@@ -1,0 +1,17 @@
+import { Readable, PassThrough } from "node:stream";
+// One source can pipe to multiple destinations; each gets the data.
+const r = Readable.from(["x"]);
+const a = new PassThrough();
+const b = new PassThrough();
+let aGot = 0, bGot = 0;
+a.on("data", () => aGot++);
+b.on("data", () => bGot++);
+let endCount = 0;
+const checkDone = () => {
+  endCount++;
+  if (endCount === 2) console.log("a:", aGot, "b:", bGot);
+};
+a.on("end", checkDone);
+b.on("end", checkDone);
+r.pipe(a);
+r.pipe(b);

--- a/test-parity/node-suite/stream/writable/cork-returns-undefined.ts
+++ b/test-parity/node-suite/stream/writable/cork-returns-undefined.ts
@@ -1,0 +1,8 @@
+import { Writable } from "node:stream";
+// cork() and uncork() return undefined (per Node docs) — they are NOT
+// chainable like on().
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+const corkResult = w.cork();
+const uncorkResult = w.uncork();
+console.log("cork returns undefined:", corkResult === undefined);
+console.log("uncork returns undefined:", uncorkResult === undefined);


### PR DESCRIPTION
### Iter-54 stream tests — multi-pipe, on() chain, pause-resume cycle, cork return

| Test | Tracking |
|---|---|
| `pipe/pipe-multiple-destinations` | #1532 |
| `events/on-returns-this-chained` | #1532 |
| `flow/pause-resume-cycle` | #1532 |
| `writable/cork-returns-undefined` | #1539 |

All 4 parity-fail — tracked in `known_failures.json`.
