### PR TITLE
fix(node:stream/web): for-await over res.body / TransformStream.readable (#1670)

### DIFF
--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -235,6 +235,31 @@ pub(crate) fn lower_stmt_for_of(
                 new_expr.callee.as_ref(),
                 ast::Expr::Ident(c) if c.sym.as_ref() == "ReadableStream"
             ),
+            // #1670: `for await (const c of res.body)` — `res.body` is a
+            // `ReadableStream` but arrives as a bare `Member` (Any-typed), so
+            // the Ident arm above misses it. Recognise `<obj>.body` on a
+            // Response/Request and `<ts>.readable` on a TransformStream, the
+            // same native-instance property mapping `var_decl` uses when those
+            // reads are bound to a typed local. Without this the loop falls
+            // through to the array-index desugar and iterates zero times.
+            ast::Expr::Member(member) => {
+                if let (ast::Expr::Ident(obj_ident), ast::MemberProp::Ident(prop_ident)) =
+                    (member.obj.as_ref(), &member.prop)
+                {
+                    let prop = prop_ident.sym.as_ref();
+                    let class = ctx
+                        .lookup_native_instance(obj_ident.sym.as_ref())
+                        .map(|(_, c)| c);
+                    matches!(
+                        (prop, class),
+                        ("body", Some("Response"))
+                            | ("body", Some("Request"))
+                            | ("readable", Some("TransformStream"))
+                    )
+                } else {
+                    false
+                }
+            }
             _ => false,
         };
 

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -710,22 +710,46 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         _ => break,
                     };
                 }
-                let is_readable_stream = if let ast::Expr::Ident(ident) = iter_inner {
-                    let name = ident.sym.as_ref();
-                    // A `new ReadableStream(...)` local is tracked by its
-                    // inferred `Named("ReadableStream")` type, not the
-                    // native-instance registry (that's only populated for
-                    // `response.body` / `blob.stream()` factories). Accept
-                    // either so a directly-constructed Web stream iterates too.
-                    matches!(
-                        ctx.lookup_native_instance(name),
-                        Some((_, "ReadableStream"))
-                    ) || matches!(
-                        ctx.lookup_local_type(name),
-                        Some(Type::Named(n)) if n == "ReadableStream"
-                    )
-                } else {
-                    false
+                let is_readable_stream = match iter_inner {
+                    ast::Expr::Ident(ident) => {
+                        let name = ident.sym.as_ref();
+                        // A `new ReadableStream(...)` local is tracked by its
+                        // inferred `Named("ReadableStream")` type, not the
+                        // native-instance registry (that's only populated for
+                        // `response.body` / `blob.stream()` factories). Accept
+                        // either so a directly-constructed Web stream iterates too.
+                        matches!(
+                            ctx.lookup_native_instance(name),
+                            Some((_, "ReadableStream"))
+                        ) || matches!(
+                            ctx.lookup_local_type(name),
+                            Some(Type::Named(n)) if n == "ReadableStream"
+                        )
+                    }
+                    // #1670: `for await (const c of res.body)` — the stream
+                    // arrives as a bare `Member` (Any-typed). Recognise
+                    // `<obj>.body` on a Response/Request and `<ts>.readable` on
+                    // a TransformStream, mirroring `var_decl`'s native-instance
+                    // property mapping for typed-local binds.
+                    ast::Expr::Member(member) => {
+                        if let (ast::Expr::Ident(obj_ident), ast::MemberProp::Ident(prop_ident)) =
+                            (member.obj.as_ref(), &member.prop)
+                        {
+                            let prop = prop_ident.sym.as_ref();
+                            let class = ctx
+                                .lookup_native_instance(obj_ident.sym.as_ref())
+                                .map(|(_, c)| c);
+                            matches!(
+                                (prop, class),
+                                ("body", Some("Response"))
+                                    | ("body", Some("Request"))
+                                    | ("readable", Some("TransformStream"))
+                            )
+                        } else {
+                            false
+                        }
+                    }
+                    _ => false,
                 };
 
                 if is_readable_stream {


### PR DESCRIPTION
## #1670 — Web Streams: `for await` over `res.body`

Closes the residual Part 2 of #1670. Verified Part 1 (inline `res.body.locked` segfault) is **already fixed** on current `main` — the Web-Streams handle probe is now wired into the generic property-get path — so this PR addresses the remaining `for await` gap.

### Problem

```ts
const r = new Response('hello world')
for await (const chunk of r.body) { /* ... */ }   // iterated 0 times (Node: 1 chunk)
```

The ReadableStream async-iterator recognition (getReader/read drain, #1646) only matched `Ident` and `new ReadableStream(...)` iterables. A bare `Member` expression like `res.body` is Any-typed at the value level, so it fell through to the array-index desugar, read `.length` (0) on the numeric stream handle, and iterated zero times. (`const b = res.body; for await (const c of b)` already worked — the typed-local bind registers `b` as a `ReadableStream` native instance.)

### Fix

Recognise `<obj>.body` on a Response/Request and `<ts>.readable` on a TransformStream in the for-await iterable check, mirroring the native-instance property mapping `var_decl` already uses for typed-local binds. Applied in both for-await lowering paths (`stmt_loops` for top-level/loop statements and `body_stmt` for function bodies); the existing cast-peel covers the `(res.body as any)` idiom.

### Validation (perry == node, both `--no-auto-optimize` and auto-optimize)

```
p1a: true                  (res.body instanceof ReadableStream)
p1b: false                 (res.body.locked, inline)
p2: 1 hello world          (for await of res.body)          ← the fix
p2-as-any: 1 abc           (for await of (res.body as any))  ← the fix
p3-direct: 2 x|y           (for await of new ReadableStream) ← #1646 regression OK
p4-array: 6                (plain array for-of)              ← regression OK
```

`cargo fmt --all -- --check` clean; `cargo test -p perry-hir --lib` 100/100 pass.
