### PR TITLE
test(parity): stream — batch of 16 tier-3/4 tests (iter-69..72) (1 free pass, 15 #1531/#1532/#1539/#1545/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1687,5 +1687,95 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream/web: writer.close() does not return a Promise. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/web/desired-size-restores-after-drain": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: writer.desiredSize does not restore to HWM after write resolves. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/transform/this-binding-in-transform": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: `this` inside transform() — not bound to Transform instance, or this.push() does not enqueue. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/readable/highwater-mark-buffer": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: readableLength after multiple push() — does not equal sum of chunk lengths. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/listeners-returns-copy": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: EE.listeners() returns a live reference — mutating it affects internal count. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/flow/sync-pause-in-data-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pause() inside 'data' listener — does not stop further synchronous emits. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/get-writer-twice-throws": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: second getWriter() on locked WritableStream does not throw TypeError. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/push-returns-true-initial": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: push() under HWM does not return true. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/write-returns-false-at-hwm": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: write() does not return false when buffered bytes cross HWM. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/web/transform-readable-empty": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: TransformStream with empty writable.close() doesn't yield {done:true} on readable side. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/from-empty-iterable": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(empty) — 'end' event not fired or fires with wrong count. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/once-removed-after-fire": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: once() listener not removed after firing — second emit invokes it again. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/find-returns-promise": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: find() — return value is not a Promise<value|undefined>. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/web/byob-on-byte-stream": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: getReader({mode:'byob'}) on bytes-type stream fails or returns wrong shape. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/destroyed-true-immediately": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroyed flag not synchronously true after destroy(). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/listener-removal-during-emit": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: removeListener() during emit() — the snapshot semantics differ (other listener not fired or fires twice). Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/listener-removal-during-emit.ts
+++ b/test-parity/node-suite/stream/events/listener-removal-during-emit.ts
@@ -1,0 +1,16 @@
+import { Readable } from "node:stream";
+// Removing a listener during emit() — the listener still fires this round
+// (because emit() snapshots the listener array).
+const r = new Readable({ read() {} });
+const fired: string[] = [];
+const fn1 = () => {
+  fired.push("fn1");
+  r.removeListener("custom", fn2);
+};
+const fn2 = () => {
+  fired.push("fn2");
+};
+r.on("custom", fn1);
+r.on("custom", fn2);
+r.emit("custom");
+console.log("fired:", fired.join(","));

--- a/test-parity/node-suite/stream/events/listeners-returns-copy.ts
+++ b/test-parity/node-suite/stream/events/listeners-returns-copy.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// listeners(event) returns a COPY of the listener array — mutating it
+// must not affect the emitter's internal list.
+const r = new Readable({ read() {} });
+const fn1 = () => {};
+const fn2 = () => {};
+r.on("data", fn1);
+r.on("data", fn2);
+const arr = r.listeners("data");
+arr.length = 0; // mutate the returned array
+console.log("internal count:", r.listenerCount("data"));
+console.log("unchanged:", r.listenerCount("data") === 2);

--- a/test-parity/node-suite/stream/events/once-removed-after-fire.ts
+++ b/test-parity/node-suite/stream/events/once-removed-after-fire.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// once(event, fn) — the listener is removed after the event fires once.
+const r = new Readable({ read() {} });
+let count = 0;
+r.once("custom", () => count++);
+r.emit("custom");
+r.emit("custom");
+console.log("listener fired:", count);
+console.log("listenerCount after fire:", r.listenerCount("custom"));

--- a/test-parity/node-suite/stream/flow/sync-pause-in-data-listener.ts
+++ b/test-parity/node-suite/stream/flow/sync-pause-in-data-listener.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// Calling pause() inside a 'data' listener stops further synchronous emits.
+const r = Readable.from(["a", "b", "c", "d"]);
+const out: string[] = [];
+r.on("data", (c) => {
+  out.push(String(c));
+  r.pause();
+});
+setImmediate(() => {
+  console.log("first batch count:", out.length);
+  console.log("flowing:", r.readableFlowing);
+});

--- a/test-parity/node-suite/stream/iter-helpers/find-returns-promise.ts
+++ b/test-parity/node-suite/stream/iter-helpers/find-returns-promise.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// r.find(fn) returns a Promise — Promise.resolve(undefined) if no match.
+const r = Readable.from([1, 2, 3, 4]);
+const p = (r as any).find((x: number) => x > 2);
+console.log("is Promise:", typeof p.then === "function");
+const value = await p;
+console.log("value:", value);

--- a/test-parity/node-suite/stream/readable/destroyed-true-immediately.ts
+++ b/test-parity/node-suite/stream/readable/destroyed-true-immediately.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// destroyed flag is true immediately (synchronously) after destroy() returns.
+const r = new Readable({ read() {} });
+console.log("before:", r.destroyed);
+r.destroy();
+console.log("after:", r.destroyed);
+console.log("sync true:", r.destroyed === true);

--- a/test-parity/node-suite/stream/readable/from-empty-iterable.ts
+++ b/test-parity/node-suite/stream/readable/from-empty-iterable.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Readable.from(emptyIterable) yields no data; 'end' fires immediately.
+const r = Readable.from([]);
+let dataCount = 0;
+let endFired = false;
+r.on("data", () => dataCount++);
+r.on("end", () => {
+  endFired = true;
+  console.log("data count:", dataCount);
+  console.log("end fired:", endFired);
+});

--- a/test-parity/node-suite/stream/readable/highwater-mark-buffer.ts
+++ b/test-parity/node-suite/stream/readable/highwater-mark-buffer.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Pushed data accumulates in the buffer; readableLength reflects total
+// buffered bytes after multiple pushes.
+const r = new Readable({ highWaterMark: 16, read() {} });
+r.push("ab");
+r.push("cd");
+r.push("ef");
+console.log("length:", r.readableLength);
+console.log("under hwm:", r.readableLength < r.readableHighWaterMark);

--- a/test-parity/node-suite/stream/readable/push-returns-true-initial.ts
+++ b/test-parity/node-suite/stream/readable/push-returns-true-initial.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// push() returns true while the buffer is below HWM (and end not pushed).
+const r = new Readable({ highWaterMark: 100, read() {} });
+const a = r.push("aa");
+const b = r.push("bb");
+console.log("first:", a, "second:", b);
+console.log("both true:", a === true && b === true);

--- a/test-parity/node-suite/stream/transform/this-binding-in-transform.ts
+++ b/test-parity/node-suite/stream/transform/this-binding-in-transform.ts
@@ -1,0 +1,13 @@
+import { Transform } from "node:stream";
+// Inside transform(), `this` should refer to the Transform instance,
+// allowing this.push() to enqueue output.
+const t = new Transform({
+  transform(chunk, _enc, cb) {
+    console.log("this is Transform:", this instanceof Transform);
+    this.push(String(chunk).toUpperCase());
+    cb();
+  },
+});
+t.on("data", () => {});
+t.write("hi");
+t.end();

--- a/test-parity/node-suite/stream/web/byob-on-byte-stream.ts
+++ b/test-parity/node-suite/stream/web/byob-on-byte-stream.ts
@@ -1,0 +1,14 @@
+import { ReadableStream } from "node:stream/web";
+// getReader({mode:'byob'}) on a type:'bytes' stream returns a BYOB reader.
+let result: any = null;
+try {
+  const rs = new ReadableStream({ type: "bytes" } as any);
+  const reader = (rs as any).getReader({ mode: "byob" });
+  result = {
+    hasRead: typeof reader.read === "function",
+    hasReleaseLock: typeof reader.releaseLock === "function",
+  };
+} catch (e: any) {
+  result = { threw: e && e.name };
+}
+console.log(JSON.stringify(result));

--- a/test-parity/node-suite/stream/web/desired-size-restores-after-drain.ts
+++ b/test-parity/node-suite/stream/web/desired-size-restores-after-drain.ts
@@ -1,0 +1,11 @@
+import { WritableStream, CountQueuingStrategy } from "node:stream/web";
+// After a write resolves (sink processed), desiredSize returns to HWM.
+const ws = new WritableStream(
+  { write() {} },
+  new CountQueuingStrategy({ highWaterMark: 2 }),
+);
+const w = ws.getWriter();
+console.log("initial:", w.desiredSize);
+await w.write("a");
+await w.ready;
+console.log("after write:", w.desiredSize);

--- a/test-parity/node-suite/stream/web/get-writer-twice-throws.ts
+++ b/test-parity/node-suite/stream/web/get-writer-twice-throws.ts
@@ -1,0 +1,13 @@
+import { WritableStream } from "node:stream/web";
+// Second getWriter() on locked WritableStream throws TypeError.
+const ws = new WritableStream({ write() {} });
+const _w1 = ws.getWriter();
+let caught: string | null = null;
+try {
+  ws.getWriter();
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);
+console.log("locked:", ws.locked);

--- a/test-parity/node-suite/stream/web/transform-readable-empty.ts
+++ b/test-parity/node-suite/stream/web/transform-readable-empty.ts
@@ -1,0 +1,9 @@
+import { TransformStream } from "node:stream/web";
+// A TransformStream with empty writable.close() yields an empty readable.
+const ts = new TransformStream();
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.close();
+const { value, done } = await reader.read();
+console.log("value:", value);
+console.log("done:", done);

--- a/test-parity/node-suite/stream/web/writer-write-after-close-rejects.ts
+++ b/test-parity/node-suite/stream/web/writer-write-after-close-rejects.ts
@@ -1,0 +1,12 @@
+import { WritableStream } from "node:stream/web";
+// Calling write() after close() should reject — the writer is closed.
+const ws = new WritableStream({ write() {} });
+const w = ws.getWriter();
+await w.close();
+let rejected = false;
+try {
+  await w.write("late");
+} catch {
+  rejected = true;
+}
+console.log("rejected:", rejected);

--- a/test-parity/node-suite/stream/writable/write-returns-false-at-hwm.ts
+++ b/test-parity/node-suite/stream/writable/write-returns-false-at-hwm.ts
@@ -1,0 +1,14 @@
+import { Writable } from "node:stream";
+// write() returns false once the buffered bytes cross the highWaterMark.
+// With a tiny HWM and a slow sink, the second write should return false.
+const w = new Writable({
+  highWaterMark: 2,
+  write(_c, _e, cb) {
+    setImmediate(cb); // delay so writes accumulate
+  },
+});
+const a = w.write("aa");
+const b = w.write("bb");
+console.log("a:", a);
+console.log("b:", b);
+console.log("at-least-one false:", a === false || b === false);


### PR DESCRIPTION
### Stream parity batch — 16 tests aggregated (iter-69..72)

**1 free pass + 15 tracked failures.**

This PR consolidates 4 iterations of stream parity testing into one PR — every test is independent (one TS file, one behavior) but they're grouped to reduce review burden.

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | desired-size-restores-after-drain, get-writer-twice-throws, transform-readable-empty, byob-on-byte-stream, writer-write-after-close-rejects ✅ | #1545 |
| Stream events / Readable | listeners-returns-copy, sync-pause-in-data-listener, push-returns-true-initial, from-empty-iterable, once-removed-after-fire, destroyed-true-immediately, listener-removal-during-emit, highwater-mark-buffer | #1532 |
| Writable buffering | write-returns-false-at-hwm, this-binding-in-transform | #1539 |
| Iter helpers | find-returns-promise | #1558 |

Free pass: `web/writer-write-after-close-rejects` — Perry already correctly rejects writes after `close()`.

All 15 failures tracked in `known_failures.json` against the relevant umbrella issues; CI parity gate unaffected.
