### PR TITLE
test(parity): stream — batch of 16 tier-4/5 tests (iter-73..76) (3 free pass, 13 #1531/#1532/#1545/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1891,5 +1891,83 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: 'readable' event ordering relative to 'end' — extra readable before end missing or out-of-order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/meta/constructor-name": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: constructor.name on stream classes — returns 'Object' or other instead of 'Readable'/'Writable'/etc. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/async-iter/single-iteration-only": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: second for-await on already-iterated Readable yields wrong count (state not drained). Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/pipe/source-error-no-propagation": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe(src,dst) source-error handling — wrong error count on src or dst. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/error-event-arg-shape": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'error' event arg — identity / instanceof Error / message wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/pipethrough-preventclose-flag": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: pipeThrough(transform, {preventClose:true}) — transform.writable should remain unlocked. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/once-with-symbol-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: once() with Symbol event name (e.g. errorMonitor) — fires wrong count or doesn't auto-remove. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/readable-no-sync-iterator": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: Web ReadableStream exposes Symbol.iterator (should be undefined; only Symbol.asyncIterator). Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/promises/finished-returns-promise": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: promises.finished(stream) — return value not a Promise or doesn't resolve. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/cancel-during-pipeto": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: rs.cancel() during pipeTo — should reject (locked stream); resolves or wrong err name. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/iterator/for-of-not-async": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: sync for-of on Readable — Perry does not throw (TypeError expected since Symbol.iterator absent). Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/iter-helpers/take-zero": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: take(0) — yields non-empty result (should yield zero items). Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/web/transform-stream-with-strategies": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: TransformStream(t, writableStrategy, readableStrategy) — 3-arg constructor form not honored. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/length-byte-exact": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: readableLength after push('é') — does not count 2 UTF-8 bytes. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/async-iter/single-iteration-only.ts
+++ b/test-parity/node-suite/stream/async-iter/single-iteration-only.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// After full async-iteration completes, a second for-await yields nothing
+// (the underlying stream is drained / ended).
+const r = Readable.from(["a", "b"]);
+const first: string[] = [];
+for await (const v of r) first.push(String(v));
+const second: string[] = [];
+for await (const v of r) second.push(String(v));
+console.log("first:", first.join(","));
+console.log("second count:", second.length);

--- a/test-parity/node-suite/stream/events/listener-symbol-toPrimitive.ts
+++ b/test-parity/node-suite/stream/events/listener-symbol-toPrimitive.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// Stream instances don't have a custom Symbol.toPrimitive override.
+const r = new Readable({ read() {} });
+console.log("toPrimitive typeof:", typeof (r as any)[Symbol.toPrimitive]);
+console.log("toPrimitive undefined:", (r as any)[Symbol.toPrimitive] === undefined);

--- a/test-parity/node-suite/stream/events/once-with-symbol-event.ts
+++ b/test-parity/node-suite/stream/events/once-with-symbol-event.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+import { errorMonitor } from "node:events";
+// once() can subscribe to Symbol events; the listener fires once then
+// auto-removes.
+const r = new Readable({ read() {} });
+let count = 0;
+r.once(errorMonitor, () => count++);
+r.on("error", () => {});
+r.destroy(new Error("first"));
+setImmediate(() => {
+  console.log("first count:", count);
+  console.log("listenerCount(errorMonitor):", r.listenerCount(errorMonitor));
+});

--- a/test-parity/node-suite/stream/iter-helpers/take-zero.ts
+++ b/test-parity/node-suite/stream/iter-helpers/take-zero.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// take(0) — yields zero items.
+const r = Readable.from([1, 2, 3]);
+const out: number[] = [];
+for await (const v of (r as any).take(0)) out.push(v as number);
+console.log("count:", out.length);
+console.log("is empty:", out.length === 0);

--- a/test-parity/node-suite/stream/iterator/for-of-not-async.ts
+++ b/test-parity/node-suite/stream/iterator/for-of-not-async.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+// Readable does NOT have Symbol.iterator — using for-of (sync) should throw.
+const r = Readable.from(["a"]);
+let caught: string | null = null;
+try {
+  // @ts-expect-error — intentionally use sync for-of on async-only iterable
+  for (const _v of r as any) {
+    // unreachable
+  }
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/meta/constructor-name.ts
+++ b/test-parity/node-suite/stream/meta/constructor-name.ts
@@ -1,0 +1,7 @@
+import { Readable, Writable, Duplex, Transform, PassThrough } from "node:stream";
+// Stream class constructor.name reflects the class identity.
+console.log("R:", new Readable({ read() {} }).constructor.name);
+console.log("W:", new Writable({ write(_c, _e, cb) { cb(); } }).constructor.name);
+console.log("D:", new Duplex({ read() {}, write(_c, _e, cb) { cb(); } }).constructor.name);
+console.log("T:", new Transform({ transform(c, _e, cb) { cb(null, c); } }).constructor.name);
+console.log("P:", new PassThrough().constructor.name);

--- a/test-parity/node-suite/stream/meta/inspect-custom-symbol.ts
+++ b/test-parity/node-suite/stream/meta/inspect-custom-symbol.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+import * as util from "node:util";
+// util.inspect.custom symbol — Stream instances may override util.inspect's
+// formatting via Symbol.for("nodejs.util.inspect.custom").
+const r = new Readable({ read() {} });
+const sym = util.inspect.custom;
+console.log("custom inspect symbol is symbol:", typeof sym === "symbol");
+console.log("inspect output is string:", typeof util.inspect(r) === "string");

--- a/test-parity/node-suite/stream/pipe/source-error-no-propagation.ts
+++ b/test-parity/node-suite/stream/pipe/source-error-no-propagation.ts
@@ -1,0 +1,20 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe() does NOT auto-propagate source errors to destination (different
+// behavior from pipeline()). Source's 'error' fires; destination remains
+// writable unless `{ end: false }` is overridden.
+let dstErrors = 0;
+let srcErrors = 0;
+const src = new Readable({ read() {} });
+const dst = new PassThrough();
+src.on("error", () => srcErrors++);
+dst.on("error", () => dstErrors++);
+src.on("data", () => {});
+dst.on("data", () => {});
+src.pipe(dst);
+src.destroy(new Error("src-fail"));
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("src errors:", srcErrors);
+    console.log("dst errors:", dstErrors);
+  });
+});

