### PR TITLE
test(parity): stream — read(undef), transform sync throw, destroy idempotent, unpipe no-arg (2 free pass, 2 #1532)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,17 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/read-with-undefined-size": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read(undefined) — not equivalent to read() no-arg form. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/destroy/destroy-twice-idempotent": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy() called twice — fires duplicate 'close' or errors. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/destroy/destroy-twice-idempotent.ts
+++ b/test-parity/node-suite/stream/destroy/destroy-twice-idempotent.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Calling destroy() twice is idempotent — only one 'close' event fires.
+let closeCount = 0;
+const r = new Readable({ read() {} });
+r.on("close", () => closeCount++);
+r.destroy();
+r.destroy();
+setImmediate(() => {
+  console.log("close count:", closeCount);
+  console.log("destroyed:", r.destroyed);
+});

--- a/test-parity/node-suite/stream/pipe/unpipe-no-arg-removes-all.ts
+++ b/test-parity/node-suite/stream/pipe/unpipe-no-arg-removes-all.ts
@@ -1,0 +1,17 @@
+import { Readable, PassThrough } from "node:stream";
+// unpipe() with no arg removes ALL pipe destinations from the source.
+const r = Readable.from(["x"]);
+const a = new PassThrough();
+const b = new PassThrough();
+let aGot = 0, bGot = 0;
+a.on("data", () => aGot++);
+b.on("data", () => bGot++);
+r.pipe(a);
+r.pipe(b);
+r.unpipe();
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("a got after unpipe:", aGot);
+    console.log("b got after unpipe:", bGot);
+  });
+});

--- a/test-parity/node-suite/stream/readable/read-with-undefined-size.ts
+++ b/test-parity/node-suite/stream/readable/read-with-undefined-size.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// read(undefined) is equivalent to read() with no args — returns all
+// buffered bytes.
+const r = new Readable({ read() {} });
+r.push("hello");
+r.push(null);
+r.on("readable", () => {
+  const got = r.read(undefined as any);
+  console.log("got:", got && got.toString("utf8"));
+});

--- a/test-parity/node-suite/stream/transform/transform-throws-sync.ts
+++ b/test-parity/node-suite/stream/transform/transform-throws-sync.ts
@@ -1,0 +1,12 @@
+import { Transform } from "node:stream";
+// A synchronous throw inside transform() — Node catches and emits 'error'.
+const t = new Transform({
+  transform(_c, _e, _cb) {
+    throw new Error("sync-throw");
+  },
+});
+let errMsg: string | null = null;
+t.on("error", (err) => (errMsg = err && err.message));
+t.on("data", () => {});
+t.write("x");
+setImmediate(() => console.log("err:", errMsg));


### PR DESCRIPTION
### Iter-66 stream tests — read(undef), transform sync throw, destroy idempotent, unpipe no-arg

| Test | Status | Tracking |
|---|---|---|
| `readable/read-with-undefined-size` | parity-fail | #1532 |
| `transform/transform-throws-sync` | ✅ PASS | sync throw caught → 'error' event |
| `destroy/destroy-twice-idempotent` | parity-fail | #1532 |
| `pipe/unpipe-no-arg-removes-all` | ✅ PASS | `unpipe()` removes all destinations |

2 free passes + 2 known_failures-tracked.
