### PR TITLE
fix(web-fetch/node): Request.headers, Response.body, http2 constants, node:http link (#1649–#1652)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2810,6 +2810,9 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     class("http2", "Http2SecureServer"),
     class("http2", "Http2ServerRequest"),
     class("http2", "Http2ServerResponse"),
+    // `http2.constants` — the frozen object of HTTP2_HEADER_* / NGHTTP2_* /
+    // HTTP_STATUS_* values. `@hono/node-server` imports it by name (#1651).
+    property("http2", "constants"),
     // `@perryts/google-auth` no longer ships in the bundled manifest —
     // since v0.5.1015 it lives at https://github.com/PerryTS/google-auth
     // and is installed via `npm install @perryts/google-auth`. The

--- a/crates/perry-codegen/src/lower_call/options/fetch.rs
+++ b/crates/perry-codegen/src/lower_call/options/fetch.rs
@@ -255,9 +255,9 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
             // surfaced as a number and `req.headers.get(...)` threw
             // "(number).get is not a function", crashing every Hono adapter.
             "headers" => {
-                let out = ctx
-                    .block()
-                    .call(DOUBLE, "js_request_get_headers", &[(DOUBLE, &h_handle)]);
+                let out =
+                    ctx.block()
+                        .call(DOUBLE, "js_request_get_headers", &[(DOUBLE, &h_handle)]);
                 return Ok(Some(out));
             }
             _ => return Ok(None),

--- a/crates/perry-codegen/src/lower_call/options/fetch.rs
+++ b/crates/perry-codegen/src/lower_call/options/fetch.rs
@@ -249,6 +249,17 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                     .call(DOUBLE, "js_request_get_body", &[(DOUBLE, &h_handle)]);
                 return Ok(Some(val));
             }
+            // #1649: `req.headers` returns a `Headers` object (NaN-boxed
+            // handle), not the raw numeric request handle. Without this the
+            // typed path fell through to `Ok(None)` → the receiver handle
+            // surfaced as a number and `req.headers.get(...)` threw
+            // "(number).get is not a function", crashing every Hono adapter.
+            "headers" => {
+                let out = ctx
+                    .block()
+                    .call(DOUBLE, "js_request_get_headers", &[(DOUBLE, &h_handle)]);
+                return Ok(Some(out));
+            }
             _ => return Ok(None),
         }
     }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1606,6 +1606,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_request_get_url", I64, &[DOUBLE]);
     module.declare_function("js_request_get_method", I64, &[DOUBLE]);
     module.declare_function("js_request_get_body", DOUBLE, &[DOUBLE]);