--- a/test-parity/node-suite/stream/promises/finished-returns-promise.ts
+++ b/test-parity/node-suite/stream/promises/finished-returns-promise.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
+// stream/promises.finished returns a Promise — verify the type and that
+// it resolves once the stream ends.
+const r = Readable.from(["x"]);
+r.on("data", () => {});
+const p = finished(r);
+console.log("is Promise:", typeof (p as any).then === "function");
+await p;
+console.log("resolved");

--- a/test-parity/node-suite/stream/readable/error-event-arg-shape.ts
+++ b/test-parity/node-suite/stream/readable/error-event-arg-shape.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// 'error' event listener receives the exact Error instance passed to destroy().
+const orig = new Error("specific-instance");
+let received: any = null;
+const r = new Readable({ read() {} });
+r.on("error", (e) => (received = e));
+r.destroy(orig);
+setImmediate(() => {
+  console.log("identity match:", received === orig);
+  console.log("instanceof Error:", received instanceof Error);
+  console.log("message:", received && (received as Error).message);
+});

--- a/test-parity/node-suite/stream/readable/length-byte-exact.ts
+++ b/test-parity/node-suite/stream/readable/length-byte-exact.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// readableLength counts BYTES (UTF-8) for string pushes, not characters.
+const r = new Readable({ read() {} });
+r.push("é"); // 2 bytes in UTF-8
+console.log("length:", r.readableLength);
+console.log("is 2:", r.readableLength === 2);

--- a/test-parity/node-suite/stream/web/cancel-during-pipeto.ts
+++ b/test-parity/node-suite/stream/web/cancel-during-pipeto.ts
@@ -1,0 +1,17 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// rs.cancel() during an active pipeTo — the pipeTo promise rejects (locked stream).
+const rs = new ReadableStream({
+  pull(c) { setTimeout(() => c.enqueue("x"), 50); },
+});
+const ws = new WritableStream({ write() {} });
+const p = rs.pipeTo(ws);
+// While locked, cancel directly errors
+let cancelErr: string | null = null;
+try {
+  await rs.cancel("manual");
+} catch (e: any) {
+  cancelErr = e && e.name;
+}
+console.log("cancel-on-locked rejected:", cancelErr);
+// pipeTo will likely still be pending
+p.catch(() => {});

