### PR TITLE
test(parity): stream — batch of 12 tier-7 tests (iter-88..90) (3 free pass, 9 #1531/#1532/#1539/#1545/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2623,5 +2623,59 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: pause→resume cycle — does not deliver all data events. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/writable-length-tracker": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: writableLength does not track buffered bytes in the writable queue. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/readable/options-autoDestroy-explicit": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: autoDestroy: false — stream still destroyed after 'end' or 'close' fires when it shouldn't. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/sink-all-four-methods": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: sink with start+write+close+abort — methods not invoked in correct order or some skipped. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipeline/error-middle-aborts-all": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline middle-stream error — does not destroy source AND sink. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/take-then-filter": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: chained take(N).filter(fn) — wrong output. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/web/from-promise-iterable": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: ReadableStream.from(customIterable) — value or done wrong. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/on-non-function-throws": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: on(event, non-function) — does not throw TypeError as expected. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/iterator-empty-after-consumed": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: second [Symbol.asyncIterator]() call — does not return immediately-done iterator. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/from-typed-array": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Uint8Array) — iteration count or first-byte value wrong. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/on-non-function-throws.ts
+++ b/test-parity/node-suite/stream/events/on-non-function-throws.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// on(event, non-function) — should throw TypeError per EE spec.
+const r = new Readable({ read() {} });
+let caught: string | null = null;
+try {
+  r.on("data", "not-a-function" as any);
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/iter-helpers/drop-larger-than-stream.ts
+++ b/test-parity/node-suite/stream/iter-helpers/drop-larger-than-stream.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// drop(N) where N > items — yields empty.
+const r = Readable.from([1, 2, 3]);
+const out: any[] = [];
+for await (const v of (r as any).drop(100)) out.push(v);
+console.log("count:", out.length);
+console.log("is empty:", out.length === 0);

--- a/test-parity/node-suite/stream/iter-helpers/take-then-filter.ts
+++ b/test-parity/node-suite/stream/iter-helpers/take-then-filter.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Chained .take(N).filter(fn) — both helpers participate.
+const r = Readable.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+const out: number[] = [];
+for await (const v of (r as any).take(6).filter((x: number) => x % 2 === 0)) {
+  out.push(v as number);
+}
+console.log("result:", out.join(","));

--- a/test-parity/node-suite/stream/pipeline/error-middle-aborts-all.ts
+++ b/test-parity/node-suite/stream/pipeline/error-middle-aborts-all.ts
@@ -1,0 +1,17 @@
+import { Readable, Transform, Writable, pipeline } from "node:stream";
+// An error in a middle transform — source AND sink should be destroyed.
+let srcClosed = false;
+let sinkClosed = false;
+const src = new Readable({ read() {} });
+const mid = new Transform({ transform(_c, _e, cb) { cb(new Error("mid-fail")); } });
+const sink = new Writable({ write(_c, _e, cb) { cb(); } });
+src.on("close", () => (srcClosed = true));
+sink.on("close", () => (sinkClosed = true));
+pipeline(src, mid, sink, () => {});
+src.push("x");
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("src destroyed:", srcClosed);
+    console.log("sink destroyed:", sinkClosed);
+  });
+});

--- a/test-parity/node-suite/stream/readable/from-typed-array.ts
+++ b/test-parity/node-suite/stream/readable/from-typed-array.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Readable.from(Uint8Array) — TypedArrays are iterable, yields each byte.
+// (Differs from Buffer which short-circuits to single chunk in Node.)
+const arr = new Uint8Array([1, 2, 3]);
+const r = Readable.from(arr);
+const out: any[] = [];
+for await (const v of r) out.push(v);
+console.log("count:", out.length);
+console.log("first:", out[0]);

--- a/test-parity/node-suite/stream/readable/highwater-mark-zero.ts
+++ b/test-parity/node-suite/stream/readable/highwater-mark-zero.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// highWaterMark: 0 — push() returns false immediately because anything
+// is at the limit.
+const r = new Readable({ highWaterMark: 0, read() {} });
+const a = r.push("x");
+console.log("push(x) returned:", a);
+console.log("readableHighWaterMark:", r.readableHighWaterMark);

--- a/test-parity/node-suite/stream/readable/iterator-empty-after-consumed.ts
+++ b/test-parity/node-suite/stream/readable/iterator-empty-after-consumed.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// After [Symbol.asyncIterator]() fully consumes the stream, a second call
+// returns an iterator that's immediately done.
+const r = Readable.from([1, 2, 3]);
+const first: any[] = [];
+for await (const v of r) first.push(v);
+const it2 = (r as any)[Symbol.asyncIterator]();
+const next = await it2.next();
+console.log("first:", first.join(","));
+console.log("second iter done:", next.done);

