### PR TITLE
test(parity): stream — prepend-once, compose chain, writable strategy-only, readable-listener drain (#1531/#1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,29 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/prepend-once-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: prependOnceListener — wrong order or no auto-removal after firing. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/instance-chain": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: r.compose(t1).compose(t2) — chained compose() returns Duplex but pipeline breaks. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/web/writable-stream-strategy-only": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: WritableStream(undefined, strategy) — second-arg-only constructor form fails. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/read-in-readable-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read() inside 'readable' listener — while-loop drain pattern produces wrong output. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/compose/instance-chain.ts
+++ b/test-parity/node-suite/stream/compose/instance-chain.ts
@@ -1,0 +1,9 @@
+import { Readable, Transform } from "node:stream";
+// readable.compose(t1).compose(t2) chains transforms (compose() returns Duplex).
+const r = Readable.from(["a", "b"]);
+const up = new Transform({ transform(c, _e, cb) { cb(null, String(c).toUpperCase()); } });
+const exclaim = new Transform({ transform(c, _e, cb) { cb(null, String(c) + "!"); } });
+const chained: any = (r as any).compose(up).compose(exclaim);
+const out: string[] = [];
+chained.on("data", (c: any) => out.push(String(c)));
+chained.on("end", () => console.log("chained:", out.join(",")));

--- a/test-parity/node-suite/stream/events/prepend-once-listener.ts
+++ b/test-parity/node-suite/stream/events/prepend-once-listener.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// prependOnceListener inserts the listener at the front and removes it
+// after one firing.
+const r = new Readable({ read() {} });
+const order: string[] = [];
+r.on("custom", () => order.push("on"));
+r.prependOnceListener("custom", () => order.push("prepend-once"));
+r.emit("custom");
+r.emit("custom"); // prepend-once should not fire again
+console.log("order:", order.join(","));
+console.log("count after 2 emits:", order.length);

--- a/test-parity/node-suite/stream/readable/read-in-readable-listener.ts
+++ b/test-parity/node-suite/stream/readable/read-in-readable-listener.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Common pattern: drain inside 'readable' listener via while-loop of read().
+const r = new Readable({ read() {} });
+r.push("aa");
+r.push("bb");
+r.push("cc");
+r.push(null);
+const out: string[] = [];
+r.on("readable", () => {
+  let c;
+  while ((c = r.read()) !== null) out.push(String(c));
+});
+r.on("end", () => console.log("drained:", out.join("|")));

--- a/test-parity/node-suite/stream/web/writable-stream-strategy-only.ts
+++ b/test-parity/node-suite/stream/web/writable-stream-strategy-only.ts
@@ -1,0 +1,6 @@
+import { WritableStream, CountQueuingStrategy } from "node:stream/web";
+// WritableStream(undefined, strategy) — uses default sink with custom strategy.
+const strategy = new CountQueuingStrategy({ highWaterMark: 7 });
+const ws = new WritableStream(undefined, strategy);
+console.log("locked:", ws.locked);
+console.log("constructed:", ws instanceof WritableStream);


### PR DESCRIPTION
### Iter-56 stream tests — prepend-once, compose chain, writable strategy-only, readable-listener drain

| Test | Tracking |
|---|---|
| `events/prepend-once-listener` | #1532 |
| `compose/instance-chain` | #1531 |
| `web/writable-stream-strategy-only` | #1545 |
| `readable/read-in-readable-listener` | #1532 |

All 4 parity-fail — tracked in `known_failures.json`.
