### PR TITLE
test(parity): stream — consolidated iter batches (iter-81..114)

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -2641,5 +2641,479 @@
     "added": "2026-05-24",
     "category": "bug-open",
     "reason": "node:stream: Readable.from(asyncGen yielding mixed types) — types lost or wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/readable-locked-after-pipe-through": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: rs.locked false after pipeThrough (should be true). Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/from-string-array-yields-each": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(['a','b','c']) — each string not a separate chunk. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/emit-returns-false-no-listeners": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: emit() — no-listener returns wrong value (not false). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/tee-after-getReader-throws": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: tee() on locked stream does not throw TypeError. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/remove-all-listeners-error-event": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: removeAllListeners('error') — does not zero the count. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/flow/paused-no-data-flow": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: paused source still emits data after push. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/sync-iterator-not-exposed": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Symbol.iterator exposed on Readable (should be undefined). Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/read-returns-buffer-default": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: read() in non-encoded mode — does not return Buffer instance. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/error-arg-is-error-instance": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'error' listener arg — wrong instance / message. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/pipe-autodestroy-default": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe() autoDestroy default — src or dst not destroyed after pipe. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/set-max-listeners-zero": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: setMaxListeners(0) — max not 0 (unlimited) per Node. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/three-stage-mid-error": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline 3-stage mid-error — src/sink destroy flags or err wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/destroyed-during-data-flow": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy() inside 'data' listener — emits wrong data count. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-array-of-promises": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from([P1, P2, P3]) — does not await each Promise. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/flat-map-async-gen": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: flatMap(asyncGenFn) — multi-yield per input not flattened. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/events/error-listener-once-cleanup": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: once('error', fn) — listener not auto-removed after fire. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-rejected-promise-in-array": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(array with one Promise.reject) — error not emitted at the right point. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/r-t-w-end-to-end": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: simple R→T→W e2e pipe — received chunks wrong (transform/uppercase not applied). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/iterator-prevent-cancel": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: readable.iterator({destroyOnReturn:false}) — early return still destroys. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/events/listeners-empty-array": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: listeners() with no listeners — not an empty array or wrong type. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/every-async-rejection": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: every(asyncFn) — fn rejection does not propagate as Promise reject. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/pipe/pipe-no-args-throws": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe() with no args — does not throw TypeError. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/double-destroy-still-destroyed": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy() twice — destroyed flag still true after both calls. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/find-async-fn": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: find(asyncFn) — returns wrong value. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/events/remove-listener-by-reference": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: removeListener(event, fn) — does not decrement listener count correctly by-reference. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/uncork-twice-after-cork": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: cork(); uncork(); uncork() — second uncork errors or breaks finish. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/readable/from-gen-yield-order": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(gen()) — yield order lost. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/double-pipe-through": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: pipeThrough().pipeThrough() chain — second transform output wrong. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/web/from-iterable-of-buffers": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: ReadableStream.from(arrayOfBuffers) — chunk count or type wrong. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/readable/method-typeof-function": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: some instance method reports wrong typeof (not 'function'). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/error-via-pipe": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: src.emit('error') during pipe — src or dst error tracking wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/flow/registration-order-emission": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: multi-'data' listeners — fire in wrong order. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-iterator-throws": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(iter that throws on next) — 'error' event not emitted. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/some-async-rejection": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: some(asyncFn) — rejection in fn does not propagate. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/events/get-listeners-instance-method": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: listeners(event) — wrong array shape or count. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/transform-readable-cancel-propagates": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: TS readable.cancel — writable.write does not reject after. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/promises/finished-stream-already-ended": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: finished(alreadyEnded) — does not resolve immediately. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/error-emit-sync": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: emit('error') — listener does not fire synchronously. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/readable-property-shape": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: stream instance methods — some typeof not 'function' (or missing). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/for-await-on-transform": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: for-await directly on TransformStream.readable — empty or wrong output. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipe/end-false-then-explicit-end": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe(dst,{end:false}) followed by manual dst.end() — dst not ending. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/for-each-await-each": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: forEach(asyncFn) — does not await each call sequentially. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/readable/from-async-iter-nested": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(asyncIter with awaits) — wrong collected output. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/pipe-to-with-pre-aborted-signal": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: pipeTo with pre-aborted signal — does not reject immediately. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/flags/destroyed-initial-false": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroyed flag — wrong initial value on R/W/D/T. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/pipe-adds-listener-on-dst": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe() does not add 'unpipe' listener on destination. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/map-then-toarray": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: map(fn).toArray() — chain returns non-Array or wrong values. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/readable/readable-mode-only": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: 'readable' event with read() drain — chunk order or count wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/writable-stream-bytes-type": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: WritableStream({type:'bytes'}) — handling differs from Node (accept-and-ignore or throw). Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/emit-after-destroy-still-works": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: custom emit() on destroyed stream — listener does not fire or fires multiple times. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/pause-sets-flowing-false": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pause() doesn't flip readableFlowing to false synchronously. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/destroy/destroy-during-flow": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroy() during flowing — extra 'data' emitted or 'close' wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/flow/data-after-end-not-fired": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: push() after end-emit — extra 'data' event fired. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-array-with-undefined": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from([1,undefined,3]) — undefined value handling differs. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/cleanup-state-after-end": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: post-pipe-end destroyed flags wrong on source or destination. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/cork-empty": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: cork()+uncork() with no writes — 'finish' doesn't fire. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/readable/destroyed-after-error": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: destroyed flag false after 'error' event handler fires. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipe/pipe-after-pause": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipe() doesn't resume a paused source stream. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/writable/writable-length-tracker": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: writableLength does not track buffered bytes in the writable queue. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/readable/options-autoDestroy-explicit": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: autoDestroy: false — stream still destroyed after 'end' or 'close' fires when it shouldn't. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/sink-all-four-methods": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: sink with start+write+close+abort — methods not invoked in correct order or some skipped. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/pipeline/error-middle-aborts-all": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline middle-stream error — does not destroy source AND sink. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/iter-helpers/take-then-filter": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: chained take(N).filter(fn) — wrong output. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/web/from-promise-iterable": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: ReadableStream.from(customIterable) — value or done wrong. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/events/on-non-function-throws": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: on(event, non-function) — does not throw TypeError as expected. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/iterator-empty-after-consumed": {
+    "issue": "1531",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: second [Symbol.asyncIterator]() call — does not return immediately-done iterator. Flips to PASS when #1531 lands."
+  },
+  "node-suite/stream/readable/from-typed-array": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(Uint8Array) — iteration count or first-byte value wrong. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/web/writer-write-resolves-after-sink": {
+    "issue": "1545",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream/web: writer.write() Promise resolution timing — resolves before sink processes chunk. Flips to PASS when #1545 lands."
+  },
+  "node-suite/stream/iter-helpers/compose-then-toarray": {
+    "issue": "1558",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: compose(transform).toArray() — chain produces wrong result. Flips to PASS when #1558 lands."
+  },
+  "node-suite/stream/events/listener-add-during-emit": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: listener added during emit — fires this round (should NOT in EE spec). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/highwater-mark-default-objectmode": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: objectMode HWM default — not 16 (object count). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/iter-and-data-listener": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: for-await + 'data' listener — data event listener counts wrong, or iter empty. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/pipeline/three-async-fns": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline with multiple async-gen stages — fails to deliver final collected output. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/events/add-listener-is-on-alias": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: addListener !== on (should be same function reference). Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-empty-map": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(empty Map) — does not yield immediate end. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/transform/objectmode-passes-objects": {
+    "issue": "1539",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: objectMode Transform — object data not preserved through transform. Flips to PASS when #1539 lands."
+  },
+  "node-suite/stream/pipeline/null-cb-error-form": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: pipeline cb on success — err arg not null/undefined or wrong type. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/readable/from-non-iterable-throws": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: Readable.from(non-iterable) — does not throw TypeError. Flips to PASS when #1532 lands."
+  },
+  "node-suite/stream/destroy/_destroy-user-impl": {
+    "issue": "1532",
+    "added": "2026-05-24",
+    "category": "bug-open",
+    "reason": "node:stream: user _destroy(err, cb) — not invoked or receives wrong error. Flips to PASS when #1532 lands."
   }
 }

--- a/test-parity/node-suite/stream/destroy/_destroy-user-impl.ts
+++ b/test-parity/node-suite/stream/destroy/_destroy-user-impl.ts
@@ -1,0 +1,18 @@
+import { Readable } from "node:stream";
+// User _destroy(err, cb) is called during destroy() with the error and a cb.
+let userCalled = false;
+let receivedErr: any = null;
+const r = new Readable({
+  read() {},
+  destroy(err: any, cb: any) {
+    userCalled = true;
+    receivedErr = err;
+    cb(err);
+  },
+});
+r.on("error", () => {});
+r.destroy(new Error("user-destroy-test"));
+setImmediate(() => {
+  console.log("user impl called:", userCalled);
+  console.log("err message:", receivedErr && (receivedErr as Error).message);
+});

