### PR TITLE
test(parity): stream — batch of 16 tier-5/6 tests (iter-77..80) (3 free pass, 13 #1531/#1532/#1539/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2641,5 +2641,83 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: readableLength after push('é') — does not count 2 UTF-8 bytes. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/compose-multi-async-fn": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: r.compose(t1).compose(t2) chained — output stream produces wrong chunks. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/events/emit-error-with-capture": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: captureRejections — async listener throws not caught into 'error' event. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/uncork-flushes-buffered": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: cork/uncork sequence — fails to compile in test harness (write callback signature). Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/web/abort-during-pipeto": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: ws.abort() during active pipeTo — pipeTo Promise doesn't reject. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/wrap-pipe-chain": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: wrap(EE) + pipe(dst) — piped output empty or wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/async-iter/return-method-explicit": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: asyncIterator.return() — does not destroy/end properly or returns wrong shape. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/destroy/destroy-during-read": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy() inside _read() — readCalls count or close-event behavior wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/transform/flush-called-once": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Transform._flush — not called exactly once after end. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/readable/symbol-async-iter-returns-iterator": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: [Symbol.asyncIterator]() — missing next/return method or not self-iterable. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/promises/finished-rejects-on-error": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: promises.finished() — does not reject when stream errors. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/text-encoder-stream-exists": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: TextEncoderStream/TextDecoderStream globals — not exposed or wrong shape. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/read-multibyte-boundary": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read(1) on multibyte UTF-8 chunk — fails to compile (Buffer-length access). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/flow/data-after-pause-resume": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pause→resume cycle — does not deliver all data events. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/async-iter/return-method-explicit.ts
+++ b/test-parity/node-suite/stream/async-iter/return-method-explicit.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// The asyncIterator's return() method exists and is callable to bail early.
+const r = Readable.from([1, 2, 3]);
+const it = (r as any)[Symbol.asyncIterator]();
+console.log("has return:", typeof it.return === "function");
+const result = await it.return();
+console.log("return result done:", result.done);
+console.log("destroyed:", r.destroyed);

--- a/test-parity/node-suite/stream/destroy/destroy-during-read.ts
+++ b/test-parity/node-suite/stream/destroy/destroy-during-read.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// destroy() inside _read() — the stream cancels mid-pull.
+let readCalls = 0;
+const r = new Readable({
+  read() {
+    readCalls++;
+    if (readCalls === 1) this.destroy();
+  },
+});
+r.on("error", () => {});
+r.on("close", () => {
+  console.log("read calls:", readCalls);
+  console.log("destroyed:", r.destroyed);
+});
+r.on("data", () => {});

--- a/test-parity/node-suite/stream/events/emit-error-with-capture.ts
+++ b/test-parity/node-suite/stream/events/emit-error-with-capture.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// EventEmitter captureRejections — when an async listener throws, the
+// 'error' event fires (if captureRejections is set).
+const r = new Readable({ read() {}, captureRejections: true } as any);
+let caughtErr: any = null;
+r.on("error", (e) => (caughtErr = e));
+r.on("custom", async () => {
+  throw new Error("async-listener-fail");
+});
+r.emit("custom");
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("captured:", caughtErr && (caughtErr as Error).message);
+  });
+});

--- a/test-parity/node-suite/stream/flow/data-after-pause-resume.ts
+++ b/test-parity/node-suite/stream/flow/data-after-pause-resume.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// After pause then resume, the stream continues delivering data events.
+const r = Readable.from(["a", "b", "c"]);
+const out: string[] = [];
+r.pause();
+r.on("data", (c) => out.push(String(c)));
+setImmediate(() => {
+  r.resume();
+});
+r.on("end", () => {
+  console.log("out:", out.join(","));
+  console.log("got 3:", out.length === 3);
+});

--- a/test-parity/node-suite/stream/promises/finished-rejects-on-error.ts
+++ b/test-parity/node-suite/stream/promises/finished-rejects-on-error.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
+// finished() rejects when the stream errors.
+const r = new Readable({ read() {} });
+r.on("error", () => {});
+setImmediate(() => r.destroy(new Error("test-err")));
+let errMsg: string | null = null;
+try {
+  await finished(r);
+} catch (e: any) {
+  errMsg = e && e.message;
+}
+console.log("rejected with:", errMsg);

