### PR TITLE
test(parity): stream — getEventListeners static, compose handler reject, pause-during-iter, Web pull pacing (1 free pass, 3 #1531/#1532)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/get-event-listeners-static": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: events.getEventListeners(emitter, event) — wrong listener array. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/async-iter-handler-rejection": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose() async-gen handler throw — composite does not emit 'error'. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/flow/pause-during-async-iter": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pause() inside for-await — affects iteration count incorrectly. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/compose/async-iter-handler-rejection.ts
+++ b/test-parity/node-suite/stream/compose/async-iter-handler-rejection.ts
@@ -1,0 +1,11 @@
+import { compose, Readable } from "node:stream";
+// An async-generator handler that throws — the composite emits 'error'.
+async function* failing(_src: AsyncIterable<any>) {
+  yield "a";
+  throw new Error("handler-fail");
+}
+const composite: any = compose(Readable.from(["x"]), failing);
+let errMsg: string | null = null;
+composite.on("error", (e: any) => (errMsg = e && e.message));
+composite.on("data", () => {});
+composite.on("close", () => console.log("err:", errMsg));

--- a/test-parity/node-suite/stream/events/get-event-listeners-static.ts
+++ b/test-parity/node-suite/stream/events/get-event-listeners-static.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+import { getEventListeners } from "node:events";
+// events.getEventListeners(emitter, event) returns the array of listeners
+// for the named event on the emitter.
+const r = new Readable({ read() {} });
+const fn1 = () => {};
+const fn2 = () => {};
+r.on("custom", fn1);
+r.on("custom", fn2);
+const listeners = getEventListeners(r, "custom");
+console.log("count:", listeners.length);
+console.log("is array:", Array.isArray(listeners));
+console.log("contains fn1:", listeners.includes(fn1));
+console.log("contains fn2:", listeners.includes(fn2));

--- a/test-parity/node-suite/stream/flow/pause-during-async-iter.ts
+++ b/test-parity/node-suite/stream/flow/pause-during-async-iter.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Calling pause() between two async-iter steps shouldn't stop iteration
+// (the iterator pulls regardless of the flowing flag).
+const r = Readable.from(["a", "b", "c"]);
+const out: string[] = [];
+for await (const v of r) {
+  out.push(String(v));
+  r.pause();
+}
+console.log("iterated:", out.join(","));
+console.log("count:", out.length);

--- a/test-parity/node-suite/stream/web/pull-promise-controls-pace.ts
+++ b/test-parity/node-suite/stream/web/pull-promise-controls-pace.ts
@@ -1,0 +1,20 @@
+import { ReadableStream } from "node:stream/web";
+// pull() returning a Promise paces the enqueue — the stream waits for
+// pull's Promise to resolve before requesting the next pull.
+let pulled = 0;
+const rs = new ReadableStream({
+  async pull(c) {
+    pulled++;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    c.enqueue(pulled);
+    if (pulled >= 3) c.close();
+  },
+});
+const reader = rs.getReader();
+const out: number[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(value);
+}
+console.log("pulled:", out.join(","));


### PR DESCRIPTION
### Iter-59 stream tests — getEventListeners static, compose handler reject, pause-during-iter, Web pull pacing

| Test | Status | Tracking |
|---|---|---|
| `events/get-event-listeners-static` | parity-fail | #1532 |
| `compose/async-iter-handler-rejection` | parity-fail | #1531 |
| `flow/pause-during-async-iter` | parity-fail | #1532 |
| `web/pull-promise-controls-pace` | ✅ PASS | `pull()` Promise paces enqueue |

1 free pass + 3 known_failures-tracked.
