### PR TITLE
fix(fetch): implement Request.text()/.json()/.arrayBuffer() (#1688)

### DIFF
--- a/crates/perry-codegen/src/lower_call/options/fetch.rs
+++ b/crates/perry-codegen/src/lower_call/options/fetch.rs
@@ -260,6 +260,25 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                         .call(DOUBLE, "js_request_get_headers", &[(DOUBLE, &h_handle)]);
                 return Ok(Some(out));
             }
+            // #1688: body-consuming methods. `js_request_get_body` already
+            // stores the body string; mirror the Response `.text()`/`.json()`/
+            // `.arrayBuffer()` path (each returns a Promise pointer NaN-boxed
+            // as POINTER_TAG).
+            "text" => {
+                let blk = ctx.block();
+                let promise = blk.call(I64, "js_request_text", &[(DOUBLE, &h_handle)]);
+                return Ok(Some(nanbox_pointer_inline(blk, &promise)));
+            }
+            "json" => {
+                let blk = ctx.block();
+                let promise = blk.call(I64, "js_request_json", &[(DOUBLE, &h_handle)]);
+                return Ok(Some(nanbox_pointer_inline(blk, &promise)));
+            }
+            "arrayBuffer" => {
+                let blk = ctx.block();
+                let promise = blk.call(I64, "js_request_array_buffer", &[(DOUBLE, &h_handle)]);
+                return Ok(Some(nanbox_pointer_inline(blk, &promise)));
+            }
             _ => return Ok(None),
         }
     }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1608,6 +1608,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_request_get_body", DOUBLE, &[DOUBLE]);
     // #1649: `req.headers` → NaN-boxed Headers handle.
     module.declare_function("js_request_get_headers", DOUBLE, &[DOUBLE]);
+    // #1688: request body-consuming methods. text/json/arrayBuffer return a
+    // Promise pointer (i64); codegen NaN-boxes it as POINTER_TAG.
+    module.declare_function("js_request_text", I64, &[DOUBLE]);
+    module.declare_function("js_request_json", I64, &[DOUBLE]);
+    module.declare_function("js_request_array_buffer", I64, &[DOUBLE]);
 
     // Response body getters — handles flow as NaN-boxed POINTER_TAG f64
     // (Phase 1 unification, refs #421). Accessors call `handle_id` to

--- a/crates/perry-ext-fetch/src/lib.rs
+++ b/crates/perry-ext-fetch/src/lib.rs
@@ -1118,6 +1118,64 @@ pub extern "C" fn js_request_get_body(handle: f64) -> f64 {
     }
 }
 
+/// Read a request's stored body (empty string for a bodiless request),
+/// or `None` for an invalid handle. (#1688)
+fn request_body_string(handle: f64) -> Option<String> {
+    let id = handle_id(handle);
+    REQUEST_HANDLES
+        .lock()
+        .unwrap()
+        .get(&id)
+        .map(|r| r.body.clone().unwrap_or_default())
+}
+
+/// request.text() -> Promise<string>. Mirrors `js_fetch_response_text`. (#1688)
+///
+/// # Safety
+/// `handle` must come from a previous `js_request_new`.
+#[no_mangle]
+pub unsafe extern "C" fn js_request_text(handle: f64) -> *mut Promise {
+    let promise = JsPromise::new();
+    let raw = promise.as_raw();
+    match request_body_string(handle) {
+        Some(s) => promise.resolve(JsValue::from_string_ptr(alloc_string(&s).as_raw())),
+        None => promise.reject_string("Invalid request handle"),
+    }
+    raw
+}
+
+/// request.json() -> Promise<string>. Returns the body as a JSON string —
+/// callers JSON.parse on the JS side, matching `js_fetch_response_json`. (#1688)
+///
+/// # Safety
+/// `handle` must come from a previous `js_request_new`.
+#[no_mangle]
+pub unsafe extern "C" fn js_request_json(handle: f64) -> *mut Promise {
+    let promise = JsPromise::new();
+    let raw = promise.as_raw();
+    match request_body_string(handle) {
+        Some(s) => promise.resolve(JsValue::from_string_ptr(alloc_string(&s).as_raw())),
+        None => promise.reject_string("Invalid request handle"),
+    }
+    raw
+}
+
+/// request.arrayBuffer() -> Promise. Resolves with the body bytes as a string
+/// (caller wraps in Uint8Array), matching `js_response_array_buffer`. (#1688)
+///
+/// # Safety
+/// `handle` must come from a previous `js_request_new`.
+#[no_mangle]
+pub unsafe extern "C" fn js_request_array_buffer(handle: f64) -> *mut Promise {
+    let promise = JsPromise::new();
+    let raw = promise.as_raw();
+    match request_body_string(handle) {
+        Some(s) => promise.resolve(JsValue::from_string_ptr(alloc_string(&s).as_raw())),
+        None => promise.reject_string("Invalid request handle"),
+    }
+    raw
+}
+
 // `get_handle` / `register_handle` referenced for future surface;
 // silence unused-import warnings without dropping them.
 #[allow(dead_code)]
