### PR TITLE
test(parity): stream — pipeTo signal abort, no-enc Buffer iter, byte stream, compose err to src (1 free pass, 3 #1531/#1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/iter-yields-buffer-no-encoding": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: for-await on Readable without setEncoding — chunks are not Buffer instances. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/byte-stream-construction": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: new ReadableStream({type:'bytes'}) — byte stream construction fails or BYOB unavailable. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/compose/error-propagates-to-source": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose() error does not destroy source. Flips to PASS when #1531 lands."
   }
 }

--- a/test-parity/node-suite/stream/compose/error-propagates-to-source.ts
+++ b/test-parity/node-suite/stream/compose/error-propagates-to-source.ts
@@ -1,0 +1,13 @@
+import { compose, Readable, Transform } from "node:stream";
+// An error in the composite should propagate back to destroy the source.
+const src = new Readable({ read() {} });
+const bad = new Transform({
+  transform(_c, _e, cb) { cb(new Error("xform-fail")); },
+});
+const composed: any = compose(src, bad);
+composed.on("error", () => {});
+composed.on("data", () => {});
+src.push("x");
+setImmediate(() => {
+  setImmediate(() => console.log("src destroyed after composite err:", src.destroyed));
+});

--- a/test-parity/node-suite/stream/readable/iter-yields-buffer-no-encoding.ts
+++ b/test-parity/node-suite/stream/readable/iter-yields-buffer-no-encoding.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Without setEncoding, async iteration over a Readable yields Buffer chunks.
+const r = new Readable({ read() {} });
+r.push("a");
+r.push("b");
+r.push(null);
+for await (const v of r) {
+  console.log("isBuffer:", Buffer.isBuffer(v), "content:", (v as Buffer).toString("utf8"));
+}

--- a/test-parity/node-suite/stream/web/byte-stream-construction.ts
+++ b/test-parity/node-suite/stream/web/byte-stream-construction.ts
@@ -1,0 +1,14 @@
+import { ReadableStream } from "node:stream/web";
+// `new ReadableStream({ type: "bytes" })` constructs a byte stream
+// (BYOB reader compatible).
+let constructed = false;
+try {
+  const rs = new ReadableStream({ type: "bytes" } as any);
+  constructed = rs instanceof ReadableStream;
+  console.log("constructed:", constructed);
+  // Try BYOB
+  const reader = (rs as any).getReader({ mode: "byob" });
+  console.log("byob reader:", typeof reader.read === "function");
+} catch (e: any) {
+  console.log("threw:", e && e.name);
+}

--- a/test-parity/node-suite/stream/web/pipe-to-with-signal-abort.ts
+++ b/test-parity/node-suite/stream/web/pipe-to-with-signal-abort.ts
@@ -1,0 +1,18 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// pipeTo(ws, { signal }) — aborting the signal rejects the returned Promise.
+const ctrl = new AbortController();
+const rs = new ReadableStream({
+  pull(c) {
+    setTimeout(() => c.enqueue("x"), 50);
+  },
+});
+const ws = new WritableStream({ write() {} });
+const p = rs.pipeTo(ws, { signal: ctrl.signal });
+setTimeout(() => ctrl.abort(), 10);
+let err: string | null = null;
+try {
+  await p;
+} catch (e: any) {
+  err = e && e.name;
+}
+console.log("aborted err name:", err);


### PR DESCRIPTION
### Iter-67 stream tests — pipeTo signal abort, no-enc Buffer iter, byte stream, compose err

| Test | Status | Tracking |
|---|---|---|
| `web/pipe-to-with-signal-abort` | ✅ PASS | mid-pipe AbortSignal rejects |
| `readable/iter-yields-buffer-no-encoding` | parity-fail | #1532 |
| `web/byte-stream-construction` | parity-fail | #1545 |
| `compose/error-propagates-to-source` | parity-fail | #1531 |

1 free pass + 3 known_failures-tracked.
