### PR TITLE
test(parity): stream — batch of 12 tier-8/9 tests (iter-97..99) (3 free pass, 9 #1532/#1545/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2581,5 +2581,59 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: unshift() during flowing mode — chunk not re-emitted in order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/for-await-on-transform": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: for-await directly on TransformStream.readable — empty or wrong output. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/end-false-then-explicit-end": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe(dst,{end:false}) followed by manual dst.end() — dst not ending. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/for-each-await-each": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: forEach(asyncFn) — does not await each call sequentially. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/readable/from-async-iter-nested": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(asyncIter with awaits) — wrong collected output. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/pipe-to-with-pre-aborted-signal": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: pipeTo with pre-aborted signal — does not reject immediately. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/flags/destroyed-initial-false": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroyed flag — wrong initial value on R/W/D/T. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/pipe-adds-listener-on-dst": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe() does not add 'unpipe' listener on destination. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/map-then-toarray": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: map(fn).toArray() — chain returns non-Array or wrong values. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/readable/readable-mode-only": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'readable' event with read() drain — chunk order or count wrong. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/listener-count-zero.ts
+++ b/test-parity/node-suite/stream/events/listener-count-zero.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// listenerCount(event) returns 0 when no listener registered.
+const r = new Readable({ read() {} });
+console.log("no listeners:", r.listenerCount("data"));
+console.log("is 0:", r.listenerCount("data") === 0);

--- a/test-parity/node-suite/stream/flags/destroyed-initial-false.ts
+++ b/test-parity/node-suite/stream/flags/destroyed-initial-false.ts
@@ -1,0 +1,10 @@
+import { Readable, Writable, Duplex, Transform } from "node:stream";
+// destroyed flag should be false on freshly-constructed streams.
+const r = new Readable({ read() {} });
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+const d = new Duplex({ read() {}, write(_c, _e, cb) { cb(); } });
+const t = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+console.log("R:", r.destroyed);
+console.log("W:", w.destroyed);
+console.log("D:", d.destroyed);
+console.log("T:", t.destroyed);

--- a/test-parity/node-suite/stream/iter-helpers/for-each-await-each.ts
+++ b/test-parity/node-suite/stream/iter-helpers/for-each-await-each.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// forEach() with an async function — awaits each call before moving on.
+const r = Readable.from([1, 2, 3]);
+const events: string[] = [];
+await (r as any).forEach(async (x: number) => {
+  events.push("start:" + x);
+  await new Promise((resolve) => setTimeout(resolve, 2));
+  events.push("end:" + x);
+});
+console.log("order:", events.join(","));

--- a/test-parity/node-suite/stream/iter-helpers/map-then-toarray.ts
+++ b/test-parity/node-suite/stream/iter-helpers/map-then-toarray.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// .map(fn).toArray() — chain map then toArray to a plain array.
+const r = Readable.from([1, 2, 3]);
+const result = await (r as any).map((x: number) => x * 10).toArray();
+console.log("is array:", Array.isArray(result));
+console.log("result:", result.join(","));

--- a/test-parity/node-suite/stream/pipe/end-false-then-explicit-end.ts
+++ b/test-parity/node-suite/stream/pipe/end-false-then-explicit-end.ts
@@ -1,0 +1,13 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe(dst, {end:false}) — manual dst.end() works after source ends.
+const r = Readable.from(["a"]);
+const dst = new PassThrough();
+const out: string[] = [];
+dst.on("data", (c) => out.push(String(c)));
+dst.on("end", () => console.log("dst ended:", out.join(",")));
+r.pipe(dst, { end: false });
+r.on("end", () => {
+  setImmediate(() => {
+    dst.end();
+  });
+});

--- a/test-parity/node-suite/stream/pipe/pipe-adds-listener-on-dst.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-adds-listener-on-dst.ts
@@ -1,0 +1,11 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe() adds an internal 'unpipe' listener on dst (Node tracks via dst.listenerCount).
+const r = Readable.from(["x"]);
+const dst = new PassThrough();
+const before = dst.listenerCount("unpipe");
+r.pipe(dst);
+const after = dst.listenerCount("unpipe");
+console.log("before:", before);
+console.log("after:", after);
+console.log("incremented:", after > before);
+dst.on("data", () => {});

--- a/test-parity/node-suite/stream/readable/from-async-iter-nested.ts
+++ b/test-parity/node-suite/stream/readable/from-async-iter-nested.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Readable.from(asyncIter) where iter yields then awaits and yields more.
+async function* gen() {
+  yield 1;
+  await new Promise((r) => setImmediate(r));
+  yield 2;
+  await new Promise((r) => setImmediate(r));
+  yield 3;
+}
+const r = Readable.from(gen());
+const out: number[] = [];
+for await (const v of r) out.push(v as number);
+console.log("collected:", out.join(","));

--- a/test-parity/node-suite/stream/readable/readable-mode-only.ts
+++ b/test-parity/node-suite/stream/readable/readable-mode-only.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// 'readable' event mode (no 'data' listener) — manually drain via read().
+const r = new Readable({ read() {} });
+r.push("aa");
+r.push("bb");
+r.push(null);
+const out: string[] = [];
+r.on("readable", () => {
+  let c;
+  while ((c = r.read()) !== null) out.push(String(c));
+});
+r.on("end", () => console.log("drained:", out.join("|")));

--- a/test-parity/node-suite/stream/web/for-await-on-transform.ts
+++ b/test-parity/node-suite/stream/web/for-await-on-transform.ts
@@ -1,0 +1,15 @@
+import { TransformStream } from "node:stream/web";
+// for-await directly over a TransformStream's readable side.
+const ts = new TransformStream({
+  transform(c, ctrl) { ctrl.enqueue(String(c).toUpperCase()); },
+});
+const writer = ts.writable.getWriter();
+const out: string[] = [];
+const iterPromise = (async () => {
+  for await (const v of ts.readable as any) out.push(String(v));
+})();
+await writer.write("a");
+await writer.write("b");
+await writer.close();
+await iterPromise;
+console.log("collected:", out.join(","));

--- a/test-parity/node-suite/stream/web/pipe-to-with-pre-aborted-signal.ts
+++ b/test-parity/node-suite/stream/web/pipe-to-with-pre-aborted-signal.ts
@@ -1,0 +1,14 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// pipeTo({signal}) with a signal that was already aborted before the call
+// rejects the returned Promise immediately.
+const ctrl = new AbortController();
+ctrl.abort();
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); } });
+const ws = new WritableStream({ write() {} });
+let rejected = false;
+try {
+  await rs.pipeTo(ws, { signal: ctrl.signal });
+} catch {
+  rejected = true;
+}
+console.log("rejected pre-aborted:", rejected);

