### PR TITLE
test(parity): stream — reader after close, single-stream compose, unshift Buffer, empty sink (1 free pass, 3 #1531/#1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,23 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/compose/single-stream-arg": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(stream) — single-stream form does not return Duplex wrap. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/unshift-buffer": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: unshift(Buffer) — explicit Buffer not properly added to front of buffer queue. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/writable-empty-object-sink": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: new WritableStream({}) — empty-sink writes don't silently succeed. Flips to PASS when #1545 lands."
   }
 }

--- a/test-parity/node-suite/stream/compose/single-stream-arg.ts
+++ b/test-parity/node-suite/stream/compose/single-stream-arg.ts
@@ -1,0 +1,8 @@
+import { compose, Readable, Duplex } from "node:stream";
+// compose() with a single stream returns a Duplex wrapping it.
+const r = Readable.from(["x"]);
+const composed: any = compose(r);
+console.log("instanceof Duplex:", composed instanceof Duplex);
+const out: string[] = [];
+composed.on("data", (c: any) => out.push(String(c)));
+composed.on("end", () => console.log("out:", out.join(",")));

--- a/test-parity/node-suite/stream/readable/unshift-buffer.ts
+++ b/test-parity/node-suite/stream/readable/unshift-buffer.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// unshift(Buffer) — explicit Buffer input is unshifted to the front.
+const r = new Readable({ read() {} });
+r.push("world");
+r.unshift(Buffer.from("hello "));
+r.push(null);
+const out: string[] = [];
+r.on("data", (c) => out.push(String(c)));
+r.on("end", () => console.log("joined:", out.join("|")));

--- a/test-parity/node-suite/stream/web/reader-after-close-done.ts
+++ b/test-parity/node-suite/stream/web/reader-after-close-done.ts
@@ -1,0 +1,12 @@
+import { ReadableStream } from "node:stream/web";
+// After the stream closes, further read() calls return { done: true, value: undefined }.
+const rs = new ReadableStream({
+  start(c) { c.enqueue("x"); c.close(); },
+});
+const reader = rs.getReader();
+const first = await reader.read();
+const second = await reader.read();
+const third = await reader.read();
+console.log("first:", first.value, first.done);
+console.log("second:", second.value, second.done);
+console.log("third:", third.value, third.done);

--- a/test-parity/node-suite/stream/web/writable-empty-object-sink.ts
+++ b/test-parity/node-suite/stream/web/writable-empty-object-sink.ts
@@ -1,0 +1,9 @@
+import { WritableStream } from "node:stream/web";
+// `new WritableStream({})` — empty sink object: writes silently succeed.
+const ws = new WritableStream({});
+const w = ws.getWriter();
+await w.write("a");
+await w.write("b");
+await w.close();
+console.log("constructed:", ws instanceof WritableStream);
+console.log("locked after close:", ws.locked);


### PR DESCRIPTION
### Iter-68 stream tests — reader after close, single-stream compose, unshift Buffer, empty sink

| Test | Status | Tracking |
|---|---|---|
| `web/reader-after-close-done` | ✅ PASS | `{done:true}` after close |
| `compose/single-stream-arg` | parity-fail | #1531 |
| `readable/unshift-buffer` | parity-fail | #1532 |
| `web/writable-empty-object-sink` | parity-fail | #1545 |

1 free pass + 3 known_failures-tracked.