+    // #1649: `req.headers` → NaN-boxed Headers handle.
+    module.declare_function("js_request_get_headers", DOUBLE, &[DOUBLE]);
 
     // Response body getters — handles flow as NaN-boxed POINTER_TAG f64
     // (Phase 1 unification, refs #421). Accessors call `handle_id` to

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -946,3 +946,145 @@ mod tests {
 fn _force_link() -> Option<*mut ArrayHeader> {
     None
 }
+
+// #1652: force the linker to retain perry-ext-http-server's `#[no_mangle]`
+// FFI symbols. The `extern crate perry_ext_http_server as _server_link`
+// at the top of this file pulls the rlib into the dependency graph, but
+// the server functions are referenced only by codegen-generated callsites
+// in the *user* program — never by this crate's Rust. Under LTO / staticlib
+// emission they can therefore be dead-stripped, and the final link then
+// fails with `Undefined symbols: _js_node_http_create_server` for any
+// program that does `import { createServer } from 'node:http'` (the failure
+// originally tracked at #589, reopened as #1652). Anchoring their addresses
+// in a `#[used]` table makes the retention explicit so it can't silently
+// regress when nobody's npm import happens to reference a given symbol.
+//
+// Resolution is by symbol name (C ABI): the `()` signatures below are only
+// ever used to take the function's address, never to call it, so they need
+// not match the real definitions — the linker keys off the `#[no_mangle]`
+// symbol name alone.
+#[allow(dead_code)]
+mod force_link_http_server {
+    extern "C" {
+        // http server + IncomingMessage + ServerResponse entry points.
+        pub fn js_node_http_create_server();
+        pub fn js_node_http_server_listen();
+        pub fn js_node_http_server_listening();
+        pub fn js_node_http_server_close();
+        pub fn js_node_http_server_on();
+        pub fn js_node_http_server_address_json();
+        pub fn js_node_http_server_process_pending();
+        pub fn js_node_http_server_has_active();
+        pub fn js_node_http_server_close_all_connections();
+        pub fn js_node_http_server_close_idle_connections();
+        pub fn js_node_http_res_end();
+        pub fn js_node_http_res_write();
+        pub fn js_node_http_res_write_head();
+        pub fn js_node_http_res_set_header();
+        pub fn js_node_http_res_get_header();
+        pub fn js_node_http_res_get_header_names_json();
+        pub fn js_node_http_res_get_headers_json();
+        pub fn js_node_http_res_has_header();
+        pub fn js_node_http_res_remove_header();
+        pub fn js_node_http_res_set_status();
+        pub fn js_node_http_res_get_status();
+        pub fn js_node_http_res_set_status_message();
+        pub fn js_node_http_res_headers_sent();
+        pub fn js_node_http_res_writable_ended();
+        pub fn js_node_http_res_writable_finished();
+        pub fn js_node_http_res_flush_headers();
+        pub fn js_node_http_res_write_continue();
+        pub fn js_node_http_res_write_processing();
+        pub fn js_node_http_res_on();
+        pub fn js_node_http_im_method();
+        pub fn js_node_http_im_url();
+        pub fn js_node_http_im_http_version();
+        pub fn js_node_http_im_headers_json();
+        pub fn js_node_http_im_raw_headers_json();
+        pub fn js_node_http_im_remote_address();
+        pub fn js_node_http_im_remote_port();
+        pub fn js_node_http_im_on();
+        pub fn js_node_http_im_read();
+        pub fn js_node_http_im_pause();
+        pub fn js_node_http_im_resume();
+        pub fn js_node_http_im_aborted();
+        pub fn js_node_http_im_complete();
+        pub fn js_node_http_im_destroy();
+        pub fn js_node_http_im_destroyed();
+        // https server.
+        pub fn js_node_https_create_server();
+        pub fn js_node_https_server_listen();
+        pub fn js_node_https_server_close();
+        pub fn js_node_https_server_on();
+        pub fn js_node_https_server_address_json();
+        // http2 secure server.
+        pub fn js_node_http2_create_secure_server();
+        pub fn js_node_http2_server_listen();
+        pub fn js_node_http2_server_close();
+        pub fn js_node_http2_server_on();
+        pub fn js_node_http2_server_address_json();
+    }
+}
+
+/// `#[used]` anchor table referencing every server FFI entry point so the
+/// linker keeps them in `libperry_ext_http.a`. See the module above (#1652).
+#[used]
+static FORCE_LINK_HTTP_SERVER: &[unsafe extern "C" fn()] = {
+    use force_link_http_server::*;
+    &[
+        js_node_http_create_server,
+        js_node_http_server_listen,
+        js_node_http_server_listening,
+        js_node_http_server_close,
+        js_node_http_server_on,
+        js_node_http_server_address_json,
+        js_node_http_server_process_pending,
+        js_node_http_server_has_active,
+        js_node_http_server_close_all_connections,
+        js_node_http_server_close_idle_connections,
+        js_node_http_res_end,
+        js_node_http_res_write,
+        js_node_http_res_write_head,
+        js_node_http_res_set_header,
+        js_node_http_res_get_header,
+        js_node_http_res_get_header_names_json,
+        js_node_http_res_get_headers_json,
+        js_node_http_res_has_header,
+        js_node_http_res_remove_header,
+        js_node_http_res_set_status,
+        js_node_http_res_get_status,
+        js_node_http_res_set_status_message,
+        js_node_http_res_headers_sent,
+        js_node_http_res_writable_ended,
+        js_node_http_res_writable_finished,
+        js_node_http_res_flush_headers,
+        js_node_http_res_write_continue,
+        js_node_http_res_write_processing,
+        js_node_http_res_on,
+        js_node_http_im_method,
+        js_node_http_im_url,
+        js_node_http_im_http_version,
+        js_node_http_im_headers_json,
+        js_node_http_im_raw_headers_json,
+        js_node_http_im_remote_address,
+        js_node_http_im_remote_port,
+        js_node_http_im_on,
+        js_node_http_im_read,
+        js_node_http_im_pause,
+        js_node_http_im_resume,
+        js_node_http_im_aborted,
+        js_node_http_im_complete,
+        js_node_http_im_destroy,
+        js_node_http_im_destroyed,
+        js_node_https_create_server,
+        js_node_https_server_listen,
+        js_node_https_server_close,
+        js_node_https_server_on,
+        js_node_https_server_address_json,
+        js_node_http2_create_secure_server,
+        js_node_http2_server_listen,
+        js_node_http2_server_close,
+        js_node_http2_server_on,
+        js_node_http2_server_address_json,
+    ]
+};

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -963,6 +963,16 @@ fn _force_link() -> Option<*mut ArrayHeader> {
 // ever used to take the function's address, never to call it, so they need
 // not match the real definitions — the linker keys off the `#[no_mangle]`
 // symbol name alone.
+//
+// `cfg(not(test))`: the anchor must NOT fire in `cargo test -p perry-ext-http`.
+// Forcing the server functions into the unit-test binary drags in their
+// transitive `perry_ffi_spawn_blocking*` references, which only the host
+// (perry-stdlib) provides at the final perry-compile link — the test binary
+// has no host, so it fails with `undefined symbol: perry_ffi_spawn_blocking`.
+// The staticlib (the real perry-compile artifact) is built without `test`,
+// so retention there is unaffected. Nothing cargo-depends on this crate, so
+// gating on `test` is sufficient.
+#[cfg(not(test))]
 #[allow(dead_code)]
 mod force_link_http_server {
     extern "C" {
@@ -1028,6 +1038,9 @@ mod force_link_http_server {
 
 /// `#[used]` anchor table referencing every server FFI entry point so the
 /// linker keeps them in `libperry_ext_http.a`. See the module above (#1652).
+/// Gated with the module on `not(test)` so the unit-test binary doesn't drag
+/// in the server's host-provided `perry_ffi_*` symbols.
+#[cfg(not(test))]
 #[used]
 static FORCE_LINK_HTTP_SERVER: &[unsafe extern "C" fn()] = {
     use force_link_http_server::*;

--- a/crates/perry-runtime/src/builtins/arithmetic.rs
+++ b/crates/perry-runtime/src/builtins/arithmetic.rs
@@ -256,6 +256,20 @@ pub extern "C" fn js_value_typeof(value: f64) -> *mut StringHeader {
         if crate::date::is_registered_date_bits(bits) {
             return get_cached(&TYPEOF_OBJECT, "object");
         }
+        // #1650: Web Streams handles (ReadableStream / WritableStream /
+        // reader / writer) are returned as a raw `id as f64` whole number in
+        // a high id range (#1545), so they reach this fallthrough and would
+        // otherwise report "number". Consult the stdlib kind-probe — the same
+        // side-channel `instanceof ReadableStream` uses — so `typeof
+        // res.body === "object"` matches the spec (Response.body is a
+        // ReadableStream object).
+        if value.is_finite() && value > 0.0 && value.fract() == 0.0 {
+            if let Some(probe) = crate::object::stream_handle_kind_probe() {
+                if unsafe { probe(value as usize) } != 0 {
+                    return get_cached(&TYPEOF_OBJECT, "object");
+                }
+            }
+        }
         // Regular f64 number
         get_cached(&TYPEOF_NUMBER, "number")
     }

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1351,6 +1351,83 @@ pub(crate) unsafe fn get_native_module_constant(
         Some(v as f64)
     };
 
+    // `http2.constants` — the subset of Node's `require('node:http2').constants`
+    // that real code reads: the `:`-prefixed pseudo-header names, the common
+    // header-name string constants, the NGHTTP2 error/session codes, and the
+    // HTTP_STATUS_* numbers. `@hono/node-server` reaches for these by name
+    // (#1651). Mixed string/number values, so this closure returns the f64
+    // directly rather than going through the `i64 as f64` shape used above.
+    let http2_const = |prop: &str| -> Option<f64> {
+        Some(match prop {
+            // Pseudo-headers (HTTP/2 request/response framing).
+            "HTTP2_HEADER_STATUS" => str_val(":status"),
+            "HTTP2_HEADER_METHOD" => str_val(":method"),
+            "HTTP2_HEADER_AUTHORITY" => str_val(":authority"),
+            "HTTP2_HEADER_SCHEME" => str_val(":scheme"),
+            "HTTP2_HEADER_PATH" => str_val(":path"),
+            "HTTP2_HEADER_PROTOCOL" => str_val(":protocol"),
+            // Common header-name constants.
+            "HTTP2_HEADER_ACCEPT" => str_val("accept"),
+            "HTTP2_HEADER_ACCEPT_ENCODING" => str_val("accept-encoding"),
+            "HTTP2_HEADER_AUTHORIZATION" => str_val("authorization"),
+            "HTTP2_HEADER_CACHE_CONTROL" => str_val("cache-control"),
+            "HTTP2_HEADER_CONNECTION" => str_val("connection"),
+            "HTTP2_HEADER_CONTENT_ENCODING" => str_val("content-encoding"),
+            "HTTP2_HEADER_CONTENT_LENGTH" => str_val("content-length"),
+            "HTTP2_HEADER_CONTENT_TYPE" => str_val("content-type"),
+            "HTTP2_HEADER_COOKIE" => str_val("cookie"),
+            "HTTP2_HEADER_DATE" => str_val("date"),
+            "HTTP2_HEADER_ETAG" => str_val("etag"),
+            "HTTP2_HEADER_HOST" => str_val("host"),
+            "HTTP2_HEADER_LOCATION" => str_val("location"),
+            "HTTP2_HEADER_SET_COOKIE" => str_val("set-cookie"),
+            "HTTP2_HEADER_USER_AGENT" => str_val("user-agent"),
+            // Default HPACK dynamic-table / frame sizes.
+            "DEFAULT_SETTINGS_HEADER_TABLE_SIZE" => 4096.0,
+            "DEFAULT_SETTINGS_ENABLE_PUSH" => 1.0,
+            "DEFAULT_SETTINGS_INITIAL_WINDOW_SIZE" => 65535.0,
+            "DEFAULT_SETTINGS_MAX_FRAME_SIZE" => 16384.0,
+            // NGHTTP2 error codes (RST_STREAM / GOAWAY).
+            "NGHTTP2_NO_ERROR" => 0.0,
+            "NGHTTP2_PROTOCOL_ERROR" => 1.0,
+            "NGHTTP2_INTERNAL_ERROR" => 2.0,
+            "NGHTTP2_FLOW_CONTROL_ERROR" => 3.0,
+            "NGHTTP2_SETTINGS_TIMEOUT" => 4.0,
+            "NGHTTP2_STREAM_CLOSED" => 5.0,
+            "NGHTTP2_FRAME_SIZE_ERROR" => 6.0,
+            "NGHTTP2_REFUSED_STREAM" => 7.0,
+            "NGHTTP2_CANCEL" => 8.0,
+            "NGHTTP2_COMPRESSION_ERROR" => 9.0,
+            "NGHTTP2_CONNECT_ERROR" => 10.0,
+            "NGHTTP2_ENHANCE_YOUR_CALM" => 11.0,
+            "NGHTTP2_INADEQUATE_SECURITY" => 12.0,
+            "NGHTTP2_HTTP_1_1_REQUIRED" => 13.0,
+            // Session/flag constants.
+            "NGHTTP2_SESSION_SERVER" => 0.0,
+            "NGHTTP2_SESSION_CLIENT" => 1.0,
+            "NGHTTP2_FLAG_NONE" => 0.0,
+            "NGHTTP2_FLAG_END_STREAM" => 1.0,
+            "NGHTTP2_FLAG_END_HEADERS" => 4.0,
+            "NGHTTP2_FLAG_ACK" => 1.0,
+            // The HTTP_STATUS_* numbers code commonly branches on.
+            "HTTP_STATUS_OK" => 200.0,
+            "HTTP_STATUS_CREATED" => 201.0,
+            "HTTP_STATUS_ACCEPTED" => 202.0,
+            "HTTP_STATUS_NO_CONTENT" => 204.0,
+            "HTTP_STATUS_NOT_MODIFIED" => 304.0,
+            "HTTP_STATUS_BAD_REQUEST" => 400.0,
+            "HTTP_STATUS_UNAUTHORIZED" => 401.0,
+            "HTTP_STATUS_FORBIDDEN" => 403.0,
+            "HTTP_STATUS_NOT_FOUND" => 404.0,
+            "HTTP_STATUS_METHOD_NOT_ALLOWED" => 405.0,
+            "HTTP_STATUS_INTERNAL_SERVER_ERROR" => 500.0,
+            "HTTP_STATUS_NOT_IMPLEMENTED" => 501.0,
+            "HTTP_STATUS_BAD_GATEWAY" => 502.0,
+            "HTTP_STATUS_SERVICE_UNAVAILABLE" => 503.0,
+            _ => return None,
+        })
+    };
+
     match module_name {
         // node:perf_hooks — `performance.timeOrigin` (ms since epoch at start)
         // and the `constants.NODE_PERFORMANCE_GC_*` numeric table. Both the
@@ -1518,6 +1595,17 @@ pub(crate) unsafe fn get_native_module_constant(
             "METHODS" => Some(unsafe { http_methods_array() }),
             _ => None,
         },
+        // node:http2 — `constants` is a sub-namespace object (the spec exposes
+        // it as a single frozen object, not loose top-level constants), so
+        // `import { constants } from 'node:http2'` binds to a real object and
+        // `constants.HTTP2_HEADER_PATH` resolves through `http2.constants`
+        // below. The `Http2ServerRequest` / `Http2ServerResponse` /
+        // `createSecureServer` exports are handled elsewhere (#1651).
+        "http2" => match property {
+            "constants" => Some(create_sub_namespace("http2.constants")),
+            _ => None,
+        },
+        "http2.constants" => http2_const(property),
         // node:cluster — all property reads are static constants on the
         // primary process. The test fixture only exercises shape, never
         // forks a worker; the `fork` / `disconnect` / `setupPrimary` /

--- a/crates/perry-stdlib/src/fetch.rs
+++ b/crates/perry-stdlib/src/fetch.rs
@@ -61,6 +61,12 @@ struct FetchResponse {
     /// the resulting registry id; subsequent reads of `.headers` return
     /// the same id (preserves `res.headers === res.headers`).
     cached_headers_id: Option<usize>,
+    /// Cached ReadableStream handle id for `response.body`, allocated on
+    /// first read so repeat `.body` reads return the same stream (the spec
+    /// requires a stable `ReadableStream`; getting a fresh unlocked stream
+    /// each time would silently un-lock a reader). None for an empty body —
+    /// `Response.body` is `ReadableStream | null` (#1650).
+    cached_body_stream_id: Option<usize>,
 }
 
 /// Extract the registry id from a Web Fetch handle f64 value.
@@ -186,6 +192,7 @@ pub unsafe extern "C" fn js_fetch_get(url_ptr: *const StringHeader) -> *mut perr
                         headers,
                         body,
                         cached_headers_id: None,
+                        cached_body_stream_id: None,
                     },
                 );
 
@@ -263,6 +270,7 @@ pub unsafe extern "C" fn js_fetch_get_with_auth(
                         headers,
                         body,
                         cached_headers_id: None,
+                        cached_body_stream_id: None,
                     },
                 );
 
@@ -342,6 +350,7 @@ pub unsafe extern "C" fn js_fetch_post_with_auth(
                         headers,
                         body,
                         cached_headers_id: None,
+                        cached_body_stream_id: None,
                     },
                 );
 
@@ -424,6 +433,7 @@ pub unsafe extern "C" fn js_fetch_post(
                         headers,
                         body,
                         cached_headers_id: None,
+                        cached_body_stream_id: None,
                     },
                 );
 
@@ -525,6 +535,7 @@ pub unsafe extern "C" fn js_fetch_with_options(
                         headers,
                         body,
                         cached_headers_id: None,
+                        cached_body_stream_id: None,
                     },
                 );
 
@@ -926,6 +937,21 @@ impl HeadersStore {
         }
         self.entries.push((lk, value.to_string()));
     }