--- a/test-parity/node-suite/stream/web/transform-pipethrough-data-flow.ts
+++ b/test-parity/node-suite/stream/web/transform-pipethrough-data-flow.ts
@@ -1,0 +1,17 @@
+import { ReadableStream, TransformStream } from "node:stream/web";
+// pipeThrough — data flows through; collect the result.
+const rs = new ReadableStream({
+  start(c) { c.enqueue("a"); c.enqueue("b"); c.close(); },
+});
+const upper = new TransformStream({
+  transform(c, ctrl) { ctrl.enqueue(String(c).toUpperCase()); },
+});
+const result = rs.pipeThrough(upper);
+const reader = result.getReader();
+const out: string[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(String(value));
+}
+console.log("piped:", out.join(","));

--- a/test-parity/node-suite/stream/writable/end-returns-this.ts
+++ b/test-parity/node-suite/stream/writable/end-returns-this.ts
@@ -1,0 +1,5 @@
+import { Writable } from "node:stream";
+// end() returns the writable itself (chainable).
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+const returned = w.end();
+console.log("end returns self:", returned === w);


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-97..99)

**3 free passes + 9 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | for-await-on-transform, pipe-to-with-pre-aborted-signal, transform-pipethrough-data-flow ✅ | #1545 |
| Pipe semantics | end-false-then-explicit-end, pipe-adds-listener-on-dst | #1532 |
| Iter helpers | for-each-await-each, map-then-toarray | #1558 |
| Readable shape | from-async-iter-nested, destroyed-initial-false, readable-mode-only | #1532 |
| Writable | end-returns-this ✅ | — |
| EE | listener-count-zero ✅ | — |

Free passes — Perry already matches Node:
- `writable/end-returns-this` (chainable)
- `events/listener-count-zero` (no-listener count is 0)
- `web/transform-pipethrough-data-flow` (pipeThrough delivers values)

All 9 failures tracked in `known_failures.json`.
