### PR TITLE
test(parity): stream — transform multi-out, web async transform, read-before-push, eventNames order (1 free pass, 3 #1532/#1539)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/transform/multi-output-per-input": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Transform pushing multiple outputs per single input — only first push consumed. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/readable/read-before-push": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read() before any push — should return null, returns wrong value. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/event-names-order-insertion": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: eventNames() — order does not match listener-insertion order. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/event-names-order-insertion.ts
+++ b/test-parity/node-suite/stream/events/event-names-order-insertion.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// eventNames() returns events in insertion order (the order in which
+// the first listener was registered).
+const r = new Readable({ read() {} });
+r.on("zeta", () => {});
+r.on("alpha", () => {});
+r.on("middle", () => {});
+const names = r.eventNames();
+console.log("names:", names.join(","));
+console.log("first is zeta:", names[0] === "zeta");

--- a/test-parity/node-suite/stream/readable/read-before-push.ts
+++ b/test-parity/node-suite/stream/readable/read-before-push.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// read() before any push is non-flowing — should return null
+// because there's no buffered data yet.
+const r = new Readable({ read() {} });
+const first = r.read();
+console.log("read before push:", first);
+console.log("is null:", first === null);

--- a/test-parity/node-suite/stream/transform/multi-output-per-input.ts
+++ b/test-parity/node-suite/stream/transform/multi-output-per-input.ts
@@ -1,0 +1,14 @@
+import { Transform } from "node:stream";
+// A transform can push multiple outputs per single input by calling
+// this.push() multiple times before invoking cb().
+const splitter = new Transform({
+  transform(chunk, _enc, cb) {
+    for (const c of String(chunk)) this.push(c);
+    cb();
+  },
+});
+const out: string[] = [];
+splitter.on("data", (c) => out.push(String(c)));
+splitter.on("end", () => console.log("split:", out.join(",")));
+splitter.write("abc");
+splitter.end();

--- a/test-parity/node-suite/stream/web/transform-async-transform-fn.ts
+++ b/test-parity/node-suite/stream/web/transform-async-transform-fn.ts
@@ -1,0 +1,15 @@
+import { TransformStream } from "node:stream/web";
+// transform() can be async — returning a Promise that resolves when the
+// transform is complete. Pull-side reader awaits accordingly.
+const ts = new TransformStream({
+  async transform(chunk, ctrl) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    ctrl.enqueue(String(chunk).toUpperCase());
+  },
+});
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("ab");
+await writer.close();
+const { value } = await reader.read();
+console.log("got:", value);


### PR DESCRIPTION
### Iter-57 stream tests — transform multi-out, web async transform, read-before-push, eventNames order

| Test | Status | Tracking |
|---|---|---|
| `transform/multi-output-per-input` | parity-fail | #1539 |
| `web/transform-async-transform-fn` | ✅ PASS | async `transform()` fn |
| `readable/read-before-push` | parity-fail | #1532 |
| `events/event-names-order-insertion` | parity-fail | #1532 |

1 free pass + 3 known_failures-tracked.
