### PR TITLE
test(parity): stream — batch of 12 tier-6/7 tests (iter-85..87) (4 free pass, 8 #1532/#1539/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2719,5 +2719,53 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pause→resume cycle — does not deliver all data events. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/sink-write-rejection-becomes-error": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: sink write cb(err) — does not emit 'error' event. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/empty-pure-end": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pure-end Readable (push(null) only) — 'end' fires with wrong data count or doesn't fire. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/get-events-set-equality": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: removeListener of un-registered listener — eventNames count wrong, or unexpected error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/from-async-generator-function": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: ReadableStream.from(asyncGen()) — iteration wrong or fails. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/objectmode-pipe": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: objectMode pipe — raw object data not preserved through pipe. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/object-stream-pause-resume": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pause/resume on objectMode Readable — wrong count or first item value. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/_writev-vs-write": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: cork+uncork dispatches to write() instead of writev() when writev is defined. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/readable/unshift-while-flowing": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: unshift() during flowing mode — chunk not re-emitted in order. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/get-events-set-equality.ts
+++ b/test-parity/node-suite/stream/events/get-events-set-equality.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// EE: removing a listener that's not registered is a no-op (no error).
+const r = new Readable({ read() {} });
+const fn = () => {};
+r.removeListener("nothing", fn); // not registered
+r.removeListener("data", () => {}); // anonymous, not the same reference
+console.log("still no listeners:", r.eventNames().length);
+console.log("no error thrown");

--- a/test-parity/node-suite/stream/pipe/objectmode-pipe.ts
+++ b/test-parity/node-suite/stream/pipe/objectmode-pipe.ts
@@ -1,0 +1,13 @@
+import { Readable, Writable } from "node:stream";
+// Pipe an objectMode Readable into an objectMode Writable; raw objects flow.
+const r = Readable.from([{ id: 1 }, { id: 2 }]);
+const received: any[] = [];
+const w = new Writable({
+  objectMode: true,
+  write(c, _e, cb) { received.push(c); cb(); },
+});
+r.pipe(w);
+w.on("finish", () => {
+  console.log("count:", received.length);
+  console.log("first id:", received[0] && received[0].id);
+});

--- a/test-parity/node-suite/stream/readable/empty-pure-end.ts
+++ b/test-parity/node-suite/stream/readable/empty-pure-end.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// A Readable that pushes null immediately fires 'end' without any 'data'.
+let dataCount = 0;
+let endFired = false;
+const r = new Readable({
+  read() {
+    this.push(null);
+  },
+});
+r.on("data", () => dataCount++);
+r.on("end", () => {
+  endFired = true;
+  console.log("data count:", dataCount);
+  console.log("end fired:", endFired);
+});

--- a/test-parity/node-suite/stream/readable/from-generator-fn.ts
+++ b/test-parity/node-suite/stream/readable/from-generator-fn.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Readable.from(generatorFunction) — passes a function, not an iterator;
+// Node calls it once and iterates the result.
+function* gen() {
+  yield 1;
+  yield 2;
+}
+const r = Readable.from(gen as any);
+const out: any[] = [];
+for await (const v of r) out.push(v);
+console.log("yielded:", out.join(","));

--- a/test-parity/node-suite/stream/readable/object-stream-pause-resume.ts
+++ b/test-parity/node-suite/stream/readable/object-stream-pause-resume.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// pause()/resume() also work on object-mode streams.
+const r = Readable.from([{ a: 1 }, { a: 2 }, { a: 3 }]);
+const out: any[] = [];
+r.pause();
+r.on("data", (c) => out.push(c));
+setImmediate(() => r.resume());
+r.on("end", () => {
+  console.log("count:", out.length);
+  console.log("first:", out[0] && out[0].a);
+});

--- a/test-parity/node-suite/stream/readable/unshift-while-flowing.ts
+++ b/test-parity/node-suite/stream/readable/unshift-while-flowing.ts
@@ -1,0 +1,18 @@
+import { Readable } from "node:stream";
+// unshift() during flowing mode — chunk re-enters at the front of the queue.
+const r = new Readable({ read() {} });
+const out: string[] = [];
+let unshifted = false;
+r.on("data", (c) => {
+  const s = String(c);
+  out.push(s);
+  if (s === "second" && !unshifted) {
+    unshifted = true;
+    r.unshift("PUT-BACK");
+  }
+});
+r.on("end", () => console.log("out:", out.join(",")));
+r.push("first");
+r.push("second");
+r.push("third");
+r.push(null);

--- a/test-parity/node-suite/stream/web/abort-no-arg.ts
+++ b/test-parity/node-suite/stream/web/abort-no-arg.ts
@@ -1,0 +1,10 @@
+import { WritableStream } from "node:stream/web";
+// abort() with no arg — abort succeeds; reason is undefined.
+let seen: any = "untouched";
+const ws = new WritableStream({
+  write() {},
+  abort(reason) { seen = reason; },
+});
+await ws.abort();
+console.log("sink reason:", seen);
+console.log("undefined:", seen === undefined);

--- a/test-parity/node-suite/stream/web/from-async-generator-function.ts
+++ b/test-parity/node-suite/stream/web/from-async-generator-function.ts
@@ -1,0 +1,15 @@
+import { ReadableStream } from "node:stream/web";
+// ReadableStream.from with an async generator's return value (an iterator).
+async function* gen() {
+  yield "a";
+  yield "b";
+}
+const rs = (ReadableStream as any).from(gen());
+const reader = rs.getReader();
+const out: string[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(String(value));
+}
+console.log("collected:", out.join(","));

--- a/test-parity/node-suite/stream/web/reader-read-after-cancel.ts
+++ b/test-parity/node-suite/stream/web/reader-read-after-cancel.ts
@@ -1,0 +1,8 @@
+import { ReadableStream } from "node:stream/web";
+// reader.read() after cancel() returns {done: true}.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); } });
+const reader = rs.getReader();
+await reader.cancel("stop");
+const result = await reader.read();
+console.log("value:", result.value);
+console.log("done:", result.done);

--- a/test-parity/node-suite/stream/web/tee-returns-readable-instances.ts
+++ b/test-parity/node-suite/stream/web/tee-returns-readable-instances.ts
@@ -1,0 +1,7 @@
+import { ReadableStream } from "node:stream/web";
+// tee() returns a 2-element array of ReadableStream instances.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const result = rs.tee();
+console.log("is array:", Array.isArray(result));
+console.log("length:", result.length);
+console.log("both ReadableStream:", result[0] instanceof ReadableStream && result[1] instanceof ReadableStream);

--- a/test-parity/node-suite/stream/writable/_writev-vs-write.ts
+++ b/test-parity/node-suite/stream/writable/_writev-vs-write.ts
@@ -1,0 +1,26 @@
+import { Writable } from "node:stream";
+// If writev is defined, cork+uncork-batched writes go through writev rather
+// than individual write calls.
+let writevCalls = 0;
+let writeCalls = 0;
+const w = new Writable({
+  write(_c, _e, cb) {
+    writeCalls++;
+    cb();
+  },
+  writev(_chunks, cb) {
+    writevCalls++;
+    cb();
+  },
+});
+w.cork();
+w.write("a");
+w.write("b");
+w.write("c");
+w.uncork();
+w.end();
+w.on("finish", () => {
+  console.log("writev calls:", writevCalls);
+  console.log("write calls:", writeCalls);
+  console.log("writev took the batch:", writevCalls > 0);
+});

--- a/test-parity/node-suite/stream/writable/sink-write-rejection-becomes-error.ts
+++ b/test-parity/node-suite/stream/writable/sink-write-rejection-becomes-error.ts
@@ -1,0 +1,11 @@
+import { Writable } from "node:stream";
+// When sink.write callback is invoked with an Error, the stream emits 'error'.
+const w = new Writable({
+  write(_c, _e, cb) {
+    cb(new Error("sink-rejection"));
+  },
+});
+let errMsg: string | null = null;
+w.on("error", (err) => (errMsg = err && err.message));
+w.write("x");
+setImmediate(() => console.log("err:", errMsg));


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-85..87)

**4 free passes + 8 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | reader-read-after-cancel ✅, abort-no-arg ✅, tee-returns-readable-instances ✅, from-async-generator-function | #1545 |
| Readable shape | from-generator-fn ✅, empty-pure-end, object-stream-pause-resume, unshift-while-flowing | #1532 |
| Stream events / pipe | sink-write-rejection-becomes-error, get-events-set-equality, objectmode-pipe | #1532 |
| Writable buffering | _writev-vs-write | #1539 |

Free passes — Perry already matches Node:
- `web/reader-read-after-cancel` (read after cancel returns {done:true})
- `web/abort-no-arg` (abort() w/o arg passes undefined reason to sink)
- `web/tee-returns-readable-instances` (tee returns [RS, RS] correctly)
- `readable/from-generator-fn` (Readable.from(generatorFn) iterates)

All 8 failures tracked in `known_failures.json`; CI parity gate unaffected.