--- a/test-parity/node-suite/stream/destroy/destroy-during-flow.ts
+++ b/test-parity/node-suite/stream/destroy/destroy-during-flow.ts
@@ -1,0 +1,18 @@
+import { Readable } from "node:stream";
+// destroy() in the middle of flowing — outstanding data is dropped,
+// 'data' stops, 'close' fires.
+const r = new Readable({ read() {} });
+let dataCount = 0;
+let closed = false;
+r.on("data", () => {
+  dataCount++;
+  if (dataCount === 1) r.destroy(); // destroy after first chunk
+});
+r.on("close", () => {
+  closed = true;
+  console.log("got chunks:", dataCount);
+  console.log("closed:", closed);
+});
+r.push("a");
+r.push("b"); // shouldn't be emitted as data
+r.push(null);

--- a/test-parity/node-suite/stream/events/add-listener-is-on-alias.ts
+++ b/test-parity/node-suite/stream/events/add-listener-is-on-alias.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// addListener is an alias of on; both should be defined and identical.
+const r = new Readable({ read() {} });
+console.log("on typeof:", typeof r.on);
+console.log("addListener typeof:", typeof r.addListener);
+console.log("identical:", r.on === r.addListener);

--- a/test-parity/node-suite/stream/events/emit-after-destroy-still-works.ts
+++ b/test-parity/node-suite/stream/events/emit-after-destroy-still-works.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// emit() on a destroyed stream — listeners still fire (emit is just EE.emit).
+const r = new Readable({ read() {} });
+let count = 0;
+r.on("error", () => {});
+r.on("custom", () => count++);
+r.destroy();
+r.emit("custom");
+setImmediate(() => {
+  console.log("destroyed:", r.destroyed);
+  console.log("custom listener fired:", count);
+});

--- a/test-parity/node-suite/stream/events/emit-returns-false-no-listeners.ts
+++ b/test-parity/node-suite/stream/events/emit-returns-false-no-listeners.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// emit('event') with no listeners returns false; with listeners returns true.
+const r = new Readable({ read() {} });
+const noListenerResult = r.emit("no-listener-here");
+r.on("present", () => {});
+const withListenerResult = r.emit("present");
+console.log("no-listener:", noListenerResult);
+console.log("with-listener:", withListenerResult);
+console.log("correct:", noListenerResult === false && withListenerResult === true);

--- a/test-parity/node-suite/stream/events/error-arg-is-error-instance.ts
+++ b/test-parity/node-suite/stream/events/error-arg-is-error-instance.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// Listener for 'error' receives the exact Error instance from destroy.
+const r = new Readable({ read() {} });
+const original = new Error("test");
+let received: any = null;
+r.on("error", (e) => (received = e));
+r.destroy(original);
+setImmediate(() => {
+  console.log("instanceof Error:", received instanceof Error);
+  console.log("same identity:", received === original);
+  console.log("message:", received && (received as Error).message);
+});

--- a/test-parity/node-suite/stream/events/error-emit-sync.ts
+++ b/test-parity/node-suite/stream/events/error-emit-sync.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// emit('error', err) — listener fires synchronously.
+const r = new Readable({ read() {} });
+let fired = false;
+r.on("error", () => (fired = true));
+r.emit("error", new Error("manual-error"));
+console.log("fired synchronously:", fired);

--- a/test-parity/node-suite/stream/events/error-listener-once-cleanup.ts
+++ b/test-parity/node-suite/stream/events/error-listener-once-cleanup.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// once('error', fn) — listener auto-removed even if error fires.
+const r = new Readable({ read() {} });
+let count = 0;
+r.once("error", () => count++);
+r.emit("error", new Error("first"));
+console.log("after first:", count);
+console.log("listener count:", r.listenerCount("error"));

--- a/test-parity/node-suite/stream/events/error-via-pipe.ts
+++ b/test-parity/node-suite/stream/events/error-via-pipe.ts
@@ -1,0 +1,19 @@
+import { Readable, PassThrough } from "node:stream";
+// emit('error') on a source while piped — destination receives the error
+// via Node's internal error propagation in pipeline (NOT just pipe).
+const src = new Readable({ read() {} });
+const dst = new PassThrough();
+let srcErr: string | null = null;
+let dstErr: string | null = null;
+src.on("error", (e) => (srcErr = e && e.message));
+dst.on("error", (e) => (dstErr = e && e.message));
+src.on("data", () => {});
+dst.on("data", () => {});
+src.pipe(dst);
+src.emit("error", new Error("manual-error"));
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("src err:", srcErr);
+    console.log("dst err:", dstErr);
+  });
+});

--- a/test-parity/node-suite/stream/events/get-listeners-instance-method.ts
+++ b/test-parity/node-suite/stream/events/get-listeners-instance-method.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// emitter.listeners(event) returns the array of registered listeners.
+const r = new Readable({ read() {} });
+const fn1 = () => {};
+const fn2 = () => {};
+r.on("custom", fn1);
+r.on("custom", fn2);
+const arr = r.listeners("custom");
+console.log("count:", arr.length);
+console.log("is array:", Array.isArray(arr));
+console.log("contains fn1:", arr.includes(fn1));
+console.log("contains fn2:", arr.includes(fn2));

--- a/test-parity/node-suite/stream/events/listener-add-during-emit.ts
+++ b/test-parity/node-suite/stream/events/listener-add-during-emit.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Adding a listener INSIDE emit() — the new listener is NOT invoked this round.
+const r = new Readable({ read() {} });
+const order: string[] = [];
+const newListener = () => order.push("late");
+r.on("custom", () => {
+  order.push("first");
+  r.on("custom", newListener); // added during emit
+});
+r.emit("custom"); // should only fire 'first'
+console.log("first emit:", order.join(","));
+r.emit("custom"); // now 'late' fires
+console.log("second emit:", order.join(","));

--- a/test-parity/node-suite/stream/events/listener-count-fresh.ts
+++ b/test-parity/node-suite/stream/events/listener-count-fresh.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// A fresh Readable: listenerCount('data') is 0; listenerCount('error') is 0.
+const r = new Readable({ read() {} });
+console.log("data:", r.listenerCount("data"));
+console.log("error:", r.listenerCount("error"));
+console.log("end:", r.listenerCount("end"));
+console.log("readable:", r.listenerCount("readable"));
+console.log("all zero:",
+  r.listenerCount("data") === 0 &&
+  r.listenerCount("error") === 0 &&
+  r.listenerCount("end") === 0);

--- a/test-parity/node-suite/stream/events/listener-count-zero.ts
+++ b/test-parity/node-suite/stream/events/listener-count-zero.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// listenerCount(event) returns 0 when no listener registered.
+const r = new Readable({ read() {} });
+console.log("no listeners:", r.listenerCount("data"));
+console.log("is 0:", r.listenerCount("data") === 0);

--- a/test-parity/node-suite/stream/events/listeners-empty-array.ts
+++ b/test-parity/node-suite/stream/events/listeners-empty-array.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// listeners(event) with no listeners — returns empty array.
+const r = new Readable({ read() {} });
+const arr = r.listeners("no-listener-here");
+console.log("is array:", Array.isArray(arr));
+console.log("length:", arr.length);
+console.log("is empty:", arr.length === 0);

