### PR TITLE
test(parity): stream — batch of 12 tier-10 tests (iter-109..111) (4 free pass, 8 #1532/#1558)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2641,5 +2641,53 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Readable.from(asyncGen yielding mixed types) — types lost or wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/set-max-listeners-zero": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: setMaxListeners(0) — max not 0 (unlimited) per Node. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/three-stage-mid-error": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline 3-stage mid-error — src/sink destroy flags or err wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/destroyed-during-data-flow": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy() inside 'data' listener — emits wrong data count. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-array-of-promises": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from([P1, P2, P3]) — does not await each Promise. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/flat-map-async-gen": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: flatMap(asyncGenFn) — multi-yield per input not flattened. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/events/error-listener-once-cleanup": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: once('error', fn) — listener not auto-removed after fire. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-rejected-promise-in-array": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(array with one Promise.reject) — error not emitted at the right point. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/r-t-w-end-to-end": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: simple R→T→W e2e pipe — received chunks wrong (transform/uppercase not applied). Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/error-listener-once-cleanup.ts
+++ b/test-parity/node-suite/stream/events/error-listener-once-cleanup.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// once('error', fn) — listener auto-removed even if error fires.
+const r = new Readable({ read() {} });
+let count = 0;
+r.once("error", () => count++);
+r.emit("error", new Error("first"));
+console.log("after first:", count);
+console.log("listener count:", r.listenerCount("error"));

--- a/test-parity/node-suite/stream/events/listener-count-fresh.ts
+++ b/test-parity/node-suite/stream/events/listener-count-fresh.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// A fresh Readable: listenerCount('data') is 0; listenerCount('error') is 0.
+const r = new Readable({ read() {} });
+console.log("data:", r.listenerCount("data"));
+console.log("error:", r.listenerCount("error"));
+console.log("end:", r.listenerCount("end"));
+console.log("readable:", r.listenerCount("readable"));
+console.log("all zero:",
+  r.listenerCount("data") === 0 &&
+  r.listenerCount("error") === 0 &&
+  r.listenerCount("end") === 0);

--- a/test-parity/node-suite/stream/events/set-max-listeners-zero.ts
+++ b/test-parity/node-suite/stream/events/set-max-listeners-zero.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// setMaxListeners(0) — 0 means unlimited; getMaxListeners returns 0.
+const r = new Readable({ read() {} });
+r.setMaxListeners(0);
+console.log("max:", r.getMaxListeners());
+console.log("is 0 (unlimited):", r.getMaxListeners() === 0);
+// Attach 30 listeners — no warning
+for (let i = 0; i < 30; i++) r.on("data", () => {});
+console.log("count:", r.listenerCount("data"));

--- a/test-parity/node-suite/stream/iter-helpers/flat-map-async-gen.ts
+++ b/test-parity/node-suite/stream/iter-helpers/flat-map-async-gen.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// flatMap(asyncGenFn) — yields multiple per input via async generator.
+const r = Readable.from([1, 2, 3]);
+const out: number[] = [];
+for await (const v of (r as any).flatMap(async function* (x: number) {
+  yield x * 10;
+  yield x * 100;
+})) {
+  out.push(v as number);
+}
+console.log("collected:", out.join(","));

--- a/test-parity/node-suite/stream/pipe/r-t-w-end-to-end.ts
+++ b/test-parity/node-suite/stream/pipe/r-t-w-end-to-end.ts
@@ -1,0 +1,12 @@
+import { Readable, Transform, Writable } from "node:stream";
+// Readable → Transform → Writable e2e.
+const r = Readable.from(["a", "b"]);
+const upper = new Transform({
+  transform(c, _e, cb) { cb(null, String(c).toUpperCase()); },
+});
+const received: string[] = [];
+const w = new Writable({
+  write(c, _e, cb) { received.push(String(c)); cb(); },
+});
+r.pipe(upper).pipe(w);
+w.on("finish", () => console.log("received:", received.join(",")));

--- a/test-parity/node-suite/stream/pipe/three-stage-mid-error.ts
+++ b/test-parity/node-suite/stream/pipe/three-stage-mid-error.ts
@@ -1,0 +1,21 @@
+import { Readable, Transform, PassThrough, pipeline } from "node:stream";
+// Three-stage pipeline with mid-stage error — src and sink both destroyed.
+const src = Readable.from(["x"]);
+const mid = new Transform({
+  transform(_c, _e, cb) {
+    cb(new Error("mid-fail"));
+  },
+});
+const sink = new PassThrough();
+sink.on("data", () => {});
+let errMsg: string | null = null;
+pipeline(src, mid, sink, (err: any) => {
+  errMsg = err && err.message;
+});
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("err:", errMsg);
+    console.log("src destroyed:", src.destroyed);
+    console.log("sink destroyed:", sink.destroyed);
+  });
+});

