### PR TITLE
test(parity): stream — destroy(string), read(NaN), Writable(null), JSON.stringify (#1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,29 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/destroy/destroy-with-non-error": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy(non-Error) — 'error' listener does not receive raw value. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/read-with-nan-size": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read(NaN) — NaN coercion to default behavior wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/writable-stream-null-sink": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: new WritableStream(null) — null sink construction differs from Node. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/meta/json-stringify-output": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: JSON.stringify(stream) — output shape differs from Node ({} vs something else). Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/destroy/destroy-with-non-error.ts
+++ b/test-parity/node-suite/stream/destroy/destroy-with-non-error.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// destroy(non-Error) — Node accepts any value, emits 'error' with the
+// raw value (not wrapped in an Error).
+const r = new Readable({ read() {} });
+let received: any = null;
+r.on("error", (err) => (received = err));
+r.destroy("string-not-error" as any);
+setImmediate(() => {
+  console.log("received:", received);
+  console.log("is string:", typeof received === "string");
+});

--- a/test-parity/node-suite/stream/meta/json-stringify-output.ts
+++ b/test-parity/node-suite/stream/meta/json-stringify-output.ts
@@ -1,0 +1,12 @@
+import { Readable, Writable } from "node:stream";
+// JSON.stringify(stream) — uses the default object serializer; the result
+// is typically "{}" (no own enumerable props), or omitted (returns
+// undefined) if the stream has custom toJSON returning undefined.
+const r = new Readable({ read() {} });
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+const rJson = JSON.stringify(r);
+const wJson = JSON.stringify(w);
+console.log("R json:", rJson);
+console.log("W json:", wJson);
+console.log("R is string:", typeof rJson === "string");
+console.log("W is string:", typeof wJson === "string");

--- a/test-parity/node-suite/stream/readable/read-with-nan-size.ts
+++ b/test-parity/node-suite/stream/readable/read-with-nan-size.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// read(NaN) — Node coerces NaN to the default behavior (returns all buffered).
+const r = new Readable({ read() {} });
+r.push("abc");
+r.push(null);
+r.on("readable", () => {
+  const got = r.read(NaN as any);
+  console.log("got:", got && got.toString("utf8"));
+  console.log("got typeof:", typeof got);
+});

--- a/test-parity/node-suite/stream/web/writable-stream-null-sink.ts
+++ b/test-parity/node-suite/stream/web/writable-stream-null-sink.ts
@@ -1,0 +1,13 @@
+import { WritableStream } from "node:stream/web";
+// new WritableStream(null) — typically constructs with default sink, but
+// Node may throw or coerce. Test the actual behavior.
+let constructed = false;
+let threw: string | null = null;
+try {
+  const ws = new WritableStream(null as any);
+  constructed = ws instanceof WritableStream;
+} catch (e: any) {
+  threw = e && e.name;
+}
+console.log("constructed:", constructed);
+console.log("threw:", threw);


### PR DESCRIPTION
### Iter-65 stream tests — destroy(string), read(NaN), Writable(null) sink, JSON.stringify

| Test | Tracking |
|---|---|
| `destroy/destroy-with-non-error` | #1532 |
| `readable/read-with-nan-size` | #1532 |
| `web/writable-stream-null-sink` | #1545 |
| `meta/json-stringify-output` | #1532 |

All 4 parity-fail — tracked in `known_failures.json`.
