### PR TITLE
fix(node:stream/web): implement ReadableStream.from(iterable) (#1645)

### DIFF
--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -111,6 +111,35 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             args,
         ),
 
+        // #1645: `ReadableStream.from(iterable)` (Node 20+). The HIR lowers
+        // `(ReadableStream as any).from(x)` to a Call whose callee is
+        // `PropertyGet { ExternFuncRef("ReadableStream"), "from" }`; route it to
+        // the runtime factory. The result is a numeric stream handle, so
+        // downstream `rs.getReader()` dispatches through the #1545 runtime
+        // stream-handle probe.
+        Expr::Call { callee, args, .. }
+            if matches!(
+                callee.as_ref(),
+                Expr::PropertyGet { object, property }
+                    if property == "from"
+                        && matches!(
+                            object.as_ref(),
+                            Expr::ExternFuncRef { name, .. } if name == "ReadableStream"
+                        )
+            ) =>
+        {
+            let arg_box = if let Some(a) = args.first() {
+                lower_expr(ctx, a)?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_readable_stream_from_iterable",
+                &[(DOUBLE, &arg_box)],
+            ))
+        }
+
         // Phase H crypto: collapse `crypto.createHash(alg).update(data).digest(enc)`
         // into a single runtime call. The HIR shape is a triple-nested
         // Call whose innermost callee is `NativeModuleRef("crypto")`.

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1658,6 +1658,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         &[DOUBLE, DOUBLE, DOUBLE, DOUBLE],
     );
     module.declare_function("js_readable_stream_get_reader", DOUBLE, &[DOUBLE]);
+    // #1645: ReadableStream.from(iterable) — builds a pre-loaded stream.
+    module.declare_function("js_readable_stream_from_iterable", DOUBLE, &[DOUBLE]);
     module.declare_function("js_readable_stream_locked", DOUBLE, &[DOUBLE]);
     module.declare_function("js_readable_stream_cancel", I64, &[DOUBLE, DOUBLE]);
     module.declare_function("js_readable_stream_tee", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -222,6 +222,46 @@ pub(crate) fn lower_var_decl_with_destructuring(
                 }
             }
 
