### PR TITLE
test(parity): stream — pre-listener pause, unshift length, transform wiring, Symbol listener count (#1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,29 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/flow/pause-before-data-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pause() before 'data' listener — flow starts anyway when listener attached. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/unshift-increases-length": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: unshift() — readableLength does not grow by chunk size. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/transform-readable-writable-wired": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: TransformStream.readable/.writable not correctly typed as ReadableStream/WritableStream instances. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/listener-count-symbol-events": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: listenerCount(Symbol) — does not count Symbol-keyed listeners. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/listener-count-symbol-events.ts
+++ b/test-parity/node-suite/stream/events/listener-count-symbol-events.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+import { errorMonitor } from "node:events";
+// listenerCount works with Symbol event names too (e.g., errorMonitor).
+const r = new Readable({ read() {} });
+r.on(errorMonitor, () => {});
+r.on(errorMonitor, () => {});
+console.log("symbol count:", r.listenerCount(errorMonitor));
+console.log("string-event count for data:", r.listenerCount("data"));

--- a/test-parity/node-suite/stream/flow/pause-before-data-listener.ts
+++ b/test-parity/node-suite/stream/flow/pause-before-data-listener.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Calling pause() before adding a 'data' listener prevents the stream
+// from auto-flowing when the listener is later added.
+const r = Readable.from(["a", "b", "c"]);
+r.pause();
+let count = 0;
+r.on("data", () => count++);
+setImmediate(() => {
+  console.log("count while paused:", count);
+  console.log("flowing:", r.readableFlowing);
+});

--- a/test-parity/node-suite/stream/readable/unshift-increases-length.ts
+++ b/test-parity/node-suite/stream/readable/unshift-increases-length.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// unshift() should increase readableLength (it adds buffered bytes).
+const r = new Readable({ read() {} });
+r.push("hello");
+const before = r.readableLength;
+r.unshift("xx");
+const after = r.readableLength;
+console.log("before:", before);
+console.log("after:", after);
+console.log("grew:", after > before);

--- a/test-parity/node-suite/stream/web/transform-readable-writable-wired.ts
+++ b/test-parity/node-suite/stream/web/transform-readable-writable-wired.ts
@@ -1,0 +1,7 @@
+import { TransformStream, ReadableStream, WritableStream } from "node:stream/web";
+// TransformStream exposes .readable (ReadableStream) and .writable
+// (WritableStream) sides; they're correctly typed instances.
+const ts = new TransformStream();
+console.log("readable instanceof ReadableStream:", ts.readable instanceof ReadableStream);
+console.log("writable instanceof WritableStream:", ts.writable instanceof WritableStream);
+console.log("readable !== writable:", ts.readable !== (ts.writable as any));


### PR DESCRIPTION
### Iter-55 stream tests — pre-listener pause, unshift length, transform wiring, Symbol listener count

| Test | Tracking |
|---|---|
| `flow/pause-before-data-listener` | #1532 |
| `readable/unshift-increases-length` | #1532 |
| `web/transform-readable-writable-wired` | #1545 |
| `events/listener-count-symbol-events` | #1532 |

All 4 parity-fail — tracked in `known_failures.json`.
