### PR TITLE
test(parity): stream — batch of 12 tier-9/10 tests (iter-103..105) (3 free pass, 9 #1532/#1545/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2587,5 +2587,59 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Writable 'finish' / 'close' event order — wrong sequence. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/end-false-then-write": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe(dst,{end:false}) then manual dst.write — output order/count wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/from-single-promise": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: RS.from(Promise) — should throw TypeError (Promise not iterable), or accept and treat as 1-value (depends on Node). Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/once-static-promise": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: events.once(stream, 'end') Promise — args shape wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/pause-resume-event-order": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: multiple pause/resume cycles — event order wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipeline/async-fn-rejection-propagates": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline async-fn throwing — cb does not receive the error. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-array-many-items": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(50-item array) — count, sum or first/last value wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/filter-then-toarray": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: filter(fn).toArray() — chain produces wrong result. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/events/close-fires-on-destroy": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'close' event after destroy — fires 0 or 2+ times (should be exactly 1). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-async-iter-mixed-values": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(asyncGen yielding mixed types) — types lost or wrong. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/close-fires-on-destroy.ts
+++ b/test-parity/node-suite/stream/events/close-fires-on-destroy.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// 'close' fires after destroy(); fires exactly once.
+let count = 0;
+const r = new Readable({ read() {} });
+r.on("close", () => count++);
+r.destroy();
+setImmediate(() => {
+  setImmediate(() => console.log("close fires:", count));
+});

--- a/test-parity/node-suite/stream/events/once-static-promise.ts
+++ b/test-parity/node-suite/stream/events/once-static-promise.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+import { once } from "node:events";
+// events.once(stream, 'end') returns a Promise<args>.
+const r = Readable.from(["x"]);
+r.on("data", () => {});
+const args = await once(r, "end");
+console.log("args is array:", Array.isArray(args));
+console.log("args length:", (args as any[]).length);

--- a/test-parity/node-suite/stream/events/pause-resume-event-order.ts
+++ b/test-parity/node-suite/stream/events/pause-resume-event-order.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// Multiple pause()/resume() cycles fire the events in cycle order.
+const r = new Readable({ read() {} });
+const fires: string[] = [];
+r.on("pause", () => fires.push("P"));
+r.on("resume", () => fires.push("R"));
+r.on("data", () => {});
+r.pause();
+r.resume();
+r.pause();
+r.resume();
+console.log("cycle:", fires.join(""));

--- a/test-parity/node-suite/stream/iter-helpers/filter-then-toarray.ts
+++ b/test-parity/node-suite/stream/iter-helpers/filter-then-toarray.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// filter(fn).toArray() — chain filter then toArray.
+const r = Readable.from([1, 2, 3, 4, 5]);
+const result = await (r as any).filter((x: number) => x % 2 === 0).toArray();
+console.log("result:", result.join(","));
+console.log("is array:", Array.isArray(result));

--- a/test-parity/node-suite/stream/iter-helpers/take-then-foreach.ts
+++ b/test-parity/node-suite/stream/iter-helpers/take-then-foreach.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// take(N).forEach(fn) — chain take with forEach.
+const r = Readable.from([1, 2, 3, 4, 5]);
+const out: number[] = [];
+await (r as any).take(3).forEach((x: number) => { out.push(x); });
+console.log("out:", out.join(","));

--- a/test-parity/node-suite/stream/pipe/end-false-then-write.ts
+++ b/test-parity/node-suite/stream/pipe/end-false-then-write.ts
@@ -1,0 +1,14 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe(dst, {end:false}) — after src ends, dst is still writable.
+const r = Readable.from(["a"]);
+const dst = new PassThrough();
+const out: string[] = [];
+dst.on("data", (c) => out.push(String(c)));
+r.pipe(dst, { end: false });
+r.on("end", () => {
+  setImmediate(() => {
+    dst.write("manual");
+    dst.end();
+  });
+});
+dst.on("end", () => console.log("out:", out.join(",")));

--- a/test-parity/node-suite/stream/pipeline/async-fn-rejection-propagates.ts
+++ b/test-parity/node-suite/stream/pipeline/async-fn-rejection-propagates.ts
@@ -1,0 +1,14 @@
+import { Readable, pipeline } from "node:stream";
+// async-fn sink that throws — pipeline cb receives the error.
+const src = Readable.from(["x"]);
+let errMsg: string | null = null;
+pipeline(
+  src,
+  async function (_s: AsyncIterable<any>) {
+    throw new Error("sink-fn-fail");
+  },
+  (err: any) => {
+    errMsg = err && err.message;
+    console.log("err:", errMsg);
+  },
+);

--- a/test-parity/node-suite/stream/readable/from-array-many-items.ts
+++ b/test-parity/node-suite/stream/readable/from-array-many-items.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Readable.from with a moderately large array — iteration counts correct.
+const arr = Array.from({ length: 50 }, (_, i) => i);
+const r = Readable.from(arr);
+const out: number[] = [];
+for await (const v of r) out.push(v as number);
+console.log("count:", out.length);
+console.log("first:", out[0], "last:", out[out.length - 1]);
+console.log("sum:", out.reduce((a, b) => a + b, 0));

--- a/test-parity/node-suite/stream/readable/from-async-iter-mixed-values.ts
+++ b/test-parity/node-suite/stream/readable/from-async-iter-mixed-values.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// Readable.from(asyncGen yielding mixed value types).
+async function* gen() {
+  yield 1;
+  yield "two";
+  yield { three: 3 };
+  yield [4, 5];
+}
+const r = Readable.from(gen());
+const out: any[] = [];
+for await (const v of r) out.push(typeof v);
+console.log("types:", out.join(","));

--- a/test-parity/node-suite/stream/web/from-plain-array.ts
+++ b/test-parity/node-suite/stream/web/from-plain-array.ts
@@ -1,0 +1,11 @@
+import { ReadableStream } from "node:stream/web";
+// ReadableStream.from(plainArray) — array is iterable, yields each element.
+const rs = (ReadableStream as any).from([10, 20, 30]);
+const reader = rs.getReader();
+const out: any[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(value);
+}
+console.log("collected:", out.join(","));

--- a/test-parity/node-suite/stream/web/from-single-promise.ts
+++ b/test-parity/node-suite/stream/web/from-single-promise.ts
@@ -1,0 +1,13 @@
+import { ReadableStream } from "node:stream/web";
+// ReadableStream.from(promise) — a Promise is NOT iterable, so this should
+// either throw TypeError or treat it as a thenable (depends on Node version).
+let result: any = null;
+try {
+  const rs = (ReadableStream as any).from(Promise.resolve("value"));
+  const reader = rs.getReader();
+  const first = await reader.read();
+  result = { value: first.value, done: first.done };
+} catch (e: any) {
+  result = { threw: e && e.name };
+}
+console.log(JSON.stringify(result));

--- a/test-parity/node-suite/stream/web/readable-stream-bytes-pull.ts
+++ b/test-parity/node-suite/stream/web/readable-stream-bytes-pull.ts
@@ -1,0 +1,20 @@
+import { ReadableStream } from "node:stream/web";
+// type:'bytes' ReadableStream with pull() that enqueues a typed-array chunk.
+let pulled = 0;
+const rs = new ReadableStream({
+  type: "bytes",
+  pull(c) {
+    pulled++;
+    if (pulled <= 2) c.enqueue(new Uint8Array([pulled]));
+    else c.close();
+  },
+} as any);
+const reader = rs.getReader();
+const out: number[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  if (value && (value as Uint8Array).length > 0) out.push((value as Uint8Array)[0]);
+}
+console.log("pulled:", pulled);
+console.log("bytes:", out.join(","));


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-103..105)

**3 free passes + 9 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | from-plain-array ✅, readable-stream-bytes-pull ✅, from-single-promise | #1545 |
| Pipe / pipeline | end-false-then-write, async-fn-rejection-propagates | #1532 |
| Stream events | once-static-promise, pause-resume-event-order, close-fires-on-destroy | #1532 |
| Readable shape | from-array-many-items, from-async-iter-mixed-values | #1532 |
| Iter helpers | take-then-foreach ✅, filter-then-toarray | #1558 |

Free passes:
- `web/from-plain-array` (RS.from([1,2,3]))
- `web/readable-stream-bytes-pull` (type:'bytes' with pull() works)
- `iter-helpers/take-then-foreach` (chain works)

All 9 failures tracked in `known_failures.json`.