+            // #1645: `const rs = ReadableStream.from(iterable)` — the `.from`
+            // Call result is typed Any, so register the binding as a
+            // ReadableStream native instance (mirroring `new ReadableStream`'s
+            // typing). Without this, `rs.getReader()` / `for await (const c of
+            // rs)` fall to generic dispatch on the numeric stream handle and
+            // fail. The Call itself is routed to `js_readable_stream_from_iterable`
+            // in codegen (expr/calls.rs).
+            if let Some(init_expr) = &decl.init {
+                if let ast::Expr::Call(call) = init_expr.as_ref() {
+                    if let ast::Callee::Expr(callee) = &call.callee {
+                        if let ast::Expr::Member(m) = callee.as_ref() {
+                            if let ast::MemberProp::Ident(prop) = &m.prop {
+                                if prop.sym.as_ref() == "from" {
+                                    let mut obj_inner: &ast::Expr = m.obj.as_ref();
+                                    loop {
+                                        obj_inner = match obj_inner {
+                                            ast::Expr::TsAs(x) => &x.expr,
+                                            ast::Expr::TsNonNull(x) => &x.expr,
+                                            ast::Expr::TsConstAssertion(x) => &x.expr,
+                                            ast::Expr::Paren(x) => &x.expr,
+                                            _ => break,
+                                        };
+                                    }
+                                    if matches!(
+                                        obj_inner,
+                                        ast::Expr::Ident(i) if i.sym.as_ref() == "ReadableStream"
+                                    ) {
+                                        ctx.register_native_instance(
+                                            name.clone(),
+                                            "readable_stream".to_string(),
+                                            "ReadableStream".to_string(),
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             // Check if this is an awaited native class instantiation (e.g., await new Redis())
             if let Some(init_expr) = &decl.init {
                 if let ast::Expr::Await(await_expr) = init_expr.as_ref() {

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -627,13 +627,43 @@ pub unsafe extern "C" fn js_readable_stream_from_response(_resp_id: f64) -> f64 
     alloc_readable_from_bytes(Vec::new()) as f64
 }
 
-// `ReadableStream.from(asyncIterable)` — deferred (issue #237 followup).
+/// `ReadableStream.from(iterable)` (Node 20+, #1645) — build a Web
+/// ReadableStream pre-loaded with the iterable's items, then closed. Today we
+/// handle the synchronous-array case (the overwhelmingly common form: a literal
+/// array, a spread, `[...set]`, etc.); each element becomes one chunk so
+/// `getReader().read()` / `for await` yield them in order, then `done`.
 #[no_mangle]
-pub unsafe extern "C" fn js_readable_stream_from_iterable(_value: f64) -> f64 {
-    let err = make_error_with_message(
-        "ReadableStream.from(asyncIterable) is not yet implemented (issue #237 followup)",
-    );
-    perry_runtime::exception::js_throw(f64::from_bits(err));
+pub unsafe extern "C" fn js_readable_stream_from_iterable(value: f64) -> f64 {
+    ensure_gc_registered();
+    let id = alloc_readable(0, 0, 0, 1.0);
+
+    // Extract the array pointer: array values arrive either NaN-boxed POINTER
+    // (top16 == 0x7FFD) or as a raw heap pointer bit-cast to f64 (top16 == 0).
+    let bits = value.to_bits();
+    let top = bits >> 48;
+    let arr_ptr = if top == 0x7FFD || top == 0x7FFF {
+        (bits & POINTER_MASK) as *const perry_runtime::ArrayHeader
+    } else if top == 0 && bits >= 0x10000 {
+        bits as *const perry_runtime::ArrayHeader
+    } else {
+        std::ptr::null()
+    };
+
+    {
+        let mut g = READABLE_STREAMS.lock().unwrap();
+        if let Some(s) = g.get_mut(&id) {
+            if !arr_ptr.is_null() {
+                let len = perry_runtime::array::js_array_length(arr_ptr);
+                for i in 0..len {
+                    let elem = perry_runtime::array::js_array_get(arr_ptr, i);
+                    s.chunks.push_back(elem.bits());
+                }
+            }
+            s.started = true;
+            s.state = ReadableState::Closed;
+        }
+    }
+    id as f64
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -884,12 +884,6 @@
     "category": "bug-open",
     "reason": "node:stream: read() with no arg should return the entire buffered chunk. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/from-iterable": {
-    "issue": "1645",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/web: ReadableStream.from(iterable) not implemented. Flips to PASS when #1645 lands."
-  },
   "node-suite/stream/events/get-max-listeners": {
     "issue": "1531",
     "added": "2026-05-23",


### PR DESCRIPTION
Implements `ReadableStream.from(iterable)` (Node 20+) for `node:stream/web` (#1645).

## Problem
`ReadableStream.from(["a","b"])` returned an empty/stub stream — the runtime `js_readable_stream_from_iterable` threw, and `(ReadableStream as any).from(x)` was never routed to it (it fell to a generic call producing a non-usable value).

## Fix
- **runtime** (`streams.rs`): implement `js_readable_stream_from_iterable` — drain a synchronous array iterable into a pre-loaded, closed `ReadableStream` (one chunk per element) so `getReader().read()` / `for await` yield them in order, then `done`.
- **codegen** (`calls.rs` + `runtime_decls`): route `Call { PropertyGet { ExternFuncRef("ReadableStream"), "from" }, args }` → `js_readable_stream_from_iterable`.
- **HIR** (`var_decl`): register a `const rs = ReadableStream.from(...)` binding as a ReadableStream native instance so `rs.getReader()` / `for await (const c of rs)` dispatch statically (the `.from` Call result is otherwise typed `Any`, and generic getReader on the numeric handle didn't resolve).

## Validation
- `node-suite/stream/web/from-iterable` now matches Node (`a: a b: b`); removed from `known_failures.json`.
- Regression: `Array.from` / `Buffer.from` / `Array.from(Set)` unaffected (routing is gated to the `ReadableStream` class ref).

Follow-up to #1545 (merged). Today handles the synchronous-array case (the dominant form); async-iterable sources can extend `js_readable_stream_from_iterable` later.
