### PR TITLE
test(parity): stream — batch of 12 tier-10/11 tests (iter-112..114) (2 free pass, 10 #1531/#1532/#1545)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2641,5 +2641,65 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Readable.from(asyncGen yielding mixed types) — types lost or wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/readable-locked-after-pipe-through": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: rs.locked false after pipeThrough (should be true). Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/from-string-array-yields-each": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(['a','b','c']) — each string not a separate chunk. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/emit-returns-false-no-listeners": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: emit() — no-listener returns wrong value (not false). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/tee-after-getReader-throws": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: tee() on locked stream does not throw TypeError. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/remove-all-listeners-error-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: removeAllListeners('error') — does not zero the count. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/flow/paused-no-data-flow": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: paused source still emits data after push. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/sync-iterator-not-exposed": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Symbol.iterator exposed on Readable (should be undefined). Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/read-returns-buffer-default": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read() in non-encoded mode — does not return Buffer instance. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/error-arg-is-error-instance": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'error' listener arg — wrong instance / message. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/pipe-autodestroy-default": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe() autoDestroy default — src or dst not destroyed after pipe. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/events/emit-returns-false-no-listeners.ts
+++ b/test-parity/node-suite/stream/events/emit-returns-false-no-listeners.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// emit('event') with no listeners returns false; with listeners returns true.
+const r = new Readable({ read() {} });
+const noListenerResult = r.emit("no-listener-here");
+r.on("present", () => {});
+const withListenerResult = r.emit("present");
+console.log("no-listener:", noListenerResult);
+console.log("with-listener:", withListenerResult);
+console.log("correct:", noListenerResult === false && withListenerResult === true);

--- a/test-parity/node-suite/stream/events/error-arg-is-error-instance.ts
+++ b/test-parity/node-suite/stream/events/error-arg-is-error-instance.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// Listener for 'error' receives the exact Error instance from destroy.
+const r = new Readable({ read() {} });
+const original = new Error("test");
+let received: any = null;
+r.on("error", (e) => (received = e));
+r.destroy(original);
+setImmediate(() => {
+  console.log("instanceof Error:", received instanceof Error);
+  console.log("same identity:", received === original);
+  console.log("message:", received && (received as Error).message);
+});

--- a/test-parity/node-suite/stream/events/remove-all-listeners-error-event.ts
+++ b/test-parity/node-suite/stream/events/remove-all-listeners-error-event.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// removeAllListeners('error') — removes ALL error listeners.
+const r = new Readable({ read() {} });
+r.on("error", () => {});
+r.on("error", () => {});
+console.log("before:", r.listenerCount("error"));
+r.removeAllListeners("error");
+console.log("after:", r.listenerCount("error"));

--- a/test-parity/node-suite/stream/flow/paused-no-data-flow.ts
+++ b/test-parity/node-suite/stream/flow/paused-no-data-flow.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// pause() on a source that has push()'ed data — no 'data' fires until resume.
+const r = new Readable({ read() {} });
+let count = 0;
+r.pause();
+r.on("data", () => count++);
+r.push("a");
+r.push("b");
+setImmediate(() => {
+  console.log("data emitted while paused:", count);
+  console.log("flowing:", r.readableFlowing);
+});

--- a/test-parity/node-suite/stream/pipe/pipe-autodestroy-default.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-autodestroy-default.ts
@@ -1,0 +1,12 @@
+import { Readable, PassThrough } from "node:stream";
+// Default autoDestroy:true — after pipe completes, both streams destroyed.
+const r = Readable.from(["x"]);
+const dst = new PassThrough();
+dst.on("data", () => {});
+r.pipe(dst);
+dst.on("end", () => {
+  setImmediate(() => {
+    console.log("src destroyed:", r.destroyed);
+    console.log("dst destroyed:", dst.destroyed);
+  });
+});

--- a/test-parity/node-suite/stream/pipe/source-unpipe-clears-events.ts
+++ b/test-parity/node-suite/stream/pipe/source-unpipe-clears-events.ts
@@ -1,0 +1,15 @@
+import { Readable, PassThrough } from "node:stream";
+// unpipe(dst) — clears the internal pipe state.
+const r = Readable.from(["x"]);
+const dst = new PassThrough();
+dst.on("data", () => {});
+r.pipe(dst);
+r.unpipe(dst);
+// Push directly to source — dst shouldn't receive
+const collected: string[] = [];
+dst.on("data", (c) => collected.push(String(c)));
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("dst received after unpipe:", collected.length);
+  });
+});

