### PR TITLE
fix(node:stream/web): TransformStreamDefaultController.terminate() (#1644)

### DIFF
--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -801,6 +801,7 @@ pub(super) fn lower_builtin_new(
         }
 
         "TransformStream" => {
+            let mut start = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
             let mut transform = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
             let mut flush = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
             let mut hwm = double_literal(1.0);
@@ -808,6 +809,9 @@ pub(super) fn lower_builtin_new(
                 if let Some(props) = extract_options_fields(ctx, &args[0]) {
                     for (k, vexpr) in &props {
                         match k.as_str() {
+                            "start" => {
+                                start = lower_expr(ctx, vexpr)?;
+                            }
                             "transform" => {
                                 transform = lower_expr(ctx, vexpr)?;
                             }
@@ -835,7 +839,12 @@ pub(super) fn lower_builtin_new(
             let h = ctx.block().call(
                 DOUBLE,
                 "js_transform_stream_new",
-                &[(DOUBLE, &transform), (DOUBLE, &flush), (DOUBLE, &hwm)],
+                &[
+                    (DOUBLE, &start),
+                    (DOUBLE, &transform),
+                    (DOUBLE, &flush),
+                    (DOUBLE, &hwm),
+                ],
             );
             Ok(Some(h))
         }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1706,7 +1706,12 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_writer_ready", I64, &[DOUBLE]);
     module.declare_function("js_writer_desired_size", DOUBLE, &[DOUBLE]);
     // TransformStream.
-    module.declare_function("js_transform_stream_new", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
+    // #1644: leading arg is the `start` hook.
+    module.declare_function(
+        "js_transform_stream_new",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, DOUBLE, DOUBLE],
+    );
     module.declare_function("js_transform_stream_readable", DOUBLE, &[DOUBLE]);
     module.declare_function("js_transform_stream_writable", DOUBLE, &[DOUBLE]);
     // #1545: node:stream/web QueuingStrategy constructors — take the options

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -1247,11 +1247,13 @@ pub unsafe extern "C" fn js_writer_desired_size(writer_handle: f64) -> f64 {
 
 #[no_mangle]
 pub unsafe extern "C" fn js_transform_stream_new(
+    start_bits: f64,
     transform_bits: f64,
     flush_bits: f64,
     hwm: f64,
 ) -> f64 {
     ensure_gc_registered();
+    let start_cb = closure_from_bits(start_bits.to_bits());
     let transform_cb = closure_from_bits(transform_bits.to_bits());
     let flush_cb = closure_from_bits(flush_bits.to_bits());
 
@@ -1301,6 +1303,14 @@ pub unsafe extern "C" fn js_transform_stream_new(
         },
     );
     TRANSFORM_PAIRS.lock().unwrap().insert(writable_id, id);
+
+    // #1644: TransformStream `start(controller)` fires synchronously at
+    // construction. The controller is the readable-side handle (same value the
+    // transform/flush callbacks receive), so `controller.enqueue(c)` /
+    // `controller.terminate()` / `controller.error(e)` act on the readable.
+    if start_cb != 0 {
+        js_closure_call1(start_cb as *const ClosureHeader, readable_id as f64);
+    }
     id as f64
 }
 
@@ -1590,6 +1600,14 @@ pub(crate) unsafe fn dispatch_stream_method(
             "cancel" => return Some(box_promise(js_readable_stream_cancel(handle, arg0))),
             "tee" => return Some(js_readable_stream_tee(handle)),
             "pipeTo" => return Some(box_promise(js_readable_stream_pipe_to(handle, arg0))),
+            // #1644: a readable handle is also its own controller. The
+            // start/transform/flush callbacks receive it as `controller`, so
+            // `controller.enqueue/close/error/terminate` dispatch here when the
+            // controller param is generically typed. `terminate()` ends the
+            // readable side (TransformStreamDefaultController.terminate).
+            "enqueue" => return Some(js_readable_stream_controller_enqueue(handle, arg0)),
+            "close" | "terminate" => return Some(js_readable_stream_controller_close(handle)),
+            "error" => return Some(js_readable_stream_controller_error(handle, arg0)),
             _ => return None,
         }
     }
@@ -1663,7 +1681,14 @@ pub unsafe extern "C" fn js_transform_stream_subclass_init(
     flush_bits: f64,
     hwm: f64,
 ) -> f64 {
-    let handle = js_transform_stream_new(transform_bits, flush_bits, hwm);
+    // #1644: subclass `super({...})` doesn't thread a `start` hook through this
+    // path (the #562 subclass shim only forwards transform/flush); pass undefined.
+    let handle = js_transform_stream_new(
+        f64::from_bits(TAG_UNDEFINED),
+        transform_bits,
+        flush_bits,
+        hwm,
+    );
     attach_handle_to_this(this_bits, handle as usize);
     f64::from_bits(TAG_UNDEFINED)
 }

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -1232,12 +1232,6 @@
     "category": "bug-open",
     "reason": "node:stream: Readable.from(Map) doesn't iterate entries via async iteration. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/controller-terminate": {
-    "issue": "1644",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/web: TransformStreamDefaultController.terminate() not implemented. Flips to PASS when #1644 lands."
-  },
   "node-suite/stream/compose/single-transform": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
Implements `TransformStreamDefaultController.terminate()` for `node:stream/web` (#1644).

## Problem
`new TransformStream({ start(controller) { controller.terminate() } })` did nothing — the readable side never closed, so `ts.readable.getReader().read()` never resolved with `done`. Two gaps:
1. The TransformStream `start` hook was never invoked (codegen dropped it; `js_transform_stream_new` didn't accept it).
2. `terminate()` wasn't a recognised controller method.

## Fix
- **codegen** (`builtin.rs` + `runtime_decls`): extract the `start` option and pass it as the leading arg to `js_transform_stream_new`.
- **runtime** (`streams.rs`): `js_transform_stream_new` takes `start_bits` and invokes `start(controller)` synchronously at construction — the controller is the readable-side handle (the same value `transform`/`flush` receive). Subclass-init passes `undefined`.
- **runtime dispatch** (`streams.rs`): a readable handle is also its own controller, so add `enqueue`/`close`/`error`/`terminate` to the generic stream-handle method dispatch (for generically-typed `controller` params). `terminate()` ends the readable side.

## Validation
- `node-suite/stream/web/controller-terminate` now matches Node (`done: true`); removed from `known_failures.json`.
- The other 5 transform-stream node-suite tests (transform-stream, -with-flush, -with-hwm, -no-args, -pipethrough) still pass.

Follow-up to #1545 (merged).
