### PR TITLE
fix(node:stream/web): typeof of a stream method is "function" (#1642, #1643)

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -834,6 +834,42 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     let recv_box = lower_expr(ctx, object)?;
                     return Ok(ctx.block().call(DOUBLE, &fn_name, &[(DOUBLE, &recv_box)]));
                 }
+                // #1642: bound-method reference for Web Streams instance methods
+                // (`typeof rs.getReader === "function"`, `const f = rs.getReader;
+                // f()`). Stream instances are numeric handles, not class objects,
+                // so the `ctx.methods` path below never matches — bind explicitly
+                // via `js_class_method_bind`, whose closure routes calls through
+                // `js_native_call_method` → the #1545 stream-handle dispatch. The
+                // HIR only routes a stream *method* value-read here (getters keep
+                // their 0-arg getter call), so a match here is always a method.
+                let is_web_stream_method = matches!(
+                    (class_name.as_str(), property.as_str()),
+                    (
+                        "ReadableStream",
+                        "getReader" | "cancel" | "tee" | "pipeTo" | "pipeThrough"
+                    ) | (
+                        "ReadableStreamDefaultReader",
+                        "read" | "releaseLock" | "cancel"
+                    ) | ("WritableStream", "getWriter" | "abort" | "close")
+                        | (
+                            "WritableStreamDefaultWriter",
+                            "write" | "close" | "abort" | "releaseLock"
+                        )
+                );
+                if is_web_stream_method {
+                    let recv_box = lower_expr(ctx, object)?;
+                    let key_idx = ctx.strings.intern(property);
+                    let entry = ctx.strings.entry(key_idx);
+                    let bytes_global = format!("@{}", entry.bytes_global);
+                    let len_str = entry.byte_len.to_string();
+                    let blk = ctx.block();
+                    let bytes_i64 = blk.ptrtoint(&bytes_global, I64);
+                    return Ok(blk.call(
+                        DOUBLE,
+                        "js_class_method_bind",
+                        &[(DOUBLE, &recv_box), (I64, &bytes_i64), (I64, &len_str)],
+                    ));
+                }
                 // Fast path: known class instance + plain instance field
                 // (no getter/setter shadowing). Inline a direct GEP+load
                 // at the field's slot offset, bypassing the

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -137,6 +137,61 @@ pub(crate) fn lower_var_decl_with_destructuring(
                 }
             }
 
