### PR TITLE
test(parity): stream — read(N) exact, Symbol.dispose call, end-chunk ordering, sequential reads (1 free pass, 3 #1532/#1539)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/read-n-consumes-exactly-n": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read(N) — consumes wrong byte count from buffered stream. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/end-with-chunk-writes-before-finish": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: end(chunk) ordering — chunk write happens after 'finish' event or not at all. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/flow/sequential-reads": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: sequential read(N) drain — buffer order or chunk boundaries wrong. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/dispose/sync-dispose-call.ts
+++ b/test-parity/node-suite/stream/dispose/sync-dispose-call.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Calling Symbol.dispose on a stream destroys it synchronously (Node 21+).
+const r = new Readable({ read() {} });
+r.on("error", () => {});
+const dispose = (r as any)[Symbol.dispose];
+if (typeof dispose === "function") {
+  dispose.call(r);
+  setImmediate(() => {
+    console.log("destroyed after Symbol.dispose:", r.destroyed);
+  });
+} else {
+  console.log("Symbol.dispose not available, typeof:", typeof dispose);
+}

--- a/test-parity/node-suite/stream/flow/sequential-reads.ts
+++ b/test-parity/node-suite/stream/flow/sequential-reads.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Multiple sequential read() calls drain the buffer in order.
+const r = new Readable({ read() {} });
+r.push("aa");
+r.push("bb");
+r.push("cc");
+r.push(null);
+const out: string[] = [];
+r.on("readable", () => {
+  let c;
+  while ((c = r.read(2)) !== null) out.push(String(c));
+});
+r.on("end", () => console.log("sequential:", out.join("|")));

--- a/test-parity/node-suite/stream/readable/read-n-consumes-exactly-n.ts
+++ b/test-parity/node-suite/stream/readable/read-n-consumes-exactly-n.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// read(N) consumes exactly N bytes (when available) from the front of
+// the buffer; subsequent reads consume the next N bytes.
+const r = new Readable({ read() {} });
+r.push("hello");
+const first = r.read(2);
+const second = r.read(2);
+const third = r.read();
+console.log("first:", first && first.toString("utf8"));
+console.log("second:", second && second.toString("utf8"));
+console.log("third:", third && third.toString("utf8"));

--- a/test-parity/node-suite/stream/writable/end-with-chunk-writes-before-finish.ts
+++ b/test-parity/node-suite/stream/writable/end-with-chunk-writes-before-finish.ts
@@ -1,0 +1,15 @@
+import { Writable } from "node:stream";
+// end(chunk) — the chunk is written BEFORE 'finish' fires.
+const order: string[] = [];
+const w = new Writable({
+  write(c, _e, cb) {
+    order.push("write:" + String(c));
+    cb();
+  },
+});
+w.on("finish", () => {
+  order.push("finish");
+  console.log("order:", order.join(","));
+  console.log("write before finish:", order.indexOf("write:end-chunk") < order.indexOf("finish"));
+});
+w.end("end-chunk");


### PR DESCRIPTION
### Iter-58 stream tests — read(N) exact, Symbol.dispose call, end-chunk ordering, sequential reads

| Test | Status | Tracking |
|---|---|---|
| `readable/read-n-consumes-exactly-n` | parity-fail | #1532 |
| `dispose/sync-dispose-call` | ✅ PASS | `Symbol.dispose()` destroys stream |
| `writable/end-with-chunk-writes-before-finish` | parity-fail | #1539 |
| `flow/sequential-reads` | parity-fail | #1532 |

1 free pass + 3 known_failures-tracked.
