### PR TITLE
test(parity): stream — batch of 12 tier-9 tests (iter-100..102) (1 free pass, 11 #1532/#1545/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2551,5 +2551,71 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: unshift() during flowing mode — chunk not re-emitted in order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/from-iterable-of-buffers": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: ReadableStream.from(arrayOfBuffers) — chunk count or type wrong. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/method-typeof-function": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: some instance method reports wrong typeof (not 'function'). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/error-via-pipe": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: src.emit('error') during pipe — src or dst error tracking wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/flow/registration-order-emission": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: multi-'data' listeners — fire in wrong order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-iterator-throws": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(iter that throws on next) — 'error' event not emitted. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/some-async-rejection": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: some(asyncFn) — rejection in fn does not propagate. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/events/get-listeners-instance-method": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: listeners(event) — wrong array shape or count. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/transform-readable-cancel-propagates": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: TS readable.cancel — writable.write does not reject after. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/promises/finished-stream-already-ended": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: finished(alreadyEnded) — does not resolve immediately. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/error-emit-sync": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: emit('error') — listener does not fire synchronously. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/readable-property-shape": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: stream instance methods — some typeof not 'function' (or missing). Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/error-emit-sync.ts
+++ b/test-parity/node-suite/stream/events/error-emit-sync.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// emit('error', err) — listener fires synchronously.
+const r = new Readable({ read() {} });
+let fired = false;
+r.on("error", () => (fired = true));
+r.emit("error", new Error("manual-error"));
+console.log("fired synchronously:", fired);

--- a/test-parity/node-suite/stream/events/error-via-pipe.ts
+++ b/test-parity/node-suite/stream/events/error-via-pipe.ts
@@ -1,0 +1,19 @@
+import { Readable, PassThrough } from "node:stream";
+// emit('error') on a source while piped — destination receives the error
+// via Node's internal error propagation in pipeline (NOT just pipe).
+const src = new Readable({ read() {} });
+const dst = new PassThrough();
+let srcErr: string | null = null;
+let dstErr: string | null = null;
+src.on("error", (e) => (srcErr = e && e.message));
+dst.on("error", (e) => (dstErr = e && e.message));
+src.on("data", () => {});
+dst.on("data", () => {});
+src.pipe(dst);
+src.emit("error", new Error("manual-error"));
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("src err:", srcErr);
+    console.log("dst err:", dstErr);
+  });
+});

--- a/test-parity/node-suite/stream/events/get-listeners-instance-method.ts
+++ b/test-parity/node-suite/stream/events/get-listeners-instance-method.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// emitter.listeners(event) returns the array of registered listeners.
+const r = new Readable({ read() {} });
+const fn1 = () => {};
+const fn2 = () => {};
+r.on("custom", fn1);
+r.on("custom", fn2);
+const arr = r.listeners("custom");
+console.log("count:", arr.length);
+console.log("is array:", Array.isArray(arr));
+console.log("contains fn1:", arr.includes(fn1));
+console.log("contains fn2:", arr.includes(fn2));

--- a/test-parity/node-suite/stream/flow/registration-order-emission.ts
+++ b/test-parity/node-suite/stream/flow/registration-order-emission.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Multiple 'data' listeners fire in registration order for each chunk.
+const r = Readable.from(["x"]);
+const order: string[] = [];
+r.on("data", () => order.push("first"));
+r.on("data", () => order.push("second"));
+r.on("data", () => order.push("third"));
+r.on("end", () => console.log("order:", order.join(",")));

--- a/test-parity/node-suite/stream/iter-helpers/some-async-rejection.ts
+++ b/test-parity/node-suite/stream/iter-helpers/some-async-rejection.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// some(asyncFn) — if asyncFn rejects, the promise rejects.
+const r = Readable.from([1, 2, 3]);
+let errMsg: string | null = null;
+try {
+  await (r as any).some(async (_x: number) => {
+    throw new Error("some-fail");
+  });
+} catch (e: any) {
+  errMsg = e && e.message;
+}
+console.log("rejected with:", errMsg);

--- a/test-parity/node-suite/stream/promises/finished-stream-already-ended.ts
+++ b/test-parity/node-suite/stream/promises/finished-stream-already-ended.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
+// finished() on a stream that's already ended — resolves immediately.
+const r = Readable.from(["x"]);
+const collected: any[] = [];
+r.on("data", (c) => collected.push(c));
+await new Promise((resolve) => r.on("end", resolve));
+// Now the stream has ended
+let resolved = false;
+finished(r).then(() => (resolved = true));
+await new Promise((r) => setImmediate(r));
+console.log("finished resolved on already-ended:", resolved);

