### PR TITLE
test(parity): stream — no sync iterator, async close hook, pipeline promise, toArray spread (1 free pass, 3 #1532/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/meta/readable-no-sync-iterator": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable should NOT expose Symbol.iterator (only Symbol.asyncIterator) — typeof differs from Node. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipeline/promise-form": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline() from node:stream/promises — return value not a Promise<undefined>. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/spread-tarray-result": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: toArray() result not spreadable array (wrong type or shape). Flips to PASS when #1558 lands."
   }
 }

--- a/test-parity/node-suite/stream/iter-helpers/spread-tarray-result.ts
+++ b/test-parity/node-suite/stream/iter-helpers/spread-tarray-result.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// `await r.toArray()` returns a plain Array that can be spread.
+const r = Readable.from([1, 2, 3]);
+const arr = await (r as any).toArray();
+console.log("is array:", Array.isArray(arr));
+const spread = [...arr, 99];
+console.log("spread:", spread.join(","));

--- a/test-parity/node-suite/stream/meta/readable-no-sync-iterator.ts
+++ b/test-parity/node-suite/stream/meta/readable-no-sync-iterator.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// Readable streams expose Symbol.asyncIterator but NOT Symbol.iterator
+// (they're async by nature).
+const r = new Readable({ read() {} });
+console.log("asyncIterator typeof:", typeof (r as any)[Symbol.asyncIterator]);
+console.log("sync iterator typeof:", typeof (r as any)[Symbol.iterator]);
+console.log("sync is undefined:", (r as any)[Symbol.iterator] === undefined);

--- a/test-parity/node-suite/stream/pipeline/promise-form.ts
+++ b/test-parity/node-suite/stream/pipeline/promise-form.ts
@@ -1,0 +1,11 @@
+import { Readable, PassThrough } from "node:stream";
+import { pipeline } from "node:stream/promises";
+// pipeline() from node:stream/promises returns a Promise (no callback form).
+const src = Readable.from(["a"]);
+const sink = new PassThrough();
+sink.on("data", () => {});
+const result = pipeline(src, sink);
+console.log("is Promise:", typeof (result as any).then === "function");
+const v = await result;
+console.log("resolved to:", v);
+console.log("is undefined:", v === undefined);

--- a/test-parity/node-suite/stream/web/writable-close-async.ts
+++ b/test-parity/node-suite/stream/web/writable-close-async.ts
@@ -1,0 +1,14 @@
+import { WritableStream } from "node:stream/web";
+// The sink's close() can return a Promise that delays writer.close() resolution.
+let closed = false;
+const ws = new WritableStream({
+  write() {},
+  async close() {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    closed = true;
+  },
+});
+const w = ws.getWriter();
+await w.write("x");
+await w.close();
+console.log("close ran (async):", closed);


### PR DESCRIPTION
### Iter-63 stream tests — no sync iter, async close, pipeline promise, toArray spread

| Test | Status | Tracking |
|---|---|---|
| `meta/readable-no-sync-iterator` | parity-fail | #1532 |
| `web/writable-close-async` | ✅ PASS | sink.close() Promise awaited |
| `pipeline/promise-form` | parity-fail | #1532 |
| `iter-helpers/spread-tarray-result` | parity-fail | #1558 |

1 free pass + 3 known_failures-tracked.