--- a/test-parity/node-suite/stream/events/on-non-function-throws.ts
+++ b/test-parity/node-suite/stream/events/on-non-function-throws.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// on(event, non-function) — should throw TypeError per EE spec.
+const r = new Readable({ read() {} });
+let caught: string | null = null;
+try {
+  r.on("data", "not-a-function" as any);
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/events/remove-all-listeners-error-event.ts
+++ b/test-parity/node-suite/stream/events/remove-all-listeners-error-event.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// removeAllListeners('error') — removes ALL error listeners.
+const r = new Readable({ read() {} });
+r.on("error", () => {});
+r.on("error", () => {});
+console.log("before:", r.listenerCount("error"));
+r.removeAllListeners("error");
+console.log("after:", r.listenerCount("error"));

--- a/test-parity/node-suite/stream/events/remove-listener-by-reference.ts
+++ b/test-parity/node-suite/stream/events/remove-listener-by-reference.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// removeListener requires the exact same function reference.
+const r = new Readable({ read() {} });
+const fn = () => {};
+r.on("custom", fn);
+r.on("custom", () => {});
+console.log("before:", r.listenerCount("custom"));
+r.removeListener("custom", fn);
+console.log("after:", r.listenerCount("custom"));
+console.log("decremented by 1:", r.listenerCount("custom") === 1);

--- a/test-parity/node-suite/stream/events/set-max-listeners-zero.ts
+++ b/test-parity/node-suite/stream/events/set-max-listeners-zero.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// setMaxListeners(0) — 0 means unlimited; getMaxListeners returns 0.
+const r = new Readable({ read() {} });
+r.setMaxListeners(0);
+console.log("max:", r.getMaxListeners());
+console.log("is 0 (unlimited):", r.getMaxListeners() === 0);
+// Attach 30 listeners — no warning
+for (let i = 0; i < 30; i++) r.on("data", () => {});
+console.log("count:", r.listenerCount("data"));

--- a/test-parity/node-suite/stream/flags/destroyed-initial-false.ts
+++ b/test-parity/node-suite/stream/flags/destroyed-initial-false.ts
@@ -1,0 +1,10 @@
+import { Readable, Writable, Duplex, Transform } from "node:stream";
+// destroyed flag should be false on freshly-constructed streams.
+const r = new Readable({ read() {} });
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+const d = new Duplex({ read() {}, write(_c, _e, cb) { cb(); } });
+const t = new Transform({ transform(c, _e, cb) { cb(null, c); } });
+console.log("R:", r.destroyed);
+console.log("W:", w.destroyed);
+console.log("D:", d.destroyed);
+console.log("T:", t.destroyed);

--- a/test-parity/node-suite/stream/flow/data-after-end-not-fired.ts
+++ b/test-parity/node-suite/stream/flow/data-after-end-not-fired.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// After 'end', further push() do nothing (no more data events).
+let dataCount = 0;
+const r = new Readable({ read() {} });
+r.on("data", () => dataCount++);
+r.push("a");
+r.push(null);
+r.on("end", () => {
+  setImmediate(() => {
+    r.push("late"); // should be ignored
+    setImmediate(() => {
+      console.log("data count:", dataCount);
+    });
+  });
+});

--- a/test-parity/node-suite/stream/flow/paused-no-data-flow.ts
+++ b/test-parity/node-suite/stream/flow/paused-no-data-flow.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// pause() on a source that has push()'ed data — no 'data' fires until resume.
+const r = new Readable({ read() {} });
+let count = 0;
+r.pause();
+r.on("data", () => count++);
+r.push("a");
+r.push("b");
+setImmediate(() => {
+  console.log("data emitted while paused:", count);
+  console.log("flowing:", r.readableFlowing);
+});

--- a/test-parity/node-suite/stream/flow/registration-order-emission.ts
+++ b/test-parity/node-suite/stream/flow/registration-order-emission.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Multiple 'data' listeners fire in registration order for each chunk.
+const r = Readable.from(["x"]);
+const order: string[] = [];
+r.on("data", () => order.push("first"));
+r.on("data", () => order.push("second"));
+r.on("data", () => order.push("third"));
+r.on("end", () => console.log("order:", order.join(",")));

--- a/test-parity/node-suite/stream/iter-helpers/compose-then-toarray.ts
+++ b/test-parity/node-suite/stream/iter-helpers/compose-then-toarray.ts
@@ -1,0 +1,7 @@
+import { Readable, Transform } from "node:stream";
+// readable.compose(transform).toArray() — chain compose with iter helper.
+const r = Readable.from(["a", "b", "c"]);
+const upper = new Transform({ transform(c, _e, cb) { cb(null, String(c).toUpperCase()); } });
+const composed: any = (r as any).compose(upper);
+const arr = await (composed as any).toArray();
+console.log("result:", arr.map((c: any) => String(c)).join(","));

--- a/test-parity/node-suite/stream/iter-helpers/drop-larger-than-stream.ts
+++ b/test-parity/node-suite/stream/iter-helpers/drop-larger-than-stream.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// drop(N) where N > items — yields empty.
+const r = Readable.from([1, 2, 3]);
+const out: any[] = [];
+for await (const v of (r as any).drop(100)) out.push(v);
+console.log("count:", out.length);
+console.log("is empty:", out.length === 0);

--- a/test-parity/node-suite/stream/iter-helpers/every-async-rejection.ts
+++ b/test-parity/node-suite/stream/iter-helpers/every-async-rejection.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// every(asyncFn) — rejection in fn propagates.
+const r = Readable.from([1, 2, 3]);
+let errMsg: string | null = null;
+try {
+  await (r as any).every(async (_x: number) => {
+    throw new Error("every-fail");
+  });
+} catch (e: any) {
+  errMsg = e && e.message;
+}
+console.log("rejected with:", errMsg);

--- a/test-parity/node-suite/stream/iter-helpers/find-async-fn.ts
+++ b/test-parity/node-suite/stream/iter-helpers/find-async-fn.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// find(asyncFn) — returns Promise<value>; stops at first match.
+const r = Readable.from([1, 2, 3, 4]);
+const result = await (r as any).find(async (x: number) => x > 2);
+console.log("result:", result);
+console.log("is 3:", result === 3);

--- a/test-parity/node-suite/stream/iter-helpers/flat-map-async-gen.ts
+++ b/test-parity/node-suite/stream/iter-helpers/flat-map-async-gen.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// flatMap(asyncGenFn) — yields multiple per input via async generator.
+const r = Readable.from([1, 2, 3]);
+const out: number[] = [];
+for await (const v of (r as any).flatMap(async function* (x: number) {
+  yield x * 10;
+  yield x * 100;
+})) {
+  out.push(v as number);
+}
+console.log("collected:", out.join(","));

--- a/test-parity/node-suite/stream/iter-helpers/for-each-await-each.ts
+++ b/test-parity/node-suite/stream/iter-helpers/for-each-await-each.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// forEach() with an async function — awaits each call before moving on.
+const r = Readable.from([1, 2, 3]);
+const events: string[] = [];
+await (r as any).forEach(async (x: number) => {
+  events.push("start:" + x);
+  await new Promise((resolve) => setTimeout(resolve, 2));
+  events.push("end:" + x);
+});
+console.log("order:", events.join(","));

--- a/test-parity/node-suite/stream/iter-helpers/map-then-toarray.ts
+++ b/test-parity/node-suite/stream/iter-helpers/map-then-toarray.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream";
+// .map(fn).toArray() — chain map then toArray to a plain array.
+const r = Readable.from([1, 2, 3]);
+const result = await (r as any).map((x: number) => x * 10).toArray();
+console.log("is array:", Array.isArray(result));
+console.log("result:", result.join(","));

--- a/test-parity/node-suite/stream/iter-helpers/some-async-rejection.ts
+++ b/test-parity/node-suite/stream/iter-helpers/some-async-rejection.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// some(asyncFn) — if asyncFn rejects, the promise rejects.
+const r = Readable.from([1, 2, 3]);
+let errMsg: string | null = null;
+try {
+  await (r as any).some(async (_x: number) => {
+    throw new Error("some-fail");
+  });
+} catch (e: any) {
+  errMsg = e && e.message;
+}
+console.log("rejected with:", errMsg);

--- a/test-parity/node-suite/stream/iter-helpers/take-then-filter.ts
+++ b/test-parity/node-suite/stream/iter-helpers/take-then-filter.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Chained .take(N).filter(fn) — both helpers participate.
+const r = Readable.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+const out: number[] = [];
+for await (const v of (r as any).take(6).filter((x: number) => x % 2 === 0)) {
+  out.push(v as number);
+}
+console.log("result:", out.join(","));

--- a/test-parity/node-suite/stream/pipe/cleanup-state-after-end.ts
+++ b/test-parity/node-suite/stream/pipe/cleanup-state-after-end.ts
@@ -1,0 +1,12 @@
+import { Readable, PassThrough } from "node:stream";
+// After source.pipe(dst) completes, source no longer listed in dst._writableState pipe.
+const r = Readable.from(["x"]);
+const dst = new PassThrough();
+dst.on("data", () => {});
+r.pipe(dst);
+dst.on("end", () => {
+  setImmediate(() => {
+    console.log("source destroyed:", r.destroyed);
+    console.log("dst destroyed:", dst.destroyed);
+  });
+});

--- a/test-parity/node-suite/stream/pipe/end-false-then-explicit-end.ts
+++ b/test-parity/node-suite/stream/pipe/end-false-then-explicit-end.ts
@@ -1,0 +1,13 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe(dst, {end:false}) — manual dst.end() works after source ends.
+const r = Readable.from(["a"]);
+const dst = new PassThrough();
+const out: string[] = [];
+dst.on("data", (c) => out.push(String(c)));
+dst.on("end", () => console.log("dst ended:", out.join(",")));
+r.pipe(dst, { end: false });
+r.on("end", () => {
+  setImmediate(() => {
+    dst.end();
+  });
+});

--- a/test-parity/node-suite/stream/pipe/pipe-adds-listener-on-dst.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-adds-listener-on-dst.ts
@@ -1,0 +1,11 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe() adds an internal 'unpipe' listener on dst (Node tracks via dst.listenerCount).
+const r = Readable.from(["x"]);
+const dst = new PassThrough();
+const before = dst.listenerCount("unpipe");
+r.pipe(dst);
+const after = dst.listenerCount("unpipe");
+console.log("before:", before);
+console.log("after:", after);
+console.log("incremented:", after > before);
+dst.on("data", () => {});

--- a/test-parity/node-suite/stream/pipe/pipe-after-pause.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-after-pause.ts
@@ -1,0 +1,10 @@
+import { Readable, PassThrough } from "node:stream";
+// pipe() to a destination resumes flow on a paused source.
+const r = Readable.from(["a", "b"]);
+r.pause();
+console.log("paused before pipe:", r.readableFlowing);
+const dst = new PassThrough();
+dst.on("data", () => {});
+r.pipe(dst);
+console.log("flowing after pipe:", r.readableFlowing);
+dst.on("end", () => console.log("done"));

--- a/test-parity/node-suite/stream/pipe/pipe-autodestroy-default.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-autodestroy-default.ts
@@ -1,0 +1,12 @@
+import { Readable, PassThrough } from "node:stream";
+// Default autoDestroy:true — after pipe completes, both streams destroyed.
+const r = Readable.from(["x"]);
+const dst = new PassThrough();
+dst.on("data", () => {});
+r.pipe(dst);
+dst.on("end", () => {
+  setImmediate(() => {
+    console.log("src destroyed:", r.destroyed);
+    console.log("dst destroyed:", dst.destroyed);
+  });
+});

--- a/test-parity/node-suite/stream/pipe/pipe-no-args-throws.ts
+++ b/test-parity/node-suite/stream/pipe/pipe-no-args-throws.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// pipe() with no args throws TypeError (destination required).
+const r = Readable.from(["x"]);
+let caught: string | null = null;
+try {
+  (r as any).pipe();
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/pipe/r-t-w-end-to-end.ts
+++ b/test-parity/node-suite/stream/pipe/r-t-w-end-to-end.ts
@@ -1,0 +1,12 @@
+import { Readable, Transform, Writable } from "node:stream";
+// Readable → Transform → Writable e2e.
+const r = Readable.from(["a", "b"]);
+const upper = new Transform({
+  transform(c, _e, cb) { cb(null, String(c).toUpperCase()); },
+});
+const received: string[] = [];
+const w = new Writable({
+  write(c, _e, cb) { received.push(String(c)); cb(); },
+});
+r.pipe(upper).pipe(w);
+w.on("finish", () => console.log("received:", received.join(",")));

--- a/test-parity/node-suite/stream/pipe/source-unpipe-clears-events.ts
+++ b/test-parity/node-suite/stream/pipe/source-unpipe-clears-events.ts
@@ -1,0 +1,15 @@
+import { Readable, PassThrough } from "node:stream";
+// unpipe(dst) — clears the internal pipe state.
+const r = Readable.from(["x"]);
+const dst = new PassThrough();
+dst.on("data", () => {});
+r.pipe(dst);
+r.unpipe(dst);
+// Push directly to source — dst shouldn't receive
+const collected: string[] = [];
+dst.on("data", (c) => collected.push(String(c)));
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("dst received after unpipe:", collected.length);
+  });
+});