--- a/test-parity/node-suite/stream/readable/from-iterator-throws.ts
+++ b/test-parity/node-suite/stream/readable/from-iterator-throws.ts
@@ -1,0 +1,16 @@
+import { Readable } from "node:stream";
+// Iterator that throws on next() — Readable.from emits 'error'.
+const throwingIter = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        throw new Error("iter-fail");
+      },
+    };
+  },
+};
+const r = Readable.from(throwingIter as any);
+let errMsg: string | null = null;
+r.on("error", (e) => (errMsg = e && e.message));
+r.on("data", () => {});
+setImmediate(() => console.log("err:", errMsg));

--- a/test-parity/node-suite/stream/readable/method-typeof-function.ts
+++ b/test-parity/node-suite/stream/readable/method-typeof-function.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// All instance methods report typeof === "function" (recent #1642/#1643 fix).
+const r = new Readable({ read() {} });
+console.log("read:", typeof r.read);
+console.log("push:", typeof r.push);
+console.log("pipe:", typeof r.pipe);
+console.log("pause:", typeof r.pause);
+console.log("resume:", typeof r.resume);
+console.log("destroy:", typeof r.destroy);
+console.log("on:", typeof r.on);
+console.log("all function:", [r.read, r.push, r.pipe, r.pause, r.resume, r.destroy, r.on].every(f => typeof f === "function"));

--- a/test-parity/node-suite/stream/readable/readable-property-shape.ts
+++ b/test-parity/node-suite/stream/readable/readable-property-shape.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Stream instance should expose .pipe, .destroy, .read methods.
+const r = new Readable({ read() {} });
+const props = ["pipe", "destroy", "read", "pause", "resume", "unpipe", "wrap"];
+for (const p of props) {
+  console.log(`${p}:`, typeof (r as any)[p]);
+}
+console.log("all function:", props.every(p => typeof (r as any)[p] === "function"));

--- a/test-parity/node-suite/stream/web/cancel-after-close.ts
+++ b/test-parity/node-suite/stream/web/cancel-after-close.ts
@@ -1,0 +1,11 @@
+import { ReadableStream } from "node:stream/web";
+// cancel() after the stream has closed — resolves to undefined.
+const rs = new ReadableStream({ start(c) { c.close(); } });
+let result: any = "untouched";
+try {
+  result = await rs.cancel("after-close");
+} catch (e: any) {
+  result = "threw:" + e.name;
+}
+console.log("result:", result);
+console.log("is undefined:", result === undefined);

--- a/test-parity/node-suite/stream/web/from-iterable-of-buffers.ts
+++ b/test-parity/node-suite/stream/web/from-iterable-of-buffers.ts
@@ -1,0 +1,15 @@
+import { ReadableStream } from "node:stream/web";
+// ReadableStream.from(arrayOfBuffers) — each element becomes a chunk.
+const rs = (ReadableStream as any).from([
+  new Uint8Array([1, 2]),
+  new Uint8Array([3, 4]),
+]);
+const reader = rs.getReader();
+const out: any[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(value);
+}
+console.log("count:", out.length);
+console.log("first is typed:", out[0] && out[0].constructor && out[0].constructor.name);

--- a/test-parity/node-suite/stream/web/transform-readable-cancel-propagates.ts
+++ b/test-parity/node-suite/stream/web/transform-readable-cancel-propagates.ts
@@ -1,0 +1,13 @@
+import { TransformStream } from "node:stream/web";
+// Cancelling the readable side aborts the writable side.
+const ts = new TransformStream();
+const reader = ts.readable.getReader();
+await reader.cancel("downstream-stop");
+const writer = ts.writable.getWriter();
+let writeRejected = false;
+try {
+  await writer.write("x");
+} catch {
+  writeRejected = true;
+}
+console.log("write rejected after readable cancel:", writeRejected);


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-100..102)

**1 free pass + 11 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | cancel-after-close ✅, from-iterable-of-buffers, transform-readable-cancel-propagates | #1545 |
| Stream events / EE | error-via-pipe, get-listeners-instance-method, error-emit-sync | #1532 |
| Readable shape | method-typeof-function, from-iterator-throws, readable-property-shape, registration-order-emission | #1532 |
| Iter helpers | some-async-rejection | #1558 |
| Promises | finished-stream-already-ended | #1532 |

Free pass: `web/cancel-after-close` (cancel on closed stream resolves undefined).

All 11 failures tracked in `known_failures.json`.
