### PR TITLE
test(parity): stream — RS.from non-iter throws, pipe dest-err, destroy ordering, TS xform error (2 free pass, 2 #1532)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,17 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/dest-error-propagates": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe error semantics — destination error or source close state differs from Node. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/error-before-data-immediate-destroy": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: immediate destroy(err) — event ordering/set ('data'/'end' should NOT fire) wrong. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/error-before-data-immediate-destroy.ts
+++ b/test-parity/node-suite/stream/events/error-before-data-immediate-destroy.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// If destroy() is called before any data is pushed, only 'error' (if err
+// supplied) and 'close' fire; no 'data' or 'end'.
+const r = new Readable({ read() {} });
+const events: string[] = [];
+r.on("data", () => events.push("data"));
+r.on("end", () => events.push("end"));
+r.on("error", () => events.push("error"));
+r.on("close", () => events.push("close"));
+r.destroy(new Error("immediate-destroy"));
+setImmediate(() => console.log("events:", events.join(",")));

--- a/test-parity/node-suite/stream/pipe/dest-error-propagates.ts
+++ b/test-parity/node-suite/stream/pipe/dest-error-propagates.ts
@@ -1,0 +1,19 @@
+import { Readable, Writable } from "node:stream";
+// When the destination errors, the source's 'unpipe' fires and downstream
+// stops. Pipe alone does NOT propagate the error back to source by default.
+let srcDestroyed = false;
+const src = new Readable({ read() {} });
+src.on("close", () => (srcDestroyed = true));
+const dst = new Writable({
+  write(_c, _e, cb) { cb(new Error("write-fail")); },
+});
+let dstErr: string | null = null;
+dst.on("error", (e) => (dstErr = e && e.message));
+src.pipe(dst);
+src.push("x");
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("dst err:", dstErr);
+    console.log("src destroyed (pipe alone shouldn't):", srcDestroyed);
+  });
+});

--- a/test-parity/node-suite/stream/web/readable-stream-from-non-iterable.ts
+++ b/test-parity/node-suite/stream/web/readable-stream-from-non-iterable.ts
@@ -1,0 +1,11 @@
+import { ReadableStream } from "node:stream/web";
+// ReadableStream.from(non-iterable) — should throw TypeError because
+// the argument doesn't have Symbol.iterator or Symbol.asyncIterator.
+let caught: string | null = null;
+try {
+  (ReadableStream as any).from(42);
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/web/transform-error-propagates.ts
+++ b/test-parity/node-suite/stream/web/transform-error-propagates.ts
@@ -1,0 +1,22 @@
+import { TransformStream } from "node:stream/web";
+// A throw in transform() aborts both the readable and writable sides;
+// further reads should reject.
+const ts = new TransformStream({
+  transform() { throw new Error("xform-boom"); },
+});
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+let writeErr: string | null = null;
+let readErr: string | null = null;
+try {
+  await writer.write("x");
+} catch (e: any) {
+  writeErr = e && e.message;
+}
+try {
+  await reader.read();
+} catch (e: any) {
+  readErr = e && e.message;
+}
+console.log("write rejected:", writeErr);
+console.log("read rejected:", readErr);


### PR DESCRIPTION
### Iter-60 stream tests — RS.from non-iter throws, pipe dest-err, destroy ordering, TS xform error

| Test | Status | Tracking |
|---|---|---|
| `web/readable-stream-from-non-iterable` | ✅ PASS | throws TypeError as documented |
| `pipe/dest-error-propagates` | parity-fail | #1532 |
| `events/error-before-data-immediate-destroy` | parity-fail | #1532 |
| `web/transform-error-propagates` | ✅ PASS | throw in transform aborts both sides |

2 free passes + 2 known_failures-tracked.

**Milestone**: iter-60 closes out 30 PRs in this loop run (#1568–#1622), with ~120 stream tests added across them.
