### PR TITLE
fix(runtime): #1663 — re-entrant microtask drain nulls Task::Promise TLS (async-resume SIGSEGV)

### DIFF
--- a/crates/perry-runtime/src/promise/microtasks.rs
+++ b/crates/perry-runtime/src/promise/microtasks.rs
@@ -183,6 +183,31 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
 
                     // Record the running promise so the trap (above)
                     // can reject its `next` if the callback throws.
+                    //
+                    // #1663: the callback can re-entrantly drain the
+                    // microtask queue — a non-transformed async closure's
+                    // `await` busy-waits on `js_promise_run_microtasks`, and
+                    // each nested `Task::Promise` dispatch overwrites these
+                    // same TLS cells (and clears them on exit). Reloading
+                    // `promise` / `next` from the cells after the callback
+                    // would then observe a stale or NULL pointer; the very
+                    // next line dereferences `(*promise).async_id` (offset
+                    // 0x30) and segfaults. Root our promise + next in a
+                    // handle scope so we reload the GC-updated pointers from
+                    // there, and save/restore the previous cell values so a
+                    // nested drain leaves the enclosing arm — and its
+                    // exception-trap routing — intact. This mirrors the
+                    // INLINE_TRAP save/restore in the Inline/AsyncStep arms.
+                    let scope = crate::gc::RuntimeHandleScope::new();
+                    let promise_handle = scope.root_raw_mut_ptr(promise);
+                    let next_handle = scope.root_raw_mut_ptr((*promise).next);
+                    let prev_promise = CURRENT_MICROTASK_PROMISE.with(|c| c.get());
+                    let prev_callback = CURRENT_MICROTASK_CALLBACK.with(|c| c.get());
+                    let prev_value = CURRENT_MICROTASK_VALUE.with(|c| c.get());
+                    let prev_next = CURRENT_MICROTASK_NEXT.with(|c| c.get());
+                    let prev_promise_handle = scope.root_raw_mut_ptr(prev_promise);
+                    let prev_next_handle = scope.root_raw_mut_ptr(prev_next);
+
                     CURRENT_MICROTASK_PROMISE.with(|c| c.set(promise));
                     CURRENT_MICROTASK_CALLBACK.with(|c| c.set(callback));
                     CURRENT_MICROTASK_VALUE.with(|c| c.set(value));
@@ -195,37 +220,44 @@ pub extern "C" fn js_promise_run_microtasks() -> i32 {
                     };
                     crate::async_hooks::before((*promise).async_id, (*promise).trigger_async_id);
                     let result = crate::closure::js_closure_call1(callback, value);
+                    // Keep the callback result rooted across `after()` (which
+                    // can run JS when async_hooks are active) via the value
+                    // cell, then reload promise/next from our handles — never
+                    // the TLS cells, which a re-entrant drain may have nulled.
                     CURRENT_MICROTASK_VALUE.with(|c| c.set(result));
-                    let promise = CURRENT_MICROTASK_PROMISE.with(|c| c.get());
+                    let promise = promise_handle.get_raw_mut_ptr::<Promise>();
+                    let next = next_handle.get_raw_mut_ptr::<Promise>();
                     crate::async_hooks::after((*promise).async_id);
                     if let Some(t) = t1 {
                         MT_TIME_NS_CALLBACK
                             .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
                     }
 
-                    // Callback returned normally; clear the running
-                    // marker so a stray longjmp from a later (nested)
-                    // microtask doesn't misattribute its rejection.
-                    CURRENT_MICROTASK_PROMISE.with(|c| c.set(std::ptr::null_mut()));
-                    CURRENT_MICROTASK_CALLBACK.with(|c| c.set(std::ptr::null()));
-
                     let t2 = if prof {
                         Some(std::time::Instant::now())
                     } else {
                         None
                     };
-                    let next = CURRENT_MICROTASK_NEXT.with(|c| c.replace(std::ptr::null_mut()));
                     if !next.is_null() {
-                        let result = CURRENT_MICROTASK_VALUE.with(|c| c.replace(0.0));
+                        let result = CURRENT_MICROTASK_VALUE.with(|c| c.get());
                         propagate_callback_result(result, next);
-                    } else {
-                        CURRENT_MICROTASK_VALUE.with(|c| c.set(0.0));
                     }
                     clear_promise_context(promise);
                     if let Some(t) = t2 {
                         MT_TIME_NS_RESOLVE
                             .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
                     }