--- a/test-parity/node-suite/stream/pipe/three-stage-mid-error.ts
+++ b/test-parity/node-suite/stream/pipe/three-stage-mid-error.ts
@@ -1,0 +1,21 @@
+import { Readable, Transform, PassThrough, pipeline } from "node:stream";
+// Three-stage pipeline with mid-stage error — src and sink both destroyed.
+const src = Readable.from(["x"]);
+const mid = new Transform({
+  transform(_c, _e, cb) {
+    cb(new Error("mid-fail"));
+  },
+});
+const sink = new PassThrough();
+sink.on("data", () => {});
+let errMsg: string | null = null;
+pipeline(src, mid, sink, (err: any) => {
+  errMsg = err && err.message;
+});
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("err:", errMsg);
+    console.log("src destroyed:", src.destroyed);
+    console.log("sink destroyed:", sink.destroyed);
+  });
+});

--- a/test-parity/node-suite/stream/pipeline/error-middle-aborts-all.ts
+++ b/test-parity/node-suite/stream/pipeline/error-middle-aborts-all.ts
@@ -1,0 +1,17 @@
+import { Readable, Transform, Writable, pipeline } from "node:stream";
+// An error in a middle transform — source AND sink should be destroyed.
+let srcClosed = false;
+let sinkClosed = false;
+const src = new Readable({ read() {} });
+const mid = new Transform({ transform(_c, _e, cb) { cb(new Error("mid-fail")); } });
+const sink = new Writable({ write(_c, _e, cb) { cb(); } });
+src.on("close", () => (srcClosed = true));
+sink.on("close", () => (sinkClosed = true));
+pipeline(src, mid, sink, () => {});
+src.push("x");
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("src destroyed:", srcClosed);
+    console.log("sink destroyed:", sinkClosed);
+  });
+});

--- a/test-parity/node-suite/stream/pipeline/null-cb-error-form.ts
+++ b/test-parity/node-suite/stream/pipeline/null-cb-error-form.ts
@@ -1,0 +1,9 @@
+import { Readable, PassThrough, pipeline } from "node:stream";
+// pipeline(src, dst, cb) — on success, cb is called with (null) or (undefined).
+const src = Readable.from(["a"]);
+const dst = new PassThrough();
+dst.on("data", () => {});
+pipeline(src, dst, (err) => {
+  console.log("err truthy:", !!err);
+  console.log("err type:", typeof err);
+});

--- a/test-parity/node-suite/stream/pipeline/three-async-fns.ts
+++ b/test-parity/node-suite/stream/pipeline/three-async-fns.ts
@@ -1,0 +1,22 @@
+import { Readable, pipeline } from "node:stream";
+// pipeline with multiple async-generator stages.
+const src = Readable.from(["a", "b"]);
+async function* upper(s: AsyncIterable<any>) {
+  for await (const c of s) yield String(c).toUpperCase();
+}
+async function* prefix(s: AsyncIterable<any>) {
+  for await (const c of s) yield "<" + c + ">";
+}
+const collected: string[] = [];
+pipeline(
+  src,
+  upper as any,
+  prefix as any,
+  async function (source: AsyncIterable<any>) {
+    for await (const v of source) collected.push(String(v));
+  },
+  (err: any) => {
+    console.log("err:", err);
+    console.log("collected:", collected.join(","));
+  },
+);

--- a/test-parity/node-suite/stream/promises/finished-stream-already-ended.ts
+++ b/test-parity/node-suite/stream/promises/finished-stream-already-ended.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
+// finished() on a stream that's already ended — resolves immediately.
+const r = Readable.from(["x"]);
+const collected: any[] = [];
+r.on("data", (c) => collected.push(c));
+await new Promise((resolve) => r.on("end", resolve));
+// Now the stream has ended
+let resolved = false;
+finished(r).then(() => (resolved = true));
+await new Promise((r) => setImmediate(r));
+console.log("finished resolved on already-ended:", resolved);

--- a/test-parity/node-suite/stream/readable/destroyed-after-error.ts
+++ b/test-parity/node-suite/stream/readable/destroyed-after-error.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// After 'error' event, destroyed flag is true.
+const r = new Readable({ read() {} });
+r.on("error", () => {
+  setImmediate(() => {
+    console.log("destroyed after error:", r.destroyed);
+  });
+});
+r.destroy(new Error("err-then-destroyed"));

--- a/test-parity/node-suite/stream/readable/destroyed-during-data-flow.ts
+++ b/test-parity/node-suite/stream/readable/destroyed-during-data-flow.ts
@@ -1,0 +1,18 @@
+import { Readable } from "node:stream";
+// destroy() inside a 'data' handler — subsequent data events stop.
+let dataCount = 0;
+let closed = false;
+const r = Readable.from(["a", "b", "c", "d", "e"]);
+r.on("data", () => {
+  dataCount++;
+  if (dataCount === 2) r.destroy();
+});
+r.on("close", () => (closed = true));
+r.on("error", () => {});
+r.on("end", () => {});
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("data emitted:", dataCount);
+    console.log("closed:", closed);
+  });
+});