--- a/test-parity/node-suite/stream/readable/from-string-array-yields-each.ts
+++ b/test-parity/node-suite/stream/readable/from-string-array-yields-each.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Readable.from(['a', 'b', 'c']) — each string is a separate chunk.
+const r = Readable.from(["a", "b", "c"]);
+const out: string[] = [];
+r.on("data", (c) => out.push(String(c)));
+r.on("end", () => {
+  console.log("count:", out.length);
+  console.log("first:", out[0]);
+});

--- a/test-parity/node-suite/stream/readable/read-returns-buffer-default.ts
+++ b/test-parity/node-suite/stream/readable/read-returns-buffer-default.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Without setEncoding, read() returns Buffer instances.
+const r = new Readable({ read() {} });
+r.push("hi");
+r.push(null);
+r.on("readable", () => {
+  const got = r.read();
+  console.log("is buffer:", Buffer.isBuffer(got));
+  console.log("toString:", got && got.toString("utf8"));
+});

--- a/test-parity/node-suite/stream/readable/sync-iterator-not-exposed.ts
+++ b/test-parity/node-suite/stream/readable/sync-iterator-not-exposed.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Symbol.iterator should not be exposed on Readable — only Symbol.asyncIterator.
+const r = Readable.from(["a"]);
+const sync = (r as any)[Symbol.iterator];
+const asyncIter = (r as any)[Symbol.asyncIterator];
+console.log("sync iterator typeof:", typeof sync);
+console.log("asyncIterator typeof:", typeof asyncIter);
+console.log("sync is undefined:", sync === undefined);

--- a/test-parity/node-suite/stream/web/readable-locked-after-pipe-through.ts
+++ b/test-parity/node-suite/stream/web/readable-locked-after-pipe-through.ts
@@ -1,0 +1,6 @@
+import { ReadableStream, TransformStream } from "node:stream/web";
+// After pipeThrough(), the source is locked (transform took the reader).
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const ts = new TransformStream();
+rs.pipeThrough(ts);
+console.log("rs locked after pipeThrough:", rs.locked);

--- a/test-parity/node-suite/stream/web/readable-with-strategy.ts
+++ b/test-parity/node-suite/stream/web/readable-with-strategy.ts
@@ -1,0 +1,11 @@
+import { ReadableStream, CountQueuingStrategy } from "node:stream/web";
+// new ReadableStream(source, strategy) — both args.
+const rs = new ReadableStream(
+  { start(c) { c.enqueue("x"); c.close(); } },
+  new CountQueuingStrategy({ highWaterMark: 5 }),
+);
+const reader = rs.getReader();
+const a = await reader.read();
+const b = await reader.read();
+console.log("a:", a.value);
+console.log("b done:", b.done);

--- a/test-parity/node-suite/stream/web/tee-after-getReader-throws.ts
+++ b/test-parity/node-suite/stream/web/tee-after-getReader-throws.ts
@@ -1,0 +1,12 @@
+import { ReadableStream } from "node:stream/web";
+// tee() on a stream that already has a reader (locked) — throws TypeError.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const _r = rs.getReader();
+let caught: string | null = null;
+try {
+  rs.tee();
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);


### PR DESCRIPTION
### Stream parity batch — 12 tests aggregated (iter-112..114)

**2 free passes + 10 tracked failures.**

| Category | Tests | Issue |
|---|---|---|
| Web stream surface | readable-with-strategy ✅, readable-locked-after-pipe-through, tee-after-getReader-throws | #1545 |
| Events | source-unpipe-clears-events ✅, emit-returns-false-no-listeners, remove-all-listeners-error-event, error-arg-is-error-instance | #1532 |
| Readable shape | from-string-array-yields-each, sync-iterator-not-exposed, read-returns-buffer-default | #1531/#1532 |
| Flow | paused-no-data-flow | #1532 |
| Pipe | pipe-autodestroy-default | #1532 |

Free passes:
- `pipe/source-unpipe-clears-events` (unpipe stops further data)
- `web/readable-with-strategy` (RS w/ strategy ctor works)

All 10 failures tracked in `known_failures.json`.