--- a/test-parity/node-suite/stream/readable/compose-multi-async-fn.ts
+++ b/test-parity/node-suite/stream/readable/compose-multi-async-fn.ts
@@ -1,0 +1,9 @@
+import { Readable, Transform } from "node:stream";
+// Chained .compose() with multiple async transforms.
+const r = Readable.from(["ab", "cd"]);
+const upper = new Transform({ transform(c, _e, cb) { cb(null, String(c).toUpperCase()); } });
+const reverse = new Transform({ transform(c, _e, cb) { cb(null, String(c).split("").reverse().join("")); } });
+const composed: any = (r as any).compose(upper).compose(reverse);
+const out: string[] = [];
+composed.on("data", (c: any) => out.push(String(c)));
+composed.on("end", () => console.log("chained:", out.join(",")));

--- a/test-parity/node-suite/stream/readable/read-multibyte-boundary.ts
+++ b/test-parity/node-suite/stream/readable/read-multibyte-boundary.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// read(1) on a multibyte UTF-8 chunk returns 1 byte (not 1 character).
+const r = new Readable({ read() {} });
+r.push("é"); // 2 bytes
+r.push(null);
+r.on("readable", () => {
+  const a = r.read(1);
+  const b = r.read(1);
+  console.log("a length:", a && a.length);
+  console.log("b length:", b && b.length);
+});

--- a/test-parity/node-suite/stream/readable/symbol-async-iter-returns-iterator.ts
+++ b/test-parity/node-suite/stream/readable/symbol-async-iter-returns-iterator.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// readable[Symbol.asyncIterator]() returns an object with next/return methods.
+const r = Readable.from(["a"]);
+const it = (r as any)[Symbol.asyncIterator]();
+console.log("has next:", typeof it.next === "function");
+console.log("has return:", typeof it.return === "function");
+console.log("self-iterable:", typeof it[Symbol.asyncIterator] === "function");
+console.log("self iterates to same:", it[Symbol.asyncIterator]() === it);

--- a/test-parity/node-suite/stream/readable/wrap-pipe-chain.ts
+++ b/test-parity/node-suite/stream/readable/wrap-pipe-chain.ts
@@ -1,0 +1,16 @@
+import { Readable, PassThrough } from "node:stream";
+import { EventEmitter } from "node:events";
+// wrap() — wrap an old-style EE emitter as a Readable, then pipe it.
+const old: any = new EventEmitter();
+old.pause = () => {};
+old.resume = () => {};
+const r = new Readable({ read() {} }).wrap(old);
+const dst = new PassThrough();
+const out: string[] = [];
+dst.on("data", (c) => out.push(String(c)));
+dst.on("end", () => console.log("piped:", out.join(",")));
+r.pipe(dst);
+setImmediate(() => {
+  old.emit("data", "x");
+  old.emit("end");
+});

--- a/test-parity/node-suite/stream/transform/flush-called-once.ts
+++ b/test-parity/node-suite/stream/transform/flush-called-once.ts
@@ -1,0 +1,17 @@
+import { Transform } from "node:stream";
+// _flush is called once after end() and before 'end' event — exactly once.
+let flushCount = 0;
+const t = new Transform({
+  transform(c, _e, cb) { cb(null, c); },
+  flush(cb) {
+    flushCount++;
+    cb();
+  },
+});
+t.on("data", () => {});
+t.on("end", () => {
+  console.log("flush count:", flushCount);
+  console.log("called once:", flushCount === 1);
+});
+t.write("x");
+t.end();

--- a/test-parity/node-suite/stream/web/abort-during-pipeto.ts
+++ b/test-parity/node-suite/stream/web/abort-during-pipeto.ts
@@ -1,0 +1,17 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// Aborting the writable side during an active pipeTo — pipeTo rejects.
+const rs = new ReadableStream({
+  pull(c) { setTimeout(() => c.enqueue("x"), 30); },
+});
+const ws = new WritableStream({ write() {} });
+const p = rs.pipeTo(ws);
+setTimeout(() => {
+  ws.abort("stop").catch(() => {});
+}, 5);
+let rejected = false;
+try {
+  await p;
+} catch {
+  rejected = true;
+}
+console.log("pipeTo rejected after abort:", rejected);

