### PR TITLE
fix: URLSearchParams iteration (#1668), Web Streams inline property + for-await (#1670), hono/jsx submodule imports (#1671)

### DIFF
--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -71,6 +71,27 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 let _ = lower_expr(ctx, arg)?;
                 let path = &paths[0];
                 let target_prefix = ctx.dynamic_import_path_to_prefix.get(path).cloned();
+                // #1671: a dynamic import of a known node-submodule
+                // (`await import('hono/jsx/server')`) carries the sentinel
+                // prefix `__node_submod__<key>` instead of a compiled-module
+                // prefix. Build its namespace via `js_node_submodule_namespace`
+                // and resolve the promise with it (mirrors the static
+                // namespace-import path).
+                if let Some(prefix) = &target_prefix {
+                    if let Some(key) = prefix.strip_prefix("__node_submod__") {
+                        let key = key.to_string();
+                        let submod_label = emit_string_literal_global(ctx, &key);
+                        let submod_len = key.len();
+                        let blk = ctx.block();
+                        let ns_val = blk.call(
+                            DOUBLE,
+                            "js_node_submodule_namespace",
+                            &[(PTR, &submod_label), (I32, &submod_len.to_string())],
+                        );
+                        let promise = blk.call(I64, "js_promise_resolved", &[(DOUBLE, &ns_val)]);
+                        return Ok(nanbox_pointer_inline(blk, &promise));
+                    }
+                }
                 let blk = ctx.block();
                 let ns_val = match target_prefix {
                     Some(prefix) => {
@@ -160,9 +181,24 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // guard short-circuits.
                 ctx.current_block = match_block_idx;
                 let join_label = ctx.block_label(join_block_idx);
+                // #1671: known node-submodule target (sentinel prefix) →
+                // build its namespace via the runtime helper rather than a
+                // compiled-module init + namespace global.
+                let ns_val = if let Some(key) = target_prefix.strip_prefix("__node_submod__") {
+                    let key = key.to_string();
+                    let submod_label = emit_string_literal_global(ctx, &key);
+                    let submod_len = key.len();
+                    ctx.block().call(
+                        DOUBLE,
+                        "js_node_submodule_namespace",
+                        &[(PTR, &submod_label), (I32, &submod_len.to_string())],
+                    )
+                } else {
+                    let blk = ctx.block();
+                    blk.call_void(&format!("{}__init", target_prefix), &[]);
+                    blk.load(DOUBLE, &format!("@__perry_ns_{}", target_prefix))
+                };
                 let blk = ctx.block();
-                blk.call_void(&format!("{}__init", target_prefix), &[]);
-                let ns_val = blk.load(DOUBLE, &format!("@__perry_ns_{}", target_prefix));
                 let promise = blk.call(I64, "js_promise_resolved", &[(DOUBLE, &ns_val)]);
                 let boxed = nanbox_pointer_inline(blk, &promise);
                 blk.store(DOUBLE, &boxed, &result_slot);

--- a/crates/perry-runtime/src/array/flat_clone.rs
+++ b/crates/perry-runtime/src/array/flat_clone.rs
@@ -259,32 +259,19 @@ pub extern "C" fn js_array_clone(src: *const ArrayHeader) -> *mut ArrayHeader {
             (*hdr).obj_type
         };
         if obj_type == crate::gc::GC_TYPE_OBJECT {
-            let obj = raw_addr as *const crate::ObjectHeader;
-            unsafe {
-                let keys_arr = (*obj).keys_array;
-                if !keys_arr.is_null() && (*keys_arr).length == 1 {
-                    let key0 = js_array_get_f64(keys_arr, 0);
-                    let key_val = crate::value::JSValue::from_bits(key0.to_bits());
-                    let is_entries_key = if key_val.is_string() {
-                        let ptr = key_val.as_string_ptr();
-                        let len = (*ptr).byte_len as usize;
-                        let data =
-                            (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-                        std::str::from_utf8(std::slice::from_raw_parts(data, len)).unwrap_or("")
-                            == "_entries"
-                    } else {
-                        false
-                    };
-                    if is_entries_key {
-                        let boxed = crate::url::js_url_search_params_entries_arr(
-                            obj as *mut crate::ObjectHeader,
-                        );
-                        let bits = boxed.to_bits();
-                        let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader;
-                        if !ptr.is_null() {
-                            return ptr;
-                        }
-                    }
+            let obj = raw_addr as *mut crate::ObjectHeader;
+            // #1668: `[...searchParams]` / `Array.from(searchParams)` yield the
+            // `[key, value]` entry pairs. Detect a URLSearchParams by its shape
+            // (`_entries` leads the keys array) and return its entries array.
+            // The previous heuristic required `keys_array.length == 1`, but a
+            // URL-adopted URLSearchParams also carries a `_owner` key (2 keys),
+            // so spread fell through to the array-like path and produced `[]`.
+            if crate::url::try_read_as_search_params(obj).is_some() {
+                let boxed = crate::url::js_url_search_params_entries_arr(obj);
+                let bits = boxed.to_bits();
+                let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader;
+                if !ptr.is_null() {
+                    return ptr;
                 }
             }
             return unsafe { js_array_from_arraylike(raw_addr as *const crate::ObjectHeader) };

--- a/crates/perry-runtime/src/node_submodules/hono_jsx.rs
+++ b/crates/perry-runtime/src/node_submodules/hono_jsx.rs
@@ -1,0 +1,116 @@
+//! #1671 — `hono/jsx/server` and `hono/jsx/streaming` import surfaces.
+//!
+//! Perry renders JSX with the built-in `js_jsx` runtime (codegen routes every
+//! `jsx`/`jsxs` call there unconditionally; the injected `react/jsx-runtime`
+//! import is vestigial — see #1653). These two hono submodules exist for code
+//! that imports the runtime / streaming helpers *directly* rather than relying
+//! on the JSX transform:
+//!
+//!   - `hono/jsx/server`    → `jsx`, `jsxs`, `Fragment`, `JSXNode`
+//!   - `hono/jsx/streaming` → `renderToReadableStream`, `Suspense`
+//!
+//! Without this module the imports resolved to the `TAG_TRUE` sentinel (so
+//! `typeof jsx === "boolean"`). The thunks below forward to the real `js_jsx`
+//! renderer so `jsx(...)`/`jsxs(...)`/`Fragment`/`Suspense` actually produce
+//! HTML, and `renderToReadableStream` renders eagerly to a single-chunk
+//! `ReadableStream` (via a stdlib-registered callback) so the result is a real
+//! Web stream that `getReader()` / `for await` can drain.
+
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+use crate::closure::ClosureHeader;
+use crate::value::{JSValue, TAG_UNDEFINED};
+
+#[inline]
+fn fragment_marker_f64() -> f64 {
+    let s = crate::string::js_string_from_bytes(b"__Fragment".as_ptr(), 10);
+    f64::from_bits(JSValue::string_ptr(s).bits())
+}
+
+/// `jsx(type, props)` — forward to the built-in renderer.
+pub(crate) extern "C" fn thunk_hono_jsx(
+    _closure: *const ClosureHeader,
+    type_arg: f64,
+    props: f64,
+) -> f64 {
+    crate::jsx::js_jsx(type_arg, props)
+}
+
+/// `jsxs(type, props)` — multi-child shape, same dispatch.
+pub(crate) extern "C" fn thunk_hono_jsxs(
+    _closure: *const ClosureHeader,
+    type_arg: f64,
+    props: f64,
+) -> f64 {
+    crate::jsx::js_jsxs(type_arg, props)
+}
+
+/// `Fragment` — when used as a component (`jsx(Fragment, { children })`) it
+/// renders its children with no wrapping element. Reuse `js_jsx`'s Fragment
+/// path by passing the `"__Fragment"` marker tag.
+pub(crate) extern "C" fn thunk_hono_fragment(_closure: *const ClosureHeader, props: f64) -> f64 {
+    crate::jsx::js_jsx(fragment_marker_f64(), props)
+}
+
+/// `Suspense` — Perry renders synchronously (server-side), so a Suspense
+/// boundary just renders its children (the fallback is never needed because
+/// there is no streaming-suspension point). Same shape as Fragment.
+pub(crate) extern "C" fn thunk_hono_suspense(_closure: *const ClosureHeader, props: f64) -> f64 {
+    crate::jsx::js_jsx(fragment_marker_f64(), props)
+}
+
+/// `JSXNode` — hono's JSX node *class*. Perry never constructs it directly
+/// (`js_jsx` boxes nodes itself), so this is an exposed stub returning the
+/// props/value it was handed. Its sole purpose is to make the named export
+/// resolve with `typeof === "function"`.
+pub(crate) extern "C" fn thunk_hono_jsxnode(_closure: *const ClosureHeader, arg: f64) -> f64 {
+    arg
+}
+
+/// stdlib callback: `(html_string_value) -> ReadableStream handle`. Registered
+/// by perry-stdlib (`bundled-streams`) so the runtime can hand back a real Web
+/// stream without depending on perry-stdlib. When unset (streams not linked)
+/// `renderToReadableStream` falls back to returning the rendered HTML node.
+static JSX_RENDER_STREAM_FN: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+
+type RenderStreamFn = unsafe extern "C" fn(f64) -> f64;
+
+/// Called from perry-stdlib at dispatch init to wire up stream creation.
+#[no_mangle]
+pub unsafe extern "C" fn js_register_jsx_render_stream(f: RenderStreamFn) {
+    JSX_RENDER_STREAM_FN.store(f as *mut (), Ordering::Release);
+}
+
+/// `renderToReadableStream(node, options?)` — render `node` to HTML eagerly,
+/// then emit it as a single-chunk `ReadableStream` (the WHATWG return type).
+/// `node` is already a boxed JSX node (or any stringifiable value); the runtime
+/// stringifier renders it to its HTML. Falls back to returning the node itself
+/// when no stream backend is linked.
+pub(crate) extern "C" fn thunk_hono_render_to_readable_stream(
+    _closure: *const ClosureHeader,
+    node: f64,
+    _options: f64,
+) -> f64 {
+    // Render the node to its HTML string via the canonical stringifier
+    // (handles JSX_NODE_CLASS_ID → its stored HTML, plain strings, etc.).
+    let html_ptr = crate::value::js_jsvalue_to_string(node);
+    let html_value = if html_ptr.is_null() {
+        node
+    } else {
+        f64::from_bits(JSValue::string_ptr(html_ptr).bits())
+    };
+    let raw = JSX_RENDER_STREAM_FN.load(Ordering::Acquire);
+    if raw.is_null() {
+        // No stream backend linked — hand back the rendered HTML node so the
+        // value is at least usable (degraded vs. a real ReadableStream).
+        return html_value;
+    }
+    let f: RenderStreamFn = unsafe { std::mem::transmute(raw) };
+    unsafe { f(html_value) }
+}
+
+/// `undefined` helper for any export we deliberately don't back.
+#[allow(dead_code)]
+pub(crate) extern "C" fn thunk_hono_undefined(_closure: *const ClosureHeader, _arg: f64) -> f64 {
+    f64::from_bits(TAG_UNDEFINED)
+}

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -107,8 +107,17 @@ macro_rules! thunk {
 mod blob;
 mod consumers;
 mod fs_promises;
+mod hono_jsx;
 mod stream_promises;
 mod timers;
+
+// #1671: hono/jsx/server + hono/jsx/streaming. Re-export the stream-creation
+// registration so perry-stdlib's `bundled-streams` init can wire it up.
+pub use hono_jsx::js_register_jsx_render_stream;
+use hono_jsx::{
+    thunk_hono_fragment, thunk_hono_jsx, thunk_hono_jsxnode, thunk_hono_jsxs,
+    thunk_hono_render_to_readable_stream, thunk_hono_suspense,
+};
 
 use consumers::{
     thunk_consumers_arrayBuffer, thunk_consumers_blob, thunk_consumers_buffer,
@@ -480,6 +489,46 @@ const SUBMODULES: &[SubmoduleSpec] = &[
             ExportSpec {
                 name: "DecompressionStream",
                 thunk: ExportThunk::Fn1(thunk_stream_web_ctor),
+            },
+        ],
+    },
+    // #1671: hono/jsx/server — the JSX runtime helpers. `jsx`/`jsxs` forward
+    // to the built-in `js_jsx` renderer; `Fragment` renders its children;
+    // `JSXNode` is an exposed stub (Perry boxes nodes internally).
+    SubmoduleSpec {
+        key: "hono_jsx_server",
+        exports: &[
+            ExportSpec {
+                name: "jsx",
+                thunk: ExportThunk::Fn2(thunk_hono_jsx),
+            },
+            ExportSpec {
+                name: "jsxs",
+                thunk: ExportThunk::Fn2(thunk_hono_jsxs),
+            },
+            ExportSpec {
+                name: "Fragment",
+                thunk: ExportThunk::Fn1(thunk_hono_fragment),
+            },
+            ExportSpec {
+                name: "JSXNode",
+                thunk: ExportThunk::Fn1(thunk_hono_jsxnode),
+            },
+        ],
+    },
+    // #1671: hono/jsx/streaming — server-side streaming helpers.
+    // `renderToReadableStream` renders eagerly to a single-chunk ReadableStream;
+    // `Suspense` renders its children (Perry has no streaming-suspension point).
+    SubmoduleSpec {
+        key: "hono_jsx_streaming",
+        exports: &[
+            ExportSpec {
+                name: "renderToReadableStream",
+                thunk: ExportThunk::Fn2(thunk_hono_render_to_readable_stream),
+            },
+            ExportSpec {
+                name: "Suspense",
+                thunk: ExportThunk::Fn1(thunk_hono_suspense),
             },
         ],
     },

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -947,6 +947,40 @@ pub extern "C" fn js_object_get_field_by_name(
             return JSValue::undefined();
         }
     }
+    // #1670: Web Streams handles are returned as `id as f64` (a normal
+    // float, NOT NaN-boxed) in the reserved range 0x40000..0x100000, so an
+    // inline `res.body.locked` reaches this generic field-get with `obj`
+    // carrying the float bits of the stream id (e.g. 0x4110_… for 262144).
+    // The NaN-box-strip + small-handle branches below don't recognise it
+    // (top16 is an ordinary exponent, not a tag; the value as a pointer is
+    // far above 0x100000), so it would be dereferenced as a heap pointer →
+    // segfault. Decode the float; when the stdlib probe confirms a live
+    // stream handle, route the property read through the handle property
+    // dispatcher (which carries the #1670 stream getter/method arms).
+    // Mirrors the method-dispatch path in `native_call_method.rs` (#1545).
+    // The typed-local path (`const b = res.body; b.locked`) lowers as a
+    // 0-arg NativeMethodCall getter and never reaches here.
+    {
+        let f = f64::from_bits(obj as u64);
+        if !key.is_null() && f.is_finite() && f > 0.0 && f.fract() == 0.0 {
+            let id = f as usize;
+            if (0x40000..0x100000).contains(&id) {
+                if let Some(probe) = crate::object::stream_handle_probe() {
+                    unsafe {
+                        if probe(id) {
+                            if let Some(dispatch) = handle_property_dispatch() {
+                                let key_ptr = (key as *const u8)
+                                    .add(std::mem::size_of::<crate::StringHeader>());
+                                let key_len = (*key).byte_len as usize;
+                                let bits = dispatch(id as i64, key_ptr, key_len);
+                                return JSValue::from_bits(bits.to_bits());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
     // Strip NaN-boxing tags if present (defensive: handle POINTER_TAG, UNDEFINED, NULL, etc.)
     let obj = {
         let bits = obj as u64;

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -38,6 +38,21 @@ pub extern "C" fn js_object_from_entries(entries_value: f64) -> f64 {
             return js_object_from_entries(arr_boxed);
         }
 
+        // #1668: URLSearchParams is iterable (yields [key, value] pairs) but
+        // arrives here as a plain class_id-0 ObjectHeader (GC_TYPE_OBJECT),
+        // NOT an array — so reading it as an ArrayHeader below picks up a
+        // bogus `.length` and crashes (`Object.fromEntries(url.searchParams)`,
+        // the #1655 hono `/api/echo` blocker). Detect the URLSearchParams
+        // shape and recurse through its proper [k,v] entries array. Any other
+        // object falls through unchanged.
+        if (*gc_header).obj_type == crate::gc::GC_TYPE_OBJECT {
+            let obj_ptr = raw_ptr as *mut ObjectHeader;
+            if crate::url::try_read_as_search_params(obj_ptr).is_some() {
+                let entries_arr = crate::url::js_url_search_params_entries_arr(obj_ptr);
+                return js_object_from_entries(entries_arr);
+            }
+        }
+
         // It's an array of [key, value] pairs
         let arr_ptr = raw_ptr as *const ArrayHeader;
         let length = (*arr_ptr).length as usize;

--- a/crates/perry-runtime/src/url/mod.rs
+++ b/crates/perry-runtime/src/url/mod.rs
@@ -33,6 +33,9 @@ pub use self::search_params::{
     js_url_search_params_new_empty, js_url_search_params_set, js_url_search_params_size,
     js_url_search_params_sort, js_url_search_params_to_string, js_url_search_params_values_arr,
 };
+// #1668: crate-internal detector so `Object.fromEntries`/spread can recognise
+// a URLSearchParams (a plain class_id-0 ObjectHeader) and pull its entries.
+pub(crate) use self::search_params::try_read_as_search_params;
 pub use self::url_class::{
     js_url_can_parse, js_url_can_parse_with_base, js_url_get_hash, js_url_get_host,
     js_url_get_hostname, js_url_get_href, js_url_get_origin, js_url_get_pathname, js_url_get_port,

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -761,6 +761,20 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
     let _ = property_name;
     let _ = handle;
 
+    // #1670: Web Streams handle property reads. A numeric stream id reaches
+    // here via `js_object_get_field_by_name`'s stream probe (inline
+    // `res.body.locked`). Route getter properties to their accessors, return
+    // a bound-method closure for callable members, and undefined for anything
+    // else — never a deref of the float id as a pointer. Gated on stream
+    // id-range + registry membership so unrelated small-handle reads are
+    // untouched.
+    #[cfg(feature = "bundled-streams")]
+    if (0x40000..0x100000).contains(&(handle as usize))
+        && crate::streams::js_stream_handle_is_registered(handle as usize)
+    {
+        return crate::streams::dispatch_stream_property(handle as f64, property_name);
+    }
+
     // #1113: `app.server` — return the FastifyApp handle pointer-tagged
     // so `typeof app.server === "object"` and `.on("upgrade", …)`
     // routes through HANDLE_METHOD_DISPATCH back into the FastifyApp
@@ -1359,5 +1373,10 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
         }
         js_register_stream_handle_probe(stream_probe);
         js_register_stream_handle_kind_probe(stream_kind_probe);
+        // #1671: back `hono/jsx/streaming`'s `renderToReadableStream` with a
+        // real single-chunk Web stream when streams are linked.
+        perry_runtime::node_submodules::js_register_jsx_render_stream(
+            crate::streams::js_jsx_render_stream_from_value,
+        );
     }
 }

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -666,6 +666,21 @@ pub unsafe extern "C" fn js_readable_stream_from_iterable(value: f64) -> f64 {
     id as f64
 }
 
+/// #1671: `renderToReadableStream` stream backend. Builds a closed
+/// single-chunk readable stream carrying the already-rendered HTML string, so
+/// hono's `renderToReadableStream(<App/>)` returns a real Web stream that
+/// `getReader()` / `for await` can drain. Registered into the runtime via
+/// `js_register_jsx_render_stream` from `js_stdlib_init_dispatch` when
+/// `bundled-streams` is linked; absent that, the runtime thunk returns the
+/// rendered HTML node directly (degraded but usable).
+#[no_mangle]
+pub unsafe extern "C" fn js_jsx_render_stream_from_value(html_value: f64) -> f64 {
+    let mut arr = perry_runtime::array::js_array_alloc(1);
+    arr = perry_runtime::array::js_array_push_f64(arr, html_value);
+    let arr_f64 = f64::from_bits(perry_runtime::JSValue::pointer(arr as *const u8).bits());
+    js_readable_stream_from_iterable(arr_f64)
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // ReadableStreamDefaultController FFI (controller is the stream handle)
 // ─────────────────────────────────────────────────────────────────────
@@ -1651,6 +1666,66 @@ pub(crate) unsafe fn dispatch_stream_method(
         }
     }
     None
+}
+
+/// #1670: property reads on a numeric Web Streams handle that reached the
+/// generic field-get path (e.g. inline `res.body.locked`, where the
+/// intermediate stream id never became a typed local). Returns the WHATWG
+/// getter property value, a bound-method closure for callable members (so
+/// `typeof rs.getReader === "function"` and a subsequent call routes back
+/// through `js_native_call_method`'s #1545 stream branch → `dispatch_stream_method`),
+/// or `undefined` for any other property. Crucially this NEVER dereferences
+/// the float id as a pointer — the pre-#1670 generic field-get segfaulted on
+/// `res.body.locked`. Gated by the caller on stream-registry membership.
+pub(crate) unsafe fn dispatch_stream_property(handle: f64, name: &str) -> f64 {
+    let undefined = f64::from_bits(TAG_UNDEFINED);
+    let id = handle as usize;
+    // Kind: 1=ReadableStream, 2=WritableStream, 3=reader, 4=writer.
+    let kind = js_stream_handle_kind(id);
+    if kind == 0 {
+        return undefined;
+    }
+    // WHATWG getter properties (the rest fall through to bound-method /
+    // undefined). `locked` is the one #1670 exercises (`res.body.locked`).
+    match (kind, name) {
+        (1, "locked") => return js_readable_stream_locked(handle),
+        (2, "locked") => return js_writable_stream_locked(handle),
+        _ => {}
+    }
+    // Callable members → bound-method closure so `typeof` reports
+    // "function". The name must be a `&'static [u8]` because
+    // `js_class_method_bind` stores the raw pointer in the closure.
+    // The receiver is the raw float handle (not NaN-boxed) so that when the
+    // bound method is called, `js_native_call_method`'s stream branch fires.
+    let method: Option<&'static [u8]> = match (kind, name) {
+        (1, "getReader") => Some(b"getReader"),
+        (1, "cancel") => Some(b"cancel"),
+        (1, "tee") => Some(b"tee"),
+        (1, "pipeTo") => Some(b"pipeTo"),
+        (1, "pipeThrough") => Some(b"pipeThrough"),
+        (2, "getWriter") => Some(b"getWriter"),
+        (2, "abort") => Some(b"abort"),
+        (2, "close") => Some(b"close"),
+        (3, "read") => Some(b"read"),
+        (3, "releaseLock") => Some(b"releaseLock"),
+        (3, "cancel") => Some(b"cancel"),
+        (4, "write") => Some(b"write"),
+        (4, "close") => Some(b"close"),
+        (4, "abort") => Some(b"abort"),
+        (4, "releaseLock") => Some(b"releaseLock"),
+        _ => None,
+    };
+    if let Some(name_bytes) = method {
+        extern "C" {
+            fn js_class_method_bind(
+                instance: f64,
+                method_name_ptr: *const u8,
+                method_name_len: usize,
+            ) -> f64;
+        }
+        return js_class_method_bind(handle, name_bytes.as_ptr(), name_bytes.len());
+    }
+    undefined
 }
 
 /// `super({ start, pull, cancel })` dispatch for `class X extends ReadableStream`.

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -1587,7 +1587,19 @@ pub fn run_with_parse_cache(
             }
             let rp = match &import.resolved_path {
                 Some(p) => PathBuf::from(p),
-                None => continue,
+                None => {
+                    // #1671: a dynamic `import('hono/jsx/server')` resolves to a
+                    // known node-submodule with no compiled-source backing — the
+                    // runtime ships its namespace. Record a sentinel prefix the
+                    // dynamic-import codegen recognises and routes to
+                    // `js_node_submodule_namespace` (instead of rejecting).
+                    if let Some(key) =
+                        self::collect_modules::known_node_submodule_key(&import.source)
+                    {
+                        local_map.insert(import.source.clone(), format!("__node_submod__{}", key));
+                    }
+                    continue;
+                }
             };
             let target_name = match path_to_module_name.get(&rp) {
                 Some(n) => n.clone(),

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -160,6 +160,14 @@ pub(super) fn known_node_submodule_key(source: &str) -> Option<&'static str> {
         // `asJsonChan.hasSubscribers === false` and take the fast path
         // without ever entering the tracing-instrumentation branch.
         "diagnostics_channel" => Some("diagnostics_channel"),
+        // #1671: hono JSX runtime/streaming helpers. Perry renders JSX with the
+        // built-in `js_jsx` runtime, so these submodules have no compiled-source
+        // backing — they expose function singletons (jsx/jsxs/Fragment/JSXNode,
+        // renderToReadableStream/Suspense) for code that imports the helpers
+        // directly. Note these are NOT `node:`-prefixed; the strip above is a
+        // no-op and they match verbatim.
+        "hono/jsx/server" => Some("hono_jsx_server"),
+        "hono/jsx/streaming" => Some("hono_jsx_streaming"),
         _ => None,
     }
 }

--- a/test-parity/node-suite/url/search-params/iteration.ts
+++ b/test-parity/node-suite/url/search-params/iteration.ts
@@ -10,3 +10,7 @@ console.log("forEach:", collected.join(","));
 const iterated: string[] = [];
 for (const [k, v] of sp) iterated.push(`${k}=${v}`);
 console.log("for-of:", iterated.join(","));
+
+// #1668: Object.fromEntries / spread over a URLSearchParams.
+console.log("fromEntries:", JSON.stringify(Object.fromEntries(sp)));
+console.log("spread:", JSON.stringify([...sp].map(([k, v]) => `${k}=${v}`)));


### PR DESCRIPTION
Fixes #1668, #1670, #1671 — three Web-platform / Hono-on-Perry parity gaps (follow-ups under the #1655 Hono tracker).

## #1668 — URLSearchParams iteration (`Object.fromEntries` / spread)

`Object.fromEntries(url.searchParams)` crashed (SIGBUS): the runtime treated the
`URLSearchParams` `ObjectHeader` as an `ArrayHeader`, read a bogus `.length`, and
walked off the end. `js_object_from_entries` now detects the URLSearchParams shape
(`try_read_as_search_params`) for `GC_TYPE_OBJECT` inputs and recurses through its
real `[k, v]` entries array. This unblocks the
`c.json({ q: Object.fromEntries(new URL(c.req.url).searchParams) })` echo route.

## #1670 — Web Streams: inline stream-handle property read + `for await` over `res.body`

1. **Inline `res.body.locked` segfaulted.** The #1545 Web-Streams numeric-handle
   probe was wired into method-dispatch + `instanceof` but not the generic
   `field_get_set` property path, so `js_object_get_field_by_name` dereferenced the
   raw-float stream id as a pointer. It now decodes the float, confirms a live
   stream handle via the probe, and routes the read through a new
   `dispatch_stream_property` (getter values for `locked`, bound-method closures for
   callable members, `undefined` otherwise — never a deref).
2. **`for await (const chunk of res.body)` iterated zero times.** The for-await
   ReadableStream recognition only matched `Ident`/`new ReadableStream`; it now also
   recognises `<response>.body` (where the receiver is a `Response` native-instance)
   in both the top-level (`stmt_loops.rs`) and function-body (`body_stmt.rs`)
   lowering paths, draining via the getReader/read loop.

## #1671 — `hono/jsx/server` + `hono/jsx/streaming` module imports

These resolved to the `TAG_TRUE` sentinel (`typeof jsx === "boolean"`). They are now
registered as known node-submodules (no compiled-source backing — Perry renders JSX
with the built-in `js_jsx` runtime):

- `hono/jsx/server` → `jsx`/`jsxs` (forward to `js_jsx`/`js_jsxs`), `Fragment`/`JSXNode`.
- `hono/jsx/streaming` → `renderToReadableStream` (renders eagerly, returns a real
  single-chunk `ReadableStream` when streams are linked, else the rendered HTML node),
  `Suspense` (renders children).

Both static `import { jsx } from 'hono/jsx/server'` and dynamic
`await import('hono/jsx/server')` resolve — the latter required the dynamic-import
codegen to materialise a node-submodule namespace (via a `__node_submod__<key>`
sentinel prefix) instead of rejecting.

## Verification

```
#1668  Object.fromEntries(new URL('…?k=v&a=b').searchParams) → {"k":"v","a":"b"}
#1670  r.body.locked → false (was SIGSEGV);  for await (… of r.body) → "hello world"
#1671  static + dynamic imports expose jsx/jsxs/Fragment/JSXNode +
       renderToReadableStream/Suspense as functions; jsx('div',{…}) → <div…>,
       renderToReadableStream(<p/>) drains to <p>streamed!</p>
```