--- a/test-parity/node-suite/stream/readable/double-destroy-still-destroyed.ts
+++ b/test-parity/node-suite/stream/readable/double-destroy-still-destroyed.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// destroy(); destroy(); — destroyed flag remains true.
+const r = new Readable({ read() {} });
+r.destroy();
+const first = r.destroyed;
+r.destroy();
+const second = r.destroyed;
+console.log("first:", first);
+console.log("second:", second);
+console.log("both true:", first === true && second === true);

--- a/test-parity/node-suite/stream/readable/from-array-of-promises.ts
+++ b/test-parity/node-suite/stream/readable/from-array-of-promises.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Readable.from([Promise.resolve(1), Promise.resolve(2)]) — Node yields
+// the resolved values (awaits each).
+const r = Readable.from([Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)]);
+const out: any[] = [];
+for await (const v of r) out.push(v);
+console.log("count:", out.length);
+console.log("values:", out.join(","));

--- a/test-parity/node-suite/stream/readable/from-array-with-undefined.ts
+++ b/test-parity/node-suite/stream/readable/from-array-with-undefined.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// Readable.from([1, undefined, 3]) — undefined as a value in objectMode
+// has special meaning (it signals end). In non-objectMode...?
+// In Node, the iterator pushes each yielded value; undefined push terminates the stream.
+const r = Readable.from([1, undefined, 3]);
+const out: any[] = [];
+r.on("data", (c) => out.push(c));
+r.on("end", () => {
+  console.log("collected:", out.length);
+  console.log("values:", out.join(","));
+});

--- a/test-parity/node-suite/stream/readable/from-async-iter-nested.ts
+++ b/test-parity/node-suite/stream/readable/from-async-iter-nested.ts
@@ -1,0 +1,13 @@
+import { Readable } from "node:stream";
+// Readable.from(asyncIter) where iter yields then awaits and yields more.
+async function* gen() {
+  yield 1;
+  await new Promise((r) => setImmediate(r));
+  yield 2;
+  await new Promise((r) => setImmediate(r));
+  yield 3;
+}
+const r = Readable.from(gen());
+const out: number[] = [];
+for await (const v of r) out.push(v as number);
+console.log("collected:", out.join(","));

--- a/test-parity/node-suite/stream/readable/from-empty-map.ts
+++ b/test-parity/node-suite/stream/readable/from-empty-map.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Readable.from(new Map()) iterates an empty Map → no data, immediate end.
+const r = Readable.from(new Map());
+const out: any[] = [];
+r.on("data", (v) => out.push(v));
+r.on("end", () => {
+  console.log("count:", out.length);
+  console.log("is empty:", out.length === 0);
+});

--- a/test-parity/node-suite/stream/readable/from-gen-yield-order.ts
+++ b/test-parity/node-suite/stream/readable/from-gen-yield-order.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// Generator yield order preserved through Readable.from + async-iter.
+function* gen() {
+  yield "alpha";
+  yield "beta";
+  yield "gamma";
+  yield "delta";
+}
+const r = Readable.from(gen());
+const out: string[] = [];
+for await (const v of r) out.push(String(v));
+console.log("order:", out.join(","));

--- a/test-parity/node-suite/stream/readable/from-iterator-throws.ts
+++ b/test-parity/node-suite/stream/readable/from-iterator-throws.ts
@@ -1,0 +1,16 @@
+import { Readable } from "node:stream";
+// Iterator that throws on next() — Readable.from emits 'error'.
+const throwingIter = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        throw new Error("iter-fail");
+      },
+    };
+  },
+};
+const r = Readable.from(throwingIter as any);
+let errMsg: string | null = null;
+r.on("error", (e) => (errMsg = e && e.message));
+r.on("data", () => {});
+setImmediate(() => console.log("err:", errMsg));