+    /// Web Fetch `Headers.append` — adds a value without clobbering an existing
+    /// one. Per spec, repeated values for the same name are combined with
+    /// `", "` so `get` returns the joined string (e.g. multiple `Set-Cookie`-
+    /// style appends become `a, b`).
+    fn append(&mut self, key: &str, value: &str) {
+        let lk = key.to_ascii_lowercase();
+        for entry in self.entries.iter_mut() {
+            if entry.0 == lk {
+                entry.1.push_str(", ");
+                entry.1.push_str(value);
+                return;
+            }
+        }
+        self.entries.push((lk, value.to_string()));
+    }
     fn get(&self, key: &str) -> Option<&str> {
         let lk = key.to_ascii_lowercase();
         self.entries
@@ -955,8 +981,11 @@ struct RequestRecord {
     url: String,
     method: String,
     body: Option<String>,
-    #[allow(dead_code)]
     headers: HeadersStore,
+    /// Cached Headers handle id, allocated on first `request.headers` read so
+    /// repeat reads return the same handle (preserves `req.headers ===
+    /// req.headers`). Mirrors `FetchResponse::cached_headers_id` (#1649).
+    cached_headers_id: Option<usize>,
 }
 
 lazy_static::lazy_static! {
@@ -1021,6 +1050,7 @@ fn alloc_response(status: u16, status_text: String, headers: HeadersStore, body:
             headers: hdr_map,
             body,
             cached_headers_id: None,
+            cached_body_stream_id: None,
         },
     );
     id
@@ -1046,6 +1076,23 @@ pub unsafe extern "C" fn js_headers_set(
     let value = string_from_header(value_ptr).unwrap_or_default();
     if let Some(store) = HEADERS_REGISTRY.lock().unwrap().get_mut(&id) {
         store.set(&key, &value);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// `headers.append(name, value)` — adds a value, combining with `", "` when
+/// the name already exists (Web Fetch spec). Returns undefined. (#1649)
+#[no_mangle]
+pub unsafe extern "C" fn js_headers_append(
+    handle: f64,
+    key_ptr: *const StringHeader,
+    value_ptr: *const StringHeader,
+) -> f64 {
+    let id = handle_id(handle);
+    let key = string_from_header(key_ptr).unwrap_or_default();
+    let value = string_from_header(value_ptr).unwrap_or_default();
+    if let Some(store) = HEADERS_REGISTRY.lock().unwrap().get_mut(&id) {
+        store.append(&key, &value);
     }
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -1265,6 +1312,7 @@ pub extern "C" fn js_response_clone(handle: f64) -> f64 {
             headers: resp.headers.clone(),
             body: resp.body.clone(),
             cached_headers_id: None,
+            cached_body_stream_id: None,
         })
     };
     if let Some(new_resp) = cloned {
@@ -1532,6 +1580,17 @@ pub fn response_bytes_clone(resp_id: usize) -> Option<Vec<u8>> {
 /// property reads on a Response handle whose id collides with a Request id.
 #[doc(hidden)]
 pub fn dispatch_request_property(req_id: usize, prop: &str) -> Option<f64> {
+    // `request.headers` — lazily allocate a Headers registry entry backed by
+    // the request's stored header map and cache the id so repeat reads return
+    // the same handle (`req.headers === req.headers`). Mirrors the Response
+    // path. Without this arm `.headers` fell through to a numeric handle and
+    // `req.headers.get(...)` threw "(number).get is not a function" — the
+    // root cause of every Hono adapter crashing on the first request (#1649).
+    if prop == "headers" {
+        // Membership check first so a non-Request id falls through.
+        REQUEST_REGISTRY.lock().unwrap().get(&req_id)?;
+        return Some(request_headers_handle(req_id));
+    }
     let guard = REQUEST_REGISTRY.lock().unwrap();
     let req = guard.get(&req_id)?;
     let bits = match prop {
@@ -1592,6 +1651,19 @@ pub fn dispatch_response_property(resp_id: usize, prop: &str) -> Option<f64> {
             }
         };
         return Some(handle_to_f64(id));
+    }
+    // `response.body` — `ReadableStream | null` per the Web Fetch spec.
+    // Returns a NaN-boxed (POINTER_TAG) single-chunk ReadableStream handle
+    // over the buffered body so `typeof res.body === 'object'` and
+    // `res.body.getReader()` route through the untyped stream dispatch
+    // (see dispatch_readable_stream_method). `null` when the response was
+    // constructed with no body. Cached so `.body` is stable across reads
+    // (the spec mandates a single stream; a fresh stream each call would
+    // silently unlock a held reader) (#1650).
+    if prop == "body" {
+        // Membership check first so a non-Response id falls through.
+        FETCH_RESPONSES.lock().unwrap().get(&resp_id)?;
+        return Some(response_body_stream(resp_id));
     }
     let guard = FETCH_RESPONSES.lock().unwrap();
     let resp = guard.get(&resp_id)?;
@@ -1717,12 +1789,20 @@ pub fn dispatch_headers_method(headers_id: usize, method: &str, args: &[f64]) ->
                 JSValue::string_ptr(js_headers_get(h_f64, str_arg(0))).bits(),
             )),
             "set" => Some(js_headers_set(h_f64, str_arg(0), str_arg(1))),
+            "append" => Some(js_headers_append(h_f64, str_arg(0), str_arg(1))),
             "has" => Some(js_headers_has(h_f64, str_arg(0))),
             "delete" => Some(js_headers_delete(h_f64, str_arg(0))),
             "forEach" => {
                 let cb = args.first().copied().unwrap_or(f64::NAN);
                 Some(js_headers_for_each(h_f64, cb))
             }
+            // The iterator helpers each return a (sorted) JS array, which is
+            // itself iterable — `for (const [k,v] of req.headers.entries())`
+            // and `[...req.headers.keys()]` both work off the untyped path
+            // Hono's type-stripped JS takes (#1649).
+            "keys" => Some(js_headers_keys(h_f64)),
+            "values" => Some(js_headers_values(h_f64)),
+            "entries" => Some(js_headers_entries(h_f64)),
             _ => None,
         }
     }