--- a/test-parity/node-suite/stream/readable/destroyed-during-data-flow.ts
+++ b/test-parity/node-suite/stream/readable/destroyed-during-data-flow.ts
@@ -1,0 +1,18 @@
+import { Readable } from "node:stream";
+// destroy() inside a 'data' handler — subsequent data events stop.
+let dataCount = 0;
+let closed = false;
+const r = Readable.from(["a", "b", "c", "d", "e"]);
+r.on("data", () => {
+  dataCount++;
+  if (dataCount === 2) r.destroy();
+});
+r.on("close", () => (closed = true));
+r.on("error", () => {});
+r.on("end", () => {});
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("data emitted:", dataCount);
+    console.log("closed:", closed);
+  });
+});

--- a/test-parity/node-suite/stream/readable/from-array-of-promises.ts
+++ b/test-parity/node-suite/stream/readable/from-array-of-promises.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Readable.from([Promise.resolve(1), Promise.resolve(2)]) — Node yields
+// the resolved values (awaits each).
+const r = Readable.from([Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)]);
+const out: any[] = [];
+for await (const v of r) out.push(v);
+console.log("count:", out.length);
+console.log("values:", out.join(","));

--- a/test-parity/node-suite/stream/readable/from-rejected-promise-in-array.ts
+++ b/test-parity/node-suite/stream/readable/from-rejected-promise-in-array.ts
@@ -1,0 +1,18 @@
+import { Readable } from "node:stream";
+// Readable.from([Promise.resolve(1), Promise.reject(err), Promise.resolve(3)])
+// — emits error when it encounters the rejection.
+const r = Readable.from([
+  Promise.resolve(1),
+  Promise.reject(new Error("inner-fail")),
+  Promise.resolve(3),
+]);
+let errMsg: string | null = null;
+r.on("error", (e) => (errMsg = e && e.message));
+const out: any[] = [];
+r.on("data", (v) => out.push(v));
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("got data count:", out.length);
+    console.log("err:", errMsg);
+  });
+});

--- a/test-parity/node-suite/stream/web/from-iterable-of-strings.ts
+++ b/test-parity/node-suite/stream/web/from-iterable-of-strings.ts
@@ -1,0 +1,12 @@
+import { ReadableStream } from "node:stream/web";
+// RS.from(stringArray) — each string is a chunk.
+const rs = (ReadableStream as any).from(["alpha", "beta", "gamma"]);
+const reader = rs.getReader();
+const out: string[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(String(value));
+}
+console.log("count:", out.length);
+console.log("joined:", out.join(","));

--- a/test-parity/node-suite/stream/web/from-uint8array-direct.ts
+++ b/test-parity/node-suite/stream/web/from-uint8array-direct.ts
@@ -1,0 +1,12 @@
+import { ReadableStream } from "node:stream/web";
+// ReadableStream.from(uint8Array) — yields each byte.
+const arr = new Uint8Array([10, 20, 30]);
+const rs = (ReadableStream as any).from(arr);
+const reader = rs.getReader();
+const out: number[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(value as number);
+}
+console.log("collected:", out.join(","));

--- a/test-parity/node-suite/stream/web/transform-no-enqueue.ts
+++ b/test-parity/node-suite/stream/web/transform-no-enqueue.ts
@@ -1,0 +1,17 @@
+import { TransformStream } from "node:stream/web";
+// TransformStream whose transform() doesn't enqueue — readable is empty.
+const ts = new TransformStream({
+  transform() {}, // discards everything
+});
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("a");
+await writer.write("b");
+await writer.close();
+let count = 0;
+while (true) {
+  const { done } = await reader.read();
+  if (done) break;
+  count++;
+}
+console.log("yielded count:", count);


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-109..111)

**4 free passes + 8 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | from-uint8array-direct ✅, from-iterable-of-strings ✅, transform-no-enqueue ✅ | #1545 |
| Events | set-max-listeners-zero, error-listener-once-cleanup, listener-count-fresh ✅ | #1532 |
| Pipeline / pipe | three-stage-mid-error, r-t-w-end-to-end | #1532 |
| Readable shape | destroyed-during-data-flow, from-array-of-promises, from-rejected-promise-in-array | #1532 |
| Iter helpers | flat-map-async-gen | #1558 |

Free passes:
- `web/from-uint8array-direct` (RS.from yields bytes)
- `web/from-iterable-of-strings` (RS.from chunks strings)
- `web/transform-no-enqueue` (transform that drops chunks → empty readable)
- `events/listener-count-fresh` (counts are zero on a fresh stream)

All 8 failures tracked in `known_failures.json`.
