### PR TITLE
test(parity): stream — batch of 12 tier-8 tests (iter-94..96) (6 free pass, 6 #1531/#1532/#1539/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2581,5 +2581,41 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: unshift() during flowing mode — chunk not re-emitted in order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/compose-with-passthrough": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(src, PassThrough) — data not preserved through PT in composite. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/events/end-fires-once-multi-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'end' event listeners — fire wrong number of times with multi-listener registration. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/uncork-without-cork": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: uncork() with no prior cork() — error or breaks finish. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/web/byte-stream-non-buffer-throws": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: bytes-typed RS — enqueue(string) does not throw TypeError. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/from-empty-iter-immediately-done": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(immediately-done iter) — wrong data count or end not firing. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/finish-then-close-writable": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Writable 'finish' / 'close' event order — wrong sequence. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/end-fires-once-multi-listener.ts
+++ b/test-parity/node-suite/stream/events/end-fires-once-multi-listener.ts
@@ -1,0 +1,14 @@
+import { Readable } from "node:stream";
+// 'end' fires exactly once even with multiple listeners.
+let counts = [0, 0, 0];
+const r = Readable.from(["x"]);
+r.on("data", () => {});
+r.on("end", () => counts[0]++);
+r.on("end", () => counts[1]++);
+r.on("end", () => counts[2]++);
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("counts:", counts.join(","));
+    console.log("all 1:", counts.every((n) => n === 1));
+  });
+});

--- a/test-parity/node-suite/stream/events/finish-then-close-writable.ts
+++ b/test-parity/node-suite/stream/events/finish-then-close-writable.ts
@@ -1,0 +1,11 @@
+import { Writable } from "node:stream";
+// On Writable: 'finish' fires before 'close'.
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+const events: string[] = [];
+w.on("finish", () => events.push("finish"));
+w.on("close", () => {
+  events.push("close");
+  console.log("order:", events.join(","));
+  console.log("finish before close:", events.indexOf("finish") < events.indexOf("close"));
+});
+w.end("x");

--- a/test-parity/node-suite/stream/readable/compose-no-args.ts
+++ b/test-parity/node-suite/stream/readable/compose-no-args.ts
@@ -1,0 +1,10 @@
+import { compose } from "node:stream";
+// compose() with no args — should throw TypeError per docs.
+let caught: string | null = null;
+try {
+  (compose as any)();
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/readable/compose-with-passthrough.ts
+++ b/test-parity/node-suite/stream/readable/compose-with-passthrough.ts
@@ -1,0 +1,8 @@
+import { Readable, PassThrough, compose } from "node:stream";
+// compose() with a PassThrough — should yield the source data unchanged.
+const src = Readable.from(["a", "b"]);
+const pt = new PassThrough();
+const composed: any = compose(src, pt);
+const out: string[] = [];
+composed.on("data", (c: any) => out.push(String(c)));
+composed.on("end", () => console.log("composed-pt:", out.join(",")));

--- a/test-parity/node-suite/stream/readable/from-empty-iter-immediately-done.ts
+++ b/test-parity/node-suite/stream/readable/from-empty-iter-immediately-done.ts
@@ -1,0 +1,20 @@
+import { Readable } from "node:stream";
+// Iterator that immediately returns {done:true} — empty stream, end fires.
+const emptyIter = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: undefined, done: true };
+      },
+    };
+  },
+};
+const r = Readable.from(emptyIter as any);
+let dataCount = 0;
+let endFired = false;
+r.on("data", () => dataCount++);
+r.on("end", () => {
+  endFired = true;
+  console.log("data count:", dataCount);
+  console.log("end fired:", endFired);
+});

--- a/test-parity/node-suite/stream/web/byte-stream-non-buffer-throws.ts
+++ b/test-parity/node-suite/stream/web/byte-stream-non-buffer-throws.ts
@@ -1,0 +1,15 @@
+import { ReadableStream } from "node:stream/web";
+// A type:"bytes" ReadableStream can only enqueue ArrayBuffer/views — string throws.
+let caught: string | null = null;
+const rs = new ReadableStream({
+  type: "bytes",
+  start(c) {
+    try {
+      c.enqueue("not-a-buffer" as any);
+    } catch (e: any) {
+      caught = e && e.name;
+    }
+  },
+} as any);
+console.log("constructed:", rs instanceof ReadableStream);
+console.log("enqueue threw:", caught);