--- a/test-parity/node-suite/stream/readable/from-non-iterable-throws.ts
+++ b/test-parity/node-suite/stream/readable/from-non-iterable-throws.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Readable.from(non-iterable) — should throw TypeError.
+let caught: string | null = null;
+try {
+  Readable.from(42 as any);
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/readable/from-rejected-promise-in-array.ts
+++ b/test-parity/node-suite/stream/readable/from-rejected-promise-in-array.ts
@@ -1,0 +1,18 @@
+import { Readable } from "node:stream";
+// Readable.from([Promise.resolve(1), Promise.reject(err), Promise.resolve(3)])
+// — emits error when it encounters the rejection.
+const r = Readable.from([
+  Promise.resolve(1),
+  Promise.reject(new Error("inner-fail")),
+  Promise.resolve(3),
+]);
+let errMsg: string | null = null;
+r.on("error", (e) => (errMsg = e && e.message));
+const out: any[] = [];
+r.on("data", (v) => out.push(v));
+setImmediate(() => {
+  setImmediate(() => {
+    console.log("got data count:", out.length);
+    console.log("err:", errMsg);
+  });
+});

--- a/test-parity/node-suite/stream/readable/from-string-array-yields-each.ts
+++ b/test-parity/node-suite/stream/readable/from-string-array-yields-each.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Readable.from(['a', 'b', 'c']) — each string is a separate chunk.
+const r = Readable.from(["a", "b", "c"]);
+const out: string[] = [];
+r.on("data", (c) => out.push(String(c)));
+r.on("end", () => {
+  console.log("count:", out.length);
+  console.log("first:", out[0]);
+});

--- a/test-parity/node-suite/stream/readable/from-typed-array.ts
+++ b/test-parity/node-suite/stream/readable/from-typed-array.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// Readable.from(Uint8Array) — TypedArrays are iterable, yields each byte.
+// (Differs from Buffer which short-circuits to single chunk in Node.)
+const arr = new Uint8Array([1, 2, 3]);
+const r = Readable.from(arr);
+const out: any[] = [];
+for await (const v of r) out.push(v);
+console.log("count:", out.length);
+console.log("first:", out[0]);

--- a/test-parity/node-suite/stream/readable/highwater-mark-default-objectmode.ts
+++ b/test-parity/node-suite/stream/readable/highwater-mark-default-objectmode.ts
@@ -1,0 +1,5 @@
+import { Readable } from "node:stream";
+// In objectMode, highWaterMark defaults to 16 (count of objects, not bytes).
+const r = new Readable({ objectMode: true, read() {} });
+console.log("hwm:", r.readableHighWaterMark);
+console.log("is 16:", r.readableHighWaterMark === 16);

--- a/test-parity/node-suite/stream/readable/highwater-mark-zero.ts
+++ b/test-parity/node-suite/stream/readable/highwater-mark-zero.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// highWaterMark: 0 — push() returns false immediately because anything
+// is at the limit.
+const r = new Readable({ highWaterMark: 0, read() {} });
+const a = r.push("x");
+console.log("push(x) returned:", a);
+console.log("readableHighWaterMark:", r.readableHighWaterMark);

--- a/test-parity/node-suite/stream/readable/iter-and-data-listener.ts
+++ b/test-parity/node-suite/stream/readable/iter-and-data-listener.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Calling for-await on a stream that ALREADY has a 'data' listener
+// works: iteration consumes; the 'data' listener also sees the same data.
+const r = Readable.from(["a", "b"]);
+const dataEvents: string[] = [];
+r.on("data", (c) => dataEvents.push(String(c)));
+const iter: string[] = [];
+for await (const v of r) iter.push(String(v));
+console.log("iter:", iter.join(","));
+console.log("data events:", dataEvents.length);

--- a/test-parity/node-suite/stream/readable/iterator-empty-after-consumed.ts
+++ b/test-parity/node-suite/stream/readable/iterator-empty-after-consumed.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// After [Symbol.asyncIterator]() fully consumes the stream, a second call
+// returns an iterator that's immediately done.
+const r = Readable.from([1, 2, 3]);
+const first: any[] = [];
+for await (const v of r) first.push(v);
+const it2 = (r as any)[Symbol.asyncIterator]();
+const next = await it2.next();
+console.log("first:", first.join(","));
+console.log("second iter done:", next.done);

--- a/test-parity/node-suite/stream/readable/iterator-prevent-cancel.ts
+++ b/test-parity/node-suite/stream/readable/iterator-prevent-cancel.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// readable.iterator({preventCancel: true}) — but Node's option is 'destroyOnReturn'.
+// The 'preventCancel' name is from Web stream's iter. Test the actual Node option.
+const r = Readable.from(["a", "b", "c"]);
+const it = (r as any).iterator({ destroyOnReturn: false });
+const first = await it.next();
+const second = await it.next();
+console.log("first:", first.value);
+console.log("second:", second.value);
+// Early return with destroyOnReturn:false — should not destroy stream
+await it.return?.();
+console.log("destroyed:", r.destroyed);

--- a/test-parity/node-suite/stream/readable/method-typeof-function.ts
+++ b/test-parity/node-suite/stream/readable/method-typeof-function.ts
@@ -1,0 +1,11 @@
+import { Readable } from "node:stream";
+// All instance methods report typeof === "function" (recent #1642/#1643 fix).
+const r = new Readable({ read() {} });
+console.log("read:", typeof r.read);
+console.log("push:", typeof r.push);
+console.log("pipe:", typeof r.pipe);
+console.log("pause:", typeof r.pause);
+console.log("resume:", typeof r.resume);
+console.log("destroy:", typeof r.destroy);
+console.log("on:", typeof r.on);
+console.log("all function:", [r.read, r.push, r.pipe, r.pause, r.resume, r.destroy, r.on].every(f => typeof f === "function"));

--- a/test-parity/node-suite/stream/readable/options-autoDestroy-explicit.ts
+++ b/test-parity/node-suite/stream/readable/options-autoDestroy-explicit.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+// autoDestroy: false — after 'end' the stream is NOT auto-destroyed; 'close'
+// does not fire until you destroy() explicitly.
+const r = new Readable({ autoDestroy: false, read() {} });
+let closed = false;
+r.on("close", () => (closed = true));
+r.on("data", () => {});
+r.on("end", () => {
+  setImmediate(() => {
+    console.log("destroyed after end:", r.destroyed);
+    console.log("closed:", closed);
+  });
+});
+r.push("a");
+r.push(null);

--- a/test-parity/node-suite/stream/readable/pause-sets-flowing-false.ts
+++ b/test-parity/node-suite/stream/readable/pause-sets-flowing-false.ts
@@ -1,0 +1,9 @@
+import { Readable } from "node:stream";
+// pause() immediately flips readableFlowing to false (after the stream
+// was flowing).
+const r = Readable.from(["x"]);
+r.on("data", () => {});
+console.log("flowing after data listener:", r.readableFlowing);
+r.pause();
+console.log("flowing after pause:", r.readableFlowing);
+console.log("is false:", r.readableFlowing === false);

--- a/test-parity/node-suite/stream/readable/read-multi-before-push.ts
+++ b/test-parity/node-suite/stream/readable/read-multi-before-push.ts
@@ -1,0 +1,7 @@
+import { Readable } from "node:stream";
+// Multiple read() calls before any push — all return null.
+const r = new Readable({ read() {} });
+console.log("r1:", r.read());
+console.log("r2:", r.read());
+console.log("r3:", r.read());
+console.log("all null:", r.read() === null && r.read() === null);

--- a/test-parity/node-suite/stream/readable/read-returns-buffer-default.ts
+++ b/test-parity/node-suite/stream/readable/read-returns-buffer-default.ts
@@ -1,0 +1,10 @@
+import { Readable } from "node:stream";
+// Without setEncoding, read() returns Buffer instances.
+const r = new Readable({ read() {} });
+r.push("hi");
+r.push(null);
+r.on("readable", () => {
+  const got = r.read();
+  console.log("is buffer:", Buffer.isBuffer(got));
+  console.log("toString:", got && got.toString("utf8"));
+});

--- a/test-parity/node-suite/stream/readable/readable-mode-only.ts
+++ b/test-parity/node-suite/stream/readable/readable-mode-only.ts
@@ -1,0 +1,12 @@
+import { Readable } from "node:stream";
+// 'readable' event mode (no 'data' listener) — manually drain via read().
+const r = new Readable({ read() {} });
+r.push("aa");
+r.push("bb");
+r.push(null);
+const out: string[] = [];
+r.on("readable", () => {
+  let c;
+  while ((c = r.read()) !== null) out.push(String(c));
+});
+r.on("end", () => console.log("drained:", out.join("|")));

--- a/test-parity/node-suite/stream/readable/readable-property-shape.ts
+++ b/test-parity/node-suite/stream/readable/readable-property-shape.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Stream instance should expose .pipe, .destroy, .read methods.
+const r = new Readable({ read() {} });
+const props = ["pipe", "destroy", "read", "pause", "resume", "unpipe", "wrap"];
+for (const p of props) {
+  console.log(`${p}:`, typeof (r as any)[p]);
+}
+console.log("all function:", props.every(p => typeof (r as any)[p] === "function"));

--- a/test-parity/node-suite/stream/readable/sync-iterator-not-exposed.ts
+++ b/test-parity/node-suite/stream/readable/sync-iterator-not-exposed.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+// Symbol.iterator should not be exposed on Readable — only Symbol.asyncIterator.
+const r = Readable.from(["a"]);
+const sync = (r as any)[Symbol.iterator];
+const asyncIter = (r as any)[Symbol.asyncIterator];
+console.log("sync iterator typeof:", typeof sync);
+console.log("asyncIterator typeof:", typeof asyncIter);
+console.log("sync is undefined:", sync === undefined);

--- a/test-parity/node-suite/stream/transform/objectmode-passes-objects.ts
+++ b/test-parity/node-suite/stream/transform/objectmode-passes-objects.ts
@@ -1,0 +1,14 @@
+import { Transform } from "node:stream";
+// objectMode: true Transform passes objects directly (no Buffer conversion).
+const t = new Transform({
+  objectMode: true,
+  transform(c, _e, cb) { cb(null, { wrapped: c }); },
+});
+const out: any[] = [];
+t.on("data", (c) => out.push(c));
+t.on("end", () => {
+  console.log("count:", out.length);
+  console.log("first wrapped:", out[0] && out[0].wrapped);
+});
+t.write({ a: 1 });
+t.end();

--- a/test-parity/node-suite/stream/web/byob-respond-byte-stream.ts
+++ b/test-parity/node-suite/stream/web/byob-respond-byte-stream.ts
@@ -1,0 +1,18 @@
+import { ReadableStream } from "node:stream/web";
+// On a bytes-typed stream, the controller exposes byobRequest when a BYOB
+// reader is pulling. Test it exists at all.
+let hasByobRequest: any = null;
+const rs = new ReadableStream({
+  type: "bytes",
+  pull(c) {
+    hasByobRequest = (c as any).byobRequest !== undefined;
+  },
+} as any);
+const reader = (rs as any).getReader({ mode: "byob" });
+const view = new Uint8Array(8);
+try {
+  await reader.read(view);
+} catch {
+  // some impls may reject
+}
+console.log("byobRequest defined during pull:", hasByobRequest);

--- a/test-parity/node-suite/stream/web/cancel-after-close.ts
+++ b/test-parity/node-suite/stream/web/cancel-after-close.ts
@@ -1,0 +1,11 @@
+import { ReadableStream } from "node:stream/web";
+// cancel() after the stream has closed — resolves to undefined.
+const rs = new ReadableStream({ start(c) { c.close(); } });
+let result: any = "untouched";
+try {
+  result = await rs.cancel("after-close");
+} catch (e: any) {
+  result = "threw:" + e.name;
+}
+console.log("result:", result);
+console.log("is undefined:", result === undefined);

--- a/test-parity/node-suite/stream/web/cancel-source-throws.ts
+++ b/test-parity/node-suite/stream/web/cancel-source-throws.ts
@@ -1,0 +1,13 @@
+import { ReadableStream } from "node:stream/web";
+// If source.cancel() throws, the cancel() Promise rejects.
+const rs = new ReadableStream({
+  start(c) { c.enqueue("x"); },
+  cancel() { throw new Error("cancel-fail"); },
+});
+let errMsg: string | null = null;
+try {
+  await rs.cancel();
+} catch (e: any) {
+  errMsg = e && e.message;
+}
+console.log("rejected with:", errMsg);

--- a/test-parity/node-suite/stream/web/double-pipe-through.ts
+++ b/test-parity/node-suite/stream/web/double-pipe-through.ts
@@ -1,0 +1,13 @@
+import { ReadableStream, TransformStream } from "node:stream/web";
+// Chain pipeThrough() twice — two transforms in sequence.
+const rs = new ReadableStream({ start(c) { c.enqueue("ab"); c.close(); } });
+const upper = new TransformStream({
+  transform(c, ctrl) { ctrl.enqueue(String(c).toUpperCase()); },
+});
+const exclaim = new TransformStream({
+  transform(c, ctrl) { ctrl.enqueue(String(c) + "!"); },
+});
+const result = rs.pipeThrough(upper).pipeThrough(exclaim);
+const reader = result.getReader();
+const { value } = await reader.read();
+console.log("result:", value);

--- a/test-parity/node-suite/stream/web/for-await-on-transform.ts
+++ b/test-parity/node-suite/stream/web/for-await-on-transform.ts
@@ -1,0 +1,15 @@
+import { TransformStream } from "node:stream/web";
+// for-await directly over a TransformStream's readable side.
+const ts = new TransformStream({
+  transform(c, ctrl) { ctrl.enqueue(String(c).toUpperCase()); },
+});
+const writer = ts.writable.getWriter();
+const out: string[] = [];
+const iterPromise = (async () => {
+  for await (const v of ts.readable as any) out.push(String(v));
+})();
+await writer.write("a");
+await writer.write("b");
+await writer.close();
+await iterPromise;
+console.log("collected:", out.join(","));

--- a/test-parity/node-suite/stream/web/from-iterable-of-buffers.ts
+++ b/test-parity/node-suite/stream/web/from-iterable-of-buffers.ts
@@ -1,0 +1,15 @@
+import { ReadableStream } from "node:stream/web";
+// ReadableStream.from(arrayOfBuffers) — each element becomes a chunk.
+const rs = (ReadableStream as any).from([
+  new Uint8Array([1, 2]),
+  new Uint8Array([3, 4]),
+]);
+const reader = rs.getReader();
+const out: any[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(value);
+}
+console.log("count:", out.length);
+console.log("first is typed:", out[0] && out[0].constructor && out[0].constructor.name);

--- a/test-parity/node-suite/stream/web/from-iterable-of-strings.ts
+++ b/test-parity/node-suite/stream/web/from-iterable-of-strings.ts
@@ -1,0 +1,12 @@
+import { ReadableStream } from "node:stream/web";
+// RS.from(stringArray) — each string is a chunk.
+const rs = (ReadableStream as any).from(["alpha", "beta", "gamma"]);
+const reader = rs.getReader();
+const out: string[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(String(value));
+}
+console.log("count:", out.length);
+console.log("joined:", out.join(","));

--- a/test-parity/node-suite/stream/web/from-promise-iterable.ts
+++ b/test-parity/node-suite/stream/web/from-promise-iterable.ts
@@ -1,0 +1,22 @@
+import { ReadableStream } from "node:stream/web";
+// ReadableStream.from accepts an iterable; a single-value iterable yields once.
+const single = {
+  [Symbol.iterator]() {
+    let yielded = false;
+    return {
+      next() {
+        if (!yielded) {
+          yielded = true;
+          return { value: "the-value", done: false };
+        }
+        return { value: undefined, done: true };
+      },
+    };
+  },
+};
+const rs = (ReadableStream as any).from(single);
+const reader = rs.getReader();
+const a = await reader.read();
+const b = await reader.read();
+console.log("a value:", a.value, "done:", a.done);
+console.log("b done:", b.done);

--- a/test-parity/node-suite/stream/web/from-then-pipe-through.ts
+++ b/test-parity/node-suite/stream/web/from-then-pipe-through.ts
@@ -1,0 +1,15 @@
+import { ReadableStream, TransformStream } from "node:stream/web";
+// RS.from(arr).pipeThrough(transform) chain
+const rs = (ReadableStream as any).from(["a", "b"]);
+const upper = new TransformStream({
+  transform(c, ctrl) { ctrl.enqueue(String(c).toUpperCase()); },
+});
+const result = rs.pipeThrough(upper);
+const reader = result.getReader();
+const out: string[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(String(value));
+}
+console.log("piped:", out.join(","));

--- a/test-parity/node-suite/stream/web/from-uint8array-direct.ts
+++ b/test-parity/node-suite/stream/web/from-uint8array-direct.ts
@@ -1,0 +1,12 @@
+import { ReadableStream } from "node:stream/web";
+// ReadableStream.from(uint8Array) — yields each byte.
+const arr = new Uint8Array([10, 20, 30]);
+const rs = (ReadableStream as any).from(arr);
+const reader = rs.getReader();
+const out: number[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(value as number);
+}
+console.log("collected:", out.join(","));

--- a/test-parity/node-suite/stream/web/pipe-to-with-pre-aborted-signal.ts
+++ b/test-parity/node-suite/stream/web/pipe-to-with-pre-aborted-signal.ts
@@ -1,0 +1,14 @@
+import { ReadableStream, WritableStream } from "node:stream/web";
+// pipeTo({signal}) with a signal that was already aborted before the call
+// rejects the returned Promise immediately.
+const ctrl = new AbortController();
+ctrl.abort();
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); } });
+const ws = new WritableStream({ write() {} });
+let rejected = false;
+try {
+  await rs.pipeTo(ws, { signal: ctrl.signal });
+} catch {
+  rejected = true;
+}
+console.log("rejected pre-aborted:", rejected);

