### PR TITLE
test(parity): stream — abort Promise, pipe end:true, Buffer through compose, Transform objMode default (#1531/#1532/#1539/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,29 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/web/writable-abort-returns-promise": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: WritableStream.abort() — return is not Promise<undefined>. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/end-true-explicit": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe(dst, {end:true}) — explicit form behaves differently from default. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/buffer-preserves": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose() — Buffer chunks not preserved through pipeline (typed as string?). Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/transform/object-mode-default-false": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Transform default objectMode — readableObjectMode/writableObjectMode wrong default. Flips to PASS when #1539 lands."
   }
 }

--- a/test-parity/node-suite/stream/compose/buffer-preserves.ts
+++ b/test-parity/node-suite/stream/compose/buffer-preserves.ts
@@ -1,0 +1,10 @@
+import { compose, Readable, Transform } from "node:stream";
+// Buffer chunks survive a compose-pipeline as Buffers (not converted to strings).
+const src = Readable.from([Buffer.from("ab")]);
+const noop = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+const composed: any = compose(src, noop);
+composed.on("data", (c: any) => {
+  console.log("is Buffer:", Buffer.isBuffer(c));
+  console.log("content:", c.toString("utf8"));
+});
+composed.on("end", () => console.log("done"));

--- a/test-parity/node-suite/stream/pipe/end-true-explicit.ts
+++ b/test-parity/node-suite/stream/pipe/end-true-explicit.ts
@@ -1,0 +1,12 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe(dst, { end: true }) — explicit form of the default; destination
+// IS ended when source ends.
+const r = Readable.from(["a"]);
+const dst = new PassThrough();
+let dstEnded = false;
+dst.on("end", () => (dstEnded = true));
+dst.on("data", () => {});
+r.pipe(dst, { end: true });
+setImmediate(() => {
+  setImmediate(() => console.log("dst ended:", dstEnded));
+});

--- a/test-parity/node-suite/stream/transform/object-mode-default-false.ts
+++ b/test-parity/node-suite/stream/transform/object-mode-default-false.ts
@@ -1,0 +1,6 @@
+import { Transform } from "node:stream";
+// Transform's default objectMode is false (both sides).
+const t = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+console.log("readableObjectMode:", t.readableObjectMode);
+console.log("writableObjectMode:", t.writableObjectMode);
+console.log("both false:", !t.readableObjectMode && !t.writableObjectMode);

--- a/test-parity/node-suite/stream/web/writable-abort-returns-promise.ts
+++ b/test-parity/node-suite/stream/web/writable-abort-returns-promise.ts
@@ -1,0 +1,8 @@
+import { WritableStream } from "node:stream/web";
+// WritableStream.abort() returns Promise<void>.
+const ws = new WritableStream({ write() {}, abort() {} });
+const p = ws.abort("stop");
+console.log("is Promise:", typeof (p as any).then === "function");
+const v = await p;
+console.log("resolves to:", v);
+console.log("is undefined:", v === undefined);


### PR DESCRIPTION
### Iter-64 stream tests — abort Promise, pipe end:true, Buffer through compose, Transform objMode default

| Test | Tracking |
|---|---|
| `web/writable-abort-returns-promise` | #1545 |
| `pipe/end-true-explicit` | #1532 |
| `compose/buffer-preserves` | #1531 |
| `transform/object-mode-default-false` | #1539 |

All 4 parity-fail — tracked in `known_failures.json`.
