### PR TITLE
test(parity): stream — from(iter-object), multi-listeners data, unshift return, pipeTo promise (#1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,29 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/from-iterable-object": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(POJO-with-Symbol.iterator) — does not iterate the custom iterable. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/data-multi-listeners-same-data": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: multiple 'data' listeners — receive different chunks or wrong order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/unshift-return-value": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: unshift() return value — not undefined. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/pipe-to-returns-promise": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: pipeTo() return value — not a Promise<undefined>. Flips to PASS when #1545 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/data-multi-listeners-same-data.ts
+++ b/test-parity/node-suite/stream/events/data-multi-listeners-same-data.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// Each registered 'data' listener receives the same chunk for every push.
+const r = new Readable({ read() {} });
+const a: string[] = [];
+const b: string[] = [];
+r.on("data", (c) => a.push(String(c)));
+r.on("data", (c) => b.push(String(c)));
+r.push("x");
+r.push("y");
+r.push(null);
+r.on("end", () => {
+  console.log("a:", a.join(","));
+  console.log("b:", b.join(","));
+  console.log("same:", a.join(",") === b.join(","));
+});

--- a/test-parity/node-suite/stream/readable/from-iterable-object.ts
+++ b/test-parity/node-suite/stream/readable/from-iterable-object.ts
@@ -1,0 +1,18 @@
+import { Readable } from "node:stream";
+// Plain object with [Symbol.iterator] is iterable; Readable.from should
+// iterate it.
+const obj = {
+  [Symbol.iterator]() {
+    let i = 0;
+    return {
+      next() {
+        if (i < 3) return { value: i++, done: false };
+        return { value: undefined, done: true };
+      },
+    };
+  },
+};
+const r = Readable.from(obj as any);
+const out: number[] = [];
+for await (const v of r) out.push(v as number);
+console.log("from iter-object:", out.join(","));

--- a/test-parity/node-suite/stream/readable/unshift-return-value.ts
+++ b/test-parity/node-suite/stream/readable/unshift-return-value.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// unshift() returns undefined (it's not chainable like on()).
+const r = new Readable({ read() {} });
+r.push("a");
+const result = r.unshift("b");
+console.log("unshift returned:", result);
+console.log("is undefined:", result === undefined);

--- a/test-parity/node-suite/stream/web/pipe-to-returns-promise.ts
+++ b/test-parity/node-suite/stream/web/pipe-to-returns-promise.ts
@@ -1,0 +1,10 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// pipeTo() returns a Promise<void> that resolves when pipe completes
+// (or rejects on error).
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const ws = new WritableStream({ write() {} });
+const p = rs.pipeTo(ws);
+console.log("is Promise:", typeof (p as any).then === "function");
+const v = await p;
+console.log("resolves to:", v);
+console.log("is undefined:", v === undefined);


### PR DESCRIPTION
### Iter-62 stream tests — from(iter-object), multi-listeners data, unshift return, pipeTo promise

| Test | Tracking |
|---|---|
| `readable/from-iterable-object` | #1532 |
| `events/data-multi-listeners-same-data` | #1532 |
| `readable/unshift-return-value` | #1532 |
| `web/pipe-to-returns-promise` | #1545 |

All 4 parity-fail — tracked in `known_failures.json`.