--- a/test-parity/node-suite/stream/web/pipethrough-with-options.ts
+++ b/test-parity/node-suite/stream/web/pipethrough-with-options.ts
@@ -1,0 +1,15 @@
+import { ReadableStream, TransformStream } from "node:stream/web";
+// pipeThrough(transform, options) — all four options accepted (preventClose,
+// preventAbort, preventCancel, signal).
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const ts = new TransformStream();
+const result = rs.pipeThrough(ts, {
+  preventClose: false,
+  preventAbort: false,
+  preventCancel: false,
+});
+console.log("returned RS:", result instanceof ReadableStream);
+// Drain to consume
+const reader = result.getReader();
+const { value } = await reader.read();
+console.log("first value:", value);

--- a/test-parity/node-suite/stream/web/readable-locked-after-pipe-through.ts
+++ b/test-parity/node-suite/stream/web/readable-locked-after-pipe-through.ts
@@ -1,0 +1,6 @@
+import { ReadableStream, TransformStream } from "node:stream/web";
+// After pipeThrough(), the source is locked (transform took the reader).
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const ts = new TransformStream();
+rs.pipeThrough(ts);
+console.log("rs locked after pipeThrough:", rs.locked);

--- a/test-parity/node-suite/stream/web/readable-with-strategy.ts
+++ b/test-parity/node-suite/stream/web/readable-with-strategy.ts
@@ -1,0 +1,11 @@
+import { ReadableStream, CountQueuingStrategy } from "node:stream/web";
+// new ReadableStream(source, strategy) — both args.
+const rs = new ReadableStream(
+  { start(c) { c.enqueue("x"); c.close(); } },
+  new CountQueuingStrategy({ highWaterMark: 5 }),
+);
+const reader = rs.getReader();
+const a = await reader.read();
+const b = await reader.read();
+console.log("a:", a.value);
+console.log("b done:", b.done);

--- a/test-parity/node-suite/stream/web/sink-all-four-methods.ts
+++ b/test-parity/node-suite/stream/web/sink-all-four-methods.ts
@@ -1,0 +1,13 @@
+import { WritableStream } from "node:stream/web";
+// Sink can define start, write, close, abort — all 4 are honored.
+const order: string[] = [];
+const ws = new WritableStream({
+  start() { order.push("start"); },
+  write(c) { order.push("write:" + String(c)); },
+  close() { order.push("close"); },
+  abort() { order.push("abort"); },
+});
+const w = ws.getWriter();
+await w.write("x");
+await w.close();
+console.log("order:", order.join(","));

--- a/test-parity/node-suite/stream/web/sink-with-arrow-methods.ts
+++ b/test-parity/node-suite/stream/web/sink-with-arrow-methods.ts
@@ -1,0 +1,12 @@
+import { WritableStream } from "node:stream/web";
+// Sink object can use arrow functions for methods (no `this`).
+let written: string | null = null;
+const ws = new WritableStream({
+  write: (c) => {
+    written = String(c);
+  },
+});
+const w = ws.getWriter();
+await w.write("hi");
+await w.close();
+console.log("written:", written);

--- a/test-parity/node-suite/stream/web/tee-after-getReader-throws.ts
+++ b/test-parity/node-suite/stream/web/tee-after-getReader-throws.ts
@@ -1,0 +1,12 @@
+import { ReadableStream } from "node:stream/web";
+// tee() on a stream that already has a reader (locked) — throws TypeError.
+const rs = new ReadableStream({ start(c) { c.enqueue("x"); c.close(); } });
+const _r = rs.getReader();
+let caught: string | null = null;
+try {
+  rs.tee();
+} catch (e: any) {
+  caught = e && e.name;
+}
+console.log("threw:", caught !== null);
+console.log("name:", caught);

--- a/test-parity/node-suite/stream/web/transform-async-flush.ts
+++ b/test-parity/node-suite/stream/web/transform-async-flush.ts
@@ -1,0 +1,20 @@
+import { TransformStream } from "node:stream/web";
+// flush() that returns a Promise — readable.close awaits it.
+let flushDone = false;
+const ts = new TransformStream({
+  transform(c, ctrl) { ctrl.enqueue(c); },
+  async flush() {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    flushDone = true;
+  },
+});
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("a");
+await writer.close();
+// drain readable
+while (true) {
+  const { done } = await reader.read();
+  if (done) break;
+}
+console.log("flush ran:", flushDone);