--- a/test-parity/node-suite/stream/web/for-await-readable-stream.ts
+++ b/test-parity/node-suite/stream/web/for-await-readable-stream.ts
@@ -1,0 +1,13 @@
+import { ReadableStream } from "node:stream/web";
+// for-await directly over a Web ReadableStream — should iterate all chunks.
+const rs = new ReadableStream({
+  start(c) {
+    c.enqueue("a");
+    c.enqueue("b");
+    c.enqueue("c");
+    c.close();
+  },
+});
+const out: string[] = [];
+for await (const v of rs as any) out.push(String(v));
+console.log("collected:", out.join(","));

--- a/test-parity/node-suite/stream/web/release-lock-without-reading.ts
+++ b/test-parity/node-suite/stream/web/release-lock-without-reading.ts
@@ -1,0 +1,10 @@
+import { ReadableStream } from "node:stream/web";
+// releaseLock() immediately after getReader() (no read) — stream unlocks.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const reader = rs.getReader();
+reader.releaseLock();
+console.log("locked after release:", rs.locked);
+// Should be able to get another reader
+const reader2 = rs.getReader();
+const { value, done } = await reader2.read();
+console.log("re-read value:", value, "done:", done);

--- a/test-parity/node-suite/stream/web/tee-both-branches-data.ts
+++ b/test-parity/node-suite/stream/web/tee-both-branches-data.ts
@@ -1,0 +1,23 @@
+import { ReadableStream } from "node:stream/web";
+// tee() — both branches receive ALL the data chunks independently.
+const rs = new ReadableStream({
+  start(c) {
+    c.enqueue("a");
+    c.enqueue("b");
+    c.close();
+  },
+});
+const [a, b] = rs.tee();
+const aOut: string[] = [];
+const bOut: string[] = [];
+async function drain(reader: ReadableStreamDefaultReader<any>, out: string[]) {
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    out.push(String(value));
+  }
+}
+await Promise.all([drain(a.getReader(), aOut), drain(b.getReader(), bOut)]);
+console.log("a:", aOut.join(","));
+console.log("b:", bOut.join(","));
+console.log("same:", aOut.join(",") === bOut.join(","));

--- a/test-parity/node-suite/stream/web/writer-ready-initial-resolved.ts
+++ b/test-parity/node-suite/stream/web/writer-ready-initial-resolved.ts
@@ -1,0 +1,8 @@
+import { WritableStream } from "node:stream/web";
+// On a freshly-created writer, ready is already resolved (no backpressure).
+const ws = new WritableStream({ write() {} });
+const w = ws.getWriter();
+let resolved = false;
+w.ready.then(() => (resolved = true));
+await new Promise((r) => setImmediate(r));
+console.log("ready resolved immediately:", resolved);

--- a/test-parity/node-suite/stream/writable/end-twice-with-chunk.ts
+++ b/test-parity/node-suite/stream/writable/end-twice-with-chunk.ts
@@ -1,0 +1,11 @@
+import { Writable } from "node:stream";
+// end(chunkA); end(chunkB) — second end's chunk is ignored.
+const received: string[] = [];
+const w = new Writable({
+  write(c, _e, cb) { received.push(String(c)); cb(); },
+});
+w.end("first");
+w.end("second"); // ignored
+w.on("finish", () => {
+  console.log("received:", received.join(","));
+});

--- a/test-parity/node-suite/stream/writable/uncork-without-cork.ts
+++ b/test-parity/node-suite/stream/writable/uncork-without-cork.ts
@@ -1,0 +1,6 @@
+import { Writable } from "node:stream";
+// uncork() without a prior cork() is a safe no-op.
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+w.uncork(); // no cork — should not error
+w.end("x");
+w.on("finish", () => console.log("finished normally:", true));


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-94..96)

**6 free passes + 6 tracked failures — best batch yet (50% pass rate).**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | for-await-readable-stream ✅, writer-ready-initial-resolved ✅, tee-both-branches-data ✅, release-lock-without-reading ✅, byte-stream-non-buffer-throws | #1545 |
| Compose | compose-no-args ✅, compose-with-passthrough | #1531 |
| Stream events | end-fires-once-multi-listener, from-empty-iter-immediately-done, finish-then-close-writable | #1532 |
| Writable buffering | end-twice-with-chunk ✅, uncork-without-cork | #1539 |

Free passes — Perry already matches Node:
- `web/for-await-readable-stream` (recent #1646/#1658 fix landed!)
- `web/writer-ready-initial-resolved` (initial ready is resolved)
- `web/tee-both-branches-data` (both branches get all chunks)
- `web/release-lock-without-reading` (releaseLock without read works)
- `readable/compose-no-args` (compose() w/ no args throws TypeError)
- `writable/end-twice-with-chunk` (second end's chunk ignored)

All 6 failures tracked in `known_failures.json`.