--- a/test-parity/node-suite/stream/readable/options-autoDestroy-explicit.ts
+++ b/test-parity/node-suite/stream/readable/options-autoDestroy-explicit.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// autoDestroy: false — after 'end' the stream is NOT auto-destroyed; 'close'
+// does not fire until you destroy() explicitly.
+const r = new Readable({ autoDestroy: false, read() {} });
+let closed = false;
+r.on("close", () => (closed = true));
+r.on("data", () => {});
+r.on("end", () => {
+  setImmediate(() => {
+    console.log("destroyed after end:", r.destroyed);
+    console.log("closed:", closed);
+  });
+});
+r.push("a");
+r.push(null);

--- a/test-parity/node-suite/stream/web/from-promise-iterable.ts
+++ b/test-parity/node-suite/stream/web/from-promise-iterable.ts
@@ -1,0 +1,22 @@
+import { ReadableStream } from "node:stream/web";
+// ReadableStream.from accepts an iterable; a single-value iterable yields once.
+const single = {
+  [Symbol.iterator]() {
+    let yielded = false;
+    return {
+      next() {
+        if (!yielded) {
+          yielded = true;
+          return { value: "the-value", done: false };
+        }
+        return { value: undefined, done: true };
+      },
+    };
+  },
+};
+const rs = (ReadableStream as any).from(single);
+const reader = rs.getReader();
+const a = await reader.read();
+const b = await reader.read();
+console.log("a value:", a.value, "done:", a.done);
+console.log("b done:", b.done);

--- a/test-parity/node-suite/stream/web/sink-all-four-methods.ts
+++ b/test-parity/node-suite/stream/web/sink-all-four-methods.ts
@@ -1,0 +1,13 @@
+import { WritableStream } from "node:stream/web";
+// Sink can define start, write, close, abort — all 4 are honored.
+const order: string[] = [];
+const ws = new WritableStream({
+  start() { order.push("start"); },
+  write(c) { order.push("write:" + String(c)); },
+  close() { order.push("close"); },
+  abort() { order.push("abort"); },
+});
+const w = ws.getWriter();
+await w.write("x");
+await w.close();
+console.log("order:", order.join(","));

--- a/test-parity/node-suite/stream/web/transform-async-flush.ts
+++ b/test-parity/node-suite/stream/web/transform-async-flush.ts
@@ -1,0 +1,20 @@
+import { TransformStream } from "node:stream/web";
+// flush() that returns a Promise — readable.close awaits it.
+let flushDone = false;
+const ts = new TransformStream({
+  transform(c, ctrl) { ctrl.enqueue(c); },
+  async flush() {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    flushDone = true;
+  },
+});
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("a");
+await writer.close();
+// drain readable
+while (true) {
+  const { done } = await reader.read();
+  if (done) break;
+}
+console.log("flush ran:", flushDone);

--- a/test-parity/node-suite/stream/writable/writable-length-tracker.ts
+++ b/test-parity/node-suite/stream/writable/writable-length-tracker.ts
@@ -1,0 +1,11 @@
+import { Writable } from "node:stream";
+// writableLength reflects buffered bytes pending in the writable queue.
+const w = new Writable({
+  highWaterMark: 100,
+  write(_c, _e, cb) { setImmediate(cb); }, // delay so writes accumulate
+});
+console.log("initial:", w.writableLength);
+w.write("ab");
+w.write("cd");
+console.log("after 2 writes:", w.writableLength);
+w.end();


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-88..90)

**3 free passes + 9 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Writable buffering | writable-length-tracker | #1539 |
| Readable shape | options-autoDestroy-explicit, iterator-empty-after-consumed, from-typed-array | #1531/#1532 |
| Pipeline | error-middle-aborts-all | #1532 |
| Web stream surface | sink-all-four-methods, from-promise-iterable, transform-async-flush ✅ | #1545 |
| Iter helpers | take-then-filter, drop-larger-than-stream ✅ | #1558 |
| EE validation | on-non-function-throws | #1532 |
| Backpressure | highwater-mark-zero ✅ | — |

Free passes — Perry already matches Node:
- `iter-helpers/drop-larger-than-stream` (drop(N>items) yields empty)
- `web/transform-async-flush` (async flush() promise awaited before readable closes)
- `readable/highwater-mark-zero` (HWM=0 makes push() return false)

All 9 failures tracked in `known_failures.json`; CI parity gate unaffected.