@@ -1758,19 +1838,47 @@ pub unsafe extern "C" fn js_blob_stream(handle: f64) -> f64 {
     crate::streams::alloc_readable_from_bytes(bytes) as f64
 }
 
-/// `response.body` — returns a single-chunk ReadableStream handle over
-/// the buffered response body. Returns `null`-tagged f64 for an unknown
-/// response handle (matching the spec's `Response.body: ReadableStream
-/// | null`).
+/// Shared `response.body` resolver used by both the typed codegen path
+/// (`js_response_body`) and the untyped property dispatcher
+/// (`dispatch_response_property`). Returns a single-chunk ReadableStream
+/// handle over the buffered body, or `null` when the response carries no
+/// body (`Response.body: ReadableStream | null`). The handle is a raw
+/// `id as f64` in the shared Web Streams id range (#1545), so the runtime
+/// machinery answers `typeof` (`"object"`), `instanceof ReadableStream`,
+/// and `.getReader()` / `reader.read()`. The stream id is cached on the
+/// FetchResponse so `.body` is stable across reads — the spec mandates a
+/// single stream, and a fresh one each call would silently unlock a held
+/// reader (#1650).
+fn response_body_stream(resp_id: usize) -> f64 {
+    if let Some(id) = FETCH_RESPONSES
+        .lock()
+        .unwrap()
+        .get(&resp_id)
+        .and_then(|r| r.cached_body_stream_id)
+    {
+        return id as f64;
+    }
+    let bytes = match FETCH_RESPONSES.lock().unwrap().get(&resp_id) {
+        Some(r) => r.body.clone(),
+        None => return f64::from_bits(TAG_NULL),
+    };
+    if bytes.is_empty() {
+        return f64::from_bits(TAG_NULL);
+    }
+    let stream_id = crate::streams::alloc_readable_from_bytes(bytes);
+    if let Some(resp) = FETCH_RESPONSES.lock().unwrap().get_mut(&resp_id) {
+        resp.cached_body_stream_id = Some(stream_id);
+    }
+    stream_id as f64
+}
+
+/// `response.body` — `ReadableStream | null` per the Web Fetch spec. The
+/// returned handle is a raw `id as f64` in the shared Web Streams id range
+/// so the #1545 runtime machinery answers `typeof`/`instanceof`/method
+/// dispatch; `null` when the response has no body. (#1650)
 #[no_mangle]
 pub unsafe extern "C" fn js_response_body(handle: f64) -> f64 {
-    let id = handle_id(handle);
-    match response_bytes_clone(id) {
-        // Streams are still a Phase 2 subsystem — keep their handle in the
-        // legacy raw-float form so streams.rs's accessors round-trip.
-        Some(bytes) => crate::streams::alloc_readable_from_bytes(bytes) as f64,
-        None => f64::from_bits(TAG_NULL),
-    }
+    response_body_stream(handle_id(handle))
 }
 
 /// Response.json(value) — static method. Allocates a Response with JSON-stringified body