@@ -1198,5 +1256,28 @@ mod tests {
         assert!(resp > 0.0);
         let status = js_fetch_response_status(resp);
         assert_eq!(status, 200.0);
+    }
+
+    // #1688: request.text()/.json()/.arrayBuffer() were unimplemented. The
+    // FFIs build a JsPromise (runtime symbols unavailable in the unittest
+    // binary, as with every other promise-returning fetch FFI), so this
+    // exercises the shared body data path they consume: a stored body
+    // round-trips, a bodiless request reads as "", and an invalid handle is
+    // None (→ the FFI rejects).
+    #[test]
+    fn request_body_data_path() {
+        let url = alloc_string("https://example.com");
+        let method = alloc_string("POST");
+        let body = alloc_string(r#"{"x":1}"#);
+        let h = unsafe { js_request_new(url.as_raw(), method.as_raw(), body.as_raw(), 0.0) };
+        assert!(h > 0.0);
+        assert_eq!(request_body_string(h).as_deref(), Some(r#"{"x":1}"#));
+
+        let url2 = alloc_string("https://example.com/empty");
+        let null = std::ptr::null::<StringHeader>();
+        let h2 = unsafe { js_request_new(url2.as_raw(), null, null, 0.0) };
+        assert_eq!(request_body_string(h2).as_deref(), Some(""));
+
+        assert_eq!(request_body_string(99_999_999.0), None);
     }
 }

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -1877,3 +1877,90 @@ pub extern "C" fn js_request_get_body(handle: f64) -> f64 {
         None => f64::from_bits(TAG_NULL),
     }
 }
+
+/// Read a request's stored body (or empty for a bodiless request). Returns
+/// `None` only for an invalid handle, so callers can reject the promise.
+fn request_body_bytes(handle: f64) -> Option<Vec<u8>> {
+    let id = handle_id(handle);
+    REQUEST_REGISTRY
+        .lock()
+        .unwrap()
+        .get(&id)
+        .map(|req| req.body.clone().unwrap_or_default().into_bytes())
+}
+
+/// request.text() -> Promise<string>. Mirrors `js_fetch_response_text`: the
+/// body is in-memory, so resolve the promise synchronously (the LLVM await
+/// loop doesn't drain the deferred pump). A bodiless request resolves to "".
+/// (#1688)
+#[no_mangle]
+pub unsafe extern "C" fn js_request_text(handle: f64) -> *mut perry_runtime::Promise {
+    let promise = perry_runtime::js_promise_new();
+    match request_body_bytes(handle) {
+        Some(body) => {
+            let text = String::from_utf8_lossy(&body).to_string();
+            let result_str = js_string_from_bytes(text.as_ptr(), text.len() as u32);
+            let result_nan = f64::from_bits(JSValue::string_ptr(result_str).bits());
+            perry_runtime::js_promise_resolve(promise, result_nan);
+        }
+        None => {
+            let err_nan = f64::from_bits(fetch_error_bits("Invalid request handle"));
+            perry_runtime::js_promise_reject(promise, err_nan);
+        }
+    }
+    promise
+}
+
+/// request.json() -> Promise<object>. Parses the stored body as JSON, mirroring
+/// `js_fetch_response_json`. (#1688)
+#[no_mangle]
+pub unsafe extern "C" fn js_request_json(handle: f64) -> *mut perry_runtime::Promise {
+    let promise = perry_runtime::js_promise_new();
+    let body = match request_body_bytes(handle) {
+        Some(b) => b,
+        None => {
+            let err_nan = f64::from_bits(fetch_error_bits("Invalid request handle"));
+            perry_runtime::js_promise_reject(promise, err_nan);
+            return promise;
+        }
+    };
+    let text = String::from_utf8_lossy(&body).to_string();
+    match serde_json::from_str::<serde_json::Value>(&text) {
+        Ok(json_value) => {
+            let js_value = json_value_to_jsvalue(&json_value);
+            perry_runtime::js_promise_resolve(promise, f64::from_bits(js_value.bits()));
+        }
+        Err(e) => {
+            let err_nan = f64::from_bits(fetch_error_bits(&format!("JSON parse error: {}", e)));
+            perry_runtime::js_promise_reject(promise, err_nan);
+        }
+    }
+    promise
+}
+
+/// request.arrayBuffer() -> Promise<ArrayBuffer>. Resolves with a real
+/// BufferHeader over the body bytes, mirroring `js_response_array_buffer`. (#1688)
+#[no_mangle]
+pub unsafe extern "C" fn js_request_array_buffer(handle: f64) -> *mut perry_runtime::Promise {
+    let promise = perry_runtime::js_promise_new();
+    let body = match request_body_bytes(handle) {
+        Some(b) => b,
+        None => {
+            let err_nan = f64::from_bits(fetch_error_bits("Invalid request handle"));
+            perry_runtime::js_promise_reject(promise, err_nan);
+            return promise;
+        }
+    };
+    let buf = perry_runtime::buffer::buffer_alloc(body.len() as u32);
+    (*buf).length = body.len() as u32;
+    if !body.is_empty() {
+        std::ptr::copy_nonoverlapping(
+            body.as_ptr(),
+            perry_runtime::buffer::buffer_data_mut(buf),
+            body.len(),
+        );
+    }
+    let val = JSValue::object_ptr(buf as *mut u8);
+    perry_runtime::js_promise_resolve(promise, f64::from_bits(val.bits()));
+    promise
+}

--- a/test-files/test_gap_fetch_response.ts
+++ b/test-files/test_gap_fetch_response.ts
@@ -16,6 +16,9 @@
 // request method: POST
 // request url: http://example.com/api
 // request body present: true
+// request text: raw body
+// request json data: true
+// request arrayBuffer byteLength: 5
 // clone text: cloned body
 // arrayBuffer byteLength: 5
 // blob size: 5
@@ -83,6 +86,18 @@ async function main(): Promise<void> {
   console.log("request method: " + req.method);
   console.log("request url: " + req.url);
   console.log("request body present: " + (req.body !== null));
+
+  // --- Request.text() / .json() / .arrayBuffer() (#1688) ---
+  // A body is read-once per the spec, so use a fresh Request for each.
+  const reqText = new Request("http://example.com/api", { method: "POST", body: "raw body" });
+  console.log("request text: " + await reqText.text());
+  const reqJson = new Request("http://example.com/api", {
+    method: "POST",
+    body: JSON.stringify({ data: true })
+  });
+  console.log("request json data: " + (await reqJson.json()).data);
+  const reqAb = new Request("http://example.com/api", { method: "POST", body: "hello" });
+  console.log("request arrayBuffer byteLength: " + (await reqAb.arrayBuffer()).byteLength);
 
   // --- Response.clone() ---
   const r5 = new Response("cloned body");
@@ -155,10 +170,13 @@ crates/perry-stdlib/src/fetch.rs:
   - js_headers_new
   - js_headers_set
   - js_headers_values
+  - js_request_array_buffer
   - js_request_get_body
   - js_request_get_method
   - js_request_get_url
+  - js_request_json
   - js_request_new
+  - js_request_text
   - js_response_array_buffer
   - js_response_blob
   - js_response_body


### PR DESCRIPTION
## Summary

Implements `Request.text()` / `.json()` / `.arrayBuffer()` under Perry-native compile. Closes #1688.

Before this change, `new Request(url, { body }).text()` / `.json()` / `.arrayBuffer()` returned `0` instead of the request body. `req.method` / `req.url` / `req.headers` already worked (#1649); only the body-consuming methods were unimplemented — the typed `module=="Request"` codegen arm in `lower_call/options/fetch.rs` handled the property getters but had no body-method dispatch, so `req.text()` fell through to a generic path that yielded `0`.

## Changes

- **Runtime (`perry-stdlib`)**: add `js_request_text` / `js_request_json` / `js_request_array_buffer`, mirroring the existing Response `js_fetch_response_text` / `js_fetch_response_json` / `js_response_array_buffer` path. Body is in-memory, so the promise resolves synchronously (the LLVM await loop doesn't drain the deferred pump). A bodiless request reads as `""`.
- **Runtime (`perry-ext-fetch`)**: same three FFIs for the well-known-flip path, matching that crate's conventions, plus a data-path unit test.
- **Codegen**: route `text` / `json` / `arrayBuffer` in the Request arm to the new FFIs (Promise pointer NaN-boxed as POINTER_TAG); declare them in `runtime_decls`.
- **Test**: extend `test_gap_fetch_response.ts` with the three body methods.

## Validation

Byte-for-byte identical to `node --experimental-strip-types` on the full `test_gap_fetch_response.ts` gap test (including the new `request text` / `request json data` / `request arrayBuffer byteLength` lines). `cargo test -p perry-ext-fetch` green (7 tests). `cargo fmt --all -- --check` clean.

Both code paths were exercised: the well-known flip routed `fetch` → `perry-ext-fetch` and linked cleanly, confirming the ext-fetch additions are also reached.

## Note (out of scope)

Using `new Request(...)` **inline** (e.g. `await new Request(...).text()`) doesn't set the `uses_fetch` feature flag, so the auto-optimize build omits the fetch module and the link fails — a pre-existing feature-detection limitation that affects all inline-Request method calls (and `js_request_new` itself), not just the new ones. Assigning to a variable first (`const r = new Request(...)`, as in the #1688 repro) works. Tracked separately in #1691.
