### PR TITLE
test(parity): stream — Stream proto EE, cancel undef Promise, autoDestroy default, NaN strategy (#1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,29 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/meta/stream-prototype-ee": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Stream class default export prototype chain doesn't reach EventEmitter. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/cancel-returns-undefined-promise": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: rs.cancel() resolves to value other than undefined. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/options/auto-destroy-true-default": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: autoDestroy:true default — stream not destroyed after 'end', 'close' may not fire. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/custom-strategy-nan-size": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: custom strategy size() returning NaN does not throw on enqueue. Flips to PASS when #1545 lands."
   }
 }

--- a/test-parity/node-suite/stream/meta/stream-prototype-ee.ts
+++ b/test-parity/node-suite/stream/meta/stream-prototype-ee.ts
@@ -1,0 +1,6 @@
+import * as stream from "node:stream";
+import { EventEmitter } from "node:events";
+// The legacy Stream class (default export of node:stream) inherits from EE.
+const Stream: any = (stream as any).default || (stream as any).Stream;
+console.log("Stream defined:", typeof Stream === "function");
+console.log("prototype chain has EE:", Stream.prototype instanceof EventEmitter);

--- a/test-parity/node-suite/stream/options/auto-destroy-true-default.ts
+++ b/test-parity/node-suite/stream/options/auto-destroy-true-default.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// autoDestroy defaults to true — after end, the stream destroys itself
+// (firing 'close' even without explicit destroy()).
+const r = new Readable({ read() {} });
+let closedFired = false;
+r.on("close", () => (closedFired = true));
+r.on("data", () => {});
+r.on("end", () => {
+  setImmediate(() => {
+    console.log("destroyed:", r.destroyed);
+    console.log("closed fired:", closedFired);
+  });
+});
+r.push("a");
+r.push(null);

--- a/test-parity/node-suite/stream/web/cancel-returns-undefined-promise.ts
+++ b/test-parity/node-suite/stream/web/cancel-returns-undefined-promise.ts
@@ -1,0 +1,8 @@
+import { ReadableStream } from "node:stream/web";
+// rs.cancel() returns Promise<undefined>.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); } });
+const p = rs.cancel("stop");
+console.log("is Promise:", typeof (p as any).then === "function");
+const v = await p;
+console.log("resolves to:", v);
+console.log("is undefined:", v === undefined);

--- a/test-parity/node-suite/stream/web/custom-strategy-nan-size.ts
+++ b/test-parity/node-suite/stream/web/custom-strategy-nan-size.ts
@@ -1,0 +1,18 @@
+import { ReadableStream } from "node:stream/web";
+// A queuing strategy whose size() returns NaN should error the stream
+// when an enqueue is attempted.
+const strategy = {
+  size: () => NaN,
+  highWaterMark: 1,
+};
+const rs = new ReadableStream({
+  start(c) {
+    try {
+      c.enqueue("x");
+      console.log("enqueue succeeded:", true);
+    } catch (e: any) {
+      console.log("enqueue threw:", e && e.name);
+    }
+  },
+}, strategy);
+console.log("constructed:", rs instanceof ReadableStream);


### PR DESCRIPTION
### Iter-61 stream tests — Stream proto EE, cancel undef Promise, autoDestroy default, NaN strategy

| Test | Tracking |
|---|---|
| `meta/stream-prototype-ee` | #1532 |
| `web/cancel-returns-undefined-promise` | #1545 |
| `options/auto-destroy-true-default` | #1532 |
| `web/custom-strategy-nan-size` | #1545 |

All 4 parity-fail — tracked in `known_failures.json`.