@@ -1854,9 +1962,48 @@ pub unsafe extern "C" fn js_request_new(
             method,
             body,
             headers,
+            cached_headers_id: None,
         },
     );
     handle_to_f64(id)
+}
+
+/// Shared `request.headers` resolver used by both the typed codegen path
+/// (`js_request_get_headers`) and the untyped property dispatcher. Lazily
+/// allocates a Headers registry entry from the request's stored header map
+/// and caches the id so `req.headers === req.headers`. Caller must have
+/// already verified `req_id` is a live Request. (#1649)
+fn request_headers_handle(req_id: usize) -> f64 {
+    if let Some(id) = REQUEST_REGISTRY
+        .lock()
+        .unwrap()
+        .get(&req_id)
+        .and_then(|r| r.cached_headers_id)
+    {
+        return handle_to_f64(id);
+    }
+    let store = match REQUEST_REGISTRY.lock().unwrap().get(&req_id) {
+        Some(r) => r.headers.clone(),
+        None => return f64::from_bits(TAG_UNDEFINED),
+    };
+    let new_id = alloc_headers(store);
+    if let Some(req) = REQUEST_REGISTRY.lock().unwrap().get_mut(&req_id) {
+        req.cached_headers_id = Some(new_id);
+    }
+    handle_to_f64(new_id)
+}
+
+/// `request.headers` — returns a NaN-boxed `Headers` handle (Web Fetch spec).
+/// Without this the typed codegen path fell through to a raw numeric handle
+/// and `req.headers.get(...)` threw "(number).get is not a function", which
+/// broke every Hono adapter on the first request (#1649).
+#[no_mangle]
+pub extern "C" fn js_request_get_headers(handle: f64) -> f64 {
+    let id = handle_id(handle);
+    if REQUEST_REGISTRY.lock().unwrap().get(&id).is_none() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    request_headers_handle(id)
 }
 
 #[no_mangle]

