### PR TITLE
test(parity): re-validate known_failures skip-list against v0.5.1026

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -8,77 +8,35 @@
       "reason": "Free-text explanation. Keep the most-actionable signal first — what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
-  "node-suite/perf_hooks/shapes/to-string-tag": {
-    "issue": "1479",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: Object.prototype.toString.call(performance) yields the generic object tag instead of '[object Performance]'. Flips to PASS when #1479 lands."
-  },
-  "node-suite/console/dir/depth-options": {
-    "issue": "1199",
-    "added": "2026-05-20",
-    "category": "bug-open",
-    "reason": "node:console granular parity: console.dir(value, { depth }) does not honor Node-compatible inspect depth limits. Flips to PASS when #1199 lands."
-  },
-  "node-suite/console/dir/show-hidden-option": {
-    "issue": "1200",
-    "added": "2026-05-20",
-    "category": "bug-open",
-    "reason": "node:console granular parity: console.dir(value, { showHidden: true }) does not render hidden properties with Node-compatible inspect notation. Flips to PASS when #1200 lands."
-  },
-  "node-suite/console/output/function-format": {
-    "issue": "1202",
-    "added": "2026-05-20",
-    "category": "bug-open",
-    "reason": "node:console granular parity: function values currently lose Node-compatible closure/function names in inspect output. Flips to PASS when #1202 lands."
-  },
-  "node-suite/console/output/json-circular": {
-    "issue": "1204",
-    "added": "2026-05-20",
-    "category": "bug-open",
-    "reason": "node:console granular parity: circular object formatting lacks Node-compatible <ref> / [Circular] tracking. Flips to PASS when #1204 lands."
-  },
-  "node-suite/console/output/no-tostring-on-string-format": {
-    "issue": "1203",
-    "added": "2026-05-20",
-    "category": "bug-open",
-    "reason": "node:console granular parity: inspecting a function whose own `toString` is overridden doesn't follow Node's function-formatting path (which renders `[Function: name]` without invoking user `toString`). Flips to PASS when #1203 lands."
-  },
   "issue_655_repro": {
     "issue": "655",
-    "added": "2026-05-15",
-    "category": "bug-open",
-    "reason": "Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict — it's a deliberate failing repro."
+    "added": "2026-05-24",
+    "category": "bug-stale",
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #655 is closed. Deliberate failing repro/harness — kept as a regression canary. Canonical regression-catcher for issue #655. Flips to PASS when the underlying fix lands. Keep regardless of CI verdict — it's a deliberate failing repro."
   },
   "test_edge_regression": {
-    "issue": null,
+    "issue": "1635",
     "added": "2026-05-15",
     "category": "gap-bisect",
-    "reason": "Broad edge-case bundle covering multiple historical regressions. Bisect needed to pin which sub-case still fails so a tracking issue can be filed against that specific behavior. Not a recent regression."
+    "reason": "Tracked in #1635 (gap-bisect backlog). Broad edge-case bundle covering multiple historical regressions. Bisect needed to pin which sub-case still fails so a tracking issue can be filed against that specific behavior. Not a recent regression."
   },
   "test_edge_type_narrowing": {
-    "issue": null,
+    "issue": "1635",
     "added": "2026-05-15",
     "category": "gap-bisect",
-    "reason": "Several TS type-narrowing patterns (control-flow narrowing, discriminated unions through generics, `in` operator narrowing) Perry's HIR doesn't track yet. Surfaced multiple narrow-fix candidates; split into per-pattern issues before tackling."
+    "reason": "Tracked in #1635 (gap-bisect backlog). Several TS type-narrowing patterns (control-flow narrowing, discriminated unions through generics, `in` operator narrowing) Perry's HIR doesn't track yet. Surfaced multiple narrow-fix candidates; split into per-pattern issues before tackling."
   },
   "test_gap_array_methods": {
-    "issue": null,
+    "issue": "1635",
     "added": "2026-05-15",
     "category": "gap-bisect",
-    "reason": "Array method coverage probe — small divergences (flat/flatMap/finally specific edge cases). Targeted bisect needed; not a recent regression. File a tracking issue once a specific sub-case is pinned."
-  },
-  "test_gap_console_methods": {
-    "issue": "1278",
-    "added": "2026-05-21",
-    "category": "gap-categorical",
-    "reason": "#1278: console.trace / Error.stack frame format diverges from Node (Perry prints native frame addresses like `0: __mh_execute_header` instead of `at <fn> (file:///…:line:col)`). Requires source-position retention through HIR/transform + native-frame → TS-source mapping. The other two divergences in this fixture (#1276 spurious `Values` column on array-of-arrays, #1277 timer ms numbers) are not gating: #1276 was fixed in v0.5.1019+; #1277 is a misdiagnosis — Perry's `Instant::now()` is correct and the apparent 1000× gap is just AOT-vs-interpreted speedup on the trivial loop workload. Flips to PASS when #1278 lands."
+    "reason": "Tracked in #1635 (gap-bisect backlog). Array method coverage probe — small divergences (flat/flatMap/finally specific edge cases). Targeted bisect needed; not a recent regression. File a tracking issue once a specific sub-case is pinned."
   },
   "test_gap_class_advanced": {
-    "issue": null,
+    "issue": "1635",
     "added": "2026-05-17",
     "category": "gap-bisect",
-    "reason": "Advanced class features (static blocks, private brand checks, etc.) — bisect required to identify which sub-feature fails byte-for-byte vs Node."
+    "reason": "Tracked in #1635 (gap-bisect backlog). Advanced class features (static blocks, private brand checks, etc.) — bisect required to identify which sub-feature fails byte-for-byte vs Node."
   },
   "test_gap_regexp_advanced": {
     "issue": null,
@@ -88,15 +46,15 @@
   },
   "test_harness_async_context": {
     "issue": "788",
-    "added": "2026-05-16",
-    "category": "bug-open",
-    "reason": "#807 harness for AsyncLocalStorage propagation through await/microtask/timer and async_hooks.createHook lifecycle. Perry now preserves ALS context across await chains, queueMicrotask, setTimeout, nested runs, and concurrent Promise.all branches (#788). Remaining failure is section 8: createHook returns undefined / lacks lifecycle + asyncId tracking, tracked by #789."
+    "added": "2026-05-24",
+    "category": "bug-stale",
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #788 is closed. Deliberate failing repro/harness — kept as a regression canary. #807 harness for AsyncLocalStorage propagation through await/microtask/timer and async_hooks.createHook lifecycle. Perry now preserves ALS context across await chains, queueMicrotask, setTimeout, nested runs, and concurrent Promise.all branches (#788). Remaining failure is section 8: createHook returns undefined / lacks lifecycle + asyncId tracking, tracked by #789."
   },
   "test_harness_class_mixins": {
     "issue": "806",
-    "added": "2026-05-16",
+    "added": "2026-05-24",
     "category": "bug-stale",
-    "reason": "#806 harness for `class X extends Fn(...)<...>` patterns. Two sub-cases surface real Perry gaps today: (1) bare-factory subclass loses the base's field initializer (`bare.kind: undefined` vs Node's `bare.kind: bare`); (2) chained mixin `WithA(WithB(WithC(Base)))` throws `TypeError: value is not a function` at construction. Captured-factory + Effect double-call shapes pass post-#740 — the harness verifies that survives. Linked to #321 umbrella; will flip to PASS as each sub-case lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #806 is closed. Deliberate failing repro/harness — kept as a regression canary. #806 harness for `class X extends Fn(...)<...>` patterns. Two sub-cases surface real Perry gaps today: (1) bare-factory subclass loses the base's field initializer (`bare.kind: undefined` vs Node's `bare.kind: bare`); (2) chained mixin `WithA(WithB(WithC(Base)))` throws `TypeError: value is not a function` at construction. Captured-factory + Effect double-call shapes pass post-#740 — the harness verifies that survives. Linked to #321 umbrella; will flip to PASS as each sub-case lands."
   },
   "test_issue_233_async_array_param_push": {
     "issue": "793",
@@ -105,10 +63,10 @@
     "reason": "#233 (16-element cap on async array-param push) closed on macOS. Linux CI still surfaces a divergence — bisect needed to pin the Linux-only sub-case before filing a new tracking issue. Rolled under the parity roadmap (#793) in the meantime."
   },
   "test_issue_422_socket_connect": {
-    "issue": null,
+    "issue": "1634",
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "#422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental — needs a CI-side fixture, not a Perry fix."
+    "reason": "Tracked in #1634 (parity CI environment fixtures). #422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental — needs a CI-side fixture, not a Perry fix."
   },
   "test_issue_462_nullish_property_access": {
     "issue": "793",
@@ -142,15 +100,9 @@
   },
   "test_issue_922_api_route_crash": {
     "issue": "922",
-    "added": "2026-05-17",
-    "category": "bug-open",
-    "reason": "Regression test from #922 (P0 production /api crash). Deliberate failing repro until the underlying codegen bug is fixed; #934 added a circuit breaker that converts the runaway loop into [PERRY ABORT] (so test fails by design — the abort message diverges from Node's success output)."
-  },
-  "test_issue_express_map_undefined": {
-    "issue": "912",
-    "added": "2026-05-17",
-    "category": "bug-open",
-    "reason": "Regression test from #911 (express map undefined / http.METHODS). The METHODS property is now in the manifest (PR adding it alongside this entry); the test may still diverge from Node in the exact METHODS list shape. Re-evaluate once express compiles cleanly."
+    "added": "2026-05-24",
+    "category": "bug-stale",
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS; #922 is closed. Deliberate failing repro/harness — kept as a regression canary. Regression test from #922 (P0 production /api crash). Deliberate failing repro until the underlying codegen bug is fixed; #934 added a circuit breaker that converts the runaway loop into [PERRY ABORT] (so test fails by design — the abort message diverges from Node's success output)."
   },
   "test_async_local_storage_context": {
     "issue": "1423",
@@ -159,40 +111,34 @@
     "reason": "AsyncLocalStorage `.enterWith()` / `.exit()` aren't implemented end-to-end — the test prints the first 10 lines (await/then/catch/nextTick/timer/immediate/interval contexts + nested outer) and then exits silently when `enterWith()` is invoked, missing the last 7 lines covering enterWith semantics + exit/restore mechanics. Sibling slice of #788 #789 (real AsyncLocalStorage tracking across await/microtasks/timers + real `async_hooks.createHook` lifecycle). Surfaced as a NEW failure on v0.5.1024 release-packages parity. Flips to PASS when `.enterWith` / `.exit` land."
   },
   "test_jsruntime_mixed_async_ordering_matrix": {
-    "issue": null,
+    "issue": "1635",
     "added": "2026-05-17",
     "category": "gap-bisect",
-    "reason": "Mixed async ordering between native + V8-fallback promise chains. Long-tail jsruntime parity work; bisect needed to identify which interleaving shape diverges."
+    "reason": "Tracked in #1635 (gap-bisect backlog). Mixed async ordering between native + V8-fallback promise chains. Long-tail jsruntime parity work; bisect needed to identify which interleaving shape diverges."
   },
   "test_net_min": {
-    "issue": null,
+    "issue": "1634",
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
+    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
   },
   "test_net_socket": {
-    "issue": null,
+    "issue": "1634",
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
+    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — needs a CI-side fixture, not a Perry fix."
   },
   "test_net_upgrade_tls": {
-    "issue": null,
+    "issue": "1634",
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test needs a TLS-capable echo server fixture; not available on CI. Environmental — needs a CI-side fixture."
+    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test needs a TLS-capable echo server fixture; not available on CI. Environmental — needs a CI-side fixture."
   },
   "test_parity_assert": {
     "issue": "793",
     "added": "2026-05-15",
     "category": "module-inventory",
     "reason": "Node.js module inventory — `node:assert` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
-  "test_parity_async_hooks": {
-    "issue": "789",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory — `node:async_hooks` createHook lifecycle + asyncId tracking missing. Tracked in #789. Flips to PASS once createHook fires."
   },
   "test_parity_buffer": {
     "issue": "793",
@@ -363,82 +309,46 @@
     "reason": "Node.js module inventory — `node:zlib` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_sock_write_map": {
-    "issue": null,
+    "issue": "1634",
     "added": "2026-05-15",
     "category": "ci-env",
-    "reason": "Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — issue #91 dispatch fix landed in v0.5.581 and is no longer the cause; needs a CI-side fixture."
+    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental — issue #91 dispatch fix landed in v0.5.581 and is no longer the cause; needs a CI-side fixture."
   },
   "test_decorators_nest_js_common_canary": {
-    "issue": null,
+    "issue": "1634",
     "added": "2026-05-18",
     "category": "ci-env",
-    "reason": "Expected-output mismatch under the Linux CI runner; same failure observed on #1038's CI run pre-merge. Triage tied to the NestJS decorators metadata-inheritance follow-ups; not a regression introduced by recent changes."
+    "reason": "Tracked in #1634 (parity CI environment fixtures). Expected-output mismatch under the Linux CI runner; same failure observed on #1038's CI run pre-merge. Triage tied to the NestJS decorators metadata-inheritance follow-ups; not a regression introduced by recent changes."
   },
   "test_ramda_sum": {
-    "issue": null,
+    "issue": "1634",
     "added": "2026-05-18",
     "category": "ci-env",
-    "reason": "Ramda npm-package fixture failure on Linux CI; observed on #1038's CI run pre-merge. Companion to the existing test_ramda_user_import skip in the compile-smoke list — the parity harness can't npm-install ramda. File a CI-side fixture issue if/when this matters for sweep coverage."
+    "reason": "Tracked in #1634 (parity CI environment fixtures). Ramda npm-package fixture failure on Linux CI; observed on #1038's CI run pre-merge. Companion to the existing test_ramda_user_import skip in the compile-smoke list — the parity harness can't npm-install ramda. File a CI-side fixture issue if/when this matters for sweep coverage."
   },
   "test_stream_on": {
-    "issue": null,
-    "added": "2026-05-18",
-    "category": "ci-env",
-    "reason": "node:stream emitter wiring still incomplete (cf. existing test_parity_stream module-inventory entry). Same failure observed on #1038 pre-merge — not a regression."
-  },
-  "test_zlib_brotli_decompress": {
-    "issue": null,
-    "added": "2026-05-18",
-    "category": "ci-env",
-    "reason": "Brotli decompression path under node:zlib not yet implemented (cf. existing test_parity_zlib module-inventory entry). Same failure observed on #1038 pre-merge — not a regression."
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream EventEmitter wiring incomplete — re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS. Real Perry gap (not ci-env); rolled under the open stream-events tracker #1532."
   },
   "node-suite/process/env/write": {
-    "issue": "1344",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:process: process.env.X = v does not persist (assignment lowering). Fix was in #1371 not yet on main. Flips to PASS when #1344 lands."
-  },
-  "node-suite/process/exit-code/exit-code-default": {
-    "issue": "1350",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:process: process.exitCode does not default to undefined. Flips to PASS when #1350 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1344 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1344 is reopened."
   },
   "node-suite/process/memory/rss-method": {
-    "issue": "1395",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:process: process.memoryUsage.rss() fast-path unimplemented. Flips to PASS when #1395 lands."
-  },
-  "node-suite/process/title/title-set": {
-    "issue": "1401",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:process: process.title is not settable. Flips to PASS when #1401 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1395 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1395 is reopened."
   },
   "node-suite/process/env/allowed-flags": {
-    "issue": "1380",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:process: allowedNodeEnvironmentFlags Set-like behavior incomplete — main returns Expr::SetNew but the test (instanceof Set / .has) still fails. #1380 reopened. Flips to PASS when #1380 lands fully."
-  },
-  "node-suite/process/exit-code/coerced-int": {
-    "issue": "1350",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:process: process.exitCode = N does not round-trip via read (same root as exit-code-default). Flips to PASS when #1350 lands."
-  },
-  "node-suite/perf_hooks/mark/detail-circular": {
-    "issue": "1512",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: mark detail with a circular reference should be accepted (structuredClone handles cycles). Perry throws. Flips to PASS when #1512 lands."
-  },
-  "node-suite/perf_hooks/mark/detail-function-throws": {
-    "issue": "1513",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:perf_hooks: mark detail with a Function value should throw DataCloneError (structuredClone refuses). Perry silently accepts. Flips to PASS when #1513 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1380 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1380 is reopened."
   },
   "node-suite/stream/classes/readable-constructor": {
     "issue": "1531",
@@ -513,10 +423,10 @@
     "reason": "node:stream: Writable does not invoke its write() option callback / finish event. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/static/readable-is-disturbed": {
-    "issue": "1534",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.isDisturbed and sibling static helpers return undefined. Flips to PASS when #1534 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1534 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1534 is reopened."
   },
   "node-suite/stream/readable/highwater-mark-default": {
     "issue": "1537",
@@ -633,22 +543,22 @@
     "reason": "node:stream: pipeline with intermediate transform doesn't propagate data → end. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/webstream/readable-to-web": {
-    "issue": "1540",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.toWeb is not implemented. Flips to PASS when #1540 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1540 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1540 is reopened."
   },
   "node-suite/stream/webstream/readable-from-web": {
-    "issue": "1540",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.fromWeb is not implemented. Flips to PASS when #1540 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1540 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1540 is reopened."
   },
   "node-suite/stream/abort/add-abort-signal": {
-    "issue": "1541",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: stream.addAbortSignal is not a function. Flips to PASS when #1541 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1541 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1541 is reopened."
   },
   "node-suite/stream/events/listener-management": {
     "issue": "1531",
@@ -699,10 +609,10 @@
     "reason": "node:stream: Transform with explicit encoding doesn't deliver transformed chunks. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/instance-compose": {
-    "issue": "1539",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: readable.compose(transform) instance method not implemented. Flips to PASS when #1539 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1539 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1539 is reopened."
   },
   "node-suite/stream/finished/with-options-signal": {
     "issue": "1532",
@@ -729,10 +639,10 @@
     "reason": "node:stream: write() should return false when buffer exceeds highWaterMark. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/imports/has-default-export": {
-    "issue": "1535",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: default export should be a function (legacy Stream constructor). Flips to PASS when #1535 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1535 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1535 is reopened."
   },
   "node-suite/stream/duplex/options-merge": {
     "issue": "1531",
@@ -741,16 +651,16 @@
     "reason": "node:stream: Duplex readableObjectMode/writableObjectMode option-split not surfaced on instance. Flips to PASS when #1531 lands."
   },
   "node-suite/stream/static/readable-is-readable": {
-    "issue": "1534",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.isReadable static helper missing. Flips to PASS when #1534 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1534 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1534 is reopened."
   },
   "node-suite/stream/static/readable-is-errored": {
-    "issue": "1534",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Readable.isErrored static helper missing. Flips to PASS when #1534 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1534 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1534 is reopened."
   },
   "node-suite/stream/options/construct-callback": {
     "issue": "1531",
@@ -993,22 +903,22 @@
     "reason": "node:stream/web.TransformStream + pipeThrough not implemented. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/webstream/writable-to-web": {
-    "issue": "1540",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Writable.toWeb is not implemented. Flips to PASS when #1540 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1540 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1540 is reopened."
   },
   "node-suite/stream/webstream/writable-from-web": {
-    "issue": "1540",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Writable.fromWeb is not implemented. Flips to PASS when #1540 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1540 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1540 is reopened."
   },
   "node-suite/stream/webstream/duplex-to-web": {
-    "issue": "1540",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Duplex.toWeb is not implemented. Flips to PASS when #1540 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1540 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1540 is reopened."
   },
   "node-suite/stream/readable/from-string": {
     "issue": "1532",
@@ -1047,16 +957,16 @@
     "reason": "node:stream: autoDestroy default behavior doesn't fire close after end. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/abort/signal-aborts-stream": {
-    "issue": "1541",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: addAbortSignal + ctrl.abort() doesn't emit error on the stream. Flips to PASS when #1541 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1541 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1541 is reopened."
   },
   "node-suite/stream/compose/multiple-transforms": {
-    "issue": "1539",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: stream.compose(t1, t2) chain doesn't propagate through transforms. Flips to PASS when #1539 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1539 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1539 is reopened."
   },
   "node-suite/stream/pipeline/already-ended": {
     "issue": "1532",
@@ -1083,10 +993,10 @@
     "reason": "node:stream: read() with no arg should return the entire buffered chunk. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/static/is-readable-module-level": {
-    "issue": "1534",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: module-level isReadable/isErrored/isDisturbed not re-exported. Flips to PASS when #1534 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1534 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1534 is reopened."
   },
   "node-suite/stream/web/from-iterable": {
     "issue": "1545",
@@ -1323,10 +1233,10 @@
     "reason": "node:stream: two concurrent Symbol.asyncIterator on same Readable should error. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/with-async-fn": {
-    "issue": "1539",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: stream.compose with async-generator middle stage does not propagate. Flips to PASS when #1539 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1539 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1539 is reopened."
   },
   "node-suite/stream/destroy/destroy-during-write": {
     "issue": "1532",
@@ -1665,16 +1575,10 @@
     "reason": "node:stream: push(undefined) crashes instead of being treated as end-of-stream. Flips to PASS when #1532 lands."
   },
   "node-suite/stream/compose/from-async-iterable": {
-    "issue": "1539",
-    "added": "2026-05-23",
+    "issue": "1633",
+    "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: stream.compose with async-iterable source does not propagate data. Flips to PASS when #1539 lands."
-  },
-  "node-suite/stream/promises/pipeline-returns-undefined": {
-    "issue": "1533",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/promises: pipeline resolves with the wrong value. Flips to PASS when #1533 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1539 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1539 is reopened."
   },
   "node-suite/stream/web/pipe-to-with-options": {
     "issue": "1545",
@@ -1833,16 +1737,16 @@
     "reason": "node:stream/web: second getReader() on locked stream does not throw TypeError. Flips to PASS when #1545 lands."
   },
   "node-suite/stream/transform/separate-hwm": {
-    "issue": "1539",
+    "issue": "1633",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: Transform with distinct readableHighWaterMark/writableHighWaterMark — second value not preserved (both end up equal). Flips to PASS when #1539 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1539 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1539 is reopened."
   },
   "node-suite/stream/push/push-returns-false-on-full": {
-    "issue": "1539",
+    "issue": "1633",
     "added": "2026-05-24",
     "category": "bug-open",
-    "reason": "node:stream: push() always returns true even when buffer crosses highWaterMark — backpressure signal missing. Flips to PASS when #1539 lands."
+    "reason": "Re-validated 2026-05-24 (v0.5.1026, Linux): #1539 was closed completed but this test still FAILS byte-for-byte vs Node. Consolidated under #1633 until the fix is re-landed or #1539 is reopened."
   },
   "node-suite/stream/events/finish-end-close-order": {
     "issue": "1532",


### PR DESCRIPTION
Re-ran the parity suite (Node 22 --experimental-strip-types, Linux) over every skip-list entry whose tracking issue was closed, plus the untracked null-issue entries. Findings drive a cleanup + retrack.

- Drop 16 entries that now PASS: console depth/show-hidden/function-format/ no-tostring/json-circular (#1199-1204), perf_hooks to-string-tag + mark detail circular/function-throws (#1479/1512/1513), process exit-code + title-set (#1350/1401), stream promises.pipeline (#1533), test_gap_console_methods (#1278), test_parity_async_hooks (#789), express map-undefined (#912), zlib brotli-decompress.
- Retrack 21 entries whose issue was closed "completed" but still FAILS on main -> new consolidated tracker #1633 (process env/allowed-flags/rss + stream static #1534 / default-export #1535 / compose #1539 / web #1540 / abort #1541).
- Point 7 ci-env entries at #1634 (CI environment fixtures), 5 gap-bisect bundles at #1635.
- test_stream_on: was mis-filed ci-env -> real open stream gap, now #1532.
- Flag 4 deliberate repro/harness canaries (#655/#788/#806/#922) as bug-stale.

Net: 314 -> 298 entries. No stdlib/codegen change; no version bump (matches existing test(parity) commit precedent).

<!--
Thanks for contributing to Perry! A few things to know before you submit:

1. Please do NOT bump `[workspace.package] version` in Cargo.toml.
2. Please do NOT edit the "**Current Version:**" line or add a "Recent
   Changes" entry in CLAUDE.md.
3. Please do NOT edit CHANGELOG.md.

The maintainer folds all of that metadata in at merge time — Perry
releases frequently, and version bumps conflict if they live on the
PR branch. See CONTRIBUTING.md for the reasoning.
-->

## Summary

<!-- One or two sentences on what this PR changes and why. -->

## Changes

<!--
- Bullet list of concrete changes, one per logical item.
- File paths optional but appreciated for non-trivial PRs.
-->

## Related issue

<!-- Fixes #123 / Closes #123 / Refs #123 — or "n/a" if standalone. -->

## Test plan

<!--
How did you verify this works? A paste of the commands you ran is perfect.
-->

- [ ] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [ ] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/`
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform

## Screenshots / output