--- a/test-parity/node-suite/stream/web/pipethrough-preventclose-flag.ts
+++ b/test-parity/node-suite/stream/web/pipethrough-preventclose-flag.ts
@@ -1,0 +1,8 @@
+import { ReadableStream, TransformStream } from "node:stream/web";
+// pipeThrough(transform, { preventClose: true }) — closing source should
+// NOT close the transform's writable side.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const ts = new TransformStream();
+const out: any = rs.pipeThrough(ts, { preventClose: true });
+console.log("returned ReadableStream:", out instanceof ReadableStream);
+console.log("transform writable still unlocked:", ts.writable.locked === false);

--- a/test-parity/node-suite/stream/web/readable-no-sync-iterator.ts
+++ b/test-parity/node-suite/stream/web/readable-no-sync-iterator.ts
@@ -1,0 +1,6 @@
+import { ReadableStream } from "node:stream/web";
+// Web ReadableStream exposes Symbol.asyncIterator but NOT Symbol.iterator.
+const rs = new ReadableStream({ start(c) { c.close(); } });
+console.log("asyncIterator typeof:", typeof (rs as any)[Symbol.asyncIterator]);
+console.log("sync iterator typeof:", typeof (rs as any)[Symbol.iterator]);
+console.log("sync iter undefined:", (rs as any)[Symbol.iterator] === undefined);

--- a/test-parity/node-suite/stream/web/transform-stream-with-strategies.ts
+++ b/test-parity/node-suite/stream/web/transform-stream-with-strategies.ts
@@ -1,0 +1,9 @@
+import { TransformStream, CountQueuingStrategy } from "node:stream/web";
+// TransformStream(transformer, writableStrategy, readableStrategy)
+// — full 3-arg form sets HWM on both sides.
+const ws = new CountQueuingStrategy({ highWaterMark: 1 });
+const rs = new CountQueuingStrategy({ highWaterMark: 4 });
+const ts = new TransformStream(undefined, ws, rs);
+console.log("constructed:", ts instanceof TransformStream);
+console.log("ws hwm:", ws.highWaterMark);
+console.log("rs hwm:", rs.highWaterMark);

--- a/test-parity/node-suite/stream/web/writer-release-lock-during-write.ts
+++ b/test-parity/node-suite/stream/web/writer-release-lock-during-write.ts
@@ -1,0 +1,17 @@
+import { WritableStream } from "node:stream/web";
+// releaseLock() while a write is pending — the pending write Promise rejects.
+const ws = new WritableStream({
+  async write() {
+    await new Promise((resolve) => setTimeout(resolve, 30));
+  },
+});
+const w = ws.getWriter();
+const writeP = w.write("x");
+w.releaseLock();
+let err: string | null = null;
+try {
+  await writeP;
+} catch (e: any) {
+  err = e && e.name;
+}
+console.log("released during write -> err name:", err);


### PR DESCRIPTION
### Stream parity batch — 16 tests aggregated (iter-73..76)

**3 free passes + 13 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Meta / introspection | constructor-name, error-event-arg-shape, length-byte-exact, inspect-custom-symbol ✅, listener-symbol-toPrimitive ✅ | #1532 |
| Async iteration | single-iteration-only, for-of-not-async | #1531 |
| Pipe semantics | source-error-no-propagation | #1532 |
| Promises form | finished-returns-promise | #1532 |
| Once-listener semantics | once-with-symbol-event | #1532 |
| Web stream surface | writer-release-lock-during-write ✅, pipethrough-preventclose-flag, cancel-during-pipeto, readable-no-sync-iterator, transform-stream-with-strategies | #1545 |
| Iter helpers | take-zero | #1558 |

Free passes — Perry already matches Node:
- `web/writer-release-lock-during-write` (writer release rejects pending write)
- `meta/inspect-custom-symbol` (util.inspect.custom symbol available)
- `events/listener-symbol-toPrimitive` (Symbol.toPrimitive correctly absent)

All 13 failures tracked in `known_failures.json`; CI parity gate unaffected.