--- a/crates/perry-stdlib/src/fetch/headers.rs
+++ b/crates/perry-stdlib/src/fetch/headers.rs
@@ -1,0 +1,183 @@
+//! Web Fetch `Headers` FFI.
+//!
+//! Split out of `fetch/mod.rs` to keep that file under the 2,000-line lint
+//! gate (mirrors the earlier `fetch_blob.rs` extraction). As a child module
+//! of `fetch`, this sees `mod.rs`'s private items (`HeadersStore`,
+//! `HEADERS_REGISTRY`, `alloc_headers`, `handle_id`, `handle_to_f64`,
+//! `string_from_header`, the `TAG_*` consts, …) through the glob `use
+//! super::*` — no extra visibility changes required.
+
+use super::*;
+
+/// new Headers() — returns NaN-boxed POINTER_TAG handle as f64.
+/// See `handle_to_f64` / `handle_id` for the encoding contract.
+#[no_mangle]
+pub extern "C" fn js_headers_new() -> f64 {
+    handle_to_f64(alloc_headers(HeadersStore::default()))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_headers_set(
+    handle: f64,
+    key_ptr: *const StringHeader,
+    value_ptr: *const StringHeader,
+) -> f64 {
+    let id = handle_id(handle);
+    let key = string_from_header(key_ptr).unwrap_or_default();
+    let value = string_from_header(value_ptr).unwrap_or_default();
+    if let Some(store) = HEADERS_REGISTRY.lock().unwrap().get_mut(&id) {
+        store.set(&key, &value);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// `headers.append(name, value)` — adds a value, combining with `", "` when
+/// the name already exists (Web Fetch spec). Returns undefined. (#1649)
+#[no_mangle]
+pub unsafe extern "C" fn js_headers_append(
+    handle: f64,
+    key_ptr: *const StringHeader,
+    value_ptr: *const StringHeader,
+) -> f64 {
+    let id = handle_id(handle);
+    let key = string_from_header(key_ptr).unwrap_or_default();
+    let value = string_from_header(value_ptr).unwrap_or_default();
+    if let Some(store) = HEADERS_REGISTRY.lock().unwrap().get_mut(&id) {
+        store.append(&key, &value);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_headers_get(
+    handle: f64,
+    key_ptr: *const StringHeader,
+) -> *mut StringHeader {
+    let id = handle_id(handle);
+    let key = match string_from_header(key_ptr) {
+        Some(k) => k,
+        None => return std::ptr::null_mut(),
+    };
+    if let Some(store) = HEADERS_REGISTRY.lock().unwrap().get(&id) {
+        if let Some(v) = store.get(&key) {
+            return js_string_from_bytes(v.as_ptr(), v.len() as u32);
+        }
+    }
+    std::ptr::null_mut()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_headers_has(handle: f64, key_ptr: *const StringHeader) -> f64 {
+    let id = handle_id(handle);
+    let key = match string_from_header(key_ptr) {
+        Some(k) => k,
+        None => return f64::from_bits(TAG_FALSE),
+    };
+    if let Some(store) = HEADERS_REGISTRY.lock().unwrap().get(&id) {
+        if store.has(&key) {
+            return f64::from_bits(TAG_TRUE);
+        }
+    }
+    f64::from_bits(TAG_FALSE)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_headers_delete(handle: f64, key_ptr: *const StringHeader) -> f64 {
+    let id = handle_id(handle);
+    let key = string_from_header(key_ptr).unwrap_or_default();
+    if let Some(store) = HEADERS_REGISTRY.lock().unwrap().get_mut(&id) {
+        store.delete(&key);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// Snapshot the headers store sorted by key (WHATWG spec: iteration order is
+/// sorted lexicographically by name, regardless of insertion order). Used by
+/// `forEach`, `keys`, `values`, `entries`, and `Symbol.iterator` so all five
+/// surfaces agree byte-for-byte (refs #576).
+fn snapshot_sorted(handle: f64) -> Vec<(String, String)> {
+    let id = handle_id(handle);
+    let mut entries: Vec<(String, String)> = match HEADERS_REGISTRY.lock().unwrap().get(&id) {
+        Some(s) => s.entries.clone(),
+        None => return Vec::new(),
+    };
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries
+}
+
+#[no_mangle]
+pub extern "C" fn js_headers_for_each(handle: f64, callback: f64) -> f64 {
+    let entries = snapshot_sorted(handle);
+    // Extract closure pointer from NaN-boxed callback
+    let cb_bits = callback.to_bits();
+    let cb_ptr = (cb_bits & 0x0000_FFFF_FFFF_FFFF) as i64;
+    if cb_ptr == 0 {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let closure = cb_ptr as *const perry_runtime::ClosureHeader;
+    for (k, v) in entries {
+        let v_ptr = js_string_from_bytes(v.as_ptr(), v.len() as u32);
+        let k_ptr = js_string_from_bytes(k.as_ptr(), k.len() as u32);
+        let v_nan = JSValue::string_ptr(v_ptr).bits();
+        let k_nan = JSValue::string_ptr(k_ptr).bits();
+        perry_runtime::js_closure_call2(closure, f64::from_bits(v_nan), f64::from_bits(k_nan));
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+
+#[inline]
+fn nanbox_array_pointer(arr: *mut perry_runtime::ArrayHeader) -> f64 {
+    let bits = POINTER_TAG | ((arr as u64) & 0x0000_FFFF_FFFF_FFFF);
+    f64::from_bits(bits)
+}
+
+/// `headers.keys()` — returns a sorted-by-key array of header names. The
+/// returned array is itself iterable, so `for (const k of headers.keys())`,
+/// spread, and `Array.from` all work via the array's existing `Symbol.iterator`
+/// (refs #576).
+#[no_mangle]
+pub extern "C" fn js_headers_keys(handle: f64) -> f64 {
+    let entries = snapshot_sorted(handle);
+    let mut arr = perry_runtime::js_array_alloc(entries.len() as u32);
+    for (k, _) in entries {
+        let k_ptr = js_string_from_bytes(k.as_ptr(), k.len() as u32);
+        let k_nan = JSValue::string_ptr(k_ptr).bits();
+        arr = perry_runtime::js_array_push_f64(arr, f64::from_bits(k_nan));
+    }
+    nanbox_array_pointer(arr)
+}
+
+/// `headers.values()` — sorted-by-key array of header values. See `js_headers_keys`.
+#[no_mangle]
+pub extern "C" fn js_headers_values(handle: f64) -> f64 {
+    let entries = snapshot_sorted(handle);
+    let mut arr = perry_runtime::js_array_alloc(entries.len() as u32);
+    for (_, v) in entries {
+        let v_ptr = js_string_from_bytes(v.as_ptr(), v.len() as u32);
+        let v_nan = JSValue::string_ptr(v_ptr).bits();
+        arr = perry_runtime::js_array_push_f64(arr, f64::from_bits(v_nan));
+    }
+    nanbox_array_pointer(arr)
+}
+
+/// `headers.entries()` — sorted-by-key array of `[key, value]` pair arrays.
+/// `for (const [k, v] of headers.entries())` and `for (const [k, v] of h)` both
+/// route here (the latter via the `Symbol.iterator` alias, see #576).
+#[no_mangle]
+pub extern "C" fn js_headers_entries(handle: f64) -> f64 {
+    let entries = snapshot_sorted(handle);
+    let mut arr = perry_runtime::js_array_alloc(entries.len() as u32);
+    for (k, v) in entries {
+        let k_ptr = js_string_from_bytes(k.as_ptr(), k.len() as u32);
+        let v_ptr = js_string_from_bytes(v.as_ptr(), v.len() as u32);
+        let k_nan = JSValue::string_ptr(k_ptr).bits();
+        let v_nan = JSValue::string_ptr(v_ptr).bits();
+        let mut pair = perry_runtime::js_array_alloc(2);
+        pair = perry_runtime::js_array_push_f64(pair, f64::from_bits(k_nan));
+        pair = perry_runtime::js_array_push_f64(pair, f64::from_bits(v_nan));
+        arr = perry_runtime::js_array_push_f64(arr, nanbox_array_pointer(pair));
+    }
+    nanbox_array_pointer(arr)
+}

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -12,6 +12,12 @@ use std::sync::Mutex;
 
 use crate::common::async_bridge::{queue_promise_resolution, spawn};
 
+// Web Fetch `Headers` FFI — split out to keep this file under the 2,000-line
+// lint gate (#1649). The child module sees mod.rs's private items via its
+// `use super::*`.
+mod headers;
+pub use headers::*;
+
 // Response handle storage
 lazy_static::lazy_static! {
     static ref FETCH_RESPONSES: Mutex<HashMap<usize, FetchResponse>> = Mutex::new(HashMap::new());
@@ -1057,179 +1063,8 @@ fn alloc_response(status: u16, status_text: String, headers: HeadersStore, body:
 }
 
 // ----------------- Headers FFI -----------------
-
-/// new Headers() — returns NaN-boxed POINTER_TAG handle as f64.
-/// See `handle_to_f64` / `handle_id` for the encoding contract.
-#[no_mangle]
-pub extern "C" fn js_headers_new() -> f64 {
-    handle_to_f64(alloc_headers(HeadersStore::default()))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn js_headers_set(
-    handle: f64,
-    key_ptr: *const StringHeader,
-    value_ptr: *const StringHeader,
-) -> f64 {
-    let id = handle_id(handle);
-    let key = string_from_header(key_ptr).unwrap_or_default();
-    let value = string_from_header(value_ptr).unwrap_or_default();
-    if let Some(store) = HEADERS_REGISTRY.lock().unwrap().get_mut(&id) {
-        store.set(&key, &value);
-    }
-    f64::from_bits(TAG_UNDEFINED)
-}
-
-/// `headers.append(name, value)` — adds a value, combining with `", "` when
-/// the name already exists (Web Fetch spec). Returns undefined. (#1649)
-#[no_mangle]
-pub unsafe extern "C" fn js_headers_append(
-    handle: f64,
-    key_ptr: *const StringHeader,
-    value_ptr: *const StringHeader,
-) -> f64 {
-    let id = handle_id(handle);
-    let key = string_from_header(key_ptr).unwrap_or_default();
-    let value = string_from_header(value_ptr).unwrap_or_default();
-    if let Some(store) = HEADERS_REGISTRY.lock().unwrap().get_mut(&id) {
-        store.append(&key, &value);
-    }
-    f64::from_bits(TAG_UNDEFINED)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn js_headers_get(
-    handle: f64,
-    key_ptr: *const StringHeader,
-) -> *mut StringHeader {
-    let id = handle_id(handle);
-    let key = match string_from_header(key_ptr) {
-        Some(k) => k,
-        None => return std::ptr::null_mut(),
-    };
-    if let Some(store) = HEADERS_REGISTRY.lock().unwrap().get(&id) {
-        if let Some(v) = store.get(&key) {
-            return js_string_from_bytes(v.as_ptr(), v.len() as u32);
-        }
-    }
-    std::ptr::null_mut()
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn js_headers_has(handle: f64, key_ptr: *const StringHeader) -> f64 {
-    let id = handle_id(handle);
-    let key = match string_from_header(key_ptr) {
-        Some(k) => k,
-        None => return f64::from_bits(TAG_FALSE),
-    };
-    if let Some(store) = HEADERS_REGISTRY.lock().unwrap().get(&id) {
-        if store.has(&key) {
-            return f64::from_bits(TAG_TRUE);
-        }
-    }
-    f64::from_bits(TAG_FALSE)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn js_headers_delete(handle: f64, key_ptr: *const StringHeader) -> f64 {
-    let id = handle_id(handle);
-    let key = string_from_header(key_ptr).unwrap_or_default();
-    if let Some(store) = HEADERS_REGISTRY.lock().unwrap().get_mut(&id) {
-        store.delete(&key);
-    }
-    f64::from_bits(TAG_UNDEFINED)
-}
-
-/// Snapshot the headers store sorted by key (WHATWG spec: iteration order is
-/// sorted lexicographically by name, regardless of insertion order). Used by
-/// `forEach`, `keys`, `values`, `entries`, and `Symbol.iterator` so all five
-/// surfaces agree byte-for-byte (refs #576).
-fn snapshot_sorted(handle: f64) -> Vec<(String, String)> {
-    let id = handle_id(handle);
-    let mut entries: Vec<(String, String)> = match HEADERS_REGISTRY.lock().unwrap().get(&id) {
-        Some(s) => s.entries.clone(),
-        None => return Vec::new(),
-    };
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
-    entries
-}
-
-#[no_mangle]
-pub extern "C" fn js_headers_for_each(handle: f64, callback: f64) -> f64 {
-    let entries = snapshot_sorted(handle);
-    // Extract closure pointer from NaN-boxed callback
-    let cb_bits = callback.to_bits();
-    let cb_ptr = (cb_bits & 0x0000_FFFF_FFFF_FFFF) as i64;
-    if cb_ptr == 0 {
-        return f64::from_bits(TAG_UNDEFINED);
-    }
-    let closure = cb_ptr as *const perry_runtime::ClosureHeader;
-    for (k, v) in entries {
-        let v_ptr = js_string_from_bytes(v.as_ptr(), v.len() as u32);
-        let k_ptr = js_string_from_bytes(k.as_ptr(), k.len() as u32);
-        let v_nan = JSValue::string_ptr(v_ptr).bits();
-        let k_nan = JSValue::string_ptr(k_ptr).bits();
-        perry_runtime::js_closure_call2(closure, f64::from_bits(v_nan), f64::from_bits(k_nan));
-    }
-    f64::from_bits(TAG_UNDEFINED)
-}
-
-const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
-
-#[inline]
-fn nanbox_array_pointer(arr: *mut perry_runtime::ArrayHeader) -> f64 {
-    let bits = POINTER_TAG | ((arr as u64) & 0x0000_FFFF_FFFF_FFFF);
-    f64::from_bits(bits)
-}
-
-/// `headers.keys()` — returns a sorted-by-key array of header names. The
-/// returned array is itself iterable, so `for (const k of headers.keys())`,
-/// spread, and `Array.from` all work via the array's existing `Symbol.iterator`
-/// (refs #576).
-#[no_mangle]
-pub extern "C" fn js_headers_keys(handle: f64) -> f64 {
-    let entries = snapshot_sorted(handle);
-    let mut arr = perry_runtime::js_array_alloc(entries.len() as u32);
-    for (k, _) in entries {
-        let k_ptr = js_string_from_bytes(k.as_ptr(), k.len() as u32);
-        let k_nan = JSValue::string_ptr(k_ptr).bits();
-        arr = perry_runtime::js_array_push_f64(arr, f64::from_bits(k_nan));
-    }
-    nanbox_array_pointer(arr)
-}
-
-/// `headers.values()` — sorted-by-key array of header values. See `js_headers_keys`.
-#[no_mangle]
-pub extern "C" fn js_headers_values(handle: f64) -> f64 {
-    let entries = snapshot_sorted(handle);
-    let mut arr = perry_runtime::js_array_alloc(entries.len() as u32);
-    for (_, v) in entries {
-        let v_ptr = js_string_from_bytes(v.as_ptr(), v.len() as u32);
-        let v_nan = JSValue::string_ptr(v_ptr).bits();
-        arr = perry_runtime::js_array_push_f64(arr, f64::from_bits(v_nan));
-    }
-    nanbox_array_pointer(arr)
-}
-
-/// `headers.entries()` — sorted-by-key array of `[key, value]` pair arrays.
-/// `for (const [k, v] of headers.entries())` and `for (const [k, v] of h)` both
-/// route here (the latter via the `Symbol.iterator` alias, see #576).
-#[no_mangle]
-pub extern "C" fn js_headers_entries(handle: f64) -> f64 {
-    let entries = snapshot_sorted(handle);
-    let mut arr = perry_runtime::js_array_alloc(entries.len() as u32);
-    for (k, v) in entries {
-        let k_ptr = js_string_from_bytes(k.as_ptr(), k.len() as u32);
-        let v_ptr = js_string_from_bytes(v.as_ptr(), v.len() as u32);
-        let k_nan = JSValue::string_ptr(k_ptr).bits();
-        let v_nan = JSValue::string_ptr(v_ptr).bits();
-        let mut pair = perry_runtime::js_array_alloc(2);
-        pair = perry_runtime::js_array_push_f64(pair, f64::from_bits(k_nan));
-        pair = perry_runtime::js_array_push_f64(pair, f64::from_bits(v_nan));
-        arr = perry_runtime::js_array_push_f64(arr, nanbox_array_pointer(pair));
-    }
-    nanbox_array_pointer(arr)
-}
+// Moved to the `headers` sub-module (#1649 pushed fetch.rs past the 2,000-line
+// lint gate; mirrors the earlier fetch_blob.rs extraction). Re-exported below.
 
 // ----------------- Response FFI (constructor + extra methods) -----------------
 

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1244 entries across 81 modules
+// Coverage: 1245 entries across 81 modules
 
 declare module "@perryts/pdf" {
   /** stdlib */
@@ -720,6 +720,8 @@ declare module "http2" {
   export class Http2ServerRequest { [key: string]: any; }
   /** stdlib */
   export class Http2ServerResponse { [key: string]: any; }
+  /** stdlib */
+  export const constants: any;
   /** stdlib */
   export function createSecureServer(...args: any[]): any;
 }

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 1244 entries across 81 modules.
+Total: 1245 entries across 81 modules.
 
 ## Modules
 
@@ -806,6 +806,10 @@ Total: 1244 entries across 81 modules.
 - `createSecureServer` — module
 - `listen` — instance *(class: `Http2SecureServer`)*
 - `on` — instance *(class: `Http2SecureServer`)*
+
+### Properties
+
+- `constants`
 
 ## `https`
 

--- a/docs/src/stdlib/http.md
+++ b/docs/src/stdlib/http.md
@@ -102,18 +102,29 @@ export default app  // for CF Workers / similar runtimes
 }
 ```
 
-### Long-lived HTTP server (port-listening) — currently blocked
+### Long-lived HTTP server (port-listening)
 
 The canonical "deploy a hono app as a native binary on a Linux VM"
-pattern — `serve({ fetch: app.fetch, port: 3000 })` via
-`@hono/node-server`, or a hand-rolled `node:http` adapter that drives
-`app.fetch` — currently fails to link because the Web Fetch FFIs
-(`Headers` / `Response` constructors) aren't pulled in alongside
-perry-ext-http-server. Tracked at [issue #589](https://github.com/PerryTS/perry/issues/589).
+pattern compiles and links on a stock Perry binary. A hand-rolled
+`node:http` adapter that drives `app.fetch` works directly:
 
-Workaround until #589 lands: deploy as an edge-runtime worker (CF
-Workers / Vercel Edge), or use [perry's Fastify binding](#fastify-server)
-with a single catch-all route delegating to `app.fetch`.
+```typescript,no-test
+import { createServer } from "node:http";
+
+const server = createServer((req, res) => {
+  const headers = new Headers();
+  headers.set("content-type", "text/plain");
+  const fetchReq = new Request(`http://localhost${req.url}`, { method: req.method });
+  // ... await app.fetch(fetchReq), then copy status/headers/body onto `res`.
+  res.end("ok");
+});
+server.listen(3000);
+```
+
+The `node:http` server FFIs and the Web Fetch `Headers` / `Request` /
+`Response` constructors now link together (issues #589, #1652). For a
+turnkey adapter, prefer [perry's Fastify binding](#fastify-server) with a
+single catch-all route delegating to `app.fetch`.
 
 ## Fastify Server
 

--- a/scripts/release_sweep_tiers/tier12_link_smoke.sh
+++ b/scripts/release_sweep_tiers/tier12_link_smoke.sh
@@ -173,6 +173,47 @@ for entry in "${TARGETS[@]}"; do
     fi
 done
 
+# --- #1652 / #589: node:http + Web Fetch link+run smoke (host only) ---
+# Guards against perry-ext-http-server's `js_node_http_*` FFI symbols, or the
+# Web Fetch Headers/Request/Response constructors, silently dropping out of
+# the default link. node:http server only links on the host (perry-ext-http
+# isn't cross-compiled to the mobile targets), so this is host-only. The
+# fixture exits immediately (never `.listen()`s), so we compile AND run it.
+NH_FIXTURE="$REPO_ROOT/tests/release/link_smoke/node_http_webfetch.ts"
+if [[ -f "$NH_FIXTURE" ]]; then
+    nh_artifact="$TIER_DIR/node_http_webfetch"
+    rm -f "$nh_artifact"
+    set +e
+    nh_log="$("$PERRY_BIN" "$NH_FIXTURE" -o "$nh_artifact" 2>&1)"
+    nh_rc=$?
+    nh_run=""
+    if [[ "$nh_rc" -eq 0 && -x "$nh_artifact" ]]; then
+        nh_run="$("$nh_artifact" 2>&1)"
+        nh_run_rc=$?
+    else
+        nh_run_rc=1
+    fi
+    set -e
+    {
+        echo
+        echo "=== node:http + Web Fetch smoke (host, #1652) ==="
+        echo "  fixture: $NH_FIXTURE"
+        echo "  compile exit=$nh_rc  run exit=$nh_run_rc"
+        echo "$nh_log" | tail -8 | sed 's/^/    compile: /'
+        echo "    run: $nh_run"
+    } >> "$LOG"
+    if [[ "$nh_rc" -eq 0 && "$nh_run_rc" -eq 0 ]] && echo "$nh_run" | grep -q "node-http-webfetch ok"; then
+        echo "  PASS (node:http + Web Fetch linked and ran)" >> "$LOG"
+        passed+=1
+        passed_targets+=("host-node-http-webfetch")
+    else
+        echo "  FAIL (node:http / Web Fetch link regression — #1652)" >> "$LOG"
+        failed+=1
+        failed_targets+=("host-node-http-webfetch")
+    fi
+    rm -f "$nh_artifact"
+fi
+
 end="$(date +%s)"
 dur="$((end - start))"
 

--- a/tests/release/link_smoke/node_http_webfetch.ts
+++ b/tests/release/link_smoke/node_http_webfetch.ts
@@ -1,0 +1,26 @@
+// Link smoke (#1652 / #589): a stock `perry compile` must link node:http's
+// server FFIs (`js_node_http_create_server` / `js_node_http_res_end` / …)
+// together with the Web Fetch `Headers` / `Request` / `Response`
+// constructors. Pre-fix this failed at link with
+// `Undefined symbols: _js_node_http_create_server` for any program that did
+// `import { createServer } from "node:http"`.
+//
+// Host-only: perry-ext-http (the node:http server staticlib) isn't
+// cross-compiled to the mobile targets, so the release sweep runs this on
+// the host. Compile + run, but never `.listen()` — the regression this
+// guards is in LINKING, and skipping the bind keeps the smoke fast and
+// non-flaky.
+import { createServer } from "node:http";
+
+const headers = new Headers();
+headers.set("content-type", "application/json");
+
+const req = new Request("http://localhost/healthz", { method: "GET", headers });
+const res = new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+
+// Constructing the server forces the createServer FFI into the link; the
+// dead branch keeps `listen` referenced without actually binding a port.
+const server = createServer((_req, _res) => {});
+if (req.method === "NEVER") server.listen(0);
+
+console.log("node-http-webfetch ok", res.status, headers.get("content-type"));


### PR DESCRIPTION
## Summary

Four Web-Fetch / Node-compat fixes from the Hono-on-Perry umbrella. Each is verified against the issue's own repro.

### #1649 — `Request.headers` is a numeric handle, not a `Headers`
`new Request(url, { headers }).headers` returned the raw FFI handle (a number), so `req.headers.get(...)` threw `(number).get is not a function` — the first thing every Hono adapter hits.

- New `js_request_get_headers` FFI returns a NaN-boxed `Headers` handle (cached so `req.headers === req.headers`), wired into the typed codegen `Request` property arm.
- Added a real `append()` to the header store and the missing `append` / `keys` / `values` / `entries` arms to the untyped header method-dispatch (the path Hono's type-stripped JS takes).

```
typeof headers: object
content-type: application/json
append: 1, 2
keys: content-type,x-a
```

### #1650 — `Response.body` is a numeric handle, not `ReadableStream | null`
`new Response('hello').body` now returns a real `ReadableStream` (or `null` for an empty body), aligned with the #1545 shared Web-Streams id space, so `instanceof` / `getReader()` / `reader.read()` all work via the existing stream machinery. Added a `typeof` probe so a stream handle reports `"object"`, and a cached, stable `response.body` stream id.

```
typeof body: object        empty body null?: true
first read done?: false len: 5   second read done?: true
instanceof ReadableStream: true
```

Remaining (out of scope, tracked as follow-ups): `for await (const x of res.body)` (use the explicit `getReader()` read-loop, which works), and inline `res.body.locked` property reads (a pre-existing #1545 field-get gap on raw-float stream handles — typed-local access works).

### #1651 — `node:http2` missing the `constants` export
`Http2ServerRequest` / `Http2ServerResponse` / `createSecureServer` already imported as functions; `constants` resolved to `undefined`. Adds `http2.constants` as a sub-namespace object populated with the `HTTP2_HEADER_*` pseudo-header/header-name strings, `NGHTTP2_*` codes, and `HTTP_STATUS_*` numbers that `@hono/node-server` reads, plus the manifest `property` entry.

### #1652 — `node:http.createServer` FFI symbols undefined (follow-up to #589)
`import { createServer } from 'node:http'` links and runs on a stock `perry compile`, including combined with the Web-Fetch `Headers`/`Request`/`Response` constructors (the hono-adapter pattern). The perry-ext-http-server symbols were retained only implicitly; this adds an explicit `#[used]` force-link anchor in perry-ext-http for every `js_node_http*`/`https`/`http2` entry point so they can't silently dead-strip, removes the stale "currently fails to link" paragraph from `docs/src/stdlib/http.md`, and adds a host-only node:http + Web-Fetch link+run smoke to the tier-12 release sweep.

## Testing
- Each issue's repro verified by hand (outputs above).
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib -p perry-ext-http` green; `cargo fmt --all -- --check` clean.
- New `tests/release/link_smoke/node_http_webfetch.ts` fixture compiles, runs, and prints `node-http-webfetch ok 200 application/json`.

## Follow-ups (separate PRs, in progress)
- **#1653** — `hono/jsx` `<Component/>` renders to HTML. Root cause: Perry's built-in `js_jsx` returns `undefined` for *any* intrinsic element (`<div>`), independent of `jsxImportSource` — needs server-side JSX→HTML rendering in the runtime.
- **#1654** — `@hono/perry-server` adapter package (now unblocked by #1649).
