### PR TITLE
docs(CLAUDE.md): correct perry-jsruntime engine — V8 via deno_core, not QuickJS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ TypeScript (.ts) → Parse (SWC) → AST → Lower → HIR → Transform → Cod
 | **perry-runtime** | Runtime: value.rs, object.rs, array.rs, string.rs, gc.rs, arena.rs, thread.rs |
 | **perry-stdlib** | Node.js API support (mysql2, redis, fetch, fastify, ws, etc.) |
 | **perry-ui** / **perry-ui-macos** / **perry-ui-ios** / **perry-ui-tvos** | Native UI (AppKit/UIKit) |
-| **perry-jsruntime** | JavaScript interop via QuickJS |
+| **perry-jsruntime** | JavaScript interop via V8 (embedded through deno_core) |
 
 ## NaN-Boxing
 


### PR DESCRIPTION
## What

Corrects the architecture table: `perry-jsruntime` is documented as "JavaScript interop via QuickJS", but the crate actually embeds **V8 through `deno_core`** (`deno_core = "0.400"` in its `Cargo.toml`; `bridge/mod.rs` is a NaN-boxed-JSValue ↔ V8 value bridge).

## Why

The stale line caused confusion while planning the eval/`new Function` strategy (tracker #1677) — the runtime-fallback engine to reason about is V8, not QuickJS. Documentation-only; no code change.

## Notes

- Single-line change to `CLAUDE.md`.
- Left version bump + CHANGELOG entry for the maintainer to fold in at merge (avoids patch-version collisions with in-flight commits).