--- a/test-parity/node-suite/stream/web/close-during-pending-writes.ts
+++ b/test-parity/node-suite/stream/web/close-during-pending-writes.ts
@@ -1,0 +1,17 @@
+import { WritableStream } from "node:stream/web";
+// close() with pending writes — must wait for the writes to complete
+// before the close promise resolves.
+let writesProcessed = 0;
+const ws = new WritableStream({
+  async write() {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    writesProcessed++;
+  },
+});
+const w = ws.getWriter();
+const a = w.write("a");
+const b = w.write("b");
+await w.close();
+console.log("writes processed:", writesProcessed);
+console.log("close resolved after writes:", writesProcessed === 2);
+await Promise.all([a, b]);

--- a/test-parity/node-suite/stream/web/text-encoder-stream-exists.ts
+++ b/test-parity/node-suite/stream/web/text-encoder-stream-exists.ts
@@ -1,0 +1,11 @@
+// TextEncoderStream is a global (per WHATWG spec); check it exists and
+// constructs.
+console.log("TextEncoderStream typeof:", typeof (globalThis as any).TextEncoderStream);
+console.log("TextDecoderStream typeof:", typeof (globalThis as any).TextDecoderStream);
+const Cls = (globalThis as any).TextEncoderStream;
+if (typeof Cls === "function") {
+  const tes = new Cls();
+  console.log("constructed:", typeof tes === "object");
+  console.log("has readable:", "readable" in tes);
+  console.log("has writable:", "writable" in tes);
+}

--- a/test-parity/node-suite/stream/web/transform-stream-flush-fn.ts
+++ b/test-parity/node-suite/stream/web/transform-stream-flush-fn.ts
@@ -1,0 +1,17 @@
+import { TransformStream } from "node:stream/web";
+// TransformStream's flush() (transformer.flush) runs before the readable
+// closes — can enqueue a final chunk.
+const ts = new TransformStream({
+  transform(c, ctrl) { ctrl.enqueue(c); },
+  flush(ctrl) { ctrl.enqueue("FINAL"); },
+});
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("x");
+await writer.close();
+const a = await reader.read();
+const b = await reader.read();
+const c = await reader.read();
+console.log("a:", a.value);
+console.log("b:", b.value);
+console.log("c done:", c.done);

--- a/test-parity/node-suite/stream/web/writer-re-acquire-after-release.ts
+++ b/test-parity/node-suite/stream/web/writer-re-acquire-after-release.ts
@@ -1,0 +1,10 @@
+import { WritableStream } from "node:stream/web";
+// After releaseLock(), getWriter() can be called again.
+const ws = new WritableStream({ write() {} });
+const w1 = ws.getWriter();
+w1.releaseLock();
+console.log("locked after release:", ws.locked);
+const w2 = ws.getWriter();
+console.log("re-acquired:", w2 !== w1);
+console.log("locked again:", ws.locked);
+await w2.close();

--- a/test-parity/node-suite/stream/writable/uncork-flushes-buffered.ts
+++ b/test-parity/node-suite/stream/writable/uncork-flushes-buffered.ts
@@ -1,0 +1,20 @@
+import { Writable } from "node:stream";
+// cork() buffers writes; uncork() flushes them. Implementation detail:
+// the buffered writes are processed in order on uncork.
+const received: string[] = [];
+const w = new Writable({
+  write(c, _e, cb) {
+    received.push(String(c));
+    cb();
+  },
+});
+w.cork();
+w.write("a");
+w.write("b");
+w.write("c");
+console.log("during cork:", received.length);
+w.uncork();
+w.end();
+w.on("finish", () => {
+  console.log("after uncork:", received.join(","));
+});


### PR DESCRIPTION
### Stream parity batch — 16 tests aggregated (iter-77..80)

**3 free passes + 13 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Compose / async-iter shape | compose-multi-async-fn, return-method-explicit, symbol-async-iter-returns-iterator | #1531 |
| Stream events / behavior | emit-error-with-capture, wrap-pipe-chain, destroy-during-read, finished-rejects-on-error, data-after-pause-resume, read-multibyte-boundary | #1532 |
| Writable buffering | uncork-flushes-buffered, flush-called-once | #1539 |
| Web stream surface | close-during-pending-writes ✅, writer-re-acquire-after-release ✅, transform-stream-flush-fn ✅, abort-during-pipeto, text-encoder-stream-exists | #1545 |

Free passes — Perry already matches Node:
- `web/close-during-pending-writes` (close() waits for in-flight writes)
- `web/writer-re-acquire-after-release` (getWriter after releaseLock works)
- `web/transform-stream-flush-fn` (flush() can enqueue final chunks)

All 13 failures tracked in `known_failures.json`; CI parity gate unaffected.