+
+                    // Restore the previous CURRENT_MICROTASK_* cells so an
+                    // enclosing (re-entrant) dispatch resumes with its own
+                    // promise/next/value for settlement and trap routing,
+                    // instead of the NULLs this arm would otherwise leave.
+                    CURRENT_MICROTASK_PROMISE
+                        .with(|c| c.set(prev_promise_handle.get_raw_mut_ptr::<Promise>()));
+                    CURRENT_MICROTASK_CALLBACK.with(|c| c.set(prev_callback));
+                    CURRENT_MICROTASK_VALUE.with(|c| c.set(prev_value));
+                    CURRENT_MICROTASK_NEXT
+                        .with(|c| c.set(prev_next_handle.get_raw_mut_ptr::<Promise>()));
                 }
                 restore_microtask_context();
                 ran += 1;

--- a/test-files/test_issue_1663_async_reentry_microtask.ts
+++ b/test-files/test_issue_1663_async_reentry_microtask.ts
@@ -1,0 +1,41 @@
+// Regression test for #1663: SIGSEGV in js_promise_run_microtasks during
+// async resumption.
+//
+// A non-transformed async closure's `await` busy-waits by re-entrantly
+// draining the microtask queue. Each nested `Task::Promise` dispatch
+// overwrote (and on exit nulled) the CURRENT_MICROTASK_PROMISE / _NEXT
+// thread-locals; when the enclosing dispatch resumed it reloaded `promise`
+// from the now-null cell and dereferenced `(*promise).async_id` (offset
+// 0x30) — a deterministic segfault. The trigger needs a prior completed
+// awaiting-call (`viaAwait`) followed by a subsequently-awaited nested
+// awaiting-call (`nested`). GC is NOT required.
+//
+// Expected output (byte-identical to `node --experimental-strip-types`):
+//   await: ok
+//   outer post: ok
+//   reached
+
+async function runCb(cb: () => Promise<void>) {
+  await cb();
+}
+
+async function viaAwait() {
+  await Promise.resolve();
+  console.log("await: ok");
+}
+
+async function nested() {
+  await runCb(async () => {
+    await runCb(async () => {
+      await Promise.resolve();
+    });
+    await Promise.resolve();
+    console.log("outer post: ok");
+  });
+}
+
+(async () => {
+  await runCb(viaAwait);
+  await nested();
+  console.log("reached");
+})();


### PR DESCRIPTION
## Summary

Fixes #1663 — a deterministic SIGSEGV in `js_promise_run_microtasks` during async resumption. Reported for a compiled Fastify + `@perryts/mysql` service that crashes on a `POST` handler doing JSON-body reads + sequential `await`ed MySQL queries (GET endpoints unaffected).

## Root cause

The `Task::Promise` arm of the microtask runner records the running promise + its chained `next` in the `CURRENT_MICROTASK_PROMISE` / `CURRENT_MICROTASK_NEXT` thread-locals, runs the callback, then **reloads** `promise` from the TLS cell to call `async_hooks::after((*promise).async_id)`.

When the callback re-entrantly drains the microtask queue — a non-transformed async closure's `await` busy-waits on `js_promise_run_microtasks` — each nested `Task::Promise` dispatch overwrites those same cells and **nulls them on exit**. On return, the enclosing arm reloaded `promise` as `NULL` and dereferenced `(*promise).async_id` (offset `0x30`), segfaulting.

The crash needs a prior **completed** awaiting-call followed by a subsequently-**awaited nested** awaiting-call — exactly the shape of a Fastify handler with several sequential awaits running under the server's re-entrant event-loop drain. GC is *not* required (an allocation-free repro crashes identically), which is why the standalone single-operation repros in the issue all survived.

This is the same crash that blocked the `async_hooks`/`AsyncLocalStorage` context test.

## Fix

Root the promise + `next` in a `RuntimeHandleScope` and reload the GC-updated pointers from there instead of the clobberable TLS cells, and save/restore the previous cell values around the callback so a nested drain leaves the enclosing arm — and its exception-trap routing — intact. This mirrors the `INLINE_TRAP` save/restore already used by the `Inline` and `AsyncStep` arms.

## Validation

- New regression test `test-files/test_issue_1663_async_reentry_microtask.ts` — byte-identical to `node --experimental-strip-types`.
- The minimal repro now prints `await: ok` / `outer post: ok` / `reached` and exits 0 under every GC mode (`default`, `PERRY_GEN_GC=0`, `PERRY_GEN_GC_EVACUATE=0`, `PERRY_GC_FORCE_EVACUATE=1`).
- `test_async_local_storage_context.ts` (previously segfaulted) now completes, byte-identical to Node.
- Async/promise/microtask test-file parity sweep vs Node: all passing (remaining sweep misses are pre-existing stdlib gaps — `dns/promises`, `readline/promises` — and jsruntime tests that require `--enable-js-runtime`).
- `cargo test -p perry-runtime` green; `cargo fmt --all -- --check` clean.
