### PR TITLE
test(parity): stream — consolidated iter-helpers batch (supersedes #1603–#1637)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1921,5 +1921,827 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: read() after end — does not consistently return null. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/end-twice-noop": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: end() called twice — second call fires duplicate 'finish' or errors. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/readable/iterate-after-toarray": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: iteration after toArray() yields wrong count (state not drained). Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/web/transform-cancel-propagates": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: TransformStream readable.cancel() does not propagate to writable — writes still succeed after cancel. Flips to PASS when #1545 lands."
+  },
+  "node-suite/perf_hooks/shapes/to-string-tag": {
+    "issue": "1479",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:perf_hooks: Object.prototype.toString.call(performance) yields the generic object tag instead of '[object Performance]'. Flips to PASS when #1479 lands."
+  },
+  "node-suite/console/dir/depth-options": {
+    "issue": "1199",
+    "added": "2026-05-20",
+    "category": "bug-open",
+    "reason": "node:console granular parity: console.dir(value, { depth }) does not honor Node-compatible inspect depth limits. Flips to PASS when #1199 lands."
+  },
+  "node-suite/console/dir/show-hidden-option": {
+    "issue": "1200",
+    "added": "2026-05-20",
+    "category": "bug-open",
+    "reason": "node:console granular parity: console.dir(value, { showHidden: true }) does not render hidden properties with Node-compatible inspect notation. Flips to PASS when #1200 lands."
+  },
+  "node-suite/console/output/function-format": {
+    "issue": "1202",
+    "added": "2026-05-20",
+    "category": "bug-open",
+    "reason": "node:console granular parity: function values currently lose Node-compatible closure/function names in inspect output. Flips to PASS when #1202 lands."
+  },
+  "node-suite/console/output/json-circular": {
+    "issue": "1204",
+    "added": "2026-05-20",
+    "category": "bug-open",
+    "reason": "node:console granular parity: circular object formatting lacks Node-compatible <ref> / [Circular] tracking. Flips to PASS when #1204 lands."
+  },
+  "node-suite/console/output/no-tostring-on-string-format": {
+    "issue": "1203",
+    "added": "2026-05-20",
+    "category": "bug-open",
+    "reason": "node:console granular parity: inspecting a function whose own `toString` is overridden doesn't follow Node's function-formatting path (which renders `[Function: name]` without invoking user `toString`). Flips to PASS when #1203 lands."
+  },
+  "test_gap_console_methods": {
+    "issue": "1278",
+    "added": "2026-05-21",
+    "category": "gap-categorical",
+    "reason": "#1278: console.trace / Error.stack frame format diverges from Node (Perry prints native frame addresses like `0: __mh_execute_header` instead of `at <fn> (file:///…:line:col)`). Requires source-position retention through HIR/transform + native-frame → TS-source mapping. The other two divergences in this fixture (#1276 spurious `Values` column on array-of-arrays, #1277 timer ms numbers) are not gating: #1276 was fixed in v0.5.1019+; #1277 is a misdiagnosis — Perry's `Instant::now()` is correct and the apparent 1000× gap is just AOT-vs-interpreted speedup on the trivial loop workload. Flips to PASS when #1278 lands."
+  },
+  "test_issue_express_map_undefined": {
+    "issue": "912",
+    "added": "2026-05-17",
+    "category": "bug-open",
+    "reason": "Regression test from #911 (express map undefined / http.METHODS). The METHODS property is now in the manifest (PR adding it alongside this entry); the test may still diverge from Node in the exact METHODS list shape. Re-evaluate once express compiles cleanly."
+  },
+  "test_parity_async_hooks": {
+    "issue": "789",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:async_hooks` createHook lifecycle + asyncId tracking missing. Tracked in #789. Flips to PASS once createHook fires."
+  },
+  "test_parity_stream_promises": {
+    "issue": "793",
+    "added": "2026-05-15",
+    "category": "module-inventory",
+    "reason": "Node.js module inventory — `node:stream/promises` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
+  },
+  "test_zlib_brotli_decompress": {
+    "issue": null,
+    "added": "2026-05-18",
+    "category": "ci-env",
+    "reason": "Brotli decompression path under node:zlib not yet implemented (cf. existing test_parity_zlib module-inventory entry). Same failure observed on #1038 pre-merge — not a regression."
+  },
+  "node-suite/process/exit-code/exit-code-default": {
+    "issue": "1350",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:process: process.exitCode does not default to undefined. Flips to PASS when #1350 lands."
+  },
+  "node-suite/process/title/title-set": {
+    "issue": "1401",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:process: process.title is not settable. Flips to PASS when #1401 lands."
+  },
+  "node-suite/process/exit-code/coerced-int": {
+    "issue": "1350",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:process: process.exitCode = N does not round-trip via read (same root as exit-code-default). Flips to PASS when #1350 lands."
+  },
+  "node-suite/perf_hooks/mark/detail-circular": {
+    "issue": "1512",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:perf_hooks: mark detail with a circular reference should be accepted (structuredClone handles cycles). Perry throws. Flips to PASS when #1512 lands."
+  },
+  "node-suite/perf_hooks/mark/detail-function-throws": {
+    "issue": "1513",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:perf_hooks: mark detail with a Function value should throw DataCloneError (structuredClone refuses). Perry silently accepts. Flips to PASS when #1513 lands."
+  },
+  "node-suite/stream/imports/promises-ns": {
+    "issue": "1533",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: stream.promises namespace is undefined (used for `await pipeline()` / `await finished()`). Flips to PASS when #1533 lands."
+  },
+  "node-suite/stream/promises/pipeline-await": {
+    "issue": "1533",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream: stream/promises pipeline await doesn't resolve correctly (depends on streams + promises ns). Flips to PASS when #1533 lands."
+  },
+  "node-suite/stream/promises/pipeline-rejects-on-error": {
+    "issue": "1533",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream/promises: pipeline doesn't reject with the underlying Error. Flips to PASS when #1533 lands."
+  },
+  "node-suite/stream/promises/finished-with-signal": {
+    "issue": "1533",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream/promises: finished with signal does not reject on abort. Flips to PASS when #1533 lands."
+  },
+  "node-suite/stream/promises/pipeline-with-signal": {
+    "issue": "1533",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream/promises: pipeline with signal does not reject on abort. Flips to PASS when #1533 lands."
+  },
+  "node-suite/stream/events/remove-listener-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'removeListener' meta-event not emitted when removeListener() is called. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/strategies-imported": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: CountQueuingStrategy / ByteLengthQueuingStrategy not exported from node:stream/web. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/returns-destination": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: r.pipe(dst) does not return dst — pipe-chain broken. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/object-mode-read-returns-object": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: objectMode Readable.read() does not return single object per call. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-buffer-direct": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Buffer) — Buffer is iterated byte-by-byte instead of emitted as single chunk. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/error-monitor-symbol": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: events.errorMonitor symbol observer not invoked on stream error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/map-async-rejection": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: readable.map(asyncFn) — rejection in fn does not abort iteration / propagate as throw. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/events/data-listener-auto-resume": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: adding 'data' listener does not flip readableFlowing to true. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/async-iter/iterator-next-direct": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: r[Symbol.asyncIterator]().next() — direct call doesn't yield correct {value, done} shape. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/writable/end-three-arg": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: end(chunk, encoding, callback) 3-arg form — cb does not fire after finish. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/iter-helpers/reduce-no-initial": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: reduce(fn) without initial — first item not used as accumulator. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/iterator/destroy-on-return-true-default": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: default destroyOnReturn:true — early break does not destroy stream. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/read-zero-probe": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read(0) probe — does not return null/trigger 'readable' without consuming. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/read-larger-than-buffered": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read(N>buffered) — does not return remaining buffered bytes at EOF. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/static/get-default-hwm-types": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: getDefaultHighWaterMark(false|true) — return type or value mismatches Node (not Number or 0). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipeline/async-fn-sink": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline(src, async fn) — fn-as-sink form not yet wired (cb not called, collected is empty). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/new-listener-meta-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'newListener' meta-event not emitted when a listener is added. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/pipe-to-locks-and-releases": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: pipeTo() does not flip rs/ws.locked true during, false after. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/unshift-after-end": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: unshift() after end — does not emit 'error' / ERR_STREAM_PUSH_AFTER_EOF. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/listener-count-by-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: listenerCount(event) — returns wrong count per event name. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/raw-listeners-once-wrapped": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: rawListeners() — once-wrapper does not expose .listener pointing at original fn. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/emit-multiple-args-stream": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: emit(event, a, b, c) — listeners receive wrong number of args (variadic args lost). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/async-handler-promise": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(src, asyncGenWithAwait) — async-await handler not iterated correctly. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/flow/multi-data-event-no-concat": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: flowing-mode push() yields concatenated chunk instead of separate 'data' events. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/byob-reader-getReader": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: getReader({mode:'byob'}) on non-byte stream does not throw TypeError. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/remove-all-listeners-no-arg": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: removeAllListeners() with no arg — does not clear every event's listeners. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/map-with-thisarg": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: iter-helper closure capture — outer-var reference in arrow fn yields wrong values. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/options/default-encoding": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Writable defaultEncoding option — encoding arg seen by _write differs from 'hex'. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/events/event-names-returns-array": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: eventNames() — returns wrong shape or missing event names. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/get-max-listeners-default": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: getMaxListeners() default — not 10, or EventEmitter.defaultMaxListeners differs. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/classes/readable-no-read-fn": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: new Readable({}) without read fn — push-based usage produces wrong output. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/from-map-entries": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Map) — entry tuples not yielded correctly. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-set-values": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Set) — values not iterated in insertion order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/writable-stream-no-args": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: new WritableStream() (no sink) — constructor or write() misbehaves. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/pipe-multiple-destinations": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe to multiple destinations — data delivered to only one or wrong counts. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/on-returns-this-chained": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: on() chained — return value not the emitter, breaking chained registration. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/flow/pause-resume-cycle": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: readableFlowing — does not track pause→flow→pause transitions correctly. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/cork-returns-undefined": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: cork()/uncork() return values differ from undefined. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/flow/pause-before-data-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pause() before 'data' listener — flow starts anyway when listener attached. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/unshift-increases-length": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: unshift() — readableLength does not grow by chunk size. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/transform-readable-writable-wired": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: TransformStream.readable/.writable not correctly typed as ReadableStream/WritableStream instances. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/listener-count-symbol-events": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: listenerCount(Symbol) — does not count Symbol-keyed listeners. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/prepend-once-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: prependOnceListener — wrong order or no auto-removal after firing. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/instance-chain": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: r.compose(t1).compose(t2) — chained compose() returns Duplex but pipeline breaks. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/web/writable-stream-strategy-only": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: WritableStream(undefined, strategy) — second-arg-only constructor form fails. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/read-in-readable-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read() inside 'readable' listener — while-loop drain pattern produces wrong output. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/transform/multi-output-per-input": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Transform pushing multiple outputs per single input — only first push consumed. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/readable/read-before-push": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read() before any push — should return null, returns wrong value. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/event-names-order-insertion": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: eventNames() — order does not match listener-insertion order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/read-n-consumes-exactly-n": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read(N) — consumes wrong byte count from buffered stream. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/end-with-chunk-writes-before-finish": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: end(chunk) ordering — chunk write happens after 'finish' event or not at all. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/flow/sequential-reads": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: sequential read(N) drain — buffer order or chunk boundaries wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/get-event-listeners-static": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: events.getEventListeners(emitter, event) — wrong listener array. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/async-iter-handler-rejection": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose() async-gen handler throw — composite does not emit 'error'. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/flow/pause-during-async-iter": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pause() inside for-await — affects iteration count incorrectly. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/dest-error-propagates": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe error semantics — destination error or source close state differs from Node. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/error-before-data-immediate-destroy": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: immediate destroy(err) — event ordering/set ('data'/'end' should NOT fire) wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/meta/stream-prototype-ee": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Stream class default export prototype chain doesn't reach EventEmitter. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/cancel-returns-undefined-promise": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: rs.cancel() resolves to value other than undefined. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/options/auto-destroy-true-default": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: autoDestroy:true default — stream not destroyed after 'end', 'close' may not fire. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/custom-strategy-nan-size": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: custom strategy size() returning NaN does not throw on enqueue. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/from-iterable-object": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(POJO-with-Symbol.iterator) — does not iterate the custom iterable. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/data-multi-listeners-same-data": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: multiple 'data' listeners — receive different chunks or wrong order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/unshift-return-value": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: unshift() return value — not undefined. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/pipe-to-returns-promise": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: pipeTo() return value — not a Promise<undefined>. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/meta/readable-no-sync-iterator": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable should NOT expose Symbol.iterator (only Symbol.asyncIterator) — typeof differs from Node. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipeline/promise-form": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline() from node:stream/promises — return value not a Promise<undefined>. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/spread-tarray-result": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: toArray() result not spreadable array (wrong type or shape). Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/web/writable-abort-returns-promise": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: WritableStream.abort() — return is not Promise<undefined>. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/end-true-explicit": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe(dst, {end:true}) — explicit form behaves differently from default. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/compose/buffer-preserves": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose() — Buffer chunks not preserved through pipeline (typed as string?). Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/transform/object-mode-default-false": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Transform default objectMode — readableObjectMode/writableObjectMode wrong default. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/destroy/destroy-with-non-error": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy(non-Error) — 'error' listener does not receive raw value. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/read-with-nan-size": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read(NaN) — NaN coercion to default behavior wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/writable-stream-null-sink": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: new WritableStream(null) — null sink construction differs from Node. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/meta/json-stringify-output": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: JSON.stringify(stream) — output shape differs from Node ({} vs something else). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/read-with-undefined-size": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read(undefined) — not equivalent to read() no-arg form. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/destroy/destroy-twice-idempotent": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy() called twice — fires duplicate 'close' or errors. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/iter-yields-buffer-no-encoding": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: for-await on Readable without setEncoding — chunks are not Buffer instances. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/byte-stream-construction": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: new ReadableStream({type:'bytes'}) — byte stream construction fails or BYOB unavailable. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/compose/error-propagates-to-source": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose() error does not destroy source. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/compose/single-stream-arg": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(stream) — single-stream form does not return Duplex wrap. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/unshift-buffer": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: unshift(Buffer) — explicit Buffer not properly added to front of buffer queue. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/writable-empty-object-sink": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: new WritableStream({}) — empty-sink writes don't silently succeed. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/web/desired-size-restores-after-drain": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: writer.desiredSize does not restore to HWM after write resolves. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/transform/this-binding-in-transform": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: `this` inside transform() — not bound to Transform instance, or this.push() does not enqueue. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/readable/highwater-mark-buffer": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: readableLength after multiple push() — does not equal sum of chunk lengths. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/listeners-returns-copy": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: EE.listeners() returns a live reference — mutating it affects internal count. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/flow/sync-pause-in-data-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pause() inside 'data' listener — does not stop further synchronous emits. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/get-writer-twice-throws": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: second getWriter() on locked WritableStream does not throw TypeError. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/push-returns-true-initial": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: push() under HWM does not return true. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/write-returns-false-at-hwm": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: write() does not return false when buffered bytes cross HWM. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/web/transform-readable-empty": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: TransformStream with empty writable.close() doesn't yield {done:true} on readable side. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/from-empty-iterable": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(empty) — 'end' event not fired or fires with wrong count. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/once-removed-after-fire": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: once() listener not removed after firing — second emit invokes it again. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/find-returns-promise": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: find() — return value is not a Promise<value|undefined>. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/web/byob-on-byte-stream": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: getReader({mode:'byob'}) on bytes-type stream fails or returns wrong shape. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/destroyed-true-immediately": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroyed flag not synchronously true after destroy(). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/listener-removal-during-emit": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: removeListener() during emit() — the snapshot semantics differ (other listener not fired or fires twice). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/promises/pipeline-returns-undefined": {
+    "issue": "1533",
+    "added": "2026-05-23",
+    "category": "bug-open",
+    "reason": "node:stream/promises: pipeline resolves with the wrong value. Flips to PASS when #1533 lands."
+  },
+  "node-suite/stream/meta/constructor-name": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: constructor.name on stream classes — returns 'Object' or other instead of 'Readable'/'Writable'/etc. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/async-iter/single-iteration-only": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: second for-await on already-iterated Readable yields wrong count (state not drained). Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/pipe/source-error-no-propagation": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe(src,dst) source-error handling — wrong error count on src or dst. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/error-event-arg-shape": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'error' event arg — identity / instanceof Error / message wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/pipethrough-preventclose-flag": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: pipeThrough(transform, {preventClose:true}) — transform.writable should remain unlocked. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/once-with-symbol-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: once() with Symbol event name (e.g. errorMonitor) — fires wrong count or doesn't auto-remove. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/readable-no-sync-iterator": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: Web ReadableStream exposes Symbol.iterator (should be undefined; only Symbol.asyncIterator). Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/promises/finished-returns-promise": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: promises.finished(stream) — return value not a Promise or doesn't resolve. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/cancel-during-pipeto": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: rs.cancel() during pipeTo — should reject (locked stream); resolves or wrong err name. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/iterator/for-of-not-async": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: sync for-of on Readable — Perry does not throw (TypeError expected since Symbol.iterator absent). Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/iter-helpers/take-zero": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: take(0) — yields non-empty result (should yield zero items). Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/web/transform-stream-with-strategies": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: TransformStream(t, writableStrategy, readableStrategy) — 3-arg constructor form not honored. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/length-byte-exact": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: readableLength after push('é') — does not count 2 UTF-8 bytes. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/abort/signal-timeout.ts
+++ b/test-parity/node-suite/stream/abort/signal-timeout.ts
@@ -1,0 +1,11 @@
+import { Readable, pipeline } from "node:stream";
+// AbortSignal.timeout(ms) aborts after ms milliseconds; pipeline gets
+// the abort as an err.
+const signal = (AbortSignal as any).timeout(20);
+const src = new Readable({ read() {} }); // never pushes
+pipeline(src, async function* (s: AsyncIterable<any>) {
+  for await (const c of s) yield c;
+}, { signal }, (err: any) => {
+  console.log("err present:", !!err);
+  console.log("err name:", err && err.name);
+});

--- a/test-parity/node-suite/stream/async-iter/iterator-next-direct.ts
+++ b/test-parity/node-suite/stream/async-iter/iterator-next-direct.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// r[Symbol.asyncIterator]() returns an async iterator whose next() yields
+// {value, done} Promises.
+const r = Readable.from(["a", "b"]);
+const it = (r as any)[Symbol.asyncIterator]();
+const a = await it.next();
+const b = await it.next();
+const c = await it.next();
+console.log("a:", a.value, a.done);
+console.log("b:", b.value, b.done);
+console.log("c done:", c.done);

--- a/test-parity/node-suite/stream/async-iter/single-iteration-only.ts
+++ b/test-parity/node-suite/stream/async-iter/single-iteration-only.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// After full async-iteration completes, a second for-await yields nothing
+// (the underlying stream is drained / ended).
+const r = Readable.from(["a", "b"]);
+const first: string[] = [];
+for await (const v of r) first.push(String(v));
+const second: string[] = [];
+for await (const v of r) second.push(String(v));
+console.log("first:", first.join(","));
+console.log("second count:", second.length);

--- a/test-parity/node-suite/stream/classes/passthrough-extends-transform.ts
+++ b/test-parity/node-suite/stream/classes/passthrough-extends-transform.ts
@@ -1,0 +1,8 @@
+import { PassThrough, Transform, Duplex, Readable, Writable } from "node:stream";
+// PassThrough extends Transform → Duplex → Readable + Writable.
+const p = new PassThrough();
+console.log("instanceof PassThrough:", p instanceof PassThrough);
+console.log("instanceof Transform:", p instanceof Transform);
+console.log("instanceof Duplex:", p instanceof Duplex);
+console.log("instanceof Readable:", p instanceof Readable);
+console.log("instanceof Writable:", p instanceof Writable);

--- a/test-parity/node-suite/stream/classes/readable-no-read-fn.ts
+++ b/test-parity/node-suite/stream/classes/readable-no-read-fn.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// new Readable({}) — no read fn — works for purely push-based usage.
+// (Calling read() emits 'error' with ERR_METHOD_NOT_IMPLEMENTED only in
+// pull mode; here we push, so no error.)
+const r = new Readable({});
+const out: string[] = [];
+r.on("data", (c) => out.push(String(c)));
+r.on("end", () => console.log("out:", out.join(",")));
+r.on("error", () => {});
+r.push("a");
+r.push("b");
+r.push(null);

--- a/test-parity/node-suite/stream/compose/async-handler-promise.ts
+++ b/test-parity/node-suite/stream/compose/async-handler-promise.ts
@@ -1,0 +1,13 @@
+import { compose, Readable } from "node:stream";
+// compose() accepts an async-generator handler that awaits between yields.
+const src = Readable.from(["a", "b", "c"]);
+async function* slow(source: AsyncIterable<any>) {
+  for await (const c of source) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    yield String(c).toUpperCase();
+  }
+}
+const composed: any = compose(src, slow);
+const out: string[] = [];
+composed.on("data", (c: any) => out.push(String(c)));
+composed.on("end", () => console.log("composed-async:", out.join(",")));

--- a/test-parity/node-suite/stream/compose/async-iter-handler-rejection.ts
+++ b/test-parity/node-suite/stream/compose/async-iter-handler-rejection.ts
@@ -1,0 +1,11 @@
+import { compose, Readable } from "node:stream";
+// An async-generator handler that throws — the composite emits 'error'.
+async function* failing(_src: AsyncIterable<any>) {
+  yield "a";
+  throw new Error("handler-fail");
+}
+const composite: any = compose(Readable.from(["x"]), failing);
+let errMsg: string | null = null;
+composite.on("error", (e: any) => (errMsg = e && e.message));
+composite.on("data", () => {});
+composite.on("close", () => console.log("err:", errMsg));

--- a/test-parity/node-suite/stream/compose/buffer-preserves.ts
+++ b/test-parity/node-suite/stream/compose/buffer-preserves.ts
@@ -1,0 +1,10 @@
+import { compose, Readable, Transform } from "node:stream";
+// Buffer chunks survive a compose-pipeline as Buffers (not converted to strings).
+const src = Readable.from([Buffer.from("ab")]);
+const noop = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+const composed: any = compose(src, noop);
+composed.on("data", (c: any) => {
+  console.log("is Buffer:", Buffer.isBuffer(c));
+  console.log("content:", c.toString("utf8"));
+});
+composed.on("end", () => console.log("done"));

--- a/test-parity/node-suite/stream/compose/error-propagates-to-source.ts
+++ b/test-parity/node-suite/stream/compose/error-propagates-to-source.ts
@@ -1,0 +1,13 @@
+import { compose, Readable, Transform } from "node:stream";
+// An error in the composite should propagate back to destroy the source.
+const src = new Readable({ read() {} });
+const bad = new Transform({
+  transform(_c, _e, cb) { cb(new Error("xform-fail")); },
+});
+const composed: any = compose(src, bad);
+composed.on("error", () => {});
+composed.on("data", () => {});
+src.push("x");
+setImmediate(() => {
+  setImmediate(() => console.log("src destroyed after composite err:", src.destroyed));
+});

--- a/test-parity/node-suite/stream/compose/instance-chain.ts
+++ b/test-parity/node-suite/stream/compose/instance-chain.ts
@@ -1,0 +1,9 @@
+import { Readable, Transform } from "node:stream";
+// readable.compose(t1).compose(t2) chains transforms (compose() returns Duplex).
+const r = Readable.from(["a", "b"]);
+const up = new Transform({ transform(c, _e, cb) { cb(null, String(c).toUpperCase()); } });
+const exclaim = new Transform({ transform(c, _e, cb) { cb(null, String(c) + "!"); } });
+const chained: any = (r as any).compose(up).compose(exclaim);
+const out: string[] = [];
+chained.on("data", (c: any) => out.push(String(c)));
+chained.on("end", () => console.log("chained:", out.join(",")));

--- a/test-parity/node-suite/stream/compose/returns-duplex-instance.ts
+++ b/test-parity/node-suite/stream/compose/returns-duplex-instance.ts
@@ -1,0 +1,9 @@
+import { compose, Duplex, Readable, Transform } from "node:stream";
+// compose(...) returns a Duplex — the composite stream is both Readable
+// and Writable from the outside, regardless of the inner components.
+const src = Readable.from(["a"]);
+const t = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+const composed: any = compose(src, t);
+console.log("instanceof Duplex:", composed instanceof Duplex);
+console.log("has write:", typeof composed.write === "function");
+console.log("has read:", typeof composed.read === "function");

--- a/test-parity/node-suite/stream/compose/single-stream-arg.ts
+++ b/test-parity/node-suite/stream/compose/single-stream-arg.ts
@@ -1,0 +1,8 @@
+import { compose, Readable, Duplex } from "node:stream";
+// compose() with a single stream returns a Duplex wrapping it.
+const r = Readable.from(["x"]);
+const composed: any = compose(r);
+console.log("instanceof Duplex:", composed instanceof Duplex);
+const out: string[] = [];
+composed.on("data", (c: any) => out.push(String(c)));
+composed.on("end", () => console.log("out:", out.join(",")));

--- a/test-parity/node-suite/stream/destroy/destroy-twice-idempotent.ts
+++ b/test-parity/node-suite/stream/destroy/destroy-twice-idempotent.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Calling destroy() twice is idempotent — only one 'close' event fires.
+let closeCount = 0;
+const r = new Readable({ read() {} });
+r.on("close", () => closeCount++);
+r.destroy();
+r.destroy();
+setImmediate(() => {
+  console.log("close count:", closeCount);
+  console.log("destroyed:", r.destroyed);
+});

--- a/test-parity/node-suite/stream/destroy/destroy-with-non-error.ts
+++ b/test-parity/node-suite/stream/destroy/destroy-with-non-error.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// destroy(non-Error) — Node accepts any value, emits 'error' with the
+// raw value (not wrapped in an Error).
+const r = new Readable({ read() {} });
+let received: any = null;
+r.on("error", (err) => (received = err));
+r.destroy("string-not-error" as any);
+setImmediate(() => {
+  console.log("received:", received);
+  console.log("is string:", typeof received === "string");
+});

--- a/test-parity/node-suite/stream/dispose/sync-dispose-call.ts
+++ b/test-parity/node-suite/stream/dispose/sync-dispose-call.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Calling Symbol.dispose on a stream destroys it synchronously (Node 21+).
+const r = new Readable({ read() {} });
+r.on("error", () => {});
+const dispose = (r as any)[Symbol.dispose];
+if (typeof dispose === "function") {
+  dispose.call(r);
+  setImmediate(() => {
+    console.log("destroyed after Symbol.dispose:", r.destroyed);
+  });
+} else {
+  console.log("Symbol.dispose not available, typeof:", typeof dispose);
+}

--- a/test-parity/node-suite/stream/events/data-listener-auto-resume.ts
+++ b/test-parity/node-suite/stream/events/data-listener-auto-resume.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// Adding a 'data' listener flips the stream into flowing mode (readableFlowing becomes true).
+const r = new Readable({ read() {} });
+console.log("flowing before:", r.readableFlowing);
+r.on("data", () => {});
+console.log("flowing after 'data':", r.readableFlowing);

--- a/test-parity/node-suite/stream/events/data-multi-listeners-same-data.ts
+++ b/test-parity/node-suite/stream/events/data-multi-listeners-same-data.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// Each registered 'data' listener receives the same chunk for every push.
+const r = new Readable({ read() {} });
+const a: string[] = [];
+const b: string[] = [];
+r.on("data", (c) => a.push(String(c)));
+r.on("data", (c) => b.push(String(c)));
+r.push("x");
+r.push("y");
+r.push(null);
+r.on("end", () => {
+  console.log("a:", a.join(","));
+  console.log("b:", b.join(","));
+  console.log("same:", a.join(",") === b.join(","));
+});

--- a/test-parity/node-suite/stream/events/emit-multiple-args-stream.ts
+++ b/test-parity/node-suite/stream/events/emit-multiple-args-stream.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// emit(event, a, b, c, ...) passes all args to each listener.
+const r = new Readable({ read() {} });
+let received: any[] = [];
+r.on("custom", (a: any, b: any, c: any) => {
+  received = [a, b, c];
+});
+r.emit("custom", 1, "two", { three: 3 });
+console.log("args:", JSON.stringify(received));

--- a/test-parity/node-suite/stream/events/error-before-data-immediate-destroy.ts
+++ b/test-parity/node-suite/stream/events/error-before-data-immediate-destroy.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// If destroy() is called before any data is pushed, only 'error' (if err
+// supplied) and 'close' fire; no 'data' or 'end'.
+const r = new Readable({ read() {} });
+const events: string[] = [];
+r.on("data", () => events.push("data"));
+r.on("end", () => events.push("end"));
+r.on("error", () => events.push("error"));
+r.on("close", () => events.push("close"));
+r.destroy(new Error("immediate-destroy"));
+setImmediate(() => console.log("events:", events.join(",")));

--- a/test-parity/node-suite/stream/events/error-monitor-symbol.ts
+++ b/test-parity/node-suite/stream/events/error-monitor-symbol.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+import { errorMonitor } from "node:events";
+// errorMonitor is a symbol that lets you observe 'error' events WITHOUT
+// consuming them. Without the symbol you can't be both observer + listener.
+const r = new Readable({ read() {} });
+let observed = false;
+let consumed = false;
+r.on(errorMonitor, () => (observed = true));
+r.on("error", () => (consumed = true));
+r.destroy(new Error("watcher-test"));
+setImmediate(() => {
+  console.log("observed:", observed);
+  console.log("consumed:", consumed);
+});

--- a/test-parity/node-suite/stream/events/event-names-order-insertion.ts
+++ b/test-parity/node-suite/stream/events/event-names-order-insertion.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// eventNames() returns events in insertion order (the order in which
+// the first listener was registered).
+const r = new Readable({ read() {} });
+r.on("zeta", () => {});
+r.on("alpha", () => {});
+r.on("middle", () => {});
+const names = r.eventNames();
+console.log("names:", names.join(","));
+console.log("first is zeta:", names[0] === "zeta");

--- a/test-parity/node-suite/stream/events/event-names-returns-array.ts
+++ b/test-parity/node-suite/stream/events/event-names-returns-array.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// eventNames() returns the array of event names currently with at least
+// one listener (string + symbol entries).
+const r = new Readable({ read() {} });
+r.on("data", () => {});
+r.on("end", () => {});
+const names = r.eventNames();
+console.log("is array:", Array.isArray(names));
+console.log("count:", names.length);
+console.log("has data:", names.includes("data"));
+console.log("has end:", names.includes("end"));

--- a/test-parity/node-suite/stream/events/get-event-listeners-static.ts
+++ b/test-parity/node-suite/stream/events/get-event-listeners-static.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+import { getEventListeners } from "node:events";
+// events.getEventListeners(emitter, event) returns the array of listeners
+// for the named event on the emitter.
+const r = new Readable({ read() {} });
+const fn1 = () => {};
+const fn2 = () => {};
+r.on("custom", fn1);
+r.on("custom", fn2);
+const listeners = getEventListeners(r, "custom");
+console.log("count:", listeners.length);
+console.log("is array:", Array.isArray(listeners));
+console.log("contains fn1:", listeners.includes(fn1));
+console.log("contains fn2:", listeners.includes(fn2));

--- a/test-parity/node-suite/stream/events/get-max-listeners-default.ts
+++ b/test-parity/node-suite/stream/events/get-max-listeners-default.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+import { EventEmitter } from "node:events";
+// getMaxListeners() returns Number; default is EventEmitter.defaultMaxListeners (10).
+const r = new Readable({ read() {} });
+console.log("default:", r.getMaxListeners());
+console.log("is number:", typeof r.getMaxListeners() === "number");
+console.log("EE default:", EventEmitter.defaultMaxListeners);

--- a/test-parity/node-suite/stream/events/listener-count-by-event.ts
+++ b/test-parity/node-suite/stream/events/listener-count-by-event.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// listenerCount(eventName) returns the number of registered listeners
+// for the given event (excludes future once()-removed wrappers count).
+const r = new Readable({ read() {} });
+r.on("data", () => {});
+r.on("data", () => {});
+r.once("end", () => {});
+console.log("data count:", r.listenerCount("data"));
+console.log("end count:", r.listenerCount("end"));
+console.log("error count:", r.listenerCount("error"));

--- a/test-parity/node-suite/stream/events/listener-count-symbol-events.ts
+++ b/test-parity/node-suite/stream/events/listener-count-symbol-events.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+import { errorMonitor } from "node:events";
+// listenerCount works with Symbol event names too (e.g., errorMonitor).
+const r = new Readable({ read() {} });
+r.on(errorMonitor, () => {});
+r.on(errorMonitor, () => {});
+console.log("symbol count:", r.listenerCount(errorMonitor));
+console.log("string-event count for data:", r.listenerCount("data"));

--- a/test-parity/node-suite/stream/events/listener-removal-during-emit.ts
+++ b/test-parity/node-suite/stream/events/listener-removal-during-emit.ts
@@ -1,0 +1,16 @@
+import { Readable } from "node:stream";
+// Removing a listener during emit() — the listener still fires this round
+// (because emit() snapshots the listener array).
+const r = new Readable({ read() {} });
+const fired: string[] = [];
+const fn1 = () => {
+  fired.push("fn1");
+  r.removeListener("custom", fn2);
+};
+const fn2 = () => {
+  fired.push("fn2");
+};
+r.on("custom", fn1);
+r.on("custom", fn2);
+r.emit("custom");
+console.log("fired:", fired.join(","));

--- a/test-parity/node-suite/stream/events/listener-symbol-toPrimitive.ts
+++ b/test-parity/node-suite/stream/events/listener-symbol-toPrimitive.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// Stream instances don't have a custom Symbol.toPrimitive override.
+const r = new Readable({ read() {} });
+console.log("toPrimitive typeof:", typeof (r as any)[Symbol.toPrimitive]);
+console.log("toPrimitive undefined:", (r as any)[Symbol.toPrimitive] === undefined);

--- a/test-parity/node-suite/stream/events/listeners-returns-copy.ts
+++ b/test-parity/node-suite/stream/events/listeners-returns-copy.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// listeners(event) returns a COPY of the listener array — mutating it
+// must not affect the emitter's internal list.
+const r = new Readable({ read() {} });
+const fn1 = () => {};
+const fn2 = () => {};
+r.on("data", fn1);
+r.on("data", fn2);
+const arr = r.listeners("data");
+arr.length = 0; // mutate the returned array
+console.log("internal count:", r.listenerCount("data"));
+console.log("unchanged:", r.listenerCount("data") === 2);

--- a/test-parity/node-suite/stream/events/new-listener-meta-event.ts
+++ b/test-parity/node-suite/stream/events/new-listener-meta-event.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// 'newListener' is fired when a listener is added, BEFORE it joins the
+// listener list. Useful for hooking into setup.
+const r = new Readable({ read() {} });
+const seenEvents: string[] = [];
+r.on("newListener", (event) => seenEvents.push(event));
+r.on("data", () => {});
+r.on("end", () => {});
+console.log("newListener fired for:", seenEvents.join(","));

--- a/test-parity/node-suite/stream/events/on-returns-this-chained.ts
+++ b/test-parity/node-suite/stream/events/on-returns-this-chained.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// on() returns the emitter itself, enabling chained registrations.
+const r = new Readable({ read() {} });
+const chained = r.on("data", () => {}).on("end", () => {});
+console.log("chained is r:", chained === r);
+console.log("data listeners:", r.listenerCount("data"));
+console.log("end listeners:", r.listenerCount("end"));

--- a/test-parity/node-suite/stream/events/once-removed-after-fire.ts
+++ b/test-parity/node-suite/stream/events/once-removed-after-fire.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// once(event, fn) — the listener is removed after the event fires once.
+const r = new Readable({ read() {} });
+let count = 0;
+r.once("custom", () => count++);
+r.emit("custom");
+r.emit("custom");
+console.log("listener fired:", count);
+console.log("listenerCount after fire:", r.listenerCount("custom"));

--- a/test-parity/node-suite/stream/events/once-with-symbol-event.ts
+++ b/test-parity/node-suite/stream/events/once-with-symbol-event.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+import { errorMonitor } from "node:events";
+// once() can subscribe to Symbol events; the listener fires once then
+// auto-removes.
+const r = new Readable({ read() {} });
+let count = 0;
+r.once(errorMonitor, () => count++);
+r.on("error", () => {});
+r.destroy(new Error("first"));
+setImmediate(() => {
+  console.log("first count:", count);
+  console.log("listenerCount(errorMonitor):", r.listenerCount(errorMonitor));
+});

--- a/test-parity/node-suite/stream/events/prepend-once-listener.ts
+++ b/test-parity/node-suite/stream/events/prepend-once-listener.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// prependOnceListener inserts the listener at the front and removes it
+// after one firing.
+const r = new Readable({ read() {} });
+const order: string[] = [];
+r.on("custom", () => order.push("on"));
+r.prependOnceListener("custom", () => order.push("prepend-once"));
+r.emit("custom");
+r.emit("custom"); // prepend-once should not fire again
+console.log("order:", order.join(","));
+console.log("count after 2 emits:", order.length);

--- a/test-parity/node-suite/stream/events/raw-listeners-once-wrapped.ts
+++ b/test-parity/node-suite/stream/events/raw-listeners-once-wrapped.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// rawListeners() returns the listener array INCLUDING the once-wrapper
+// for once() listeners (.listener points to the original fn).
+const r = new Readable({ read() {} });
+const fn = () => {};
+r.once("end", fn);
+const raw = r.rawListeners("end");
+console.log("raw length:", raw.length);
+console.log("raw[0] is wrapper:", (raw[0] as any).listener === fn);

--- a/test-parity/node-suite/stream/events/remove-all-listeners-no-arg.ts
+++ b/test-parity/node-suite/stream/events/remove-all-listeners-no-arg.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// removeAllListeners() without an event name clears EVERY listener for
+// every event on the emitter.
+const r = new Readable({ read() {} });
+r.on("data", () => {});
+r.on("end", () => {});
+r.on("error", () => {});
+r.removeAllListeners();
+console.log("event names left:", r.eventNames().length);

--- a/test-parity/node-suite/stream/events/remove-listener-event.ts
+++ b/test-parity/node-suite/stream/events/remove-listener-event.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+// 'removeListener' is emitted when a listener is removed via removeListener().
+const r = new Readable({ read() {} });
+let fired = false;
+let firedEvent: string | null = null;
+r.on("removeListener", (event) => {
+  fired = true;
+  firedEvent = event;
+});
+const fn = () => {};
+r.on("data", fn);
+r.removeListener("data", fn);
+console.log("removeListener event fired:", fired);
+console.log("event name:", firedEvent);

--- a/test-parity/node-suite/stream/flow/multi-data-event-no-concat.ts
+++ b/test-parity/node-suite/stream/flow/multi-data-event-no-concat.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+// In flowing mode, each push() generally produces its own 'data' event
+// (chunks not concatenated unless buffered before listener attaches).
+const r = new Readable({ read() {} });
+const events: string[] = [];
+r.on("data", (c) => events.push(String(c)));
+r.on("end", () => {
+  console.log("event count:", events.length);
+  console.log("each event:", events.join(","));
+});
+r.push("a");
+r.push("b");
+r.push("c");
+r.push(null);

--- a/test-parity/node-suite/stream/flow/pause-before-data-listener.ts
+++ b/test-parity/node-suite/stream/flow/pause-before-data-listener.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Calling pause() before adding a 'data' listener prevents the stream
+// from auto-flowing when the listener is later added.
+const r = Readable.from(["a", "b", "c"]);
+r.pause();
+let count = 0;
+r.on("data", () => count++);
+setImmediate(() => {
+  console.log("count while paused:", count);
+  console.log("flowing:", r.readableFlowing);
+});

--- a/test-parity/node-suite/stream/flow/pause-during-async-iter.ts
+++ b/test-parity/node-suite/stream/flow/pause-during-async-iter.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Calling pause() between two async-iter steps shouldn't stop iteration
+// (the iterator pulls regardless of the flowing flag).
+const r = Readable.from(["a", "b", "c"]);
+const out: string[] = [];
+for await (const v of r) {
+  out.push(String(v));
+  r.pause();
+}
+console.log("iterated:", out.join(","));
+console.log("count:", out.length);

--- a/test-parity/node-suite/stream/flow/pause-resume-cycle.ts
+++ b/test-parity/node-suite/stream/flow/pause-resume-cycle.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// A stream can cycle through paused → flowing → paused. The
+// readableFlowing getter reflects each state.
+const r = new Readable({ read() {} });
+console.log("initial:", r.readableFlowing);
+r.on("data", () => {});
+console.log("after data:", r.readableFlowing);
+r.pause();
+console.log("after pause:", r.readableFlowing);
+r.resume();
+console.log("after resume:", r.readableFlowing);

--- a/test-parity/node-suite/stream/flow/sequential-reads.ts
+++ b/test-parity/node-suite/stream/flow/sequential-reads.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Multiple sequential read() calls drain the buffer in order.
+const r = new Readable({ read() {} });
+r.push("aa");
+r.push("bb");
+r.push("cc");
+r.push(null);
+const out: string[] = [];
+r.on("readable", () => {
+  let c;
+  while ((c = r.read(2)) !== null) out.push(String(c));
+});
+r.on("end", () => console.log("sequential:", out.join("|")));

--- a/test-parity/node-suite/stream/flow/sync-pause-in-data-listener.ts
+++ b/test-parity/node-suite/stream/flow/sync-pause-in-data-listener.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// Calling pause() inside a 'data' listener stops further synchronous emits.
+const r = Readable.from(["a", "b", "c", "d"]);
+const out: string[] = [];
+r.on("data", (c) => {
+  out.push(String(c));
+  r.pause();
+});
+setImmediate(() => {
+  console.log("first batch count:", out.length);
+  console.log("flowing:", r.readableFlowing);
+});

--- a/test-parity/node-suite/stream/iter-helpers/every-empty-true.ts
+++ b/test-parity/node-suite/stream/iter-helpers/every-empty-true.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// every(fn) on an empty stream returns true (vacuously).
+const r = Readable.from([]);
+const result = await (r as any).every((_x: any) => false);
+console.log("every(empty) returns:", result);

--- a/test-parity/node-suite/stream/iter-helpers/find-no-match.ts
+++ b/test-parity/node-suite/stream/iter-helpers/find-no-match.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// find(fn) returns undefined when no item matches the predicate.
+const r = Readable.from([1, 2, 3, 4]);
+const result = await (r as any).find((x: number) => x > 10);
+console.log("found:", result);
+console.log("is undefined:", result === undefined);

--- a/test-parity/node-suite/stream/iter-helpers/find-returns-promise.ts
+++ b/test-parity/node-suite/stream/iter-helpers/find-returns-promise.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// r.find(fn) returns a Promise — Promise.resolve(undefined) if no match.
+const r = Readable.from([1, 2, 3, 4]);
+const p = (r as any).find((x: number) => x > 2);
+console.log("is Promise:", typeof p.then === "function");
+const value = await p;
+console.log("value:", value);

--- a/test-parity/node-suite/stream/iter-helpers/map-async-rejection.ts
+++ b/test-parity/node-suite/stream/iter-helpers/map-async-rejection.ts
@@ -1,0 +1,17 @@
+import { Readable } from "node:stream";
+// readable.map(asyncFn) — when the async fn throws, the resulting iterable
+// rejects and iteration ends.
+const r = Readable.from([1, 2, 3]);
+const mapped = r.map(async (x: number) => {
+  if (x === 2) throw new Error("map-fail");
+  return x * 10;
+});
+const out: number[] = [];
+let err: string | null = null;
+try {
+  for await (const v of mapped as any) out.push(v as number);
+} catch (e: any) {
+  err = e && e.message;
+}
+console.log("out:", out.join(","));
+console.log("err:", err);

--- a/test-parity/node-suite/stream/iter-helpers/map-with-thisarg.ts
+++ b/test-parity/node-suite/stream/iter-helpers/map-with-thisarg.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Iterator helpers accept { signal, concurrency } options but do NOT have
+// a thisArg in the options bag — fn binds normally. Confirm: arrow fn
+// referencing outer var works.
+const r = Readable.from([1, 2, 3]);
+const multiplier = 10;
+const mapped = r.map((x: any) => (x as number) * multiplier);
+const out: number[] = [];
+for await (const v of mapped as any) out.push(v);
+console.log("mapped:", out.join(","));

--- a/test-parity/node-suite/stream/iter-helpers/reduce-no-initial.ts
+++ b/test-parity/node-suite/stream/iter-helpers/reduce-no-initial.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// reduce(fn) without an initial value uses the first stream item as the
+// accumulator, then folds the rest.
+const r = Readable.from([1, 2, 3, 4]);
+const sum = await (r as any).reduce((acc: number, x: number) => acc + x);
+console.log("sum:", sum);

--- a/test-parity/node-suite/stream/iter-helpers/some-empty-false.ts
+++ b/test-parity/node-suite/stream/iter-helpers/some-empty-false.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// some(fn) on an empty stream returns false (no item to match).
+const r = Readable.from([]);
+const result = await (r as any).some((_x: any) => true);
+console.log("some(empty) returns:", result);

--- a/test-parity/node-suite/stream/iter-helpers/spread-tarray-result.ts
+++ b/test-parity/node-suite/stream/iter-helpers/spread-tarray-result.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// `await r.toArray()` returns a plain Array that can be spread.
+const r = Readable.from([1, 2, 3]);
+const arr = await (r as any).toArray();
+console.log("is array:", Array.isArray(arr));
+const spread = [...arr, 99];
+console.log("spread:", spread.join(","));

--- a/test-parity/node-suite/stream/iter-helpers/take-zero.ts
+++ b/test-parity/node-suite/stream/iter-helpers/take-zero.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// take(0) — yields zero items.
+const r = Readable.from([1, 2, 3]);
+const out: number[] = [];
+for await (const v of (r as any).take(0)) out.push(v as number);
+console.log("count:", out.length);
+console.log("is empty:", out.length === 0);

--- a/test-parity/node-suite/stream/iterator/destroy-on-return-true-default.ts
+++ b/test-parity/node-suite/stream/iterator/destroy-on-return-true-default.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// The default for the iterator is destroyOnReturn: true — early-return
+// destroys the stream.
+const r = Readable.from(["a", "b", "c"]);
+let count = 0;
+for await (const _v of r) {
+  count++;
+  if (count === 1) break; // early return
+}
+setImmediate(() => {
+  console.log("destroyed after early break:", r.destroyed);
+});

--- a/test-parity/node-suite/stream/iterator/for-of-not-async.ts
+++ b/test-parity/node-suite/stream/iterator/for-of-not-async.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+// Readable does NOT have Symbol.iterator — using for-of (sync) should throw.
+const r = Readable.from(["a"]);
+let caught: string | null = null;
+try {
+  // @ts-expect-error — intentionally use sync for-of on async-only iterable
+  for (const _v of r as any) {
+    // unreachable
+  }
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/meta/constructor-name.ts
+++ b/test-parity/node-suite/stream/meta/constructor-name.ts
@@ -1,0 +1,7 @@
+import { Readable, Writable, Duplex, Transform, PassThrough } from "node:stream";
+// Stream class constructor.name reflects the class identity.
+console.log("R:", new Readable({ read() {} }).constructor.name);
+console.log("W:", new Writable({ write(_c, _e, cb) { cb(); } }).constructor.name);
+console.log("D:", new Duplex({ read() {}, write(_c, _e, cb) { cb(); } }).constructor.name);
+console.log("T:", new Transform({ transform(c, _e, cb) { cb(null, c); } }).constructor.name);
+console.log("P:", new PassThrough().constructor.name);

--- a/test-parity/node-suite/stream/meta/inspect-custom-symbol.ts
+++ b/test-parity/node-suite/stream/meta/inspect-custom-symbol.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+import * as util from "node:util";
+// util.inspect.custom symbol — Stream instances may override util.inspect's
+// formatting via Symbol.for("nodejs.util.inspect.custom").
+const r = new Readable({ read() {} });
+const sym = util.inspect.custom;
+console.log("custom inspect symbol is symbol:", typeof sym === "symbol");
+console.log("inspect output is string:", typeof util.inspect(r) === "string");

--- a/test-parity/node-suite/stream/meta/instanceof-eventemitter.ts
+++ b/test-parity/node-suite/stream/meta/instanceof-eventemitter.ts
@@ -1,0 +1,13 @@
+import { Readable, Writable, Duplex, Transform, PassThrough } from "node:stream";
+import { EventEmitter } from "node:events";
+// All Node stream classes inherit from EventEmitter.
+const r = new Readable({ read() {} });
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+const d = new Duplex({ read() {}, write(_c, _e, cb) { cb(); } });
+const t = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+const p = new PassThrough();
+console.log("R:", r instanceof EventEmitter);
+console.log("W:", w instanceof EventEmitter);
+console.log("D:", d instanceof EventEmitter);
+console.log("T:", t instanceof EventEmitter);
+console.log("P:", p instanceof EventEmitter);

--- a/test-parity/node-suite/stream/meta/json-stringify-output.ts
+++ b/test-parity/node-suite/stream/meta/json-stringify-output.ts
@@ -1,0 +1,12 @@
+import { Readable, Writable } from "node:stream";
+// JSON.stringify(stream) — uses the default object serializer; the result
+// is typically "{}" (no own enumerable props), or omitted (returns
+// undefined) if the stream has custom toJSON returning undefined.
+const r = new Readable({ read() {} });
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+const rJson = JSON.stringify(r);
+const wJson = JSON.stringify(w);
+console.log("R json:", rJson);
+console.log("W json:", wJson);
+console.log("R is string:", typeof rJson === "string");
+console.log("W is string:", typeof wJson === "string");

--- a/test-parity/node-suite/stream/meta/readable-no-sync-iterator.ts
+++ b/test-parity/node-suite/stream/meta/readable-no-sync-iterator.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// Readable streams expose Symbol.asyncIterator but NOT Symbol.iterator
+// (they're async by nature).
+const r = new Readable({ read() {} });
+console.log("asyncIterator typeof:", typeof (r as any)[Symbol.asyncIterator]);
+console.log("sync iterator typeof:", typeof (r as any)[Symbol.iterator]);
+console.log("sync is undefined:", (r as any)[Symbol.iterator] === undefined);

--- a/test-parity/node-suite/stream/meta/stream-prototype-ee.ts
+++ b/test-parity/node-suite/stream/meta/stream-prototype-ee.ts
@@ -1,0 +1,6 @@
+import * as stream from "node:stream";
+import { EventEmitter } from "node:events";
+// The legacy Stream class (default export of node:stream) inherits from EE.
+const Stream: any = (stream as any).default || (stream as any).Stream;
+console.log("Stream defined:", typeof Stream === "function");
+console.log("prototype chain has EE:", Stream.prototype instanceof EventEmitter);

--- a/test-parity/node-suite/stream/options/auto-destroy-true-default.ts
+++ b/test-parity/node-suite/stream/options/auto-destroy-true-default.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// autoDestroy defaults to true — after end, the stream destroys itself
+// (firing 'close' even without explicit destroy()).
+const r = new Readable({ read() {} });
+let closedFired = false;
+r.on("close", () => (closedFired = true));
+r.on("data", () => {});
+r.on("end", () => {
+  setImmediate(() => {
+    console.log("destroyed:", r.destroyed);
+    console.log("closed fired:", closedFired);
+  });
+});
+r.push("a");
+r.push(null);

--- a/test-parity/node-suite/stream/options/default-encoding.ts
+++ b/test-parity/node-suite/stream/options/default-encoding.ts
@@ -1,0 +1,14 @@
+import { Writable } from "node:stream";
+// Writable's defaultEncoding option controls the encoding used when
+// write(chunk) is called without an explicit encoding arg.
+let seenEnc: any = null;
+const w = new Writable({
+  defaultEncoding: "hex",
+  write(_c, enc, cb) {
+    if (!seenEnc) seenEnc = enc;
+    cb();
+  },
+});
+w.write("abcdef");
+w.end();
+w.on("finish", () => console.log("default encoding:", seenEnc));

--- a/test-parity/node-suite/stream/pipe/dest-error-propagates.ts
+++ b/test-parity/node-suite/stream/pipe/dest-error-propagates.ts
@@ -1,0 +1,19 @@
+import { Readable, Writable } from "node:stream";
+// When the destination errors, the source's 'unpipe' fires and downstream
+// stops. Pipe alone does NOT propagate the error back to source by default.
+let srcDestroyed = false;
+const src = new Readable({ read() {} });
+src.on("close", () => (srcDestroyed = true));
+const dst = new Writable({
+  write(_c, _e, cb) { cb(new Error("write-fail")); },
+});
+let dstErr: string | null = null;
+dst.on("error", (e) => (dstErr = e && e.message));
+src.pipe(dst);
+src.push("x");
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("dst err:", dstErr);
+    console.log("src destroyed (pipe alone shouldn't):", srcDestroyed);
+  });
+});

--- a/test-parity/node-suite/stream/pipe/end-true-explicit.ts
+++ b/test-parity/node-suite/stream/pipe/end-true-explicit.ts
@@ -1,0 +1,12 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe(dst, { end: true }) — explicit form of the default; destination
+// IS ended when source ends.
+const r = Readable.from(["a"]);
+const dst = new PassThrough();
+let dstEnded = false;
+dst.on("end", () => (dstEnded = true));
+dst.on("data", () => {});
+r.pipe(dst, { end: true });
+setImmediate(() => {
+  setImmediate(() => console.log("dst ended:", dstEnded));
+});

--- a/test-parity/node-suite/stream/pipe/pipe-multiple-destinations.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-multiple-destinations.ts
@@ -1,0 +1,17 @@
+import { Readable, PassThrough } from "node:stream";
+// One source can pipe to multiple destinations; each gets the data.
+const r = Readable.from(["x"]);
+const a = new PassThrough();
+const b = new PassThrough();
+let aGot = 0, bGot = 0;
+a.on("data", () => aGot++);
+b.on("data", () => bGot++);
+let endCount = 0;
+const checkDone = () => {
+  endCount++;
+  if (endCount === 2) console.log("a:", aGot, "b:", bGot);
+};
+a.on("end", checkDone);
+b.on("end", checkDone);
+r.pipe(a);
+r.pipe(b);

--- a/test-parity/node-suite/stream/pipe/returns-destination.ts
+++ b/test-parity/node-suite/stream/pipe/returns-destination.ts
@@ -1,0 +1,12 @@
+import { Readable, PassThrough } from "node:stream";
+// readable.pipe(dst) returns dst (so you can chain `.pipe(next)`).
+const r = Readable.from(["x"]);
+const middle = new PassThrough();
+const sink = new PassThrough();
+const returned = r.pipe(middle);
+console.log("returned is middle:", returned === middle);
+// Chain pipe
+const chained = middle.pipe(sink);
+console.log("chained is sink:", chained === sink);
+sink.on("data", () => {});
+sink.on("end", () => console.log("done"));

--- a/test-parity/node-suite/stream/pipe/source-error-no-propagation.ts
+++ b/test-parity/node-suite/stream/pipe/source-error-no-propagation.ts
@@ -1,0 +1,20 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe() does NOT auto-propagate source errors to destination (different
+// behavior from pipeline()). Source's 'error' fires; destination remains
+// writable unless `{ end: false }` is overridden.
+let dstErrors = 0;
+let srcErrors = 0;
+const src = new Readable({ read() {} });
+const dst = new PassThrough();
+src.on("error", () => srcErrors++);
+dst.on("error", () => dstErrors++);
+src.on("data", () => {});
+dst.on("data", () => {});
+src.pipe(dst);
+src.destroy(new Error("src-fail"));
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("src errors:", srcErrors);
+    console.log("dst errors:", dstErrors);
+  });
+});

--- a/test-parity/node-suite/stream/pipe/unpipe-no-arg-removes-all.ts
+++ b/test-parity/node-suite/stream/pipe/unpipe-no-arg-removes-all.ts
@@ -1,0 +1,17 @@
+import { Readable, PassThrough } from "node:stream";
+// unpipe() with no arg removes ALL pipe destinations from the source.
+const r = Readable.from(["x"]);
+const a = new PassThrough();
+const b = new PassThrough();
+let aGot = 0, bGot = 0;
+a.on("data", () => aGot++);
+b.on("data", () => bGot++);
+r.pipe(a);
+r.pipe(b);
+r.unpipe();
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("a got after unpipe:", aGot);
+    console.log("b got after unpipe:", bGot);
+  });
+});

--- a/test-parity/node-suite/stream/pipeline/async-fn-sink.ts
+++ b/test-parity/node-suite/stream/pipeline/async-fn-sink.ts
@@ -1,0 +1,15 @@
+import { Readable, pipeline } from "node:stream";
+// pipeline(src, async fn) — fn receives the async-iterable source and
+// can collect or process it; pipeline calls the cb when fn resolves.
+const src = Readable.from(["a", "b", "c"]);
+const collected: string[] = [];
+pipeline(
+  src,
+  async function (source: AsyncIterable<any>) {
+    for await (const v of source) collected.push(String(v));
+  },
+  (err: any) => {
+    console.log("err:", err);
+    console.log("collected:", collected.join(","));
+  },
+);

--- a/test-parity/node-suite/stream/pipeline/promise-form.ts
+++ b/test-parity/node-suite/stream/pipeline/promise-form.ts
@@ -1,0 +1,11 @@
+import { Readable, PassThrough } from "node:stream";
+import { pipeline } from "node:stream/promises";
+// pipeline() from node:stream/promises returns a Promise (no callback form).
+const src = Readable.from(["a"]);
+const sink = new PassThrough();
+sink.on("data", () => {});
+const result = pipeline(src, sink);
+console.log("is Promise:", typeof (result as any).then === "function");
+const v = await result;
+console.log("resolved to:", v);
+console.log("is undefined:", v === undefined);

--- a/test-parity/node-suite/stream/promises/finished-returns-promise.ts
+++ b/test-parity/node-suite/stream/promises/finished-returns-promise.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
+// stream/promises.finished returns a Promise — verify the type and that
+// it resolves once the stream ends.
+const r = Readable.from(["x"]);
+r.on("data", () => {});
+const p = finished(r);
+console.log("is Promise:", typeof (p as any).then === "function");
+await p;
+console.log("resolved");

--- a/test-parity/node-suite/stream/readable/destroyed-true-immediately.ts
+++ b/test-parity/node-suite/stream/readable/destroyed-true-immediately.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// destroyed flag is true immediately (synchronously) after destroy() returns.
+const r = new Readable({ read() {} });
+console.log("before:", r.destroyed);
+r.destroy();
+console.log("after:", r.destroyed);
+console.log("sync true:", r.destroyed === true);

--- a/test-parity/node-suite/stream/readable/error-event-arg-shape.ts
+++ b/test-parity/node-suite/stream/readable/error-event-arg-shape.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// 'error' event listener receives the exact Error instance passed to destroy().
+const orig = new Error("specific-instance");
+let received: any = null;
+const r = new Readable({ read() {} });
+r.on("error", (e) => (received = e));
+r.destroy(orig);
+setImmediate(() => {
+  console.log("identity match:", received === orig);
+  console.log("instanceof Error:", received instanceof Error);
+  console.log("message:", received && (received as Error).message);
+});

--- a/test-parity/node-suite/stream/readable/from-buffer-direct.ts
+++ b/test-parity/node-suite/stream/readable/from-buffer-direct.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Readable.from(Buffer) — Buffer is iterable so each byte is a chunk in
+// objectMode, BUT Node short-circuits and emits whole Buffer as one chunk.
+const r = Readable.from(Buffer.from("abc"));
+const chunks: any[] = [];
+r.on("data", (c) => chunks.push(c));
+r.on("end", () => {
+  console.log("chunk count:", chunks.length);
+  console.log("first chunk is buffer:", Buffer.isBuffer(chunks[0]));
+});

--- a/test-parity/node-suite/stream/readable/from-empty-iterable.ts
+++ b/test-parity/node-suite/stream/readable/from-empty-iterable.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Readable.from(emptyIterable) yields no data; 'end' fires immediately.
+const r = Readable.from([]);
+let dataCount = 0;
+let endFired = false;
+r.on("data", () => dataCount++);
+r.on("end", () => {
+  endFired = true;
+  console.log("data count:", dataCount);
+  console.log("end fired:", endFired);
+});

--- a/test-parity/node-suite/stream/readable/from-iterable-object.ts
+++ b/test-parity/node-suite/stream/readable/from-iterable-object.ts
@@ -1,0 +1,18 @@
+import { Readable } from "node:stream";
+// Plain object with [Symbol.iterator] is iterable; Readable.from should
+// iterate it.
+const obj = {
+  [Symbol.iterator]() {
+    let i = 0;
+    return {
+      next() {
+        if (i < 3) return { value: i++, done: false };
+        return { value: undefined, done: true };
+      },
+    };
+  },
+};
+const r = Readable.from(obj as any);
+const out: number[] = [];
+for await (const v of r) out.push(v as number);
+console.log("from iter-object:", out.join(","));

--- a/test-parity/node-suite/stream/readable/from-map-entries.ts
+++ b/test-parity/node-suite/stream/readable/from-map-entries.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// Readable.from(Map) iterates entries (since Map is iterable yielding [k, v]).
+const m = new Map<string, number>([
+  ["a", 1],
+  ["b", 2],
+]);
+const r = Readable.from(m);
+const out: string[] = [];
+for await (const v of r) {
+  out.push(JSON.stringify(v));
+}
+console.log("entries:", out.join("|"));

--- a/test-parity/node-suite/stream/readable/from-set-values.ts
+++ b/test-parity/node-suite/stream/readable/from-set-values.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Readable.from(Set) iterates the set values in insertion order.
+const s = new Set([10, 20, 30]);
+const r = Readable.from(s);
+const out: number[] = [];
+for await (const v of r) {
+  out.push(v as number);
+}
+console.log("values:", out.join(","));

--- a/test-parity/node-suite/stream/readable/highwater-mark-buffer.ts
+++ b/test-parity/node-suite/stream/readable/highwater-mark-buffer.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Pushed data accumulates in the buffer; readableLength reflects total
+// buffered bytes after multiple pushes.
+const r = new Readable({ highWaterMark: 16, read() {} });
+r.push("ab");
+r.push("cd");
+r.push("ef");
+console.log("length:", r.readableLength);
+console.log("under hwm:", r.readableLength < r.readableHighWaterMark);

--- a/test-parity/node-suite/stream/readable/iter-yields-buffer-no-encoding.ts
+++ b/test-parity/node-suite/stream/readable/iter-yields-buffer-no-encoding.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Without setEncoding, async iteration over a Readable yields Buffer chunks.
+const r = new Readable({ read() {} });
+r.push("a");
+r.push("b");
+r.push(null);
+for await (const v of r) {
+  console.log("isBuffer:", Buffer.isBuffer(v), "content:", (v as Buffer).toString("utf8"));
+}

--- a/test-parity/node-suite/stream/readable/iterate-after-toarray.ts
+++ b/test-parity/node-suite/stream/readable/iterate-after-toarray.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// After consuming a stream via toArray(), further iteration yields no
+// values (the stream is drained / ended).
+const r = Readable.from(["a", "b", "c"]);
+const first = await (r as any).toArray();
+const second: any[] = [];
+for await (const v of r as any) {
+  second.push(v);
+}
+console.log("first:", first.join(","));
+console.log("second count:", second.length);

--- a/test-parity/node-suite/stream/readable/length-byte-exact.ts
+++ b/test-parity/node-suite/stream/readable/length-byte-exact.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// readableLength counts BYTES (UTF-8) for string pushes, not characters.
+const r = new Readable({ read() {} });
+r.push("é"); // 2 bytes in UTF-8
+console.log("length:", r.readableLength);
+console.log("is 2:", r.readableLength === 2);

--- a/test-parity/node-suite/stream/readable/object-mode-read-returns-object.ts
+++ b/test-parity/node-suite/stream/readable/object-mode-read-returns-object.ts
@@ -1,0 +1,16 @@
+import { Readable } from "node:stream";
+// In objectMode, read() returns ONE object at a time (not concatenated).
+const r = new Readable({
+  objectMode: true,
+  read() {
+    this.push({ a: 1 });
+    this.push({ b: 2 });
+    this.push(null);
+  },
+});
+r.on("readable", () => {
+  const first = r.read();
+  const second = r.read();
+  console.log("first:", JSON.stringify(first));
+  console.log("second:", JSON.stringify(second));
+});

--- a/test-parity/node-suite/stream/readable/push-returns-true-initial.ts
+++ b/test-parity/node-suite/stream/readable/push-returns-true-initial.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// push() returns true while the buffer is below HWM (and end not pushed).
+const r = new Readable({ highWaterMark: 100, read() {} });
+const a = r.push("aa");
+const b = r.push("bb");
+console.log("first:", a, "second:", b);
+console.log("both true:", a === true && b === true);

--- a/test-parity/node-suite/stream/readable/read-before-push.ts
+++ b/test-parity/node-suite/stream/readable/read-before-push.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// read() before any push is non-flowing — should return null
+// because there's no buffered data yet.
+const r = new Readable({ read() {} });
+const first = r.read();
+console.log("read before push:", first);
+console.log("is null:", first === null);

--- a/test-parity/node-suite/stream/readable/read-in-readable-listener.ts
+++ b/test-parity/node-suite/stream/readable/read-in-readable-listener.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Common pattern: drain inside 'readable' listener via while-loop of read().
+const r = new Readable({ read() {} });
+r.push("aa");
+r.push("bb");
+r.push("cc");
+r.push(null);
+const out: string[] = [];
+r.on("readable", () => {
+  let c;
+  while ((c = r.read()) !== null) out.push(String(c));
+});
+r.on("end", () => console.log("drained:", out.join("|")));

--- a/test-parity/node-suite/stream/readable/read-larger-than-buffered.ts
+++ b/test-parity/node-suite/stream/readable/read-larger-than-buffered.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// When the requested size exceeds the buffered bytes (and end is reached),
+// read(N) returns whatever is buffered before EOF.
+const r = new Readable({ read() {} });
+r.push("hi");
+r.push(null);
+r.on("readable", () => {
+  const got = r.read(1000); // request way more than 2 bytes
+  console.log("got bytes:", got && got.length);
+  console.log("got string:", got && got.toString("utf8"));
+});

--- a/test-parity/node-suite/stream/readable/read-n-consumes-exactly-n.ts
+++ b/test-parity/node-suite/stream/readable/read-n-consumes-exactly-n.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// read(N) consumes exactly N bytes (when available) from the front of
+// the buffer; subsequent reads consume the next N bytes.
+const r = new Readable({ read() {} });
+r.push("hello");
+const first = r.read(2);
+const second = r.read(2);
+const third = r.read();
+console.log("first:", first && first.toString("utf8"));
+console.log("second:", second && second.toString("utf8"));
+console.log("third:", third && third.toString("utf8"));

--- a/test-parity/node-suite/stream/readable/read-with-nan-size.ts
+++ b/test-parity/node-suite/stream/readable/read-with-nan-size.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// read(NaN) — Node coerces NaN to the default behavior (returns all buffered).
+const r = new Readable({ read() {} });
+r.push("abc");
+r.push(null);
+r.on("readable", () => {
+  const got = r.read(NaN as any);
+  console.log("got:", got && got.toString("utf8"));
+  console.log("got typeof:", typeof got);
+});

--- a/test-parity/node-suite/stream/readable/read-with-undefined-size.ts
+++ b/test-parity/node-suite/stream/readable/read-with-undefined-size.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// read(undefined) is equivalent to read() with no args — returns all
+// buffered bytes.
+const r = new Readable({ read() {} });
+r.push("hello");
+r.push(null);
+r.on("readable", () => {
+  const got = r.read(undefined as any);
+  console.log("got:", got && got.toString("utf8"));
+});

--- a/test-parity/node-suite/stream/readable/read-zero-probe.ts
+++ b/test-parity/node-suite/stream/readable/read-zero-probe.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// read(0) is a no-op probe — it does NOT consume bytes but may trigger
+// a 'readable' event when data is available.
+let readableFired = 0;
+const r = new Readable({ read() {} });
+r.on("readable", () => readableFired++);
+r.push("data");
+const r0 = r.read(0);
+console.log("read(0):", r0); // null — no consumption
+console.log("readable fired:", readableFired > 0);
+// data still available
+const remaining = r.read();
+console.log("remaining length:", remaining && remaining.length);

--- a/test-parity/node-suite/stream/readable/unshift-after-end.ts
+++ b/test-parity/node-suite/stream/readable/unshift-after-end.ts
@@ -1,0 +1,17 @@
+import { Readable } from "node:stream";
+// unshift() after the stream has ended is documented as a no-op /
+// recoverable; in practice Node emits 'error' (ERR_STREAM_PUSH_AFTER_EOF).
+const r = new Readable({ read() {} });
+r.push("a");
+r.push(null);
+let errMsg: string | null = null;
+r.on("error", (err) => (errMsg = err && err.message));
+r.on("data", () => {});
+r.on("end", () => {
+  try {
+    r.unshift("late");
+  } catch (e: any) {
+    errMsg = e.message;
+  }
+  setImmediate(() => console.log("err:", errMsg));
+});

--- a/test-parity/node-suite/stream/readable/unshift-buffer.ts
+++ b/test-parity/node-suite/stream/readable/unshift-buffer.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// unshift(Buffer) — explicit Buffer input is unshifted to the front.
+const r = new Readable({ read() {} });
+r.push("world");
+r.unshift(Buffer.from("hello "));
+r.push(null);
+const out: string[] = [];
+r.on("data", (c) => out.push(String(c)));
+r.on("end", () => console.log("joined:", out.join("|")));

--- a/test-parity/node-suite/stream/readable/unshift-increases-length.ts
+++ b/test-parity/node-suite/stream/readable/unshift-increases-length.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// unshift() should increase readableLength (it adds buffered bytes).
+const r = new Readable({ read() {} });
+r.push("hello");
+const before = r.readableLength;
+r.unshift("xx");
+const after = r.readableLength;
+console.log("before:", before);
+console.log("after:", after);
+console.log("grew:", after > before);

--- a/test-parity/node-suite/stream/readable/unshift-return-value.ts
+++ b/test-parity/node-suite/stream/readable/unshift-return-value.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// unshift() returns undefined (it's not chainable like on()).
+const r = new Readable({ read() {} });
+r.push("a");
+const result = r.unshift("b");
+console.log("unshift returned:", result);
+console.log("is undefined:", result === undefined);

--- a/test-parity/node-suite/stream/static/get-default-hwm-types.ts
+++ b/test-parity/node-suite/stream/static/get-default-hwm-types.ts
@@ -1,0 +1,9 @@
+import { getDefaultHighWaterMark } from "node:stream";
+// getDefaultHighWaterMark returns a number for both modes; check both
+// arities explicitly (boolean indicates objectMode).
+const std = getDefaultHighWaterMark(false);
+const obj = getDefaultHighWaterMark(true);
+console.log("std is number:", typeof std === "number");
+console.log("obj is number:", typeof obj === "number");
+console.log("std > 0:", std > 0);
+console.log("obj > 0:", obj > 0);

--- a/test-parity/node-suite/stream/transform/multi-output-per-input.ts
+++ b/test-parity/node-suite/stream/transform/multi-output-per-input.ts
@@ -1,0 +1,14 @@
+import { Transform } from "node:stream";
+// A transform can push multiple outputs per single input by calling
+// this.push() multiple times before invoking cb().
+const splitter = new Transform({
+  transform(chunk, _enc, cb) {
+    for (const c of String(chunk)) this.push(c);
+    cb();
+  },
+});
+const out: string[] = [];
+splitter.on("data", (c) => out.push(String(c)));
+splitter.on("end", () => console.log("split:", out.join(",")));
+splitter.write("abc");
+splitter.end();

--- a/test-parity/node-suite/stream/transform/object-mode-default-false.ts
+++ b/test-parity/node-suite/stream/transform/object-mode-default-false.ts
@@ -1,0 +1,6 @@
+import { Transform } from "node:stream";
+// Transform's default objectMode is false (both sides).
+const t = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+console.log("readableObjectMode:", t.readableObjectMode);
+console.log("writableObjectMode:", t.writableObjectMode);
+console.log("both false:", !t.readableObjectMode && !t.writableObjectMode);

--- a/test-parity/node-suite/stream/transform/this-binding-in-transform.ts
+++ b/test-parity/node-suite/stream/transform/this-binding-in-transform.ts
@@ -1,0 +1,13 @@
+import { Transform } from "node:stream";
+// Inside transform(), `this` should refer to the Transform instance,
+// allowing this.push() to enqueue output.
+const t = new Transform({
+  transform(chunk, _enc, cb) {
+    console.log("this is Transform:", this instanceof Transform);
+    this.push(String(chunk).toUpperCase());
+    cb();
+  },
+});
+t.on("data", () => {});
+t.write("hi");
+t.end();

--- a/test-parity/node-suite/stream/transform/transform-throws-sync.ts
+++ b/test-parity/node-suite/stream/transform/transform-throws-sync.ts
@@ -1,0 +1,12 @@
+import { Transform } from "node:stream";
+// A synchronous throw inside transform() — Node catches and emits 'error'.
+const t = new Transform({
+  transform(_c, _e, _cb) {
+    throw new Error("sync-throw");
+  },
+});
+let errMsg: string | null = null;
+t.on("error", (err) => (errMsg = err && err.message));
+t.on("data", () => {});
+t.write("x");
+setImmediate(() => console.log("err:", errMsg));

--- a/test-parity/node-suite/stream/web/byob-on-byte-stream.ts
+++ b/test-parity/node-suite/stream/web/byob-on-byte-stream.ts
@@ -1,0 +1,14 @@
+import { ReadableStream } from "node:stream/web";
+// getReader({mode:'byob'}) on a type:'bytes' stream returns a BYOB reader.
+let result: any = null;
+try {
+  const rs = new ReadableStream({ type: "bytes" } as any);
+  const reader = (rs as any).getReader({ mode: "byob" });
+  result = {
+    hasRead: typeof reader.read === "function",
+    hasReleaseLock: typeof reader.releaseLock === "function",
+  };
+} catch (e: any) {
+  result = { threw: e && e.name };
+}
+console.log(JSON.stringify(result));

--- a/test-parity/node-suite/stream/web/byob-reader-getReader.ts
+++ b/test-parity/node-suite/stream/web/byob-reader-getReader.ts
@@ -1,0 +1,11 @@
+import { ReadableStream } from "node:stream/web";
+// getReader({ mode: "byob" }) returns a BYOB reader on byte streams.
+// Without type:'bytes', it should throw TypeError.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+let caught: string | null = null;
+try {
+  rs.getReader({ mode: "byob" } as any);
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("byob on non-byte stream throws:", caught);

--- a/test-parity/node-suite/stream/web/byte-stream-construction.ts
+++ b/test-parity/node-suite/stream/web/byte-stream-construction.ts
@@ -1,0 +1,14 @@
+import { ReadableStream } from "node:stream/web";
+// `new ReadableStream({ type: "bytes" })` constructs a byte stream
+// (BYOB reader compatible).
+let constructed = false;
+try {
+  const rs = new ReadableStream({ type: "bytes" } as any);
+  constructed = rs instanceof ReadableStream;
+  console.log("constructed:", constructed);
+  // Try BYOB
+  const reader = (rs as any).getReader({ mode: "byob" });
+  console.log("byob reader:", typeof reader.read === "function");
+} catch (e: any) {
+  console.log("threw:", e && e.name);
+}

--- a/test-parity/node-suite/stream/web/cancel-during-pipeto.ts
+++ b/test-parity/node-suite/stream/web/cancel-during-pipeto.ts
@@ -1,0 +1,17 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// rs.cancel() during an active pipeTo — the pipeTo promise rejects (locked stream).
+const rs = new ReadableStream({
+  pull(c) { setTimeout(() => c.enqueue("x"), 50); },
+});
+const ws = new WritableStream({ write() {} });
+const p = rs.pipeTo(ws);
+// While locked, cancel directly errors
+let cancelErr: string | null = null;
+try {
+  await rs.cancel("manual");
+} catch (e: any) {
+  cancelErr = e && e.name;
+}
+console.log("cancel-on-locked rejected:", cancelErr);
+// pipeTo will likely still be pending
+p.catch(() => {});

--- a/test-parity/node-suite/stream/web/cancel-no-reader.ts
+++ b/test-parity/node-suite/stream/web/cancel-no-reader.ts
@@ -1,0 +1,11 @@
+import { ReadableStream } from "node:stream/web";
+// rs.cancel() works directly without first calling getReader() — it
+// cancels the stream and rejects future reads.
+let cancelled = false;
+const rs = new ReadableStream({
+  start(c) { c.enqueue("x"); },
+  cancel() { cancelled = true; },
+});
+await rs.cancel("done");
+console.log("cancelled hook fired:", cancelled);
+console.log("locked after cancel:", rs.locked);

--- a/test-parity/node-suite/stream/web/cancel-returns-undefined-promise.ts
+++ b/test-parity/node-suite/stream/web/cancel-returns-undefined-promise.ts
@@ -1,0 +1,8 @@
+import { ReadableStream } from "node:stream/web";
+// rs.cancel() returns Promise<undefined>.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); } });
+const p = rs.cancel("stop");
+console.log("is Promise:", typeof (p as any).then === "function");
+const v = await p;
+console.log("resolves to:", v);
+console.log("is undefined:", v === undefined);

--- a/test-parity/node-suite/stream/web/custom-strategy-nan-size.ts
+++ b/test-parity/node-suite/stream/web/custom-strategy-nan-size.ts
@@ -1,0 +1,18 @@
+import { ReadableStream } from "node:stream/web";
+// A queuing strategy whose size() returns NaN should error the stream
+// when an enqueue is attempted.
+const strategy = {
+  size: () => NaN,
+  highWaterMark: 1,
+};
+const rs = new ReadableStream({
+  start(c) {
+    try {
+      c.enqueue("x");
+      console.log("enqueue succeeded:", true);
+    } catch (e: any) {
+      console.log("enqueue threw:", e && e.name);
+    }
+  },
+}, strategy);
+console.log("constructed:", rs instanceof ReadableStream);

--- a/test-parity/node-suite/stream/web/desired-size-restores-after-drain.ts
+++ b/test-parity/node-suite/stream/web/desired-size-restores-after-drain.ts
@@ -1,0 +1,11 @@
+import { WritableStream, CountQueuingStrategy } from "node:stream/web";
+// After a write resolves (sink processed), desiredSize returns to HWM.
+const ws = new WritableStream(
+  { write() {} },
+  new CountQueuingStrategy({ highWaterMark: 2 }),
+);
+const w = ws.getWriter();
+console.log("initial:", w.desiredSize);
+await w.write("a");
+await w.ready;
+console.log("after write:", w.desiredSize);

--- a/test-parity/node-suite/stream/web/get-writer-twice-throws.ts
+++ b/test-parity/node-suite/stream/web/get-writer-twice-throws.ts
@@ -1,0 +1,13 @@
+import { WritableStream } from "node:stream/web";
+// Second getWriter() on locked WritableStream throws TypeError.
+const ws = new WritableStream({ write() {} });
+const _w1 = ws.getWriter();
+let caught: string | null = null;
+try {
+  ws.getWriter();
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);
+console.log("locked:", ws.locked);

--- a/test-parity/node-suite/stream/web/locked-initial-false.ts
+++ b/test-parity/node-suite/stream/web/locked-initial-false.ts
@@ -1,0 +1,11 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// .locked starts false on a freshly-constructed stream; flips true after
+// getReader()/getWriter().
+const rs = new ReadableStream();
+const ws = new WritableStream();
+console.log("rs initial locked:", rs.locked);
+console.log("ws initial locked:", ws.locked);
+const _r = rs.getReader();
+const _w = ws.getWriter();
+console.log("rs after getReader:", rs.locked);
+console.log("ws after getWriter:", ws.locked);

--- a/test-parity/node-suite/stream/web/pipe-to-locks-and-releases.ts
+++ b/test-parity/node-suite/stream/web/pipe-to-locks-and-releases.ts
@@ -1,0 +1,11 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// pipeTo() takes an internal reader/writer, so during the call rs.locked
+// and ws.locked are true; after completion the lock should release.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const ws = new WritableStream({ write() {} });
+const p = rs.pipeTo(ws);
+console.log("rs.locked during:", rs.locked);
+console.log("ws.locked during:", ws.locked);
+await p;
+console.log("rs.locked after:", rs.locked);
+console.log("ws.locked after:", ws.locked);

--- a/test-parity/node-suite/stream/web/pipe-to-returns-promise.ts
+++ b/test-parity/node-suite/stream/web/pipe-to-returns-promise.ts
@@ -1,0 +1,10 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// pipeTo() returns a Promise<void> that resolves when pipe completes
+// (or rejects on error).
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const ws = new WritableStream({ write() {} });
+const p = rs.pipeTo(ws);
+console.log("is Promise:", typeof (p as any).then === "function");
+const v = await p;
+console.log("resolves to:", v);
+console.log("is undefined:", v === undefined);

--- a/test-parity/node-suite/stream/web/pipe-to-with-signal-abort.ts
+++ b/test-parity/node-suite/stream/web/pipe-to-with-signal-abort.ts
@@ -1,0 +1,18 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// pipeTo(ws, { signal }) — aborting the signal rejects the returned Promise.
+const ctrl = new AbortController();
+const rs = new ReadableStream({
+  pull(c) {
+    setTimeout(() => c.enqueue("x"), 50);
+  },
+});
+const ws = new WritableStream({ write() {} });
+const p = rs.pipeTo(ws, { signal: ctrl.signal });
+setTimeout(() => ctrl.abort(), 10);
+let err: string | null = null;
+try {
+  await p;
+} catch (e: any) {
+  err = e && e.name;
+}
+console.log("aborted err name:", err);

--- a/test-parity/node-suite/stream/web/pipethrough-preventclose-flag.ts
+++ b/test-parity/node-suite/stream/web/pipethrough-preventclose-flag.ts
@@ -1,0 +1,8 @@
+import { ReadableStream, TransformStream } from "node:stream/web";
+// pipeThrough(transform, { preventClose: true }) — closing source should
+// NOT close the transform's writable side.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const ts = new TransformStream();
+const out: any = rs.pipeThrough(ts, { preventClose: true });
+console.log("returned ReadableStream:", out instanceof ReadableStream);
+console.log("transform writable still unlocked:", ts.writable.locked === false);

--- a/test-parity/node-suite/stream/web/pull-promise-controls-pace.ts
+++ b/test-parity/node-suite/stream/web/pull-promise-controls-pace.ts
@@ -1,0 +1,20 @@
+import { ReadableStream } from "node:stream/web";
+// pull() returning a Promise paces the enqueue — the stream waits for
+// pull's Promise to resolve before requesting the next pull.
+let pulled = 0;
+const rs = new ReadableStream({
+  async pull(c) {
+    pulled++;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    c.enqueue(pulled);
+    if (pulled >= 3) c.close();
+  },
+});
+const reader = rs.getReader();
+const out: number[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(value);
+}
+console.log("pulled:", out.join(","));

--- a/test-parity/node-suite/stream/web/readable-no-sync-iterator.ts
+++ b/test-parity/node-suite/stream/web/readable-no-sync-iterator.ts
@@ -1,0 +1,6 @@
+import { ReadableStream } from "node:stream/web";
+// Web ReadableStream exposes Symbol.asyncIterator but NOT Symbol.iterator.
+const rs = new ReadableStream({ start(c) { c.close(); } });
+console.log("asyncIterator typeof:", typeof (rs as any)[Symbol.asyncIterator]);
+console.log("sync iterator typeof:", typeof (rs as any)[Symbol.iterator]);
+console.log("sync iter undefined:", (rs as any)[Symbol.iterator] === undefined);

--- a/test-parity/node-suite/stream/web/readable-stream-from-non-iterable.ts
+++ b/test-parity/node-suite/stream/web/readable-stream-from-non-iterable.ts
@@ -1,0 +1,11 @@
+import { ReadableStream } from "node:stream/web";
+// ReadableStream.from(non-iterable) — should throw TypeError because
+// the argument doesn't have Symbol.iterator or Symbol.asyncIterator.
+let caught: string | null = null;
+try {
+  (ReadableStream as any).from(42);
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/web/reader-after-close-done.ts
+++ b/test-parity/node-suite/stream/web/reader-after-close-done.ts
@@ -1,0 +1,12 @@
+import { ReadableStream } from "node:stream/web";
+// After the stream closes, further read() calls return { done: true, value: undefined }.
+const rs = new ReadableStream({
+  start(c) { c.enqueue("x"); c.close(); },
+});
+const reader = rs.getReader();
+const first = await reader.read();
+const second = await reader.read();
+const third = await reader.read();
+console.log("first:", first.value, first.done);
+console.log("second:", second.value, second.done);
+console.log("third:", third.value, third.done);

--- a/test-parity/node-suite/stream/web/reader-symbol-dispose.ts
+++ b/test-parity/node-suite/stream/web/reader-symbol-dispose.ts
@@ -1,0 +1,6 @@
+import { ReadableStream } from "node:stream/web";
+// Web ReadableStreamDefaultReader exposes Symbol.dispose (Node 22+) so it
+// can be used with `using` declarations to auto-release the lock.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const reader = rs.getReader();
+console.log("has Symbol.dispose:", typeof (reader as any)[Symbol.dispose]);

--- a/test-parity/node-suite/stream/web/start-throw-rejects.ts
+++ b/test-parity/node-suite/stream/web/start-throw-rejects.ts
@@ -1,0 +1,16 @@
+import { ReadableStream } from "node:stream/web";
+// If the underlying source's start() throws (or returns a rejected
+// Promise), the stream errors and reads/cancel reject.
+const rs = new ReadableStream({
+  start() {
+    throw new Error("start-fail");
+  },
+});
+const reader = rs.getReader();
+let errMsg: string | null = null;
+try {
+  await reader.read();
+} catch (e: any) {
+  errMsg = e && e.message;
+}
+console.log("read rejected:", errMsg);

--- a/test-parity/node-suite/stream/web/strategies-imported.ts
+++ b/test-parity/node-suite/stream/web/strategies-imported.ts
@@ -1,0 +1,13 @@
+import {
+  ReadableStream,
+  CountQueuingStrategy,
+  ByteLengthQueuingStrategy,
+} from "node:stream/web";
+// Both queuing strategy classes are exported from node:stream/web and
+// can be passed to ReadableStream constructor's 2nd arg.
+const c = new CountQueuingStrategy({ highWaterMark: 5 });
+const b = new ByteLengthQueuingStrategy({ highWaterMark: 1024 });
+console.log("count hwm:", c.highWaterMark);
+console.log("byte hwm:", b.highWaterMark);
+const rs = new ReadableStream({ start(c) { c.close(); } }, c);
+console.log("rs constructed:", rs instanceof ReadableStream);

--- a/test-parity/node-suite/stream/web/transform-async-transform-fn.ts
+++ b/test-parity/node-suite/stream/web/transform-async-transform-fn.ts
@@ -1,0 +1,15 @@
+import { TransformStream } from "node:stream/web";
+// transform() can be async — returning a Promise that resolves when the
+// transform is complete. Pull-side reader awaits accordingly.
+const ts = new TransformStream({
+  async transform(chunk, ctrl) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    ctrl.enqueue(String(chunk).toUpperCase());
+  },
+});
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("ab");
+await writer.close();
+const { value } = await reader.read();
+console.log("got:", value);

--- a/test-parity/node-suite/stream/web/transform-cancel-propagates.ts
+++ b/test-parity/node-suite/stream/web/transform-cancel-propagates.ts
@@ -1,0 +1,14 @@
+import { TransformStream } from "node:stream/web";
+// readable.cancel() on a TransformStream propagates to writable —
+// further writes should be rejected (writer.closed promise rejects).
+const ts = new TransformStream();
+const reader = ts.readable.getReader();
+await reader.cancel("downstream-stop");
+const writer = ts.writable.getWriter();
+let rejected = false;
+try {
+  await writer.write("late");
+} catch {
+  rejected = true;
+}
+console.log("write rejected after cancel:", rejected);

--- a/test-parity/node-suite/stream/web/transform-error-propagates.ts
+++ b/test-parity/node-suite/stream/web/transform-error-propagates.ts
@@ -1,0 +1,22 @@
+import { TransformStream } from "node:stream/web";
+// A throw in transform() aborts both the readable and writable sides;
+// further reads should reject.
+const ts = new TransformStream({
+  transform() { throw new Error("xform-boom"); },
+});
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+let writeErr: string | null = null;
+let readErr: string | null = null;
+try {
+  await writer.write("x");
+} catch (e: any) {
+  writeErr = e && e.message;
+}
+try {
+  await reader.read();
+} catch (e: any) {
+  readErr = e && e.message;
+}
+console.log("write rejected:", writeErr);
+console.log("read rejected:", readErr);

--- a/test-parity/node-suite/stream/web/transform-readable-empty.ts
+++ b/test-parity/node-suite/stream/web/transform-readable-empty.ts
@@ -1,0 +1,9 @@
+import { TransformStream } from "node:stream/web";
+// A TransformStream with empty writable.close() yields an empty readable.
+const ts = new TransformStream();
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.close();
+const { value, done } = await reader.read();
+console.log("value:", value);
+console.log("done:", done);

--- a/test-parity/node-suite/stream/web/transform-readable-writable-wired.ts
+++ b/test-parity/node-suite/stream/web/transform-readable-writable-wired.ts
@@ -1,0 +1,7 @@
+import { TransformStream, ReadableStream, WritableStream } from "node:stream/web";
+// TransformStream exposes .readable (ReadableStream) and .writable
+// (WritableStream) sides; they're correctly typed instances.
+const ts = new TransformStream();
+console.log("readable instanceof ReadableStream:", ts.readable instanceof ReadableStream);
+console.log("writable instanceof WritableStream:", ts.writable instanceof WritableStream);
+console.log("readable !== writable:", ts.readable !== (ts.writable as any));

--- a/test-parity/node-suite/stream/web/transform-stream-with-strategies.ts
+++ b/test-parity/node-suite/stream/web/transform-stream-with-strategies.ts
@@ -1,0 +1,9 @@
+import { TransformStream, CountQueuingStrategy } from "node:stream/web";
+// TransformStream(transformer, writableStrategy, readableStrategy)
+// — full 3-arg form sets HWM on both sides.
+const ws = new CountQueuingStrategy({ highWaterMark: 1 });
+const rs = new CountQueuingStrategy({ highWaterMark: 4 });
+const ts = new TransformStream(undefined, ws, rs);
+console.log("constructed:", ts instanceof TransformStream);
+console.log("ws hwm:", ws.highWaterMark);
+console.log("rs hwm:", rs.highWaterMark);

--- a/test-parity/node-suite/stream/web/writable-abort-returns-promise.ts
+++ b/test-parity/node-suite/stream/web/writable-abort-returns-promise.ts
@@ -1,0 +1,8 @@
+import { WritableStream } from "node:stream/web";
+// WritableStream.abort() returns Promise<void>.
+const ws = new WritableStream({ write() {}, abort() {} });
+const p = ws.abort("stop");
+console.log("is Promise:", typeof (p as any).then === "function");
+const v = await p;
+console.log("resolves to:", v);
+console.log("is undefined:", v === undefined);

--- a/test-parity/node-suite/stream/web/writable-close-async.ts
+++ b/test-parity/node-suite/stream/web/writable-close-async.ts
@@ -1,0 +1,14 @@
+import { WritableStream } from "node:stream/web";
+// The sink's close() can return a Promise that delays writer.close() resolution.
+let closed = false;
+const ws = new WritableStream({
+  write() {},
+  async close() {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    closed = true;
+  },
+});
+const w = ws.getWriter();
+await w.write("x");
+await w.close();
+console.log("close ran (async):", closed);

--- a/test-parity/node-suite/stream/web/writable-empty-object-sink.ts
+++ b/test-parity/node-suite/stream/web/writable-empty-object-sink.ts
@@ -1,0 +1,9 @@
+import { WritableStream } from "node:stream/web";
+// `new WritableStream({})` — empty sink object: writes silently succeed.
+const ws = new WritableStream({});
+const w = ws.getWriter();
+await w.write("a");
+await w.write("b");
+await w.close();
+console.log("constructed:", ws instanceof WritableStream);
+console.log("locked after close:", ws.locked);

--- a/test-parity/node-suite/stream/web/writable-stream-no-args.ts
+++ b/test-parity/node-suite/stream/web/writable-stream-no-args.ts
@@ -1,0 +1,9 @@
+import { WritableStream } from "node:stream/web";
+// `new WritableStream()` with no underlying sink should still construct
+// — writes are silently dropped (the default sink swallows everything).
+const ws = new WritableStream();
+const w = ws.getWriter();
+await w.write("x");
+await w.close();
+console.log("locked:", ws.locked);
+console.log("constructed:", ws instanceof WritableStream);

--- a/test-parity/node-suite/stream/web/writable-stream-null-sink.ts
+++ b/test-parity/node-suite/stream/web/writable-stream-null-sink.ts
@@ -1,0 +1,13 @@
+import { WritableStream } from "node:stream/web";
+// new WritableStream(null) — typically constructs with default sink, but
+// Node may throw or coerce. Test the actual behavior.
+let constructed = false;
+let threw: string | null = null;
+try {
+  const ws = new WritableStream(null as any);
+  constructed = ws instanceof WritableStream;
+} catch (e: any) {
+  threw = e && e.name;
+}
+console.log("constructed:", constructed);
+console.log("threw:", threw);

--- a/test-parity/node-suite/stream/web/writable-stream-strategy-only.ts
+++ b/test-parity/node-suite/stream/web/writable-stream-strategy-only.ts
@@ -1,0 +1,6 @@
+import { WritableStream, CountQueuingStrategy } from "node:stream/web";
+// WritableStream(undefined, strategy) — uses default sink with custom strategy.
+const strategy = new CountQueuingStrategy({ highWaterMark: 7 });
+const ws = new WritableStream(undefined, strategy);
+console.log("locked:", ws.locked);
+console.log("constructed:", ws instanceof WritableStream);

--- a/test-parity/node-suite/stream/web/writer-release-lock-during-write.ts
+++ b/test-parity/node-suite/stream/web/writer-release-lock-during-write.ts
@@ -1,0 +1,17 @@
+import { WritableStream } from "node:stream/web";
+// releaseLock() while a write is pending — the pending write Promise rejects.
+const ws = new WritableStream({
+  async write() {
+    await new Promise((resolve) => setTimeout(resolve, 30));
+  },
+});
+const w = ws.getWriter();
+const writeP = w.write("x");
+w.releaseLock();
+let err: string | null = null;
+try {
+  await writeP;
+} catch (e: any) {
+  err = e && e.name;
+}
+console.log("released during write -> err name:", err);

--- a/test-parity/node-suite/stream/web/writer-write-after-close-rejects.ts
+++ b/test-parity/node-suite/stream/web/writer-write-after-close-rejects.ts
@@ -1,0 +1,12 @@
+import { WritableStream } from "node:stream/web";
+// Calling write() after close() should reject — the writer is closed.
+const ws = new WritableStream({ write() {} });
+const w = ws.getWriter();
+await w.close();
+let rejected = false;
+try {
+  await w.write("late");
+} catch {
+  rejected = true;
+}
+console.log("rejected:", rejected);

--- a/test-parity/node-suite/stream/writable/cork-returns-undefined.ts
+++ b/test-parity/node-suite/stream/writable/cork-returns-undefined.ts
@@ -1,0 +1,8 @@
+import { Writable } from "node:stream";
+// cork() and uncork() return undefined (per Node docs) — they are NOT
+// chainable like on().
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+const corkResult = w.cork();
+const uncorkResult = w.uncork();
+console.log("cork returns undefined:", corkResult === undefined);
+console.log("uncork returns undefined:", uncorkResult === undefined);

--- a/test-parity/node-suite/stream/writable/end-three-arg.ts
+++ b/test-parity/node-suite/stream/writable/end-three-arg.ts
@@ -1,0 +1,9 @@
+import { Writable } from "node:stream";
+// end(chunk, encoding, callback) — full 3-arg form: writes chunk with
+// encoding, then calls cb after finish.
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+let cbFired = false;
+w.end("done", "utf8", () => (cbFired = true));
+w.on("finish", () => {
+  setImmediate(() => console.log("end-cb fired:", cbFired));
+});

--- a/test-parity/node-suite/stream/writable/end-twice-noop.ts
+++ b/test-parity/node-suite/stream/writable/end-twice-noop.ts
@@ -1,0 +1,8 @@
+import { Writable } from "node:stream";
+// end() called twice — second call is a no-op (no error, no duplicate 'finish').
+let finishCount = 0;
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+w.on("finish", () => finishCount++);
+w.end("a");
+w.end(); // no-op
+setImmediate(() => console.log("finish count:", finishCount));

--- a/test-parity/node-suite/stream/writable/end-with-chunk-writes-before-finish.ts
+++ b/test-parity/node-suite/stream/writable/end-with-chunk-writes-before-finish.ts
@@ -1,0 +1,15 @@
+import { Writable } from "node:stream";
+// end(chunk) — the chunk is written BEFORE 'finish' fires.
+const order: string[] = [];
+const w = new Writable({
+  write(c, _e, cb) {
+    order.push("write:" + String(c));
+    cb();
+  },
+});
+w.on("finish", () => {
+  order.push("finish");
+  console.log("order:", order.join(","));
+  console.log("write before finish:", order.indexOf("write:end-chunk") < order.indexOf("finish"));
+});
+w.end("end-chunk");

--- a/test-parity/node-suite/stream/writable/write-returns-false-at-hwm.ts
+++ b/test-parity/node-suite/stream/writable/write-returns-false-at-hwm.ts
@@ -1,0 +1,14 @@
+import { Writable } from "node:stream";
+// write() returns false once the buffered bytes cross the highWaterMark.
+// With a tiny HWM and a slow sink, the second write should return false.
+const w = new Writable({
+  highWaterMark: 2,
+  write(_c, _e, cb) {
+    setImmediate(cb); // delay so writes accumulate
+  },
+});
+const a = w.write("aa");
+const b = w.write("bb");
+console.log("a:", a);
+console.log("b:", b);
+console.log("at-least-one false:", a === false || b === false);


### PR DESCRIPTION
## Summary

Consolidates **29 stream parity test PRs** (#1603–#1637) into one to avoid resolving the same `known_failures.json` conflict ~29 times and churning ~29 version-less merges through `main`.

- **140 new** `node-suite/stream` parity tests (iter42–68 + batch2/3) covering readable/writable/transform/web/compose/events/pipe/pipeline/iter-helpers edge cases.
- **+137** `known_failures.json` skip-list entries — union of all 29 branches, every entry carries issue + date provenance. Diff is purely additive (0 removals, 0 changed values).

Test-only; no runtime/Rust changes (matches the existing test-PR convention — no version bump / changelog).

## Supersedes

Closes by superseding: #1603 #1604 #1605 #1606 #1607 #1609 #1610 #1611 #1612 #1613 #1614 #1615 #1616 #1617 #1618 #1619 #1620 #1621 #1622 #1623 #1624 #1626 #1627 #1628 #1629 #1630 #1631 #1632 #1637

## Verification

- All 29 branches verified to touch only `test-parity/` paths.
- New test files are disjoint across branches (0 path collisions).
- `known_failures.json` union: 0 conflicts, 0 removed keys, 0 changed values.
- `cargo fmt --all -- --check` clean.