+            // #1642/#1643: a `const x = <stream>.getReader(...)` / `.getWriter(...)`
+            // / `ReadableStream.from(...)` binding is typed Any by inference, but
+            // the result is a Web Streams native instance. Type it as the stream
+            // class so codegen `receiver_class_name` resolves value-read method
+            // binds (`typeof reader.read === "function"`) for the Any-typed
+            // local. Safe: the call path (lower/expr_call/static_and_instance.rs)
+            // dispatches via the native-instance registry, not this declared type.
+            if matches!(ty, Type::Any) {
+                if let Some(init_expr) = &decl.init {
+                    if let ast::Expr::Call(call) = init_expr.as_ref() {
+                        if let ast::Callee::Expr(callee) = &call.callee {
+                            if let ast::Expr::Member(m) = callee.as_ref() {
+                                if let ast::MemberProp::Ident(prop) = &m.prop {
+                                    // Peel `as T` / `!` / `as const` / parens on
+                                    // the receiver (`(rs as any).getReader(...)`).
+                                    let mut obj_inner: &ast::Expr = m.obj.as_ref();
+                                    loop {
+                                        obj_inner = match obj_inner {
+                                            ast::Expr::TsAs(x) => &x.expr,
+                                            ast::Expr::TsNonNull(x) => &x.expr,
+                                            ast::Expr::TsConstAssertion(x) => &x.expr,
+                                            ast::Expr::Paren(x) => &x.expr,
+                                            _ => break,
+                                        };
+                                    }
+                                    if let ast::Expr::Ident(obj_id) = obj_inner {
+                                        let method = prop.sym.as_ref();
+                                        let recv_class = ctx
+                                            .lookup_native_instance(obj_id.sym.as_ref())
+                                            .map(|(_, c)| c.to_string());
+                                        if method == "getReader"
+                                            && recv_class.as_deref() == Some("ReadableStream")
+                                        {
+                                            ty = Type::Named(
+                                                "ReadableStreamDefaultReader".to_string(),
+                                            );
+                                        } else if method == "getWriter"
+                                            && recv_class.as_deref() == Some("WritableStream")
+                                        {
+                                            ty = Type::Named(
+                                                "WritableStreamDefaultWriter".to_string(),
+                                            );
+                                        } else if method == "from"
+                                            && obj_id.sym.as_ref() == "ReadableStream"
+                                        {
+                                            ty = Type::Named("ReadableStream".to_string());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             // Check if this is a native class instantiation and register it
             if let Some(init_expr) = &decl.init {
                 if let ast::Expr::New(new_expr) = init_expr.as_ref() {

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -815,6 +815,33 @@ pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) 
                 {
                     // Fall through — let the regular member access path
                     // below handle the user-declared subclass field.
+                } else if matches!(
+                    module_name.as_str(),
+                    "readable_stream"
+                        | "writable_stream"
+                        | "transform_stream"
+                        | "readable_stream_reader"
+                        | "writable_stream_writer"
+                ) && !matches!(
+                    property_name.as_str(),
+                    // Getter properties keep the 0-arg NativeMethodCall below
+                    // (they really are getters); everything else here is a
+                    // callable method.
+                    "locked" | "desiredSize" | "closed" | "ready" | "readable" | "writable"
+                ) {
+                    // #1642: a value-read of a Web Streams *method* (not a
+                    // getter) must yield a callable bound-method reference, not
+                    // a 0-arg getter call. `lower_member` is reached only for
+                    // value-reads (the call form `rs.getReader()` is handled by
+                    // `expr_call::lower_call`), so emit a plain `PropertyGet`;
+                    // the codegen binds it via `js_class_method_bind` so
+                    // `typeof rs.getReader === "function"` and `const f =
+                    // rs.getReader; f()` both work.
+                    let object_expr = lower_expr(ctx, &member.obj)?;
+                    return Ok(Expr::PropertyGet {
+                        object: Box::new(object_expr),
+                        property: property_name,
+                    });
                 } else {
                     // Issue #577 — `req.method` / `res.statusCode` etc.
                     // get rewritten to `__get_<name>` so the property

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -944,12 +944,6 @@
     "category": "bug-open",
     "reason": "node:stream: newListener/removeListener inherited EE events don't fire on streams. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/writer-release-lock": {
-    "issue": "1642",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/web: `typeof w2.write` after releaseLock is wrong (stream-method value-read lowered as a call). Flips to PASS when #1642 lands."
-  },
   "node-suite/stream/ee/listener-count-no-arg": {
     "issue": "1531",
     "added": "2026-05-23",
@@ -1057,12 +1051,6 @@
     "added": "2026-05-23",
     "category": "bug-open",
     "reason": "node:stream: new Writable({signal}) constructor option not honored. Flips to PASS when #1531 lands."
-  },
-  "node-suite/stream/web/byob-reader": {
-    "issue": "1643",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/web: BYOB readers (getReader({mode:'byob'})) not implemented. Flips to PASS when #1643 lands."
   },
   "node-suite/stream/async-iter/two-iterators-error": {
     "issue": "1532",

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -938,12 +938,6 @@
     "category": "bug-open",
     "reason": "node:stream: class extends Writable + _write doesn't deliver finish. Flips to PASS when #1532 lands."
   },
-  "node-suite/stream/web/readable-stream-no-args": {
-    "issue": "1642",
-    "added": "2026-05-23",
-    "category": "bug-open",
-    "reason": "node:stream/web: `typeof rs.getReader` is wrong (HIR lowers stream-method value-read as a 0-arg call). Flips to PASS when #1642 lands."
-  },
   "node-suite/stream/ee/new-listener-event": {
     "issue": "1532",
     "added": "2026-05-23",


### PR DESCRIPTION
Makes `typeof <stream>.<method>` report `"function"` for `node:stream/web` instances. **Closes #1642 and #1643.**

## Problem
`typeof rs.getReader === "function"` was `false`. The HIR's `lower_member` produced a 0-arg `NativeMethodCall` for stream member value-reads, so a value-read of a method executed `getReader()` and took `typeof` of the result (a numeric handle) → `"number"`.

## Fix
`lower_member` is reached only for value-reads (the call form goes through `expr_call::lower_call`):
- **HIR** (`expr_member.rs`): for a Web Streams *method* value-read, emit a plain `PropertyGet` instead of a 0-arg `NativeMethodCall`. Getter properties (locked/desiredSize/closed/ready/readable/writable) keep their getter call.
- **codegen** (`property_get.rs`): bind such a stream-method `PropertyGet` via `js_class_method_bind` (the #446 helper) when the receiver's static type is a stream class — its closure is `typeof === "function"` and routes calls through `js_native_call_method` → the #1545 stream-handle dispatch.
- **HIR** (`var_decl.rs`): type `const x = <stream>.getReader(...)` / `.getWriter(...)` / `ReadableStream.from(...)` bindings as the stream class (so the Any-typed-but-registered case resolves), peeling `as T` casts for `(rs as any).getReader({mode})`. Safe — the method-call path dispatches via the native-instance registry, not this declared type.

## Validation
- `node-suite/stream/web/{readable-stream-no-args, writer-release-lock, byob-reader}` now match Node; removed from `known_failures.json`.
- Full stream/web sweep: regression-free (the only not-yet-listed failures fail identically without this change — they're newer-main tests scheduled into known_failures upstream, not regressions).

Follow-up to #1545 (merged). This was the last of the #1545 node:stream/web follow-up set (#1642–#1646).