--- a/test-parity/node-suite/stream/web/transform-flush-throws.ts
+++ b/test-parity/node-suite/stream/web/transform-flush-throws.ts
@@ -1,0 +1,21 @@
+import { TransformStream } from "node:stream/web";
+// If flush() throws, the readable side errors.
+const ts = new TransformStream({
+  transform(c, ctrl) { ctrl.enqueue(c); },
+  flush() { throw new Error("flush-fail"); },
+});
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("a");
+await writer.close();
+let errMsg: string | null = null;
+try {
+  // consume to trigger flush
+  while (true) {
+    const { done } = await reader.read();
+    if (done) break;
+  }
+} catch (e: any) {
+  errMsg = e && e.message;
+}
+console.log("rejected with:", errMsg);

--- a/test-parity/node-suite/stream/web/transform-no-enqueue.ts
+++ b/test-parity/node-suite/stream/web/transform-no-enqueue.ts
@@ -1,0 +1,17 @@
+import { TransformStream } from "node:stream/web";
+// TransformStream whose transform() doesn't enqueue — readable is empty.
+const ts = new TransformStream({
+  transform() {}, // discards everything
+});
+const writer = ts.writable.getWriter();
+const reader = ts.readable.getReader();
+await writer.write("a");
+await writer.write("b");
+await writer.close();
+let count = 0;
+while (true) {
+  const { done } = await reader.read();
+  if (done) break;
+  count++;
+}
+console.log("yielded count:", count);

--- a/test-parity/node-suite/stream/web/transform-pipethrough-data-flow.ts
+++ b/test-parity/node-suite/stream/web/transform-pipethrough-data-flow.ts
@@ -1,0 +1,17 @@
+import { ReadableStream, TransformStream } from "node:stream/web";
+// pipeThrough — data flows through; collect the result.
+const rs = new ReadableStream({
+  start(c) { c.enqueue("a"); c.enqueue("b"); c.close(); },
+});
+const upper = new TransformStream({
+  transform(c, ctrl) { ctrl.enqueue(String(c).toUpperCase()); },
+});
+const result = rs.pipeThrough(upper);
+const reader = result.getReader();
+const out: string[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  out.push(String(value));
+}
+console.log("piped:", out.join(","));

--- a/test-parity/node-suite/stream/web/transform-readable-cancel-propagates.ts
+++ b/test-parity/node-suite/stream/web/transform-readable-cancel-propagates.ts
@@ -1,0 +1,13 @@
+import { TransformStream } from "node:stream/web";
+// Cancelling the readable side aborts the writable side.
+const ts = new TransformStream();
+const reader = ts.readable.getReader();
+await reader.cancel("downstream-stop");
+const writer = ts.writable.getWriter();
+let writeRejected = false;
+try {
+  await writer.write("x");
+} catch {
+  writeRejected = true;
+}
+console.log("write rejected after readable cancel:", writeRejected);

--- a/test-parity/node-suite/stream/web/transform-strategy-size-fn.ts
+++ b/test-parity/node-suite/stream/web/transform-strategy-size-fn.ts
@@ -1,0 +1,16 @@
+import { TransformStream } from "node:stream/web";
+// TransformStream's writableStrategy can have a custom size() function.
+let sizeCalled = 0;
+const ts = new TransformStream(undefined, {
+  highWaterMark: 10,
+  size: (chunk: any) => {
+    sizeCalled++;
+    return String(chunk).length;
+  },
+});
+const writer = ts.writable.getWriter();
+await writer.write("ab");
+await writer.write("cdef");
+await writer.close();
+console.log("size called:", sizeCalled);
+console.log("at least 2 calls:", sizeCalled >= 2);

--- a/test-parity/node-suite/stream/web/writable-stream-bytes-type.ts
+++ b/test-parity/node-suite/stream/web/writable-stream-bytes-type.ts
@@ -1,0 +1,11 @@
+import { WritableStream } from "node:stream/web";
+// type:"bytes" is not a documented WritableStream sink option (only on
+// ReadableStream). Confirm Node either ignores it or constructs anyway.
+let constructed = false;
+try {
+  const ws = new WritableStream({ type: "bytes", write() {} } as any);
+  constructed = ws instanceof WritableStream;
+} catch (e: any) {
+  console.log("threw:", e && e.name);
+}
+console.log("constructed (or threw above):", constructed);

--- a/test-parity/node-suite/stream/web/writer-write-resolves-after-sink.ts
+++ b/test-parity/node-suite/stream/web/writer-write-resolves-after-sink.ts
@@ -1,0 +1,16 @@
+import { WritableStream } from "node:stream/web";
+// writer.write() Promise resolution timing: resolves AFTER the sink's
+// write() has processed the chunk.
+let written = false;
+const ws = new WritableStream({
+  async write() {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    written = true;
+  },
+});
+const w = ws.getWriter();
+const p = w.write("x");
+console.log("before await:", written);
+await p;
+console.log("after await:", written);
+console.log("resolved after sink:", written);

--- a/test-parity/node-suite/stream/writable/cork-empty.ts
+++ b/test-parity/node-suite/stream/writable/cork-empty.ts
@@ -1,0 +1,7 @@
+import { Writable } from "node:stream";
+// cork() then immediately uncork() with no writes — finish fires normally.
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+w.cork();
+w.uncork();
+w.end();
+w.on("finish", () => console.log("finished normally:", true));

--- a/test-parity/node-suite/stream/writable/end-returns-this.ts
+++ b/test-parity/node-suite/stream/writable/end-returns-this.ts
@@ -1,0 +1,5 @@
+import { Writable } from "node:stream";
+// end() returns the writable itself (chainable).
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+const returned = w.end();
+console.log("end returns self:", returned === w);

--- a/test-parity/node-suite/stream/writable/uncork-twice-after-cork.ts
+++ b/test-parity/node-suite/stream/writable/uncork-twice-after-cork.ts
@@ -1,0 +1,9 @@
+import { Writable } from "node:stream";
+// cork(); uncork(); uncork() — second uncork is a safe no-op.
+const w = new Writable({ write(_c, _e, cb) { cb(); } });
+w.cork();
+w.write("x");
+w.uncork();
+w.uncork(); // no-op
+w.end();
+w.on("finish", () => console.log("finished:", true));

--- a/test-parity/node-suite/stream/writable/writable-length-tracker.ts
+++ b/test-parity/node-suite/stream/writable/writable-length-tracker.ts
@@ -1,0 +1,11 @@
+import { Writable } from "node:stream";
+// writableLength reflects buffered bytes pending in the writable queue.
+const w = new Writable({
+  highWaterMark: 100,
+  write(_c, _e, cb) { setImmediate(cb); }, // delay so writes accumulate
+});
+console.log("initial:", w.writableLength);
+w.write("ab");
+w.write("cd");
+console.log("after 2 writes:", w.writableLength);
+w.end();


### PR DESCRIPTION
Consolidates the 8 open `test(parity): stream` batch PRs into a single PR — these all just add disjoint test files and append to the shared `test-parity/known_failures.json`, so one PR is far cheaper to review/merge than N sequential ones.

### Supersedes

| PR | Branch | Tests |
|----|--------|-------|
| #1640 | feat/stream-iter-batch5 | iter-81..84 (16 tests) |
| #1659 | feat/stream-iter-batch7 | iter-88..90 (12) |
| #1661 | feat/stream-iter-batch8 | iter-91..93 (12) |
| #1669 | feat/stream-iter-batch10 | iter-97..99 (12) |
| #1683 | feat/stream-iter-batch11 | iter-100..102 (12) |
| #1687 | feat/stream-iter-batch13 | iter-106..108 (12) |
| #1689 | feat/stream-iter-batch14 | iter-109..111 (12) |
| #1693 | feat/stream-iter-batch15 | iter-112..114 (12) |

### What's in here

- **100 new `node-suite/stream` parity tests**, all disjoint filenames — verified no collisions across branches and none already present on `main`.
- **21 free-pass** tests (run clean, no skip entry).
- **79 skip-listed** entries added to `known_failures.json`, tracked against #1531 / #1532 / #1539 / #1545 / #1558.

### How it was assembled

Branched fresh from `origin/main`. For each source branch, checked out only its new test files, then rebuilt `known_failures.json` as `main ∪ (each branch's own additions not already on main)` — so the 440 existing entries are byte-identical (diff is **+474 / -0**, no em-dash reformatting noise) and no entry a prior fix PR removed gets re-added.

Note: pass/skip status for each test reflects the original batch author's assessment; the `parity` suite is tag-push-gated and does not run on this PR, so the 21 free-pass tests were not re-validated against current `main`.

Once this is green, the 8 superseded PRs above can be closed.
