### PR TITLE
test(parity): stream — batch of 12 tier-7/8 tests (iter-91..93) (2 free pass, 10 #1532/#1539/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2587,5 +2587,65 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: unshift() during flowing mode — chunk not re-emitted in order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/writable-stream-bytes-type": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: WritableStream({type:'bytes'}) — handling differs from Node (accept-and-ignore or throw). Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/emit-after-destroy-still-works": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: custom emit() on destroyed stream — listener does not fire or fires multiple times. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/pause-sets-flowing-false": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pause() doesn't flip readableFlowing to false synchronously. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/destroy/destroy-during-flow": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy() during flowing — extra 'data' emitted or 'close' wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/flow/data-after-end-not-fired": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: push() after end-emit — extra 'data' event fired. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-array-with-undefined": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from([1,undefined,3]) — undefined value handling differs. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/cleanup-state-after-end": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: post-pipe-end destroyed flags wrong on source or destination. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/cork-empty": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: cork()+uncork() with no writes — 'finish' doesn't fire. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/readable/destroyed-after-error": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroyed flag false after 'error' event handler fires. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/pipe-after-pause": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe() doesn't resume a paused source stream. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/destroy/destroy-during-flow.ts
+++ b/test-parity/node-suite/stream/destroy/destroy-during-flow.ts
@@ -1,0 +1,18 @@
+import { Readable } from "node:stream";
+// destroy() in the middle of flowing — outstanding data is dropped,
+// 'data' stops, 'close' fires.
+const r = new Readable({ read() {} });
+let dataCount = 0;
+let closed = false;
+r.on("data", () => {
+  dataCount++;
+  if (dataCount === 1) r.destroy(); // destroy after first chunk
+});
+r.on("close", () => {
+  closed = true;
+  console.log("got chunks:", dataCount);
+  console.log("closed:", closed);
+});
+r.push("a");
+r.push("b"); // shouldn't be emitted as data
+r.push(null);

--- a/test-parity/node-suite/stream/events/emit-after-destroy-still-works.ts
+++ b/test-parity/node-suite/stream/events/emit-after-destroy-still-works.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// emit() on a destroyed stream — listeners still fire (emit is just EE.emit).
+const r = new Readable({ read() {} });
+let count = 0;
+r.on("error", () => {});
+r.on("custom", () => count++);
+r.destroy();
+r.emit("custom");
+setImmediate(() => {
+  console.log("destroyed:", r.destroyed);
+  console.log("custom listener fired:", count);
+});

--- a/test-parity/node-suite/stream/flow/data-after-end-not-fired.ts
+++ b/test-parity/node-suite/stream/flow/data-after-end-not-fired.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// After 'end', further push() do nothing (no more data events).
+let dataCount = 0;
+const r = new Readable({ read() {} });
+r.on("data", () => dataCount++);
+r.push("a");
+r.push(null);
+r.on("end", () => {
+  setImmediate(() => {
+    r.push("late"); // should be ignored
+    setImmediate(() => {
+      console.log("data count:", dataCount);
+    });
+  });
+});

--- a/test-parity/node-suite/stream/pipe/cleanup-state-after-end.ts
+++ b/test-parity/node-suite/stream/pipe/cleanup-state-after-end.ts
@@ -1,0 +1,12 @@
+import { Readable, PassThrough } from "node:stream";
+// After source.pipe(dst) completes, source no longer listed in dst._writableState pipe.
+const r = Readable.from(["x"]);
+const dst = new PassThrough();
+dst.on("data", () => {});
+r.pipe(dst);
+dst.on("end", () => {
+  setImmediate(() => {
+    console.log("source destroyed:", r.destroyed);
+    console.log("dst destroyed:", dst.destroyed);
+  });
+});

--- a/test-parity/node-suite/stream/pipe/pipe-after-pause.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-after-pause.ts
@@ -1,0 +1,10 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe() to a destination resumes flow on a paused source.
+const r = Readable.from(["a", "b"]);
+r.pause();
+console.log("paused before pipe:", r.readableFlowing);
+const dst = new PassThrough();
+dst.on("data", () => {});
+r.pipe(dst);
+console.log("flowing after pipe:", r.readableFlowing);
+dst.on("end", () => console.log("done"));

--- a/test-parity/node-suite/stream/readable/destroyed-after-error.ts
+++ b/test-parity/node-suite/stream/readable/destroyed-after-error.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// After 'error' event, destroyed flag is true.
+const r = new Readable({ read() {} });
+r.on("error", () => {
+  setImmediate(() => {
+    console.log("destroyed after error:", r.destroyed);
+  });
+});
+r.destroy(new Error("err-then-destroyed"));

--- a/test-parity/node-suite/stream/readable/from-array-with-undefined.ts
+++ b/test-parity/node-suite/stream/readable/from-array-with-undefined.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Readable.from([1, undefined, 3]) — undefined as a value in objectMode
+// has special meaning (it signals end). In non-objectMode...?
+// In Node, the iterator pushes each yielded value; undefined push terminates the stream.
+const r = Readable.from([1, undefined, 3]);
+const out: any[] = [];
+r.on("data", (c) => out.push(c));
+r.on("end", () => {
+  console.log("collected:", out.length);
+  console.log("values:", out.join(","));
+});

--- a/test-parity/node-suite/stream/readable/pause-sets-flowing-false.ts
+++ b/test-parity/node-suite/stream/readable/pause-sets-flowing-false.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// pause() immediately flips readableFlowing to false (after the stream
+// was flowing).
+const r = Readable.from(["x"]);
+r.on("data", () => {});
+console.log("flowing after data listener:", r.readableFlowing);
+r.pause();
+console.log("flowing after pause:", r.readableFlowing);
+console.log("is false:", r.readableFlowing === false);

--- a/test-parity/node-suite/stream/web/cancel-source-throws.ts
+++ b/test-parity/node-suite/stream/web/cancel-source-throws.ts
@@ -1,0 +1,13 @@
+import { ReadableStream } from "node:stream/web";
+// If source.cancel() throws, the cancel() Promise rejects.
+const rs = new ReadableStream({
+  start(c) { c.enqueue("x"); },
+  cancel() { throw new Error("cancel-fail"); },
+});
+let errMsg: string | null = null;
+try {
+  await rs.cancel();
+} catch (e: any) {
+  errMsg = e && e.message;
+}
+console.log("rejected with:", errMsg);

--- a/test-parity/node-suite/stream/web/transform-flush-throws.ts
+++ b/test-parity/node-suite/stream/web/transform-flush-throws.ts
@@ -1,0 +1,21 @@
+import { TransformStream } from "node:stream/web";
+// If flush() throws, the readable side errors.
+const ts = new TransformStream({
+  transform(c, ctrl) { ctrl.enqueue(c); },
+  flush() { throw new Error("flush-fail"); },
+});
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("a");
+await writer.close();
+let errMsg: string | null = null;
+try {
+  // consume to trigger flush
+  while (true) {
+    const { done } = await reader.read();
+    if (done) break;
+  }
+} catch (e: any) {
+  errMsg = e && e.message;
+}
+console.log("rejected with:", errMsg);

--- a/test-parity/node-suite/stream/web/writable-stream-bytes-type.ts
+++ b/test-parity/node-suite/stream/web/writable-stream-bytes-type.ts
@@ -1,0 +1,11 @@
+import { WritableStream } from "node:stream/web";
+// type:"bytes" is not a documented WritableStream sink option (only on
+// ReadableStream). Confirm Node either ignores it or constructs anyway.
+let constructed = false;
+try {
+  const ws = new WritableStream({ type: "bytes", write() {} } as any);
+  constructed = ws instanceof WritableStream;
+} catch (e: any) {
+  console.log("threw:", e && e.name);
+}
+console.log("constructed (or threw above):", constructed);

--- a/test-parity/node-suite/stream/writable/cork-empty.ts
+++ b/test-parity/node-suite/stream/writable/cork-empty.ts
@@ -1,0 +1,7 @@
+import { Writable } from "node:stream";
+// cork() then immediately uncork() with no writes — finish fires normally.
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+w.cork();
+w.uncork();
+w.end();
+w.on("finish", () => console.log("finished normally:", true));


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-91..93)

**2 free passes + 10 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | writable-stream-bytes-type, cancel-source-throws ✅, transform-flush-throws ✅ | #1545 |
| Readable shape / flow | pause-sets-flowing-false, destroy-during-flow, data-after-end-not-fired, from-array-with-undefined, destroyed-after-error, pipe-after-pause | #1532 |
| Pipe semantics | cleanup-state-after-end | #1532 |
| Writable buffering | cork-empty | #1539 |
| EE / stream events | emit-after-destroy-still-works | #1532 |

Free passes:
- `web/cancel-source-throws` (source.cancel throw → cancel() rejects correctly)
- `web/transform-flush-throws` (flush() throw → reader rejects correctly)

All 10 failures tracked in `known_failures.json`.
