### PR TITLE
fix(node): typeof on Set/Map method values reports "function" (#1380, verifies #1539/#1541)

### DIFF
--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -46,6 +46,40 @@ use super::{
     I18nLowerCtx,
 };
 
+/// #1380: method names addressable on a `Set` instance, used by the
+/// `typeof set.<name>` fold to report "function" (Set method values are
+/// not materialized as real function objects). Includes the ES2024
+/// composition methods.
+fn is_set_method_name(name: &str) -> bool {
+    matches!(
+        name,
+        "has"
+            | "add"
+            | "delete"
+            | "clear"
+            | "forEach"
+            | "entries"
+            | "values"
+            | "keys"
+            | "union"
+            | "intersection"
+            | "difference"
+            | "symmetricDifference"
+            | "isSubsetOf"
+            | "isSupersetOf"
+            | "isDisjointFrom"
+    )
+}
+
+/// #1380: method names addressable on a `Map` instance, used by the
+/// `typeof map.<name>` fold (same rationale as `is_set_method_name`).
+fn is_map_method_name(name: &str) -> bool {
+    matches!(
+        name,
+        "has" | "get" | "set" | "delete" | "clear" | "forEach" | "entries" | "values" | "keys"
+    )
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::Integer(i) => Ok(double_literal(*i as f64)),
@@ -108,7 +142,21 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // misclassification.
                 Expr::GlobalGet(_) => Some("object"),
                 Expr::PropertyGet { object, property } => {
-                    if let Expr::ExternFuncRef { name, .. } = object.as_ref() {
+                    // #1380: `typeof set.has` / `typeof map.get` → "function".
+                    // Set/Map methods aren't materialized as real function
+                    // objects — a bare `set.has` read returns the (absent)
+                    // data property, so `js_value_typeof` would report
+                    // "undefined". The receiver type is known here via
+                    // `is_set_expr`/`is_map_expr` (the same routing that makes
+                    // `set.size` resolve to a number), so fold known method
+                    // names to "function". Covers
+                    // `process.allowedNodeEnvironmentFlags` (lowered to a Set)
+                    // whose `.has`/`.size` callers feature-detect with typeof.
+                    if (is_set_expr(ctx, object) && is_set_method_name(property))
+                        || (is_map_expr(ctx, object) && is_map_method_name(property))
+                    {
+                        Some("function")
+                    } else if let Expr::ExternFuncRef { name, .. } = object.as_ref() {
                         if ctx.namespace_imports.contains(name)
                             && ctx.class_ids.contains_key(property)
                         {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -332,12 +332,6 @@
     "category": "bug-open",
     "reason": "node:stream EventEmitter wiring incomplete — re-validated 2026-05-24 (v0.5.1026, Linux): still FAILS. Real Perry gap (not ci-env); rolled under the open stream-events tracker #1532."
   },
-  "node-suite/process/env/allowed-flags": {
-    "issue": "1380",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:process: process.allowedNodeEnvironmentFlags is a Set, but `typeof aSet.has` reads 'undefined' for every Set (method-value-typeof gap), so `f.has` is not seen as a function. Reopened #1380; the real fix is general Set-method-value typeof."
-  },
   "node-suite/stream/classes/readable-constructor": {
     "issue": "1531",
     "added": "2026-05-23",


### PR DESCRIPTION
## Summary

Closes the three open node-builtin parity gaps **#1380 / #1539 / #1541**, verified byte-for-byte against `node --experimental-strip-types`.

The only code change here is for **#1380**. While investigating I found that **#1539** and **#1541** are already fixed on `main` (by the `unwrap_ts_wrappers` receiver-peel that landed with the #1633 re-validation, plus the #1545 web-streams work) — their acceptance repros now pass, so this PR just confirms them and removes the stale skip-list entry that #1380 needs.

### #1380 — `typeof process.allowedNodeEnvironmentFlags.has === "function"`

`process.allowedNodeEnvironmentFlags` lowers to `new Set()`. The repro feature-detects with:

```ts
typeof f.has  === "function"   // was: false  ❌
typeof f.size === "number"     // was: true   ✓
```

`.size` already routed to the Set size helper (a number), but `typeof set.has` read the *absent* `has` data property, so `js_value_typeof` reported `"undefined"` and the method wasn't seen as a function.

**Fix:** fold known Set/Map method names to `"function"` in the codegen `typeof` short-circuit (`expr/literals_vars.rs`), gated by the existing `is_set_expr` / `is_map_expr` receiver-type analysis — the same routing that makes `set.size` resolve to a number. Includes the ES2024 Set composition methods (`union`/`intersection`/`difference`/…).

The fold is tightly scoped — verified it does **not** over-fire:

| expr | node | perry |
|------|------|-------|
| `typeof set.has` | function | function |
| `typeof set.size` | number | number |
| `typeof (set as any).bogus` | undefined | undefined |
| `typeof map.get` | function | function |
| `typeof plainObj.has` (where `has: 5`) | number | number |

### #1539 / #1541 — already fixed on `main`

`(stream as any).compose`/`duplexPair`/`addAbortSignal` — the static `typeof … === "function"` repros pass, and the `(stream as any).<method>(...)` **call** form now dispatches correctly because `try_native_module_methods` peels TS-cast wrappers off the receiver via `unwrap_ts_wrappers`. No new code needed; this PR removes the `allowed-flags` skip-list entry that was still blocking #1380.

## Validation

All four acceptance repros pass byte-for-byte vs Node:

- `node-suite/process/env/allowed-flags` (#1380) — FAIL→PASS via this change
- `node-suite/stream/static/compose-helper` (#1539) — PASS
- `node-suite/stream/static/duplex-pair` (#1539) — PASS
- `node-suite/stream/abort/add-abort-signal` (#1541) — PASS

A/B confirmed (stashed-revert rebuild): the 4 targets fail on `main` without the Set-typeof fix where applicable, and a 192-test regression sweep over `process/*`, the affected `stream/*` subdirs, and every `(X as any).Y(...)` repro surfaced **zero** new failures (all 10 non-known failures fail identically on `main` — pre-existing, unrelated gaps).

## Notes

- No version bump / CHANGELOG entry (left for the maintainer to fold in at merge, per repo convention).
- `cargo fmt --all -- --check` clean.



Closes #1380.
