### PR TITLE
test(parity): stream — batch of 16 tier-6 tests (iter-81..84) (4 free pass, 12 #1532/#1539/#1545/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2641,5 +2641,77 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: readableLength after push('é') — does not count 2 UTF-8 bytes. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/writer-write-resolves-after-sink": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: writer.write() Promise resolution timing — resolves before sink processes chunk. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/iter-helpers/compose-then-toarray": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(transform).toArray() — chain produces wrong result. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/events/listener-add-during-emit": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: listener added during emit — fires this round (should NOT in EE spec). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/highwater-mark-default-objectmode": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: objectMode HWM default — not 16 (object count). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/iter-and-data-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: for-await + 'data' listener — data event listener counts wrong, or iter empty. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipeline/three-async-fns": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline with multiple async-gen stages — fails to deliver final collected output. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/add-listener-is-on-alias": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: addListener !== on (should be same function reference). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-empty-map": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(empty Map) — does not yield immediate end. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/transform/objectmode-passes-objects": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: objectMode Transform — object data not preserved through transform. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/pipeline/null-cb-error-form": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline cb on success — err arg not null/undefined or wrong type. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-non-iterable-throws": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(non-iterable) — does not throw TypeError. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/destroy/_destroy-user-impl": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/destroy/_destroy-user-impl.ts
+++ b/test-parity/node-suite/stream/destroy/_destroy-user-impl.ts
@@ -1,0 +1,18 @@
+import { Readable } from "node:stream";
+// User _destroy(err, cb) is called during destroy() with the error and a cb.
+let userCalled = false;
+let receivedErr: any = null;
+const r = new Readable({
+  read() {},
+  destroy(err: any, cb: any) {
+    userCalled = true;
+    receivedErr = err;
+    cb(err);
+  },
+});
+r.on("error", () => {});
+r.destroy(new Error("user-destroy-test"));
+setImmediate(() => {
+  console.log("user impl called:", userCalled);
+  console.log("err message:", receivedErr && (receivedErr as Error).message);
+});

--- a/test-parity/node-suite/stream/events/add-listener-is-on-alias.ts
+++ b/test-parity/node-suite/stream/events/add-listener-is-on-alias.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// addListener is an alias of on; both should be defined and identical.
+const r = new Readable({ read() {} });
+console.log("on typeof:", typeof r.on);
+console.log("addListener typeof:", typeof r.addListener);
+console.log("identical:", r.on === r.addListener);

--- a/test-parity/node-suite/stream/events/listener-add-during-emit.ts
+++ b/test-parity/node-suite/stream/events/listener-add-during-emit.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Adding a listener INSIDE emit() — the new listener is NOT invoked this round.
+const r = new Readable({ read() {} });
+const order: string[] = [];
+const newListener = () => order.push("late");
+r.on("custom", () => {
+  order.push("first");
+  r.on("custom", newListener); // added during emit
+});
+r.emit("custom"); // should only fire 'first'
+console.log("first emit:", order.join(","));
+r.emit("custom"); // now 'late' fires
+console.log("second emit:", order.join(","));

--- a/test-parity/node-suite/stream/iter-helpers/compose-then-toarray.ts
+++ b/test-parity/node-suite/stream/iter-helpers/compose-then-toarray.ts
@@ -1,0 +1,7 @@
+import { Readable, Transform } from "node:stream";
+// readable.compose(transform).toArray() — chain compose with iter helper.
+const r = Readable.from(["a", "b", "c"]);
+const upper = new Transform({ transform(c, _e, cb) { cb(null, String(c).toUpperCase()); } });
+const composed: any = (r as any).compose(upper);
+const arr = await (composed as any).toArray();
+console.log("result:", arr.map((c: any) => String(c)).join(","));

--- a/test-parity/node-suite/stream/pipeline/null-cb-error-form.ts
+++ b/test-parity/node-suite/stream/pipeline/null-cb-error-form.ts
@@ -1,0 +1,9 @@
+import { Readable, PassThrough, pipeline } from "node:stream";
+// pipeline(src, dst, cb) — on success, cb is called with (null) or (undefined).
+const src = Readable.from(["a"]);
+const dst = new PassThrough();
+dst.on("data", () => {});
+pipeline(src, dst, (err) => {
+  console.log("err truthy:", !!err);
+  console.log("err type:", typeof err);
+});

--- a/test-parity/node-suite/stream/pipeline/three-async-fns.ts
+++ b/test-parity/node-suite/stream/pipeline/three-async-fns.ts
@@ -1,0 +1,22 @@
+import { Readable, pipeline } from "node:stream";
+// pipeline with multiple async-generator stages.
+const src = Readable.from(["a", "b"]);
+async function* upper(s: AsyncIterable<any>) {
+  for await (const c of s) yield String(c).toUpperCase();
+}
+async function* prefix(s: AsyncIterable<any>) {
+  for await (const c of s) yield "<" + c + ">";
+}
+const collected: string[] = [];
+pipeline(
+  src,
+  upper as any,
+  prefix as any,
+  async function (source: AsyncIterable<any>) {
+    for await (const v of source) collected.push(String(v));
+  },
+  (err: any) => {
+    console.log("err:", err);
+    console.log("collected:", collected.join(","));
+  },
+);

--- a/test-parity/node-suite/stream/readable/from-empty-map.ts
+++ b/test-parity/node-suite/stream/readable/from-empty-map.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Readable.from(new Map()) iterates an empty Map → no data, immediate end.
+const r = Readable.from(new Map());
+const out: any[] = [];
+r.on("data", (v) => out.push(v));
+r.on("end", () => {
+  console.log("count:", out.length);
+  console.log("is empty:", out.length === 0);
+});

--- a/test-parity/node-suite/stream/readable/from-non-iterable-throws.ts
+++ b/test-parity/node-suite/stream/readable/from-non-iterable-throws.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Readable.from(non-iterable) — should throw TypeError.
+let caught: string | null = null;
+try {
+  Readable.from(42 as any);
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/readable/highwater-mark-default-objectmode.ts
+++ b/test-parity/node-suite/stream/readable/highwater-mark-default-objectmode.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// In objectMode, highWaterMark defaults to 16 (count of objects, not bytes).
+const r = new Readable({ objectMode: true, read() {} });
+console.log("hwm:", r.readableHighWaterMark);
+console.log("is 16:", r.readableHighWaterMark === 16);

--- a/test-parity/node-suite/stream/readable/iter-and-data-listener.ts
+++ b/test-parity/node-suite/stream/readable/iter-and-data-listener.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Calling for-await on a stream that ALREADY has a 'data' listener
+// works: iteration consumes; the 'data' listener also sees the same data.
+const r = Readable.from(["a", "b"]);
+const dataEvents: string[] = [];
+r.on("data", (c) => dataEvents.push(String(c)));
+const iter: string[] = [];
+for await (const v of r) iter.push(String(v));
+console.log("iter:", iter.join(","));
+console.log("data events:", dataEvents.length);

--- a/test-parity/node-suite/stream/readable/read-multi-before-push.ts
+++ b/test-parity/node-suite/stream/readable/read-multi-before-push.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// Multiple read() calls before any push — all return null.
+const r = new Readable({ read() {} });
+console.log("r1:", r.read());
+console.log("r2:", r.read());
+console.log("r3:", r.read());
+console.log("all null:", r.read() === null && r.read() === null);

--- a/test-parity/node-suite/stream/transform/objectmode-passes-objects.ts
+++ b/test-parity/node-suite/stream/transform/objectmode-passes-objects.ts
@@ -1,0 +1,14 @@
+import { Transform } from "node:stream";
+// objectMode: true Transform passes objects directly (no Buffer conversion).
+const t = new Transform({
+  objectMode: true,
+  transform(c, _e, cb) { cb(null, { wrapped: c }); },
+});
+const out: any[] = [];
+t.on("data", (c) => out.push(c));
+t.on("end", () => {
+  console.log("count:", out.length);
+  console.log("first wrapped:", out[0] && out[0].wrapped);
+});
+t.write({ a: 1 });
+t.end();

--- a/test-parity/node-suite/stream/web/byob-respond-byte-stream.ts
+++ b/test-parity/node-suite/stream/web/byob-respond-byte-stream.ts
@@ -1,0 +1,18 @@
+import { ReadableStream } from "node:stream/web";
+// On a bytes-typed stream, the controller exposes byobRequest when a BYOB
+// reader is pulling. Test it exists at all.
+let hasByobRequest: any = null;
+const rs = new ReadableStream({
+  type: "bytes",
+  pull(c) {
+    hasByobRequest = (c as any).byobRequest !== undefined;
+  },
+} as any);
+const reader = (rs as any).getReader({ mode: "byob" });
+const view = new Uint8Array(8);
+try {
+  await reader.read(view);
+} catch {
+  // some impls may reject
+}
+console.log("byobRequest defined during pull:", hasByobRequest);

--- a/test-parity/node-suite/stream/web/sink-with-arrow-methods.ts
+++ b/test-parity/node-suite/stream/web/sink-with-arrow-methods.ts
@@ -1,0 +1,12 @@
+import { WritableStream } from "node:stream/web";
+// Sink object can use arrow functions for methods (no `this`).
+let written: string | null = null;
+const ws = new WritableStream({
+  write: (c) => {
+    written = String(c);
+  },
+});
+const w = ws.getWriter();
+await w.write("hi");
+await w.close();
+console.log("written:", written);

--- a/test-parity/node-suite/stream/web/transform-strategy-size-fn.ts
+++ b/test-parity/node-suite/stream/web/transform-strategy-size-fn.ts
@@ -1,0 +1,16 @@
+import { TransformStream } from "node:stream/web";
+// TransformStream's writableStrategy can have a custom size() function.
+let sizeCalled = 0;
+const ts = new TransformStream(undefined, {
+  highWaterMark: 10,
+  size: (chunk: any) => {
+    sizeCalled++;
+    return String(chunk).length;
+  },
+});
+const writer = ts.writable.getWriter();
+await writer.write("ab");
+await writer.write("cdef");
+await writer.close();
+console.log("size called:", sizeCalled);
+console.log("at least 2 calls:", sizeCalled >= 2);

--- a/test-parity/node-suite/stream/web/writer-write-resolves-after-sink.ts
+++ b/test-parity/node-suite/stream/web/writer-write-resolves-after-sink.ts
@@ -1,0 +1,16 @@
+import { WritableStream } from "node:stream/web";
+// writer.write() Promise resolution timing: resolves AFTER the sink's
+// write() has processed the chunk.
+let written = false;
+const ws = new WritableStream({
+  async write() {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    written = true;
+  },
+});
+const w = ws.getWriter();
+const p = w.write("x");
+console.log("before await:", written);
+await p;
+console.log("after await:", written);
+console.log("resolved after sink:", written);


### PR DESCRIPTION
### Stream parity batch — 16 tests aggregated (iter-81..84)

**4 free passes + 12 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | writer-write-resolves-after-sink, transform-strategy-size-fn ✅, sink-with-arrow-methods ✅, byob-respond-byte-stream ✅ | #1545 |
| Iter helpers | compose-then-toarray | #1558 |
| Stream events / behavior | listener-add-during-emit, highwater-mark-default-objectmode, iter-and-data-listener, three-async-fns, add-listener-is-on-alias, from-empty-map, null-cb-error-form, from-non-iterable-throws, _destroy-user-impl, read-multi-before-push ✅ | #1532 |
| Writable / Transform | objectmode-passes-objects | #1539 |

Free passes — Perry already matches Node:
- `web/transform-strategy-size-fn` (custom size() function called per write)
- `web/sink-with-arrow-methods` (arrow fn sink methods work without `this`)
- `web/byob-respond-byte-stream` (byobRequest available during pull on bytes stream)
- `readable/read-multi-before-push` (multiple read() before any push returns null)

All 12 failures tracked in `known_failures.json`; CI parity gate unaffected.
